### PR TITLE
Fix confusing screen when visiting a confirmation link for an already-confirmed email

### DIFF
--- a/app/controllers/auth/confirmations_controller.rb
+++ b/app/controllers/auth/confirmations_controller.rb
@@ -38,6 +38,12 @@ class Auth::ConfirmationsController < Devise::ConfirmationsController
     show
   end
 
+  def redirect_to_app?
+    truthy_param?(:redirect_to_app)
+  end
+
+  helper_method :redirect_to_app?
+
   private
 
   def require_captcha_if_needed!
@@ -81,7 +87,7 @@ class Auth::ConfirmationsController < Devise::ConfirmationsController
   end
 
   def after_confirmation_path_for(_resource_name, user)
-    if user.created_by_application && truthy_param?(:redirect_to_app)
+    if user.created_by_application && redirect_to_app?
       user.created_by_application.confirmation_redirect_uri
     elsif user_signed_in?
       web_url('start')

--- a/app/views/auth/confirmations/new.html.haml
+++ b/app/views/auth/confirmations/new.html.haml
@@ -1,13 +1,25 @@
 - content_for :page_title do
   = t('auth.resend_confirmation')
 
-= simple_form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|
-  = render 'shared/error_messages', object: resource
+- if resource.errors.of_kind?(:email, :already_confirmed)
+  .simple_form
+    = render 'auth/shared/progress', stage: 'completed'
 
-  .fields-group
-    = f.input :email, autofocus: true, wrapper: :with_label, label: t('simple_form.labels.defaults.email'), input_html: { 'aria-label': t('simple_form.labels.defaults.email') }, readonly: current_user.present?, hint: current_user.present? && t('auth.confirmations.wrong_email_hint')
+    %h1.title= t('auth.confirmations.welcome_title', name: resource.account.username)
+    %p.lead= t('auth.confirmations.registration_complete', domain: site_hostname)
+    - if resource.created_by_application && redirect_to_app?
+      - app = resource.created_by_application
+      %p.lead= t('auth.confirmations.redirect_to_app_html', app_name: app.name, clicking_this_link: link_to(t('auth.confirmations.clicking_this_link'), app.confirmation_redirect_uri))
+    - else
+      %p.lead= t('auth.confirmations.proceed_to_login_html', login_link: link_to_login(t('auth.confirmations.login_link')))
+- else
+  = simple_form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|
+    = render 'shared/error_messages', object: resource
 
-  .actions
-    = f.button :button, t('auth.resend_confirmation'), type: :submit
+    .fields-group
+      = f.input :email, autofocus: true, wrapper: :with_label, label: t('simple_form.labels.defaults.email'), input_html: { 'aria-label': t('simple_form.labels.defaults.email') }, readonly: current_user.present?, hint: current_user.present? && t('auth.confirmations.wrong_email_hint')
+
+    .actions
+      = f.button :button, t('auth.resend_confirmation'), type: :submit
 
 .form-footer= render 'auth/shared/links'

--- a/app/views/auth/confirmations/new.html.haml
+++ b/app/views/auth/confirmations/new.html.haml
@@ -3,15 +3,19 @@
 
 - if resource.errors.of_kind?(:email, :already_confirmed)
   .simple_form
-    = render 'auth/shared/progress', stage: 'completed'
+    = render 'auth/shared/progress', stage: resource.approved? ? 'completed' : 'confirmed'
 
-    %h1.title= t('auth.confirmations.welcome_title', name: resource.account.username)
-    %p.lead= t('auth.confirmations.registration_complete', domain: site_hostname)
-    - if resource.created_by_application && redirect_to_app?
-      - app = resource.created_by_application
-      %p.lead= t('auth.confirmations.redirect_to_app_html', app_name: app.name, clicking_this_link: link_to(t('auth.confirmations.clicking_this_link'), app.confirmation_redirect_uri))
+    - if resource.approved?
+      %h1.title= t('auth.confirmations.welcome_title', name: resource.account.username)
+      %p.lead= t('auth.confirmations.registration_complete', domain: site_hostname)
+      - if resource.created_by_application && redirect_to_app?
+        - app = resource.created_by_application
+        %p.lead= t('auth.confirmations.redirect_to_app_html', app_name: app.name, clicking_this_link: link_to(t('auth.confirmations.clicking_this_link'), app.confirmation_redirect_uri))
+      - else
+        %p.lead= t('auth.confirmations.proceed_to_login_html', login_link: link_to_login(t('auth.confirmations.login_link')))
     - else
-      %p.lead= t('auth.confirmations.proceed_to_login_html', login_link: link_to_login(t('auth.confirmations.login_link')))
+      %h1.title= t('auth.confirmations.awaiting_review_title')
+      %p.lead= t('auth.confirmations.awaiting_review', domain: site_hostname)
 - else
   = simple_form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|
     = render 'shared/error_messages', object: resource

