### PR TITLE
Add expiry option of 1 month to Custom Filters

### DIFF
--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -5,6 +5,10 @@ module SettingsHelper
     LanguagesHelper.sorted_locale_keys(LanguagesHelper::SUPPORTED_LOCALES.keys)
   end
 
+  def filter_expires_in_options
+    CustomFilter.expires_in_options
+  end
+
   def ui_languages
     LanguagesHelper.sorted_locale_keys(I18n.available_locales)
   end

--- a/app/models/custom_filter.rb
+++ b/app/models/custom_filter.rb
@@ -51,7 +51,7 @@ class CustomFilter < ApplicationRecord
     return @expires_in if defined?(@expires_in)
     return nil if expires_at.nil?
 
-    [30.minutes, 1.hour, 6.hours, 12.hours, 1.day, 1.week].find { |expires_in| expires_in.from_now >= expires_at }
+    CustomFilter.expires_in_options.find { |expires_in| expires_in.from_now >= expires_at }
   end
 
   def irreversible=(value)
@@ -60,6 +60,10 @@ class CustomFilter < ApplicationRecord
 
   def irreversible?
     hide_action?
+  end
+
+  def self.expires_in_options
+    [30.minutes, 1.hour, 6.hours, 12.hours, 1.day, 1.week, 1.month]
   end
 
   def self.cached_filters_for(account_id)

--- a/app/views/filters/_filter.html.haml
+++ b/app/views/filters/_filter.html.haml
@@ -5,7 +5,7 @@
     - if filter.expires?
       .expiration{ title: t('filters.index.expires_on', date: l(filter.expires_at)) }
         - if filter.expired?
-          = t('invites.expired')
+          = t('filters.expired')
         - else
           = t('filters.index.expires_in', distance: distance_of_time_in_words_to_now(filter.expires_at))
 

--- a/app/views/filters/_filter_fields.html.haml
+++ b/app/views/filters/_filter_fields.html.haml
@@ -2,7 +2,7 @@
   .fields-row__column.fields-row__column-6.fields-group
     = f.input :title, as: :string, wrapper: :with_label, hint: false
   .fields-row__column.fields-row__column-6.fields-group
-    = f.input :expires_in, wrapper: :with_label, collection: [30.minutes, 1.hour, 6.hours, 12.hours, 1.day, 1.week].map(&:to_i), label_method: ->(i) { I18n.t("invites.expires_in.#{i}") }, include_blank: I18n.t('invites.expires_in_prompt')
+    = f.input :expires_in, wrapper: :with_label, collection: filter_expires_in_options.map(&:to_i), label_method: ->(i) { I18n.t("filters.expires_in.#{i}") }, include_blank: I18n.t('filters.expires_in_prompt')
 
 .fields-group
   = f.input :context, wrapper: :with_block_label, collection: CustomFilter::VALID_CONTEXTS, as: :check_boxes, collection_wrapper_tag: 'ul', item_wrapper_tag: 'li', label_method: ->(context) { I18n.t("filters.contexts.#{context}") }, include_blank: false

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1238,6 +1238,16 @@ en:
     errors:
       deprecated_api_multiple_keywords: These parameters cannot be changed from this application because they apply to more than one filter keyword. Use a more recent application or the web interface.
       invalid_context: None or invalid context supplied
+    expired: Expired
+    expires_in:
+      '1800': 30 minutes
+      '21600': 6 hours
+      '2629746': 1 month
+      '3600': 1 hour
+      '43200': 12 hours
+      '604800': 1 week
+      '86400': 1 day
+    expires_in_prompt: Never
     index:
       contexts: Filters in %{contexts}
       delete: Delete

--- a/spec/helpers/settings_helper_spec.rb
+++ b/spec/helpers/settings_helper_spec.rb
@@ -3,6 +3,12 @@
 require 'rails_helper'
 
 describe SettingsHelper do
+  describe 'filter_expires_in_options' do
+    it 'has 7 values' do
+      expect(helper.filter_expires_in_options.size).to eq(7)
+    end
+  end
+
   describe 'session_device_icon' do
     context 'with a mobile device' do
       let(:session) { SessionActivation.new(user_agent: 'Mozilla/5.0 (iPhone)') }


### PR DESCRIPTION
Given current world events, some of them will remain fairly traumatizing for longer than the current filter expiry options, as such I've added the option to expire them after one month as well.

This PR also:
- centralises the options to the CustomFilter model
- sets the localisation values from the `filters.*` keys, despite these being mostly the same as `invites.*` it's important to have clean separation between features.

There's currently no direct test coverage I could see for the CustomFilter model, and I think adding it would likely be out of scope of this PR.