### PR TITLE
Update README requirements from node 14 to node 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Mastodon acts as an OAuth2 provider, so 3rd party apps can use the REST and Stre
 - **PostgreSQL** 9.5+
 - **Redis** 4+
 - **Ruby** 2.7+
-- **Node.js** 14+
+- **Node.js** 16+
 
 The repository includes deployment configurations for **Docker and docker-compose** as well as specific platforms like **Heroku**, **Scalingo**, and **Nanobox**. For Helm charts, reference the [mastodon/chart repository](https://github.com/mastodon/chart). The [**standalone** installation guide](https://docs.joinmastodon.org/admin/install/) is available in the documentation.
 


### PR DESCRIPTION
It's the required version according to [package.json](https://github.com/mastodon/mastodon/blob/main/package.json).

Since https://github.com/mastodon/mastodon/pull/25198