### PR TITLE
Add ability to auto detect the language of statuses via environment variable

### DIFF
--- a/app/lib/translation_service/deepl.rb
+++ b/app/lib/translation_service/deepl.rb
@@ -11,7 +11,8 @@ class TranslationService::DeepL < TranslationService
   end
 
   def translate(texts, source_language, target_language)
-    form = { text: texts, source_lang: source_language&.upcase, target_lang: target_language, tag_handling: 'html' }
+    form = { text: texts, target_lang: target_language, tag_handling: 'html' }
+    form[:source_lang] = source_language&.upcase if source_language != 'auto'
     request(:post, '/v2/translate', form: form) do |res|
       transform_response(res.body_with_limit)
     end

--- a/spec/services/translate_status_service_spec.rb
+++ b/spec/services/translate_status_service_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe TranslateStatusService, type: :service do
   subject(:service) { described_class.new }
 
-  let(:status) { Fabricate(:status, text: text, spoiler_text: spoiler_text, language: 'en', preloadable_poll: poll, media_attachments: media_attachments) }
+  let(:status) { Fabricate(:status, text: text, spoiler_text: spoiler_text, language: 'en', preloadable_poll: poll, media_attachments: media_attachments, visibility: 0) }
   let(:text) { 'Hello' }
   let(:spoiler_text) { '' }
   let(:poll) { nil }


### PR DESCRIPTION
There's currently no way to translate a status that has been labeled with an incorrect language. 

This PR solves this problem by allowing instance administrators to have a status' language be auto detected by the translation backend instead of relying on the self-reporting of the authors.

