### PR TITLE
Use `normalizes` to prepare `Webhook#events` value

### DIFF
--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -33,11 +33,11 @@ class Webhook < ApplicationRecord
   validates :secret, presence: true, length: { minimum: 12 }
   validates :events, presence: true
 
-  validate :validate_events
+  validate :events_validation_error, if: :invalid_events?
   validate :validate_permissions
   validate :validate_template
 
-  before_validation :strip_events
+  normalizes :events, with: ->(events) { events.filter_map(&:strip).filter_map(&:presence) }
   before_validation :generate_secret
 
   def rotate_secret!
@@ -69,8 +69,12 @@ class Webhook < ApplicationRecord
 
   private
 
-  def validate_events
-    errors.add(:events, :invalid) if events.any? { |e| EVENTS.exclude?(e) }
+  def events_validation_error
+    errors.add(:events, :invalid)
+  end
+
+  def invalid_events?
+    events.blank? || events.difference(EVENTS).any?
   end
 
   def validate_permissions
@@ -86,10 +90,6 @@ class Webhook < ApplicationRecord
     rescue Parslet::ParseFailed
       errors.add(:template, :invalid)
     end
-  end
-
-  def strip_events
-    self.events = events.filter_map { |str| str.strip.presence } if events.present?
   end
 
   def generate_secret

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -37,7 +37,7 @@ class Webhook < ApplicationRecord
   validate :validate_permissions
   validate :validate_template
 
-  normalizes :events, with: ->(events) { events.filter_map(&:strip).filter_map(&:presence) }
+  normalizes :events, with: ->(events) { events.filter_map { |event| event.strip.presence } }
   before_validation :generate_secret
 
   def rotate_secret!

--- a/spec/models/webhook_spec.rb
+++ b/spec/models/webhook_spec.rb
@@ -5,6 +5,37 @@ require 'rails_helper'
 RSpec.describe Webhook do
   let(:webhook) { Fabricate(:webhook) }
 
+  describe 'Validations' do
+    it 'requires presence of events' do
+      record = described_class.new(events: nil)
+      record.valid?
+
+      expect(record).to model_have_error_on_field(:events)
+    end
+
+    it 'requires non-empty events value' do
+      record = described_class.new(events: [])
+      record.valid?
+
+      expect(record).to model_have_error_on_field(:events)
+    end
+
+    it 'requires valid events value from EVENTS' do
+      record = described_class.new(events: ['account.invalid'])
+      record.valid?
+
+      expect(record).to model_have_error_on_field(:events)
+    end
+  end
+
+  describe 'Normalizations' do
+    it 'cleans up events values' do
+      record = described_class.new(events: ['account.approved', 'account.created     ', ''])
+
+      expect(record.events).to eq(%w(account.approved account.created))
+    end
+  end
+
   describe '#rotate_secret!' do
     it 'changes the secret' do
       previous_value = webhook.secret


### PR DESCRIPTION
Same deal as https://github.com/mastodon/mastodon/pull/27602 - left this out of initial PR post-upgrade. I think this one does not have the caching<>Marshall interaction issue the other one does.