### PR TITLE
Fix light mode colors for advanced interface banner

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -3272,8 +3272,8 @@ $ui-header-height: 55px;
 }
 
 .switch-to-advanced {
-  color: $classic-primary-color;
-  background-color: $classic-base-color;
+  color: $light-text-color;
+  background-color: $ui-base-color;
   padding: 15px;
   border-radius: 4px;
   margin-top: 4px;


### PR DESCRIPTION
Woops! I thought that the `$classic-primary-color` and `$classic-base-color` I used for the little "open in advanced interface" banner were themed, but it wasn't. Sorry about that. (for my defence: I didn't checked all the themes during the back-and-forth for that little banner 😅)

So here is a fix, relying on commonly themed variables instead.

Before:
![image](https://github.com/mastodon/mastodon/assets/411336/1f001796-b545-4bac-b1e9-af7215111085)

After:
![image](https://github.com/mastodon/mastodon/assets/411336/8d98dc65-3d05-430f-aa7d-9ad7ef1fc5ec)