### PR TITLE
Account statuses filter spec speedup

### DIFF
--- a/spec/lib/account_statuses_filter_spec.rb
+++ b/spec/lib/account_statuses_filter_spec.rb
@@ -89,15 +89,11 @@ RSpec.describe AccountStatusesFilter do
       let(:current_account) { nil }
       let(:direct_status) { nil }
 
-      it 'returns only public statuses' do
+      it 'returns only public statuses, public replies, and public reblogs' do
         expect(results_unique_visibilities).to match_array %w(unlisted public)
-      end
 
-      it 'returns public replies' do
         expect(results_in_reply_to_ids).to_not be_empty
-      end
 
-      it 'returns public reblogs' do
         expect(results_reblog_of_ids).to_not be_empty
       end
 
@@ -119,15 +115,11 @@ RSpec.describe AccountStatusesFilter do
     context 'when accessed by self' do
       let(:current_account) { account }
 
-      it 'returns everything' do
+      it 'returns all statuses, replies, and reblogs' do
         expect(results_unique_visibilities).to match_array %w(direct private unlisted public)
-      end
 
-      it 'returns replies' do
         expect(results_in_reply_to_ids).to_not be_empty
-      end
 
-      it 'returns reblogs' do
         expect(results_reblog_of_ids).to_not be_empty
       end
 
@@ -141,15 +133,11 @@ RSpec.describe AccountStatusesFilter do
         current_account.follow!(account)
       end
 
-      it 'returns private statuses' do
+      it 'returns private statuses, replies, and reblogs' do
         expect(results_unique_visibilities).to match_array %w(private unlisted public)
-      end
 
-      it 'returns replies' do
         expect(results_in_reply_to_ids).to_not be_empty
-      end
 
-      it 'returns reblogs' do
         expect(results_reblog_of_ids).to_not be_empty
       end
 
@@ -167,15 +155,11 @@ RSpec.describe AccountStatusesFilter do
     context 'when accessed by a non-follower' do
       let(:current_account) { Fabricate(:account) }
 
-      it 'returns only public statuses' do
+      it 'returns only public statuses, replies, and reblogs' do
         expect(results_unique_visibilities).to match_array %w(unlisted public)
-      end
 
-      it 'returns public replies' do
         expect(results_in_reply_to_ids).to_not be_empty
-      end
 
-      it 'returns public reblogs' do
         expect(results_reblog_of_ids).to_not be_empty
       end
 

--- a/spec/lib/account_statuses_filter_spec.rb
+++ b/spec/lib/account_statuses_filter_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe AccountStatusesFilter do
       let(:direct_status) { nil }
 
       it 'returns only public statuses' do
-        expect(subject.pluck(:visibility).uniq).to match_array %w(unlisted public)
+        expect(results_unique_visibilities).to match_array %w(unlisted public)
       end
 
       it 'returns public replies' do
@@ -120,7 +120,7 @@ RSpec.describe AccountStatusesFilter do
       let(:current_account) { account }
 
       it 'returns everything' do
-        expect(subject.pluck(:visibility).uniq).to match_array %w(direct private unlisted public)
+        expect(results_unique_visibilities).to match_array %w(direct private unlisted public)
       end
 
       it 'returns replies' do
@@ -142,7 +142,7 @@ RSpec.describe AccountStatusesFilter do
       end
 
       it 'returns private statuses' do
-        expect(subject.pluck(:visibility).uniq).to match_array %w(private unlisted public)
+        expect(results_unique_visibilities).to match_array %w(private unlisted public)
       end
 
       it 'returns replies' do
@@ -168,7 +168,7 @@ RSpec.describe AccountStatusesFilter do
       let(:current_account) { Fabricate(:account) }
 
       it 'returns only public statuses' do
-        expect(subject.pluck(:visibility).uniq).to match_array %w(unlisted public)
+        expect(results_unique_visibilities).to match_array %w(unlisted public)
       end
 
       it 'returns public replies' do
@@ -252,6 +252,12 @@ RSpec.describe AccountStatusesFilter do
       end
 
       it_behaves_like 'filter params'
+    end
+
+    private
+
+    def results_unique_visibilities
+      subject.pluck(:visibility).uniq
     end
   end
 end

--- a/spec/lib/account_statuses_filter_spec.rb
+++ b/spec/lib/account_statuses_filter_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe AccountStatusesFilter do
       end
 
       it 'returns public replies' do
-        expect(subject.pluck(:in_reply_to_id)).to_not be_empty
+        expect(results_in_reply_to_ids).to_not be_empty
       end
 
       it 'returns public reblogs' do
