### PR TITLE
Fix empty ENV variables not using default nil value

### DIFF
--- a/config/initializers/chewy.rb
+++ b/config/initializers/chewy.rb
@@ -3,9 +3,9 @@
 enabled         = ENV['ES_ENABLED'] == 'true'
 host            = ENV.fetch('ES_HOST') { 'localhost' }
 port            = ENV.fetch('ES_PORT') { 9200 }
-user            = ENV.fetch('ES_USER') { nil }
-password        = ENV.fetch('ES_PASS') { nil }
-fallback_prefix = ENV.fetch('REDIS_NAMESPACE') { nil }
+user            = ENV.fetch('ES_USER', nil).presence
+password        = ENV.fetch('ES_PASS', nil).presence
+fallback_prefix = ENV.fetch('REDIS_NAMESPACE', nil).presence
 prefix          = ENV.fetch('ES_PREFIX') { fallback_prefix }
 
 Chewy.settings = {

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -394,7 +394,7 @@ Devise.setup do |config|
     config.check_at_sign          = true
     config.pam_default_suffix     = ENV.fetch('PAM_EMAIL_DOMAIN') { ENV['LOCAL_DOMAIN'] }
     config.pam_default_service    = ENV.fetch('PAM_DEFAULT_SERVICE') { 'rpam' }
-    config.pam_controlled_service = ENV.fetch('PAM_CONTROLLED_SERVICE') { nil }
+    config.pam_controlled_service = ENV.fetch('PAM_CONTROLLED_SERVICE', nil).presence
   end
 
   if ENV['LDAP_ENABLED'] == 'true'


### PR DESCRIPTION
Without this fix, `ES_USER=` configures an empty string for `ES_USER`, but the code expects a `nil` value when not set

This results in `:` in the authorization header (empty password + empty username), which does not work with ES.

I also fixed a similar issue for PAM config