### PR TITLE
Fixes #23135 - Allow cross origin request for /nodeinfo/2.0 API

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -14,6 +14,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
     with_options headers: :any, credentials: false do
       with_options methods: [:get] do
         resource '/.well-known/*'
+        resource '/nodeinfo/*'
         resource '/@:username'
         resource '/users/:username'
       end


### PR DESCRIPTION
As noted in #23135, missing CORS headers on `/nodeinfo/2.0` endpoint are an issue for any web pages supposed to work with different Fediverse applications. While the proper approach to determine the software running on a Fediverse instance would be downloading `/.well-known/nodeinfo` and then `/nodeinfo/2.0`, the latter currently fails for Mastodon. I’ve hit this issue myself when implementing “Share to Fediverse” functionality.

Adding CORS headers for `/nodeinfo/2.0` is trivial. And given that the information produced is public, there is no reason CORS headers shouldn’t be there.