### PR TITLE
Change PWA start URL from `/home` to `/`

### DIFF
--- a/app/serializers/manifest_serializer.rb
+++ b/app/serializers/manifest_serializer.rb
@@ -16,10 +16,17 @@ class ManifestSerializer < ActiveModel::Serializer
     512
   ).freeze
 
-  attributes :name, :short_name,
+  attributes :id, :name, :short_name,
              :icons, :theme_color, :background_color,
              :display, :start_url, :scope,
              :share_target, :shortcuts
+
+  def id
+    # This is set to `/home` because that was the old value of `start_url` and
+    # thus the fallback ID computed by Chrome:
+    # https://developer.chrome.com/blog/pwa-manifest-id/
+    '/home'
+  end
 
   def name
     object.title
@@ -53,7 +60,7 @@ class ManifestSerializer < ActiveModel::Serializer
   end
 
   def start_url
-    '/home'
+    '/'
   end
 
   def scope


### PR DESCRIPTION
See https://github.com/mastodon/mastodon/issues/27314#issuecomment-1753242257

This lets the web UI redirect to the appropriate path when the advanced interface is enabled.