### PR TITLE
Fix "Too many open files" errors when using ElasticSearch

### DIFF
--- a/config/initializers/chewy.rb
+++ b/config/initializers/chewy.rb
@@ -22,6 +22,7 @@ Chewy.settings = {
     number_of_replicas: ['single_node_cluster', nil].include?(ENV['ES_PRESET'].presence) ? 0 : 1,
   },
   transport_options: transport_options,
+  adapter: :net_http,
 }
 
 # We use our own async strategy even outside the request-response


### PR DESCRIPTION
This change sets the Faraday adapter used for ElasticSearch to `:net_http`.

The `elasticsearch-transport` gem tries to auto detect a suitable Faraday adapter.  Mastodon uses the Faraday default adapter of `:net_http`, but since `elasticsearch-transport` sees that the `httpclient` gem is available it lets Faraday use that one.  Unfortunately `httpclient` does not properly clean up its connections, leading to a lot of established connections to ElasticSearch over time.

See also: https://github.com/elastic/elastic-transport-ruby/blob/e074fcff9b23f9697f6c8da843437e410f998073/lib/elastic/transport/client.rb#L291-L304

Resolves #18063