### PR TITLE
Fix "Hide these posts from home" list setting not refreshing when switching lists

### DIFF
--- a/app/javascript/mastodon/features/list_timeline/index.jsx
+++ b/app/javascript/mastodon/features/list_timeline/index.jsx
@@ -204,7 +204,7 @@ class ListTimeline extends PureComponent {
           </div>
 
           <div className='setting-toggle'>
-            <Toggle id={`list-${id}-exclusive`} defaultChecked={isExclusive} onChange={this.onExclusiveToggle} />
+            <Toggle id={`list-${id}-exclusive`} checked={isExclusive} onChange={this.onExclusiveToggle} />
             <label htmlFor={`list-${id}-exclusive`} className='setting-toggle__label'>
               <FormattedMessage id='lists.exclusive' defaultMessage='Hide these posts from home' />
             </label>


### PR DESCRIPTION
Fixes https://github.com/mastodon/mastodon/issues/27097

The list settings Toggle for this control is populating using an incorrect field, `defaultChecked`, when it should use `checked`. From the `react-toggle` [NPM docs](https://www.npmjs.com/package/react-toggle): 
| Prop | Type | Description |
| ----- | ---- | ---------- |
| checked | boolean | If true, the toggle is checked. If false, the toggle is unchecked. Use this if you want to treat the toggle as a controlled component |
| defaultChecked | boolean | If true on initial render, the toggle is checked. If false on initial render, the toggle is unchecked. Use this if you want to treat the toggle as an uncontrolled component |

This causes the checkbox to only refresh on initial render, and not when switching lists.