### PR TITLE
Fix dismiss button overlapping with text in dismissable banners

### DIFF
--- a/app/javascript/mastodon/components/dismissable_banner.tsx
+++ b/app/javascript/mastodon/components/dismissable_banner.tsx
@@ -33,8 +33,6 @@ export const DismissableBanner: React.FC<PropsWithChildren<Props>> = ({
 
   return (
     <div className='dismissable-banner'>
-      <div className='dismissable-banner__message'>{children}</div>
-
       <div className='dismissable-banner__action'>
         <IconButton
           icon='times'
@@ -42,6 +40,8 @@ export const DismissableBanner: React.FC<PropsWithChildren<Props>> = ({
           onClick={handleDismiss}
         />
       </div>
+
+      <div className='dismissable-banner__message'>{children}</div>
     </div>
   );
 };

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -8941,7 +8941,7 @@ noscript {
   }
 
   &__action {
-    float: inline-end;
+    float: right;
     padding: 15px 10px;
 
     .icon-button {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -8941,9 +8941,7 @@ noscript {
   }
 
   &__action {
-    position: absolute;
-    inset-inline-end: 0;
-    top: 0;
+    float: inline-end;
     padding: 15px 10px;
 
     .icon-button {

--- a/app/javascript/styles/mastodon/rtl.scss
+++ b/app/javascript/styles/mastodon/rtl.scss
@@ -58,4 +58,11 @@ body.rtl {
   .fa-chevron-right::before {
     content: '\F053';
   }
+
+  .dismissable-banner,
+  .warning-banner {
+    &__action {
+      float: left;
+    }
+  }
 }


### PR DESCRIPTION
## Before

![image](https://github.com/mastodon/mastodon/assets/384364/56641987-aae4-4b96-bbda-cd7836463516)
![image](https://github.com/mastodon/mastodon/assets/384364/acba7fa1-2967-4359-9a18-2e60c7cfec06)

## After

![image](https://github.com/mastodon/mastodon/assets/384364/8efa4e7b-36ed-4ef5-ae53-eb9f21b18317)
![image](https://github.com/mastodon/mastodon/assets/384364/ea02ea2b-353a-433b-9f66-2c1044ee32ee)