### PR TITLE
Fix container build when cache is disabled

### DIFF
--- a/.github/workflows/build-container-image.yml
+++ b/.github/workflows/build-container-image.yml
@@ -95,5 +95,5 @@ jobs:
           push: ${{ inputs.push_to_images != '' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: ${{ inputs.cache && 'type=gha' }}
-          cache-to: ${{ inputs.cache && 'type=gha,mode=max' }}
+          cache-from: ${{ inputs.cache && 'type=gha' || '' }}
+          cache-to: ${{ inputs.cache && 'type=gha,mode=max' || '' }}


### PR DESCRIPTION
The current action was equivalent to `cache-to: false`, which Docker understood as "cache to the `false` container on the registry", which is not what we want.