### PR TITLE
Remove Renovate's Lock File Maintenance task

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,7 +3,6 @@
   extends: [
     'config:recommended',
     ':labels(dependencies)',
-    ':maintainLockFilesMonthly', // update non-direct dependencies monthly
     ':prConcurrentLimitNone', // Remove limit for open PRs at any time.
     ':prHourlyLimit2', // Rate limit PR creation to a maximum of two per hour.
   ],


### PR DESCRIPTION
I initially though this would update every non-direct dependencies, but this is not the case. Instead, it removes the lockfile and regenerate them from the `package.json` / `Gemfile`, which result in our direct dependency locked versions being ignored.