### PR TITLE
Remove unmatched `rubocop:enable` declaration

### DIFF
--- a/app/helpers/languages_helper.rb
+++ b/app/helpers/languages_helper.rb
@@ -298,5 +298,3 @@ module LanguagesHelper
     locale_name.to_sym if locale_name.present? && I18n.available_locales.include?(locale_name.to_sym)
   end
 end
-
-# rubocop:enable Metrics/ModuleLength


### PR DESCRIPTION
The `disable` was removed previously: b7d995cb0078c2bbbbefd90f0b4a9818b58a1377