### PR TITLE
Consolidate JSON parsing in serializers specs

### DIFF
--- a/spec/controllers/emojis_controller_spec.rb
+++ b/spec/controllers/emojis_controller_spec.rb
@@ -8,13 +8,11 @@ describe EmojisController do
   let(:emoji) { Fabricate(:custom_emoji) }
 
   describe 'GET #show' do
-    subject(:body) { JSON.parse(response.body, symbolize_names: true) }
-
     let(:response) { get :show, params: { id: emoji.id, format: :json } }
 
     it 'returns the right response' do
       expect(response).to have_http_status 200
-      expect(body[:name]).to eq ':coolcat:'
+      expect(body_as_json[:name]).to eq ':coolcat:'
     end
   end
 end

--- a/spec/serializers/activitypub/device_serializer_spec.rb
+++ b/spec/serializers/activitypub/device_serializer_spec.rb
@@ -3,13 +3,7 @@
 require 'rails_helper'
 
 describe ActivityPub::DeviceSerializer do
-  let(:serialization) do
-    JSON.parse(
-      ActiveModelSerializers::SerializableResource.new(
-        record, serializer: described_class
-      ).to_json
-    )
-  end
+  let(:serialization) { serialized_record_json(record, described_class) }
   let(:record) { Fabricate(:device) }
 
   describe 'type' do

--- a/spec/serializers/activitypub/note_serializer_spec.rb
+++ b/spec/serializers/activitypub/note_serializer_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe ActivityPub::NoteSerializer do
-  subject { JSON.parse(@serialization.to_json) }
+  subject { serialized_record_json(parent, described_class, adapter: ActivityPub::Adapter) }
 
   let!(:account) { Fabricate(:account) }
   let!(:other) { Fabricate(:account) }
@@ -13,10 +13,6 @@ describe ActivityPub::NoteSerializer do
   let!(:reply_by_other_first) { Fabricate(:status, account: other, thread: parent, visibility: :public) }
   let!(:reply_by_account_third) { Fabricate(:status, account: account, thread: parent, visibility: :public) }
   let!(:reply_by_account_visibility_direct) { Fabricate(:status, account: account, thread: parent, visibility: :direct) }
