### PR TITLE
Rename Paperclip UrlGeneratorExtensions -> URLGeneratorExtensions

### DIFF
--- a/lib/paperclip/url_generator_extensions.rb
+++ b/lib/paperclip/url_generator_extensions.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 module Paperclip
-  module UrlGeneratorExtensions
+  module URLGeneratorExtensions
     def for_as_default(style_name)
       attachment_options[:interpolator].interpolate(default_url, @attachment, style_name)
     end
   end
 end
 
-Paperclip::UrlGenerator.prepend(Paperclip::UrlGeneratorExtensions)
+Paperclip::UrlGenerator.prepend(Paperclip::URLGeneratorExtensions)


### PR DESCRIPTION
_Extracted from https://github.com/mastodon/mastodon/pull/27556_

Because we already configure `URL` as an acroynm in inflections.rb elsewhere in the project, zeitwerk expects it be named this way for autoload. If it were critical to preserve the `UrlGener...` module name, we could rename the file like `u_r_l_gener...` instead.