### PR TITLE
Fix processing of `min_id` and `max_id` parameters in `/api/v2/search`

### DIFF
--- a/app/services/statuses_search_service.rb
+++ b/app/services/statuses_search_service.rb
@@ -39,12 +39,12 @@ class StatusesSearchService < BaseService
     end
 
     if @options[:min_id]
-      timestamp = Mastodon::Snowflake.to_time(@options[:min_id])
+      timestamp = Mastodon::Snowflake.to_time(@options[:min_id].to_i)
       syntax_options << "after:\"#{timestamp.iso8601}\""
     end
 
     if @options[:max_id]
-      timestamp = Mastodon::Snowflake.to_time(@options[:max_id])
+      timestamp = Mastodon::Snowflake.to_time(@options[:max_id].to_i)
       syntax_options << "before:\"#{timestamp.iso8601}\""
     end
 


### PR DESCRIPTION
Fixes #26924