### PR TITLE
Fix line wrapping of language selection button with long locale codes

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -284,6 +284,7 @@
   font-size: 11px;
   padding: 0 3px;
   line-height: 27px;
+  white-space: nowrap;
 
   &:hover,
   &:active,


### PR DESCRIPTION
Fixes https://github.com/mastodon/mastodon/issues/26967 and https://github.com/mastodon/mastodon/issues/19302