### PR TITLE
Add `Api::V1::Instances::BaseController` base controller class

### DIFF
--- a/app/controllers/api/v1/instances/activity_controller.rb
+++ b/app/controllers/api/v1/instances/activity_controller.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
-class Api::V1::Instances::ActivityController < Api::BaseController
+class Api::V1::Instances::ActivityController < Api::V1::Instances::BaseController
   before_action :require_enabled_api!
-
-  skip_before_action :require_authenticated_user!, unless: :limited_federation_mode?
-
-  vary_by ''
 
   def show
     cache_even_if_authenticated!

--- a/app/controllers/api/v1/instances/base_controller.rb
+++ b/app/controllers/api/v1/instances/base_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Api::V1::Instances::BaseController < Api::BaseController
+  skip_before_action :require_authenticated_user!,
+                     unless: :limited_federation_mode?
+
+  vary_by ''
+end

--- a/app/controllers/api/v1/instances/domain_blocks_controller.rb
+++ b/app/controllers/api/v1/instances/domain_blocks_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class Api::V1::Instances::DomainBlocksController < Api::BaseController
-  skip_before_action :require_authenticated_user!, unless: :limited_federation_mode?
-
+class Api::V1::Instances::DomainBlocksController < Api::V1::Instances::BaseController
   before_action :require_enabled_api!
   before_action :set_domain_blocks
 

--- a/app/controllers/api/v1/instances/extended_descriptions_controller.rb
+++ b/app/controllers/api/v1/instances/extended_descriptions_controller.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 
-class Api::V1::Instances::ExtendedDescriptionsController < Api::BaseController
-  skip_before_action :require_authenticated_user!, unless: :limited_federation_mode?
+class Api::V1::Instances::ExtendedDescriptionsController < Api::V1::Instances::BaseController
   skip_around_action :set_locale
 
   before_action :set_extended_description
-
-  vary_by ''
 
   # Override `current_user` to avoid reading session cookies unless in whitelist mode
   def current_user

--- a/app/controllers/api/v1/instances/languages_controller.rb
+++ b/app/controllers/api/v1/instances/languages_controller.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 
-class Api::V1::Instances::LanguagesController < Api::BaseController
-  skip_before_action :require_authenticated_user!, unless: :limited_federation_mode?
+class Api::V1::Instances::LanguagesController < Api::V1::Instances::BaseController
   skip_around_action :set_locale
 
   before_action :set_languages
-
-  vary_by ''
 
   def show
     cache_even_if_authenticated!

--- a/app/controllers/api/v1/instances/peers_controller.rb
+++ b/app/controllers/api/v1/instances/peers_controller.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 
-class Api::V1::Instances::PeersController < Api::BaseController
+class Api::V1::Instances::PeersController < Api::V1::Instances::BaseController
   before_action :require_enabled_api!
 
-  skip_before_action :require_authenticated_user!, unless: :limited_federation_mode?
   skip_around_action :set_locale
-
-  vary_by ''
 
   # Override `current_user` to avoid reading session cookies unless in whitelist mode
   def current_user

--- a/app/controllers/api/v1/instances/privacy_policies_controller.rb
+++ b/app/controllers/api/v1/instances/privacy_policies_controller.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
-class Api::V1::Instances::PrivacyPoliciesController < Api::BaseController
-  skip_before_action :require_authenticated_user!, unless: :limited_federation_mode?
-
+class Api::V1::Instances::PrivacyPoliciesController < Api::V1::Instances::BaseController
   before_action :set_privacy_policy
-
-  vary_by ''
 
   def show
     cache_even_if_authenticated!

--- a/app/controllers/api/v1/instances/rules_controller.rb
+++ b/app/controllers/api/v1/instances/rules_controller.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 
-class Api::V1::Instances::RulesController < Api::BaseController
-  skip_before_action :require_authenticated_user!, unless: :limited_federation_mode?
+class Api::V1::Instances::RulesController < Api::V1::Instances::BaseController
   skip_around_action :set_locale
 
   before_action :set_rules
-
-  vary_by ''
 
   # Override `current_user` to avoid reading session cookies unless in whitelist mode
   def current_user

--- a/app/controllers/api/v1/instances/translation_languages_controller.rb
+++ b/app/controllers/api/v1/instances/translation_languages_controller.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
-class Api::V1::Instances::TranslationLanguagesController < Api::BaseController
-  skip_before_action :require_authenticated_user!, unless: :limited_federation_mode?
-
+class Api::V1::Instances::TranslationLanguagesController < Api::V1::Instances::BaseController
   before_action :set_languages
-
-  vary_by ''
 
   def show
     cache_even_if_authenticated!


### PR DESCRIPTION
Pulls out common `skip_before_action` declaration and `vary` instruction. The reqeusts/cache_spec has good coverage of the vary setup and passes after changes here.