### PR TITLE
Fix `Rails/BulkChangeTable` cop

### DIFF
--- a/db/migrate/20160222143943_add_profile_fields_to_accounts.rb
+++ b/db/migrate/20160222143943_add_profile_fields_to_accounts.rb
@@ -2,8 +2,10 @@
 
 class AddProfileFieldsToAccounts < ActiveRecord::Migration[4.2]
   def change
-    add_column :accounts, :note, :text, null: false, default: ''
-    add_column :accounts, :display_name, :string, null: false, default: ''
-    add_column :accounts, :uri, :string, null: false, default: ''
+    change_table :accounts, bulk: true do |t|
+      t.column :note, :text, null: false, default: ''
+      t.column :display_name, :string, null: false, default: ''
+      t.column :uri, :string, null: false, default: ''
+    end
   end
 end

--- a/db/migrate/20160223162837_add_metadata_to_statuses.rb
+++ b/db/migrate/20160223162837_add_metadata_to_statuses.rb
@@ -2,7 +2,9 @@
 
 class AddMetadataToStatuses < ActiveRecord::Migration[4.2]
   def change
-    add_column :statuses, :in_reply_to_id, :integer, null: true
-    add_column :statuses, :reblog_of_id, :integer, null: true
+    change_table(:statuses, bulk: true) do |t|
+      t.column :in_reply_to_id, :integer, null: true
+      t.column :reblog_of_id, :integer, null: true
+    end
   end
 end

--- a/db/migrate/20160305115639_add_devise_to_users.rb
+++ b/db/migrate/20160305115639_add_devise_to_users.rb
@@ -2,7 +2,7 @@
 
 class AddDeviseToUsers < ActiveRecord::Migration[4.2]
   def self.up
-    change_table(:users) do |t|
+    change_table(:users, bulk: true) do |t|
       ## Database authenticatable
       t.string :encrypted_password, null: false, default: ''
 

--- a/db/migrate/20160314164231_add_owner_to_application.rb
+++ b/db/migrate/20160314164231_add_owner_to_application.rb
@@ -2,8 +2,10 @@
 
 class AddOwnerToApplication < ActiveRecord::Migration[4.2]
   def change
-    add_column :oauth_applications, :owner_id, :integer, null: true
-    add_column :oauth_applications, :owner_type, :string, null: true
+    change_table(:oauth_applications, bulk: true) do |t|
+      t.column :owner_id, :integer, null: true
+      t.column :owner_type, :string, null: true
+    end
     add_index :oauth_applications, [:owner_id, :owner_type]
   end
 end

--- a/db/migrate/20160926213048_remove_owner_from_application.rb
+++ b/db/migrate/20160926213048_remove_owner_from_application.rb
@@ -2,8 +2,10 @@
 
 class RemoveOwnerFromApplication < ActiveRecord::Migration[5.0]
   def change
-    remove_index :oauth_applications, [:owner_id, :owner_type]
-    remove_column :oauth_applications, :owner_id, :integer, null: true
-    remove_column :oauth_applications, :owner_type, :string, null: true
+    change_table(:oauth_applications, bulk: true) do |t|
+      t.remove_index [:owner_id, :owner_type]
+      t.remove :owner_id, type: :integer, options: { null: true }
+      t.remove :owner_type, type: :string, options: { null: true }
+    end
   end
 end

--- a/db/migrate/20161003142332_add_confirmable_to_users.rb
+++ b/db/migrate/20161003142332_add_confirmable_to_users.rb
@@ -2,10 +2,12 @@
 
 class AddConfirmableToUsers < ActiveRecord::Migration[5.0]
   def change
-    add_column :users, :confirmation_token, :string
-    add_column :users, :confirmed_at, :datetime
-    add_column :users, :confirmation_sent_at, :datetime
-    add_column :users, :unconfirmed_email, :string
+    change_table(:users, bulk: true) do |t|
+      t.column :confirmation_token, :string
+      t.column :confirmed_at, :datetime
+      t.column :confirmation_sent_at, :datetime
+      t.column :unconfirmed_email, :string
+    end
     add_index :users, :confirmation_token, unique: true
   end
 end

--- a/db/migrate/20170112154826_migrate_settings.rb
+++ b/db/migrate/20170112154826_migrate_settings.rb
@@ -2,20 +2,24 @@
 
 class MigrateSettings < ActiveRecord::Migration[4.2]
   def up
