### PR TITLE
Fix keyboard navigation

### DIFF
--- a/app/javascript/mastodon/components/status_list.jsx
+++ b/app/javascript/mastodon/components/status_list.jsx
@@ -50,13 +50,11 @@ export default class StatusList extends ImmutablePureComponent {
   };
 
   handleMoveUp = (id, featured) => {
-    const elementIndex = this.getCurrentStatusIndex(id, featured) - 1;
-    this._selectChild(elementIndex, true);
+    this._selectChild(id, featured, true);
   };
 
   handleMoveDown = (id, featured) => {
-    const elementIndex = this.getCurrentStatusIndex(id, featured) + 1;
-    this._selectChild(elementIndex, false);
+    this._selectChild(id, featured, false);
   };
 
   handleLoadOlder = debounce(() => {
@@ -64,18 +62,29 @@ export default class StatusList extends ImmutablePureComponent {
     onLoadMore(lastId || (statusIds.size > 0 ? statusIds.last() : undefined));
   }, 300, { leading: true });
 
-  _selectChild (index, align_top) {
+  _selectChild (id, featured, up) {
+    const align_top = up;
     const container = this.node.node;
-    const element = container.querySelector(`article:nth-of-type(${index + 1}) .focusable`);
+    const elementIndex = this.getCurrentStatusIndex(id, featured);
+    const increment = up ? -1 : 1
+    let index = elementIndex;
 
-    if (element) {
-      if (align_top && container.scrollTop > element.offsetTop) {
-        element.scrollIntoView(true);
-      } else if (!align_top && container.scrollTop + container.clientHeight < element.offsetTop + element.offsetHeight) {
-        element.scrollIntoView(false);
+    let element = null;
+    while (element === null) {
+      index += increment;
+      const article = container.querySelector(`article:nth-of-type(${index + 1})`);
+      if (article === null) {
+        return;
       }
-      element.focus();
+      element = article.querySelector(".focusable");
     }
+
+    if (align_top && container.scrollTop > element.offsetTop) {
+      element.scrollIntoView(true);
+    } else if (!align_top && container.scrollTop + container.clientHeight < element.offsetTop + element.offsetHeight) {
+      element.scrollIntoView(false);
+    }
+    element.focus();
   }
 
   setRef = c => {

--- a/app/javascript/mastodon/components/status_list.jsx
+++ b/app/javascript/mastodon/components/status_list.jsx
@@ -77,6 +77,14 @@ export default class StatusList extends ImmutablePureComponent {
         return;
       }
       element = article.querySelector(".focusable");
+
+      // This happens when the article contains a LoadGap element. We just want
+      // to stop the navigation there so that the user does not erroneously skip
+      // over it.
+      if (element === null &&
+          article.querySelector(".load-more.load-gap") !== null) {
+        return;
+      }
     }
 
     if (align_top && container.scrollTop > element.offsetTop) {


### PR DESCRIPTION
When using keyboard navigation, the current code will be stumped by HTML article elements that are empty. We now skip over them.