### PR TITLE
Use Rails 7.1 `normalizes` feature

### DIFF
--- a/app/models/account_alias.rb
+++ b/app/models/account_alias.rb
@@ -23,10 +23,7 @@ class AccountAlias < ApplicationRecord
   after_create :add_to_account
   after_destroy :remove_from_account
 
-  def acct=(val)
-    val = val.to_s.strip
-    super(val.start_with?('@') ? val[1..] : val)
-  end
+  normalizes :acct, with: ->(acct) { acct.strip.delete_prefix('@') }
 
   def pretty_acct
     username, domain = acct.split('@', 2)

--- a/app/models/account_migration.rb
+++ b/app/models/account_migration.rb
@@ -25,6 +25,8 @@ class AccountMigration < ApplicationRecord
   before_validation :set_target_account
   before_validation :set_followers_count
 
+  normalizes :acct, with: ->(acct) { acct.strip.delete_prefix('@') }
+
   validates :acct, presence: true, domain: { acct: true }
   validate :validate_migration_cooldown
   validate :validate_target_account
@@ -49,10 +51,6 @@ class AccountMigration < ApplicationRecord
 
   def cooldown_at
     created_at + COOLDOWN_PERIOD
-  end
-
-  def acct=(val)
-    super(val.to_s.strip.gsub(/\A@/, ''))
   end
 
   private

--- a/app/models/account_warning.rb
+++ b/app/models/account_warning.rb
@@ -27,7 +27,7 @@ class AccountWarning < ApplicationRecord
     suspend: 4_000,
   }, _suffix: :action
 
-  before_validation :before_validate
+  normalizes :text, with: ->(text) { text.to_s }, apply_to_nil: true
 
   belongs_to :account, inverse_of: :account_warnings
   belongs_to :target_account, class_name: 'Account', inverse_of: :strikes
@@ -49,11 +49,5 @@ class AccountWarning < ApplicationRecord
 
   def to_log_human_identifier
     target_account.acct
-  end
-
-  private
-
-  def before_validate
-    self.text = '' if text.blank?
   end
 end

--- a/app/models/featured_tag.rb
+++ b/app/models/featured_tag.rb
@@ -23,7 +23,7 @@ class FeaturedTag < ApplicationRecord
   validate :validate_tag_uniqueness, on: :create
   validate :validate_featured_tags_limit, on: :create
 
-  before_validation :strip_name
+  normalizes :name, with: ->(name) { name.strip.delete_prefix('#') }
 
   before_create :set_tag
   before_create :reset_data
@@ -49,10 +49,6 @@ class FeaturedTag < ApplicationRecord
   end
 
   private
-
-  def strip_name
-    self.name = name&.strip&.delete_prefix('#')
-  end
 
   def set_tag
     self.tag = Tag.find_or_create_by_names(name)&.first

--- a/app/models/relay.rb
+++ b/app/models/relay.rb
@@ -19,7 +19,8 @@ class Relay < ApplicationRecord
 
   scope :enabled, -> { accepted }
 
-  before_validation :strip_url
+  normalizes :inbox_url, with: ->(inbox_url) { inbox_url.strip }
+
   before_destroy :ensure_disabled
 
   alias enabled? accepted?
@@ -75,9 +76,5 @@ class Relay < ApplicationRecord
 
   def ensure_disabled
     disable! if enabled?
-  end
-
-  def strip_url
-    inbox_url&.strip!
   end
 end


### PR DESCRIPTION
Another new Rails 7.1 feature -- useful for replacing custom setters or before validation in models where there's just some lightweight data prep happening.

This PR has each change in a separate commit so if any of these have concerns I can pull out just the desired ones pretty easily.