### PR TITLE
Update `rails/ujs` delegate method usage

### DIFF
--- a/app/javascript/packs/admin.jsx
+++ b/app/javascript/packs/admin.jsx
@@ -2,7 +2,7 @@ import './public-path';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 
-import delegate from '@rails/ujs';
+import Rails from '@rails/ujs';
 
 import ready from '../mastodon/ready';
 
@@ -20,7 +20,7 @@ const setAnnouncementEndsAttributes = (target) => {
   }
 };
 
-delegate(document, 'input[type="datetime-local"]#announcement_starts_at', 'change', ({ target }) => {
+Rails.delegate(document, 'input[type="datetime-local"]#announcement_starts_at', 'change', ({ target }) => {
   setAnnouncementEndsAttributes(target);
 });
 
@@ -43,7 +43,7 @@ const hideSelectAll = () => {
   hiddenField.value = '0';
 };
 
-delegate(document, '#batch_checkbox_all', 'change', ({ target }) => {
+Rails.delegate(document, '#batch_checkbox_all', 'change', ({ target }) => {
   const selectAllMatchingElement = document.querySelector('.batch-table__select-all');
 
   [].forEach.call(document.querySelectorAll(batchCheckboxClassName), (content) => {
@@ -59,7 +59,7 @@ delegate(document, '#batch_checkbox_all', 'change', ({ target }) => {
   }
 });
 
-delegate(document, '.batch-table__select-all button', 'click', () => {
+Rails.delegate(document, '.batch-table__select-all button', 'click', () => {
   const hiddenField = document.querySelector('#select_all_matching');
   const active = hiddenField.value === '1';
   const selectedMsg = document.querySelector('.batch-table__select-all .selected');
@@ -76,7 +76,7 @@ delegate(document, '.batch-table__select-all button', 'click', () => {
   }
 });
 
-delegate(document, batchCheckboxClassName, 'change', () => {
+Rails.delegate(document, batchCheckboxClassName, 'change', () => {
   const checkAllElement = document.querySelector('#batch_checkbox_all');
   const selectAllMatchingElement = document.querySelector('.batch-table__select-all');
 
@@ -94,19 +94,19 @@ delegate(document, batchCheckboxClassName, 'change', () => {
   }
 });
 
-delegate(document, '.media-spoiler-show-button', 'click', () => {
+Rails.delegate(document, '.media-spoiler-show-button', 'click', () => {
   [].forEach.call(document.querySelectorAll('button.media-spoiler'), (element) => {
     element.click();
   });
 });
 
-delegate(document, '.media-spoiler-hide-button', 'click', () => {
+Rails.delegate(document, '.media-spoiler-hide-button', 'click', () => {
   [].forEach.call(document.querySelectorAll('.spoiler-button.spoiler-button--visible button'), (element) => {
     element.click();
   });
 });
 
-delegate(document, '.filter-subset--with-select select', 'change', ({ target }) => {
+Rails.delegate(document, '.filter-subset--with-select select', 'change', ({ target }) => {
   target.form.submit();
 });
 
@@ -123,7 +123,7 @@ const onDomainBlockSeverityChange = (target) => {
   }
 };
 
-delegate(document, '#domain_block_severity', 'change', ({ target }) => onDomainBlockSeverityChange(target));
+Rails.delegate(document, '#domain_block_severity', 'change', ({ target }) => onDomainBlockSeverityChange(target));
 
 const onEnableBootstrapTimelineAccountsChange = (target) => {
   const bootstrapTimelineAccountsField = document.querySelector('#form_admin_settings_bootstrap_timeline_accounts');
@@ -140,7 +140,7 @@ const onEnableBootstrapTimelineAccountsChange = (target) => {
   }
 };
 
-delegate(document, '#form_admin_settings_enable_bootstrap_timeline_accounts', 'change', ({ target }) => onEnableBootstrapTimelineAccountsChange(target));
+Rails.delegate(document, '#form_admin_settings_enable_bootstrap_timeline_accounts', 'change', ({ target }) => onEnableBootstrapTimelineAccountsChange(target));
 
 const onChangeRegistrationMode = (target) => {
   const enabled = target.value === 'approved';
@@ -177,7 +177,7 @@ const convertLocalDatetimeToUTC = (value) => {
   return fullISO8601.slice(0, fullISO8601.indexOf('T') + 6);
 };
 
-delegate(document, '#form_admin_settings_registrations_mode', 'change', ({ target }) => onChangeRegistrationMode(target));
+Rails.delegate(document, '#form_admin_settings_registrations_mode', 'change', ({ target }) => onChangeRegistrationMode(target));
 
 ready(() => {
   const domainBlockSeverityInput = document.getElementById('domain_block_severity');
@@ -214,7 +214,7 @@ ready(() => {
     }
   });
 
-  delegate(document, 'form', 'submit', ({ target }) => {
+  Rails.delegate(document, 'form', 'submit', ({ target }) => {
     [].forEach.call(target.querySelectorAll('input[type="datetime-local"]'), element => {
       if (element.value && element.validity.valid) {
         element.value = convertLocalDatetimeToUTC(element.value);

--- a/app/javascript/packs/public.jsx
+++ b/app/javascript/packs/public.jsx
@@ -5,7 +5,7 @@ import './public-path';
 import { IntlMessageFormat }  from 'intl-messageformat';
 import { defineMessages } from 'react-intl';
 
-import delegate from '@rails/ujs';
+import Rails from '@rails/ujs';
 import axios from 'axios';
 import { throttle } from 'lodash';
 
@@ -145,7 +145,7 @@ function loaded() {
       });
   }
 
-  delegate(document, '#user_account_attributes_username', 'input', throttle(({ target }) => {
+  Rails.delegate(document, '#user_account_attributes_username', 'input', throttle(({ target }) => {
     if (target.value && target.value.length > 0) {
       axios.get('/api/v1/accounts/lookup', { params: { acct: target.value } }).then(() => {
         target.setCustomValidity(formatMessage(messages.usernameTaken));
@@ -157,7 +157,7 @@ function loaded() {
     }
   }, 500, { leading: false, trailing: true }));
 
-  delegate(document, '#user_password,#user_password_confirmation', 'input', () => {
+  Rails.delegate(document, '#user_password,#user_password_confirmation', 'input', () => {
     const password = document.getElementById('user_password');
     const confirmation = document.getElementById('user_password_confirmation');
     if (!confirmation) return;
@@ -171,7 +171,7 @@ function loaded() {
     }
   });
 
-  delegate(document, '.status__content__spoiler-link', 'click', function() {
+  Rails.delegate(document, '.status__content__spoiler-link', 'click', function() {
     const statusEl = this.parentNode.parentNode;
 
     if (statusEl.dataset.spoiler === 'expanded') {
@@ -192,7 +192,7 @@ function loaded() {
   });
 }
 
-delegate(document, '#edit_profile input[type=file]', 'change', ({ target }) => {
+Rails.delegate(document, '#edit_profile input[type=file]', 'change', ({ target }) => {
   const avatar = document.getElementById(target.id + '-preview');
   const [file] = target.files || [];
   const url = file ? URL.createObjectURL(file) : avatar.dataset.originalSrc;
@@ -200,13 +200,13 @@ delegate(document, '#edit_profile input[type=file]', 'change', ({ target }) => {
   avatar.src = url;
 });
 
-delegate(document, '.input-copy input', 'click', ({ target }) => {
+Rails.delegate(document, '.input-copy input', 'click', ({ target }) => {
   target.focus();
   target.select();
   target.setSelectionRange(0, target.value.length);
 });
 
-delegate(document, '.input-copy button', 'click', ({ target }) => {
+Rails.delegate(document, '.input-copy button', 'click', ({ target }) => {
   const input = target.parentNode.querySelector('.input-copy__wrapper input');
 
   const oldReadOnly = input.readonly;
@@ -248,23 +248,23 @@ const toggleSidebar = () => {
   sidebar.classList.toggle('visible');
 };
 
-delegate(document, '.sidebar__toggle__icon', 'click', () => {
+Rails.delegate(document, '.sidebar__toggle__icon', 'click', () => {
   toggleSidebar();
 });
 
-delegate(document, '.sidebar__toggle__icon', 'keydown', e => {
+Rails.delegate(document, '.sidebar__toggle__icon', 'keydown', e => {
   if (e.key === ' ' || e.key === 'Enter') {
     e.preventDefault();
     toggleSidebar();
   }
 });
 
-delegate(document, '.custom-emoji', 'mouseover', ({ target }) => target.src = target.getAttribute('data-original'));
-delegate(document, '.custom-emoji', 'mouseout', ({ target }) => target.src = target.getAttribute('data-static'));
+Rails.delegate(document, '.custom-emoji', 'mouseover', ({ target }) => target.src = target.getAttribute('data-original'));
+Rails.delegate(document, '.custom-emoji', 'mouseout', ({ target }) => target.src = target.getAttribute('data-static'));
 
 // Empty the honeypot fields in JS in case something like an extension
 // automatically filled them.
-delegate(document, '#registration_new_user,#new_user', 'submit', () => {
+Rails.delegate(document, '#registration_new_user,#new_user', 'submit', () => {
   ['user_website', 'user_confirm_password', 'registration_user_website', 'registration_user_confirm_password'].forEach(id => {
     const field = document.getElementById(id);
     if (field) {


### PR DESCRIPTION
As noted here - https://github.com/mastodon/mastodon/pull/25963#issuecomment-1777793823 - the Rails 7.1 update PR has a regression around the rails/ujs integration. I believe this style is more correct than what was in the 7.1 update.

The only testing I did here was to confirm I had browser console errors before this change (instead of working JS decorations) and then confirmed both that I had no errors after the change and that one of the features (new user signup password/confirmation highlighting) worked. I did not do an exhaustive check of every delegated action.