### PR TITLE
Fix `Lint/UselessAssignment` cop

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -48,27 +48,6 @@ Lint/UnusedBlockArgument:
     - 'config/initializers/paperclip.rb'
     - 'config/initializers/simple_form.rb'
 
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Lint/UselessAssignment:
-  Exclude:
-    - 'app/services/activitypub/process_status_update_service.rb'
-    - 'config/initializers/3_omniauth.rb'
-    - 'db/migrate/20190511134027_add_silenced_at_suspended_at_to_accounts.rb'
-    - 'db/post_migrate/20190511152737_remove_suspended_silenced_account_fields.rb'
-    - 'spec/controllers/api/v1/favourites_controller_spec.rb'
-    - 'spec/controllers/concerns/account_controller_concern_spec.rb'
-    - 'spec/helpers/jsonld_helper_spec.rb'
-    - 'spec/models/account_spec.rb'
-    - 'spec/models/domain_block_spec.rb'
-    - 'spec/models/status_spec.rb'
-    - 'spec/models/user_spec.rb'
-    - 'spec/models/webauthn_credentials_spec.rb'
-    - 'spec/services/account_search_service_spec.rb'
-    - 'spec/services/post_status_service_spec.rb'
-    - 'spec/services/precompute_feed_service_spec.rb'
-    - 'spec/services/resolve_url_service_spec.rb'
-    - 'spec/views/statuses/show.html.haml_spec.rb'
-
 # Configuration parameters: AllowedMethods, AllowedPatterns, CountRepeatedAttributes.
 Metrics/AbcSize:
   Max: 144

--- a/app/services/activitypub/process_status_update_service.rb
+++ b/app/services/activitypub/process_status_update_service.rb
@@ -97,8 +97,6 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
       end
     end
 
-    added_media_attachments = @next_media_attachments - previous_media_attachments
-
     @status.ordered_media_attachment_ids = @next_media_attachments.map(&:id)
 
     @media_attachments_changed = true if @status.ordered_media_attachment_ids != previous_media_attachments_ids

--- a/config/initializers/3_omniauth.rb
+++ b/config/initializers/3_omniauth.rb
@@ -9,9 +9,6 @@ Rails.application.config.middleware.use OmniAuth::Builder do
 end
 
 Devise.setup do |config|
-  # Devise omniauth strategies
-  options = {}
-
   # CAS strategy
   if ENV['CAS_ENABLED'] == 'true'
     cas_options = {}

--- a/db/migrate/20190511134027_add_silenced_at_suspended_at_to_accounts.rb
+++ b/db/migrate/20190511134027_add_silenced_at_suspended_at_to_accounts.rb
@@ -19,7 +19,6 @@ class AddSilencedAtSuspendedAtToAccounts < ActiveRecord::Migration[5.2]
     # Record suspend date of blocks and silences for users whose limitations match
     # a domain block
     DomainBlock.where(severity: [:silence, :suspend]).find_each do |block|
-      scope = block.accounts
       if block.suspend?
         block.accounts.where(suspended: true).in_batches.update_all(suspended_at: block.created_at)
       else

--- a/db/post_migrate/20190511152737_remove_suspended_silenced_account_fields.rb
+++ b/db/post_migrate/20190511152737_remove_suspended_silenced_account_fields.rb
@@ -18,7 +18,6 @@ class RemoveSuspendedSilencedAccountFields < ActiveRecord::Migration[5.2]
     # Record suspend date of blocks and silences for users whose limitations match
     # a domain block
     DomainBlock.where(severity: [:silence, :suspend]).find_each do |block|
-      scope = block.accounts
       if block.suspend?
         block.accounts.where(suspended: true).in_batches.update_all(suspended_at: block.created_at)
       else

--- a/spec/controllers/concerns/account_controller_concern_spec.rb
+++ b/spec/controllers/concerns/account_controller_concern_spec.rb
@@ -62,7 +62,7 @@ describe AccountControllerConcern do
     end
 
     it 'sets link headers' do
-      account = Fabricate(:account, username: 'username')
+      Fabricate(:account, username: 'username')
       get 'success', params: { account_username: 'username' }
       expect(response.headers['Link'].to_s).to eq '<http://test.host/.well-known/webfinger?resource=acct%3Ausername%40cb6e6126.ngrok.io>; rel="lrdd"; type="application/jrd+json", <https://cb6e6126.ngrok.io/users/username>; rel="alternate"; type="application/activity+json"'
     end

