### PR TITLE
Use `ENV.fetch` in views, fixes rubocop haml-lint issue

### DIFF
--- a/app/views/auth/registrations/edit.html.haml
+++ b/app/views/auth/registrations/edit.html.haml
@@ -3,7 +3,7 @@
 
 - if self_destruct?
   .flash-message.warning
-    = t('auth.status.self_destruct', domain: ENV['LOCAL_DOMAIN'])
+    = t('auth.status.self_destruct', domain: ENV.fetch('LOCAL_DOMAIN'))
 - else
   = render partial: 'status', locals: { user: @user, strikes: @strikes }
 

--- a/app/views/errors/self_destruct.html.haml
+++ b/app/views/errors/self_destruct.html.haml
@@ -3,7 +3,7 @@
 
 .simple_form
   %h1.title= t('self_destruct.title')
-  %p.lead= t('self_destruct.lead_html', domain: ENV['LOCAL_DOMAIN'])
+  %p.lead= t('self_destruct.lead_html', domain: ENV.fetch('LOCAL_DOMAIN'))
 
 .form-footer
   %ul.no-list


### PR DESCRIPTION
Fixes an issue added after this regeneration was run but before it was merged - https://github.com/mastodon/mastodon/pull/27513#issuecomment-1776846228