-
-  before do
-    @serialization = ActiveModelSerializers::SerializableResource.new(parent, serializer: described_class, adapter: ActivityPub::Adapter)
-  end
 
   it 'has the expected shape' do
     expect(subject).to include({

--- a/spec/serializers/activitypub/one_time_key_serializer_spec.rb
+++ b/spec/serializers/activitypub/one_time_key_serializer_spec.rb
@@ -3,13 +3,7 @@
 require 'rails_helper'
 
 describe ActivityPub::OneTimeKeySerializer do
-  let(:serialization) do
-    JSON.parse(
-      ActiveModelSerializers::SerializableResource.new(
-        record, serializer: described_class
-      ).to_json
-    )
-  end
+  let(:serialization) { serialized_record_json(record, described_class) }
   let(:record) { Fabricate(:one_time_key) }
 
   describe 'type' do

--- a/spec/serializers/activitypub/undo_like_serializer_spec.rb
+++ b/spec/serializers/activitypub/undo_like_serializer_spec.rb
@@ -3,13 +3,7 @@
 require 'rails_helper'
 
 describe ActivityPub::UndoLikeSerializer do
-  let(:serialization) do
-    JSON.parse(
-      ActiveModelSerializers::SerializableResource.new(
-        record, serializer: described_class
-      ).to_json
-    )
-  end
+  let(:serialization) { serialized_record_json(record, described_class) }
   let(:record) { Fabricate(:favourite) }
 
   describe 'type' do

--- a/spec/serializers/activitypub/update_poll_serializer_spec.rb
+++ b/spec/serializers/activitypub/update_poll_serializer_spec.rb
@@ -3,15 +3,11 @@
 require 'rails_helper'
 
 describe ActivityPub::UpdatePollSerializer do
-  subject { JSON.parse(@serialization.to_json) }
+  subject { serialized_record_json(status, described_class, adapter: ActivityPub::Adapter) }
 
   let(:account) { Fabricate(:account) }
   let(:poll)    { Fabricate(:poll, account: account) }
   let!(:status) { Fabricate(:status, account: account, poll: poll) }
-
-  before do
-    @serialization = ActiveModelSerializers::SerializableResource.new(status, serializer: described_class, adapter: ActivityPub::Adapter)
-  end
 
   it 'has a Update type' do
     expect(subject['type']).to eql('Update')

--- a/spec/serializers/activitypub/vote_serializer_spec.rb
+++ b/spec/serializers/activitypub/vote_serializer_spec.rb
@@ -3,13 +3,7 @@
 require 'rails_helper'
 
 describe ActivityPub::VoteSerializer do
-  let(:serialization) do
-    JSON.parse(
-      ActiveModelSerializers::SerializableResource.new(
-        record, serializer: described_class
-      ).to_json
-    )
-  end
+  let(:serialization) { serialized_record_json(record, described_class) }
   let(:record) { Fabricate(:poll_vote) }
 
   describe 'type' do

--- a/spec/serializers/rest/account_serializer_spec.rb
+++ b/spec/serializers/rest/account_serializer_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe REST::AccountSerializer do
-  subject { JSON.parse(ActiveModelSerializers::SerializableResource.new(account, serializer: described_class).to_json) }
+  subject { serialized_record_json(account, described_class) }
 
   let(:role)    { Fabricate(:user_role, name: 'Role', highlighted: true) }
   let(:user)    { Fabricate(:user, role: role) }

--- a/spec/serializers/rest/encrypted_message_serializer_spec.rb
+++ b/spec/serializers/rest/encrypted_message_serializer_spec.rb
@@ -3,13 +3,7 @@
 require 'rails_helper'
 
 describe REST::EncryptedMessageSerializer do
-  let(:serialization) do
-    JSON.parse(
-      ActiveModelSerializers::SerializableResource.new(
-        record, serializer: described_class
-      ).to_json
-    )
-  end
+  let(:serialization) { serialized_record_json(record, described_class) }
   let(:record) { Fabricate(:encrypted_message) }
 
   describe 'account' do

--- a/spec/serializers/rest/instance_serializer_spec.rb
+++ b/spec/serializers/rest/instance_serializer_spec.rb
@@ -3,13 +3,7 @@
 require 'rails_helper'
 
 describe REST::InstanceSerializer do
-  let(:serialization) do
-    JSON.parse(
-      ActiveModelSerializers::SerializableResource.new(
-        record, serializer: described_class
-      ).to_json
-    )
-  end
+  let(:serialization) { serialized_record_json(record, described_class) }
   let(:record) { InstancePresenter.new }
 
   describe 'usage' do

--- a/spec/serializers/rest/keys/claim_result_serializer_spec.rb
+++ b/spec/serializers/rest/keys/claim_result_serializer_spec.rb
@@ -3,13 +3,7 @@
 require 'rails_helper'
 
 describe REST::Keys::ClaimResultSerializer do
-  let(:serialization) do
-    JSON.parse(
-      ActiveModelSerializers::SerializableResource.new(
-        record, serializer: described_class
-      ).to_json
-    )
-  end
+  let(:serialization) { serialized_record_json(record, described_class) }
   let(:record) { Keys::ClaimService::Result.new(Account.new(id: 123), 456) }
 
   describe 'account' do

--- a/spec/serializers/rest/keys/device_serializer_spec.rb
+++ b/spec/serializers/rest/keys/device_serializer_spec.rb
@@ -3,13 +3,7 @@
 require 'rails_helper'
 
 describe REST::Keys::DeviceSerializer do
-  let(:serialization) do
-    JSON.parse(
-      ActiveModelSerializers::SerializableResource.new(
-        record, serializer: described_class
-      ).to_json
-    )
-  end
+  let(:serialization) { serialized_record_json(record, described_class) }
   let(:record) { Device.new(name: 'Device name') }
 
   describe 'name' do

--- a/spec/serializers/rest/keys/query_result_serializer_spec.rb
+++ b/spec/serializers/rest/keys/query_result_serializer_spec.rb
@@ -3,13 +3,7 @@
 require 'rails_helper'
 
 describe REST::Keys::QueryResultSerializer do
-  let(:serialization) do
-    JSON.parse(
-      ActiveModelSerializers::SerializableResource.new(
-        record, serializer: described_class
-      ).to_json
-    )
-  end
+  let(:serialization) { serialized_record_json(record, described_class) }
   let(:record) { Keys::QueryService::Result.new(Account.new(id: 123), []) }
 
   describe 'account' do

--- a/spec/serializers/rest/suggestion_serializer_spec.rb
+++ b/spec/serializers/rest/suggestion_serializer_spec.rb
@@ -3,13 +3,7 @@
 require 'rails_helper'
 
 describe REST::SuggestionSerializer do
-  let(:serialization) do
-    JSON.parse(
-      ActiveModelSerializers::SerializableResource.new(
-        record, serializer: described_class
-      ).to_json
-    )
-  end
+  let(:serialization) { serialized_record_json(record, described_class) }
   let(:record) do
     AccountSuggestions::Suggestion.new(
       account: account,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,6 +52,14 @@ def json_str_to_hash(str)
   JSON.parse(str, symbolize_names: true)
 end
 
+def serialized_record_json(record, serializer)
+  JSON.parse(
+    ActiveModelSerializers::SerializableResource.new(
+      record, serializer: serializer
+    ).to_json
+  )
+end
+
 def expect_push_bulk_to_match(klass, matcher)
   allow(Sidekiq::Client).to receive(:push_bulk)
   yield

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,10 +52,13 @@ def json_str_to_hash(str)
   JSON.parse(str, symbolize_names: true)
 end
 
-def serialized_record_json(record, serializer)
+def serialized_record_json(record, serializer, adapter: nil)
+  options = { serializer: serializer }
+  options[:adapter] = adapter if adapter.present?
   JSON.parse(
     ActiveModelSerializers::SerializableResource.new(
-      record, serializer: serializer
+      record,
+      options
     ).to_json
   )
 end


### PR DESCRIPTION
Multiple changes:

- Update a controller which was not using the existing `body_as_json` helper to use it
- Add a similar helper for the serializer specs to DRY up some of the setup in those

Both of these are in advance of separate branch work trying to gain some perf benefits around JSON parsing in both spec and app usage.