### PR TITLE
Downgrade signature verification debug logging from `warn` to `debug`

### DIFF
--- a/app/controllers/concerns/signature_verification.rb
+++ b/app/controllers/concerns/signature_verification.rb
@@ -119,7 +119,7 @@ module SignatureVerification
   private
 
   def fail_with!(message, **options)
-    Rails.logger.warn { "Signature verification failed: #{message}" }
+    Rails.logger.debug { "Signature verification failed: #{message}" }
 
     @signature_verification_failure_reason = { error: message }.merge(options)
     @signed_request_actor = nil


### PR DESCRIPTION
The logging added in #26637 was not meant to have `warn` severity