@@ -124,7 +124,7 @@ RSpec.describe AccountStatusesFilter do
       end
 
       it 'returns replies' do
-        expect(subject.pluck(:in_reply_to_id)).to_not be_empty
+        expect(results_in_reply_to_ids).to_not be_empty
       end
 
       it 'returns reblogs' do
@@ -146,7 +146,7 @@ RSpec.describe AccountStatusesFilter do
       end
 
       it 'returns replies' do
-        expect(subject.pluck(:in_reply_to_id)).to_not be_empty
+        expect(results_in_reply_to_ids).to_not be_empty
       end
 
       it 'returns reblogs' do
@@ -172,7 +172,7 @@ RSpec.describe AccountStatusesFilter do
       end
 
       it 'returns public replies' do
-        expect(subject.pluck(:in_reply_to_id)).to_not be_empty
+        expect(results_in_reply_to_ids).to_not be_empty
       end
 
       it 'returns public reblogs' do
@@ -258,6 +258,10 @@ RSpec.describe AccountStatusesFilter do
 
     def results_unique_visibilities
       subject.pluck(:visibility).uniq
+    end
+
+    def results_in_reply_to_ids
+      subject.pluck(:in_reply_to_id)
     end
   end
 end

--- a/spec/lib/account_statuses_filter_spec.rb
+++ b/spec/lib/account_statuses_filter_spec.rb
@@ -3,8 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe AccountStatusesFilter do
-  subject { described_class.new(account, current_account, params) }
-
   let(:account) { Fabricate(:account) }
   let(:current_account) { nil }
   let(:params) { {} }
@@ -38,6 +36,8 @@ RSpec.describe AccountStatusesFilter do
   end
 
   describe '#results' do
+    subject { described_class.new(account, current_account, params) }
+
     let(:tag) { Fabricate(:tag) }
 
     before do

--- a/spec/lib/account_statuses_filter_spec.rb
+++ b/spec/lib/account_statuses_filter_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe AccountStatusesFilter do
   end
 
   describe '#results' do
-    subject { described_class.new(account, current_account, params) }
+    subject { described_class.new(account, current_account, params).results }
 
     let(:tag) { Fabricate(:tag) }
 
@@ -56,7 +56,7 @@ RSpec.describe AccountStatusesFilter do
         let(:params) { { only_media: true } }
 
         it 'returns only statuses with media' do
-          expect(subject.results.all?(&:with_media?)).to be true
+          expect(subject.all?(&:with_media?)).to be true
         end
       end
 
@@ -64,7 +64,7 @@ RSpec.describe AccountStatusesFilter do
         let(:params) { { tagged: tag.name } }
 
         it 'returns only statuses with tag' do
-          expect(subject.results.all? { |s| s.tags.include?(tag) }).to be true
+          expect(subject.all? { |s| s.tags.include?(tag) }).to be true
         end
       end
 
@@ -72,7 +72,7 @@ RSpec.describe AccountStatusesFilter do
         let(:params) { { exclude_replies: true } }
 
         it 'returns only statuses that are not replies' do
-          expect(subject.results.none?(&:reply?)).to be true
+          expect(subject.none?(&:reply?)).to be true
         end
       end
 
@@ -80,7 +80,7 @@ RSpec.describe AccountStatusesFilter do
         let(:params) { { exclude_reblogs: true } }
 
         it 'returns only statuses that are not reblogs' do
-          expect(subject.results.none?(&:reblog?)).to be true
+          expect(subject.none?(&:reblog?)).to be true
         end
       end
     end
@@ -90,15 +90,15 @@ RSpec.describe AccountStatusesFilter do
       let(:direct_status) { nil }
 
       it 'returns only public statuses' do
-        expect(subject.results.pluck(:visibility).uniq).to match_array %w(unlisted public)
+        expect(subject.pluck(:visibility).uniq).to match_array %w(unlisted public)
       end
 
       it 'returns public replies' do
-        expect(subject.results.pluck(:in_reply_to_id)).to_not be_empty
+        expect(subject.pluck(:in_reply_to_id)).to_not be_empty
       end
 
       it 'returns public reblogs' do
-        expect(subject.results.pluck(:reblog_of_id)).to_not be_empty
+        expect(subject.pluck(:reblog_of_id)).to_not be_empty
       end
 
       it_behaves_like 'filter params'
@@ -112,7 +112,7 @@ RSpec.describe AccountStatusesFilter do
       end
 
       it 'returns nothing' do
