### PR TITLE
Rename Panjabi to Punjabi

### DIFF
--- a/app/helpers/languages_helper.rb
+++ b/app/helpers/languages_helper.rb
@@ -127,7 +127,7 @@ module LanguagesHelper
     om: ['Oromo', 'Afaan Oromoo'].freeze,
     or: ['Oriya', 'ଓଡ଼ିଆ'].freeze,
     os: ['Ossetian', 'ирон æвзаг'].freeze,
-    pa: ['Panjabi', 'ਪੰਜਾਬੀ'].freeze,
+    pa: ['Punjabi', 'ਪੰਜਾਬੀ'].freeze,
     pi: ['Pāli', 'पाऴि'].freeze,
     pl: ['Polish', 'Polski'].freeze,
     ps: ['Pashto', 'پښتو'].freeze,


### PR DESCRIPTION
Closes https://github.com/mastodon/mastodon/issues/25296

I think it makes sense to use this spelling variant, because people can now find the language by typing either "pa" or "pu", so discoverability is better. It also aligns with the CLDR.