### PR TITLE
Handle featured collections without items

### DIFF
--- a/app/services/activitypub/fetch_featured_collection_service.rb
+++ b/app/services/activitypub/fetch_featured_collection_service.rb
@@ -37,6 +37,8 @@ class ActivityPub::FetchFeaturedCollectionService < BaseService
   end
 
   def process_items(items)
+    return if items.nil?
+
     process_note_items(items) if @options[:note]
     process_hashtag_items(items) if @options[:hashtag]
   end

--- a/spec/services/activitypub/fetch_featured_collection_service_spec.rb
+++ b/spec/services/activitypub/fetch_featured_collection_service_spec.rb
@@ -76,6 +76,7 @@ RSpec.describe ActivityPub::FetchFeaturedCollectionService, type: :service do
       stub_request(:get, 'https://example.com/account/pinned/unknown-inlined').to_return(status: 200, body: Oj.dump(status_json_pinned_unknown_inlined))
       stub_request(:get, 'https://example.com/account/pinned/unknown-unreachable').to_return(status: 404)
       stub_request(:get, 'https://example.com/account/pinned/unknown-reachable').to_return(status: 200, body: Oj.dump(status_json_pinned_unknown_unreachable))
+      stub_request(:get, 'https://example.com/account/collections/featured').to_return(status: 200, body: Oj.dump(featured_with_null))
 
       subject.call(actor, note: true, hashtag: false)
     end

--- a/spec/services/activitypub/fetch_featured_collection_service_spec.rb
+++ b/spec/services/activitypub/fetch_featured_collection_service_spec.rb
@@ -42,12 +42,22 @@ RSpec.describe ActivityPub::FetchFeaturedCollectionService, type: :service do
     }
   end
 
+  let(:featured_with_null) do
+    {
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      id: 'https://example.com/account/collections/featured',
+      totalItems: 0,
+      type: 'OrderedCollection',
+    }
+  end
+
   let(:items) do
     [
       'https://example.com/account/pinned/known', # known
       status_json_pinned_unknown_inlined, # unknown inlined
       'https://example.com/account/pinned/unknown-unreachable', # unknown unreachable
       'https://example.com/account/pinned/unknown-reachable', # unknown reachable
+      'https://example.com/account/collections/featured', # featured with null
     ]
   end
 


### PR DESCRIPTION
This is what returns from `https://ovo.st/club/board/collections/featured`

```json
{
    "@context": "https://www.w3.org/ns/activitystreams",
    "id": "https://ovo.st/club/board/collections/featured",
    "totalItems": 0,
    "type": "OrderedCollection"
}
```

And this PR would handle this kind of situation. So sidekiq will not fail