### PR TITLE
Fix inefficient queries in “Follows and followers” as well as several admin pages

### DIFF
--- a/app/models/relationship_filter.rb
+++ b/app/models/relationship_filter.rb
@@ -62,13 +62,13 @@ class RelationshipFilter
   def relationship_scope(value)
     case value
     when 'following'
-      account.following.eager_load(:account_stat).reorder(nil)
+      account.following.includes(:account_stat).reorder(nil)
     when 'followed_by'
-      account.followers.eager_load(:account_stat).reorder(nil)
+      account.followers.includes(:account_stat).reorder(nil)
     when 'mutual'
-      account.followers.eager_load(:account_stat).reorder(nil).merge(Account.where(id: account.following))
+      account.followers.includes(:account_stat).reorder(nil).merge(Account.where(id: account.following))
     when 'invited'
-      Account.joins(user: :invite).merge(Invite.where(user: account.user)).eager_load(:account_stat).reorder(nil)
+      Account.joins(user: :invite).merge(Invite.where(user: account.user)).includes(:account_stat).reorder(nil)
     else
       raise Mastodon::InvalidParameterError, "Unknown relationship: #{value}"
     end


### PR DESCRIPTION
`eager_load` was used to avoid doing a separate query for `account_stats`, but actually caused Rails to try to load every `includes` in the same query, which resulted in two overly-complex queries.

Getting rid of `eager_load` and replacing it with `includes` means more queries will be issued (one for loading `Account`s, one for loading `AccountStat`s, one for `User`s, one for `UserIp`s, and one for `UserInviteRequest`s; instead of the two queries that were previously performed), but each of those queries will be simpler.