### PR TITLE
Change some worker lock TTLs

### DIFF
--- a/app/workers/account_deletion_worker.rb
+++ b/app/workers/account_deletion_worker.rb
@@ -3,7 +3,7 @@
 class AccountDeletionWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'pull', lock: :until_executed
+  sidekiq_options queue: 'pull', lock: :until_executed, lock_ttl: 1.week.to_i
 
   def perform(account_id, options = {})
     account = Account.find(account_id)

--- a/app/workers/activitypub/synchronize_featured_collection_worker.rb
+++ b/app/workers/activitypub/synchronize_featured_collection_worker.rb
@@ -3,7 +3,7 @@
 class ActivityPub::SynchronizeFeaturedCollectionWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'pull', lock: :until_executed
+  sidekiq_options queue: 'pull', lock: :until_executed, lock_ttl: 1.day.to_i
 
   def perform(account_id, options = {})
     options = { note: true, hashtag: false }.deep_merge(options.deep_symbolize_keys)

--- a/app/workers/activitypub/synchronize_featured_tags_collection_worker.rb
+++ b/app/workers/activitypub/synchronize_featured_tags_collection_worker.rb
@@ -3,7 +3,7 @@
 class ActivityPub::SynchronizeFeaturedTagsCollectionWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'pull', lock: :until_executed
+  sidekiq_options queue: 'pull', lock: :until_executed, lock_ttl: 1.day.to_i
 
   def perform(account_id, url)
     ActivityPub::FetchFeaturedTagsCollectionService.new.call(Account.find(account_id), url)

--- a/app/workers/activitypub/update_distribution_worker.rb
+++ b/app/workers/activitypub/update_distribution_worker.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ActivityPub::UpdateDistributionWorker < ActivityPub::RawDistributionWorker
-  sidekiq_options queue: 'push', lock: :until_executed
+  sidekiq_options queue: 'push', lock: :until_executed, lock_ttl: 1.day.to_i
 
   # Distribute an profile update to servers that might have a copy
   # of the account in question

--- a/app/workers/admin/account_deletion_worker.rb
+++ b/app/workers/admin/account_deletion_worker.rb
@@ -3,7 +3,7 @@
 class Admin::AccountDeletionWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'pull', lock: :until_executed
+  sidekiq_options queue: 'pull', lock: :until_executed, lock_ttl: 1.week.to_i
 
   def perform(account_id)
     DeleteAccountService.new.call(Account.find(account_id), reserve_username: true, reserve_email: true)

--- a/app/workers/admin/domain_purge_worker.rb
+++ b/app/workers/admin/domain_purge_worker.rb
@@ -3,7 +3,7 @@
 class Admin::DomainPurgeWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'pull', lock: :until_executed
+  sidekiq_options queue: 'pull', lock: :until_executed, lock_ttl: 1.week.to_i
 
   def perform(domain)
     PurgeDomainService.new.call(domain)

--- a/app/workers/publish_scheduled_status_worker.rb
+++ b/app/workers/publish_scheduled_status_worker.rb
@@ -3,7 +3,7 @@
 class PublishScheduledStatusWorker
   include Sidekiq::Worker
 
-  sidekiq_options lock: :until_executed
+  sidekiq_options lock: :until_executed, lock_ttl: 1.hour.to_i
 
   def perform(scheduled_status_id)
     scheduled_status = ScheduledStatus.find(scheduled_status_id)

--- a/app/workers/resolve_account_worker.rb
+++ b/app/workers/resolve_account_worker.rb
@@ -3,7 +3,7 @@
 class ResolveAccountWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'pull', lock: :until_executed
+  sidekiq_options queue: 'pull', lock: :until_executed, lock_ttl: 1.day.to_i
 
   def perform(uri)
     ResolveAccountService.new.call(uri)

--- a/app/workers/scheduler/indexing_scheduler.rb
+++ b/app/workers/scheduler/indexing_scheduler.rb
@@ -5,7 +5,7 @@ class Scheduler::IndexingScheduler
   include Redisable
   include DatabaseHelper
 
-  sidekiq_options retry: 0, lock: :until_executed, lock_ttl: 1.day.to_i
+  sidekiq_options retry: 0, lock: :until_executed, lock_ttl: 30.minutes.to_i
 
   IMPORT_BATCH_SIZE = 1000
   SCAN_BATCH_SIZE = 10 * IMPORT_BATCH_SIZE

--- a/app/workers/scheduler/scheduled_statuses_scheduler.rb
+++ b/app/workers/scheduler/scheduled_statuses_scheduler.rb
@@ -3,7 +3,7 @@
 class Scheduler::ScheduledStatusesScheduler
   include Sidekiq::Worker
 
-  sidekiq_options retry: 0, lock: :until_executed, lock_ttl: 1.day.to_i
+  sidekiq_options retry: 0, lock: :until_executed, lock_ttl: 1.hour.to_i
 
   def perform
     publish_scheduled_statuses!

--- a/app/workers/verify_account_links_worker.rb
+++ b/app/workers/verify_account_links_worker.rb
@@ -3,7 +3,7 @@
 class VerifyAccountLinksWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'default', retry: false, lock: :until_executed
+  sidekiq_options queue: 'default', retry: false, lock: :until_executed, lock_ttl: 1.hour.to_i
 
   def perform(account_id)
     account = Account.find(account_id)


### PR DESCRIPTION
We use `sidekiq-unique-jobs` throughout the code base to prevent wasteful or unsafe parallel queuing and execution of duplicate jobs. However, it is possible for locks to be left dangling if e.g. a `sidekiq` process gets killed or terminates in an unclean way. In these cases, too long of a TTL would cause degraded performance/functionality. Our default TTL of 50 days is fine to make sure nothing is stuck forever, but for most functionality, smaller TTLs make more sense.

The TTL runs from the time the job is first enqueued, and it is released when the job has finished (because we only ever use `until_executed`). This means we need to consider the normal time from queuing to execution, not just the execution time.

- `IndexingScheduler` is perfectly safe to run multiple instances of and running multiple instances of it won't cause duplicate work, instead, it may actually go through the backlog faster. The presence of a lock is purely to avoid filling the queue with only indexing jobs. The longer this job is skipped, the more work it will have to perform.
- `ScheduledStatusesScheduler` is safe but wasteful to run multiple instances of, but should be a pretty quick job. The longer the TTL, the more scheduled posts will miss their expected date. The longer this job is skipped, the more work it will have to perform.
- `VerifyAccountLinksWorker` should be safe but wasteful to run multiple instances of. It should be a pretty quick job, but most of it depends on network connectivity, so its duration can vary widely. The default expiration of 50 days is unsuitable for this job.
- `AccountDeletionWorker`, `Admin::AccountDeletionWorker` and `Admin::DomainPurgeWorker` should be safe to run multiple instances of, but would be wasteful. They can also be pretty long and be queued in large batches. The default of 50 days is likely unsuitable for these jobs too, though.
- `ActivityPub::SynchronizeFeaturedCollectionWorker`, `ActivityPub::SynchronizeFeaturedTagsCollectionWorker`, and `ActivityPub::UpdateDistributionWorker` are safe but wasteful to run duplicate jobs of. They should be fast, but can be enqueued in batches and depend on network connectivity. The default expiration of 50 days is unsuitable for them.