### PR TITLE
Keep version string displayed without breakpoints in UI

### DIFF
--- a/app/javascript/mastodon/features/ui/components/link_footer.jsx
+++ b/app/javascript/mastodon/features/ui/components/link_footer.jsx
@@ -98,7 +98,7 @@ class LinkFooter extends PureComponent {
           {DividingCircle}
           <Link to='/keyboard-shortcuts'><FormattedMessage id='footer.keyboard_shortcuts' defaultMessage='Keyboard shortcuts' /></Link>
           {DividingCircle}
-          <a href={source_url} rel='noopener noreferrer' target='_blank'><FormattedMessage id='footer.source_code' defaultMessage='View source code' /></a> v{version}
+          <a href={source_url} rel='noopener noreferrer' target='_blank'><FormattedMessage id='footer.source_code' defaultMessage='View source code' /></a> <span class="incline-block">v{version}</span>
         </p>
       </div>
     );

--- a/app/javascript/mastodon/features/ui/components/link_footer.jsx
+++ b/app/javascript/mastodon/features/ui/components/link_footer.jsx
@@ -98,9 +98,7 @@ class LinkFooter extends PureComponent {
           {DividingCircle}
           <Link to='/keyboard-shortcuts'><FormattedMessage id='footer.keyboard_shortcuts' defaultMessage='Keyboard shortcuts' /></Link>
           {DividingCircle}
-          <a href={source_url} rel='noopener noreferrer' target='_blank'><FormattedMessage id='footer.source_code' defaultMessage='View source code' /></a>
-          <br />
-          v{version}
+          <a href={source_url} rel='noopener noreferrer' target='_blank'><FormattedMessage id='footer.source_code' defaultMessage='View source code' /></a> v{version}
         </p>
       </div>
     );

--- a/app/javascript/mastodon/features/ui/components/link_footer.jsx
+++ b/app/javascript/mastodon/features/ui/components/link_footer.jsx
@@ -98,7 +98,9 @@ class LinkFooter extends PureComponent {
           {DividingCircle}
           <Link to='/keyboard-shortcuts'><FormattedMessage id='footer.keyboard_shortcuts' defaultMessage='Keyboard shortcuts' /></Link>
           {DividingCircle}
-          <a href={source_url} rel='noopener noreferrer' target='_blank'><FormattedMessage id='footer.source_code' defaultMessage='View source code' /></a> <span class="incline-block">v{version}</span>
+          <a href={source_url} rel='noopener noreferrer' target='_blank'><FormattedMessage id='footer.source_code' defaultMessage='View source code' /></a>
+          {DividingCircle}
+          <span class="inline-block">v{version}</span>
         </p>
       </div>
     );

--- a/app/javascript/mastodon/features/ui/components/link_footer.jsx
+++ b/app/javascript/mastodon/features/ui/components/link_footer.jsx
@@ -99,7 +99,7 @@ class LinkFooter extends PureComponent {
           <Link to='/keyboard-shortcuts'><FormattedMessage id='footer.keyboard_shortcuts' defaultMessage='Keyboard shortcuts' /></Link>
           {DividingCircle}
           <a href={source_url} rel='noopener noreferrer' target='_blank'><FormattedMessage id='footer.source_code' defaultMessage='View source code' /></a>
-          {DividingCircle}
+          <br />
           v{version}
         </p>
       </div>

--- a/app/javascript/mastodon/features/ui/components/link_footer.jsx
+++ b/app/javascript/mastodon/features/ui/components/link_footer.jsx
@@ -100,7 +100,7 @@ class LinkFooter extends PureComponent {
           {DividingCircle}
           <a href={source_url} rel='noopener noreferrer' target='_blank'><FormattedMessage id='footer.source_code' defaultMessage='View source code' /></a>
           {DividingCircle}
-          <span class="inline-block">v{version}</span>
+          <span class='inline-block'>v{version}</span>
         </p>
       </div>
     );

--- a/app/javascript/mastodon/features/ui/components/link_footer.jsx
+++ b/app/javascript/mastodon/features/ui/components/link_footer.jsx
@@ -100,7 +100,7 @@ class LinkFooter extends PureComponent {
           {DividingCircle}
           <a href={source_url} rel='noopener noreferrer' target='_blank'><FormattedMessage id='footer.source_code' defaultMessage='View source code' /></a>
           {DividingCircle}
-          <span class='inline-block'>v{version}</span>
+          <span class='version'>v{version}</span>
         </p>
       </div>
     );

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -9008,8 +9008,8 @@ noscript {
     color: $dark-text-color;
     margin-bottom: 20px;
 
-    .inline-block {
-      display: inline-block;
+    .version {
+      white-space: nowrap;
     }
 
     strong {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -9007,8 +9007,10 @@ noscript {
   p {
     color: $dark-text-color;
     margin-bottom: 20px;
-    white-space: normal;
-    overflow-wrap: normal;
+    
+    .inline-block {
+      display: inline-block;
+    }
 
     strong {
       font-weight: 500;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -9007,6 +9007,8 @@ noscript {
   p {
     color: $dark-text-color;
     margin-bottom: 20px;
+    white-space: normal;
+    overflow-wrap: normal;
 
     strong {
       font-weight: 500;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -9007,7 +9007,7 @@ noscript {
   p {
     color: $dark-text-color;
     margin-bottom: 20px;
-    
+
     .inline-block {
       display: inline-block;
     }


### PR DESCRIPTION
Currently the folks running tagged releases have version strings that appear tucked into a nice corner with the rest of the line. But with more and more sites running soft-forks, release candidates, and nightly releases this causes the version string text to break in odd places and look sloppy.

**Current:**
<img width="278" alt="CleanShot 2023-09-20 at 12 13 45@2x" src="https://github.com/mastodon/mastodon/assets/3002053/4ab85945-d277-4852-8854-c0f0cd66f477">

This adds an span to force the version string to adapt to ether complete the existing line or start a dedicated line in the bottom left corner, instead of running off the end of the current list.

**Small string:**
<img width="269" alt="CleanShot 2023-09-20 at 12 13 00@2x" src="https://github.com/mastodon/mastodon/assets/3002053/27fd6998-35be-4845-84bd-bb33d8e968ec">

**Larger string:**
<img width="272" alt="CleanShot 2023-09-20 at 12 13 14@2x" src="https://github.com/mastodon/mastodon/assets/3002053/1eb516f7-a556-40f4-874b-2b8ee319d745">

<img width="263" alt="CleanShot 2023-09-20 at 12 25 03@2x" src="https://github.com/mastodon/mastodon/assets/3002053/9e5208d8-34de-4287-b80d-0af252fb5f03">
