### PR TITLE
Fix `Naming/VariableNumber` cop

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -86,20 +86,6 @@ Metrics/CyclomaticComplexity:
 Metrics/PerceivedComplexity:
   Max: 27
 
-# Configuration parameters: EnforcedStyle, CheckMethodNames, CheckSymbols, AllowedIdentifiers, AllowedPatterns.
-# SupportedStyles: snake_case, normalcase, non_integer
-# AllowedIdentifiers: capture3, iso8601, rfc1123_date, rfc822, rfc2822, rfc3339, x86_64
-Naming/VariableNumber:
-  Exclude:
-    - 'db/migrate/20180106000232_add_index_on_statuses_for_api_v1_accounts_account_id_statuses.rb'
-    - 'db/migrate/20180514140000_revert_index_change_on_statuses_for_api_v1_accounts_account_id_statuses.rb'
-    - 'db/migrate/20190820003045_update_statuses_index.rb'
-    - 'db/migrate/20190823221802_add_local_index_to_statuses.rb'
-    - 'db/migrate/20200119112504_add_public_index_to_statuses.rb'
-    - 'spec/models/account_spec.rb'
-    - 'spec/models/domain_block_spec.rb'
-    - 'spec/models/user_spec.rb'
-
 Performance/MapMethodChain:
   Exclude:
     - 'app/models/feed.rb'

--- a/db/migrate/.rubocop.yml
+++ b/db/migrate/.rubocop.yml
@@ -1,0 +1,4 @@
+inherit_from: ../../.rubocop.yml
+
+Naming/VariableNumber:
+  CheckSymbols: false

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -719,10 +719,10 @@ RSpec.describe Account do
 
     context 'when is local' do
       it 'is invalid if the username is not unique in case-insensitive comparison among local accounts' do
-        account_1 = Fabricate(:account, username: 'the_doctor')
-        account_2 = Fabricate.build(:account, username: 'the_Doctor')
-        account_2.valid?
-        expect(account_2).to model_have_error_on_field(:username)
+        _account = Fabricate(:account, username: 'the_doctor')
+        non_unique_account = Fabricate.build(:account, username: 'the_Doctor')
+        non_unique_account.valid?
+        expect(non_unique_account).to model_have_error_on_field(:username)
       end
 
       it 'is invalid if the username is reserved' do
@@ -743,9 +743,9 @@ RSpec.describe Account do
       end
 
       it 'is valid if we are creating a possibly-conflicting instance actor account' do
-        account_1 = Fabricate(:account, username: 'examplecom')
-        account_2 = Fabricate.build(:account, id: -99, actor_type: 'Application', locked: true, username: 'example.com')
-        expect(account_2.valid?).to be true
+        _account = Fabricate(:account, username: 'examplecom')
+        instance_account = Fabricate.build(:account, id: -99, actor_type: 'Application', locked: true, username: 'example.com')
+        expect(instance_account.valid?).to be true
       end
 
       it 'is invalid if the username doesn\'t only contains letters, numbers and underscores' do
@@ -877,17 +877,17 @@ RSpec.describe Account do
 
     describe 'remote' do
       it 'returns an array of accounts who have a domain' do
-        account_1 = Fabricate(:account, domain: nil)
-        account_2 = Fabricate(:account, domain: 'example.com')
-        expect(described_class.remote).to contain_exactly(account_2)
+        _account = Fabricate(:account, domain: nil)
+        account_with_domain = Fabricate(:account, domain: 'example.com')
+        expect(described_class.remote).to contain_exactly(account_with_domain)
       end
     end
 
     describe 'local' do
       it 'returns an array of accounts who do not have a domain' do
-        account_1 = Fabricate(:account, domain: nil)
-        account_2 = Fabricate(:account, domain: 'example.com')
-        expect(described_class.where('id > 0').local).to contain_exactly(account_1)
+        local_account = Fabricate(:account, domain: nil)
+        _account_with_domain = Fabricate(:account, domain: 'example.com')
+        expect(described_class.where('id > 0').local).to contain_exactly(local_account)
       end
     end
 
@@ -911,17 +911,17 @@ RSpec.describe Account do
 
     describe 'silenced' do
       it 'returns an array of accounts who are silenced' do
-        account_1 = Fabricate(:account, silenced: true)
-        account_2 = Fabricate(:account, silenced: false)
-        expect(described_class.silenced).to contain_exactly(account_1)
+        silenced_account = Fabricate(:account, silenced: true)
+        _account = Fabricate(:account, silenced: false)
+        expect(described_class.silenced).to contain_exactly(silenced_account)
       end
     end
 
     describe 'suspended' do
       it 'returns an array of accounts who are suspended' do
-        account_1 = Fabricate(:account, suspended: true)
-        account_2 = Fabricate(:account, suspended: false)
-        expect(described_class.suspended).to contain_exactly(account_1)
+        suspended_account = Fabricate(:account, suspended: true)
+        _account = Fabricate(:account, suspended: false)
+        expect(described_class.suspended).to contain_exactly(suspended_account)
       end
     end
 

--- a/spec/models/domain_block_spec.rb
+++ b/spec/models/domain_block_spec.rb
@@ -11,10 +11,10 @@ RSpec.describe DomainBlock do
     end
 
     it 'is invalid if the same normalized domain already exists' do
-      domain_block_1 = Fabricate(:domain_block, domain: 'にゃん')
-      domain_block_2 = Fabricate.build(:domain_block, domain: 'xn--r9j5b5b')
-      domain_block_2.valid?
-      expect(domain_block_2).to model_have_error_on_field(:domain)
+      _domain_block = Fabricate(:domain_block, domain: 'にゃん')
+      domain_block_with_normalized_value = Fabricate.build(:domain_block, domain: 'xn--r9j5b5b')
+      domain_block_with_normalized_value.valid?
+      expect(domain_block_with_normalized_value).to model_have_error_on_field(:domain)
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -55,17 +55,17 @@ RSpec.describe User do
   describe 'scopes' do
     describe 'recent' do
       it 'returns an array of recent users ordered by id' do
-        user_1 = Fabricate(:user)
-        user_2 = Fabricate(:user)
-        expect(described_class.recent).to eq [user_2, user_1]
+        first_user = Fabricate(:user)
+        second_user = Fabricate(:user)
+        expect(described_class.recent).to eq [second_user, first_user]
       end
     end
 
     describe 'confirmed' do
       it 'returns an array of users who are confirmed' do
-        user_1 = Fabricate(:user, confirmed_at: nil)
-        user_2 = Fabricate(:user, confirmed_at: Time.zone.now)
-        expect(described_class.confirmed).to contain_exactly(user_2)
+        unconfirmed_user = Fabricate(:user, confirmed_at: nil)
+        confirmed_user = Fabricate(:user, confirmed_at: Time.zone.now)
+        expect(described_class.confirmed).to contain_exactly(confirmed_user)
       end
     end
 


### PR DESCRIPTION
Two changes:

- In the specs, use better named variables.
- Add rubocop config for db/migrate to disable the symbol check so valid index names don't get flagged