--- a/spec/helpers/jsonld_helper_spec.rb
+++ b/spec/helpers/jsonld_helper_spec.rb
@@ -158,14 +158,14 @@ describe JsonLdHelper do
       it 'deems a safe compacting as such' do
         json['object'].delete('convo')
         compacted = compact(json)
-        deemed_compatible = patch_for_forwarding!(json, compacted)
+        patch_for_forwarding!(json, compacted)
         expect(compacted['to']).to eq ['https://www.w3.org/ns/activitystreams#Public']
         expect(safe_for_forwarding?(json, compacted)).to be true
       end
 
       it 'deems an unsafe compacting as such' do
         compacted = compact(json)
-        deemed_compatible = patch_for_forwarding!(json, compacted)
+        patch_for_forwarding!(json, compacted)
         expect(compacted['to']).to eq ['https://www.w3.org/ns/activitystreams#Public']
         expect(safe_for_forwarding?(json, compacted)).to be false
       end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -356,7 +356,7 @@ RSpec.describe Account do
     end
 
     it 'does not return suspended users' do
-      match = Fabricate(
+      Fabricate(
         :account,
         display_name: 'Display Name',
         username: 'username',
@@ -483,7 +483,7 @@ RSpec.describe Account do
       end
 
       it 'does not return non-followed accounts' do
-        match = Fabricate(
+        Fabricate(
           :account,
           display_name: 'A & l & i & c & e',
           username: 'username',
@@ -495,7 +495,7 @@ RSpec.describe Account do
       end
 
       it 'does not return suspended users' do
-        match = Fabricate(
+        Fabricate(
           :account,
           display_name: 'Display Name',
           username: 'username',
@@ -535,7 +535,7 @@ RSpec.describe Account do
     end
 
     it 'does not return suspended users' do
-      match = Fabricate(
+      Fabricate(
         :account,
         display_name: 'Display Name',
         username: 'username',

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe Status do
 
   describe '#replies_count' do
     it 'is the number of replies' do
-      reply = Fabricate(:status, account: bob, thread: subject)
+      Fabricate(:status, account: bob, thread: subject)
       expect(subject.replies_count).to eq 1
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe User do
 
     describe 'confirmed' do
       it 'returns an array of users who are confirmed' do
-        unconfirmed_user = Fabricate(:user, confirmed_at: nil)
+        Fabricate(:user, confirmed_at: nil)
         confirmed_user = Fabricate(:user, confirmed_at: Time.zone.now)
         expect(described_class.confirmed).to contain_exactly(confirmed_user)
       end

--- a/spec/models/webauthn_credentials_spec.rb
+++ b/spec/models/webauthn_credentials_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe WebauthnCredential do
     end
 
     it 'is invalid if already exist a webauthn credential with the same external id' do
-      existing_webauthn_credential = Fabricate(:webauthn_credential, external_id: '_Typ0ygudDnk9YUVWLQayw')
+      Fabricate(:webauthn_credential, external_id: '_Typ0ygudDnk9YUVWLQayw')
       new_webauthn_credential = Fabricate.build(:webauthn_credential, external_id: '_Typ0ygudDnk9YUVWLQayw')
 
       new_webauthn_credential.valid?
@@ -47,7 +47,7 @@ RSpec.describe WebauthnCredential do
 
     it 'is invalid if user already registered a webauthn credential with the same nickname' do
       user = Fabricate(:user)
-      existing_webauthn_credential = Fabricate(:webauthn_credential, user_id: user.id, nickname: 'USB Key')
+      Fabricate(:webauthn_credential, user_id: user.id, nickname: 'USB Key')
       new_webauthn_credential = Fabricate.build(:webauthn_credential, user_id: user.id, nickname: 'USB Key')
 
       new_webauthn_credential.valid?

--- a/spec/services/account_search_service_spec.rb
+++ b/spec/services/account_search_service_spec.rb
@@ -56,7 +56,7 @@ describe AccountSearchService, type: :service do
         service = instance_double(ResolveAccountService, call: nil)
         allow(ResolveAccountService).to receive(:new).and_return(service)
 
-        results = subject.call('newuser@remote.com', nil, limit: 10, resolve: true)
+        subject.call('newuser@remote.com', nil, limit: 10, resolve: true)
         expect(service).to have_received(:call).with('newuser@remote.com')
       end
 
@@ -64,14 +64,14 @@ describe AccountSearchService, type: :service do
         service = instance_double(ResolveAccountService, call: nil)
         allow(ResolveAccountService).to receive(:new).and_return(service)
 
-        results = subject.call('newuser@remote.com', nil, limit: 10, resolve: false)
+        subject.call('newuser@remote.com', nil, limit: 10, resolve: false)
         expect(service).to_not have_received(:call)
       end
     end
 
     it 'returns the fuzzy match first, and does not return suspended exacts' do
       partial = Fabricate(:account, username: 'exactness')
-      exact   = Fabricate(:account, username: 'exact', suspended: true)
+      Fabricate(:account, username: 'exact', suspended: true)
       results = subject.call('exact', nil, limit: 10)
 
       expect(results.size).to eq 1
@@ -79,7 +79,7 @@ describe AccountSearchService, type: :service do
     end
 
     it 'does not return suspended remote accounts' do
-      remote  = Fabricate(:account, username: 'a', domain: 'remote', display_name: 'e', suspended: true)
+      Fabricate(:account, username: 'a', domain: 'remote', display_name: 'e', suspended: true)
       results = subject.call('a@example.com', nil, limit: 2)
 
       expect(results.size).to eq 0

--- a/spec/services/post_status_service_spec.rb
+++ b/spec/services/post_status_service_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe PostStatusService, type: :service do
 
   it 'processes duplicate mentions correctly' do
     account = Fabricate(:account)
-    mentioned_account = Fabricate(:account, username: 'alice')
+    Fabricate(:account, username: 'alice')
 
     expect do
       subject.call(account, text: '@alice @alice @alice hey @alice')
@@ -212,7 +212,7 @@ RSpec.describe PostStatusService, type: :service do
     account = Fabricate(:account)
     media = Fabricate(:media_attachment, account: Fabricate(:account))
 
-    status = subject.call(
+    subject.call(
       account,
       text: 'test status update',
       media_ids: [media.id]

--- a/spec/services/precompute_feed_service_spec.rb
+++ b/spec/services/precompute_feed_service_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe PrecomputeFeedService, type: :service do
       muted_account = Fabricate(:account)
       Fabricate(:mute, account: account, target_account: muted_account)
       reblog = Fabricate(:status, account: muted_account)
-      status = Fabricate(:status, account: account, reblog: reblog)
+      Fabricate(:status, account: account, reblog: reblog)
 
       subject.call(account)
 

--- a/spec/services/resolve_url_service_spec.rb
+++ b/spec/services/resolve_url_service_spec.rb
@@ -7,8 +7,8 @@ describe ResolveURLService, type: :service do
 
   describe '#call' do
     it 'returns nil when there is no resource url' do
-      url           = 'http://example.com/missing-resource'
-      known_account = Fabricate(:account, uri: url, domain: 'example.com')
+      url = 'http://example.com/missing-resource'
+      Fabricate(:account, uri: url, domain: 'example.com')
       service = instance_double(FetchResourceService)
 
       allow(FetchResourceService).to receive(:new).and_return service

--- a/spec/views/statuses/show.html.haml_spec.rb
+++ b/spec/views/statuses/show.html.haml_spec.rb
@@ -13,7 +13,7 @@ describe 'statuses/show.html.haml', without_verify_partial_doubles: true do
   it 'has valid opengraph tags' do
     alice  = Fabricate(:account, username: 'alice', display_name: 'Alice')
     status = Fabricate(:status, account: alice, text: 'Hello World')
-    media  = Fabricate(:media_attachment, account: alice, status: status, type: :video)
+    Fabricate(:media_attachment, account: alice, status: status, type: :video)
 
     assign(:status, status)
     assign(:account, alice)
@@ -32,7 +32,7 @@ describe 'statuses/show.html.haml', without_verify_partial_doubles: true do
   it 'has twitter player tag' do
     alice  = Fabricate(:account, username: 'alice', display_name: 'Alice')
     status = Fabricate(:status, account: alice, text: 'Hello World')
-    media  = Fabricate(:media_attachment, account: alice, status: status, type: :video)
+    Fabricate(:media_attachment, account: alice, status: status, type: :video)
 
     assign(:status, status)
     assign(:account, alice)


### PR DESCRIPTION
The majority of these are spec setup areas which were probably copy/pasted from other existing examples w/out regard for whether the variable assignment was needed. Couple other places I suspect were used at some point in time but changes to the surrounding code made them unnecessary.