### PR TITLE
Improve alt text form accessibility with long texts

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -5979,7 +5979,7 @@ a.status-card {
     max-height: 50vh;
     border: 0;
 
-    @media screen and (max-height: 600px) {
+    @media screen and (height <= 600px) {
       max-height: 20vh;
     }
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -5909,6 +5909,7 @@ a.status-card {
 .report-modal__comment {
   box-sizing: border-box;
   width: 50%;
+  min-width: 50%;
 
   @media screen and (width <= 480px) {
     width: 100%;
@@ -5977,6 +5978,14 @@ a.status-card {
     min-height: 100px;
     max-height: 50vh;
     border: 0;
+
+    @media screen and (max-height: 600px) {
+      max-height: 20vh;
+    }
+
+    @media screen and (max-width: $no-columns-breakpoint) {
+      max-height: 20vh;
+    }
   }
 
   .setting-toggle {


### PR DESCRIPTION
With long texts the Apply button goes out of view.

## Before this change:

![mementomori test_home](https://github.com/mastodon/mastodon/assets/1534150/43590ce5-171e-448e-a89a-cca4ec0ab4c4)

![mementomori test_home (2)](https://github.com/mastodon/mastodon/assets/1534150/9e126fbd-d330-4190-a188-a633a6ea4909)

![mementomori test_home (5)](https://github.com/mastodon/mastodon/assets/1534150/bb4c60e6-cab9-4bbc-aa1d-6a8e440a2eaf)

## After:

![mementomori test_home (1)](https://github.com/mastodon/mastodon/assets/1534150/53c34995-e6dd-4fa7-8b11-782a7c974588)

![mementomori test_home (3)](https://github.com/mastodon/mastodon/assets/1534150/66d221eb-0fc4-4970-b4f2-d8752a96d30c)

![mementomori test_home (4)](https://github.com/mastodon/mastodon/assets/1534150/161e8de7-a058-4a24-b2d9-cce44257814c)
