### PR TITLE
Bump version to v4.0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,23 @@ All notable changes to this project will be documented in this file.
 ## End of life notice
 
 **The 4.0.x branch will not receive any update after 2023-10-31.**
-This means that no security fix will be made available for this branch after this date, and you will need to update to a more recent version (such as the 4.1.x branch) to receive security fixes.
+This means that no security fix will be made available for this branch after this date, and you will need to update to a more recent version (such as the 4.2.x branch) to receive security fixes.
+
+## [4.0.12] - 2023-10-10
+
+### Changed
+
+- Change some worker lock TTLs to be shorter-lived ([ClearlyClaire](https://github.com/mastodon/mastodon/pull/27246))
+- Change user archive export allowed period from 7 days to 6 days ([suddjian](https://github.com/mastodon/mastodon/pull/27200))
+
+### Fixed
+
+- Fix mentions being matched in some URL query strings ([mjankowski](https://github.com/mastodon/mastodon/pull/25656))
+- Fix multiple instances of the trend refresh scheduler sometimes running at once ([ClearlyClaire](https://github.com/mastodon/mastodon/pull/27253))
+- Fix importer returning negative row estimates ([jgillich](https://github.com/mastodon/mastodon/pull/27258))
+- Fix filtering audit log for entries about disabling 2FA ([ClearlyClaire](https://github.com/mastodon/mastodon/pull/27186))
+- Fix tIME chunk not being properly removed from PNG uploads ([TheEssem](https://github.com/mastodon/mastodon/pull/27111))
+- Fix inefficient queries in “Follows and followers” as well as several admin pages ([ClearlyClaire](https://github.com/mastodon/mastodon/pull/27116), [ClearlyClaire](https://github.com/mastodon/mastodon/pull/27306))
 
 ## [4.0.11] - 2023-09-20
 

--- a/app/lib/importer/base_importer.rb
+++ b/app/lib/importer/base_importer.rb
@@ -34,7 +34,9 @@ class Importer::BaseImporter
   # Estimate the amount of documents that would be indexed. Not exact!
   # @returns [Integer]
   def estimate!
-    ActiveRecord::Base.connection_pool.with_connection { |connection| connection.select_one("SELECT reltuples AS estimate FROM pg_class WHERE relname = '#{index.adapter.target.table_name}'")['estimate'].to_i }
+    reltuples = ActiveRecord::Base.connection_pool.with_connection { |connection| connection.select_one("SELECT reltuples FROM pg_class WHERE relname = '#{index.adapter.target.table_name}'")['reltuples'].to_i }
+    # If the table has never yet been vacuumed or analyzed, reltuples contains -1
+    [reltuples, 0].max
   end
 
   # Import data from the database into the index

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -61,9 +61,9 @@ class Account < ApplicationRecord
     trust_level
   )
 
-  USERNAME_RE   = /[a-z0-9_]+([a-z0-9_\.-]+[a-z0-9_]+)?/i
-  MENTION_RE    = /(?<=^|[^\/[:word:]])@((#{USERNAME_RE})(?:@[[:word:]\.\-]+[[:word:]]+)?)/i
-  URL_PREFIX_RE = /\Ahttp(s?):\/\/[^\/]+/
+  USERNAME_RE   = /[a-z0-9_]+([a-z0-9_.-]+[a-z0-9_]+)?/i
+  MENTION_RE    = %r{(?<![=/[:word:]])@((#{USERNAME_RE})(?:@[[:word:].-]+[[:word:]]+)?)}i
+  URL_PREFIX_RE = %r{\Ahttp(s?)://[^/]+}
   USERNAME_ONLY_RE = /\A#{USERNAME_RE}\z/i
 
   include Attachmentable

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -114,8 +114,8 @@ class Account < ApplicationRecord
   scope :searchable, -> { without_unapproved.without_suspended.where(moved_to_account_id: nil) }
   scope :discoverable, -> { searchable.without_silenced.where(discoverable: true).left_outer_joins(:account_stat) }
   scope :followable_by, ->(account) { joins(arel_table.join(Follow.arel_table, Arel::Nodes::OuterJoin).on(arel_table[:id].eq(Follow.arel_table[:target_account_id]).and(Follow.arel_table[:account_id].eq(account.id))).join_sources).where(Follow.arel_table[:id].eq(nil)).joins(arel_table.join(FollowRequest.arel_table, Arel::Nodes::OuterJoin).on(arel_table[:id].eq(FollowRequest.arel_table[:target_account_id]).and(FollowRequest.arel_table[:account_id].eq(account.id))).join_sources).where(FollowRequest.arel_table[:id].eq(nil)) }
-  scope :by_recent_status, -> { order(Arel.sql('(case when account_stats.last_status_at is null then 1 else 0 end) asc, account_stats.last_status_at desc, accounts.id desc')) }
-  scope :by_recent_sign_in, -> { order(Arel.sql('(case when users.current_sign_in_at is null then 1 else 0 end) asc, users.current_sign_in_at desc, accounts.id desc')) }
+  scope :by_recent_status, -> { includes(:account_stat).merge(AccountStat.order('last_status_at DESC NULLS LAST')).references(:account_stat) }
+  scope :by_recent_sign_in, -> { order(Arel.sql('users.current_sign_in_at DESC NULLS LAST')) }
   scope :popular, -> { order('account_stats.followers_count desc') }
   scope :by_domain_and_subdomains, ->(domain) { where(domain: domain).or(where(arel_table[:domain].matches("%.#{domain}"))) }
   scope :not_excluded_by_account, ->(account) { where.not(id: account.excluded_from_timeline_account_ids) }

--- a/app/models/admin/action_log_filter.rb
+++ b/app/models/admin/action_log_filter.rb
@@ -38,7 +38,7 @@ class Admin::ActionLogFilter
     destroy_status: { target_type: 'Status', action: 'destroy' }.freeze,
     destroy_user_role: { target_type: 'UserRole', action: 'destroy' }.freeze,
     destroy_canonical_email_block: { target_type: 'CanonicalEmailBlock', action: 'destroy' }.freeze,
-    disable_2fa_user: { target_type: 'User', action: 'disable' }.freeze,
+    disable_2fa_user: { target_type: 'User', action: 'disable_2fa' }.freeze,
     disable_custom_emoji: { target_type: 'CustomEmoji', action: 'disable' }.freeze,
     disable_user: { target_type: 'User', action: 'disable' }.freeze,
     enable_custom_emoji: { target_type: 'CustomEmoji', action: 'enable' }.freeze,

--- a/app/models/concerns/account_avatar.rb
+++ b/app/models/concerns/account_avatar.rb
@@ -18,7 +18,7 @@ module AccountAvatar
 
   included do
     # Avatar upload
-    has_attached_file :avatar, styles: ->(f) { avatar_styles(f) }, convert_options: { all: '+profile "!icc,*" +set modify-date +set create-date' }, processors: [:lazy_thumbnail]
+    has_attached_file :avatar, styles: ->(f) { avatar_styles(f) }, convert_options: { all: '+profile "!icc,*" +set date:modify +set date:create +set date:timestamp' }, processors: [:lazy_thumbnail]
     validates_attachment_content_type :avatar, content_type: IMAGE_MIME_TYPES
     validates_attachment_size :avatar, less_than: LIMIT
     remotable_attachment :avatar, LIMIT, suppress_errors: false

--- a/app/models/concerns/account_header.rb
+++ b/app/models/concerns/account_header.rb
@@ -19,7 +19,7 @@ module AccountHeader
 
   included do
     # Header upload
-    has_attached_file :header, styles: ->(f) { header_styles(f) }, convert_options: { all: '+profile "!icc,*" +set modify-date +set create-date' }, processors: [:lazy_thumbnail]
+    has_attached_file :header, styles: ->(f) { header_styles(f) }, convert_options: { all: '+profile "!icc,*" +set date:modify +set date:create +set date:timestamp' }, processors: [:lazy_thumbnail]
     validates_attachment_content_type :header, content_type: IMAGE_MIME_TYPES
     validates_attachment_size :header, less_than: LIMIT
     remotable_attachment :header, LIMIT, suppress_errors: false

--- a/app/models/custom_emoji.rb
+++ b/app/models/custom_emoji.rb
@@ -37,7 +37,7 @@ class CustomEmoji < ApplicationRecord
   belongs_to :category, class_name: 'CustomEmojiCategory', optional: true
   has_one :local_counterpart, -> { where(domain: nil) }, class_name: 'CustomEmoji', primary_key: :shortcode, foreign_key: :shortcode
 
-  has_attached_file :image, styles: { static: { format: 'png', convert_options: '-coalesce +profile "!icc,*" +set modify-date +set create-date' } }, validate_media_type: false
+  has_attached_file :image, styles: { static: { format: 'png', convert_options: '-coalesce +profile "!icc,*" +set date:modify +set date:create +set date:timestamp' } }, validate_media_type: false
 
   before_validation :downcase_domain
 

--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -168,7 +168,7 @@ class MediaAttachment < ApplicationRecord
   }.freeze
 
   GLOBAL_CONVERT_OPTIONS = {
-    all: '-quality 90 +profile "!icc,*" +set modify-date +set create-date',
+    all: '-quality 90 +profile "!icc,*" +set date:modify +set date:create +set date:timestamp',
   }.freeze
 
   belongs_to :account,          inverse_of: :media_attachments, optional: true

--- a/app/models/preview_card.rb
+++ b/app/models/preview_card.rb
@@ -50,7 +50,7 @@ class PreviewCard < ApplicationRecord
   has_and_belongs_to_many :statuses
   has_one :trend, class_name: 'PreviewCardTrend', inverse_of: :preview_card, dependent: :destroy
 
-  has_attached_file :image, processors: [:thumbnail, :blurhash_transcoder], styles: ->(f) { image_styles(f) }, convert_options: { all: '-quality 90 +profile "!icc,*" +set modify-date +set create-date' }, validate_media_type: false
+  has_attached_file :image, processors: [:thumbnail, :blurhash_transcoder], styles: ->(f) { image_styles(f) }, convert_options: { all: '-quality 90 +profile "!icc,*" +set date:modify +set date:create +set date:timestamp' }, validate_media_type: false
 
   validates :url, presence: true, uniqueness: true
   validates_attachment_content_type :image, content_type: IMAGE_MIME_TYPES

--- a/app/models/preview_card_provider.rb
+++ b/app/models/preview_card_provider.rb
@@ -25,7 +25,7 @@ class PreviewCardProvider < ApplicationRecord
 
   validates :domain, presence: true, uniqueness: true, domain: true
 
-  has_attached_file :icon, styles: { static: { format: 'png', convert_options: '-coalesce +profile "!icc,*" +set modify-date +set create-date' } }, validate_media_type: false
+  has_attached_file :icon, styles: { static: { format: 'png', convert_options: '-coalesce +profile "!icc,*" +set date:modify +set date:create +set date:timestamp' } }, validate_media_type: false
   validates_attachment :icon, content_type: { content_type: ICON_MIME_TYPES }, size: { less_than: LIMIT }
   remotable_attachment :icon, LIMIT
 

--- a/app/models/relationship_filter.rb
+++ b/app/models/relationship_filter.rb
@@ -60,13 +60,13 @@ class RelationshipFilter
   def relationship_scope(value)
     case value
     when 'following'
-      account.following.eager_load(:account_stat).reorder(nil)
+      account.following.includes(:account_stat).reorder(nil)
     when 'followed_by'
-      account.followers.eager_load(:account_stat).reorder(nil)
+      account.followers.includes(:account_stat).reorder(nil)
     when 'mutual'
-      account.followers.eager_load(:account_stat).reorder(nil).merge(Account.where(id: account.following))
+      account.followers.includes(:account_stat).reorder(nil).merge(Account.where(id: account.following))
     when 'invited'
-      Account.joins(user: :invite).merge(Invite.where(user: account.user)).eager_load(:account_stat).reorder(nil)
+      Account.joins(user: :invite).merge(Invite.where(user: account.user)).includes(:account_stat).reorder(nil)
     else
       raise Mastodon::InvalidParameterError, "Unknown relationship: #{value}"
     end

--- a/app/models/relationship_filter.rb
+++ b/app/models/relationship_filter.rb
@@ -112,7 +112,7 @@ class RelationshipFilter
   def activity_scope(value)
     case value
     when 'dormant'
-      AccountStat.where(last_status_at: nil).or(AccountStat.where(AccountStat.arel_table[:last_status_at].lt(1.month.ago)))
+      Account.joins(:account_stat).where(account_stat: { last_status_at: [nil, ...1.month.ago] })
     else
       raise Mastodon::InvalidParameterError, "Unknown activity: #{value}"
     end

--- a/app/models/site_upload.rb
+++ b/app/models/site_upload.rb
@@ -40,7 +40,7 @@ class SiteUpload < ApplicationRecord
     mascot: {}.freeze,
   }.freeze
 
-  has_attached_file :file, styles: ->(file) { STYLES[file.instance.var.to_sym] }, convert_options: { all: '-coalesce +profile "!icc,*" +set modify-date +set create-date' }, processors: [:lazy_thumbnail, :blurhash_transcoder, :type_corrector]
+  has_attached_file :file, styles: ->(file) { STYLES[file.instance.var.to_sym] }, convert_options: { all: '-coalesce +profile "!icc,*" +set date:modify +set date:create +set date:timestamp' }, processors: [:lazy_thumbnail, :blurhash_transcoder, :type_corrector]
 
   validates_attachment_content_type :file, content_type: /\Aimage\/.*\z/
   validates :file, presence: true

--- a/app/policies/backup_policy.rb
+++ b/app/policies/backup_policy.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class BackupPolicy < ApplicationPolicy
-  MIN_AGE = 1.week
+  MIN_AGE = 6.days
 
   def create?
     user_signed_in? && current_user.backups.where('created_at >= ?', MIN_AGE.ago).count.zero?

--- a/app/workers/account_deletion_worker.rb
+++ b/app/workers/account_deletion_worker.rb
@@ -3,7 +3,7 @@
 class AccountDeletionWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'pull', lock: :until_executed
+  sidekiq_options queue: 'pull', lock: :until_executed, lock_ttl: 1.week.to_i
 
   def perform(account_id, options = {})
     reserve_username = options.with_indifferent_access.fetch(:reserve_username, true)

--- a/app/workers/activitypub/synchronize_featured_collection_worker.rb
+++ b/app/workers/activitypub/synchronize_featured_collection_worker.rb
@@ -3,7 +3,7 @@
 class ActivityPub::SynchronizeFeaturedCollectionWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'pull', lock: :until_executed
+  sidekiq_options queue: 'pull', lock: :until_executed, lock_ttl: 1.day.to_i
 
   def perform(account_id, options = {})
     options = { note: true, hashtag: false }.deep_merge(options.deep_symbolize_keys)

--- a/app/workers/activitypub/synchronize_featured_tags_collection_worker.rb
+++ b/app/workers/activitypub/synchronize_featured_tags_collection_worker.rb
@@ -3,7 +3,7 @@
 class ActivityPub::SynchronizeFeaturedTagsCollectionWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'pull', lock: :until_executed
+  sidekiq_options queue: 'pull', lock: :until_executed, lock_ttl: 1.day.to_i
 
   def perform(account_id, url)
     ActivityPub::FetchFeaturedTagsCollectionService.new.call(Account.find(account_id), url)

--- a/app/workers/activitypub/update_distribution_worker.rb
+++ b/app/workers/activitypub/update_distribution_worker.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ActivityPub::UpdateDistributionWorker < ActivityPub::RawDistributionWorker
-  sidekiq_options queue: 'push', lock: :until_executed
+  sidekiq_options queue: 'push', lock: :until_executed, lock_ttl: 1.day.to_i
 
   # Distribute an profile update to servers that might have a copy
   # of the account in question

--- a/app/workers/admin/account_deletion_worker.rb
+++ b/app/workers/admin/account_deletion_worker.rb
@@ -3,7 +3,7 @@
 class Admin::AccountDeletionWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'pull', lock: :until_executed
+  sidekiq_options queue: 'pull', lock: :until_executed, lock_ttl: 1.week.to_i
 
   def perform(account_id)
     DeleteAccountService.new.call(Account.find(account_id), reserve_username: true, reserve_email: true)

--- a/app/workers/admin/domain_purge_worker.rb
+++ b/app/workers/admin/domain_purge_worker.rb
@@ -3,7 +3,7 @@
 class Admin::DomainPurgeWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'pull', lock: :until_executed
+  sidekiq_options queue: 'pull', lock: :until_executed, lock_ttl: 1.week.to_i
 
   def perform(domain)
     PurgeDomainService.new.call(domain)

--- a/app/workers/publish_scheduled_status_worker.rb
+++ b/app/workers/publish_scheduled_status_worker.rb
@@ -3,7 +3,7 @@
 class PublishScheduledStatusWorker
   include Sidekiq::Worker
 
-  sidekiq_options lock: :until_executed
+  sidekiq_options lock: :until_executed, lock_ttl: 1.hour.to_i
 
   def perform(scheduled_status_id)
     scheduled_status = ScheduledStatus.find(scheduled_status_id)

--- a/app/workers/resolve_account_worker.rb
+++ b/app/workers/resolve_account_worker.rb
@@ -3,7 +3,7 @@
 class ResolveAccountWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'pull', lock: :until_executed
+  sidekiq_options queue: 'pull', lock: :until_executed, lock_ttl: 1.day.to_i
 
   def perform(uri)
     ResolveAccountService.new.call(uri)

--- a/app/workers/scheduler/indexing_scheduler.rb
+++ b/app/workers/scheduler/indexing_scheduler.rb
@@ -4,7 +4,7 @@ class Scheduler::IndexingScheduler
   include Sidekiq::Worker
   include Redisable
 
-  sidekiq_options retry: 0
+  sidekiq_options retry: 0, lock: :until_executed, lock_ttl: 30.minutes.to_i
 
   IMPORT_BATCH_SIZE = 1000
   SCAN_BATCH_SIZE = 10 * IMPORT_BATCH_SIZE

--- a/app/workers/scheduler/scheduled_statuses_scheduler.rb
+++ b/app/workers/scheduler/scheduled_statuses_scheduler.rb
@@ -3,7 +3,7 @@
 class Scheduler::ScheduledStatusesScheduler
   include Sidekiq::Worker
 
-  sidekiq_options retry: 0
+  sidekiq_options retry: 0, lock: :until_executed, lock_ttl: 1.hour.to_i
 
   def perform
     publish_scheduled_statuses!

--- a/app/workers/scheduler/trends/refresh_scheduler.rb
+++ b/app/workers/scheduler/trends/refresh_scheduler.rb
@@ -3,7 +3,7 @@
 class Scheduler::Trends::RefreshScheduler
   include Sidekiq::Worker
 
-  sidekiq_options retry: 0
+  sidekiq_options retry: 0, lock: :until_executed, lock_ttl: 30.minutes.to_i
 
   def perform
     Trends.refresh!

--- a/app/workers/verify_account_links_worker.rb
+++ b/app/workers/verify_account_links_worker.rb
@@ -3,7 +3,7 @@
 class VerifyAccountLinksWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'default', retry: false, lock: :until_executed
+  sidekiq_options queue: 'default', retry: false, lock: :until_executed, lock_ttl: 1.hour.to_i
 
   def perform(account_id)
     account = Account.find(account_id)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
 
   web:
     build: .
-    image: ghcr.io/mastodon/mastodon:v4.0.11
+    image: ghcr.io/mastodon/mastodon:v4.0.12
     restart: always
     env_file: .env.production
     command: bash -c "rm -f /mastodon/tmp/pids/server.pid; bundle exec rails s -p 3000"
@@ -77,7 +77,7 @@ services:
 
   streaming:
     build: .
-    image: ghcr.io/mastodon/mastodon:v4.0.11
+    image: ghcr.io/mastodon/mastodon:v4.0.12
     restart: always
     env_file: .env.production
     command: node ./streaming
@@ -95,7 +95,7 @@ services:
 
   sidekiq:
     build: .
-    image: ghcr.io/mastodon/mastodon:v4.0.11
+    image: ghcr.io/mastodon/mastodon:v4.0.12
     restart: always
     env_file: .env.production
     command: bundle exec sidekiq

--- a/lib/mastodon/version.rb
+++ b/lib/mastodon/version.rb
@@ -13,7 +13,7 @@ module Mastodon
     end
 
     def patch
-      11
+      12
     end
 
     def flags

--- a/spec/fabricators/account_stat_fabricator.rb
+++ b/spec/fabricators/account_stat_fabricator.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 Fabricator(:account_stat) do
-  account         nil
-  statuses_count  ""
-  following_count ""
-  followers_count ""
+  account { Fabricate.build(:account) }
+  statuses_count  '123'
+  following_count '456'
+  followers_count '789'
 end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -689,7 +689,7 @@ RSpec.describe Account, type: :model do
       expect(subject.match('Check this out https://medium.com/@alice/some-article#.abcdef123')).to be_nil
     end
 
-    xit 'does not match URL querystring' do
+    it 'does not match URL query string' do
       expect(subject.match('https://example.com/?x=@alice')).to be_nil
     end
   end

--- a/spec/models/relationship_filter_spec.rb
+++ b/spec/models/relationship_filter_spec.rb
@@ -6,32 +6,60 @@ describe RelationshipFilter do
   let(:account) { Fabricate(:account) }
 
   describe '#results' do
-    context 'when default params are used' do
-      let(:subject) do
-        RelationshipFilter.new(account, 'order' => 'active').results
+    let(:account_of_7_months) { Fabricate(:account_stat, statuses_count: 1, last_status_at: 7.months.ago).account }
+    let(:account_of_1_day)    { Fabricate(:account_stat, statuses_count: 1, last_status_at: 1.day.ago).account }
+    let(:account_of_3_days)   { Fabricate(:account_stat, statuses_count: 1, last_status_at: 3.days.ago).account }
+    let(:silent_account)      { Fabricate(:account_stat, statuses_count: 0, last_status_at: nil).account }
+
+    before do
+      account.follow!(account_of_7_months)
+      account.follow!(account_of_1_day)
+      account.follow!(account_of_3_days)
+      account.follow!(silent_account)
+    end
+
+    context 'when ordering by last activity' do
+      context 'when not filtering' do
+        subject do
+          described_class.new(account, 'order' => 'active').results
+        end
+
+        it 'returns followings ordered by last activity' do
+          expect(subject).to eq [account_of_1_day, account_of_3_days, account_of_7_months, silent_account]
+        end
       end
 
-      before do
-        add_following_account_with(last_status_at: 7.days.ago)
-        add_following_account_with(last_status_at: 1.day.ago)
-        add_following_account_with(last_status_at: 3.days.ago)
-      end
+      context 'when filtering for dormant accounts' do
+        subject do
+          described_class.new(account, 'order' => 'active', 'activity' => 'dormant').results
+        end
 
-      it 'returns followings ordered by last activity' do
-        expected_result = account.following.eager_load(:account_stat).reorder(nil).by_recent_status
-
-        expect(subject).to eq expected_result
+        it 'returns dormant followings ordered by last activity' do
+          expect(subject).to eq [account_of_7_months, silent_account]
+        end
       end
     end
-  end
 
-  def add_following_account_with(last_status_at:)
-    following_account = Fabricate(:account)
-    Fabricate(:account_stat, account: following_account,
-                             last_status_at: last_status_at,
-                             statuses_count: 1,
-                             following_count: 0,
-                             followers_count: 0)
-    Fabricate(:follow, account: account, target_account: following_account).account
+    context 'when ordering by account creation' do
+      context 'when not filtering' do
+        subject do
+          described_class.new(account, 'order' => 'recent').results
+        end
+
+        it 'returns followings ordered by last account creation' do
+          expect(subject).to eq [silent_account, account_of_3_days, account_of_1_day, account_of_7_months]
+        end
+      end
+
+      context 'when filtering for dormant accounts' do
+        subject do
+          described_class.new(account, 'order' => 'recent', 'activity' => 'dormant').results
+        end
+
+        it 'returns dormant followings ordered by last activity' do
+          expect(subject).to eq [silent_account, account_of_7_months]
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
### Changed

- Change some worker lock TTLs to be shorter-lived ([ClearlyClaire](https://github.com/mastodon/mastodon/pull/27246))
- Change user archive export allowed period from 7 days to 6 days ([suddjian](https://github.com/mastodon/mastodon/pull/27200))

### Fixed

- Fix mentions being matched in some URL query strings ([mjankowski](https://github.com/mastodon/mastodon/pull/25656))
- Fix multiple instances of the trend refresh scheduler sometimes running at once ([ClearlyClaire](https://github.com/mastodon/mastodon/pull/27253))
- Fix importer returning negative row estimates ([jgillich](https://github.com/mastodon/mastodon/pull/27258))
- Fix filtering audit log for entries about disabling 2FA ([ClearlyClaire](https://github.com/mastodon/mastodon/pull/27186))
- Fix tIME chunk not being properly removed from PNG uploads ([TheEssem](https://github.com/mastodon/mastodon/pull/27111))
- Fix inefficient queries in “Follows and followers” as well as several admin pages ([ClearlyClaire](https://github.com/mastodon/mastodon/pull/27116), [ClearlyClaire](https://github.com/mastodon/mastodon/pull/27306))