### PR TITLE
Change links to posts and profiles in posts to open in web UI

### DIFF
--- a/app/controllers/redirects_controller.rb
+++ b/app/controllers/redirects_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class RedirectsController < ApplicationController
+  before_action :set_url
+  before_action :set_resource
+
+  def show
+    expires_in(1.day, public: true, stale_while_revalidate: 30.seconds, stale_if_error: 1.day) unless user_signed_in?
+
+    case @resource
+    when Account
+      redirect_to web_url("@#{@resource.pretty_acct}")
+    when Status
+      redirect_to web_url("@#{@resource.account.pretty_acct}/#{@resource.id}")
+    else
+      redirect_to @url, allow_other_host: true
+    end
+  end
+
+  private
+
+  def set_url
+    @url = params.require(:url)
+  end
+
+  def set_resource
+    @resource = ResolveURLService.new.call(@url) if user_signed_in?
+  end
+end

--- a/app/javascript/mastodon/components/status_content.jsx
+++ b/app/javascript/mastodon/components/status_content.jsx
@@ -124,6 +124,7 @@ class StatusContent extends PureComponent {
         link.setAttribute('href', `/tags/${link.text.replace(/^#/, '')}`);
       } else {
         link.setAttribute('title', link.href);
+        link.setAttribute('href', `/redirect?url=${encodeURIComponent(link.href)}`);
         link.classList.add('unhandled-link');
       }
     }

