### PR TITLE
Reduce AbcSize complexity in `InitialStateSerializer`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -26,7 +26,7 @@ Lint/NonLocalExitFromIterator:
 
 # Configuration parameters: AllowedMethods, AllowedPatterns, CountRepeatedAttributes.
 Metrics/AbcSize:
-  Max: 144
+  Max: 125
 
 # Configuration parameters: CountBlocks, Max.
 Metrics/BlockNesting:

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -89,11 +89,11 @@ class InitialStateSerializer < ActiveModel::Serializer
       associations: [:account_stat, :user, { moved_to_account: [:account_stat, :user] }]
     )
 
-    store[object.current_account.id.to_s]  = ActiveModelSerializers::SerializableResource.new(object.current_account, serializer: REST::AccountSerializer) if object.current_account
-    store[object.admin.id.to_s]            = ActiveModelSerializers::SerializableResource.new(object.admin, serializer: REST::AccountSerializer) if object.admin
-    store[object.owner.id.to_s]            = ActiveModelSerializers::SerializableResource.new(object.owner, serializer: REST::AccountSerializer) if object.owner
-    store[object.disabled_account.id.to_s] = ActiveModelSerializers::SerializableResource.new(object.disabled_account, serializer: REST::AccountSerializer) if object.disabled_account
-    store[object.moved_to_account.id.to_s] = ActiveModelSerializers::SerializableResource.new(object.moved_to_account, serializer: REST::AccountSerializer) if object.moved_to_account
+    store[object.current_account.id.to_s]  = serialized_resource(object.current_account) if object.current_account
+    store[object.admin.id.to_s]            = serialized_resource(object.admin) if object.admin
+    store[object.owner.id.to_s]            = serialized_resource(object.owner) if object.owner
+    store[object.disabled_account.id.to_s] = serialized_resource(object.disabled_account) if object.disabled_account
+    store[object.moved_to_account.id.to_s] = serialized_resource(object.moved_to_account) if object.moved_to_account
 
     store
   end
@@ -107,6 +107,10 @@ class InitialStateSerializer < ActiveModel::Serializer
   end
 
   private
+
+  def serialized_resource(resource)
+    ActiveModelSerializers::SerializableResource.new(resource, serializer: REST::AccountSerializer)
+  end
 
   def instance_presenter
     @instance_presenter ||= InstancePresenter.new

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -89,11 +89,11 @@ class InitialStateSerializer < ActiveModel::Serializer
       associations: [:account_stat, :user, { moved_to_account: [:account_stat, :user] }]
     )
 
-    store[object.current_account.id.to_s]  = serialized_resource(object.current_account) if object.current_account
-    store[object.admin.id.to_s]            = serialized_resource(object.admin) if object.admin
-    store[object.owner.id.to_s]            = serialized_resource(object.owner) if object.owner
-    store[object.disabled_account.id.to_s] = serialized_resource(object.disabled_account) if object.disabled_account
-    store[object.moved_to_account.id.to_s] = serialized_resource(object.moved_to_account) if object.moved_to_account
+    store[object.current_account.id.to_s]  = serialized_account(object.current_account) if object.current_account
+    store[object.admin.id.to_s]            = serialized_account(object.admin) if object.admin
+    store[object.owner.id.to_s]            = serialized_account(object.owner) if object.owner
+    store[object.disabled_account.id.to_s] = serialized_account(object.disabled_account) if object.disabled_account
+    store[object.moved_to_account.id.to_s] = serialized_account(object.moved_to_account) if object.moved_to_account
 
     store
   end
@@ -112,8 +112,8 @@ class InitialStateSerializer < ActiveModel::Serializer
     object.current_account.user
   end
 
-  def serialized_resource(resource)
-    ActiveModelSerializers::SerializableResource.new(resource, serializer: REST::AccountSerializer)
+  def serialized_account(account)
+    ActiveModelSerializers::SerializableResource.new(account, serializer: REST::AccountSerializer)
   end
 
   def instance_presenter

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -39,18 +39,18 @@ class InitialStateSerializer < ActiveModel::Serializer
 
     if object.current_account
       store[:me]                = object.current_account.id.to_s
-      store[:unfollow_modal]    = object.current_account.user.setting_unfollow_modal
-      store[:boost_modal]       = object.current_account.user.setting_boost_modal
-      store[:delete_modal]      = object.current_account.user.setting_delete_modal
-      store[:auto_play_gif]     = object.current_account.user.setting_auto_play_gif
-      store[:display_media]     = object.current_account.user.setting_display_media
-      store[:expand_spoilers]   = object.current_account.user.setting_expand_spoilers
-      store[:reduce_motion]     = object.current_account.user.setting_reduce_motion
-      store[:disable_swiping]   = object.current_account.user.setting_disable_swiping
-      store[:advanced_layout]   = object.current_account.user.setting_advanced_layout
-      store[:use_blurhash]      = object.current_account.user.setting_use_blurhash
-      store[:use_pending_items] = object.current_account.user.setting_use_pending_items
-      store[:show_trends]       = Setting.trends && object.current_account.user.setting_trends
+      store[:unfollow_modal]    = object_account_user.setting_unfollow_modal
+      store[:boost_modal]       = object_account_user.setting_boost_modal
+      store[:delete_modal]      = object_account_user.setting_delete_modal
+      store[:auto_play_gif]     = object_account_user.setting_auto_play_gif
+      store[:display_media]     = object_account_user.setting_display_media
+      store[:expand_spoilers]   = object_account_user.setting_expand_spoilers
+      store[:reduce_motion]     = object_account_user.setting_reduce_motion
+      store[:disable_swiping]   = object_account_user.setting_disable_swiping
+      store[:advanced_layout]   = object_account_user.setting_advanced_layout
+      store[:use_blurhash]      = object_account_user.setting_use_blurhash
+      store[:use_pending_items] = object_account_user.setting_use_pending_items
+      store[:show_trends]       = Setting.trends && object_account_user.setting_trends
     else
       store[:auto_play_gif] = Setting.auto_play_gif
       store[:display_media] = Setting.display_media
@@ -71,9 +71,9 @@ class InitialStateSerializer < ActiveModel::Serializer
 
     if object.current_account
       store[:me]                = object.current_account.id.to_s
-      store[:default_privacy]   = object.visibility || object.current_account.user.setting_default_privacy
-      store[:default_sensitive] = object.current_account.user.setting_default_sensitive
-      store[:default_language]  = object.current_account.user.preferred_posting_language
+      store[:default_privacy]   = object.visibility || object_account_user.setting_default_privacy
+      store[:default_sensitive] = object_account_user.setting_default_sensitive
+      store[:default_language]  = object_account_user.preferred_posting_language
     end
 
     store[:text] = object.text if object.text
@@ -107,6 +107,10 @@ class InitialStateSerializer < ActiveModel::Serializer
   end
 
   private
+
+  def object_account_user
+    object.current_account.user
+  end
 
   def serialized_resource(resource)
     ActiveModelSerializers::SerializableResource.new(resource, serializer: REST::AccountSerializer)


### PR DESCRIPTION
Two private method extractions to DRY up the class and improve readability a bit.