### PR TITLE
Fix `Rails/FindEach` cop

### DIFF
--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -246,7 +246,7 @@ class FeedManager
   # @param [Account] target_account
   # @return [void]
   def clear_from_lists(account, target_account)
-    List.where(account: account).each do |list|
+    List.where(account: account).find_each do |list|
       clear_from_list(list, target_account)
     end
   end

--- a/app/services/activitypub/fetch_featured_tags_collection_service.rb
+++ b/app/services/activitypub/fetch_featured_tags_collection_service.rb
@@ -55,7 +55,7 @@ class ActivityPub::FetchFeaturedTagsCollectionService < BaseService
 
     FeaturedTag.includes(:tag).references(:tag).where(account: @account).where.not(tag: { name: normalized_names }).delete_all
 
-    FeaturedTag.includes(:tag).references(:tag).where(account: @account, tag: { name: normalized_names }).each do |featured_tag|
+    FeaturedTag.includes(:tag).references(:tag).where(account: @account, tag: { name: normalized_names }).find_each do |featured_tag|
       featured_tag.update(name: tags.delete(featured_tag.tag.name))
     end
 

--- a/app/services/activitypub/synchronize_followers_service.rb
+++ b/app/services/activitypub/synchronize_followers_service.rb
@@ -23,7 +23,7 @@ class ActivityPub::SynchronizeFollowersService < BaseService
   private
 
   def remove_unexpected_local_followers!
-    @account.followers.local.where.not(id: @expected_followers.map(&:id)).find_each do |unexpected_follower|
+    @account.followers.local.where.not(id: @expected_followers.map(&:id)).reorder(nil).find_each do |unexpected_follower|
       UnfollowService.new.call(unexpected_follower, @account)
     end
   end

--- a/app/services/activitypub/synchronize_followers_service.rb
+++ b/app/services/activitypub/synchronize_followers_service.rb
@@ -23,7 +23,7 @@ class ActivityPub::SynchronizeFollowersService < BaseService
   private
 
   def remove_unexpected_local_followers!
-    @account.followers.local.where.not(id: @expected_followers.map(&:id)).each do |unexpected_follower|
+    @account.followers.local.where.not(id: @expected_followers.map(&:id)).find_each do |unexpected_follower|
       UnfollowService.new.call(unexpected_follower, @account)
     end
   end

--- a/app/services/appeal_service.rb
+++ b/app/services/appeal_service.rb
@@ -22,7 +22,7 @@ class AppealService < BaseService
   end
 
   def notify_staff!
-    User.those_who_can(:manage_appeals).includes(:account).each do |u|
+    User.those_who_can(:manage_appeals).includes(:account).find_each do |u|
       AdminMailer.with(recipient: u.account).new_appeal(@appeal).deliver_later if u.allows_appeal_emails?
     end
   end

--- a/app/services/approve_appeal_service.rb
+++ b/app/services/approve_appeal_service.rb
@@ -53,7 +53,7 @@ class ApproveAppealService < BaseService
 
   def undo_mark_statuses_as_sensitive!
     representative_account = Account.representative
-    @strike.statuses.includes(:media_attachments).each do |status|
+    @strike.statuses.includes(:media_attachments).find_each do |status|
       UpdateStatusService.new.call(status, representative_account.id, sensitive: false) if status.with_media?
     end
   end

--- a/app/services/process_hashtags_service.rb
+++ b/app/services/process_hashtags_service.rb
@@ -24,7 +24,7 @@ class ProcessHashtagsService < BaseService
     added_tags = @current_tags - @previous_tags
 
     unless added_tags.empty?
-      @account.featured_tags.where(tag_id: added_tags.map(&:id)).each do |featured_tag|
+      @account.featured_tags.where(tag_id: added_tags.map(&:id)).find_each do |featured_tag|
         featured_tag.increment(@status.created_at)
       end
     end
@@ -32,7 +32,7 @@ class ProcessHashtagsService < BaseService
     removed_tags = @previous_tags - @current_tags
 
     unless removed_tags.empty?
-      @account.featured_tags.where(tag_id: removed_tags.map(&:id)).each do |featured_tag|
+      @account.featured_tags.where(tag_id: removed_tags.map(&:id)).find_each do |featured_tag|
         featured_tag.decrement(@status.id)
       end
     end

--- a/app/services/remove_status_service.rb
+++ b/app/services/remove_status_service.rb
@@ -114,7 +114,7 @@ class RemoveStatusService < BaseService
   end
 
   def remove_from_hashtags
-    @account.featured_tags.where(tag_id: @status.tags.map(&:id)).each do |featured_tag|
+    @account.featured_tags.where(tag_id: @status.tags.map(&:id)).find_each do |featured_tag|
       featured_tag.decrement(@status.id)
     end
 

--- a/app/services/report_service.rb
+++ b/app/services/report_service.rb
@@ -42,7 +42,7 @@ class ReportService < BaseService
   def notify_staff!
     return if @report.unresolved_siblings?
 
-    User.those_who_can(:manage_reports).includes(:account).each do |u|
+    User.those_who_can(:manage_reports).includes(:account).find_each do |u|
       LocalNotificationWorker.perform_async(u.account_id, @report.id, 'Report', 'admin.report')
       AdminMailer.with(recipient: u.account).new_report(@report).deliver_later if u.allows_report_emails?
     end


### PR DESCRIPTION
Fixes one of the failures associated with this attempted rubocop-rails upgrade: https://github.com/mastodon/mastodon/actions/runs/6130221543/job/16639113304?pr=26867

The actual change here provides a performance improvement (batch loading) to the queries.