### PR TITLE
Run `yarn dedupe` when updating with Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,6 +12,7 @@
   // If we do not want a package to be grouped with others, we need to set its groupName
   // to `null` after any other rule set it to something.
   dependencyDashboardHeader: 'This issue lists Renovate updates and detected dependencies. Read the [Dependency Dashboard](https://docs.renovatebot.com/key-concepts/dashboard/) docs to learn more. Before approving any upgrade: read the description and comments in the [`renovate.json5` file](https://github.com/mastodon/mastodon/blob/main/.github/renovate.json5).',
+  postUpdateOptions: ['yarnDedupeHighest'],
   packageRules: [
     {
       // Require Dependency Dashboard Approval for major version bumps of these node packages


### PR DESCRIPTION
Perform deduplication of dependencies after updating dependencies in Renovate as in #27670.

**reference:**

- https://docs.renovatebot.com/configuration-options/#postupdateoptions
- https://yarnpkg.com/cli/dedupe