### PR TITLE
Add `Api::V1::Statuses::BaseController` base controller class

### DIFF
--- a/app/controllers/api/v1/statuses/base_controller.rb
+++ b/app/controllers/api/v1/statuses/base_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class Api::V1::Statuses::BaseController < Api::BaseController
+  include Authorization
+
+  before_action :set_status
+
+  private
+
+  def set_status
+    @status = Status.find(params[:status_id])
+    authorize @status, :show?
+  rescue Mastodon::NotPermittedError
+    not_found
+  end
+end

--- a/app/controllers/api/v1/statuses/bookmarks_controller.rb
+++ b/app/controllers/api/v1/statuses/bookmarks_controller.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
-class Api::V1::Statuses::BookmarksController < Api::BaseController
-  include Authorization
-
+class Api::V1::Statuses::BookmarksController < Api::V1::Statuses::BaseController
   before_action -> { doorkeeper_authorize! :write, :'write:bookmarks' }
   before_action :require_user!
-  before_action :set_status, only: [:create]
+  skip_before_action :set_status, only: [:destroy]
 
   def create
     current_account.bookmarks.find_or_create_by!(account: current_account, status: @status)
@@ -25,15 +23,6 @@ class Api::V1::Statuses::BookmarksController < Api::BaseController
     bookmark&.destroy!
 
     render json: @status, serializer: REST::StatusSerializer, relationships: StatusRelationshipsPresenter.new([@status], current_account.id, bookmarks_map: { @status.id => false })
-  rescue Mastodon::NotPermittedError
-    not_found
-  end
-
-  private
-
-  def set_status
-    @status = Status.find(params[:status_id])
-    authorize @status, :show?
   rescue Mastodon::NotPermittedError
     not_found
   end

--- a/app/controllers/api/v1/statuses/favourited_by_accounts_controller.rb
+++ b/app/controllers/api/v1/statuses/favourited_by_accounts_controller.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: true
 
-class Api::V1::Statuses::FavouritedByAccountsController < Api::BaseController
-  include Authorization
-
+class Api::V1::Statuses::FavouritedByAccountsController < Api::V1::Statuses::BaseController
   before_action -> { authorize_if_got_token! :read, :'read:accounts' }
-  before_action :set_status
   after_action :insert_pagination_headers
 
   def index
@@ -59,13 +56,6 @@ class Api::V1::Statuses::FavouritedByAccountsController < Api::BaseController
 
   def records_continue?
     @accounts.size == limit_param(DEFAULT_ACCOUNTS_LIMIT)
-  end
-
-  def set_status
-    @status = Status.find(params[:status_id])
-    authorize @status, :show?
-  rescue Mastodon::NotPermittedError
-    not_found
   end
 
   def pagination_params(core_params)

--- a/app/controllers/api/v1/statuses/favourites_controller.rb
+++ b/app/controllers/api/v1/statuses/favourites_controller.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
-class Api::V1::Statuses::FavouritesController < Api::BaseController
-  include Authorization
-
+class Api::V1::Statuses::FavouritesController < Api::V1::Statuses::BaseController
   before_action -> { doorkeeper_authorize! :write, :'write:favourites' }
   before_action :require_user!
-  before_action :set_status, only: [:create]
+  skip_before_action :set_status, only: [:destroy]
 
   def create
     FavouriteService.new.call(current_account, @status)
@@ -27,15 +25,6 @@ class Api::V1::Statuses::FavouritesController < Api::BaseController
 
     relationships = StatusRelationshipsPresenter.new([@status], current_account.id, favourites_map: { @status.id => false }, attributes_map: { @status.id => { favourites_count: count } })
     render json: @status, serializer: REST::StatusSerializer, relationships: relationships
-  rescue Mastodon::NotPermittedError
-    not_found
-  end
-
-  private
-
-  def set_status
-    @status = Status.find(params[:status_id])
-    authorize @status, :show?
   rescue Mastodon::NotPermittedError
     not_found
   end

--- a/app/controllers/api/v1/statuses/histories_controller.rb
+++ b/app/controllers/api/v1/statuses/histories_controller.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: true
 
-class Api::V1::Statuses::HistoriesController < Api::BaseController
-  include Authorization
-
+class Api::V1::Statuses::HistoriesController < Api::V1::Statuses::BaseController
   before_action -> { authorize_if_got_token! :read, :'read:statuses' }
-  before_action :set_status
 
   def show
     cache_if_unauthenticated!
@@ -15,12 +12,5 @@ class Api::V1::Statuses::HistoriesController < Api::BaseController
 
   def status_edits
     @status.edits.includes(:account, status: [:account]).to_a.presence || [@status.build_snapshot(at_time: @status.edited_at || @status.created_at)]
-  end
-
-  def set_status
-    @status = Status.find(params[:status_id])
-    authorize @status, :show?
-  rescue Mastodon::NotPermittedError
-    not_found
   end
 end

--- a/app/controllers/api/v1/statuses/mutes_controller.rb
+++ b/app/controllers/api/v1/statuses/mutes_controller.rb
@@ -1,11 +1,8 @@
 # frozen_string_literal: true
 
