### PR TITLE
Use `normalizes` on `CustomFilter#context` value

### DIFF
--- a/app/models/custom_filter.rb
+++ b/app/models/custom_filter.rb
@@ -41,7 +41,7 @@ class CustomFilter < ApplicationRecord
   validates :title, :context, presence: true
   validate :context_must_be_valid
 
-  before_validation :clean_up_contexts
+  normalizes :context, with: ->(context) { context.map(&:strip).filter_map(&:presence) }
 
   before_save :prepare_cache_invalidation!
   before_destroy :prepare_cache_invalidation!
@@ -113,10 +113,6 @@ class CustomFilter < ApplicationRecord
   end
 
   private
-
-  def clean_up_contexts
-    self.context = Array(context).map(&:strip).filter_map(&:presence)
-  end
 
   def context_must_be_valid
     errors.add(:context, I18n.t('filters.errors.invalid_context')) if invalid_context_value?

--- a/spec/models/custom_filter_spec.rb
+++ b/spec/models/custom_filter_spec.rb
@@ -32,4 +32,12 @@ RSpec.describe CustomFilter do
       expect(record).to model_have_error_on_field(:context)
     end
   end
+
+  describe 'Normalizations' do
+    it 'cleans up context values' do
+      record = described_class.new(context: ['home', 'notifications', 'public    ', ''])
+
+      expect(record.context).to eq(%w(home notifications public))
+    end
+  end
 end


### PR DESCRIPTION
This was originally in https://github.com/mastodon/mastodon/pull/27521 but after the final Rails 7.1 rebase there were some errors that I couldn't figure out quickly so I removed it from that one.

Added some spec coverage here to be more confident and I think this change (adding normalization, refactor on existing validation) preserves the prior validations and data cleanup behaviour. Will watch CI to see if the prior issue is resolved.