### PR TITLE
Move RSpec config for streaming/search managers to be near classes

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -11,10 +11,6 @@ if RUN_SYSTEM_SPECS
   ENV['STREAMING_API_BASE_URL'] = "http://localhost:#{STREAMING_PORT}"
 end
 
-if RUN_SEARCH_SPECS
-  # Include any configuration or setups specific to search tests here
-end
-
 require File.expand_path('../config/environment', __dir__)
 
 abort('The Rails environment is running in production mode!') if Rails.env.production?

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -95,7 +95,6 @@ RSpec.configure do |config|
   end
 
   config.around :each, type: :system do |example|
-    # driven_by :selenium, using: :chrome, screen_size: [1600, 1200]
     driven_by :selenium, using: :headless_chrome, screen_size: [1600, 1200]
 
     # The streaming server needs access to the database

--- a/spec/support/streaming_server_manager.rb
+++ b/spec/support/streaming_server_manager.rb
@@ -76,3 +76,32 @@ class StreamingServerManager
     @running_thread.join
   end
 end
+
+RSpec.configure do |config|
+  config.before :suite do
+    if streaming_examples_present?
+      # Compile assets
+      Webpacker.compile
+
+      # Start the node streaming server
+      streaming_server_manager.start(port: STREAMING_PORT)
+    end
+  end
+
+  config.after :suite do
+    if streaming_examples_present?
+      # Stop the node streaming server
+      streaming_server_manager.stop
+    end
+  end
+
+  private
+
+  def streaming_server_manager
+    @streaming_server_manager ||= StreamingServerManager.new
+  end
+
+  def streaming_examples_present?
+    RUN_SYSTEM_SPECS
+  end
+end


### PR DESCRIPTION
As followup on https://github.com/mastodon/mastodon/pull/27727 and pulled out of the same WIP branch, this moves the RSpec config setup for the search and streaming specs to sit near the files which now have those manager classes.

Same as prior one, this is basically organizational only (continuing to prepare for other changes) and does not change the actual config or behavior. Along with https://github.com/mastodon/mastodon/pull/27732 this one is the last of the prep stuff from the WIP branch.