### PR TITLE
Fix string truncations in settings menu

### DIFF
--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -1,7 +1,7 @@
 @use 'sass:math';
 
 $no-columns-breakpoint: 600px;
-$sidebar-width: 240px;
+$sidebar-width: 270px;
 $content-width: 840px;
 
 .admin-wrapper {


### PR DESCRIPTION
I am getting a number of string truncations for the gd locale in the settings menu

![truncations](https://github.com/mastodon/mastodon/assets/4095570/4bd4650b-8efc-49d4-8140-0b21af6cb7d6)

I can't shorten the translations any further, so I have made the menu 30 pixels wider.