### PR TITLE
Change `/api/v1/announcements` to return regular `Status` entities

### DIFF
--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -59,11 +59,13 @@ class Announcement < ApplicationRecord
   end
 
   def statuses
-    @statuses ||= if status_ids.nil?
-                    []
-                  else
-                    Status.where(id: status_ids).distributable_visibility
-                  end
+    @statuses ||= begin
+      if status_ids.nil?
+        []
+      else
+        Status.with_includes.distributable_visibility.where(id: status_ids)
+      end
+    end
   end
 
   def tags

--- a/app/serializers/rest/announcement_serializer.rb
+++ b/app/serializers/rest/announcement_serializer.rb
@@ -9,7 +9,7 @@ class REST::AnnouncementSerializer < ActiveModel::Serializer
   attribute :read, if: :current_user?
 
   has_many :mentions
-  has_many :statuses
+  has_many :statuses, serializer: REST::StatusSerializer
   has_many :tags, serializer: REST::StatusSerializer::TagSerializer
   has_many :emojis, serializer: REST::CustomEmojiSerializer
   has_many :reactions, serializer: REST::ReactionSerializer
@@ -47,18 +47,6 @@ class REST::AnnouncementSerializer < ActiveModel::Serializer
 
     def acct
       object.pretty_acct
-    end
-  end
-
-  class StatusSerializer < ActiveModel::Serializer
-    attributes :id, :url
-
-    def id
-      object.id.to_s
-    end
-
-    def url
-      ActivityPub::TagManager.instance.url_for(object)
     end
   end
 end


### PR DESCRIPTION
This fixes links in announcements linking to `/@undefined/:id` in the web interface. This may have performance implications due to the need to run filters for the linked statuses, though.

EDIT: performance implications should be minimal, and are several orders of magnitude less important than the existing ones on emoji reactions