### PR TITLE
Add PWA shortcut to `/explore` page

### DIFF
--- a/app/serializers/manifest_serializer.rb
+++ b/app/serializers/manifest_serializer.rb
@@ -84,6 +84,10 @@ class ManifestSerializer < ActiveModel::Serializer
         name: 'Notifications',
         url: '/notifications',
       },
+      {
+        name: 'Explore',
+        url: '/explore',
+      },
     ]
   end
 end


### PR DESCRIPTION
This will allow PWA users to access the Explore page with ease.