### PR TITLE
Disable sidekiq unique jobs in test env

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -43,6 +43,7 @@ end
 Sidekiq.logger.level = ::Logger.const_get(ENV.fetch('RAILS_LOG_LEVEL', 'info').upcase.to_s)
 
 SidekiqUniqueJobs.configure do |config|
+  config.enabled         = !Rails.env.test?
   config.reaper          = :ruby
   config.reaper_count    = 1000
   config.reaper_interval = 600


### PR DESCRIPTION
This is recommended by both Sidekiq - https://github.com/sidekiq/sidekiq/issues/1269#issuecomment-219147640 - and the unique jobs gem - https://github.com/mhenrixon/sidekiq-unique-jobs#uniqueness

I believe this might fix the intermittent spec failure seen sometimes in the `PollExpirationNotifyWorker` and `UpdateStatusService` (maybe others?) specs. I've never been able to force these failures, but see them occasionally. Running just the failing specs in a loop before this change, I'd see ~10% of spec runs fail. With this change, looping through ~100 spec runs, I saw zero failures.