### PR TITLE
Prefer native apps over PWA

### DIFF
--- a/app/serializers/manifest_serializer.rb
+++ b/app/serializers/manifest_serializer.rb
@@ -8,7 +8,8 @@ class ManifestSerializer < ActiveModel::Serializer
   attributes :id, :name, :short_name,
              :icons, :theme_color, :background_color,
              :display, :start_url, :scope,
-             :share_target, :shortcuts
+             :share_target, :shortcuts,
+             :prefer_related_applications, :related_applications
 
   def id
     # This is set to `/home` because that was the old value of `start_url` and
@@ -87,6 +88,30 @@ class ManifestSerializer < ActiveModel::Serializer
         name: 'Explore',
         url: '/explore',
       },
+    ]
+  end
+
+  def prefer_related_applications
+    true
+  end
+
+  def related_applications
+    [
+      {
+        "platform": "play",
+        "url": "https://play.google.com/store/apps/details?id=org.joinmastodon.android",
+        "id": "org.joinmastodon.android"
+      },
+      {
+        "platform": "itunes",
+        "url": "https://apps.apple.com/us/app/mastodon-for-iphone/id1571998974",
+        "id": "id1571998974"
+      },
+      {
+        "platform": "f-droid",
+        "url": "https://f-droid.org/en/packages/org.joinmastodon.android/",
+        "id": "org.joinmastodon.android"
+      }
     ]
   end
 end

--- a/app/serializers/manifest_serializer.rb
+++ b/app/serializers/manifest_serializer.rb
@@ -87,7 +87,7 @@ class ManifestSerializer < ActiveModel::Serializer
       {
         name: 'Explore',
         url: '/explore',
-      },
+      }
     ]
   end
 
@@ -98,19 +98,19 @@ class ManifestSerializer < ActiveModel::Serializer
   def related_applications
     [
       {
-        "platform": "play",
-        "url": "https://play.google.com/store/apps/details?id=org.joinmastodon.android",
-        "id": "org.joinmastodon.android"
+        platform: 'play',
+        url: 'https://play.google.com/store/apps/details?id=org.joinmastodon.android',
+        id: 'org.joinmastodon.android'
       },
       {
-        "platform": "itunes",
-        "url": "https://apps.apple.com/us/app/mastodon-for-iphone/id1571998974",
-        "id": "id1571998974"
+        platform: 'itunes',
+        url: 'https://apps.apple.com/us/app/mastodon-for-iphone/id1571998974',
+        id: 'id1571998974'
       },
       {
-        "platform": "f-droid",
-        "url": "https://f-droid.org/en/packages/org.joinmastodon.android/",
-        "id": "org.joinmastodon.android"
+        platform: 'f-droid',
+        url: 'https://f-droid.org/en/packages/org.joinmastodon.android/',
+        id: 'org.joinmastodon.android'
       }
     ]
   end

--- a/app/serializers/manifest_serializer.rb
+++ b/app/serializers/manifest_serializer.rb
@@ -87,7 +87,7 @@ class ManifestSerializer < ActiveModel::Serializer
       {
         name: 'Explore',
         url: '/explore',
-      }
+      },
     ]
   end
 
@@ -100,18 +100,18 @@ class ManifestSerializer < ActiveModel::Serializer
       {
         platform: 'play',
         url: 'https://play.google.com/store/apps/details?id=org.joinmastodon.android',
-        id: 'org.joinmastodon.android'
+        id: 'org.joinmastodon.android',
       },
       {
         platform: 'itunes',
         url: 'https://apps.apple.com/us/app/mastodon-for-iphone/id1571998974',
-        id: 'id1571998974'
+        id: 'id1571998974',
       },
       {
         platform: 'f-droid',
         url: 'https://f-droid.org/en/packages/org.joinmastodon.android/',
-        id: 'org.joinmastodon.android'
-      }
+        id: 'org.joinmastodon.android',
+      },
     ]
   end
 end


### PR DESCRIPTION
This PR enables the [native app install prompt](https://developer.chrome.com/blog/app-install-banners-native/#what-are-the-criteria) for the PWA by setting the [`prefer_related_applications`](https://developer.mozilla.org/en-US/docs/Web/Manifest/prefer_related_applications) property to true in the manifest file.  This property tells the browser to suggest the installation of the native app (if supported) listed in [`related_applications`](https://developer.mozilla.org/en-US/docs/Web/Manifest/related_applications), instead of the PWA.