### PR TITLE
Fix incorrect proptypes from react-router-v5 update

### DIFF
--- a/app/javascript/mastodon/components/status.jsx
+++ b/app/javascript/mastodon/components/status.jsx
@@ -11,7 +11,7 @@ import { HotKeys } from 'react-hotkeys';
 
 import { Icon }  from 'mastodon/components/icon';
 import PictureInPicturePlaceholder from 'mastodon/components/picture_in_picture_placeholder';
-import { withOptionalRouter, WithRouterPropTypes } from 'mastodon/utils/react_router';
+import { withOptionalRouter, WithOptionalRouterPropTypes } from 'mastodon/utils/react_router';
 
 import Card from '../features/status/components/card';
 // We use the component (and not the container) since we do not want
@@ -113,7 +113,7 @@ class Status extends ImmutablePureComponent {
       inUse: PropTypes.bool,
       available: PropTypes.bool,
     }),
-    ...WithRouterPropTypes,
+    ...WithOptionalRouterPropTypes,
   };
 
   // Avoid checking props that are functions (and whose equality will always

--- a/app/javascript/mastodon/utils/react_router.jsx
+++ b/app/javascript/mastodon/utils/react_router.jsx
@@ -49,6 +49,7 @@ export function withOptionalRouter(Component) {
   C.displayName = displayName;
   C.WrappedComponent = Component;
   C.propTypes = {
+    ...Component.propTypes,
     wrappedComponentRef: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.func,


### PR DESCRIPTION
`withOptionalRouter` defines an extra `wrappedComponentRef` prop, which should be added to `propTypes`, but the original wrapped component's other prop types should be kept.

Additionally, `app/javascript/mastodon/components/status.jsx` was using `withOptionalRouter` but defining non-optional react-router props.