### PR TITLE
Fix modal content not being selectable

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -5226,6 +5226,7 @@ a.status-card {
 
 .modal-root__modal {
   pointer-events: auto;
+  user-select: text;
   display: flex;
 }
 


### PR DESCRIPTION
The generic modal introduced in https://github.com/mastodon/mastodon/commit/60ebfa182f944d5803dd6f3d54aa5e9ef24fc922 sets `user-select: none` on the container, but does not set a `user-select: text` on the modal itself. Other modal types (for example the error modal) do this.

This means that a user cannot select (e.g. for copy&paste-ing) the content of a modal. One example of that is the modal that shows older versions of a toot if the toot is edited. Copy-pasting them to easily diff them would be nice, but is made hard because of this.