### PR TITLE
Fix missing libyaml-dev dependency in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update && \
         libgdbm-dev \
         libgmp-dev \
         libssl-dev \
-        libyaml-0-2 \
+        libyaml-dev \
         ca-certificates \
         libreadline8 \
         python3 \


### PR DESCRIPTION
The upstream Ruby moritzheiber/ruby-jemalloc Docker image has changed and Mastodon now requires `libyaml-dev` to be installed.

Fixes compile errors:
```
63.09
63.09 An error occurred while installing psych (5.1.1), and Bundler cannot continue.
63.09
63.09 In Gemfile:
63.09   devise-two-factor was resolved to 4.1.1, which depends on
63.09     devise was resolved to 4.9.3, which depends on
63.09       responders was resolved to 3.1.1, which depends on
63.09         railties was resolved to 7.1.1, which depends on
63.09           irb was resolved to 1.8.1, which depends on
63.09             rdoc was resolved to 6.5.0, which depends on
63.09               psych
```