### PR TITLE
Fix bug where remote suspension causes local instance to remove remote follows

### DIFF
--- a/app/services/suspend_account_service.rb
+++ b/app/services/suspend_account_service.rb
@@ -20,7 +20,7 @@ class SuspendAccountService < BaseService
   private
 
   def reject_remote_follows!
-    return if @account.local? || !@account.activitypub?
+    return if @account.local? || !@account.activitypub? || @account.suspension_origin_remote?
 
     # When suspending a remote account, the account obviously doesn't
     # actually become suspended on its origin server, i.e. unlike a


### PR DESCRIPTION
This does not have an issue number, but I noticed this bug while looking at the comment.

The comment presumes that this code will only be run when the suspension comes locally, but I've observed the code being triggered when a remote account gets suspended remotely, causing the local server to issue follow rejects to that account.

According to the comment, this is not intended, and any (temporary) local suspension will effectively remove remote follows.