### PR TITLE
Fix width of large text icon buttons

### DIFF
--- a/app/javascript/mastodon/features/compose/components/text_icon_button.jsx
+++ b/app/javascript/mastodon/features/compose/components/text_icon_button.jsx
@@ -4,7 +4,7 @@ import { PureComponent } from 'react';
 const iconStyle = {
   height: null,
   lineHeight: '27px',
-  width: `${18 * 1.28571429}px`,
+  minWidth: `${18 * 1.28571429}px`,
 };
 
 export default class TextIconButton extends PureComponent {


### PR DESCRIPTION
Follow-up to #27100

cc @gunchleoc

## Before

![image](https://github.com/mastodon/mastodon/assets/384364/6633dc4e-15e5-4d3b-9275-7b26bbde2cb8)

## After

![image](https://github.com/mastodon/mastodon/assets/384364/f48434e2-3b11-4102-9b00-85fe5e027055)