### PR TITLE
Have `Follow` activities bypass availability

### DIFF
--- a/app/services/follow_service.rb
+++ b/app/services/follow_service.rb
@@ -71,7 +71,7 @@ class FollowService < BaseService
     if @target_account.local?
       LocalNotificationWorker.perform_async(@target_account.id, follow_request.id, follow_request.class.name, 'follow_request')
     elsif @target_account.activitypub?
-      ActivityPub::DeliveryWorker.perform_async(build_json(follow_request), @source_account.id, @target_account.inbox_url)
+      ActivityPub::DeliveryWorker.perform_async(build_json(follow_request), @source_account.id, @target_account.inbox_url, { "bypass_availability" => true })
     end
 
     follow_request

--- a/app/services/follow_service.rb
+++ b/app/services/follow_service.rb
@@ -71,7 +71,7 @@ class FollowService < BaseService
     if @target_account.local?
       LocalNotificationWorker.perform_async(@target_account.id, follow_request.id, follow_request.class.name, 'follow_request')
     elsif @target_account.activitypub?
-      ActivityPub::DeliveryWorker.perform_async(build_json(follow_request), @source_account.id, @target_account.inbox_url, { "bypass_availability" => true })
+      ActivityPub::DeliveryWorker.perform_async(build_json(follow_request), @source_account.id, @target_account.inbox_url, { 'bypass_availability' => true })
     end
 
     follow_request

--- a/app/workers/activitypub/delivery_worker.rb
+++ b/app/workers/activitypub/delivery_worker.rb
@@ -25,7 +25,7 @@ class ActivityPub::DeliveryWorker
   def perform(json, source_account_id, inbox_url, options = {})
     @options        = options.with_indifferent_access
 
-    return unless DeliveryFailureTracker.available?(inbox_url) && !@options[:bypass_availability]
+    return unless DeliveryFailureTracker.available?(inbox_url) || @options[:bypass_availability]
 
     @json           = json
     @source_account = Account.find(source_account_id)

--- a/app/workers/activitypub/delivery_worker.rb
+++ b/app/workers/activitypub/delivery_worker.rb
@@ -25,7 +25,7 @@ class ActivityPub::DeliveryWorker
   def perform(json, source_account_id, inbox_url, options = {})
     @options        = options.with_indifferent_access
 
-    return unless DeliveryFailureTracker.available?(inbox_url) || @options[:bypass_availability]
+    return unless @options[:bypass_availability] || DeliveryFailureTracker.available?(inbox_url)
 
     @json           = json
     @source_account = Account.find(source_account_id)

--- a/app/workers/activitypub/delivery_worker.rb
+++ b/app/workers/activitypub/delivery_worker.rb
@@ -23,9 +23,10 @@ class ActivityPub::DeliveryWorker
   HEADERS = { 'Content-Type' => 'application/activity+json' }.freeze
 
   def perform(json, source_account_id, inbox_url, options = {})
-    return unless DeliveryFailureTracker.available?(inbox_url)
-
     @options        = options.with_indifferent_access
+
+    return unless DeliveryFailureTracker.available?(inbox_url) && !@options[:bypass_availability]
+
     @json           = json
     @source_account = Account.find(source_account_id)
     @inbox_url      = inbox_url


### PR DESCRIPTION
This fixes https://github.com/mastodon/mastodon/issues/27458, and is related to (but does not resolve) https://github.com/Automattic/wordpress-activitypub/issues/523

This is in accordance with the suggestion I made here: https://github.com/mastodon/mastodon/issues/27525#issuecomment-1779880830

The consequences of this is that Follow requests can bounce around the queue for a while, without being affected by availability. They'll still be affected by stoplight, but those are temporary.

A user could technically spam follows and have them enter the queue en-masse, but these would be short-circuited by stoplight all the same, so I don't think that has much impact. (Besides, users could still do this with the likes of fav-unfav or other activities, so there's not much increased risk)

---

This PR is intended to help "wedged" federation, where a remote account is not "accessible" (or "stuck in Follow Request state") because the local server has stopped delivery for that server.

This is especially notable in cases where the remote server is a follow-along-like actor (such as a blog) which is not intended to have social dynamics, such as "following back", or "mentioning" the account out of the blue, which would've otherwise unwedged federation in other cases.

This PR adds a simple availability bypass to the delivery worker, which is only granted on the case of a user-initiated follow request.

These follow requests are then often accompanied by an authorisation, which then unwedges the delivery failure tracker, as it has now "seen" a response from that inbox. Normal federation can resume hereafter.

By effect, a `Follow` activity then becomes a SYN-like first step to re-establish federation after it has broken down or bugged via the availability tracker.