### PR TITLE
Fix post edits not being forwarded as expected

### DIFF
--- a/app/lib/activitypub/activity/update.rb
+++ b/app/lib/activitypub/activity/update.rb
@@ -30,6 +30,6 @@ class ActivityPub::Activity::Update < ActivityPub::Activity
 
     return if @status.nil?
 
-    ActivityPub::ProcessStatusUpdateService.new.call(@status, @object, request_id: @options[:request_id])
+    ActivityPub::ProcessStatusUpdateService.new.call(@status, @json, @object, request_id: @options[:request_id])
   end
 end

--- a/app/services/activitypub/fetch_remote_poll_service.rb
+++ b/app/services/activitypub/fetch_remote_poll_service.rb
@@ -8,6 +8,6 @@ class ActivityPub::FetchRemotePollService < BaseService
 
     return unless supported_context?(json)
 
-    ActivityPub::ProcessStatusUpdateService.new.call(poll.status, json)
+    ActivityPub::ProcessStatusUpdateService.new.call(poll.status, json, json)
   end
 end

--- a/app/services/activitypub/process_status_update_service.rb
+++ b/app/services/activitypub/process_status_update_service.rb
@@ -5,10 +5,11 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
   include Redisable
   include Lockable
 
-  def call(status, json, request_id: nil)
+  def call(status, activity_json, object_json, request_id: nil)
     raise ArgumentError, 'Status has unsaved changes' if status.changed?
 
-    @json                      = json
+    @activity_json             = activity_json
+    @json                      = object_json
     @status_parser             = ActivityPub::Parser::StatusParser.new(@json)
     @uri                       = @status_parser.uri
     @status                    = status
@@ -306,6 +307,6 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
   end
 
   def forwarder
-    @forwarder ||= ActivityPub::Forwarder.new(@account, @json, @status)
+    @forwarder ||= ActivityPub::Forwarder.new(@account, @activity_json, @status)
   end
 end

--- a/spec/services/activitypub/process_status_update_service_spec.rb
+++ b/spec/services/activitypub/process_status_update_service_spec.rb
@@ -41,12 +41,12 @@ RSpec.describe ActivityPub::ProcessStatusUpdateService, type: :service do
 
   describe '#call' do
     it 'updates text' do
-      subject.call(status, json)
+      subject.call(status, json, json)
       expect(status.reload.text).to eq 'Hello universe'
     end
 
     it 'updates content warning' do
-      subject.call(status, json)
+      subject.call(status, json, json)
       expect(status.reload.spoiler_text).to eq 'Show more'
     end
 
@@ -64,7 +64,7 @@ RSpec.describe ActivityPub::ProcessStatusUpdateService, type: :service do
       end
 
       before do
-        subject.call(status, json)
+        subject.call(status, json, json)
       end
 
       it 'does not create any edits' do
@@ -87,7 +87,7 @@ RSpec.describe ActivityPub::ProcessStatusUpdateService, type: :service do
       end
 
       before do
-        subject.call(status, json)
+        subject.call(status, json, json)
       end
 
       it 'does not create any edits' do
@@ -134,7 +134,7 @@ RSpec.describe ActivityPub::ProcessStatusUpdateService, type: :service do
       end
 
       before do
-        subject.call(status, json)
+        subject.call(status, json, json)
       end
 
       it 'does not create any edits' do
@@ -186,7 +186,7 @@ RSpec.describe ActivityPub::ProcessStatusUpdateService, type: :service do
       end
 
       before do
-        subject.call(status, json)
+        subject.call(status, json, json)
       end
 
       it 'does not create any edits' do
@@ -214,11 +214,11 @@ RSpec.describe ActivityPub::ProcessStatusUpdateService, type: :service do
       end
 
       it 'does not create any edits' do
-        expect { subject.call(status, json) }.to_not(change { status.reload.edits.pluck(&:id) })
+        expect { subject.call(status, json, json) }.to_not(change { status.reload.edits.pluck(&:id) })
       end
 
       it 'does not update the text, spoiler_text or edited_at' do