-    remove_index :settings, [:target_type, :target_id, :var]
-    rename_column :settings, :target_id, :thing_id
-    rename_column :settings, :target_type, :thing_type
-    change_column :settings, :thing_id, :integer, null: true, default: nil
-    change_column :settings, :thing_type, :string, null: true, default: nil
-    add_index :settings, [:thing_type, :thing_id, :var], unique: true
+    change_table(:settings, bulk: true) do |t|
+      t.remove_index [:target_type, :target_id, :var]
+      t.rename :target_id, :thing_id
+      t.rename :target_type, :thing_type
+      t.change :thing_id, :integer, null: true, default: nil
+      t.change :thing_type, :string, null: true, default: nil
+      t.index [:thing_type, :thing_id, :var], unique: true
+    end
   end
 
   def down
-    remove_index :settings, [:thing_type, :thing_id, :var]
-    rename_column :settings, :thing_id, :target_id
-    rename_column :settings, :thing_type, :target_type
-    change_column :settings, :target_id, :integer, null: false
-    change_column :settings, :target_type, :string, null: false, default: ''
-    add_index :settings, [:target_type, :target_id, :var], unique: true
+    change_table(:settings, bulk: true) do |t|
+      t.remove_index [:thing_type, :thing_id, :var]
+      t.rename :thing_id, :target_id
+      t.rename :thing_type, :target_type
+      t.column :target_id, :integer, null: false
+      t.column :target_type, :string, null: false, default: ''
+      t.index [:target_type, :target_id, :var], unique: true
+    end
   end
 end

--- a/db/migrate/20170127165745_add_devise_two_factor_to_users.rb
+++ b/db/migrate/20170127165745_add_devise_two_factor_to_users.rb
@@ -2,10 +2,12 @@
 
 class AddDeviseTwoFactorToUsers < ActiveRecord::Migration[5.0]
   def change
-    add_column :users, :encrypted_otp_secret, :string
-    add_column :users, :encrypted_otp_secret_iv, :string
-    add_column :users, :encrypted_otp_secret_salt, :string
-    add_column :users, :consumed_timestep, :integer
-    add_column :users, :otp_required_for_login, :boolean
+    change_table(:users, bulk: true) do |t|
+      t.column :encrypted_otp_secret, :string
+      t.column :encrypted_otp_secret_iv, :string
+      t.column :encrypted_otp_secret_salt, :string
+      t.column :consumed_timestep, :integer
+      t.column :otp_required_for_login, :boolean
+    end
   end
 end

--- a/db/migrate/20170322143850_change_primary_key_to_bigint_on_statuses.rb
+++ b/db/migrate/20170322143850_change_primary_key_to_bigint_on_statuses.rb
@@ -2,9 +2,11 @@
 
 class ChangePrimaryKeyToBigintOnStatuses < ActiveRecord::Migration[5.0]
   def change
-    change_column :statuses, :id, :bigint
-    change_column :statuses, :reblog_of_id, :bigint
-    change_column :statuses, :in_reply_to_id, :bigint
+    change_table(:statuses, bulk: true) do |t|
+      t.change :id, :bigint
+      t.change :reblog_of_id, :bigint
+      t.change :in_reply_to_id, :bigint
+    end
 
     change_column :media_attachments, :status_id, :bigint
     change_column :mentions, :status_id, :bigint

--- a/db/migrate/20170330021336_add_counter_caches.rb
+++ b/db/migrate/20170330021336_add_counter_caches.rb
@@ -2,11 +2,15 @@
 
 class AddCounterCaches < ActiveRecord::Migration[5.0]
   def change
-    add_column :statuses, :favourites_count, :integer, null: false, default: 0
-    add_column :statuses, :reblogs_count, :integer, null: false, default: 0
-    add_column :accounts, :statuses_count, :integer, null: false, default: 0
-    add_column :accounts, :followers_count, :integer, null: false, default: 0
-    add_column :accounts, :following_count, :integer, null: false, default: 0
+    change_table(:statuses, bulk: true) do |t|
+      t.column :favourites_count, :integer, null: false, default: 0
+      t.column :reblogs_count, :integer, null: false, default: 0
+    end
+    change_table(:accounts, bulk: true) do |t|
+      t.column :statuses_count, :integer, null: false, default: 0
+      t.column :followers_count, :integer, null: false, default: 0
+      t.column :following_count, :integer, null: false, default: 0
+    end
   end
 end
 

