### PR TITLE
Use latest 20 posts by timestamp for explore prompt calculation

### DIFF
--- a/app/javascript/mastodon/features/home_timeline/index.jsx
+++ b/app/javascript/mastodon/features/home_timeline/index.jsx
@@ -41,7 +41,7 @@ const getHomeFeedSpeed = createSelector([
   state => state.get('statuses'),
 ], (statusIds, pendingStatusIds, statusMap) => {
   const recentStatusIds = pendingStatusIds.concat(statusIds);
-  const statuses = recentStatusIds.filter(id => id !== null).map(id => statusMap.get(id)).filter(status => status?.get('account') !== me).take(20);
+  const statuses = recentStatusIds.filter(id => id !== null).map(id => statusMap.get(id)).filter(status => status?.get('account') !== me).sortBy(status => status?.get('created_at', 0)).takeLast(20);
 
   if (statuses.isEmpty()) {
     return {


### PR DESCRIPTION
The explore prompt will display if the average time between posts in the latest 20 is greater than 30 minutes per post; but it currently uses the order that posts are displayed on the timeline to take the latest 20, but the `created_at` timestamp for the calculation. If some post is displayed out of order, because it took a long time before it got propagated to your server, then the explore prompt will show up even on a busy timeline.

This change sorts the posts by the `created_at` timestamp before taking the most recent 20, so out of order posts will only be considered only if there are fewer than 20 other posts on your timeline.

Closes #27726