-        expect { subject.call(status, json) }.to_not(change { s = status.reload; [s.text, s.spoiler_text, s.edited_at] })
+        expect { subject.call(status, json, json) }.to_not(change { s = status.reload; [s.text, s.spoiler_text, s.edited_at] })
       end
     end
 
@@ -233,7 +233,7 @@ RSpec.describe ActivityPub::ProcessStatusUpdateService, type: :service do
       end
 
       before do
-        subject.call(status, json)
+        subject.call(status, json, json)
       end
 
       it 'does not create any edits' do
@@ -257,7 +257,7 @@ RSpec.describe ActivityPub::ProcessStatusUpdateService, type: :service do
 
       before do
         status.update(ordered_media_attachment_ids: nil)
-        subject.call(status, json)
+        subject.call(status, json, json)
       end
 
       it 'does not create any edits' do
@@ -271,7 +271,7 @@ RSpec.describe ActivityPub::ProcessStatusUpdateService, type: :service do
 
     context 'when originally without tags' do
       before do
-        subject.call(status, json)
+        subject.call(status, json, json)
       end
 
       it 'updates tags' do
@@ -297,7 +297,7 @@ RSpec.describe ActivityPub::ProcessStatusUpdateService, type: :service do
       end
 
       before do
-        subject.call(status, json)
+        subject.call(status, json, json)
       end
 
       it 'updates tags' do
@@ -307,7 +307,7 @@ RSpec.describe ActivityPub::ProcessStatusUpdateService, type: :service do
 
     context 'when originally without mentions' do
       before do
-        subject.call(status, json)
+        subject.call(status, json, json)
       end
 
       it 'updates mentions' do
@@ -319,7 +319,7 @@ RSpec.describe ActivityPub::ProcessStatusUpdateService, type: :service do
       let(:mentions) { [alice, bob] }
 
       before do
-        subject.call(status, json)
+        subject.call(status, json, json)
       end
 
       it 'updates mentions' do
@@ -330,7 +330,7 @@ RSpec.describe ActivityPub::ProcessStatusUpdateService, type: :service do
     context 'when originally without media attachments' do
       before do
         stub_request(:get, 'https://example.com/foo.png').to_return(body: attachment_fixture('emojo.png'))
-        subject.call(status, json)
+        subject.call(status, json, json)
       end
 
       let(:payload) do
@@ -380,7 +380,7 @@ RSpec.describe ActivityPub::ProcessStatusUpdateService, type: :service do
 
       before do
         allow(RedownloadMediaWorker).to receive(:perform_async)
-        subject.call(status, json)
+        subject.call(status, json, json)
       end
 
       it 'updates the existing media attachment in-place' do
@@ -408,7 +408,7 @@ RSpec.describe ActivityPub::ProcessStatusUpdateService, type: :service do
       before do
         poll = Fabricate(:poll, status: status)
         status.update(preloadable_poll: poll)
-        subject.call(status, json)
+        subject.call(status, json, json)
       end
 
       it 'removes poll' do
@@ -438,7 +438,7 @@ RSpec.describe ActivityPub::ProcessStatusUpdateService, type: :service do
       end
 
       before do
-        subject.call(status, json)
+        subject.call(status, json, json)
       end
 
       it 'creates a poll' do
@@ -454,12 +454,12 @@ RSpec.describe ActivityPub::ProcessStatusUpdateService, type: :service do
     end
 
     it 'creates edit history' do
-      subject.call(status, json)
+      subject.call(status, json, json)
       expect(status.edits.reload.map(&:text)).to eq ['Hello world', 'Hello universe']
     end
 
     it 'sets edited timestamp' do
-      subject.call(status, json)
+      subject.call(status, json, json)
       expect(status.reload.edited_at.to_s).to eq '2021-09-08 22:39:25 UTC'
     end
   end


### PR DESCRIPTION
Fixes #26731

The decision whether to forward was based on the presence of a JSON-LD signature in the embedded object… but the signature is not on the embedded object but on the root activity.