### PR TITLE
Add shortcode to search query transformer

### DIFF
--- a/app/lib/search_query_parser.rb
+++ b/app/lib/search_query_parser.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 class SearchQueryParser < Parslet::Parser
-  rule(:term)      { match('[^\s":]').repeat(1).as(:term) }
+  rule(:term)      { match('[^\s":+-]').repeat(1).as(:term) }
   rule(:quote)     { str('"') }
   rule(:colon)     { str(':') }
   rule(:space)     { match('\s').repeat(1) }
   rule(:operator)  { (str('+') | str('-')).as(:operator) }
   rule(:prefix)    { term >> colon }
-  rule(:shortcode) { (colon >> term >> colon.maybe).as(:shortcode) }
+  rule(:shortcode) { (operator.maybe >> colon >> term >> colon.maybe).as(:shortcode) }
   rule(:phrase)    { (quote >> (match('[^\s"]').repeat(1).as(:term) >> space.maybe).repeat >> quote).as(:phrase) }
   rule(:clause)    { (operator.maybe >> prefix.maybe.as(:prefix) >> (phrase | term | shortcode)).as(:clause) | prefix.as(:clause) | quote.as(:junk) }
   rule(:query)     { (clause >> space.maybe).repeat.as(:query) }

--- a/app/lib/search_query_transformer.rb
+++ b/app/lib/search_query_transformer.rb
@@ -222,10 +222,29 @@ class SearchQueryTransformer < Parslet::Transform
     end
   end
 
+  class ShortCodeClause
+    attr_reader :operator, :prefix, :shortcode
+
+    def initialize(operator, shortcode)
+      @operator = Operator.symbol(operator)
+      @shortcode = shortcode
+    end
+
+    def to_query
+      { multi_match: { type: 'most_fields', query: @shortcode, fields: ['text', 'text.stemmed'], operator: 'and' } }
+    end
+  end
+
   rule(clause: subtree(:clause)) do
     prefix   = clause[:prefix][:term].to_s if clause[:prefix]
     operator = clause[:operator]&.to_s
-    term     = clause[:phrase] ? clause[:phrase].map { |term| term[:term].to_s }.join(' ') : clause[:term].to_s
+    term = if clause[:phrase]
+             clause[:phrase].map { |term| term[:term].to_s }.join(' ')
+           elsif clause[:shortcode]
+             clause[:shortcode][:term].to_s
+           else
+             clause[:term].to_s
+           end
 
     if clause[:prefix] && SUPPORTED_PREFIXES.include?(prefix)
       PrefixClause.new(prefix, operator, term, current_account: current_account)
@@ -235,6 +254,8 @@ class SearchQueryTransformer < Parslet::Transform
       TermClause.new(operator, term)
     elsif clause[:phrase]
       PhraseClause.new(operator, term)
+    elsif clause[:shortcode]
+      ShortCodeClause.new(operator, term)
     else
       raise "Unexpected clause type: #{clause}"
     end

--- a/spec/lib/search_query_parser_spec.rb
+++ b/spec/lib/search_query_parser_spec.rb
@@ -32,6 +32,10 @@ describe SearchQueryParser do
     it 'consumes ":foo:"' do
       expect(parser.shortcode).to parse(':foo:')
     end
+
+    it 'consumes "+:foo:"' do
+      expect(parser.shortcode).to parse('+:foo:')
+    end
   end
 
   context 'with phrase' do
@@ -51,6 +55,10 @@ describe SearchQueryParser do
 
     it 'consumes "foo:bar"' do
       expect(parser.clause).to parse('foo:bar')
+    end
+
+    it 'consumes "+:foo:"' do
+      expect(parser.clause).to parse('+:foo:')
     end
 
     it 'consumes "-foo:bar"' do
@@ -93,6 +101,14 @@ describe SearchQueryParser do
 
     it 'consumes "foo:bar bar: hello"' do
       expect(parser.query).to parse('foo:bar bar: hello')
+    end
+
+    it 'consumes "foo +:bar:"' do
+      expect(parser.query).to parse('foo +:bar:')
+    end
+
+    it 'consumes "foo+:bar:"' do
+      expect(parser.query).to parse('foo+:bar:')
     end
   end
 end

--- a/spec/lib/search_query_transformer_spec.rb
+++ b/spec/lib/search_query_transformer_spec.rb
@@ -58,6 +58,26 @@ describe SearchQueryTransformer do
     end
   end
 
+  context 'with ":foo:"' do
+    let(:query) { ':foo:' }
+
+    it 'transforms clauses' do
+      expect(subject.send(:must_clauses).map(&:shortcode)).to contain_exactly('foo')
+      expect(subject.send(:must_not_clauses)).to be_empty
+      expect(subject.send(:filter_clauses)).to be_empty
+    end
+  end
+
+  context 'with "-:foo:"' do
+    let(:query) { '-:foo:' }
+
+    it 'transforms clauses' do
+      expect(subject.send(:must_clauses)).to be_empty
+      expect(subject.send(:must_not_clauses).map(&:shortcode)).to contain_exactly('foo')
+      expect(subject.send(:filter_clauses)).to be_empty
+    end
+  end
+
   context 'with \'"hello world"\'' do
     let(:query) { '"hello world"' }
 


### PR DESCRIPTION
Attempt to fix https://github.com/mastodon/mastodon/issues/27171

You can now search for shortcode text.
<img width="713" alt="Screenshot 2023-09-27 at 3 47 07 PM" src="https://github.com/mastodon/mastodon/assets/15234688/1621f1f2-23e1-43a5-a6e4-604ce3c7a01a">

Searching with an Emoji works:
<img width="759" alt="Screenshot 2023-09-27 at 3 48 30 PM" src="https://github.com/mastodon/mastodon/assets/15234688/d3d3cc5e-d66c-47b7-8e6b-f91acad596f9">

But searching for that emoji with shortcode still does not work:
<img width="914" alt="Screenshot 2023-09-27 at 4 03 59 PM" src="https://github.com/mastodon/mastodon/assets/15234688/12f37aed-0ba0-4b98-8444-ac6d82f29ff3">

Note that this also (still) works for accounts:
<img width="575" alt="Screenshot 2023-09-27 at 4 07 36 PM" src="https://github.com/mastodon/mastodon/assets/15234688/07c56bcc-a1b3-4fd3-b54d-2fb7eeb0059d">
