### PR TITLE
Remove bundle audit skipping sidekiq CVE

### DIFF
--- a/.bundler-audit.yml
+++ b/.bundler-audit.yml
@@ -1,4 +1,0 @@
----
-ignore:
-  # Sidekiq security issue, fixes in the latest Sidekiq 7 but we can not upgrade. Will be fixed in Sidekiq 6.5.10
-  - CVE-2023-26141


### PR DESCRIPTION
With https://github.com/mastodon/mastodon/pull/27287 merged, I think we no longer need the ignore?