### PR TITLE
Fix searching by username by reverting account verbatim tokenizer to `standard`

### DIFF
--- a/app/chewy/accounts_index.rb
+++ b/app/chewy/accounts_index.rb
@@ -34,7 +34,7 @@ class AccountsIndex < Chewy::Index
       },
 
       verbatim: {
-        tokenizer: 'uax_url_email',
+        tokenizer: 'standard',
         filter: %w(lowercase asciifolding cjk_width),
       },
 


### PR DESCRIPTION
This partially reverts #26686, which has broken searching remote users by username (only exact full handle match is considered)