--- a/app/javascript/mastodon/components/status_content.jsx
+++ b/app/javascript/mastodon/components/status_content.jsx
@@ -122,6 +122,11 @@ class StatusContent extends PureComponent {
       } else if (link.textContent[0] === '#' || (link.previousSibling && link.previousSibling.textContent && link.previousSibling.textContent[link.previousSibling.textContent.length - 1] === '#')) {
         link.addEventListener('click', this.onHashtagClick.bind(this, link.text), false);
         link.setAttribute('href', `/tags/${link.text.replace(/^#/, '')}`);
+     } else if (status.get('uri') === link.href) {
+        // the link points to the source of the status. this happens e.g. with lemmy posts.
+        // there is no use in trying to open the url on this instance as it's already opened.
+        link.setAttribute('title', link.href);
+        link.classList.add('unhandled-link');
       } else {
         link.setAttribute('title', link.href);
         link.setAttribute('href', `/redirect?url=${encodeURIComponent(link.href)}`);

--- a/app/javascript/mastodon/components/status_content.jsx
+++ b/app/javascript/mastodon/components/status_content.jsx
@@ -122,7 +122,7 @@ class StatusContent extends PureComponent {
       } else if (link.textContent[0] === '#' || (link.previousSibling && link.previousSibling.textContent && link.previousSibling.textContent[link.previousSibling.textContent.length - 1] === '#')) {
         link.addEventListener('click', this.onHashtagClick.bind(this, link.text), false);
         link.setAttribute('href', `/tags/${link.text.replace(/^#/, '')}`);
-     } else if (status.get('uri') === link.href) {
+      } else if (status.get('uri') === link.href) {
         // the link points to the source of the status. this happens e.g. with lemmy posts.
         // there is no use in trying to open the url on this instance as it's already opened.
         link.setAttribute('title', link.href);

--- a/app/javascript/mastodon/features/account/components/header.jsx
+++ b/app/javascript/mastodon/features/account/components/header.jsx
@@ -235,10 +235,18 @@ class Header extends ImmutablePureComponent {
     for (var i = 0; i < links.length; ++i) {
       link = links[i];
 
+      if (link.classList.contains('status-link')) {
+        continue;
+      }
+
+      link.classList.add('status-link');
+
       if (link.textContent[0] === '#' || (link.previousSibling && link.previousSibling.textContent && link.previousSibling.textContent[link.previousSibling.textContent.length - 1] === '#')) {
         link.addEventListener('click', this.handleHashtagClick, false);
       } else if (link.classList.contains('mention')) {
         link.addEventListener('click', this.handleMentionClick, false);
+      } else {
+        link.setAttribute('href', `/redirect?url=${encodeURIComponent(link.href)}`);
       }
     }
   }

--- a/app/javascript/mastodon/features/status/components/card.jsx
+++ b/app/javascript/mastodon/features/status/components/card.jsx
@@ -208,7 +208,7 @@ export default class Card extends PureComponent {
               <div className='status-card__actions' onClick={this.handleEmbedClick} role='none'>
                 <div>
                   <button type='button' onClick={this.handleEmbedClick}><Icon id='play' icon={PlayArrowIcon} /></button>
-                  <a href={card.get('url')} onClick={this.handleExternalLinkClick} target='_blank' rel='noopener noreferrer'><Icon id='external-link' icon={OpenInNewIcon} /></a>
+                  <a href={`/redirect?url=${encodeURIComponent(card.get('url'))}`} onClick={this.handleExternalLinkClick} target='_blank' rel='noopener noreferrer'><Icon id='external-link' icon={OpenInNewIcon} /></a>
                 </div>
               </div>
             ) : spoilerButton}
@@ -219,7 +219,7 @@ export default class Card extends PureComponent {
       return (
         <div className={classNames('status-card', { expanded: largeImage })} ref={this.setRef} onClick={revealed ? null : this.handleReveal} role={revealed ? 'button' : null}>
           {embed}
-          <a href={card.get('url')} target='_blank' rel='noopener noreferrer'>{description}</a>
+          <a href={`/redirect?url=${encodeURIComponent(card.get('url'))}`} target='_blank' rel='noopener noreferrer'>{description}</a>
         </div>
       );
     } else if (card.get('image')) {
@@ -239,7 +239,7 @@ export default class Card extends PureComponent {
 
     return (
       <>
-        <a href={card.get('url')} className={classNames('status-card', { expanded: largeImage, bottomless: showAuthor })} target='_blank' rel='noopener noreferrer' ref={this.setRef}>
+        <a href={`/redirect?url=${encodeURIComponent(card.get('url'))}`} className={classNames('status-card', { expanded: largeImage, bottomless: showAuthor })} target='_blank' rel='noopener noreferrer' ref={this.setRef}>
           {embed}
           {description}
         </a>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,29 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Redirect",
+      "warning_code": 18,
+      "fingerprint": "8b543fdb2adb90f9c9e26ab6a67065ed577be23bc7fa3ed8158bb022394d0382",
+      "check_name": "Redirect",
+      "message": "Possible unprotected redirect",
+      "file": "app/controllers/redirects_controller.rb",
+      "line": 16,
+      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
+      "code": "redirect_to(params.require(:url), :allow_other_host => true)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "RedirectsController",
+        "method": "show"
+      },
+      "user_input": "params.require(:url)",
+      "confidence": "Weak",
+      "cwe_id": [
+        601
+      ],
+      "note": ""
+    }
+  ],
+  "updated": "2023-10-30 04:08:29 +0100",
+  "brakeman_version": "6.0.1"
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -202,6 +202,7 @@ Rails.application.routes.draw do
 
   get '/media_proxy/:id/(*any)', to: 'media_proxy#show', as: :media_proxy, format: false
   get '/backups/:id/download', to: 'backups#download', as: :download_backup, format: false
+  get '/redirect', to: 'redirects#show', format: false
 
   resource :authorize_interaction, only: [:show]
   resource :share, only: [:show]


### PR DESCRIPTION
One of the most common reasons for people landing outside their logged-in Mastodon interface now is links to posts within other posts, made more popular by quoting features in various mobile apps. Mobile apps like Tusky and Toot! take advantage of the search API to check all tapped links in posts for potentially being posts or profiles, and if so, opening them in-app. In the browser, we are more limited: we can't run an asynchronous request to the search API in the link click event *and* open a link in a new tab if it's just a regular link, as this triggers browsers' pop-up blocking; you can generally only open new tabs only within immediate the lifespan of the click event. This is why instead I am introducing a server-side redirect route that will perform the check and redirect. Client-side we only need to replace all links to go through this route, instead of going directly to the target.

___

Fixes MAS-202, fixes #1399, fixes #21869