### PR TITLE
Fix language sorting in settings

### DIFF
--- a/app/helpers/languages_helper.rb
+++ b/app/helpers/languages_helper.rb
@@ -205,6 +205,21 @@ module LanguagesHelper
     zgh: ['Standard Moroccan Tamazight', 'ⵜⴰⵎⴰⵣⵉⵖⵜ'].freeze,
   }.freeze
 
+  TEST_ARRAY = {
+    ckb: [english: 'Sorani (Kurdish)', native: 'سۆرانی'].freeze,
+    cnr: [english: 'Montenegrin', native: 'crnogorski'].freeze,
+    zgh: [english: 'Standard Moroccan Tamazight', native: 'ⵜⴰⵎⴰⵣⵉⵖⵜ'].freeze,
+  }.freeze
+
+  # TEST_ARRAY..sort_by!(&:last[0]).freeze
+
+  TEST_ARRAY2 = {
+    bar: ['foo'],
+    foo: ['bar'],
+  }.freeze
+
+  TEST_ARRAY2 = TEST_ARRAY2.sort_by { |_, value| value[0] }
+
   # e.g. For Chinese, which is not a language,
   # but a language family in spite of sharing the main locale code
   # We need to be able to filter these
@@ -215,6 +230,8 @@ module LanguagesHelper
     'zh-YUE': ['Cantonese', '廣東話'].freeze,
   }.freeze
 
+  # .sort_by!(&:last[0])
+  # .sort_by{|_, value| value[0]}
   SUPPORTED_LOCALES = {}.merge(ISO_639_1).merge(ISO_639_1_REGIONAL).merge(ISO_639_3).freeze
 
   # For ISO-639-1 and ISO-639-3 language codes, we have their official

--- a/app/helpers/languages_helper.rb
+++ b/app/helpers/languages_helper.rb
@@ -235,19 +235,9 @@ module LanguagesHelper
     if locale.blank? || locale == 'und'
       '000'
     elsif (supported_locale = SUPPORTED_LOCALES[locale.to_sym])
-      if /.*[a-zA-Z].*/.match?(supported_locale[1])
-        # Strip accents from Latin characters so e.g. Íslenska won't be bumped to the bottom.
-        # We have to exclude non-Latin languages from the transliterator, because results are dire.
-        ActiveSupport::Inflector.transliterate(supported_locale[1]).downcase
-      else
-        supported_locale[1].downcase
-      end
+      ASCIIFolding.new.fold(supported_locale[1]).downcase
     elsif (regional_locale = REGIONAL_LOCALE_NAMES[locale.to_sym])
-      if /.*[a-zA-Z].*/.match?(regional_locale)
-        ActiveSupport::Inflector.transliterate(regional_locale).downcase
-      else
-        regional_locale.downcase
-      end
+      ASCIIFolding.new.fold(regional_locale).downcase
     else
       locale
     end

--- a/app/helpers/languages_helper.rb
+++ b/app/helpers/languages_helper.rb
@@ -259,6 +259,22 @@ module LanguagesHelper
     end
   end
 
+  def self.native_locale_name2(locale)
+    if locale.blank? || locale == 'und'
+      I18n.t('generic.none')
+    elsif (supported_locale = SUPPORTED_LOCALES[locale.to_sym])
+      supported_locale[1]
+    elsif (regional_locale = REGIONAL_LOCALE_NAMES[locale.to_sym])
+      regional_locale
+    else
+      locale
+    end
+  end
+
+  def self.sorted_locale_keys(locales)
+    locales.sort_by { |key, _| native_locale_name2(key) }
+  end
+
   def standard_locale_name(locale)
     if locale.blank?
       I18n.t('generic.none')

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -2,7 +2,7 @@
 
 module SettingsHelper
   def filterable_languages
-    LanguagesHelper::SUPPORTED_LOCALES.keys
+    LanguagesHelper.sorted_locale_keys(LanguagesHelper::SUPPORTED_LOCALES.keys)
   end
 
   def session_device_icon(session)

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -5,6 +5,10 @@ module SettingsHelper
     LanguagesHelper.sorted_locale_keys(LanguagesHelper::SUPPORTED_LOCALES.keys)
   end
 
+  def ui_languages
+    LanguagesHelper.sorted_locale_keys(I18n.available_locales)
+  end
+
   def session_device_icon(session)
     device = session.detection.device
 

