### PR TITLE
Run scheduled actions only on the main repo

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   compute-suffix:
     runs-on: ubuntu-latest
+    if: github.repository == 'mastodon/mastodon'
     steps:
       - id: version_vars
         env:

--- a/.github/workflows/crowdin-download.yml
+++ b/.github/workflows/crowdin-download.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   download-translations:
     runs-on: ubuntu-latest
+    if: github.repository == 'mastodon/mastodon'
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Otherwise, if you enable actions on your fork (to test things for example), then those will also run here, and fail due to permissions