### PR TITLE
Silence deprecation warning in CacheBuster spec

### DIFF
--- a/spec/lib/cache_buster_spec.rb
+++ b/spec/lib/cache_buster_spec.rb
@@ -28,6 +28,14 @@ describe CacheBuster do
     end
 
     context 'when using default options' do
+      around do |example|
+        # Disables the CacheBuster.new deprecation warning about default arguments.
+        # Remove this `silence` block when default arg support is removed from CacheBuster
+        ActiveSupport::Deprecation.silence do
+          example.run
+        end
+      end
+
       include_examples 'makes_request'
     end
 


### PR DESCRIPTION
This silences the deprecation output during spec runs only. Actual usage will still see the deprecation.

Added a comment to note that this deprecation silence can be removed when the feature change is made in 4.3 as well.