--- a/app/views/auth/shared/_progress.html.haml
+++ b/app/views/auth/shared/_progress.html.haml
@@ -1,4 +1,4 @@
-- progress_index = { rules: 0, details: 1, confirm: 2 }[stage.to_sym]
+- progress_index = { rules: 0, details: 1, confirm: 2, completed: 3 }[stage.to_sym]
 
 %ol.progress-tracker
   %li{ class: progress_index.positive? ? 'completed' : 'active' }

--- a/app/views/auth/shared/_progress.html.haml
+++ b/app/views/auth/shared/_progress.html.haml
@@ -1,4 +1,4 @@
-- progress_index = { rules: 0, details: 1, confirm: 2, completed: 3 }[stage.to_sym]
+- progress_index = { rules: 0, details: 1, confirm: 2, confirmed: 3, completed: 4 }[stage.to_sym]
 
 %ol.progress-tracker
   %li{ class: progress_index.positive? ? 'completed' : 'active' }
@@ -20,6 +20,8 @@
     .label= t('auth.progress.confirm')
   - if approved_registrations?
     %li.separator{ class: progress_index > 2 ? 'completed' : nil }
-    %li
+    %li{ class: [progress_index > 3 && 'completed', progress_index == 3 && 'active'] }
       .circle
+        - if progress_index > 3
+          = check_icon
       .label= t('auth.progress.review')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1040,6 +1040,12 @@ en:
       hint_html: Just one more thing! We need to confirm you're a human (this is so we can keep the spam out!). Solve the CAPTCHA below and click "Continue".
       title: Security check
     confirmations:
+      clicking_this_link: clicking this link
+      login_link: log in
+      proceed_to_login_html: You can now proceed to %{login_link}.
+      redirect_to_app_html: You should have been redirected to the <strong>%{app_name}</strong> app. If that did not happen, try %{clicking_this_link} or manually return to the app.
+      registration_complete: Your registration on %{domain} is now complete!
+      welcome_title: Welcome, %{name}!
       wrong_email_hint: If that e-mail address is not correct, you can change it in account settings.
     delete_account: Delete account
     delete_account_html: If you wish to delete your account, you can <a href="%{path}">proceed here</a>. You will be asked for confirmation.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1040,6 +1040,8 @@ en:
       hint_html: Just one more thing! We need to confirm you're a human (this is so we can keep the spam out!). Solve the CAPTCHA below and click "Continue".
       title: Security check
     confirmations:
+      awaiting_review: Your e-mail address is confirmed! The %{domain} staff is now reviewing your registration. You will receive an e-mail if they approve your account!
+      awaiting_review_title: Your registration is being reviewed
       clicking_this_link: clicking this link
       login_link: log in
       proceed_to_login_html: You can now proceed to %{login_link}.

--- a/spec/features/captcha_spec.rb
+++ b/spec/features/captcha_spec.rb
@@ -30,6 +30,14 @@ describe 'email confirmation flow when captcha is enabled' do
       click_on I18n.t('challenge.confirm')
       expect(user.reload.confirmed?).to be true
       expect(page).to have_current_path(/\A#{client_app.confirmation_redirect_uri}/, url: true)
+
+      # Browsers will generally reload the original page upon redirection
+      # to external handlers, so test this as well
+      visit "/auth/confirmation?confirmation_token=#{user.confirmation_token}&redirect_to_app=true"
+
+      # It presents a page with a link to the app callback
+      expect(page).to have_content(I18n.t('auth.confirmations.registration_complete', domain: 'cb6e6126.ngrok.io'))
+      expect(page).to have_link(I18n.t('auth.confirmations.clicking_this_link'), href: client_app.confirmation_redirect_uri)
     end
   end
 end


### PR DESCRIPTION
This adds a new screen prompting to log in or go back to app when confirming registration. This is particularly useful for mobile apps, where browsers usually reload the original page in addition to prompting for the application handler.

## Before the change

![image](https://github.com/mastodon/mastodon/assets/384364/56dc87e2-4aba-40de-b462-642c50c185d0)

## After the change

### When pending moderation approval

![image](https://github.com/mastodon/mastodon/assets/384364/59e1e61f-054d-4bba-b0d7-0aa7d7bdd811)

### When registering from an app

![image](https://github.com/mastodon/mastodon/assets/384364/c601bb99-3b63-4aea-9ab1-f4fce5422dd6)

### When not registering from an app

![image](https://github.com/mastodon/mastodon/assets/384364/ae3d8525-87cd-41c2-a51c-479d3831dd51)