### PR TITLE
Don't use multiple columns in app scope settings if screen width isn't enough

### DIFF
--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -279,6 +279,12 @@ code {
     }
   }
 
+  .input.with_block_label.doorkeeper_application_scopes ul {
+    @media screen and (width <= 1000px) {
+      column-count: unset;
+    }
+  }
+
   .input.with_block_label.user_role_permissions_as_keys ul {
     columns: unset;
   }


### PR DESCRIPTION
The form used to set scopes for an application looks great with multiple columns on desktop, but when using it on mobile the screen width isn't enough and text overlaps, making some descriptions unreadable (especially in the admin section), like this:
![Screenshot 2023-09-10 225217](https://github.com/mastodon/mastodon/assets/36609914/da4e981e-b060-427e-ae06-9d15624a2732)

We can try using `column-count: unset;` for devices with a screen width smaller than 1000px, that's the point where text starts overlapping.

https://github.com/mastodon/mastodon/assets/36609914/25334aeb-da32-48b2-8cd1-a00d24b7d679

This PR adds a rule specific for this particular form, as other forms with multiple columns (like the one in Preferences > Other) don't have as much text and look fine.
