### PR TITLE
Add a helper to render tests with Intl and a Redux Store

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -195,6 +195,7 @@ module.exports = {
           'config/webpack/**',
           'app/javascript/mastodon/performance.js',
           'app/javascript/mastodon/test_setup.js',
+          'app/javascript/mastodon/test_util.tsx',
           'app/javascript/**/__tests__/**',
         ],
       },

--- a/app/javascript/mastodon/store/index.ts
+++ b/app/javascript/mastodon/store/index.ts
@@ -9,32 +9,35 @@ import { errorsMiddleware } from './middlewares/errors';
 import { loadingBarMiddleware } from './middlewares/loading_bar';
 import { soundsMiddleware } from './middlewares/sounds';
 
-export const store = configureStore({
-  reducer: rootReducer,
-  middleware: (getDefaultMiddleware) =>
-    getDefaultMiddleware({
-      // In development, Redux Toolkit enables 2 default middlewares to detect
-      // common issues with states. Unfortunately, our use of ImmutableJS for state
-      // triggers both, so lets disable them until our state is fully refactored
+export const createStore = () =>
+  configureStore({
+    reducer: rootReducer,
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware({
+        // In development, Redux Toolkit enables 2 default middlewares to detect
+        // common issues with states. Unfortunately, our use of ImmutableJS for state
+        // triggers both, so lets disable them until our state is fully refactored
 
-      // https://redux-toolkit.js.org/api/serializabilityMiddleware
-      // This checks recursively that every values in the state are serializable in JSON
-      // Which is not the case, as we use ImmutableJS structures, but also File objects
-      serializableCheck: false,
+        // https://redux-toolkit.js.org/api/serializabilityMiddleware
+        // This checks recursively that every values in the state are serializable in JSON
+        // Which is not the case, as we use ImmutableJS structures, but also File objects
+        serializableCheck: false,
 
-      // https://redux-toolkit.js.org/api/immutabilityMiddleware
-      // This checks recursively if every value in the state is immutable (ie, a JS primitive type)
-      // But this is not the case, as our Root State is an ImmutableJS map, which is an object
-      immutableCheck: false,
-    })
-      .concat(
-        loadingBarMiddleware({
-          promiseTypeSuffixes: ['REQUEST', 'SUCCESS', 'FAIL'],
-        }),
-      )
-      .concat(errorsMiddleware)
-      .concat(soundsMiddleware()),
-});
+        // https://redux-toolkit.js.org/api/immutabilityMiddleware
+        // This checks recursively if every value in the state is immutable (ie, a JS primitive type)
+        // But this is not the case, as our Root State is an ImmutableJS map, which is an object
+        immutableCheck: false,
+      })
+        .concat(
+          loadingBarMiddleware({
+            promiseTypeSuffixes: ['REQUEST', 'SUCCESS', 'FAIL'],
+          }),
+        )
+        .concat(errorsMiddleware)
+        .concat(soundsMiddleware()),
+  });
+
+export const store = createStore();
 
 // Infer the `RootState` and `AppDispatch` types from the store itself
 export type RootState = ReturnType<typeof rootReducer>;

--- a/app/javascript/mastodon/test_util.tsx
+++ b/app/javascript/mastodon/test_util.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import { IntlProvider } from 'react-intl';
+
+import { Provider } from 'react-redux';
+
+import type { RenderOptions } from '@testing-library/react';
+import { render as testRender } from '@testing-library/react';
+
+import { createStore } from 'mastodon/store';
+
+export const render = (node: React.ReactNode, opts?: RenderOptions) => {
+  const store = createStore();
+  return testRender(
+    <Provider store={store}>
+      <IntlProvider locale='unknown' messages={{}} textComponent='span'>
+        {node}
+      </IntlProvider>
+    </Provider>,
+    opts,
+  );
+};
+
+export { fireEvent } from '@testing-library/react';


### PR DESCRIPTION
This PR adds a test utility that allows one to render components with an appropriate internationalization settings and a pre-configured Redux store. This significantly reduces the amount of boilerplate required when writing tests for existing or new components in Jest.

* A new eslintrc rule is added to allow the use of `@testing-library/react` within `app/javascript/mastodon/test_util.tsx`
* `store/index.js` is modified to expose a function, `createStore()`, which allows the creation of a store. This is used in `test_util.tsx` to ensure that each time a new component is rendered in a test that it gets a fresh store with the default state initialized. The function is immediately invoked within `store/index.js` to preserve the existing behavior.
* `test_util.tsx` is added which exposes a `render` function intended to mirror `@testing-library/react`, and the `fireEvent` function from `@testing-library/react`. This render function can be used instead of `@testing-library/react` to gain the benefits mentioned at the beginning.

I'm using this in the search state refactor PR, and wanted to submit it early to reduce the size of that PR and make it available to other folks developing the FE.