### PR TITLE
Extract helper methods for react props in views/media/player

### DIFF
--- a/app/helpers/media_helper.rb
+++ b/app/helpers/media_helper.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module MediaHelper
+  HEIGHT = 380
+  WIDTH = 670
+
+  def react_video_props(media_attachment)
+    meta = media_attachment.file.meta || {}
+    {
+      alt: media_attachment.description,
+      blurhash: media_attachment.blurhash,
+      detailed: true,
+      editable: true,
+      frameRate: meta.dig('original', 'frame_rate'),
+      height: HEIGHT,
+      inline: true,
+      media: [ActiveModelSerializers::SerializableResource.new(media_attachment, serializer: REST::MediaAttachmentSerializer)].as_json,
+      preview: media_attachment.thumbnail.present? ? media_attachment.thumbnail.url : media_attachment.file.url(:small),
+      src: media_attachment.file.url(:original),
+      width: WIDTH,
+    }
+  end
+
+  def react_media_gallery_props(media_attachment)
+    {
+      autoplay: true,
+      height: HEIGHT,
+      media: [ActiveModelSerializers::SerializableResource.new(media_attachment, serializer: REST::MediaAttachmentSerializer).as_json],
+      standalone: true,
+    }
+  end
+
+  def react_audio_props(media_attachment)
+    meta = media_attachment.file.meta || {}
+    {
+      accentColor: meta.dig('colors', 'accent'),
+      alt: media_attachment.description,
+      backgroundColor: meta.dig('colors', 'background'),
+      duration: meta.dig(:original, :duration),
+      foregroundColor: meta.dig('colors', 'foreground'),
+      fullscreen: true,
+      height: HEIGHT,
+      poster: media_attachment.thumbnail.present? ? media_attachment.thumbnail.url : media_attachment.account.avatar_static_url,
+      src: media_attachment.file.url(:original),
+      width: WIDTH,
+    }
+  end
+end

--- a/app/views/media/player.html.haml
+++ b/app/views/media/player.html.haml
@@ -2,18 +2,15 @@
   = render_initial_state
   = javascript_pack_tag 'public', crossorigin: 'anonymous'
 
-:ruby
-  meta = @media_attachment.file.meta || {}
-
 - if @media_attachment.video?
-  = react_component :video, src: @media_attachment.file.url(:original), preview: @media_attachment.thumbnail.present? ? @media_attachment.thumbnail.url : @media_attachment.file.url(:small), frameRate: meta.dig('original', 'frame_rate'), blurhash: @media_attachment.blurhash, width: 670, height: 380, editable: true, detailed: true, inline: true, alt: @media_attachment.description, media: [ActiveModelSerializers::SerializableResource.new(@media_attachment, serializer: REST::MediaAttachmentSerializer)].as_json do
+  = react_component :video, react_video_props(@media_attachment) do
     %video{ controls: 'controls' }
       %source{ src: @media_attachment.file.url(:original) }
 - elsif @media_attachment.gifv?
-  = react_component :media_gallery, height: 380, standalone: true, autoplay: true, media: [ActiveModelSerializers::SerializableResource.new(@media_attachment, serializer: REST::MediaAttachmentSerializer).as_json] do
+  = react_component :media_gallery, react_media_gallery_props(@media_attachment) do
     %video{ autoplay: 'autoplay', muted: 'muted', loop: 'loop' }
       %source{ src: @media_attachment.file.url(:original) }
 - elsif @media_attachment.audio?
-  = react_component :audio, src: @media_attachment.file.url(:original), poster: @media_attachment.thumbnail.present? ? @media_attachment.thumbnail.url : @media_attachment.account.avatar_static_url, backgroundColor: meta.dig('colors', 'background'), foregroundColor: meta.dig('colors', 'foreground'), accentColor: meta.dig('colors', 'accent'), width: 670, height: 380, fullscreen: true, alt: @media_attachment.description, duration: meta.dig(:original, :duration) do
+  = react_component :audio, react_audio_props(@media_attachment) do
     %audio{ controls: 'controls' }
       %source{ src: @media_attachment.file.url(:original) }


### PR DESCRIPTION
Mild readability improvement by breaking out the props being passed in to helper methods. Probably room for future refactor in the helper methods themselves to DRY up some repetition between them.

Side note - while working on this I noticed that on lines 9 and 13 in this file - https://github.com/mastodon/mastodon/blob/main/app/views/media/player.html.haml#L9 - the first one for `:video` makes a call like `media: [some_code].as_json` whereas the second one for `:media_gallery` makes the call like `media: [some_code.as_json]` — note the difference of the `to_json` call being either in/out of the array. For the purposes of this PR I left those unchanged.