### PR TITLE
Spec coverage for `api/v1/trends` controllers

### DIFF
--- a/spec/controllers/api/v1/trends/links_controller_spec.rb
+++ b/spec/controllers/api/v1/trends/links_controller_spec.rb
@@ -2,14 +2,36 @@
 
 require 'rails_helper'
 
-describe Api::V1::Trends::LinksController do
+RSpec.describe Api::V1::Trends::LinksController do
   render_views
 
   describe 'GET #index' do
-    it 'returns http success' do
-      get :index
+    around do |example|
+      previous = Setting.trends
+      example.run
+      Setting.trends = previous
+    end
 
-      expect(response).to have_http_status(200)
+    context 'when trends are disabled' do
+      before { Setting.trends = false }
+
+      it 'returns http success' do
+        get :index
+
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context 'when trends are enabled' do
+      before do
+        Setting.trends = true
+      end
+
+      it 'returns http success' do
+        get :index
+
+        expect(response).to have_http_status(200)
+      end
     end
   end
 end

--- a/spec/controllers/api/v1/trends/links_controller_spec.rb
+++ b/spec/controllers/api/v1/trends/links_controller_spec.rb
@@ -23,14 +23,22 @@ RSpec.describe Api::V1::Trends::LinksController do
     end
 
     context 'when trends are enabled' do
-      before do
-        Setting.trends = true
-      end
+      before { Setting.trends = true }
 
       it 'returns http success' do
+        prepare_trends
+        stub_const('Api::V1::Trends::LinksController::DEFAULT_LINKS_LIMIT', 2)
         get :index
 
         expect(response).to have_http_status(200)
+        expect(response.headers).to include('Link')
+      end
+
+      def prepare_trends
+        Fabricate.times(3, :preview_card, trendable: true, language: 'en').each do |link|
+          2.times { |i| Trends.links.add(link, i) }
+        end
+        Trends::Links.new(threshold: 1).refresh
       end
     end
   end

--- a/spec/controllers/api/v1/trends/statuses_controller_spec.rb
+++ b/spec/controllers/api/v1/trends/statuses_controller_spec.rb
@@ -2,14 +2,36 @@
 
 require 'rails_helper'
 
-describe Api::V1::Trends::StatusesController do
+RSpec.describe Api::V1::Trends::StatusesController do
   render_views
 
   describe 'GET #index' do
-    it 'returns http success' do
-      get :index
+    around do |example|
+      previous = Setting.trends
+      example.run
+      Setting.trends = previous
+    end
 
-      expect(response).to have_http_status(200)
+    context 'when trends are disabled' do
+      before { Setting.trends = false }
+
+      it 'returns http success' do
+        get :index
+
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context 'when trends are enabled' do
+      before do
+        Setting.trends = true
+      end
+
+      it 'returns http success' do
+        get :index
+
+        expect(response).to have_http_status(200)
+      end
     end
   end
 end

--- a/spec/controllers/api/v1/trends/tags_controller_spec.rb
+++ b/spec/controllers/api/v1/trends/tags_controller_spec.rb
@@ -6,16 +6,35 @@ RSpec.describe Api::V1::Trends::TagsController do
   render_views
 
   describe 'GET #index' do
-    before do
-      Fabricate.times(10, :tag).each do |tag|
-        10.times { |i| Trends.tags.add(tag, i) }
-      end
-
-      get :index
+    around do |example|
+      previous = Setting.trends
+      example.run
+      Setting.trends = previous
     end
 
-    it 'returns http success' do
-      expect(response).to have_http_status(200)
+    context 'when trends are disabled' do
+      before { Setting.trends = false }
+
+      it 'returns http success' do
+        get :index
+
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context 'when trends are enabled' do
+      before do
+        Setting.trends = true
+        Fabricate.times(10, :tag).each do |tag|
+          10.times { |i| Trends.tags.add(tag, i) }
+        end
+      end
+
+      it 'returns http success' do
+        get :index
+
+        expect(response).to have_http_status(200)
+      end
     end
   end
 end

--- a/spec/controllers/api/v1/trends/tags_controller_spec.rb
+++ b/spec/controllers/api/v1/trends/tags_controller_spec.rb
@@ -19,21 +19,27 @@ RSpec.describe Api::V1::Trends::TagsController do
         get :index
 
         expect(response).to have_http_status(200)
+        expect(response.headers).to_not include('Link')
       end
     end
 
     context 'when trends are enabled' do
-      before do
-        Setting.trends = true
-        Fabricate.times(10, :tag).each do |tag|
-          10.times { |i| Trends.tags.add(tag, i) }
-        end
-      end
+      before { Setting.trends = true }
 
       it 'returns http success' do
+        prepare_trends
+        stub_const('Api::V1::Trends::TagsController::DEFAULT_TAGS_LIMIT', 2)
         get :index
 
         expect(response).to have_http_status(200)
+        expect(response.headers).to include('Link')
+      end
+
+      def prepare_trends
+        Fabricate.times(3, :tag, trendable: true).each do |tag|
+          2.times { |i| Trends.tags.add(tag, i) }
+        end
+        Trends::Tags.new(threshold: 1).refresh
       end
     end
   end


### PR DESCRIPTION
The specs here were not exercising the scenarios where trends are disabled, and they were not fully exercising the pagination paths. These changes get us to 100% coverage for these controllers, and are in advance of a separate refactor to the area.