### PR TITLE
Let use http_hidden_proxy on docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,7 +111,7 @@ services:
       test: ['CMD-SHELL', "ps aux | grep '[s]idekiq\ 6' || false"]
 
   ## Uncomment to enable federation with tor instances along with adding the following ENV variables
-  ## http_proxy=http://privoxy:8118
+  ## http_hidden_proxy=http://privoxy:8118
   ## ALLOW_ACCESS_TO_HIDDEN_SERVICE=true
   # tor:
   #   image: sirboops/tor


### PR DESCRIPTION
`http_hidden_proxy` is more priopriate env var when enabling federation with onion addresses

#18427