### PR TITLE
Fix #26708

### DIFF
--- a/lib/mastodon/redis_config.rb
+++ b/lib/mastodon/redis_config.rb
@@ -4,12 +4,23 @@ def setup_redis_env_url(prefix = nil, defaults = true)
   prefix = "#{prefix.to_s.upcase}_" unless prefix.nil?
   prefix = '' if prefix.nil?
 
-  return if ENV["#{prefix}REDIS_URL"].present?
+  if ENV["#{prefix}REDIS_URL"].present?
+    address = Addressable::URI.parse(ENV["#{prefix}REDIS_URL"])
+    password = address.password
+    host = address.host
+    port = address.port
+    db = address.path.delete_prefix('/')
+  else
+    password = ''
+    host = 'localhost'
+    port = 6379
+    db = 0
+  end
 
-  password = ENV.fetch("#{prefix}REDIS_PASSWORD") { '' if defaults }
-  host     = ENV.fetch("#{prefix}REDIS_HOST") { 'localhost' if defaults }
-  port     = ENV.fetch("#{prefix}REDIS_PORT") { 6379 if defaults }
-  db       = ENV.fetch("#{prefix}REDIS_DB") { 0 if defaults }
+  password = ENV.fetch("#{prefix}REDIS_PASSWORD") { password if defaults }
+  host     = ENV.fetch("#{prefix}REDIS_HOST") { host if defaults }
+  port     = ENV.fetch("#{prefix}REDIS_PORT") { port if defaults }
+  db       = ENV.fetch("#{prefix}REDIS_DB") { db if defaults }
 
   ENV["#{prefix}REDIS_URL"] = begin
     if [password, host, port, db].all?(&:nil?)


### PR DESCRIPTION
#26708 is caused by `setup_redis_env_url` not changing the `REDIS_URL`  after it has once been set, making it impossible to change the redis configuration afterwards using the same environment variables that were originally used to configure it.

This PR fixes this bug by using any existing `REDIS_URL` variable as the defaults that can be overwritten by the other environment variables instead of ignoring them entirely.

This does lead to a little more work being done for every time the `setup_redis_env_url` function is run, but given that this is only the case during a restart, I believe that any increased time spent on this function will be offset by the increase in convenience it provides to administrators.

