### PR TITLE
Improve Github Actions Job concurrency

### DIFF
--- a/.github/workflows/build-push-pr.yml
+++ b/.github/workflows/build-push-pr.yml
@@ -3,6 +3,10 @@ on:
   pull_request:
     types: [labeled, synchronize, reopened, ready_for_review, opened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   packages: write

--- a/.github/workflows/bundler-audit.yml
+++ b/.github/workflows/bundler-audit.yml
@@ -19,6 +19,10 @@ on:
   schedule:
     - cron: '0 5 * * 1'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   security:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-i18n.yml
+++ b/.github/workflows/check-i18n.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 env:
   RAILS_ENV: test
 

--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -14,6 +14,10 @@ on:
       - config/locales/doorkeeper.en.yml
       - .github/workflows/crowdin-upload.yml
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   upload-translations:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-css.yml
+++ b/.github/workflows/lint-css.yml
@@ -27,6 +27,10 @@ on:
       - '.github/workflows/lint-css.yml'
       - '.github/stylelint-matcher.json'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-haml.yml
+++ b/.github/workflows/lint-haml.yml
@@ -23,6 +23,10 @@ on:
       - '**/*.haml'
       - 'Gemfile*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -31,6 +31,10 @@ on:
       - '**/*.tsx'
       - '.github/workflows/lint-js.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-json.yml
+++ b/.github/workflows/lint-json.yml
@@ -23,6 +23,10 @@ on:
       - '.github/workflows/lint-json.yml'
       - '!app/javascript/mastodon/locales/*.json'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-md.yml
+++ b/.github/workflows/lint-md.yml
@@ -23,6 +23,10 @@ on:
       - 'package.json'
       - 'yarn.lock'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-ruby.yml
+++ b/.github/workflows/lint-ruby.yml
@@ -23,6 +23,10 @@ on:
       - '**/*.rake'
       - '.github/workflows/lint-ruby.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-yml.yml
+++ b/.github/workflows/lint-yml.yml
@@ -25,6 +25,10 @@ on:
       - '.github/workflows/lint-yml.yml'
       - '!config/locales/*.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-image-build.yml
+++ b/.github/workflows/test-image-build.yml
@@ -7,6 +7,11 @@ on:
       - .github/workflows/build-releases.yml
       - .github/workflows/test-image-build.yml
       - Dockerfile
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/test-image-build.yml
+++ b/.github/workflows/test-image-build.yml
@@ -8,17 +8,13 @@ on:
       - .github/workflows/test-image-build.yml
       - Dockerfile
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.sha || github.ref }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
 
 jobs:
   build-image:
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.sha || github.ref }}
       cancel-in-progress: true
 
     uses: ./.github/workflows/build-container-image.yml

--- a/.github/workflows/test-js.yml
+++ b/.github/workflows/test-js.yml
@@ -27,6 +27,10 @@ on:
       - '**/*.snap'
       - '.github/workflows/test-js.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-migrations-one-step.yml
+++ b/.github/workflows/test-migrations-one-step.yml
@@ -6,6 +6,10 @@ on:
       - 'renovate/**'
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pre_job:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-migrations-two-step.yml
+++ b/.github/workflows/test-migrations-two-step.yml
@@ -6,6 +6,10 @@ on:
       - 'renovate/**'
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pre_job:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -12,7 +12,7 @@ env:
   BUNDLE_FROZEN: true
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.sha || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Adds concurrency control to all jobs, and prevents concurrency from cancelling jobs when multiple PRs are merged in succession.

The expression used here is based on the example at: https://docs.github.com/en/actions/learn-github-actions/expressions#example