### PR TITLE
Fix recent search items not handling overflows correctly

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -5061,6 +5061,11 @@ a.status-card {
           font-weight: 700;
           color: $primary-text-color;
         }
+
+        span {
+          overflow: inherit;
+          text-overflow: inherit;
+        }
       }
     }
   }


### PR DESCRIPTION
Currently, if an item in recent searches is too long (this happens frequently when looking up a remote toot by its URL, for example), the overflow isn't correctly handled, making the cross button at the right not visible.

![Screenshot 2023-09-11 221300](https://github.com/mastodon/mastodon/assets/36609914/6b48598e-b612-441b-a362-d080e7e8e30b)
![Screenshot 2023-09-11 222404](https://github.com/mastodon/mastodon/assets/36609914/763e759c-eb82-4d5c-840c-6adb00bd8e16)

`overflow` and `text-overflow` rules are set for the parent, but not inherited by `<span>`. This PR fixes that.
![Screenshot 2023-09-11 222521](https://github.com/mastodon/mastodon/assets/36609914/9c3f1df9-3f0b-4ea2-8b51-f77f741bc0a6)
![Screenshot 2023-09-11 222554](https://github.com/mastodon/mastodon/assets/36609914/39eab351-5b12-4828-a29c-7ff5249c9cc2)
![Screenshot 2023-09-11 223711](https://github.com/mastodon/mastodon/assets/36609914/cd57a5c0-c52a-4605-bca5-f600935304dc)



