### PR TITLE
Use framework helpers instead of i-vars in controller specs

### DIFF
--- a/spec/controllers/auth/confirmations_controller_spec.rb
+++ b/spec/controllers/auth/confirmations_controller_spec.rb
@@ -7,7 +7,7 @@ describe Auth::ConfirmationsController do
 
   describe 'GET #new' do
     it 'returns http success' do
-      @request.env['devise.mapping'] = Devise.mappings[:user]
+      request.env['devise.mapping'] = Devise.mappings[:user]
       get :new
       expect(response).to have_http_status(200)
     end
@@ -19,7 +19,7 @@ describe Auth::ConfirmationsController do
 
       before do
         allow(BootstrapTimelineWorker).to receive(:perform_async)
-        @request.env['devise.mapping'] = Devise.mappings[:user]
+        request.env['devise.mapping'] = Devise.mappings[:user]
         get :show, params: { confirmation_token: 'foobar' }
       end
 
@@ -37,7 +37,7 @@ describe Auth::ConfirmationsController do
 
       before do
         allow(BootstrapTimelineWorker).to receive(:perform_async)
-        @request.env['devise.mapping'] = Devise.mappings[:user]
+        request.env['devise.mapping'] = Devise.mappings[:user]
         get :show, params: { confirmation_token: 'foobar' }
       end
 
@@ -51,7 +51,7 @@ describe Auth::ConfirmationsController do
 
       before do
         allow(BootstrapTimelineWorker).to receive(:perform_async)
-        @request.env['devise.mapping'] = Devise.mappings[:user]
+        request.env['devise.mapping'] = Devise.mappings[:user]
         sign_in(user, scope: :user)
         get :show, params: { confirmation_token: 'foobar' }
       end
@@ -66,7 +66,7 @@ describe Auth::ConfirmationsController do
 
       before do
         allow(BootstrapTimelineWorker).to receive(:perform_async)
-        @request.env['devise.mapping'] = Devise.mappings[:user]
+        request.env['devise.mapping'] = Devise.mappings[:user]
         user.approved = false
         user.save!
         sign_in(user, scope: :user)
@@ -83,7 +83,7 @@ describe Auth::ConfirmationsController do
 
       before do
         allow(BootstrapTimelineWorker).to receive(:perform_async)
-        @request.env['devise.mapping'] = Devise.mappings[:user]
+        request.env['devise.mapping'] = Devise.mappings[:user]
         get :show, params: { confirmation_token: 'foobar' }
       end
 

--- a/spec/controllers/auth/passwords_controller_spec.rb
+++ b/spec/controllers/auth/passwords_controller_spec.rb
@@ -7,7 +7,7 @@ describe Auth::PasswordsController do
 
   describe 'GET #new' do
     it 'returns http success' do
-      @request.env['devise.mapping'] = Devise.mappings[:user]
+      request.env['devise.mapping'] = Devise.mappings[:user]
       get :new
       expect(response).to have_http_status(200)
     end

--- a/spec/controllers/auth/sessions_controller_spec.rb
+++ b/spec/controllers/auth/sessions_controller_spec.rb
@@ -378,7 +378,7 @@ RSpec.describe Auth::SessionsController do
 
         context 'when using a valid webauthn credential' do
           before do
-            @controller.session[:webauthn_challenge] = challenge
+            controller.session[:webauthn_challenge] = challenge
 
             post :create, params: { user: { credential: fake_credential } }, session: { attempt_user_id: user.id, attempt_user_updated_at: user.updated_at.to_s }
           end

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe HomeController do
 
     context 'when not signed in' do
       it 'returns http success' do
-        @request.path = '/'
+        request.path = '/'
         expect(subject).to have_http_status(:success)
       end
     end

--- a/spec/controllers/settings/two_factor_authentication/webauthn_credentials_controller_spec.rb
+++ b/spec/controllers/settings/two_factor_authentication/webauthn_credentials_controller_spec.rb
@@ -130,7 +130,7 @@ describe Settings::TwoFactorAuthentication::WebauthnCredentialsController do
           it 'stores the challenge on the session' do
             get :options
 
-            expect(@controller.session[:webauthn_challenge]).to be_present
+            expect(controller.session[:webauthn_challenge]).to be_present
           end
 
           it 'does not change webauthn_id' do
@@ -155,7 +155,7 @@ describe Settings::TwoFactorAuthentication::WebauthnCredentialsController do
           it 'stores the challenge on the session' do
             get :options
 
-            expect(@controller.session[:webauthn_challenge]).to be_present
+            expect(controller.session[:webauthn_challenge]).to be_present
           end
 
           it 'sets user webauthn_id' do
@@ -218,7 +218,7 @@ describe Settings::TwoFactorAuthentication::WebauthnCredentialsController do
 
           context 'when creation succeeds' do
             it 'returns http success' do
-              @controller.session[:webauthn_challenge] = challenge
+              controller.session[:webauthn_challenge] = challenge
 
               post :create, params: { credential: new_webauthn_credential, nickname: nickname }
 
@@ -226,7 +226,7 @@ describe Settings::TwoFactorAuthentication::WebauthnCredentialsController do
             end
 
             it 'adds a new credential to user credentials' do
-              @controller.session[:webauthn_challenge] = challenge
+              controller.session[:webauthn_challenge] = challenge
 
               expect do
                 post :create, params: { credential: new_webauthn_credential, nickname: nickname }
@@ -234,7 +234,7 @@ describe Settings::TwoFactorAuthentication::WebauthnCredentialsController do
             end
 
             it 'does not change webauthn_id' do
-              @controller.session[:webauthn_challenge] = challenge
+              controller.session[:webauthn_challenge] = challenge
 
               expect do
                 post :create, params: { credential: new_webauthn_credential, nickname: nickname }
@@ -244,7 +244,7 @@ describe Settings::TwoFactorAuthentication::WebauthnCredentialsController do
 
           context 'when the nickname is already used' do
             it 'fails' do
-              @controller.session[:webauthn_challenge] = challenge
+              controller.session[:webauthn_challenge] = challenge
 
               post :create, params: { credential: new_webauthn_credential, nickname: 'USB Key' }
 
@@ -264,7 +264,7 @@ describe Settings::TwoFactorAuthentication::WebauthnCredentialsController do
             end
 
             it 'fails' do
-              @controller.session[:webauthn_challenge] = challenge
+              controller.session[:webauthn_challenge] = challenge
 
               post :create, params: { credential: new_webauthn_credential, nickname: nickname }
 
@@ -277,7 +277,7 @@ describe Settings::TwoFactorAuthentication::WebauthnCredentialsController do
         context 'when user have not enabled webauthn' do
           context 'when creation succeeds' do
             it 'creates a webauthn credential' do
-              @controller.session[:webauthn_challenge] = challenge
+              controller.session[:webauthn_challenge] = challenge
 
               expect do
                 post :create, params: { credential: new_webauthn_credential, nickname: nickname }


### PR DESCRIPTION
This is just the framework update portion of https://github.com/mastodon/mastodon/pull/27766

I'd like to review the rest of them a bit more first, and converted that other one to draft. I think these are safe though.