### PR TITLE
Archive uploaded CI assets into single file between build/test

### DIFF
--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Archive asset artifacts
         run: |
-          tar cvzf artifacts.tar.gz public/assets public/packs*
+          tar --exclude={"*.br","*.gz"} -zcf artifacts.tar.gz public/assets public/packs*
 
       - uses: actions/upload-artifact@v3
         if: matrix.mode == 'test'

--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -48,12 +48,15 @@ jobs:
         run: |-
           ./bin/rails assets:precompile
 
+      - name: Archive asset artifacts
+        run: |
+          tar cvzf artifacts.tar.gz public/assets public/packs*
+
       - uses: actions/upload-artifact@v3
         if: matrix.mode == 'test'
         with:
           path: |-
-            ./public/assets
-            ./public/packs-test
+            ./artifacts.tar.gz
           name: ${{ github.sha }}
           retention-days: 0
 
@@ -122,8 +125,12 @@ jobs:
 
       - uses: actions/download-artifact@v3
         with:
-          path: './public'
+          path: './'
           name: ${{ github.sha }}
+
+      - name: Expand archived asset artifacts
+        run: |
+          tar xvzf artifacts.tar.gz
 
       - name: Set up Ruby environment
         uses: ./.github/actions/setup-ruby


### PR DESCRIPTION
Related to https://github.com/mastodon/mastodon/pull/27660 and https://github.com/mastodon/mastodon/pull/27663 this is attempting to speed up the upload artifacts portion of the build job and the download portion of the test job.

Will also watch performance here and update with numbers.