### PR TITLE
Add a config file for easily find or change some settings like status max chars

### DIFF
--- a/app/lib/activitypub/parser/media_attachment_parser.rb
+++ b/app/lib/activitypub/parser/media_attachment_parser.rb
@@ -28,7 +28,7 @@ class ActivityPub::Parser::MediaAttachmentParser
 
   def description
     str = @json['summary'].presence || @json['name'].presence
-    str = str.strip[0...MediaAttachment::MAX_DESCRIPTION_LENGTH] if str.present?
+    str = str.strip[0...Rails.configuration.x.mastodon.media_attachments[:max_description_length]] if str.present?
     str
   end
 

--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -200,7 +200,7 @@ class MediaAttachment < ApplicationRecord
   before_file_validate :set_type_and_extension
   before_file_validate :check_video_dimensions
 
-  validates_attachment_content_type :file, content_type: self.supported_mime_types
+  validates_attachment_content_type :file, content_type: supported_mime_types
   validates_attachment_size :file, less_than: ->(m) { m.larger_media_format? ? VIDEO_LIMIT : IMAGE_LIMIT }
   remotable_attachment :file, VIDEO_LIMIT, suppress_errors: false, download_on_assign: false, attribute_name: :remote_url
 
@@ -209,7 +209,7 @@ class MediaAttachment < ApplicationRecord
                     processors: [:lazy_thumbnail, :blurhash_transcoder, :color_extractor],
                     convert_options: GLOBAL_CONVERT_OPTIONS
 
-  validates_attachment_content_type :thumbnail, content_type: self.image_mime_types
+  validates_attachment_content_type :thumbnail, content_type: image_mime_types
   validates_attachment_size :thumbnail, less_than: IMAGE_LIMIT
   remotable_attachment :thumbnail, IMAGE_LIMIT, suppress_errors: true, download_on_assign: false
 

--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -37,8 +37,6 @@ class MediaAttachment < ApplicationRecord
   enum type: { image: 0, gifv: 1, video: 2, unknown: 3, audio: 4 }
   enum processing: { queued: 0, in_progress: 1, complete: 2, failed: 3 }, _prefix: true
 
-  MAX_DESCRIPTION_LENGTH = 1_500
-
   IMAGE_LIMIT = 16.megabytes
   VIDEO_LIMIT = 99.megabytes
 
@@ -214,7 +212,7 @@ class MediaAttachment < ApplicationRecord
   remotable_attachment :thumbnail, IMAGE_LIMIT, suppress_errors: true, download_on_assign: false
 
   validates :account, presence: true
-  validates :description, length: { maximum: MAX_DESCRIPTION_LENGTH }
+  validates :description, length: { maximum: Rails.configuration.x.mastodon.media_attachments[:max_description_length] }
   validates :file, presence: true, if: :local?
   validates :thumbnail, absence: true, if: -> { local? && !audio_or_video? }
 

--- a/app/serializers/rest/instance_serializer.rb
+++ b/app/serializers/rest/instance_serializer.rb
@@ -55,7 +55,7 @@ class REST::InstanceSerializer < ActiveModel::Serializer
       statuses: {
         max_characters: Rails.configuration.x.mastodon.statuses[:max_characters],
         max_media_attachments: 4,
-        characters_reserved_per_url: Rails.configuration.x.mastodon.statuses[:url_placeholder_chars],
+        characters_reserved_per_url: Rails.configuration.x.mastodon.statuses[:url_placeholder_characters],
       },
 
       media_attachments: {

--- a/app/serializers/rest/instance_serializer.rb
+++ b/app/serializers/rest/instance_serializer.rb
@@ -53,9 +53,9 @@ class REST::InstanceSerializer < ActiveModel::Serializer
       },
 
       statuses: {
-        max_characters: StatusLengthValidator::MAX_CHARS,
+        max_characters: Rails.configuration.x.mastodon.statuses[:max_characters],
         max_media_attachments: 4,
-        characters_reserved_per_url: StatusLengthValidator::URL_PLACEHOLDER_CHARS,
+        characters_reserved_per_url: Rails.configuration.x.mastodon.statuses[:url_placeholder_chars],
       },
 
       media_attachments: {
@@ -68,8 +68,8 @@ class REST::InstanceSerializer < ActiveModel::Serializer
       },
 
       polls: {
-        max_options: PollValidator::MAX_OPTIONS,
-        max_characters_per_option: PollValidator::MAX_OPTION_CHARS,
+        max_options: Rails.configuration.x.mastodon.polls[:max_options],
+        max_characters_per_option: Rails.configuration.x.mastodon.polls[:max_option_characters],
         min_expiration: PollValidator::MIN_EXPIRATION,
         max_expiration: PollValidator::MAX_EXPIRATION,
       },

