### PR TITLE
Link to remote profile instead of local profile

### DIFF
--- a/app/javascript/mastodon/features/follow_requests/components/account_authorize.jsx
+++ b/app/javascript/mastodon/features/follow_requests/components/account_authorize.jsx
@@ -2,8 +2,6 @@ import PropTypes from 'prop-types';
 
 import { defineMessages, injectIntl } from 'react-intl';
 
-import { Link } from 'react-router-dom';
-
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 
@@ -32,10 +30,10 @@ class AccountAuthorize extends ImmutablePureComponent {
     return (
       <div className='account-authorize__wrapper'>
         <div className='account-authorize'>
-          <Link to={`/@${account.get('acct')}`} className='detailed-status__display-name'>
+          <a href={account.get('uri')} className='detailed-status__display-name'>
             <div className='account-authorize__avatar'><Avatar account={account} size={48} /></div>
             <DisplayName account={account} />
-          </Link>
+          </a>
 
           <div className='account__header__content translate' dangerouslySetInnerHTML={content} />
         </div>


### PR DESCRIPTION
# Description
closes #27234 

When evaluating follow requests, past history of the profile is really important, and seeing the remote profile for a user is part of that process. Right now, it's two clicks to reach the remote profile instead of just one. This PR updates the link, so that it points to the absolute url of the profile - the local one for local servers, and the remote one for remote servers.


I tried this out as an experiment, but I don't think it actually improves the user experience. There are a couple issues with the flow for remote profiles.

- You cannot approve from a remote server (it doesn't know there's a follow request)
- You cannot get back to follow requests without using the browser's back button (the back button goes to remote server's home)

Essentially the user finds themself abandoned on a remote profile page with no way to take action or go back home.