### PR TITLE
Change onboarding prompt to use full width of banner in web UI

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -8877,7 +8877,6 @@ noscript {
   border-radius: 8px;
   border: 1px solid $highlight-text-color;
   background: rgba($highlight-text-color, 0.15);
-  padding-inline-end: 45px;
   overflow: hidden;
 
   &__background-image {
@@ -8940,7 +8939,7 @@ noscript {
     position: absolute;
     inset-inline-end: 0;
     top: 0;
-    padding: 10px;
+    padding: 15px 10px;
 
     .icon-button {
       color: $highlight-text-color;


### PR DESCRIPTION
I didn't like the padding on one side.