### PR TITLE
Only enable github-rspec for pull_request events

### DIFF
--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -113,7 +113,7 @@ jobs:
       CAS_ENABLED: true
       BUNDLE_WITH: 'pam_authentication test'
       CI_JOBS: ${{ matrix.ci_job }}/4
-      GITHUB_RSPEC: ${{ matrix.ruby-version == '.ruby-version' }}
+      GITHUB_RSPEC: ${{ matrix.ruby-version == '.ruby-version' && github.event.pull_request && 'true' }}
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Follow-up to #27450 excluding annotations from the `push` events that happen when opening PRs from the Mastodon repository itself.