--- a/db/migrate/20170425202925_add_oembed_to_preview_cards.rb
+++ b/db/migrate/20170425202925_add_oembed_to_preview_cards.rb
@@ -2,13 +2,15 @@
 
 class AddOEmbedToPreviewCards < ActiveRecord::Migration[5.0]
   def change
-    add_column :preview_cards, :type, :integer, default: 0, null: false
-    add_column :preview_cards, :html, :text, null: false, default: ''
-    add_column :preview_cards, :author_name, :string, null: false, default: ''
-    add_column :preview_cards, :author_url, :string, null: false, default: ''
-    add_column :preview_cards, :provider_name, :string, null: false, default: ''
-    add_column :preview_cards, :provider_url, :string, null: false, default: ''
-    add_column :preview_cards, :width, :integer, default: 0, null: false
-    add_column :preview_cards, :height, :integer, default: 0, null: false
+    change_table(:preview_cards, bulk: true) do |t|
+      t.column :type, :integer, default: 0, null: false
+      t.column :html, :text, null: false, default: ''
+      t.column :author_name, :string, null: false, default: ''
+      t.column :author_url, :string, null: false, default: ''
+      t.column :provider_name, :string, null: false, default: ''
+      t.column :provider_url, :string, null: false, default: ''
+      t.column :width, :integer, default: 0, null: false
+      t.column :height, :integer, default: 0, null: false
+    end
   end
 end

--- a/db/migrate/20170427011934_re_add_owner_to_application.rb
+++ b/db/migrate/20170427011934_re_add_owner_to_application.rb
@@ -2,8 +2,10 @@
 
 class ReAddOwnerToApplication < ActiveRecord::Migration[5.0]
   def change
-    add_column :oauth_applications, :owner_id, :integer, null: true
-    add_column :oauth_applications, :owner_type, :string, null: true
+    change_table(:oauth_applications, bulk: true) do |t|
+      t.column :owner_id, :integer, null: true
+      t.column :owner_type, :string, null: true
+    end
     add_index :oauth_applications, [:owner_id, :owner_type]
     add_foreign_key :oauth_applications, :users, column: :owner_id, on_delete: :cascade
   end

--- a/db/migrate/20170520145338_change_language_filter_to_opt_out.rb
+++ b/db/migrate/20170520145338_change_language_filter_to_opt_out.rb
@@ -3,9 +3,12 @@
 class ChangeLanguageFilterToOptOut < ActiveRecord::Migration[5.0]
   def change
     remove_index :users, :allowed_languages
-    remove_column :users, :allowed_languages
 
-    add_column :users, :filtered_languages, :string, array: true, default: [], null: false
+    change_table(:users, bulk: true) do |t|
+      t.remove :allowed_languages
+      t.column :filtered_languages, :string, array: true, default: [], null: false
+    end
+
     add_index :users, :filtered_languages, using: :gin
   end
 end

--- a/db/migrate/20170624134742_add_description_to_session_activations.rb
+++ b/db/migrate/20170624134742_add_description_to_session_activations.rb
@@ -2,8 +2,10 @@
 
 class AddDescriptionToSessionActivations < ActiveRecord::Migration[5.1]
   def change
-    add_column :session_activations, :user_agent, :string, null: false, default: ''
-    add_column :session_activations, :ip, :inet
+    change_table(:session_activations, bulk: true) do |t|
+      t.column :user_agent, :string, null: false, default: ''
+      t.column :ip, :inet
+    end
     add_foreign_key :session_activations, :users, on_delete: :cascade
   end
 end

--- a/db/migrate/20170718211102_add_activitypub_to_accounts.rb
+++ b/db/migrate/20170718211102_add_activitypub_to_accounts.rb
@@ -2,10 +2,12 @@
 
 class AddActivityPubToAccounts < ActiveRecord::Migration[5.1]
   def change
-    add_column :accounts, :inbox_url, :string, null: false, default: ''
-    add_column :accounts, :outbox_url, :string, null: false, default: ''
-    add_column :accounts, :shared_inbox_url, :string, null: false, default: ''
-    add_column :accounts, :followers_url, :string, null: false, default: ''
-    add_column :accounts, :protocol, :integer, null: false, default: 0
+    change_table(:accounts, bulk: true) do |t|
+      t.column :inbox_url, :string, null: false, default: ''
+      t.column :outbox_url, :string, null: false, default: ''
+      t.column :shared_inbox_url, :string, null: false, default: ''
+      t.column :followers_url, :string, null: false, default: ''
+      t.column :protocol, :integer, null: false, default: 0
+    end
   end
 end

