### PR TITLE
Fix `RSpec/MessageChain` cop

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -133,12 +133,6 @@ RSpec/LetSetup:
     - 'spec/services/unsuspend_account_service_spec.rb'
     - 'spec/workers/scheduler/user_cleanup_scheduler_spec.rb'
 
-RSpec/MessageChain:
-  Exclude:
-    - 'spec/models/concerns/remotable_spec.rb'
-    - 'spec/models/session_activation_spec.rb'
-    - 'spec/models/setting_spec.rb'
-
 RSpec/MultipleExpectations:
   Max: 8
 

--- a/spec/fabricators/session_activation_fabricator.rb
+++ b/spec/fabricators/session_activation_fabricator.rb
@@ -2,5 +2,5 @@
 
 Fabricator(:session_activation) do
   user { Fabricate.build(:user) }
-  session_id 'MyString'
+  session_id { sequence(:session_id) { |i| "session_id_#{i}" } }
 end

--- a/spec/models/concerns/remotable_spec.rb
+++ b/spec/models/concerns/remotable_spec.rb
@@ -69,7 +69,9 @@ RSpec.describe Remotable do
 
     context 'with an invalid URL' do
       before do
-        allow(Addressable::URI).to receive_message_chain(:parse, :normalize).with(url).with(no_args).and_raise(Addressable::URI::InvalidURIError)
+        parsed = instance_double(Addressable::URI)
+        allow(parsed).to receive(:normalize).with(no_args).and_raise(Addressable::URI::InvalidURIError)
+        allow(Addressable::URI).to receive(:parse).with(url).and_return(parsed)
       end
 
       it 'makes no request' do

--- a/spec/models/session_activation_spec.rb
+++ b/spec/models/session_activation_spec.rb
@@ -98,34 +98,44 @@ RSpec.describe SessionActivation do
     end
 
     context 'when id exists' do
-      let(:id) { '1' }
+      let!(:session_activation) { Fabricate(:session_activation) }
 
-      it 'calls where.destroy_all' do
-        expect(described_class).to receive_message_chain(:where, :destroy_all)
-          .with(session_id: id).with(no_args)
+      it 'destroys the record' do
+        described_class.deactivate(session_activation.session_id)
 
-        described_class.deactivate(id)
+        expect { session_activation.reload }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
   end
 
   describe '.purge_old' do
-    it 'calls order.offset.destroy_all' do
-      expect(described_class).to receive_message_chain(:order, :offset, :destroy_all)
-        .with('created_at desc').with(Rails.configuration.x.max_session_activations).with(no_args)
+    around do |example|
+      before = Rails.configuration.x.max_session_activations
+      Rails.configuration.x.max_session_activations = 1
+      example.run
+      Rails.configuration.x.max_session_activations = before
+    end
 
+    let!(:oldest_session_activation) { Fabricate(:session_activation, created_at: 10.days.ago) }
+    let!(:newest_session_activation) { Fabricate(:session_activation, created_at: 5.days.ago) }
+
+    it 'preserves the newest X records based on config' do
       described_class.purge_old
+
+      expect { oldest_session_activation.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { newest_session_activation.reload }.to_not raise_error
     end
   end
 
   describe '.exclusive' do
-    let(:id) { '1' }
+    let!(:unwanted_session_activation) { Fabricate(:session_activation) }
+    let!(:wanted_session_activation) { Fabricate(:session_activation) }
 
-    it 'calls where.destroy_all' do
-      expect(described_class).to receive_message_chain(:where, :not, :destroy_all)
-        .with(session_id: id).with(no_args)
+    it 'preserves supplied record and destroys all others' do
+      described_class.exclusive(wanted_session_activation.session_id)
 
-      described_class.exclusive(id)
+      expect { unwanted_session_activation.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { wanted_session_activation.reload }.to_not raise_error
     end
   end
 end

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -77,10 +77,13 @@ RSpec.describe Setting do
             let(:default_value) { { default_value: 'default_value' } }
 
             it 'calls default_value.with_indifferent_access.merge!' do
-              expect(default_value).to receive_message_chain(:with_indifferent_access, :merge!)
-                .with(db_val.value)
+              indifferent_hash = instance_double(Hash, merge!: nil)
+              allow(default_value).to receive(:with_indifferent_access).and_return(indifferent_hash)
 
               described_class[key]
+
+              expect(default_value).to have_received(:with_indifferent_access)
+              expect(indifferent_hash).to have_received(:merge!)
             end
           end
 

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Setting do
               described_class[key]
 
               expect(default_value).to have_received(:with_indifferent_access)
-              expect(indifferent_hash).to have_received(:merge!)
+              expect(indifferent_hash).to have_received(:merge!).with(db_val.value)
             end
           end
 


### PR DESCRIPTION
The changes to remoteable and setting are preserving the existing stub approach, just updating style to satisfy the cop.

The session activation one was excessively stubbing out the interaction and very tightly coupled to the implementation. Rewrote part of this to check the results not the methods, and updated the fabricator to produce multiple valid instances in the process.