### PR TITLE
Fix explore prompt appearing because of posts being received out of order

### DIFF
--- a/app/javascript/mastodon/features/home_timeline/index.jsx
+++ b/app/javascript/mastodon/features/home_timeline/index.jsx
@@ -39,8 +39,17 @@ const getHomeFeedSpeed = createSelector([
 ], (statusIds, pendingStatusIds, statusMap) => {
   const recentStatusIds = pendingStatusIds.size > 0 ? pendingStatusIds : statusIds;
   const statuses = recentStatusIds.filter(id => id !== null).map(id => statusMap.get(id)).filter(status => status?.get('account') !== me).take(20);
-  const oldest = new Date(statuses.getIn([statuses.size - 1, 'created_at'], 0));
-  const newest = new Date(statuses.getIn([0, 'created_at'], 0));
+
+  if (statuses.isEmpty()) {
+    return {
+      gap: 0,
+      newest: new Date(0),
+    };
+  }
+
+  const datetimes = statuses.map(status => status.get('created_at', 0));
+  const oldest = new Date(datetimes.min());
+  const newest = new Date(datetimes.max());
   const averageGap = (newest - oldest) / (1000 * (statuses.size + 1)); // Average gap between posts on first page in seconds
 
   return {


### PR DESCRIPTION
Under certain conditions (e.g. it went down for a time), a server can receive posts in a non-chronological order, in which case they will be inserted into home timelines in the order they were discovered.

This causes the explore prompt to be displayed each time an old post appears, only to disappear when a recent post appears.