### PR TITLE
Fix `Rails/I18nLocaleTexts` cop

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -158,11 +158,6 @@ Rails/HasManyOrHasOneDependent:
     - 'app/models/user.rb'
     - 'app/models/web/push_subscription.rb'
 
-Rails/I18nLocaleTexts:
-  Exclude:
-    - 'lib/tasks/mastodon.rake'
-    - 'spec/helpers/flashes_helper_spec.rb'
-
 # Configuration parameters: Include.
 # Include: app/controllers/**/*.rb, app/mailers/**/*.rb
 Rails/LexicallyScopedActionFilter:

--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -427,7 +427,11 @@ namespace :mastodon do
             from: env['SMTP_FROM_ADDRESS'],
           }
 
-          mail = ActionMailer::Base.new.mail to: send_to, subject: 'Test', body: 'Mastodon SMTP configuration works!'
+          mail = ActionMailer::Base.new.mail(
+            to: send_to,
+            subject: 'Test', # rubocop:disable Rails/I18nLocaleTexts
+            body: 'Mastodon SMTP configuration works!'
+          )
           mail.deliver
           break
         rescue => e

--- a/spec/helpers/flashes_helper_spec.rb
+++ b/spec/helpers/flashes_helper_spec.rb
@@ -4,16 +4,23 @@ require 'rails_helper'
 
 describe FlashesHelper do
   describe 'user_facing_flashes' do
-    it 'returns user facing flashes' do
+    before do
+      # rubocop:disable Rails/I18nLocaleTexts
       flash[:alert] = 'an alert'
       flash[:error] = 'an error'
       flash[:notice] = 'a notice'
       flash[:success] = 'a success'
       flash[:not_user_facing] = 'a not user facing flash'
-      expect(helper.user_facing_flashes).to eq 'alert' => 'an alert',
-                                               'error' => 'an error',
-                                               'notice' => 'a notice',
-                                               'success' => 'a success'
+      # rubocop:enable Rails/I18nLocaleTexts
+    end
+
+    it 'returns user facing flashes' do
+      expect(helper.user_facing_flashes).to eq(
+        'alert' => 'an alert',
+        'error' => 'an error',
+        'notice' => 'a notice',
+        'success' => 'a success'
+      )
     end
   end
 end


### PR DESCRIPTION
Both of these want us to i18n in a place where it would be really bizarre to do so ... but they are not false positives (arguably the flash one is by virtue of being in spec?).

Update here is just to opt-out via inline `disable`.

Tidied up the flash spec while in there.
