### PR TITLE
Disable Babel polyfill injection in dev

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -52,6 +52,10 @@ module.exports = (api) => {
   case 'development':
     reactOptions.development = true;
     envOptions.debug = true;
+
+    // We need Babel to not inject polyfills in dev, as this breaks `preval` files
+    envOptions.useBuiltIns = false;
+    envOptions.corejs = undefined;
     break;
   }
 


### PR DESCRIPTION
In https://github.com/mastodon/mastodon/pull/27333 I added `useBuiltIns: "usage"`, which causes Babel to inject polyfills into those files. The polyfills are injected using ESM `import` symtax, which disables the handling of `export.` (CommonJS exports).

This causes the build in dev to fail, because in dev Babel does not convert the exports to CJS (not sure why).

I tried various things but I am unsure of why this happens. A simple fix is to no longer have Babel inject polyfills in dev, which was the previous behaviour.

We have plans to rewrite the emoji-related code in the future, which will remove the need for `preval`, and switching to Vite should also solve this.

Fixes #27686