### PR TITLE
Fix `RSpec/LetSetup` cop in spec/controllers/admin area

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -130,11 +130,6 @@ RSpec/InstanceVariable:
 
 RSpec/LetSetup:
   Exclude:
-    - 'spec/controllers/admin/accounts_controller_spec.rb'
-    - 'spec/controllers/admin/action_logs_controller_spec.rb'
-    - 'spec/controllers/admin/instances_controller_spec.rb'
-    - 'spec/controllers/admin/reports/actions_controller_spec.rb'
-    - 'spec/controllers/admin/statuses_controller_spec.rb'
     - 'spec/controllers/api/v1/accounts/statuses_controller_spec.rb'
     - 'spec/controllers/api/v1/filters_controller_spec.rb'
     - 'spec/controllers/api/v2/admin/accounts_controller_spec.rb'

--- a/spec/controllers/admin/accounts_controller_spec.rb
+++ b/spec/controllers/admin/accounts_controller_spec.rb
@@ -285,7 +285,10 @@ RSpec.describe Admin::AccountsController do
 
     let(:current_user) { Fabricate(:user, role: role) }
     let(:account) { Fabricate(:account, suspended: true) }
-    let!(:email_block) { Fabricate(:canonical_email_block, reference_account: account) }
+
+    before do
+      _email_block = Fabricate(:canonical_email_block, reference_account: account)
+    end
 
     context 'when user is admin' do
       let(:role) { UserRole.find_by(name: 'Admin') }

--- a/spec/controllers/admin/action_logs_controller_spec.rb
+++ b/spec/controllers/admin/action_logs_controller_spec.rb
@@ -8,8 +8,8 @@ describe Admin::ActionLogsController do
   # Action logs typically cause issues when their targets are not in the database
   let!(:account) { Fabricate(:account) }
 
-  let!(:orphaned_logs) do
-    %w(
+  before do
+    _orphaned_logs = %w(
       Account User UserRole Report DomainBlock DomainAllow
       EmailDomainBlock UnavailableDomain Status AccountWarning
       Announcement IpBlock Instance CustomEmoji CanonicalEmailBlock Appeal

--- a/spec/controllers/admin/instances_controller_spec.rb
+++ b/spec/controllers/admin/instances_controller_spec.rb
@@ -8,10 +8,10 @@ RSpec.describe Admin::InstancesController do
   let(:current_user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
 
   let!(:account_popular_main) { Fabricate(:account, domain: 'popular') }
-  let!(:account_popular_other) { Fabricate(:account, domain: 'popular') }
-  let!(:account_less_popular) { Fabricate(:account, domain: 'less.popular') }
 
   before do
+    _account_less_popular = Fabricate(:account, domain: 'less.popular')
+    _account_popular_other = Fabricate(:account, domain: 'popular')
     sign_in current_user, scope: :user
   end
 

--- a/spec/controllers/admin/reports/actions_controller_spec.rb
+++ b/spec/controllers/admin/reports/actions_controller_spec.rb
@@ -54,11 +54,14 @@ describe Admin::Reports::ActionsController do
   describe 'POST #create' do
     let(:target_account) { Fabricate(:account) }
     let(:statuses)       { [Fabricate(:status, account: target_account), Fabricate(:status, account: target_account)] }
-    let!(:media)         { Fabricate(:media_attachment, account: target_account, status: statuses[0]) }
     let(:report)         { Fabricate(:report, target_account: target_account, status_ids: statuses.map(&:id)) }
     let(:text)           { 'hello' }
     let(:common_params) do
       { report_id: report.id, text: text }
+    end
+
+    before do
+      _media = Fabricate(:media_attachment, account: target_account, status: statuses[0])
     end
 
     shared_examples 'common behavior' do
@@ -122,14 +125,17 @@ describe Admin::Reports::ActionsController do
         let(:action) { 'mark_as_sensitive' }
         let(:statuses) { [media_attached_status, media_attached_deleted_status] }
 
-        let!(:status) { Fabricate(:status, account: target_account) }
         let(:media_attached_status) { Fabricate(:status, account: target_account) }
-        let!(:media_attachment) { Fabricate(:media_attachment, account: target_account, status: media_attached_status) }
         let(:media_attached_deleted_status) { Fabricate(:status, account: target_account, deleted_at: 1.day.ago) }
-        let!(:media_attachment2) { Fabricate(:media_attachment, account: target_account, status: media_attached_deleted_status) }
         let(:last_media_attached_status) { Fabricate(:status, account: target_account) }
-        let!(:last_media_attachment) { Fabricate(:media_attachment, account: target_account, status: last_media_attached_status) }
-        let!(:last_status) { Fabricate(:status, account: target_account) }
+
+        before do
+          _last_media_attachment = Fabricate(:media_attachment, account: target_account, status: last_media_attached_status)
+          _last_status = Fabricate(:status, account: target_account)
+          _media_attachment = Fabricate(:media_attachment, account: target_account, status: media_attached_status)
+          _media_attachment2 = Fabricate(:media_attachment, account: target_account, status: media_attached_deleted_status)
+          _status = Fabricate(:status, account: target_account)
+        end
 
         it_behaves_like 'common behavior'
 

--- a/spec/controllers/admin/statuses_controller_spec.rb
+++ b/spec/controllers/admin/statuses_controller_spec.rb
@@ -9,13 +9,14 @@ describe Admin::StatusesController do
   let(:account) { Fabricate(:account) }
   let!(:status) { Fabricate(:status, account: account) }
   let(:media_attached_status) { Fabricate(:status, account: account, sensitive: !sensitive) }
-  let!(:media_attachment) { Fabricate(:media_attachment, account: account, status: media_attached_status) }
   let(:last_media_attached_status) { Fabricate(:status, account: account, sensitive: !sensitive) }
-  let!(:last_media_attachment) { Fabricate(:media_attachment, account: account, status: last_media_attached_status) }
-  let!(:last_status) { Fabricate(:status, account: account) }
   let(:sensitive) { true }
 
   before do
+    _last_media_attachment = Fabricate(:media_attachment, account: account, status: last_media_attached_status)
+    _last_status = Fabricate(:status, account: account)
+    _media_attachment = Fabricate(:media_attachment, account: account, status: media_attached_status)
+
     sign_in user, scope: :user
   end
 


### PR DESCRIPTION
Some of the other things under this rule need more finessing, but the `/admin/` area ones were all just straightforward records which were effectively `before` setup just not placed there. Kept some variable names to reflect purpose of each setup.