--- a/app/serializers/rest/instance_serializer.rb
+++ b/app/serializers/rest/instance_serializer.rb
@@ -60,9 +60,9 @@ class REST::InstanceSerializer < ActiveModel::Serializer
 
       media_attachments: {
         supported_mime_types: MediaAttachment.supported_mime_types,
-        image_size_limit: MediaAttachment::IMAGE_LIMIT,
+        image_size_limit: MediaAttachment.image_size_limit,
         image_matrix_limit: Attachmentable::MAX_MATRIX_LIMIT,
-        video_size_limit: MediaAttachment::VIDEO_LIMIT,
+        video_size_limit: MediaAttachment.video_size_limit,
         video_frame_rate_limit: MediaAttachment::MAX_VIDEO_FRAME_RATE,
         video_matrix_limit: MediaAttachment::MAX_VIDEO_MATRIX_LIMIT,
       },

--- a/app/serializers/rest/instance_serializer.rb
+++ b/app/serializers/rest/instance_serializer.rb
@@ -49,7 +49,7 @@ class REST::InstanceSerializer < ActiveModel::Serializer
       },
 
       accounts: {
-        max_featured_tags: FeaturedTag::LIMIT,
+        max_featured_tags: Rails.configuration.x.mastodon.accounts[:max_featured_tags],
       },
 
       statuses: {

--- a/app/serializers/rest/instance_serializer.rb
+++ b/app/serializers/rest/instance_serializer.rb
@@ -59,7 +59,7 @@ class REST::InstanceSerializer < ActiveModel::Serializer
       },
 
       media_attachments: {
-        supported_mime_types: MediaAttachment::IMAGE_MIME_TYPES + MediaAttachment::VIDEO_MIME_TYPES + MediaAttachment::AUDIO_MIME_TYPES,
+        supported_mime_types: MediaAttachment.supported_mime_types,
         image_size_limit: MediaAttachment::IMAGE_LIMIT,
         image_matrix_limit: Attachmentable::MAX_MATRIX_LIMIT,
         video_size_limit: MediaAttachment::VIDEO_LIMIT,

--- a/app/serializers/rest/v1/instance_serializer.rb
+++ b/app/serializers/rest/v1/instance_serializer.rb
@@ -63,9 +63,9 @@ class REST::V1::InstanceSerializer < ActiveModel::Serializer
       },
 
       statuses: {
-        max_characters: StatusLengthValidator::MAX_CHARS,
+        max_characters: Rails.configuration.x.mastodon.statuses[:max_characters],
         max_media_attachments: 4,
-        characters_reserved_per_url: StatusLengthValidator::URL_PLACEHOLDER_CHARS,
+        characters_reserved_per_url: Rails.configuration.x.mastodon.statuses[:url_placeholder_chars],
       },
 
       media_attachments: {
@@ -78,8 +78,8 @@ class REST::V1::InstanceSerializer < ActiveModel::Serializer
       },
 
       polls: {
-        max_options: PollValidator::MAX_OPTIONS,
-        max_characters_per_option: PollValidator::MAX_OPTION_CHARS,
+        max_options: Rails.configuration.x.mastodon.polls[:max_options],
+        max_characters_per_option: Rails.configuration.x.mastodon.polls[:max_option_characters],
         min_expiration: PollValidator::MIN_EXPIRATION,
         max_expiration: PollValidator::MAX_EXPIRATION,
       },