-class Api::V1::Statuses::MutesController < Api::BaseController
-  include Authorization
-
+class Api::V1::Statuses::MutesController < Api::V1::Statuses::BaseController
   before_action -> { doorkeeper_authorize! :write, :'write:mutes' }
   before_action :require_user!
-  before_action :set_status
   before_action :set_conversation
 
   def create
@@ -23,13 +20,6 @@ class Api::V1::Statuses::MutesController < Api::BaseController
   end
 
   private
-
-  def set_status
-    @status = Status.find(params[:status_id])
-    authorize @status, :show?
-  rescue Mastodon::NotPermittedError
-    not_found
-  end
 
   def set_conversation
     @conversation = @status.conversation

--- a/app/controllers/api/v1/statuses/pins_controller.rb
+++ b/app/controllers/api/v1/statuses/pins_controller.rb
@@ -1,11 +1,8 @@
 # frozen_string_literal: true
 
-class Api::V1::Statuses::PinsController < Api::BaseController
-  include Authorization
-
+class Api::V1::Statuses::PinsController < Api::V1::Statuses::BaseController
   before_action -> { doorkeeper_authorize! :write, :'write:accounts' }
   before_action :require_user!
-  before_action :set_status
 
   def create
     StatusPin.create!(account: current_account, status: @status)
@@ -25,10 +22,6 @@ class Api::V1::Statuses::PinsController < Api::BaseController
   end
 
   private
-
-  def set_status
-    @status = Status.find(params[:status_id])
-  end
 
   def distribute_add_activity!
     json = ActiveModelSerializers::SerializableResource.new(

--- a/app/controllers/api/v1/statuses/reblogged_by_accounts_controller.rb
+++ b/app/controllers/api/v1/statuses/reblogged_by_accounts_controller.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: true
 
-class Api::V1::Statuses::RebloggedByAccountsController < Api::BaseController
-  include Authorization
-
+class Api::V1::Statuses::RebloggedByAccountsController < Api::V1::Statuses::BaseController
   before_action -> { authorize_if_got_token! :read, :'read:accounts' }
-  before_action :set_status
   after_action :insert_pagination_headers
 
   def index
@@ -55,13 +52,6 @@ class Api::V1::Statuses::RebloggedByAccountsController < Api::BaseController
 
   def records_continue?
     @accounts.size == limit_param(DEFAULT_ACCOUNTS_LIMIT)
-  end
-
-  def set_status
-    @status = Status.find(params[:status_id])
-    authorize @status, :show?
-  rescue Mastodon::NotPermittedError
-    not_found
   end
 
   def pagination_params(core_params)

--- a/app/controllers/api/v1/statuses/reblogs_controller.rb
+++ b/app/controllers/api/v1/statuses/reblogs_controller.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-class Api::V1::Statuses::ReblogsController < Api::BaseController
-  include Authorization
+class Api::V1::Statuses::ReblogsController < Api::V1::Statuses::BaseController
   include Redisable
   include Lockable
 
   before_action -> { doorkeeper_authorize! :write, :'write:statuses' }
   before_action :require_user!
   before_action :set_reblog, only: [:create]
+  skip_before_action :set_status
 
   override_rate_limit_headers :create, family: :statuses
 

--- a/app/controllers/api/v1/statuses/sources_controller.rb
+++ b/app/controllers/api/v1/statuses/sources_controller.rb
@@ -1,21 +1,9 @@
 # frozen_string_literal: true
 
-class Api::V1::Statuses::SourcesController < Api::BaseController
-  include Authorization
-
+class Api::V1::Statuses::SourcesController < Api::V1::Statuses::BaseController
   before_action -> { doorkeeper_authorize! :read, :'read:statuses' }
-  before_action :set_status
 
   def show
     render json: @status, serializer: REST::StatusSourceSerializer
-  end
-
-  private
-
-  def set_status
-    @status = Status.find(params[:status_id])
-    authorize @status, :show?
-  rescue Mastodon::NotPermittedError
-    not_found
   end
 end

--- a/app/controllers/api/v1/statuses/translations_controller.rb
+++ b/app/controllers/api/v1/statuses/translations_controller.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: true
 
-class Api::V1::Statuses::TranslationsController < Api::BaseController
-  include Authorization
-
+class Api::V1::Statuses::TranslationsController < Api::V1::Statuses::BaseController
   before_action -> { doorkeeper_authorize! :read, :'read:statuses' }
-  before_action :set_status
   before_action :set_translation
 
   rescue_from TranslationService::NotConfiguredError, with: :not_found
@@ -23,13 +20,6 @@ class Api::V1::Statuses::TranslationsController < Api::BaseController
   end
 
   private
-
-  def set_status
-    @status = Status.find(params[:status_id])
-    authorize @status, :show?
-  rescue Mastodon::NotPermittedError
-    not_found
-  end
 
   def set_translation
     @translation = TranslateStatusService.new.call(@status, content_locale)


### PR DESCRIPTION
These were all pulling in `Authorization` and all had same definitions of a `set_status` method called in most cases. Reblogs is slightly different, so skip there and keep existing.