### PR TITLE
Improve interaction modal error handling

### DIFF
--- a/app/controllers/api/v1/peers/search_controller.rb
+++ b/app/controllers/api/v1/peers/search_controller.rb
@@ -41,5 +41,7 @@ class Api::V1::Peers::SearchController < Api::BaseController
       domain = TagManager.instance.normalize_domain(domain)
       @domains = Instance.searchable.where(Instance.arel_table[:domain].matches("#{Instance.sanitize_sql_like(domain)}%", false, true)).limit(10).pluck(:domain)
     end
+  rescue Addressable::URI::InvalidURIError
+    @domains = []
   end
 end

--- a/app/javascript/packs/remote_interaction_helper.ts
+++ b/app/javascript/packs/remote_interaction_helper.ts
@@ -140,7 +140,9 @@ const fromAcct = (acct: string) => {
 };
 
 const fetchInteractionURL = (uri_or_domain: string) => {
-  if (/^https?:\/\//.test(uri_or_domain)) {
+  if (uri_or_domain === '') {
+    fetchInteractionURLFailure();
+  } else if (/^https?:\/\//.test(uri_or_domain)) {
     fromURL(uri_or_domain);
   } else if (uri_or_domain.includes('@')) {
     fromAcct(uri_or_domain);


### PR DESCRIPTION
- consider an empty input as an error instead of going to `https://authorize_interaction/…` (but similarly to the “Publish” button, do not disable the button on empty input)
- display the input as invalid and disable the button whenever the input's value cannot be parsed as an URL or handle
- fix handling of invalid input in `/api/v1/peers/search`