### PR TITLE
Fix some remote posts getting truncated

### DIFF
--- a/app/javascript/mastodon/components/__tests__/hashtag_bar.tsx
+++ b/app/javascript/mastodon/components/__tests__/hashtag_bar.tsx
@@ -45,6 +45,21 @@ describe('computeHashtagBarForStatus', () => {
     );
   });
 
+  it('does not truncate the contents when the last child is a text node', () => {
+    const status = createStatus(
+      'this is a #<a class="zrl" href="https://example.com/search?tag=test">test</a>. Some more text',
+      ['test'],
+    );
+
+    const { hashtagsInBar, statusContentProps } =
+      computeHashtagBarForStatus(status);
+
+    expect(hashtagsInBar).toEqual([]);
+    expect(statusContentProps.statusContent).toMatchInlineSnapshot(
+      `"this is a #<a class="zrl" href="https://example.com/search?tag=test">test</a>. Some more text"`,
+    );
+  });
+
   it('extract tags from the last line', () => {
     const status = createStatus(
       '<p>Simple text</p><p><a href="test">#hashtag</a></p>',

--- a/app/javascript/mastodon/components/hashtag_bar.tsx
+++ b/app/javascript/mastodon/components/hashtag_bar.tsx
@@ -109,7 +109,7 @@ export function computeHashtagBarForStatus(status: StatusLike): {
 
   const lastChild = template.content.lastChild;
 
-  if (!lastChild) return defaultResult;
+  if (!lastChild || lastChild.nodeType === Node.TEXT_NODE) return defaultResult;
 
   template.content.removeChild(lastChild);
   const contentWithoutLastLine = template;


### PR DESCRIPTION
Fixes #27305

Hubzilla do not wrap statuses in a tag, so `template.content.lastChild` ends up being a text node, and `Array.from(lastChild.childNodes)` results in an empty array. The last line was thus considered as only including hashtags, which is not true, and was thus incorrectly removed from the displayed DOM.