### PR TITLE
Extract class from CSP configuration/initialization

### DIFF
--- a/app/lib/content_security_policy.rb
+++ b/app/lib/content_security_policy.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ContentSecurityPolicy
+  def base_host
+    Rails.configuration.x.web_domain
+  end
+end

--- a/app/lib/content_security_policy.rb
+++ b/app/lib/content_security_policy.rb
@@ -4,4 +4,22 @@ class ContentSecurityPolicy
   def base_host
     Rails.configuration.x.web_domain
   end
+
+  def assets_host
+    url_from_configured_asset_host || url_from_base_host
+  end
+
+  private
+
+  def url_from_configured_asset_host
+    Rails.configuration.action_controller.asset_host
+  end
+
+  def url_from_base_host
+    host_to_url(base_host)
+  end
+
+  def host_to_url(str)
+    "http#{Rails.configuration.x.use_https ? 's' : ''}://#{str.split('/').first}" if str.present?
+  end
 end

--- a/app/lib/content_security_policy.rb
+++ b/app/lib/content_security_policy.rb
@@ -48,16 +48,12 @@ class ContentSecurityPolicy
   end
 
   def uri_from_configuration_and_string(host_string)
-    Addressable::URI.parse("#{host_protocol}://#{host_from_string_with_optional_path(host_string)}").tap do |uri|
+    Addressable::URI.parse("#{host_protocol}://#{host_string}").tap do |uri|
       uri.path += '/' unless uri.path.blank? || uri.path.end_with?('/')
     end.to_s
   end
 
   def host_protocol
     Rails.configuration.x.use_https ? 'https' : 'http'
-  end
-
-  def host_from_string_with_optional_path(host_string)
-    host_string.split('/').first
   end
 end

--- a/app/lib/content_security_policy.rb
+++ b/app/lib/content_security_policy.rb
@@ -28,11 +28,7 @@ class ContentSecurityPolicy
   end
 
   def host_to_url(host_string)
-    return if host_string.blank?
-
-    Addressable::URI.parse("http#{Rails.configuration.x.use_https ? 's' : ''}://#{host_string}").tap do |uri|
-      uri.path += '/' unless uri.path.blank? || uri.path.end_with?('/')
-    end.to_s
+    uri_from_configuration_and_string(host_string) if host_string.present?
   end
 
   def s3_alias_host
@@ -49,5 +45,19 @@ class ContentSecurityPolicy
 
   def s3_hostname_host
     host_to_url ENV.fetch('S3_HOSTNAME', nil)
+  end
+
+  def uri_from_configuration_and_string(host_string)
+    Addressable::URI.parse("#{host_protocol}://#{host_from_string_with_optional_path(host_string)}").tap do |uri|
+      uri.path += '/' unless uri.path.blank? || uri.path.end_with?('/')
+    end.to_s
+  end
+
+  def host_protocol
+    Rails.configuration.x.use_https ? 'https' : 'http'
+  end
+
+  def host_from_string_with_optional_path(host_string)
+    host_string.split('/').first
   end
 end

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -6,6 +6,8 @@
 # See the Securing Rails Applications Guide for more information:
 # https://guides.rubyonrails.org/security.html#content-security-policy-header
 
+require_relative '../../app/lib/content_security_policy'
+
 def host_to_url(str)
   return if str.blank?
 
@@ -14,10 +16,10 @@ def host_to_url(str)
   uri.to_s
 end
 
-base_host = Rails.configuration.x.web_domain
+policy = ContentSecurityPolicy.new
 
 assets_host   = Rails.configuration.action_controller.asset_host
-assets_host ||= host_to_url(base_host)
+assets_host ||= host_to_url(policy.base_host)
 
 media_host   = host_to_url(ENV['S3_ALIAS_HOST'])
 media_host ||= host_to_url(ENV['S3_CLOUDFRONT_HOST'])

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -8,23 +8,9 @@
 
 require_relative '../../app/lib/content_security_policy'
 
-def host_to_url(str)
-  return if str.blank?
-
-  uri = Addressable::URI.parse("http#{Rails.configuration.x.use_https ? 's' : ''}://#{str}")
-  uri.path += '/' unless uri.path.blank? || uri.path.end_with?('/')
-  uri.to_s
-end
-
 policy = ContentSecurityPolicy.new
-
 assets_host = policy.assets_host
-
-media_host   = host_to_url(ENV['S3_ALIAS_HOST'])
-media_host ||= host_to_url(ENV['S3_CLOUDFRONT_HOST'])
-media_host ||= host_to_url(ENV['AZURE_ALIAS_HOST'])
-media_host ||= host_to_url(ENV['S3_HOSTNAME']) if ENV['S3_ENABLED'] == 'true'
-media_host ||= assets_host
+media_host = policy.media_host
 
 def sso_host
   return unless ENV['ONE_CLICK_SSO_LOGIN'] == 'true'

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -18,8 +18,7 @@ end
 
 policy = ContentSecurityPolicy.new
 
-assets_host   = Rails.configuration.action_controller.asset_host
-assets_host ||= host_to_url(policy.base_host)
+assets_host = policy.assets_host
 
 media_host   = host_to_url(ENV['S3_ALIAS_HOST'])
 media_host ||= host_to_url(ENV['S3_CLOUDFRONT_HOST'])

