### PR TITLE
Use `deliveries.size` in mailer-related examples in controller specs

### DIFF
--- a/spec/controllers/admin/disputes/appeals_controller_spec.rb
+++ b/spec/controllers/admin/disputes/appeals_controller_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Admin::Disputes::AppealsController do
     it 'notifies target account about approved appeal' do
       expect(UserMailer.deliveries.size).to eq(1)
       expect(UserMailer.deliveries.first.to.first).to eq(target_account.user.email)
-      expect(UserMailer.deliveries.first.subject).to match(/approved/)
+      expect(UserMailer.deliveries.first.subject).to eq(I18n.t('user_mailer.appeal_approved.subject', date: I18n.l(appeal.created_at)))
     end
   end
 
@@ -65,7 +65,7 @@ RSpec.describe Admin::Disputes::AppealsController do
     it 'notifies target account about rejected appeal' do
       expect(UserMailer.deliveries.size).to eq(1)
       expect(UserMailer.deliveries.first.to.first).to eq(target_account.user.email)
-      expect(UserMailer.deliveries.first.subject).to match(/rejected/)
+      expect(UserMailer.deliveries.first.subject).to eq(I18n.t('user_mailer.appeal_rejected.subject', date: I18n.l(appeal.created_at)))
     end
   end
 end

--- a/spec/controllers/admin/disputes/appeals_controller_spec.rb
+++ b/spec/controllers/admin/disputes/appeals_controller_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe Admin::Disputes::AppealsController do
     it 'notifies target account about approved appeal' do
       expect(UserMailer.deliveries.size).to eq(1)
       expect(UserMailer.deliveries.first.to.first).to eq(target_account.user.email)
+      expect(UserMailer.deliveries.first.subject).to match(/approved/)
     end
   end
 
@@ -64,6 +65,7 @@ RSpec.describe Admin::Disputes::AppealsController do
     it 'notifies target account about rejected appeal' do
       expect(UserMailer.deliveries.size).to eq(1)
       expect(UserMailer.deliveries.first.to.first).to eq(target_account.user.email)
+      expect(UserMailer.deliveries.first.subject).to match(/rejected/)
     end
   end
 end

--- a/spec/controllers/admin/disputes/appeals_controller_spec.rb
+++ b/spec/controllers/admin/disputes/appeals_controller_spec.rb
@@ -33,8 +33,6 @@ RSpec.describe Admin::Disputes::AppealsController do
     let(:current_user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
 
     before do
-      allow(UserMailer).to receive(:appeal_approved)
-        .and_return(instance_double(ActionMailer::MessageDelivery, deliver_later: nil))
       post :approve, params: { id: appeal.id }
     end
 
@@ -47,7 +45,7 @@ RSpec.describe Admin::Disputes::AppealsController do
     end
 
     it 'notifies target account about approved appeal' do
-      expect(UserMailer).to have_received(:appeal_approved).with(target_account.user, appeal)
+      expect(UserMailer.deliveries.size).to eq(1)
     end
   end
 
@@ -55,8 +53,6 @@ RSpec.describe Admin::Disputes::AppealsController do
     let(:current_user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
 
     before do
-      allow(UserMailer).to receive(:appeal_rejected)
-        .and_return(instance_double(ActionMailer::MessageDelivery, deliver_later: nil))
       post :reject, params: { id: appeal.id }
     end
 
@@ -65,7 +61,7 @@ RSpec.describe Admin::Disputes::AppealsController do
     end
 
     it 'notifies target account about rejected appeal' do
-      expect(UserMailer).to have_received(:appeal_rejected).with(target_account.user, appeal)
+      expect(UserMailer.deliveries.size).to eq(1)
     end
   end
 end

--- a/spec/controllers/admin/disputes/appeals_controller_spec.rb
+++ b/spec/controllers/admin/disputes/appeals_controller_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe Admin::Disputes::AppealsController do
 
     it 'notifies target account about approved appeal' do
       expect(UserMailer.deliveries.size).to eq(1)
+      expect(UserMailer.deliveries.first.to.first).to eq(target_account.user.email)
     end
   end
 
@@ -62,6 +63,7 @@ RSpec.describe Admin::Disputes::AppealsController do
 
     it 'notifies target account about rejected appeal' do
       expect(UserMailer.deliveries.size).to eq(1)
+      expect(UserMailer.deliveries.first.to.first).to eq(target_account.user.email)
     end
   end
 end

--- a/spec/controllers/auth/sessions_controller_spec.rb
+++ b/spec/controllers/auth/sessions_controller_spec.rb
@@ -141,6 +141,8 @@ RSpec.describe Auth::SessionsController do
 
         it 'sends a suspicious sign-in mail' do
           expect(UserMailer.deliveries.size).to eq(1)
+          expect(UserMailer.deliveries.first.to.first).to eq(user.email)
+          expect(UserMailer.deliveries.first.subject).to eq(I18n.t('user_mailer.suspicious_sign_in.subject'))
         end
       end
 

--- a/spec/controllers/auth/sessions_controller_spec.rb
+++ b/spec/controllers/auth/sessions_controller_spec.rb
@@ -127,8 +127,6 @@ RSpec.describe Auth::SessionsController do
 
         before do
           allow_any_instance_of(ActionDispatch::Request).to receive(:remote_ip).and_return(current_ip)
-          allow(UserMailer).to receive(:suspicious_sign_in)
-            .and_return(instance_double(ActionMailer::MessageDelivery, deliver_later!: nil))
           user.update(current_sign_in_at: 1.month.ago)
           post :create, params: { user: { email: user.email, password: user.password } }
         end
@@ -142,7 +140,7 @@ RSpec.describe Auth::SessionsController do
         end
 
         it 'sends a suspicious sign-in mail' do
-          expect(UserMailer).to have_received(:suspicious_sign_in).with(user, current_ip, anything, anything)
+          expect(UserMailer.deliveries.size).to eq(1)
         end
       end
 


### PR DESCRIPTION
These changes were originally in https://github.com/mastodon/mastodon/pull/25884 and would have caught the bug discovered there - https://github.com/mastodon/mastodon/pull/27486/commits/e87fa080d07c62fc28d29628b892e225717531b3 - (missing deliver call on one of the mailer lines). This should have been included in https://github.com/mastodon/mastodon/pull/27486 as well.