### PR TITLE
Fix inefficiencies in `PlainTextFormatter`

### DIFF
--- a/app/lib/plain_text_formatter.rb
+++ b/app/lib/plain_text_formatter.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class PlainTextFormatter
-  include ActionView::Helpers::TextHelper
-
   NEWLINE_TAGS_RE = %r{(<br />|<br>|</p>)+}
 
   attr_reader :text, :local
@@ -18,7 +16,10 @@ class PlainTextFormatter
     if local?
       text
     else
-      html_entities.decode(strip_tags(insert_newlines)).chomp
+      node = Nokogiri::HTML.fragment(insert_newlines)
+      # Elements that are entirely removed with our Sanitize config
+      node.xpath('.//iframe|.//math|.//noembed|.//noframes|.//noscript|.//plaintext|.//script|.//style|.//svg|.//xmp').remove
+      node.text.chomp
     end
   end
 
@@ -26,9 +27,5 @@ class PlainTextFormatter
 
   def insert_newlines
     text.gsub(NEWLINE_TAGS_RE) { |match| "#{match}\n" }
-  end
-
-  def html_entities
-    HTMLEntities.new
   end
 end


### PR DESCRIPTION
Profiling `tootctl search deploy` revealed that over 50% of the CPU time was spent in `PlainTextFormatter#to_s`.

This replaces the two-step stripping and decoding with parsing using `#text` from Nokogiri, with a very simple sanitization step consistent with our full HTML-oriented sanitization to completely remove some elements (not doing so would not lead to a security risk, but would increase inconsistencies).

For the overwhelming majority of posts (I tested on 900k of the most recent remote posts known to my server and found no differences), this results in the exact same string, but performs about three times as fast (processing the 40k most recent remote posts known to my server took 100s with the old code, and 30s with the new code).