### PR TITLE
Allow status updates from other actors via ActivityPub

### DIFF
--- a/app/lib/activitypub/activity.rb
+++ b/app/lib/activitypub/activity.rb
@@ -75,6 +75,14 @@ class ActivityPub::Activity
     @object_uri ||= uri_from_bearcap(value_or_id(@object))
   end
 
+  def object_actor_uri
+    @object_actor_uri ||= value_or_id(first_of_value(@object['attributedTo']))
+  end
+
+  def object_actor
+    @object_actor ||= Account.find_by(uri: object_actor_uri)
+  end
+
   def unsupported_object_type?
     @object.is_a?(String) || !(supported_object_type? || converted_object_type?)
   end
@@ -102,13 +110,9 @@ class ActivityPub::Activity
     return status unless status.nil?
 
     # If the boosted toot is embedded and it is a self-boost, handle it like a Create
-    unless unsupported_object_type?
-      actor_id = value_or_id(first_of_value(@object['attributedTo']))
-
-      if actor_id == @account.uri
-        virtual_object = { 'type' => 'Create', 'actor' => actor_id, 'object' => @object }
-        return ActivityPub::Activity.factory(virtual_object, @account, request_id: @options[:request_id]).perform
-      end
+    if !unsupported_object_type? && (object_actor_uri == @account.uri)
+      virtual_object = { 'type' => 'Create', 'actor' => actor_id, 'object' => @object }
+      return ActivityPub::Activity.factory(virtual_object, @account, request_id: @options[:request_id]).perform
     end
 
     fetch_remote_original_status

--- a/app/lib/activitypub/activity.rb
+++ b/app/lib/activitypub/activity.rb
@@ -111,7 +111,7 @@ class ActivityPub::Activity
 
     # If the boosted toot is embedded and it is a self-boost, handle it like a Create
     if !unsupported_object_type? && (object_actor_uri == @account.uri)
-      virtual_object = { 'type' => 'Create', 'actor' => actor_id, 'object' => @object }
+      virtual_object = { 'type' => 'Create', 'actor' => object_actor_uri, 'object' => @object }
       return ActivityPub::Activity.factory(virtual_object, @account, request_id: @options[:request_id]).perform
     end
 

--- a/app/lib/activitypub/activity/update.rb
+++ b/app/lib/activitypub/activity/update.rb
@@ -26,11 +26,13 @@ class ActivityPub::Activity::Update < ActivityPub::Activity
   def update_status
     return reject_payload! if non_matching_uri_hosts?(@account.uri, object_uri)
 
-    editor_id = @account.id
-    status_account_id = object_actor ? object_actor.id : editor_id
     @status = Status.find_by(uri: object_uri, account_id: status_account_id)
     return if @status.nil?
 
-    ActivityPub::ProcessStatusUpdateService.new.call(@status, @json, @object, request_id: @options[:request_id], editor_id: editor_id)
+    ActivityPub::ProcessStatusUpdateService.new.call(@status, @json, @object, request_id: @options[:request_id], activity_account_id: @account.id)
+  end
+
+  def status_account_id
+    object_actor ? object_actor.id : @account.id
   end
 end

--- a/app/lib/activitypub/activity/update.rb
+++ b/app/lib/activitypub/activity/update.rb
@@ -26,7 +26,8 @@ class ActivityPub::Activity::Update < ActivityPub::Activity
   def update_status
     return reject_payload! if non_matching_uri_hosts?(@account.uri, object_uri)
 
-    @status = Status.find_by(uri: object_uri, account_id: @account.id)
+    status_account_id = object_actor ? object_actor.id : @account.id
+    @status = Status.find_by(uri: object_uri, account_id: status_account_id)
 
     return if @status.nil?
 

--- a/app/lib/activitypub/activity/update.rb
+++ b/app/lib/activitypub/activity/update.rb
@@ -26,11 +26,11 @@ class ActivityPub::Activity::Update < ActivityPub::Activity
   def update_status
     return reject_payload! if non_matching_uri_hosts?(@account.uri, object_uri)
 
