### PR TITLE
Add confirmation dialog when clicking remote URLs in moderation action log

### DIFF
--- a/app/helpers/admin/action_logs_helper.rb
+++ b/app/helpers/admin/action_logs_helper.rb
@@ -16,9 +16,13 @@ module Admin::ActionLogsHelper
     when 'Report'
       link_to "##{log.human_identifier.presence || log.target_id}", admin_report_path(log.target_id)
     when 'DomainBlock', 'DomainAllow', 'EmailDomainBlock', 'UnavailableDomain'
-      link_to log.human_identifier, "https://#{log.human_identifier.presence}"
+      link_to log.human_identifier, "https://#{log.human_identifier.presence}", data: { confirm: t('admin.action_logs.external_link', url: "https//#{log.human_identifier.presence}") }
     when 'Status'
-      link_to log.human_identifier, log.permalink
+      if log.permalink.blank? || TagManager.instance.local_url?(log.permalink)
+        link_to log.human_identifier, log.permalink
+      else
+        link_to log.human_identifier, log.permalink, data: { confirm: t('admin.action_logs.external_link', url: log.permalink) }
+      end
     when 'AccountWarning'
       link_to log.human_identifier, disputes_strike_path(log.target_id)
     when 'Announcement'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -289,6 +289,7 @@ en:
         update_user_role_html: "%{name} changed %{target} role"
       deleted_account: deleted account
       empty: No logs found.
+      external_link: You are going to visit the external link %{url}. Proceed?
       filter_by_action: Filter by action
       filter_by_user: Filter by user
       title: Audit log


### PR DESCRIPTION
![image](https://github.com/mastodon/mastodon/assets/384364/73167eac-0a56-4df5-8c7a-bc3f62301d30)

Alternate take to #27139