### PR TITLE
Feature: Allow oauth application introspection without read scope

### DIFF
--- a/app/controllers/api/v1/apps/credentials_controller.rb
+++ b/app/controllers/api/v1/apps/credentials_controller.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 class Api::V1::Apps::CredentialsController < Api::BaseController
-  before_action -> { doorkeeper_authorize! :read }
-
   def show
-    render json: doorkeeper_token.application, serializer: REST::ApplicationSerializer, fields: %i(name website vapid_key)
+    return doorkeeper_render_error unless valid_doorkeeper_token?
+
+    render json: doorkeeper_token.application, serializer: REST::ApplicationSerializer, fields: %i(name website vapid_key client_id scopes)
   end
 end

--- a/app/serializers/rest/application_serializer.rb
+++ b/app/serializers/rest/application_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class REST::ApplicationSerializer < ActiveModel::Serializer
-  attributes :id, :name, :website, :redirect_uri,
+  attributes :id, :name, :website, :scopes, :redirect_uri,
              :client_id, :client_secret, :vapid_key
 
   def id


### PR DESCRIPTION
This also allows the API Client to retrieve it's registered client_id from just knowing the access_token, and to see which scopes the application has access to.

This is a little weird because it's the scopes of the application, not the scopes of the token, which may be different. However, the current behavior of this endpoint is to return information about the application, not about the token.

This will enable applications to verify credentials whilst using very restricted scopes (e.g., I only need access to `admin:read:domain_blocks` and I don't need any other access, but i still want to be able to verify that my credentials are valid)

We may in the future wish to look into supporting full token introspection, however, a [bug in Doorkeeper](https://github.com/doorkeeper-gem/doorkeeper/pull/1501) means that we can't actually use Doorkeeper's token introspection endpoint (which is an OAuth 2.0 standard). This PR came up after discussions with Oliphant regarding trying to figure out what scopes the application previously had been granted (allowing for upgrading to additional scopes in the future)