--- a/app/serializers/rest/v1/instance_serializer.rb
+++ b/app/serializers/rest/v1/instance_serializer.rb
@@ -65,7 +65,7 @@ class REST::V1::InstanceSerializer < ActiveModel::Serializer
       statuses: {
         max_characters: Rails.configuration.x.mastodon.statuses[:max_characters],
         max_media_attachments: 4,
-        characters_reserved_per_url: Rails.configuration.x.mastodon.statuses[:url_placeholder_chars],
+        characters_reserved_per_url: Rails.configuration.x.mastodon.statuses[:url_placeholder_characters],
       },
 
       media_attachments: {

--- a/app/serializers/rest/v1/instance_serializer.rb
+++ b/app/serializers/rest/v1/instance_serializer.rb
@@ -69,7 +69,7 @@ class REST::V1::InstanceSerializer < ActiveModel::Serializer
       },
 
       media_attachments: {
-        supported_mime_types: MediaAttachment::IMAGE_MIME_TYPES + MediaAttachment::VIDEO_MIME_TYPES + MediaAttachment::AUDIO_MIME_TYPES,
+        supported_mime_types: MediaAttachment.supported_mime_types,
         image_size_limit: MediaAttachment::IMAGE_LIMIT,
         image_matrix_limit: Attachmentable::MAX_MATRIX_LIMIT,
         video_size_limit: MediaAttachment::VIDEO_LIMIT,

--- a/app/serializers/rest/v1/instance_serializer.rb
+++ b/app/serializers/rest/v1/instance_serializer.rb
@@ -70,9 +70,9 @@ class REST::V1::InstanceSerializer < ActiveModel::Serializer
 
       media_attachments: {
         supported_mime_types: MediaAttachment.supported_mime_types,
-        image_size_limit: MediaAttachment::IMAGE_LIMIT,
+        image_size_limit: MediaAttachment.image_size_limit,
         image_matrix_limit: Attachmentable::MAX_MATRIX_LIMIT,
-        video_size_limit: MediaAttachment::VIDEO_LIMIT,
+        video_size_limit: MediaAttachment.video_size_limit,
         video_frame_rate_limit: MediaAttachment::MAX_VIDEO_FRAME_RATE,
         video_matrix_limit: MediaAttachment::MAX_VIDEO_MATRIX_LIMIT,
       },

--- a/app/serializers/rest/v1/instance_serializer.rb
+++ b/app/serializers/rest/v1/instance_serializer.rb
@@ -59,7 +59,7 @@ class REST::V1::InstanceSerializer < ActiveModel::Serializer
   def configuration
     {
       accounts: {
-        max_featured_tags: FeaturedTag::LIMIT,
+        max_featured_tags: Rails.configuration.x.mastodon.accounts[:max_featured_tags],
       },
 
       statuses: {

--- a/app/services/activitypub/fetch_featured_tags_collection_service.rb
+++ b/app/services/activitypub/fetch_featured_tags_collection_service.rb
@@ -33,7 +33,7 @@ class ActivityPub::FetchFeaturedTagsCollectionService < BaseService
 
       all_items.concat(items)
 
-      break if all_items.size >= FeaturedTag::LIMIT
+      break if all_items.size >= Rails.configuration.x.mastodon.accounts[:max_featured_tags]
 
       collection = collection['next'].present? ? fetch_collection(collection['next']) : nil
     end
@@ -49,7 +49,7 @@ class ActivityPub::FetchFeaturedTagsCollectionService < BaseService
   end
 
   def process_items(items)
-    names            = items.filter_map { |item| item['type'] == 'Hashtag' && item['name']&.delete_prefix('#') }.take(FeaturedTag::LIMIT)
+    names            = items.filter_map { |item| item['type'] == 'Hashtag' && item['name']&.delete_prefix('#') }.take(Rails.configuration.x.mastodon.accounts[:max_featured_tags])
     tags             = names.index_by { |name| HashtagNormalizer.new.normalize(name) }
     normalized_names = tags.keys
 

--- a/app/validators/poll_validator.rb
+++ b/app/validators/poll_validator.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class PollValidator < ActiveModel::Validator
-  MAX_OPTIONS      = 4
-  MAX_OPTION_CHARS = 50
   MAX_EXPIRATION   = 1.month.freeze
   MIN_EXPIRATION   = 5.minutes.freeze
 
@@ -10,8 +8,8 @@ class PollValidator < ActiveModel::Validator
     current_time = Time.now.utc
 
     poll.errors.add(:options, I18n.t('polls.errors.too_few_options')) unless poll.options.size > 1
-    poll.errors.add(:options, I18n.t('polls.errors.too_many_options', max: MAX_OPTIONS)) if poll.options.size > MAX_OPTIONS
-    poll.errors.add(:options, I18n.t('polls.errors.over_character_limit', max: MAX_OPTION_CHARS)) if poll.options.any? { |option| option.mb_chars.grapheme_length > MAX_OPTION_CHARS }
+    poll.errors.add(:options, I18n.t('polls.errors.too_many_options', max: Rails.configuration.x.mastodon.polls[:max_options])) if poll.options.size > Rails.configuration.x.mastodon.polls[:max_options]
+    poll.errors.add(:options, I18n.t('polls.errors.over_character_limit', max: Rails.configuration.x.mastodon.polls[:max_option_characters])) if poll.options.any? { |option| option.mb_chars.grapheme_length > Rails.configuration.x.mastodon.polls[:max_option_characters] }
     poll.errors.add(:options, I18n.t('polls.errors.duplicate_options')) unless poll.options.uniq.size == poll.options.size
     poll.errors.add(:expires_at, I18n.t('polls.errors.duration_too_long')) if poll.expires_at.nil? || poll.expires_at - current_time > MAX_EXPIRATION
     poll.errors.add(:expires_at, I18n.t('polls.errors.duration_too_short')) if poll.expires_at.present? && (poll.expires_at - current_time).ceil < MIN_EXPIRATION

--- a/app/validators/status_length_validator.rb
+++ b/app/validators/status_length_validator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class StatusLengthValidator < ActiveModel::Validator
-  URL_PLACEHOLDER = 'x' * Rails.configuration.x.mastodon.statuses[:url_placeholder_chars]
+  URL_PLACEHOLDER = 'x' * Rails.configuration.x.mastodon.statuses[:url_placeholder_characters]
 
   def validate(status)
     return unless status.local? && !status.reblog?

--- a/app/validators/status_length_validator.rb
+++ b/app/validators/status_length_validator.rb
@@ -1,20 +1,18 @@
 # frozen_string_literal: true
 
 class StatusLengthValidator < ActiveModel::Validator
-  MAX_CHARS = 500
-  URL_PLACEHOLDER_CHARS = 23
-  URL_PLACEHOLDER = 'x' * 23
+  URL_PLACEHOLDER = 'x' * Rails.configuration.x.mastodon.statuses[:url_placeholder_chars]
 
   def validate(status)
     return unless status.local? && !status.reblog?
 
-    status.errors.add(:text, I18n.t('statuses.over_character_limit', max: MAX_CHARS)) if too_long?(status)
+    status.errors.add(:text, I18n.t('statuses.over_character_limit', max: Rails.configuration.x.mastodon.statuses[:max_characters])) if too_long?(status)
   end
 
   private
 
   def too_long?(status)
-    countable_length(combined_text(status)) > MAX_CHARS
+    countable_length(combined_text(status)) > Rails.configuration.x.mastodon.statuses[:max_characters]
   end
 
   def countable_length(str)

--- a/config/initializers/mastodon.rb
+++ b/config/initializers/mastodon.rb
@@ -1,0 +1,5 @@
+module Mastodon
+  class Application < Rails::Application
+    config.x.mastodon = config_for(:mastodon)
+  end
+end

--- a/config/initializers/mastodon.rb
+++ b/config/initializers/mastodon.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Mastodon
   class Application < Rails::Application
     config.x.mastodon = config_for(:mastodon)

--- a/config/mastodon.yml
+++ b/config/mastodon.yml
@@ -1,7 +1,7 @@
 shared:
   statuses:
     max_characters: 500
-    url_placeholder_chars: 23
+    url_placeholder_characters: 23
 
   polls:
     max_options: 4

--- a/config/mastodon.yml
+++ b/config/mastodon.yml
@@ -1,0 +1,8 @@
+shared:
+  statuses:
+    max_characters: 500
+    url_placeholder_chars: 23
+
+  polls:
+    max_options: 4
+    max_option_characters: 50

--- a/config/mastodon.yml
+++ b/config/mastodon.yml
@@ -7,6 +7,9 @@ shared:
     url_placeholder_characters: 23
 
   media_attachments:
+    file_size_limit:
+      image: 16777216 # 16 MiB
+      video: 103809024 # 99 MiB
     max_description_length: 1500
     mime_types:
       image:

--- a/config/mastodon.yml
+++ b/config/mastodon.yml
@@ -7,6 +7,7 @@ shared:
     url_placeholder_characters: 23
 
   media_attachments:
+    max_description_length: 1500
     mime_types:
       image:
         image/jpeg:

--- a/config/mastodon.yml
+++ b/config/mastodon.yml
@@ -6,6 +6,45 @@ shared:
     max_characters: 500
     url_placeholder_characters: 23
 
+  media_attachments:
+    mime_types:
+      image:
+        image/jpeg:
+        image/png:
+        image/gif:
+        image/heic:
+          should_convert: true
+        image/heif:
+          should_convert: true
+        image/webp:
+        image/avif:
+          should_convert: true
+      video:
+        video/webm:
+          should_convert: true
+        video/mp4:
+        video/quicktime:
+          should_convert: true
+        video/ogg:
+      audio:
+        audio/wave:
+        audio/wav:
+        audio/x-wav:
+        audio/x-pn-wave:
+        audio/vnd.wave:
+        audio/ogg:
+        audio/vorbis:
+        audio/mpeg:
+        audio/mp3:
+        audio/webm:
+        audio/flac:
+        audio/aac:
+        audio/m4a:
+        audio/x-m4a:
+        audio/mp4:
+        audio/3gpp:
+        video/x-ms-asf:
+
   polls:
     max_options: 4
     max_option_characters: 50

--- a/config/mastodon.yml
+++ b/config/mastodon.yml
@@ -1,4 +1,7 @@
 shared:
+  accounts:
+    max_featured_tags: 10
+
   statuses:
     max_characters: 500
     url_placeholder_characters: 23

--- a/lib/paperclip/transcoder.rb
+++ b/lib/paperclip/transcoder.rb
@@ -41,7 +41,7 @@ module Paperclip
         @output_options['vframes'] = 1
       when 'mp4'
         unless eligible_to_passthrough?(metadata)
-          size_limit_in_bits = MediaAttachment::VIDEO_LIMIT * 8
+          size_limit_in_bits = MediaAttachment.video_size_limit * 8
           desired_bitrate = (metadata.width * metadata.height * 30 * BITS_PER_PIXEL).floor
           duration = [metadata.duration, 1].max
           maximum_bitrate = (size_limit_in_bits / duration).floor - 192_000 # Leave some space for the audio stream

--- a/spec/models/media_attachment_spec.rb
+++ b/spec/models/media_attachment_spec.rb
@@ -236,27 +236,27 @@ RSpec.describe MediaAttachment, :paperclip_processing do
 
   describe 'size limit validation' do
     it 'rejects video files that are too large' do
-      stub_const 'MediaAttachment::IMAGE_LIMIT', 100.megabytes
-      stub_const 'MediaAttachment::VIDEO_LIMIT', 1.kilobyte
+      Rails.configuration.x.media_attachments[:file_size_limit][:image] = 100.megabytes
+      Rails.configuration.x.media_attachments[:file_size_limit][:video] = 1.kilobyte
       expect { Fabricate(:media_attachment, file: attachment_fixture('attachment.webm')) }.to raise_error(ActiveRecord::RecordInvalid)
     end
 
     it 'accepts video files that are small enough' do
-      stub_const 'MediaAttachment::IMAGE_LIMIT', 1.kilobyte
-      stub_const 'MediaAttachment::VIDEO_LIMIT', 100.megabytes
+      Rails.configuration.x.media_attachments[:file_size_limit][:image] = 1.kilobyte
+      Rails.configuration.x.media_attachments[:file_size_limit][:video] = 100.megabytes
       media = Fabricate(:media_attachment, file: attachment_fixture('attachment.webm'))
       expect(media.valid?).to be true
     end
 
     it 'rejects image files that are too large' do
-      stub_const 'MediaAttachment::IMAGE_LIMIT', 1.kilobyte
-      stub_const 'MediaAttachment::VIDEO_LIMIT', 100.megabytes
+      Rails.configuration.x.media_attachments[:file_size_limit][:image] = 1.kilobyte
+      Rails.configuration.x.media_attachments[:file_size_limit][:video] = 100.megabytes
       expect { Fabricate(:media_attachment, file: attachment_fixture('attachment.jpg')) }.to raise_error(ActiveRecord::RecordInvalid)
     end
 
     it 'accepts image files that are small enough' do
-      stub_const 'MediaAttachment::IMAGE_LIMIT', 100.megabytes
-      stub_const 'MediaAttachment::VIDEO_LIMIT', 1.kilobyte
+      Rails.configuration.x.media_attachments[:file_size_limit][:image] = 100.megabytes
+      Rails.configuration.x.media_attachments[:file_size_limit][:video] = 1.kilobyte
       media = Fabricate(:media_attachment, file: attachment_fixture('attachment.jpg'))
       expect(media.valid?).to be true
     end


### PR DESCRIPTION
Add a config file `config/mastodon.yml`

At this time, This will contains:
- `accounts.max_featured_tags`
- `statuses.max_characters`
- `statuses.url_placeholder_chars`
- `media_attachments.file_size_limit.image`
- `media_attachments.file_size_limit.video`
- `media_attachments.max_description_length`
- `media_attachments.mime_types`
- `polls.max_options`
- `polls.max_option_characters`

And will be more on later PRs.

This will fixes #25546, #12265 partially.
I found #5697 PR.
but this PR will only introduces a config file, not env. So It can not be easily switching value, not encouraging to change it.
But there are already many servers which fork and change these values. For those, this will make them comfortable.


So this is trying to make middle ground:
1. Not easily configurable, should fork to change it.
2. But, Can find and replace it easily.