--- a/db/migrate/20171006142024_add_uri_to_custom_emojis.rb
+++ b/db/migrate/20171006142024_add_uri_to_custom_emojis.rb
@@ -2,7 +2,11 @@
 
 class AddUriToCustomEmojis < ActiveRecord::Migration[5.2]
   def change
-    add_column :custom_emojis, :uri, :string
-    add_column :custom_emojis, :image_remote_url, :string
+    safety_assured do
+      change_table(:custom_emojis, bulk: true) do |t|
+        t.column :uri, :string
+        t.column :image_remote_url, :string
+      end
+    end
   end
 end

--- a/db/migrate/20180812123222_change_relays_enabled.rb
+++ b/db/migrate/20180812123222_change_relays_enabled.rb
@@ -15,7 +15,9 @@ class ChangeRelaysEnabled < ActiveRecord::Migration[5.2]
   end
 
   def down
-    remove_column :relays, :state
-    add_column :relays, :enabled, :boolean, default: false, null: false
+    change_table(:relays, bulk: true) do |t|
+      t.remove :state
+      t.column :enabled, :boolean, default: false, null: false
+    end
   end
 end

--- a/db/migrate/20190511134027_add_silenced_at_suspended_at_to_accounts.rb
+++ b/db/migrate/20190511134027_add_silenced_at_suspended_at_to_accounts.rb
@@ -13,8 +13,12 @@ class AddSilencedAtSuspendedAtToAccounts < ActiveRecord::Migration[5.2]
   end
 
   def up
-    add_column :accounts, :silenced_at, :datetime
-    add_column :accounts, :suspended_at, :datetime
+    safety_assured do
+      change_table(:accounts, bulk: true) do |t|
+        t.column :silenced_at, :datetime
+        t.column :suspended_at, :datetime
+      end
+    end
 
     # Record suspend date of blocks and silences for users whose limitations match
     # a domain block
@@ -36,7 +40,9 @@ class AddSilencedAtSuspendedAtToAccounts < ActiveRecord::Migration[5.2]
     Account.where(suspended: false).where.not(suspended_at: nil).in_batches.update_all(suspended: true)
     Account.where(silenced: false).where.not(silenced_at: nil).in_batches.update_all(silenced: true)
 
-    remove_column :accounts, :silenced_at
-    remove_column :accounts, :suspended_at
+    change_table(:accounts, bulk: true) do |t|
+      t.column :silenced_at, :datetime
+      t.column :suspended_at, :datetime
+    end
   end
 end

--- a/db/migrate/20190805123746_add_capabilities_to_tags.rb
+++ b/db/migrate/20190805123746_add_capabilities_to_tags.rb
@@ -2,10 +2,14 @@
 
 class AddCapabilitiesToTags < ActiveRecord::Migration[5.2]
   def change
-    add_column :tags, :usable, :boolean
-    add_column :tags, :trendable, :boolean
-    add_column :tags, :listable, :boolean
-    add_column :tags, :reviewed_at, :datetime
-    add_column :tags, :requested_review_at, :datetime
+    safety_assured do
+      change_table(:tags, bulk: true) do |t|
+        t.column :usable, :boolean
+        t.column :trendable, :boolean
+        t.column :listable, :boolean
+        t.column :reviewed_at, :datetime
+        t.column :requested_review_at, :datetime
+      end
+    end
   end
 end

--- a/db/migrate/20190807135426_add_comments_to_domain_blocks.rb
+++ b/db/migrate/20190807135426_add_comments_to_domain_blocks.rb
@@ -2,7 +2,11 @@
 
 class AddCommentsToDomainBlocks < ActiveRecord::Migration[5.2]
   def change
-    add_column :domain_blocks, :private_comment, :text
-    add_column :domain_blocks, :public_comment, :text
+    safety_assured do
+      change_table(:domain_blocks, bulk: true) do |t|
+        t.column :private_comment, :text
+        t.column :public_comment, :text
+      end
+    end
   end
 end

--- a/db/migrate/20190815225426_add_last_status_at_to_tags.rb
+++ b/db/migrate/20190815225426_add_last_status_at_to_tags.rb
@@ -2,7 +2,11 @@
 
 class AddLastStatusAtToTags < ActiveRecord::Migration[5.2]
   def change
