### PR TITLE
Fix `Rails/RedundantActiveRecordAllMethod` cop

### DIFF
--- a/app/lib/delivery_failure_tracker.rb
+++ b/app/lib/delivery_failure_tracker.rb
@@ -62,7 +62,7 @@ class DeliveryFailureTracker
         key.delete_prefix(exhausted_deliveries_key_by(''))
       end
 
-      domains - UnavailableDomain.all.pluck(:domain)
+      domains - UnavailableDomain.pluck(:domain)
     end
 
     def warning_domains_map(domains = nil)

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -109,7 +109,7 @@ class UserRole < ApplicationRecord
   end
 
   def self.that_can(*any_of_privileges)
-    select { |role| role.can?(*any_of_privileges) }
+    all.select { |role| role.can?(*any_of_privileges) }
   end
 
   def everyone?

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -109,7 +109,7 @@ class UserRole < ApplicationRecord
   end
 
   def self.that_can(*any_of_privileges)
-    all.select { |role| role.can?(*any_of_privileges) }
+    select { |role| role.can?(*any_of_privileges) }
   end
 
   def everyone?

--- a/spec/lib/vacuum/imports_vacuum_spec.rb
+++ b/spec/lib/vacuum/imports_vacuum_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Vacuum::ImportsVacuum do
 
   describe '#perform' do
     it 'cleans up the expected imports' do
-      expect { subject.perform }.to change { BulkImport.all.pluck(:id) }.from([old_unconfirmed, new_unconfirmed, recent_ongoing, recent_finished, old_finished].map(&:id)).to([new_unconfirmed, recent_ongoing, recent_finished].map(&:id))
+      expect { subject.perform }.to change { BulkImport.pluck(:id) }.from([old_unconfirmed, new_unconfirmed, recent_ongoing, recent_finished, old_finished].map(&:id)).to([new_unconfirmed, recent_ongoing, recent_finished].map(&:id))
     end
   end
 end


### PR DESCRIPTION
Fixes one of the failures associated with this attempted rubocop-rails upgrade: https://github.com/mastodon/mastodon/actions/runs/6130221543/job/16639113304?pr=26867