### PR TITLE
Add user preference to show posts from users limited server-wide

### DIFF
--- a/app/models/concerns/account/interactions.rb
+++ b/app/models/concerns/account/interactions.rb
@@ -290,6 +290,7 @@ module Account::Interactions
     relations = {
       blocked_by: Account.blocked_by_map(account_ids, id),
       following: Account.following_map(account_ids, id),
+      followed_by: Account.followed_by_map(account_ids, id),
     }
 
     return relations if options[:skip_blocking_and_muting]

--- a/app/models/user_settings.rb
+++ b/app/models/user_settings.rb
@@ -15,6 +15,7 @@ class UserSettings
   setting :default_language, default: nil
   setting :default_sensitive, default: false
   setting :default_privacy, default: nil, in: %w(public unlisted private)
+  setting :show_limited_users, default: 'none', in: %w(none followers all)
 
   setting_inverse_alias :indexable, :noindex
 

--- a/app/views/settings/preferences/other/show.html.haml
+++ b/app/views/settings/preferences/other/show.html.haml
@@ -23,6 +23,13 @@
     .fields-group
       = ff.input :default_sensitive, wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_default_sensitive'), hint: I18n.t('simple_form.hints.defaults.setting_default_sensitive')
 
+    %h4= t 'preferences.limited_accounts'
+
+    %p.hint= t 'preferences.limited_accounts_hint'
+
+    .fields-group
+      = ff.input :show_limited_users, collection: %w(none followers all), label_method: ->(item) { safe_join([t("simple_form.labels.defaults.setting_show_limited_users_#{item}"), content_tag(:span, t("simple_form.hints.defaults.setting_show_limited_users_#{item}"), class: 'hint')]) }, hint: false, as: :radio_buttons, collection_wrapper_tag: 'ul', item_wrapper_tag: 'li'
+
   %h4= t 'preferences.public_timelines'
 
   .fields-group

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1529,6 +1529,8 @@ en:
       too_few_options: must have more than one item
       too_many_options: can't contain more than %{max} items
   preferences:
+    limited_accounts: Limited accounts
+    limited_accounts_hint: Limited accounts are accounts whose reach is limited by moderators. Their posts do not show up in trends or public feeds. They can still be followed and interacted with, but their posts will not show up unless you follow them or have opted to see posts from limited accounts.
     other: Other
     posting_defaults: Posting defaults
     public_timelines: Public timelines

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -59,6 +59,9 @@ en:
         setting_display_media_default: Hide media marked as sensitive
         setting_display_media_hide_all: Always hide media
         setting_display_media_show_all: Always show media
+        setting_show_limited_users_all: Show posts and notifications regardless of whether the account has been limited by moderators, and auto-accepts follow requests unless your account is locked. Please keep in mind this may make you more exposed to unsolicited or rude replies.
+        setting_show_limited_users_followers: Hide posts and notifications from accounts who have been limited by moderators, unless you follow them or they follow you.
+        setting_show_limited_users_none: Hide posts and notifications from accounts who have been limited by moderators, unless you follow them.
         setting_use_blurhash: Gradients are based on the colors of the hidden visuals but obfuscate any details
         setting_use_pending_items: Hide timeline updates behind a click instead of automatically scrolling the feed
         username: You can use letters, numbers, and underscores
@@ -216,6 +219,9 @@ en:
         setting_expand_spoilers: Always expand posts marked with content warnings
         setting_hide_network: Hide your social graph
         setting_reduce_motion: Reduce motion in animations
+        setting_show_limited_users_all: Show posts from limited users
+        setting_show_limited_users_followers: Ignore limited users unless you follow them or they follow you
+        setting_show_limited_users_none: Ignore limited users you don't follow
         setting_system_font_ui: Use system's default font
         setting_theme: Site theme
         setting_trends: Show today's trends


### PR DESCRIPTION
Fixes #26524

Potentially addresses #19355 as well

(This has not been discussed internally, and it has not been tested; more specific tests would also need to be written)

This PR introduces a setting to decide which limited users to show the posts of:
- “Hide posts from limited users” (only show from people you follow): this is the current behavior, kept to not cause a breaking change
- “Show posts from limited users who follow you”: this is probably the one that makes the most sense, as once you've accepted someone into your followers (which is a required step for limited users), it makes sense to see their replies/notifications even if you do not interact with them
- “Show posts from limited users”: useful if you feel your server's moderators are too heavy-handed with limits

![image](https://github.com/mastodon/mastodon/assets/384364/fd84f370-2be2-4222-8dec-c06050299dac)