### PR TITLE
Fix `Capybara/ClickLinkOrButtonStyle` cop in spec/features/admin area

### DIFF
--- a/spec/features/admin/accounts_spec.rb
+++ b/spec/features/admin/accounts_spec.rb
@@ -22,7 +22,7 @@ describe 'Admin::Accounts' do
 
     context 'without selecting any accounts' do
       it 'displays a notice about account selection' do
-        click_on button_for_suspend
+        click_button button_for_suspend
 
         expect(page).to have_content(selection_error_text)
       end
@@ -32,7 +32,7 @@ describe 'Admin::Accounts' do
       it 'suspends the account' do
         batch_checkbox_for(approved_user_account).check
 
-        click_on button_for_suspend
+        click_button button_for_suspend
 
         expect(approved_user_account.reload).to be_suspended
       end
@@ -42,7 +42,7 @@ describe 'Admin::Accounts' do
       it 'approves the account user' do
         batch_checkbox_for(unapproved_user_account).check
 
-        click_on button_for_approve
+        click_button button_for_approve
 
         expect(unapproved_user_account.reload.user).to be_approved
       end
@@ -52,7 +52,7 @@ describe 'Admin::Accounts' do
       it 'rejects and removes the account' do
         batch_checkbox_for(unapproved_user_account).check
 
-        click_on button_for_reject
+        click_button button_for_reject
 
         expect { unapproved_user_account.reload }.to raise_error(ActiveRecord::RecordNotFound)
       end

--- a/spec/features/admin/custom_emojis_spec.rb
+++ b/spec/features/admin/custom_emojis_spec.rb
@@ -16,7 +16,7 @@ describe 'Admin::CustomEmojis' do
 
     context 'without selecting any records' do
       it 'displays a notice about selection' do
-        click_on button_for_enable
+        click_button button_for_enable
 
         expect(page).to have_content(selection_error_text)
       end

--- a/spec/features/admin/email_domain_blocks_spec.rb
+++ b/spec/features/admin/email_domain_blocks_spec.rb
@@ -16,7 +16,7 @@ describe 'Admin::EmailDomainBlocks' do
 
     context 'without selecting any records' do
       it 'displays a notice about selection' do
-        click_on button_for_delete
+        click_button button_for_delete
 
         expect(page).to have_content(selection_error_text)
       end

--- a/spec/features/admin/ip_blocks_spec.rb
+++ b/spec/features/admin/ip_blocks_spec.rb
@@ -16,7 +16,7 @@ describe 'Admin::IpBlocks' do
 
     context 'without selecting any records' do
       it 'displays a notice about selection' do
-        click_on button_for_delete
+        click_button button_for_delete
 
         expect(page).to have_content(selection_error_text)
       end

--- a/spec/features/admin/statuses_spec.rb
+++ b/spec/features/admin/statuses_spec.rb
@@ -17,7 +17,7 @@ describe 'Admin::Statuses' do
 
     context 'without selecting any records' do
       it 'displays a notice about selection' do
-        click_on button_for_report
+        click_button button_for_report
 
         expect(page).to have_content(selection_error_text)
       end

--- a/spec/features/admin/trends/links/preview_card_providers_spec.rb
+++ b/spec/features/admin/trends/links/preview_card_providers_spec.rb
@@ -16,7 +16,7 @@ describe 'Admin::Trends::Links::PreviewCardProviders' do
 
     context 'without selecting any records' do
       it 'displays a notice about selection' do
-        click_on button_for_allow
+        click_button button_for_allow
 
         expect(page).to have_content(selection_error_text)
       end

--- a/spec/features/admin/trends/links_spec.rb
+++ b/spec/features/admin/trends/links_spec.rb
@@ -16,7 +16,7 @@ describe 'Admin::Trends::Links' do
 
     context 'without selecting any records' do
       it 'displays a notice about selection' do
-        click_on button_for_allow
+        click_button button_for_allow
 
         expect(page).to have_content(selection_error_text)
       end

--- a/spec/features/admin/trends/statuses_spec.rb
+++ b/spec/features/admin/trends/statuses_spec.rb
@@ -16,7 +16,7 @@ describe 'Admin::Trends::Statuses' do
 
     context 'without selecting any records' do
       it 'displays a notice about selection' do
-        click_on button_for_allow
+        click_button button_for_allow
 
         expect(page).to have_content(selection_error_text)
       end

--- a/spec/features/admin/trends/tags_spec.rb
+++ b/spec/features/admin/trends/tags_spec.rb
@@ -16,7 +16,7 @@ describe 'Admin::Trends::Tags' do
 
     context 'without selecting any records' do
       it 'displays a notice about selection' do
-        click_on button_for_allow
+        click_button button_for_allow
 
         expect(page).to have_content(selection_error_text)
       end


### PR DESCRIPTION
There are failures after merging https://github.com/mastodon/mastodon/pull/26982 because I did not rebase this one - https://github.com/mastodon/mastodon/pull/25027 - after the first was merged.

This updates the missed violations.