### PR TITLE
Fix Redux types

### DIFF
--- a/app/javascript/mastodon/store/middlewares/errors.ts
+++ b/app/javascript/mastodon/store/middlewares/errors.ts
@@ -5,7 +5,7 @@ import { showAlertForError } from '../../actions/alerts';
 
 const defaultFailSuffix = 'FAIL';
 
-export const errorsMiddleware: Middleware<Record<string, never>, RootState> =
+export const errorsMiddleware: Middleware<unknown, RootState> =
   ({ dispatch }) =>
   (next) =>
   (action: AnyAction & { skipAlert?: boolean; skipNotFound?: boolean }) => {

--- a/app/javascript/mastodon/store/middlewares/loading_bar.ts
+++ b/app/javascript/mastodon/store/middlewares/loading_bar.ts
@@ -15,7 +15,7 @@ const defaultTypeSuffixes: Config['promiseTypeSuffixes'] = [
 
 export const loadingBarMiddleware = (
   config: Config = {},
-): Middleware<Record<string, never>, RootState> => {
+): Middleware<unknown, RootState> => {
   const promiseTypeSuffixes = config.promiseTypeSuffixes ?? defaultTypeSuffixes;
 
   return ({ dispatch }) =>

--- a/app/javascript/mastodon/store/middlewares/sounds.ts
+++ b/app/javascript/mastodon/store/middlewares/sounds.ts
@@ -34,10 +34,7 @@ const play = (audio: HTMLAudioElement) => {
   void audio.play();
 };
 
-export const soundsMiddleware = (): Middleware<
-  Record<string, never>,
-  RootState
-> => {
+export const soundsMiddleware = (): Middleware<unknown, RootState> => {
   const soundCache: Record<string, HTMLAudioElement> = {};
 
   void ready(() => {

--- a/app/javascript/mastodon/store/typed_functions.ts
+++ b/app/javascript/mastodon/store/typed_functions.ts
@@ -12,5 +12,4 @@ export const createAppAsyncThunk = createAsyncThunk.withTypes<{
   state: RootState;
   dispatch: AppDispatch;
   rejectValue: string;
-  extra: { s: string; n: number };
 }>();


### PR DESCRIPTION
Middlewares do not  need the state, do using `unknown` is better here, and avoids a type definition loop.

This fixes a type issue when using `dispatch` with `createAppAsyncThunk`.