### PR TITLE
Capture minimum postgres version 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Mastodon acts as an OAuth2 provider, so 3rd party apps can use the REST and Stre
 
 ### Requirements
 
-- **PostgreSQL** 9.5+
+- **PostgreSQL** 12+
 - **Redis** 4+
 - **Ruby** 2.7+
 - **Node.js** 16+

--- a/config/initializers/strong_migrations.rb
+++ b/config/initializers/strong_migrations.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
 StrongMigrations.start_after = 2017_09_24_022025
-StrongMigrations.target_version = 10
+StrongMigrations.target_version = 12


### PR DESCRIPTION
Per @renchap request -- we set the expectation of not supporting EOL'd postgres in the 4.2 release notes - https://github.com/mastodon/mastodon/releases/tag/v4.2.0 - this change updates the README to reflect 12+ and also updates the strong migrations target version.

I also included the removal of a bunch of version-dependent checks in the migration helpers. This is probably fine since we're dropping that support, but it also feels odd to edit what I think is essentially "vendored" code originally taken from the gitlab project. It may make sense outside the scope of this PR to actually do it that way: vendor the files as-is taken from gitlab, and then separate out the additions made to the script. Alternately, if I'm thinking about this wrong and it's very much "our" script at this point even though its origins are another project, none of this matters and we can modify away.

Also open to feedback on any other areas of code/docs which could be bumped to require PG12+ and/or optimized if we no longer need to support older.