### PR TITLE
Consider shown and pending status in explore prompt calculation

### DIFF
--- a/app/javascript/mastodon/features/home_timeline/index.jsx
+++ b/app/javascript/mastodon/features/home_timeline/index.jsx
@@ -37,7 +37,7 @@ const getHomeFeedSpeed = createSelector([
   state => state.getIn(['timelines', 'home', 'pendingItems'], ImmutableList()),
   state => state.get('statuses'),
 ], (statusIds, pendingStatusIds, statusMap) => {
-  const recentStatusIds = pendingStatusIds.size > 0 ? pendingStatusIds : statusIds;
+  const recentStatusIds = pendingStatusIds.concat(statusIds);
   const statuses = recentStatusIds.filter(id => id !== null).map(id => statusMap.get(id)).filter(status => status?.get('account') !== me).take(20);
 
   if (statuses.isEmpty()) {


### PR DESCRIPTION
The explore prompt had been picking between shown and pending statuses when deciding whether to display the explore prompt, which prompts you to follow more people if your timeline is not very busy.

Considering just the pending statuses would mean that sometimes, if you had posted something which was now a pending status, that would be filtered out (as the explore prompt calculation filters out our own status) leaving no statuses, and thus show the explore prompt, even if there is plenty of activity in the shown statuses.

Instead, we should be considering the first 20 of both the pending and shown statuses for this computation; we need to concatenate the lists.

Fixes #27197, fixes #27362