### PR TITLE
Fix unsafe URLs in audit log resulting from domain blocks

### DIFF
--- a/app/helpers/admin/action_logs_helper.rb
+++ b/app/helpers/admin/action_logs_helper.rb
@@ -16,7 +16,7 @@ module Admin::ActionLogsHelper
     when 'Report'
       link_to "##{log.human_identifier.presence || log.target_id}", admin_report_path(log.target_id)
     when 'Instance', 'DomainBlock', 'DomainAllow', 'UnavailableDomain'
-      link_to log.human_identifier, admin_instance_path(log.human_identifier)
+      log.human_identifier.present? ? link_to(log.human_identifier, admin_instance_path(log.human_identifier)) : I18n.t('admin.action_logs.unavailable_instance')
     when 'Status'
       link_to log.human_identifier, log.permalink
     when 'AccountWarning'

--- a/app/helpers/admin/action_logs_helper.rb
+++ b/app/helpers/admin/action_logs_helper.rb
@@ -15,8 +15,10 @@ module Admin::ActionLogsHelper
       link_to log.human_identifier, admin_roles_path(log.target_id)
     when 'Report'
       link_to "##{log.human_identifier.presence || log.target_id}", admin_report_path(log.target_id)
-    when 'DomainBlock', 'DomainAllow', 'EmailDomainBlock', 'UnavailableDomain'
-      link_to log.human_identifier, "https://#{log.human_identifier.presence}"
+    when 'DomainBlock', 'DomainAllow', 'UnavailableDomain'
+      link_to log.human_identifier, admin_instance_path(log.target.domain)
+    when 'EmailDomainBlock'
+      link_to log.human_identifier, admin_email_domain_blocks_path
     when 'Status'
       link_to log.human_identifier, log.permalink
     when 'AccountWarning'

--- a/app/helpers/admin/action_logs_helper.rb
+++ b/app/helpers/admin/action_logs_helper.rb
@@ -15,17 +15,15 @@ module Admin::ActionLogsHelper
       link_to log.human_identifier, admin_roles_path(log.target_id)
     when 'Report'
       link_to "##{log.human_identifier.presence || log.target_id}", admin_report_path(log.target_id)
-    when 'DomainBlock', 'DomainAllow', 'UnavailableDomain'
-      link_to log.human_identifier, admin_instance_path(log.target.domain)
-    when 'EmailDomainBlock'
-      link_to log.human_identifier, admin_email_domain_blocks_path
+    when 'Instance', 'DomainBlock', 'DomainAllow', 'UnavailableDomain'
+      link_to log.human_identifier, admin_instance_path(log.human_identifier)
     when 'Status'
       link_to log.human_identifier, log.permalink
     when 'AccountWarning'
       link_to log.human_identifier, disputes_strike_path(log.target_id)
     when 'Announcement'
       link_to truncate(log.human_identifier), edit_admin_announcement_path(log.target_id)
-    when 'IpBlock', 'Instance', 'CustomEmoji'
+    when 'IpBlock', 'EmailDomainBlock', 'CustomEmoji'
       log.human_identifier
     when 'CanonicalEmailBlock'
       content_tag(:samp, (log.human_identifier.presence || '')[0...7], title: log.human_identifier)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -293,6 +293,7 @@ en:
       filter_by_action: Filter by action
       filter_by_user: Filter by user
       title: Audit log
+      unavailable_instance: "(domain name unavailable)"
     announcements:
       destroyed_msg: Announcement successfully deleted!
       edit:


### PR DESCRIPTION
Fixes #25842

We don't currently have a "show" page for email domain blocks, so I can only link to the index page, and the rows don't contain any identifiers so I can't even do a relative link within the page, so just linking to the index page will have to do.

I noticed this after testing some stuff in the audit log for domain blocks and accidentally opening a horrific domain.