### PR TITLE
Do not truncate backtrace when the `BACKTRACE` env variable is set

### DIFF
--- a/lib/mastodon/sidekiq_middleware.rb
+++ b/lib/mastodon/sidekiq_middleware.rb
@@ -16,7 +16,7 @@ class Mastodon::SidekiqMiddleware
   private
 
   def limit_backtrace_and_raise(exception)
-    exception.set_backtrace(exception.backtrace.first(BACKTRACE_LIMIT))
+    exception.set_backtrace(exception.backtrace.first(BACKTRACE_LIMIT)) unless ENV['BACKTRACE']
     raise exception
   end
 


### PR DESCRIPTION
Backtrace silencers can be disabled by setting the `BACKTRACE` environment variable, but that results in mostly useless sidekiq traces as only the first 3 lines are kept. This PR fixes it by changing our middleware not to truncate traces when `BACKTRACE` is set.