### PR TITLE
Fix `account_id`, `max_id` and `min_id` params not working in search

### DIFF
--- a/app/lib/search_query_parser.rb
+++ b/app/lib/search_query_parser.rb
@@ -8,7 +8,7 @@ class SearchQueryParser < Parslet::Parser
   rule(:operator)  { (str('+') | str('-')).as(:operator) }
   rule(:prefix)    { term >> colon }
   rule(:shortcode) { (colon >> term >> colon.maybe).as(:shortcode) }
-  rule(:phrase)    { (quote >> (term >> space.maybe).repeat >> quote).as(:phrase) }
+  rule(:phrase)    { (quote >> (match('[^\s"]').repeat(1).as(:term) >> space.maybe).repeat >> quote).as(:phrase) }
   rule(:clause)    { (operator.maybe >> prefix.maybe.as(:prefix) >> (phrase | term | shortcode)).as(:clause) | prefix.as(:clause) | quote.as(:junk) }
   rule(:query)     { (clause >> space.maybe).repeat.as(:query) }
   root(:query)

--- a/app/lib/search_query_transformer.rb
+++ b/app/lib/search_query_transformer.rb
@@ -225,17 +225,16 @@ class SearchQueryTransformer < Parslet::Transform
   rule(clause: subtree(:clause)) do
     prefix   = clause[:prefix][:term].to_s if clause[:prefix]
     operator = clause[:operator]&.to_s
+    term     = clause[:phrase] ? clause[:phrase].map { |term| term[:term].to_s }.join(' ') : clause[:term].to_s
 
     if clause[:prefix] && SUPPORTED_PREFIXES.include?(prefix)
-      PrefixClause.new(prefix, operator, clause[:term].to_s, current_account: current_account)
+      PrefixClause.new(prefix, operator, term, current_account: current_account)
     elsif clause[:prefix]
-      TermClause.new(operator, "#{prefix} #{clause[:term]}")
+      TermClause.new(operator, "#{prefix} #{term}")
     elsif clause[:term]
-      TermClause.new(operator, clause[:term].to_s)
-    elsif clause[:shortcode]
-      TermClause.new(operator, ":#{clause[:term]}:")
+      TermClause.new(operator, term)
     elsif clause[:phrase]
-      PhraseClause.new(operator, clause[:phrase].is_a?(Array) ? clause[:phrase].map { |p| p[:term].to_s }.join(' ') : clause[:phrase].to_s)
+      PhraseClause.new(operator, term)
     else
       raise "Unexpected clause type: #{clause}"
     end

--- a/app/services/statuses_search_service.rb
+++ b/app/services/statuses_search_service.rb
@@ -8,6 +8,7 @@ class StatusesSearchService < BaseService
     @limit   = options[:limit].to_i
     @offset  = options[:offset].to_i
 
+    convert_deprecated_options!
     status_search_results
   end
 
@@ -27,5 +28,26 @@ class StatusesSearchService < BaseService
 
   def parsed_query
     SearchQueryTransformer.new.apply(SearchQueryParser.new.parse(@query), current_account: @account)
+  end
+
+  def convert_deprecated_options!
+    syntax_options = []
+
+    if @options[:account_id]
+      username = Account.select(:username, :domain).find(@options[:account_id]).acct
+      syntax_options << "from:@#{username}"
+    end
+
+    if @options[:min_id]
+      timestamp = Mastodon::Snowflake.to_time(@options[:min_id])
+      syntax_options << "after:\"#{timestamp.iso8601}\""
+    end
+
+    if @options[:max_id]
+      timestamp = Mastodon::Snowflake.to_time(@options[:max_id])
+      syntax_options << "before:\"#{timestamp.iso8601}\""
+    end
+
+    @query = "#{@query} #{syntax_options.join(' ')}".strip if syntax_options.any?
   end
 end

--- a/lib/mastodon/snowflake.rb
+++ b/lib/mastodon/snowflake.rb
@@ -104,6 +104,10 @@ module Mastodon::Snowflake
       id
     end
 
+    def to_time(id)
+      Time.at((id >> 16) / 1000).utc
+    end
+
     private
 
     def already_defined?

--- a/spec/lib/search_query_transformer_spec.rb
+++ b/spec/lib/search_query_transformer_spec.rb
@@ -57,4 +57,24 @@ describe SearchQueryTransformer do
       expect(subject.send(:filter_clauses)).to be_empty
     end
   end
+
+  context 'with \'"hello world"\'' do
+    let(:query) { '"hello world"' }
+
+    it 'transforms clauses' do
+      expect(subject.send(:must_clauses).map(&:phrase)).to contain_exactly('hello world')
+      expect(subject.send(:must_not_clauses)).to be_empty
+      expect(subject.send(:filter_clauses)).to be_empty
+    end
+  end
+
+  context 'with \'before:"2022-01-01 23:00"\'' do
+    let(:query) { 'before:"2022-01-01 23:00"' }
+
+    it 'transforms clauses' do
+      expect(subject.send(:must_clauses)).to be_empty
+      expect(subject.send(:must_not_clauses)).to be_empty
+      expect(subject.send(:filter_clauses).map(&:term)).to contain_exactly(lt: '2022-01-01 23:00', time_zone: 'UTC')
+    end
+  end
 end


### PR DESCRIPTION
Fix #26837

These parameters should be considered deprecated, but since they were documented, they can't be removed yet. This also fixes `before:"0000-00-00 00:00:00"` not being properly matched due to the colons in the phrase.