### PR TITLE
Fix AutosuggestTextarea re-render

### DIFF
--- a/app/javascript/mastodon/components/autosuggest_textarea.jsx
+++ b/app/javascript/mastodon/components/autosuggest_textarea.jsx
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import { flushSync } from 'react-dom';
 
 import classNames from 'classnames';
 
@@ -74,7 +75,9 @@ export default class AutosuggestTextarea extends ImmutablePureComponent {
       this.setState({ lastToken: token, selectedSuggestion: 0, tokenStart });
       this.props.onSuggestionsFetchRequested(token);
     } else if (token === null) {
-      this.setState({ lastToken: null });
+      flushSync(() => {
+        this.setState({ lastToken: null });
+      });
       this.props.onSuggestionsClearRequested();
     }
 

--- a/app/javascript/mastodon/components/autosuggest_textarea.jsx
+++ b/app/javascript/mastodon/components/autosuggest_textarea.jsx
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import { flushSync } from 'react-dom';
 
 import classNames from 'classnames';
 
@@ -75,9 +74,7 @@ export default class AutosuggestTextarea extends ImmutablePureComponent {
       this.setState({ lastToken: token, selectedSuggestion: 0, tokenStart });
       this.props.onSuggestionsFetchRequested(token);
     } else if (token === null) {
-      flushSync(() => {
-        this.setState({ lastToken: null });
-      });
+      this.state.lastToken = null;
       this.props.onSuggestionsClearRequested();
     }
 


### PR DESCRIPTION
Follow-up to #25047.

This is probably an unintended behavior caused by concurrent rendering introduced in React 18.

Therefore, we are using flushSync to opt out only the problematic parts and make them behave as before.


