### PR TITLE
Add exclude_sensitive query parameter to /api/v1/accounts/:id/statuses

### DIFF
--- a/app/lib/account_statuses_filter.rb
+++ b/app/lib/account_statuses_filter.rb
@@ -7,6 +7,7 @@ class AccountStatusesFilter
     only_media
     exclude_replies
     exclude_reblogs
+    exclude_sensitive
   ).freeze
 
   attr_reader :params, :account, :current_account
@@ -24,7 +25,8 @@ class AccountStatusesFilter
     scope.merge!(only_media_scope) if only_media?
     scope.merge!(no_replies_scope) if exclude_replies?
     scope.merge!(no_reblogs_scope) if exclude_reblogs?
-    scope.merge!(hashtag_scope)    if tagged?
+    scope.merge!(no_sensitive_scope) if exclude_sensitive?
+    scope.merge!(hashtag_scope) if tagged?
 
     scope
   end
@@ -81,6 +83,10 @@ class AccountStatusesFilter
     Status.without_reblogs
   end
 
+  def no_sensitive_scope
+    Status.without_sensitive
+  end
+
   def pinned_scope
     account.pinned_statuses.group(Status.arel_table[:id], StatusPin.arel_table[:created_at])
   end
@@ -133,6 +139,10 @@ class AccountStatusesFilter
 
   def exclude_reblogs?
     truthy_param?(:exclude_reblogs)
+  end
+
+  def exclude_sensitive?
+    truthy_param?(:exclude_sensitive)
   end
 
   def tagged?

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -103,6 +103,7 @@ class Status < ApplicationRecord
   scope :with_accounts, ->(ids) { where(id: ids).includes(:account) }
   scope :without_replies, -> { where('statuses.reply = FALSE OR statuses.in_reply_to_account_id = statuses.account_id') }
   scope :without_reblogs, -> { where(statuses: { reblog_of_id: nil }) }
+  scope :without_sensitive, -> { where(sensitive: false) }
   scope :with_public_visibility, -> { where(visibility: :public) }
   scope :tagged_with, ->(tag_ids) { joins(:statuses_tags).where(statuses_tags: { tag_id: tag_ids }) }
   scope :excluding_silenced_accounts, -> { left_outer_joins(:account).where(accounts: { silenced_at: nil }) }

--- a/spec/controllers/api/v1/accounts/statuses_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/statuses_controller_spec.rb
@@ -10,11 +10,11 @@ describe Api::V1::Accounts::StatusesController do
 
   before do
     allow(controller).to receive(:doorkeeper_token) { token }
-    Fabricate(:status, account: user.account)
   end
 
   describe 'GET #index' do
     it 'returns expected headers', :aggregate_failures do
+      Fabricate(:status, account: user.account)
       get :index, params: { account_id: user.account.id, limit: 1 }
 
       expect(response).to have_http_status(200)
@@ -30,7 +30,6 @@ describe Api::V1::Accounts::StatusesController do
     end
 
     context 'with exclude replies' do
-      let!(:older_statuses) { user.account.statuses.destroy_all }
       let!(:status) { Fabricate(:status, account: user.account) }
       let!(:status_self_reply) { Fabricate(:status, account: user.account, thread: status) }
 
@@ -45,6 +44,25 @@ describe Api::V1::Accounts::StatusesController do
 
         expect(response).to have_http_status(200)
         expect(post_ids).to eq [status.id, status_self_reply.id]
+      end
+    end
+
+    context 'with exclude sensitive' do
+      let!(:sensitive_status) { Fabricate(:status, sensitive: true, account: user.account) }
+      let!(:insensitive_status) { Fabricate(:status, account: user.account) }
+
+      before do
+        get :index, params: { account_id: user.account.id, exclude_sensitive: true }
+      end
+
+      it 'returns http success' do
+        expect(response).to have_http_status(200)
+      end
+
+      it 'does not return posts marked sensitive' do
+        json = body_as_json
+        post_ids = json.map { |item| item[:id].to_i }.sort
+        expect(post_ids).to eq [insensitive_status.id]
       end
     end
 

--- a/spec/lib/account_statuses_filter_spec.rb
+++ b/spec/lib/account_statuses_filter_spec.rb
@@ -17,6 +17,10 @@ RSpec.describe AccountStatusesFilter do
     Fabricate(:status, account: account, visibility: visibility, tags: [tag])
   end
 
+  def status_with_sensitive_content!(visibility)
+    Fabricate(:status, account: account, visibility: visibility, sensitive: true)
+  end
+
   def status_with_parent!(visibility)
     Fabricate(:status, account: account, visibility: visibility, thread: Fabricate(:status))
   end
@@ -46,6 +50,7 @@ RSpec.describe AccountStatusesFilter do
       status!(:private)
       status_with_parent!(:public)
       status_with_reblog!(:public)
+      status_with_sensitive_content!(:public)
       status_with_tag!(:public, tag)
       status_with_mention!(:direct)
       status_with_media_attachment!(:public)
@@ -81,6 +86,14 @@ RSpec.describe AccountStatusesFilter do
 
         it 'returns only statuses that are not reblogs' do
           expect(subject.results.none?(&:reblog?)).to be true
+        end
+      end
+
+      context 'with exclude sensitive param' do
+        let(:params) { { exclude_sensitive: true } }
+
+        it 'does not return sensitive statuses' do
+          expect(subject.results.none?(&:sensitive?)).to be true
         end
       end
     end


### PR DESCRIPTION
Fixes #26903
Adds a new query parameter - `exclude_sensitive` to /api/v1/accounts/:id/statuses that filters out sensitive statuses in the response.

The PR documenting this change is [created.](https://github.com/mastodon/documentation/pull/1321)