### PR TITLE
Add search configuration to instance api

### DIFF
--- a/app/lib/search_query_transformer.rb
+++ b/app/lib/search_query_transformer.rb
@@ -12,6 +12,23 @@ class SearchQueryTransformer < Parslet::Transform
     in
   ).freeze
 
+  SUPPORTED_OPERATOR = %w(
+    +
+    -
+  ).freeze
+
+  SUPPORTED_PROPERTIES = %w(
+    image
+    video
+    audio
+    media
+    poll
+    link
+    embed
+    sensitive
+    reply
+  ).freeze
+
   class Query
     def initialize(clauses, options = {})
       raise ArgumentError if options[:current_account].nil?
@@ -152,6 +169,8 @@ class SearchQueryTransformer < Parslet::Transform
 
       case prefix
       when 'has', 'is'
+        raise "Unknown properties: #{term}" unless SUPPORTED_PROPERTIES.include?(term)
+
         @filter = :properties
         @type = :term
         @term = term

--- a/app/serializers/rest/instance_serializer.rb
+++ b/app/serializers/rest/instance_serializer.rb
@@ -77,6 +77,13 @@ class REST::InstanceSerializer < ActiveModel::Serializer
       translation: {
         enabled: TranslationService.configured?,
       },
+
+      search: {
+        enabled: Chewy.enabled?,
+        supported_prefix: SearchQueryTransformer::SUPPORTED_PREFIXES,
+        supported_properties: SearchQueryTransformer::SUPPORTED_PROPERTIES,
+        supported_operator: SearchQueryTransformer::SUPPORTED_OPERATOR,
+      },
     }
   end
 


### PR DESCRIPTION
Until now, it was not possible to determine whether full-text search was supported via the API.

Now that the search functionality has been expanded, we should take advantage of this opportunity to start publishing our support status.

```
configuration: {
  search: {
    enabled: false,
    supported_prefix: [
      "has",
      "is",
      "language",
      "from",
      "before",
      "after",
      "during",
      "in"
    ],
    supported_properties: [
      "image",
      "video",
      "audio",
      "media",
      "poll",
      "link",
      "embed",
      "sensitive",
      "reply"
    ],
    supported_operator: [
      "+",
      "-"
    ]
  }
},
```