### PR TITLE
Fix sign up steps progress layout in right-to-left locales

### DIFF
--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -1185,14 +1185,14 @@ code {
   }
 
   li:first-child .label {
-    left: auto;
     inset-inline-start: 0;
+    inset-inline-end: auto;
     text-align: start;
     transform: none;
   }
 
   li:last-child .label {
-    left: auto;
+    inset-inline-start: auto;
     inset-inline-end: 0;
     text-align: end;
     transform: none;


### PR DESCRIPTION
## Before

![image](https://github.com/mastodon/mastodon/assets/384364/34e9032e-50e0-4ff8-8623-14396cedb063)

## After

![image](https://github.com/mastodon/mastodon/assets/384364/7dc39ebd-2823-40ea-9fb6-2437184854b1)