### PR TITLE
Add zeitwerk inflector for cli->CLI

### DIFF
--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -13,21 +13,22 @@
 # end
 
 ActiveSupport::Inflector.inflections(:en) do |inflect|
-  inflect.acronym 'StatsD'
-  inflect.acronym 'OEmbed'
-  inflect.acronym 'OStatus'
   inflect.acronym 'ActivityPub'
-  inflect.acronym 'PubSubHubbub'
   inflect.acronym 'ActivityStreams'
-  inflect.acronym 'JsonLd'
-  inflect.acronym 'Ed25519'
-  inflect.acronym 'TOC'
-  inflect.acronym 'RSS'
-  inflect.acronym 'REST'
-  inflect.acronym 'URL'
   inflect.acronym 'ASCII'
+  inflect.acronym 'CLI'
   inflect.acronym 'DeepL'
   inflect.acronym 'DSL'
+  inflect.acronym 'Ed25519'
+  inflect.acronym 'JsonLd'
+  inflect.acronym 'OEmbed'
+  inflect.acronym 'OStatus'
+  inflect.acronym 'PubSubHubbub'
+  inflect.acronym 'REST'
+  inflect.acronym 'RSS'
+  inflect.acronym 'StatsD'
+  inflect.acronym 'TOC'
+  inflect.acronym 'URL'
 
   inflect.singular 'data', 'data'
 end


### PR DESCRIPTION
_Extracted from https://github.com/mastodon/mastodon/pull/27556_

Pre-requisite for getting the autoload_lib feature enabled. This one tells zeitwerk to expect `CLI` instead of `Cli` in our `lib/mastodon/cli/*` classes. We could alternately move the files to a `c_l_i` dir, or rename the module to `Cli`, but those feel worse than this mapping update.