### PR TITLE
Fix Yarn version in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -15,6 +15,6 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 RUN gem install foreman
 
 # [Optional] Uncomment this line to install global node packages.
-RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g yarn" 2>&1
+RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && corepack enable" 2>&1
 
 COPY welcome-message.txt /usr/local/etc/vscode-dev-containers/first-run-notice.txt

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -11,6 +11,7 @@ bundle install
 git checkout -- Gemfile.lock
 
 # Fetch Javascript dependencies
+corepack enable
 yarn install --immutable
 
 # [re]create, migrate, and seed the test database

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -11,7 +11,7 @@ bundle install
 git checkout -- Gemfile.lock
 
 # Fetch Javascript dependencies
-corepack enable
+corepack prepare
 yarn install --immutable
 
 # [re]create, migrate, and seed the test database


### PR DESCRIPTION
Attempting to start a devcontainer triggers Yarn 1, and results in error during asset compilation (post #27073 merger)

> Mastodon and Webpacker requires Yarn ">=4 <5" and you are using 1.22.19

This triggers corepack to detect proper version