### PR TITLE
Fix invalid Content-Type header for WebP images

### DIFF
--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-# Be sure to restart your server when you modify this file.
-
 Mime::Type.register 'application/json', :json, %w(text/x-json application/jsonrequest application/jrd+json application/activity+json application/ld+json)
 Mime::Type.register 'text/xml',         :xml,  %w(application/xml application/atom+xml application/xrd+xml)
+
+# WebP is not defined in Rack 2.2.
+Rack::Mime::MIME_TYPES['.webp'] = 'image/webp'

--- a/spec/models/media_attachment_spec.rb
+++ b/spec/models/media_attachment_spec.rb
@@ -105,6 +105,9 @@ RSpec.describe MediaAttachment, paperclip_processing: true do
 
       # sets file extension
       expect(media.file_file_name).to end_with extension
+
+      # Rack::Mime (used by PublicFileServerMiddleware) recognizes file extension
+      expect(Rack::Mime.mime_type(extension, nil)).to eq content_type
     end
 
     it 'saves media attachment with correct size metadata' do


### PR DESCRIPTION
When using Rails to serve files, WebP images are served with `Content-Type: text/plain`.

This is because [Rack 2.2 does not support image/webp](https://github.com/rack/rack/blob/2-2-stable/lib/rack/mime.rb). Upgrading to Rack 3 [requires upgrading Sprockets,](https://github.com/rails/sprockets/blob/3.x/sprockets.gemspec#L14) and that is a bigger task (I am not familiar with the upgrade process).