### PR TITLE
Improve keyboard accessibility of About Page section component using buttons

### DIFF
--- a/app/javascript/mastodon/features/about/index.jsx
+++ b/app/javascript/mastodon/features/about/index.jsx
@@ -62,10 +62,11 @@ class Section extends PureComponent {
     collapsed: !this.props.open,
   };
 
-  handleClick = (e) => {
+  handleClick = () => {
     const { onOpen } = this.props;
-    
-    this.setState({ collapsed: !e.currentTarget.open }, () => onOpen && onOpen());
+    const { collapsed } = this.state;
+
+    this.setState({ collapsed: !collapsed }, () => onOpen && onOpen());
   };
 
   render () {
@@ -73,13 +74,15 @@ class Section extends PureComponent {
     const { collapsed } = this.state;
 
     return (
-      <details open={!collapsed} onToggle={this.handleClick} className={classNames('about__section', { active: !collapsed })}>
-        <summary className='about__section__title'>
+      <div className={classNames('about__section', { active: !collapsed })}>
+        <button aria-expanded={!collapsed} onClick={this.handleClick} className='about__section__title'>
           <Icon id={collapsed ? 'chevron-right' : 'chevron-down'} icon={collapsed ? ChevronRightIcon : ExpandMoreIcon} /> {title}
-        </summary>
+        </button>
 
-        <div className='about__section__body'>{children}</div>
-      </details>
+        {!collapsed && (
+          <div className='about__section__body'>{children}</div>
+        )}
+      </div>
     );
   }
 

--- a/app/javascript/mastodon/features/about/index.jsx
+++ b/app/javascript/mastodon/features/about/index.jsx
@@ -62,11 +62,10 @@ class Section extends PureComponent {
     collapsed: !this.props.open,
   };
 
-  handleClick = () => {
+  handleClick = (e) => {
     const { onOpen } = this.props;
-    const { collapsed } = this.state;
-
-    this.setState({ collapsed: !collapsed }, () => onOpen && onOpen());
+    
+    this.setState({ collapsed: !e.currentTarget.open }, () => onOpen && onOpen());
   };
 
   render () {
@@ -74,7 +73,7 @@ class Section extends PureComponent {
     const { collapsed } = this.state;
 
     return (
-      <details open={!collapsed} onOpen={this.handleClick} className={classNames('about__section', { active: !collapsed })}>
+      <details open={!collapsed} onToggle={this.handleClick} className={classNames('about__section', { active: !collapsed })}>
         <summary className='about__section__title'>
           <Icon id={collapsed ? 'chevron-right' : 'chevron-down'} icon={collapsed ? ChevronRightIcon : ExpandMoreIcon} /> {title}
         </summary>

--- a/app/javascript/mastodon/features/about/index.jsx
+++ b/app/javascript/mastodon/features/about/index.jsx
@@ -74,15 +74,13 @@ class Section extends PureComponent {
     const { collapsed } = this.state;
 
     return (
-      <div className={classNames('about__section', { active: !collapsed })}>
-        <div className='about__section__title' role='button' tabIndex={0} onClick={this.handleClick}>
+      <details open={!collapsed} onOpen={this.handleClick} className={classNames('about__section', { active: !collapsed })}>
+        <summary className='about__section__title'>
           <Icon id={collapsed ? 'chevron-right' : 'chevron-down'} icon={collapsed ? ChevronRightIcon : ExpandMoreIcon} /> {title}
-        </div>
+        </summary>
 
-        {!collapsed && (
-          <div className='about__section__body'>{children}</div>
-        )}
-      </div>
+        <div className='about__section__body'>{children}</div>
+      </details>
     );
   }
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -9146,11 +9146,8 @@ noscript {
       background: lighten($ui-base-color, 4%);
       color: $highlight-text-color;
       cursor: pointer;
-      list-style: none;
-    }
-
-    &__title::-webkit-details-marker {
-      display: none;
+      border: unset;
+      width: 100%;
     }
 
     &.active &__title {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -9146,6 +9146,11 @@ noscript {
       background: lighten($ui-base-color, 4%);
       color: $highlight-text-color;
       cursor: pointer;
+      list-style: none;
+    }
+
+    &__title::-webkit-details-marker {
+      display: none;
     }
 
     &.active &__title {


### PR DESCRIPTION
On the **/about** page

<img width="570" alt="Collapsible sections on the mastodon about page" src="https://github.com/mastodon/mastodon/assets/85184231/cb9d53b8-ebe3-4489-9703-4e9811e676a7">

The section were not usable with a keyboard interface because only a `onClick` was present, and they were not conveying their current state (expanded or collapsed) 

I used the [details](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details) element to improve that, it's well supported
