### PR TITLE
Only enable resource owner password grant flow if LDAP or PAM is enabled

### DIFF
--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -164,7 +164,11 @@ Doorkeeper.configure do
   #   http://tools.ietf.org/html/rfc6819#section-4.4.3
   #
 
-  grant_flows %w(authorization_code password client_credentials)
+  if Devise.ldap_authentication || Devise.pam_authentication
+    grant_flows %w(authorization_code client_credentials password)
+  else
+    grant_flows %w(authorization_code client_credentials)
+  end
 
   # Under some circumstances you might want to have applications auto-approved,
   # so that the user skips the authorization step.


### PR DESCRIPTION
Resource Owner Password Grant flow is considered insecure and should not generally be used. It seems that both PAM and LDAP seem to require it, which is unfortunate, but this at least improves the security of servers that aren't using those.

I'm not sure if this works completely, as when testing locally I received a bunch of strange unrelated errors.