### PR TITLE
Fix Elastic check deprecation warning about gem version

### DIFF
--- a/app/lib/admin/system_check/elasticsearch_check.rb
+++ b/app/lib/admin/system_check/elasticsearch_check.rb
@@ -76,18 +76,20 @@ class Admin::SystemCheck::ElasticsearchCheck < Admin::SystemCheck::BaseCheck
   end
 
   def compatible_version?
-    return false if running_version.nil?
-
     running_version_ok? || compatible_wire_version_ok?
   rescue ArgumentError
     false
   end
 
   def running_version_ok?
+    return false if running_version.blank?
+
     gem_version_running >= gem_version_required
   end
 
   def compatible_wire_version_ok?
+    return false if compatible_wire_version.blank?
+
     gem_version_compatible_wire >= gem_version_required
   end
 

--- a/app/lib/admin/system_check/elasticsearch_check.rb
+++ b/app/lib/admin/system_check/elasticsearch_check.rb
@@ -78,10 +78,22 @@ class Admin::SystemCheck::ElasticsearchCheck < Admin::SystemCheck::BaseCheck
   def compatible_version?
     return false if running_version.nil?
 
-    Gem::Version.new(running_version) >= Gem::Version.new(required_version) ||
-      Gem::Version.new(compatible_wire_version) >= Gem::Version.new(required_version)
+    gem_version_running >= gem_version_required ||
+      gem_version_compatible_wire >= gem_version_required
   rescue ArgumentError
     false
+  end
+
+  def gem_version_running
+    Gem::Version.new(running_version)
+  end
+
+  def gem_version_required
+    Gem::Version.new(required_version)
+  end
+
+  def gem_version_compatible_wire
+    Gem::Version.new(compatible_wire_version)
   end
 
   def mismatched_indexes

--- a/app/lib/admin/system_check/elasticsearch_check.rb
+++ b/app/lib/admin/system_check/elasticsearch_check.rb
@@ -78,10 +78,17 @@ class Admin::SystemCheck::ElasticsearchCheck < Admin::SystemCheck::BaseCheck
   def compatible_version?
     return false if running_version.nil?
 
-    gem_version_running >= gem_version_required ||
-      gem_version_compatible_wire >= gem_version_required
+    running_version_ok? || compatible_wire_version_ok?
   rescue ArgumentError
     false
+  end
+
+  def running_version_ok?
+    gem_version_running >= gem_version_required
+  end
+
+  def compatible_wire_version_ok?
+    gem_version_compatible_wire >= gem_version_required
   end
 
   def gem_version_running


### PR DESCRIPTION
There's a deprecation warning about passing `nil` values to `Gem::Version.new` which is coming from the elasticsearch check class, when it attempts to pass in a nil value for the compatible wire version. The warning is:

> nil versions are discouraged and will be deprecated in Rubygems 4 

This change modifies the logic to avoid calling `Gem::Version.new` when there is going to a nil value for the compatible wire version.

While in there, did a little method extraction/naming to make clear what's happening with both the running version and compatible wire version checks.

I don't think there is a change in behavior here, just avoiding the deprecation warning.