### PR TITLE
Fix when unfollow a tag, my post also disappears from the home timeline

### DIFF
--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -192,6 +192,7 @@ class FeedManager
     # also tagged with another followed hashtag or from a followed user
     scope = from_tag.statuses
                     .where(id: timeline_status_ids)
+                    .where.not(account: into_account)
                     .where.not(account: into_account.following)
                     .tagged_with_none(TagFollow.where(account: into_account).pluck(:tag_id))
 


### PR DESCRIPTION
When I unfollow a tag, at the same time the posts using that tag are removed from my home timeline. The exception to this is that the posts of the people I am following are not deleted. However, my own posts will be deleted.
Fixed this.