### PR TITLE
Add recent searches in web UI

### DIFF
--- a/app/javascript/mastodon/actions/store.js
+++ b/app/javascript/mastodon/actions/store.js
@@ -2,6 +2,7 @@ import { Iterable, fromJS } from 'immutable';
 
 import { hydrateCompose } from './compose';
 import { importFetchedAccounts } from './importer';
+import { hydrateSearch } from './search';
 
 export const STORE_HYDRATE = 'STORE_HYDRATE';
 export const STORE_HYDRATE_LAZY = 'STORE_HYDRATE_LAZY';
@@ -20,6 +21,7 @@ export function hydrateStore(rawState) {
     });
 
     dispatch(hydrateCompose());
+    dispatch(hydrateSearch());
     dispatch(importFetchedAccounts(Object.values(rawState.accounts)));
   };
 }

--- a/app/javascript/mastodon/features/compose/components/search.jsx
+++ b/app/javascript/mastodon/features/compose/components/search.jsx
@@ -16,6 +16,17 @@ const messages = defineMessages({
   placeholderSignedIn: { id: 'search.search_or_paste', defaultMessage: 'Search or paste URL' },
 });
 
+const labelForRecentSearch = search => {
+  switch(search.get('type')) {
+  case 'account':
+    return `@${search.get('q')}`;
+  case 'hashtag':
+    return `#${search.get('q')}`;
+  default:
+    return search.get('q');
+  }
+};
+
 class Search extends PureComponent {
 
   static contextTypes = {
@@ -187,12 +198,16 @@ class Search extends PureComponent {
   };
 
   handleRecentSearchClick = search => {
+    const { onChange } = this.props;
     const { router } = this.context;
 
     if (search.get('type') === 'account') {
       router.history.push(`/@${search.get('q')}`);
     } else if (search.get('type') === 'hashtag') {
       router.history.push(`/tags/${search.get('q')}`);
+    } else {
+      onChange(search.get('q'));
+      this._submit(search.get('type'));
     }
 
     this._unfocus();
@@ -221,10 +236,14 @@ class Search extends PureComponent {
   }
 
   _submit (type) {
-    const { onSubmit, openInRoute } = this.props;
+    const { onSubmit, openInRoute, value, onClickSearchResult } = this.props;
     const { router } = this.context;
 
     onSubmit(type);
+
+    if (value) {
+      onClickSearchResult(value, type);
+    }
 
     if (openInRoute) {
       router.history.push('/search');
@@ -243,7 +262,7 @@ class Search extends PureComponent {
     const { recent } = this.props;
 
     return recent.toArray().map(search => ({
-      label: search.get('type') === 'account' ? `@${search.get('q')}` : `#${search.get('q')}`,
+      label: labelForRecentSearch(search),
 
       action: () => this.handleRecentSearchClick(search),
 
@@ -359,7 +378,7 @@ class Search extends PureComponent {
           {searchEnabled ? (
             <div className='search__popout__menu'>
               {this.defaultOptions.map(({ key, label, action }, i) => (
-                <button key={key} onMouseDown={action} className={classNames('search__popout__menu__item', { selected: selectedOption === (options.length + i) })}>
+                <button key={key} onMouseDown={action} className={classNames('search__popout__menu__item', { selected: selectedOption === ((options.length || recent.size) + i) })}>
                   {label}
                 </button>
               ))}

--- a/app/javascript/mastodon/features/compose/containers/search_container.js
+++ b/app/javascript/mastodon/features/compose/containers/search_container.js
@@ -15,7 +15,7 @@ import Search from '../components/search';
 const mapStateToProps = state => ({
   value: state.getIn(['search', 'value']),
   submitted: state.getIn(['search', 'submitted']),
-  recent: state.getIn(['search', 'recent']),
+  recent: state.getIn(['search', 'recent']).reverse(),
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/app/javascript/mastodon/reducers/search.js
+++ b/app/javascript/mastodon/reducers/search.js
@@ -14,8 +14,7 @@ import {
   SEARCH_SHOW,
   SEARCH_EXPAND_REQUEST,
   SEARCH_EXPAND_SUCCESS,
-  SEARCH_RESULT_CLICK,
-  SEARCH_RESULT_FORGET,
+  SEARCH_HISTORY_UPDATE,
 } from '../actions/search';
 
 const initialState = ImmutableMap({
@@ -73,10 +72,8 @@ export default function search(state = initialState, action) {
   case SEARCH_EXPAND_SUCCESS:
     const results = action.searchType === 'hashtags' ? ImmutableOrderedSet(fromJS(action.results.hashtags)) : action.results[action.searchType].map(item => item.id);
     return state.updateIn(['results', action.searchType], list => list.union(results));
-  case SEARCH_RESULT_CLICK:
-    return state.update('recent', set => set.add(fromJS(action.result)));
-  case SEARCH_RESULT_FORGET:
-    return state.update('recent', set => set.filterNot(result => result.get('q') === action.q));
+  case SEARCH_HISTORY_UPDATE:
+    return state.set('recent', ImmutableOrderedSet(fromJS(action.recent)));
   default:
     return state;
   }

--- a/app/javascript/mastodon/settings.js
+++ b/app/javascript/mastodon/settings.js
@@ -46,3 +46,4 @@ export default class Settings {
 export const pushNotificationsSetting = new Settings('mastodon_push_notification_data');
 export const tagHistory = new Settings('mastodon_tag_history');
 export const bannerSettings = new Settings('mastodon_banner_settings');
+export const searchHistory = new Settings('mastodon_search_history');


### PR DESCRIPTION
Previously, recent searches were not persisted between page reloads. It would also only remember "Go to profile" and "Go to hashtag" quick-actions. Now, it will remember all types of searches and save them to local storage just like recently used hashtags.