### PR TITLE
Move "Privacy and reach" from "Public profile" to top-level navigation

### DIFF
--- a/app/views/settings/privacy/show.html.haml
+++ b/app/views/settings/privacy/show.html.haml
@@ -2,8 +2,7 @@
   = t('privacy.title')
 
 - content_for :heading do
-  %h2= t('settings.profile')
-  = render partial: 'settings/shared/profile_navigation'
+  %h2= t('privacy.title')
 
 = simple_form_for @account, url: settings_privacy_path do |f|
   = render 'shared/error_messages', object: @account

--- a/app/views/settings/shared/_profile_navigation.html.haml
+++ b/app/views/settings/shared/_profile_navigation.html.haml
@@ -2,6 +2,5 @@
   = render_navigation renderer: :links do |primary|
     :ruby
       primary.item :edit_profile, safe_join([material_symbol('person'), t('settings.edit_profile')]), settings_profile_path
-      primary.item :privacy_reach, safe_join([material_symbol('lock'), t('privacy.title')]), settings_privacy_path
       primary.item :verification, safe_join([material_symbol('check'), t('verification.verification')]), settings_verification_path
       primary.item :featured_tags, safe_join([material_symbol('tag'), t('settings.featured_tags')]), settings_featured_tags_path

--- a/config/navigation.rb
+++ b/config/navigation.rb
@@ -12,7 +12,8 @@ SimpleNavigation::Configuration.run do |navigation|
            if: -> { Rails.configuration.x.mastodon.software_update_url.present? && current_user.can?(:view_devops) && SoftwareUpdate.urgent_pending? },
            html: { class: 'warning' }
 
-    n.item :profile, safe_join([material_symbol('person'), t('settings.profile')]), settings_profile_path, if: -> { current_user.functional? && !self_destruct }, highlights_on: %r{/settings/profile|/settings/featured_tags|/settings/verification|/settings/privacy}
+    n.item :profile, safe_join([material_symbol('person'), t('settings.profile')]), settings_profile_path, if: -> { current_user.functional? && !self_destruct }, highlights_on: %r{/settings/profile|/settings/featured_tags|/settings/verification}
+    n.item :privacy, safe_join([material_symbol('globe'), t('privacy.title')]), settings_privacy_path, if: -> { current_user.functional? && !self_destruct }, highlights_on: %r{/settings/privacy}
 
     n.item :preferences, safe_join([material_symbol('settings'), t('settings.preferences')]), settings_preferences_path, if: -> { current_user.functional? && !self_destruct } do |s|
       s.item :appearance, safe_join([material_symbol('computer'), t('settings.appearance')]), settings_preferences_appearance_path


### PR DESCRIPTION
closes #27060 

Move "Privacy and reach" from "Public profile" and add it to top-level navigation.
![screenshot of top-half of "Privacy and reach" page. "Privacy and reach" is available in the navigation below "Public profile". The profile navigation tabs have been removed and the title of the page is "Privacy and reach" now.](https://github.com/user-attachments/assets/eaca8eeb-918a-4b09-b804-7146ca6ad5a9)

There are a lot of posts on Mastodon that follow this format:

> If you're concerned about reach on Mastodon, *please* make sure you've made your public posts searchable.
>
> Go to your server's web site, then Preferences (gear icon)> Public profile> Privacy and reach tab, then in the section "Search” turn on "Include public posts in search results." This setting defaults to OFF, and if you want people to find your posts you need to turn it on.

To me that indicates that "Privacy and reach" is hard to find. I've moved it to the top-level navigation.