-    add_column :tags, :last_status_at, :datetime
-    add_column :tags, :last_trend_at, :datetime
+    safety_assured do
+      change_table(:tags, bulk: true) do |t|
+        t.column :last_status_at, :datetime
+        t.column :last_trend_at, :datetime
+      end
+    end
   end
 end

--- a/db/migrate/20190901035623_add_max_score_to_tags.rb
+++ b/db/migrate/20190901035623_add_max_score_to_tags.rb
@@ -2,7 +2,11 @@
 
 class AddMaxScoreToTags < ActiveRecord::Migration[5.2]
   def change
-    add_column :tags, :max_score, :float
-    add_column :tags, :max_score_at, :datetime
+    safety_assured do
+      change_table(:tags, bulk: true) do |t|
+        t.column :max_score, :float
+        t.column :max_score_at, :datetime
+      end
+    end
   end
 end

--- a/db/migrate/20200417125749_add_storage_schema_version.rb
+++ b/db/migrate/20200417125749_add_storage_schema_version.rb
@@ -3,8 +3,12 @@
 class AddStorageSchemaVersion < ActiveRecord::Migration[5.2]
   def change
     add_column :preview_cards, :image_storage_schema_version, :integer
-    add_column :accounts, :avatar_storage_schema_version, :integer
-    add_column :accounts, :header_storage_schema_version, :integer
+    safety_assured do
+      change_table(:accounts, bulk: true) do |t|
+        t.column :avatar_storage_schema_version, :integer
+        t.column :header_storage_schema_version, :integer
+      end
+    end
     add_column :media_attachments, :file_storage_schema_version, :integer
     add_column :custom_emojis, :image_storage_schema_version, :integer
   end

--- a/db/migrate/20200608113046_add_sign_in_token_to_users.rb
+++ b/db/migrate/20200608113046_add_sign_in_token_to_users.rb
@@ -2,7 +2,11 @@
 
 class AddSignInTokenToUsers < ActiveRecord::Migration[5.2]
   def change
-    add_column :users, :sign_in_token, :string
-    add_column :users, :sign_in_token_sent_at, :datetime
+    safety_assured do
+      change_table(:users, bulk: true) do |t|
+        t.column :sign_in_token, :string
+        t.column :sign_in_token_sent_at, :datetime
+      end
+    end
   end
 end

--- a/db/migrate/20211112011713_add_language_to_preview_cards.rb
+++ b/db/migrate/20211112011713_add_language_to_preview_cards.rb
@@ -2,8 +2,12 @@
 
 class AddLanguageToPreviewCards < ActiveRecord::Migration[6.1]
   def change
-    add_column :preview_cards, :language, :string
-    add_column :preview_cards, :max_score, :float
-    add_column :preview_cards, :max_score_at, :datetime
+    safety_assured do
+      change_table(:preview_cards, bulk: true) do |t|
+        t.column :language, :string
+        t.column :max_score, :float
+        t.column :max_score_at, :datetime
+      end
+    end
   end
 end

--- a/db/migrate/20211231080958_add_category_to_reports.rb
+++ b/db/migrate/20211231080958_add_category_to_reports.rb
@@ -8,16 +8,24 @@ class AddCategoryToReports < ActiveRecord::Migration[6.1]
   disable_ddl_transaction!
 
   def up
-    safety_assured { add_column_with_default :reports, :category, :int, default: 0, allow_null: false }
-    add_column :reports, :action_taken_at, :datetime
-    add_column :reports, :rule_ids, :bigint, array: true
-    safety_assured { execute 'UPDATE reports SET action_taken_at = updated_at WHERE action_taken = TRUE' }
+    safety_assured do
+      add_column_with_default :reports, :category, :int, default: 0, allow_null: false
+      change_table(:reports, bulk: true) do |t|
+        t.column :action_taken_at, :datetime
+        t.column :rule_ids, :bigint, array: true
+      end
+      execute 'UPDATE reports SET action_taken_at = updated_at WHERE action_taken = TRUE'
+    end
   end
 
   def down
-    safety_assured { execute 'UPDATE reports SET action_taken = TRUE WHERE action_taken_at IS NOT NULL' }
-    remove_column :reports, :category
-    remove_column :reports, :action_taken_at
-    remove_column :reports, :rule_ids
+    safety_assured do
+      execute 'UPDATE reports SET action_taken = TRUE WHERE action_taken_at IS NOT NULL'
+      remove_column :reports, :category
+      change_table(:reports, bulk: true) do |t|
+        t.column :action_taken_at, :datetime
+        t.column :rule_ids, :bigint, array: true
+      end
+    end
   end
 end