--- a/spec/lib/content_security_policy_spec.rb
+++ b/spec/lib/content_security_policy_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ContentSecurityPolicy do
+  subject { described_class.new }
+
+  describe '#base_host' do
+    it 'returns the configured value for the web domain' do
+      expect(subject.base_host).to eq Rails.configuration.x.web_domain
+    end
+  end
+end

--- a/spec/lib/content_security_policy_spec.rb
+++ b/spec/lib/content_security_policy_spec.rb
@@ -5,9 +5,57 @@ require 'rails_helper'
 describe ContentSecurityPolicy do
   subject { described_class.new }
 
+  around do |example|
+    original_asset_host = Rails.configuration.action_controller.asset_host
+    original_web_domain = Rails.configuration.x.web_domain
+    original_use_https = Rails.configuration.x.use_https
+    example.run
+    Rails.configuration.action_controller.asset_host = original_asset_host
+    Rails.configuration.x.web_domain = original_web_domain
+    Rails.configuration.x.use_https = original_use_https
+  end
+
   describe '#base_host' do
+    before { Rails.configuration.x.web_domain = 'host.example' }
+
     it 'returns the configured value for the web domain' do
-      expect(subject.base_host).to eq Rails.configuration.x.web_domain
+      expect(subject.base_host).to eq 'host.example'
+    end
+  end
+
+  describe '#assets_host' do
+    context 'when asset_host is not configured' do
+      before { Rails.configuration.action_controller.asset_host = nil }
+
+      context 'with a configured web domain' do
+        before { Rails.configuration.x.web_domain = 'host.example' }
+
+        context 'when use_https is enabled' do
+          before { Rails.configuration.x.use_https = true }
+
+          it 'returns value from base host with https protocol' do
+            expect(subject.assets_host).to eq 'https://host.example'
+          end
+        end
+
+        context 'when use_https is disabled' do
+          before { Rails.configuration.x.use_https = false }
+
+          it 'returns value from base host with http protocol' do
+            expect(subject.assets_host).to eq 'http://host.example'
+          end
+        end
+      end
+    end
+
+    context 'when asset_host is configured' do
+      before do
+        Rails.configuration.action_controller.asset_host = 'https://assets.host.example'
+      end
+
+      it 'returns full value from configured host' do
+        expect(subject.assets_host).to eq 'https://assets.host.example'
+      end
     end
   end
 end

--- a/spec/lib/content_security_policy_spec.rb
+++ b/spec/lib/content_security_policy_spec.rb
@@ -58,4 +58,60 @@ describe ContentSecurityPolicy do
       end
     end
   end
+
+  describe '#media_host' do
+    context 'when there is no configured CDN' do
+      it 'defaults to using the assets_host value' do
+        expect(subject.media_host).to eq(subject.assets_host)
+      end
+    end
+
+    context 'when an S3 alias host is configured' do
+      around do |example|
+        ClimateControl.modify S3_ALIAS_HOST: 'asset-host.s3-alias.example' do
+          example.run
+        end
+      end
+
+      it 'uses the s3 alias host value' do
+        expect(subject.media_host).to eq 'https://asset-host.s3-alias.example'
+      end
+    end
+
+    context 'when an S3 cloudfront host is configured' do
+      around do |example|
+        ClimateControl.modify S3_CLOUDFRONT_HOST: 'asset-host.s3-cloudfront.example' do
+          example.run
+        end
+      end
+
+      it 'uses the s3 cloudfront host value' do
+        expect(subject.media_host).to eq 'https://asset-host.s3-cloudfront.example'
+      end
+    end
+
+    context 'when an azure alias host is configured' do
+      around do |example|
+        ClimateControl.modify AZURE_ALIAS_HOST: 'asset-host.azure-alias.example' do
+          example.run
+        end
+      end
+
+      it 'uses the azure alias host value' do
+        expect(subject.media_host).to eq 'https://asset-host.azure-alias.example'
+      end
+    end
+
+    context 'when s3_enabled is configured' do
+      around do |example|
+        ClimateControl.modify S3_ENABLED: 'true', S3_HOSTNAME: 'asset-host.s3.example' do
+          example.run
+        end
+      end
+
+      it 'uses the s3 hostname host value' do
+        expect(subject.media_host).to eq 'https://asset-host.s3.example'
+      end
+    end
+  end
 end

--- a/spec/lib/content_security_policy_spec.rb
+++ b/spec/lib/content_security_policy_spec.rb
@@ -78,6 +78,18 @@ describe ContentSecurityPolicy do
       end
     end
 
+    context 'when an S3 alias host with a trailing path is configured' do
+      around do |example|
+        ClimateControl.modify S3_ALIAS_HOST: 'asset-host.s3-alias.example/pathname' do
+          example.run
+        end
+      end
+
+      it 'uses the s3 alias host value and preserves the path' do
+        expect(subject.media_host).to eq 'https://asset-host.s3-alias.example/pathname/'
+      end
+    end
+
     context 'when an S3 cloudfront host is configured' do
       around do |example|
         ClimateControl.modify S3_CLOUDFRONT_HOST: 'asset-host.s3-cloudfront.example' do


### PR DESCRIPTION
As discussed here - https://github.com/mastodon/mastodon/pull/26889#issuecomment-1715762574

This is just a first pass which attempts to do nothing but a) extract a usable class from the CSP config, b) add some coverage around current behavior.

I have attempted to not change any behavior here. Assuming this direction is ok, there's probably more to add here in the way of edge case spec coverage, further refactors to the main initializer file, and then as change behavior or chase down more edge case bugs, expand this coverage when doing so.
