### PR TITLE
Ignore CVE-2023-26141 (Sidekiq) from bundler audit

### DIFF
--- a/.bundler-audit.yml
+++ b/.bundler-audit.yml
@@ -1,0 +1,4 @@
+---
+ignore:
+  # Sidekiq security issue, fixes in the latest Sidekiq 7 but we can not upgrade. Will be fixed in Sidekiq 6.5.10
+  - CVE-2023-26141


### PR DESCRIPTION
The fix is in Sidekiq 7, which we can not easily upgrade to at the moment.

Sidekiq 6.5.10 should be released at some point with the fix, but until then let's ignore it so every PR does not fail checks.