### PR TITLE
Link to hashtag timelines from the Trending hashtags moderation interface

### DIFF
--- a/app/views/admin/trends/tags/_tag.html.haml
+++ b/app/views/admin/trends/tags/_tag.html.haml
@@ -10,7 +10,7 @@
 
       %br/
 
-      = link_to root_path + "tags/#{tag.display_name}" do
+      = link_to tag_path(tag) do
         = t('admin.trends.tags.used_by_over_week', count: tag.history.reduce(0) { |sum, day| sum + day.accounts })
 
       - if tag.trendable? && (rank = Trends.tags.rank(tag.id))

--- a/app/views/admin/trends/tags/_tag.html.haml
+++ b/app/views/admin/trends/tags/_tag.html.haml
@@ -10,7 +10,7 @@
 
       %br/
 
-      = link_to tag_path(tag) do
+      = link_to tag_path(tag), target: '_blank' do
         = t('admin.trends.tags.used_by_over_week', count: tag.history.reduce(0) { |sum, day| sum + day.accounts })
 
       - if tag.trendable? && (rank = Trends.tags.rank(tag.id))

--- a/app/views/admin/trends/tags/_tag.html.haml
+++ b/app/views/admin/trends/tags/_tag.html.haml
@@ -10,7 +10,8 @@
 
       %br/
 
-      = t('admin.trends.tags.used_by_over_week', count: tag.history.reduce(0) { |sum, day| sum + day.accounts })
+      = link_to root_path + "tags/#{tag.display_name}" do
+        = t('admin.trends.tags.used_by_over_week', count: tag.history.reduce(0) { |sum, day| sum + day.accounts })
 
       - if tag.trendable? && (rank = Trends.tags.rank(tag.id))
         ·


### PR DESCRIPTION
Motivation: This will save me a lot of copy/paste effort while moderating hashtags

![admin_hashtags](https://github.com/mastodon/mastodon/assets/4095570/088d0af9-085a-4b64-ae49-798e438b9d4b)
