### PR TITLE
Change min age of backup policy from 1 week to 6 days

### DIFF
--- a/app/policies/backup_policy.rb
+++ b/app/policies/backup_policy.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class BackupPolicy < ApplicationPolicy
-  MIN_AGE = 1.week
+  MIN_AGE = 6.days
 
   def create?
     user_signed_in? && current_user.backups.where('created_at >= ?', MIN_AGE.ago).count.zero?


### PR DESCRIPTION
This allows users to actually take backups every week on the same day. A precise 1-week time frame progressively shifts the allowable window out of phase, causing frustration.

Resolves #22970