### PR TITLE
Fix `Setting.authorized_fetch` not being properly taken into consideration

### DIFF
--- a/app/helpers/authorized_fetch_helper.rb
+++ b/app/helpers/authorized_fetch_helper.rb
@@ -2,7 +2,7 @@
 
 module AuthorizedFetchHelper
   def authorized_fetch_mode?
-    ENV.fetch('AUTHORIZED_FETCH') { Setting.authorized_fetch } == 'true' || Rails.configuration.x.limited_federation_mode
+    ENV.fetch('AUTHORIZED_FETCH') { Setting.authorized_fetch && 'true' } == 'true' || Rails.configuration.x.limited_federation_mode
   end
 
   def authorized_fetch_overridden?


### PR DESCRIPTION
`Setting.authorized_fetch` is a boolean, so the comparison `== 'true'` was always false.