### PR TITLE
Fix include `Rails.application.routes.url_helpers` (Rails 7.1 prep)

### DIFF
--- a/app/helpers/routing_helper.rb
+++ b/app/helpers/routing_helper.rb
@@ -3,11 +3,12 @@
 module RoutingHelper
   extend ActiveSupport::Concern
 
-  include Rails.application.routes.url_helpers
   include ActionView::Helpers::AssetTagHelper
   include Webpacker::Helper
 
   included do
+    include Rails.application.routes.url_helpers
+
     def default_url_options
       ActionMailer::Base.default_url_options
     end


### PR DESCRIPTION
Extracted from https://github.com/mastodon/mastodon/pull/25963

In Rails 7.1 there is a load order change and these methods do not get generated/included correctly when included at the module level. This changes them to get pulled in via the `included` block for the class using this module, which fixes the error in Rails 7.1 and (I think?) should be harmless to pull in ahead of time.