### PR TITLE
Fix #26849 by adding the domain of the current SSO provider to the form-action CSP

### DIFF
--- a/app/controllers/concerns/web_app_controller_concern.rb
+++ b/app/controllers/concerns/web_app_controller_concern.rb
@@ -11,7 +11,7 @@ module WebAppControllerConcern
   end
 
   def skip_csrf_meta_tags?
-    !(ENV['OMNIAUTH_ONLY'] == 'true' && Devise.omniauth_providers.length == 1) && current_user.nil?
+    !(ENV['ONE_CLICK_SSO_LOGIN'] == 'true' && ENV['OMNIAUTH_ONLY'] == 'true' && Devise.omniauth_providers.length == 1) && current_user.nil?
   end
 
   def set_app_body_class

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -113,6 +113,6 @@ class InitialStateSerializer < ActiveModel::Serializer
   end
 
   def sso_redirect
-    "/auth/auth/#{Devise.omniauth_providers[0]}" if ENV['OMNIAUTH_ONLY'] == 'true' && Devise.omniauth_providers.length == 1
+    "/auth/auth/#{Devise.omniauth_providers[0]}" if ENV['ONE_CLICK_SSO_LOGIN'] == 'true' && ENV['OMNIAUTH_ONLY'] == 'true' && Devise.omniauth_providers.length == 1
   end
 end


### PR DESCRIPTION
Fixes #26849

Without the SSO provider in form-action CSP, a browser will reject the redirect to the SSO provider after clicking on the 'Login or Register' button introduced by #26083.

The CSP header on instances not using a single SSO method as their sole authentication method should remain unaltered.