### PR TITLE
Add support for displaying unknown servers on /admin/instances/:domain

### DIFF
--- a/app/controllers/admin/instances_controller.rb
+++ b/app/controllers/admin/instances_controller.rb
@@ -49,7 +49,7 @@ module Admin
     private
 
     def set_instance
-      @instance = Instance.find(TagManager.instance.normalize_domain(params[:id]&.strip))
+      @instance = Instance.find_or_initialize_by(domain: TagManager.instance.normalize_domain(params[:id]&.strip))
     end
 
     def set_instances

--- a/app/views/admin/instances/show.html.haml
+++ b/app/views/admin/instances/show.html.haml
@@ -7,27 +7,31 @@
     = ' - '
     = l(@time_period.last)
 
-  %p
-    = fa_icon 'info fw'
-    = t('admin.instances.totals_time_period_hint_html')
+  - if @instance.persisted?
+    %p
+      = fa_icon 'info fw'
+      = t('admin.instances.totals_time_period_hint_html')
 
-  .dashboard
-    .dashboard__item
-      = react_admin_component :counter, measure: 'instance_accounts', start_at: @time_period.first, end_at: @time_period.last, params: { domain: @instance.domain }, label: t('admin.instances.dashboard.instance_accounts_measure'), href: admin_accounts_path(origin: 'remote', by_domain: @instance.domain)
-    .dashboard__item
-      = react_admin_component :counter, measure: 'instance_statuses', start_at: @time_period.first, end_at: @time_period.last, params: { domain: @instance.domain }, label: t('admin.instances.dashboard.instance_statuses_measure')
-    .dashboard__item
-      = react_admin_component :counter, measure: 'instance_media_attachments', start_at: @time_period.first, end_at: @time_period.last, params: { domain: @instance.domain }, label: t('admin.instances.dashboard.instance_media_attachments_measure')
-    .dashboard__item
-      = react_admin_component :counter, measure: 'instance_follows', start_at: @time_period.first, end_at: @time_period.last, params: { domain: @instance.domain }, label: t('admin.instances.dashboard.instance_follows_measure')
-    .dashboard__item
-      = react_admin_component :counter, measure: 'instance_followers', start_at: @time_period.first, end_at: @time_period.last, params: { domain: @instance.domain }, label: t('admin.instances.dashboard.instance_followers_measure')
-    .dashboard__item
-      = react_admin_component :counter, measure: 'instance_reports', start_at: @time_period.first, end_at: @time_period.last, params: { domain: @instance.domain }, label: t('admin.instances.dashboard.instance_reports_measure'), href: admin_reports_path(by_target_domain: @instance.domain)
-    .dashboard__item
-      = react_admin_component :dimension, dimension: 'instance_accounts', start_at: @time_period.first, end_at: @time_period.last, params: { domain: @instance.domain }, limit: 8, label: t('admin.instances.dashboard.instance_accounts_dimension')
-    .dashboard__item
-      = react_admin_component :dimension, dimension: 'instance_languages', start_at: @time_period.first, end_at: @time_period.last, params: { domain: @instance.domain }, limit: 8, label: t('admin.instances.dashboard.instance_languages_dimension')
+    .dashboard
+      .dashboard__item
+        = react_admin_component :counter, measure: 'instance_accounts', start_at: @time_period.first, end_at: @time_period.last, params: { domain: @instance.domain }, label: t('admin.instances.dashboard.instance_accounts_measure'), href: admin_accounts_path(origin: 'remote', by_domain: @instance.domain)
+      .dashboard__item
+        = react_admin_component :counter, measure: 'instance_statuses', start_at: @time_period.first, end_at: @time_period.last, params: { domain: @instance.domain }, label: t('admin.instances.dashboard.instance_statuses_measure')
+      .dashboard__item
+        = react_admin_component :counter, measure: 'instance_media_attachments', start_at: @time_period.first, end_at: @time_period.last, params: { domain: @instance.domain }, label: t('admin.instances.dashboard.instance_media_attachments_measure')
+      .dashboard__item
+        = react_admin_component :counter, measure: 'instance_follows', start_at: @time_period.first, end_at: @time_period.last, params: { domain: @instance.domain }, label: t('admin.instances.dashboard.instance_follows_measure')
+      .dashboard__item
+        = react_admin_component :counter, measure: 'instance_followers', start_at: @time_period.first, end_at: @time_period.last, params: { domain: @instance.domain }, label: t('admin.instances.dashboard.instance_followers_measure')
+      .dashboard__item
+        = react_admin_component :counter, measure: 'instance_reports', start_at: @time_period.first, end_at: @time_period.last, params: { domain: @instance.domain }, label: t('admin.instances.dashboard.instance_reports_measure'), href: admin_reports_path(by_target_domain: @instance.domain)
+      .dashboard__item
+        = react_admin_component :dimension, dimension: 'instance_accounts', start_at: @time_period.first, end_at: @time_period.last, params: { domain: @instance.domain }, limit: 8, label: t('admin.instances.dashboard.instance_accounts_dimension')
+      .dashboard__item
+        = react_admin_component :dimension, dimension: 'instance_languages', start_at: @time_period.first, end_at: @time_period.last, params: { domain: @instance.domain }, limit: 8, label: t('admin.instances.dashboard.instance_languages_dimension')
+  - else
+    %p
+      = t('admin.instances.unknown_instance')
 
 %hr.spacer/
 
