### PR TITLE
Fix deprecation warning about `rewhere: true` being default behavior (Rails 7.1 prep)

### DIFF
--- a/app/models/report_filter.rb
+++ b/app/models/report_filter.rb
@@ -19,7 +19,7 @@ class ReportFilter
     scope = Report.unresolved
 
     params.each do |key, value|
-      scope = scope.merge scope_for(key, value), rewhere: true
+      scope = scope.merge scope_for(key, value)
     end
 
     scope


### PR DESCRIPTION
Extracted from https://github.com/mastodon/mastodon/pull/25963

This behavior is the default in 7.0, which I believe means the option being included here is basically pointless.

It's a deprecation warning in 7.1, and I think will be an error/failure/removal in 7.2.