### PR TITLE
Revert to using primary database in IndexingScheduler

### DIFF
--- a/app/workers/scheduler/indexing_scheduler.rb
+++ b/app/workers/scheduler/indexing_scheduler.rb
@@ -16,9 +16,7 @@ class Scheduler::IndexingScheduler
     indexes.each do |type|
       with_redis do |redis|
         redis.sscan_each("chewy:queue:#{type.name}", count: SCAN_BATCH_SIZE).each_slice(IMPORT_BATCH_SIZE) do |ids|
-          with_read_replica do
-            type.import!(ids)
-          end
+          type.import!(ids)
 
           redis.srem("chewy:queue:#{type.name}", ids)
         end


### PR DESCRIPTION
Partially reverts #26692, as there is no guarantee for the posts to have reached the replica when the scheduler tries to process them.

I did not change `AddToPublicStatusesIndexWorker` because those perform more work and the cases in which a post would fail to index are extremely likely.

I do not think reverting to use the primary poses any significant performance issue, as the performance issues we did see were caused by unrelated bugs (N+1, seq scan and reindexing of too many posts, all of which have been fixed)