### PR TITLE
Change Rails' cache format to 7.0

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -64,13 +64,6 @@ module Mastodon
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
 
-    # TODO: Release a version which uses the 7.0 defaults as specified above,
-    # but preserves the 6.1 cache format as set below. In a subsequent change,
-    # remove this line setting to 6.1 cache format, and then release another version.
-    # https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#new-activesupport-cache-serialization-format
-    # https://github.com/mastodon/mastodon/pull/24241#discussion_r1162890242
-    config.active_support.cache_format_version = 6.1
-
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.


### PR DESCRIPTION
~~This will require a note in the update notes to either do go through 4.2.x or to fully stop all services before restarting them.~~ because #28609 changed the namespace, it is no longer necessary to either fully stop all services or go through 4.2.x

Fixes #27757