### PR TITLE
Add audit logs to Admin::InstancesController

### DIFF
--- a/app/controllers/admin/instances_controller.rb
+++ b/app/controllers/admin/instances_controller.rb
@@ -13,6 +13,7 @@ module Admin
     def show
       authorize :instance, :show?
       @time_period = (6.days.ago.to_date...Time.now.utc.to_date)
+      @action_logs = Admin::ActionLogFilter.new(target_domain: @instance.domain).results.limit(5)
     end
 
     def destroy

--- a/app/models/admin/action_log_filter.rb
+++ b/app/models/admin/action_log_filter.rb
@@ -5,6 +5,14 @@ class Admin::ActionLogFilter
     action_type
     account_id
     target_account_id
+    target_domain
+  ).freeze
+
+  INSTANCE_TARGET_TYPES = %w(
+    DomainBlock
+    DomainAllow
+    Instance
+    UnavailableDomain
   ).freeze
 
   ACTION_TYPE_MAP = {
@@ -95,6 +103,9 @@ class Admin::ActionLogFilter
     when 'target_account_id'
       account = Account.find_or_initialize_by(id: value)
       latest_action_logs.where(target: [account, account.user].compact)
+    when 'target_domain'
+      normalized_domain = TagManager.instance.normalize_domain(value)
+      latest_action_logs.where(human_identifier: normalized_domain, target_type: INSTANCE_TARGET_TYPES)
     else
       raise Mastodon::InvalidParameterError, "Unknown filter: #{key}"
     end

--- a/app/views/admin/instances/show.html.haml
+++ b/app/views/admin/instances/show.html.haml
@@ -114,6 +114,16 @@
 - if @instance.persisted?
   %hr.spacer/
 
+  %h3= t('admin.instances.audit_log.title')
+  - if @action_logs.empty?
+    %p= t('accounts.nothing_here')
+  - else
+    .report-notes
+      = render partial: 'admin/action_logs/action_log', collection: @action_logs
+    = link_to t('admin.instances.audit_log.view_all'), admin_action_logs_path(target_domain: @instance.domain), class: 'button'
+
+  %hr.spacer/
+
   %h3= t('admin.instances.availability.title')
 
   %p

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -471,6 +471,9 @@ en:
       title: Follow recommendations
       unsuppress: Restore follow recommendation
     instances:
+      audit_log:
+        title: Recent Audit Logs
+        view_all: View full audit logs
       availability:
         description_html:
           one: If delivering to the domain fails <strong>%{count} day</strong> without succeeding, no further delivery attempts will be made unless a delivery <em>from</em> the domain is received.

--- a/spec/controllers/admin/instances_controller_spec.rb
+++ b/spec/controllers/admin/instances_controller_spec.rb
@@ -37,10 +37,32 @@ RSpec.describe Admin::InstancesController do
   end
 
   describe 'GET #show' do
+    before do
+      allow(Admin::ActionLogFilter).to receive(:new).and_call_original
+    end
+
     it 'shows an instance page' do
       get :show, params: { id: account_popular_main.domain }
 
       expect(response).to have_http_status(200)
+
+      instance = assigns(:instance)
+      expect(instance).to_not be_new_record
+
+      expect(Admin::ActionLogFilter).to have_received(:new).with(target_domain: account_popular_main.domain)
+
+      action_logs = assigns(:action_logs).to_a
+      expect(action_logs.size).to eq 0
+    end
+
+    context 'with an unknown domain' do
+      it 'returns http success' do
+        get :show, params: { id: 'unknown.example' }
+        expect(response).to have_http_status(200)
+
+        instance = assigns(:instance)
+        expect(instance).to be_new_record
+      end
     end
   end
 


### PR DESCRIPTION
This allows an administrator or moderator to see the latest 5 audit logs for an instance's domain, from the instance details:

![](https://user-images.githubusercontent.com/30827/270827808-a49963ce-8d22-4b63-bb6f-4936f91b4089.png)

![](https://user-images.githubusercontent.com/30827/270828004-afdc6874-1f78-4d3b-ab35-4cdb06582b4e.png)

This was originally mentioned in #27150 which was a follow up to #27139, @ClearlyClaire noted that we'd need an additional index on the `human_identifier` column in `admin_action_logs`, which we're using because `instances` isn't actually a table with IDs, but instead a view of all known instance domains (currently there's no index on `human_identifier` in `Admin::ActionLogs`).

An alternative to using `human_identifier` would be to enable an index on the `route_param` value, and then have a migration to backfill that column for all `Admin::ActionLogs` that target domains. We'd also need to change `DomainBlock`, `DomainAllow`, `Instance` and `UnavailableDomain` models all to have a `to_log_route_param` method defined.