### PR TITLE
Fix duplicate reports being sent when reporting some remote posts

### DIFF
--- a/app/services/report_service.rb
+++ b/app/services/report_service.rb
@@ -57,7 +57,7 @@ class ReportService < BaseService
 
   def forward_to_replied_to!
     # Send report to servers to which the account was replying to, so they also have a chance to act
-    inbox_urls = Account.remote.where(domain: forward_to_domains).where(id: Status.where(id: reported_status_ids).where.not(in_reply_to_account_id: nil).select(:in_reply_to_account_id)).inboxes - [@target_account.inbox_url]
+    inbox_urls = Account.remote.where(domain: forward_to_domains).where(id: Status.where(id: reported_status_ids).where.not(in_reply_to_account_id: nil).select(:in_reply_to_account_id)).inboxes - [@target_account.inbox_url, @target_account.shared_inbox_url]
 
     inbox_urls.each do |inbox_url|
       ActivityPub::DeliveryWorker.perform_async(payload, some_local_account.id, inbox_url)


### PR DESCRIPTION
Whenever a remote post in reply to the same server is replied to, Mastodon may send two copies of the `Flag` activity: one for the reported user, and one for people being replied to.

This is because the report is sent to the reported account's personal inbox (not changed, in case other software rely on this) and reports to replied-to users are sent using shared inbox, with the existing deduplication logic not accounting for this discrepancy.