### PR TITLE
Remove unused before block from settings/branding spec

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -55,7 +55,6 @@ RSpec/AnyInstance:
     - 'spec/controllers/activitypub/inboxes_controller_spec.rb'
     - 'spec/controllers/admin/accounts_controller_spec.rb'
     - 'spec/controllers/admin/resets_controller_spec.rb'
-    - 'spec/controllers/admin/settings/branding_controller_spec.rb'
     - 'spec/controllers/auth/sessions_controller_spec.rb'
     - 'spec/controllers/settings/two_factor_authentication/confirmations_controller_spec.rb'
     - 'spec/controllers/settings/two_factor_authentication/recovery_codes_controller_spec.rb'

--- a/spec/controllers/admin/settings/branding_controller_spec.rb
+++ b/spec/controllers/admin/settings/branding_controller_spec.rb
@@ -19,10 +19,6 @@ RSpec.describe Admin::Settings::BrandingController do
     end
 
     describe 'PUT #update' do
-      before do
-        allow_any_instance_of(Form::AdminSettings).to receive(:valid?).and_return(true)
-      end
-
       around do |example|
         before = Setting.site_short_description
         Setting.site_short_description = nil


### PR DESCRIPTION
I think this was just copy/pasted in during a prior change - https://github.com/mastodon/mastodon/commit/7c152acb2cc545a87610de349a94e14f45fbed5d#diff-3521d9f8146208ee960c8fd245319529cee9e4b02999a2b4b6b89e99bc3444c2R23 - and is not actually needed for this spec to function.