### PR TITLE
Fix batch attachment deletion when using OpenStack Swift

### DIFF
--- a/app/lib/attachment_batch.rb
+++ b/app/lib/attachment_batch.rb
@@ -75,7 +75,7 @@ class AttachmentBatch
             end
           when :fog
             logger.debug { "Deleting #{attachment.path(style)}" }
-            attachment.directory.files.new(key: attachment.path(style)).destroy
+            attachment.send(:directory).files.new(key: attachment.path(style)).destroy
           when :azure
             logger.debug { "Deleting #{attachment.path(style)}" }
             attachment.destroy


### PR DESCRIPTION
Fixes an issue introduced by #23302. `directory` is a private method.