### PR TITLE
Reduce CI job matrix job count

### DIFF
--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Load database schema
         run: './bin/rails db:create db:schema:load db:seed'
 
-      - run: bundle exec rake
+      - run: bin/rspec
 
   test-e2e:
     name: End to End testing

--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -105,7 +105,6 @@ jobs:
       SAML_ENABLED: true
       CAS_ENABLED: true
       BUNDLE_WITH: 'pam_authentication test'
-      CI_JOBS: ${{ matrix.ci_job }}/4
       GITHUB_RSPEC: ${{ matrix.ruby-version == '.ruby-version' && github.event.pull_request && 'true' }}
 
     strategy:
@@ -115,11 +114,6 @@ jobs:
           - '3.0'
           - '3.1'
           - '.ruby-version'
-        ci_job:
-          - 1
-          - 2
-          - 3
-          - 4
     steps:
       - uses: actions/checkout@v4
 
@@ -141,7 +135,7 @@ jobs:
       - name: Load database schema
         run: './bin/rails db:create db:schema:load db:seed'
 
-      - run: bundle exec rake rspec_chunked
+      - run: bundle exec rake
 
   test-e2e:
     name: End to End testing

--- a/Gemfile
+++ b/Gemfile
@@ -103,9 +103,6 @@ gem 'rdf-normalize', '~> 0.5'
 gem 'private_address_check', '~> 0.5'
 
 group :test do
-  # Used to split testing into chunks in CI
-  gem 'rspec_chunked', '~> 0.6'
-
   # Adds RSpec Error/Warning annotations to GitHub PRs on the Files tab
   gem 'rspec-github', '~> 2.4', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -648,7 +648,6 @@ GEM
       rspec-mocks (~> 3.0)
       sidekiq (>= 5, < 8)
     rspec-support (3.12.1)
-    rspec_chunked (0.6)
     rubocop (1.57.1)
       base64 (~> 0.1.1)
       json (~> 2.3)
@@ -919,7 +918,6 @@ DEPENDENCIES
   rspec-github (~> 2.4)
   rspec-rails (~> 6.0)
   rspec-sidekiq (~> 4.0)
-  rspec_chunked (~> 0.6)
   rubocop
   rubocop-capybara
   rubocop-performance


### PR DESCRIPTION
Previously we were splitting each full ruby spec suite run into four parts, and running each of those parts for each supported ruby version. This creates 12 ruby testing jobs on each CI run.

While we benefit from the parallelization of the spec suite itself running, we pay penalties for this setup:

- Overall concurrent jobs across the account are limited, so the more we use in each workflow, there's a potential delay to other workflows/jobs starting.
- To the extent the setup portions of each job are expensive, we make it worse by running them 12x instead of 3x

This change removes the `rspec_chunked` gem and stops using the CI job split matrix, reverting back instead to a regular full spec suite run in each ruby version.