@@ -62,33 +66,34 @@
   - else
     = link_to t('admin.domain_blocks.add_new'), new_admin_domain_block_path(_domain: @instance.domain), class: 'button'
 
-%hr.spacer/
+- if @instance.persisted?
+  %hr.spacer/
 
-%h3= t('admin.instances.availability.title')
+  %h3= t('admin.instances.availability.title')
 
-%p
-  = t('admin.instances.availability.description_html', count: DeliveryFailureTracker::FAILURE_DAYS_THRESHOLD)
+  %p
+    = t('admin.instances.availability.description_html', count: DeliveryFailureTracker::FAILURE_DAYS_THRESHOLD)
 
-.availability-indicator
-  %ul.availability-indicator__graphic
-    - @instance.availability_over_days(14).each do |(date, failing)|
-      %li.availability-indicator__graphic__item{ class: failing ? 'negative' : 'neutral', title: l(date) }
-  .availability-indicator__hint
-    - if @instance.unavailable?
-      %span.negative-hint
-        = t('admin.instances.availability.failure_threshold_reached', date: l(@instance.unavailable_domain.created_at.to_date))
-        = link_to t('admin.instances.delivery.restart'), restart_delivery_admin_instance_path(@instance), data: { confirm: t('admin.accounts.are_you_sure'), method: :post }
-    - elsif @instance.exhausted_deliveries_days.empty?
-      %span.positive-hint
-        = t('admin.instances.availability.no_failures_recorded')
-        = link_to t('admin.instances.delivery.stop'), stop_delivery_admin_instance_path(@instance), data: { confirm: t('admin.accounts.are_you_sure'), method: :post }
-    - else
-      %span.negative-hint
-        = t('admin.instances.availability.failures_recorded', count: @instance.delivery_failure_tracker.days)
-        %span= link_to t('admin.instances.delivery.clear'), clear_delivery_errors_admin_instance_path(@instance), data: { confirm: t('admin.accounts.are_you_sure'), method: :post } unless @instance.exhausted_deliveries_days.empty?
-        %span= link_to t('admin.instances.delivery.stop'), stop_delivery_admin_instance_path(@instance), data: { confirm: t('admin.accounts.are_you_sure'), method: :post }
+  .availability-indicator
+    %ul.availability-indicator__graphic
+      - @instance.availability_over_days(14).each do |(date, failing)|
+        %li.availability-indicator__graphic__item{ class: failing ? 'negative' : 'neutral', title: l(date) }
+    .availability-indicator__hint
+      - if @instance.unavailable?
+        %span.negative-hint
+          = t('admin.instances.availability.failure_threshold_reached', date: l(@instance.unavailable_domain.created_at.to_date))
+          = link_to t('admin.instances.delivery.restart'), restart_delivery_admin_instance_path(@instance), data: { confirm: t('admin.accounts.are_you_sure'), method: :post }
+      - elsif @instance.exhausted_deliveries_days.empty?
+        %span.positive-hint
+          = t('admin.instances.availability.no_failures_recorded')
+          = link_to t('admin.instances.delivery.stop'), stop_delivery_admin_instance_path(@instance), data: { confirm: t('admin.accounts.are_you_sure'), method: :post }
+      - else
+        %span.negative-hint
+          = t('admin.instances.availability.failures_recorded', count: @instance.delivery_failure_tracker.days)
+          %span= link_to t('admin.instances.delivery.clear'), clear_delivery_errors_admin_instance_path(@instance), data: { confirm: t('admin.accounts.are_you_sure'), method: :post } unless @instance.exhausted_deliveries_days.empty?
+          %span= link_to t('admin.instances.delivery.stop'), stop_delivery_admin_instance_path(@instance), data: { confirm: t('admin.accounts.are_you_sure'), method: :post }
 
-- if @instance.purgeable?
-  %p= t('admin.instances.purge_description_html')
+  - if @instance.purgeable?
+    %p= t('admin.instances.purge_description_html')
 
-  = link_to t('admin.instances.purge'), admin_instance_path(@instance), data: { confirm: t('admin.instances.confirm_purge'), method: :delete }, class: 'button button--destructive'
+    = link_to t('admin.instances.purge'), admin_instance_path(@instance), data: { confirm: t('admin.instances.confirm_purge'), method: :delete }, class: 'button button--destructive'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -534,6 +534,7 @@ en:
       total_reported: Reports about them
       total_storage: Media attachments
       totals_time_period_hint_html: The totals displayed below include data for all time.
+      unknown_instance: There is currently no record of this domain on this server.
     invites:
       deactivate_all: Deactivate all
       filter:


### PR DESCRIPTION
Return a blank page offering moderation actions instead of a 404 when visiting the moderation interface for an unknown domain:
![image](https://github.com/mastodon/mastodon/assets/384364/974561f5-15a7-454c-9ea9-6d6bb05ef8f6)

This is in order for one of the changes proposed by #27139 to not be jarring and confusing (see https://github.com/mastodon/mastodon/pull/27139#issuecomment-1735048137).