### PR TITLE
Fix `#hashtag` matching on individual components in search

### DIFF
--- a/app/lib/search_query_transformer.rb
+++ b/app/lib/search_query_transformer.rb
@@ -121,7 +121,7 @@ class SearchQueryTransformer < Parslet::Transform
 
     def to_query
       if @term.start_with?('#')
-        { match: { tags: { query: @term } } }
+        { match: { tags: { query: @term, operator: 'and' } } }
       else
         { multi_match: { type: 'most_fields', query: @term, fields: ['text', 'text.stemmed'], operator: 'and' } }
       end


### PR DESCRIPTION
The match query would tokenize on word delimeters and the default "OR" operator would result in e.g. a search for `#tag20` yielding results that have a hashtag that contains `20` or `tag` separately.