### PR TITLE
Fixes website not loading for unlogged users

### DIFF
--- a/app/javascript/mastodon/reducers/accounts.ts
+++ b/app/javascript/mastodon/reducers/accounts.ts
@@ -41,32 +41,34 @@ const normalizeAccounts = (
   return state;
 };
 
-export const accountsReducer: Reducer<typeof initialState> = (
-  state = initialState,
-  action,
-) => {
-  const currentUserId = me;
-
-  if (!currentUserId)
+function getCurrentUser() {
+  if (!me)
     throw new Error(
       'No current user (me) defined when calling `accountsReducer`',
     );
 
+  return me;
+}
+
+export const accountsReducer: Reducer<typeof initialState> = (
+  state = initialState,
+  action,
+) => {
   if (revealAccount.match(action))
     return state.setIn([action.payload.id, 'hidden'], false);
   else if (importAccounts.match(action))
     return normalizeAccounts(state, action.payload.accounts);
-  else if (followAccountSuccess.match(action))
+  else if (followAccountSuccess.match(action)) {
     return state
       .update(
         action.payload.relationship.id,
         (account) => account?.update('followers_count', (n) => n + 1),
       )
       .update(
-        currentUserId,
+        getCurrentUser(),
         (account) => account?.update('following_count', (n) => n + 1),
       );
-  else if (unfollowAccountSuccess.match(action))
+  } else if (unfollowAccountSuccess.match(action))
     return state
       .update(
         action.payload.relationship.id,
@@ -74,7 +76,7 @@ export const accountsReducer: Reducer<typeof initialState> = (
           account?.update('followers_count', (n) => Math.max(0, n - 1)),
       )
       .update(
-        currentUserId,
+        getCurrentUser(),
         (account) =>
           account?.update('following_count', (n) => Math.max(0, n - 1)),
       );

--- a/spec/system/unlogged_spec.rb
+++ b/spec/system/unlogged_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'UnloggedBrowsing' do
+  subject { page }
+
+  before do
+    visit root_path
+  end
+
+  it 'loads the home page' do
+    expect(subject).to have_css('div.app-holder')
+
+    expect(subject).to have_css('div.columns-area__panels__main')
+  end
+end


### PR DESCRIPTION
I made a mistake in #26559 and inadvertently added a check when the reducer runs, which happens on page load.

This needs to only be checked when those specific actions are dispatched, which only happen when you are logged in.

Added a system check to ensure the UI loads when not logged in.

Fixes #27697