### PR TITLE
Change score half-life for trending posts from 2 hours to 1 hour

### DIFF
--- a/app/models/trends/statuses.rb
+++ b/app/models/trends/statuses.rb
@@ -8,7 +8,7 @@ class Trends::Statuses < Trends::Base
   self.default_options = {
     threshold: 5,
     review_threshold: 3,
-    score_halflife: 2.hours.freeze,
+    score_halflife: 1.hour.freeze,
     decay_threshold: 0.3,
   }
 


### PR DESCRIPTION
This minor adjustment should make the explore tab have fresher content more often...