### PR TITLE
Fix `<ColumnBackButtonSlim>`

### DIFF
--- a/app/javascript/mastodon/components/column_back_button.jsx
+++ b/app/javascript/mastodon/components/column_back_button.jsx
@@ -11,7 +11,7 @@ import { ReactComponent as ArrowBackIcon } from '@material-symbols/svg-600/outli
 import { Icon }  from 'mastodon/components/icon';
 import { WithRouterPropTypes } from 'mastodon/utils/react_router';
 
-class ColumnBackButton extends PureComponent {
+export class ColumnBackButton extends PureComponent {
 
   static propTypes = {
     multiColumn: PropTypes.bool,

--- a/app/javascript/mastodon/components/column_back_button_slim.jsx
+++ b/app/javascript/mastodon/components/column_back_button_slim.jsx
@@ -4,10 +4,9 @@ import { ReactComponent as ArrowBackIcon } from '@material-symbols/svg-600/outli
 
 import { Icon }  from 'mastodon/components/icon';
 
-import ColumnBackButton from './column_back_button';
+import { ColumnBackButton } from './column_back_button';
 
 export default class ColumnBackButtonSlim extends ColumnBackButton {
-
   render () {
     return (
       <div className='column-back-button--slim'>
@@ -18,5 +17,4 @@ export default class ColumnBackButtonSlim extends ColumnBackButton {
       </div>
     );
   }
-
 }


### PR DESCRIPTION
You can not extend something that is not a class, and #25047 added a `withRouter` wrapping the export.

The fix is not ideal, but I will try to rewrite those components as functional ones and remove the slim version in a further PR.