-    status_account_id = object_actor ? object_actor.id : @account.id
+    editor_id = @account.id
+    status_account_id = object_actor ? object_actor.id : editor_id
     @status = Status.find_by(uri: object_uri, account_id: status_account_id)
-
     return if @status.nil?
 
-    ActivityPub::ProcessStatusUpdateService.new.call(@status, @json, @object, request_id: @options[:request_id])
+    ActivityPub::ProcessStatusUpdateService.new.call(@status, @json, @object, request_id: @options[:request_id], editor_id: editor_id)
   end
 end

--- a/app/services/activitypub/process_status_update_service.rb
+++ b/app/services/activitypub/process_status_update_service.rb
@@ -5,7 +5,7 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
   include Redisable
   include Lockable
 
-  def call(status, activity_json, object_json, request_id: nil)
+  def call(status, activity_json, object_json, request_id: nil, editor_id: nil)
     raise ArgumentError, 'Status has unsaved changes' if status.changed?
 
     @activity_json             = activity_json
@@ -17,6 +17,7 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
     @media_attachments_changed = false
     @poll_changed              = false
     @request_id                = request_id
+    @editor_id                 = editor_id
 
     # Only native types can be updated at the moment
     return @status if !expected_type? || already_updated_more_recently?
@@ -251,7 +252,8 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
     return unless significant_changes?
 
     @previous_edit&.save!
-    @status.snapshot!(account_id: @account.id, rate_limit: false)
+    account_id = @editor_id || @account.id
+    @status.snapshot!(account_id: account_id, rate_limit: false)
   end
 
   def skip_download?

--- a/spec/services/activitypub/process_status_update_service_spec.rb
+++ b/spec/services/activitypub/process_status_update_service_spec.rb
@@ -462,5 +462,23 @@ RSpec.describe ActivityPub::ProcessStatusUpdateService, type: :service do
       subject.call(status, json, json)
       expect(status.reload.edited_at.to_s).to eq '2021-09-08 22:39:25 UTC'
     end
+
+    context 'with an editor_id' do
+      let(:editor) { Fabricate(:account) }
+
+      it 'creates edits with the right editor' do
+        allow(DistributionWorker).to receive(:perform_async)
+        subject.call(status, json, json, editor_id: editor.id)
+        expect(status.edits.reload.last.account_id).to eq editor.id
+      end
+    end
+
+    context 'without an editor_id' do
+      it 'creates edits with the right editor' do
+        allow(DistributionWorker).to receive(:perform_async)
+        subject.call(status, json, json)
+        expect(status.edits.reload.last.account_id).to eq status.account.id
+      end
+    end
   end
 end

--- a/spec/services/activitypub/process_status_update_service_spec.rb
+++ b/spec/services/activitypub/process_status_update_service_spec.rb
@@ -463,17 +463,17 @@ RSpec.describe ActivityPub::ProcessStatusUpdateService, type: :service do
       expect(status.reload.edited_at.to_s).to eq '2021-09-08 22:39:25 UTC'
     end
 
-    context 'with an editor_id' do
-      let(:editor) { Fabricate(:account) }
+    context 'with an activity_account_id' do
+      let(:activity_account) { Fabricate(:account) }
 
       it 'creates edits with the right editor' do
         allow(DistributionWorker).to receive(:perform_async)
-        subject.call(status, json, json, editor_id: editor.id)
-        expect(status.edits.reload.last.account_id).to eq editor.id
+        subject.call(status, json, json, activity_account_id: activity_account.id)
+        expect(status.edits.reload.last.account_id).to eq activity_account.id
       end
     end
 
-    context 'without an editor_id' do
+    context 'without an activity_account_id' do
       it 'creates edits with the right editor' do
         allow(DistributionWorker).to receive(:perform_async)
         subject.call(status, json, json)


### PR DESCRIPTION
Some ActivityPub services allow status updates from actors other than the actor to whom an object (status) is attributedTo. Specifically, we're looking at implementing the ActivityPub version of this existing feature in Discourse via the [Discourse ActivityPub plugin](https://github.com/discourse/discourse-activity-pub). See further: https://github.com/discourse/discourse-activity-pub/pull/34