### PR TITLE
Use `hash_including` to check `AccountFilter` setup in `admin/accounts` controller spec

### DIFF
--- a/spec/controllers/admin/accounts_controller_spec.rb
+++ b/spec/controllers/admin/accounts_controller_spec.rb
@@ -20,8 +20,7 @@ RSpec.describe Admin::AccountsController do
     it 'filters with parameters' do
       account_filter = instance_double(AccountFilter, results: Account.all)
       allow(AccountFilter).to receive(:new).and_return(account_filter)
-
-      get :index, params: {
+      params = {
         origin: 'local',
         by_domain: 'domain',
         status: 'active',
@@ -31,17 +30,9 @@ RSpec.describe Admin::AccountsController do
         ip: '0.0.0.42',
       }
 
-      expect(AccountFilter).to have_received(:new) do |params|
-        h = params.to_h
+      get :index, params: params
 
-        expect(h[:origin]).to eq 'local'
-        expect(h[:by_domain]).to eq 'domain'
-        expect(h[:status]).to eq 'active'
-        expect(h[:username]).to eq 'username'
-        expect(h[:display_name]).to eq 'display name'
-        expect(h[:email]).to eq 'local-part@domain'
-        expect(h[:ip]).to eq '0.0.0.42'
-      end
+      expect(AccountFilter).to have_received(:new).with(hash_including(params))
     end
 
     it 'paginates accounts' do


### PR DESCRIPTION
This example is verifying that the params passed into controller get passed along to set up the filter. Changes just clean that up a bit but preserve the check.