### PR TITLE
Refactor, lint fix, and bug fix on admin/roles/form partial

### DIFF
--- a/app/helpers/admin/roles_helper.rb
+++ b/app/helpers/admin/roles_helper.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Admin
+  module RolesHelper
+    def privilege_label(privilege)
+      safe_join(
+        [
+          t("admin.roles.privileges.#{privilege}"),
+          content_tag(:span, t("admin.roles.privileges.#{privilege}_description"), class: 'hint'),
+        ]
+      )
+    end
+  end
+end

--- a/app/helpers/admin/roles_helper.rb
+++ b/app/helpers/admin/roles_helper.rb
@@ -10,5 +10,15 @@ module Admin
         ]
       )
     end
+
+    def disable_permissions?(permissions)
+      permissions.filter { |privilege| role_flag_value(privilege).zero? }
+    end
+
+    private
+
+    def role_flag_value(privilege)
+      UserRole::FLAGS[privilege] & current_user.role.computed_permissions
+    end
   end
 end

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -49,7 +49,7 @@ class UserRole < ApplicationRecord
         invite_users
       ).freeze,
 
-      moderation: %w(
+      moderation: %i(
         view_dashboard
         view_audit_log
         manage_users
@@ -63,7 +63,7 @@ class UserRole < ApplicationRecord
         manage_invites
       ).freeze,
 
-      administration: %w(
+      administration: %i(
         manage_settings
         manage_rules
         manage_roles
@@ -72,7 +72,7 @@ class UserRole < ApplicationRecord
         manage_announcements
       ).freeze,
 
-      devops: %w(
+      devops: %i(
         view_devops
       ).freeze,
 

--- a/app/views/admin/roles/_form.html.haml
+++ b/app/views/admin/roles/_form.html.haml
@@ -31,6 +31,6 @@
     - (form.object.everyone? ? UserRole::Flags::CATEGORIES.slice(:invites) : UserRole::Flags::CATEGORIES).each do |category, permissions|
       %h4= t(category, scope: 'admin.roles.categories')
 
-      = form.input :permissions_as_keys, collection: permissions, wrapper: :with_block_label, include_blank: false, label_method: ->(privilege) { safe_join([t("admin.roles.privileges.#{privilege}"), content_tag(:span, t("admin.roles.privileges.#{privilege}_description"), class: 'hint')]) }, required: false, as: :check_boxes, collection_wrapper_tag: 'ul', item_wrapper_tag: 'li', label: false, hint: false, disabled: permissions.filter { |privilege| UserRole::FLAGS[privilege] & current_user.role.computed_permissions == 0 }
+      = form.input :permissions_as_keys, collection: permissions, wrapper: :with_block_label, include_blank: false, label_method: ->(privilege) { privilege_label(privilege) }, required: false, as: :check_boxes, collection_wrapper_tag: 'ul', item_wrapper_tag: 'li', label: false, hint: false, disabled: permissions.filter { |privilege| UserRole::FLAGS[privilege] & current_user.role.computed_permissions == 0 }
 
   %hr.spacer/

--- a/app/views/admin/roles/_form.html.haml
+++ b/app/views/admin/roles/_form.html.haml
@@ -31,6 +31,6 @@
     - (form.object.everyone? ? UserRole::Flags::CATEGORIES.slice(:invites) : UserRole::Flags::CATEGORIES).each do |category, permissions|
       %h4= t(category, scope: 'admin.roles.categories')
 
-      = form.input :permissions_as_keys, collection: permissions, wrapper: :with_block_label, include_blank: false, label_method: ->(privilege) { privilege_label(privilege) }, required: false, as: :check_boxes, collection_wrapper_tag: 'ul', item_wrapper_tag: 'li', label: false, hint: false, disabled: permissions.filter { |privilege| UserRole::FLAGS[privilege] & current_user.role.computed_permissions == 0 }
+      = form.input :permissions_as_keys, collection: permissions, wrapper: :with_block_label, include_blank: false, label_method: ->(privilege) { privilege_label(privilege) }, required: false, as: :check_boxes, collection_wrapper_tag: 'ul', item_wrapper_tag: 'li', label: false, hint: false, disabled: disable_permissions?(permissions)
 
   %hr.spacer/


### PR DESCRIPTION
There's a few things here:

- Extract two new methods to make partial more readable: `privilege_label` (applies i18n) and `disable_permissions?` (checks if any of the perms should disable the form)
- Convert the hash of string values in `UserRole::Flags::CATEGORIES` into symbols. When these are strings and they are sent into `UserRole::FLAGS` to get a value, there's not a hash key with the string value and `nil` is returned instead of the expected flag score/value that the symbol would get. I think that this constant is only ever used in this view/form interaction so I don't think the change impacts anything else.
- Replace an `== 0` check with a `zero?` check to solve the haml lint complaint