--- a/app/views/settings/preferences/appearance/show.html.haml
+++ b/app/views/settings/preferences/appearance/show.html.haml
@@ -7,7 +7,7 @@
 = simple_form_for current_user, url: settings_preferences_appearance_path, html: { method: :put, id: 'edit_user' } do |f|
   .fields-row
     .fields-group.fields-row__column.fields-row__column-6
-      = f.input :locale, collection: I18n.available_locales, wrapper: :with_label, include_blank: false, label_method: ->(locale) { native_locale_name(locale) }, selected: I18n.locale, hint: false
+      = f.input :locale, collection: ui_languages, wrapper: :with_label, include_blank: false, label_method: ->(locale) { native_locale_name(locale) }, selected: I18n.locale, hint: false
     .fields-group.fields-row__column.fields-row__column-6
       = f.input :time_zone, wrapper: :with_label, collection: ActiveSupport::TimeZone.all.map { |tz| ["(GMT#{tz.formatted_offset}) #{tz.name}", tz.tzinfo.name] }, hint: false
 

--- a/spec/helpers/languages_helper_spec.rb
+++ b/spec/helpers/languages_helper_spec.rb
@@ -64,25 +64,25 @@ describe LanguagesHelper do
   describe 'sorted_locales' do
     context 'when sorting with native name' do
       it 'returns Suomi after Gàidhlig' do
-        expect(helper.sorted_locale_keys(%w(fi gd))).to eq(%w(gd fi))
+        expect(described_class.sorted_locale_keys(%w(fi gd))).to eq(%w(gd fi))
       end
     end
 
     context 'when sorting with diacritics' do
       it 'returns Íslensk before Suomi' do
-        expect(helper.sorted_locale_keys(%w(fi is))).to eq(%w(is fi))
+        expect(described_class.sorted_locale_keys(%w(fi is))).to eq(%w(is fi))
       end
     end
 
     context 'when sorting with non-Latin' do
       it 'returns Suomi before Amharic' do
-        expect(helper.sorted_locale_keys(%w(am fi))).to eq(%w(fi am))
+        expect(described_class.sorted_locale_keys(%w(am fi))).to eq(%w(fi am))
       end
     end
 
     context 'when sorting with local variants' do
       it 'returns variant in-line' do
-        expect(helper.sorted_locale_keys(%w(en eo en-GB))).to eq(%w(en en-GB eo))
+        expect(described_class.sorted_locale_keys(%w(en eo en-GB))).to eq(%w(en en-GB eo))
       end
     end
   end

--- a/spec/helpers/languages_helper_spec.rb
+++ b/spec/helpers/languages_helper_spec.rb
@@ -60,4 +60,30 @@ describe LanguagesHelper do
       end
     end
   end
+
+  describe 'sorted_locales' do
+    context 'when sorting with native name' do
+      it 'returns Suomi after Gàidhlig' do
+        expect(helper.sorted_locale_keys(%w(fi gd))).to eq(%w(gd fi))
+      end
+    end
+
+    context 'when sorting with diacritics' do
+      it 'returns Íslensk before Suomi' do
+        expect(helper.sorted_locale_keys(%w(fi is))).to eq(%w(is fi))
+      end
+    end
+
+    context 'when sorting with non-Latin' do
+      it 'returns Suomi before Amharic' do
+        expect(helper.sorted_locale_keys(%w(am fi))).to eq(%w(fi am))
+      end
+    end
+
+    context 'when sorting with local variants' do
+      it 'returns variant in-line' do
+        expect(helper.sorted_locale_keys(%w(en eo en-GB))).to eq(%w(en en-GB eo))
+      end
+    end
+  end
 end


### PR DESCRIPTION
Re. https://github.com/mastodon/mastodon/issues/17999

This fixes the problem for the UI language, posting language and filtered language settings.

Things that still need fixing and that aren't covered by this PR:

- Trends moderation as mentioned in the issue - I didn't check those yet as it's hell to generate any trends. Is there an easy way to generate trending posts or links?
- In the compose window, everything below the frequently used languages also need fixing. I could not find the spot in the code where the code should go - where on Earth does `initialState?.languages` gets its contents from?
- I also noticed that when filtering languages from someone you follow, the native name is omitted. Sorting is according to last used language, which I think is fine.

Screenshot of the new sorting:

![image](https://github.com/mastodon/mastodon/assets/4095570/5aa95bac-4379-4b07-8986-a5ba2db6da95)
