### PR TITLE
Change S3 checksum mode to be disabled by default

### DIFF
--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -91,28 +91,26 @@ if ENV['S3_ENABLED'] == 'true'
   # Some S3-compatible providers might not actually be compatible with some APIs
   # used by kt-paperclip, see https://github.com/mastodon/mastodon/issues/16822
   # and https://github.com/mastodon/mastodon/issues/26394
-  if ENV['S3_FORCE_SINGLE_REQUEST'] == 'true' || ENV['S3_DISABLE_CHECKSUM_MODE'] == 'true'
-    module Paperclip
-      module Storage
-        module S3Extensions
-          def copy_to_local_file(style, local_dest_path)
-            log("copying #{path(style)} to local file #{local_dest_path}")
+  module Paperclip
+    module Storage
+      module S3Extensions
+        def copy_to_local_file(style, local_dest_path)
+          log("copying #{path(style)} to local file #{local_dest_path}")
 
-            options = {}
-            options[:mode] = 'single_request' if ENV['S3_FORCE_SINGLE_REQUEST'] == 'true'
-            options[:checksum_mode] = 'DISABLED' if ENV['S3_DISABLE_CHECKSUM_MODE'] == 'true'
+          options = {}
+          options[:mode] = 'single_request' if ENV['S3_FORCE_SINGLE_REQUEST'] == 'true'
+          options[:checksum_mode] = 'DISABLED' unless ENV['S3_ENABLE_CHECKSUM_MODE'] == 'true'
 
-            s3_object(style).download_file(local_dest_path, options)
-          rescue Aws::Errors::ServiceError => e
-            warn("#{e} - cannot copy #{path(style)} to local file #{local_dest_path}")
-            false
-          end
+          s3_object(style).download_file(local_dest_path, options)
+        rescue Aws::Errors::ServiceError => e
+          warn("#{e} - cannot copy #{path(style)} to local file #{local_dest_path}")
+          false
         end
       end
     end
-
-    Paperclip::Storage::S3.prepend(Paperclip::Storage::S3Extensions)
   end
+
+  Paperclip::Storage::S3.prepend(Paperclip::Storage::S3Extensions)
 elsif ENV['SWIFT_ENABLED'] == 'true'
   require 'fog/openstack'
 


### PR DESCRIPTION
This removes the `S3_DISABLE_CHECKSUM_MODE` env variable and introduces the `S3_ENABLE_CHECKSUM_MODE` env variable instead.

The reason is that it seems that more people use S3-compatible providers which do not implement this feature (and thus error out if enabled) than S3-compatible providers which do implement it (which might be AWS S3 only).