### PR TITLE
Fix Jest config

### DIFF
--- a/.watchmanconfig
+++ b/.watchmanconfig
@@ -1,0 +1,3 @@
+{
+  "ignore_dirs": ["node_modules/", "public/"]
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -19,7 +19,7 @@ const config = {
   // Those packages are ESM, so we need them to be processed by Babel
   transformIgnorePatterns: ['/node_modules/(?!(redent|strip-indent)/)'],
   coverageDirectory: '<rootDir>/coverage',
-  moduleDirectories: ['<rootDir>/node_modules', '<rootDir>/app/javascript'],
+  moduleDirectories: ['node_modules', '<rootDir>/app/javascript'],
   moduleNameMapper: {
     '\\.svg$': '<rootDir>/app/javascript/__mocks__/svg.js',
   },


### PR DESCRIPTION
- The default for `moduleDirectories` is `node_modules`, without the prefix. Reverting to the default solves the issue of Jest not loading the correct packages when loading packages with specific version dependencies
- Added a `.watchmanconfig` to have Watchman (Jest's file watcher) ignore some large directories

This should fix the various errors in dep update PRs, like #25612