-        expect(subject.results.to_a).to be_empty
+        expect(subject.to_a).to be_empty
       end
     end
 
@@ -120,15 +120,15 @@ RSpec.describe AccountStatusesFilter do
       let(:current_account) { account }
 
       it 'returns everything' do
-        expect(subject.results.pluck(:visibility).uniq).to match_array %w(direct private unlisted public)
+        expect(subject.pluck(:visibility).uniq).to match_array %w(direct private unlisted public)
       end
 
       it 'returns replies' do
-        expect(subject.results.pluck(:in_reply_to_id)).to_not be_empty
+        expect(subject.pluck(:in_reply_to_id)).to_not be_empty
       end
 
       it 'returns reblogs' do
-        expect(subject.results.pluck(:reblog_of_id)).to_not be_empty
+        expect(subject.pluck(:reblog_of_id)).to_not be_empty
       end
 
       it_behaves_like 'filter params'
@@ -142,22 +142,22 @@ RSpec.describe AccountStatusesFilter do
       end
 
       it 'returns private statuses' do
-        expect(subject.results.pluck(:visibility).uniq).to match_array %w(private unlisted public)
+        expect(subject.pluck(:visibility).uniq).to match_array %w(private unlisted public)
       end
 
       it 'returns replies' do
-        expect(subject.results.pluck(:in_reply_to_id)).to_not be_empty
+        expect(subject.pluck(:in_reply_to_id)).to_not be_empty
       end
 
       it 'returns reblogs' do
-        expect(subject.results.pluck(:reblog_of_id)).to_not be_empty
+        expect(subject.pluck(:reblog_of_id)).to_not be_empty
       end
 
       context 'when there is a direct status mentioning the non-follower' do
         let!(:direct_status) { status_with_mention!(:direct, current_account) }
 
         it 'returns the direct status' do
-          expect(subject.results.pluck(:id)).to include(direct_status.id)
+          expect(subject.pluck(:id)).to include(direct_status.id)
         end
       end
 
@@ -168,22 +168,22 @@ RSpec.describe AccountStatusesFilter do
       let(:current_account) { Fabricate(:account) }
 
       it 'returns only public statuses' do
-        expect(subject.results.pluck(:visibility).uniq).to match_array %w(unlisted public)
+        expect(subject.pluck(:visibility).uniq).to match_array %w(unlisted public)
       end
 
       it 'returns public replies' do
-        expect(subject.results.pluck(:in_reply_to_id)).to_not be_empty
+        expect(subject.pluck(:in_reply_to_id)).to_not be_empty
       end
 
       it 'returns public reblogs' do
-        expect(subject.results.pluck(:reblog_of_id)).to_not be_empty
+        expect(subject.pluck(:reblog_of_id)).to_not be_empty
       end
 
       context 'when there is a private status mentioning the non-follower' do
         let!(:private_status) { status_with_mention!(:private, current_account) }
 
         it 'returns the private status' do
-          expect(subject.results.pluck(:id)).to include(private_status.id)
+          expect(subject.pluck(:id)).to include(private_status.id)
         end
       end
 
@@ -195,7 +195,7 @@ RSpec.describe AccountStatusesFilter do
         end
 
         it 'does not return reblog of blocked account' do
-          expect(subject.results.pluck(:id)).to_not include(reblog.id)
+          expect(subject.pluck(:id)).to_not include(reblog.id)
         end
       end
 
@@ -209,7 +209,7 @@ RSpec.describe AccountStatusesFilter do
         end
 
         it 'does not return reblog of blocked domain' do
-          expect(subject.results.pluck(:id)).to_not include(reblog.id)
+          expect(subject.pluck(:id)).to_not include(reblog.id)
         end
       end
 
@@ -223,7 +223,7 @@ RSpec.describe AccountStatusesFilter do
         end
 
         it 'returns the reblog from the non-blocked domain' do
-          expect(subject.results.pluck(:id)).to include(reblog.id)
+          expect(subject.pluck(:id)).to include(reblog.id)
         end
       end
 
@@ -235,7 +235,7 @@ RSpec.describe AccountStatusesFilter do
         end
 
         it 'does not return reblog of muted account' do
-          expect(subject.results.pluck(:id)).to_not include(reblog.id)
+          expect(subject.pluck(:id)).to_not include(reblog.id)
         end
       end
 
@@ -247,7 +247,7 @@ RSpec.describe AccountStatusesFilter do
         end
 
         it 'does not return reblog of blocked-by account' do
