### PR TITLE
Add banner for forwarded reports made by remote users about remote content

### DIFF
--- a/app/views/admin/reports/_header_details.html.haml
+++ b/app/views/admin/reports/_header_details.html.haml
@@ -22,7 +22,7 @@
         = t('admin.reports.resolved')
       - else
         = t('admin.reports.unresolved')
-  - unless report.target_account.local?
+  - if report.account.local? && !report.target_account.local?
     .report-header__details__item
       .report-header__details__item__header
         %strong= t('admin.reports.forwarded')

--- a/app/views/admin/reports/show.html.haml
+++ b/app/views/admin/reports/show.html.haml
@@ -7,6 +7,9 @@
   - else
     = link_to t('admin.reports.mark_as_unresolved'), reopen_admin_report_path(@report), method: :post, class: 'button'
 
+- unless @report.account.local? || @report.target_account.local?
+  .flash-message= t('admin.reports.forwarded_replies_explanation')
+
 .report-header
   = render 'admin/reports/header_card', report: @report
   = render 'admin/reports/header_details', report: @report

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -611,6 +611,7 @@ en:
       created_at: Reported
       delete_and_resolve: Delete posts
       forwarded: Forwarded
+      forwarded_replies_explanation: This report is from a remote user and about remote content. It has been forwarded to you because the reported content is in reply to one of your users.
       forwarded_to: Forwarded to %{domain}
       mark_as_resolved: Mark as resolved
       mark_as_sensitive: Mark as sensitive


### PR DESCRIPTION
Fixes #27537

![image](https://github.com/mastodon/mastodon/assets/384364/393ab436-b2a8-49f2-8d10-452887ac0434)