### PR TITLE
Change Content-Security-Policy to be tighter on media paths

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -5,7 +5,11 @@
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
 def host_to_url(str)
-  "http#{Rails.configuration.x.use_https ? 's' : ''}://#{str.split('/').first}" if str.present?
+  return if str.blank?
+
+  uri = Addressable::URI.parse("http#{Rails.configuration.x.use_https ? 's' : ''}://#{str}")
+  uri.path += '/' unless uri.path.blank? || uri.path.end_with?('/')
+  uri.to_s
 end
 
 base_host = Rails.configuration.x.web_domain


### PR DESCRIPTION
Related to #24177, which was fixed by broadening the CSP more than needed.

Indeed, some of the occurrences of #24177 were because people used `example.com/bucket` as `S3_ALIAS_HOST`, which resulted in `https://example.com/bucket` in the CSP, forbidding access to anything that is not exactly `https://example.com/bucket`. This was fixed by broadening to `https://example.com/`, but `https://example.com/bucket/` (notice the trailing `/`) would have worked as well.