### PR TITLE
Capybara config update

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -27,6 +27,10 @@ Capybara.javascript_driver = :headless_chrome
 
 RSpec.configure do |config|
   config.before(:each, type: :system) do
+    driven_by :rack_test
+  end
+
+  config.before(:each, :js, type: :system) do
     driven_by Capybara.javascript_driver
   end
 end

--- a/spec/support/javascript_errors.rb
+++ b/spec/support/javascript_errors.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.configure do |config|
-  config.after(:each, type: :system) do
+  config.after(:each, :js) do
     errors = page.driver.browser.logs.get(:browser)
     if errors.present?
       aggregate_failures 'javascript errrors' do

--- a/spec/system/new_statuses_spec.rb
+++ b/spec/system/new_statuses_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'NewStatuses', :sidekiq_inline do
+describe 'NewStatuses', :js, :sidekiq_inline do
   include ProfileStories
 
   subject { page }

--- a/spec/system/ocr_spec.rb
+++ b/spec/system/ocr_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'OCR', :paperclip_processing, :sidekiq_inline do
+describe 'OCR', :js, :paperclip_processing, :sidekiq_inline do
   include ProfileStories
 
   let(:email)               { 'test@example.com' }

--- a/spec/system/report_interface_spec.rb
+++ b/spec/system/report_interface_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'report interface', :paperclip_processing do
+describe 'report interface', :js, :paperclip_processing do
   include ProfileStories
 
   let(:email)               { 'admin@example.com' }

--- a/spec/system/share_entrypoint_spec.rb
+++ b/spec/system/share_entrypoint_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'ShareEntrypoint' do
+describe 'ShareEntrypoint', :js do
   include ProfileStories
 
   subject { page }

--- a/spec/system/unlogged_spec.rb
+++ b/spec/system/unlogged_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'UnloggedBrowsing' do
+describe 'UnloggedBrowsing', :js do
   subject { page }
 
   before do


### PR DESCRIPTION
From same WIP branch as https://github.com/mastodon/mastodon/pull/27727 this one:

- Pulls out the capybara configuration from rails_helper into separate file
- Configures interaction of ENV vars and capybara setup such that the spec runs don't have network errors on JS spec runs (previously the hostname configuration of test env and capybara setup did not match, so there were missing asset and other errors in JS console)
- Add rspec hook which adds a JS errors/warnings check after all `:js` specs - this would have caught some of the recent issues around JS changes leading to errors.
- Version bump on selenium-webdriver