-          expect(subject.results.pluck(:id)).to_not include(reblog.id)
+          expect(subject.pluck(:id)).to_not include(reblog.id)
         end
       end
 

--- a/spec/lib/account_statuses_filter_spec.rb
+++ b/spec/lib/account_statuses_filter_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe AccountStatusesFilter do
         let!(:direct_status) { status_with_mention!(:direct, current_account) }
 
         it 'returns the direct status' do
-          expect(subject.pluck(:id)).to include(direct_status.id)
+          expect(results_ids).to include(direct_status.id)
         end
       end
 
@@ -183,7 +183,7 @@ RSpec.describe AccountStatusesFilter do
         let!(:private_status) { status_with_mention!(:private, current_account) }
 
         it 'returns the private status' do
-          expect(subject.pluck(:id)).to include(private_status.id)
+          expect(results_ids).to include(private_status.id)
         end
       end
 
@@ -195,7 +195,7 @@ RSpec.describe AccountStatusesFilter do
         end
 
         it 'does not return reblog of blocked account' do
-          expect(subject.pluck(:id)).to_not include(reblog.id)
+          expect(results_ids).to_not include(reblog.id)
         end
       end
 
@@ -209,7 +209,7 @@ RSpec.describe AccountStatusesFilter do
         end
 
         it 'does not return reblog of blocked domain' do
-          expect(subject.pluck(:id)).to_not include(reblog.id)
+          expect(results_ids).to_not include(reblog.id)
         end
       end
 
@@ -223,7 +223,7 @@ RSpec.describe AccountStatusesFilter do
         end
 
         it 'returns the reblog from the non-blocked domain' do
-          expect(subject.pluck(:id)).to include(reblog.id)
+          expect(results_ids).to include(reblog.id)
         end
       end
 
@@ -235,7 +235,7 @@ RSpec.describe AccountStatusesFilter do
         end
 
         it 'does not return reblog of muted account' do
-          expect(subject.pluck(:id)).to_not include(reblog.id)
+          expect(results_ids).to_not include(reblog.id)
         end
       end
 
@@ -247,7 +247,7 @@ RSpec.describe AccountStatusesFilter do
         end
 
         it 'does not return reblog of blocked-by account' do
-          expect(subject.pluck(:id)).to_not include(reblog.id)
+          expect(results_ids).to_not include(reblog.id)
         end
       end
 
@@ -266,6 +266,10 @@ RSpec.describe AccountStatusesFilter do
 
     def results_reblog_of_ids
       subject.pluck(:reblog_of_id)
+    end
+
+    def results_ids
+      subject.pluck(:id)
     end
   end
 end

--- a/spec/lib/account_statuses_filter_spec.rb
+++ b/spec/lib/account_statuses_filter_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe AccountStatusesFilter do
       end
 
       it 'returns public reblogs' do
-        expect(subject.pluck(:reblog_of_id)).to_not be_empty
+        expect(results_reblog_of_ids).to_not be_empty
       end
 
       it_behaves_like 'filter params'
@@ -128,7 +128,7 @@ RSpec.describe AccountStatusesFilter do
       end
 
       it 'returns reblogs' do
-        expect(subject.pluck(:reblog_of_id)).to_not be_empty
+        expect(results_reblog_of_ids).to_not be_empty
       end
 
       it_behaves_like 'filter params'
@@ -150,7 +150,7 @@ RSpec.describe AccountStatusesFilter do
       end
 
       it 'returns reblogs' do
-        expect(subject.pluck(:reblog_of_id)).to_not be_empty
+        expect(results_reblog_of_ids).to_not be_empty
       end
 
       context 'when there is a direct status mentioning the non-follower' do
@@ -176,7 +176,7 @@ RSpec.describe AccountStatusesFilter do
       end
 
       it 'returns public reblogs' do
-        expect(subject.pluck(:reblog_of_id)).to_not be_empty
+        expect(results_reblog_of_ids).to_not be_empty
       end
 
       context 'when there is a private status mentioning the non-follower' do
@@ -262,6 +262,10 @@ RSpec.describe AccountStatusesFilter do
 
     def results_in_reply_to_ids
       subject.pluck(:in_reply_to_id)
+    end
+
+    def results_reblog_of_ids
+      subject.pluck(:reblog_of_id)
     end
   end
 end


### PR DESCRIPTION
First 6 commits are naming refactors. Final commit combines what are related examples (asserations about different parts of same method result) into fewer examples. Speeds up this spec file run by ~25%.