### PR TITLE
Run Prettier on JS & JSX files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -50,10 +50,7 @@ module.exports = {
     react: {
       version: 'detect',
     },
-    'import/ignore': [
-      'node_modules',
-      '\\.(css|scss|json)$',
-    ],
+    'import/ignore': ['node_modules', '\\.(css|scss|json)$'],
     'import/resolver': {
       typescript: {},
     },
@@ -62,17 +59,14 @@ module.exports = {
   rules: {
     'consistent-return': 'error',
     'dot-notation': 'error',
-    eqeqeq: ['error', 'always', { 'null': 'ignore' }],
+    eqeqeq: ['error', 'always', { null: 'ignore' }],
     'jsx-quotes': ['error', 'prefer-single'],
     'no-case-declarations': 'off',
     'no-catch-shadow': 'error',
     'no-console': [
       'warn',
       {
-        allow: [
-          'error',
-          'warn',
-        ],
+        allow: ['error', 'warn'],
       },
     ],
     'no-empty': 'off',
@@ -147,9 +141,7 @@ module.exports = {
     'jsx-a11y/no-noninteractive-element-interactions': [
       'warn',
       {
-        handlers: [
-          'onClick',
-        ],
+        handlers: ['onClick'],
       },
     ],
     // recommended rule is:
@@ -167,9 +159,7 @@ module.exports = {
     'jsx-a11y/no-static-element-interactions': [
       'warn',
       {
-        handlers: [
-          'onClick',
-        ],
+        handlers: ['onClick'],
       },
     ],
 
@@ -241,7 +231,8 @@ module.exports = {
           },
           // Immutable / Redux / data store
           {
-            pattern: '{immutable,react-redux,react-immutable-proptypes,react-immutable-pure-component,reselect}',
+            pattern:
+              '{immutable,react-redux,react-immutable-proptypes,react-immutable-pure-component,reselect}',
             group: 'external',
             position: 'before',
           },
@@ -318,10 +309,7 @@ module.exports = {
       },
     },
     {
-      files: [
-        '**/*.ts',
-        '**/*.tsx',
-      ],
+      files: ['**/*.ts', '**/*.tsx'],
 
       extends: [
         'eslint:recommended',
@@ -348,7 +336,10 @@ module.exports = {
         '@typescript-eslint/consistent-type-definitions': ['warn', 'interface'],
         '@typescript-eslint/consistent-type-exports': 'error',
         '@typescript-eslint/consistent-type-imports': 'error',
-        "@typescript-eslint/prefer-nullish-coalescing": ['error', {ignorePrimitives: {boolean: true}}],
+        '@typescript-eslint/prefer-nullish-coalescing': [
+          'error',
+          { ignorePrimitives: { boolean: true } },
+        ],
 
         'jsdoc/require-jsdoc': 'off',
 
@@ -356,26 +347,24 @@ module.exports = {
         // to enforce better practices when converting from JS
         'import/no-default-export': 'warn',
         'react/prefer-stateless-function': 'warn',
-        'react/function-component-definition': ['error', { namedComponents: 'arrow-function' }],
+        'react/function-component-definition': [
+          'error',
+          { namedComponents: 'arrow-function' },
+        ],
         'react/jsx-uses-react': 'off', // not needed with new JSX transform
         'react/react-in-jsx-scope': 'off', // not needed with new JSX transform
         'react/prop-types': 'off',
       },
     },
     {
-      files: [
-        '**/__tests__/*.js',
-        '**/__tests__/*.jsx',
-      ],
+      files: ['**/__tests__/*.js', '**/__tests__/*.jsx'],
 
       env: {
         jest: true,
       },
     },
     {
-      files: [
-        'streaming/**/*',
-      ],
+      files: ['streaming/**/*'],
       rules: {
         'import/no-commonjs': 'off',
       },

--- a/.prettierignore
+++ b/.prettierignore
@@ -67,10 +67,6 @@ docker-compose.override.yml
 # Ignore vendored CSS reset
 app/javascript/styles/mastodon/reset.scss
 
-# Ignore Javascript pending https://github.com/mastodon/mastodon/pull/23631
-*.js
-*.jsx
-
 # Ignore HTML till cleaned and included in CI
 *.html
 

--- a/app/javascript/mastodon/actions/accounts.js
+++ b/app/javascript/mastodon/actions/accounts.js
@@ -4,79 +4,81 @@ import { importFetchedAccount, importFetchedAccounts } from './importer';
 
 export const ACCOUNT_FETCH_REQUEST = 'ACCOUNT_FETCH_REQUEST';
 export const ACCOUNT_FETCH_SUCCESS = 'ACCOUNT_FETCH_SUCCESS';
-export const ACCOUNT_FETCH_FAIL    = 'ACCOUNT_FETCH_FAIL';
+export const ACCOUNT_FETCH_FAIL = 'ACCOUNT_FETCH_FAIL';
 
 export const ACCOUNT_LOOKUP_REQUEST = 'ACCOUNT_LOOKUP_REQUEST';
 export const ACCOUNT_LOOKUP_SUCCESS = 'ACCOUNT_LOOKUP_SUCCESS';
-export const ACCOUNT_LOOKUP_FAIL    = 'ACCOUNT_LOOKUP_FAIL';
+export const ACCOUNT_LOOKUP_FAIL = 'ACCOUNT_LOOKUP_FAIL';
 
 export const ACCOUNT_FOLLOW_REQUEST = 'ACCOUNT_FOLLOW_REQUEST';
 export const ACCOUNT_FOLLOW_SUCCESS = 'ACCOUNT_FOLLOW_SUCCESS';
-export const ACCOUNT_FOLLOW_FAIL    = 'ACCOUNT_FOLLOW_FAIL';
+export const ACCOUNT_FOLLOW_FAIL = 'ACCOUNT_FOLLOW_FAIL';
 
 export const ACCOUNT_UNFOLLOW_REQUEST = 'ACCOUNT_UNFOLLOW_REQUEST';
 export const ACCOUNT_UNFOLLOW_SUCCESS = 'ACCOUNT_UNFOLLOW_SUCCESS';
-export const ACCOUNT_UNFOLLOW_FAIL    = 'ACCOUNT_UNFOLLOW_FAIL';
+export const ACCOUNT_UNFOLLOW_FAIL = 'ACCOUNT_UNFOLLOW_FAIL';
 
 export const ACCOUNT_BLOCK_REQUEST = 'ACCOUNT_BLOCK_REQUEST';
 export const ACCOUNT_BLOCK_SUCCESS = 'ACCOUNT_BLOCK_SUCCESS';
-export const ACCOUNT_BLOCK_FAIL    = 'ACCOUNT_BLOCK_FAIL';
+export const ACCOUNT_BLOCK_FAIL = 'ACCOUNT_BLOCK_FAIL';
 
 export const ACCOUNT_UNBLOCK_REQUEST = 'ACCOUNT_UNBLOCK_REQUEST';
 export const ACCOUNT_UNBLOCK_SUCCESS = 'ACCOUNT_UNBLOCK_SUCCESS';
-export const ACCOUNT_UNBLOCK_FAIL    = 'ACCOUNT_UNBLOCK_FAIL';
+export const ACCOUNT_UNBLOCK_FAIL = 'ACCOUNT_UNBLOCK_FAIL';
 
 export const ACCOUNT_MUTE_REQUEST = 'ACCOUNT_MUTE_REQUEST';
 export const ACCOUNT_MUTE_SUCCESS = 'ACCOUNT_MUTE_SUCCESS';
-export const ACCOUNT_MUTE_FAIL    = 'ACCOUNT_MUTE_FAIL';
+export const ACCOUNT_MUTE_FAIL = 'ACCOUNT_MUTE_FAIL';
 
 export const ACCOUNT_UNMUTE_REQUEST = 'ACCOUNT_UNMUTE_REQUEST';
 export const ACCOUNT_UNMUTE_SUCCESS = 'ACCOUNT_UNMUTE_SUCCESS';
-export const ACCOUNT_UNMUTE_FAIL    = 'ACCOUNT_UNMUTE_FAIL';
+export const ACCOUNT_UNMUTE_FAIL = 'ACCOUNT_UNMUTE_FAIL';
 
 export const ACCOUNT_PIN_REQUEST = 'ACCOUNT_PIN_REQUEST';
 export const ACCOUNT_PIN_SUCCESS = 'ACCOUNT_PIN_SUCCESS';
-export const ACCOUNT_PIN_FAIL    = 'ACCOUNT_PIN_FAIL';
+export const ACCOUNT_PIN_FAIL = 'ACCOUNT_PIN_FAIL';
 
 export const ACCOUNT_UNPIN_REQUEST = 'ACCOUNT_UNPIN_REQUEST';
 export const ACCOUNT_UNPIN_SUCCESS = 'ACCOUNT_UNPIN_SUCCESS';
-export const ACCOUNT_UNPIN_FAIL    = 'ACCOUNT_UNPIN_FAIL';
+export const ACCOUNT_UNPIN_FAIL = 'ACCOUNT_UNPIN_FAIL';
 
 export const FOLLOWERS_FETCH_REQUEST = 'FOLLOWERS_FETCH_REQUEST';
 export const FOLLOWERS_FETCH_SUCCESS = 'FOLLOWERS_FETCH_SUCCESS';
-export const FOLLOWERS_FETCH_FAIL    = 'FOLLOWERS_FETCH_FAIL';
+export const FOLLOWERS_FETCH_FAIL = 'FOLLOWERS_FETCH_FAIL';
 
 export const FOLLOWERS_EXPAND_REQUEST = 'FOLLOWERS_EXPAND_REQUEST';
 export const FOLLOWERS_EXPAND_SUCCESS = 'FOLLOWERS_EXPAND_SUCCESS';
-export const FOLLOWERS_EXPAND_FAIL    = 'FOLLOWERS_EXPAND_FAIL';
+export const FOLLOWERS_EXPAND_FAIL = 'FOLLOWERS_EXPAND_FAIL';
 
 export const FOLLOWING_FETCH_REQUEST = 'FOLLOWING_FETCH_REQUEST';
 export const FOLLOWING_FETCH_SUCCESS = 'FOLLOWING_FETCH_SUCCESS';
-export const FOLLOWING_FETCH_FAIL    = 'FOLLOWING_FETCH_FAIL';
+export const FOLLOWING_FETCH_FAIL = 'FOLLOWING_FETCH_FAIL';
 
 export const FOLLOWING_EXPAND_REQUEST = 'FOLLOWING_EXPAND_REQUEST';
 export const FOLLOWING_EXPAND_SUCCESS = 'FOLLOWING_EXPAND_SUCCESS';
-export const FOLLOWING_EXPAND_FAIL    = 'FOLLOWING_EXPAND_FAIL';
+export const FOLLOWING_EXPAND_FAIL = 'FOLLOWING_EXPAND_FAIL';
 
 export const RELATIONSHIPS_FETCH_REQUEST = 'RELATIONSHIPS_FETCH_REQUEST';
 export const RELATIONSHIPS_FETCH_SUCCESS = 'RELATIONSHIPS_FETCH_SUCCESS';
-export const RELATIONSHIPS_FETCH_FAIL    = 'RELATIONSHIPS_FETCH_FAIL';
+export const RELATIONSHIPS_FETCH_FAIL = 'RELATIONSHIPS_FETCH_FAIL';
 
 export const FOLLOW_REQUESTS_FETCH_REQUEST = 'FOLLOW_REQUESTS_FETCH_REQUEST';
 export const FOLLOW_REQUESTS_FETCH_SUCCESS = 'FOLLOW_REQUESTS_FETCH_SUCCESS';
-export const FOLLOW_REQUESTS_FETCH_FAIL    = 'FOLLOW_REQUESTS_FETCH_FAIL';
+export const FOLLOW_REQUESTS_FETCH_FAIL = 'FOLLOW_REQUESTS_FETCH_FAIL';
 
 export const FOLLOW_REQUESTS_EXPAND_REQUEST = 'FOLLOW_REQUESTS_EXPAND_REQUEST';
 export const FOLLOW_REQUESTS_EXPAND_SUCCESS = 'FOLLOW_REQUESTS_EXPAND_SUCCESS';
-export const FOLLOW_REQUESTS_EXPAND_FAIL    = 'FOLLOW_REQUESTS_EXPAND_FAIL';
+export const FOLLOW_REQUESTS_EXPAND_FAIL = 'FOLLOW_REQUESTS_EXPAND_FAIL';
 
-export const FOLLOW_REQUEST_AUTHORIZE_REQUEST = 'FOLLOW_REQUEST_AUTHORIZE_REQUEST';
-export const FOLLOW_REQUEST_AUTHORIZE_SUCCESS = 'FOLLOW_REQUEST_AUTHORIZE_SUCCESS';
-export const FOLLOW_REQUEST_AUTHORIZE_FAIL    = 'FOLLOW_REQUEST_AUTHORIZE_FAIL';
+export const FOLLOW_REQUEST_AUTHORIZE_REQUEST =
+  'FOLLOW_REQUEST_AUTHORIZE_REQUEST';
+export const FOLLOW_REQUEST_AUTHORIZE_SUCCESS =
+  'FOLLOW_REQUEST_AUTHORIZE_SUCCESS';
+export const FOLLOW_REQUEST_AUTHORIZE_FAIL = 'FOLLOW_REQUEST_AUTHORIZE_FAIL';
 
 export const FOLLOW_REQUEST_REJECT_REQUEST = 'FOLLOW_REQUEST_REJECT_REQUEST';
 export const FOLLOW_REQUEST_REJECT_SUCCESS = 'FOLLOW_REQUEST_REJECT_SUCCESS';
-export const FOLLOW_REQUEST_REJECT_FAIL    = 'FOLLOW_REQUEST_REJECT_FAIL';
+export const FOLLOW_REQUEST_REJECT_FAIL = 'FOLLOW_REQUEST_REJECT_FAIL';
 
 export const ACCOUNT_REVEAL = 'ACCOUNT_REVEAL';
 
@@ -85,25 +87,31 @@ export function fetchAccount(id) {
     dispatch(fetchRelationships([id]));
     dispatch(fetchAccountRequest(id));
 
-    api(getState).get(`/api/v1/accounts/${id}`).then(response => {
-      dispatch(importFetchedAccount(response.data));
-      dispatch(fetchAccountSuccess());
-    }).catch(error => {
-      dispatch(fetchAccountFail(id, error));
-    });
+    api(getState)
+      .get(`/api/v1/accounts/${id}`)
+      .then((response) => {
+        dispatch(importFetchedAccount(response.data));
+        dispatch(fetchAccountSuccess());
+      })
+      .catch((error) => {
+        dispatch(fetchAccountFail(id, error));
+      });
   };
 }
 
-export const lookupAccount = acct => (dispatch, getState) => {
+export const lookupAccount = (acct) => (dispatch, getState) => {
   dispatch(lookupAccountRequest(acct));
 
-  api(getState).get('/api/v1/accounts/lookup', { params: { acct } }).then(response => {
-    dispatch(fetchRelationships([response.data.id]));
-    dispatch(importFetchedAccount(response.data));
-    dispatch(lookupAccountSuccess());
-  }).catch(error => {
-    dispatch(lookupAccountFail(acct, error));
-  });
+  api(getState)
+    .get('/api/v1/accounts/lookup', { params: { acct } })
+    .then((response) => {
+      dispatch(fetchRelationships([response.data.id]));
+      dispatch(importFetchedAccount(response.data));
+      dispatch(lookupAccountSuccess());
+    })
+    .catch((error) => {
+      dispatch(lookupAccountFail(acct, error));
+    });
 };
 
 export const lookupAccountRequest = (acct) => ({
@@ -146,16 +154,23 @@ export function fetchAccountFail(id, error) {
 
 export function followAccount(id, options = { reblogs: true }) {
   return (dispatch, getState) => {
-    const alreadyFollowing = getState().getIn(['relationships', id, 'following']);
+    const alreadyFollowing = getState().getIn([
+      'relationships',
+      id,
+      'following',
+    ]);
     const locked = getState().getIn(['accounts', id, 'locked'], false);
 
     dispatch(followAccountRequest(id, locked));
 
-    api(getState).post(`/api/v1/accounts/${id}/follow`, options).then(response => {
-      dispatch(followAccountSuccess(response.data, alreadyFollowing));
-    }).catch(error => {
-      dispatch(followAccountFail(error, locked));
-    });
+    api(getState)
+      .post(`/api/v1/accounts/${id}/follow`, options)
+      .then((response) => {
+        dispatch(followAccountSuccess(response.data, alreadyFollowing));
+      })
+      .catch((error) => {
+        dispatch(followAccountFail(error, locked));
+      });
   };
 }
 
@@ -163,11 +178,16 @@ export function unfollowAccount(id) {
   return (dispatch, getState) => {
     dispatch(unfollowAccountRequest(id));
 
-    api(getState).post(`/api/v1/accounts/${id}/unfollow`).then(response => {
-      dispatch(unfollowAccountSuccess(response.data, getState().get('statuses')));
-    }).catch(error => {
-      dispatch(unfollowAccountFail(error));
-    });
+    api(getState)
+      .post(`/api/v1/accounts/${id}/unfollow`)
+      .then((response) => {
+        dispatch(
+          unfollowAccountSuccess(response.data, getState().get('statuses')),
+        );
+      })
+      .catch((error) => {
+        dispatch(unfollowAccountFail(error));
+      });
   };
 }
 
@@ -227,12 +247,17 @@ export function blockAccount(id) {
   return (dispatch, getState) => {
     dispatch(blockAccountRequest(id));
 
-    api(getState).post(`/api/v1/accounts/${id}/block`).then(response => {
-      // Pass in entire statuses map so we can use it to filter stuff in different parts of the reducers
-      dispatch(blockAccountSuccess(response.data, getState().get('statuses')));
-    }).catch(error => {
-      dispatch(blockAccountFail(id, error));
-    });
+    api(getState)
+      .post(`/api/v1/accounts/${id}/block`)
+      .then((response) => {
+        // Pass in entire statuses map so we can use it to filter stuff in different parts of the reducers
+        dispatch(
+          blockAccountSuccess(response.data, getState().get('statuses')),
+        );
+      })
+      .catch((error) => {
+        dispatch(blockAccountFail(id, error));
+      });
   };
 }
 
@@ -240,11 +265,14 @@ export function unblockAccount(id) {
   return (dispatch, getState) => {
     dispatch(unblockAccountRequest(id));
 
-    api(getState).post(`/api/v1/accounts/${id}/unblock`).then(response => {
-      dispatch(unblockAccountSuccess(response.data));
-    }).catch(error => {
-      dispatch(unblockAccountFail(id, error));
-    });
+    api(getState)
+      .post(`/api/v1/accounts/${id}/unblock`)
+      .then((response) => {
+        dispatch(unblockAccountSuccess(response.data));
+      })
+      .catch((error) => {
+        dispatch(unblockAccountFail(id, error));
+      });
   };
 }
 
@@ -291,17 +319,19 @@ export function unblockAccountFail(error) {
   };
 }
 
-
-export function muteAccount(id, notifications, duration=0) {
+export function muteAccount(id, notifications, duration = 0) {
   return (dispatch, getState) => {
     dispatch(muteAccountRequest(id));
 
-    api(getState).post(`/api/v1/accounts/${id}/mute`, { notifications, duration }).then(response => {
-      // Pass in entire statuses map so we can use it to filter stuff in different parts of the reducers
-      dispatch(muteAccountSuccess(response.data, getState().get('statuses')));
-    }).catch(error => {
-      dispatch(muteAccountFail(id, error));
-    });
+    api(getState)
+      .post(`/api/v1/accounts/${id}/mute`, { notifications, duration })
+      .then((response) => {
+        // Pass in entire statuses map so we can use it to filter stuff in different parts of the reducers
+        dispatch(muteAccountSuccess(response.data, getState().get('statuses')));
+      })
+      .catch((error) => {
+        dispatch(muteAccountFail(id, error));
+      });
   };
 }
 
@@ -309,11 +339,14 @@ export function unmuteAccount(id) {
   return (dispatch, getState) => {
     dispatch(unmuteAccountRequest(id));
 
-    api(getState).post(`/api/v1/accounts/${id}/unmute`).then(response => {
-      dispatch(unmuteAccountSuccess(response.data));
-    }).catch(error => {
-      dispatch(unmuteAccountFail(id, error));
-    });
+    api(getState)
+      .post(`/api/v1/accounts/${id}/unmute`)
+      .then((response) => {
+        dispatch(unmuteAccountSuccess(response.data));
+      })
+      .catch((error) => {
+        dispatch(unmuteAccountFail(id, error));
+      });
   };
 }
 
@@ -360,20 +393,26 @@ export function unmuteAccountFail(error) {
   };
 }
 
-
 export function fetchFollowers(id) {
   return (dispatch, getState) => {
     dispatch(fetchFollowersRequest(id));
 
-    api(getState).get(`/api/v1/accounts/${id}/followers`).then(response => {
-      const next = getLinks(response).refs.find(link => link.rel === 'next');
+    api(getState)
+      .get(`/api/v1/accounts/${id}/followers`)
+      .then((response) => {
+        const next = getLinks(response).refs.find(
+          (link) => link.rel === 'next',
+        );
 
-      dispatch(importFetchedAccounts(response.data));
-      dispatch(fetchFollowersSuccess(id, response.data, next ? next.uri : null));
-      dispatch(fetchRelationships(response.data.map(item => item.id)));
-    }).catch(error => {
-      dispatch(fetchFollowersFail(id, error));
-    });
+        dispatch(importFetchedAccounts(response.data));
+        dispatch(
+          fetchFollowersSuccess(id, response.data, next ? next.uri : null),
+        );
+        dispatch(fetchRelationships(response.data.map((item) => item.id)));
+      })
+      .catch((error) => {
+        dispatch(fetchFollowersFail(id, error));
+      });
   };
 }
 
@@ -412,15 +451,22 @@ export function expandFollowers(id) {
 
     dispatch(expandFollowersRequest(id));
 
-    api(getState).get(url).then(response => {
-      const next = getLinks(response).refs.find(link => link.rel === 'next');
+    api(getState)
+      .get(url)
+      .then((response) => {
+        const next = getLinks(response).refs.find(
+          (link) => link.rel === 'next',
+        );
 
-      dispatch(importFetchedAccounts(response.data));
-      dispatch(expandFollowersSuccess(id, response.data, next ? next.uri : null));
-      dispatch(fetchRelationships(response.data.map(item => item.id)));
-    }).catch(error => {
-      dispatch(expandFollowersFail(id, error));
-    });
+        dispatch(importFetchedAccounts(response.data));
+        dispatch(
+          expandFollowersSuccess(id, response.data, next ? next.uri : null),
+        );
+        dispatch(fetchRelationships(response.data.map((item) => item.id)));
+      })
+      .catch((error) => {
+        dispatch(expandFollowersFail(id, error));
+      });
   };
 }
 
@@ -452,15 +498,22 @@ export function fetchFollowing(id) {
   return (dispatch, getState) => {
     dispatch(fetchFollowingRequest(id));
 
-    api(getState).get(`/api/v1/accounts/${id}/following`).then(response => {
-      const next = getLinks(response).refs.find(link => link.rel === 'next');
+    api(getState)
+      .get(`/api/v1/accounts/${id}/following`)
+      .then((response) => {
+        const next = getLinks(response).refs.find(
+          (link) => link.rel === 'next',
+        );
 
-      dispatch(importFetchedAccounts(response.data));
-      dispatch(fetchFollowingSuccess(id, response.data, next ? next.uri : null));
-      dispatch(fetchRelationships(response.data.map(item => item.id)));
-    }).catch(error => {
-      dispatch(fetchFollowingFail(id, error));
-    });
+        dispatch(importFetchedAccounts(response.data));
+        dispatch(
+          fetchFollowingSuccess(id, response.data, next ? next.uri : null),
+        );
+        dispatch(fetchRelationships(response.data.map((item) => item.id)));
+      })
+      .catch((error) => {
+        dispatch(fetchFollowingFail(id, error));
+      });
   };
 }
 
@@ -499,15 +552,22 @@ export function expandFollowing(id) {
 
     dispatch(expandFollowingRequest(id));
 
-    api(getState).get(url).then(response => {
-      const next = getLinks(response).refs.find(link => link.rel === 'next');
+    api(getState)
+      .get(url)
+      .then((response) => {
+        const next = getLinks(response).refs.find(
+          (link) => link.rel === 'next',
+        );
 
-      dispatch(importFetchedAccounts(response.data));
-      dispatch(expandFollowingSuccess(id, response.data, next ? next.uri : null));
-      dispatch(fetchRelationships(response.data.map(item => item.id)));
-    }).catch(error => {
-      dispatch(expandFollowingFail(id, error));
-    });
+        dispatch(importFetchedAccounts(response.data));
+        dispatch(
+          expandFollowingSuccess(id, response.data, next ? next.uri : null),
+        );
+        dispatch(fetchRelationships(response.data.map((item) => item.id)));
+      })
+      .catch((error) => {
+        dispatch(expandFollowingFail(id, error));
+      });
   };
 }
 
@@ -539,7 +599,9 @@ export function fetchRelationships(accountIds) {
   return (dispatch, getState) => {
     const state = getState();
     const loadedRelationships = state.get('relationships');
-    const newAccountIds = accountIds.filter(id => loadedRelationships.get(id, null) === null);
+    const newAccountIds = accountIds.filter(
+      (id) => loadedRelationships.get(id, null) === null,
+    );
     const signedIn = !!state.getIn(['meta', 'me']);
 
     if (!signedIn || newAccountIds.length === 0) {
@@ -548,11 +610,18 @@ export function fetchRelationships(accountIds) {
 
     dispatch(fetchRelationshipsRequest(newAccountIds));
 
-    api(getState).get(`/api/v1/accounts/relationships?${newAccountIds.map(id => `id[]=${id}`).join('&')}`).then(response => {
-      dispatch(fetchRelationshipsSuccess(response.data));
-    }).catch(error => {
-      dispatch(fetchRelationshipsFail(error));
-    });
+    api(getState)
+      .get(
+        `/api/v1/accounts/relationships?${newAccountIds
+          .map((id) => `id[]=${id}`)
+          .join('&')}`,
+      )
+      .then((response) => {
+        dispatch(fetchRelationshipsSuccess(response.data));
+      })
+      .catch((error) => {
+        dispatch(fetchRelationshipsFail(error));
+      });
   };
 }
 
@@ -585,11 +654,18 @@ export function fetchFollowRequests() {
   return (dispatch, getState) => {
     dispatch(fetchFollowRequestsRequest());
 
-    api(getState).get('/api/v1/follow_requests').then(response => {
-      const next = getLinks(response).refs.find(link => link.rel === 'next');
-      dispatch(importFetchedAccounts(response.data));
-      dispatch(fetchFollowRequestsSuccess(response.data, next ? next.uri : null));
-    }).catch(error => dispatch(fetchFollowRequestsFail(error)));
+    api(getState)
+      .get('/api/v1/follow_requests')
+      .then((response) => {
+        const next = getLinks(response).refs.find(
+          (link) => link.rel === 'next',
+        );
+        dispatch(importFetchedAccounts(response.data));
+        dispatch(
+          fetchFollowRequestsSuccess(response.data, next ? next.uri : null),
+        );
+      })
+      .catch((error) => dispatch(fetchFollowRequestsFail(error)));
   };
 }
 
@@ -624,11 +700,18 @@ export function expandFollowRequests() {
 
     dispatch(expandFollowRequestsRequest());
 
-    api(getState).get(url).then(response => {
-      const next = getLinks(response).refs.find(link => link.rel === 'next');
-      dispatch(importFetchedAccounts(response.data));
-      dispatch(expandFollowRequestsSuccess(response.data, next ? next.uri : null));
-    }).catch(error => dispatch(expandFollowRequestsFail(error)));
+    api(getState)
+      .get(url)
+      .then((response) => {
+        const next = getLinks(response).refs.find(
+          (link) => link.rel === 'next',
+        );
+        dispatch(importFetchedAccounts(response.data));
+        dispatch(
+          expandFollowRequestsSuccess(response.data, next ? next.uri : null),
+        );
+      })
+      .catch((error) => dispatch(expandFollowRequestsFail(error)));
   };
 }
 
@@ -660,7 +743,7 @@ export function authorizeFollowRequest(id) {
     api(getState)
       .post(`/api/v1/follow_requests/${id}/authorize`)
       .then(() => dispatch(authorizeFollowRequestSuccess(id)))
-      .catch(error => dispatch(authorizeFollowRequestFail(id, error)));
+      .catch((error) => dispatch(authorizeFollowRequestFail(id, error)));
   };
 }
 
@@ -686,7 +769,6 @@ export function authorizeFollowRequestFail(id, error) {
   };
 }
 
-
 export function rejectFollowRequest(id) {
   return (dispatch, getState) => {
     dispatch(rejectFollowRequestRequest(id));
@@ -694,7 +776,7 @@ export function rejectFollowRequest(id) {
     api(getState)
       .post(`/api/v1/follow_requests/${id}/reject`)
       .then(() => dispatch(rejectFollowRequestSuccess(id)))
-      .catch(error => dispatch(rejectFollowRequestFail(id, error)));
+      .catch((error) => dispatch(rejectFollowRequestFail(id, error)));
   };
 }
 
@@ -724,11 +806,14 @@ export function pinAccount(id) {
   return (dispatch, getState) => {
     dispatch(pinAccountRequest(id));
 
-    api(getState).post(`/api/v1/accounts/${id}/pin`).then(response => {
-      dispatch(pinAccountSuccess(response.data));
-    }).catch(error => {
-      dispatch(pinAccountFail(error));
-    });
+    api(getState)
+      .post(`/api/v1/accounts/${id}/pin`)
+      .then((response) => {
+        dispatch(pinAccountSuccess(response.data));
+      })
+      .catch((error) => {
+        dispatch(pinAccountFail(error));
+      });
   };
 }
 
@@ -736,11 +821,14 @@ export function unpinAccount(id) {
   return (dispatch, getState) => {
     dispatch(unpinAccountRequest(id));
 
-    api(getState).post(`/api/v1/accounts/${id}/unpin`).then(response => {
-      dispatch(unpinAccountSuccess(response.data));
-    }).catch(error => {
-      dispatch(unpinAccountFail(error));
-    });
+    api(getState)
+      .post(`/api/v1/accounts/${id}/unpin`)
+      .then((response) => {
+        dispatch(unpinAccountSuccess(response.data));
+      })
+      .catch((error) => {
+        dispatch(unpinAccountFail(error));
+      });
   };
 }
 
@@ -786,7 +874,7 @@ export function unpinAccountFail(error) {
   };
 }
 
-export const revealAccount = id => ({
+export const revealAccount = (id) => ({
   type: ACCOUNT_REVEAL,
   id,
 });

--- a/app/javascript/mastodon/actions/alerts.js
+++ b/app/javascript/mastodon/actions/alerts.js
@@ -2,17 +2,26 @@ import { defineMessages } from 'react-intl';
 
 const messages = defineMessages({
   unexpectedTitle: { id: 'alert.unexpected.title', defaultMessage: 'Oops!' },
-  unexpectedMessage: { id: 'alert.unexpected.message', defaultMessage: 'An unexpected error occurred.' },
-  rateLimitedTitle: { id: 'alert.rate_limited.title', defaultMessage: 'Rate limited' },
-  rateLimitedMessage: { id: 'alert.rate_limited.message', defaultMessage: 'Please retry after {retry_time, time, medium}.' },
+  unexpectedMessage: {
+    id: 'alert.unexpected.message',
+    defaultMessage: 'An unexpected error occurred.',
+  },
+  rateLimitedTitle: {
+    id: 'alert.rate_limited.title',
+    defaultMessage: 'Rate limited',
+  },
+  rateLimitedMessage: {
+    id: 'alert.rate_limited.message',
+    defaultMessage: 'Please retry after {retry_time, time, medium}.',
+  },
 });
 
-export const ALERT_SHOW    = 'ALERT_SHOW';
+export const ALERT_SHOW = 'ALERT_SHOW';
 export const ALERT_DISMISS = 'ALERT_DISMISS';
-export const ALERT_CLEAR   = 'ALERT_CLEAR';
-export const ALERT_NOOP    = 'ALERT_NOOP';
+export const ALERT_CLEAR = 'ALERT_CLEAR';
+export const ALERT_NOOP = 'ALERT_NOOP';
 
-export const dismissAlert = alert => ({
+export const dismissAlert = (alert) => ({
   type: ALERT_DISMISS,
   alert,
 });
@@ -21,7 +30,7 @@ export const clearAlert = () => ({
   type: ALERT_CLEAR,
 });
 
-export const showAlert = alert => ({
+export const showAlert = (alert) => ({
   type: ALERT_SHOW,
   alert,
 });
@@ -40,7 +49,7 @@ export const showAlertForError = (error, skipNotFound = false) => {
       return showAlert({
         title: messages.rateLimitedTitle,
         message: messages.rateLimitedMessage,
-        values: { 'retry_time': new Date(headers['x-ratelimit-reset']) },
+        values: { retry_time: new Date(headers['x-ratelimit-reset']) },
       });
     }
 
@@ -56,4 +65,4 @@ export const showAlertForError = (error, skipNotFound = false) => {
     title: messages.unexpectedTitle,
     message: messages.unexpectedMessage,
   });
-}
+};

--- a/app/javascript/mastodon/actions/announcements.js
+++ b/app/javascript/mastodon/actions/announcements.js
@@ -4,21 +4,27 @@ import { normalizeAnnouncement } from './importer/normalizer';
 
 export const ANNOUNCEMENTS_FETCH_REQUEST = 'ANNOUNCEMENTS_FETCH_REQUEST';
 export const ANNOUNCEMENTS_FETCH_SUCCESS = 'ANNOUNCEMENTS_FETCH_SUCCESS';
-export const ANNOUNCEMENTS_FETCH_FAIL    = 'ANNOUNCEMENTS_FETCH_FAIL';
-export const ANNOUNCEMENTS_UPDATE        = 'ANNOUNCEMENTS_UPDATE';
-export const ANNOUNCEMENTS_DELETE        = 'ANNOUNCEMENTS_DELETE';
+export const ANNOUNCEMENTS_FETCH_FAIL = 'ANNOUNCEMENTS_FETCH_FAIL';
+export const ANNOUNCEMENTS_UPDATE = 'ANNOUNCEMENTS_UPDATE';
+export const ANNOUNCEMENTS_DELETE = 'ANNOUNCEMENTS_DELETE';
 
 export const ANNOUNCEMENTS_DISMISS_REQUEST = 'ANNOUNCEMENTS_DISMISS_REQUEST';
 export const ANNOUNCEMENTS_DISMISS_SUCCESS = 'ANNOUNCEMENTS_DISMISS_SUCCESS';
-export const ANNOUNCEMENTS_DISMISS_FAIL    = 'ANNOUNCEMENTS_DISMISS_FAIL';
+export const ANNOUNCEMENTS_DISMISS_FAIL = 'ANNOUNCEMENTS_DISMISS_FAIL';
 
-export const ANNOUNCEMENTS_REACTION_ADD_REQUEST = 'ANNOUNCEMENTS_REACTION_ADD_REQUEST';
-export const ANNOUNCEMENTS_REACTION_ADD_SUCCESS = 'ANNOUNCEMENTS_REACTION_ADD_SUCCESS';
-export const ANNOUNCEMENTS_REACTION_ADD_FAIL    = 'ANNOUNCEMENTS_REACTION_ADD_FAIL';
+export const ANNOUNCEMENTS_REACTION_ADD_REQUEST =
+  'ANNOUNCEMENTS_REACTION_ADD_REQUEST';
+export const ANNOUNCEMENTS_REACTION_ADD_SUCCESS =
+  'ANNOUNCEMENTS_REACTION_ADD_SUCCESS';
+export const ANNOUNCEMENTS_REACTION_ADD_FAIL =
+  'ANNOUNCEMENTS_REACTION_ADD_FAIL';
 
-export const ANNOUNCEMENTS_REACTION_REMOVE_REQUEST = 'ANNOUNCEMENTS_REACTION_REMOVE_REQUEST';
-export const ANNOUNCEMENTS_REACTION_REMOVE_SUCCESS = 'ANNOUNCEMENTS_REACTION_REMOVE_SUCCESS';
-export const ANNOUNCEMENTS_REACTION_REMOVE_FAIL    = 'ANNOUNCEMENTS_REACTION_REMOVE_FAIL';
+export const ANNOUNCEMENTS_REACTION_REMOVE_REQUEST =
+  'ANNOUNCEMENTS_REACTION_REMOVE_REQUEST';
+export const ANNOUNCEMENTS_REACTION_REMOVE_SUCCESS =
+  'ANNOUNCEMENTS_REACTION_REMOVE_SUCCESS';
+export const ANNOUNCEMENTS_REACTION_REMOVE_FAIL =
+  'ANNOUNCEMENTS_REACTION_REMOVE_FAIL';
 
 export const ANNOUNCEMENTS_REACTION_UPDATE = 'ANNOUNCEMENTS_REACTION_UPDATE';
 
@@ -26,57 +32,70 @@ export const ANNOUNCEMENTS_TOGGLE_SHOW = 'ANNOUNCEMENTS_TOGGLE_SHOW';
 
 const noOp = () => {};
 
-export const fetchAnnouncements = (done = noOp) => (dispatch, getState) => {
-  dispatch(fetchAnnouncementsRequest());
+export const fetchAnnouncements =
+  (done = noOp) =>
+  (dispatch, getState) => {
+    dispatch(fetchAnnouncementsRequest());
 
-  api(getState).get('/api/v1/announcements').then(response => {
-    dispatch(fetchAnnouncementsSuccess(response.data.map(x => normalizeAnnouncement(x))));
-  }).catch(error => {
-    dispatch(fetchAnnouncementsFail(error));
-  }).finally(() => {
-    done();
-  });
-};
+    api(getState)
+      .get('/api/v1/announcements')
+      .then((response) => {
+        dispatch(
+          fetchAnnouncementsSuccess(
+            response.data.map((x) => normalizeAnnouncement(x)),
+          ),
+        );
+      })
+      .catch((error) => {
+        dispatch(fetchAnnouncementsFail(error));
+      })
+      .finally(() => {
+        done();
+      });
+  };
 
 export const fetchAnnouncementsRequest = () => ({
   type: ANNOUNCEMENTS_FETCH_REQUEST,
   skipLoading: true,
 });
 
-export const fetchAnnouncementsSuccess = announcements => ({
+export const fetchAnnouncementsSuccess = (announcements) => ({
   type: ANNOUNCEMENTS_FETCH_SUCCESS,
   announcements,
   skipLoading: true,
 });
 
-export const fetchAnnouncementsFail= error => ({
+export const fetchAnnouncementsFail = (error) => ({
   type: ANNOUNCEMENTS_FETCH_FAIL,
   error,
   skipLoading: true,
   skipAlert: true,
 });
 
-export const updateAnnouncements = announcement => ({
+export const updateAnnouncements = (announcement) => ({
   type: ANNOUNCEMENTS_UPDATE,
   announcement: normalizeAnnouncement(announcement),
 });
 
-export const dismissAnnouncement = announcementId => (dispatch, getState) => {
+export const dismissAnnouncement = (announcementId) => (dispatch, getState) => {
   dispatch(dismissAnnouncementRequest(announcementId));
 
-  api(getState).post(`/api/v1/announcements/${announcementId}/dismiss`).then(() => {
-    dispatch(dismissAnnouncementSuccess(announcementId));
-  }).catch(error => {
-    dispatch(dismissAnnouncementFail(announcementId, error));
-  });
+  api(getState)
+    .post(`/api/v1/announcements/${announcementId}/dismiss`)
+    .then(() => {
+      dispatch(dismissAnnouncementSuccess(announcementId));
+    })
+    .catch((error) => {
+      dispatch(dismissAnnouncementFail(announcementId, error));
+    });
 };
 
-export const dismissAnnouncementRequest = announcementId => ({
+export const dismissAnnouncementRequest = (announcementId) => ({
   type: ANNOUNCEMENTS_DISMISS_REQUEST,
   id: announcementId,
 });
 
-export const dismissAnnouncementSuccess = announcementId => ({
+export const dismissAnnouncementSuccess = (announcementId) => ({
   type: ANNOUNCEMENTS_DISMISS_SUCCESS,
   id: announcementId,
 });
@@ -88,12 +107,16 @@ export const dismissAnnouncementFail = (announcementId, error) => ({
 });
 
 export const addReaction = (announcementId, name) => (dispatch, getState) => {
-  const announcement = getState().getIn(['announcements', 'items']).find(x => x.get('id') === announcementId);
+  const announcement = getState()
+    .getIn(['announcements', 'items'])
+    .find((x) => x.get('id') === announcementId);
 
   let alreadyAdded = false;
 
   if (announcement) {
-    const reaction = announcement.get('reactions').find(x => x.get('name') === name);
+    const reaction = announcement
+      .get('reactions')
+      .find((x) => x.get('name') === name);
     if (reaction && reaction.get('me')) {
       alreadyAdded = true;
     }
@@ -103,13 +126,20 @@ export const addReaction = (announcementId, name) => (dispatch, getState) => {
     dispatch(addReactionRequest(announcementId, name, alreadyAdded));
   }
 
-  api(getState).put(`/api/v1/announcements/${announcementId}/reactions/${encodeURIComponent(name)}`).then(() => {
-    dispatch(addReactionSuccess(announcementId, name, alreadyAdded));
-  }).catch(err => {
-    if (!alreadyAdded) {
-      dispatch(addReactionFail(announcementId, name, err));
-    }
-  });
+  api(getState)
+    .put(
+      `/api/v1/announcements/${announcementId}/reactions/${encodeURIComponent(
+        name,
+      )}`,
+    )
+    .then(() => {
+      dispatch(addReactionSuccess(announcementId, name, alreadyAdded));
+    })
+    .catch((err) => {
+      if (!alreadyAdded) {
+        dispatch(addReactionFail(announcementId, name, err));
+      }
+    });
 };
 
 export const addReactionRequest = (announcementId, name) => ({
@@ -134,15 +164,23 @@ export const addReactionFail = (announcementId, name, error) => ({
   skipLoading: true,
 });
 
-export const removeReaction = (announcementId, name) => (dispatch, getState) => {
-  dispatch(removeReactionRequest(announcementId, name));
+export const removeReaction =
+  (announcementId, name) => (dispatch, getState) => {
+    dispatch(removeReactionRequest(announcementId, name));
 
-  api(getState).delete(`/api/v1/announcements/${announcementId}/reactions/${encodeURIComponent(name)}`).then(() => {
-    dispatch(removeReactionSuccess(announcementId, name));
-  }).catch(err => {
-    dispatch(removeReactionFail(announcementId, name, err));
-  });
-};
+    api(getState)
+      .delete(
+        `/api/v1/announcements/${announcementId}/reactions/${encodeURIComponent(
+          name,
+        )}`,
+      )
+      .then(() => {
+        dispatch(removeReactionSuccess(announcementId, name));
+      })
+      .catch((err) => {
+        dispatch(removeReactionFail(announcementId, name, err));
+      });
+  };
 
 export const removeReactionRequest = (announcementId, name) => ({
   type: ANNOUNCEMENTS_REACTION_REMOVE_REQUEST,
@@ -166,7 +204,7 @@ export const removeReactionFail = (announcementId, name, error) => ({
   skipLoading: true,
 });
 
-export const updateReaction = reaction => ({
+export const updateReaction = (reaction) => ({
   type: ANNOUNCEMENTS_REACTION_UPDATE,
   reaction,
 });
@@ -175,7 +213,7 @@ export const toggleShowAnnouncements = () => ({
   type: ANNOUNCEMENTS_TOGGLE_SHOW,
 });
 
-export const deleteAnnouncement = id => ({
+export const deleteAnnouncement = (id) => ({
   type: ANNOUNCEMENTS_DELETE,
   id,
 });

--- a/app/javascript/mastodon/actions/blocks.js
+++ b/app/javascript/mastodon/actions/blocks.js
@@ -6,11 +6,11 @@ import { openModal } from './modal';
 
 export const BLOCKS_FETCH_REQUEST = 'BLOCKS_FETCH_REQUEST';
 export const BLOCKS_FETCH_SUCCESS = 'BLOCKS_FETCH_SUCCESS';
-export const BLOCKS_FETCH_FAIL    = 'BLOCKS_FETCH_FAIL';
+export const BLOCKS_FETCH_FAIL = 'BLOCKS_FETCH_FAIL';
 
 export const BLOCKS_EXPAND_REQUEST = 'BLOCKS_EXPAND_REQUEST';
 export const BLOCKS_EXPAND_SUCCESS = 'BLOCKS_EXPAND_SUCCESS';
-export const BLOCKS_EXPAND_FAIL    = 'BLOCKS_EXPAND_FAIL';
+export const BLOCKS_EXPAND_FAIL = 'BLOCKS_EXPAND_FAIL';
 
 export const BLOCKS_INIT_MODAL = 'BLOCKS_INIT_MODAL';
 
@@ -18,12 +18,17 @@ export function fetchBlocks() {
   return (dispatch, getState) => {
     dispatch(fetchBlocksRequest());
 
-    api(getState).get('/api/v1/blocks').then(response => {
-      const next = getLinks(response).refs.find(link => link.rel === 'next');
-      dispatch(importFetchedAccounts(response.data));
-      dispatch(fetchBlocksSuccess(response.data, next ? next.uri : null));
-      dispatch(fetchRelationships(response.data.map(item => item.id)));
-    }).catch(error => dispatch(fetchBlocksFail(error)));
+    api(getState)
+      .get('/api/v1/blocks')
+      .then((response) => {
+        const next = getLinks(response).refs.find(
+          (link) => link.rel === 'next',
+        );
+        dispatch(importFetchedAccounts(response.data));
+        dispatch(fetchBlocksSuccess(response.data, next ? next.uri : null));
+        dispatch(fetchRelationships(response.data.map((item) => item.id)));
+      })
+      .catch((error) => dispatch(fetchBlocksFail(error)));
   };
 }
 
@@ -58,12 +63,17 @@ export function expandBlocks() {
 
     dispatch(expandBlocksRequest());
 
-    api(getState).get(url).then(response => {
-      const next = getLinks(response).refs.find(link => link.rel === 'next');
-      dispatch(importFetchedAccounts(response.data));
-      dispatch(expandBlocksSuccess(response.data, next ? next.uri : null));
-      dispatch(fetchRelationships(response.data.map(item => item.id)));
-    }).catch(error => dispatch(expandBlocksFail(error)));
+    api(getState)
+      .get(url)
+      .then((response) => {
+        const next = getLinks(response).refs.find(
+          (link) => link.rel === 'next',
+        );
+        dispatch(importFetchedAccounts(response.data));
+        dispatch(expandBlocksSuccess(response.data, next ? next.uri : null));
+        dispatch(fetchRelationships(response.data.map((item) => item.id)));
+      })
+      .catch((error) => dispatch(expandBlocksFail(error)));
   };
 }
 
@@ -89,7 +99,7 @@ export function expandBlocksFail(error) {
 }
 
 export function initBlockModal(account) {
-  return dispatch => {
+  return (dispatch) => {
     dispatch({
       type: BLOCKS_INIT_MODAL,
       account,

--- a/app/javascript/mastodon/actions/bookmarks.js
+++ b/app/javascript/mastodon/actions/bookmarks.js
@@ -2,13 +2,18 @@ import api, { getLinks } from '../api';
 
 import { importFetchedStatuses } from './importer';
 
-export const BOOKMARKED_STATUSES_FETCH_REQUEST = 'BOOKMARKED_STATUSES_FETCH_REQUEST';
-export const BOOKMARKED_STATUSES_FETCH_SUCCESS = 'BOOKMARKED_STATUSES_FETCH_SUCCESS';
-export const BOOKMARKED_STATUSES_FETCH_FAIL    = 'BOOKMARKED_STATUSES_FETCH_FAIL';
+export const BOOKMARKED_STATUSES_FETCH_REQUEST =
+  'BOOKMARKED_STATUSES_FETCH_REQUEST';
+export const BOOKMARKED_STATUSES_FETCH_SUCCESS =
+  'BOOKMARKED_STATUSES_FETCH_SUCCESS';
+export const BOOKMARKED_STATUSES_FETCH_FAIL = 'BOOKMARKED_STATUSES_FETCH_FAIL';
 
-export const BOOKMARKED_STATUSES_EXPAND_REQUEST = 'BOOKMARKED_STATUSES_EXPAND_REQUEST';
-export const BOOKMARKED_STATUSES_EXPAND_SUCCESS = 'BOOKMARKED_STATUSES_EXPAND_SUCCESS';
-export const BOOKMARKED_STATUSES_EXPAND_FAIL    = 'BOOKMARKED_STATUSES_EXPAND_FAIL';
+export const BOOKMARKED_STATUSES_EXPAND_REQUEST =
+  'BOOKMARKED_STATUSES_EXPAND_REQUEST';
+export const BOOKMARKED_STATUSES_EXPAND_SUCCESS =
+  'BOOKMARKED_STATUSES_EXPAND_SUCCESS';
+export const BOOKMARKED_STATUSES_EXPAND_FAIL =
+  'BOOKMARKED_STATUSES_EXPAND_FAIL';
 
 export function fetchBookmarkedStatuses() {
   return (dispatch, getState) => {
@@ -18,13 +23,20 @@ export function fetchBookmarkedStatuses() {
 
     dispatch(fetchBookmarkedStatusesRequest());
 
-    api(getState).get('/api/v1/bookmarks').then(response => {
-      const next = getLinks(response).refs.find(link => link.rel === 'next');
-      dispatch(importFetchedStatuses(response.data));
-      dispatch(fetchBookmarkedStatusesSuccess(response.data, next ? next.uri : null));
-    }).catch(error => {
-      dispatch(fetchBookmarkedStatusesFail(error));
-    });
+    api(getState)
+      .get('/api/v1/bookmarks')
+      .then((response) => {
+        const next = getLinks(response).refs.find(
+          (link) => link.rel === 'next',
+        );
+        dispatch(importFetchedStatuses(response.data));
+        dispatch(
+          fetchBookmarkedStatusesSuccess(response.data, next ? next.uri : null),
+        );
+      })
+      .catch((error) => {
+        dispatch(fetchBookmarkedStatusesFail(error));
+      });
   };
 }
 
@@ -53,19 +65,32 @@ export function expandBookmarkedStatuses() {
   return (dispatch, getState) => {
     const url = getState().getIn(['status_lists', 'bookmarks', 'next'], null);
 
-    if (url === null || getState().getIn(['status_lists', 'bookmarks', 'isLoading'])) {
+    if (
+      url === null ||
+      getState().getIn(['status_lists', 'bookmarks', 'isLoading'])
+    ) {
       return;
     }
 
     dispatch(expandBookmarkedStatusesRequest());
 
-    api(getState).get(url).then(response => {
-      const next = getLinks(response).refs.find(link => link.rel === 'next');
-      dispatch(importFetchedStatuses(response.data));
-      dispatch(expandBookmarkedStatusesSuccess(response.data, next ? next.uri : null));
-    }).catch(error => {
-      dispatch(expandBookmarkedStatusesFail(error));
-    });
+    api(getState)
+      .get(url)
+      .then((response) => {
+        const next = getLinks(response).refs.find(
+          (link) => link.rel === 'next',
+        );
+        dispatch(importFetchedStatuses(response.data));
+        dispatch(
+          expandBookmarkedStatusesSuccess(
+            response.data,
+            next ? next.uri : null,
+          ),
+        );
+      })
+      .catch((error) => {
+        dispatch(expandBookmarkedStatusesFail(error));
+      });
   };
 }
 

--- a/app/javascript/mastodon/actions/boosts.js
+++ b/app/javascript/mastodon/actions/boosts.js
@@ -7,23 +7,27 @@ export function initBoostModal(props) {
   return (dispatch, getState) => {
     const default_privacy = getState().getIn(['compose', 'default_privacy']);
 
-    const privacy = props.status.get('visibility') === 'private' ? 'private' : default_privacy;
+    const privacy =
+      props.status.get('visibility') === 'private'
+        ? 'private'
+        : default_privacy;
 
     dispatch({
       type: BOOSTS_INIT_MODAL,
       privacy,
     });
 
-    dispatch(openModal({
-      modalType: 'BOOST',
-      modalProps: props,
-    }));
+    dispatch(
+      openModal({
+        modalType: 'BOOST',
+        modalProps: props,
+      }),
+    );
   };
 }
 
-
 export function changeBoostPrivacy(privacy) {
-  return dispatch => {
+  return (dispatch) => {
     dispatch({
       type: BOOSTS_CHANGE_PRIVACY,
       privacy,

--- a/app/javascript/mastodon/actions/columns.js
+++ b/app/javascript/mastodon/actions/columns.js
@@ -1,12 +1,12 @@
 import { saveSettings } from './settings';
 
-export const COLUMN_ADD           = 'COLUMN_ADD';
-export const COLUMN_REMOVE        = 'COLUMN_REMOVE';
-export const COLUMN_MOVE          = 'COLUMN_MOVE';
+export const COLUMN_ADD = 'COLUMN_ADD';
+export const COLUMN_REMOVE = 'COLUMN_REMOVE';
+export const COLUMN_MOVE = 'COLUMN_MOVE';
 export const COLUMN_PARAMS_CHANGE = 'COLUMN_PARAMS_CHANGE';
 
 export function addColumn(id, params) {
-  return dispatch => {
+  return (dispatch) => {
     dispatch({
       type: COLUMN_ADD,
       id,
@@ -18,7 +18,7 @@ export function addColumn(id, params) {
 }
 
 export function removeColumn(uuid) {
-  return dispatch => {
+  return (dispatch) => {
     dispatch({
       type: COLUMN_REMOVE,
       uuid,
@@ -29,7 +29,7 @@ export function removeColumn(uuid) {
 }
 
 export function moveColumn(uuid, direction) {
-  return dispatch => {
+  return (dispatch) => {
     dispatch({
       type: COLUMN_MOVE,
       uuid,
@@ -41,7 +41,7 @@ export function moveColumn(uuid, direction) {
 }
 
 export function changeColumnParams(uuid, path, value) {
-  return dispatch => {
+  return (dispatch) => {
     dispatch({
       type: COLUMN_PARAMS_CHANGE,
       uuid,

--- a/app/javascript/mastodon/actions/compose.js
+++ b/app/javascript/mastodon/actions/compose.js
@@ -18,26 +18,26 @@ let fetchComposeSuggestionsAccountsController;
 /** @type {AbortController | undefined} */
 let fetchComposeSuggestionsTagsController;
 
-export const COMPOSE_CHANGE          = 'COMPOSE_CHANGE';
-export const COMPOSE_SUBMIT_REQUEST  = 'COMPOSE_SUBMIT_REQUEST';
-export const COMPOSE_SUBMIT_SUCCESS  = 'COMPOSE_SUBMIT_SUCCESS';
-export const COMPOSE_SUBMIT_FAIL     = 'COMPOSE_SUBMIT_FAIL';
-export const COMPOSE_REPLY           = 'COMPOSE_REPLY';
-export const COMPOSE_REPLY_CANCEL    = 'COMPOSE_REPLY_CANCEL';
-export const COMPOSE_DIRECT          = 'COMPOSE_DIRECT';
-export const COMPOSE_MENTION         = 'COMPOSE_MENTION';
-export const COMPOSE_RESET           = 'COMPOSE_RESET';
+export const COMPOSE_CHANGE = 'COMPOSE_CHANGE';
+export const COMPOSE_SUBMIT_REQUEST = 'COMPOSE_SUBMIT_REQUEST';
+export const COMPOSE_SUBMIT_SUCCESS = 'COMPOSE_SUBMIT_SUCCESS';
+export const COMPOSE_SUBMIT_FAIL = 'COMPOSE_SUBMIT_FAIL';
+export const COMPOSE_REPLY = 'COMPOSE_REPLY';
+export const COMPOSE_REPLY_CANCEL = 'COMPOSE_REPLY_CANCEL';
+export const COMPOSE_DIRECT = 'COMPOSE_DIRECT';
+export const COMPOSE_MENTION = 'COMPOSE_MENTION';
+export const COMPOSE_RESET = 'COMPOSE_RESET';
 
-export const COMPOSE_UPLOAD_REQUEST    = 'COMPOSE_UPLOAD_REQUEST';
-export const COMPOSE_UPLOAD_SUCCESS    = 'COMPOSE_UPLOAD_SUCCESS';
-export const COMPOSE_UPLOAD_FAIL       = 'COMPOSE_UPLOAD_FAIL';
-export const COMPOSE_UPLOAD_PROGRESS   = 'COMPOSE_UPLOAD_PROGRESS';
+export const COMPOSE_UPLOAD_REQUEST = 'COMPOSE_UPLOAD_REQUEST';
+export const COMPOSE_UPLOAD_SUCCESS = 'COMPOSE_UPLOAD_SUCCESS';
+export const COMPOSE_UPLOAD_FAIL = 'COMPOSE_UPLOAD_FAIL';
+export const COMPOSE_UPLOAD_PROGRESS = 'COMPOSE_UPLOAD_PROGRESS';
 export const COMPOSE_UPLOAD_PROCESSING = 'COMPOSE_UPLOAD_PROCESSING';
-export const COMPOSE_UPLOAD_UNDO       = 'COMPOSE_UPLOAD_UNDO';
+export const COMPOSE_UPLOAD_UNDO = 'COMPOSE_UPLOAD_UNDO';
 
-export const THUMBNAIL_UPLOAD_REQUEST  = 'THUMBNAIL_UPLOAD_REQUEST';
-export const THUMBNAIL_UPLOAD_SUCCESS  = 'THUMBNAIL_UPLOAD_SUCCESS';
-export const THUMBNAIL_UPLOAD_FAIL     = 'THUMBNAIL_UPLOAD_FAIL';
+export const THUMBNAIL_UPLOAD_REQUEST = 'THUMBNAIL_UPLOAD_REQUEST';
+export const THUMBNAIL_UPLOAD_SUCCESS = 'THUMBNAIL_UPLOAD_SUCCESS';
+export const THUMBNAIL_UPLOAD_FAIL = 'THUMBNAIL_UPLOAD_FAIL';
 export const THUMBNAIL_UPLOAD_PROGRESS = 'THUMBNAIL_UPLOAD_PROGRESS';
 
 export const COMPOSE_SUGGESTIONS_CLEAR = 'COMPOSE_SUGGESTIONS_CLEAR';
@@ -48,42 +48,52 @@ export const COMPOSE_SUGGESTION_TAGS_UPDATE = 'COMPOSE_SUGGESTION_TAGS_UPDATE';
 
 export const COMPOSE_TAG_HISTORY_UPDATE = 'COMPOSE_TAG_HISTORY_UPDATE';
 
-export const COMPOSE_MOUNT   = 'COMPOSE_MOUNT';
+export const COMPOSE_MOUNT = 'COMPOSE_MOUNT';
 export const COMPOSE_UNMOUNT = 'COMPOSE_UNMOUNT';
 
-export const COMPOSE_SENSITIVITY_CHANGE  = 'COMPOSE_SENSITIVITY_CHANGE';
-export const COMPOSE_SPOILERNESS_CHANGE  = 'COMPOSE_SPOILERNESS_CHANGE';
+export const COMPOSE_SENSITIVITY_CHANGE = 'COMPOSE_SENSITIVITY_CHANGE';
+export const COMPOSE_SPOILERNESS_CHANGE = 'COMPOSE_SPOILERNESS_CHANGE';
 export const COMPOSE_SPOILER_TEXT_CHANGE = 'COMPOSE_SPOILER_TEXT_CHANGE';
-export const COMPOSE_VISIBILITY_CHANGE   = 'COMPOSE_VISIBILITY_CHANGE';
-export const COMPOSE_COMPOSING_CHANGE    = 'COMPOSE_COMPOSING_CHANGE';
-export const COMPOSE_LANGUAGE_CHANGE     = 'COMPOSE_LANGUAGE_CHANGE';
+export const COMPOSE_VISIBILITY_CHANGE = 'COMPOSE_VISIBILITY_CHANGE';
+export const COMPOSE_COMPOSING_CHANGE = 'COMPOSE_COMPOSING_CHANGE';
+export const COMPOSE_LANGUAGE_CHANGE = 'COMPOSE_LANGUAGE_CHANGE';
 
 export const COMPOSE_EMOJI_INSERT = 'COMPOSE_EMOJI_INSERT';
 
-export const COMPOSE_UPLOAD_CHANGE_REQUEST     = 'COMPOSE_UPLOAD_UPDATE_REQUEST';
-export const COMPOSE_UPLOAD_CHANGE_SUCCESS     = 'COMPOSE_UPLOAD_UPDATE_SUCCESS';
-export const COMPOSE_UPLOAD_CHANGE_FAIL        = 'COMPOSE_UPLOAD_UPDATE_FAIL';
+export const COMPOSE_UPLOAD_CHANGE_REQUEST = 'COMPOSE_UPLOAD_UPDATE_REQUEST';
+export const COMPOSE_UPLOAD_CHANGE_SUCCESS = 'COMPOSE_UPLOAD_UPDATE_SUCCESS';
+export const COMPOSE_UPLOAD_CHANGE_FAIL = 'COMPOSE_UPLOAD_UPDATE_FAIL';
 
-export const COMPOSE_POLL_ADD             = 'COMPOSE_POLL_ADD';
-export const COMPOSE_POLL_REMOVE          = 'COMPOSE_POLL_REMOVE';
-export const COMPOSE_POLL_OPTION_ADD      = 'COMPOSE_POLL_OPTION_ADD';
-export const COMPOSE_POLL_OPTION_CHANGE   = 'COMPOSE_POLL_OPTION_CHANGE';
-export const COMPOSE_POLL_OPTION_REMOVE   = 'COMPOSE_POLL_OPTION_REMOVE';
+export const COMPOSE_POLL_ADD = 'COMPOSE_POLL_ADD';
+export const COMPOSE_POLL_REMOVE = 'COMPOSE_POLL_REMOVE';
+export const COMPOSE_POLL_OPTION_ADD = 'COMPOSE_POLL_OPTION_ADD';
+export const COMPOSE_POLL_OPTION_CHANGE = 'COMPOSE_POLL_OPTION_CHANGE';
+export const COMPOSE_POLL_OPTION_REMOVE = 'COMPOSE_POLL_OPTION_REMOVE';
 export const COMPOSE_POLL_SETTINGS_CHANGE = 'COMPOSE_POLL_SETTINGS_CHANGE';
 
 export const INIT_MEDIA_EDIT_MODAL = 'INIT_MEDIA_EDIT_MODAL';
 
-export const COMPOSE_CHANGE_MEDIA_DESCRIPTION = 'COMPOSE_CHANGE_MEDIA_DESCRIPTION';
-export const COMPOSE_CHANGE_MEDIA_FOCUS       = 'COMPOSE_CHANGE_MEDIA_FOCUS';
+export const COMPOSE_CHANGE_MEDIA_DESCRIPTION =
+  'COMPOSE_CHANGE_MEDIA_DESCRIPTION';
+export const COMPOSE_CHANGE_MEDIA_FOCUS = 'COMPOSE_CHANGE_MEDIA_FOCUS';
 
 export const COMPOSE_SET_STATUS = 'COMPOSE_SET_STATUS';
 export const COMPOSE_FOCUS = 'COMPOSE_FOCUS';
 
 const messages = defineMessages({
-  uploadErrorLimit: { id: 'upload_error.limit', defaultMessage: 'File upload limit exceeded.' },
-  uploadErrorPoll:  { id: 'upload_error.poll', defaultMessage: 'File upload not allowed with polls.' },
+  uploadErrorLimit: {
+    id: 'upload_error.limit',
+    defaultMessage: 'File upload limit exceeded.',
+  },
+  uploadErrorPoll: {
+    id: 'upload_error.poll',
+    defaultMessage: 'File upload not allowed with polls.',
+  },
   open: { id: 'compose.published.open', defaultMessage: 'Open' },
-  published: { id: 'compose.published.body', defaultMessage: 'Post published.' },
+  published: {
+    id: 'compose.published.body',
+    defaultMessage: 'Post published.',
+  },
   saved: { id: 'compose.saved.body', defaultMessage: 'Post saved.' },
 });
 
@@ -94,7 +104,7 @@ export const ensureComposeIsVisible = (getState, routerHistory) => {
 };
 
 export function setComposeToStatus(status, text, spoiler_text) {
-  return{
+  return {
     type: COMPOSE_SET_STATUS,
     status,
     text,
@@ -132,14 +142,15 @@ export function resetCompose() {
   };
 }
 
-export const focusCompose = (routerHistory, defaultText) => (dispatch, getState) => {
-  dispatch({
-    type: COMPOSE_FOCUS,
-    defaultText,
-  });
+export const focusCompose =
+  (routerHistory, defaultText) => (dispatch, getState) => {
+    dispatch({
+      type: COMPOSE_FOCUS,
+      defaultText,
+    });
 
-  ensureComposeIsVisible(getState, routerHistory);
-};
+    ensureComposeIsVisible(getState, routerHistory);
+  };
 
 export function mentionCompose(account, routerHistory) {
   return (dispatch, getState) => {
@@ -165,8 +176,8 @@ export function directCompose(account, routerHistory) {
 
 export function submitCompose(routerHistory) {
   return function (dispatch, getState) {
-    const status   = getState().getIn(['compose', 'text'], '');
-    const media    = getState().getIn(['compose', 'media_attachments']);
+    const status = getState().getIn(['compose', 'text'], '');
+    const media = getState().getIn(['compose', 'media_attachments']);
     const statusId = getState().getIn(['compose', 'id'], null);
 
     if ((!status || !status.length) && media.size === 0) {
@@ -180,11 +191,13 @@ export function submitCompose(routerHistory) {
     // API call.
     let media_attributes;
     if (statusId !== null) {
-      media_attributes = media.map(item => {
+      media_attributes = media.map((item) => {
         let focus;
 
         if (item.getIn(['meta', 'focus'])) {
-          focus = `${item.getIn(['meta', 'focus', 'x']).toFixed(2)},${item.getIn(['meta', 'focus', 'y']).toFixed(2)}`;
+          focus = `${item.getIn(['meta', 'focus', 'x']).toFixed(2)},${item
+            .getIn(['meta', 'focus', 'y'])
+            .toFixed(2)}`;
         }
 
         return {
@@ -195,64 +208,91 @@ export function submitCompose(routerHistory) {
       });
     }
 
-    api(getState).request({
-      url: statusId === null ? '/api/v1/statuses' : `/api/v1/statuses/${statusId}`,
-      method: statusId === null ? 'post' : 'put',
-      data: {
-        status,
-        in_reply_to_id: getState().getIn(['compose', 'in_reply_to'], null),
-        media_ids: media.map(item => item.get('id')),
-        media_attributes,
-        sensitive: getState().getIn(['compose', 'sensitive']),
-        spoiler_text: getState().getIn(['compose', 'spoiler']) ? getState().getIn(['compose', 'spoiler_text'], '') : '',
-        visibility: getState().getIn(['compose', 'privacy']),
-        poll: getState().getIn(['compose', 'poll'], null),
-        language: getState().getIn(['compose', 'language']),
-      },
-      headers: {
-        'Idempotency-Key': getState().getIn(['compose', 'idempotencyKey']),
-      },
-    }).then(function (response) {
-      if (routerHistory && (routerHistory.location.pathname === '/publish' || routerHistory.location.pathname === '/statuses/new') && window.history.state) {
-        routerHistory.goBack();
-      }
-
-      dispatch(insertIntoTagHistory(response.data.tags, status));
-      dispatch(submitComposeSuccess({ ...response.data }));
-
-      // To make the app more responsive, immediately push the status
-      // into the columns
-      const insertIfOnline = timelineId => {
-        const timeline = getState().getIn(['timelines', timelineId]);
-
-        if (timeline && timeline.get('items').size > 0 && timeline.getIn(['items', 0]) !== null && timeline.get('online')) {
-          dispatch(updateTimeline(timelineId, { ...response.data }));
+    api(getState)
+      .request({
+        url:
+          statusId === null
+            ? '/api/v1/statuses'
+            : `/api/v1/statuses/${statusId}`,
+        method: statusId === null ? 'post' : 'put',
+        data: {
+          status,
+          in_reply_to_id: getState().getIn(['compose', 'in_reply_to'], null),
+          media_ids: media.map((item) => item.get('id')),
+          media_attributes,
+          sensitive: getState().getIn(['compose', 'sensitive']),
+          spoiler_text: getState().getIn(['compose', 'spoiler'])
+            ? getState().getIn(['compose', 'spoiler_text'], '')
+            : '',
+          visibility: getState().getIn(['compose', 'privacy']),
+          poll: getState().getIn(['compose', 'poll'], null),
+          language: getState().getIn(['compose', 'language']),
+        },
+        headers: {
+          'Idempotency-Key': getState().getIn(['compose', 'idempotencyKey']),
+        },
+      })
+      .then(function (response) {
+        if (
+          routerHistory &&
+          (routerHistory.location.pathname === '/publish' ||
+            routerHistory.location.pathname === '/statuses/new') &&
+          window.history.state
+        ) {
+          routerHistory.goBack();
         }
-      };
 
-      if (statusId) {
-        dispatch(importFetchedStatus({ ...response.data }));
-      }
+        dispatch(insertIntoTagHistory(response.data.tags, status));
+        dispatch(submitComposeSuccess({ ...response.data }));
 
-      if (statusId === null && response.data.visibility !== 'direct') {
-        insertIfOnline('home');
-      }
+        // To make the app more responsive, immediately push the status
+        // into the columns
+        const insertIfOnline = (timelineId) => {
+          const timeline = getState().getIn(['timelines', timelineId]);
 
-      if (statusId === null && response.data.in_reply_to_id === null && response.data.visibility === 'public') {
-        insertIfOnline('community');
-        insertIfOnline('public');
-        insertIfOnline(`account:${response.data.account.id}`);
-      }
+          if (
+            timeline &&
+            timeline.get('items').size > 0 &&
+            timeline.getIn(['items', 0]) !== null &&
+            timeline.get('online')
+          ) {
+            dispatch(updateTimeline(timelineId, { ...response.data }));
+          }
+        };
 
-      dispatch(showAlert({
-        message: statusId === null ? messages.published : messages.saved,
-        action: messages.open,
-        dismissAfter: 10000,
-        onClick: () => routerHistory.push(`/@${response.data.account.username}/${response.data.id}`),
-      }));
-    }).catch(function (error) {
-      dispatch(submitComposeFail(error));
-    });
+        if (statusId) {
+          dispatch(importFetchedStatus({ ...response.data }));
+        }
+
+        if (statusId === null && response.data.visibility !== 'direct') {
+          insertIfOnline('home');
+        }
+
+        if (
+          statusId === null &&
+          response.data.in_reply_to_id === null &&
+          response.data.visibility === 'public'
+        ) {
+          insertIfOnline('community');
+          insertIfOnline('public');
+          insertIfOnline(`account:${response.data.account.id}`);
+        }
+
+        dispatch(
+          showAlert({
+            message: statusId === null ? messages.published : messages.saved,
+            action: messages.open,
+            dismissAfter: 10000,
+            onClick: () =>
+              routerHistory.push(
+                `/@${response.data.account.username}/${response.data.id}`,
+              ),
+          }),
+        );
+      })
+      .catch(function (error) {
+        dispatch(submitComposeFail(error));
+      });
   };
 }
 
@@ -303,37 +343,48 @@ export function uploadCompose(files) {
       const data = new FormData();
       data.append('file', file);
 
-      api(getState).post('/api/v2/media', data, {
-        onUploadProgress: function({ loaded }){
-          progress[i] = loaded;
-          dispatch(uploadComposeProgress(progress.reduce((a, v) => a + v, 0), total));
-        },
-      }).then(({ status, data }) => {
-        // If server-side processing of the media attachment has not completed yet,
-        // poll the server until it is, before showing the media attachment as uploaded
+      api(getState)
+        .post('/api/v2/media', data, {
+          onUploadProgress: function ({ loaded }) {
+            progress[i] = loaded;
+            dispatch(
+              uploadComposeProgress(
+                progress.reduce((a, v) => a + v, 0),
+                total,
+              ),
+            );
+          },
+        })
+        .then(({ status, data }) => {
+          // If server-side processing of the media attachment has not completed yet,
+          // poll the server until it is, before showing the media attachment as uploaded
 
-        if (status === 200) {
-          dispatch(uploadComposeSuccess(data, file));
-        } else if (status === 202) {
-          dispatch(uploadComposeProcessing());
+          if (status === 200) {
+            dispatch(uploadComposeSuccess(data, file));
+          } else if (status === 202) {
+            dispatch(uploadComposeProcessing());
 
-          let tryCount = 1;
+            let tryCount = 1;
 
-          const poll = () => {
-            api(getState).get(`/api/v1/media/${data.id}`).then(response => {
-              if (response.status === 200) {
-                dispatch(uploadComposeSuccess(response.data, file));
-              } else if (response.status === 206) {
-                const retryAfter = (Math.log2(tryCount) || 1) * 1000;
-                tryCount += 1;
-                setTimeout(() => poll(), retryAfter);
-              }
-            }).catch(error => dispatch(uploadComposeFail(error)));
-          };
+            const poll = () => {
+              api(getState)
+                .get(`/api/v1/media/${data.id}`)
+                .then((response) => {
+                  if (response.status === 200) {
+                    dispatch(uploadComposeSuccess(response.data, file));
+                  } else if (response.status === 206) {
+                    const retryAfter = (Math.log2(tryCount) || 1) * 1000;
+                    tryCount += 1;
+                    setTimeout(() => poll(), retryAfter);
+                  }
+                })
+                .catch((error) => dispatch(uploadComposeFail(error)));
+            };
 
-          poll();
-        }
-      }).catch(error => dispatch(uploadComposeFail(error)));
+            poll();
+          }
+        })
+        .catch((error) => dispatch(uploadComposeFail(error)));
     }
   };
 }
@@ -350,15 +401,18 @@ export const uploadThumbnail = (id, file) => (dispatch, getState) => {
 
   data.append('thumbnail', file);
 
-  api(getState).put(`/api/v1/media/${id}`, data, {
-    onUploadProgress: ({ loaded }) => {
-      dispatch(uploadThumbnailProgress(loaded, total));
-    },
-  }).then(({ data }) => {
-    dispatch(uploadThumbnailSuccess(data));
-  }).catch(error => {
-    dispatch(uploadThumbnailFail(id, error));
-  });
+  api(getState)
+    .put(`/api/v1/media/${id}`, data, {
+      onUploadProgress: ({ loaded }) => {
+        dispatch(uploadThumbnailProgress(loaded, total));
+      },
+    })
+    .then(({ data }) => {
+      dispatch(uploadThumbnailSuccess(data));
+    })
+    .catch((error) => {
+      dispatch(uploadThumbnailFail(id, error));
+    });
 };
 
 export const uploadThumbnailRequest = () => ({
@@ -373,29 +427,31 @@ export const uploadThumbnailProgress = (loaded, total) => ({
   skipLoading: true,
 });
 
-export const uploadThumbnailSuccess = media => ({
+export const uploadThumbnailSuccess = (media) => ({
   type: THUMBNAIL_UPLOAD_SUCCESS,
   media,
   skipLoading: true,
 });
 
-export const uploadThumbnailFail = error => ({
+export const uploadThumbnailFail = (error) => ({
   type: THUMBNAIL_UPLOAD_FAIL,
   error,
   skipLoading: true,
 });
 
 export function initMediaEditModal(id) {
-  return dispatch => {
+  return (dispatch) => {
     dispatch({
       type: INIT_MEDIA_EDIT_MODAL,
       id,
     });
 
-    dispatch(openModal({
-      modalType: 'FOCAL_POINT',
-      modalProps: { id },
-    }));
+    dispatch(
+      openModal({
+        modalType: 'FOCAL_POINT',
+        modalProps: { id },
+      }),
+    );
   };
 }
 
@@ -418,7 +474,9 @@ export function changeUploadCompose(id, params) {
   return (dispatch, getState) => {
     dispatch(changeUploadComposeRequest());
 
-    let media = getState().getIn(['compose', 'media_attachments']).find((item) => item.get('id') === id);
+    let media = getState()
+      .getIn(['compose', 'media_attachments'])
+      .find((item) => item.get('id') === id);
 
     // Editing already-attached media is deferred to editing the post itself.
     // For simplicity's sake, fake an API reply.
@@ -433,11 +491,14 @@ export function changeUploadCompose(id, params) {
 
       dispatch(changeUploadComposeSuccess(data, true));
     } else {
-      api(getState).put(`/api/v1/media/${id}`, params).then(response => {
-        dispatch(changeUploadComposeSuccess(response.data, false));
-      }).catch(error => {
-        dispatch(changeUploadComposeFail(id, error));
-      });
+      api(getState)
+        .put(`/api/v1/media/${id}`, params)
+        .then((response) => {
+          dispatch(changeUploadComposeSuccess(response.data, false));
+        })
+        .catch((error) => {
+          dispatch(changeUploadComposeFail(id, error));
+        });
     }
   };
 }
@@ -514,80 +575,96 @@ export function clearComposeSuggestions() {
   };
 }
 
-const fetchComposeSuggestionsAccounts = throttle((dispatch, getState, token) => {
-  if (fetchComposeSuggestionsAccountsController) {
-    fetchComposeSuggestionsAccountsController.abort();
-  }
-
-  fetchComposeSuggestionsAccountsController = new AbortController();
-
-  api(getState).get('/api/v1/accounts/search', {
-    signal: fetchComposeSuggestionsAccountsController.signal,
-
-    params: {
-      q: token.slice(1),
-      resolve: false,
-      limit: 4,
-    },
-  }).then(response => {
-    dispatch(importFetchedAccounts(response.data));
-    dispatch(readyComposeSuggestionsAccounts(token, response.data));
-  }).catch(error => {
-    if (!axios.isCancel(error)) {
-      dispatch(showAlertForError(error));
+const fetchComposeSuggestionsAccounts = throttle(
+  (dispatch, getState, token) => {
+    if (fetchComposeSuggestionsAccountsController) {
+      fetchComposeSuggestionsAccountsController.abort();
     }
-  }).finally(() => {
-    fetchComposeSuggestionsAccountsController = undefined;
-  });
-}, 200, { leading: true, trailing: true });
+
+    fetchComposeSuggestionsAccountsController = new AbortController();
+
+    api(getState)
+      .get('/api/v1/accounts/search', {
+        signal: fetchComposeSuggestionsAccountsController.signal,
+
+        params: {
+          q: token.slice(1),
+          resolve: false,
+          limit: 4,
+        },
+      })
+      .then((response) => {
+        dispatch(importFetchedAccounts(response.data));
+        dispatch(readyComposeSuggestionsAccounts(token, response.data));
+      })
+      .catch((error) => {
+        if (!axios.isCancel(error)) {
+          dispatch(showAlertForError(error));
+        }
+      })
+      .finally(() => {
+        fetchComposeSuggestionsAccountsController = undefined;
+      });
+  },
+  200,
+  { leading: true, trailing: true },
+);
 
 const fetchComposeSuggestionsEmojis = (dispatch, getState, token) => {
   const results = emojiSearch(token.replace(':', ''), { maxResults: 5 });
   dispatch(readyComposeSuggestionsEmojis(token, results));
 };
 
-const fetchComposeSuggestionsTags = throttle((dispatch, getState, token) => {
-  if (fetchComposeSuggestionsTagsController) {
-    fetchComposeSuggestionsTagsController.abort();
-  }
-
-  dispatch(updateSuggestionTags(token));
-
-  fetchComposeSuggestionsTagsController = new AbortController();
-
-  api(getState).get('/api/v2/search', {
-    signal: fetchComposeSuggestionsTagsController.signal,
-
-    params: {
-      type: 'hashtags',
-      q: token.slice(1),
-      resolve: false,
-      limit: 4,
-      exclude_unreviewed: true,
-    },
-  }).then(({ data }) => {
-    dispatch(readyComposeSuggestionsTags(token, data.hashtags));
-  }).catch(error => {
-    if (!axios.isCancel(error)) {
-      dispatch(showAlertForError(error));
+const fetchComposeSuggestionsTags = throttle(
+  (dispatch, getState, token) => {
+    if (fetchComposeSuggestionsTagsController) {
+      fetchComposeSuggestionsTagsController.abort();
     }
-  }).finally(() => {
-    fetchComposeSuggestionsTagsController = undefined;
-  });
-}, 200, { leading: true, trailing: true });
+
+    dispatch(updateSuggestionTags(token));
+
+    fetchComposeSuggestionsTagsController = new AbortController();
+
+    api(getState)
+      .get('/api/v2/search', {
+        signal: fetchComposeSuggestionsTagsController.signal,
+
+        params: {
+          type: 'hashtags',
+          q: token.slice(1),
+          resolve: false,
+          limit: 4,
+          exclude_unreviewed: true,
+        },
+      })
+      .then(({ data }) => {
+        dispatch(readyComposeSuggestionsTags(token, data.hashtags));
+      })
+      .catch((error) => {
+        if (!axios.isCancel(error)) {
+          dispatch(showAlertForError(error));
+        }
+      })
+      .finally(() => {
+        fetchComposeSuggestionsTagsController = undefined;
+      });
+  },
+  200,
+  { leading: true, trailing: true },
+);
 
 export function fetchComposeSuggestions(token) {
   return (dispatch, getState) => {
     switch (token[0]) {
-    case ':':
-      fetchComposeSuggestionsEmojis(dispatch, getState, token);
-      break;
-    case '#':
-      fetchComposeSuggestionsTags(dispatch, getState, token);
-      break;
-    default:
-      fetchComposeSuggestionsAccounts(dispatch, getState, token);
-      break;
+      case ':':
+        fetchComposeSuggestionsEmojis(dispatch, getState, token);
+        break;
+      case '#':
+        fetchComposeSuggestionsTags(dispatch, getState, token);
+        break;
+      default:
+        fetchComposeSuggestionsAccounts(dispatch, getState, token);
+        break;
     }
   };
 }
@@ -619,21 +696,26 @@ export function selectComposeSuggestion(position, token, suggestion, path) {
     let completion, startPosition;
 
     if (suggestion.type === 'emoji') {
-      completion    = suggestion.native || suggestion.colons;
+      completion = suggestion.native || suggestion.colons;
       startPosition = position - 1;
 
       dispatch(useEmoji(suggestion));
     } else if (suggestion.type === 'hashtag') {
-      completion    = `#${suggestion.name}`;
+      completion = `#${suggestion.name}`;
       startPosition = position - 1;
     } else if (suggestion.type === 'account') {
-      completion    = getState().getIn(['accounts', suggestion.id, 'acct']);
+      completion = getState().getIn(['accounts', suggestion.id, 'acct']);
       startPosition = position;
     }
 
     // We don't want to replace hashtags that vary only in case due to accessibility, but we need to fire off an event so that
     // the suggestions are dismissed and the cursor moves forward.
-    if (suggestion.type !== 'hashtag' || token.slice(1).localeCompare(suggestion.name, undefined, { sensitivity: 'accent' }) !== 0) {
+    if (
+      suggestion.type !== 'hashtag' ||
+      token.slice(1).localeCompare(suggestion.name, undefined, {
+        sensitivity: 'accent',
+      }) !== 0
+    ) {
       dispatch({
         type: COMPOSE_SUGGESTION_SELECT,
         position: startPosition,
@@ -687,7 +769,7 @@ function insertIntoTagHistory(recognizedTags, text) {
     // FIXME: Matching input hashtags with recognized hashtags has become more
     // complicated because of new normalization rules, it's no longer just
     // a case sensitivity issue
-    const names = recognizedTags.map(tag => {
+    const names = recognizedTags.map((tag) => {
       const matches = text.match(new RegExp(`#${tag.name}`, 'i'));
 
       if (matches && matches.length > 0) {
@@ -697,7 +779,12 @@ function insertIntoTagHistory(recognizedTags, text) {
       }
     });
 
-    const intersectedOldHistory = oldHistory.filter(name => names.findIndex(newName => newName.toLowerCase() === name.toLowerCase()) === -1);
+    const intersectedOldHistory = oldHistory.filter(
+      (name) =>
+        names.findIndex(
+          (newName) => newName.toLowerCase() === name.toLowerCase(),
+        ) === -1,
+    );
 
     names.push(...intersectedOldHistory.toJS());
 
@@ -726,7 +813,7 @@ export function changeComposeSensitivity() {
   };
 }
 
-export const changeComposeLanguage = language => ({
+export const changeComposeLanguage = (language) => ({
   type: COMPOSE_LANGUAGE_CHANGE,
   language,
 });

--- a/app/javascript/mastodon/actions/conversations.js
+++ b/app/javascript/mastodon/actions/conversations.js
@@ -6,19 +6,19 @@ import {
   importFetchedStatus,
 } from './importer';
 
-export const CONVERSATIONS_MOUNT   = 'CONVERSATIONS_MOUNT';
+export const CONVERSATIONS_MOUNT = 'CONVERSATIONS_MOUNT';
 export const CONVERSATIONS_UNMOUNT = 'CONVERSATIONS_UNMOUNT';
 
 export const CONVERSATIONS_FETCH_REQUEST = 'CONVERSATIONS_FETCH_REQUEST';
 export const CONVERSATIONS_FETCH_SUCCESS = 'CONVERSATIONS_FETCH_SUCCESS';
-export const CONVERSATIONS_FETCH_FAIL    = 'CONVERSATIONS_FETCH_FAIL';
-export const CONVERSATIONS_UPDATE        = 'CONVERSATIONS_UPDATE';
+export const CONVERSATIONS_FETCH_FAIL = 'CONVERSATIONS_FETCH_FAIL';
+export const CONVERSATIONS_UPDATE = 'CONVERSATIONS_UPDATE';
 
 export const CONVERSATIONS_READ = 'CONVERSATIONS_READ';
 
 export const CONVERSATIONS_DELETE_REQUEST = 'CONVERSATIONS_DELETE_REQUEST';
 export const CONVERSATIONS_DELETE_SUCCESS = 'CONVERSATIONS_DELETE_SUCCESS';
-export const CONVERSATIONS_DELETE_FAIL    = 'CONVERSATIONS_DELETE_FAIL';
+export const CONVERSATIONS_DELETE_FAIL = 'CONVERSATIONS_DELETE_FAIL';
 
 export const mountConversations = () => ({
   type: CONVERSATIONS_MOUNT,
@@ -28,54 +28,86 @@ export const unmountConversations = () => ({
   type: CONVERSATIONS_UNMOUNT,
 });
 
-export const markConversationRead = conversationId => (dispatch, getState) => {
-  dispatch({
-    type: CONVERSATIONS_READ,
-    id: conversationId,
-  });
+export const markConversationRead =
+  (conversationId) => (dispatch, getState) => {
+    dispatch({
+      type: CONVERSATIONS_READ,
+      id: conversationId,
+    });
 
-  api(getState).post(`/api/v1/conversations/${conversationId}/read`);
-};
+    api(getState).post(`/api/v1/conversations/${conversationId}/read`);
+  };
 
-export const expandConversations = ({ maxId } = {}) => (dispatch, getState) => {
-  dispatch(expandConversationsRequest());
+export const expandConversations =
+  ({ maxId } = {}) =>
+  (dispatch, getState) => {
+    dispatch(expandConversationsRequest());
 
-  const params = { max_id: maxId };
+    const params = { max_id: maxId };
 
-  if (!maxId) {
-    params.since_id = getState().getIn(['conversations', 'items', 0, 'last_status']);
-  }
+    if (!maxId) {
+      params.since_id = getState().getIn([
+        'conversations',
+        'items',
+        0,
+        'last_status',
+      ]);
+    }
 
-  const isLoadingRecent = !!params.since_id;
+    const isLoadingRecent = !!params.since_id;
 
-  api(getState).get('/api/v1/conversations', { params })
-    .then(response => {
-      const next = getLinks(response).refs.find(link => link.rel === 'next');
+    api(getState)
+      .get('/api/v1/conversations', { params })
+      .then((response) => {
+        const next = getLinks(response).refs.find(
+          (link) => link.rel === 'next',
+        );
 
-      dispatch(importFetchedAccounts(response.data.reduce((aggr, item) => aggr.concat(item.accounts), [])));
-      dispatch(importFetchedStatuses(response.data.map(item => item.last_status).filter(x => !!x)));
-      dispatch(expandConversationsSuccess(response.data, next ? next.uri : null, isLoadingRecent));
-    })
-    .catch(err => dispatch(expandConversationsFail(err)));
-};
+        dispatch(
+          importFetchedAccounts(
+            response.data.reduce(
+              (aggr, item) => aggr.concat(item.accounts),
+              [],
+            ),
+          ),
+        );
+        dispatch(
+          importFetchedStatuses(
+            response.data.map((item) => item.last_status).filter((x) => !!x),
+          ),
+        );
+        dispatch(
+          expandConversationsSuccess(
+            response.data,
+            next ? next.uri : null,
+            isLoadingRecent,
+          ),
+        );
+      })
+      .catch((err) => dispatch(expandConversationsFail(err)));
+  };
 
 export const expandConversationsRequest = () => ({
   type: CONVERSATIONS_FETCH_REQUEST,
 });
 
-export const expandConversationsSuccess = (conversations, next, isLoadingRecent) => ({
+export const expandConversationsSuccess = (
+  conversations,
+  next,
+  isLoadingRecent,
+) => ({
   type: CONVERSATIONS_FETCH_SUCCESS,
   conversations,
   next,
   isLoadingRecent,
 });
 
-export const expandConversationsFail = error => ({
+export const expandConversationsFail = (error) => ({
   type: CONVERSATIONS_FETCH_FAIL,
   error,
 });
 
-export const updateConversations = conversation => dispatch => {
+export const updateConversations = (conversation) => (dispatch) => {
   dispatch(importFetchedAccounts(conversation.accounts));
 
   if (conversation.last_status) {
@@ -88,20 +120,21 @@ export const updateConversations = conversation => dispatch => {
   });
 };
 
-export const deleteConversation = conversationId => (dispatch, getState) => {
+export const deleteConversation = (conversationId) => (dispatch, getState) => {
   dispatch(deleteConversationRequest(conversationId));
 
-  api(getState).delete(`/api/v1/conversations/${conversationId}`)
+  api(getState)
+    .delete(`/api/v1/conversations/${conversationId}`)
     .then(() => dispatch(deleteConversationSuccess(conversationId)))
-    .catch(error => dispatch(deleteConversationFail(conversationId, error)));
+    .catch((error) => dispatch(deleteConversationFail(conversationId, error)));
 };
 
-export const deleteConversationRequest = id => ({
+export const deleteConversationRequest = (id) => ({
   type: CONVERSATIONS_DELETE_REQUEST,
   id,
 });
 
-export const deleteConversationSuccess = id => ({
+export const deleteConversationSuccess = (id) => ({
   type: CONVERSATIONS_DELETE_SUCCESS,
   id,
 });

--- a/app/javascript/mastodon/actions/custom_emojis.js
+++ b/app/javascript/mastodon/actions/custom_emojis.js
@@ -8,11 +8,14 @@ export function fetchCustomEmojis() {
   return (dispatch, getState) => {
     dispatch(fetchCustomEmojisRequest());
 
-    api(getState).get('/api/v1/custom_emojis').then(response => {
-      dispatch(fetchCustomEmojisSuccess(response.data));
-    }).catch(error => {
-      dispatch(fetchCustomEmojisFail(error));
-    });
+    api(getState)
+      .get('/api/v1/custom_emojis')
+      .then((response) => {
+        dispatch(fetchCustomEmojisSuccess(response.data));
+      })
+      .catch((error) => {
+        dispatch(fetchCustomEmojisFail(error));
+      });
   };
 }
 

--- a/app/javascript/mastodon/actions/directory.js
+++ b/app/javascript/mastodon/actions/directory.js
@@ -5,58 +5,70 @@ import { importFetchedAccounts } from './importer';
 
 export const DIRECTORY_FETCH_REQUEST = 'DIRECTORY_FETCH_REQUEST';
 export const DIRECTORY_FETCH_SUCCESS = 'DIRECTORY_FETCH_SUCCESS';
-export const DIRECTORY_FETCH_FAIL    = 'DIRECTORY_FETCH_FAIL';
+export const DIRECTORY_FETCH_FAIL = 'DIRECTORY_FETCH_FAIL';
 
 export const DIRECTORY_EXPAND_REQUEST = 'DIRECTORY_EXPAND_REQUEST';
 export const DIRECTORY_EXPAND_SUCCESS = 'DIRECTORY_EXPAND_SUCCESS';
-export const DIRECTORY_EXPAND_FAIL    = 'DIRECTORY_EXPAND_FAIL';
+export const DIRECTORY_EXPAND_FAIL = 'DIRECTORY_EXPAND_FAIL';
 
-export const fetchDirectory = params => (dispatch, getState) => {
+export const fetchDirectory = (params) => (dispatch, getState) => {
   dispatch(fetchDirectoryRequest());
 
-  api(getState).get('/api/v1/directory', { params: { ...params, limit: 20 } }).then(({ data }) => {
-    dispatch(importFetchedAccounts(data));
-    dispatch(fetchDirectorySuccess(data));
-    dispatch(fetchRelationships(data.map(x => x.id)));
-  }).catch(error => dispatch(fetchDirectoryFail(error)));
+  api(getState)
+    .get('/api/v1/directory', { params: { ...params, limit: 20 } })
+    .then(({ data }) => {
+      dispatch(importFetchedAccounts(data));
+      dispatch(fetchDirectorySuccess(data));
+      dispatch(fetchRelationships(data.map((x) => x.id)));
+    })
+    .catch((error) => dispatch(fetchDirectoryFail(error)));
 };
 
 export const fetchDirectoryRequest = () => ({
   type: DIRECTORY_FETCH_REQUEST,
 });
 
-export const fetchDirectorySuccess = accounts => ({
+export const fetchDirectorySuccess = (accounts) => ({
   type: DIRECTORY_FETCH_SUCCESS,
   accounts,
 });
 
-export const fetchDirectoryFail = error => ({
+export const fetchDirectoryFail = (error) => ({
   type: DIRECTORY_FETCH_FAIL,
   error,
 });
 
-export const expandDirectory = params => (dispatch, getState) => {
+export const expandDirectory = (params) => (dispatch, getState) => {
   dispatch(expandDirectoryRequest());
 
-  const loadedItems = getState().getIn(['user_lists', 'directory', 'items']).size;
+  const loadedItems = getState().getIn([
+    'user_lists',
+    'directory',
+    'items',
+  ]).size;
 
-  api(getState).get('/api/v1/directory', { params: { ...params, offset: loadedItems, limit: 20 } }).then(({ data }) => {
-    dispatch(importFetchedAccounts(data));
-    dispatch(expandDirectorySuccess(data));
-    dispatch(fetchRelationships(data.map(x => x.id)));
-  }).catch(error => dispatch(expandDirectoryFail(error)));
+  api(getState)
+    .get('/api/v1/directory', {
+      params: { ...params, offset: loadedItems, limit: 20 },
+    })
+    .then(({ data }) => {
+      dispatch(importFetchedAccounts(data));
+      dispatch(expandDirectorySuccess(data));
+      dispatch(fetchRelationships(data.map((x) => x.id)));
+    })
+    .catch((error) => dispatch(expandDirectoryFail(error)));
 };
 
 export const expandDirectoryRequest = () => ({
   type: DIRECTORY_EXPAND_REQUEST,
 });
 
-export const expandDirectorySuccess = accounts => ({
+export const expandDirectorySuccess = (accounts) => ({
   type: DIRECTORY_EXPAND_SUCCESS,
   accounts,
 });
 
-export const expandDirectoryFail = error => ({
+export const expandDirectoryFail = (error) => ({
   type: DIRECTORY_EXPAND_FAIL,
   error,
 });

--- a/app/javascript/mastodon/actions/domain_blocks.js
+++ b/app/javascript/mastodon/actions/domain_blocks.js
@@ -2,32 +2,39 @@ import api, { getLinks } from '../api';
 
 export const DOMAIN_BLOCK_REQUEST = 'DOMAIN_BLOCK_REQUEST';
 export const DOMAIN_BLOCK_SUCCESS = 'DOMAIN_BLOCK_SUCCESS';
-export const DOMAIN_BLOCK_FAIL    = 'DOMAIN_BLOCK_FAIL';
+export const DOMAIN_BLOCK_FAIL = 'DOMAIN_BLOCK_FAIL';
 
 export const DOMAIN_UNBLOCK_REQUEST = 'DOMAIN_UNBLOCK_REQUEST';
 export const DOMAIN_UNBLOCK_SUCCESS = 'DOMAIN_UNBLOCK_SUCCESS';
-export const DOMAIN_UNBLOCK_FAIL    = 'DOMAIN_UNBLOCK_FAIL';
+export const DOMAIN_UNBLOCK_FAIL = 'DOMAIN_UNBLOCK_FAIL';
 
 export const DOMAIN_BLOCKS_FETCH_REQUEST = 'DOMAIN_BLOCKS_FETCH_REQUEST';
 export const DOMAIN_BLOCKS_FETCH_SUCCESS = 'DOMAIN_BLOCKS_FETCH_SUCCESS';
-export const DOMAIN_BLOCKS_FETCH_FAIL    = 'DOMAIN_BLOCKS_FETCH_FAIL';
+export const DOMAIN_BLOCKS_FETCH_FAIL = 'DOMAIN_BLOCKS_FETCH_FAIL';
 
 export const DOMAIN_BLOCKS_EXPAND_REQUEST = 'DOMAIN_BLOCKS_EXPAND_REQUEST';
 export const DOMAIN_BLOCKS_EXPAND_SUCCESS = 'DOMAIN_BLOCKS_EXPAND_SUCCESS';
-export const DOMAIN_BLOCKS_EXPAND_FAIL    = 'DOMAIN_BLOCKS_EXPAND_FAIL';
+export const DOMAIN_BLOCKS_EXPAND_FAIL = 'DOMAIN_BLOCKS_EXPAND_FAIL';
 
 export function blockDomain(domain) {
   return (dispatch, getState) => {
     dispatch(blockDomainRequest(domain));
 
-    api(getState).post('/api/v1/domain_blocks', { domain }).then(() => {
-      const at_domain = '@' + domain;
-      const accounts = getState().get('accounts').filter(item => item.get('acct').endsWith(at_domain)).valueSeq().map(item => item.get('id'));
+    api(getState)
+      .post('/api/v1/domain_blocks', { domain })
+      .then(() => {
+        const at_domain = '@' + domain;
+        const accounts = getState()
+          .get('accounts')
+          .filter((item) => item.get('acct').endsWith(at_domain))
+          .valueSeq()
+          .map((item) => item.get('id'));
 
-      dispatch(blockDomainSuccess(domain, accounts));
-    }).catch(err => {
-      dispatch(blockDomainFail(domain, err));
-    });
+        dispatch(blockDomainSuccess(domain, accounts));
+      })
+      .catch((err) => {
+        dispatch(blockDomainFail(domain, err));
+      });
   };
 }
 
@@ -58,13 +65,20 @@ export function unblockDomain(domain) {
   return (dispatch, getState) => {
     dispatch(unblockDomainRequest(domain));
 
-    api(getState).delete('/api/v1/domain_blocks', { params: { domain } }).then(() => {
-      const at_domain = '@' + domain;
-      const accounts = getState().get('accounts').filter(item => item.get('acct').endsWith(at_domain)).valueSeq().map(item => item.get('id'));
-      dispatch(unblockDomainSuccess(domain, accounts));
-    }).catch(err => {
-      dispatch(unblockDomainFail(domain, err));
-    });
+    api(getState)
+      .delete('/api/v1/domain_blocks', { params: { domain } })
+      .then(() => {
+        const at_domain = '@' + domain;
+        const accounts = getState()
+          .get('accounts')
+          .filter((item) => item.get('acct').endsWith(at_domain))
+          .valueSeq()
+          .map((item) => item.get('id'));
+        dispatch(unblockDomainSuccess(domain, accounts));
+      })
+      .catch((err) => {
+        dispatch(unblockDomainFail(domain, err));
+      });
   };
 }
 
@@ -95,12 +109,19 @@ export function fetchDomainBlocks() {
   return (dispatch, getState) => {
     dispatch(fetchDomainBlocksRequest());
 
-    api(getState).get('/api/v1/domain_blocks').then(response => {
-      const next = getLinks(response).refs.find(link => link.rel === 'next');
-      dispatch(fetchDomainBlocksSuccess(response.data, next ? next.uri : null));
-    }).catch(err => {
-      dispatch(fetchDomainBlocksFail(err));
-    });
+    api(getState)
+      .get('/api/v1/domain_blocks')
+      .then((response) => {
+        const next = getLinks(response).refs.find(
+          (link) => link.rel === 'next',
+        );
+        dispatch(
+          fetchDomainBlocksSuccess(response.data, next ? next.uri : null),
+        );
+      })
+      .catch((err) => {
+        dispatch(fetchDomainBlocksFail(err));
+      });
   };
 }
 
@@ -135,12 +156,19 @@ export function expandDomainBlocks() {
 
     dispatch(expandDomainBlocksRequest());
 
-    api(getState).get(url).then(response => {
-      const next = getLinks(response).refs.find(link => link.rel === 'next');
-      dispatch(expandDomainBlocksSuccess(response.data, next ? next.uri : null));
-    }).catch(err => {
-      dispatch(expandDomainBlocksFail(err));
-    });
+    api(getState)
+      .get(url)
+      .then((response) => {
+        const next = getLinks(response).refs.find(
+          (link) => link.rel === 'next',
+        );
+        dispatch(
+          expandDomainBlocksSuccess(response.data, next ? next.uri : null),
+        );
+      })
+      .catch((err) => {
+        dispatch(expandDomainBlocksFail(err));
+      });
   };
 }
 

--- a/app/javascript/mastodon/actions/emojis.js
+++ b/app/javascript/mastodon/actions/emojis.js
@@ -3,7 +3,7 @@ import { saveSettings } from './settings';
 export const EMOJI_USE = 'EMOJI_USE';
 
 export function useEmoji(emoji) {
-  return dispatch => {
+  return (dispatch) => {
     dispatch({
       type: EMOJI_USE,
       emoji,

--- a/app/javascript/mastodon/actions/favourites.js
+++ b/app/javascript/mastodon/actions/favourites.js
@@ -2,13 +2,18 @@ import api, { getLinks } from '../api';
 
 import { importFetchedStatuses } from './importer';
 
-export const FAVOURITED_STATUSES_FETCH_REQUEST = 'FAVOURITED_STATUSES_FETCH_REQUEST';
-export const FAVOURITED_STATUSES_FETCH_SUCCESS = 'FAVOURITED_STATUSES_FETCH_SUCCESS';
-export const FAVOURITED_STATUSES_FETCH_FAIL    = 'FAVOURITED_STATUSES_FETCH_FAIL';
+export const FAVOURITED_STATUSES_FETCH_REQUEST =
+  'FAVOURITED_STATUSES_FETCH_REQUEST';
+export const FAVOURITED_STATUSES_FETCH_SUCCESS =
+  'FAVOURITED_STATUSES_FETCH_SUCCESS';
+export const FAVOURITED_STATUSES_FETCH_FAIL = 'FAVOURITED_STATUSES_FETCH_FAIL';
 
-export const FAVOURITED_STATUSES_EXPAND_REQUEST = 'FAVOURITED_STATUSES_EXPAND_REQUEST';
-export const FAVOURITED_STATUSES_EXPAND_SUCCESS = 'FAVOURITED_STATUSES_EXPAND_SUCCESS';
-export const FAVOURITED_STATUSES_EXPAND_FAIL    = 'FAVOURITED_STATUSES_EXPAND_FAIL';
+export const FAVOURITED_STATUSES_EXPAND_REQUEST =
+  'FAVOURITED_STATUSES_EXPAND_REQUEST';
+export const FAVOURITED_STATUSES_EXPAND_SUCCESS =
+  'FAVOURITED_STATUSES_EXPAND_SUCCESS';
+export const FAVOURITED_STATUSES_EXPAND_FAIL =
+  'FAVOURITED_STATUSES_EXPAND_FAIL';
 
 export function fetchFavouritedStatuses() {
   return (dispatch, getState) => {
@@ -18,13 +23,20 @@ export function fetchFavouritedStatuses() {
 
     dispatch(fetchFavouritedStatusesRequest());
 
-    api(getState).get('/api/v1/favourites').then(response => {
-      const next = getLinks(response).refs.find(link => link.rel === 'next');
-      dispatch(importFetchedStatuses(response.data));
-      dispatch(fetchFavouritedStatusesSuccess(response.data, next ? next.uri : null));
-    }).catch(error => {
-      dispatch(fetchFavouritedStatusesFail(error));
-    });
+    api(getState)
+      .get('/api/v1/favourites')
+      .then((response) => {
+        const next = getLinks(response).refs.find(
+          (link) => link.rel === 'next',
+        );
+        dispatch(importFetchedStatuses(response.data));
+        dispatch(
+          fetchFavouritedStatusesSuccess(response.data, next ? next.uri : null),
+        );
+      })
+      .catch((error) => {
+        dispatch(fetchFavouritedStatusesFail(error));
+      });
   };
 }
 
@@ -56,19 +68,32 @@ export function expandFavouritedStatuses() {
   return (dispatch, getState) => {
     const url = getState().getIn(['status_lists', 'favourites', 'next'], null);
 
-    if (url === null || getState().getIn(['status_lists', 'favourites', 'isLoading'])) {
+    if (
+      url === null ||
+      getState().getIn(['status_lists', 'favourites', 'isLoading'])
+    ) {
       return;
     }
 
     dispatch(expandFavouritedStatusesRequest());
 
-    api(getState).get(url).then(response => {
-      const next = getLinks(response).refs.find(link => link.rel === 'next');
-      dispatch(importFetchedStatuses(response.data));
-      dispatch(expandFavouritedStatusesSuccess(response.data, next ? next.uri : null));
-    }).catch(error => {
-      dispatch(expandFavouritedStatusesFail(error));
-    });
+    api(getState)
+      .get(url)
+      .then((response) => {
+        const next = getLinks(response).refs.find(
+          (link) => link.rel === 'next',
+        );
+        dispatch(importFetchedStatuses(response.data));
+        dispatch(
+          expandFavouritedStatusesSuccess(
+            response.data,
+            next ? next.uri : null,
+          ),
+        );
+      })
+      .catch((error) => {
+        dispatch(expandFavouritedStatusesFail(error));
+      });
   };
 }
 

--- a/app/javascript/mastodon/actions/featured_tags.js
+++ b/app/javascript/mastodon/actions/featured_tags.js
@@ -2,7 +2,7 @@ import api from '../api';
 
 export const FEATURED_TAGS_FETCH_REQUEST = 'FEATURED_TAGS_FETCH_REQUEST';
 export const FEATURED_TAGS_FETCH_SUCCESS = 'FEATURED_TAGS_FETCH_SUCCESS';
-export const FEATURED_TAGS_FETCH_FAIL    = 'FEATURED_TAGS_FETCH_FAIL';
+export const FEATURED_TAGS_FETCH_FAIL = 'FEATURED_TAGS_FETCH_FAIL';
 
 export const fetchFeaturedTags = (id) => (dispatch, getState) => {
   if (getState().getIn(['user_lists', 'featured_tags', id, 'items'])) {
@@ -11,9 +11,10 @@ export const fetchFeaturedTags = (id) => (dispatch, getState) => {
 
   dispatch(fetchFeaturedTagsRequest(id));
 
-  api(getState).get(`/api/v1/accounts/${id}/featured_tags`)
+  api(getState)
+    .get(`/api/v1/accounts/${id}/featured_tags`)
     .then(({ data }) => dispatch(fetchFeaturedTagsSuccess(id, data)))
-    .catch(err => dispatch(fetchFeaturedTagsFail(id, err)));
+    .catch((err) => dispatch(fetchFeaturedTagsFail(id, err)));
 };
 
 export const fetchFeaturedTagsRequest = (id) => ({

--- a/app/javascript/mastodon/actions/filters.js
+++ b/app/javascript/mastodon/actions/filters.js
@@ -4,24 +4,28 @@ import { openModal } from './modal';
 
 export const FILTERS_FETCH_REQUEST = 'FILTERS_FETCH_REQUEST';
 export const FILTERS_FETCH_SUCCESS = 'FILTERS_FETCH_SUCCESS';
-export const FILTERS_FETCH_FAIL    = 'FILTERS_FETCH_FAIL';
+export const FILTERS_FETCH_FAIL = 'FILTERS_FETCH_FAIL';
 
 export const FILTERS_STATUS_CREATE_REQUEST = 'FILTERS_STATUS_CREATE_REQUEST';
 export const FILTERS_STATUS_CREATE_SUCCESS = 'FILTERS_STATUS_CREATE_SUCCESS';
-export const FILTERS_STATUS_CREATE_FAIL    = 'FILTERS_STATUS_CREATE_FAIL';
+export const FILTERS_STATUS_CREATE_FAIL = 'FILTERS_STATUS_CREATE_FAIL';
 
 export const FILTERS_CREATE_REQUEST = 'FILTERS_CREATE_REQUEST';
 export const FILTERS_CREATE_SUCCESS = 'FILTERS_CREATE_SUCCESS';
-export const FILTERS_CREATE_FAIL    = 'FILTERS_CREATE_FAIL';
+export const FILTERS_CREATE_FAIL = 'FILTERS_CREATE_FAIL';
 
-export const initAddFilter = (status, { contextType }) => dispatch =>
-  dispatch(openModal({
-    modalType: 'FILTER',
-    modalProps: {
-      statusId: status?.get('id'),
-      contextType: contextType,
-    },
-  }));
+export const initAddFilter =
+  (status, { contextType }) =>
+  (dispatch) =>
+    dispatch(
+      openModal({
+        modalType: 'FILTER',
+        modalProps: {
+          statusId: status?.get('id'),
+          contextType: contextType,
+        },
+      }),
+    );
 
 export const fetchFilters = () => (dispatch, getState) => {
   dispatch({
@@ -31,67 +35,79 @@ export const fetchFilters = () => (dispatch, getState) => {
 
   api(getState)
     .get('/api/v2/filters')
-    .then(({ data }) => dispatch({
-      type: FILTERS_FETCH_SUCCESS,
-      filters: data,
-      skipLoading: true,
-    }))
-    .catch(err => dispatch({
-      type: FILTERS_FETCH_FAIL,
-      err,
-      skipLoading: true,
-      skipAlert: true,
-    }));
+    .then(({ data }) =>
+      dispatch({
+        type: FILTERS_FETCH_SUCCESS,
+        filters: data,
+        skipLoading: true,
+      }),
+    )
+    .catch((err) =>
+      dispatch({
+        type: FILTERS_FETCH_FAIL,
+        err,
+        skipLoading: true,
+        skipAlert: true,
+      }),
+    );
 };
 
-export const createFilterStatus = (params, onSuccess, onFail) => (dispatch, getState) => {
-  dispatch(createFilterStatusRequest());
+export const createFilterStatus =
+  (params, onSuccess, onFail) => (dispatch, getState) => {
+    dispatch(createFilterStatusRequest());
 
-  api(getState).post(`/api/v2/filters/${params.filter_id}/statuses`, params).then(response => {
-    dispatch(createFilterStatusSuccess(response.data));
-    if (onSuccess) onSuccess();
-  }).catch(error => {
-    dispatch(createFilterStatusFail(error));
-    if (onFail) onFail();
-  });
-};
+    api(getState)
+      .post(`/api/v2/filters/${params.filter_id}/statuses`, params)
+      .then((response) => {
+        dispatch(createFilterStatusSuccess(response.data));
+        if (onSuccess) onSuccess();
+      })
+      .catch((error) => {
+        dispatch(createFilterStatusFail(error));
+        if (onFail) onFail();
+      });
+  };
 
 export const createFilterStatusRequest = () => ({
   type: FILTERS_STATUS_CREATE_REQUEST,
 });
 
-export const createFilterStatusSuccess = filter_status => ({
+export const createFilterStatusSuccess = (filter_status) => ({
   type: FILTERS_STATUS_CREATE_SUCCESS,
   filter_status,
 });
 
-export const createFilterStatusFail = error => ({
+export const createFilterStatusFail = (error) => ({
   type: FILTERS_STATUS_CREATE_FAIL,
   error,
 });
 
-export const createFilter = (params, onSuccess, onFail) => (dispatch, getState) => {
-  dispatch(createFilterRequest());
+export const createFilter =
+  (params, onSuccess, onFail) => (dispatch, getState) => {
+    dispatch(createFilterRequest());
 
-  api(getState).post('/api/v2/filters', params).then(response => {
-    dispatch(createFilterSuccess(response.data));
-    if (onSuccess) onSuccess(response.data);
-  }).catch(error => {
-    dispatch(createFilterFail(error));
-    if (onFail) onFail();
-  });
-};
+    api(getState)
+      .post('/api/v2/filters', params)
+      .then((response) => {
+        dispatch(createFilterSuccess(response.data));
+        if (onSuccess) onSuccess(response.data);
+      })
+      .catch((error) => {
+        dispatch(createFilterFail(error));
+        if (onFail) onFail();
+      });
+  };
 
 export const createFilterRequest = () => ({
   type: FILTERS_CREATE_REQUEST,
 });
 
-export const createFilterSuccess = filter => ({
+export const createFilterSuccess = (filter) => ({
   type: FILTERS_CREATE_SUCCESS,
   filter,
 });
 
-export const createFilterFail = error => ({
+export const createFilterFail = (error) => ({
   type: FILTERS_CREATE_FAIL,
   error,
 });

--- a/app/javascript/mastodon/actions/height_cache.js
+++ b/app/javascript/mastodon/actions/height_cache.js
@@ -1,7 +1,7 @@
 export const HEIGHT_CACHE_SET = 'HEIGHT_CACHE_SET';
 export const HEIGHT_CACHE_CLEAR = 'HEIGHT_CACHE_CLEAR';
 
-export function setHeight (key, id, height) {
+export function setHeight(key, id, height) {
   return {
     type: HEIGHT_CACHE_SET,
     key,
@@ -10,7 +10,7 @@ export function setHeight (key, id, height) {
   };
 }
 
-export function clearHeight () {
+export function clearHeight() {
   return {
     type: HEIGHT_CACHE_CLEAR,
   };

--- a/app/javascript/mastodon/actions/history.js
+++ b/app/javascript/mastodon/actions/history.js
@@ -4,9 +4,9 @@ import { importFetchedAccounts } from './importer';
 
 export const HISTORY_FETCH_REQUEST = 'HISTORY_FETCH_REQUEST';
 export const HISTORY_FETCH_SUCCESS = 'HISTORY_FETCH_SUCCESS';
-export const HISTORY_FETCH_FAIL    = 'HISTORY_FETCH_FAIL';
+export const HISTORY_FETCH_FAIL = 'HISTORY_FETCH_FAIL';
 
-export const fetchHistory = statusId => (dispatch, getState) => {
+export const fetchHistory = (statusId) => (dispatch, getState) => {
   const loading = getState().getIn(['history', statusId, 'loading']);
 
   if (loading) {
@@ -15,13 +15,16 @@ export const fetchHistory = statusId => (dispatch, getState) => {
 
   dispatch(fetchHistoryRequest(statusId));
 
-  api(getState).get(`/api/v1/statuses/${statusId}/history`).then(({ data }) => {
-    dispatch(importFetchedAccounts(data.map(x => x.account)));
-    dispatch(fetchHistorySuccess(statusId, data));
-  }).catch(error => dispatch(fetchHistoryFail(error)));
+  api(getState)
+    .get(`/api/v1/statuses/${statusId}/history`)
+    .then(({ data }) => {
+      dispatch(importFetchedAccounts(data.map((x) => x.account)));
+      dispatch(fetchHistorySuccess(statusId, data));
+    })
+    .catch((error) => dispatch(fetchHistoryFail(error)));
 };
 
-export const fetchHistoryRequest = statusId => ({
+export const fetchHistoryRequest = (statusId) => ({
   type: HISTORY_FETCH_REQUEST,
   statusId,
 });
@@ -32,7 +35,7 @@ export const fetchHistorySuccess = (statusId, history) => ({
   history,
 });
 
-export const fetchHistoryFail = error => ({
+export const fetchHistoryFail = (error) => ({
   type: HISTORY_FETCH_FAIL,
   error,
 });

--- a/app/javascript/mastodon/actions/importer/index.js
+++ b/app/javascript/mastodon/actions/importer/index.js
@@ -1,14 +1,14 @@
 import { normalizeAccount, normalizeStatus, normalizePoll } from './normalizer';
 
-export const ACCOUNT_IMPORT  = 'ACCOUNT_IMPORT';
+export const ACCOUNT_IMPORT = 'ACCOUNT_IMPORT';
 export const ACCOUNTS_IMPORT = 'ACCOUNTS_IMPORT';
-export const STATUS_IMPORT   = 'STATUS_IMPORT';
+export const STATUS_IMPORT = 'STATUS_IMPORT';
 export const STATUSES_IMPORT = 'STATUSES_IMPORT';
-export const POLLS_IMPORT    = 'POLLS_IMPORT';
-export const FILTERS_IMPORT  = 'FILTERS_IMPORT';
+export const POLLS_IMPORT = 'POLLS_IMPORT';
+export const FILTERS_IMPORT = 'FILTERS_IMPORT';
 
 function pushUnique(array, object) {
-  if (array.every(element => element.id !== object.id)) {
+  if (array.every((element) => element.id !== object.id)) {
     array.push(object);
   }
 }
@@ -69,11 +69,14 @@ export function importFetchedStatuses(statuses) {
     const filters = [];
 
     function processStatus(status) {
-      pushUnique(normalStatuses, normalizeStatus(status, getState().getIn(['statuses', status.id])));
+      pushUnique(
+        normalStatuses,
+        normalizeStatus(status, getState().getIn(['statuses', status.id])),
+      );
       pushUnique(accounts, status.account);
 
       if (status.filtered) {
-        status.filtered.forEach(result => pushUnique(filters, result.filter));
+        status.filtered.forEach((result) => pushUnique(filters, result.filter));
       }
 
       if (status.reblog && status.reblog.id) {
@@ -81,7 +84,13 @@ export function importFetchedStatuses(statuses) {
       }
 
       if (status.poll && status.poll.id) {
-        pushUnique(polls, normalizePoll(status.poll, getState().getIn(['polls', status.poll.id])));
+        pushUnique(
+          polls,
+          normalizePoll(
+            status.poll,
+            getState().getIn(['polls', status.poll.id]),
+          ),
+        );
       }
     }
 
@@ -96,6 +105,8 @@ export function importFetchedStatuses(statuses) {
 
 export function importFetchedPoll(poll) {
   return (dispatch, getState) => {
-    dispatch(importPolls([normalizePoll(poll, getState().getIn(['polls', poll.id]))]));
+    dispatch(
+      importPolls([normalizePoll(poll, getState().getIn(['polls', poll.id]))]),
+    );
   };
 }

--- a/app/javascript/mastodon/actions/interactions.js
+++ b/app/javascript/mastodon/actions/interactions.js
@@ -5,7 +5,7 @@ import { importFetchedAccounts, importFetchedStatus } from './importer';
 
 export const REBLOG_REQUEST = 'REBLOG_REQUEST';
 export const REBLOG_SUCCESS = 'REBLOG_SUCCESS';
-export const REBLOG_FAIL    = 'REBLOG_FAIL';
+export const REBLOG_FAIL = 'REBLOG_FAIL';
 
 export const REBLOGS_EXPAND_REQUEST = 'REBLOGS_EXPAND_REQUEST';
 export const REBLOGS_EXPAND_SUCCESS = 'REBLOGS_EXPAND_SUCCESS';
@@ -13,23 +13,23 @@ export const REBLOGS_EXPAND_FAIL = 'REBLOGS_EXPAND_FAIL';
 
 export const FAVOURITE_REQUEST = 'FAVOURITE_REQUEST';
 export const FAVOURITE_SUCCESS = 'FAVOURITE_SUCCESS';
-export const FAVOURITE_FAIL    = 'FAVOURITE_FAIL';
+export const FAVOURITE_FAIL = 'FAVOURITE_FAIL';
 
 export const UNREBLOG_REQUEST = 'UNREBLOG_REQUEST';
 export const UNREBLOG_SUCCESS = 'UNREBLOG_SUCCESS';
-export const UNREBLOG_FAIL    = 'UNREBLOG_FAIL';
+export const UNREBLOG_FAIL = 'UNREBLOG_FAIL';
 
 export const UNFAVOURITE_REQUEST = 'UNFAVOURITE_REQUEST';
 export const UNFAVOURITE_SUCCESS = 'UNFAVOURITE_SUCCESS';
-export const UNFAVOURITE_FAIL    = 'UNFAVOURITE_FAIL';
+export const UNFAVOURITE_FAIL = 'UNFAVOURITE_FAIL';
 
 export const REBLOGS_FETCH_REQUEST = 'REBLOGS_FETCH_REQUEST';
 export const REBLOGS_FETCH_SUCCESS = 'REBLOGS_FETCH_SUCCESS';
-export const REBLOGS_FETCH_FAIL    = 'REBLOGS_FETCH_FAIL';
+export const REBLOGS_FETCH_FAIL = 'REBLOGS_FETCH_FAIL';
 
 export const FAVOURITES_FETCH_REQUEST = 'FAVOURITES_FETCH_REQUEST';
 export const FAVOURITES_FETCH_SUCCESS = 'FAVOURITES_FETCH_SUCCESS';
-export const FAVOURITES_FETCH_FAIL    = 'FAVOURITES_FETCH_FAIL';
+export const FAVOURITES_FETCH_FAIL = 'FAVOURITES_FETCH_FAIL';
 
 export const FAVOURITES_EXPAND_REQUEST = 'FAVOURITES_EXPAND_REQUEST';
 export const FAVOURITES_EXPAND_SUCCESS = 'FAVOURITES_EXPAND_SUCCESS';
@@ -37,32 +37,35 @@ export const FAVOURITES_EXPAND_FAIL = 'FAVOURITES_EXPAND_FAIL';
 
 export const PIN_REQUEST = 'PIN_REQUEST';
 export const PIN_SUCCESS = 'PIN_SUCCESS';
-export const PIN_FAIL    = 'PIN_FAIL';
+export const PIN_FAIL = 'PIN_FAIL';
 
 export const UNPIN_REQUEST = 'UNPIN_REQUEST';
 export const UNPIN_SUCCESS = 'UNPIN_SUCCESS';
-export const UNPIN_FAIL    = 'UNPIN_FAIL';
+export const UNPIN_FAIL = 'UNPIN_FAIL';
 
 export const BOOKMARK_REQUEST = 'BOOKMARK_REQUEST';
 export const BOOKMARK_SUCCESS = 'BOOKMARKED_SUCCESS';
-export const BOOKMARK_FAIL    = 'BOOKMARKED_FAIL';
+export const BOOKMARK_FAIL = 'BOOKMARKED_FAIL';
 
 export const UNBOOKMARK_REQUEST = 'UNBOOKMARKED_REQUEST';
 export const UNBOOKMARK_SUCCESS = 'UNBOOKMARKED_SUCCESS';
-export const UNBOOKMARK_FAIL    = 'UNBOOKMARKED_FAIL';
+export const UNBOOKMARK_FAIL = 'UNBOOKMARKED_FAIL';
 
 export function reblog(status, visibility) {
   return function (dispatch, getState) {
     dispatch(reblogRequest(status));
 
-    api(getState).post(`/api/v1/statuses/${status.get('id')}/reblog`, { visibility }).then(function (response) {
-      // The reblog API method returns a new status wrapped around the original. In this case we are only
-      // interested in how the original is modified, hence passing it skipping the wrapper
-      dispatch(importFetchedStatus(response.data.reblog));
-      dispatch(reblogSuccess(status));
-    }).catch(function (error) {
-      dispatch(reblogFail(status, error));
-    });
+    api(getState)
+      .post(`/api/v1/statuses/${status.get('id')}/reblog`, { visibility })
+      .then(function (response) {
+        // The reblog API method returns a new status wrapped around the original. In this case we are only
+        // interested in how the original is modified, hence passing it skipping the wrapper
+        dispatch(importFetchedStatus(response.data.reblog));
+        dispatch(reblogSuccess(status));
+      })
+      .catch(function (error) {
+        dispatch(reblogFail(status, error));
+      });
   };
 }
 
@@ -70,12 +73,15 @@ export function unreblog(status) {
   return (dispatch, getState) => {
     dispatch(unreblogRequest(status));
 
-    api(getState).post(`/api/v1/statuses/${status.get('id')}/unreblog`).then(response => {
-      dispatch(importFetchedStatus(response.data));
-      dispatch(unreblogSuccess(status));
-    }).catch(error => {
-      dispatch(unreblogFail(status, error));
-    });
+    api(getState)
+      .post(`/api/v1/statuses/${status.get('id')}/unreblog`)
+      .then((response) => {
+        dispatch(importFetchedStatus(response.data));
+        dispatch(unreblogSuccess(status));
+      })
+      .catch((error) => {
+        dispatch(unreblogFail(status, error));
+      });
   };
 }
 
@@ -133,12 +139,15 @@ export function favourite(status) {
   return function (dispatch, getState) {
     dispatch(favouriteRequest(status));
 
-    api(getState).post(`/api/v1/statuses/${status.get('id')}/favourite`).then(function (response) {
-      dispatch(importFetchedStatus(response.data));
-      dispatch(favouriteSuccess(status));
-    }).catch(function (error) {
-      dispatch(favouriteFail(status, error));
-    });
+    api(getState)
+      .post(`/api/v1/statuses/${status.get('id')}/favourite`)
+      .then(function (response) {
+        dispatch(importFetchedStatus(response.data));
+        dispatch(favouriteSuccess(status));
+      })
+      .catch(function (error) {
+        dispatch(favouriteFail(status, error));
+      });
   };
 }
 
@@ -146,12 +155,15 @@ export function unfavourite(status) {
   return (dispatch, getState) => {
     dispatch(unfavouriteRequest(status));
 
-    api(getState).post(`/api/v1/statuses/${status.get('id')}/unfavourite`).then(response => {
-      dispatch(importFetchedStatus(response.data));
-      dispatch(unfavouriteSuccess(status));
-    }).catch(error => {
-      dispatch(unfavouriteFail(status, error));
-    });
+    api(getState)
+      .post(`/api/v1/statuses/${status.get('id')}/unfavourite`)
+      .then((response) => {
+        dispatch(importFetchedStatus(response.data));
+        dispatch(unfavouriteSuccess(status));
+      })
+      .catch((error) => {
+        dispatch(unfavouriteFail(status, error));
+      });
   };
 }
 
@@ -209,12 +221,15 @@ export function bookmark(status) {
   return function (dispatch, getState) {
     dispatch(bookmarkRequest(status));
 
-    api(getState).post(`/api/v1/statuses/${status.get('id')}/bookmark`).then(function (response) {
-      dispatch(importFetchedStatus(response.data));
-      dispatch(bookmarkSuccess(status, response.data));
-    }).catch(function (error) {
-      dispatch(bookmarkFail(status, error));
-    });
+    api(getState)
+      .post(`/api/v1/statuses/${status.get('id')}/bookmark`)
+      .then(function (response) {
+        dispatch(importFetchedStatus(response.data));
+        dispatch(bookmarkSuccess(status, response.data));
+      })
+      .catch(function (error) {
+        dispatch(bookmarkFail(status, error));
+      });
   };
 }
 
@@ -222,12 +237,15 @@ export function unbookmark(status) {
   return (dispatch, getState) => {
     dispatch(unbookmarkRequest(status));
 
-    api(getState).post(`/api/v1/statuses/${status.get('id')}/unbookmark`).then(response => {
-      dispatch(importFetchedStatus(response.data));
-      dispatch(unbookmarkSuccess(status, response.data));
-    }).catch(error => {
-      dispatch(unbookmarkFail(status, error));
-    });
+    api(getState)
+      .post(`/api/v1/statuses/${status.get('id')}/unbookmark`)
+      .then((response) => {
+        dispatch(importFetchedStatus(response.data));
+        dispatch(unbookmarkSuccess(status, response.data));
+      })
+      .catch((error) => {
+        dispatch(unbookmarkFail(status, error));
+      });
   };
 }
 
@@ -281,14 +299,21 @@ export function fetchReblogs(id) {
   return (dispatch, getState) => {
     dispatch(fetchReblogsRequest(id));
 
-    api(getState).get(`/api/v1/statuses/${id}/reblogged_by`).then(response => {
-      const next = getLinks(response).refs.find(link => link.rel === 'next');
-      dispatch(importFetchedAccounts(response.data));
-      dispatch(fetchReblogsSuccess(id, response.data, next ? next.uri : null));
-      dispatch(fetchRelationships(response.data.map(item => item.id)));
-    }).catch(error => {
-      dispatch(fetchReblogsFail(id, error));
-    });
+    api(getState)
+      .get(`/api/v1/statuses/${id}/reblogged_by`)
+      .then((response) => {
+        const next = getLinks(response).refs.find(
+          (link) => link.rel === 'next',
+        );
+        dispatch(importFetchedAccounts(response.data));
+        dispatch(
+          fetchReblogsSuccess(id, response.data, next ? next.uri : null),
+        );
+        dispatch(fetchRelationships(response.data.map((item) => item.id)));
+      })
+      .catch((error) => {
+        dispatch(fetchReblogsFail(id, error));
+      });
   };
 }
 
@@ -325,13 +350,20 @@ export function expandReblogs(id) {
 
     dispatch(expandReblogsRequest(id));
 
-    api(getState).get(url).then(response => {
-      const next = getLinks(response).refs.find(link => link.rel === 'next');
+    api(getState)
+      .get(url)
+      .then((response) => {
+        const next = getLinks(response).refs.find(
+          (link) => link.rel === 'next',
+        );
 
-      dispatch(importFetchedAccounts(response.data));
-      dispatch(expandReblogsSuccess(id, response.data, next ? next.uri : null));
-      dispatch(fetchRelationships(response.data.map(item => item.id)));
-    }).catch(error => dispatch(expandReblogsFail(id, error)));
+        dispatch(importFetchedAccounts(response.data));
+        dispatch(
+          expandReblogsSuccess(id, response.data, next ? next.uri : null),
+        );
+        dispatch(fetchRelationships(response.data.map((item) => item.id)));
+      })
+      .catch((error) => dispatch(expandReblogsFail(id, error)));
   };
 }
 
@@ -363,14 +395,21 @@ export function fetchFavourites(id) {
   return (dispatch, getState) => {
     dispatch(fetchFavouritesRequest(id));
 
-    api(getState).get(`/api/v1/statuses/${id}/favourited_by`).then(response => {
-      const next = getLinks(response).refs.find(link => link.rel === 'next');
-      dispatch(importFetchedAccounts(response.data));
-      dispatch(fetchFavouritesSuccess(id, response.data, next ? next.uri : null));
-      dispatch(fetchRelationships(response.data.map(item => item.id)));
-    }).catch(error => {
-      dispatch(fetchFavouritesFail(id, error));
-    });
+    api(getState)
+      .get(`/api/v1/statuses/${id}/favourited_by`)
+      .then((response) => {
+        const next = getLinks(response).refs.find(
+          (link) => link.rel === 'next',
+        );
+        dispatch(importFetchedAccounts(response.data));
+        dispatch(
+          fetchFavouritesSuccess(id, response.data, next ? next.uri : null),
+        );
+        dispatch(fetchRelationships(response.data.map((item) => item.id)));
+      })
+      .catch((error) => {
+        dispatch(fetchFavouritesFail(id, error));
+      });
   };
 }
 
@@ -407,13 +446,20 @@ export function expandFavourites(id) {
 
     dispatch(expandFavouritesRequest(id));
 
-    api(getState).get(url).then(response => {
-      const next = getLinks(response).refs.find(link => link.rel === 'next');
+    api(getState)
+      .get(url)
+      .then((response) => {
+        const next = getLinks(response).refs.find(
+          (link) => link.rel === 'next',
+        );
 
-      dispatch(importFetchedAccounts(response.data));
-      dispatch(expandFavouritesSuccess(id, response.data, next ? next.uri : null));
-      dispatch(fetchRelationships(response.data.map(item => item.id)));
-    }).catch(error => dispatch(expandFavouritesFail(id, error)));
+        dispatch(importFetchedAccounts(response.data));
+        dispatch(
+          expandFavouritesSuccess(id, response.data, next ? next.uri : null),
+        );
+        dispatch(fetchRelationships(response.data.map((item) => item.id)));
+      })
+      .catch((error) => dispatch(expandFavouritesFail(id, error)));
   };
 }
 
@@ -445,12 +491,15 @@ export function pin(status) {
   return (dispatch, getState) => {
     dispatch(pinRequest(status));
 
-    api(getState).post(`/api/v1/statuses/${status.get('id')}/pin`).then(response => {
-      dispatch(importFetchedStatus(response.data));
-      dispatch(pinSuccess(status));
-    }).catch(error => {
-      dispatch(pinFail(status, error));
-    });
+    api(getState)
+      .post(`/api/v1/statuses/${status.get('id')}/pin`)
+      .then((response) => {
+        dispatch(importFetchedStatus(response.data));
+        dispatch(pinSuccess(status));
+      })
+      .catch((error) => {
+        dispatch(pinFail(status, error));
+      });
   };
 }
 
@@ -479,16 +528,19 @@ export function pinFail(status, error) {
   };
 }
 
-export function unpin (status) {
+export function unpin(status) {
   return (dispatch, getState) => {
     dispatch(unpinRequest(status));
 
-    api(getState).post(`/api/v1/statuses/${status.get('id')}/unpin`).then(response => {
-      dispatch(importFetchedStatus(response.data));
-      dispatch(unpinSuccess(status));
-    }).catch(error => {
-      dispatch(unpinFail(status, error));
-    });
+    api(getState)
+      .post(`/api/v1/statuses/${status.get('id')}/unpin`)
+      .then((response) => {
+        dispatch(importFetchedStatus(response.data));
+        dispatch(unpinSuccess(status));
+      })
+      .catch((error) => {
+        dispatch(unpinFail(status, error));
+      });
   };
 }
 

--- a/app/javascript/mastodon/actions/languages.js
+++ b/app/javascript/mastodon/actions/languages.js
@@ -2,7 +2,7 @@ import { saveSettings } from './settings';
 
 export const LANGUAGE_USE = 'LANGUAGE_USE';
 
-export const useLanguage = language => dispatch => {
+export const useLanguage = (language) => (dispatch) => {
   dispatch({
     type: LANGUAGE_USE,
     language,

--- a/app/javascript/mastodon/actions/lists.js
+++ b/app/javascript/mastodon/actions/lists.js
@@ -5,69 +5,70 @@ import { importFetchedAccounts } from './importer';
 
 export const LIST_FETCH_REQUEST = 'LIST_FETCH_REQUEST';
 export const LIST_FETCH_SUCCESS = 'LIST_FETCH_SUCCESS';
-export const LIST_FETCH_FAIL    = 'LIST_FETCH_FAIL';
+export const LIST_FETCH_FAIL = 'LIST_FETCH_FAIL';
 
 export const LISTS_FETCH_REQUEST = 'LISTS_FETCH_REQUEST';
 export const LISTS_FETCH_SUCCESS = 'LISTS_FETCH_SUCCESS';
-export const LISTS_FETCH_FAIL    = 'LISTS_FETCH_FAIL';
+export const LISTS_FETCH_FAIL = 'LISTS_FETCH_FAIL';
 
 export const LIST_EDITOR_TITLE_CHANGE = 'LIST_EDITOR_TITLE_CHANGE';
-export const LIST_EDITOR_RESET        = 'LIST_EDITOR_RESET';
-export const LIST_EDITOR_SETUP        = 'LIST_EDITOR_SETUP';
+export const LIST_EDITOR_RESET = 'LIST_EDITOR_RESET';
+export const LIST_EDITOR_SETUP = 'LIST_EDITOR_SETUP';
 
 export const LIST_CREATE_REQUEST = 'LIST_CREATE_REQUEST';
 export const LIST_CREATE_SUCCESS = 'LIST_CREATE_SUCCESS';
-export const LIST_CREATE_FAIL    = 'LIST_CREATE_FAIL';
+export const LIST_CREATE_FAIL = 'LIST_CREATE_FAIL';
 
 export const LIST_UPDATE_REQUEST = 'LIST_UPDATE_REQUEST';
 export const LIST_UPDATE_SUCCESS = 'LIST_UPDATE_SUCCESS';
-export const LIST_UPDATE_FAIL    = 'LIST_UPDATE_FAIL';
+export const LIST_UPDATE_FAIL = 'LIST_UPDATE_FAIL';
 
 export const LIST_DELETE_REQUEST = 'LIST_DELETE_REQUEST';
 export const LIST_DELETE_SUCCESS = 'LIST_DELETE_SUCCESS';
-export const LIST_DELETE_FAIL    = 'LIST_DELETE_FAIL';
+export const LIST_DELETE_FAIL = 'LIST_DELETE_FAIL';
 
 export const LIST_ACCOUNTS_FETCH_REQUEST = 'LIST_ACCOUNTS_FETCH_REQUEST';
 export const LIST_ACCOUNTS_FETCH_SUCCESS = 'LIST_ACCOUNTS_FETCH_SUCCESS';
-export const LIST_ACCOUNTS_FETCH_FAIL    = 'LIST_ACCOUNTS_FETCH_FAIL';
+export const LIST_ACCOUNTS_FETCH_FAIL = 'LIST_ACCOUNTS_FETCH_FAIL';
 
 export const LIST_EDITOR_SUGGESTIONS_CHANGE = 'LIST_EDITOR_SUGGESTIONS_CHANGE';
-export const LIST_EDITOR_SUGGESTIONS_READY  = 'LIST_EDITOR_SUGGESTIONS_READY';
-export const LIST_EDITOR_SUGGESTIONS_CLEAR  = 'LIST_EDITOR_SUGGESTIONS_CLEAR';
+export const LIST_EDITOR_SUGGESTIONS_READY = 'LIST_EDITOR_SUGGESTIONS_READY';
+export const LIST_EDITOR_SUGGESTIONS_CLEAR = 'LIST_EDITOR_SUGGESTIONS_CLEAR';
 
 export const LIST_EDITOR_ADD_REQUEST = 'LIST_EDITOR_ADD_REQUEST';
 export const LIST_EDITOR_ADD_SUCCESS = 'LIST_EDITOR_ADD_SUCCESS';
-export const LIST_EDITOR_ADD_FAIL    = 'LIST_EDITOR_ADD_FAIL';
+export const LIST_EDITOR_ADD_FAIL = 'LIST_EDITOR_ADD_FAIL';
 
 export const LIST_EDITOR_REMOVE_REQUEST = 'LIST_EDITOR_REMOVE_REQUEST';
 export const LIST_EDITOR_REMOVE_SUCCESS = 'LIST_EDITOR_REMOVE_SUCCESS';
-export const LIST_EDITOR_REMOVE_FAIL    = 'LIST_EDITOR_REMOVE_FAIL';
+export const LIST_EDITOR_REMOVE_FAIL = 'LIST_EDITOR_REMOVE_FAIL';
 
 export const LIST_ADDER_RESET = 'LIST_ADDER_RESET';
 export const LIST_ADDER_SETUP = 'LIST_ADDER_SETUP';
 
 export const LIST_ADDER_LISTS_FETCH_REQUEST = 'LIST_ADDER_LISTS_FETCH_REQUEST';
 export const LIST_ADDER_LISTS_FETCH_SUCCESS = 'LIST_ADDER_LISTS_FETCH_SUCCESS';
-export const LIST_ADDER_LISTS_FETCH_FAIL    = 'LIST_ADDER_LISTS_FETCH_FAIL';
+export const LIST_ADDER_LISTS_FETCH_FAIL = 'LIST_ADDER_LISTS_FETCH_FAIL';
 
-export const fetchList = id => (dispatch, getState) => {
+export const fetchList = (id) => (dispatch, getState) => {
   if (getState().getIn(['lists', id])) {
     return;
   }
 
   dispatch(fetchListRequest(id));
 
-  api(getState).get(`/api/v1/lists/${id}`)
+  api(getState)
+    .get(`/api/v1/lists/${id}`)
     .then(({ data }) => dispatch(fetchListSuccess(data)))
-    .catch(err => dispatch(fetchListFail(id, err)));
+    .catch((err) => dispatch(fetchListFail(id, err)));
 };
 
-export const fetchListRequest = id => ({
+export const fetchListRequest = (id) => ({
   type: LIST_FETCH_REQUEST,
   id,
 });
 
-export const fetchListSuccess = list => ({
+export const fetchListSuccess = (list) => ({
   type: LIST_FETCH_SUCCESS,
   list,
 });
@@ -81,28 +82,29 @@ export const fetchListFail = (id, error) => ({
 export const fetchLists = () => (dispatch, getState) => {
   dispatch(fetchListsRequest());
 
-  api(getState).get('/api/v1/lists')
+  api(getState)
+    .get('/api/v1/lists')
     .then(({ data }) => dispatch(fetchListsSuccess(data)))
-    .catch(err => dispatch(fetchListsFail(err)));
+    .catch((err) => dispatch(fetchListsFail(err)));
 };
 
 export const fetchListsRequest = () => ({
   type: LISTS_FETCH_REQUEST,
 });
 
-export const fetchListsSuccess = lists => ({
+export const fetchListsSuccess = (lists) => ({
   type: LISTS_FETCH_SUCCESS,
   lists,
 });
 
-export const fetchListsFail = error => ({
+export const fetchListsFail = (error) => ({
   type: LISTS_FETCH_FAIL,
   error,
 });
 
-export const submitListEditor = shouldReset => (dispatch, getState) => {
+export const submitListEditor = (shouldReset) => (dispatch, getState) => {
   const listId = getState().getIn(['listEditor', 'listId']);
-  const title  = getState().getIn(['listEditor', 'title']);
+  const title = getState().getIn(['listEditor', 'title']);
 
   if (listId === null) {
     dispatch(createList(title, shouldReset));
@@ -111,7 +113,7 @@ export const submitListEditor = shouldReset => (dispatch, getState) => {
   }
 };
 
-export const setupListEditor = listId => (dispatch, getState) => {
+export const setupListEditor = (listId) => (dispatch, getState) => {
   dispatch({
     type: LIST_EDITOR_SETUP,
     list: getState().getIn(['lists', listId]),
@@ -120,7 +122,7 @@ export const setupListEditor = listId => (dispatch, getState) => {
   dispatch(fetchListAccounts(listId));
 };
 
-export const changeListEditorTitle = value => ({
+export const changeListEditorTitle = (value) => ({
   type: LIST_EDITOR_TITLE_CHANGE,
   value,
 });
@@ -128,47 +130,60 @@ export const changeListEditorTitle = value => ({
 export const createList = (title, shouldReset) => (dispatch, getState) => {
   dispatch(createListRequest());
 
-  api(getState).post('/api/v1/lists', { title }).then(({ data }) => {
-    dispatch(createListSuccess(data));
+  api(getState)
+    .post('/api/v1/lists', { title })
+    .then(({ data }) => {
+      dispatch(createListSuccess(data));
 
-    if (shouldReset) {
-      dispatch(resetListEditor());
-    }
-  }).catch(err => dispatch(createListFail(err)));
+      if (shouldReset) {
+        dispatch(resetListEditor());
+      }
+    })
+    .catch((err) => dispatch(createListFail(err)));
 };
 
 export const createListRequest = () => ({
   type: LIST_CREATE_REQUEST,
 });
 
-export const createListSuccess = list => ({
+export const createListSuccess = (list) => ({
   type: LIST_CREATE_SUCCESS,
   list,
 });
 
-export const createListFail = error => ({
+export const createListFail = (error) => ({
   type: LIST_CREATE_FAIL,
   error,
 });
 
-export const updateList = (id, title, shouldReset, isExclusive, replies_policy) => (dispatch, getState) => {
-  dispatch(updateListRequest(id));
+export const updateList =
+  (id, title, shouldReset, isExclusive, replies_policy) =>
+  (dispatch, getState) => {
+    dispatch(updateListRequest(id));
 
-  api(getState).put(`/api/v1/lists/${id}`, { title, replies_policy, exclusive: typeof isExclusive === 'undefined' ? undefined : !!isExclusive }).then(({ data }) => {
-    dispatch(updateListSuccess(data));
+    api(getState)
+      .put(`/api/v1/lists/${id}`, {
+        title,
+        replies_policy,
+        exclusive:
+          typeof isExclusive === 'undefined' ? undefined : !!isExclusive,
+      })
+      .then(({ data }) => {
+        dispatch(updateListSuccess(data));
 
-    if (shouldReset) {
-      dispatch(resetListEditor());
-    }
-  }).catch(err => dispatch(updateListFail(id, err)));
-};
+        if (shouldReset) {
+          dispatch(resetListEditor());
+        }
+      })
+      .catch((err) => dispatch(updateListFail(id, err)));
+  };
 
-export const updateListRequest = id => ({
+export const updateListRequest = (id) => ({
   type: LIST_UPDATE_REQUEST,
   id,
 });
 
-export const updateListSuccess = list => ({
+export const updateListSuccess = (list) => ({
   type: LIST_UPDATE_SUCCESS,
   list,
 });
@@ -183,20 +198,21 @@ export const resetListEditor = () => ({
   type: LIST_EDITOR_RESET,
 });
 
-export const deleteList = id => (dispatch, getState) => {
+export const deleteList = (id) => (dispatch, getState) => {
   dispatch(deleteListRequest(id));
 
-  api(getState).delete(`/api/v1/lists/${id}`)
+  api(getState)
+    .delete(`/api/v1/lists/${id}`)
     .then(() => dispatch(deleteListSuccess(id)))
-    .catch(err => dispatch(deleteListFail(id, err)));
+    .catch((err) => dispatch(deleteListFail(id, err)));
 };
 
-export const deleteListRequest = id => ({
+export const deleteListRequest = (id) => ({
   type: LIST_DELETE_REQUEST,
   id,
 });
 
-export const deleteListSuccess = id => ({
+export const deleteListSuccess = (id) => ({
   type: LIST_DELETE_SUCCESS,
   id,
 });
@@ -207,16 +223,19 @@ export const deleteListFail = (id, error) => ({
   error,
 });
 
-export const fetchListAccounts = listId => (dispatch, getState) => {
+export const fetchListAccounts = (listId) => (dispatch, getState) => {
   dispatch(fetchListAccountsRequest(listId));
 
-  api(getState).get(`/api/v1/lists/${listId}/accounts`, { params: { limit: 0 } }).then(({ data }) => {
-    dispatch(importFetchedAccounts(data));
-    dispatch(fetchListAccountsSuccess(listId, data));
-  }).catch(err => dispatch(fetchListAccountsFail(listId, err)));
+  api(getState)
+    .get(`/api/v1/lists/${listId}/accounts`, { params: { limit: 0 } })
+    .then(({ data }) => {
+      dispatch(importFetchedAccounts(data));
+      dispatch(fetchListAccountsSuccess(listId, data));
+    })
+    .catch((err) => dispatch(fetchListAccountsFail(listId, err)));
 };
 
-export const fetchListAccountsRequest = id => ({
+export const fetchListAccountsRequest = (id) => ({
   type: LIST_ACCOUNTS_FETCH_REQUEST,
   id,
 });
@@ -234,7 +253,7 @@ export const fetchListAccountsFail = (id, error) => ({
   error,
 });
 
-export const fetchListSuggestions = q => (dispatch, getState) => {
+export const fetchListSuggestions = (q) => (dispatch, getState) => {
   const params = {
     q,
     resolve: false,
@@ -242,10 +261,13 @@ export const fetchListSuggestions = q => (dispatch, getState) => {
     following: true,
   };
 
-  api(getState).get('/api/v1/accounts/search', { params }).then(({ data }) => {
-    dispatch(importFetchedAccounts(data));
-    dispatch(fetchListSuggestionsReady(q, data));
-  }).catch(error => dispatch(showAlertForError(error)));
+  api(getState)
+    .get('/api/v1/accounts/search', { params })
+    .then(({ data }) => {
+      dispatch(importFetchedAccounts(data));
+      dispatch(fetchListSuggestionsReady(q, data));
+    })
+    .catch((error) => dispatch(showAlertForError(error)));
 };
 
 export const fetchListSuggestionsReady = (query, accounts) => ({
@@ -258,21 +280,22 @@ export const clearListSuggestions = () => ({
   type: LIST_EDITOR_SUGGESTIONS_CLEAR,
 });
 
-export const changeListSuggestions = value => ({
+export const changeListSuggestions = (value) => ({
   type: LIST_EDITOR_SUGGESTIONS_CHANGE,
   value,
 });
 
-export const addToListEditor = accountId => (dispatch, getState) => {
+export const addToListEditor = (accountId) => (dispatch, getState) => {
   dispatch(addToList(getState().getIn(['listEditor', 'listId']), accountId));
 };
 
 export const addToList = (listId, accountId) => (dispatch, getState) => {
   dispatch(addToListRequest(listId, accountId));
 
-  api(getState).post(`/api/v1/lists/${listId}/accounts`, { account_ids: [accountId] })
+  api(getState)
+    .post(`/api/v1/lists/${listId}/accounts`, { account_ids: [accountId] })
     .then(() => dispatch(addToListSuccess(listId, accountId)))
-    .catch(err => dispatch(addToListFail(listId, accountId, err)));
+    .catch((err) => dispatch(addToListFail(listId, accountId, err)));
 };
 
 export const addToListRequest = (listId, accountId) => ({
@@ -294,16 +317,21 @@ export const addToListFail = (listId, accountId, error) => ({
   error,
 });
 
-export const removeFromListEditor = accountId => (dispatch, getState) => {
-  dispatch(removeFromList(getState().getIn(['listEditor', 'listId']), accountId));
+export const removeFromListEditor = (accountId) => (dispatch, getState) => {
+  dispatch(
+    removeFromList(getState().getIn(['listEditor', 'listId']), accountId),
+  );
 };
 
 export const removeFromList = (listId, accountId) => (dispatch, getState) => {
   dispatch(removeFromListRequest(listId, accountId));
 
-  api(getState).delete(`/api/v1/lists/${listId}/accounts`, { params: { account_ids: [accountId] } })
+  api(getState)
+    .delete(`/api/v1/lists/${listId}/accounts`, {
+      params: { account_ids: [accountId] },
+    })
     .then(() => dispatch(removeFromListSuccess(listId, accountId)))
-    .catch(err => dispatch(removeFromListFail(listId, accountId, err)));
+    .catch((err) => dispatch(removeFromListFail(listId, accountId, err)));
 };
 
 export const removeFromListRequest = (listId, accountId) => ({
@@ -329,7 +357,7 @@ export const resetListAdder = () => ({
   type: LIST_ADDER_RESET,
 });
 
-export const setupListAdder = accountId => (dispatch, getState) => {
+export const setupListAdder = (accountId) => (dispatch, getState) => {
   dispatch({
     type: LIST_ADDER_SETUP,
     account: getState().getIn(['accounts', accountId]),
@@ -338,16 +366,17 @@ export const setupListAdder = accountId => (dispatch, getState) => {
   dispatch(fetchAccountLists(accountId));
 };
 
-export const fetchAccountLists = accountId => (dispatch, getState) => {
+export const fetchAccountLists = (accountId) => (dispatch, getState) => {
   dispatch(fetchAccountListsRequest(accountId));
 
-  api(getState).get(`/api/v1/accounts/${accountId}/lists`)
+  api(getState)
+    .get(`/api/v1/accounts/${accountId}/lists`)
     .then(({ data }) => dispatch(fetchAccountListsSuccess(accountId, data)))
-    .catch(err => dispatch(fetchAccountListsFail(accountId, err)));
+    .catch((err) => dispatch(fetchAccountListsFail(accountId, err)));
 };
 
-export const fetchAccountListsRequest = id => ({
-  type:LIST_ADDER_LISTS_FETCH_REQUEST,
+export const fetchAccountListsRequest = (id) => ({
+  type: LIST_ADDER_LISTS_FETCH_REQUEST,
   id,
 });
 
@@ -363,11 +392,12 @@ export const fetchAccountListsFail = (id, err) => ({
   err,
 });
 
-export const addToListAdder = listId => (dispatch, getState) => {
+export const addToListAdder = (listId) => (dispatch, getState) => {
   dispatch(addToList(listId, getState().getIn(['listAdder', 'accountId'])));
 };
 
-export const removeFromListAdder = listId => (dispatch, getState) => {
-  dispatch(removeFromList(listId, getState().getIn(['listAdder', 'accountId'])));
+export const removeFromListAdder = (listId) => (dispatch, getState) => {
+  dispatch(
+    removeFromList(listId, getState().getIn(['listAdder', 'accountId'])),
+  );
 };
-

--- a/app/javascript/mastodon/actions/markers.js
+++ b/app/javascript/mastodon/actions/markers.js
@@ -7,12 +7,12 @@ import { compareId } from '../compare_id';
 
 export const MARKERS_FETCH_REQUEST = 'MARKERS_FETCH_REQUEST';
 export const MARKERS_FETCH_SUCCESS = 'MARKERS_FETCH_SUCCESS';
-export const MARKERS_FETCH_FAIL    = 'MARKERS_FETCH_FAIL';
+export const MARKERS_FETCH_FAIL = 'MARKERS_FETCH_FAIL';
 export const MARKERS_SUBMIT_SUCCESS = 'MARKERS_SUBMIT_SUCCESS';
 
 export const synchronouslySubmitMarkers = () => (dispatch, getState) => {
   const accessToken = getState().getIn(['meta', 'access_token'], '');
-  const params      = _buildParams(getState());
+  const params = _buildParams(getState());
 
   if (Object.keys(params).length === 0 || accessToken === '') {
     return;
@@ -27,7 +27,7 @@ export const synchronouslySubmitMarkers = () => (dispatch, getState) => {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${accessToken}`,
+        Authorization: `Bearer ${accessToken}`,
       },
       body: JSON.stringify(params),
     });
@@ -66,16 +66,24 @@ export const synchronouslySubmitMarkers = () => (dispatch, getState) => {
 const _buildParams = (state) => {
   const params = {};
 
-  const lastHomeId         = state.getIn(['timelines', 'home', 'items'], ImmutableList()).find(item => item !== null);
+  const lastHomeId = state
+    .getIn(['timelines', 'home', 'items'], ImmutableList())
+    .find((item) => item !== null);
   const lastNotificationId = state.getIn(['notifications', 'lastReadId']);
 
-  if (lastHomeId && compareId(lastHomeId, state.getIn(['markers', 'home'])) > 0) {
+  if (
+    lastHomeId &&
+    compareId(lastHomeId, state.getIn(['markers', 'home'])) > 0
+  ) {
     params.home = {
       last_read_id: lastHomeId,
     };
   }
 
-  if (lastNotificationId && compareId(lastNotificationId, state.getIn(['markers', 'notifications'])) > 0) {
+  if (
+    lastNotificationId &&
+    compareId(lastNotificationId, state.getIn(['markers', 'notifications'])) > 0
+  ) {
     params.notifications = {
       last_read_id: lastNotificationId,
     };
@@ -84,18 +92,25 @@ const _buildParams = (state) => {
   return params;
 };
 
-const debouncedSubmitMarkers = debounce((dispatch, getState) => {
-  const accessToken = getState().getIn(['meta', 'access_token'], '');
-  const params      = _buildParams(getState());
+const debouncedSubmitMarkers = debounce(
+  (dispatch, getState) => {
+    const accessToken = getState().getIn(['meta', 'access_token'], '');
+    const params = _buildParams(getState());
 
-  if (Object.keys(params).length === 0 || accessToken === '') {
-    return;
-  }
+    if (Object.keys(params).length === 0 || accessToken === '') {
+      return;
+    }
 
-  api(getState).post('/api/v1/markers', params).then(() => {
-    dispatch(submitMarkersSuccess(params));
-  }).catch(() => {});
-}, 300000, { leading: true, trailing: true });
+    api(getState)
+      .post('/api/v1/markers', params)
+      .then(() => {
+        dispatch(submitMarkersSuccess(params));
+      })
+      .catch(() => {});
+  },
+  300000,
+  { leading: true, trailing: true },
+);
 
 export function submitMarkersSuccess({ home, notifications }) {
   return {
@@ -106,7 +121,8 @@ export function submitMarkersSuccess({ home, notifications }) {
 }
 
 export function submitMarkers(params = {}) {
-  const result = (dispatch, getState) => debouncedSubmitMarkers(dispatch, getState);
+  const result = (dispatch, getState) =>
+    debouncedSubmitMarkers(dispatch, getState);
 
   if (params.immediate === true) {
     debouncedSubmitMarkers.flush();
@@ -120,11 +136,14 @@ export const fetchMarkers = () => (dispatch, getState) => {
 
   dispatch(fetchMarkersRequest());
 
-  api(getState).get('/api/v1/markers', { params }).then(response => {
-    dispatch(fetchMarkersSuccess(response.data));
-  }).catch(error => {
-    dispatch(fetchMarkersFail(error));
-  });
+  api(getState)
+    .get('/api/v1/markers', { params })
+    .then((response) => {
+      dispatch(fetchMarkersSuccess(response.data));
+    })
+    .catch((error) => {
+      dispatch(fetchMarkersFail(error));
+    });
 };
 
 export function fetchMarkersRequest() {

--- a/app/javascript/mastodon/actions/mutes.js
+++ b/app/javascript/mastodon/actions/mutes.js
@@ -6,26 +6,32 @@ import { openModal } from './modal';
 
 export const MUTES_FETCH_REQUEST = 'MUTES_FETCH_REQUEST';
 export const MUTES_FETCH_SUCCESS = 'MUTES_FETCH_SUCCESS';
-export const MUTES_FETCH_FAIL    = 'MUTES_FETCH_FAIL';
+export const MUTES_FETCH_FAIL = 'MUTES_FETCH_FAIL';
 
 export const MUTES_EXPAND_REQUEST = 'MUTES_EXPAND_REQUEST';
 export const MUTES_EXPAND_SUCCESS = 'MUTES_EXPAND_SUCCESS';
-export const MUTES_EXPAND_FAIL    = 'MUTES_EXPAND_FAIL';
+export const MUTES_EXPAND_FAIL = 'MUTES_EXPAND_FAIL';
 
 export const MUTES_INIT_MODAL = 'MUTES_INIT_MODAL';
-export const MUTES_TOGGLE_HIDE_NOTIFICATIONS = 'MUTES_TOGGLE_HIDE_NOTIFICATIONS';
+export const MUTES_TOGGLE_HIDE_NOTIFICATIONS =
+  'MUTES_TOGGLE_HIDE_NOTIFICATIONS';
 export const MUTES_CHANGE_DURATION = 'MUTES_CHANGE_DURATION';
 
 export function fetchMutes() {
   return (dispatch, getState) => {
     dispatch(fetchMutesRequest());
 
-    api(getState).get('/api/v1/mutes').then(response => {
-      const next = getLinks(response).refs.find(link => link.rel === 'next');
-      dispatch(importFetchedAccounts(response.data));
-      dispatch(fetchMutesSuccess(response.data, next ? next.uri : null));
-      dispatch(fetchRelationships(response.data.map(item => item.id)));
-    }).catch(error => dispatch(fetchMutesFail(error)));
+    api(getState)
+      .get('/api/v1/mutes')
+      .then((response) => {
+        const next = getLinks(response).refs.find(
+          (link) => link.rel === 'next',
+        );
+        dispatch(importFetchedAccounts(response.data));
+        dispatch(fetchMutesSuccess(response.data, next ? next.uri : null));
+        dispatch(fetchRelationships(response.data.map((item) => item.id)));
+      })
+      .catch((error) => dispatch(fetchMutesFail(error)));
   };
 }
 
@@ -60,12 +66,17 @@ export function expandMutes() {
 
     dispatch(expandMutesRequest());
 
-    api(getState).get(url).then(response => {
-      const next = getLinks(response).refs.find(link => link.rel === 'next');
-      dispatch(importFetchedAccounts(response.data));
-      dispatch(expandMutesSuccess(response.data, next ? next.uri : null));
-      dispatch(fetchRelationships(response.data.map(item => item.id)));
-    }).catch(error => dispatch(expandMutesFail(error)));
+    api(getState)
+      .get(url)
+      .then((response) => {
+        const next = getLinks(response).refs.find(
+          (link) => link.rel === 'next',
+        );
+        dispatch(importFetchedAccounts(response.data));
+        dispatch(expandMutesSuccess(response.data, next ? next.uri : null));
+        dispatch(fetchRelationships(response.data.map((item) => item.id)));
+      })
+      .catch((error) => dispatch(expandMutesFail(error)));
   };
 }
 
@@ -91,7 +102,7 @@ export function expandMutesFail(error) {
 }
 
 export function initMuteModal(account) {
-  return dispatch => {
+  return (dispatch) => {
     dispatch({
       type: MUTES_INIT_MODAL,
       account,
@@ -102,13 +113,13 @@ export function initMuteModal(account) {
 }
 
 export function toggleHideNotifications() {
-  return dispatch => {
+  return (dispatch) => {
     dispatch({ type: MUTES_TOGGLE_HIDE_NOTIFICATIONS });
   };
 }
 
 export function changeMuteDuration(duration) {
-  return dispatch => {
+  return (dispatch) => {
     dispatch({
       type: MUTES_CHANGE_DURATION,
       duration,

--- a/app/javascript/mastodon/actions/notifications.js
+++ b/app/javascript/mastodon/actions/notifications.js
@@ -21,34 +21,44 @@ import { submitMarkers } from './markers';
 import { register as registerPushNotifications } from './push_notifications';
 import { saveSettings } from './settings';
 
-export const NOTIFICATIONS_UPDATE      = 'NOTIFICATIONS_UPDATE';
+export const NOTIFICATIONS_UPDATE = 'NOTIFICATIONS_UPDATE';
 export const NOTIFICATIONS_UPDATE_NOOP = 'NOTIFICATIONS_UPDATE_NOOP';
 
 export const NOTIFICATIONS_EXPAND_REQUEST = 'NOTIFICATIONS_EXPAND_REQUEST';
 export const NOTIFICATIONS_EXPAND_SUCCESS = 'NOTIFICATIONS_EXPAND_SUCCESS';
-export const NOTIFICATIONS_EXPAND_FAIL    = 'NOTIFICATIONS_EXPAND_FAIL';
+export const NOTIFICATIONS_EXPAND_FAIL = 'NOTIFICATIONS_EXPAND_FAIL';
 
 export const NOTIFICATIONS_FILTER_SET = 'NOTIFICATIONS_FILTER_SET';
 
-export const NOTIFICATIONS_CLEAR        = 'NOTIFICATIONS_CLEAR';
-export const NOTIFICATIONS_SCROLL_TOP   = 'NOTIFICATIONS_SCROLL_TOP';
+export const NOTIFICATIONS_CLEAR = 'NOTIFICATIONS_CLEAR';
+export const NOTIFICATIONS_SCROLL_TOP = 'NOTIFICATIONS_SCROLL_TOP';
 export const NOTIFICATIONS_LOAD_PENDING = 'NOTIFICATIONS_LOAD_PENDING';
 
-export const NOTIFICATIONS_MOUNT   = 'NOTIFICATIONS_MOUNT';
+export const NOTIFICATIONS_MOUNT = 'NOTIFICATIONS_MOUNT';
 export const NOTIFICATIONS_UNMOUNT = 'NOTIFICATIONS_UNMOUNT';
 
 export const NOTIFICATIONS_MARK_AS_READ = 'NOTIFICATIONS_MARK_AS_READ';
 
-export const NOTIFICATIONS_SET_BROWSER_SUPPORT    = 'NOTIFICATIONS_SET_BROWSER_SUPPORT';
-export const NOTIFICATIONS_SET_BROWSER_PERMISSION = 'NOTIFICATIONS_SET_BROWSER_PERMISSION';
+export const NOTIFICATIONS_SET_BROWSER_SUPPORT =
+  'NOTIFICATIONS_SET_BROWSER_SUPPORT';
+export const NOTIFICATIONS_SET_BROWSER_PERMISSION =
+  'NOTIFICATIONS_SET_BROWSER_PERMISSION';
 
 defineMessages({
-  mention: { id: 'notification.mention', defaultMessage: '{name} mentioned you' },
+  mention: {
+    id: 'notification.mention',
+    defaultMessage: '{name} mentioned you',
+  },
   group: { id: 'notifications.group', defaultMessage: '{count} notifications' },
 });
 
 const fetchRelatedRelationships = (dispatch, notifications) => {
-  const accountIds = notifications.filter(item => ['follow', 'follow_request', 'admin.sign_up'].indexOf(item.type) !== -1).map(item => item.account.id);
+  const accountIds = notifications
+    .filter(
+      (item) =>
+        ['follow', 'follow_request', 'admin.sign_up'].indexOf(item.type) !== -1,
+    )
+    .map((item) => item.account.id);
 
   if (accountIds.length > 0) {
     dispatch(fetchRelationships(accountIds));
@@ -61,17 +71,39 @@ export const loadPending = () => ({
 
 export function updateNotifications(notification, intlMessages, intlLocale) {
   return (dispatch, getState) => {
-    const activeFilter = getState().getIn(['settings', 'notifications', 'quickFilter', 'active']);
-    const showInColumn = activeFilter === 'all' ? getState().getIn(['settings', 'notifications', 'shows', notification.type], true) : activeFilter === notification.type;
-    const showAlert    = getState().getIn(['settings', 'notifications', 'alerts', notification.type], true);
-    const playSound    = getState().getIn(['settings', 'notifications', 'sounds', notification.type], true);
+    const activeFilter = getState().getIn([
+      'settings',
+      'notifications',
+      'quickFilter',
+      'active',
+    ]);
+    const showInColumn =
+      activeFilter === 'all'
+        ? getState().getIn(
+            ['settings', 'notifications', 'shows', notification.type],
+            true,
+          )
+        : activeFilter === notification.type;
+    const showAlert = getState().getIn(
+      ['settings', 'notifications', 'alerts', notification.type],
+      true,
+    );
+    const playSound = getState().getIn(
+      ['settings', 'notifications', 'sounds', notification.type],
+      true,
+    );
 
     let filtered = false;
 
-    if (['mention', 'status'].includes(notification.type) && notification.status.filtered) {
-      const filters = notification.status.filtered.filter(result => result.filter.context.includes('notifications'));
+    if (
+      ['mention', 'status'].includes(notification.type) &&
+      notification.status.filtered
+    ) {
+      const filters = notification.status.filtered.filter((result) =>
+        result.filter.context.includes('notifications'),
+      );
 
-      if (filters.some(result => result.filter.filter_action === 'hide')) {
+      if (filters.some((result) => result.filter.filter_action === 'hide')) {
         return;
       }
 
@@ -99,7 +131,7 @@ export function updateNotifications(notification, intlMessages, intlLocale) {
         type: NOTIFICATIONS_UPDATE,
         notification,
         usePendingItems: preferPendingItems,
-        meta: (playSound && !filtered) ? { sound: 'boop' } : undefined,
+        meta: playSound && !filtered ? { sound: 'boop' } : undefined,
       });
 
       fetchRelatedRelationships(dispatch, [notification]);
@@ -112,10 +144,27 @@ export function updateNotifications(notification, intlMessages, intlLocale) {
 
     // Desktop notifications
     if (typeof window.Notification !== 'undefined' && showAlert && !filtered) {
-      const title = new IntlMessageFormat(intlMessages[`notification.${notification.type}`], intlLocale).format({ name: notification.account.display_name.length > 0 ? notification.account.display_name : notification.account.username });
-      const body  = (notification.status && notification.status.spoiler_text.length > 0) ? notification.status.spoiler_text : unescapeHTML(notification.status ? notification.status.content : '');
+      const title = new IntlMessageFormat(
+        intlMessages[`notification.${notification.type}`],
+        intlLocale,
+      ).format({
+        name:
+          notification.account.display_name.length > 0
+            ? notification.account.display_name
+            : notification.account.username,
+      });
+      const body =
+        notification.status && notification.status.spoiler_text.length > 0
+          ? notification.status.spoiler_text
+          : unescapeHTML(
+              notification.status ? notification.status.content : '',
+            );
 
-      const notify = new Notification(title, { body, icon: notification.account.avatar, tag: notification.id });
+      const notify = new Notification(title, {
+        body,
+        icon: notification.account.avatar,
+        tag: notification.id,
+      });
 
       notify.addEventListener('click', () => {
         window.focus();
@@ -125,9 +174,14 @@ export function updateNotifications(notification, intlMessages, intlLocale) {
   };
 }
 
-const excludeTypesFromSettings = state => state.getIn(['settings', 'notifications', 'shows']).filter(enabled => !enabled).keySeq().toJS();
+const excludeTypesFromSettings = (state) =>
+  state
+    .getIn(['settings', 'notifications', 'shows'])
+    .filter((enabled) => !enabled)
+    .keySeq()
+    .toJS();
 
-const excludeTypesFromFilter = filter => {
+const excludeTypesFromFilter = (filter) => {
   const allTypes = ImmutableList([
     'follow',
     'follow_request',
@@ -141,7 +195,7 @@ const excludeTypesFromFilter = filter => {
     'admin.report',
   ]);
 
-  return allTypes.filterNot(item => item === filter).toJS();
+  return allTypes.filterNot((item) => item === filter).toJS();
 };
 
 const noOp = () => {};
@@ -150,7 +204,12 @@ let expandNotificationsController = new AbortController();
 
 export function expandNotifications({ maxId, forceLoad } = {}, done = noOp) {
   return (dispatch, getState) => {
-    const activeFilter = getState().getIn(['settings', 'notifications', 'quickFilter', 'active']);
+    const activeFilter = getState().getIn([
+      'settings',
+      'notifications',
+      'quickFilter',
+      'active',
+    ]);
     const notifications = getState().get('notifications');
     const isLoadingMore = !!maxId;
 
@@ -166,12 +225,18 @@ export function expandNotifications({ maxId, forceLoad } = {}, done = noOp) {
 
     const params = {
       max_id: maxId,
-      exclude_types: activeFilter === 'all'
-        ? excludeTypesFromSettings(getState())
-        : excludeTypesFromFilter(activeFilter),
+      exclude_types:
+        activeFilter === 'all'
+          ? excludeTypesFromSettings(getState())
+          : excludeTypesFromFilter(activeFilter),
     };
 
-    if (!params.max_id && (notifications.get('items', ImmutableList()).size + notifications.get('pendingItems', ImmutableList()).size) > 0) {
+    if (
+      !params.max_id &&
+      notifications.get('items', ImmutableList()).size +
+        notifications.get('pendingItems', ImmutableList()).size >
+        0
+    ) {
       const a = notifications.getIn(['pendingItems', 0, 'id']);
       const b = notifications.getIn(['items', 0, 'id']);
 
@@ -186,21 +251,52 @@ export function expandNotifications({ maxId, forceLoad } = {}, done = noOp) {
 
     dispatch(expandNotificationsRequest(isLoadingMore));
 
-    api(getState).get('/api/v1/notifications', { params, signal: expandNotificationsController.signal }).then(response => {
-      const next = getLinks(response).refs.find(link => link.rel === 'next');
+    api(getState)
+      .get('/api/v1/notifications', {
+        params,
+        signal: expandNotificationsController.signal,
+      })
+      .then((response) => {
+        const next = getLinks(response).refs.find(
+          (link) => link.rel === 'next',
+        );
 
-      dispatch(importFetchedAccounts(response.data.map(item => item.account)));
-      dispatch(importFetchedStatuses(response.data.map(item => item.status).filter(status => !!status)));
-      dispatch(importFetchedAccounts(response.data.filter(item => item.report).map(item => item.report.target_account)));
+        dispatch(
+          importFetchedAccounts(response.data.map((item) => item.account)),
+        );
+        dispatch(
+          importFetchedStatuses(
+            response.data
+              .map((item) => item.status)
+              .filter((status) => !!status),
+          ),
+        );
+        dispatch(
+          importFetchedAccounts(
+            response.data
+              .filter((item) => item.report)
+              .map((item) => item.report.target_account),
+          ),
+        );
 
-      dispatch(expandNotificationsSuccess(response.data, next ? next.uri : null, isLoadingMore, isLoadingRecent, isLoadingRecent && preferPendingItems));
-      fetchRelatedRelationships(dispatch, response.data);
-      dispatch(submitMarkers());
-    }).catch(error => {
-      dispatch(expandNotificationsFail(error, isLoadingMore));
-    }).finally(() => {
-      done();
-    });
+        dispatch(
+          expandNotificationsSuccess(
+            response.data,
+            next ? next.uri : null,
+            isLoadingMore,
+            isLoadingRecent,
+            isLoadingRecent && preferPendingItems,
+          ),
+        );
+        fetchRelatedRelationships(dispatch, response.data);
+        dispatch(submitMarkers());
+      })
+      .catch((error) => {
+        dispatch(expandNotificationsFail(error, isLoadingMore));
+      })
+      .finally(() => {
+        done();
+      });
   };
 }
 
@@ -211,7 +307,13 @@ export function expandNotificationsRequest(isLoadingMore) {
   };
 }
 
-export function expandNotificationsSuccess(notifications, next, isLoadingMore, isLoadingRecent, usePendingItems) {
+export function expandNotificationsSuccess(
+  notifications,
+  next,
+  isLoadingMore,
+  isLoadingRecent,
+  usePendingItems,
+) {
   return {
     type: NOTIFICATIONS_EXPAND_SUCCESS,
     notifications,
@@ -248,8 +350,8 @@ export function scrollTopNotifications(top) {
   };
 }
 
-export function setFilter (filterType) {
-  return dispatch => {
+export function setFilter(filterType) {
+  return (dispatch) => {
     dispatch({
       type: NOTIFICATIONS_FILTER_SET,
       path: ['notifications', 'quickFilter', 'active'],
@@ -268,29 +370,32 @@ export const unmountNotifications = () => ({
   type: NOTIFICATIONS_UNMOUNT,
 });
 
-
 export const markNotificationsAsRead = () => ({
   type: NOTIFICATIONS_MARK_AS_READ,
 });
 
 // Browser support
 export function setupBrowserNotifications() {
-  return dispatch => {
+  return (dispatch) => {
     dispatch(setBrowserSupport('Notification' in window));
     if ('Notification' in window) {
       dispatch(setBrowserPermission(Notification.permission));
     }
 
     if ('Notification' in window && 'permissions' in navigator) {
-      navigator.permissions.query({ name: 'notifications' }).then((status) => {
-        status.onchange = () => dispatch(setBrowserPermission(Notification.permission));
-      }).catch(console.warn);
+      navigator.permissions
+        .query({ name: 'notifications' })
+        .then((status) => {
+          status.onchange = () =>
+            dispatch(setBrowserPermission(Notification.permission));
+        })
+        .catch(console.warn);
     }
   };
 }
 
 export function requestBrowserPermission(callback = noOp) {
-  return dispatch => {
+  return (dispatch) => {
     requestNotificationPermission((permission) => {
       dispatch(setBrowserPermission(permission));
       callback(permission);
@@ -302,14 +407,14 @@ export function requestBrowserPermission(callback = noOp) {
   };
 }
 
-export function setBrowserSupport (value) {
+export function setBrowserSupport(value) {
   return {
     type: NOTIFICATIONS_SET_BROWSER_SUPPORT,
     value,
   };
 }
 
-export function setBrowserPermission (value) {
+export function setBrowserPermission(value) {
   return {
     type: NOTIFICATIONS_SET_BROWSER_PERMISSION,
     value,

--- a/app/javascript/mastodon/actions/onboarding.js
+++ b/app/javascript/mastodon/actions/onboarding.js
@@ -2,7 +2,7 @@ import { changeSetting, saveSettings } from './settings';
 
 export const INTRODUCTION_VERSION = 20181216044202;
 
-export const closeOnboarding = () => dispatch => {
+export const closeOnboarding = () => (dispatch) => {
   dispatch(changeSetting(['introductionVersion'], INTRODUCTION_VERSION));
   dispatch(saveSettings());
 };

--- a/app/javascript/mastodon/actions/picture_in_picture.js
+++ b/app/javascript/mastodon/actions/picture_in_picture.js
@@ -22,7 +22,12 @@ export const PICTURE_IN_PICTURE_REMOVE = 'PICTURE_IN_PICTURE_REMOVE';
  * @param {MediaProps} props
  * @returns {object}
  */
-export const deployPictureInPicture = (statusId, accountId, playerType, props) => {
+export const deployPictureInPicture = (
+  statusId,
+  accountId,
+  playerType,
+  props,
+) => {
   // @ts-expect-error
   return (dispatch, getState) => {
     // Do not open a player for a toot that does not exist

--- a/app/javascript/mastodon/actions/pin_statuses.js
+++ b/app/javascript/mastodon/actions/pin_statuses.js
@@ -11,12 +11,15 @@ export function fetchPinnedStatuses() {
   return (dispatch, getState) => {
     dispatch(fetchPinnedStatusesRequest());
 
-    api(getState).get(`/api/v1/accounts/${me}/statuses`, { params: { pinned: true } }).then(response => {
-      dispatch(importFetchedStatuses(response.data));
-      dispatch(fetchPinnedStatusesSuccess(response.data, null));
-    }).catch(error => {
-      dispatch(fetchPinnedStatusesFail(error));
-    });
+    api(getState)
+      .get(`/api/v1/accounts/${me}/statuses`, { params: { pinned: true } })
+      .then((response) => {
+        dispatch(importFetchedStatuses(response.data));
+        dispatch(fetchPinnedStatusesSuccess(response.data, null));
+      })
+      .catch((error) => {
+        dispatch(fetchPinnedStatusesFail(error));
+      });
   };
 }
 

--- a/app/javascript/mastodon/actions/polls.js
+++ b/app/javascript/mastodon/actions/polls.js
@@ -4,44 +4,46 @@ import { importFetchedPoll } from './importer';
 
 export const POLL_VOTE_REQUEST = 'POLL_VOTE_REQUEST';
 export const POLL_VOTE_SUCCESS = 'POLL_VOTE_SUCCESS';
-export const POLL_VOTE_FAIL    = 'POLL_VOTE_FAIL';
+export const POLL_VOTE_FAIL = 'POLL_VOTE_FAIL';
 
 export const POLL_FETCH_REQUEST = 'POLL_FETCH_REQUEST';
 export const POLL_FETCH_SUCCESS = 'POLL_FETCH_SUCCESS';
-export const POLL_FETCH_FAIL    = 'POLL_FETCH_FAIL';
+export const POLL_FETCH_FAIL = 'POLL_FETCH_FAIL';
 
 export const vote = (pollId, choices) => (dispatch, getState) => {
   dispatch(voteRequest());
 
-  api(getState).post(`/api/v1/polls/${pollId}/votes`, { choices })
+  api(getState)
+    .post(`/api/v1/polls/${pollId}/votes`, { choices })
     .then(({ data }) => {
       dispatch(importFetchedPoll(data));
       dispatch(voteSuccess(data));
     })
-    .catch(err => dispatch(voteFail(err)));
+    .catch((err) => dispatch(voteFail(err)));
 };
 
-export const fetchPoll = pollId => (dispatch, getState) => {
+export const fetchPoll = (pollId) => (dispatch, getState) => {
   dispatch(fetchPollRequest());
 
-  api(getState).get(`/api/v1/polls/${pollId}`)
+  api(getState)
+    .get(`/api/v1/polls/${pollId}`)
     .then(({ data }) => {
       dispatch(importFetchedPoll(data));
       dispatch(fetchPollSuccess(data));
     })
-    .catch(err => dispatch(fetchPollFail(err)));
+    .catch((err) => dispatch(fetchPollFail(err)));
 };
 
 export const voteRequest = () => ({
   type: POLL_VOTE_REQUEST,
 });
 
-export const voteSuccess = poll => ({
+export const voteSuccess = (poll) => ({
   type: POLL_VOTE_SUCCESS,
   poll,
 });
 
-export const voteFail = error => ({
+export const voteFail = (error) => ({
   type: POLL_VOTE_FAIL,
   error,
 });
@@ -50,12 +52,12 @@ export const fetchPollRequest = () => ({
   type: POLL_FETCH_REQUEST,
 });
 
-export const fetchPollSuccess = poll => ({
+export const fetchPollSuccess = (poll) => ({
   type: POLL_FETCH_SUCCESS,
   poll,
 });
 
-export const fetchPollFail = error => ({
+export const fetchPollFail = (error) => ({
   type: POLL_FETCH_FAIL,
   error,
 });

--- a/app/javascript/mastodon/actions/push_notifications/index.js
+++ b/app/javascript/mastodon/actions/push_notifications/index.js
@@ -2,7 +2,7 @@ import { saveSettings } from './registerer';
 import { setAlerts } from './setter';
 
 export function changeAlerts(path, value) {
-  return dispatch => {
+  return (dispatch) => {
     dispatch(setAlerts(path, value));
     dispatch(saveSettings());
   };

--- a/app/javascript/mastodon/actions/push_notifications/registerer.js
+++ b/app/javascript/mastodon/actions/push_notifications/registerer.js
@@ -3,25 +3,31 @@ import { me } from '../../initial_state';
 import { pushNotificationsSetting } from '../../settings';
 import { decode as decodeBase64 } from '../../utils/base64';
 
-import { setBrowserSupport, setSubscription, clearSubscription } from './setter';
+import {
+  setBrowserSupport,
+  setSubscription,
+  clearSubscription,
+} from './setter';
 
 // Taken from https://www.npmjs.com/package/web-push
 const urlBase64ToUint8Array = (base64String) => {
-  const padding = '='.repeat((4 - base64String.length % 4) % 4);
-  const base64 = (base64String + padding)
-    .replace(/-/g, '+')
-    .replace(/_/g, '/');
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
 
   return decodeBase64(base64);
 };
 
-const getApplicationServerKey = () => document.querySelector('[name="applicationServerKey"]').getAttribute('content');
+const getApplicationServerKey = () =>
+  document
+    .querySelector('[name="applicationServerKey"]')
+    .getAttribute('content');
 
 const getRegistration = () => navigator.serviceWorker.ready;
 
 const getPushSubscription = (registration) =>
-  registration.pushManager.getSubscription()
-    .then(subscription => ({ registration, subscription }));
+  registration.pushManager
+    .getSubscription()
+    .then((subscription) => ({ registration, subscription }));
 
 const subscribe = (registration) =>
   registration.pushManager.subscribe({
@@ -30,7 +36,9 @@ const subscribe = (registration) =>
   });
 
 const unsubscribe = ({ registration, subscription }) =>
-  subscription ? subscription.unsubscribe().then(() => registration) : registration;
+  subscription
+    ? subscription.unsubscribe().then(() => registration)
+    : registration;
 
 const sendSubscriptionToBackend = (subscription) => {
   const params = { subscription };
@@ -42,19 +50,26 @@ const sendSubscriptionToBackend = (subscription) => {
     }
   }
 
-  return api().post('/api/web/push_subscriptions', params).then(response => response.data);
+  return api()
+    .post('/api/web/push_subscriptions', params)
+    .then((response) => response.data);
 };
 
 // Last one checks for payload support: https://web-push-book.gauntface.com/chapter-06/01-non-standards-browsers/#no-payload
-const supportsPushNotifications = ('serviceWorker' in navigator && 'PushManager' in window && 'getKey' in PushSubscription.prototype);
+const supportsPushNotifications =
+  'serviceWorker' in navigator &&
+  'PushManager' in window &&
+  'getKey' in PushSubscription.prototype;
 
-export function register () {
+export function register() {
   return (dispatch, getState) => {
     dispatch(setBrowserSupport(supportsPushNotifications));
 
     if (supportsPushNotifications) {
       if (!getApplicationServerKey()) {
-        console.error('The VAPID public key is not set. You will not be able to receive Web Push Notifications.');
+        console.error(
+          'The VAPID public key is not set. You will not be able to receive Web Push Notifications.',
+        );
         return;
       }
 
@@ -63,26 +78,41 @@ export function register () {
         .then(({ registration, subscription }) => {
           if (subscription !== null) {
             // We have a subscription, check if it is still valid
-            const currentServerKey = (new Uint8Array(subscription.options.applicationServerKey)).toString();
-            const subscriptionServerKey = urlBase64ToUint8Array(getApplicationServerKey()).toString();
-            const serverEndpoint = getState().getIn(['push_notifications', 'subscription', 'endpoint']);
+            const currentServerKey = new Uint8Array(
+              subscription.options.applicationServerKey,
+            ).toString();
+            const subscriptionServerKey = urlBase64ToUint8Array(
+              getApplicationServerKey(),
+            ).toString();
+            const serverEndpoint = getState().getIn([
+              'push_notifications',
+              'subscription',
+              'endpoint',
+            ]);
 
             // If the VAPID public key did not change and the endpoint corresponds
             // to the endpoint saved in the backend, the subscription is valid
-            if (subscriptionServerKey === currentServerKey && subscription.endpoint === serverEndpoint) {
+            if (
+              subscriptionServerKey === currentServerKey &&
+              subscription.endpoint === serverEndpoint
+            ) {
               return subscription;
             } else {
               // Something went wrong, try to subscribe again
-              return unsubscribe({ registration, subscription }).then(subscribe).then(
-                subscription => sendSubscriptionToBackend(subscription));
+              return unsubscribe({ registration, subscription })
+                .then(subscribe)
+                .then((subscription) =>
+                  sendSubscriptionToBackend(subscription),
+                );
             }
           }
 
           // No subscription, try to subscribe
-          return subscribe(registration).then(
-            subscription => sendSubscriptionToBackend(subscription));
+          return subscribe(registration).then((subscription) =>
+            sendSubscriptionToBackend(subscription),
+          );
         })
-        .then(subscription => {
+        .then((subscription) => {
           // If we got a PushSubscription (and not a subscription object from the backend)
           // it means that the backend subscription is valid (and was set during hydration)
           if (!(subscription instanceof PushSubscription)) {
@@ -92,11 +122,19 @@ export function register () {
             }
           }
         })
-        .catch(error => {
+        .catch((error) => {
           if (error.code === 20 && error.name === 'AbortError') {
-            console.warn('Your browser supports Web Push Notifications, but does not seem to implement the VAPID protocol.');
-          } else if (error.code === 5 && error.name === 'InvalidCharacterError') {
-            console.error('The VAPID public key seems to be invalid:', getApplicationServerKey());
+            console.warn(
+              'Your browser supports Web Push Notifications, but does not seem to implement the VAPID protocol.',
+            );
+          } else if (
+            error.code === 5 &&
+            error.name === 'InvalidCharacterError'
+          ) {
+            console.error(
+              'The VAPID public key seems to be invalid:',
+              getApplicationServerKey(),
+            );
           }
 
           // Clear alerts and hide UI settings
@@ -105,9 +143,7 @@ export function register () {
             pushNotificationsSetting.remove(me);
           }
 
-          return getRegistration()
-            .then(getPushSubscription)
-            .then(unsubscribe);
+          return getRegistration().then(getPushSubscription).then(unsubscribe);
         })
         .catch(console.warn);
     } else {
@@ -123,12 +159,15 @@ export function saveSettings() {
     const alerts = state.get('alerts');
     const data = { alerts };
 
-    api().put(`/api/web/push_subscriptions/${subscription.get('id')}`, {
-      data,
-    }).then(() => {
-      if (me) {
-        pushNotificationsSetting.set(me, data);
-      }
-    }).catch(console.warn);
+    api()
+      .put(`/api/web/push_subscriptions/${subscription.get('id')}`, {
+        data,
+      })
+      .then(() => {
+        if (me) {
+          pushNotificationsSetting.set(me, data);
+        }
+      })
+      .catch(console.warn);
   };
 }

--- a/app/javascript/mastodon/actions/push_notifications/setter.js
+++ b/app/javascript/mastodon/actions/push_notifications/setter.js
@@ -3,28 +3,28 @@ export const SET_SUBSCRIPTION = 'PUSH_NOTIFICATIONS_SET_SUBSCRIPTION';
 export const CLEAR_SUBSCRIPTION = 'PUSH_NOTIFICATIONS_CLEAR_SUBSCRIPTION';
 export const SET_ALERTS = 'PUSH_NOTIFICATIONS_SET_ALERTS';
 
-export function setBrowserSupport (value) {
+export function setBrowserSupport(value) {
   return {
     type: SET_BROWSER_SUPPORT,
     value,
   };
 }
 
-export function setSubscription (subscription) {
+export function setSubscription(subscription) {
   return {
     type: SET_SUBSCRIPTION,
     subscription,
   };
 }
 
-export function clearSubscription () {
+export function clearSubscription() {
   return {
     type: CLEAR_SUBSCRIPTION,
   };
 }
 
-export function setAlerts (path, value) {
-  return dispatch => {
+export function setAlerts(path, value) {
+  return (dispatch) => {
     dispatch({
       type: SET_ALERTS,
       path,

--- a/app/javascript/mastodon/actions/reports.js
+++ b/app/javascript/mastodon/actions/reports.js
@@ -4,39 +4,45 @@ import { openModal } from './modal';
 
 export const REPORT_SUBMIT_REQUEST = 'REPORT_SUBMIT_REQUEST';
 export const REPORT_SUBMIT_SUCCESS = 'REPORT_SUBMIT_SUCCESS';
-export const REPORT_SUBMIT_FAIL    = 'REPORT_SUBMIT_FAIL';
+export const REPORT_SUBMIT_FAIL = 'REPORT_SUBMIT_FAIL';
 
-export const initReport = (account, status) => dispatch =>
-  dispatch(openModal({
-    modalType: 'REPORT',
-    modalProps: {
-      accountId: account.get('id'),
-      statusId: status?.get('id'),
-    },
-  }));
+export const initReport = (account, status) => (dispatch) =>
+  dispatch(
+    openModal({
+      modalType: 'REPORT',
+      modalProps: {
+        accountId: account.get('id'),
+        statusId: status?.get('id'),
+      },
+    }),
+  );
 
-export const submitReport = (params, onSuccess, onFail) => (dispatch, getState) => {
-  dispatch(submitReportRequest());
+export const submitReport =
+  (params, onSuccess, onFail) => (dispatch, getState) => {
+    dispatch(submitReportRequest());
 
-  api(getState).post('/api/v1/reports', params).then(response => {
-    dispatch(submitReportSuccess(response.data));
-    if (onSuccess) onSuccess();
-  }).catch(error => {
-    dispatch(submitReportFail(error));
-    if (onFail) onFail();
-  });
-};
+    api(getState)
+      .post('/api/v1/reports', params)
+      .then((response) => {
+        dispatch(submitReportSuccess(response.data));
+        if (onSuccess) onSuccess();
+      })
+      .catch((error) => {
+        dispatch(submitReportFail(error));
+        if (onFail) onFail();
+      });
+  };
 
 export const submitReportRequest = () => ({
   type: REPORT_SUBMIT_REQUEST,
 });
 
-export const submitReportSuccess = report => ({
+export const submitReportSuccess = (report) => ({
   type: REPORT_SUBMIT_SUCCESS,
   report,
 });
 
-export const submitReportFail = error => ({
+export const submitReportFail = (error) => ({
   type: REPORT_SUBMIT_FAIL,
   error,
 });

--- a/app/javascript/mastodon/actions/search.js
+++ b/app/javascript/mastodon/actions/search.js
@@ -8,18 +8,18 @@ import { fetchRelationships } from './accounts';
 import { importFetchedAccounts, importFetchedStatuses } from './importer';
 
 export const SEARCH_CHANGE = 'SEARCH_CHANGE';
-export const SEARCH_CLEAR  = 'SEARCH_CLEAR';
-export const SEARCH_SHOW   = 'SEARCH_SHOW';
+export const SEARCH_CLEAR = 'SEARCH_CLEAR';
+export const SEARCH_SHOW = 'SEARCH_SHOW';
 
 export const SEARCH_FETCH_REQUEST = 'SEARCH_FETCH_REQUEST';
 export const SEARCH_FETCH_SUCCESS = 'SEARCH_FETCH_SUCCESS';
-export const SEARCH_FETCH_FAIL    = 'SEARCH_FETCH_FAIL';
+export const SEARCH_FETCH_FAIL = 'SEARCH_FETCH_FAIL';
 
 export const SEARCH_EXPAND_REQUEST = 'SEARCH_EXPAND_REQUEST';
 export const SEARCH_EXPAND_SUCCESS = 'SEARCH_EXPAND_SUCCESS';
-export const SEARCH_EXPAND_FAIL    = 'SEARCH_EXPAND_FAIL';
+export const SEARCH_EXPAND_FAIL = 'SEARCH_EXPAND_FAIL';
 
-export const SEARCH_HISTORY_UPDATE  = 'SEARCH_HISTORY_UPDATE';
+export const SEARCH_HISTORY_UPDATE = 'SEARCH_HISTORY_UPDATE';
 
 export function changeSearch(value) {
   return {
@@ -36,37 +36,48 @@ export function clearSearch() {
 
 export function submitSearch(type) {
   return (dispatch, getState) => {
-    const value    = getState().getIn(['search', 'value']);
+    const value = getState().getIn(['search', 'value']);
     const signedIn = !!getState().getIn(['meta', 'me']);
 
     if (value.length === 0) {
-      dispatch(fetchSearchSuccess({ accounts: [], statuses: [], hashtags: [] }, '', type));
+      dispatch(
+        fetchSearchSuccess(
+          { accounts: [], statuses: [], hashtags: [] },
+          '',
+          type,
+        ),
+      );
       return;
     }
 
     dispatch(fetchSearchRequest(type));
 
-    api(getState).get('/api/v2/search', {
-      params: {
-        q: value,
-        resolve: signedIn,
-        limit: 11,
-        type,
-      },
-    }).then(response => {
-      if (response.data.accounts) {
-        dispatch(importFetchedAccounts(response.data.accounts));
-      }
+    api(getState)
+      .get('/api/v2/search', {
+        params: {
+          q: value,
+          resolve: signedIn,
+          limit: 11,
+          type,
+        },
+      })
+      .then((response) => {
+        if (response.data.accounts) {
+          dispatch(importFetchedAccounts(response.data.accounts));
+        }
 
-      if (response.data.statuses) {
-        dispatch(importFetchedStatuses(response.data.statuses));
-      }
+        if (response.data.statuses) {
+          dispatch(importFetchedStatuses(response.data.statuses));
+        }
 
-      dispatch(fetchSearchSuccess(response.data, value, type));
-      dispatch(fetchRelationships(response.data.accounts.map(item => item.id)));
-    }).catch(error => {
-      dispatch(fetchSearchFail(error));
-    });
+        dispatch(fetchSearchSuccess(response.data, value, type));
+        dispatch(
+          fetchRelationships(response.data.accounts.map((item) => item.id)),
+        );
+      })
+      .catch((error) => {
+        dispatch(fetchSearchFail(error));
+      });
   };
 }
 
@@ -93,33 +104,36 @@ export function fetchSearchFail(error) {
   };
 }
 
-export const expandSearch = type => (dispatch, getState) => {
-  const value  = getState().getIn(['search', 'value']);
+export const expandSearch = (type) => (dispatch, getState) => {
+  const value = getState().getIn(['search', 'value']);
   const offset = getState().getIn(['search', 'results', type]).size - 1;
 
   dispatch(expandSearchRequest(type));
 
-  api(getState).get('/api/v2/search', {
-    params: {
-      q: value,
-      type,
-      offset,
-      limit: 11,
-    },
-  }).then(({ data }) => {
-    if (data.accounts) {
-      dispatch(importFetchedAccounts(data.accounts));
-    }
+  api(getState)
+    .get('/api/v2/search', {
+      params: {
+        q: value,
+        type,
+        offset,
+        limit: 11,
+      },
+    })
+    .then(({ data }) => {
+      if (data.accounts) {
+        dispatch(importFetchedAccounts(data.accounts));
+      }
 
-    if (data.statuses) {
-      dispatch(importFetchedStatuses(data.statuses));
-    }
+      if (data.statuses) {
+        dispatch(importFetchedStatuses(data.statuses));
+      }
 
-    dispatch(expandSearchSuccess(data, value, type));
-    dispatch(fetchRelationships(data.accounts.map(item => item.id)));
-  }).catch(error => {
-    dispatch(expandSearchFail(error));
-  });
+      dispatch(expandSearchSuccess(data, value, type));
+      dispatch(fetchRelationships(data.accounts.map((item) => item.id)));
+    })
+    .catch((error) => {
+      dispatch(expandSearchFail(error));
+    });
 };
 
 export const expandSearchRequest = (searchType) => ({
@@ -134,7 +148,7 @@ export const expandSearchSuccess = (results, searchTerm, searchType) => ({
   searchType,
 });
 
-export const expandSearchFail = error => ({
+export const expandSearchFail = (error) => ({
   type: SEARCH_EXPAND_FAIL,
   error,
 });
@@ -152,25 +166,30 @@ export const openURL = (value, history, onFailure) => (dispatch, getState) => {
 
   dispatch(fetchSearchRequest());
 
-  api(getState).get('/api/v2/search', { params: { q: value, resolve: true } }).then(response => {
-    if (response.data.accounts?.length > 0) {
-      dispatch(importFetchedAccounts(response.data.accounts));
-      history.push(`/@${response.data.accounts[0].acct}`);
-    } else if (response.data.statuses?.length > 0) {
-      dispatch(importFetchedStatuses(response.data.statuses));
-      history.push(`/@${response.data.statuses[0].account.acct}/${response.data.statuses[0].id}`);
-    } else if (onFailure) {
-      onFailure();
-    }
+  api(getState)
+    .get('/api/v2/search', { params: { q: value, resolve: true } })
+    .then((response) => {
+      if (response.data.accounts?.length > 0) {
+        dispatch(importFetchedAccounts(response.data.accounts));
+        history.push(`/@${response.data.accounts[0].acct}`);
+      } else if (response.data.statuses?.length > 0) {
+        dispatch(importFetchedStatuses(response.data.statuses));
+        history.push(
+          `/@${response.data.statuses[0].account.acct}/${response.data.statuses[0].id}`,
+        );
+      } else if (onFailure) {
+        onFailure();
+      }
 
-    dispatch(fetchSearchSuccess(response.data, value));
-  }).catch(err => {
-    dispatch(fetchSearchFail(err));
+      dispatch(fetchSearchSuccess(response.data, value));
+    })
+    .catch((err) => {
+      dispatch(fetchSearchFail(err));
 
-    if (onFailure) {
-      onFailure();
-    }
-  });
+      if (onFailure) {
+        onFailure();
+      }
+    });
 };
 
 export const clickSearchResult = (q, type) => (dispatch, getState) => {
@@ -182,16 +201,16 @@ export const clickSearchResult = (q, type) => (dispatch, getState) => {
   dispatch(updateSearchHistory(current));
 };
 
-export const forgetSearchResult = q => (dispatch, getState) => {
+export const forgetSearchResult = (q) => (dispatch, getState) => {
   const previous = getState().getIn(['search', 'recent']);
   const me = getState().getIn(['meta', 'me']);
-  const current = previous.filterNot(result => result.get('q') === q);
+  const current = previous.filterNot((result) => result.get('q') === q);
 
   searchHistory.set(me, current.toJS());
   dispatch(updateSearchHistory(current));
 };
 
-export const updateSearchHistory = recent => ({
+export const updateSearchHistory = (recent) => ({
   type: SEARCH_HISTORY_UPDATE,
   recent,
 });

--- a/app/javascript/mastodon/actions/server.js
+++ b/app/javascript/mastodon/actions/server.js
@@ -4,19 +4,25 @@ import { importFetchedAccount } from './importer';
 
 export const SERVER_FETCH_REQUEST = 'Server_FETCH_REQUEST';
 export const SERVER_FETCH_SUCCESS = 'Server_FETCH_SUCCESS';
-export const SERVER_FETCH_FAIL    = 'Server_FETCH_FAIL';
+export const SERVER_FETCH_FAIL = 'Server_FETCH_FAIL';
 
-export const SERVER_TRANSLATION_LANGUAGES_FETCH_REQUEST = 'SERVER_TRANSLATION_LANGUAGES_FETCH_REQUEST';
-export const SERVER_TRANSLATION_LANGUAGES_FETCH_SUCCESS = 'SERVER_TRANSLATION_LANGUAGES_FETCH_SUCCESS';
-export const SERVER_TRANSLATION_LANGUAGES_FETCH_FAIL    = 'SERVER_TRANSLATION_LANGUAGES_FETCH_FAIL';
+export const SERVER_TRANSLATION_LANGUAGES_FETCH_REQUEST =
+  'SERVER_TRANSLATION_LANGUAGES_FETCH_REQUEST';
+export const SERVER_TRANSLATION_LANGUAGES_FETCH_SUCCESS =
+  'SERVER_TRANSLATION_LANGUAGES_FETCH_SUCCESS';
+export const SERVER_TRANSLATION_LANGUAGES_FETCH_FAIL =
+  'SERVER_TRANSLATION_LANGUAGES_FETCH_FAIL';
 
 export const EXTENDED_DESCRIPTION_REQUEST = 'EXTENDED_DESCRIPTION_REQUEST';
 export const EXTENDED_DESCRIPTION_SUCCESS = 'EXTENDED_DESCRIPTION_SUCCESS';
-export const EXTENDED_DESCRIPTION_FAIL    = 'EXTENDED_DESCRIPTION_FAIL';
+export const EXTENDED_DESCRIPTION_FAIL = 'EXTENDED_DESCRIPTION_FAIL';
 
-export const SERVER_DOMAIN_BLOCKS_FETCH_REQUEST = 'SERVER_DOMAIN_BLOCKS_FETCH_REQUEST';
-export const SERVER_DOMAIN_BLOCKS_FETCH_SUCCESS = 'SERVER_DOMAIN_BLOCKS_FETCH_SUCCESS';
-export const SERVER_DOMAIN_BLOCKS_FETCH_FAIL    = 'SERVER_DOMAIN_BLOCKS_FETCH_FAIL';
+export const SERVER_DOMAIN_BLOCKS_FETCH_REQUEST =
+  'SERVER_DOMAIN_BLOCKS_FETCH_REQUEST';
+export const SERVER_DOMAIN_BLOCKS_FETCH_SUCCESS =
+  'SERVER_DOMAIN_BLOCKS_FETCH_SUCCESS';
+export const SERVER_DOMAIN_BLOCKS_FETCH_FAIL =
+  'SERVER_DOMAIN_BLOCKS_FETCH_FAIL';
 
 export const fetchServer = () => (dispatch, getState) => {
   if (getState().getIn(['server', 'server', 'isLoading'])) {
@@ -26,22 +32,25 @@ export const fetchServer = () => (dispatch, getState) => {
   dispatch(fetchServerRequest());
 
   api(getState)
-    .get('/api/v2/instance').then(({ data }) => {
-      if (data.contact.account) dispatch(importFetchedAccount(data.contact.account));
+    .get('/api/v2/instance')
+    .then(({ data }) => {
+      if (data.contact.account)
+        dispatch(importFetchedAccount(data.contact.account));
       dispatch(fetchServerSuccess(data));
-    }).catch(err => dispatch(fetchServerFail(err)));
+    })
+    .catch((err) => dispatch(fetchServerFail(err)));
 };
 
 const fetchServerRequest = () => ({
   type: SERVER_FETCH_REQUEST,
 });
 
-const fetchServerSuccess = server => ({
+const fetchServerSuccess = (server) => ({
   type: SERVER_FETCH_SUCCESS,
   server,
 });
 
-const fetchServerFail = error => ({
+const fetchServerFail = (error) => ({
   type: SERVER_FETCH_FAIL,
   error,
 });
@@ -50,21 +59,23 @@ export const fetchServerTranslationLanguages = () => (dispatch, getState) => {
   dispatch(fetchServerTranslationLanguagesRequest());
 
   api(getState)
-    .get('/api/v1/instance/translation_languages').then(({ data }) => {
+    .get('/api/v1/instance/translation_languages')
+    .then(({ data }) => {
       dispatch(fetchServerTranslationLanguagesSuccess(data));
-    }).catch(err => dispatch(fetchServerTranslationLanguagesFail(err)));
+    })
+    .catch((err) => dispatch(fetchServerTranslationLanguagesFail(err)));
 };
 
 const fetchServerTranslationLanguagesRequest = () => ({
   type: SERVER_TRANSLATION_LANGUAGES_FETCH_REQUEST,
 });
 
-const fetchServerTranslationLanguagesSuccess = translationLanguages => ({
+const fetchServerTranslationLanguagesSuccess = (translationLanguages) => ({
   type: SERVER_TRANSLATION_LANGUAGES_FETCH_SUCCESS,
   translationLanguages,
 });
 
-const fetchServerTranslationLanguagesFail = error => ({
+const fetchServerTranslationLanguagesFail = (error) => ({
   type: SERVER_TRANSLATION_LANGUAGES_FETCH_FAIL,
   error,
 });
@@ -79,19 +90,19 @@ export const fetchExtendedDescription = () => (dispatch, getState) => {
   api(getState)
     .get('/api/v1/instance/extended_description')
     .then(({ data }) => dispatch(fetchExtendedDescriptionSuccess(data)))
-    .catch(err => dispatch(fetchExtendedDescriptionFail(err)));
+    .catch((err) => dispatch(fetchExtendedDescriptionFail(err)));
 };
 
 const fetchExtendedDescriptionRequest = () => ({
   type: EXTENDED_DESCRIPTION_REQUEST,
 });
 
-const fetchExtendedDescriptionSuccess = description => ({
+const fetchExtendedDescriptionSuccess = (description) => ({
   type: EXTENDED_DESCRIPTION_SUCCESS,
   description,
 });
 
-const fetchExtendedDescriptionFail = error => ({
+const fetchExtendedDescriptionFail = (error) => ({
   type: EXTENDED_DESCRIPTION_FAIL,
   error,
 });
@@ -106,7 +117,7 @@ export const fetchDomainBlocks = () => (dispatch, getState) => {
   api(getState)
     .get('/api/v1/instance/domain_blocks')
     .then(({ data }) => dispatch(fetchDomainBlocksSuccess(true, data)))
-    .catch(err => {
+    .catch((err) => {
       if (err.response.status === 404) {
         dispatch(fetchDomainBlocksSuccess(false, []));
       } else {
@@ -125,7 +136,7 @@ const fetchDomainBlocksSuccess = (isAvailable, blocks) => ({
   blocks,
 });
 
-const fetchDomainBlocksFail = error => ({
+const fetchDomainBlocksFail = (error) => ({
   type: SERVER_DOMAIN_BLOCKS_FETCH_FAIL,
   error,
 });

--- a/app/javascript/mastodon/actions/settings.js
+++ b/app/javascript/mastodon/actions/settings.js
@@ -5,10 +5,10 @@ import api from '../api';
 import { showAlertForError } from './alerts';
 
 export const SETTING_CHANGE = 'SETTING_CHANGE';
-export const SETTING_SAVE   = 'SETTING_SAVE';
+export const SETTING_SAVE = 'SETTING_SAVE';
 
 export function changeSetting(path, value) {
-  return dispatch => {
+  return (dispatch) => {
     dispatch({
       type: SETTING_CHANGE,
       path,
@@ -19,17 +19,25 @@ export function changeSetting(path, value) {
   };
 }
 
-const debouncedSave = debounce((dispatch, getState) => {
-  if (getState().getIn(['settings', 'saved'])) {
-    return;
-  }
+const debouncedSave = debounce(
+  (dispatch, getState) => {
+    if (getState().getIn(['settings', 'saved'])) {
+      return;
+    }
 
-  const data = getState().get('settings').filter((_, path) => path !== 'saved').toJS();
+    const data = getState()
+      .get('settings')
+      .filter((_, path) => path !== 'saved')
+      .toJS();
 
-  api().put('/api/web/settings', { data })
-    .then(() => dispatch({ type: SETTING_SAVE }))
-    .catch(error => dispatch(showAlertForError(error)));
-}, 5000, { trailing: true });
+    api()
+      .put('/api/web/settings', { data })
+      .then(() => dispatch({ type: SETTING_SAVE }))
+      .catch((error) => dispatch(showAlertForError(error)));
+  },
+  5000,
+  { trailing: true },
+);
 
 export function saveSettings() {
   return (dispatch, getState) => debouncedSave(dispatch, getState);

--- a/app/javascript/mastodon/actions/statuses.js
+++ b/app/javascript/mastodon/actions/statuses.js
@@ -1,43 +1,47 @@
 import api from '../api';
 
 import { ensureComposeIsVisible, setComposeToStatus } from './compose';
-import { importFetchedStatus, importFetchedStatuses, importFetchedAccount } from './importer';
+import {
+  importFetchedStatus,
+  importFetchedStatuses,
+  importFetchedAccount,
+} from './importer';
 import { deleteFromTimelines } from './timelines';
 
 export const STATUS_FETCH_REQUEST = 'STATUS_FETCH_REQUEST';
 export const STATUS_FETCH_SUCCESS = 'STATUS_FETCH_SUCCESS';
-export const STATUS_FETCH_FAIL    = 'STATUS_FETCH_FAIL';
+export const STATUS_FETCH_FAIL = 'STATUS_FETCH_FAIL';
 
 export const STATUS_DELETE_REQUEST = 'STATUS_DELETE_REQUEST';
 export const STATUS_DELETE_SUCCESS = 'STATUS_DELETE_SUCCESS';
-export const STATUS_DELETE_FAIL    = 'STATUS_DELETE_FAIL';
+export const STATUS_DELETE_FAIL = 'STATUS_DELETE_FAIL';
 
 export const CONTEXT_FETCH_REQUEST = 'CONTEXT_FETCH_REQUEST';
 export const CONTEXT_FETCH_SUCCESS = 'CONTEXT_FETCH_SUCCESS';
-export const CONTEXT_FETCH_FAIL    = 'CONTEXT_FETCH_FAIL';
+export const CONTEXT_FETCH_FAIL = 'CONTEXT_FETCH_FAIL';
 
 export const STATUS_MUTE_REQUEST = 'STATUS_MUTE_REQUEST';
 export const STATUS_MUTE_SUCCESS = 'STATUS_MUTE_SUCCESS';
-export const STATUS_MUTE_FAIL    = 'STATUS_MUTE_FAIL';
+export const STATUS_MUTE_FAIL = 'STATUS_MUTE_FAIL';
 
 export const STATUS_UNMUTE_REQUEST = 'STATUS_UNMUTE_REQUEST';
 export const STATUS_UNMUTE_SUCCESS = 'STATUS_UNMUTE_SUCCESS';
-export const STATUS_UNMUTE_FAIL    = 'STATUS_UNMUTE_FAIL';
+export const STATUS_UNMUTE_FAIL = 'STATUS_UNMUTE_FAIL';
 
-export const STATUS_REVEAL   = 'STATUS_REVEAL';
-export const STATUS_HIDE     = 'STATUS_HIDE';
+export const STATUS_REVEAL = 'STATUS_REVEAL';
+export const STATUS_HIDE = 'STATUS_HIDE';
 export const STATUS_COLLAPSE = 'STATUS_COLLAPSE';
 
 export const REDRAFT = 'REDRAFT';
 
 export const STATUS_FETCH_SOURCE_REQUEST = 'STATUS_FETCH_SOURCE_REQUEST';
 export const STATUS_FETCH_SOURCE_SUCCESS = 'STATUS_FETCH_SOURCE_SUCCESS';
-export const STATUS_FETCH_SOURCE_FAIL    = 'STATUS_FETCH_SOURCE_FAIL';
+export const STATUS_FETCH_SOURCE_FAIL = 'STATUS_FETCH_SOURCE_FAIL';
 
 export const STATUS_TRANSLATE_REQUEST = 'STATUS_TRANSLATE_REQUEST';
 export const STATUS_TRANSLATE_SUCCESS = 'STATUS_TRANSLATE_SUCCESS';
-export const STATUS_TRANSLATE_FAIL    = 'STATUS_TRANSLATE_FAIL';
-export const STATUS_TRANSLATE_UNDO    = 'STATUS_TRANSLATE_UNDO';
+export const STATUS_TRANSLATE_FAIL = 'STATUS_TRANSLATE_FAIL';
+export const STATUS_TRANSLATE_UNDO = 'STATUS_TRANSLATE_UNDO';
 
 export function fetchStatusRequest(id, skipLoading) {
   return {
@@ -49,7 +53,8 @@ export function fetchStatusRequest(id, skipLoading) {
 
 export function fetchStatus(id, forceFetch = false) {
   return (dispatch, getState) => {
-    const skipLoading = !forceFetch && getState().getIn(['statuses', id], null) !== null;
+    const skipLoading =
+      !forceFetch && getState().getIn(['statuses', id], null) !== null;
 
     dispatch(fetchContext(id));
 
@@ -59,12 +64,15 @@ export function fetchStatus(id, forceFetch = false) {
 
     dispatch(fetchStatusRequest(id, skipLoading));
 
-    api(getState).get(`/api/v1/statuses/${id}`).then(response => {
-      dispatch(importFetchedStatus(response.data));
-      dispatch(fetchStatusSuccess(skipLoading));
-    }).catch(error => {
-      dispatch(fetchStatusFail(id, error, skipLoading));
-    });
+    api(getState)
+      .get(`/api/v1/statuses/${id}`)
+      .then((response) => {
+        dispatch(importFetchedStatus(response.data));
+        dispatch(fetchStatusSuccess(skipLoading));
+      })
+      .catch((error) => {
+        dispatch(fetchStatusFail(id, error, skipLoading));
+      });
   };
 }
 
@@ -97,18 +105,30 @@ export const editStatus = (id, routerHistory) => (dispatch, getState) => {
   let status = getState().getIn(['statuses', id]);
 
   if (status.get('poll')) {
-    status = status.set('poll', getState().getIn(['polls', status.get('poll')]));
+    status = status.set(
+      'poll',
+      getState().getIn(['polls', status.get('poll')]),
+    );
   }
 
   dispatch(fetchStatusSourceRequest());
 
-  api(getState).get(`/api/v1/statuses/${id}/source`).then(response => {
-    dispatch(fetchStatusSourceSuccess());
-    ensureComposeIsVisible(getState, routerHistory);
-    dispatch(setComposeToStatus(status, response.data.text, response.data.spoiler_text));
-  }).catch(error => {
-    dispatch(fetchStatusSourceFail(error));
-  });
+  api(getState)
+    .get(`/api/v1/statuses/${id}/source`)
+    .then((response) => {
+      dispatch(fetchStatusSourceSuccess());
+      ensureComposeIsVisible(getState, routerHistory);
+      dispatch(
+        setComposeToStatus(
+          status,
+          response.data.text,
+          response.data.spoiler_text,
+        ),
+      );
+    })
+    .catch((error) => {
+      dispatch(fetchStatusSourceFail(error));
+    });
 };
 
 export const fetchStatusSourceRequest = () => ({
@@ -119,7 +139,7 @@ export const fetchStatusSourceSuccess = () => ({
   type: STATUS_FETCH_SOURCE_SUCCESS,
 });
 
-export const fetchStatusSourceFail = error => ({
+export const fetchStatusSourceFail = (error) => ({
   type: STATUS_FETCH_SOURCE_FAIL,
   error,
 });
@@ -129,23 +149,29 @@ export function deleteStatus(id, routerHistory, withRedraft = false) {
     let status = getState().getIn(['statuses', id]);
 
     if (status.get('poll')) {
-      status = status.set('poll', getState().getIn(['polls', status.get('poll')]));
+      status = status.set(
+        'poll',
+        getState().getIn(['polls', status.get('poll')]),
+      );
     }
 
     dispatch(deleteStatusRequest(id));
 
-    api(getState).delete(`/api/v1/statuses/${id}`).then(response => {
-      dispatch(deleteStatusSuccess(id));
-      dispatch(deleteFromTimelines(id));
-      dispatch(importFetchedAccount(response.data.account));
+    api(getState)
+      .delete(`/api/v1/statuses/${id}`)
+      .then((response) => {
+        dispatch(deleteStatusSuccess(id));
+        dispatch(deleteFromTimelines(id));
+        dispatch(importFetchedAccount(response.data.account));
 
-      if (withRedraft) {
-        dispatch(redraft(status, response.data.text));
-        ensureComposeIsVisible(getState, routerHistory);
-      }
-    }).catch(error => {
-      dispatch(deleteStatusFail(id, error));
-    });
+        if (withRedraft) {
+          dispatch(redraft(status, response.data.text));
+          ensureComposeIsVisible(getState, routerHistory);
+        }
+      })
+      .catch((error) => {
+        dispatch(deleteStatusFail(id, error));
+      });
   };
 }
 
@@ -171,24 +197,36 @@ export function deleteStatusFail(id, error) {
   };
 }
 
-export const updateStatus = status => dispatch =>
+export const updateStatus = (status) => (dispatch) =>
   dispatch(importFetchedStatus(status));
 
 export function fetchContext(id) {
   return (dispatch, getState) => {
     dispatch(fetchContextRequest(id));
 
-    api(getState).get(`/api/v1/statuses/${id}/context`).then(response => {
-      dispatch(importFetchedStatuses(response.data.ancestors.concat(response.data.descendants)));
-      dispatch(fetchContextSuccess(id, response.data.ancestors, response.data.descendants));
+    api(getState)
+      .get(`/api/v1/statuses/${id}/context`)
+      .then((response) => {
+        dispatch(
+          importFetchedStatuses(
+            response.data.ancestors.concat(response.data.descendants),
+          ),
+        );
+        dispatch(
+          fetchContextSuccess(
+            id,
+            response.data.ancestors,
+            response.data.descendants,
+          ),
+        );
+      })
+      .catch((error) => {
+        if (error.response && error.response.status === 404) {
+          dispatch(deleteFromTimelines(id));
+        }
 
-    }).catch(error => {
-      if (error.response && error.response.status === 404) {
-        dispatch(deleteFromTimelines(id));
-      }
-
-      dispatch(fetchContextFail(id, error));
-    });
+        dispatch(fetchContextFail(id, error));
+      });
   };
 }
 
@@ -222,11 +260,14 @@ export function muteStatus(id) {
   return (dispatch, getState) => {
     dispatch(muteStatusRequest(id));
 
-    api(getState).post(`/api/v1/statuses/${id}/mute`).then(() => {
-      dispatch(muteStatusSuccess(id));
-    }).catch(error => {
-      dispatch(muteStatusFail(id, error));
-    });
+    api(getState)
+      .post(`/api/v1/statuses/${id}/mute`)
+      .then(() => {
+        dispatch(muteStatusSuccess(id));
+      })
+      .catch((error) => {
+        dispatch(muteStatusFail(id, error));
+      });
   };
 }
 
@@ -256,11 +297,14 @@ export function unmuteStatus(id) {
   return (dispatch, getState) => {
     dispatch(unmuteStatusRequest(id));
 
-    api(getState).post(`/api/v1/statuses/${id}/unmute`).then(() => {
-      dispatch(unmuteStatusSuccess(id));
-    }).catch(error => {
-      dispatch(unmuteStatusFail(id, error));
-    });
+    api(getState)
+      .post(`/api/v1/statuses/${id}/unmute`)
+      .then(() => {
+        dispatch(unmuteStatusSuccess(id));
+      })
+      .catch((error) => {
+        dispatch(unmuteStatusFail(id, error));
+      });
   };
 }
 
@@ -316,17 +360,20 @@ export function toggleStatusCollapse(id, isCollapsed) {
   };
 }
 
-export const translateStatus = id => (dispatch, getState) => {
+export const translateStatus = (id) => (dispatch, getState) => {
   dispatch(translateStatusRequest(id));
 
-  api(getState).post(`/api/v1/statuses/${id}/translate`).then(response => {
-    dispatch(translateStatusSuccess(id, response.data));
-  }).catch(error => {
-    dispatch(translateStatusFail(id, error));
-  });
+  api(getState)
+    .post(`/api/v1/statuses/${id}/translate`)
+    .then((response) => {
+      dispatch(translateStatusSuccess(id, response.data));
+    })
+    .catch((error) => {
+      dispatch(translateStatusFail(id, error));
+    });
 };
 
-export const translateStatusRequest = id => ({
+export const translateStatusRequest = (id) => ({
   type: STATUS_TRANSLATE_REQUEST,
   id,
 });

--- a/app/javascript/mastodon/actions/store.js
+++ b/app/javascript/mastodon/actions/store.js
@@ -7,12 +7,11 @@ import { hydrateSearch } from './search';
 export const STORE_HYDRATE = 'STORE_HYDRATE';
 export const STORE_HYDRATE_LAZY = 'STORE_HYDRATE_LAZY';
 
-const convertState = rawState =>
-  fromJS(rawState, (k, v) =>
-    Iterable.isIndexed(v) ? v.toList() : v.toMap());
+const convertState = (rawState) =>
+  fromJS(rawState, (k, v) => (Iterable.isIndexed(v) ? v.toList() : v.toMap()));
 
 export function hydrateStore(rawState) {
-  return dispatch => {
+  return (dispatch) => {
     const state = convertState(rawState);
 
     dispatch({

--- a/app/javascript/mastodon/actions/streaming.js
+++ b/app/javascript/mastodon/actions/streaming.js
@@ -28,8 +28,7 @@ import {
  * @param {number} max
  * @returns {number}
  */
-const randomUpTo = max =>
-  Math.floor(Math.random() * Math.floor(max));
+const randomUpTo = (max) => Math.floor(Math.random() * Math.floor(max));
 
 /**
  * @param {string} timelineId
@@ -41,7 +40,12 @@ const randomUpTo = max =>
  * @param {function(object): boolean} [options.accept]
  * @returns {function(): void}
  */
-export const connectTimelineStream = (timelineId, channelName, params = {}, options = {}) => {
+export const connectTimelineStream = (
+  timelineId,
+  channelName,
+  params = {},
+  options = {},
+) => {
   const { messages } = getLocale();
 
   return connectStream(channelName, params, (dispatch, getState) => {
@@ -54,10 +58,13 @@ export const connectTimelineStream = (timelineId, channelName, params = {}, opti
      * @param {function(Function, Function): void} fallback
      */
 
-    const useFallback = fallback => {
+    const useFallback = (fallback) => {
       fallback(dispatch, () => {
-        // eslint-disable-next-line react-hooks/rules-of-hooks -- this is not a react hook
-        pollingId = setTimeout(() => useFallback(fallback), 20000 + randomUpTo(20000));
+        pollingId = setTimeout(
+          // eslint-disable-next-line react-hooks/rules-of-hooks
+          () => useFallback(fallback),
+          20000 + randomUpTo(20000),
+        );
       });
     };
 
@@ -68,7 +75,8 @@ export const connectTimelineStream = (timelineId, channelName, params = {}, opti
         // @ts-expect-error
         if (pollingId) {
           // @ts-ignore
-          clearTimeout(pollingId); pollingId = null;
+          clearTimeout(pollingId);
+          pollingId = null;
         }
 
         if (options.fillGaps) {
@@ -80,43 +88,57 @@ export const connectTimelineStream = (timelineId, channelName, params = {}, opti
         dispatch(disconnectTimeline(timelineId));
 
         if (options.fallback) {
-          // @ts-expect-error
-          pollingId = setTimeout(() => useFallback(options.fallback), randomUpTo(40000));
+          // @ts-ignore
+          pollingId = setTimeout(
+            // @ts-ignore
+            () => useFallback(options.fallback),
+            randomUpTo(40000),
+          );
         }
       },
 
       onReceive(data) {
         switch (data.event) {
-        case 'update':
-          // @ts-expect-error
-          dispatch(updateTimeline(timelineId, JSON.parse(data.payload), options.accept));
-          break;
-        case 'status.update':
-          // @ts-expect-error
-          dispatch(updateStatus(JSON.parse(data.payload)));
-          break;
-        case 'delete':
-          dispatch(deleteFromTimelines(data.payload));
-          break;
-        case 'notification':
-          // @ts-expect-error
-          dispatch(updateNotifications(JSON.parse(data.payload), messages, locale));
-          break;
-        case 'conversation':
-          // @ts-expect-error
-          dispatch(updateConversations(JSON.parse(data.payload)));
-          break;
-        case 'announcement':
-          // @ts-expect-error
-          dispatch(updateAnnouncements(JSON.parse(data.payload)));
-          break;
-        case 'announcement.reaction':
-          // @ts-expect-error
-          dispatch(updateAnnouncementsReaction(JSON.parse(data.payload)));
-          break;
-        case 'announcement.delete':
-          dispatch(deleteAnnouncement(data.payload));
-          break;
+          // @ts-ignore
+          case 'update':
+            dispatch(
+              updateTimeline(
+                timelineId,
+                // @ts-ignore
+                JSON.parse(data.payload),
+                options.accept,
+              ),
+            );
+            break;
+          case 'status.update':
+            // @ts-expect-error
+            dispatch(updateStatus(JSON.parse(data.payload)));
+            break;
+          case 'delete':
+            dispatch(deleteFromTimelines(data.payload));
+            break;
+          // @ts-ignore
+          case 'notification':
+            dispatch(
+              // @ts-ignore
+              updateNotifications(JSON.parse(data.payload), messages, locale),
+            );
+            break;
+          case 'conversation':
+            // @ts-expect-error
+            dispatch(updateConversations(JSON.parse(data.payload)));
+            break;
+          case 'announcement':
+            // @ts-expect-error
+            dispatch(updateAnnouncements(JSON.parse(data.payload)));
+            break;
+          case 'announcement.reaction':
+            // @ts-expect-error
+            dispatch(updateAnnouncementsReaction(JSON.parse(data.payload)));
+            break;
+          case 'announcement.delete':
+            dispatch(deleteAnnouncement(data.payload));
+            break;
         }
       },
     };
@@ -128,19 +150,31 @@ export const connectTimelineStream = (timelineId, channelName, params = {}, opti
  * @param {function(): void} done
  */
 const refreshHomeTimelineAndNotification = (dispatch, done) => {
-  // @ts-expect-error
-  dispatch(expandHomeTimeline({}, () =>
-    // @ts-expect-error
-    dispatch(expandNotifications({}, () =>
-      dispatch(fetchAnnouncements(done))))));
+  dispatch(
+    // @ts-ignore
+    expandHomeTimeline({}, () =>
+      dispatch(
+        // @ts-ignore
+        expandNotifications({}, () => dispatch(fetchAnnouncements(done))),
+      ),
+    ),
+  );
 };
 
 /**
  * @returns {function(): void}
  */
 export const connectUserStream = () =>
-  // @ts-expect-error
-  connectTimelineStream('home', 'user', {}, { fallback: refreshHomeTimelineAndNotification, fillGaps: fillHomeTimelineGaps });
+  connectTimelineStream(
+    'home',
+    'user',
+    {},
+    {
+      // @ts-expect-error
+      fallback: refreshHomeTimelineAndNotification,
+      fillGaps: fillHomeTimelineGaps,
+    },
+  );
 
 /**
  * @param {Object} options
@@ -148,7 +182,12 @@ export const connectUserStream = () =>
  * @returns {function(): void}
  */
 export const connectCommunityStream = ({ onlyMedia } = {}) =>
-  connectTimelineStream(`community${onlyMedia ? ':media' : ''}`, `public:local${onlyMedia ? ':media' : ''}`, {}, { fillGaps: () => (fillCommunityTimelineGaps({ onlyMedia })) });
+  connectTimelineStream(
+    `community${onlyMedia ? ':media' : ''}`,
+    `public:local${onlyMedia ? ':media' : ''}`,
+    {},
+    { fillGaps: () => fillCommunityTimelineGaps({ onlyMedia }) },
+  );
 
 /**
  * @param {Object} options
@@ -157,7 +196,12 @@ export const connectCommunityStream = ({ onlyMedia } = {}) =>
  * @returns {function(): void}
  */
 export const connectPublicStream = ({ onlyMedia, onlyRemote } = {}) =>
-  connectTimelineStream(`public${onlyRemote ? ':remote' : ''}${onlyMedia ? ':media' : ''}`, `public${onlyRemote ? ':remote' : ''}${onlyMedia ? ':media' : ''}`, {}, { fillGaps: () => fillPublicTimelineGaps({ onlyMedia, onlyRemote }) });
+  connectTimelineStream(
+    `public${onlyRemote ? ':remote' : ''}${onlyMedia ? ':media' : ''}`,
+    `public${onlyRemote ? ':remote' : ''}${onlyMedia ? ':media' : ''}`,
+    {},
+    { fillGaps: () => fillPublicTimelineGaps({ onlyMedia, onlyRemote }) },
+  );
 
 /**
  * @param {string} columnId
@@ -167,7 +211,12 @@ export const connectPublicStream = ({ onlyMedia, onlyRemote } = {}) =>
  * @returns {function(): void}
  */
 export const connectHashtagStream = (columnId, tagName, onlyLocal, accept) =>
-  connectTimelineStream(`hashtag:${columnId}${onlyLocal ? ':local' : ''}`, `hashtag${onlyLocal ? ':local' : ''}`, { tag: tagName }, { accept });
+  connectTimelineStream(
+    `hashtag:${columnId}${onlyLocal ? ':local' : ''}`,
+    `hashtag${onlyLocal ? ':local' : ''}`,
+    { tag: tagName },
+    { accept },
+  );
 
 /**
  * @returns {function(): void}
@@ -179,5 +228,10 @@ export const connectDirectStream = () =>
  * @param {string} listId
  * @returns {function(): void}
  */
-export const connectListStream = listId =>
-  connectTimelineStream(`list:${listId}`, 'list', { list: listId }, { fillGaps: () => fillListTimelineGaps(listId) });
+export const connectListStream = (listId) =>
+  connectTimelineStream(
+    `list:${listId}`,
+    'list',
+    { list: listId },
+    { fillGaps: () => fillListTimelineGaps(listId) },
+  );

--- a/app/javascript/mastodon/actions/suggestions.js
+++ b/app/javascript/mastodon/actions/suggestions.js
@@ -5,7 +5,7 @@ import { importFetchedAccounts } from './importer';
 
 export const SUGGESTIONS_FETCH_REQUEST = 'SUGGESTIONS_FETCH_REQUEST';
 export const SUGGESTIONS_FETCH_SUCCESS = 'SUGGESTIONS_FETCH_SUCCESS';
-export const SUGGESTIONS_FETCH_FAIL    = 'SUGGESTIONS_FETCH_FAIL';
+export const SUGGESTIONS_FETCH_FAIL = 'SUGGESTIONS_FETCH_FAIL';
 
 export const SUGGESTIONS_DISMISS = 'SUGGESTIONS_DISMISS';
 
@@ -13,14 +13,19 @@ export function fetchSuggestions(withRelationships = false) {
   return (dispatch, getState) => {
     dispatch(fetchSuggestionsRequest());
 
-    api(getState).get('/api/v2/suggestions', { params: { limit: 20 } }).then(response => {
-      dispatch(importFetchedAccounts(response.data.map(x => x.account)));
-      dispatch(fetchSuggestionsSuccess(response.data));
+    api(getState)
+      .get('/api/v2/suggestions', { params: { limit: 20 } })
+      .then((response) => {
+        dispatch(importFetchedAccounts(response.data.map((x) => x.account)));
+        dispatch(fetchSuggestionsSuccess(response.data));
 
-      if (withRelationships) {
-        dispatch(fetchRelationships(response.data.map(item => item.account.id)));
-      }
-    }).catch(error => dispatch(fetchSuggestionsFail(error)));
+        if (withRelationships) {
+          dispatch(
+            fetchRelationships(response.data.map((item) => item.account.id)),
+          );
+        }
+      })
+      .catch((error) => dispatch(fetchSuggestionsFail(error)));
   };
 }
 
@@ -48,18 +53,24 @@ export function fetchSuggestionsFail(error) {
   };
 }
 
-export const dismissSuggestion = accountId => (dispatch, getState) => {
+export const dismissSuggestion = (accountId) => (dispatch, getState) => {
   dispatch({
     type: SUGGESTIONS_DISMISS,
     id: accountId,
   });
 
-  api(getState).delete(`/api/v1/suggestions/${accountId}`).then(() => {
-    dispatch(fetchSuggestionsRequest());
+  api(getState)
+    .delete(`/api/v1/suggestions/${accountId}`)
+    .then(() => {
+      dispatch(fetchSuggestionsRequest());
 
-    api(getState).get('/api/v2/suggestions').then(response => {
-      dispatch(importFetchedAccounts(response.data.map(x => x.account)));
-      dispatch(fetchSuggestionsSuccess(response.data));
-    }).catch(error => dispatch(fetchSuggestionsFail(error)));
-  }).catch(() => {});
+      api(getState)
+        .get('/api/v2/suggestions')
+        .then((response) => {
+          dispatch(importFetchedAccounts(response.data.map((x) => x.account)));
+          dispatch(fetchSuggestionsSuccess(response.data));
+        })
+        .catch((error) => dispatch(fetchSuggestionsFail(error)));
+    })
+    .catch(() => {});
 };

--- a/app/javascript/mastodon/actions/tags.js
+++ b/app/javascript/mastodon/actions/tags.js
@@ -2,32 +2,39 @@ import api, { getLinks } from '../api';
 
 export const HASHTAG_FETCH_REQUEST = 'HASHTAG_FETCH_REQUEST';
 export const HASHTAG_FETCH_SUCCESS = 'HASHTAG_FETCH_SUCCESS';
-export const HASHTAG_FETCH_FAIL    = 'HASHTAG_FETCH_FAIL';
+export const HASHTAG_FETCH_FAIL = 'HASHTAG_FETCH_FAIL';
 
-export const FOLLOWED_HASHTAGS_FETCH_REQUEST = 'FOLLOWED_HASHTAGS_FETCH_REQUEST';
-export const FOLLOWED_HASHTAGS_FETCH_SUCCESS = 'FOLLOWED_HASHTAGS_FETCH_SUCCESS';
-export const FOLLOWED_HASHTAGS_FETCH_FAIL    = 'FOLLOWED_HASHTAGS_FETCH_FAIL';
+export const FOLLOWED_HASHTAGS_FETCH_REQUEST =
+  'FOLLOWED_HASHTAGS_FETCH_REQUEST';
+export const FOLLOWED_HASHTAGS_FETCH_SUCCESS =
+  'FOLLOWED_HASHTAGS_FETCH_SUCCESS';
+export const FOLLOWED_HASHTAGS_FETCH_FAIL = 'FOLLOWED_HASHTAGS_FETCH_FAIL';
 
-export const FOLLOWED_HASHTAGS_EXPAND_REQUEST = 'FOLLOWED_HASHTAGS_EXPAND_REQUEST';
-export const FOLLOWED_HASHTAGS_EXPAND_SUCCESS = 'FOLLOWED_HASHTAGS_EXPAND_SUCCESS';
-export const FOLLOWED_HASHTAGS_EXPAND_FAIL    = 'FOLLOWED_HASHTAGS_EXPAND_FAIL';
+export const FOLLOWED_HASHTAGS_EXPAND_REQUEST =
+  'FOLLOWED_HASHTAGS_EXPAND_REQUEST';
+export const FOLLOWED_HASHTAGS_EXPAND_SUCCESS =
+  'FOLLOWED_HASHTAGS_EXPAND_SUCCESS';
+export const FOLLOWED_HASHTAGS_EXPAND_FAIL = 'FOLLOWED_HASHTAGS_EXPAND_FAIL';
 
 export const HASHTAG_FOLLOW_REQUEST = 'HASHTAG_FOLLOW_REQUEST';
 export const HASHTAG_FOLLOW_SUCCESS = 'HASHTAG_FOLLOW_SUCCESS';
-export const HASHTAG_FOLLOW_FAIL    = 'HASHTAG_FOLLOW_FAIL';
+export const HASHTAG_FOLLOW_FAIL = 'HASHTAG_FOLLOW_FAIL';
 
 export const HASHTAG_UNFOLLOW_REQUEST = 'HASHTAG_UNFOLLOW_REQUEST';
 export const HASHTAG_UNFOLLOW_SUCCESS = 'HASHTAG_UNFOLLOW_SUCCESS';
-export const HASHTAG_UNFOLLOW_FAIL    = 'HASHTAG_UNFOLLOW_FAIL';
+export const HASHTAG_UNFOLLOW_FAIL = 'HASHTAG_UNFOLLOW_FAIL';
 
-export const fetchHashtag = name => (dispatch, getState) => {
+export const fetchHashtag = (name) => (dispatch, getState) => {
   dispatch(fetchHashtagRequest());
 
-  api(getState).get(`/api/v1/tags/${name}`).then(({ data }) => {
-    dispatch(fetchHashtagSuccess(name, data));
-  }).catch(err => {
-    dispatch(fetchHashtagFail(err));
-  });
+  api(getState)
+    .get(`/api/v1/tags/${name}`)
+    .then(({ data }) => {
+      dispatch(fetchHashtagSuccess(name, data));
+    })
+    .catch((err) => {
+      dispatch(fetchHashtagFail(err));
+    });
 };
 
 export const fetchHashtagRequest = () => ({
@@ -40,7 +47,7 @@ export const fetchHashtagSuccess = (name, tag) => ({
   tag,
 });
 
-export const fetchHashtagFail = error => ({
+export const fetchHashtagFail = (error) => ({
   type: HASHTAG_FETCH_FAIL,
   error,
 });
@@ -48,12 +55,17 @@ export const fetchHashtagFail = error => ({
 export const fetchFollowedHashtags = () => (dispatch, getState) => {
   dispatch(fetchFollowedHashtagsRequest());
 
-  api(getState).get('/api/v1/followed_tags').then(response => {
-    const next = getLinks(response).refs.find(link => link.rel === 'next');
-    dispatch(fetchFollowedHashtagsSuccess(response.data, next ? next.uri : null));
-  }).catch(err => {
-    dispatch(fetchFollowedHashtagsFail(err));
-  });
+  api(getState)
+    .get('/api/v1/followed_tags')
+    .then((response) => {
+      const next = getLinks(response).refs.find((link) => link.rel === 'next');
+      dispatch(
+        fetchFollowedHashtagsSuccess(response.data, next ? next.uri : null),
+      );
+    })
+    .catch((err) => {
+      dispatch(fetchFollowedHashtagsFail(err));
+    });
 };
 
 export function fetchFollowedHashtagsRequest() {
@@ -87,12 +99,19 @@ export function expandFollowedHashtags() {
 
     dispatch(expandFollowedHashtagsRequest());
 
-    api(getState).get(url).then(response => {
-      const next = getLinks(response).refs.find(link => link.rel === 'next');
-      dispatch(expandFollowedHashtagsSuccess(response.data, next ? next.uri : null));
-    }).catch(error => {
-      dispatch(expandFollowedHashtagsFail(error));
-    });
+    api(getState)
+      .get(url)
+      .then((response) => {
+        const next = getLinks(response).refs.find(
+          (link) => link.rel === 'next',
+        );
+        dispatch(
+          expandFollowedHashtagsSuccess(response.data, next ? next.uri : null),
+        );
+      })
+      .catch((error) => {
+        dispatch(expandFollowedHashtagsFail(error));
+      });
   };
 }
 
@@ -117,17 +136,20 @@ export function expandFollowedHashtagsFail(error) {
   };
 }
 
-export const followHashtag = name => (dispatch, getState) => {
+export const followHashtag = (name) => (dispatch, getState) => {
   dispatch(followHashtagRequest(name));
 
-  api(getState).post(`/api/v1/tags/${name}/follow`).then(({ data }) => {
-    dispatch(followHashtagSuccess(name, data));
-  }).catch(err => {
-    dispatch(followHashtagFail(name, err));
-  });
+  api(getState)
+    .post(`/api/v1/tags/${name}/follow`)
+    .then(({ data }) => {
+      dispatch(followHashtagSuccess(name, data));
+    })
+    .catch((err) => {
+      dispatch(followHashtagFail(name, err));
+    });
 };
 
-export const followHashtagRequest = name => ({
+export const followHashtagRequest = (name) => ({
   type: HASHTAG_FOLLOW_REQUEST,
   name,
 });
@@ -144,17 +166,20 @@ export const followHashtagFail = (name, error) => ({
   error,
 });
 
-export const unfollowHashtag = name => (dispatch, getState) => {
+export const unfollowHashtag = (name) => (dispatch, getState) => {
   dispatch(unfollowHashtagRequest(name));
 
-  api(getState).post(`/api/v1/tags/${name}/unfollow`).then(({ data }) => {
-    dispatch(unfollowHashtagSuccess(name, data));
-  }).catch(err => {
-    dispatch(unfollowHashtagFail(name, err));
-  });
+  api(getState)
+    .post(`/api/v1/tags/${name}/unfollow`)
+    .then(({ data }) => {
+      dispatch(unfollowHashtagSuccess(name, data));
+    })
+    .catch((err) => {
+      dispatch(unfollowHashtagFail(name, err));
+    });
 };
 
-export const unfollowHashtagRequest = name => ({
+export const unfollowHashtagRequest = (name) => ({
   type: HASHTAG_UNFOLLOW_REQUEST,
   name,
 });

--- a/app/javascript/mastodon/actions/timelines.js
+++ b/app/javascript/mastodon/actions/timelines.js
@@ -7,22 +7,22 @@ import { usePendingItems as preferPendingItems } from 'mastodon/initial_state';
 import { importFetchedStatus, importFetchedStatuses } from './importer';
 import { submitMarkers } from './markers';
 
-export const TIMELINE_UPDATE  = 'TIMELINE_UPDATE';
-export const TIMELINE_DELETE  = 'TIMELINE_DELETE';
-export const TIMELINE_CLEAR   = 'TIMELINE_CLEAR';
+export const TIMELINE_UPDATE = 'TIMELINE_UPDATE';
+export const TIMELINE_DELETE = 'TIMELINE_DELETE';
+export const TIMELINE_CLEAR = 'TIMELINE_CLEAR';
 
 export const TIMELINE_EXPAND_REQUEST = 'TIMELINE_EXPAND_REQUEST';
 export const TIMELINE_EXPAND_SUCCESS = 'TIMELINE_EXPAND_SUCCESS';
-export const TIMELINE_EXPAND_FAIL    = 'TIMELINE_EXPAND_FAIL';
+export const TIMELINE_EXPAND_FAIL = 'TIMELINE_EXPAND_FAIL';
 
-export const TIMELINE_SCROLL_TOP   = 'TIMELINE_SCROLL_TOP';
+export const TIMELINE_SCROLL_TOP = 'TIMELINE_SCROLL_TOP';
 export const TIMELINE_LOAD_PENDING = 'TIMELINE_LOAD_PENDING';
-export const TIMELINE_DISCONNECT   = 'TIMELINE_DISCONNECT';
-export const TIMELINE_CONNECT      = 'TIMELINE_CONNECT';
+export const TIMELINE_DISCONNECT = 'TIMELINE_DISCONNECT';
+export const TIMELINE_CONNECT = 'TIMELINE_CONNECT';
 
 export const TIMELINE_MARK_AS_PARTIAL = 'TIMELINE_MARK_AS_PARTIAL';
 
-export const loadPending = timeline => ({
+export const loadPending = (timeline) => ({
   type: TIMELINE_LOAD_PENDING,
   timeline,
 });
@@ -57,9 +57,12 @@ export function updateTimeline(timeline, status, accept) {
 
 export function deleteFromTimelines(id) {
   return (dispatch, getState) => {
-    const accountId  = getState().getIn(['statuses', id, 'account']);
-    const references = getState().get('statuses').filter(status => status.get('reblog') === id).map(status => status.get('id'));
-    const reblogOf   = getState().getIn(['statuses', id, 'reblog'], null);
+    const accountId = getState().getIn(['statuses', id, 'account']);
+    const references = getState()
+      .get('statuses')
+      .filter((status) => status.get('reblog') === id)
+      .map((status) => status.get('id'));
+    const reblogOf = getState().getIn(['statuses', id, 'reblog'], null);
 
     dispatch({
       type: TIMELINE_DELETE,
@@ -87,7 +90,10 @@ const parseTags = (tags = {}, mode) => {
 
 export function expandTimeline(timelineId, path, params = {}, done = noOp) {
   return (dispatch, getState) => {
-    const timeline = getState().getIn(['timelines', timelineId], ImmutableMap());
+    const timeline = getState().getIn(
+      ['timelines', timelineId],
+      ImmutableMap(),
+    );
     const isLoadingMore = !!params.max_id;
 
     if (timeline.get('isLoading')) {
@@ -95,7 +101,13 @@ export function expandTimeline(timelineId, path, params = {}, done = noOp) {
       return;
     }
 
-    if (!params.max_id && !params.pinned && (timeline.get('items', ImmutableList()).size + timeline.get('pendingItems', ImmutableList()).size) > 0) {
+    if (
+      !params.max_id &&
+      !params.pinned &&
+      timeline.get('items', ImmutableList()).size +
+        timeline.get('pendingItems', ImmutableList()).size >
+        0
+    ) {
       const a = timeline.getIn(['pendingItems', 0]);
       const b = timeline.getIn(['items', 0]);
 
@@ -110,59 +122,159 @@ export function expandTimeline(timelineId, path, params = {}, done = noOp) {
 
     dispatch(expandTimelineRequest(timelineId, isLoadingMore));
 
-    api(getState).get(path, { params }).then(response => {
-      const next = getLinks(response).refs.find(link => link.rel === 'next');
-      dispatch(importFetchedStatuses(response.data));
-      dispatch(expandTimelineSuccess(timelineId, response.data, next ? next.uri : null, response.status === 206, isLoadingRecent, isLoadingMore, isLoadingRecent && preferPendingItems));
+    api(getState)
+      .get(path, { params })
+      .then((response) => {
+        const next = getLinks(response).refs.find(
+          (link) => link.rel === 'next',
+        );
+        dispatch(importFetchedStatuses(response.data));
+        dispatch(
+          expandTimelineSuccess(
+            timelineId,
+            response.data,
+            next ? next.uri : null,
+            response.status === 206,
+            isLoadingRecent,
+            isLoadingMore,
+            isLoadingRecent && preferPendingItems,
+          ),
+        );
 
-      if (timelineId === 'home') {
-        dispatch(submitMarkers());
-      }
-    }).catch(error => {
-      dispatch(expandTimelineFail(timelineId, error, isLoadingMore));
-    }).finally(() => {
-      done();
-    });
+        if (timelineId === 'home') {
+          dispatch(submitMarkers());
+        }
+      })
+      .catch((error) => {
+        dispatch(expandTimelineFail(timelineId, error, isLoadingMore));
+      })
+      .finally(() => {
+        done();
+      });
   };
 }
 
 export function fillTimelineGaps(timelineId, path, params = {}, done = noOp) {
   return (dispatch, getState) => {
-    const timeline = getState().getIn(['timelines', timelineId], ImmutableMap());
+    const timeline = getState().getIn(
+      ['timelines', timelineId],
+      ImmutableMap(),
+    );
     const items = timeline.get('items');
-    const nullIndexes = items.map((statusId, index) => statusId === null ? index : null);
-    const gaps = nullIndexes.map(index => index > 0 ? items.get(index - 1) : null);
+    const nullIndexes = items.map((statusId, index) =>
+      statusId === null ? index : null,
+    );
+    const gaps = nullIndexes.map((index) =>
+      index > 0 ? items.get(index - 1) : null,
+    );
 
     // Only expand at most two gaps to avoid doing too many requests
     done = gaps.take(2).reduce((done, maxId) => {
-      return (() => dispatch(expandTimeline(timelineId, path, { ...params, maxId }, done)));
+      return () =>
+        dispatch(expandTimeline(timelineId, path, { ...params, maxId }, done));
     }, done);
 
     done();
   };
 }
 
-export const expandHomeTimeline            = ({ maxId } = {}, done = noOp) => expandTimeline('home', '/api/v1/timelines/home', { max_id: maxId }, done);
-export const expandPublicTimeline          = ({ maxId, onlyMedia, onlyRemote } = {}, done = noOp) => expandTimeline(`public${onlyRemote ? ':remote' : ''}${onlyMedia ? ':media' : ''}`, '/api/v1/timelines/public', { remote: !!onlyRemote, max_id: maxId, only_media: !!onlyMedia }, done);
-export const expandCommunityTimeline       = ({ maxId, onlyMedia } = {}, done = noOp) => expandTimeline(`community${onlyMedia ? ':media' : ''}`, '/api/v1/timelines/public', { local: true, max_id: maxId, only_media: !!onlyMedia }, done);
-export const expandAccountTimeline         = (accountId, { maxId, withReplies, tagged } = {}) => expandTimeline(`account:${accountId}${withReplies ? ':with_replies' : ''}${tagged ? `:${tagged}` : ''}`, `/api/v1/accounts/${accountId}/statuses`, { exclude_replies: !withReplies, exclude_reblogs: withReplies, tagged, max_id: maxId });
-export const expandAccountFeaturedTimeline = (accountId, { tagged } = {}) => expandTimeline(`account:${accountId}:pinned${tagged ? `:${tagged}` : ''}`, `/api/v1/accounts/${accountId}/statuses`, { pinned: true, tagged });
-export const expandAccountMediaTimeline    = (accountId, { maxId } = {}) => expandTimeline(`account:${accountId}:media`, `/api/v1/accounts/${accountId}/statuses`, { max_id: maxId, only_media: true, limit: 40 });
-export const expandListTimeline            = (id, { maxId } = {}, done = noOp) => expandTimeline(`list:${id}`, `/api/v1/timelines/list/${id}`, { max_id: maxId }, done);
-export const expandHashtagTimeline         = (hashtag, { maxId, tags, local } = {}, done = noOp) => {
-  return expandTimeline(`hashtag:${hashtag}${local ? ':local' : ''}`, `/api/v1/timelines/tag/${hashtag}`, {
-    max_id: maxId,
-    any:    parseTags(tags, 'any'),
-    all:    parseTags(tags, 'all'),
-    none:   parseTags(tags, 'none'),
-    local:  local,
-  }, done);
+export const expandHomeTimeline = ({ maxId } = {}, done = noOp) =>
+  expandTimeline('home', '/api/v1/timelines/home', { max_id: maxId }, done);
+export const expandPublicTimeline = (
+  { maxId, onlyMedia, onlyRemote } = {},
+  done = noOp,
+) =>
+  expandTimeline(
+    `public${onlyRemote ? ':remote' : ''}${onlyMedia ? ':media' : ''}`,
+    '/api/v1/timelines/public',
+    { remote: !!onlyRemote, max_id: maxId, only_media: !!onlyMedia },
+    done,
+  );
+export const expandCommunityTimeline = (
+  { maxId, onlyMedia } = {},
+  done = noOp,
+) =>
+  expandTimeline(
+    `community${onlyMedia ? ':media' : ''}`,
+    '/api/v1/timelines/public',
+    { local: true, max_id: maxId, only_media: !!onlyMedia },
+    done,
+  );
+export const expandAccountTimeline = (
+  accountId,
+  { maxId, withReplies, tagged } = {},
+) =>
+  expandTimeline(
+    `account:${accountId}${withReplies ? ':with_replies' : ''}${
+      tagged ? `:${tagged}` : ''
+    }`,
+    `/api/v1/accounts/${accountId}/statuses`,
+    {
+      exclude_replies: !withReplies,
+      exclude_reblogs: withReplies,
+      tagged,
+      max_id: maxId,
+    },
+  );
+export const expandAccountFeaturedTimeline = (accountId, { tagged } = {}) =>
+  expandTimeline(
+    `account:${accountId}:pinned${tagged ? `:${tagged}` : ''}`,
+    `/api/v1/accounts/${accountId}/statuses`,
+    { pinned: true, tagged },
+  );
+export const expandAccountMediaTimeline = (accountId, { maxId } = {}) =>
+  expandTimeline(
+    `account:${accountId}:media`,
+    `/api/v1/accounts/${accountId}/statuses`,
+    { max_id: maxId, only_media: true, limit: 40 },
+  );
+export const expandListTimeline = (id, { maxId } = {}, done = noOp) =>
+  expandTimeline(
+    `list:${id}`,
+    `/api/v1/timelines/list/${id}`,
+    { max_id: maxId },
+    done,
+  );
+export const expandHashtagTimeline = (
+  hashtag,
+  { maxId, tags, local } = {},
+  done = noOp,
+) => {
+  return expandTimeline(
+    `hashtag:${hashtag}${local ? ':local' : ''}`,
+    `/api/v1/timelines/tag/${hashtag}`,
+    {
+      max_id: maxId,
+      any: parseTags(tags, 'any'),
+      all: parseTags(tags, 'all'),
+      none: parseTags(tags, 'none'),
+      local: local,
+    },
+    done,
+  );
 };
 
-export const fillHomeTimelineGaps      = (done = noOp) => fillTimelineGaps('home', '/api/v1/timelines/home', {}, done);
-export const fillPublicTimelineGaps    = ({ onlyMedia, onlyRemote } = {}, done = noOp) => fillTimelineGaps(`public${onlyRemote ? ':remote' : ''}${onlyMedia ? ':media' : ''}`, '/api/v1/timelines/public', { remote: !!onlyRemote, only_media: !!onlyMedia }, done);
-export const fillCommunityTimelineGaps = ({ onlyMedia } = {}, done = noOp) => fillTimelineGaps(`community${onlyMedia ? ':media' : ''}`, '/api/v1/timelines/public', { local: true, only_media: !!onlyMedia }, done);
-export const fillListTimelineGaps      = (id, done = noOp) => fillTimelineGaps(`list:${id}`, `/api/v1/timelines/list/${id}`, {}, done);
+export const fillHomeTimelineGaps = (done = noOp) =>
+  fillTimelineGaps('home', '/api/v1/timelines/home', {}, done);
+export const fillPublicTimelineGaps = (
+  { onlyMedia, onlyRemote } = {},
+  done = noOp,
+) =>
+  fillTimelineGaps(
+    `public${onlyRemote ? ':remote' : ''}${onlyMedia ? ':media' : ''}`,
+    '/api/v1/timelines/public',
+    { remote: !!onlyRemote, only_media: !!onlyMedia },
+    done,
+  );
+export const fillCommunityTimelineGaps = ({ onlyMedia } = {}, done = noOp) =>
+  fillTimelineGaps(
+    `community${onlyMedia ? ':media' : ''}`,
+    '/api/v1/timelines/public',
+    { local: true, only_media: !!onlyMedia },
+    done,
+  );
+export const fillListTimelineGaps = (id, done = noOp) =>
+  fillTimelineGaps(`list:${id}`, `/api/v1/timelines/list/${id}`, {}, done);
 
 export function expandTimelineRequest(timeline, isLoadingMore) {
   return {
@@ -172,7 +284,15 @@ export function expandTimelineRequest(timeline, isLoadingMore) {
   };
 }
 
-export function expandTimelineSuccess(timeline, statuses, next, partial, isLoadingRecent, isLoadingMore, usePendingItems) {
+export function expandTimelineSuccess(
+  timeline,
+  statuses,
+  next,
+  partial,
+  isLoadingRecent,
+  isLoadingMore,
+  usePendingItems,
+) {
   return {
     type: TIMELINE_EXPAND_SUCCESS,
     timeline,
@@ -211,13 +331,13 @@ export function connectTimeline(timeline) {
   };
 }
 
-export const disconnectTimeline = timeline => ({
+export const disconnectTimeline = (timeline) => ({
   type: TIMELINE_DISCONNECT,
   timeline,
   usePendingItems: preferPendingItems,
 });
 
-export const markAsPartial = timeline => ({
+export const markAsPartial = (timeline) => ({
   type: TIMELINE_MARK_AS_PARTIAL,
   timeline,
 });

--- a/app/javascript/mastodon/actions/trends.js
+++ b/app/javascript/mastodon/actions/trends.js
@@ -4,19 +4,19 @@ import { importFetchedStatuses } from './importer';
 
 export const TRENDS_TAGS_FETCH_REQUEST = 'TRENDS_TAGS_FETCH_REQUEST';
 export const TRENDS_TAGS_FETCH_SUCCESS = 'TRENDS_TAGS_FETCH_SUCCESS';
-export const TRENDS_TAGS_FETCH_FAIL    = 'TRENDS_TAGS_FETCH_FAIL';
+export const TRENDS_TAGS_FETCH_FAIL = 'TRENDS_TAGS_FETCH_FAIL';
 
 export const TRENDS_LINKS_FETCH_REQUEST = 'TRENDS_LINKS_FETCH_REQUEST';
 export const TRENDS_LINKS_FETCH_SUCCESS = 'TRENDS_LINKS_FETCH_SUCCESS';
-export const TRENDS_LINKS_FETCH_FAIL    = 'TRENDS_LINKS_FETCH_FAIL';
+export const TRENDS_LINKS_FETCH_FAIL = 'TRENDS_LINKS_FETCH_FAIL';
 
 export const TRENDS_STATUSES_FETCH_REQUEST = 'TRENDS_STATUSES_FETCH_REQUEST';
 export const TRENDS_STATUSES_FETCH_SUCCESS = 'TRENDS_STATUSES_FETCH_SUCCESS';
-export const TRENDS_STATUSES_FETCH_FAIL    = 'TRENDS_STATUSES_FETCH_FAIL';
+export const TRENDS_STATUSES_FETCH_FAIL = 'TRENDS_STATUSES_FETCH_FAIL';
 
 export const TRENDS_STATUSES_EXPAND_REQUEST = 'TRENDS_STATUSES_EXPAND_REQUEST';
 export const TRENDS_STATUSES_EXPAND_SUCCESS = 'TRENDS_STATUSES_EXPAND_SUCCESS';
-export const TRENDS_STATUSES_EXPAND_FAIL    = 'TRENDS_STATUSES_EXPAND_FAIL';
+export const TRENDS_STATUSES_EXPAND_FAIL = 'TRENDS_STATUSES_EXPAND_FAIL';
 
 export const fetchTrendingHashtags = () => (dispatch, getState) => {
   dispatch(fetchTrendingHashtagsRequest());
@@ -24,7 +24,7 @@ export const fetchTrendingHashtags = () => (dispatch, getState) => {
   api(getState)
     .get('/api/v1/trends/tags')
     .then(({ data }) => dispatch(fetchTrendingHashtagsSuccess(data)))
-    .catch(err => dispatch(fetchTrendingHashtagsFail(err)));
+    .catch((err) => dispatch(fetchTrendingHashtagsFail(err)));
 };
 
 export const fetchTrendingHashtagsRequest = () => ({
@@ -32,13 +32,13 @@ export const fetchTrendingHashtagsRequest = () => ({
   skipLoading: true,
 });
 
-export const fetchTrendingHashtagsSuccess = trends => ({
+export const fetchTrendingHashtagsSuccess = (trends) => ({
   type: TRENDS_TAGS_FETCH_SUCCESS,
   trends,
   skipLoading: true,
 });
 
-export const fetchTrendingHashtagsFail = error => ({
+export const fetchTrendingHashtagsFail = (error) => ({
   type: TRENDS_TAGS_FETCH_FAIL,
   error,
   skipLoading: true,
@@ -51,7 +51,7 @@ export const fetchTrendingLinks = () => (dispatch, getState) => {
   api(getState)
     .get('/api/v1/trends/links')
     .then(({ data }) => dispatch(fetchTrendingLinksSuccess(data)))
-    .catch(err => dispatch(fetchTrendingLinksFail(err)));
+    .catch((err) => dispatch(fetchTrendingLinksFail(err)));
 };
 
 export const fetchTrendingLinksRequest = () => ({
@@ -59,13 +59,13 @@ export const fetchTrendingLinksRequest = () => ({
   skipLoading: true,
 });
 
-export const fetchTrendingLinksSuccess = trends => ({
+export const fetchTrendingLinksSuccess = (trends) => ({
   type: TRENDS_LINKS_FETCH_SUCCESS,
   trends,
   skipLoading: true,
 });
 
-export const fetchTrendingLinksFail = error => ({
+export const fetchTrendingLinksFail = (error) => ({
   type: TRENDS_LINKS_FETCH_FAIL,
   error,
   skipLoading: true,
@@ -79,11 +79,16 @@ export const fetchTrendingStatuses = () => (dispatch, getState) => {
 
   dispatch(fetchTrendingStatusesRequest());
 
-  api(getState).get('/api/v1/trends/statuses').then(response => {
-    const next = getLinks(response).refs.find(link => link.rel === 'next');
-    dispatch(importFetchedStatuses(response.data));
-    dispatch(fetchTrendingStatusesSuccess(response.data, next ? next.uri : null));
-  }).catch(err => dispatch(fetchTrendingStatusesFail(err)));
+  api(getState)
+    .get('/api/v1/trends/statuses')
+    .then((response) => {
+      const next = getLinks(response).refs.find((link) => link.rel === 'next');
+      dispatch(importFetchedStatuses(response.data));
+      dispatch(
+        fetchTrendingStatusesSuccess(response.data, next ? next.uri : null),
+      );
+    })
+    .catch((err) => dispatch(fetchTrendingStatusesFail(err)));
 };
 
 export const fetchTrendingStatusesRequest = () => ({
@@ -98,30 +103,37 @@ export const fetchTrendingStatusesSuccess = (statuses, next) => ({
   skipLoading: true,
 });
 
-export const fetchTrendingStatusesFail = error => ({
+export const fetchTrendingStatusesFail = (error) => ({
   type: TRENDS_STATUSES_FETCH_FAIL,
   error,
   skipLoading: true,
   skipAlert: true,
 });
 
-
 export const expandTrendingStatuses = () => (dispatch, getState) => {
   const url = getState().getIn(['status_lists', 'trending', 'next'], null);
 
-  if (url === null || getState().getIn(['status_lists', 'trending', 'isLoading'])) {
+  if (
+    url === null ||
+    getState().getIn(['status_lists', 'trending', 'isLoading'])
+  ) {
     return;
   }
 
   dispatch(expandTrendingStatusesRequest());
 
-  api(getState).get(url).then(response => {
-    const next = getLinks(response).refs.find(link => link.rel === 'next');
-    dispatch(importFetchedStatuses(response.data));
-    dispatch(expandTrendingStatusesSuccess(response.data, next ? next.uri : null));
-  }).catch(error => {
-    dispatch(expandTrendingStatusesFail(error));
-  });
+  api(getState)
+    .get(url)
+    .then((response) => {
+      const next = getLinks(response).refs.find((link) => link.rel === 'next');
+      dispatch(importFetchedStatuses(response.data));
+      dispatch(
+        expandTrendingStatusesSuccess(response.data, next ? next.uri : null),
+      );
+    })
+    .catch((error) => {
+      dispatch(expandTrendingStatusesFail(error));
+    });
 };
 
 export const expandTrendingStatusesRequest = () => ({
@@ -134,7 +146,7 @@ export const expandTrendingStatusesSuccess = (statuses, next) => ({
   next,
 });
 
-export const expandTrendingStatusesFail = error => ({
+export const expandTrendingStatusesFail = (error) => ({
   type: TRENDS_STATUSES_EXPAND_FAIL,
   error,
 });

--- a/app/javascript/mastodon/components/__tests__/autosuggest_emoji-test.jsx
+++ b/app/javascript/mastodon/components/__tests__/autosuggest_emoji-test.jsx
@@ -9,7 +9,7 @@ describe('<AutosuggestEmoji />', () => {
       colons: ':foobar:',
     };
     const component = renderer.create(<AutosuggestEmoji emoji={emoji} />);
-    const tree      = component.toJSON();
+    const tree = component.toJSON();
 
     expect(tree).toMatchSnapshot();
   });
@@ -22,7 +22,7 @@ describe('<AutosuggestEmoji />', () => {
       colons: ':foobar:',
     };
     const component = renderer.create(<AutosuggestEmoji emoji={emoji} />);
-    const tree      = component.toJSON();
+    const tree = component.toJSON();
 
     expect(tree).toMatchSnapshot();
   });

--- a/app/javascript/mastodon/components/__tests__/avatar-test.jsx
+++ b/app/javascript/mastodon/components/__tests__/avatar-test.jsx
@@ -13,12 +13,14 @@ describe('<Avatar />', () => {
     avatar_static: '/static/alice.jpg',
   });
 
-  const size     = 100;
+  const size = 100;
 
   describe('Autoplay', () => {
     it('renders a animated avatar', () => {
-      const component = renderer.create(<Avatar account={account} animate size={size} />);
-      const tree      = component.toJSON();
+      const component = renderer.create(
+        <Avatar account={account} animate size={size} />,
+      );
+      const tree = component.toJSON();
 
       expect(tree).toMatchSnapshot();
     });
@@ -26,8 +28,10 @@ describe('<Avatar />', () => {
 
   describe('Still', () => {
     it('renders a still avatar', () => {
-      const component = renderer.create(<Avatar account={account} size={size} />);
-      const tree      = component.toJSON();
+      const component = renderer.create(
+        <Avatar account={account} size={size} />,
+      );
+      const tree = component.toJSON();
 
       expect(tree).toMatchSnapshot();
     });

--- a/app/javascript/mastodon/components/__tests__/avatar_overlay-test.jsx
+++ b/app/javascript/mastodon/components/__tests__/avatar_overlay-test.jsx
@@ -22,8 +22,10 @@ describe('<AvatarOverlay', () => {
   });
 
   it('renders a overlay avatar', () => {
-    const component = renderer.create(<AvatarOverlay account={account} friend={friend} />);
-    const tree      = component.toJSON();
+    const component = renderer.create(
+      <AvatarOverlay account={account} friend={friend} />,
+    );
+    const tree = component.toJSON();
 
     expect(tree).toMatchSnapshot();
   });

--- a/app/javascript/mastodon/components/__tests__/button-test.jsx
+++ b/app/javascript/mastodon/components/__tests__/button-test.jsx
@@ -6,15 +6,15 @@ import Button from '../button';
 describe('<Button />', () => {
   it('renders a button element', () => {
     const component = renderer.create(<Button />);
-    const tree      = component.toJSON();
+    const tree = component.toJSON();
 
     expect(tree).toMatchSnapshot();
   });
 
   it('renders the given text', () => {
-    const text      = 'foo';
+    const text = 'foo';
     const component = renderer.create(<Button text={text} />);
-    const tree      = component.toJSON();
+    const tree = component.toJSON();
 
     expect(tree).toMatchSnapshot();
   });
@@ -29,7 +29,11 @@ describe('<Button />', () => {
 
   it('does not handle click events if props.disabled given', () => {
     const handler = jest.fn();
-    render(<Button onClick={handler} disabled>button</Button>);
+    render(
+      <Button onClick={handler} disabled>
+        button
+      </Button>,
+    );
     fireEvent.click(screen.getByText('button'));
 
     expect(handler.mock.calls.length).toEqual(0);
@@ -37,38 +41,38 @@ describe('<Button />', () => {
 
   it('renders a disabled attribute if props.disabled given', () => {
     const component = renderer.create(<Button disabled />);
-    const tree      = component.toJSON();
+    const tree = component.toJSON();
 
     expect(tree).toMatchSnapshot();
   });
 
   it('renders the children', () => {
-    const children  = <p>children</p>;
+    const children = <p>children</p>;
     const component = renderer.create(<Button>{children}</Button>);
-    const tree      = component.toJSON();
+    const tree = component.toJSON();
 
     expect(tree).toMatchSnapshot();
   });
 
   it('renders the props.text instead of children', () => {
-    const text      = 'foo';
-    const children  = <p>children</p>;
+    const text = 'foo';
+    const children = <p>children</p>;
     const component = renderer.create(<Button text={text}>{children}</Button>);
-    const tree      = component.toJSON();
+    const tree = component.toJSON();
 
     expect(tree).toMatchSnapshot();
   });
 
   it('renders class="button--block" if props.block given', () => {
     const component = renderer.create(<Button block />);
-    const tree      = component.toJSON();
+    const tree = component.toJSON();
 
     expect(tree).toMatchSnapshot();
   });
 
   it('adds class "button-secondary" if props.secondary given', () => {
     const component = renderer.create(<Button secondary />);
-    const tree      = component.toJSON();
+    const tree = component.toJSON();
 
     expect(tree).toMatchSnapshot();
   });

--- a/app/javascript/mastodon/components/__tests__/display_name-test.jsx
+++ b/app/javascript/mastodon/components/__tests__/display_name-test.jsx
@@ -1,4 +1,4 @@
-import { fromJS }  from 'immutable';
+import { fromJS } from 'immutable';
 
 import renderer from 'react-test-renderer';
 
@@ -12,7 +12,7 @@ describe('<DisplayName />', () => {
       display_name_html: '<p>Foo</p>',
     });
     const component = renderer.create(<DisplayName account={account} />);
-    const tree      = component.toJSON();
+    const tree = component.toJSON();
 
     expect(tree).toMatchSnapshot();
   });

--- a/app/javascript/mastodon/components/account.jsx
+++ b/app/javascript/mastodon/components/account.jsx
@@ -24,17 +24,25 @@ import { RelativeTimestamp } from './relative_timestamp';
 const messages = defineMessages({
   follow: { id: 'account.follow', defaultMessage: 'Follow' },
   unfollow: { id: 'account.unfollow', defaultMessage: 'Unfollow' },
-  cancel_follow_request: { id: 'account.cancel_follow_request', defaultMessage: 'Withdraw follow request' },
+  cancel_follow_request: {
+    id: 'account.cancel_follow_request',
+    defaultMessage: 'Withdraw follow request',
+  },
   unblock: { id: 'account.unblock_short', defaultMessage: 'Unblock' },
   unmute: { id: 'account.unmute_short', defaultMessage: 'Unmute' },
-  mute_notifications: { id: 'account.mute_notifications_short', defaultMessage: 'Mute notifications' },
-  unmute_notifications: { id: 'account.unmute_notifications_short', defaultMessage: 'Unmute notifications' },
+  mute_notifications: {
+    id: 'account.mute_notifications_short',
+    defaultMessage: 'Mute notifications',
+  },
+  unmute_notifications: {
+    id: 'account.unmute_notifications_short',
+    defaultMessage: 'Unmute notifications',
+  },
   mute: { id: 'account.mute_short', defaultMessage: 'Mute' },
   block: { id: 'account.block_short', defaultMessage: 'Block' },
 });
 
 class Account extends ImmutablePureComponent {
-
   static propTypes = {
     size: PropTypes.number,
     account: ImmutablePropTypes.map,
@@ -80,8 +88,19 @@ class Account extends ImmutablePureComponent {
     this.props.onActionClick(this.props.account);
   };
 
-  render () {
-    const { account, intl, hidden, withBio, onActionClick, actionIcon, actionTitle, defaultAction, size, minimal } = this.props;
+  render() {
+    const {
+      account,
+      intl,
+      hidden,
+      withBio,
+      onActionClick,
+      actionIcon,
+      actionTitle,
+      defaultAction,
+      size,
+      minimal,
+    } = this.props;
 
     if (!account) {
       return <EmptyAccount size={size} minimal={minimal} />;
@@ -99,50 +118,110 @@ class Account extends ImmutablePureComponent {
     let buttons;
 
     if (actionIcon && onActionClick) {
-      buttons = <IconButton icon={actionIcon} title={actionTitle} onClick={this.handleAction} />;
-    } else if (!actionIcon && account.get('id') !== me && account.get('relationship', null) !== null) {
+      buttons = (
+        <IconButton
+          icon={actionIcon}
+          title={actionTitle}
+          onClick={this.handleAction}
+        />
+      );
+    } else if (
+      !actionIcon &&
+      account.get('id') !== me &&
+      account.get('relationship', null) !== null
+    ) {
       const following = account.getIn(['relationship', 'following']);
       const requested = account.getIn(['relationship', 'requested']);
-      const blocking  = account.getIn(['relationship', 'blocking']);
-      const muting  = account.getIn(['relationship', 'muting']);
+      const blocking = account.getIn(['relationship', 'blocking']);
+      const muting = account.getIn(['relationship', 'muting']);
 
       if (requested) {
-        buttons = <Button text={intl.formatMessage(messages.cancel_follow_request)} onClick={this.handleFollow} />;
+        buttons = (
+          <Button
+            text={intl.formatMessage(messages.cancel_follow_request)}
+            onClick={this.handleFollow}
+          />
+        );
       } else if (blocking) {
-        buttons = <Button text={intl.formatMessage(messages.unblock)} onClick={this.handleBlock} />;
+        buttons = (
+          <Button
+            text={intl.formatMessage(messages.unblock)}
+            onClick={this.handleBlock}
+          />
+        );
       } else if (muting) {
         let hidingNotificationsButton;
 
         if (account.getIn(['relationship', 'muting_notifications'])) {
-          hidingNotificationsButton = <Button text={intl.formatMessage(messages.unmute_notifications)} onClick={this.handleUnmuteNotifications} />;
+          hidingNotificationsButton = (
+            <Button
+              text={intl.formatMessage(messages.unmute_notifications)}
+              onClick={this.handleUnmuteNotifications}
+            />
+          );
         } else {
-          hidingNotificationsButton = <Button text={intl.formatMessage(messages.mute_notifications)} onClick={this.handleMuteNotifications} />;
+          hidingNotificationsButton = (
+            <Button
+              text={intl.formatMessage(messages.mute_notifications)}
+              onClick={this.handleMuteNotifications}
+            />
+          );
         }
 
         buttons = (
           <>
-            <Button text={intl.formatMessage(messages.unmute)} onClick={this.handleMute} />
+            <Button
+              text={intl.formatMessage(messages.unmute)}
+              onClick={this.handleMute}
+            />
             {hidingNotificationsButton}
           </>
         );
       } else if (defaultAction === 'mute') {
-        buttons = <Button title={intl.formatMessage(messages.mute)} onClick={this.handleMute} />;
+        buttons = (
+          <Button
+            title={intl.formatMessage(messages.mute)}
+            onClick={this.handleMute}
+          />
+        );
       } else if (defaultAction === 'block') {
-        buttons = <Button text={intl.formatMessage(messages.block)} onClick={this.handleBlock} />;
+        buttons = (
+          <Button
+            text={intl.formatMessage(messages.block)}
+            onClick={this.handleBlock}
+          />
+        );
       } else if (!account.get('moved') || following) {
-        buttons = <Button text={intl.formatMessage(following ? messages.unfollow : messages.follow)} onClick={this.handleFollow} />;
+        buttons = (
+          <Button
+            text={intl.formatMessage(
+              following ? messages.unfollow : messages.follow,
+            )}
+            onClick={this.handleFollow}
+          />
+        );
       }
     }
 
     let muteTimeRemaining;
 
     if (account.get('mute_expires_at')) {
-      muteTimeRemaining = <>· <RelativeTimestamp timestamp={account.get('mute_expires_at')} futureDate /></>;
+      muteTimeRemaining = (
+        <>
+          ·{' '}
+          <RelativeTimestamp
+            timestamp={account.get('mute_expires_at')}
+            futureDate
+          />
+        </>
+      );
     }
 
     let verification;
 
-    const firstVerifiedField = account.get('fields').find(item => !!item.get('verified_at'));
+    const firstVerifiedField = account
+      .get('fields')
+      .find((item) => !!item.get('verified_at'));
 
     if (firstVerifiedField) {
       verification = <VerifiedBadge link={firstVerifiedField.get('value')} />;
@@ -151,7 +230,12 @@ class Account extends ImmutablePureComponent {
     return (
       <div className={classNames('account', { 'account--minimal': minimal })}>
         <div className='account__wrapper'>
-          <Link key={account.get('id')} className='account__display-name' title={account.get('acct')} to={`/@${account.get('acct')}`}>
+          <Link
+            key={account.get('id')}
+            className='account__display-name'
+            title={account.get('acct')}
+            to={`/@${account.get('acct')}`}
+          >
             <div className='account__avatar-wrapper'>
               <Avatar account={account} size={size} />
             </div>
@@ -160,31 +244,38 @@ class Account extends ImmutablePureComponent {
               <DisplayName account={account} />
               {!minimal && (
                 <div className='account__details'>
-                  <ShortNumber value={account.get('followers_count')} renderer={FollowersCounter} /> {verification} {muteTimeRemaining}
+                  <ShortNumber
+                    value={account.get('followers_count')}
+                    renderer={FollowersCounter}
+                  />{' '}
+                  {verification} {muteTimeRemaining}
                 </div>
               )}
             </div>
           </Link>
 
-          {!minimal && (
-            <div className='account__relationship'>
-              {buttons}
-            </div>
-          )}
+          {!minimal && <div className='account__relationship'>{buttons}</div>}
         </div>
 
-        {withBio && (account.get('note').length > 0 ? (
-          <div
-            className='account__note translate'
-            dangerouslySetInnerHTML={{ __html: account.get('note_emojified') }}
-          />
-        ) : (
-          <div className='account__note account__note--missing'><FormattedMessage id='account.no_bio' defaultMessage='No description provided.' /></div>
-        ))}
+        {withBio &&
+          (account.get('note').length > 0 ? (
+            <div
+              className='account__note translate'
+              dangerouslySetInnerHTML={{
+                __html: account.get('note_emojified'),
+              }}
+            />
+          ) : (
+            <div className='account__note account__note--missing'>
+              <FormattedMessage
+                id='account.no_bio'
+                defaultMessage='No description provided.'
+              />
+            </div>
+          ))}
       </div>
     );
   }
-
 }
 
 export default injectIntl(Account);

--- a/app/javascript/mastodon/components/admin/Counter.jsx
+++ b/app/javascript/mastodon/components/admin/Counter.jsx
@@ -22,14 +22,13 @@ const percIncrease = (a, b) => {
   } else if (b === 0 && a === 0) {
     percent = 0;
   } else {
-    percent = - 1;
+    percent = -1;
   }
 
   return percent;
 };
 
 export default class Counter extends PureComponent {
-
   static propTypes = {
     measure: PropTypes.string.isRequired,
     start_at: PropTypes.string.isRequired,
@@ -45,20 +44,28 @@ export default class Counter extends PureComponent {
     data: null,
   };
 
-  componentDidMount () {
+  componentDidMount() {
     const { measure, start_at, end_at, params } = this.props;
 
-    api().post('/api/v1/admin/measures', { keys: [measure], start_at, end_at, [measure]: params }).then(res => {
-      this.setState({
-        loading: false,
-        data: res.data,
+    api()
+      .post('/api/v1/admin/measures', {
+        keys: [measure],
+        start_at,
+        end_at,
+        [measure]: params,
+      })
+      .then((res) => {
+        this.setState({
+          loading: false,
+          data: res.data,
+        });
+      })
+      .catch((err) => {
+        console.error(err);
       });
-    }).catch(err => {
-      console.error(err);
-    });
   }
 
-  render () {
+  render() {
     const { label, href, target } = this.props;
     const { loading, data } = this.state;
 
@@ -67,35 +74,53 @@ export default class Counter extends PureComponent {
     if (loading) {
       content = (
         <>
-          <span className='sparkline__value__total'><Skeleton width={43} /></span>
-          <span className='sparkline__value__change'><Skeleton width={43} /></span>
+          <span className='sparkline__value__total'>
+            <Skeleton width={43} />
+          </span>
+          <span className='sparkline__value__change'>
+            <Skeleton width={43} />
+          </span>
         </>
       );
     } else {
       const measure = data[0];
-      const percentChange = measure.previous_total && percIncrease(measure.previous_total * 1, measure.total * 1);
+      const percentChange =
+        measure.previous_total &&
+        percIncrease(measure.previous_total * 1, measure.total * 1);
 
       content = (
         <>
-          <span className='sparkline__value__total'>{measure.human_value || <FormattedNumber value={measure.total} />}</span>
-          {measure.previous_total && (<span className={classNames('sparkline__value__change', { positive: percentChange > 0, negative: percentChange < 0 })}>{percentChange > 0 && '+'}<FormattedNumber value={percentChange} style='percent' /></span>)}
+          <span className='sparkline__value__total'>
+            {measure.human_value || <FormattedNumber value={measure.total} />}
+          </span>
+          {measure.previous_total && (
+            <span
+              className={classNames('sparkline__value__change', {
+                positive: percentChange > 0,
+                negative: percentChange < 0,
+              })}
+            >
+              {percentChange > 0 && '+'}
+              <FormattedNumber value={percentChange} style='percent' />
+            </span>
+          )}
         </>
       );
     }
 
     const inner = (
       <>
-        <div className='sparkline__value'>
-          {content}
-        </div>
+        <div className='sparkline__value'>{content}</div>
 
-        <div className='sparkline__label'>
-          {label}
-        </div>
+        <div className='sparkline__label'>{label}</div>
 
         <div className='sparkline__graph'>
           {!loading && (
-            <Sparklines width={259} height={55} data={data[0].data.map(x => x.value * 1)}>
+            <Sparklines
+              width={259}
+              height={55}
+              data={data[0].data.map((x) => x.value * 1)}
+            >
               <SparklinesCurve />
             </Sparklines>
           )}
@@ -110,12 +135,7 @@ export default class Counter extends PureComponent {
         </a>
       );
     } else {
-      return (
-        <div className='sparkline'>
-          {inner}
-        </div>
-      );
+      return <div className='sparkline'>{inner}</div>;
     }
   }
-
 }

--- a/app/javascript/mastodon/components/admin/Dimension.jsx
+++ b/app/javascript/mastodon/components/admin/Dimension.jsx
@@ -8,7 +8,6 @@ import { Skeleton } from 'mastodon/components/skeleton';
 import { roundTo10 } from 'mastodon/utils/numbers';
 
 export default class Dimension extends PureComponent {
-
   static propTypes = {
     dimension: PropTypes.string.isRequired,
     start_at: PropTypes.string.isRequired,
@@ -23,20 +22,29 @@ export default class Dimension extends PureComponent {
     data: null,
   };
 
-  componentDidMount () {
+  componentDidMount() {
     const { start_at, end_at, dimension, limit, params } = this.props;
 
-    api().post('/api/v1/admin/dimensions', { keys: [dimension], start_at, end_at, limit, [dimension]: params }).then(res => {
-      this.setState({
-        loading: false,
-        data: res.data,
+    api()
+      .post('/api/v1/admin/dimensions', {
+        keys: [dimension],
+        start_at,
+        end_at,
+        limit,
+        [dimension]: params,
+      })
+      .then((res) => {
+        this.setState({
+          loading: false,
+          data: res.data,
+        });
+      })
+      .catch((err) => {
+        console.error(err);
       });
-    }).catch(err => {
-      console.error(err);
-    });
   }
 
-  render () {
+  render() {
     const { label, limit } = this.props;
     const { loading, data } = this.state;
 
@@ -61,20 +69,28 @@ export default class Dimension extends PureComponent {
         </table>
       );
     } else {
-      const sum = data[0].data.reduce((sum, cur) => sum + (cur.value * 1), 0);
+      const sum = data[0].data.reduce((sum, cur) => sum + cur.value * 1, 0);
 
       content = (
         <table>
           <tbody>
-            {data[0].data.map(item => (
+            {data[0].data.map((item) => (
               <tr className='dimension__item' key={item.key}>
                 <td className='dimension__item__key'>
-                  <span className={`dimension__item__indicator dimension__item__indicator--${roundTo10(((item.value * 1) / sum) * 100)}`} />
+                  <span
+                    className={`dimension__item__indicator dimension__item__indicator--${roundTo10(
+                      ((item.value * 1) / sum) * 100,
+                    )}`}
+                  />
                   <span title={item.key}>{item.human_key}</span>
                 </td>
 
                 <td className='dimension__item__value'>
-                  {typeof item.human_value !== 'undefined' ? item.human_value : <FormattedNumber value={item.value} />}
+                  {typeof item.human_value !== 'undefined' ? (
+                    item.human_value
+                  ) : (
+                    <FormattedNumber value={item.value} />
+                  )}
                 </td>
               </tr>
             ))}
@@ -91,5 +107,4 @@ export default class Dimension extends PureComponent {
       </div>
     );
   }
-
 }

--- a/app/javascript/mastodon/components/admin/ImpactReport.jsx
+++ b/app/javascript/mastodon/components/admin/ImpactReport.jsx
@@ -9,7 +9,6 @@ import api from 'mastodon/api';
 import { Skeleton } from 'mastodon/components/skeleton';
 
 export default class ImpactReport extends PureComponent {
-
   static propTypes = {
     domain: PropTypes.string.isRequired,
   };
@@ -19,7 +18,7 @@ export default class ImpactReport extends PureComponent {
     data: null,
   };
 
-  componentDidMount () {
+  componentDidMount() {
     const { domain } = this.props;
 
     const params = {
@@ -27,59 +26,96 @@ export default class ImpactReport extends PureComponent {
       include_subdomains: true,
     };
 
-    api().post('/api/v1/admin/measures', {
-      keys: ['instance_accounts', 'instance_follows', 'instance_followers'],
-      start_at: null,
-      end_at: null,
-      instance_accounts: params,
-      instance_follows: params,
-      instance_followers: params,
-    }).then(res => {
-      this.setState({
-        loading: false,
-        data: res.data,
+    api()
+      .post('/api/v1/admin/measures', {
+        keys: ['instance_accounts', 'instance_follows', 'instance_followers'],
+        start_at: null,
+        end_at: null,
+        instance_accounts: params,
+        instance_follows: params,
+        instance_followers: params,
+      })
+      .then((res) => {
+        this.setState({
+          loading: false,
+          data: res.data,
+        });
+      })
+      .catch((err) => {
+        console.error(err);
       });
-    }).catch(err => {
-      console.error(err);
-    });
   }
 
-  render () {
+  render() {
     const { loading, data } = this.state;
 
     return (
       <div className='dimension'>
-        <h4><FormattedMessage id='admin.impact_report.title' defaultMessage='Impact summary' /></h4>
+        <h4>
+          <FormattedMessage
+            id='admin.impact_report.title'
+            defaultMessage='Impact summary'
+          />
+        </h4>
 
         <table>
           <tbody>
             <tr className='dimension__item'>
               <td className='dimension__item__key'>
-                <FormattedMessage id='admin.impact_report.instance_accounts' defaultMessage='Accounts profiles this would delete' />
+                <FormattedMessage
+                  id='admin.impact_report.instance_accounts'
+                  defaultMessage='Accounts profiles this would delete'
+                />
               </td>
 
               <td className='dimension__item__value'>
-                {loading ? <Skeleton width={60} /> : <FormattedNumber value={data[0].total} />}
+                {loading ? (
+                  <Skeleton width={60} />
+                ) : (
+                  <FormattedNumber value={data[0].total} />
+                )}
               </td>
             </tr>
 
-            <tr className={classNames('dimension__item', { negative: !loading && data[1].total > 0 })}>
+            <tr
+              className={classNames('dimension__item', {
+                negative: !loading && data[1].total > 0,
+              })}
+            >
               <td className='dimension__item__key'>
-                <FormattedMessage id='admin.impact_report.instance_follows' defaultMessage='Followers their users would lose' />
+                <FormattedMessage
+                  id='admin.impact_report.instance_follows'
+                  defaultMessage='Followers their users would lose'
+                />
               </td>
 
               <td className='dimension__item__value'>
-                {loading ? <Skeleton width={60} /> : <FormattedNumber value={data[1].total} />}
+                {loading ? (
+                  <Skeleton width={60} />
+                ) : (
+                  <FormattedNumber value={data[1].total} />
+                )}
               </td>
             </tr>
 
-            <tr className={classNames('dimension__item', { negative: !loading && data[2].total > 0 })}>
+            <tr
+              className={classNames('dimension__item', {
+                negative: !loading && data[2].total > 0,
+              })}
+            >
               <td className='dimension__item__key'>
-                <FormattedMessage id='admin.impact_report.instance_followers' defaultMessage='Followers our users would lose' />
+                <FormattedMessage
+                  id='admin.impact_report.instance_followers'
+                  defaultMessage='Followers our users would lose'
+                />
               </td>
 
               <td className='dimension__item__value'>
-                {loading ? <Skeleton width={60} /> : <FormattedNumber value={data[2].total} />}
+                {loading ? (
+                  <Skeleton width={60} />
+                ) : (
+                  <FormattedNumber value={data[2].total} />
+                )}
               </td>
             </tr>
           </tbody>
@@ -87,5 +123,4 @@ export default class ImpactReport extends PureComponent {
       </div>
     );
   }
-
 }

--- a/app/javascript/mastodon/components/admin/ReportReasonSelector.jsx
+++ b/app/javascript/mastodon/components/admin/ReportReasonSelector.jsx
@@ -11,11 +11,13 @@ const messages = defineMessages({
   legal: { id: 'report.categories.legal', defaultMessage: 'Legal' },
   other: { id: 'report.categories.other', defaultMessage: 'Other' },
   spam: { id: 'report.categories.spam', defaultMessage: 'Spam' },
-  violation: { id: 'report.categories.violation', defaultMessage: 'Content violates one or more server rules' },
+  violation: {
+    id: 'report.categories.violation',
+    defaultMessage: 'Content violates one or more server rules',
+  },
 });
 
 class Category extends PureComponent {
-
   static propTypes = {
     id: PropTypes.string.isRequired,
     text: PropTypes.string.isRequired,
@@ -33,19 +35,32 @@ class Category extends PureComponent {
     }
   };
 
-  render () {
+  render() {
     const { id, text, disabled, selected, children } = this.props;
 
     return (
-      <div tabIndex={0} role='button' className={classNames('report-reason-selector__category', { selected, disabled })} onClick={this.handleClick}>
+      <div
+        tabIndex={0}
+        role='button'
+        className={classNames('report-reason-selector__category', {
+          selected,
+          disabled,
+        })}
+        onClick={this.handleClick}
+      >
         {selected && <input type='hidden' name='report[category]' value={id} />}
 
         <div className='report-reason-selector__category__label'>
-          <span className={classNames('poll__input', { active: selected, disabled })} />
+          <span
+            className={classNames('poll__input', {
+              active: selected,
+              disabled,
+            })}
+          />
           {text}
         </div>
 
-        {(selected && children) && (
+        {selected && children && (
           <div className='report-reason-selector__category__rules'>
             {children}
           </div>
@@ -53,11 +68,9 @@ class Category extends PureComponent {
       </div>
     );
   }
-
 }
 
 class Rule extends PureComponent {
-
   static propTypes = {
     id: PropTypes.string.isRequired,
     text: PropTypes.string.isRequired,
@@ -74,22 +87,36 @@ class Rule extends PureComponent {
     }
   };
 
-  render () {
+  render() {
     const { id, text, disabled, selected } = this.props;
 
     return (
-      <div tabIndex={0} role='button' className={classNames('report-reason-selector__rule', { selected, disabled })} onClick={this.handleClick}>
-        <span className={classNames('poll__input', { checkbox: true, active: selected, disabled })} />
-        {selected && <input type='hidden' name='report[rule_ids][]' value={id} />}
+      <div
+        tabIndex={0}
+        role='button'
+        className={classNames('report-reason-selector__rule', {
+          selected,
+          disabled,
+        })}
+        onClick={this.handleClick}
+      >
+        <span
+          className={classNames('poll__input', {
+            checkbox: true,
+            active: selected,
+            disabled,
+          })}
+        />
+        {selected && (
+          <input type='hidden' name='report[rule_ids][]' value={id} />
+        )}
         {text}
       </div>
     );
   }
-
 }
 
 class ReportReasonSelector extends PureComponent {
-
   static propTypes = {
     id: PropTypes.string.isRequired,
     category: PropTypes.string.isRequired,
@@ -105,13 +132,16 @@ class ReportReasonSelector extends PureComponent {
   };
 
   componentDidMount() {
-    api().get('/api/v1/instance').then(res => {
-      this.setState({
-        rules: res.data.rules,
+    api()
+      .get('/api/v1/instance')
+      .then((res) => {
+        this.setState({
+          rules: res.data.rules,
+        });
+      })
+      .catch((err) => {
+        console.error(err);
       });
-    }).catch(err => {
-      console.error(err);
-    });
   }
 
   _save = () => {
@@ -122,44 +152,80 @@ class ReportReasonSelector extends PureComponent {
       return;
     }
 
-    api().put(`/api/v1/admin/reports/${id}`, {
-      category,
-      rule_ids,
-    }).catch(err => {
-      console.error(err);
-    });
+    api()
+      .put(`/api/v1/admin/reports/${id}`, {
+        category,
+        rule_ids,
+      })
+      .catch((err) => {
+        console.error(err);
+      });
   };
 
-  handleSelect = id => {
+  handleSelect = (id) => {
     this.setState({ category: id }, () => this._save());
   };
 
-  handleToggle = id => {
+  handleToggle = (id) => {
     const { rule_ids } = this.state;
 
     if (rule_ids.includes(id)) {
-      this.setState({ rule_ids: rule_ids.filter(x => x !== id ) }, () => this._save());
+      this.setState({ rule_ids: rule_ids.filter((x) => x !== id) }, () =>
+        this._save(),
+      );
     } else {
       this.setState({ rule_ids: [...rule_ids, id] }, () => this._save());
     }
   };
 
-  render () {
+  render() {
     const { disabled, intl } = this.props;
     const { rules, category, rule_ids } = this.state;
 
     return (
       <div className='report-reason-selector'>
-        <Category id='other' text={intl.formatMessage(messages.other)} selected={category === 'other'} onSelect={this.handleSelect} disabled={disabled} />
-        <Category id='legal' text={intl.formatMessage(messages.legal)} selected={category === 'legal'} onSelect={this.handleSelect} disabled={disabled} />
-        <Category id='spam' text={intl.formatMessage(messages.spam)} selected={category === 'spam'} onSelect={this.handleSelect} disabled={disabled} />
-        <Category id='violation' text={intl.formatMessage(messages.violation)} selected={category === 'violation'} onSelect={this.handleSelect} disabled={disabled}>
-          {rules.map(rule => <Rule key={rule.id} id={rule.id} text={rule.text} selected={rule_ids.includes(rule.id)} onToggle={this.handleToggle} disabled={disabled} />)}
+        <Category
+          id='other'
+          text={intl.formatMessage(messages.other)}
+          selected={category === 'other'}
+          onSelect={this.handleSelect}
+          disabled={disabled}
+        />
+        <Category
+          id='legal'
+          text={intl.formatMessage(messages.legal)}
+          selected={category === 'legal'}
+          onSelect={this.handleSelect}
+          disabled={disabled}
+        />
+        <Category
+          id='spam'
+          text={intl.formatMessage(messages.spam)}
+          selected={category === 'spam'}
+          onSelect={this.handleSelect}
+          disabled={disabled}
+        />
+        <Category
+          id='violation'
+          text={intl.formatMessage(messages.violation)}
+          selected={category === 'violation'}
+          onSelect={this.handleSelect}
+          disabled={disabled}
+        >
+          {rules.map((rule) => (
+            <Rule
+              key={rule.id}
+              id={rule.id}
+              text={rule.text}
+              selected={rule_ids.includes(rule.id)}
+              onToggle={this.handleToggle}
+              disabled={disabled}
+            />
+          ))}
         </Category>
       </div>
     );
   }
-
 }
 
 export default injectIntl(ReportReasonSelector);

--- a/app/javascript/mastodon/components/admin/Retention.jsx
+++ b/app/javascript/mastodon/components/admin/Retention.jsx
@@ -8,17 +8,18 @@ import classNames from 'classnames';
 import api from 'mastodon/api';
 import { roundTo10 } from 'mastodon/utils/numbers';
 
-const dateForCohort = cohort => {
-  switch(cohort.frequency) {
-  case 'day':
-    return <FormattedDate value={cohort.period} month='long' day='2-digit' />;
-  default:
-    return <FormattedDate value={cohort.period} month='long' year='numeric' />;
+const dateForCohort = (cohort) => {
+  switch (cohort.frequency) {
+    case 'day':
+      return <FormattedDate value={cohort.period} month='long' day='2-digit' />;
+    default:
+      return (
+        <FormattedDate value={cohort.period} month='long' year='numeric' />
+      );
   }
 };
 
 export default class Retention extends PureComponent {
-
   static propTypes = {
     start_at: PropTypes.string,
     end_at: PropTypes.string,
@@ -30,27 +31,35 @@ export default class Retention extends PureComponent {
     data: null,
   };
 
-  componentDidMount () {
+  componentDidMount() {
     const { start_at, end_at, frequency } = this.props;
 
-    api().post('/api/v1/admin/retention', { start_at, end_at, frequency }).then(res => {
-      this.setState({
-        loading: false,
-        data: res.data,
+    api()
+      .post('/api/v1/admin/retention', { start_at, end_at, frequency })
+      .then((res) => {
+        this.setState({
+          loading: false,
+          data: res.data,
+        });
+      })
+      .catch((err) => {
+        console.error(err);
       });
-    }).catch(err => {
-      console.error(err);
-    });
   }
 
-  render () {
+  render() {
     const { loading, data } = this.state;
     const { frequency } = this.props;
 
     let content;
 
     if (loading) {
-      content = <FormattedMessage id='loading_indicator.label' defaultMessage='Loading...' />;
+      content = (
+        <FormattedMessage
+          id='loading_indicator.label'
+          defaultMessage='Loading...'
+        />
+      );
     } else {
       content = (
         <table className='retention__table'>
@@ -58,13 +67,19 @@ export default class Retention extends PureComponent {
             <tr>
               <th>
                 <div className='retention__table__date retention__table__label'>
-                  <FormattedMessage id='admin.dashboard.retention.cohort' defaultMessage='Sign-up month' />
+                  <FormattedMessage
+                    id='admin.dashboard.retention.cohort'
+                    defaultMessage='Sign-up month'
+                  />
                 </div>
               </th>
 
               <th>
                 <div className='retention__table__number retention__table__label'>
-                  <FormattedMessage id='admin.dashboard.retention.cohort_size' defaultMessage='New users' />
+                  <FormattedMessage
+                    id='admin.dashboard.retention.cohort_size'
+                    defaultMessage='New users'
+                  />
                 </div>
               </th>
 
@@ -80,22 +95,44 @@ export default class Retention extends PureComponent {
             <tr>
               <td>
                 <div className='retention__table__date retention__table__average'>
-                  <FormattedMessage id='admin.dashboard.retention.average' defaultMessage='Average' />
+                  <FormattedMessage
+                    id='admin.dashboard.retention.average'
+                    defaultMessage='Average'
+                  />
                 </div>
               </td>
 
               <td>
                 <div className='retention__table__size'>
-                  <FormattedNumber value={data.reduce((sum, cohort, i) => sum + ((cohort.data[0].value * 1) - sum) / (i + 1), 0)} maximumFractionDigits={0} />
+                  <FormattedNumber
+                    value={data.reduce(
+                      (sum, cohort, i) =>
+                        sum + (cohort.data[0].value * 1 - sum) / (i + 1),
+                      0,
+                    )}
+                    maximumFractionDigits={0}
+                  />
                 </div>
               </td>
 
               {data[0].data.slice(1).map((retention, i) => {
-                const average = data.reduce((sum, cohort, k) => cohort.data[i + 1] ? sum + (cohort.data[i + 1].rate - sum)/(k + 1) : sum, 0);
+                const average = data.reduce(
+                  (sum, cohort, k) =>
+                    cohort.data[i + 1]
+                      ? sum + (cohort.data[i + 1].rate - sum) / (k + 1)
+                      : sum,
+                  0,
+                );
 
                 return (
                   <td key={retention.date}>
-                    <div className={classNames('retention__table__box', 'retention__table__average', `retention__table__box--${roundTo10(average * 100)}`)}>
+                    <div
+                      className={classNames(
+                        'retention__table__box',
+                        'retention__table__average',
+                        `retention__table__box--${roundTo10(average * 100)}`,
+                      )}
+                    >
                       <FormattedNumber value={average} style='percent' />
                     </div>
                   </td>
@@ -105,7 +142,7 @@ export default class Retention extends PureComponent {
           </thead>
 
           <tbody>
-            {data.slice(0, -1).map(cohort => (
+            {data.slice(0, -1).map((cohort) => (
               <tr key={cohort.period}>
                 <td>
                   <div className='retention__table__date'>
@@ -119,9 +156,16 @@ export default class Retention extends PureComponent {
                   </div>
                 </td>
 
-                {cohort.data.slice(1).map(retention => (
+                {cohort.data.slice(1).map((retention) => (
                   <td key={retention.date}>
-                    <div className={classNames('retention__table__box', `retention__table__box--${roundTo10(retention.rate * 100)}`)}>
+                    <div
+                      className={classNames(
+                        'retention__table__box',
+                        `retention__table__box--${roundTo10(
+                          retention.rate * 100,
+                        )}`,
+                      )}
+                    >
                       <FormattedNumber value={retention.rate} style='percent' />
                     </div>
                   </td>
@@ -134,12 +178,22 @@ export default class Retention extends PureComponent {
     }
 
     let title = null;
-    switch(frequency) {
-    case 'day':
-      title = <FormattedMessage id='admin.dashboard.daily_retention' defaultMessage='User retention rate by day after sign-up' />;
-      break;
-    default:
-      title = <FormattedMessage id='admin.dashboard.monthly_retention' defaultMessage='User retention rate by month after sign-up' />;
+    switch (frequency) {
+      case 'day':
+        title = (
+          <FormattedMessage
+            id='admin.dashboard.daily_retention'
+            defaultMessage='User retention rate by day after sign-up'
+          />
+        );
+        break;
+      default:
+        title = (
+          <FormattedMessage
+            id='admin.dashboard.monthly_retention'
+            defaultMessage='User retention rate by month after sign-up'
+          />
+        );
     }
 
     return (
@@ -150,5 +204,4 @@ export default class Retention extends PureComponent {
       </div>
     );
   }
-
 }

--- a/app/javascript/mastodon/components/admin/Trends.jsx
+++ b/app/javascript/mastodon/components/admin/Trends.jsx
@@ -9,7 +9,6 @@ import api from 'mastodon/api';
 import Hashtag from 'mastodon/components/hashtag';
 
 export default class Trends extends PureComponent {
-
   static propTypes = {
     limit: PropTypes.number.isRequired,
   };
@@ -19,20 +18,23 @@ export default class Trends extends PureComponent {
     data: null,
   };
 
-  componentDidMount () {
+  componentDidMount() {
     const { limit } = this.props;
 
-    api().get('/api/v1/admin/trends/tags', { params: { limit } }).then(res => {
-      this.setState({
-        loading: false,
-        data: res.data,
+    api()
+      .get('/api/v1/admin/trends/tags', { params: { limit } })
+      .then((res) => {
+        this.setState({
+          loading: false,
+          data: res.data,
+        });
+      })
+      .catch((err) => {
+        console.error(err);
       });
-    }).catch(err => {
-      console.error(err);
-    });
   }
 
-  render () {
+  render() {
     const { limit } = this.props;
     const { loading, data } = this.state;
 
@@ -49,15 +51,27 @@ export default class Trends extends PureComponent {
     } else {
       content = (
         <div>
-          {data.map(hashtag => (
+          {data.map((hashtag) => (
             <Hashtag
               key={hashtag.name}
               name={hashtag.name}
-              to={hashtag.id === undefined ? undefined : `/admin/tags/${hashtag.id}`}
-              people={hashtag.history[0].accounts * 1 + hashtag.history[1].accounts * 1}
+              to={
+                hashtag.id === undefined
+                  ? undefined
+                  : `/admin/tags/${hashtag.id}`
+              }
+              people={
+                hashtag.history[0].accounts * 1 +
+                hashtag.history[1].accounts * 1
+              }
               uses={hashtag.history[0].uses * 1 + hashtag.history[1].uses * 1}
-              history={hashtag.history.reverse().map(day => day.uses)}
-              className={classNames(hashtag.requires_review && 'trends__item--requires-review', !hashtag.trendable && !hashtag.requires_review && 'trends__item--disabled')}
+              history={hashtag.history.reverse().map((day) => day.uses)}
+              className={classNames(
+                hashtag.requires_review && 'trends__item--requires-review',
+                !hashtag.trendable &&
+                  !hashtag.requires_review &&
+                  'trends__item--disabled',
+              )}
             />
           ))}
         </div>
@@ -66,11 +80,15 @@ export default class Trends extends PureComponent {
 
     return (
       <div className='trends trends--compact'>
-        <h4><FormattedMessage id='trends.trending_now' defaultMessage='Trending now' /></h4>
+        <h4>
+          <FormattedMessage
+            id='trends.trending_now'
+            defaultMessage='Trending now'
+          />
+        </h4>
 
         {content}
       </div>
     );
   }
-
 }

--- a/app/javascript/mastodon/components/attachment_list.jsx
+++ b/app/javascript/mastodon/components/attachment_list.jsx
@@ -7,18 +7,17 @@ import classNames from 'classnames';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 
-import { Icon }  from 'mastodon/components/icon';
+import { Icon } from 'mastodon/components/icon';
 
-const filename = url => url.split('/').pop().split('#')[0].split('?')[0];
+const filename = (url) => url.split('/').pop().split('#')[0].split('?')[0];
 
 export default class AttachmentList extends ImmutablePureComponent {
-
   static propTypes = {
     media: ImmutablePropTypes.list.isRequired,
     compact: PropTypes.bool,
   };
 
-  render () {
+  render() {
     const { media, compact } = this.props;
 
     return (
@@ -30,15 +29,23 @@ export default class AttachmentList extends ImmutablePureComponent {
         )}
 
         <ul className='attachment-list__list'>
-          {media.map(attachment => {
-            const displayUrl = attachment.get('remote_url') || attachment.get('url');
+          {media.map((attachment) => {
+            const displayUrl =
+              attachment.get('remote_url') || attachment.get('url');
 
             return (
               <li key={attachment.get('id')}>
                 <a href={displayUrl} target='_blank' rel='noopener noreferrer'>
                   {compact && <Icon id='link' />}
-                  {compact && ' ' }
-                  {displayUrl ? filename(displayUrl) : <FormattedMessage id='attachments_list.unprocessed' defaultMessage='(unprocessed)' />}
+                  {compact && ' '}
+                  {displayUrl ? (
+                    filename(displayUrl)
+                  ) : (
+                    <FormattedMessage
+                      id='attachments_list.unprocessed'
+                      defaultMessage='(unprocessed)'
+                    />
+                  )}
                 </a>
               </li>
             );
@@ -47,5 +54,4 @@ export default class AttachmentList extends ImmutablePureComponent {
       </div>
     );
   }
-
 }

--- a/app/javascript/mastodon/components/autosuggest_emoji.jsx
+++ b/app/javascript/mastodon/components/autosuggest_emoji.jsx
@@ -6,19 +6,20 @@ import { assetHost } from 'mastodon/utils/config';
 import unicodeMapping from '../features/emoji/emoji_unicode_mapping_light';
 
 export default class AutosuggestEmoji extends PureComponent {
-
   static propTypes = {
     emoji: PropTypes.object.isRequired,
   };
 
-  render () {
+  render() {
     const { emoji } = this.props;
     let url;
 
     if (emoji.custom) {
       url = emoji.imageUrl;
     } else {
-      const mapping = unicodeMapping[emoji.native] || unicodeMapping[emoji.native.replace(/\uFE0F$/, '')];
+      const mapping =
+        unicodeMapping[emoji.native] ||
+        unicodeMapping[emoji.native.replace(/\uFE0F$/, '')];
 
       if (!mapping) {
         return null;
@@ -39,5 +40,4 @@ export default class AutosuggestEmoji extends PureComponent {
       </div>
     );
   }
-
 }

--- a/app/javascript/mastodon/components/autosuggest_input.jsx
+++ b/app/javascript/mastodon/components/autosuggest_input.jsx
@@ -13,7 +13,7 @@ import { AutosuggestHashtag } from './autosuggest_hashtag';
 const textAtCursorMatchesToken = (str, caretPosition, searchTokens) => {
   let word;
 
-  let left  = str.slice(0, caretPosition).search(/\S+$/);
+  let left = str.slice(0, caretPosition).search(/\S+$/);
   let right = str.slice(caretPosition).search(/\s/);
 
   if (right < 0) {
@@ -36,7 +36,6 @@ const textAtCursorMatchesToken = (str, caretPosition, searchTokens) => {
 };
 
 export default class AutosuggestInput extends ImmutablePureComponent {
-
   static propTypes = {
     value: PropTypes.string,
     suggestions: ImmutablePropTypes.list,
@@ -71,7 +70,11 @@ export default class AutosuggestInput extends ImmutablePureComponent {
   };
 
   onChange = (e) => {
-    const [ tokenStart, token ] = textAtCursorMatchesToken(e.target.value, e.target.selectionStart, this.props.searchTokens);
+    const [tokenStart, token] = textAtCursorMatchesToken(
+      e.target.value,
+      e.target.selectionStart,
+      this.props.searchTokens,
+    );
 
     if (token !== null && this.state.lastToken !== token) {
       this.setState({ lastToken: token, selectedSuggestion: 0, tokenStart });
@@ -99,40 +102,55 @@ export default class AutosuggestInput extends ImmutablePureComponent {
       return;
     }
 
-    switch(e.key) {
-    case 'Escape':
-      if (suggestions.size === 0 || suggestionsHidden) {
-        document.querySelector('.ui').parentElement.focus();
-      } else {
-        e.preventDefault();
-        this.setState({ suggestionsHidden: true });
-      }
+    switch (e.key) {
+      case 'Escape':
+        if (suggestions.size === 0 || suggestionsHidden) {
+          document.querySelector('.ui').parentElement.focus();
+        } else {
+          e.preventDefault();
+          this.setState({ suggestionsHidden: true });
+        }
 
-      break;
-    case 'ArrowDown':
-      if (suggestions.size > 0 && !suggestionsHidden) {
-        e.preventDefault();
-        this.setState({ selectedSuggestion: Math.min(selectedSuggestion + 1, suggestions.size - 1) });
-      }
+        break;
+      case 'ArrowDown':
+        if (suggestions.size > 0 && !suggestionsHidden) {
+          e.preventDefault();
+          this.setState({
+            selectedSuggestion: Math.min(
+              selectedSuggestion + 1,
+              suggestions.size - 1,
+            ),
+          });
+        }
 
-      break;
-    case 'ArrowUp':
-      if (suggestions.size > 0 && !suggestionsHidden) {
-        e.preventDefault();
-        this.setState({ selectedSuggestion: Math.max(selectedSuggestion - 1, 0) });
-      }
+        break;
+      case 'ArrowUp':
+        if (suggestions.size > 0 && !suggestionsHidden) {
+          e.preventDefault();
+          this.setState({
+            selectedSuggestion: Math.max(selectedSuggestion - 1, 0),
+          });
+        }
 
-      break;
-    case 'Enter':
-    case 'Tab':
-      // Select suggestion
-      if (this.state.lastToken !== null && suggestions.size > 0 && !suggestionsHidden) {
-        e.preventDefault();
-        e.stopPropagation();
-        this.props.onSuggestionSelected(this.state.tokenStart, this.state.lastToken, suggestions.get(selectedSuggestion));
-      }
+        break;
+      case 'Enter':
+      case 'Tab':
+        // Select suggestion
+        if (
+          this.state.lastToken !== null &&
+          suggestions.size > 0 &&
+          !suggestionsHidden
+        ) {
+          e.preventDefault();
+          e.stopPropagation();
+          this.props.onSuggestionSelected(
+            this.state.tokenStart,
+            this.state.lastToken,
+            suggestions.get(selectedSuggestion),
+          );
+        }
 
-      break;
+        break;
     }
 
     if (e.defaultPrevented || !this.props.onKeyDown) {
@@ -151,14 +169,25 @@ export default class AutosuggestInput extends ImmutablePureComponent {
   };
 
   onSuggestionClick = (e) => {
-    const suggestion = this.props.suggestions.get(e.currentTarget.getAttribute('data-index'));
+    const suggestion = this.props.suggestions.get(
+      e.currentTarget.getAttribute('data-index'),
+    );
     e.preventDefault();
-    this.props.onSuggestionSelected(this.state.tokenStart, this.state.lastToken, suggestion);
+    this.props.onSuggestionSelected(
+      this.state.tokenStart,
+      this.state.lastToken,
+      suggestion,
+    );
     this.input.focus();
   };
 
-  UNSAFE_componentWillReceiveProps (nextProps) {
-    if (nextProps.suggestions !== this.props.suggestions && nextProps.suggestions.size > 0 && this.state.suggestionsHidden && this.state.focused) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    if (
+      nextProps.suggestions !== this.props.suggestions &&
+      nextProps.suggestions.size > 0 &&
+      this.state.suggestionsHidden &&
+      this.state.focused
+    ) {
       this.setState({ suggestionsHidden: false });
     }
   }
@@ -173,24 +202,45 @@ export default class AutosuggestInput extends ImmutablePureComponent {
 
     if (suggestion.type === 'emoji') {
       inner = <AutosuggestEmoji emoji={suggestion} />;
-      key   = suggestion.id;
-    } else if (suggestion.type ==='hashtag') {
+      key = suggestion.id;
+    } else if (suggestion.type === 'hashtag') {
       inner = <AutosuggestHashtag tag={suggestion} />;
-      key   = suggestion.name;
+      key = suggestion.name;
     } else if (suggestion.type === 'account') {
       inner = <AutosuggestAccountContainer id={suggestion.id} />;
-      key   = suggestion.id;
+      key = suggestion.id;
     }
 
     return (
-      <div role='button' tabIndex={0} key={key} data-index={i} className={classNames('autosuggest-textarea__suggestions__item', { selected: i === selectedSuggestion })} onMouseDown={this.onSuggestionClick}>
+      <div
+        role='button'
+        tabIndex={0}
+        key={key}
+        data-index={i}
+        className={classNames('autosuggest-textarea__suggestions__item', {
+          selected: i === selectedSuggestion,
+        })}
+        onMouseDown={this.onSuggestionClick}
+      >
         {inner}
       </div>
     );
   };
 
-  render () {
-    const { value, suggestions, disabled, placeholder, onKeyUp, autoFocus, className, id, maxLength, lang, spellCheck } = this.props;
+  render() {
+    const {
+      value,
+      suggestions,
+      disabled,
+      placeholder,
+      onKeyUp,
+      autoFocus,
+      className,
+      id,
+      maxLength,
+      lang,
+      spellCheck,
+    } = this.props;
     const { suggestionsHidden } = this.state;
 
     return (
@@ -220,11 +270,16 @@ export default class AutosuggestInput extends ImmutablePureComponent {
           />
         </label>
 
-        <div className={`autosuggest-textarea__suggestions ${suggestionsHidden || suggestions.isEmpty() ? '' : 'autosuggest-textarea__suggestions--visible'}`}>
+        <div
+          className={`autosuggest-textarea__suggestions ${
+            suggestionsHidden || suggestions.isEmpty()
+              ? ''
+              : 'autosuggest-textarea__suggestions--visible'
+          }`}
+        >
           {suggestions.map(this.renderSuggestion)}
         </div>
       </div>
     );
   }
-
 }

--- a/app/javascript/mastodon/components/autosuggest_textarea.jsx
+++ b/app/javascript/mastodon/components/autosuggest_textarea.jsx
@@ -15,7 +15,7 @@ import { AutosuggestHashtag } from './autosuggest_hashtag';
 const textAtCursorMatchesToken = (str, caretPosition) => {
   let word;
 
-  let left  = str.slice(0, caretPosition).search(/\S+$/);
+  let left = str.slice(0, caretPosition).search(/\S+$/);
   let right = str.slice(caretPosition).search(/\s/);
 
   if (right < 0) {
@@ -24,7 +24,11 @@ const textAtCursorMatchesToken = (str, caretPosition) => {
     word = str.slice(left, right + caretPosition);
   }
 
-  if (!word || word.trim().length < 3 || ['@', ':', '#'].indexOf(word[0]) === -1) {
+  if (
+    !word ||
+    word.trim().length < 3 ||
+    ['@', ':', '#'].indexOf(word[0]) === -1
+  ) {
     return [null, null];
   }
 
@@ -38,7 +42,6 @@ const textAtCursorMatchesToken = (str, caretPosition) => {
 };
 
 export default class AutosuggestTextarea extends ImmutablePureComponent {
-
   static propTypes = {
     value: PropTypes.string,
     suggestions: ImmutablePropTypes.list,
@@ -68,7 +71,10 @@ export default class AutosuggestTextarea extends ImmutablePureComponent {
   };
 
   onChange = (e) => {
-    const [ tokenStart, token ] = textAtCursorMatchesToken(e.target.value, e.target.selectionStart);
+    const [tokenStart, token] = textAtCursorMatchesToken(
+      e.target.value,
+      e.target.selectionStart,
+    );
 
     if (token !== null && this.state.lastToken !== token) {
       this.setState({ lastToken: token, selectedSuggestion: 0, tokenStart });
@@ -96,40 +102,55 @@ export default class AutosuggestTextarea extends ImmutablePureComponent {
       return;
     }
 
-    switch(e.key) {
-    case 'Escape':
-      if (suggestions.size === 0 || suggestionsHidden) {
-        document.querySelector('.ui').parentElement.focus();
-      } else {
-        e.preventDefault();
-        this.setState({ suggestionsHidden: true });
-      }
+    switch (e.key) {
+      case 'Escape':
+        if (suggestions.size === 0 || suggestionsHidden) {
+          document.querySelector('.ui').parentElement.focus();
+        } else {
+          e.preventDefault();
+          this.setState({ suggestionsHidden: true });
+        }
 
-      break;
-    case 'ArrowDown':
-      if (suggestions.size > 0 && !suggestionsHidden) {
-        e.preventDefault();
-        this.setState({ selectedSuggestion: Math.min(selectedSuggestion + 1, suggestions.size - 1) });
-      }
+        break;
+      case 'ArrowDown':
+        if (suggestions.size > 0 && !suggestionsHidden) {
+          e.preventDefault();
+          this.setState({
+            selectedSuggestion: Math.min(
+              selectedSuggestion + 1,
+              suggestions.size - 1,
+            ),
+          });
+        }
 
-      break;
-    case 'ArrowUp':
-      if (suggestions.size > 0 && !suggestionsHidden) {
-        e.preventDefault();
-        this.setState({ selectedSuggestion: Math.max(selectedSuggestion - 1, 0) });
-      }
+        break;
+      case 'ArrowUp':
+        if (suggestions.size > 0 && !suggestionsHidden) {
+          e.preventDefault();
+          this.setState({
+            selectedSuggestion: Math.max(selectedSuggestion - 1, 0),
+          });
+        }
 
-      break;
-    case 'Enter':
-    case 'Tab':
-      // Select suggestion
-      if (this.state.lastToken !== null && suggestions.size > 0 && !suggestionsHidden) {
-        e.preventDefault();
-        e.stopPropagation();
-        this.props.onSuggestionSelected(this.state.tokenStart, this.state.lastToken, suggestions.get(selectedSuggestion));
-      }
+        break;
+      case 'Enter':
+      case 'Tab':
+        // Select suggestion
+        if (
+          this.state.lastToken !== null &&
+          suggestions.size > 0 &&
+          !suggestionsHidden
+        ) {
+          e.preventDefault();
+          e.stopPropagation();
+          this.props.onSuggestionSelected(
+            this.state.tokenStart,
+            this.state.lastToken,
+            suggestions.get(selectedSuggestion),
+          );
+        }
 
-      break;
+        break;
     }
 
     if (e.defaultPrevented || !this.props.onKeyDown) {
@@ -151,14 +172,25 @@ export default class AutosuggestTextarea extends ImmutablePureComponent {
   };
 
   onSuggestionClick = (e) => {
-    const suggestion = this.props.suggestions.get(e.currentTarget.getAttribute('data-index'));
+    const suggestion = this.props.suggestions.get(
+      e.currentTarget.getAttribute('data-index'),
+    );
     e.preventDefault();
-    this.props.onSuggestionSelected(this.state.tokenStart, this.state.lastToken, suggestion);
+    this.props.onSuggestionSelected(
+      this.state.tokenStart,
+      this.state.lastToken,
+      suggestion,
+    );
     this.textarea.focus();
   };
 
-  UNSAFE_componentWillReceiveProps (nextProps) {
-    if (nextProps.suggestions !== this.props.suggestions && nextProps.suggestions.size > 0 && this.state.suggestionsHidden && this.state.focused) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    if (
+      nextProps.suggestions !== this.props.suggestions &&
+      nextProps.suggestions.size > 0 &&
+      this.state.suggestionsHidden &&
+      this.state.focused
+    ) {
       this.setState({ suggestionsHidden: false });
     }
   }
@@ -180,28 +212,49 @@ export default class AutosuggestTextarea extends ImmutablePureComponent {
 
     if (suggestion.type === 'emoji') {
       inner = <AutosuggestEmoji emoji={suggestion} />;
-      key   = suggestion.id;
+      key = suggestion.id;
     } else if (suggestion.type === 'hashtag') {
       inner = <AutosuggestHashtag tag={suggestion} />;
-      key   = suggestion.name;
+      key = suggestion.name;
     } else if (suggestion.type === 'account') {
       inner = <AutosuggestAccountContainer id={suggestion.id} />;
-      key   = suggestion.id;
+      key = suggestion.id;
     }
 
     return (
-      <div role='button' tabIndex={0} key={key} data-index={i} className={classNames('autosuggest-textarea__suggestions__item', { selected: i === selectedSuggestion })} onMouseDown={this.onSuggestionClick}>
+      <div
+        role='button'
+        tabIndex={0}
+        key={key}
+        data-index={i}
+        className={classNames('autosuggest-textarea__suggestions__item', {
+          selected: i === selectedSuggestion,
+        })}
+        onMouseDown={this.onSuggestionClick}
+      >
         {inner}
       </div>
     );
   };
 
-  render () {
-    const { value, suggestions, disabled, placeholder, onKeyUp, autoFocus, lang, children } = this.props;
+  render() {
+    const {
+      value,
+      suggestions,
+      disabled,
+      placeholder,
+      onKeyUp,
+      autoFocus,
+      lang,
+      children,
+    } = this.props;
     const { suggestionsHidden } = this.state;
 
     return [
-      <div className='compose-form__autosuggest-wrapper' key='autosuggest-wrapper'>
+      <div
+        className='compose-form__autosuggest-wrapper'
+        key='autosuggest-wrapper'
+      >
         <div className='autosuggest-textarea'>
           <label>
             <span style={{ display: 'none' }}>{placeholder}</span>
@@ -228,12 +281,20 @@ export default class AutosuggestTextarea extends ImmutablePureComponent {
         {children}
       </div>,
 
-      <div className='autosuggest-textarea__suggestions-wrapper' key='suggestions-wrapper'>
-        <div className={`autosuggest-textarea__suggestions ${suggestionsHidden || suggestions.isEmpty() ? '' : 'autosuggest-textarea__suggestions--visible'}`}>
+      <div
+        className='autosuggest-textarea__suggestions-wrapper'
+        key='suggestions-wrapper'
+      >
+        <div
+          className={`autosuggest-textarea__suggestions ${
+            suggestionsHidden || suggestions.isEmpty()
+              ? ''
+              : 'autosuggest-textarea__suggestions--visible'
+          }`}
+        >
           {suggestions.map(this.renderSuggestion)}
         </div>
       </div>,
     ];
   }
-
 }

--- a/app/javascript/mastodon/components/avatar_composite.jsx
+++ b/app/javascript/mastodon/components/avatar_composite.jsx
@@ -8,7 +8,6 @@ import { autoPlayGif } from '../initial_state';
 import { Avatar } from './avatar';
 
 export default class AvatarComposite extends PureComponent {
-
   static propTypes = {
     accounts: ImmutablePropTypes.list.isRequired,
     animate: PropTypes.bool,
@@ -19,15 +18,15 @@ export default class AvatarComposite extends PureComponent {
     animate: autoPlayGif,
   };
 
-  renderItem (account, size, index) {
+  renderItem(account, size, index) {
     const { animate } = this.props;
 
-    let width  = 50;
+    let width = 50;
     let height = 100;
-    let top    = 'auto';
-    let left   = 'auto';
+    let top = 'auto';
+    let left = 'auto';
     let bottom = 'auto';
-    let right  = 'auto';
+    let right = 'auto';
 
     if (size === 1) {
       width = 100;
@@ -91,8 +90,15 @@ export default class AvatarComposite extends PureComponent {
     const { accounts, size } = this.props;
 
     return (
-      <div className='account__avatar-composite' style={{ width: `${size}px`, height: `${size}px` }}>
-        {accounts.take(4).map((account, i) => this.renderItem(account, Math.min(accounts.size, 4), i))}
+      <div
+        className='account__avatar-composite'
+        style={{ width: `${size}px`, height: `${size}px` }}
+      >
+        {accounts
+          .take(4)
+          .map((account, i) =>
+            this.renderItem(account, Math.min(accounts.size, 4), i),
+          )}
 
         {accounts.size > 4 && (
           <span className='account__avatar-composite__label'>
@@ -102,5 +108,4 @@ export default class AvatarComposite extends PureComponent {
       </div>
     );
   }
-
 }

--- a/app/javascript/mastodon/components/badge.jsx
+++ b/app/javascript/mastodon/components/badge.jsx
@@ -6,7 +6,6 @@ import { ReactComponent as GroupsIcon } from '@material-design-icons/svg/outline
 import { ReactComponent as PersonIcon } from '@material-design-icons/svg/outlined/person.svg';
 import { ReactComponent as SmartToyIcon } from '@material-design-icons/svg/outlined/smart_toy.svg';
 
-
 export const Badge = ({ icon, label, domain }) => (
   <div className='account-role'>
     {icon}
@@ -26,9 +25,19 @@ Badge.defaultProps = {
 };
 
 export const GroupBadge = () => (
-  <Badge icon={<GroupsIcon />} label={<FormattedMessage id='account.badges.group' defaultMessage='Group' />} />
+  <Badge
+    icon={<GroupsIcon />}
+    label={
+      <FormattedMessage id='account.badges.group' defaultMessage='Group' />
+    }
+  />
 );
 
 export const AutomatedBadge = () => (
-  <Badge icon={<SmartToyIcon />} label={<FormattedMessage id='account.badges.bot' defaultMessage='Automated' />} />
+  <Badge
+    icon={<SmartToyIcon />}
+    label={
+      <FormattedMessage id='account.badges.bot' defaultMessage='Automated' />
+    }
+  />
 );

--- a/app/javascript/mastodon/components/button.jsx
+++ b/app/javascript/mastodon/components/button.jsx
@@ -4,7 +4,6 @@ import { PureComponent } from 'react';
 import classNames from 'classnames';
 
 export default class Button extends PureComponent {
-
   static propTypes = {
     text: PropTypes.node,
     type: PropTypes.string,
@@ -35,7 +34,7 @@ export default class Button extends PureComponent {
     this.node.focus();
   }
 
-  render () {
+  render() {
     const className = classNames('button', this.props.className, {
       'button-secondary': this.props.secondary,
       'button--block': this.props.block,
@@ -54,5 +53,4 @@ export default class Button extends PureComponent {
       </button>
     );
   }
-
 }

--- a/app/javascript/mastodon/components/column.jsx
+++ b/app/javascript/mastodon/components/column.jsx
@@ -8,14 +8,13 @@ import { scrollTop } from '../scroll';
 const listenerOptions = supportsPassiveEvents ? { passive: true } : false;
 
 export default class Column extends PureComponent {
-
   static propTypes = {
     children: PropTypes.node,
     label: PropTypes.string,
     bindToDocument: PropTypes.bool,
   };
 
-  scrollTop () {
+  scrollTop() {
     let scrollable = null;
 
     if (this.props.bindToDocument) {
@@ -28,7 +27,7 @@ export default class Column extends PureComponent {
       if (scrollable.classList.contains('scrollable--flex')) {
         scrollable = scrollable?.querySelector('.scrollable') || scrollable;
       }
-   }
+    }
 
     if (!scrollable) {
       return;
@@ -45,11 +44,11 @@ export default class Column extends PureComponent {
     this._interruptScrollAnimation();
   };
 
-  setRef = c => {
+  setRef = (c) => {
     this.node = c;
   };
 
-  componentDidMount () {
+  componentDidMount() {
     if (this.props.bindToDocument) {
       document.addEventListener('wheel', this.handleWheel, listenerOptions);
     } else {
@@ -57,7 +56,7 @@ export default class Column extends PureComponent {
     }
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     if (this.props.bindToDocument) {
       document.removeEventListener('wheel', this.handleWheel, listenerOptions);
     } else {
@@ -65,14 +64,18 @@ export default class Column extends PureComponent {
     }
   }
 
-  render () {
+  render() {
     const { label, children } = this.props;
 
     return (
-      <div role='region' aria-label={label} className='column' ref={this.setRef}>
+      <div
+        role='region'
+        aria-label={label}
+        className='column'
+        ref={this.setRef}
+      >
         {children}
       </div>
     );
   }
-
 }

--- a/app/javascript/mastodon/components/column_back_button.jsx
+++ b/app/javascript/mastodon/components/column_back_button.jsx
@@ -4,10 +4,9 @@ import { createPortal } from 'react-dom';
 
 import { FormattedMessage } from 'react-intl';
 
-import { Icon }  from 'mastodon/components/icon';
+import { Icon } from 'mastodon/components/icon';
 
 export default class ColumnBackButton extends PureComponent {
-
   static contextTypes = {
     router: PropTypes.object,
   };
@@ -30,12 +29,16 @@ export default class ColumnBackButton extends PureComponent {
     }
   };
 
-  render () {
+  render() {
     const { multiColumn } = this.props;
 
     const component = (
       <button onClick={this.handleClick} className='column-back-button'>
-        <Icon id='chevron-left' className='column-back-button__icon' fixedWidth />
+        <Icon
+          id='chevron-left'
+          className='column-back-button__icon'
+          fixedWidth
+        />
         <FormattedMessage id='column_back_button.label' defaultMessage='Back' />
       </button>
     );
@@ -58,5 +61,4 @@ export default class ColumnBackButton extends PureComponent {
       }
     }
   }
-
 }

--- a/app/javascript/mastodon/components/column_back_button_slim.jsx
+++ b/app/javascript/mastodon/components/column_back_button_slim.jsx
@@ -1,20 +1,30 @@
 import { FormattedMessage } from 'react-intl';
 
-import { Icon }  from 'mastodon/components/icon';
+import { Icon } from 'mastodon/components/icon';
 
 import ColumnBackButton from './column_back_button';
 
 export default class ColumnBackButtonSlim extends ColumnBackButton {
-
-  render () {
+  render() {
     return (
       <div className='column-back-button--slim'>
-        <div role='button' tabIndex={0} onClick={this.handleClick} className='column-back-button column-back-button--slim-button'>
-          <Icon id='chevron-left' className='column-back-button__icon' fixedWidth />
-          <FormattedMessage id='column_back_button.label' defaultMessage='Back' />
+        <div
+          role='button'
+          tabIndex={0}
+          onClick={this.handleClick}
+          className='column-back-button column-back-button--slim-button'
+        >
+          <Icon
+            id='chevron-left'
+            className='column-back-button__icon'
+            fixedWidth
+          />
+          <FormattedMessage
+            id='column_back_button.label'
+            defaultMessage='Back'
+          />
         </div>
       </div>
     );
   }
-
 }

--- a/app/javascript/mastodon/components/column_header.jsx
+++ b/app/javascript/mastodon/components/column_header.jsx
@@ -6,17 +6,22 @@ import { FormattedMessage, injectIntl, defineMessages } from 'react-intl';
 
 import classNames from 'classnames';
 
-import { Icon }  from 'mastodon/components/icon';
+import { Icon } from 'mastodon/components/icon';
 
 const messages = defineMessages({
   show: { id: 'column_header.show_settings', defaultMessage: 'Show settings' },
   hide: { id: 'column_header.hide_settings', defaultMessage: 'Hide settings' },
-  moveLeft: { id: 'column_header.moveLeft_settings', defaultMessage: 'Move column to the left' },
-  moveRight: { id: 'column_header.moveRight_settings', defaultMessage: 'Move column to the right' },
+  moveLeft: {
+    id: 'column_header.moveLeft_settings',
+    defaultMessage: 'Move column to the left',
+  },
+  moveRight: {
+    id: 'column_header.moveRight_settings',
+    defaultMessage: 'Move column to the right',
+  },
 });
 
 class ColumnHeader extends PureComponent {
-
   static contextTypes = {
     router: PropTypes.object,
     identity: PropTypes.object,
@@ -84,26 +89,39 @@ class ColumnHeader extends PureComponent {
     this.props.onPin();
   };
 
-  render () {
+  render() {
     const { router } = this.context;
-    const { title, icon, active, children, pinned, multiColumn, extraButton, showBackButton, intl: { formatMessage }, placeholder, appendContent, collapseIssues } = this.props;
+    const {
+      title,
+      icon,
+      active,
+      children,
+      pinned,
+      multiColumn,
+      extraButton,
+      showBackButton,
+      intl: { formatMessage },
+      placeholder,
+      appendContent,
+      collapseIssues,
+    } = this.props;
     const { collapsed, animating } = this.state;
 
     const wrapperClassName = classNames('column-header__wrapper', {
-      'active': active,
+      active: active,
     });
 
     const buttonClassName = classNames('column-header', {
-      'active': active,
+      active: active,
     });
 
     const collapsibleClassName = classNames('column-header__collapsible', {
-      'collapsed': collapsed,
-      'animating': animating,
+      collapsed: collapsed,
+      animating: animating,
     });
 
     const collapsibleButtonClassName = classNames('column-header__button', {
-      'active': !collapsed,
+      active: !collapsed,
     });
 
     let extraContent, pinButton, moveButtons, backButton, collapseButton;
@@ -117,37 +135,84 @@ class ColumnHeader extends PureComponent {
     }
 
     if (multiColumn && pinned) {
-      pinButton = <button key='pin-button' className='text-btn column-header__setting-btn' onClick={this.handlePin}><Icon id='times' /> <FormattedMessage id='column_header.unpin' defaultMessage='Unpin' /></button>;
+      pinButton = (
+        <button
+          key='pin-button'
+          className='text-btn column-header__setting-btn'
+          onClick={this.handlePin}
+        >
+          <Icon id='times' />{' '}
+          <FormattedMessage id='column_header.unpin' defaultMessage='Unpin' />
+        </button>
+      );
 
       moveButtons = (
         <div key='move-buttons' className='column-header__setting-arrows'>
-          <button title={formatMessage(messages.moveLeft)} aria-label={formatMessage(messages.moveLeft)} className='icon-button column-header__setting-btn' onClick={this.handleMoveLeft}><Icon id='chevron-left' /></button>
-          <button title={formatMessage(messages.moveRight)} aria-label={formatMessage(messages.moveRight)} className='icon-button column-header__setting-btn' onClick={this.handleMoveRight}><Icon id='chevron-right' /></button>
+          <button
+            title={formatMessage(messages.moveLeft)}
+            aria-label={formatMessage(messages.moveLeft)}
+            className='icon-button column-header__setting-btn'
+            onClick={this.handleMoveLeft}
+          >
+            <Icon id='chevron-left' />
+          </button>
+          <button
+            title={formatMessage(messages.moveRight)}
+            aria-label={formatMessage(messages.moveRight)}
+            className='icon-button column-header__setting-btn'
+            onClick={this.handleMoveRight}
+          >
+            <Icon id='chevron-right' />
+          </button>
         </div>
       );
     } else if (multiColumn && this.props.onPin) {
-      pinButton = <button key='pin-button' className='text-btn column-header__setting-btn' onClick={this.handlePin}><Icon id='plus' /> <FormattedMessage id='column_header.pin' defaultMessage='Pin' /></button>;
-    }
-
-    if (!pinned && ((multiColumn && router.history.location?.state?.fromMastodon) || showBackButton)) {
-      backButton = (
-        <button onClick={this.handleBackClick} className='column-header__back-button'>
-          <Icon id='chevron-left' className='column-back-button__icon' fixedWidth />
-          <FormattedMessage id='column_back_button.label' defaultMessage='Back' />
+      pinButton = (
+        <button
+          key='pin-button'
+          className='text-btn column-header__setting-btn'
+          onClick={this.handlePin}
+        >
+          <Icon id='plus' />{' '}
+          <FormattedMessage id='column_header.pin' defaultMessage='Pin' />
         </button>
       );
     }
 
-    const collapsedContent = [
-      extraContent,
-    ];
+    if (
+      !pinned &&
+      ((multiColumn && router.history.location?.state?.fromMastodon) ||
+        showBackButton)
+    ) {
+      backButton = (
+        <button
+          onClick={this.handleBackClick}
+          className='column-header__back-button'
+        >
+          <Icon
+            id='chevron-left'
+            className='column-back-button__icon'
+            fixedWidth
+          />
+          <FormattedMessage
+            id='column_back_button.label'
+            defaultMessage='Back'
+          />
+        </button>
+      );
+    }
+
+    const collapsedContent = [extraContent];
 
     if (multiColumn) {
       collapsedContent.push(pinButton);
       collapsedContent.push(moveButtons);
     }
 
-    if (this.context.identity.signedIn && (children || (multiColumn && this.props.onPin))) {
+    if (
+      this.context.identity.signedIn &&
+      (children || (multiColumn && this.props.onPin))
+    ) {
       collapseButton = (
         <button
           className={collapsibleButtonClassName}
@@ -184,7 +249,11 @@ class ColumnHeader extends PureComponent {
           </div>
         </h1>
 
-        <div className={collapsibleClassName} tabIndex={collapsed ? -1 : null} onTransitionEnd={this.handleTransitionEnd}>
+        <div
+          className={collapsibleClassName}
+          tabIndex={collapsed ? -1 : null}
+          onTransitionEnd={this.handleTransitionEnd}
+        >
           <div className='column-header__collapsible-inner'>
             {(!collapsed || animating) && collapsedContent}
           </div>
@@ -212,7 +281,6 @@ class ColumnHeader extends PureComponent {
       }
     }
   }
-
 }
 
 export default injectIntl(ColumnHeader);

--- a/app/javascript/mastodon/components/dropdown_menu.jsx
+++ b/app/javascript/mastodon/components/dropdown_menu.jsx
@@ -8,20 +8,22 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import { supportsPassiveEvents } from 'detect-passive-events';
 import Overlay from 'react-overlays/Overlay';
 
-import { CircularProgress } from "./circular_progress";
+import { CircularProgress } from './circular_progress';
 import { IconButton } from './icon_button';
 
-const listenerOptions = supportsPassiveEvents ? { passive: true, capture: true } : true;
+const listenerOptions = supportsPassiveEvents
+  ? { passive: true, capture: true }
+  : true;
 let id = 0;
 
 class DropdownMenu extends PureComponent {
-
   static contextTypes = {
     router: PropTypes.object,
   };
 
   static propTypes = {
-    items: PropTypes.oneOfType([PropTypes.array, ImmutablePropTypes.list]).isRequired,
+    items: PropTypes.oneOfType([PropTypes.array, ImmutablePropTypes.list])
+      .isRequired,
     loading: PropTypes.bool,
     scrollable: PropTypes.bool,
     onClose: PropTypes.func.isRequired,
@@ -36,65 +38,79 @@ class DropdownMenu extends PureComponent {
     style: {},
   };
 
-  handleDocumentClick = e => {
+  handleDocumentClick = (e) => {
     if (this.node && !this.node.contains(e.target)) {
       this.props.onClose();
       e.stopPropagation();
     }
   };
 
-  componentDidMount () {
-    document.addEventListener('click', this.handleDocumentClick, { capture: true });
+  componentDidMount() {
+    document.addEventListener('click', this.handleDocumentClick, {
+      capture: true,
+    });
     document.addEventListener('keydown', this.handleKeyDown, { capture: true });
-    document.addEventListener('touchend', this.handleDocumentClick, listenerOptions);
+    document.addEventListener(
+      'touchend',
+      this.handleDocumentClick,
+      listenerOptions,
+    );
 
     if (this.focusedItem && this.props.openedViaKeyboard) {
       this.focusedItem.focus({ preventScroll: true });
     }
   }
 
-  componentWillUnmount () {
-    document.removeEventListener('click', this.handleDocumentClick, { capture: true });
-    document.removeEventListener('keydown', this.handleKeyDown, { capture: true });
-    document.removeEventListener('touchend', this.handleDocumentClick, listenerOptions);
+  componentWillUnmount() {
+    document.removeEventListener('click', this.handleDocumentClick, {
+      capture: true,
+    });
+    document.removeEventListener('keydown', this.handleKeyDown, {
+      capture: true,
+    });
+    document.removeEventListener(
+      'touchend',
+      this.handleDocumentClick,
+      listenerOptions,
+    );
   }
 
-  setRef = c => {
+  setRef = (c) => {
     this.node = c;
   };
 
-  setFocusRef = c => {
+  setFocusRef = (c) => {
     this.focusedItem = c;
   };
 
-  handleKeyDown = e => {
+  handleKeyDown = (e) => {
     const items = Array.from(this.node.querySelectorAll('a, button'));
     const index = items.indexOf(document.activeElement);
     let element = null;
 
-    switch(e.key) {
-    case 'ArrowDown':
-      element = items[index+1] || items[0];
-      break;
-    case 'ArrowUp':
-      element = items[index-1] || items[items.length-1];
-      break;
-    case 'Tab':
-      if (e.shiftKey) {
-        element = items[index-1] || items[items.length-1];
-      } else {
-        element = items[index+1] || items[0];
-      }
-      break;
-    case 'Home':
-      element = items[0];
-      break;
-    case 'End':
-      element = items[items.length-1];
-      break;
-    case 'Escape':
-      this.props.onClose();
-      break;
+    switch (e.key) {
+      case 'ArrowDown':
+        element = items[index + 1] || items[0];
+        break;
+      case 'ArrowUp':
+        element = items[index - 1] || items[items.length - 1];
+        break;
+      case 'Tab':
+        if (e.shiftKey) {
+          element = items[index - 1] || items[items.length - 1];
+        } else {
+          element = items[index + 1] || items[0];
+        }
+        break;
+      case 'Home':
+        element = items[0];
+        break;
+      case 'End':
+        element = items[items.length - 1];
+        break;
+      case 'Escape':
+        this.props.onClose();
+        break;
     }
 
     if (element) {
@@ -104,13 +120,13 @@ class DropdownMenu extends PureComponent {
     }
   };
 
-  handleItemKeyPress = e => {
+  handleItemKeyPress = (e) => {
     if (e.key === 'Enter' || e.key === ' ') {
       this.handleClick(e);
     }
   };
 
-  handleClick = e => {
+  handleClick = (e) => {
     const { onItemClick } = this.props;
     onItemClick(e);
   };
@@ -123,24 +139,43 @@ class DropdownMenu extends PureComponent {
     const { text, href = '#', target = '_blank', method, dangerous } = option;
 
     return (
-      <li className={classNames('dropdown-menu__item', { 'dropdown-menu__item--dangerous': dangerous })} key={`${text}-${i}`}>
-        <a href={href} target={target} data-method={method} rel='noopener noreferrer' role='button' tabIndex={0} ref={i === 0 ? this.setFocusRef : null} onClick={this.handleClick} onKeyPress={this.handleItemKeyPress} data-index={i}>
+      <li
+        className={classNames('dropdown-menu__item', {
+          'dropdown-menu__item--dangerous': dangerous,
+        })}
+        key={`${text}-${i}`}
+      >
+        <a
+          href={href}
+          target={target}
+          data-method={method}
+          rel='noopener noreferrer'
+          role='button'
+          tabIndex={0}
+          ref={i === 0 ? this.setFocusRef : null}
+          onClick={this.handleClick}
+          onKeyPress={this.handleItemKeyPress}
+          data-index={i}
+        >
           {text}
         </a>
       </li>
     );
   };
 
-  render () {
+  render() {
     const { items, scrollable, renderHeader, loading } = this.props;
 
     let renderItem = this.props.renderItem || this.renderItem;
 
     return (
-      <div className={classNames('dropdown-menu__container', { 'dropdown-menu__container--loading': loading })} ref={this.setRef}>
-        {loading && (
-          <CircularProgress size={30} strokeWidth={3.5} />
-        )}
+      <div
+        className={classNames('dropdown-menu__container', {
+          'dropdown-menu__container--loading': loading,
+        })}
+        ref={this.setRef}
+      >
+        {loading && <CircularProgress size={30} strokeWidth={3.5} />}
 
         {!loading && renderHeader && (
           <div className='dropdown-menu__container__header'>
@@ -149,18 +184,25 @@ class DropdownMenu extends PureComponent {
         )}
 
         {!loading && (
-          <ul className={classNames('dropdown-menu__container__list', { 'dropdown-menu__container__list--scrollable': scrollable })}>
-            {items.map((option, i) => renderItem(option, i, { onClick: this.handleClick, onKeyPress: this.handleItemKeyPress }))}
+          <ul
+            className={classNames('dropdown-menu__container__list', {
+              'dropdown-menu__container__list--scrollable': scrollable,
+            })}
+          >
+            {items.map((option, i) =>
+              renderItem(option, i, {
+                onClick: this.handleClick,
+                onKeyPress: this.handleItemKeyPress,
+              }),
+            )}
           </ul>
         )}
       </div>
     );
   }
-
 }
 
 export default class Dropdown extends PureComponent {
-
   static contextTypes = {
     router: PropTypes.object,
   };
@@ -168,7 +210,8 @@ export default class Dropdown extends PureComponent {
   static propTypes = {
     children: PropTypes.node,
     icon: PropTypes.string,
-    items: PropTypes.oneOfType([PropTypes.array, ImmutablePropTypes.list]).isRequired,
+    items: PropTypes.oneOfType([PropTypes.array, ImmutablePropTypes.list])
+      .isRequired,
     loading: PropTypes.bool,
     size: PropTypes.number,
     title: PropTypes.string,
@@ -216,26 +259,26 @@ export default class Dropdown extends PureComponent {
   };
 
   handleButtonKeyDown = (e) => {
-    switch(e.key) {
-    case ' ':
-    case 'Enter':
-      this.handleMouseDown();
-      break;
+    switch (e.key) {
+      case ' ':
+      case 'Enter':
+        this.handleMouseDown();
+        break;
     }
   };
 
   handleKeyPress = (e) => {
-    switch(e.key) {
-    case ' ':
-    case 'Enter':
-      this.handleClick(e);
-      e.stopPropagation();
-      e.preventDefault();
-      break;
+    switch (e.key) {
+      case ' ':
+      case 'Enter':
+        this.handleClick(e);
+        e.stopPropagation();
+        e.preventDefault();
+        break;
     }
   };
 
-  handleItemClick = e => {
+  handleItemClick = (e) => {
     const { onItemClick } = this.props;
     const i = Number(e.currentTarget.getAttribute('data-index'));
     const item = this.props.items[i];
@@ -254,7 +297,7 @@ export default class Dropdown extends PureComponent {
     }
   };
 
-  setTargetRef = c => {
+  setTargetRef = (c) => {
     this.target = c;
   };
 
@@ -272,7 +315,7 @@ export default class Dropdown extends PureComponent {
     this.handleClose();
   };
 
-  render () {
+  render() {
     const {
       icon,
       items,
@@ -290,12 +333,14 @@ export default class Dropdown extends PureComponent {
 
     const open = this.state.id === openDropdownId;
 
-    const button = children ? cloneElement(Children.only(children), {
-      onClick: this.handleClick,
-      onMouseDown: this.handleMouseDown,
-      onKeyDown: this.handleButtonKeyDown,
-      onKeyPress: this.handleKeyPress,
-    }) : (
+    const button = children ? (
+      cloneElement(Children.only(children), {
+        onClick: this.handleClick,
+        onMouseDown: this.handleMouseDown,
+        onKeyDown: this.handleButtonKeyDown,
+        onKeyPress: this.handleKeyPress,
+      })
+    ) : (
       <IconButton
         icon={!open ? icon : 'close'}
         title={title}
@@ -311,14 +356,22 @@ export default class Dropdown extends PureComponent {
 
     return (
       <>
-        <span ref={this.setTargetRef}>
-          {button}
-        </span>
-        <Overlay show={open} offset={[5, 5]} placement={'bottom'} flip target={this.findTarget} popperConfig={{ strategy: 'fixed' }}>
+        <span ref={this.setTargetRef}>{button}</span>
+        <Overlay
+          show={open}
+          offset={[5, 5]}
+          placement={'bottom'}
+          flip
+          target={this.findTarget}
+          popperConfig={{ strategy: 'fixed' }}
+        >
           {({ props, arrowProps, placement }) => (
             <div {...props}>
               <div className={`dropdown-animation dropdown-menu ${placement}`}>
-                <div className={`dropdown-menu__arrow ${placement}`} {...arrowProps} />
+                <div
+                  className={`dropdown-menu__arrow ${placement}`}
+                  {...arrowProps}
+                />
                 <DropdownMenu
                   items={items}
                   loading={loading}
@@ -336,5 +389,4 @@ export default class Dropdown extends PureComponent {
       </>
     );
   }
-
 }

--- a/app/javascript/mastodon/components/edited_timestamp/containers/dropdown_menu_container.js
+++ b/app/javascript/mastodon/components/edited_timestamp/containers/dropdown_menu_container.js
@@ -1,6 +1,9 @@
 import { connect } from 'react-redux';
 
-import { openDropdownMenu, closeDropdownMenu } from 'mastodon/actions/dropdown_menu';
+import {
+  openDropdownMenu,
+  closeDropdownMenu,
+} from 'mastodon/actions/dropdown_menu';
 import { fetchHistory } from 'mastodon/actions/history';
 import DropdownMenu from 'mastodon/components/dropdown_menu';
 
@@ -12,16 +15,14 @@ const mapStateToProps = (state, { statusId }) => ({
 });
 
 const mapDispatchToProps = (dispatch, { statusId }) => ({
-
-  onOpen (id, onItemClick, keyboard) {
+  onOpen(id, onItemClick, keyboard) {
     dispatch(fetchHistory(statusId));
     dispatch(openDropdownMenu(id, keyboard));
   },
 
-  onClose (id) {
+  onClose(id) {
     dispatch(closeDropdownMenu(id));
   },
-
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(DropdownMenu);

--- a/app/javascript/mastodon/components/edited_timestamp/index.jsx
+++ b/app/javascript/mastodon/components/edited_timestamp/index.jsx
@@ -6,25 +6,24 @@ import { FormattedMessage, injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 
 import { openModal } from 'mastodon/actions/modal';
-import { Icon }  from 'mastodon/components/icon';
+import { Icon } from 'mastodon/components/icon';
 import InlineAccount from 'mastodon/components/inline_account';
 import { RelativeTimestamp } from 'mastodon/components/relative_timestamp';
 
 import DropdownMenu from './containers/dropdown_menu_container';
 
 const mapDispatchToProps = (dispatch, { statusId }) => ({
-
-  onItemClick (index) {
-    dispatch(openModal({
-      modalType: 'COMPARE_HISTORY',
-      modalProps: { index, statusId },
-    }));
+  onItemClick(index) {
+    dispatch(
+      openModal({
+        modalType: 'COMPARE_HISTORY',
+        modalProps: { index, statusId },
+      }),
+    );
   },
-
 });
 
 class EditedTimestamp extends PureComponent {
-
   static propTypes = {
     statusId: PropTypes.string.isRequired,
     timestamp: PropTypes.string.isRequired,
@@ -37,41 +36,78 @@ class EditedTimestamp extends PureComponent {
     onItemClick(i);
   };
 
-  renderHeader = items => {
+  renderHeader = (items) => {
     return (
-      <FormattedMessage id='status.edited_x_times' defaultMessage='Edited {count, plural, one {# time} other {# times}}' values={{ count: items.size - 1 }} />
+      <FormattedMessage
+        id='status.edited_x_times'
+        defaultMessage='Edited {count, plural, one {# time} other {# times}}'
+        values={{ count: items.size - 1 }}
+      />
     );
   };
 
   renderItem = (item, index, { onClick, onKeyPress }) => {
-    const formattedDate = <RelativeTimestamp timestamp={item.get('created_at')} short={false} />;
+    const formattedDate = (
+      <RelativeTimestamp timestamp={item.get('created_at')} short={false} />
+    );
     const formattedName = <InlineAccount accountId={item.get('account')} />;
 
     const label = item.get('original') ? (
-      <FormattedMessage id='status.history.created' defaultMessage='{name} created {date}' values={{ name: formattedName, date: formattedDate }} />
+      <FormattedMessage
+        id='status.history.created'
+        defaultMessage='{name} created {date}'
+        values={{ name: formattedName, date: formattedDate }}
+      />
     ) : (
-      <FormattedMessage id='status.history.edited' defaultMessage='{name} edited {date}' values={{ name: formattedName, date: formattedDate }} />
+      <FormattedMessage
+        id='status.history.edited'
+        defaultMessage='{name} edited {date}'
+        values={{ name: formattedName, date: formattedDate }}
+      />
     );
 
     return (
-      <li className='dropdown-menu__item edited-timestamp__history__item' key={item.get('created_at')}>
-        <button data-index={index} onClick={onClick} onKeyPress={onKeyPress}>{label}</button>
+      <li
+        className='dropdown-menu__item edited-timestamp__history__item'
+        key={item.get('created_at')}
+      >
+        <button data-index={index} onClick={onClick} onKeyPress={onKeyPress}>
+          {label}
+        </button>
       </li>
     );
   };
 
-  render () {
+  render() {
     const { timestamp, intl, statusId } = this.props;
 
     return (
-      <DropdownMenu statusId={statusId} renderItem={this.renderItem} scrollable renderHeader={this.renderHeader} onItemClick={this.handleItemClick}>
+      <DropdownMenu
+        statusId={statusId}
+        renderItem={this.renderItem}
+        scrollable
+        renderHeader={this.renderHeader}
+        onItemClick={this.handleItemClick}
+      >
         <button className='dropdown-menu__text-button'>
-          <FormattedMessage id='status.edited' defaultMessage='Edited {date}' values={{ date: intl.formatDate(timestamp, { hour12: false, month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit' }) }} /> <Icon id='caret-down' />
+          <FormattedMessage
+            id='status.edited'
+            defaultMessage='Edited {date}'
+            values={{
+              date: intl.formatDate(timestamp, {
+                hour12: false,
+                month: 'short',
+                day: '2-digit',
+                hour: '2-digit',
+                minute: '2-digit',
+              }),
+            }}
+          />{' '}
+          <Icon id='caret-down' />
         </button>
       </DropdownMenu>
     );
   }
-
 }
 
 export default connect(null, mapDispatchToProps)(injectIntl(EditedTimestamp));

--- a/app/javascript/mastodon/components/error_boundary.jsx
+++ b/app/javascript/mastodon/components/error_boundary.jsx
@@ -10,7 +10,6 @@ import StackTrace from 'stacktrace-js';
 import { version, source_url } from 'mastodon/initial_state';
 
 export default class ErrorBoundary extends PureComponent {
-
   static propTypes = {
     children: PropTypes.node,
   };
@@ -23,7 +22,7 @@ export default class ErrorBoundary extends PureComponent {
     componentStack: undefined,
   };
 
-  componentDidCatch (error, info) {
+  componentDidCatch(error, info) {
     this.setState({
       hasError: true,
       errorMessage: error.toString(),
@@ -32,15 +31,17 @@ export default class ErrorBoundary extends PureComponent {
       mappedStackTrace: undefined,
     });
 
-    StackTrace.fromError(error).then((stackframes) => {
-      this.setState({
-        mappedStackTrace: stackframes.map((sf) => sf.toString()).join('\n'),
+    StackTrace.fromError(error)
+      .then((stackframes) => {
+        this.setState({
+          mappedStackTrace: stackframes.map((sf) => sf.toString()).join('\n'),
+        });
+      })
+      .catch(() => {
+        this.setState({
+          mappedStackTrace: undefined,
+        });
       });
-    }).catch(() => {
-      this.setState({
-        mappedStackTrace: undefined,
-      });
-    });
   }
 
   handleCopyStackTrace = () => {
@@ -52,7 +53,7 @@ export default class ErrorBoundary extends PureComponent {
       contents.push(mappedStackTrace);
     }
 
-    textarea.textContent    = contents.join('\n\n\n');
+    textarea.textContent = contents.join('\n\n\n');
     textarea.style.position = 'fixed';
 
     document.body.appendChild(textarea);
@@ -61,7 +62,6 @@ export default class ErrorBoundary extends PureComponent {
       textarea.select();
       document.execCommand('copy');
     } catch (e) {
-
     } finally {
       document.body.removeChild(textarea);
     }
@@ -77,28 +77,59 @@ export default class ErrorBoundary extends PureComponent {
       return this.props.children;
     }
 
-    const likelyBrowserAddonIssue = errorMessage && errorMessage.includes('NotFoundError');
+    const likelyBrowserAddonIssue =
+      errorMessage && errorMessage.includes('NotFoundError');
 
     return (
       <div className='error-boundary'>
         <div>
           <p className='error-boundary__error'>
-            { likelyBrowserAddonIssue ? (
-              <FormattedMessage id='error.unexpected_crash.explanation_addons' defaultMessage='This page could not be displayed correctly. This error is likely caused by a browser add-on or automatic translation tools.' />
+            {likelyBrowserAddonIssue ? (
+              <FormattedMessage
+                id='error.unexpected_crash.explanation_addons'
+                defaultMessage='This page could not be displayed correctly. This error is likely caused by a browser add-on or automatic translation tools.'
+              />
             ) : (
-              <FormattedMessage id='error.unexpected_crash.explanation' defaultMessage='Due to a bug in our code or a browser compatibility issue, this page could not be displayed correctly.' />
+              <FormattedMessage
+                id='error.unexpected_crash.explanation'
+                defaultMessage='Due to a bug in our code or a browser compatibility issue, this page could not be displayed correctly.'
+              />
             )}
           </p>
 
           <p>
-            { likelyBrowserAddonIssue ? (
-              <FormattedMessage id='error.unexpected_crash.next_steps_addons' defaultMessage='Try disabling them and refreshing the page. If that does not help, you may still be able to use Mastodon through a different browser or native app.' />
+            {likelyBrowserAddonIssue ? (
+              <FormattedMessage
+                id='error.unexpected_crash.next_steps_addons'
+                defaultMessage='Try disabling them and refreshing the page. If that does not help, you may still be able to use Mastodon through a different browser or native app.'
+              />
             ) : (
-              <FormattedMessage id='error.unexpected_crash.next_steps' defaultMessage='Try refreshing the page. If that does not help, you may still be able to use Mastodon through a different browser or native app.' />
+              <FormattedMessage
+                id='error.unexpected_crash.next_steps'
+                defaultMessage='Try refreshing the page. If that does not help, you may still be able to use Mastodon through a different browser or native app.'
+              />
             )}
           </p>
 
-          <p className='error-boundary__footer'>Mastodon v{version} · <a href={source_url} rel='noopener noreferrer' target='_blank'><FormattedMessage id='errors.unexpected_crash.report_issue' defaultMessage='Report issue' /></a> · <button onClick={this.handleCopyStackTrace} className={copied ? 'copied' : ''}><FormattedMessage id='errors.unexpected_crash.copy_stacktrace' defaultMessage='Copy stacktrace to clipboard' /></button></p>
+          <p className='error-boundary__footer'>
+            Mastodon v{version} ·{' '}
+            <a href={source_url} rel='noopener noreferrer' target='_blank'>
+              <FormattedMessage
+                id='errors.unexpected_crash.report_issue'
+                defaultMessage='Report issue'
+              />
+            </a>{' '}
+            ·{' '}
+            <button
+              onClick={this.handleCopyStackTrace}
+              className={copied ? 'copied' : ''}
+            >
+              <FormattedMessage
+                id='errors.unexpected_crash.copy_stacktrace'
+                defaultMessage='Copy stacktrace to clipboard'
+              />
+            </button>
+          </p>
         </div>
 
         <Helmet>
@@ -107,5 +138,4 @@ export default class ErrorBoundary extends PureComponent {
       </div>
     );
   }
-
 }

--- a/app/javascript/mastodon/components/hashtag.jsx
+++ b/app/javascript/mastodon/components/hashtag.jsx
@@ -61,10 +61,10 @@ export const ImmutableHashtag = ({ hashtag }) => (
       hashtag.getIn(['history', 0, 'accounts']) * 1 +
       hashtag.getIn(['history', 1, 'accounts']) * 1
     }
-    // @ts-expect-error
     history={hashtag
       .get('history')
       .reverse()
+      // @ts-expect-error
       .map((day) => day.get('uses'))
       .toArray()}
   />
@@ -74,15 +74,22 @@ ImmutableHashtag.propTypes = {
   hashtag: ImmutablePropTypes.map.isRequired,
 };
 
-// @ts-expect-error
 const Hashtag = ({
+  // @ts-expect-error
   name,
+  // @ts-expect-error
   to,
+  // @ts-expect-error
   people,
+  // @ts-expect-error
   uses,
+  // @ts-expect-error
   history,
+  // @ts-expect-error
   className,
+  // @ts-expect-error
   description,
+  // @ts-expect-error
   withGraph,
 }) => (
   <div className={classNames('trends__item', className)}>

--- a/app/javascript/mastodon/components/hashtag.jsx
+++ b/app/javascript/mastodon/components/hashtag.jsx
@@ -15,7 +15,6 @@ import { ShortNumber } from 'mastodon/components/short_number';
 import { Skeleton } from 'mastodon/components/skeleton';
 
 class SilentErrorBoundary extends Component {
-
   static propTypes = {
     children: PropTypes.node,
   };
@@ -35,7 +34,6 @@ class SilentErrorBoundary extends Component {
 
     return this.props.children;
   }
-
 }
 
 /**
@@ -59,9 +57,16 @@ export const ImmutableHashtag = ({ hashtag }) => (
   <Hashtag
     name={hashtag.get('name')}
     to={`/tags/${hashtag.get('name')}`}
-    people={hashtag.getIn(['history', 0, 'accounts']) * 1 + hashtag.getIn(['history', 1, 'accounts']) * 1}
+    people={
+      hashtag.getIn(['history', 0, 'accounts']) * 1 +
+      hashtag.getIn(['history', 1, 'accounts']) * 1
+    }
     // @ts-expect-error
-    history={hashtag.get('history').reverse().map((day) => day.get('uses')).toArray()}
+    history={hashtag
+      .get('history')
+      .reverse()
+      .map((day) => day.get('uses'))
+      .toArray()}
   />
 );
 
@@ -70,17 +75,34 @@ ImmutableHashtag.propTypes = {
 };
 
 // @ts-expect-error
-const Hashtag = ({ name, to, people, uses, history, className, description, withGraph }) => (
+const Hashtag = ({
+  name,
+  to,
+  people,
+  uses,
+  history,
+  className,
+  description,
+  withGraph,
+}) => (
   <div className={classNames('trends__item', className)}>
     <div className='trends__item__name'>
       <Link to={to}>
-        {name ? <>#<span>{name}</span></> : <Skeleton width={50} />}
+        {name ? (
+          <>
+            #<span>{name}</span>
+          </>
+        ) : (
+          <Skeleton width={50} />
+        )}
       </Link>
 
       {description ? (
         <span>{description}</span>
+      ) : typeof people !== 'undefined' ? (
+        <ShortNumber value={people} renderer={accountsCountRenderer} />
       ) : (
-        typeof people !== 'undefined' ? <ShortNumber value={people} renderer={accountsCountRenderer} /> : <Skeleton width={100} />
+        <Skeleton width={100} />
       )}
     </div>
 
@@ -93,7 +115,11 @@ const Hashtag = ({ name, to, people, uses, history, className, description, with
     {withGraph && (
       <div className='trends__item__sparkline'>
         <SilentErrorBoundary>
-          <Sparklines width={50} height={28} data={history ? history : Array.from(Array(7)).map(() => 0)}>
+          <Sparklines
+            width={50}
+            height={28}
+            data={history ? history : Array.from(Array(7)).map(() => 0)}
+          >
             <SparklinesCurve style={{ fill: 'none' }} />
           </Sparklines>
         </SilentErrorBoundary>

--- a/app/javascript/mastodon/components/inline_account.jsx
+++ b/app/javascript/mastodon/components/inline_account.jsx
@@ -17,21 +17,20 @@ const makeMapStateToProps = () => {
 };
 
 class InlineAccount extends PureComponent {
-
   static propTypes = {
     account: ImmutablePropTypes.map.isRequired,
   };
 
-  render () {
+  render() {
     const { account } = this.props;
 
     return (
       <span className='inline-account'>
-        <Avatar size={13} account={account} /> <strong>{account.get('username')}</strong>
+        <Avatar size={13} account={account} />{' '}
+        <strong>{account.get('username')}</strong>
       </span>
     );
   }
-
 }
 
 export default connect(makeMapStateToProps)(InlineAccount);

--- a/app/javascript/mastodon/components/intersection_observer_article.jsx
+++ b/app/javascript/mastodon/components/intersection_observer_article.jsx
@@ -5,10 +5,14 @@ import getRectFromEntry from '../features/ui/util/get_rect_from_entry';
 import scheduleIdleTask from '../features/ui/util/schedule_idle_task';
 
 // Diff these props in the "unrendered" state
-const updateOnPropsForUnrendered = ['id', 'index', 'listLength', 'cachedHeight'];
+const updateOnPropsForUnrendered = [
+  'id',
+  'index',
+  'listLength',
+  'cachedHeight',
+];
 
 export default class IntersectionObserverArticle extends Component {
-
   static propTypes = {
     intersectionObserverWrapper: PropTypes.object.isRequired,
     id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
@@ -24,34 +28,36 @@ export default class IntersectionObserverArticle extends Component {
     isHidden: false, // set to true in requestIdleCallback to trigger un-render
   };
 
-  shouldComponentUpdate (nextProps, nextState) {
-    const isUnrendered = !this.state.isIntersecting && (this.state.isHidden || this.props.cachedHeight);
-    const willBeUnrendered = !nextState.isIntersecting && (nextState.isHidden || nextProps.cachedHeight);
+  shouldComponentUpdate(nextProps, nextState) {
+    const isUnrendered =
+      !this.state.isIntersecting &&
+      (this.state.isHidden || this.props.cachedHeight);
+    const willBeUnrendered =
+      !nextState.isIntersecting &&
+      (nextState.isHidden || nextProps.cachedHeight);
     if (!!isUnrendered !== !!willBeUnrendered) {
       // If we're going from rendered to unrendered (or vice versa) then update
       return true;
     }
     // If we are and remain hidden, diff based on props
     if (isUnrendered) {
-      return !updateOnPropsForUnrendered.every(prop => nextProps[prop] === this.props[prop]);
+      return !updateOnPropsForUnrendered.every(
+        (prop) => nextProps[prop] === this.props[prop],
+      );
     }
     // Else, assume the children have changed
     return true;
   }
 
-  componentDidMount () {
+  componentDidMount() {
     const { intersectionObserverWrapper, id } = this.props;
 
-    intersectionObserverWrapper.observe(
-      id,
-      this.node,
-      this.handleIntersection,
-    );
+    intersectionObserverWrapper.observe(id, this.node, this.handleIntersection);
 
     this.componentMounted = true;
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     const { intersectionObserverWrapper, id } = this.props;
     intersectionObserverWrapper.unobserve(id, this.node);
 
@@ -102,7 +108,7 @@ export default class IntersectionObserverArticle extends Component {
     this.node = node;
   };
 
-  render () {
+  render() {
     const { children, id, index, listLength, cachedHeight } = this.props;
     const { isIntersecting, isHidden } = this.state;
 
@@ -112,7 +118,11 @@ export default class IntersectionObserverArticle extends Component {
           ref={this.handleRef}
           aria-posinset={index + 1}
           aria-setsize={listLength}
-          style={{ height: `${this.height || cachedHeight}px`, opacity: 0, overflow: 'hidden' }}
+          style={{
+            height: `${this.height || cachedHeight}px`,
+            opacity: 0,
+            overflow: 'hidden',
+          }}
           data-id={id}
           tabIndex={-1}
         >
@@ -122,10 +132,15 @@ export default class IntersectionObserverArticle extends Component {
     }
 
     return (
-      <article ref={this.handleRef} aria-posinset={index + 1} aria-setsize={listLength} data-id={id} tabIndex={-1}>
+      <article
+        ref={this.handleRef}
+        aria-posinset={index + 1}
+        aria-setsize={listLength}
+        data-id={id}
+        tabIndex={-1}
+      >
         {children && cloneElement(children, { hidden: false })}
       </article>
     );
   }
-
 }

--- a/app/javascript/mastodon/components/media_attachments.jsx
+++ b/app/javascript/mastodon/components/media_attachments.jsx
@@ -6,10 +6,13 @@ import ImmutablePureComponent from 'react-immutable-pure-component';
 import noop from 'lodash/noop';
 
 import Bundle from 'mastodon/features/ui/components/bundle';
-import { MediaGallery, Video, Audio } from 'mastodon/features/ui/util/async-components';
+import {
+  MediaGallery,
+  Video,
+  Audio,
+} from 'mastodon/features/ui/util/async-components';
 
 export default class MediaAttachments extends ImmutablePureComponent {
-
   static propTypes = {
     status: ImmutablePropTypes.map.isRequired,
     lang: PropTypes.string,
@@ -22,38 +25,33 @@ export default class MediaAttachments extends ImmutablePureComponent {
     width: 239,
   };
 
-  updateOnProps = [
-    'status',
-  ];
+  updateOnProps = ['status'];
 
   renderLoadingMediaGallery = () => {
     const { height, width } = this.props;
 
-    return (
-      <div className='media-gallery' style={{ height, width }} />
-    );
+    return <div className='media-gallery' style={{ height, width }} />;
   };
 
   renderLoadingVideoPlayer = () => {
     const { height, width } = this.props;
 
-    return (
-      <div className='video-player' style={{ height, width }} />
-    );
+    return <div className='video-player' style={{ height, width }} />;
   };
 
   renderLoadingAudioPlayer = () => {
     const { height, width } = this.props;
 
-    return (
-      <div className='audio-player' style={{ height, width }} />
-    );
+    return <div className='audio-player' style={{ height, width }} />;
   };
 
-  render () {
+  render() {
     const { status, width, height } = this.props;
     const mediaAttachments = status.get('media_attachments');
-    const language = status.getIn(['language', 'translation']) || status.get('language') || this.props.lang;
+    const language =
+      status.getIn(['language', 'translation']) ||
+      status.get('language') ||
+      this.props.lang;
 
     if (mediaAttachments.size === 0) {
       return null;
@@ -61,18 +59,22 @@ export default class MediaAttachments extends ImmutablePureComponent {
 
     if (mediaAttachments.getIn([0, 'type']) === 'audio') {
       const audio = mediaAttachments.get(0);
-      const description = audio.getIn(['translation', 'description']) || audio.get('description');
+      const description =
+        audio.getIn(['translation', 'description']) || audio.get('description');
 
       return (
-        <Bundle fetchComponent={Audio} loading={this.renderLoadingAudioPlayer} >
-          {Component => (
+        <Bundle fetchComponent={Audio} loading={this.renderLoadingAudioPlayer}>
+          {(Component) => (
             <Component
               src={audio.get('url')}
               alt={description}
               lang={language}
               width={width}
               height={height}
-              poster={audio.get('preview_url') || status.getIn(['account', 'avatar_static'])}
+              poster={
+                audio.get('preview_url') ||
+                status.getIn(['account', 'avatar_static'])
+              }
               backgroundColor={audio.getIn(['meta', 'colors', 'background'])}
               foregroundColor={audio.getIn(['meta', 'colors', 'foreground'])}
               accentColor={audio.getIn(['meta', 'colors', 'accent'])}
@@ -83,11 +85,12 @@ export default class MediaAttachments extends ImmutablePureComponent {
       );
     } else if (mediaAttachments.getIn([0, 'type']) === 'video') {
       const video = mediaAttachments.get(0);
-      const description = video.getIn(['translation', 'description']) || video.get('description');
+      const description =
+        video.getIn(['translation', 'description']) || video.get('description');
 
       return (
-        <Bundle fetchComponent={Video} loading={this.renderLoadingVideoPlayer} >
-          {Component => (
+        <Bundle fetchComponent={Video} loading={this.renderLoadingVideoPlayer}>
+          {(Component) => (
             <Component
               preview={video.get('preview_url')}
               frameRate={video.getIn(['meta', 'original', 'frame_rate'])}
@@ -106,8 +109,11 @@ export default class MediaAttachments extends ImmutablePureComponent {
       );
     } else {
       return (
-        <Bundle fetchComponent={MediaGallery} loading={this.renderLoadingMediaGallery} >
-          {Component => (
+        <Bundle
+          fetchComponent={MediaGallery}
+          loading={this.renderLoadingMediaGallery}
+        >
+          {(Component) => (
             <Component
               media={mediaAttachments}
               lang={language}
@@ -121,5 +127,4 @@ export default class MediaAttachments extends ImmutablePureComponent {
       );
     }
   }
-
 }

--- a/app/javascript/mastodon/components/media_gallery.jsx
+++ b/app/javascript/mastodon/components/media_gallery.jsx
@@ -17,11 +17,13 @@ import { autoPlayGif, displayMedia, useBlurhash } from '../initial_state';
 import { IconButton } from './icon_button';
 
 const messages = defineMessages({
-  toggle_visible: { id: 'media_gallery.toggle_visible', defaultMessage: '{number, plural, one {Hide image} other {Hide images}}' },
+  toggle_visible: {
+    id: 'media_gallery.toggle_visible',
+    defaultMessage: '{number, plural, one {Hide image} other {Hide images}}',
+  },
 });
 
 class Item extends PureComponent {
-
   static propTypes = {
     attachment: ImmutablePropTypes.map.isRequired,
     lang: PropTypes.string,
@@ -61,7 +63,7 @@ class Item extends PureComponent {
     return this.props.autoplay || autoPlayGif;
   }
 
-  hoverToPlay () {
+  hoverToPlay() {
     const { attachment } = this.props;
     return !this.getAutoPlay() && attachment.get('type') === 'gifv';
   }
@@ -85,12 +87,14 @@ class Item extends PureComponent {
     this.setState({ loaded: true });
   };
 
-  render () {
-    const { attachment, lang, index, size, standalone, displayWidth, visible } = this.props;
+  render() {
+    const { attachment, lang, index, size, standalone, displayWidth, visible } =
+      this.props;
 
-    let badges = [], thumbnail;
+    let badges = [],
+      thumbnail;
 
-    let width  = 50;
+    let width = 50;
     let height = 100;
 
     if (size === 1) {
@@ -102,15 +106,36 @@ class Item extends PureComponent {
     }
 
     if (attachment.get('description')?.length > 0) {
-      badges.push(<span key='alt' className='media-gallery__gifv__label'>ALT</span>);
+      badges.push(
+        <span key='alt' className='media-gallery__gifv__label'>
+          ALT
+        </span>,
+      );
     }
 
-    const description = attachment.getIn(['translation', 'description']) || attachment.get('description');
+    const description =
+      attachment.getIn(['translation', 'description']) ||
+      attachment.get('description');
 
     if (attachment.get('type') === 'unknown') {
       return (
-        <div className={classNames('media-gallery__item', { standalone, 'media-gallery__item--tall': height === 100, 'media-gallery__item--wide': width === 100 })} key={attachment.get('id')}>
-          <a className='media-gallery__item-thumbnail' href={attachment.get('remote_url') || attachment.get('url')} style={{ cursor: 'pointer' }} title={description} lang={lang} target='_blank' rel='noopener noreferrer'>
+        <div
+          className={classNames('media-gallery__item', {
+            standalone,
+            'media-gallery__item--tall': height === 100,
+            'media-gallery__item--wide': width === 100,
+          })}
+          key={attachment.get('id')}
+        >
+          <a
+            className='media-gallery__item-thumbnail'
+            href={attachment.get('remote_url') || attachment.get('url')}
+            style={{ cursor: 'pointer' }}
+            title={description}
+            lang={lang}
+            target='_blank'
+            rel='noopener noreferrer'
+          >
             <Blurhash
               hash={attachment.get('blurhash')}
               className='media-gallery__preview'
@@ -120,21 +145,27 @@ class Item extends PureComponent {
         </div>
       );
     } else if (attachment.get('type') === 'image') {
-      const previewUrl   = attachment.get('preview_url');
+      const previewUrl = attachment.get('preview_url');
       const previewWidth = attachment.getIn(['meta', 'small', 'width']);
 
-      const originalUrl   = attachment.get('url');
+      const originalUrl = attachment.get('url');
       const originalWidth = attachment.getIn(['meta', 'original', 'width']);
 
-      const hasSize = typeof originalWidth === 'number' && typeof previewWidth === 'number';
+      const hasSize =
+        typeof originalWidth === 'number' && typeof previewWidth === 'number';
 
-      const srcSet = hasSize ? `${originalUrl} ${originalWidth}w, ${previewUrl} ${previewWidth}w` : null;
-      const sizes  = hasSize && (displayWidth > 0) ? `${displayWidth * (width / 100)}px` : null;
+      const srcSet = hasSize
+        ? `${originalUrl} ${originalWidth}w, ${previewUrl} ${previewWidth}w`
+        : null;
+      const sizes =
+        hasSize && displayWidth > 0
+          ? `${displayWidth * (width / 100)}px`
+          : null;
 
       const focusX = attachment.getIn(['meta', 'focus', 'x']) || 0;
       const focusY = attachment.getIn(['meta', 'focus', 'y']) || 0;
-      const x      = ((focusX /  2) + .5) * 100;
-      const y      = ((focusY / -2) + .5) * 100;
+      const x = (focusX / 2 + 0.5) * 100;
+      const y = (focusY / -2 + 0.5) * 100;
 
       thumbnail = (
         <a
@@ -159,10 +190,16 @@ class Item extends PureComponent {
     } else if (attachment.get('type') === 'gifv') {
       const autoPlay = this.getAutoPlay();
 
-      badges.push(<span key='gif' className='media-gallery__gifv__label'>GIF</span>);
+      badges.push(
+        <span key='gif' className='media-gallery__gifv__label'>
+          GIF
+        </span>,
+      );
 
       thumbnail = (
-        <div className={classNames('media-gallery__gifv', { autoplay: autoPlay })}>
+        <div
+          className={classNames('media-gallery__gifv', { autoplay: autoPlay })}
+        >
           <video
             className='media-gallery__item-gifv-thumbnail'
             aria-label={description}
@@ -183,7 +220,14 @@ class Item extends PureComponent {
     }
 
     return (
-      <div className={classNames('media-gallery__item', { standalone, 'media-gallery__item--tall': height === 100, 'media-gallery__item--wide': width === 100 })} key={attachment.get('id')}>
+      <div
+        className={classNames('media-gallery__item', {
+          standalone,
+          'media-gallery__item--tall': height === 100,
+          'media-gallery__item--wide': width === 100,
+        })}
+        key={attachment.get('id')}
+      >
         <Blurhash
           hash={attachment.get('blurhash')}
           dummy={!useBlurhash}
@@ -194,19 +238,13 @@ class Item extends PureComponent {
 
         {visible && thumbnail}
 
-        {badges && (
-          <div className='media-gallery__item__badges'>
-            {badges}
-          </div>
-        )}
+        {badges && <div className='media-gallery__item__badges'>{badges}</div>}
       </div>
     );
   }
-
 }
 
 class MediaGallery extends PureComponent {
-
   static propTypes = {
     sensitive: PropTypes.bool,
     media: ImmutablePropTypes.list.isRequired,
@@ -223,33 +261,51 @@ class MediaGallery extends PureComponent {
   };
 
   state = {
-    visible: this.props.visible !== undefined ? this.props.visible : (displayMedia !== 'hide_all' && !this.props.sensitive || displayMedia === 'show_all'),
+    visible:
+      this.props.visible !== undefined
+        ? this.props.visible
+        : (displayMedia !== 'hide_all' && !this.props.sensitive) ||
+          displayMedia === 'show_all',
     width: this.props.defaultWidth,
   };
 
-  componentDidMount () {
+  componentDidMount() {
     window.addEventListener('resize', this.handleResize, { passive: true });
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     window.removeEventListener('resize', this.handleResize);
   }
 
-  UNSAFE_componentWillReceiveProps (nextProps) {
-    if (!is(nextProps.media, this.props.media) && nextProps.visible === undefined) {
-      this.setState({ visible: displayMedia !== 'hide_all' && !nextProps.sensitive || displayMedia === 'show_all' });
-    } else if (!is(nextProps.visible, this.props.visible) && nextProps.visible !== undefined) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    if (
+      !is(nextProps.media, this.props.media) &&
+      nextProps.visible === undefined
+    ) {
+      this.setState({
+        visible:
+          (displayMedia !== 'hide_all' && !nextProps.sensitive) ||
+          displayMedia === 'show_all',
+      });
+    } else if (
+      !is(nextProps.visible, this.props.visible) &&
+      nextProps.visible !== undefined
+    ) {
       this.setState({ visible: nextProps.visible });
     }
   }
 
-  handleResize = debounce(() => {
-    if (this.node) {
-      this._setDimensions();
-    }
-  }, 250, {
-    trailing: true,
-  });
+  handleResize = debounce(
+    () => {
+      if (this.node) {
+        this._setDimensions();
+      }
+    },
+    250,
+    {
+      trailing: true,
+    },
+  );
 
   handleOpen = () => {
     if (this.props.onToggleVisibility) {
@@ -263,7 +319,7 @@ class MediaGallery extends PureComponent {
     this.props.onOpenMedia(this.props.media, index, this.props.lang);
   };
 
-  handleRef = c => {
+  handleRef = (c) => {
     this.node = c;
 
     if (this.node) {
@@ -271,7 +327,7 @@ class MediaGallery extends PureComponent {
     }
   };
 
-  _setDimensions () {
+  _setDimensions() {
     const width = this.node.offsetWidth;
 
     // offsetWidth triggers a layout, so only calculate when we need to
@@ -289,7 +345,7 @@ class MediaGallery extends PureComponent {
     return media.size === 1 && media.getIn([0, 'meta', 'small', 'aspect']);
   }
 
-  render () {
+  render() {
     const { media, lang, intl, sensitive, defaultWidth, autoplay } = this.props;
     const { visible } = this.state;
     const width = this.state.width || defaultWidth;
@@ -299,37 +355,103 @@ class MediaGallery extends PureComponent {
     const style = {};
 
     if (this.isFullSizeEligible()) {
-      style.aspectRatio = `${this.props.media.getIn([0, 'meta', 'small', 'aspect'])}`;
+      style.aspectRatio = `${this.props.media.getIn([
+        0,
+        'meta',
+        'small',
+        'aspect',
+      ])}`;
     } else {
       style.aspectRatio = '3 / 2';
     }
 
-    const size     = media.take(4).size;
-    const uncached = media.every(attachment => attachment.get('type') === 'unknown');
+    const size = media.take(4).size;
+    const uncached = media.every(
+      (attachment) => attachment.get('type') === 'unknown',
+    );
 
     if (this.isFullSizeEligible()) {
-      children = <Item standalone autoplay={autoplay} onClick={this.handleClick} attachment={media.get(0)} lang={lang} displayWidth={width} visible={visible} />;
+      children = (
+        <Item
+          standalone
+          autoplay={autoplay}
+          onClick={this.handleClick}
+          attachment={media.get(0)}
+          lang={lang}
+          displayWidth={width}
+          visible={visible}
+        />
+      );
     } else {
-      children = media.take(4).map((attachment, i) => <Item key={attachment.get('id')} autoplay={autoplay} onClick={this.handleClick} attachment={attachment} index={i} lang={lang} size={size} displayWidth={width} visible={visible || uncached} />);
+      children = media
+        .take(4)
+        .map((attachment, i) => (
+          <Item
+            key={attachment.get('id')}
+            autoplay={autoplay}
+            onClick={this.handleClick}
+            attachment={attachment}
+            index={i}
+            lang={lang}
+            size={size}
+            displayWidth={width}
+            visible={visible || uncached}
+          />
+        ));
     }
 
     if (uncached) {
       spoilerButton = (
         <button type='button' disabled className='spoiler-button__overlay'>
           <span className='spoiler-button__overlay__label'>
-            <FormattedMessage id='status.uncached_media_warning' defaultMessage='Preview not available' />
-            <span className='spoiler-button__overlay__action'><FormattedMessage id='status.media.open' defaultMessage='Click to open' /></span>
+            <FormattedMessage
+              id='status.uncached_media_warning'
+              defaultMessage='Preview not available'
+            />
+            <span className='spoiler-button__overlay__action'>
+              <FormattedMessage
+                id='status.media.open'
+                defaultMessage='Click to open'
+              />
+            </span>
           </span>
         </button>
       );
     } else if (visible) {
-      spoilerButton = <IconButton title={intl.formatMessage(messages.toggle_visible, { number: size })} icon='eye-slash' overlay onClick={this.handleOpen} ariaHidden />;
+      spoilerButton = (
+        <IconButton
+          title={intl.formatMessage(messages.toggle_visible, { number: size })}
+          icon='eye-slash'
+          overlay
+          onClick={this.handleOpen}
+          ariaHidden
+        />
+      );
     } else {
       spoilerButton = (
-        <button type='button' onClick={this.handleOpen} className='spoiler-button__overlay'>
+        <button
+          type='button'
+          onClick={this.handleOpen}
+          className='spoiler-button__overlay'
+        >
           <span className='spoiler-button__overlay__label'>
-            {sensitive ? <FormattedMessage id='status.sensitive_warning' defaultMessage='Sensitive content' /> : <FormattedMessage id='status.media_hidden' defaultMessage='Media hidden' />}
-            <span className='spoiler-button__overlay__action'><FormattedMessage id='status.media.show' defaultMessage='Click to show' /></span>
+            {sensitive ? (
+              <FormattedMessage
+                id='status.sensitive_warning'
+                defaultMessage='Sensitive content'
+              />
+            ) : (
+              <FormattedMessage
+                id='status.media_hidden'
+                defaultMessage='Media hidden'
+              />
+            )}
+            <span className='spoiler-button__overlay__action'>
+              <FormattedMessage
+                id='status.media.show'
+                defaultMessage='Click to show'
+              />
+            </span>
           </span>
         </button>
       );
@@ -337,7 +459,12 @@ class MediaGallery extends PureComponent {
 
     return (
       <div className='media-gallery' style={style} ref={this.handleRef}>
-        <div className={classNames('spoiler-button', { 'spoiler-button--minified': visible && !uncached, 'spoiler-button--click-thru': uncached })}>
+        <div
+          className={classNames('spoiler-button', {
+            'spoiler-button--minified': visible && !uncached,
+            'spoiler-button--click-thru': uncached,
+          })}
+        >
           {spoilerButton}
         </div>
 
@@ -345,7 +472,6 @@ class MediaGallery extends PureComponent {
       </div>
     );
   }
-
 }
 
 export default injectIntl(MediaGallery);

--- a/app/javascript/mastodon/components/modal_root.jsx
+++ b/app/javascript/mastodon/components/modal_root.jsx
@@ -6,7 +6,6 @@ import { multiply } from 'color-blend';
 import { createBrowserHistory } from 'history';
 
 export default class ModalRoot extends PureComponent {
-
   static contextTypes = {
     router: PropTypes.object,
   };
@@ -25,15 +24,21 @@ export default class ModalRoot extends PureComponent {
   activeElement = this.props.children ? document.activeElement : null;
 
   handleKeyUp = (e) => {
-    if ((e.key === 'Escape' || e.key === 'Esc' || e.keyCode === 27)
-         && !!this.props.children) {
+    if (
+      (e.key === 'Escape' || e.key === 'Esc' || e.keyCode === 27) &&
+      !!this.props.children
+    ) {
       this.props.onClose();
     }
   };
 
   handleKeyDown = (e) => {
     if (e.key === 'Tab') {
-      const focusable = Array.from(this.node.querySelectorAll('button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])')).filter((x) => window.getComputedStyle(x).display !== 'none');
+      const focusable = Array.from(
+        this.node.querySelectorAll(
+          'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        ),
+      ).filter((x) => window.getComputedStyle(x).display !== 'none');
       const index = focusable.indexOf(e.target);
 
       let element;
@@ -52,33 +57,39 @@ export default class ModalRoot extends PureComponent {
     }
   };
 
-  componentDidMount () {
+  componentDidMount() {
     window.addEventListener('keyup', this.handleKeyUp, false);
     window.addEventListener('keydown', this.handleKeyDown, false);
-    this.history = this.context.router ? this.context.router.history : createBrowserHistory();
+    this.history = this.context.router
+      ? this.context.router.history
+      : createBrowserHistory();
   }
 
-  UNSAFE_componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (!!nextProps.children && !this.props.children) {
       this.activeElement = document.activeElement;
 
-      this.getSiblings().forEach(sibling => sibling.setAttribute('inert', true));
+      this.getSiblings().forEach((sibling) =>
+        sibling.setAttribute('inert', true),
+      );
     }
   }
 
-  componentDidUpdate (prevProps) {
+  componentDidUpdate(prevProps) {
     if (!this.props.children && !!prevProps.children) {
-      this.getSiblings().forEach(sibling => sibling.removeAttribute('inert'));
+      this.getSiblings().forEach((sibling) => sibling.removeAttribute('inert'));
 
       // Because of the wicg-inert polyfill, the activeElement may not be
       // immediately selectable, we have to wait for observers to run, as
       // described in https://github.com/WICG/inert#performance-and-gotchas
-      Promise.resolve().then(() => {
-        if (!this.props.ignoreFocus) {
-          this.activeElement.focus({ preventScroll: true });
-        }
-        this.activeElement = null;
-      }).catch(console.error);
+      Promise.resolve()
+        .then(() => {
+          if (!this.props.ignoreFocus) {
+            this.activeElement.focus({ preventScroll: true });
+          }
+          this.activeElement = null;
+        })
+        .catch(console.error);
 
       this._handleModalClose();
     }
@@ -90,12 +101,12 @@ export default class ModalRoot extends PureComponent {
     }
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     window.removeEventListener('keyup', this.handleKeyUp);
     window.removeEventListener('keydown', this.handleKeyDown);
   }
 
-  _handleModalOpen () {
+  _handleModalOpen() {
     this._modalHistoryKey = Date.now();
     this.unlistenHistory = this.history.listen((_, action) => {
       if (action === 'POP') {
@@ -104,7 +115,7 @@ export default class ModalRoot extends PureComponent {
     });
   }
 
-  _handleModalClose () {
+  _handleModalClose() {
     if (this.unlistenHistory) {
       this.unlistenHistory();
     }
@@ -114,22 +125,27 @@ export default class ModalRoot extends PureComponent {
     }
   }
 
-  _ensureHistoryBuffer () {
+  _ensureHistoryBuffer() {
     const { pathname, state } = this.history.location;
     if (!state || state.mastodonModalKey !== this._modalHistoryKey) {
-      this.history.push(pathname, { ...state, mastodonModalKey: this._modalHistoryKey });
+      this.history.push(pathname, {
+        ...state,
+        mastodonModalKey: this._modalHistoryKey,
+      });
     }
   }
 
   getSiblings = () => {
-    return Array(...this.node.parentElement.childNodes).filter(node => node !== this.node);
+    return Array(...this.node.parentElement.childNodes).filter(
+      (node) => node !== this.node,
+    );
   };
 
-  setRef = ref => {
+  setRef = (ref) => {
     this.node = ref;
   };
 
-  render () {
+  render() {
     const { children, onClose } = this.props;
     const visible = !!children;
 
@@ -142,17 +158,30 @@ export default class ModalRoot extends PureComponent {
     let backgroundColor = null;
 
     if (this.props.backgroundColor) {
-      backgroundColor = multiply({ ...this.props.backgroundColor, a: 1 }, { r: 0, g: 0, b: 0, a: 0.7 });
+      backgroundColor = multiply(
+        { ...this.props.backgroundColor, a: 1 },
+        { r: 0, g: 0, b: 0, a: 0.7 },
+      );
     }
 
     return (
       <div className='modal-root' ref={this.setRef}>
         <div style={{ pointerEvents: visible ? 'auto' : 'none' }}>
-          <div role='presentation' className='modal-root__overlay' onClick={onClose} style={{ backgroundColor: backgroundColor ? `rgba(${backgroundColor.r}, ${backgroundColor.g}, ${backgroundColor.b}, 0.7)` : null }} />
-          <div role='dialog' className='modal-root__container'>{children}</div>
+          <div
+            role='presentation'
+            className='modal-root__overlay'
+            onClick={onClose}
+            style={{
+              backgroundColor: backgroundColor
+                ? `rgba(${backgroundColor.r}, ${backgroundColor.g}, ${backgroundColor.b}, 0.7)`
+                : null,
+            }}
+          />
+          <div role='dialog' className='modal-root__container'>
+            {children}
+          </div>
         </div>
       </div>
     );
   }
-
 }

--- a/app/javascript/mastodon/components/navigation_portal.jsx
+++ b/app/javascript/mastodon/components/navigation_portal.jsx
@@ -6,23 +6,29 @@ import AccountNavigation from 'mastodon/features/account/navigation';
 import Trends from 'mastodon/features/getting_started/containers/trends_container';
 import { showTrends } from 'mastodon/initial_state';
 
-const DefaultNavigation = () => (
+const DefaultNavigation = () =>
   showTrends ? (
     <>
       <div className='flex-spacer' />
       <Trends />
     </>
-  ) : null
-);
+  ) : null;
 
 class NavigationPortal extends PureComponent {
-
-  render () {
+  render() {
     return (
       <Switch>
         <Route path='/@:acct' exact component={AccountNavigation} />
-        <Route path='/@:acct/tagged/:tagged?' exact component={AccountNavigation} />
-        <Route path='/@:acct/with_replies' exact component={AccountNavigation} />
+        <Route
+          path='/@:acct/tagged/:tagged?'
+          exact
+          component={AccountNavigation}
+        />
+        <Route
+          path='/@:acct/with_replies'
+          exact
+          component={AccountNavigation}
+        />
         <Route path='/@:acct/followers' exact component={AccountNavigation} />
         <Route path='/@:acct/following' exact component={AccountNavigation} />
         <Route path='/@:acct/media' exact component={AccountNavigation} />
@@ -30,6 +36,5 @@ class NavigationPortal extends PureComponent {
       </Switch>
     );
   }
-
 }
 export default withRouter(NavigationPortal);

--- a/app/javascript/mastodon/components/picture_in_picture_placeholder.jsx
+++ b/app/javascript/mastodon/components/picture_in_picture_placeholder.jsx
@@ -6,10 +6,9 @@ import { FormattedMessage } from 'react-intl';
 import { connect } from 'react-redux';
 
 import { removePictureInPicture } from 'mastodon/actions/picture_in_picture';
-import { Icon }  from 'mastodon/components/icon';
+import { Icon } from 'mastodon/components/icon';
 
 class PictureInPicturePlaceholder extends PureComponent {
-
   static propTypes = {
     dispatch: PropTypes.func.isRequired,
     aspectRatio: PropTypes.string,
@@ -20,17 +19,25 @@ class PictureInPicturePlaceholder extends PureComponent {
     dispatch(removePictureInPicture());
   };
 
-  render () {
+  render() {
     const { aspectRatio } = this.props;
 
     return (
-      <div className='picture-in-picture-placeholder' style={{ aspectRatio }} role='button' tabIndex={0} onClick={this.handleClick}>
+      <div
+        className='picture-in-picture-placeholder'
+        style={{ aspectRatio }}
+        role='button'
+        tabIndex={0}
+        onClick={this.handleClick}
+      >
         <Icon id='window-restore' />
-        <FormattedMessage id='picture_in_picture.restore' defaultMessage='Put it back' />
+        <FormattedMessage
+          id='picture_in_picture.restore'
+          defaultMessage='Put it back'
+        />
       </div>
     );
   }
-
 }
 
 export default connect()(PictureInPicturePlaceholder);

--- a/app/javascript/mastodon/components/poll.jsx
+++ b/app/javascript/mastodon/components/poll.jsx
@@ -10,7 +10,7 @@ import ImmutablePureComponent from 'react-immutable-pure-component';
 import escapeTextContentForBrowser from 'escape-html';
 import spring from 'react-motion/lib/spring';
 
-import { Icon }  from 'mastodon/components/icon';
+import { Icon } from 'mastodon/components/icon';
 import emojify from 'mastodon/features/emoji/emoji';
 import Motion from 'mastodon/features/ui/util/optional_motion';
 
@@ -31,13 +31,13 @@ const messages = defineMessages({
   },
 });
 
-const makeEmojiMap = record => record.get('emojis').reduce((obj, emoji) => {
-  obj[`:${emoji.get('shortcode')}:`] = emoji.toJS();
-  return obj;
-}, {});
+const makeEmojiMap = (record) =>
+  record.get('emojis').reduce((obj, emoji) => {
+    obj[`:${emoji.get('shortcode')}:`] = emoji.toJS();
+    return obj;
+  }, {});
 
 class Poll extends ImmutablePureComponent {
-
   static contextTypes = {
     identity: PropTypes.object,
   };
@@ -56,37 +56,39 @@ class Poll extends ImmutablePureComponent {
     expired: null,
   };
 
-  static getDerivedStateFromProps (props, state) {
+  static getDerivedStateFromProps(props, state) {
     const { poll } = props;
     const expires_at = poll.get('expires_at');
-    const expired = poll.get('expired') || expires_at !== null && (new Date(expires_at)).getTime() < Date.now();
-    return (expired === state.expired) ? null : { expired };
+    const expired =
+      poll.get('expired') ||
+      (expires_at !== null && new Date(expires_at).getTime() < Date.now());
+    return expired === state.expired ? null : { expired };
   }
 
-  componentDidMount () {
+  componentDidMount() {
     this._setupTimer();
   }
 
-  componentDidUpdate () {
+  componentDidUpdate() {
     this._setupTimer();
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     clearTimeout(this._timer);
   }
 
-  _setupTimer () {
+  _setupTimer() {
     const { poll } = this.props;
     clearTimeout(this._timer);
     if (!this.state.expired) {
-      const delay = (new Date(poll.get('expires_at'))).getTime() - Date.now();
+      const delay = new Date(poll.get('expires_at')).getTime() - Date.now();
       this._timer = setTimeout(() => {
         this.setState({ expired: true });
       }, delay);
     }
   }
 
-  _toggleOption = value => {
+  _toggleOption = (value) => {
     if (this.props.poll.get('multiple')) {
       const tmp = { ...this.state.selected };
       if (tmp[value]) {
@@ -132,18 +134,27 @@ class Poll extends ImmutablePureComponent {
 
   handleReveal = () => {
     this.setState({ revealed: true });
-  }
+  };
 
-  renderOption (option, optionIndex, showResults) {
+  renderOption(option, optionIndex, showResults) {
     const { poll, lang, disabled, intl } = this.props;
-    const pollVotesCount  = poll.get('voters_count') || poll.get('votes_count');
-    const percent         = pollVotesCount === 0 ? 0 : (option.get('votes_count') / pollVotesCount) * 100;
-    const leading         = poll.get('options').filterNot(other => other.get('title') === option.get('title')).every(other => option.get('votes_count') >= other.get('votes_count'));
-    const active          = !!this.state.selected[`${optionIndex}`];
-    const voted           = option.get('voted') || (poll.get('own_votes') && poll.get('own_votes').includes(optionIndex));
+    const pollVotesCount = poll.get('voters_count') || poll.get('votes_count');
+    const percent =
+      pollVotesCount === 0
+        ? 0
+        : (option.get('votes_count') / pollVotesCount) * 100;
+    const leading = poll
+      .get('options')
+      .filterNot((other) => other.get('title') === option.get('title'))
+      .every((other) => option.get('votes_count') >= other.get('votes_count'));
+    const active = !!this.state.selected[`${optionIndex}`];
+    const voted =
+      option.get('voted') ||
+      (poll.get('own_votes') && poll.get('own_votes').includes(optionIndex));
 
     const title = option.getIn(['translation', 'title']) || option.get('title');
-    let titleHtml = option.getIn(['translation', 'titleHtml']) || option.get('titleHtml');
+    let titleHtml =
+      option.getIn(['translation', 'titleHtml']) || option.get('titleHtml');
 
     if (!titleHtml) {
       const emojiMap = makeEmojiMap(poll);
@@ -152,7 +163,9 @@ class Poll extends ImmutablePureComponent {
 
     return (
       <li key={option.get('title')}>
-        <label className={classNames('poll__option', { selectable: !showResults })}>
+        <label
+          className={classNames('poll__option', { selectable: !showResults })}
+        >
           <input
             name='vote-options'
             type={poll.get('multiple') ? 'checkbox' : 'radio'}
@@ -164,7 +177,10 @@ class Poll extends ImmutablePureComponent {
 
           {!showResults && (
             <span
-              className={classNames('poll__input', { checkbox: poll.get('multiple'), active })}
+              className={classNames('poll__input', {
+                checkbox: poll.get('multiple'),
+                active,
+              })}
               tabIndex={0}
               role={poll.get('multiple') ? 'checkbox' : 'radio'}
               onKeyPress={this.handleOptionKeyPress}
@@ -191,23 +207,35 @@ class Poll extends ImmutablePureComponent {
             dangerouslySetInnerHTML={{ __html: titleHtml }}
           />
 
-          {!!voted && <span className='poll__voted'>
-            <Icon id='check' className='poll__voted__mark' title={intl.formatMessage(messages.voted)} />
-          </span>}
+          {!!voted && (
+            <span className='poll__voted'>
+              <Icon
+                id='check'
+                className='poll__voted__mark'
+                title={intl.formatMessage(messages.voted)}
+              />
+            </span>
+          )}
         </label>
 
         {showResults && (
-          <Motion defaultStyle={{ width: 0 }} style={{ width: spring(percent, { stiffness: 180, damping: 12 }) }}>
-            {({ width }) =>
-              <span className={classNames('poll__chart', { leading })} style={{ width: `${width}%` }} />
-            }
+          <Motion
+            defaultStyle={{ width: 0 }}
+            style={{ width: spring(percent, { stiffness: 180, damping: 12 }) }}
+          >
+            {({ width }) => (
+              <span
+                className={classNames('poll__chart', { leading })}
+                style={{ width: `${width}%` }}
+              />
+            )}
           </Motion>
         )}
       </li>
     );
   }
 
-  render () {
+  render() {
     const { poll, intl } = this.props;
     const { revealed, expired } = this.state;
 
@@ -215,35 +243,82 @@ class Poll extends ImmutablePureComponent {
       return null;
     }
 
-    const timeRemaining = expired ? intl.formatMessage(messages.closed) : <RelativeTimestamp timestamp={poll.get('expires_at')} futureDate />;
-    const showResults   = poll.get('voted') || revealed || expired;
-    const disabled      = this.props.disabled || Object.entries(this.state.selected).every(item => !item);
+    const timeRemaining = expired ? (
+      intl.formatMessage(messages.closed)
+    ) : (
+      <RelativeTimestamp timestamp={poll.get('expires_at')} futureDate />
+    );
+    const showResults = poll.get('voted') || revealed || expired;
+    const disabled =
+      this.props.disabled ||
+      Object.entries(this.state.selected).every((item) => !item);
 
     let votesCount = null;
 
-    if (poll.get('voters_count') !== null && poll.get('voters_count') !== undefined) {
-      votesCount = <FormattedMessage id='poll.total_people' defaultMessage='{count, plural, one {# person} other {# people}}' values={{ count: poll.get('voters_count') }} />;
+    if (
+      poll.get('voters_count') !== null &&
+      poll.get('voters_count') !== undefined
+    ) {
+      votesCount = (
+        <FormattedMessage
+          id='poll.total_people'
+          defaultMessage='{count, plural, one {# person} other {# people}}'
+          values={{ count: poll.get('voters_count') }}
+        />
+      );
     } else {
-      votesCount = <FormattedMessage id='poll.total_votes' defaultMessage='{count, plural, one {# vote} other {# votes}}' values={{ count: poll.get('votes_count') }} />;
+      votesCount = (
+        <FormattedMessage
+          id='poll.total_votes'
+          defaultMessage='{count, plural, one {# vote} other {# votes}}'
+          values={{ count: poll.get('votes_count') }}
+        />
+      );
     }
 
     return (
       <div className='poll'>
         <ul>
-          {poll.get('options').map((option, i) => this.renderOption(option, i, showResults))}
+          {poll
+            .get('options')
+            .map((option, i) => this.renderOption(option, i, showResults))}
         </ul>
 
         <div className='poll__footer'>
-          {!showResults && <button className='button button-secondary' disabled={disabled || !this.context.identity.signedIn} onClick={this.handleVote}><FormattedMessage id='poll.vote' defaultMessage='Vote' /></button>}
-          {!showResults && <><button className='poll__link' onClick={this.handleReveal}><FormattedMessage id='poll.reveal' defaultMessage='See results' /></button> · </>}
-          {showResults && !this.props.disabled && <><button className='poll__link' onClick={this.handleRefresh}><FormattedMessage id='poll.refresh' defaultMessage='Refresh' /></button> · </>}
+          {!showResults && (
+            <button
+              className='button button-secondary'
+              disabled={disabled || !this.context.identity.signedIn}
+              onClick={this.handleVote}
+            >
+              <FormattedMessage id='poll.vote' defaultMessage='Vote' />
+            </button>
+          )}
+          {!showResults && (
+            <>
+              <button className='poll__link' onClick={this.handleReveal}>
+                <FormattedMessage
+                  id='poll.reveal'
+                  defaultMessage='See results'
+                />
+              </button>{' '}
+              ·{' '}
+            </>
+          )}
+          {showResults && !this.props.disabled && (
+            <>
+              <button className='poll__link' onClick={this.handleRefresh}>
+                <FormattedMessage id='poll.refresh' defaultMessage='Refresh' />
+              </button>{' '}
+              ·{' '}
+            </>
+          )}
           {votesCount}
           {poll.get('expires_at') && <> · {timeRemaining}</>}
         </div>
       </div>
     );
   }
-
 }
 
 export default injectIntl(Poll);

--- a/app/javascript/mastodon/components/regeneration_indicator.jsx
+++ b/app/javascript/mastodon/components/regeneration_indicator.jsx
@@ -9,8 +9,15 @@ const RegenerationIndicator = () => (
     </div>
 
     <div className='regeneration-indicator__label'>
-      <FormattedMessage id='regeneration_indicator.label' tagName='strong' defaultMessage='Loading&hellip;' />
-      <FormattedMessage id='regeneration_indicator.sublabel' defaultMessage='Your home feed is being prepared!' />
+      <FormattedMessage
+        id='regeneration_indicator.label'
+        tagName='strong'
+        defaultMessage='Loading&hellip;'
+      />
+      <FormattedMessage
+        id='regeneration_indicator.sublabel'
+        defaultMessage='Your home feed is being prepared!'
+      />
     </div>
   </div>
 );

--- a/app/javascript/mastodon/components/scrollable_list.jsx
+++ b/app/javascript/mastodon/components/scrollable_list.jsx
@@ -12,7 +12,11 @@ import { throttle } from 'lodash';
 import ScrollContainer from 'mastodon/containers/scroll_container';
 
 import IntersectionObserverArticleContainer from '../containers/intersection_observer_article_container';
-import { attachFullscreenListener, detachFullscreenListener, isFullscreen } from '../features/ui/util/fullscreen';
+import {
+  attachFullscreenListener,
+  detachFullscreenListener,
+  isFullscreen,
+} from '../features/ui/util/fullscreen';
 import IntersectionObserverWrapper from '../features/ui/util/intersection_observer_wrapper';
 
 import { LoadMore } from './load_more';
@@ -30,7 +34,6 @@ const mapStateToProps = (state, { scrollKey }) => {
 };
 
 class ScrollableList extends PureComponent {
-
   static contextTypes = {
     router: PropTypes.object,
   };
@@ -66,33 +69,42 @@ class ScrollableList extends PureComponent {
 
   intersectionObserverWrapper = new IntersectionObserverWrapper();
 
-  handleScroll = throttle(() => {
-    if (this.node) {
-      const scrollTop = this.getScrollTop();
-      const scrollHeight = this.getScrollHeight();
-      const clientHeight = this.getClientHeight();
-      const offset = scrollHeight - scrollTop - clientHeight;
+  handleScroll = throttle(
+    () => {
+      if (this.node) {
+        const scrollTop = this.getScrollTop();
+        const scrollHeight = this.getScrollHeight();
+        const clientHeight = this.getClientHeight();
+        const offset = scrollHeight - scrollTop - clientHeight;
 
-      if (400 > offset && this.props.onLoadMore && this.props.hasMore && !this.props.isLoading) {
-        this.props.onLoadMore();
-      }
+        if (
+          400 > offset &&
+          this.props.onLoadMore &&
+          this.props.hasMore &&
+          !this.props.isLoading
+        ) {
+          this.props.onLoadMore();
+        }
 
-      if (scrollTop < 100 && this.props.onScrollToTop) {
-        this.props.onScrollToTop();
-      } else if (this.props.onScroll) {
-        this.props.onScroll();
-      }
+        if (scrollTop < 100 && this.props.onScrollToTop) {
+          this.props.onScrollToTop();
+        } else if (this.props.onScroll) {
+          this.props.onScroll();
+        }
 
-      if (!this.lastScrollWasSynthetic) {
-        // If the last scroll wasn't caused by setScrollTop(), assume it was
-        // intentional and cancel any pending scroll reset on mouse idle
-        this.scrollToTopOnMouseIdle = false;
+        if (!this.lastScrollWasSynthetic) {
+          // If the last scroll wasn't caused by setScrollTop(), assume it was
+          // intentional and cancel any pending scroll reset on mouse idle
+          this.scrollToTopOnMouseIdle = false;
+        }
+        this.lastScrollWasSynthetic = false;
       }
-      this.lastScrollWasSynthetic = false;
-    }
-  }, 150, {
-    trailing: true,
-  });
+    },
+    150,
+    {
+      trailing: true,
+    },
+  );
 
   mouseIdleTimer = null;
   mouseMovedRecently = false;
@@ -101,13 +113,13 @@ class ScrollableList extends PureComponent {
 
   _getScrollingElement = () => {
     if (this.props.bindToDocument) {
-      return (document.scrollingElement || document.body);
+      return document.scrollingElement || document.body;
     } else {
       return this.node;
     }
   };
 
-  setScrollTop = newScrollTop => {
+  setScrollTop = (newScrollTop) => {
     if (this.getScrollTop() !== newScrollTop) {
       this.lastScrollWasSynthetic = true;
 
@@ -138,11 +150,15 @@ class ScrollableList extends PureComponent {
     this.mouseMovedRecently = true;
   }, MOUSE_IDLE_DELAY / 2);
 
-  handleWheel = throttle(() => {
-    this.scrollToTopOnMouseIdle = false;
-  }, 150, {
-    trailing: true,
-  });
+  handleWheel = throttle(
+    () => {
+      this.scrollToTopOnMouseIdle = false;
+    },
+    150,
+    {
+      trailing: true,
+    },
+  );
 
   handleMouseIdle = () => {
     if (this.scrollToTopOnMouseIdle && !this.props.preventScroll) {
@@ -153,7 +169,7 @@ class ScrollableList extends PureComponent {
     this.scrollToTopOnMouseIdle = false;
   };
 
-  componentDidMount () {
+  componentDidMount() {
     this.attachScrollListener();
     this.attachIntersectionObserver();
 
@@ -189,20 +205,29 @@ class ScrollableList extends PureComponent {
     this.setScrollTop(newScrollTop);
   };
 
-  getSnapshotBeforeUpdate (prevProps) {
-    const someItemInserted = Children.count(prevProps.children) > 0 &&
-      Children.count(prevProps.children) < Children.count(this.props.children) &&
+  getSnapshotBeforeUpdate(prevProps) {
+    const someItemInserted =
+      Children.count(prevProps.children) > 0 &&
+      Children.count(prevProps.children) <
+        Children.count(this.props.children) &&
       this.getFirstChildKey(prevProps) !== this.getFirstChildKey(this.props);
-    const pendingChanged = (prevProps.numPending > 0) !== (this.props.numPending > 0);
+    const pendingChanged =
+      prevProps.numPending > 0 !== this.props.numPending > 0;
 
-    if (pendingChanged || someItemInserted && (this.getScrollTop() > 0 || this.mouseMovedRecently || this.props.preventScroll)) {
+    if (
+      pendingChanged ||
+      (someItemInserted &&
+        (this.getScrollTop() > 0 ||
+          this.mouseMovedRecently ||
+          this.props.preventScroll))
+    ) {
       return this.getScrollHeight() - this.getScrollTop();
     } else {
       return null;
     }
   }
 
-  componentDidUpdate (prevProps, prevState, snapshot) {
+  componentDidUpdate(prevProps, prevState, snapshot) {
     // Reset the scroll position when a new child comes in in order not to
     // jerk the scrollbar around if you're already scrolled down the page.
     if (snapshot !== null) {
@@ -216,7 +241,7 @@ class ScrollableList extends PureComponent {
     }
   };
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     this.clearMouseIdleTimer();
     this.detachScrollListener();
     this.detachIntersectionObserver();
@@ -228,31 +253,32 @@ class ScrollableList extends PureComponent {
     this.setState({ fullscreen: isFullscreen() });
   };
 
-  attachIntersectionObserver () {
+  attachIntersectionObserver() {
     let nodeOptions = {
       root: this.node,
       rootMargin: '300% 0px',
     };
 
-    this.intersectionObserverWrapper
-      .connect(this.props.bindToDocument ? {} : nodeOptions);
+    this.intersectionObserverWrapper.connect(
+      this.props.bindToDocument ? {} : nodeOptions,
+    );
   }
 
-  detachIntersectionObserver () {
+  detachIntersectionObserver() {
     this.intersectionObserverWrapper.disconnect();
   }
 
-  attachScrollListener () {
+  attachScrollListener() {
     if (this.props.bindToDocument) {
       document.addEventListener('scroll', this.handleScroll);
-      document.addEventListener('wheel', this.handleWheel,  listenerOptions);
+      document.addEventListener('wheel', this.handleWheel, listenerOptions);
     } else {
       this.node.addEventListener('scroll', this.handleScroll);
       this.node.addEventListener('wheel', this.handleWheel, listenerOptions);
     }
   }
 
-  detachScrollListener () {
+  detachScrollListener() {
     if (this.props.bindToDocument) {
       document.removeEventListener('scroll', this.handleScroll);
       document.removeEventListener('wheel', this.handleWheel, listenerOptions);
@@ -262,9 +288,9 @@ class ScrollableList extends PureComponent {
     }
   }
 
-  getFirstChildKey (props) {
+  getFirstChildKey(props) {
     const { children } = props;
-    let firstChild     = children;
+    let firstChild = children;
 
     if (children instanceof ImmutableList) {
       firstChild = children.get(0);
@@ -279,12 +305,12 @@ class ScrollableList extends PureComponent {
     this.node = c;
   };
 
-  handleLoadMore = e => {
+  handleLoadMore = (e) => {
     e.preventDefault();
     this.props.onLoadMore();
   };
 
-  handleLoadPending = e => {
+  handleLoadPending = (e) => {
     e.preventDefault();
     this.props.onLoadPending();
     // Prevent the weird scroll-jumping behavior, as we explicitly don't want to
@@ -296,13 +322,32 @@ class ScrollableList extends PureComponent {
     this.mouseMovedRecently = true;
   };
 
-  render () {
-    const { children, scrollKey, trackScroll, showLoading, isLoading, hasMore, numPending, prepend, alwaysPrepend, append, emptyMessage, onLoadMore } = this.props;
+  render() {
+    const {
+      children,
+      scrollKey,
+      trackScroll,
+      showLoading,
+      isLoading,
+      hasMore,
+      numPending,
+      prepend,
+      alwaysPrepend,
+      append,
+      emptyMessage,
+      onLoadMore,
+    } = this.props;
     const { fullscreen } = this.state;
     const childrenCount = Children.count(children);
 
-    const loadMore     = (hasMore && onLoadMore) ? <LoadMore visible={!isLoading} onClick={this.handleLoadMore} /> : null;
-    const loadPending  = (numPending > 0) ? <LoadPending count={numPending} onClick={this.handleLoadPending} /> : null;
+    const loadMore =
+      hasMore && onLoadMore ? (
+        <LoadMore visible={!isLoading} onClick={this.handleLoadMore} />
+      ) : null;
+    const loadPending =
+      numPending > 0 ? (
+        <LoadPending count={numPending} onClick={this.handleLoadPending} />
+      ) : null;
     let scrollableArea = null;
 
     if (showLoading) {
@@ -317,9 +362,19 @@ class ScrollableList extends PureComponent {
           </div>
         </div>
       );
-    } else if (isLoading || childrenCount > 0 || numPending > 0 || hasMore || !emptyMessage) {
+    } else if (
+      isLoading ||
+      childrenCount > 0 ||
+      numPending > 0 ||
+      hasMore ||
+      !emptyMessage
+    ) {
       scrollableArea = (
-        <div className={classNames('scrollable', { fullscreen })} ref={this.setRef} onMouseMove={this.handleMouseMove}>
+        <div
+          className={classNames('scrollable', { fullscreen })}
+          ref={this.setRef}
+          onMouseMove={this.handleMouseMove}
+        >
           <div role='feed' className='item-list'>
             {prepend}
 
@@ -332,7 +387,11 @@ class ScrollableList extends PureComponent {
                 index={index}
                 listLength={childrenCount}
                 intersectionObserverWrapper={this.intersectionObserverWrapper}
-                saveHeightKey={trackScroll ? `${this.context.router.route.location.key}:${scrollKey}` : null}
+                saveHeightKey={
+                  trackScroll
+                    ? `${this.context.router.route.location.key}:${scrollKey}`
+                    : null
+                }
               >
                 {cloneElement(child, {
                   getScrollPosition: this.getScrollPosition,
@@ -351,12 +410,13 @@ class ScrollableList extends PureComponent {
       );
     } else {
       scrollableArea = (
-        <div className={classNames('scrollable scrollable--flex', { fullscreen })} ref={this.setRef}>
+        <div
+          className={classNames('scrollable scrollable--flex', { fullscreen })}
+          ref={this.setRef}
+        >
           {alwaysPrepend && prepend}
 
-          <div className='empty-column-indicator'>
-            {emptyMessage}
-          </div>
+          <div className='empty-column-indicator'>{emptyMessage}</div>
         </div>
       );
     }
@@ -371,7 +431,8 @@ class ScrollableList extends PureComponent {
       return scrollableArea;
     }
   }
-
 }
 
-export default connect(mapStateToProps, null, null, { forwardRef: true })(ScrollableList);
+export default connect(mapStateToProps, null, null, { forwardRef: true })(
+  ScrollableList,
+);

--- a/app/javascript/mastodon/components/server_banner.jsx
+++ b/app/javascript/mastodon/components/server_banner.jsx
@@ -15,37 +15,55 @@ import Account from 'mastodon/containers/account_container';
 import { domain } from 'mastodon/initial_state';
 
 const messages = defineMessages({
-  aboutActiveUsers: { id: 'server_banner.about_active_users', defaultMessage: 'People using this server during the last 30 days (Monthly Active Users)' },
+  aboutActiveUsers: {
+    id: 'server_banner.about_active_users',
+    defaultMessage:
+      'People using this server during the last 30 days (Monthly Active Users)',
+  },
 });
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   server: state.getIn(['server', 'server']),
 });
 
 class ServerBanner extends PureComponent {
-
   static propTypes = {
     server: PropTypes.object,
     dispatch: PropTypes.func,
     intl: PropTypes.object,
   };
 
-  componentDidMount () {
+  componentDidMount() {
     const { dispatch } = this.props;
     dispatch(fetchServer());
   }
 
-  render () {
+  render() {
     const { server, intl } = this.props;
     const isLoading = server.get('isLoading');
 
     return (
       <div className='server-banner'>
         <div className='server-banner__introduction'>
-          <FormattedMessage id='server_banner.introduction' defaultMessage='{domain} is part of the decentralized social network powered by {mastodon}.' values={{ domain: <strong>{domain}</strong>, mastodon: <a href='https://joinmastodon.org' target='_blank'>Mastodon</a> }} />
+          <FormattedMessage
+            id='server_banner.introduction'
+            defaultMessage='{domain} is part of the decentralized social network powered by {mastodon}.'
+            values={{
+              domain: <strong>{domain}</strong>,
+              mastodon: (
+                <a href='https://joinmastodon.org' target='_blank'>
+                  Mastodon
+                </a>
+              ),
+            }}
+          />
         </div>
 
-        <ServerHeroImage blurhash={server.getIn(['thumbnail', 'blurhash'])} src={server.getIn(['thumbnail', 'url'])} className='server-banner__hero' />
+        <ServerHeroImage
+          blurhash={server.getIn(['thumbnail', 'blurhash'])}
+          src={server.getIn(['thumbnail', 'url'])}
+          className='server-banner__hero'
+        />
 
         <div className='server-banner__description'>
           {isLoading ? (
@@ -56,30 +74,62 @@ class ServerBanner extends PureComponent {
               <br />
               <Skeleton width='70%' />
             </>
-          ) : server.get('description')}
+          ) : (
+            server.get('description')
+          )}
         </div>
 
         <div className='server-banner__meta'>
           <div className='server-banner__meta__column'>
-            <h4><FormattedMessage id='server_banner.administered_by' defaultMessage='Administered by:' /></h4>
+            <h4>
+              <FormattedMessage
+                id='server_banner.administered_by'
+                defaultMessage='Administered by:'
+              />
+            </h4>
 
-            <Account id={server.getIn(['contact', 'account', 'id'])} size={36} minimal />
+            <Account
+              id={server.getIn(['contact', 'account', 'id'])}
+              size={36}
+              minimal
+            />
           </div>
 
           <div className='server-banner__meta__column'>
-            <h4><FormattedMessage id='server_banner.server_stats' defaultMessage='Server stats:' /></h4>
+            <h4>
+              <FormattedMessage
+                id='server_banner.server_stats'
+                defaultMessage='Server stats:'
+              />
+            </h4>
 
             {isLoading ? (
               <>
-                <strong className='server-banner__number'><Skeleton width='10ch' /></strong>
+                <strong className='server-banner__number'>
+                  <Skeleton width='10ch' />
+                </strong>
                 <br />
-                <span className='server-banner__number-label'><Skeleton width='5ch' /></span>
+                <span className='server-banner__number-label'>
+                  <Skeleton width='5ch' />
+                </span>
               </>
             ) : (
               <>
-                <strong className='server-banner__number'><ShortNumber value={server.getIn(['usage', 'users', 'active_month'])} /></strong>
+                <strong className='server-banner__number'>
+                  <ShortNumber
+                    value={server.getIn(['usage', 'users', 'active_month'])}
+                  />
+                </strong>
                 <br />
-                <span className='server-banner__number-label' title={intl.formatMessage(messages.aboutActiveUsers)}><FormattedMessage id='server_banner.active_users' defaultMessage='active users' /></span>
+                <span
+                  className='server-banner__number-label'
+                  title={intl.formatMessage(messages.aboutActiveUsers)}
+                >
+                  <FormattedMessage
+                    id='server_banner.active_users'
+                    defaultMessage='active users'
+                  />
+                </span>
               </>
             )}
           </div>
@@ -87,11 +137,15 @@ class ServerBanner extends PureComponent {
 
         <hr className='spacer' />
 
-        <Link className='button button--block button-secondary' to='/about'><FormattedMessage id='server_banner.learn_more' defaultMessage='Learn more' /></Link>
+        <Link className='button button--block button-secondary' to='/about'>
+          <FormattedMessage
+            id='server_banner.learn_more'
+            defaultMessage='Learn more'
+          />
+        </Link>
       </div>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(injectIntl(ServerBanner));

--- a/app/javascript/mastodon/components/status.jsx
+++ b/app/javascript/mastodon/components/status.jsx
@@ -9,14 +9,18 @@ import ImmutablePureComponent from 'react-immutable-pure-component';
 
 import { HotKeys } from 'react-hotkeys';
 
-import { Icon }  from 'mastodon/components/icon';
+import { Icon } from 'mastodon/components/icon';
 import PictureInPicturePlaceholder from 'mastodon/components/picture_in_picture_placeholder';
 
 import Card from '../features/status/components/card';
 // We use the component (and not the container) since we do not want
 // to use the progress bar to show download progress
 import Bundle from '../features/ui/components/bundle';
-import { MediaGallery, Video, Audio } from '../features/ui/util/async-components';
+import {
+  MediaGallery,
+  Video,
+  Audio,
+} from '../features/ui/util/async-components';
 import { displayMedia } from '../initial_state';
 
 import { Avatar } from './avatar';
@@ -32,14 +36,24 @@ const domParser = new DOMParser();
 export const textForScreenReader = (intl, status, rebloggedByText = false) => {
   const displayName = status.getIn(['account', 'display_name']);
 
-  const spoilerText = status.getIn(['translation', 'spoiler_text']) || status.get('spoiler_text');
-  const contentHtml = status.getIn(['translation', 'contentHtml']) || status.get('contentHtml');
-  const contentText = domParser.parseFromString(contentHtml, 'text/html').documentElement.textContent;
+  const spoilerText =
+    status.getIn(['translation', 'spoiler_text']) || status.get('spoiler_text');
+  const contentHtml =
+    status.getIn(['translation', 'contentHtml']) || status.get('contentHtml');
+  const contentText = domParser.parseFromString(contentHtml, 'text/html')
+    .documentElement.textContent;
 
   const values = [
-    displayName.length === 0 ? status.getIn(['account', 'acct']).split('@')[0] : displayName,
+    displayName.length === 0
+      ? status.getIn(['account', 'acct']).split('@')[0]
+      : displayName,
     spoilerText && status.get('hidden') ? spoilerText : contentText,
-    intl.formatDate(status.get('created_at'), { hour: '2-digit', minute: '2-digit', month: 'short', day: 'numeric' }),
+    intl.formatDate(status.get('created_at'), {
+      hour: '2-digit',
+      minute: '2-digit',
+      month: 'short',
+      day: 'numeric',
+    }),
     status.getIn(['account', 'acct']),
   ];
 
@@ -55,23 +69,34 @@ export const defaultMediaVisibility = (status) => {
     return undefined;
   }
 
-  if (status.get('reblog', null) !== null && typeof status.get('reblog') === 'object') {
+  if (
+    status.get('reblog', null) !== null &&
+    typeof status.get('reblog') === 'object'
+  ) {
     status = status.get('reblog');
   }
 
-  return (displayMedia !== 'hide_all' && !status.get('sensitive') || displayMedia === 'show_all');
+  return (
+    (displayMedia !== 'hide_all' && !status.get('sensitive')) ||
+    displayMedia === 'show_all'
+  );
 };
 
 const messages = defineMessages({
   public_short: { id: 'privacy.public.short', defaultMessage: 'Public' },
   unlisted_short: { id: 'privacy.unlisted.short', defaultMessage: 'Unlisted' },
-  private_short: { id: 'privacy.private.short', defaultMessage: 'Followers only' },
-  direct_short: { id: 'privacy.direct.short', defaultMessage: 'Mentioned people only' },
+  private_short: {
+    id: 'privacy.private.short',
+    defaultMessage: 'Followers only',
+  },
+  direct_short: {
+    id: 'privacy.direct.short',
+    defaultMessage: 'Mentioned people only',
+  },
   edited: { id: 'status.edited', defaultMessage: 'Edited {date}' },
 });
 
 class Status extends ImmutablePureComponent {
-
   static contextTypes = {
     router: PropTypes.object,
   };
@@ -150,7 +175,7 @@ class Status extends ImmutablePureComponent {
     this.setState({ showMedia: !this.state.showMedia });
   };
 
-  handleClick = e => {
+  handleClick = (e) => {
     if (e && (e.button !== 0 || e.ctrlKey || e.metaKey)) {
       return;
     }
@@ -162,12 +187,12 @@ class Status extends ImmutablePureComponent {
     this.handleHotkeyOpen();
   };
 
-  handlePrependAccountClick = e => {
+  handlePrependAccountClick = (e) => {
     this.handleAccountClick(e, false);
   };
 
   handleAccountClick = (e, proper = true) => {
-    if (e && (e.button !== 0 || e.ctrlKey || e.metaKey))  {
+    if (e && (e.button !== 0 || e.ctrlKey || e.metaKey)) {
       return;
     }
 
@@ -183,7 +208,7 @@ class Status extends ImmutablePureComponent {
     this.props.onToggleHidden(this._properStatus());
   };
 
-  handleCollapsedToggle = isCollapsed => {
+  handleCollapsedToggle = (isCollapsed) => {
     this.props.onToggleCollapsed(this._properStatus(), isCollapsed);
   };
 
@@ -191,58 +216,88 @@ class Status extends ImmutablePureComponent {
     this.props.onTranslate(this._properStatus());
   };
 
-  getAttachmentAspectRatio () {
+  getAttachmentAspectRatio() {
     const attachments = this._properStatus().get('media_attachments');
 
     if (attachments.getIn([0, 'type']) === 'video') {
-      return `${attachments.getIn([0, 'meta', 'original', 'width'])} / ${attachments.getIn([0, 'meta', 'original', 'height'])}`;
+      return `${attachments.getIn([
+        0,
+        'meta',
+        'original',
+        'width',
+      ])} / ${attachments.getIn([0, 'meta', 'original', 'height'])}`;
     } else if (attachments.getIn([0, 'type']) === 'audio') {
       return '16 / 9';
     } else {
-      return (attachments.size === 1 && attachments.getIn([0, 'meta', 'small', 'aspect'])) ? attachments.getIn([0, 'meta', 'small', 'aspect']) : '3 / 2'
+      return attachments.size === 1 &&
+        attachments.getIn([0, 'meta', 'small', 'aspect'])
+        ? attachments.getIn([0, 'meta', 'small', 'aspect'])
+        : '3 / 2';
     }
   }
 
   renderLoadingMediaGallery = () => {
     return (
-      <div className='media-gallery' style={{ aspectRatio: this.getAttachmentAspectRatio() }} />
+      <div
+        className='media-gallery'
+        style={{ aspectRatio: this.getAttachmentAspectRatio() }}
+      />
     );
   };
 
   renderLoadingVideoPlayer = () => {
     return (
-      <div className='video-player' style={{ aspectRatio: this.getAttachmentAspectRatio() }} />
+      <div
+        className='video-player'
+        style={{ aspectRatio: this.getAttachmentAspectRatio() }}
+      />
     );
   };
 
   renderLoadingAudioPlayer = () => {
     return (
-      <div className='audio-player' style={{ aspectRatio: this.getAttachmentAspectRatio() }} />
+      <div
+        className='audio-player'
+        style={{ aspectRatio: this.getAttachmentAspectRatio() }}
+      />
     );
   };
 
   handleOpenVideo = (options) => {
     const status = this._properStatus();
-    const lang = status.getIn(['translation', 'language']) || status.get('language');
-    this.props.onOpenVideo(status.get('id'), status.getIn(['media_attachments', 0]), lang, options);
+    const lang =
+      status.getIn(['translation', 'language']) || status.get('language');
+    this.props.onOpenVideo(
+      status.get('id'),
+      status.getIn(['media_attachments', 0]),
+      lang,
+      options,
+    );
   };
 
   handleOpenMedia = (media, index) => {
     const status = this._properStatus();
-    const lang = status.getIn(['translation', 'language']) || status.get('language');
+    const lang =
+      status.getIn(['translation', 'language']) || status.get('language');
     this.props.onOpenMedia(status.get('id'), media, index, lang);
   };
 
-  handleHotkeyOpenMedia = e => {
+  handleHotkeyOpenMedia = (e) => {
     const { onOpenMedia, onOpenVideo } = this.props;
     const status = this._properStatus();
 
     e.preventDefault();
 
     if (status.get('media_attachments').size > 0) {
-      const lang = status.getIn(['translation', 'language']) || status.get('language');
+      const lang =
+        status.getIn(['translation', 'language']) || status.get('language');
       if (status.getIn(['media_attachments', 0, 'type']) === 'video') {
-        onOpenVideo(status.get('id'), status.getIn(['media_attachments', 0]), lang, { startTime: 0 });
+        onOpenVideo(
+          status.get('id'),
+          status.getIn(['media_attachments', 0]),
+          lang,
+          { startTime: 0 },
+        );
       } else {
         onOpenMedia(status.get('id'), status.get('media_attachments'), 0, lang);
       }
@@ -256,7 +311,7 @@ class Status extends ImmutablePureComponent {
     deployPictureInPicture(status, type, mediaProps);
   };
 
-  handleHotkeyReply = e => {
+  handleHotkeyReply = (e) => {
     e.preventDefault();
     this.props.onReply(this._properStatus(), this.context.router.history);
   };
@@ -265,13 +320,16 @@ class Status extends ImmutablePureComponent {
     this.props.onFavourite(this._properStatus());
   };
 
-  handleHotkeyBoost = e => {
+  handleHotkeyBoost = (e) => {
     this.props.onReblog(this._properStatus(), e);
   };
 
-  handleHotkeyMention = e => {
+  handleHotkeyMention = (e) => {
     e.preventDefault();
-    this.props.onMention(this._properStatus().get('account'), this.context.router.history);
+    this.props.onMention(
+      this._properStatus().get('account'),
+      this.context.router.history,
+    );
   };
 
   handleHotkeyOpen = () => {
@@ -287,7 +345,9 @@ class Status extends ImmutablePureComponent {
       return;
     }
 
-    router.history.push(`/@${status.getIn(['account', 'acct'])}/${status.get('id')}`);
+    router.history.push(
+      `/@${status.getIn(['account', 'acct'])}/${status.get('id')}`,
+    );
   };
 
   handleHotkeyOpenProfile = () => {
@@ -305,12 +365,18 @@ class Status extends ImmutablePureComponent {
     router.history.push(`/@${status.getIn(['account', 'acct'])}`);
   };
 
-  handleHotkeyMoveUp = e => {
-    this.props.onMoveUp(this.props.status.get('id'), e.target.getAttribute('data-featured'));
+  handleHotkeyMoveUp = (e) => {
+    this.props.onMoveUp(
+      this.props.status.get('id'),
+      e.target.getAttribute('data-featured'),
+    );
   };
 
-  handleHotkeyMoveDown = e => {
-    this.props.onMoveDown(this.props.status.get('id'), e.target.getAttribute('data-featured'));
+  handleHotkeyMoveDown = (e) => {
+    this.props.onMoveDown(
+      this.props.status.get('id'),
+      e.target.getAttribute('data-featured'),
+    );
   };
 
   handleHotkeyToggleHidden = () => {
@@ -321,7 +387,7 @@ class Status extends ImmutablePureComponent {
     this.handleToggleMediaVisibility();
   };
 
-  handleUnfilterClick = e => {
+  handleUnfilterClick = (e) => {
     this.setState({ forceFilter: false });
     e.preventDefault();
   };
@@ -330,22 +396,36 @@ class Status extends ImmutablePureComponent {
     this.setState({ forceFilter: true });
   };
 
-  _properStatus () {
+  _properStatus() {
     const { status } = this.props;
 
-    if (status.get('reblog', null) !== null && typeof status.get('reblog') === 'object') {
+    if (
+      status.get('reblog', null) !== null &&
+      typeof status.get('reblog') === 'object'
+    ) {
       return status.get('reblog');
     } else {
       return status;
     }
   }
 
-  handleRef = c => {
+  handleRef = (c) => {
     this.node = c;
   };
 
-  render () {
-    const { intl, hidden, featured, unread, showThread, scrollKey, pictureInPicture, previousId, nextInReplyToId, rootId } = this.props;
+  render() {
+    const {
+      intl,
+      hidden,
+      featured,
+      unread,
+      showThread,
+      scrollKey,
+      pictureInPicture,
+      previousId,
+      nextInReplyToId,
+      rootId,
+    } = this.props;
 
     let { status, account, ...other } = this.props;
 
@@ -353,27 +433,38 @@ class Status extends ImmutablePureComponent {
       return null;
     }
 
-    const handlers = this.props.muted ? {} : {
-      reply: this.handleHotkeyReply,
-      favourite: this.handleHotkeyFavourite,
-      boost: this.handleHotkeyBoost,
-      mention: this.handleHotkeyMention,
-      open: this.handleHotkeyOpen,
-      openProfile: this.handleHotkeyOpenProfile,
-      moveUp: this.handleHotkeyMoveUp,
-      moveDown: this.handleHotkeyMoveDown,
-      toggleHidden: this.handleHotkeyToggleHidden,
-      toggleSensitive: this.handleHotkeyToggleSensitive,
-      openMedia: this.handleHotkeyOpenMedia,
-    };
+    const handlers = this.props.muted
+      ? {}
+      : {
+          reply: this.handleHotkeyReply,
+          favourite: this.handleHotkeyFavourite,
+          boost: this.handleHotkeyBoost,
+          mention: this.handleHotkeyMention,
+          open: this.handleHotkeyOpen,
+          openProfile: this.handleHotkeyOpenProfile,
+          moveUp: this.handleHotkeyMoveUp,
+          moveDown: this.handleHotkeyMoveDown,
+          toggleHidden: this.handleHotkeyToggleHidden,
+          toggleSensitive: this.handleHotkeyToggleSensitive,
+          openMedia: this.handleHotkeyOpenMedia,
+        };
 
     let media, statusAvatar, prepend, rebloggedByText;
 
     if (hidden) {
       return (
         <HotKeys handlers={handlers}>
-          <div ref={this.handleRef} className={classNames('status__wrapper', { focusable: !this.props.muted })} tabIndex={0}>
-            <span>{status.getIn(['account', 'display_name']) || status.getIn(['account', 'username'])}</span>
+          <div
+            ref={this.handleRef}
+            className={classNames('status__wrapper', {
+              focusable: !this.props.muted,
+            })}
+            tabIndex={0}
+          >
+            <span>
+              {status.getIn(['account', 'display_name']) ||
+                status.getIn(['account', 'username'])}
+            </span>
             <span>{status.get('content')}</span>
           </div>
         </HotKeys>
@@ -382,22 +473,39 @@ class Status extends ImmutablePureComponent {
 
     const connectUp = previousId && previousId === status.get('in_reply_to_id');
     const connectToRoot = rootId && rootId === status.get('in_reply_to_id');
-    const connectReply = nextInReplyToId && nextInReplyToId === status.get('id');
+    const connectReply =
+      nextInReplyToId && nextInReplyToId === status.get('id');
     const matchedFilters = status.get('matched_filters');
 
-    if (this.state.forceFilter === undefined ? matchedFilters : this.state.forceFilter) {
-      const minHandlers = this.props.muted ? {} : {
-        moveUp: this.handleHotkeyMoveUp,
-        moveDown: this.handleHotkeyMoveDown,
-      };
+    if (
+      this.state.forceFilter === undefined
+        ? matchedFilters
+        : this.state.forceFilter
+    ) {
+      const minHandlers = this.props.muted
+        ? {}
+        : {
+            moveUp: this.handleHotkeyMoveUp,
+            moveDown: this.handleHotkeyMoveDown,
+          };
 
       return (
         <HotKeys handlers={minHandlers}>
-          <div className='status__wrapper status__wrapper--filtered focusable' tabIndex={0} ref={this.handleRef}>
-            <FormattedMessage id='status.filtered' defaultMessage='Filtered' />: {matchedFilters.join(', ')}.
-            {' '}
-            <button className='status__wrapper--filtered__button' onClick={this.handleUnfilterClick}>
-              <FormattedMessage id='status.show_filter_reason' defaultMessage='Show anyway' />
+          <div
+            className='status__wrapper status__wrapper--filtered focusable'
+            tabIndex={0}
+            ref={this.handleRef}
+          >
+            <FormattedMessage id='status.filtered' defaultMessage='Filtered' />:{' '}
+            {matchedFilters.join(', ')}.{' '}
+            <button
+              className='status__wrapper--filtered__button'
+              onClick={this.handleUnfilterClick}
+            >
+              <FormattedMessage
+                id='status.show_filter_reason'
+                defaultMessage='Show anyway'
+              />
             </button>
           </div>
         </HotKeys>
@@ -407,67 +515,151 @@ class Status extends ImmutablePureComponent {
     if (featured) {
       prepend = (
         <div className='status__prepend'>
-          <div className='status__prepend-icon-wrapper'><Icon id='thumb-tack' className='status__prepend-icon' fixedWidth /></div>
+          <div className='status__prepend-icon-wrapper'>
+            <Icon id='thumb-tack' className='status__prepend-icon' fixedWidth />
+          </div>
           <FormattedMessage id='status.pinned' defaultMessage='Pinned post' />
         </div>
       );
-    } else if (status.get('reblog', null) !== null && typeof status.get('reblog') === 'object') {
-      const display_name_html = { __html: status.getIn(['account', 'display_name_html']) };
+    } else if (
+      status.get('reblog', null) !== null &&
+      typeof status.get('reblog') === 'object'
+    ) {
+      const display_name_html = {
+        __html: status.getIn(['account', 'display_name_html']),
+      };
 
       prepend = (
         <div className='status__prepend'>
-          <div className='status__prepend-icon-wrapper'><Icon id='retweet' className='status__prepend-icon' fixedWidth /></div>
-          <FormattedMessage id='status.reblogged_by' defaultMessage='{name} boosted' values={{ name: <a onClick={this.handlePrependAccountClick} data-id={status.getIn(['account', 'id'])} href={`/@${status.getIn(['account', 'acct'])}`} className='status__display-name muted'><bdi><strong dangerouslySetInnerHTML={display_name_html} /></bdi></a> }} />
+          <div className='status__prepend-icon-wrapper'>
+            <Icon id='retweet' className='status__prepend-icon' fixedWidth />
+          </div>
+          <FormattedMessage
+            id='status.reblogged_by'
+            defaultMessage='{name} boosted'
+            values={{
+              name: (
+                <a
+                  onClick={this.handlePrependAccountClick}
+                  data-id={status.getIn(['account', 'id'])}
+                  href={`/@${status.getIn(['account', 'acct'])}`}
+                  className='status__display-name muted'
+                >
+                  <bdi>
+                    <strong dangerouslySetInnerHTML={display_name_html} />
+                  </bdi>
+                </a>
+              ),
+            }}
+          />
         </div>
       );
 
-      rebloggedByText = intl.formatMessage({ id: 'status.reblogged_by', defaultMessage: '{name} boosted' }, { name: status.getIn(['account', 'acct']) });
+      rebloggedByText = intl.formatMessage(
+        { id: 'status.reblogged_by', defaultMessage: '{name} boosted' },
+        { name: status.getIn(['account', 'acct']) },
+      );
 
       account = status.get('account');
-      status  = status.get('reblog');
+      status = status.get('reblog');
     } else if (status.get('visibility') === 'direct') {
       prepend = (
         <div className='status__prepend'>
-          <div className='status__prepend-icon-wrapper'><Icon id='at' className='status__prepend-icon' fixedWidth /></div>
-          <FormattedMessage id='status.direct_indicator' defaultMessage='Private mention' />
+          <div className='status__prepend-icon-wrapper'>
+            <Icon id='at' className='status__prepend-icon' fixedWidth />
+          </div>
+          <FormattedMessage
+            id='status.direct_indicator'
+            defaultMessage='Private mention'
+          />
         </div>
       );
-    } else if (showThread && status.get('in_reply_to_id') && status.get('in_reply_to_account_id') === status.getIn(['account', 'id'])) {
-      const display_name_html = { __html: status.getIn(['account', 'display_name_html']) };
+    } else if (
+      showThread &&
+      status.get('in_reply_to_id') &&
+      status.get('in_reply_to_account_id') === status.getIn(['account', 'id'])
+    ) {
+      const display_name_html = {
+        __html: status.getIn(['account', 'display_name_html']),
+      };
 
       prepend = (
         <div className='status__prepend'>
-          <div className='status__prepend-icon-wrapper'><Icon id='reply' className='status__prepend-icon' fixedWidth /></div>
-          <FormattedMessage id='status.replied_to' defaultMessage='Replied to {name}' values={{ name: <a onClick={this.handlePrependAccountClick} data-id={status.getIn(['account', 'id'])} href={`/@${status.getIn(['account', 'acct'])}`} className='status__display-name muted'><bdi><strong dangerouslySetInnerHTML={display_name_html} /></bdi></a> }} />
+          <div className='status__prepend-icon-wrapper'>
+            <Icon id='reply' className='status__prepend-icon' fixedWidth />
+          </div>
+          <FormattedMessage
+            id='status.replied_to'
+            defaultMessage='Replied to {name}'
+            values={{
+              name: (
+                <a
+                  onClick={this.handlePrependAccountClick}
+                  data-id={status.getIn(['account', 'id'])}
+                  href={`/@${status.getIn(['account', 'acct'])}`}
+                  className='status__display-name muted'
+                >
+                  <bdi>
+                    <strong dangerouslySetInnerHTML={display_name_html} />
+                  </bdi>
+                </a>
+              ),
+            }}
+          />
         </div>
       );
     }
 
     if (pictureInPicture.get('inUse')) {
-      media = <PictureInPicturePlaceholder aspectRatio={this.getAttachmentAspectRatio()} />;
+      media = (
+        <PictureInPicturePlaceholder
+          aspectRatio={this.getAttachmentAspectRatio()}
+        />
+      );
     } else if (status.get('media_attachments').size > 0) {
-      const language = status.getIn(['translation', 'language']) || status.get('language');
+      const language =
+        status.getIn(['translation', 'language']) || status.get('language');
 
       if (status.getIn(['media_attachments', 0, 'type']) === 'audio') {
         const attachment = status.getIn(['media_attachments', 0]);
-        const description = attachment.getIn(['translation', 'description']) || attachment.get('description');
+        const description =
+          attachment.getIn(['translation', 'description']) ||
+          attachment.get('description');
 
         media = (
-          <Bundle fetchComponent={Audio} loading={this.renderLoadingAudioPlayer} >
-            {Component => (
+          <Bundle
+            fetchComponent={Audio}
+            loading={this.renderLoadingAudioPlayer}
+          >
+            {(Component) => (
               <Component
                 src={attachment.get('url')}
                 alt={description}
                 lang={language}
-                poster={attachment.get('preview_url') || status.getIn(['account', 'avatar_static'])}
-                backgroundColor={attachment.getIn(['meta', 'colors', 'background'])}
-                foregroundColor={attachment.getIn(['meta', 'colors', 'foreground'])}
+                poster={
+                  attachment.get('preview_url') ||
+                  status.getIn(['account', 'avatar_static'])
+                }
+                backgroundColor={attachment.getIn([
+                  'meta',
+                  'colors',
+                  'background',
+                ])}
+                foregroundColor={attachment.getIn([
+                  'meta',
+                  'colors',
+                  'foreground',
+                ])}
                 accentColor={attachment.getIn(['meta', 'colors', 'accent'])}
                 duration={attachment.getIn(['meta', 'original', 'duration'], 0)}
                 width={this.props.cachedMediaWidth}
                 height={110}
                 cacheWidth={this.props.cacheMediaWidth}
-                deployPictureInPicture={pictureInPicture.get('available') ? this.handleDeployPictureInPicture : undefined}
+                deployPictureInPicture={
+                  pictureInPicture.get('available')
+                    ? this.handleDeployPictureInPicture
+                    : undefined
+                }
                 sensitive={status.get('sensitive')}
                 blurhash={attachment.get('blurhash')}
                 visible={this.state.showMedia}
@@ -478,22 +670,35 @@ class Status extends ImmutablePureComponent {
         );
       } else if (status.getIn(['media_attachments', 0, 'type']) === 'video') {
         const attachment = status.getIn(['media_attachments', 0]);
-        const description = attachment.getIn(['translation', 'description']) || attachment.get('description');
+        const description =
+          attachment.getIn(['translation', 'description']) ||
+          attachment.get('description');
 
         media = (
-          <Bundle fetchComponent={Video} loading={this.renderLoadingVideoPlayer} >
-            {Component => (
+          <Bundle
+            fetchComponent={Video}
+            loading={this.renderLoadingVideoPlayer}
+          >
+            {(Component) => (
               <Component
                 preview={attachment.get('preview_url')}
                 frameRate={attachment.getIn(['meta', 'original', 'frame_rate'])}
-                aspectRatio={`${attachment.getIn(['meta', 'original', 'width'])} / ${attachment.getIn(['meta', 'original', 'height'])}`}
+                aspectRatio={`${attachment.getIn([
+                  'meta',
+                  'original',
+                  'width',
+                ])} / ${attachment.getIn(['meta', 'original', 'height'])}`}
                 blurhash={attachment.get('blurhash')}
                 src={attachment.get('url')}
                 alt={description}
                 lang={language}
                 sensitive={status.get('sensitive')}
                 onOpenVideo={this.handleOpenVideo}
-                deployPictureInPicture={pictureInPicture.get('available') ? this.handleDeployPictureInPicture : undefined}
+                deployPictureInPicture={
+                  pictureInPicture.get('available')
+                    ? this.handleDeployPictureInPicture
+                    : undefined
+                }
                 visible={this.state.showMedia}
                 onToggleVisibility={this.handleToggleMediaVisibility}
               />
@@ -502,8 +707,11 @@ class Status extends ImmutablePureComponent {
         );
       } else {
         media = (
-          <Bundle fetchComponent={MediaGallery} loading={this.renderLoadingMediaGallery}>
-            {Component => (
+          <Bundle
+            fetchComponent={MediaGallery}
+            loading={this.renderLoadingMediaGallery}
+          >
+            {(Component) => (
               <Component
                 media={status.get('media_attachments')}
                 lang={language}
@@ -533,40 +741,120 @@ class Status extends ImmutablePureComponent {
     if (account === undefined || account === null) {
       statusAvatar = <Avatar account={status.get('account')} size={46} />;
     } else {
-      statusAvatar = <AvatarOverlay account={status.get('account')} friend={account} />;
+      statusAvatar = (
+        <AvatarOverlay account={status.get('account')} friend={account} />
+      );
     }
 
     const visibilityIconInfo = {
-      'public': { icon: 'globe', text: intl.formatMessage(messages.public_short) },
-      'unlisted': { icon: 'unlock', text: intl.formatMessage(messages.unlisted_short) },
-      'private': { icon: 'lock', text: intl.formatMessage(messages.private_short) },
-      'direct': { icon: 'at', text: intl.formatMessage(messages.direct_short) },
+      public: {
+        icon: 'globe',
+        text: intl.formatMessage(messages.public_short),
+      },
+      unlisted: {
+        icon: 'unlock',
+        text: intl.formatMessage(messages.unlisted_short),
+      },
+      private: {
+        icon: 'lock',
+        text: intl.formatMessage(messages.private_short),
+      },
+      direct: { icon: 'at', text: intl.formatMessage(messages.direct_short) },
     };
 
     const visibilityIcon = visibilityIconInfo[status.get('visibility')];
 
-    const {statusContentProps, hashtagBar} = getHashtagBarForStatus(status);
-    const expanded = !status.get('hidden')
+    const { statusContentProps, hashtagBar } = getHashtagBarForStatus(status);
+    const expanded = !status.get('hidden');
 
     return (
       <HotKeys handlers={handlers}>
-        <div className={classNames('status__wrapper', `status__wrapper-${status.get('visibility')}`, { 'status__wrapper-reply': !!status.get('in_reply_to_id'), unread, focusable: !this.props.muted })} tabIndex={this.props.muted ? null : 0} data-featured={featured ? 'true' : null} aria-label={textForScreenReader(intl, status, rebloggedByText)} ref={this.handleRef} data-nosnippet={status.getIn(['account', 'noindex'], true) || undefined}>
+        <div
+          className={classNames(
+            'status__wrapper',
+            `status__wrapper-${status.get('visibility')}`,
+            {
+              'status__wrapper-reply': !!status.get('in_reply_to_id'),
+              unread,
+              focusable: !this.props.muted,
+            },
+          )}
+          tabIndex={this.props.muted ? null : 0}
+          data-featured={featured ? 'true' : null}
+          aria-label={textForScreenReader(intl, status, rebloggedByText)}
+          ref={this.handleRef}
+          data-nosnippet={
+            status.getIn(['account', 'noindex'], true) || undefined
+          }
+        >
           {prepend}
 
-          <div className={classNames('status', `status-${status.get('visibility')}`, { 'status-reply': !!status.get('in_reply_to_id'), 'status--in-thread': !!rootId, 'status--first-in-thread': previousId && (!connectUp || connectToRoot), muted: this.props.muted })} data-id={status.get('id')}>
-            {(connectReply || connectUp || connectToRoot) && <div className={classNames('status__line', { 'status__line--full': connectReply, 'status__line--first': !status.get('in_reply_to_id') && !connectToRoot })} />}
+          <div
+            className={classNames(
+              'status',
+              `status-${status.get('visibility')}`,
+              {
+                'status-reply': !!status.get('in_reply_to_id'),
+                'status--in-thread': !!rootId,
+                'status--first-in-thread':
+                  previousId && (!connectUp || connectToRoot),
+                muted: this.props.muted,
+              },
+            )}
+            data-id={status.get('id')}
+          >
+            {(connectReply || connectUp || connectToRoot) && (
+              <div
+                className={classNames('status__line', {
+                  'status__line--full': connectReply,
+                  'status__line--first':
+                    !status.get('in_reply_to_id') && !connectToRoot,
+                })}
+              />
+            )}
 
             {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
             <div onClick={this.handleClick} className='status__info'>
-              <a href={`/@${status.getIn(['account', 'acct'])}/${status.get('id')}`} className='status__relative-time' target='_blank' rel='noopener noreferrer'>
-                <span className='status__visibility-icon'><Icon id={visibilityIcon.icon} title={visibilityIcon.text} /></span>
-                <RelativeTimestamp timestamp={status.get('created_at')} />{status.get('edited_at') && <abbr title={intl.formatMessage(messages.edited, { date: intl.formatDate(status.get('edited_at'), { hour12: false, year: 'numeric', month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit' }) })}> *</abbr>}
+              <a
+                href={`/@${status.getIn(['account', 'acct'])}/${status.get(
+                  'id',
+                )}`}
+                className='status__relative-time'
+                target='_blank'
+                rel='noopener noreferrer'
+              >
+                <span className='status__visibility-icon'>
+                  <Icon id={visibilityIcon.icon} title={visibilityIcon.text} />
+                </span>
+                <RelativeTimestamp timestamp={status.get('created_at')} />
+                {status.get('edited_at') && (
+                  <abbr
+                    title={intl.formatMessage(messages.edited, {
+                      date: intl.formatDate(status.get('edited_at'), {
+                        hour12: false,
+                        year: 'numeric',
+                        month: 'short',
+                        day: '2-digit',
+                        hour: '2-digit',
+                        minute: '2-digit',
+                      }),
+                    })}
+                  >
+                    {' '}
+                    *
+                  </abbr>
+                )}
               </a>
 
-              <a onClick={this.handleAccountClick} href={`/@${status.getIn(['account', 'acct'])}`} title={status.getIn(['account', 'acct'])} className='status__display-name' target='_blank' rel='noopener noreferrer'>
-                <div className='status__avatar'>
-                  {statusAvatar}
-                </div>
+              <a
+                onClick={this.handleAccountClick}
+                href={`/@${status.getIn(['account', 'acct'])}`}
+                title={status.getIn(['account', 'acct'])}
+                className='status__display-name'
+                target='_blank'
+                rel='noopener noreferrer'
+              >
+                <div className='status__avatar'>{statusAvatar}</div>
 
                 <DisplayName account={status.get('account')} />
               </a>
@@ -587,13 +875,18 @@ class Status extends ImmutablePureComponent {
 
             {expanded && hashtagBar}
 
-            <StatusActionBar scrollKey={scrollKey} status={status} account={account} onFilter={matchedFilters ? this.handleFilterClick : null} {...other} />
+            <StatusActionBar
+              scrollKey={scrollKey}
+              status={status}
+              account={account}
+              onFilter={matchedFilters ? this.handleFilterClick : null}
+              {...other}
+            />
           </div>
         </div>
       </HotKeys>
     );
   }
-
 }
 
 export default injectIntl(Status);

--- a/app/javascript/mastodon/components/status_action_bar.jsx
+++ b/app/javascript/mastodon/components/status_action_bar.jsx
@@ -8,7 +8,10 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 import { connect } from 'react-redux';
 
-import { PERMISSION_MANAGE_USERS, PERMISSION_MANAGE_FEDERATION } from 'mastodon/permissions';
+import {
+  PERMISSION_MANAGE_USERS,
+  PERMISSION_MANAGE_FEDERATION,
+} from 'mastodon/permissions';
 
 import DropdownMenuContainer from '../containers/dropdown_menu_container';
 import { me } from '../initial_state';
@@ -28,30 +31,66 @@ const messages = defineMessages({
   more: { id: 'status.more', defaultMessage: 'More' },
   replyAll: { id: 'status.replyAll', defaultMessage: 'Reply to thread' },
   reblog: { id: 'status.reblog', defaultMessage: 'Boost' },
-  reblog_private: { id: 'status.reblog_private', defaultMessage: 'Boost with original visibility' },
-  cancel_reblog_private: { id: 'status.cancel_reblog_private', defaultMessage: 'Unboost' },
-  cannot_reblog: { id: 'status.cannot_reblog', defaultMessage: 'This post cannot be boosted' },
+  reblog_private: {
+    id: 'status.reblog_private',
+    defaultMessage: 'Boost with original visibility',
+  },
+  cancel_reblog_private: {
+    id: 'status.cancel_reblog_private',
+    defaultMessage: 'Unboost',
+  },
+  cannot_reblog: {
+    id: 'status.cannot_reblog',
+    defaultMessage: 'This post cannot be boosted',
+  },
   favourite: { id: 'status.favourite', defaultMessage: 'Favorite' },
   bookmark: { id: 'status.bookmark', defaultMessage: 'Bookmark' },
-  removeBookmark: { id: 'status.remove_bookmark', defaultMessage: 'Remove bookmark' },
+  removeBookmark: {
+    id: 'status.remove_bookmark',
+    defaultMessage: 'Remove bookmark',
+  },
   open: { id: 'status.open', defaultMessage: 'Expand this status' },
   report: { id: 'status.report', defaultMessage: 'Report @{name}' },
-  muteConversation: { id: 'status.mute_conversation', defaultMessage: 'Mute conversation' },
-  unmuteConversation: { id: 'status.unmute_conversation', defaultMessage: 'Unmute conversation' },
+  muteConversation: {
+    id: 'status.mute_conversation',
+    defaultMessage: 'Mute conversation',
+  },
+  unmuteConversation: {
+    id: 'status.unmute_conversation',
+    defaultMessage: 'Unmute conversation',
+  },
   pin: { id: 'status.pin', defaultMessage: 'Pin on profile' },
   unpin: { id: 'status.unpin', defaultMessage: 'Unpin from profile' },
   embed: { id: 'status.embed', defaultMessage: 'Embed' },
-  admin_account: { id: 'status.admin_account', defaultMessage: 'Open moderation interface for @{name}' },
-  admin_status: { id: 'status.admin_status', defaultMessage: 'Open this post in the moderation interface' },
-  admin_domain: { id: 'status.admin_domain', defaultMessage: 'Open moderation interface for {domain}' },
+  admin_account: {
+    id: 'status.admin_account',
+    defaultMessage: 'Open moderation interface for @{name}',
+  },
+  admin_status: {
+    id: 'status.admin_status',
+    defaultMessage: 'Open this post in the moderation interface',
+  },
+  admin_domain: {
+    id: 'status.admin_domain',
+    defaultMessage: 'Open moderation interface for {domain}',
+  },
   copy: { id: 'status.copy', defaultMessage: 'Copy link to post' },
   hide: { id: 'status.hide', defaultMessage: 'Hide post' },
-  blockDomain: { id: 'account.block_domain', defaultMessage: 'Block domain {domain}' },
-  unblockDomain: { id: 'account.unblock_domain', defaultMessage: 'Unblock domain {domain}' },
+  blockDomain: {
+    id: 'account.block_domain',
+    defaultMessage: 'Block domain {domain}',
+  },
+  unblockDomain: {
+    id: 'account.unblock_domain',
+    defaultMessage: 'Unblock domain {domain}',
+  },
   unmute: { id: 'account.unmute', defaultMessage: 'Unmute @{name}' },
   unblock: { id: 'account.unblock', defaultMessage: 'Unblock @{name}' },
   filter: { id: 'status.filter', defaultMessage: 'Filter this post' },
-  openOriginalPage: { id: 'account.open_original_page', defaultMessage: 'Open original page' },
+  openOriginalPage: {
+    id: 'account.open_original_page',
+    defaultMessage: 'Open original page',
+  },
 });
 
 const mapStateToProps = (state, { status }) => ({
@@ -59,7 +98,6 @@ const mapStateToProps = (state, { status }) => ({
 });
 
 class StatusActionBar extends ImmutablePureComponent {
-
   static contextTypes = {
     router: PropTypes.object,
     identity: PropTypes.object,
@@ -96,11 +134,7 @@ class StatusActionBar extends ImmutablePureComponent {
 
   // Avoid checking props that are functions (and whose equality will always
   // evaluate to false. See react-immutable-pure-component for usage.
-  updateOnProps = [
-    'status',
-    'relationship',
-    'withDismiss',
-  ];
+  updateOnProps = ['status', 'relationship', 'withDismiss'];
 
   handleReplyClick = () => {
     const { signedIn } = this.context.identity;
@@ -113,11 +147,13 @@ class StatusActionBar extends ImmutablePureComponent {
   };
 
   handleShareClick = () => {
-    navigator.share({
-      url: this.props.status.get('url'),
-    }).catch((e) => {
-      if (e.name !== 'AbortError') console.error(e);
-    });
+    navigator
+      .share({
+        url: this.props.status.get('url'),
+      })
+      .catch((e) => {
+        if (e.name !== 'AbortError') console.error(e);
+      });
   };
 
   handleFavouriteClick = () => {
@@ -130,7 +166,7 @@ class StatusActionBar extends ImmutablePureComponent {
     }
   };
 
-  handleReblogClick = e => {
+  handleReblogClick = (e) => {
     const { signedIn } = this.context.identity;
 
     if (signedIn) {
@@ -161,11 +197,17 @@ class StatusActionBar extends ImmutablePureComponent {
   };
 
   handleMentionClick = () => {
-    this.props.onMention(this.props.status.get('account'), this.context.router.history);
+    this.props.onMention(
+      this.props.status.get('account'),
+      this.context.router.history,
+    );
   };
 
   handleDirectClick = () => {
-    this.props.onDirect(this.props.status.get('account'), this.context.router.history);
+    this.props.onDirect(
+      this.props.status.get('account'),
+      this.context.router.history,
+    );
   };
 
   handleMuteClick = () => {
@@ -205,7 +247,12 @@ class StatusActionBar extends ImmutablePureComponent {
   };
 
   handleOpen = () => {
-    this.context.router.history.push(`/@${this.props.status.getIn(['account', 'acct'])}/${this.props.status.get('id')}`);
+    this.context.router.history.push(
+      `/@${this.props.status.getIn([
+        'account',
+        'acct',
+      ])}/${this.props.status.get('id')}`,
+    );
   };
 
   handleEmbed = () => {
@@ -233,79 +280,173 @@ class StatusActionBar extends ImmutablePureComponent {
     this.props.onFilter();
   };
 
-  render () {
-    const { status, relationship, intl, withDismiss, withCounters, scrollKey } = this.props;
+  render() {
+    const { status, relationship, intl, withDismiss, withCounters, scrollKey } =
+      this.props;
     const { signedIn, permissions } = this.context.identity;
 
-    const publicStatus       = ['public', 'unlisted'].includes(status.get('visibility'));
-    const pinnableStatus     = ['public', 'unlisted', 'private'].includes(status.get('visibility'));
+    const publicStatus = ['public', 'unlisted'].includes(
+      status.get('visibility'),
+    );
+    const pinnableStatus = ['public', 'unlisted', 'private'].includes(
+      status.get('visibility'),
+    );
     const mutingConversation = status.get('muted');
-    const account            = status.get('account');
-    const writtenByMe        = status.getIn(['account', 'id']) === me;
-    const isRemote           = status.getIn(['account', 'username']) !== status.getIn(['account', 'acct']);
+    const account = status.get('account');
+    const writtenByMe = status.getIn(['account', 'id']) === me;
+    const isRemote =
+      status.getIn(['account', 'username']) !==
+      status.getIn(['account', 'acct']);
 
     let menu = [];
 
-    menu.push({ text: intl.formatMessage(messages.open), action: this.handleOpen });
+    menu.push({
+      text: intl.formatMessage(messages.open),
+      action: this.handleOpen,
+    });
 
     if (publicStatus && isRemote) {
-      menu.push({ text: intl.formatMessage(messages.openOriginalPage), href: status.get('url') });
+      menu.push({
+        text: intl.formatMessage(messages.openOriginalPage),
+        href: status.get('url'),
+      });
     }
 
-    menu.push({ text: intl.formatMessage(messages.copy), action: this.handleCopy });
+    menu.push({
+      text: intl.formatMessage(messages.copy),
+      action: this.handleCopy,
+    });
 
     if (publicStatus && 'share' in navigator) {
-      menu.push({ text: intl.formatMessage(messages.share), action: this.handleShareClick });
+      menu.push({
+        text: intl.formatMessage(messages.share),
+        action: this.handleShareClick,
+      });
     }
 
     if (publicStatus && (signedIn || !isRemote)) {
-      menu.push({ text: intl.formatMessage(messages.embed), action: this.handleEmbed });
+      menu.push({
+        text: intl.formatMessage(messages.embed),
+        action: this.handleEmbed,
+      });
     }
 
     if (signedIn) {
       menu.push(null);
 
-      menu.push({ text: intl.formatMessage(status.get('bookmarked') ? messages.removeBookmark : messages.bookmark), action: this.handleBookmarkClick });
+      menu.push({
+        text: intl.formatMessage(
+          status.get('bookmarked')
+            ? messages.removeBookmark
+            : messages.bookmark,
+        ),
+        action: this.handleBookmarkClick,
+      });
 
       if (writtenByMe && pinnableStatus) {
-        menu.push({ text: intl.formatMessage(status.get('pinned') ? messages.unpin : messages.pin), action: this.handlePinClick });
+        menu.push({
+          text: intl.formatMessage(
+            status.get('pinned') ? messages.unpin : messages.pin,
+          ),
+          action: this.handlePinClick,
+        });
       }
 
       menu.push(null);
 
       if (writtenByMe || withDismiss) {
-        menu.push({ text: intl.formatMessage(mutingConversation ? messages.unmuteConversation : messages.muteConversation), action: this.handleConversationMuteClick });
+        menu.push({
+          text: intl.formatMessage(
+            mutingConversation
+              ? messages.unmuteConversation
+              : messages.muteConversation,
+          ),
+          action: this.handleConversationMuteClick,
+        });
         menu.push(null);
       }
 
       if (writtenByMe) {
-        menu.push({ text: intl.formatMessage(messages.edit), action: this.handleEditClick });
-        menu.push({ text: intl.formatMessage(messages.delete), action: this.handleDeleteClick, dangerous: true });
-        menu.push({ text: intl.formatMessage(messages.redraft), action: this.handleRedraftClick, dangerous: true });
+        menu.push({
+          text: intl.formatMessage(messages.edit),
+          action: this.handleEditClick,
+        });
+        menu.push({
+          text: intl.formatMessage(messages.delete),
+          action: this.handleDeleteClick,
+          dangerous: true,
+        });
+        menu.push({
+          text: intl.formatMessage(messages.redraft),
+          action: this.handleRedraftClick,
+          dangerous: true,
+        });
       } else {
-        menu.push({ text: intl.formatMessage(messages.mention, { name: account.get('username') }), action: this.handleMentionClick });
-        menu.push({ text: intl.formatMessage(messages.direct, { name: account.get('username') }), action: this.handleDirectClick });
+        menu.push({
+          text: intl.formatMessage(messages.mention, {
+            name: account.get('username'),
+          }),
+          action: this.handleMentionClick,
+        });
+        menu.push({
+          text: intl.formatMessage(messages.direct, {
+            name: account.get('username'),
+          }),
+          action: this.handleDirectClick,
+        });
         menu.push(null);
 
         if (relationship && relationship.get('muting')) {
-          menu.push({ text: intl.formatMessage(messages.unmute, { name: account.get('username') }), action: this.handleMuteClick });
+          menu.push({
+            text: intl.formatMessage(messages.unmute, {
+              name: account.get('username'),
+            }),
+            action: this.handleMuteClick,
+          });
         } else {
-          menu.push({ text: intl.formatMessage(messages.mute, { name: account.get('username') }), action: this.handleMuteClick, dangerous: true });
+          menu.push({
+            text: intl.formatMessage(messages.mute, {
+              name: account.get('username'),
+            }),
+            action: this.handleMuteClick,
+            dangerous: true,
+          });
         }
 
         if (relationship && relationship.get('blocking')) {
-          menu.push({ text: intl.formatMessage(messages.unblock, { name: account.get('username') }), action: this.handleBlockClick });
+          menu.push({
+            text: intl.formatMessage(messages.unblock, {
+              name: account.get('username'),
+            }),
+            action: this.handleBlockClick,
+          });
         } else {
-          menu.push({ text: intl.formatMessage(messages.block, { name: account.get('username') }), action: this.handleBlockClick, dangerous: true });
+          menu.push({
+            text: intl.formatMessage(messages.block, {
+              name: account.get('username'),
+            }),
+            action: this.handleBlockClick,
+            dangerous: true,
+          });
         }
 
         if (!this.props.onFilter) {
           menu.push(null);
-          menu.push({ text: intl.formatMessage(messages.filter), action: this.handleFilterClick, dangerous: true });
+          menu.push({
+            text: intl.formatMessage(messages.filter),
+            action: this.handleFilterClick,
+            dangerous: true,
+          });
           menu.push(null);
         }
 
-        menu.push({ text: intl.formatMessage(messages.report, { name: account.get('username') }), action: this.handleReport, dangerous: true });
+        menu.push({
+          text: intl.formatMessage(messages.report, {
+            name: account.get('username'),
+          }),
+          action: this.handleReport,
+          dangerous: true,
+        });
 
         if (account.get('acct') !== account.get('username')) {
           const domain = account.get('acct').split('@')[1];
@@ -313,21 +454,56 @@ class StatusActionBar extends ImmutablePureComponent {
           menu.push(null);
 
           if (relationship && relationship.get('domain_blocking')) {
-            menu.push({ text: intl.formatMessage(messages.unblockDomain, { domain }), action: this.handleUnblockDomain });
+            menu.push({
+              text: intl.formatMessage(messages.unblockDomain, { domain }),
+              action: this.handleUnblockDomain,
+            });
           } else {
-            menu.push({ text: intl.formatMessage(messages.blockDomain, { domain }), action: this.handleBlockDomain, dangerous: true });
+            menu.push({
+              text: intl.formatMessage(messages.blockDomain, { domain }),
+              action: this.handleBlockDomain,
+              dangerous: true,
+            });
           }
         }
 
-        if ((permissions & PERMISSION_MANAGE_USERS) === PERMISSION_MANAGE_USERS || (isRemote && (permissions & PERMISSION_MANAGE_FEDERATION) === PERMISSION_MANAGE_FEDERATION)) {
+        if (
+          (permissions & PERMISSION_MANAGE_USERS) === PERMISSION_MANAGE_USERS ||
+          (isRemote &&
+            (permissions & PERMISSION_MANAGE_FEDERATION) ===
+              PERMISSION_MANAGE_FEDERATION)
+        ) {
           menu.push(null);
-          if ((permissions & PERMISSION_MANAGE_USERS) === PERMISSION_MANAGE_USERS) {
-            menu.push({ text: intl.formatMessage(messages.admin_account, { name: account.get('username') }), href: `/admin/accounts/${status.getIn(['account', 'id'])}` });
-            menu.push({ text: intl.formatMessage(messages.admin_status), href: `/admin/accounts/${status.getIn(['account', 'id'])}/statuses/${status.get('id')}` });
+          if (
+            (permissions & PERMISSION_MANAGE_USERS) ===
+            PERMISSION_MANAGE_USERS
+          ) {
+            menu.push({
+              text: intl.formatMessage(messages.admin_account, {
+                name: account.get('username'),
+              }),
+              href: `/admin/accounts/${status.getIn(['account', 'id'])}`,
+            });
+            menu.push({
+              text: intl.formatMessage(messages.admin_status),
+              href: `/admin/accounts/${status.getIn([
+                'account',
+                'id',
+              ])}/statuses/${status.get('id')}`,
+            });
           }
-          if (isRemote && (permissions & PERMISSION_MANAGE_FEDERATION) === PERMISSION_MANAGE_FEDERATION) {
+          if (
+            isRemote &&
+            (permissions & PERMISSION_MANAGE_FEDERATION) ===
+              PERMISSION_MANAGE_FEDERATION
+          ) {
             const domain = account.get('acct').split('@')[1];
-            menu.push({ text: intl.formatMessage(messages.admin_domain, { domain: domain }), href: `/admin/instances/${domain}` });
+            menu.push({
+              text: intl.formatMessage(messages.admin_domain, {
+                domain: domain,
+              }),
+              href: `/admin/instances/${domain}`,
+            });
           }
         }
       }
@@ -343,7 +519,9 @@ class StatusActionBar extends ImmutablePureComponent {
       replyTitle = intl.formatMessage(messages.replyAll);
     }
 
-    const reblogPrivate = status.getIn(['account', 'id']) === me && status.get('visibility') === 'private';
+    const reblogPrivate =
+      status.getIn(['account', 'id']) === me &&
+      status.get('visibility') === 'private';
 
     let reblogTitle = '';
     if (status.get('reblogged')) {
@@ -357,15 +535,56 @@ class StatusActionBar extends ImmutablePureComponent {
     }
 
     const filterButton = this.props.onFilter && (
-      <IconButton className='status__action-bar__button' title={intl.formatMessage(messages.hide)} icon='eye' onClick={this.handleHideClick} />
+      <IconButton
+        className='status__action-bar__button'
+        title={intl.formatMessage(messages.hide)}
+        icon='eye'
+        onClick={this.handleHideClick}
+      />
     );
 
     return (
       <div className='status__action-bar'>
-        <IconButton className='status__action-bar__button' title={replyTitle} icon={status.get('in_reply_to_account_id') === status.getIn(['account', 'id']) ? 'reply' : replyIcon} onClick={this.handleReplyClick} counter={status.get('replies_count')} />
-        <IconButton className={classNames('status__action-bar__button', { reblogPrivate })} disabled={!publicStatus && !reblogPrivate} active={status.get('reblogged')} title={reblogTitle} icon='retweet' onClick={this.handleReblogClick} counter={withCounters ? status.get('reblogs_count') : undefined} />
-        <IconButton className='status__action-bar__button star-icon' animate active={status.get('favourited')} title={intl.formatMessage(messages.favourite)} icon='star' onClick={this.handleFavouriteClick} counter={withCounters ? status.get('favourites_count') : undefined} />
-        <IconButton className='status__action-bar__button bookmark-icon' disabled={!signedIn} active={status.get('bookmarked')} title={intl.formatMessage(messages.bookmark)} icon='bookmark' onClick={this.handleBookmarkClick} />
+        <IconButton
+          className='status__action-bar__button'
+          title={replyTitle}
+          icon={
+            status.get('in_reply_to_account_id') ===
+            status.getIn(['account', 'id'])
+              ? 'reply'
+              : replyIcon
+          }
+          onClick={this.handleReplyClick}
+          counter={status.get('replies_count')}
+        />
+        <IconButton
+          className={classNames('status__action-bar__button', {
+            reblogPrivate,
+          })}
+          disabled={!publicStatus && !reblogPrivate}
+          active={status.get('reblogged')}
+          title={reblogTitle}
+          icon='retweet'
+          onClick={this.handleReblogClick}
+          counter={withCounters ? status.get('reblogs_count') : undefined}
+        />
+        <IconButton
+          className='status__action-bar__button star-icon'
+          animate
+          active={status.get('favourited')}
+          title={intl.formatMessage(messages.favourite)}
+          icon='star'
+          onClick={this.handleFavouriteClick}
+          counter={withCounters ? status.get('favourites_count') : undefined}
+        />
+        <IconButton
+          className='status__action-bar__button bookmark-icon'
+          disabled={!signedIn}
+          active={status.get('bookmarked')}
+          title={intl.formatMessage(messages.bookmark)}
+          icon='bookmark'
+          onClick={this.handleBookmarkClick}
+        />
 
         {filterButton}
 
@@ -383,7 +602,6 @@ class StatusActionBar extends ImmutablePureComponent {
       </div>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(injectIntl(StatusActionBar));

--- a/app/javascript/mastodon/components/status_content.jsx
+++ b/app/javascript/mastodon/components/status_content.jsx
@@ -9,9 +9,12 @@ import { Link } from 'react-router-dom';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
 
-import { Icon }  from 'mastodon/components/icon';
+import { Icon } from 'mastodon/components/icon';
 import PollContainer from 'mastodon/containers/poll_container';
-import { autoPlayGif, languages as preloadedLanguages } from 'mastodon/initial_state';
+import {
+  autoPlayGif,
+  languages as preloadedLanguages,
+} from 'mastodon/initial_state';
 
 const MAX_HEIGHT = 706; // 22px * 32 (+ 2px padding at the top)
 
@@ -21,32 +24,44 @@ const MAX_HEIGHT = 706; // 22px * 32 (+ 2px padding at the top)
  * @returns {string}
  */
 export function getStatusContent(status) {
-  return status.getIn(['translation', 'contentHtml']) || status.get('contentHtml');
+  return (
+    status.getIn(['translation', 'contentHtml']) || status.get('contentHtml')
+  );
 }
 
 class TranslateButton extends PureComponent {
-
   static propTypes = {
     translation: ImmutablePropTypes.map,
     onClick: PropTypes.func,
   };
 
-  render () {
+  render() {
     const { translation, onClick } = this.props;
 
     if (translation) {
-      const language     = preloadedLanguages.find(lang => lang[0] === translation.get('detected_source_language'));
-      const languageName = language ? language[2] : translation.get('detected_source_language');
-      const provider     = translation.get('provider');
+      const language = preloadedLanguages.find(
+        (lang) => lang[0] === translation.get('detected_source_language'),
+      );
+      const languageName = language
+        ? language[2]
+        : translation.get('detected_source_language');
+      const provider = translation.get('provider');
 
       return (
         <div className='translate-button'>
           <div className='translate-button__meta'>
-            <FormattedMessage id='status.translated_from_with' defaultMessage='Translated from {lang} using {provider}' values={{ lang: languageName, provider }} />
+            <FormattedMessage
+              id='status.translated_from_with'
+              defaultMessage='Translated from {lang} using {provider}'
+              values={{ lang: languageName, provider }}
+            />
           </div>
 
           <button className='link-button' onClick={onClick}>
-            <FormattedMessage id='status.show_original' defaultMessage='Show original' />
+            <FormattedMessage
+              id='status.show_original'
+              defaultMessage='Show original'
+            />
           </button>
         </div>
       );
@@ -58,15 +73,13 @@ class TranslateButton extends PureComponent {
       </button>
     );
   }
-
 }
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   languages: state.getIn(['server', 'translationLanguages', 'items']),
 });
 
 class StatusContent extends PureComponent {
-
   static contextTypes = {
     router: PropTypes.object,
     identity: PropTypes.object,
@@ -89,7 +102,7 @@ class StatusContent extends PureComponent {
     hidden: true,
   };
 
-  _updateStatusLinks () {
+  _updateStatusLinks() {
     const node = this.node;
 
     if (!node) {
@@ -110,14 +123,31 @@ class StatusContent extends PureComponent {
 
       link.classList.add('status-link');
 
-      mention = this.props.status.get('mentions').find(item => link.href === item.get('url'));
+      mention = this.props.status
+        .get('mentions')
+        .find((item) => link.href === item.get('url'));
 
       if (mention) {
-        link.addEventListener('click', this.onMentionClick.bind(this, mention), false);
+        link.addEventListener(
+          'click',
+          this.onMentionClick.bind(this, mention),
+          false,
+        );
         link.setAttribute('title', `@${mention.get('acct')}`);
         link.setAttribute('href', `/@${mention.get('acct')}`);
-      } else if (link.textContent[0] === '#' || (link.previousSibling && link.previousSibling.textContent && link.previousSibling.textContent[link.previousSibling.textContent.length - 1] === '#')) {
-        link.addEventListener('click', this.onHashtagClick.bind(this, link.text), false);
+      } else if (
+        link.textContent[0] === '#' ||
+        (link.previousSibling &&
+          link.previousSibling.textContent &&
+          link.previousSibling.textContent[
+            link.previousSibling.textContent.length - 1
+          ] === '#')
+      ) {
+        link.addEventListener(
+          'click',
+          this.onHashtagClick.bind(this, link.text),
+          false,
+        );
         link.setAttribute('href', `/tags/${link.text.replace(/^#/, '')}`);
       } else {
         link.setAttribute('title', link.href);
@@ -129,10 +159,10 @@ class StatusContent extends PureComponent {
       const { collapsible, onClick } = this.props;
 
       const collapsed =
-          collapsible
-          && onClick
-          && node.clientHeight > MAX_HEIGHT
-          && status.get('spoiler_text').length === 0;
+        collapsible &&
+        onClick &&
+        node.clientHeight > MAX_HEIGHT &&
+        status.get('spoiler_text').length === 0;
 
       onCollapsedToggle(collapsed);
     }
@@ -164,11 +194,11 @@ class StatusContent extends PureComponent {
     }
   };
 
-  componentDidMount () {
+  componentDidMount() {
     this._updateStatusLinks();
   }
 
-  componentDidUpdate () {
+  componentDidUpdate() {
     this._updateStatusLinks();
   }
 
@@ -197,12 +227,19 @@ class StatusContent extends PureComponent {
       return;
     }
 
-    const [ startX, startY ] = this.startXY;
-    const [ deltaX, deltaY ] = [Math.abs(e.clientX - startX), Math.abs(e.clientY - startY)];
+    const [startX, startY] = this.startXY;
+    const [deltaX, deltaY] = [
+      Math.abs(e.clientX - startX),
+      Math.abs(e.clientY - startY),
+    ];
 
     let element = e.target;
     while (element) {
-      if (element.localName === 'button' || element.localName === 'a' || element.localName === 'label') {
+      if (
+        element.localName === 'button' ||
+        element.localName === 'a' ||
+        element.localName === 'label'
+      ) {
         return;
       }
       element = element.parentNode;
@@ -234,18 +271,32 @@ class StatusContent extends PureComponent {
     this.node = c;
   };
 
-  render () {
+  render() {
     const { status, intl, statusContent } = this.props;
 
-    const hidden = this.props.onExpandedToggle ? !this.props.expanded : this.state.hidden;
+    const hidden = this.props.onExpandedToggle
+      ? !this.props.expanded
+      : this.state.hidden;
     const renderReadMore = this.props.onClick && status.get('collapsed');
     const contentLocale = intl.locale.replace(/[_-].*/, '');
-    const targetLanguages = this.props.languages?.get(status.get('language') || 'und');
-    const renderTranslate = this.props.onTranslate && this.context.identity.signedIn && ['public', 'unlisted'].includes(status.get('visibility')) && status.get('search_index').trim().length > 0 && targetLanguages?.includes(contentLocale);
+    const targetLanguages = this.props.languages?.get(
+      status.get('language') || 'und',
+    );
+    const renderTranslate =
+      this.props.onTranslate &&
+      this.context.identity.signedIn &&
+      ['public', 'unlisted'].includes(status.get('visibility')) &&
+      status.get('search_index').trim().length > 0 &&
+      targetLanguages?.includes(contentLocale);
 
     const content = { __html: statusContent ?? getStatusContent(status) };
-    const spoilerContent = { __html: status.getIn(['translation', 'spoilerHtml']) || status.get('spoilerHtml') };
-    const language = status.getIn(['translation', 'language']) || status.get('language');
+    const spoilerContent = {
+      __html:
+        status.getIn(['translation', 'spoilerHtml']) ||
+        status.get('spoilerHtml'),
+    };
+    const language =
+      status.getIn(['translation', 'language']) || status.get('language');
     const classNames = classnames('status__content', {
       'status__content--with-action': this.props.onClick && this.context.router,
       'status__content--with-spoiler': status.get('spoiler_text').length > 0,
@@ -253,13 +304,21 @@ class StatusContent extends PureComponent {
     });
 
     const readMoreButton = renderReadMore && (
-      <button className='status__content__read-more-button' onClick={this.props.onClick} key='read-more'>
-        <FormattedMessage id='status.read_more' defaultMessage='Read more' /><Icon id='angle-right' fixedWidth />
+      <button
+        className='status__content__read-more-button'
+        onClick={this.props.onClick}
+        key='read-more'
+      >
+        <FormattedMessage id='status.read_more' defaultMessage='Read more' />
+        <Icon id='angle-right' fixedWidth />
       </button>
     );
 
     const translateButton = renderTranslate && (
-      <TranslateButton onClick={this.handleTranslate} translation={status.get('translation')} />
+      <TranslateButton
+        onClick={this.handleTranslate}
+        translation={status.get('translation')}
+      />
     );
 
     const poll = !!status.get('poll') && (
@@ -269,29 +328,74 @@ class StatusContent extends PureComponent {
     if (status.get('spoiler_text').length > 0) {
       let mentionsPlaceholder = '';
 
-      const mentionLinks = status.get('mentions').map(item => (
-        <Link to={`/@${item.get('acct')}`} key={item.get('id')} className='status-link mention'>
-          @<span>{item.get('username')}</span>
-        </Link>
-      )).reduce((aggregate, item) => [...aggregate, item, ' '], []);
+      const mentionLinks = status
+        .get('mentions')
+        .map((item) => (
+          <Link
+            to={`/@${item.get('acct')}`}
+            key={item.get('id')}
+            className='status-link mention'
+          >
+            @<span>{item.get('username')}</span>
+          </Link>
+        ))
+        .reduce((aggregate, item) => [...aggregate, item, ' '], []);
 
-      const toggleText = hidden ? <FormattedMessage id='status.show_more' defaultMessage='Show more' /> : <FormattedMessage id='status.show_less' defaultMessage='Show less' />;
+      const toggleText = hidden ? (
+        <FormattedMessage id='status.show_more' defaultMessage='Show more' />
+      ) : (
+        <FormattedMessage id='status.show_less' defaultMessage='Show less' />
+      );
 
       if (hidden) {
         mentionsPlaceholder = <div>{mentionLinks}</div>;
       }
 
       return (
-        <div className={classNames} ref={this.setRef} tabIndex={0} onMouseDown={this.handleMouseDown} onMouseUp={this.handleMouseUp} onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave}>
-          <p style={{ marginBottom: hidden && status.get('mentions').isEmpty() ? '0px' : null }}>
-            <span dangerouslySetInnerHTML={spoilerContent} className='translate' lang={language} />
-            {' '}
-            <button type='button' className={`status__content__spoiler-link ${hidden ? 'status__content__spoiler-link--show-more' : 'status__content__spoiler-link--show-less'}`} onClick={this.handleSpoilerClick} aria-expanded={!hidden}>{toggleText}</button>
+        <div
+          className={classNames}
+          ref={this.setRef}
+          tabIndex={0}
+          onMouseDown={this.handleMouseDown}
+          onMouseUp={this.handleMouseUp}
+          onMouseEnter={this.handleMouseEnter}
+          onMouseLeave={this.handleMouseLeave}
+        >
+          <p
+            style={{
+              marginBottom:
+                hidden && status.get('mentions').isEmpty() ? '0px' : null,
+            }}
+          >
+            <span
+              dangerouslySetInnerHTML={spoilerContent}
+              className='translate'
+              lang={language}
+            />{' '}
+            <button
+              type='button'
+              className={`status__content__spoiler-link ${
+                hidden
+                  ? 'status__content__spoiler-link--show-more'
+                  : 'status__content__spoiler-link--show-less'
+              }`}
+              onClick={this.handleSpoilerClick}
+              aria-expanded={!hidden}
+            >
+              {toggleText}
+            </button>
           </p>
 
           {mentionsPlaceholder}
 
-          <div tabIndex={!hidden ? 0 : null} className={`status__content__text ${!hidden ? 'status__content__text--visible' : ''} translate`} lang={language} dangerouslySetInnerHTML={content} />
+          <div
+            tabIndex={!hidden ? 0 : null}
+            className={`status__content__text ${
+              !hidden ? 'status__content__text--visible' : ''
+            } translate`}
+            lang={language}
+            dangerouslySetInnerHTML={content}
+          />
 
           {!hidden && poll}
           {translateButton}
@@ -300,8 +404,21 @@ class StatusContent extends PureComponent {
     } else if (this.props.onClick) {
       return (
         <>
-          <div className={classNames} ref={this.setRef} tabIndex={0} onMouseDown={this.handleMouseDown} onMouseUp={this.handleMouseUp} key='status-content' onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave}>
-            <div className='status__content__text status__content__text--visible translate' lang={language} dangerouslySetInnerHTML={content} />
+          <div
+            className={classNames}
+            ref={this.setRef}
+            tabIndex={0}
+            onMouseDown={this.handleMouseDown}
+            onMouseUp={this.handleMouseUp}
+            key='status-content'
+            onMouseEnter={this.handleMouseEnter}
+            onMouseLeave={this.handleMouseLeave}
+          >
+            <div
+              className='status__content__text status__content__text--visible translate'
+              lang={language}
+              dangerouslySetInnerHTML={content}
+            />
 
             {poll}
             {translateButton}
@@ -312,8 +429,18 @@ class StatusContent extends PureComponent {
       );
     } else {
       return (
-        <div className={classNames} ref={this.setRef} tabIndex={0} onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave}>
-          <div className='status__content__text status__content__text--visible translate' lang={language} dangerouslySetInnerHTML={content} />
+        <div
+          className={classNames}
+          ref={this.setRef}
+          tabIndex={0}
+          onMouseEnter={this.handleMouseEnter}
+          onMouseLeave={this.handleMouseLeave}
+        >
+          <div
+            className='status__content__text status__content__text--visible translate'
+            lang={language}
+            dangerouslySetInnerHTML={content}
+          />
 
           {poll}
           {translateButton}
@@ -321,7 +448,6 @@ class StatusContent extends PureComponent {
       );
     }
   }
-
 }
 
 export default connect(mapStateToProps)(injectIntl(StatusContent));

--- a/app/javascript/mastodon/components/status_list.jsx
+++ b/app/javascript/mastodon/components/status_list.jsx
@@ -13,7 +13,6 @@ import { LoadGap } from './load_gap';
 import ScrollableList from './scrollable_list';
 
 export default class StatusList extends ImmutablePureComponent {
-
   static propTypes = {
     scrollKey: PropTypes.string.isRequired,
     statusIds: ImmutablePropTypes.list.isRequired,
@@ -59,79 +58,99 @@ export default class StatusList extends ImmutablePureComponent {
     this._selectChild(elementIndex, false);
   };
 
-  handleLoadOlder = debounce(() => {
-    const { statusIds, lastId, onLoadMore } = this.props;
-    onLoadMore(lastId || (statusIds.size > 0 ? statusIds.last() : undefined));
-  }, 300, { leading: true });
+  handleLoadOlder = debounce(
+    () => {
+      const { statusIds, lastId, onLoadMore } = this.props;
+      onLoadMore(lastId || (statusIds.size > 0 ? statusIds.last() : undefined));
+    },
+    300,
+    { leading: true },
+  );
 
-  _selectChild (index, align_top) {
+  _selectChild(index, align_top) {
     const container = this.node.node;
-    const element = container.querySelector(`article:nth-of-type(${index + 1}) .focusable`);
+    const element = container.querySelector(
+      `article:nth-of-type(${index + 1}) .focusable`,
+    );
 
     if (element) {
       if (align_top && container.scrollTop > element.offsetTop) {
         element.scrollIntoView(true);
-      } else if (!align_top && container.scrollTop + container.clientHeight < element.offsetTop + element.offsetHeight) {
+      } else if (
+        !align_top &&
+        container.scrollTop + container.clientHeight <
+          element.offsetTop + element.offsetHeight
+      ) {
         element.scrollIntoView(false);
       }
       element.focus();
     }
   }
 
-  setRef = c => {
+  setRef = (c) => {
     this.node = c;
   };
 
-  render () {
-    const { statusIds, featuredStatusIds, onLoadMore, timelineId, ...other }  = this.props;
+  render() {
+    const { statusIds, featuredStatusIds, onLoadMore, timelineId, ...other } =
+      this.props;
     const { isLoading, isPartial } = other;
 
     if (isPartial) {
       return <RegenerationIndicator />;
     }
 
-    let scrollableContent = (isLoading || statusIds.size > 0) ? (
-      statusIds.map((statusId, index) => statusId === null ? (
-        <LoadGap
-          key={'gap:' + statusIds.get(index + 1)}
-          disabled={isLoading}
-          maxId={index > 0 ? statusIds.get(index - 1) : null}
-          onClick={onLoadMore}
-        />
-      ) : (
-        <StatusContainer
-          key={statusId}
-          id={statusId}
-          onMoveUp={this.handleMoveUp}
-          onMoveDown={this.handleMoveDown}
-          contextType={timelineId}
-          scrollKey={this.props.scrollKey}
-          showThread
-          withCounters={this.props.withCounters}
-        />
-      ))
-    ) : null;
+    let scrollableContent =
+      isLoading || statusIds.size > 0
+        ? statusIds.map((statusId, index) =>
+            statusId === null ? (
+              <LoadGap
+                key={'gap:' + statusIds.get(index + 1)}
+                disabled={isLoading}
+                maxId={index > 0 ? statusIds.get(index - 1) : null}
+                onClick={onLoadMore}
+              />
+            ) : (
+              <StatusContainer
+                key={statusId}
+                id={statusId}
+                onMoveUp={this.handleMoveUp}
+                onMoveDown={this.handleMoveDown}
+                contextType={timelineId}
+                scrollKey={this.props.scrollKey}
+                showThread
+                withCounters={this.props.withCounters}
+              />
+            ),
+          )
+        : null;
 
     if (scrollableContent && featuredStatusIds) {
-      scrollableContent = featuredStatusIds.map(statusId => (
-        <StatusContainer
-          key={`f-${statusId}`}
-          id={statusId}
-          featured
-          onMoveUp={this.handleMoveUp}
-          onMoveDown={this.handleMoveDown}
-          contextType={timelineId}
-          showThread
-          withCounters={this.props.withCounters}
-        />
-      )).concat(scrollableContent);
+      scrollableContent = featuredStatusIds
+        .map((statusId) => (
+          <StatusContainer
+            key={`f-${statusId}`}
+            id={statusId}
+            featured
+            onMoveUp={this.handleMoveUp}
+            onMoveDown={this.handleMoveDown}
+            contextType={timelineId}
+            showThread
+            withCounters={this.props.withCounters}
+          />
+        ))
+        .concat(scrollableContent);
     }
 
     return (
-      <ScrollableList {...other} showLoading={isLoading && statusIds.size === 0} onLoadMore={onLoadMore && this.handleLoadOlder} ref={this.setRef}>
+      <ScrollableList
+        {...other}
+        showLoading={isLoading && statusIds.size === 0}
+        onLoadMore={onLoadMore && this.handleLoadOlder}
+        ref={this.setRef}
+      >
         {scrollableContent}
       </ScrollableList>
     );
   }
-
 }

--- a/app/javascript/mastodon/containers/account_container.jsx
+++ b/app/javascript/mastodon/containers/account_container.jsx
@@ -17,7 +17,10 @@ import { unfollowModal } from '../initial_state';
 import { makeGetAccount } from '../selectors';
 
 const messages = defineMessages({
-  unfollowConfirm: { id: 'confirmations.unfollow.confirm', defaultMessage: 'Unfollow' },
+  unfollowConfirm: {
+    id: 'confirmations.unfollow.confirm',
+    defaultMessage: 'Unfollow',
+  },
 });
 
 const makeMapStateToProps = () => {
@@ -31,18 +34,28 @@ const makeMapStateToProps = () => {
 };
 
 const mapDispatchToProps = (dispatch, { intl }) => ({
-
-  onFollow (account) {
-    if (account.getIn(['relationship', 'following']) || account.getIn(['relationship', 'requested'])) {
+  onFollow(account) {
+    if (
+      account.getIn(['relationship', 'following']) ||
+      account.getIn(['relationship', 'requested'])
+    ) {
       if (unfollowModal) {
-        dispatch(openModal({
-          modalType: 'CONFIRM',
-          modalProps: {
-            message: <FormattedMessage id='confirmations.unfollow.message' defaultMessage='Are you sure you want to unfollow {name}?' values={{ name: <strong>@{account.get('acct')}</strong> }} />,
-            confirm: intl.formatMessage(messages.unfollowConfirm),
-            onConfirm: () => dispatch(unfollowAccount(account.get('id'))),
-          },
-        }));
+        dispatch(
+          openModal({
+            modalType: 'CONFIRM',
+            modalProps: {
+              message: (
+                <FormattedMessage
+                  id='confirmations.unfollow.message'
+                  defaultMessage='Are you sure you want to unfollow {name}?'
+                  values={{ name: <strong>@{account.get('acct')}</strong> }}
+                />
+              ),
+              confirm: intl.formatMessage(messages.unfollowConfirm),
+              onConfirm: () => dispatch(unfollowAccount(account.get('id'))),
+            },
+          }),
+        );
       } else {
         dispatch(unfollowAccount(account.get('id')));
       }
@@ -51,7 +64,7 @@ const mapDispatchToProps = (dispatch, { intl }) => ({
     }
   },
 
-  onBlock (account) {
+  onBlock(account) {
     if (account.getIn(['relationship', 'blocking'])) {
       dispatch(unblockAccount(account.get('id')));
     } else {
@@ -59,7 +72,7 @@ const mapDispatchToProps = (dispatch, { intl }) => ({
     }
   },
 
-  onMute (account) {
+  onMute(account) {
     if (account.getIn(['relationship', 'muting'])) {
       dispatch(unmuteAccount(account.get('id')));
     } else {
@@ -67,10 +80,11 @@ const mapDispatchToProps = (dispatch, { intl }) => ({
     }
   },
 
-
-  onMuteNotifications (account, notifications) {
+  onMuteNotifications(account, notifications) {
     dispatch(muteAccount(account.get('id'), notifications));
   },
 });
 
-export default injectIntl(connect(makeMapStateToProps, mapDispatchToProps)(Account));
+export default injectIntl(
+  connect(makeMapStateToProps, mapDispatchToProps)(Account),
+);

--- a/app/javascript/mastodon/containers/admin_component.jsx
+++ b/app/javascript/mastodon/containers/admin_component.jsx
@@ -4,19 +4,13 @@ import { PureComponent } from 'react';
 import { IntlProvider } from 'mastodon/locales';
 
 export default class AdminComponent extends PureComponent {
-
   static propTypes = {
     children: PropTypes.node.isRequired,
   };
 
-  render () {
+  render() {
     const { children } = this.props;
 
-    return (
-      <IntlProvider>
-        {children}
-      </IntlProvider>
-    );
+    return <IntlProvider>{children}</IntlProvider>;
   }
-
 }

--- a/app/javascript/mastodon/containers/compose_container.jsx
+++ b/app/javascript/mastodon/containers/compose_container.jsx
@@ -9,7 +9,6 @@ import initialState from '../initial_state';
 import { IntlProvider } from '../locales';
 import { store } from '../store';
 
-
 if (initialState) {
   store.dispatch(hydrateStore(initialState));
 }
@@ -17,8 +16,7 @@ if (initialState) {
 store.dispatch(fetchCustomEmojis());
 
 export default class ComposeContainer extends PureComponent {
-
-  render () {
+  render() {
     return (
       <IntlProvider>
         <Provider store={store}>
@@ -27,5 +25,4 @@ export default class ComposeContainer extends PureComponent {
       </IntlProvider>
     );
   }
-
 }

--- a/app/javascript/mastodon/containers/domain_container.jsx
+++ b/app/javascript/mastodon/containers/domain_container.jsx
@@ -7,7 +7,10 @@ import { openModal } from '../actions/modal';
 import { Domain } from '../components/domain';
 
 const messages = defineMessages({
-  blockDomainConfirm: { id: 'confirmations.domain_block.confirm', defaultMessage: 'Block entire domain' },
+  blockDomainConfirm: {
+    id: 'confirmations.domain_block.confirm',
+    defaultMessage: 'Block entire domain',
+  },
 });
 
 const makeMapStateToProps = () => {
@@ -17,20 +20,30 @@ const makeMapStateToProps = () => {
 };
 
 const mapDispatchToProps = (dispatch, { intl }) => ({
-  onBlockDomain (domain) {
-    dispatch(openModal({
-      modalType: 'CONFIRM',
-      modalProps: {
-        message: <FormattedMessage id='confirmations.domain_block.message' defaultMessage='Are you really, really sure you want to block the entire {domain}? In most cases a few targeted blocks or mutes are sufficient and preferable. You will not see content from that domain in any public timelines or your notifications. Your followers from that domain will be removed.' values={{ domain: <strong>{domain}</strong> }} />,
-        confirm: intl.formatMessage(messages.blockDomainConfirm),
-        onConfirm: () => dispatch(blockDomain(domain)),
-      },
-    }));
+  onBlockDomain(domain) {
+    dispatch(
+      openModal({
+        modalType: 'CONFIRM',
+        modalProps: {
+          message: (
+            <FormattedMessage
+              id='confirmations.domain_block.message'
+              defaultMessage='Are you really, really sure you want to block the entire {domain}? In most cases a few targeted blocks or mutes are sufficient and preferable. You will not see content from that domain in any public timelines or your notifications. Your followers from that domain will be removed.'
+              values={{ domain: <strong>{domain}</strong> }}
+            />
+          ),
+          confirm: intl.formatMessage(messages.blockDomainConfirm),
+          onConfirm: () => dispatch(blockDomain(domain)),
+        },
+      }),
+    );
   },
 
-  onUnblockDomain (domain) {
+  onUnblockDomain(domain) {
     dispatch(unblockDomain(domain));
   },
 });
 
-export default injectIntl(connect(makeMapStateToProps, mapDispatchToProps)(Domain));
+export default injectIntl(
+  connect(makeMapStateToProps, mapDispatchToProps)(Domain),
+);

--- a/app/javascript/mastodon/containers/dropdown_menu_container.js
+++ b/app/javascript/mastodon/containers/dropdown_menu_container.js
@@ -7,7 +7,7 @@ import { openModal, closeModal } from '../actions/modal';
 import DropdownMenu from '../components/dropdown_menu';
 import { isUserTouching } from '../is_mobile';
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   openDropdownId: state.getIn(['dropdown_menu', 'openId']),
   openedViaKeyboard: state.getIn(['dropdown_menu', 'keyboard']),
 });
@@ -18,21 +18,27 @@ const mapDispatchToProps = (dispatch, { status, items, scrollKey }) => ({
       dispatch(fetchRelationships([status.getIn(['account', 'id'])]));
     }
 
-    dispatch(isUserTouching() ? openModal({
-      modalType: 'ACTIONS',
-      modalProps: {
-        status,
-        actions: items,
-        onClick: onItemClick,
-      },
-    }) : openDropdownMenu(id, keyboard, scrollKey));
+    dispatch(
+      isUserTouching()
+        ? openModal({
+            modalType: 'ACTIONS',
+            modalProps: {
+              status,
+              actions: items,
+              onClick: onItemClick,
+            },
+          })
+        : openDropdownMenu(id, keyboard, scrollKey),
+    );
   },
 
   onClose(id) {
-    dispatch(closeModal({
-      modalType: 'ACTIONS',
-      ignoreFocus: false,
-    }));
+    dispatch(
+      closeModal({
+        modalType: 'ACTIONS',
+        ignoreFocus: false,
+      }),
+    );
     dispatch(closeDropdownMenu(id));
   },
 });

--- a/app/javascript/mastodon/containers/intersection_observer_article_container.js
+++ b/app/javascript/mastodon/containers/intersection_observer_article_container.js
@@ -8,11 +8,12 @@ const makeMapStateToProps = (state, props) => ({
 });
 
 const mapDispatchToProps = (dispatch) => ({
-
-  onHeightChange (key, id, height) {
+  onHeightChange(key, id, height) {
     dispatch(setHeight(key, id, height));
   },
-
 });
 
-export default connect(makeMapStateToProps, mapDispatchToProps)(IntersectionObserverArticle);
+export default connect(
+  makeMapStateToProps,
+  mapDispatchToProps,
+)(IntersectionObserverArticle);

--- a/app/javascript/mastodon/containers/mastodon.jsx
+++ b/app/javascript/mastodon/containers/mastodon.jsx
@@ -18,7 +18,8 @@ import initialState, { title as siteTitle } from 'mastodon/initial_state';
 import { IntlProvider } from 'mastodon/locales';
 import { store } from 'mastodon/store';
 
-const title = process.env.NODE_ENV === 'production' ? siteTitle : `${siteTitle} (Dev)`;
+const title =
+  process.env.NODE_ENV === 'production' ? siteTitle : `${siteTitle} (Dev)`;
 
 const hydrateAction = hydrateStore(initialState);
 
@@ -27,7 +28,7 @@ if (initialState.meta.me) {
   store.dispatch(fetchCustomEmojis());
 }
 
-const createIdentityContext = state => ({
+const createIdentityContext = (state) => ({
   signedIn: !!state.meta.me,
   accountId: state.meta.me,
   disabledAccountId: state.meta.disabled_account_id,
@@ -36,7 +37,6 @@ const createIdentityContext = state => ({
 });
 
 export default class Mastodon extends PureComponent {
-
   static childContextTypes = {
     identity: PropTypes.shape({
       signedIn: PropTypes.bool.isRequired,
@@ -60,18 +60,22 @@ export default class Mastodon extends PureComponent {
     }
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     if (this.disconnect) {
       this.disconnect();
       this.disconnect = null;
     }
   }
 
-  shouldUpdateScroll (prevRouterProps, { location }) {
-    return !(location.state?.mastodonModalKey && location.state?.mastodonModalKey !== prevRouterProps?.location?.state?.mastodonModalKey);
+  shouldUpdateScroll(prevRouterProps, { location }) {
+    return !(
+      location.state?.mastodonModalKey &&
+      location.state?.mastodonModalKey !==
+        prevRouterProps?.location?.state?.mastodonModalKey
+    );
   }
 
-  render () {
+  render() {
     return (
       <IntlProvider>
         <ReduxProvider store={store}>
@@ -88,5 +92,4 @@ export default class Mastodon extends PureComponent {
       </IntlProvider>
     );
   }
-
 }

--- a/app/javascript/mastodon/containers/media_container.jsx
+++ b/app/javascript/mastodon/containers/media_container.jsx
@@ -18,7 +18,6 @@ import { getScrollbarWidth } from 'mastodon/utils/scrollbar';
 const MEDIA_COMPONENTS = { MediaGallery, Video, Card, Poll, Hashtag, Audio };
 
 export default class MediaContainer extends PureComponent {
-
   static propTypes = {
     components: PropTypes.object.isRequired,
   };
@@ -41,7 +40,9 @@ export default class MediaContainer extends PureComponent {
 
   handleOpenVideo = (lang, options) => {
     const { components } = this.props;
-    const { media } = JSON.parse(components[options.componentIndex].getAttribute('data-props'));
+    const { media } = JSON.parse(
+      components[options.componentIndex].getAttribute('data-props'),
+    );
     const mediaList = fromJS(media);
 
     document.body.classList.add('with-modals--active');
@@ -63,11 +64,11 @@ export default class MediaContainer extends PureComponent {
     });
   };
 
-  setBackgroundColor = color => {
+  setBackgroundColor = (color) => {
     this.setState({ backgroundColor: color });
   };
 
-  render () {
+  render() {
     const { components } = this.props;
 
     let handleOpenVideo;
@@ -83,20 +84,24 @@ export default class MediaContainer extends PureComponent {
           {[].map.call(components, (component, i) => {
             const componentName = component.getAttribute('data-component');
             const Component = MEDIA_COMPONENTS[componentName];
-            const { media, card, poll, hashtag, ...props } = JSON.parse(component.getAttribute('data-props'));
+            const { media, card, poll, hashtag, ...props } = JSON.parse(
+              component.getAttribute('data-props'),
+            );
 
             Object.assign(props, {
-              ...(media   ? { media:   fromJS(media)   } : {}),
-              ...(card    ? { card:    fromJS(card)    } : {}),
-              ...(poll    ? { poll:    fromJS(poll)    } : {}),
+              ...(media ? { media: fromJS(media) } : {}),
+              ...(card ? { card: fromJS(card) } : {}),
+              ...(poll ? { poll: fromJS(poll) } : {}),
               ...(hashtag ? { hashtag: fromJS(hashtag) } : {}),
 
-              ...(componentName === 'Video' ? {
-                componentIndex: i,
-                onOpenVideo: handleOpenVideo,
-              } : {
-                onOpenMedia: this.handleOpenMedia,
-              }),
+              ...(componentName === 'Video'
+                ? {
+                    componentIndex: i,
+                    onOpenVideo: handleOpenVideo,
+                  }
+                : {
+                    onOpenMedia: this.handleOpenMedia,
+                  }),
             });
 
             return createPortal(
@@ -105,7 +110,10 @@ export default class MediaContainer extends PureComponent {
             );
           })}
 
-          <ModalRoot backgroundColor={this.state.backgroundColor} onClose={this.handleCloseMedia}>
+          <ModalRoot
+            backgroundColor={this.state.backgroundColor}
+            onClose={this.handleCloseMedia}
+          >
             {this.state.media && (
               <MediaModal
                 media={this.state.media}
@@ -123,5 +131,4 @@ export default class MediaContainer extends PureComponent {
       </IntlProvider>
     );
   }
-
 }

--- a/app/javascript/mastodon/containers/poll_container.js
+++ b/app/javascript/mastodon/containers/poll_container.js
@@ -14,7 +14,7 @@ const mapDispatchToProps = (dispatch, { pollId }) => ({
     { leading: true },
   ),
 
-  onVote (choices) {
+  onVote(choices) {
     dispatch(vote(pollId, choices));
   },
 });

--- a/app/javascript/mastodon/containers/scroll_container.js
+++ b/app/javascript/mastodon/containers/scroll_container.js
@@ -5,14 +5,15 @@ import { ScrollContainer as OriginalScrollContainer } from 'react-router-scroll-
 // There are a few things we need to do differently, though.
 const defaultShouldUpdateScroll = (prevRouterProps, { location }) => {
   // If the change is caused by opening a modal, do not scroll to top
-  return !(location.state?.mastodonModalKey && location.state?.mastodonModalKey !== prevRouterProps?.location?.state?.mastodonModalKey);
+  return !(
+    location.state?.mastodonModalKey &&
+    location.state?.mastodonModalKey !==
+      prevRouterProps?.location?.state?.mastodonModalKey
+  );
 };
 
-export default
-class ScrollContainer extends OriginalScrollContainer {
-
+export default class ScrollContainer extends OriginalScrollContainer {
   static defaultProps = {
     shouldUpdateScroll: defaultShouldUpdateScroll,
   };
-
 }

--- a/app/javascript/mastodon/containers/status_container.jsx
+++ b/app/javascript/mastodon/containers/status_container.jsx
@@ -2,10 +2,7 @@ import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
 
 import { connect } from 'react-redux';
 
-import {
-  unmuteAccount,
-  unblockAccount,
-} from '../actions/accounts';
+import { unmuteAccount, unblockAccount } from '../actions/accounts';
 import { showAlertForError } from '../actions/alerts';
 import { initBlockModal } from '../actions/blocks';
 import { initBoostModal } from '../actions/boosts';
@@ -14,13 +11,8 @@ import {
   mentionCompose,
   directCompose,
 } from '../actions/compose';
-import {
-  blockDomain,
-  unblockDomain,
-} from '../actions/domain_blocks';
-import {
-  initAddFilter,
-} from '../actions/filters';
+import { blockDomain, unblockDomain } from '../actions/domain_blocks';
+import { initAddFilter } from '../actions/filters';
 import {
   reblog,
   favourite,
@@ -51,15 +43,39 @@ import { boostModal, deleteModal } from '../initial_state';
 import { makeGetStatus, makeGetPictureInPicture } from '../selectors';
 
 const messages = defineMessages({
-  deleteConfirm: { id: 'confirmations.delete.confirm', defaultMessage: 'Delete' },
-  deleteMessage: { id: 'confirmations.delete.message', defaultMessage: 'Are you sure you want to delete this status?' },
-  redraftConfirm: { id: 'confirmations.redraft.confirm', defaultMessage: 'Delete & redraft' },
-  redraftMessage: { id: 'confirmations.redraft.message', defaultMessage: 'Are you sure you want to delete this status and re-draft it? Favorites and boosts will be lost, and replies to the original post will be orphaned.' },
+  deleteConfirm: {
+    id: 'confirmations.delete.confirm',
+    defaultMessage: 'Delete',
+  },
+  deleteMessage: {
+    id: 'confirmations.delete.message',
+    defaultMessage: 'Are you sure you want to delete this status?',
+  },
+  redraftConfirm: {
+    id: 'confirmations.redraft.confirm',
+    defaultMessage: 'Delete & redraft',
+  },
+  redraftMessage: {
+    id: 'confirmations.redraft.message',
+    defaultMessage:
+      'Are you sure you want to delete this status and re-draft it? Favorites and boosts will be lost, and replies to the original post will be orphaned.',
+  },
   replyConfirm: { id: 'confirmations.reply.confirm', defaultMessage: 'Reply' },
-  replyMessage: { id: 'confirmations.reply.message', defaultMessage: 'Replying now will overwrite the message you are currently composing. Are you sure you want to proceed?' },
+  replyMessage: {
+    id: 'confirmations.reply.message',
+    defaultMessage:
+      'Replying now will overwrite the message you are currently composing. Are you sure you want to proceed?',
+  },
   editConfirm: { id: 'confirmations.edit.confirm', defaultMessage: 'Edit' },
-  editMessage: { id: 'confirmations.edit.message', defaultMessage: 'Editing now will overwrite the message you are currently composing. Are you sure you want to proceed?' },
-  blockDomainConfirm: { id: 'confirmations.domain_block.confirm', defaultMessage: 'Block entire domain' },
+  editMessage: {
+    id: 'confirmations.edit.message',
+    defaultMessage:
+      'Editing now will overwrite the message you are currently composing. Are you sure you want to proceed?',
+  },
+  blockDomainConfirm: {
+    id: 'confirmations.domain_block.confirm',
+    defaultMessage: 'Block entire domain',
+  },
 });
 
 const makeMapStateToProps = () => {
@@ -68,7 +84,9 @@ const makeMapStateToProps = () => {
 
   const mapStateToProps = (state, props) => ({
     status: getStatus(state, props),
-    nextInReplyToId: props.nextId ? state.getIn(['statuses', props.nextId, 'in_reply_to_id']) : null,
+    nextInReplyToId: props.nextId
+      ? state.getIn(['statuses', props.nextId, 'in_reply_to_id'])
+      : null,
     pictureInPicture: getPictureInPicture(state, props),
   });
 
@@ -76,26 +94,28 @@ const makeMapStateToProps = () => {
 };
 
 const mapDispatchToProps = (dispatch, { intl, contextType }) => ({
-
-  onReply (status, router) {
+  onReply(status, router) {
     dispatch((_, getState) => {
       let state = getState();
 
       if (state.getIn(['compose', 'text']).trim().length !== 0) {
-        dispatch(openModal({
-          modalType: 'CONFIRM',
-          modalProps: {
-            message: intl.formatMessage(messages.replyMessage),
-            confirm: intl.formatMessage(messages.replyConfirm),
-            onConfirm: () => dispatch(replyCompose(status, router)) },
-        }));
+        dispatch(
+          openModal({
+            modalType: 'CONFIRM',
+            modalProps: {
+              message: intl.formatMessage(messages.replyMessage),
+              confirm: intl.formatMessage(messages.replyConfirm),
+              onConfirm: () => dispatch(replyCompose(status, router)),
+            },
+          }),
+        );
       } else {
         dispatch(replyCompose(status, router));
       }
     });
   },
 
-  onModalReblog (status, privacy) {
+  onModalReblog(status, privacy) {
     if (status.get('reblogged')) {
       dispatch(unreblog(status));
     } else {
@@ -103,7 +123,7 @@ const mapDispatchToProps = (dispatch, { intl, contextType }) => ({
     }
   },
 
-  onReblog (status, e) {
+  onReblog(status, e) {
     if ((e && e.shiftKey) || !boostModal) {
       this.onModalReblog(status);
     } else {
@@ -111,7 +131,7 @@ const mapDispatchToProps = (dispatch, { intl, contextType }) => ({
     }
   },
 
-  onFavourite (status) {
+  onFavourite(status) {
     if (status.get('favourited')) {
       dispatch(unfavourite(status));
     } else {
@@ -119,7 +139,7 @@ const mapDispatchToProps = (dispatch, { intl, contextType }) => ({
     }
   },
 
-  onBookmark (status) {
+  onBookmark(status) {
     if (status.get('bookmarked')) {
       dispatch(unbookmark(status));
     } else {
@@ -127,7 +147,7 @@ const mapDispatchToProps = (dispatch, { intl, contextType }) => ({
     }
   },
 
-  onPin (status) {
+  onPin(status) {
     if (status.get('pinned')) {
       dispatch(unpin(status));
     } else {
@@ -135,50 +155,61 @@ const mapDispatchToProps = (dispatch, { intl, contextType }) => ({
     }
   },
 
-  onEmbed (status) {
-    dispatch(openModal({
-      modalType: 'EMBED',
-      modalProps: {
-        id: status.get('id'),
-        onError: error => dispatch(showAlertForError(error)),
-      },
-    }));
+  onEmbed(status) {
+    dispatch(
+      openModal({
+        modalType: 'EMBED',
+        modalProps: {
+          id: status.get('id'),
+          onError: (error) => dispatch(showAlertForError(error)),
+        },
+      }),
+    );
   },
 
-  onDelete (status, history, withRedraft = false) {
+  onDelete(status, history, withRedraft = false) {
     if (!deleteModal) {
       dispatch(deleteStatus(status.get('id'), history, withRedraft));
     } else {
-      dispatch(openModal({
-        modalType: 'CONFIRM',
-        modalProps: {
-          message: intl.formatMessage(withRedraft ? messages.redraftMessage : messages.deleteMessage),
-          confirm: intl.formatMessage(withRedraft ? messages.redraftConfirm : messages.deleteConfirm),
-          onConfirm: () => dispatch(deleteStatus(status.get('id'), history, withRedraft)),
-        },
-      }));
+      dispatch(
+        openModal({
+          modalType: 'CONFIRM',
+          modalProps: {
+            message: intl.formatMessage(
+              withRedraft ? messages.redraftMessage : messages.deleteMessage,
+            ),
+            confirm: intl.formatMessage(
+              withRedraft ? messages.redraftConfirm : messages.deleteConfirm,
+            ),
+            onConfirm: () =>
+              dispatch(deleteStatus(status.get('id'), history, withRedraft)),
+          },
+        }),
+      );
     }
   },
 
-  onEdit (status, history) {
+  onEdit(status, history) {
     dispatch((_, getState) => {
       let state = getState();
       if (state.getIn(['compose', 'text']).trim().length !== 0) {
-        dispatch(openModal({
-          modalType: 'CONFIRM',
-          modalProps: {
-            message: intl.formatMessage(messages.editMessage),
-            confirm: intl.formatMessage(messages.editConfirm),
-            onConfirm: () => dispatch(editStatus(status.get('id'), history)),
-          },
-        }));
+        dispatch(
+          openModal({
+            modalType: 'CONFIRM',
+            modalProps: {
+              message: intl.formatMessage(messages.editMessage),
+              confirm: intl.formatMessage(messages.editConfirm),
+              onConfirm: () => dispatch(editStatus(status.get('id'), history)),
+            },
+          }),
+        );
       } else {
         dispatch(editStatus(status.get('id'), history));
       }
     });
   },
 
-  onTranslate (status) {
+  onTranslate(status) {
     if (status.get('translation')) {
       dispatch(undoStatusTranslation(status.get('id'), status.get('poll')));
     } else {
@@ -186,54 +217,58 @@ const mapDispatchToProps = (dispatch, { intl, contextType }) => ({
     }
   },
 
-  onDirect (account, router) {
+  onDirect(account, router) {
     dispatch(directCompose(account, router));
   },
 
-  onMention (account, router) {
+  onMention(account, router) {
     dispatch(mentionCompose(account, router));
   },
 
-  onOpenMedia (statusId, media, index, lang) {
-    dispatch(openModal({
-      modalType: 'MEDIA',
-      modalProps: { statusId, media, index, lang },
-    }));
+  onOpenMedia(statusId, media, index, lang) {
+    dispatch(
+      openModal({
+        modalType: 'MEDIA',
+        modalProps: { statusId, media, index, lang },
+      }),
+    );
   },
 
-  onOpenVideo (statusId, media, lang, options) {
-    dispatch(openModal({
-      modalType: 'VIDEO',
-      modalProps: { statusId, media, lang, options },
-    }));
+  onOpenVideo(statusId, media, lang, options) {
+    dispatch(
+      openModal({
+        modalType: 'VIDEO',
+        modalProps: { statusId, media, lang, options },
+      }),
+    );
   },
 
-  onBlock (status) {
+  onBlock(status) {
     const account = status.get('account');
     dispatch(initBlockModal(account));
   },
 
-  onUnblock (account) {
+  onUnblock(account) {
     dispatch(unblockAccount(account.get('id')));
   },
 
-  onReport (status) {
+  onReport(status) {
     dispatch(initReport(status.get('account'), status));
   },
 
-  onAddFilter (status) {
+  onAddFilter(status) {
     dispatch(initAddFilter(status, { contextType }));
   },
 
-  onMute (account) {
+  onMute(account) {
     dispatch(initMuteModal(account));
   },
 
-  onUnmute (account) {
+  onUnmute(account) {
     dispatch(unmuteAccount(account.get('id')));
   },
 
-  onMuteConversation (status) {
+  onMuteConversation(status) {
     if (status.get('muted')) {
       dispatch(unmuteStatus(status.get('id')));
     } else {
@@ -241,7 +276,7 @@ const mapDispatchToProps = (dispatch, { intl, contextType }) => ({
     }
   },
 
-  onToggleHidden (status) {
+  onToggleHidden(status) {
     if (status.get('hidden')) {
       dispatch(revealStatus(status.get('id')));
     } else {
@@ -249,40 +284,58 @@ const mapDispatchToProps = (dispatch, { intl, contextType }) => ({
     }
   },
 
-  onToggleCollapsed (status, isCollapsed) {
+  onToggleCollapsed(status, isCollapsed) {
     dispatch(toggleStatusCollapse(status.get('id'), isCollapsed));
   },
 
-  onBlockDomain (domain) {
-    dispatch(openModal({
-      modalType: 'CONFIRM',
-      modalProps: {
-        message: <FormattedMessage id='confirmations.domain_block.message' defaultMessage='Are you really, really sure you want to block the entire {domain}? In most cases a few targeted blocks or mutes are sufficient and preferable. You will not see content from that domain in any public timelines or your notifications. Your followers from that domain will be removed.' values={{ domain: <strong>{domain}</strong> }} />,
-        confirm: intl.formatMessage(messages.blockDomainConfirm),
-        onConfirm: () => dispatch(blockDomain(domain)),
-      },
-    }));
+  onBlockDomain(domain) {
+    dispatch(
+      openModal({
+        modalType: 'CONFIRM',
+        modalProps: {
+          message: (
+            <FormattedMessage
+              id='confirmations.domain_block.message'
+              defaultMessage='Are you really, really sure you want to block the entire {domain}? In most cases a few targeted blocks or mutes are sufficient and preferable. You will not see content from that domain in any public timelines or your notifications. Your followers from that domain will be removed.'
+              values={{ domain: <strong>{domain}</strong> }}
+            />
+          ),
+          confirm: intl.formatMessage(messages.blockDomainConfirm),
+          onConfirm: () => dispatch(blockDomain(domain)),
+        },
+      }),
+    );
   },
 
-  onUnblockDomain (domain) {
+  onUnblockDomain(domain) {
     dispatch(unblockDomain(domain));
   },
 
-  deployPictureInPicture (status, type, mediaProps) {
-    dispatch(deployPictureInPicture(status.get('id'), status.getIn(['account', 'id']), type, mediaProps));
-  },
-
-  onInteractionModal (type, status) {
-    dispatch(openModal({
-      modalType: 'INTERACTION',
-      modalProps: {
+  deployPictureInPicture(status, type, mediaProps) {
+    dispatch(
+      deployPictureInPicture(
+        status.get('id'),
+        status.getIn(['account', 'id']),
         type,
-        accountId: status.getIn(['account', 'id']),
-        url: status.get('uri'),
-      },
-    }));
+        mediaProps,
+      ),
+    );
   },
 
+  onInteractionModal(type, status) {
+    dispatch(
+      openModal({
+        modalType: 'INTERACTION',
+        modalProps: {
+          type,
+          accountId: status.getIn(['account', 'id']),
+          url: status.get('uri'),
+        },
+      }),
+    );
+  },
 });
 
-export default injectIntl(connect(makeMapStateToProps, mapDispatchToProps)(Status));
+export default injectIntl(
+  connect(makeMapStateToProps, mapDispatchToProps)(Status),
+);

--- a/app/javascript/mastodon/features/about/index.jsx
+++ b/app/javascript/mastodon/features/about/index.jsx
@@ -9,9 +9,13 @@ import { Helmet } from 'react-helmet';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
 
-import { fetchServer, fetchExtendedDescription, fetchDomainBlocks  } from 'mastodon/actions/server';
+import {
+  fetchServer,
+  fetchExtendedDescription,
+  fetchDomainBlocks,
+} from 'mastodon/actions/server';
 import Column from 'mastodon/components/column';
-import { Icon  }  from 'mastodon/components/icon';
+import { Icon } from 'mastodon/components/icon';
 import { ServerHeroImage } from 'mastodon/components/server_hero_image';
 import { Skeleton } from 'mastodon/components/skeleton';
 import Account from 'mastodon/containers/account_container';
@@ -21,10 +25,24 @@ const messages = defineMessages({
   title: { id: 'column.about', defaultMessage: 'About' },
   rules: { id: 'about.rules', defaultMessage: 'Server rules' },
   blocks: { id: 'about.blocks', defaultMessage: 'Moderated servers' },
-  silenced: { id: 'about.domain_blocks.silenced.title', defaultMessage: 'Limited' },
-  silencedExplanation: { id: 'about.domain_blocks.silenced.explanation', defaultMessage: 'You will generally not see profiles and content from this server, unless you explicitly look it up or opt into it by following.' },
-  suspended: { id: 'about.domain_blocks.suspended.title', defaultMessage: 'Suspended' },
-  suspendedExplanation: { id: 'about.domain_blocks.suspended.explanation', defaultMessage: 'No data from this server will be processed, stored or exchanged, making any interaction or communication with users from this server impossible.' },
+  silenced: {
+    id: 'about.domain_blocks.silenced.title',
+    defaultMessage: 'Limited',
+  },
+  silencedExplanation: {
+    id: 'about.domain_blocks.silenced.explanation',
+    defaultMessage:
+      'You will generally not see profiles and content from this server, unless you explicitly look it up or opt into it by following.',
+  },
+  suspended: {
+    id: 'about.domain_blocks.suspended.title',
+    defaultMessage: 'Suspended',
+  },
+  suspendedExplanation: {
+    id: 'about.domain_blocks.suspended.explanation',
+    defaultMessage:
+      'No data from this server will be processed, stored or exchanged, making any interaction or communication with users from this server impossible.',
+  },
 });
 
 const severityMessages = {
@@ -39,14 +57,13 @@ const severityMessages = {
   },
 };
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   server: state.getIn(['server', 'server']),
   extendedDescription: state.getIn(['server', 'extendedDescription']),
   domainBlocks: state.getIn(['server', 'domainBlocks']),
 });
 
 class Section extends PureComponent {
-
   static propTypes = {
     title: PropTypes.string,
     children: PropTypes.node,
@@ -65,27 +82,29 @@ class Section extends PureComponent {
     this.setState({ collapsed: !collapsed }, () => onOpen && onOpen());
   };
 
-  render () {
+  render() {
     const { title, children } = this.props;
     const { collapsed } = this.state;
 
     return (
       <div className={classNames('about__section', { active: !collapsed })}>
-        <div className='about__section__title' role='button' tabIndex={0} onClick={this.handleClick}>
-          <Icon id={collapsed ? 'chevron-right' : 'chevron-down'} fixedWidth /> {title}
+        <div
+          className='about__section__title'
+          role='button'
+          tabIndex={0}
+          onClick={this.handleClick}
+        >
+          <Icon id={collapsed ? 'chevron-right' : 'chevron-down'} fixedWidth />{' '}
+          {title}
         </div>
 
-        {!collapsed && (
-          <div className='about__section__body'>{children}</div>
-        )}
+        {!collapsed && <div className='about__section__body'>{children}</div>}
       </div>
     );
   }
-
 }
 
 class About extends PureComponent {
-
   static propTypes = {
     server: ImmutablePropTypes.map,
     extendedDescription: ImmutablePropTypes.map,
@@ -99,7 +118,7 @@ class About extends PureComponent {
     multiColumn: PropTypes.bool,
   };
 
-  componentDidMount () {
+  componentDidMount() {
     const { dispatch } = this.props;
     dispatch(fetchServer());
     dispatch(fetchExtendedDescription());
@@ -110,32 +129,85 @@ class About extends PureComponent {
     dispatch(fetchDomainBlocks());
   };
 
-  render () {
-    const { multiColumn, intl, server, extendedDescription, domainBlocks } = this.props;
+  render() {
+    const { multiColumn, intl, server, extendedDescription, domainBlocks } =
+      this.props;
     const isLoading = server.get('isLoading');
 
     return (
-      <Column bindToDocument={!multiColumn} label={intl.formatMessage(messages.title)}>
+      <Column
+        bindToDocument={!multiColumn}
+        label={intl.formatMessage(messages.title)}
+      >
         <div className='scrollable about'>
           <div className='about__header'>
-            <ServerHeroImage blurhash={server.getIn(['thumbnail', 'blurhash'])} src={server.getIn(['thumbnail', 'url'])} srcSet={server.getIn(['thumbnail', 'versions'])?.map((value, key) => `${value} ${key.replace('@', '')}`).join(', ')} className='about__header__hero' />
-            <h1>{isLoading ? <Skeleton width='10ch' /> : server.get('domain')}</h1>
-            <p><FormattedMessage id='about.powered_by' defaultMessage='Decentralized social media powered by {mastodon}' values={{ mastodon: <a href='https://joinmastodon.org' className='about__mail' target='_blank'>Mastodon</a> }} /></p>
+            <ServerHeroImage
+              blurhash={server.getIn(['thumbnail', 'blurhash'])}
+              src={server.getIn(['thumbnail', 'url'])}
+              srcSet={server
+                .getIn(['thumbnail', 'versions'])
+                ?.map((value, key) => `${value} ${key.replace('@', '')}`)
+                .join(', ')}
+              className='about__header__hero'
+            />
+            <h1>
+              {isLoading ? <Skeleton width='10ch' /> : server.get('domain')}
+            </h1>
+            <p>
+              <FormattedMessage
+                id='about.powered_by'
+                defaultMessage='Decentralized social media powered by {mastodon}'
+                values={{
+                  mastodon: (
+                    <a
+                      href='https://joinmastodon.org'
+                      className='about__mail'
+                      target='_blank'
+                    >
+                      Mastodon
+                    </a>
+                  ),
+                }}
+              />
+            </p>
           </div>
 
           <div className='about__meta'>
             <div className='about__meta__column'>
-              <h4><FormattedMessage id='server_banner.administered_by' defaultMessage='Administered by:' /></h4>
+              <h4>
+                <FormattedMessage
+                  id='server_banner.administered_by'
+                  defaultMessage='Administered by:'
+                />
+              </h4>
 
-              <Account id={server.getIn(['contact', 'account', 'id'])} size={36} minimal />
+              <Account
+                id={server.getIn(['contact', 'account', 'id'])}
+                size={36}
+                minimal
+              />
             </div>
 
             <hr className='about__meta__divider' />
 
             <div className='about__meta__column'>
-              <h4><FormattedMessage id='about.contact' defaultMessage='Contact:' /></h4>
+              <h4>
+                <FormattedMessage
+                  id='about.contact'
+                  defaultMessage='Contact:'
+                />
+              </h4>
 
-              {isLoading ? <Skeleton width='10ch' /> : <a className='about__mail' href={`mailto:${server.getIn(['contact', 'email'])}`}>{server.getIn(['contact', 'email'])}</a>}
+              {isLoading ? (
+                <Skeleton width='10ch' />
+              ) : (
+                <a
+                  className='about__mail'
+                  href={`mailto:${server.getIn(['contact', 'email'])}`}
+                >
+                  {server.getIn(['contact', 'email'])}
+                </a>
+              )}
             </div>
           </div>
 
@@ -150,63 +222,121 @@ class About extends PureComponent {
                 <br />
                 <Skeleton width='70%' />
               </>
-            ) : (extendedDescription.get('content')?.length > 0 ? (
+            ) : extendedDescription.get('content')?.length > 0 ? (
               <div
                 className='prose'
-                dangerouslySetInnerHTML={{ __html: extendedDescription.get('content') }}
+                dangerouslySetInnerHTML={{
+                  __html: extendedDescription.get('content'),
+                }}
               />
             ) : (
-              <p><FormattedMessage id='about.not_available' defaultMessage='This information has not been made available on this server.' /></p>
-            ))}
+              <p>
+                <FormattedMessage
+                  id='about.not_available'
+                  defaultMessage='This information has not been made available on this server.'
+                />
+              </p>
+            )}
           </Section>
 
           <Section title={intl.formatMessage(messages.rules)}>
-            {!isLoading && (server.get('rules', []).isEmpty() ? (
-              <p><FormattedMessage id='about.not_available' defaultMessage='This information has not been made available on this server.' /></p>
-            ) : (
-              <ol className='rules-list'>
-                {server.get('rules').map(rule => (
-                  <li key={rule.get('id')}>
-                    <span className='rules-list__text'>{rule.get('text')}</span>
-                  </li>
-                ))}
-              </ol>
-            ))}
+            {!isLoading &&
+              (server.get('rules', []).isEmpty() ? (
+                <p>
+                  <FormattedMessage
+                    id='about.not_available'
+                    defaultMessage='This information has not been made available on this server.'
+                  />
+                </p>
+              ) : (
+                <ol className='rules-list'>
+                  {server.get('rules').map((rule) => (
+                    <li key={rule.get('id')}>
+                      <span className='rules-list__text'>
+                        {rule.get('text')}
+                      </span>
+                    </li>
+                  ))}
+                </ol>
+              ))}
           </Section>
 
-          <Section title={intl.formatMessage(messages.blocks)} onOpen={this.handleDomainBlocksOpen}>
+          <Section
+            title={intl.formatMessage(messages.blocks)}
+            onOpen={this.handleDomainBlocksOpen}
+          >
             {domainBlocks.get('isLoading') ? (
               <>
                 <Skeleton width='100%' />
                 <br />
                 <Skeleton width='70%' />
               </>
-            ) : (domainBlocks.get('isAvailable') ? (
+            ) : domainBlocks.get('isAvailable') ? (
               <>
-                <p><FormattedMessage id='about.domain_blocks.preamble' defaultMessage='Mastodon generally allows you to view content from and interact with users from any other server in the fediverse. These are the exceptions that have been made on this particular server.' /></p>
+                <p>
+                  <FormattedMessage
+                    id='about.domain_blocks.preamble'
+                    defaultMessage='Mastodon generally allows you to view content from and interact with users from any other server in the fediverse. These are the exceptions that have been made on this particular server.'
+                  />
+                </p>
 
                 <div className='about__domain-blocks'>
-                  {domainBlocks.get('items').map(block => (
-                    <div className='about__domain-blocks__domain' key={block.get('domain')}>
+                  {domainBlocks.get('items').map((block) => (
+                    <div
+                      className='about__domain-blocks__domain'
+                      key={block.get('domain')}
+                    >
                       <div className='about__domain-blocks__domain__header'>
-                        <h6><span title={`SHA-256: ${block.get('digest')}`}>{block.get('domain')}</span></h6>
-                        <span className='about__domain-blocks__domain__type' title={intl.formatMessage(severityMessages[block.get('severity')].explanation)}>{intl.formatMessage(severityMessages[block.get('severity')].title)}</span>
+                        <h6>
+                          <span title={`SHA-256: ${block.get('digest')}`}>
+                            {block.get('domain')}
+                          </span>
+                        </h6>
+                        <span
+                          className='about__domain-blocks__domain__type'
+                          title={intl.formatMessage(
+                            severityMessages[block.get('severity')].explanation,
+                          )}
+                        >
+                          {intl.formatMessage(
+                            severityMessages[block.get('severity')].title,
+                          )}
+                        </span>
                       </div>
 
-                      <p>{(block.get('comment') || '').length > 0 ? block.get('comment') : <FormattedMessage id='about.domain_blocks.no_reason_available' defaultMessage='Reason not available' />}</p>
+                      <p>
+                        {(block.get('comment') || '').length > 0 ? (
+                          block.get('comment')
+                        ) : (
+                          <FormattedMessage
+                            id='about.domain_blocks.no_reason_available'
+                            defaultMessage='Reason not available'
+                          />
+                        )}
+                      </p>
                     </div>
                   ))}
                 </div>
               </>
             ) : (
-              <p><FormattedMessage id='about.not_available' defaultMessage='This information has not been made available on this server.' /></p>
-            ))}
+              <p>
+                <FormattedMessage
+                  id='about.not_available'
+                  defaultMessage='This information has not been made available on this server.'
+                />
+              </p>
+            )}
           </Section>
 
           <LinkFooter />
 
           <div className='about__footer'>
-            <p><FormattedMessage id='about.disclaimer' defaultMessage='Mastodon is free, open-source software, and a trademark of Mastodon gGmbH.' /></p>
+            <p>
+              <FormattedMessage
+                id='about.disclaimer'
+                defaultMessage='Mastodon is free, open-source software, and a trademark of Mastodon gGmbH.'
+              />
+            </p>
           </div>
         </div>
 
@@ -217,7 +347,6 @@ class About extends PureComponent {
       </Column>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(injectIntl(About));

--- a/app/javascript/mastodon/features/account/components/account_note.jsx
+++ b/app/javascript/mastodon/features/account/components/account_note.jsx
@@ -10,11 +10,13 @@ import ImmutablePureComponent from 'react-immutable-pure-component';
 import Textarea from 'react-textarea-autosize';
 
 const messages = defineMessages({
-  placeholder: { id: 'account_note.placeholder', defaultMessage: 'Click to add a note' },
+  placeholder: {
+    id: 'account_note.placeholder',
+    defaultMessage: 'Click to add a note',
+  },
 });
 
 class InlineAlert extends PureComponent {
-
   static propTypes = {
     show: PropTypes.bool,
   };
@@ -25,29 +27,37 @@ class InlineAlert extends PureComponent {
 
   static TRANSITION_DELAY = 200;
 
-  UNSAFE_componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (!this.props.show && nextProps.show) {
       this.setState({ mountMessage: true });
     } else if (this.props.show && !nextProps.show) {
-      setTimeout(() => this.setState({ mountMessage: false }), InlineAlert.TRANSITION_DELAY);
+      setTimeout(
+        () => this.setState({ mountMessage: false }),
+        InlineAlert.TRANSITION_DELAY,
+      );
     }
   }
 
-  render () {
+  render() {
     const { show } = this.props;
     const { mountMessage } = this.state;
 
     return (
-      <span aria-live='polite' role='status' className='inline-alert' style={{ opacity: show ? 1 : 0 }}>
-        {mountMessage && <FormattedMessage id='generic.saved' defaultMessage='Saved' />}
+      <span
+        aria-live='polite'
+        role='status'
+        className='inline-alert'
+        style={{ opacity: show ? 1 : 0 }}
+      >
+        {mountMessage && (
+          <FormattedMessage id='generic.saved' defaultMessage='Saved' />
+        )}
       </span>
     );
   }
-
 }
 
 class AccountNote extends ImmutablePureComponent {
-
   static propTypes = {
     account: ImmutablePropTypes.map.isRequired,
     value: PropTypes.string,
@@ -61,11 +71,11 @@ class AccountNote extends ImmutablePureComponent {
     saved: false,
   };
 
-  UNSAFE_componentWillMount () {
+  UNSAFE_componentWillMount() {
     this._reset();
   }
 
-  UNSAFE_componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const accountWillChange = !is(this.props.account, nextProps.account);
     const newState = {};
 
@@ -84,21 +94,21 @@ class AccountNote extends ImmutablePureComponent {
     this.setState(newState);
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     if (this._isDirty()) {
       this._save(false);
     }
   }
 
-  setTextareaRef = c => {
+  setTextareaRef = (c) => {
     this.textarea = c;
   };
 
-  handleChange = e => {
+  handleChange = (e) => {
     this.setState({ value: e.target.value, saving: false });
   };
 
-  handleKeyDown = e => {
+  handleKeyDown = (e) => {
     if (e.keyCode === 13 && (e.ctrlKey || e.metaKey)) {
       e.preventDefault();
 
@@ -124,23 +134,30 @@ class AccountNote extends ImmutablePureComponent {
     }
   };
 
-  _save (showMessage = true) {
+  _save(showMessage = true) {
     this.setState({ saving: true }, () => this.props.onSave(this.state.value));
 
     if (showMessage) {
-      this.setState({ saved: true }, () => setTimeout(() => this.setState({ saved: false }), 2000));
+      this.setState({ saved: true }, () =>
+        setTimeout(() => this.setState({ saved: false }), 2000),
+      );
     }
   }
 
-  _reset (callback) {
+  _reset(callback) {
     this.setState({ value: this.props.value }, callback);
   }
 
-  _isDirty () {
-    return !this.state.saving && this.props.value !== null && this.state.value !== null && this.state.value !== this.props.value;
+  _isDirty() {
+    return (
+      !this.state.saving &&
+      this.props.value !== null &&
+      this.state.value !== null &&
+      this.state.value !== this.props.value
+    );
   }
 
-  render () {
+  render() {
     const { account, intl } = this.props;
     const { value, saved } = this.state;
 
@@ -151,7 +168,11 @@ class AccountNote extends ImmutablePureComponent {
     return (
       <div className='account__header__account-note'>
         <label htmlFor={`account-note-${account.get('id')}`}>
-          <FormattedMessage id='account.account_note_header' defaultMessage='Note' /> <InlineAlert show={saved} />
+          <FormattedMessage
+            id='account.account_note_header'
+            defaultMessage='Note'
+          />{' '}
+          <InlineAlert show={saved} />
         </label>
 
         <Textarea
@@ -168,7 +189,6 @@ class AccountNote extends ImmutablePureComponent {
       </div>
     );
   }
-
 }
 
 export default injectIntl(AccountNote);

--- a/app/javascript/mastodon/features/account/components/featured_tags.jsx
+++ b/app/javascript/mastodon/features/account/components/featured_tags.jsx
@@ -8,12 +8,17 @@ import ImmutablePureComponent from 'react-immutable-pure-component';
 import Hashtag from 'mastodon/components/hashtag';
 
 const messages = defineMessages({
-  lastStatusAt: { id: 'account.featured_tags.last_status_at', defaultMessage: 'Last post on {date}' },
-  empty: { id: 'account.featured_tags.last_status_never', defaultMessage: 'No posts' },
+  lastStatusAt: {
+    id: 'account.featured_tags.last_status_at',
+    defaultMessage: 'Last post on {date}',
+  },
+  empty: {
+    id: 'account.featured_tags.last_status_never',
+    defaultMessage: 'No posts',
+  },
 });
 
 class FeaturedTags extends ImmutablePureComponent {
-
   static contextTypes = {
     router: PropTypes.object,
   };
@@ -25,7 +30,7 @@ class FeaturedTags extends ImmutablePureComponent {
     intl: PropTypes.object.isRequired,
   };
 
-  render () {
+  render() {
     const { account, featuredTags, intl } = this.props;
 
     if (!account || account.get('suspended') || featuredTags.isEmpty()) {
@@ -34,22 +39,44 @@ class FeaturedTags extends ImmutablePureComponent {
 
     return (
       <div className='getting-started__trends'>
-        <h4><FormattedMessage id='account.featured_tags.title' defaultMessage="{name}'s featured hashtags" values={{ name: <bdi dangerouslySetInnerHTML={{ __html: account.get('display_name_html') }} /> }} /></h4>
+        <h4>
+          <FormattedMessage
+            id='account.featured_tags.title'
+            defaultMessage="{name}'s featured hashtags"
+            values={{
+              name: (
+                <bdi
+                  dangerouslySetInnerHTML={{
+                    __html: account.get('display_name_html'),
+                  }}
+                />
+              ),
+            }}
+          />
+        </h4>
 
-        {featuredTags.take(3).map(featuredTag => (
+        {featuredTags.take(3).map((featuredTag) => (
           <Hashtag
             key={featuredTag.get('name')}
             name={featuredTag.get('name')}
             to={`/@${account.get('acct')}/tagged/${featuredTag.get('name')}`}
             uses={featuredTag.get('statuses_count') * 1}
             withGraph={false}
-            description={((featuredTag.get('statuses_count') * 1) > 0) ? intl.formatMessage(messages.lastStatusAt, { date: intl.formatDate(featuredTag.get('last_status_at'), { month: 'short', day: '2-digit' }) }) : intl.formatMessage(messages.empty)}
+            description={
+              featuredTag.get('statuses_count') * 1 > 0
+                ? intl.formatMessage(messages.lastStatusAt, {
+                    date: intl.formatDate(featuredTag.get('last_status_at'), {
+                      month: 'short',
+                      day: '2-digit',
+                    }),
+                  })
+                : intl.formatMessage(messages.empty)
+            }
           />
         ))}
       </div>
     );
   }
-
 }
 
 export default injectIntl(FeaturedTags);

--- a/app/javascript/mastodon/features/account/components/follow_request_note.jsx
+++ b/app/javascript/mastodon/features/account/components/follow_request_note.jsx
@@ -3,36 +3,62 @@ import { FormattedMessage } from 'react-intl';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 
-import { Icon }  from 'mastodon/components/icon';
+import { Icon } from 'mastodon/components/icon';
 
 export default class FollowRequestNote extends ImmutablePureComponent {
-
   static propTypes = {
     account: ImmutablePropTypes.map.isRequired,
   };
 
-  render () {
+  render() {
     const { account, onAuthorize, onReject } = this.props;
 
     return (
       <div className='follow-request-banner'>
         <div className='follow-request-banner__message'>
-          <FormattedMessage id='account.requested_follow' defaultMessage='{name} has requested to follow you' values={{ name: <bdi><strong dangerouslySetInnerHTML={{ __html: account.get('display_name_html') }} /></bdi> }} />
+          <FormattedMessage
+            id='account.requested_follow'
+            defaultMessage='{name} has requested to follow you'
+            values={{
+              name: (
+                <bdi>
+                  <strong
+                    dangerouslySetInnerHTML={{
+                      __html: account.get('display_name_html'),
+                    }}
+                  />
+                </bdi>
+              ),
+            }}
+          />
         </div>
 
         <div className='follow-request-banner__action'>
-          <button type='button' className='button button-tertiary button--confirmation' onClick={onAuthorize}>
+          <button
+            type='button'
+            className='button button-tertiary button--confirmation'
+            onClick={onAuthorize}
+          >
             <Icon id='check' fixedWidth />
-            <FormattedMessage id='follow_request.authorize' defaultMessage='Authorize' />
+            <FormattedMessage
+              id='follow_request.authorize'
+              defaultMessage='Authorize'
+            />
           </button>
 
-          <button type='button' className='button button-tertiary button--destructive' onClick={onReject}>
+          <button
+            type='button'
+            className='button button-tertiary button--destructive'
+            onClick={onReject}
+          >
             <Icon id='times' fixedWidth />
-            <FormattedMessage id='follow_request.reject' defaultMessage='Reject' />
+            <FormattedMessage
+              id='follow_request.reject'
+              defaultMessage='Reject'
+            />
           </button>
         </div>
       </div>
     );
   }
-
 }

--- a/app/javascript/mastodon/features/account/components/header.jsx
+++ b/app/javascript/mastodon/features/account/components/header.jsx
@@ -12,13 +12,20 @@ import ImmutablePureComponent from 'react-immutable-pure-component';
 import { Avatar } from 'mastodon/components/avatar';
 import { Badge, AutomatedBadge, GroupBadge } from 'mastodon/components/badge';
 import Button from 'mastodon/components/button';
-import { FollowersCounter, FollowingCounter, StatusesCounter } from 'mastodon/components/counters';
-import { Icon }  from 'mastodon/components/icon';
+import {
+  FollowersCounter,
+  FollowingCounter,
+  StatusesCounter,
+} from 'mastodon/components/counters';
+import { Icon } from 'mastodon/components/icon';
 import { IconButton } from 'mastodon/components/icon_button';
 import { ShortNumber } from 'mastodon/components/short_number';
 import DropdownMenuContainer from 'mastodon/containers/dropdown_menu_container';
 import { autoPlayGif, me, domain } from 'mastodon/initial_state';
-import { PERMISSION_MANAGE_USERS, PERMISSION_MANAGE_FEDERATION } from 'mastodon/permissions';
+import {
+  PERMISSION_MANAGE_USERS,
+  PERMISSION_MANAGE_FEDERATION,
+} from 'mastodon/permissions';
 
 import AccountNoteContainer from '../containers/account_note_container';
 import FollowRequestNoteContainer from '../containers/follow_request_note_container';
@@ -26,48 +33,113 @@ import FollowRequestNoteContainer from '../containers/follow_request_note_contai
 const messages = defineMessages({
   unfollow: { id: 'account.unfollow', defaultMessage: 'Unfollow' },
   follow: { id: 'account.follow', defaultMessage: 'Follow' },
-  cancel_follow_request: { id: 'account.cancel_follow_request', defaultMessage: 'Withdraw follow request' },
-  requested: { id: 'account.requested', defaultMessage: 'Awaiting approval. Click to cancel follow request' },
+  cancel_follow_request: {
+    id: 'account.cancel_follow_request',
+    defaultMessage: 'Withdraw follow request',
+  },
+  requested: {
+    id: 'account.requested',
+    defaultMessage: 'Awaiting approval. Click to cancel follow request',
+  },
   unblock: { id: 'account.unblock', defaultMessage: 'Unblock @{name}' },
   edit_profile: { id: 'account.edit_profile', defaultMessage: 'Edit profile' },
-  linkVerifiedOn: { id: 'account.link_verified_on', defaultMessage: 'Ownership of this link was checked on {date}' },
-  account_locked: { id: 'account.locked_info', defaultMessage: 'This account privacy status is set to locked. The owner manually reviews who can follow them.' },
+  linkVerifiedOn: {
+    id: 'account.link_verified_on',
+    defaultMessage: 'Ownership of this link was checked on {date}',
+  },
+  account_locked: {
+    id: 'account.locked_info',
+    defaultMessage:
+      'This account privacy status is set to locked. The owner manually reviews who can follow them.',
+  },
   mention: { id: 'account.mention', defaultMessage: 'Mention @{name}' },
   direct: { id: 'account.direct', defaultMessage: 'Privately mention @{name}' },
   unmute: { id: 'account.unmute', defaultMessage: 'Unmute @{name}' },
   block: { id: 'account.block', defaultMessage: 'Block @{name}' },
   mute: { id: 'account.mute', defaultMessage: 'Mute @{name}' },
   report: { id: 'account.report', defaultMessage: 'Report @{name}' },
-  share: { id: 'account.share', defaultMessage: 'Share @{name}\'s profile' },
+  share: { id: 'account.share', defaultMessage: "Share @{name}'s profile" },
   media: { id: 'account.media', defaultMessage: 'Media' },
-  blockDomain: { id: 'account.block_domain', defaultMessage: 'Block domain {domain}' },
-  unblockDomain: { id: 'account.unblock_domain', defaultMessage: 'Unblock domain {domain}' },
-  hideReblogs: { id: 'account.hide_reblogs', defaultMessage: 'Hide boosts from @{name}' },
-  showReblogs: { id: 'account.show_reblogs', defaultMessage: 'Show boosts from @{name}' },
-  enableNotifications: { id: 'account.enable_notifications', defaultMessage: 'Notify me when @{name} posts' },
-  disableNotifications: { id: 'account.disable_notifications', defaultMessage: 'Stop notifying me when @{name} posts' },
+  blockDomain: {
+    id: 'account.block_domain',
+    defaultMessage: 'Block domain {domain}',
+  },
+  unblockDomain: {
+    id: 'account.unblock_domain',
+    defaultMessage: 'Unblock domain {domain}',
+  },
+  hideReblogs: {
+    id: 'account.hide_reblogs',
+    defaultMessage: 'Hide boosts from @{name}',
+  },
+  showReblogs: {
+    id: 'account.show_reblogs',
+    defaultMessage: 'Show boosts from @{name}',
+  },
+  enableNotifications: {
+    id: 'account.enable_notifications',
+    defaultMessage: 'Notify me when @{name} posts',
+  },
+  disableNotifications: {
+    id: 'account.disable_notifications',
+    defaultMessage: 'Stop notifying me when @{name} posts',
+  },
   pins: { id: 'navigation_bar.pins', defaultMessage: 'Pinned posts' },
-  preferences: { id: 'navigation_bar.preferences', defaultMessage: 'Preferences' },
-  follow_requests: { id: 'navigation_bar.follow_requests', defaultMessage: 'Follow requests' },
+  preferences: {
+    id: 'navigation_bar.preferences',
+    defaultMessage: 'Preferences',
+  },
+  follow_requests: {
+    id: 'navigation_bar.follow_requests',
+    defaultMessage: 'Follow requests',
+  },
   favourites: { id: 'navigation_bar.favourites', defaultMessage: 'Favorites' },
   lists: { id: 'navigation_bar.lists', defaultMessage: 'Lists' },
-  followed_tags: { id: 'navigation_bar.followed_tags', defaultMessage: 'Followed hashtags' },
+  followed_tags: {
+    id: 'navigation_bar.followed_tags',
+    defaultMessage: 'Followed hashtags',
+  },
   blocks: { id: 'navigation_bar.blocks', defaultMessage: 'Blocked users' },
-  domain_blocks: { id: 'navigation_bar.domain_blocks', defaultMessage: 'Blocked domains' },
+  domain_blocks: {
+    id: 'navigation_bar.domain_blocks',
+    defaultMessage: 'Blocked domains',
+  },
   mutes: { id: 'navigation_bar.mutes', defaultMessage: 'Muted users' },
   endorse: { id: 'account.endorse', defaultMessage: 'Feature on profile' },
-  unendorse: { id: 'account.unendorse', defaultMessage: 'Don\'t feature on profile' },
-  add_or_remove_from_list: { id: 'account.add_or_remove_from_list', defaultMessage: 'Add or Remove from lists' },
-  admin_account: { id: 'status.admin_account', defaultMessage: 'Open moderation interface for @{name}' },
-  admin_domain: { id: 'status.admin_domain', defaultMessage: 'Open moderation interface for {domain}' },
-  languages: { id: 'account.languages', defaultMessage: 'Change subscribed languages' },
-  openOriginalPage: { id: 'account.open_original_page', defaultMessage: 'Open original page' },
+  unendorse: {
+    id: 'account.unendorse',
+    defaultMessage: "Don't feature on profile",
+  },
+  add_or_remove_from_list: {
+    id: 'account.add_or_remove_from_list',
+    defaultMessage: 'Add or Remove from lists',
+  },
+  admin_account: {
+    id: 'status.admin_account',
+    defaultMessage: 'Open moderation interface for @{name}',
+  },
+  admin_domain: {
+    id: 'status.admin_domain',
+    defaultMessage: 'Open moderation interface for {domain}',
+  },
+  languages: {
+    id: 'account.languages',
+    defaultMessage: 'Change subscribed languages',
+  },
+  openOriginalPage: {
+    id: 'account.open_original_page',
+    defaultMessage: 'Open original page',
+  },
 });
 
-const titleFromAccount = account => {
+const titleFromAccount = (account) => {
   const displayName = account.get('display_name');
-  const acct = account.get('acct') === account.get('username') ? `${account.get('username')}@${domain}` : account.get('acct');
-  const prefix = displayName.trim().length === 0 ? account.get('username') : displayName;
+  const acct =
+    account.get('acct') === account.get('username')
+      ? `${account.get('username')}@${domain}`
+      : account.get('acct');
+  const prefix =
+    displayName.trim().length === 0 ? account.get('username') : displayName;
 
   return `${prefix} (@${acct})`;
 };
@@ -82,7 +154,6 @@ const dateFormatOptions = {
 };
 
 class Header extends ImmutablePureComponent {
-
   static contextTypes = {
     identity: PropTypes.object,
     router: PropTypes.object,
@@ -113,7 +184,7 @@ class Header extends ImmutablePureComponent {
     hidden: PropTypes.bool,
   };
 
-  setRef = c => {
+  setRef = (c) => {
     this.node = c;
   };
 
@@ -155,7 +226,7 @@ class Header extends ImmutablePureComponent {
     }
   };
 
-  handleAvatarClick = e => {
+  handleAvatarClick = (e) => {
     if (e.button === 0 && !(e.ctrlKey || e.metaKey)) {
       e.preventDefault();
       this.props.onOpenAvatar();
@@ -165,14 +236,16 @@ class Header extends ImmutablePureComponent {
   handleShare = () => {
     const { account } = this.props;
 
-    navigator.share({
-      url: account.get('url'),
-    }).catch((e) => {
-      if (e.name !== 'AbortError') console.error(e);
-    });
+    navigator
+      .share({
+        url: account.get('url'),
+      })
+      .catch((e) => {
+        if (e.name !== 'AbortError') console.error(e);
+      });
   };
 
-  handleHashtagClick = e => {
+  handleHashtagClick = (e) => {
     const { router } = this.context;
     const value = e.currentTarget.textContent.replace(/^#/, '');
 
@@ -182,7 +255,7 @@ class Header extends ImmutablePureComponent {
     }
   };
 
-  handleMentionClick = e => {
+  handleMentionClick = (e) => {
     const { router } = this.context;
     const { onOpenURL } = this.props;
 
@@ -197,7 +270,7 @@ class Header extends ImmutablePureComponent {
     }
   };
 
-  _attachLinkEvents () {
+  _attachLinkEvents() {
     const node = this.node;
 
     if (!node) {
@@ -211,7 +284,14 @@ class Header extends ImmutablePureComponent {
     for (var i = 0; i < links.length; ++i) {
       link = links[i];
 
-      if (link.textContent[0] === '#' || (link.previousSibling && link.previousSibling.textContent && link.previousSibling.textContent[link.previousSibling.textContent.length - 1] === '#')) {
+      if (
+        link.textContent[0] === '#' ||
+        (link.previousSibling &&
+          link.previousSibling.textContent &&
+          link.previousSibling.textContent[
+            link.previousSibling.textContent.length - 1
+          ] === '#')
+      ) {
         link.addEventListener('click', this.handleHashtagClick, false);
       } else if (link.classList.contains('mention')) {
         link.addEventListener('click', this.handleMentionClick, false);
@@ -219,15 +299,15 @@ class Header extends ImmutablePureComponent {
     }
   }
 
-  componentDidMount () {
+  componentDidMount() {
     this._attachLinkEvents();
   }
 
-  componentDidUpdate () {
+  componentDidUpdate() {
     this._attachLinkEvents();
   }
 
-  render () {
+  render() {
     const { account, hidden, intl, domain } = this.props;
     const { signedIn, permissions } = this.context.identity;
 
@@ -235,44 +315,130 @@ class Header extends ImmutablePureComponent {
       return null;
     }
 
-    const suspended    = account.get('suspended');
-    const isRemote     = account.get('acct') !== account.get('username');
+    const suspended = account.get('suspended');
+    const isRemote = account.get('acct') !== account.get('username');
     const remoteDomain = isRemote ? account.get('acct').split('@')[1] : null;
 
-    let info        = [];
-    let actionBtn   = '';
-    let bellBtn     = '';
-    let lockedIcon  = '';
-    let menu        = [];
+    let info = [];
+    let actionBtn = '';
+    let bellBtn = '';
+    let lockedIcon = '';
+    let menu = [];
 
-    if (me !== account.get('id') && account.getIn(['relationship', 'followed_by'])) {
-      info.push(<span key='followed_by' className='relationship-tag'><FormattedMessage id='account.follows_you' defaultMessage='Follows you' /></span>);
-    } else if (me !== account.get('id') && account.getIn(['relationship', 'blocking'])) {
-      info.push(<span key='blocked' className='relationship-tag'><FormattedMessage id='account.blocked' defaultMessage='Blocked' /></span>);
+    if (
+      me !== account.get('id') &&
+      account.getIn(['relationship', 'followed_by'])
+    ) {
+      info.push(
+        <span key='followed_by' className='relationship-tag'>
+          <FormattedMessage
+            id='account.follows_you'
+            defaultMessage='Follows you'
+          />
+        </span>,
+      );
+    } else if (
+      me !== account.get('id') &&
+      account.getIn(['relationship', 'blocking'])
+    ) {
+      info.push(
+        <span key='blocked' className='relationship-tag'>
+          <FormattedMessage id='account.blocked' defaultMessage='Blocked' />
+        </span>,
+      );
     }
 
     if (me !== account.get('id') && account.getIn(['relationship', 'muting'])) {
-      info.push(<span key='muted' className='relationship-tag'><FormattedMessage id='account.muted' defaultMessage='Muted' /></span>);
-    } else if (me !== account.get('id') && account.getIn(['relationship', 'domain_blocking'])) {
-      info.push(<span key='domain_blocked' className='relationship-tag'><FormattedMessage id='account.domain_blocked' defaultMessage='Domain blocked' /></span>);
+      info.push(
+        <span key='muted' className='relationship-tag'>
+          <FormattedMessage id='account.muted' defaultMessage='Muted' />
+        </span>,
+      );
+    } else if (
+      me !== account.get('id') &&
+      account.getIn(['relationship', 'domain_blocking'])
+    ) {
+      info.push(
+        <span key='domain_blocked' className='relationship-tag'>
+          <FormattedMessage
+            id='account.domain_blocked'
+            defaultMessage='Domain blocked'
+          />
+        </span>,
+      );
     }
 
-    if (account.getIn(['relationship', 'requested']) || account.getIn(['relationship', 'following'])) {
-      bellBtn = <IconButton icon={account.getIn(['relationship', 'notifying']) ? 'bell' : 'bell-o'} size={24} active={account.getIn(['relationship', 'notifying'])} title={intl.formatMessage(account.getIn(['relationship', 'notifying']) ? messages.disableNotifications : messages.enableNotifications, { name: account.get('username') })} onClick={this.props.onNotifyToggle} />;
+    if (
+      account.getIn(['relationship', 'requested']) ||
+      account.getIn(['relationship', 'following'])
+    ) {
+      bellBtn = (
+        <IconButton
+          icon={
+            account.getIn(['relationship', 'notifying']) ? 'bell' : 'bell-o'
+          }
+          size={24}
+          active={account.getIn(['relationship', 'notifying'])}
+          title={intl.formatMessage(
+            account.getIn(['relationship', 'notifying'])
+              ? messages.disableNotifications
+              : messages.enableNotifications,
+            { name: account.get('username') },
+          )}
+          onClick={this.props.onNotifyToggle}
+        />
+      );
     }
 
     if (me !== account.get('id')) {
-      if (signedIn && !account.get('relationship')) { // Wait until the relationship is loaded
+      if (signedIn && !account.get('relationship')) {
+        // Wait until the relationship is loaded
         actionBtn = '';
       } else if (account.getIn(['relationship', 'requested'])) {
-        actionBtn = <Button text={intl.formatMessage(messages.cancel_follow_request)} title={intl.formatMessage(messages.requested)} onClick={this.props.onFollow} />;
+        actionBtn = (
+          <Button
+            text={intl.formatMessage(messages.cancel_follow_request)}
+            title={intl.formatMessage(messages.requested)}
+            onClick={this.props.onFollow}
+          />
+        );
       } else if (!account.getIn(['relationship', 'blocking'])) {
-        actionBtn = <Button disabled={account.getIn(['relationship', 'blocked_by'])} className={classNames({ 'button--destructive': account.getIn(['relationship', 'following']) })} text={intl.formatMessage(account.getIn(['relationship', 'following']) ? messages.unfollow : messages.follow)} onClick={signedIn ? this.props.onFollow : this.props.onInteractionModal} />;
+        actionBtn = (
+          <Button
+            disabled={account.getIn(['relationship', 'blocked_by'])}
+            className={classNames({
+              'button--destructive': account.getIn([
+                'relationship',
+                'following',
+              ]),
+            })}
+            text={intl.formatMessage(
+              account.getIn(['relationship', 'following'])
+                ? messages.unfollow
+                : messages.follow,
+            )}
+            onClick={
+              signedIn ? this.props.onFollow : this.props.onInteractionModal
+            }
+          />
+        );
       } else if (account.getIn(['relationship', 'blocking'])) {
-        actionBtn = <Button text={intl.formatMessage(messages.unblock, { name: account.get('username') })} onClick={this.props.onBlock} />;
+        actionBtn = (
+          <Button
+            text={intl.formatMessage(messages.unblock, {
+              name: account.get('username'),
+            })}
+            onClick={this.props.onBlock}
+          />
+        );
       }
     } else {
-      actionBtn = <Button text={intl.formatMessage(messages.edit_profile)} onClick={this.openEditProfile} />;
+      actionBtn = (
+        <Button
+          text={intl.formatMessage(messages.edit_profile)}
+          onClick={this.openEditProfile}
+        />
+      );
     }
 
     if (account.get('moved') && !account.getIn(['relationship', 'following'])) {
@@ -280,96 +446,219 @@ class Header extends ImmutablePureComponent {
     }
 
     if (account.get('locked')) {
-      lockedIcon = <Icon id='lock' title={intl.formatMessage(messages.account_locked)} />;
+      lockedIcon = (
+        <Icon id='lock' title={intl.formatMessage(messages.account_locked)} />
+      );
     }
 
     if (signedIn && account.get('id') !== me) {
-      menu.push({ text: intl.formatMessage(messages.mention, { name: account.get('username') }), action: this.props.onMention });
-      menu.push({ text: intl.formatMessage(messages.direct, { name: account.get('username') }), action: this.props.onDirect });
+      menu.push({
+        text: intl.formatMessage(messages.mention, {
+          name: account.get('username'),
+        }),
+        action: this.props.onMention,
+      });
+      menu.push({
+        text: intl.formatMessage(messages.direct, {
+          name: account.get('username'),
+        }),
+        action: this.props.onDirect,
+      });
       menu.push(null);
     }
 
     if (isRemote) {
-      menu.push({ text: intl.formatMessage(messages.openOriginalPage), href: account.get('url') });
+      menu.push({
+        text: intl.formatMessage(messages.openOriginalPage),
+        href: account.get('url'),
+      });
     }
 
     if ('share' in navigator) {
-      menu.push({ text: intl.formatMessage(messages.share, { name: account.get('username') }), action: this.handleShare });
+      menu.push({
+        text: intl.formatMessage(messages.share, {
+          name: account.get('username'),
+        }),
+        action: this.handleShare,
+      });
       menu.push(null);
     }
 
     if (account.get('id') === me) {
-      menu.push({ text: intl.formatMessage(messages.edit_profile), href: '/settings/profile' });
-      menu.push({ text: intl.formatMessage(messages.preferences), href: '/settings/preferences' });
+      menu.push({
+        text: intl.formatMessage(messages.edit_profile),
+        href: '/settings/profile',
+      });
+      menu.push({
+        text: intl.formatMessage(messages.preferences),
+        href: '/settings/preferences',
+      });
       menu.push({ text: intl.formatMessage(messages.pins), to: '/pinned' });
       menu.push(null);
-      menu.push({ text: intl.formatMessage(messages.follow_requests), to: '/follow_requests' });
-      menu.push({ text: intl.formatMessage(messages.favourites), to: '/favourites' });
+      menu.push({
+        text: intl.formatMessage(messages.follow_requests),
+        to: '/follow_requests',
+      });
+      menu.push({
+        text: intl.formatMessage(messages.favourites),
+        to: '/favourites',
+      });
       menu.push({ text: intl.formatMessage(messages.lists), to: '/lists' });
-      menu.push({ text: intl.formatMessage(messages.followed_tags), to: '/followed_tags' });
+      menu.push({
+        text: intl.formatMessage(messages.followed_tags),
+        to: '/followed_tags',
+      });
       menu.push(null);
       menu.push({ text: intl.formatMessage(messages.mutes), to: '/mutes' });
       menu.push({ text: intl.formatMessage(messages.blocks), to: '/blocks' });
-      menu.push({ text: intl.formatMessage(messages.domain_blocks), to: '/domain_blocks' });
+      menu.push({
+        text: intl.formatMessage(messages.domain_blocks),
+        to: '/domain_blocks',
+      });
     } else if (signedIn) {
       if (account.getIn(['relationship', 'following'])) {
         if (!account.getIn(['relationship', 'muting'])) {
           if (account.getIn(['relationship', 'showing_reblogs'])) {
-            menu.push({ text: intl.formatMessage(messages.hideReblogs, { name: account.get('username') }), action: this.props.onReblogToggle });
+            menu.push({
+              text: intl.formatMessage(messages.hideReblogs, {
+                name: account.get('username'),
+              }),
+              action: this.props.onReblogToggle,
+            });
           } else {
-            menu.push({ text: intl.formatMessage(messages.showReblogs, { name: account.get('username') }), action: this.props.onReblogToggle });
+            menu.push({
+              text: intl.formatMessage(messages.showReblogs, {
+                name: account.get('username'),
+              }),
+              action: this.props.onReblogToggle,
+            });
           }
 
-          menu.push({ text: intl.formatMessage(messages.languages), action: this.props.onChangeLanguages });
+          menu.push({
+            text: intl.formatMessage(messages.languages),
+            action: this.props.onChangeLanguages,
+          });
           menu.push(null);
         }
 
-        menu.push({ text: intl.formatMessage(account.getIn(['relationship', 'endorsed']) ? messages.unendorse : messages.endorse), action: this.props.onEndorseToggle });
-        menu.push({ text: intl.formatMessage(messages.add_or_remove_from_list), action: this.props.onAddToList });
+        menu.push({
+          text: intl.formatMessage(
+            account.getIn(['relationship', 'endorsed'])
+              ? messages.unendorse
+              : messages.endorse,
+          ),
+          action: this.props.onEndorseToggle,
+        });
+        menu.push({
+          text: intl.formatMessage(messages.add_or_remove_from_list),
+          action: this.props.onAddToList,
+        });
         menu.push(null);
       }
 
       if (account.getIn(['relationship', 'muting'])) {
-        menu.push({ text: intl.formatMessage(messages.unmute, { name: account.get('username') }), action: this.props.onMute });
+        menu.push({
+          text: intl.formatMessage(messages.unmute, {
+            name: account.get('username'),
+          }),
+          action: this.props.onMute,
+        });
       } else {
-        menu.push({ text: intl.formatMessage(messages.mute, { name: account.get('username') }), action: this.props.onMute, dangerous: true });
+        menu.push({
+          text: intl.formatMessage(messages.mute, {
+            name: account.get('username'),
+          }),
+          action: this.props.onMute,
+          dangerous: true,
+        });
       }
 
       if (account.getIn(['relationship', 'blocking'])) {
-        menu.push({ text: intl.formatMessage(messages.unblock, { name: account.get('username') }), action: this.props.onBlock });
+        menu.push({
+          text: intl.formatMessage(messages.unblock, {
+            name: account.get('username'),
+          }),
+          action: this.props.onBlock,
+        });
       } else {
-        menu.push({ text: intl.formatMessage(messages.block, { name: account.get('username') }), action: this.props.onBlock, dangerous: true });
+        menu.push({
+          text: intl.formatMessage(messages.block, {
+            name: account.get('username'),
+          }),
+          action: this.props.onBlock,
+          dangerous: true,
+        });
       }
 
-      menu.push({ text: intl.formatMessage(messages.report, { name: account.get('username') }), action: this.props.onReport, dangerous: true });
+      menu.push({
+        text: intl.formatMessage(messages.report, {
+          name: account.get('username'),
+        }),
+        action: this.props.onReport,
+        dangerous: true,
+      });
     }
 
     if (signedIn && isRemote) {
       menu.push(null);
 
       if (account.getIn(['relationship', 'domain_blocking'])) {
-        menu.push({ text: intl.formatMessage(messages.unblockDomain, { domain: remoteDomain }), action: this.props.onUnblockDomain });
+        menu.push({
+          text: intl.formatMessage(messages.unblockDomain, {
+            domain: remoteDomain,
+          }),
+          action: this.props.onUnblockDomain,
+        });
       } else {
-        menu.push({ text: intl.formatMessage(messages.blockDomain, { domain: remoteDomain }), action: this.props.onBlockDomain, dangerous: true });
+        menu.push({
+          text: intl.formatMessage(messages.blockDomain, {
+            domain: remoteDomain,
+          }),
+          action: this.props.onBlockDomain,
+          dangerous: true,
+        });
       }
     }
 
-    if ((account.get('id') !== me && (permissions & PERMISSION_MANAGE_USERS) === PERMISSION_MANAGE_USERS) || (isRemote && (permissions & PERMISSION_MANAGE_FEDERATION) === PERMISSION_MANAGE_FEDERATION)) {
+    if (
+      (account.get('id') !== me &&
+        (permissions & PERMISSION_MANAGE_USERS) === PERMISSION_MANAGE_USERS) ||
+      (isRemote &&
+        (permissions & PERMISSION_MANAGE_FEDERATION) ===
+          PERMISSION_MANAGE_FEDERATION)
+    ) {
       menu.push(null);
       if ((permissions & PERMISSION_MANAGE_USERS) === PERMISSION_MANAGE_USERS) {
-        menu.push({ text: intl.formatMessage(messages.admin_account, { name: account.get('username') }), href: `/admin/accounts/${account.get('id')}` });
+        menu.push({
+          text: intl.formatMessage(messages.admin_account, {
+            name: account.get('username'),
+          }),
+          href: `/admin/accounts/${account.get('id')}`,
+        });
       }
-      if (isRemote && (permissions & PERMISSION_MANAGE_FEDERATION) === PERMISSION_MANAGE_FEDERATION) {
-        menu.push({ text: intl.formatMessage(messages.admin_domain, { domain: remoteDomain }), href: `/admin/instances/${remoteDomain}` });
+      if (
+        isRemote &&
+        (permissions & PERMISSION_MANAGE_FEDERATION) ===
+          PERMISSION_MANAGE_FEDERATION
+      ) {
+        menu.push({
+          text: intl.formatMessage(messages.admin_domain, {
+            domain: remoteDomain,
+          }),
+          href: `/admin/instances/${remoteDomain}`,
+        });
       }
     }
 
-    const content         = { __html: account.get('note_emojified') };
+    const content = { __html: account.get('note_emojified') };
     const displayNameHtml = { __html: account.get('display_name_html') };
-    const fields          = account.get('fields');
-    const isLocal         = account.get('acct').indexOf('@') === -1;
-    const acct            = isLocal && domain ? `${account.get('acct')}@${domain}` : account.get('acct');
-    const isIndexable     = !account.get('noindex');
+    const fields = account.get('fields');
+    const isLocal = account.get('acct').indexOf('@') === -1;
+    const acct =
+      isLocal && domain
+        ? `${account.get('acct')}@${domain}`
+        : account.get('acct');
+    const isIndexable = !account.get('noindex');
 
     const badges = [];
 
@@ -380,25 +669,57 @@ class Header extends ImmutablePureComponent {
     }
 
     account.get('roles', []).forEach((role) => {
-      badges.push(<Badge key={`role-badge-${role.get('id')}`} label={<span>{role.get('name')}</span>} domain={domain} />);
+      badges.push(
+        <Badge
+          key={`role-badge-${role.get('id')}`}
+          label={<span>{role.get('name')}</span>}
+          domain={domain}
+        />,
+      );
     });
 
     return (
-      <div className={classNames('account__header', { inactive: !!account.get('moved') })} onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave}>
-        {!(suspended || hidden || account.get('moved')) && account.getIn(['relationship', 'requested_by']) && <FollowRequestNoteContainer account={account} />}
+      <div
+        className={classNames('account__header', {
+          inactive: !!account.get('moved'),
+        })}
+        onMouseEnter={this.handleMouseEnter}
+        onMouseLeave={this.handleMouseLeave}
+      >
+        {!(suspended || hidden || account.get('moved')) &&
+          account.getIn(['relationship', 'requested_by']) && (
+            <FollowRequestNoteContainer account={account} />
+          )}
 
         <div className='account__header__image'>
-          <div className='account__header__info'>
-            {!suspended && info}
-          </div>
+          <div className='account__header__info'>{!suspended && info}</div>
 
-          {!(suspended || hidden) && <img src={autoPlayGif ? account.get('header') : account.get('header_static')} alt='' className='parallax' />}
+          {!(suspended || hidden) && (
+            <img
+              src={
+                autoPlayGif
+                  ? account.get('header')
+                  : account.get('header_static')
+              }
+              alt=''
+              className='parallax'
+            />
+          )}
         </div>
 
         <div className='account__header__bar'>
           <div className='account__header__tabs'>
-            <a className='avatar' href={account.get('avatar')} rel='noopener noreferrer' target='_blank' onClick={this.handleAvatarClick}>
-              <Avatar account={suspended || hidden ? undefined : account} size={90} />
+            <a
+              className='avatar'
+              href={account.get('avatar')}
+              rel='noopener noreferrer'
+              target='_blank'
+              onClick={this.handleAvatarClick}
+            >
+              <Avatar
+                account={suspended || hidden ? undefined : account}
+                size={90}
+              />
             </a>
 
             {!suspended && (
@@ -410,7 +731,13 @@ class Header extends ImmutablePureComponent {
                   </>
                 )}
 
-                <DropdownMenuContainer disabled={menu.length === 0} items={menu} icon='ellipsis-v' size={24} direction='right' />
+                <DropdownMenuContainer
+                  disabled={menu.length === 0}
+                  items={menu}
+                  icon='ellipsis-v'
+                  size={24}
+                  direction='right'
+                />
               </div>
             )}
           </div>
@@ -425,30 +752,74 @@ class Header extends ImmutablePureComponent {
           </div>
 
           {badges.length > 0 && (
-            <div className='account__header__badges'>
-              {badges}
-            </div>
+            <div className='account__header__badges'>{badges}</div>
           )}
 
           {!(suspended || hidden) && (
             <div className='account__header__extra'>
               <div className='account__header__bio' ref={this.setRef}>
-                {(account.get('id') !== me && signedIn) && <AccountNoteContainer account={account} />}
+                {account.get('id') !== me && signedIn && (
+                  <AccountNoteContainer account={account} />
+                )}
 
-                {account.get('note').length > 0 && account.get('note') !== '<p></p>' && <div className='account__header__content translate' dangerouslySetInnerHTML={content} />}
+                {account.get('note').length > 0 &&
+                  account.get('note') !== '<p></p>' && (
+                    <div
+                      className='account__header__content translate'
+                      dangerouslySetInnerHTML={content}
+                    />
+                  )}
 
                 <div className='account__header__fields'>
                   <dl>
-                    <dt><FormattedMessage id='account.joined_short' defaultMessage='Joined' /></dt>
-                    <dd>{intl.formatDate(account.get('created_at'), { year: 'numeric', month: 'short', day: '2-digit' })}</dd>
+                    <dt>
+                      <FormattedMessage
+                        id='account.joined_short'
+                        defaultMessage='Joined'
+                      />
+                    </dt>
+                    <dd>
+                      {intl.formatDate(account.get('created_at'), {
+                        year: 'numeric',
+                        month: 'short',
+                        day: '2-digit',
+                      })}
+                    </dd>
                   </dl>
 
                   {fields.map((pair, i) => (
-                    <dl key={i} className={classNames({ verified: pair.get('verified_at') })}>
-                      <dt dangerouslySetInnerHTML={{ __html: pair.get('name_emojified') }} title={pair.get('name')} className='translate' />
+                    <dl
+                      key={i}
+                      className={classNames({
+                        verified: pair.get('verified_at'),
+                      })}
+                    >
+                      <dt
+                        dangerouslySetInnerHTML={{
+                          __html: pair.get('name_emojified'),
+                        }}
+                        title={pair.get('name')}
+                        className='translate'
+                      />
 
                       <dd className='translate' title={pair.get('value_plain')}>
-                        {pair.get('verified_at') && <span title={intl.formatMessage(messages.linkVerifiedOn, { date: intl.formatDate(pair.get('verified_at'), dateFormatOptions) })}><Icon id='check' className='verified__mark' /></span>} <span dangerouslySetInnerHTML={{ __html: pair.get('value_emojified') }} />
+                        {pair.get('verified_at') && (
+                          <span
+                            title={intl.formatMessage(messages.linkVerifiedOn, {
+                              date: intl.formatDate(
+                                pair.get('verified_at'),
+                                dateFormatOptions,
+                              ),
+                            })}
+                          >
+                            <Icon id='check' className='verified__mark' />
+                          </span>
+                        )}{' '}
+                        <span
+                          dangerouslySetInnerHTML={{
+                            __html: pair.get('value_emojified'),
+                          }}
+                        />
                       </dd>
                     </dl>
                   ))}
@@ -456,21 +827,36 @@ class Header extends ImmutablePureComponent {
               </div>
 
               <div className='account__header__extra__links'>
-                <NavLink isActive={this.isStatusesPageActive} activeClassName='active' to={`/@${account.get('acct')}`} title={intl.formatNumber(account.get('statuses_count'))}>
+                <NavLink
+                  isActive={this.isStatusesPageActive}
+                  activeClassName='active'
+                  to={`/@${account.get('acct')}`}
+                  title={intl.formatNumber(account.get('statuses_count'))}
+                >
                   <ShortNumber
                     value={account.get('statuses_count')}
                     renderer={StatusesCounter}
                   />
                 </NavLink>
 
-                <NavLink exact activeClassName='active' to={`/@${account.get('acct')}/following`} title={intl.formatNumber(account.get('following_count'))}>
+                <NavLink
+                  exact
+                  activeClassName='active'
+                  to={`/@${account.get('acct')}/following`}
+                  title={intl.formatNumber(account.get('following_count'))}
+                >
                   <ShortNumber
                     value={account.get('following_count')}
                     renderer={FollowingCounter}
                   />
                 </NavLink>
 
-                <NavLink exact activeClassName='active' to={`/@${account.get('acct')}/followers`} title={intl.formatNumber(account.get('followers_count'))}>
+                <NavLink
+                  exact
+                  activeClassName='active'
+                  to={`/@${account.get('acct')}/followers`}
+                  title={intl.formatNumber(account.get('followers_count'))}
+                >
                   <ShortNumber
                     value={account.get('followers_count')}
                     renderer={FollowersCounter}
@@ -483,13 +869,15 @@ class Header extends ImmutablePureComponent {
 
         <Helmet>
           <title>{titleFromAccount(account)}</title>
-          <meta name='robots' content={(isLocal && isIndexable) ? 'all' : 'noindex'} />
+          <meta
+            name='robots'
+            content={isLocal && isIndexable ? 'all' : 'noindex'}
+          />
           <link rel='canonical' href={account.get('url')} />
         </Helmet>
       </div>
     );
   }
-
 }
 
 export default injectIntl(Header);

--- a/app/javascript/mastodon/features/account/containers/account_note_container.js
+++ b/app/javascript/mastodon/features/account/containers/account_note_container.js
@@ -9,11 +9,9 @@ const mapStateToProps = (state, { account }) => ({
 });
 
 const mapDispatchToProps = (dispatch, { account }) => ({
-
-  onSave (value) {
-    dispatch(submitAccountNote({ id: account.get('id'), value}));
+  onSave(value) {
+    dispatch(submitAccountNote({ id: account.get('id'), value }));
   },
-
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(AccountNote);

--- a/app/javascript/mastodon/features/account/containers/featured_tags_container.js
+++ b/app/javascript/mastodon/features/account/containers/featured_tags_container.js
@@ -10,7 +10,10 @@ const mapStateToProps = () => {
 
   return (state, { accountId }) => ({
     account: getAccount(state, accountId),
-    featuredTags: state.getIn(['user_lists', 'featured_tags', accountId, 'items'], ImmutableList()),
+    featuredTags: state.getIn(
+      ['user_lists', 'featured_tags', accountId, 'items'],
+      ImmutableList(),
+    ),
   });
 };
 

--- a/app/javascript/mastodon/features/account/containers/follow_request_note_container.js
+++ b/app/javascript/mastodon/features/account/containers/follow_request_note_container.js
@@ -1,15 +1,18 @@
 import { connect } from 'react-redux';
 
-import { authorizeFollowRequest, rejectFollowRequest } from 'mastodon/actions/accounts';
+import {
+  authorizeFollowRequest,
+  rejectFollowRequest,
+} from 'mastodon/actions/accounts';
 
 import FollowRequestNote from '../components/follow_request_note';
 
 const mapDispatchToProps = (dispatch, { account }) => ({
-  onAuthorize () {
+  onAuthorize() {
     dispatch(authorizeFollowRequest(account.get('id')));
   },
 
-  onReject () {
+  onReject() {
     dispatch(rejectFollowRequest(account.get('id')));
   },
 });

--- a/app/javascript/mastodon/features/account/navigation.jsx
+++ b/app/javascript/mastodon/features/account/navigation.jsx
@@ -6,7 +6,14 @@ import { connect } from 'react-redux';
 import FeaturedTags from 'mastodon/features/account/containers/featured_tags_container';
 import { normalizeForLookup } from 'mastodon/reducers/accounts_map';
 
-const mapStateToProps = (state, { match: { params: { acct } } }) => {
+const mapStateToProps = (
+  state,
+  {
+    match: {
+      params: { acct },
+    },
+  },
+) => {
   const accountId = state.getIn(['accounts_map', normalizeForLookup(acct)]);
 
   if (!accountId) {
@@ -22,7 +29,6 @@ const mapStateToProps = (state, { match: { params: { acct } } }) => {
 };
 
 class AccountNavigation extends PureComponent {
-
   static propTypes = {
     match: PropTypes.shape({
       params: PropTypes.shape({
@@ -35,8 +41,14 @@ class AccountNavigation extends PureComponent {
     isLoading: PropTypes.bool,
   };
 
-  render () {
-    const { accountId, isLoading, match: { params: { tagged } } } = this.props;
+  render() {
+    const {
+      accountId,
+      isLoading,
+      match: {
+        params: { tagged },
+      },
+    } = this.props;
 
     if (isLoading) {
       return null;
@@ -49,7 +61,6 @@ class AccountNavigation extends PureComponent {
       </>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(AccountNavigation);

--- a/app/javascript/mastodon/features/account_gallery/components/media_item.jsx
+++ b/app/javascript/mastodon/features/account_gallery/components/media_item.jsx
@@ -6,11 +6,10 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 
 import { Blurhash } from 'mastodon/components/blurhash';
-import { Icon }  from 'mastodon/components/icon';
+import { Icon } from 'mastodon/components/icon';
 import { autoPlayGif, displayMedia, useBlurhash } from 'mastodon/initial_state';
 
 export default class MediaItem extends ImmutablePureComponent {
-
   static propTypes = {
     attachment: ImmutablePropTypes.map.isRequired,
     displayWidth: PropTypes.number.isRequired,
@@ -18,7 +17,10 @@ export default class MediaItem extends ImmutablePureComponent {
   };
 
   state = {
-    visible: displayMedia !== 'hide_all' && !this.props.attachment.getIn(['status', 'sensitive']) || displayMedia === 'show_all',
+    visible:
+      (displayMedia !== 'hide_all' &&
+        !this.props.attachment.getIn(['status', 'sensitive'])) ||
+      displayMedia === 'show_all',
     loaded: false,
   };
 
@@ -26,24 +28,27 @@ export default class MediaItem extends ImmutablePureComponent {
     this.setState({ loaded: true });
   };
 
-  handleMouseEnter = e => {
+  handleMouseEnter = (e) => {
     if (this.hoverToPlay()) {
       e.target.play();
     }
   };
 
-  handleMouseLeave = e => {
+  handleMouseLeave = (e) => {
     if (this.hoverToPlay()) {
       e.target.pause();
       e.target.currentTime = 0;
     }
   };
 
-  hoverToPlay () {
-    return !autoPlayGif && ['gifv', 'video'].indexOf(this.props.attachment.get('type')) !== -1;
+  hoverToPlay() {
+    return (
+      !autoPlayGif &&
+      ['gifv', 'video'].indexOf(this.props.attachment.get('type')) !== -1
+    );
   }
 
-  handleClick = e => {
+  handleClick = (e) => {
     if (e.button === 0 && !(e.ctrlKey || e.metaKey)) {
       e.preventDefault();
 
@@ -55,14 +60,14 @@ export default class MediaItem extends ImmutablePureComponent {
     }
   };
 
-  render () {
+  render() {
     const { attachment, displayWidth } = this.props;
     const { visible, loaded } = this.state;
 
-    const width  = `${Math.floor((displayWidth - 4) / 3) - 4}px`;
+    const width = `${Math.floor((displayWidth - 4) / 3) - 4}px`;
     const height = width;
     const status = attachment.get('status');
-    const title  = status.get('spoiler_text') || attachment.get('description');
+    const title = status.get('spoiler_text') || attachment.get('description');
 
     let thumbnail, label, icon, content;
 
@@ -76,7 +81,10 @@ export default class MediaItem extends ImmutablePureComponent {
       if (['audio', 'video'].includes(attachment.get('type'))) {
         content = (
           <img
-            src={attachment.get('preview_url') || status.getIn(['account', 'avatar_static'])}
+            src={
+              attachment.get('preview_url') ||
+              status.getIn(['account', 'avatar_static'])
+            }
             alt={attachment.get('description')}
             lang={status.get('language')}
             onLoad={this.handleImageLoad}
@@ -91,8 +99,8 @@ export default class MediaItem extends ImmutablePureComponent {
       } else if (attachment.get('type') === 'image') {
         const focusX = attachment.getIn(['meta', 'focus', 'x']) || 0;
         const focusY = attachment.getIn(['meta', 'focus', 'y']) || 0;
-        const x      = ((focusX /  2) + .5) * 100;
-        const y      = ((focusY / -2) + .5) * 100;
+        const x = (focusX / 2 + 0.5) * 100;
+        const y = (focusY / -2 + 0.5) * 100;
 
         content = (
           <img
@@ -139,10 +147,19 @@ export default class MediaItem extends ImmutablePureComponent {
 
     return (
       <div className='account-gallery__item' style={{ width, height }}>
-        <a className='media-gallery__item-thumbnail' href={`/@${status.getIn(['account', 'acct'])}/${status.get('id')}`} onClick={this.handleClick} title={title} target='_blank' rel='noopener noreferrer'>
+        <a
+          className='media-gallery__item-thumbnail'
+          href={`/@${status.getIn(['account', 'acct'])}/${status.get('id')}`}
+          onClick={this.handleClick}
+          title={title}
+          target='_blank'
+          rel='noopener noreferrer'
+        >
           <Blurhash
             hash={attachment.get('blurhash')}
-            className={classNames('media-gallery__preview', { 'media-gallery__preview--hidden': visible && loaded })}
+            className={classNames('media-gallery__preview', {
+              'media-gallery__preview--hidden': visible && loaded,
+            })}
             dummy={!useBlurhash}
           />
 
@@ -151,5 +168,4 @@ export default class MediaItem extends ImmutablePureComponent {
       </div>
     );
   }
-
 }

--- a/app/javascript/mastodon/features/account_gallery/index.jsx
+++ b/app/javascript/mastodon/features/account_gallery/index.jsx
@@ -23,7 +23,8 @@ import Column from '../ui/components/column';
 import MediaItem from './components/media_item';
 
 const mapStateToProps = (state, { params: { acct, id } }) => {
-  const accountId = id || state.getIn(['accounts_map', normalizeForLookup(acct)]);
+  const accountId =
+    id || state.getIn(['accounts_map', normalizeForLookup(acct)]);
 
   if (!accountId) {
     return {
@@ -35,15 +36,22 @@ const mapStateToProps = (state, { params: { acct, id } }) => {
     accountId,
     isAccount: !!state.getIn(['accounts', accountId]),
     attachments: getAccountGallery(state, accountId),
-    isLoading: state.getIn(['timelines', `account:${accountId}:media`, 'isLoading']),
-    hasMore: state.getIn(['timelines', `account:${accountId}:media`, 'hasMore']),
+    isLoading: state.getIn([
+      'timelines',
+      `account:${accountId}:media`,
+      'isLoading',
+    ]),
+    hasMore: state.getIn([
+      'timelines',
+      `account:${accountId}:media`,
+      'hasMore',
+    ]),
     suspended: state.getIn(['accounts', accountId, 'suspended'], false),
     blockedBy: state.getIn(['relationships', accountId, 'blocked_by'], false),
   };
 };
 
 class LoadMoreMedia extends ImmutablePureComponent {
-
   static propTypes = {
     maxId: PropTypes.string,
     onLoadMore: PropTypes.func.isRequired,
@@ -53,19 +61,14 @@ class LoadMoreMedia extends ImmutablePureComponent {
     this.props.onLoadMore(this.props.maxId);
   };
 
-  render () {
+  render() {
     return (
-      <LoadMore
-        disabled={this.props.disabled}
-        onClick={this.handleLoadMore}
-      />
+      <LoadMore disabled={this.props.disabled} onClick={this.handleLoadMore} />
     );
   }
-
 }
 
 class AccountGallery extends ImmutablePureComponent {
-
   static propTypes = {
     params: PropTypes.shape({
       acct: PropTypes.string,
@@ -86,15 +89,19 @@ class AccountGallery extends ImmutablePureComponent {
     width: 323,
   };
 
-  _load () {
+  _load() {
     const { accountId, isAccount, dispatch } = this.props;
 
     if (!isAccount) dispatch(fetchAccount(accountId));
     dispatch(expandAccountMediaTimeline(accountId));
   }
 
-  componentDidMount () {
-    const { params: { acct }, accountId, dispatch } = this.props;
+  componentDidMount() {
+    const {
+      params: { acct },
+      accountId,
+      dispatch,
+    } = this.props;
 
     if (accountId) {
       this._load();
@@ -103,8 +110,12 @@ class AccountGallery extends ImmutablePureComponent {
     }
   }
 
-  componentDidUpdate (prevProps) {
-    const { params: { acct }, accountId, dispatch } = this.props;
+  componentDidUpdate(prevProps) {
+    const {
+      params: { acct },
+      accountId,
+      dispatch,
+    } = this.props;
 
     if (prevProps.accountId !== accountId && accountId) {
       this._load();
@@ -115,11 +126,15 @@ class AccountGallery extends ImmutablePureComponent {
 
   handleScrollToBottom = () => {
     if (this.props.hasMore) {
-      this.handleLoadMore(this.props.attachments.size > 0 ? this.props.attachments.last().getIn(['status', 'id']) : undefined);
+      this.handleLoadMore(
+        this.props.attachments.size > 0
+          ? this.props.attachments.last().getIn(['status', 'id'])
+          : undefined,
+      );
     }
   };
 
-  handleScroll = e => {
+  handleScroll = (e) => {
     const { scrollTop, scrollHeight, clientHeight } = e.target;
     const offset = scrollHeight - scrollTop - clientHeight;
 
@@ -128,49 +143,77 @@ class AccountGallery extends ImmutablePureComponent {
     }
   };
 
-  handleLoadMore = maxId => {
-    this.props.dispatch(expandAccountMediaTimeline(this.props.accountId, { maxId }));
+  handleLoadMore = (maxId) => {
+    this.props.dispatch(
+      expandAccountMediaTimeline(this.props.accountId, { maxId }),
+    );
   };
 
-  handleLoadOlder = e => {
+  handleLoadOlder = (e) => {
     e.preventDefault();
     this.handleScrollToBottom();
   };
 
-  handleOpenMedia = attachment => {
+  handleOpenMedia = (attachment) => {
     const { dispatch } = this.props;
     const statusId = attachment.getIn(['status', 'id']);
     const lang = attachment.getIn(['status', 'language']);
 
     if (attachment.get('type') === 'video') {
-      dispatch(openModal({
-        modalType: 'VIDEO',
-        modalProps: { media: attachment, statusId, lang, options: { autoPlay: true } },
-      }));
+      dispatch(
+        openModal({
+          modalType: 'VIDEO',
+          modalProps: {
+            media: attachment,
+            statusId,
+            lang,
+            options: { autoPlay: true },
+          },
+        }),
+      );
     } else if (attachment.get('type') === 'audio') {
-      dispatch(openModal({
-        modalType: 'AUDIO',
-        modalProps: { media: attachment, statusId, lang, options: { autoPlay: true } },
-      }));
+      dispatch(
+        openModal({
+          modalType: 'AUDIO',
+          modalProps: {
+            media: attachment,
+            statusId,
+            lang,
+            options: { autoPlay: true },
+          },
+        }),
+      );
     } else {
       const media = attachment.getIn(['status', 'media_attachments']);
-      const index = media.findIndex(x => x.get('id') === attachment.get('id'));
+      const index = media.findIndex(
+        (x) => x.get('id') === attachment.get('id'),
+      );
 
-      dispatch(openModal({
-        modalType: 'MEDIA',
-        modalProps: { media, index, statusId, lang },
-      }));
+      dispatch(
+        openModal({
+          modalType: 'MEDIA',
+          modalProps: { media, index, statusId, lang },
+        }),
+      );
     }
   };
 
-  handleRef = c => {
+  handleRef = (c) => {
     if (c) {
       this.setState({ width: c.offsetWidth });
     }
   };
 
-  render () {
-    const { attachments, isLoading, hasMore, isAccount, multiColumn, blockedBy, suspended } = this.props;
+  render() {
+    const {
+      attachments,
+      isLoading,
+      hasMore,
+      isAccount,
+      multiColumn,
+      blockedBy,
+      suspended,
+    } = this.props;
     const { width } = this.state;
 
     if (!isAccount) {
@@ -190,15 +233,27 @@ class AccountGallery extends ImmutablePureComponent {
     let loadOlder = null;
 
     if (hasMore && !(isLoading && attachments.size === 0)) {
-      loadOlder = <LoadMore visible={!isLoading} onClick={this.handleLoadOlder} />;
+      loadOlder = (
+        <LoadMore visible={!isLoading} onClick={this.handleLoadOlder} />
+      );
     }
 
     let emptyMessage;
 
     if (suspended) {
-      emptyMessage = <FormattedMessage id='empty_column.account_suspended' defaultMessage='Account suspended' />;
+      emptyMessage = (
+        <FormattedMessage
+          id='empty_column.account_suspended'
+          defaultMessage='Account suspended'
+        />
+      );
     } else if (blockedBy) {
-      emptyMessage = <FormattedMessage id='empty_column.account_unavailable' defaultMessage='Profile unavailable' />;
+      emptyMessage = (
+        <FormattedMessage
+          id='empty_column.account_unavailable'
+          defaultMessage='Profile unavailable'
+        />
+      );
     }
 
     return (
@@ -206,20 +261,38 @@ class AccountGallery extends ImmutablePureComponent {
         <ColumnBackButton multiColumn={multiColumn} />
 
         <ScrollContainer scrollKey='account_gallery'>
-          <div className='scrollable scrollable--flex' onScroll={this.handleScroll}>
+          <div
+            className='scrollable scrollable--flex'
+            onScroll={this.handleScroll}
+          >
             <HeaderContainer accountId={this.props.accountId} />
 
-            {(suspended || blockedBy) ? (
-              <div className='empty-column-indicator'>
-                {emptyMessage}
-              </div>
+            {suspended || blockedBy ? (
+              <div className='empty-column-indicator'>{emptyMessage}</div>
             ) : (
-              <div role='feed' className='account-gallery__container' ref={this.handleRef}>
-                {attachments.map((attachment, index) => attachment === null ? (
-                  <LoadMoreMedia key={'more:' + attachments.getIn(index + 1, 'id')} maxId={index > 0 ? attachments.getIn(index - 1, 'id') : null} onLoadMore={this.handleLoadMore} />
-                ) : (
-                  <MediaItem key={attachment.get('id')} attachment={attachment} displayWidth={width} onOpenMedia={this.handleOpenMedia} />
-                ))}
+              <div
+                role='feed'
+                className='account-gallery__container'
+                ref={this.handleRef}
+              >
+                {attachments.map((attachment, index) =>
+                  attachment === null ? (
+                    <LoadMoreMedia
+                      key={'more:' + attachments.getIn(index + 1, 'id')}
+                      maxId={
+                        index > 0 ? attachments.getIn(index - 1, 'id') : null
+                      }
+                      onLoadMore={this.handleLoadMore}
+                    />
+                  ) : (
+                    <MediaItem
+                      key={attachment.get('id')}
+                      attachment={attachment}
+                      displayWidth={width}
+                      onOpenMedia={this.handleOpenMedia}
+                    />
+                  ),
+                )}
 
                 {loadOlder}
               </div>
@@ -235,7 +308,6 @@ class AccountGallery extends ImmutablePureComponent {
       </Column>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(AccountGallery);

--- a/app/javascript/mastodon/features/account_timeline/components/header.jsx
+++ b/app/javascript/mastodon/features/account_timeline/components/header.jsx
@@ -13,7 +13,6 @@ import MemorialNote from './memorial_note';
 import MovedNote from './moved_note';
 
 export default class Header extends ImmutablePureComponent {
-
   static propTypes = {
     account: ImmutablePropTypes.map,
     onFollow: PropTypes.func.isRequired,
@@ -112,7 +111,7 @@ export default class Header extends ImmutablePureComponent {
     this.props.onOpenAvatar(this.props.account);
   };
 
-  render () {
+  render() {
     const { account, hidden, hideTabs } = this.props;
 
     if (account === null) {
@@ -121,8 +120,10 @@ export default class Header extends ImmutablePureComponent {
 
     return (
       <div className='account-timeline__header'>
-        {(!hidden && account.get('memorial')) && <MemorialNote />}
-        {(!hidden && account.get('moved')) && <MovedNote from={account} to={account.get('moved')} />}
+        {!hidden && account.get('memorial') && <MemorialNote />}
+        {!hidden && account.get('moved') && (
+          <MovedNote from={account} to={account.get('moved')} />
+        )}
 
         <InnerHeader
           account={account}
@@ -149,13 +150,21 @@ export default class Header extends ImmutablePureComponent {
 
         {!(hideTabs || hidden) && (
           <div className='account__section-headline'>
-            <NavLink exact to={`/@${account.get('acct')}`}><FormattedMessage id='account.posts' defaultMessage='Posts' /></NavLink>
-            <NavLink exact to={`/@${account.get('acct')}/with_replies`}><FormattedMessage id='account.posts_with_replies' defaultMessage='Posts and replies' /></NavLink>
-            <NavLink exact to={`/@${account.get('acct')}/media`}><FormattedMessage id='account.media' defaultMessage='Media' /></NavLink>
+            <NavLink exact to={`/@${account.get('acct')}`}>
+              <FormattedMessage id='account.posts' defaultMessage='Posts' />
+            </NavLink>
+            <NavLink exact to={`/@${account.get('acct')}/with_replies`}>
+              <FormattedMessage
+                id='account.posts_with_replies'
+                defaultMessage='Posts and replies'
+              />
+            </NavLink>
+            <NavLink exact to={`/@${account.get('acct')}/media`}>
+              <FormattedMessage id='account.media' defaultMessage='Media' />
+            </NavLink>
           </div>
         )}
       </div>
     );
   }
-
 }

--- a/app/javascript/mastodon/features/account_timeline/components/limited_account_hint.jsx
+++ b/app/javascript/mastodon/features/account_timeline/components/limited_account_hint.jsx
@@ -10,31 +10,38 @@ import Button from 'mastodon/components/button';
 import { domain } from 'mastodon/initial_state';
 
 const mapDispatchToProps = (dispatch, { accountId }) => ({
-
-  reveal () {
+  reveal() {
     dispatch(revealAccount(accountId));
   },
-
 });
 
 class LimitedAccountHint extends PureComponent {
-
   static propTypes = {
     accountId: PropTypes.string.isRequired,
     reveal: PropTypes.func,
   };
 
-  render () {
+  render() {
     const { reveal } = this.props;
 
     return (
       <div className='limited-account-hint'>
-        <p><FormattedMessage id='limited_account_hint.title' defaultMessage='This profile has been hidden by the moderators of {domain}.' values={{ domain }} /></p>
-        <Button onClick={reveal}><FormattedMessage id='limited_account_hint.action' defaultMessage='Show profile anyway' /></Button>
+        <p>
+          <FormattedMessage
+            id='limited_account_hint.title'
+            defaultMessage='This profile has been hidden by the moderators of {domain}.'
+            values={{ domain }}
+          />
+        </p>
+        <Button onClick={reveal}>
+          <FormattedMessage
+            id='limited_account_hint.action'
+            defaultMessage='Show profile anyway'
+          />
+        </Button>
       </div>
     );
   }
-
 }
 
 export default connect(() => {}, mapDispatchToProps)(LimitedAccountHint);

--- a/app/javascript/mastodon/features/account_timeline/components/memorial_note.jsx
+++ b/app/javascript/mastodon/features/account_timeline/components/memorial_note.jsx
@@ -3,7 +3,10 @@ import { FormattedMessage } from 'react-intl';
 const MemorialNote = () => (
   <div className='account-memorial-banner'>
     <div className='account-memorial-banner__message'>
-      <FormattedMessage id='account.in_memoriam' defaultMessage='In Memoriam.' />
+      <FormattedMessage
+        id='account.in_memoriam'
+        defaultMessage='In Memoriam.'
+      />
     </div>
   </div>
 );

--- a/app/javascript/mastodon/features/account_timeline/components/moved_note.jsx
+++ b/app/javascript/mastodon/features/account_timeline/components/moved_note.jsx
@@ -9,31 +9,53 @@ import { AvatarOverlay } from '../../../components/avatar_overlay';
 import { DisplayName } from '../../../components/display_name';
 
 export default class MovedNote extends ImmutablePureComponent {
-
   static propTypes = {
     from: ImmutablePropTypes.map.isRequired,
     to: ImmutablePropTypes.map.isRequired,
   };
 
-  render () {
+  render() {
     const { from, to } = this.props;
 
     return (
       <div className='moved-account-banner'>
         <div className='moved-account-banner__message'>
-          <FormattedMessage id='account.moved_to' defaultMessage='{name} has indicated that their new account is now:' values={{ name: <bdi><strong dangerouslySetInnerHTML={{ __html: from.get('display_name_html') }} /></bdi> }} />
+          <FormattedMessage
+            id='account.moved_to'
+            defaultMessage='{name} has indicated that their new account is now:'
+            values={{
+              name: (
+                <bdi>
+                  <strong
+                    dangerouslySetInnerHTML={{
+                      __html: from.get('display_name_html'),
+                    }}
+                  />
+                </bdi>
+              ),
+            }}
+          />
         </div>
 
         <div className='moved-account-banner__action'>
-          <Link to={`/@${to.get('acct')}`} className='detailed-status__display-name'>
-            <div className='detailed-status__display-avatar'><AvatarOverlay account={to} friend={from} /></div>
+          <Link
+            to={`/@${to.get('acct')}`}
+            className='detailed-status__display-name'
+          >
+            <div className='detailed-status__display-avatar'>
+              <AvatarOverlay account={to} friend={from} />
+            </div>
             <DisplayName account={to} />
           </Link>
 
-          <Link to={`/@${to.get('acct')}`} className='button'><FormattedMessage id='account.go_to_profile' defaultMessage='Go to profile' /></Link>
+          <Link to={`/@${to.get('acct')}`} className='button'>
+            <FormattedMessage
+              id='account.go_to_profile'
+              defaultMessage='Go to profile'
+            />
+          </Link>
         </div>
       </div>
     );
   }
-
 }

--- a/app/javascript/mastodon/features/account_timeline/containers/header_container.jsx
+++ b/app/javascript/mastodon/features/account_timeline/containers/header_container.jsx
@@ -13,10 +13,7 @@ import {
   unpinAccount,
 } from '../../../actions/accounts';
 import { initBlockModal } from '../../../actions/blocks';
-import {
-  mentionCompose,
-  directCompose,
-} from '../../../actions/compose';
+import { mentionCompose, directCompose } from '../../../actions/compose';
 import { blockDomain, unblockDomain } from '../../../actions/domain_blocks';
 import { openModal } from '../../../actions/modal';
 import { initMuteModal } from '../../../actions/mutes';
@@ -26,9 +23,18 @@ import { makeGetAccount, getAccountHidden } from '../../../selectors';
 import Header from '../components/header';
 
 const messages = defineMessages({
-  cancelFollowRequestConfirm: { id: 'confirmations.cancel_follow_request.confirm', defaultMessage: 'Withdraw request' },
-  unfollowConfirm: { id: 'confirmations.unfollow.confirm', defaultMessage: 'Unfollow' },
-  blockDomainConfirm: { id: 'confirmations.domain_block.confirm', defaultMessage: 'Block entire domain' },
+  cancelFollowRequestConfirm: {
+    id: 'confirmations.cancel_follow_request.confirm',
+    defaultMessage: 'Withdraw request',
+  },
+  unfollowConfirm: {
+    id: 'confirmations.unfollow.confirm',
+    defaultMessage: 'Unfollow',
+  },
+  blockDomainConfirm: {
+    id: 'confirmations.domain_block.confirm',
+    defaultMessage: 'Block entire domain',
+  },
 });
 
 const makeMapStateToProps = () => {
@@ -44,31 +50,46 @@ const makeMapStateToProps = () => {
 };
 
 const mapDispatchToProps = (dispatch, { intl }) => ({
-
-  onFollow (account) {
+  onFollow(account) {
     if (account.getIn(['relationship', 'following'])) {
       if (unfollowModal) {
-        dispatch(openModal({
-          modalType: 'CONFIRM',
-          modalProps: {
-            message: <FormattedMessage id='confirmations.unfollow.message' defaultMessage='Are you sure you want to unfollow {name}?' values={{ name: <strong>@{account.get('acct')}</strong> }} />,
-            confirm: intl.formatMessage(messages.unfollowConfirm),
-            onConfirm: () => dispatch(unfollowAccount(account.get('id'))),
-          },
-        }));
+        dispatch(
+          openModal({
+            modalType: 'CONFIRM',
+            modalProps: {
+              message: (
+                <FormattedMessage
+                  id='confirmations.unfollow.message'
+                  defaultMessage='Are you sure you want to unfollow {name}?'
+                  values={{ name: <strong>@{account.get('acct')}</strong> }}
+                />
+              ),
+              confirm: intl.formatMessage(messages.unfollowConfirm),
+              onConfirm: () => dispatch(unfollowAccount(account.get('id'))),
+            },
+          }),
+        );
       } else {
         dispatch(unfollowAccount(account.get('id')));
       }
     } else if (account.getIn(['relationship', 'requested'])) {
       if (unfollowModal) {
-        dispatch(openModal({
-          modalType: 'CONFIRM',
-          modalProps: {
-            message: <FormattedMessage id='confirmations.cancel_follow_request.message' defaultMessage='Are you sure you want to withdraw your request to follow {name}?' values={{ name: <strong>@{account.get('acct')}</strong> }} />,
-            confirm: intl.formatMessage(messages.cancelFollowRequestConfirm),
-            onConfirm: () => dispatch(unfollowAccount(account.get('id'))),
-          },
-        }));
+        dispatch(
+          openModal({
+            modalType: 'CONFIRM',
+            modalProps: {
+              message: (
+                <FormattedMessage
+                  id='confirmations.cancel_follow_request.message'
+                  defaultMessage='Are you sure you want to withdraw your request to follow {name}?'
+                  values={{ name: <strong>@{account.get('acct')}</strong> }}
+                />
+              ),
+              confirm: intl.formatMessage(messages.cancelFollowRequestConfirm),
+              onConfirm: () => dispatch(unfollowAccount(account.get('id'))),
+            },
+          }),
+        );
       } else {
         dispatch(unfollowAccount(account.get('id')));
       }
@@ -77,18 +98,20 @@ const mapDispatchToProps = (dispatch, { intl }) => ({
     }
   },
 
-  onInteractionModal (account) {
-    dispatch(openModal({
-      modalType: 'INTERACTION',
-      modalProps: {
-        type: 'follow',
-        accountId: account.get('id'),
-        url: account.get('uri'),
-      },
-    }));
+  onInteractionModal(account) {
+    dispatch(
+      openModal({
+        modalType: 'INTERACTION',
+        modalProps: {
+          type: 'follow',
+          accountId: account.get('id'),
+          url: account.get('uri'),
+        },
+      }),
+    );
   },
 
-  onBlock (account) {
+  onBlock(account) {
     if (account.getIn(['relationship', 'blocking'])) {
       dispatch(unblockAccount(account.get('id')));
     } else {
@@ -96,15 +119,15 @@ const mapDispatchToProps = (dispatch, { intl }) => ({
     }
   },
 
-  onMention (account, router) {
+  onMention(account, router) {
     dispatch(mentionCompose(account, router));
   },
 
-  onDirect (account, router) {
+  onDirect(account, router) {
     dispatch(directCompose(account, router));
   },
 
-  onReblogToggle (account) {
+  onReblogToggle(account) {
     if (account.getIn(['relationship', 'showing_reblogs'])) {
       dispatch(followAccount(account.get('id'), { reblogs: false }));
     } else {
@@ -112,7 +135,7 @@ const mapDispatchToProps = (dispatch, { intl }) => ({
     }
   },
 
-  onEndorseToggle (account) {
+  onEndorseToggle(account) {
     if (account.getIn(['relationship', 'endorsed'])) {
       dispatch(unpinAccount(account.get('id')));
     } else {
@@ -120,7 +143,7 @@ const mapDispatchToProps = (dispatch, { intl }) => ({
     }
   },
 
-  onNotifyToggle (account) {
+  onNotifyToggle(account) {
     if (account.getIn(['relationship', 'notifying'])) {
       dispatch(followAccount(account.get('id'), { notify: false }));
     } else {
@@ -128,11 +151,11 @@ const mapDispatchToProps = (dispatch, { intl }) => ({
     }
   },
 
-  onReport (account) {
+  onReport(account) {
     dispatch(initReport(account));
   },
 
-  onMute (account) {
+  onMute(account) {
     if (account.getIn(['relationship', 'muting'])) {
       dispatch(unmuteAccount(account.get('id')));
     } else {
@@ -140,53 +163,68 @@ const mapDispatchToProps = (dispatch, { intl }) => ({
     }
   },
 
-  onBlockDomain (domain) {
-    dispatch(openModal({
-      modalType: 'CONFIRM',
-      modalProps: {
-        message: <FormattedMessage id='confirmations.domain_block.message' defaultMessage='Are you really, really sure you want to block the entire {domain}? In most cases a few targeted blocks or mutes are sufficient and preferable. You will not see content from that domain in any public timelines or your notifications. Your followers from that domain will be removed.' values={{ domain: <strong>{domain}</strong> }} />,
-        confirm: intl.formatMessage(messages.blockDomainConfirm),
-        onConfirm: () => dispatch(blockDomain(domain)),
-      },
-    }));
+  onBlockDomain(domain) {
+    dispatch(
+      openModal({
+        modalType: 'CONFIRM',
+        modalProps: {
+          message: (
+            <FormattedMessage
+              id='confirmations.domain_block.message'
+              defaultMessage='Are you really, really sure you want to block the entire {domain}? In most cases a few targeted blocks or mutes are sufficient and preferable. You will not see content from that domain in any public timelines or your notifications. Your followers from that domain will be removed.'
+              values={{ domain: <strong>{domain}</strong> }}
+            />
+          ),
+          confirm: intl.formatMessage(messages.blockDomainConfirm),
+          onConfirm: () => dispatch(blockDomain(domain)),
+        },
+      }),
+    );
   },
 
-  onUnblockDomain (domain) {
+  onUnblockDomain(domain) {
     dispatch(unblockDomain(domain));
   },
 
-  onAddToList (account) {
-    dispatch(openModal({
-      modalType: 'LIST_ADDER',
-      modalProps: {
-        accountId: account.get('id'),
-      },
-    }));
+  onAddToList(account) {
+    dispatch(
+      openModal({
+        modalType: 'LIST_ADDER',
+        modalProps: {
+          accountId: account.get('id'),
+        },
+      }),
+    );
   },
 
-  onChangeLanguages (account) {
-    dispatch(openModal({
-      modalType: 'SUBSCRIBED_LANGUAGES',
-      modalProps: {
-        accountId: account.get('id'),
-      },
-    }));
+  onChangeLanguages(account) {
+    dispatch(
+      openModal({
+        modalType: 'SUBSCRIBED_LANGUAGES',
+        modalProps: {
+          accountId: account.get('id'),
+        },
+      }),
+    );
   },
 
-  onOpenAvatar (account) {
-    dispatch(openModal({
-      modalType: 'IMAGE',
-      modalProps: {
-        src: account.get('avatar'),
-        alt: account.get('acct'),
-      },
-    }));
+  onOpenAvatar(account) {
+    dispatch(
+      openModal({
+        modalType: 'IMAGE',
+        modalProps: {
+          src: account.get('avatar'),
+          alt: account.get('acct'),
+        },
+      }),
+    );
   },
 
-  onOpenURL (url, routerHistory, onFailure) {
+  onOpenURL(url, routerHistory, onFailure) {
     dispatch(openURL(url, routerHistory, onFailure));
   },
-
 });
 
-export default injectIntl(connect(makeMapStateToProps, mapDispatchToProps)(Header));
+export default injectIntl(
+  connect(makeMapStateToProps, mapDispatchToProps)(Header),
+);

--- a/app/javascript/mastodon/features/account_timeline/index.jsx
+++ b/app/javascript/mastodon/features/account_timeline/index.jsx
@@ -15,7 +15,12 @@ import { getAccountHidden } from 'mastodon/selectors';
 
 import { lookupAccount, fetchAccount } from '../../actions/accounts';
 import { fetchFeaturedTags } from '../../actions/featured_tags';
-import { expandAccountFeaturedTimeline, expandAccountTimeline, connectTimeline, disconnectTimeline } from '../../actions/timelines';
+import {
+  expandAccountFeaturedTimeline,
+  expandAccountTimeline,
+  connectTimeline,
+  disconnectTimeline,
+} from '../../actions/timelines';
 import ColumnBackButton from '../../components/column_back_button';
 import { LoadingIndicator } from '../../components/loading_indicator';
 import StatusList from '../../components/status_list';
@@ -26,8 +31,12 @@ import HeaderContainer from './containers/header_container';
 
 const emptyList = ImmutableList();
 
-const mapStateToProps = (state, { params: { acct, id, tagged }, withReplies = false }) => {
-  const accountId = id || state.getIn(['accounts_map', normalizeForLookup(acct)]);
+const mapStateToProps = (
+  state,
+  { params: { acct, id, tagged }, withReplies = false },
+) => {
+  const accountId =
+    id || state.getIn(['accounts_map', normalizeForLookup(acct)]);
 
   if (accountId === null) {
     return {
@@ -42,15 +51,32 @@ const mapStateToProps = (state, { params: { acct, id, tagged }, withReplies = fa
     };
   }
 
-  const path = withReplies ? `${accountId}:with_replies` : `${accountId}${tagged ? `:${tagged}` : ''}`;
+  const path = withReplies
+    ? `${accountId}:with_replies`
+    : `${accountId}${tagged ? `:${tagged}` : ''}`;
 
   return {
     accountId,
-    remote: !!(state.getIn(['accounts', accountId, 'acct']) !== state.getIn(['accounts', accountId, 'username'])),
+    remote: !!(
+      state.getIn(['accounts', accountId, 'acct']) !==
+      state.getIn(['accounts', accountId, 'username'])
+    ),
     remoteUrl: state.getIn(['accounts', accountId, 'url']),
     isAccount: !!state.getIn(['accounts', accountId]),
-    statusIds: state.getIn(['timelines', `account:${path}`, 'items'], emptyList),
-    featuredStatusIds: withReplies ? ImmutableList() : state.getIn(['timelines', `account:${accountId}:pinned${tagged ? `:${tagged}` : ''}`, 'items'], emptyList),
+    statusIds: state.getIn(
+      ['timelines', `account:${path}`, 'items'],
+      emptyList,
+    ),
+    featuredStatusIds: withReplies
+      ? ImmutableList()
+      : state.getIn(
+          [
+            'timelines',
+            `account:${accountId}:pinned${tagged ? `:${tagged}` : ''}`,
+            'items',
+          ],
+          emptyList,
+        ),
     isLoading: state.getIn(['timelines', `account:${path}`, 'isLoading']),
     hasMore: state.getIn(['timelines', `account:${path}`, 'hasMore']),
     suspended: state.getIn(['accounts', accountId, 'suspended'], false),
@@ -60,7 +86,15 @@ const mapStateToProps = (state, { params: { acct, id, tagged }, withReplies = fa
 };
 
 const RemoteHint = ({ url }) => (
-  <TimelineHint url={url} resource={<FormattedMessage id='timeline_hint.resources.statuses' defaultMessage='Older posts' />} />
+  <TimelineHint
+    url={url}
+    resource={
+      <FormattedMessage
+        id='timeline_hint.resources.statuses'
+        defaultMessage='Older posts'
+      />
+    }
+  />
 );
 
 RemoteHint.propTypes = {
@@ -68,7 +102,6 @@ RemoteHint.propTypes = {
 };
 
 class AccountTimeline extends ImmutablePureComponent {
-
   static propTypes = {
     params: PropTypes.shape({
       acct: PropTypes.string,
@@ -91,8 +124,13 @@ class AccountTimeline extends ImmutablePureComponent {
     multiColumn: PropTypes.bool,
   };
 
-  _load () {
-    const { accountId, withReplies, params: { tagged }, dispatch } = this.props;
+  _load() {
+    const {
+      accountId,
+      withReplies,
+      params: { tagged },
+      dispatch,
+    } = this.props;
 
     dispatch(fetchAccount(accountId));
 
@@ -108,8 +146,12 @@ class AccountTimeline extends ImmutablePureComponent {
     }
   }
 
-  componentDidMount () {
-    const { params: { acct }, accountId, dispatch } = this.props;
+  componentDidMount() {
+    const {
+      params: { acct },
+      accountId,
+      dispatch,
+    } = this.props;
 
     if (accountId) {
       this._load();
@@ -118,8 +160,13 @@ class AccountTimeline extends ImmutablePureComponent {
     }
   }
 
-  componentDidUpdate (prevProps) {
-    const { params: { acct, tagged }, accountId, withReplies, dispatch } = this.props;
+  componentDidUpdate(prevProps) {
+    const {
+      params: { acct, tagged },
+      accountId,
+      withReplies,
+      dispatch,
+    } = this.props;
 
     if (prevProps.accountId !== accountId && accountId) {
       this._load();
@@ -137,7 +184,7 @@ class AccountTimeline extends ImmutablePureComponent {
     }
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     const { dispatch, accountId } = this.props;
 
     if (accountId === me) {
@@ -145,12 +192,31 @@ class AccountTimeline extends ImmutablePureComponent {
     }
   }
 
-  handleLoadMore = maxId => {
-    this.props.dispatch(expandAccountTimeline(this.props.accountId, { maxId, withReplies: this.props.withReplies, tagged: this.props.params.tagged }));
+  handleLoadMore = (maxId) => {
+    this.props.dispatch(
+      expandAccountTimeline(this.props.accountId, {
+        maxId,
+        withReplies: this.props.withReplies,
+        tagged: this.props.params.tagged,
+      }),
+    );
   };
 
-  render () {
-    const { accountId, statusIds, featuredStatusIds, isLoading, hasMore, blockedBy, suspended, isAccount, hidden, multiColumn, remote, remoteUrl } = this.props;
+  render() {
+    const {
+      accountId,
+      statusIds,
+      featuredStatusIds,
+      isLoading,
+      hasMore,
+      blockedBy,
+      suspended,
+      isAccount,
+      hidden,
+      multiColumn,
+      remote,
+      remoteUrl,
+    } = this.props;
 
     if (isLoading && statusIds.isEmpty()) {
       return (
@@ -169,15 +235,30 @@ class AccountTimeline extends ImmutablePureComponent {
     const forceEmptyState = suspended || blockedBy || hidden;
 
     if (suspended) {
-      emptyMessage = <FormattedMessage id='empty_column.account_suspended' defaultMessage='Account suspended' />;
+      emptyMessage = (
+        <FormattedMessage
+          id='empty_column.account_suspended'
+          defaultMessage='Account suspended'
+        />
+      );
     } else if (hidden) {
       emptyMessage = <LimitedAccountHint accountId={accountId} />;
     } else if (blockedBy) {
-      emptyMessage = <FormattedMessage id='empty_column.account_unavailable' defaultMessage='Profile unavailable' />;
+      emptyMessage = (
+        <FormattedMessage
+          id='empty_column.account_unavailable'
+          defaultMessage='Profile unavailable'
+        />
+      );
     } else if (remote && statusIds.isEmpty()) {
       emptyMessage = <RemoteHint url={remoteUrl} />;
     } else {
-      emptyMessage = <FormattedMessage id='empty_column.account_timeline' defaultMessage='No posts found' />;
+      emptyMessage = (
+        <FormattedMessage
+          id='empty_column.account_timeline'
+          defaultMessage='No posts found'
+        />
+      );
     }
 
     const remoteMessage = remote ? <RemoteHint url={remoteUrl} /> : null;
@@ -187,7 +268,13 @@ class AccountTimeline extends ImmutablePureComponent {
         <ColumnBackButton multiColumn={multiColumn} />
 
         <StatusList
-          prepend={<HeaderContainer accountId={this.props.accountId} hideTabs={forceEmptyState} tagged={this.props.params.tagged} />}
+          prepend={
+            <HeaderContainer
+              accountId={this.props.accountId}
+              hideTabs={forceEmptyState}
+              tagged={this.props.params.tagged}
+            />
+          }
           alwaysPrepend
           append={remoteMessage}
           scrollKey='account_timeline'
@@ -203,7 +290,6 @@ class AccountTimeline extends ImmutablePureComponent {
       </Column>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(AccountTimeline);

--- a/app/javascript/mastodon/features/audio/index.jsx
+++ b/app/javascript/mastodon/features/audio/index.jsx
@@ -9,8 +9,12 @@ import { is } from 'immutable';
 
 import { throttle, debounce } from 'lodash';
 
-import { Icon }  from 'mastodon/components/icon';
-import { formatTime, getPointerPosition, fileNameFromURL } from 'mastodon/features/video';
+import { Icon } from 'mastodon/components/icon';
+import {
+  formatTime,
+  getPointerPosition,
+  fileNameFromURL,
+} from 'mastodon/features/video';
 
 import { Blurhash } from '../../components/blurhash';
 import { displayMedia, useBlurhash } from '../../initial_state';
@@ -27,10 +31,9 @@ const messages = defineMessages({
 });
 
 const TICK_SIZE = 10;
-const PADDING   = 180;
+const PADDING = 180;
 
 class Audio extends PureComponent {
-
   static propTypes = {
     src: PropTypes.string.isRequired,
     alt: PropTypes.string,
@@ -66,15 +69,19 @@ class Audio extends PureComponent {
     muted: false,
     volume: 1,
     dragging: false,
-    revealed: this.props.visible !== undefined ? this.props.visible : (displayMedia !== 'hide_all' && !this.props.sensitive || displayMedia === 'show_all'),
+    revealed:
+      this.props.visible !== undefined
+        ? this.props.visible
+        : (displayMedia !== 'hide_all' && !this.props.sensitive) ||
+          displayMedia === 'show_all',
   };
 
-  constructor (props) {
+  constructor(props) {
     super(props);
     this.visualizer = new Visualizer(TICK_SIZE);
   }
 
-  setPlayerRef = c => {
+  setPlayerRef = (c) => {
     this.player = c;
 
     if (this.player) {
@@ -97,9 +104,11 @@ class Audio extends PureComponent {
     };
   }
 
-  _setDimensions () {
-    const width  = this.player.offsetWidth;
-    const height = this.props.fullscreen ? this.player.offsetHeight : (width / (16/9));
+  _setDimensions() {
+    const width = this.player.offsetWidth;
+    const height = this.props.fullscreen
+      ? this.player.offsetHeight
+      : width / (16 / 9);
 
     if (this.props.cacheWidth) {
       this.props.cacheWidth(width);
@@ -108,15 +117,15 @@ class Audio extends PureComponent {
     this.setState({ width, height });
   }
 
-  setSeekRef = c => {
+  setSeekRef = (c) => {
     this.seek = c;
   };
 
-  setVolumeRef = c => {
+  setVolumeRef = (c) => {
     this.volume = c;
   };
 
-  setAudioRef = c => {
+  setAudioRef = (c) => {
     this.audio = c;
 
     if (this.audio) {
@@ -125,31 +134,39 @@ class Audio extends PureComponent {
     }
   };
 
-  setCanvasRef = c => {
+  setCanvasRef = (c) => {
     this.canvas = c;
 
     this.visualizer.setCanvas(c);
   };
 
-  componentDidMount () {
+  componentDidMount() {
     window.addEventListener('scroll', this.handleScroll);
     window.addEventListener('resize', this.handleResize, { passive: true });
   }
 
-  componentDidUpdate (prevProps, prevState) {
-    if (prevProps.src !== this.props.src || this.state.width !== prevState.width || this.state.height !== prevState.height || prevProps.accentColor !== this.props.accentColor) {
+  componentDidUpdate(prevProps, prevState) {
+    if (
+      prevProps.src !== this.props.src ||
+      this.state.width !== prevState.width ||
+      this.state.height !== prevState.height ||
+      prevProps.accentColor !== this.props.accentColor
+    ) {
       this._clear();
       this._draw();
     }
   }
 
-  UNSAFE_componentWillReceiveProps (nextProps) {
-    if (!is(nextProps.visible, this.props.visible) && nextProps.visible !== undefined) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    if (
+      !is(nextProps.visible, this.props.visible) &&
+      nextProps.visible !== undefined
+    ) {
       this.setState({ revealed: nextProps.visible });
     }
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     window.removeEventListener('scroll', this.handleScroll);
     window.removeEventListener('resize', this.handleResize);
 
@@ -170,13 +187,17 @@ class Audio extends PureComponent {
     }
   };
 
-  handleResize = debounce(() => {
-    if (this.player) {
-      this._setDimensions();
-    }
-  }, 250, {
-    trailing: true,
-  });
+  handleResize = debounce(
+    () => {
+      if (this.player) {
+        this._setDimensions();
+      }
+    },
+    250,
+    {
+      trailing: true,
+    },
+  );
 
   handlePlay = () => {
     this.setState({ paused: false });
@@ -200,18 +221,25 @@ class Audio extends PureComponent {
     const lastTimeRange = this.audio.buffered.length - 1;
 
     if (lastTimeRange > -1) {
-      this.setState({ buffer: Math.ceil(this.audio.buffered.end(lastTimeRange) / this.audio.duration * 100) });
+      this.setState({
+        buffer: Math.ceil(
+          (this.audio.buffered.end(lastTimeRange) / this.audio.duration) * 100,
+        ),
+      });
     }
   };
 
   toggleMute = () => {
     const muted = !(this.state.muted || this.state.volume === 0);
 
-    this.setState((state) => ({ muted, volume: Math.max(state.volume || 0.5, 0.05) }), () => {
-      if (this.gainNode) {
-        this.gainNode.gain.value = this.state.muted ? 0 : this.state.volume;
-      }
-    });
+    this.setState(
+      (state) => ({ muted, volume: Math.max(state.volume || 0.5, 0.05) }),
+      () => {
+        if (this.gainNode) {
+          this.gainNode.gain.value = this.state.muted ? 0 : this.state.volume;
+        }
+      },
+    );
   };
 
   toggleReveal = () => {
@@ -222,7 +250,7 @@ class Audio extends PureComponent {
     }
   };
 
-  handleVolumeMouseDown = e => {
+  handleVolumeMouseDown = (e) => {
     document.addEventListener('mousemove', this.handleMouseVolSlide, true);
     document.addEventListener('mouseup', this.handleVolumeMouseUp, true);
     document.addEventListener('touchmove', this.handleMouseVolSlide, true);
@@ -241,7 +269,7 @@ class Audio extends PureComponent {
     document.removeEventListener('touchend', this.handleVolumeMouseUp, true);
   };
 
-  handleMouseDown = e => {
+  handleMouseDown = (e) => {
     document.addEventListener('mousemove', this.handleMouseMove, true);
     document.addEventListener('mouseup', this.handleMouseUp, true);
     document.addEventListener('touchmove', this.handleMouseMove, true);
@@ -265,7 +293,7 @@ class Audio extends PureComponent {
     this.audio.play();
   };
 
-  handleMouseMove = throttle(e => {
+  handleMouseMove = throttle((e) => {
     const { x } = getPointerPosition(this.seek, e);
     const currentTime = this.audio.duration * x;
 
@@ -283,36 +311,45 @@ class Audio extends PureComponent {
     });
   };
 
-  handleMouseVolSlide = throttle(e => {
+  handleMouseVolSlide = throttle((e) => {
     const { x } = getPointerPosition(this.volume, e);
 
-    if(!isNaN(x)) {
-      this.setState((state) => ({ volume: x, muted: state.muted && x === 0 }), () => {
-        if (this.gainNode) {
-          this.gainNode.gain.value = this.state.muted ? 0 : x;
-        }
-      });
+    if (!isNaN(x)) {
+      this.setState(
+        (state) => ({ volume: x, muted: state.muted && x === 0 }),
+        () => {
+          if (this.gainNode) {
+            this.gainNode.gain.value = this.state.muted ? 0 : x;
+          }
+        },
+      );
     }
   }, 15);
 
-  handleScroll = throttle(() => {
-    if (!this.canvas || !this.audio) {
-      return;
-    }
-
-    const { top, height } = this.canvas.getBoundingClientRect();
-    const inView = (top <= (window.innerHeight || document.documentElement.clientHeight)) && (top + height >= 0);
-
-    if (!this.state.paused && !inView) {
-      this.audio.pause();
-
-      if (this.props.deployPictureInPicture) {
-        this.props.deployPictureInPicture('audio', this._pack());
+  handleScroll = throttle(
+    () => {
+      if (!this.canvas || !this.audio) {
+        return;
       }
 
-      this.setState({ paused: true });
-    }
-  }, 150, { trailing: true });
+      const { top, height } = this.canvas.getBoundingClientRect();
+      const inView =
+        top <= (window.innerHeight || document.documentElement.clientHeight) &&
+        top + height >= 0;
+
+      if (!this.state.paused && !inView) {
+        this.audio.pause();
+
+        if (this.props.deployPictureInPicture) {
+          this.props.deployPictureInPicture('audio', this._pack());
+        }
+
+        this.setState({ paused: true });
+      }
+    },
+    150,
+    { trailing: true },
+  );
 
   handleMouseEnter = () => {
     this.setState({ hovered: true });
@@ -334,11 +371,11 @@ class Audio extends PureComponent {
     }
   };
 
-  _initAudioContext () {
+  _initAudioContext() {
     const AudioContext = window.AudioContext || window.webkitAudioContext;
-    const context      = new AudioContext();
-    const source       = context.createMediaElementSource(this.audio);
-    const gainNode     = context.createGain();
+    const context = new AudioContext();
+    const source = context.createMediaElementSource(this.audio);
+    const gainNode = context.createGain();
 
     gainNode.gain.value = this.state.muted ? 0 : this.state.volume;
 
@@ -351,24 +388,27 @@ class Audio extends PureComponent {
   }
 
   handleDownload = () => {
-    fetch(this.props.src).then(res => res.blob()).then(blob => {
-      const element   = document.createElement('a');
-      const objectURL = URL.createObjectURL(blob);
+    fetch(this.props.src)
+      .then((res) => res.blob())
+      .then((blob) => {
+        const element = document.createElement('a');
+        const objectURL = URL.createObjectURL(blob);
 
-      element.setAttribute('href', objectURL);
-      element.setAttribute('download', fileNameFromURL(this.props.src));
+        element.setAttribute('href', objectURL);
+        element.setAttribute('download', fileNameFromURL(this.props.src));
 
-      document.body.appendChild(element);
-      element.click();
-      document.body.removeChild(element);
+        document.body.appendChild(element);
+        element.click();
+        document.body.removeChild(element);
 
-      URL.revokeObjectURL(objectURL);
-    }).catch(err => {
-      console.error(err);
-    });
+        URL.revokeObjectURL(objectURL);
+      })
+      .catch((err) => {
+        console.error(err);
+      });
   };
 
-  _renderCanvas () {
+  _renderCanvas() {
     requestAnimationFrame(() => {
       if (!this.audio) return;
 
@@ -387,14 +427,23 @@ class Audio extends PureComponent {
   }
 
   _draw() {
-    this.visualizer.draw(this._getCX(), this._getCY(), this._getAccentColor(), this._getRadius(), this._getScaleCoefficient());
+    this.visualizer.draw(
+      this._getCX(),
+      this._getCY(),
+      this._getAccentColor(),
+      this._getRadius(),
+      this._getScaleCoefficient(),
+    );
   }
 
-  _getRadius () {
-    return parseInt((this.state.height || this.props.height) / 2 - PADDING * this._getScaleCoefficient());
+  _getRadius() {
+    return parseInt(
+      (this.state.height || this.props.height) / 2 -
+        PADDING * this._getScaleCoefficient(),
+    );
   }
 
-  _getScaleCoefficient () {
+  _getScaleCoefficient() {
     return (this.state.height || this.props.height) / 982;
   }
 
@@ -406,19 +455,19 @@ class Audio extends PureComponent {
     return Math.floor((this.state.height || this.props.height) / 2);
   }
 
-  _getAccentColor () {
+  _getAccentColor() {
     return this.props.accentColor || '#ffffff';
   }
 
-  _getBackgroundColor () {
+  _getBackgroundColor() {
     return this.props.backgroundColor || '#000000';
   }
 
-  _getForegroundColor () {
+  _getForegroundColor() {
     return this.props.foregroundColor || '#ffffff';
   }
 
-  seekBy (time) {
+  seekBy(time) {
     const currentTime = this.audio.currentTime + time;
 
     if (!isNaN(currentTime)) {
@@ -428,7 +477,7 @@ class Audio extends PureComponent {
     }
   }
 
-  handleAudioKeyDown = e => {
+  handleAudioKeyDown = (e) => {
     // On the audio element or the seek bar, we can safely use the space bar
     // for playback control because there are no buttons to press
 
@@ -439,48 +488,81 @@ class Audio extends PureComponent {
     }
   };
 
-  handleKeyDown = e => {
-    switch(e.key) {
-    case 'k':
-      e.preventDefault();
-      e.stopPropagation();
-      this.togglePlay();
-      break;
-    case 'm':
-      e.preventDefault();
-      e.stopPropagation();
-      this.toggleMute();
-      break;
-    case 'j':
-      e.preventDefault();
-      e.stopPropagation();
-      this.seekBy(-10);
-      break;
-    case 'l':
-      e.preventDefault();
-      e.stopPropagation();
-      this.seekBy(10);
-      break;
+  handleKeyDown = (e) => {
+    switch (e.key) {
+      case 'k':
+        e.preventDefault();
+        e.stopPropagation();
+        this.togglePlay();
+        break;
+      case 'm':
+        e.preventDefault();
+        e.stopPropagation();
+        this.toggleMute();
+        break;
+      case 'j':
+        e.preventDefault();
+        e.stopPropagation();
+        this.seekBy(-10);
+        break;
+      case 'l':
+        e.preventDefault();
+        e.stopPropagation();
+        this.seekBy(10);
+        break;
     }
   };
 
-  render () {
-    const { src, intl, alt, lang, editable, autoPlay, sensitive, blurhash } = this.props;
-    const { paused, volume, currentTime, duration, buffer, dragging, revealed } = this.state;
+  render() {
+    const { src, intl, alt, lang, editable, autoPlay, sensitive, blurhash } =
+      this.props;
+    const {
+      paused,
+      volume,
+      currentTime,
+      duration,
+      buffer,
+      dragging,
+      revealed,
+    } = this.state;
     const progress = Math.min((currentTime / duration) * 100, 100);
     const muted = this.state.muted || volume === 0;
 
     let warning;
 
     if (sensitive) {
-      warning = <FormattedMessage id='status.sensitive_warning' defaultMessage='Sensitive content' />;
+      warning = (
+        <FormattedMessage
+          id='status.sensitive_warning'
+          defaultMessage='Sensitive content'
+        />
+      );
     } else {
-      warning = <FormattedMessage id='status.media_hidden' defaultMessage='Media hidden' />;
+      warning = (
+        <FormattedMessage
+          id='status.media_hidden'
+          defaultMessage='Media hidden'
+        />
+      );
     }
 
     return (
-      <div className={classNames('audio-player', { editable, inactive: !revealed })} ref={this.setPlayerRef} style={{ backgroundColor: this._getBackgroundColor(), color: this._getForegroundColor(), aspectRatio: '16 / 9' }} onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave} tabIndex={0} onKeyDown={this.handleKeyDown}>
-
+      <div
+        className={classNames('audio-player', {
+          editable,
+          inactive: !revealed,
+        })}
+        ref={this.setPlayerRef}
+        style={{
+          backgroundColor: this._getBackgroundColor(),
+          color: this._getForegroundColor(),
+          aspectRatio: '16 / 9',
+        }}
+        onMouseEnter={this.handleMouseEnter}
+        onMouseLeave={this.handleMouseLeave}
+        tabIndex={0}
+        onKeyDown={this.handleKeyDown}
+      >
         <Blurhash
           hash={blurhash}
           className={classNames('media-gallery__preview', {
@@ -489,16 +571,18 @@ class Audio extends PureComponent {
           dummy={!useBlurhash}
         />
 
-        {(revealed || editable) && <audio
-          src={src}
-          ref={this.setAudioRef}
-          preload={autoPlay ? 'auto' : 'none'}
-          onPlay={this.handlePlay}
-          onPause={this.handlePause}
-          onProgress={this.handleProgress}
-          onLoadedData={this.handleLoadedData}
-          crossOrigin='anonymous'
-        />}
+        {(revealed || editable) && (
+          <audio
+            src={src}
+            ref={this.setAudioRef}
+            preload={autoPlay ? 'auto' : 'none'}
+            onPlay={this.handlePlay}
+            onPause={this.handlePause}
+            onProgress={this.handleProgress}
+            onLoadedData={this.handleLoadedData}
+            crossOrigin='anonymous'
+          />
+        )}
 
         <canvas
           role='button'
@@ -515,38 +599,73 @@ class Audio extends PureComponent {
           lang={lang}
         />
 
-        <div className={classNames('spoiler-button', { 'spoiler-button--hidden': revealed || editable })}>
-          <button type='button' className='spoiler-button__overlay' onClick={this.toggleReveal}>
+        <div
+          className={classNames('spoiler-button', {
+            'spoiler-button--hidden': revealed || editable,
+          })}
+        >
+          <button
+            type='button'
+            className='spoiler-button__overlay'
+            onClick={this.toggleReveal}
+          >
             <span className='spoiler-button__overlay__label'>
               {warning}
-              <span className='spoiler-button__overlay__action'><FormattedMessage id='status.media.show' defaultMessage='Click to show' /></span>
+              <span className='spoiler-button__overlay__action'>
+                <FormattedMessage
+                  id='status.media.show'
+                  defaultMessage='Click to show'
+                />
+              </span>
             </span>
           </button>
         </div>
 
-        {(revealed || editable) && <img
-          src={this.props.poster}
-          alt=''
-          style={{
-            position: 'absolute',
-            left: '50%',
-            top: '50%',
-            height: `calc(${(100 - 2 * 100 * PADDING / 982)}% - ${TICK_SIZE * 2}px)`,
-            aspectRatio: '1',
-            transform: 'translate(-50%, -50%)',
-            borderRadius: '50%',
-            pointerEvents: 'none',
-          }}
-        />}
+        {(revealed || editable) && (
+          <img
+            src={this.props.poster}
+            alt=''
+            style={{
+              position: 'absolute',
+              left: '50%',
+              top: '50%',
+              height: `calc(${100 - (2 * 100 * PADDING) / 982}% - ${
+                TICK_SIZE * 2
+              }px)`,
+              aspectRatio: '1',
+              transform: 'translate(-50%, -50%)',
+              borderRadius: '50%',
+              pointerEvents: 'none',
+            }}
+          />
+        )}
 
-        <div className='video-player__seek' onMouseDown={this.handleMouseDown} ref={this.setSeekRef}>
-          <div className='video-player__seek__buffer' style={{ width: `${buffer}%` }} />
-          <div className='video-player__seek__progress' style={{ width: `${progress}%`, backgroundColor: this._getAccentColor() }} />
+        <div
+          className='video-player__seek'
+          onMouseDown={this.handleMouseDown}
+          ref={this.setSeekRef}
+        >
+          <div
+            className='video-player__seek__buffer'
+            style={{ width: `${buffer}%` }}
+          />
+          <div
+            className='video-player__seek__progress'
+            style={{
+              width: `${progress}%`,
+              backgroundColor: this._getAccentColor(),
+            }}
+          />
 
           <span
-            className={classNames('video-player__seek__handle', { active: dragging })}
+            className={classNames('video-player__seek__handle', {
+              active: dragging,
+            })}
             tabIndex={0}
-            style={{ left: `${progress}%`, backgroundColor: this._getAccentColor() }}
+            style={{
+              left: `${progress}%`,
+              backgroundColor: this._getAccentColor(),
+            }}
             onKeyDown={this.handleAudioKeyDown}
           />
         </div>
@@ -554,29 +673,90 @@ class Audio extends PureComponent {
         <div className='video-player__controls active'>
           <div className='video-player__buttons-bar'>
             <div className='video-player__buttons left'>
-              <button type='button' title={intl.formatMessage(paused ? messages.play : messages.pause)} aria-label={intl.formatMessage(paused ? messages.play : messages.pause)} className='player-button' onClick={this.togglePlay}><Icon id={paused ? 'play' : 'pause'} fixedWidth /></button>
-              <button type='button' title={intl.formatMessage(muted ? messages.unmute : messages.mute)} aria-label={intl.formatMessage(muted ? messages.unmute : messages.mute)} className='player-button' onClick={this.toggleMute}><Icon id={muted ? 'volume-off' : 'volume-up'} fixedWidth /></button>
+              <button
+                type='button'
+                title={intl.formatMessage(
+                  paused ? messages.play : messages.pause,
+                )}
+                aria-label={intl.formatMessage(
+                  paused ? messages.play : messages.pause,
+                )}
+                className='player-button'
+                onClick={this.togglePlay}
+              >
+                <Icon id={paused ? 'play' : 'pause'} fixedWidth />
+              </button>
+              <button
+                type='button'
+                title={intl.formatMessage(
+                  muted ? messages.unmute : messages.mute,
+                )}
+                aria-label={intl.formatMessage(
+                  muted ? messages.unmute : messages.mute,
+                )}
+                className='player-button'
+                onClick={this.toggleMute}
+              >
+                <Icon id={muted ? 'volume-off' : 'volume-up'} fixedWidth />
+              </button>
 
-              <div className={classNames('video-player__volume', { active: this.state.hovered })} ref={this.setVolumeRef} onMouseDown={this.handleVolumeMouseDown}>
-                <div className='video-player__volume__current' style={{ width: `${muted ? 0 : volume * 100}%`, backgroundColor: this._getAccentColor() }} />
+              <div
+                className={classNames('video-player__volume', {
+                  active: this.state.hovered,
+                })}
+                ref={this.setVolumeRef}
+                onMouseDown={this.handleVolumeMouseDown}
+              >
+                <div
+                  className='video-player__volume__current'
+                  style={{
+                    width: `${muted ? 0 : volume * 100}%`,
+                    backgroundColor: this._getAccentColor(),
+                  }}
+                />
 
                 <span
                   className='video-player__volume__handle'
                   tabIndex={0}
-                  style={{ left: `${muted ? 0 : volume * 100}%`, backgroundColor: this._getAccentColor() }}
+                  style={{
+                    left: `${muted ? 0 : volume * 100}%`,
+                    backgroundColor: this._getAccentColor(),
+                  }}
                 />
               </div>
 
               <span className='video-player__time'>
-                <span className='video-player__time-current'>{formatTime(Math.floor(currentTime))}</span>
+                <span className='video-player__time-current'>
+                  {formatTime(Math.floor(currentTime))}
+                </span>
                 <span className='video-player__time-sep'>/</span>
-                <span className='video-player__time-total'>{formatTime(Math.floor(this.state.duration || this.props.duration))}</span>
+                <span className='video-player__time-total'>
+                  {formatTime(
+                    Math.floor(this.state.duration || this.props.duration),
+                  )}
+                </span>
               </span>
             </div>
 
             <div className='video-player__buttons right'>
-              {!editable && <button type='button' title={intl.formatMessage(messages.hide)} aria-label={intl.formatMessage(messages.hide)} className='player-button' onClick={this.toggleReveal}><Icon id='eye-slash' fixedWidth /></button>}
-              <a title={intl.formatMessage(messages.download)} aria-label={intl.formatMessage(messages.download)} className='video-player__download__icon player-button' href={this.props.src} download>
+              {!editable && (
+                <button
+                  type='button'
+                  title={intl.formatMessage(messages.hide)}
+                  aria-label={intl.formatMessage(messages.hide)}
+                  className='player-button'
+                  onClick={this.toggleReveal}
+                >
+                  <Icon id='eye-slash' fixedWidth />
+                </button>
+              )}
+              <a
+                title={intl.formatMessage(messages.download)}
+                aria-label={intl.formatMessage(messages.download)}
+                className='video-player__download__icon player-button'
+                href={this.props.src}
+                download
+              >
                 <Icon id={'download'} fixedWidth />
               </a>
             </div>
@@ -585,7 +765,6 @@ class Audio extends PureComponent {
       </div>
     );
   }
-
 }
 
 export default injectIntl(Audio);

--- a/app/javascript/mastodon/features/audio/visualizer.js
+++ b/app/javascript/mastodon/features/audio/visualizer.js
@@ -9,13 +9,12 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 */
 
 const hex2rgba = (hex, alpha = 1) => {
-  const [r, g, b] = hex.match(/\w\w/g).map(x => parseInt(x, 16));
+  const [r, g, b] = hex.match(/\w\w/g).map((x) => parseInt(x, 16));
   return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 };
 
 export default class Visualizer {
-
-  constructor (tickSize) {
+  constructor(tickSize) {
     this.tickSize = tickSize;
   }
 
@@ -37,18 +36,18 @@ export default class Visualizer {
     this.analyser = analyser;
   }
 
-  getTickPoints (count) {
+  getTickPoints(count) {
     const coords = [];
 
-    for(let i = 0; i < count; i++) {
-      const rad = Math.PI * 2 * i / count;
+    for (let i = 0; i < count; i++) {
+      const rad = (Math.PI * 2 * i) / count;
       coords.push({ x: Math.cos(rad), y: -Math.sin(rad) });
     }
 
     return coords;
   }
 
-  drawTick (cx, cy, mainColor, x1, y1, x2, y2) {
+  drawTick(cx, cy, mainColor, x1, y1, x2, y2) {
     const dx1 = Math.ceil(cx + x1);
     const dy1 = Math.ceil(cy + y1);
     const dx2 = Math.ceil(cx + x2);
@@ -70,7 +69,7 @@ export default class Visualizer {
     this.context.stroke();
   }
 
-  getTicks (count, size, radius, scaleCoefficient) {
+  getTicks(count, size, radius, scaleCoefficient) {
     const ticks = this.getTickPoints(count);
     const lesser = 200;
     const m = [];
@@ -117,20 +116,24 @@ export default class Visualizer {
     }));
   }
 
-  clear (width, height) {
+  clear(width, height) {
     this.context.clearRect(0, 0, width, height);
   }
 
-  draw (cx, cy, color, radius, coefficient) {
+  draw(cx, cy, color, radius, coefficient) {
     this.context.save();
 
-    const ticks = this.getTicks(parseInt(360 * coefficient), this.tickSize, radius, coefficient);
+    const ticks = this.getTicks(
+      parseInt(360 * coefficient),
+      this.tickSize,
+      radius,
+      coefficient,
+    );
 
-    ticks.forEach(tick => {
+    ticks.forEach((tick) => {
       this.drawTick(cx, cy, color, tick.x1, tick.y1, tick.x2, tick.y2);
     });
 
     this.context.restore();
   }
-
 }

--- a/app/javascript/mastodon/features/blocks/index.jsx
+++ b/app/javascript/mastodon/features/blocks/index.jsx
@@ -19,14 +19,13 @@ const messages = defineMessages({
   heading: { id: 'column.blocks', defaultMessage: 'Blocked users' },
 });
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   accountIds: state.getIn(['user_lists', 'blocks', 'items']),
   hasMore: !!state.getIn(['user_lists', 'blocks', 'next']),
   isLoading: state.getIn(['user_lists', 'blocks', 'isLoading'], true),
 });
 
 class Blocks extends ImmutablePureComponent {
-
   static propTypes = {
     params: PropTypes.object.isRequired,
     dispatch: PropTypes.func.isRequired,
@@ -37,15 +36,19 @@ class Blocks extends ImmutablePureComponent {
     multiColumn: PropTypes.bool,
   };
 
-  UNSAFE_componentWillMount () {
+  UNSAFE_componentWillMount() {
     this.props.dispatch(fetchBlocks());
   }
 
-  handleLoadMore = debounce(() => {
-    this.props.dispatch(expandBlocks());
-  }, 300, { leading: true });
+  handleLoadMore = debounce(
+    () => {
+      this.props.dispatch(expandBlocks());
+    },
+    300,
+    { leading: true },
+  );
 
-  render () {
+  render() {
     const { intl, accountIds, hasMore, multiColumn, isLoading } = this.props;
 
     if (!accountIds) {
@@ -56,10 +59,19 @@ class Blocks extends ImmutablePureComponent {
       );
     }
 
-    const emptyMessage = <FormattedMessage id='empty_column.blocks' defaultMessage="You haven't blocked any users yet." />;
+    const emptyMessage = (
+      <FormattedMessage
+        id='empty_column.blocks'
+        defaultMessage="You haven't blocked any users yet."
+      />
+    );
 
     return (
-      <Column bindToDocument={!multiColumn} icon='ban' heading={intl.formatMessage(messages.heading)}>
+      <Column
+        bindToDocument={!multiColumn}
+        icon='ban'
+        heading={intl.formatMessage(messages.heading)}
+      >
         <ColumnBackButtonSlim />
         <ScrollableList
           scrollKey='blocks'
@@ -69,14 +81,13 @@ class Blocks extends ImmutablePureComponent {
           emptyMessage={emptyMessage}
           bindToDocument={!multiColumn}
         >
-          {accountIds.map(id =>
-            <AccountContainer key={id} id={id} defaultAction='block' />,
-          )}
+          {accountIds.map((id) => (
+            <AccountContainer key={id} id={id} defaultAction='block' />
+          ))}
         </ScrollableList>
       </Column>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(injectIntl(Blocks));

--- a/app/javascript/mastodon/features/bookmarked_statuses/index.jsx
+++ b/app/javascript/mastodon/features/bookmarked_statuses/index.jsx
@@ -10,7 +10,10 @@ import { connect } from 'react-redux';
 
 import { debounce } from 'lodash';
 
-import { fetchBookmarkedStatuses, expandBookmarkedStatuses } from 'mastodon/actions/bookmarks';
+import {
+  fetchBookmarkedStatuses,
+  expandBookmarkedStatuses,
+} from 'mastodon/actions/bookmarks';
 import { addColumn, removeColumn, moveColumn } from 'mastodon/actions/columns';
 import ColumnHeader from 'mastodon/components/column_header';
 import StatusList from 'mastodon/components/status_list';
@@ -21,14 +24,13 @@ const messages = defineMessages({
   heading: { id: 'column.bookmarks', defaultMessage: 'Bookmarks' },
 });
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   statusIds: getStatusList(state, 'bookmarks'),
   isLoading: state.getIn(['status_lists', 'bookmarks', 'isLoading'], true),
   hasMore: !!state.getIn(['status_lists', 'bookmarks', 'next']),
 });
 
 class Bookmarks extends ImmutablePureComponent {
-
   static propTypes = {
     dispatch: PropTypes.func.isRequired,
     statusIds: ImmutablePropTypes.list.isRequired,
@@ -39,7 +41,7 @@ class Bookmarks extends ImmutablePureComponent {
     isLoading: PropTypes.bool,
   };
 
-  UNSAFE_componentWillMount () {
+  UNSAFE_componentWillMount() {
     this.props.dispatch(fetchBookmarkedStatuses());
   }
 
@@ -62,22 +64,36 @@ class Bookmarks extends ImmutablePureComponent {
     this.column.scrollTop();
   };
 
-  setRef = c => {
+  setRef = (c) => {
     this.column = c;
   };
 
-  handleLoadMore = debounce(() => {
-    this.props.dispatch(expandBookmarkedStatuses());
-  }, 300, { leading: true });
+  handleLoadMore = debounce(
+    () => {
+      this.props.dispatch(expandBookmarkedStatuses());
+    },
+    300,
+    { leading: true },
+  );
 
-  render () {
-    const { intl, statusIds, columnId, multiColumn, hasMore, isLoading } = this.props;
+  render() {
+    const { intl, statusIds, columnId, multiColumn, hasMore, isLoading } =
+      this.props;
     const pinned = !!columnId;
 
-    const emptyMessage = <FormattedMessage id='empty_column.bookmarked_statuses' defaultMessage="You don't have any bookmarked posts yet. When you bookmark one, it will show up here." />;
+    const emptyMessage = (
+      <FormattedMessage
+        id='empty_column.bookmarked_statuses'
+        defaultMessage="You don't have any bookmarked posts yet. When you bookmark one, it will show up here."
+      />
+    );
 
     return (
-      <Column bindToDocument={!multiColumn} ref={this.setRef} label={intl.formatMessage(messages.heading)}>
+      <Column
+        bindToDocument={!multiColumn}
+        ref={this.setRef}
+        label={intl.formatMessage(messages.heading)}
+      >
         <ColumnHeader
           icon='bookmark'
           title={intl.formatMessage(messages.heading)}
@@ -106,7 +122,6 @@ class Bookmarks extends ImmutablePureComponent {
       </Column>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(injectIntl(Bookmarks));

--- a/app/javascript/mastodon/features/closed_registrations_modal/index.jsx
+++ b/app/javascript/mastodon/features/closed_registrations_modal/index.jsx
@@ -6,18 +6,17 @@ import { connect } from 'react-redux';
 import { fetchServer } from 'mastodon/actions/server';
 import { domain } from 'mastodon/initial_state';
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   message: state.getIn(['server', 'server', 'registrations', 'message']),
 });
 
 class ClosedRegistrationsModal extends ImmutablePureComponent {
-
-  componentDidMount () {
+  componentDidMount() {
     const { dispatch } = this.props;
     dispatch(fetchServer());
   }
 
-  render () {
+  render() {
     let closedRegistrationsMessage;
 
     if (this.props.message) {
@@ -42,7 +41,12 @@ class ClosedRegistrationsModal extends ImmutablePureComponent {
     return (
       <div className='modal-root__modal interaction-modal'>
         <div className='interaction-modal__lead'>
-          <h3><FormattedMessage id='closed_registrations_modal.title' defaultMessage='Signing up on Mastodon' /></h3>
+          <h3>
+            <FormattedMessage
+              id='closed_registrations_modal.title'
+              defaultMessage='Signing up on Mastodon'
+            />
+          </h3>
           <p>
             <FormattedMessage
               id='closed_registrations_modal.preamble'
@@ -53,25 +57,42 @@ class ClosedRegistrationsModal extends ImmutablePureComponent {
 
         <div className='interaction-modal__choices'>
           <div className='interaction-modal__choices__choice'>
-            <h3><FormattedMessage id='interaction_modal.on_this_server' defaultMessage='On this server' /></h3>
+            <h3>
+              <FormattedMessage
+                id='interaction_modal.on_this_server'
+                defaultMessage='On this server'
+              />
+            </h3>
             {closedRegistrationsMessage}
           </div>
 
           <div className='interaction-modal__choices__choice'>
-            <h3><FormattedMessage id='interaction_modal.on_another_server' defaultMessage='On a different server' /></h3>
+            <h3>
+              <FormattedMessage
+                id='interaction_modal.on_another_server'
+                defaultMessage='On a different server'
+              />
+            </h3>
             <p className='prose'>
               <FormattedMessage
                 id='closed_registrations.other_server_instructions'
                 defaultMessage='Since Mastodon is decentralized, you can create an account on another server and still interact with this one.'
               />
             </p>
-            <a href='https://joinmastodon.org/servers' className='button button--block'><FormattedMessage id='closed_registrations_modal.find_another_server' defaultMessage='Find another server' /></a>
+            <a
+              href='https://joinmastodon.org/servers'
+              className='button button--block'
+            >
+              <FormattedMessage
+                id='closed_registrations_modal.find_another_server'
+                defaultMessage='Find another server'
+              />
+            </a>
           </div>
         </div>
       </div>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(ClosedRegistrationsModal);

--- a/app/javascript/mastodon/features/community_timeline/components/column_settings.jsx
+++ b/app/javascript/mastodon/features/community_timeline/components/column_settings.jsx
@@ -8,7 +8,6 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import SettingToggle from '../../notifications/components/setting_toggle';
 
 class ColumnSettings extends PureComponent {
-
   static propTypes = {
     settings: ImmutablePropTypes.map.isRequired,
     onChange: PropTypes.func.isRequired,
@@ -16,18 +15,27 @@ class ColumnSettings extends PureComponent {
     columnId: PropTypes.string,
   };
 
-  render () {
+  render() {
     const { settings, onChange } = this.props;
 
     return (
       <div>
         <div className='column-settings__row'>
-          <SettingToggle settings={settings} settingPath={['other', 'onlyMedia']} onChange={onChange} label={<FormattedMessage id='community.column_settings.media_only' defaultMessage='Media only' />} />
+          <SettingToggle
+            settings={settings}
+            settingPath={['other', 'onlyMedia']}
+            onChange={onChange}
+            label={
+              <FormattedMessage
+                id='community.column_settings.media_only'
+                defaultMessage='Media only'
+              />
+            }
+          />
         </div>
       </div>
     );
   }
-
 }
 
 export default injectIntl(ColumnSettings);

--- a/app/javascript/mastodon/features/community_timeline/containers/column_settings_container.js
+++ b/app/javascript/mastodon/features/community_timeline/containers/column_settings_container.js
@@ -7,16 +7,19 @@ import ColumnSettings from '../components/column_settings';
 const mapStateToProps = (state, { columnId }) => {
   const uuid = columnId;
   const columns = state.getIn(['settings', 'columns']);
-  const index = columns.findIndex(c => c.get('uuid') === uuid);
+  const index = columns.findIndex((c) => c.get('uuid') === uuid);
 
   return {
-    settings: (uuid && index >= 0) ? columns.get(index).get('params') : state.getIn(['settings', 'community']),
+    settings:
+      uuid && index >= 0
+        ? columns.get(index).get('params')
+        : state.getIn(['settings', 'community']),
   };
 };
 
 const mapDispatchToProps = (dispatch, { columnId }) => {
   return {
-    onChange (key, checked) {
+    onChange(key, checked) {
       if (columnId) {
         dispatch(changeColumnParams(columnId, key, checked));
       } else {

--- a/app/javascript/mastodon/features/community_timeline/index.jsx
+++ b/app/javascript/mastodon/features/community_timeline/index.jsx
@@ -26,9 +26,15 @@ const messages = defineMessages({
 const mapStateToProps = (state, { columnId }) => {
   const uuid = columnId;
   const columns = state.getIn(['settings', 'columns']);
-  const index = columns.findIndex(c => c.get('uuid') === uuid);
-  const onlyMedia = (columnId && index >= 0) ? columns.get(index).getIn(['params', 'other', 'onlyMedia']) : state.getIn(['settings', 'community', 'other', 'onlyMedia']);
-  const timelineState = state.getIn(['timelines', `community${onlyMedia ? ':media' : ''}`]);
+  const index = columns.findIndex((c) => c.get('uuid') === uuid);
+  const onlyMedia =
+    columnId && index >= 0
+      ? columns.get(index).getIn(['params', 'other', 'onlyMedia'])
+      : state.getIn(['settings', 'community', 'other', 'onlyMedia']);
+  const timelineState = state.getIn([
+    'timelines',
+    `community${onlyMedia ? ':media' : ''}`,
+  ]);
 
   return {
     hasUnread: !!timelineState && timelineState.get('unread') > 0,
@@ -37,7 +43,6 @@ const mapStateToProps = (state, { columnId }) => {
 };
 
 class CommunityTimeline extends PureComponent {
-
   static contextTypes = {
     router: PropTypes.object,
     identity: PropTypes.object,
@@ -75,7 +80,7 @@ class CommunityTimeline extends PureComponent {
     this.column.scrollTop();
   };
 
-  componentDidMount () {
+  componentDidMount() {
     const { dispatch, onlyMedia } = this.props;
     const { signedIn } = this.context.identity;
 
@@ -86,7 +91,7 @@ class CommunityTimeline extends PureComponent {
     }
   }
 
-  componentDidUpdate (prevProps) {
+  componentDidUpdate(prevProps) {
     const { signedIn } = this.context.identity;
 
     if (prevProps.onlyMedia !== this.props.onlyMedia) {
@@ -104,29 +109,33 @@ class CommunityTimeline extends PureComponent {
     }
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     if (this.disconnect) {
       this.disconnect();
       this.disconnect = null;
     }
   }
 
-  setRef = c => {
+  setRef = (c) => {
     this.column = c;
   };
 
-  handleLoadMore = maxId => {
+  handleLoadMore = (maxId) => {
     const { dispatch, onlyMedia } = this.props;
 
     dispatch(expandCommunityTimeline({ maxId, onlyMedia }));
   };
 
-  render () {
+  render() {
     const { intl, hasUnread, columnId, multiColumn, onlyMedia } = this.props;
     const pinned = !!columnId;
 
     return (
-      <Column bindToDocument={!multiColumn} ref={this.setRef} label={intl.formatMessage(messages.title)}>
+      <Column
+        bindToDocument={!multiColumn}
+        ref={this.setRef}
+        label={intl.formatMessage(messages.title)}
+      >
         <ColumnHeader
           icon='users'
           active={hasUnread}
@@ -141,12 +150,25 @@ class CommunityTimeline extends PureComponent {
         </ColumnHeader>
 
         <StatusListContainer
-          prepend={<DismissableBanner id='community_timeline'><FormattedMessage id='dismissable_banner.community_timeline' defaultMessage='These are the most recent public posts from people whose accounts are hosted by {domain}.' values={{ domain }} /></DismissableBanner>}
+          prepend={
+            <DismissableBanner id='community_timeline'>
+              <FormattedMessage
+                id='dismissable_banner.community_timeline'
+                defaultMessage='These are the most recent public posts from people whose accounts are hosted by {domain}.'
+                values={{ domain }}
+              />
+            </DismissableBanner>
+          }
           trackScroll={!pinned}
           scrollKey={`community_timeline-${columnId}`}
           timelineId={`community${onlyMedia ? ':media' : ''}`}
           onLoadMore={this.handleLoadMore}
-          emptyMessage={<FormattedMessage id='empty_column.community' defaultMessage='The local timeline is empty. Write something publicly to get the ball rolling!' />}
+          emptyMessage={
+            <FormattedMessage
+              id='empty_column.community'
+              defaultMessage='The local timeline is empty. Write something publicly to get the ball rolling!'
+            />
+          }
           bindToDocument={!multiColumn}
         />
 
@@ -157,7 +179,6 @@ class CommunityTimeline extends PureComponent {
       </Column>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(injectIntl(CommunityTimeline));

--- a/app/javascript/mastodon/features/compose/components/action_bar.jsx
+++ b/app/javascript/mastodon/features/compose/components/action_bar.jsx
@@ -10,13 +10,25 @@ import DropdownMenuContainer from '../../../containers/dropdown_menu_container';
 const messages = defineMessages({
   edit_profile: { id: 'account.edit_profile', defaultMessage: 'Edit profile' },
   pins: { id: 'navigation_bar.pins', defaultMessage: 'Pinned posts' },
-  preferences: { id: 'navigation_bar.preferences', defaultMessage: 'Preferences' },
-  follow_requests: { id: 'navigation_bar.follow_requests', defaultMessage: 'Follow requests' },
+  preferences: {
+    id: 'navigation_bar.preferences',
+    defaultMessage: 'Preferences',
+  },
+  follow_requests: {
+    id: 'navigation_bar.follow_requests',
+    defaultMessage: 'Follow requests',
+  },
   favourites: { id: 'navigation_bar.favourites', defaultMessage: 'Favorites' },
   lists: { id: 'navigation_bar.lists', defaultMessage: 'Lists' },
-  followed_tags: { id: 'navigation_bar.followed_tags', defaultMessage: 'Followed hashtags' },
+  followed_tags: {
+    id: 'navigation_bar.followed_tags',
+    defaultMessage: 'Followed hashtags',
+  },
   blocks: { id: 'navigation_bar.blocks', defaultMessage: 'Blocked users' },
-  domain_blocks: { id: 'navigation_bar.domain_blocks', defaultMessage: 'Blocked domains' },
+  domain_blocks: {
+    id: 'navigation_bar.domain_blocks',
+    defaultMessage: 'Blocked domains',
+  },
   mutes: { id: 'navigation_bar.mutes', defaultMessage: 'Muted users' },
   filters: { id: 'navigation_bar.filters', defaultMessage: 'Muted words' },
   logout: { id: 'navigation_bar.logout', defaultMessage: 'Logout' },
@@ -24,7 +36,6 @@ const messages = defineMessages({
 });
 
 class ActionBar extends PureComponent {
-
   static propTypes = {
     account: ImmutablePropTypes.map.isRequired,
     onLogout: PropTypes.func.isRequired,
@@ -35,37 +46,65 @@ class ActionBar extends PureComponent {
     this.props.onLogout();
   };
 
-  render () {
+  render() {
     const { intl } = this.props;
 
     let menu = [];
 
-    menu.push({ text: intl.formatMessage(messages.edit_profile), href: '/settings/profile' });
-    menu.push({ text: intl.formatMessage(messages.preferences), href: '/settings/preferences' });
+    menu.push({
+      text: intl.formatMessage(messages.edit_profile),
+      href: '/settings/profile',
+    });
+    menu.push({
+      text: intl.formatMessage(messages.preferences),
+      href: '/settings/preferences',
+    });
     menu.push({ text: intl.formatMessage(messages.pins), to: '/pinned' });
     menu.push(null);
-    menu.push({ text: intl.formatMessage(messages.follow_requests), to: '/follow_requests' });
-    menu.push({ text: intl.formatMessage(messages.favourites), to: '/favourites' });
-    menu.push({ text: intl.formatMessage(messages.bookmarks), to: '/bookmarks' });
+    menu.push({
+      text: intl.formatMessage(messages.follow_requests),
+      to: '/follow_requests',
+    });
+    menu.push({
+      text: intl.formatMessage(messages.favourites),
+      to: '/favourites',
+    });
+    menu.push({
+      text: intl.formatMessage(messages.bookmarks),
+      to: '/bookmarks',
+    });
     menu.push({ text: intl.formatMessage(messages.lists), to: '/lists' });
-    menu.push({ text: intl.formatMessage(messages.followed_tags), to: '/followed_tags' });
+    menu.push({
+      text: intl.formatMessage(messages.followed_tags),
+      to: '/followed_tags',
+    });
     menu.push(null);
     menu.push({ text: intl.formatMessage(messages.mutes), to: '/mutes' });
     menu.push({ text: intl.formatMessage(messages.blocks), to: '/blocks' });
-    menu.push({ text: intl.formatMessage(messages.domain_blocks), to: '/domain_blocks' });
+    menu.push({
+      text: intl.formatMessage(messages.domain_blocks),
+      to: '/domain_blocks',
+    });
     menu.push({ text: intl.formatMessage(messages.filters), href: '/filters' });
     menu.push(null);
-    menu.push({ text: intl.formatMessage(messages.logout), action: this.handleLogout });
+    menu.push({
+      text: intl.formatMessage(messages.logout),
+      action: this.handleLogout,
+    });
 
     return (
       <div className='compose__action-bar'>
         <div className='compose__action-bar-dropdown'>
-          <DropdownMenuContainer items={menu} icon='bars' size={18} direction='right' />
+          <DropdownMenuContainer
+            items={menu}
+            icon='bars'
+            size={18}
+            direction='right'
+          />
         </div>
       </div>
     );
   }
-
 }
 
 export default injectIntl(ActionBar);

--- a/app/javascript/mastodon/features/compose/components/autosuggest_account.jsx
+++ b/app/javascript/mastodon/features/compose/components/autosuggest_account.jsx
@@ -5,20 +5,20 @@ import { Avatar } from '../../../components/avatar';
 import { DisplayName } from '../../../components/display_name';
 
 export default class AutosuggestAccount extends ImmutablePureComponent {
-
   static propTypes = {
     account: ImmutablePropTypes.map.isRequired,
   };
 
-  render () {
+  render() {
     const { account } = this.props;
 
     return (
       <div className='autosuggest-account' title={account.get('acct')}>
-        <div className='autosuggest-account-icon'><Avatar account={account} size={18} /></div>
+        <div className='autosuggest-account-icon'>
+          <Avatar account={account} size={18} />
+        </div>
         <DisplayName account={account} />
       </div>
     );
   }
-
 }

--- a/app/javascript/mastodon/features/compose/components/character_counter.jsx
+++ b/app/javascript/mastodon/features/compose/components/character_counter.jsx
@@ -4,23 +4,25 @@ import { PureComponent } from 'react';
 import { length } from 'stringz';
 
 export default class CharacterCounter extends PureComponent {
-
   static propTypes = {
     text: PropTypes.string.isRequired,
     max: PropTypes.number.isRequired,
   };
 
-  checkRemainingText (diff) {
+  checkRemainingText(diff) {
     if (diff < 0) {
-      return <span className='character-counter character-counter--over'>{diff}</span>;
+      return (
+        <span className='character-counter character-counter--over'>
+          {diff}
+        </span>
+      );
     }
 
     return <span className='character-counter'>{diff}</span>;
   }
 
-  render () {
+  render() {
     const diff = this.props.max - length(this.props.text);
     return this.checkRemainingText(diff);
   }
-
 }

--- a/app/javascript/mastodon/features/compose/components/compose_form.jsx
+++ b/app/javascript/mastodon/features/compose/components/compose_form.jsx
@@ -9,7 +9,7 @@ import ImmutablePureComponent from 'react-immutable-pure-component';
 
 import { length } from 'stringz';
 
-import { Icon }  from 'mastodon/components/icon';
+import { Icon } from 'mastodon/components/icon';
 
 import AutosuggestInput from '../../../components/autosuggest_input';
 import AutosuggestTextarea from '../../../components/autosuggest_textarea';
@@ -28,18 +28,30 @@ import { countableText } from '../util/counter';
 
 import CharacterCounter from './character_counter';
 
-const allowedAroundShortCode = '><\u0085\u0020\u00a0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u202f\u205f\u3000\u2028\u2029\u0009\u000a\u000b\u000c\u000d';
+const allowedAroundShortCode =
+  '><\u0085\u0020\u00a0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u202f\u205f\u3000\u2028\u2029\u0009\u000a\u000b\u000c\u000d';
 
 const messages = defineMessages({
-  placeholder: { id: 'compose_form.placeholder', defaultMessage: 'What is on your mind?' },
-  spoiler_placeholder: { id: 'compose_form.spoiler_placeholder', defaultMessage: 'Write your warning here' },
+  placeholder: {
+    id: 'compose_form.placeholder',
+    defaultMessage: 'What is on your mind?',
+  },
+  spoiler_placeholder: {
+    id: 'compose_form.spoiler_placeholder',
+    defaultMessage: 'Write your warning here',
+  },
   publish: { id: 'compose_form.publish', defaultMessage: 'Publish' },
-  publishLoud: { id: 'compose_form.publish_loud', defaultMessage: '{publish}!' },
-  saveChanges: { id: 'compose_form.save_changes', defaultMessage: 'Save changes' },
+  publishLoud: {
+    id: 'compose_form.publish_loud',
+    defaultMessage: '{publish}!',
+  },
+  saveChanges: {
+    id: 'compose_form.save_changes',
+    defaultMessage: 'Save changes',
+  },
 });
 
 class ComposeForm extends ImmutablePureComponent {
-
   static contextTypes = {
     router: PropTypes.object,
   };
@@ -92,15 +104,26 @@ class ComposeForm extends ImmutablePureComponent {
   };
 
   getFulltextForCharacterCounting = () => {
-    return [this.props.spoiler? this.props.spoilerText: '', countableText(this.props.text)].join('');
+    return [
+      this.props.spoiler ? this.props.spoilerText : '',
+      countableText(this.props.text),
+    ].join('');
   };
 
   canSubmit = () => {
-    const { isSubmitting, isChangingUpload, isUploading, anyMedia } = this.props;
+    const { isSubmitting, isChangingUpload, isUploading, anyMedia } =
+      this.props;
     const fulltext = this.getFulltextForCharacterCounting();
-    const isOnlyWhitespace = fulltext.length !== 0 && fulltext.trim().length === 0;
+    const isOnlyWhitespace =
+      fulltext.length !== 0 && fulltext.trim().length === 0;
 
-    return !(isSubmitting || isUploading || isChangingUpload || length(fulltext) > 500 || (isOnlyWhitespace && !anyMedia));
+    return !(
+      isSubmitting ||
+      isUploading ||
+      isChangingUpload ||
+      length(fulltext) > 500 ||
+      (isOnlyWhitespace && !anyMedia)
+    );
   };
 
   handleSubmit = (e) => {
@@ -114,7 +137,9 @@ class ComposeForm extends ImmutablePureComponent {
       return;
     }
 
-    this.props.onSubmit(this.context.router ? this.context.router.history : null);
+    this.props.onSubmit(
+      this.context.router ? this.context.router.history : null,
+    );
 
     if (e) {
       e.preventDefault();
@@ -144,21 +169,24 @@ class ComposeForm extends ImmutablePureComponent {
   handleFocus = () => {
     if (this.composeForm && !this.props.singleColumn) {
       const { left, right } = this.composeForm.getBoundingClientRect();
-      if (left < 0 || right > (window.innerWidth || document.documentElement.clientWidth)) {
+      if (
+        left < 0 ||
+        right > (window.innerWidth || document.documentElement.clientWidth)
+      ) {
         this.composeForm.scrollIntoView();
       }
     }
   };
 
-  componentDidMount () {
-    this._updateFocusAndSelection({ });
+  componentDidMount() {
+    this._updateFocusAndSelection({});
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     if (this.timeout) clearTimeout(this.timeout);
   }
 
-  componentDidUpdate (prevProps) {
+  componentDidUpdate(prevProps) {
     this._updateFocusAndSelection(prevProps);
   }
 
@@ -171,27 +199,38 @@ class ComposeForm extends ImmutablePureComponent {
     if (this.props.focusDate && this.props.focusDate !== prevProps.focusDate) {
       let selectionEnd, selectionStart;
 
-      if (this.props.preselectDate !== prevProps.preselectDate && this.props.isInReply) {
-        selectionEnd   = this.props.text.length;
+      if (
+        this.props.preselectDate !== prevProps.preselectDate &&
+        this.props.isInReply
+      ) {
+        selectionEnd = this.props.text.length;
         selectionStart = this.props.text.search(/\s/) + 1;
       } else if (typeof this.props.caretPosition === 'number') {
         selectionStart = this.props.caretPosition;
-        selectionEnd   = this.props.caretPosition;
+        selectionEnd = this.props.caretPosition;
       } else {
-        selectionEnd   = this.props.text.length;
+        selectionEnd = this.props.text.length;
         selectionStart = selectionEnd;
       }
 
       // Because of the wicg-inert polyfill, the activeElement may not be
       // immediately selectable, we have to wait for observers to run, as
       // described in https://github.com/WICG/inert#performance-and-gotchas
-      Promise.resolve().then(() => {
-        this.autosuggestTextarea.textarea.setSelectionRange(selectionStart, selectionEnd);
-        this.autosuggestTextarea.textarea.focus();
-        this.setState({ highlighted: true });
-        this.timeout = setTimeout(() => this.setState({ highlighted: false }), 700);
-      }).catch(console.error);
-    } else if(prevProps.isSubmitting && !this.props.isSubmitting) {
+      Promise.resolve()
+        .then(() => {
+          this.autosuggestTextarea.textarea.setSelectionRange(
+            selectionStart,
+            selectionEnd,
+          );
+          this.autosuggestTextarea.textarea.focus();
+          this.setState({ highlighted: true });
+          this.timeout = setTimeout(
+            () => this.setState({ highlighted: false }),
+            700,
+          );
+        })
+        .catch(console.error);
+    } else if (prevProps.isSubmitting && !this.props.isSubmitting) {
       this.autosuggestTextarea.textarea.focus();
     } else if (this.props.spoiler !== prevProps.spoiler) {
       if (this.props.spoiler) {
@@ -210,19 +249,22 @@ class ComposeForm extends ImmutablePureComponent {
     this.spoilerText = c;
   };
 
-  setRef = c => {
+  setRef = (c) => {
     this.composeForm = c;
   };
 
   handleEmojiPick = (data) => {
-    const { text }     = this.props;
-    const position     = this.autosuggestTextarea.textarea.selectionStart;
-    const needsSpace   = data.custom && position > 0 && !allowedAroundShortCode.includes(text[position - 1]);
+    const { text } = this.props;
+    const position = this.autosuggestTextarea.textarea.selectionStart;
+    const needsSpace =
+      data.custom &&
+      position > 0 &&
+      !allowedAroundShortCode.includes(text[position - 1]);
 
     this.props.onPickEmoji(position, data, needsSpace);
   };
 
-  render () {
+  render() {
     const { intl, onPaste, autoFocus } = this.props;
     const { highlighted } = this.state;
     const disabled = this.props.isSubmitting;
@@ -231,10 +273,22 @@ class ComposeForm extends ImmutablePureComponent {
 
     if (this.props.isEditing) {
       publishText = intl.formatMessage(messages.saveChanges);
-    } else if (this.props.privacy === 'private' || this.props.privacy === 'direct') {
-      publishText = <span className='compose-form__publish-private'><Icon id='lock' /> {intl.formatMessage(messages.publish)}</span>;
+    } else if (
+      this.props.privacy === 'private' ||
+      this.props.privacy === 'direct'
+    ) {
+      publishText = (
+        <span className='compose-form__publish-private'>
+          <Icon id='lock' /> {intl.formatMessage(messages.publish)}
+        </span>
+      );
     } else {
-      publishText = this.props.privacy !== 'unlisted' ? intl.formatMessage(messages.publishLoud, { publish: intl.formatMessage(messages.publish) }) : intl.formatMessage(messages.publish);
+      publishText =
+        this.props.privacy !== 'unlisted'
+          ? intl.formatMessage(messages.publishLoud, {
+              publish: intl.formatMessage(messages.publish),
+            })
+          : intl.formatMessage(messages.publish);
     }
 
     return (
@@ -243,7 +297,13 @@ class ComposeForm extends ImmutablePureComponent {
 
         <ReplyIndicatorContainer />
 
-        <div className={`spoiler-input ${this.props.spoiler ? 'spoiler-input--visible' : ''}`} ref={this.setRef} aria-hidden={!this.props.spoiler}>
+        <div
+          className={`spoiler-input ${
+            this.props.spoiler ? 'spoiler-input--visible' : ''
+          }`}
+          ref={this.setRef}
+          aria-hidden={!this.props.spoiler}
+        >
           <AutosuggestInput
             placeholder={intl.formatMessage(messages.spoiler_placeholder)}
             value={this.props.spoilerText}
@@ -263,7 +323,11 @@ class ComposeForm extends ImmutablePureComponent {
           />
         </div>
 
-        <div className={classNames('compose-form__highlightable', { active: highlighted })}>
+        <div
+          className={classNames('compose-form__highlightable', {
+            active: highlighted,
+          })}
+        >
           <AutosuggestTextarea
             ref={this.setAutosuggestTextarea}
             placeholder={intl.formatMessage(messages.placeholder)}
@@ -297,7 +361,10 @@ class ComposeForm extends ImmutablePureComponent {
             </div>
 
             <div className='character-counter__wrapper'>
-              <CharacterCounter max={500} text={this.getFulltextForCharacterCounting()} />
+              <CharacterCounter
+                max={500}
+                text={this.getFulltextForCharacterCounting()}
+              />
             </div>
           </div>
         </div>
@@ -315,7 +382,6 @@ class ComposeForm extends ImmutablePureComponent {
       </form>
     );
   }
-
 }
 
 export default injectIntl(ComposeForm);

--- a/app/javascript/mastodon/features/compose/components/emoji_picker_dropdown.jsx
+++ b/app/javascript/mastodon/features/compose/components/emoji_picker_dropdown.jsx
@@ -20,7 +20,10 @@ const messages = defineMessages({
   emoji_search: { id: 'emoji_button.search', defaultMessage: 'Search...' },
   custom: { id: 'emoji_button.custom', defaultMessage: 'Custom' },
   recent: { id: 'emoji_button.recent', defaultMessage: 'Frequently used' },
-  search_results: { id: 'emoji_button.search_results', defaultMessage: 'Search results' },
+  search_results: {
+    id: 'emoji_button.search_results',
+    defaultMessage: 'Search results',
+  },
   people: { id: 'emoji_button.people', defaultMessage: 'People' },
   nature: { id: 'emoji_button.nature', defaultMessage: 'Nature' },
   food: { id: 'emoji_button.food', defaultMessage: 'Food & Drink' },
@@ -33,7 +36,9 @@ const messages = defineMessages({
 
 let EmojiPicker, Emoji; // load asynchronously
 
-const listenerOptions = supportsPassiveEvents ? { passive: true, capture: true } : true;
+const listenerOptions = supportsPassiveEvents
+  ? { passive: true, capture: true }
+  : true;
 
 const backgroundImageFn = () => `${assetHost}/emoji/sheet_13.png`;
 
@@ -48,24 +53,26 @@ const notFoundFn = () => (
     />
 
     <div className='emoji-mart-no-results-label'>
-      <FormattedMessage id='emoji_button.not_found' defaultMessage='No matching emojis found' />
+      <FormattedMessage
+        id='emoji_button.not_found'
+        defaultMessage='No matching emojis found'
+      />
     </div>
   </div>
 );
 
 class ModifierPickerMenu extends PureComponent {
-
   static propTypes = {
     active: PropTypes.bool,
     onSelect: PropTypes.func.isRequired,
     onClose: PropTypes.func.isRequired,
   };
 
-  handleClick = e => {
+  handleClick = (e) => {
     this.props.onSelect(e.currentTarget.getAttribute('data-index') * 1);
   };
 
-  UNSAFE_componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.active) {
       this.attachListeners();
     } else {
@@ -73,49 +80,117 @@ class ModifierPickerMenu extends PureComponent {
     }
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     this.removeListeners();
   }
 
-  handleDocumentClick = e => {
+  handleDocumentClick = (e) => {
     if (this.node && !this.node.contains(e.target)) {
       this.props.onClose();
     }
   };
 
-  attachListeners () {
-    document.addEventListener('click', this.handleDocumentClick, { capture: true });
-    document.addEventListener('touchend', this.handleDocumentClick, listenerOptions);
-  }
-
-  removeListeners () {
-    document.removeEventListener('click', this.handleDocumentClick, { capture: true });
-    document.removeEventListener('touchend', this.handleDocumentClick, listenerOptions);
-  }
-
-  setRef = c => {
-    this.node = c;
-  };
-
-  render () {
-    const { active } = this.props;
-
-    return (
-      <div className='emoji-picker-dropdown__modifiers__menu' style={{ display: active ? 'block' : 'none' }} ref={this.setRef}>
-        <button type='button' onClick={this.handleClick} data-index={1}><Emoji emoji='fist' set='twitter' size={22} sheetSize={32} skin={1} backgroundImageFn={backgroundImageFn} /></button>
-        <button type='button' onClick={this.handleClick} data-index={2}><Emoji emoji='fist' set='twitter' size={22} sheetSize={32} skin={2} backgroundImageFn={backgroundImageFn} /></button>
-        <button type='button' onClick={this.handleClick} data-index={3}><Emoji emoji='fist' set='twitter' size={22} sheetSize={32} skin={3} backgroundImageFn={backgroundImageFn} /></button>
-        <button type='button' onClick={this.handleClick} data-index={4}><Emoji emoji='fist' set='twitter' size={22} sheetSize={32} skin={4} backgroundImageFn={backgroundImageFn} /></button>
-        <button type='button' onClick={this.handleClick} data-index={5}><Emoji emoji='fist' set='twitter' size={22} sheetSize={32} skin={5} backgroundImageFn={backgroundImageFn} /></button>
-        <button type='button' onClick={this.handleClick} data-index={6}><Emoji emoji='fist' set='twitter' size={22} sheetSize={32} skin={6} backgroundImageFn={backgroundImageFn} /></button>
-      </div>
+  attachListeners() {
+    document.addEventListener('click', this.handleDocumentClick, {
+      capture: true,
+    });
+    document.addEventListener(
+      'touchend',
+      this.handleDocumentClick,
+      listenerOptions,
     );
   }
 
+  removeListeners() {
+    document.removeEventListener('click', this.handleDocumentClick, {
+      capture: true,
+    });
+    document.removeEventListener(
+      'touchend',
+      this.handleDocumentClick,
+      listenerOptions,
+    );
+  }
+
+  setRef = (c) => {
+    this.node = c;
+  };
+
+  render() {
+    const { active } = this.props;
+
+    return (
+      <div
+        className='emoji-picker-dropdown__modifiers__menu'
+        style={{ display: active ? 'block' : 'none' }}
+        ref={this.setRef}
+      >
+        <button type='button' onClick={this.handleClick} data-index={1}>
+          <Emoji
+            emoji='fist'
+            set='twitter'
+            size={22}
+            sheetSize={32}
+            skin={1}
+            backgroundImageFn={backgroundImageFn}
+          />
+        </button>
+        <button type='button' onClick={this.handleClick} data-index={2}>
+          <Emoji
+            emoji='fist'
+            set='twitter'
+            size={22}
+            sheetSize={32}
+            skin={2}
+            backgroundImageFn={backgroundImageFn}
+          />
+        </button>
+        <button type='button' onClick={this.handleClick} data-index={3}>
+          <Emoji
+            emoji='fist'
+            set='twitter'
+            size={22}
+            sheetSize={32}
+            skin={3}
+            backgroundImageFn={backgroundImageFn}
+          />
+        </button>
+        <button type='button' onClick={this.handleClick} data-index={4}>
+          <Emoji
+            emoji='fist'
+            set='twitter'
+            size={22}
+            sheetSize={32}
+            skin={4}
+            backgroundImageFn={backgroundImageFn}
+          />
+        </button>
+        <button type='button' onClick={this.handleClick} data-index={5}>
+          <Emoji
+            emoji='fist'
+            set='twitter'
+            size={22}
+            sheetSize={32}
+            skin={5}
+            backgroundImageFn={backgroundImageFn}
+          />
+        </button>
+        <button type='button' onClick={this.handleClick} data-index={6}>
+          <Emoji
+            emoji='fist'
+            set='twitter'
+            size={22}
+            sheetSize={32}
+            skin={6}
+            backgroundImageFn={backgroundImageFn}
+          />
+        </button>
+      </div>
+    );
+  }
 }
 
 class ModifierPicker extends PureComponent {
-
   static propTypes = {
     active: PropTypes.bool,
     modifier: PropTypes.number,
@@ -132,26 +207,36 @@ class ModifierPicker extends PureComponent {
     }
   };
 
-  handleSelect = modifier => {
+  handleSelect = (modifier) => {
     this.props.onChange(modifier);
     this.props.onClose();
   };
 
-  render () {
+  render() {
     const { active, modifier } = this.props;
 
     return (
       <div className='emoji-picker-dropdown__modifiers'>
-        <Emoji emoji='fist' set='twitter' size={22} sheetSize={32} skin={modifier} onClick={this.handleClick} backgroundImageFn={backgroundImageFn} />
-        <ModifierPickerMenu active={active} onSelect={this.handleSelect} onClose={this.props.onClose} />
+        <Emoji
+          emoji='fist'
+          set='twitter'
+          size={22}
+          sheetSize={32}
+          skin={modifier}
+          onClick={this.handleClick}
+          backgroundImageFn={backgroundImageFn}
+        />
+        <ModifierPickerMenu
+          active={active}
+          onSelect={this.handleSelect}
+          onClose={this.props.onClose}
+        />
       </div>
     );
   }
-
 }
 
 class EmojiPickerMenuImpl extends PureComponent {
-
   static propTypes = {
     custom_emojis: ImmutablePropTypes.list,
     frequentlyUsedEmojis: PropTypes.arrayOf(PropTypes.string),
@@ -175,15 +260,21 @@ class EmojiPickerMenuImpl extends PureComponent {
     readyToFocus: false,
   };
 
-  handleDocumentClick = e => {
+  handleDocumentClick = (e) => {
     if (this.node && !this.node.contains(e.target)) {
       this.props.onClose();
     }
   };
 
-  componentDidMount () {
-    document.addEventListener('click', this.handleDocumentClick, { capture: true });
-    document.addEventListener('touchend', this.handleDocumentClick, listenerOptions);
+  componentDidMount() {
+    document.addEventListener('click', this.handleDocumentClick, {
+      capture: true,
+    });
+    document.addEventListener(
+      'touchend',
+      this.handleDocumentClick,
+      listenerOptions,
+    );
 
     // Because of https://github.com/react-bootstrap/react-bootstrap/issues/2614 we need
     // to wait for a frame before focusing
@@ -196,12 +287,18 @@ class EmojiPickerMenuImpl extends PureComponent {
     });
   }
 
-  componentWillUnmount () {
-    document.removeEventListener('click', this.handleDocumentClick, { capture: true });
-    document.removeEventListener('touchend', this.handleDocumentClick, listenerOptions);
+  componentWillUnmount() {
+    document.removeEventListener('click', this.handleDocumentClick, {
+      capture: true,
+    });
+    document.removeEventListener(
+      'touchend',
+      this.handleDocumentClick,
+      listenerOptions,
+    );
   }
 
-  setRef = c => {
+  setRef = (c) => {
     this.node = c;
   };
 
@@ -244,12 +341,19 @@ class EmojiPickerMenuImpl extends PureComponent {
     this.setState({ modifierOpen: false });
   };
 
-  handleModifierChange = modifier => {
+  handleModifierChange = (modifier) => {
     this.props.onSkinTone(modifier);
   };
 
-  render () {
-    const { loading, style, intl, custom_emojis, skinTone, frequentlyUsedEmojis } = this.props;
+  render() {
+    const {
+      loading,
+      style,
+      intl,
+      custom_emojis,
+      skinTone,
+      frequentlyUsedEmojis,
+    } = this.props;
 
     if (loading) {
       return <div style={{ width: 299 }} />;
@@ -271,10 +375,20 @@ class EmojiPickerMenuImpl extends PureComponent {
       'flags',
     ];
 
-    categoriesSort.splice(1, 0, ...Array.from(categoriesFromEmojis(custom_emojis)).sort());
+    categoriesSort.splice(
+      1,
+      0,
+      ...Array.from(categoriesFromEmojis(custom_emojis)).sort(),
+    );
 
     return (
-      <div className={classNames('emoji-picker-dropdown__menu', { selecting: modifierOpen })} style={style} ref={this.setRef}>
+      <div
+        className={classNames('emoji-picker-dropdown__menu', {
+          selecting: modifierOpen,
+        })}
+        style={style}
+        ref={this.setRef}
+      >
         <EmojiPicker
           perLine={8}
           emojiSize={22}
@@ -307,13 +421,11 @@ class EmojiPickerMenuImpl extends PureComponent {
       </div>
     );
   }
-
 }
 
 const EmojiPickerMenu = injectIntl(EmojiPickerMenuImpl);
 
 class EmojiPickerDropdown extends PureComponent {
-
   static propTypes = {
     custom_emojis: ImmutablePropTypes.list,
     frequentlyUsedEmojis: PropTypes.arrayOf(PropTypes.string),
@@ -339,14 +451,16 @@ class EmojiPickerDropdown extends PureComponent {
     if (!EmojiPicker) {
       this.setState({ loading: true });
 
-      EmojiPickerAsync().then(EmojiMart => {
-        EmojiPicker = EmojiMart.Picker;
-        Emoji       = EmojiMart.Emoji;
+      EmojiPickerAsync()
+        .then((EmojiMart) => {
+          EmojiPicker = EmojiMart.Picker;
+          Emoji = EmojiMart.Emoji;
 
-        this.setState({ loading: false });
-      }).catch(() => {
-        this.setState({ loading: false, active: false });
-      });
+          this.setState({ loading: false });
+        })
+        .catch(() => {
+          this.setState({ loading: false, active: false });
+        });
     }
   };
 
@@ -364,13 +478,13 @@ class EmojiPickerDropdown extends PureComponent {
     }
   };
 
-  handleKeyDown = e => {
+  handleKeyDown = (e) => {
     if (e.key === 'Escape') {
       this.onHideDropdown();
     }
   };
 
-  setTargetRef = c => {
+  setTargetRef = (c) => {
     this.target = c;
   };
 
@@ -378,23 +492,49 @@ class EmojiPickerDropdown extends PureComponent {
     return this.target;
   };
 
-  render () {
-    const { intl, onPickEmoji, onSkinTone, skinTone, frequentlyUsedEmojis, button } = this.props;
+  render() {
+    const {
+      intl,
+      onPickEmoji,
+      onSkinTone,
+      skinTone,
+      frequentlyUsedEmojis,
+      button,
+    } = this.props;
     const title = intl.formatMessage(messages.emoji);
     const { active, loading } = this.state;
 
     return (
       <div className='emoji-picker-dropdown' onKeyDown={this.handleKeyDown}>
-        <div ref={this.setTargetRef} className='emoji-button' title={title} aria-label={title} aria-expanded={active} role='button' onClick={this.onToggle} onKeyDown={this.onToggle} tabIndex={0}>
-          {button || <img
-            className={classNames('emojione', { 'pulse-loading': active && loading })}
-            alt='🙂'
-            src={`${assetHost}/emoji/1f642.svg`}
-          />}
+        <div
+          ref={this.setTargetRef}
+          className='emoji-button'
+          title={title}
+          aria-label={title}
+          aria-expanded={active}
+          role='button'
+          onClick={this.onToggle}
+          onKeyDown={this.onToggle}
+          tabIndex={0}
+        >
+          {button || (
+            <img
+              className={classNames('emojione', {
+                'pulse-loading': active && loading,
+              })}
+              alt='🙂'
+              src={`${assetHost}/emoji/1f642.svg`}
+            />
+          )}
         </div>
 
-        <Overlay show={active} placement={'bottom'} target={this.findTarget} popperConfig={{ strategy: 'fixed' }}>
-          {({ props, placement })=> (
+        <Overlay
+          show={active}
+          placement={'bottom'}
+          target={this.findTarget}
+          popperConfig={{ strategy: 'fixed' }}
+        >
+          {({ props, placement }) => (
             <div {...props} style={{ ...props.style, width: 299 }}>
               <div className={`dropdown-animation ${placement}`}>
                 <EmojiPickerMenu
@@ -413,7 +553,6 @@ class EmojiPickerDropdown extends PureComponent {
       </div>
     );
   }
-
 }
 
 export default injectIntl(EmojiPickerDropdown);

--- a/app/javascript/mastodon/features/compose/components/language_dropdown.jsx
+++ b/app/javascript/mastodon/features/compose/components/language_dropdown.jsx
@@ -15,15 +15,22 @@ import { loupeIcon, deleteIcon } from 'mastodon/utils/icons';
 import TextIconButton from './text_icon_button';
 
 const messages = defineMessages({
-  changeLanguage: { id: 'compose.language.change', defaultMessage: 'Change language' },
-  search: { id: 'compose.language.search', defaultMessage: 'Search languages...' },
+  changeLanguage: {
+    id: 'compose.language.change',
+    defaultMessage: 'Change language',
+  },
+  search: {
+    id: 'compose.language.search',
+    defaultMessage: 'Search languages...',
+  },
   clear: { id: 'emoji_button.clear', defaultMessage: 'Clear' },
 });
 
-const listenerOptions = supportsPassiveEvents ? { passive: true, capture: true } : true;
+const listenerOptions = supportsPassiveEvents
+  ? { passive: true, capture: true }
+  : true;
 
 class LanguageDropdownMenu extends PureComponent {
-
   static propTypes = {
     value: PropTypes.string.isRequired,
     frequentlyUsedLanguages: PropTypes.arrayOf(PropTypes.string).isRequired,
@@ -41,16 +48,22 @@ class LanguageDropdownMenu extends PureComponent {
     searchValue: '',
   };
 
-  handleDocumentClick = e => {
+  handleDocumentClick = (e) => {
     if (this.node && !this.node.contains(e.target)) {
       this.props.onClose();
       e.stopPropagation();
     }
   };
 
-  componentDidMount () {
-    document.addEventListener('click', this.handleDocumentClick, { capture: true });
-    document.addEventListener('touchend', this.handleDocumentClick, listenerOptions);
+  componentDidMount() {
+    document.addEventListener('click', this.handleDocumentClick, {
+      capture: true,
+    });
+    document.addEventListener(
+      'touchend',
+      this.handleDocumentClick,
+      listenerOptions,
+    );
 
     // Because of https://github.com/react-bootstrap/react-bootstrap/issues/2614 we need
     // to wait for a frame before focusing
@@ -62,16 +75,22 @@ class LanguageDropdownMenu extends PureComponent {
     });
   }
 
-  componentWillUnmount () {
-    document.removeEventListener('click', this.handleDocumentClick, { capture: true });
-    document.removeEventListener('touchend', this.handleDocumentClick, listenerOptions);
+  componentWillUnmount() {
+    document.removeEventListener('click', this.handleDocumentClick, {
+      capture: true,
+    });
+    document.removeEventListener(
+      'touchend',
+      this.handleDocumentClick,
+      listenerOptions,
+    );
   }
 
-  setRef = c => {
+  setRef = (c) => {
     this.node = c;
   };
 
-  setListRef = c => {
+  setListRef = (c) => {
     this.listNode = c;
   };
 
@@ -79,7 +98,7 @@ class LanguageDropdownMenu extends PureComponent {
     this.setState({ searchValue: target.value });
   };
 
-  search () {
+  search() {
     const { languages, value, frequentlyUsedLanguages } = this.props;
     const { searchValue } = this.state;
 
@@ -97,21 +116,26 @@ class LanguageDropdownMenu extends PureComponent {
           const indexOfA = frequentlyUsedLanguages.indexOf(a[0]);
           const indexOfB = frequentlyUsedLanguages.indexOf(b[0]);
 
-          return ((indexOfA > -1 ? indexOfA : Infinity) - (indexOfB > -1 ? indexOfB : Infinity));
+          return (
+            (indexOfA > -1 ? indexOfA : Infinity) -
+            (indexOfB > -1 ? indexOfB : Infinity)
+          );
         }
       });
     }
 
-    return fuzzysort.go(searchValue, languages, {
-      keys: ['0', '1', '2'],
-      limit: 5,
-      threshold: -10000,
-    }).map(result => result.obj);
+    return fuzzysort
+      .go(searchValue, languages, {
+        keys: ['0', '1', '2'],
+        limit: 5,
+        threshold: -10000,
+      })
+      .map((result) => result.obj);
   }
 
-  frequentlyUsed () {
+  frequentlyUsed() {
     const { languages, value } = this.props;
-    const current = languages.find(lang => lang[0] === value);
+    const current = languages.find((lang) => lang[0] === value);
     const results = [];
 
     if (current) {
@@ -121,7 +145,7 @@ class LanguageDropdownMenu extends PureComponent {
     return results;
   }
 
-  handleClick = e => {
+  handleClick = (e) => {
     const value = e.currentTarget.getAttribute('data-index');
 
     e.preventDefault();
@@ -130,38 +154,44 @@ class LanguageDropdownMenu extends PureComponent {
     this.props.onChange(value);
   };
 
-  handleKeyDown = e => {
+  handleKeyDown = (e) => {
     const { onClose } = this.props;
-    const index = Array.from(this.listNode.childNodes).findIndex(node => node === e.currentTarget);
+    const index = Array.from(this.listNode.childNodes).findIndex(
+      (node) => node === e.currentTarget,
+    );
 
     let element = null;
 
-    switch(e.key) {
-    case 'Escape':
-      onClose();
-      break;
-    case 'Enter':
-      this.handleClick(e);
-      break;
-    case 'ArrowDown':
-      element = this.listNode.childNodes[index + 1] || this.listNode.firstChild;
-      break;
-    case 'ArrowUp':
-      element = this.listNode.childNodes[index - 1] || this.listNode.lastChild;
-      break;
-    case 'Tab':
-      if (e.shiftKey) {
-        element = this.listNode.childNodes[index - 1] || this.listNode.lastChild;
-      } else {
-        element = this.listNode.childNodes[index + 1] || this.listNode.firstChild;
-      }
-      break;
-    case 'Home':
-      element = this.listNode.firstChild;
-      break;
-    case 'End':
-      element = this.listNode.lastChild;
-      break;
+    switch (e.key) {
+      case 'Escape':
+        onClose();
+        break;
+      case 'Enter':
+        this.handleClick(e);
+        break;
+      case 'ArrowDown':
+        element =
+          this.listNode.childNodes[index + 1] || this.listNode.firstChild;
+        break;
+      case 'ArrowUp':
+        element =
+          this.listNode.childNodes[index - 1] || this.listNode.lastChild;
+        break;
+      case 'Tab':
+        if (e.shiftKey) {
+          element =
+            this.listNode.childNodes[index - 1] || this.listNode.lastChild;
+        } else {
+          element =
+            this.listNode.childNodes[index + 1] || this.listNode.firstChild;
+        }
+        break;
+      case 'Home':
+        element = this.listNode.firstChild;
+        break;
+      case 'End':
+        element = this.listNode.lastChild;
+        break;
     }
 
     if (element) {
@@ -171,39 +201,39 @@ class LanguageDropdownMenu extends PureComponent {
     }
   };
 
-  handleSearchKeyDown = e => {
+  handleSearchKeyDown = (e) => {
     const { onChange, onClose } = this.props;
     const { searchValue } = this.state;
 
     let element = null;
 
-    switch(e.key) {
-    case 'Tab':
-    case 'ArrowDown':
-      element = this.listNode.firstChild;
+    switch (e.key) {
+      case 'Tab':
+      case 'ArrowDown':
+        element = this.listNode.firstChild;
 
-      if (element) {
-        element.focus();
-        e.preventDefault();
-        e.stopPropagation();
-      }
+        if (element) {
+          element.focus();
+          e.preventDefault();
+          e.stopPropagation();
+        }
 
-      break;
-    case 'Enter':
-      element = this.listNode.firstChild;
+        break;
+      case 'Enter':
+        element = this.listNode.firstChild;
 
-      if (element) {
-        onChange(element.getAttribute('data-index'));
-        onClose();
-      }
-      break;
-    case 'Escape':
-      if (searchValue !== '') {
-        e.preventDefault();
-        this.handleClear();
-      }
+        if (element) {
+          onChange(element.getAttribute('data-index'));
+          onClose();
+        }
+        break;
+      case 'Escape':
+        if (searchValue !== '') {
+          e.preventDefault();
+          this.handleClear();
+        }
 
-      break;
+        break;
     }
   };
 
@@ -211,17 +241,36 @@ class LanguageDropdownMenu extends PureComponent {
     this.setState({ searchValue: '' });
   };
 
-  renderItem = lang => {
+  renderItem = (lang) => {
     const { value } = this.props;
 
     return (
-      <div key={lang[0]} role='option' tabIndex={0} data-index={lang[0]} className={classNames('language-dropdown__dropdown__results__item', { active: lang[0] === value })} aria-selected={lang[0] === value} onClick={this.handleClick} onKeyDown={this.handleKeyDown}>
-        <span className='language-dropdown__dropdown__results__item__native-name' lang={lang[0]}>{lang[2]}</span> <span className='language-dropdown__dropdown__results__item__common-name'>({lang[1]})</span>
+      <div
+        key={lang[0]}
+        role='option'
+        tabIndex={0}
+        data-index={lang[0]}
+        className={classNames('language-dropdown__dropdown__results__item', {
+          active: lang[0] === value,
+        })}
+        aria-selected={lang[0] === value}
+        onClick={this.handleClick}
+        onKeyDown={this.handleKeyDown}
+      >
+        <span
+          className='language-dropdown__dropdown__results__item__native-name'
+          lang={lang[0]}
+        >
+          {lang[2]}
+        </span>{' '}
+        <span className='language-dropdown__dropdown__results__item__common-name'>
+          ({lang[1]})
+        </span>
       </div>
     );
   };
 
-  render () {
+  render() {
     const { intl } = this.props;
     const { searchValue } = this.state;
     const isSearching = searchValue !== '';
@@ -230,21 +279,37 @@ class LanguageDropdownMenu extends PureComponent {
     return (
       <div ref={this.setRef}>
         <div className='emoji-mart-search'>
-          <input type='search' value={searchValue} onChange={this.handleSearchChange} onKeyDown={this.handleSearchKeyDown} placeholder={intl.formatMessage(messages.search)} />
-          <button type='button' className='emoji-mart-search-icon' disabled={!isSearching} aria-label={intl.formatMessage(messages.clear)} onClick={this.handleClear}>{!isSearching ? loupeIcon : deleteIcon}</button>
+          <input
+            type='search'
+            value={searchValue}
+            onChange={this.handleSearchChange}
+            onKeyDown={this.handleSearchKeyDown}
+            placeholder={intl.formatMessage(messages.search)}
+          />
+          <button
+            type='button'
+            className='emoji-mart-search-icon'
+            disabled={!isSearching}
+            aria-label={intl.formatMessage(messages.clear)}
+            onClick={this.handleClear}
+          >
+            {!isSearching ? loupeIcon : deleteIcon}
+          </button>
         </div>
 
-        <div className='language-dropdown__dropdown__results emoji-mart-scroll' role='listbox' ref={this.setListRef}>
+        <div
+          className='language-dropdown__dropdown__results emoji-mart-scroll'
+          role='listbox'
+          ref={this.setListRef}
+        >
           {results.map(this.renderItem)}
         </div>
       </div>
     );
   }
-
 }
 
 class LanguageDropdown extends PureComponent {
-
   static propTypes = {
     value: PropTypes.string,
     frequentlyUsedLanguages: PropTypes.arrayOf(PropTypes.string),
@@ -277,12 +342,12 @@ class LanguageDropdown extends PureComponent {
     onClose(value);
   };
 
-  handleChange = value => {
+  handleChange = (value) => {
     const { onChange } = this.props;
     onChange(value);
   };
 
-  setTargetRef = c => {
+  setTargetRef = (c) => {
     this.target = c;
   };
 
@@ -294,13 +359,15 @@ class LanguageDropdown extends PureComponent {
     this.setState({ placement: state.placement });
   };
 
-  render () {
+  render() {
     const { value, intl, frequentlyUsedLanguages } = this.props;
     const { open, placement } = this.state;
 
     return (
-      <div className={classNames('privacy-dropdown', placement, { active: open })}>
-        <div className='privacy-dropdown__value' ref={this.setTargetRef} >
+      <div
+        className={classNames('privacy-dropdown', placement, { active: open })}
+      >
+        <div className='privacy-dropdown__value' ref={this.setTargetRef}>
           <TextIconButton
             className='privacy-dropdown__value-icon'
             label={value && value.toUpperCase()}
@@ -310,10 +377,21 @@ class LanguageDropdown extends PureComponent {
           />
         </div>
 
-        <Overlay show={open} placement={'bottom'} flip target={this.findTarget} popperConfig={{ strategy: 'fixed', onFirstUpdate: this.handleOverlayEnter }}>
+        <Overlay
+          show={open}
+          placement={'bottom'}
+          flip
+          target={this.findTarget}
+          popperConfig={{
+            strategy: 'fixed',
+            onFirstUpdate: this.handleOverlayEnter,
+          }}
+        >
           {({ props, placement }) => (
             <div {...props}>
-              <div className={`dropdown-animation language-dropdown__dropdown ${placement}`} >
+              <div
+                className={`dropdown-animation language-dropdown__dropdown ${placement}`}
+              >
                 <LanguageDropdownMenu
                   value={value}
                   frequentlyUsedLanguages={frequentlyUsedLanguages}
@@ -328,7 +406,6 @@ class LanguageDropdown extends PureComponent {
       </div>
     );
   }
-
 }
 
 export default injectIntl(LanguageDropdown);

--- a/app/javascript/mastodon/features/compose/components/navigation_bar.jsx
+++ b/app/javascript/mastodon/features/compose/components/navigation_bar.jsx
@@ -12,15 +12,14 @@ import { Avatar } from '../../../components/avatar';
 import ActionBar from './action_bar';
 
 export default class NavigationBar extends ImmutablePureComponent {
-
   static propTypes = {
     account: ImmutablePropTypes.map.isRequired,
     onLogout: PropTypes.func.isRequired,
     onClose: PropTypes.func,
   };
 
-  render () {
-    const username = this.props.account.get('acct')
+  render() {
+    const username = this.props.account.get('acct');
     return (
       <div className='navigation-bar'>
         <Link to={`/@${username}`}>
@@ -31,20 +30,32 @@ export default class NavigationBar extends ImmutablePureComponent {
         <div className='navigation-bar__profile'>
           <span>
             <Link to={`/@${username}`}>
-              <strong className='navigation-bar__profile-account'>@{username}</strong>
+              <strong className='navigation-bar__profile-account'>
+                @{username}
+              </strong>
             </Link>
           </span>
 
           <span>
-            <a href='/settings/profile' className='navigation-bar__profile-edit'><FormattedMessage id='navigation_bar.edit_profile' defaultMessage='Edit profile' /></a>
+            <a
+              href='/settings/profile'
+              className='navigation-bar__profile-edit'
+            >
+              <FormattedMessage
+                id='navigation_bar.edit_profile'
+                defaultMessage='Edit profile'
+              />
+            </a>
           </span>
         </div>
 
         <div className='navigation-bar__actions'>
-          <ActionBar account={this.props.account} onLogout={this.props.onLogout} />
+          <ActionBar
+            account={this.props.account}
+            onLogout={this.props.onLogout}
+          />
         </div>
       </div>
     );
   }
-
 }

--- a/app/javascript/mastodon/features/compose/components/poll_button.jsx
+++ b/app/javascript/mastodon/features/compose/components/poll_button.jsx
@@ -16,7 +16,6 @@ const iconStyle = {
 };
 
 class PollButton extends PureComponent {
-
   static propTypes = {
     disabled: PropTypes.bool,
     unavailable: PropTypes.bool,
@@ -29,7 +28,7 @@ class PollButton extends PureComponent {
     this.props.onClick();
   };
 
-  render () {
+  render() {
     const { intl, active, unavailable, disabled } = this.props;
 
     if (unavailable) {
@@ -40,7 +39,9 @@ class PollButton extends PureComponent {
       <div className='compose-form__poll-button'>
         <IconButton
           icon='tasks'
-          title={intl.formatMessage(active ? messages.remove_poll : messages.add_poll)}
+          title={intl.formatMessage(
+            active ? messages.remove_poll : messages.add_poll,
+          )}
           disabled={disabled}
           onClick={this.handleClick}
           className={`compose-form__poll-button-icon ${active ? 'active' : ''}`}
@@ -51,7 +52,6 @@ class PollButton extends PureComponent {
       </div>
     );
   }
-
 }
 
 export default injectIntl(PollButton);

--- a/app/javascript/mastodon/features/compose/components/poll_form.jsx
+++ b/app/javascript/mastodon/features/compose/components/poll_form.jsx
@@ -9,23 +9,49 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 
 import AutosuggestInput from 'mastodon/components/autosuggest_input';
-import { Icon }  from 'mastodon/components/icon';
+import { Icon } from 'mastodon/components/icon';
 import { IconButton } from 'mastodon/components/icon_button';
 
 const messages = defineMessages({
-  option_placeholder: { id: 'compose_form.poll.option_placeholder', defaultMessage: 'Choice {number}' },
-  add_option: { id: 'compose_form.poll.add_option', defaultMessage: 'Add a choice' },
-  remove_option: { id: 'compose_form.poll.remove_option', defaultMessage: 'Remove this choice' },
-  poll_duration: { id: 'compose_form.poll.duration', defaultMessage: 'Poll duration' },
-  switchToMultiple: { id: 'compose_form.poll.switch_to_multiple', defaultMessage: 'Change poll to allow multiple choices' },
-  switchToSingle: { id: 'compose_form.poll.switch_to_single', defaultMessage: 'Change poll to allow for a single choice' },
-  minutes: { id: 'intervals.full.minutes', defaultMessage: '{number, plural, one {# minute} other {# minutes}}' },
-  hours: { id: 'intervals.full.hours', defaultMessage: '{number, plural, one {# hour} other {# hours}}' },
-  days: { id: 'intervals.full.days', defaultMessage: '{number, plural, one {# day} other {# days}}' },
+  option_placeholder: {
+    id: 'compose_form.poll.option_placeholder',
+    defaultMessage: 'Choice {number}',
+  },
+  add_option: {
+    id: 'compose_form.poll.add_option',
+    defaultMessage: 'Add a choice',
+  },
+  remove_option: {
+    id: 'compose_form.poll.remove_option',
+    defaultMessage: 'Remove this choice',
+  },
+  poll_duration: {
+    id: 'compose_form.poll.duration',
+    defaultMessage: 'Poll duration',
+  },
+  switchToMultiple: {
+    id: 'compose_form.poll.switch_to_multiple',
+    defaultMessage: 'Change poll to allow multiple choices',
+  },
+  switchToSingle: {
+    id: 'compose_form.poll.switch_to_single',
+    defaultMessage: 'Change poll to allow for a single choice',
+  },
+  minutes: {
+    id: 'intervals.full.minutes',
+    defaultMessage: '{number, plural, one {# minute} other {# minutes}}',
+  },
+  hours: {
+    id: 'intervals.full.hours',
+    defaultMessage: '{number, plural, one {# hour} other {# hours}}',
+  },
+  days: {
+    id: 'intervals.full.days',
+    defaultMessage: '{number, plural, one {# day} other {# days}}',
+  },
 });
 
 class OptionIntl extends PureComponent {
-
   static propTypes = {
     title: PropTypes.string.isRequired,
     lang: PropTypes.string,
@@ -42,7 +68,7 @@ class OptionIntl extends PureComponent {
     intl: PropTypes.object.isRequired,
   };
 
-  handleOptionTitleChange = e => {
+  handleOptionTitleChange = (e) => {
     this.props.onChange(this.props.index, e.target.value);
   };
 
@@ -50,14 +76,13 @@ class OptionIntl extends PureComponent {
     this.props.onRemove(this.props.index);
   };
 
-
-  handleToggleMultiple = e => {
+  handleToggleMultiple = (e) => {
     this.props.onToggleMultiple();
     e.preventDefault();
     e.stopPropagation();
   };
 
-  handleCheckboxKeypress = e => {
+  handleCheckboxKeypress = (e) => {
     if (e.key === 'Enter' || e.key === ' ') {
       this.handleToggleMultiple(e);
     }
@@ -72,10 +97,14 @@ class OptionIntl extends PureComponent {
   };
 
   onSuggestionSelected = (tokenStart, token, value) => {
-    this.props.onSuggestionSelected(tokenStart, token, value, ['poll', 'options', this.props.index]);
+    this.props.onSuggestionSelected(tokenStart, token, value, [
+      'poll',
+      'options',
+      this.props.index,
+    ]);
   };
 
-  render () {
+  render() {
     const { isPollMultiple, title, lang, index, autoFocus, intl } = this.props;
 
     return (
@@ -87,12 +116,22 @@ class OptionIntl extends PureComponent {
             onKeyPress={this.handleCheckboxKeypress}
             role='button'
             tabIndex={0}
-            title={intl.formatMessage(isPollMultiple ? messages.switchToSingle : messages.switchToMultiple)}
-            aria-label={intl.formatMessage(isPollMultiple ? messages.switchToSingle : messages.switchToMultiple)}
+            title={intl.formatMessage(
+              isPollMultiple
+                ? messages.switchToSingle
+                : messages.switchToMultiple,
+            )}
+            aria-label={intl.formatMessage(
+              isPollMultiple
+                ? messages.switchToSingle
+                : messages.switchToMultiple,
+            )}
           />
 
           <AutosuggestInput
-            placeholder={intl.formatMessage(messages.option_placeholder, { number: index + 1 })}
+            placeholder={intl.formatMessage(messages.option_placeholder, {
+              number: index + 1,
+            })}
             maxLength={50}
             value={title}
             lang={lang}
@@ -108,18 +147,21 @@ class OptionIntl extends PureComponent {
         </label>
 
         <div className='poll__cancel'>
-          <IconButton disabled={index <= 1} title={intl.formatMessage(messages.remove_option)} icon='times' onClick={this.handleOptionRemove} />
+          <IconButton
+            disabled={index <= 1}
+            title={intl.formatMessage(messages.remove_option)}
+            icon='times'
+            onClick={this.handleOptionRemove}
+          />
         </div>
       </li>
     );
   }
-
 }
 
 const Option = injectIntl(OptionIntl);
 
 class PollForm extends ImmutablePureComponent {
-
   static propTypes = {
     options: ImmutablePropTypes.list,
     lang: PropTypes.string,
@@ -140,7 +182,7 @@ class PollForm extends ImmutablePureComponent {
     this.props.onAddOption('');
   };
 
-  handleSelectDuration = e => {
+  handleSelectDuration = (e) => {
     this.props.onChangeSettings(e.target.value, this.props.isMultiple);
   };
 
@@ -148,8 +190,17 @@ class PollForm extends ImmutablePureComponent {
     this.props.onChangeSettings(this.props.expiresIn, !this.props.isMultiple);
   };
 
-  render () {
-    const { options, lang, expiresIn, isMultiple, onChangeOption, onRemoveOption, intl, ...other } = this.props;
+  render() {
+    const {
+      options,
+      lang,
+      expiresIn,
+      isMultiple,
+      onChangeOption,
+      onRemoveOption,
+      intl,
+      ...other
+    } = this.props;
 
     if (!options) {
       return null;
@@ -160,28 +211,63 @@ class PollForm extends ImmutablePureComponent {
     return (
       <div className='compose-form__poll-wrapper'>
         <ul>
-          {options.map((title, i) => <Option title={title} lang={lang} key={i} index={i} onChange={onChangeOption} onRemove={onRemoveOption} isPollMultiple={isMultiple} onToggleMultiple={this.handleToggleMultiple} autoFocus={i === autoFocusIndex} {...other} />)}
+          {options.map((title, i) => (
+            <Option
+              title={title}
+              lang={lang}
+              key={i}
+              index={i}
+              onChange={onChangeOption}
+              onRemove={onRemoveOption}
+              isPollMultiple={isMultiple}
+              onToggleMultiple={this.handleToggleMultiple}
+              autoFocus={i === autoFocusIndex}
+              {...other}
+            />
+          ))}
         </ul>
 
         <div className='poll__footer'>
-          <button type='button' disabled={options.size >= 4} className='button button-secondary' onClick={this.handleAddOption}><Icon id='plus' /> <FormattedMessage {...messages.add_option} /></button>
+          <button
+            type='button'
+            disabled={options.size >= 4}
+            className='button button-secondary'
+            onClick={this.handleAddOption}
+          >
+            <Icon id='plus' /> <FormattedMessage {...messages.add_option} />
+          </button>
 
           {/* eslint-disable-next-line jsx-a11y/no-onchange */}
           <select value={expiresIn} onChange={this.handleSelectDuration}>
-            <option value={300}>{intl.formatMessage(messages.minutes, { number: 5 })}</option>
-            <option value={1800}>{intl.formatMessage(messages.minutes, { number: 30 })}</option>
-            <option value={3600}>{intl.formatMessage(messages.hours, { number: 1 })}</option>
-            <option value={21600}>{intl.formatMessage(messages.hours, { number: 6 })}</option>
-            <option value={43200}>{intl.formatMessage(messages.hours, { number: 12 })}</option>
-            <option value={86400}>{intl.formatMessage(messages.days, { number: 1 })}</option>
-            <option value={259200}>{intl.formatMessage(messages.days, { number: 3 })}</option>
-            <option value={604800}>{intl.formatMessage(messages.days, { number: 7 })}</option>
+            <option value={300}>
+              {intl.formatMessage(messages.minutes, { number: 5 })}
+            </option>
+            <option value={1800}>
+              {intl.formatMessage(messages.minutes, { number: 30 })}
+            </option>
+            <option value={3600}>
+              {intl.formatMessage(messages.hours, { number: 1 })}
+            </option>
+            <option value={21600}>
+              {intl.formatMessage(messages.hours, { number: 6 })}
+            </option>
+            <option value={43200}>
+              {intl.formatMessage(messages.hours, { number: 12 })}
+            </option>
+            <option value={86400}>
+              {intl.formatMessage(messages.days, { number: 1 })}
+            </option>
+            <option value={259200}>
+              {intl.formatMessage(messages.days, { number: 3 })}
+            </option>
+            <option value={604800}>
+              {intl.formatMessage(messages.days, { number: 7 })}
+            </option>
           </select>
         </div>
       </div>
     );
   }
-
 }
 
 export default injectIntl(PollForm);

--- a/app/javascript/mastodon/features/compose/components/privacy_dropdown.jsx
+++ b/app/javascript/mastodon/features/compose/components/privacy_dropdown.jsx
@@ -8,7 +8,7 @@ import classNames from 'classnames';
 import { supportsPassiveEvents } from 'detect-passive-events';
 import Overlay from 'react-overlays/Overlay';
 
-import { Icon }  from 'mastodon/components/icon';
+import { Icon } from 'mastodon/components/icon';
 
 import { IconButton } from '../../../components/icon_button';
 
@@ -16,18 +16,37 @@ const messages = defineMessages({
   public_short: { id: 'privacy.public.short', defaultMessage: 'Public' },
   public_long: { id: 'privacy.public.long', defaultMessage: 'Visible for all' },
   unlisted_short: { id: 'privacy.unlisted.short', defaultMessage: 'Unlisted' },
-  unlisted_long: { id: 'privacy.unlisted.long', defaultMessage: 'Visible for all, but opted-out of discovery features' },
-  private_short: { id: 'privacy.private.short', defaultMessage: 'Followers only' },
-  private_long: { id: 'privacy.private.long', defaultMessage: 'Visible for followers only' },
-  direct_short: { id: 'privacy.direct.short', defaultMessage: 'Mentioned people only' },
-  direct_long: { id: 'privacy.direct.long', defaultMessage: 'Visible for mentioned users only' },
-  change_privacy: { id: 'privacy.change', defaultMessage: 'Adjust status privacy' },
+  unlisted_long: {
+    id: 'privacy.unlisted.long',
+    defaultMessage: 'Visible for all, but opted-out of discovery features',
+  },
+  private_short: {
+    id: 'privacy.private.short',
+    defaultMessage: 'Followers only',
+  },
+  private_long: {
+    id: 'privacy.private.long',
+    defaultMessage: 'Visible for followers only',
+  },
+  direct_short: {
+    id: 'privacy.direct.short',
+    defaultMessage: 'Mentioned people only',
+  },
+  direct_long: {
+    id: 'privacy.direct.long',
+    defaultMessage: 'Visible for mentioned users only',
+  },
+  change_privacy: {
+    id: 'privacy.change',
+    defaultMessage: 'Adjust status privacy',
+  },
 });
 
-const listenerOptions = supportsPassiveEvents ? { passive: true, capture: true } : true;
+const listenerOptions = supportsPassiveEvents
+  ? { passive: true, capture: true }
+  : true;
 
 class PrivacyDropdownMenu extends PureComponent {
-
   static propTypes = {
     style: PropTypes.object,
     items: PropTypes.array.isRequired,
@@ -36,47 +55,47 @@ class PrivacyDropdownMenu extends PureComponent {
     onChange: PropTypes.func.isRequired,
   };
 
-  handleDocumentClick = e => {
+  handleDocumentClick = (e) => {
     if (this.node && !this.node.contains(e.target)) {
       this.props.onClose();
       e.stopPropagation();
     }
   };
 
-  handleKeyDown = e => {
+  handleKeyDown = (e) => {
     const { items } = this.props;
     const value = e.currentTarget.getAttribute('data-index');
-    const index = items.findIndex(item => {
-      return (item.value === value);
+    const index = items.findIndex((item) => {
+      return item.value === value;
     });
     let element = null;
 
-    switch(e.key) {
-    case 'Escape':
-      this.props.onClose();
-      break;
-    case 'Enter':
-      this.handleClick(e);
-      break;
-    case 'ArrowDown':
-      element = this.node.childNodes[index + 1] || this.node.firstChild;
-      break;
-    case 'ArrowUp':
-      element = this.node.childNodes[index - 1] || this.node.lastChild;
-      break;
-    case 'Tab':
-      if (e.shiftKey) {
-        element = this.node.childNodes[index - 1] || this.node.lastChild;
-      } else {
+    switch (e.key) {
+      case 'Escape':
+        this.props.onClose();
+        break;
+      case 'Enter':
+        this.handleClick(e);
+        break;
+      case 'ArrowDown':
         element = this.node.childNodes[index + 1] || this.node.firstChild;
-      }
-      break;
-    case 'Home':
-      element = this.node.firstChild;
-      break;
-    case 'End':
-      element = this.node.lastChild;
-      break;
+        break;
+      case 'ArrowUp':
+        element = this.node.childNodes[index - 1] || this.node.lastChild;
+        break;
+      case 'Tab':
+        if (e.shiftKey) {
+          element = this.node.childNodes[index - 1] || this.node.lastChild;
+        } else {
+          element = this.node.childNodes[index + 1] || this.node.firstChild;
+        }
+        break;
+      case 'Home':
+        element = this.node.firstChild;
+        break;
+      case 'End':
+        element = this.node.lastChild;
+        break;
     }
 
     if (element) {
@@ -87,7 +106,7 @@ class PrivacyDropdownMenu extends PureComponent {
     }
   };
 
-  handleClick = e => {
+  handleClick = (e) => {
     const value = e.currentTarget.getAttribute('data-index');
 
     e.preventDefault();
@@ -96,32 +115,56 @@ class PrivacyDropdownMenu extends PureComponent {
     this.props.onChange(value);
   };
 
-  componentDidMount () {
-    document.addEventListener('click', this.handleDocumentClick, { capture: true });
-    document.addEventListener('touchend', this.handleDocumentClick, listenerOptions);
+  componentDidMount() {
+    document.addEventListener('click', this.handleDocumentClick, {
+      capture: true,
+    });
+    document.addEventListener(
+      'touchend',
+      this.handleDocumentClick,
+      listenerOptions,
+    );
     if (this.focusedItem) this.focusedItem.focus({ preventScroll: true });
   }
 
-  componentWillUnmount () {
-    document.removeEventListener('click', this.handleDocumentClick, { capture: true });
-    document.removeEventListener('touchend', this.handleDocumentClick, listenerOptions);
+  componentWillUnmount() {
+    document.removeEventListener('click', this.handleDocumentClick, {
+      capture: true,
+    });
+    document.removeEventListener(
+      'touchend',
+      this.handleDocumentClick,
+      listenerOptions,
+    );
   }
 
-  setRef = c => {
+  setRef = (c) => {
     this.node = c;
   };
 
-  setFocusRef = c => {
+  setFocusRef = (c) => {
     this.focusedItem = c;
   };
 
-  render () {
+  render() {
     const { style, items, value } = this.props;
 
     return (
       <div style={{ ...style }} role='listbox' ref={this.setRef}>
-        {items.map(item => (
-          <div role='option' tabIndex={0} key={item.value} data-index={item.value} onKeyDown={this.handleKeyDown} onClick={this.handleClick} className={classNames('privacy-dropdown__option', { active: item.value === value })} aria-selected={item.value === value} ref={item.value === value ? this.setFocusRef : null}>
+        {items.map((item) => (
+          <div
+            role='option'
+            tabIndex={0}
+            key={item.value}
+            data-index={item.value}
+            onKeyDown={this.handleKeyDown}
+            onClick={this.handleClick}
+            className={classNames('privacy-dropdown__option', {
+              active: item.value === value,
+            })}
+            aria-selected={item.value === value}
+            ref={item.value === value ? this.setFocusRef : null}
+          >
             <div className='privacy-dropdown__option__icon'>
               <Icon id={item.icon} fixedWidth />
             </div>
@@ -135,11 +178,9 @@ class PrivacyDropdownMenu extends PureComponent {
       </div>
     );
   }
-
 }
 
 class PrivacyDropdown extends PureComponent {
-
   static propTypes = {
     isUserTouching: PropTypes.func,
     onModalOpen: PropTypes.func,
@@ -163,7 +204,10 @@ class PrivacyDropdown extends PureComponent {
         this.props.onModalClose();
       } else {
         this.props.onModalOpen({
-          actions: this.options.map(option => ({ ...option, active: option.value === this.props.value })),
+          actions: this.options.map((option) => ({
+            ...option,
+            active: option.value === this.props.value,
+          })),
           onClick: this.handleModalActionClick,
         });
       }
@@ -184,11 +228,11 @@ class PrivacyDropdown extends PureComponent {
     this.props.onChange(value);
   };
 
-  handleKeyDown = e => {
-    switch(e.key) {
-    case 'Escape':
-      this.handleClose();
-      break;
+  handleKeyDown = (e) => {
+    switch (e.key) {
+      case 'Escape':
+        this.handleClose();
+        break;
     }
   };
 
@@ -199,11 +243,11 @@ class PrivacyDropdown extends PureComponent {
   };
 
   handleButtonKeyDown = (e) => {
-    switch(e.key) {
-    case ' ':
-    case 'Enter':
-      this.handleMouseDown();
-      break;
+    switch (e.key) {
+      case ' ':
+      case 'Enter':
+        this.handleMouseDown();
+        break;
     }
   };
 
@@ -214,27 +258,47 @@ class PrivacyDropdown extends PureComponent {
     this.setState({ open: false });
   };
 
-  handleChange = value => {
+  handleChange = (value) => {
     this.props.onChange(value);
   };
 
-  UNSAFE_componentWillMount () {
-    const { intl: { formatMessage } } = this.props;
+  UNSAFE_componentWillMount() {
+    const {
+      intl: { formatMessage },
+    } = this.props;
 
     this.options = [
-      { icon: 'globe', value: 'public', text: formatMessage(messages.public_short), meta: formatMessage(messages.public_long) },
-      { icon: 'unlock', value: 'unlisted', text: formatMessage(messages.unlisted_short), meta: formatMessage(messages.unlisted_long) },
-      { icon: 'lock', value: 'private', text: formatMessage(messages.private_short), meta: formatMessage(messages.private_long) },
+      {
+        icon: 'globe',
+        value: 'public',
+        text: formatMessage(messages.public_short),
+        meta: formatMessage(messages.public_long),
+      },
+      {
+        icon: 'unlock',
+        value: 'unlisted',
+        text: formatMessage(messages.unlisted_short),
+        meta: formatMessage(messages.unlisted_long),
+      },
+      {
+        icon: 'lock',
+        value: 'private',
+        text: formatMessage(messages.private_short),
+        meta: formatMessage(messages.private_long),
+      },
     ];
 
     if (!this.props.noDirect) {
-      this.options.push(
-        { icon: 'at', value: 'direct', text: formatMessage(messages.direct_short), meta: formatMessage(messages.direct_long) },
-      );
+      this.options.push({
+        icon: 'at',
+        value: 'direct',
+        text: formatMessage(messages.direct_short),
+        meta: formatMessage(messages.direct_long),
+      });
     }
   }
 
-  setTargetRef = c => {
+  setTargetRef = (c) => {
     this.target = c;
   };
 
@@ -246,15 +310,25 @@ class PrivacyDropdown extends PureComponent {
     this.setState({ placement: state.placement });
   };
 
-  render () {
+  render() {
     const { value, container, disabled, intl } = this.props;
     const { open, placement } = this.state;
 
-    const valueOption = this.options.find(item => item.value === value);
+    const valueOption = this.options.find((item) => item.value === value);
 
     return (
-      <div className={classNames('privacy-dropdown', placement, { active: open })} onKeyDown={this.handleKeyDown}>
-        <div className={classNames('privacy-dropdown__value', { active: this.options.indexOf(valueOption) === (placement === 'bottom' ? 0 : (this.options.length - 1)) })} ref={this.setTargetRef}>
+      <div
+        className={classNames('privacy-dropdown', placement, { active: open })}
+        onKeyDown={this.handleKeyDown}
+      >
+        <div
+          className={classNames('privacy-dropdown__value', {
+            active:
+              this.options.indexOf(valueOption) ===
+              (placement === 'bottom' ? 0 : this.options.length - 1),
+          })}
+          ref={this.setTargetRef}
+        >
           <IconButton
             className='privacy-dropdown__value-icon'
             icon={valueOption.icon}
@@ -271,10 +345,22 @@ class PrivacyDropdown extends PureComponent {
           />
         </div>
 
-        <Overlay show={open} placement={'bottom'} flip target={this.findTarget} container={container} popperConfig={{ strategy: 'fixed', onFirstUpdate: this.handleOverlayEnter }}>
+        <Overlay
+          show={open}
+          placement={'bottom'}
+          flip
+          target={this.findTarget}
+          container={container}
+          popperConfig={{
+            strategy: 'fixed',
+            onFirstUpdate: this.handleOverlayEnter,
+          }}
+        >
           {({ props, placement }) => (
             <div {...props}>
-              <div className={`dropdown-animation privacy-dropdown__dropdown ${placement}`}>
+              <div
+                className={`dropdown-animation privacy-dropdown__dropdown ${placement}`}
+              >
                 <PrivacyDropdownMenu
                   items={this.options}
                   value={value}
@@ -288,7 +374,6 @@ class PrivacyDropdown extends PureComponent {
       </div>
     );
   }
-
 }
 
 export default injectIntl(PrivacyDropdown);

--- a/app/javascript/mastodon/features/compose/components/reply_indicator.jsx
+++ b/app/javascript/mastodon/features/compose/components/reply_indicator.jsx
@@ -16,7 +16,6 @@ const messages = defineMessages({
 });
 
 class ReplyIndicator extends ImmutablePureComponent {
-
   static contextTypes = {
     router: PropTypes.object,
   };
@@ -34,11 +33,13 @@ class ReplyIndicator extends ImmutablePureComponent {
   handleAccountClick = (e) => {
     if (e.button === 0 && !(e.ctrlKey || e.metaKey)) {
       e.preventDefault();
-      this.context.router.history.push(`/@${this.props.status.getIn(['account', 'acct'])}`);
+      this.context.router.history.push(
+        `/@${this.props.status.getIn(['account', 'acct'])}`,
+      );
     }
   };
 
-  render () {
+  render() {
     const { status, intl } = this.props;
 
     if (!status) {
@@ -50,26 +51,38 @@ class ReplyIndicator extends ImmutablePureComponent {
     return (
       <div className='reply-indicator'>
         <div className='reply-indicator__header'>
-          <div className='reply-indicator__cancel'><IconButton title={intl.formatMessage(messages.cancel)} icon='times' onClick={this.handleClick} inverted /></div>
+          <div className='reply-indicator__cancel'>
+            <IconButton
+              title={intl.formatMessage(messages.cancel)}
+              icon='times'
+              onClick={this.handleClick}
+              inverted
+            />
+          </div>
 
-          <a href={`/@${status.getIn(['account', 'acct'])}`} onClick={this.handleAccountClick} className='reply-indicator__display-name'>
-            <div className='reply-indicator__display-avatar'><Avatar account={status.get('account')} size={24} /></div>
+          <a
+            href={`/@${status.getIn(['account', 'acct'])}`}
+            onClick={this.handleAccountClick}
+            className='reply-indicator__display-name'
+          >
+            <div className='reply-indicator__display-avatar'>
+              <Avatar account={status.get('account')} size={24} />
+            </div>
             <DisplayName account={status.get('account')} />
           </a>
         </div>
 
-        <div className='reply-indicator__content translate' dangerouslySetInnerHTML={content} />
+        <div
+          className='reply-indicator__content translate'
+          dangerouslySetInnerHTML={content}
+        />
 
         {status.get('media_attachments').size > 0 && (
-          <AttachmentList
-            compact
-            media={status.get('media_attachments')}
-          />
+          <AttachmentList compact media={status.get('media_attachments')} />
         )}
       </div>
     );
   }
-
 }
 
 export default injectIntl(ReplyIndicator);

--- a/app/javascript/mastodon/features/compose/components/search.jsx
+++ b/app/javascript/mastodon/features/compose/components/search.jsx
@@ -1,34 +1,41 @@
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 
-import { defineMessages, injectIntl, FormattedMessage, FormattedList } from 'react-intl';
+import {
+  defineMessages,
+  injectIntl,
+  FormattedMessage,
+  FormattedList,
+} from 'react-intl';
 
 import classNames from 'classnames';
 
 import ImmutablePropTypes from 'react-immutable-proptypes';
 
-import { Icon }  from 'mastodon/components/icon';
+import { Icon } from 'mastodon/components/icon';
 import { domain, searchEnabled } from 'mastodon/initial_state';
 import { HASHTAG_REGEX } from 'mastodon/utils/hashtags';
 
 const messages = defineMessages({
   placeholder: { id: 'search.placeholder', defaultMessage: 'Search' },
-  placeholderSignedIn: { id: 'search.search_or_paste', defaultMessage: 'Search or paste URL' },
+  placeholderSignedIn: {
+    id: 'search.search_or_paste',
+    defaultMessage: 'Search or paste URL',
+  },
 });
 
-const labelForRecentSearch = search => {
-  switch(search.get('type')) {
-  case 'account':
-    return `@${search.get('q')}`;
-  case 'hashtag':
-    return `#${search.get('q')}`;
-  default:
-    return search.get('q');
+const labelForRecentSearch = (search) => {
+  switch (search.get('type')) {
+    case 'account':
+      return `@${search.get('q')}`;
+    case 'hashtag':
+      return `#${search.get('q')}`;
+    default:
+      return search.get('q');
   }
 };
 
 class Search extends PureComponent {
-
   static contextTypes = {
     router: PropTypes.object.isRequired,
     identity: PropTypes.object.isRequired,
@@ -57,17 +64,120 @@ class Search extends PureComponent {
   };
 
   defaultOptions = [
-    { label: <><mark>has:</mark> <FormattedList type='disjunction' value={['media', 'poll', 'embed']} /></>, action: e => { e.preventDefault(); this._insertText('has:') } },
-    { label: <><mark>is:</mark> <FormattedList type='disjunction' value={['reply', 'sensitive']} /></>, action: e => { e.preventDefault(); this._insertText('is:') } },
-    { label: <><mark>language:</mark> <FormattedMessage id='search_popout.language_code' defaultMessage='ISO language code' /></>, action: e => { e.preventDefault(); this._insertText('language:') } },
-    { label: <><mark>from:</mark> <FormattedMessage id='search_popout.user' defaultMessage='user' /></>, action: e => { e.preventDefault(); this._insertText('from:') } },
-    { label: <><mark>before:</mark> <FormattedMessage id='search_popout.specific_date' defaultMessage='specific date' /></>, action: e => { e.preventDefault(); this._insertText('before:') } },
-    { label: <><mark>during:</mark> <FormattedMessage id='search_popout.specific_date' defaultMessage='specific date' /></>, action: e => { e.preventDefault(); this._insertText('during:') } },
-    { label: <><mark>after:</mark> <FormattedMessage id='search_popout.specific_date' defaultMessage='specific date' /></>, action: e => { e.preventDefault(); this._insertText('after:') } },
-    { label: <><mark>in:</mark> <FormattedList type='disjunction' value={['all', 'library']} /></>, action: e => { e.preventDefault(); this._insertText('in:') } }
+    {
+      label: (
+        <>
+          <mark>has:</mark>{' '}
+          <FormattedList
+            type='disjunction'
+            value={['media', 'poll', 'embed']}
+          />
+        </>
+      ),
+      action: (e) => {
+        e.preventDefault();
+        this._insertText('has:');
+      },
+    },
+    {
+      label: (
+        <>
+          <mark>is:</mark>{' '}
+          <FormattedList type='disjunction' value={['reply', 'sensitive']} />
+        </>
+      ),
+      action: (e) => {
+        e.preventDefault();
+        this._insertText('is:');
+      },
+    },
+    {
+      label: (
+        <>
+          <mark>language:</mark>{' '}
+          <FormattedMessage
+            id='search_popout.language_code'
+            defaultMessage='ISO language code'
+          />
+        </>
+      ),
+      action: (e) => {
+        e.preventDefault();
+        this._insertText('language:');
+      },
+    },
+    {
+      label: (
+        <>
+          <mark>from:</mark>{' '}
+          <FormattedMessage id='search_popout.user' defaultMessage='user' />
+        </>
+      ),
+      action: (e) => {
+        e.preventDefault();
+        this._insertText('from:');
+      },
+    },
+    {
+      label: (
+        <>
+          <mark>before:</mark>{' '}
+          <FormattedMessage
+            id='search_popout.specific_date'
+            defaultMessage='specific date'
+          />
+        </>
+      ),
+      action: (e) => {
+        e.preventDefault();
+        this._insertText('before:');
+      },
+    },
+    {
+      label: (
+        <>
+          <mark>during:</mark>{' '}
+          <FormattedMessage
+            id='search_popout.specific_date'
+            defaultMessage='specific date'
+          />
+        </>
+      ),
+      action: (e) => {
+        e.preventDefault();
+        this._insertText('during:');
+      },
+    },
+    {
+      label: (
+        <>
+          <mark>after:</mark>{' '}
+          <FormattedMessage
+            id='search_popout.specific_date'
+            defaultMessage='specific date'
+          />
+        </>
+      ),
+      action: (e) => {
+        e.preventDefault();
+        this._insertText('after:');
+      },
+    },
+    {
+      label: (
+        <>
+          <mark>in:</mark>{' '}
+          <FormattedList type='disjunction' value={['all', 'library']} />
+        </>
+      ),
+      action: (e) => {
+        e.preventDefault();
+        this._insertText('in:');
+      },
+    },
   ];
 
-  setRef = c => {
+  setRef = (c) => {
     this.searchForm = c;
   };
 
@@ -79,7 +189,7 @@ class Search extends PureComponent {
     this._calculateOptions(target.value);
   };
 
-  handleClear = e => {
+  handleClear = (e) => {
     const { value, submitted, onClear } = this.props;
 
     e.preventDefault();
@@ -92,51 +202,55 @@ class Search extends PureComponent {
 
   handleKeyDown = (e) => {
     const { selectedOption } = this.state;
-    const options = searchEnabled ? this._getOptions().concat(this.defaultOptions) : this._getOptions();
+    const options = searchEnabled
+      ? this._getOptions().concat(this.defaultOptions)
+      : this._getOptions();
 
-    switch(e.key) {
-    case 'Escape':
-      e.preventDefault();
-      this._unfocus();
+    switch (e.key) {
+      case 'Escape':
+        e.preventDefault();
+        this._unfocus();
 
-      break;
-    case 'ArrowDown':
-      e.preventDefault();
+        break;
+      case 'ArrowDown':
+        e.preventDefault();
 
-      if (options.length > 0) {
-        this.setState({ selectedOption: Math.min(selectedOption + 1, options.length - 1) });
-      }
-
-      break;
-    case 'ArrowUp':
-      e.preventDefault();
-
-      if (options.length > 0) {
-        this.setState({ selectedOption: Math.max(selectedOption - 1, -1) });
-      }
-
-      break;
-    case 'Enter':
-      e.preventDefault();
-
-      if (selectedOption === -1) {
-        this._submit();
-      } else if (options.length > 0) {
-        options[selectedOption].action(e);
-      }
-
-      break;
-    case 'Delete':
-      if (selectedOption > -1 && options.length > 0) {
-        const search = options[selectedOption];
-
-        if (typeof search.forget === 'function') {
-          e.preventDefault();
-          search.forget(e);
+        if (options.length > 0) {
+          this.setState({
+            selectedOption: Math.min(selectedOption + 1, options.length - 1),
+          });
         }
-      }
 
-      break;
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+
+        if (options.length > 0) {
+          this.setState({ selectedOption: Math.max(selectedOption - 1, -1) });
+        }
+
+        break;
+      case 'Enter':
+        e.preventDefault();
+
+        if (selectedOption === -1) {
+          this._submit();
+        } else if (options.length > 0) {
+          options[selectedOption].action(e);
+        }
+
+        break;
+      case 'Delete':
+        if (selectedOption > -1 && options.length > 0) {
+          const search = options[selectedOption];
+
+          if (typeof search.forget === 'function') {
+            e.preventDefault();
+            search.forget(e);
+          }
+        }
+
+        break;
     }
   };
 
@@ -149,7 +263,10 @@ class Search extends PureComponent {
     if (this.searchForm && !singleColumn) {
       const { left, right } = this.searchForm.getBoundingClientRect();
 
-      if (left < 0 || right > (window.innerWidth || document.documentElement.clientWidth)) {
+      if (
+        left < 0 ||
+        right > (window.innerWidth || document.documentElement.clientWidth)
+      ) {
         this.searchForm.scrollIntoView();
       }
     }
@@ -197,7 +314,7 @@ class Search extends PureComponent {
     this._submit('accounts');
   };
 
-  handleRecentSearchClick = search => {
+  handleRecentSearchClick = (search) => {
     const { onChange } = this.props;
     const { router } = this.context;
 
@@ -213,17 +330,17 @@ class Search extends PureComponent {
     this._unfocus();
   };
 
-  handleForgetRecentSearchClick = search => {
+  handleForgetRecentSearchClick = (search) => {
     const { onForgetSearchResult } = this.props;
 
     onForgetSearchResult(search.get('q'));
   };
 
-  _unfocus () {
+  _unfocus() {
     document.querySelector('.ui').parentElement.focus();
   }
 
-  _insertText (text) {
+  _insertText(text) {
     const { value, onChange } = this.props;
 
     if (value === '') {
@@ -235,7 +352,7 @@ class Search extends PureComponent {
     }
   }
 
-  _submit (type) {
+  _submit(type) {
     const { onSubmit, openInRoute, value, onClickSearchResult } = this.props;
     const { router } = this.context;
 
@@ -252,7 +369,7 @@ class Search extends PureComponent {
     this._unfocus();
   }
 
-  _getOptions () {
+  _getOptions() {
     const { options } = this.state;
 
     if (options.length > 0) {
@@ -261,58 +378,110 @@ class Search extends PureComponent {
 
     const { recent } = this.props;
 
-    return recent.toArray().map(search => ({
+    return recent.toArray().map((search) => ({
       label: labelForRecentSearch(search),
 
       action: () => this.handleRecentSearchClick(search),
 
-      forget: e => {
+      forget: (e) => {
         e.stopPropagation();
         this.handleForgetRecentSearchClick(search);
       },
     }));
   }
 
-  _calculateOptions (value) {
+  _calculateOptions(value) {
     const trimmedValue = value.trim();
     const options = [];
 
     if (trimmedValue.length > 0) {
-      const couldBeURL = trimmedValue.startsWith('https://') && !trimmedValue.includes(' ');
+      const couldBeURL =
+        trimmedValue.startsWith('https://') && !trimmedValue.includes(' ');
 
       if (couldBeURL) {
-        options.push({ key: 'open-url', label: <FormattedMessage id='search.quick_action.open_url' defaultMessage='Open URL in Mastodon' />, action: this.handleURLClick });
+        options.push({
+          key: 'open-url',
+          label: (
+            <FormattedMessage
+              id='search.quick_action.open_url'
+              defaultMessage='Open URL in Mastodon'
+            />
+          ),
+          action: this.handleURLClick,
+        });
       }
 
-      const couldBeHashtag = (trimmedValue.startsWith('#') && trimmedValue.length > 1) || trimmedValue.match(HASHTAG_REGEX);
+      const couldBeHashtag =
+        (trimmedValue.startsWith('#') && trimmedValue.length > 1) ||
+        trimmedValue.match(HASHTAG_REGEX);
 
       if (couldBeHashtag) {
-        options.push({ key: 'go-to-hashtag', label: <FormattedMessage id='search.quick_action.go_to_hashtag' defaultMessage='Go to hashtag {x}' values={{ x: <mark>#{trimmedValue.replace(/^#/, '')}</mark> }} />, action: this.handleHashtagClick });
+        options.push({
+          key: 'go-to-hashtag',
+          label: (
+            <FormattedMessage
+              id='search.quick_action.go_to_hashtag'
+              defaultMessage='Go to hashtag {x}'
+              values={{ x: <mark>#{trimmedValue.replace(/^#/, '')}</mark> }}
+            />
+          ),
+          action: this.handleHashtagClick,
+        });
       }
 
       const couldBeUsername = trimmedValue.match(/^@?[a-z0-9_-]+(@[^\s]+)?$/i);
 
       if (couldBeUsername) {
-        options.push({ key: 'go-to-account', label: <FormattedMessage id='search.quick_action.go_to_account' defaultMessage='Go to profile {x}' values={{ x: <mark>@{trimmedValue.replace(/^@/, '')}</mark> }} />, action: this.handleAccountClick });
+        options.push({
+          key: 'go-to-account',
+          label: (
+            <FormattedMessage
+              id='search.quick_action.go_to_account'
+              defaultMessage='Go to profile {x}'
+              values={{ x: <mark>@{trimmedValue.replace(/^@/, '')}</mark> }}
+            />
+          ),
+          action: this.handleAccountClick,
+        });
       }
 
       const couldBeStatusSearch = searchEnabled;
 
       if (couldBeStatusSearch) {
-        options.push({ key: 'status-search', label: <FormattedMessage id='search.quick_action.status_search' defaultMessage='Posts matching {x}' values={{ x: <mark>{trimmedValue}</mark> }} />, action: this.handleStatusSearch });
+        options.push({
+          key: 'status-search',
+          label: (
+            <FormattedMessage
+              id='search.quick_action.status_search'
+              defaultMessage='Posts matching {x}'
+              values={{ x: <mark>{trimmedValue}</mark> }}
+            />
+          ),
+          action: this.handleStatusSearch,
+        });
       }
 
       const couldBeUserSearch = true;
 
       if (couldBeUserSearch) {
-        options.push({ key: 'account-search', label: <FormattedMessage id='search.quick_action.account_search' defaultMessage='Profiles matching {x}' values={{ x: <mark>{trimmedValue}</mark> }} />, action: this.handleAccountSearch });
+        options.push({
+          key: 'account-search',
+          label: (
+            <FormattedMessage
+              id='search.quick_action.account_search'
+              defaultMessage='Profiles matching {x}'
+              values={{ x: <mark>{trimmedValue}</mark> }}
+            />
+          ),
+          action: this.handleAccountSearch,
+        });
       }
     }
 
     this.setState({ options });
   }
 
-  render () {
+  render() {
     const { intl, value, submitted, recent } = this.props;
     const { expanded, options, selectedOption } = this.state;
     const { signedIn } = this.context.identity;
@@ -325,8 +494,12 @@ class Search extends PureComponent {
           ref={this.setRef}
           className='search__input'
           type='text'
-          placeholder={intl.formatMessage(signedIn ? messages.placeholderSignedIn : messages.placeholder)}
-          aria-label={intl.formatMessage(signedIn ? messages.placeholderSignedIn : messages.placeholder)}
+          placeholder={intl.formatMessage(
+            signedIn ? messages.placeholderSignedIn : messages.placeholder,
+          )}
+          aria-label={intl.formatMessage(
+            signedIn ? messages.placeholderSignedIn : messages.placeholder,
+          )}
           value={value}
           onChange={this.handleChange}
           onKeyDown={this.handleKeyDown}
@@ -334,25 +507,53 @@ class Search extends PureComponent {
           onBlur={this.handleBlur}
         />
 
-        <div role='button' tabIndex={0} className='search__icon' onClick={this.handleClear}>
+        <div
+          role='button'
+          tabIndex={0}
+          className='search__icon'
+          onClick={this.handleClear}
+        >
           <Icon id='search' className={hasValue ? '' : 'active'} />
-          <Icon id='times-circle' className={hasValue ? 'active' : ''} aria-label={intl.formatMessage(messages.placeholder)} />
+          <Icon
+            id='times-circle'
+            className={hasValue ? 'active' : ''}
+            aria-label={intl.formatMessage(messages.placeholder)}
+          />
         </div>
 
         <div className='search__popout'>
           {options.length === 0 && (
             <>
-              <h4><FormattedMessage id='search_popout.recent' defaultMessage='Recent searches' /></h4>
+              <h4>
+                <FormattedMessage
+                  id='search_popout.recent'
+                  defaultMessage='Recent searches'
+                />
+              </h4>
 
               <div className='search__popout__menu'>
-                {recent.size > 0 ? this._getOptions().map(({ label, action, forget }, i) => (
-                  <button key={label} onMouseDown={action} className={classNames('search__popout__menu__item search__popout__menu__item--flex', { selected: selectedOption === i })}>
-                    <span>{label}</span>
-                    <button className='icon-button' onMouseDown={forget}><Icon id='times' /></button>
-                  </button>
-                )) : (
+                {recent.size > 0 ? (
+                  this._getOptions().map(({ label, action, forget }, i) => (
+                    <button
+                      key={label}
+                      onMouseDown={action}
+                      className={classNames(
+                        'search__popout__menu__item search__popout__menu__item--flex',
+                        { selected: selectedOption === i },
+                      )}
+                    >
+                      <span>{label}</span>
+                      <button className='icon-button' onMouseDown={forget}>
+                        <Icon id='times' />
+                      </button>
+                    </button>
+                  ))
+                ) : (
                   <div className='search__popout__menu__message'>
-                    <FormattedMessage id='search.no_recent_searches' defaultMessage='No recent searches' />
+                    <FormattedMessage
+                      id='search.no_recent_searches'
+                      defaultMessage='No recent searches'
+                    />
                   </div>
                 )}
               </div>
@@ -361,11 +562,22 @@ class Search extends PureComponent {
 
           {options.length > 0 && (
             <>
-              <h4><FormattedMessage id='search_popout.quick_actions' defaultMessage='Quick actions' /></h4>
+              <h4>
+                <FormattedMessage
+                  id='search_popout.quick_actions'
+                  defaultMessage='Quick actions'
+                />
+              </h4>
 
               <div className='search__popout__menu'>
                 {options.map(({ key, label, action }, i) => (
-                  <button key={key} onMouseDown={action} className={classNames('search__popout__menu__item', { selected: selectedOption === i })}>
+                  <button
+                    key={key}
+                    onMouseDown={action}
+                    className={classNames('search__popout__menu__item', {
+                      selected: selectedOption === i,
+                    })}
+                  >
                     {label}
                   </button>
                 ))}
@@ -373,26 +585,41 @@ class Search extends PureComponent {
             </>
           )}
 
-          <h4><FormattedMessage id='search_popout.options' defaultMessage='Search options' /></h4>
+          <h4>
+            <FormattedMessage
+              id='search_popout.options'
+              defaultMessage='Search options'
+            />
+          </h4>
 
           {searchEnabled ? (
             <div className='search__popout__menu'>
               {this.defaultOptions.map(({ key, label, action }, i) => (
-                <button key={key} onMouseDown={action} className={classNames('search__popout__menu__item', { selected: selectedOption === ((options.length || recent.size) + i) })}>
+                <button
+                  key={key}
+                  onMouseDown={action}
+                  className={classNames('search__popout__menu__item', {
+                    selected:
+                      selectedOption === (options.length || recent.size) + i,
+                  })}
+                >
                   {label}
                 </button>
               ))}
             </div>
           ) : (
             <div className='search__popout__menu__message'>
-              <FormattedMessage id='search_popout.full_text_search_disabled_message' defaultMessage='Not available on {domain}.' values={{ domain }} />
+              <FormattedMessage
+                id='search_popout.full_text_search_disabled_message'
+                defaultMessage='Not available on {domain}.'
+                values={{ domain }}
+              />
             </div>
           )}
         </div>
       </div>
     );
   }
-
 }
 
 export default injectIntl(Search);

--- a/app/javascript/mastodon/features/compose/components/search_results.jsx
+++ b/app/javascript/mastodon/features/compose/components/search_results.jsx
@@ -5,7 +5,7 @@ import { FormattedMessage } from 'react-intl';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 
-import { Icon }  from 'mastodon/components/icon';
+import { Icon } from 'mastodon/components/icon';
 import { LoadMore } from 'mastodon/components/load_more';
 import { SearchSection } from 'mastodon/features/explore/components/search_section';
 
@@ -15,7 +15,7 @@ import StatusContainer from '../../../containers/status_container';
 
 const INITIAL_PAGE_LIMIT = 10;
 
-const withoutLastResult = list => {
+const withoutLastResult = (list) => {
   if (list.size > INITIAL_PAGE_LIMIT && list.size % INITIAL_PAGE_LIMIT === 1) {
     return list.skipLast(1);
   } else {
@@ -24,7 +24,6 @@ const withoutLastResult = list => {
 };
 
 class SearchResults extends ImmutablePureComponent {
-
   static propTypes = {
     results: ImmutablePropTypes.map.isRequired,
     expandSearch: PropTypes.func.isRequired,
@@ -37,44 +36,91 @@ class SearchResults extends ImmutablePureComponent {
 
   handleLoadMoreHashtags = () => this.props.expandSearch('hashtags');
 
-  render () {
+  render() {
     const { results } = this.props;
 
     let accounts, statuses, hashtags;
 
     if (results.get('accounts') && results.get('accounts').size > 0) {
       accounts = (
-        <SearchSection title={<><Icon id='users' fixedWidth /><FormattedMessage id='search_results.accounts' defaultMessage='Profiles' /></>}>
-          {withoutLastResult(results.get('accounts')).map(accountId => <AccountContainer key={accountId} id={accountId} />)}
-          {(results.get('accounts').size > INITIAL_PAGE_LIMIT && results.get('accounts').size % INITIAL_PAGE_LIMIT === 1) && <LoadMore visible onClick={this.handleLoadMoreAccounts} />}
+        <SearchSection
+          title={
+            <>
+              <Icon id='users' fixedWidth />
+              <FormattedMessage
+                id='search_results.accounts'
+                defaultMessage='Profiles'
+              />
+            </>
+          }
+        >
+          {withoutLastResult(results.get('accounts')).map((accountId) => (
+            <AccountContainer key={accountId} id={accountId} />
+          ))}
+          {results.get('accounts').size > INITIAL_PAGE_LIMIT &&
+            results.get('accounts').size % INITIAL_PAGE_LIMIT === 1 && (
+              <LoadMore visible onClick={this.handleLoadMoreAccounts} />
+            )}
         </SearchSection>
       );
     }
 
     if (results.get('hashtags') && results.get('hashtags').size > 0) {
       hashtags = (
-        <SearchSection title={<><Icon id='hashtag' fixedWidth /><FormattedMessage id='search_results.hashtags' defaultMessage='Hashtags' /></>}>
-          {withoutLastResult(results.get('hashtags')).map(hashtag => <Hashtag key={hashtag.get('name')} hashtag={hashtag} />)}
-          {(results.get('hashtags').size > INITIAL_PAGE_LIMIT && results.get('hashtags').size % INITIAL_PAGE_LIMIT === 1) && <LoadMore visible onClick={this.handleLoadMoreHashtags} />}
+        <SearchSection
+          title={
+            <>
+              <Icon id='hashtag' fixedWidth />
+              <FormattedMessage
+                id='search_results.hashtags'
+                defaultMessage='Hashtags'
+              />
+            </>
+          }
+        >
+          {withoutLastResult(results.get('hashtags')).map((hashtag) => (
+            <Hashtag key={hashtag.get('name')} hashtag={hashtag} />
+          ))}
+          {results.get('hashtags').size > INITIAL_PAGE_LIMIT &&
+            results.get('hashtags').size % INITIAL_PAGE_LIMIT === 1 && (
+              <LoadMore visible onClick={this.handleLoadMoreHashtags} />
+            )}
         </SearchSection>
       );
     }
 
     if (results.get('statuses') && results.get('statuses').size > 0) {
       statuses = (
-        <SearchSection title={<><Icon id='quote-right' fixedWidth /><FormattedMessage id='search_results.statuses' defaultMessage='Posts' /></>}>
-          {withoutLastResult(results.get('statuses')).map(statusId => <StatusContainer key={statusId} id={statusId} />)}
-          {(results.get('statuses').size > INITIAL_PAGE_LIMIT && results.get('statuses').size % INITIAL_PAGE_LIMIT === 1) && <LoadMore visible onClick={this.handleLoadMoreStatuses} />}
+        <SearchSection
+          title={
+            <>
+              <Icon id='quote-right' fixedWidth />
+              <FormattedMessage
+                id='search_results.statuses'
+                defaultMessage='Posts'
+              />
+            </>
+          }
+        >
+          {withoutLastResult(results.get('statuses')).map((statusId) => (
+            <StatusContainer key={statusId} id={statusId} />
+          ))}
+          {results.get('statuses').size > INITIAL_PAGE_LIMIT &&
+            results.get('statuses').size % INITIAL_PAGE_LIMIT === 1 && (
+              <LoadMore visible onClick={this.handleLoadMoreStatuses} />
+            )}
         </SearchSection>
       );
     }
-
 
     return (
       <div className='search-results'>
         <div className='search-results__header'>
           <Icon id='search' fixedWidth />
-          <FormattedMessage id='explore.search_results' defaultMessage='Search results' />
+          <FormattedMessage
+            id='explore.search_results'
+            defaultMessage='Search results'
+          />
         </div>
 
         {accounts}
@@ -83,7 +129,6 @@ class SearchResults extends ImmutablePureComponent {
       </div>
     );
   }
-
 }
 
 export default SearchResults;

--- a/app/javascript/mastodon/features/compose/components/text_icon_button.jsx
+++ b/app/javascript/mastodon/features/compose/components/text_icon_button.jsx
@@ -8,7 +8,6 @@ const iconStyle = {
 };
 
 export default class TextIconButton extends PureComponent {
-
   static propTypes = {
     label: PropTypes.string.isRequired,
     title: PropTypes.string,
@@ -17,7 +16,7 @@ export default class TextIconButton extends PureComponent {
     ariaControls: PropTypes.string,
   };
 
-  render () {
+  render() {
     const { label, title, active, ariaControls } = this.props;
 
     return (
@@ -28,11 +27,11 @@ export default class TextIconButton extends PureComponent {
         className={`text-icon-button ${active ? 'active' : ''}`}
         aria-expanded={active}
         onClick={this.props.onClick}
-        aria-controls={ariaControls} style={iconStyle}
+        aria-controls={ariaControls}
+        style={iconStyle}
       >
         {label}
       </button>
     );
   }
-
 }

--- a/app/javascript/mastodon/features/compose/components/upload.jsx
+++ b/app/javascript/mastodon/features/compose/components/upload.jsx
@@ -7,12 +7,11 @@ import ImmutablePureComponent from 'react-immutable-pure-component';
 
 import spring from 'react-motion/lib/spring';
 
-import { Icon }  from 'mastodon/components/icon';
+import { Icon } from 'mastodon/components/icon';
 
 import Motion from '../../ui/util/optional_motion';
 
 export default class Upload extends ImmutablePureComponent {
-
   static contextTypes = {
     router: PropTypes.object,
   };
@@ -23,17 +22,17 @@ export default class Upload extends ImmutablePureComponent {
     onOpenFocalPoint: PropTypes.func.isRequired,
   };
 
-  handleUndoClick = e => {
+  handleUndoClick = (e) => {
     e.stopPropagation();
     this.props.onUndo(this.props.media.get('id'));
   };
 
-  handleFocalPointClick = e => {
+  handleFocalPointClick = (e) => {
     e.stopPropagation();
     this.props.onOpenFocalPoint(this.props.media.get('id'));
   };
 
-  render () {
+  render() {
     const { media } = this.props;
 
     if (!media) {
@@ -42,22 +41,62 @@ export default class Upload extends ImmutablePureComponent {
 
     const focusX = media.getIn(['meta', 'focus', 'x']);
     const focusY = media.getIn(['meta', 'focus', 'y']);
-    const x = ((focusX /  2) + .5) * 100;
-    const y = ((focusY / -2) + .5) * 100;
+    const x = (focusX / 2 + 0.5) * 100;
+    const y = (focusY / -2 + 0.5) * 100;
 
     return (
       <div className='compose-form__upload'>
-        <Motion defaultStyle={{ scale: 0.8 }} style={{ scale: spring(1, { stiffness: 180, damping: 12 }) }}>
+        <Motion
+          defaultStyle={{ scale: 0.8 }}
+          style={{ scale: spring(1, { stiffness: 180, damping: 12 }) }}
+        >
           {({ scale }) => (
-            <div className='compose-form__upload-thumbnail' style={{ transform: `scale(${scale})`, backgroundImage: `url(${media.get('preview_url')})`, backgroundPosition: `${x}% ${y}%` }}>
+            <div
+              className='compose-form__upload-thumbnail'
+              style={{
+                transform: `scale(${scale})`,
+                backgroundImage: `url(${media.get('preview_url')})`,
+                backgroundPosition: `${x}% ${y}%`,
+              }}
+            >
               <div className='compose-form__upload__actions'>
-                <button type='button' className='icon-button' onClick={this.handleUndoClick}><Icon id='times' /> <FormattedMessage id='upload_form.undo' defaultMessage='Delete' /></button>
-                <button type='button' className='icon-button' onClick={this.handleFocalPointClick}><Icon id='pencil' /> <FormattedMessage id='upload_form.edit' defaultMessage='Edit' /></button>
+                <button
+                  type='button'
+                  className='icon-button'
+                  onClick={this.handleUndoClick}
+                >
+                  <Icon id='times' />{' '}
+                  <FormattedMessage
+                    id='upload_form.undo'
+                    defaultMessage='Delete'
+                  />
+                </button>
+                <button
+                  type='button'
+                  className='icon-button'
+                  onClick={this.handleFocalPointClick}
+                >
+                  <Icon id='pencil' />{' '}
+                  <FormattedMessage
+                    id='upload_form.edit'
+                    defaultMessage='Edit'
+                  />
+                </button>
               </div>
 
               {(media.get('description') || '').length === 0 && (
                 <div className='compose-form__upload__warning'>
-                  <button type='button' className='icon-button' onClick={this.handleFocalPointClick}><Icon id='info-circle' /> <FormattedMessage id='upload_form.description_missing' defaultMessage='No description added' /></button>
+                  <button
+                    type='button'
+                    className='icon-button'
+                    onClick={this.handleFocalPointClick}
+                  >
+                    <Icon id='info-circle' />{' '}
+                    <FormattedMessage
+                      id='upload_form.description_missing'
+                      defaultMessage='No description added'
+                    />
+                  </button>
                 </div>
               )}
             </div>
@@ -66,5 +105,4 @@ export default class Upload extends ImmutablePureComponent {
       </div>
     );
   }
-
 }

--- a/app/javascript/mastodon/features/compose/components/upload_button.jsx
+++ b/app/javascript/mastodon/features/compose/components/upload_button.jsx
@@ -9,12 +9,18 @@ import { connect } from 'react-redux';
 import { IconButton } from '../../../components/icon_button';
 
 const messages = defineMessages({
-  upload: { id: 'upload_button.label', defaultMessage: 'Add images, a video or an audio file' },
+  upload: {
+    id: 'upload_button.label',
+    defaultMessage: 'Add images, a video or an audio file',
+  },
 });
 
 const makeMapStateToProps = () => {
-  const mapStateToProps = state => ({
-    acceptContentTypes: state.getIn(['media_attachments', 'accept_content_types']),
+  const mapStateToProps = (state) => ({
+    acceptContentTypes: state.getIn([
+      'media_attachments',
+      'accept_content_types',
+    ]),
   });
 
   return mapStateToProps;
@@ -26,7 +32,6 @@ const iconStyle = {
 };
 
 class UploadButton extends ImmutablePureComponent {
-
   static propTypes = {
     disabled: PropTypes.bool,
     unavailable: PropTypes.bool,
@@ -51,8 +56,9 @@ class UploadButton extends ImmutablePureComponent {
     this.fileElement = c;
   };
 
-  render () {
-    const { intl, resetFileKey, unavailable, disabled, acceptContentTypes } = this.props;
+  render() {
+    const { intl, resetFileKey, unavailable, disabled, acceptContentTypes } =
+      this.props;
 
     if (unavailable) {
       return null;
@@ -62,7 +68,16 @@ class UploadButton extends ImmutablePureComponent {
 
     return (
       <div className='compose-form__upload-button'>
-        <IconButton icon='paperclip' title={message} disabled={disabled} onClick={this.handleClick} className='compose-form__upload-button-icon' size={18} inverted style={iconStyle} />
+        <IconButton
+          icon='paperclip'
+          title={message}
+          disabled={disabled}
+          onClick={this.handleClick}
+          className='compose-form__upload-button-icon'
+          size={18}
+          inverted
+          style={iconStyle}
+        />
         <label>
           <span style={{ display: 'none' }}>{message}</span>
           <input
@@ -79,7 +94,6 @@ class UploadButton extends ImmutablePureComponent {
       </div>
     );
   }
-
 }
 
 export default connect(makeMapStateToProps)(injectIntl(UploadButton));

--- a/app/javascript/mastodon/features/compose/components/upload_form.jsx
+++ b/app/javascript/mastodon/features/compose/components/upload_form.jsx
@@ -6,12 +6,11 @@ import UploadContainer from '../containers/upload_container';
 import UploadProgressContainer from '../containers/upload_progress_container';
 
 export default class UploadForm extends ImmutablePureComponent {
-
   static propTypes = {
     mediaIds: ImmutablePropTypes.list.isRequired,
   };
 
-  render () {
+  render() {
     const { mediaIds } = this.props;
 
     return (
@@ -19,7 +18,7 @@ export default class UploadForm extends ImmutablePureComponent {
         <UploadProgressContainer />
 
         <div className='compose-form__uploads-wrapper'>
-          {mediaIds.map(id => (
+          {mediaIds.map((id) => (
             <UploadContainer id={id} key={id} />
           ))}
         </div>
@@ -28,5 +27,4 @@ export default class UploadForm extends ImmutablePureComponent {
       </div>
     );
   }
-
 }

--- a/app/javascript/mastodon/features/compose/components/upload_progress.jsx
+++ b/app/javascript/mastodon/features/compose/components/upload_progress.jsx
@@ -5,19 +5,18 @@ import { FormattedMessage } from 'react-intl';
 
 import spring from 'react-motion/lib/spring';
 
-import { Icon }  from 'mastodon/components/icon';
+import { Icon } from 'mastodon/components/icon';
 
 import Motion from '../../ui/util/optional_motion';
 
 export default class UploadProgress extends PureComponent {
-
   static propTypes = {
     active: PropTypes.bool,
     progress: PropTypes.number,
     isProcessing: PropTypes.bool,
   };
 
-  render () {
+  render() {
     const { active, progress, isProcessing } = this.props;
 
     if (!active) {
@@ -27,9 +26,19 @@ export default class UploadProgress extends PureComponent {
     let message;
 
     if (isProcessing) {
-      message = <FormattedMessage id='upload_progress.processing' defaultMessage='Processing…' />;
+      message = (
+        <FormattedMessage
+          id='upload_progress.processing'
+          defaultMessage='Processing…'
+        />
+      );
     } else {
-      message = <FormattedMessage id='upload_progress.label' defaultMessage='Uploading…' />;
+      message = (
+        <FormattedMessage
+          id='upload_progress.label'
+          defaultMessage='Uploading…'
+        />
+      );
     }
 
     return (
@@ -42,15 +51,20 @@ export default class UploadProgress extends PureComponent {
           {message}
 
           <div className='upload-progress__backdrop'>
-            <Motion defaultStyle={{ width: 0 }} style={{ width: spring(progress) }}>
-              {({ width }) =>
-                <div className='upload-progress__tracker' style={{ width: `${width}%` }} />
-              }
+            <Motion
+              defaultStyle={{ width: 0 }}
+              style={{ width: spring(progress) }}
+            >
+              {({ width }) => (
+                <div
+                  className='upload-progress__tracker'
+                  style={{ width: `${width}%` }}
+                />
+              )}
             </Motion>
           </div>
         </div>
       </div>
     );
   }
-
 }

--- a/app/javascript/mastodon/features/compose/components/warning.jsx
+++ b/app/javascript/mastodon/features/compose/components/warning.jsx
@@ -6,23 +6,34 @@ import spring from 'react-motion/lib/spring';
 import Motion from '../../ui/util/optional_motion';
 
 export default class Warning extends PureComponent {
-
   static propTypes = {
     message: PropTypes.node.isRequired,
   };
 
-  render () {
+  render() {
     const { message } = this.props;
 
     return (
-      <Motion defaultStyle={{ opacity: 0, scaleX: 0.85, scaleY: 0.75 }} style={{ opacity: spring(1, { damping: 35, stiffness: 400 }), scaleX: spring(1, { damping: 35, stiffness: 400 }), scaleY: spring(1, { damping: 35, stiffness: 400 }) }}>
+      <Motion
+        defaultStyle={{ opacity: 0, scaleX: 0.85, scaleY: 0.75 }}
+        style={{
+          opacity: spring(1, { damping: 35, stiffness: 400 }),
+          scaleX: spring(1, { damping: 35, stiffness: 400 }),
+          scaleY: spring(1, { damping: 35, stiffness: 400 }),
+        }}
+      >
         {({ opacity, scaleX, scaleY }) => (
-          <div className='compose-form__warning' style={{ opacity: opacity, transform: `scale(${scaleX}, ${scaleY})` }}>
+          <div
+            className='compose-form__warning'
+            style={{
+              opacity: opacity,
+              transform: `scale(${scaleX}, ${scaleY})`,
+            }}
+          >
             {message}
           </div>
         )}
       </Motion>
     );
   }
-
 }

--- a/app/javascript/mastodon/features/compose/containers/compose_form_container.js
+++ b/app/javascript/mastodon/features/compose/containers/compose_form_container.js
@@ -12,7 +12,7 @@ import {
 } from '../../../actions/compose';
 import ComposeForm from '../components/compose_form';
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   text: state.getIn(['compose', 'text']),
   suggestions: state.getIn(['compose', 'suggestions']),
   spoiler: state.getIn(['compose', 'spoiler']),
@@ -31,39 +31,37 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = (dispatch) => ({
-
-  onChange (text) {
+  onChange(text) {
     dispatch(changeCompose(text));
   },
 
-  onSubmit (router) {
+  onSubmit(router) {
     dispatch(submitCompose(router));
   },
 
-  onClearSuggestions () {
+  onClearSuggestions() {
     dispatch(clearComposeSuggestions());
   },
 
-  onFetchSuggestions (token) {
+  onFetchSuggestions(token) {
     dispatch(fetchComposeSuggestions(token));
   },
 
-  onSuggestionSelected (position, token, suggestion, path) {
+  onSuggestionSelected(position, token, suggestion, path) {
     dispatch(selectComposeSuggestion(position, token, suggestion, path));
   },
 
-  onChangeSpoilerText (checked) {
+  onChangeSpoilerText(checked) {
     dispatch(changeComposeSpoilerText(checked));
   },
 
-  onPaste (files) {
+  onPaste(files) {
     dispatch(uploadCompose(files));
   },
 
-  onPickEmoji (position, data, needsSpace) {
+  onPickEmoji(position, data, needsSpace) {
     dispatch(insertEmojiCompose(position, data, needsSpace));
   },
-
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(ComposeForm);

--- a/app/javascript/mastodon/features/compose/containers/emoji_picker_dropdown_container.js
+++ b/app/javascript/mastodon/features/compose/containers/emoji_picker_dropdown_container.js
@@ -7,7 +7,7 @@ import { changeSetting } from '../../../actions/settings';
 import EmojiPickerDropdown from '../components/emoji_picker_dropdown';
 
 const perLine = 8;
-const lines   = 2;
+const lines = 2;
 
 const DEFAULTS = [
   '+1',
@@ -28,51 +28,61 @@ const DEFAULTS = [
   'ok_hand',
 ];
 
-const getFrequentlyUsedEmojis = createSelector([
-  state => state.getIn(['settings', 'frequentlyUsedEmojis'], ImmutableMap()),
-], emojiCounters => {
-  let emojis = emojiCounters
-    .keySeq()
-    .sort((a, b) => emojiCounters.get(a) - emojiCounters.get(b))
-    .reverse()
-    .slice(0, perLine * lines)
-    .toArray();
+const getFrequentlyUsedEmojis = createSelector(
+  [
+    (state) =>
+      state.getIn(['settings', 'frequentlyUsedEmojis'], ImmutableMap()),
+  ],
+  (emojiCounters) => {
+    let emojis = emojiCounters
+      .keySeq()
+      .sort((a, b) => emojiCounters.get(a) - emojiCounters.get(b))
+      .reverse()
+      .slice(0, perLine * lines)
+      .toArray();
 
-  if (emojis.length < DEFAULTS.length) {
-    let uniqueDefaults = DEFAULTS.filter(emoji => !emojis.includes(emoji));
-    emojis = emojis.concat(uniqueDefaults.slice(0, DEFAULTS.length - emojis.length));
-  }
+    if (emojis.length < DEFAULTS.length) {
+      let uniqueDefaults = DEFAULTS.filter((emoji) => !emojis.includes(emoji));
+      emojis = emojis.concat(
+        uniqueDefaults.slice(0, DEFAULTS.length - emojis.length),
+      );
+    }
 
-  return emojis;
-});
+    return emojis;
+  },
+);
 
-const getCustomEmojis = createSelector([
-  state => state.get('custom_emojis'),
-], emojis => emojis.filter(e => e.get('visible_in_picker')).sort((a, b) => {
-  const aShort = a.get('shortcode').toLowerCase();
-  const bShort = b.get('shortcode').toLowerCase();
+const getCustomEmojis = createSelector(
+  [(state) => state.get('custom_emojis')],
+  (emojis) =>
+    emojis
+      .filter((e) => e.get('visible_in_picker'))
+      .sort((a, b) => {
+        const aShort = a.get('shortcode').toLowerCase();
+        const bShort = b.get('shortcode').toLowerCase();
 
-  if (aShort < bShort) {
-    return -1;
-  } else if (aShort > bShort ) {
-    return 1;
-  } else {
-    return 0;
-  }
-}));
+        if (aShort < bShort) {
+          return -1;
+        } else if (aShort > bShort) {
+          return 1;
+        } else {
+          return 0;
+        }
+      }),
+);
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   custom_emojis: getCustomEmojis(state),
   skinTone: state.getIn(['settings', 'skinTone']),
   frequentlyUsedEmojis: getFrequentlyUsedEmojis(state),
 });
 
 const mapDispatchToProps = (dispatch, { onPickEmoji }) => ({
-  onSkinTone: skinTone => {
+  onSkinTone: (skinTone) => {
     dispatch(changeSetting(['skinTone'], skinTone));
   },
 
-  onPickEmoji: emoji => {
+  onPickEmoji: (emoji) => {
     // eslint-disable-next-line react-hooks/rules-of-hooks -- this is not a react hook
     dispatch(useEmoji(emoji));
 
@@ -82,4 +92,7 @@ const mapDispatchToProps = (dispatch, { onPickEmoji }) => ({
   },
 });
 
-export default connect(mapStateToProps, mapDispatchToProps)(EmojiPickerDropdown);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(EmojiPickerDropdown);

--- a/app/javascript/mastodon/features/compose/containers/language_dropdown_container.js
+++ b/app/javascript/mastodon/features/compose/containers/language_dropdown_container.js
@@ -7,31 +7,33 @@ import { useLanguage } from 'mastodon/actions/languages';
 
 import LanguageDropdown from '../components/language_dropdown';
 
-const getFrequentlyUsedLanguages = createSelector([
-  state => state.getIn(['settings', 'frequentlyUsedLanguages'], ImmutableMap()),
-], languageCounters => (
-  languageCounters.keySeq()
-    .sort((a, b) => languageCounters.get(a) - languageCounters.get(b))
-    .reverse()
-    .toArray()
-));
+const getFrequentlyUsedLanguages = createSelector(
+  [
+    (state) =>
+      state.getIn(['settings', 'frequentlyUsedLanguages'], ImmutableMap()),
+  ],
+  (languageCounters) =>
+    languageCounters
+      .keySeq()
+      .sort((a, b) => languageCounters.get(a) - languageCounters.get(b))
+      .reverse()
+      .toArray(),
+);
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   frequentlyUsedLanguages: getFrequentlyUsedLanguages(state),
   value: state.getIn(['compose', 'language']),
 });
 
-const mapDispatchToProps = dispatch => ({
-
-  onChange (value) {
+const mapDispatchToProps = (dispatch) => ({
+  onChange(value) {
     dispatch(changeComposeLanguage(value));
   },
 
-  onClose (value) {
+  onClose(value) {
     // eslint-disable-next-line react-hooks/rules-of-hooks -- this is not a react hook
     dispatch(useLanguage(value));
   },
-
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(LanguageDropdown);

--- a/app/javascript/mastodon/features/compose/containers/navigation_container.js
+++ b/app/javascript/mastodon/features/compose/containers/navigation_container.js
@@ -1,6 +1,6 @@
 import { defineMessages, injectIntl } from 'react-intl';
 
-import { connect }   from 'react-redux';
+import { connect } from 'react-redux';
 
 import { openModal } from 'mastodon/actions/modal';
 import { logOut } from 'mastodon/utils/log_out';
@@ -9,28 +9,38 @@ import { me } from '../../../initial_state';
 import NavigationBar from '../components/navigation_bar';
 
 const messages = defineMessages({
-  logoutMessage: { id: 'confirmations.logout.message', defaultMessage: 'Are you sure you want to log out?' },
-  logoutConfirm: { id: 'confirmations.logout.confirm', defaultMessage: 'Log out' },
+  logoutMessage: {
+    id: 'confirmations.logout.message',
+    defaultMessage: 'Are you sure you want to log out?',
+  },
+  logoutConfirm: {
+    id: 'confirmations.logout.confirm',
+    defaultMessage: 'Log out',
+  },
 });
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
   return {
     account: state.getIn(['accounts', me]),
   };
 };
 
 const mapDispatchToProps = (dispatch, { intl }) => ({
-  onLogout () {
-    dispatch(openModal({
-      modalType: 'CONFIRM',
-      modalProps: {
-        message: intl.formatMessage(messages.logoutMessage),
-        confirm: intl.formatMessage(messages.logoutConfirm),
-        closeWhenConfirm: false,
-        onConfirm: () => logOut(),
-      },
-    }));
+  onLogout() {
+    dispatch(
+      openModal({
+        modalType: 'CONFIRM',
+        modalProps: {
+          message: intl.formatMessage(messages.logoutMessage),
+          confirm: intl.formatMessage(messages.logoutConfirm),
+          closeWhenConfirm: false,
+          onConfirm: () => logOut(),
+        },
+      }),
+    );
   },
 });
 
-export default injectIntl(connect(mapStateToProps, mapDispatchToProps)(NavigationBar));
+export default injectIntl(
+  connect(mapStateToProps, mapDispatchToProps)(NavigationBar),
+);

--- a/app/javascript/mastodon/features/compose/containers/poll_button_container.js
+++ b/app/javascript/mastodon/features/compose/containers/poll_button_container.js
@@ -3,14 +3,15 @@ import { connect } from 'react-redux';
 import { addPoll, removePoll } from '../../../actions/compose';
 import PollButton from '../components/poll_button';
 
-const mapStateToProps = state => ({
-  unavailable: state.getIn(['compose', 'is_uploading']) || (state.getIn(['compose', 'media_attachments']).size > 0),
+const mapStateToProps = (state) => ({
+  unavailable:
+    state.getIn(['compose', 'is_uploading']) ||
+    state.getIn(['compose', 'media_attachments']).size > 0,
   active: state.getIn(['compose', 'poll']) !== null,
 });
 
-const mapDispatchToProps = dispatch => ({
-
-  onClick () {
+const mapDispatchToProps = (dispatch) => ({
+  onClick() {
     dispatch((_, getState) => {
       if (getState().getIn(['compose', 'poll'])) {
         dispatch(removePoll());
@@ -19,7 +20,6 @@ const mapDispatchToProps = dispatch => ({
       }
     });
   },
-
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(PollButton);

--- a/app/javascript/mastodon/features/compose/containers/poll_form_container.js
+++ b/app/javascript/mastodon/features/compose/containers/poll_form_container.js
@@ -11,7 +11,7 @@ import {
 } from '../../../actions/compose';
 import PollForm from '../components/poll_form';
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   suggestions: state.getIn(['compose', 'suggestions']),
   options: state.getIn(['compose', 'poll', 'options']),
   lang: state.getIn(['compose', 'language']),
@@ -19,7 +19,7 @@ const mapStateToProps = state => ({
   isMultiple: state.getIn(['compose', 'poll', 'multiple']),
 });
 
-const mapDispatchToProps = dispatch => ({
+const mapDispatchToProps = (dispatch) => ({
   onAddOption(title) {
     dispatch(addPollOption(title));
   },
@@ -36,18 +36,17 @@ const mapDispatchToProps = dispatch => ({
     dispatch(changePollSettings(expiresIn, isMultiple));
   },
 
-  onClearSuggestions () {
+  onClearSuggestions() {
     dispatch(clearComposeSuggestions());
   },
 
-  onFetchSuggestions (token) {
+  onFetchSuggestions(token) {
     dispatch(fetchComposeSuggestions(token));
   },
 
-  onSuggestionSelected (position, token, accountId, path) {
+  onSuggestionSelected(position, token, accountId, path) {
     dispatch(selectComposeSuggestion(position, token, accountId, path));
   },
-
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(PollForm);

--- a/app/javascript/mastodon/features/compose/containers/privacy_dropdown_container.js
+++ b/app/javascript/mastodon/features/compose/containers/privacy_dropdown_container.js
@@ -5,26 +5,30 @@ import { openModal, closeModal } from '../../../actions/modal';
 import { isUserTouching } from '../../../is_mobile';
 import PrivacyDropdown from '../components/privacy_dropdown';
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   value: state.getIn(['compose', 'privacy']),
 });
 
-const mapDispatchToProps = dispatch => ({
-
-  onChange (value) {
+const mapDispatchToProps = (dispatch) => ({
+  onChange(value) {
     dispatch(changeComposeVisibility(value));
   },
 
   isUserTouching,
-  onModalOpen: props => dispatch(openModal({
-    modalType: 'ACTIONS',
-    modalProps: props,
-  })),
-  onModalClose: () => dispatch(closeModal({
-    modalType: undefined,
-    ignoreFocus: false,
-  })),
-
+  onModalOpen: (props) =>
+    dispatch(
+      openModal({
+        modalType: 'ACTIONS',
+        modalProps: props,
+      }),
+    ),
+  onModalClose: () =>
+    dispatch(
+      closeModal({
+        modalType: undefined,
+        ignoreFocus: false,
+      }),
+    ),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(PrivacyDropdown);

--- a/app/javascript/mastodon/features/compose/containers/reply_indicator_container.js
+++ b/app/javascript/mastodon/features/compose/containers/reply_indicator_container.js
@@ -7,13 +7,13 @@ import ReplyIndicator from '../components/reply_indicator';
 const makeMapStateToProps = () => {
   const getStatus = makeGetStatus();
 
-  const mapStateToProps = state => {
+  const mapStateToProps = (state) => {
     let statusId = state.getIn(['compose', 'id'], null);
-    let editing  = true;
+    let editing = true;
 
     if (statusId === null) {
       statusId = state.getIn(['compose', 'in_reply_to']);
-      editing  = false;
+      editing = false;
     }
 
     return {
@@ -25,12 +25,10 @@ const makeMapStateToProps = () => {
   return mapStateToProps;
 };
 
-const mapDispatchToProps = dispatch => ({
-
-  onCancel () {
+const mapDispatchToProps = (dispatch) => ({
+  onCancel() {
     dispatch(cancelReplyCompose());
   },
-
 });
 
 export default connect(makeMapStateToProps, mapDispatchToProps)(ReplyIndicator);

--- a/app/javascript/mastodon/features/compose/containers/search_container.js
+++ b/app/javascript/mastodon/features/compose/containers/search_container.js
@@ -12,42 +12,40 @@ import {
 
 import Search from '../components/search';
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   value: state.getIn(['search', 'value']),
   submitted: state.getIn(['search', 'submitted']),
   recent: state.getIn(['search', 'recent']).reverse(),
 });
 
-const mapDispatchToProps = dispatch => ({
-
-  onChange (value) {
+const mapDispatchToProps = (dispatch) => ({
+  onChange(value) {
     dispatch(changeSearch(value));
   },
 
-  onClear () {
+  onClear() {
     dispatch(clearSearch());
   },
 
-  onSubmit (type) {
+  onSubmit(type) {
     dispatch(submitSearch(type));
   },
 
-  onShow () {
+  onShow() {
     dispatch(showSearch());
   },
 
-  onOpenURL (q, routerHistory) {
+  onOpenURL(q, routerHistory) {
     dispatch(openURL(q, routerHistory));
   },
 
-  onClickSearchResult (q, type) {
+  onClickSearchResult(q, type) {
     dispatch(clickSearchResult(q, type));
   },
 
-  onForgetSearchResult (q) {
+  onForgetSearchResult(q) {
     dispatch(forgetSearchResult(q));
   },
-
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(Search);

--- a/app/javascript/mastodon/features/compose/containers/search_results_container.js
+++ b/app/javascript/mastodon/features/compose/containers/search_results_container.js
@@ -1,20 +1,24 @@
 import { connect } from 'react-redux';
 
 import { expandSearch } from 'mastodon/actions/search';
-import { fetchSuggestions, dismissSuggestion } from 'mastodon/actions/suggestions';
+import {
+  fetchSuggestions,
+  dismissSuggestion,
+} from 'mastodon/actions/suggestions';
 
 import SearchResults from '../components/search_results';
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   results: state.getIn(['search', 'results']),
   suggestions: state.getIn(['suggestions', 'items']),
   searchTerm: state.getIn(['search', 'searchTerm']),
 });
 
-const mapDispatchToProps = dispatch => ({
+const mapDispatchToProps = (dispatch) => ({
   fetchSuggestions: () => dispatch(fetchSuggestions()),
-  expandSearch: type => dispatch(expandSearch(type)),
-  dismissSuggestion: account => dispatch(dismissSuggestion(account.get('id'))),
+  expandSearch: (type) => dispatch(expandSearch(type)),
+  dismissSuggestion: (account) =>
+    dispatch(dismissSuggestion(account.get('id'))),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(SearchResults);

--- a/app/javascript/mastodon/features/compose/containers/sensitive_button_container.jsx
+++ b/app/javascript/mastodon/features/compose/containers/sensitive_button_container.jsx
@@ -12,30 +12,29 @@ import { changeComposeSensitivity } from 'mastodon/actions/compose';
 const messages = defineMessages({
   marked: {
     id: 'compose_form.sensitive.marked',
-    defaultMessage: '{count, plural, one {Media is marked as sensitive} other {Media is marked as sensitive}}',
+    defaultMessage:
+      '{count, plural, one {Media is marked as sensitive} other {Media is marked as sensitive}}',
   },
   unmarked: {
     id: 'compose_form.sensitive.unmarked',
-    defaultMessage: '{count, plural, one {Media is not marked as sensitive} other {Media is not marked as sensitive}}',
+    defaultMessage:
+      '{count, plural, one {Media is not marked as sensitive} other {Media is not marked as sensitive}}',
   },
 });
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   active: state.getIn(['compose', 'sensitive']),
   disabled: state.getIn(['compose', 'spoiler']),
   mediaCount: state.getIn(['compose', 'media_attachments']).size,
 });
 
-const mapDispatchToProps = dispatch => ({
-
-  onClick () {
+const mapDispatchToProps = (dispatch) => ({
+  onClick() {
     dispatch(changeComposeSensitivity());
   },
-
 });
 
 class SensitiveButton extends PureComponent {
-
   static propTypes = {
     active: PropTypes.bool,
     disabled: PropTypes.bool,
@@ -44,12 +43,18 @@ class SensitiveButton extends PureComponent {
     intl: PropTypes.object.isRequired,
   };
 
-  render () {
+  render() {
     const { active, disabled, mediaCount, onClick, intl } = this.props;
 
     return (
       <div className='compose-form__sensitive-button'>
-        <label className={classNames('icon-button', { active })} title={intl.formatMessage(active ? messages.marked : messages.unmarked, { count: mediaCount })}>
+        <label
+          className={classNames('icon-button', { active })}
+          title={intl.formatMessage(
+            active ? messages.marked : messages.unmarked,
+            { count: mediaCount },
+          )}
+        >
           <input
             name='mark-sensitive'
             type='checkbox'
@@ -67,7 +72,9 @@ class SensitiveButton extends PureComponent {
       </div>
     );
   }
-
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(injectIntl(SensitiveButton));
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(injectIntl(SensitiveButton));

--- a/app/javascript/mastodon/features/compose/containers/spoiler_button_container.js
+++ b/app/javascript/mastodon/features/compose/containers/spoiler_button_container.js
@@ -6,23 +6,31 @@ import { changeComposeSpoilerness } from '../../../actions/compose';
 import TextIconButton from '../components/text_icon_button';
 
 const messages = defineMessages({
-  marked: { id: 'compose_form.spoiler.marked', defaultMessage: 'Text is hidden behind warning' },
-  unmarked: { id: 'compose_form.spoiler.unmarked', defaultMessage: 'Text is not hidden' },
+  marked: {
+    id: 'compose_form.spoiler.marked',
+    defaultMessage: 'Text is hidden behind warning',
+  },
+  unmarked: {
+    id: 'compose_form.spoiler.unmarked',
+    defaultMessage: 'Text is not hidden',
+  },
 });
 
 const mapStateToProps = (state, { intl }) => ({
   label: 'CW',
-  title: intl.formatMessage(state.getIn(['compose', 'spoiler']) ? messages.marked : messages.unmarked),
+  title: intl.formatMessage(
+    state.getIn(['compose', 'spoiler']) ? messages.marked : messages.unmarked,
+  ),
   active: state.getIn(['compose', 'spoiler']),
   ariaControls: 'cw-spoiler-input',
 });
 
-const mapDispatchToProps = dispatch => ({
-
-  onClick () {
+const mapDispatchToProps = (dispatch) => ({
+  onClick() {
     dispatch(changeComposeSpoilerness());
   },
-
 });
 
-export default injectIntl(connect(mapStateToProps, mapDispatchToProps)(TextIconButton));
+export default injectIntl(
+  connect(mapStateToProps, mapDispatchToProps)(TextIconButton),
+);

--- a/app/javascript/mastodon/features/compose/containers/upload_button_container.js
+++ b/app/javascript/mastodon/features/compose/containers/upload_button_container.js
@@ -3,18 +3,23 @@ import { connect } from 'react-redux';
 import { uploadCompose } from '../../../actions/compose';
 import UploadButton from '../components/upload_button';
 
-const mapStateToProps = state => ({
-  disabled: state.getIn(['compose', 'is_uploading']) || (state.getIn(['compose', 'media_attachments']).size + state.getIn(['compose', 'pending_media_attachments']) > 3 || state.getIn(['compose', 'media_attachments']).some(m => ['video', 'audio'].includes(m.get('type')))),
+const mapStateToProps = (state) => ({
+  disabled:
+    state.getIn(['compose', 'is_uploading']) ||
+    state.getIn(['compose', 'media_attachments']).size +
+      state.getIn(['compose', 'pending_media_attachments']) >
+      3 ||
+    state
+      .getIn(['compose', 'media_attachments'])
+      .some((m) => ['video', 'audio'].includes(m.get('type'))),
   unavailable: state.getIn(['compose', 'poll']) !== null,
   resetFileKey: state.getIn(['compose', 'resetFileKey']),
 });
 
-const mapDispatchToProps = dispatch => ({
-
-  onSelectFile (files) {
+const mapDispatchToProps = (dispatch) => ({
+  onSelectFile(files) {
     dispatch(uploadCompose(files));
   },
-
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(UploadButton);

--- a/app/javascript/mastodon/features/compose/containers/upload_container.js
+++ b/app/javascript/mastodon/features/compose/containers/upload_container.js
@@ -1,26 +1,30 @@
 import { connect } from 'react-redux';
 
-import { undoUploadCompose, initMediaEditModal, submitCompose } from '../../../actions/compose';
+import {
+  undoUploadCompose,
+  initMediaEditModal,
+  submitCompose,
+} from '../../../actions/compose';
 import Upload from '../components/upload';
 
 const mapStateToProps = (state, { id }) => ({
-  media: state.getIn(['compose', 'media_attachments']).find(item => item.get('id') === id),
+  media: state
+    .getIn(['compose', 'media_attachments'])
+    .find((item) => item.get('id') === id),
 });
 
-const mapDispatchToProps = dispatch => ({
-
-  onUndo: id => {
+const mapDispatchToProps = (dispatch) => ({
+  onUndo: (id) => {
     dispatch(undoUploadCompose(id));
   },
 
-  onOpenFocalPoint: id => {
+  onOpenFocalPoint: (id) => {
     dispatch(initMediaEditModal(id));
   },
 
-  onSubmit (router) {
+  onSubmit(router) {
     dispatch(submitCompose(router));
   },
-
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(Upload);

--- a/app/javascript/mastodon/features/compose/containers/upload_form_container.js
+++ b/app/javascript/mastodon/features/compose/containers/upload_form_container.js
@@ -2,8 +2,10 @@ import { connect } from 'react-redux';
 
 import UploadForm from '../components/upload_form';
 
-const mapStateToProps = state => ({
-  mediaIds: state.getIn(['compose', 'media_attachments']).map(item => item.get('id')),
+const mapStateToProps = (state) => ({
+  mediaIds: state
+    .getIn(['compose', 'media_attachments'])
+    .map((item) => item.get('id')),
 });
 
 export default connect(mapStateToProps)(UploadForm);

--- a/app/javascript/mastodon/features/compose/containers/upload_progress_container.js
+++ b/app/javascript/mastodon/features/compose/containers/upload_progress_container.js
@@ -2,7 +2,7 @@ import { connect } from 'react-redux';
 
 import UploadProgress from '../components/upload_progress';
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   active: state.getIn(['compose', 'is_uploading']),
   progress: state.getIn(['compose', 'progress']),
   isProcessing: state.getIn(['compose', 'is_processing']),

--- a/app/javascript/mastodon/features/compose/containers/warning_container.jsx
+++ b/app/javascript/mastodon/features/compose/containers/warning_container.jsx
@@ -9,25 +9,70 @@ import { HASHTAG_PATTERN_REGEX } from 'mastodon/utils/hashtags';
 
 import Warning from '../components/warning';
 
-const mapStateToProps = state => ({
-  needsLockWarning: state.getIn(['compose', 'privacy']) === 'private' && !state.getIn(['accounts', me, 'locked']),
-  hashtagWarning: state.getIn(['compose', 'privacy']) !== 'public' && HASHTAG_PATTERN_REGEX.test(state.getIn(['compose', 'text'])),
+const mapStateToProps = (state) => ({
+  needsLockWarning:
+    state.getIn(['compose', 'privacy']) === 'private' &&
+    !state.getIn(['accounts', me, 'locked']),
+  hashtagWarning:
+    state.getIn(['compose', 'privacy']) !== 'public' &&
+    HASHTAG_PATTERN_REGEX.test(state.getIn(['compose', 'text'])),
   directMessageWarning: state.getIn(['compose', 'privacy']) === 'direct',
 });
 
-const WarningWrapper = ({ needsLockWarning, hashtagWarning, directMessageWarning }) => {
+const WarningWrapper = ({
+  needsLockWarning,
+  hashtagWarning,
+  directMessageWarning,
+}) => {
   if (needsLockWarning) {
-    return <Warning message={<FormattedMessage id='compose_form.lock_disclaimer' defaultMessage='Your account is not {locked}. Anyone can follow you to view your follower-only posts.' values={{ locked: <a href='/settings/profile'><FormattedMessage id='compose_form.lock_disclaimer.lock' defaultMessage='locked' /></a> }} />} />;
+    return (
+      <Warning
+        message={
+          <FormattedMessage
+            id='compose_form.lock_disclaimer'
+            defaultMessage='Your account is not {locked}. Anyone can follow you to view your follower-only posts.'
+            values={{
+              locked: (
+                <a href='/settings/profile'>
+                  <FormattedMessage
+                    id='compose_form.lock_disclaimer.lock'
+                    defaultMessage='locked'
+                  />
+                </a>
+              ),
+            }}
+          />
+        }
+      />
+    );
   }
 
   if (hashtagWarning) {
-    return <Warning message={<FormattedMessage id='compose_form.hashtag_warning' defaultMessage="This post won't be listed under any hashtag as it is unlisted. Only public posts can be searched by hashtag." />} />;
+    return (
+      <Warning
+        message={
+          <FormattedMessage
+            id='compose_form.hashtag_warning'
+            defaultMessage="This post won't be listed under any hashtag as it is unlisted. Only public posts can be searched by hashtag."
+          />
+        }
+      />
+    );
   }
 
   if (directMessageWarning) {
     const message = (
       <span>
-        <FormattedMessage id='compose_form.encryption_warning' defaultMessage='Posts on Mastodon are not end-to-end encrypted. Do not share any dangerous information over Mastodon.' /> <a href='/terms' target='_blank'><FormattedMessage id='compose_form.direct_message_warning_learn_more' defaultMessage='Learn more' /></a>
+        <FormattedMessage
+          id='compose_form.encryption_warning'
+          defaultMessage='Posts on Mastodon are not end-to-end encrypted. Do not share any dangerous information over Mastodon.'
+        />{' '}
+        <a href='/terms' target='_blank'>
+          <FormattedMessage
+            id='compose_form.direct_message_warning_learn_more'
+            defaultMessage='Learn more'
+          />
+        </a>
       </span>
     );
 

--- a/app/javascript/mastodon/features/compose/index.jsx
+++ b/app/javascript/mastodon/features/compose/index.jsx
@@ -13,11 +13,15 @@ import spring from 'react-motion/lib/spring';
 
 import { openModal } from 'mastodon/actions/modal';
 import Column from 'mastodon/components/column';
-import { Icon }  from 'mastodon/components/icon';
+import { Icon } from 'mastodon/components/icon';
 import { logOut } from 'mastodon/utils/log_out';
 
 import elephantUIPlane from '../../../images/elephant_ui_plane.svg';
-import { changeComposing, mountCompose, unmountCompose } from '../../actions/compose';
+import {
+  changeComposing,
+  mountCompose,
+  unmountCompose,
+} from '../../actions/compose';
 import { mascot } from '../../initial_state';
 import { isMobile } from '../../is_mobile';
 import Motion from '../ui/util/optional_motion';
@@ -30,23 +34,42 @@ import SearchResultsContainer from './containers/search_results_container';
 const messages = defineMessages({
   start: { id: 'getting_started.heading', defaultMessage: 'Getting started' },
   home_timeline: { id: 'tabs_bar.home', defaultMessage: 'Home' },
-  notifications: { id: 'tabs_bar.notifications', defaultMessage: 'Notifications' },
-  public: { id: 'navigation_bar.public_timeline', defaultMessage: 'Federated timeline' },
-  community: { id: 'navigation_bar.community_timeline', defaultMessage: 'Local timeline' },
-  preferences: { id: 'navigation_bar.preferences', defaultMessage: 'Preferences' },
+  notifications: {
+    id: 'tabs_bar.notifications',
+    defaultMessage: 'Notifications',
+  },
+  public: {
+    id: 'navigation_bar.public_timeline',
+    defaultMessage: 'Federated timeline',
+  },
+  community: {
+    id: 'navigation_bar.community_timeline',
+    defaultMessage: 'Local timeline',
+  },
+  preferences: {
+    id: 'navigation_bar.preferences',
+    defaultMessage: 'Preferences',
+  },
   logout: { id: 'navigation_bar.logout', defaultMessage: 'Logout' },
   compose: { id: 'navigation_bar.compose', defaultMessage: 'Compose new post' },
-  logoutMessage: { id: 'confirmations.logout.message', defaultMessage: 'Are you sure you want to log out?' },
-  logoutConfirm: { id: 'confirmations.logout.confirm', defaultMessage: 'Log out' },
+  logoutMessage: {
+    id: 'confirmations.logout.message',
+    defaultMessage: 'Are you sure you want to log out?',
+  },
+  logoutConfirm: {
+    id: 'confirmations.logout.confirm',
+    defaultMessage: 'Log out',
+  },
 });
 
 const mapStateToProps = (state, ownProps) => ({
   columns: state.getIn(['settings', 'columns']),
-  showSearch: ownProps.multiColumn ? state.getIn(['search', 'submitted']) && !state.getIn(['search', 'hidden']) : false,
+  showSearch: ownProps.multiColumn
+    ? state.getIn(['search', 'submitted']) && !state.getIn(['search', 'hidden'])
+    : false,
 });
 
 class Compose extends PureComponent {
-
   static propTypes = {
     dispatch: PropTypes.func.isRequired,
     columns: ImmutablePropTypes.list.isRequired,
@@ -55,31 +78,33 @@ class Compose extends PureComponent {
     intl: PropTypes.object.isRequired,
   };
 
-  componentDidMount () {
+  componentDidMount() {
     const { dispatch } = this.props;
     dispatch(mountCompose());
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     const { dispatch } = this.props;
     dispatch(unmountCompose());
   }
 
-  handleLogoutClick = e => {
+  handleLogoutClick = (e) => {
     const { dispatch, intl } = this.props;
 
     e.preventDefault();
     e.stopPropagation();
 
-    dispatch(openModal({
-      modalType: 'CONFIRM',
-      modalProps: {
-        message: intl.formatMessage(messages.logoutMessage),
-        confirm: intl.formatMessage(messages.logoutConfirm),
-        closeWhenConfirm: false,
-        onConfirm: () => logOut(),
-      },
-    }));
+    dispatch(
+      openModal({
+        modalType: 'CONFIRM',
+        modalProps: {
+          message: intl.formatMessage(messages.logoutMessage),
+          confirm: intl.formatMessage(messages.logoutConfirm),
+          closeWhenConfirm: false,
+          onConfirm: () => logOut(),
+        },
+      }),
+    );
 
     return false;
   };
@@ -92,33 +117,89 @@ class Compose extends PureComponent {
     this.props.dispatch(changeComposing(false));
   };
 
-  render () {
+  render() {
     const { multiColumn, showSearch, intl } = this.props;
 
     if (multiColumn) {
       const { columns } = this.props;
 
       return (
-        <div className='drawer' role='region' aria-label={intl.formatMessage(messages.compose)}>
+        <div
+          className='drawer'
+          role='region'
+          aria-label={intl.formatMessage(messages.compose)}
+        >
           <nav className='drawer__header'>
-            <Link to='/getting-started' className='drawer__tab' title={intl.formatMessage(messages.start)} aria-label={intl.formatMessage(messages.start)}><Icon id='bars' fixedWidth /></Link>
-            {!columns.some(column => column.get('id') === 'HOME') && (
-              <Link to='/home' className='drawer__tab' title={intl.formatMessage(messages.home_timeline)} aria-label={intl.formatMessage(messages.home_timeline)}><Icon id='home' fixedWidth /></Link>
+            <Link
+              to='/getting-started'
+              className='drawer__tab'
+              title={intl.formatMessage(messages.start)}
+              aria-label={intl.formatMessage(messages.start)}
+            >
+              <Icon id='bars' fixedWidth />
+            </Link>
+            {!columns.some((column) => column.get('id') === 'HOME') && (
+              <Link
+                to='/home'
+                className='drawer__tab'
+                title={intl.formatMessage(messages.home_timeline)}
+                aria-label={intl.formatMessage(messages.home_timeline)}
+              >
+                <Icon id='home' fixedWidth />
+              </Link>
             )}
-            {!columns.some(column => column.get('id') === 'NOTIFICATIONS') && (
-              <Link to='/notifications' className='drawer__tab' title={intl.formatMessage(messages.notifications)} aria-label={intl.formatMessage(messages.notifications)}><Icon id='bell' fixedWidth /></Link>
+            {!columns.some(
+              (column) => column.get('id') === 'NOTIFICATIONS',
+            ) && (
+              <Link
+                to='/notifications'
+                className='drawer__tab'
+                title={intl.formatMessage(messages.notifications)}
+                aria-label={intl.formatMessage(messages.notifications)}
+              >
+                <Icon id='bell' fixedWidth />
+              </Link>
             )}
-            {!columns.some(column => column.get('id') === 'COMMUNITY') && (
-              <Link to='/public/local' className='drawer__tab' title={intl.formatMessage(messages.community)} aria-label={intl.formatMessage(messages.community)}><Icon id='users' fixedWidth /></Link>
+            {!columns.some((column) => column.get('id') === 'COMMUNITY') && (
+              <Link
+                to='/public/local'
+                className='drawer__tab'
+                title={intl.formatMessage(messages.community)}
+                aria-label={intl.formatMessage(messages.community)}
+              >
+                <Icon id='users' fixedWidth />
+              </Link>
             )}
-            {!columns.some(column => column.get('id') === 'PUBLIC') && (
-              <Link to='/public' className='drawer__tab' title={intl.formatMessage(messages.public)} aria-label={intl.formatMessage(messages.public)}><Icon id='globe' fixedWidth /></Link>
+            {!columns.some((column) => column.get('id') === 'PUBLIC') && (
+              <Link
+                to='/public'
+                className='drawer__tab'
+                title={intl.formatMessage(messages.public)}
+                aria-label={intl.formatMessage(messages.public)}
+              >
+                <Icon id='globe' fixedWidth />
+              </Link>
             )}
-            <a href='/settings/preferences' className='drawer__tab' title={intl.formatMessage(messages.preferences)} aria-label={intl.formatMessage(messages.preferences)}><Icon id='cog' fixedWidth /></a>
-            <a href='/auth/sign_out' className='drawer__tab' title={intl.formatMessage(messages.logout)} aria-label={intl.formatMessage(messages.logout)} onClick={this.handleLogoutClick}><Icon id='sign-out' fixedWidth /></a>
+            <a
+              href='/settings/preferences'
+              className='drawer__tab'
+              title={intl.formatMessage(messages.preferences)}
+              aria-label={intl.formatMessage(messages.preferences)}
+            >
+              <Icon id='cog' fixedWidth />
+            </a>
+            <a
+              href='/auth/sign_out'
+              className='drawer__tab'
+              title={intl.formatMessage(messages.logout)}
+              aria-label={intl.formatMessage(messages.logout)}
+              onClick={this.handleLogoutClick}
+            >
+              <Icon id='sign-out' fixedWidth />
+            </a>
           </nav>
 
-          {multiColumn && <SearchContainer /> }
+          {multiColumn && <SearchContainer />}
 
           <div className='drawer__pager'>
             <div className='drawer__inner' onFocus={this.onFocus}>
@@ -131,9 +212,23 @@ class Compose extends PureComponent {
               </div>
             </div>
 
-            <Motion defaultStyle={{ x: -100 }} style={{ x: spring(showSearch ? 0 : -100, { stiffness: 210, damping: 20 }) }}>
+            <Motion
+              defaultStyle={{ x: -100 }}
+              style={{
+                x: spring(showSearch ? 0 : -100, {
+                  stiffness: 210,
+                  damping: 20,
+                }),
+              }}
+            >
               {({ x }) => (
-                <div className='drawer__inner darker' style={{ transform: `translateX(${x}%)`, visibility: x === -100 ? 'hidden' : 'visible' }}>
+                <div
+                  className='drawer__inner darker'
+                  style={{
+                    transform: `translateX(${x}%)`,
+                    visibility: x === -100 ? 'hidden' : 'visible',
+                  }}
+                >
                   <SearchResultsContainer />
                 </div>
               )}
@@ -154,7 +249,6 @@ class Compose extends PureComponent {
       </Column>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(injectIntl(Compose));

--- a/app/javascript/mastodon/features/compose/util/counter.js
+++ b/app/javascript/mastodon/features/compose/util/counter.js
@@ -5,5 +5,5 @@ const urlPlaceholder = '$2xxxxxxxxxxxxxxxxxxxxxxx';
 export function countableText(inputText) {
   return inputText
     .replace(urlRegex, urlPlaceholder)
-    .replace(/(^|[^/\w])@(([a-z0-9_]+)@[a-z0-9.-]+[a-z0-9]+)/ig, '$1@$3');
+    .replace(/(^|[^/\w])@(([a-z0-9_]+)@[a-z0-9.-]+[a-z0-9]+)/gi, '$1@$3');
 }

--- a/app/javascript/mastodon/features/compose/util/url_regex.js
+++ b/app/javascript/mastodon/features/compose/util/url_regex.js
@@ -10,14 +10,14 @@ import validUrlQueryEndingChars from 'twitter-text/dist/regexp/validUrlQueryEndi
 // optional.
 
 export const urlRegex = regexSupplant(
-  '('                                                          + // $1 URL
-    '(#{validUrlPrecedingChars})'                              + // $2
-    '(https?:\\/\\/)'                                          + // $3 Protocol
-    '(#{validDomain})'                                         + // $4 Domain(s)
-    '(?::(#{validPortNumber}))?'                               + // $5 Port number (optional)
-    '(\\/#{validUrlPath}*)?'                                   + // $6 URL Path
-    '(\\?#{validUrlQueryChars}*#{validUrlQueryEndingChars})?'  + // $7 Query String
-  ')',
+  '(' + // $1 URL
+    '(#{validUrlPrecedingChars})' + // $2
+    '(https?:\\/\\/)' + // $3 Protocol
+    '(#{validDomain})' + // $4 Domain(s)
+    '(?::(#{validPortNumber}))?' + // $5 Port number (optional)
+    '(\\/#{validUrlPath}*)?' + // $6 URL Path
+    '(\\?#{validUrlQueryChars}*#{validUrlQueryEndingChars})?' + // $7 Query String
+    ')',
   {
     validUrlPrecedingChars,
     validDomain,

--- a/app/javascript/mastodon/features/direct_timeline/components/conversation.jsx
+++ b/app/javascript/mastodon/features/direct_timeline/components/conversation.jsx
@@ -22,14 +22,22 @@ const messages = defineMessages({
   more: { id: 'status.more', defaultMessage: 'More' },
   open: { id: 'conversation.open', defaultMessage: 'View conversation' },
   reply: { id: 'status.reply', defaultMessage: 'Reply' },
-  markAsRead: { id: 'conversation.mark_as_read', defaultMessage: 'Mark as read' },
+  markAsRead: {
+    id: 'conversation.mark_as_read',
+    defaultMessage: 'Mark as read',
+  },
   delete: { id: 'conversation.delete', defaultMessage: 'Delete conversation' },
-  muteConversation: { id: 'status.mute_conversation', defaultMessage: 'Mute conversation' },
-  unmuteConversation: { id: 'status.unmute_conversation', defaultMessage: 'Unmute conversation' },
+  muteConversation: {
+    id: 'status.mute_conversation',
+    defaultMessage: 'Mute conversation',
+  },
+  unmuteConversation: {
+    id: 'status.unmute_conversation',
+    defaultMessage: 'Unmute conversation',
+  },
 });
 
 class Conversation extends ImmutablePureComponent {
-
   static contextTypes = {
     router: PropTypes.object,
   };
@@ -38,7 +46,7 @@ class Conversation extends ImmutablePureComponent {
     conversationId: PropTypes.string.isRequired,
     accounts: ImmutablePropTypes.list.isRequired,
     lastStatus: ImmutablePropTypes.map,
-    unread:PropTypes.bool.isRequired,
+    unread: PropTypes.bool.isRequired,
     scrollKey: PropTypes.string,
     onMoveUp: PropTypes.func,
     onMoveDown: PropTypes.func,
@@ -84,7 +92,9 @@ class Conversation extends ImmutablePureComponent {
       markRead();
     }
 
-    this.context.router.history.push(`/@${lastStatus.getIn(['account', 'acct'])}/${lastStatus.get('id')}`);
+    this.context.router.history.push(
+      `/@${lastStatus.getIn(['account', 'acct'])}/${lastStatus.get('id')}`,
+    );
   };
 
   handleMarkAsRead = () => {
@@ -115,7 +125,7 @@ class Conversation extends ImmutablePureComponent {
     this.props.onToggleHidden(this.props.lastStatus);
   };
 
-  render () {
+  render() {
     const { accounts, lastStatus, unread, scrollKey, intl } = this.props;
 
     if (lastStatus === null) {
@@ -127,16 +137,40 @@ class Conversation extends ImmutablePureComponent {
       null,
     ];
 
-    menu.push({ text: intl.formatMessage(lastStatus.get('muted') ? messages.unmuteConversation : messages.muteConversation), action: this.handleConversationMute });
+    menu.push({
+      text: intl.formatMessage(
+        lastStatus.get('muted')
+          ? messages.unmuteConversation
+          : messages.muteConversation,
+      ),
+      action: this.handleConversationMute,
+    });
 
     if (unread) {
-      menu.push({ text: intl.formatMessage(messages.markAsRead), action: this.handleMarkAsRead });
+      menu.push({
+        text: intl.formatMessage(messages.markAsRead),
+        action: this.handleMarkAsRead,
+      });
       menu.push(null);
     }
 
-    menu.push({ text: intl.formatMessage(messages.delete), action: this.handleDelete });
+    menu.push({
+      text: intl.formatMessage(messages.delete),
+      action: this.handleDelete,
+    });
 
-    const names = accounts.map(a => <Link to={`/@${a.get('acct')}`} key={a.get('id')} title={a.get('acct')}><bdi><strong className='display-name__html' dangerouslySetInnerHTML={{ __html: a.get('display_name_html') }} /></bdi></Link>).reduce((prev, cur) => [prev, ', ', cur]);
+    const names = accounts
+      .map((a) => (
+        <Link to={`/@${a.get('acct')}`} key={a.get('id')} title={a.get('acct')}>
+          <bdi>
+            <strong
+              className='display-name__html'
+              dangerouslySetInnerHTML={{ __html: a.get('display_name_html') }}
+            />
+          </bdi>
+        </Link>
+      ))
+      .reduce((prev, cur) => [prev, ', ', cur]);
 
     const handlers = {
       reply: this.handleReply,
@@ -148,19 +182,37 @@ class Conversation extends ImmutablePureComponent {
 
     return (
       <HotKeys handlers={handlers}>
-        <div className={classNames('conversation focusable muted', { 'conversation--unread': unread })} tabIndex={0}>
-          <div className='conversation__avatar' onClick={this.handleClick} role='presentation'>
+        <div
+          className={classNames('conversation focusable muted', {
+            'conversation--unread': unread,
+          })}
+          tabIndex={0}
+        >
+          <div
+            className='conversation__avatar'
+            onClick={this.handleClick}
+            role='presentation'
+          >
             <AvatarComposite accounts={accounts} size={48} />
           </div>
 
           <div className='conversation__content'>
             <div className='conversation__content__info'>
               <div className='conversation__content__relative-time'>
-                {unread && <span className='conversation__unread' />} <RelativeTimestamp timestamp={lastStatus.get('created_at')} />
+                {unread && <span className='conversation__unread' />}{' '}
+                <RelativeTimestamp timestamp={lastStatus.get('created_at')} />
               </div>
 
-              <div className='conversation__content__names' onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave}>
-                <FormattedMessage id='conversation.with' defaultMessage='With {names}' values={{ names: <span>{names}</span> }} />
+              <div
+                className='conversation__content__names'
+                onMouseEnter={this.handleMouseEnter}
+                onMouseLeave={this.handleMouseLeave}
+              >
+                <FormattedMessage
+                  id='conversation.with'
+                  defaultMessage='With {names}'
+                  values={{ names: <span>{names}</span> }}
+                />
               </div>
             </div>
 
@@ -180,7 +232,12 @@ class Conversation extends ImmutablePureComponent {
             )}
 
             <div className='status__action-bar'>
-              <IconButton className='status__action-bar-button' title={intl.formatMessage(messages.reply)} icon='reply' onClick={this.handleReply} />
+              <IconButton
+                className='status__action-bar-button'
+                title={intl.formatMessage(messages.reply)}
+                icon='reply'
+                onClick={this.handleReply}
+              />
 
               <div className='status__action-bar-dropdown'>
                 <DropdownMenuContainer
@@ -199,7 +256,6 @@ class Conversation extends ImmutablePureComponent {
       </HotKeys>
     );
   }
-
 }
 
 export default injectIntl(Conversation);

--- a/app/javascript/mastodon/features/direct_timeline/components/conversations_list.jsx
+++ b/app/javascript/mastodon/features/direct_timeline/components/conversations_list.jsx
@@ -9,7 +9,6 @@ import ScrollableList from '../../../components/scrollable_list';
 import ConversationContainer from '../containers/conversation_container';
 
 export default class ConversationsList extends ImmutablePureComponent {
-
   static propTypes = {
     conversations: ImmutablePropTypes.list.isRequired,
     scrollKey: PropTypes.string.isRequired,
@@ -18,50 +17,67 @@ export default class ConversationsList extends ImmutablePureComponent {
     onLoadMore: PropTypes.func,
   };
 
-  getCurrentIndex = id => this.props.conversations.findIndex(x => x.get('id') === id);
+  getCurrentIndex = (id) =>
+    this.props.conversations.findIndex((x) => x.get('id') === id);
 
-  handleMoveUp = id => {
+  handleMoveUp = (id) => {
     const elementIndex = this.getCurrentIndex(id) - 1;
     this._selectChild(elementIndex, true);
   };
 
-  handleMoveDown = id => {
+  handleMoveDown = (id) => {
     const elementIndex = this.getCurrentIndex(id) + 1;
     this._selectChild(elementIndex, false);
   };
 
-  _selectChild (index, align_top) {
+  _selectChild(index, align_top) {
     const container = this.node.node;
-    const element = container.querySelector(`article:nth-of-type(${index + 1}) .focusable`);
+    const element = container.querySelector(
+      `article:nth-of-type(${index + 1}) .focusable`,
+    );
 
     if (element) {
       if (align_top && container.scrollTop > element.offsetTop) {
         element.scrollIntoView(true);
-      } else if (!align_top && container.scrollTop + container.clientHeight < element.offsetTop + element.offsetHeight) {
+      } else if (
+        !align_top &&
+        container.scrollTop + container.clientHeight <
+          element.offsetTop + element.offsetHeight
+      ) {
         element.scrollIntoView(false);
       }
       element.focus();
     }
   }
 
-  setRef = c => {
+  setRef = (c) => {
     this.node = c;
   };
 
-  handleLoadOlder = debounce(() => {
-    const last = this.props.conversations.last();
+  handleLoadOlder = debounce(
+    () => {
+      const last = this.props.conversations.last();
 
-    if (last && last.get('last_status')) {
-      this.props.onLoadMore(last.get('last_status'));
-    }
-  }, 300, { leading: true });
+      if (last && last.get('last_status')) {
+        this.props.onLoadMore(last.get('last_status'));
+      }
+    },
+    300,
+    { leading: true },
+  );
 
-  render () {
+  render() {
     const { conversations, isLoading, onLoadMore, ...other } = this.props;
 
     return (
-      <ScrollableList {...other} isLoading={isLoading} showLoading={isLoading && conversations.isEmpty()} onLoadMore={onLoadMore && this.handleLoadOlder} ref={this.setRef}>
-        {conversations.map(item => (
+      <ScrollableList
+        {...other}
+        isLoading={isLoading}
+        showLoading={isLoading && conversations.isEmpty()}
+        onLoadMore={onLoadMore && this.handleLoadOlder}
+        ref={this.setRef}
+      >
+        {conversations.map((item) => (
           <ConversationContainer
             key={item.get('id')}
             conversationId={item.get('id')}
@@ -73,5 +89,4 @@ export default class ConversationsList extends ImmutablePureComponent {
       </ScrollableList>
     );
   }
-
 }

--- a/app/javascript/mastodon/features/direct_timeline/containers/conversation_container.js
+++ b/app/javascript/mastodon/features/direct_timeline/containers/conversation_container.js
@@ -3,27 +3,43 @@ import { defineMessages, injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 
 import { replyCompose } from 'mastodon/actions/compose';
-import { markConversationRead, deleteConversation } from 'mastodon/actions/conversations';
+import {
+  markConversationRead,
+  deleteConversation,
+} from 'mastodon/actions/conversations';
 import { openModal } from 'mastodon/actions/modal';
-import { muteStatus, unmuteStatus, hideStatus, revealStatus } from 'mastodon/actions/statuses';
+import {
+  muteStatus,
+  unmuteStatus,
+  hideStatus,
+  revealStatus,
+} from 'mastodon/actions/statuses';
 import { makeGetStatus } from 'mastodon/selectors';
 
 import Conversation from '../components/conversation';
 
 const messages = defineMessages({
   replyConfirm: { id: 'confirmations.reply.confirm', defaultMessage: 'Reply' },
-  replyMessage: { id: 'confirmations.reply.message', defaultMessage: 'Replying now will overwrite the message you are currently composing. Are you sure you want to proceed?' },
+  replyMessage: {
+    id: 'confirmations.reply.message',
+    defaultMessage:
+      'Replying now will overwrite the message you are currently composing. Are you sure you want to proceed?',
+  },
 });
 
 const mapStateToProps = () => {
   const getStatus = makeGetStatus();
 
   return (state, { conversationId }) => {
-    const conversation = state.getIn(['conversations', 'items']).find(x => x.get('id') === conversationId);
+    const conversation = state
+      .getIn(['conversations', 'items'])
+      .find((x) => x.get('id') === conversationId);
     const lastStatusId = conversation.get('last_status', null);
 
     return {
-      accounts: conversation.get('accounts').map(accountId => state.getIn(['accounts', accountId], null)),
+      accounts: conversation
+        .get('accounts')
+        .map((accountId) => state.getIn(['accounts', accountId], null)),
       unread: conversation.get('unread'),
       lastStatus: lastStatusId && getStatus(state, { id: lastStatusId }),
     };
@@ -31,35 +47,36 @@ const mapStateToProps = () => {
 };
 
 const mapDispatchToProps = (dispatch, { intl, conversationId }) => ({
-
-  markRead () {
+  markRead() {
     dispatch(markConversationRead(conversationId));
   },
 
-  reply (status, router) {
+  reply(status, router) {
     dispatch((_, getState) => {
       let state = getState();
 
       if (state.getIn(['compose', 'text']).trim().length !== 0) {
-        dispatch(openModal({
-          modalType: 'CONFIRM',
-          modalProps: {
-            message: intl.formatMessage(messages.replyMessage),
-            confirm: intl.formatMessage(messages.replyConfirm),
-            onConfirm: () => dispatch(replyCompose(status, router)),
-          },
-        }));
+        dispatch(
+          openModal({
+            modalType: 'CONFIRM',
+            modalProps: {
+              message: intl.formatMessage(messages.replyMessage),
+              confirm: intl.formatMessage(messages.replyConfirm),
+              onConfirm: () => dispatch(replyCompose(status, router)),
+            },
+          }),
+        );
       } else {
         dispatch(replyCompose(status, router));
       }
     });
   },
 
-  delete () {
+  delete() {
     dispatch(deleteConversation(conversationId));
   },
 
-  onMute (status) {
+  onMute(status) {
     if (status.get('muted')) {
       dispatch(unmuteStatus(status.get('id')));
     } else {
@@ -67,14 +84,15 @@ const mapDispatchToProps = (dispatch, { intl, conversationId }) => ({
     }
   },
 
-  onToggleHidden (status) {
+  onToggleHidden(status) {
     if (status.get('hidden')) {
       dispatch(revealStatus(status.get('id')));
     } else {
       dispatch(hideStatus(status.get('id')));
     }
   },
-
 });
 
-export default injectIntl(connect(mapStateToProps, mapDispatchToProps)(Conversation));
+export default injectIntl(
+  connect(mapStateToProps, mapDispatchToProps)(Conversation),
+);

--- a/app/javascript/mastodon/features/direct_timeline/containers/conversations_list_container.js
+++ b/app/javascript/mastodon/features/direct_timeline/containers/conversations_list_container.js
@@ -3,14 +3,14 @@ import { connect } from 'react-redux';
 import { expandConversations } from '../../../actions/conversations';
 import ConversationsList from '../components/conversations_list';
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   conversations: state.getIn(['conversations', 'items']),
   isLoading: state.getIn(['conversations', 'isLoading'], true),
   hasMore: state.getIn(['conversations', 'hasMore'], false),
 });
 
-const mapDispatchToProps = dispatch => ({
-  onLoadMore: maxId => dispatch(expandConversations({ maxId })),
+const mapDispatchToProps = (dispatch) => ({
+  onLoadMore: (maxId) => dispatch(expandConversations({ maxId })),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(ConversationsList);

--- a/app/javascript/mastodon/features/direct_timeline/index.jsx
+++ b/app/javascript/mastodon/features/direct_timeline/index.jsx
@@ -8,7 +8,11 @@ import { Helmet } from 'react-helmet';
 import { connect } from 'react-redux';
 
 import { addColumn, removeColumn, moveColumn } from 'mastodon/actions/columns';
-import { mountConversations, unmountConversations, expandConversations } from 'mastodon/actions/conversations';
+import {
+  mountConversations,
+  unmountConversations,
+  expandConversations,
+} from 'mastodon/actions/conversations';
 import { connectDirectStream } from 'mastodon/actions/streaming';
 import Column from 'mastodon/components/column';
 import ColumnHeader from 'mastodon/components/column_header';
@@ -20,7 +24,6 @@ const messages = defineMessages({
 });
 
 class DirectTimeline extends PureComponent {
-
   static propTypes = {
     dispatch: PropTypes.func.isRequired,
     columnId: PropTypes.string,
@@ -48,7 +51,7 @@ class DirectTimeline extends PureComponent {
     this.column.scrollTop();
   };
 
-  componentDidMount () {
+  componentDidMount() {
     const { dispatch } = this.props;
 
     dispatch(mountConversations());
@@ -56,7 +59,7 @@ class DirectTimeline extends PureComponent {
     this.disconnect = dispatch(connectDirectStream());
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     this.props.dispatch(unmountConversations());
 
     if (this.disconnect) {
@@ -65,20 +68,24 @@ class DirectTimeline extends PureComponent {
     }
   }
 
-  setRef = c => {
+  setRef = (c) => {
     this.column = c;
   };
 
-  handleLoadMore = maxId => {
+  handleLoadMore = (maxId) => {
     this.props.dispatch(expandConversations({ maxId }));
   };
 
-  render () {
+  render() {
     const { intl, hasUnread, columnId, multiColumn } = this.props;
     const pinned = !!columnId;
 
     return (
-      <Column bindToDocument={!multiColumn} ref={this.setRef} label={intl.formatMessage(messages.title)}>
+      <Column
+        bindToDocument={!multiColumn}
+        ref={this.setRef}
+        label={intl.formatMessage(messages.title)}
+      >
         <ColumnHeader
           icon='at'
           active={hasUnread}
@@ -96,9 +103,29 @@ class DirectTimeline extends PureComponent {
           timelineId='direct'
           bindToDocument={!multiColumn}
           onLoadMore={this.handleLoadMore}
-          prepend={<div className='follow_requests-unlocked_explanation'><span><FormattedMessage id='compose_form.encryption_warning' defaultMessage='Posts on Mastodon are not end-to-end encrypted. Do not share any dangerous information over Mastodon.' /> <a href='/terms' target='_blank'><FormattedMessage id='compose_form.direct_message_warning_learn_more' defaultMessage='Learn more' /></a></span></div>}
+          prepend={
+            <div className='follow_requests-unlocked_explanation'>
+              <span>
+                <FormattedMessage
+                  id='compose_form.encryption_warning'
+                  defaultMessage='Posts on Mastodon are not end-to-end encrypted. Do not share any dangerous information over Mastodon.'
+                />{' '}
+                <a href='/terms' target='_blank'>
+                  <FormattedMessage
+                    id='compose_form.direct_message_warning_learn_more'
+                    defaultMessage='Learn more'
+                  />
+                </a>
+              </span>
+            </div>
+          }
           alwaysPrepend
-          emptyMessage={<FormattedMessage id='empty_column.direct' defaultMessage="You don't have any private mentions yet. When you send or receive one, it will show up here." />}
+          emptyMessage={
+            <FormattedMessage
+              id='empty_column.direct'
+              defaultMessage="You don't have any private mentions yet. When you send or receive one, it will show up here."
+            />
+          }
         />
 
         <Helmet>
@@ -108,7 +135,6 @@ class DirectTimeline extends PureComponent {
       </Column>
     );
   }
-
 }
 
 export default connect()(injectIntl(DirectTimeline));

--- a/app/javascript/mastodon/features/directory/components/account_card.jsx
+++ b/app/javascript/mastodon/features/directory/components/account_card.jsx
@@ -26,12 +26,24 @@ import { makeGetAccount } from 'mastodon/selectors';
 const messages = defineMessages({
   unfollow: { id: 'account.unfollow', defaultMessage: 'Unfollow' },
   follow: { id: 'account.follow', defaultMessage: 'Follow' },
-  cancel_follow_request: { id: 'account.cancel_follow_request', defaultMessage: 'Withdraw follow request' },
-  cancelFollowRequestConfirm: { id: 'confirmations.cancel_follow_request.confirm', defaultMessage: 'Withdraw request' },
-  requested: { id: 'account.requested', defaultMessage: 'Awaiting approval. Click to cancel follow request' },
+  cancel_follow_request: {
+    id: 'account.cancel_follow_request',
+    defaultMessage: 'Withdraw follow request',
+  },
+  cancelFollowRequestConfirm: {
+    id: 'confirmations.cancel_follow_request.confirm',
+    defaultMessage: 'Withdraw request',
+  },
+  requested: {
+    id: 'account.requested',
+    defaultMessage: 'Awaiting approval. Click to cancel follow request',
+  },
   unblock: { id: 'account.unblock_short', defaultMessage: 'Unblock' },
   unmute: { id: 'account.unmute_short', defaultMessage: 'Unmute' },
-  unfollowConfirm: { id: 'confirmations.unfollow.confirm', defaultMessage: 'Unfollow' },
+  unfollowConfirm: {
+    id: 'confirmations.unfollow.confirm',
+    defaultMessage: 'Unfollow',
+  },
   edit_profile: { id: 'account.edit_profile', defaultMessage: 'Edit profile' },
 });
 
@@ -62,21 +74,30 @@ const mapDispatchToProps = (dispatch, { intl }) => ({
               ),
               confirm: intl.formatMessage(messages.unfollowConfirm),
               onConfirm: () => dispatch(unfollowAccount(account.get('id'))),
-            } }),
+            },
+          }),
         );
       } else {
         dispatch(unfollowAccount(account.get('id')));
       }
     } else if (account.getIn(['relationship', 'requested'])) {
       if (unfollowModal) {
-        dispatch(openModal({
-          modalType: 'CONFIRM',
-          modalProps: {
-            message: <FormattedMessage id='confirmations.cancel_follow_request.message' defaultMessage='Are you sure you want to withdraw your request to follow {name}?' values={{ name: <strong>@{account.get('acct')}</strong> }} />,
-            confirm: intl.formatMessage(messages.cancelFollowRequestConfirm),
-            onConfirm: () => dispatch(unfollowAccount(account.get('id'))),
-          },
-        }));
+        dispatch(
+          openModal({
+            modalType: 'CONFIRM',
+            modalProps: {
+              message: (
+                <FormattedMessage
+                  id='confirmations.cancel_follow_request.message'
+                  defaultMessage='Are you sure you want to withdraw your request to follow {name}?'
+                  values={{ name: <strong>@{account.get('acct')}</strong> }}
+                />
+              ),
+              confirm: intl.formatMessage(messages.cancelFollowRequestConfirm),
+              onConfirm: () => dispatch(unfollowAccount(account.get('id'))),
+            },
+          }),
+        );
       } else {
         dispatch(unfollowAccount(account.get('id')));
       }
@@ -96,11 +117,9 @@ const mapDispatchToProps = (dispatch, { intl }) => ({
       dispatch(unmuteAccount(account.get('id')));
     }
   },
-
 });
 
 class AccountCard extends ImmutablePureComponent {
-
   static propTypes = {
     account: ImmutablePropTypes.map.isRequired,
     intl: PropTypes.object.isRequired,
@@ -157,35 +176,80 @@ class AccountCard extends ImmutablePureComponent {
     let actionBtn;
 
     if (me !== account.get('id')) {
-      if (!account.get('relationship')) { // Wait until the relationship is loaded
+      if (!account.get('relationship')) {
+        // Wait until the relationship is loaded
         actionBtn = '';
       } else if (account.getIn(['relationship', 'requested'])) {
-        actionBtn = <Button  text={intl.formatMessage(messages.cancel_follow_request)} title={intl.formatMessage(messages.requested)} onClick={this.handleFollow} />;
+        actionBtn = (
+          <Button
+            text={intl.formatMessage(messages.cancel_follow_request)}
+            title={intl.formatMessage(messages.requested)}
+            onClick={this.handleFollow}
+          />
+        );
       } else if (account.getIn(['relationship', 'muting'])) {
-        actionBtn = <Button  text={intl.formatMessage(messages.unmute)} onClick={this.handleMute} />;
+        actionBtn = (
+          <Button
+            text={intl.formatMessage(messages.unmute)}
+            onClick={this.handleMute}
+          />
+        );
       } else if (!account.getIn(['relationship', 'blocking'])) {
-        actionBtn = <Button disabled={account.getIn(['relationship', 'blocked_by'])} className={classNames({ 'button--destructive': account.getIn(['relationship', 'following']) })} text={intl.formatMessage(account.getIn(['relationship', 'following']) ? messages.unfollow : messages.follow)} onClick={this.handleFollow} />;
+        actionBtn = (
+          <Button
+            disabled={account.getIn(['relationship', 'blocked_by'])}
+            className={classNames({
+              'button--destructive': account.getIn([
+                'relationship',
+                'following',
+              ]),
+            })}
+            text={intl.formatMessage(
+              account.getIn(['relationship', 'following'])
+                ? messages.unfollow
+                : messages.follow,
+            )}
+            onClick={this.handleFollow}
+          />
+        );
       } else if (account.getIn(['relationship', 'blocking'])) {
-        actionBtn = <Button  text={intl.formatMessage(messages.unblock)} onClick={this.handleBlock} />;
+        actionBtn = (
+          <Button
+            text={intl.formatMessage(messages.unblock)}
+            onClick={this.handleBlock}
+          />
+        );
       }
     } else {
-      actionBtn = <Button  text={intl.formatMessage(messages.edit_profile)} onClick={this.handleEditProfile} />;
+      actionBtn = (
+        <Button
+          text={intl.formatMessage(messages.edit_profile)}
+          onClick={this.handleEditProfile}
+        />
+      );
     }
 
     return (
       <div className='account-card'>
-        <Link to={`/@${account.get('acct')}`} className='account-card__permalink'>
+        <Link
+          to={`/@${account.get('acct')}`}
+          className='account-card__permalink'
+        >
           <div className='account-card__header'>
             <img
               src={
-                autoPlayGif ? account.get('header') : account.get('header_static')
+                autoPlayGif
+                  ? account.get('header')
+                  : account.get('header_static')
               }
               alt=''
             />
           </div>
 
           <div className='account-card__title'>
-            <div className='account-card__title__avatar'><Avatar account={account} size={56} /></div>
+            <div className='account-card__title__avatar'>
+              <Avatar account={account} size={56} />
+            </div>
             <DisplayName account={account} />
           </div>
         </Link>
@@ -229,14 +293,13 @@ class AccountCard extends ImmutablePureComponent {
             </div>
           </div>
 
-          <div className='account-card__actions__button'>
-            {actionBtn}
-          </div>
+          <div className='account-card__actions__button'>{actionBtn}</div>
         </div>
       </div>
     );
   }
-
 }
 
-export default injectIntl(connect(makeMapStateToProps, mapDispatchToProps)(AccountCard));
+export default injectIntl(
+  connect(makeMapStateToProps, mapDispatchToProps)(AccountCard),
+);

--- a/app/javascript/mastodon/features/directory/index.jsx
+++ b/app/javascript/mastodon/features/directory/index.jsx
@@ -9,7 +9,12 @@ import { List as ImmutableList } from 'immutable';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
 
-import { addColumn, removeColumn, moveColumn, changeColumnParams } from 'mastodon/actions/columns';
+import {
+  addColumn,
+  removeColumn,
+  moveColumn,
+  changeColumnParams,
+} from 'mastodon/actions/columns';
 import { fetchDirectory, expandDirectory } from 'mastodon/actions/directory';
 import Column from 'mastodon/components/column';
 import ColumnHeader from 'mastodon/components/column_header';
@@ -22,20 +27,28 @@ import AccountCard from './components/account_card';
 
 const messages = defineMessages({
   title: { id: 'column.directory', defaultMessage: 'Browse profiles' },
-  recentlyActive: { id: 'directory.recently_active', defaultMessage: 'Recently active' },
+  recentlyActive: {
+    id: 'directory.recently_active',
+    defaultMessage: 'Recently active',
+  },
   newArrivals: { id: 'directory.new_arrivals', defaultMessage: 'New arrivals' },
   local: { id: 'directory.local', defaultMessage: 'From {domain} only' },
-  federated: { id: 'directory.federated', defaultMessage: 'From known fediverse' },
+  federated: {
+    id: 'directory.federated',
+    defaultMessage: 'From known fediverse',
+  },
 });
 
-const mapStateToProps = state => ({
-  accountIds: state.getIn(['user_lists', 'directory', 'items'], ImmutableList()),
+const mapStateToProps = (state) => ({
+  accountIds: state.getIn(
+    ['user_lists', 'directory', 'items'],
+    ImmutableList(),
+  ),
   isLoading: state.getIn(['user_lists', 'directory', 'isLoading'], true),
   domain: state.getIn(['meta', 'domain']),
 });
 
 class Directory extends PureComponent {
-
   static contextTypes = {
     router: PropTypes.object,
   };
@@ -70,11 +83,11 @@ class Directory extends PureComponent {
   };
 
   getParams = (props, state) => ({
-    order: state.order === null ? (props.params.order || 'active') : state.order,
-    local: state.local === null ? (props.params.local || false) : state.local,
+    order: state.order === null ? props.params.order || 'active' : state.order,
+    local: state.local === null ? props.params.local || false : state.local,
   });
 
-  handleMove = dir => {
+  handleMove = (dir) => {
     const { columnId, dispatch } = this.props;
     dispatch(moveColumn(columnId, dir));
   };
@@ -83,26 +96,29 @@ class Directory extends PureComponent {
     this.column.scrollTop();
   };
 
-  componentDidMount () {
+  componentDidMount() {
     const { dispatch } = this.props;
     dispatch(fetchDirectory(this.getParams(this.props, this.state)));
   }
 
-  componentDidUpdate (prevProps, prevState) {
+  componentDidUpdate(prevProps, prevState) {
     const { dispatch } = this.props;
     const paramsOld = this.getParams(prevProps, prevState);
     const paramsNew = this.getParams(this.props, this.state);
 
-    if (paramsOld.order !== paramsNew.order || paramsOld.local !== paramsNew.local) {
+    if (
+      paramsOld.order !== paramsNew.order ||
+      paramsOld.local !== paramsNew.local
+    ) {
       dispatch(fetchDirectory(paramsNew));
     }
   }
 
-  setRef = c => {
+  setRef = (c) => {
     this.column = c;
   };
 
-  handleChangeOrder = e => {
+  handleChangeOrder = (e) => {
     const { dispatch, columnId } = this.props;
 
     if (columnId) {
@@ -112,7 +128,7 @@ class Directory extends PureComponent {
     }
   };
 
-  handleChangeLocal = e => {
+  handleChangeLocal = (e) => {
     const { dispatch, columnId } = this.props;
 
     if (columnId) {
@@ -127,29 +143,58 @@ class Directory extends PureComponent {
     dispatch(expandDirectory(this.getParams(this.props, this.state)));
   };
 
-  render () {
-    const { isLoading, accountIds, intl, columnId, multiColumn, domain } = this.props;
-    const { order, local }  = this.getParams(this.props, this.state);
+  render() {
+    const { isLoading, accountIds, intl, columnId, multiColumn, domain } =
+      this.props;
+    const { order, local } = this.getParams(this.props, this.state);
     const pinned = !!columnId;
 
     const scrollableArea = (
       <div className='scrollable'>
         <div className='filter-form'>
           <div className='filter-form__column' role='group'>
-            <RadioButton name='order' value='active' label={intl.formatMessage(messages.recentlyActive)} checked={order === 'active'} onChange={this.handleChangeOrder} />
-            <RadioButton name='order' value='new' label={intl.formatMessage(messages.newArrivals)} checked={order === 'new'} onChange={this.handleChangeOrder} />
+            <RadioButton
+              name='order'
+              value='active'
+              label={intl.formatMessage(messages.recentlyActive)}
+              checked={order === 'active'}
+              onChange={this.handleChangeOrder}
+            />
+            <RadioButton
+              name='order'
+              value='new'
+              label={intl.formatMessage(messages.newArrivals)}
+              checked={order === 'new'}
+              onChange={this.handleChangeOrder}
+            />
           </div>
 
           <div className='filter-form__column' role='group'>
-            <RadioButton name='local' value='1' label={intl.formatMessage(messages.local, { domain })} checked={local} onChange={this.handleChangeLocal} />
-            <RadioButton name='local' value='0' label={intl.formatMessage(messages.federated)} checked={!local} onChange={this.handleChangeLocal} />
+            <RadioButton
+              name='local'
+              value='1'
+              label={intl.formatMessage(messages.local, { domain })}
+              checked={local}
+              onChange={this.handleChangeLocal}
+            />
+            <RadioButton
+              name='local'
+              value='0'
+              label={intl.formatMessage(messages.federated)}
+              checked={!local}
+              onChange={this.handleChangeLocal}
+            />
           </div>
         </div>
 
         <div className='directory__list'>
-          {isLoading ? <LoadingIndicator /> : accountIds.map(accountId => (
-            <AccountCard id={accountId} key={accountId} />
-          ))}
+          {isLoading ? (
+            <LoadingIndicator />
+          ) : (
+            accountIds.map((accountId) => (
+              <AccountCard id={accountId} key={accountId} />
+            ))
+          )}
         </div>
 
         <LoadMore onClick={this.handleLoadMore} visible={!isLoading} />
@@ -157,7 +202,11 @@ class Directory extends PureComponent {
     );
 
     return (
-      <Column bindToDocument={!multiColumn} ref={this.setRef} label={intl.formatMessage(messages.title)}>
+      <Column
+        bindToDocument={!multiColumn}
+        ref={this.setRef}
+        label={intl.formatMessage(messages.title)}
+      >
         <ColumnHeader
           icon='address-book-o'
           title={intl.formatMessage(messages.title)}
@@ -168,7 +217,13 @@ class Directory extends PureComponent {
           multiColumn={multiColumn}
         />
 
-        {multiColumn && !pinned ? <ScrollContainer scrollKey='directory'>{scrollableArea}</ScrollContainer> : scrollableArea}
+        {multiColumn && !pinned ? (
+          <ScrollContainer scrollKey='directory'>
+            {scrollableArea}
+          </ScrollContainer>
+        ) : (
+          scrollableArea
+        )}
 
         <Helmet>
           <title>{intl.formatMessage(messages.title)}</title>
@@ -177,7 +232,6 @@ class Directory extends PureComponent {
       </Column>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(injectIntl(Directory));

--- a/app/javascript/mastodon/features/domain_blocks/index.jsx
+++ b/app/javascript/mastodon/features/domain_blocks/index.jsx
@@ -10,7 +10,10 @@ import { connect } from 'react-redux';
 
 import { debounce } from 'lodash';
 
-import { fetchDomainBlocks, expandDomainBlocks } from '../../actions/domain_blocks';
+import {
+  fetchDomainBlocks,
+  expandDomainBlocks,
+} from '../../actions/domain_blocks';
 import ColumnBackButtonSlim from '../../components/column_back_button_slim';
 import { LoadingIndicator } from '../../components/loading_indicator';
 import ScrollableList from '../../components/scrollable_list';
@@ -19,16 +22,18 @@ import Column from '../ui/components/column';
 
 const messages = defineMessages({
   heading: { id: 'column.domain_blocks', defaultMessage: 'Blocked domains' },
-  unblockDomain: { id: 'account.unblock_domain', defaultMessage: 'Unblock domain {domain}' },
+  unblockDomain: {
+    id: 'account.unblock_domain',
+    defaultMessage: 'Unblock domain {domain}',
+  },
 });
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   domains: state.getIn(['domain_lists', 'blocks', 'items']),
   hasMore: !!state.getIn(['domain_lists', 'blocks', 'next']),
 });
 
 class Blocks extends ImmutablePureComponent {
-
   static propTypes = {
     params: PropTypes.object.isRequired,
     dispatch: PropTypes.func.isRequired,
@@ -38,15 +43,19 @@ class Blocks extends ImmutablePureComponent {
     multiColumn: PropTypes.bool,
   };
 
-  UNSAFE_componentWillMount () {
+  UNSAFE_componentWillMount() {
     this.props.dispatch(fetchDomainBlocks());
   }
 
-  handleLoadMore = debounce(() => {
-    this.props.dispatch(expandDomainBlocks());
-  }, 300, { leading: true });
+  handleLoadMore = debounce(
+    () => {
+      this.props.dispatch(expandDomainBlocks());
+    },
+    300,
+    { leading: true },
+  );
 
-  render () {
+  render() {
     const { intl, domains, hasMore, multiColumn } = this.props;
 
     if (!domains) {
@@ -57,10 +66,19 @@ class Blocks extends ImmutablePureComponent {
       );
     }
 
-    const emptyMessage = <FormattedMessage id='empty_column.domain_blocks' defaultMessage='There are no blocked domains yet.' />;
+    const emptyMessage = (
+      <FormattedMessage
+        id='empty_column.domain_blocks'
+        defaultMessage='There are no blocked domains yet.'
+      />
+    );
 
     return (
-      <Column bindToDocument={!multiColumn} icon='minus-circle' heading={intl.formatMessage(messages.heading)}>
+      <Column
+        bindToDocument={!multiColumn}
+        icon='minus-circle'
+        heading={intl.formatMessage(messages.heading)}
+      >
         <ColumnBackButtonSlim />
 
         <ScrollableList
@@ -70,9 +88,9 @@ class Blocks extends ImmutablePureComponent {
           emptyMessage={emptyMessage}
           bindToDocument={!multiColumn}
         >
-          {domains.map(domain =>
-            <DomainContainer key={domain} domain={domain} />,
-          )}
+          {domains.map((domain) => (
+            <DomainContainer key={domain} domain={domain} />
+          ))}
         </ScrollableList>
 
         <Helmet>
@@ -81,7 +99,6 @@ class Blocks extends ImmutablePureComponent {
       </Column>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(injectIntl(Blocks));

--- a/app/javascript/mastodon/features/emoji/__tests__/emoji-test.js
+++ b/app/javascript/mastodon/features/emoji/__tests__/emoji-test.js
@@ -7,7 +7,9 @@ describe('emoji', () => {
     });
 
     it('ignores shortcodes inside of tags', () => {
-      expect(emojify('<p data-foo=":smile:"></p>')).toEqual('<p data-foo=":smile:"></p>');
+      expect(emojify('<p data-foo=":smile:"></p>')).toEqual(
+        '<p data-foo=":smile:"></p>',
+      );
     });
 
     it('works with unclosed tags', () => {
@@ -21,57 +23,99 @@ describe('emoji', () => {
     });
 
     it('does unicode', () => {
-      expect(emojify('\uD83D\uDC69\u200D\uD83D\uDC69\u200D\uD83D\uDC66\u200D\uD83D\uDC66')).toEqual(
-        '<img draggable="false" class="emojione" alt="👩‍👩‍👦‍👦" title=":woman-woman-boy-boy:" src="/emoji/1f469-200d-1f469-200d-1f466-200d-1f466.svg">');
+      expect(
+        emojify(
+          '\uD83D\uDC69\u200D\uD83D\uDC69\u200D\uD83D\uDC66\u200D\uD83D\uDC66',
+        ),
+      ).toEqual(
+        '<img draggable="false" class="emojione" alt="👩‍👩‍👦‍👦" title=":woman-woman-boy-boy:" src="/emoji/1f469-200d-1f469-200d-1f466-200d-1f466.svg">',
+      );
       expect(emojify('👨‍👩‍👧‍👧')).toEqual(
-        '<img draggable="false" class="emojione" alt="👨‍👩‍👧‍👧" title=":man-woman-girl-girl:" src="/emoji/1f468-200d-1f469-200d-1f467-200d-1f467.svg">');
-      expect(emojify('👩‍👩‍👦')).toEqual('<img draggable="false" class="emojione" alt="👩‍👩‍👦" title=":woman-woman-boy:" src="/emoji/1f469-200d-1f469-200d-1f466.svg">');
+        '<img draggable="false" class="emojione" alt="👨‍👩‍👧‍👧" title=":man-woman-girl-girl:" src="/emoji/1f468-200d-1f469-200d-1f467-200d-1f467.svg">',
+      );
+      expect(emojify('👩‍👩‍👦')).toEqual(
+        '<img draggable="false" class="emojione" alt="👩‍👩‍👦" title=":woman-woman-boy:" src="/emoji/1f469-200d-1f469-200d-1f466.svg">',
+      );
       expect(emojify('\u2757')).toEqual(
-        '<img draggable="false" class="emojione" alt="❗" title=":exclamation:" src="/emoji/2757.svg">');
+        '<img draggable="false" class="emojione" alt="❗" title=":exclamation:" src="/emoji/2757.svg">',
+      );
     });
 
     it('does multiple unicode', () => {
       expect(emojify('\u2757 #\uFE0F\u20E3')).toEqual(
-        '<img draggable="false" class="emojione" alt="❗" title=":exclamation:" src="/emoji/2757.svg"> <img draggable="false" class="emojione" alt="#️⃣" title=":hash:" src="/emoji/23-20e3.svg">');
+        '<img draggable="false" class="emojione" alt="❗" title=":exclamation:" src="/emoji/2757.svg"> <img draggable="false" class="emojione" alt="#️⃣" title=":hash:" src="/emoji/23-20e3.svg">',
+      );
       expect(emojify('\u2757#\uFE0F\u20E3')).toEqual(
-        '<img draggable="false" class="emojione" alt="❗" title=":exclamation:" src="/emoji/2757.svg"><img draggable="false" class="emojione" alt="#️⃣" title=":hash:" src="/emoji/23-20e3.svg">');
+        '<img draggable="false" class="emojione" alt="❗" title=":exclamation:" src="/emoji/2757.svg"><img draggable="false" class="emojione" alt="#️⃣" title=":hash:" src="/emoji/23-20e3.svg">',
+      );
       expect(emojify('\u2757 #\uFE0F\u20E3 \u2757')).toEqual(
-        '<img draggable="false" class="emojione" alt="❗" title=":exclamation:" src="/emoji/2757.svg"> <img draggable="false" class="emojione" alt="#️⃣" title=":hash:" src="/emoji/23-20e3.svg"> <img draggable="false" class="emojione" alt="❗" title=":exclamation:" src="/emoji/2757.svg">');
+        '<img draggable="false" class="emojione" alt="❗" title=":exclamation:" src="/emoji/2757.svg"> <img draggable="false" class="emojione" alt="#️⃣" title=":hash:" src="/emoji/23-20e3.svg"> <img draggable="false" class="emojione" alt="❗" title=":exclamation:" src="/emoji/2757.svg">',
+      );
       expect(emojify('foo \u2757 #\uFE0F\u20E3 bar')).toEqual(
-        'foo <img draggable="false" class="emojione" alt="❗" title=":exclamation:" src="/emoji/2757.svg"> <img draggable="false" class="emojione" alt="#️⃣" title=":hash:" src="/emoji/23-20e3.svg"> bar');
+        'foo <img draggable="false" class="emojione" alt="❗" title=":exclamation:" src="/emoji/2757.svg"> <img draggable="false" class="emojione" alt="#️⃣" title=":hash:" src="/emoji/23-20e3.svg"> bar',
+      );
     });
 
     it('ignores unicode inside of tags', () => {
-      expect(emojify('<p data-foo="\uD83D\uDC69\uD83D\uDC69\uD83D\uDC66"></p>')).toEqual('<p data-foo="\uD83D\uDC69\uD83D\uDC69\uD83D\uDC66"></p>');
+      expect(
+        emojify('<p data-foo="\uD83D\uDC69\uD83D\uDC69\uD83D\uDC66"></p>'),
+      ).toEqual('<p data-foo="\uD83D\uDC69\uD83D\uDC69\uD83D\uDC66"></p>');
     });
 
     it('does multiple emoji properly (issue 5188)', () => {
-      expect(emojify('👌🌈💕')).toEqual('<img draggable="false" class="emojione" alt="👌" title=":ok_hand:" src="/emoji/1f44c.svg"><img draggable="false" class="emojione" alt="🌈" title=":rainbow:" src="/emoji/1f308.svg"><img draggable="false" class="emojione" alt="💕" title=":two_hearts:" src="/emoji/1f495.svg">');
-      expect(emojify('👌 🌈 💕')).toEqual('<img draggable="false" class="emojione" alt="👌" title=":ok_hand:" src="/emoji/1f44c.svg"> <img draggable="false" class="emojione" alt="🌈" title=":rainbow:" src="/emoji/1f308.svg"> <img draggable="false" class="emojione" alt="💕" title=":two_hearts:" src="/emoji/1f495.svg">');
+      expect(emojify('👌🌈💕')).toEqual(
+        '<img draggable="false" class="emojione" alt="👌" title=":ok_hand:" src="/emoji/1f44c.svg"><img draggable="false" class="emojione" alt="🌈" title=":rainbow:" src="/emoji/1f308.svg"><img draggable="false" class="emojione" alt="💕" title=":two_hearts:" src="/emoji/1f495.svg">',
+      );
+      expect(emojify('👌 🌈 💕')).toEqual(
+        '<img draggable="false" class="emojione" alt="👌" title=":ok_hand:" src="/emoji/1f44c.svg"> <img draggable="false" class="emojione" alt="🌈" title=":rainbow:" src="/emoji/1f308.svg"> <img draggable="false" class="emojione" alt="💕" title=":two_hearts:" src="/emoji/1f495.svg">',
+      );
     });
 
     it('does an emoji that has no shortcode', () => {
-      expect(emojify('👁‍🗨')).toEqual('<img draggable="false" class="emojione" alt="👁‍🗨" title="" src="/emoji/1f441-200d-1f5e8.svg">');
+      expect(emojify('👁‍🗨')).toEqual(
+        '<img draggable="false" class="emojione" alt="👁‍🗨" title="" src="/emoji/1f441-200d-1f5e8.svg">',
+      );
     });
 
     it('does an emoji whose filename is irregular', () => {
-      expect(emojify('↙️')).toEqual('<img draggable="false" class="emojione" alt="↙️" title=":arrow_lower_left:" src="/emoji/2199.svg">');
+      expect(emojify('↙️')).toEqual(
+        '<img draggable="false" class="emojione" alt="↙️" title=":arrow_lower_left:" src="/emoji/2199.svg">',
+      );
     });
 
     it('avoid emojifying on invisible text', () => {
-      expect(emojify('<a href="http://example.com/test%F0%9F%98%84"><span class="invisible">http://</span><span class="ellipsis">example.com/te</span><span class="invisible">st😄</span></a>'))
-        .toEqual('<a href="http://example.com/test%F0%9F%98%84"><span class="invisible">http://</span><span class="ellipsis">example.com/te</span><span class="invisible">st😄</span></a>');
-      expect(emojify('<span class="invisible">:luigi:</span>', { ':luigi:': { static_url: 'luigi.exe' } }))
-        .toEqual('<span class="invisible">:luigi:</span>');
+      expect(
+        emojify(
+          '<a href="http://example.com/test%F0%9F%98%84"><span class="invisible">http://</span><span class="ellipsis">example.com/te</span><span class="invisible">st😄</span></a>',
+        ),
+      ).toEqual(
+        '<a href="http://example.com/test%F0%9F%98%84"><span class="invisible">http://</span><span class="ellipsis">example.com/te</span><span class="invisible">st😄</span></a>',
+      );
+      expect(
+        emojify('<span class="invisible">:luigi:</span>', {
+          ':luigi:': { static_url: 'luigi.exe' },
+        }),
+      ).toEqual('<span class="invisible">:luigi:</span>');
     });
 
     it('avoid emojifying on invisible text with nested tags', () => {
-      expect(emojify('<span class="invisible">😄<span class="foo">bar</span>😴</span>😇'))
-        .toEqual('<span class="invisible">😄<span class="foo">bar</span>😴</span><img draggable="false" class="emojione" alt="😇" title=":innocent:" src="/emoji/1f607.svg">');
-      expect(emojify('<span class="invisible">😄<span class="invisible">😕</span>😴</span>😇'))
-        .toEqual('<span class="invisible">😄<span class="invisible">😕</span>😴</span><img draggable="false" class="emojione" alt="😇" title=":innocent:" src="/emoji/1f607.svg">');
-      expect(emojify('<span class="invisible">😄<br>😴</span>😇'))
-        .toEqual('<span class="invisible">😄<br>😴</span><img draggable="false" class="emojione" alt="😇" title=":innocent:" src="/emoji/1f607.svg">');
+      expect(
+        emojify(
+          '<span class="invisible">😄<span class="foo">bar</span>😴</span>😇',
+        ),
+      ).toEqual(
+        '<span class="invisible">😄<span class="foo">bar</span>😴</span><img draggable="false" class="emojione" alt="😇" title=":innocent:" src="/emoji/1f607.svg">',
+      );
+      expect(
+        emojify(
+          '<span class="invisible">😄<span class="invisible">😕</span>😴</span>😇',
+        ),
+      ).toEqual(
+        '<span class="invisible">😄<span class="invisible">😕</span>😴</span><img draggable="false" class="emojione" alt="😇" title=":innocent:" src="/emoji/1f607.svg">',
+      );
+      expect(emojify('<span class="invisible">😄<br>😴</span>😇')).toEqual(
+        '<span class="invisible">😄<br>😴</span><img draggable="false" class="emojione" alt="😇" title=":innocent:" src="/emoji/1f607.svg">',
+      );
     });
 
     it('does not emojify emojis with textual presentation VS15 character', () => {
@@ -80,18 +124,25 @@ describe('emoji', () => {
     });
 
     it('does an simple emoji properly', () => {
-      expect(emojify('♀♂'))
-        .toEqual('<img draggable="false" class="emojione" alt="♀" title=":female_sign:" src="/emoji/2640.svg"><img draggable="false" class="emojione" alt="♂" title=":male_sign:" src="/emoji/2642.svg">');
+      expect(emojify('♀♂')).toEqual(
+        '<img draggable="false" class="emojione" alt="♀" title=":female_sign:" src="/emoji/2640.svg"><img draggable="false" class="emojione" alt="♂" title=":male_sign:" src="/emoji/2642.svg">',
+      );
     });
 
     it('does an emoji containing ZWJ properly', () => {
-      expect(emojify('💂‍♀️💂‍♂️'))
-        .toEqual('<img draggable="false" class="emojione" alt="💂\u200D♀️" title=":female-guard:" src="/emoji/1f482-200d-2640-fe0f_border.svg"><img draggable="false" class="emojione" alt="💂\u200D♂️" title=":male-guard:" src="/emoji/1f482-200d-2642-fe0f_border.svg">');
+      expect(emojify('💂‍♀️💂‍♂️')).toEqual(
+        '<img draggable="false" class="emojione" alt="💂\u200D♀️" title=":female-guard:" src="/emoji/1f482-200d-2640-fe0f_border.svg"><img draggable="false" class="emojione" alt="💂\u200D♂️" title=":male-guard:" src="/emoji/1f482-200d-2642-fe0f_border.svg">',
+      );
     });
 
     it('keeps ordering as expected (issue fixed by PR 20677)', () => {
-      expect(emojify('<p>💕 <a class="hashtag" href="https://example.com/tags/foo" rel="nofollow noopener noreferrer" target="_blank">#<span>foo</span></a> test: foo.</p>'))
-        .toEqual('<p><img draggable="false" class="emojione" alt="💕" title=":two_hearts:" src="/emoji/1f495.svg"> <a class="hashtag" href="https://example.com/tags/foo" rel="nofollow noopener noreferrer" target="_blank">#<span>foo</span></a> test: foo.</p>');
+      expect(
+        emojify(
+          '<p>💕 <a class="hashtag" href="https://example.com/tags/foo" rel="nofollow noopener noreferrer" target="_blank">#<span>foo</span></a> test: foo.</p>',
+        ),
+      ).toEqual(
+        '<p><img draggable="false" class="emojione" alt="💕" title=":two_hearts:" src="/emoji/1f495.svg"> <a class="hashtag" href="https://example.com/tags/foo" rel="nofollow noopener noreferrer" target="_blank">#<span>foo</span></a> test: foo.</p>',
+      );
     });
   });
 });

--- a/app/javascript/mastodon/features/emoji/__tests__/emoji_index-test.js
+++ b/app/javascript/mastodon/features/emoji/__tests__/emoji_index-test.js
@@ -3,7 +3,8 @@ import { pick } from 'lodash';
 
 import { search } from '../emoji_mart_search_light';
 
-const trimEmojis = emoji => pick(emoji, ['id', 'unified', 'native', 'custom']);
+const trimEmojis = (emoji) =>
+  pick(emoji, ['id', 'unified', 'native', 'custom']);
 
 describe('emoji_index', () => {
   it('should give same result for emoji_index_light and emoji-mart', () => {
@@ -118,33 +119,37 @@ describe('emoji_index', () => {
       },
     ];
     expect(search('masto', { custom }).map(trimEmojis)).toEqual(expected);
-    expect(emojiIndex.search('masto', { custom }).map(trimEmojis)).toEqual(expected);
+    expect(emojiIndex.search('masto', { custom }).map(trimEmojis)).toEqual(
+      expected,
+    );
   });
 
   it('should filter only emojis we care about, exclude pineapple', () => {
-    const emojisToShowFilter = emoji => emoji.unified !== '1F34D';
-    expect(search('apple', { emojisToShowFilter }).map((obj) => obj.id))
-      .not.toContain('pineapple');
-    expect(emojiIndex.search('apple', { emojisToShowFilter }).map((obj) => obj.id))
-      .not.toContain('pineapple');
+    const emojisToShowFilter = (emoji) => emoji.unified !== '1F34D';
+    expect(
+      search('apple', { emojisToShowFilter }).map((obj) => obj.id),
+    ).not.toContain('pineapple');
+    expect(
+      emojiIndex.search('apple', { emojisToShowFilter }).map((obj) => obj.id),
+    ).not.toContain('pineapple');
   });
 
   it('does an emoji whose unified name is irregular', () => {
     const expected = [
       {
-        'id': 'water_polo',
-        'unified': '1f93d',
-        'native': '🤽',
+        id: 'water_polo',
+        unified: '1f93d',
+        native: '🤽',
       },
       {
-        'id': 'man-playing-water-polo',
-        'unified': '1f93d-200d-2642-fe0f',
-        'native': '🤽‍♂️',
+        id: 'man-playing-water-polo',
+        unified: '1f93d-200d-2642-fe0f',
+        native: '🤽‍♂️',
       },
       {
-        'id': 'woman-playing-water-polo',
-        'unified': '1f93d-200d-2640-fe0f',
-        'native': '🤽‍♀️',
+        id: 'woman-playing-water-polo',
+        unified: '1f93d-200d-2640-fe0f',
+        native: '🤽‍♀️',
       },
     ];
     expect(search('polo').map(trimEmojis)).toEqual(expected);

--- a/app/javascript/mastodon/features/emoji/emoji.js
+++ b/app/javascript/mastodon/features/emoji/emoji.js
@@ -10,21 +10,110 @@ const trie = new Trie(Object.keys(unicodeMapping));
 
 // Convert to file names from emojis. (For different variation selector emojis)
 const emojiFilenames = (emojis) => {
-  return emojis.map(v => unicodeMapping[v].filename);
+  return emojis.map((v) => unicodeMapping[v].filename);
 };
 
 // Emoji requiring extra borders depending on theme
-const darkEmoji = emojiFilenames(['🎱', '🐜', '⚫', '🖤', '⬛', '◼️', '◾', '◼️', '✒️', '▪️', '💣', '🎳', '📷', '📸', '♣️', '🕶️', '✴️', '🔌', '💂‍♀️', '📽️', '🍳', '🦍', '💂', '🔪', '🕳️', '🕹️', '🕋', '🖊️', '🖋️', '💂‍♂️', '🎤', '🎓', '🎥', '🎼', '♠️', '🎩', '🦃', '📼', '📹', '🎮', '🐃', '🏴', '🐞', '🕺', '📱', '📲', '🚲']);
-const lightEmoji = emojiFilenames(['👽', '⚾', '🐔', '☁️', '💨', '🕊️', '👀', '🍥', '👻', '🐐', '❕', '❔', '⛸️', '🌩️', '🔊', '🔇', '📃', '🌧️', '🐏', '🍚', '🍙', '🐓', '🐑', '💀', '☠️', '🌨️', '🔉', '🔈', '💬', '💭', '🏐', '🏳️', '⚪', '⬜', '◽', '◻️', '▫️']);
+const darkEmoji = emojiFilenames([
+  '🎱',
+  '🐜',
+  '⚫',
+  '🖤',
+  '⬛',
+  '◼️',
+  '◾',
+  '◼️',
+  '✒️',
+  '▪️',
+  '💣',
+  '🎳',
+  '📷',
+  '📸',
+  '♣️',
+  '🕶️',
+  '✴️',
+  '🔌',
+  '💂‍♀️',
+  '📽️',
+  '🍳',
+  '🦍',
+  '💂',
+  '🔪',
+  '🕳️',
+  '🕹️',
+  '🕋',
+  '🖊️',
+  '🖋️',
+  '💂‍♂️',
+  '🎤',
+  '🎓',
+  '🎥',
+  '🎼',
+  '♠️',
+  '🎩',
+  '🦃',
+  '📼',
+  '📹',
+  '🎮',
+  '🐃',
+  '🏴',
+  '🐞',
+  '🕺',
+  '📱',
+  '📲',
+  '🚲',
+]);
+const lightEmoji = emojiFilenames([
+  '👽',
+  '⚾',
+  '🐔',
+  '☁️',
+  '💨',
+  '🕊️',
+  '👀',
+  '🍥',
+  '👻',
+  '🐐',
+  '❕',
+  '❔',
+  '⛸️',
+  '🌩️',
+  '🔊',
+  '🔇',
+  '📃',
+  '🌧️',
+  '🐏',
+  '🍚',
+  '🍙',
+  '🐓',
+  '🐑',
+  '💀',
+  '☠️',
+  '🌨️',
+  '🔉',
+  '🔈',
+  '💬',
+  '💭',
+  '🏐',
+  '🏳️',
+  '⚪',
+  '⬜',
+  '◽',
+  '◻️',
+  '▫️',
+]);
 
 const emojiFilename = (filename) => {
-  const borderedEmoji = (document.body && document.body.classList.contains('theme-mastodon-light')) ? lightEmoji : darkEmoji;
-  return borderedEmoji.includes(filename) ? (filename + '_border') : filename;
+  const borderedEmoji =
+    document.body && document.body.classList.contains('theme-mastodon-light')
+      ? lightEmoji
+      : darkEmoji;
+  return borderedEmoji.includes(filename) ? filename + '_border' : filename;
 };
 
 const emojifyTextNode = (node, customEmojis) => {
-  const VS15 = 0xFE0E;
-  const VS16 = 0xFE0F;
+  const VS15 = 0xfe0e;
+  const VS16 = 0xfe0f;
 
   let str = node.textContent;
 
@@ -40,7 +129,11 @@ const emojifyTextNode = (node, customEmojis) => {
         i += str.codePointAt(i) < 65536 ? 1 : 2;
       }
     } else {
-      while (i < str.length && str[i] !== ':' && !(unicode_emoji = trie.search(str.slice(i)))) {
+      while (
+        i < str.length &&
+        str[i] !== ':' &&
+        !(unicode_emoji = trie.search(str.slice(i)))
+      ) {
         i += str.codePointAt(i) < 65536 ? 1 : 2;
       }
     }
@@ -50,8 +143,10 @@ const emojifyTextNode = (node, customEmojis) => {
       break;
     }
 
-    let rend, replacement = null;
-    if (str[i] === ':') { // Potentially the start of a custom emoji :shortcode:
+    let rend,
+      replacement = null;
+    if (str[i] === ':') {
+      // Potentially the start of a custom emoji :shortcode:
       rend = str.indexOf(':', i + 1) + 1;
 
       // no matching ending ':', skip
@@ -80,11 +175,15 @@ const emojifyTextNode = (node, customEmojis) => {
       replacement.setAttribute('src', filename);
       replacement.setAttribute('data-original', custom_emoji.url);
       replacement.setAttribute('data-static', custom_emoji.static_url);
-    } else { // start of an unicode emoji
+    } else {
+      // start of an unicode emoji
       rend = i + unicode_emoji.length;
 
       // If the matched character was followed by VS15 (for selecting text presentation), skip it.
-      if (str.codePointAt(rend - 1) !== VS16 && str.codePointAt(rend) === VS15) {
+      if (
+        str.codePointAt(rend - 1) !== VS16 &&
+        str.codePointAt(rend) === VS15
+      ) {
         i = rend + 1;
         continue;
       }
@@ -97,7 +196,10 @@ const emojifyTextNode = (node, customEmojis) => {
       replacement.setAttribute('class', 'emojione');
       replacement.setAttribute('alt', unicode_emoji);
       replacement.setAttribute('title', title);
-      replacement.setAttribute('src', `${assetHost}/emoji/${emojiFilename(filename)}.svg`);
+      replacement.setAttribute(
+        'src',
+        `${assetHost}/emoji/${emojiFilename(filename)}.svg`,
+      );
     }
 
     // Add the processed-up-to-now string and the emoji replacement
@@ -113,14 +215,14 @@ const emojifyTextNode = (node, customEmojis) => {
 
 const emojifyNode = (node, customEmojis) => {
   for (const child of node.childNodes) {
-    switch(child.nodeType) {
-    case Node.TEXT_NODE:
-      emojifyTextNode(child, customEmojis);
-      break;
-    case Node.ELEMENT_NODE:
-      if (!child.classList.contains('invisible'))
-        emojifyNode(child, customEmojis);
-      break;
+    switch (child.nodeType) {
+      case Node.TEXT_NODE:
+        emojifyTextNode(child, customEmojis);
+        break;
+      case Node.ELEMENT_NODE:
+        if (!child.classList.contains('invisible'))
+          emojifyNode(child, customEmojis);
+        break;
     }
   }
 };
@@ -129,8 +231,7 @@ const emojify = (str, customEmojis = {}) => {
   const wrapper = document.createElement('div');
   wrapper.innerHTML = str;
 
-  if (!Object.keys(customEmojis).length)
-    customEmojis = null;
+  if (!Object.keys(customEmojis).length) customEmojis = null;
 
   emojifyNode(wrapper, customEmojis);
 
@@ -142,10 +243,10 @@ export default emojify;
 export const buildCustomEmojis = (customEmojis) => {
   const emojis = [];
 
-  customEmojis.forEach(emoji => {
+  customEmojis.forEach((emoji) => {
     const shortcode = emoji.get('shortcode');
-    const url       = autoPlayGif ? emoji.get('url') : emoji.get('static_url');
-    const name      = shortcode.replace(':', '');
+    const url = autoPlayGif ? emoji.get('url') : emoji.get('static_url');
+    const name = shortcode.replace(':', '');
 
     emojis.push({
       id: name,
@@ -163,4 +264,11 @@ export const buildCustomEmojis = (customEmojis) => {
   return emojis;
 };
 
-export const categoriesFromEmojis = customEmojis => customEmojis.reduce((set, emoji) => set.add(emoji.get('category') ? `custom-${emoji.get('category')}` : 'custom'), new Set(['custom']));
+export const categoriesFromEmojis = (customEmojis) =>
+  customEmojis.reduce(
+    (set, emoji) =>
+      set.add(
+        emoji.get('category') ? `custom-${emoji.get('category')}` : 'custom',
+      ),
+    new Set(['custom']),
+  );

--- a/app/javascript/mastodon/features/emoji/emoji_compressed.js
+++ b/app/javascript/mastodon/features/emoji/emoji_compressed.js
@@ -9,27 +9,28 @@
 
 const { emojiIndex } = require('emoji-mart');
 let data = require('emoji-mart/data/all.json');
-const { uncompress: emojiMartUncompress } = require('emoji-mart/dist/utils/data');
+const {
+  uncompress: emojiMartUncompress,
+} = require('emoji-mart/dist/utils/data');
 
 const emojiMap = require('./emoji_map.json');
 const { unicodeToFilename } = require('./unicode_to_filename');
 const { unicodeToUnifiedName } = require('./unicode_to_unified_name');
 
-
-if(data.compressed) {
+if (data.compressed) {
   data = emojiMartUncompress(data);
 }
 
 const emojiMartData = data;
 
-const excluded       = ['®', '©', '™'];
-const skinTones      = ['🏻', '🏼', '🏽', '🏾', '🏿'];
-const shortcodeMap   = {};
+const excluded = ['®', '©', '™'];
+const skinTones = ['🏻', '🏼', '🏽', '🏾', '🏿'];
+const shortcodeMap = {};
 
 const shortCodesToEmojiData = {};
 const emojisWithoutShortCodes = [];
 
-Object.keys(emojiIndex.emojis).forEach(key => {
+Object.keys(emojiIndex.emojis).forEach((key) => {
   let emoji = emojiIndex.emojis[key];
 
   // Emojis with skin tone modifiers are stored like this
@@ -40,22 +41,22 @@ Object.keys(emojiIndex.emojis).forEach(key => {
   shortcodeMap[emoji.native] = emoji.id;
 });
 
-const stripModifiers = unicode => {
-  skinTones.forEach(tone => {
+const stripModifiers = (unicode) => {
+  skinTones.forEach((tone) => {
     unicode = unicode.replace(tone, '');
   });
 
   return unicode;
 };
 
-Object.keys(emojiMap).forEach(key => {
+Object.keys(emojiMap).forEach((key) => {
   if (excluded.includes(key)) {
     delete emojiMap[key];
     return;
   }
 
   const normalizedKey = stripModifiers(key);
-  let shortcode       = shortcodeMap[normalizedKey];
+  let shortcode = shortcodeMap[normalizedKey];
 
   if (!shortcode) {
     shortcode = shortcodeMap[normalizedKey + '\uFE0F'];
@@ -81,7 +82,7 @@ Object.keys(emojiMap).forEach(key => {
   }
 });
 
-Object.keys(emojiIndex.emojis).forEach(key => {
+Object.keys(emojiIndex.emojis).forEach((key) => {
   let emoji = emojiIndex.emojis[key];
 
   // Emojis with skin tone modifiers are stored like this
@@ -93,9 +94,11 @@ Object.keys(emojiIndex.emojis).forEach(key => {
   let { short_names, search, unified } = emojiMartData.emojis[key];
 
   if (short_names[0] !== key) {
-    throw new Error('The compressor expects the first short_code to be the ' +
-      'key. It may need to be rewritten if the emoji change such that this ' +
-      'is no longer the case.');
+    throw new Error(
+      'The compressor expects the first short_code to be the ' +
+        'key. It may need to be rewritten if the emoji change such that this ' +
+        'is no longer the case.',
+    );
   }
 
   short_names = short_names.slice(1); // first short name can be inferred from the key
@@ -116,20 +119,22 @@ Object.keys(emojiIndex.emojis).forEach(key => {
 
 // JSON.parse/stringify is to emulate what @preval is doing and avoid any
 // inconsistent behavior in dev mode
-module.exports = JSON.parse(JSON.stringify([
-  shortCodesToEmojiData,
-  /*
-   * The property `skins` is not found in the current context.
-   * This could potentially lead to issues when interacting with modules or data structures
-   * that expect the presence of `skins` property.
-   * Currently, no definitions or references to `skins` property can be found in:
-   * - {@link node_modules/emoji-mart/dist/utils/data.js}
-   * - {@link node_modules/emoji-mart/data/all.json}
-   * - {@link app/javascript/mastodon/features/emoji/emoji_compressed.d.ts#Skins}
-   * Future refactorings or updates should consider adding definitions or handling for `skins` property.
-   */
-  emojiMartData.skins,
-  emojiMartData.categories,
-  emojiMartData.aliases,
-  emojisWithoutShortCodes,
-]));
+module.exports = JSON.parse(
+  JSON.stringify([
+    shortCodesToEmojiData,
+    /*
+     * The property `skins` is not found in the current context.
+     * This could potentially lead to issues when interacting with modules or data structures
+     * that expect the presence of `skins` property.
+     * Currently, no definitions or references to `skins` property can be found in:
+     * - {@link node_modules/emoji-mart/dist/utils/data.js}
+     * - {@link node_modules/emoji-mart/data/all.json}
+     * - {@link app/javascript/mastodon/features/emoji/emoji_compressed.d.ts#Skins}
+     * Future refactorings or updates should consider adding definitions or handling for `skins` property.
+     */
+    emojiMartData.skins,
+    emojiMartData.categories,
+    emojiMartData.aliases,
+    emojisWithoutShortCodes,
+  ]),
+);

--- a/app/javascript/mastodon/features/emoji/emoji_mart_search_light.js
+++ b/app/javascript/mastodon/features/emoji/emoji_mart_search_light.js
@@ -16,7 +16,7 @@ for (let emoji in data.emojis) {
   let id = short_names[0];
 
   if (emoticons) {
-    emoticons.forEach(emoticon => {
+    emoticons.forEach((emoticon) => {
       if (emoticonsList[emoticon]) {
         return;
       }
@@ -54,10 +54,12 @@ function addCustomToPool(custom, pool) {
   index = {};
 }
 
-function search(value, { emojisToShowFilter, maxResults, include, exclude, custom } = {}) {
+function search(
+  value,
+  { emojisToShowFilter, maxResults, include, exclude, custom } = {},
+) {
   if (custom !== undefined) {
-    if (customEmojisList !== custom)
-      addCustomToPool(custom, originalPool);
+    if (customEmojisList !== custom) addCustomToPool(custom, originalPool);
   } else {
     custom = [];
   }
@@ -84,19 +86,29 @@ function search(value, { emojisToShowFilter, maxResults, include, exclude, custo
     if (include.length || exclude.length) {
       pool = {};
 
-      data.categories.forEach(category => {
-        let isIncluded = include && include.length ? include.indexOf(category.name.toLowerCase()) > -1 : true;
-        let isExcluded = exclude && exclude.length ? exclude.indexOf(category.name.toLowerCase()) > -1 : false;
+      data.categories.forEach((category) => {
+        let isIncluded =
+          include && include.length
+            ? include.indexOf(category.name.toLowerCase()) > -1
+            : true;
+        let isExcluded =
+          exclude && exclude.length
+            ? exclude.indexOf(category.name.toLowerCase()) > -1
+            : false;
         if (!isIncluded || isExcluded) {
           return;
         }
 
-        category.emojis.forEach(emojiId => pool[emojiId] = data.emojis[emojiId]);
+        category.emojis.forEach(
+          (emojiId) => (pool[emojiId] = data.emojis[emojiId]),
+        );
       });
 
       if (custom.length) {
-        let customIsIncluded = include && include.length ? include.indexOf('custom') > -1 : true;
-        let customIsExcluded = exclude && exclude.length ? exclude.indexOf('custom') > -1 : false;
+        let customIsIncluded =
+          include && include.length ? include.indexOf('custom') > -1 : true;
+        let customIsExcluded =
+          exclude && exclude.length ? exclude.indexOf('custom') > -1 : false;
         if (customIsIncluded && !customIsExcluded) {
           addCustomToPool(custom, pool);
         }
@@ -158,7 +170,7 @@ function search(value, { emojisToShowFilter, maxResults, include, exclude, custo
       results = [];
     }
 
-    allResults = values.map(searchValue).filter(a => a);
+    allResults = values.map(searchValue).filter((a) => a);
 
     if (allResults.length > 1) {
       allResults = intersect.apply(null, allResults);
@@ -171,7 +183,9 @@ function search(value, { emojisToShowFilter, maxResults, include, exclude, custo
 
   if (results) {
     if (emojisToShowFilter) {
-      results = results.filter((result) => emojisToShowFilter(data.emojis[result.id]));
+      results = results.filter((result) =>
+        emojisToShowFilter(data.emojis[result.id]),
+      );
     }
 
     if (results && results.length > maxResults) {

--- a/app/javascript/mastodon/features/emoji/emoji_picker.js
+++ b/app/javascript/mastodon/features/emoji/emoji_picker.js
@@ -1,7 +1,4 @@
 import Emoji from 'emoji-mart/dist-es/components/emoji/emoji';
 import Picker from 'emoji-mart/dist-es/components/picker/picker';
 
-export {
-  Picker,
-  Emoji,
-};
+export { Picker, Emoji };

--- a/app/javascript/mastodon/features/emoji/emoji_unicode_mapping_light.js
+++ b/app/javascript/mastodon/features/emoji/emoji_unicode_mapping_light.js
@@ -17,7 +17,7 @@ const [
 const unicodeMapping = {};
 
 function processEmojiMapData(emojiMapData, shortCode) {
-  let [ native, filename ] = emojiMapData;
+  let [native, filename] = emojiMapData;
   if (!filename) {
     // filename name can be derived from unicodeToFilename
     filename = unicodeToFilename(native);
@@ -29,9 +29,13 @@ function processEmojiMapData(emojiMapData, shortCode) {
 }
 
 Object.keys(shortCodesToEmojiData).forEach((shortCode) => {
-  let [ filenameData ] = shortCodesToEmojiData[shortCode];
-  filenameData.forEach(emojiMapData => processEmojiMapData(emojiMapData, shortCode));
+  let [filenameData] = shortCodesToEmojiData[shortCode];
+  filenameData.forEach((emojiMapData) =>
+    processEmojiMapData(emojiMapData, shortCode),
+  );
 });
-emojisWithoutShortCodes.forEach(emojiMapData => processEmojiMapData(emojiMapData));
+emojisWithoutShortCodes.forEach((emojiMapData) =>
+  processEmojiMapData(emojiMapData),
+);
 
 export default unicodeMapping;

--- a/app/javascript/mastodon/features/emoji/emoji_utils.js
+++ b/app/javascript/mastodon/features/emoji/emoji_utils.js
@@ -32,52 +32,52 @@ const buildSearch = (data) => {
 
 const _String = String;
 
-const stringFromCodePoint = _String.fromCodePoint || function () {
-  let MAX_SIZE = 0x4000;
-  let codeUnits = [];
-  let highSurrogate;
-  let lowSurrogate;
-  let index = -1;
-  let length = arguments.length;
-  if (!length) {
-    return '';
-  }
-  let result = '';
-  while (++index < length) {
-    let codePoint = Number(arguments[index]);
-    if (
-      !isFinite(codePoint) ||       // `NaN`, `+Infinity`, or `-Infinity`
-      codePoint < 0 ||              // not a valid Unicode code point
-      codePoint > 0x10FFFF ||       // not a valid Unicode code point
-      Math.floor(codePoint) !== codePoint // not an integer
-    ) {
-      throw RangeError('Invalid code point: ' + codePoint);
+const stringFromCodePoint =
+  _String.fromCodePoint ||
+  function () {
+    let MAX_SIZE = 0x4000;
+    let codeUnits = [];
+    let highSurrogate;
+    let lowSurrogate;
+    let index = -1;
+    let length = arguments.length;
+    if (!length) {
+      return '';
     }
-    if (codePoint <= 0xFFFF) { // BMP code point
-      codeUnits.push(codePoint);
-    } else { // Astral code point; split in surrogate halves
-      // http://mathiasbynens.be/notes/javascript-encoding#surrogate-formulae
-      codePoint -= 0x10000;
-      highSurrogate = (codePoint >> 10) + 0xD800;
-      lowSurrogate = (codePoint % 0x400) + 0xDC00;
-      codeUnits.push(highSurrogate, lowSurrogate);
+    let result = '';
+    while (++index < length) {
+      let codePoint = Number(arguments[index]);
+      if (
+        !isFinite(codePoint) || // `NaN`, `+Infinity`, or `-Infinity`
+        codePoint < 0 || // not a valid Unicode code point
+        codePoint > 0x10ffff || // not a valid Unicode code point
+        Math.floor(codePoint) !== codePoint // not an integer
+      ) {
+        throw RangeError('Invalid code point: ' + codePoint);
+      }
+      if (codePoint <= 0xffff) {
+        // BMP code point
+        codeUnits.push(codePoint);
+      } else {
+        // Astral code point; split in surrogate halves
+        // http://mathiasbynens.be/notes/javascript-encoding#surrogate-formulae
+        codePoint -= 0x10000;
+        highSurrogate = (codePoint >> 10) + 0xd800;
+        lowSurrogate = (codePoint % 0x400) + 0xdc00;
+        codeUnits.push(highSurrogate, lowSurrogate);
+      }
+      if (index + 1 === length || codeUnits.length > MAX_SIZE) {
+        result += String.fromCharCode.apply(null, codeUnits);
+        codeUnits.length = 0;
+      }
     }
-    if (index + 1 === length || codeUnits.length > MAX_SIZE) {
-      result += String.fromCharCode.apply(null, codeUnits);
-      codeUnits.length = 0;
-    }
-  }
-  return result;
-};
-
+    return result;
+  };
 
 const _JSON = JSON;
 
 const COLONS_REGEX = /^(?::([^:]+):)(?::skin-tone-(\d):)?$/;
-const SKINS = [
-  '1F3FA', '1F3FB', '1F3FC',
-  '1F3FD', '1F3FE', '1F3FF',
-];
+const SKINS = ['1F3FA', '1F3FB', '1F3FC', '1F3FD', '1F3FE', '1F3FF'];
 
 function unifiedToNative(unified) {
   let unicodes = unified.split('-'),
@@ -87,7 +87,16 @@ function unifiedToNative(unified) {
 }
 
 function sanitize(emoji) {
-  let { name, short_names, skin_tone, skin_variations, emoticons, unified, custom, imageUrl } = emoji,
+  let {
+      name,
+      short_names,
+      skin_tone,
+      skin_variations,
+      emoticons,
+      unified,
+      custom,
+      imageUrl,
+    } = emoji,
     id = emoji.id || short_names[0],
     colons = `:${id}:`;
 
@@ -206,7 +215,7 @@ function intersect(a, b) {
   const uniqA = uniq(a);
   const uniqB = uniq(b);
 
-  return uniqA.filter(item => uniqB.indexOf(item) >= 0);
+  return uniqA.filter((item) => uniqB.indexOf(item) >= 0);
 }
 
 function deepMerge(a, b) {

--- a/app/javascript/mastodon/features/emoji/unicode_to_filename.js
+++ b/app/javascript/mastodon/features/emoji/unicode_to_filename.js
@@ -14,9 +14,11 @@ exports.unicodeToFilename = (str) => {
       if (result.length > 0) {
         result += '-';
       }
-      result += (0x10000 + ((p - 0xD800) << 10) + (charCode - 0xDC00)).toString(16);
+      result += (0x10000 + ((p - 0xd800) << 10) + (charCode - 0xdc00)).toString(
+        16,
+      );
       p = 0;
-    } else if (0xD800 <= charCode && charCode <= 0xDBFF) {
+    } else if (0xd800 <= charCode && charCode <= 0xdbff) {
       p = charCode;
     } else {
       if (result.length > 0) {

--- a/app/javascript/mastodon/features/explore/components/search_section.jsx
+++ b/app/javascript/mastodon/features/explore/components/search_section.jsx
@@ -6,7 +6,14 @@ export const SearchSection = ({ title, onClickMore, children }) => (
   <div className='search-results__section'>
     <div className='search-results__section__header'>
       <h3>{title}</h3>
-      {onClickMore && <button onClick={onClickMore}><FormattedMessage id='search_results.see_all' defaultMessage='See all' /></button>}
+      {onClickMore && (
+        <button onClick={onClickMore}>
+          <FormattedMessage
+            id='search_results.see_all'
+            defaultMessage='See all'
+          />
+        </button>
+      )}
     </div>
 
     {children}

--- a/app/javascript/mastodon/features/explore/components/story.jsx
+++ b/app/javascript/mastodon/features/explore/components/story.jsx
@@ -12,7 +12,6 @@ import { ShortNumber } from 'mastodon/components/short_number';
 import { Skeleton } from 'mastodon/components/skeleton';
 
 export default class Story extends PureComponent {
-
   static propTypes = {
     url: PropTypes.string,
     title: PropTypes.string,
@@ -33,29 +32,92 @@ export default class Story extends PureComponent {
 
   handleImageLoad = () => this.setState({ thumbnailLoaded: true });
 
-  render () {
-    const { expanded, url, title, lang, publisher, author, publishedAt, sharedTimes, thumbnail, thumbnailDescription, blurhash } = this.props;
+  render() {
+    const {
+      expanded,
+      url,
+      title,
+      lang,
+      publisher,
+      author,
+      publishedAt,
+      sharedTimes,
+      thumbnail,
+      thumbnailDescription,
+      blurhash,
+    } = this.props;
 
     const { thumbnailLoaded } = this.state;
 
     return (
-      <a className={classNames('story', { expanded })} href={url} target='blank' rel='noopener'>
+      <a
+        className={classNames('story', { expanded })}
+        href={url}
+        target='blank'
+        rel='noopener'
+      >
         <div className='story__details'>
-          <div className='story__details__publisher'>{publisher ? <span lang={lang}>{publisher}</span> : <Skeleton width={50} />}{publishedAt && <> · <RelativeTimestamp timestamp={publishedAt} /></>}</div>
-          <div className='story__details__title' lang={lang}>{title ? title : <Skeleton />}</div>
-          <div className='story__details__shared'>{author && <><FormattedMessage id='link_preview.author' defaultMessage='By {name}' values={{ name: <strong>{author}</strong> }} /> · </>}{typeof sharedTimes === 'number' ? <ShortNumber value={sharedTimes} renderer={accountsCountRenderer} /> : <Skeleton width={100} />}</div>
+          <div className='story__details__publisher'>
+            {publisher ? (
+              <span lang={lang}>{publisher}</span>
+            ) : (
+              <Skeleton width={50} />
+            )}
+            {publishedAt && (
+              <>
+                {' '}
+                · <RelativeTimestamp timestamp={publishedAt} />
+              </>
+            )}
+          </div>
+          <div className='story__details__title' lang={lang}>
+            {title ? title : <Skeleton />}
+          </div>
+          <div className='story__details__shared'>
+            {author && (
+              <>
+                <FormattedMessage
+                  id='link_preview.author'
+                  defaultMessage='By {name}'
+                  values={{ name: <strong>{author}</strong> }}
+                />{' '}
+                ·{' '}
+              </>
+            )}
+            {typeof sharedTimes === 'number' ? (
+              <ShortNumber
+                value={sharedTimes}
+                renderer={accountsCountRenderer}
+              />
+            ) : (
+              <Skeleton width={100} />
+            )}
+          </div>
         </div>
 
         <div className='story__thumbnail'>
           {thumbnail ? (
             <>
-              <div className={classNames('story__thumbnail__preview', { 'story__thumbnail__preview--hidden': thumbnailLoaded })}><Blurhash hash={blurhash} /></div>
-              <img src={thumbnail} onLoad={this.handleImageLoad} alt={thumbnailDescription} title={thumbnailDescription} lang={lang} />
+              <div
+                className={classNames('story__thumbnail__preview', {
+                  'story__thumbnail__preview--hidden': thumbnailLoaded,
+                })}
+              >
+                <Blurhash hash={blurhash} />
+              </div>
+              <img
+                src={thumbnail}
+                onLoad={this.handleImageLoad}
+                alt={thumbnailDescription}
+                title={thumbnailDescription}
+                lang={lang}
+              />
             </>
-          ) : <Skeleton />}
+          ) : (
+            <Skeleton />
+          )}
         </div>
       </a>
     );
   }
-
 }

--- a/app/javascript/mastodon/features/explore/index.jsx
+++ b/app/javascript/mastodon/features/explore/index.jsx
@@ -21,16 +21,18 @@ import Tags from './tags';
 
 const messages = defineMessages({
   title: { id: 'explore.title', defaultMessage: 'Explore' },
-  searchResults: { id: 'explore.search_results', defaultMessage: 'Search results' },
+  searchResults: {
+    id: 'explore.search_results',
+    defaultMessage: 'Search results',
+  },
 });
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   layout: state.getIn(['meta', 'layout']),
   isSearching: state.getIn(['search', 'submitted']) || !trendsEnabled,
 });
 
 class Explore extends PureComponent {
-
   static contextTypes = {
     router: PropTypes.object,
     identity: PropTypes.object,
@@ -46,7 +48,7 @@ class Explore extends PureComponent {
     this.column.scrollTop();
   };
 
-  setRef = c => {
+  setRef = (c) => {
     this.column = c;
   };
 
@@ -55,10 +57,16 @@ class Explore extends PureComponent {
     const { signedIn } = this.context.identity;
 
     return (
-      <Column bindToDocument={!multiColumn} ref={this.setRef} label={intl.formatMessage(messages.title)}>
+      <Column
+        bindToDocument={!multiColumn}
+        ref={this.setRef}
+        label={intl.formatMessage(messages.title)}
+      >
         <ColumnHeader
           icon={isSearching ? 'search' : 'hashtag'}
-          title={intl.formatMessage(isSearching ? messages.searchResults : messages.title)}
+          title={intl.formatMessage(
+            isSearching ? messages.searchResults : messages.title,
+          )}
           onClick={this.handleHeaderClick}
           multiColumn={multiColumn}
         />
@@ -74,21 +82,37 @@ class Explore extends PureComponent {
             <>
               <div className='account__section-headline'>
                 <NavLink exact to='/explore'>
-                  <FormattedMessage tagName='div' id='explore.trending_statuses' defaultMessage='Posts' />
+                  <FormattedMessage
+                    tagName='div'
+                    id='explore.trending_statuses'
+                    defaultMessage='Posts'
+                  />
                 </NavLink>
 
                 <NavLink exact to='/explore/tags'>
-                  <FormattedMessage tagName='div' id='explore.trending_tags' defaultMessage='Hashtags' />
+                  <FormattedMessage
+                    tagName='div'
+                    id='explore.trending_tags'
+                    defaultMessage='Hashtags'
+                  />
                 </NavLink>
 
                 {signedIn && (
                   <NavLink exact to='/explore/suggestions'>
-                    <FormattedMessage tagName='div' id='explore.suggested_follows' defaultMessage='People' />
+                    <FormattedMessage
+                      tagName='div'
+                      id='explore.suggested_follows'
+                      defaultMessage='People'
+                    />
                   </NavLink>
                 )}
 
                 <NavLink exact to='/explore/links'>
-                  <FormattedMessage tagName='div' id='explore.trending_links' defaultMessage='News' />
+                  <FormattedMessage
+                    tagName='div'
+                    id='explore.trending_links'
+                    defaultMessage='News'
+                  />
                 </NavLink>
               </div>
 
@@ -111,7 +135,6 @@ class Explore extends PureComponent {
       </Column>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(injectIntl(Explore));

--- a/app/javascript/mastodon/features/explore/links.jsx
+++ b/app/javascript/mastodon/features/explore/links.jsx
@@ -12,30 +12,32 @@ import { LoadingIndicator } from 'mastodon/components/loading_indicator';
 
 import Story from './components/story';
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   links: state.getIn(['trends', 'links', 'items']),
   isLoading: state.getIn(['trends', 'links', 'isLoading']),
 });
 
 class Links extends PureComponent {
-
   static propTypes = {
     links: ImmutablePropTypes.list,
     isLoading: PropTypes.bool,
     dispatch: PropTypes.func.isRequired,
   };
 
-  componentDidMount () {
+  componentDidMount() {
     const { dispatch } = this.props;
     dispatch(fetchTrendingLinks());
   }
 
-  render () {
+  render() {
     const { isLoading, links } = this.props;
 
     const banner = (
       <DismissableBanner id='explore/links'>
-        <FormattedMessage id='dismissable_banner.explore_links' defaultMessage='These are news stories being shared the most on the social web today. Newer news stories posted by more different people are ranked higher.' />
+        <FormattedMessage
+          id='dismissable_banner.explore_links'
+          defaultMessage='These are news stories being shared the most on the social web today. Newer news stories posted by more different people are ranked higher.'
+        />
       </DismissableBanner>
     );
 
@@ -45,7 +47,10 @@ class Links extends PureComponent {
           {banner}
 
           <div className='empty-column-indicator'>
-            <FormattedMessage id='empty_column.explore_statuses' defaultMessage='Nothing is trending right now. Check back later!' />
+            <FormattedMessage
+              id='empty_column.explore_statuses'
+              defaultMessage='Nothing is trending right now. Check back later!'
+            />
           </div>
         </div>
       );
@@ -55,26 +60,32 @@ class Links extends PureComponent {
       <div className='explore__links'>
         {banner}
 
-        {isLoading ? (<LoadingIndicator />) : links.map((link, i) => (
-          <Story
-            key={link.get('id')}
-            expanded={i === 0}
-            lang={link.get('language')}
-            url={link.get('url')}
-            title={link.get('title')}
-            publisher={link.get('provider_name')}
-            publishedAt={link.get('published_at')}
-            author={link.get('author_name')}
-            sharedTimes={link.getIn(['history', 0, 'accounts']) * 1 + link.getIn(['history', 1, 'accounts']) * 1}
-            thumbnail={link.get('image')}
-            thumbnailDescription={link.get('image_description')}
-            blurhash={link.get('blurhash')}
-          />
-        ))}
+        {isLoading ? (
+          <LoadingIndicator />
+        ) : (
+          links.map((link, i) => (
+            <Story
+              key={link.get('id')}
+              expanded={i === 0}
+              lang={link.get('language')}
+              url={link.get('url')}
+              title={link.get('title')}
+              publisher={link.get('provider_name')}
+              publishedAt={link.get('published_at')}
+              author={link.get('author_name')}
+              sharedTimes={
+                link.getIn(['history', 0, 'accounts']) * 1 +
+                link.getIn(['history', 1, 'accounts']) * 1
+              }
+              thumbnail={link.get('image')}
+              thumbnailDescription={link.get('image_description')}
+              blurhash={link.get('blurhash')}
+            />
+          ))
+        )}
       </div>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(Links);

--- a/app/javascript/mastodon/features/explore/results.jsx
+++ b/app/javascript/mastodon/features/explore/results.jsx
@@ -22,7 +22,7 @@ const messages = defineMessages({
   title: { id: 'search_results.title', defaultMessage: 'Search for {q}' },
 });
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   isLoading: state.getIn(['search', 'isLoading']),
   results: state.getIn(['search', 'results']),
   q: state.getIn(['search', 'searchTerm']),
@@ -32,7 +32,7 @@ const mapStateToProps = state => ({
 const INITIAL_PAGE_LIMIT = 10;
 const INITIAL_DISPLAY = 4;
 
-const hidePeek = list => {
+const hidePeek = (list) => {
   if (list.size > INITIAL_PAGE_LIMIT && list.size % INITIAL_PAGE_LIMIT === 1) {
     return list.skipLast(1);
   } else {
@@ -40,20 +40,18 @@ const hidePeek = list => {
   }
 };
 
-const renderAccounts = accounts => hidePeek(accounts).map(id => (
-  <Account key={id} id={id} />
-));
+const renderAccounts = (accounts) =>
+  hidePeek(accounts).map((id) => <Account key={id} id={id} />);
 
-const renderHashtags = hashtags => hidePeek(hashtags).map(hashtag => (
-  <Hashtag key={hashtag.get('name')} hashtag={hashtag} />
-));
+const renderHashtags = (hashtags) =>
+  hidePeek(hashtags).map((hashtag) => (
+    <Hashtag key={hashtag.get('name')} hashtag={hashtag} />
+  ));
 
-const renderStatuses = statuses => hidePeek(statuses).map(id => (
-  <Status key={id} id={id} />
-));
+const renderStatuses = (statuses) =>
+  hidePeek(statuses).map((id) => <Status key={id} id={id} />);
 
 class Results extends PureComponent {
-
   static propTypes = {
     results: ImmutablePropTypes.contains({
       accounts: ImmutablePropTypes.orderedSet,
@@ -80,7 +78,7 @@ class Results extends PureComponent {
     }
 
     return null;
-  };
+  }
 
   handleSelectAll = () => {
     const { submittedType, dispatch } = this.props;
@@ -116,7 +114,7 @@ class Results extends PureComponent {
     }
 
     this.setState({ type: 'hashtags' });
-  }
+  };
 
   handleSelectStatuses = () => {
     const { submittedType, dispatch } = this.props;
@@ -128,13 +126,13 @@ class Results extends PureComponent {
     }
 
     this.setState({ type: 'statuses' });
-  }
+  };
 
   handleLoadMoreAccounts = () => this._loadMore('accounts');
   handleLoadMoreStatuses = () => this._loadMore('statuses');
   handleLoadMoreHashtags = () => this._loadMore('hashtags');
 
-  _loadMore (type) {
+  _loadMore(type) {
     const { dispatch } = this.props;
     dispatch(expandSearch(type));
   }
@@ -147,12 +145,16 @@ class Results extends PureComponent {
     }
   };
 
-  render () {
+  render() {
     const { intl, isLoading, q, results } = this.props;
     const { type } = this.state;
 
     // We request 1 more result than we display so we can tell if there'd be a next page
-    const hasMore = type !== 'all' ? results.get(type, ImmutableList()).size > INITIAL_PAGE_LIMIT && results.get(type).size % INITIAL_PAGE_LIMIT === 1 : false;
+    const hasMore =
+      type !== 'all'
+        ? results.get(type, ImmutableList()).size > INITIAL_PAGE_LIMIT &&
+          results.get(type).size % INITIAL_PAGE_LIMIT === 1
+        : false;
 
     let filteredResults;
 
@@ -161,49 +163,123 @@ class Results extends PureComponent {
       const hashtags = results.get('hashtags', ImmutableList());
       const statuses = results.get('statuses', ImmutableList());
 
-      switch(type) {
-      case 'all':
-        filteredResults = (accounts.size + hashtags.size + statuses.size) > 0 ? (
-          <>
-            {accounts.size > 0 && (
-              <SearchSection key='accounts' title={<><Icon id='users' fixedWidth /><FormattedMessage id='search_results.accounts' defaultMessage='Profiles' /></>} onClickMore={this.handleLoadMoreAccounts}>
-                {accounts.take(INITIAL_DISPLAY).map(id => <Account key={id} id={id} />)}
-              </SearchSection>
-            )}
+      switch (type) {
+        case 'all':
+          filteredResults =
+            accounts.size + hashtags.size + statuses.size > 0 ? (
+              <>
+                {accounts.size > 0 && (
+                  <SearchSection
+                    key='accounts'
+                    title={
+                      <>
+                        <Icon id='users' fixedWidth />
+                        <FormattedMessage
+                          id='search_results.accounts'
+                          defaultMessage='Profiles'
+                        />
+                      </>
+                    }
+                    onClickMore={this.handleLoadMoreAccounts}
+                  >
+                    {accounts.take(INITIAL_DISPLAY).map((id) => (
+                      <Account key={id} id={id} />
+                    ))}
+                  </SearchSection>
+                )}
 
-            {hashtags.size > 0 && (
-              <SearchSection key='hashtags' title={<><Icon id='hashtag' fixedWidth /><FormattedMessage id='search_results.hashtags' defaultMessage='Hashtags' /></>} onClickMore={this.handleLoadMoreHashtags}>
-                {hashtags.take(INITIAL_DISPLAY).map(hashtag => <Hashtag key={hashtag.get('name')} hashtag={hashtag} />)}
-              </SearchSection>
-            )}
+                {hashtags.size > 0 && (
+                  <SearchSection
+                    key='hashtags'
+                    title={
+                      <>
+                        <Icon id='hashtag' fixedWidth />
+                        <FormattedMessage
+                          id='search_results.hashtags'
+                          defaultMessage='Hashtags'
+                        />
+                      </>
+                    }
+                    onClickMore={this.handleLoadMoreHashtags}
+                  >
+                    {hashtags.take(INITIAL_DISPLAY).map((hashtag) => (
+                      <Hashtag key={hashtag.get('name')} hashtag={hashtag} />
+                    ))}
+                  </SearchSection>
+                )}
 
-            {statuses.size > 0 && (
-              <SearchSection key='statuses' title={<><Icon id='quote-right' fixedWidth /><FormattedMessage id='search_results.statuses' defaultMessage='Posts' /></>} onClickMore={this.handleLoadMoreStatuses}>
-                {statuses.take(INITIAL_DISPLAY).map(id => <Status key={id} id={id} />)}
-              </SearchSection>
-            )}
-          </>
-        ) : [];
-        break;
-      case 'accounts':
-        filteredResults = renderAccounts(accounts);
-        break;
-      case 'hashtags':
-        filteredResults = renderHashtags(hashtags);
-        break;
-      case 'statuses':
-        filteredResults = renderStatuses(statuses);
-        break;
+                {statuses.size > 0 && (
+                  <SearchSection
+                    key='statuses'
+                    title={
+                      <>
+                        <Icon id='quote-right' fixedWidth />
+                        <FormattedMessage
+                          id='search_results.statuses'
+                          defaultMessage='Posts'
+                        />
+                      </>
+                    }
+                    onClickMore={this.handleLoadMoreStatuses}
+                  >
+                    {statuses.take(INITIAL_DISPLAY).map((id) => (
+                      <Status key={id} id={id} />
+                    ))}
+                  </SearchSection>
+                )}
+              </>
+            ) : (
+              []
+            );
+          break;
+        case 'accounts':
+          filteredResults = renderAccounts(accounts);
+          break;
+        case 'hashtags':
+          filteredResults = renderHashtags(hashtags);
+          break;
+        case 'statuses':
+          filteredResults = renderStatuses(statuses);
+          break;
       }
     }
 
     return (
       <>
         <div className='account__section-headline'>
-          <button onClick={this.handleSelectAll} className={type === 'all' ? 'active' : undefined}><FormattedMessage id='search_results.all' defaultMessage='All' /></button>
-          <button onClick={this.handleSelectAccounts} className={type === 'accounts' ? 'active' : undefined}><FormattedMessage id='search_results.accounts' defaultMessage='Profiles' /></button>
-          <button onClick={this.handleSelectHashtags} className={type === 'hashtags' ? 'active' : undefined}><FormattedMessage id='search_results.hashtags' defaultMessage='Hashtags' /></button>
-          <button onClick={this.handleSelectStatuses} className={type === 'statuses' ? 'active' : undefined}><FormattedMessage id='search_results.statuses' defaultMessage='Posts' /></button>
+          <button
+            onClick={this.handleSelectAll}
+            className={type === 'all' ? 'active' : undefined}
+          >
+            <FormattedMessage id='search_results.all' defaultMessage='All' />
+          </button>
+          <button
+            onClick={this.handleSelectAccounts}
+            className={type === 'accounts' ? 'active' : undefined}
+          >
+            <FormattedMessage
+              id='search_results.accounts'
+              defaultMessage='Profiles'
+            />
+          </button>
+          <button
+            onClick={this.handleSelectHashtags}
+            className={type === 'hashtags' ? 'active' : undefined}
+          >
+            <FormattedMessage
+              id='search_results.hashtags'
+              defaultMessage='Hashtags'
+            />
+          </button>
+          <button
+            onClick={this.handleSelectStatuses}
+            className={type === 'statuses' ? 'active' : undefined}
+          >
+            <FormattedMessage
+              id='search_results.statuses'
+              defaultMessage='Posts'
+            />
+          </button>
         </div>
 
         <div className='explore__search-results'>
@@ -212,7 +288,12 @@ class Results extends PureComponent {
             isLoading={isLoading}
             onLoadMore={this.handleLoadMore}
             hasMore={hasMore}
-            emptyMessage={<FormattedMessage id='search_results.nothing_found' defaultMessage='Could not find anything for these search terms' />}
+            emptyMessage={
+              <FormattedMessage
+                id='search_results.nothing_found'
+                defaultMessage='Could not find anything for these search terms'
+              />
+            }
             bindToDocument
           >
             {filteredResults}
@@ -225,7 +306,6 @@ class Results extends PureComponent {
       </>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(injectIntl(Results));

--- a/app/javascript/mastodon/features/explore/statuses.jsx
+++ b/app/javascript/mastodon/features/explore/statuses.jsx
@@ -8,19 +8,21 @@ import { connect } from 'react-redux';
 
 import { debounce } from 'lodash';
 
-import { fetchTrendingStatuses, expandTrendingStatuses } from 'mastodon/actions/trends';
+import {
+  fetchTrendingStatuses,
+  expandTrendingStatuses,
+} from 'mastodon/actions/trends';
 import { DismissableBanner } from 'mastodon/components/dismissable_banner';
 import StatusList from 'mastodon/components/status_list';
 import { getStatusList } from 'mastodon/selectors';
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   statusIds: getStatusList(state, 'trending'),
   isLoading: state.getIn(['status_lists', 'trending', 'isLoading'], true),
   hasMore: !!state.getIn(['status_lists', 'trending', 'next']),
 });
 
 class Statuses extends PureComponent {
-
   static propTypes = {
     statusIds: ImmutablePropTypes.list,
     isLoading: PropTypes.bool,
@@ -29,25 +31,37 @@ class Statuses extends PureComponent {
     dispatch: PropTypes.func.isRequired,
   };
 
-  componentDidMount () {
+  componentDidMount() {
     const { dispatch } = this.props;
     dispatch(fetchTrendingStatuses());
   }
 
-  handleLoadMore = debounce(() => {
-    const { dispatch } = this.props;
-    dispatch(expandTrendingStatuses());
-  }, 300, { leading: true });
+  handleLoadMore = debounce(
+    () => {
+      const { dispatch } = this.props;
+      dispatch(expandTrendingStatuses());
+    },
+    300,
+    { leading: true },
+  );
 
-  render () {
+  render() {
     const { isLoading, hasMore, statusIds, multiColumn } = this.props;
 
-    const emptyMessage = <FormattedMessage id='empty_column.explore_statuses' defaultMessage='Nothing is trending right now. Check back later!' />;
+    const emptyMessage = (
+      <FormattedMessage
+        id='empty_column.explore_statuses'
+        defaultMessage='Nothing is trending right now. Check back later!'
+      />
+    );
 
     return (
       <>
         <DismissableBanner id='explore/statuses'>
-          <FormattedMessage id='dismissable_banner.explore_statuses' defaultMessage='These are posts from across the social web that are gaining traction today. Newer posts with more boosts and favorites are ranked higher.' />
+          <FormattedMessage
+            id='dismissable_banner.explore_statuses'
+            defaultMessage='These are posts from across the social web that are gaining traction today. Newer posts with more boosts and favorites are ranked higher.'
+          />
         </DismissableBanner>
 
         <StatusList
@@ -65,7 +79,6 @@ class Statuses extends PureComponent {
       </>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(Statuses);

--- a/app/javascript/mastodon/features/explore/suggestions.jsx
+++ b/app/javascript/mastodon/features/explore/suggestions.jsx
@@ -10,32 +10,34 @@ import { fetchSuggestions } from 'mastodon/actions/suggestions';
 import { LoadingIndicator } from 'mastodon/components/loading_indicator';
 import AccountCard from 'mastodon/features/directory/components/account_card';
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   suggestions: state.getIn(['suggestions', 'items']),
   isLoading: state.getIn(['suggestions', 'isLoading']),
 });
 
 class Suggestions extends PureComponent {
-
   static propTypes = {
     isLoading: PropTypes.bool,
     suggestions: ImmutablePropTypes.list,
     dispatch: PropTypes.func.isRequired,
   };
 
-  componentDidMount () {
+  componentDidMount() {
     const { dispatch } = this.props;
     dispatch(fetchSuggestions(true));
   }
 
-  render () {
+  render() {
     const { isLoading, suggestions } = this.props;
 
     if (!isLoading && suggestions.isEmpty()) {
       return (
         <div className='explore__suggestions scrollable scrollable--flex'>
           <div className='empty-column-indicator'>
-            <FormattedMessage id='empty_column.explore_statuses' defaultMessage='Nothing is trending right now. Check back later!' />
+            <FormattedMessage
+              id='empty_column.explore_statuses'
+              defaultMessage='Nothing is trending right now. Check back later!'
+            />
           </div>
         </div>
       );
@@ -43,13 +45,19 @@ class Suggestions extends PureComponent {
 
     return (
       <div className='explore__suggestions'>
-        {isLoading ? <LoadingIndicator /> : suggestions.map(suggestion => (
-          <AccountCard key={suggestion.get('account')} id={suggestion.get('account')} />
-        ))}
+        {isLoading ? (
+          <LoadingIndicator />
+        ) : (
+          suggestions.map((suggestion) => (
+            <AccountCard
+              key={suggestion.get('account')}
+              id={suggestion.get('account')}
+            />
+          ))
+        )}
       </div>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(Suggestions);

--- a/app/javascript/mastodon/features/explore/tags.jsx
+++ b/app/javascript/mastodon/features/explore/tags.jsx
@@ -11,30 +11,32 @@ import { DismissableBanner } from 'mastodon/components/dismissable_banner';
 import { ImmutableHashtag as Hashtag } from 'mastodon/components/hashtag';
 import { LoadingIndicator } from 'mastodon/components/loading_indicator';
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   hashtags: state.getIn(['trends', 'tags', 'items']),
   isLoadingHashtags: state.getIn(['trends', 'tags', 'isLoading']),
 });
 
 class Tags extends PureComponent {
-
   static propTypes = {
     hashtags: ImmutablePropTypes.list,
     isLoading: PropTypes.bool,
     dispatch: PropTypes.func.isRequired,
   };
 
-  componentDidMount () {
+  componentDidMount() {
     const { dispatch } = this.props;
     dispatch(fetchTrendingHashtags());
   }
 
-  render () {
+  render() {
     const { isLoading, hashtags } = this.props;
 
     const banner = (
       <DismissableBanner id='explore/tags'>
-        <FormattedMessage id='dismissable_banner.explore_tags' defaultMessage='These are hashtags that are gaining traction on the social web today. Hashtags that are used by more different people are ranked higher.' />
+        <FormattedMessage
+          id='dismissable_banner.explore_tags'
+          defaultMessage='These are hashtags that are gaining traction on the social web today. Hashtags that are used by more different people are ranked higher.'
+        />
       </DismissableBanner>
     );
 
@@ -44,7 +46,10 @@ class Tags extends PureComponent {
           {banner}
 
           <div className='empty-column-indicator'>
-            <FormattedMessage id='empty_column.explore_statuses' defaultMessage='Nothing is trending right now. Check back later!' />
+            <FormattedMessage
+              id='empty_column.explore_statuses'
+              defaultMessage='Nothing is trending right now. Check back later!'
+            />
           </div>
         </div>
       );
@@ -54,13 +59,16 @@ class Tags extends PureComponent {
       <div className='explore__links'>
         {banner}
 
-        {isLoading ? (<LoadingIndicator />) : hashtags.map(hashtag => (
-          <Hashtag key={hashtag.get('name')} hashtag={hashtag} />
-        ))}
+        {isLoading ? (
+          <LoadingIndicator />
+        ) : (
+          hashtags.map((hashtag) => (
+            <Hashtag key={hashtag.get('name')} hashtag={hashtag} />
+          ))
+        )}
       </div>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(Tags);

--- a/app/javascript/mastodon/features/favourited_statuses/index.jsx
+++ b/app/javascript/mastodon/features/favourited_statuses/index.jsx
@@ -11,7 +11,10 @@ import { connect } from 'react-redux';
 import { debounce } from 'lodash';
 
 import { addColumn, removeColumn, moveColumn } from 'mastodon/actions/columns';
-import { fetchFavouritedStatuses, expandFavouritedStatuses } from 'mastodon/actions/favourites';
+import {
+  fetchFavouritedStatuses,
+  expandFavouritedStatuses,
+} from 'mastodon/actions/favourites';
 import ColumnHeader from 'mastodon/components/column_header';
 import StatusList from 'mastodon/components/status_list';
 import Column from 'mastodon/features/ui/components/column';
@@ -21,14 +24,13 @@ const messages = defineMessages({
   heading: { id: 'column.favourites', defaultMessage: 'Favorites' },
 });
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   statusIds: getStatusList(state, 'favourites'),
   isLoading: state.getIn(['status_lists', 'favourites', 'isLoading'], true),
   hasMore: !!state.getIn(['status_lists', 'favourites', 'next']),
 });
 
 class Favourites extends ImmutablePureComponent {
-
   static propTypes = {
     dispatch: PropTypes.func.isRequired,
     statusIds: ImmutablePropTypes.list.isRequired,
@@ -39,7 +41,7 @@ class Favourites extends ImmutablePureComponent {
     isLoading: PropTypes.bool,
   };
 
-  UNSAFE_componentWillMount () {
+  UNSAFE_componentWillMount() {
     this.props.dispatch(fetchFavouritedStatuses());
   }
 
@@ -62,22 +64,36 @@ class Favourites extends ImmutablePureComponent {
     this.column.scrollTop();
   };
 
-  setRef = c => {
+  setRef = (c) => {
     this.column = c;
   };
 
-  handleLoadMore = debounce(() => {
-    this.props.dispatch(expandFavouritedStatuses());
-  }, 300, { leading: true });
+  handleLoadMore = debounce(
+    () => {
+      this.props.dispatch(expandFavouritedStatuses());
+    },
+    300,
+    { leading: true },
+  );
 
-  render () {
-    const { intl, statusIds, columnId, multiColumn, hasMore, isLoading } = this.props;
+  render() {
+    const { intl, statusIds, columnId, multiColumn, hasMore, isLoading } =
+      this.props;
     const pinned = !!columnId;
 
-    const emptyMessage = <FormattedMessage id='empty_column.favourited_statuses' defaultMessage="You don't have any favorite posts yet. When you favorite one, it will show up here." />;
+    const emptyMessage = (
+      <FormattedMessage
+        id='empty_column.favourited_statuses'
+        defaultMessage="You don't have any favorite posts yet. When you favorite one, it will show up here."
+      />
+    );
 
     return (
-      <Column bindToDocument={!multiColumn} ref={this.setRef} label={intl.formatMessage(messages.heading)}>
+      <Column
+        bindToDocument={!multiColumn}
+        ref={this.setRef}
+        label={intl.formatMessage(messages.heading)}
+      >
         <ColumnHeader
           icon='star'
           title={intl.formatMessage(messages.heading)}
@@ -106,7 +122,6 @@ class Favourites extends ImmutablePureComponent {
       </Column>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(injectIntl(Favourites));

--- a/app/javascript/mastodon/features/favourites/index.jsx
+++ b/app/javascript/mastodon/features/favourites/index.jsx
@@ -10,9 +10,12 @@ import { connect } from 'react-redux';
 
 import { debounce } from 'lodash';
 
-import { fetchFavourites, expandFavourites } from 'mastodon/actions/interactions';
+import {
+  fetchFavourites,
+  expandFavourites,
+} from 'mastodon/actions/interactions';
 import ColumnHeader from 'mastodon/components/column_header';
-import { Icon }  from 'mastodon/components/icon';
+import { Icon } from 'mastodon/components/icon';
 import { LoadingIndicator } from 'mastodon/components/loading_indicator';
 import ScrollableList from 'mastodon/components/scrollable_list';
 import AccountContainer from 'mastodon/containers/account_container';
@@ -23,13 +26,25 @@ const messages = defineMessages({
 });
 
 const mapStateToProps = (state, props) => ({
-  accountIds: state.getIn(['user_lists', 'favourited_by', props.params.statusId, 'items']),
-  hasMore: !!state.getIn(['user_lists', 'favourited_by', props.params.statusId, 'next']),
-  isLoading: state.getIn(['user_lists', 'favourited_by', props.params.statusId, 'isLoading'], true),
+  accountIds: state.getIn([
+    'user_lists',
+    'favourited_by',
+    props.params.statusId,
+    'items',
+  ]),
+  hasMore: !!state.getIn([
+    'user_lists',
+    'favourited_by',
+    props.params.statusId,
+    'next',
+  ]),
+  isLoading: state.getIn(
+    ['user_lists', 'favourited_by', props.params.statusId, 'isLoading'],
+    true,
+  ),
 });
 
 class Favourites extends ImmutablePureComponent {
-
   static propTypes = {
     params: PropTypes.object.isRequired,
     dispatch: PropTypes.func.isRequired,
@@ -40,7 +55,7 @@ class Favourites extends ImmutablePureComponent {
     intl: PropTypes.object.isRequired,
   };
 
-  UNSAFE_componentWillMount () {
+  UNSAFE_componentWillMount() {
     if (!this.props.accountIds) {
       this.props.dispatch(fetchFavourites(this.props.params.statusId));
     }
@@ -50,11 +65,15 @@ class Favourites extends ImmutablePureComponent {
     this.props.dispatch(fetchFavourites(this.props.params.statusId));
   };
 
-  handleLoadMore = debounce(() => {
-    this.props.dispatch(expandFavourites(this.props.params.statusId));
-  }, 300, { leading: true });
+  handleLoadMore = debounce(
+    () => {
+      this.props.dispatch(expandFavourites(this.props.params.statusId));
+    },
+    300,
+    { leading: true },
+  );
 
-  render () {
+  render() {
     const { intl, accountIds, hasMore, isLoading, multiColumn } = this.props;
 
     if (!accountIds) {
@@ -65,16 +84,29 @@ class Favourites extends ImmutablePureComponent {
       );
     }
 
-    const emptyMessage = <FormattedMessage id='empty_column.favourites' defaultMessage='No one has favorited this post yet. When someone does, they will show up here.' />;
+    const emptyMessage = (
+      <FormattedMessage
+        id='empty_column.favourites'
+        defaultMessage='No one has favorited this post yet. When someone does, they will show up here.'
+      />
+    );
 
     return (
       <Column bindToDocument={!multiColumn}>
         <ColumnHeader
           showBackButton
           multiColumn={multiColumn}
-          extraButton={(
-            <button type='button' className='column-header__button' title={intl.formatMessage(messages.refresh)} aria-label={intl.formatMessage(messages.refresh)} onClick={this.handleRefresh}><Icon id='refresh' /></button>
-          )}
+          extraButton={
+            <button
+              type='button'
+              className='column-header__button'
+              title={intl.formatMessage(messages.refresh)}
+              aria-label={intl.formatMessage(messages.refresh)}
+              onClick={this.handleRefresh}
+            >
+              <Icon id='refresh' />
+            </button>
+          }
         />
 
         <ScrollableList
@@ -85,9 +117,9 @@ class Favourites extends ImmutablePureComponent {
           emptyMessage={emptyMessage}
           bindToDocument={!multiColumn}
         >
-          {accountIds.map(id =>
-            <AccountContainer key={id} id={id} withNote={false} />,
-          )}
+          {accountIds.map((id) => (
+            <AccountContainer key={id} id={id} withNote={false} />
+          ))}
         </ScrollableList>
 
         <Helmet>
@@ -96,7 +128,6 @@ class Favourites extends ImmutablePureComponent {
       </Column>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(injectIntl(Favourites));

--- a/app/javascript/mastodon/features/filters/added_to_filter.jsx
+++ b/app/javascript/mastodon/features/filters/added_to_filter.jsx
@@ -14,7 +14,6 @@ const mapStateToProps = (state, { filterId }) => ({
 });
 
 class AddedToFilter extends PureComponent {
-
   static propTypes = {
     onClose: PropTypes.func.isRequired,
     contextType: PropTypes.string,
@@ -27,14 +26,19 @@ class AddedToFilter extends PureComponent {
     onClose();
   };
 
-  render () {
+  render() {
     const { filter, contextType } = this.props;
 
     let expiredMessage = null;
     if (filter.get('expires_at') && filter.get('expires_at') < new Date()) {
       expiredMessage = (
         <>
-          <h4 className='report-dialog-modal__subtitle'><FormattedMessage id='filter_modal.added.expired_title' defaultMessage='Expired filter!' /></h4>
+          <h4 className='report-dialog-modal__subtitle'>
+            <FormattedMessage
+              id='filter_modal.added.expired_title'
+              defaultMessage='Expired filter!'
+            />
+          </h4>
           <p className='report-dialog-modal__lead'>
             <FormattedMessage
               id='filter_modal.added.expired_explanation'
@@ -46,10 +50,18 @@ class AddedToFilter extends PureComponent {
     }
 
     let contextMismatchMessage = null;
-    if (contextType && !filter.get('context').includes(toServerSideType(contextType))) {
+    if (
+      contextType &&
+      !filter.get('context').includes(toServerSideType(contextType))
+    ) {
       contextMismatchMessage = (
         <>
-          <h4 className='report-dialog-modal__subtitle'><FormattedMessage id='filter_modal.added.context_mismatch_title' defaultMessage='Context mismatch!' /></h4>
+          <h4 className='report-dialog-modal__subtitle'>
+            <FormattedMessage
+              id='filter_modal.added.context_mismatch_title'
+              defaultMessage='Context mismatch!'
+            />
+          </h4>
           <p className='report-dialog-modal__lead'>
             <FormattedMessage
               id='filter_modal.added.context_mismatch_explanation'
@@ -71,7 +83,12 @@ class AddedToFilter extends PureComponent {
 
     return (
       <>
-        <h3 className='report-dialog-modal__title'><FormattedMessage id='filter_modal.added.title' defaultMessage='Filter added!' /></h3>
+        <h3 className='report-dialog-modal__title'>
+          <FormattedMessage
+            id='filter_modal.added.title'
+            defaultMessage='Filter added!'
+          />
+        </h3>
         <p className='report-dialog-modal__lead'>
           <FormattedMessage
             id='filter_modal.added.short_explanation'
@@ -83,7 +100,12 @@ class AddedToFilter extends PureComponent {
         {expiredMessage}
         {contextMismatchMessage}
 
-        <h4 className='report-dialog-modal__subtitle'><FormattedMessage id='filter_modal.added.review_and_configure_title' defaultMessage='Filter settings' /></h4>
+        <h4 className='report-dialog-modal__subtitle'>
+          <FormattedMessage
+            id='filter_modal.added.review_and_configure_title'
+            defaultMessage='Filter settings'
+          />
+        </h4>
         <p className='report-dialog-modal__lead'>
           <FormattedMessage
             id='filter_modal.added.review_and_configure'
@@ -95,12 +117,13 @@ class AddedToFilter extends PureComponent {
         <div className='flex-spacer' />
 
         <div className='report-dialog-modal__actions'>
-          <Button onClick={this.handleCloseClick}><FormattedMessage id='report.close' defaultMessage='Done' /></Button>
+          <Button onClick={this.handleCloseClick}>
+            <FormattedMessage id='report.close' defaultMessage='Done' />
+          </Button>
         </div>
       </>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(AddedToFilter);

--- a/app/javascript/mastodon/features/filters/select_filter.jsx
+++ b/app/javascript/mastodon/features/filters/select_filter.jsx
@@ -7,12 +7,15 @@ import { connect } from 'react-redux';
 
 import fuzzysort from 'fuzzysort';
 
-import { Icon }  from 'mastodon/components/icon';
+import { Icon } from 'mastodon/components/icon';
 import { toServerSideType } from 'mastodon/utils/filters';
 import { loupeIcon, deleteIcon } from 'mastodon/utils/icons';
 
 const messages = defineMessages({
-  search: { id: 'filter_modal.select_filter.search', defaultMessage: 'Search or create' },
+  search: {
+    id: 'filter_modal.select_filter.search',
+    defaultMessage: 'Search or create',
+  },
   clear: { id: 'emoji_button.clear', defaultMessage: 'Clear' },
 });
 
@@ -20,14 +23,17 @@ const mapStateToProps = (state, { contextType }) => ({
   filters: Array.from(state.get('filters').values()).map((filter) => [
     filter.get('id'),
     filter.get('title'),
-    filter.get('keywords')?.map((keyword) => keyword.get('keyword')).join('\n'),
+    filter
+      .get('keywords')
+      ?.map((keyword) => keyword.get('keyword'))
+      .join('\n'),
     filter.get('expires_at') && filter.get('expires_at') < new Date(),
-    contextType && !filter.get('context').includes(toServerSideType(contextType)),
+    contextType &&
+      !filter.get('context').includes(toServerSideType(contextType)),
   ]),
 });
 
 class SelectFilter extends PureComponent {
-
   static propTypes = {
     onSelectFilter: PropTypes.func.isRequired,
     onNewFilter: PropTypes.func.isRequired,
@@ -39,7 +45,7 @@ class SelectFilter extends PureComponent {
     searchValue: '',
   };
 
-  search () {
+  search() {
     const { filters } = this.props;
     const { searchValue } = this.state;
 
@@ -47,38 +53,73 @@ class SelectFilter extends PureComponent {
       return filters;
     }
 
-    return fuzzysort.go(searchValue, filters, {
-      keys: ['1', '2'],
-      limit: 5,
-      threshold: -10000,
-    }).map(result => result.obj);
+    return fuzzysort
+      .go(searchValue, filters, {
+        keys: ['1', '2'],
+        limit: 5,
+        threshold: -10000,
+      })
+      .map((result) => result.obj);
   }
 
-  renderItem = filter => {
+  renderItem = (filter) => {
     let warning = null;
     if (filter[3] || filter[4]) {
       warning = (
         <span className='language-dropdown__dropdown__results__item__common-name'>
           (
-          {filter[3] && <FormattedMessage id='filter_modal.select_filter.expired' defaultMessage='expired' />}
+          {filter[3] && (
+            <FormattedMessage
+              id='filter_modal.select_filter.expired'
+              defaultMessage='expired'
+            />
+          )}
           {filter[3] && filter[4] && ', '}
-          {filter[4] && <FormattedMessage id='filter_modal.select_filter.context_mismatch' defaultMessage='does not apply to this context' />}
+          {filter[4] && (
+            <FormattedMessage
+              id='filter_modal.select_filter.context_mismatch'
+              defaultMessage='does not apply to this context'
+            />
+          )}
           )
         </span>
       );
     }
 
     return (
-      <div key={filter[0]} role='button' tabIndex={0} data-index={filter[0]} className='language-dropdown__dropdown__results__item' onClick={this.handleItemClick} onKeyDown={this.handleKeyDown}>
-        <span className='language-dropdown__dropdown__results__item__native-name'>{filter[1]}</span> {warning}
+      <div
+        key={filter[0]}
+        role='button'
+        tabIndex={0}
+        data-index={filter[0]}
+        className='language-dropdown__dropdown__results__item'
+        onClick={this.handleItemClick}
+        onKeyDown={this.handleKeyDown}
+      >
+        <span className='language-dropdown__dropdown__results__item__native-name'>
+          {filter[1]}
+        </span>{' '}
+        {warning}
       </div>
     );
   };
 
-  renderCreateNew (name) {
+  renderCreateNew(name) {
     return (
-      <div key='add-new-filter' role='button' tabIndex={0} className='language-dropdown__dropdown__results__item' onClick={this.handleNewFilterClick} onKeyDown={this.handleKeyDown}>
-        <Icon id='plus' fixedWidth /> <FormattedMessage id='filter_modal.select_filter.prompt_new' defaultMessage='New category: {name}' values={{ name }} />
+      <div
+        key='add-new-filter'
+        role='button'
+        tabIndex={0}
+        className='language-dropdown__dropdown__results__item'
+        onClick={this.handleNewFilterClick}
+        onKeyDown={this.handleKeyDown}
+      >
+        <Icon id='plus' fixedWidth />{' '}
+        <FormattedMessage
+          id='filter_modal.select_filter.prompt_new'
+          defaultMessage='New category: {name}'
+          values={{ name }}
+        />
       </div>
     );
   }
@@ -87,39 +128,45 @@ class SelectFilter extends PureComponent {
     this.setState({ searchValue: target.value });
   };
 
-  setListRef = c => {
+  setListRef = (c) => {
     this.listNode = c;
   };
 
-  handleKeyDown = e => {
-    const index = Array.from(this.listNode.childNodes).findIndex(node => node === e.currentTarget);
+  handleKeyDown = (e) => {
+    const index = Array.from(this.listNode.childNodes).findIndex(
+      (node) => node === e.currentTarget,
+    );
 
     let element = null;
 
-    switch(e.key) {
-    case ' ':
-    case 'Enter':
-      e.currentTarget.click();
-      break;
-    case 'ArrowDown':
-      element = this.listNode.childNodes[index + 1] || this.listNode.firstChild;
-      break;
-    case 'ArrowUp':
-      element = this.listNode.childNodes[index - 1] || this.listNode.lastChild;
-      break;
-    case 'Tab':
-      if (e.shiftKey) {
-        element = this.listNode.childNodes[index - 1] || this.listNode.lastChild;
-      } else {
-        element = this.listNode.childNodes[index + 1] || this.listNode.firstChild;
-      }
-      break;
-    case 'Home':
-      element = this.listNode.firstChild;
-      break;
-    case 'End':
-      element = this.listNode.lastChild;
-      break;
+    switch (e.key) {
+      case ' ':
+      case 'Enter':
+        e.currentTarget.click();
+        break;
+      case 'ArrowDown':
+        element =
+          this.listNode.childNodes[index + 1] || this.listNode.firstChild;
+        break;
+      case 'ArrowUp':
+        element =
+          this.listNode.childNodes[index - 1] || this.listNode.lastChild;
+        break;
+      case 'Tab':
+        if (e.shiftKey) {
+          element =
+            this.listNode.childNodes[index - 1] || this.listNode.lastChild;
+        } else {
+          element =
+            this.listNode.childNodes[index + 1] || this.listNode.firstChild;
+        }
+        break;
+      case 'Home':
+        element = this.listNode.firstChild;
+        break;
+      case 'End':
+        element = this.listNode.lastChild;
+        break;
     }
 
     if (element) {
@@ -129,21 +176,21 @@ class SelectFilter extends PureComponent {
     }
   };
 
-  handleSearchKeyDown = e => {
+  handleSearchKeyDown = (e) => {
     let element = null;
 
-    switch(e.key) {
-    case 'Tab':
-    case 'ArrowDown':
-      element = this.listNode.firstChild;
+    switch (e.key) {
+      case 'Tab':
+      case 'ArrowDown':
+        element = this.listNode.firstChild;
 
-      if (element) {
-        element.focus();
-        e.preventDefault();
-        e.stopPropagation();
-      }
+        if (element) {
+          element.focus();
+          e.preventDefault();
+          e.stopPropagation();
+        }
 
-      break;
+        break;
     }
   };
 
@@ -151,7 +198,7 @@ class SelectFilter extends PureComponent {
     this.setState({ searchValue: '' });
   };
 
-  handleItemClick = e => {
+  handleItemClick = (e) => {
     const value = e.currentTarget.getAttribute('data-index');
 
     e.preventDefault();
@@ -159,13 +206,13 @@ class SelectFilter extends PureComponent {
     this.props.onSelectFilter(value);
   };
 
-  handleNewFilterClick = e => {
+  handleNewFilterClick = (e) => {
     e.preventDefault();
 
     this.props.onNewFilter(this.state.searchValue);
   };
 
-  render () {
+  render() {
     const { intl } = this.props;
 
     const { searchValue } = this.state;
@@ -174,23 +221,50 @@ class SelectFilter extends PureComponent {
 
     return (
       <>
-        <h3 className='report-dialog-modal__title'><FormattedMessage id='filter_modal.select_filter.title' defaultMessage='Filter this post' /></h3>
-        <p className='report-dialog-modal__lead'><FormattedMessage id='filter_modal.select_filter.subtitle' defaultMessage='Use an existing category or create a new one' /></p>
+        <h3 className='report-dialog-modal__title'>
+          <FormattedMessage
+            id='filter_modal.select_filter.title'
+            defaultMessage='Filter this post'
+          />
+        </h3>
+        <p className='report-dialog-modal__lead'>
+          <FormattedMessage
+            id='filter_modal.select_filter.subtitle'
+            defaultMessage='Use an existing category or create a new one'
+          />
+        </p>
 
         <div className='emoji-mart-search'>
-          <input type='search' value={searchValue} onChange={this.handleSearchChange} onKeyDown={this.handleSearchKeyDown} placeholder={intl.formatMessage(messages.search)} autoFocus />
-          <button type='button' className='emoji-mart-search-icon' disabled={!isSearching} aria-label={intl.formatMessage(messages.clear)} onClick={this.handleClear}>{!isSearching ? loupeIcon : deleteIcon}</button>
+          <input
+            type='search'
+            value={searchValue}
+            onChange={this.handleSearchChange}
+            onKeyDown={this.handleSearchKeyDown}
+            placeholder={intl.formatMessage(messages.search)}
+            autoFocus
+          />
+          <button
+            type='button'
+            className='emoji-mart-search-icon'
+            disabled={!isSearching}
+            aria-label={intl.formatMessage(messages.clear)}
+            onClick={this.handleClear}
+          >
+            {!isSearching ? loupeIcon : deleteIcon}
+          </button>
         </div>
 
-        <div className='language-dropdown__dropdown__results emoji-mart-scroll' role='listbox' ref={this.setListRef}>
+        <div
+          className='language-dropdown__dropdown__results emoji-mart-scroll'
+          role='listbox'
+          ref={this.setListRef}
+        >
           {results.map(this.renderItem)}
-          {isSearching && this.renderCreateNew(searchValue) }
+          {isSearching && this.renderCreateNew(searchValue)}
         </div>
-
       </>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(injectIntl(SelectFilter));

--- a/app/javascript/mastodon/features/firehose/index.jsx
+++ b/app/javascript/mastodon/features/firehose/index.jsx
@@ -8,8 +8,14 @@ import { NavLink } from 'react-router-dom';
 
 import { addColumn } from 'mastodon/actions/columns';
 import { changeSetting } from 'mastodon/actions/settings';
-import { connectPublicStream, connectCommunityStream } from 'mastodon/actions/streaming';
-import { expandPublicTimeline, expandCommunityTimeline } from 'mastodon/actions/timelines';
+import {
+  connectPublicStream,
+  connectCommunityStream,
+} from 'mastodon/actions/streaming';
+import {
+  expandPublicTimeline,
+  expandCommunityTimeline,
+} from 'mastodon/actions/timelines';
 import { DismissableBanner } from 'mastodon/components/dismissable_banner';
 import initialState, { domain } from 'mastodon/initial_state';
 import { useAppDispatch, useAppSelector } from 'mastodon/store';
@@ -34,7 +40,9 @@ const useIdentity = () => ({
 
 const ColumnSettings = () => {
   const dispatch = useAppDispatch();
-  const settings = useAppSelector((state) => state.getIn(['settings', 'firehose']));
+  const settings = useAppSelector((state) =>
+    state.getIn(['settings', 'firehose']),
+  );
   const onChange = useCallback(
     (key, checked) => dispatch(changeSetting(['firehose', ...key], checked)),
     [dispatch],
@@ -47,7 +55,12 @@ const ColumnSettings = () => {
           settings={settings}
           settingPath={['onlyMedia']}
           onChange={onChange}
-          label={<FormattedMessage id='community.column_settings.media_only' defaultMessage='Media only' />}
+          label={
+            <FormattedMessage
+              id='community.column_settings.media_only'
+              defaultMessage='Media only'
+            />
+          }
         />
       </div>
     </div>
@@ -60,12 +73,19 @@ const Firehose = ({ feedType, multiColumn }) => {
   const { signedIn } = useIdentity();
   const columnRef = useRef(null);
 
-  const onlyMedia = useAppSelector((state) => state.getIn(['settings', 'firehose', 'onlyMedia'], false));
-  const hasUnread = useAppSelector((state) => state.getIn(['timelines', `${feedType}${onlyMedia ? ':media' : ''}`, 'unread'], 0) > 0);
+  const onlyMedia = useAppSelector((state) =>
+    state.getIn(['settings', 'firehose', 'onlyMedia'], false),
+  );
+  const hasUnread = useAppSelector(
+    (state) =>
+      state.getIn(
+        ['timelines', `${feedType}${onlyMedia ? ':media' : ''}`, 'unread'],
+        0,
+      ) > 0,
+  );
 
-  const handlePin = useCallback(
-    () => {
-      switch(feedType) {
+  const handlePin = useCallback(() => {
+    switch (feedType) {
       case 'community':
         dispatch(addColumn('COMMUNITY', { other: { onlyMedia } }));
         break;
@@ -73,91 +93,104 @@ const Firehose = ({ feedType, multiColumn }) => {
         dispatch(addColumn('PUBLIC', { other: { onlyMedia } }));
         break;
       case 'public:remote':
-        dispatch(addColumn('REMOTE', { other: { onlyMedia, onlyRemote: true } }));
+        dispatch(
+          addColumn('REMOTE', { other: { onlyMedia, onlyRemote: true } }),
+        );
         break;
-      }
-    },
-    [dispatch, onlyMedia, feedType],
-  );
+    }
+  }, [dispatch, onlyMedia, feedType]);
 
   const handleLoadMore = useCallback(
     (maxId) => {
-      switch(feedType) {
-      case 'community':
-        dispatch(expandCommunityTimeline({ maxId, onlyMedia }));
-        break;
-      case 'public':
-        dispatch(expandPublicTimeline({ maxId, onlyMedia }));
-        break;
-      case 'public:remote':
-        dispatch(expandPublicTimeline({ maxId, onlyMedia, onlyRemote: true }));
-        break;
+      switch (feedType) {
+        case 'community':
+          dispatch(expandCommunityTimeline({ maxId, onlyMedia }));
+          break;
+        case 'public':
+          dispatch(expandPublicTimeline({ maxId, onlyMedia }));
+          break;
+        case 'public:remote':
+          dispatch(
+            expandPublicTimeline({ maxId, onlyMedia, onlyRemote: true }),
+          );
+          break;
       }
     },
     [dispatch, onlyMedia, feedType],
   );
 
-  const handleHeaderClick = useCallback(() => columnRef.current?.scrollTop(), []);
+  const handleHeaderClick = useCallback(
+    () => columnRef.current?.scrollTop(),
+    [],
+  );
 
   useEffect(() => {
     let disconnect;
 
-    switch(feedType) {
-    case 'community':
-      dispatch(expandCommunityTimeline({ onlyMedia }));
-      if (signedIn) {
-        disconnect = dispatch(connectCommunityStream({ onlyMedia }));
-      }
-      break;
-    case 'public':
-      dispatch(expandPublicTimeline({ onlyMedia }));
-      if (signedIn) {
-        disconnect = dispatch(connectPublicStream({ onlyMedia }));
-      }
-      break;
-    case 'public:remote':
-      dispatch(expandPublicTimeline({ onlyMedia, onlyRemote: true }));
-      if (signedIn) {
-        disconnect = dispatch(connectPublicStream({ onlyMedia, onlyRemote: true }));
-      }
-      break;
+    switch (feedType) {
+      case 'community':
+        dispatch(expandCommunityTimeline({ onlyMedia }));
+        if (signedIn) {
+          disconnect = dispatch(connectCommunityStream({ onlyMedia }));
+        }
+        break;
+      case 'public':
+        dispatch(expandPublicTimeline({ onlyMedia }));
+        if (signedIn) {
+          disconnect = dispatch(connectPublicStream({ onlyMedia }));
+        }
+        break;
+      case 'public:remote':
+        dispatch(expandPublicTimeline({ onlyMedia, onlyRemote: true }));
+        if (signedIn) {
+          disconnect = dispatch(
+            connectPublicStream({ onlyMedia, onlyRemote: true }),
+          );
+        }
+        break;
     }
 
     return () => disconnect?.();
   }, [dispatch, signedIn, feedType, onlyMedia]);
 
-  const prependBanner = feedType === 'community' ? (
-    <DismissableBanner id='community_timeline'>
-      <FormattedMessage
-        id='dismissable_banner.community_timeline'
-        defaultMessage='These are the most recent public posts from people whose accounts are hosted by {domain}.'
-        values={{ domain }}
-      />
-    </DismissableBanner>
-  ) : (
-    <DismissableBanner id='public_timeline'>
-      <FormattedMessage
-        id='dismissable_banner.public_timeline'
-        defaultMessage='These are the most recent public posts from people on the social web that people on {domain} follow.'
-        values={{ domain }}
-      />
-    </DismissableBanner>
-  );
+  const prependBanner =
+    feedType === 'community' ? (
+      <DismissableBanner id='community_timeline'>
+        <FormattedMessage
+          id='dismissable_banner.community_timeline'
+          defaultMessage='These are the most recent public posts from people whose accounts are hosted by {domain}.'
+          values={{ domain }}
+        />
+      </DismissableBanner>
+    ) : (
+      <DismissableBanner id='public_timeline'>
+        <FormattedMessage
+          id='dismissable_banner.public_timeline'
+          defaultMessage='These are the most recent public posts from people on the social web that people on {domain} follow.'
+          values={{ domain }}
+        />
+      </DismissableBanner>
+    );
 
-  const emptyMessage = feedType === 'community' ? (
-    <FormattedMessage
-      id='empty_column.community'
-      defaultMessage='The local timeline is empty. Write something publicly to get the ball rolling!'
-    />
-  ) : (
-    <FormattedMessage
-      id='empty_column.public'
-      defaultMessage='There is nothing here! Write something publicly, or manually follow users from other servers to fill it up'
-    />
-  );
+  const emptyMessage =
+    feedType === 'community' ? (
+      <FormattedMessage
+        id='empty_column.community'
+        defaultMessage='The local timeline is empty. Write something publicly to get the ball rolling!'
+      />
+    ) : (
+      <FormattedMessage
+        id='empty_column.public'
+        defaultMessage='There is nothing here! Write something publicly, or manually follow users from other servers to fill it up'
+      />
+    );
 
   return (
-    <Column bindToDocument={!multiColumn} ref={columnRef} label={intl.formatMessage(messages.title)}>
+    <Column
+      bindToDocument={!multiColumn}
+      ref={columnRef}
+      label={intl.formatMessage(messages.title)}
+    >
       <ColumnHeader
         icon='globe'
         active={hasUnread}
@@ -172,15 +205,27 @@ const Firehose = ({ feedType, multiColumn }) => {
       <div className='scrollable scrollable--flex'>
         <div className='account__section-headline'>
           <NavLink exact to='/public/local'>
-            <FormattedMessage tagName='div' id='firehose.local' defaultMessage='This server' />
+            <FormattedMessage
+              tagName='div'
+              id='firehose.local'
+              defaultMessage='This server'
+            />
           </NavLink>
 
           <NavLink exact to='/public/remote'>
-            <FormattedMessage tagName='div' id='firehose.remote' defaultMessage='Other servers' />
+            <FormattedMessage
+              tagName='div'
+              id='firehose.remote'
+              defaultMessage='Other servers'
+            />
           </NavLink>
 
           <NavLink exact to='/public'>
-            <FormattedMessage tagName='div' id='firehose.all' defaultMessage='All' />
+            <FormattedMessage
+              tagName='div'
+              id='firehose.all'
+              defaultMessage='All'
+            />
           </NavLink>
         </div>
 
@@ -201,7 +246,7 @@ const Firehose = ({ feedType, multiColumn }) => {
       </Helmet>
     </Column>
   );
-}
+};
 
 Firehose.propTypes = {
   multiColumn: PropTypes.bool,

--- a/app/javascript/mastodon/features/follow_requests/components/account_authorize.jsx
+++ b/app/javascript/mastodon/features/follow_requests/components/account_authorize.jsx
@@ -17,7 +17,6 @@ const messages = defineMessages({
 });
 
 class AccountAuthorize extends ImmutablePureComponent {
-
   static propTypes = {
     account: ImmutablePropTypes.map.isRequired,
     onAuthorize: PropTypes.func.isRequired,
@@ -25,29 +24,48 @@ class AccountAuthorize extends ImmutablePureComponent {
     intl: PropTypes.object.isRequired,
   };
 
-  render () {
+  render() {
     const { intl, account, onAuthorize, onReject } = this.props;
     const content = { __html: account.get('note_emojified') };
 
     return (
       <div className='account-authorize__wrapper'>
         <div className='account-authorize'>
-          <Link to={`/@${account.get('acct')}`} className='detailed-status__display-name'>
-            <div className='account-authorize__avatar'><Avatar account={account} size={48} /></div>
+          <Link
+            to={`/@${account.get('acct')}`}
+            className='detailed-status__display-name'
+          >
+            <div className='account-authorize__avatar'>
+              <Avatar account={account} size={48} />
+            </div>
             <DisplayName account={account} />
           </Link>
 
-          <div className='account__header__content translate' dangerouslySetInnerHTML={content} />
+          <div
+            className='account__header__content translate'
+            dangerouslySetInnerHTML={content}
+          />
         </div>
 
         <div className='account--panel'>
-          <div className='account--panel__button'><IconButton title={intl.formatMessage(messages.authorize)} icon='check' onClick={onAuthorize} /></div>
-          <div className='account--panel__button'><IconButton title={intl.formatMessage(messages.reject)} icon='times' onClick={onReject} /></div>
+          <div className='account--panel__button'>
+            <IconButton
+              title={intl.formatMessage(messages.authorize)}
+              icon='check'
+              onClick={onAuthorize}
+            />
+          </div>
+          <div className='account--panel__button'>
+            <IconButton
+              title={intl.formatMessage(messages.reject)}
+              icon='times'
+              onClick={onReject}
+            />
+          </div>
         </div>
       </div>
     );
   }
-
 }
 
 export default injectIntl(AccountAuthorize);

--- a/app/javascript/mastodon/features/follow_requests/containers/account_authorize_container.js
+++ b/app/javascript/mastodon/features/follow_requests/containers/account_authorize_container.js
@@ -1,6 +1,9 @@
 import { connect } from 'react-redux';
 
-import { authorizeFollowRequest, rejectFollowRequest } from '../../../actions/accounts';
+import {
+  authorizeFollowRequest,
+  rejectFollowRequest,
+} from '../../../actions/accounts';
 import { makeGetAccount } from '../../../selectors';
 import AccountAuthorize from '../components/account_authorize';
 
@@ -15,13 +18,16 @@ const makeMapStateToProps = () => {
 };
 
 const mapDispatchToProps = (dispatch, { id }) => ({
-  onAuthorize () {
+  onAuthorize() {
     dispatch(authorizeFollowRequest(id));
   },
 
-  onReject () {
+  onReject() {
     dispatch(rejectFollowRequest(id));
   },
 });
 
-export default connect(makeMapStateToProps, mapDispatchToProps)(AccountAuthorize);
+export default connect(
+  makeMapStateToProps,
+  mapDispatchToProps,
+)(AccountAuthorize);

--- a/app/javascript/mastodon/features/follow_requests/index.jsx
+++ b/app/javascript/mastodon/features/follow_requests/index.jsx
@@ -10,7 +10,10 @@ import { connect } from 'react-redux';
 
 import { debounce } from 'lodash';
 
-import { fetchFollowRequests, expandFollowRequests } from '../../actions/accounts';
+import {
+  fetchFollowRequests,
+  expandFollowRequests,
+} from '../../actions/accounts';
 import ColumnBackButtonSlim from '../../components/column_back_button_slim';
 import ScrollableList from '../../components/scrollable_list';
 import { me } from '../../initial_state';
@@ -22,7 +25,7 @@ const messages = defineMessages({
   heading: { id: 'column.follow_requests', defaultMessage: 'Follow requests' },
 });
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   accountIds: state.getIn(['user_lists', 'follow_requests', 'items']),
   isLoading: state.getIn(['user_lists', 'follow_requests', 'isLoading'], true),
   hasMore: !!state.getIn(['user_lists', 'follow_requests', 'next']),
@@ -31,7 +34,6 @@ const mapStateToProps = state => ({
 });
 
 class FollowRequests extends ImmutablePureComponent {
-
   static propTypes = {
     params: PropTypes.object.isRequired,
     dispatch: PropTypes.func.isRequired,
@@ -44,18 +46,35 @@ class FollowRequests extends ImmutablePureComponent {
     multiColumn: PropTypes.bool,
   };
 
-  UNSAFE_componentWillMount () {
+  UNSAFE_componentWillMount() {
     this.props.dispatch(fetchFollowRequests());
   }
 
-  handleLoadMore = debounce(() => {
-    this.props.dispatch(expandFollowRequests());
-  }, 300, { leading: true });
+  handleLoadMore = debounce(
+    () => {
+      this.props.dispatch(expandFollowRequests());
+    },
+    300,
+    { leading: true },
+  );
 
-  render () {
-    const { intl, accountIds, hasMore, multiColumn, locked, domain, isLoading } = this.props;
+  render() {
+    const {
+      intl,
+      accountIds,
+      hasMore,
+      multiColumn,
+      locked,
+      domain,
+      isLoading,
+    } = this.props;
 
-    const emptyMessage = <FormattedMessage id='empty_column.follow_requests' defaultMessage="You don't have any follow requests yet. When you receive one, it will show up here." />;
+    const emptyMessage = (
+      <FormattedMessage
+        id='empty_column.follow_requests'
+        defaultMessage="You don't have any follow requests yet. When you receive one, it will show up here."
+      />
+    );
     const unlockedPrependMessage = !locked && accountIds.size > 0 && (
       <div className='follow_requests-unlocked_explanation'>
         <FormattedMessage
@@ -67,7 +86,11 @@ class FollowRequests extends ImmutablePureComponent {
     );
 
     return (
-      <Column bindToDocument={!multiColumn} icon='user-plus' heading={intl.formatMessage(messages.heading)}>
+      <Column
+        bindToDocument={!multiColumn}
+        icon='user-plus'
+        heading={intl.formatMessage(messages.heading)}
+      >
         <ColumnBackButtonSlim />
         <ScrollableList
           scrollKey='follow_requests'
@@ -79,9 +102,9 @@ class FollowRequests extends ImmutablePureComponent {
           bindToDocument={!multiColumn}
           prepend={unlockedPrependMessage}
         >
-          {accountIds.map(id =>
-            <AccountAuthorizeContainer key={id} id={id} />,
-          )}
+          {accountIds.map((id) => (
+            <AccountAuthorizeContainer key={id} id={id} />
+          ))}
         </ScrollableList>
 
         <Helmet>
@@ -90,7 +113,6 @@ class FollowRequests extends ImmutablePureComponent {
       </Column>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(injectIntl(FollowRequests));

--- a/app/javascript/mastodon/features/followed_tags/index.jsx
+++ b/app/javascript/mastodon/features/followed_tags/index.jsx
@@ -10,7 +10,10 @@ import { connect } from 'react-redux';
 
 import { debounce } from 'lodash';
 
-import { expandFollowedHashtags, fetchFollowedHashtags } from 'mastodon/actions/tags';
+import {
+  expandFollowedHashtags,
+  fetchFollowedHashtags,
+} from 'mastodon/actions/tags';
 import ColumnHeader from 'mastodon/components/column_header';
 import Hashtag from 'mastodon/components/hashtag';
 import ScrollableList from 'mastodon/components/scrollable_list';
@@ -20,14 +23,13 @@ const messages = defineMessages({
   heading: { id: 'followed_tags', defaultMessage: 'Followed hashtags' },
 });
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   hashtags: state.getIn(['followed_tags', 'items']),
   isLoading: state.getIn(['followed_tags', 'isLoading'], true),
   hasMore: !!state.getIn(['followed_tags', 'next']),
 });
 
 class FollowedTags extends ImmutablePureComponent {
-
   static propTypes = {
     params: PropTypes.object.isRequired,
     dispatch: PropTypes.func.isRequired,
@@ -42,14 +44,23 @@ class FollowedTags extends ImmutablePureComponent {
     this.props.dispatch(fetchFollowedHashtags());
   }
 
-  handleLoadMore = debounce(() => {
-    this.props.dispatch(expandFollowedHashtags());
-  }, 300, { leading: true });
+  handleLoadMore = debounce(
+    () => {
+      this.props.dispatch(expandFollowedHashtags());
+    },
+    300,
+    { leading: true },
+  );
 
-  render () {
+  render() {
     const { intl, hashtags, isLoading, hasMore, multiColumn } = this.props;
 
-    const emptyMessage = <FormattedMessage id='empty_column.followed_tags' defaultMessage='You have not followed any hashtags yet. When you do, they will show up here.' />;
+    const emptyMessage = (
+      <FormattedMessage
+        id='empty_column.followed_tags'
+        defaultMessage='You have not followed any hashtags yet. When you do, they will show up here.'
+      />
+    );
 
     return (
       <Column bindToDocument={!multiColumn}>
@@ -75,8 +86,15 @@ class FollowedTags extends ImmutablePureComponent {
               to={`/tags/${hashtag.get('name')}`}
               withGraph={false}
               // Taken from ImmutableHashtag. Should maybe refactor ImmutableHashtag to accept more options?
-              people={hashtag.getIn(['history', 0, 'accounts']) * 1 + hashtag.getIn(['history', 1, 'accounts']) * 1}
-              history={hashtag.get('history').reverse().map((day) => day.get('uses')).toArray()}
+              people={
+                hashtag.getIn(['history', 0, 'accounts']) * 1 +
+                hashtag.getIn(['history', 1, 'accounts']) * 1
+              }
+              history={hashtag
+                .get('history')
+                .reverse()
+                .map((day) => day.get('uses'))
+                .toArray()}
             />
           ))}
         </ScrollableList>
@@ -87,7 +105,6 @@ class FollowedTags extends ImmutablePureComponent {
       </Column>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(injectIntl(FollowedTags));

--- a/app/javascript/mastodon/features/followers/index.jsx
+++ b/app/javascript/mastodon/features/followers/index.jsx
@@ -28,7 +28,8 @@ import HeaderContainer from '../account_timeline/containers/header_container';
 import Column from '../ui/components/column';
 
 const mapStateToProps = (state, { params: { acct, id } }) => {
-  const accountId = id || state.getIn(['accounts_map', normalizeForLookup(acct)]);
+  const accountId =
+    id || state.getIn(['accounts_map', normalizeForLookup(acct)]);
 
   if (!accountId) {
     return {
@@ -38,12 +39,18 @@ const mapStateToProps = (state, { params: { acct, id } }) => {
 
   return {
     accountId,
-    remote: !!(state.getIn(['accounts', accountId, 'acct']) !== state.getIn(['accounts', accountId, 'username'])),
+    remote: !!(
+      state.getIn(['accounts', accountId, 'acct']) !==
+      state.getIn(['accounts', accountId, 'username'])
+    ),
     remoteUrl: state.getIn(['accounts', accountId, 'url']),
     isAccount: !!state.getIn(['accounts', accountId]),
     accountIds: state.getIn(['user_lists', 'followers', accountId, 'items']),
     hasMore: !!state.getIn(['user_lists', 'followers', accountId, 'next']),
-    isLoading: state.getIn(['user_lists', 'followers', accountId, 'isLoading'], true),
+    isLoading: state.getIn(
+      ['user_lists', 'followers', accountId, 'isLoading'],
+      true,
+    ),
     suspended: state.getIn(['accounts', accountId, 'suspended'], false),
     hidden: getAccountHidden(state, accountId),
     blockedBy: state.getIn(['relationships', accountId, 'blocked_by'], false),
@@ -51,7 +58,15 @@ const mapStateToProps = (state, { params: { acct, id } }) => {
 };
 
 const RemoteHint = ({ url }) => (
-  <TimelineHint url={url} resource={<FormattedMessage id='timeline_hint.resources.followers' defaultMessage='Followers' />} />
+  <TimelineHint
+    url={url}
+    resource={
+      <FormattedMessage
+        id='timeline_hint.resources.followers'
+        defaultMessage='Followers'
+      />
+    }
+  />
 );
 
 RemoteHint.propTypes = {
@@ -59,7 +74,6 @@ RemoteHint.propTypes = {
 };
 
 class Followers extends ImmutablePureComponent {
-
   static propTypes = {
     params: PropTypes.shape({
       acct: PropTypes.string,
@@ -79,15 +93,19 @@ class Followers extends ImmutablePureComponent {
     multiColumn: PropTypes.bool,
   };
 
-  _load () {
+  _load() {
     const { accountId, isAccount, dispatch } = this.props;
 
     if (!isAccount) dispatch(fetchAccount(accountId));
     dispatch(fetchFollowers(accountId));
   }
 
-  componentDidMount () {
-    const { params: { acct }, accountId, dispatch } = this.props;
+  componentDidMount() {
+    const {
+      params: { acct },
+      accountId,
+      dispatch,
+    } = this.props;
 
     if (accountId) {
       this._load();
@@ -96,8 +114,12 @@ class Followers extends ImmutablePureComponent {
     }
   }
 
-  componentDidUpdate (prevProps) {
-    const { params: { acct }, accountId, dispatch } = this.props;
+  componentDidUpdate(prevProps) {
+    const {
+      params: { acct },
+      accountId,
+      dispatch,
+    } = this.props;
 
     if (prevProps.accountId !== accountId && accountId) {
       this._load();
@@ -106,12 +128,28 @@ class Followers extends ImmutablePureComponent {
     }
   }
 
-  handleLoadMore = debounce(() => {
-    this.props.dispatch(expandFollowers(this.props.accountId));
-  }, 300, { leading: true });
+  handleLoadMore = debounce(
+    () => {
+      this.props.dispatch(expandFollowers(this.props.accountId));
+    },
+    300,
+    { leading: true },
+  );
 
-  render () {
-    const { accountId, accountIds, hasMore, blockedBy, isAccount, multiColumn, isLoading, suspended, hidden, remote, remoteUrl } = this.props;
+  render() {
+    const {
+      accountId,
+      accountIds,
+      hasMore,
+      blockedBy,
+      isAccount,
+      multiColumn,
+      isLoading,
+      suspended,
+      hidden,
+      remote,
+      remoteUrl,
+    } = this.props;
 
     if (!isAccount) {
       return (
@@ -132,15 +170,30 @@ class Followers extends ImmutablePureComponent {
     const forceEmptyState = blockedBy || suspended || hidden;
 
     if (suspended) {
-      emptyMessage = <FormattedMessage id='empty_column.account_suspended' defaultMessage='Account suspended' />;
+      emptyMessage = (
+        <FormattedMessage
+          id='empty_column.account_suspended'
+          defaultMessage='Account suspended'
+        />
+      );
     } else if (hidden) {
       emptyMessage = <LimitedAccountHint accountId={accountId} />;
     } else if (blockedBy) {
-      emptyMessage = <FormattedMessage id='empty_column.account_unavailable' defaultMessage='Profile unavailable' />;
+      emptyMessage = (
+        <FormattedMessage
+          id='empty_column.account_unavailable'
+          defaultMessage='Profile unavailable'
+        />
+      );
     } else if (remote && accountIds.isEmpty()) {
       emptyMessage = <RemoteHint url={remoteUrl} />;
     } else {
-      emptyMessage = <FormattedMessage id='account.followers.empty' defaultMessage='No one follows this user yet.' />;
+      emptyMessage = (
+        <FormattedMessage
+          id='account.followers.empty'
+          defaultMessage='No one follows this user yet.'
+        />
+      );
     }
 
     const remoteMessage = remote ? <RemoteHint url={remoteUrl} /> : null;
@@ -154,20 +207,23 @@ class Followers extends ImmutablePureComponent {
           hasMore={!forceEmptyState && hasMore}
           isLoading={isLoading}
           onLoadMore={this.handleLoadMore}
-          prepend={<HeaderContainer accountId={this.props.accountId} hideTabs />}
+          prepend={
+            <HeaderContainer accountId={this.props.accountId} hideTabs />
+          }
           alwaysPrepend
           append={remoteMessage}
           emptyMessage={emptyMessage}
           bindToDocument={!multiColumn}
         >
-          {forceEmptyState ? [] : accountIds.map(id =>
-            <AccountContainer key={id} id={id} withNote={false} />,
-          )}
+          {forceEmptyState
+            ? []
+            : accountIds.map((id) => (
+                <AccountContainer key={id} id={id} withNote={false} />
+              ))}
         </ScrollableList>
       </Column>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(Followers);

--- a/app/javascript/mastodon/features/following/index.jsx
+++ b/app/javascript/mastodon/features/following/index.jsx
@@ -28,7 +28,8 @@ import HeaderContainer from '../account_timeline/containers/header_container';
 import Column from '../ui/components/column';
 
 const mapStateToProps = (state, { params: { acct, id } }) => {
-  const accountId = id || state.getIn(['accounts_map', normalizeForLookup(acct)]);
+  const accountId =
+    id || state.getIn(['accounts_map', normalizeForLookup(acct)]);
 
   if (!accountId) {
     return {
@@ -38,12 +39,18 @@ const mapStateToProps = (state, { params: { acct, id } }) => {
 
   return {
     accountId,
-    remote: !!(state.getIn(['accounts', accountId, 'acct']) !== state.getIn(['accounts', accountId, 'username'])),
+    remote: !!(
+      state.getIn(['accounts', accountId, 'acct']) !==
+      state.getIn(['accounts', accountId, 'username'])
+    ),
     remoteUrl: state.getIn(['accounts', accountId, 'url']),
     isAccount: !!state.getIn(['accounts', accountId]),
     accountIds: state.getIn(['user_lists', 'following', accountId, 'items']),
     hasMore: !!state.getIn(['user_lists', 'following', accountId, 'next']),
-    isLoading: state.getIn(['user_lists', 'following', accountId, 'isLoading'], true),
+    isLoading: state.getIn(
+      ['user_lists', 'following', accountId, 'isLoading'],
+      true,
+    ),
     suspended: state.getIn(['accounts', accountId, 'suspended'], false),
     hidden: getAccountHidden(state, accountId),
     blockedBy: state.getIn(['relationships', accountId, 'blocked_by'], false),
@@ -51,7 +58,15 @@ const mapStateToProps = (state, { params: { acct, id } }) => {
 };
 
 const RemoteHint = ({ url }) => (
-  <TimelineHint url={url} resource={<FormattedMessage id='timeline_hint.resources.follows' defaultMessage='Follows' />} />
+  <TimelineHint
+    url={url}
+    resource={
+      <FormattedMessage
+        id='timeline_hint.resources.follows'
+        defaultMessage='Follows'
+      />
+    }
+  />
 );
 
 RemoteHint.propTypes = {
@@ -59,7 +74,6 @@ RemoteHint.propTypes = {
 };
 
 class Following extends ImmutablePureComponent {
-
   static propTypes = {
     params: PropTypes.shape({
       acct: PropTypes.string,
@@ -79,15 +93,19 @@ class Following extends ImmutablePureComponent {
     multiColumn: PropTypes.bool,
   };
 
-  _load () {
+  _load() {
     const { accountId, isAccount, dispatch } = this.props;
 
     if (!isAccount) dispatch(fetchAccount(accountId));
     dispatch(fetchFollowing(accountId));
   }
 
-  componentDidMount () {
-    const { params: { acct }, accountId, dispatch } = this.props;
+  componentDidMount() {
+    const {
+      params: { acct },
+      accountId,
+      dispatch,
+    } = this.props;
 
     if (accountId) {
       this._load();
@@ -96,8 +114,12 @@ class Following extends ImmutablePureComponent {
     }
   }
 
-  componentDidUpdate (prevProps) {
-    const { params: { acct }, accountId, dispatch } = this.props;
+  componentDidUpdate(prevProps) {
+    const {
+      params: { acct },
+      accountId,
+      dispatch,
+    } = this.props;
 
     if (prevProps.accountId !== accountId && accountId) {
       this._load();
@@ -106,12 +128,28 @@ class Following extends ImmutablePureComponent {
     }
   }
 
-  handleLoadMore = debounce(() => {
-    this.props.dispatch(expandFollowing(this.props.accountId));
-  }, 300, { leading: true });
+  handleLoadMore = debounce(
+    () => {
+      this.props.dispatch(expandFollowing(this.props.accountId));
+    },
+    300,
+    { leading: true },
+  );
 
-  render () {
-    const { accountId, accountIds, hasMore, blockedBy, isAccount, multiColumn, isLoading, suspended, hidden, remote, remoteUrl } = this.props;
+  render() {
+    const {
+      accountId,
+      accountIds,
+      hasMore,
+      blockedBy,
+      isAccount,
+      multiColumn,
+      isLoading,
+      suspended,
+      hidden,
+      remote,
+      remoteUrl,
+    } = this.props;
 
     if (!isAccount) {
       return (
@@ -132,15 +170,30 @@ class Following extends ImmutablePureComponent {
     const forceEmptyState = blockedBy || suspended || hidden;
 
     if (suspended) {
-      emptyMessage = <FormattedMessage id='empty_column.account_suspended' defaultMessage='Account suspended' />;
+      emptyMessage = (
+        <FormattedMessage
+          id='empty_column.account_suspended'
+          defaultMessage='Account suspended'
+        />
+      );
     } else if (hidden) {
       emptyMessage = <LimitedAccountHint accountId={accountId} />;
     } else if (blockedBy) {
-      emptyMessage = <FormattedMessage id='empty_column.account_unavailable' defaultMessage='Profile unavailable' />;
+      emptyMessage = (
+        <FormattedMessage
+          id='empty_column.account_unavailable'
+          defaultMessage='Profile unavailable'
+        />
+      );
     } else if (remote && accountIds.isEmpty()) {
       emptyMessage = <RemoteHint url={remoteUrl} />;
     } else {
-      emptyMessage = <FormattedMessage id='account.follows.empty' defaultMessage="This user doesn't follow anyone yet." />;
+      emptyMessage = (
+        <FormattedMessage
+          id='account.follows.empty'
+          defaultMessage="This user doesn't follow anyone yet."
+        />
+      );
     }
 
     const remoteMessage = remote ? <RemoteHint url={remoteUrl} /> : null;
@@ -154,20 +207,23 @@ class Following extends ImmutablePureComponent {
           hasMore={!forceEmptyState && hasMore}
           isLoading={isLoading}
           onLoadMore={this.handleLoadMore}
-          prepend={<HeaderContainer accountId={this.props.accountId} hideTabs />}
+          prepend={
+            <HeaderContainer accountId={this.props.accountId} hideTabs />
+          }
           alwaysPrepend
           append={remoteMessage}
           emptyMessage={emptyMessage}
           bindToDocument={!multiColumn}
         >
-          {forceEmptyState ? [] : accountIds.map(id =>
-            <AccountContainer key={id} id={id} withNote={false} />,
-          )}
+          {forceEmptyState
+            ? []
+            : accountIds.map((id) => (
+                <AccountContainer key={id} id={id} withNote={false} />
+              ))}
         </ScrollableList>
       </Column>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(Following);

--- a/app/javascript/mastodon/features/getting_started/components/announcements.jsx
+++ b/app/javascript/mastodon/features/getting_started/components/announcements.jsx
@@ -1,7 +1,12 @@
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 
-import { defineMessages, injectIntl, FormattedMessage, FormattedDate } from 'react-intl';
+import {
+  defineMessages,
+  injectIntl,
+  FormattedMessage,
+  FormattedDate,
+} from 'react-intl';
 
 import classNames from 'classnames';
 
@@ -14,11 +19,16 @@ import ReactSwipeableViews from 'react-swipeable-views';
 
 import elephantUIPlane from 'mastodon/../images/elephant_ui_plane.svg';
 import { AnimatedNumber } from 'mastodon/components/animated_number';
-import { Icon }  from 'mastodon/components/icon';
+import { Icon } from 'mastodon/components/icon';
 import { IconButton } from 'mastodon/components/icon_button';
 import EmojiPickerDropdown from 'mastodon/features/compose/containers/emoji_picker_dropdown_container';
 import unicodeMapping from 'mastodon/features/emoji/emoji_unicode_mapping_light';
-import { autoPlayGif, reduceMotion, disableSwiping, mascot } from 'mastodon/initial_state';
+import {
+  autoPlayGif,
+  reduceMotion,
+  disableSwiping,
+  mascot,
+} from 'mastodon/initial_state';
 import { assetHost } from 'mastodon/utils/config';
 
 const messages = defineMessages({
@@ -28,7 +38,6 @@ const messages = defineMessages({
 });
 
 class Content extends ImmutablePureComponent {
-
   static contextTypes = {
     router: PropTypes.object,
   };
@@ -37,19 +46,19 @@ class Content extends ImmutablePureComponent {
     announcement: ImmutablePropTypes.map.isRequired,
   };
 
-  setRef = c => {
+  setRef = (c) => {
     this.node = c;
   };
 
-  componentDidMount () {
+  componentDidMount() {
     this._updateLinks();
   }
 
-  componentDidUpdate () {
+  componentDidUpdate() {
     this._updateLinks();
   }
 
-  _updateLinks () {
+  _updateLinks() {
     const node = this.node;
 
     if (!node) {
@@ -67,17 +76,40 @@ class Content extends ImmutablePureComponent {
 
       link.classList.add('status-link');
 
-      let mention = this.props.announcement.get('mentions').find(item => link.href === item.get('url'));
+      let mention = this.props.announcement
+        .get('mentions')
+        .find((item) => link.href === item.get('url'));
 
       if (mention) {
-        link.addEventListener('click', this.onMentionClick.bind(this, mention), false);
+        link.addEventListener(
+          'click',
+          this.onMentionClick.bind(this, mention),
+          false,
+        );
         link.setAttribute('title', mention.get('acct'));
-      } else if (link.textContent[0] === '#' || (link.previousSibling && link.previousSibling.textContent && link.previousSibling.textContent[link.previousSibling.textContent.length - 1] === '#')) {
-        link.addEventListener('click', this.onHashtagClick.bind(this, link.text), false);
+      } else if (
+        link.textContent[0] === '#' ||
+        (link.previousSibling &&
+          link.previousSibling.textContent &&
+          link.previousSibling.textContent[
+            link.previousSibling.textContent.length - 1
+          ] === '#')
+      ) {
+        link.addEventListener(
+          'click',
+          this.onHashtagClick.bind(this, link.text),
+          false,
+        );
       } else {
-        let status = this.props.announcement.get('statuses').find(item => link.href === item.get('url'));
+        let status = this.props.announcement
+          .get('statuses')
+          .find((item) => link.href === item.get('url'));
         if (status) {
-          link.addEventListener('click', this.onStatusClick.bind(this, status), false);
+          link.addEventListener(
+            'click',
+            this.onStatusClick.bind(this, status),
+            false,
+          );
         }
         link.setAttribute('title', link.href);
         link.classList.add('unhandled-link');
@@ -107,7 +139,9 @@ class Content extends ImmutablePureComponent {
   onStatusClick = (status, e) => {
     if (this.context.router && e.button === 0 && !(e.ctrlKey || e.metaKey)) {
       e.preventDefault();
-      this.context.router.history.push(`/@${status.getIn(['account', 'acct'])}/${status.get('id')}`);
+      this.context.router.history.push(
+        `/@${status.getIn(['account', 'acct'])}/${status.get('id')}`,
+      );
     }
   };
 
@@ -137,7 +171,7 @@ class Content extends ImmutablePureComponent {
     }
   };
 
-  render () {
+  render() {
     const { announcement } = this.props;
 
     return (
@@ -150,18 +184,16 @@ class Content extends ImmutablePureComponent {
       />
     );
   }
-
 }
 
 class Emoji extends PureComponent {
-
   static propTypes = {
     emoji: PropTypes.string.isRequired,
     emojiMap: ImmutablePropTypes.map.isRequired,
     hovered: PropTypes.bool.isRequired,
   };
 
-  render () {
+  render() {
     const { emoji, emojiMap, hovered } = this.props;
 
     if (unicodeMapping[emoji]) {
@@ -178,7 +210,10 @@ class Emoji extends PureComponent {
         />
       );
     } else if (emojiMap.get(emoji)) {
-      const filename  = (autoPlayGif || hovered) ? emojiMap.getIn([emoji, 'url']) : emojiMap.getIn([emoji, 'static_url']);
+      const filename =
+        autoPlayGif || hovered
+          ? emojiMap.getIn([emoji, 'url'])
+          : emojiMap.getIn([emoji, 'static_url']);
       const shortCode = `:${emoji}:`;
 
       return (
@@ -194,11 +229,9 @@ class Emoji extends PureComponent {
       return null;
     }
   }
-
 }
 
 class Reaction extends ImmutablePureComponent {
-
   static propTypes = {
     announcementId: PropTypes.string.isRequired,
     reaction: ImmutablePropTypes.map.isRequired,
@@ -213,7 +246,8 @@ class Reaction extends ImmutablePureComponent {
   };
 
   handleClick = () => {
-    const { reaction, announcementId, addReaction, removeReaction } = this.props;
+    const { reaction, announcementId, addReaction, removeReaction } =
+      this.props;
 
     if (reaction.get('me')) {
       removeReaction(announcementId, reaction.get('name'));
@@ -226,7 +260,7 @@ class Reaction extends ImmutablePureComponent {
 
   handleMouseLeave = () => this.setState({ hovered: false });
 
-  render () {
+  render() {
     const { reaction } = this.props;
 
     let shortCode = reaction.get('name');
@@ -236,17 +270,32 @@ class Reaction extends ImmutablePureComponent {
     }
 
     return (
-      <button className={classNames('reactions-bar__item', { active: reaction.get('me') })} onClick={this.handleClick} onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave} title={`:${shortCode}:`} style={this.props.style}>
-        <span className='reactions-bar__item__emoji'><Emoji hovered={this.state.hovered} emoji={reaction.get('name')} emojiMap={this.props.emojiMap} /></span>
-        <span className='reactions-bar__item__count'><AnimatedNumber value={reaction.get('count')} /></span>
+      <button
+        className={classNames('reactions-bar__item', {
+          active: reaction.get('me'),
+        })}
+        onClick={this.handleClick}
+        onMouseEnter={this.handleMouseEnter}
+        onMouseLeave={this.handleMouseLeave}
+        title={`:${shortCode}:`}
+        style={this.props.style}
+      >
+        <span className='reactions-bar__item__emoji'>
+          <Emoji
+            hovered={this.state.hovered}
+            emoji={reaction.get('name')}
+            emojiMap={this.props.emojiMap}
+          />
+        </span>
+        <span className='reactions-bar__item__count'>
+          <AnimatedNumber value={reaction.get('count')} />
+        </span>
       </button>
     );
   }
-
 }
 
 class ReactionsBar extends ImmutablePureComponent {
-
   static propTypes = {
     announcementId: PropTypes.string.isRequired,
     reactions: ImmutablePropTypes.list.isRequired,
@@ -255,38 +304,55 @@ class ReactionsBar extends ImmutablePureComponent {
     emojiMap: ImmutablePropTypes.map.isRequired,
   };
 
-  handleEmojiPick = data => {
+  handleEmojiPick = (data) => {
     const { addReaction, announcementId } = this.props;
     addReaction(announcementId, data.native.replace(/:/g, ''));
   };
 
-  willEnter () {
+  willEnter() {
     return { scale: reduceMotion ? 1 : 0 };
   }
 
-  willLeave () {
-    return { scale: reduceMotion ? 0 : spring(0, { stiffness: 170, damping: 26 }) };
+  willLeave() {
+    return {
+      scale: reduceMotion ? 0 : spring(0, { stiffness: 170, damping: 26 }),
+    };
   }
 
-  render () {
+  render() {
     const { reactions } = this.props;
-    const visibleReactions = reactions.filter(x => x.get('count') > 0);
+    const visibleReactions = reactions.filter((x) => x.get('count') > 0);
 
-    const styles = visibleReactions.map(reaction => ({
-      key: reaction.get('name'),
-      data: reaction,
-      style: { scale: reduceMotion ? 1 : spring(1, { stiffness: 150, damping: 13 }) },
-    })).toArray();
+    const styles = visibleReactions
+      .map((reaction) => ({
+        key: reaction.get('name'),
+        data: reaction,
+        style: {
+          scale: reduceMotion ? 1 : spring(1, { stiffness: 150, damping: 13 }),
+        },
+      }))
+      .toArray();
 
     return (
-      <TransitionMotion styles={styles} willEnter={this.willEnter} willLeave={this.willLeave}>
-        {items => (
-          <div className={classNames('reactions-bar', { 'reactions-bar--empty': visibleReactions.isEmpty() })}>
+      <TransitionMotion
+        styles={styles}
+        willEnter={this.willEnter}
+        willLeave={this.willLeave}
+      >
+        {(items) => (
+          <div
+            className={classNames('reactions-bar', {
+              'reactions-bar--empty': visibleReactions.isEmpty(),
+            })}
+          >
             {items.map(({ key, data, style }) => (
               <Reaction
                 key={key}
                 reaction={data}
-                style={{ transform: `scale(${style.scale})`, position: style.scale < 0.5 ? 'absolute' : 'static' }}
+                style={{
+                  transform: `scale(${style.scale})`,
+                  position: style.scale < 0.5 ? 'absolute' : 'static',
+                }}
                 announcementId={this.props.announcementId}
                 addReaction={this.props.addReaction}
                 removeReaction={this.props.removeReaction}
@@ -294,17 +360,20 @@ class ReactionsBar extends ImmutablePureComponent {
               />
             ))}
 
-            {visibleReactions.size < 8 && <EmojiPickerDropdown onPickEmoji={this.handleEmojiPick} button={<Icon id='plus' />} />}
+            {visibleReactions.size < 8 && (
+              <EmojiPickerDropdown
+                onPickEmoji={this.handleEmojiPick}
+                button={<Icon id='plus' />}
+              />
+            )}
           </div>
         )}
       </TransitionMotion>
     );
   }
-
 }
 
 class Announcement extends ImmutablePureComponent {
-
   static propTypes = {
     announcement: ImmutablePropTypes.map.isRequired,
     emojiMap: ImmutablePropTypes.map.isRequired,
@@ -318,29 +387,73 @@ class Announcement extends ImmutablePureComponent {
     unread: !this.props.announcement.get('read'),
   };
 
-  componentDidUpdate () {
+  componentDidUpdate() {
     const { selected, announcement } = this.props;
     if (!selected && this.state.unread !== !announcement.get('read')) {
       this.setState({ unread: !announcement.get('read') });
     }
   }
 
-  render () {
+  render() {
     const { announcement } = this.props;
     const { unread } = this.state;
-    const startsAt = announcement.get('starts_at') && new Date(announcement.get('starts_at'));
-    const endsAt = announcement.get('ends_at') && new Date(announcement.get('ends_at'));
+    const startsAt =
+      announcement.get('starts_at') && new Date(announcement.get('starts_at'));
+    const endsAt =
+      announcement.get('ends_at') && new Date(announcement.get('ends_at'));
     const now = new Date();
     const hasTimeRange = startsAt && endsAt;
-    const skipYear = hasTimeRange && startsAt.getFullYear() === endsAt.getFullYear() && endsAt.getFullYear() === now.getFullYear();
-    const skipEndDate = hasTimeRange && startsAt.getDate() === endsAt.getDate() && startsAt.getMonth() === endsAt.getMonth() && startsAt.getFullYear() === endsAt.getFullYear();
+    const skipYear =
+      hasTimeRange &&
+      startsAt.getFullYear() === endsAt.getFullYear() &&
+      endsAt.getFullYear() === now.getFullYear();
+    const skipEndDate =
+      hasTimeRange &&
+      startsAt.getDate() === endsAt.getDate() &&
+      startsAt.getMonth() === endsAt.getMonth() &&
+      startsAt.getFullYear() === endsAt.getFullYear();
     const skipTime = announcement.get('all_day');
 
     return (
       <div className='announcements__item'>
         <strong className='announcements__item__range'>
-          <FormattedMessage id='announcement.announcement' defaultMessage='Announcement' />
-          {hasTimeRange && <span> · <FormattedDate value={startsAt} hour12={false} year={(skipYear || startsAt.getFullYear() === now.getFullYear()) ? undefined : 'numeric'} month='short' day='2-digit' hour={skipTime ? undefined : '2-digit'} minute={skipTime ? undefined : '2-digit'} /> - <FormattedDate value={endsAt} hour12={false} year={(skipYear || endsAt.getFullYear() === now.getFullYear()) ? undefined : 'numeric'} month={skipEndDate ? undefined : 'short'} day={skipEndDate ? undefined : '2-digit'} hour={skipTime ? undefined : '2-digit'} minute={skipTime ? undefined : '2-digit'} /></span>}
+          <FormattedMessage
+            id='announcement.announcement'
+            defaultMessage='Announcement'
+          />
+          {hasTimeRange && (
+            <span>
+              {' '}
+              ·{' '}
+              <FormattedDate
+                value={startsAt}
+                hour12={false}
+                year={
+                  skipYear || startsAt.getFullYear() === now.getFullYear()
+                    ? undefined
+                    : 'numeric'
+                }
+                month='short'
+                day='2-digit'
+                hour={skipTime ? undefined : '2-digit'}
+                minute={skipTime ? undefined : '2-digit'}
+              />{' '}
+              -{' '}
+              <FormattedDate
+                value={endsAt}
+                hour12={false}
+                year={
+                  skipYear || endsAt.getFullYear() === now.getFullYear()
+                    ? undefined
+                    : 'numeric'
+                }
+                month={skipEndDate ? undefined : 'short'}
+                day={skipEndDate ? undefined : '2-digit'}
+                hour={skipTime ? undefined : '2-digit'}
+                minute={skipTime ? undefined : '2-digit'}
+              />
+            </span>
+          )}
         </strong>
 
         <Content announcement={announcement} />
@@ -357,11 +470,9 @@ class Announcement extends ImmutablePureComponent {
       </div>
     );
   }
-
 }
 
 class Announcements extends ImmutablePureComponent {
-
   static propTypes = {
     announcements: ImmutablePropTypes.list,
     emojiMap: ImmutablePropTypes.map.isRequired,
@@ -376,41 +487,50 @@ class Announcements extends ImmutablePureComponent {
   };
 
   static getDerivedStateFromProps(props, state) {
-    if (props.announcements.size > 0 && state.index >= props.announcements.size) {
+    if (
+      props.announcements.size > 0 &&
+      state.index >= props.announcements.size
+    ) {
       return { index: props.announcements.size - 1 };
     } else {
       return null;
     }
   }
 
-  componentDidMount () {
+  componentDidMount() {
     this._markAnnouncementAsRead();
   }
 
-  componentDidUpdate () {
+  componentDidUpdate() {
     this._markAnnouncementAsRead();
   }
 
-  _markAnnouncementAsRead () {
+  _markAnnouncementAsRead() {
     const { dismissAnnouncement, announcements } = this.props;
     const { index } = this.state;
     const announcement = announcements.get(announcements.size - 1 - index);
     if (!announcement.get('read')) dismissAnnouncement(announcement.get('id'));
   }
 
-  handleChangeIndex = index => {
+  handleChangeIndex = (index) => {
     this.setState({ index: index % this.props.announcements.size });
   };
 
   handleNextClick = () => {
-    this.setState({ index: (this.state.index + 1) % this.props.announcements.size });
+    this.setState({
+      index: (this.state.index + 1) % this.props.announcements.size,
+    });
   };
 
   handlePrevClick = () => {
-    this.setState({ index: (this.props.announcements.size + this.state.index - 1) % this.props.announcements.size });
+    this.setState({
+      index:
+        (this.props.announcements.size + this.state.index - 1) %
+        this.props.announcements.size,
+    });
   };
 
-  render () {
+  render() {
     const { announcements, intl } = this.props;
     const { index } = this.state;
 
@@ -420,36 +540,61 @@ class Announcements extends ImmutablePureComponent {
 
     return (
       <div className='announcements'>
-        <img className='announcements__mastodon' alt='' draggable='false' src={mascot || elephantUIPlane} />
+        <img
+          className='announcements__mastodon'
+          alt=''
+          draggable='false'
+          src={mascot || elephantUIPlane}
+        />
 
         <div className='announcements__container'>
-          <ReactSwipeableViews animateHeight animateTransitions={!reduceMotion} index={index} onChangeIndex={this.handleChangeIndex}>
-            {announcements.map((announcement, idx) => (
-              <Announcement
-                key={announcement.get('id')}
-                announcement={announcement}
-                emojiMap={this.props.emojiMap}
-                addReaction={this.props.addReaction}
-                removeReaction={this.props.removeReaction}
-                intl={intl}
-                selected={index === idx}
-                disabled={disableSwiping}
-              />
-            )).reverse()}
+          <ReactSwipeableViews
+            animateHeight
+            animateTransitions={!reduceMotion}
+            index={index}
+            onChangeIndex={this.handleChangeIndex}
+          >
+            {announcements
+              .map((announcement, idx) => (
+                <Announcement
+                  key={announcement.get('id')}
+                  announcement={announcement}
+                  emojiMap={this.props.emojiMap}
+                  addReaction={this.props.addReaction}
+                  removeReaction={this.props.removeReaction}
+                  intl={intl}
+                  selected={index === idx}
+                  disabled={disableSwiping}
+                />
+              ))
+              .reverse()}
           </ReactSwipeableViews>
 
           {announcements.size > 1 && (
             <div className='announcements__pagination'>
-              <IconButton disabled={announcements.size === 1} title={intl.formatMessage(messages.previous)} icon='chevron-left' onClick={this.handlePrevClick} size={13} />
-              <span>{index + 1} / {announcements.size}</span>
-              <IconButton disabled={announcements.size === 1} title={intl.formatMessage(messages.next)} icon='chevron-right' onClick={this.handleNextClick} size={13} />
+              <IconButton
+                disabled={announcements.size === 1}
+                title={intl.formatMessage(messages.previous)}
+                icon='chevron-left'
+                onClick={this.handlePrevClick}
+                size={13}
+              />
+              <span>
+                {index + 1} / {announcements.size}
+              </span>
+              <IconButton
+                disabled={announcements.size === 1}
+                title={intl.formatMessage(messages.next)}
+                icon='chevron-right'
+                onClick={this.handleNextClick}
+                size={13}
+              />
             </div>
           )}
         </div>
       </div>
     );
   }
-
 }
 
 export default injectIntl(Announcements);

--- a/app/javascript/mastodon/features/getting_started/components/trends.jsx
+++ b/app/javascript/mastodon/features/getting_started/components/trends.jsx
@@ -10,7 +10,6 @@ import ImmutablePureComponent from 'react-immutable-pure-component';
 import { ImmutableHashtag as Hashtag } from 'mastodon/components/hashtag';
 
 export default class Trends extends ImmutablePureComponent {
-
   static defaultProps = {
     loading: false,
   };
@@ -20,18 +19,21 @@ export default class Trends extends ImmutablePureComponent {
     fetchTrends: PropTypes.func.isRequired,
   };
 
-  componentDidMount () {
+  componentDidMount() {
     this.props.fetchTrends();
-    this.refreshInterval = setInterval(() => this.props.fetchTrends(), 900 * 1000);
+    this.refreshInterval = setInterval(
+      () => this.props.fetchTrends(),
+      900 * 1000,
+    );
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     if (this.refreshInterval) {
       clearInterval(this.refreshInterval);
     }
   }
 
-  render () {
+  render() {
     const { trends } = this.props;
 
     if (!trends || trends.isEmpty()) {
@@ -42,13 +44,17 @@ export default class Trends extends ImmutablePureComponent {
       <div className='getting-started__trends'>
         <h4>
           <Link to={'/explore/tags'}>
-            <FormattedMessage id='trends.trending_now' defaultMessage='Trending now' />
+            <FormattedMessage
+              id='trends.trending_now'
+              defaultMessage='Trending now'
+            />
           </Link>
         </h4>
 
-        {trends.take(3).map(hashtag => <Hashtag key={hashtag.get('name')} hashtag={hashtag} />)}
+        {trends.take(3).map((hashtag) => (
+          <Hashtag key={hashtag.get('name')} hashtag={hashtag} />
+        ))}
       </div>
     );
   }
-
 }

--- a/app/javascript/mastodon/features/getting_started/containers/announcements_container.js
+++ b/app/javascript/mastodon/features/getting_started/containers/announcements_container.js
@@ -2,19 +2,30 @@ import { Map as ImmutableMap } from 'immutable';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 
-import { addReaction, removeReaction, dismissAnnouncement } from 'mastodon/actions/announcements';
+import {
+  addReaction,
+  removeReaction,
+  dismissAnnouncement,
+} from 'mastodon/actions/announcements';
 
 import Announcements from '../components/announcements';
 
-const customEmojiMap = createSelector([state => state.get('custom_emojis')], items => items.reduce((map, emoji) => map.set(emoji.get('shortcode'), emoji), ImmutableMap()));
+const customEmojiMap = createSelector(
+  [(state) => state.get('custom_emojis')],
+  (items) =>
+    items.reduce(
+      (map, emoji) => map.set(emoji.get('shortcode'), emoji),
+      ImmutableMap(),
+    ),
+);
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   announcements: state.getIn(['announcements', 'items']),
   emojiMap: customEmojiMap(state),
 });
 
-const mapDispatchToProps = dispatch => ({
-  dismissAnnouncement: id => dispatch(dismissAnnouncement(id)),
+const mapDispatchToProps = (dispatch) => ({
+  dismissAnnouncement: (id) => dispatch(dismissAnnouncement(id)),
   addReaction: (id, name) => dispatch(addReaction(id, name)),
   removeReaction: (id, name) => dispatch(removeReaction(id, name)),
 });

--- a/app/javascript/mastodon/features/getting_started/containers/trends_container.js
+++ b/app/javascript/mastodon/features/getting_started/containers/trends_container.js
@@ -4,11 +4,11 @@ import { fetchTrendingHashtags } from 'mastodon/actions/trends';
 
 import Trends from '../components/trends';
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   trends: state.getIn(['trends', 'tags', 'items']),
 });
 
-const mapDispatchToProps = dispatch => ({
+const mapDispatchToProps = (dispatch) => ({
   fetchTrends: () => dispatch(fetchTrendingHashtags()),
 });
 

--- a/app/javascript/mastodon/features/getting_started/index.jsx
+++ b/app/javascript/mastodon/features/getting_started/index.jsx
@@ -23,18 +23,39 @@ import TrendsContainer from './containers/trends_container';
 
 const messages = defineMessages({
   home_timeline: { id: 'tabs_bar.home', defaultMessage: 'Home' },
-  notifications: { id: 'tabs_bar.notifications', defaultMessage: 'Notifications' },
-  public_timeline: { id: 'navigation_bar.public_timeline', defaultMessage: 'Federated timeline' },
-  settings_subheading: { id: 'column_subheading.settings', defaultMessage: 'Settings' },
-  community_timeline: { id: 'navigation_bar.community_timeline', defaultMessage: 'Local timeline' },
+  notifications: {
+    id: 'tabs_bar.notifications',
+    defaultMessage: 'Notifications',
+  },
+  public_timeline: {
+    id: 'navigation_bar.public_timeline',
+    defaultMessage: 'Federated timeline',
+  },
+  settings_subheading: {
+    id: 'column_subheading.settings',
+    defaultMessage: 'Settings',
+  },
+  community_timeline: {
+    id: 'navigation_bar.community_timeline',
+    defaultMessage: 'Local timeline',
+  },
   explore: { id: 'navigation_bar.explore', defaultMessage: 'Explore' },
   direct: { id: 'navigation_bar.direct', defaultMessage: 'Private mentions' },
   bookmarks: { id: 'navigation_bar.bookmarks', defaultMessage: 'Bookmarks' },
-  preferences: { id: 'navigation_bar.preferences', defaultMessage: 'Preferences' },
-  follow_requests: { id: 'navigation_bar.follow_requests', defaultMessage: 'Follow requests' },
+  preferences: {
+    id: 'navigation_bar.preferences',
+    defaultMessage: 'Preferences',
+  },
+  follow_requests: {
+    id: 'navigation_bar.follow_requests',
+    defaultMessage: 'Follow requests',
+  },
   favourites: { id: 'navigation_bar.favourites', defaultMessage: 'Favorites' },
   blocks: { id: 'navigation_bar.blocks', defaultMessage: 'Blocked users' },
-  domain_blocks: { id: 'navigation_bar.domain_blocks', defaultMessage: 'Blocked domains' },
+  domain_blocks: {
+    id: 'navigation_bar.domain_blocks',
+    defaultMessage: 'Blocked domains',
+  },
   mutes: { id: 'navigation_bar.mutes', defaultMessage: 'Muted users' },
   pins: { id: 'navigation_bar.pins', defaultMessage: 'Pinned posts' },
   lists: { id: 'navigation_bar.lists', defaultMessage: 'Lists' },
@@ -44,12 +65,15 @@ const messages = defineMessages({
   menu: { id: 'getting_started.heading', defaultMessage: 'Getting started' },
 });
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   myAccount: state.getIn(['accounts', me]),
-  unreadFollowRequests: state.getIn(['user_lists', 'follow_requests', 'items'], ImmutableList()).size,
+  unreadFollowRequests: state.getIn(
+    ['user_lists', 'follow_requests', 'items'],
+    ImmutableList(),
+  ).size,
 });
 
-const mapDispatchToProps = dispatch => ({
+const mapDispatchToProps = (dispatch) => ({
   fetchFollowRequests: () => dispatch(fetchFollowRequests()),
 });
 
@@ -64,7 +88,6 @@ const badgeDisplay = (number, limit) => {
 };
 
 class GettingStarted extends ImmutablePureComponent {
-
   static contextTypes = {
     router: PropTypes.object.isRequired,
     identity: PropTypes.object,
@@ -79,7 +102,7 @@ class GettingStarted extends ImmutablePureComponent {
     unreadNotifications: PropTypes.number,
   };
 
-  componentDidMount () {
+  componentDidMount() {
     const { fetchFollowRequests } = this.props;
     const { signedIn } = this.context.identity;
 
@@ -90,62 +113,130 @@ class GettingStarted extends ImmutablePureComponent {
     fetchFollowRequests();
   }
 
-  render () {
+  render() {
     const { intl, myAccount, multiColumn, unreadFollowRequests } = this.props;
     const { signedIn } = this.context.identity;
 
     const navItems = [];
 
     navItems.push(
-      <ColumnSubheading key='header-discover' text={intl.formatMessage(messages.discover)} />,
+      <ColumnSubheading
+        key='header-discover'
+        text={intl.formatMessage(messages.discover)}
+      />,
     );
 
     if (showTrends) {
       navItems.push(
-        <ColumnLink key='explore' icon='hashtag' text={intl.formatMessage(messages.explore)} to='/explore' />,
+        <ColumnLink
+          key='explore'
+          icon='hashtag'
+          text={intl.formatMessage(messages.explore)}
+          to='/explore'
+        />,
       );
     }
 
     navItems.push(
-      <ColumnLink key='community_timeline' icon='users' text={intl.formatMessage(messages.community_timeline)} to='/public/local' />,
-      <ColumnLink key='public_timeline' icon='globe' text={intl.formatMessage(messages.public_timeline)} to='/public' />,
+      <ColumnLink
+        key='community_timeline'
+        icon='users'
+        text={intl.formatMessage(messages.community_timeline)}
+        to='/public/local'
+      />,
+      <ColumnLink
+        key='public_timeline'
+        icon='globe'
+        text={intl.formatMessage(messages.public_timeline)}
+        to='/public'
+      />,
     );
 
     if (signedIn) {
       navItems.push(
-        <ColumnSubheading key='header-personal' text={intl.formatMessage(messages.personal)} />,
-        <ColumnLink key='home' icon='home' text={intl.formatMessage(messages.home_timeline)} to='/home' />,
-        <ColumnLink key='direct' icon='at' text={intl.formatMessage(messages.direct)} to='/conversations' />,
-        <ColumnLink key='bookmark' icon='bookmark' text={intl.formatMessage(messages.bookmarks)} to='/bookmarks' />,
-        <ColumnLink key='favourites' icon='star' text={intl.formatMessage(messages.favourites)} to='/favourites' />,
-        <ColumnLink key='lists' icon='list-ul' text={intl.formatMessage(messages.lists)} to='/lists' />,
+        <ColumnSubheading
+          key='header-personal'
+          text={intl.formatMessage(messages.personal)}
+        />,
+        <ColumnLink
+          key='home'
+          icon='home'
+          text={intl.formatMessage(messages.home_timeline)}
+          to='/home'
+        />,
+        <ColumnLink
+          key='direct'
+          icon='at'
+          text={intl.formatMessage(messages.direct)}
+          to='/conversations'
+        />,
+        <ColumnLink
+          key='bookmark'
+          icon='bookmark'
+          text={intl.formatMessage(messages.bookmarks)}
+          to='/bookmarks'
+        />,
+        <ColumnLink
+          key='favourites'
+          icon='star'
+          text={intl.formatMessage(messages.favourites)}
+          to='/favourites'
+        />,
+        <ColumnLink
+          key='lists'
+          icon='list-ul'
+          text={intl.formatMessage(messages.lists)}
+          to='/lists'
+        />,
       );
 
       if (myAccount.get('locked') || unreadFollowRequests > 0) {
-        navItems.push(<ColumnLink key='follow_requests' icon='user-plus' text={intl.formatMessage(messages.follow_requests)} badge={badgeDisplay(unreadFollowRequests, 40)} to='/follow_requests' />);
+        navItems.push(
+          <ColumnLink
+            key='follow_requests'
+            icon='user-plus'
+            text={intl.formatMessage(messages.follow_requests)}
+            badge={badgeDisplay(unreadFollowRequests, 40)}
+            to='/follow_requests'
+          />,
+        );
       }
 
       navItems.push(
-        <ColumnSubheading key='header-settings' text={intl.formatMessage(messages.settings_subheading)} />,
-        <ColumnLink key='preferences' icon='gears' text={intl.formatMessage(messages.preferences)} href='/settings/preferences' />,
+        <ColumnSubheading
+          key='header-settings'
+          text={intl.formatMessage(messages.settings_subheading)}
+        />,
+        <ColumnLink
+          key='preferences'
+          icon='gears'
+          text={intl.formatMessage(messages.preferences)}
+          href='/settings/preferences'
+        />,
       );
     }
 
     return (
       <Column>
-        {(signedIn && !multiColumn) ? <NavigationContainer /> : <ColumnHeader title={intl.formatMessage(messages.menu)} icon='bars' multiColumn={multiColumn} />}
+        {signedIn && !multiColumn ? (
+          <NavigationContainer />
+        ) : (
+          <ColumnHeader
+            title={intl.formatMessage(messages.menu)}
+            icon='bars'
+            multiColumn={multiColumn}
+          />
+        )}
 
         <div className='getting-started scrollable scrollable--flex'>
-          <div className='getting-started__wrapper'>
-            {navItems}
-          </div>
+          <div className='getting-started__wrapper'>{navItems}</div>
 
           {!multiColumn && <div className='flex-spacer' />}
 
           <LinkFooter multiColumn />
         </div>
 
-        {(multiColumn && showTrends) && <TrendsContainer />}
+        {multiColumn && showTrends && <TrendsContainer />}
 
         <Helmet>
           <title>{intl.formatMessage(messages.menu)}</title>
@@ -154,7 +245,9 @@ class GettingStarted extends ImmutablePureComponent {
       </Column>
     );
   }
-
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(injectIntl(GettingStarted));
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(injectIntl(GettingStarted));

--- a/app/javascript/mastodon/features/hashtag_timeline/components/column_settings.jsx
+++ b/app/javascript/mastodon/features/hashtag_timeline/components/column_settings.jsx
@@ -12,12 +12,17 @@ import Toggle from 'react-toggle';
 import SettingToggle from '../../notifications/components/setting_toggle';
 
 const messages = defineMessages({
-  placeholder: { id: 'hashtag.column_settings.select.placeholder', defaultMessage: 'Enter hashtags…' },
-  noOptions: { id: 'hashtag.column_settings.select.no_options_message', defaultMessage: 'No suggestions found' },
+  placeholder: {
+    id: 'hashtag.column_settings.select.placeholder',
+    defaultMessage: 'Enter hashtags…',
+  },
+  noOptions: {
+    id: 'hashtag.column_settings.select.no_options_message',
+    defaultMessage: 'No suggestions found',
+  },
 });
 
 class ColumnSettings extends PureComponent {
-
   static propTypes = {
     settings: ImmutablePropTypes.map.isRequired,
     onChange: PropTypes.func.isRequired,
@@ -29,11 +34,13 @@ class ColumnSettings extends PureComponent {
     open: this.hasTags(),
   };
 
-  hasTags () {
-    return ['all', 'any', 'none'].map(mode => this.tags(mode).length > 0).includes(true);
+  hasTags() {
+    return ['all', 'any', 'none']
+      .map((mode) => this.tags(mode).length > 0)
+      .includes(true);
   }
 
-  tags (mode) {
+  tags(mode) {
     let tags = this.props.settings.getIn(['tags', mode]) || [];
 
     if (tags.toJS) {
@@ -43,12 +50,12 @@ class ColumnSettings extends PureComponent {
     }
   }
 
-  onSelect = mode => value => {
+  onSelect = (mode) => (value) => {
     const oldValue = this.tags(mode);
 
     // Prevent changes that add more than 4 tags, but allow removing
     // tags that were already added before
-    if ((value.length > 4) && !(value < oldValue)) {
+    if (value.length > 4 && !(value < oldValue)) {
       return;
     }
 
@@ -65,14 +72,15 @@ class ColumnSettings extends PureComponent {
 
   noOptionsMessage = () => this.props.intl.formatMessage(messages.noOptions);
 
-  modeSelect (mode) {
+  modeSelect(mode) {
     return (
       <div className='column-settings__row'>
-        <span className='column-settings__section'>
-          {this.modeLabel(mode)}
-        </span>
+        <span className='column-settings__section'>{this.modeLabel(mode)}</span>
 
-        <NonceProvider nonce={document.querySelector('meta[name=style-nonce]').content} cacheKey='tags'>
+        <NonceProvider
+          nonce={document.querySelector('meta[name=style-nonce]').content}
+          cacheKey='tags'
+        >
           <AsyncSelect
             isMulti
             autoFocus
@@ -90,30 +98,52 @@ class ColumnSettings extends PureComponent {
     );
   }
 
-  modeLabel (mode) {
-    switch(mode) {
-    case 'any':
-      return <FormattedMessage id='hashtag.column_settings.tag_mode.any' defaultMessage='Any of these' />;
-    case 'all':
-      return <FormattedMessage id='hashtag.column_settings.tag_mode.all' defaultMessage='All of these' />;
-    case 'none':
-      return <FormattedMessage id='hashtag.column_settings.tag_mode.none' defaultMessage='None of these' />;
-    default:
-      return '';
+  modeLabel(mode) {
+    switch (mode) {
+      case 'any':
+        return (
+          <FormattedMessage
+            id='hashtag.column_settings.tag_mode.any'
+            defaultMessage='Any of these'
+          />
+        );
+      case 'all':
+        return (
+          <FormattedMessage
+            id='hashtag.column_settings.tag_mode.all'
+            defaultMessage='All of these'
+          />
+        );
+      case 'none':
+        return (
+          <FormattedMessage
+            id='hashtag.column_settings.tag_mode.none'
+            defaultMessage='None of these'
+          />
+        );
+      default:
+        return '';
     }
   }
 
-  render () {
+  render() {
     const { settings, onChange } = this.props;
 
     return (
       <div>
         <div className='column-settings__row'>
           <div className='setting-toggle'>
-            <Toggle id='hashtag.column_settings.tag_toggle' onChange={this.onToggle} checked={this.state.open} />
+            <Toggle
+              id='hashtag.column_settings.tag_toggle'
+              onChange={this.onToggle}
+              checked={this.state.open}
+            />
 
             <span className='setting-toggle__label'>
-              <FormattedMessage id='hashtag.column_settings.tag_toggle' defaultMessage='Include additional tags in this column' />
+              <FormattedMessage
+                id='hashtag.column_settings.tag_toggle'
+                defaultMessage='Include additional tags in this column'
+              />
             </span>
           </div>
         </div>
@@ -127,12 +157,21 @@ class ColumnSettings extends PureComponent {
         )}
 
         <div className='column-settings__row'>
-          <SettingToggle settings={settings} settingPath={['local']} onChange={onChange} label={<FormattedMessage id='community.column_settings.local_only' defaultMessage='Local only' />} />
+          <SettingToggle
+            settings={settings}
+            settingPath={['local']}
+            onChange={onChange}
+            label={
+              <FormattedMessage
+                id='community.column_settings.local_only'
+                defaultMessage='Local only'
+              />
+            }
+          />
         </div>
       </div>
     );
   }
-
 }
 
 export default injectIntl(ColumnSettings);

--- a/app/javascript/mastodon/features/hashtag_timeline/components/hashtag_header.jsx
+++ b/app/javascript/mastodon/features/hashtag_timeline/components/hashtag_header.jsx
@@ -9,7 +9,10 @@ import { ShortNumber } from 'mastodon/components/short_number';
 
 const messages = defineMessages({
   followHashtag: { id: 'hashtag.follow', defaultMessage: 'Follow hashtag' },
-  unfollowHashtag: { id: 'hashtag.unfollow', defaultMessage: 'Unfollow hashtag' },
+  unfollowHashtag: {
+    id: 'hashtag.unfollow',
+    defaultMessage: 'Unfollow hashtag',
+  },
 });
 
 const usesRenderer = (displayNumber, pluralReady) => (
@@ -50,14 +53,30 @@ export const HashtagHeader = injectIntl(({ tag, intl, disabled, onClick }) => {
     return null;
   }
 
-  const [uses, people] = tag.get('history').reduce((arr, day) => [arr[0] + day.get('uses') * 1, arr[1] + day.get('accounts') * 1], [0, 0]);
+  const [uses, people] = tag
+    .get('history')
+    .reduce(
+      (arr, day) => [
+        arr[0] + day.get('uses') * 1,
+        arr[1] + day.get('accounts') * 1,
+      ],
+      [0, 0],
+    );
   const dividingCircle = <span aria-hidden>{' · '}</span>;
 
   return (
     <div className='hashtag-header'>
       <div className='hashtag-header__header'>
         <h1>#{tag.get('name')}</h1>
-        <Button onClick={onClick} text={intl.formatMessage(tag.get('following') ? messages.unfollowHashtag : messages.followHashtag)} disabled={disabled} />
+        <Button
+          onClick={onClick}
+          text={intl.formatMessage(
+            tag.get('following')
+              ? messages.unfollowHashtag
+              : messages.followHashtag,
+          )}
+          disabled={disabled}
+        />
       </div>
 
       <div>
@@ -65,7 +84,10 @@ export const HashtagHeader = injectIntl(({ tag, intl, disabled, onClick }) => {
         {dividingCircle}
         <ShortNumber value={people} renderer={peopleRenderer} />
         {dividingCircle}
-        <ShortNumber value={tag.getIn(['history', 0, 'uses']) * 1} renderer={usesTodayRenderer} />
+        <ShortNumber
+          value={tag.getIn(['history', 0, 'uses']) * 1}
+          renderer={usesTodayRenderer}
+        />
       </div>
     </div>
   );

--- a/app/javascript/mastodon/features/hashtag_timeline/containers/column_settings_container.js
+++ b/app/javascript/mastodon/features/hashtag_timeline/containers/column_settings_container.js
@@ -6,7 +6,7 @@ import ColumnSettings from '../components/column_settings';
 
 const mapStateToProps = (state, { columnId }) => {
   const columns = state.getIn(['settings', 'columns']);
-  const index   = columns.findIndex(c => c.get('uuid') === columnId);
+  const index = columns.findIndex((c) => c.get('uuid') === columnId);
 
   if (!(columnId && index >= 0)) {
     return {};
@@ -14,18 +14,20 @@ const mapStateToProps = (state, { columnId }) => {
 
   return {
     settings: columns.get(index).get('params'),
-    onLoad (value) {
-      return api(() => state).get('/api/v2/search', { params: { q: value, type: 'hashtags' } }).then(response => {
-        return (response.data.hashtags || []).map((tag) => {
-          return { value: tag.name, label: `#${tag.name}` };
+    onLoad(value) {
+      return api(() => state)
+        .get('/api/v2/search', { params: { q: value, type: 'hashtags' } })
+        .then((response) => {
+          return (response.data.hashtags || []).map((tag) => {
+            return { value: tag.name, label: `#${tag.name}` };
+          });
         });
-      });
     },
   };
 };
 
 const mapDispatchToProps = (dispatch, { columnId }) => ({
-  onChange (key, value) {
+  onChange(key, value) {
     dispatch(changeColumnParams(columnId, key, value));
   },
 });

--- a/app/javascript/mastodon/features/hashtag_timeline/index.jsx
+++ b/app/javascript/mastodon/features/hashtag_timeline/index.jsx
@@ -12,8 +12,15 @@ import { isEqual } from 'lodash';
 
 import { addColumn, removeColumn, moveColumn } from 'mastodon/actions/columns';
 import { connectHashtagStream } from 'mastodon/actions/streaming';
-import { fetchHashtag, followHashtag, unfollowHashtag } from 'mastodon/actions/tags';
-import { expandHashtagTimeline, clearTimeline } from 'mastodon/actions/timelines';
+import {
+  fetchHashtag,
+  followHashtag,
+  unfollowHashtag,
+} from 'mastodon/actions/tags';
+import {
+  expandHashtagTimeline,
+  clearTimeline,
+} from 'mastodon/actions/timelines';
 import Column from 'mastodon/components/column';
 import ColumnHeader from 'mastodon/components/column_header';
 
@@ -23,12 +30,16 @@ import { HashtagHeader } from './components/hashtag_header';
 import ColumnSettingsContainer from './containers/column_settings_container';
 
 const mapStateToProps = (state, props) => ({
-  hasUnread: state.getIn(['timelines', `hashtag:${props.params.id}${props.params.local ? ':local' : ''}`, 'unread']) > 0,
+  hasUnread:
+    state.getIn([
+      'timelines',
+      `hashtag:${props.params.id}${props.params.local ? ':local' : ''}`,
+      'unread',
+    ]) > 0,
   tag: state.getIn(['tags', props.params.id]),
 });
 
 class HashtagTimeline extends PureComponent {
-
   disconnects = [];
 
   static contextTypes = {
@@ -56,18 +67,42 @@ class HashtagTimeline extends PureComponent {
 
   title = () => {
     const { id } = this.props.params;
-    const title  = [id];
+    const title = [id];
 
     if (this.additionalFor('any')) {
-      title.push(' ', <FormattedMessage key='any' id='hashtag.column_header.tag_mode.any'  values={{ additional: this.additionalFor('any') }} defaultMessage='or {additional}' />);
+      title.push(
+        ' ',
+        <FormattedMessage
+          key='any'
+          id='hashtag.column_header.tag_mode.any'
+          values={{ additional: this.additionalFor('any') }}
+          defaultMessage='or {additional}'
+        />,
+      );
     }
 
     if (this.additionalFor('all')) {
-      title.push(' ', <FormattedMessage key='all' id='hashtag.column_header.tag_mode.all'  values={{ additional: this.additionalFor('all') }} defaultMessage='and {additional}' />);
+      title.push(
+        ' ',
+        <FormattedMessage
+          key='all'
+          id='hashtag.column_header.tag_mode.all'
+          values={{ additional: this.additionalFor('all') }}
+          defaultMessage='and {additional}'
+        />,
+      );
     }
 
     if (this.additionalFor('none')) {
-      title.push(' ', <FormattedMessage key='none' id='hashtag.column_header.tag_mode.none' values={{ additional: this.additionalFor('none') }} defaultMessage='without {additional}' />);
+      title.push(
+        ' ',
+        <FormattedMessage
+          key='none'
+          id='hashtag.column_header.tag_mode.none'
+          values={{ additional: this.additionalFor('none') }}
+          defaultMessage='without {additional}'
+        />,
+      );
     }
 
     return title;
@@ -77,7 +112,7 @@ class HashtagTimeline extends PureComponent {
     const { tags } = this.props.params;
 
     if (tags && (tags[mode] || []).length > 0) {
-      return tags[mode].map(tag => tag.value).join('/');
+      return tags[mode].map((tag) => tag.value).join('/');
     } else {
       return '';
     }
@@ -92,33 +127,39 @@ class HashtagTimeline extends PureComponent {
     this.column.scrollTop();
   };
 
-  _subscribe (dispatch, id, tags = {}, local) {
+  _subscribe(dispatch, id, tags = {}, local) {
     const { signedIn } = this.context.identity;
 
     if (!signedIn) {
       return;
     }
 
-    let any  = (tags.any || []).map(tag => tag.value);
-    let all  = (tags.all || []).map(tag => tag.value);
-    let none = (tags.none || []).map(tag => tag.value);
+    let any = (tags.any || []).map((tag) => tag.value);
+    let all = (tags.all || []).map((tag) => tag.value);
+    let none = (tags.none || []).map((tag) => tag.value);
 
-    [id, ...any].map(tag => {
-      this.disconnects.push(dispatch(connectHashtagStream(id, tag, local, status => {
-        let tags = status.tags.map(tag => tag.name);
+    [id, ...any].map((tag) => {
+      this.disconnects.push(
+        dispatch(
+          connectHashtagStream(id, tag, local, (status) => {
+            let tags = status.tags.map((tag) => tag.name);
 
-        return all.filter(tag => tags.includes(tag)).length === all.length &&
-               none.filter(tag => tags.includes(tag)).length === 0;
-      })));
+            return (
+              all.filter((tag) => tags.includes(tag)).length === all.length &&
+              none.filter((tag) => tags.includes(tag)).length === 0
+            );
+          }),
+        ),
+      );
     });
   }
 
-  _unsubscribe () {
-    this.disconnects.map(disconnect => disconnect());
+  _unsubscribe() {
+    this.disconnects.map((disconnect) => disconnect());
     this.disconnects = [];
   }
 
-  _unload () {
+  _unload() {
     const { dispatch } = this.props;
     const { id, local } = this.props.params;
 
@@ -135,31 +176,35 @@ class HashtagTimeline extends PureComponent {
     dispatch(fetchHashtag(id));
   }
 
-  componentDidMount () {
+  componentDidMount() {
     this._load();
   }
 
-  componentDidUpdate (prevProps) {
+  componentDidUpdate(prevProps) {
     const { params } = this.props;
     const { id, tags, local } = prevProps.params;
 
-    if (id !== params.id || !isEqual(tags, params.tags) || !isEqual(local, params.local)) {
+    if (
+      id !== params.id ||
+      !isEqual(tags, params.tags) ||
+      !isEqual(local, params.local)
+    ) {
       this._unload();
       this._load();
     }
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     this._unsubscribe();
   }
 
-  setRef = c => {
+  setRef = (c) => {
     this.column = c;
   };
 
-  handleLoadMore = maxId => {
+  handleLoadMore = (maxId) => {
     const { dispatch, params } = this.props;
-    const { id, tags, local }  = params;
+    const { id, tags, local } = params;
 
     dispatch(expandHashtagTimeline(id, { maxId, tags, local }));
   };
@@ -180,7 +225,7 @@ class HashtagTimeline extends PureComponent {
     }
   };
 
-  render () {
+  render() {
     const { hasUnread, columnId, multiColumn, tag } = this.props;
     const { id, local } = this.props.params;
     const pinned = !!columnId;
@@ -203,13 +248,26 @@ class HashtagTimeline extends PureComponent {
         </ColumnHeader>
 
         <StatusListContainer
-          prepend={pinned ? null : <HashtagHeader tag={tag} disabled={!signedIn} onClick={this.handleFollow} />}
+          prepend={
+            pinned ? null : (
+              <HashtagHeader
+                tag={tag}
+                disabled={!signedIn}
+                onClick={this.handleFollow}
+              />
+            )
+          }
           alwaysPrepend
           trackScroll={!pinned}
           scrollKey={`hashtag_timeline-${columnId}`}
           timelineId={`hashtag:${id}${local ? ':local' : ''}`}
           onLoadMore={this.handleLoadMore}
-          emptyMessage={<FormattedMessage id='empty_column.hashtag' defaultMessage='There is nothing in this hashtag yet.' />}
+          emptyMessage={
+            <FormattedMessage
+              id='empty_column.hashtag'
+              defaultMessage='There is nothing in this hashtag yet.'
+            />
+          }
           bindToDocument={!multiColumn}
         />
 
@@ -220,7 +278,6 @@ class HashtagTimeline extends PureComponent {
       </Column>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(HashtagTimeline);

--- a/app/javascript/mastodon/features/home_timeline/index.jsx
+++ b/app/javascript/mastodon/features/home_timeline/index.jsx
@@ -10,7 +10,10 @@ import { List as ImmutableList } from 'immutable';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 
-import { fetchAnnouncements, toggleShowAnnouncements } from 'mastodon/actions/announcements';
+import {
+  fetchAnnouncements,
+  toggleShowAnnouncements,
+} from 'mastodon/actions/announcements';
 import { IconWithBadge } from 'mastodon/components/icon_with_badge';
 import { NotSignedInIndicator } from 'mastodon/components/not_signed_in_indicator';
 import AnnouncementsContainer from 'mastodon/features/getting_started/containers/announcements_container';
@@ -28,48 +31,69 @@ import { ExplorePrompt } from './components/explore_prompt';
 
 const messages = defineMessages({
   title: { id: 'column.home', defaultMessage: 'Home' },
-  show_announcements: { id: 'home.show_announcements', defaultMessage: 'Show announcements' },
-  hide_announcements: { id: 'home.hide_announcements', defaultMessage: 'Hide announcements' },
+  show_announcements: {
+    id: 'home.show_announcements',
+    defaultMessage: 'Show announcements',
+  },
+  hide_announcements: {
+    id: 'home.hide_announcements',
+    defaultMessage: 'Hide announcements',
+  },
 });
 
-const getHomeFeedSpeed = createSelector([
-  state => state.getIn(['timelines', 'home', 'items'], ImmutableList()),
-  state => state.getIn(['timelines', 'home', 'pendingItems'], ImmutableList()),
-  state => state.get('statuses'),
-], (statusIds, pendingStatusIds, statusMap) => {
-  const recentStatusIds = pendingStatusIds.size > 0 ? pendingStatusIds : statusIds;
-  const statuses = recentStatusIds.filter(id => id !== null).map(id => statusMap.get(id)).filter(status => status?.get('account') !== me).take(20);
-  const oldest = new Date(statuses.getIn([statuses.size - 1, 'created_at'], 0));
-  const newest = new Date(statuses.getIn([0, 'created_at'], 0));
-  const averageGap = (newest - oldest) / (1000 * (statuses.size + 1)); // Average gap between posts on first page in seconds
+const getHomeFeedSpeed = createSelector(
+  [
+    (state) => state.getIn(['timelines', 'home', 'items'], ImmutableList()),
+    (state) =>
+      state.getIn(['timelines', 'home', 'pendingItems'], ImmutableList()),
+    (state) => state.get('statuses'),
+  ],
+  (statusIds, pendingStatusIds, statusMap) => {
+    const recentStatusIds =
+      pendingStatusIds.size > 0 ? pendingStatusIds : statusIds;
+    const statuses = recentStatusIds
+      .filter((id) => id !== null)
+      .map((id) => statusMap.get(id))
+      .filter((status) => status?.get('account') !== me)
+      .take(20);
+    const oldest = new Date(
+      statuses.getIn([statuses.size - 1, 'created_at'], 0),
+    );
+    const newest = new Date(statuses.getIn([0, 'created_at'], 0));
+    const averageGap = (newest - oldest) / (1000 * (statuses.size + 1)); // Average gap between posts on first page in seconds
 
-  return {
-    gap: averageGap,
-    newest,
-  };
-});
-
-const homeTooSlow = createSelector([
-  state => state.getIn(['timelines', 'home', 'isLoading']),
-  state => state.getIn(['timelines', 'home', 'isPartial']),
-  getHomeFeedSpeed,
-], (isLoading, isPartial, speed) =>
-  !isLoading && !isPartial // Only if the home feed has finished loading
-  && (speed.gap > (30 * 60) // If the average gap between posts is more than 20 minutes
-  || (Date.now() - speed.newest) > (1000 * 3600)) // If the most recent post is from over an hour ago
+    return {
+      gap: averageGap,
+      newest,
+    };
+  },
 );
 
-const mapStateToProps = state => ({
+const homeTooSlow = createSelector(
+  [
+    (state) => state.getIn(['timelines', 'home', 'isLoading']),
+    (state) => state.getIn(['timelines', 'home', 'isPartial']),
+    getHomeFeedSpeed,
+  ],
+  (isLoading, isPartial, speed) =>
+    !isLoading &&
+    !isPartial && // Only if the home feed has finished loading
+    (speed.gap > 30 * 60 || // If the average gap between posts is more than 20 minutes
+      Date.now() - speed.newest > 1000 * 3600), // If the most recent post is from over an hour ago
+);
+
+const mapStateToProps = (state) => ({
   hasUnread: state.getIn(['timelines', 'home', 'unread']) > 0,
   isPartial: state.getIn(['timelines', 'home', 'isPartial']),
   hasAnnouncements: !state.getIn(['announcements', 'items']).isEmpty(),
-  unreadAnnouncements: state.getIn(['announcements', 'items']).count(item => !item.get('read')),
+  unreadAnnouncements: state
+    .getIn(['announcements', 'items'])
+    .count((item) => !item.get('read')),
   showAnnouncements: state.getIn(['announcements', 'show']),
   tooSlow: homeTooSlow(state),
 });
 
 class HomeTimeline extends PureComponent {
-
   static contextTypes = {
     identity: PropTypes.object,
   };
@@ -106,28 +130,28 @@ class HomeTimeline extends PureComponent {
     this.column.scrollTop();
   };
 
-  setRef = c => {
+  setRef = (c) => {
     this.column = c;
   };
 
-  handleLoadMore = maxId => {
+  handleLoadMore = (maxId) => {
     this.props.dispatch(expandHomeTimeline({ maxId }));
   };
 
-  componentDidMount () {
+  componentDidMount() {
     setTimeout(() => this.props.dispatch(fetchAnnouncements()), 700);
     this._checkIfReloadNeeded(false, this.props.isPartial);
   }
 
-  componentDidUpdate (prevProps) {
+  componentDidUpdate(prevProps) {
     this._checkIfReloadNeeded(prevProps.isPartial, this.props.isPartial);
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     this._stopPolling();
   }
 
-  _checkIfReloadNeeded (wasPartial, isPartial) {
+  _checkIfReloadNeeded(wasPartial, isPartial) {
     const { dispatch } = this.props;
 
     if (wasPartial === isPartial) {
@@ -141,7 +165,7 @@ class HomeTimeline extends PureComponent {
     }
   }
 
-  _stopPolling () {
+  _stopPolling() {
     if (this.polling) {
       clearInterval(this.polling);
       this.polling = null;
@@ -153,8 +177,17 @@ class HomeTimeline extends PureComponent {
     this.props.dispatch(toggleShowAnnouncements());
   };
 
-  render () {
-    const { intl, hasUnread, columnId, multiColumn, tooSlow, hasAnnouncements, unreadAnnouncements, showAnnouncements } = this.props;
+  render() {
+    const {
+      intl,
+      hasUnread,
+      columnId,
+      multiColumn,
+      tooSlow,
+      hasAnnouncements,
+      unreadAnnouncements,
+      showAnnouncements,
+    } = this.props;
     const pinned = !!columnId;
     const { signedIn } = this.context.identity;
     const banners = [];
@@ -165,9 +198,19 @@ class HomeTimeline extends PureComponent {
       announcementsButton = (
         <button
           type='button'
-          className={classNames('column-header__button', { 'active': showAnnouncements })}
-          title={intl.formatMessage(showAnnouncements ? messages.hide_announcements : messages.show_announcements)}
-          aria-label={intl.formatMessage(showAnnouncements ? messages.hide_announcements : messages.show_announcements)}
+          className={classNames('column-header__button', {
+            active: showAnnouncements,
+          })}
+          title={intl.formatMessage(
+            showAnnouncements
+              ? messages.hide_announcements
+              : messages.show_announcements,
+          )}
+          aria-label={intl.formatMessage(
+            showAnnouncements
+              ? messages.hide_announcements
+              : messages.show_announcements,
+          )}
           onClick={this.handleToggleAnnouncementsClick}
         >
           <IconWithBadge id='bullhorn' count={unreadAnnouncements} />
@@ -184,7 +227,11 @@ class HomeTimeline extends PureComponent {
     }
 
     return (
-      <Column bindToDocument={!multiColumn} ref={this.setRef} label={intl.formatMessage(messages.title)}>
+      <Column
+        bindToDocument={!multiColumn}
+        ref={this.setRef}
+        label={intl.formatMessage(messages.title)}
+      >
         <ColumnHeader
           icon='home'
           active={hasUnread}
@@ -195,7 +242,9 @@ class HomeTimeline extends PureComponent {
           pinned={pinned}
           multiColumn={multiColumn}
           extraButton={announcementsButton}
-          appendContent={hasAnnouncements && showAnnouncements && <AnnouncementsContainer />}
+          appendContent={
+            hasAnnouncements && showAnnouncements && <AnnouncementsContainer />
+          }
         >
           <ColumnSettings />
         </ColumnHeader>
@@ -208,10 +257,17 @@ class HomeTimeline extends PureComponent {
             scrollKey={`home_timeline-${columnId}`}
             onLoadMore={this.handleLoadMore}
             timelineId='home'
-            emptyMessage={<FormattedMessage id='empty_column.home' defaultMessage='Your home timeline is empty! Follow more people to fill it up.' />}
+            emptyMessage={
+              <FormattedMessage
+                id='empty_column.home'
+                defaultMessage='Your home timeline is empty! Follow more people to fill it up.'
+              />
+            }
             bindToDocument={!multiColumn}
           />
-        ) : <NotSignedInIndicator />}
+        ) : (
+          <NotSignedInIndicator />
+        )}
 
         <Helmet>
           <title>{intl.formatMessage(messages.title)}</title>
@@ -220,7 +276,6 @@ class HomeTimeline extends PureComponent {
       </Column>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(injectIntl(HomeTimeline));

--- a/app/javascript/mastodon/features/interaction_modal/index.jsx
+++ b/app/javascript/mastodon/features/interaction_modal/index.jsx
@@ -12,37 +12,44 @@ import { throttle, escapeRegExp } from 'lodash';
 import { openModal, closeModal } from 'mastodon/actions/modal';
 import api from 'mastodon/api';
 import Button from 'mastodon/components/button';
-import { Icon }  from 'mastodon/components/icon';
+import { Icon } from 'mastodon/components/icon';
 import { registrationsOpen, sso_redirect } from 'mastodon/initial_state';
 
 const messages = defineMessages({
-  loginPrompt: { id: 'interaction_modal.login.prompt', defaultMessage: 'Domain of your home server, e.g. mastodon.social' },
+  loginPrompt: {
+    id: 'interaction_modal.login.prompt',
+    defaultMessage: 'Domain of your home server, e.g. mastodon.social',
+  },
 });
 
 const mapStateToProps = (state, { accountId }) => ({
   displayNameHtml: state.getIn(['accounts', accountId, 'display_name_html']),
-  signupUrl: state.getIn(['server', 'server', 'registrations', 'url'], null) || '/auth/sign_up',
+  signupUrl:
+    state.getIn(['server', 'server', 'registrations', 'url'], null) ||
+    '/auth/sign_up',
 });
 
 const mapDispatchToProps = (dispatch) => ({
   onSignupClick() {
-    dispatch(closeModal({
+    dispatch(
+      closeModal({
         modalType: undefined,
         ignoreFocus: false,
-      }));
+      }),
+    );
     dispatch(openModal({ modalType: 'CLOSED_REGISTRATIONS' }));
   },
 });
 
 const PERSISTENCE_KEY = 'mastodon_home';
 
-const isValidDomain = value => {
+const isValidDomain = (value) => {
   const url = new URL('https:///path');
   url.hostname = value;
   return url.hostname === value;
 };
 
-const valueToDomain = value => {
+const valueToDomain = (value) => {
   // If the user starts typing an URL
   if (/^https?:\/\//.test(value)) {
     try {
@@ -57,7 +64,7 @@ const valueToDomain = value => {
     } catch {
       return undefined;
     }
-  // If the user writes their full handle including username
+    // If the user writes their full handle including username
   } else if (value.includes('@')) {
     if (value.replace(/^@/, '').split('@').length > 2) {
       return undefined;
@@ -79,14 +86,13 @@ const addInputToOptions = (value, options) => {
 };
 
 class LoginForm extends React.PureComponent {
-
   static propTypes = {
     resourceUrl: PropTypes.string,
     intl: PropTypes.object.isRequired,
   };
 
   state = {
-    value: localStorage ? (localStorage.getItem(PERSISTENCE_KEY) || '') : '',
+    value: localStorage ? localStorage.getItem(PERSISTENCE_KEY) || '' : '',
     expanded: false,
     selectedOption: -1,
     isLoading: false,
@@ -96,7 +102,7 @@ class LoginForm extends React.PureComponent {
     networkOptions: [],
   };
 
-  setRef = c => {
+  setRef = (c) => {
     this.input = c;
   };
 
@@ -127,20 +133,31 @@ class LoginForm extends React.PureComponent {
     try {
       new URL(url);
       return true;
-    } catch(_) {
+    } catch (_) {
       return false;
     }
   };
 
   handleChange = ({ target }) => {
     const error = !this.isValueValid(target.value);
-    this.setState(state => ({ error, value: target.value, isLoading: true, options: addInputToOptions(target.value, state.networkOptions) }), () => this._loadOptions());
+    this.setState(
+      (state) => ({
+        error,
+        value: target.value,
+        isLoading: true,
+        options: addInputToOptions(target.value, state.networkOptions),
+      }),
+      () => this._loadOptions(),
+    );
   };
 
   handleMessage = (event) => {
     const { resourceUrl } = this.props;
 
-    if (event.origin !== window.origin || event.source !== this.iframeRef.contentWindow) {
+    if (
+      event.origin !== window.origin ||
+      event.source !== this.iframeRef.contentWindow
+    ) {
       return;
     }
 
@@ -149,7 +166,12 @@ class LoginForm extends React.PureComponent {
     } else if (event.data?.type === 'fetchInteractionURL-success') {
       if (/^https?:\/\//.test(event.data.template)) {
         try {
-          const url = new URL(event.data.template.replace('{uri}', encodeURIComponent(resourceUrl)));
+          const url = new URL(
+            event.data.template.replace(
+              '{uri}',
+              encodeURIComponent(resourceUrl),
+            ),
+          );
 
           if (localStorage) {
             localStorage.setItem(PERSISTENCE_KEY, event.data.uri_or_domain);
@@ -166,11 +188,11 @@ class LoginForm extends React.PureComponent {
     }
   };
 
-  componentDidMount () {
+  componentDidMount() {
     window.addEventListener('message', this.handleMessage);
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     window.removeEventListener('message', this.handleMessage);
   }
 
@@ -179,15 +201,18 @@ class LoginForm extends React.PureComponent {
 
     this.setState({ isSubmitting: true });
 
-    this.iframeRef.contentWindow.postMessage({
-      type: 'fetchInteractionURL',
-      uri_or_domain: value.trim(),
-    }, window.origin);
+    this.iframeRef.contentWindow.postMessage(
+      {
+        type: 'fetchInteractionURL',
+        uri_or_domain: value.trim(),
+      },
+      window.origin,
+    );
   };
 
   setIFrameRef = (iframe) => {
     this.iframeRef = iframe;
-  }
+  };
 
   handleFocus = () => {
     this.setState({ expanded: true });
@@ -200,83 +225,111 @@ class LoginForm extends React.PureComponent {
   handleKeyDown = (e) => {
     const { options, selectedOption } = this.state;
 
-    switch(e.key) {
-    case 'ArrowDown':
-      e.preventDefault();
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
 
-      if (options.length > 0) {
-        this.setState({ selectedOption: Math.min(selectedOption + 1, options.length - 1) });
-      }
+        if (options.length > 0) {
+          this.setState({
+            selectedOption: Math.min(selectedOption + 1, options.length - 1),
+          });
+        }
 
-      break;
-    case 'ArrowUp':
-      e.preventDefault();
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
 
-      if (options.length > 0) {
-        this.setState({ selectedOption: Math.max(selectedOption - 1, -1) });
-      }
+        if (options.length > 0) {
+          this.setState({ selectedOption: Math.max(selectedOption - 1, -1) });
+        }
 
-      break;
-    case 'Enter':
-      e.preventDefault();
+        break;
+      case 'Enter':
+        e.preventDefault();
 
-      if (selectedOption === -1) {
-        this.handleSubmit();
-      } else if (options.length > 0) {
-        this.setState({ value: options[selectedOption], error: false }, () => this.handleSubmit());
-      }
+        if (selectedOption === -1) {
+          this.handleSubmit();
+        } else if (options.length > 0) {
+          this.setState({ value: options[selectedOption], error: false }, () =>
+            this.handleSubmit(),
+          );
+        }
 
-      break;
+        break;
     }
   };
 
-  handleOptionClick = e => {
-    const index  = Number(e.currentTarget.getAttribute('data-index'));
+  handleOptionClick = (e) => {
+    const index = Number(e.currentTarget.getAttribute('data-index'));
     const option = this.state.options[index];
 
     e.preventDefault();
-    this.setState({ selectedOption: index, value: option, error: false }, () => this.handleSubmit());
+    this.setState({ selectedOption: index, value: option, error: false }, () =>
+      this.handleSubmit(),
+    );
   };
 
-  _loadOptions = throttle(() => {
-    const { value } = this.state;
+  _loadOptions = throttle(
+    () => {
+      const { value } = this.state;
 
-    const domain = valueToDomain(value.trim());
+      const domain = valueToDomain(value.trim());
 
-    if (typeof domain === 'undefined') {
-      this.setState({ options: [], networkOptions: [], isLoading: false, error: true });
-      return;
-    }
-
-    if (domain.length === 0) {
-      this.setState({ options: [], networkOptions: [], isLoading: false });
-      return;
-    }
-
-    api().get('/api/v1/peers/search', { params: { q: domain } }).then(({ data }) => {
-      if (!data) {
-        data = [];
+      if (typeof domain === 'undefined') {
+        this.setState({
+          options: [],
+          networkOptions: [],
+          isLoading: false,
+          error: true,
+        });
+        return;
       }
 
-      this.setState((state) => ({ networkOptions: data, options: addInputToOptions(state.value, data), isLoading: false }));
-    }).catch(() => {
-      this.setState({ isLoading: false });
-    });
-  }, 200, { leading: true, trailing: true });
+      if (domain.length === 0) {
+        this.setState({ options: [], networkOptions: [], isLoading: false });
+        return;
+      }
 
-  render () {
+      api()
+        .get('/api/v1/peers/search', { params: { q: domain } })
+        .then(({ data }) => {
+          if (!data) {
+            data = [];
+          }
+
+          this.setState((state) => ({
+            networkOptions: data,
+            options: addInputToOptions(state.value, data),
+            isLoading: false,
+          }));
+        })
+        .catch(() => {
+          this.setState({ isLoading: false });
+        });
+    },
+    200,
+    { leading: true, trailing: true },
+  );
+
+  render() {
     const { intl } = this.props;
-    const { value, expanded, options, selectedOption, error, isSubmitting } = this.state;
+    const { value, expanded, options, selectedOption, error, isSubmitting } =
+      this.state;
     const domain = (valueToDomain(value) || '').trim();
     const domainRegExp = new RegExp(`(${escapeRegExp(domain)})`, 'gi');
     const hasPopOut = domain.length > 0 && options.length > 0;
 
     return (
-      <div className={classNames('interaction-modal__login', { focused: expanded, expanded: hasPopOut, invalid: error })}>
-
+      <div
+        className={classNames('interaction-modal__login', {
+          focused: expanded,
+          expanded: hasPopOut,
+          invalid: error,
+        })}
+      >
         <iframe
           ref={this.setIFrameRef}
-          style={{display: 'none'}}
+          style={{ display: 'none' }}
           src='/remote_interaction_helper'
           sandbox='allow-scripts allow-same-origin'
           title='remote interaction helper'
@@ -299,25 +352,35 @@ class LoginForm extends React.PureComponent {
             spellcheck='false'
           />
 
-          <Button onClick={this.handleSubmit} disabled={isSubmitting || error}><FormattedMessage id='interaction_modal.login.action' defaultMessage='Take me home' /></Button>
+          <Button onClick={this.handleSubmit} disabled={isSubmitting || error}>
+            <FormattedMessage
+              id='interaction_modal.login.action'
+              defaultMessage='Take me home'
+            />
+          </Button>
         </div>
 
         {hasPopOut && (
           <div className='search__popout'>
             <div className='search__popout__menu'>
               {options.map((option, i) => (
-                <button key={option} onMouseDown={this.handleOptionClick} data-index={i} className={classNames('search__popout__menu__item', { selected: selectedOption === i })}>
-                  {option.split(domainRegExp).map((part, i) => (
-                    part.toLowerCase() === domain.toLowerCase() ? (
-                      <mark key={i}>
-                        {part}
-                      </mark>
-                    ) : (
-                      <span key={i}>
-                        {part}
-                      </span>
-                    )
-                  ))}
+                <button
+                  key={option}
+                  onMouseDown={this.handleOptionClick}
+                  data-index={i}
+                  className={classNames('search__popout__menu__item', {
+                    selected: selectedOption === i,
+                  })}
+                >
+                  {option
+                    .split(domainRegExp)
+                    .map((part, i) =>
+                      part.toLowerCase() === domain.toLowerCase() ? (
+                        <mark key={i}>{part}</mark>
+                      ) : (
+                        <span key={i}>{part}</span>
+                      ),
+                    )}
                 </button>
               ))}
             </div>
@@ -326,13 +389,11 @@ class LoginForm extends React.PureComponent {
       </div>
     );
   }
-
 }
 
 const IntlLoginForm = injectIntl(LoginForm);
 
 class InteractionModal extends React.PureComponent {
-
   static propTypes = {
     displayNameHtml: PropTypes.string,
     url: PropTypes.string,
@@ -345,34 +406,79 @@ class InteractionModal extends React.PureComponent {
     this.props.onSignupClick();
   };
 
-  render () {
+  render() {
     const { url, type, displayNameHtml, signupUrl } = this.props;
 
     const name = <bdi dangerouslySetInnerHTML={{ __html: displayNameHtml }} />;
 
     let title, actionDescription, icon;
 
-    switch(type) {
-    case 'reply':
-      icon = <Icon id='reply' />;
-      title = <FormattedMessage id='interaction_modal.title.reply' defaultMessage="Reply to {name}'s post" values={{ name }} />;
-      actionDescription = <FormattedMessage id='interaction_modal.description.reply' defaultMessage='With an account on Mastodon, you can respond to this post.' />;
-      break;
-    case 'reblog':
-      icon = <Icon id='retweet' />;
-      title = <FormattedMessage id='interaction_modal.title.reblog' defaultMessage="Boost {name}'s post" values={{ name }} />;
-      actionDescription = <FormattedMessage id='interaction_modal.description.reblog' defaultMessage='With an account on Mastodon, you can boost this post to share it with your own followers.' />;
-      break;
-    case 'favourite':
-      icon = <Icon id='star' />;
-      title = <FormattedMessage id='interaction_modal.title.favourite' defaultMessage="Favorite {name}'s post" values={{ name }} />;
-      actionDescription = <FormattedMessage id='interaction_modal.description.favourite' defaultMessage='With an account on Mastodon, you can favorite this post to let the author know you appreciate it and save it for later.' />;
-      break;
-    case 'follow':
-      icon = <Icon id='user-plus' />;
-      title = <FormattedMessage id='interaction_modal.title.follow' defaultMessage='Follow {name}' values={{ name }} />;
-      actionDescription = <FormattedMessage id='interaction_modal.description.follow' defaultMessage='With an account on Mastodon, you can follow {name} to receive their posts in your home feed.' values={{ name }} />;
-      break;
+    switch (type) {
+      case 'reply':
+        icon = <Icon id='reply' />;
+        title = (
+          <FormattedMessage
+            id='interaction_modal.title.reply'
+            defaultMessage="Reply to {name}'s post"
+            values={{ name }}
+          />
+        );
+        actionDescription = (
+          <FormattedMessage
+            id='interaction_modal.description.reply'
+            defaultMessage='With an account on Mastodon, you can respond to this post.'
+          />
+        );
+        break;
+      case 'reblog':
+        icon = <Icon id='retweet' />;
+        title = (
+          <FormattedMessage
+            id='interaction_modal.title.reblog'
+            defaultMessage="Boost {name}'s post"
+            values={{ name }}
+          />
+        );
+        actionDescription = (
+          <FormattedMessage
+            id='interaction_modal.description.reblog'
+            defaultMessage='With an account on Mastodon, you can boost this post to share it with your own followers.'
+          />
+        );
+        break;
+      case 'favourite':
+        icon = <Icon id='star' />;
+        title = (
+          <FormattedMessage
+            id='interaction_modal.title.favourite'
+            defaultMessage="Favorite {name}'s post"
+            values={{ name }}
+          />
+        );
+        actionDescription = (
+          <FormattedMessage
+            id='interaction_modal.description.favourite'
+            defaultMessage='With an account on Mastodon, you can favorite this post to let the author know you appreciate it and save it for later.'
+          />
+        );
+        break;
+      case 'follow':
+        icon = <Icon id='user-plus' />;
+        title = (
+          <FormattedMessage
+            id='interaction_modal.title.follow'
+            defaultMessage='Follow {name}'
+            values={{ name }}
+          />
+        );
+        actionDescription = (
+          <FormattedMessage
+            id='interaction_modal.description.follow'
+            defaultMessage='With an account on Mastodon, you can follow {name} to receive their posts in your home feed.'
+            values={{ name }}
+          />
+        );
+        break;
     }
 
     let signupButton;
@@ -380,19 +486,28 @@ class InteractionModal extends React.PureComponent {
     if (sso_redirect) {
       signupButton = (
         <a href={sso_redirect} data-method='post' className='link-button'>
-          <FormattedMessage id='sign_in_banner.create_account' defaultMessage='Create account' />
+          <FormattedMessage
+            id='sign_in_banner.create_account'
+            defaultMessage='Create account'
+          />
         </a>
       );
     } else if (registrationsOpen) {
       signupButton = (
         <a href={signupUrl} className='link-button'>
-          <FormattedMessage id='sign_in_banner.create_account' defaultMessage='Create account' />
+          <FormattedMessage
+            id='sign_in_banner.create_account'
+            defaultMessage='Create account'
+          />
         </a>
       );
     } else {
       signupButton = (
         <button className='link-button' onClick={this.handleSignupClick}>
-          <FormattedMessage id='sign_in_banner.create_account' defaultMessage='Create account' />
+          <FormattedMessage
+            id='sign_in_banner.create_account'
+            defaultMessage='Create account'
+          />
         </button>
       );
     }
@@ -400,18 +515,38 @@ class InteractionModal extends React.PureComponent {
     return (
       <div className='modal-root__modal interaction-modal'>
         <div className='interaction-modal__lead'>
-          <h3><span className='interaction-modal__icon'>{icon}</span> {title}</h3>
-          <p>{actionDescription} <strong><FormattedMessage id='interaction_modal.sign_in' defaultMessage='You are not logged in to this server. Where is your account hosted?' /></strong></p>
+          <h3>
+            <span className='interaction-modal__icon'>{icon}</span> {title}
+          </h3>
+          <p>
+            {actionDescription}{' '}
+            <strong>
+              <FormattedMessage
+                id='interaction_modal.sign_in'
+                defaultMessage='You are not logged in to this server. Where is your account hosted?'
+              />
+            </strong>
+          </p>
         </div>
 
         <IntlLoginForm resourceUrl={url} />
 
-        <p className='hint'><FormattedMessage id='interaction_modal.sign_in_hint' defaultMessage="Tip: That's the website where you signed up. If you don't remember, look for the welcome e-mail in your inbox. You can also enter your full username! (e.g. @Mastodon@mastodon.social)" /></p>
-        <p><FormattedMessage id='interaction_modal.no_account_yet' defaultMessage='Not on Mastodon?' /> {signupButton}</p>
+        <p className='hint'>
+          <FormattedMessage
+            id='interaction_modal.sign_in_hint'
+            defaultMessage="Tip: That's the website where you signed up. If you don't remember, look for the welcome e-mail in your inbox. You can also enter your full username! (e.g. @Mastodon@mastodon.social)"
+          />
+        </p>
+        <p>
+          <FormattedMessage
+            id='interaction_modal.no_account_yet'
+            defaultMessage='Not on Mastodon?'
+          />{' '}
+          {signupButton}
+        </p>
       </div>
     );
   }
-
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(InteractionModal);

--- a/app/javascript/mastodon/features/keyboard_shortcuts/index.jsx
+++ b/app/javascript/mastodon/features/keyboard_shortcuts/index.jsx
@@ -10,17 +10,19 @@ import Column from 'mastodon/components/column';
 import ColumnHeader from 'mastodon/components/column_header';
 
 const messages = defineMessages({
-  heading: { id: 'keyboard_shortcuts.heading', defaultMessage: 'Keyboard Shortcuts' },
+  heading: {
+    id: 'keyboard_shortcuts.heading',
+    defaultMessage: 'Keyboard Shortcuts',
+  },
 });
 
 class KeyboardShortcuts extends ImmutablePureComponent {
-
   static propTypes = {
     intl: PropTypes.object.isRequired,
     multiColumn: PropTypes.bool,
   };
 
-  render () {
+  render() {
     const { intl, multiColumn } = this.props;
 
     return (
@@ -35,134 +37,361 @@ class KeyboardShortcuts extends ImmutablePureComponent {
           <table>
             <thead>
               <tr>
-                <th><FormattedMessage id='keyboard_shortcuts.hotkey' defaultMessage='Hotkey' /></th>
-                <th><FormattedMessage id='keyboard_shortcuts.description' defaultMessage='Description' /></th>
+                <th>
+                  <FormattedMessage
+                    id='keyboard_shortcuts.hotkey'
+                    defaultMessage='Hotkey'
+                  />
+                </th>
+                <th>
+                  <FormattedMessage
+                    id='keyboard_shortcuts.description'
+                    defaultMessage='Description'
+                  />
+                </th>
               </tr>
             </thead>
             <tbody>
               <tr>
-                <td><kbd>r</kbd></td>
-                <td><FormattedMessage id='keyboard_shortcuts.reply' defaultMessage='to reply' /></td>
+                <td>
+                  <kbd>r</kbd>
+                </td>
+                <td>
+                  <FormattedMessage
+                    id='keyboard_shortcuts.reply'
+                    defaultMessage='to reply'
+                  />
+                </td>
               </tr>
               <tr>
-                <td><kbd>m</kbd></td>
-                <td><FormattedMessage id='keyboard_shortcuts.mention' defaultMessage='to mention author' /></td>
+                <td>
+                  <kbd>m</kbd>
+                </td>
+                <td>
+                  <FormattedMessage
+                    id='keyboard_shortcuts.mention'
+                    defaultMessage='to mention author'
+                  />
+                </td>
               </tr>
               <tr>
-                <td><kbd>p</kbd></td>
-                <td><FormattedMessage id='keyboard_shortcuts.profile' defaultMessage="to open author's profile" /></td>
+                <td>
+                  <kbd>p</kbd>
+                </td>
+                <td>
+                  <FormattedMessage
+                    id='keyboard_shortcuts.profile'
+                    defaultMessage="to open author's profile"
+                  />
+                </td>
               </tr>
               <tr>
-                <td><kbd>f</kbd></td>
-                <td><FormattedMessage id='keyboard_shortcuts.favourite' defaultMessage='to favorite' /></td>
+                <td>
+                  <kbd>f</kbd>
+                </td>
+                <td>
+                  <FormattedMessage
+                    id='keyboard_shortcuts.favourite'
+                    defaultMessage='to favorite'
+                  />
+                </td>
               </tr>
               <tr>
-                <td><kbd>b</kbd></td>
-                <td><FormattedMessage id='keyboard_shortcuts.boost' defaultMessage='to boost' /></td>
+                <td>
+                  <kbd>b</kbd>
+                </td>
+                <td>
+                  <FormattedMessage
+                    id='keyboard_shortcuts.boost'
+                    defaultMessage='to boost'
+                  />
+                </td>
               </tr>
               <tr>
-                <td><kbd>enter</kbd>, <kbd>o</kbd></td>
-                <td><FormattedMessage id='keyboard_shortcuts.enter' defaultMessage='to open status' /></td>
+                <td>
+                  <kbd>enter</kbd>, <kbd>o</kbd>
+                </td>
+                <td>
+                  <FormattedMessage
+                    id='keyboard_shortcuts.enter'
+                    defaultMessage='to open status'
+                  />
+                </td>
               </tr>
               <tr>
-                <td><kbd>e</kbd></td>
-                <td><FormattedMessage id='keyboard_shortcuts.open_media' defaultMessage='to open media' /></td>
+                <td>
+                  <kbd>e</kbd>
+                </td>
+                <td>
+                  <FormattedMessage
+                    id='keyboard_shortcuts.open_media'
+                    defaultMessage='to open media'
+                  />
+                </td>
               </tr>
               <tr>
-                <td><kbd>x</kbd></td>
-                <td><FormattedMessage id='keyboard_shortcuts.toggle_hidden' defaultMessage='to show/hide text behind CW' /></td>
+                <td>
+                  <kbd>x</kbd>
+                </td>
+                <td>
+                  <FormattedMessage
+                    id='keyboard_shortcuts.toggle_hidden'
+                    defaultMessage='to show/hide text behind CW'
+                  />
+                </td>
               </tr>
               <tr>
-                <td><kbd>h</kbd></td>
-                <td><FormattedMessage id='keyboard_shortcuts.toggle_sensitivity' defaultMessage='to show/hide media' /></td>
+                <td>
+                  <kbd>h</kbd>
+                </td>
+                <td>
+                  <FormattedMessage
+                    id='keyboard_shortcuts.toggle_sensitivity'
+                    defaultMessage='to show/hide media'
+                  />
+                </td>
               </tr>
               <tr>
-                <td><kbd>up</kbd>, <kbd>k</kbd></td>
-                <td><FormattedMessage id='keyboard_shortcuts.up' defaultMessage='to move up in the list' /></td>
+                <td>
+                  <kbd>up</kbd>, <kbd>k</kbd>
+                </td>
+                <td>
+                  <FormattedMessage
+                    id='keyboard_shortcuts.up'
+                    defaultMessage='to move up in the list'
+                  />
+                </td>
               </tr>
               <tr>
-                <td><kbd>down</kbd>, <kbd>j</kbd></td>
-                <td><FormattedMessage id='keyboard_shortcuts.down' defaultMessage='to move down in the list' /></td>
+                <td>
+                  <kbd>down</kbd>, <kbd>j</kbd>
+                </td>
+                <td>
+                  <FormattedMessage
+                    id='keyboard_shortcuts.down'
+                    defaultMessage='to move down in the list'
+                  />
+                </td>
               </tr>
               <tr>
-                <td><kbd>1</kbd>-<kbd>9</kbd></td>
-                <td><FormattedMessage id='keyboard_shortcuts.column' defaultMessage='to focus a status in one of the columns' /></td>
+                <td>
+                  <kbd>1</kbd>-<kbd>9</kbd>
+                </td>
+                <td>
+                  <FormattedMessage
+                    id='keyboard_shortcuts.column'
+                    defaultMessage='to focus a status in one of the columns'
+                  />
+                </td>
               </tr>
               <tr>
-                <td><kbd>n</kbd></td>
-                <td><FormattedMessage id='keyboard_shortcuts.compose' defaultMessage='to focus the compose textarea' /></td>
+                <td>
+                  <kbd>n</kbd>
+                </td>
+                <td>
+                  <FormattedMessage
+                    id='keyboard_shortcuts.compose'
+                    defaultMessage='to focus the compose textarea'
+                  />
+                </td>
               </tr>
               <tr>
-                <td><kbd>alt</kbd>+<kbd>n</kbd></td>
-                <td><FormattedMessage id='keyboard_shortcuts.toot' defaultMessage='to start a brand new post' /></td>
+                <td>
+                  <kbd>alt</kbd>+<kbd>n</kbd>
+                </td>
+                <td>
+                  <FormattedMessage
+                    id='keyboard_shortcuts.toot'
+                    defaultMessage='to start a brand new post'
+                  />
+                </td>
               </tr>
               <tr>
-                <td><kbd>alt</kbd>+<kbd>x</kbd></td>
-                <td><FormattedMessage id='keyboard_shortcuts.spoilers' defaultMessage='to show/hide CW field' /></td>
+                <td>
+                  <kbd>alt</kbd>+<kbd>x</kbd>
+                </td>
+                <td>
+                  <FormattedMessage
+                    id='keyboard_shortcuts.spoilers'
+                    defaultMessage='to show/hide CW field'
+                  />
+                </td>
               </tr>
               <tr>
-                <td><kbd>backspace</kbd></td>
-                <td><FormattedMessage id='keyboard_shortcuts.back' defaultMessage='to navigate back' /></td>
+                <td>
+                  <kbd>backspace</kbd>
+                </td>
+                <td>
+                  <FormattedMessage
+                    id='keyboard_shortcuts.back'
+                    defaultMessage='to navigate back'
+                  />
+                </td>
               </tr>
               <tr>
-                <td><kbd>s</kbd></td>
-                <td><FormattedMessage id='keyboard_shortcuts.search' defaultMessage='to focus search' /></td>
+                <td>
+                  <kbd>s</kbd>
+                </td>
+                <td>
+                  <FormattedMessage
+                    id='keyboard_shortcuts.search'
+                    defaultMessage='to focus search'
+                  />
+                </td>
               </tr>
               <tr>
-                <td><kbd>esc</kbd></td>
-                <td><FormattedMessage id='keyboard_shortcuts.unfocus' defaultMessage='to un-focus compose textarea/search' /></td>
+                <td>
+                  <kbd>esc</kbd>
+                </td>
+                <td>
+                  <FormattedMessage
+                    id='keyboard_shortcuts.unfocus'
+                    defaultMessage='to un-focus compose textarea/search'
+                  />
+                </td>
               </tr>
               <tr>
-                <td><kbd>g</kbd>+<kbd>h</kbd></td>
-                <td><FormattedMessage id='keyboard_shortcuts.home' defaultMessage='to open home timeline' /></td>
+                <td>
+                  <kbd>g</kbd>+<kbd>h</kbd>
+                </td>
+                <td>
+                  <FormattedMessage
+                    id='keyboard_shortcuts.home'
+                    defaultMessage='to open home timeline'
+                  />
+                </td>
               </tr>
               <tr>
-                <td><kbd>g</kbd>+<kbd>n</kbd></td>
-                <td><FormattedMessage id='keyboard_shortcuts.notifications' defaultMessage='to open notifications column' /></td>
+                <td>
+                  <kbd>g</kbd>+<kbd>n</kbd>
+                </td>
+                <td>
+                  <FormattedMessage
+                    id='keyboard_shortcuts.notifications'
+                    defaultMessage='to open notifications column'
+                  />
+                </td>
               </tr>
               <tr>
-                <td><kbd>g</kbd>+<kbd>l</kbd></td>
-                <td><FormattedMessage id='keyboard_shortcuts.local' defaultMessage='to open local timeline' /></td>
+                <td>
+                  <kbd>g</kbd>+<kbd>l</kbd>
+                </td>
+                <td>
+                  <FormattedMessage
+                    id='keyboard_shortcuts.local'
+                    defaultMessage='to open local timeline'
+                  />
+                </td>
               </tr>
               <tr>
-                <td><kbd>g</kbd>+<kbd>t</kbd></td>
-                <td><FormattedMessage id='keyboard_shortcuts.federated' defaultMessage='to open federated timeline' /></td>
+                <td>
+                  <kbd>g</kbd>+<kbd>t</kbd>
+                </td>
+                <td>
+                  <FormattedMessage
+                    id='keyboard_shortcuts.federated'
+                    defaultMessage='to open federated timeline'
+                  />
+                </td>
               </tr>
               <tr>
-                <td><kbd>g</kbd>+<kbd>d</kbd></td>
-                <td><FormattedMessage id='keyboard_shortcuts.direct' defaultMessage='to open direct messages column' /></td>
+                <td>
+                  <kbd>g</kbd>+<kbd>d</kbd>
+                </td>
+                <td>
+                  <FormattedMessage
+                    id='keyboard_shortcuts.direct'
+                    defaultMessage='to open direct messages column'
+                  />
+                </td>
               </tr>
               <tr>
-                <td><kbd>g</kbd>+<kbd>s</kbd></td>
-                <td><FormattedMessage id='keyboard_shortcuts.start' defaultMessage='to open "get started" column' /></td>
+                <td>
+                  <kbd>g</kbd>+<kbd>s</kbd>
+                </td>
+                <td>
+                  <FormattedMessage
+                    id='keyboard_shortcuts.start'
+                    defaultMessage='to open "get started" column'
+                  />
+                </td>
               </tr>
               <tr>
-                <td><kbd>g</kbd>+<kbd>f</kbd></td>
-                <td><FormattedMessage id='keyboard_shortcuts.favourites' defaultMessage='to open favorites list' /></td>
+                <td>
+                  <kbd>g</kbd>+<kbd>f</kbd>
+                </td>
+                <td>
+                  <FormattedMessage
+                    id='keyboard_shortcuts.favourites'
+                    defaultMessage='to open favorites list'
+                  />
+                </td>
               </tr>
               <tr>
-                <td><kbd>g</kbd>+<kbd>p</kbd></td>
-                <td><FormattedMessage id='keyboard_shortcuts.pinned' defaultMessage='to open pinned posts list' /></td>
+                <td>
+                  <kbd>g</kbd>+<kbd>p</kbd>
+                </td>
+                <td>
+                  <FormattedMessage
+                    id='keyboard_shortcuts.pinned'
+                    defaultMessage='to open pinned posts list'
+                  />
+                </td>
               </tr>
               <tr>
-                <td><kbd>g</kbd>+<kbd>u</kbd></td>
-                <td><FormattedMessage id='keyboard_shortcuts.my_profile' defaultMessage='to open your profile' /></td>
+                <td>
+                  <kbd>g</kbd>+<kbd>u</kbd>
+                </td>
+                <td>
+                  <FormattedMessage
+                    id='keyboard_shortcuts.my_profile'
+                    defaultMessage='to open your profile'
+                  />
+                </td>
               </tr>
               <tr>
-                <td><kbd>g</kbd>+<kbd>b</kbd></td>
-                <td><FormattedMessage id='keyboard_shortcuts.blocked' defaultMessage='to open blocked users list' /></td>
+                <td>
+                  <kbd>g</kbd>+<kbd>b</kbd>
+                </td>
+                <td>
+                  <FormattedMessage
+                    id='keyboard_shortcuts.blocked'
+                    defaultMessage='to open blocked users list'
+                  />
+                </td>
               </tr>
               <tr>
-                <td><kbd>g</kbd>+<kbd>m</kbd></td>
-                <td><FormattedMessage id='keyboard_shortcuts.muted' defaultMessage='to open muted users list' /></td>
+                <td>
+                  <kbd>g</kbd>+<kbd>m</kbd>
+                </td>
+                <td>
+                  <FormattedMessage
+                    id='keyboard_shortcuts.muted'
+                    defaultMessage='to open muted users list'
+                  />
+                </td>
               </tr>
               <tr>
-                <td><kbd>g</kbd>+<kbd>r</kbd></td>
-                <td><FormattedMessage id='keyboard_shortcuts.requests' defaultMessage='to open follow requests list' /></td>
+                <td>
+                  <kbd>g</kbd>+<kbd>r</kbd>
+                </td>
+                <td>
+                  <FormattedMessage
+                    id='keyboard_shortcuts.requests'
+                    defaultMessage='to open follow requests list'
+                  />
+                </td>
               </tr>
               <tr>
-                <td><kbd>?</kbd></td>
-                <td><FormattedMessage id='keyboard_shortcuts.legend' defaultMessage='to display this legend' /></td>
+                <td>
+                  <kbd>?</kbd>
+                </td>
+                <td>
+                  <FormattedMessage
+                    id='keyboard_shortcuts.legend'
+                    defaultMessage='to display this legend'
+                  />
+                </td>
               </tr>
             </tbody>
           </table>
@@ -174,7 +403,6 @@ class KeyboardShortcuts extends ImmutablePureComponent {
       </Column>
     );
   }
-
 }
 
 export default injectIntl(KeyboardShortcuts);

--- a/app/javascript/mastodon/features/list_adder/components/account.jsx
+++ b/app/javascript/mastodon/features/list_adder/components/account.jsx
@@ -19,25 +19,25 @@ const makeMapStateToProps = () => {
 };
 
 class Account extends ImmutablePureComponent {
-
   static propTypes = {
     account: ImmutablePropTypes.map.isRequired,
   };
 
-  render () {
+  render() {
     const { account } = this.props;
     return (
       <div className='account'>
         <div className='account__wrapper'>
           <div className='account__display-name'>
-            <div className='account__avatar-wrapper'><Avatar account={account} size={36} /></div>
+            <div className='account__avatar-wrapper'>
+              <Avatar account={account} size={36} />
+            </div>
             <DisplayName account={account} />
           </div>
         </div>
       </div>
     );
   }
-
 }
 
 export default connect(makeMapStateToProps)(injectIntl(Account));

--- a/app/javascript/mastodon/features/list_adder/components/list.jsx
+++ b/app/javascript/mastodon/features/list_adder/components/list.jsx
@@ -6,10 +6,10 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 import { connect } from 'react-redux';
 
-import { Icon }  from 'mastodon/components/icon';
+import { Icon } from 'mastodon/components/icon';
 
 import { removeFromListAdder, addToListAdder } from '../../../actions/lists';
-import { IconButton }  from '../../../components/icon_button';
+import { IconButton } from '../../../components/icon_button';
 
 const messages = defineMessages({
   remove: { id: 'lists.account.remove', defaultMessage: 'Remove from list' },
@@ -18,7 +18,10 @@ const messages = defineMessages({
 
 const MapStateToProps = (state, { listId, added }) => ({
   list: state.get('lists').get(listId),
-  added: typeof added === 'undefined' ? state.getIn(['listAdder', 'lists', 'items']).includes(listId) : added,
+  added:
+    typeof added === 'undefined'
+      ? state.getIn(['listAdder', 'lists', 'items']).includes(listId)
+      : added,
 });
 
 const mapDispatchToProps = (dispatch, { listId }) => ({
@@ -27,7 +30,6 @@ const mapDispatchToProps = (dispatch, { listId }) => ({
 });
 
 class List extends ImmutablePureComponent {
-
   static propTypes = {
     list: ImmutablePropTypes.map.isRequired,
     intl: PropTypes.object.isRequired,
@@ -40,15 +42,27 @@ class List extends ImmutablePureComponent {
     added: false,
   };
 
-  render () {
+  render() {
     const { list, intl, onRemove, onAdd, added } = this.props;
 
     let button;
 
     if (added) {
-      button = <IconButton icon='times' title={intl.formatMessage(messages.remove)} onClick={onRemove} />;
+      button = (
+        <IconButton
+          icon='times'
+          title={intl.formatMessage(messages.remove)}
+          onClick={onRemove}
+        />
+      );
     } else {
-      button = <IconButton icon='plus' title={intl.formatMessage(messages.add)} onClick={onAdd} />;
+      button = (
+        <IconButton
+          icon='plus'
+          title={intl.formatMessage(messages.add)}
+          onClick={onAdd}
+        />
+      );
     }
 
     return (
@@ -59,14 +73,11 @@ class List extends ImmutablePureComponent {
             {list.get('title')}
           </div>
 
-          <div className='account__relationship'>
-            {button}
-          </div>
+          <div className='account__relationship'>{button}</div>
         </div>
       </div>
     );
   }
-
 }
 
 export default connect(MapStateToProps, mapDispatchToProps)(injectIntl(List));

--- a/app/javascript/mastodon/features/list_adder/index.jsx
+++ b/app/javascript/mastodon/features/list_adder/index.jsx
@@ -14,25 +14,30 @@ import Account from './components/account';
 import List from './components/list';
 // hack
 
-const getOrderedLists = createSelector([state => state.get('lists')], lists => {
-  if (!lists) {
-    return lists;
-  }
+const getOrderedLists = createSelector(
+  [(state) => state.get('lists')],
+  (lists) => {
+    if (!lists) {
+      return lists;
+    }
 
-  return lists.toList().filter(item => !!item).sort((a, b) => a.get('title').localeCompare(b.get('title')));
+    return lists
+      .toList()
+      .filter((item) => !!item)
+      .sort((a, b) => a.get('title').localeCompare(b.get('title')));
+  },
+);
+
+const mapStateToProps = (state) => ({
+  listIds: getOrderedLists(state).map((list) => list.get('id')),
 });
 
-const mapStateToProps = state => ({
-  listIds: getOrderedLists(state).map(list=>list.get('id')),
-});
-
-const mapDispatchToProps = dispatch => ({
-  onInitialize: accountId => dispatch(setupListAdder(accountId)),
+const mapDispatchToProps = (dispatch) => ({
+  onInitialize: (accountId) => dispatch(setupListAdder(accountId)),
   onReset: () => dispatch(resetListAdder()),
 });
 
 class ListAdder extends ImmutablePureComponent {
-
   static propTypes = {
     accountId: PropTypes.string.isRequired,
     onClose: PropTypes.func.isRequired,
@@ -42,17 +47,17 @@ class ListAdder extends ImmutablePureComponent {
     listIds: ImmutablePropTypes.list.isRequired,
   };
 
-  componentDidMount () {
+  componentDidMount() {
     const { onInitialize, accountId } = this.props;
     onInitialize(accountId);
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     const { onReset } = this.props;
     onReset();
   }
 
-  render () {
+  render() {
     const { accountId, listIds } = this.props;
 
     return (
@@ -63,14 +68,17 @@ class ListAdder extends ImmutablePureComponent {
 
         <NewListForm />
 
-
         <div className='list-adder__lists'>
-          {listIds.map(ListId => <List key={ListId} listId={ListId} />)}
+          {listIds.map((ListId) => (
+            <List key={ListId} listId={ListId} />
+          ))}
         </div>
       </div>
     );
   }
-
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(injectIntl(ListAdder));
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(injectIntl(ListAdder));

--- a/app/javascript/mastodon/features/list_editor/components/account.jsx
+++ b/app/javascript/mastodon/features/list_editor/components/account.jsx
@@ -22,7 +22,10 @@ const makeMapStateToProps = () => {
 
   const mapStateToProps = (state, { accountId, added }) => ({
     account: getAccount(state, accountId),
-    added: typeof added === 'undefined' ? state.getIn(['listEditor', 'accounts', 'items']).includes(accountId) : added,
+    added:
+      typeof added === 'undefined'
+        ? state.getIn(['listEditor', 'accounts', 'items']).includes(accountId)
+        : added,
   });
 
   return mapStateToProps;
@@ -34,7 +37,6 @@ const mapDispatchToProps = (dispatch, { accountId }) => ({
 });
 
 class Account extends ImmutablePureComponent {
-
   static propTypes = {
     account: ImmutablePropTypes.map.isRequired,
     intl: PropTypes.object.isRequired,
@@ -47,33 +49,47 @@ class Account extends ImmutablePureComponent {
     added: false,
   };
 
-  render () {
+  render() {
     const { account, intl, onRemove, onAdd, added } = this.props;
 
     let button;
 
     if (added) {
-      button = <IconButton icon='times' title={intl.formatMessage(messages.remove)} onClick={onRemove} />;
+      button = (
+        <IconButton
+          icon='times'
+          title={intl.formatMessage(messages.remove)}
+          onClick={onRemove}
+        />
+      );
     } else {
-      button = <IconButton icon='plus' title={intl.formatMessage(messages.add)} onClick={onAdd} />;
+      button = (
+        <IconButton
+          icon='plus'
+          title={intl.formatMessage(messages.add)}
+          onClick={onAdd}
+        />
+      );
     }
 
     return (
       <div className='account'>
         <div className='account__wrapper'>
           <div className='account__display-name'>
-            <div className='account__avatar-wrapper'><Avatar account={account} size={36} /></div>
+            <div className='account__avatar-wrapper'>
+              <Avatar account={account} size={36} />
+            </div>
             <DisplayName account={account} />
           </div>
 
-          <div className='account__relationship'>
-            {button}
-          </div>
+          <div className='account__relationship'>{button}</div>
         </div>
       </div>
     );
   }
-
 }
 
-export default connect(makeMapStateToProps, mapDispatchToProps)(injectIntl(Account));
+export default connect(
+  makeMapStateToProps,
+  mapDispatchToProps,
+)(injectIntl(Account));

--- a/app/javascript/mastodon/features/list_editor/components/edit_list_form.jsx
+++ b/app/javascript/mastodon/features/list_editor/components/edit_list_form.jsx
@@ -5,25 +5,29 @@ import { defineMessages, injectIntl } from 'react-intl';
 
 import { connect } from 'react-redux';
 
-import { changeListEditorTitle, submitListEditor } from '../../../actions/lists';
+import {
+  changeListEditorTitle,
+  submitListEditor,
+} from '../../../actions/lists';
 import { IconButton } from '../../../components/icon_button';
 
 const messages = defineMessages({
   title: { id: 'lists.edit.submit', defaultMessage: 'Change title' },
 });
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   value: state.getIn(['listEditor', 'title']),
-  disabled: !state.getIn(['listEditor', 'isChanged']) || !state.getIn(['listEditor', 'title']),
+  disabled:
+    !state.getIn(['listEditor', 'isChanged']) ||
+    !state.getIn(['listEditor', 'title']),
 });
 
-const mapDispatchToProps = dispatch => ({
-  onChange: value => dispatch(changeListEditorTitle(value)),
+const mapDispatchToProps = (dispatch) => ({
+  onChange: (value) => dispatch(changeListEditorTitle(value)),
   onSubmit: () => dispatch(submitListEditor(false)),
 });
 
 class ListForm extends PureComponent {
-
   static propTypes = {
     value: PropTypes.string.isRequired,
     disabled: PropTypes.bool,
@@ -32,11 +36,11 @@ class ListForm extends PureComponent {
     onSubmit: PropTypes.func.isRequired,
   };
 
-  handleChange = e => {
+  handleChange = (e) => {
     this.props.onChange(e.target.value);
   };
 
-  handleSubmit = e => {
+  handleSubmit = (e) => {
     e.preventDefault();
     this.props.onSubmit();
   };
@@ -45,7 +49,7 @@ class ListForm extends PureComponent {
     this.props.onSubmit();
   };
 
-  render () {
+  render() {
     const { value, disabled, intl } = this.props;
 
     const title = intl.formatMessage(messages.title);
@@ -67,7 +71,9 @@ class ListForm extends PureComponent {
       </form>
     );
   }
-
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(injectIntl(ListForm));
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(injectIntl(ListForm));

--- a/app/javascript/mastodon/features/list_editor/components/search.jsx
+++ b/app/javascript/mastodon/features/list_editor/components/search.jsx
@@ -7,26 +7,32 @@ import classNames from 'classnames';
 
 import { connect } from 'react-redux';
 
-import { Icon }  from 'mastodon/components/icon';
+import { Icon } from 'mastodon/components/icon';
 
-import { fetchListSuggestions, clearListSuggestions, changeListSuggestions } from '../../../actions/lists';
+import {
+  fetchListSuggestions,
+  clearListSuggestions,
+  changeListSuggestions,
+} from '../../../actions/lists';
 
 const messages = defineMessages({
-  search: { id: 'lists.search', defaultMessage: 'Search among people you follow' },
+  search: {
+    id: 'lists.search',
+    defaultMessage: 'Search among people you follow',
+  },
 });
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   value: state.getIn(['listEditor', 'suggestions', 'value']),
 });
 
-const mapDispatchToProps = dispatch => ({
-  onSubmit: value => dispatch(fetchListSuggestions(value)),
+const mapDispatchToProps = (dispatch) => ({
+  onSubmit: (value) => dispatch(fetchListSuggestions(value)),
   onClear: () => dispatch(clearListSuggestions()),
-  onChange: value => dispatch(changeListSuggestions(value)),
+  onChange: (value) => dispatch(changeListSuggestions(value)),
 });
 
 class Search extends PureComponent {
-
   static propTypes = {
     intl: PropTypes.object.isRequired,
     value: PropTypes.string.isRequired,
@@ -35,11 +41,11 @@ class Search extends PureComponent {
     onClear: PropTypes.func.isRequired,
   };
 
-  handleChange = e => {
+  handleChange = (e) => {
     this.props.onChange(e.target.value);
   };
 
-  handleKeyUp = e => {
+  handleKeyUp = (e) => {
     if (e.keyCode === 13) {
       this.props.onSubmit(this.props.value);
     }
@@ -49,14 +55,16 @@ class Search extends PureComponent {
     this.props.onClear();
   };
 
-  render () {
+  render() {
     const { value, intl } = this.props;
     const hasValue = value.length > 0;
 
     return (
       <div className='list-editor__search search'>
         <label>
-          <span style={{ display: 'none' }}>{intl.formatMessage(messages.search)}</span>
+          <span style={{ display: 'none' }}>
+            {intl.formatMessage(messages.search)}
+          </span>
 
           <input
             className='search__input'
@@ -68,14 +76,22 @@ class Search extends PureComponent {
           />
         </label>
 
-        <div role='button' tabIndex={0} className='search__icon' onClick={this.handleClear}>
+        <div
+          role='button'
+          tabIndex={0}
+          className='search__icon'
+          onClick={this.handleClear}
+        >
           <Icon id='search' className={classNames({ active: !hasValue })} />
-          <Icon id='times-circle' aria-label={intl.formatMessage(messages.search)} className={classNames({ active: hasValue })} />
+          <Icon
+            id='times-circle'
+            aria-label={intl.formatMessage(messages.search)}
+            className={classNames({ active: hasValue })}
+          />
         </div>
       </div>
     );
   }
-
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(injectIntl(Search));

--- a/app/javascript/mastodon/features/list_editor/index.jsx
+++ b/app/javascript/mastodon/features/list_editor/index.jsx
@@ -8,26 +8,29 @@ import { connect } from 'react-redux';
 
 import spring from 'react-motion/lib/spring';
 
-import { setupListEditor, clearListSuggestions, resetListEditor } from '../../actions/lists';
+import {
+  setupListEditor,
+  clearListSuggestions,
+  resetListEditor,
+} from '../../actions/lists';
 import Motion from '../ui/util/optional_motion';
 
 import Account from './components/account';
 import EditListForm from './components/edit_list_form';
 import Search from './components/search';
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   accountIds: state.getIn(['listEditor', 'accounts', 'items']),
   searchAccountIds: state.getIn(['listEditor', 'suggestions', 'items']),
 });
 
-const mapDispatchToProps = dispatch => ({
-  onInitialize: listId => dispatch(setupListEditor(listId)),
+const mapDispatchToProps = (dispatch) => ({
+  onInitialize: (listId) => dispatch(setupListEditor(listId)),
   onClear: () => dispatch(clearListSuggestions()),
   onReset: () => dispatch(resetListEditor()),
 });
 
 class ListEditor extends ImmutablePureComponent {
-
   static propTypes = {
     listId: PropTypes.string.isRequired,
     onClose: PropTypes.func.isRequired,
@@ -39,17 +42,17 @@ class ListEditor extends ImmutablePureComponent {
     searchAccountIds: ImmutablePropTypes.list.isRequired,
   };
 
-  componentDidMount () {
+  componentDidMount() {
     const { onInitialize, listId } = this.props;
     onInitialize(listId);
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     const { onReset } = this.props;
     onReset();
   }
 
-  render () {
+  render() {
     const { accountIds, searchAccountIds, onClear } = this.props;
     const showSearch = searchAccountIds.size > 0;
 
@@ -61,15 +64,37 @@ class ListEditor extends ImmutablePureComponent {
 
         <div className='drawer__pager'>
           <div className='drawer__inner list-editor__accounts'>
-            {accountIds.map(accountId => <Account key={accountId} accountId={accountId} added />)}
+            {accountIds.map((accountId) => (
+              <Account key={accountId} accountId={accountId} added />
+            ))}
           </div>
 
-          {showSearch && <div role='button' tabIndex={-1} className='drawer__backdrop' onClick={onClear} />}
+          {showSearch && (
+            <div
+              role='button'
+              tabIndex={-1}
+              className='drawer__backdrop'
+              onClick={onClear}
+            />
+          )}
 
-          <Motion defaultStyle={{ x: -100 }} style={{ x: spring(showSearch ? 0 : -100, { stiffness: 210, damping: 20 }) }}>
+          <Motion
+            defaultStyle={{ x: -100 }}
+            style={{
+              x: spring(showSearch ? 0 : -100, { stiffness: 210, damping: 20 }),
+            }}
+          >
             {({ x }) => (
-              <div className='drawer__inner backdrop' style={{ transform: x === 0 ? null : `translateX(${x}%)`, visibility: x === -100 ? 'hidden' : 'visible' }}>
-                {searchAccountIds.map(accountId => <Account key={accountId} accountId={accountId} />)}
+              <div
+                className='drawer__inner backdrop'
+                style={{
+                  transform: x === 0 ? null : `translateX(${x}%)`,
+                  visibility: x === -100 ? 'hidden' : 'visible',
+                }}
+              >
+                {searchAccountIds.map((accountId) => (
+                  <Account key={accountId} accountId={accountId} />
+                ))}
               </div>
             )}
           </Motion>
@@ -77,7 +102,9 @@ class ListEditor extends ImmutablePureComponent {
       </div>
     );
   }
-
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(injectIntl(ListEditor));
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(injectIntl(ListEditor));

--- a/app/javascript/mastodon/features/list_timeline/index.jsx
+++ b/app/javascript/mastodon/features/list_timeline/index.jsx
@@ -17,27 +17,39 @@ import { connectListStream } from 'mastodon/actions/streaming';
 import { expandListTimeline } from 'mastodon/actions/timelines';
 import Column from 'mastodon/components/column';
 import ColumnHeader from 'mastodon/components/column_header';
-import { Icon }  from 'mastodon/components/icon';
+import { Icon } from 'mastodon/components/icon';
 import { LoadingIndicator } from 'mastodon/components/loading_indicator';
 import { RadioButton } from 'mastodon/components/radio_button';
 import BundleColumnError from 'mastodon/features/ui/components/bundle_column_error';
 import StatusListContainer from 'mastodon/features/ui/containers/status_list_container';
 
 const messages = defineMessages({
-  deleteMessage: { id: 'confirmations.delete_list.message', defaultMessage: 'Are you sure you want to permanently delete this list?' },
-  deleteConfirm: { id: 'confirmations.delete_list.confirm', defaultMessage: 'Delete' },
-  followed:   { id: 'lists.replies_policy.followed', defaultMessage: 'Any followed user' },
-  none:    { id: 'lists.replies_policy.none', defaultMessage: 'No one' },
-  list:  { id: 'lists.replies_policy.list', defaultMessage: 'Members of the list' },
+  deleteMessage: {
+    id: 'confirmations.delete_list.message',
+    defaultMessage: 'Are you sure you want to permanently delete this list?',
+  },
+  deleteConfirm: {
+    id: 'confirmations.delete_list.confirm',
+    defaultMessage: 'Delete',
+  },
+  followed: {
+    id: 'lists.replies_policy.followed',
+    defaultMessage: 'Any followed user',
+  },
+  none: { id: 'lists.replies_policy.none', defaultMessage: 'No one' },
+  list: {
+    id: 'lists.replies_policy.list',
+    defaultMessage: 'Members of the list',
+  },
 });
 
 const mapStateToProps = (state, props) => ({
   list: state.getIn(['lists', props.params.id]),
-  hasUnread: state.getIn(['timelines', `list:${props.params.id}`, 'unread']) > 0,
+  hasUnread:
+    state.getIn(['timelines', `list:${props.params.id}`, 'unread']) > 0,
 });
 
 class ListTimeline extends PureComponent {
-
   static contextTypes = {
     router: PropTypes.object,
   };
@@ -72,7 +84,7 @@ class ListTimeline extends PureComponent {
     this.column.scrollTop();
   };
 
-  componentDidMount () {
+  componentDidMount() {
     const { dispatch } = this.props;
     const { id } = this.props.params;
 
@@ -82,7 +94,7 @@ class ListTimeline extends PureComponent {
     this.disconnect = dispatch(connectListStream(id));
   }
 
-  UNSAFE_componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { dispatch } = this.props;
     const { id } = nextProps.params;
 
@@ -99,49 +111,53 @@ class ListTimeline extends PureComponent {
     }
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     if (this.disconnect) {
       this.disconnect();
       this.disconnect = null;
     }
   }
 
-  setRef = c => {
+  setRef = (c) => {
     this.column = c;
   };
 
-  handleLoadMore = maxId => {
+  handleLoadMore = (maxId) => {
     const { id } = this.props.params;
     this.props.dispatch(expandListTimeline(id, { maxId }));
   };
 
   handleEditClick = () => {
-    this.props.dispatch(openModal({
-      modalType: 'LIST_EDITOR',
-      modalProps: { listId: this.props.params.id },
-    }));
+    this.props.dispatch(
+      openModal({
+        modalType: 'LIST_EDITOR',
+        modalProps: { listId: this.props.params.id },
+      }),
+    );
   };
 
   handleDeleteClick = () => {
     const { dispatch, columnId, intl } = this.props;
     const { id } = this.props.params;
 
-    dispatch(openModal({
-      modalType: 'CONFIRM',
-      modalProps: {
-        message: intl.formatMessage(messages.deleteMessage),
-        confirm: intl.formatMessage(messages.deleteConfirm),
-        onConfirm: () => {
-          dispatch(deleteList(id));
+    dispatch(
+      openModal({
+        modalType: 'CONFIRM',
+        modalProps: {
+          message: intl.formatMessage(messages.deleteMessage),
+          confirm: intl.formatMessage(messages.deleteConfirm),
+          onConfirm: () => {
+            dispatch(deleteList(id));
 
-          if (columnId) {
-            dispatch(removeColumn(columnId));
-          } else {
-            this.context.router.history.push('/lists');
-          }
+            if (columnId) {
+              dispatch(removeColumn(columnId));
+            } else {
+              this.context.router.history.push('/lists');
+            }
+          },
         },
-      },
-    }));
+      }),
+    );
   };
 
   handleRepliesPolicyChange = ({ target }) => {
@@ -156,11 +172,11 @@ class ListTimeline extends PureComponent {
     dispatch(updateList(id, undefined, false, target.checked, undefined));
   };
 
-  render () {
+  render() {
     const { hasUnread, columnId, multiColumn, list, intl } = this.props;
     const { id } = this.props.params;
     const pinned = !!columnId;
-    const title  = list ? list.get('title') : id;
+    const title = list ? list.get('title') : id;
     const replies_policy = list ? list.get('replies_policy') : undefined;
     const isExclusive = list ? list.get('exclusive') : undefined;
 
@@ -191,30 +207,68 @@ class ListTimeline extends PureComponent {
           multiColumn={multiColumn}
         >
           <div className='column-settings__row column-header__links'>
-            <button type='button' className='text-btn column-header__setting-btn' tabIndex={0} onClick={this.handleEditClick}>
-              <Icon id='pencil' /> <FormattedMessage id='lists.edit' defaultMessage='Edit list' />
+            <button
+              type='button'
+              className='text-btn column-header__setting-btn'
+              tabIndex={0}
+              onClick={this.handleEditClick}
+            >
+              <Icon id='pencil' />{' '}
+              <FormattedMessage id='lists.edit' defaultMessage='Edit list' />
             </button>
 
-            <button type='button' className='text-btn column-header__setting-btn' tabIndex={0} onClick={this.handleDeleteClick}>
-              <Icon id='trash' /> <FormattedMessage id='lists.delete' defaultMessage='Delete list' />
+            <button
+              type='button'
+              className='text-btn column-header__setting-btn'
+              tabIndex={0}
+              onClick={this.handleDeleteClick}
+            >
+              <Icon id='trash' />{' '}
+              <FormattedMessage
+                id='lists.delete'
+                defaultMessage='Delete list'
+              />
             </button>
           </div>
 
           <div className='setting-toggle'>
-            <Toggle id={`list-${id}-exclusive`} defaultChecked={isExclusive} onChange={this.onExclusiveToggle} />
-            <label htmlFor={`list-${id}-exclusive`} className='setting-toggle__label'>
-              <FormattedMessage id='lists.exclusive' defaultMessage='Hide these posts from home' />
+            <Toggle
+              id={`list-${id}-exclusive`}
+              defaultChecked={isExclusive}
+              onChange={this.onExclusiveToggle}
+            />
+            <label
+              htmlFor={`list-${id}-exclusive`}
+              className='setting-toggle__label'
+            >
+              <FormattedMessage
+                id='lists.exclusive'
+                defaultMessage='Hide these posts from home'
+              />
             </label>
           </div>
 
-          { replies_policy !== undefined && (
+          {replies_policy !== undefined && (
             <div role='group' aria-labelledby={`list-${id}-replies-policy`}>
-              <span id={`list-${id}-replies-policy`} className='column-settings__section'>
-                <FormattedMessage id='lists.replies_policy.title' defaultMessage='Show replies to:' />
+              <span
+                id={`list-${id}-replies-policy`}
+                className='column-settings__section'
+              >
+                <FormattedMessage
+                  id='lists.replies_policy.title'
+                  defaultMessage='Show replies to:'
+                />
               </span>
               <div className='column-settings__row'>
-                { ['none', 'list', 'followed'].map(policy => (
-                  <RadioButton name='order' key={policy} value={policy} label={intl.formatMessage(messages[policy])} checked={replies_policy === policy} onChange={this.handleRepliesPolicyChange} />
+                {['none', 'list', 'followed'].map((policy) => (
+                  <RadioButton
+                    name='order'
+                    key={policy}
+                    value={policy}
+                    label={intl.formatMessage(messages[policy])}
+                    checked={replies_policy === policy}
+                    onChange={this.handleRepliesPolicyChange}
+                  />
                 ))}
               </div>
             </div>
@@ -226,7 +280,12 @@ class ListTimeline extends PureComponent {
           scrollKey={`list_timeline-${columnId}`}
           timelineId={`list:${id}`}
           onLoadMore={this.handleLoadMore}
-          emptyMessage={<FormattedMessage id='empty_column.list' defaultMessage='There is nothing in this list yet. When members of this list post new statuses, they will appear here.' />}
+          emptyMessage={
+            <FormattedMessage
+              id='empty_column.list'
+              defaultMessage='There is nothing in this list yet. When members of this list post new statuses, they will appear here.'
+            />
+          }
           bindToDocument={!multiColumn}
         />
 
@@ -237,7 +296,6 @@ class ListTimeline extends PureComponent {
       </Column>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(injectIntl(ListTimeline));

--- a/app/javascript/mastodon/features/lists/components/new_list_form.jsx
+++ b/app/javascript/mastodon/features/lists/components/new_list_form.jsx
@@ -5,26 +5,31 @@ import { defineMessages, injectIntl } from 'react-intl';
 
 import { connect } from 'react-redux';
 
-import { changeListEditorTitle, submitListEditor } from 'mastodon/actions/lists';
+import {
+  changeListEditorTitle,
+  submitListEditor,
+} from 'mastodon/actions/lists';
 import Button from 'mastodon/components/button';
 
 const messages = defineMessages({
-  label: { id: 'lists.new.title_placeholder', defaultMessage: 'New list title' },
+  label: {
+    id: 'lists.new.title_placeholder',
+    defaultMessage: 'New list title',
+  },
   title: { id: 'lists.new.create', defaultMessage: 'Add list' },
 });
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   value: state.getIn(['listEditor', 'title']),
   disabled: state.getIn(['listEditor', 'isSubmitting']),
 });
 
-const mapDispatchToProps = dispatch => ({
-  onChange: value => dispatch(changeListEditorTitle(value)),
+const mapDispatchToProps = (dispatch) => ({
+  onChange: (value) => dispatch(changeListEditorTitle(value)),
   onSubmit: () => dispatch(submitListEditor(true)),
 });
 
 class NewListForm extends PureComponent {
-
   static propTypes = {
     value: PropTypes.string.isRequired,
     disabled: PropTypes.bool,
@@ -33,11 +38,11 @@ class NewListForm extends PureComponent {
     onSubmit: PropTypes.func.isRequired,
   };
 
-  handleChange = e => {
+  handleChange = (e) => {
     this.props.onChange(e.target.value);
   };
 
-  handleSubmit = e => {
+  handleSubmit = (e) => {
     e.preventDefault();
     this.props.onSubmit();
   };
@@ -46,7 +51,7 @@ class NewListForm extends PureComponent {
     this.props.onSubmit();
   };
 
-  render () {
+  render() {
     const { value, disabled, intl } = this.props;
 
     const label = intl.formatMessage(messages.label);
@@ -74,7 +79,9 @@ class NewListForm extends PureComponent {
       </form>
     );
   }
-
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(injectIntl(NewListForm));
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(injectIntl(NewListForm));

--- a/app/javascript/mastodon/features/lists/index.jsx
+++ b/app/javascript/mastodon/features/lists/index.jsx
@@ -24,20 +24,25 @@ const messages = defineMessages({
   subheading: { id: 'lists.subheading', defaultMessage: 'Your lists' },
 });
 
-const getOrderedLists = createSelector([state => state.get('lists')], lists => {
-  if (!lists) {
-    return lists;
-  }
+const getOrderedLists = createSelector(
+  [(state) => state.get('lists')],
+  (lists) => {
+    if (!lists) {
+      return lists;
+    }
 
-  return lists.toList().filter(item => !!item).sort((a, b) => a.get('title').localeCompare(b.get('title')));
-});
+    return lists
+      .toList()
+      .filter((item) => !!item)
+      .sort((a, b) => a.get('title').localeCompare(b.get('title')));
+  },
+);
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   lists: getOrderedLists(state),
 });
 
 class Lists extends ImmutablePureComponent {
-
   static propTypes = {
     params: PropTypes.object.isRequired,
     dispatch: PropTypes.func.isRequired,
@@ -46,11 +51,11 @@ class Lists extends ImmutablePureComponent {
     multiColumn: PropTypes.bool,
   };
 
-  UNSAFE_componentWillMount () {
+  UNSAFE_componentWillMount() {
     this.props.dispatch(fetchLists());
   }
 
-  render () {
+  render() {
     const { intl, lists, multiColumn } = this.props;
 
     if (!lists) {
@@ -61,23 +66,42 @@ class Lists extends ImmutablePureComponent {
       );
     }
 
-    const emptyMessage = <FormattedMessage id='empty_column.lists' defaultMessage="You don't have any lists yet. When you create one, it will show up here." />;
+    const emptyMessage = (
+      <FormattedMessage
+        id='empty_column.lists'
+        defaultMessage="You don't have any lists yet. When you create one, it will show up here."
+      />
+    );
 
     return (
-      <Column bindToDocument={!multiColumn} label={intl.formatMessage(messages.heading)}>
-        <ColumnHeader title={intl.formatMessage(messages.heading)} icon='list-ul' multiColumn={multiColumn} />
+      <Column
+        bindToDocument={!multiColumn}
+        label={intl.formatMessage(messages.heading)}
+      >
+        <ColumnHeader
+          title={intl.formatMessage(messages.heading)}
+          icon='list-ul'
+          multiColumn={multiColumn}
+        />
 
         <NewListForm />
 
         <ScrollableList
           scrollKey='lists'
           emptyMessage={emptyMessage}
-          prepend={<ColumnSubheading text={intl.formatMessage(messages.subheading)} />}
+          prepend={
+            <ColumnSubheading text={intl.formatMessage(messages.subheading)} />
+          }
           bindToDocument={!multiColumn}
         >
-          {lists.map(list =>
-            <ColumnLink key={list.get('id')} to={`/lists/${list.get('id')}`} icon='list-ul' text={list.get('title')} />,
-          )}
+          {lists.map((list) => (
+            <ColumnLink
+              key={list.get('id')}
+              to={`/lists/${list.get('id')}`}
+              icon='list-ul'
+              text={list.get('title')}
+            />
+          ))}
         </ScrollableList>
 
         <Helmet>
@@ -87,7 +111,6 @@ class Lists extends ImmutablePureComponent {
       </Column>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(injectIntl(Lists));

--- a/app/javascript/mastodon/features/mutes/index.jsx
+++ b/app/javascript/mastodon/features/mutes/index.jsx
@@ -21,14 +21,13 @@ const messages = defineMessages({
   heading: { id: 'column.mutes', defaultMessage: 'Muted users' },
 });
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   accountIds: state.getIn(['user_lists', 'mutes', 'items']),
   hasMore: !!state.getIn(['user_lists', 'mutes', 'next']),
   isLoading: state.getIn(['user_lists', 'mutes', 'isLoading'], true),
 });
 
 class Mutes extends ImmutablePureComponent {
-
   static propTypes = {
     params: PropTypes.object.isRequired,
     dispatch: PropTypes.func.isRequired,
@@ -39,15 +38,19 @@ class Mutes extends ImmutablePureComponent {
     multiColumn: PropTypes.bool,
   };
 
-  UNSAFE_componentWillMount () {
+  UNSAFE_componentWillMount() {
     this.props.dispatch(fetchMutes());
   }
 
-  handleLoadMore = debounce(() => {
-    this.props.dispatch(expandMutes());
-  }, 300, { leading: true });
+  handleLoadMore = debounce(
+    () => {
+      this.props.dispatch(expandMutes());
+    },
+    300,
+    { leading: true },
+  );
 
-  render () {
+  render() {
     const { intl, hasMore, accountIds, multiColumn, isLoading } = this.props;
 
     if (!accountIds) {
@@ -58,10 +61,19 @@ class Mutes extends ImmutablePureComponent {
       );
     }
 
-    const emptyMessage = <FormattedMessage id='empty_column.mutes' defaultMessage="You haven't muted any users yet." />;
+    const emptyMessage = (
+      <FormattedMessage
+        id='empty_column.mutes'
+        defaultMessage="You haven't muted any users yet."
+      />
+    );
 
     return (
-      <Column bindToDocument={!multiColumn} icon='volume-off' heading={intl.formatMessage(messages.heading)}>
+      <Column
+        bindToDocument={!multiColumn}
+        icon='volume-off'
+        heading={intl.formatMessage(messages.heading)}
+      >
         <ColumnBackButtonSlim />
         <ScrollableList
           scrollKey='mutes'
@@ -71,9 +83,9 @@ class Mutes extends ImmutablePureComponent {
           emptyMessage={emptyMessage}
           bindToDocument={!multiColumn}
         >
-          {accountIds.map(id =>
-            <AccountContainer key={id} id={id} defaultAction='mute' />,
-          )}
+          {accountIds.map((id) => (
+            <AccountContainer key={id} id={id} defaultAction='mute' />
+          ))}
         </ScrollableList>
 
         <Helmet>
@@ -82,7 +94,6 @@ class Mutes extends ImmutablePureComponent {
       </Column>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(injectIntl(Mutes));

--- a/app/javascript/mastodon/features/notifications/components/clear_column_button.jsx
+++ b/app/javascript/mastodon/features/notifications/components/clear_column_button.jsx
@@ -3,18 +3,26 @@ import { PureComponent } from 'react';
 
 import { FormattedMessage } from 'react-intl';
 
-import { Icon }  from 'mastodon/components/icon';
+import { Icon } from 'mastodon/components/icon';
 
 export default class ClearColumnButton extends PureComponent {
-
   static propTypes = {
     onClick: PropTypes.func.isRequired,
   };
 
-  render () {
+  render() {
     return (
-      <button className='text-btn column-header__setting-btn' tabIndex={0} onClick={this.props.onClick}><Icon id='eraser' /> <FormattedMessage id='notifications.clear' defaultMessage='Clear notifications' /></button>
+      <button
+        className='text-btn column-header__setting-btn'
+        tabIndex={0}
+        onClick={this.props.onClick}
+      >
+        <Icon id='eraser' />{' '}
+        <FormattedMessage
+          id='notifications.clear'
+          defaultMessage='Clear notifications'
+        />
+      </button>
     );
   }
-
 }

--- a/app/javascript/mastodon/features/notifications/components/column_settings.jsx
+++ b/app/javascript/mastodon/features/notifications/components/column_settings.jsx
@@ -5,14 +5,16 @@ import { FormattedMessage } from 'react-intl';
 
 import ImmutablePropTypes from 'react-immutable-proptypes';
 
-import { PERMISSION_MANAGE_USERS, PERMISSION_MANAGE_REPORTS } from 'mastodon/permissions';
+import {
+  PERMISSION_MANAGE_USERS,
+  PERMISSION_MANAGE_REPORTS,
+} from 'mastodon/permissions';
 
 import ClearColumnButton from './clear_column_button';
 import GrantPermissionButton from './grant_permission_button';
 import SettingToggle from './setting_toggle';
 
 export default class ColumnSettings extends PureComponent {
-
   static contextTypes = {
     identity: PropTypes.object,
   };
@@ -32,31 +34,87 @@ export default class ColumnSettings extends PureComponent {
     this.props.onChange(['push', ...path], checked);
   };
 
-  render () {
-    const { settings, pushSettings, onChange, onClear, alertsEnabled, browserSupport, browserPermission, onRequestNotificationPermission } = this.props;
+  render() {
+    const {
+      settings,
+      pushSettings,
+      onChange,
+      onClear,
+      alertsEnabled,
+      browserSupport,
+      browserPermission,
+      onRequestNotificationPermission,
+    } = this.props;
 
-    const unreadMarkersShowStr = <FormattedMessage id='notifications.column_settings.unread_notifications.highlight' defaultMessage='Highlight unread notifications' />;
-    const filterBarShowStr = <FormattedMessage id='notifications.column_settings.filter_bar.show_bar' defaultMessage='Show filter bar' />;
-    const filterAdvancedStr = <FormattedMessage id='notifications.column_settings.filter_bar.advanced' defaultMessage='Display all categories' />;
-    const alertStr = <FormattedMessage id='notifications.column_settings.alert' defaultMessage='Desktop notifications' />;
-    const showStr = <FormattedMessage id='notifications.column_settings.show' defaultMessage='Show in column' />;
-    const soundStr = <FormattedMessage id='notifications.column_settings.sound' defaultMessage='Play sound' />;
+    const unreadMarkersShowStr = (
+      <FormattedMessage
+        id='notifications.column_settings.unread_notifications.highlight'
+        defaultMessage='Highlight unread notifications'
+      />
+    );
+    const filterBarShowStr = (
+      <FormattedMessage
+        id='notifications.column_settings.filter_bar.show_bar'
+        defaultMessage='Show filter bar'
+      />
+    );
+    const filterAdvancedStr = (
+      <FormattedMessage
+        id='notifications.column_settings.filter_bar.advanced'
+        defaultMessage='Display all categories'
+      />
+    );
+    const alertStr = (
+      <FormattedMessage
+        id='notifications.column_settings.alert'
+        defaultMessage='Desktop notifications'
+      />
+    );
+    const showStr = (
+      <FormattedMessage
+        id='notifications.column_settings.show'
+        defaultMessage='Show in column'
+      />
+    );
+    const soundStr = (
+      <FormattedMessage
+        id='notifications.column_settings.sound'
+        defaultMessage='Play sound'
+      />
+    );
 
-    const showPushSettings = pushSettings.get('browserSupport') && pushSettings.get('isSubscribed');
-    const pushStr = showPushSettings && <FormattedMessage id='notifications.column_settings.push' defaultMessage='Push notifications' />;
+    const showPushSettings =
+      pushSettings.get('browserSupport') && pushSettings.get('isSubscribed');
+    const pushStr = showPushSettings && (
+      <FormattedMessage
+        id='notifications.column_settings.push'
+        defaultMessage='Push notifications'
+      />
+    );
 
     return (
       <div>
         {alertsEnabled && browserSupport && browserPermission === 'denied' && (
           <div className='column-settings__row column-settings__row--with-margin'>
-            <span className='warning-hint'><FormattedMessage id='notifications.permission_denied' defaultMessage='Desktop notifications are unavailable due to previously denied browser permissions request' /></span>
+            <span className='warning-hint'>
+              <FormattedMessage
+                id='notifications.permission_denied'
+                defaultMessage='Desktop notifications are unavailable due to previously denied browser permissions request'
+              />
+            </span>
           </div>
         )}
 
         {alertsEnabled && browserSupport && browserPermission === 'default' && (
           <div className='column-settings__row column-settings__row--with-margin'>
             <span className='warning-hint'>
-              <FormattedMessage id='notifications.permission_required' defaultMessage='Desktop notifications are unavailable because the required permission has not been granted.' /> <GrantPermissionButton onClick={onRequestNotificationPermission} />
+              <FormattedMessage
+                id='notifications.permission_required'
+                defaultMessage='Desktop notifications are unavailable because the required permission has not been granted.'
+              />{' '}
+              <GrantPermissionButton
+                onClick={onRequestNotificationPermission}
+              />
             </span>
           </div>
         )}
@@ -66,141 +124,507 @@ export default class ColumnSettings extends PureComponent {
         </div>
 
         <div role='group' aria-labelledby='notifications-unread-markers'>
-          <span id='notifications-unread-markers' className='column-settings__section'>
-            <FormattedMessage id='notifications.column_settings.unread_notifications.category' defaultMessage='Unread notifications' />
+          <span
+            id='notifications-unread-markers'
+            className='column-settings__section'
+          >
+            <FormattedMessage
+              id='notifications.column_settings.unread_notifications.category'
+              defaultMessage='Unread notifications'
+            />
           </span>
 
           <div className='column-settings__row'>
-            <SettingToggle id='unread-notification-markers' prefix='notifications' settings={settings} settingPath={['showUnread']} onChange={onChange} label={unreadMarkersShowStr} />
+            <SettingToggle
+              id='unread-notification-markers'
+              prefix='notifications'
+              settings={settings}
+              settingPath={['showUnread']}
+              onChange={onChange}
+              label={unreadMarkersShowStr}
+            />
           </div>
         </div>
 
         <div role='group' aria-labelledby='notifications-filter-bar'>
-          <span id='notifications-filter-bar' className='column-settings__section'>
-            <FormattedMessage id='notifications.column_settings.filter_bar.category' defaultMessage='Quick filter bar' />
+          <span
+            id='notifications-filter-bar'
+            className='column-settings__section'
+          >
+            <FormattedMessage
+              id='notifications.column_settings.filter_bar.category'
+              defaultMessage='Quick filter bar'
+            />
           </span>
 
           <div className='column-settings__row'>
-            <SettingToggle id='show-filter-bar' prefix='notifications' settings={settings} settingPath={['quickFilter', 'show']} onChange={onChange} label={filterBarShowStr} />
-            <SettingToggle id='show-filter-bar' prefix='notifications' settings={settings} settingPath={['quickFilter', 'advanced']} onChange={onChange} label={filterAdvancedStr} />
+            <SettingToggle
+              id='show-filter-bar'
+              prefix='notifications'
+              settings={settings}
+              settingPath={['quickFilter', 'show']}
+              onChange={onChange}
+              label={filterBarShowStr}
+            />
+            <SettingToggle
+              id='show-filter-bar'
+              prefix='notifications'
+              settings={settings}
+              settingPath={['quickFilter', 'advanced']}
+              onChange={onChange}
+              label={filterAdvancedStr}
+            />
           </div>
         </div>
 
         <div role='group' aria-labelledby='notifications-follow'>
-          <span id='notifications-follow' className='column-settings__section'><FormattedMessage id='notifications.column_settings.follow' defaultMessage='New followers:' /></span>
+          <span id='notifications-follow' className='column-settings__section'>
+            <FormattedMessage
+              id='notifications.column_settings.follow'
+              defaultMessage='New followers:'
+            />
+          </span>
 
           <div className='column-settings__row'>
-            <SettingToggle disabled={browserPermission === 'denied'} prefix='notifications_desktop' settings={settings} settingPath={['alerts', 'follow']} onChange={onChange} label={alertStr} />
-            {showPushSettings && <SettingToggle prefix='notifications_push' settings={pushSettings} settingPath={['alerts', 'follow']} onChange={this.onPushChange} label={pushStr} />}
-            <SettingToggle prefix='notifications' settings={settings} settingPath={['shows', 'follow']} onChange={onChange} label={showStr} />
-            <SettingToggle prefix='notifications' settings={settings} settingPath={['sounds', 'follow']} onChange={onChange} label={soundStr} />
+            <SettingToggle
+              disabled={browserPermission === 'denied'}
+              prefix='notifications_desktop'
+              settings={settings}
+              settingPath={['alerts', 'follow']}
+              onChange={onChange}
+              label={alertStr}
+            />
+            {showPushSettings && (
+              <SettingToggle
+                prefix='notifications_push'
+                settings={pushSettings}
+                settingPath={['alerts', 'follow']}
+                onChange={this.onPushChange}
+                label={pushStr}
+              />
+            )}
+            <SettingToggle
+              prefix='notifications'
+              settings={settings}
+              settingPath={['shows', 'follow']}
+              onChange={onChange}
+              label={showStr}
+            />
+            <SettingToggle
+              prefix='notifications'
+              settings={settings}
+              settingPath={['sounds', 'follow']}
+              onChange={onChange}
+              label={soundStr}
+            />
           </div>
         </div>
 
         <div role='group' aria-labelledby='notifications-follow-request'>
-          <span id='notifications-follow-request' className='column-settings__section'><FormattedMessage id='notifications.column_settings.follow_request' defaultMessage='New follow requests:' /></span>
+          <span
+            id='notifications-follow-request'
+            className='column-settings__section'
+          >
+            <FormattedMessage
+              id='notifications.column_settings.follow_request'
+              defaultMessage='New follow requests:'
+            />
+          </span>
 
           <div className='column-settings__row'>
-            <SettingToggle disabled={browserPermission === 'denied'} prefix='notifications_desktop' settings={settings} settingPath={['alerts', 'follow_request']} onChange={onChange} label={alertStr} />
-            {showPushSettings && <SettingToggle prefix='notifications_push' settings={pushSettings} settingPath={['alerts', 'follow_request']} onChange={this.onPushChange} label={pushStr} />}
-            <SettingToggle prefix='notifications' settings={settings} settingPath={['shows', 'follow_request']} onChange={onChange} label={showStr} />
-            <SettingToggle prefix='notifications' settings={settings} settingPath={['sounds', 'follow_request']} onChange={onChange} label={soundStr} />
+            <SettingToggle
+              disabled={browserPermission === 'denied'}
+              prefix='notifications_desktop'
+              settings={settings}
+              settingPath={['alerts', 'follow_request']}
+              onChange={onChange}
+              label={alertStr}
+            />
+            {showPushSettings && (
+              <SettingToggle
+                prefix='notifications_push'
+                settings={pushSettings}
+                settingPath={['alerts', 'follow_request']}
+                onChange={this.onPushChange}
+                label={pushStr}
+              />
+            )}
+            <SettingToggle
+              prefix='notifications'
+              settings={settings}
+              settingPath={['shows', 'follow_request']}
+              onChange={onChange}
+              label={showStr}
+            />
+            <SettingToggle
+              prefix='notifications'
+              settings={settings}
+              settingPath={['sounds', 'follow_request']}
+              onChange={onChange}
+              label={soundStr}
+            />
           </div>
         </div>
 
         <div role='group' aria-labelledby='notifications-favourite'>
-          <span id='notifications-favourite' className='column-settings__section'><FormattedMessage id='notifications.column_settings.favourite' defaultMessage='Favorites:' /></span>
+          <span
+            id='notifications-favourite'
+            className='column-settings__section'
+          >
+            <FormattedMessage
+              id='notifications.column_settings.favourite'
+              defaultMessage='Favorites:'
+            />
+          </span>
 
           <div className='column-settings__row'>
-            <SettingToggle disabled={browserPermission === 'denied'} prefix='notifications_desktop' settings={settings} settingPath={['alerts', 'favourite']} onChange={onChange} label={alertStr} />
-            {showPushSettings && <SettingToggle prefix='notifications_push' settings={pushSettings} settingPath={['alerts', 'favourite']} onChange={this.onPushChange} label={pushStr} />}
-            <SettingToggle prefix='notifications' settings={settings} settingPath={['shows', 'favourite']} onChange={onChange} label={showStr} />
-            <SettingToggle prefix='notifications' settings={settings} settingPath={['sounds', 'favourite']} onChange={onChange} label={soundStr} />
+            <SettingToggle
+              disabled={browserPermission === 'denied'}
+              prefix='notifications_desktop'
+              settings={settings}
+              settingPath={['alerts', 'favourite']}
+              onChange={onChange}
+              label={alertStr}
+            />
+            {showPushSettings && (
+              <SettingToggle
+                prefix='notifications_push'
+                settings={pushSettings}
+                settingPath={['alerts', 'favourite']}
+                onChange={this.onPushChange}
+                label={pushStr}
+              />
+            )}
+            <SettingToggle
+              prefix='notifications'
+              settings={settings}
+              settingPath={['shows', 'favourite']}
+              onChange={onChange}
+              label={showStr}
+            />
+            <SettingToggle
+              prefix='notifications'
+              settings={settings}
+              settingPath={['sounds', 'favourite']}
+              onChange={onChange}
+              label={soundStr}
+            />
           </div>
         </div>
 
         <div role='group' aria-labelledby='notifications-mention'>
-          <span id='notifications-mention' className='column-settings__section'><FormattedMessage id='notifications.column_settings.mention' defaultMessage='Mentions:' /></span>
+          <span id='notifications-mention' className='column-settings__section'>
+            <FormattedMessage
+              id='notifications.column_settings.mention'
+              defaultMessage='Mentions:'
+            />
+          </span>
 
           <div className='column-settings__row'>
-            <SettingToggle disabled={browserPermission === 'denied'} prefix='notifications_desktop' settings={settings} settingPath={['alerts', 'mention']} onChange={onChange} label={alertStr} />
-            {showPushSettings && <SettingToggle prefix='notifications_push' settings={pushSettings} settingPath={['alerts', 'mention']} onChange={this.onPushChange} label={pushStr} />}
-            <SettingToggle prefix='notifications' settings={settings} settingPath={['shows', 'mention']} onChange={onChange} label={showStr} />
-            <SettingToggle prefix='notifications' settings={settings} settingPath={['sounds', 'mention']} onChange={onChange} label={soundStr} />
+            <SettingToggle
+              disabled={browserPermission === 'denied'}
+              prefix='notifications_desktop'
+              settings={settings}
+              settingPath={['alerts', 'mention']}
+              onChange={onChange}
+              label={alertStr}
+            />
+            {showPushSettings && (
+              <SettingToggle
+                prefix='notifications_push'
+                settings={pushSettings}
+                settingPath={['alerts', 'mention']}
+                onChange={this.onPushChange}
+                label={pushStr}
+              />
+            )}
+            <SettingToggle
+              prefix='notifications'
+              settings={settings}
+              settingPath={['shows', 'mention']}
+              onChange={onChange}
+              label={showStr}
+            />
+            <SettingToggle
+              prefix='notifications'
+              settings={settings}
+              settingPath={['sounds', 'mention']}
+              onChange={onChange}
+              label={soundStr}
+            />
           </div>
         </div>
 
         <div role='group' aria-labelledby='notifications-reblog'>
-          <span id='notifications-reblog' className='column-settings__section'><FormattedMessage id='notifications.column_settings.reblog' defaultMessage='Boosts:' /></span>
+          <span id='notifications-reblog' className='column-settings__section'>
+            <FormattedMessage
+              id='notifications.column_settings.reblog'
+              defaultMessage='Boosts:'
+            />
+          </span>
 
           <div className='column-settings__row'>
-            <SettingToggle disabled={browserPermission === 'denied'} prefix='notifications_desktop' settings={settings} settingPath={['alerts', 'reblog']} onChange={onChange} label={alertStr} />
-            {showPushSettings && <SettingToggle prefix='notifications_push' settings={pushSettings} settingPath={['alerts', 'reblog']} onChange={this.onPushChange} label={pushStr} />}
-            <SettingToggle prefix='notifications' settings={settings} settingPath={['shows', 'reblog']} onChange={onChange} label={showStr} />
-            <SettingToggle prefix='notifications' settings={settings} settingPath={['sounds', 'reblog']} onChange={onChange} label={soundStr} />
+            <SettingToggle
+              disabled={browserPermission === 'denied'}
+              prefix='notifications_desktop'
+              settings={settings}
+              settingPath={['alerts', 'reblog']}
+              onChange={onChange}
+              label={alertStr}
+            />
+            {showPushSettings && (
+              <SettingToggle
+                prefix='notifications_push'
+                settings={pushSettings}
+                settingPath={['alerts', 'reblog']}
+                onChange={this.onPushChange}
+                label={pushStr}
+              />
+            )}
+            <SettingToggle
+              prefix='notifications'
+              settings={settings}
+              settingPath={['shows', 'reblog']}
+              onChange={onChange}
+              label={showStr}
+            />
+            <SettingToggle
+              prefix='notifications'
+              settings={settings}
+              settingPath={['sounds', 'reblog']}
+              onChange={onChange}
+              label={soundStr}
+            />
           </div>
         </div>
 
         <div role='group' aria-labelledby='notifications-poll'>
-          <span id='notifications-poll' className='column-settings__section'><FormattedMessage id='notifications.column_settings.poll' defaultMessage='Poll results:' /></span>
+          <span id='notifications-poll' className='column-settings__section'>
+            <FormattedMessage
+              id='notifications.column_settings.poll'
+              defaultMessage='Poll results:'
+            />
+          </span>
 
           <div className='column-settings__row'>
-            <SettingToggle disabled={browserPermission === 'denied'} prefix='notifications_desktop' settings={settings} settingPath={['alerts', 'poll']} onChange={onChange} label={alertStr} />
-            {showPushSettings && <SettingToggle prefix='notifications_push' settings={pushSettings} settingPath={['alerts', 'poll']} onChange={this.onPushChange} label={pushStr} />}
-            <SettingToggle prefix='notifications' settings={settings} settingPath={['shows', 'poll']} onChange={onChange} label={showStr} />
-            <SettingToggle prefix='notifications' settings={settings} settingPath={['sounds', 'poll']} onChange={onChange} label={soundStr} />
+            <SettingToggle
+              disabled={browserPermission === 'denied'}
+              prefix='notifications_desktop'
+              settings={settings}
+              settingPath={['alerts', 'poll']}
+              onChange={onChange}
+              label={alertStr}
+            />
+            {showPushSettings && (
+              <SettingToggle
+                prefix='notifications_push'
+                settings={pushSettings}
+                settingPath={['alerts', 'poll']}
+                onChange={this.onPushChange}
+                label={pushStr}
+              />
+            )}
+            <SettingToggle
+              prefix='notifications'
+              settings={settings}
+              settingPath={['shows', 'poll']}
+              onChange={onChange}
+              label={showStr}
+            />
+            <SettingToggle
+              prefix='notifications'
+              settings={settings}
+              settingPath={['sounds', 'poll']}
+              onChange={onChange}
+              label={soundStr}
+            />
           </div>
         </div>
 
         <div role='group' aria-labelledby='notifications-status'>
-          <span id='notifications-status' className='column-settings__section'><FormattedMessage id='notifications.column_settings.status' defaultMessage='New posts:' /></span>
+          <span id='notifications-status' className='column-settings__section'>
+            <FormattedMessage
+              id='notifications.column_settings.status'
+              defaultMessage='New posts:'
+            />
+          </span>
 
           <div className='column-settings__row'>
-            <SettingToggle disabled={browserPermission === 'denied'} prefix='notifications_desktop' settings={settings} settingPath={['alerts', 'status']} onChange={onChange} label={alertStr} />
-            {showPushSettings && <SettingToggle prefix='notifications_push' settings={pushSettings} settingPath={['alerts', 'status']} onChange={this.onPushChange} label={pushStr} />}
-            <SettingToggle prefix='notifications' settings={settings} settingPath={['shows', 'status']} onChange={onChange} label={showStr} />
-            <SettingToggle prefix='notifications' settings={settings} settingPath={['sounds', 'status']} onChange={onChange} label={soundStr} />
+            <SettingToggle
+              disabled={browserPermission === 'denied'}
+              prefix='notifications_desktop'
+              settings={settings}
+              settingPath={['alerts', 'status']}
+              onChange={onChange}
+              label={alertStr}
+            />
+            {showPushSettings && (
+              <SettingToggle
+                prefix='notifications_push'
+                settings={pushSettings}
+                settingPath={['alerts', 'status']}
+                onChange={this.onPushChange}
+                label={pushStr}
+              />
+            )}
+            <SettingToggle
+              prefix='notifications'
+              settings={settings}
+              settingPath={['shows', 'status']}
+              onChange={onChange}
+              label={showStr}
+            />
+            <SettingToggle
+              prefix='notifications'
+              settings={settings}
+              settingPath={['sounds', 'status']}
+              onChange={onChange}
+              label={soundStr}
+            />
           </div>
         </div>
 
         <div role='group' aria-labelledby='notifications-update'>
-          <span id='notifications-update' className='column-settings__section'><FormattedMessage id='notifications.column_settings.update' defaultMessage='Edits:' /></span>
+          <span id='notifications-update' className='column-settings__section'>
+            <FormattedMessage
+              id='notifications.column_settings.update'
+              defaultMessage='Edits:'
+            />
+          </span>
 
           <div className='column-settings__row'>
-            <SettingToggle disabled={browserPermission === 'denied'} prefix='notifications_desktop' settings={settings} settingPath={['alerts', 'update']} onChange={onChange} label={alertStr} />
-            {showPushSettings && <SettingToggle prefix='notifications_push' settings={pushSettings} settingPath={['alerts', 'update']} onChange={this.onPushChange} label={pushStr} />}
-            <SettingToggle prefix='notifications' settings={settings} settingPath={['shows', 'update']} onChange={onChange} label={showStr} />
-            <SettingToggle prefix='notifications' settings={settings} settingPath={['sounds', 'update']} onChange={onChange} label={soundStr} />
+            <SettingToggle
+              disabled={browserPermission === 'denied'}
+              prefix='notifications_desktop'
+              settings={settings}
+              settingPath={['alerts', 'update']}
+              onChange={onChange}
+              label={alertStr}
+            />
+            {showPushSettings && (
+              <SettingToggle
+                prefix='notifications_push'
+                settings={pushSettings}
+                settingPath={['alerts', 'update']}
+                onChange={this.onPushChange}
+                label={pushStr}
+              />
+            )}
+            <SettingToggle
+              prefix='notifications'
+              settings={settings}
+              settingPath={['shows', 'update']}
+              onChange={onChange}
+              label={showStr}
+            />
+            <SettingToggle
+              prefix='notifications'
+              settings={settings}
+              settingPath={['sounds', 'update']}
+              onChange={onChange}
+              label={soundStr}
+            />
           </div>
         </div>
 
-        {((this.context.identity.permissions & PERMISSION_MANAGE_USERS) === PERMISSION_MANAGE_USERS) && (
+        {(this.context.identity.permissions & PERMISSION_MANAGE_USERS) ===
+          PERMISSION_MANAGE_USERS && (
           <div role='group' aria-labelledby='notifications-admin-sign-up'>
-            <span id='notifications-status' className='column-settings__section'><FormattedMessage id='notifications.column_settings.admin.sign_up' defaultMessage='New sign-ups:' /></span>
+            <span
+              id='notifications-status'
+              className='column-settings__section'
+            >
+              <FormattedMessage
+                id='notifications.column_settings.admin.sign_up'
+                defaultMessage='New sign-ups:'
+              />
+            </span>
 
             <div className='column-settings__row'>
-              <SettingToggle disabled={browserPermission === 'denied'} prefix='notifications_desktop' settings={settings} settingPath={['alerts', 'admin.sign_up']} onChange={onChange} label={alertStr} />
-              {showPushSettings && <SettingToggle prefix='notifications_push' settings={pushSettings} settingPath={['alerts', 'admin.sign_up']} onChange={this.onPushChange} label={pushStr} />}
-              <SettingToggle prefix='notifications' settings={settings} settingPath={['shows', 'admin.sign_up']} onChange={onChange} label={showStr} />
-              <SettingToggle prefix='notifications' settings={settings} settingPath={['sounds', 'admin.sign_up']} onChange={onChange} label={soundStr} />
+              <SettingToggle
+                disabled={browserPermission === 'denied'}
+                prefix='notifications_desktop'
+                settings={settings}
+                settingPath={['alerts', 'admin.sign_up']}
+                onChange={onChange}
+                label={alertStr}
+              />
+              {showPushSettings && (
+                <SettingToggle
+                  prefix='notifications_push'
+                  settings={pushSettings}
+                  settingPath={['alerts', 'admin.sign_up']}
+                  onChange={this.onPushChange}
+                  label={pushStr}
+                />
+              )}
+              <SettingToggle
+                prefix='notifications'
+                settings={settings}
+                settingPath={['shows', 'admin.sign_up']}
+                onChange={onChange}
+                label={showStr}
+              />
+              <SettingToggle
+                prefix='notifications'
+                settings={settings}
+                settingPath={['sounds', 'admin.sign_up']}
+                onChange={onChange}
+                label={soundStr}
+              />
             </div>
           </div>
         )}
 
-        {((this.context.identity.permissions & PERMISSION_MANAGE_REPORTS) === PERMISSION_MANAGE_REPORTS) && (
+        {(this.context.identity.permissions & PERMISSION_MANAGE_REPORTS) ===
+          PERMISSION_MANAGE_REPORTS && (
           <div role='group' aria-labelledby='notifications-admin-report'>
-            <span id='notifications-status' className='column-settings__section'><FormattedMessage id='notifications.column_settings.admin.report' defaultMessage='New reports:' /></span>
+            <span
+              id='notifications-status'
+              className='column-settings__section'
+            >
+              <FormattedMessage
+                id='notifications.column_settings.admin.report'
+                defaultMessage='New reports:'
+              />
+            </span>
 
             <div className='column-settings__row'>
-              <SettingToggle disabled={browserPermission === 'denied'} prefix='notifications_desktop' settings={settings} settingPath={['alerts', 'admin.report']} onChange={onChange} label={alertStr} />
-              {showPushSettings && <SettingToggle prefix='notifications_push' settings={pushSettings} settingPath={['alerts', 'admin.report']} onChange={this.onPushChange} label={pushStr} />}
-              <SettingToggle prefix='notifications' settings={settings} settingPath={['shows', 'admin.report']} onChange={onChange} label={showStr} />
-              <SettingToggle prefix='notifications' settings={settings} settingPath={['sounds', 'admin.report']} onChange={onChange} label={soundStr} />
+              <SettingToggle
+                disabled={browserPermission === 'denied'}
+                prefix='notifications_desktop'
+                settings={settings}
+                settingPath={['alerts', 'admin.report']}
+                onChange={onChange}
+                label={alertStr}
+              />
+              {showPushSettings && (
+                <SettingToggle
+                  prefix='notifications_push'
+                  settings={pushSettings}
+                  settingPath={['alerts', 'admin.report']}
+                  onChange={this.onPushChange}
+                  label={pushStr}
+                />
+              )}
+              <SettingToggle
+                prefix='notifications'
+                settings={settings}
+                settingPath={['shows', 'admin.report']}
+                onChange={onChange}
+                label={showStr}
+              />
+              <SettingToggle
+                prefix='notifications'
+                settings={settings}
+                settingPath={['sounds', 'admin.report']}
+                onChange={onChange}
+                label={soundStr}
+              />
             </div>
           </div>
         )}
       </div>
     );
   }
-
 }

--- a/app/javascript/mastodon/features/notifications/components/filter_bar.jsx
+++ b/app/javascript/mastodon/features/notifications/components/filter_bar.jsx
@@ -3,19 +3,24 @@ import { PureComponent } from 'react';
 
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
 
-import { Icon }  from 'mastodon/components/icon';
+import { Icon } from 'mastodon/components/icon';
 
 const tooltips = defineMessages({
   mentions: { id: 'notifications.filter.mentions', defaultMessage: 'Mentions' },
-  favourites: { id: 'notifications.filter.favourites', defaultMessage: 'Favorites' },
+  favourites: {
+    id: 'notifications.filter.favourites',
+    defaultMessage: 'Favorites',
+  },
   boosts: { id: 'notifications.filter.boosts', defaultMessage: 'Boosts' },
   polls: { id: 'notifications.filter.polls', defaultMessage: 'Poll results' },
   follows: { id: 'notifications.filter.follows', defaultMessage: 'Follows' },
-  statuses: { id: 'notifications.filter.statuses', defaultMessage: 'Updates from people you follow' },
+  statuses: {
+    id: 'notifications.filter.statuses',
+    defaultMessage: 'Updates from people you follow',
+  },
 });
 
 class FilterBar extends PureComponent {
-
   static propTypes = {
     selectFilter: PropTypes.func.isRequired,
     selectedFilter: PropTypes.string.isRequired,
@@ -23,11 +28,11 @@ class FilterBar extends PureComponent {
     intl: PropTypes.object.isRequired,
   };
 
-  onClick (notificationType) {
+  onClick(notificationType) {
     return () => this.props.selectFilter(notificationType);
   }
 
-  render () {
+  render() {
     const { selectedFilter, advancedMode, intl } = this.props;
     const renderedElement = !advancedMode ? (
       <div className='notification__filter-bar'>
@@ -107,7 +112,6 @@ class FilterBar extends PureComponent {
     );
     return renderedElement;
   }
-
 }
 
 export default injectIntl(FilterBar);

--- a/app/javascript/mastodon/features/notifications/components/follow_request.jsx
+++ b/app/javascript/mastodon/features/notifications/components/follow_request.jsx
@@ -17,7 +17,6 @@ const messages = defineMessages({
 });
 
 class FollowRequest extends ImmutablePureComponent {
-
   static propTypes = {
     account: ImmutablePropTypes.map.isRequired,
     onAuthorize: PropTypes.func.isRequired,
@@ -25,7 +24,7 @@ class FollowRequest extends ImmutablePureComponent {
     intl: PropTypes.object.isRequired,
   };
 
-  render () {
+  render() {
     const { intl, hidden, account, onAuthorize, onReject } = this.props;
 
     if (!account) {
@@ -44,20 +43,34 @@ class FollowRequest extends ImmutablePureComponent {
     return (
       <div className='account'>
         <div className='account__wrapper'>
-          <Link key={account.get('id')} className='account__display-name' title={account.get('acct')} to={`/@${account.get('acct')}`}>
-            <div className='account__avatar-wrapper'><Avatar account={account} size={36} /></div>
+          <Link
+            key={account.get('id')}
+            className='account__display-name'
+            title={account.get('acct')}
+            to={`/@${account.get('acct')}`}
+          >
+            <div className='account__avatar-wrapper'>
+              <Avatar account={account} size={36} />
+            </div>
             <DisplayName account={account} />
           </Link>
 
           <div className='account__relationship'>
-            <IconButton title={intl.formatMessage(messages.authorize)} icon='check' onClick={onAuthorize} />
-            <IconButton title={intl.formatMessage(messages.reject)} icon='times' onClick={onReject} />
+            <IconButton
+              title={intl.formatMessage(messages.authorize)}
+              icon='check'
+              onClick={onAuthorize}
+            />
+            <IconButton
+              title={intl.formatMessage(messages.reject)}
+              icon='times'
+              onClick={onReject}
+            />
           </div>
         </div>
       </div>
     );
   }
-
 }
 
 export default injectIntl(FollowRequest);

--- a/app/javascript/mastodon/features/notifications/components/grant_permission_button.jsx
+++ b/app/javascript/mastodon/features/notifications/components/grant_permission_button.jsx
@@ -4,17 +4,22 @@ import { PureComponent } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 export default class GrantPermissionButton extends PureComponent {
-
   static propTypes = {
     onClick: PropTypes.func.isRequired,
   };
 
-  render () {
+  render() {
     return (
-      <button className='text-btn column-header__permission-btn' tabIndex={0} onClick={this.props.onClick}>
-        <FormattedMessage id='notifications.grant_permission' defaultMessage='Grant permission.' />
+      <button
+        className='text-btn column-header__permission-btn'
+        tabIndex={0}
+        onClick={this.props.onClick}
+      >
+        <FormattedMessage
+          id='notifications.grant_permission'
+          defaultMessage='Grant permission.'
+        />
       </button>
     );
   }
-
 }

--- a/app/javascript/mastodon/features/notifications/components/notification.jsx
+++ b/app/javascript/mastodon/features/notifications/components/notification.jsx
@@ -10,7 +10,7 @@ import ImmutablePureComponent from 'react-immutable-pure-component';
 
 import { HotKeys } from 'react-hotkeys';
 
-import { Icon }  from 'mastodon/components/icon';
+import { Icon } from 'mastodon/components/icon';
 import AccountContainer from 'mastodon/containers/account_container';
 import StatusContainer from 'mastodon/containers/status_container';
 import { me } from 'mastodon/initial_state';
@@ -20,27 +20,51 @@ import FollowRequestContainer from '../containers/follow_request_container';
 import Report from './report';
 
 const messages = defineMessages({
-  favourite: { id: 'notification.favourite', defaultMessage: '{name} favorited your status' },
+  favourite: {
+    id: 'notification.favourite',
+    defaultMessage: '{name} favorited your status',
+  },
   follow: { id: 'notification.follow', defaultMessage: '{name} followed you' },
-  ownPoll: { id: 'notification.own_poll', defaultMessage: 'Your poll has ended' },
-  poll: { id: 'notification.poll', defaultMessage: 'A poll you have voted in has ended' },
-  reblog: { id: 'notification.reblog', defaultMessage: '{name} boosted your status' },
+  ownPoll: {
+    id: 'notification.own_poll',
+    defaultMessage: 'Your poll has ended',
+  },
+  poll: {
+    id: 'notification.poll',
+    defaultMessage: 'A poll you have voted in has ended',
+  },
+  reblog: {
+    id: 'notification.reblog',
+    defaultMessage: '{name} boosted your status',
+  },
   status: { id: 'notification.status', defaultMessage: '{name} just posted' },
   update: { id: 'notification.update', defaultMessage: '{name} edited a post' },
-  adminSignUp: { id: 'notification.admin.sign_up', defaultMessage: '{name} signed up' },
-  adminReport: { id: 'notification.admin.report', defaultMessage: '{name} reported {target}' },
+  adminSignUp: {
+    id: 'notification.admin.sign_up',
+    defaultMessage: '{name} signed up',
+  },
+  adminReport: {
+    id: 'notification.admin.report',
+    defaultMessage: '{name} reported {target}',
+  },
 });
 
 const notificationForScreenReader = (intl, message, timestamp) => {
   const output = [message];
 
-  output.push(intl.formatDate(timestamp, { hour: '2-digit', minute: '2-digit', month: 'short', day: 'numeric' }));
+  output.push(
+    intl.formatDate(timestamp, {
+      hour: '2-digit',
+      minute: '2-digit',
+      month: 'short',
+      day: 'numeric',
+    }),
+  );
 
   return output.join(', ');
 };
 
 class Notification extends ImmutablePureComponent {
-
   static contextTypes = {
     router: PropTypes.object,
   };
@@ -77,7 +101,13 @@ class Notification extends ImmutablePureComponent {
     const { notification } = this.props;
 
     if (notification.get('status')) {
-      this.context.router.history.push(`/@${notification.getIn(['status', 'account', 'acct'])}/${notification.get('status')}`);
+      this.context.router.history.push(
+        `/@${notification.getIn([
+          'status',
+          'account',
+          'acct',
+        ])}/${notification.get('status')}`,
+      );
     } else {
       this.handleOpenProfile();
     }
@@ -85,10 +115,12 @@ class Notification extends ImmutablePureComponent {
 
   handleOpenProfile = () => {
     const { notification } = this.props;
-    this.context.router.history.push(`/@${notification.getIn(['account', 'acct'])}`);
+    this.context.router.history.push(
+      `/@${notification.getIn(['account', 'acct'])}`,
+    );
   };
 
-  handleMention = e => {
+  handleMention = (e) => {
     e.preventDefault();
 
     const { notification, onMention } = this.props;
@@ -100,7 +132,7 @@ class Notification extends ImmutablePureComponent {
     if (status) this.props.onFavourite(status);
   };
 
-  handleHotkeyBoost = e => {
+  handleHotkeyBoost = (e) => {
     const { status } = this.props;
     if (status) this.props.onReblog(status, e);
   };
@@ -110,7 +142,7 @@ class Notification extends ImmutablePureComponent {
     if (status) this.props.onToggleHidden(status);
   };
 
-  getHandlers () {
+  getHandlers() {
     return {
       reply: this.handleMention,
       favourite: this.handleHotkeyFavourite,
@@ -124,19 +156,33 @@ class Notification extends ImmutablePureComponent {
     };
   }
 
-  renderFollow (notification, account, link) {
+  renderFollow(notification, account, link) {
     const { intl, unread } = this.props;
 
     return (
       <HotKeys handlers={this.getHandlers()}>
-        <div className={classNames('notification notification-follow focusable', { unread })} tabIndex={0} aria-label={notificationForScreenReader(intl, intl.formatMessage(messages.follow, { name: account.get('acct') }), notification.get('created_at'))}>
+        <div
+          className={classNames('notification notification-follow focusable', {
+            unread,
+          })}
+          tabIndex={0}
+          aria-label={notificationForScreenReader(
+            intl,
+            intl.formatMessage(messages.follow, { name: account.get('acct') }),
+            notification.get('created_at'),
+          )}
+        >
           <div className='notification__message'>
             <div className='notification__favourite-icon-wrapper'>
               <Icon id='user-plus' fixedWidth />
             </div>
 
             <span title={notification.get('created_at')}>
-              <FormattedMessage id='notification.follow' defaultMessage='{name} followed you' values={{ name: link }} />
+              <FormattedMessage
+                id='notification.follow'
+                defaultMessage='{name} followed you'
+                values={{ name: link }}
+              />
             </span>
           </div>
 
@@ -146,29 +192,54 @@ class Notification extends ImmutablePureComponent {
     );
   }
 
-  renderFollowRequest (notification, account, link) {
+  renderFollowRequest(notification, account, link) {
     const { intl, unread } = this.props;
 
     return (
       <HotKeys handlers={this.getHandlers()}>
-        <div className={classNames('notification notification-follow-request focusable', { unread })} tabIndex={0} aria-label={notificationForScreenReader(intl, intl.formatMessage({ id: 'notification.follow_request', defaultMessage: '{name} has requested to follow you' }, { name: account.get('acct') }), notification.get('created_at'))}>
+        <div
+          className={classNames(
+            'notification notification-follow-request focusable',
+            { unread },
+          )}
+          tabIndex={0}
+          aria-label={notificationForScreenReader(
+            intl,
+            intl.formatMessage(
+              {
+                id: 'notification.follow_request',
+                defaultMessage: '{name} has requested to follow you',
+              },
+              { name: account.get('acct') },
+            ),
+            notification.get('created_at'),
+          )}
+        >
           <div className='notification__message'>
             <div className='notification__favourite-icon-wrapper'>
               <Icon id='user' fixedWidth />
             </div>
 
             <span title={notification.get('created_at')}>
-              <FormattedMessage id='notification.follow_request' defaultMessage='{name} has requested to follow you' values={{ name: link }} />
+              <FormattedMessage
+                id='notification.follow_request'
+                defaultMessage='{name} has requested to follow you'
+                values={{ name: link }}
+              />
             </span>
           </div>
 
-          <FollowRequestContainer id={account.get('id')} withNote={false} hidden={this.props.hidden} />
+          <FollowRequestContainer
+            id={account.get('id')}
+            withNote={false}
+            hidden={this.props.hidden}
+          />
         </div>
       </HotKeys>
     );
   }
 
-  renderMention (notification) {
+  renderMention(notification) {
     return (
       <StatusContainer
         id={notification.get('status')}
@@ -186,19 +257,36 @@ class Notification extends ImmutablePureComponent {
     );
   }
 
-  renderFavourite (notification, link) {
+  renderFavourite(notification, link) {
     const { intl, unread } = this.props;
 
     return (
       <HotKeys handlers={this.getHandlers()}>
-        <div className={classNames('notification notification-favourite focusable', { unread })} tabIndex={0} aria-label={notificationForScreenReader(intl, intl.formatMessage(messages.favourite, { name: notification.getIn(['account', 'acct']) }), notification.get('created_at'))}>
+        <div
+          className={classNames(
+            'notification notification-favourite focusable',
+            { unread },
+          )}
+          tabIndex={0}
+          aria-label={notificationForScreenReader(
+            intl,
+            intl.formatMessage(messages.favourite, {
+              name: notification.getIn(['account', 'acct']),
+            }),
+            notification.get('created_at'),
+          )}
+        >
           <div className='notification__message'>
             <div className='notification__favourite-icon-wrapper'>
               <Icon id='star' className='star-icon' fixedWidth />
             </div>
 
             <span title={notification.get('created_at')}>
-              <FormattedMessage id='notification.favourite' defaultMessage='{name} favorited your status' values={{ name: link }} />
+              <FormattedMessage
+                id='notification.favourite'
+                defaultMessage='{name} favorited your status'
+                values={{ name: link }}
+              />
             </span>
           </div>
 
@@ -218,19 +306,35 @@ class Notification extends ImmutablePureComponent {
     );
   }
 
-  renderReblog (notification, link) {
+  renderReblog(notification, link) {
     const { intl, unread } = this.props;
 
     return (
       <HotKeys handlers={this.getHandlers()}>
-        <div className={classNames('notification notification-reblog focusable', { unread })} tabIndex={0} aria-label={notificationForScreenReader(intl, intl.formatMessage(messages.reblog, { name: notification.getIn(['account', 'acct']) }), notification.get('created_at'))}>
+        <div
+          className={classNames('notification notification-reblog focusable', {
+            unread,
+          })}
+          tabIndex={0}
+          aria-label={notificationForScreenReader(
+            intl,
+            intl.formatMessage(messages.reblog, {
+              name: notification.getIn(['account', 'acct']),
+            }),
+            notification.get('created_at'),
+          )}
+        >
           <div className='notification__message'>
             <div className='notification__favourite-icon-wrapper'>
               <Icon id='retweet' fixedWidth />
             </div>
 
             <span title={notification.get('created_at')}>
-              <FormattedMessage id='notification.reblog' defaultMessage='{name} boosted your status' values={{ name: link }} />
+              <FormattedMessage
+                id='notification.reblog'
+                defaultMessage='{name} boosted your status'
+                values={{ name: link }}
+              />
             </span>
           </div>
 
@@ -250,7 +354,7 @@ class Notification extends ImmutablePureComponent {
     );
   }
 
-  renderStatus (notification, link) {
+  renderStatus(notification, link) {
     const { intl, unread, status } = this.props;
 
     if (!status) {
@@ -259,14 +363,30 @@ class Notification extends ImmutablePureComponent {
 
     return (
       <HotKeys handlers={this.getHandlers()}>
-        <div className={classNames('notification notification-status focusable', { unread })} tabIndex={0} aria-label={notificationForScreenReader(intl, intl.formatMessage(messages.status, { name: notification.getIn(['account', 'acct']) }), notification.get('created_at'))}>
+        <div
+          className={classNames('notification notification-status focusable', {
+            unread,
+          })}
+          tabIndex={0}
+          aria-label={notificationForScreenReader(
+            intl,
+            intl.formatMessage(messages.status, {
+              name: notification.getIn(['account', 'acct']),
+            }),
+            notification.get('created_at'),
+          )}
+        >
           <div className='notification__message'>
             <div className='notification__favourite-icon-wrapper'>
               <Icon id='home' fixedWidth />
             </div>
 
             <span title={notification.get('created_at')}>
-              <FormattedMessage id='notification.status' defaultMessage='{name} just posted' values={{ name: link }} />
+              <FormattedMessage
+                id='notification.status'
+                defaultMessage='{name} just posted'
+                values={{ name: link }}
+              />
             </span>
           </div>
 
@@ -287,7 +407,7 @@ class Notification extends ImmutablePureComponent {
     );
   }
 
-  renderUpdate (notification, link) {
+  renderUpdate(notification, link) {
     const { intl, unread, status } = this.props;
 
     if (!status) {
@@ -296,14 +416,30 @@ class Notification extends ImmutablePureComponent {
 
     return (
       <HotKeys handlers={this.getHandlers()}>
-        <div className={classNames('notification notification-update focusable', { unread })} tabIndex={0} aria-label={notificationForScreenReader(intl, intl.formatMessage(messages.update, { name: notification.getIn(['account', 'acct']) }), notification.get('created_at'))}>
+        <div
+          className={classNames('notification notification-update focusable', {
+            unread,
+          })}
+          tabIndex={0}
+          aria-label={notificationForScreenReader(
+            intl,
+            intl.formatMessage(messages.update, {
+              name: notification.getIn(['account', 'acct']),
+            }),
+            notification.get('created_at'),
+          )}
+        >
           <div className='notification__message'>
             <div className='notification__favourite-icon-wrapper'>
               <Icon id='pencil' fixedWidth />
             </div>
 
             <span title={notification.get('created_at')}>
-              <FormattedMessage id='notification.update' defaultMessage='{name} edited a post' values={{ name: link }} />
+              <FormattedMessage
+                id='notification.update'
+                defaultMessage='{name} edited a post'
+                values={{ name: link }}
+              />
             </span>
           </div>
 
@@ -324,10 +460,12 @@ class Notification extends ImmutablePureComponent {
     );
   }
 
-  renderPoll (notification, account) {
+  renderPoll(notification, account) {
     const { intl, unread, status } = this.props;
-    const ownPoll  = me === account.get('id');
-    const message  = ownPoll ? intl.formatMessage(messages.ownPoll) : intl.formatMessage(messages.poll);
+    const ownPoll = me === account.get('id');
+    const message = ownPoll
+      ? intl.formatMessage(messages.ownPoll)
+      : intl.formatMessage(messages.poll);
 
     if (!status) {
       return null;
@@ -335,7 +473,17 @@ class Notification extends ImmutablePureComponent {
 
     return (
       <HotKeys handlers={this.getHandlers()}>
-        <div className={classNames('notification notification-poll focusable', { unread })} tabIndex={0} aria-label={notificationForScreenReader(intl, message, notification.get('created_at'))}>
+        <div
+          className={classNames('notification notification-poll focusable', {
+            unread,
+          })}
+          tabIndex={0}
+          aria-label={notificationForScreenReader(
+            intl,
+            message,
+            notification.get('created_at'),
+          )}
+        >
           <div className='notification__message'>
             <div className='notification__favourite-icon-wrapper'>
               <Icon id='tasks' fixedWidth />
@@ -343,9 +491,15 @@ class Notification extends ImmutablePureComponent {
 
             <span title={notification.get('created_at')}>
               {ownPoll ? (
-                <FormattedMessage id='notification.own_poll' defaultMessage='Your poll has ended' />
+                <FormattedMessage
+                  id='notification.own_poll'
+                  defaultMessage='Your poll has ended'
+                />
               ) : (
-                <FormattedMessage id='notification.poll' defaultMessage='A poll you have voted in has ended' />
+                <FormattedMessage
+                  id='notification.poll'
+                  defaultMessage='A poll you have voted in has ended'
+                />
               )}
             </span>
           </div>
@@ -367,19 +521,36 @@ class Notification extends ImmutablePureComponent {
     );
   }
 
-  renderAdminSignUp (notification, account, link) {
+  renderAdminSignUp(notification, account, link) {
     const { intl, unread } = this.props;
 
     return (
       <HotKeys handlers={this.getHandlers()}>
-        <div className={classNames('notification notification-admin-sign-up focusable', { unread })} tabIndex={0} aria-label={notificationForScreenReader(intl, intl.formatMessage(messages.adminSignUp, { name: account.get('acct') }), notification.get('created_at'))}>
+        <div
+          className={classNames(
+            'notification notification-admin-sign-up focusable',
+            { unread },
+          )}
+          tabIndex={0}
+          aria-label={notificationForScreenReader(
+            intl,
+            intl.formatMessage(messages.adminSignUp, {
+              name: account.get('acct'),
+            }),
+            notification.get('created_at'),
+          )}
+        >
           <div className='notification__message'>
             <div className='notification__favourite-icon-wrapper'>
               <Icon id='user-plus' fixedWidth />
             </div>
 
             <span title={notification.get('created_at')}>
-              <FormattedMessage id='notification.admin.sign_up' defaultMessage='{name} signed up' values={{ name: link }} />
+              <FormattedMessage
+                id='notification.admin.sign_up'
+                defaultMessage='{name} signed up'
+                values={{ name: link }}
+              />
             </span>
           </div>
 
@@ -389,7 +560,7 @@ class Notification extends ImmutablePureComponent {
     );
   }
 
-  renderAdminReport (notification, account, link) {
+  renderAdminReport(notification, account, link) {
     const { intl, unread, report } = this.props;
 
     if (!report) {
@@ -397,60 +568,102 @@ class Notification extends ImmutablePureComponent {
     }
 
     const targetAccount = report.get('target_account');
-    const targetDisplayNameHtml = { __html: targetAccount.get('display_name_html') };
-    const targetLink = <bdi><Link className='notification__display-name' title={targetAccount.get('acct')} to={`/@${targetAccount.get('acct')}`} dangerouslySetInnerHTML={targetDisplayNameHtml} /></bdi>;
+    const targetDisplayNameHtml = {
+      __html: targetAccount.get('display_name_html'),
+    };
+    const targetLink = (
+      <bdi>
+        <Link
+          className='notification__display-name'
+          title={targetAccount.get('acct')}
+          to={`/@${targetAccount.get('acct')}`}
+          dangerouslySetInnerHTML={targetDisplayNameHtml}
+        />
+      </bdi>
+    );
 
     return (
       <HotKeys handlers={this.getHandlers()}>
-        <div className={classNames('notification notification-admin-report focusable', { unread })} tabIndex={0} aria-label={notificationForScreenReader(intl, intl.formatMessage(messages.adminReport, { name: account.get('acct'), target: notification.getIn(['report', 'target_account', 'acct']) }), notification.get('created_at'))}>
+        <div
+          className={classNames(
+            'notification notification-admin-report focusable',
+            { unread },
+          )}
+          tabIndex={0}
+          aria-label={notificationForScreenReader(
+            intl,
+            intl.formatMessage(messages.adminReport, {
+              name: account.get('acct'),
+              target: notification.getIn(['report', 'target_account', 'acct']),
+            }),
+            notification.get('created_at'),
+          )}
+        >
           <div className='notification__message'>
             <div className='notification__favourite-icon-wrapper'>
               <Icon id='flag' fixedWidth />
             </div>
 
             <span title={notification.get('created_at')}>
-              <FormattedMessage id='notification.admin.report' defaultMessage='{name} reported {target}' values={{ name: link, target: targetLink }} />
+              <FormattedMessage
+                id='notification.admin.report'
+                defaultMessage='{name} reported {target}'
+                values={{ name: link, target: targetLink }}
+              />
             </span>
           </div>
 
-          <Report account={account} report={notification.get('report')} hidden={this.props.hidden} />
+          <Report
+            account={account}
+            report={notification.get('report')}
+            hidden={this.props.hidden}
+          />
         </div>
       </HotKeys>
     );
   }
 
-  render () {
+  render() {
     const { notification } = this.props;
-    const account          = notification.get('account');
-    const displayNameHtml  = { __html: account.get('display_name_html') };
-    const link             = <bdi><Link className='notification__display-name' href={`/@${account.get('acct')}`} title={account.get('acct')} to={`/@${account.get('acct')}`} dangerouslySetInnerHTML={displayNameHtml} /></bdi>;
+    const account = notification.get('account');
+    const displayNameHtml = { __html: account.get('display_name_html') };
+    const link = (
+      <bdi>
+        <Link
+          className='notification__display-name'
+          href={`/@${account.get('acct')}`}
+          title={account.get('acct')}
+          to={`/@${account.get('acct')}`}
+          dangerouslySetInnerHTML={displayNameHtml}
+        />
+      </bdi>
+    );
 
-    switch(notification.get('type')) {
-    case 'follow':
-      return this.renderFollow(notification, account, link);
-    case 'follow_request':
-      return this.renderFollowRequest(notification, account, link);
-    case 'mention':
-      return this.renderMention(notification);
-    case 'favourite':
-      return this.renderFavourite(notification, link);
-    case 'reblog':
-      return this.renderReblog(notification, link);
-    case 'status':
-      return this.renderStatus(notification, link);
-    case 'update':
-      return this.renderUpdate(notification, link);
-    case 'poll':
-      return this.renderPoll(notification, account);
-    case 'admin.sign_up':
-      return this.renderAdminSignUp(notification, account, link);
-    case 'admin.report':
-      return this.renderAdminReport(notification, account, link);
+    switch (notification.get('type')) {
+      case 'follow':
+        return this.renderFollow(notification, account, link);
+      case 'follow_request':
+        return this.renderFollowRequest(notification, account, link);
+      case 'mention':
+        return this.renderMention(notification);
+      case 'favourite':
+        return this.renderFavourite(notification, link);
+      case 'reblog':
+        return this.renderReblog(notification, link);
+      case 'status':
+        return this.renderStatus(notification, link);
+      case 'update':
+        return this.renderUpdate(notification, link);
+      case 'poll':
+        return this.renderPoll(notification, account);
+      case 'admin.sign_up':
+        return this.renderAdminSignUp(notification, account, link);
+      case 'admin.report':
+        return this.renderAdminReport(notification, account, link);
     }
 
     return null;
   }
-
 }
 
 export default injectIntl(Notification);

--- a/app/javascript/mastodon/features/notifications/components/notifications_permission_banner.jsx
+++ b/app/javascript/mastodon/features/notifications/components/notifications_permission_banner.jsx
@@ -8,7 +8,7 @@ import { connect } from 'react-redux';
 import { requestBrowserPermission } from 'mastodon/actions/notifications';
 import { changeSetting } from 'mastodon/actions/settings';
 import Button from 'mastodon/components/button';
-import { Icon }  from 'mastodon/components/icon';
+import { Icon } from 'mastodon/components/icon';
 import { IconButton } from 'mastodon/components/icon_button';
 
 const messages = defineMessages({
@@ -16,7 +16,6 @@ const messages = defineMessages({
 });
 
 class NotificationsPermissionBanner extends PureComponent {
-
   static propTypes = {
     dispatch: PropTypes.func.isRequired,
     intl: PropTypes.object.isRequired,
@@ -27,25 +26,46 @@ class NotificationsPermissionBanner extends PureComponent {
   };
 
   handleClose = () => {
-    this.props.dispatch(changeSetting(['notifications', 'dismissPermissionBanner'], true));
+    this.props.dispatch(
+      changeSetting(['notifications', 'dismissPermissionBanner'], true),
+    );
   };
 
-  render () {
+  render() {
     const { intl } = this.props;
 
     return (
       <div className='notifications-permission-banner'>
         <div className='notifications-permission-banner__close'>
-          <IconButton icon='times' onClick={this.handleClose} title={intl.formatMessage(messages.close)} />
+          <IconButton
+            icon='times'
+            onClick={this.handleClose}
+            title={intl.formatMessage(messages.close)}
+          />
         </div>
 
-        <h2><FormattedMessage id='notifications_permission_banner.title' defaultMessage='Never miss a thing' /></h2>
-        <p><FormattedMessage id='notifications_permission_banner.how_to_control' defaultMessage="To receive notifications when Mastodon isn't open, enable desktop notifications. You can control precisely which types of interactions generate desktop notifications through the {icon} button above once they're enabled." values={{ icon: <Icon id='sliders' /> }} /></p>
-        <Button onClick={this.handleClick}><FormattedMessage id='notifications_permission_banner.enable' defaultMessage='Enable desktop notifications' /></Button>
+        <h2>
+          <FormattedMessage
+            id='notifications_permission_banner.title'
+            defaultMessage='Never miss a thing'
+          />
+        </h2>
+        <p>
+          <FormattedMessage
+            id='notifications_permission_banner.how_to_control'
+            defaultMessage="To receive notifications when Mastodon isn't open, enable desktop notifications. You can control precisely which types of interactions generate desktop notifications through the {icon} button above once they're enabled."
+            values={{ icon: <Icon id='sliders' /> }}
+          />
+        </p>
+        <Button onClick={this.handleClick}>
+          <FormattedMessage
+            id='notifications_permission_banner.enable'
+            defaultMessage='Enable desktop notifications'
+          />
+        </Button>
       </div>
     );
   }
-
 }
 
 export default connect()(injectIntl(NotificationsPermissionBanner));

--- a/app/javascript/mastodon/features/notifications/components/report.jsx
+++ b/app/javascript/mastodon/features/notifications/components/report.jsx
@@ -11,14 +11,22 @@ import { RelativeTimestamp } from 'mastodon/components/relative_timestamp';
 // This needs to be kept in sync with app/models/report.rb
 const messages = defineMessages({
   openReport: { id: 'report_notification.open', defaultMessage: 'Open report' },
-  other: { id: 'report_notification.categories.other', defaultMessage: 'Other' },
+  other: {
+    id: 'report_notification.categories.other',
+    defaultMessage: 'Other',
+  },
   spam: { id: 'report_notification.categories.spam', defaultMessage: 'Spam' },
-  legal: { id: 'report_notification.categories.legal', defaultMessage: 'Legal' },
-  violation: { id: 'report_notification.categories.violation', defaultMessage: 'Rule violation' },
+  legal: {
+    id: 'report_notification.categories.legal',
+    defaultMessage: 'Legal',
+  },
+  violation: {
+    id: 'report_notification.categories.violation',
+    defaultMessage: 'Rule violation',
+  },
 });
 
 class Report extends ImmutablePureComponent {
-
   static propTypes = {
     account: ImmutablePropTypes.map.isRequired,
     report: ImmutablePropTypes.map.isRequired,
@@ -26,7 +34,7 @@ class Report extends ImmutablePureComponent {
     intl: PropTypes.object.isRequired,
   };
 
-  render () {
+  render() {
     const { intl, hidden, report, account } = this.props;
 
     if (!report) {
@@ -34,34 +42,50 @@ class Report extends ImmutablePureComponent {
     }
 
     if (hidden) {
-      return (
-        <>
-          {report.get('id')}
-        </>
-      );
+      return <>{report.get('id')}</>;
     }
 
     return (
       <div className='notification__report'>
         <div className='notification__report__avatar'>
-          <AvatarOverlay account={report.get('target_account')} friend={account} />
+          <AvatarOverlay
+            account={report.get('target_account')}
+            friend={account}
+          />
         </div>
 
         <div className='notification__report__details'>
           <div>
-            <RelativeTimestamp timestamp={report.get('created_at')} short={false} /> · <FormattedMessage id='report_notification.attached_statuses' defaultMessage='{count, plural, one {# post} other {# posts}} attached' values={{ count: report.get('status_ids').size }} />
+            <RelativeTimestamp
+              timestamp={report.get('created_at')}
+              short={false}
+            />{' '}
+            ·{' '}
+            <FormattedMessage
+              id='report_notification.attached_statuses'
+              defaultMessage='{count, plural, one {# post} other {# posts}} attached'
+              values={{ count: report.get('status_ids').size }}
+            />
             <br />
-            <strong>{intl.formatMessage(messages[report.get('category')])}</strong>
+            <strong>
+              {intl.formatMessage(messages[report.get('category')])}
+            </strong>
           </div>
 
           <div className='notification__report__actions'>
-            <a href={`/admin/reports/${report.get('id')}`} className='button' target='_blank' rel='noopener noreferrer'>{intl.formatMessage(messages.openReport)}</a>
+            <a
+              href={`/admin/reports/${report.get('id')}`}
+              className='button'
+              target='_blank'
+              rel='noopener noreferrer'
+            >
+              {intl.formatMessage(messages.openReport)}
+            </a>
           </div>
         </div>
       </div>
     );
   }
-
 }
 
 export default injectIntl(Report);

--- a/app/javascript/mastodon/features/notifications/components/setting_toggle.jsx
+++ b/app/javascript/mastodon/features/notifications/components/setting_toggle.jsx
@@ -6,7 +6,6 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import Toggle from 'react-toggle';
 
 export default class SettingToggle extends PureComponent {
-
   static propTypes = {
     prefix: PropTypes.string,
     settings: ImmutablePropTypes.map.isRequired,
@@ -21,16 +20,26 @@ export default class SettingToggle extends PureComponent {
     this.props.onChange(this.props.settingPath, target.checked);
   };
 
-  render () {
-    const { prefix, settings, settingPath, label, defaultValue, disabled } = this.props;
-    const id = ['setting-toggle', prefix, ...settingPath].filter(Boolean).join('-');
+  render() {
+    const { prefix, settings, settingPath, label, defaultValue, disabled } =
+      this.props;
+    const id = ['setting-toggle', prefix, ...settingPath]
+      .filter(Boolean)
+      .join('-');
 
     return (
       <div className='setting-toggle'>
-        <Toggle disabled={disabled} id={id} checked={settings.getIn(settingPath, defaultValue)} onChange={this.onChange} onKeyDown={this.onKeyDown} />
-        <label htmlFor={id} className='setting-toggle__label'>{label}</label>
+        <Toggle
+          disabled={disabled}
+          id={id}
+          checked={settings.getIn(settingPath, defaultValue)}
+          onChange={this.onChange}
+          onKeyDown={this.onKeyDown}
+        />
+        <label htmlFor={id} className='setting-toggle__label'>
+          {label}
+        </label>
       </div>
     );
   }
-
 }

--- a/app/javascript/mastodon/features/notifications/containers/column_settings_container.js
+++ b/app/javascript/mastodon/features/notifications/containers/column_settings_container.js
@@ -4,52 +4,85 @@ import { connect } from 'react-redux';
 
 import { showAlert } from '../../../actions/alerts';
 import { openModal } from '../../../actions/modal';
-import { setFilter, clearNotifications, requestBrowserPermission } from '../../../actions/notifications';
+import {
+  setFilter,
+  clearNotifications,
+  requestBrowserPermission,
+} from '../../../actions/notifications';
 import { changeAlerts as changePushNotifications } from '../../../actions/push_notifications';
 import { changeSetting } from '../../../actions/settings';
 import ColumnSettings from '../components/column_settings';
 
 const messages = defineMessages({
-  clearMessage: { id: 'notifications.clear_confirmation', defaultMessage: 'Are you sure you want to permanently clear all your notifications?' },
-  clearConfirm: { id: 'notifications.clear', defaultMessage: 'Clear notifications' },
-  permissionDenied: { id: 'notifications.permission_denied_alert', defaultMessage: 'Desktop notifications can\'t be enabled, as browser permission has been denied before' },
+  clearMessage: {
+    id: 'notifications.clear_confirmation',
+    defaultMessage:
+      'Are you sure you want to permanently clear all your notifications?',
+  },
+  clearConfirm: {
+    id: 'notifications.clear',
+    defaultMessage: 'Clear notifications',
+  },
+  permissionDenied: {
+    id: 'notifications.permission_denied_alert',
+    defaultMessage:
+      "Desktop notifications can't be enabled, as browser permission has been denied before",
+  },
 });
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   settings: state.getIn(['settings', 'notifications']),
   pushSettings: state.get('push_notifications'),
-  alertsEnabled: state.getIn(['settings', 'notifications', 'alerts']).includes(true),
+  alertsEnabled: state
+    .getIn(['settings', 'notifications', 'alerts'])
+    .includes(true),
   browserSupport: state.getIn(['notifications', 'browserSupport']),
   browserPermission: state.getIn(['notifications', 'browserPermission']),
 });
 
 const mapDispatchToProps = (dispatch, { intl }) => ({
-
-  onChange (path, checked) {
+  onChange(path, checked) {
     if (path[0] === 'push') {
-      if (checked && typeof window.Notification !== 'undefined' && Notification.permission !== 'granted') {
-        dispatch(requestBrowserPermission((permission) => {
-          if (permission === 'granted') {
-            dispatch(changePushNotifications(path.slice(1), checked));
-          } else {
-            dispatch(showAlert({ message: messages.permissionDenied }));
-          }
-        }));
+      if (
+        checked &&
+        typeof window.Notification !== 'undefined' &&
+        Notification.permission !== 'granted'
+      ) {
+        dispatch(
+          requestBrowserPermission((permission) => {
+            if (permission === 'granted') {
+              dispatch(changePushNotifications(path.slice(1), checked));
+            } else {
+              dispatch(showAlert({ message: messages.permissionDenied }));
+            }
+          }),
+        );
       } else {
         dispatch(changePushNotifications(path.slice(1), checked));
       }
     } else if (path[0] === 'quickFilter') {
       dispatch(changeSetting(['notifications', ...path], checked));
       dispatch(setFilter('all'));
-    } else if (path[0] === 'alerts' && checked && typeof window.Notification !== 'undefined' && Notification.permission !== 'granted') {
-      if (checked && typeof window.Notification !== 'undefined' && Notification.permission !== 'granted') {
-        dispatch(requestBrowserPermission((permission) => {
-          if (permission === 'granted') {
-            dispatch(changeSetting(['notifications', ...path], checked));
-          } else {
-            dispatch(showAlert({ message: messages.permissionDenied }));
-          }
-        }));
+    } else if (
+      path[0] === 'alerts' &&
+      checked &&
+      typeof window.Notification !== 'undefined' &&
+      Notification.permission !== 'granted'
+    ) {
+      if (
+        checked &&
+        typeof window.Notification !== 'undefined' &&
+        Notification.permission !== 'granted'
+      ) {
+        dispatch(
+          requestBrowserPermission((permission) => {
+            if (permission === 'granted') {
+              dispatch(changeSetting(['notifications', ...path], checked));
+            } else {
+              dispatch(showAlert({ message: messages.permissionDenied }));
+            }
+          }),
+        );
       } else {
         dispatch(changeSetting(['notifications', ...path], checked));
       }
@@ -58,21 +91,24 @@ const mapDispatchToProps = (dispatch, { intl }) => ({
     }
   },
 
-  onClear () {
-    dispatch(openModal({
-      modalType: 'CONFIRM',
-      modalProps: {
-        message: intl.formatMessage(messages.clearMessage),
-        confirm: intl.formatMessage(messages.clearConfirm),
-        onConfirm: () => dispatch(clearNotifications()),
-      },
-    }));
+  onClear() {
+    dispatch(
+      openModal({
+        modalType: 'CONFIRM',
+        modalProps: {
+          message: intl.formatMessage(messages.clearMessage),
+          confirm: intl.formatMessage(messages.clearConfirm),
+          onConfirm: () => dispatch(clearNotifications()),
+        },
+      }),
+    );
   },
 
-  onRequestNotificationPermission () {
+  onRequestNotificationPermission() {
     dispatch(requestBrowserPermission());
   },
-
 });
 
-export default injectIntl(connect(mapStateToProps, mapDispatchToProps)(ColumnSettings));
+export default injectIntl(
+  connect(mapStateToProps, mapDispatchToProps)(ColumnSettings),
+);

--- a/app/javascript/mastodon/features/notifications/containers/filter_bar_container.js
+++ b/app/javascript/mastodon/features/notifications/containers/filter_bar_container.js
@@ -3,13 +3,23 @@ import { connect } from 'react-redux';
 import { setFilter } from '../../../actions/notifications';
 import FilterBar from '../components/filter_bar';
 
-const makeMapStateToProps = state => ({
-  selectedFilter: state.getIn(['settings', 'notifications', 'quickFilter', 'active']),
-  advancedMode: state.getIn(['settings', 'notifications', 'quickFilter', 'advanced']),
+const makeMapStateToProps = (state) => ({
+  selectedFilter: state.getIn([
+    'settings',
+    'notifications',
+    'quickFilter',
+    'active',
+  ]),
+  advancedMode: state.getIn([
+    'settings',
+    'notifications',
+    'quickFilter',
+    'advanced',
+  ]),
 });
 
 const mapDispatchToProps = (dispatch) => ({
-  selectFilter (newActiveFilter) {
+  selectFilter(newActiveFilter) {
     dispatch(setFilter(newActiveFilter));
   },
 });

--- a/app/javascript/mastodon/features/notifications/containers/follow_request_container.js
+++ b/app/javascript/mastodon/features/notifications/containers/follow_request_container.js
@@ -1,6 +1,9 @@
 import { connect } from 'react-redux';
 
-import { authorizeFollowRequest, rejectFollowRequest } from 'mastodon/actions/accounts';
+import {
+  authorizeFollowRequest,
+  rejectFollowRequest,
+} from 'mastodon/actions/accounts';
 import { makeGetAccount } from 'mastodon/selectors';
 
 import FollowRequest from '../components/follow_request';
@@ -16,11 +19,11 @@ const makeMapStateToProps = () => {
 };
 
 const mapDispatchToProps = (dispatch, { id }) => ({
-  onAuthorize () {
+  onAuthorize() {
     dispatch(authorizeFollowRequest(id));
   },
 
-  onReject () {
+  onReject() {
     dispatch(rejectFollowRequest(id));
   },
 });

--- a/app/javascript/mastodon/features/notifications/containers/notification_container.js
+++ b/app/javascript/mastodon/features/notifications/containers/notification_container.js
@@ -8,12 +8,13 @@ import {
   unreblog,
   unfavourite,
 } from '../../../actions/interactions';
-import {
-  hideStatus,
-  revealStatus,
-} from '../../../actions/statuses';
+import { hideStatus, revealStatus } from '../../../actions/statuses';
 import { boostModal } from '../../../initial_state';
-import { makeGetNotification, makeGetStatus, makeGetReport } from '../../../selectors';
+import {
+  makeGetNotification,
+  makeGetStatus,
+  makeGetReport,
+} from '../../../selectors';
 import Notification from '../components/notification';
 
 const makeMapStateToProps = () => {
@@ -22,27 +23,42 @@ const makeMapStateToProps = () => {
   const getReport = makeGetReport();
 
   const mapStateToProps = (state, props) => {
-    const notification = getNotification(state, props.notification, props.accountId);
+    const notification = getNotification(
+      state,
+      props.notification,
+      props.accountId,
+    );
     return {
       notification: notification,
-      status: notification.get('status') ? getStatus(state, { id: notification.get('status'), contextType: 'notifications' }) : null,
-      report: notification.get('report') ? getReport(state, notification.get('report'), notification.getIn(['report', 'target_account', 'id'])) : null,
+      status: notification.get('status')
+        ? getStatus(state, {
+            id: notification.get('status'),
+            contextType: 'notifications',
+          })
+        : null,
+      report: notification.get('report')
+        ? getReport(
+            state,
+            notification.get('report'),
+            notification.getIn(['report', 'target_account', 'id']),
+          )
+        : null,
     };
   };
 
   return mapStateToProps;
 };
 
-const mapDispatchToProps = dispatch => ({
+const mapDispatchToProps = (dispatch) => ({
   onMention: (account, router) => {
     dispatch(mentionCompose(account, router));
   },
 
-  onModalReblog (status, privacy) {
+  onModalReblog(status, privacy) {
     dispatch(reblog(status, privacy));
   },
 
-  onReblog (status, e) {
+  onReblog(status, e) {
     if (status.get('reblogged')) {
       dispatch(unreblog(status));
     } else {
@@ -54,7 +70,7 @@ const mapDispatchToProps = dispatch => ({
     }
   },
 
-  onFavourite (status) {
+  onFavourite(status) {
     if (status.get('favourited')) {
       dispatch(unfavourite(status));
     } else {
@@ -62,7 +78,7 @@ const mapDispatchToProps = dispatch => ({
     }
   },
 
-  onToggleHidden (status) {
+  onToggleHidden(status) {
     if (status.get('hidden')) {
       dispatch(revealStatus(status.get('id')));
     } else {

--- a/app/javascript/mastodon/features/notifications/index.jsx
+++ b/app/javascript/mastodon/features/notifications/index.jsx
@@ -13,7 +13,7 @@ import { createSelector } from 'reselect';
 import { debounce } from 'lodash';
 
 import { compareId } from 'mastodon/compare_id';
-import { Icon }  from 'mastodon/components/icon';
+import { Icon } from 'mastodon/components/icon';
 import { NotSignedInIndicator } from 'mastodon/components/not_signed_in_indicator';
 
 import { addColumn, removeColumn, moveColumn } from '../../actions/columns';
@@ -38,44 +38,80 @@ import NotificationContainer from './containers/notification_container';
 
 const messages = defineMessages({
   title: { id: 'column.notifications', defaultMessage: 'Notifications' },
-  markAsRead : { id: 'notifications.mark_as_read', defaultMessage: 'Mark every notification as read' },
+  markAsRead: {
+    id: 'notifications.mark_as_read',
+    defaultMessage: 'Mark every notification as read',
+  },
 });
 
-const getExcludedTypes = createSelector([
-  state => state.getIn(['settings', 'notifications', 'shows']),
-], (shows) => {
-  return ImmutableList(shows.filter(item => !item).keys());
-});
+const getExcludedTypes = createSelector(
+  [(state) => state.getIn(['settings', 'notifications', 'shows'])],
+  (shows) => {
+    return ImmutableList(shows.filter((item) => !item).keys());
+  },
+);
 
-const getNotifications = createSelector([
-  state => state.getIn(['settings', 'notifications', 'quickFilter', 'show']),
-  state => state.getIn(['settings', 'notifications', 'quickFilter', 'active']),
-  getExcludedTypes,
-  state => state.getIn(['notifications', 'items']),
-], (showFilterBar, allowedType, excludedTypes, notifications) => {
-  if (!showFilterBar || allowedType === 'all') {
-    // used if user changed the notification settings after loading the notifications from the server
-    // otherwise a list of notifications will come pre-filtered from the backend
-    // we need to turn it off for FilterBar in order not to block ourselves from seeing a specific category
-    return notifications.filterNot(item => item !== null && excludedTypes.includes(item.get('type')));
-  }
-  return notifications.filter(item => item === null || allowedType === item.get('type'));
-});
+const getNotifications = createSelector(
+  [
+    (state) =>
+      state.getIn(['settings', 'notifications', 'quickFilter', 'show']),
+    (state) =>
+      state.getIn(['settings', 'notifications', 'quickFilter', 'active']),
+    getExcludedTypes,
+    (state) => state.getIn(['notifications', 'items']),
+  ],
+  (showFilterBar, allowedType, excludedTypes, notifications) => {
+    if (!showFilterBar || allowedType === 'all') {
+      // used if user changed the notification settings after loading the notifications from the server
+      // otherwise a list of notifications will come pre-filtered from the backend
+      // we need to turn it off for FilterBar in order not to block ourselves from seeing a specific category
+      return notifications.filterNot(
+        (item) => item !== null && excludedTypes.includes(item.get('type')),
+      );
+    }
+    return notifications.filter(
+      (item) => item === null || allowedType === item.get('type'),
+    );
+  },
+);
 
-const mapStateToProps = state => ({
-  showFilterBar: state.getIn(['settings', 'notifications', 'quickFilter', 'show']),
+const mapStateToProps = (state) => ({
+  showFilterBar: state.getIn([
+    'settings',
+    'notifications',
+    'quickFilter',
+    'show',
+  ]),
   notifications: getNotifications(state),
   isLoading: state.getIn(['notifications', 'isLoading'], 0) > 0,
-  isUnread: state.getIn(['notifications', 'unread']) > 0 || state.getIn(['notifications', 'pendingItems']).size > 0,
+  isUnread:
+    state.getIn(['notifications', 'unread']) > 0 ||
+    state.getIn(['notifications', 'pendingItems']).size > 0,
   hasMore: state.getIn(['notifications', 'hasMore']),
-  numPending: state.getIn(['notifications', 'pendingItems'], ImmutableList()).size,
-  lastReadId: state.getIn(['settings', 'notifications', 'showUnread']) ? state.getIn(['notifications', 'readMarkerId']) : '0',
-  canMarkAsRead: state.getIn(['settings', 'notifications', 'showUnread']) && state.getIn(['notifications', 'readMarkerId']) !== '0' && getNotifications(state).some(item => item !== null && compareId(item.get('id'), state.getIn(['notifications', 'readMarkerId'])) > 0),
-  needsNotificationPermission: state.getIn(['settings', 'notifications', 'alerts']).includes(true) && state.getIn(['notifications', 'browserSupport']) && state.getIn(['notifications', 'browserPermission']) === 'default' && !state.getIn(['settings', 'notifications', 'dismissPermissionBanner']),
+  numPending: state.getIn(['notifications', 'pendingItems'], ImmutableList())
+    .size,
+  lastReadId: state.getIn(['settings', 'notifications', 'showUnread'])
+    ? state.getIn(['notifications', 'readMarkerId'])
+    : '0',
+  canMarkAsRead:
+    state.getIn(['settings', 'notifications', 'showUnread']) &&
+    state.getIn(['notifications', 'readMarkerId']) !== '0' &&
+    getNotifications(state).some(
+      (item) =>
+        item !== null &&
+        compareId(
+          item.get('id'),
+          state.getIn(['notifications', 'readMarkerId']),
+        ) > 0,
+    ),
+  needsNotificationPermission:
+    state.getIn(['settings', 'notifications', 'alerts']).includes(true) &&
+    state.getIn(['notifications', 'browserSupport']) &&
+    state.getIn(['notifications', 'browserPermission']) === 'default' &&
+    !state.getIn(['settings', 'notifications', 'dismissPermissionBanner']),
 });
 
 class Notifications extends PureComponent {
-
   static contextTypes = {
     identity: PropTypes.object,
   };
@@ -104,7 +140,7 @@ class Notifications extends PureComponent {
     this.props.dispatch(mountNotifications());
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     this.handleLoadOlder.cancel();
     this.handleScrollToTop.cancel();
     this.handleScroll.cancel();
@@ -116,10 +152,16 @@ class Notifications extends PureComponent {
     this.props.dispatch(expandNotifications({ maxId }));
   };
 
-  handleLoadOlder = debounce(() => {
-    const last = this.props.notifications.last();
-    this.props.dispatch(expandNotifications({ maxId: last && last.get('id') }));
-  }, 300, { leading: true });
+  handleLoadOlder = debounce(
+    () => {
+      const last = this.props.notifications.last();
+      this.props.dispatch(
+        expandNotifications({ maxId: last && last.get('id') }),
+      );
+    },
+    300,
+    { leading: true },
+  );
 
   handleLoadPending = () => {
     this.props.dispatch(loadPending());
@@ -152,28 +194,40 @@ class Notifications extends PureComponent {
     this.column.scrollTop();
   };
 
-  setColumnRef = c => {
+  setColumnRef = (c) => {
     this.column = c;
   };
 
-  handleMoveUp = id => {
-    const elementIndex = this.props.notifications.findIndex(item => item !== null && item.get('id') === id) - 1;
+  handleMoveUp = (id) => {
+    const elementIndex =
+      this.props.notifications.findIndex(
+        (item) => item !== null && item.get('id') === id,
+      ) - 1;
     this._selectChild(elementIndex, true);
   };
 
-  handleMoveDown = id => {
-    const elementIndex = this.props.notifications.findIndex(item => item !== null && item.get('id') === id) + 1;
+  handleMoveDown = (id) => {
+    const elementIndex =
+      this.props.notifications.findIndex(
+        (item) => item !== null && item.get('id') === id,
+      ) + 1;
     this._selectChild(elementIndex, false);
   };
 
-  _selectChild (index, align_top) {
+  _selectChild(index, align_top) {
     const container = this.column.node;
-    const element = container.querySelector(`article:nth-of-type(${index + 1}) .focusable`);
+    const element = container.querySelector(
+      `article:nth-of-type(${index + 1}) .focusable`,
+    );
 
     if (element) {
       if (align_top && container.scrollTop > element.offsetTop) {
         element.scrollIntoView(true);
-      } else if (!align_top && container.scrollTop + container.clientHeight < element.offsetTop + element.offsetHeight) {
+      } else if (
+        !align_top &&
+        container.scrollTop + container.clientHeight <
+          element.offsetTop + element.offsetHeight
+      ) {
         element.scrollIntoView(false);
       }
       element.focus();
@@ -185,38 +239,59 @@ class Notifications extends PureComponent {
     this.props.dispatch(submitMarkers({ immediate: true }));
   };
 
-  render () {
-    const { intl, notifications, isLoading, isUnread, columnId, multiColumn, hasMore, numPending, showFilterBar, lastReadId, canMarkAsRead, needsNotificationPermission } = this.props;
+  render() {
+    const {
+      intl,
+      notifications,
+      isLoading,
+      isUnread,
+      columnId,
+      multiColumn,
+      hasMore,
+      numPending,
+      showFilterBar,
+      lastReadId,
+      canMarkAsRead,
+      needsNotificationPermission,
+    } = this.props;
     const pinned = !!columnId;
-    const emptyMessage = <FormattedMessage id='empty_column.notifications' defaultMessage="You don't have any notifications yet. When other people interact with you, you will see it here." />;
+    const emptyMessage = (
+      <FormattedMessage
+        id='empty_column.notifications'
+        defaultMessage="You don't have any notifications yet. When other people interact with you, you will see it here."
+      />
+    );
     const { signedIn } = this.context.identity;
 
     let scrollableContent = null;
 
-    const filterBarContainer = (signedIn && showFilterBar)
-      ? (<FilterBarContainer />)
-      : null;
+    const filterBarContainer =
+      signedIn && showFilterBar ? <FilterBarContainer /> : null;
 
     if (isLoading && this.scrollableContent) {
       scrollableContent = this.scrollableContent;
     } else if (notifications.size > 0 || hasMore) {
-      scrollableContent = notifications.map((item, index) => item === null ? (
-        <LoadGap
-          key={'gap:' + notifications.getIn([index + 1, 'id'])}
-          disabled={isLoading}
-          maxId={index > 0 ? notifications.getIn([index - 1, 'id']) : null}
-          onClick={this.handleLoadGap}
-        />
-      ) : (
-        <NotificationContainer
-          key={item.get('id')}
-          notification={item}
-          accountId={item.get('account')}
-          onMoveUp={this.handleMoveUp}
-          onMoveDown={this.handleMoveDown}
-          unread={lastReadId !== '0' && compareId(item.get('id'), lastReadId) > 0}
-        />
-      ));
+      scrollableContent = notifications.map((item, index) =>
+        item === null ? (
+          <LoadGap
+            key={'gap:' + notifications.getIn([index + 1, 'id'])}
+            disabled={isLoading}
+            maxId={index > 0 ? notifications.getIn([index - 1, 'id']) : null}
+            onClick={this.handleLoadGap}
+          />
+        ) : (
+          <NotificationContainer
+            key={item.get('id')}
+            notification={item}
+            accountId={item.get('account')}
+            onMoveUp={this.handleMoveUp}
+            onMoveDown={this.handleMoveDown}
+            unread={
+              lastReadId !== '0' && compareId(item.get('id'), lastReadId) > 0
+            }
+          />
+        ),
+      );
     } else {
       scrollableContent = null;
     }
@@ -234,7 +309,9 @@ class Notifications extends PureComponent {
           showLoading={isLoading && notifications.size === 0}
           hasMore={hasMore}
           numPending={numPending}
-          prepend={needsNotificationPermission && <NotificationsPermissionBanner />}
+          prepend={
+            needsNotificationPermission && <NotificationsPermissionBanner />
+          }
           alwaysPrepend
           emptyMessage={emptyMessage}
           onLoadMore={this.handleLoadOlder}
@@ -266,7 +343,11 @@ class Notifications extends PureComponent {
     }
 
     return (
-      <Column bindToDocument={!multiColumn} ref={this.setColumnRef} label={intl.formatMessage(messages.title)}>
+      <Column
+        bindToDocument={!multiColumn}
+        ref={this.setColumnRef}
+        label={intl.formatMessage(messages.title)}
+      >
         <ColumnHeader
           icon='bell'
           active={isUnread}
@@ -291,7 +372,6 @@ class Notifications extends PureComponent {
       </Column>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(injectIntl(Notifications));

--- a/app/javascript/mastodon/features/onboarding/components/arrow_small_right.jsx
+++ b/app/javascript/mastodon/features/onboarding/components/arrow_small_right.jsx
@@ -1,6 +1,14 @@
 const ArrowSmallRight = () => (
-  <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='currentColor'>
-    <path fillRule='evenodd' d='M5 10a.75.75 0 01.75-.75h6.638L10.23 7.29a.75.75 0 111.04-1.08l3.5 3.25a.75.75 0 010 1.08l-3.5 3.25a.75.75 0 11-1.04-1.08l2.158-1.96H5.75A.75.75 0 015 10z' clipRule='evenodd' />
+  <svg
+    xmlns='http://www.w3.org/2000/svg'
+    viewBox='0 0 20 20'
+    fill='currentColor'
+  >
+    <path
+      fillRule='evenodd'
+      d='M5 10a.75.75 0 01.75-.75h6.638L10.23 7.29a.75.75 0 111.04-1.08l3.5 3.25a.75.75 0 010 1.08l-3.5 3.25a.75.75 0 11-1.04-1.08l2.158-1.96H5.75A.75.75 0 015 10z'
+      clipRule='evenodd'
+    />
   </svg>
 );
 

--- a/app/javascript/mastodon/features/onboarding/components/progress_indicator.jsx
+++ b/app/javascript/mastodon/features/onboarding/components/progress_indicator.jsx
@@ -7,11 +7,21 @@ import { Check } from 'mastodon/components/check';
 
 const ProgressIndicator = ({ steps, completed }) => (
   <div className='onboarding__progress-indicator'>
-    {(new Array(steps)).fill().map((_, i) => (
+    {new Array(steps).fill().map((_, i) => (
       <Fragment key={i}>
-        {i > 0 && <div className={classNames('onboarding__progress-indicator__line', { active: completed > i })} />}
+        {i > 0 && (
+          <div
+            className={classNames('onboarding__progress-indicator__line', {
+              active: completed > i,
+            })}
+          />
+        )}
 
-        <div className={classNames('onboarding__progress-indicator__step', { active: completed > i })}>
+        <div
+          className={classNames('onboarding__progress-indicator__step', {
+            active: completed > i,
+          })}
+        >
           {completed > i && <Check />}
         </div>
       </Fragment>

--- a/app/javascript/mastodon/features/onboarding/components/step.jsx
+++ b/app/javascript/mastodon/features/onboarding/components/step.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 
 import { Check } from 'mastodon/components/check';
-import { Icon }  from 'mastodon/components/icon';
+import { Icon } from 'mastodon/components/icon';
 
 import ArrowSmallRight from './arrow_small_right';
 
@@ -17,7 +17,13 @@ const Step = ({ label, description, icon, completed, onClick, href }) => {
         <p>{description}</p>
       </div>
 
-      <div className={completed ? 'onboarding__steps__item__progress' : 'onboarding__steps__item__go'}>
+      <div
+        className={
+          completed
+            ? 'onboarding__steps__item__progress'
+            : 'onboarding__steps__item__go'
+        }
+      >
         {completed ? <Check /> : <ArrowSmallRight />}
       </div>
     </>
@@ -25,7 +31,13 @@ const Step = ({ label, description, icon, completed, onClick, href }) => {
 
   if (href) {
     return (
-      <a href={href} onClick={onClick} target='_blank' rel='noopener' className='onboarding__steps__item'>
+      <a
+        href={href}
+        onClick={onClick}
+        target='_blank'
+        rel='noopener'
+        className='onboarding__steps__item'
+      >
         {content}
       </a>
     );

--- a/app/javascript/mastodon/features/onboarding/follows.jsx
+++ b/app/javascript/mastodon/features/onboarding/follows.jsx
@@ -13,13 +13,12 @@ import ColumnBackButton from 'mastodon/components/column_back_button';
 import { EmptyAccount } from 'mastodon/components/empty_account';
 import Account from 'mastodon/containers/account_container';
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   suggestions: state.getIn(['suggestions', 'items']),
   isLoading: state.getIn(['suggestions', 'isLoading']),
 });
 
 class Follows extends PureComponent {
-
   static propTypes = {
     onBack: PropTypes.func,
     dispatch: PropTypes.func.isRequired,
@@ -28,27 +27,42 @@ class Follows extends PureComponent {
     multiColumn: PropTypes.bool,
   };
 
-  componentDidMount () {
+  componentDidMount() {
     const { dispatch } = this.props;
     dispatch(fetchSuggestions(true));
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     const { dispatch } = this.props;
     dispatch(markAsPartial('home'));
   }
 
-  render () {
+  render() {
     const { onBack, isLoading, suggestions, multiColumn } = this.props;
 
     let loadedContent;
 
     if (isLoading) {
-      loadedContent = (new Array(8)).fill().map((_, i) => <EmptyAccount key={i} />);
+      loadedContent = new Array(8)
+        .fill()
+        .map((_, i) => <EmptyAccount key={i} />);
     } else if (suggestions.isEmpty()) {
-      loadedContent = <div className='follow-recommendations__empty'><FormattedMessage id='onboarding.follows.empty' defaultMessage='Unfortunately, no results can be shown right now. You can try using search or browsing the explore page to find people to follow, or try again later.' /></div>;
+      loadedContent = (
+        <div className='follow-recommendations__empty'>
+          <FormattedMessage
+            id='onboarding.follows.empty'
+            defaultMessage='Unfortunately, no results can be shown right now. You can try using search or browsing the explore page to find people to follow, or try again later.'
+          />
+        </div>
+      );
     } else {
-      loadedContent = suggestions.map(suggestion => <Account id={suggestion.get('account')} key={suggestion.get('account')} withBio />);
+      loadedContent = suggestions.map((suggestion) => (
+        <Account
+          id={suggestion.get('account')}
+          key={suggestion.get('account')}
+          withBio
+        />
+      ));
     }
 
     return (
@@ -57,24 +71,42 @@ class Follows extends PureComponent {
 
         <div className='scrollable privacy-policy'>
           <div className='column-title'>
-            <h3><FormattedMessage id='onboarding.follows.title' defaultMessage='Popular on Mastodon' /></h3>
-            <p><FormattedMessage id='onboarding.follows.lead' defaultMessage='You curate your own home feed. The more people you follow, the more active and interesting it will be. These profiles may be a good starting point—you can always unfollow them later!' /></p>
+            <h3>
+              <FormattedMessage
+                id='onboarding.follows.title'
+                defaultMessage='Popular on Mastodon'
+              />
+            </h3>
+            <p>
+              <FormattedMessage
+                id='onboarding.follows.lead'
+                defaultMessage='You curate your own home feed. The more people you follow, the more active and interesting it will be. These profiles may be a good starting point—you can always unfollow them later!'
+              />
+            </p>
           </div>
 
-          <div className='follow-recommendations'>
-            {loadedContent}
-          </div>
+          <div className='follow-recommendations'>{loadedContent}</div>
 
-          <p className='onboarding__lead'><FormattedMessage id='onboarding.tips.accounts_from_other_servers' defaultMessage='<strong>Did you know?</strong> Since Mastodon is decentralized, some profiles you come across will be hosted on servers other than yours. And yet you can interact with them seamlessly! Their server is in the second half of their username!' values={{ strong: chunks => <strong>{chunks}</strong> }} /></p>
+          <p className='onboarding__lead'>
+            <FormattedMessage
+              id='onboarding.tips.accounts_from_other_servers'
+              defaultMessage='<strong>Did you know?</strong> Since Mastodon is decentralized, some profiles you come across will be hosted on servers other than yours. And yet you can interact with them seamlessly! Their server is in the second half of their username!'
+              values={{ strong: (chunks) => <strong>{chunks}</strong> }}
+            />
+          </p>
 
           <div className='onboarding__footer'>
-            <button className='link-button' onClick={onBack}><FormattedMessage id='onboarding.actions.back' defaultMessage='Take me back' /></button>
+            <button className='link-button' onClick={onBack}>
+              <FormattedMessage
+                id='onboarding.actions.back'
+                defaultMessage='Take me back'
+              />
+            </button>
           </div>
         </div>
       </Column>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(Follows);

--- a/app/javascript/mastodon/features/onboarding/index.jsx
+++ b/app/javascript/mastodon/features/onboarding/index.jsx
@@ -26,19 +26,21 @@ import Follows from './follows';
 import Share from './share';
 
 const messages = defineMessages({
-  template: { id: 'onboarding.compose.template', defaultMessage: 'Hello #Mastodon!' },
+  template: {
+    id: 'onboarding.compose.template',
+    defaultMessage: 'Hello #Mastodon!',
+  },
 });
 
 const mapStateToProps = () => {
   const getAccount = makeGetAccount();
 
-  return state => ({
+  return (state) => ({
     account: getAccount(state, me),
   });
 };
 
 class Onboarding extends ImmutablePureComponent {
-
   static contextTypes = {
     router: PropTypes.object.isRequired,
   };
@@ -75,7 +77,9 @@ class Onboarding extends ImmutablePureComponent {
     const { dispatch, intl } = this.props;
     const { router } = this.context;
 
-    dispatch(focusCompose(router.history, intl.formatMessage(messages.template)));
+    dispatch(
+      focusCompose(router.history, intl.formatMessage(messages.template)),
+    );
   };
 
   handleShareClick = () => {
@@ -86,56 +90,168 @@ class Onboarding extends ImmutablePureComponent {
     this.setState({ step: null });
   };
 
-  handleWindowFocus = debounce(() => {
-    const { dispatch, account } = this.props;
-    dispatch(fetchAccount(account.get('id')));
-  }, 1000, { trailing: true });
+  handleWindowFocus = debounce(
+    () => {
+      const { dispatch, account } = this.props;
+      dispatch(fetchAccount(account.get('id')));
+    },
+    1000,
+    { trailing: true },
+  );
 
-  componentDidMount () {
+  componentDidMount() {
     window.addEventListener('focus', this.handleWindowFocus, false);
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     window.removeEventListener('focus', this.handleWindowFocus);
   }
 
-  render () {
+  render() {
     const { account, multiColumn } = this.props;
     const { step, shareClicked } = this.state;
 
-    switch(step) {
-    case 'follows':
-      return <Follows onBack={this.handleBackClick} multiColumn={multiColumn} />;
-    case 'share':
-      return <Share onBack={this.handleBackClick} multiColumn={multiColumn} />;
+    switch (step) {
+      case 'follows':
+        return (
+          <Follows onBack={this.handleBackClick} multiColumn={multiColumn} />
+        );
+      case 'share':
+        return (
+          <Share onBack={this.handleBackClick} multiColumn={multiColumn} />
+        );
     }
 
     return (
       <Column>
         <div className='scrollable privacy-policy'>
           <div className='column-title'>
-            <img src={illustration} alt='' className='onboarding__illustration' />
-            <h3><FormattedMessage id='onboarding.start.title' defaultMessage="You've made it!" /></h3>
-            <p><FormattedMessage id='onboarding.start.lead' defaultMessage="Your new Mastodon account is ready to go. Here's how you can make the most of it:" /></p>
+            <img
+              src={illustration}
+              alt=''
+              className='onboarding__illustration'
+            />
+            <h3>
+              <FormattedMessage
+                id='onboarding.start.title'
+                defaultMessage="You've made it!"
+              />
+            </h3>
+            <p>
+              <FormattedMessage
+                id='onboarding.start.lead'
+                defaultMessage="Your new Mastodon account is ready to go. Here's how you can make the most of it:"
+              />
+            </p>
           </div>
 
           <div className='onboarding__steps'>
-            <Step onClick={this.handleProfileClick} href='/settings/profile' completed={(!account.get('avatar').endsWith('missing.png')) || (account.get('display_name').length > 0 && account.get('note').length > 0)} icon='address-book-o' label={<FormattedMessage id='onboarding.steps.setup_profile.title' defaultMessage='Customize your profile' />} description={<FormattedMessage id='onboarding.steps.setup_profile.body' defaultMessage='Others are more likely to interact with you with a filled out profile.' />} />
-            <Step onClick={this.handleFollowClick} completed={(account.get('following_count') * 1) >= 7} icon='user-plus' label={<FormattedMessage id='onboarding.steps.follow_people.title' defaultMessage='Find at least {count, plural, one {one person} other {# people}} to follow' values={{ count: 7 }} />} description={<FormattedMessage id='onboarding.steps.follow_people.body' defaultMessage="You curate your own home feed. Let's fill it with interesting people." />} />
-            <Step onClick={this.handleComposeClick} completed={(account.get('statuses_count') * 1) >= 1} icon='pencil-square-o' label={<FormattedMessage id='onboarding.steps.publish_status.title' defaultMessage='Make your first post' />} description={<FormattedMessage id='onboarding.steps.publish_status.body' defaultMessage='Say hello to the world.' values={{ emoji: <img className='emojione' alt='🐘' src={`${assetHost}/emoji/1f418.svg`} /> }} />} />
-            <Step onClick={this.handleShareClick} completed={shareClicked} icon='copy' label={<FormattedMessage id='onboarding.steps.share_profile.title' defaultMessage='Share your profile' />} description={<FormattedMessage id='onboarding.steps.share_profile.body' defaultMessage='Let your friends know how to find you on Mastodon!' />} />
+            <Step
+              onClick={this.handleProfileClick}
+              href='/settings/profile'
+              completed={
+                !account.get('avatar').endsWith('missing.png') ||
+                (account.get('display_name').length > 0 &&
+                  account.get('note').length > 0)
+              }
+              icon='address-book-o'
+              label={
+                <FormattedMessage
+                  id='onboarding.steps.setup_profile.title'
+                  defaultMessage='Customize your profile'
+                />
+              }
+              description={
+                <FormattedMessage
+                  id='onboarding.steps.setup_profile.body'
+                  defaultMessage='Others are more likely to interact with you with a filled out profile.'
+                />
+              }
+            />
+            <Step
+              onClick={this.handleFollowClick}
+              completed={account.get('following_count') * 1 >= 7}
+              icon='user-plus'
+              label={
+                <FormattedMessage
+                  id='onboarding.steps.follow_people.title'
+                  defaultMessage='Find at least {count, plural, one {one person} other {# people}} to follow'
+                  values={{ count: 7 }}
+                />
+              }
+              description={
+                <FormattedMessage
+                  id='onboarding.steps.follow_people.body'
+                  defaultMessage="You curate your own home feed. Let's fill it with interesting people."
+                />
+              }
+            />
+            <Step
+              onClick={this.handleComposeClick}
+              completed={account.get('statuses_count') * 1 >= 1}
+              icon='pencil-square-o'
+              label={
+                <FormattedMessage
+                  id='onboarding.steps.publish_status.title'
+                  defaultMessage='Make your first post'
+                />
+              }
+              description={
+                <FormattedMessage
+                  id='onboarding.steps.publish_status.body'
+                  defaultMessage='Say hello to the world.'
+                  values={{
+                    emoji: (
+                      <img
+                        className='emojione'
+                        alt='🐘'
+                        src={`${assetHost}/emoji/1f418.svg`}
+                      />
+                    ),
+                  }}
+                />
+              }
+            />
+            <Step
+              onClick={this.handleShareClick}
+              completed={shareClicked}
+              icon='copy'
+              label={
+                <FormattedMessage
+                  id='onboarding.steps.share_profile.title'
+                  defaultMessage='Share your profile'
+                />
+              }
+              description={
+                <FormattedMessage
+                  id='onboarding.steps.share_profile.body'
+                  defaultMessage='Let your friends know how to find you on Mastodon!'
+                />
+              }
+            />
           </div>
 
-          <p className='onboarding__lead'><FormattedMessage id='onboarding.start.skip' defaultMessage="Don't need help getting started?" /></p>
+          <p className='onboarding__lead'>
+            <FormattedMessage
+              id='onboarding.start.skip'
+              defaultMessage="Don't need help getting started?"
+            />
+          </p>
 
           <div className='onboarding__links'>
             <Link to='/explore' className='onboarding__link'>
-              <FormattedMessage id='onboarding.actions.go_to_explore' defaultMessage='Take me to trending' />
+              <FormattedMessage
+                id='onboarding.actions.go_to_explore'
+                defaultMessage='Take me to trending'
+              />
               <ArrowSmallRight />
             </Link>
 
             <Link to='/home' className='onboarding__link'>
-              <FormattedMessage id='onboarding.actions.go_to_home' defaultMessage='Take me to my home feed' />
+              <FormattedMessage
+                id='onboarding.actions.go_to_home'
+                defaultMessage='Take me to my home feed'
+              />
               <ArrowSmallRight />
             </Link>
           </div>
@@ -147,7 +263,6 @@ class Onboarding extends ImmutablePureComponent {
       </Column>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(injectIntl(Onboarding));

--- a/app/javascript/mastodon/features/onboarding/share.jsx
+++ b/app/javascript/mastodon/features/onboarding/share.jsx
@@ -13,21 +13,23 @@ import SwipeableViews from 'react-swipeable-views';
 
 import Column from 'mastodon/components/column';
 import ColumnBackButton from 'mastodon/components/column_back_button';
-import { Icon }  from 'mastodon/components/icon';
+import { Icon } from 'mastodon/components/icon';
 import { me, domain } from 'mastodon/initial_state';
 
 import ArrowSmallRight from './components/arrow_small_right';
 
 const messages = defineMessages({
-  shareableMessage: { id: 'onboarding.share.message', defaultMessage: 'I\'m {username} on #Mastodon! Come follow me at {url}' },
+  shareableMessage: {
+    id: 'onboarding.share.message',
+    defaultMessage: "I'm {username} on #Mastodon! Come follow me at {url}",
+  },
 });
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   account: state.getIn(['accounts', me]),
 });
 
 class CopyPasteText extends PureComponent {
-
   static propTypes = {
     value: PropTypes.string,
   };
@@ -37,7 +39,7 @@ class CopyPasteText extends PureComponent {
     focused: false,
   };
 
-  setRef = c => {
+  setRef = (c) => {
     this.input = c;
   };
 
@@ -48,7 +50,7 @@ class CopyPasteText extends PureComponent {
     this.input.setSelectionRange(0, this.props.value.length);
   };
 
-  handleButtonClick = e => {
+  handleButtonClick = (e) => {
     e.stopPropagation();
 
     const { value } = this.props;
@@ -66,29 +68,47 @@ class CopyPasteText extends PureComponent {
     this.setState({ focused: false });
   };
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     if (this.timeout) clearTimeout(this.timeout);
   }
 
-  render () {
+  render() {
     const { value } = this.props;
     const { copied, focused } = this.state;
 
     return (
-      <div className={classNames('copy-paste-text', { copied, focused })} tabIndex='0' role='button' onClick={this.handleInputClick}>
-        <textarea readOnly value={value} ref={this.setRef} onClick={this.handleInputClick} onFocus={this.handleFocus} onBlur={this.handleBlur} />
+      <div
+        className={classNames('copy-paste-text', { copied, focused })}
+        tabIndex='0'
+        role='button'
+        onClick={this.handleInputClick}
+      >
+        <textarea
+          readOnly
+          value={value}
+          ref={this.setRef}
+          onClick={this.handleInputClick}
+          onFocus={this.handleFocus}
+          onBlur={this.handleBlur}
+        />
 
         <button className='button' onClick={this.handleButtonClick}>
-          <Icon id='copy' /> {copied ? <FormattedMessage id='copypaste.copied' defaultMessage='Copied' /> : <FormattedMessage id='copypaste.copy_to_clipboard' defaultMessage='Copy to clipboard' />}
+          <Icon id='copy' />{' '}
+          {copied ? (
+            <FormattedMessage id='copypaste.copied' defaultMessage='Copied' />
+          ) : (
+            <FormattedMessage
+              id='copypaste.copy_to_clipboard'
+              defaultMessage='Copy to clipboard'
+            />
+          )}
         </button>
       </div>
     );
   }
-
 }
 
 class TipCarousel extends PureComponent {
-
   static propTypes = {
     children: PropTypes.node,
   };
@@ -97,40 +117,58 @@ class TipCarousel extends PureComponent {
     index: 0,
   };
 
-  handleSwipe = index => {
+  handleSwipe = (index) => {
     this.setState({ index });
   };
 
-  handleChangeIndex = e => {
-    this.setState({ index: Number(e.currentTarget.getAttribute('data-index')) });
+  handleChangeIndex = (e) => {
+    this.setState({
+      index: Number(e.currentTarget.getAttribute('data-index')),
+    });
   };
 
-  handleKeyDown = e => {
-    switch(e.key) {
-    case 'ArrowLeft':
-      e.preventDefault();
-      this.setState(({ index }, { children }) => ({ index: Math.abs(index - 1) % children.length }));
-      break;
-    case 'ArrowRight':
-      e.preventDefault();
-      this.setState(({ index }, { children }) => ({ index: (index + 1) % children.length }));
-      break;
+  handleKeyDown = (e) => {
+    switch (e.key) {
+      case 'ArrowLeft':
+        e.preventDefault();
+        this.setState(({ index }, { children }) => ({
+          index: Math.abs(index - 1) % children.length,
+        }));
+        break;
+      case 'ArrowRight':
+        e.preventDefault();
+        this.setState(({ index }, { children }) => ({
+          index: (index + 1) % children.length,
+        }));
+        break;
     }
   };
 
-  render () {
+  render() {
     const { children } = this.props;
     const { index } = this.state;
 
     return (
       <div className='tip-carousel' tabIndex='0' onKeyDown={this.handleKeyDown}>
-        <SwipeableViews onChangeIndex={this.handleSwipe} index={index} enableMouseEvents tabIndex='-1'>
+        <SwipeableViews
+          onChangeIndex={this.handleSwipe}
+          index={index}
+          enableMouseEvents
+          tabIndex='-1'
+        >
           {children}
         </SwipeableViews>
 
         <div className='media-modal__pagination'>
           {children.map((_, i) => (
-            <button key={i} className={classNames('media-modal__page-dot', { active: i === index })} data-index={i} onClick={this.handleChangeIndex}>
+            <button
+              key={i}
+              className={classNames('media-modal__page-dot', {
+                active: i === index,
+              })}
+              data-index={i}
+              onClick={this.handleChangeIndex}
+            >
               {i + 1}
             </button>
           ))}
@@ -138,11 +176,9 @@ class TipCarousel extends PureComponent {
       </div>
     );
   }
-
 }
 
 class Share extends PureComponent {
-
   static propTypes = {
     onBack: PropTypes.func,
     account: ImmutablePropTypes.map,
@@ -150,10 +186,10 @@ class Share extends PureComponent {
     intl: PropTypes.object,
   };
 
-  render () {
+  render() {
     const { onBack, account, multiColumn, intl } = this.props;
 
-    const url = (new URL(`/@${account.get('username')}`, document.baseURI)).href;
+    const url = new URL(`/@${account.get('username')}`, document.baseURI).href;
 
     return (
       <Column>
@@ -161,40 +197,97 @@ class Share extends PureComponent {
 
         <div className='scrollable privacy-policy'>
           <div className='column-title'>
-            <h3><FormattedMessage id='onboarding.share.title' defaultMessage='Share your profile' /></h3>
-            <p><FormattedMessage id='onboarding.share.lead' defaultMessage='Let people know how they can find you on Mastodon!' /></p>
+            <h3>
+              <FormattedMessage
+                id='onboarding.share.title'
+                defaultMessage='Share your profile'
+              />
+            </h3>
+            <p>
+              <FormattedMessage
+                id='onboarding.share.lead'
+                defaultMessage='Let people know how they can find you on Mastodon!'
+              />
+            </p>
           </div>
 
-          <CopyPasteText value={intl.formatMessage(messages.shareableMessage, { username: `@${account.get('username')}@${domain}`, url })} />
+          <CopyPasteText
+            value={intl.formatMessage(messages.shareableMessage, {
+              username: `@${account.get('username')}@${domain}`,
+              url,
+            })}
+          />
 
           <TipCarousel>
-            <div><p className='onboarding__lead'><FormattedMessage id='onboarding.tips.verification' defaultMessage='<strong>Did you know?</strong> You can verify your account by putting a link to your Mastodon profile on your own website and adding the website to your profile. No fees or documents necessary!'  values={{ strong: chunks => <strong>{chunks}</strong> }}  /></p></div>
-            <div><p className='onboarding__lead'><FormattedMessage id='onboarding.tips.migration' defaultMessage='<strong>Did you know?</strong> If you feel like {domain} is not a great server choice for you in the future, you can move to another Mastodon server without losing your followers. You can even host your own server!' values={{ domain, strong: chunks => <strong>{chunks}</strong> }} /></p></div>
-            <div><p className='onboarding__lead'><FormattedMessage id='onboarding.tips.2fa' defaultMessage='<strong>Did you know?</strong> You can secure your account by setting up two-factor authentication in your account settings. It works with any TOTP app of your choice, no phone number necessary!'  values={{ strong: chunks => <strong>{chunks}</strong> }}  /></p></div>
+            <div>
+              <p className='onboarding__lead'>
+                <FormattedMessage
+                  id='onboarding.tips.verification'
+                  defaultMessage='<strong>Did you know?</strong> You can verify your account by putting a link to your Mastodon profile on your own website and adding the website to your profile. No fees or documents necessary!'
+                  values={{ strong: (chunks) => <strong>{chunks}</strong> }}
+                />
+              </p>
+            </div>
+            <div>
+              <p className='onboarding__lead'>
+                <FormattedMessage
+                  id='onboarding.tips.migration'
+                  defaultMessage='<strong>Did you know?</strong> If you feel like {domain} is not a great server choice for you in the future, you can move to another Mastodon server without losing your followers. You can even host your own server!'
+                  values={{
+                    domain,
+                    strong: (chunks) => <strong>{chunks}</strong>,
+                  }}
+                />
+              </p>
+            </div>
+            <div>
+              <p className='onboarding__lead'>
+                <FormattedMessage
+                  id='onboarding.tips.2fa'
+                  defaultMessage='<strong>Did you know?</strong> You can secure your account by setting up two-factor authentication in your account settings. It works with any TOTP app of your choice, no phone number necessary!'
+                  values={{ strong: (chunks) => <strong>{chunks}</strong> }}
+                />
+              </p>
+            </div>
           </TipCarousel>
 
-          <p className='onboarding__lead'><FormattedMessage id='onboarding.share.next_steps' defaultMessage='Possible next steps:' /></p>
+          <p className='onboarding__lead'>
+            <FormattedMessage
+              id='onboarding.share.next_steps'
+              defaultMessage='Possible next steps:'
+            />
+          </p>
 
           <div className='onboarding__links'>
             <Link to='/home' className='onboarding__link'>
-              <FormattedMessage id='onboarding.actions.go_to_home' defaultMessage='Take me to my home feed' />
+              <FormattedMessage
+                id='onboarding.actions.go_to_home'
+                defaultMessage='Take me to my home feed'
+              />
               <ArrowSmallRight />
             </Link>
 
             <Link to='/explore' className='onboarding__link'>
-              <FormattedMessage id='onboarding.actions.go_to_explore' defaultMessage='Take me to trending' />
+              <FormattedMessage
+                id='onboarding.actions.go_to_explore'
+                defaultMessage='Take me to trending'
+              />
               <ArrowSmallRight />
             </Link>
           </div>
 
           <div className='onboarding__footer'>
-            <button className='link-button' onClick={onBack}><FormattedMessage id='onboarding.action.back' defaultMessage='Take me back' /></button>
+            <button className='link-button' onClick={onBack}>
+              <FormattedMessage
+                id='onboarding.action.back'
+                defaultMessage='Take me back'
+              />
+            </button>
           </div>
         </div>
       </Column>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(injectIntl(Share));

--- a/app/javascript/mastodon/features/picture_in_picture/components/footer.jsx
+++ b/app/javascript/mastodon/features/picture_in_picture/components/footer.jsx
@@ -10,7 +10,12 @@ import { connect } from 'react-redux';
 
 import { initBoostModal } from 'mastodon/actions/boosts';
 import { replyCompose } from 'mastodon/actions/compose';
-import { reblog, favourite, unreblog, unfavourite } from 'mastodon/actions/interactions';
+import {
+  reblog,
+  favourite,
+  unreblog,
+  unfavourite,
+} from 'mastodon/actions/interactions';
 import { openModal } from 'mastodon/actions/modal';
 import { IconButton } from 'mastodon/components/icon_button';
 import { me, boostModal } from 'mastodon/initial_state';
@@ -20,12 +25,25 @@ const messages = defineMessages({
   reply: { id: 'status.reply', defaultMessage: 'Reply' },
   replyAll: { id: 'status.replyAll', defaultMessage: 'Reply to thread' },
   reblog: { id: 'status.reblog', defaultMessage: 'Boost' },
-  reblog_private: { id: 'status.reblog_private', defaultMessage: 'Boost with original visibility' },
-  cancel_reblog_private: { id: 'status.cancel_reblog_private', defaultMessage: 'Unboost' },
-  cannot_reblog: { id: 'status.cannot_reblog', defaultMessage: 'This post cannot be boosted' },
+  reblog_private: {
+    id: 'status.reblog_private',
+    defaultMessage: 'Boost with original visibility',
+  },
+  cancel_reblog_private: {
+    id: 'status.cancel_reblog_private',
+    defaultMessage: 'Unboost',
+  },
+  cannot_reblog: {
+    id: 'status.cannot_reblog',
+    defaultMessage: 'This post cannot be boosted',
+  },
   favourite: { id: 'status.favourite', defaultMessage: 'Favorite' },
   replyConfirm: { id: 'confirmations.reply.confirm', defaultMessage: 'Reply' },
-  replyMessage: { id: 'confirmations.reply.message', defaultMessage: 'Replying now will overwrite the message you are currently composing. Are you sure you want to proceed?' },
+  replyMessage: {
+    id: 'confirmations.reply.message',
+    defaultMessage:
+      'Replying now will overwrite the message you are currently composing. Are you sure you want to proceed?',
+  },
   open: { id: 'status.open', defaultMessage: 'Expand this status' },
 });
 
@@ -41,7 +59,6 @@ const makeMapStateToProps = () => {
 };
 
 class Footer extends ImmutablePureComponent {
-
   static contextTypes = {
     router: PropTypes.object,
     identity: PropTypes.object,
@@ -74,26 +91,30 @@ class Footer extends ImmutablePureComponent {
 
     if (signedIn) {
       if (askReplyConfirmation) {
-        dispatch(openModal({
-          modalType: 'CONFIRM',
-          modalProps: {
-            message: intl.formatMessage(messages.replyMessage),
-            confirm: intl.formatMessage(messages.replyConfirm),
-            onConfirm: this._performReply,
-          },
-        }));
+        dispatch(
+          openModal({
+            modalType: 'CONFIRM',
+            modalProps: {
+              message: intl.formatMessage(messages.replyMessage),
+              confirm: intl.formatMessage(messages.replyConfirm),
+              onConfirm: this._performReply,
+            },
+          }),
+        );
       } else {
         this._performReply();
       }
     } else {
-      dispatch(openModal({
-        modalType: 'INTERACTION',
-        modalProps: {
-          type: 'reply',
-          accountId: status.getIn(['account', 'id']),
-          url: status.get('uri'),
-        },
-      }));
+      dispatch(
+        openModal({
+          modalType: 'INTERACTION',
+          modalProps: {
+            type: 'reply',
+            accountId: status.getIn(['account', 'id']),
+            url: status.get('uri'),
+          },
+        }),
+      );
     }
   };
 
@@ -108,14 +129,16 @@ class Footer extends ImmutablePureComponent {
         dispatch(favourite(status));
       }
     } else {
-      dispatch(openModal({
-        modalType: 'INTERACTION',
-        modalProps: {
-          type: 'favourite',
-          accountId: status.getIn(['account', 'id']),
-          url: status.get('uri'),
-        },
-      }));
+      dispatch(
+        openModal({
+          modalType: 'INTERACTION',
+          modalProps: {
+            type: 'favourite',
+            accountId: status.getIn(['account', 'id']),
+            url: status.get('uri'),
+          },
+        }),
+      );
     }
   };
 
@@ -124,7 +147,7 @@ class Footer extends ImmutablePureComponent {
     dispatch(reblog(status, privacy));
   };
 
-  handleReblogClick = e => {
+  handleReblogClick = (e) => {
     const { dispatch, status } = this.props;
     const { signedIn } = this.context.identity;
 
@@ -137,18 +160,20 @@ class Footer extends ImmutablePureComponent {
         dispatch(initBoostModal({ status, onReblog: this._performReblog }));
       }
     } else {
-      dispatch(openModal({
-        modalType: 'INTERACTION',
-        modalProps: {
-          type: 'reblog',
-          accountId: status.getIn(['account', 'id']),
-          url: status.get('uri'),
-        },
-      }));
+      dispatch(
+        openModal({
+          modalType: 'INTERACTION',
+          modalProps: {
+            type: 'reblog',
+            accountId: status.getIn(['account', 'id']),
+            url: status.get('uri'),
+          },
+        }),
+      );
     }
   };
 
-  handleOpenClick = e => {
+  handleOpenClick = (e) => {
     const { router } = this.context;
 
     if (e.button !== 0 || !router) {
@@ -161,14 +186,20 @@ class Footer extends ImmutablePureComponent {
       onClose();
     }
 
-    router.history.push(`/@${status.getIn(['account', 'acct'])}/${status.get('id')}`);
+    router.history.push(
+      `/@${status.getIn(['account', 'acct'])}/${status.get('id')}`,
+    );
   };
 
-  render () {
+  render() {
     const { status, intl, withOpenButton } = this.props;
 
-    const publicStatus  = ['public', 'unlisted'].includes(status.get('visibility'));
-    const reblogPrivate = status.getIn(['account', 'id']) === me && status.get('visibility') === 'private';
+    const publicStatus = ['public', 'unlisted'].includes(
+      status.get('visibility'),
+    );
+    const reblogPrivate =
+      status.getIn(['account', 'id']) === me &&
+      status.get('visibility') === 'private';
 
     let replyIcon, replyTitle;
 
@@ -194,14 +225,48 @@ class Footer extends ImmutablePureComponent {
 
     return (
       <div className='picture-in-picture__footer'>
-        <IconButton className='status__action-bar-button' title={replyTitle} icon={status.get('in_reply_to_account_id') === status.getIn(['account', 'id']) ? 'reply' : replyIcon} onClick={this.handleReplyClick} counter={status.get('replies_count')} />
-        <IconButton className={classNames('status__action-bar-button', { reblogPrivate })} disabled={!publicStatus && !reblogPrivate}  active={status.get('reblogged')} title={reblogTitle} icon='retweet' onClick={this.handleReblogClick} counter={status.get('reblogs_count')} />
-        <IconButton className='status__action-bar-button star-icon' animate active={status.get('favourited')} title={intl.formatMessage(messages.favourite)} icon='star' onClick={this.handleFavouriteClick} counter={status.get('favourites_count')} />
-        {withOpenButton && <IconButton className='status__action-bar-button' title={intl.formatMessage(messages.open)} icon='external-link' onClick={this.handleOpenClick} href={`/@${status.getIn(['account', 'acct'])}/${status.get('id')}`} />}
+        <IconButton
+          className='status__action-bar-button'
+          title={replyTitle}
+          icon={
+            status.get('in_reply_to_account_id') ===
+            status.getIn(['account', 'id'])
+              ? 'reply'
+              : replyIcon
+          }
+          onClick={this.handleReplyClick}
+          counter={status.get('replies_count')}
+        />
+        <IconButton
+          className={classNames('status__action-bar-button', { reblogPrivate })}
+          disabled={!publicStatus && !reblogPrivate}
+          active={status.get('reblogged')}
+          title={reblogTitle}
+          icon='retweet'
+          onClick={this.handleReblogClick}
+          counter={status.get('reblogs_count')}
+        />
+        <IconButton
+          className='status__action-bar-button star-icon'
+          animate
+          active={status.get('favourited')}
+          title={intl.formatMessage(messages.favourite)}
+          icon='star'
+          onClick={this.handleFavouriteClick}
+          counter={status.get('favourites_count')}
+        />
+        {withOpenButton && (
+          <IconButton
+            className='status__action-bar-button'
+            title={intl.formatMessage(messages.open)}
+            icon='external-link'
+            onClick={this.handleOpenClick}
+            href={`/@${status.getIn(['account', 'acct'])}/${status.get('id')}`}
+          />
+        )}
       </div>
     );
   }
-
 }
 
 export default connect(makeMapStateToProps)(injectIntl(Footer));

--- a/app/javascript/mastodon/features/picture_in_picture/components/header.jsx
+++ b/app/javascript/mastodon/features/picture_in_picture/components/header.jsx
@@ -21,7 +21,6 @@ const mapStateToProps = (state, { accountId }) => ({
 });
 
 class Header extends ImmutablePureComponent {
-
   static propTypes = {
     accountId: PropTypes.string.isRequired,
     statusId: PropTypes.string.isRequired,
@@ -30,21 +29,27 @@ class Header extends ImmutablePureComponent {
     intl: PropTypes.object.isRequired,
   };
 
-  render () {
+  render() {
     const { account, statusId, onClose, intl } = this.props;
 
     return (
       <div className='picture-in-picture__header'>
-        <Link to={`/@${account.get('acct')}/${statusId}`} className='picture-in-picture__header__account'>
+        <Link
+          to={`/@${account.get('acct')}/${statusId}`}
+          className='picture-in-picture__header__account'
+        >
           <Avatar account={account} size={36} />
           <DisplayName account={account} />
         </Link>
 
-        <IconButton icon='times' onClick={onClose} title={intl.formatMessage(messages.close)} />
+        <IconButton
+          icon='times'
+          onClick={onClose}
+          title={intl.formatMessage(messages.close)}
+        />
       </div>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(injectIntl(Header));

--- a/app/javascript/mastodon/features/picture_in_picture/index.jsx
+++ b/app/javascript/mastodon/features/picture_in_picture/index.jsx
@@ -10,12 +10,11 @@ import Video from 'mastodon/features/video';
 import Footer from './components/footer';
 import Header from './components/header';
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   ...state.get('picture_in_picture'),
 });
 
 class PictureInPicture extends Component {
-
   static propTypes = {
     statusId: PropTypes.string,
     accountId: PropTypes.string,
@@ -36,7 +35,7 @@ class PictureInPicture extends Component {
     dispatch(removePictureInPicture());
   };
 
-  render () {
+  render() {
     const { type, src, currentTime, accountId, statusId } = this.props;
 
     if (!currentTime) {
@@ -75,7 +74,11 @@ class PictureInPicture extends Component {
 
     return (
       <div className='picture-in-picture'>
-        <Header accountId={accountId} statusId={statusId} onClose={this.handleClose} />
+        <Header
+          accountId={accountId}
+          statusId={statusId}
+          onClose={this.handleClose}
+        />
 
         {player}
 
@@ -83,7 +86,6 @@ class PictureInPicture extends Component {
       </div>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(PictureInPicture);

--- a/app/javascript/mastodon/features/pinned_statuses/index.jsx
+++ b/app/javascript/mastodon/features/pinned_statuses/index.jsx
@@ -19,13 +19,12 @@ const messages = defineMessages({
   heading: { id: 'column.pins', defaultMessage: 'Pinned post' },
 });
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   statusIds: getStatusList(state, 'pins'),
   hasMore: !!state.getIn(['status_lists', 'pins', 'next']),
 });
 
 class PinnedStatuses extends ImmutablePureComponent {
-
   static propTypes = {
     dispatch: PropTypes.func.isRequired,
     statusIds: ImmutablePropTypes.list.isRequired,
@@ -34,7 +33,7 @@ class PinnedStatuses extends ImmutablePureComponent {
     multiColumn: PropTypes.bool,
   };
 
-  UNSAFE_componentWillMount () {
+  UNSAFE_componentWillMount() {
     this.props.dispatch(fetchPinnedStatuses());
   }
 
@@ -42,15 +41,20 @@ class PinnedStatuses extends ImmutablePureComponent {
     this.column.scrollTop();
   };
 
-  setRef = c => {
+  setRef = (c) => {
     this.column = c;
   };
 
-  render () {
+  render() {
     const { intl, statusIds, hasMore, multiColumn } = this.props;
 
     return (
-      <Column bindToDocument={!multiColumn} icon='thumb-tack' heading={intl.formatMessage(messages.heading)} ref={this.setRef}>
+      <Column
+        bindToDocument={!multiColumn}
+        icon='thumb-tack'
+        heading={intl.formatMessage(messages.heading)}
+        ref={this.setRef}
+      >
         <ColumnBackButtonSlim />
         <StatusList
           statusIds={statusIds}
@@ -64,7 +68,6 @@ class PinnedStatuses extends ImmutablePureComponent {
       </Column>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(injectIntl(PinnedStatuses));

--- a/app/javascript/mastodon/features/privacy_policy/index.jsx
+++ b/app/javascript/mastodon/features/privacy_policy/index.jsx
@@ -1,7 +1,12 @@
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 
-import { FormattedMessage, FormattedDate, injectIntl, defineMessages } from 'react-intl';
+import {
+  FormattedMessage,
+  FormattedDate,
+  injectIntl,
+  defineMessages,
+} from 'react-intl';
 
 import { Helmet } from 'react-helmet';
 
@@ -14,7 +19,6 @@ const messages = defineMessages({
 });
 
 class PrivacyPolicy extends PureComponent {
-
   static propTypes = {
     intl: PropTypes.object,
     multiColumn: PropTypes.bool,
@@ -26,24 +30,56 @@ class PrivacyPolicy extends PureComponent {
     isLoading: true,
   };
 
-  componentDidMount () {
-    api().get('/api/v1/instance/privacy_policy').then(({ data }) => {
-      this.setState({ content: data.content, lastUpdated: data.updated_at, isLoading: false });
-    }).catch(() => {
-      this.setState({ isLoading: false });
-    });
+  componentDidMount() {
+    api()
+      .get('/api/v1/instance/privacy_policy')
+      .then(({ data }) => {
+        this.setState({
+          content: data.content,
+          lastUpdated: data.updated_at,
+          isLoading: false,
+        });
+      })
+      .catch(() => {
+        this.setState({ isLoading: false });
+      });
   }
 
-  render () {
+  render() {
     const { intl, multiColumn } = this.props;
     const { isLoading, content, lastUpdated } = this.state;
 
     return (
-      <Column bindToDocument={!multiColumn} label={intl.formatMessage(messages.title)}>
+      <Column
+        bindToDocument={!multiColumn}
+        label={intl.formatMessage(messages.title)}
+      >
         <div className='scrollable privacy-policy'>
           <div className='column-title'>
-            <h3><FormattedMessage id='privacy_policy.title' defaultMessage='Privacy Policy' /></h3>
-            <p><FormattedMessage id='privacy_policy.last_updated' defaultMessage='Last updated {date}' values={{ date: isLoading ? <Skeleton width='10ch' /> : <FormattedDate value={lastUpdated} year='numeric' month='short' day='2-digit' /> }} /></p>
+            <h3>
+              <FormattedMessage
+                id='privacy_policy.title'
+                defaultMessage='Privacy Policy'
+              />
+            </h3>
+            <p>
+              <FormattedMessage
+                id='privacy_policy.last_updated'
+                defaultMessage='Last updated {date}'
+                values={{
+                  date: isLoading ? (
+                    <Skeleton width='10ch' />
+                  ) : (
+                    <FormattedDate
+                      value={lastUpdated}
+                      year='numeric'
+                      month='short'
+                      day='2-digit'
+                    />
+                  ),
+                }}
+              />
+            </p>
           </div>
 
           <div
@@ -59,7 +95,6 @@ class PrivacyPolicy extends PureComponent {
       </Column>
     );
   }
-
 }
 
 export default injectIntl(PrivacyPolicy);

--- a/app/javascript/mastodon/features/public_timeline/components/column_settings.jsx
+++ b/app/javascript/mastodon/features/public_timeline/components/column_settings.jsx
@@ -8,7 +8,6 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import SettingToggle from '../../notifications/components/setting_toggle';
 
 class ColumnSettings extends PureComponent {
-
   static propTypes = {
     settings: ImmutablePropTypes.map.isRequired,
     onChange: PropTypes.func.isRequired,
@@ -16,19 +15,38 @@ class ColumnSettings extends PureComponent {
     columnId: PropTypes.string,
   };
 
-  render () {
+  render() {
     const { settings, onChange } = this.props;
 
     return (
       <div>
         <div className='column-settings__row'>
-          <SettingToggle settings={settings} settingPath={['other', 'onlyMedia']} onChange={onChange} label={<FormattedMessage id='community.column_settings.media_only' defaultMessage='Media only' />} />
-          <SettingToggle settings={settings} settingPath={['other', 'onlyRemote']} onChange={onChange} label={<FormattedMessage id='community.column_settings.remote_only' defaultMessage='Remote only' />} />
+          <SettingToggle
+            settings={settings}
+            settingPath={['other', 'onlyMedia']}
+            onChange={onChange}
+            label={
+              <FormattedMessage
+                id='community.column_settings.media_only'
+                defaultMessage='Media only'
+              />
+            }
+          />
+          <SettingToggle
+            settings={settings}
+            settingPath={['other', 'onlyRemote']}
+            onChange={onChange}
+            label={
+              <FormattedMessage
+                id='community.column_settings.remote_only'
+                defaultMessage='Remote only'
+              />
+            }
+          />
         </div>
       </div>
     );
   }
-
 }
 
 export default injectIntl(ColumnSettings);

--- a/app/javascript/mastodon/features/public_timeline/containers/column_settings_container.js
+++ b/app/javascript/mastodon/features/public_timeline/containers/column_settings_container.js
@@ -7,16 +7,19 @@ import ColumnSettings from '../components/column_settings';
 const mapStateToProps = (state, { columnId }) => {
   const uuid = columnId;
   const columns = state.getIn(['settings', 'columns']);
-  const index = columns.findIndex(c => c.get('uuid') === uuid);
+  const index = columns.findIndex((c) => c.get('uuid') === uuid);
 
   return {
-    settings: (uuid && index >= 0) ? columns.get(index).get('params') : state.getIn(['settings', 'public']),
+    settings:
+      uuid && index >= 0
+        ? columns.get(index).get('params')
+        : state.getIn(['settings', 'public']),
   };
 };
 
 const mapDispatchToProps = (dispatch, { columnId }) => {
   return {
-    onChange (key, checked) {
+    onChange(key, checked) {
       if (columnId) {
         dispatch(changeColumnParams(columnId, key, checked));
       } else {

--- a/app/javascript/mastodon/features/public_timeline/index.jsx
+++ b/app/javascript/mastodon/features/public_timeline/index.jsx
@@ -26,10 +26,19 @@ const messages = defineMessages({
 const mapStateToProps = (state, { columnId }) => {
   const uuid = columnId;
   const columns = state.getIn(['settings', 'columns']);
-  const index = columns.findIndex(c => c.get('uuid') === uuid);
-  const onlyMedia = (columnId && index >= 0) ? columns.get(index).getIn(['params', 'other', 'onlyMedia']) : state.getIn(['settings', 'public', 'other', 'onlyMedia']);
-  const onlyRemote = (columnId && index >= 0) ? columns.get(index).getIn(['params', 'other', 'onlyRemote']) : state.getIn(['settings', 'public', 'other', 'onlyRemote']);
-  const timelineState = state.getIn(['timelines', `public${onlyRemote ? ':remote' : ''}${onlyMedia ? ':media' : ''}`]);
+  const index = columns.findIndex((c) => c.get('uuid') === uuid);
+  const onlyMedia =
+    columnId && index >= 0
+      ? columns.get(index).getIn(['params', 'other', 'onlyMedia'])
+      : state.getIn(['settings', 'public', 'other', 'onlyMedia']);
+  const onlyRemote =
+    columnId && index >= 0
+      ? columns.get(index).getIn(['params', 'other', 'onlyRemote'])
+      : state.getIn(['settings', 'public', 'other', 'onlyRemote']);
+  const timelineState = state.getIn([
+    'timelines',
+    `public${onlyRemote ? ':remote' : ''}${onlyMedia ? ':media' : ''}`,
+  ]);
 
   return {
     hasUnread: !!timelineState && timelineState.get('unread') > 0,
@@ -39,7 +48,6 @@ const mapStateToProps = (state, { columnId }) => {
 };
 
 class PublicTimeline extends PureComponent {
-
   static contextTypes = {
     router: PropTypes.object,
     identity: PropTypes.object,
@@ -65,7 +73,11 @@ class PublicTimeline extends PureComponent {
     if (columnId) {
       dispatch(removeColumn(columnId));
     } else {
-      dispatch(addColumn(onlyRemote ? 'REMOTE' : 'PUBLIC', { other: { onlyMedia, onlyRemote } }));
+      dispatch(
+        addColumn(onlyRemote ? 'REMOTE' : 'PUBLIC', {
+          other: { onlyMedia, onlyRemote },
+        }),
+      );
     }
   };
 
@@ -78,21 +90,26 @@ class PublicTimeline extends PureComponent {
     this.column.scrollTop();
   };
 
-  componentDidMount () {
+  componentDidMount() {
     const { dispatch, onlyMedia, onlyRemote } = this.props;
     const { signedIn } = this.context.identity;
 
     dispatch(expandPublicTimeline({ onlyMedia, onlyRemote }));
 
     if (signedIn) {
-      this.disconnect = dispatch(connectPublicStream({ onlyMedia, onlyRemote }));
+      this.disconnect = dispatch(
+        connectPublicStream({ onlyMedia, onlyRemote }),
+      );
     }
   }
 
-  componentDidUpdate (prevProps) {
+  componentDidUpdate(prevProps) {
     const { signedIn } = this.context.identity;
 
-    if (prevProps.onlyMedia !== this.props.onlyMedia || prevProps.onlyRemote !== this.props.onlyRemote) {
+    if (
+      prevProps.onlyMedia !== this.props.onlyMedia ||
+      prevProps.onlyRemote !== this.props.onlyRemote
+    ) {
       const { dispatch, onlyMedia, onlyRemote } = this.props;
 
       if (this.disconnect) {
@@ -102,34 +119,41 @@ class PublicTimeline extends PureComponent {
       dispatch(expandPublicTimeline({ onlyMedia, onlyRemote }));
 
       if (signedIn) {
-        this.disconnect = dispatch(connectPublicStream({ onlyMedia, onlyRemote }));
+        this.disconnect = dispatch(
+          connectPublicStream({ onlyMedia, onlyRemote }),
+        );
       }
     }
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     if (this.disconnect) {
       this.disconnect();
       this.disconnect = null;
     }
   }
 
-  setRef = c => {
+  setRef = (c) => {
     this.column = c;
   };
 
-  handleLoadMore = maxId => {
+  handleLoadMore = (maxId) => {
     const { dispatch, onlyMedia, onlyRemote } = this.props;
 
     dispatch(expandPublicTimeline({ maxId, onlyMedia, onlyRemote }));
   };
 
-  render () {
-    const { intl, columnId, hasUnread, multiColumn, onlyMedia, onlyRemote } = this.props;
+  render() {
+    const { intl, columnId, hasUnread, multiColumn, onlyMedia, onlyRemote } =
+      this.props;
     const pinned = !!columnId;
 
     return (
-      <Column bindToDocument={!multiColumn} ref={this.setRef} label={intl.formatMessage(messages.title)}>
+      <Column
+        bindToDocument={!multiColumn}
+        ref={this.setRef}
+        label={intl.formatMessage(messages.title)}
+      >
         <ColumnHeader
           icon='globe'
           active={hasUnread}
@@ -144,12 +168,27 @@ class PublicTimeline extends PureComponent {
         </ColumnHeader>
 
         <StatusListContainer
-          prepend={<DismissableBanner id='public_timeline'><FormattedMessage id='dismissable_banner.public_timeline' defaultMessage='These are the most recent public posts from people on the social web that people on {domain} follow.' values={{ domain }} /></DismissableBanner>}
-          timelineId={`public${onlyRemote ? ':remote' : ''}${onlyMedia ? ':media' : ''}`}
+          prepend={
+            <DismissableBanner id='public_timeline'>
+              <FormattedMessage
+                id='dismissable_banner.public_timeline'
+                defaultMessage='These are the most recent public posts from people on the social web that people on {domain} follow.'
+                values={{ domain }}
+              />
+            </DismissableBanner>
+          }
+          timelineId={`public${onlyRemote ? ':remote' : ''}${
+            onlyMedia ? ':media' : ''
+          }`}
           onLoadMore={this.handleLoadMore}
           trackScroll={!pinned}
           scrollKey={`public_timeline-${columnId}`}
-          emptyMessage={<FormattedMessage id='empty_column.public' defaultMessage='There is nothing here! Write something publicly, or manually follow users from other servers to fill it up' />}
+          emptyMessage={
+            <FormattedMessage
+              id='empty_column.public'
+              defaultMessage='There is nothing here! Write something publicly, or manually follow users from other servers to fill it up'
+            />
+          }
           bindToDocument={!multiColumn}
         />
 
@@ -160,7 +199,6 @@ class PublicTimeline extends PureComponent {
       </Column>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(injectIntl(PublicTimeline));

--- a/app/javascript/mastodon/features/reblogs/index.jsx
+++ b/app/javascript/mastodon/features/reblogs/index.jsx
@@ -10,7 +10,7 @@ import { connect } from 'react-redux';
 
 import { debounce } from 'lodash';
 
-import { Icon }  from 'mastodon/components/icon';
+import { Icon } from 'mastodon/components/icon';
 
 import { fetchReblogs, expandReblogs } from '../../actions/interactions';
 import ColumnHeader from '../../components/column_header';
@@ -24,13 +24,25 @@ const messages = defineMessages({
 });
 
 const mapStateToProps = (state, props) => ({
-  accountIds: state.getIn(['user_lists', 'reblogged_by', props.params.statusId, 'items']),
-  hasMore: !!state.getIn(['user_lists', 'reblogged_by', props.params.statusId, 'next']),
-  isLoading: state.getIn(['user_lists', 'reblogged_by', props.params.statusId, 'isLoading'], true),
+  accountIds: state.getIn([
+    'user_lists',
+    'reblogged_by',
+    props.params.statusId,
+    'items',
+  ]),
+  hasMore: !!state.getIn([
+    'user_lists',
+    'reblogged_by',
+    props.params.statusId,
+    'next',
+  ]),
+  isLoading: state.getIn(
+    ['user_lists', 'reblogged_by', props.params.statusId, 'isLoading'],
+    true,
+  ),
 });
 
 class Reblogs extends ImmutablePureComponent {
-
   static propTypes = {
     params: PropTypes.object.isRequired,
     dispatch: PropTypes.func.isRequired,
@@ -41,21 +53,25 @@ class Reblogs extends ImmutablePureComponent {
     intl: PropTypes.object.isRequired,
   };
 
-  UNSAFE_componentWillMount () {
+  UNSAFE_componentWillMount() {
     if (!this.props.accountIds) {
       this.props.dispatch(fetchReblogs(this.props.params.statusId));
     }
-  };
+  }
 
   handleRefresh = () => {
     this.props.dispatch(fetchReblogs(this.props.params.statusId));
   };
 
-  handleLoadMore = debounce(() => {
-    this.props.dispatch(expandReblogs(this.props.params.statusId));
-  }, 300, { leading: true });
+  handleLoadMore = debounce(
+    () => {
+      this.props.dispatch(expandReblogs(this.props.params.statusId));
+    },
+    300,
+    { leading: true },
+  );
 
-  render () {
+  render() {
     const { intl, accountIds, hasMore, isLoading, multiColumn } = this.props;
 
     if (!accountIds) {
@@ -66,16 +82,29 @@ class Reblogs extends ImmutablePureComponent {
       );
     }
 
-    const emptyMessage = <FormattedMessage id='status.reblogs.empty' defaultMessage='No one has boosted this post yet. When someone does, they will show up here.' />;
+    const emptyMessage = (
+      <FormattedMessage
+        id='status.reblogs.empty'
+        defaultMessage='No one has boosted this post yet. When someone does, they will show up here.'
+      />
+    );
 
     return (
       <Column bindToDocument={!multiColumn}>
         <ColumnHeader
           showBackButton
           multiColumn={multiColumn}
-          extraButton={(
-            <button type='button' className='column-header__button' title={intl.formatMessage(messages.refresh)} aria-label={intl.formatMessage(messages.refresh)} onClick={this.handleRefresh}><Icon id='refresh' /></button>
-          )}
+          extraButton={
+            <button
+              type='button'
+              className='column-header__button'
+              title={intl.formatMessage(messages.refresh)}
+              aria-label={intl.formatMessage(messages.refresh)}
+              onClick={this.handleRefresh}
+            >
+              <Icon id='refresh' />
+            </button>
+          }
         />
 
         <ScrollableList
@@ -86,9 +115,9 @@ class Reblogs extends ImmutablePureComponent {
           emptyMessage={emptyMessage}
           bindToDocument={!multiColumn}
         >
-          {accountIds.map(id =>
-            <AccountContainer key={id} id={id} withNote={false} />,
-          )}
+          {accountIds.map((id) => (
+            <AccountContainer key={id} id={id} withNote={false} />
+          ))}
         </ScrollableList>
 
         <Helmet>
@@ -97,7 +126,6 @@ class Reblogs extends ImmutablePureComponent {
       </Column>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(injectIntl(Reblogs));

--- a/app/javascript/mastodon/features/report/category.jsx
+++ b/app/javascript/mastodon/features/report/category.jsx
@@ -12,26 +12,44 @@ import Button from 'mastodon/components/button';
 import Option from './components/option';
 
 const messages = defineMessages({
-  dislike: { id: 'report.reasons.dislike', defaultMessage: 'I don\'t like it' },
-  dislike_description: { id: 'report.reasons.dislike_description', defaultMessage: 'It is not something you want to see' },
-  spam: { id: 'report.reasons.spam', defaultMessage: 'It\'s spam' },
-  spam_description: { id: 'report.reasons.spam_description', defaultMessage: 'Malicious links, fake engagement, or repetitive replies' },
-  legal: { id: 'report.reasons.legal', defaultMessage: 'It\'s illegal' },
-  legal_description: { id: 'report.reasons.legal_description', defaultMessage: 'You believe it violates the law of your or the server\'s country' },
-  violation: { id: 'report.reasons.violation', defaultMessage: 'It violates server rules' },
-  violation_description: { id: 'report.reasons.violation_description', defaultMessage: 'You are aware that it breaks specific rules' },
-  other: { id: 'report.reasons.other', defaultMessage: 'It\'s something else' },
-  other_description: { id: 'report.reasons.other_description', defaultMessage: 'The issue does not fit into other categories' },
+  dislike: { id: 'report.reasons.dislike', defaultMessage: "I don't like it" },
+  dislike_description: {
+    id: 'report.reasons.dislike_description',
+    defaultMessage: 'It is not something you want to see',
+  },
+  spam: { id: 'report.reasons.spam', defaultMessage: "It's spam" },
+  spam_description: {
+    id: 'report.reasons.spam_description',
+    defaultMessage: 'Malicious links, fake engagement, or repetitive replies',
+  },
+  legal: { id: 'report.reasons.legal', defaultMessage: "It's illegal" },
+  legal_description: {
+    id: 'report.reasons.legal_description',
+    defaultMessage:
+      "You believe it violates the law of your or the server's country",
+  },
+  violation: {
+    id: 'report.reasons.violation',
+    defaultMessage: 'It violates server rules',
+  },
+  violation_description: {
+    id: 'report.reasons.violation_description',
+    defaultMessage: 'You are aware that it breaks specific rules',
+  },
+  other: { id: 'report.reasons.other', defaultMessage: "It's something else" },
+  other_description: {
+    id: 'report.reasons.other_description',
+    defaultMessage: 'The issue does not fit into other categories',
+  },
   status: { id: 'report.category.title_status', defaultMessage: 'post' },
   account: { id: 'report.category.title_account', defaultMessage: 'profile' },
 });
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   rules: state.getIn(['server', 'server', 'rules'], ImmutableList()),
 });
 
 class Category extends PureComponent {
-
   static propTypes = {
     onNextStep: PropTypes.func.isRequired,
     rules: ImmutablePropTypes.list,
@@ -44,16 +62,16 @@ class Category extends PureComponent {
   handleNextClick = () => {
     const { onNextStep, category } = this.props;
 
-    switch(category) {
-    case 'dislike':
-      onNextStep('thanks');
-      break;
-    case 'violation':
-      onNextStep('rules');
-      break;
-    default:
-      onNextStep('statuses');
-      break;
+    switch (category) {
+      case 'dislike':
+        onNextStep('thanks');
+        break;
+      case 'violation':
+        onNextStep('rules');
+        break;
+      default:
+        onNextStep('statuses');
+        break;
     }
   };
 
@@ -65,29 +83,32 @@ class Category extends PureComponent {
     }
   };
 
-  render () {
+  render() {
     const { category, startedFrom, rules, intl } = this.props;
 
-    const options = rules.size > 0 ? [
-      'dislike',
-      'spam',
-      'legal',
-      'violation',
-      'other',
-    ] : [
-      'dislike',
-      'spam',
-      'legal',
-      'other',
-    ];
+    const options =
+      rules.size > 0
+        ? ['dislike', 'spam', 'legal', 'violation', 'other']
+        : ['dislike', 'spam', 'legal', 'other'];
 
     return (
       <>
-        <h3 className='report-dialog-modal__title'><FormattedMessage id='report.category.title' defaultMessage="Tell us what's going on with this {type}" values={{ type: intl.formatMessage(messages[startedFrom]) }} /></h3>
-        <p className='report-dialog-modal__lead'><FormattedMessage id='report.category.subtitle' defaultMessage='Choose the best match' /></p>
+        <h3 className='report-dialog-modal__title'>
+          <FormattedMessage
+            id='report.category.title'
+            defaultMessage="Tell us what's going on with this {type}"
+            values={{ type: intl.formatMessage(messages[startedFrom]) }}
+          />
+        </h3>
+        <p className='report-dialog-modal__lead'>
+          <FormattedMessage
+            id='report.category.subtitle'
+            defaultMessage='Choose the best match'
+          />
+        </p>
 
         <div>
-          {options.map(item => (
+          {options.map((item) => (
             <Option
               key={item}
               name='category'
@@ -103,12 +124,13 @@ class Category extends PureComponent {
         <div className='flex-spacer' />
 
         <div className='report-dialog-modal__actions'>
-          <Button onClick={this.handleNextClick} disabled={category === null}><FormattedMessage id='report.next' defaultMessage='Next' /></Button>
+          <Button onClick={this.handleNextClick} disabled={category === null}>
+            <FormattedMessage id='report.next' defaultMessage='Next' />
+          </Button>
         </div>
       </>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(injectIntl(Category));

--- a/app/javascript/mastodon/features/report/comment.jsx
+++ b/app/javascript/mastodon/features/report/comment.jsx
@@ -15,42 +15,75 @@ import Button from 'mastodon/components/button';
 import { useAppDispatch, useAppSelector } from 'mastodon/store';
 
 const messages = defineMessages({
-  placeholder: { id: 'report.placeholder', defaultMessage: 'Type or paste additional comments' },
+  placeholder: {
+    id: 'report.placeholder',
+    defaultMessage: 'Type or paste additional comments',
+  },
 });
 
 const selectRepliedToAccountIds = createSelector(
-  [
-    (state) => state.get('statuses'),
-    (_, statusIds) => statusIds,
-  ],
-  (statusesMap, statusIds) => statusIds.map((statusId) => statusesMap.getIn([statusId, 'in_reply_to_account_id'])),
+  [(state) => state.get('statuses'), (_, statusIds) => statusIds],
+  (statusesMap, statusIds) =>
+    statusIds.map((statusId) =>
+      statusesMap.getIn([statusId, 'in_reply_to_account_id']),
+    ),
   {
     resultEqualityCheck: shallowEqual,
-  }
+  },
 );
 
-const Comment = ({ comment, domain, statusIds, isRemote, isSubmitting, selectedDomains, onSubmit, onChangeComment, onToggleDomain }) => {
+const Comment = ({
+  comment,
+  domain,
+  statusIds,
+  isRemote,
+  isSubmitting,
+  selectedDomains,
+  onSubmit,
+  onChangeComment,
+  onToggleDomain,
+}) => {
   const intl = useIntl();
 
   const dispatch = useAppDispatch();
   const loadedRef = useRef(false);
 
   const handleClick = useCallback(() => onSubmit(), [onSubmit]);
-  const handleChange = useCallback((e) => onChangeComment(e.target.value), [onChangeComment]);
-  const handleToggleDomain = useCallback(e => onToggleDomain(e.target.value, e.target.checked), [onToggleDomain]);
+  const handleChange = useCallback(
+    (e) => onChangeComment(e.target.value),
+    [onChangeComment],
+  );
+  const handleToggleDomain = useCallback(
+    (e) => onToggleDomain(e.target.value, e.target.checked),
+    [onToggleDomain],
+  );
 
-  const handleKeyDown = useCallback((e) => {
-    if (e.keyCode === 13 && (e.ctrlKey || e.metaKey)) {
-      handleClick();
-    }
-  }, [handleClick]);
+  const handleKeyDown = useCallback(
+    (e) => {
+      if (e.keyCode === 13 && (e.ctrlKey || e.metaKey)) {
+        handleClick();
+      }
+    },
+    [handleClick],
+  );
 
   // Memoize accountIds since we don't want it to trigger `useEffect` on each render
-  const accountIds = useAppSelector((state) => domain ? selectRepliedToAccountIds(state, statusIds) : ImmutableList());
+  const accountIds = useAppSelector((state) =>
+    domain ? selectRepliedToAccountIds(state, statusIds) : ImmutableList(),
+  );
 
   // While we could memoize `availableDomains`, it is pretty inexpensive to recompute
   const accountsMap = useAppSelector((state) => state.get('accounts'));
-  const availableDomains = domain ? OrderedSet([domain]).union(accountIds.map((accountId) => accountsMap.getIn([accountId, 'acct'], '').split('@')[1]).filter(domain => !!domain)) : OrderedSet();
+  const availableDomains = domain
+    ? OrderedSet([domain]).union(
+        accountIds
+          .map(
+            (accountId) =>
+              accountsMap.getIn([accountId, 'acct'], '').split('@')[1],
+          )
+          .filter((domain) => !!domain),
+      )
+    : OrderedSet();
 
   useEffect(() => {
     if (loadedRef.current) {
@@ -65,7 +98,11 @@ const Comment = ({ comment, domain, statusIds, isRemote, isSubmitting, selectedD
     });
 
     // Then, fetch missing replied-to accounts
-    const unknownAccounts = OrderedSet(accountIds.filter(accountId => accountId && !accountsMap.has(accountId)));
+    const unknownAccounts = OrderedSet(
+      accountIds.filter(
+        (accountId) => accountId && !accountsMap.has(accountId),
+      ),
+    );
     unknownAccounts.forEach((accountId) => {
       dispatch(fetchAccount(accountId));
     });
@@ -73,7 +110,12 @@ const Comment = ({ comment, domain, statusIds, isRemote, isSubmitting, selectedD
 
   return (
     <>
-      <h3 className='report-dialog-modal__title'><FormattedMessage id='report.comment.title' defaultMessage='Is there anything else you think we should know?' /></h3>
+      <h3 className='report-dialog-modal__title'>
+        <FormattedMessage
+          id='report.comment.title'
+          defaultMessage='Is there anything else you think we should know?'
+        />
+      </h3>
 
       <textarea
         className='report-dialog-modal__textarea'
@@ -86,12 +128,29 @@ const Comment = ({ comment, domain, statusIds, isRemote, isSubmitting, selectedD
 
       {isRemote && (
         <>
-          <p className='report-dialog-modal__lead'><FormattedMessage id='report.forward_hint' defaultMessage='The account is from another server. Send an anonymized copy of the report there as well?' /></p>
+          <p className='report-dialog-modal__lead'>
+            <FormattedMessage
+              id='report.forward_hint'
+              defaultMessage='The account is from another server. Send an anonymized copy of the report there as well?'
+            />
+          </p>
 
-          { availableDomains.map((domain) => (
-            <label className='report-dialog-modal__toggle' key={`toggle-${domain}`}>
-              <Toggle checked={selectedDomains.includes(domain)} disabled={isSubmitting} onChange={handleToggleDomain} value={domain} />
-              <FormattedMessage id='report.forward' defaultMessage='Forward to {target}' values={{ target: domain }} />
+          {availableDomains.map((domain) => (
+            <label
+              className='report-dialog-modal__toggle'
+              key={`toggle-${domain}`}
+            >
+              <Toggle
+                checked={selectedDomains.includes(domain)}
+                disabled={isSubmitting}
+                onChange={handleToggleDomain}
+                value={domain}
+              />
+              <FormattedMessage
+                id='report.forward'
+                defaultMessage='Forward to {target}'
+                values={{ target: domain }}
+              />
             </label>
           ))}
         </>
@@ -100,11 +159,13 @@ const Comment = ({ comment, domain, statusIds, isRemote, isSubmitting, selectedD
       <div className='flex-spacer' />
 
       <div className='report-dialog-modal__actions'>
-        <Button onClick={handleClick} disabled={isSubmitting}><FormattedMessage id='report.submit' defaultMessage='Submit report' /></Button>
+        <Button onClick={handleClick} disabled={isSubmitting}>
+          <FormattedMessage id='report.submit' defaultMessage='Submit report' />
+        </Button>
       </div>
     </>
   );
-}
+};
 
 Comment.propTypes = {
   comment: PropTypes.string.isRequired,

--- a/app/javascript/mastodon/features/report/components/option.jsx
+++ b/app/javascript/mastodon/features/report/components/option.jsx
@@ -6,7 +6,6 @@ import classNames from 'classnames';
 import { Check } from 'mastodon/components/check';
 
 export default class Option extends PureComponent {
-
   static propTypes = {
     name: PropTypes.string.isRequired,
     value: PropTypes.string.isRequired,
@@ -18,7 +17,7 @@ export default class Option extends PureComponent {
     labelComponent: PropTypes.node,
   };
 
-  handleKeyPress = e => {
+  handleKeyPress = (e) => {
     const { value, checked, onToggle } = this.props;
 
     if (e.key === 'Enter' || e.key === ' ') {
@@ -28,28 +27,49 @@ export default class Option extends PureComponent {
     }
   };
 
-  handleChange = e => {
+  handleChange = (e) => {
     const { value, onToggle } = this.props;
     onToggle(value, e.target.checked);
   };
 
-  render () {
-    const { name, value, checked, label, labelComponent, description, multiple } = this.props;
+  render() {
+    const {
+      name,
+      value,
+      checked,
+      label,
+      labelComponent,
+      description,
+      multiple,
+    } = this.props;
 
     return (
       <label className='dialog-option poll__option selectable'>
-        <input type={multiple ? 'checkbox' : 'radio'} name={name} value={value} checked={checked} onChange={this.handleChange} />
+        <input
+          type={multiple ? 'checkbox' : 'radio'}
+          name={name}
+          value={value}
+          checked={checked}
+          onChange={this.handleChange}
+        />
 
         <span
-          className={classNames('poll__input', { active: checked, checkbox: multiple })}
+          className={classNames('poll__input', {
+            active: checked,
+            checkbox: multiple,
+          })}
           tabIndex={0}
           role='radio'
           onKeyPress={this.handleKeyPress}
           aria-checked={checked}
           aria-label={label}
-        >{checked && <Check />}</span>
+        >
+          {checked && <Check />}
+        </span>
 
-        {labelComponent ? labelComponent : (
+        {labelComponent ? (
+          labelComponent
+        ) : (
           <span className='poll__option__text'>
             <strong>{label}</strong>
             {description}
@@ -58,5 +78,4 @@ export default class Option extends PureComponent {
       </label>
     );
   }
-
 }

--- a/app/javascript/mastodon/features/report/components/status_check_box.jsx
+++ b/app/javascript/mastodon/features/report/components/status_check_box.jsx
@@ -7,7 +7,7 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 
 import { Avatar } from 'mastodon/components/avatar';
 import { DisplayName } from 'mastodon/components/display_name';
-import { Icon }  from 'mastodon/components/icon';
+import { Icon } from 'mastodon/components/icon';
 import MediaAttachments from 'mastodon/components/media_attachments';
 import { RelativeTimestamp } from 'mastodon/components/relative_timestamp';
 import StatusContent from 'mastodon/components/status_content';
@@ -17,12 +17,17 @@ import Option from './option';
 const messages = defineMessages({
   public_short: { id: 'privacy.public.short', defaultMessage: 'Public' },
   unlisted_short: { id: 'privacy.unlisted.short', defaultMessage: 'Unlisted' },
-  private_short: { id: 'privacy.private.short', defaultMessage: 'Followers only' },
-  direct_short: { id: 'privacy.direct.short', defaultMessage: 'Mentioned people only' },
+  private_short: {
+    id: 'privacy.private.short',
+    defaultMessage: 'Followers only',
+  },
+  direct_short: {
+    id: 'privacy.direct.short',
+    defaultMessage: 'Mentioned people only',
+  },
 });
 
 class StatusCheckBox extends PureComponent {
-
   static propTypes = {
     id: PropTypes.string.isRequired,
     status: ImmutablePropTypes.map.isRequired,
@@ -36,7 +41,7 @@ class StatusCheckBox extends PureComponent {
     onToggle(value, checked);
   };
 
-  render () {
+  render() {
     const { status, checked, intl } = this.props;
 
     if (status.get('reblog')) {
@@ -44,10 +49,19 @@ class StatusCheckBox extends PureComponent {
     }
 
     const visibilityIconInfo = {
-      'public': { icon: 'globe', text: intl.formatMessage(messages.public_short) },
-      'unlisted': { icon: 'unlock', text: intl.formatMessage(messages.unlisted_short) },
-      'private': { icon: 'lock', text: intl.formatMessage(messages.private_short) },
-      'direct': { icon: 'at', text: intl.formatMessage(messages.direct_short) },
+      public: {
+        icon: 'globe',
+        text: intl.formatMessage(messages.public_short),
+      },
+      unlisted: {
+        icon: 'unlock',
+        text: intl.formatMessage(messages.unlisted_short),
+      },
+      private: {
+        icon: 'lock',
+        text: intl.formatMessage(messages.private_short),
+      },
+      direct: { icon: 'at', text: intl.formatMessage(messages.direct_short) },
     };
 
     const visibilityIcon = visibilityIconInfo[status.get('visibility')];
@@ -60,7 +74,11 @@ class StatusCheckBox extends PureComponent {
           </div>
 
           <div>
-            <DisplayName account={status.get('account')} /> · <span className='status__visibility-icon'><Icon id={visibilityIcon.icon} title={visibilityIcon.text} /></span> <RelativeTimestamp timestamp={status.get('created_at')} />
+            <DisplayName account={status.get('account')} /> ·{' '}
+            <span className='status__visibility-icon'>
+              <Icon id={visibilityIcon.icon} title={visibilityIcon.text} />
+            </span>{' '}
+            <RelativeTimestamp timestamp={status.get('created_at')} />
           </div>
         </div>
 
@@ -81,7 +99,6 @@ class StatusCheckBox extends PureComponent {
       />
     );
   }
-
 }
 
 export default injectIntl(StatusCheckBox);

--- a/app/javascript/mastodon/features/report/rules.jsx
+++ b/app/javascript/mastodon/features/report/rules.jsx
@@ -10,12 +10,11 @@ import Button from 'mastodon/components/button';
 
 import Option from './components/option';
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   rules: state.getIn(['server', 'server', 'rules']),
 });
 
 class Rules extends PureComponent {
-
   static propTypes = {
     onNextStep: PropTypes.func.isRequired,
     rules: ImmutablePropTypes.list,
@@ -33,16 +32,26 @@ class Rules extends PureComponent {
     onToggle(value, checked);
   };
 
-  render () {
+  render() {
     const { rules, selectedRuleIds } = this.props;
 
     return (
       <>
-        <h3 className='report-dialog-modal__title'><FormattedMessage id='report.rules.title' defaultMessage='Which rules are being violated?' /></h3>
-        <p className='report-dialog-modal__lead'><FormattedMessage id='report.rules.subtitle' defaultMessage='Select all that apply' /></p>
+        <h3 className='report-dialog-modal__title'>
+          <FormattedMessage
+            id='report.rules.title'
+            defaultMessage='Which rules are being violated?'
+          />
+        </h3>
+        <p className='report-dialog-modal__lead'>
+          <FormattedMessage
+            id='report.rules.subtitle'
+            defaultMessage='Select all that apply'
+          />
+        </p>
 
         <div>
-          {rules.map(item => (
+          {rules.map((item) => (
             <Option
               key={item.get('id')}
               name='rule_ids'
@@ -58,12 +67,16 @@ class Rules extends PureComponent {
         <div className='flex-spacer' />
 
         <div className='report-dialog-modal__actions'>
-          <Button onClick={this.handleNextClick} disabled={selectedRuleIds.size < 1}><FormattedMessage id='report.next' defaultMessage='Next' /></Button>
+          <Button
+            onClick={this.handleNextClick}
+            disabled={selectedRuleIds.size < 1}
+          >
+            <FormattedMessage id='report.next' defaultMessage='Next' />
+          </Button>
         </div>
       </>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(Rules);

--- a/app/javascript/mastodon/features/report/statuses.jsx
+++ b/app/javascript/mastodon/features/report/statuses.jsx
@@ -12,12 +12,17 @@ import { LoadingIndicator } from 'mastodon/components/loading_indicator';
 import StatusCheckBox from 'mastodon/features/report/containers/status_check_box_container';
 
 const mapStateToProps = (state, { accountId }) => ({
-  availableStatusIds: OrderedSet(state.getIn(['timelines', `account:${accountId}:with_replies`, 'items'])),
-  isLoading: state.getIn(['timelines', `account:${accountId}:with_replies`, 'isLoading']),
+  availableStatusIds: OrderedSet(
+    state.getIn(['timelines', `account:${accountId}:with_replies`, 'items']),
+  ),
+  isLoading: state.getIn([
+    'timelines',
+    `account:${accountId}:with_replies`,
+    'isLoading',
+  ]),
 });
 
 class Statuses extends PureComponent {
-
   static propTypes = {
     onNextStep: PropTypes.func.isRequired,
     accountId: PropTypes.string.isRequired,
@@ -32,34 +37,52 @@ class Statuses extends PureComponent {
     onNextStep('comment');
   };
 
-  render () {
-    const { availableStatusIds, selectedStatusIds, onToggle, isLoading } = this.props;
+  render() {
+    const { availableStatusIds, selectedStatusIds, onToggle, isLoading } =
+      this.props;
 
     return (
       <>
-        <h3 className='report-dialog-modal__title'><FormattedMessage id='report.statuses.title' defaultMessage='Are there any posts that back up this report?' /></h3>
-        <p className='report-dialog-modal__lead'><FormattedMessage id='report.statuses.subtitle' defaultMessage='Select all that apply' /></p>
+        <h3 className='report-dialog-modal__title'>
+          <FormattedMessage
+            id='report.statuses.title'
+            defaultMessage='Are there any posts that back up this report?'
+          />
+        </h3>
+        <p className='report-dialog-modal__lead'>
+          <FormattedMessage
+            id='report.statuses.subtitle'
+            defaultMessage='Select all that apply'
+          />
+        </p>
 
         <div className='report-dialog-modal__statuses'>
-          {isLoading ? <LoadingIndicator /> : availableStatusIds.union(selectedStatusIds).map(statusId => (
-            <StatusCheckBox
-              id={statusId}
-              key={statusId}
-              checked={selectedStatusIds.includes(statusId)}
-              onToggle={onToggle}
-            />
-          ))}
+          {isLoading ? (
+            <LoadingIndicator />
+          ) : (
+            availableStatusIds
+              .union(selectedStatusIds)
+              .map((statusId) => (
+                <StatusCheckBox
+                  id={statusId}
+                  key={statusId}
+                  checked={selectedStatusIds.includes(statusId)}
+                  onToggle={onToggle}
+                />
+              ))
+          )}
         </div>
 
         <div className='flex-spacer' />
 
         <div className='report-dialog-modal__actions'>
-          <Button onClick={this.handleNextClick}><FormattedMessage id='report.next' defaultMessage='Next' /></Button>
+          <Button onClick={this.handleNextClick}>
+            <FormattedMessage id='report.next' defaultMessage='Next' />
+          </Button>
         </div>
       </>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(Statuses);

--- a/app/javascript/mastodon/features/report/thanks.jsx
+++ b/app/javascript/mastodon/features/report/thanks.jsx
@@ -16,7 +16,6 @@ import Button from 'mastodon/components/button';
 const mapStateToProps = () => ({});
 
 class Thanks extends PureComponent {
-
   static propTypes = {
     submitted: PropTypes.bool,
     onClose: PropTypes.func.isRequired,
@@ -47,42 +46,118 @@ class Thanks extends PureComponent {
     onClose();
   };
 
-  render () {
+  render() {
     const { account, submitted } = this.props;
 
     return (
       <>
-        <h3 className='report-dialog-modal__title'>{submitted ? <FormattedMessage id='report.thanks.title_actionable' defaultMessage="Thanks for reporting, we'll look into this." /> : <FormattedMessage id='report.thanks.title' defaultMessage="Don't want to see this?" />}</h3>
-        <p className='report-dialog-modal__lead'>{submitted ? <FormattedMessage id='report.thanks.take_action_actionable' defaultMessage='While we review this, you can take action against @{name}:' values={{ name: account.get('username') }} /> : <FormattedMessage id='report.thanks.take_action' defaultMessage='Here are your options for controlling what you see on Mastodon:' />}</p>
+        <h3 className='report-dialog-modal__title'>
+          {submitted ? (
+            <FormattedMessage
+              id='report.thanks.title_actionable'
+              defaultMessage="Thanks for reporting, we'll look into this."
+            />
+          ) : (
+            <FormattedMessage
+              id='report.thanks.title'
+              defaultMessage="Don't want to see this?"
+            />
+          )}
+        </h3>
+        <p className='report-dialog-modal__lead'>
+          {submitted ? (
+            <FormattedMessage
+              id='report.thanks.take_action_actionable'
+              defaultMessage='While we review this, you can take action against @{name}:'
+              values={{ name: account.get('username') }}
+            />
+          ) : (
+            <FormattedMessage
+              id='report.thanks.take_action'
+              defaultMessage='Here are your options for controlling what you see on Mastodon:'
+            />
+          )}
+        </p>
 
         {account.getIn(['relationship', 'following']) && (
           <>
-            <h4 className='report-dialog-modal__subtitle'><FormattedMessage id='report.unfollow' defaultMessage='Unfollow @{name}' values={{ name: account.get('username') }} /></h4>
-            <p className='report-dialog-modal__lead'><FormattedMessage id='report.unfollow_explanation' defaultMessage='You are following this account. To not see their posts in your home feed anymore, unfollow them.' /></p>
-            <Button secondary onClick={this.handleUnfollowClick}><FormattedMessage id='account.unfollow' defaultMessage='Unfollow' /></Button>
+            <h4 className='report-dialog-modal__subtitle'>
+              <FormattedMessage
+                id='report.unfollow'
+                defaultMessage='Unfollow @{name}'
+                values={{ name: account.get('username') }}
+              />
+            </h4>
+            <p className='report-dialog-modal__lead'>
+              <FormattedMessage
+                id='report.unfollow_explanation'
+                defaultMessage='You are following this account. To not see their posts in your home feed anymore, unfollow them.'
+              />
+            </p>
+            <Button secondary onClick={this.handleUnfollowClick}>
+              <FormattedMessage
+                id='account.unfollow'
+                defaultMessage='Unfollow'
+              />
+            </Button>
             <hr />
           </>
         )}
 
-        <h4 className='report-dialog-modal__subtitle'><FormattedMessage id='account.mute' defaultMessage='Mute @{name}' values={{ name: account.get('username') }} /></h4>
-        <p className='report-dialog-modal__lead'><FormattedMessage id='report.mute_explanation' defaultMessage='You will not see their posts. They can still follow you and see your posts and will not know that they are muted.' /></p>
-        <Button secondary onClick={this.handleMuteClick}>{!account.getIn(['relationship', 'muting']) ? <FormattedMessage id='report.mute' defaultMessage='Mute' /> : <FormattedMessage id='account.muted' defaultMessage='Muted' />}</Button>
+        <h4 className='report-dialog-modal__subtitle'>
+          <FormattedMessage
+            id='account.mute'
+            defaultMessage='Mute @{name}'
+            values={{ name: account.get('username') }}
+          />
+        </h4>
+        <p className='report-dialog-modal__lead'>
+          <FormattedMessage
+            id='report.mute_explanation'
+            defaultMessage='You will not see their posts. They can still follow you and see your posts and will not know that they are muted.'
+          />
+        </p>
+        <Button secondary onClick={this.handleMuteClick}>
+          {!account.getIn(['relationship', 'muting']) ? (
+            <FormattedMessage id='report.mute' defaultMessage='Mute' />
+          ) : (
+            <FormattedMessage id='account.muted' defaultMessage='Muted' />
+          )}
+        </Button>
 
         <hr />
 
-        <h4 className='report-dialog-modal__subtitle'><FormattedMessage id='account.block' defaultMessage='Block @{name}' values={{ name: account.get('username') }} /></h4>
-        <p className='report-dialog-modal__lead'><FormattedMessage id='report.block_explanation' defaultMessage='You will not see their posts. They will not be able to see your posts or follow you. They will be able to tell that they are blocked.' /></p>
-        <Button secondary onClick={this.handleBlockClick}>{!account.getIn(['relationship', 'blocking']) ? <FormattedMessage id='report.block' defaultMessage='Block' /> : <FormattedMessage id='account.blocked' defaultMessage='Blocked' />}</Button>
+        <h4 className='report-dialog-modal__subtitle'>
+          <FormattedMessage
+            id='account.block'
+            defaultMessage='Block @{name}'
+            values={{ name: account.get('username') }}
+          />
+        </h4>
+        <p className='report-dialog-modal__lead'>
+          <FormattedMessage
+            id='report.block_explanation'
+            defaultMessage='You will not see their posts. They will not be able to see your posts or follow you. They will be able to tell that they are blocked.'
+          />
+        </p>
+        <Button secondary onClick={this.handleBlockClick}>
+          {!account.getIn(['relationship', 'blocking']) ? (
+            <FormattedMessage id='report.block' defaultMessage='Block' />
+          ) : (
+            <FormattedMessage id='account.blocked' defaultMessage='Blocked' />
+          )}
+        </Button>
 
         <div className='flex-spacer' />
 
         <div className='report-dialog-modal__actions'>
-          <Button onClick={this.handleCloseClick}><FormattedMessage id='report.close' defaultMessage='Done' /></Button>
+          <Button onClick={this.handleCloseClick}>
+            <FormattedMessage id='report.close' defaultMessage='Done' />
+          </Button>
         </div>
       </>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(Thanks);

--- a/app/javascript/mastodon/features/standalone/compose/index.jsx
+++ b/app/javascript/mastodon/features/standalone/compose/index.jsx
@@ -6,8 +6,7 @@ import ModalContainer from '../../ui/containers/modal_container';
 import NotificationsContainer from '../../ui/containers/notifications_container';
 
 export default class Compose extends PureComponent {
-
-  render () {
+  render() {
     return (
       <div>
         <ComposeFormContainer autoFocus />
@@ -17,5 +16,4 @@ export default class Compose extends PureComponent {
       </div>
     );
   }
-
 }

--- a/app/javascript/mastodon/features/status/components/action_bar.jsx
+++ b/app/javascript/mastodon/features/status/components/action_bar.jsx
@@ -8,7 +8,10 @@ import classNames from 'classnames';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
 
-import { PERMISSION_MANAGE_USERS, PERMISSION_MANAGE_FEDERATION } from 'mastodon/permissions';
+import {
+  PERMISSION_MANAGE_USERS,
+  PERMISSION_MANAGE_FEDERATION,
+} from 'mastodon/permissions';
 
 import { IconButton } from '../../../components/icon_button';
 import DropdownMenuContainer from '../../../containers/dropdown_menu_container';
@@ -22,30 +25,63 @@ const messages = defineMessages({
   mention: { id: 'status.mention', defaultMessage: 'Mention @{name}' },
   reply: { id: 'status.reply', defaultMessage: 'Reply' },
   reblog: { id: 'status.reblog', defaultMessage: 'Boost' },
-  reblog_private: { id: 'status.reblog_private', defaultMessage: 'Boost with original visibility' },
-  cancel_reblog_private: { id: 'status.cancel_reblog_private', defaultMessage: 'Unboost' },
-  cannot_reblog: { id: 'status.cannot_reblog', defaultMessage: 'This post cannot be boosted' },
+  reblog_private: {
+    id: 'status.reblog_private',
+    defaultMessage: 'Boost with original visibility',
+  },
+  cancel_reblog_private: {
+    id: 'status.cancel_reblog_private',
+    defaultMessage: 'Unboost',
+  },
+  cannot_reblog: {
+    id: 'status.cannot_reblog',
+    defaultMessage: 'This post cannot be boosted',
+  },
   favourite: { id: 'status.favourite', defaultMessage: 'Favorite' },
   bookmark: { id: 'status.bookmark', defaultMessage: 'Bookmark' },
   more: { id: 'status.more', defaultMessage: 'More' },
   mute: { id: 'status.mute', defaultMessage: 'Mute @{name}' },
-  muteConversation: { id: 'status.mute_conversation', defaultMessage: 'Mute conversation' },
-  unmuteConversation: { id: 'status.unmute_conversation', defaultMessage: 'Unmute conversation' },
+  muteConversation: {
+    id: 'status.mute_conversation',
+    defaultMessage: 'Mute conversation',
+  },
+  unmuteConversation: {
+    id: 'status.unmute_conversation',
+    defaultMessage: 'Unmute conversation',
+  },
   block: { id: 'status.block', defaultMessage: 'Block @{name}' },
   report: { id: 'status.report', defaultMessage: 'Report @{name}' },
   share: { id: 'status.share', defaultMessage: 'Share' },
   pin: { id: 'status.pin', defaultMessage: 'Pin on profile' },
   unpin: { id: 'status.unpin', defaultMessage: 'Unpin from profile' },
   embed: { id: 'status.embed', defaultMessage: 'Embed' },
-  admin_account: { id: 'status.admin_account', defaultMessage: 'Open moderation interface for @{name}' },
-  admin_status: { id: 'status.admin_status', defaultMessage: 'Open this post in the moderation interface' },
-  admin_domain: { id: 'status.admin_domain', defaultMessage: 'Open moderation interface for {domain}' },
+  admin_account: {
+    id: 'status.admin_account',
+    defaultMessage: 'Open moderation interface for @{name}',
+  },
+  admin_status: {
+    id: 'status.admin_status',
+    defaultMessage: 'Open this post in the moderation interface',
+  },
+  admin_domain: {
+    id: 'status.admin_domain',
+    defaultMessage: 'Open moderation interface for {domain}',
+  },
   copy: { id: 'status.copy', defaultMessage: 'Copy link to post' },
-  blockDomain: { id: 'account.block_domain', defaultMessage: 'Block domain {domain}' },
-  unblockDomain: { id: 'account.unblock_domain', defaultMessage: 'Unblock domain {domain}' },
+  blockDomain: {
+    id: 'account.block_domain',
+    defaultMessage: 'Block domain {domain}',
+  },
+  unblockDomain: {
+    id: 'account.unblock_domain',
+    defaultMessage: 'Unblock domain {domain}',
+  },
   unmute: { id: 'account.unmute', defaultMessage: 'Unmute @{name}' },
   unblock: { id: 'account.unblock', defaultMessage: 'Unblock @{name}' },
-  openOriginalPage: { id: 'account.open_original_page', defaultMessage: 'Open original page' },
+  openOriginalPage: {
+    id: 'account.open_original_page',
+    defaultMessage: 'Open original page',
+  },
 });
 
 const mapStateToProps = (state, { status }) => ({
@@ -53,7 +89,6 @@ const mapStateToProps = (state, { status }) => ({
 });
 
 class ActionBar extends PureComponent {
-
   static contextTypes = {
     router: PropTypes.object,
     identity: PropTypes.object,
@@ -112,11 +147,17 @@ class ActionBar extends PureComponent {
   };
 
   handleDirectClick = () => {
-    this.props.onDirect(this.props.status.get('account'), this.context.router.history);
+    this.props.onDirect(
+      this.props.status.get('account'),
+      this.context.router.history,
+    );
   };
 
   handleMentionClick = () => {
-    this.props.onMention(this.props.status.get('account'), this.context.router.history);
+    this.props.onMention(
+      this.props.status.get('account'),
+      this.context.router.history,
+    );
   };
 
   handleMuteClick = () => {
@@ -182,31 +223,49 @@ class ActionBar extends PureComponent {
     navigator.clipboard.writeText(url);
   };
 
-  render () {
+  render() {
     const { status, relationship, intl } = this.props;
     const { signedIn, permissions } = this.context.identity;
 
-    const publicStatus       = ['public', 'unlisted'].includes(status.get('visibility'));
-    const pinnableStatus     = ['public', 'unlisted', 'private'].includes(status.get('visibility'));
+    const publicStatus = ['public', 'unlisted'].includes(
+      status.get('visibility'),
+    );
+    const pinnableStatus = ['public', 'unlisted', 'private'].includes(
+      status.get('visibility'),
+    );
     const mutingConversation = status.get('muted');
-    const account            = status.get('account');
-    const writtenByMe        = status.getIn(['account', 'id']) === me;
-    const isRemote           = status.getIn(['account', 'username']) !== status.getIn(['account', 'acct']);
+    const account = status.get('account');
+    const writtenByMe = status.getIn(['account', 'id']) === me;
+    const isRemote =
+      status.getIn(['account', 'username']) !==
+      status.getIn(['account', 'acct']);
 
     let menu = [];
 
     if (publicStatus && isRemote) {
-      menu.push({ text: intl.formatMessage(messages.openOriginalPage), href: status.get('url') });
+      menu.push({
+        text: intl.formatMessage(messages.openOriginalPage),
+        href: status.get('url'),
+      });
     }
 
-    menu.push({ text: intl.formatMessage(messages.copy), action: this.handleCopy });
+    menu.push({
+      text: intl.formatMessage(messages.copy),
+      action: this.handleCopy,
+    });
 
     if (publicStatus && 'share' in navigator) {
-      menu.push({ text: intl.formatMessage(messages.share), action: this.handleShare });
+      menu.push({
+        text: intl.formatMessage(messages.share),
+        action: this.handleShare,
+      });
     }
 
     if (publicStatus && (signedIn || !isRemote)) {
-      menu.push({ text: intl.formatMessage(messages.embed), action: this.handleEmbed });
+      menu.push({
+        text: intl.formatMessage(messages.embed),
+        action: this.handleEmbed,
+      });
     }
 
     if (signedIn) {
@@ -214,32 +273,88 @@ class ActionBar extends PureComponent {
 
       if (writtenByMe) {
         if (pinnableStatus) {
-          menu.push({ text: intl.formatMessage(status.get('pinned') ? messages.unpin : messages.pin), action: this.handlePinClick });
+          menu.push({
+            text: intl.formatMessage(
+              status.get('pinned') ? messages.unpin : messages.pin,
+            ),
+            action: this.handlePinClick,
+          });
           menu.push(null);
         }
 
-        menu.push({ text: intl.formatMessage(mutingConversation ? messages.unmuteConversation : messages.muteConversation), action: this.handleConversationMuteClick });
+        menu.push({
+          text: intl.formatMessage(
+            mutingConversation
+              ? messages.unmuteConversation
+              : messages.muteConversation,
+          ),
+          action: this.handleConversationMuteClick,
+        });
         menu.push(null);
-        menu.push({ text: intl.formatMessage(messages.edit), action: this.handleEditClick });
-        menu.push({ text: intl.formatMessage(messages.delete), action: this.handleDeleteClick, dangerous: true });
-        menu.push({ text: intl.formatMessage(messages.redraft), action: this.handleRedraftClick, dangerous: true });
+        menu.push({
+          text: intl.formatMessage(messages.edit),
+          action: this.handleEditClick,
+        });
+        menu.push({
+          text: intl.formatMessage(messages.delete),
+          action: this.handleDeleteClick,
+          dangerous: true,
+        });
+        menu.push({
+          text: intl.formatMessage(messages.redraft),
+          action: this.handleRedraftClick,
+          dangerous: true,
+        });
       } else {
-        menu.push({ text: intl.formatMessage(messages.mention, { name: status.getIn(['account', 'username']) }), action: this.handleMentionClick });
+        menu.push({
+          text: intl.formatMessage(messages.mention, {
+            name: status.getIn(['account', 'username']),
+          }),
+          action: this.handleMentionClick,
+        });
         menu.push(null);
 
         if (relationship && relationship.get('muting')) {
-          menu.push({ text: intl.formatMessage(messages.unmute, { name: account.get('username') }), action: this.handleMuteClick });
+          menu.push({
+            text: intl.formatMessage(messages.unmute, {
+              name: account.get('username'),
+            }),
+            action: this.handleMuteClick,
+          });
         } else {
-          menu.push({ text: intl.formatMessage(messages.mute, { name: account.get('username') }), action: this.handleMuteClick, dangerous: true });
+          menu.push({
+            text: intl.formatMessage(messages.mute, {
+              name: account.get('username'),
+            }),
+            action: this.handleMuteClick,
+            dangerous: true,
+          });
         }
 
         if (relationship && relationship.get('blocking')) {
-          menu.push({ text: intl.formatMessage(messages.unblock, { name: account.get('username') }), action: this.handleBlockClick });
+          menu.push({
+            text: intl.formatMessage(messages.unblock, {
+              name: account.get('username'),
+            }),
+            action: this.handleBlockClick,
+          });
         } else {
-          menu.push({ text: intl.formatMessage(messages.block, { name: account.get('username') }), action: this.handleBlockClick, dangerous: true });
+          menu.push({
+            text: intl.formatMessage(messages.block, {
+              name: account.get('username'),
+            }),
+            action: this.handleBlockClick,
+            dangerous: true,
+          });
         }
 
-        menu.push({ text: intl.formatMessage(messages.report, { name: status.getIn(['account', 'username']) }), action: this.handleReport, dangerous: true });
+        menu.push({
+          text: intl.formatMessage(messages.report, {
+            name: status.getIn(['account', 'username']),
+          }),
+          action: this.handleReport,
+          dangerous: true,
+        });
 
         if (account.get('acct') !== account.get('username')) {
           const domain = account.get('acct').split('@')[1];
@@ -247,21 +362,56 @@ class ActionBar extends PureComponent {
           menu.push(null);
 
           if (relationship && relationship.get('domain_blocking')) {
-            menu.push({ text: intl.formatMessage(messages.unblockDomain, { domain }), action: this.handleUnblockDomain });
+            menu.push({
+              text: intl.formatMessage(messages.unblockDomain, { domain }),
+              action: this.handleUnblockDomain,
+            });
           } else {
-            menu.push({ text: intl.formatMessage(messages.blockDomain, { domain }), action: this.handleBlockDomain, dangerous: true });
+            menu.push({
+              text: intl.formatMessage(messages.blockDomain, { domain }),
+              action: this.handleBlockDomain,
+              dangerous: true,
+            });
           }
         }
 
-        if ((permissions & PERMISSION_MANAGE_USERS) === PERMISSION_MANAGE_USERS || (isRemote && (permissions & PERMISSION_MANAGE_FEDERATION) === PERMISSION_MANAGE_FEDERATION)) {
+        if (
+          (permissions & PERMISSION_MANAGE_USERS) === PERMISSION_MANAGE_USERS ||
+          (isRemote &&
+            (permissions & PERMISSION_MANAGE_FEDERATION) ===
+              PERMISSION_MANAGE_FEDERATION)
+        ) {
           menu.push(null);
-          if ((permissions & PERMISSION_MANAGE_USERS) === PERMISSION_MANAGE_USERS) {
-            menu.push({ text: intl.formatMessage(messages.admin_account, { name: status.getIn(['account', 'username']) }), href: `/admin/accounts/${status.getIn(['account', 'id'])}` });
-            menu.push({ text: intl.formatMessage(messages.admin_status), href: `/admin/accounts/${status.getIn(['account', 'id'])}/statuses/${status.get('id')}` });
+          if (
+            (permissions & PERMISSION_MANAGE_USERS) ===
+            PERMISSION_MANAGE_USERS
+          ) {
+            menu.push({
+              text: intl.formatMessage(messages.admin_account, {
+                name: status.getIn(['account', 'username']),
+              }),
+              href: `/admin/accounts/${status.getIn(['account', 'id'])}`,
+            });
+            menu.push({
+              text: intl.formatMessage(messages.admin_status),
+              href: `/admin/accounts/${status.getIn([
+                'account',
+                'id',
+              ])}/statuses/${status.get('id')}`,
+            });
           }
-          if (isRemote && (permissions & PERMISSION_MANAGE_FEDERATION) === PERMISSION_MANAGE_FEDERATION) {
+          if (
+            isRemote &&
+            (permissions & PERMISSION_MANAGE_FEDERATION) ===
+              PERMISSION_MANAGE_FEDERATION
+          ) {
             const domain = account.get('acct').split('@')[1];
-            menu.push({ text: intl.formatMessage(messages.admin_domain, { domain: domain }), href: `/admin/instances/${domain}` });
+            menu.push({
+              text: intl.formatMessage(messages.admin_domain, {
+                domain: domain,
+              }),
+              href: `/admin/instances/${domain}`,
+            });
           }
         }
       }
@@ -274,7 +424,9 @@ class ActionBar extends PureComponent {
       replyIcon = 'reply-all';
     }
 
-    const reblogPrivate = status.getIn(['account', 'id']) === me && status.get('visibility') === 'private';
+    const reblogPrivate =
+      status.getIn(['account', 'id']) === me &&
+      status.get('visibility') === 'private';
 
     let reblogTitle;
     if (status.get('reblogged')) {
@@ -289,18 +441,62 @@ class ActionBar extends PureComponent {
 
     return (
       <div className='detailed-status__action-bar'>
-        <div className='detailed-status__button'><IconButton title={intl.formatMessage(messages.reply)} icon={status.get('in_reply_to_account_id') === status.getIn(['account', 'id']) ? 'reply' : replyIcon} onClick={this.handleReplyClick} /></div>
-        <div className='detailed-status__button'><IconButton className={classNames({ reblogPrivate })} disabled={!publicStatus && !reblogPrivate} active={status.get('reblogged')} title={reblogTitle} icon='retweet' onClick={this.handleReblogClick} /></div>
-        <div className='detailed-status__button'><IconButton className='star-icon' animate active={status.get('favourited')} title={intl.formatMessage(messages.favourite)} icon='star' onClick={this.handleFavouriteClick} /></div>
-        <div className='detailed-status__button'><IconButton className='bookmark-icon' disabled={!signedIn} active={status.get('bookmarked')} title={intl.formatMessage(messages.bookmark)} icon='bookmark' onClick={this.handleBookmarkClick} /></div>
+        <div className='detailed-status__button'>
+          <IconButton
+            title={intl.formatMessage(messages.reply)}
+            icon={
+              status.get('in_reply_to_account_id') ===
+              status.getIn(['account', 'id'])
+                ? 'reply'
+                : replyIcon
+            }
+            onClick={this.handleReplyClick}
+          />
+        </div>
+        <div className='detailed-status__button'>
+          <IconButton
+            className={classNames({ reblogPrivate })}
+            disabled={!publicStatus && !reblogPrivate}
+            active={status.get('reblogged')}
+            title={reblogTitle}
+            icon='retweet'
+            onClick={this.handleReblogClick}
+          />
+        </div>
+        <div className='detailed-status__button'>
+          <IconButton
+            className='star-icon'
+            animate
+            active={status.get('favourited')}
+            title={intl.formatMessage(messages.favourite)}
+            icon='star'
+            onClick={this.handleFavouriteClick}
+          />
+        </div>
+        <div className='detailed-status__button'>
+          <IconButton
+            className='bookmark-icon'
+            disabled={!signedIn}
+            active={status.get('bookmarked')}
+            title={intl.formatMessage(messages.bookmark)}
+            icon='bookmark'
+            onClick={this.handleBookmarkClick}
+          />
+        </div>
 
         <div className='detailed-status__action-bar-dropdown'>
-          <DropdownMenuContainer size={18} icon='ellipsis-h' status={status} items={menu} direction='left' title={intl.formatMessage(messages.more)} />
+          <DropdownMenuContainer
+            size={18}
+            icon='ellipsis-h'
+            status={status}
+            items={menu}
+            direction='left'
+            title={intl.formatMessage(messages.more)}
+          />
         </div>
       </div>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(injectIntl(ActionBar));

--- a/app/javascript/mastodon/features/status/components/card.jsx
+++ b/app/javascript/mastodon/features/status/components/card.jsx
@@ -11,20 +11,24 @@ import Immutable from 'immutable';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 
 import { Blurhash } from 'mastodon/components/blurhash';
-import { Icon }  from 'mastodon/components/icon';
+import { Icon } from 'mastodon/components/icon';
 import { RelativeTimestamp } from 'mastodon/components/relative_timestamp';
 import { useBlurhash } from 'mastodon/initial_state';
 
 const IDNA_PREFIX = 'xn--';
 
-const decodeIDNA = domain => {
+const decodeIDNA = (domain) => {
   return domain
     .split('.')
-    .map(part => part.indexOf(IDNA_PREFIX) === 0 ? punycode.decode(part.slice(IDNA_PREFIX.length)) : part)
+    .map((part) =>
+      part.indexOf(IDNA_PREFIX) === 0
+        ? punycode.decode(part.slice(IDNA_PREFIX.length))
+        : part,
+    )
     .join('.');
 };
 
-const getHostname = url => {
+const getHostname = (url) => {
   const parser = document.createElement('a');
   parser.href = url;
   return parser.hostname;
@@ -32,7 +36,7 @@ const getHostname = url => {
 
 const domParser = new DOMParser();
 
-const addAutoPlay = html => {
+const addAutoPlay = (html) => {
   const document = domParser.parseFromString(html, 'text/html').documentElement;
   const iframe = document.querySelector('iframe');
 
@@ -54,7 +58,6 @@ const addAutoPlay = html => {
 };
 
 export default class Card extends PureComponent {
-
   static propTypes = {
     card: ImmutablePropTypes.map,
     onOpenMedia: PropTypes.func.isRequired,
@@ -67,7 +70,7 @@ export default class Card extends PureComponent {
     revealed: !this.props.sensitive,
   };
 
-  UNSAFE_componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (!Immutable.is(this.props.card, nextProps.card)) {
       this.setState({ embedded: false, previewLoaded: false });
     }
@@ -77,11 +80,11 @@ export default class Card extends PureComponent {
     }
   }
 
-  componentDidMount () {
+  componentDidMount() {
     window.addEventListener('resize', this.handleResize, { passive: true });
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     window.removeEventListener('resize', this.handleResize);
   }
 
@@ -89,7 +92,7 @@ export default class Card extends PureComponent {
     this.setState({ embedded: true });
   };
 
-  setRef = c => {
+  setRef = (c) => {
     this.node = c;
   };
 
@@ -97,13 +100,13 @@ export default class Card extends PureComponent {
     this.setState({ previewLoaded: true });
   };
 
-  handleReveal = e => {
+  handleReveal = (e) => {
     e.preventDefault();
     e.stopPropagation();
     this.setState({ revealed: true });
   };
 
-  renderVideo () {
+  renderVideo() {
     const { card } = this.props;
     const content = { __html: addAutoPlay(card.get('html')) };
 
@@ -117,7 +120,7 @@ export default class Card extends PureComponent {
     );
   }
 
-  render () {
+  render() {
     const { card } = this.props;
     const { embedded, revealed } = this.state;
 
@@ -125,21 +128,50 @@ export default class Card extends PureComponent {
       return null;
     }
 
-    const provider    = card.get('provider_name').length === 0 ? decodeIDNA(getHostname(card.get('url'))) : card.get('provider_name');
+    const provider =
+      card.get('provider_name').length === 0
+        ? decodeIDNA(getHostname(card.get('url')))
+        : card.get('provider_name');
     const interactive = card.get('type') === 'video';
-    const language    = card.get('language') || '';
-    const largeImage  = (card.get('image')?.length > 0 && card.get('width') > card.get('height')) || interactive;
+    const language = card.get('language') || '';
+    const largeImage =
+      (card.get('image')?.length > 0 &&
+        card.get('width') > card.get('height')) ||
+      interactive;
 
     const description = (
       <div className='status-card__content'>
         <span className='status-card__host'>
           <span lang={language}>{provider}</span>
-          {card.get('published_at') && <> · <RelativeTimestamp timestamp={card.get('published_at')} /></>}
+          {card.get('published_at') && (
+            <>
+              {' '}
+              · <RelativeTimestamp timestamp={card.get('published_at')} />
+            </>
+          )}
         </span>
 
-        <strong className='status-card__title' title={card.get('title')} lang={language}>{card.get('title')}</strong>
+        <strong
+          className='status-card__title'
+          title={card.get('title')}
+          lang={language}
+        >
+          {card.get('title')}
+        </strong>
 
-        {card.get('author_name').length > 0 ? <span className='status-card__author'><FormattedMessage id='link_preview.author' defaultMessage='By {name}' values={{ name: <strong>{card.get('author_name')}</strong> }} /></span> : <span className='status-card__description'>{card.get('description')}</span>}
+        {card.get('author_name').length > 0 ? (
+          <span className='status-card__author'>
+            <FormattedMessage
+              id='link_preview.author'
+              defaultMessage='By {name}'
+              values={{ name: <strong>{card.get('author_name')}</strong> }}
+            />
+          </span>
+        ) : (
+          <span className='status-card__description'>
+            {card.get('description')}
+          </span>
+        )}
       </div>
     );
 
@@ -160,7 +192,8 @@ export default class Card extends PureComponent {
     let canvas = (
       <Blurhash
         className={classNames('status-card__image-preview', {
-          'status-card__image-preview--hidden': revealed && this.state.previewLoaded,
+          'status-card__image-preview--hidden':
+            revealed && this.state.previewLoaded,
         })}
         hash={card.get('blurhash')}
         dummy={!useBlurhash}
@@ -168,19 +201,45 @@ export default class Card extends PureComponent {
     );
 
     const thumbnailDescription = card.get('image_description');
-    const thumbnail = <img src={card.get('image')} alt={thumbnailDescription} title={thumbnailDescription} lang={language} style={thumbnailStyle} onLoad={this.handleImageLoad} className='status-card__image-image' />;
+    const thumbnail = (
+      <img
+        src={card.get('image')}
+        alt={thumbnailDescription}
+        title={thumbnailDescription}
+        lang={language}
+        style={thumbnailStyle}
+        onLoad={this.handleImageLoad}
+        className='status-card__image-image'
+      />
+    );
 
     let spoilerButton = (
-      <button type='button' onClick={this.handleReveal} className='spoiler-button__overlay'>
+      <button
+        type='button'
+        onClick={this.handleReveal}
+        className='spoiler-button__overlay'
+      >
         <span className='spoiler-button__overlay__label'>
-          <FormattedMessage id='status.sensitive_warning' defaultMessage='Sensitive content' />
-          <span className='spoiler-button__overlay__action'><FormattedMessage id='status.media.show' defaultMessage='Click to show' /></span>
+          <FormattedMessage
+            id='status.sensitive_warning'
+            defaultMessage='Sensitive content'
+          />
+          <span className='spoiler-button__overlay__action'>
+            <FormattedMessage
+              id='status.media.show'
+              defaultMessage='Click to show'
+            />
+          </span>
         </span>
       </button>
     );
 
     spoilerButton = (
-      <div className={classNames('spoiler-button', { 'spoiler-button--minified': revealed })}>
+      <div
+        className={classNames('spoiler-button', {
+          'spoiler-button--minified': revealed,
+        })}
+      >
         {spoilerButton}
       </div>
     );
@@ -195,21 +254,42 @@ export default class Card extends PureComponent {
             {thumbnail}
 
             {revealed ? (
-              <div className='status-card__actions' onClick={this.handleEmbedClick} role='none'>
+              <div
+                className='status-card__actions'
+                onClick={this.handleEmbedClick}
+                role='none'
+              >
                 <div>
-                  <button type='button' onClick={this.handleEmbedClick}><Icon id='play' /></button>
-                  <a href={card.get('url')} target='_blank' rel='noopener noreferrer'><Icon id='external-link' /></a>
+                  <button type='button' onClick={this.handleEmbedClick}>
+                    <Icon id='play' />
+                  </button>
+                  <a
+                    href={card.get('url')}
+                    target='_blank'
+                    rel='noopener noreferrer'
+                  >
+                    <Icon id='external-link' />
+                  </a>
                 </div>
               </div>
-            ) : spoilerButton}
+            ) : (
+              spoilerButton
+            )}
           </div>
         );
       }
 
       return (
-        <div className={classNames('status-card', { expanded: largeImage })} ref={this.setRef} onClick={revealed ? null : this.handleReveal} role={revealed ? 'button' : null}>
+        <div
+          className={classNames('status-card', { expanded: largeImage })}
+          ref={this.setRef}
+          onClick={revealed ? null : this.handleReveal}
+          role={revealed ? 'button' : null}
+        >
           {embed}
-          <a href={card.get('url')} target='_blank' rel='noopener noreferrer'>{description}</a>
+          <a href={card.get('url')} target='_blank' rel='noopener noreferrer'>
+            {description}
+          </a>
         </div>
       );
     } else if (card.get('image')) {
@@ -228,11 +308,16 @@ export default class Card extends PureComponent {
     }
 
     return (
-      <a href={card.get('url')} className={classNames('status-card', { expanded: largeImage })} target='_blank' rel='noopener noreferrer' ref={this.setRef}>
+      <a
+        href={card.get('url')}
+        className={classNames('status-card', { expanded: largeImage })}
+        target='_blank'
+        rel='noopener noreferrer'
+        ref={this.setRef}
+      >
         {embed}
         {description}
       </a>
     );
   }
-
 }

--- a/app/javascript/mastodon/features/status/components/detailed_status.jsx
+++ b/app/javascript/mastodon/features/status/components/detailed_status.jsx
@@ -1,6 +1,11 @@
 import PropTypes from 'prop-types';
 
-import { injectIntl, defineMessages, FormattedDate, FormattedMessage } from 'react-intl';
+import {
+  injectIntl,
+  defineMessages,
+  FormattedDate,
+  FormattedMessage,
+} from 'react-intl';
 
 import classNames from 'classnames';
 import { Link } from 'react-router-dom';
@@ -11,7 +16,7 @@ import ImmutablePureComponent from 'react-immutable-pure-component';
 import { AnimatedNumber } from 'mastodon/components/animated_number';
 import EditedTimestamp from 'mastodon/components/edited_timestamp';
 import { getHashtagBarForStatus } from 'mastodon/components/hashtag_bar';
-import { Icon }  from 'mastodon/components/icon';
+import { Icon } from 'mastodon/components/icon';
 import PictureInPicturePlaceholder from 'mastodon/components/picture_in_picture_placeholder';
 
 import { Avatar } from '../../../components/avatar';
@@ -27,12 +32,17 @@ import Card from './card';
 const messages = defineMessages({
   public_short: { id: 'privacy.public.short', defaultMessage: 'Public' },
   unlisted_short: { id: 'privacy.unlisted.short', defaultMessage: 'Unlisted' },
-  private_short: { id: 'privacy.private.short', defaultMessage: 'Followers only' },
-  direct_short: { id: 'privacy.direct.short', defaultMessage: 'Mentioned people only' },
+  private_short: {
+    id: 'privacy.private.short',
+    defaultMessage: 'Followers only',
+  },
+  direct_short: {
+    id: 'privacy.direct.short',
+    defaultMessage: 'Mentioned people only',
+  },
 });
 
 class DetailedStatus extends ImmutablePureComponent {
-
   static contextTypes = {
     router: PropTypes.object,
   };
@@ -62,23 +72,32 @@ class DetailedStatus extends ImmutablePureComponent {
   handleAccountClick = (e) => {
     if (e.button === 0 && !(e.ctrlKey || e.metaKey) && this.context.router) {
       e.preventDefault();
-      this.context.router.history.push(`/@${this.props.status.getIn(['account', 'acct'])}`);
+      this.context.router.history.push(
+        `/@${this.props.status.getIn(['account', 'acct'])}`,
+      );
     }
 
     e.stopPropagation();
   };
 
   handleOpenVideo = (options) => {
-    this.props.onOpenVideo(this.props.status.getIn(['media_attachments', 0]), options);
+    this.props.onOpenVideo(
+      this.props.status.getIn(['media_attachments', 0]),
+      options,
+    );
   };
 
   handleExpandedToggle = () => {
     this.props.onToggleHidden(this.props.status);
   };
 
-  _measureHeight (heightJustChanged) {
+  _measureHeight(heightJustChanged) {
     if (this.props.measureHeight && this.node) {
-      scheduleIdleTask(() => this.node && this.setState({ height: Math.ceil(this.node.scrollHeight) + 1 }));
+      scheduleIdleTask(
+        () =>
+          this.node &&
+          this.setState({ height: Math.ceil(this.node.scrollHeight) + 1 }),
+      );
 
       if (this.props.onHeightChange && heightJustChanged) {
         this.props.onHeightChange();
@@ -86,16 +105,16 @@ class DetailedStatus extends ImmutablePureComponent {
     }
   }
 
-  setRef = c => {
+  setRef = (c) => {
     this.node = c;
     this._measureHeight();
   };
 
-  componentDidUpdate (prevProps, prevState) {
+  componentDidUpdate(prevProps, prevState) {
     this._measureHeight(prevState.height !== this.state.height);
   }
 
-  handleModalLink = e => {
+  handleModalLink = (e) => {
     e.preventDefault();
 
     let href;
@@ -106,7 +125,11 @@ class DetailedStatus extends ImmutablePureComponent {
       href = e.target.href;
     }
 
-    window.open(href, 'mastodon-intent', 'width=445,height=600,resizable=no,menubar=no,status=no,scrollbars=yes');
+    window.open(
+      href,
+      'mastodon-intent',
+      'width=445,height=600,resizable=no,menubar=no,status=no,scrollbars=yes',
+    );
   };
 
   handleTranslate = () => {
@@ -114,29 +137,40 @@ class DetailedStatus extends ImmutablePureComponent {
     onTranslate(status);
   };
 
-  _properStatus () {
+  _properStatus() {
     const { status } = this.props;
 
-    if (status.get('reblog', null) !== null && typeof status.get('reblog') === 'object') {
+    if (
+      status.get('reblog', null) !== null &&
+      typeof status.get('reblog') === 'object'
+    ) {
       return status.get('reblog');
     } else {
       return status;
     }
   }
 
-  getAttachmentAspectRatio () {
+  getAttachmentAspectRatio() {
     const attachments = this._properStatus().get('media_attachments');
 
     if (attachments.getIn([0, 'type']) === 'video') {
-      return `${attachments.getIn([0, 'meta', 'original', 'width'])} / ${attachments.getIn([0, 'meta', 'original', 'height'])}`;
+      return `${attachments.getIn([
+        0,
+        'meta',
+        'original',
+        'width',
+      ])} / ${attachments.getIn([0, 'meta', 'original', 'height'])}`;
     } else if (attachments.getIn([0, 'type']) === 'audio') {
       return '16 / 9';
     } else {
-      return (attachments.size === 1 && attachments.getIn([0, 'meta', 'small', 'aspect'])) ? attachments.getIn([0, 'meta', 'small', 'aspect']) : '3 / 2'
+      return attachments.size === 1 &&
+        attachments.getIn([0, 'meta', 'small', 'aspect'])
+        ? attachments.getIn([0, 'meta', 'small', 'aspect'])
+        : '3 / 2';
     }
   }
 
-  render () {
+  render() {
     const status = this._properStatus();
     const outerStyle = { boxSizing: 'border-box' };
     const { intl, compact, pictureInPicture } = this.props;
@@ -145,7 +179,7 @@ class DetailedStatus extends ImmutablePureComponent {
       return null;
     }
 
-    let media           = '';
+    let media = '';
     let applicationLink = '';
     let reblogLink = '';
     let reblogIcon = 'retweet';
@@ -156,14 +190,21 @@ class DetailedStatus extends ImmutablePureComponent {
       outerStyle.height = `${this.state.height}px`;
     }
 
-    const language = status.getIn(['translation', 'language']) || status.get('language');
+    const language =
+      status.getIn(['translation', 'language']) || status.get('language');
 
     if (pictureInPicture.get('inUse')) {
-      media = <PictureInPicturePlaceholder aspectRatio={this.getAttachmentAspectRatio()} />;
+      media = (
+        <PictureInPicturePlaceholder
+          aspectRatio={this.getAttachmentAspectRatio()}
+        />
+      );
     } else if (status.get('media_attachments').size > 0) {
       if (status.getIn(['media_attachments', 0, 'type']) === 'audio') {
         const attachment = status.getIn(['media_attachments', 0]);
-        const description = attachment.getIn(['translation', 'description']) || attachment.get('description');
+        const description =
+          attachment.getIn(['translation', 'description']) ||
+          attachment.get('description');
 
         media = (
           <Audio
@@ -171,7 +212,10 @@ class DetailedStatus extends ImmutablePureComponent {
             alt={description}
             lang={language}
             duration={attachment.getIn(['meta', 'original', 'duration'], 0)}
-            poster={attachment.get('preview_url') || status.getIn(['account', 'avatar_static'])}
+            poster={
+              attachment.get('preview_url') ||
+              status.getIn(['account', 'avatar_static'])
+            }
             backgroundColor={attachment.getIn(['meta', 'colors', 'background'])}
             foregroundColor={attachment.getIn(['meta', 'colors', 'foreground'])}
             accentColor={attachment.getIn(['meta', 'colors', 'accent'])}
@@ -184,13 +228,19 @@ class DetailedStatus extends ImmutablePureComponent {
         );
       } else if (status.getIn(['media_attachments', 0, 'type']) === 'video') {
         const attachment = status.getIn(['media_attachments', 0]);
-        const description = attachment.getIn(['translation', 'description']) || attachment.get('description');
+        const description =
+          attachment.getIn(['translation', 'description']) ||
+          attachment.get('description');
 
         media = (
           <Video
             preview={attachment.get('preview_url')}
             frameRate={attachment.getIn(['meta', 'original', 'frame_rate'])}
-            aspectRatio={`${attachment.getIn(['meta', 'original', 'width'])} / ${attachment.getIn(['meta', 'original', 'height'])}`}
+            aspectRatio={`${attachment.getIn([
+              'meta',
+              'original',
+              'width',
+            ])} / ${attachment.getIn(['meta', 'original', 'height'])}`}
             blurhash={attachment.get('blurhash')}
             src={attachment.get('url')}
             alt={description}
@@ -218,22 +268,55 @@ class DetailedStatus extends ImmutablePureComponent {
         );
       }
     } else if (status.get('spoiler_text').length === 0) {
-      media = <Card sensitive={status.get('sensitive')} onOpenMedia={this.props.onOpenMedia} card={status.get('card', null)} />;
+      media = (
+        <Card
+          sensitive={status.get('sensitive')}
+          onOpenMedia={this.props.onOpenMedia}
+          card={status.get('card', null)}
+        />
+      );
     }
 
     if (status.get('application')) {
-      applicationLink = <> · <a className='detailed-status__application' href={status.getIn(['application', 'website'])} target='_blank' rel='noopener noreferrer'>{status.getIn(['application', 'name'])}</a></>;
+      applicationLink = (
+        <>
+          {' '}
+          ·{' '}
+          <a
+            className='detailed-status__application'
+            href={status.getIn(['application', 'website'])}
+            target='_blank'
+            rel='noopener noreferrer'
+          >
+            {status.getIn(['application', 'name'])}
+          </a>
+        </>
+      );
     }
 
     const visibilityIconInfo = {
-      'public': { icon: 'globe', text: intl.formatMessage(messages.public_short) },
-      'unlisted': { icon: 'unlock', text: intl.formatMessage(messages.unlisted_short) },
-      'private': { icon: 'lock', text: intl.formatMessage(messages.private_short) },
-      'direct': { icon: 'at', text: intl.formatMessage(messages.direct_short) },
+      public: {
+        icon: 'globe',
+        text: intl.formatMessage(messages.public_short),
+      },
+      unlisted: {
+        icon: 'unlock',
+        text: intl.formatMessage(messages.unlisted_short),
+      },
+      private: {
+        icon: 'lock',
+        text: intl.formatMessage(messages.private_short),
+      },
+      direct: { icon: 'at', text: intl.formatMessage(messages.direct_short) },
     };
 
     const visibilityIcon = visibilityIconInfo[status.get('visibility')];
-    const visibilityLink = <> · <Icon id={visibilityIcon.icon} title={visibilityIcon.text} /></>;
+    const visibilityLink = (
+      <>
+        {' '}
+        · <Icon id={visibilityIcon.icon} title={visibilityIcon.text} />
+      </>
+    );
 
     if (['private', 'direct'].includes(status.get('visibility'))) {
       reblogLink = '';
@@ -241,7 +324,12 @@ class DetailedStatus extends ImmutablePureComponent {
       reblogLink = (
         <>
           {' · '}
-          <Link to={`/@${status.getIn(['account', 'acct'])}/${status.get('id')}/reblogs`} className='detailed-status__link'>
+          <Link
+            to={`/@${status.getIn(['account', 'acct'])}/${status.get(
+              'id',
+            )}/reblogs`}
+            className='detailed-status__link'
+          >
             <Icon id={reblogIcon} />
             <span className='detailed-status__reblogs'>
               <AnimatedNumber value={status.get('reblogs_count')} />
@@ -253,7 +341,11 @@ class DetailedStatus extends ImmutablePureComponent {
       reblogLink = (
         <>
           {' · '}
-          <a href={`/interact/${status.get('id')}?type=reblog`} className='detailed-status__link' onClick={this.handleModalLink}>
+          <a
+            href={`/interact/${status.get('id')}?type=reblog`}
+            className='detailed-status__link'
+            onClick={this.handleModalLink}
+          >
             <Icon id={reblogIcon} />
             <span className='detailed-status__reblogs'>
               <AnimatedNumber value={status.get('reblogs_count')} />
@@ -265,7 +357,12 @@ class DetailedStatus extends ImmutablePureComponent {
 
     if (this.context.router) {
       favouriteLink = (
-        <Link to={`/@${status.getIn(['account', 'acct'])}/${status.get('id')}/favourites`} className='detailed-status__link'>
+        <Link
+          to={`/@${status.getIn(['account', 'acct'])}/${status.get(
+            'id',
+          )}/favourites`}
+          className='detailed-status__link'
+        >
           <Icon id='star' />
           <span className='detailed-status__favorites'>
             <AnimatedNumber value={status.get('favourites_count')} />
@@ -274,7 +371,11 @@ class DetailedStatus extends ImmutablePureComponent {
       );
     } else {
       favouriteLink = (
-        <a href={`/interact/${status.get('id')}?type=favourite`} className='detailed-status__link' onClick={this.handleModalLink}>
+        <a
+          href={`/interact/${status.get('id')}?type=favourite`}
+          className='detailed-status__link'
+          onClick={this.handleModalLink}
+        >
           <Icon id='star' />
           <span className='detailed-status__favorites'>
             <AnimatedNumber value={status.get('favourites_count')} />
@@ -287,26 +388,46 @@ class DetailedStatus extends ImmutablePureComponent {
       edited = (
         <>
           {' · '}
-          <EditedTimestamp statusId={status.get('id')} timestamp={status.get('edited_at')} />
+          <EditedTimestamp
+            statusId={status.get('id')}
+            timestamp={status.get('edited_at')}
+          />
         </>
       );
     }
 
-    const {statusContentProps, hashtagBar} = getHashtagBarForStatus(status);
-    const expanded = !status.get('hidden')
+    const { statusContentProps, hashtagBar } = getHashtagBarForStatus(status);
+    const expanded = !status.get('hidden');
 
     return (
       <div style={outerStyle}>
-        <div ref={this.setRef} className={classNames('detailed-status', { compact })}>
+        <div
+          ref={this.setRef}
+          className={classNames('detailed-status', { compact })}
+        >
           {status.get('visibility') === 'direct' && (
             <div className='status__prepend'>
-              <div className='status__prepend-icon-wrapper'><Icon id='at' className='status__prepend-icon' fixedWidth /></div>
-              <FormattedMessage id='status.direct_indicator' defaultMessage='Private mention' />
+              <div className='status__prepend-icon-wrapper'>
+                <Icon id='at' className='status__prepend-icon' fixedWidth />
+              </div>
+              <FormattedMessage
+                id='status.direct_indicator'
+                defaultMessage='Private mention'
+              />
             </div>
           )}
-          <a href={`/@${status.getIn(['account', 'acct'])}`} onClick={this.handleAccountClick} className='detailed-status__display-name'>
-            <div className='detailed-status__display-avatar'><Avatar account={status.get('account')} size={46} /></div>
-            <DisplayName account={status.get('account')} localDomain={this.props.domain} />
+          <a
+            href={`/@${status.getIn(['account', 'acct'])}`}
+            onClick={this.handleAccountClick}
+            className='detailed-status__display-name'
+          >
+            <div className='detailed-status__display-avatar'>
+              <Avatar account={status.get('account')} size={46} />
+            </div>
+            <DisplayName
+              account={status.get('account')}
+              localDomain={this.props.domain}
+            />
           </a>
 
           <StatusContent
@@ -322,15 +443,33 @@ class DetailedStatus extends ImmutablePureComponent {
           {expanded && hashtagBar}
 
           <div className='detailed-status__meta'>
-            <a className='detailed-status__datetime' href={`/@${status.getIn(['account', 'acct'])}/${status.get('id')}`} target='_blank' rel='noopener noreferrer'>
-              <FormattedDate value={new Date(status.get('created_at'))} hour12={false} year='numeric' month='short' day='2-digit' hour='2-digit' minute='2-digit' />
-            </a>{edited}{visibilityLink}{applicationLink}{reblogLink} · {favouriteLink}
+            <a
+              className='detailed-status__datetime'
+              href={`/@${status.getIn(['account', 'acct'])}/${status.get(
+                'id',
+              )}`}
+              target='_blank'
+              rel='noopener noreferrer'
+            >
+              <FormattedDate
+                value={new Date(status.get('created_at'))}
+                hour12={false}
+                year='numeric'
+                month='short'
+                day='2-digit'
+                hour='2-digit'
+                minute='2-digit'
+              />
+            </a>
+            {edited}
+            {visibilityLink}
+            {applicationLink}
+            {reblogLink} · {favouriteLink}
           </div>
         </div>
       </div>
     );
   }
-
 }
 
 export default injectIntl(DetailedStatus);

--- a/app/javascript/mastodon/features/status/containers/detailed_status_container.js
+++ b/app/javascript/mastodon/features/status/containers/detailed_status_container.js
@@ -33,12 +33,29 @@ import { makeGetStatus, makeGetPictureInPicture } from '../../../selectors';
 import DetailedStatus from '../components/detailed_status';
 
 const messages = defineMessages({
-  deleteConfirm: { id: 'confirmations.delete.confirm', defaultMessage: 'Delete' },
-  deleteMessage: { id: 'confirmations.delete.message', defaultMessage: 'Are you sure you want to delete this status?' },
-  redraftConfirm: { id: 'confirmations.redraft.confirm', defaultMessage: 'Delete & redraft' },
-  redraftMessage: { id: 'confirmations.redraft.message', defaultMessage: 'Are you sure you want to delete this status and re-draft it? Favorites and boosts will be lost, and replies to the original post will be orphaned.' },
+  deleteConfirm: {
+    id: 'confirmations.delete.confirm',
+    defaultMessage: 'Delete',
+  },
+  deleteMessage: {
+    id: 'confirmations.delete.message',
+    defaultMessage: 'Are you sure you want to delete this status?',
+  },
+  redraftConfirm: {
+    id: 'confirmations.redraft.confirm',
+    defaultMessage: 'Delete & redraft',
+  },
+  redraftMessage: {
+    id: 'confirmations.redraft.message',
+    defaultMessage:
+      'Are you sure you want to delete this status and re-draft it? Favorites and boosts will be lost, and replies to the original post will be orphaned.',
+  },
   replyConfirm: { id: 'confirmations.reply.confirm', defaultMessage: 'Reply' },
-  replyMessage: { id: 'confirmations.reply.message', defaultMessage: 'Replying now will overwrite the message you are currently composing. Are you sure you want to proceed?' },
+  replyMessage: {
+    id: 'confirmations.reply.message',
+    defaultMessage:
+      'Replying now will overwrite the message you are currently composing. Are you sure you want to proceed?',
+  },
 });
 
 const makeMapStateToProps = () => {
@@ -55,30 +72,31 @@ const makeMapStateToProps = () => {
 };
 
 const mapDispatchToProps = (dispatch, { intl }) => ({
-
-  onReply (status, router) {
+  onReply(status, router) {
     dispatch((_, getState) => {
       let state = getState();
       if (state.getIn(['compose', 'text']).trim().length !== 0) {
-        dispatch(openModal({
-          modalType: 'CONFIRM',
-          modalProps: {
-            message: intl.formatMessage(messages.replyMessage),
-            confirm: intl.formatMessage(messages.replyConfirm),
-            onConfirm: () => dispatch(replyCompose(status, router)),
-          },
-        }));
+        dispatch(
+          openModal({
+            modalType: 'CONFIRM',
+            modalProps: {
+              message: intl.formatMessage(messages.replyMessage),
+              confirm: intl.formatMessage(messages.replyConfirm),
+              onConfirm: () => dispatch(replyCompose(status, router)),
+            },
+          }),
+        );
       } else {
         dispatch(replyCompose(status, router));
       }
     });
   },
 
-  onModalReblog (status, privacy) {
+  onModalReblog(status, privacy) {
     dispatch(reblog(status, privacy));
   },
 
-  onReblog (status, e) {
+  onReblog(status, e) {
     if (status.get('reblogged')) {
       dispatch(unreblog(status));
     } else {
@@ -90,7 +108,7 @@ const mapDispatchToProps = (dispatch, { intl }) => ({
     }
   },
 
-  onFavourite (status) {
+  onFavourite(status) {
     if (status.get('favourited')) {
       dispatch(unfavourite(status));
     } else {
@@ -98,7 +116,7 @@ const mapDispatchToProps = (dispatch, { intl }) => ({
     }
   },
 
-  onPin (status) {
+  onPin(status) {
     if (status.get('pinned')) {
       dispatch(unpin(status));
     } else {
@@ -106,67 +124,80 @@ const mapDispatchToProps = (dispatch, { intl }) => ({
     }
   },
 
-  onEmbed (status) {
-    dispatch(openModal({
-      modalType: 'EMBED',
-      modalProps: {
-        id: status.get('id'),
-        onError: error => dispatch(showAlertForError(error)),
-      },
-    }));
+  onEmbed(status) {
+    dispatch(
+      openModal({
+        modalType: 'EMBED',
+        modalProps: {
+          id: status.get('id'),
+          onError: (error) => dispatch(showAlertForError(error)),
+        },
+      }),
+    );
   },
 
-  onDelete (status, history, withRedraft = false) {
+  onDelete(status, history, withRedraft = false) {
     if (!deleteModal) {
       dispatch(deleteStatus(status.get('id'), history, withRedraft));
     } else {
-      dispatch(openModal({
-        modalType: 'CONFIRM',
-        modalProps: {
-          message: intl.formatMessage(withRedraft ? messages.redraftMessage : messages.deleteMessage),
-          confirm: intl.formatMessage(withRedraft ? messages.redraftConfirm : messages.deleteConfirm),
-          onConfirm: () => dispatch(deleteStatus(status.get('id'), history, withRedraft)),
-        },
-      }));
+      dispatch(
+        openModal({
+          modalType: 'CONFIRM',
+          modalProps: {
+            message: intl.formatMessage(
+              withRedraft ? messages.redraftMessage : messages.deleteMessage,
+            ),
+            confirm: intl.formatMessage(
+              withRedraft ? messages.redraftConfirm : messages.deleteConfirm,
+            ),
+            onConfirm: () =>
+              dispatch(deleteStatus(status.get('id'), history, withRedraft)),
+          },
+        }),
+      );
     }
   },
 
-  onDirect (account, router) {
+  onDirect(account, router) {
     dispatch(directCompose(account, router));
   },
 
-  onMention (account, router) {
+  onMention(account, router) {
     dispatch(mentionCompose(account, router));
   },
 
-  onOpenMedia (media, index, lang) {
-    dispatch(openModal({
-      modalType: 'MEDIA',
-      modalProps: { media, index, lang },
-    }));
+  onOpenMedia(media, index, lang) {
+    dispatch(
+      openModal({
+        modalType: 'MEDIA',
+        modalProps: { media, index, lang },
+      }),
+    );
   },
 
-  onOpenVideo (media, lang, options) {
-    dispatch(openModal({
-      modalType: 'VIDEO',
-      modalProps: { media, lang, options },
-    }));
+  onOpenVideo(media, lang, options) {
+    dispatch(
+      openModal({
+        modalType: 'VIDEO',
+        modalProps: { media, lang, options },
+      }),
+    );
   },
 
-  onBlock (status) {
+  onBlock(status) {
     const account = status.get('account');
     dispatch(initBlockModal(account));
   },
 
-  onReport (status) {
+  onReport(status) {
     dispatch(initReport(status.get('account'), status));
   },
 
-  onMute (account) {
+  onMute(account) {
     dispatch(initMuteModal(account));
   },
 
-  onMuteConversation (status) {
+  onMuteConversation(status) {
     if (status.get('muted')) {
       dispatch(unmuteStatus(status.get('id')));
     } else {
@@ -174,14 +205,15 @@ const mapDispatchToProps = (dispatch, { intl }) => ({
     }
   },
 
-  onToggleHidden (status) {
+  onToggleHidden(status) {
     if (status.get('hidden')) {
       dispatch(revealStatus(status.get('id')));
     } else {
       dispatch(hideStatus(status.get('id')));
     }
   },
-
 });
 
-export default injectIntl(connect(makeMapStateToProps, mapDispatchToProps)(DetailedStatus));
+export default injectIntl(
+  connect(makeMapStateToProps, mapDispatchToProps)(DetailedStatus),
+);

--- a/app/javascript/mastodon/features/subscribed_languages_modal/index.jsx
+++ b/app/javascript/mastodon/features/subscribed_languages_modal/index.jsx
@@ -18,28 +18,39 @@ const messages = defineMessages({
   close: { id: 'lightbox.close', defaultMessage: 'Close' },
 });
 
-const getAccountLanguages = createSelector([
-  (state, accountId) => state.getIn(['timelines', `account:${accountId}`, 'items'], ImmutableList()),
-  state => state.get('statuses'),
-], (statusIds, statuses) =>
-  new ImmutableSet(statusIds.map(statusId => statuses.get(statusId)).filter(status => !status.get('reblog')).map(status => status.get('language'))));
+const getAccountLanguages = createSelector(
+  [
+    (state, accountId) =>
+      state.getIn(
+        ['timelines', `account:${accountId}`, 'items'],
+        ImmutableList(),
+      ),
+    (state) => state.get('statuses'),
+  ],
+  (statusIds, statuses) =>
+    new ImmutableSet(
+      statusIds
+        .map((statusId) => statuses.get(statusId))
+        .filter((status) => !status.get('reblog'))
+        .map((status) => status.get('language')),
+    ),
+);
 
 const mapStateToProps = (state, { accountId }) => ({
   acct: state.getIn(['accounts', accountId, 'acct']),
   availableLanguages: getAccountLanguages(state, accountId),
-  selectedLanguages: ImmutableSet(state.getIn(['relationships', accountId, 'languages']) || ImmutableList()),
+  selectedLanguages: ImmutableSet(
+    state.getIn(['relationships', accountId, 'languages']) || ImmutableList(),
+  ),
 });
 
 const mapDispatchToProps = (dispatch, { accountId }) => ({
-
-  onSubmit (languages) {
+  onSubmit(languages) {
     dispatch(followAccount(accountId, { languages }));
   },
-
 });
 
 class SubscribedLanguagesModal extends ImmutablePureComponent {
-
   static propTypes = {
     accountId: PropTypes.string.isRequired,
     acct: PropTypes.string.isRequired,
@@ -74,8 +85,10 @@ class SubscribedLanguagesModal extends ImmutablePureComponent {
     this.props.onClose();
   };
 
-  renderItem (value) {
-    const language = this.props.languages.find(language => language[0] === value);
+  renderItem(value) {
+    const language = this.props.languages.find(
+      (language) => language[0] === value,
+    );
     const checked = this.state.selectedLanguages.includes(value);
 
     if (!language) {
@@ -95,33 +108,65 @@ class SubscribedLanguagesModal extends ImmutablePureComponent {
     );
   }
 
-  render () {
-    const { acct, availableLanguages, selectedLanguages, intl, onClose } = this.props;
+  render() {
+    const { acct, availableLanguages, selectedLanguages, intl, onClose } =
+      this.props;
 
     return (
       <div className='modal-root__modal report-dialog-modal'>
         <div className='report-modal__target'>
-          <IconButton className='report-modal__close' title={intl.formatMessage(messages.close)} icon='times' onClick={onClose} size={20} />
-          <FormattedMessage id='subscribed_languages.target' defaultMessage='Change subscribed languages for {target}' values={{ target: <strong>{acct}</strong> }} />
+          <IconButton
+            className='report-modal__close'
+            title={intl.formatMessage(messages.close)}
+            icon='times'
+            onClick={onClose}
+            size={20}
+          />
+          <FormattedMessage
+            id='subscribed_languages.target'
+            defaultMessage='Change subscribed languages for {target}'
+            values={{ target: <strong>{acct}</strong> }}
+          />
         </div>
 
         <div className='report-dialog-modal__container'>
-          <p className='report-dialog-modal__lead'><FormattedMessage id='subscribed_languages.lead' defaultMessage='Only posts in selected languages will appear on your home and list timelines after the change. Select none to receive posts in all languages.' /></p>
+          <p className='report-dialog-modal__lead'>
+            <FormattedMessage
+              id='subscribed_languages.lead'
+              defaultMessage='Only posts in selected languages will appear on your home and list timelines after the change. Select none to receive posts in all languages.'
+            />
+          </p>
 
           <div>
-            {availableLanguages.union(selectedLanguages).delete(null).map(value => this.renderItem(value))}
+            {availableLanguages
+              .union(selectedLanguages)
+              .delete(null)
+              .map((value) => this.renderItem(value))}
           </div>
 
           <div className='flex-spacer' />
 
           <div className='report-dialog-modal__actions'>
-            <Button disabled={is(this.state.selectedLanguages, this.props.selectedLanguages)} onClick={this.handleSubmit}><FormattedMessage id='subscribed_languages.save' defaultMessage='Save changes' /></Button>
+            <Button
+              disabled={is(
+                this.state.selectedLanguages,
+                this.props.selectedLanguages,
+              )}
+              onClick={this.handleSubmit}
+            >
+              <FormattedMessage
+                id='subscribed_languages.save'
+                defaultMessage='Save changes'
+              />
+            </Button>
           </div>
         </div>
       </div>
     );
   }
-
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(injectIntl(SubscribedLanguagesModal));
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(injectIntl(SubscribedLanguagesModal));

--- a/app/javascript/mastodon/features/ui/components/actions_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/actions_modal.jsx
@@ -8,7 +8,6 @@ import ImmutablePureComponent from 'react-immutable-pure-component';
 import { IconButton } from '../../../components/icon_button';
 
 export default class ActionsModal extends ImmutablePureComponent {
-
   static propTypes = {
     status: ImmutablePropTypes.map,
     actions: PropTypes.array,
@@ -20,14 +19,39 @@ export default class ActionsModal extends ImmutablePureComponent {
       return <li key={`sep-${i}`} className='dropdown-menu__separator' />;
     }
 
-    const { icon = null, text, meta = null, active = false, href = '#' } = action;
+    const {
+      icon = null,
+      text,
+      meta = null,
+      active = false,
+      href = '#',
+    } = action;
 
     return (
       <li key={`${text}-${i}`}>
-        <a href={href} target='_blank' rel='noopener noreferrer' onClick={this.props.onClick} data-index={i} className={classNames({ active })}>
-          {icon && <IconButton title={text} icon={icon} role='presentation' tabIndex={-1} inverted />}
+        <a
+          href={href}
+          target='_blank'
+          rel='noopener noreferrer'
+          onClick={this.props.onClick}
+          data-index={i}
+          className={classNames({ active })}
+        >
+          {icon && (
+            <IconButton
+              title={text}
+              icon={icon}
+              role='presentation'
+              tabIndex={-1}
+              inverted
+            />
+          )}
           <div>
-            <div className={classNames({ 'actions-modal__item-label': !!meta })}>{text}</div>
+            <div
+              className={classNames({ 'actions-modal__item-label': !!meta })}
+            >
+              {text}
+            </div>
             <div>{meta}</div>
           </div>
         </a>
@@ -35,7 +59,7 @@ export default class ActionsModal extends ImmutablePureComponent {
     );
   };
 
-  render () {
+  render() {
     return (
       <div className='modal-root__modal actions-modal'>
         <ul className={classNames({ 'with-status': !!status })}>
@@ -44,5 +68,4 @@ export default class ActionsModal extends ImmutablePureComponent {
       </div>
     );
   }
-
 }

--- a/app/javascript/mastodon/features/ui/components/audio_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/audio_modal.jsx
@@ -9,11 +9,14 @@ import Footer from 'mastodon/features/picture_in_picture/components/footer';
 
 const mapStateToProps = (state, { statusId }) => ({
   status: state.getIn(['statuses', statusId]),
-  accountStaticAvatar: state.getIn(['accounts', state.getIn(['statuses', statusId, 'account']), 'avatar_static']),
+  accountStaticAvatar: state.getIn([
+    'accounts',
+    state.getIn(['statuses', statusId, 'account']),
+    'avatar_static',
+  ]),
 });
 
 class AudioModal extends ImmutablePureComponent {
-
   static propTypes = {
     media: ImmutablePropTypes.map.isRequired,
     statusId: PropTypes.string.isRequired,
@@ -26,11 +29,13 @@ class AudioModal extends ImmutablePureComponent {
     onChangeBackgroundColor: PropTypes.func.isRequired,
   };
 
-  render () {
+  render() {
     const { media, status, accountStaticAvatar, onClose } = this.props;
     const options = this.props.options || {};
-    const language = status.getIn(['translation', 'language']) || status.get('language');
-    const description = media.getIn(['translation', 'description']) || media.get('description');
+    const language =
+      status.getIn(['translation', 'language']) || status.get('language');
+    const description =
+      media.getIn(['translation', 'description']) || media.get('description');
 
     return (
       <div className='modal-root__modal audio-modal'>
@@ -50,12 +55,19 @@ class AudioModal extends ImmutablePureComponent {
         </div>
 
         <div className='media-modal__overlay'>
-          {status && <Footer statusId={status.get('id')} withOpenButton onClose={onClose} />}
+          {status && (
+            <Footer
+              statusId={status.get('id')}
+              withOpenButton
+              onClose={onClose}
+            />
+          )}
         </div>
       </div>
     );
   }
-
 }
 
-export default connect(mapStateToProps, null, null, { forwardRef: true })(AudioModal);
+export default connect(mapStateToProps, null, null, { forwardRef: true })(
+  AudioModal,
+);

--- a/app/javascript/mastodon/features/ui/components/block_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/block_modal.jsx
@@ -14,14 +14,14 @@ import { makeGetAccount } from '../../../selectors';
 const makeMapStateToProps = () => {
   const getAccount = makeGetAccount();
 
-  const mapStateToProps = state => ({
+  const mapStateToProps = (state) => ({
     account: getAccount(state, state.getIn(['blocks', 'new', 'account_id'])),
   });
 
   return mapStateToProps;
 };
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
     onConfirm(account) {
       dispatch(blockAccount(account.get('id')));
@@ -33,16 +33,17 @@ const mapDispatchToProps = dispatch => {
     },
 
     onClose() {
-      dispatch(closeModal({
-        modalType: undefined,
-        ignoreFocus: false,
-      }));
+      dispatch(
+        closeModal({
+          modalType: undefined,
+          ignoreFocus: false,
+        }),
+      );
     },
   };
 };
 
 class BlockModal extends PureComponent {
-
   static propTypes = {
     account: PropTypes.object.isRequired,
     onClose: PropTypes.func.isRequired,
@@ -73,7 +74,7 @@ class BlockModal extends PureComponent {
     this.button = c;
   };
 
-  render () {
+  render() {
     const { account } = this.props;
 
     return (
@@ -89,20 +90,37 @@ class BlockModal extends PureComponent {
         </div>
 
         <div className='block-modal__action-bar'>
-          <Button onClick={this.handleCancel} className='block-modal__cancel-button'>
-            <FormattedMessage id='confirmation_modal.cancel' defaultMessage='Cancel' />
+          <Button
+            onClick={this.handleCancel}
+            className='block-modal__cancel-button'
+          >
+            <FormattedMessage
+              id='confirmation_modal.cancel'
+              defaultMessage='Cancel'
+            />
           </Button>
-          <Button onClick={this.handleSecondary} className='confirmation-modal__secondary-button'>
-            <FormattedMessage id='confirmations.block.block_and_report' defaultMessage='Block & Report' />
+          <Button
+            onClick={this.handleSecondary}
+            className='confirmation-modal__secondary-button'
+          >
+            <FormattedMessage
+              id='confirmations.block.block_and_report'
+              defaultMessage='Block & Report'
+            />
           </Button>
           <Button onClick={this.handleClick} ref={this.setRef}>
-            <FormattedMessage id='confirmations.block.confirm' defaultMessage='Block' />
+            <FormattedMessage
+              id='confirmations.block.confirm'
+              defaultMessage='Block'
+            />
           </Button>
         </div>
       </div>
     );
   }
-
 }
 
-export default connect(makeMapStateToProps, mapDispatchToProps)(injectIntl(BlockModal));
+export default connect(
+  makeMapStateToProps,
+  mapDispatchToProps,
+)(injectIntl(BlockModal));

--- a/app/javascript/mastodon/features/ui/components/boost_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/boost_modal.jsx
@@ -10,7 +10,7 @@ import { connect } from 'react-redux';
 
 import { changeBoostPrivacy } from 'mastodon/actions/boosts';
 import AttachmentList from 'mastodon/components/attachment_list';
-import { Icon }  from 'mastodon/components/icon';
+import { Icon } from 'mastodon/components/icon';
 import PrivacyDropdown from 'mastodon/features/compose/components/privacy_dropdown';
 
 import { Avatar } from '../../../components/avatar';
@@ -20,21 +20,30 @@ import { RelativeTimestamp } from '../../../components/relative_timestamp';
 import StatusContent from '../../../components/status_content';
 
 const messages = defineMessages({
-  cancel_reblog: { id: 'status.cancel_reblog_private', defaultMessage: 'Unboost' },
+  cancel_reblog: {
+    id: 'status.cancel_reblog_private',
+    defaultMessage: 'Unboost',
+  },
   reblog: { id: 'status.reblog', defaultMessage: 'Boost' },
   public_short: { id: 'privacy.public.short', defaultMessage: 'Public' },
   unlisted_short: { id: 'privacy.unlisted.short', defaultMessage: 'Unlisted' },
-  private_short: { id: 'privacy.private.short', defaultMessage: 'Followers only' },
-  direct_short: { id: 'privacy.direct.short', defaultMessage: 'Mentioned people only' },
+  private_short: {
+    id: 'privacy.private.short',
+    defaultMessage: 'Followers only',
+  },
+  direct_short: {
+    id: 'privacy.direct.short',
+    defaultMessage: 'Mentioned people only',
+  },
 });
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
   return {
     privacy: state.getIn(['boosts', 'new', 'privacy']),
   };
 };
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
     onChangeBoostPrivacy(value) {
       dispatch(changeBoostPrivacy(value));
@@ -43,7 +52,6 @@ const mapDispatchToProps = dispatch => {
 };
 
 class BoostModal extends ImmutablePureComponent {
-
   static contextTypes = {
     router: PropTypes.object,
   };
@@ -70,7 +78,9 @@ class BoostModal extends ImmutablePureComponent {
     if (e.button === 0 && !(e.ctrlKey || e.metaKey)) {
       e.preventDefault();
       this.props.onClose();
-      this.context.router.history.push(`/@${this.props.status.getIn(['account', 'acct'])}`);
+      this.context.router.history.push(
+        `/@${this.props.status.getIn(['account', 'acct'])}`,
+      );
     }
   };
 
@@ -82,15 +92,26 @@ class BoostModal extends ImmutablePureComponent {
     this.button = c;
   };
 
-  render () {
+  render() {
     const { status, privacy, intl } = this.props;
-    const buttonText = status.get('reblogged') ? messages.cancel_reblog : messages.reblog;
+    const buttonText = status.get('reblogged')
+      ? messages.cancel_reblog
+      : messages.reblog;
 
     const visibilityIconInfo = {
-      'public': { icon: 'globe', text: intl.formatMessage(messages.public_short) },
-      'unlisted': { icon: 'unlock', text: intl.formatMessage(messages.unlisted_short) },
-      'private': { icon: 'lock', text: intl.formatMessage(messages.private_short) },
-      'direct': { icon: 'at', text: intl.formatMessage(messages.direct_short) },
+      public: {
+        icon: 'globe',
+        text: intl.formatMessage(messages.public_short),
+      },
+      unlisted: {
+        icon: 'unlock',
+        text: intl.formatMessage(messages.unlisted_short),
+      },
+      private: {
+        icon: 'lock',
+        text: intl.formatMessage(messages.private_short),
+      },
+      direct: { icon: 'at', text: intl.formatMessage(messages.direct_short) },
     };
 
     const visibilityIcon = visibilityIconInfo[status.get('visibility')];
@@ -98,14 +119,33 @@ class BoostModal extends ImmutablePureComponent {
     return (
       <div className='modal-root__modal boost-modal'>
         <div className='boost-modal__container'>
-          <div className={classNames('status', `status-${status.get('visibility')}`, 'light')}>
+          <div
+            className={classNames(
+              'status',
+              `status-${status.get('visibility')}`,
+              'light',
+            )}
+          >
             <div className='status__info'>
-              <a href={`/@${status.getIn(['account', 'acct'])}/${status.get('id')}`} className='status__relative-time' target='_blank' rel='noopener noreferrer'>
-                <span className='status__visibility-icon'><Icon id={visibilityIcon.icon} title={visibilityIcon.text} /></span>
+              <a
+                href={`/@${status.getIn(['account', 'acct'])}/${status.get(
+                  'id',
+                )}`}
+                className='status__relative-time'
+                target='_blank'
+                rel='noopener noreferrer'
+              >
+                <span className='status__visibility-icon'>
+                  <Icon id={visibilityIcon.icon} title={visibilityIcon.text} />
+                </span>
                 <RelativeTimestamp timestamp={status.get('created_at')} />
               </a>
 
-              <a onClick={this.handleAccountClick} href={`/@${status.getIn(['account', 'acct'])}`} className='status__display-name'>
+              <a
+                onClick={this.handleAccountClick}
+                href={`/@${status.getIn(['account', 'acct'])}`}
+                className='status__display-name'
+              >
                 <div className='status__avatar'>
                   <Avatar account={status.get('account')} size={48} />
                 </div>
@@ -117,30 +157,46 @@ class BoostModal extends ImmutablePureComponent {
             <StatusContent status={status} />
 
             {status.get('media_attachments').size > 0 && (
-              <AttachmentList
-                compact
-                media={status.get('media_attachments')}
-              />
+              <AttachmentList compact media={status.get('media_attachments')} />
             )}
           </div>
         </div>
 
         <div className='boost-modal__action-bar'>
-          <div><FormattedMessage id='boost_modal.combo' defaultMessage='You can press {combo} to skip this next time' values={{ combo: <span>Shift + <Icon id='retweet' /></span> }} /></div>
-          {status.get('visibility') !== 'private' && !status.get('reblogged') && (
-            <PrivacyDropdown
-              noDirect
-              value={privacy}
-              container={this._findContainer}
-              onChange={this.props.onChangeBoostPrivacy}
+          <div>
+            <FormattedMessage
+              id='boost_modal.combo'
+              defaultMessage='You can press {combo} to skip this next time'
+              values={{
+                combo: (
+                  <span>
+                    Shift + <Icon id='retweet' />
+                  </span>
+                ),
+              }}
             />
-          )}
-          <Button text={intl.formatMessage(buttonText)} onClick={this.handleReblog} ref={this.setRef} />
+          </div>
+          {status.get('visibility') !== 'private' &&
+            !status.get('reblogged') && (
+              <PrivacyDropdown
+                noDirect
+                value={privacy}
+                container={this._findContainer}
+                onChange={this.props.onChangeBoostPrivacy}
+              />
+            )}
+          <Button
+            text={intl.formatMessage(buttonText)}
+            onClick={this.handleReblog}
+            ref={this.setRef}
+          />
         </div>
       </div>
     );
   }
-
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(injectIntl(BoostModal));
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(injectIntl(BoostModal));

--- a/app/javascript/mastodon/features/ui/components/bundle.jsx
+++ b/app/javascript/mastodon/features/ui/components/bundle.jsx
@@ -2,10 +2,9 @@ import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 
 const emptyComponent = () => null;
-const noop = () => { };
+const noop = () => {};
 
 class Bundle extends PureComponent {
-
   static propTypes = {
     fetchComponent: PropTypes.func.isRequired,
     loading: PropTypes.func,
@@ -26,7 +25,7 @@ class Bundle extends PureComponent {
     onFetchFail: noop,
   };
 
-  static cache = new Map;
+  static cache = new Map();
 
   state = {
     mod: undefined,
@@ -43,14 +42,20 @@ class Bundle extends PureComponent {
     }
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     if (this.timeout) {
       clearTimeout(this.timeout);
     }
   }
 
   load = (props) => {
-    const { fetchComponent, onFetch, onFetchSuccess, onFetchFail, renderDelay } = props || this.props;
+    const {
+      fetchComponent,
+      onFetch,
+      onFetchSuccess,
+      onFetchFail,
+      renderDelay,
+    } = props || this.props;
     const cachedMod = Bundle.cache.get(fetchComponent);
 
     if (fetchComponent === undefined) {
@@ -70,7 +75,10 @@ class Bundle extends PureComponent {
 
     if (renderDelay !== 0) {
       this.timestamp = new Date();
-      this.timeout = setTimeout(() => this.setState({ forceRender: true }), renderDelay);
+      this.timeout = setTimeout(
+        () => this.setState({ forceRender: true }),
+        renderDelay,
+      );
     }
 
     return fetchComponent()
@@ -86,12 +94,17 @@ class Bundle extends PureComponent {
   };
 
   render() {
-    const { loading: Loading, error: Error, children, renderDelay } = this.props;
+    const {
+      loading: Loading,
+      error: Error,
+      children,
+      renderDelay,
+    } = this.props;
     const { mod, forceRender } = this.state;
-    const elapsed = this.timestamp ? (new Date() - this.timestamp) : renderDelay;
+    const elapsed = this.timestamp ? new Date() - this.timestamp : renderDelay;
 
     if (mod === undefined) {
-      return (elapsed >= renderDelay || forceRender) ? <Loading /> : null;
+      return elapsed >= renderDelay || forceRender ? <Loading /> : null;
     }
 
     if (mod === null) {
@@ -100,7 +113,6 @@ class Bundle extends PureComponent {
 
     return children(mod);
   }
-
 }
 
 export default Bundle;

--- a/app/javascript/mastodon/features/ui/components/bundle_column_error.jsx
+++ b/app/javascript/mastodon/features/ui/components/bundle_column_error.jsx
@@ -12,7 +12,6 @@ import Column from 'mastodon/components/column';
 import { autoPlayGif } from 'mastodon/initial_state';
 
 class GIF extends PureComponent {
-
   static propTypes = {
     src: PropTypes.string.isRequired,
     staticSrc: PropTypes.string.isRequired,
@@ -44,14 +43,14 @@ class GIF extends PureComponent {
     }
   };
 
-  render () {
+  render() {
     const { src, staticSrc, className, animate } = this.props;
     const { hovering } = this.state;
 
     return (
       <img
         className={className}
-        src={(hovering || animate) ? src : staticSrc}
+        src={hovering || animate ? src : staticSrc}
         alt=''
         role='presentation'
         onMouseEnter={this.handleMouseEnter}
@@ -59,11 +58,9 @@ class GIF extends PureComponent {
       />
     );
   }
-
 }
 
 class CopyButton extends PureComponent {
-
   static propTypes = {
     children: PropTypes.node.isRequired,
     value: PropTypes.string.isRequired,
@@ -80,23 +77,30 @@ class CopyButton extends PureComponent {
     this.timeout = setTimeout(() => this.setState({ copied: false }), 700);
   };
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     if (this.timeout) clearTimeout(this.timeout);
   }
 
-  render () {
+  render() {
     const { children } = this.props;
     const { copied } = this.state;
 
     return (
-      <Button onClick={this.handleClick} className={copied ? 'copied' : 'copyable'}>{copied ? <FormattedMessage id='copypaste.copied' defaultMessage='Copied' /> : children}</Button>
+      <Button
+        onClick={this.handleClick}
+        className={copied ? 'copied' : 'copyable'}
+      >
+        {copied ? (
+          <FormattedMessage id='copypaste.copied' defaultMessage='Copied' />
+        ) : (
+          children
+        )}
+      </Button>
     );
   }
-
 }
 
 class BundleColumnError extends PureComponent {
-
   static propTypes = {
     errorType: PropTypes.oneOf(['routing', 'network', 'error']),
     onRetry: PropTypes.func,
@@ -117,39 +121,97 @@ class BundleColumnError extends PureComponent {
     }
   };
 
-  render () {
+  render() {
     const { errorType, multiColumn, stacktrace } = this.props;
 
     let title, body;
 
-    switch(errorType) {
-    case 'routing':
-      title = <FormattedMessage id='bundle_column_error.routing.title' defaultMessage='404' />;
-      body = <FormattedMessage id='bundle_column_error.routing.body' defaultMessage='The requested page could not be found. Are you sure the URL in the address bar is correct?' />;
-      break;
-    case 'network':
-      title = <FormattedMessage id='bundle_column_error.network.title' defaultMessage='Network error' />;
-      body = <FormattedMessage id='bundle_column_error.network.body' defaultMessage='There was an error when trying to load this page. This could be due to a temporary problem with your internet connection or this server.' />;
-      break;
-    case 'error':
-      title = <FormattedMessage id='bundle_column_error.error.title' defaultMessage='Oh, no!' />;
-      body = <FormattedMessage id='bundle_column_error.error.body' defaultMessage='The requested page could not be rendered. It could be due to a bug in our code, or a browser compatibility issue.' />;
-      break;
+    switch (errorType) {
+      case 'routing':
+        title = (
+          <FormattedMessage
+            id='bundle_column_error.routing.title'
+            defaultMessage='404'
+          />
+        );
+        body = (
+          <FormattedMessage
+            id='bundle_column_error.routing.body'
+            defaultMessage='The requested page could not be found. Are you sure the URL in the address bar is correct?'
+          />
+        );
+        break;
+      case 'network':
+        title = (
+          <FormattedMessage
+            id='bundle_column_error.network.title'
+            defaultMessage='Network error'
+          />
+        );
+        body = (
+          <FormattedMessage
+            id='bundle_column_error.network.body'
+            defaultMessage='There was an error when trying to load this page. This could be due to a temporary problem with your internet connection or this server.'
+          />
+        );
+        break;
+      case 'error':
+        title = (
+          <FormattedMessage
+            id='bundle_column_error.error.title'
+            defaultMessage='Oh, no!'
+          />
+        );
+        body = (
+          <FormattedMessage
+            id='bundle_column_error.error.body'
+            defaultMessage='The requested page could not be rendered. It could be due to a bug in our code, or a browser compatibility issue.'
+          />
+        );
+        break;
     }
 
     return (
       <Column bindToDocument={!multiColumn}>
         <div className='error-column'>
-          <GIF src='/oops.gif' staticSrc='/oops.png' className='error-column__image' />
+          <GIF
+            src='/oops.gif'
+            staticSrc='/oops.png'
+            className='error-column__image'
+          />
 
           <div className='error-column__message'>
             <h1>{title}</h1>
             <p>{body}</p>
 
             <div className='error-column__message__actions'>
-              {errorType === 'network' && <Button onClick={this.handleRetry}><FormattedMessage id='bundle_column_error.retry' defaultMessage='Try again' /></Button>}
-              {errorType === 'error' && <CopyButton value={stacktrace}><FormattedMessage id='bundle_column_error.copy_stacktrace' defaultMessage='Copy error report' /></CopyButton>}
-              <Link to='/' className={classNames('button', { 'button-tertiary': errorType !== 'routing' })}><FormattedMessage id='bundle_column_error.return' defaultMessage='Go back home' /></Link>
+              {errorType === 'network' && (
+                <Button onClick={this.handleRetry}>
+                  <FormattedMessage
+                    id='bundle_column_error.retry'
+                    defaultMessage='Try again'
+                  />
+                </Button>
+              )}
+              {errorType === 'error' && (
+                <CopyButton value={stacktrace}>
+                  <FormattedMessage
+                    id='bundle_column_error.copy_stacktrace'
+                    defaultMessage='Copy error report'
+                  />
+                </CopyButton>
+              )}
+              <Link
+                to='/'
+                className={classNames('button', {
+                  'button-tertiary': errorType !== 'routing',
+                })}
+              >
+                <FormattedMessage
+                  id='bundle_column_error.return'
+                  defaultMessage='Go back home'
+                />
+              </Link>
             </div>
           </div>
         </div>
@@ -160,7 +222,6 @@ class BundleColumnError extends PureComponent {
       </Column>
     );
   }
-
 }
 
 export default injectIntl(BundleColumnError);

--- a/app/javascript/mastodon/features/ui/components/bundle_modal_error.jsx
+++ b/app/javascript/mastodon/features/ui/components/bundle_modal_error.jsx
@@ -6,13 +6,15 @@ import { defineMessages, injectIntl } from 'react-intl';
 import { IconButton } from '../../../components/icon_button';
 
 const messages = defineMessages({
-  error: { id: 'bundle_modal_error.message', defaultMessage: 'Something went wrong while loading this component.' },
+  error: {
+    id: 'bundle_modal_error.message',
+    defaultMessage: 'Something went wrong while loading this component.',
+  },
   retry: { id: 'bundle_modal_error.retry', defaultMessage: 'Try again' },
   close: { id: 'bundle_modal_error.close', defaultMessage: 'Close' },
 });
 
 class BundleModalError extends PureComponent {
-
   static propTypes = {
     onRetry: PropTypes.func.isRequired,
     onClose: PropTypes.func.isRequired,
@@ -23,15 +25,23 @@ class BundleModalError extends PureComponent {
     this.props.onRetry();
   };
 
-  render () {
-    const { onClose, intl: { formatMessage } } = this.props;
+  render() {
+    const {
+      onClose,
+      intl: { formatMessage },
+    } = this.props;
 
     // Keep the markup in sync with <ModalLoading />
     // (make sure they have the same dimensions)
     return (
       <div className='modal-root__modal error-modal'>
         <div className='error-modal__body'>
-          <IconButton title={formatMessage(messages.retry)} icon='refresh' onClick={this.handleRetry} size={64} />
+          <IconButton
+            title={formatMessage(messages.retry)}
+            icon='refresh'
+            onClick={this.handleRetry}
+            size={64}
+          />
           {formatMessage(messages.error)}
         </div>
 
@@ -48,7 +58,6 @@ class BundleModalError extends PureComponent {
       </div>
     );
   }
-
 }
 
 export default injectIntl(BundleModalError);

--- a/app/javascript/mastodon/features/ui/components/column.jsx
+++ b/app/javascript/mastodon/features/ui/components/column.jsx
@@ -9,7 +9,6 @@ import { scrollTop } from '../../../scroll';
 import ColumnHeader from './column_header';
 
 export default class Column extends PureComponent {
-
   static propTypes = {
     heading: PropTypes.string,
     icon: PropTypes.string,
@@ -28,7 +27,7 @@ export default class Column extends PureComponent {
     this._interruptScrollAnimation = scrollTop(scrollable);
   };
 
-  scrollTop () {
+  scrollTop() {
     const scrollable = this.node.querySelector('.scrollable');
 
     if (!scrollable) {
@@ -37,7 +36,6 @@ export default class Column extends PureComponent {
 
     this._interruptScrollAnimation = scrollTop(scrollable);
   }
-
 
   handleScroll = debounce(() => {
     if (typeof this._interruptScrollAnimation !== 'undefined') {
@@ -49,14 +47,23 @@ export default class Column extends PureComponent {
     this.node = c;
   };
 
-  render () {
+  render() {
     const { heading, icon, children, active, hideHeadingOnMobile } = this.props;
 
-    const showHeading = heading && (!hideHeadingOnMobile || (hideHeadingOnMobile && !isMobile(window.innerWidth)));
+    const showHeading =
+      heading &&
+      (!hideHeadingOnMobile ||
+        (hideHeadingOnMobile && !isMobile(window.innerWidth)));
 
     const columnHeaderId = showHeading && heading.replace(/ /g, '-');
     const header = showHeading && (
-      <ColumnHeader icon={icon} active={active} type={heading} onClick={this.handleHeaderClick} columnHeaderId={columnHeaderId} />
+      <ColumnHeader
+        icon={icon}
+        active={active}
+        type={heading}
+        onClick={this.handleHeaderClick}
+        columnHeaderId={columnHeaderId}
+      />
     );
     return (
       <div
@@ -71,5 +78,4 @@ export default class Column extends PureComponent {
       </div>
     );
   }
-
 }

--- a/app/javascript/mastodon/features/ui/components/column_header.jsx
+++ b/app/javascript/mastodon/features/ui/components/column_header.jsx
@@ -3,10 +3,9 @@ import { PureComponent } from 'react';
 
 import classNames from 'classnames';
 
-import { Icon }  from 'mastodon/components/icon';
+import { Icon } from 'mastodon/components/icon';
 
 export default class ColumnHeader extends PureComponent {
-
   static propTypes = {
     icon: PropTypes.string,
     type: PropTypes.string,
@@ -19,16 +18,21 @@ export default class ColumnHeader extends PureComponent {
     this.props.onClick();
   };
 
-  render () {
+  render() {
     const { icon, type, active, columnHeaderId } = this.props;
     let iconElement = '';
 
     if (icon) {
-      iconElement = <Icon id={icon} fixedWidth className='column-header__icon' />;
+      iconElement = (
+        <Icon id={icon} fixedWidth className='column-header__icon' />
+      );
     }
 
     return (
-      <h1 className={classNames('column-header', { active })} id={columnHeaderId || null}>
+      <h1
+        className={classNames('column-header', { active })}
+        id={columnHeaderId || null}
+      >
         <button onClick={this.handleClick}>
           {iconElement}
           {type}
@@ -36,5 +40,4 @@ export default class ColumnHeader extends PureComponent {
       </h1>
     );
   }
-
 }

--- a/app/javascript/mastodon/features/ui/components/column_link.jsx
+++ b/app/javascript/mastodon/features/ui/components/column_link.jsx
@@ -3,16 +3,41 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { NavLink } from 'react-router-dom';
 
-import { Icon }  from 'mastodon/components/icon';
+import { Icon } from 'mastodon/components/icon';
 
-const ColumnLink = ({ icon, text, to, href, method, badge, transparent, ...other }) => {
-  const className = classNames('column-link', { 'column-link--transparent': transparent });
-  const badgeElement = typeof badge !== 'undefined' ? <span className='column-link__badge'>{badge}</span> : null;
-  const iconElement = typeof icon === 'string' ? <Icon id={icon} fixedWidth className='column-link__icon' /> : icon;
+const ColumnLink = ({
+  icon,
+  text,
+  to,
+  href,
+  method,
+  badge,
+  transparent,
+  ...other
+}) => {
+  const className = classNames('column-link', {
+    'column-link--transparent': transparent,
+  });
+  const badgeElement =
+    typeof badge !== 'undefined' ? (
+      <span className='column-link__badge'>{badge}</span>
+    ) : null;
+  const iconElement =
+    typeof icon === 'string' ? (
+      <Icon id={icon} fixedWidth className='column-link__icon' />
+    ) : (
+      icon
+    );
 
   if (href) {
     return (
-      <a href={href} className={className} data-method={method} title={text} {...other}>
+      <a
+        href={href}
+        className={className}
+        data-method={method}
+        title={text}
+        {...other}
+      >
         {iconElement}
         <span>{text}</span>
         {badgeElement}

--- a/app/javascript/mastodon/features/ui/components/column_loading.jsx
+++ b/app/javascript/mastodon/features/ui/components/column_loading.jsx
@@ -6,7 +6,6 @@ import Column from '../../../components/column';
 import ColumnHeader from '../../../components/column_header';
 
 export default class ColumnLoading extends ImmutablePureComponent {
-
   static propTypes = {
     title: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
     icon: PropTypes.string,
@@ -23,10 +22,15 @@ export default class ColumnLoading extends ImmutablePureComponent {
 
     return (
       <Column>
-        <ColumnHeader icon={icon} title={title} multiColumn={multiColumn} focusable={false} placeholder />
+        <ColumnHeader
+          icon={icon}
+          title={title}
+          multiColumn={multiColumn}
+          focusable={false}
+          placeholder
+        />
         <div className='scrollable' />
       </Column>
     );
   }
-
 }

--- a/app/javascript/mastodon/features/ui/components/column_subheading.jsx
+++ b/app/javascript/mastodon/features/ui/components/column_subheading.jsx
@@ -1,11 +1,7 @@
 import PropTypes from 'prop-types';
 
 const ColumnSubheading = ({ text }) => {
-  return (
-    <div className='column-subheading'>
-      {text}
-    </div>
-  );
+  return <div className='column-subheading'>{text}</div>;
 };
 
 ColumnSubheading.propTypes = {

--- a/app/javascript/mastodon/features/ui/components/columns_area.jsx
+++ b/app/javascript/mastodon/features/ui/components/columns_area.jsx
@@ -29,22 +29,21 @@ import DrawerLoading from './drawer_loading';
 import NavigationPanel from './navigation_panel';
 
 const componentMap = {
-  'COMPOSE': Compose,
-  'HOME': HomeTimeline,
-  'NOTIFICATIONS': Notifications,
-  'PUBLIC': PublicTimeline,
-  'REMOTE': PublicTimeline,
-  'COMMUNITY': CommunityTimeline,
-  'HASHTAG': HashtagTimeline,
-  'DIRECT': DirectTimeline,
-  'FAVOURITES': FavouritedStatuses,
-  'BOOKMARKS': BookmarkedStatuses,
-  'LIST': ListTimeline,
-  'DIRECTORY': Directory,
+  COMPOSE: Compose,
+  HOME: HomeTimeline,
+  NOTIFICATIONS: Notifications,
+  PUBLIC: PublicTimeline,
+  REMOTE: PublicTimeline,
+  COMMUNITY: CommunityTimeline,
+  HASHTAG: HashtagTimeline,
+  DIRECT: DirectTimeline,
+  FAVOURITES: FavouritedStatuses,
+  BOOKMARKS: BookmarkedStatuses,
+  LIST: ListTimeline,
+  DIRECTORY: Directory,
 };
 
 export default class ColumnsArea extends ImmutablePureComponent {
-
   static contextTypes = {
     router: PropTypes.object.isRequired,
   };
@@ -57,7 +56,8 @@ export default class ColumnsArea extends ImmutablePureComponent {
   };
 
   // Corresponds to (max-width: $no-gap-breakpoint + 285px - 1px) in SCSS
-  mediaQuery = 'matchMedia' in window && window.matchMedia('(max-width: 1174px)');
+  mediaQuery =
+    'matchMedia' in window && window.matchMedia('(max-width: 1174px)');
 
   state = {
     renderComposePanel: !(this.mediaQuery && this.mediaQuery.matches),
@@ -65,7 +65,11 @@ export default class ColumnsArea extends ImmutablePureComponent {
 
   componentDidMount() {
     if (!this.props.singleColumn) {
-      this.node.addEventListener('wheel', this.handleWheel, supportsPassiveEvents ? { passive: true } : false);
+      this.node.addEventListener(
+        'wheel',
+        this.handleWheel,
+        supportsPassiveEvents ? { passive: true } : false,
+      );
     }
 
     if (this.mediaQuery) {
@@ -77,22 +81,34 @@ export default class ColumnsArea extends ImmutablePureComponent {
       this.setState({ renderComposePanel: !this.mediaQuery.matches });
     }
 
-    this.isRtlLayout = document.getElementsByTagName('body')[0].classList.contains('rtl');
+    this.isRtlLayout = document
+      .getElementsByTagName('body')[0]
+      .classList.contains('rtl');
   }
 
   UNSAFE_componentWillUpdate(nextProps) {
-    if (this.props.singleColumn !== nextProps.singleColumn && nextProps.singleColumn) {
+    if (
+      this.props.singleColumn !== nextProps.singleColumn &&
+      nextProps.singleColumn
+    ) {
       this.node.removeEventListener('wheel', this.handleWheel);
     }
   }
 
   componentDidUpdate(prevProps) {
-    if (this.props.singleColumn !== prevProps.singleColumn && !this.props.singleColumn) {
-      this.node.addEventListener('wheel', this.handleWheel, supportsPassiveEvents ? { passive: true } : false);
+    if (
+      this.props.singleColumn !== prevProps.singleColumn &&
+      !this.props.singleColumn
+    ) {
+      this.node.addEventListener(
+        'wheel',
+        this.handleWheel,
+        supportsPassiveEvents ? { passive: true } : false,
+      );
     }
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     if (!this.props.singleColumn) {
       this.node.removeEventListener('wheel', this.handleWheel);
     }
@@ -109,7 +125,10 @@ export default class ColumnsArea extends ImmutablePureComponent {
   handleChildrenContentChange() {
     if (!this.props.singleColumn) {
       const modifier = this.isRtlLayout ? -1 : 1;
-      this._interruptScrollAnimation = scrollRight(this.node, (this.node.scrollWidth - window.innerWidth) * modifier);
+      this._interruptScrollAnimation = scrollRight(
+        this.node,
+        (this.node.scrollWidth - window.innerWidth) * modifier,
+      );
     }
   }
 
@@ -129,15 +148,19 @@ export default class ColumnsArea extends ImmutablePureComponent {
     this.node = node;
   };
 
-  renderLoading = columnId => () => {
-    return columnId === 'COMPOSE' ? <DrawerLoading /> : <ColumnLoading multiColumn />;
+  renderLoading = (columnId) => () => {
+    return columnId === 'COMPOSE' ? (
+      <DrawerLoading />
+    ) : (
+      <ColumnLoading multiColumn />
+    );
   };
 
   renderError = (props) => {
     return <BundleColumnError multiColumn errorType='network' {...props} />;
   };
 
-  render () {
+  render() {
     const { columns, children, singleColumn, isModalOpen } = this.props;
     const { renderComposePanel } = this.state;
 
@@ -151,7 +174,9 @@ export default class ColumnsArea extends ImmutablePureComponent {
           </div>
 
           <div className='columns-area__panels__main'>
-            <div className='tabs-bar__wrapper'><div id='tabs-bar__portal' /></div>
+            <div className='tabs-bar__wrapper'>
+              <div id='tabs-bar__portal' />
+            </div>
             <div className='columns-area columns-area--mobile'>{children}</div>
           </div>
 
@@ -165,21 +190,40 @@ export default class ColumnsArea extends ImmutablePureComponent {
     }
 
     return (
-      <div className={`columns-area ${ isModalOpen ? 'unscrollable' : '' }`} ref={this.setRef}>
-        {columns.map(column => {
-          const params = column.get('params', null) === null ? null : column.get('params').toJS();
-          const other  = params && params.other ? params.other : {};
+      <div
+        className={`columns-area ${isModalOpen ? 'unscrollable' : ''}`}
+        ref={this.setRef}
+      >
+        {columns.map((column) => {
+          const params =
+            column.get('params', null) === null
+              ? null
+              : column.get('params').toJS();
+          const other = params && params.other ? params.other : {};
 
           return (
-            <BundleContainer key={column.get('uuid')} fetchComponent={componentMap[column.get('id')]} loading={this.renderLoading(column.get('id'))} error={this.renderError}>
-              {SpecificComponent => <SpecificComponent columnId={column.get('uuid')} params={params} multiColumn {...other} />}
+            <BundleContainer
+              key={column.get('uuid')}
+              fetchComponent={componentMap[column.get('id')]}
+              loading={this.renderLoading(column.get('id'))}
+              error={this.renderError}
+            >
+              {(SpecificComponent) => (
+                <SpecificComponent
+                  columnId={column.get('uuid')}
+                  params={params}
+                  multiColumn
+                  {...other}
+                />
+              )}
             </BundleContainer>
           );
         })}
 
-        {Children.map(children, child => cloneElement(child, { multiColumn: true }))}
+        {Children.map(children, (child) =>
+          cloneElement(child, { multiColumn: true }),
+        )}
       </div>
     );
   }
-
 }

--- a/app/javascript/mastodon/features/ui/components/compare_history_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/compare_history_modal.jsx
@@ -20,19 +20,18 @@ const mapStateToProps = (state, { statusId }) => ({
   versions: state.getIn(['history', statusId, 'items']),
 });
 
-const mapDispatchToProps = dispatch => ({
-
+const mapDispatchToProps = (dispatch) => ({
   onClose() {
-    dispatch(closeModal({
-      modalType: undefined,
-      ignoreFocus: false,
-    }));
+    dispatch(
+      closeModal({
+        modalType: undefined,
+        ignoreFocus: false,
+      }),
+    );
   },
-
 });
 
 class CompareHistoryModal extends PureComponent {
-
   static propTypes = {
     onClose: PropTypes.func.isRequired,
     index: PropTypes.number.isRequired,
@@ -41,7 +40,7 @@ class CompareHistoryModal extends PureComponent {
     versions: ImmutablePropTypes.list.isRequired,
   };
 
-  render () {
+  render() {
     const { index, versions, language, onClose } = this.props;
     const currentVersion = versions.get(index);
 
@@ -50,22 +49,49 @@ class CompareHistoryModal extends PureComponent {
       return obj;
     }, {});
 
-    const content = { __html: emojify(currentVersion.get('content'), emojiMap) };
-    const spoilerContent = { __html: emojify(escapeTextContentForBrowser(currentVersion.get('spoiler_text')), emojiMap) };
+    const content = {
+      __html: emojify(currentVersion.get('content'), emojiMap),
+    };
+    const spoilerContent = {
+      __html: emojify(
+        escapeTextContentForBrowser(currentVersion.get('spoiler_text')),
+        emojiMap,
+      ),
+    };
 
-    const formattedDate = <RelativeTimestamp timestamp={currentVersion.get('created_at')} short={false} />;
-    const formattedName = <InlineAccount accountId={currentVersion.get('account')} />;
+    const formattedDate = (
+      <RelativeTimestamp
+        timestamp={currentVersion.get('created_at')}
+        short={false}
+      />
+    );
+    const formattedName = (
+      <InlineAccount accountId={currentVersion.get('account')} />
+    );
 
     const label = currentVersion.get('original') ? (
-      <FormattedMessage id='status.history.created' defaultMessage='{name} created {date}' values={{ name: formattedName, date: formattedDate }} />
+      <FormattedMessage
+        id='status.history.created'
+        defaultMessage='{name} created {date}'
+        values={{ name: formattedName, date: formattedDate }}
+      />
     ) : (
-      <FormattedMessage id='status.history.edited' defaultMessage='{name} edited {date}' values={{ name: formattedName, date: formattedDate }} />
+      <FormattedMessage
+        id='status.history.edited'
+        defaultMessage='{name} edited {date}'
+        values={{ name: formattedName, date: formattedDate }}
+      />
     );
 
     return (
       <div className='modal-root__modal compare-history-modal'>
         <div className='report-modal__target'>
-          <IconButton className='report-modal__close' icon='times' onClick={onClose} size={20} />
+          <IconButton
+            className='report-modal__close'
+            icon='times'
+            onClick={onClose}
+            size={20}
+          />
           {label}
         </div>
 
@@ -73,23 +99,36 @@ class CompareHistoryModal extends PureComponent {
           <div className='status__content'>
             {currentVersion.get('spoiler_text').length > 0 && (
               <>
-                <div className='translate' dangerouslySetInnerHTML={spoilerContent} lang={language} />
+                <div
+                  className='translate'
+                  dangerouslySetInnerHTML={spoilerContent}
+                  lang={language}
+                />
                 <hr />
               </>
             )}
 
-            <div className='status__content__text status__content__text--visible translate' dangerouslySetInnerHTML={content} lang={language} />
+            <div
+              className='status__content__text status__content__text--visible translate'
+              dangerouslySetInnerHTML={content}
+              lang={language}
+            />
 
             {!!currentVersion.get('poll') && (
               <div className='poll'>
                 <ul>
-                  {currentVersion.getIn(['poll', 'options']).map(option => (
+                  {currentVersion.getIn(['poll', 'options']).map((option) => (
                     <li key={option.get('title')}>
                       <span className='poll__input disabled' />
 
                       <span
                         className='poll__option__text translate'
-                        dangerouslySetInnerHTML={{ __html: emojify(escapeTextContentForBrowser(option.get('title')), emojiMap) }}
+                        dangerouslySetInnerHTML={{
+                          __html: emojify(
+                            escapeTextContentForBrowser(option.get('title')),
+                            emojiMap,
+                          ),
+                        }}
                         lang={language}
                       />
                     </li>
@@ -104,7 +143,9 @@ class CompareHistoryModal extends PureComponent {
       </div>
     );
   }
-
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(CompareHistoryModal);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(CompareHistoryModal);

--- a/app/javascript/mastodon/features/ui/components/compose_panel.jsx
+++ b/app/javascript/mastodon/features/ui/components/compose_panel.jsx
@@ -3,7 +3,11 @@ import { PureComponent } from 'react';
 
 import { connect } from 'react-redux';
 
-import { changeComposing, mountCompose, unmountCompose } from 'mastodon/actions/compose';
+import {
+  changeComposing,
+  mountCompose,
+  unmountCompose,
+} from 'mastodon/actions/compose';
 import ServerBanner from 'mastodon/components/server_banner';
 import ComposeFormContainer from 'mastodon/features/compose/containers/compose_form_container';
 import NavigationContainer from 'mastodon/features/compose/containers/navigation_container';
@@ -12,7 +16,6 @@ import SearchContainer from 'mastodon/features/compose/containers/search_contain
 import LinkFooter from './link_footer';
 
 class ComposePanel extends PureComponent {
-
   static contextTypes = {
     identity: PropTypes.object.isRequired,
   };
@@ -31,12 +34,12 @@ class ComposePanel extends PureComponent {
     dispatch(changeComposing(false));
   };
 
-  componentDidMount () {
+  componentDidMount() {
     const { dispatch } = this.props;
     dispatch(mountCompose());
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     const { dispatch } = this.props;
     dispatch(unmountCompose());
   }
@@ -66,7 +69,6 @@ class ComposePanel extends PureComponent {
       </div>
     );
   }
-
 }
 
 export default connect()(ComposePanel);

--- a/app/javascript/mastodon/features/ui/components/confirmation_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/confirmation_modal.jsx
@@ -6,7 +6,6 @@ import { injectIntl, FormattedMessage } from 'react-intl';
 import Button from '../../../components/button';
 
 class ConfirmationModal extends PureComponent {
-
   static propTypes = {
     message: PropTypes.node.isRequired,
     confirm: PropTypes.string.isRequired,
@@ -46,28 +45,35 @@ class ConfirmationModal extends PureComponent {
     this.button = c;
   };
 
-  render () {
+  render() {
     const { message, confirm, secondary } = this.props;
 
     return (
       <div className='modal-root__modal confirmation-modal'>
-        <div className='confirmation-modal__container'>
-          {message}
-        </div>
+        <div className='confirmation-modal__container'>{message}</div>
 
         <div className='confirmation-modal__action-bar'>
-          <Button onClick={this.handleCancel} className='confirmation-modal__cancel-button'>
-            <FormattedMessage id='confirmation_modal.cancel' defaultMessage='Cancel' />
+          <Button
+            onClick={this.handleCancel}
+            className='confirmation-modal__cancel-button'
+          >
+            <FormattedMessage
+              id='confirmation_modal.cancel'
+              defaultMessage='Cancel'
+            />
           </Button>
           {secondary !== undefined && (
-            <Button text={secondary} onClick={this.handleSecondary} className='confirmation-modal__secondary-button' />
+            <Button
+              text={secondary}
+              onClick={this.handleSecondary}
+              className='confirmation-modal__secondary-button'
+            />
           )}
           <Button text={confirm} onClick={this.handleClick} ref={this.setRef} />
         </div>
       </div>
     );
   }
-
 }
 
 export default injectIntl(ConfirmationModal);

--- a/app/javascript/mastodon/features/ui/components/disabled_account_banner.jsx
+++ b/app/javascript/mastodon/features/ui/components/disabled_account_banner.jsx
@@ -8,35 +8,48 @@ import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 
 import { openModal } from 'mastodon/actions/modal';
-import { disabledAccountId, movedToAccountId, domain } from 'mastodon/initial_state';
+import {
+  disabledAccountId,
+  movedToAccountId,
+  domain,
+} from 'mastodon/initial_state';
 import { logOut } from 'mastodon/utils/log_out';
 
 const messages = defineMessages({
-  logoutMessage: { id: 'confirmations.logout.message', defaultMessage: 'Are you sure you want to log out?' },
-  logoutConfirm: { id: 'confirmations.logout.confirm', defaultMessage: 'Log out' },
+  logoutMessage: {
+    id: 'confirmations.logout.message',
+    defaultMessage: 'Are you sure you want to log out?',
+  },
+  logoutConfirm: {
+    id: 'confirmations.logout.confirm',
+    defaultMessage: 'Log out',
+  },
 });
 
 const mapStateToProps = (state) => ({
   disabledAcct: state.getIn(['accounts', disabledAccountId, 'acct']),
-  movedToAcct: movedToAccountId ? state.getIn(['accounts', movedToAccountId, 'acct']) : undefined,
+  movedToAcct: movedToAccountId
+    ? state.getIn(['accounts', movedToAccountId, 'acct'])
+    : undefined,
 });
 
 const mapDispatchToProps = (dispatch, { intl }) => ({
-  onLogout () {
-    dispatch(openModal({
-      modalType: 'CONFIRM',
-      modalProps: {
-        message: intl.formatMessage(messages.logoutMessage),
-        confirm: intl.formatMessage(messages.logoutConfirm),
-        closeWhenConfirm: false,
-        onConfirm: () => logOut(),
-      },
-    }));
+  onLogout() {
+    dispatch(
+      openModal({
+        modalType: 'CONFIRM',
+        modalProps: {
+          message: intl.formatMessage(messages.logoutMessage),
+          confirm: intl.formatMessage(messages.logoutConfirm),
+          closeWhenConfirm: false,
+          onConfirm: () => logOut(),
+        },
+      }),
+    );
   },
 });
 
 class DisabledAccountBanner extends PureComponent {
-
   static propTypes = {
     disabledAcct: PropTypes.string.isRequired,
     movedToAcct: PropTypes.string,
@@ -44,7 +57,7 @@ class DisabledAccountBanner extends PureComponent {
     intl: PropTypes.object.isRequired,
   };
 
-  handleLogOutClick = e => {
+  handleLogOutClick = (e) => {
     e.preventDefault();
     e.stopPropagation();
 
@@ -53,7 +66,7 @@ class DisabledAccountBanner extends PureComponent {
     return false;
   };
 
-  render () {
+  render() {
     const { disabledAcct, movedToAcct } = this.props;
 
     const disabledAccountLink = (
@@ -71,7 +84,13 @@ class DisabledAccountBanner extends PureComponent {
               defaultMessage='Your account {disabledAccount} is currently disabled because you moved to {movedToAccount}.'
               values={{
                 disabledAccount: disabledAccountLink,
-                movedToAccount: <Link to={`/@${movedToAcct}`}>{movedToAcct.includes('@') ? movedToAcct : `${movedToAcct}@${domain}`}</Link>,
+                movedToAccount: (
+                  <Link to={`/@${movedToAcct}`}>
+                    {movedToAcct.includes('@')
+                      ? movedToAcct
+                      : `${movedToAcct}@${domain}`}
+                  </Link>
+                ),
               }}
             />
           ) : (
@@ -85,15 +104,26 @@ class DisabledAccountBanner extends PureComponent {
           )}
         </p>
         <a href='/auth/edit' className='button button--block'>
-          <FormattedMessage id='disabled_account_banner.account_settings' defaultMessage='Account settings' />
+          <FormattedMessage
+            id='disabled_account_banner.account_settings'
+            defaultMessage='Account settings'
+          />
         </a>
-        <button type='button' className='button button--block button-tertiary' onClick={this.handleLogOutClick}>
-          <FormattedMessage id='confirmations.logout.confirm' defaultMessage='Log out' />
+        <button
+          type='button'
+          className='button button--block button-tertiary'
+          onClick={this.handleLogOutClick}
+        >
+          <FormattedMessage
+            id='confirmations.logout.confirm'
+            defaultMessage='Log out'
+          />
         </button>
       </div>
     );
   }
-
 }
 
-export default injectIntl(connect(mapStateToProps, mapDispatchToProps)(DisabledAccountBanner));
+export default injectIntl(
+  connect(mapStateToProps, mapDispatchToProps)(DisabledAccountBanner),
+);

--- a/app/javascript/mastodon/features/ui/components/embed_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/embed_modal.jsx
@@ -12,7 +12,6 @@ const messages = defineMessages({
 });
 
 class EmbedModal extends ImmutablePureComponent {
-
   static propTypes = {
     id: PropTypes.string.isRequired,
     onClose: PropTypes.func.isRequired,
@@ -25,29 +24,32 @@ class EmbedModal extends ImmutablePureComponent {
     oembed: null,
   };
 
-  componentDidMount () {
+  componentDidMount() {
     const { id } = this.props;
 
     this.setState({ loading: true });
 
-    api().get(`/api/web/embeds/${id}`).then(res => {
-      this.setState({ loading: false, oembed: res.data });
+    api()
+      .get(`/api/web/embeds/${id}`)
+      .then((res) => {
+        this.setState({ loading: false, oembed: res.data });
 
-      const iframeDocument = this.iframe.contentWindow.document;
+        const iframeDocument = this.iframe.contentWindow.document;
 
-      iframeDocument.open();
-      iframeDocument.write(res.data.html);
-      iframeDocument.close();
+        iframeDocument.open();
+        iframeDocument.write(res.data.html);
+        iframeDocument.close();
 
-      iframeDocument.body.style.margin = 0;
-      this.iframe.width  = iframeDocument.body.scrollWidth;
-      this.iframe.height = iframeDocument.body.scrollHeight;
-    }).catch(error => {
-      this.props.onError(error);
-    });
+        iframeDocument.body.style.margin = 0;
+        this.iframe.width = iframeDocument.body.scrollWidth;
+        this.iframe.height = iframeDocument.body.scrollHeight;
+      })
+      .catch((error) => {
+        this.props.onError(error);
+      });
   }
 
-  setIframeRef = c =>  {
+  setIframeRef = (c) => {
     this.iframe = c;
   };
 
@@ -55,32 +57,47 @@ class EmbedModal extends ImmutablePureComponent {
     e.target.select();
   };
 
-  render () {
+  render() {
     const { intl, onClose } = this.props;
     const { oembed } = this.state;
 
     return (
       <div className='modal-root__modal report-modal embed-modal'>
         <div className='report-modal__target'>
-          <IconButton className='media-modal__close' title={intl.formatMessage(messages.close)} icon='times' onClick={onClose} size={16} />
+          <IconButton
+            className='media-modal__close'
+            title={intl.formatMessage(messages.close)}
+            icon='times'
+            onClick={onClose}
+            size={16}
+          />
           <FormattedMessage id='status.embed' defaultMessage='Embed' />
         </div>
 
-        <div className='report-modal__container embed-modal__container' style={{ display: 'block' }}>
+        <div
+          className='report-modal__container embed-modal__container'
+          style={{ display: 'block' }}
+        >
           <p className='hint'>
-            <FormattedMessage id='embed.instructions' defaultMessage='Embed this status on your website by copying the code below.' />
+            <FormattedMessage
+              id='embed.instructions'
+              defaultMessage='Embed this status on your website by copying the code below.'
+            />
           </p>
 
           <input
             type='text'
             className='embed-modal__html'
             readOnly
-            value={oembed && oembed.html || ''}
+            value={(oembed && oembed.html) || ''}
             onClick={this.handleTextareaClick}
           />
 
           <p className='hint'>
-            <FormattedMessage id='embed.preview' defaultMessage='Here is what it will look like:' />
+            <FormattedMessage
+              id='embed.preview'
+              defaultMessage='Here is what it will look like:'
+            />
           </p>
 
           <iframe
@@ -94,7 +111,6 @@ class EmbedModal extends ImmutablePureComponent {
       </div>
     );
   }
-
 }
 
 export default injectIntl(EmbedModal);

--- a/app/javascript/mastodon/features/ui/components/filter_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/filter_modal.jsx
@@ -5,7 +5,11 @@ import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 import { connect } from 'react-redux';
 
-import { fetchFilters, createFilter, createFilterStatus } from 'mastodon/actions/filters';
+import {
+  fetchFilters,
+  createFilter,
+  createFilterStatus,
+} from 'mastodon/actions/filters';
 import { fetchStatus } from 'mastodon/actions/statuses';
 import { IconButton } from 'mastodon/components/icon_button';
 import AddedToFilter from 'mastodon/features/filters/added_to_filter';
@@ -16,7 +20,6 @@ const messages = defineMessages({
 });
 
 class FilterModal extends ImmutablePureComponent {
-
   static propTypes = {
     statusId: PropTypes.string.isRequired,
     contextType: PropTypes.string,
@@ -38,14 +41,18 @@ class FilterModal extends ImmutablePureComponent {
   handleSuccess = () => {
     const { dispatch, statusId } = this.props;
     dispatch(fetchStatus(statusId, true));
-    this.setState({ isSubmitting: false, isSubmitted: true, step: 'submitted' });
+    this.setState({
+      isSubmitting: false,
+      isSubmitted: true,
+      step: 'submitted',
+    });
   };
 
   handleFail = () => {
     this.setState({ isSubmitting: false });
   };
 
-  handleNextStep = step => {
+  handleNextStep = (step) => {
     this.setState({ step });
   };
 
@@ -54,10 +61,16 @@ class FilterModal extends ImmutablePureComponent {
 
     this.setState({ isSubmitting: true, filterId });
 
-    dispatch(createFilterStatus({
-      filter_id: filterId,
-      status_id: statusId,
-    }, this.handleSuccess, this.handleFail));
+    dispatch(
+      createFilterStatus(
+        {
+          filter_id: filterId,
+          status_id: statusId,
+        },
+        this.handleSuccess,
+        this.handleFail,
+      ),
+    );
   };
 
   handleNewFilter = (title) => {
@@ -65,72 +78,76 @@ class FilterModal extends ImmutablePureComponent {
 
     this.setState({ isSubmitting: true });
 
-    dispatch(createFilter({
-      title,
-      context: ['home', 'notifications', 'public', 'thread', 'account'],
-      action: 'warn',
-    }, this.handleNewFilterSuccess, this.handleFail));
+    dispatch(
+      createFilter(
+        {
+          title,
+          context: ['home', 'notifications', 'public', 'thread', 'account'],
+          action: 'warn',
+        },
+        this.handleNewFilterSuccess,
+        this.handleFail,
+      ),
+    );
   };
 
-  componentDidMount () {
+  componentDidMount() {
     const { dispatch } = this.props;
 
     dispatch(fetchFilters());
   }
 
-  render () {
-    const {
-      intl,
-      statusId,
-      contextType,
-      onClose,
-    } = this.props;
+  render() {
+    const { intl, statusId, contextType, onClose } = this.props;
 
-    const {
-      step,
-      filterId,
-    } = this.state;
+    const { step, filterId } = this.state;
 
     let stepComponent;
 
-    switch(step) {
-    case 'select':
-      stepComponent = (
-        <SelectFilter
-          contextType={contextType}
-          onSelectFilter={this.handleSelectFilter}
-          onNewFilter={this.handleNewFilter}
-        />
-      );
-      break;
-    case 'create':
-      stepComponent = null;
-      break;
-    case 'submitted':
-      stepComponent = (
-        <AddedToFilter
-          contextType={contextType}
-          filterId={filterId}
-          statusId={statusId}
-          onClose={onClose}
-        />
-      );
+    switch (step) {
+      case 'select':
+        stepComponent = (
+          <SelectFilter
+            contextType={contextType}
+            onSelectFilter={this.handleSelectFilter}
+            onNewFilter={this.handleNewFilter}
+          />
+        );
+        break;
+      case 'create':
+        stepComponent = null;
+        break;
+      case 'submitted':
+        stepComponent = (
+          <AddedToFilter
+            contextType={contextType}
+            filterId={filterId}
+            statusId={statusId}
+            onClose={onClose}
+          />
+        );
     }
 
     return (
       <div className='modal-root__modal report-dialog-modal'>
         <div className='report-modal__target'>
-          <IconButton className='report-modal__close' title={intl.formatMessage(messages.close)} icon='times' onClick={onClose} size={20} />
-          <FormattedMessage id='filter_modal.title.status' defaultMessage='Filter a post' />
+          <IconButton
+            className='report-modal__close'
+            title={intl.formatMessage(messages.close)}
+            icon='times'
+            onClick={onClose}
+            size={20}
+          />
+          <FormattedMessage
+            id='filter_modal.title.status'
+            defaultMessage='Filter a post'
+          />
         </div>
 
-        <div className='report-dialog-modal__container'>
-          {stepComponent}
-        </div>
+        <div className='report-dialog-modal__container'>{stepComponent}</div>
       </div>
     );
   }
-
 }
 
 export default connect()(injectIntl(FilterModal));

--- a/app/javascript/mastodon/features/ui/components/focal_point_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/focal_point_modal.jsx
@@ -26,21 +26,41 @@ import { Tesseract as fetchTesseract } from 'mastodon/features/ui/util/async-com
 import { me } from 'mastodon/initial_state';
 import { assetHost } from 'mastodon/utils/config';
 
-import { changeUploadCompose, uploadThumbnail, onChangeMediaDescription, onChangeMediaFocus } from '../../../actions/compose';
+import {
+  changeUploadCompose,
+  uploadThumbnail,
+  onChangeMediaDescription,
+  onChangeMediaFocus,
+} from '../../../actions/compose';
 import Video, { getPointerPosition } from '../../video';
 
 const messages = defineMessages({
   close: { id: 'lightbox.close', defaultMessage: 'Close' },
   apply: { id: 'upload_modal.apply', defaultMessage: 'Apply' },
   applying: { id: 'upload_modal.applying', defaultMessage: 'Applying…' },
-  placeholder: { id: 'upload_modal.description_placeholder', defaultMessage: 'A quick brown fox jumps over the lazy dog' },
-  chooseImage: { id: 'upload_modal.choose_image', defaultMessage: 'Choose image' },
-  discardMessage: { id: 'confirmations.discard_edit_media.message', defaultMessage: 'You have unsaved changes to the media description or preview, discard them anyway?' },
-  discardConfirm: { id: 'confirmations.discard_edit_media.confirm', defaultMessage: 'Discard' },
+  placeholder: {
+    id: 'upload_modal.description_placeholder',
+    defaultMessage: 'A quick brown fox jumps over the lazy dog',
+  },
+  chooseImage: {
+    id: 'upload_modal.choose_image',
+    defaultMessage: 'Choose image',
+  },
+  discardMessage: {
+    id: 'confirmations.discard_edit_media.message',
+    defaultMessage:
+      'You have unsaved changes to the media description or preview, discard them anyway?',
+  },
+  discardConfirm: {
+    id: 'confirmations.discard_edit_media.confirm',
+    defaultMessage: 'Discard',
+  },
 });
 
 const mapStateToProps = (state, { id }) => ({
-  media: state.getIn(['compose', 'media_attachments']).find(item => item.get('id') === id),
+  media: state
+    .getIn(['compose', 'media_attachments'])
+    .find((item) => item.get('id') === id),
   account: state.getIn(['accounts', me]),
   isUploadingThumbnail: state.getIn(['compose', 'isUploadingThumbnail']),
   description: state.getIn(['compose', 'media_modal', 'description']),
@@ -52,9 +72,13 @@ const mapStateToProps = (state, { id }) => ({
 });
 
 const mapDispatchToProps = (dispatch, { id }) => ({
-
   onSave: (description, x, y) => {
-    dispatch(changeUploadCompose(id, { description, focus: `${x.toFixed(2)},${y.toFixed(2)}` }));
+    dispatch(
+      changeUploadCompose(id, {
+        description,
+        focus: `${x.toFixed(2)},${y.toFixed(2)}`,
+      }),
+    );
   },
 
   onChangeDescription: (description) => {
@@ -65,18 +89,18 @@ const mapDispatchToProps = (dispatch, { id }) => ({
     dispatch(onChangeMediaFocus(focusX, focusY));
   },
 
-  onSelectThumbnail: files => {
+  onSelectThumbnail: (files) => {
     dispatch(uploadThumbnail(id, files[0]));
   },
-
 });
 
-const removeExtraLineBreaks = str => str.replace(/\n\n/g, '******')
-  .replace(/\n/g, ' ')
-  .replace(/\*\*\*\*\*\*/g, '\n\n');
+const removeExtraLineBreaks = (str) =>
+  str
+    .replace(/\n\n/g, '******')
+    .replace(/\n/g, ' ')
+    .replace(/\*\*\*\*\*\*/g, '\n\n');
 
 class ImageLoader extends PureComponent {
-
   static propTypes = {
     src: PropTypes.string.isRequired,
     width: PropTypes.number,
@@ -93,7 +117,7 @@ class ImageLoader extends PureComponent {
     image.src = this.props.src;
   }
 
-  render () {
+  render() {
     const { loading } = this.state;
 
     if (loading) {
@@ -102,11 +126,9 @@ class ImageLoader extends PureComponent {
       return <img {...this.props} alt='' />;
     }
   }
-
 }
 
 class FocalPointModal extends ImmutablePureComponent {
-
   static propTypes = {
     media: ImmutablePropTypes.map.isRequired,
     account: ImmutablePropTypes.map.isRequired,
@@ -127,12 +149,12 @@ class FocalPointModal extends ImmutablePureComponent {
     ocrStatus: '',
   };
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     document.removeEventListener('mousemove', this.handleMouseMove);
     document.removeEventListener('mouseup', this.handleMouseUp);
   }
 
-  handleMouseDown = e => {
+  handleMouseDown = (e) => {
     document.addEventListener('mousemove', this.handleMouseMove);
     document.addEventListener('mouseup', this.handleMouseUp);
 
@@ -140,7 +162,7 @@ class FocalPointModal extends ImmutablePureComponent {
     this.setState({ dragging: true });
   };
 
-  handleTouchStart = e => {
+  handleTouchStart = (e) => {
     document.addEventListener('touchmove', this.handleMouseMove);
     document.addEventListener('touchend', this.handleTouchEnd);
 
@@ -148,7 +170,7 @@ class FocalPointModal extends ImmutablePureComponent {
     this.setState({ dragging: true });
   };
 
-  handleMouseMove = e => {
+  handleMouseMove = (e) => {
     this.updatePosition(e);
   };
 
@@ -166,15 +188,15 @@ class FocalPointModal extends ImmutablePureComponent {
     this.setState({ dragging: false });
   };
 
-  updatePosition = e => {
+  updatePosition = (e) => {
     const { x, y } = getPointerPosition(this.node, e);
-    const focusX   = (x - .5) *  2;
-    const focusY   = (y - .5) * -2;
+    const focusX = (x - 0.5) * 2;
+    const focusY = (y - 0.5) * -2;
 
     this.props.onChangeFocus(focusX, focusY);
   };
 
-  handleChange = e => {
+  handleChange = (e) => {
     this.props.onChangeDescription(e.target.value);
   };
 
@@ -188,7 +210,11 @@ class FocalPointModal extends ImmutablePureComponent {
   handleSubmit = (e) => {
     e.preventDefault();
     e.stopPropagation();
-    this.props.onSave(this.props.description, this.props.focusX, this.props.focusY);
+    this.props.onSave(
+      this.props.description,
+      this.props.focusX,
+      this.props.focusY,
+    );
   };
 
   getCloseConfirmationMessage = () => {
@@ -204,7 +230,7 @@ class FocalPointModal extends ImmutablePureComponent {
     }
   };
 
-  setRef = c => {
+  setRef = (c) => {
     this.node = c;
   };
 
@@ -217,59 +243,63 @@ class FocalPointModal extends ImmutablePureComponent {
 
     this.setState({ detecting: true });
 
-    fetchTesseract().then(({ createWorker }) => {
-      const worker = createWorker({
-        workerPath: tesseractWorkerPath,
-        corePath: tesseractCorePath,
-        langPath: `${assetHost}/ocr/lang-data/`,
-        logger: ({ status, progress }) => {
-          if (status === 'recognizing text') {
-            this.setState({ ocrStatus: 'detecting', progress });
-          } else {
-            this.setState({ ocrStatus: 'preparing', progress });
+    fetchTesseract()
+      .then(({ createWorker }) => {
+        const worker = createWorker({
+          workerPath: tesseractWorkerPath,
+          corePath: tesseractCorePath,
+          langPath: `${assetHost}/ocr/lang-data/`,
+          logger: ({ status, progress }) => {
+            if (status === 'recognizing text') {
+              this.setState({ ocrStatus: 'detecting', progress });
+            } else {
+              this.setState({ ocrStatus: 'preparing', progress });
+            }
+          },
+          cacheMethod: refreshCache ? 'refresh' : 'write',
+        });
+
+        let media_url = media.get('url');
+
+        if (window.URL && URL.createObjectURL) {
+          try {
+            media_url = URL.createObjectURL(media.get('file'));
+          } catch (error) {
+            console.error(error);
           }
-        },
-        cacheMethod: refreshCache ? 'refresh' : 'write',
-      });
-
-      let media_url = media.get('url');
-
-      if (window.URL && URL.createObjectURL) {
-        try {
-          media_url = URL.createObjectURL(media.get('file'));
-        } catch (error) {
-          console.error(error);
         }
-      }
 
-      return (async () => {
-        await worker.load();
-        await worker.loadLanguage('eng');
-        await worker.initialize('eng');
-        const { data: { text } } = await worker.recognize(media_url);
+        return (async () => {
+          await worker.load();
+          await worker.loadLanguage('eng');
+          await worker.initialize('eng');
+          const {
+            data: { text },
+          } = await worker.recognize(media_url);
+          this.setState({ detecting: false });
+          this.props.onChangeDescription(removeExtraLineBreaks(text));
+          await worker.terminate();
+        })().catch((e) => {
+          if (refreshCache) {
+            throw e;
+          } else {
+            this._detectText(true);
+          }
+        });
+      })
+      .catch((e) => {
+        console.error(e);
         this.setState({ detecting: false });
-        this.props.onChangeDescription(removeExtraLineBreaks(text));
-        await worker.terminate();
-      })().catch((e) => {
-        if (refreshCache) {
-          throw e;
-        } else {
-          this._detectText(true);
-        }
       });
-    }).catch((e) => {
-      console.error(e);
-      this.setState({ detecting: false });
-    });
   };
 
-  handleThumbnailChange = e => {
+  handleThumbnailChange = (e) => {
     if (e.target.files.length > 0) {
       this.props.onSelectThumbnail(e.target.files);
     }
   };
 
-  setFileInputRef = c => {
+  setFileInputRef = (c) => {
     this.fileInput = c;
   };
 
@@ -277,57 +307,124 @@ class FocalPointModal extends ImmutablePureComponent {
     this.fileInput.click();
   };
 
-  render () {
-    const { media, intl, account, onClose, isUploadingThumbnail, description, lang, focusX, focusY, dirty, is_changing_upload } = this.props;
+  render() {
+    const {
+      media,
+      intl,
+      account,
+      onClose,
+      isUploadingThumbnail,
+      description,
+      lang,
+      focusX,
+      focusY,
+      dirty,
+      is_changing_upload,
+    } = this.props;
     const { dragging, detecting, progress, ocrStatus } = this.state;
-    const x = (focusX /  2) + .5;
-    const y = (focusY / -2) + .5;
+    const x = focusX / 2 + 0.5;
+    const y = focusY / -2 + 0.5;
 
-    const width  = media.getIn(['meta', 'original', 'width']) || null;
+    const width = media.getIn(['meta', 'original', 'width']) || null;
     const height = media.getIn(['meta', 'original', 'height']) || null;
     const focals = ['image', 'gifv'].includes(media.get('type'));
     const thumbnailable = ['audio', 'video'].includes(media.get('type'));
 
-    const previewRatio  = 16/9;
-    const previewWidth  = 200;
+    const previewRatio = 16 / 9;
+    const previewWidth = 200;
     const previewHeight = previewWidth / previewRatio;
 
     let descriptionLabel = null;
 
     if (media.get('type') === 'audio') {
-      descriptionLabel = <FormattedMessage id='upload_form.audio_description' defaultMessage='Describe for people who are hard of hearing' />;
+      descriptionLabel = (
+        <FormattedMessage
+          id='upload_form.audio_description'
+          defaultMessage='Describe for people who are hard of hearing'
+        />
+      );
     } else if (media.get('type') === 'video') {
-      descriptionLabel = <FormattedMessage id='upload_form.video_description' defaultMessage='Describe for people who are deaf, hard of hearing, blind or have low vision' />;
+      descriptionLabel = (
+        <FormattedMessage
+          id='upload_form.video_description'
+          defaultMessage='Describe for people who are deaf, hard of hearing, blind or have low vision'
+        />
+      );
     } else {
-      descriptionLabel = <FormattedMessage id='upload_form.description' defaultMessage='Describe for people who are blind or have low vision' />;
+      descriptionLabel = (
+        <FormattedMessage
+          id='upload_form.description'
+          defaultMessage='Describe for people who are blind or have low vision'
+        />
+      );
     }
 
     let ocrMessage = '';
     if (ocrStatus === 'detecting') {
-      ocrMessage = <FormattedMessage id='upload_modal.analyzing_picture' defaultMessage='Analyzing picture…' />;
+      ocrMessage = (
+        <FormattedMessage
+          id='upload_modal.analyzing_picture'
+          defaultMessage='Analyzing picture…'
+        />
+      );
     } else {
-      ocrMessage = <FormattedMessage id='upload_modal.preparing_ocr' defaultMessage='Preparing OCR…' />;
+      ocrMessage = (
+        <FormattedMessage
+          id='upload_modal.preparing_ocr'
+          defaultMessage='Preparing OCR…'
+        />
+      );
     }
 
     return (
       <div className='modal-root__modal report-modal' style={{ maxWidth: 960 }}>
         <div className='report-modal__target'>
-          <IconButton className='report-modal__close' title={intl.formatMessage(messages.close)} icon='times' onClick={onClose} size={20} />
-          <FormattedMessage id='upload_modal.edit_media' defaultMessage='Edit media' />
+          <IconButton
+            className='report-modal__close'
+            title={intl.formatMessage(messages.close)}
+            icon='times'
+            onClick={onClose}
+            size={20}
+          />
+          <FormattedMessage
+            id='upload_modal.edit_media'
+            defaultMessage='Edit media'
+          />
         </div>
 
         <div className='report-modal__container'>
-          <form className='report-modal__comment' onSubmit={this.handleSubmit} >
-            {focals && <p><FormattedMessage id='upload_modal.hint' defaultMessage='Click or drag the circle on the preview to choose the focal point which will always be in view on all thumbnails.' /></p>}
+          <form className='report-modal__comment' onSubmit={this.handleSubmit}>
+            {focals && (
+              <p>
+                <FormattedMessage
+                  id='upload_modal.hint'
+                  defaultMessage='Click or drag the circle on the preview to choose the focal point which will always be in view on all thumbnails.'
+                />
+              </p>
+            )}
 
             {thumbnailable && (
               <>
-                <label className='setting-text-label' htmlFor='upload-modal__thumbnail'><FormattedMessage id='upload_form.thumbnail' defaultMessage='Change thumbnail' /></label>
+                <label
+                  className='setting-text-label'
+                  htmlFor='upload-modal__thumbnail'
+                >
+                  <FormattedMessage
+                    id='upload_form.thumbnail'
+                    defaultMessage='Change thumbnail'
+                  />
+                </label>
 
-                <Button disabled={isUploadingThumbnail || !media.get('unattached')} text={intl.formatMessage(messages.chooseImage)} onClick={this.handleFileInputClick} />
+                <Button
+                  disabled={isUploadingThumbnail || !media.get('unattached')}
+                  text={intl.formatMessage(messages.chooseImage)}
+                  onClick={this.handleFileInputClick}
+                />
 
                 <label>
-                  <span style={{ display: 'none' }}>{intl.formatMessage(messages.chooseImage)}</span>
+                  <span style={{ display: 'none' }}>
+                    {intl.formatMessage(messages.chooseImage)}
+                  </span>
 
                   <input
                     id='upload-modal__thumbnail'
@@ -344,7 +441,10 @@ class FocalPointModal extends ImmutablePureComponent {
               </>
             )}
 
-            <label className='setting-text-label' htmlFor='upload-modal__description'>
+            <label
+              className='setting-text-label'
+              htmlFor='upload-modal__description'
+            >
               {descriptionLabel}
             </label>
 
@@ -361,41 +461,100 @@ class FocalPointModal extends ImmutablePureComponent {
               />
 
               <div className='setting-text__modifiers'>
-                <UploadProgress progress={progress * 100} active={detecting} icon='file-text-o' message={ocrMessage} />
+                <UploadProgress
+                  progress={progress * 100}
+                  active={detecting}
+                  icon='file-text-o'
+                  message={ocrMessage}
+                />
               </div>
             </div>
 
             <div className='setting-text__toolbar'>
               <button
                 type='button'
-                disabled={detecting || media.get('type') !== 'image' || is_changing_upload}
+                disabled={
+                  detecting ||
+                  media.get('type') !== 'image' ||
+                  is_changing_upload
+                }
                 className='link-button'
                 onClick={this.handleTextDetection}
               >
-                <FormattedMessage id='upload_modal.detect_text' defaultMessage='Detect text from picture' />
+                <FormattedMessage
+                  id='upload_modal.detect_text'
+                  defaultMessage='Detect text from picture'
+                />
               </button>
-              <CharacterCounter max={1500} text={detecting ? '' : description} />
+              <CharacterCounter
+                max={1500}
+                text={detecting ? '' : description}
+              />
             </div>
 
             <Button
               type='submit'
-              disabled={!dirty || detecting || isUploadingThumbnail || length(description) > 1500 || is_changing_upload}
-              text={intl.formatMessage(is_changing_upload ? messages.applying : messages.apply)}
+              disabled={
+                !dirty ||
+                detecting ||
+                isUploadingThumbnail ||
+                length(description) > 1500 ||
+                is_changing_upload
+              }
+              text={intl.formatMessage(
+                is_changing_upload ? messages.applying : messages.apply,
+              )}
             />
           </form>
 
           <div className='focal-point-modal__content'>
             {focals && (
-              <div className={classNames('focal-point', { dragging })} ref={this.setRef} onMouseDown={this.handleMouseDown} onTouchStart={this.handleTouchStart}>
-                {media.get('type') === 'image' && <ImageLoader src={media.get('url')} width={width} height={height} alt='' />}
-                {media.get('type') === 'gifv' && <GIFV src={media.get('url')} key={media.get('url')} width={width} height={height} />}
+              <div
+                className={classNames('focal-point', { dragging })}
+                ref={this.setRef}
+                onMouseDown={this.handleMouseDown}
+                onTouchStart={this.handleTouchStart}
+              >
+                {media.get('type') === 'image' && (
+                  <ImageLoader
+                    src={media.get('url')}
+                    width={width}
+                    height={height}
+                    alt=''
+                  />
+                )}
+                {media.get('type') === 'gifv' && (
+                  <GIFV
+                    src={media.get('url')}
+                    key={media.get('url')}
+                    width={width}
+                    height={height}
+                  />
+                )}
 
                 <div className='focal-point__preview'>
-                  <strong><FormattedMessage id='upload_modal.preview_label' defaultMessage='Preview ({ratio})' values={{ ratio: '16:9' }} /></strong>
-                  <div style={{ width: previewWidth, height: previewHeight, backgroundImage: `url(${media.get('preview_url')})`, backgroundSize: 'cover', backgroundPosition: `${x * 100}% ${y * 100}%` }} />
+                  <strong>
+                    <FormattedMessage
+                      id='upload_modal.preview_label'
+                      defaultMessage='Preview ({ratio})'
+                      values={{ ratio: '16:9' }}
+                    />
+                  </strong>
+                  <div
+                    style={{
+                      width: previewWidth,
+                      height: previewHeight,
+                      backgroundImage: `url(${media.get('preview_url')})`,
+                      backgroundSize: 'cover',
+                      backgroundPosition: `${x * 100}% ${y * 100}%`,
+                    }}
+                  />
                 </div>
 
-                <div className='focal-point__reticle' style={{ top: `${y * 100}%`, left: `${x * 100}%` }} />
+                <div
+                  className='focal-point__reticle'
+                  style={{ top: `${y * 100}%`, left: `${x * 100}%` }}
+                />
                 <div className='focal-point__overlay' />
               </div>
             )}
@@ -417,7 +576,9 @@ class FocalPointModal extends ImmutablePureComponent {
                 src={media.get('url')}
                 duration={media.getIn(['meta', 'original', 'duration'], 0)}
                 height={150}
-                poster={media.get('preview_url') || account.get('avatar_static')}
+                poster={
+                  media.get('preview_url') || account.get('avatar_static')
+                }
                 backgroundColor={media.getIn(['meta', 'colors', 'background'])}
                 foregroundColor={media.getIn(['meta', 'colors', 'foreground'])}
                 accentColor={media.getIn(['meta', 'colors', 'accent'])}
@@ -429,7 +590,6 @@ class FocalPointModal extends ImmutablePureComponent {
       </div>
     );
   }
-
 }
 
 export default connect(mapStateToProps, mapDispatchToProps, null, {

--- a/app/javascript/mastodon/features/ui/components/follow_requests_column_link.jsx
+++ b/app/javascript/mastodon/features/ui/components/follow_requests_column_link.jsx
@@ -11,28 +11,33 @@ import { IconWithBadge } from 'mastodon/components/icon_with_badge';
 import ColumnLink from 'mastodon/features/ui/components/column_link';
 
 const messages = defineMessages({
-  text: { id: 'navigation_bar.follow_requests', defaultMessage: 'Follow requests' },
+  text: {
+    id: 'navigation_bar.follow_requests',
+    defaultMessage: 'Follow requests',
+  },
 });
 
-const mapStateToProps = state => ({
-  count: state.getIn(['user_lists', 'follow_requests', 'items'], ImmutableList()).size,
+const mapStateToProps = (state) => ({
+  count: state.getIn(
+    ['user_lists', 'follow_requests', 'items'],
+    ImmutableList(),
+  ).size,
 });
 
 class FollowRequestsColumnLink extends Component {
-
   static propTypes = {
     dispatch: PropTypes.func.isRequired,
     count: PropTypes.number.isRequired,
     intl: PropTypes.object.isRequired,
   };
 
-  componentDidMount () {
+  componentDidMount() {
     const { dispatch } = this.props;
 
     dispatch(fetchFollowRequests());
   }
 
-  render () {
+  render() {
     const { count, intl } = this.props;
 
     if (count === 0) {
@@ -43,12 +48,17 @@ class FollowRequestsColumnLink extends Component {
       <ColumnLink
         transparent
         to='/follow_requests'
-        icon={<IconWithBadge className='column-link__icon' id='user-plus' count={count} />}
+        icon={
+          <IconWithBadge
+            className='column-link__icon'
+            id='user-plus'
+            count={count}
+          />
+        }
         text={intl.formatMessage(messages.text)}
       />
     );
   }
-
 }
 
 export default injectIntl(connect(mapStateToProps)(FollowRequestsColumnLink));

--- a/app/javascript/mastodon/features/ui/components/header.jsx
+++ b/app/javascript/mastodon/features/ui/components/header.jsx
@@ -14,7 +14,7 @@ import { Icon } from 'mastodon/components/icon';
 import { WordmarkLogo, SymbolLogo } from 'mastodon/components/logo';
 import { registrationsOpen, me, sso_redirect } from 'mastodon/initial_state';
 
-const Account = connect(state => ({
+const Account = connect((state) => ({
   account: state.getIn(['accounts', me]),
 }))(({ account }) => (
   <Link to={`/@${account.get('acct')}`} title={account.get('acct')}>
@@ -27,7 +27,9 @@ const messages = defineMessages({
 });
 
 const mapStateToProps = (state) => ({
-  signupUrl: state.getIn(['server', 'server', 'registrations', 'url'], null) || '/auth/sign_up',
+  signupUrl:
+    state.getIn(['server', 'server', 'registrations', 'url'], null) ||
+    '/auth/sign_up',
 });
 
 const mapDispatchToProps = (dispatch) => ({
@@ -36,11 +38,10 @@ const mapDispatchToProps = (dispatch) => ({
   },
   dispatchServer() {
     dispatch(fetchServer());
-  }
+  },
 });
 
 class Header extends PureComponent {
-
   static contextTypes = {
     identity: PropTypes.object,
   };
@@ -53,44 +54,74 @@ class Header extends PureComponent {
     intl: PropTypes.object.isRequired,
   };
 
-  componentDidMount () {
+  componentDidMount() {
     const { dispatchServer } = this.props;
     dispatchServer();
   }
 
-  render () {
+  render() {
     const { signedIn } = this.context.identity;
-    const { location, openClosedRegistrationsModal, signupUrl, intl } = this.props;
+    const { location, openClosedRegistrationsModal, signupUrl, intl } =
+      this.props;
 
     let content;
 
     if (signedIn) {
       content = (
         <>
-          {location.pathname !== '/search' && <Link to='/search' className='button button-secondary' aria-label={intl.formatMessage(messages.search)}><Icon id='search' /></Link>}
-          {location.pathname !== '/publish' && <Link to='/publish' className='button button-secondary'><FormattedMessage id='compose_form.publish_form' defaultMessage='New post' /></Link>}
+          {location.pathname !== '/search' && (
+            <Link
+              to='/search'
+              className='button button-secondary'
+              aria-label={intl.formatMessage(messages.search)}
+            >
+              <Icon id='search' />
+            </Link>
+          )}
+          {location.pathname !== '/publish' && (
+            <Link to='/publish' className='button button-secondary'>
+              <FormattedMessage
+                id='compose_form.publish_form'
+                defaultMessage='New post'
+              />
+            </Link>
+          )}
           <Account />
         </>
       );
     } else {
-
       if (sso_redirect) {
         content = (
-            <a href={sso_redirect} data-method='post' className='button button--block button-tertiary'><FormattedMessage id='sign_in_banner.sso_redirect' defaultMessage='Login or Register' /></a>
-        )
+          <a
+            href={sso_redirect}
+            data-method='post'
+            className='button button--block button-tertiary'
+          >
+            <FormattedMessage
+              id='sign_in_banner.sso_redirect'
+              defaultMessage='Login or Register'
+            />
+          </a>
+        );
       } else {
         let signupButton;
 
         if (registrationsOpen) {
           signupButton = (
             <a href={signupUrl} className='button'>
-              <FormattedMessage id='sign_in_banner.create_account' defaultMessage='Create account' />
+              <FormattedMessage
+                id='sign_in_banner.create_account'
+                defaultMessage='Create account'
+              />
             </a>
           );
         } else {
           signupButton = (
             <button className='button' onClick={openClosedRegistrationsModal}>
-              <FormattedMessage id='sign_in_banner.create_account' defaultMessage='Create account' />
+              <FormattedMessage
+                id='sign_in_banner.create_account'
+                defaultMessage='Create account'
+              />
             </button>
           );
         }
@@ -98,7 +129,12 @@ class Header extends PureComponent {
         content = (
           <>
             {signupButton}
-            <a href='/auth/sign_in' className='button button-tertiary'><FormattedMessage id='sign_in_banner.sign_in' defaultMessage='Login' /></a>
+            <a href='/auth/sign_in' className='button button-tertiary'>
+              <FormattedMessage
+                id='sign_in_banner.sign_in'
+                defaultMessage='Login'
+              />
+            </a>
           </>
         );
       }
@@ -111,13 +147,12 @@ class Header extends PureComponent {
           <SymbolLogo />
         </Link>
 
-        <div className='ui__header__links'>
-          {content}
-        </div>
+        <div className='ui__header__links'>{content}</div>
       </div>
     );
   }
-
 }
 
-export default injectIntl(withRouter(connect(mapStateToProps, mapDispatchToProps)(Header)));
+export default injectIntl(
+  withRouter(connect(mapStateToProps, mapDispatchToProps)(Header)),
+);

--- a/app/javascript/mastodon/features/ui/components/image_loader.jsx
+++ b/app/javascript/mastodon/features/ui/components/image_loader.jsx
@@ -8,7 +8,6 @@ import { LoadingBar } from 'react-redux-loading-bar';
 import ZoomableImage from './zoomable_image';
 
 export default class ImageLoader extends PureComponent {
-
   static propTypes = {
     alt: PropTypes.string,
     lang: PropTypes.string,
@@ -44,27 +43,29 @@ export default class ImageLoader extends PureComponent {
     return this._canvasContext;
   }
 
-  componentDidMount () {
+  componentDidMount() {
     this.loadImage(this.props);
   }
 
-  UNSAFE_componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (this.props.src !== nextProps.src) {
       this.loadImage(nextProps);
     }
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     this.removeEventListeners();
   }
 
-  loadImage (props) {
+  loadImage(props) {
     this.removeEventListeners();
     this.setState({ loading: true, error: false });
-    Promise.all([
-      props.previewSrc && this.loadPreviewCanvas(props),
-      this.hasSize() && this.loadOriginalImage(props),
-    ].filter(Boolean))
+    Promise.all(
+      [
+        props.previewSrc && this.loadPreviewCanvas(props),
+        this.hasSize() && this.loadOriginalImage(props),
+      ].filter(Boolean),
+    )
       .then(() => {
         this.setState({ loading: false, error: false });
         this.clearPreviewCanvas();
@@ -72,68 +73,70 @@ export default class ImageLoader extends PureComponent {
       .catch(() => this.setState({ loading: false, error: true }));
   }
 
-  loadPreviewCanvas = ({ previewSrc, width, height }) => new Promise((resolve, reject) => {
-    const image = new Image();
-    const removeEventListeners = () => {
-      image.removeEventListener('error', handleError);
-      image.removeEventListener('load', handleLoad);
-    };
-    const handleError = () => {
-      removeEventListeners();
-      reject();
-    };
-    const handleLoad = () => {
-      removeEventListeners();
-      this.canvasContext.drawImage(image, 0, 0, width, height);
-      resolve();
-    };
-    image.addEventListener('error', handleError);
-    image.addEventListener('load', handleLoad);
-    image.src = previewSrc;
-    this.removers.push(removeEventListeners);
-  });
+  loadPreviewCanvas = ({ previewSrc, width, height }) =>
+    new Promise((resolve, reject) => {
+      const image = new Image();
+      const removeEventListeners = () => {
+        image.removeEventListener('error', handleError);
+        image.removeEventListener('load', handleLoad);
+      };
+      const handleError = () => {
+        removeEventListeners();
+        reject();
+      };
+      const handleLoad = () => {
+        removeEventListeners();
+        this.canvasContext.drawImage(image, 0, 0, width, height);
+        resolve();
+      };
+      image.addEventListener('error', handleError);
+      image.addEventListener('load', handleLoad);
+      image.src = previewSrc;
+      this.removers.push(removeEventListeners);
+    });
 
-  clearPreviewCanvas () {
+  clearPreviewCanvas() {
     const { width, height } = this.canvas;
     this.canvasContext.clearRect(0, 0, width, height);
   }
 
-  loadOriginalImage = ({ src }) => new Promise((resolve, reject) => {
-    const image = new Image();
-    const removeEventListeners = () => {
-      image.removeEventListener('error', handleError);
-      image.removeEventListener('load', handleLoad);
-    };
-    const handleError = () => {
-      removeEventListeners();
-      reject();
-    };
-    const handleLoad = () => {
-      removeEventListeners();
-      resolve();
-    };
-    image.addEventListener('error', handleError);
-    image.addEventListener('load', handleLoad);
-    image.src = src;
-    this.removers.push(removeEventListeners);
-  });
+  loadOriginalImage = ({ src }) =>
+    new Promise((resolve, reject) => {
+      const image = new Image();
+      const removeEventListeners = () => {
+        image.removeEventListener('error', handleError);
+        image.removeEventListener('load', handleLoad);
+      };
+      const handleError = () => {
+        removeEventListeners();
+        reject();
+      };
+      const handleLoad = () => {
+        removeEventListeners();
+        resolve();
+      };
+      image.addEventListener('error', handleError);
+      image.addEventListener('load', handleLoad);
+      image.src = src;
+      this.removers.push(removeEventListeners);
+    });
 
-  removeEventListeners () {
-    this.removers.forEach(listeners => listeners());
+  removeEventListeners() {
+    this.removers.forEach((listeners) => listeners());
     this.removers = [];
   }
 
-  hasSize () {
+  hasSize() {
     const { width, height } = this.props;
     return typeof width === 'number' && typeof height === 'number';
   }
 
-  setCanvasRef = c => {
+  setCanvasRef = (c) => {
     this.canvas = c;
     if (c) this.setState({ width: c.offsetWidth });
   };
 
-  render () {
+  render() {
     const { alt, lang, src, width, height, onClick } = this.props;
     const { loading } = this.state;
 
@@ -146,7 +149,10 @@ export default class ImageLoader extends PureComponent {
       <div className={className}>
         {loading ? (
           <>
-            <div className='loading-bar__container' style={{ width: this.state.width || width }}>
+            <div
+              className='loading-bar__container'
+              style={{ width: this.state.width || width }}
+            >
               <LoadingBar className='loading-bar' loading={1} />
             </div>
             <canvas
@@ -170,5 +176,4 @@ export default class ImageLoader extends PureComponent {
       </div>
     );
   }
-
 }

--- a/app/javascript/mastodon/features/ui/components/image_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/image_modal.jsx
@@ -14,7 +14,6 @@ const messages = defineMessages({
 });
 
 class ImageModal extends PureComponent {
-
   static propTypes = {
     src: PropTypes.string.isRequired,
     alt: PropTypes.string.isRequired,
@@ -27,12 +26,12 @@ class ImageModal extends PureComponent {
   };
 
   toggleNavigation = () => {
-    this.setState(prevState => ({
+    this.setState((prevState) => ({
       navigationHidden: !prevState.navigationHidden,
     }));
   };
 
-  render () {
+  render() {
     const { intl, src, alt, onClose } = this.props;
     const { navigationHidden } = this.state;
 
@@ -42,7 +41,11 @@ class ImageModal extends PureComponent {
 
     return (
       <div className='modal-root__modal media-modal'>
-        <div className='media-modal__closer' role='presentation' onClick={onClose} >
+        <div
+          className='media-modal__closer'
+          role='presentation'
+          onClick={onClose}
+        >
           <ImageLoader
             src={src}
             width={400}
@@ -53,12 +56,17 @@ class ImageModal extends PureComponent {
         </div>
 
         <div className={navigationClassName}>
-          <IconButton className='media-modal__close' title={intl.formatMessage(messages.close)} icon='times' onClick={onClose} size={40} />
+          <IconButton
+            className='media-modal__close'
+            title={intl.formatMessage(messages.close)}
+            icon='times'
+            onClick={onClose}
+            size={40}
+          />
         </div>
       </div>
     );
   }
-
 }
 
 export default injectIntl(ImageModal);

--- a/app/javascript/mastodon/features/ui/components/link_footer.jsx
+++ b/app/javascript/mastodon/features/ui/components/link_footer.jsx
@@ -8,31 +8,44 @@ import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 
 import { openModal } from 'mastodon/actions/modal';
-import { domain, version, source_url, statusPageUrl, profile_directory as profileDirectory } from 'mastodon/initial_state';
+import {
+  domain,
+  version,
+  source_url,
+  statusPageUrl,
+  profile_directory as profileDirectory,
+} from 'mastodon/initial_state';
 import { PERMISSION_INVITE_USERS } from 'mastodon/permissions';
 import { logOut } from 'mastodon/utils/log_out';
 
 const messages = defineMessages({
-  logoutMessage: { id: 'confirmations.logout.message', defaultMessage: 'Are you sure you want to log out?' },
-  logoutConfirm: { id: 'confirmations.logout.confirm', defaultMessage: 'Log out' },
+  logoutMessage: {
+    id: 'confirmations.logout.message',
+    defaultMessage: 'Are you sure you want to log out?',
+  },
+  logoutConfirm: {
+    id: 'confirmations.logout.confirm',
+    defaultMessage: 'Log out',
+  },
 });
 
 const mapDispatchToProps = (dispatch, { intl }) => ({
-  onLogout () {
-    dispatch(openModal({
-      modalType: 'CONFIRM',
-      modalProps: {
-        message: intl.formatMessage(messages.logoutMessage),
-        confirm: intl.formatMessage(messages.logoutConfirm),
-        closeWhenConfirm: false,
-        onConfirm: () => logOut(),
-      },
-    }));
+  onLogout() {
+    dispatch(
+      openModal({
+        modalType: 'CONFIRM',
+        modalProps: {
+          message: intl.formatMessage(messages.logoutMessage),
+          confirm: intl.formatMessage(messages.logoutConfirm),
+          closeWhenConfirm: false,
+          onConfirm: () => logOut(),
+        },
+      }),
+    );
   },
 });
 
 class LinkFooter extends PureComponent {
-
   static contextTypes = {
     identity: PropTypes.object,
   };
@@ -43,7 +56,7 @@ class LinkFooter extends PureComponent {
     intl: PropTypes.object.isRequired,
   };
 
-  handleLogoutClick = e => {
+  handleLogoutClick = (e) => {
     e.preventDefault();
     e.stopPropagation();
 
@@ -52,11 +65,13 @@ class LinkFooter extends PureComponent {
     return false;
   };
 
-  render () {
+  render() {
     const { signedIn, permissions } = this.context.identity;
     const { multiColumn } = this.props;
 
-    const canInvite = signedIn && ((permissions & PERMISSION_INVITE_USERS) === PERMISSION_INVITE_USERS);
+    const canInvite =
+      signedIn &&
+      (permissions & PERMISSION_INVITE_USERS) === PERMISSION_INVITE_USERS;
     const canProfileDirectory = profileDirectory;
 
     const DividingCircle = <span aria-hidden>{' · '}</span>;
@@ -64,48 +79,83 @@ class LinkFooter extends PureComponent {
     return (
       <div className='link-footer'>
         <p>
-          <strong>{domain}</strong>:
-          {' '}
-          <Link to='/about' target={multiColumn ? '_blank' : undefined}><FormattedMessage id='footer.about' defaultMessage='About' /></Link>
+          <strong>{domain}</strong>:{' '}
+          <Link to='/about' target={multiColumn ? '_blank' : undefined}>
+            <FormattedMessage id='footer.about' defaultMessage='About' />
+          </Link>
           {statusPageUrl && (
             <>
               {DividingCircle}
-              <a href={statusPageUrl} target='_blank' rel='noopener'><FormattedMessage id='footer.status' defaultMessage='Status' /></a>
+              <a href={statusPageUrl} target='_blank' rel='noopener'>
+                <FormattedMessage id='footer.status' defaultMessage='Status' />
+              </a>
             </>
           )}
           {canInvite && (
             <>
               {DividingCircle}
-              <a href='/invites' target='_blank'><FormattedMessage id='footer.invite' defaultMessage='Invite people' /></a>
+              <a href='/invites' target='_blank'>
+                <FormattedMessage
+                  id='footer.invite'
+                  defaultMessage='Invite people'
+                />
+              </a>
             </>
           )}
           {canProfileDirectory && (
             <>
               {DividingCircle}
-              <Link to='/directory'><FormattedMessage id='footer.directory' defaultMessage='Profiles directory' /></Link>
+              <Link to='/directory'>
+                <FormattedMessage
+                  id='footer.directory'
+                  defaultMessage='Profiles directory'
+                />
+              </Link>
             </>
           )}
           {DividingCircle}
-          <Link to='/privacy-policy' target={multiColumn ? '_blank' : undefined}><FormattedMessage id='footer.privacy_policy' defaultMessage='Privacy policy' /></Link>
+          <Link
+            to='/privacy-policy'
+            target={multiColumn ? '_blank' : undefined}
+          >
+            <FormattedMessage
+              id='footer.privacy_policy'
+              defaultMessage='Privacy policy'
+            />
+          </Link>
         </p>
 
         <p>
-          <strong>Mastodon</strong>:
-          {' '}
-          <a href='https://joinmastodon.org' target='_blank'><FormattedMessage id='footer.about' defaultMessage='About' /></a>
+          <strong>Mastodon</strong>:{' '}
+          <a href='https://joinmastodon.org' target='_blank'>
+            <FormattedMessage id='footer.about' defaultMessage='About' />
+          </a>
           {DividingCircle}
-          <a href='https://joinmastodon.org/apps' target='_blank'><FormattedMessage id='footer.get_app' defaultMessage='Get the app' /></a>
+          <a href='https://joinmastodon.org/apps' target='_blank'>
+            <FormattedMessage
+              id='footer.get_app'
+              defaultMessage='Get the app'
+            />
+          </a>
           {DividingCircle}
-          <Link to='/keyboard-shortcuts'><FormattedMessage id='footer.keyboard_shortcuts' defaultMessage='Keyboard shortcuts' /></Link>
+          <Link to='/keyboard-shortcuts'>
+            <FormattedMessage
+              id='footer.keyboard_shortcuts'
+              defaultMessage='Keyboard shortcuts'
+            />
+          </Link>
           {DividingCircle}
-          <a href={source_url} rel='noopener noreferrer' target='_blank'><FormattedMessage id='footer.source_code' defaultMessage='View source code' /></a>
-          {DividingCircle}
-          v{version}
+          <a href={source_url} rel='noopener noreferrer' target='_blank'>
+            <FormattedMessage
+              id='footer.source_code'
+              defaultMessage='View source code'
+            />
+          </a>
+          {DividingCircle}v{version}
         </p>
       </div>
     );
   }
-
 }
 
 export default injectIntl(connect(null, mapDispatchToProps)(LinkFooter));

--- a/app/javascript/mastodon/features/ui/components/list_panel.jsx
+++ b/app/javascript/mastodon/features/ui/components/list_panel.jsx
@@ -11,31 +11,37 @@ import { fetchLists } from 'mastodon/actions/lists';
 
 import ColumnLink from './column_link';
 
-const getOrderedLists = createSelector([state => state.get('lists')], lists => {
-  if (!lists) {
-    return lists;
-  }
+const getOrderedLists = createSelector(
+  [(state) => state.get('lists')],
+  (lists) => {
+    if (!lists) {
+      return lists;
+    }
 
-  return lists.toList().filter(item => !!item).sort((a, b) => a.get('title').localeCompare(b.get('title'))).take(4);
-});
+    return lists
+      .toList()
+      .filter((item) => !!item)
+      .sort((a, b) => a.get('title').localeCompare(b.get('title')))
+      .take(4);
+  },
+);
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   lists: getOrderedLists(state),
 });
 
 class ListPanel extends ImmutablePureComponent {
-
   static propTypes = {
     dispatch: PropTypes.func.isRequired,
     lists: ImmutablePropTypes.list,
   };
 
-  componentDidMount () {
+  componentDidMount() {
     const { dispatch } = this.props;
     dispatch(fetchLists());
   }
 
-  render () {
+  render() {
     const { lists } = this.props;
 
     if (!lists || lists.isEmpty()) {
@@ -46,13 +52,19 @@ class ListPanel extends ImmutablePureComponent {
       <div className='list-panel'>
         <hr />
 
-        {lists.map(list => (
-          <ColumnLink icon='list-ul' key={list.get('id')} strict text={list.get('title')} to={`/lists/${list.get('id')}`} transparent />
+        {lists.map((list) => (
+          <ColumnLink
+            icon='list-ul'
+            key={list.get('id')}
+            strict
+            text={list.get('title')}
+            to={`/lists/${list.get('id')}`}
+            transparent
+          />
         ))}
       </div>
     );
   }
-
 }
 
 export default withRouter(connect(mapStateToProps)(ListPanel));

--- a/app/javascript/mastodon/features/ui/components/media_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/media_modal.jsx
@@ -11,7 +11,7 @@ import ReactSwipeableViews from 'react-swipeable-views';
 
 import { getAverageFromBlurhash } from 'mastodon/blurhash';
 import { GIFV } from 'mastodon/components/gifv';
-import { Icon }  from 'mastodon/components/icon';
+import { Icon } from 'mastodon/components/icon';
 import { IconButton } from 'mastodon/components/icon_button';
 import Footer from 'mastodon/features/picture_in_picture/components/footer';
 import Video from 'mastodon/features/video';
@@ -26,7 +26,6 @@ const messages = defineMessages({
 });
 
 class MediaModal extends ImmutablePureComponent {
-
   static propTypes = {
     media: ImmutablePropTypes.list.isRequired,
     statusId: PropTypes.string,
@@ -65,7 +64,8 @@ class MediaModal extends ImmutablePureComponent {
 
   handlePrevClick = () => {
     this.setState({
-      index: (this.props.media.size + this.getIndex() - 1) % this.props.media.size,
+      index:
+        (this.props.media.size + this.getIndex() - 1) % this.props.media.size,
       zoomButtonHidden: true,
     });
   };
@@ -80,33 +80,33 @@ class MediaModal extends ImmutablePureComponent {
   };
 
   handleKeyDown = (e) => {
-    switch(e.key) {
-    case 'ArrowLeft':
-      this.handlePrevClick();
-      e.preventDefault();
-      e.stopPropagation();
-      break;
-    case 'ArrowRight':
-      this.handleNextClick();
-      e.preventDefault();
-      e.stopPropagation();
-      break;
+    switch (e.key) {
+      case 'ArrowLeft':
+        this.handlePrevClick();
+        e.preventDefault();
+        e.stopPropagation();
+        break;
+      case 'ArrowRight':
+        this.handleNextClick();
+        e.preventDefault();
+        e.stopPropagation();
+        break;
     }
   };
 
-  componentDidMount () {
+  componentDidMount() {
     window.addEventListener('keydown', this.handleKeyDown, false);
 
     this._sendBackgroundColor();
   }
 
-  componentDidUpdate (prevProps, prevState) {
+  componentDidUpdate(prevProps, prevState) {
     if (prevState.index !== this.state.index) {
       this._sendBackgroundColor();
     }
   }
 
-  _sendBackgroundColor () {
+  _sendBackgroundColor() {
     const { media, onChangeBackgroundColor } = this.props;
     const index = this.getIndex();
     const blurhash = media.getIn([index, 'blurhash']);
@@ -117,88 +117,114 @@ class MediaModal extends ImmutablePureComponent {
     }
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     window.removeEventListener('keydown', this.handleKeyDown);
 
     this.props.onChangeBackgroundColor(null);
   }
 
-  getIndex () {
+  getIndex() {
     return this.state.index !== null ? this.state.index : this.props.index;
   }
 
   toggleNavigation = () => {
-    this.setState(prevState => ({
+    this.setState((prevState) => ({
       navigationHidden: !prevState.navigationHidden,
     }));
   };
 
-  render () {
+  render() {
     const { media, statusId, lang, intl, onClose } = this.props;
     const { navigationHidden } = this.state;
 
     const index = this.getIndex();
 
-    const leftNav  = media.size > 1 && <button tabIndex={0} className='media-modal__nav media-modal__nav--left' onClick={this.handlePrevClick} aria-label={intl.formatMessage(messages.previous)}><Icon id='chevron-left' fixedWidth /></button>;
-    const rightNav = media.size > 1 && <button tabIndex={0} className='media-modal__nav  media-modal__nav--right' onClick={this.handleNextClick} aria-label={intl.formatMessage(messages.next)}><Icon id='chevron-right' fixedWidth /></button>;
+    const leftNav = media.size > 1 && (
+      <button
+        tabIndex={0}
+        className='media-modal__nav media-modal__nav--left'
+        onClick={this.handlePrevClick}
+        aria-label={intl.formatMessage(messages.previous)}
+      >
+        <Icon id='chevron-left' fixedWidth />
+      </button>
+    );
+    const rightNav = media.size > 1 && (
+      <button
+        tabIndex={0}
+        className='media-modal__nav  media-modal__nav--right'
+        onClick={this.handleNextClick}
+        aria-label={intl.formatMessage(messages.next)}
+      >
+        <Icon id='chevron-right' fixedWidth />
+      </button>
+    );
 
-    const content = media.map((image) => {
-      const width  = image.getIn(['meta', 'original', 'width']) || null;
-      const height = image.getIn(['meta', 'original', 'height']) || null;
-      const description = image.getIn(['translation', 'description']) || image.get('description');
+    const content = media
+      .map((image) => {
+        const width = image.getIn(['meta', 'original', 'width']) || null;
+        const height = image.getIn(['meta', 'original', 'height']) || null;
+        const description =
+          image.getIn(['translation', 'description']) ||
+          image.get('description');
 
-      if (image.get('type') === 'image') {
-        return (
-          <ImageLoader
-            previewSrc={image.get('preview_url')}
-            src={image.get('url')}
-            width={width}
-            height={height}
-            alt={description}
-            lang={lang}
-            key={image.get('url')}
-            onClick={this.toggleNavigation}
-            zoomButtonHidden={this.state.zoomButtonHidden}
-          />
-        );
-      } else if (image.get('type') === 'video') {
-        const { currentTime, autoPlay, volume } = this.props;
+        if (image.get('type') === 'image') {
+          return (
+            <ImageLoader
+              previewSrc={image.get('preview_url')}
+              src={image.get('url')}
+              width={width}
+              height={height}
+              alt={description}
+              lang={lang}
+              key={image.get('url')}
+              onClick={this.toggleNavigation}
+              zoomButtonHidden={this.state.zoomButtonHidden}
+            />
+          );
+        } else if (image.get('type') === 'video') {
+          const { currentTime, autoPlay, volume } = this.props;
 
-        return (
-          <Video
-            preview={image.get('preview_url')}
-            blurhash={image.get('blurhash')}
-            src={image.get('url')}
-            width={image.get('width')}
-            height={image.get('height')}
-            frameRate={image.getIn(['meta', 'original', 'frame_rate'])}
-            aspectRatio={`${image.getIn(['meta', 'original', 'width'])} / ${image.getIn(['meta', 'original', 'height'])}`}
-            currentTime={currentTime || 0}
-            autoPlay={autoPlay || false}
-            volume={volume || 1}
-            onCloseVideo={onClose}
-            detailed
-            alt={description}
-            lang={lang}
-            key={image.get('url')}
-          />
-        );
-      } else if (image.get('type') === 'gifv') {
-        return (
-          <GIFV
-            src={image.get('url')}
-            width={width}
-            height={height}
-            key={image.get('url')}
-            alt={description}
-            lang={lang}
-            onClick={this.toggleNavigation}
-          />
-        );
-      }
+          return (
+            <Video
+              preview={image.get('preview_url')}
+              blurhash={image.get('blurhash')}
+              src={image.get('url')}
+              width={image.get('width')}
+              height={image.get('height')}
+              frameRate={image.getIn(['meta', 'original', 'frame_rate'])}
+              aspectRatio={`${image.getIn([
+                'meta',
+                'original',
+                'width',
+              ])} / ${image.getIn(['meta', 'original', 'height'])}`}
+              currentTime={currentTime || 0}
+              autoPlay={autoPlay || false}
+              volume={volume || 1}
+              onCloseVideo={onClose}
+              detailed
+              alt={description}
+              lang={lang}
+              key={image.get('url')}
+            />
+          );
+        } else if (image.get('type') === 'gifv') {
+          return (
+            <GIFV
+              src={image.get('url')}
+              width={width}
+              height={height}
+              key={image.get('url')}
+              alt={description}
+              lang={lang}
+              onClick={this.toggleNavigation}
+            />
+          );
+        }
 
-      return null;
-    }).toArray();
+        return null;
+      })
+      .toArray();
 
     // you can't use 100vh, because the viewport height is taller
     // than the visible part of the document in some mobile
@@ -221,7 +247,14 @@ class MediaModal extends ImmutablePureComponent {
 
     if (media.size > 1) {
       pagination = media.map((item, i) => (
-        <button key={i} className={classNames('media-modal__page-dot', { active: i === index })} data-index={i} onClick={this.handleChangeIndex}>
+        <button
+          key={i}
+          className={classNames('media-modal__page-dot', {
+            active: i === index,
+          })}
+          data-index={i}
+          onClick={this.handleChangeIndex}
+        >
           {i + 1}
         </button>
       ));
@@ -229,7 +262,11 @@ class MediaModal extends ImmutablePureComponent {
 
     return (
       <div className='modal-root__modal media-modal'>
-        <div className='media-modal__closer' role='presentation' onClick={onClose} >
+        <div
+          className='media-modal__closer'
+          role='presentation'
+          onClick={onClose}
+        >
           <ReactSwipeableViews
             style={swipeableViewsStyle}
             containerStyle={containerStyle}
@@ -243,20 +280,29 @@ class MediaModal extends ImmutablePureComponent {
         </div>
 
         <div className={navigationClassName}>
-          <IconButton className='media-modal__close' title={intl.formatMessage(messages.close)} icon='times' onClick={onClose} size={40} />
+          <IconButton
+            className='media-modal__close'
+            title={intl.formatMessage(messages.close)}
+            icon='times'
+            onClick={onClose}
+            size={40}
+          />
 
           {leftNav}
           {rightNav}
 
           <div className='media-modal__overlay'>
-            {pagination && <ul className='media-modal__pagination'>{pagination}</ul>}
-            {statusId && <Footer statusId={statusId} withOpenButton onClose={onClose} />}
+            {pagination && (
+              <ul className='media-modal__pagination'>{pagination}</ul>
+            )}
+            {statusId && (
+              <Footer statusId={statusId} withOpenButton onClose={onClose} />
+            )}
           </div>
         </div>
       </div>
     );
   }
-
 }
 
 export default injectIntl(MediaModal);

--- a/app/javascript/mastodon/features/ui/components/modal_root.jsx
+++ b/app/javascript/mastodon/features/ui/components/modal_root.jsx
@@ -33,29 +33,28 @@ import ModalLoading from './modal_loading';
 import VideoModal from './video_modal';
 
 export const MODAL_COMPONENTS = {
-  'MEDIA': () => Promise.resolve({ default: MediaModal }),
-  'VIDEO': () => Promise.resolve({ default: VideoModal }),
-  'AUDIO': () => Promise.resolve({ default: AudioModal }),
-  'IMAGE': () => Promise.resolve({ default: ImageModal }),
-  'BOOST': () => Promise.resolve({ default: BoostModal }),
-  'CONFIRM': () => Promise.resolve({ default: ConfirmationModal }),
-  'MUTE': MuteModal,
-  'BLOCK': BlockModal,
-  'REPORT': ReportModal,
-  'ACTIONS': () => Promise.resolve({ default: ActionsModal }),
-  'EMBED': EmbedModal,
-  'LIST_EDITOR': ListEditor,
-  'FOCAL_POINT': () => Promise.resolve({ default: FocalPointModal }),
-  'LIST_ADDER': ListAdder,
-  'COMPARE_HISTORY': CompareHistoryModal,
-  'FILTER': FilterModal,
-  'SUBSCRIBED_LANGUAGES': SubscribedLanguagesModal,
-  'INTERACTION': InteractionModal,
-  'CLOSED_REGISTRATIONS': ClosedRegistrationsModal,
+  MEDIA: () => Promise.resolve({ default: MediaModal }),
+  VIDEO: () => Promise.resolve({ default: VideoModal }),
+  AUDIO: () => Promise.resolve({ default: AudioModal }),
+  IMAGE: () => Promise.resolve({ default: ImageModal }),
+  BOOST: () => Promise.resolve({ default: BoostModal }),
+  CONFIRM: () => Promise.resolve({ default: ConfirmationModal }),
+  MUTE: MuteModal,
+  BLOCK: BlockModal,
+  REPORT: ReportModal,
+  ACTIONS: () => Promise.resolve({ default: ActionsModal }),
+  EMBED: EmbedModal,
+  LIST_EDITOR: ListEditor,
+  FOCAL_POINT: () => Promise.resolve({ default: FocalPointModal }),
+  LIST_ADDER: ListAdder,
+  COMPARE_HISTORY: CompareHistoryModal,
+  FILTER: FilterModal,
+  SUBSCRIBED_LANGUAGES: SubscribedLanguagesModal,
+  INTERACTION: InteractionModal,
+  CLOSED_REGISTRATIONS: ClosedRegistrationsModal,
 };
 
 export default class ModalRoot extends PureComponent {
-
   static propTypes = {
     type: PropTypes.string,
     props: PropTypes.object,
@@ -67,11 +66,11 @@ export default class ModalRoot extends PureComponent {
     backgroundColor: null,
   };
 
-  getSnapshotBeforeUpdate () {
+  getSnapshotBeforeUpdate() {
     return { visible: !!this.props.type };
   }
 
-  componentDidUpdate (prevProps, prevState, { visible }) {
+  componentDidUpdate(prevProps, prevState, { visible }) {
     if (visible) {
       document.body.classList.add('with-modals--active');
       document.documentElement.style.marginRight = `${getScrollbarWidth()}px`;
@@ -81,12 +80,16 @@ export default class ModalRoot extends PureComponent {
     }
   }
 
-  setBackgroundColor = color => {
+  setBackgroundColor = (color) => {
     this.setState({ backgroundColor: color });
   };
 
-  renderLoading = modalId => () => {
-    return ['MEDIA', 'VIDEO', 'BOOST', 'CONFIRM', 'ACTIONS'].indexOf(modalId) === -1 ? <ModalLoading /> : null;
+  renderLoading = (modalId) => () => {
+    return ['MEDIA', 'VIDEO', 'BOOST', 'CONFIRM', 'ACTIONS'].indexOf(
+      modalId,
+    ) === -1 ? (
+      <ModalLoading />
+    ) : null;
   };
 
   renderError = (props) => {
@@ -105,19 +108,38 @@ export default class ModalRoot extends PureComponent {
     this._modal = c;
   };
 
-  render () {
+  render() {
     const { type, props, ignoreFocus } = this.props;
     const { backgroundColor } = this.state;
     const visible = !!type;
 
     return (
-      <Base backgroundColor={backgroundColor} onClose={this.handleClose} ignoreFocus={ignoreFocus}>
+      <Base
+        backgroundColor={backgroundColor}
+        onClose={this.handleClose}
+        ignoreFocus={ignoreFocus}
+      >
         {visible && (
           <>
-            <BundleContainer fetchComponent={MODAL_COMPONENTS[type]} loading={this.renderLoading(type)} error={this.renderError} renderDelay={200}>
+            <BundleContainer
+              fetchComponent={MODAL_COMPONENTS[type]}
+              loading={this.renderLoading(type)}
+              error={this.renderError}
+              renderDelay={200}
+            >
               {(SpecificComponent) => {
-                const ref = typeof SpecificComponent !== 'function' ? this.setModalRef : undefined;
-                return <SpecificComponent {...props} onChangeBackgroundColor={this.setBackgroundColor} onClose={this.handleClose} ref={ref} />
+                const ref =
+                  typeof SpecificComponent !== 'function'
+                    ? this.setModalRef
+                    : undefined;
+                return (
+                  <SpecificComponent
+                    {...props}
+                    onChangeBackgroundColor={this.setBackgroundColor}
+                    onClose={this.handleClose}
+                    ref={ref}
+                  />
+                );
               }}
             </BundleContainer>
 
@@ -129,5 +151,4 @@ export default class ModalRoot extends PureComponent {
       </Base>
     );
   }
-
 }

--- a/app/javascript/mastodon/features/ui/components/mute_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/mute_modal.jsx
@@ -9,17 +9,29 @@ import Toggle from 'react-toggle';
 
 import { muteAccount } from '../../../actions/accounts';
 import { closeModal } from '../../../actions/modal';
-import { toggleHideNotifications, changeMuteDuration } from '../../../actions/mutes';
+import {
+  toggleHideNotifications,
+  changeMuteDuration,
+} from '../../../actions/mutes';
 import Button from '../../../components/button';
 
 const messages = defineMessages({
-  minutes: { id: 'intervals.full.minutes', defaultMessage: '{number, plural, one {# minute} other {# minutes}}' },
-  hours: { id: 'intervals.full.hours', defaultMessage: '{number, plural, one {# hour} other {# hours}}' },
-  days: { id: 'intervals.full.days', defaultMessage: '{number, plural, one {# day} other {# days}}' },
+  minutes: {
+    id: 'intervals.full.minutes',
+    defaultMessage: '{number, plural, one {# minute} other {# minutes}}',
+  },
+  hours: {
+    id: 'intervals.full.hours',
+    defaultMessage: '{number, plural, one {# hour} other {# hours}}',
+  },
+  days: {
+    id: 'intervals.full.days',
+    defaultMessage: '{number, plural, one {# day} other {# days}}',
+  },
   indefinite: { id: 'mute_modal.indefinite', defaultMessage: 'Indefinite' },
 });
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
   return {
     account: state.getIn(['mutes', 'new', 'account']),
     notifications: state.getIn(['mutes', 'new', 'notifications']),
@@ -27,17 +39,19 @@ const mapStateToProps = state => {
   };
 };
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch) => {
   return {
     onConfirm(account, notifications, muteDuration) {
       dispatch(muteAccount(account.get('id'), notifications, muteDuration));
     },
 
     onClose() {
-      dispatch(closeModal({
-        modalType: undefined,
-        ignoreFocus: false,
-      }));
+      dispatch(
+        closeModal({
+          modalType: undefined,
+          ignoreFocus: false,
+        }),
+      );
     },
 
     onToggleNotifications() {
@@ -51,7 +65,6 @@ const mapDispatchToProps = dispatch => {
 };
 
 class MuteModal extends PureComponent {
-
   static propTypes = {
     account: PropTypes.object.isRequired,
     notifications: PropTypes.bool.isRequired,
@@ -69,7 +82,11 @@ class MuteModal extends PureComponent {
 
   handleClick = () => {
     this.props.onClose();
-    this.props.onConfirm(this.props.account, this.props.notifications, this.props.muteDuration);
+    this.props.onConfirm(
+      this.props.account,
+      this.props.notifications,
+      this.props.muteDuration,
+    );
   };
 
   handleCancel = () => {
@@ -88,7 +105,7 @@ class MuteModal extends PureComponent {
     this.props.onChangeMuteDuration(e);
   };
 
-  render () {
+  render() {
     const { account, notifications, muteDuration, intl } = this.props;
 
     return (
@@ -108,40 +125,83 @@ class MuteModal extends PureComponent {
             />
           </p>
           <div className='setting-toggle'>
-            <Toggle id='mute-modal__hide-notifications-checkbox' checked={notifications} onChange={this.toggleNotifications} />
-            <label className='setting-toggle__label' htmlFor='mute-modal__hide-notifications-checkbox'>
-              <FormattedMessage id='mute_modal.hide_notifications' defaultMessage='Hide notifications from this user?' />
+            <Toggle
+              id='mute-modal__hide-notifications-checkbox'
+              checked={notifications}
+              onChange={this.toggleNotifications}
+            />
+            <label
+              className='setting-toggle__label'
+              htmlFor='mute-modal__hide-notifications-checkbox'
+            >
+              <FormattedMessage
+                id='mute_modal.hide_notifications'
+                defaultMessage='Hide notifications from this user?'
+              />
             </label>
           </div>
           <div>
-            <span><FormattedMessage id='mute_modal.duration' defaultMessage='Duration' />: </span>
+            <span>
+              <FormattedMessage
+                id='mute_modal.duration'
+                defaultMessage='Duration'
+              />
+              :{' '}
+            </span>
 
             {/* eslint-disable-next-line jsx-a11y/no-onchange */}
             <select value={muteDuration} onChange={this.changeMuteDuration}>
-              <option value={0}>{intl.formatMessage(messages.indefinite)}</option>
-              <option value={300}>{intl.formatMessage(messages.minutes, { number: 5 })}</option>
-              <option value={1800}>{intl.formatMessage(messages.minutes, { number: 30 })}</option>
-              <option value={3600}>{intl.formatMessage(messages.hours, { number: 1 })}</option>
-              <option value={21600}>{intl.formatMessage(messages.hours, { number: 6 })}</option>
-              <option value={86400}>{intl.formatMessage(messages.days, { number: 1 })}</option>
-              <option value={259200}>{intl.formatMessage(messages.days, { number: 3 })}</option>
-              <option value={604800}>{intl.formatMessage(messages.days, { number: 7 })}</option>
+              <option value={0}>
+                {intl.formatMessage(messages.indefinite)}
+              </option>
+              <option value={300}>
+                {intl.formatMessage(messages.minutes, { number: 5 })}
+              </option>
+              <option value={1800}>
+                {intl.formatMessage(messages.minutes, { number: 30 })}
+              </option>
+              <option value={3600}>
+                {intl.formatMessage(messages.hours, { number: 1 })}
+              </option>
+              <option value={21600}>
+                {intl.formatMessage(messages.hours, { number: 6 })}
+              </option>
+              <option value={86400}>
+                {intl.formatMessage(messages.days, { number: 1 })}
+              </option>
+              <option value={259200}>
+                {intl.formatMessage(messages.days, { number: 3 })}
+              </option>
+              <option value={604800}>
+                {intl.formatMessage(messages.days, { number: 7 })}
+              </option>
             </select>
           </div>
         </div>
 
         <div className='mute-modal__action-bar'>
-          <Button onClick={this.handleCancel} className='mute-modal__cancel-button'>
-            <FormattedMessage id='confirmation_modal.cancel' defaultMessage='Cancel' />
+          <Button
+            onClick={this.handleCancel}
+            className='mute-modal__cancel-button'
+          >
+            <FormattedMessage
+              id='confirmation_modal.cancel'
+              defaultMessage='Cancel'
+            />
           </Button>
           <Button onClick={this.handleClick} ref={this.setRef}>
-            <FormattedMessage id='confirmations.mute.confirm' defaultMessage='Mute' />
+            <FormattedMessage
+              id='confirmations.mute.confirm'
+              defaultMessage='Mute'
+            />
           </Button>
         </div>
       </div>
     );
   }
-
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(injectIntl(MuteModal));
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(injectIntl(MuteModal));

--- a/app/javascript/mastodon/features/ui/components/navigation_panel.jsx
+++ b/app/javascript/mastodon/features/ui/components/navigation_panel.jsx
@@ -19,23 +19,38 @@ import SignInBanner from './sign_in_banner';
 
 const messages = defineMessages({
   home: { id: 'tabs_bar.home', defaultMessage: 'Home' },
-  notifications: { id: 'tabs_bar.notifications', defaultMessage: 'Notifications' },
+  notifications: {
+    id: 'tabs_bar.notifications',
+    defaultMessage: 'Notifications',
+  },
   explore: { id: 'explore.title', defaultMessage: 'Explore' },
   firehose: { id: 'column.firehose', defaultMessage: 'Live feeds' },
   direct: { id: 'navigation_bar.direct', defaultMessage: 'Private mentions' },
   favourites: { id: 'navigation_bar.favourites', defaultMessage: 'Favorites' },
   bookmarks: { id: 'navigation_bar.bookmarks', defaultMessage: 'Bookmarks' },
   lists: { id: 'navigation_bar.lists', defaultMessage: 'Lists' },
-  preferences: { id: 'navigation_bar.preferences', defaultMessage: 'Preferences' },
-  followsAndFollowers: { id: 'navigation_bar.follows_and_followers', defaultMessage: 'Follows and followers' },
+  preferences: {
+    id: 'navigation_bar.preferences',
+    defaultMessage: 'Preferences',
+  },
+  followsAndFollowers: {
+    id: 'navigation_bar.follows_and_followers',
+    defaultMessage: 'Follows and followers',
+  },
   about: { id: 'navigation_bar.about', defaultMessage: 'About' },
   search: { id: 'navigation_bar.search', defaultMessage: 'Search' },
-  advancedInterface: { id: 'navigation_bar.advanced_interface', defaultMessage: 'Open in advanced web interface' },
-  openedInClassicInterface: { id: 'navigation_bar.opened_in_classic_interface', defaultMessage: 'Posts, accounts, and other specific pages are opened by default in the classic web interface.' },
+  advancedInterface: {
+    id: 'navigation_bar.advanced_interface',
+    defaultMessage: 'Open in advanced web interface',
+  },
+  openedInClassicInterface: {
+    id: 'navigation_bar.opened_in_classic_interface',
+    defaultMessage:
+      'Posts, accounts, and other specific pages are opened by default in the classic web interface.',
+  },
 });
 
 class NavigationPanel extends Component {
-
   static contextTypes = {
     router: PropTypes.object.isRequired,
     identity: PropTypes.object.isRequired,
@@ -49,20 +64,24 @@ class NavigationPanel extends Component {
     return match || location.pathname.startsWith('/public');
   };
 
-  render () {
+  render() {
     const { intl } = this.props;
     const { signedIn, disabledAccountId } = this.context.identity;
 
     return (
       <div className='navigation-panel'>
         <div className='navigation-panel__logo'>
-          <Link to='/' className='column-link column-link--logo'><WordmarkLogo /></Link>
+          <Link to='/' className='column-link column-link--logo'>
+            <WordmarkLogo />
+          </Link>
 
           {transientSingleColumn ? (
             <div class='switch-to-advanced'>
-              {intl.formatMessage(messages.openedInClassicInterface)}
-              {" "}
-              <a href={`/deck${location.pathname}`} class='switch-to-advanced__toggle'>
+              {intl.formatMessage(messages.openedInClassicInterface)}{' '}
+              <a
+                href={`/deck${location.pathname}`}
+                class='switch-to-advanced__toggle'
+              >
                 {intl.formatMessage(messages.advancedInterface)}
               </a>
             </div>
@@ -73,54 +92,109 @@ class NavigationPanel extends Component {
 
         {signedIn && (
           <>
-            <ColumnLink transparent to='/home' icon='home' text={intl.formatMessage(messages.home)} />
-            <ColumnLink transparent to='/notifications' icon={<NotificationsCounterIcon className='column-link__icon' />} text={intl.formatMessage(messages.notifications)} />
+            <ColumnLink
+              transparent
+              to='/home'
+              icon='home'
+              text={intl.formatMessage(messages.home)}
+            />
+            <ColumnLink
+              transparent
+              to='/notifications'
+              icon={<NotificationsCounterIcon className='column-link__icon' />}
+              text={intl.formatMessage(messages.notifications)}
+            />
             <FollowRequestsColumnLink />
           </>
         )}
 
         {trendsEnabled ? (
-          <ColumnLink transparent to='/explore' icon='hashtag' text={intl.formatMessage(messages.explore)} />
+          <ColumnLink
+            transparent
+            to='/explore'
+            icon='hashtag'
+            text={intl.formatMessage(messages.explore)}
+          />
         ) : (
-          <ColumnLink transparent to='/search' icon='search' text={intl.formatMessage(messages.search)} />
+          <ColumnLink
+            transparent
+            to='/search'
+            icon='search'
+            text={intl.formatMessage(messages.search)}
+          />
         )}
 
         {(signedIn || timelinePreview) && (
-          <ColumnLink transparent to='/public/local' isActive={this.isFirehoseActive} icon='globe' text={intl.formatMessage(messages.firehose)} />
+          <ColumnLink
+            transparent
+            to='/public/local'
+            isActive={this.isFirehoseActive}
+            icon='globe'
+            text={intl.formatMessage(messages.firehose)}
+          />
         )}
 
         {!signedIn && (
           <div className='navigation-panel__sign-in-banner'>
             <hr />
-            { disabledAccountId ? <DisabledAccountBanner /> : <SignInBanner /> }
+            {disabledAccountId ? <DisabledAccountBanner /> : <SignInBanner />}
           </div>
         )}
 
         {signedIn && (
           <>
-            <ColumnLink transparent to='/conversations' icon='at' text={intl.formatMessage(messages.direct)} />
-            <ColumnLink transparent to='/bookmarks' icon='bookmark' text={intl.formatMessage(messages.bookmarks)} />
-            <ColumnLink transparent to='/favourites' icon='star' text={intl.formatMessage(messages.favourites)} />
-            <ColumnLink transparent to='/lists' icon='list-ul' text={intl.formatMessage(messages.lists)} />
+            <ColumnLink
+              transparent
+              to='/conversations'
+              icon='at'
+              text={intl.formatMessage(messages.direct)}
+            />
+            <ColumnLink
+              transparent
+              to='/bookmarks'
+              icon='bookmark'
+              text={intl.formatMessage(messages.bookmarks)}
+            />
+            <ColumnLink
+              transparent
+              to='/favourites'
+              icon='star'
+              text={intl.formatMessage(messages.favourites)}
+            />
+            <ColumnLink
+              transparent
+              to='/lists'
+              icon='list-ul'
+              text={intl.formatMessage(messages.lists)}
+            />
 
             <ListPanel />
 
             <hr />
 
-            <ColumnLink transparent href='/settings/preferences' icon='cog' text={intl.formatMessage(messages.preferences)} />
+            <ColumnLink
+              transparent
+              href='/settings/preferences'
+              icon='cog'
+              text={intl.formatMessage(messages.preferences)}
+            />
           </>
         )}
 
         <div className='navigation-panel__legal'>
           <hr />
-          <ColumnLink transparent to='/about' icon='ellipsis-h' text={intl.formatMessage(messages.about)} />
+          <ColumnLink
+            transparent
+            to='/about'
+            icon='ellipsis-h'
+            text={intl.formatMessage(messages.about)}
+          />
         </div>
 
         <NavigationPortal />
       </div>
     );
   }
-
 }
 
 export default injectIntl(NavigationPanel);

--- a/app/javascript/mastodon/features/ui/components/notifications_counter_icon.js
+++ b/app/javascript/mastodon/features/ui/components/notifications_counter_icon.js
@@ -2,7 +2,7 @@ import { connect } from 'react-redux';
 
 import { IconWithBadge } from 'mastodon/components/icon_with_badge';
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   count: state.getIn(['notifications', 'unread']),
   id: 'bell',
 });

--- a/app/javascript/mastodon/features/ui/components/report_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/report_modal.jsx
@@ -33,7 +33,6 @@ const makeMapStateToProps = () => {
 };
 
 class ReportModal extends ImmutablePureComponent {
-
   static propTypes = {
     accountId: PropTypes.string.isRequired,
     statusId: PropTypes.string,
@@ -44,7 +43,9 @@ class ReportModal extends ImmutablePureComponent {
 
   state = {
     step: 'category',
-    selectedStatusIds: OrderedSet(this.props.statusId ? [this.props.statusId] : []),
+    selectedStatusIds: OrderedSet(
+      this.props.statusId ? [this.props.statusId] : [],
+    ),
     selectedDomains: OrderedSet(),
     comment: '',
     category: null,
@@ -55,19 +56,31 @@ class ReportModal extends ImmutablePureComponent {
 
   handleSubmit = () => {
     const { dispatch, accountId } = this.props;
-    const { selectedStatusIds, selectedDomains, comment, category, selectedRuleIds } = this.state;
+    const {
+      selectedStatusIds,
+      selectedDomains,
+      comment,
+      category,
+      selectedRuleIds,
+    } = this.state;
 
     this.setState({ isSubmitting: true });
 
-    dispatch(submitReport({
-      account_id: accountId,
-      status_ids: selectedStatusIds.toArray(),
-      forward_to_domains: selectedDomains.toArray(),
-      comment,
-      forward: selectedDomains.size > 0,
-      category,
-      rule_ids: selectedRuleIds.toArray(),
-    }, this.handleSuccess, this.handleFail));
+    dispatch(
+      submitReport(
+        {
+          account_id: accountId,
+          status_ids: selectedStatusIds.toArray(),
+          forward_to_domains: selectedDomains.toArray(),
+          comment,
+          forward: selectedDomains.size > 0,
+          category,
+          rule_ids: selectedRuleIds.toArray(),
+        },
+        this.handleSuccess,
+        this.handleFail,
+      ),
+    );
   };
 
   handleSuccess = () => {
@@ -90,46 +103,49 @@ class ReportModal extends ImmutablePureComponent {
 
   handleDomainToggle = (domain, checked) => {
     if (checked) {
-      this.setState((state) => ({ selectedDomains: state.selectedDomains.add(domain) }));
+      this.setState((state) => ({
+        selectedDomains: state.selectedDomains.add(domain),
+      }));
     } else {
-      this.setState((state) => ({ selectedDomains: state.selectedDomains.remove(domain) }));
+      this.setState((state) => ({
+        selectedDomains: state.selectedDomains.remove(domain),
+      }));
     }
   };
 
   handleRuleToggle = (ruleId, checked) => {
     if (checked) {
-      this.setState((state) => ({ selectedRuleIds: state.selectedRuleIds.add(ruleId) }));
+      this.setState((state) => ({
+        selectedRuleIds: state.selectedRuleIds.add(ruleId),
+      }));
     } else {
-      this.setState((state) => ({ selectedRuleIds: state.selectedRuleIds.remove(ruleId) }));
+      this.setState((state) => ({
+        selectedRuleIds: state.selectedRuleIds.remove(ruleId),
+      }));
     }
   };
 
-  handleChangeCategory = category => {
+  handleChangeCategory = (category) => {
     this.setState({ category });
   };
 
-  handleChangeComment = comment => {
+  handleChangeComment = (comment) => {
     this.setState({ comment });
   };
 
-  handleNextStep = step => {
+  handleNextStep = (step) => {
     this.setState({ step });
   };
 
-  componentDidMount () {
+  componentDidMount() {
     const { dispatch, accountId } = this.props;
 
     dispatch(expandAccountTimeline(accountId, { withReplies: true }));
     dispatch(fetchServer());
   }
 
-  render () {
-    const {
-      accountId,
-      account,
-      intl,
-      onClose,
-    } = this.props;
+  render() {
+    const { accountId, account, intl, onClose } = this.props;
 
     if (!account) {
       return null;
@@ -146,80 +162,83 @@ class ReportModal extends ImmutablePureComponent {
       isSubmitted,
     } = this.state;
 
-    const domain   = account.get('acct').split('@')[1];
+    const domain = account.get('acct').split('@')[1];
     const isRemote = !!domain;
 
     let stepComponent;
 
-    switch(step) {
-    case 'category':
-      stepComponent = (
-        <Category
-          onNextStep={this.handleNextStep}
-          startedFrom={this.props.statusId ? 'status' : 'account'}
-          category={category}
-          onChangeCategory={this.handleChangeCategory}
-        />
-      );
-      break;
-    case 'rules':
-      stepComponent = (
-        <Rules
-          onNextStep={this.handleNextStep}
-          selectedRuleIds={selectedRuleIds}
-          onToggle={this.handleRuleToggle}
-        />
-      );
-      break;
-    case 'statuses':
-      stepComponent = (
-        <Statuses
-          onNextStep={this.handleNextStep}
-          accountId={accountId}
-          selectedStatusIds={selectedStatusIds}
-          onToggle={this.handleStatusToggle}
-        />
-      );
-      break;
-    case 'comment':
-      stepComponent = (
-        <Comment
-          onSubmit={this.handleSubmit}
-          isSubmitting={isSubmitting}
-          isRemote={isRemote}
-          comment={comment}
-          domain={domain}
-          onChangeComment={this.handleChangeComment}
-          statusIds={selectedStatusIds}
-          selectedDomains={selectedDomains}
-          onToggleDomain={this.handleDomainToggle}
-        />
-      );
-      break;
-    case 'thanks':
-      stepComponent = (
-        <Thanks
-          submitted={isSubmitted}
-          account={account}
-          onClose={onClose}
-        />
-      );
+    switch (step) {
+      case 'category':
+        stepComponent = (
+          <Category
+            onNextStep={this.handleNextStep}
+            startedFrom={this.props.statusId ? 'status' : 'account'}
+            category={category}
+            onChangeCategory={this.handleChangeCategory}
+          />
+        );
+        break;
+      case 'rules':
+        stepComponent = (
+          <Rules
+            onNextStep={this.handleNextStep}
+            selectedRuleIds={selectedRuleIds}
+            onToggle={this.handleRuleToggle}
+          />
+        );
+        break;
+      case 'statuses':
+        stepComponent = (
+          <Statuses
+            onNextStep={this.handleNextStep}
+            accountId={accountId}
+            selectedStatusIds={selectedStatusIds}
+            onToggle={this.handleStatusToggle}
+          />
+        );
+        break;
+      case 'comment':
+        stepComponent = (
+          <Comment
+            onSubmit={this.handleSubmit}
+            isSubmitting={isSubmitting}
+            isRemote={isRemote}
+            comment={comment}
+            domain={domain}
+            onChangeComment={this.handleChangeComment}
+            statusIds={selectedStatusIds}
+            selectedDomains={selectedDomains}
+            onToggleDomain={this.handleDomainToggle}
+          />
+        );
+        break;
+      case 'thanks':
+        stepComponent = (
+          <Thanks submitted={isSubmitted} account={account} onClose={onClose} />
+        );
     }
 
     return (
       <div className='modal-root__modal report-dialog-modal'>
         <div className='report-modal__target'>
-          <IconButton className='report-modal__close' title={intl.formatMessage(messages.close)} icon='times' onClick={onClose} size={20} />
-          <FormattedMessage id='report.target' defaultMessage='Report {target}' values={{ target: <strong>{account.get('acct')}</strong> }} />
+          <IconButton
+            className='report-modal__close'
+            title={intl.formatMessage(messages.close)}
+            icon='times'
+            onClick={onClose}
+            size={20}
+          />
+          <FormattedMessage
+            id='report.target'
+            defaultMessage='Report {target}'
+            values={{ target: <strong>{account.get('acct')}</strong> }}
+          />
         </div>
 
-        <div className='report-dialog-modal__container'>
-          {stepComponent}
-        </div>
+        <div className='report-dialog-modal__container'>{stepComponent}</div>
       </div>
     );
   }
-
 }
 
 export default connect(makeMapStateToProps)(injectIntl(ReportModal));

--- a/app/javascript/mastodon/features/ui/components/sign_in_banner.jsx
+++ b/app/javascript/mastodon/features/ui/components/sign_in_banner.jsx
@@ -2,7 +2,6 @@ import { useCallback } from 'react';
 
 import { FormattedMessage } from 'react-intl';
 
-
 import { openModal } from 'mastodon/actions/modal';
 import { registrationsOpen, sso_redirect } from 'mastodon/initial_state';
 import { useAppDispatch, useAppSelector } from 'mastodon/store';
@@ -17,36 +16,70 @@ const SignInBanner = () => {
 
   let signupButton;
 
-  const signupUrl = useAppSelector((state) => state.getIn(['server', 'server', 'registrations', 'url'], null) || '/auth/sign_up');
+  const signupUrl = useAppSelector(
+    (state) =>
+      state.getIn(['server', 'server', 'registrations', 'url'], null) ||
+      '/auth/sign_up',
+  );
 
   if (sso_redirect) {
     return (
       <div className='sign-in-banner'>
-        <p><FormattedMessage id='sign_in_banner.text' defaultMessage='Login to follow profiles or hashtags, favorite, share and reply to posts. You can also interact from your account on a different server.' /></p>
-        <a href={sso_redirect} data-method='post' className='button button--block button-tertiary'><FormattedMessage id='sign_in_banner.sso_redirect' defaultMessage='Login or Register' /></a>
+        <p>
+          <FormattedMessage
+            id='sign_in_banner.text'
+            defaultMessage='Login to follow profiles or hashtags, favorite, share and reply to posts. You can also interact from your account on a different server.'
+          />
+        </p>
+        <a
+          href={sso_redirect}
+          data-method='post'
+          className='button button--block button-tertiary'
+        >
+          <FormattedMessage
+            id='sign_in_banner.sso_redirect'
+            defaultMessage='Login or Register'
+          />
+        </a>
       </div>
-    )
+    );
   }
 
   if (registrationsOpen) {
     signupButton = (
       <a href={signupUrl} className='button button--block'>
-        <FormattedMessage id='sign_in_banner.create_account' defaultMessage='Create account' />
+        <FormattedMessage
+          id='sign_in_banner.create_account'
+          defaultMessage='Create account'
+        />
       </a>
     );
   } else {
     signupButton = (
-      <button className='button button--block' onClick={openClosedRegistrationsModal}>
-        <FormattedMessage id='sign_in_banner.create_account' defaultMessage='Create account' />
+      <button
+        className='button button--block'
+        onClick={openClosedRegistrationsModal}
+      >
+        <FormattedMessage
+          id='sign_in_banner.create_account'
+          defaultMessage='Create account'
+        />
       </button>
     );
   }
 
   return (
     <div className='sign-in-banner'>
-      <p><FormattedMessage id='sign_in_banner.text' defaultMessage='Login to follow profiles or hashtags, favorite, share and reply to posts. You can also interact from your account on a different server.' /></p>
+      <p>
+        <FormattedMessage
+          id='sign_in_banner.text'
+          defaultMessage='Login to follow profiles or hashtags, favorite, share and reply to posts. You can also interact from your account on a different server.'
+        />
+      </p>
       {signupButton}
-      <a href='/auth/sign_in' className='button button--block button-tertiary'><FormattedMessage id='sign_in_banner.sign_in' defaultMessage='Login' /></a>
+      <a href='/auth/sign_in' className='button button--block button-tertiary'>
+        <FormattedMessage id='sign_in_banner.sign_in' defaultMessage='Login' />
+      </a>
     </div>
   );
 };

--- a/app/javascript/mastodon/features/ui/components/upload_area.jsx
+++ b/app/javascript/mastodon/features/ui/components/upload_area.jsx
@@ -8,7 +8,6 @@ import spring from 'react-motion/lib/spring';
 import Motion from '../util/optional_motion';
 
 export default class UploadArea extends PureComponent {
-
   static propTypes = {
     active: PropTypes.bool,
     onClose: PropTypes.func,
@@ -17,39 +16,64 @@ export default class UploadArea extends PureComponent {
   handleKeyUp = (e) => {
     const keyCode = e.keyCode;
     if (this.props.active) {
-      switch(keyCode) {
-      case 27:
-        e.preventDefault();
-        e.stopPropagation();
-        this.props.onClose();
-        break;
+      switch (keyCode) {
+        case 27:
+          e.preventDefault();
+          e.stopPropagation();
+          this.props.onClose();
+          break;
       }
     }
   };
 
-  componentDidMount () {
+  componentDidMount() {
     window.addEventListener('keyup', this.handleKeyUp, false);
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     window.removeEventListener('keyup', this.handleKeyUp);
   }
 
-  render () {
+  render() {
     const { active } = this.props;
 
     return (
-      <Motion defaultStyle={{ backgroundOpacity: 0, backgroundScale: 0.95 }} style={{ backgroundOpacity: spring(active ? 1 : 0, { stiffness: 150, damping: 15 }), backgroundScale: spring(active ? 1 : 0.95, { stiffness: 200, damping: 3 }) }}>
+      <Motion
+        defaultStyle={{ backgroundOpacity: 0, backgroundScale: 0.95 }}
+        style={{
+          backgroundOpacity: spring(active ? 1 : 0, {
+            stiffness: 150,
+            damping: 15,
+          }),
+          backgroundScale: spring(active ? 1 : 0.95, {
+            stiffness: 200,
+            damping: 3,
+          }),
+        }}
+      >
         {({ backgroundOpacity, backgroundScale }) => (
-          <div className='upload-area' style={{ visibility: active ? 'visible' : 'hidden', opacity: backgroundOpacity }}>
+          <div
+            className='upload-area'
+            style={{
+              visibility: active ? 'visible' : 'hidden',
+              opacity: backgroundOpacity,
+            }}
+          >
             <div className='upload-area__drop'>
-              <div className='upload-area__background' style={{ transform: `scale(${backgroundScale})` }} />
-              <div className='upload-area__content'><FormattedMessage id='upload_area.title' defaultMessage='Drag & drop to upload' /></div>
+              <div
+                className='upload-area__background'
+                style={{ transform: `scale(${backgroundScale})` }}
+              />
+              <div className='upload-area__content'>
+                <FormattedMessage
+                  id='upload_area.title'
+                  defaultMessage='Drag & drop to upload'
+                />
+              </div>
             </div>
           </div>
         )}
       </Motion>
     );
   }
-
 }

--- a/app/javascript/mastodon/features/ui/components/video_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/video_modal.jsx
@@ -13,7 +13,6 @@ const mapStateToProps = (state, { statusId }) => ({
 });
 
 class VideoModal extends ImmutablePureComponent {
-
   static propTypes = {
     media: ImmutablePropTypes.map.isRequired,
     statusId: PropTypes.string,
@@ -27,7 +26,7 @@ class VideoModal extends ImmutablePureComponent {
     onChangeBackgroundColor: PropTypes.func.isRequired,
   };
 
-  componentDidMount () {
+  componentDidMount() {
     const { media, onChangeBackgroundColor } = this.props;
 
     const backgroundColor = getAverageFromBlurhash(media.get('blurhash'));
@@ -37,11 +36,13 @@ class VideoModal extends ImmutablePureComponent {
     }
   }
 
-  render () {
+  render() {
     const { media, status, onClose } = this.props;
     const options = this.props.options || {};
-    const language = status.getIn(['translation', 'language']) || status.get('language');
-    const description = media.getIn(['translation', 'description']) || media.get('description');
+    const language =
+      status.getIn(['translation', 'language']) || status.get('language');
+    const description =
+      media.getIn(['translation', 'description']) || media.get('description');
 
     return (
       <div className='modal-root__modal video-modal'>
@@ -49,7 +50,11 @@ class VideoModal extends ImmutablePureComponent {
           <Video
             preview={media.get('preview_url')}
             frameRate={media.getIn(['meta', 'original', 'frame_rate'])}
-            aspectRatio={`${media.getIn(['meta', 'original', 'width'])} / ${media.getIn(['meta', 'original', 'height'])}`}
+            aspectRatio={`${media.getIn([
+              'meta',
+              'original',
+              'width',
+            ])} / ${media.getIn(['meta', 'original', 'height'])}`}
             blurhash={media.get('blurhash')}
             src={media.get('url')}
             currentTime={options.startTime}
@@ -64,12 +69,19 @@ class VideoModal extends ImmutablePureComponent {
         </div>
 
         <div className='media-modal__overlay'>
-          {status && <Footer statusId={status.get('id')} withOpenButton onClose={onClose} />}
+          {status && (
+            <Footer
+              statusId={status.get('id')}
+              withOpenButton
+              onClose={onClose}
+            />
+          )}
         </div>
       </div>
     );
   }
-
 }
 
-export default connect(mapStateToProps, null, null, { forwardRef: true })(VideoModal);
+export default connect(mapStateToProps, null, null, { forwardRef: true })(
+  VideoModal,
+);

--- a/app/javascript/mastodon/features/ui/components/zoomable_image.jsx
+++ b/app/javascript/mastodon/features/ui/components/zoomable_image.jsx
@@ -6,7 +6,10 @@ import { defineMessages, injectIntl } from 'react-intl';
 import { IconButton } from 'mastodon/components/icon_button';
 
 const messages = defineMessages({
-  compress: { id: 'lightbox.compress', defaultMessage: 'Compress image view box' },
+  compress: {
+    id: 'lightbox.compress',
+    defaultMessage: 'Compress image view box',
+  },
   expand: { id: 'lightbox.expand', defaultMessage: 'Expand image view box' },
 });
 
@@ -20,13 +23,15 @@ const getMidpoint = (p1, p2) => ({
 });
 
 const getDistance = (p1, p2) =>
-  Math.sqrt(Math.pow(p1.clientX - p2.clientX, 2) + Math.pow(p1.clientY - p2.clientY, 2));
+  Math.sqrt(
+    Math.pow(p1.clientX - p2.clientX, 2) + Math.pow(p1.clientY - p2.clientY, 2),
+  );
 
 const clamp = (min, max, value) => Math.min(max, Math.max(min, value));
 
 // Normalizing mousewheel speed across browsers
 // copy from: https://github.com/facebookarchive/fixed-data-table/blob/master/src/vendor_upstream/dom/normalizeWheel.js
-const normalizeWheel = event => {
+const normalizeWheel = (event) => {
   // Reasonable defaults
   const PIXEL_STEP = 10;
   const LINE_HEIGHT = 40;
@@ -68,10 +73,12 @@ const normalizeWheel = event => {
   }
 
   if ((pX || pY) && event.deltaMode) {
-    if (event.deltaMode === 1) { // delta in LINE units
+    if (event.deltaMode === 1) {
+      // delta in LINE units
       pX *= LINE_HEIGHT;
       pY *= LINE_HEIGHT;
-    } else { // delta in PAGE units
+    } else {
+      // delta in PAGE units
       pX *= PAGE_HEIGHT;
       pY *= PAGE_HEIGHT;
     }
@@ -79,10 +86,10 @@ const normalizeWheel = event => {
 
   // Fall-back if spin cannot be determined
   if (pX && !sX) {
-    sX = (pX < 1) ? -1 : 1;
+    sX = pX < 1 ? -1 : 1;
   }
   if (pY && !sY) {
-    sY = (pY < 1) ? -1 : 1;
+    sY = pY < 1 ? -1 : 1;
   }
 
   return {
@@ -94,7 +101,6 @@ const normalizeWheel = event => {
 };
 
 class ZoomableImage extends PureComponent {
-
   static propTypes = {
     alt: PropTypes.string,
     lang: PropTypes.string,
@@ -143,102 +149,137 @@ class ZoomableImage extends PureComponent {
   lastTouchEndTime = 0;
   lastDistance = 0;
 
-  componentDidMount () {
+  componentDidMount() {
     let handler = this.handleTouchStart;
     this.container.addEventListener('touchstart', handler);
-    this.removers.push(() => this.container.removeEventListener('touchstart', handler));
+    this.removers.push(() =>
+      this.container.removeEventListener('touchstart', handler),
+    );
     handler = this.handleTouchMove;
     // on Chrome 56+, touch event listeners will default to passive
     // https://www.chromestatus.com/features/5093566007214080
     this.container.addEventListener('touchmove', handler, { passive: false });
-    this.removers.push(() => this.container.removeEventListener('touchend', handler));
+    this.removers.push(() =>
+      this.container.removeEventListener('touchend', handler),
+    );
 
     handler = this.mouseDownHandler;
     this.container.addEventListener('mousedown', handler);
-    this.removers.push(() => this.container.removeEventListener('mousedown', handler));
+    this.removers.push(() =>
+      this.container.removeEventListener('mousedown', handler),
+    );
 
     handler = this.mouseWheelHandler;
     this.container.addEventListener('wheel', handler);
-    this.removers.push(() => this.container.removeEventListener('wheel', handler));
+    this.removers.push(() =>
+      this.container.removeEventListener('wheel', handler),
+    );
     // Old Chrome
     this.container.addEventListener('mousewheel', handler);
-    this.removers.push(() => this.container.removeEventListener('mousewheel', handler));
+    this.removers.push(() =>
+      this.container.removeEventListener('mousewheel', handler),
+    );
     // Old Firefox
     this.container.addEventListener('DOMMouseScroll', handler);
-    this.removers.push(() => this.container.removeEventListener('DOMMouseScroll', handler));
+    this.removers.push(() =>
+      this.container.removeEventListener('DOMMouseScroll', handler),
+    );
 
     this.initZoomMatrix();
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     this.removeEventListeners();
   }
 
-  componentDidUpdate () {
-    this.setState({ zoomState: this.state.scale >= this.state.zoomMatrix.rate ? 'compress' : 'expand' });
+  componentDidUpdate() {
+    this.setState({
+      zoomState:
+        this.state.scale >= this.state.zoomMatrix.rate ? 'compress' : 'expand',
+    });
 
     if (this.state.scale === MIN_SCALE) {
       this.container.style.removeProperty('cursor');
     }
   }
 
-  UNSAFE_componentWillReceiveProps () {
+  UNSAFE_componentWillReceiveProps() {
     // reset when slide to next image
     if (this.props.zoomButtonHidden) {
-      this.setState({
-        scale: MIN_SCALE,
-        lockTranslate: { x: 0, y: 0 },
-      }, () => {
-        this.container.scrollLeft = 0;
-        this.container.scrollTop = 0;
-      });
+      this.setState(
+        {
+          scale: MIN_SCALE,
+          lockTranslate: { x: 0, y: 0 },
+        },
+        () => {
+          this.container.scrollLeft = 0;
+          this.container.scrollTop = 0;
+        },
+      );
     }
   }
 
-  removeEventListeners () {
-    this.removers.forEach(listeners => listeners());
+  removeEventListeners() {
+    this.removers.forEach((listeners) => listeners());
     this.removers = [];
   }
 
-  mouseWheelHandler = e => {
+  mouseWheelHandler = (e) => {
     e.preventDefault();
 
     const event = normalizeWheel(e);
 
     if (this.state.zoomMatrix.type === 'width') {
       // full width, scroll vertical
-      this.container.scrollTop = Math.max(this.container.scrollTop + event.pixelY, this.state.lockScroll.y);
+      this.container.scrollTop = Math.max(
+        this.container.scrollTop + event.pixelY,
+        this.state.lockScroll.y,
+      );
     } else {
       // full height, scroll horizontal
-      this.container.scrollLeft = Math.max(this.container.scrollLeft + event.pixelY, this.state.lockScroll.x);
+      this.container.scrollLeft = Math.max(
+        this.container.scrollLeft + event.pixelY,
+        this.state.lockScroll.x,
+      );
     }
 
     // lock horizontal scroll
-    this.container.scrollLeft = Math.max(this.container.scrollLeft + event.pixelX, this.state.lockScroll.x);
+    this.container.scrollLeft = Math.max(
+      this.container.scrollLeft + event.pixelX,
+      this.state.lockScroll.x,
+    );
   };
 
-  mouseDownHandler = e => {
+  mouseDownHandler = (e) => {
     this.container.style.cursor = 'grabbing';
     this.container.style.userSelect = 'none';
 
-    this.setState({ dragPosition: {
-      left: this.container.scrollLeft,
-      top: this.container.scrollTop,
-      // Get the current mouse position
-      x: e.clientX,
-      y: e.clientY,
-    } });
+    this.setState({
+      dragPosition: {
+        left: this.container.scrollLeft,
+        top: this.container.scrollTop,
+        // Get the current mouse position
+        x: e.clientX,
+        y: e.clientY,
+      },
+    });
 
     this.image.addEventListener('mousemove', this.mouseMoveHandler);
     this.image.addEventListener('mouseup', this.mouseUpHandler);
   };
 
-  mouseMoveHandler = e => {
+  mouseMoveHandler = (e) => {
     const dx = e.clientX - this.state.dragPosition.x;
     const dy = e.clientY - this.state.dragPosition.y;
 
-    this.container.scrollLeft = Math.max(this.state.dragPosition.left - dx, this.state.lockScroll.x);
-    this.container.scrollTop = Math.max(this.state.dragPosition.top - dy, this.state.lockScroll.y);
+    this.container.scrollLeft = Math.max(
+      this.state.dragPosition.left - dx,
+      this.state.lockScroll.x,
+    );
+    this.container.scrollTop = Math.max(
+      this.state.dragPosition.top - dy,
+      this.state.lockScroll.y,
+    );
 
     this.setState({ dragged: true });
   };
@@ -251,13 +292,13 @@ class ZoomableImage extends PureComponent {
     this.image.removeEventListener('mouseup', this.mouseUpHandler);
   };
 
-  handleTouchStart = e => {
+  handleTouchStart = (e) => {
     if (e.touches.length !== 2) return;
 
     this.lastDistance = getDistance(...e.touches);
   };
 
-  handleTouchMove = e => {
+  handleTouchMove = (e) => {
     const { scrollTop, scrollHeight, clientHeight } = this.container;
     if (e.touches.length === 1 && scrollTop !== scrollHeight - clientHeight) {
       // prevent propagating event to MediaModal
@@ -272,7 +313,11 @@ class ZoomableImage extends PureComponent {
     const distance = getDistance(...e.touches);
     const midpoint = getMidpoint(...e.touches);
     const _MAX_SCALE = Math.max(MAX_SCALE, this.state.zoomMatrix.rate);
-    const scale = clamp(MIN_SCALE, _MAX_SCALE, this.state.scale * distance / this.lastDistance);
+    const scale = clamp(
+      MIN_SCALE,
+      _MAX_SCALE,
+      (this.state.scale * distance) / this.lastDistance,
+    );
 
     this.zoom(scale, midpoint);
 
@@ -290,8 +335,10 @@ class ZoomableImage extends PureComponent {
     // scrollWidth = clientWidth * scale
     // scrollWidth' = clientWidth * nextScale
     // Solve x = x' for nextScrollLeft
-    const nextScrollLeft = (scrollLeft + midpoint.x) * nextScale / scale - midpoint.x;
-    const nextScrollTop = (scrollTop + midpoint.y) * nextScale / scale - midpoint.y;
+    const nextScrollLeft =
+      ((scrollLeft + midpoint.x) * nextScale) / scale - midpoint.x;
+    const nextScrollTop =
+      ((scrollTop + midpoint.y) * nextScale) / scale - midpoint.y;
 
     this.setState({ scale: nextScale }, () => {
       this.container.scrollLeft = nextScrollLeft;
@@ -300,15 +347,21 @@ class ZoomableImage extends PureComponent {
       if (nextScale < zoomMatrix.rate) {
         this.setState({
           lockTranslate: {
-            x: zoomMatrix.fullScreen ? 0 : zoomMatrix.translateX * ((nextScale - MIN_SCALE) / (zoomMatrix.rate - MIN_SCALE)),
-            y: zoomMatrix.fullScreen ? 0 : zoomMatrix.translateY * ((nextScale - MIN_SCALE) / (zoomMatrix.rate - MIN_SCALE)),
+            x: zoomMatrix.fullScreen
+              ? 0
+              : zoomMatrix.translateX *
+                ((nextScale - MIN_SCALE) / (zoomMatrix.rate - MIN_SCALE)),
+            y: zoomMatrix.fullScreen
+              ? 0
+              : zoomMatrix.translateY *
+                ((nextScale - MIN_SCALE) / (zoomMatrix.rate - MIN_SCALE)),
           },
         });
       }
     });
   }
 
-  handleClick = e => {
+  handleClick = (e) => {
     // don't propagate event to MediaModal
     e.stopPropagation();
     const dragged = this.state.dragged;
@@ -319,7 +372,7 @@ class ZoomableImage extends PureComponent {
     this.setState({ navigationHidden: !this.state.navigationHidden });
   };
 
-  handleMouseDown = e => {
+  handleMouseDown = (e) => {
     e.preventDefault();
   };
 
@@ -329,13 +382,23 @@ class ZoomableImage extends PureComponent {
     const { offsetWidth, offsetHeight } = this.image;
     const clientHeightFixed = clientHeight - NAV_BAR_HEIGHT;
 
-    const type = width / height < clientWidth / clientHeightFixed ? 'width' : 'height';
-    const fullScreen = type === 'width' ?  width > clientWidth : height > clientHeightFixed;
-    const rate = type === 'width' ? Math.min(clientWidth, width) / offsetWidth : Math.min(clientHeightFixed, height) / offsetHeight;
-    const scrollTop = type === 'width' ?  (clientHeight - offsetHeight) / 2 - NAV_BAR_HEIGHT : (clientHeightFixed - offsetHeight) / 2;
+    const type =
+      width / height < clientWidth / clientHeightFixed ? 'width' : 'height';
+    const fullScreen =
+      type === 'width' ? width > clientWidth : height > clientHeightFixed;
+    const rate =
+      type === 'width'
+        ? Math.min(clientWidth, width) / offsetWidth
+        : Math.min(clientHeightFixed, height) / offsetHeight;
+    const scrollTop =
+      type === 'width'
+        ? (clientHeight - offsetHeight) / 2 - NAV_BAR_HEIGHT
+        : (clientHeightFixed - offsetHeight) / 2;
     const scrollLeft = (clientWidth - offsetWidth) / 2;
-    const translateX = type === 'width' ? (width - offsetWidth) / (2 * rate) : 0;
-    const translateY = type === 'height' ? (height - offsetHeight) / (2 * rate) : 0;
+    const translateX =
+      type === 'width' ? (width - offsetWidth) / (2 * rate) : 0;
+    const translateY =
+      type === 'height' ? (height - offsetHeight) / (2 * rate) : 0;
 
     this.setState({
       zoomMatrix: {
@@ -355,62 +418,76 @@ class ZoomableImage extends PureComponent {
     });
   };
 
-  handleZoomClick = e => {
+  handleZoomClick = (e) => {
     e.preventDefault();
     e.stopPropagation();
 
     const { scale, zoomMatrix } = this.state;
 
-    if ( scale >= zoomMatrix.rate ) {
-      this.setState({
-        scale: MIN_SCALE,
-        lockScroll: {
-          x: 0,
-          y: 0,
+    if (scale >= zoomMatrix.rate) {
+      this.setState(
+        {
+          scale: MIN_SCALE,
+          lockScroll: {
+            x: 0,
+            y: 0,
+          },
+          lockTranslate: {
+            x: 0,
+            y: 0,
+          },
         },
-        lockTranslate: {
-          x: 0,
-          y: 0,
+        () => {
+          this.container.scrollLeft = 0;
+          this.container.scrollTop = 0;
         },
-      }, () => {
-        this.container.scrollLeft = 0;
-        this.container.scrollTop = 0;
-      });
+      );
     } else {
-      this.setState({
-        scale: zoomMatrix.rate,
-        lockScroll: {
-          x: zoomMatrix.scrollLeft,
-          y: zoomMatrix.scrollTop,
+      this.setState(
+        {
+          scale: zoomMatrix.rate,
+          lockScroll: {
+            x: zoomMatrix.scrollLeft,
+            y: zoomMatrix.scrollTop,
+          },
+          lockTranslate: {
+            x: zoomMatrix.fullScreen ? 0 : zoomMatrix.translateX,
+            y: zoomMatrix.fullScreen ? 0 : zoomMatrix.translateY,
+          },
         },
-        lockTranslate: {
-          x: zoomMatrix.fullScreen ? 0 : zoomMatrix.translateX,
-          y: zoomMatrix.fullScreen ? 0 : zoomMatrix.translateY,
+        () => {
+          this.container.scrollLeft = zoomMatrix.scrollLeft;
+          this.container.scrollTop = zoomMatrix.scrollTop;
         },
-      }, () => {
-        this.container.scrollLeft = zoomMatrix.scrollLeft;
-        this.container.scrollTop = zoomMatrix.scrollTop;
-      });
+      );
     }
 
     this.container.style.cursor = 'grab';
     this.container.style.removeProperty('user-select');
   };
 
-  setContainerRef = c => {
+  setContainerRef = (c) => {
     this.container = c;
   };
 
-  setImageRef = c => {
+  setImageRef = (c) => {
     this.image = c;
   };
 
-  render () {
+  render() {
     const { alt, lang, src, width, height, intl } = this.props;
     const { scale, lockTranslate } = this.state;
     const overflow = scale === MIN_SCALE ? 'hidden' : 'scroll';
-    const zoomButtonShouldHide = this.state.navigationHidden || this.props.zoomButtonHidden || this.state.zoomMatrix.rate <= MIN_SCALE ? 'media-modal__zoom-button--hidden' : '';
-    const zoomButtonTitle = this.state.zoomState === 'compress' ? intl.formatMessage(messages.compress) : intl.formatMessage(messages.expand);
+    const zoomButtonShouldHide =
+      this.state.navigationHidden ||
+      this.props.zoomButtonHidden ||
+      this.state.zoomMatrix.rate <= MIN_SCALE
+        ? 'media-modal__zoom-button--hidden'
+        : '';
+    const zoomButtonTitle =
+      this.state.zoomState === 'compress'
+        ? intl.formatMessage(messages.compress)
+        : intl.formatMessage(messages.expand);
 
     return (
       <>
@@ -421,7 +498,8 @@ class ZoomableImage extends PureComponent {
           onClick={this.handleZoomClick}
           size={40}
           style={{
-            fontSize: '30px', /* Fontawesome's fa-compress fa-expand is larger than fa-close */
+            fontSize:
+              '30px' /* Fontawesome's fa-compress fa-expand is larger than fa-close */,
           }}
         />
         <div
@@ -450,7 +528,6 @@ class ZoomableImage extends PureComponent {
       </>
     );
   }
-
 }
 
 export default injectIntl(ZoomableImage);

--- a/app/javascript/mastodon/features/ui/containers/bundle_container.js
+++ b/app/javascript/mastodon/features/ui/containers/bundle_container.js
@@ -1,16 +1,20 @@
 import { connect } from 'react-redux';
 
-import { fetchBundleRequest, fetchBundleSuccess, fetchBundleFail } from '../../../actions/bundles';
+import {
+  fetchBundleRequest,
+  fetchBundleSuccess,
+  fetchBundleFail,
+} from '../../../actions/bundles';
 import Bundle from '../components/bundle';
 
-const mapDispatchToProps = dispatch => ({
-  onFetch () {
+const mapDispatchToProps = (dispatch) => ({
+  onFetch() {
     dispatch(fetchBundleRequest());
   },
-  onFetchSuccess () {
+  onFetchSuccess() {
     dispatch(fetchBundleSuccess());
   },
-  onFetchFail (error) {
+  onFetchFail(error) {
     dispatch(fetchBundleFail(error));
   },
 });

--- a/app/javascript/mastodon/features/ui/containers/columns_area_container.js
+++ b/app/javascript/mastodon/features/ui/containers/columns_area_container.js
@@ -2,9 +2,11 @@ import { connect } from 'react-redux';
 
 import ColumnsArea from '../components/columns_area';
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   columns: state.getIn(['settings', 'columns']),
   isModalOpen: !!state.get('modal').modalType,
 });
 
-export default connect(mapStateToProps, null, null, { forwardRef: true })(ColumnsArea);
+export default connect(mapStateToProps, null, null, { forwardRef: true })(
+  ColumnsArea,
+);

--- a/app/javascript/mastodon/features/ui/containers/loading_bar_container.js
+++ b/app/javascript/mastodon/features/ui/containers/loading_bar_container.js
@@ -1,4 +1,4 @@
-import { connect }    from 'react-redux';
+import { connect } from 'react-redux';
 
 import LoadingBar from 'react-redux-loading-bar';
 

--- a/app/javascript/mastodon/features/ui/containers/modal_container.js
+++ b/app/javascript/mastodon/features/ui/containers/modal_container.js
@@ -3,14 +3,14 @@ import { connect } from 'react-redux';
 import { openModal, closeModal } from '../../../actions/modal';
 import ModalRoot from '../components/modal_root';
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   ignoreFocus: state.getIn(['modal', 'ignoreFocus']),
   type: state.getIn(['modal', 'stack', 0, 'modalType'], null),
   props: state.getIn(['modal', 'stack', 0, 'modalProps'], {}),
 });
 
-const mapDispatchToProps = dispatch => ({
-  onClose (confirmationMessage, ignoreFocus = false) {
+const mapDispatchToProps = (dispatch) => ({
+  onClose(confirmationMessage, ignoreFocus = false) {
     if (confirmationMessage) {
       dispatch(
         openModal({
@@ -18,17 +18,23 @@ const mapDispatchToProps = dispatch => ({
           modalProps: {
             message: confirmationMessage.message,
             confirm: confirmationMessage.confirm,
-            onConfirm: () => dispatch(closeModal({
-              modalType: undefined,
-              ignoreFocus: { ignoreFocus },
-            })),
-          } }),
+            onConfirm: () =>
+              dispatch(
+                closeModal({
+                  modalType: undefined,
+                  ignoreFocus: { ignoreFocus },
+                }),
+              ),
+          },
+        }),
       );
     } else {
-      dispatch(closeModal({
-        modalType: undefined,
-        ignoreFocus: { ignoreFocus },
-      }));
+      dispatch(
+        closeModal({
+          modalType: undefined,
+          ignoreFocus: { ignoreFocus },
+        }),
+      );
     }
   },
 });

--- a/app/javascript/mastodon/features/ui/containers/notifications_container.js
+++ b/app/javascript/mastodon/features/ui/containers/notifications_container.js
@@ -16,7 +16,7 @@ const formatIfNeeded = (intl, message, values) => {
 };
 
 const mapStateToProps = (state, { intl }) => ({
-  notifications: getAlerts(state).map(alert => ({
+  notifications: getAlerts(state).map((alert) => ({
     ...alert,
     action: formatIfNeeded(intl, alert.action, alert.values),
     title: formatIfNeeded(intl, alert.title, alert.values),
@@ -25,9 +25,11 @@ const mapStateToProps = (state, { intl }) => ({
 });
 
 const mapDispatchToProps = (dispatch) => ({
-  onDismiss (alert) {
+  onDismiss(alert) {
     dispatch(dismissAlert(alert));
   },
 });
 
-export default injectIntl(connect(mapStateToProps, mapDispatchToProps)(NotificationStack));
+export default injectIntl(
+  connect(mapStateToProps, mapDispatchToProps)(NotificationStack),
+);

--- a/app/javascript/mastodon/features/ui/containers/status_list_container.js
+++ b/app/javascript/mastodon/features/ui/containers/status_list_container.js
@@ -8,30 +8,41 @@ import { scrollTopTimeline, loadPending } from '../../../actions/timelines';
 import StatusList from '../../../components/status_list';
 import { me } from '../../../initial_state';
 
-const makeGetStatusIds = (pending = false) => createSelector([
-  (state, { type }) => state.getIn(['settings', type], ImmutableMap()),
-  (state, { type }) => state.getIn(['timelines', type, pending ? 'pendingItems' : 'items'], ImmutableList()),
-  (state)           => state.get('statuses'),
-], (columnSettings, statusIds, statuses) => {
-  return statusIds.filter(id => {
-    if (id === null) return true;
+const makeGetStatusIds = (pending = false) =>
+  createSelector(
+    [
+      (state, { type }) => state.getIn(['settings', type], ImmutableMap()),
+      (state, { type }) =>
+        state.getIn(
+          ['timelines', type, pending ? 'pendingItems' : 'items'],
+          ImmutableList(),
+        ),
+      (state) => state.get('statuses'),
+    ],
+    (columnSettings, statusIds, statuses) => {
+      return statusIds.filter((id) => {
+        if (id === null) return true;
 
-    const statusForId = statuses.get(id);
-    let showStatus    = true;
+        const statusForId = statuses.get(id);
+        let showStatus = true;
 
-    if (statusForId.get('account') === me) return true;
+        if (statusForId.get('account') === me) return true;
 
-    if (columnSettings.getIn(['shows', 'reblog']) === false) {
-      showStatus = showStatus && statusForId.get('reblog') === null;
-    }
+        if (columnSettings.getIn(['shows', 'reblog']) === false) {
+          showStatus = showStatus && statusForId.get('reblog') === null;
+        }
 
-    if (columnSettings.getIn(['shows', 'reply']) === false) {
-      showStatus = showStatus && (statusForId.get('in_reply_to_id') === null || statusForId.get('in_reply_to_account_id') === me);
-    }
+        if (columnSettings.getIn(['shows', 'reply']) === false) {
+          showStatus =
+            showStatus &&
+            (statusForId.get('in_reply_to_id') === null ||
+              statusForId.get('in_reply_to_account_id') === me);
+        }
 
-    return showStatus;
-  });
-});
+        return showStatus;
+      });
+    },
+  );
 
 const makeMapStateToProps = () => {
   const getStatusIds = makeGetStatusIds();
@@ -39,10 +50,10 @@ const makeMapStateToProps = () => {
 
   const mapStateToProps = (state, { timelineId }) => ({
     statusIds: getStatusIds(state, { type: timelineId }),
-    lastId:    state.getIn(['timelines', timelineId, 'items'])?.last(),
+    lastId: state.getIn(['timelines', timelineId, 'items'])?.last(),
     isLoading: state.getIn(['timelines', timelineId, 'isLoading'], true),
     isPartial: state.getIn(['timelines', timelineId, 'isPartial'], false),
-    hasMore:   state.getIn(['timelines', timelineId, 'hasMore']),
+    hasMore: state.getIn(['timelines', timelineId, 'hasMore']),
     numPending: getPendingStatusIds(state, { type: timelineId }).size,
   });
 
@@ -50,7 +61,6 @@ const makeMapStateToProps = () => {
 };
 
 const mapDispatchToProps = (dispatch, { timelineId }) => ({
-
   onScrollToTop: debounce(() => {
     dispatch(scrollTopTimeline(timelineId, true));
   }, 100),
@@ -60,7 +70,6 @@ const mapDispatchToProps = (dispatch, { timelineId }) => ({
   }, 100),
 
   onLoadPending: () => dispatch(loadPending(timelineId)),
-
 });
 
 export default connect(makeMapStateToProps, mapDispatchToProps)(StatusList);

--- a/app/javascript/mastodon/features/ui/index.jsx
+++ b/app/javascript/mastodon/features/ui/index.jsx
@@ -12,17 +12,34 @@ import { debounce } from 'lodash';
 import { HotKeys } from 'react-hotkeys';
 
 import { focusApp, unfocusApp, changeLayout } from 'mastodon/actions/app';
-import { synchronouslySubmitMarkers, submitMarkers, fetchMarkers } from 'mastodon/actions/markers';
+import {
+  synchronouslySubmitMarkers,
+  submitMarkers,
+  fetchMarkers,
+} from 'mastodon/actions/markers';
 import { INTRODUCTION_VERSION } from 'mastodon/actions/onboarding';
 import PictureInPicture from 'mastodon/features/picture_in_picture';
 import { layoutFromWindow } from 'mastodon/is_mobile';
 
-import { uploadCompose, resetCompose, changeComposeSpoilerness } from '../../actions/compose';
+import {
+  uploadCompose,
+  resetCompose,
+  changeComposeSpoilerness,
+} from '../../actions/compose';
 import { clearHeight } from '../../actions/height_cache';
 import { expandNotifications } from '../../actions/notifications';
-import { fetchServer, fetchServerTranslationLanguages } from '../../actions/server';
+import {
+  fetchServer,
+  fetchServerTranslationLanguages,
+} from '../../actions/server';
 import { expandHomeTimeline } from '../../actions/timelines';
-import initialState, { me, owner, singleUserMode, trendsEnabled, trendsAsLanding } from '../../initial_state';
+import initialState, {
+  me,
+  owner,
+  singleUserMode,
+  trendsEnabled,
+  trendsAsLanding,
+} from '../../initial_state';
 
 import BundleColumnError from './components/bundle_column_error';
 import Header from './components/header';
@@ -70,17 +87,25 @@ import { WrappedSwitch, WrappedRoute } from './util/react_router_helpers';
 import '../../components/status';
 
 const messages = defineMessages({
-  beforeUnload: { id: 'ui.beforeunload', defaultMessage: 'Your draft will be lost if you leave Mastodon.' },
+  beforeUnload: {
+    id: 'ui.beforeunload',
+    defaultMessage: 'Your draft will be lost if you leave Mastodon.',
+  },
 });
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
   layout: state.getIn(['meta', 'layout']),
   isComposing: state.getIn(['compose', 'is_composing']),
   hasComposingText: state.getIn(['compose', 'text']).trim().length !== 0,
   hasMediaAttachments: state.getIn(['compose', 'media_attachments']).size > 0,
-  canUploadMore: !state.getIn(['compose', 'media_attachments']).some(x => ['audio', 'video'].includes(x.get('type'))) && state.getIn(['compose', 'media_attachments']).size < 4,
+  canUploadMore:
+    !state
+      .getIn(['compose', 'media_attachments'])
+      .some((x) => ['audio', 'video'].includes(x.get('type'))) &&
+    state.getIn(['compose', 'media_attachments']).size < 4,
   dropdownMenuIsOpen: state.getIn(['dropdown_menu', 'openId']) !== null,
-  firstLaunch: state.getIn(['settings', 'introductionVersion'], 0) < INTRODUCTION_VERSION,
+  firstLaunch:
+    state.getIn(['settings', 'introductionVersion'], 0) < INTRODUCTION_VERSION,
   username: state.getIn(['accounts', me, 'username']),
 });
 
@@ -118,7 +143,6 @@ const keyMap = {
 };
 
 class SwitchingColumnsArea extends PureComponent {
-
   static contextTypes = {
     identity: PropTypes.object,
   };
@@ -129,7 +153,7 @@ class SwitchingColumnsArea extends PureComponent {
     singleColumn: PropTypes.bool,
   };
 
-  UNSAFE_componentWillMount () {
+  UNSAFE_componentWillMount() {
     if (this.props.singleColumn) {
       document.body.classList.toggle('layout-single-column', true);
       document.body.classList.toggle('layout-multiple-columns', false);
@@ -139,24 +163,32 @@ class SwitchingColumnsArea extends PureComponent {
     }
   }
 
-  componentDidUpdate (prevProps) {
-    if (![this.props.location.pathname, '/'].includes(prevProps.location.pathname)) {
+  componentDidUpdate(prevProps) {
+    if (
+      ![this.props.location.pathname, '/'].includes(prevProps.location.pathname)
+    ) {
       this.node.handleChildrenContentChange();
     }
 
     if (prevProps.singleColumn !== this.props.singleColumn) {
-      document.body.classList.toggle('layout-single-column', this.props.singleColumn);
-      document.body.classList.toggle('layout-multiple-columns', !this.props.singleColumn);
+      document.body.classList.toggle(
+        'layout-single-column',
+        this.props.singleColumn,
+      );
+      document.body.classList.toggle(
+        'layout-multiple-columns',
+        !this.props.singleColumn,
+      );
     }
   }
 
-  setRef = c => {
+  setRef = (c) => {
     if (c) {
       this.node = c;
     }
   };
 
-  render () {
+  render() {
     const { children, singleColumn } = this.props;
     const { signedIn } = this.context.identity;
     const pathName = this.props.location.pathname;
@@ -170,7 +202,13 @@ class SwitchingColumnsArea extends PureComponent {
         redirect = <Redirect from='/' to='/deck/getting-started' exact />;
       }
     } else if (singleUserMode && owner && initialState?.accounts[owner]) {
-      redirect = <Redirect from='/' to={`/@${initialState.accounts[owner].username}`} exact />;
+      redirect = (
+        <Redirect
+          from='/'
+          to={`/@${initialState.accounts[owner].username}`}
+          exact
+        />
+      );
     } else if (trendsEnabled && trendsAsLanding) {
       redirect = <Redirect from='/' to='/explore' exact />;
     } else {
@@ -183,55 +221,223 @@ class SwitchingColumnsArea extends PureComponent {
           {redirect}
 
           {singleColumn ? <Redirect from='/deck' to='/home' exact /> : null}
-          {singleColumn && pathName.startsWith('/deck/') ? <Redirect from={pathName} to={pathName.slice(5)} /> : null}
-          {!singleColumn && pathName === '/getting-started' ? <Redirect from='/getting-started' to='/deck/getting-started' exact /> : null}
+          {singleColumn && pathName.startsWith('/deck/') ? (
+            <Redirect from={pathName} to={pathName.slice(5)} />
+          ) : null}
+          {!singleColumn && pathName === '/getting-started' ? (
+            <Redirect
+              from='/getting-started'
+              to='/deck/getting-started'
+              exact
+            />
+          ) : null}
 
-          <WrappedRoute path='/getting-started' component={GettingStarted} content={children} />
-          <WrappedRoute path='/keyboard-shortcuts' component={KeyboardShortcuts} content={children} />
+          <WrappedRoute
+            path='/getting-started'
+            component={GettingStarted}
+            content={children}
+          />
+          <WrappedRoute
+            path='/keyboard-shortcuts'
+            component={KeyboardShortcuts}
+            content={children}
+          />
           <WrappedRoute path='/about' component={About} content={children} />
-          <WrappedRoute path='/privacy-policy' component={PrivacyPolicy} content={children} />
+          <WrappedRoute
+            path='/privacy-policy'
+            component={PrivacyPolicy}
+            content={children}
+          />
 
-          <WrappedRoute path={['/home', '/timelines/home']} component={HomeTimeline} content={children} />
+          <WrappedRoute
+            path={['/home', '/timelines/home']}
+            component={HomeTimeline}
+            content={children}
+          />
           <Redirect from='/timelines/public' to='/public' exact />
           <Redirect from='/timelines/public/local' to='/public/local' exact />
-          <WrappedRoute path='/public' exact component={Firehose} componentParams={{ feedType: 'public' }} content={children} />
-          <WrappedRoute path='/public/local' exact component={Firehose} componentParams={{ feedType: 'community' }} content={children} />
-          <WrappedRoute path='/public/remote' exact component={Firehose} componentParams={{ feedType: 'public:remote' }} content={children} />
-          <WrappedRoute path={['/conversations', '/timelines/direct']} component={DirectTimeline} content={children} />
-          <WrappedRoute path='/tags/:id' component={HashtagTimeline} content={children} />
-          <WrappedRoute path='/lists/:id' component={ListTimeline} content={children} />
-          <WrappedRoute path='/notifications' component={Notifications} content={children} />
-          <WrappedRoute path='/favourites' component={FavouritedStatuses} content={children} />
+          <WrappedRoute
+            path='/public'
+            exact
+            component={Firehose}
+            componentParams={{ feedType: 'public' }}
+            content={children}
+          />
+          <WrappedRoute
+            path='/public/local'
+            exact
+            component={Firehose}
+            componentParams={{ feedType: 'community' }}
+            content={children}
+          />
+          <WrappedRoute
+            path='/public/remote'
+            exact
+            component={Firehose}
+            componentParams={{ feedType: 'public:remote' }}
+            content={children}
+          />
+          <WrappedRoute
+            path={['/conversations', '/timelines/direct']}
+            component={DirectTimeline}
+            content={children}
+          />
+          <WrappedRoute
+            path='/tags/:id'
+            component={HashtagTimeline}
+            content={children}
+          />
+          <WrappedRoute
+            path='/lists/:id'
+            component={ListTimeline}
+            content={children}
+          />
+          <WrappedRoute
+            path='/notifications'
+            component={Notifications}
+            content={children}
+          />
+          <WrappedRoute
+            path='/favourites'
+            component={FavouritedStatuses}
+            content={children}
+          />
 
-          <WrappedRoute path='/bookmarks' component={BookmarkedStatuses} content={children} />
-          <WrappedRoute path='/pinned' component={PinnedStatuses} content={children} />
+          <WrappedRoute
+            path='/bookmarks'
+            component={BookmarkedStatuses}
+            content={children}
+          />
+          <WrappedRoute
+            path='/pinned'
+            component={PinnedStatuses}
+            content={children}
+          />
 
-          <WrappedRoute path='/start' exact component={Onboarding} content={children} />
-          <WrappedRoute path='/directory' component={Directory} content={children} />
-          <WrappedRoute path={['/explore', '/search']} component={Explore} content={children} />
-          <WrappedRoute path={['/publish', '/statuses/new']} component={Compose} content={children} />
+          <WrappedRoute
+            path='/start'
+            exact
+            component={Onboarding}
+            content={children}
+          />
+          <WrappedRoute
+            path='/directory'
+            component={Directory}
+            content={children}
+          />
+          <WrappedRoute
+            path={['/explore', '/search']}
+            component={Explore}
+            content={children}
+          />
+          <WrappedRoute
+            path={['/publish', '/statuses/new']}
+            component={Compose}
+            content={children}
+          />
 
-          <WrappedRoute path={['/@:acct', '/accounts/:id']} exact component={AccountTimeline} content={children} />
-          <WrappedRoute path='/@:acct/tagged/:tagged?' exact component={AccountTimeline} content={children} />
-          <WrappedRoute path={['/@:acct/with_replies', '/accounts/:id/with_replies']} component={AccountTimeline} content={children} componentParams={{ withReplies: true }} />
-          <WrappedRoute path={['/accounts/:id/followers', '/users/:acct/followers', '/@:acct/followers']} component={Followers} content={children} />
-          <WrappedRoute path={['/accounts/:id/following', '/users/:acct/following', '/@:acct/following']} component={Following} content={children} />
-          <WrappedRoute path={['/@:acct/media', '/accounts/:id/media']} component={AccountGallery} content={children} />
-          <WrappedRoute path='/@:acct/:statusId' exact component={Status} content={children} />
-          <WrappedRoute path='/@:acct/:statusId/reblogs' component={Reblogs} content={children} />
-          <WrappedRoute path='/@:acct/:statusId/favourites' component={Favourites} content={children} />
+          <WrappedRoute
+            path={['/@:acct', '/accounts/:id']}
+            exact
+            component={AccountTimeline}
+            content={children}
+          />
+          <WrappedRoute
+            path='/@:acct/tagged/:tagged?'
+            exact
+            component={AccountTimeline}
+            content={children}
+          />
+          <WrappedRoute
+            path={['/@:acct/with_replies', '/accounts/:id/with_replies']}
+            component={AccountTimeline}
+            content={children}
+            componentParams={{ withReplies: true }}
+          />
+          <WrappedRoute
+            path={[
+              '/accounts/:id/followers',
+              '/users/:acct/followers',
+              '/@:acct/followers',
+            ]}
+            component={Followers}
+            content={children}
+          />
+          <WrappedRoute
+            path={[
+              '/accounts/:id/following',
+              '/users/:acct/following',
+              '/@:acct/following',
+            ]}
+            component={Following}
+            content={children}
+          />
+          <WrappedRoute
+            path={['/@:acct/media', '/accounts/:id/media']}
+            component={AccountGallery}
+            content={children}
+          />
+          <WrappedRoute
+            path='/@:acct/:statusId'
+            exact
+            component={Status}
+            content={children}
+          />
+          <WrappedRoute
+            path='/@:acct/:statusId/reblogs'
+            component={Reblogs}
+            content={children}
+          />
+          <WrappedRoute
+            path='/@:acct/:statusId/favourites'
+            component={Favourites}
+            content={children}
+          />
 
           {/* Legacy routes, cannot be easily factored with other routes because they share a param name */}
-          <WrappedRoute path='/timelines/tag/:id' component={HashtagTimeline} content={children} />
-          <WrappedRoute path='/timelines/list/:id' component={ListTimeline} content={children} />
-          <WrappedRoute path='/statuses/:statusId' exact component={Status} content={children} />
-          <WrappedRoute path='/statuses/:statusId/reblogs' component={Reblogs} content={children} />
-          <WrappedRoute path='/statuses/:statusId/favourites' component={Favourites} content={children} />
+          <WrappedRoute
+            path='/timelines/tag/:id'
+            component={HashtagTimeline}
+            content={children}
+          />
+          <WrappedRoute
+            path='/timelines/list/:id'
+            component={ListTimeline}
+            content={children}
+          />
+          <WrappedRoute
+            path='/statuses/:statusId'
+            exact
+            component={Status}
+            content={children}
+          />
+          <WrappedRoute
+            path='/statuses/:statusId/reblogs'
+            component={Reblogs}
+            content={children}
+          />
+          <WrappedRoute
+            path='/statuses/:statusId/favourites'
+            component={Favourites}
+            content={children}
+          />
 
-          <WrappedRoute path='/follow_requests' component={FollowRequests} content={children} />
+          <WrappedRoute
+            path='/follow_requests'
+            component={FollowRequests}
+            content={children}
+          />
           <WrappedRoute path='/blocks' component={Blocks} content={children} />
-          <WrappedRoute path='/domain_blocks' component={DomainBlocks} content={children} />
-          <WrappedRoute path='/followed_tags' component={FollowedTags} content={children} />
+          <WrappedRoute
+            path='/domain_blocks'
+            component={DomainBlocks}
+            content={children}
+          />
+          <WrappedRoute
+            path='/followed_tags'
+            component={FollowedTags}
+            content={children}
+          />
           <WrappedRoute path='/mutes' component={Mutes} content={children} />
           <WrappedRoute path='/lists' component={Lists} content={children} />
 
@@ -240,11 +446,9 @@ class SwitchingColumnsArea extends PureComponent {
       </ColumnsAreaContainer>
     );
   }
-
 }
 
 class UI extends PureComponent {
-
   static contextTypes = {
     router: PropTypes.object.isRequired,
     identity: PropTypes.object.isRequired,
@@ -269,8 +473,14 @@ class UI extends PureComponent {
     draggingOver: false,
   };
 
-  handleBeforeUnload = e => {
-    const { intl, dispatch, isComposing, hasComposingText, hasMediaAttachments } = this.props;
+  handleBeforeUnload = (e) => {
+    const {
+      intl,
+      dispatch,
+      isComposing,
+      hasComposingText,
+      hasMediaAttachments,
+    } = this.props;
 
     dispatch(synchronouslySubmitMarkers());
 
@@ -303,7 +513,12 @@ class UI extends PureComponent {
       this.dragTargets.push(e.target);
     }
 
-    if (e.dataTransfer && Array.from(e.dataTransfer.types).includes('Files') && this.props.canUploadMore && this.context.identity.signedIn) {
+    if (
+      e.dataTransfer &&
+      Array.from(e.dataTransfer.types).includes('Files') &&
+      this.props.canUploadMore &&
+      this.context.identity.signedIn
+    ) {
       this.setState({ draggingOver: true });
     }
   };
@@ -316,9 +531,7 @@ class UI extends PureComponent {
 
     try {
       e.dataTransfer.dropEffect = 'copy';
-    } catch (err) {
-
-    }
+    } catch (err) {}
 
     return false;
   };
@@ -331,7 +544,12 @@ class UI extends PureComponent {
     this.setState({ draggingOver: false });
     this.dragTargets = [];
 
-    if (e.dataTransfer && e.dataTransfer.files.length >= 1 && this.props.canUploadMore && this.context.identity.signedIn) {
+    if (
+      e.dataTransfer &&
+      e.dataTransfer.files.length >= 1 &&
+      this.props.canUploadMore &&
+      this.context.identity.signedIn
+    ) {
       this.props.dispatch(uploadCompose(e.dataTransfer.files));
     }
   };
@@ -340,7 +558,9 @@ class UI extends PureComponent {
     e.preventDefault();
     e.stopPropagation();
 
-    this.dragTargets = this.dragTargets.filter(el => el !== e.target && this.node.contains(el));
+    this.dragTargets = this.dragTargets.filter(
+      (el) => el !== e.target && this.node.contains(el),
+    );
 
     if (this.dragTargets.length > 0) {
       return;
@@ -350,7 +570,11 @@ class UI extends PureComponent {
   };
 
   dataTransferIsText = (dataTransfer) => {
-    return (dataTransfer && Array.from(dataTransfer.types).filter((type) => type === 'text/plain').length === 1);
+    return (
+      dataTransfer &&
+      Array.from(dataTransfer.types).filter((type) => type === 'text/plain')
+        .length === 1
+    );
   };
 
   closeUploadModal = () => {
@@ -365,11 +589,15 @@ class UI extends PureComponent {
     }
   };
 
-  handleLayoutChange = debounce(() => {
-    this.props.dispatch(clearHeight()); // The cached heights are no longer accurate, invalidate
-  }, 500, {
-    trailing: true,
-  });
+  handleLayoutChange = debounce(
+    () => {
+      this.props.dispatch(clearHeight()); // The cached heights are no longer accurate, invalidate
+    },
+    500,
+    {
+      trailing: true,
+    },
+  );
 
   handleResize = () => {
     const layout = layoutFromWindow();
@@ -382,7 +610,7 @@ class UI extends PureComponent {
     }
   };
 
-  componentDidMount () {
+  componentDidMount() {
     const { signedIn } = this.context.identity;
 
     window.addEventListener('focus', this.handleWindowFocus, false);
@@ -396,8 +624,11 @@ class UI extends PureComponent {
     document.addEventListener('dragleave', this.handleDragLeave, false);
     document.addEventListener('dragend', this.handleDragEnd, false);
 
-    if ('serviceWorker' in  navigator) {
-      navigator.serviceWorker.addEventListener('message', this.handleServiceWorkerPostMessage);
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.addEventListener(
+        'message',
+        this.handleServiceWorkerPostMessage,
+      );
     }
 
     if (signedIn) {
@@ -414,7 +645,7 @@ class UI extends PureComponent {
     };
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     window.removeEventListener('focus', this.handleWindowFocus);
     window.removeEventListener('blur', this.handleWindowBlur);
     window.removeEventListener('beforeunload', this.handleBeforeUnload);
@@ -427,21 +658,23 @@ class UI extends PureComponent {
     document.removeEventListener('dragend', this.handleDragEnd);
   }
 
-  setRef = c => {
+  setRef = (c) => {
     this.node = c;
   };
 
-  handleHotkeyNew = e => {
+  handleHotkeyNew = (e) => {
     e.preventDefault();
 
-    const element = this.node.querySelector('.compose-form__autosuggest-wrapper textarea');
+    const element = this.node.querySelector(
+      '.compose-form__autosuggest-wrapper textarea',
+    );
 
     if (element) {
       element.focus();
     }
   };
 
-  handleHotkeySearch = e => {
+  handleHotkeySearch = (e) => {
     e.preventDefault();
 
     const element = this.node.querySelector('.search__input');
@@ -451,18 +684,18 @@ class UI extends PureComponent {
     }
   };
 
-  handleHotkeyForceNew = e => {
+  handleHotkeyForceNew = (e) => {
     this.handleHotkeyNew(e);
     this.props.dispatch(resetCompose());
   };
 
-  handleHotkeyToggleComposeSpoilers = e => {
+  handleHotkeyToggleComposeSpoilers = (e) => {
     e.preventDefault();
     this.props.dispatch(changeComposeSpoilerness());
   };
 
-  handleHotkeyFocusColumn = e => {
-    const index  = (e.key * 1) + 1; // First child is drawer, skip that
+  handleHotkeyFocusColumn = (e) => {
+    const index = e.key * 1 + 1; // First child is drawer, skip that
     const column = this.node.querySelector(`.column:nth-child(${index})`);
     if (!column) return;
     const container = column.querySelector('.scrollable');
@@ -489,7 +722,7 @@ class UI extends PureComponent {
     }
   };
 
-  setHotkeysRef = c => {
+  setHotkeysRef = (c) => {
     this.hotkeys = c;
   };
 
@@ -549,9 +782,10 @@ class UI extends PureComponent {
     this.context.router.history.push('/follow_requests');
   };
 
-  render () {
+  render() {
     const { draggingOver } = this.state;
-    const { children, isComposing, location, dropdownMenuIsOpen, layout } = this.props;
+    const { children, isComposing, location, dropdownMenuIsOpen, layout } =
+      this.props;
 
     const handlers = {
       help: this.handleHotkeyToggleHelp,
@@ -576,11 +810,24 @@ class UI extends PureComponent {
     };
 
     return (
-      <HotKeys keyMap={keyMap} handlers={handlers} ref={this.setHotkeysRef} attach={window} focused>
-        <div className={classNames('ui', { 'is-composing': isComposing })} ref={this.setRef} style={{ pointerEvents: dropdownMenuIsOpen ? 'none' : null }}>
+      <HotKeys
+        keyMap={keyMap}
+        handlers={handlers}
+        ref={this.setHotkeysRef}
+        attach={window}
+        focused
+      >
+        <div
+          className={classNames('ui', { 'is-composing': isComposing })}
+          ref={this.setRef}
+          style={{ pointerEvents: dropdownMenuIsOpen ? 'none' : null }}
+        >
           <Header />
 
-          <SwitchingColumnsArea location={location} singleColumn={layout === 'mobile' || layout === 'single-column'}>
+          <SwitchingColumnsArea
+            location={location}
+            singleColumn={layout === 'mobile' || layout === 'single-column'}
+          >
             {children}
           </SwitchingColumnsArea>
 
@@ -593,7 +840,6 @@ class UI extends PureComponent {
       </HotKeys>
     );
   }
-
 }
 
 export default connect(mapStateToProps)(injectIntl(withRouter(UI)));

--- a/app/javascript/mastodon/features/ui/util/async-components.js
+++ b/app/javascript/mastodon/features/ui/util/async-components.js
@@ -1,191 +1,257 @@
-export function EmojiPicker () {
-  return import(/* webpackChunkName: "emoji_picker" */'../../emoji/emoji_picker');
+export function EmojiPicker() {
+  return import(
+    /* webpackChunkName: "emoji_picker" */ '../../emoji/emoji_picker'
+  );
 }
 
-export function Compose () {
-  return import(/* webpackChunkName: "features/compose" */'../../compose');
+export function Compose() {
+  return import(/* webpackChunkName: "features/compose" */ '../../compose');
 }
 
-export function Notifications () {
-  return import(/* webpackChunkName: "features/notifications" */'../../notifications');
+export function Notifications() {
+  return import(
+    /* webpackChunkName: "features/notifications" */ '../../notifications'
+  );
 }
 
-export function HomeTimeline () {
-  return import(/* webpackChunkName: "features/home_timeline" */'../../home_timeline');
+export function HomeTimeline() {
+  return import(
+    /* webpackChunkName: "features/home_timeline" */ '../../home_timeline'
+  );
 }
 
-export function PublicTimeline () {
-  return import(/* webpackChunkName: "features/public_timeline" */'../../public_timeline');
+export function PublicTimeline() {
+  return import(
+    /* webpackChunkName: "features/public_timeline" */ '../../public_timeline'
+  );
 }
 
-export function CommunityTimeline () {
-  return import(/* webpackChunkName: "features/community_timeline" */'../../community_timeline');
+export function CommunityTimeline() {
+  return import(
+    /* webpackChunkName: "features/community_timeline" */ '../../community_timeline'
+  );
 }
 
-export function Firehose () {
-  return import(/* webpackChunkName: "features/firehose" */'../../firehose');
+export function Firehose() {
+  return import(/* webpackChunkName: "features/firehose" */ '../../firehose');
 }
 
-export function HashtagTimeline () {
-  return import(/* webpackChunkName: "features/hashtag_timeline" */'../../hashtag_timeline');
+export function HashtagTimeline() {
+  return import(
+    /* webpackChunkName: "features/hashtag_timeline" */ '../../hashtag_timeline'
+  );
 }
 
 export function DirectTimeline() {
-  return import(/* webpackChunkName: "features/direct_timeline" */'../../direct_timeline');
+  return import(
+    /* webpackChunkName: "features/direct_timeline" */ '../../direct_timeline'
+  );
 }
 
-export function ListTimeline () {
-  return import(/* webpackChunkName: "features/list_timeline" */'../../list_timeline');
+export function ListTimeline() {
+  return import(
+    /* webpackChunkName: "features/list_timeline" */ '../../list_timeline'
+  );
 }
 
-export function Lists () {
-  return import(/* webpackChunkName: "features/lists" */'../../lists');
+export function Lists() {
+  return import(/* webpackChunkName: "features/lists" */ '../../lists');
 }
 
-export function Status () {
-  return import(/* webpackChunkName: "features/status" */'../../status');
+export function Status() {
+  return import(/* webpackChunkName: "features/status" */ '../../status');
 }
 
-export function GettingStarted () {
-  return import(/* webpackChunkName: "features/getting_started" */'../../getting_started');
+export function GettingStarted() {
+  return import(
+    /* webpackChunkName: "features/getting_started" */ '../../getting_started'
+  );
 }
 
-export function KeyboardShortcuts () {
-  return import(/* webpackChunkName: "features/keyboard_shortcuts" */'../../keyboard_shortcuts');
+export function KeyboardShortcuts() {
+  return import(
+    /* webpackChunkName: "features/keyboard_shortcuts" */ '../../keyboard_shortcuts'
+  );
 }
 
-export function PinnedStatuses () {
-  return import(/* webpackChunkName: "features/pinned_statuses" */'../../pinned_statuses');
+export function PinnedStatuses() {
+  return import(
+    /* webpackChunkName: "features/pinned_statuses" */ '../../pinned_statuses'
+  );
 }
 
-export function AccountTimeline () {
-  return import(/* webpackChunkName: "features/account_timeline" */'../../account_timeline');
+export function AccountTimeline() {
+  return import(
+    /* webpackChunkName: "features/account_timeline" */ '../../account_timeline'
+  );
 }
 
-export function AccountGallery () {
-  return import(/* webpackChunkName: "features/account_gallery" */'../../account_gallery');
+export function AccountGallery() {
+  return import(
+    /* webpackChunkName: "features/account_gallery" */ '../../account_gallery'
+  );
 }
 
-export function Followers () {
-  return import(/* webpackChunkName: "features/followers" */'../../followers');
+export function Followers() {
+  return import(/* webpackChunkName: "features/followers" */ '../../followers');
 }
 
-export function Following () {
-  return import(/* webpackChunkName: "features/following" */'../../following');
+export function Following() {
+  return import(/* webpackChunkName: "features/following" */ '../../following');
 }
 
-export function Reblogs () {
-  return import(/* webpackChunkName: "features/reblogs" */'../../reblogs');
+export function Reblogs() {
+  return import(/* webpackChunkName: "features/reblogs" */ '../../reblogs');
 }
 
-export function Favourites () {
-  return import(/* webpackChunkName: "features/favourites" */'../../favourites');
+export function Favourites() {
+  return import(
+    /* webpackChunkName: "features/favourites" */ '../../favourites'
+  );
 }
 
-export function FollowRequests () {
-  return import(/* webpackChunkName: "features/follow_requests" */'../../follow_requests');
+export function FollowRequests() {
+  return import(
+    /* webpackChunkName: "features/follow_requests" */ '../../follow_requests'
+  );
 }
 
-export function FavouritedStatuses () {
-  return import(/* webpackChunkName: "features/favourited_statuses" */'../../favourited_statuses');
+export function FavouritedStatuses() {
+  return import(
+    /* webpackChunkName: "features/favourited_statuses" */ '../../favourited_statuses'
+  );
 }
 
-export function FollowedTags () {
-  return import(/* webpackChunkName: "features/followed_tags" */'../../followed_tags');
+export function FollowedTags() {
+  return import(
+    /* webpackChunkName: "features/followed_tags" */ '../../followed_tags'
+  );
 }
 
-export function BookmarkedStatuses () {
-  return import(/* webpackChunkName: "features/bookmarked_statuses" */'../../bookmarked_statuses');
+export function BookmarkedStatuses() {
+  return import(
+    /* webpackChunkName: "features/bookmarked_statuses" */ '../../bookmarked_statuses'
+  );
 }
 
-export function Blocks () {
-  return import(/* webpackChunkName: "features/blocks" */'../../blocks');
+export function Blocks() {
+  return import(/* webpackChunkName: "features/blocks" */ '../../blocks');
 }
 
-export function DomainBlocks () {
-  return import(/* webpackChunkName: "features/domain_blocks" */'../../domain_blocks');
+export function DomainBlocks() {
+  return import(
+    /* webpackChunkName: "features/domain_blocks" */ '../../domain_blocks'
+  );
 }
 
-export function Mutes () {
-  return import(/* webpackChunkName: "features/mutes" */'../../mutes');
+export function Mutes() {
+  return import(/* webpackChunkName: "features/mutes" */ '../../mutes');
 }
 
-export function MuteModal () {
-  return import(/* webpackChunkName: "modals/mute_modal" */'../components/mute_modal');
+export function MuteModal() {
+  return import(
+    /* webpackChunkName: "modals/mute_modal" */ '../components/mute_modal'
+  );
 }
 
-export function BlockModal () {
-  return import(/* webpackChunkName: "modals/block_modal" */'../components/block_modal');
+export function BlockModal() {
+  return import(
+    /* webpackChunkName: "modals/block_modal" */ '../components/block_modal'
+  );
 }
 
-export function ReportModal () {
-  return import(/* webpackChunkName: "modals/report_modal" */'../components/report_modal');
+export function ReportModal() {
+  return import(
+    /* webpackChunkName: "modals/report_modal" */ '../components/report_modal'
+  );
 }
 
-export function MediaGallery () {
-  return import(/* webpackChunkName: "status/media_gallery" */'../../../components/media_gallery');
+export function MediaGallery() {
+  return import(
+    /* webpackChunkName: "status/media_gallery" */ '../../../components/media_gallery'
+  );
 }
 
-export function Video () {
-  return import(/* webpackChunkName: "features/video" */'../../video');
+export function Video() {
+  return import(/* webpackChunkName: "features/video" */ '../../video');
 }
 
-export function EmbedModal () {
-  return import(/* webpackChunkName: "modals/embed_modal" */'../components/embed_modal');
+export function EmbedModal() {
+  return import(
+    /* webpackChunkName: "modals/embed_modal" */ '../components/embed_modal'
+  );
 }
 
-export function ListEditor () {
-  return import(/* webpackChunkName: "features/list_editor" */'../../list_editor');
+export function ListEditor() {
+  return import(
+    /* webpackChunkName: "features/list_editor" */ '../../list_editor'
+  );
 }
 
-export function ListAdder () {
-  return import(/*webpackChunkName: "features/list_adder" */'../../list_adder');
+export function ListAdder() {
+  return import(
+    /*webpackChunkName: "features/list_adder" */ '../../list_adder'
+  );
 }
 
-export function Tesseract () {
-  return import(/*webpackChunkName: "tesseract" */'tesseract.js');
+export function Tesseract() {
+  return import(/*webpackChunkName: "tesseract" */ 'tesseract.js');
 }
 
-export function Audio () {
-  return import(/* webpackChunkName: "features/audio" */'../../audio');
+export function Audio() {
+  return import(/* webpackChunkName: "features/audio" */ '../../audio');
 }
 
-export function Directory () {
-  return import(/* webpackChunkName: "features/directory" */'../../directory');
+export function Directory() {
+  return import(/* webpackChunkName: "features/directory" */ '../../directory');
 }
 
-export function Onboarding () {
-  return import(/* webpackChunkName: "features/onboarding" */'../../onboarding');
+export function Onboarding() {
+  return import(
+    /* webpackChunkName: "features/onboarding" */ '../../onboarding'
+  );
 }
 
-export function CompareHistoryModal () {
-  return import(/*webpackChunkName: "modals/compare_history_modal" */'../components/compare_history_modal');
+export function CompareHistoryModal() {
+  return import(
+    /*webpackChunkName: "modals/compare_history_modal" */ '../components/compare_history_modal'
+  );
 }
 
-export function Explore () {
-  return import(/* webpackChunkName: "features/explore" */'../../explore');
+export function Explore() {
+  return import(/* webpackChunkName: "features/explore" */ '../../explore');
 }
 
-export function FilterModal () {
-  return import(/*webpackChunkName: "modals/filter_modal" */'../components/filter_modal');
+export function FilterModal() {
+  return import(
+    /*webpackChunkName: "modals/filter_modal" */ '../components/filter_modal'
+  );
 }
 
-export function InteractionModal () {
-  return import(/*webpackChunkName: "modals/interaction_modal" */'../../interaction_modal');
+export function InteractionModal() {
+  return import(
+    /*webpackChunkName: "modals/interaction_modal" */ '../../interaction_modal'
+  );
 }
 
-export function SubscribedLanguagesModal () {
-  return import(/*webpackChunkName: "modals/subscribed_languages_modal" */'../../subscribed_languages_modal');
+export function SubscribedLanguagesModal() {
+  return import(
+    /*webpackChunkName: "modals/subscribed_languages_modal" */ '../../subscribed_languages_modal'
+  );
 }
 
-export function ClosedRegistrationsModal () {
-  return import(/*webpackChunkName: "modals/closed_registrations_modal" */'../../closed_registrations_modal');
+export function ClosedRegistrationsModal() {
+  return import(
+    /*webpackChunkName: "modals/closed_registrations_modal" */ '../../closed_registrations_modal'
+  );
 }
 
-export function About () {
-  return import(/*webpackChunkName: "features/about" */'../../about');
+export function About() {
+  return import(/*webpackChunkName: "features/about" */ '../../about');
 }
 
-export function PrivacyPolicy () {
-  return import(/*webpackChunkName: "features/privacy_policy" */'../../privacy_policy');
+export function PrivacyPolicy() {
+  return import(
+    /*webpackChunkName: "features/privacy_policy" */ '../../privacy_policy'
+  );
 }

--- a/app/javascript/mastodon/features/ui/util/fullscreen.js
+++ b/app/javascript/mastodon/features/ui/util/fullscreen.js
@@ -1,7 +1,8 @@
 // APIs for normalizing fullscreen operations. Note that Edge uses
 // the WebKit-prefixed APIs currently (as of Edge 16).
 
-export const isFullscreen = () => document.fullscreenElement ||
+export const isFullscreen = () =>
+  document.fullscreenElement ||
   document.webkitFullscreenElement ||
   document.mozFullScreenElement;
 
@@ -15,7 +16,7 @@ export const exitFullscreen = () => {
   }
 };
 
-export const requestFullscreen = el => {
+export const requestFullscreen = (el) => {
   if (el.requestFullscreen) {
     el.requestFullscreen();
   } else if (el.webkitRequestFullscreen) {

--- a/app/javascript/mastodon/features/ui/util/get_rect_from_entry.js
+++ b/app/javascript/mastodon/features/ui/util/get_rect_from_entry.js
@@ -1,4 +1,3 @@
-
 // Get the bounding client rect from an IntersectionObserver entry.
 // This is to work around a bug in Chrome: https://crbug.com/737228
 
@@ -8,14 +7,17 @@ function getRectFromEntry(entry) {
   if (typeof hasBoundingRectBug !== 'boolean') {
     const boundingRect = entry.target.getBoundingClientRect();
     const observerRect = entry.boundingClientRect;
-    hasBoundingRectBug = boundingRect.height !== observerRect.height ||
+    hasBoundingRectBug =
+      boundingRect.height !== observerRect.height ||
       boundingRect.top !== observerRect.top ||
       boundingRect.width !== observerRect.width ||
       boundingRect.bottom !== observerRect.bottom ||
       boundingRect.left !== observerRect.left ||
       boundingRect.right !== observerRect.right;
   }
-  return hasBoundingRectBug ? entry.target.getBoundingClientRect() : entry.boundingClientRect;
+  return hasBoundingRectBug
+    ? entry.target.getBoundingClientRect()
+    : entry.boundingClientRect;
 }
 
 export default getRectFromEntry;

--- a/app/javascript/mastodon/features/ui/util/intersection_observer_wrapper.js
+++ b/app/javascript/mastodon/features/ui/util/intersection_observer_wrapper.js
@@ -6,14 +6,13 @@
 // https://developers.google.com/web/updates/2016/04/intersectionobserver
 
 class IntersectionObserverWrapper {
-
   callbacks = {};
   observerBacklog = [];
   observer = null;
 
-  connect (options) {
+  connect(options) {
     const onIntersection = (entries) => {
-      entries.forEach(entry => {
+      entries.forEach((entry) => {
         const id = entry.target.getAttribute('data-id');
         if (this.callbacks[id]) {
           this.callbacks[id](entry);
@@ -22,36 +21,35 @@ class IntersectionObserverWrapper {
     };
 
     this.observer = new IntersectionObserver(onIntersection, options);
-    this.observerBacklog.forEach(([ id, node, callback ]) => {
+    this.observerBacklog.forEach(([id, node, callback]) => {
       this.observe(id, node, callback);
     });
     this.observerBacklog = null;
   }
 
-  observe (id, node, callback) {
+  observe(id, node, callback) {
     if (!this.observer) {
-      this.observerBacklog.push([ id, node, callback ]);
+      this.observerBacklog.push([id, node, callback]);
     } else {
       this.callbacks[id] = callback;
       this.observer.observe(node);
     }
   }
 
-  unobserve (id, node) {
+  unobserve(id, node) {
     if (this.observer) {
       delete this.callbacks[id];
       this.observer.unobserve(node);
     }
   }
 
-  disconnect () {
+  disconnect() {
     if (this.observer) {
       this.callbacks = {};
       this.observer.disconnect();
       this.observer = null;
     }
   }
-
 }
 
 export default IntersectionObserverWrapper;

--- a/app/javascript/mastodon/features/ui/util/react_router_helpers.jsx
+++ b/app/javascript/mastodon/features/ui/util/react_router_helpers.jsx
@@ -15,21 +15,23 @@ export class WrappedSwitch extends PureComponent {
     router: PropTypes.object,
   };
 
-  render () {
+  render() {
     const { multiColumn, children } = this.props;
     const { location } = this.context.router.route;
 
-    const decklessLocation = multiColumn && location.pathname.startsWith('/deck')
-      ? {...location, pathname: location.pathname.slice(5)}
-      : location;
+    const decklessLocation =
+      multiColumn && location.pathname.startsWith('/deck')
+        ? { ...location, pathname: location.pathname.slice(5) }
+        : location;
 
     return (
       <Switch location={decklessLocation}>
-        {Children.map(children, child => child ? cloneElement(child, { multiColumn }) : null)}
+        {Children.map(children, (child) =>
+          child ? cloneElement(child, { multiColumn }) : null,
+        )}
       </Switch>
     );
   }
-
 }
 
 WrappedSwitch.propTypes = {
@@ -41,7 +43,6 @@ WrappedSwitch.propTypes = {
 // them to the rendered component, together with the content to
 // be rendered inside (the children)
 export class WrappedRoute extends Component {
-
   static propTypes = {
     component: PropTypes.func.isRequired,
     content: PropTypes.node,
@@ -53,7 +54,7 @@ export class WrappedRoute extends Component {
     componentParams: {},
   };
 
-  static getDerivedStateFromError () {
+  static getDerivedStateFromError() {
     return {
       hasError: true,
     };
@@ -64,12 +65,19 @@ export class WrappedRoute extends Component {
     stacktrace: '',
   };
 
-  componentDidCatch (error) {
-    StackTrace.fromError(error).then(stackframes => {
-      this.setState({ stacktrace: error.toString() + '\n' + stackframes.map(frame => frame.toString()).join('\n') });
-    }).catch(err => {
-      console.error(err);
-    });
+  componentDidCatch(error) {
+    StackTrace.fromError(error)
+      .then((stackframes) => {
+        this.setState({
+          stacktrace:
+            error.toString() +
+            '\n' +
+            stackframes.map((frame) => frame.toString()).join('\n'),
+        });
+      })
+      .catch((err) => {
+        console.error(err);
+      });
   }
 
   renderComponent = ({ match }) => {
@@ -87,8 +95,20 @@ export class WrappedRoute extends Component {
     }
 
     return (
-      <BundleContainer fetchComponent={component} loading={this.renderLoading} error={this.renderError}>
-        {Component => <Component params={match.params} multiColumn={multiColumn} {...componentParams}>{content}</Component>}
+      <BundleContainer
+        fetchComponent={component}
+        loading={this.renderLoading}
+        error={this.renderError}
+      >
+        {(Component) => (
+          <Component
+            params={match.params}
+            multiColumn={multiColumn}
+            {...componentParams}
+          >
+            {content}
+          </Component>
+        )}
       </BundleContainer>
     );
   };
@@ -103,10 +123,9 @@ export class WrappedRoute extends Component {
     return <BundleColumnError {...props} errorType='network' />;
   };
 
-  render () {
+  render() {
     const { component: Component, content, ...rest } = this.props;
 
     return <Route {...rest} render={this.renderComponent} />;
   }
-
 }

--- a/app/javascript/mastodon/features/ui/util/reduced_motion.jsx
+++ b/app/javascript/mastodon/features/ui/util/reduced_motion.jsx
@@ -9,11 +9,12 @@ const stylesToKeep = ['opacity', 'backgroundOpacity'];
 
 const extractValue = (value) => {
   // This is either an object with a "val" property or it's a number
-  return (typeof value === 'object' && value && 'val' in value) ? value.val : value;
+  return typeof value === 'object' && value && 'val' in value
+    ? value.val
+    : value;
 };
 
 class ReducedMotion extends Component {
-
   static propTypes = {
     defaultStyle: PropTypes.object,
     style: PropTypes.object,
@@ -21,10 +22,9 @@ class ReducedMotion extends Component {
   };
 
   render() {
-
     const { style, defaultStyle, children } = this.props;
 
-    Object.keys(style).forEach(key => {
+    Object.keys(style).forEach((key) => {
       if (stylesToKeep.includes(key)) {
         return;
       }
@@ -39,7 +39,6 @@ class ReducedMotion extends Component {
       </Motion>
     );
   }
-
 }
 
 export default ReducedMotion;

--- a/app/javascript/mastodon/features/video/index.jsx
+++ b/app/javascript/mastodon/features/video/index.jsx
@@ -10,10 +10,14 @@ import { is } from 'immutable';
 import { throttle } from 'lodash';
 
 import { Blurhash } from 'mastodon/components/blurhash';
-import { Icon }  from 'mastodon/components/icon';
+import { Icon } from 'mastodon/components/icon';
 
 import { displayMedia, useBlurhash } from '../../initial_state';
-import { isFullscreen, requestFullscreen, exitFullscreen } from '../ui/util/fullscreen';
+import {
+  isFullscreen,
+  requestFullscreen,
+  exitFullscreen,
+} from '../ui/util/fullscreen';
 
 const messages = defineMessages({
   play: { id: 'video.play', defaultMessage: 'Play' },
@@ -24,22 +28,25 @@ const messages = defineMessages({
   expand: { id: 'video.expand', defaultMessage: 'Expand video' },
   close: { id: 'video.close', defaultMessage: 'Close video' },
   fullscreen: { id: 'video.fullscreen', defaultMessage: 'Full screen' },
-  exit_fullscreen: { id: 'video.exit_fullscreen', defaultMessage: 'Exit full screen' },
+  exit_fullscreen: {
+    id: 'video.exit_fullscreen',
+    defaultMessage: 'Exit full screen',
+  },
 });
 
-export const formatTime = secondsNum => {
-  let hours   = Math.floor(secondsNum / 3600);
-  let minutes = Math.floor((secondsNum - (hours * 3600)) / 60);
-  let seconds = secondsNum - (hours * 3600) - (minutes * 60);
+export const formatTime = (secondsNum) => {
+  let hours = Math.floor(secondsNum / 3600);
+  let minutes = Math.floor((secondsNum - hours * 3600) / 60);
+  let seconds = secondsNum - hours * 3600 - minutes * 60;
 
-  if (hours   < 10) hours   = '0' + hours;
+  if (hours < 10) hours = '0' + hours;
   if (minutes < 10) minutes = '0' + minutes;
   if (seconds < 10) seconds = '0' + seconds;
 
   return (hours === '00' ? '' : `${hours}:`) + `${minutes}:${seconds}`;
 };
 
-export const findElementPosition = el => {
+export const findElementPosition = (el) => {
   let box;
 
   if (el.getBoundingClientRect && el.parentNode) {
@@ -54,15 +61,15 @@ export const findElementPosition = el => {
   }
 
   const docEl = document.documentElement;
-  const body  = document.body;
+  const body = document.body;
 
   const clientLeft = docEl.clientLeft || body.clientLeft || 0;
   const scrollLeft = window.pageXOffset || body.scrollLeft;
-  const left       = (box.left + scrollLeft) - clientLeft;
+  const left = box.left + scrollLeft - clientLeft;
 
   const clientTop = docEl.clientTop || body.clientTop || 0;
   const scrollTop = window.pageYOffset || body.scrollTop;
-  const top       = (box.top + scrollTop) - clientTop;
+  const top = box.top + scrollTop - clientTop;
 
   return {
     left: Math.round(left),
@@ -92,16 +99,15 @@ export const getPointerPosition = (el, event) => {
   return position;
 };
 
-export const fileNameFromURL = str => {
-  const url      = new URL(str);
+export const fileNameFromURL = (str) => {
+  const url = new URL(str);
   const pathname = url.pathname;
-  const index    = pathname.lastIndexOf('/');
+  const index = pathname.lastIndexOf('/');
 
   return pathname.slice(index + 1);
 };
 
 class Video extends PureComponent {
-
   static propTypes = {
     preview: PropTypes.string,
     frameRate: PropTypes.string,
@@ -141,14 +147,18 @@ class Video extends PureComponent {
     fullscreen: false,
     hovered: false,
     muted: false,
-    revealed: this.props.visible !== undefined ? this.props.visible : (displayMedia !== 'hide_all' && !this.props.sensitive || displayMedia === 'show_all'),
+    revealed:
+      this.props.visible !== undefined
+        ? this.props.visible
+        : (displayMedia !== 'hide_all' && !this.props.sensitive) ||
+          displayMedia === 'show_all',
   };
 
-  setPlayerRef = c => {
+  setPlayerRef = (c) => {
     this.player = c;
   };
 
-  setVideoRef = c => {
+  setVideoRef = (c) => {
     this.video = c;
 
     if (this.video) {
@@ -156,15 +166,15 @@ class Video extends PureComponent {
     }
   };
 
-  setSeekRef = c => {
+  setSeekRef = (c) => {
     this.seek = c;
   };
 
-  setVolumeRef = c => {
+  setVolumeRef = (c) => {
     this.volume = c;
   };
 
-  handleClickRoot = e => e.stopPropagation();
+  handleClickRoot = (e) => e.stopPropagation();
 
   handlePlay = () => {
     this.setState({ paused: false });
@@ -175,7 +185,7 @@ class Video extends PureComponent {
     this.setState({ paused: true });
   };
 
-  _updateTime () {
+  _updateTime() {
     requestAnimationFrame(() => {
       if (!this.video) return;
 
@@ -190,11 +200,11 @@ class Video extends PureComponent {
   handleTimeUpdate = () => {
     this.setState({
       currentTime: this.video.currentTime,
-      duration:this.video.duration,
+      duration: this.video.duration,
     });
   };
 
-  handleVolumeMouseDown = e => {
+  handleVolumeMouseDown = (e) => {
     document.addEventListener('mousemove', this.handleMouseVolSlide, true);
     document.addEventListener('mouseup', this.handleVolumeMouseUp, true);
     document.addEventListener('touchmove', this.handleMouseVolSlide, true);
@@ -213,18 +223,21 @@ class Video extends PureComponent {
     document.removeEventListener('touchend', this.handleVolumeMouseUp, true);
   };
 
-  handleMouseVolSlide = throttle(e => {
+  handleMouseVolSlide = throttle((e) => {
     const { x } = getPointerPosition(this.volume, e);
 
-    if(!isNaN(x)) {
-      this.setState((state) => ({ volume: x, muted: state.muted && x === 0 }), () => {
-        this.video.volume = x;
-        this.video.muted = this.state.muted;
-      });
+    if (!isNaN(x)) {
+      this.setState(
+        (state) => ({ volume: x, muted: state.muted && x === 0 }),
+        () => {
+          this.video.volume = x;
+          this.video.muted = this.state.muted;
+        },
+      );
     }
   }, 15);
 
-  handleMouseDown = e => {
+  handleMouseDown = (e) => {
     document.addEventListener('mousemove', this.handleMouseMove, true);
     document.addEventListener('mouseup', this.handleMouseUp, true);
     document.addEventListener('touchmove', this.handleMouseMove, true);
@@ -248,7 +261,7 @@ class Video extends PureComponent {
     this.video.play();
   };
 
-  handleMouseMove = throttle(e => {
+  handleMouseMove = throttle((e) => {
     const { x } = getPointerPosition(this.seek, e);
     const currentTime = this.video.duration * x;
 
@@ -259,7 +272,7 @@ class Video extends PureComponent {
     }
   }, 15);
 
-  seekBy (time) {
+  seekBy(time) {
     const currentTime = this.video.currentTime + time;
 
     if (!isNaN(currentTime)) {
@@ -269,7 +282,7 @@ class Video extends PureComponent {
     }
   }
 
-  handleVideoKeyDown = e => {
+  handleVideoKeyDown = (e) => {
     // On the video element or the seek bar, we can safely use the space bar
     // for playback control because there are no buttons to press
 
@@ -280,45 +293,45 @@ class Video extends PureComponent {
     }
   };
 
-  handleKeyDown = e => {
+  handleKeyDown = (e) => {
     const frameTime = 1 / this.getFrameRate();
 
-    switch(e.key) {
-    case 'k':
-      e.preventDefault();
-      e.stopPropagation();
-      this.togglePlay();
-      break;
-    case 'm':
-      e.preventDefault();
-      e.stopPropagation();
-      this.toggleMute();
-      break;
-    case 'f':
-      e.preventDefault();
-      e.stopPropagation();
-      this.toggleFullscreen();
-      break;
-    case 'j':
-      e.preventDefault();
-      e.stopPropagation();
-      this.seekBy(-10);
-      break;
-    case 'l':
-      e.preventDefault();
-      e.stopPropagation();
-      this.seekBy(10);
-      break;
-    case ',':
-      e.preventDefault();
-      e.stopPropagation();
-      this.seekBy(-frameTime);
-      break;
-    case '.':
-      e.preventDefault();
-      e.stopPropagation();
-      this.seekBy(frameTime);
-      break;
+    switch (e.key) {
+      case 'k':
+        e.preventDefault();
+        e.stopPropagation();
+        this.togglePlay();
+        break;
+      case 'm':
+        e.preventDefault();
+        e.stopPropagation();
+        this.toggleMute();
+        break;
+      case 'f':
+        e.preventDefault();
+        e.stopPropagation();
+        this.toggleFullscreen();
+        break;
+      case 'j':
+        e.preventDefault();
+        e.stopPropagation();
+        this.seekBy(-10);
+        break;
+      case 'l':
+        e.preventDefault();
+        e.stopPropagation();
+        this.seekBy(10);
+        break;
+      case ',':
+        e.preventDefault();
+        e.stopPropagation();
+        this.seekBy(-frameTime);
+        break;
+      case '.':
+        e.preventDefault();
+        e.stopPropagation();
+        this.seekBy(frameTime);
+        break;
     }
 
     // If we are in fullscreen mode, we don't want any hotkeys
@@ -350,22 +363,54 @@ class Video extends PureComponent {
     }
   };
 
-  componentDidMount () {
-    document.addEventListener('fullscreenchange', this.handleFullscreenChange, true);
-    document.addEventListener('webkitfullscreenchange', this.handleFullscreenChange, true);
-    document.addEventListener('mozfullscreenchange', this.handleFullscreenChange, true);
-    document.addEventListener('MSFullscreenChange', this.handleFullscreenChange, true);
+  componentDidMount() {
+    document.addEventListener(
+      'fullscreenchange',
+      this.handleFullscreenChange,
+      true,
+    );
+    document.addEventListener(
+      'webkitfullscreenchange',
+      this.handleFullscreenChange,
+      true,
+    );
+    document.addEventListener(
+      'mozfullscreenchange',
+      this.handleFullscreenChange,
+      true,
+    );
+    document.addEventListener(
+      'MSFullscreenChange',
+      this.handleFullscreenChange,
+      true,
+    );
 
     window.addEventListener('scroll', this.handleScroll);
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     window.removeEventListener('scroll', this.handleScroll);
 
-    document.removeEventListener('fullscreenchange', this.handleFullscreenChange, true);
-    document.removeEventListener('webkitfullscreenchange', this.handleFullscreenChange, true);
-    document.removeEventListener('mozfullscreenchange', this.handleFullscreenChange, true);
-    document.removeEventListener('MSFullscreenChange', this.handleFullscreenChange, true);
+    document.removeEventListener(
+      'fullscreenchange',
+      this.handleFullscreenChange,
+      true,
+    );
+    document.removeEventListener(
+      'webkitfullscreenchange',
+      this.handleFullscreenChange,
+      true,
+    );
+    document.removeEventListener(
+      'mozfullscreenchange',
+      this.handleFullscreenChange,
+      true,
+    );
+    document.removeEventListener(
+      'MSFullscreenChange',
+      this.handleFullscreenChange,
+      true,
+    );
 
     if (!this.state.paused && this.video && this.props.deployPictureInPicture) {
       this.props.deployPictureInPicture('video', {
@@ -377,41 +422,50 @@ class Video extends PureComponent {
     }
   }
 
-  UNSAFE_componentWillReceiveProps (nextProps) {
-    if (!is(nextProps.visible, this.props.visible) && nextProps.visible !== undefined) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    if (
+      !is(nextProps.visible, this.props.visible) &&
+      nextProps.visible !== undefined
+    ) {
       this.setState({ revealed: nextProps.visible });
     }
   }
 
-  componentDidUpdate (prevProps, prevState) {
+  componentDidUpdate(prevProps, prevState) {
     if (prevState.revealed && !this.state.revealed && this.video) {
       this.video.pause();
     }
   }
 
-  handleScroll = throttle(() => {
-    if (!this.video) {
-      return;
-    }
-
-    const { top, height } = this.video.getBoundingClientRect();
-    const inView = (top <= (window.innerHeight || document.documentElement.clientHeight)) && (top + height >= 0);
-
-    if (!this.state.paused && !inView) {
-      this.video.pause();
-
-      if (this.props.deployPictureInPicture) {
-        this.props.deployPictureInPicture('video', {
-          src: this.props.src,
-          currentTime: this.video.currentTime,
-          muted: this.video.muted,
-          volume: this.video.volume,
-        });
+  handleScroll = throttle(
+    () => {
+      if (!this.video) {
+        return;
       }
 
-      this.setState({ paused: true });
-    }
-  }, 150, { trailing: true });
+      const { top, height } = this.video.getBoundingClientRect();
+      const inView =
+        top <= (window.innerHeight || document.documentElement.clientHeight) &&
+        top + height >= 0;
+
+      if (!this.state.paused && !inView) {
+        this.video.pause();
+
+        if (this.props.deployPictureInPicture) {
+          this.props.deployPictureInPicture('video', {
+            src: this.props.src,
+            currentTime: this.video.currentTime,
+            muted: this.video.muted,
+            volume: this.video.volume,
+          });
+        }
+
+        this.setState({ paused: true });
+      }
+    },
+    150,
+    { trailing: true },
+  );
 
   handleFullscreenChange = () => {
     this.setState({ fullscreen: isFullscreen() });
@@ -428,10 +482,13 @@ class Video extends PureComponent {
   toggleMute = () => {
     const muted = !(this.video.muted || this.state.volume === 0);
 
-    this.setState((state) => ({ muted, volume: Math.max(state.volume || 0.5, 0.05) }), () => {
-      this.video.volume = this.state.volume;
-      this.video.muted = this.state.muted;
-    });
+    this.setState(
+      (state) => ({ muted, volume: Math.max(state.volume || 0.5, 0.05) }),
+      () => {
+        this.video.volume = this.state.volume;
+        this.video.muted = this.state.muted;
+      },
+    );
   };
 
   toggleReveal = () => {
@@ -466,7 +523,11 @@ class Video extends PureComponent {
     const lastTimeRange = this.video.buffered.length - 1;
 
     if (lastTimeRange > -1) {
-      this.setState({ buffer: Math.ceil(this.video.buffered.end(lastTimeRange) / this.video.duration * 100) });
+      this.setState({
+        buffer: Math.ceil(
+          (this.video.buffered.end(lastTimeRange) / this.video.duration) * 100,
+        ),
+      });
     }
   };
 
@@ -490,7 +551,7 @@ class Video extends PureComponent {
     this.props.onCloseVideo();
   };
 
-  getFrameRate () {
+  getFrameRate() {
     if (this.props.frameRate && isNaN(this.props.frameRate)) {
       // The frame rate is returned as a fraction string so we
       // need to convert it to a number
@@ -501,9 +562,33 @@ class Video extends PureComponent {
     return this.props.frameRate;
   }
 
-  render () {
-    const { preview, src, aspectRatio, onOpenVideo, onCloseVideo, intl, alt, lang, detailed, sensitive, editable, blurhash, autoFocus } = this.props;
-    const { currentTime, duration, volume, buffer, dragging, paused, fullscreen, hovered, revealed } = this.state;
+  render() {
+    const {
+      preview,
+      src,
+      aspectRatio,
+      onOpenVideo,
+      onCloseVideo,
+      intl,
+      alt,
+      lang,
+      detailed,
+      sensitive,
+      editable,
+      blurhash,
+      autoFocus,
+    } = this.props;
+    const {
+      currentTime,
+      duration,
+      volume,
+      buffer,
+      dragging,
+      paused,
+      fullscreen,
+      hovered,
+      revealed,
+    } = this.state;
     const progress = Math.min((currentTime / duration) * 100, 100);
     const muted = this.state.muted || volume === 0;
 
@@ -520,9 +605,19 @@ class Video extends PureComponent {
     let warning;
 
     if (sensitive) {
-      warning = <FormattedMessage id='status.sensitive_warning' defaultMessage='Sensitive content' />;
+      warning = (
+        <FormattedMessage
+          id='status.sensitive_warning'
+          defaultMessage='Sensitive content'
+        />
+      );
     } else {
-      warning = <FormattedMessage id='status.media_hidden' defaultMessage='Media hidden' />;
+      warning = (
+        <FormattedMessage
+          id='status.media_hidden'
+          defaultMessage='Media hidden'
+        />
+      );
     }
 
     // The outer wrapper is necessary to avoid reflowing the layout when going into full screen
@@ -530,7 +625,12 @@ class Video extends PureComponent {
       <div style={{ aspectRatio }}>
         <div
           role='menuitem'
-          className={classNames('video-player', { inactive: !revealed, detailed, fullscreen, editable })}
+          className={classNames('video-player', {
+            inactive: !revealed,
+            detailed,
+            fullscreen,
+            editable,
+          })}
           style={{ aspectRatio }}
           ref={this.setPlayerRef}
           onMouseEnter={this.handleMouseEnter}
@@ -547,43 +647,74 @@ class Video extends PureComponent {
             dummy={!useBlurhash}
           />
 
-          {(revealed || editable) && <video
-            ref={this.setVideoRef}
-            src={src}
-            poster={preview}
-            preload={preload}
-            role='button'
-            tabIndex={0}
-            aria-label={alt}
-            title={alt}
-            lang={lang}
-            volume={volume}
-            onClick={this.togglePlay}
-            onKeyDown={this.handleVideoKeyDown}
-            onPlay={this.handlePlay}
-            onPause={this.handlePause}
-            onLoadedData={this.handleLoadedData}
-            onProgress={this.handleProgress}
-            onVolumeChange={this.handleVolumeChange}
-            style={{ width: '100%' }}
-          />}
+          {(revealed || editable) && (
+            <video
+              ref={this.setVideoRef}
+              src={src}
+              poster={preview}
+              preload={preload}
+              role='button'
+              tabIndex={0}
+              aria-label={alt}
+              title={alt}
+              lang={lang}
+              volume={volume}
+              onClick={this.togglePlay}
+              onKeyDown={this.handleVideoKeyDown}
+              onPlay={this.handlePlay}
+              onPause={this.handlePause}
+              onLoadedData={this.handleLoadedData}
+              onProgress={this.handleProgress}
+              onVolumeChange={this.handleVolumeChange}
+              style={{ width: '100%' }}
+            />
+          )}
 
-          <div className={classNames('spoiler-button', { 'spoiler-button--hidden': revealed || editable })}>
-            <button type='button' className='spoiler-button__overlay' onClick={this.toggleReveal}>
+          <div
+            className={classNames('spoiler-button', {
+              'spoiler-button--hidden': revealed || editable,
+            })}
+          >
+            <button
+              type='button'
+              className='spoiler-button__overlay'
+              onClick={this.toggleReveal}
+            >
               <span className='spoiler-button__overlay__label'>
                 {warning}
-                <span className='spoiler-button__overlay__action'><FormattedMessage id='status.media.show' defaultMessage='Click to show' /></span>
+                <span className='spoiler-button__overlay__action'>
+                  <FormattedMessage
+                    id='status.media.show'
+                    defaultMessage='Click to show'
+                  />
+                </span>
               </span>
             </button>
           </div>
 
-          <div className={classNames('video-player__controls', { active: paused || hovered })}>
-            <div className='video-player__seek' onMouseDown={this.handleMouseDown} ref={this.setSeekRef}>
-              <div className='video-player__seek__buffer' style={{ width: `${buffer}%` }} />
-              <div className='video-player__seek__progress' style={{ width: `${progress}%` }} />
+          <div
+            className={classNames('video-player__controls', {
+              active: paused || hovered,
+            })}
+          >
+            <div
+              className='video-player__seek'
+              onMouseDown={this.handleMouseDown}
+              ref={this.setSeekRef}
+            >
+              <div
+                className='video-player__seek__buffer'
+                style={{ width: `${buffer}%` }}
+              />
+              <div
+                className='video-player__seek__progress'
+                style={{ width: `${progress}%` }}
+              />
 
               <span
-                className={classNames('video-player__seek__handle', { active: dragging })}
+                className={classNames('video-player__seek__handle', {
+                  active: dragging,
+                })}
                 tabIndex={0}
                 style={{ left: `${progress}%` }}
                 onKeyDown={this.handleVideoKeyDown}
@@ -592,11 +723,45 @@ class Video extends PureComponent {
 
             <div className='video-player__buttons-bar'>
               <div className='video-player__buttons left'>
-                <button type='button' title={intl.formatMessage(paused ? messages.play : messages.pause)} aria-label={intl.formatMessage(paused ? messages.play : messages.pause)} className='player-button' onClick={this.togglePlay} autoFocus={autoFocus}><Icon id={paused ? 'play' : 'pause'} fixedWidth /></button>
-                <button type='button' title={intl.formatMessage(muted ? messages.unmute : messages.mute)} aria-label={intl.formatMessage(muted ? messages.unmute : messages.mute)} className='player-button' onClick={this.toggleMute}><Icon id={muted ? 'volume-off' : 'volume-up'} fixedWidth /></button>
+                <button
+                  type='button'
+                  title={intl.formatMessage(
+                    paused ? messages.play : messages.pause,
+                  )}
+                  aria-label={intl.formatMessage(
+                    paused ? messages.play : messages.pause,
+                  )}
+                  className='player-button'
+                  onClick={this.togglePlay}
+                  autoFocus={autoFocus}
+                >
+                  <Icon id={paused ? 'play' : 'pause'} fixedWidth />
+                </button>
+                <button
+                  type='button'
+                  title={intl.formatMessage(
+                    muted ? messages.unmute : messages.mute,
+                  )}
+                  aria-label={intl.formatMessage(
+                    muted ? messages.unmute : messages.mute,
+                  )}
+                  className='player-button'
+                  onClick={this.toggleMute}
+                >
+                  <Icon id={muted ? 'volume-off' : 'volume-up'} fixedWidth />
+                </button>
 
-                <div className={classNames('video-player__volume', { active: this.state.hovered })} onMouseDown={this.handleVolumeMouseDown} ref={this.setVolumeRef}>
-                  <div className='video-player__volume__current' style={{ width: `${muted ? 0 : volume * 100}%` }} />
+                <div
+                  className={classNames('video-player__volume', {
+                    active: this.state.hovered,
+                  })}
+                  onMouseDown={this.handleVolumeMouseDown}
+                  ref={this.setVolumeRef}
+                >
+                  <div
+                    className='video-player__volume__current'
+                    style={{ width: `${muted ? 0 : volume * 100}%` }}
+                  />
 
                   <span
                     className={classNames('video-player__volume__handle')}
@@ -607,18 +772,70 @@ class Video extends PureComponent {
 
                 {(detailed || fullscreen) && (
                   <span className='video-player__time'>
-                    <span className='video-player__time-current'>{formatTime(Math.floor(currentTime))}</span>
+                    <span className='video-player__time-current'>
+                      {formatTime(Math.floor(currentTime))}
+                    </span>
                     <span className='video-player__time-sep'>/</span>
-                    <span className='video-player__time-total'>{formatTime(Math.floor(duration))}</span>
+                    <span className='video-player__time-total'>
+                      {formatTime(Math.floor(duration))}
+                    </span>
                   </span>
                 )}
               </div>
 
               <div className='video-player__buttons right'>
-                {(!onCloseVideo && !editable && !fullscreen && !this.props.alwaysVisible) && <button type='button' title={intl.formatMessage(messages.hide)} aria-label={intl.formatMessage(messages.hide)} className='player-button' onClick={this.toggleReveal}><Icon id='eye-slash' fixedWidth /></button>}
-                {(!fullscreen && onOpenVideo) && <button type='button' title={intl.formatMessage(messages.expand)} aria-label={intl.formatMessage(messages.expand)} className='player-button' onClick={this.handleOpenVideo}><Icon id='expand' fixedWidth /></button>}
-                {onCloseVideo && <button type='button' title={intl.formatMessage(messages.close)} aria-label={intl.formatMessage(messages.close)} className='player-button' onClick={this.handleCloseVideo}><Icon id='compress' fixedWidth /></button>}
-                <button type='button' title={intl.formatMessage(fullscreen ? messages.exit_fullscreen : messages.fullscreen)} aria-label={intl.formatMessage(fullscreen ? messages.exit_fullscreen : messages.fullscreen)} className='player-button' onClick={this.toggleFullscreen}><Icon id={fullscreen ? 'compress' : 'arrows-alt'} fixedWidth /></button>
+                {!onCloseVideo &&
+                  !editable &&
+                  !fullscreen &&
+                  !this.props.alwaysVisible && (
+                    <button
+                      type='button'
+                      title={intl.formatMessage(messages.hide)}
+                      aria-label={intl.formatMessage(messages.hide)}
+                      className='player-button'
+                      onClick={this.toggleReveal}
+                    >
+                      <Icon id='eye-slash' fixedWidth />
+                    </button>
+                  )}
+                {!fullscreen && onOpenVideo && (
+                  <button
+                    type='button'
+                    title={intl.formatMessage(messages.expand)}
+                    aria-label={intl.formatMessage(messages.expand)}
+                    className='player-button'
+                    onClick={this.handleOpenVideo}
+                  >
+                    <Icon id='expand' fixedWidth />
+                  </button>
+                )}
+                {onCloseVideo && (
+                  <button
+                    type='button'
+                    title={intl.formatMessage(messages.close)}
+                    aria-label={intl.formatMessage(messages.close)}
+                    className='player-button'
+                    onClick={this.handleCloseVideo}
+                  >
+                    <Icon id='compress' fixedWidth />
+                  </button>
+                )}
+                <button
+                  type='button'
+                  title={intl.formatMessage(
+                    fullscreen ? messages.exit_fullscreen : messages.fullscreen,
+                  )}
+                  aria-label={intl.formatMessage(
+                    fullscreen ? messages.exit_fullscreen : messages.fullscreen,
+                  )}
+                  className='player-button'
+                  onClick={this.toggleFullscreen}
+                >
+                  <Icon
+                    id={fullscreen ? 'compress' : 'arrows-alt'}
+                    fixedWidth
+                  />
+                </button>
               </div>
             </div>
           </div>
@@ -626,7 +843,6 @@ class Video extends PureComponent {
       </div>
     );
   }
-
 }
 
 export default injectIntl(Video);

--- a/app/javascript/mastodon/initial_state.js
+++ b/app/javascript/mastodon/initial_state.js
@@ -96,11 +96,15 @@ const element = document.getElementById('initial-state');
 const initialState = element?.textContent && JSON.parse(element.textContent);
 
 /** @type {string} */
-const initialPath = document.querySelector("head meta[name=initialPath]")?.getAttribute("content") ?? '';
+const initialPath =
+  document
+    .querySelector('head meta[name=initialPath]')
+    ?.getAttribute('content') ?? '';
 /** @type {boolean} */
-export const hasMultiColumnPath = initialPath === '/'
-  || initialPath === '/getting-started'
-  || initialPath.startsWith('/deck');
+export const hasMultiColumnPath =
+  initialPath === '/' ||
+  initialPath === '/getting-started' ||
+  initialPath.startsWith('/deck');
 
 /**
  * @template {keyof InitialStateMeta} K

--- a/app/javascript/mastodon/load_keyboard_extensions.js
+++ b/app/javascript/mastodon/load_keyboard_extensions.js
@@ -3,12 +3,14 @@
 // can at least log in using KaiOS devices).
 
 function importArrowKeyNavigation() {
-  return import(/* webpackChunkName: "arrow-key-navigation" */ 'arrow-key-navigation');
+  return import(
+    /* webpackChunkName: "arrow-key-navigation" */ 'arrow-key-navigation'
+  );
 }
 
 export default function loadKeyboardExtensions() {
   if (/KAIOS/.test(navigator.userAgent)) {
-    return importArrowKeyNavigation().then(arrowKeyNav => {
+    return importArrowKeyNavigation().then((arrowKeyNav) => {
       arrowKeyNav.register();
     });
   }

--- a/app/javascript/mastodon/main.jsx
+++ b/app/javascript/mastodon/main.jsx
@@ -21,7 +21,11 @@ function main() {
     root.render(<Mastodon {...props} />);
     store.dispatch(setupBrowserNotifications());
 
-    if (process.env.NODE_ENV === 'production' && me && 'serviceWorker' in navigator) {
+    if (
+      process.env.NODE_ENV === 'production' &&
+      me &&
+      'serviceWorker' in navigator
+    ) {
       const { Workbox } = await import('workbox-window');
       const wb = new Workbox('/sw.js');
       /** @type {ServiceWorkerRegistration} */
@@ -33,8 +37,14 @@ function main() {
         console.error(err);
       }
 
-      if (registration && 'Notification' in window && Notification.permission === 'granted') {
-        const registerPushNotifications = await import('mastodon/actions/push_notifications');
+      if (
+        registration &&
+        'Notification' in window &&
+        Notification.permission === 'granted'
+      ) {
+        const registerPushNotifications = await import(
+          'mastodon/actions/push_notifications'
+        );
 
         store.dispatch(registerPushNotifications.register());
       }

--- a/app/javascript/mastodon/performance.js
+++ b/app/javascript/mastodon/performance.js
@@ -6,7 +6,10 @@
 import * as marky from 'marky';
 
 if (process.env.NODE_ENV === 'development') {
-  if (typeof performance !== 'undefined' && performance.setResourceTimingBufferSize) {
+  if (
+    typeof performance !== 'undefined' &&
+    performance.setResourceTimingBufferSize
+  ) {
     // Increase Firefox's performance entry limit; otherwise it's capped to 150.
     // See: https://bugzilla.mozilla.org/show_bug.cgi?id=1331135
     performance.setResourceTimingBufferSize(Infinity);

--- a/app/javascript/mastodon/reducers/accounts.js
+++ b/app/javascript/mastodon/reducers/accounts.js
@@ -12,13 +12,14 @@ const normalizeAccount = (state, account) => {
   delete account.following_count;
   delete account.statuses_count;
 
-  account.hidden = state.getIn([account.id, 'hidden']) === false ? false : account.limited;
+  account.hidden =
+    state.getIn([account.id, 'hidden']) === false ? false : account.limited;
 
   return state.set(account.id, fromJS(account));
 };
 
 const normalizeAccounts = (state, accounts) => {
-  accounts.forEach(account => {
+  accounts.forEach((account) => {
     state = normalizeAccount(state, account);
   });
 
@@ -26,14 +27,14 @@ const normalizeAccounts = (state, accounts) => {
 };
 
 export default function accounts(state = initialState, action) {
-  switch(action.type) {
-  case ACCOUNT_IMPORT:
-    return normalizeAccount(state, action.account);
-  case ACCOUNTS_IMPORT:
-    return normalizeAccounts(state, action.accounts);
-  case ACCOUNT_REVEAL:
-    return state.setIn([action.id, 'hidden'], false);
-  default:
-    return state;
+  switch (action.type) {
+    case ACCOUNT_IMPORT:
+      return normalizeAccount(state, action.account);
+    case ACCOUNTS_IMPORT:
+      return normalizeAccounts(state, action.accounts);
+    case ACCOUNT_REVEAL:
+      return state.setIn([action.id, 'hidden'], false);
+    default:
+      return state;
   }
 }

--- a/app/javascript/mastodon/reducers/accounts_counters.js
+++ b/app/javascript/mastodon/reducers/accounts_counters.js
@@ -8,14 +8,18 @@ import {
 } from '../actions/accounts';
 import { ACCOUNT_IMPORT, ACCOUNTS_IMPORT } from '../actions/importer';
 
-const normalizeAccount = (state, account) => state.set(account.id, fromJS({
-  followers_count: account.followers_count,
-  following_count: account.following_count,
-  statuses_count: account.statuses_count,
-}));
+const normalizeAccount = (state, account) =>
+  state.set(
+    account.id,
+    fromJS({
+      followers_count: account.followers_count,
+      following_count: account.following_count,
+      statuses_count: account.statuses_count,
+    }),
+  );
 
 const normalizeAccounts = (state, accounts) => {
-  accounts.forEach(account => {
+  accounts.forEach((account) => {
     state = normalizeAccount(state, account);
   });
 
@@ -23,27 +27,30 @@ const normalizeAccounts = (state, accounts) => {
 };
 
 const incrementFollowers = (state, accountId) =>
-  state.updateIn([accountId, 'followers_count'], num => num + 1)
-    .updateIn([me, 'following_count'], num => num + 1);
+  state
+    .updateIn([accountId, 'followers_count'], (num) => num + 1)
+    .updateIn([me, 'following_count'], (num) => num + 1);
 
 const decrementFollowers = (state, accountId) =>
-  state.updateIn([accountId, 'followers_count'], num => Math.max(0, num - 1))
-    .updateIn([me, 'following_count'], num => Math.max(0, num - 1));
+  state
+    .updateIn([accountId, 'followers_count'], (num) => Math.max(0, num - 1))
+    .updateIn([me, 'following_count'], (num) => Math.max(0, num - 1));
 
 const initialState = ImmutableMap();
 
 export default function accountsCounters(state = initialState, action) {
-  switch(action.type) {
-  case ACCOUNT_IMPORT:
-    return normalizeAccount(state, action.account);
-  case ACCOUNTS_IMPORT:
-    return normalizeAccounts(state, action.accounts);
-  case ACCOUNT_FOLLOW_SUCCESS:
-    return action.alreadyFollowing ? state :
-      incrementFollowers(state, action.relationship.id);
-  case ACCOUNT_UNFOLLOW_SUCCESS:
-    return decrementFollowers(state, action.relationship.id);
-  default:
-    return state;
+  switch (action.type) {
+    case ACCOUNT_IMPORT:
+      return normalizeAccount(state, action.account);
+    case ACCOUNTS_IMPORT:
+      return normalizeAccounts(state, action.accounts);
+    case ACCOUNT_FOLLOW_SUCCESS:
+      return action.alreadyFollowing
+        ? state
+        : incrementFollowers(state, action.relationship.id);
+    case ACCOUNT_UNFOLLOW_SUCCESS:
+      return decrementFollowers(state, action.relationship.id);
+    default:
+      return state;
   }
 }

--- a/app/javascript/mastodon/reducers/accounts_map.js
+++ b/app/javascript/mastodon/reducers/accounts_map.js
@@ -3,19 +3,28 @@ import { Map as ImmutableMap } from 'immutable';
 import { ACCOUNT_LOOKUP_FAIL } from '../actions/accounts';
 import { ACCOUNT_IMPORT, ACCOUNTS_IMPORT } from '../actions/importer';
 
-export const normalizeForLookup = str => str.toLowerCase();
+export const normalizeForLookup = (str) => str.toLowerCase();
 
 const initialState = ImmutableMap();
 
 export default function accountsMap(state = initialState, action) {
-  switch(action.type) {
-  case ACCOUNT_LOOKUP_FAIL:
-    return action.error?.response?.status === 404 ? state.set(normalizeForLookup(action.acct), null) : state;
-  case ACCOUNT_IMPORT:
-    return state.set(normalizeForLookup(action.account.acct), action.account.id);
-  case ACCOUNTS_IMPORT:
-    return state.withMutations(map => action.accounts.forEach(account => map.set(normalizeForLookup(account.acct), account.id)));
-  default:
-    return state;
+  switch (action.type) {
+    case ACCOUNT_LOOKUP_FAIL:
+      return action.error?.response?.status === 404
+        ? state.set(normalizeForLookup(action.acct), null)
+        : state;
+    case ACCOUNT_IMPORT:
+      return state.set(
+        normalizeForLookup(action.account.acct),
+        action.account.id,
+      );
+    case ACCOUNTS_IMPORT:
+      return state.withMutations((map) =>
+        action.accounts.forEach((account) =>
+          map.set(normalizeForLookup(account.acct), account.id),
+        ),
+      );
+    default:
+      return state;
   }
 }

--- a/app/javascript/mastodon/reducers/alerts.js
+++ b/app/javascript/mastodon/reducers/alerts.js
@@ -1,10 +1,6 @@
 import { List as ImmutableList } from 'immutable';
 
-import {
-  ALERT_SHOW,
-  ALERT_DISMISS,
-  ALERT_CLEAR,
-} from '../actions/alerts';
+import { ALERT_SHOW, ALERT_DISMISS, ALERT_CLEAR } from '../actions/alerts';
 
 const initialState = ImmutableList([]);
 
@@ -17,14 +13,14 @@ const addAlert = (state, alert) =>
   });
 
 export default function alerts(state = initialState, action) {
-  switch(action.type) {
-  case ALERT_SHOW:
-    return addAlert(state, action.alert);
-  case ALERT_DISMISS:
-    return state.filterNot(item => item.key === action.alert.key);
-  case ALERT_CLEAR:
-    return state.clear();
-  default:
-    return state;
+  switch (action.type) {
+    case ALERT_SHOW:
+      return addAlert(state, action.alert);
+    case ALERT_DISMISS:
+      return state.filterNot((item) => item.key === action.alert.key);
+    case ALERT_CLEAR:
+      return state.clear();
+    default:
+      return state;
   }
 }

--- a/app/javascript/mastodon/reducers/announcements.js
+++ b/app/javascript/mastodon/reducers/announcements.js
@@ -21,83 +21,104 @@ const initialState = ImmutableMap({
   show: false,
 });
 
-const updateReaction = (state, id, name, updater) => state.update('items', list => list.map(announcement => {
-  if (announcement.get('id') === id) {
-    return announcement.update('reactions', reactions => {
-      const idx = reactions.findIndex(reaction => reaction.get('name') === name);
+const updateReaction = (state, id, name, updater) =>
+  state.update('items', (list) =>
+    list.map((announcement) => {
+      if (announcement.get('id') === id) {
+        return announcement.update('reactions', (reactions) => {
+          const idx = reactions.findIndex(
+            (reaction) => reaction.get('name') === name,
+          );
 
-      if (idx > -1) {
-        return reactions.update(idx, reaction => updater(reaction));
+          if (idx > -1) {
+            return reactions.update(idx, (reaction) => updater(reaction));
+          }
+
+          return reactions.push(updater(fromJS({ name, count: 0 })));
+        });
       }
 
-      return reactions.push(updater(fromJS({ name, count: 0 })));
-    });
-  }
+      return announcement;
+    }),
+  );
 
-  return announcement;
-}));
+const updateReactionCount = (state, reaction) =>
+  updateReaction(state, reaction.announcement_id, reaction.name, (x) =>
+    x.set('count', reaction.count),
+  );
 
-const updateReactionCount = (state, reaction) => updateReaction(state, reaction.announcement_id, reaction.name, x => x.set('count', reaction.count));
+const addReaction = (state, id, name) =>
+  updateReaction(state, id, name, (x) =>
+    x.set('me', true).update('count', (y) => y + 1),
+  );
 
-const addReaction = (state, id, name) => updateReaction(state, id, name, x => x.set('me', true).update('count', y => y + 1));
+const removeReaction = (state, id, name) =>
+  updateReaction(state, id, name, (x) =>
+    x.set('me', false).update('count', (y) => y - 1),
+  );
 
-const removeReaction = (state, id, name) => updateReaction(state, id, name, x => x.set('me', false).update('count', y => y - 1));
-
-const sortAnnouncements = list => list.sortBy(x => x.get('starts_at') || x.get('published_at'));
+const sortAnnouncements = (list) =>
+  list.sortBy((x) => x.get('starts_at') || x.get('published_at'));
 
 const updateAnnouncement = (state, announcement) => {
-  const idx = state.get('items').findIndex(x => x.get('id') === announcement.get('id'));
+  const idx = state
+    .get('items')
+    .findIndex((x) => x.get('id') === announcement.get('id'));
 
   if (idx > -1) {
     // Deep merge is used because announcements from the streaming API do not contain
     // personalized data about which reactions have been selected by the given user,
     // and that is information we want to preserve
-    return state.update('items', list => sortAnnouncements(list.update(idx, x => x.mergeDeep(announcement))));
+    return state.update('items', (list) =>
+      sortAnnouncements(list.update(idx, (x) => x.mergeDeep(announcement))),
+    );
   }
 
-  return state.update('items', list => sortAnnouncements(list.unshift(announcement)));
+  return state.update('items', (list) =>
+    sortAnnouncements(list.unshift(announcement)),
+  );
 };
 
 export default function announcementsReducer(state = initialState, action) {
-  switch(action.type) {
-  case ANNOUNCEMENTS_TOGGLE_SHOW:
-    return state.withMutations(map => {
-      map.set('show', !map.get('show'));
-    });
-  case ANNOUNCEMENTS_FETCH_REQUEST:
-    return state.set('isLoading', true);
-  case ANNOUNCEMENTS_FETCH_SUCCESS:
-    return state.withMutations(map => {
-      const items = fromJS(action.announcements);
+  switch (action.type) {
+    case ANNOUNCEMENTS_TOGGLE_SHOW:
+      return state.withMutations((map) => {
+        map.set('show', !map.get('show'));
+      });
+    case ANNOUNCEMENTS_FETCH_REQUEST:
+      return state.set('isLoading', true);
+    case ANNOUNCEMENTS_FETCH_SUCCESS:
+      return state.withMutations((map) => {
+        const items = fromJS(action.announcements);
 
-      map.set('items', items);
-      map.set('isLoading', false);
-    });
-  case ANNOUNCEMENTS_FETCH_FAIL:
-    return state.set('isLoading', false);
-  case ANNOUNCEMENTS_UPDATE:
-    return updateAnnouncement(state, fromJS(action.announcement));
-  case ANNOUNCEMENTS_REACTION_UPDATE:
-    return updateReactionCount(state, action.reaction);
-  case ANNOUNCEMENTS_REACTION_ADD_REQUEST:
-  case ANNOUNCEMENTS_REACTION_REMOVE_FAIL:
-    return addReaction(state, action.id, action.name);
-  case ANNOUNCEMENTS_REACTION_REMOVE_REQUEST:
-  case ANNOUNCEMENTS_REACTION_ADD_FAIL:
-    return removeReaction(state, action.id, action.name);
-  case ANNOUNCEMENTS_DISMISS_SUCCESS:
-    return updateAnnouncement(state, fromJS({ 'id': action.id, 'read': true }));
-  case ANNOUNCEMENTS_DELETE:
-    return state.update('items', list => {
-      const idx = list.findIndex(x => x.get('id') === action.id);
+        map.set('items', items);
+        map.set('isLoading', false);
+      });
+    case ANNOUNCEMENTS_FETCH_FAIL:
+      return state.set('isLoading', false);
+    case ANNOUNCEMENTS_UPDATE:
+      return updateAnnouncement(state, fromJS(action.announcement));
+    case ANNOUNCEMENTS_REACTION_UPDATE:
+      return updateReactionCount(state, action.reaction);
+    case ANNOUNCEMENTS_REACTION_ADD_REQUEST:
+    case ANNOUNCEMENTS_REACTION_REMOVE_FAIL:
+      return addReaction(state, action.id, action.name);
+    case ANNOUNCEMENTS_REACTION_REMOVE_REQUEST:
+    case ANNOUNCEMENTS_REACTION_ADD_FAIL:
+      return removeReaction(state, action.id, action.name);
+    case ANNOUNCEMENTS_DISMISS_SUCCESS:
+      return updateAnnouncement(state, fromJS({ id: action.id, read: true }));
+    case ANNOUNCEMENTS_DELETE:
+      return state.update('items', (list) => {
+        const idx = list.findIndex((x) => x.get('id') === action.id);
 
-      if (idx > -1) {
-        return list.delete(idx);
-      }
+        if (idx > -1) {
+          return list.delete(idx);
+        }
 
-      return list;
-    });
-  default:
-    return state;
+        return list;
+      });
+    default:
+      return state;
   }
 }

--- a/app/javascript/mastodon/reducers/blocks.js
+++ b/app/javascript/mastodon/reducers/blocks.js
@@ -1,8 +1,6 @@
 import Immutable from 'immutable';
 
-import {
-  BLOCKS_INIT_MODAL,
-} from '../actions/blocks';
+import { BLOCKS_INIT_MODAL } from '../actions/blocks';
 
 const initialState = Immutable.Map({
   new: Immutable.Map({
@@ -12,11 +10,11 @@ const initialState = Immutable.Map({
 
 export default function mutes(state = initialState, action) {
   switch (action.type) {
-  case BLOCKS_INIT_MODAL:
-    return state.withMutations((state) => {
-      state.setIn(['new', 'account_id'], action.account.get('id'));
-    });
-  default:
-    return state;
+    case BLOCKS_INIT_MODAL:
+      return state.withMutations((state) => {
+        state.setIn(['new', 'account_id'], action.account.get('id'));
+      });
+    default:
+      return state;
   }
 }

--- a/app/javascript/mastodon/reducers/boosts.js
+++ b/app/javascript/mastodon/reducers/boosts.js
@@ -13,13 +13,13 @@ const initialState = Immutable.Map({
 
 export default function mutes(state = initialState, action) {
   switch (action.type) {
-  case BOOSTS_INIT_MODAL:
-    return state.withMutations((state) => {
-      state.setIn(['new', 'privacy'], action.privacy);
-    });
-  case BOOSTS_CHANGE_PRIVACY:
-    return state.setIn(['new', 'privacy'], action.privacy);
-  default:
-    return state;
+    case BOOSTS_INIT_MODAL:
+      return state.withMutations((state) => {
+        state.setIn(['new', 'privacy'], action.privacy);
+      });
+    case BOOSTS_CHANGE_PRIVACY:
+      return state.setIn(['new', 'privacy'], action.privacy);
+    default:
+      return state;
   }
 }

--- a/app/javascript/mastodon/reducers/compose.js
+++ b/app/javascript/mastodon/reducers/compose.js
@@ -1,4 +1,9 @@
-import { Map as ImmutableMap, List as ImmutableList, OrderedSet as ImmutableOrderedSet, fromJS } from 'immutable';
+import {
+  Map as ImmutableMap,
+  List as ImmutableList,
+  OrderedSet as ImmutableOrderedSet,
+  fromJS,
+} from 'immutable';
 
 import {
   COMPOSE_MOUNT,
@@ -84,7 +89,7 @@ const initialState = ImmutableMap({
   default_privacy: 'public',
   default_sensitive: false,
   default_language: 'en',
-  resetFileKey: Math.floor((Math.random() * 0x10000)),
+  resetFileKey: Math.floor(Math.random() * 0x10000),
   idempotencyKey: null,
   tagHistory: ImmutableList(),
   media_modal: ImmutableMap({
@@ -109,11 +114,18 @@ function statusToTextMentions(state, status) {
     set = set.add(`@${status.getIn(['account', 'acct'])} `);
   }
 
-  return set.union(status.get('mentions').filterNot(mention => mention.get('id') === me).map(mention => `@${mention.get('acct')} `)).join('');
+  return set
+    .union(
+      status
+        .get('mentions')
+        .filterNot((mention) => mention.get('id') === me)
+        .map((mention) => `@${mention.get('acct')} `),
+    )
+    .join('');
 }
 
 function clearAll(state) {
-  return state.withMutations(map => {
+  return state.withMutations((map) => {
     map.set('id', null);
     map.set('text', '');
     map.set('spoiler', false);
@@ -124,7 +136,7 @@ function clearAll(state) {
     map.set('privacy', state.get('default_privacy'));
     map.set('sensitive', state.get('default_sensitive'));
     map.set('language', state.get('default_language'));
-    map.update('media_attachments', list => list.clear());
+    map.update('media_attachments', (list) => list.clear());
     map.set('poll', null);
     map.set('idempotencyKey', uuid());
   });
@@ -133,18 +145,23 @@ function clearAll(state) {
 function appendMedia(state, media, file) {
   const prevSize = state.get('media_attachments').size;
 
-  return state.withMutations(map => {
+  return state.withMutations((map) => {
     if (media.get('type') === 'image') {
       media = media.set('file', file);
     }
-    map.update('media_attachments', list => list.push(media.set('unattached', true)));
+    map.update('media_attachments', (list) =>
+      list.push(media.set('unattached', true)),
+    );
     map.set('is_uploading', false);
     map.set('is_processing', false);
-    map.set('resetFileKey', Math.floor((Math.random() * 0x10000)));
+    map.set('resetFileKey', Math.floor(Math.random() * 0x10000));
     map.set('idempotencyKey', uuid());
-    map.update('pending_media_attachments', n => n - 1);
+    map.update('pending_media_attachments', (n) => n - 1);
 
-    if (prevSize === 0 && (state.get('default_sensitive') || state.get('spoiler'))) {
+    if (
+      prevSize === 0 &&
+      (state.get('default_sensitive') || state.get('spoiler'))
+    ) {
       map.set('sensitive', true);
     }
   });
@@ -153,8 +170,10 @@ function appendMedia(state, media, file) {
 function removeMedia(state, mediaId) {
   const prevSize = state.get('media_attachments').size;
 
-  return state.withMutations(map => {
-    map.update('media_attachments', list => list.filterNot(item => item.get('id') === mediaId));
+  return state.withMutations((map) => {
+    map.update('media_attachments', (list) =>
+      list.filterNot((item) => item.get('id') === mediaId),
+    );
     map.set('idempotencyKey', uuid());
 
     if (prevSize === 1) {
@@ -164,8 +183,14 @@ function removeMedia(state, mediaId) {
 }
 
 const insertSuggestion = (state, position, token, completion, path) => {
-  return state.withMutations(map => {
-    map.updateIn(path, oldText => `${oldText.slice(0, position)}${completion} ${oldText.slice(position + token.length)}`);
+  return state.withMutations((map) => {
+    map.updateIn(
+      path,
+      (oldText) =>
+        `${oldText.slice(0, position)}${completion} ${oldText.slice(
+          position + token.length,
+        )}`,
+    );
     map.set('suggestion_token', null);
     map.set('suggestions', ImmutableList());
     if (path.length === 1 && path[0] === 'text') {
@@ -177,8 +202,14 @@ const insertSuggestion = (state, position, token, completion, path) => {
 };
 
 const ignoreSuggestion = (state, position, token, completion, path) => {
-  return state.withMutations(map => {
-    map.updateIn(path, oldText => `${oldText.slice(0, position + token.length)} ${oldText.slice(position + token.length)}`);
+  return state.withMutations((map) => {
+    map.updateIn(
+      path,
+      (oldText) =>
+        `${oldText.slice(0, position + token.length)} ${oldText.slice(
+          position + token.length,
+        )}`,
+    );
     map.set('suggestion_token', null);
     map.set('suggestions', ImmutableList());
     map.set('focusDate', new Date());
@@ -188,9 +219,14 @@ const ignoreSuggestion = (state, position, token, completion, path) => {
 };
 
 const sortHashtagsByUse = (state, tags) => {
-  const personalHistory = state.get('tagHistory').map(tag => tag.toLowerCase());
+  const personalHistory = state
+    .get('tagHistory')
+    .map((tag) => tag.toLowerCase());
 
-  const tagsWithLowercase = tags.map(t => ({ ...t, lowerName: t.name.toLowerCase() }));
+  const tagsWithLowercase = tags.map((t) => ({
+    ...t,
+    lowerName: t.name.toLowerCase(),
+  }));
   const sorted = tagsWithLowercase.sort((a, b) => {
     const usedA = personalHistory.includes(a.lowerName);
     const usedB = personalHistory.includes(b.lowerName);
@@ -203,7 +239,7 @@ const sortHashtagsByUse = (state, tags) => {
       return 1;
     }
   });
-  sorted.forEach(tag => delete tag.lowerName);
+  sorted.forEach((tag) => delete tag.lowerName);
   return sorted;
 };
 
@@ -228,7 +264,9 @@ const hydrate = (state, hydratedState) => {
   state = clearAll(state.merge(hydratedState));
 
   if (hydratedState.get('text')) {
-    state = state.set('text', hydratedState.get('text')).set('focusDate', new Date());
+    state = state
+      .set('text', hydratedState.get('text'))
+      .set('focusDate', new Date());
   }
 
   return state;
@@ -236,27 +274,49 @@ const hydrate = (state, hydratedState) => {
 
 const domParser = new DOMParser();
 
-const expandMentions = status => {
-  const fragment = domParser.parseFromString(status.get('content'), 'text/html').documentElement;
+const expandMentions = (status) => {
+  const fragment = domParser.parseFromString(
+    status.get('content'),
+    'text/html',
+  ).documentElement;
 
-  status.get('mentions').forEach(mention => {
-    fragment.querySelector(`a[href="${mention.get('url')}"]`).textContent = `@${mention.get('acct')}`;
+  status.get('mentions').forEach((mention) => {
+    fragment.querySelector(
+      `a[href="${mention.get('url')}"]`,
+    ).textContent = `@${mention.get('acct')}`;
   });
 
   return fragment.innerHTML;
 };
 
-const expiresInFromExpiresAt = expires_at => {
+const expiresInFromExpiresAt = (expires_at) => {
   if (!expires_at) return 24 * 3600;
   const delta = (new Date(expires_at).getTime() - Date.now()) / 1000;
-  return [300, 1800, 3600, 21600, 86400, 259200, 604800].find(expires_in => expires_in >= delta) || 24 * 3600;
+  return (
+    [300, 1800, 3600, 21600, 86400, 259200, 604800].find(
+      (expires_in) => expires_in >= delta,
+    ) || 24 * 3600
+  );
 };
 
 const mergeLocalHashtagResults = (suggestions, prefix, tagHistory) => {
   prefix = prefix.toLowerCase();
   if (suggestions.length < 4) {
-    const localTags = tagHistory.filter(tag => tag.toLowerCase().startsWith(prefix) && !suggestions.some(suggestion => suggestion.type === 'hashtag' && suggestion.name.toLowerCase() === tag.toLowerCase()));
-    return suggestions.concat(localTags.slice(0, 4 - suggestions.length).toJS().map(tag => ({ type: 'hashtag', name: tag })));
+    const localTags = tagHistory.filter(
+      (tag) =>
+        tag.toLowerCase().startsWith(prefix) &&
+        !suggestions.some(
+          (suggestion) =>
+            suggestion.type === 'hashtag' &&
+            suggestion.name.toLowerCase() === tag.toLowerCase(),
+        ),
+    );
+    return suggestions.concat(
+      localTags
+        .slice(0, 4 - suggestions.length)
+        .toJS()
+        .map((tag) => ({ type: 'hashtag', name: tag })),
+    );
   } else {
     return suggestions;
   }
@@ -264,11 +324,18 @@ const mergeLocalHashtagResults = (suggestions, prefix, tagHistory) => {
 
 const normalizeSuggestions = (state, { accounts, emojis, tags, token }) => {
   if (accounts) {
-    return accounts.map(item => ({ id: item.id, type: 'account' }));
+    return accounts.map((item) => ({ id: item.id, type: 'account' }));
   } else if (emojis) {
-    return emojis.map(item => ({ ...item, type: 'emoji' }));
+    return emojis.map((item) => ({ ...item, type: 'emoji' }));
   } else {
-    return mergeLocalHashtagResults(sortHashtagsByUse(state, tags.map(item => ({ ...item, type: 'hashtag' }))), token.slice(1), state.get('tagHistory'));
+    return mergeLocalHashtagResults(
+      sortHashtagsByUse(
+        state,
+        tags.map((item) => ({ ...item, type: 'hashtag' })),
+      ),
+      token.slice(1),
+      state.get('tagHistory'),
+    );
   }
 };
 
@@ -277,260 +344,360 @@ const updateSuggestionTags = (state, token) => {
 
   const suggestions = state.get('suggestions').toJS();
   return state.merge({
-    suggestions: ImmutableList(mergeLocalHashtagResults(suggestions, prefix, state.get('tagHistory'))),
+    suggestions: ImmutableList(
+      mergeLocalHashtagResults(suggestions, prefix, state.get('tagHistory')),
+    ),
     suggestion_token: token,
   });
 };
 
 export default function compose(state = initialState, action) {
-  switch(action.type) {
-  case STORE_HYDRATE:
-    return hydrate(state, action.state.get('compose'));
-  case COMPOSE_MOUNT:
-    return state.set('mounted', state.get('mounted') + 1);
-  case COMPOSE_UNMOUNT:
-    return state
-      .set('mounted', Math.max(state.get('mounted') - 1, 0))
-      .set('is_composing', false);
-  case COMPOSE_SENSITIVITY_CHANGE:
-    return state.withMutations(map => {
-      if (!state.get('spoiler')) {
-        map.set('sensitive', !state.get('sensitive'));
-      }
+  switch (action.type) {
+    case STORE_HYDRATE:
+      return hydrate(state, action.state.get('compose'));
+    case COMPOSE_MOUNT:
+      return state.set('mounted', state.get('mounted') + 1);
+    case COMPOSE_UNMOUNT:
+      return state
+        .set('mounted', Math.max(state.get('mounted') - 1, 0))
+        .set('is_composing', false);
+    case COMPOSE_SENSITIVITY_CHANGE:
+      return state.withMutations((map) => {
+        if (!state.get('spoiler')) {
+          map.set('sensitive', !state.get('sensitive'));
+        }
 
-      map.set('idempotencyKey', uuid());
-    });
-  case COMPOSE_SPOILERNESS_CHANGE:
-    return state.withMutations(map => {
-      map.set('spoiler', !state.get('spoiler'));
-      map.set('idempotencyKey', uuid());
+        map.set('idempotencyKey', uuid());
+      });
+    case COMPOSE_SPOILERNESS_CHANGE:
+      return state.withMutations((map) => {
+        map.set('spoiler', !state.get('spoiler'));
+        map.set('idempotencyKey', uuid());
 
-      if (!state.get('sensitive') && state.get('media_attachments').size >= 1) {
-        map.set('sensitive', true);
-      }
-    });
-  case COMPOSE_SPOILER_TEXT_CHANGE:
-    if (!state.get('spoiler')) return state;
-    return state
-      .set('spoiler_text', action.text)
-      .set('idempotencyKey', uuid());
-  case COMPOSE_VISIBILITY_CHANGE:
-    return state
-      .set('privacy', action.value)
-      .set('idempotencyKey', uuid());
-  case COMPOSE_CHANGE:
-    return state
-      .set('text', action.text)
-      .set('idempotencyKey', uuid());
-  case COMPOSE_COMPOSING_CHANGE:
-    return state.set('is_composing', action.value);
-  case COMPOSE_REPLY:
-    return state.withMutations(map => {
-      map.set('id', null);
-      map.set('in_reply_to', action.status.get('id'));
-      map.set('text', statusToTextMentions(state, action.status));
-      map.set('privacy', privacyPreference(action.status.get('visibility'), state.get('default_privacy')));
-      map.set('focusDate', new Date());
-      map.set('caretPosition', null);
-      map.set('preselectDate', new Date());
-      map.set('idempotencyKey', uuid());
-
-      map.update('media_attachments', list => list.filter(media => media.get('unattached')));
-
-      if (action.status.get('language') && !action.status.has('translation')) {
-        map.set('language', action.status.get('language'));
-      } else {
-        map.set('language', state.get('default_language'));
-      }
-
-      if (action.status.get('spoiler_text').length > 0) {
-        map.set('spoiler', true);
-        map.set('spoiler_text', action.status.get('spoiler_text'));
-
-        if (map.get('media_attachments').size >= 1) {
+        if (
+          !state.get('sensitive') &&
+          state.get('media_attachments').size >= 1
+        ) {
           map.set('sensitive', true);
         }
-      } else {
-        map.set('spoiler', false);
-        map.set('spoiler_text', '');
-      }
-    });
-  case COMPOSE_SUBMIT_REQUEST:
-    return state.set('is_submitting', true);
-  case COMPOSE_UPLOAD_CHANGE_REQUEST:
-    return state.set('is_changing_upload', true);
-  case COMPOSE_REPLY_CANCEL:
-  case COMPOSE_RESET:
-  case COMPOSE_SUBMIT_SUCCESS:
-    return clearAll(state);
-  case COMPOSE_SUBMIT_FAIL:
-    return state.set('is_submitting', false);
-  case COMPOSE_UPLOAD_CHANGE_FAIL:
-    return state.set('is_changing_upload', false);
-  case COMPOSE_UPLOAD_REQUEST:
-    return state.set('is_uploading', true).update('pending_media_attachments', n => n + 1);
-  case COMPOSE_UPLOAD_PROCESSING:
-    return state.set('is_processing', true);
-  case COMPOSE_UPLOAD_SUCCESS:
-    return appendMedia(state, fromJS(action.media), action.file);
-  case COMPOSE_UPLOAD_FAIL:
-    return state.set('is_uploading', false).set('is_processing', false).update('pending_media_attachments', n => n - 1);
-  case COMPOSE_UPLOAD_UNDO:
-    return removeMedia(state, action.media_id);
-  case COMPOSE_UPLOAD_PROGRESS:
-    return state.set('progress', Math.round((action.loaded / action.total) * 100));
-  case THUMBNAIL_UPLOAD_REQUEST:
-    return state.set('isUploadingThumbnail', true);
-  case THUMBNAIL_UPLOAD_PROGRESS:
-    return state.set('thumbnailProgress', Math.round((action.loaded / action.total) * 100));
-  case THUMBNAIL_UPLOAD_FAIL:
-    return state.set('isUploadingThumbnail', false);
-  case THUMBNAIL_UPLOAD_SUCCESS:
-    return state
-      .set('isUploadingThumbnail', false)
-      .update('media_attachments', list => list.map(item => {
-        if (item.get('id') === action.media.id) {
-          return fromJS(action.media);
+      });
+    case COMPOSE_SPOILER_TEXT_CHANGE:
+      if (!state.get('spoiler')) return state;
+      return state
+        .set('spoiler_text', action.text)
+        .set('idempotencyKey', uuid());
+    case COMPOSE_VISIBILITY_CHANGE:
+      return state.set('privacy', action.value).set('idempotencyKey', uuid());
+    case COMPOSE_CHANGE:
+      return state.set('text', action.text).set('idempotencyKey', uuid());
+    case COMPOSE_COMPOSING_CHANGE:
+      return state.set('is_composing', action.value);
+    case COMPOSE_REPLY:
+      return state.withMutations((map) => {
+        map.set('id', null);
+        map.set('in_reply_to', action.status.get('id'));
+        map.set('text', statusToTextMentions(state, action.status));
+        map.set(
+          'privacy',
+          privacyPreference(
+            action.status.get('visibility'),
+            state.get('default_privacy'),
+          ),
+        );
+        map.set('focusDate', new Date());
+        map.set('caretPosition', null);
+        map.set('preselectDate', new Date());
+        map.set('idempotencyKey', uuid());
+
+        map.update('media_attachments', (list) =>
+          list.filter((media) => media.get('unattached')),
+        );
+
+        if (
+          action.status.get('language') &&
+          !action.status.has('translation')
+        ) {
+          map.set('language', action.status.get('language'));
+        } else {
+          map.set('language', state.get('default_language'));
         }
 
-        return item;
-      }));
-  case INIT_MEDIA_EDIT_MODAL:
-    const media =  state.get('media_attachments').find(item => item.get('id') === action.id);
-    return state.set('media_modal', ImmutableMap({
-      id: action.id,
-      description: media.get('description') || '',
-      focusX: media.getIn(['meta', 'focus', 'x'], 0),
-      focusY: media.getIn(['meta', 'focus', 'y'], 0),
-      dirty: false,
-    }));
-  case COMPOSE_CHANGE_MEDIA_DESCRIPTION:
-    return state.setIn(['media_modal', 'description'], action.description).setIn(['media_modal', 'dirty'], true);
-  case COMPOSE_CHANGE_MEDIA_FOCUS:
-    return state.setIn(['media_modal', 'focusX'], action.focusX).setIn(['media_modal', 'focusY'], action.focusY).setIn(['media_modal', 'dirty'], true);
-  case COMPOSE_MENTION:
-    return state.withMutations(map => {
-      map.update('text', text => [text.trim(), `@${action.account.get('acct')} `].filter((str) => str.length !== 0).join(' '));
-      map.set('focusDate', new Date());
-      map.set('caretPosition', null);
-      map.set('idempotencyKey', uuid());
-    });
-  case COMPOSE_DIRECT:
-    return state.withMutations(map => {
-      map.update('text', text => [text.trim(), `@${action.account.get('acct')} `].filter((str) => str.length !== 0).join(' '));
-      map.set('privacy', 'direct');
-      map.set('focusDate', new Date());
-      map.set('caretPosition', null);
-      map.set('idempotencyKey', uuid());
-    });
-  case COMPOSE_SUGGESTIONS_CLEAR:
-    return state.update('suggestions', ImmutableList(), list => list.clear()).set('suggestion_token', null);
-  case COMPOSE_SUGGESTIONS_READY:
-    return state.set('suggestions', ImmutableList(normalizeSuggestions(state, action))).set('suggestion_token', action.token);
-  case COMPOSE_SUGGESTION_SELECT:
-    return insertSuggestion(state, action.position, action.token, action.completion, action.path);
-  case COMPOSE_SUGGESTION_IGNORE:
-    return ignoreSuggestion(state, action.position, action.token, action.completion, action.path);
-  case COMPOSE_SUGGESTION_TAGS_UPDATE:
-    return updateSuggestionTags(state, action.token);
-  case COMPOSE_TAG_HISTORY_UPDATE:
-    return state.set('tagHistory', fromJS(action.tags));
-  case TIMELINE_DELETE:
-    if (action.id === state.get('in_reply_to')) {
-      return state.set('in_reply_to', null);
-    } else if (action.id === state.get('id')) {
-      return state.set('id', null);
-    } else {
+        if (action.status.get('spoiler_text').length > 0) {
+          map.set('spoiler', true);
+          map.set('spoiler_text', action.status.get('spoiler_text'));
+
+          if (map.get('media_attachments').size >= 1) {
+            map.set('sensitive', true);
+          }
+        } else {
+          map.set('spoiler', false);
+          map.set('spoiler_text', '');
+        }
+      });
+    case COMPOSE_SUBMIT_REQUEST:
+      return state.set('is_submitting', true);
+    case COMPOSE_UPLOAD_CHANGE_REQUEST:
+      return state.set('is_changing_upload', true);
+    case COMPOSE_REPLY_CANCEL:
+    case COMPOSE_RESET:
+    case COMPOSE_SUBMIT_SUCCESS:
+      return clearAll(state);
+    case COMPOSE_SUBMIT_FAIL:
+      return state.set('is_submitting', false);
+    case COMPOSE_UPLOAD_CHANGE_FAIL:
+      return state.set('is_changing_upload', false);
+    case COMPOSE_UPLOAD_REQUEST:
+      return state
+        .set('is_uploading', true)
+        .update('pending_media_attachments', (n) => n + 1);
+    case COMPOSE_UPLOAD_PROCESSING:
+      return state.set('is_processing', true);
+    case COMPOSE_UPLOAD_SUCCESS:
+      return appendMedia(state, fromJS(action.media), action.file);
+    case COMPOSE_UPLOAD_FAIL:
+      return state
+        .set('is_uploading', false)
+        .set('is_processing', false)
+        .update('pending_media_attachments', (n) => n - 1);
+    case COMPOSE_UPLOAD_UNDO:
+      return removeMedia(state, action.media_id);
+    case COMPOSE_UPLOAD_PROGRESS:
+      return state.set(
+        'progress',
+        Math.round((action.loaded / action.total) * 100),
+      );
+    case THUMBNAIL_UPLOAD_REQUEST:
+      return state.set('isUploadingThumbnail', true);
+    case THUMBNAIL_UPLOAD_PROGRESS:
+      return state.set(
+        'thumbnailProgress',
+        Math.round((action.loaded / action.total) * 100),
+      );
+    case THUMBNAIL_UPLOAD_FAIL:
+      return state.set('isUploadingThumbnail', false);
+    case THUMBNAIL_UPLOAD_SUCCESS:
+      return state
+        .set('isUploadingThumbnail', false)
+        .update('media_attachments', (list) =>
+          list.map((item) => {
+            if (item.get('id') === action.media.id) {
+              return fromJS(action.media);
+            }
+
+            return item;
+          }),
+        );
+    case INIT_MEDIA_EDIT_MODAL:
+      const media = state
+        .get('media_attachments')
+        .find((item) => item.get('id') === action.id);
+      return state.set(
+        'media_modal',
+        ImmutableMap({
+          id: action.id,
+          description: media.get('description') || '',
+          focusX: media.getIn(['meta', 'focus', 'x'], 0),
+          focusY: media.getIn(['meta', 'focus', 'y'], 0),
+          dirty: false,
+        }),
+      );
+    case COMPOSE_CHANGE_MEDIA_DESCRIPTION:
+      return state
+        .setIn(['media_modal', 'description'], action.description)
+        .setIn(['media_modal', 'dirty'], true);
+    case COMPOSE_CHANGE_MEDIA_FOCUS:
+      return state
+        .setIn(['media_modal', 'focusX'], action.focusX)
+        .setIn(['media_modal', 'focusY'], action.focusY)
+        .setIn(['media_modal', 'dirty'], true);
+    case COMPOSE_MENTION:
+      return state.withMutations((map) => {
+        map.update('text', (text) =>
+          [text.trim(), `@${action.account.get('acct')} `]
+            .filter((str) => str.length !== 0)
+            .join(' '),
+        );
+        map.set('focusDate', new Date());
+        map.set('caretPosition', null);
+        map.set('idempotencyKey', uuid());
+      });
+    case COMPOSE_DIRECT:
+      return state.withMutations((map) => {
+        map.update('text', (text) =>
+          [text.trim(), `@${action.account.get('acct')} `]
+            .filter((str) => str.length !== 0)
+            .join(' '),
+        );
+        map.set('privacy', 'direct');
+        map.set('focusDate', new Date());
+        map.set('caretPosition', null);
+        map.set('idempotencyKey', uuid());
+      });
+    case COMPOSE_SUGGESTIONS_CLEAR:
+      return state
+        .update('suggestions', ImmutableList(), (list) => list.clear())
+        .set('suggestion_token', null);
+    case COMPOSE_SUGGESTIONS_READY:
+      return state
+        .set('suggestions', ImmutableList(normalizeSuggestions(state, action)))
+        .set('suggestion_token', action.token);
+    case COMPOSE_SUGGESTION_SELECT:
+      return insertSuggestion(
+        state,
+        action.position,
+        action.token,
+        action.completion,
+        action.path,
+      );
+    case COMPOSE_SUGGESTION_IGNORE:
+      return ignoreSuggestion(
+        state,
+        action.position,
+        action.token,
+        action.completion,
+        action.path,
+      );
+    case COMPOSE_SUGGESTION_TAGS_UPDATE:
+      return updateSuggestionTags(state, action.token);
+    case COMPOSE_TAG_HISTORY_UPDATE:
+      return state.set('tagHistory', fromJS(action.tags));
+    case TIMELINE_DELETE:
+      if (action.id === state.get('in_reply_to')) {
+        return state.set('in_reply_to', null);
+      } else if (action.id === state.get('id')) {
+        return state.set('id', null);
+      } else {
+        return state;
+      }
+    case COMPOSE_EMOJI_INSERT:
+      return insertEmoji(
+        state,
+        action.position,
+        action.emoji,
+        action.needsSpace,
+      );
+    case COMPOSE_UPLOAD_CHANGE_SUCCESS:
+      return state
+        .set('is_changing_upload', false)
+        .setIn(['media_modal', 'dirty'], false)
+        .update('media_attachments', (list) =>
+          list.map((item) => {
+            if (item.get('id') === action.media.id) {
+              return fromJS(action.media).set('unattached', !action.attached);
+            }
+
+            return item;
+          }),
+        );
+    case REDRAFT:
+      return state.withMutations((map) => {
+        map.set(
+          'text',
+          action.raw_text || unescapeHTML(expandMentions(action.status)),
+        );
+        map.set('in_reply_to', action.status.get('in_reply_to_id'));
+        map.set('privacy', action.status.get('visibility'));
+        map.set(
+          'media_attachments',
+          action.status
+            .get('media_attachments')
+            .map((media) => media.set('unattached', true)),
+        );
+        map.set('focusDate', new Date());
+        map.set('caretPosition', null);
+        map.set('idempotencyKey', uuid());
+        map.set('sensitive', action.status.get('sensitive'));
+        map.set('language', action.status.get('language'));
+        map.set('id', null);
+
+        if (action.status.get('spoiler_text').length > 0) {
+          map.set('spoiler', true);
+          map.set('spoiler_text', action.status.get('spoiler_text'));
+        } else {
+          map.set('spoiler', false);
+          map.set('spoiler_text', '');
+        }
+
+        if (action.status.get('poll')) {
+          map.set(
+            'poll',
+            ImmutableMap({
+              options: action.status
+                .getIn(['poll', 'options'])
+                .map((x) => x.get('title')),
+              multiple: action.status.getIn(['poll', 'multiple']),
+              expires_in: expiresInFromExpiresAt(
+                action.status.getIn(['poll', 'expires_at']),
+              ),
+            }),
+          );
+        }
+      });
+    case COMPOSE_SET_STATUS:
+      return state.withMutations((map) => {
+        map.set('id', action.status.get('id'));
+        map.set('text', action.text);
+        map.set('in_reply_to', action.status.get('in_reply_to_id'));
+        map.set('privacy', action.status.get('visibility'));
+        map.set('media_attachments', action.status.get('media_attachments'));
+        map.set('focusDate', new Date());
+        map.set('caretPosition', null);
+        map.set('idempotencyKey', uuid());
+        map.set('sensitive', action.status.get('sensitive'));
+        map.set('language', action.status.get('language'));
+
+        if (action.spoiler_text.length > 0) {
+          map.set('spoiler', true);
+          map.set('spoiler_text', action.spoiler_text);
+        } else {
+          map.set('spoiler', false);
+          map.set('spoiler_text', '');
+        }
+
+        if (action.status.get('poll')) {
+          map.set(
+            'poll',
+            ImmutableMap({
+              options: action.status
+                .getIn(['poll', 'options'])
+                .map((x) => x.get('title')),
+              multiple: action.status.getIn(['poll', 'multiple']),
+              expires_in: expiresInFromExpiresAt(
+                action.status.getIn(['poll', 'expires_at']),
+              ),
+            }),
+          );
+        }
+      });
+    case COMPOSE_POLL_ADD:
+      return state.set('poll', initialPoll);
+    case COMPOSE_POLL_REMOVE:
+      return state.set('poll', null);
+    case COMPOSE_POLL_OPTION_ADD:
+      return state.updateIn(['poll', 'options'], (options) =>
+        options.push(action.title),
+      );
+    case COMPOSE_POLL_OPTION_CHANGE:
+      return state.setIn(['poll', 'options', action.index], action.title);
+    case COMPOSE_POLL_OPTION_REMOVE:
+      return state.updateIn(['poll', 'options'], (options) =>
+        options.delete(action.index),
+      );
+    case COMPOSE_POLL_SETTINGS_CHANGE:
+      return state.update('poll', (poll) =>
+        poll
+          .set('expires_in', action.expiresIn)
+          .set('multiple', action.isMultiple),
+      );
+    case COMPOSE_LANGUAGE_CHANGE:
+      return state.set('language', action.language);
+    case COMPOSE_FOCUS:
+      return state
+        .set('focusDate', new Date())
+        .update('text', (text) =>
+          text.length > 0 ? text : action.defaultText,
+        );
+    default:
       return state;
-    }
-  case COMPOSE_EMOJI_INSERT:
-    return insertEmoji(state, action.position, action.emoji, action.needsSpace);
-  case COMPOSE_UPLOAD_CHANGE_SUCCESS:
-    return state
-      .set('is_changing_upload', false)
-      .setIn(['media_modal', 'dirty'], false)
-      .update('media_attachments', list => list.map(item => {
-        if (item.get('id') === action.media.id) {
-          return fromJS(action.media).set('unattached', !action.attached);
-        }
-
-        return item;
-      }));
-  case REDRAFT:
-    return state.withMutations(map => {
-      map.set('text', action.raw_text || unescapeHTML(expandMentions(action.status)));
-      map.set('in_reply_to', action.status.get('in_reply_to_id'));
-      map.set('privacy', action.status.get('visibility'));
-      map.set('media_attachments', action.status.get('media_attachments').map((media) => media.set('unattached', true)));
-      map.set('focusDate', new Date());
-      map.set('caretPosition', null);
-      map.set('idempotencyKey', uuid());
-      map.set('sensitive', action.status.get('sensitive'));
-      map.set('language', action.status.get('language'));
-      map.set('id', null);
-
-      if (action.status.get('spoiler_text').length > 0) {
-        map.set('spoiler', true);
-        map.set('spoiler_text', action.status.get('spoiler_text'));
-      } else {
-        map.set('spoiler', false);
-        map.set('spoiler_text', '');
-      }
-
-      if (action.status.get('poll')) {
-        map.set('poll', ImmutableMap({
-          options: action.status.getIn(['poll', 'options']).map(x => x.get('title')),
-          multiple: action.status.getIn(['poll', 'multiple']),
-          expires_in: expiresInFromExpiresAt(action.status.getIn(['poll', 'expires_at'])),
-        }));
-      }
-    });
-  case COMPOSE_SET_STATUS:
-    return state.withMutations(map => {
-      map.set('id', action.status.get('id'));
-      map.set('text', action.text);
-      map.set('in_reply_to', action.status.get('in_reply_to_id'));
-      map.set('privacy', action.status.get('visibility'));
-      map.set('media_attachments', action.status.get('media_attachments'));
-      map.set('focusDate', new Date());
-      map.set('caretPosition', null);
-      map.set('idempotencyKey', uuid());
-      map.set('sensitive', action.status.get('sensitive'));
-      map.set('language', action.status.get('language'));
-
-      if (action.spoiler_text.length > 0) {
-        map.set('spoiler', true);
-        map.set('spoiler_text', action.spoiler_text);
-      } else {
-        map.set('spoiler', false);
-        map.set('spoiler_text', '');
-      }
-
-      if (action.status.get('poll')) {
-        map.set('poll', ImmutableMap({
-          options: action.status.getIn(['poll', 'options']).map(x => x.get('title')),
-          multiple: action.status.getIn(['poll', 'multiple']),
-          expires_in: expiresInFromExpiresAt(action.status.getIn(['poll', 'expires_at'])),
-        }));
-      }
-    });
-  case COMPOSE_POLL_ADD:
-    return state.set('poll', initialPoll);
-  case COMPOSE_POLL_REMOVE:
-    return state.set('poll', null);
-  case COMPOSE_POLL_OPTION_ADD:
-    return state.updateIn(['poll', 'options'], options => options.push(action.title));
-  case COMPOSE_POLL_OPTION_CHANGE:
-    return state.setIn(['poll', 'options', action.index], action.title);
-  case COMPOSE_POLL_OPTION_REMOVE:
-    return state.updateIn(['poll', 'options'], options => options.delete(action.index));
-  case COMPOSE_POLL_SETTINGS_CHANGE:
-    return state.update('poll', poll => poll.set('expires_in', action.expiresIn).set('multiple', action.isMultiple));
-  case COMPOSE_LANGUAGE_CHANGE:
-    return state.set('language', action.language);
-  case COMPOSE_FOCUS:
-    return state.set('focusDate', new Date()).update('text', text => text.length > 0 ? text : action.defaultText);
-  default:
-    return state;
   }
 }

--- a/app/javascript/mastodon/reducers/contexts.js
+++ b/app/javascript/mastodon/reducers/contexts.js
@@ -13,76 +13,98 @@ const initialState = ImmutableMap({
   replies: ImmutableMap(),
 });
 
-const normalizeContext = (immutableState, id, ancestors, descendants) => immutableState.withMutations(state => {
-  state.update('inReplyTos', immutableAncestors => immutableAncestors.withMutations(inReplyTos => {
-    state.update('replies', immutableDescendants => immutableDescendants.withMutations(replies => {
-      function addReply({ id, in_reply_to_id }) {
-        if (in_reply_to_id && !inReplyTos.has(id)) {
+const normalizeContext = (immutableState, id, ancestors, descendants) =>
+  immutableState.withMutations((state) => {
+    state.update('inReplyTos', (immutableAncestors) =>
+      immutableAncestors.withMutations((inReplyTos) => {
+        state.update('replies', (immutableDescendants) =>
+          immutableDescendants.withMutations((replies) => {
+            function addReply({ id, in_reply_to_id }) {
+              if (in_reply_to_id && !inReplyTos.has(id)) {
+                replies.update(in_reply_to_id, ImmutableList(), (siblings) => {
+                  const index = siblings.findLastIndex(
+                    (sibling) => compareId(sibling, id) < 0,
+                  );
+                  return siblings.insert(index + 1, id);
+                });
 
-          replies.update(in_reply_to_id, ImmutableList(), siblings => {
-            const index = siblings.findLastIndex(sibling => compareId(sibling, id) < 0);
-            return siblings.insert(index + 1, id);
-          });
+                inReplyTos.set(id, in_reply_to_id);
+              }
+            }
 
-          inReplyTos.set(id, in_reply_to_id);
-        }
-      }
+            // We know in_reply_to_id of statuses but `id` itself.
+            // So we assume that the status of the id replies to last ancestors.
 
-      // We know in_reply_to_id of statuses but `id` itself.
-      // So we assume that the status of the id replies to last ancestors.
+            ancestors.forEach(addReply);
 
-      ancestors.forEach(addReply);
+            if (ancestors[0]) {
+              addReply({
+                id,
+                in_reply_to_id: ancestors[ancestors.length - 1].id,
+              });
+            }
 
-      if (ancestors[0]) {
-        addReply({ id, in_reply_to_id: ancestors[ancestors.length - 1].id });
-      }
+            descendants.forEach(addReply);
+          }),
+        );
+      }),
+    );
+  });
 
-      descendants.forEach(addReply);
-    }));
-  }));
-});
+const deleteFromContexts = (immutableState, ids) =>
+  immutableState.withMutations((state) => {
+    state.update('inReplyTos', (immutableAncestors) =>
+      immutableAncestors.withMutations((inReplyTos) => {
+        state.update('replies', (immutableDescendants) =>
+          immutableDescendants.withMutations((replies) => {
+            ids.forEach((id) => {
+              const inReplyToIdOfId = inReplyTos.get(id);
+              const repliesOfId = replies.get(id);
+              const siblings = replies.get(inReplyToIdOfId);
 
-const deleteFromContexts = (immutableState, ids) => immutableState.withMutations(state => {
-  state.update('inReplyTos', immutableAncestors => immutableAncestors.withMutations(inReplyTos => {
-    state.update('replies', immutableDescendants => immutableDescendants.withMutations(replies => {
-      ids.forEach(id => {
-        const inReplyToIdOfId = inReplyTos.get(id);
-        const repliesOfId = replies.get(id);
-        const siblings = replies.get(inReplyToIdOfId);
+              if (siblings) {
+                replies.set(
+                  inReplyToIdOfId,
+                  siblings.filterNot((sibling) => sibling === id),
+                );
+              }
 
-        if (siblings) {
-          replies.set(inReplyToIdOfId, siblings.filterNot(sibling => sibling === id));
-        }
+              if (repliesOfId) {
+                repliesOfId.forEach((reply) => inReplyTos.delete(reply));
+              }
 
-
-        if (repliesOfId) {
-          repliesOfId.forEach(reply => inReplyTos.delete(reply));
-        }
-
-        inReplyTos.delete(id);
-        replies.delete(id);
-      });
-    }));
-  }));
-});
+              inReplyTos.delete(id);
+              replies.delete(id);
+            });
+          }),
+        );
+      }),
+    );
+  });
 
 const filterContexts = (state, relationship, statuses) => {
   const ownedStatusIds = statuses
-    .filter(status => status.get('account') === relationship.id)
-    .map(status => status.get('id'));
+    .filter((status) => status.get('account') === relationship.id)
+    .map((status) => status.get('id'));
 
   return deleteFromContexts(state, ownedStatusIds);
 };
 
 const updateContext = (state, status) => {
   if (status.in_reply_to_id) {
-    return state.withMutations(mutable => {
-      const replies = mutable.getIn(['replies', status.in_reply_to_id], ImmutableList());
+    return state.withMutations((mutable) => {
+      const replies = mutable.getIn(
+        ['replies', status.in_reply_to_id],
+        ImmutableList(),
+      );
 
       mutable.setIn(['inReplyTos', status.id], status.in_reply_to_id);
 
       if (!replies.includes(status.id)) {
-        mutable.setIn(['replies', status.in_reply_to_id], replies.push(status.id));
+        mutable.setIn(
+          ['replies', status.in_reply_to_id],
+          replies.push(status.id),
+        );
       }
     });
   }
@@ -91,17 +113,22 @@ const updateContext = (state, status) => {
 };
 
 export default function replies(state = initialState, action) {
-  switch(action.type) {
-  case ACCOUNT_BLOCK_SUCCESS:
-  case ACCOUNT_MUTE_SUCCESS:
-    return filterContexts(state, action.relationship, action.statuses);
-  case CONTEXT_FETCH_SUCCESS:
-    return normalizeContext(state, action.id, action.ancestors, action.descendants);
-  case TIMELINE_DELETE:
-    return deleteFromContexts(state, [action.id]);
-  case TIMELINE_UPDATE:
-    return updateContext(state, action.status);
-  default:
-    return state;
+  switch (action.type) {
+    case ACCOUNT_BLOCK_SUCCESS:
+    case ACCOUNT_MUTE_SUCCESS:
+      return filterContexts(state, action.relationship, action.statuses);
+    case CONTEXT_FETCH_SUCCESS:
+      return normalizeContext(
+        state,
+        action.id,
+        action.ancestors,
+        action.descendants,
+      );
+    case TIMELINE_DELETE:
+      return deleteFromContexts(state, [action.id]);
+    case TIMELINE_UPDATE:
+      return updateContext(state, action.status);
+    default:
+      return state;
   }
 }

--- a/app/javascript/mastodon/reducers/conversations.js
+++ b/app/javascript/mastodon/reducers/conversations.js
@@ -1,6 +1,9 @@
 import { Map as ImmutableMap, List as ImmutableList } from 'immutable';
 
-import { ACCOUNT_BLOCK_SUCCESS, ACCOUNT_MUTE_SUCCESS } from 'mastodon/actions/accounts';
+import {
+  ACCOUNT_BLOCK_SUCCESS,
+  ACCOUNT_MUTE_SUCCESS,
+} from 'mastodon/actions/accounts';
 import { DOMAIN_BLOCK_SUCCESS } from 'mastodon/actions/domain_blocks';
 
 import {
@@ -22,32 +25,41 @@ const initialState = ImmutableMap({
   mounted: false,
 });
 
-const conversationToMap = item => ImmutableMap({
-  id: item.id,
-  unread: item.unread,
-  accounts: ImmutableList(item.accounts.map(a => a.id)),
-  last_status: item.last_status ? item.last_status.id : null,
-});
+const conversationToMap = (item) =>
+  ImmutableMap({
+    id: item.id,
+    unread: item.unread,
+    accounts: ImmutableList(item.accounts.map((a) => a.id)),
+    last_status: item.last_status ? item.last_status.id : null,
+  });
 
-const updateConversation = (state, item) => state.update('items', list => {
-  const index   = list.findIndex(x => x.get('id') === item.id);
-  const newItem = conversationToMap(item);
+const updateConversation = (state, item) =>
+  state.update('items', (list) => {
+    const index = list.findIndex((x) => x.get('id') === item.id);
+    const newItem = conversationToMap(item);
 
-  if (index === -1) {
-    return list.unshift(newItem);
-  } else {
-    return list.set(index, newItem);
-  }
-});
+    if (index === -1) {
+      return list.unshift(newItem);
+    } else {
+      return list.set(index, newItem);
+    }
+  });
 
-const expandNormalizedConversations = (state, conversations, next, isLoadingRecent) => {
+const expandNormalizedConversations = (
+  state,
+  conversations,
+  next,
+  isLoadingRecent,
+) => {
   let items = ImmutableList(conversations.map(conversationToMap));
 
-  return state.withMutations(mutable => {
+  return state.withMutations((mutable) => {
     if (!items.isEmpty()) {
-      mutable.update('items', list => {
-        list = list.map(oldItem => {
-          const newItemIndex = items.findIndex(x => x.get('id') === oldItem.get('id'));
+      mutable.update('items', (list) => {
+        list = list.map((oldItem) => {
+          const newItemIndex = items.findIndex(
+            (x) => x.get('id') === oldItem.get('id'),
+          );
 
           if (newItemIndex === -1) {
             return oldItem;
@@ -61,13 +73,16 @@ const expandNormalizedConversations = (state, conversations, next, isLoadingRece
 
         list = list.concat(items);
 
-        return list.sortBy(x => x.get('last_status'), (a, b) => {
-          if(a === null || b === null) {
-            return -1;
-          }
+        return list.sortBy(
+          (x) => x.get('last_status'),
+          (a, b) => {
+            if (a === null || b === null) {
+              return -1;
+            }
 
-          return compareId(a, b) * -1;
-        });
+            return compareId(a, b) * -1;
+          },
+        );
       });
     }
 
@@ -80,39 +95,52 @@ const expandNormalizedConversations = (state, conversations, next, isLoadingRece
 };
 
 const filterConversations = (state, accountIds) => {
-  return state.update('items', list => list.filterNot(item => item.get('accounts').some(accountId => accountIds.includes(accountId))));
+  return state.update('items', (list) =>
+    list.filterNot((item) =>
+      item.get('accounts').some((accountId) => accountIds.includes(accountId)),
+    ),
+  );
 };
 
 export default function conversations(state = initialState, action) {
   switch (action.type) {
-  case CONVERSATIONS_FETCH_REQUEST:
-    return state.set('isLoading', true);
-  case CONVERSATIONS_FETCH_FAIL:
-    return state.set('isLoading', false);
-  case CONVERSATIONS_FETCH_SUCCESS:
-    return expandNormalizedConversations(state, action.conversations, action.next, action.isLoadingRecent);
-  case CONVERSATIONS_UPDATE:
-    return updateConversation(state, action.conversation);
-  case CONVERSATIONS_MOUNT:
-    return state.update('mounted', count => count + 1);
-  case CONVERSATIONS_UNMOUNT:
-    return state.update('mounted', count => count - 1);
-  case CONVERSATIONS_READ:
-    return state.update('items', list => list.map(item => {
-      if (item.get('id') === action.id) {
-        return item.set('unread', false);
-      }
+    case CONVERSATIONS_FETCH_REQUEST:
+      return state.set('isLoading', true);
+    case CONVERSATIONS_FETCH_FAIL:
+      return state.set('isLoading', false);
+    case CONVERSATIONS_FETCH_SUCCESS:
+      return expandNormalizedConversations(
+        state,
+        action.conversations,
+        action.next,
+        action.isLoadingRecent,
+      );
+    case CONVERSATIONS_UPDATE:
+      return updateConversation(state, action.conversation);
+    case CONVERSATIONS_MOUNT:
+      return state.update('mounted', (count) => count + 1);
+    case CONVERSATIONS_UNMOUNT:
+      return state.update('mounted', (count) => count - 1);
+    case CONVERSATIONS_READ:
+      return state.update('items', (list) =>
+        list.map((item) => {
+          if (item.get('id') === action.id) {
+            return item.set('unread', false);
+          }
 
-      return item;
-    }));
-  case ACCOUNT_BLOCK_SUCCESS:
-  case ACCOUNT_MUTE_SUCCESS:
-    return filterConversations(state, [action.relationship.id]);
-  case DOMAIN_BLOCK_SUCCESS:
-    return filterConversations(state, action.accounts);
-  case CONVERSATIONS_DELETE_SUCCESS:
-    return state.update('items', list => list.filterNot(item => item.get('id') === action.id));
-  default:
-    return state;
+          return item;
+        }),
+      );
+    case ACCOUNT_BLOCK_SUCCESS:
+    case ACCOUNT_MUTE_SUCCESS:
+      return filterConversations(state, [action.relationship.id]);
+    case DOMAIN_BLOCK_SUCCESS:
+      return filterConversations(state, action.accounts);
+    case CONVERSATIONS_DELETE_SUCCESS:
+      return state.update('items', (list) =>
+        list.filterNot((item) => item.get('id') === action.id),
+      );
+    default:
+      return state;
   }
 }

--- a/app/javascript/mastodon/reducers/custom_emojis.js
+++ b/app/javascript/mastodon/reducers/custom_emojis.js
@@ -7,7 +7,7 @@ import { search as emojiSearch } from '../features/emoji/emoji_mart_search_light
 const initialState = ImmutableList([]);
 
 export default function custom_emojis(state = initialState, action) {
-  if(action.type === CUSTOM_EMOJIS_FETCH_SUCCESS) {
+  if (action.type === CUSTOM_EMOJIS_FETCH_SUCCESS) {
     state = ConvertToImmutable(action.custom_emojis);
     emojiSearch('', { custom: buildCustomEmojis(state) });
   }

--- a/app/javascript/mastodon/reducers/domain_lists.js
+++ b/app/javascript/mastodon/reducers/domain_lists.js
@@ -1,4 +1,7 @@
-import { Map as ImmutableMap, OrderedSet as ImmutableOrderedSet } from 'immutable';
+import {
+  Map as ImmutableMap,
+  OrderedSet as ImmutableOrderedSet,
+} from 'immutable';
 
 import {
   DOMAIN_BLOCKS_FETCH_SUCCESS,
@@ -13,14 +16,20 @@ const initialState = ImmutableMap({
 });
 
 export default function domainLists(state = initialState, action) {
-  switch(action.type) {
-  case DOMAIN_BLOCKS_FETCH_SUCCESS:
-    return state.setIn(['blocks', 'items'], ImmutableOrderedSet(action.domains)).setIn(['blocks', 'next'], action.next);
-  case DOMAIN_BLOCKS_EXPAND_SUCCESS:
-    return state.updateIn(['blocks', 'items'], set => set.union(action.domains)).setIn(['blocks', 'next'], action.next);
-  case DOMAIN_UNBLOCK_SUCCESS:
-    return state.updateIn(['blocks', 'items'], set => set.delete(action.domain));
-  default:
-    return state;
+  switch (action.type) {
+    case DOMAIN_BLOCKS_FETCH_SUCCESS:
+      return state
+        .setIn(['blocks', 'items'], ImmutableOrderedSet(action.domains))
+        .setIn(['blocks', 'next'], action.next);
+    case DOMAIN_BLOCKS_EXPAND_SUCCESS:
+      return state
+        .updateIn(['blocks', 'items'], (set) => set.union(action.domains))
+        .setIn(['blocks', 'next'], action.next);
+    case DOMAIN_UNBLOCK_SUCCESS:
+      return state.updateIn(['blocks', 'items'], (set) =>
+        set.delete(action.domain),
+      );
+    default:
+      return state;
   }
 }

--- a/app/javascript/mastodon/reducers/dropdown_menu.js
+++ b/app/javascript/mastodon/reducers/dropdown_menu.js
@@ -5,15 +5,25 @@ import {
   DROPDOWN_MENU_CLOSE,
 } from '../actions/dropdown_menu';
 
-const initialState = Immutable.Map({ openId: null, keyboard: false, scroll_key: null });
+const initialState = Immutable.Map({
+  openId: null,
+  keyboard: false,
+  scroll_key: null,
+});
 
 export default function dropdownMenu(state = initialState, action) {
   switch (action.type) {
-  case DROPDOWN_MENU_OPEN:
-    return state.merge({ openId: action.id, keyboard: action.keyboard, scroll_key: action.scroll_key });
-  case DROPDOWN_MENU_CLOSE:
-    return state.get('openId') === action.id ? state.set('openId', null).set('scroll_key', null) : state;
-  default:
-    return state;
+    case DROPDOWN_MENU_OPEN:
+      return state.merge({
+        openId: action.id,
+        keyboard: action.keyboard,
+        scroll_key: action.scroll_key,
+      });
+    case DROPDOWN_MENU_CLOSE:
+      return state.get('openId') === action.id
+        ? state.set('openId', null).set('scroll_key', null)
+        : state;
+    default:
+      return state;
   }
 }

--- a/app/javascript/mastodon/reducers/filters.js
+++ b/app/javascript/mastodon/reducers/filters.js
@@ -1,6 +1,9 @@
 import { Map as ImmutableMap, is, fromJS } from 'immutable';
 
-import { FILTERS_FETCH_SUCCESS, FILTERS_CREATE_SUCCESS } from '../actions/filters';
+import {
+  FILTERS_FETCH_SUCCESS,
+  FILTERS_CREATE_SUCCESS,
+} from '../actions/filters';
 import { FILTERS_IMPORT } from '../actions/importer';
 
 const normalizeFilter = (state, filter) => {
@@ -17,14 +20,18 @@ const normalizeFilter = (state, filter) => {
     return state;
   } else {
     // Do not overwrite keywords when receiving a partial filter
-    return state.update(filter.id, ImmutableMap(), (old) => (
-      old.mergeWith(((old_value, new_value) => (new_value === undefined ? old_value : new_value)), normalizedFilter)
-    ));
+    return state.update(filter.id, ImmutableMap(), (old) =>
+      old.mergeWith(
+        (old_value, new_value) =>
+          new_value === undefined ? old_value : new_value,
+        normalizedFilter,
+      ),
+    );
   }
 };
 
 const normalizeFilters = (state, filters) => {
-  filters.forEach(filter => {
+  filters.forEach((filter) => {
     state = normalizeFilter(state, filter);
   });
 
@@ -32,14 +39,14 @@ const normalizeFilters = (state, filters) => {
 };
 
 export default function filters(state = ImmutableMap(), action) {
-  switch(action.type) {
-  case FILTERS_CREATE_SUCCESS:
-    return normalizeFilter(state, action.filter);
-  case FILTERS_FETCH_SUCCESS:
-    return normalizeFilters(ImmutableMap(), action.filters);
-  case FILTERS_IMPORT:
-    return normalizeFilters(state, action.filters);
-  default:
-    return state;
+  switch (action.type) {
+    case FILTERS_CREATE_SUCCESS:
+      return normalizeFilter(state, action.filter);
+    case FILTERS_FETCH_SUCCESS:
+      return normalizeFilters(ImmutableMap(), action.filters);
+    case FILTERS_IMPORT:
+      return normalizeFilters(state, action.filters);
+    default:
+      return state;
   }
 }

--- a/app/javascript/mastodon/reducers/followed_tags.js
+++ b/app/javascript/mastodon/reducers/followed_tags.js
@@ -16,28 +16,28 @@ const initialState = ImmutableMap({
 });
 
 export default function followed_tags(state = initialState, action) {
-  switch(action.type) {
-  case FOLLOWED_HASHTAGS_FETCH_REQUEST:
-    return state.set('isLoading', true);
-  case FOLLOWED_HASHTAGS_FETCH_SUCCESS:
-    return state.withMutations(map => {
-      map.set('items', fromJS(action.followed_tags));
-      map.set('isLoading', false);
-      map.set('next', action.next);
-    });
-  case FOLLOWED_HASHTAGS_FETCH_FAIL:
-    return state.set('isLoading', false);
-  case FOLLOWED_HASHTAGS_EXPAND_REQUEST:
-    return state.set('isLoading', true);
-  case FOLLOWED_HASHTAGS_EXPAND_SUCCESS:
-    return state.withMutations(map => {
-      map.update('items', set => set.concat(fromJS(action.followed_tags)));
-      map.set('isLoading', false);
-      map.set('next', action.next);
-    });
-  case FOLLOWED_HASHTAGS_EXPAND_FAIL:
-    return state.set('isLoading', false);
-  default:
-    return state;
+  switch (action.type) {
+    case FOLLOWED_HASHTAGS_FETCH_REQUEST:
+      return state.set('isLoading', true);
+    case FOLLOWED_HASHTAGS_FETCH_SUCCESS:
+      return state.withMutations((map) => {
+        map.set('items', fromJS(action.followed_tags));
+        map.set('isLoading', false);
+        map.set('next', action.next);
+      });
+    case FOLLOWED_HASHTAGS_FETCH_FAIL:
+      return state.set('isLoading', false);
+    case FOLLOWED_HASHTAGS_EXPAND_REQUEST:
+      return state.set('isLoading', true);
+    case FOLLOWED_HASHTAGS_EXPAND_SUCCESS:
+      return state.withMutations((map) => {
+        map.update('items', (set) => set.concat(fromJS(action.followed_tags)));
+        map.set('isLoading', false);
+        map.set('next', action.next);
+      });
+    case FOLLOWED_HASHTAGS_EXPAND_FAIL:
+      return state.set('isLoading', false);
+    default:
+      return state;
   }
 }

--- a/app/javascript/mastodon/reducers/height_cache.js
+++ b/app/javascript/mastodon/reducers/height_cache.js
@@ -5,7 +5,7 @@ import { HEIGHT_CACHE_SET, HEIGHT_CACHE_CLEAR } from '../actions/height_cache';
 const initialState = ImmutableMap();
 
 const setHeight = (state, key, id, height) => {
-  return state.update(key, ImmutableMap(), map => map.set(id, height));
+  return state.update(key, ImmutableMap(), (map) => map.set(id, height));
 };
 
 const clearHeights = () => {
@@ -13,12 +13,12 @@ const clearHeights = () => {
 };
 
 export default function statuses(state = initialState, action) {
-  switch(action.type) {
-  case HEIGHT_CACHE_SET:
-    return setHeight(state, action.key, action.id, action.height);
-  case HEIGHT_CACHE_CLEAR:
-    return clearHeights();
-  default:
-    return state;
+  switch (action.type) {
+    case HEIGHT_CACHE_SET:
+      return setHeight(state, action.key, action.id, action.height);
+    case HEIGHT_CACHE_CLEAR:
+      return clearHeights();
+    default:
+      return state;
   }
 }

--- a/app/javascript/mastodon/reducers/history.js
+++ b/app/javascript/mastodon/reducers/history.js
@@ -1,6 +1,10 @@
 import { Map as ImmutableMap, List as ImmutableList, fromJS } from 'immutable';
 
-import { HISTORY_FETCH_REQUEST, HISTORY_FETCH_SUCCESS, HISTORY_FETCH_FAIL } from 'mastodon/actions/history';
+import {
+  HISTORY_FETCH_REQUEST,
+  HISTORY_FETCH_SUCCESS,
+  HISTORY_FETCH_FAIL,
+} from 'mastodon/actions/history';
 
 const initialHistory = ImmutableMap({
   loading: false,
@@ -10,20 +14,37 @@ const initialHistory = ImmutableMap({
 const initialState = ImmutableMap();
 
 export default function history(state = initialState, action) {
-  switch(action.type) {
-  case HISTORY_FETCH_REQUEST:
-    return state.update(action.statusId, initialHistory, history => history.withMutations(map => {
-      map.set('loading', true);
-      map.set('items', ImmutableList());
-    }));
-  case HISTORY_FETCH_SUCCESS:
-    return state.update(action.statusId, initialHistory, history => history.withMutations(map => {
-      map.set('loading', false);
-      map.set('items', fromJS(action.history.map((x, i) => ({ ...x, account: x.account.id, original: i === 0 })).reverse()));
-    }));
-  case HISTORY_FETCH_FAIL:
-    return state.update(action.statusId, initialHistory, history => history.set('loading', false));
-  default:
-    return state;
+  switch (action.type) {
+    case HISTORY_FETCH_REQUEST:
+      return state.update(action.statusId, initialHistory, (history) =>
+        history.withMutations((map) => {
+          map.set('loading', true);
+          map.set('items', ImmutableList());
+        }),
+      );
+    case HISTORY_FETCH_SUCCESS:
+      return state.update(action.statusId, initialHistory, (history) =>
+        history.withMutations((map) => {
+          map.set('loading', false);
+          map.set(
+            'items',
+            fromJS(
+              action.history
+                .map((x, i) => ({
+                  ...x,
+                  account: x.account.id,
+                  original: i === 0,
+                }))
+                .reverse(),
+            ),
+          );
+        }),
+      );
+    case HISTORY_FETCH_FAIL:
+      return state.update(action.statusId, initialHistory, (history) =>
+        history.set('loading', false),
+      );
+    default:
+      return state;
   }
 }

--- a/app/javascript/mastodon/reducers/list_adder.js
+++ b/app/javascript/mastodon/reducers/list_adder.js
@@ -21,28 +21,34 @@ const initialState = ImmutableMap({
 });
 
 export default function listAdderReducer(state = initialState, action) {
-  switch(action.type) {
-  case LIST_ADDER_RESET:
-    return initialState;
-  case LIST_ADDER_SETUP:
-    return state.withMutations(map => {
-      map.set('accountId', action.account.get('id'));
-    });
-  case LIST_ADDER_LISTS_FETCH_REQUEST:
-    return state.setIn(['lists', 'isLoading'], true);
-  case LIST_ADDER_LISTS_FETCH_FAIL:
-    return state.setIn(['lists', 'isLoading'], false);
-  case LIST_ADDER_LISTS_FETCH_SUCCESS:
-    return state.update('lists', lists => lists.withMutations(map => {
-      map.set('isLoading', false);
-      map.set('loaded', true);
-      map.set('items', ImmutableList(action.lists.map(item => item.id)));
-    }));
-  case LIST_EDITOR_ADD_SUCCESS:
-    return state.updateIn(['lists', 'items'], list => list.unshift(action.listId));
-  case LIST_EDITOR_REMOVE_SUCCESS:
-    return state.updateIn(['lists', 'items'], list => list.filterNot(item => item === action.listId));
-  default:
-    return state;
+  switch (action.type) {
+    case LIST_ADDER_RESET:
+      return initialState;
+    case LIST_ADDER_SETUP:
+      return state.withMutations((map) => {
+        map.set('accountId', action.account.get('id'));
+      });
+    case LIST_ADDER_LISTS_FETCH_REQUEST:
+      return state.setIn(['lists', 'isLoading'], true);
+    case LIST_ADDER_LISTS_FETCH_FAIL:
+      return state.setIn(['lists', 'isLoading'], false);
+    case LIST_ADDER_LISTS_FETCH_SUCCESS:
+      return state.update('lists', (lists) =>
+        lists.withMutations((map) => {
+          map.set('isLoading', false);
+          map.set('loaded', true);
+          map.set('items', ImmutableList(action.lists.map((item) => item.id)));
+        }),
+      );
+    case LIST_EDITOR_ADD_SUCCESS:
+      return state.updateIn(['lists', 'items'], (list) =>
+        list.unshift(action.listId),
+      );
+    case LIST_EDITOR_REMOVE_SUCCESS:
+      return state.updateIn(['lists', 'items'], (list) =>
+        list.filterNot((item) => item === action.listId),
+      );
+    default:
+      return state;
   }
 }

--- a/app/javascript/mastodon/reducers/list_editor.js
+++ b/app/javascript/mastodon/reducers/list_editor.js
@@ -40,60 +40,74 @@ const initialState = ImmutableMap({
 });
 
 export default function listEditorReducer(state = initialState, action) {
-  switch(action.type) {
-  case LIST_EDITOR_RESET:
-    return initialState;
-  case LIST_EDITOR_SETUP:
-    return state.withMutations(map => {
-      map.set('listId', action.list.get('id'));
-      map.set('title', action.list.get('title'));
-      map.set('isExclusive', action.list.get('is_exclusive'));
-      map.set('isSubmitting', false);
-    });
-  case LIST_EDITOR_TITLE_CHANGE:
-    return state.withMutations(map => {
-      map.set('title', action.value);
-      map.set('isChanged', true);
-    });
-  case LIST_CREATE_REQUEST:
-  case LIST_UPDATE_REQUEST:
-    return state.withMutations(map => {
-      map.set('isSubmitting', true);
-      map.set('isChanged', false);
-    });
-  case LIST_CREATE_FAIL:
-  case LIST_UPDATE_FAIL:
-    return state.set('isSubmitting', false);
-  case LIST_CREATE_SUCCESS:
-  case LIST_UPDATE_SUCCESS:
-    return state.withMutations(map => {
-      map.set('isSubmitting', false);
-      map.set('listId', action.list.id);
-    });
-  case LIST_ACCOUNTS_FETCH_REQUEST:
-    return state.setIn(['accounts', 'isLoading'], true);
-  case LIST_ACCOUNTS_FETCH_FAIL:
-    return state.setIn(['accounts', 'isLoading'], false);
-  case LIST_ACCOUNTS_FETCH_SUCCESS:
-    return state.update('accounts', accounts => accounts.withMutations(map => {
-      map.set('isLoading', false);
-      map.set('loaded', true);
-      map.set('items', ImmutableList(action.accounts.map(item => item.id)));
-    }));
-  case LIST_EDITOR_SUGGESTIONS_CHANGE:
-    return state.setIn(['suggestions', 'value'], action.value);
-  case LIST_EDITOR_SUGGESTIONS_READY:
-    return state.setIn(['suggestions', 'items'], ImmutableList(action.accounts.map(item => item.id)));
-  case LIST_EDITOR_SUGGESTIONS_CLEAR:
-    return state.update('suggestions', suggestions => suggestions.withMutations(map => {
-      map.set('items', ImmutableList());
-      map.set('value', '');
-    }));
-  case LIST_EDITOR_ADD_SUCCESS:
-    return state.updateIn(['accounts', 'items'], list => list.unshift(action.accountId));
-  case LIST_EDITOR_REMOVE_SUCCESS:
-    return state.updateIn(['accounts', 'items'], list => list.filterNot(item => item === action.accountId));
-  default:
-    return state;
+  switch (action.type) {
+    case LIST_EDITOR_RESET:
+      return initialState;
+    case LIST_EDITOR_SETUP:
+      return state.withMutations((map) => {
+        map.set('listId', action.list.get('id'));
+        map.set('title', action.list.get('title'));
+        map.set('isExclusive', action.list.get('is_exclusive'));
+        map.set('isSubmitting', false);
+      });
+    case LIST_EDITOR_TITLE_CHANGE:
+      return state.withMutations((map) => {
+        map.set('title', action.value);
+        map.set('isChanged', true);
+      });
+    case LIST_CREATE_REQUEST:
+    case LIST_UPDATE_REQUEST:
+      return state.withMutations((map) => {
+        map.set('isSubmitting', true);
+        map.set('isChanged', false);
+      });
+    case LIST_CREATE_FAIL:
+    case LIST_UPDATE_FAIL:
+      return state.set('isSubmitting', false);
+    case LIST_CREATE_SUCCESS:
+    case LIST_UPDATE_SUCCESS:
+      return state.withMutations((map) => {
+        map.set('isSubmitting', false);
+        map.set('listId', action.list.id);
+      });
+    case LIST_ACCOUNTS_FETCH_REQUEST:
+      return state.setIn(['accounts', 'isLoading'], true);
+    case LIST_ACCOUNTS_FETCH_FAIL:
+      return state.setIn(['accounts', 'isLoading'], false);
+    case LIST_ACCOUNTS_FETCH_SUCCESS:
+      return state.update('accounts', (accounts) =>
+        accounts.withMutations((map) => {
+          map.set('isLoading', false);
+          map.set('loaded', true);
+          map.set(
+            'items',
+            ImmutableList(action.accounts.map((item) => item.id)),
+          );
+        }),
+      );
+    case LIST_EDITOR_SUGGESTIONS_CHANGE:
+      return state.setIn(['suggestions', 'value'], action.value);
+    case LIST_EDITOR_SUGGESTIONS_READY:
+      return state.setIn(
+        ['suggestions', 'items'],
+        ImmutableList(action.accounts.map((item) => item.id)),
+      );
+    case LIST_EDITOR_SUGGESTIONS_CLEAR:
+      return state.update('suggestions', (suggestions) =>
+        suggestions.withMutations((map) => {
+          map.set('items', ImmutableList());
+          map.set('value', '');
+        }),
+      );
+    case LIST_EDITOR_ADD_SUCCESS:
+      return state.updateIn(['accounts', 'items'], (list) =>
+        list.unshift(action.accountId),
+      );
+    case LIST_EDITOR_REMOVE_SUCCESS:
+      return state.updateIn(['accounts', 'items'], (list) =>
+        list.filterNot((item) => item === action.accountId),
+      );
+    default:
+      return state;
   }
 }

--- a/app/javascript/mastodon/reducers/lists.js
+++ b/app/javascript/mastodon/reducers/lists.js
@@ -14,7 +14,7 @@ const initialState = ImmutableMap();
 const normalizeList = (state, list) => state.set(list.id, fromJS(list));
 
 const normalizeLists = (state, lists) => {
-  lists.forEach(list => {
+  lists.forEach((list) => {
     state = normalizeList(state, list);
   });
 
@@ -22,17 +22,17 @@ const normalizeLists = (state, lists) => {
 };
 
 export default function lists(state = initialState, action) {
-  switch(action.type) {
-  case LIST_FETCH_SUCCESS:
-  case LIST_CREATE_SUCCESS:
-  case LIST_UPDATE_SUCCESS:
-    return normalizeList(state, action.list);
-  case LISTS_FETCH_SUCCESS:
-    return normalizeLists(state, action.lists);
-  case LIST_DELETE_SUCCESS:
-  case LIST_FETCH_FAIL:
-    return state.set(action.id, false);
-  default:
-    return state;
+  switch (action.type) {
+    case LIST_FETCH_SUCCESS:
+    case LIST_CREATE_SUCCESS:
+    case LIST_UPDATE_SUCCESS:
+      return normalizeList(state, action.list);
+    case LISTS_FETCH_SUCCESS:
+      return normalizeLists(state, action.lists);
+    case LIST_DELETE_SUCCESS:
+    case LIST_FETCH_FAIL:
+      return state.set(action.id, false);
+    default:
+      return state;
   }
 }

--- a/app/javascript/mastodon/reducers/markers.js
+++ b/app/javascript/mastodon/reducers/markers.js
@@ -1,9 +1,6 @@
 import { Map as ImmutableMap } from 'immutable';
 
-import {
-  MARKERS_SUBMIT_SUCCESS,
-} from '../actions/markers';
-
+import { MARKERS_SUBMIT_SUCCESS } from '../actions/markers';
 
 const initialState = ImmutableMap({
   home: '0',
@@ -11,16 +8,16 @@ const initialState = ImmutableMap({
 });
 
 export default function markers(state = initialState, action) {
-  switch(action.type) {
-  case MARKERS_SUBMIT_SUCCESS:
-    if (action.home) {
-      state = state.set('home', action.home);
-    }
-    if (action.notifications) {
-      state = state.set('notifications', action.notifications);
-    }
-    return state;
-  default:
-    return state;
+  switch (action.type) {
+    case MARKERS_SUBMIT_SUCCESS:
+      if (action.home) {
+        state = state.set('home', action.home);
+      }
+      if (action.notifications) {
+        state = state.set('notifications', action.notifications);
+      }
+      return state;
+    default:
+      return state;
   }
 }

--- a/app/javascript/mastodon/reducers/media_attachments.js
+++ b/app/javascript/mastodon/reducers/media_attachments.js
@@ -7,10 +7,10 @@ const initialState = ImmutableMap({
 });
 
 export default function meta(state = initialState, action) {
-  switch(action.type) {
-  case STORE_HYDRATE:
-    return state.merge(action.state.get('media_attachments'));
-  default:
-    return state;
+  switch (action.type) {
+    case STORE_HYDRATE:
+      return state.merge(action.state.get('media_attachments'));
+    default:
+      return state;
   }
 }

--- a/app/javascript/mastodon/reducers/meta.js
+++ b/app/javascript/mastodon/reducers/meta.js
@@ -12,12 +12,14 @@ const initialState = ImmutableMap({
 });
 
 export default function meta(state = initialState, action) {
-  switch(action.type) {
-  case STORE_HYDRATE:
-    return state.merge(action.state.get('meta')).set('permissions', action.state.getIn(['role', 'permissions']));
-  case changeLayout.type:
-    return state.set('layout', action.payload.layout);
-  default:
-    return state;
+  switch (action.type) {
+    case STORE_HYDRATE:
+      return state
+        .merge(action.state.get('meta'))
+        .set('permissions', action.state.getIn(['role', 'permissions']));
+    case changeLayout.type:
+      return state.set('layout', action.payload.layout);
+    default:
+      return state;
   }
 }

--- a/app/javascript/mastodon/reducers/mutes.js
+++ b/app/javascript/mastodon/reducers/mutes.js
@@ -16,16 +16,16 @@ const initialState = Immutable.Map({
 
 export default function mutes(state = initialState, action) {
   switch (action.type) {
-  case MUTES_INIT_MODAL:
-    return state.withMutations((state) => {
-      state.setIn(['new', 'account'], action.account);
-      state.setIn(['new', 'notifications'], true);
-    });
-  case MUTES_TOGGLE_HIDE_NOTIFICATIONS:
-    return state.updateIn(['new', 'notifications'], (old) => !old);
-  case MUTES_CHANGE_DURATION:
-    return state.setIn(['new', 'duration'], Number(action.duration));
-  default:
-    return state;
+    case MUTES_INIT_MODAL:
+      return state.withMutations((state) => {
+        state.setIn(['new', 'account'], action.account);
+        state.setIn(['new', 'notifications'], true);
+      });
+    case MUTES_TOGGLE_HIDE_NOTIFICATIONS:
+      return state.updateIn(['new', 'notifications'], (old) => !old);
+    case MUTES_CHANGE_DURATION:
+      return state.setIn(['new', 'duration'], Number(action.duration));
+    default:
+      return state;
   }
 }

--- a/app/javascript/mastodon/reducers/picture_in_picture.js
+++ b/app/javascript/mastodon/reducers/picture_in_picture.js
@@ -1,4 +1,7 @@
-import { PICTURE_IN_PICTURE_DEPLOY, PICTURE_IN_PICTURE_REMOVE } from 'mastodon/actions/picture_in_picture';
+import {
+  PICTURE_IN_PICTURE_DEPLOY,
+  PICTURE_IN_PICTURE_REMOVE,
+} from 'mastodon/actions/picture_in_picture';
 
 import { TIMELINE_DELETE } from '../actions/timelines';
 
@@ -13,14 +16,19 @@ const initialState = {
 };
 
 export default function pictureInPicture(state = initialState, action) {
-  switch(action.type) {
-  case PICTURE_IN_PICTURE_DEPLOY:
-    return { statusId: action.statusId, accountId: action.accountId, type: action.playerType, ...action.props };
-  case PICTURE_IN_PICTURE_REMOVE:
-    return { ...initialState };
-  case TIMELINE_DELETE:
-    return (state.statusId === action.id) ? { ...initialState } : state;
-  default:
-    return state;
+  switch (action.type) {
+    case PICTURE_IN_PICTURE_DEPLOY:
+      return {
+        statusId: action.statusId,
+        accountId: action.accountId,
+        type: action.playerType,
+        ...action.props,
+      };
+    case PICTURE_IN_PICTURE_REMOVE:
+      return { ...initialState };
+    case TIMELINE_DELETE:
+      return state.statusId === action.id ? { ...initialState } : state;
+    default:
+      return state;
   }
 }

--- a/app/javascript/mastodon/reducers/polls.js
+++ b/app/javascript/mastodon/reducers/polls.js
@@ -3,28 +3,39 @@ import { Map as ImmutableMap, fromJS } from 'immutable';
 import { POLLS_IMPORT } from 'mastodon/actions/importer';
 
 import { normalizePollOptionTranslation } from '../actions/importer/normalizer';
-import { STATUS_TRANSLATE_SUCCESS, STATUS_TRANSLATE_UNDO } from '../actions/statuses';
+import {
+  STATUS_TRANSLATE_SUCCESS,
+  STATUS_TRANSLATE_UNDO,
+} from '../actions/statuses';
 
-const importPolls = (state, polls) => state.withMutations(map => polls.forEach(poll => map.set(poll.id, fromJS(poll))));
+const importPolls = (state, polls) =>
+  state.withMutations((map) =>
+    polls.forEach((poll) => map.set(poll.id, fromJS(poll))),
+  );
 
 const statusTranslateSuccess = (state, pollTranslation) => {
-  return state.withMutations(map => {
+  return state.withMutations((map) => {
     if (pollTranslation) {
       const poll = state.get(pollTranslation.id);
 
       pollTranslation.options.forEach((item, index) => {
-        map.setIn([pollTranslation.id, 'options', index, 'translation'], fromJS(normalizePollOptionTranslation(item, poll)));
+        map.setIn(
+          [pollTranslation.id, 'options', index, 'translation'],
+          fromJS(normalizePollOptionTranslation(item, poll)),
+        );
       });
     }
   });
 };
 
 const statusTranslateUndo = (state, id) => {
-  return state.withMutations(map => {
+  return state.withMutations((map) => {
     const options = map.getIn([id, 'options']);
 
     if (options) {
-      options.forEach((item, index) => map.deleteIn([id, 'options', index, 'translation']));
+      options.forEach((item, index) =>
+        map.deleteIn([id, 'options', index, 'translation']),
+      );
     }
   });
 };
@@ -32,14 +43,14 @@ const statusTranslateUndo = (state, id) => {
 const initialState = ImmutableMap();
 
 export default function polls(state = initialState, action) {
-  switch(action.type) {
-  case POLLS_IMPORT:
-    return importPolls(state, action.polls);
-  case STATUS_TRANSLATE_SUCCESS:
-    return statusTranslateSuccess(state, action.translation.poll);
-  case STATUS_TRANSLATE_UNDO:
-    return statusTranslateUndo(state, action.pollId);
-  default:
-    return state;
+  switch (action.type) {
+    case POLLS_IMPORT:
+      return importPolls(state, action.polls);
+    case STATUS_TRANSLATE_SUCCESS:
+      return statusTranslateSuccess(state, action.translation.poll);
+    case STATUS_TRANSLATE_UNDO:
+      return statusTranslateUndo(state, action.pollId);
+    default:
+      return state;
   }
 }

--- a/app/javascript/mastodon/reducers/push_notifications.js
+++ b/app/javascript/mastodon/reducers/push_notifications.js
@@ -1,6 +1,11 @@
 import Immutable from 'immutable';
 
-import { SET_BROWSER_SUPPORT, SET_SUBSCRIPTION, CLEAR_SUBSCRIPTION, SET_ALERTS } from '../actions/push_notifications';
+import {
+  SET_BROWSER_SUPPORT,
+  SET_SUBSCRIPTION,
+  CLEAR_SUBSCRIPTION,
+  SET_ALERTS,
+} from '../actions/push_notifications';
 import { STORE_HYDRATE } from '../actions/store';
 
 const initialState = Immutable.Map({
@@ -18,37 +23,46 @@ const initialState = Immutable.Map({
 });
 
 export default function push_subscriptions(state = initialState, action) {
-  switch(action.type) {
-  case STORE_HYDRATE: {
-    const push_subscription = action.state.get('push_subscription');
+  switch (action.type) {
+    case STORE_HYDRATE: {
+      const push_subscription = action.state.get('push_subscription');
 
-    if (push_subscription) {
-      return state
-        .set('subscription', new Immutable.Map({
-          id: push_subscription.get('id'),
-          endpoint: push_subscription.get('endpoint'),
-        }))
-        .set('alerts', push_subscription.get('alerts') || initialState.get('alerts'))
-        .set('isSubscribed', true);
+      if (push_subscription) {
+        return state
+          .set(
+            'subscription',
+            new Immutable.Map({
+              id: push_subscription.get('id'),
+              endpoint: push_subscription.get('endpoint'),
+            }),
+          )
+          .set(
+            'alerts',
+            push_subscription.get('alerts') || initialState.get('alerts'),
+          )
+          .set('isSubscribed', true);
+      }
+
+      return state;
     }
-
-    return state;
-  }
-  case SET_SUBSCRIPTION:
-    return state
-      .set('subscription', new Immutable.Map({
-        id: action.subscription.id,
-        endpoint: action.subscription.endpoint,
-      }))
-      .set('alerts', new Immutable.Map(action.subscription.alerts))
-      .set('isSubscribed', true);
-  case SET_BROWSER_SUPPORT:
-    return state.set('browserSupport', action.value);
-  case CLEAR_SUBSCRIPTION:
-    return initialState;
-  case SET_ALERTS:
-    return state.setIn(action.path, action.value);
-  default:
-    return state;
+    case SET_SUBSCRIPTION:
+      return state
+        .set(
+          'subscription',
+          new Immutable.Map({
+            id: action.subscription.id,
+            endpoint: action.subscription.endpoint,
+          }),
+        )
+        .set('alerts', new Immutable.Map(action.subscription.alerts))
+        .set('isSubscribed', true);
+    case SET_BROWSER_SUPPORT:
+      return state.set('browserSupport', action.value);
+    case CLEAR_SUBSCRIPTION:
+      return initialState;
+    case SET_ALERTS:
+      return state.setIn(action.path, action.value);
+    default:
+      return state;
   }
 }

--- a/app/javascript/mastodon/reducers/relationships.js
+++ b/app/javascript/mastodon/reducers/relationships.js
@@ -1,8 +1,6 @@
 import { Map as ImmutableMap, fromJS } from 'immutable';
 
-import {
-  submitAccountNote,
-} from '../actions/account_notes';
+import { submitAccountNote } from '../actions/account_notes';
 import {
   ACCOUNT_FOLLOW_SUCCESS,
   ACCOUNT_FOLLOW_REQUEST,
@@ -24,15 +22,13 @@ import {
   DOMAIN_BLOCK_SUCCESS,
   DOMAIN_UNBLOCK_SUCCESS,
 } from '../actions/domain_blocks';
-import {
-  NOTIFICATIONS_UPDATE,
-} from '../actions/notifications';
+import { NOTIFICATIONS_UPDATE } from '../actions/notifications';
 
-
-const normalizeRelationship = (state, relationship) => state.set(relationship.id, fromJS(relationship));
+const normalizeRelationship = (state, relationship) =>
+  state.set(relationship.id, fromJS(relationship));
 
 const normalizeRelationships = (state, relationships) => {
-  relationships.forEach(relationship => {
+  relationships.forEach((relationship) => {
     state = normalizeRelationship(state, relationship);
   });
 
@@ -40,8 +36,8 @@ const normalizeRelationships = (state, relationships) => {
 };
 
 const setDomainBlocking = (state, accounts, blocking) => {
-  return state.withMutations(map => {
-    accounts.forEach(id => {
+  return state.withMutations((map) => {
+    accounts.forEach((id) => {
       map.setIn([id, 'domain_blocking'], blocking);
     });
   });
@@ -50,39 +46,53 @@ const setDomainBlocking = (state, accounts, blocking) => {
 const initialState = ImmutableMap();
 
 export default function relationships(state = initialState, action) {
-  switch(action.type) {
-  case FOLLOW_REQUEST_AUTHORIZE_SUCCESS:
-    return state.setIn([action.id, 'followed_by'], true).setIn([action.id, 'requested_by'], false);
-  case FOLLOW_REQUEST_REJECT_SUCCESS:
-    return state.setIn([action.id, 'followed_by'], false).setIn([action.id, 'requested_by'], false);
-  case NOTIFICATIONS_UPDATE:
-    return action.notification.type === 'follow_request' ? state.setIn([action.notification.account.id, 'requested_by'], true) : state;
-  case ACCOUNT_FOLLOW_REQUEST:
-    return state.getIn([action.id, 'following']) ? state : state.setIn([action.id, action.locked ? 'requested' : 'following'], true);
-  case ACCOUNT_FOLLOW_FAIL:
-    return state.setIn([action.id, action.locked ? 'requested' : 'following'], false);
-  case ACCOUNT_UNFOLLOW_REQUEST:
-    return state.setIn([action.id, 'following'], false);
-  case ACCOUNT_UNFOLLOW_FAIL:
-    return state.setIn([action.id, 'following'], true);
-  case ACCOUNT_FOLLOW_SUCCESS:
-  case ACCOUNT_UNFOLLOW_SUCCESS:
-  case ACCOUNT_BLOCK_SUCCESS:
-  case ACCOUNT_UNBLOCK_SUCCESS:
-  case ACCOUNT_MUTE_SUCCESS:
-  case ACCOUNT_UNMUTE_SUCCESS:
-  case ACCOUNT_PIN_SUCCESS:
-  case ACCOUNT_UNPIN_SUCCESS:
-    return normalizeRelationship(state, action.relationship);
-  case RELATIONSHIPS_FETCH_SUCCESS:
-    return normalizeRelationships(state, action.relationships);
-  case submitAccountNote.fulfilled:
-    return normalizeRelationship(state, action.payload.relationship);
-  case DOMAIN_BLOCK_SUCCESS:
-    return setDomainBlocking(state, action.accounts, true);
-  case DOMAIN_UNBLOCK_SUCCESS:
-    return setDomainBlocking(state, action.accounts, false);
-  default:
-    return state;
+  switch (action.type) {
+    case FOLLOW_REQUEST_AUTHORIZE_SUCCESS:
+      return state
+        .setIn([action.id, 'followed_by'], true)
+        .setIn([action.id, 'requested_by'], false);
+    case FOLLOW_REQUEST_REJECT_SUCCESS:
+      return state
+        .setIn([action.id, 'followed_by'], false)
+        .setIn([action.id, 'requested_by'], false);
+    case NOTIFICATIONS_UPDATE:
+      return action.notification.type === 'follow_request'
+        ? state.setIn([action.notification.account.id, 'requested_by'], true)
+        : state;
+    case ACCOUNT_FOLLOW_REQUEST:
+      return state.getIn([action.id, 'following'])
+        ? state
+        : state.setIn(
+            [action.id, action.locked ? 'requested' : 'following'],
+            true,
+          );
+    case ACCOUNT_FOLLOW_FAIL:
+      return state.setIn(
+        [action.id, action.locked ? 'requested' : 'following'],
+        false,
+      );
+    case ACCOUNT_UNFOLLOW_REQUEST:
+      return state.setIn([action.id, 'following'], false);
+    case ACCOUNT_UNFOLLOW_FAIL:
+      return state.setIn([action.id, 'following'], true);
+    case ACCOUNT_FOLLOW_SUCCESS:
+    case ACCOUNT_UNFOLLOW_SUCCESS:
+    case ACCOUNT_BLOCK_SUCCESS:
+    case ACCOUNT_UNBLOCK_SUCCESS:
+    case ACCOUNT_MUTE_SUCCESS:
+    case ACCOUNT_UNMUTE_SUCCESS:
+    case ACCOUNT_PIN_SUCCESS:
+    case ACCOUNT_UNPIN_SUCCESS:
+      return normalizeRelationship(state, action.relationship);
+    case RELATIONSHIPS_FETCH_SUCCESS:
+      return normalizeRelationships(state, action.relationships);
+    case submitAccountNote.fulfilled:
+      return normalizeRelationship(state, action.payload.relationship);
+    case DOMAIN_BLOCK_SUCCESS:
+      return setDomainBlocking(state, action.accounts, true);
+    case DOMAIN_UNBLOCK_SUCCESS:
+      return setDomainBlocking(state, action.accounts, false);
+    default:
+      return state;
   }
 }

--- a/app/javascript/mastodon/reducers/search.js
+++ b/app/javascript/mastodon/reducers/search.js
@@ -1,4 +1,8 @@
-import { Map as ImmutableMap, OrderedSet as ImmutableOrderedSet, fromJS } from 'immutable';
+import {
+  Map as ImmutableMap,
+  OrderedSet as ImmutableOrderedSet,
+  fromJS,
+} from 'immutable';
 
 import {
   COMPOSE_MENTION,
@@ -29,52 +33,64 @@ const initialState = ImmutableMap({
 });
 
 export default function search(state = initialState, action) {
-  switch(action.type) {
-  case SEARCH_CHANGE:
-    return state.set('value', action.value);
-  case SEARCH_CLEAR:
-    return state.withMutations(map => {
-      map.set('value', '');
-      map.set('results', ImmutableMap());
-      map.set('submitted', false);
-      map.set('hidden', false);
-      map.set('searchTerm', '');
-      map.set('type', null);
-    });
-  case SEARCH_SHOW:
-    return state.set('hidden', false);
-  case COMPOSE_REPLY:
-  case COMPOSE_MENTION:
-  case COMPOSE_DIRECT:
-    return state.set('hidden', true);
-  case SEARCH_FETCH_REQUEST:
-    return state.withMutations(map => {
-      map.set('isLoading', true);
-      map.set('submitted', true);
-      map.set('type', action.searchType);
-    });
-  case SEARCH_FETCH_FAIL:
-    return state.set('isLoading', false);
-  case SEARCH_FETCH_SUCCESS:
-    return state.withMutations(map => {
-      map.set('results', ImmutableMap({
-        accounts: ImmutableOrderedSet(action.results.accounts.map(item => item.id)),
-        statuses: ImmutableOrderedSet(action.results.statuses.map(item => item.id)),
-        hashtags: ImmutableOrderedSet(fromJS(action.results.hashtags)),
-      }));
+  switch (action.type) {
+    case SEARCH_CHANGE:
+      return state.set('value', action.value);
+    case SEARCH_CLEAR:
+      return state.withMutations((map) => {
+        map.set('value', '');
+        map.set('results', ImmutableMap());
+        map.set('submitted', false);
+        map.set('hidden', false);
+        map.set('searchTerm', '');
+        map.set('type', null);
+      });
+    case SEARCH_SHOW:
+      return state.set('hidden', false);
+    case COMPOSE_REPLY:
+    case COMPOSE_MENTION:
+    case COMPOSE_DIRECT:
+      return state.set('hidden', true);
+    case SEARCH_FETCH_REQUEST:
+      return state.withMutations((map) => {
+        map.set('isLoading', true);
+        map.set('submitted', true);
+        map.set('type', action.searchType);
+      });
+    case SEARCH_FETCH_FAIL:
+      return state.set('isLoading', false);
+    case SEARCH_FETCH_SUCCESS:
+      return state.withMutations((map) => {
+        map.set(
+          'results',
+          ImmutableMap({
+            accounts: ImmutableOrderedSet(
+              action.results.accounts.map((item) => item.id),
+            ),
+            statuses: ImmutableOrderedSet(
+              action.results.statuses.map((item) => item.id),
+            ),
+            hashtags: ImmutableOrderedSet(fromJS(action.results.hashtags)),
+          }),
+        );
 
-      map.set('searchTerm', action.searchTerm);
-      map.set('type', action.searchType);
-      map.set('isLoading', false);
-    });
-  case SEARCH_EXPAND_REQUEST:
-    return state.set('type', action.searchType);
-  case SEARCH_EXPAND_SUCCESS:
-    const results = action.searchType === 'hashtags' ? ImmutableOrderedSet(fromJS(action.results.hashtags)) : action.results[action.searchType].map(item => item.id);
-    return state.updateIn(['results', action.searchType], list => list.union(results));
-  case SEARCH_HISTORY_UPDATE:
-    return state.set('recent', ImmutableOrderedSet(fromJS(action.recent)));
-  default:
-    return state;
+        map.set('searchTerm', action.searchTerm);
+        map.set('type', action.searchType);
+        map.set('isLoading', false);
+      });
+    case SEARCH_EXPAND_REQUEST:
+      return state.set('type', action.searchType);
+    case SEARCH_EXPAND_SUCCESS:
+      const results =
+        action.searchType === 'hashtags'
+          ? ImmutableOrderedSet(fromJS(action.results.hashtags))
+          : action.results[action.searchType].map((item) => item.id);
+      return state.updateIn(['results', action.searchType], (list) =>
+        list.union(results),
+      );
+    case SEARCH_HISTORY_UPDATE:
+      return state.set('recent', ImmutableOrderedSet(fromJS(action.recent)));
+    default:
+      return state;
   }
 }

--- a/app/javascript/mastodon/reducers/server.js
+++ b/app/javascript/mastodon/reducers/server.js
@@ -33,31 +33,43 @@ const initialState = ImmutableMap({
 
 export default function server(state = initialState, action) {
   switch (action.type) {
-  case SERVER_FETCH_REQUEST:
-    return state.setIn(['server', 'isLoading'], true);
-  case SERVER_FETCH_SUCCESS:
-    return state.set('server', fromJS(action.server)).setIn(['server', 'isLoading'], false);
-  case SERVER_FETCH_FAIL:
-    return state.setIn(['server', 'isLoading'], false);
-  case SERVER_TRANSLATION_LANGUAGES_FETCH_REQUEST:
-    return state.setIn(['translationLanguages', 'isLoading'], true);
-  case SERVER_TRANSLATION_LANGUAGES_FETCH_SUCCESS:
-    return state.setIn(['translationLanguages', 'items'], fromJS(action.translationLanguages)).setIn(['translationLanguages', 'isLoading'], false);
-  case SERVER_TRANSLATION_LANGUAGES_FETCH_FAIL:
-    return state.setIn(['translationLanguages', 'isLoading'], false);
-  case EXTENDED_DESCRIPTION_REQUEST:
-    return state.setIn(['extendedDescription', 'isLoading'], true);
-  case EXTENDED_DESCRIPTION_SUCCESS:
-    return state.set('extendedDescription', fromJS(action.description)).setIn(['extendedDescription', 'isLoading'], false);
-  case EXTENDED_DESCRIPTION_FAIL:
-    return state.setIn(['extendedDescription', 'isLoading'], false);
-  case SERVER_DOMAIN_BLOCKS_FETCH_REQUEST:
-    return state.setIn(['domainBlocks', 'isLoading'], true);
-  case SERVER_DOMAIN_BLOCKS_FETCH_SUCCESS:
-    return state.setIn(['domainBlocks', 'items'], fromJS(action.blocks)).setIn(['domainBlocks', 'isLoading'], false).setIn(['domainBlocks', 'isAvailable'], action.isAvailable);
-  case SERVER_DOMAIN_BLOCKS_FETCH_FAIL:
-    return state.setIn(['domainBlocks', 'isLoading'], false);
-  default:
-    return state;
+    case SERVER_FETCH_REQUEST:
+      return state.setIn(['server', 'isLoading'], true);
+    case SERVER_FETCH_SUCCESS:
+      return state
+        .set('server', fromJS(action.server))
+        .setIn(['server', 'isLoading'], false);
+    case SERVER_FETCH_FAIL:
+      return state.setIn(['server', 'isLoading'], false);
+    case SERVER_TRANSLATION_LANGUAGES_FETCH_REQUEST:
+      return state.setIn(['translationLanguages', 'isLoading'], true);
+    case SERVER_TRANSLATION_LANGUAGES_FETCH_SUCCESS:
+      return state
+        .setIn(
+          ['translationLanguages', 'items'],
+          fromJS(action.translationLanguages),
+        )
+        .setIn(['translationLanguages', 'isLoading'], false);
+    case SERVER_TRANSLATION_LANGUAGES_FETCH_FAIL:
+      return state.setIn(['translationLanguages', 'isLoading'], false);
+    case EXTENDED_DESCRIPTION_REQUEST:
+      return state.setIn(['extendedDescription', 'isLoading'], true);
+    case EXTENDED_DESCRIPTION_SUCCESS:
+      return state
+        .set('extendedDescription', fromJS(action.description))
+        .setIn(['extendedDescription', 'isLoading'], false);
+    case EXTENDED_DESCRIPTION_FAIL:
+      return state.setIn(['extendedDescription', 'isLoading'], false);
+    case SERVER_DOMAIN_BLOCKS_FETCH_REQUEST:
+      return state.setIn(['domainBlocks', 'isLoading'], true);
+    case SERVER_DOMAIN_BLOCKS_FETCH_SUCCESS:
+      return state
+        .setIn(['domainBlocks', 'items'], fromJS(action.blocks))
+        .setIn(['domainBlocks', 'isLoading'], false)
+        .setIn(['domainBlocks', 'isAvailable'], action.isAvailable);
+    case SERVER_DOMAIN_BLOCKS_FETCH_FAIL:
+      return state.setIn(['domainBlocks', 'isLoading'], false);
+    default:
+      return state;
   }
 }

--- a/app/javascript/mastodon/reducers/settings.js
+++ b/app/javascript/mastodon/reducers/settings.js
@@ -1,6 +1,11 @@
 import { Map as ImmutableMap, fromJS } from 'immutable';
 
-import { COLUMN_ADD, COLUMN_REMOVE, COLUMN_MOVE, COLUMN_PARAMS_CHANGE } from '../actions/columns';
+import {
+  COLUMN_ADD,
+  COLUMN_REMOVE,
+  COLUMN_MOVE,
+  COLUMN_PARAMS_CHANGE,
+} from '../actions/columns';
 import { EMOJI_USE } from '../actions/emojis';
 import { LANGUAGE_USE } from '../actions/languages';
 import { LIST_DELETE_SUCCESS, LIST_FETCH_FAIL } from '../actions/lists';
@@ -108,11 +113,12 @@ const defaultColumns = fromJS([
   { id: 'NOTIFICATIONS', uuid: uuid(), params: {} },
 ]);
 
-const hydrate = (state, settings) => state.mergeDeep(settings).update('columns', (val = defaultColumns) => val);
+const hydrate = (state, settings) =>
+  state.mergeDeep(settings).update('columns', (val = defaultColumns) => val);
 
 const moveColumn = (state, uuid, direction) => {
-  const columns  = state.get('columns');
-  const index    = columns.findIndex(item => item.get('uuid') === uuid);
+  const columns = state.get('columns');
+  const index = columns.findIndex((item) => item.get('uuid') === uuid);
   const newIndex = index + direction;
 
   let newColumns;
@@ -120,60 +126,81 @@ const moveColumn = (state, uuid, direction) => {
   newColumns = columns.splice(index, 1);
   newColumns = newColumns.splice(newIndex, 0, columns.get(index));
 
-  return state
-    .set('columns', newColumns)
-    .set('saved', false);
+  return state.set('columns', newColumns).set('saved', false);
 };
 
 const changeColumnParams = (state, uuid, path, value) => {
   const columns = state.get('columns');
-  const index   = columns.findIndex(item => item.get('uuid') === uuid);
+  const index = columns.findIndex((item) => item.get('uuid') === uuid);
 
-  const newColumns = columns.update(index, column => column.updateIn(['params', ...path], () => value));
+  const newColumns = columns.update(index, (column) =>
+    column.updateIn(['params', ...path], () => value),
+  );
 
-  return state
-    .set('columns', newColumns)
-    .set('saved', false);
+  return state.set('columns', newColumns).set('saved', false);
 };
 
-const updateFrequentEmojis = (state, emoji) => state.update('frequentlyUsedEmojis', ImmutableMap(), map => map.update(emoji.id, 0, count => count + 1)).set('saved', false);
+const updateFrequentEmojis = (state, emoji) =>
+  state
+    .update('frequentlyUsedEmojis', ImmutableMap(), (map) =>
+      map.update(emoji.id, 0, (count) => count + 1),
+    )
+    .set('saved', false);
 
-const updateFrequentLanguages = (state, language) => state.update('frequentlyUsedLanguages', ImmutableMap(), map => map.update(language, 0, count => count + 1)).set('saved', false);
+const updateFrequentLanguages = (state, language) =>
+  state
+    .update('frequentlyUsedLanguages', ImmutableMap(), (map) =>
+      map.update(language, 0, (count) => count + 1),
+    )
+    .set('saved', false);
 
-const filterDeadListColumns = (state, listId) => state.update('columns', columns => columns.filterNot(column => column.get('id') === 'LIST' && column.get('params').get('id') === listId));
+const filterDeadListColumns = (state, listId) =>
+  state.update('columns', (columns) =>
+    columns.filterNot(
+      (column) =>
+        column.get('id') === 'LIST' &&
+        column.get('params').get('id') === listId,
+    ),
+  );
 
 export default function settings(state = initialState, action) {
-  switch(action.type) {
-  case STORE_HYDRATE:
-    return hydrate(state, action.state.get('settings'));
-  case NOTIFICATIONS_FILTER_SET:
-  case SETTING_CHANGE:
-    return state
-      .setIn(action.path, action.value)
-      .set('saved', false);
-  case COLUMN_ADD:
-    return state
-      .update('columns', list => list.push(fromJS({ id: action.id, uuid: uuid(), params: action.params })))
-      .set('saved', false);
-  case COLUMN_REMOVE:
-    return state
-      .update('columns', list => list.filterNot(item => item.get('uuid') === action.uuid))
-      .set('saved', false);
-  case COLUMN_MOVE:
-    return moveColumn(state, action.uuid, action.direction);
-  case COLUMN_PARAMS_CHANGE:
-    return changeColumnParams(state, action.uuid, action.path, action.value);
-  case EMOJI_USE:
-    return updateFrequentEmojis(state, action.emoji);
-  case LANGUAGE_USE:
-    return updateFrequentLanguages(state, action.language);
-  case SETTING_SAVE:
-    return state.set('saved', true);
-  case LIST_FETCH_FAIL:
-    return action.error.response.status === 404 ? filterDeadListColumns(state, action.id) : state;
-  case LIST_DELETE_SUCCESS:
-    return filterDeadListColumns(state, action.id);
-  default:
-    return state;
+  switch (action.type) {
+    case STORE_HYDRATE:
+      return hydrate(state, action.state.get('settings'));
+    case NOTIFICATIONS_FILTER_SET:
+    case SETTING_CHANGE:
+      return state.setIn(action.path, action.value).set('saved', false);
+    case COLUMN_ADD:
+      return state
+        .update('columns', (list) =>
+          list.push(
+            fromJS({ id: action.id, uuid: uuid(), params: action.params }),
+          ),
+        )
+        .set('saved', false);
+    case COLUMN_REMOVE:
+      return state
+        .update('columns', (list) =>
+          list.filterNot((item) => item.get('uuid') === action.uuid),
+        )
+        .set('saved', false);
+    case COLUMN_MOVE:
+      return moveColumn(state, action.uuid, action.direction);
+    case COLUMN_PARAMS_CHANGE:
+      return changeColumnParams(state, action.uuid, action.path, action.value);
+    case EMOJI_USE:
+      return updateFrequentEmojis(state, action.emoji);
+    case LANGUAGE_USE:
+      return updateFrequentLanguages(state, action.language);
+    case SETTING_SAVE:
+      return state.set('saved', true);
+    case LIST_FETCH_FAIL:
+      return action.error.response.status === 404
+        ? filterDeadListColumns(state, action.id)
+        : state;
+    case LIST_DELETE_SUCCESS:
+      return filterDeadListColumns(state, action.id);
+    default:
+      return state;
   }
 }

--- a/app/javascript/mastodon/reducers/status_lists.js
+++ b/app/javascript/mastodon/reducers/status_lists.js
@@ -1,4 +1,7 @@
-import { Map as ImmutableMap, OrderedSet as ImmutableOrderedSet } from 'immutable';
+import {
+  Map as ImmutableMap,
+  OrderedSet as ImmutableOrderedSet,
+} from 'immutable';
 
 import {
   ACCOUNT_BLOCK_SUCCESS,
@@ -28,9 +31,7 @@ import {
   PIN_SUCCESS,
   UNPIN_SUCCESS,
 } from '../actions/interactions';
-import {
-  PINNED_STATUSES_FETCH_SUCCESS,
-} from '../actions/pin_statuses';
+import { PINNED_STATUSES_FETCH_SUCCESS } from '../actions/pin_statuses';
 import {
   TRENDS_STATUSES_FETCH_REQUEST,
   TRENDS_STATUSES_FETCH_SUCCESS,
@@ -39,8 +40,6 @@ import {
   TRENDS_STATUSES_EXPAND_SUCCESS,
   TRENDS_STATUSES_EXPAND_FAIL,
 } from '../actions/trends';
-
-
 
 const initialState = ImmutableMap({
   favourites: ImmutableMap({
@@ -66,20 +65,24 @@ const initialState = ImmutableMap({
 });
 
 const normalizeList = (state, listType, statuses, next) => {
-  return state.update(listType, listMap => listMap.withMutations(map => {
-    map.set('next', next);
-    map.set('loaded', true);
-    map.set('isLoading', false);
-    map.set('items', ImmutableOrderedSet(statuses.map(item => item.id)));
-  }));
+  return state.update(listType, (listMap) =>
+    listMap.withMutations((map) => {
+      map.set('next', next);
+      map.set('loaded', true);
+      map.set('isLoading', false);
+      map.set('items', ImmutableOrderedSet(statuses.map((item) => item.id)));
+    }),
+  );
 };
 
 const appendToList = (state, listType, statuses, next) => {
-  return state.update(listType, listMap => listMap.withMutations(map => {
-    map.set('next', next);
-    map.set('isLoading', false);
-    map.set('items', map.get('items').union(statuses.map(item => item.id)));
-  }));
+  return state.update(listType, (listMap) =>
+    listMap.withMutations((map) => {
+      map.set('next', next);
+      map.set('isLoading', false);
+      map.set('items', map.get('items').union(statuses.map((item) => item.id)));
+    }),
+  );
 };
 
 const prependOneToList = (state, listType, status) => {
@@ -93,59 +96,70 @@ const prependOneToList = (state, listType, status) => {
 };
 
 const removeOneFromList = (state, listType, status) => {
-  return state.updateIn([listType, 'items'], (list) => list.delete(status.get('id')));
+  return state.updateIn([listType, 'items'], (list) =>
+    list.delete(status.get('id')),
+  );
 };
 
 export default function statusLists(state = initialState, action) {
-  switch(action.type) {
-  case FAVOURITED_STATUSES_FETCH_REQUEST:
-  case FAVOURITED_STATUSES_EXPAND_REQUEST:
-    return state.setIn(['favourites', 'isLoading'], true);
-  case FAVOURITED_STATUSES_FETCH_FAIL:
-  case FAVOURITED_STATUSES_EXPAND_FAIL:
-    return state.setIn(['favourites', 'isLoading'], false);
-  case FAVOURITED_STATUSES_FETCH_SUCCESS:
-    return normalizeList(state, 'favourites', action.statuses, action.next);
-  case FAVOURITED_STATUSES_EXPAND_SUCCESS:
-    return appendToList(state, 'favourites', action.statuses, action.next);
-  case BOOKMARKED_STATUSES_FETCH_REQUEST:
-  case BOOKMARKED_STATUSES_EXPAND_REQUEST:
-    return state.setIn(['bookmarks', 'isLoading'], true);
-  case BOOKMARKED_STATUSES_FETCH_FAIL:
-  case BOOKMARKED_STATUSES_EXPAND_FAIL:
-    return state.setIn(['bookmarks', 'isLoading'], false);
-  case BOOKMARKED_STATUSES_FETCH_SUCCESS:
-    return normalizeList(state, 'bookmarks', action.statuses, action.next);
-  case BOOKMARKED_STATUSES_EXPAND_SUCCESS:
-    return appendToList(state, 'bookmarks', action.statuses, action.next);
-  case TRENDS_STATUSES_FETCH_REQUEST:
-  case TRENDS_STATUSES_EXPAND_REQUEST:
-    return state.setIn(['trending', 'isLoading'], true);
-  case TRENDS_STATUSES_FETCH_FAIL:
-  case TRENDS_STATUSES_EXPAND_FAIL:
-    return state.setIn(['trending', 'isLoading'], false);
-  case TRENDS_STATUSES_FETCH_SUCCESS:
-    return normalizeList(state, 'trending', action.statuses, action.next);
-  case TRENDS_STATUSES_EXPAND_SUCCESS:
-    return appendToList(state, 'trending', action.statuses, action.next);
-  case FAVOURITE_SUCCESS:
-    return prependOneToList(state, 'favourites', action.status);
-  case UNFAVOURITE_SUCCESS:
-    return removeOneFromList(state, 'favourites', action.status);
-  case BOOKMARK_SUCCESS:
-    return prependOneToList(state, 'bookmarks', action.status);
-  case UNBOOKMARK_SUCCESS:
-    return removeOneFromList(state, 'bookmarks', action.status);
-  case PINNED_STATUSES_FETCH_SUCCESS:
-    return normalizeList(state, 'pins', action.statuses, action.next);
-  case PIN_SUCCESS:
-    return prependOneToList(state, 'pins', action.status);
-  case UNPIN_SUCCESS:
-    return removeOneFromList(state, 'pins', action.status);
-  case ACCOUNT_BLOCK_SUCCESS:
-  case ACCOUNT_MUTE_SUCCESS:
-    return state.updateIn(['trending', 'items'], ImmutableOrderedSet(), list => list.filterNot(statusId => action.statuses.getIn([statusId, 'account']) === action.relationship.id));
-  default:
-    return state;
+  switch (action.type) {
+    case FAVOURITED_STATUSES_FETCH_REQUEST:
+    case FAVOURITED_STATUSES_EXPAND_REQUEST:
+      return state.setIn(['favourites', 'isLoading'], true);
+    case FAVOURITED_STATUSES_FETCH_FAIL:
+    case FAVOURITED_STATUSES_EXPAND_FAIL:
+      return state.setIn(['favourites', 'isLoading'], false);
+    case FAVOURITED_STATUSES_FETCH_SUCCESS:
+      return normalizeList(state, 'favourites', action.statuses, action.next);
+    case FAVOURITED_STATUSES_EXPAND_SUCCESS:
+      return appendToList(state, 'favourites', action.statuses, action.next);
+    case BOOKMARKED_STATUSES_FETCH_REQUEST:
+    case BOOKMARKED_STATUSES_EXPAND_REQUEST:
+      return state.setIn(['bookmarks', 'isLoading'], true);
+    case BOOKMARKED_STATUSES_FETCH_FAIL:
+    case BOOKMARKED_STATUSES_EXPAND_FAIL:
+      return state.setIn(['bookmarks', 'isLoading'], false);
+    case BOOKMARKED_STATUSES_FETCH_SUCCESS:
+      return normalizeList(state, 'bookmarks', action.statuses, action.next);
+    case BOOKMARKED_STATUSES_EXPAND_SUCCESS:
+      return appendToList(state, 'bookmarks', action.statuses, action.next);
+    case TRENDS_STATUSES_FETCH_REQUEST:
+    case TRENDS_STATUSES_EXPAND_REQUEST:
+      return state.setIn(['trending', 'isLoading'], true);
+    case TRENDS_STATUSES_FETCH_FAIL:
+    case TRENDS_STATUSES_EXPAND_FAIL:
+      return state.setIn(['trending', 'isLoading'], false);
+    case TRENDS_STATUSES_FETCH_SUCCESS:
+      return normalizeList(state, 'trending', action.statuses, action.next);
+    case TRENDS_STATUSES_EXPAND_SUCCESS:
+      return appendToList(state, 'trending', action.statuses, action.next);
+    case FAVOURITE_SUCCESS:
+      return prependOneToList(state, 'favourites', action.status);
+    case UNFAVOURITE_SUCCESS:
+      return removeOneFromList(state, 'favourites', action.status);
+    case BOOKMARK_SUCCESS:
+      return prependOneToList(state, 'bookmarks', action.status);
+    case UNBOOKMARK_SUCCESS:
+      return removeOneFromList(state, 'bookmarks', action.status);
+    case PINNED_STATUSES_FETCH_SUCCESS:
+      return normalizeList(state, 'pins', action.statuses, action.next);
+    case PIN_SUCCESS:
+      return prependOneToList(state, 'pins', action.status);
+    case UNPIN_SUCCESS:
+      return removeOneFromList(state, 'pins', action.status);
+    case ACCOUNT_BLOCK_SUCCESS:
+    case ACCOUNT_MUTE_SUCCESS:
+      return state.updateIn(
+        ['trending', 'items'],
+        ImmutableOrderedSet(),
+        (list) =>
+          list.filterNot(
+            (statusId) =>
+              action.statuses.getIn([statusId, 'account']) ===
+              action.relationship.id,
+          ),
+      );
+    default:
+      return state;
   }
 }

--- a/app/javascript/mastodon/reducers/statuses.js
+++ b/app/javascript/mastodon/reducers/statuses.js
@@ -32,10 +32,12 @@ import { TIMELINE_DELETE } from '../actions/timelines';
 const importStatus = (state, status) => state.set(status.id, fromJS(status));
 
 const importStatuses = (state, statuses) =>
-  state.withMutations(mutable => statuses.forEach(status => importStatus(mutable, status)));
+  state.withMutations((mutable) =>
+    statuses.forEach((status) => importStatus(mutable, status)),
+  );
 
 const deleteStatus = (state, id, references) => {
-  references.forEach(ref => {
+  references.forEach((ref) => {
     state = deleteStatus(state, ref, []);
   });
 
@@ -43,91 +45,117 @@ const deleteStatus = (state, id, references) => {
 };
 
 const statusTranslateSuccess = (state, id, translation) => {
-  return state.withMutations(map => {
-    map.setIn([id, 'translation'], fromJS(normalizeStatusTranslation(translation, map.get(id))));
+  return state.withMutations((map) => {
+    map.setIn(
+      [id, 'translation'],
+      fromJS(normalizeStatusTranslation(translation, map.get(id))),
+    );
 
     const list = map.getIn([id, 'media_attachments']);
     if (translation.media_attachments && list) {
-      translation.media_attachments.forEach(item => {
-        const index = list.findIndex(i => i.get('id') === item.id);
-        map.setIn([id, 'media_attachments', index, 'translation'], fromJS({ description: item.description }));
+      translation.media_attachments.forEach((item) => {
+        const index = list.findIndex((i) => i.get('id') === item.id);
+        map.setIn(
+          [id, 'media_attachments', index, 'translation'],
+          fromJS({ description: item.description }),
+        );
       });
     }
   });
 };
 
 const statusTranslateUndo = (state, id) => {
-  return state.withMutations(map => {
+  return state.withMutations((map) => {
     map.deleteIn([id, 'translation']);
-    map.getIn([id, 'media_attachments']).forEach((item, index) => map.deleteIn([id, 'media_attachments', index, 'translation']));
+    map
+      .getIn([id, 'media_attachments'])
+      .forEach((item, index) =>
+        map.deleteIn([id, 'media_attachments', index, 'translation']),
+      );
   });
 };
 
 const initialState = ImmutableMap();
 
 export default function statuses(state = initialState, action) {
-  switch(action.type) {
-  case STATUS_FETCH_REQUEST:
-    return state.setIn([action.id, 'isLoading'], true);
-  case STATUS_FETCH_FAIL:
-    return state.delete(action.id);
-  case STATUS_IMPORT:
-    return importStatus(state, action.status);
-  case STATUSES_IMPORT:
-    return importStatuses(state, action.statuses);
-  case FAVOURITE_REQUEST:
-    return state.setIn([action.status.get('id'), 'favourited'], true);
-  case FAVOURITE_FAIL:
-    return state.get(action.status.get('id')) === undefined ? state : state.setIn([action.status.get('id'), 'favourited'], false);
-  case UNFAVOURITE_REQUEST:
-    return state.setIn([action.status.get('id'), 'favourited'], false);
-  case UNFAVOURITE_FAIL:
-    return state.get(action.status.get('id')) === undefined ? state : state.setIn([action.status.get('id'), 'favourited'], true);
-  case BOOKMARK_REQUEST:
-    return state.get(action.status.get('id')) === undefined ? state : state.setIn([action.status.get('id'), 'bookmarked'], true);
-  case BOOKMARK_FAIL:
-    return state.get(action.status.get('id')) === undefined ? state : state.setIn([action.status.get('id'), 'bookmarked'], false);
-  case UNBOOKMARK_REQUEST:
-    return state.get(action.status.get('id')) === undefined ? state : state.setIn([action.status.get('id'), 'bookmarked'], false);
-  case UNBOOKMARK_FAIL:
-    return state.get(action.status.get('id')) === undefined ? state : state.setIn([action.status.get('id'), 'bookmarked'], true);
-  case REBLOG_REQUEST:
-    return state.setIn([action.status.get('id'), 'reblogged'], true);
-  case REBLOG_FAIL:
-    return state.get(action.status.get('id')) === undefined ? state : state.setIn([action.status.get('id'), 'reblogged'], false);
-  case UNREBLOG_REQUEST:
-    return state.setIn([action.status.get('id'), 'reblogged'], false);
-  case UNREBLOG_FAIL:
-    return state.get(action.status.get('id')) === undefined ? state : state.setIn([action.status.get('id'), 'reblogged'], true);
-  case STATUS_MUTE_SUCCESS:
-    return state.setIn([action.id, 'muted'], true);
-  case STATUS_UNMUTE_SUCCESS:
-    return state.setIn([action.id, 'muted'], false);
-  case STATUS_REVEAL:
-    return state.withMutations(map => {
-      action.ids.forEach(id => {
-        if (!(state.get(id) === undefined)) {
-          map.setIn([id, 'hidden'], false);
-        }
+  switch (action.type) {
+    case STATUS_FETCH_REQUEST:
+      return state.setIn([action.id, 'isLoading'], true);
+    case STATUS_FETCH_FAIL:
+      return state.delete(action.id);
+    case STATUS_IMPORT:
+      return importStatus(state, action.status);
+    case STATUSES_IMPORT:
+      return importStatuses(state, action.statuses);
+    case FAVOURITE_REQUEST:
+      return state.setIn([action.status.get('id'), 'favourited'], true);
+    case FAVOURITE_FAIL:
+      return state.get(action.status.get('id')) === undefined
+        ? state
+        : state.setIn([action.status.get('id'), 'favourited'], false);
+    case UNFAVOURITE_REQUEST:
+      return state.setIn([action.status.get('id'), 'favourited'], false);
+    case UNFAVOURITE_FAIL:
+      return state.get(action.status.get('id')) === undefined
+        ? state
+        : state.setIn([action.status.get('id'), 'favourited'], true);
+    case BOOKMARK_REQUEST:
+      return state.get(action.status.get('id')) === undefined
+        ? state
+        : state.setIn([action.status.get('id'), 'bookmarked'], true);
+    case BOOKMARK_FAIL:
+      return state.get(action.status.get('id')) === undefined
+        ? state
+        : state.setIn([action.status.get('id'), 'bookmarked'], false);
+    case UNBOOKMARK_REQUEST:
+      return state.get(action.status.get('id')) === undefined
+        ? state
+        : state.setIn([action.status.get('id'), 'bookmarked'], false);
+    case UNBOOKMARK_FAIL:
+      return state.get(action.status.get('id')) === undefined
+        ? state
+        : state.setIn([action.status.get('id'), 'bookmarked'], true);
+    case REBLOG_REQUEST:
+      return state.setIn([action.status.get('id'), 'reblogged'], true);
+    case REBLOG_FAIL:
+      return state.get(action.status.get('id')) === undefined
+        ? state
+        : state.setIn([action.status.get('id'), 'reblogged'], false);
+    case UNREBLOG_REQUEST:
+      return state.setIn([action.status.get('id'), 'reblogged'], false);
+    case UNREBLOG_FAIL:
+      return state.get(action.status.get('id')) === undefined
+        ? state
+        : state.setIn([action.status.get('id'), 'reblogged'], true);
+    case STATUS_MUTE_SUCCESS:
+      return state.setIn([action.id, 'muted'], true);
+    case STATUS_UNMUTE_SUCCESS:
+      return state.setIn([action.id, 'muted'], false);
+    case STATUS_REVEAL:
+      return state.withMutations((map) => {
+        action.ids.forEach((id) => {
+          if (!(state.get(id) === undefined)) {
+            map.setIn([id, 'hidden'], false);
+          }
+        });
       });
-    });
-  case STATUS_HIDE:
-    return state.withMutations(map => {
-      action.ids.forEach(id => {
-        if (!(state.get(id) === undefined)) {
-          map.setIn([id, 'hidden'], true);
-        }
+    case STATUS_HIDE:
+      return state.withMutations((map) => {
+        action.ids.forEach((id) => {
+          if (!(state.get(id) === undefined)) {
+            map.setIn([id, 'hidden'], true);
+          }
+        });
       });
-    });
-  case STATUS_COLLAPSE:
-    return state.setIn([action.id, 'collapsed'], action.isCollapsed);
-  case TIMELINE_DELETE:
-    return deleteStatus(state, action.id, action.references);
-  case STATUS_TRANSLATE_SUCCESS:
-    return statusTranslateSuccess(state, action.id, action.translation);
-  case STATUS_TRANSLATE_UNDO:
-    return statusTranslateUndo(state, action.id);
-  default:
-    return state;
+    case STATUS_COLLAPSE:
+      return state.setIn([action.id, 'collapsed'], action.isCollapsed);
+    case TIMELINE_DELETE:
+      return deleteStatus(state, action.id, action.references);
+    case STATUS_TRANSLATE_SUCCESS:
+      return statusTranslateSuccess(state, action.id, action.translation);
+    case STATUS_TRANSLATE_UNDO:
+      return statusTranslateUndo(state, action.id);
+    default:
+      return state;
   }
 }

--- a/app/javascript/mastodon/reducers/suggestions.js
+++ b/app/javascript/mastodon/reducers/suggestions.js
@@ -1,6 +1,9 @@
 import { Map as ImmutableMap, List as ImmutableList, fromJS } from 'immutable';
 
-import { ACCOUNT_BLOCK_SUCCESS, ACCOUNT_MUTE_SUCCESS } from 'mastodon/actions/accounts';
+import {
+  ACCOUNT_BLOCK_SUCCESS,
+  ACCOUNT_MUTE_SUCCESS,
+} from 'mastodon/actions/accounts';
 import { DOMAIN_BLOCK_SUCCESS } from 'mastodon/actions/domain_blocks';
 
 import {
@@ -10,31 +13,41 @@ import {
   SUGGESTIONS_DISMISS,
 } from '../actions/suggestions';
 
-
 const initialState = ImmutableMap({
   items: ImmutableList(),
   isLoading: false,
 });
 
 export default function suggestionsReducer(state = initialState, action) {
-  switch(action.type) {
-  case SUGGESTIONS_FETCH_REQUEST:
-    return state.set('isLoading', true);
-  case SUGGESTIONS_FETCH_SUCCESS:
-    return state.withMutations(map => {
-      map.set('items', fromJS(action.suggestions.map(x => ({ ...x, account: x.account.id }))));
-      map.set('isLoading', false);
-    });
-  case SUGGESTIONS_FETCH_FAIL:
-    return state.set('isLoading', false);
-  case SUGGESTIONS_DISMISS:
-    return state.update('items', list => list.filterNot(x => x.account === action.id));
-  case ACCOUNT_BLOCK_SUCCESS:
-  case ACCOUNT_MUTE_SUCCESS:
-    return state.update('items', list => list.filterNot(x => x.account === action.relationship.id));
-  case DOMAIN_BLOCK_SUCCESS:
-    return state.update('items', list => list.filterNot(x => action.accounts.includes(x.account)));
-  default:
-    return state;
+  switch (action.type) {
+    case SUGGESTIONS_FETCH_REQUEST:
+      return state.set('isLoading', true);
+    case SUGGESTIONS_FETCH_SUCCESS:
+      return state.withMutations((map) => {
+        map.set(
+          'items',
+          fromJS(
+            action.suggestions.map((x) => ({ ...x, account: x.account.id })),
+          ),
+        );
+        map.set('isLoading', false);
+      });
+    case SUGGESTIONS_FETCH_FAIL:
+      return state.set('isLoading', false);
+    case SUGGESTIONS_DISMISS:
+      return state.update('items', (list) =>
+        list.filterNot((x) => x.account === action.id),
+      );
+    case ACCOUNT_BLOCK_SUCCESS:
+    case ACCOUNT_MUTE_SUCCESS:
+      return state.update('items', (list) =>
+        list.filterNot((x) => x.account === action.relationship.id),
+      );
+    case DOMAIN_BLOCK_SUCCESS:
+      return state.update('items', (list) =>
+        list.filterNot((x) => action.accounts.includes(x.account)),
+      );
+    default:
+      return state;
   }
 }

--- a/app/javascript/mastodon/reducers/tags.js
+++ b/app/javascript/mastodon/reducers/tags.js
@@ -11,16 +11,16 @@ import {
 const initialState = ImmutableMap();
 
 export default function tags(state = initialState, action) {
-  switch(action.type) {
-  case HASHTAG_FETCH_SUCCESS:
-    return state.set(action.name, fromJS(action.tag));
-  case HASHTAG_FOLLOW_REQUEST:
-  case HASHTAG_UNFOLLOW_FAIL:
-    return state.setIn([action.name, 'following'], true);
-  case HASHTAG_FOLLOW_FAIL:
-  case HASHTAG_UNFOLLOW_REQUEST:
-    return state.setIn([action.name, 'following'], false);
-  default:
-    return state;
+  switch (action.type) {
+    case HASHTAG_FETCH_SUCCESS:
+      return state.set(action.name, fromJS(action.tag));
+    case HASHTAG_FOLLOW_REQUEST:
+    case HASHTAG_UNFOLLOW_FAIL:
+      return state.setIn([action.name, 'following'], true);
+    case HASHTAG_FOLLOW_FAIL:
+    case HASHTAG_UNFOLLOW_REQUEST:
+      return state.setIn([action.name, 'following'], false);
+    default:
+      return state;
   }
 }

--- a/app/javascript/mastodon/reducers/timelines.js
+++ b/app/javascript/mastodon/reducers/timelines.js
@@ -1,4 +1,9 @@
-import { Map as ImmutableMap, List as ImmutableList, OrderedSet as ImmutableOrderedSet, fromJS } from 'immutable';
+import {
+  Map as ImmutableMap,
+  List as ImmutableList,
+  OrderedSet as ImmutableOrderedSet,
+  fromJS,
+} from 'immutable';
 
 import {
   ACCOUNT_BLOCK_SUCCESS,
@@ -32,7 +37,15 @@ const initialTimeline = ImmutableMap({
   items: ImmutableList(),
 });
 
-const expandNormalizedTimeline = (state, timeline, statuses, next, isPartial, isLoadingRecent, usePendingItems) => {
+const expandNormalizedTimeline = (
+  state,
+  timeline,
+  statuses,
+  next,
+  isPartial,
+  isLoadingRecent,
+  usePendingItems,
+) => {
   // This method is pretty tricky because:
   // - existing items in the timeline might be out of order
   // - the existing timeline may have gaps, most often explicitly noted with a `null` item
@@ -40,77 +53,118 @@ const expandNormalizedTimeline = (state, timeline, statuses, next, isPartial, is
   // - `statuses` may include items that are already included in the timeline
   // - this function can be called either to fill in a gap, or load newer items
 
-  return state.update(timeline, initialTimeline, map => map.withMutations(mMap => {
-    mMap.set('isLoading', false);
-    mMap.set('isPartial', isPartial);
+  return state.update(timeline, initialTimeline, (map) =>
+    map.withMutations((mMap) => {
+      mMap.set('isLoading', false);
+      mMap.set('isPartial', isPartial);
 
-    if (!next && !isLoadingRecent) mMap.set('hasMore', false);
+      if (!next && !isLoadingRecent) mMap.set('hasMore', false);
 
-    if (timeline.endsWith(':pinned')) {
-      mMap.set('items', statuses.map(status => status.get('id')));
-    } else if (!statuses.isEmpty()) {
-      usePendingItems = isLoadingRecent && (usePendingItems || !mMap.get('pendingItems').isEmpty());
-
-      mMap.update(usePendingItems ? 'pendingItems' : 'items', ImmutableList(), oldIds => {
-        const newIds = statuses.map(status => status.get('id'));
-
-        // Now this gets tricky, as we don't necessarily know for sure where the gap to fill is
-        // and some items in the timeline may not be properly ordered.
-
-        // However, we know that `newIds.last()` is the oldest item that was requested and that
-        // there is no “hole” between `newIds.last()` and `newIds.first()`.
-
-        // First, find the furthest (if properly sorted, oldest) item in the timeline that is
-        // newer than the oldest fetched one, as it's most likely that it delimits the gap.
-        // Start the gap *after* that item.
-        const lastIndex = oldIds.findLastIndex(id => id !== null && compareId(id, newIds.last()) >= 0) + 1;
-
-        // Then, try to find the furthest (if properly sorted, oldest) item in the timeline that
-        // is newer than the most recent fetched one, as it delimits a section comprised of only
-        // items older or within `newIds` (or that were deleted from the server, so should be removed
-        // anyway).
-        // Stop the gap *after* that item.
-        const firstIndex = oldIds.take(lastIndex).findLastIndex(id => id !== null && compareId(id, newIds.first()) > 0) + 1;
-
-        let insertedIds = ImmutableOrderedSet(newIds).withMutations(insertedIds => {
-          // It is possible, though unlikely, that the slice we are replacing contains items older
-          // than the elements we got from the API. Get them and add them back at the back of the
-          // slice.
-          const olderIds = oldIds.slice(firstIndex, lastIndex).filter(id => id !== null && compareId(id, newIds.last()) < 0);
-          insertedIds.union(olderIds);
-
-          // Make sure we aren't inserting duplicates
-          insertedIds.subtract(oldIds.take(firstIndex), oldIds.skip(lastIndex));
-        }).toList();
-
-        // Finally, insert a gap marker if the data is marked as partial by the server
-        if (isPartial && (firstIndex === 0 || oldIds.get(firstIndex - 1) !== null)) {
-          insertedIds = insertedIds.unshift(null);
-        }
-
-        return oldIds.take(firstIndex).concat(
-          insertedIds,
-          oldIds.skip(lastIndex),
+      if (timeline.endsWith(':pinned')) {
+        mMap.set(
+          'items',
+          statuses.map((status) => status.get('id')),
         );
-      });
-    }
-  }));
+      } else if (!statuses.isEmpty()) {
+        usePendingItems =
+          isLoadingRecent &&
+          (usePendingItems || !mMap.get('pendingItems').isEmpty());
+
+        mMap.update(
+          usePendingItems ? 'pendingItems' : 'items',
+          ImmutableList(),
+          (oldIds) => {
+            const newIds = statuses.map((status) => status.get('id'));
+
+            // Now this gets tricky, as we don't necessarily know for sure where the gap to fill is
+            // and some items in the timeline may not be properly ordered.
+
+            // However, we know that `newIds.last()` is the oldest item that was requested and that
+            // there is no “hole” between `newIds.last()` and `newIds.first()`.
+
+            // First, find the furthest (if properly sorted, oldest) item in the timeline that is
+            // newer than the oldest fetched one, as it's most likely that it delimits the gap.
+            // Start the gap *after* that item.
+            const lastIndex =
+              oldIds.findLastIndex(
+                (id) => id !== null && compareId(id, newIds.last()) >= 0,
+              ) + 1;
+
+            // Then, try to find the furthest (if properly sorted, oldest) item in the timeline that
+            // is newer than the most recent fetched one, as it delimits a section comprised of only
+            // items older or within `newIds` (or that were deleted from the server, so should be removed
+            // anyway).
+            // Stop the gap *after* that item.
+            const firstIndex =
+              oldIds
+                .take(lastIndex)
+                .findLastIndex(
+                  (id) => id !== null && compareId(id, newIds.first()) > 0,
+                ) + 1;
+
+            let insertedIds = ImmutableOrderedSet(newIds)
+              .withMutations((insertedIds) => {
+                // It is possible, though unlikely, that the slice we are replacing contains items older
+                // than the elements we got from the API. Get them and add them back at the back of the
+                // slice.
+                const olderIds = oldIds
+                  .slice(firstIndex, lastIndex)
+                  .filter(
+                    (id) => id !== null && compareId(id, newIds.last()) < 0,
+                  );
+                insertedIds.union(olderIds);
+
+                // Make sure we aren't inserting duplicates
+                insertedIds.subtract(
+                  oldIds.take(firstIndex),
+                  oldIds.skip(lastIndex),
+                );
+              })
+              .toList();
+
+            // Finally, insert a gap marker if the data is marked as partial by the server
+            if (
+              isPartial &&
+              (firstIndex === 0 || oldIds.get(firstIndex - 1) !== null)
+            ) {
+              insertedIds = insertedIds.unshift(null);
+            }
+
+            return oldIds
+              .take(firstIndex)
+              .concat(insertedIds, oldIds.skip(lastIndex));
+          },
+        );
+      }
+    }),
+  );
 };
 
 const updateTimeline = (state, timeline, status, usePendingItems) => {
   const top = state.getIn([timeline, 'top']);
 
   if (usePendingItems || !state.getIn([timeline, 'pendingItems']).isEmpty()) {
-    if (state.getIn([timeline, 'pendingItems'], ImmutableList()).includes(status.get('id')) || state.getIn([timeline, 'items'], ImmutableList()).includes(status.get('id'))) {
+    if (
+      state
+        .getIn([timeline, 'pendingItems'], ImmutableList())
+        .includes(status.get('id')) ||
+      state
+        .getIn([timeline, 'items'], ImmutableList())
+        .includes(status.get('id'))
+    ) {
       return state;
     }
 
-    return state.update(timeline, initialTimeline, map => map.update('pendingItems', list => list.unshift(status.get('id'))).update('unread', unread => unread + 1));
+    return state.update(timeline, initialTimeline, (map) =>
+      map
+        .update('pendingItems', (list) => list.unshift(status.get('id')))
+        .update('unread', (unread) => unread + 1),
+    );
   }
 
-  const ids        = state.getIn([timeline, 'items'], ImmutableList());
+  const ids = state.getIn([timeline, 'items'], ImmutableList());
   const includesId = ids.includes(status.get('id'));
-  const unread     = state.getIn([timeline, 'unread'], 0);
+  const unread = state.getIn([timeline, 'unread'], 0);
 
   if (includesId) {
     return state;
@@ -118,23 +172,31 @@ const updateTimeline = (state, timeline, status, usePendingItems) => {
 
   let newIds = ids;
 
-  return state.update(timeline, initialTimeline, map => map.withMutations(mMap => {
-    if (!top) mMap.set('unread', unread + 1);
-    if (top && ids.size > 40) newIds = newIds.take(20);
-    mMap.set('items', newIds.unshift(status.get('id')));
-  }));
+  return state.update(timeline, initialTimeline, (map) =>
+    map.withMutations((mMap) => {
+      if (!top) mMap.set('unread', unread + 1);
+      if (top && ids.size > 40) newIds = newIds.take(20);
+      mMap.set('items', newIds.unshift(status.get('id')));
+    }),
+  );
 };
 
 const deleteStatus = (state, id, references, exclude_account = null) => {
-  state.keySeq().forEach(timeline => {
-    if (exclude_account === null || (timeline !== `account:${exclude_account}` && !timeline.startsWith(`account:${exclude_account}:`))) {
-      const helper = list => list.filterNot(item => item === id);
-      state = state.updateIn([timeline, 'items'], helper).updateIn([timeline, 'pendingItems'], helper);
+  state.keySeq().forEach((timeline) => {
+    if (
+      exclude_account === null ||
+      (timeline !== `account:${exclude_account}` &&
+        !timeline.startsWith(`account:${exclude_account}:`))
+    ) {
+      const helper = (list) => list.filterNot((item) => item === id);
+      state = state
+        .updateIn([timeline, 'items'], helper)
+        .updateIn([timeline, 'pendingItems'], helper);
     }
   });
 
   // Remove reblogs of deleted status
-  references.forEach(ref => {
+  references.forEach((ref) => {
     state = deleteStatus(state, ref, [], exclude_account);
   });
 
@@ -148,28 +210,37 @@ const clearTimeline = (state, timeline) => {
 const filterTimelines = (state, relationship, statuses) => {
   let references;
 
-  statuses.forEach(status => {
+  statuses.forEach((status) => {
     if (status.get('account') !== relationship.id) {
       return;
     }
 
-    references = statuses.filter(item => item.get('reblog') === status.get('id')).map(item => item.get('id'));
-    state      = deleteStatus(state, status.get('id'), references, relationship.id);
+    references = statuses
+      .filter((item) => item.get('reblog') === status.get('id'))
+      .map((item) => item.get('id'));
+    state = deleteStatus(state, status.get('id'), references, relationship.id);
   });
 
   return state;
 };
 
 const filterTimeline = (timeline, state, relationship, statuses) => {
-  const helper = list => list.filterNot(statusId => statuses.getIn([statusId, 'account']) === relationship.id);
-  return state.updateIn([timeline, 'items'], ImmutableList(), helper).updateIn([timeline, 'pendingItems'], ImmutableList(), helper);
+  const helper = (list) =>
+    list.filterNot(
+      (statusId) => statuses.getIn([statusId, 'account']) === relationship.id,
+    );
+  return state
+    .updateIn([timeline, 'items'], ImmutableList(), helper)
+    .updateIn([timeline, 'pendingItems'], ImmutableList(), helper);
 };
 
 const updateTop = (state, timeline, top) => {
-  return state.update(timeline, initialTimeline, map => map.withMutations(mMap => {
-    if (top) mMap.set('unread', mMap.get('pendingItems').size);
-    mMap.set('top', top);
-  }));
+  return state.update(timeline, initialTimeline, (map) =>
+    map.withMutations((mMap) => {
+      if (top) mMap.set('unread', mMap.get('pendingItems').size);
+      mMap.set('top', top);
+    }),
+  );
 };
 
 const reconnectTimeline = (state, usePendingItems) => {
@@ -177,51 +248,87 @@ const reconnectTimeline = (state, usePendingItems) => {
     return state;
   }
 
-  return state.withMutations(mMap => {
-    mMap.update(usePendingItems ? 'pendingItems' : 'items', items => items.first() ? items.unshift(null) : items);
+  return state.withMutations((mMap) => {
+    mMap.update(usePendingItems ? 'pendingItems' : 'items', (items) =>
+      items.first() ? items.unshift(null) : items,
+    );
     mMap.set('online', true);
   });
 };
 
 export default function timelines(state = initialState, action) {
-  switch(action.type) {
-  case TIMELINE_LOAD_PENDING:
-    return state.update(action.timeline, initialTimeline, map =>
-      map.update('items', list => map.get('pendingItems').concat(list.take(40))).set('pendingItems', ImmutableList()).set('unread', 0));
-  case TIMELINE_EXPAND_REQUEST:
-    return state.update(action.timeline, initialTimeline, map => map.set('isLoading', true));
-  case TIMELINE_EXPAND_FAIL:
-    return state.update(action.timeline, initialTimeline, map => map.set('isLoading', false));
-  case TIMELINE_EXPAND_SUCCESS:
-    return expandNormalizedTimeline(state, action.timeline, fromJS(action.statuses), action.next, action.partial, action.isLoadingRecent, action.usePendingItems);
-  case TIMELINE_UPDATE:
-    return updateTimeline(state, action.timeline, fromJS(action.status), action.usePendingItems);
-  case TIMELINE_DELETE:
-    return deleteStatus(state, action.id, action.references, action.reblogOf);
-  case TIMELINE_CLEAR:
-    return clearTimeline(state, action.timeline);
-  case ACCOUNT_BLOCK_SUCCESS:
-  case ACCOUNT_MUTE_SUCCESS:
-    return filterTimelines(state, action.relationship, action.statuses);
-  case ACCOUNT_UNFOLLOW_SUCCESS:
-    return filterTimeline('home', state, action.relationship, action.statuses);
-  case TIMELINE_SCROLL_TOP:
-    return updateTop(state, action.timeline, action.top);
-  case TIMELINE_CONNECT:
-    return state.update(action.timeline, initialTimeline, map => reconnectTimeline(map, action.usePendingItems));
-  case TIMELINE_DISCONNECT:
-    return state.update(
-      action.timeline,
-      initialTimeline,
-      map => map.set('online', false).update(action.usePendingItems ? 'pendingItems' : 'items', items => items.first() ? items.unshift(null) : items),
-    );
-  case TIMELINE_MARK_AS_PARTIAL:
-    return state.update(
-      action.timeline,
-      initialTimeline,
-      map => map.set('isPartial', true).set('items', ImmutableList()).set('pendingItems', ImmutableList()).set('unread', 0),
-    );
-  default:
-    return state;
+  switch (action.type) {
+    case TIMELINE_LOAD_PENDING:
+      return state.update(action.timeline, initialTimeline, (map) =>
+        map
+          .update('items', (list) =>
+            map.get('pendingItems').concat(list.take(40)),
+          )
+          .set('pendingItems', ImmutableList())
+          .set('unread', 0),
+      );
+    case TIMELINE_EXPAND_REQUEST:
+      return state.update(action.timeline, initialTimeline, (map) =>
+        map.set('isLoading', true),
+      );
+    case TIMELINE_EXPAND_FAIL:
+      return state.update(action.timeline, initialTimeline, (map) =>
+        map.set('isLoading', false),
+      );
+    case TIMELINE_EXPAND_SUCCESS:
+      return expandNormalizedTimeline(
+        state,
+        action.timeline,
+        fromJS(action.statuses),
+        action.next,
+        action.partial,
+        action.isLoadingRecent,
+        action.usePendingItems,
+      );
+    case TIMELINE_UPDATE:
+      return updateTimeline(
+        state,
+        action.timeline,
+        fromJS(action.status),
+        action.usePendingItems,
+      );
+    case TIMELINE_DELETE:
+      return deleteStatus(state, action.id, action.references, action.reblogOf);
+    case TIMELINE_CLEAR:
+      return clearTimeline(state, action.timeline);
+    case ACCOUNT_BLOCK_SUCCESS:
+    case ACCOUNT_MUTE_SUCCESS:
+      return filterTimelines(state, action.relationship, action.statuses);
+    case ACCOUNT_UNFOLLOW_SUCCESS:
+      return filterTimeline(
+        'home',
+        state,
+        action.relationship,
+        action.statuses,
+      );
+    case TIMELINE_SCROLL_TOP:
+      return updateTop(state, action.timeline, action.top);
+    case TIMELINE_CONNECT:
+      return state.update(action.timeline, initialTimeline, (map) =>
+        reconnectTimeline(map, action.usePendingItems),
+      );
+    case TIMELINE_DISCONNECT:
+      return state.update(action.timeline, initialTimeline, (map) =>
+        map
+          .set('online', false)
+          .update(action.usePendingItems ? 'pendingItems' : 'items', (items) =>
+            items.first() ? items.unshift(null) : items,
+          ),
+      );
+    case TIMELINE_MARK_AS_PARTIAL:
+      return state.update(action.timeline, initialTimeline, (map) =>
+        map
+          .set('isPartial', true)
+          .set('items', ImmutableList())
+          .set('pendingItems', ImmutableList())
+          .set('unread', 0),
+      );
+    default:
+      return state;
   }
 }

--- a/app/javascript/mastodon/reducers/trends.js
+++ b/app/javascript/mastodon/reducers/trends.js
@@ -22,26 +22,26 @@ const initialState = ImmutableMap({
 });
 
 export default function trendsReducer(state = initialState, action) {
-  switch(action.type) {
-  case TRENDS_TAGS_FETCH_REQUEST:
-    return state.setIn(['tags', 'isLoading'], true);
-  case TRENDS_TAGS_FETCH_SUCCESS:
-    return state.withMutations(map => {
-      map.setIn(['tags', 'items'], fromJS(action.trends));
-      map.setIn(['tags', 'isLoading'], false);
-    });
-  case TRENDS_TAGS_FETCH_FAIL:
-    return state.setIn(['tags', 'isLoading'], false);
-  case TRENDS_LINKS_FETCH_REQUEST:
-    return state.setIn(['links', 'isLoading'], true);
-  case TRENDS_LINKS_FETCH_SUCCESS:
-    return state.withMutations(map => {
-      map.setIn(['links', 'items'], fromJS(action.trends));
-      map.setIn(['links', 'isLoading'], false);
-    });
-  case TRENDS_LINKS_FETCH_FAIL:
-    return state.setIn(['links', 'isLoading'], false);
-  default:
-    return state;
+  switch (action.type) {
+    case TRENDS_TAGS_FETCH_REQUEST:
+      return state.setIn(['tags', 'isLoading'], true);
+    case TRENDS_TAGS_FETCH_SUCCESS:
+      return state.withMutations((map) => {
+        map.setIn(['tags', 'items'], fromJS(action.trends));
+        map.setIn(['tags', 'isLoading'], false);
+      });
+    case TRENDS_TAGS_FETCH_FAIL:
+      return state.setIn(['tags', 'isLoading'], false);
+    case TRENDS_LINKS_FETCH_REQUEST:
+      return state.setIn(['links', 'isLoading'], true);
+    case TRENDS_LINKS_FETCH_SUCCESS:
+      return state.withMutations((map) => {
+        map.setIn(['links', 'items'], fromJS(action.trends));
+        map.setIn(['links', 'isLoading'], false);
+      });
+    case TRENDS_LINKS_FETCH_FAIL:
+      return state.setIn(['links', 'isLoading'], false);
+    default:
+      return state;
   }
 }

--- a/app/javascript/mastodon/reducers/user_lists.js
+++ b/app/javascript/mastodon/reducers/user_lists.js
@@ -66,11 +66,7 @@ import {
   MUTES_EXPAND_SUCCESS,
   MUTES_EXPAND_FAIL,
 } from '../actions/mutes';
-import {
-  NOTIFICATIONS_UPDATE,
-} from '../actions/notifications';
-
-
+import { NOTIFICATIONS_UPDATE } from '../actions/notifications';
 
 const initialListState = ImmutableMap({
   next: null,
@@ -90,22 +86,30 @@ const initialState = ImmutableMap({
 });
 
 const normalizeList = (state, path, accounts, next) => {
-  return state.setIn(path, ImmutableMap({
-    next,
-    items: ImmutableList(accounts.map(item => item.id)),
-    isLoading: false,
-  }));
+  return state.setIn(
+    path,
+    ImmutableMap({
+      next,
+      items: ImmutableList(accounts.map((item) => item.id)),
+      isLoading: false,
+    }),
+  );
 };
 
 const appendToList = (state, path, accounts, next) => {
-  return state.updateIn(path, map => {
-    return map.set('next', next).set('isLoading', false).update('items', list => list.concat(accounts.map(item => item.id)));
+  return state.updateIn(path, (map) => {
+    return map
+      .set('next', next)
+      .set('isLoading', false)
+      .update('items', (list) => list.concat(accounts.map((item) => item.id)));
   });
 };
 
 const normalizeFollowRequest = (state, notification) => {
-  return state.updateIn(['follow_requests', 'items'], list => {
-    return list.filterNot(item => item === notification.account.id).unshift(notification.account.id);
+  return state.updateIn(['follow_requests', 'items'], (list) => {
+    return list
+      .filterNot((item) => item === notification.account.id)
+      .unshift(notification.account.id);
   });
 };
 
@@ -115,106 +119,172 @@ const normalizeFeaturedTag = (featuredTags, accountId) => {
 };
 
 const normalizeFeaturedTags = (state, path, featuredTags, accountId) => {
-  return state.setIn(path, ImmutableMap({
-    items: ImmutableList(featuredTags.map(featuredTag => normalizeFeaturedTag(featuredTag, accountId)).sort((a, b) => b.get('statuses_count') - a.get('statuses_count'))),
-    isLoading: false,
-  }));
+  return state.setIn(
+    path,
+    ImmutableMap({
+      items: ImmutableList(
+        featuredTags
+          .map((featuredTag) => normalizeFeaturedTag(featuredTag, accountId))
+          .sort((a, b) => b.get('statuses_count') - a.get('statuses_count')),
+      ),
+      isLoading: false,
+    }),
+  );
 };
 
 export default function userLists(state = initialState, action) {
-  switch(action.type) {
-  case FOLLOWERS_FETCH_SUCCESS:
-    return normalizeList(state, ['followers', action.id], action.accounts, action.next);
-  case FOLLOWERS_EXPAND_SUCCESS:
-    return appendToList(state, ['followers', action.id], action.accounts, action.next);
-  case FOLLOWERS_FETCH_REQUEST:
-  case FOLLOWERS_EXPAND_REQUEST:
-    return state.setIn(['followers', action.id, 'isLoading'], true);
-  case FOLLOWERS_FETCH_FAIL:
-  case FOLLOWERS_EXPAND_FAIL:
-    return state.setIn(['followers', action.id, 'isLoading'], false);
-  case FOLLOWING_FETCH_SUCCESS:
-    return normalizeList(state, ['following', action.id], action.accounts, action.next);
-  case FOLLOWING_EXPAND_SUCCESS:
-    return appendToList(state, ['following', action.id], action.accounts, action.next);
-  case FOLLOWING_FETCH_REQUEST:
-  case FOLLOWING_EXPAND_REQUEST:
-    return state.setIn(['following', action.id, 'isLoading'], true);
-  case FOLLOWING_FETCH_FAIL:
-  case FOLLOWING_EXPAND_FAIL:
-    return state.setIn(['following', action.id, 'isLoading'], false);
-  case REBLOGS_FETCH_SUCCESS:
-    return normalizeList(state, ['reblogged_by', action.id], action.accounts, action.next);
-  case REBLOGS_EXPAND_SUCCESS:
-    return appendToList(state, ['reblogged_by', action.id], action.accounts, action.next);
-  case REBLOGS_FETCH_REQUEST:
-  case REBLOGS_EXPAND_REQUEST:
-    return state.setIn(['reblogged_by', action.id, 'isLoading'], true);
-  case REBLOGS_FETCH_FAIL:
-  case REBLOGS_EXPAND_FAIL:
-    return state.setIn(['reblogged_by', action.id, 'isLoading'], false);
-  case FAVOURITES_FETCH_SUCCESS:
-    return normalizeList(state, ['favourited_by', action.id], action.accounts, action.next);
-  case FAVOURITES_EXPAND_SUCCESS:
-    return appendToList(state, ['favourited_by', action.id], action.accounts, action.next);
-  case FAVOURITES_FETCH_REQUEST:
-  case FAVOURITES_EXPAND_REQUEST:
-    return state.setIn(['favourited_by', action.id, 'isLoading'], true);
-  case FAVOURITES_FETCH_FAIL:
-  case FAVOURITES_EXPAND_FAIL:
-    return state.setIn(['favourited_by', action.id, 'isLoading'], false);
-  case NOTIFICATIONS_UPDATE:
-    return action.notification.type === 'follow_request' ? normalizeFollowRequest(state, action.notification) : state;
-  case FOLLOW_REQUESTS_FETCH_SUCCESS:
-    return normalizeList(state, ['follow_requests'], action.accounts, action.next);
-  case FOLLOW_REQUESTS_EXPAND_SUCCESS:
-    return appendToList(state, ['follow_requests'], action.accounts, action.next);
-  case FOLLOW_REQUESTS_FETCH_REQUEST:
-  case FOLLOW_REQUESTS_EXPAND_REQUEST:
-    return state.setIn(['follow_requests', 'isLoading'], true);
-  case FOLLOW_REQUESTS_FETCH_FAIL:
-  case FOLLOW_REQUESTS_EXPAND_FAIL:
-    return state.setIn(['follow_requests', 'isLoading'], false);
-  case FOLLOW_REQUEST_AUTHORIZE_SUCCESS:
-  case FOLLOW_REQUEST_REJECT_SUCCESS:
-    return state.updateIn(['follow_requests', 'items'], list => list.filterNot(item => item === action.id));
-  case BLOCKS_FETCH_SUCCESS:
-    return normalizeList(state, ['blocks'], action.accounts, action.next);
-  case BLOCKS_EXPAND_SUCCESS:
-    return appendToList(state, ['blocks'], action.accounts, action.next);
-  case BLOCKS_FETCH_REQUEST:
-  case BLOCKS_EXPAND_REQUEST:
-    return state.setIn(['blocks', 'isLoading'], true);
-  case BLOCKS_FETCH_FAIL:
-  case BLOCKS_EXPAND_FAIL:
-    return state.setIn(['blocks', 'isLoading'], false);
-  case MUTES_FETCH_SUCCESS:
-    return normalizeList(state, ['mutes'], action.accounts, action.next);
-  case MUTES_EXPAND_SUCCESS:
-    return appendToList(state, ['mutes'], action.accounts, action.next);
-  case MUTES_FETCH_REQUEST:
-  case MUTES_EXPAND_REQUEST:
-    return state.setIn(['mutes', 'isLoading'], true);
-  case MUTES_FETCH_FAIL:
-  case MUTES_EXPAND_FAIL:
-    return state.setIn(['mutes', 'isLoading'], false);
-  case DIRECTORY_FETCH_SUCCESS:
-    return normalizeList(state, ['directory'], action.accounts, action.next);
-  case DIRECTORY_EXPAND_SUCCESS:
-    return appendToList(state, ['directory'], action.accounts, action.next);
-  case DIRECTORY_FETCH_REQUEST:
-  case DIRECTORY_EXPAND_REQUEST:
-    return state.setIn(['directory', 'isLoading'], true);
-  case DIRECTORY_FETCH_FAIL:
-  case DIRECTORY_EXPAND_FAIL:
-    return state.setIn(['directory', 'isLoading'], false);
-  case FEATURED_TAGS_FETCH_SUCCESS:
-    return normalizeFeaturedTags(state, ['featured_tags', action.id], action.tags, action.id);
-  case FEATURED_TAGS_FETCH_REQUEST:
-    return state.setIn(['featured_tags', action.id, 'isLoading'], true);
-  case FEATURED_TAGS_FETCH_FAIL:
-    return state.setIn(['featured_tags', action.id, 'isLoading'], false);
-  default:
-    return state;
+  switch (action.type) {
+    case FOLLOWERS_FETCH_SUCCESS:
+      return normalizeList(
+        state,
+        ['followers', action.id],
+        action.accounts,
+        action.next,
+      );
+    case FOLLOWERS_EXPAND_SUCCESS:
+      return appendToList(
+        state,
+        ['followers', action.id],
+        action.accounts,
+        action.next,
+      );
+    case FOLLOWERS_FETCH_REQUEST:
+    case FOLLOWERS_EXPAND_REQUEST:
+      return state.setIn(['followers', action.id, 'isLoading'], true);
+    case FOLLOWERS_FETCH_FAIL:
+    case FOLLOWERS_EXPAND_FAIL:
+      return state.setIn(['followers', action.id, 'isLoading'], false);
+    case FOLLOWING_FETCH_SUCCESS:
+      return normalizeList(
+        state,
+        ['following', action.id],
+        action.accounts,
+        action.next,
+      );
+    case FOLLOWING_EXPAND_SUCCESS:
+      return appendToList(
+        state,
+        ['following', action.id],
+        action.accounts,
+        action.next,
+      );
+    case FOLLOWING_FETCH_REQUEST:
+    case FOLLOWING_EXPAND_REQUEST:
+      return state.setIn(['following', action.id, 'isLoading'], true);
+    case FOLLOWING_FETCH_FAIL:
+    case FOLLOWING_EXPAND_FAIL:
+      return state.setIn(['following', action.id, 'isLoading'], false);
+    case REBLOGS_FETCH_SUCCESS:
+      return normalizeList(
+        state,
+        ['reblogged_by', action.id],
+        action.accounts,
+        action.next,
+      );
+    case REBLOGS_EXPAND_SUCCESS:
+      return appendToList(
+        state,
+        ['reblogged_by', action.id],
+        action.accounts,
+        action.next,
+      );
+    case REBLOGS_FETCH_REQUEST:
+    case REBLOGS_EXPAND_REQUEST:
+      return state.setIn(['reblogged_by', action.id, 'isLoading'], true);
+    case REBLOGS_FETCH_FAIL:
+    case REBLOGS_EXPAND_FAIL:
+      return state.setIn(['reblogged_by', action.id, 'isLoading'], false);
+    case FAVOURITES_FETCH_SUCCESS:
+      return normalizeList(
+        state,
+        ['favourited_by', action.id],
+        action.accounts,
+        action.next,
+      );
+    case FAVOURITES_EXPAND_SUCCESS:
+      return appendToList(
+        state,
+        ['favourited_by', action.id],
+        action.accounts,
+        action.next,
+      );
+    case FAVOURITES_FETCH_REQUEST:
+    case FAVOURITES_EXPAND_REQUEST:
+      return state.setIn(['favourited_by', action.id, 'isLoading'], true);
+    case FAVOURITES_FETCH_FAIL:
+    case FAVOURITES_EXPAND_FAIL:
+      return state.setIn(['favourited_by', action.id, 'isLoading'], false);
+    case NOTIFICATIONS_UPDATE:
+      return action.notification.type === 'follow_request'
+        ? normalizeFollowRequest(state, action.notification)
+        : state;
+    case FOLLOW_REQUESTS_FETCH_SUCCESS:
+      return normalizeList(
+        state,
+        ['follow_requests'],
+        action.accounts,
+        action.next,
+      );
+    case FOLLOW_REQUESTS_EXPAND_SUCCESS:
+      return appendToList(
+        state,
+        ['follow_requests'],
+        action.accounts,
+        action.next,
+      );
+    case FOLLOW_REQUESTS_FETCH_REQUEST:
+    case FOLLOW_REQUESTS_EXPAND_REQUEST:
+      return state.setIn(['follow_requests', 'isLoading'], true);
+    case FOLLOW_REQUESTS_FETCH_FAIL:
+    case FOLLOW_REQUESTS_EXPAND_FAIL:
+      return state.setIn(['follow_requests', 'isLoading'], false);
+    case FOLLOW_REQUEST_AUTHORIZE_SUCCESS:
+    case FOLLOW_REQUEST_REJECT_SUCCESS:
+      return state.updateIn(['follow_requests', 'items'], (list) =>
+        list.filterNot((item) => item === action.id),
+      );
+    case BLOCKS_FETCH_SUCCESS:
+      return normalizeList(state, ['blocks'], action.accounts, action.next);
+    case BLOCKS_EXPAND_SUCCESS:
+      return appendToList(state, ['blocks'], action.accounts, action.next);
+    case BLOCKS_FETCH_REQUEST:
+    case BLOCKS_EXPAND_REQUEST:
+      return state.setIn(['blocks', 'isLoading'], true);
+    case BLOCKS_FETCH_FAIL:
+    case BLOCKS_EXPAND_FAIL:
+      return state.setIn(['blocks', 'isLoading'], false);
+    case MUTES_FETCH_SUCCESS:
+      return normalizeList(state, ['mutes'], action.accounts, action.next);
+    case MUTES_EXPAND_SUCCESS:
+      return appendToList(state, ['mutes'], action.accounts, action.next);
+    case MUTES_FETCH_REQUEST:
+    case MUTES_EXPAND_REQUEST:
+      return state.setIn(['mutes', 'isLoading'], true);
+    case MUTES_FETCH_FAIL:
+    case MUTES_EXPAND_FAIL:
+      return state.setIn(['mutes', 'isLoading'], false);
+    case DIRECTORY_FETCH_SUCCESS:
+      return normalizeList(state, ['directory'], action.accounts, action.next);
+    case DIRECTORY_EXPAND_SUCCESS:
+      return appendToList(state, ['directory'], action.accounts, action.next);
+    case DIRECTORY_FETCH_REQUEST:
+    case DIRECTORY_EXPAND_REQUEST:
+      return state.setIn(['directory', 'isLoading'], true);
+    case DIRECTORY_FETCH_FAIL:
+    case DIRECTORY_EXPAND_FAIL:
+      return state.setIn(['directory', 'isLoading'], false);
+    case FEATURED_TAGS_FETCH_SUCCESS:
+      return normalizeFeaturedTags(
+        state,
+        ['featured_tags', action.id],
+        action.tags,
+        action.id,
+      );
+    case FEATURED_TAGS_FETCH_REQUEST:
+      return state.setIn(['featured_tags', action.id, 'isLoading'], true);
+    case FEATURED_TAGS_FETCH_FAIL:
+      return state.setIn(['featured_tags', action.id, 'isLoading'], false);
+    default:
+      return state;
   }
 }

--- a/app/javascript/mastodon/selectors/index.js
+++ b/app/javascript/mastodon/selectors/index.js
@@ -5,22 +5,33 @@ import { toServerSideType } from 'mastodon/utils/filters';
 
 import { me } from '../initial_state';
 
-const getAccountBase         = (state, id) => state.getIn(['accounts', id], null);
-const getAccountCounters     = (state, id) => state.getIn(['accounts_counters', id], null);
-const getAccountRelationship = (state, id) => state.getIn(['relationships', id], null);
-const getAccountMoved        = (state, id) => state.getIn(['accounts', state.getIn(['accounts', id, 'moved'])]);
+const getAccountBase = (state, id) => state.getIn(['accounts', id], null);
+const getAccountCounters = (state, id) =>
+  state.getIn(['accounts_counters', id], null);
+const getAccountRelationship = (state, id) =>
+  state.getIn(['relationships', id], null);
+const getAccountMoved = (state, id) =>
+  state.getIn(['accounts', state.getIn(['accounts', id, 'moved'])]);
 
 export const makeGetAccount = () => {
-  return createSelector([getAccountBase, getAccountCounters, getAccountRelationship, getAccountMoved], (base, counters, relationship, moved) => {
-    if (base === null) {
-      return null;
-    }
+  return createSelector(
+    [
+      getAccountBase,
+      getAccountCounters,
+      getAccountRelationship,
+      getAccountMoved,
+    ],
+    (base, counters, relationship, moved) => {
+      if (base === null) {
+        return null;
+      }
 
-    return base.merge(counters).withMutations(map => {
-      map.set('relationship', relationship);
-      map.set('moved', moved);
-    });
-  });
+      return base.merge(counters).withMutations((map) => {
+        map.set('relationship', relationship);
+        map.set('moved', moved);
+      });
+    },
+  );
 };
 
 const getFilters = (state, { contextType }) => {
@@ -29,16 +40,32 @@ const getFilters = (state, { contextType }) => {
   const serverSideType = toServerSideType(contextType);
   const now = new Date();
 
-  return state.get('filters').filter((filter) => filter.get('context').includes(serverSideType) && (filter.get('expires_at') === null || filter.get('expires_at') > now));
+  return state
+    .get('filters')
+    .filter(
+      (filter) =>
+        filter.get('context').includes(serverSideType) &&
+        (filter.get('expires_at') === null || filter.get('expires_at') > now),
+    );
 };
 
 export const makeGetStatus = () => {
   return createSelector(
     [
       (state, { id }) => state.getIn(['statuses', id]),
-      (state, { id }) => state.getIn(['statuses', state.getIn(['statuses', id, 'reblog'])]),
-      (state, { id }) => state.getIn(['accounts', state.getIn(['statuses', id, 'account'])]),
-      (state, { id }) => state.getIn(['accounts', state.getIn(['statuses', state.getIn(['statuses', id, 'reblog']), 'account'])]),
+      (state, { id }) =>
+        state.getIn(['statuses', state.getIn(['statuses', id, 'reblog'])]),
+      (state, { id }) =>
+        state.getIn(['accounts', state.getIn(['statuses', id, 'account'])]),
+      (state, { id }) =>
+        state.getIn([
+          'accounts',
+          state.getIn([
+            'statuses',
+            state.getIn(['statuses', id, 'reblog']),
+            'account',
+          ]),
+        ]),
       getFilters,
     ],
 
@@ -55,17 +82,29 @@ export const makeGetStatus = () => {
 
       let filtered = false;
       if ((accountReblog || accountBase).get('id') !== me && filters) {
-        let filterResults = statusReblog?.get('filtered') || statusBase.get('filtered') || ImmutableList();
-        if (filterResults.some((result) => filters.getIn([result.get('filter'), 'filter_action']) === 'hide')) {
+        let filterResults =
+          statusReblog?.get('filtered') ||
+          statusBase.get('filtered') ||
+          ImmutableList();
+        if (
+          filterResults.some(
+            (result) =>
+              filters.getIn([result.get('filter'), 'filter_action']) === 'hide',
+          )
+        ) {
           return null;
         }
-        filterResults = filterResults.filter(result => filters.has(result.get('filter')));
+        filterResults = filterResults.filter((result) =>
+          filters.has(result.get('filter')),
+        );
         if (!filterResults.isEmpty()) {
-          filtered = filterResults.map(result => filters.getIn([result.get('filter'), 'title']));
+          filtered = filterResults.map((result) =>
+            filters.getIn([result.get('filter'), 'title']),
+          );
         }
       }
 
-      return statusBase.withMutations(map => {
+      return statusBase.withMutations((map) => {
         map.set('reblog', statusReblog);
         map.set('account', accountBase);
         map.set('matched_filters', filtered);
@@ -75,13 +114,17 @@ export const makeGetStatus = () => {
 };
 
 export const makeGetPictureInPicture = () => {
-  return createSelector([
-    (state, { id }) => state.get('picture_in_picture').statusId === id,
-    (state) => state.getIn(['meta', 'layout']) !== 'mobile',
-  ], (inUse, available) => ImmutableMap({
-    inUse: inUse && available,
-    available,
-  }));
+  return createSelector(
+    [
+      (state, { id }) => state.get('picture_in_picture').statusId === id,
+      (state) => state.getIn(['meta', 'layout']) !== 'mobile',
+    ],
+    (inUse, available) =>
+      ImmutableMap({
+        inUse: inUse && available,
+        available,
+      }),
+  );
 };
 
 const ALERT_DEFAULTS = {
@@ -89,45 +132,75 @@ const ALERT_DEFAULTS = {
   style: false,
 };
 
-export const getAlerts = createSelector(state => state.get('alerts'), alerts =>
-  alerts.map(item => ({
-    ...ALERT_DEFAULTS,
-    ...item,
-  })).toArray());
+export const getAlerts = createSelector(
+  (state) => state.get('alerts'),
+  (alerts) =>
+    alerts
+      .map((item) => ({
+        ...ALERT_DEFAULTS,
+        ...item,
+      }))
+      .toArray(),
+);
 
-export const makeGetNotification = () => createSelector([
-  (_, base)             => base,
-  (state, _, accountId) => state.getIn(['accounts', accountId]),
-], (base, account) => base.set('account', account));
+export const makeGetNotification = () =>
+  createSelector(
+    [
+      (_, base) => base,
+      (state, _, accountId) => state.getIn(['accounts', accountId]),
+    ],
+    (base, account) => base.set('account', account),
+  );
 
-export const makeGetReport = () => createSelector([
-  (_, base) => base,
-  (state, _, targetAccountId) => state.getIn(['accounts', targetAccountId]),
-], (base, targetAccount) => base.set('target_account', targetAccount));
+export const makeGetReport = () =>
+  createSelector(
+    [
+      (_, base) => base,
+      (state, _, targetAccountId) => state.getIn(['accounts', targetAccountId]),
+    ],
+    (base, targetAccount) => base.set('target_account', targetAccount),
+  );
 
-export const getAccountGallery = createSelector([
-  (state, id) => state.getIn(['timelines', `account:${id}:media`, 'items'], ImmutableList()),
-  state       => state.get('statuses'),
-  (state, id) => state.getIn(['accounts', id]),
-], (statusIds, statuses, account) => {
-  let medias = ImmutableList();
+export const getAccountGallery = createSelector(
+  [
+    (state, id) =>
+      state.getIn(
+        ['timelines', `account:${id}:media`, 'items'],
+        ImmutableList(),
+      ),
+    (state) => state.get('statuses'),
+    (state, id) => state.getIn(['accounts', id]),
+  ],
+  (statusIds, statuses, account) => {
+    let medias = ImmutableList();
 
-  statusIds.forEach(statusId => {
-    const status = statuses.get(statusId).set('account', account);
-    medias = medias.concat(status.get('media_attachments').map(media => media.set('status', status)));
-  });
+    statusIds.forEach((statusId) => {
+      const status = statuses.get(statusId).set('account', account);
+      medias = medias.concat(
+        status
+          .get('media_attachments')
+          .map((media) => media.set('status', status)),
+      );
+    });
 
-  return medias;
-});
+    return medias;
+  },
+);
 
-export const getAccountHidden = createSelector([
-  (state, id) => state.getIn(['accounts', id, 'hidden']),
-  (state, id) => state.getIn(['relationships', id, 'following']) || state.getIn(['relationships', id, 'requested']),
-  (state, id) => id === me,
-], (hidden, followingOrRequested, isSelf) => {
-  return hidden && !(isSelf || followingOrRequested);
-});
+export const getAccountHidden = createSelector(
+  [
+    (state, id) => state.getIn(['accounts', id, 'hidden']),
+    (state, id) =>
+      state.getIn(['relationships', id, 'following']) ||
+      state.getIn(['relationships', id, 'requested']),
+    (state, id) => id === me,
+  ],
+  (hidden, followingOrRequested, isSelf) => {
+    return hidden && !(isSelf || followingOrRequested);
+  },
+);
 
-export const getStatusList = createSelector([
-  (state, type) => state.getIn(['status_lists', type, 'items']),
-], (items) => items.toList());
+export const getStatusList = createSelector(
+  [(state, type) => state.getIn(['status_lists', type, 'items'])],
+  (items) => items.toList(),
+);

--- a/app/javascript/mastodon/service_worker/entry.js
+++ b/app/javascript/mastodon/service_worker/entry.js
@@ -58,31 +58,37 @@ registerRoute(
 
 // Cause a new version of a registered Service Worker to replace an existing one
 // that is already installed, and replace the currently active worker on open pages.
-self.addEventListener('install', function(event) {
-  event.waitUntil(Promise.all([openWebCache(), fetchRoot()]).then(([cache, root]) => cache.put('/', root)));
+self.addEventListener('install', function (event) {
+  event.waitUntil(
+    Promise.all([openWebCache(), fetchRoot()]).then(([cache, root]) =>
+      cache.put('/', root),
+    ),
+  );
 });
 
-self.addEventListener('activate', function(event) {
+self.addEventListener('activate', function (event) {
   event.waitUntil(self.clients.claim());
 });
 
-self.addEventListener('fetch', function(event) {
+self.addEventListener('fetch', function (event) {
   const url = new URL(event.request.url);
 
   if (url.pathname === '/auth/sign_out') {
     const asyncResponse = fetch(event.request);
     const asyncCache = openWebCache();
 
-    event.respondWith(asyncResponse.then(response => {
-      if (response.ok || response.type === 'opaqueredirect') {
-        return Promise.all([
-          asyncCache.then(cache => cache.delete('/')),
-          indexedDB.deleteDatabase('mastodon'),
-        ]).then(() => response);
-      }
+    event.respondWith(
+      asyncResponse.then((response) => {
+        if (response.ok || response.type === 'opaqueredirect') {
+          return Promise.all([
+            asyncCache.then((cache) => cache.delete('/')),
+            indexedDB.deleteDatabase('mastodon'),
+          ]).then(() => response);
+        }
 
-      return response;
-    }));
+        return response;
+      }),
+    );
   }
 });
 

--- a/app/javascript/mastodon/service_worker/web_push_locales.js
+++ b/app/javascript/mastodon/service_worker/web_push_locales.js
@@ -3,18 +3,21 @@
 
 /* @preval */
 
-const fs   = require('fs');
+const fs = require('fs');
 const path = require('path');
 
-const filtered  = {};
+const filtered = {};
 const filenames = fs.readdirSync(path.resolve(__dirname, '../locales'));
 
-filenames.forEach(filename => {
+filenames.forEach((filename) => {
   if (!filename.match(/\.json$/)) return;
 
-  const content = fs.readFileSync(path.resolve(__dirname, `../locales/${filename}`), 'utf-8');
-  const full    = JSON.parse(content);
-  const locale  = filename.split('.')[0];
+  const content = fs.readFileSync(
+    path.resolve(__dirname, `../locales/${filename}`),
+    'utf-8',
+  );
+  const full = JSON.parse(content);
+  const locale = filename.split('.')[0];
 
   filtered[locale] = {
     'notification.favourite': full['notification.favourite'] || '',

--- a/app/javascript/mastodon/service_worker/web_push_notifications.js
+++ b/app/javascript/mastodon/service_worker/web_push_notifications.js
@@ -7,31 +7,47 @@ import locales from './web_push_locales';
 const MAX_NOTIFICATIONS = 5;
 const GROUP_TAG = 'tag';
 
-const notify = options =>
-  self.registration.getNotifications().then(notifications => {
-    if (notifications.length >= MAX_NOTIFICATIONS) { // Reached the maximum number of notifications, proceed with grouping
+const notify = (options) =>
+  self.registration.getNotifications().then((notifications) => {
+    if (notifications.length >= MAX_NOTIFICATIONS) {
+      // Reached the maximum number of notifications, proceed with grouping
       const group = {
-        title: formatMessage('notifications.group', options.data.preferred_locale, { count: notifications.length + 1 }),
-        body: notifications.sort((n1, n2) => n1.timestamp < n2.timestamp).map(notification => notification.title).join('\n'),
+        title: formatMessage(
+          'notifications.group',
+          options.data.preferred_locale,
+          { count: notifications.length + 1 },
+        ),
+        body: notifications
+          .sort((n1, n2) => n1.timestamp < n2.timestamp)
+          .map((notification) => notification.title)
+          .join('\n'),
         badge: '/badge.png',
         icon: '/android-chrome-192x192.png',
         tag: GROUP_TAG,
         data: {
-          url: (new URL('/notifications', self.location)).href,
+          url: new URL('/notifications', self.location).href,
           count: notifications.length + 1,
           preferred_locale: options.data.preferred_locale,
         },
       };
 
-      notifications.forEach(notification => notification.close());
+      notifications.forEach((notification) => notification.close());
 
       return self.registration.showNotification(group.title, group);
-    } else if (notifications.length === 1 && notifications[0].tag === GROUP_TAG) { // Already grouped, proceed with appending the notification to the group
+    } else if (
+      notifications.length === 1 &&
+      notifications[0].tag === GROUP_TAG
+    ) {
+      // Already grouped, proceed with appending the notification to the group
       const group = cloneNotification(notifications[0]);
 
-      group.title = formatMessage('notifications.group', options.data.preferred_locale, { count: group.data.count + 1 });
-      group.body  = `${options.title}\n${group.body}`;
-      group.data  = { ...group.data, count: group.data.count + 1 };
+      group.title = formatMessage(
+        'notifications.group',
+        options.data.preferred_locale,
+        { count: group.data.count + 1 },
+      );
+      group.body = `${options.title}\n${group.body}`;
+      group.data = { ...group.data, count: group.data.count + 1 };
 
       return self.registration.showNotification(group.title, group);
     }
@@ -40,31 +56,33 @@ const notify = options =>
   });
 
 const fetchFromApi = (path, method, accessToken) => {
-  const url = (new URL(path, self.location)).href;
+  const url = new URL(path, self.location).href;
 
   return fetch(url, {
     headers: {
-      'Authorization': `Bearer ${accessToken}`,
+      Authorization: `Bearer ${accessToken}`,
       'Content-Type': 'application/json',
     },
 
     method: method,
     credentials: 'include',
-  }).then(res => {
-    if (res.ok) {
-      return res;
-    } else {
-      throw new Error(res.status);
-    }
-  }).then(res => res.json());
+  })
+    .then((res) => {
+      if (res.ok) {
+        return res;
+      } else {
+        throw new Error(res.status);
+      }
+    })
+    .then((res) => res.json());
 };
 
-const cloneNotification = notification => {
+const cloneNotification = (notification) => {
   const clone = {};
   let k;
 
   // Object.assign() does not work with notifications
-  for(k in notification) {
+  for (k in notification) {
     clone[k] = notification[k];
   }
 
@@ -72,112 +90,169 @@ const cloneNotification = notification => {
 };
 
 const formatMessage = (messageId, locale, values = {}) =>
-  (new IntlMessageFormat(locales[locale][messageId], locale)).format(values);
+  new IntlMessageFormat(locales[locale][messageId], locale).format(values);
 
-const htmlToPlainText = html =>
-  unescape(html.replace(/<br\s*\/?>/g, '\n').replace(/<\/p><p>/g, '\n\n').replace(/<[^>]*>/g, ''));
+const htmlToPlainText = (html) =>
+  unescape(
+    html
+      .replace(/<br\s*\/?>/g, '\n')
+      .replace(/<\/p><p>/g, '\n\n')
+      .replace(/<[^>]*>/g, ''),
+  );
 
 export const handlePush = (event) => {
-  const { access_token, notification_id, preferred_locale, title, body, icon } = event.data.json();
+  const { access_token, notification_id, preferred_locale, title, body, icon } =
+    event.data.json();
 
   // Placeholder until more information can be loaded
   event.waitUntil(
-    fetchFromApi(`/api/v1/notifications/${notification_id}`, 'get', access_token).then(notification => {
-      const options = {};
+    fetchFromApi(
+      `/api/v1/notifications/${notification_id}`,
+      'get',
+      access_token,
+    )
+      .then((notification) => {
+        const options = {};
 
-      options.title     = formatMessage(`notification.${notification.type}`, preferred_locale, { name: notification.account.display_name.length > 0 ? notification.account.display_name : notification.account.username });
-      options.body      = notification.status && htmlToPlainText(notification.status.content);
-      options.icon      = notification.account.avatar_static;
-      options.timestamp = notification.created_at && new Date(notification.created_at);
-      options.tag       = notification.id;
-      options.badge     = '/badge.png';
-      options.image     = notification.status && notification.status.media_attachments.length > 0 && notification.status.media_attachments[0].preview_url || undefined;
-      options.data      = { access_token, preferred_locale, id: notification.status ? notification.status.id : notification.account.id };
+        options.title = formatMessage(
+          `notification.${notification.type}`,
+          preferred_locale,
+          {
+            name:
+              notification.account.display_name.length > 0
+                ? notification.account.display_name
+                : notification.account.username,
+          },
+        );
+        options.body =
+          notification.status && htmlToPlainText(notification.status.content);
+        options.icon = notification.account.avatar_static;
+        options.timestamp =
+          notification.created_at && new Date(notification.created_at);
+        options.tag = notification.id;
+        options.badge = '/badge.png';
+        options.image =
+          (notification.status &&
+            notification.status.media_attachments.length > 0 &&
+            notification.status.media_attachments[0].preview_url) ||
+          undefined;
+        options.data = {
+          access_token,
+          preferred_locale,
+          id: notification.status
+            ? notification.status.id
+            : notification.account.id,
+        };
 
-      if (notification.status) {
-        options.data.url = `/@${notification.status.account.acct}/${notification.status.id}`;
-      } else {
-        options.data.url = `/@${notification.account.acct}`;
-      }
-
-      if (notification.status && notification.status.spoiler_text || notification.status.sensitive) {
-        options.data.hiddenBody  = htmlToPlainText(notification.status.content);
-        options.data.hiddenImage = notification.status.media_attachments.length > 0 && notification.status.media_attachments[0].preview_url;
-
-        if (notification.status.spoiler_text) {
-          options.body    = notification.status.spoiler_text;
+        if (notification.status) {
+          options.data.url = `/@${notification.status.account.acct}/${notification.status.id}`;
+        } else {
+          options.data.url = `/@${notification.account.acct}`;
         }
 
-        options.image   = undefined;
-        options.actions = [actionExpand(preferred_locale)];
-      } else if (['mention', 'status'].includes(notification.type)) {
-        options.actions = [actionReblog(preferred_locale), actionFavourite(preferred_locale)];
-      }
+        if (
+          (notification.status && notification.status.spoiler_text) ||
+          notification.status.sensitive
+        ) {
+          options.data.hiddenBody = htmlToPlainText(
+            notification.status.content,
+          );
+          options.data.hiddenImage =
+            notification.status.media_attachments.length > 0 &&
+            notification.status.media_attachments[0].preview_url;
 
-      return notify(options);
-    }).catch(() => {
-      return notify({
-        title,
-        body,
-        icon,
-        tag: notification_id,
-        timestamp: new Date(),
-        badge: '/badge.png',
-        data: { access_token, preferred_locale, url: '/notifications' },
-      });
-    }),
+          if (notification.status.spoiler_text) {
+            options.body = notification.status.spoiler_text;
+          }
+
+          options.image = undefined;
+          options.actions = [actionExpand(preferred_locale)];
+        } else if (['mention', 'status'].includes(notification.type)) {
+          options.actions = [
+            actionReblog(preferred_locale),
+            actionFavourite(preferred_locale),
+          ];
+        }
+
+        return notify(options);
+      })
+      .catch(() => {
+        return notify({
+          title,
+          body,
+          icon,
+          tag: notification_id,
+          timestamp: new Date(),
+          badge: '/badge.png',
+          data: { access_token, preferred_locale, url: '/notifications' },
+        });
+      }),
   );
 };
 
-const actionExpand = preferred_locale => ({
+const actionExpand = (preferred_locale) => ({
   action: 'expand',
   icon: '/web-push-icon_expand.png',
   title: formatMessage('status.show_more', preferred_locale),
 });
 
-const actionReblog = preferred_locale => ({
+const actionReblog = (preferred_locale) => ({
   action: 'reblog',
   icon: '/web-push-icon_reblog.png',
   title: formatMessage('status.reblog', preferred_locale),
 });
 
-const actionFavourite = preferred_locale => ({
+const actionFavourite = (preferred_locale) => ({
   action: 'favourite',
   icon: '/web-push-icon_favourite.png',
   title: formatMessage('status.favourite', preferred_locale),
 });
 
-const findBestClient = clients => {
-  const focusedClient = clients.find(client => client.focused);
-  const visibleClient = clients.find(client => client.visibilityState === 'visible');
+const findBestClient = (clients) => {
+  const focusedClient = clients.find((client) => client.focused);
+  const visibleClient = clients.find(
+    (client) => client.visibilityState === 'visible',
+  );
 
   return focusedClient || visibleClient || clients[0];
 };
 
-const expandNotification = notification => {
+const expandNotification = (notification) => {
   const newNotification = cloneNotification(notification);
 
-  newNotification.body    = newNotification.data.hiddenBody;
-  newNotification.image   = newNotification.data.hiddenImage;
-  newNotification.actions = [actionReblog(notification.data.preferred_locale), actionFavourite(notification.data.preferred_locale)];
+  newNotification.body = newNotification.data.hiddenBody;
+  newNotification.image = newNotification.data.hiddenImage;
+  newNotification.actions = [
+    actionReblog(notification.data.preferred_locale),
+    actionFavourite(notification.data.preferred_locale),
+  ];
 
-  return self.registration.showNotification(newNotification.title, newNotification);
+  return self.registration.showNotification(
+    newNotification.title,
+    newNotification,
+  );
 };
 
 const removeActionFromNotification = (notification, action) => {
   const newNotification = cloneNotification(notification);
 
-  newNotification.actions = newNotification.actions.filter(item => item.action !== action);
+  newNotification.actions = newNotification.actions.filter(
+    (item) => item.action !== action,
+  );
 
-  return self.registration.showNotification(newNotification.title, newNotification);
+  return self.registration.showNotification(
+    newNotification.title,
+    newNotification,
+  );
 };
 
-const openUrl = url =>
-  self.clients.matchAll({ type: 'window' }).then(clientList => {
-    if (clientList.length !== 0 && 'navigate' in clientList[0]) { // Chrome 42-48 does not support navigate
+const openUrl = (url) =>
+  self.clients.matchAll({ type: 'window' }).then((clientList) => {
+    if (clientList.length !== 0 && 'navigate' in clientList[0]) {
+      // Chrome 42-48 does not support navigate
       const client = findBestClient(clientList);
 
-      return client.navigate(url).then(client => client.focus());
+      return client.navigate(url).then((client) => client.focus());
     }
 
     return self.clients.openWindow(url);
@@ -190,10 +265,26 @@ export const handleNotificationClick = (event) => {
         resolve(expandNotification(event.notification));
       } else if (event.action === 'reblog') {
         const { data } = event.notification;
-        resolve(fetchFromApi(`/api/v1/statuses/${data.id}/reblog`, 'post', data.access_token).then(() => removeActionFromNotification(event.notification, 'reblog')));
+        resolve(
+          fetchFromApi(
+            `/api/v1/statuses/${data.id}/reblog`,
+            'post',
+            data.access_token,
+          ).then(() =>
+            removeActionFromNotification(event.notification, 'reblog'),
+          ),
+        );
       } else if (event.action === 'favourite') {
         const { data } = event.notification;
-        resolve(fetchFromApi(`/api/v1/statuses/${data.id}/favourite`, 'post', data.access_token).then(() => removeActionFromNotification(event.notification, 'favourite')));
+        resolve(
+          fetchFromApi(
+            `/api/v1/statuses/${data.id}/favourite`,
+            'post',
+            data.access_token,
+          ).then(() =>
+            removeActionFromNotification(event.notification, 'favourite'),
+          ),
+        );
       } else {
         reject(`Unknown action: ${event.action}`);
       }

--- a/app/javascript/mastodon/settings.js
+++ b/app/javascript/mastodon/settings.js
@@ -1,5 +1,4 @@
 export default class Settings {
-
   constructor(keyBase = null) {
     this.keyBase = keyBase;
   }
@@ -35,15 +34,15 @@ export default class Settings {
       const key = this.generateKey(id);
       try {
         localStorage.removeItem(key);
-      } catch (e) {
-      }
+      } catch (e) {}
     }
     return data;
   }
-
 }
 
-export const pushNotificationsSetting = new Settings('mastodon_push_notification_data');
+export const pushNotificationsSetting = new Settings(
+  'mastodon_push_notification_data',
+);
 export const tagHistory = new Settings('mastodon_tag_history');
 export const bannerSettings = new Settings('mastodon_banner_settings');
 export const searchHistory = new Settings('mastodon_search_history');

--- a/app/javascript/mastodon/stream.js
+++ b/app/javascript/mastodon/stream.js
@@ -35,14 +35,14 @@ const subscriptionCounters = {};
 /**
  * @param {Subscription} subscription
  */
-const addSubscription = subscription => {
+const addSubscription = (subscription) => {
   subscriptions.push(subscription);
 };
 
 /**
  * @param {Subscription} subscription
  */
-const removeSubscription = subscription => {
+const removeSubscription = (subscription) => {
   const index = subscriptions.indexOf(subscription);
 
   if (index !== -1) {
@@ -60,7 +60,9 @@ const subscribe = ({ channelName, params, onConnect }) => {
 
   if (subscriptionCounters[key] === 0) {
     // @ts-expect-error
-    sharedConnection.send(JSON.stringify({ type: 'subscribe', stream: channelName, ...params }));
+    sharedConnection.send(
+      JSON.stringify({ type: 'subscribe', stream: channelName, ...params }),
+    );
   }
 
   subscriptionCounters[key] += 1;
@@ -76,9 +78,14 @@ const unsubscribe = ({ channelName, params, onDisconnect }) => {
   subscriptionCounters[key] = subscriptionCounters[key] || 1;
 
   // @ts-expect-error
-  if (subscriptionCounters[key] === 1 && sharedConnection.readyState === WebSocketClient.OPEN) {
+  if (
+    subscriptionCounters[key] === 1 &&
+    sharedConnection.readyState === WebSocketClient.OPEN
+  ) {
     // @ts-expect-error
-    sharedConnection.send(JSON.stringify({ type: 'unsubscribe', stream: channelName, ...params }));
+    sharedConnection.send(
+      JSON.stringify({ type: 'unsubscribe', stream: channelName, ...params }),
+    );
   }
 
   subscriptionCounters[key] -= 1;
@@ -87,40 +94,46 @@ const unsubscribe = ({ channelName, params, onDisconnect }) => {
 
 const sharedCallbacks = {
   connected() {
-    subscriptions.forEach(subscription => subscribe(subscription));
+    subscriptions.forEach((subscription) => subscribe(subscription));
   },
 
   // @ts-expect-error
   received(data) {
     const { stream } = data;
 
-    subscriptions.filter(({ channelName, params }) => {
-      const streamChannelName = stream[0];
+    subscriptions
+      .filter(({ channelName, params }) => {
+        const streamChannelName = stream[0];
 
-      if (stream.length === 1) {
-        return channelName === streamChannelName;
-      }
+        if (stream.length === 1) {
+          return channelName === streamChannelName;
+        }
 
-      const streamIdentifier = stream[1];
+        const streamIdentifier = stream[1];
 
-      if (['hashtag', 'hashtag:local'].includes(channelName)) {
-        return channelName === streamChannelName && params.tag === streamIdentifier;
-      } else if (channelName === 'list') {
-        return channelName === streamChannelName && params.list === streamIdentifier;
-      }
+        if (['hashtag', 'hashtag:local'].includes(channelName)) {
+          return (
+            channelName === streamChannelName && params.tag === streamIdentifier
+          );
+        } else if (channelName === 'list') {
+          return (
+            channelName === streamChannelName &&
+            params.list === streamIdentifier
+          );
+        }
 
-      return false;
-    }).forEach(subscription => {
-      subscription.onReceive(data);
-    });
+        return false;
+      })
+      .forEach((subscription) => {
+        subscription.onReceive(data);
+      });
   },
 
   disconnected() {
-    subscriptions.forEach(subscription => unsubscribe(subscription));
+    subscriptions.forEach((subscription) => unsubscribe(subscription));
   },
 
-  reconnected() {
-  },
+  reconnected() {},
 };
 
 /**
@@ -133,7 +146,9 @@ const channelNameWithInlineParams = (channelName, params) => {
     return channelName;
   }
 
-  return `${channelName}&${Object.keys(params).map(key => `${key}=${params[key]}`).join('&')}`;
+  return `${channelName}&${Object.keys(params)
+    .map((key) => `${key}=${params[key]}`)
+    .join('&')}`;
 };
 
 /**
@@ -143,61 +158,75 @@ const channelNameWithInlineParams = (channelName, params) => {
  * @returns {function(): void}
  */
 // @ts-expect-error
-export const connectStream = (channelName, params, callbacks) => (dispatch, getState) => {
-  const streamingAPIBaseURL = getState().getIn(['meta', 'streaming_api_base_url']);
-  const accessToken = getState().getIn(['meta', 'access_token']);
-  const { onConnect, onReceive, onDisconnect } = callbacks(dispatch, getState);
+export const connectStream =
+  (channelName, params, callbacks) => (dispatch, getState) => {
+    const streamingAPIBaseURL = getState().getIn([
+      'meta',
+      'streaming_api_base_url',
+    ]);
+    const accessToken = getState().getIn(['meta', 'access_token']);
+    const { onConnect, onReceive, onDisconnect } = callbacks(
+      dispatch,
+      getState,
+    );
 
-  // If we cannot use a websockets connection, we must fall back
-  // to using individual connections for each channel
-  if (!streamingAPIBaseURL.startsWith('ws')) {
-    const connection = createConnection(streamingAPIBaseURL, accessToken, channelNameWithInlineParams(channelName, params), {
-      connected() {
-        onConnect();
-      },
+    // If we cannot use a websockets connection, we must fall back
+    // to using individual connections for each channel
+    if (!streamingAPIBaseURL.startsWith('ws')) {
+      const connection = createConnection(
+        streamingAPIBaseURL,
+        accessToken,
+        channelNameWithInlineParams(channelName, params),
+        {
+          connected() {
+            onConnect();
+          },
 
-      received(data) {
-        onReceive(data);
-      },
+          received(data) {
+            onReceive(data);
+          },
 
-      disconnected() {
-        onDisconnect();
-      },
+          disconnected() {
+            onDisconnect();
+          },
 
-      reconnected() {
-        onConnect();
-      },
-    });
+          reconnected() {
+            onConnect();
+          },
+        },
+      );
+
+      return () => {
+        connection.close();
+      };
+    }
+
+    const subscription = {
+      channelName,
+      params,
+      onConnect,
+      onReceive,
+      onDisconnect,
+    };
+
+    addSubscription(subscription);
+
+    // If a connection is open, we can execute the subscription right now. Otherwise,
+    // because we have already registered it, it will be executed on connect
+
+    if (!sharedConnection) {
+      sharedConnection = /** @type {WebSocketClient} */ (
+        createConnection(streamingAPIBaseURL, accessToken, '', sharedCallbacks)
+      );
+    } else if (sharedConnection.readyState === WebSocketClient.OPEN) {
+      subscribe(subscription);
+    }
 
     return () => {
-      connection.close();
+      removeSubscription(subscription);
+      unsubscribe(subscription);
     };
-  }
-
-  const subscription = {
-    channelName,
-    params,
-    onConnect,
-    onReceive,
-    onDisconnect,
   };
-
-  addSubscription(subscription);
-
-  // If a connection is open, we can execute the subscription right now. Otherwise,
-  // because we have already registered it, it will be executed on connect
-
-  if (!sharedConnection) {
-    sharedConnection = /** @type {WebSocketClient} */ (createConnection(streamingAPIBaseURL, accessToken, '', sharedCallbacks));
-  } else if (sharedConnection.readyState === WebSocketClient.OPEN) {
-    subscribe(subscription);
-  }
-
-  return () => {
-    removeSubscription(subscription);
-    unsubscribe(subscription);
-  };
-};
 
 const KNOWN_EVENT_TYPES = [
   'update',
@@ -229,7 +258,12 @@ const handleEventSourceMessage = (e, received) => {
  * @param {{ connected: Function, received: function(StreamEvent): void, disconnected: Function, reconnected: Function }} callbacks
  * @returns {WebSocketClient | EventSource}
  */
-const createConnection = (streamingAPIBaseURL, accessToken, channelName, { connected, received, disconnected, reconnected }) => {
+const createConnection = (
+  streamingAPIBaseURL,
+  accessToken,
+  channelName,
+  { connected, received, disconnected, reconnected },
+) => {
   const params = channelName.split('&');
 
   // @ts-expect-error
@@ -237,11 +271,14 @@ const createConnection = (streamingAPIBaseURL, accessToken, channelName, { conne
 
   if (streamingAPIBaseURL.startsWith('ws')) {
     // @ts-expect-error
-    const ws = new WebSocketClient(`${streamingAPIBaseURL}/api/v1/streaming/?${params.join('&')}`, accessToken);
+    const ws = new WebSocketClient(
+      `${streamingAPIBaseURL}/api/v1/streaming/?${params.join('&')}`,
+      accessToken,
+    );
 
     // @ts-expect-error
     ws.onopen = connected;
-    ws.onmessage = e => received(JSON.parse(e.data));
+    ws.onmessage = (e) => received(JSON.parse(e.data));
     // @ts-expect-error
     ws.onclose = disconnected;
     // @ts-expect-error
@@ -259,14 +296,20 @@ const createConnection = (streamingAPIBaseURL, accessToken, channelName, { conne
 
   params.push(`access_token=${accessToken}`);
 
-  const es = new EventSource(`${streamingAPIBaseURL}/api/v1/streaming/${channelName}?${params.join('&')}`);
+  const es = new EventSource(
+    `${streamingAPIBaseURL}/api/v1/streaming/${channelName}?${params.join(
+      '&',
+    )}`,
+  );
 
   es.onopen = () => {
     connected();
   };
 
-  KNOWN_EVENT_TYPES.forEach(type => {
-    es.addEventListener(type, e => handleEventSourceMessage(/** @type {MessageEvent} */(e), received));
+  KNOWN_EVENT_TYPES.forEach((type) => {
+    es.addEventListener(type, (e) =>
+      handleEventSourceMessage(/** @type {MessageEvent} */ (e), received),
+    );
   });
 
   es.onerror = /** @type {function(): void} */ (disconnected);

--- a/app/javascript/mastodon/stream.js
+++ b/app/javascript/mastodon/stream.js
@@ -77,9 +77,9 @@ const unsubscribe = ({ channelName, params, onDisconnect }) => {
 
   subscriptionCounters[key] = subscriptionCounters[key] || 1;
 
-  // @ts-expect-error
   if (
     subscriptionCounters[key] === 1 &&
+    // @ts-expect-error
     sharedConnection.readyState === WebSocketClient.OPEN
   ) {
     // @ts-expect-error
@@ -157,8 +157,9 @@ const channelNameWithInlineParams = (channelName, params) => {
  * @param {function(Function, Function): { onConnect: (function(): void), onReceive: (function(StreamEvent): void), onDisconnect: (function(): void) }} callbacks
  * @returns {function(): void}
  */
-// @ts-expect-error
+
 export const connectStream =
+  // @ts-expect-error
   (channelName, params, callbacks) => (dispatch, getState) => {
     const streamingAPIBaseURL = getState().getIn([
       'meta',
@@ -270,9 +271,9 @@ const createConnection = (
   channelName = params.shift();
 
   if (streamingAPIBaseURL.startsWith('ws')) {
-    // @ts-expect-error
     const ws = new WebSocketClient(
       `${streamingAPIBaseURL}/api/v1/streaming/?${params.join('&')}`,
+      // @ts-expect-error
       accessToken,
     );
 

--- a/app/javascript/mastodon/utils/__tests__/html-test.js
+++ b/app/javascript/mastodon/utils/__tests__/html-test.js
@@ -3,7 +3,9 @@ import * as html from '../html';
 describe('html', () => {
   describe('unescapeHTML', () => {
     it('returns unescaped HTML', () => {
-      const output = html.unescapeHTML('<p>lorem</p><p>ipsum</p><br>&lt;br&gt;');
+      const output = html.unescapeHTML(
+        '<p>lorem</p><p>ipsum</p><br>&lt;br&gt;',
+      );
       expect(output).toEqual('lorem\n\nipsum\n<br>');
     });
   });

--- a/app/javascript/mastodon/utils/html.js
+++ b/app/javascript/mastodon/utils/html.js
@@ -1,6 +1,9 @@
 // NB: This function can still return unsafe HTML
 export const unescapeHTML = (html) => {
   const wrapper = document.createElement('div');
-  wrapper.innerHTML = html.replace(/<br\s*\/?>/g, '\n').replace(/<\/p><p>/g, '\n\n').replace(/<[^>]*>/g, '');
+  wrapper.innerHTML = html
+    .replace(/<br\s*\/?>/g, '\n')
+    .replace(/<\/p><p>/g, '\n\n')
+    .replace(/<[^>]*>/g, '');
   return wrapper.textContent;
 };

--- a/app/javascript/mastodon/utils/icons.jsx
+++ b/app/javascript/mastodon/utils/icons.jsx
@@ -1,13 +1,23 @@
 // Copied from emoji-mart for consistency with emoji picker and since
 // they don't export the icons in the package
 export const loupeIcon = (
-  <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' width='13' height='13'>
+  <svg
+    xmlns='http://www.w3.org/2000/svg'
+    viewBox='0 0 20 20'
+    width='13'
+    height='13'
+  >
     <path d='M12.9 14.32a8 8 0 1 1 1.41-1.41l5.35 5.33-1.42 1.42-5.33-5.34zM8 14A6 6 0 1 0 8 2a6 6 0 0 0 0 12z' />
   </svg>
 );
 
 export const deleteIcon = (
-  <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' width='13' height='13'>
+  <svg
+    xmlns='http://www.w3.org/2000/svg'
+    viewBox='0 0 20 20'
+    width='13'
+    height='13'
+  >
     <path d='M10 8.586L2.929 1.515 1.515 2.929 8.586 10l-7.071 7.071 1.414 1.414L10 11.414l7.071 7.071 1.414-1.414L11.414 10l7.071-7.071-1.414-1.414L10 8.586z' />
   </svg>
 );

--- a/app/javascript/mastodon/utils/notifications.js
+++ b/app/javascript/mastodon/utils/notifications.js
@@ -5,7 +5,7 @@ const checkNotificationPromise = () => {
   try {
     // eslint-disable-next-line promise/valid-params, promise/catch-or-return
     Notification.requestPermission().then();
-  } catch(e) {
+  } catch (e) {
     return false;
   }
 
@@ -14,7 +14,7 @@ const checkNotificationPromise = () => {
 
 const handlePermission = (permission, callback) => {
   // Whatever the user answers, we make sure Chrome stores the information
-  if(!('permission' in Notification)) {
+  if (!('permission' in Notification)) {
     Notification.permission = permission;
   }
 
@@ -23,8 +23,12 @@ const handlePermission = (permission, callback) => {
 
 export const requestNotificationPermission = (callback) => {
   if (checkNotificationPromise()) {
-    Notification.requestPermission().then((permission) => handlePermission(permission, callback)).catch(console.warn);
+    Notification.requestPermission()
+      .then((permission) => handlePermission(permission, callback))
+      .catch(console.warn);
   } else {
-    Notification.requestPermission((permission) => handlePermission(permission, callback));
+    Notification.requestPermission((permission) =>
+      handlePermission(permission, callback),
+    );
   }
 };

--- a/app/javascript/mastodon/utils/scrollbar.js
+++ b/app/javascript/mastodon/utils/scrollbar.js
@@ -29,7 +29,9 @@ export const getScrollbarWidth = () => {
     return cachedScrollbarWidth;
   }
 
-  const scrollbarWidth = isMobile(window.innerWidth) ? 0 : getActualScrollbarWidth();
+  const scrollbarWidth = isMobile(window.innerWidth)
+    ? 0
+    : getActualScrollbarWidth();
   cachedScrollbarWidth = scrollbarWidth;
 
   return scrollbarWidth;

--- a/app/javascript/packs/admin.jsx
+++ b/app/javascript/packs/admin.jsx
@@ -8,7 +8,9 @@ import ready from '../mastodon/ready';
 
 const setAnnouncementEndsAttributes = (target) => {
   const valid = target?.value && target?.validity?.valid;
-  const element = document.querySelector('input[type="datetime-local"]#announcement_ends_at');
+  const element = document.querySelector(
+    'input[type="datetime-local"]#announcement_ends_at',
+  );
   if (valid) {
     element.classList.remove('optional');
     element.required = true;
@@ -20,22 +22,35 @@ const setAnnouncementEndsAttributes = (target) => {
   }
 };
 
-delegate(document, 'input[type="datetime-local"]#announcement_starts_at', 'change', ({ target }) => {
-  setAnnouncementEndsAttributes(target);
-});
+delegate(
+  document,
+  'input[type="datetime-local"]#announcement_starts_at',
+  'change',
+  ({ target }) => {
+    setAnnouncementEndsAttributes(target);
+  },
+);
 
 const batchCheckboxClassName = '.batch-checkbox input[type="checkbox"]';
 
 const showSelectAll = () => {
-  const selectAllMatchingElement = document.querySelector('.batch-table__select-all');
+  const selectAllMatchingElement = document.querySelector(
+    '.batch-table__select-all',
+  );
   selectAllMatchingElement.classList.add('active');
 };
 
 const hideSelectAll = () => {
-  const selectAllMatchingElement = document.querySelector('.batch-table__select-all');
+  const selectAllMatchingElement = document.querySelector(
+    '.batch-table__select-all',
+  );
   const hiddenField = document.querySelector('#select_all_matching');
-  const selectedMsg = document.querySelector('.batch-table__select-all .selected');
-  const notSelectedMsg = document.querySelector('.batch-table__select-all .not-selected');
+  const selectedMsg = document.querySelector(
+    '.batch-table__select-all .selected',
+  );
+  const notSelectedMsg = document.querySelector(
+    '.batch-table__select-all .not-selected',
+  );
 
   selectAllMatchingElement.classList.remove('active');
   selectedMsg.classList.remove('active');
@@ -44,11 +59,16 @@ const hideSelectAll = () => {
 };
 
 delegate(document, '#batch_checkbox_all', 'change', ({ target }) => {
-  const selectAllMatchingElement = document.querySelector('.batch-table__select-all');
+  const selectAllMatchingElement = document.querySelector(
+    '.batch-table__select-all',
+  );
 
-  [].forEach.call(document.querySelectorAll(batchCheckboxClassName), (content) => {
-    content.checked = target.checked;
-  });
+  [].forEach.call(
+    document.querySelectorAll(batchCheckboxClassName),
+    (content) => {
+      content.checked = target.checked;
+    },
+  );
 
   if (selectAllMatchingElement) {
     if (target.checked) {
@@ -62,8 +82,12 @@ delegate(document, '#batch_checkbox_all', 'change', ({ target }) => {
 delegate(document, '.batch-table__select-all button', 'click', () => {
   const hiddenField = document.querySelector('#select_all_matching');
   const active = hiddenField.value === '1';
-  const selectedMsg = document.querySelector('.batch-table__select-all .selected');
-  const notSelectedMsg = document.querySelector('.batch-table__select-all .not-selected');
+  const selectedMsg = document.querySelector(
+    '.batch-table__select-all .selected',
+  );
+  const notSelectedMsg = document.querySelector(
+    '.batch-table__select-all .not-selected',
+  );
 
   if (active) {
     hiddenField.value = '0';
@@ -78,11 +102,21 @@ delegate(document, '.batch-table__select-all button', 'click', () => {
 
 delegate(document, batchCheckboxClassName, 'change', () => {
   const checkAllElement = document.querySelector('#batch_checkbox_all');
-  const selectAllMatchingElement = document.querySelector('.batch-table__select-all');
+  const selectAllMatchingElement = document.querySelector(
+    '.batch-table__select-all',
+  );
 
   if (checkAllElement) {
-    checkAllElement.checked = [].every.call(document.querySelectorAll(batchCheckboxClassName), (content) => content.checked);
-    checkAllElement.indeterminate = !checkAllElement.checked && [].some.call(document.querySelectorAll(batchCheckboxClassName), (content) => content.checked);
+    checkAllElement.checked = [].every.call(
+      document.querySelectorAll(batchCheckboxClassName),
+      (content) => content.checked,
+    );
+    checkAllElement.indeterminate =
+      !checkAllElement.checked &&
+      [].some.call(
+        document.querySelectorAll(batchCheckboxClassName),
+        (content) => content.checked,
+      );
 
     if (selectAllMatchingElement) {
       if (checkAllElement.checked) {
@@ -95,78 +129,113 @@ delegate(document, batchCheckboxClassName, 'change', () => {
 });
 
 delegate(document, '.media-spoiler-show-button', 'click', () => {
-  [].forEach.call(document.querySelectorAll('button.media-spoiler'), (element) => {
-    element.click();
-  });
+  [].forEach.call(
+    document.querySelectorAll('button.media-spoiler'),
+    (element) => {
+      element.click();
+    },
+  );
 });
 
 delegate(document, '.media-spoiler-hide-button', 'click', () => {
-  [].forEach.call(document.querySelectorAll('.spoiler-button.spoiler-button--visible button'), (element) => {
-    element.click();
-  });
+  [].forEach.call(
+    document.querySelectorAll('.spoiler-button.spoiler-button--visible button'),
+    (element) => {
+      element.click();
+    },
+  );
 });
 
-delegate(document, '.filter-subset--with-select select', 'change', ({ target }) => {
-  target.form.submit();
-});
+delegate(
+  document,
+  '.filter-subset--with-select select',
+  'change',
+  ({ target }) => {
+    target.form.submit();
+  },
+);
 
 const onDomainBlockSeverityChange = (target) => {
-  const rejectMediaDiv   = document.querySelector('.input.with_label.domain_block_reject_media');
-  const rejectReportsDiv = document.querySelector('.input.with_label.domain_block_reject_reports');
+  const rejectMediaDiv = document.querySelector(
+    '.input.with_label.domain_block_reject_media',
+  );
+  const rejectReportsDiv = document.querySelector(
+    '.input.with_label.domain_block_reject_reports',
+  );
 
   if (rejectMediaDiv) {
-    rejectMediaDiv.style.display = (target.value === 'suspend') ? 'none' : 'block';
+    rejectMediaDiv.style.display =
+      target.value === 'suspend' ? 'none' : 'block';
   }
 
   if (rejectReportsDiv) {
-    rejectReportsDiv.style.display = (target.value === 'suspend') ? 'none' : 'block';
+    rejectReportsDiv.style.display =
+      target.value === 'suspend' ? 'none' : 'block';
   }
 };
 
-delegate(document, '#domain_block_severity', 'change', ({ target }) => onDomainBlockSeverityChange(target));
+delegate(document, '#domain_block_severity', 'change', ({ target }) =>
+  onDomainBlockSeverityChange(target),
+);
 
 const onEnableBootstrapTimelineAccountsChange = (target) => {
-  const bootstrapTimelineAccountsField = document.querySelector('#form_admin_settings_bootstrap_timeline_accounts');
+  const bootstrapTimelineAccountsField = document.querySelector(
+    '#form_admin_settings_bootstrap_timeline_accounts',
+  );
 
   if (bootstrapTimelineAccountsField) {
     bootstrapTimelineAccountsField.disabled = !target.checked;
     if (target.checked) {
       bootstrapTimelineAccountsField.parentElement.classList.remove('disabled');
-      bootstrapTimelineAccountsField.parentElement.parentElement.classList.remove('disabled');
+      bootstrapTimelineAccountsField.parentElement.parentElement.classList.remove(
+        'disabled',
+      );
     } else {
       bootstrapTimelineAccountsField.parentElement.classList.add('disabled');
-      bootstrapTimelineAccountsField.parentElement.parentElement.classList.add('disabled');
+      bootstrapTimelineAccountsField.parentElement.parentElement.classList.add(
+        'disabled',
+      );
     }
   }
 };
 
-delegate(document, '#form_admin_settings_enable_bootstrap_timeline_accounts', 'change', ({ target }) => onEnableBootstrapTimelineAccountsChange(target));
+delegate(
+  document,
+  '#form_admin_settings_enable_bootstrap_timeline_accounts',
+  'change',
+  ({ target }) => onEnableBootstrapTimelineAccountsChange(target),
+);
 
 const onChangeRegistrationMode = (target) => {
   const enabled = target.value === 'approved';
 
-  [].forEach.call(document.querySelectorAll('#form_admin_settings_require_invite_text'), (input) => {
-    input.disabled = !enabled;
-    if (enabled) {
-      let element = input;
-      do {
-        element.classList.remove('disabled');
-        element = element.parentElement;
-      } while (element && !element.classList.contains('fields-group'));
-    } else {
-      let element = input;
-      do {
-        element.classList.add('disabled');
-        element = element.parentElement;
-      } while (element && !element.classList.contains('fields-group'));
-    }
-  });
+  [].forEach.call(
+    document.querySelectorAll('#form_admin_settings_require_invite_text'),
+    (input) => {
+      input.disabled = !enabled;
+      if (enabled) {
+        let element = input;
+        do {
+          element.classList.remove('disabled');
+          element = element.parentElement;
+        } while (element && !element.classList.contains('fields-group'));
+      } else {
+        let element = input;
+        do {
+          element.classList.add('disabled');
+          element = element.parentElement;
+        } while (element && !element.classList.contains('fields-group'));
+      }
+    },
+  );
 };
 
 const convertUTCDateTimeToLocal = (value) => {
   const date = new Date(value + 'Z');
-  const twoChars = (x) => (x.toString().padStart(2, '0'));
-  return `${date.getFullYear()}-${twoChars(date.getMonth()+1)}-${twoChars(date.getDate())}T${twoChars(date.getHours())}:${twoChars(date.getMinutes())}`;
+  const twoChars = (x) => x.toString().padStart(2, '0');
+  return `${date.getFullYear()}-${twoChars(date.getMonth() + 1)}-${twoChars(
+    date.getDate(),
+  )}T${twoChars(date.getHours())}:${twoChars(date.getMinutes())}`;
 };
 
 const convertLocalDatetimeToUTC = (value) => {
@@ -177,72 +246,112 @@ const convertLocalDatetimeToUTC = (value) => {
   return fullISO8601.slice(0, fullISO8601.indexOf('T') + 6);
 };
 
-delegate(document, '#form_admin_settings_registrations_mode', 'change', ({ target }) => onChangeRegistrationMode(target));
+delegate(
+  document,
+  '#form_admin_settings_registrations_mode',
+  'change',
+  ({ target }) => onChangeRegistrationMode(target),
+);
 
 ready(() => {
-  const domainBlockSeverityInput = document.getElementById('domain_block_severity');
-  if (domainBlockSeverityInput) onDomainBlockSeverityChange(domainBlockSeverityInput);
+  const domainBlockSeverityInput = document.getElementById(
+    'domain_block_severity',
+  );
+  if (domainBlockSeverityInput)
+    onDomainBlockSeverityChange(domainBlockSeverityInput);
 
-  const enableBootstrapTimelineAccounts = document.getElementById('form_admin_settings_enable_bootstrap_timeline_accounts');
-  if (enableBootstrapTimelineAccounts) onEnableBootstrapTimelineAccountsChange(enableBootstrapTimelineAccounts);
+  const enableBootstrapTimelineAccounts = document.getElementById(
+    'form_admin_settings_enable_bootstrap_timeline_accounts',
+  );
+  if (enableBootstrapTimelineAccounts)
+    onEnableBootstrapTimelineAccountsChange(enableBootstrapTimelineAccounts);
 
-  const registrationMode = document.getElementById('form_admin_settings_registrations_mode');
+  const registrationMode = document.getElementById(
+    'form_admin_settings_registrations_mode',
+  );
   if (registrationMode) onChangeRegistrationMode(registrationMode);
 
   const checkAllElement = document.querySelector('#batch_checkbox_all');
   if (checkAllElement) {
-    checkAllElement.checked = [].every.call(document.querySelectorAll(batchCheckboxClassName), (content) => content.checked);
-    checkAllElement.indeterminate = !checkAllElement.checked && [].some.call(document.querySelectorAll(batchCheckboxClassName), (content) => content.checked);
+    checkAllElement.checked = [].every.call(
+      document.querySelectorAll(batchCheckboxClassName),
+      (content) => content.checked,
+    );
+    checkAllElement.indeterminate =
+      !checkAllElement.checked &&
+      [].some.call(
+        document.querySelectorAll(batchCheckboxClassName),
+        (content) => content.checked,
+      );
   }
 
-  document.querySelector('a#add-instance-button')?.addEventListener('click', (e) => {
-    const domain = document.querySelector('input[type="text"]#by_domain')?.value;
+  document
+    .querySelector('a#add-instance-button')
+    ?.addEventListener('click', (e) => {
+      const domain = document.querySelector(
+        'input[type="text"]#by_domain',
+      )?.value;
 
-    if (domain) {
-      const url = new URL(event.target.href);
-      url.searchParams.set('_domain', domain);
-      e.target.href = url;
-    }
-  });
-
-  [].forEach.call(document.querySelectorAll('input[type="datetime-local"]'), element => {
-    if (element.value) {
-      element.value = convertUTCDateTimeToLocal(element.value);
-    }
-    if (element.placeholder) {
-      element.placeholder = convertUTCDateTimeToLocal(element.placeholder);
-    }
-  });
-
-  delegate(document, 'form', 'submit', ({ target }) => {
-    [].forEach.call(target.querySelectorAll('input[type="datetime-local"]'), element => {
-      if (element.value && element.validity.valid) {
-        element.value = convertLocalDatetimeToUTC(element.value);
+      if (domain) {
+        const url = new URL(event.target.href);
+        url.searchParams.set('_domain', domain);
+        e.target.href = url;
       }
     });
+
+  [].forEach.call(
+    document.querySelectorAll('input[type="datetime-local"]'),
+    (element) => {
+      if (element.value) {
+        element.value = convertUTCDateTimeToLocal(element.value);
+      }
+      if (element.placeholder) {
+        element.placeholder = convertUTCDateTimeToLocal(element.placeholder);
+      }
+    },
+  );
+
+  delegate(document, 'form', 'submit', ({ target }) => {
+    [].forEach.call(
+      target.querySelectorAll('input[type="datetime-local"]'),
+      (element) => {
+        if (element.value && element.validity.valid) {
+          element.value = convertLocalDatetimeToUTC(element.value);
+        }
+      },
+    );
   });
 
-  const announcementStartsAt = document.querySelector('input[type="datetime-local"]#announcement_starts_at');
+  const announcementStartsAt = document.querySelector(
+    'input[type="datetime-local"]#announcement_starts_at',
+  );
   if (announcementStartsAt) {
     setAnnouncementEndsAttributes(announcementStartsAt);
   }
 
-  [].forEach.call(document.querySelectorAll('[data-admin-component]'), element => {
-    const componentName  = element.getAttribute('data-admin-component');
-    const componentProps = JSON.parse(element.getAttribute('data-props'));
+  [].forEach.call(
+    document.querySelectorAll('[data-admin-component]'),
+    (element) => {
+      const componentName = element.getAttribute('data-admin-component');
+      const componentProps = JSON.parse(element.getAttribute('data-props'));
 
-    import('../mastodon/containers/admin_component').then(({ default: AdminComponent }) => {
-      return import('../mastodon/components/admin/' + componentName).then(({ default: Component }) => {
-        const root = createRoot(element);
+      import('../mastodon/containers/admin_component')
+        .then(({ default: AdminComponent }) => {
+          return import('../mastodon/components/admin/' + componentName).then(
+            ({ default: Component }) => {
+              const root = createRoot(element);
 
-        root.render (
-          <AdminComponent>
-            <Component {...componentProps} />
-          </AdminComponent>,
-        );
-      });
-    }).catch(error => {
-      console.error(error);
-    });
-  });
+              root.render(
+                <AdminComponent>
+                  <Component {...componentProps} />
+                </AdminComponent>,
+              );
+            },
+          );
+        })
+        .catch((error) => {
+          console.error(error);
+        });
+    },
+  );
 });

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -1,5 +1,5 @@
 import './public-path';
-import main from "mastodon/main"
+import main from 'mastodon/main';
 
 import { start } from '../mastodon/common';
 import { loadLocale } from '../mastodon/locales';
@@ -10,6 +10,6 @@ start();
 loadPolyfills()
   .then(loadLocale)
   .then(main)
-  .catch(e => {
+  .catch((e) => {
     console.error(e);
   });

--- a/app/javascript/packs/public-path.js
+++ b/app/javascript/packs/public-path.js
@@ -18,4 +18,7 @@ function formatPublicPath(host = '', path = '') {
 const cdnHost = document.querySelector('meta[name=cdn-host]');
 
 // eslint-disable-next-line no-undef
-__webpack_public_path__ = formatPublicPath(cdnHost ? cdnHost.content : '', process.env.PUBLIC_OUTPUT_PATH);
+__webpack_public_path__ = formatPublicPath(
+  cdnHost ? cdnHost.content : '',
+  process.env.PUBLIC_OUTPUT_PATH,
+);

--- a/app/javascript/packs/public.jsx
+++ b/app/javascript/packs/public.jsx
@@ -1,17 +1,17 @@
-import { createRoot }  from 'react-dom/client';
+import { createRoot } from 'react-dom/client';
 
 import './public-path';
 
-import { IntlMessageFormat }  from 'intl-messageformat';
+import { IntlMessageFormat } from 'intl-messageformat';
 import { defineMessages } from 'react-intl';
 
-import { delegate }  from '@rails/ujs';
+import { delegate } from '@rails/ujs';
 import axios from 'axios';
 import { throttle } from 'lodash';
 
 import { start } from '../mastodon/common';
-import { timeAgoString }  from '../mastodon/components/relative_timestamp';
-import emojify  from '../mastodon/features/emoji/emoji';
+import { timeAgoString } from '../mastodon/components/relative_timestamp';
+import emojify from '../mastodon/features/emoji/emoji';
 import loadKeyboardExtensions from '../mastodon/load_keyboard_extensions';
 import { loadLocale, getLocale } from '../mastodon/locales';
 import { loadPolyfills } from '../mastodon/polyfills';
@@ -22,12 +22,21 @@ import 'cocoon-js-vanilla';
 start();
 
 const messages = defineMessages({
-  usernameTaken: { id: 'username.taken', defaultMessage: 'That username is taken. Try another' },
-  passwordExceedsLength: { id: 'password_confirmation.exceeds_maxlength', defaultMessage: 'Password confirmation exceeds the maximum password length' },
-  passwordDoesNotMatch: { id: 'password_confirmation.mismatching', defaultMessage: 'Password confirmation does not match' },
+  usernameTaken: {
+    id: 'username.taken',
+    defaultMessage: 'That username is taken. Try another',
+  },
+  passwordExceedsLength: {
+    id: 'password_confirmation.exceeds_maxlength',
+    defaultMessage: 'Password confirmation exceeds the maximum password length',
+  },
+  passwordDoesNotMatch: {
+    id: 'password_confirmation.mismatching',
+    defaultMessage: 'Password confirmation does not match',
+  },
 });
 
-window.addEventListener('message', e => {
+window.addEventListener('message', (e) => {
   const data = e.data || {};
 
   if (!window.parent || data.type !== 'setHeight') {
@@ -35,11 +44,14 @@ window.addEventListener('message', e => {
   }
 
   ready(() => {
-    window.parent.postMessage({
-      type: 'setHeight',
-      id: data.id,
-      height: document.getElementsByTagName('html')[0].scrollHeight,
-    }, '*');
+    window.parent.postMessage(
+      {
+        type: 'setHeight',
+        id: data.id,
+        height: document.getElementsByTagName('html')[0].scrollHeight,
+      },
+      '*',
+    );
   });
 });
 
@@ -69,7 +81,10 @@ function loaded() {
   });
 
   const formatMessage = ({ id, defaultMessage }, values) => {
-    const messageFormat = new IntlMessageFormat(localeData[id] || defaultMessage, locale);
+    const messageFormat = new IntlMessageFormat(
+      localeData[id] || defaultMessage,
+      locale,
+    );
     return messageFormat.format(values);
   };
 
@@ -85,48 +100,67 @@ function loaded() {
     content.textContent = formattedDate;
   });
 
-  const isToday = date => {
+  const isToday = (date) => {
     const today = new Date();
 
-    return date.getDate() === today.getDate() &&
+    return (
+      date.getDate() === today.getDate() &&
       date.getMonth() === today.getMonth() &&
-      date.getFullYear() === today.getFullYear();
+      date.getFullYear() === today.getFullYear()
+    );
   };
-  const todayFormat = new IntlMessageFormat(localeData['relative_format.today'] || 'Today at {time}', locale);
+  const todayFormat = new IntlMessageFormat(
+    localeData['relative_format.today'] || 'Today at {time}',
+    locale,
+  );
 
-  [].forEach.call(document.querySelectorAll('time.relative-formatted'), (content) => {
-    const datetime = new Date(content.getAttribute('datetime'));
+  [].forEach.call(
+    document.querySelectorAll('time.relative-formatted'),
+    (content) => {
+      const datetime = new Date(content.getAttribute('datetime'));
 
-    let formattedContent;
+      let formattedContent;
 
-    if (isToday(datetime)) {
-      const formattedTime = timeFormat.format(datetime);
+      if (isToday(datetime)) {
+        const formattedTime = timeFormat.format(datetime);
 
-      formattedContent = todayFormat.format({ time: formattedTime });
-    } else {
-      formattedContent = dateFormat.format(datetime);
-    }
+        formattedContent = todayFormat.format({ time: formattedTime });
+      } else {
+        formattedContent = dateFormat.format(datetime);
+      }
 
-    content.title = formattedContent;
-    content.textContent = formattedContent;
-  });
+      content.title = formattedContent;
+      content.textContent = formattedContent;
+    },
+  );
 
   [].forEach.call(document.querySelectorAll('time.time-ago'), (content) => {
     const datetime = new Date(content.getAttribute('datetime'));
-    const now      = new Date();
+    const now = new Date();
 
     const timeGiven = content.getAttribute('datetime').includes('T');
-    content.title = timeGiven ? dateTimeFormat.format(datetime) : dateFormat.format(datetime);
-    content.textContent = timeAgoString({
-      formatMessage,
-      formatDate: (date, options) => (new Intl.DateTimeFormat(locale, options)).format(date),
-    }, datetime, now, now.getFullYear(), timeGiven);
+    content.title = timeGiven
+      ? dateTimeFormat.format(datetime)
+      : dateFormat.format(datetime);
+    content.textContent = timeAgoString(
+      {
+        formatMessage,
+        formatDate: (date, options) =>
+          new Intl.DateTimeFormat(locale, options).format(date),
+      },
+      datetime,
+      now,
+      now.getFullYear(),
+      timeGiven,
+    );
   });
 
   const reactComponents = document.querySelectorAll('[data-component]');
 
   if (reactComponents.length > 0) {
-    import(/* webpackChunkName: "containers/media_container" */ '../mastodon/containers/media_container')
+    import(
+      /* webpackChunkName: "containers/media_container" */ '../mastodon/containers/media_container'
+    )
       .then(({ default: MediaContainer }) => {
         [].forEach.call(reactComponents, (component) => {
           [].forEach.call(component.children, (child) => {
@@ -137,59 +171,99 @@ function loaded() {
         const content = document.createElement('div');
 
         const root = createRoot(content);
-        root.render(<MediaContainer locale={locale} components={reactComponents} />);
+        root.render(
+          <MediaContainer locale={locale} components={reactComponents} />,
+        );
         document.body.appendChild(content);
       })
-      .catch(error => {
+      .catch((error) => {
         console.error(error);
       });
   }
 
-  delegate(document, '#user_account_attributes_username', 'input', throttle(({ target }) => {
-    if (target.value && target.value.length > 0) {
-      axios.get('/api/v1/accounts/lookup', { params: { acct: target.value } }).then(() => {
-        target.setCustomValidity(formatMessage(messages.usernameTaken));
-      }).catch(() => {
-        target.setCustomValidity('');
-      });
-    } else {
-      target.setCustomValidity('');
-    }
-  }, 500, { leading: false, trailing: true }));
+  delegate(
+    document,
+    '#user_account_attributes_username',
+    'input',
+    throttle(
+      ({ target }) => {
+        if (target.value && target.value.length > 0) {
+          axios
+            .get('/api/v1/accounts/lookup', { params: { acct: target.value } })
+            .then(() => {
+              target.setCustomValidity(formatMessage(messages.usernameTaken));
+            })
+            .catch(() => {
+              target.setCustomValidity('');
+            });
+        } else {
+          target.setCustomValidity('');
+        }
+      },
+      500,
+      { leading: false, trailing: true },
+    ),
+  );
 
-  delegate(document, '#user_password,#user_password_confirmation', 'input', () => {
-    const password = document.getElementById('user_password');
-    const confirmation = document.getElementById('user_password_confirmation');
-    if (!confirmation) return;
+  delegate(
+    document,
+    '#user_password,#user_password_confirmation',
+    'input',
+    () => {
+      const password = document.getElementById('user_password');
+      const confirmation = document.getElementById(
+        'user_password_confirmation',
+      );
+      if (!confirmation) return;
 
-    if (confirmation.value && confirmation.value.length > password.maxLength) {
-      confirmation.setCustomValidity(formatMessage(messages.passwordExceedsLength));
-    } else if (password.value && password.value !== confirmation.value) {
-      confirmation.setCustomValidity(formatMessage(messages.passwordDoesNotMatch));
-    } else {
-      confirmation.setCustomValidity('');
-    }
-  });
+      if (
+        confirmation.value &&
+        confirmation.value.length > password.maxLength
+      ) {
+        confirmation.setCustomValidity(
+          formatMessage(messages.passwordExceedsLength),
+        );
+      } else if (password.value && password.value !== confirmation.value) {
+        confirmation.setCustomValidity(
+          formatMessage(messages.passwordDoesNotMatch),
+        );
+      } else {
+        confirmation.setCustomValidity('');
+      }
+    },
+  );
 
-  delegate(document, '.status__content__spoiler-link', 'click', function() {
+  delegate(document, '.status__content__spoiler-link', 'click', function () {
     const statusEl = this.parentNode.parentNode;
 
     if (statusEl.dataset.spoiler === 'expanded') {
       statusEl.dataset.spoiler = 'folded';
-      this.textContent = (new IntlMessageFormat(localeData['status.show_more'] || 'Show more', locale)).format();
+      this.textContent = new IntlMessageFormat(
+        localeData['status.show_more'] || 'Show more',
+        locale,
+      ).format();
     } else {
       statusEl.dataset.spoiler = 'expanded';
-      this.textContent = (new IntlMessageFormat(localeData['status.show_less'] || 'Show less', locale)).format();
+      this.textContent = new IntlMessageFormat(
+        localeData['status.show_less'] || 'Show less',
+        locale,
+      ).format();
     }
 
     return false;
   });
 
-  [].forEach.call(document.querySelectorAll('.status__content__spoiler-link'), (spoilerLink) => {
-    const statusEl = spoilerLink.parentNode.parentNode;
-    const message = (statusEl.dataset.spoiler === 'expanded') ? (localeData['status.show_less'] || 'Show less') : (localeData['status.show_more'] || 'Show more');
-    spoilerLink.textContent = (new IntlMessageFormat(message, locale)).format();
-  });
+  [].forEach.call(
+    document.querySelectorAll('.status__content__spoiler-link'),
+    (spoilerLink) => {
+      const statusEl = spoilerLink.parentNode.parentNode;
+      const message =
+        statusEl.dataset.spoiler === 'expanded'
+          ? localeData['status.show_less'] || 'Show less'
+          : localeData['status.show_more'] || 'Show more';
+      spoilerLink.textContent = new IntlMessageFormat(message, locale).format();
+    },
+  );
 }
 
 delegate(document, '#edit_profile input[type=file]', 'change', ({ target }) => {
@@ -252,20 +326,35 @@ delegate(document, '.sidebar__toggle__icon', 'click', () => {
   toggleSidebar();
 });
 
-delegate(document, '.sidebar__toggle__icon', 'keydown', e => {
+delegate(document, '.sidebar__toggle__icon', 'keydown', (e) => {
   if (e.key === ' ' || e.key === 'Enter') {
     e.preventDefault();
     toggleSidebar();
   }
 });
 
-delegate(document, '.custom-emoji', 'mouseover', ({ target }) => target.src = target.getAttribute('data-original'));
-delegate(document, '.custom-emoji', 'mouseout', ({ target }) => target.src = target.getAttribute('data-static'));
+delegate(
+  document,
+  '.custom-emoji',
+  'mouseover',
+  ({ target }) => (target.src = target.getAttribute('data-original')),
+);
+delegate(
+  document,
+  '.custom-emoji',
+  'mouseout',
+  ({ target }) => (target.src = target.getAttribute('data-static')),
+);
 
 // Empty the honeypot fields in JS in case something like an extension
 // automatically filled them.
 delegate(document, '#registration_new_user,#new_user', 'submit', () => {
-  ['user_website', 'user_confirm_password', 'registration_user_website', 'registration_user_confirm_password'].forEach(id => {
+  [
+    'user_website',
+    'user_confirm_password',
+    'registration_user_website',
+    'registration_user_confirm_password',
+  ].forEach((id) => {
     const field = document.getElementById(id);
     if (field) {
       field.value = '';
@@ -281,6 +370,6 @@ loadPolyfills()
   .then(loadLocale)
   .then(main)
   .then(loadKeyboardExtensions)
-  .catch(error => {
+  .catch((error) => {
     console.error(error);
   });

--- a/app/javascript/packs/share.jsx
+++ b/app/javascript/packs/share.jsx
@@ -2,7 +2,7 @@ import './public-path';
 import { createRoot } from 'react-dom/client';
 
 import { start } from '../mastodon/common';
-import ComposeContainer  from '../mastodon/containers/compose_container';
+import ComposeContainer from '../mastodon/containers/compose_container';
 import { loadPolyfills } from '../mastodon/polyfills';
 import ready from '../mastodon/ready';
 
@@ -13,7 +13,7 @@ function loaded() {
 
   if (mountNode) {
     const attr = mountNode.getAttribute('data-props');
-    if(!attr) return;
+    if (!attr) return;
 
     const props = JSON.parse(attr);
     const root = createRoot(mountNode);
@@ -25,6 +25,8 @@ function main() {
   ready(loaded);
 }
 
-loadPolyfills().then(main).catch(error => {
-  console.error(error);
-});
+loadPolyfills()
+  .then(main)
+  .catch((error) => {
+    console.error(error);
+  });

--- a/app/javascript/packs/sign_up.js
+++ b/app/javascript/packs/sign_up.js
@@ -5,16 +5,19 @@ import ready from '../mastodon/ready';
 
 ready(() => {
   setInterval(() => {
-    axios.get('/api/v1/emails/check_confirmation').then((response) => {
-      if (response.data) {
-        window.location = '/start';
-      }
-    }).catch(error => {
-      console.error(error);
-    });
+    axios
+      .get('/api/v1/emails/check_confirmation')
+      .then((response) => {
+        if (response.data) {
+          window.location = '/start';
+        }
+      })
+      .catch((error) => {
+        console.error(error);
+      });
   }, 5000);
 
-  document.querySelectorAll('.timer-button').forEach(button => {
+  document.querySelectorAll('.timer-button').forEach((button) => {
     let counter = 30;
 
     const container = document.createElement('span');

--- a/app/javascript/packs/two_factor_authentication.js
+++ b/app/javascript/packs/two_factor_authentication.js
@@ -14,62 +14,83 @@ function getCSRFToken() {
 }
 
 function hideFlashMessages() {
-  Array.from(document.getElementsByClassName('flash-message')).forEach(function(flashMessage) {
-    flashMessage.classList.add('hidden');
-  });
+  Array.from(document.getElementsByClassName('flash-message')).forEach(
+    function (flashMessage) {
+      flashMessage.classList.add('hidden');
+    },
+  );
 }
 
 function callback(url, body) {
-  axios.post(url, JSON.stringify(body), {
-    headers: {
-      'Content-Type': 'application/json',
-      'Accept': 'application/json',
-      'X-CSRF-Token': getCSRFToken(),
-    },
-    credentials: 'same-origin',
-  }).then(function(response) {
-    window.location.replace(response.data.redirect_path);
-  }).catch(function(error) {
-    if (error.response.status === 422) {
-      const errorMessage = document.getElementById('security-key-error-message');
-      errorMessage.classList.remove('hidden');
-      console.error(error.response.data.error);
-    } else {
-      console.error(error);
-    }
-  });
+  axios
+    .post(url, JSON.stringify(body), {
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        'X-CSRF-Token': getCSRFToken(),
+      },
+      credentials: 'same-origin',
+    })
+    .then(function (response) {
+      window.location.replace(response.data.redirect_path);
+    })
+    .catch(function (error) {
+      if (error.response.status === 422) {
+        const errorMessage = document.getElementById(
+          'security-key-error-message',
+        );
+        errorMessage.classList.remove('hidden');
+        console.error(error.response.data.error);
+      } else {
+        console.error(error);
+      }
+    });
 }
 
 ready(() => {
   if (!WebAuthnJSON.supported()) {
-    const unsupported_browser_message = document.getElementById('unsupported-browser-message');
+    const unsupported_browser_message = document.getElementById(
+      'unsupported-browser-message',
+    );
     if (unsupported_browser_message) {
       unsupported_browser_message.classList.remove('hidden');
       document.querySelector('.btn.js-webauthn').disabled = true;
     }
   }
 
-
-  const webAuthnCredentialRegistrationForm = document.getElementById('new_webauthn_credential');
+  const webAuthnCredentialRegistrationForm = document.getElementById(
+    'new_webauthn_credential',
+  );
   if (webAuthnCredentialRegistrationForm) {
     webAuthnCredentialRegistrationForm.addEventListener('submit', (event) => {
       event.preventDefault();
 
-      var nickname = event.target.querySelector('input[name="new_webauthn_credential[nickname]"]');
+      var nickname = event.target.querySelector(
+        'input[name="new_webauthn_credential[nickname]"]',
+      );
       if (nickname.value) {
-        axios.get('/settings/security_keys/options')
+        axios
+          .get('/settings/security_keys/options')
           .then((response) => {
             const credentialOptions = response.data;
 
-            WebAuthnJSON.create({ 'publicKey': credentialOptions }).then((credential) => {
-              var params = { 'credential': credential, 'nickname': nickname.value };
-              callback('/settings/security_keys', params);
-            }).catch((error) => {
-              const errorMessage = document.getElementById('security-key-error-message');
-              errorMessage.classList.remove('hidden');
-              console.error(error);
-            });
-          }).catch((error) => {
+            WebAuthnJSON.create({ publicKey: credentialOptions })
+              .then((credential) => {
+                var params = {
+                  credential: credential,
+                  nickname: nickname.value,
+                };
+                callback('/settings/security_keys', params);
+              })
+              .catch((error) => {
+                const errorMessage = document.getElementById(
+                  'security-key-error-message',
+                );
+                errorMessage.classList.remove('hidden');
+                console.error(error);
+              });
+          })
+          .catch((error) => {
             console.error(error.response.data.error);
           });
       } else {
@@ -78,29 +99,38 @@ ready(() => {
     });
   }
 
-  const webAuthnCredentialAuthenticationForm = document.getElementById('webauthn-form');
+  const webAuthnCredentialAuthenticationForm =
+    document.getElementById('webauthn-form');
   if (webAuthnCredentialAuthenticationForm) {
     webAuthnCredentialAuthenticationForm.addEventListener('submit', (event) => {
       event.preventDefault();
 
-      axios.get('sessions/security_key_options')
+      axios
+        .get('sessions/security_key_options')
         .then((response) => {
           const credentialOptions = response.data;
 
-          WebAuthnJSON.get({ 'publicKey': credentialOptions }).then((credential) => {
-            var params = { 'user': { 'credential': credential } };
-            callback('sign_in', params);
-          }).catch((error) => {
-            const errorMessage = document.getElementById('security-key-error-message');
-            errorMessage.classList.remove('hidden');
-            console.error(error);
-          });
-        }).catch((error) => {
+          WebAuthnJSON.get({ publicKey: credentialOptions })
+            .then((credential) => {
+              var params = { user: { credential: credential } };
+              callback('sign_in', params);
+            })
+            .catch((error) => {
+              const errorMessage = document.getElementById(
+                'security-key-error-message',
+              );
+              errorMessage.classList.remove('hidden');
+              console.error(error);
+            });
+        })
+        .catch((error) => {
           console.error(error.response.data.error);
         });
     });
 
-    const otpAuthenticationForm = document.getElementById('otp-authentication-form');
+    const otpAuthenticationForm = document.getElementById(
+      'otp-authentication-form',
+    );
 
     const linkToOtp = document.getElementById('link-to-otp');
     linkToOtp.addEventListener('click', () => {

--- a/babel.config.js
+++ b/babel.config.js
@@ -24,52 +24,47 @@ module.exports = (api) => {
       ['@babel/react', reactOptions],
       ['@babel/env', envOptions],
     ],
-    plugins: [
-      ['formatjs'],
-      'preval',
-    ],
+    plugins: [['formatjs'], 'preval'],
     overrides: [
       {
         test: /tesseract\.js/,
-        presets: [
-          ['@babel/env', { ...envOptions, modules: 'commonjs' }],
-        ],
+        presets: [['@babel/env', { ...envOptions, modules: 'commonjs' }]],
       },
     ],
   };
 
   switch (env) {
-  case 'production':
-    config.plugins.push(...[
-      'lodash',
-      [
-        'transform-react-remove-prop-types',
-        {
-          mode: 'remove',
-          removeImport: true,
-          additionalLibraries: [
-            'react-immutable-proptypes',
+    case 'production':
+      config.plugins.push(
+        ...[
+          'lodash',
+          [
+            'transform-react-remove-prop-types',
+            {
+              mode: 'remove',
+              removeImport: true,
+              additionalLibraries: ['react-immutable-proptypes'],
+            },
           ],
-        },
-      ],
-      '@babel/transform-react-inline-elements',
-      [
-        '@babel/transform-runtime',
-        {
-          helpers: true,
-          regenerator: false,
-          useESModules: true,
-        },
-      ],
-    ]);
-    break;
-  case 'development':
-    reactOptions.development = true;
-    envOptions.debug = true;
-    break;
-  case 'test':
-    envOptions.modules = 'commonjs';
-    break;
+          '@babel/transform-react-inline-elements',
+          [
+            '@babel/transform-runtime',
+            {
+              helpers: true,
+              regenerator: false,
+              useESModules: true,
+            },
+          ],
+        ],
+      );
+      break;
+    case 'development':
+      reactOptions.development = true;
+      envOptions.debug = true;
+      break;
+    case 'test':
+      envOptions.modules = 'commonjs';
+      break;
   }
 
   return config;

--- a/config/formatjs-formatter.js
+++ b/config/formatjs-formatter.js
@@ -1,6 +1,9 @@
 const path = require('path');
 
-const currentTranslations = require(path.join(__dirname, "../app/javascript/mastodon/locales/en.json"));
+const currentTranslations = require(path.join(
+  __dirname,
+  '../app/javascript/mastodon/locales/en.json',
+));
 
 exports.format = (msgs) => {
   const results = {};

--- a/config/webpack/configuration.js
+++ b/config/webpack/configuration.js
@@ -7,7 +7,9 @@ const { env } = require('process');
 const { load } = require('js-yaml');
 
 const configPath = resolve('config', 'webpacker.yml');
-const settings = load(readFileSync(configPath), 'utf8')[env.RAILS_ENV || env.NODE_ENV];
+const settings = load(readFileSync(configPath), 'utf8')[
+  env.RAILS_ENV || env.NODE_ENV
+];
 
 const themePath = resolve('config', 'themes.yml');
 const themes = load(readFileSync(themePath), 'utf8');

--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -57,6 +57,6 @@ module.exports = merge(sharedConfig, {
       settings.dev_server.watch_options,
       watchOptions,
     ),
-    writeToDisk: filePath => /ocr/.test(filePath),
+    writeToDisk: (filePath) => /ocr/.test(filePath),
   },
 });

--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -42,24 +42,27 @@ module.exports = merge(sharedConfig, {
       cache: true,
       test: /\.(js|css|html|json|ico|svg|eot|otf|ttf|map)$/,
     }),
-    new BundleAnalyzerPlugin({ // generates report.html
+    new BundleAnalyzerPlugin({
+      // generates report.html
       analyzerMode: 'static',
       openAnalyzer: false,
       logLevel: 'silent', // do not bother Webpacker, who runs with --json and parses stdout
     }),
     new InjectManifest({
-      additionalManifestEntries: ['1f602.svg', 'sheet_13.png'].map((filename) => {
-        const path = resolve(root, 'public', 'emoji', filename);
-        const body = readFileSync(path);
-        const md5  = createHash('md5');
+      additionalManifestEntries: ['1f602.svg', 'sheet_13.png'].map(
+        (filename) => {
+          const path = resolve(root, 'public', 'emoji', filename);
+          const body = readFileSync(path);
+          const md5 = createHash('md5');
 
-        md5.update(body);
+          md5.update(body);
 
-        return {
-          revision: md5.digest('hex'),
-          url: `/emoji/${filename}`,
-        };
-      }),
+          return {
+            revision: md5.digest('hex'),
+            url: `/emoji/${filename}`,
+          };
+        },
+      ),
       exclude: [
         /(?:base|extra)_polyfills-.*\.js$/,
         /locale_.*\.js$/,
@@ -68,7 +71,14 @@ module.exports = merge(sharedConfig, {
       include: [/\.js$/, /\.css$/],
       maximumFileSizeToCacheInBytes: 2 * 1_024 * 1_024, // 2 MiB
       swDest: resolve(root, 'public', 'packs', 'sw.js'),
-      swSrc: resolve(root, 'app', 'javascript', 'mastodon', 'service_worker', 'entry.js'),
+      swSrc: resolve(
+        root,
+        'app',
+        'javascript',
+        'mastodon',
+        'service_worker',
+        'entry.js',
+      ),
     }),
   ],
 });

--- a/config/webpack/rules/babel.js
+++ b/config/webpack/rules/babel.js
@@ -4,10 +4,9 @@ const { env, settings } = require('../configuration');
 
 module.exports = {
   test: /\.(js|jsx|mjs|ts|tsx)$/,
-  include: [
-    settings.source_path,
-    ...settings.resolved_paths,
-  ].map(p => resolve(p)),
+  include: [settings.source_path, ...settings.resolved_paths].map((p) =>
+    resolve(p),
+  ),
   exclude: /node_modules/,
   use: [
     {

--- a/config/webpack/rules/node_modules.js
+++ b/config/webpack/rules/node_modules.js
@@ -5,18 +5,13 @@ const { settings, env } = require('../configuration');
 module.exports = {
   test: /\.(js|mjs)$/,
   include: /node_modules/,
-  exclude: [
-    /@babel(?:\/|\\{1,2})runtime/,
-    /tesseract.js/,
-  ],
+  exclude: [/@babel(?:\/|\\{1,2})runtime/, /tesseract.js/],
   use: [
     {
       loader: 'babel-loader',
       options: {
         babelrc: false,
-        plugins: [
-          'transform-react-remove-prop-types',
-        ],
+        plugins: ['transform-react-remove-prop-types'],
         cacheDirectory: join(settings.cache_path, 'babel-loader-node-modules'),
         cacheCompression: env.NODE_ENV === 'production',
         compact: false,

--- a/config/webpack/shared.js
+++ b/config/webpack/shared.js
@@ -21,7 +21,8 @@ module.exports = {
     packPaths.reduce((map, entry) => {
       const localMap = map;
       const namespace = relative(join(entryPath), dirname(entry));
-      localMap[join(namespace, basename(entry, extname(entry)))] = resolve(entry);
+      localMap[join(namespace, basename(entry, extname(entry)))] =
+        resolve(entry);
       return localMap;
     }, {}),
     Object.keys(themes).reduce((themePaths, name) => {
@@ -61,19 +62,17 @@ module.exports = {
   },
 
   module: {
-    rules: Object.keys(rules).map(key => rules[key]),
+    rules: Object.keys(rules).map((key) => rules[key]),
     strictExportPresence: true,
   },
 
   plugins: [
     new webpack.EnvironmentPlugin(JSON.parse(JSON.stringify(env))),
-    new webpack.NormalModuleReplacementPlugin(
-      /^history\//, (resource) => {
-        // temporary fix for https://github.com/ReactTraining/react-router/issues/5576
-        // to reduce bundle size
-        resource.request = resource.request.replace(/^history/, 'history/es');
-      },
-    ),
+    new webpack.NormalModuleReplacementPlugin(/^history\//, (resource) => {
+      // temporary fix for https://github.com/ReactTraining/react-router/issues/5576
+      // to reduce bundle size
+      resource.request = resource.request.replace(/^history/, 'history/es');
+    }),
     new MiniCssExtractPlugin({
       filename: 'css/[name]-[contenthash:8].css',
       chunkFilename: 'css/[name]-[contenthash:8].chunk.css',
@@ -87,15 +86,12 @@ module.exports = {
     }),
     new CircularDependencyPlugin({
       failOnError: true,
-    })
+    }),
   ],
 
   resolve: {
     extensions: settings.extensions,
-    modules: [
-      resolve(settings.source_path),
-      'node_modules',
-    ],
+    modules: [resolve(settings.source_path), 'node_modules'],
   },
 
   resolveLoader: {

--- a/ide-helper.js
+++ b/ide-helper.js
@@ -6,7 +6,7 @@ jetbrains://WebStorm/settings?name=Languages+%26+Frameworks--JavaScript--Webpack
 module.exports = {
   resolve: {
     alias: {
-      'mastodon': path.resolve(__dirname, 'app/javascript/mastodon'),
+      mastodon: path.resolve(__dirname, 'app/javascript/mastodon'),
     },
   },
 };

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,3 @@
 module.exports = ({ env }) => ({
-  plugins: [
-    'autoprefixer',
-    env === 'production' ? 'cssnano' : '',
-  ],
+  plugins: ['autoprefixer', env === 'production' ? 'cssnano' : ''],
 });

--- a/public/embed.js
+++ b/public/embed.js
@@ -25,7 +25,11 @@
     window.addEventListener('message', function (e) {
       var data = e.data || {};
 
-      if (typeof data !== 'object' || data.type !== 'setHeight' || !iframes.has(data.id)) {
+      if (
+        typeof data !== 'object' ||
+        data.type !== 'setHeight' ||
+        !iframes.has(data.id)
+      ) {
         return;
       }
 
@@ -38,32 +42,40 @@
       iframe.height = data.height;
     });
 
-    [].forEach.call(document.querySelectorAll('iframe.mastodon-embed'), function (iframe) {
-      // select unique id for each iframe
-      var id = 0, failCount = 0, idBuffer = new Uint32Array(1);
-      while (id === 0 || iframes.has(id)) {
-        id = crypto.getRandomValues(idBuffer)[0];
-        failCount++;
-        if (failCount > 100) {
-          // give up and assign (easily guessable) unique number if getRandomValues is broken or no luck
-          id = -(iframes.size + 1);
-          break;
+    [].forEach.call(
+      document.querySelectorAll('iframe.mastodon-embed'),
+      function (iframe) {
+        // select unique id for each iframe
+        var id = 0,
+          failCount = 0,
+          idBuffer = new Uint32Array(1);
+        while (id === 0 || iframes.has(id)) {
+          id = crypto.getRandomValues(idBuffer)[0];
+          failCount++;
+          if (failCount > 100) {
+            // give up and assign (easily guessable) unique number if getRandomValues is broken or no luck
+            id = -(iframes.size + 1);
+            break;
+          }
         }
-      }
 
-      iframes.set(id, iframe);
+        iframes.set(id, iframe);
 
-      iframe.scrolling = 'no';
-      iframe.style.overflow = 'hidden';
+        iframe.scrolling = 'no';
+        iframe.style.overflow = 'hidden';
 
-      iframe.onload = function () {
-        iframe.contentWindow.postMessage({
-          type: 'setHeight',
-          id: id,
-        }, '*');
-      };
+        iframe.onload = function () {
+          iframe.contentWindow.postMessage(
+            {
+              type: 'setHeight',
+              id: id,
+            },
+            '*',
+          );
+        };
 
-      iframe.onload();
-    });
+        iframe.onload();
+      },
+    );
   });
 })();

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -31,14 +31,13 @@ module.exports = {
   },
   overrides: [
     {
-      'files': ['app/javascript/styles/mailer.scss'],
+      files: ['app/javascript/styles/mailer.scss'],
       rules: {
         'property-no-unknown': [
           true,
           {
-            ignoreProperties: [
-              '/^mso-/',
-            ] },
+            ignoreProperties: ['/^mso-/'],
+          },
         ],
       },
     },


### PR DESCRIPTION
This PR removed `.js` and `.jsx` from the files ignored by Prettier (first commit), then runs `yarn fix` (second commit).

It formats every JS & JSX files using Prettier, hence the very large diff.

This is the recommended way of handling JS formatting in the JS ecosystem, and is recommended by ESLint (rather than having ESLint check for formatting issues).

If this gets merged, then another PR needs to add the merged commit to `.git-blame-ignore-revs` so this refactor is i[gnored in Github's blame view](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view).

If/when this is merged, then forks should make the same change in their `.prettierignore`, and run `yarn fix` on their whole codebase when rebasing this commit.

Open PRs will also need to be rebased, and run `yarn fix` to make their code compliant with the new format.