--- a/db/migrate/20220202200743_add_trendable_to_accounts.rb
+++ b/db/migrate/20220202200743_add_trendable_to_accounts.rb
@@ -2,8 +2,12 @@
 
 class AddTrendableToAccounts < ActiveRecord::Migration[6.1]
   def change
-    add_column :accounts, :trendable, :boolean
-    add_column :accounts, :reviewed_at, :datetime
-    add_column :accounts, :requested_review_at, :datetime
+    safety_assured do
+      change_table(:accounts, bulk: true) do |t|
+        t.column :trendable, :boolean
+        t.column :reviewed_at, :datetime
+        t.column :requested_review_at, :datetime
+      end
+    end
   end
 end

--- a/db/migrate/20220224010024_add_ips_to_email_domain_blocks.rb
+++ b/db/migrate/20220224010024_add_ips_to_email_domain_blocks.rb
@@ -2,7 +2,11 @@
 
 class AddIpsToEmailDomainBlocks < ActiveRecord::Migration[6.1]
   def change
-    add_column :email_domain_blocks, :ips, :inet, array: true
-    add_column :email_domain_blocks, :last_refresh_at, :datetime
+    safety_assured do
+      change_table(:email_domain_blocks, bulk: true) do |t|
+        t.column :ips, :inet, array: true
+        t.column :last_refresh_at, :datetime
+      end
+    end
   end
 end

--- a/db/migrate/20220227041951_add_last_used_at_to_oauth_access_tokens.rb
+++ b/db/migrate/20220227041951_add_last_used_at_to_oauth_access_tokens.rb
@@ -2,7 +2,11 @@
 
 class AddLastUsedAtToOauthAccessTokens < ActiveRecord::Migration[6.1]
   def change
-    add_column :oauth_access_tokens, :last_used_at, :datetime
-    add_column :oauth_access_tokens, :last_used_ip, :inet
+    safety_assured do
+      change_table(:oauth_access_tokens, bulk: true) do |t|
+        t.column :last_used_at, :datetime
+        t.column :last_used_ip, :inet
+      end
+    end
   end
 end

--- a/db/migrate/20220303000827_add_ordered_media_attachment_ids_to_status_edits.rb
+++ b/db/migrate/20220303000827_add_ordered_media_attachment_ids_to_status_edits.rb
@@ -2,9 +2,13 @@
 
 class AddOrderedMediaAttachmentIdsToStatusEdits < ActiveRecord::Migration[6.1]
   def change
-    add_column :status_edits, :ordered_media_attachment_ids, :bigint, array: true
-    add_column :status_edits, :media_descriptions, :text, array: true
-    add_column :status_edits, :poll_options, :string, array: true
-    add_column :status_edits, :sensitive, :boolean
+    safety_assured do
+      change_table(:status_edits, bulk: true) do |t|
+        t.column :ordered_media_attachment_ids, :bigint, array: true
+        t.column :media_descriptions, :text, array: true
+        t.column :poll_options, :string, array: true
+        t.column :sensitive, :boolean
+      end
+    end
   end
 end

--- a/db/migrate/20220824164433_add_human_identifier_to_admin_action_logs.rb
+++ b/db/migrate/20220824164433_add_human_identifier_to_admin_action_logs.rb
@@ -2,8 +2,12 @@
 
 class AddHumanIdentifierToAdminActionLogs < ActiveRecord::Migration[6.1]
   def change
-    add_column :admin_action_logs, :human_identifier, :string
-    add_column :admin_action_logs, :route_param, :string
-    add_column :admin_action_logs, :permalink, :string
+    safety_assured do
+      change_table(:admin_action_logs, bulk: true) do |t|
+        t.column :human_identifier, :string
+        t.column :route_param, :string
+        t.column :permalink, :string
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes one of the failures associated with this attempted rubocop-rails upgrade: https://github.com/mastodon/mastodon/actions/runs/6130221543/job/16639113304?pr=26867

Similar to other recent PRs which change historical migrations -- it's generally a bad idea to change old migrations, but I think the risk here is minimal. These migrations are all sufficiently old that I doubt they will be run in production anywhere, so the benefit here is almost entirely to local dev envs, CI, etc.