### PR TITLE
Add base class for `api/v1/timelines/*` controllers

### DIFF
--- a/app/controllers/api/v1/timelines/base_controller.rb
+++ b/app/controllers/api/v1/timelines/base_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class Api::V1::Timelines::BaseController < Api::BaseController
+  after_action :insert_pagination_headers, unless: -> { @statuses.empty? }
 end

--- a/app/controllers/api/v1/timelines/base_controller.rb
+++ b/app/controllers/api/v1/timelines/base_controller.rb
@@ -18,17 +18,16 @@ class Api::V1::Timelines::BaseController < Api::BaseController
   end
 
   def next_path_params
-    pagination_params(max_id: pagination_max_id)
+    pagination_params.merge(max_id: pagination_max_id)
   end
 
   def prev_path_params
-    pagination_params(min_id: pagination_since_id)
+    pagination_params.merge(min_id: pagination_since_id)
   end
 
-  def pagination_params(core_params)
+  def pagination_params
     params
       .slice(*self.class::PERMITTED_PARAMS)
       .permit(*self.class::PERMITTED_PARAMS)
-      .merge(core_params)
   end
 end

--- a/app/controllers/api/v1/timelines/base_controller.rb
+++ b/app/controllers/api/v1/timelines/base_controller.rb
@@ -24,4 +24,11 @@ class Api::V1::Timelines::BaseController < Api::BaseController
   def prev_path_params
     pagination_params(min_id: pagination_since_id)
   end
+
+  def pagination_params(core_params)
+    params
+      .slice(*self.class::PERMITTED_PARAMS)
+      .permit(*self.class::PERMITTED_PARAMS)
+      .merge(core_params)
+  end
 end

--- a/app/controllers/api/v1/timelines/base_controller.rb
+++ b/app/controllers/api/v1/timelines/base_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Api::V1::Timelines::BaseController < Api::BaseController
+end

--- a/app/controllers/api/v1/timelines/base_controller.rb
+++ b/app/controllers/api/v1/timelines/base_controller.rb
@@ -18,20 +18,20 @@ class Api::V1::Timelines::BaseController < Api::BaseController
   end
 
   def next_path_params
-    permitted_pagination_params.merge(max_id: pagination_max_id)
+    permitted_params.merge(max_id: pagination_max_id)
   end
 
   def prev_path_params
-    permitted_pagination_params.merge(min_id: pagination_since_id)
-  end
-
-  def permitted_pagination_params
-    params
-      .slice(*permitted_params)
-      .permit(*permitted_params)
+    permitted_params.merge(min_id: pagination_since_id)
   end
 
   def permitted_params
+    params
+      .slice(*default_permitted_params)
+      .permit(*default_permitted_params)
+  end
+
+  def default_permitted_params
     self.class::PERMITTED_PARAMS
   end
 end

--- a/app/controllers/api/v1/timelines/base_controller.rb
+++ b/app/controllers/api/v1/timelines/base_controller.rb
@@ -2,4 +2,10 @@
 
 class Api::V1::Timelines::BaseController < Api::BaseController
   after_action :insert_pagination_headers, unless: -> { @statuses.empty? }
+
+  private
+
+  def insert_pagination_headers
+    set_pagination_headers(next_path, prev_path)
+  end
 end

--- a/app/controllers/api/v1/timelines/base_controller.rb
+++ b/app/controllers/api/v1/timelines/base_controller.rb
@@ -27,11 +27,7 @@ class Api::V1::Timelines::BaseController < Api::BaseController
 
   def permitted_params
     params
-      .slice(*default_permitted_params)
-      .permit(*default_permitted_params)
-  end
-
-  def default_permitted_params
-    self.class::PERMITTED_PARAMS
+      .slice(*self.class::PERMITTED_PARAMS)
+      .permit(*self.class::PERMITTED_PARAMS)
   end
 end

--- a/app/controllers/api/v1/timelines/base_controller.rb
+++ b/app/controllers/api/v1/timelines/base_controller.rb
@@ -27,7 +27,11 @@ class Api::V1::Timelines::BaseController < Api::BaseController
 
   def permitted_pagination_params
     params
-      .slice(*self.class::PERMITTED_PARAMS)
-      .permit(*self.class::PERMITTED_PARAMS)
+      .slice(*permitted_params)
+      .permit(*permitted_params)
+  end
+
+  def permitted_params
+    self.class::PERMITTED_PARAMS
   end
 end

--- a/app/controllers/api/v1/timelines/base_controller.rb
+++ b/app/controllers/api/v1/timelines/base_controller.rb
@@ -18,14 +18,14 @@ class Api::V1::Timelines::BaseController < Api::BaseController
   end
 
   def next_path_params
-    pagination_params.merge(max_id: pagination_max_id)
+    permitted_pagination_params.merge(max_id: pagination_max_id)
   end
 
   def prev_path_params
-    pagination_params.merge(min_id: pagination_since_id)
+    permitted_pagination_params.merge(min_id: pagination_since_id)
   end
 
-  def pagination_params
+  def permitted_pagination_params
     params
       .slice(*self.class::PERMITTED_PARAMS)
       .permit(*self.class::PERMITTED_PARAMS)

--- a/app/controllers/api/v1/timelines/base_controller.rb
+++ b/app/controllers/api/v1/timelines/base_controller.rb
@@ -16,4 +16,12 @@ class Api::V1::Timelines::BaseController < Api::BaseController
   def pagination_since_id
     @statuses.first.id
   end
+
+  def next_path_params
+    pagination_params(max_id: pagination_max_id)
+  end
+
+  def prev_path_params
+    pagination_params(min_id: pagination_since_id)
+  end
 end

--- a/app/controllers/api/v1/timelines/base_controller.rb
+++ b/app/controllers/api/v1/timelines/base_controller.rb
@@ -8,4 +8,12 @@ class Api::V1::Timelines::BaseController < Api::BaseController
   def insert_pagination_headers
     set_pagination_headers(next_path, prev_path)
   end
+
+  def pagination_max_id
+    @statuses.last.id
+  end
+
+  def pagination_since_id
+    @statuses.first.id
+  end
 end

--- a/app/controllers/api/v1/timelines/home_controller.rb
+++ b/app/controllers/api/v1/timelines/home_controller.rb
@@ -42,7 +42,7 @@ class Api::V1::Timelines::HomeController < Api::V1::Timelines::BaseController
   end
 
   def pagination_params(core_params)
-    params.slice(PERMITTED_PARAMS).permit(PERMITTED_PARAMS).merge(core_params)
+    params.slice(*PERMITTED_PARAMS).permit(*PERMITTED_PARAMS).merge(core_params)
   end
 
   def next_path

--- a/app/controllers/api/v1/timelines/home_controller.rb
+++ b/app/controllers/api/v1/timelines/home_controller.rb
@@ -39,10 +39,6 @@ class Api::V1::Timelines::HomeController < Api::V1::Timelines::BaseController
     HomeFeed.new(current_account)
   end
 
-  def insert_pagination_headers
-    set_pagination_headers(next_path, prev_path)
-  end
-
   def pagination_params(core_params)
     params.slice(:local, :limit).permit(:local, :limit).merge(core_params)
   end

--- a/app/controllers/api/v1/timelines/home_controller.rb
+++ b/app/controllers/api/v1/timelines/home_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Api::V1::Timelines::HomeController < Api::BaseController
+class Api::V1::Timelines::HomeController < Api::V1::Timelines::BaseController
   before_action -> { doorkeeper_authorize! :read, :'read:statuses' }, only: [:show]
   before_action :require_user!, only: [:show]
   after_action :insert_pagination_headers, unless: -> { @statuses.empty? }

--- a/app/controllers/api/v1/timelines/home_controller.rb
+++ b/app/controllers/api/v1/timelines/home_controller.rb
@@ -44,10 +44,10 @@ class Api::V1::Timelines::HomeController < Api::V1::Timelines::BaseController
   end
 
   def next_path
-    api_v1_timelines_home_url pagination_params(max_id: pagination_max_id)
+    api_v1_timelines_home_url next_path_params
   end
 
   def prev_path
-    api_v1_timelines_home_url pagination_params(min_id: pagination_since_id)
+    api_v1_timelines_home_url prev_path_params
   end
 end

--- a/app/controllers/api/v1/timelines/home_controller.rb
+++ b/app/controllers/api/v1/timelines/home_controller.rb
@@ -41,10 +41,6 @@ class Api::V1::Timelines::HomeController < Api::V1::Timelines::BaseController
     HomeFeed.new(current_account)
   end
 
-  def pagination_params(core_params)
-    params.slice(*PERMITTED_PARAMS).permit(*PERMITTED_PARAMS).merge(core_params)
-  end
-
   def next_path
     api_v1_timelines_home_url next_path_params
   end

--- a/app/controllers/api/v1/timelines/home_controller.rb
+++ b/app/controllers/api/v1/timelines/home_controller.rb
@@ -3,7 +3,6 @@
 class Api::V1::Timelines::HomeController < Api::V1::Timelines::BaseController
   before_action -> { doorkeeper_authorize! :read, :'read:statuses' }, only: [:show]
   before_action :require_user!, only: [:show]
-  after_action :insert_pagination_headers, unless: -> { @statuses.empty? }
 
   def show
     with_read_replica do

--- a/app/controllers/api/v1/timelines/home_controller.rb
+++ b/app/controllers/api/v1/timelines/home_controller.rb
@@ -4,6 +4,8 @@ class Api::V1::Timelines::HomeController < Api::V1::Timelines::BaseController
   before_action -> { doorkeeper_authorize! :read, :'read:statuses' }, only: [:show]
   before_action :require_user!, only: [:show]
 
+  PERMITTED_PARAMS = %i(local limit).freeze
+
   def show
     with_read_replica do
       @statuses = load_statuses
@@ -40,7 +42,7 @@ class Api::V1::Timelines::HomeController < Api::V1::Timelines::BaseController
   end
 
   def pagination_params(core_params)
-    params.slice(:local, :limit).permit(:local, :limit).merge(core_params)
+    params.slice(PERMITTED_PARAMS).permit(PERMITTED_PARAMS).merge(core_params)
   end
 
   def next_path

--- a/app/controllers/api/v1/timelines/home_controller.rb
+++ b/app/controllers/api/v1/timelines/home_controller.rb
@@ -50,12 +50,4 @@ class Api::V1::Timelines::HomeController < Api::V1::Timelines::BaseController
   def prev_path
     api_v1_timelines_home_url pagination_params(min_id: pagination_since_id)
   end
-
-  def pagination_max_id
-    @statuses.last.id
-  end
-
-  def pagination_since_id
-    @statuses.first.id
-  end
 end

--- a/app/controllers/api/v1/timelines/list_controller.rb
+++ b/app/controllers/api/v1/timelines/list_controller.rb
@@ -6,6 +6,8 @@ class Api::V1::Timelines::ListController < Api::V1::Timelines::BaseController
   before_action :set_list
   before_action :set_statuses
 
+  PERMITTED_PARAMS = %i(limit).freeze
+
   def show
     render json: @statuses,
            each_serializer: REST::StatusSerializer,
@@ -40,7 +42,7 @@ class Api::V1::Timelines::ListController < Api::V1::Timelines::BaseController
   end
 
   def pagination_params(core_params)
-    params.slice(:limit).permit(:limit).merge(core_params)
+    params.slice(PERMITTED_PARAMS).permit(PERMITTED_PARAMS).merge(core_params)
   end
 
   def next_path

--- a/app/controllers/api/v1/timelines/list_controller.rb
+++ b/app/controllers/api/v1/timelines/list_controller.rb
@@ -39,10 +39,6 @@ class Api::V1::Timelines::ListController < Api::V1::Timelines::BaseController
     ListFeed.new(@list)
   end
 
-  def insert_pagination_headers
-    set_pagination_headers(next_path, prev_path)
-  end
-
   def pagination_params(core_params)
     params.slice(:limit).permit(:limit).merge(core_params)
   end

--- a/app/controllers/api/v1/timelines/list_controller.rb
+++ b/app/controllers/api/v1/timelines/list_controller.rb
@@ -41,10 +41,6 @@ class Api::V1::Timelines::ListController < Api::V1::Timelines::BaseController
     ListFeed.new(@list)
   end
 
-  def pagination_params(core_params)
-    params.slice(PERMITTED_PARAMS).permit(PERMITTED_PARAMS).merge(core_params)
-  end
-
   def next_path
     api_v1_timelines_list_url params[:id], next_path_params
   end

--- a/app/controllers/api/v1/timelines/list_controller.rb
+++ b/app/controllers/api/v1/timelines/list_controller.rb
@@ -6,8 +6,6 @@ class Api::V1::Timelines::ListController < Api::V1::Timelines::BaseController
   before_action :set_list
   before_action :set_statuses
 
-  after_action :insert_pagination_headers, unless: -> { @statuses.empty? }
-
   def show
     render json: @statuses,
            each_serializer: REST::StatusSerializer,

--- a/app/controllers/api/v1/timelines/list_controller.rb
+++ b/app/controllers/api/v1/timelines/list_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Api::V1::Timelines::ListController < Api::BaseController
+class Api::V1::Timelines::ListController < Api::V1::Timelines::BaseController
   before_action -> { doorkeeper_authorize! :read, :'read:lists' }
   before_action :require_user!
   before_action :set_list

--- a/app/controllers/api/v1/timelines/list_controller.rb
+++ b/app/controllers/api/v1/timelines/list_controller.rb
@@ -44,10 +44,10 @@ class Api::V1::Timelines::ListController < Api::V1::Timelines::BaseController
   end
 
   def next_path
-    api_v1_timelines_list_url params[:id], pagination_params(max_id: pagination_max_id)
+    api_v1_timelines_list_url params[:id], next_path_params
   end
 
   def prev_path
-    api_v1_timelines_list_url params[:id], pagination_params(min_id: pagination_since_id)
+    api_v1_timelines_list_url params[:id], prev_path_params
   end
 end

--- a/app/controllers/api/v1/timelines/list_controller.rb
+++ b/app/controllers/api/v1/timelines/list_controller.rb
@@ -50,12 +50,4 @@ class Api::V1::Timelines::ListController < Api::V1::Timelines::BaseController
   def prev_path
     api_v1_timelines_list_url params[:id], pagination_params(min_id: pagination_since_id)
   end
-
-  def pagination_max_id
-    @statuses.last.id
-  end
-
-  def pagination_since_id
-    @statuses.first.id
-  end
 end

--- a/app/controllers/api/v1/timelines/public_controller.rb
+++ b/app/controllers/api/v1/timelines/public_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Api::V1::Timelines::PublicController < Api::BaseController
+class Api::V1::Timelines::PublicController < Api::V1::Timelines::BaseController
   before_action :require_user!, only: [:show], if: :require_auth?
   after_action :insert_pagination_headers, unless: -> { @statuses.empty? }
 

--- a/app/controllers/api/v1/timelines/public_controller.rb
+++ b/app/controllers/api/v1/timelines/public_controller.rb
@@ -43,10 +43,6 @@ class Api::V1::Timelines::PublicController < Api::V1::Timelines::BaseController
     )
   end
 
-  def pagination_params(core_params)
-    params.slice(*PERMITTED_PARAMS).permit(*PERMITTED_PARAMS).merge(core_params)
-  end
-
   def next_path
     api_v1_timelines_public_url next_path_params
   end

--- a/app/controllers/api/v1/timelines/public_controller.rb
+++ b/app/controllers/api/v1/timelines/public_controller.rb
@@ -44,7 +44,7 @@ class Api::V1::Timelines::PublicController < Api::V1::Timelines::BaseController
   end
 
   def pagination_params(core_params)
-    params.slice(PERMITTED_PARAMS).permit(PERMITTED_PARAMS).merge(core_params)
+    params.slice(*PERMITTED_PARAMS).permit(*PERMITTED_PARAMS).merge(core_params)
   end
 
   def next_path

--- a/app/controllers/api/v1/timelines/public_controller.rb
+++ b/app/controllers/api/v1/timelines/public_controller.rb
@@ -3,6 +3,8 @@
 class Api::V1::Timelines::PublicController < Api::V1::Timelines::BaseController
   before_action :require_user!, only: [:show], if: :require_auth?
 
+  PERMITTED_PARAMS = %i(local remote limit only_media).freeze
+
   def show
     cache_if_unauthenticated!
     @statuses = load_statuses
@@ -42,7 +44,7 @@ class Api::V1::Timelines::PublicController < Api::V1::Timelines::BaseController
   end
 
   def pagination_params(core_params)
-    params.slice(:local, :remote, :limit, :only_media).permit(:local, :remote, :limit, :only_media).merge(core_params)
+    params.slice(PERMITTED_PARAMS).permit(PERMITTED_PARAMS).merge(core_params)
   end
 
   def next_path

--- a/app/controllers/api/v1/timelines/public_controller.rb
+++ b/app/controllers/api/v1/timelines/public_controller.rb
@@ -52,12 +52,4 @@ class Api::V1::Timelines::PublicController < Api::V1::Timelines::BaseController
   def prev_path
     api_v1_timelines_public_url pagination_params(min_id: pagination_since_id)
   end
-
-  def pagination_max_id
-    @statuses.last.id
-  end
-
-  def pagination_since_id
-    @statuses.first.id
-  end
 end

--- a/app/controllers/api/v1/timelines/public_controller.rb
+++ b/app/controllers/api/v1/timelines/public_controller.rb
@@ -2,7 +2,6 @@
 
 class Api::V1::Timelines::PublicController < Api::V1::Timelines::BaseController
   before_action :require_user!, only: [:show], if: :require_auth?
-  after_action :insert_pagination_headers, unless: -> { @statuses.empty? }
 
   def show
     cache_if_unauthenticated!

--- a/app/controllers/api/v1/timelines/public_controller.rb
+++ b/app/controllers/api/v1/timelines/public_controller.rb
@@ -46,10 +46,10 @@ class Api::V1::Timelines::PublicController < Api::V1::Timelines::BaseController
   end
 
   def next_path
-    api_v1_timelines_public_url pagination_params(max_id: pagination_max_id)
+    api_v1_timelines_public_url next_path_params
   end
 
   def prev_path
-    api_v1_timelines_public_url pagination_params(min_id: pagination_since_id)
+    api_v1_timelines_public_url prev_path_params
   end
 end

--- a/app/controllers/api/v1/timelines/public_controller.rb
+++ b/app/controllers/api/v1/timelines/public_controller.rb
@@ -41,10 +41,6 @@ class Api::V1::Timelines::PublicController < Api::V1::Timelines::BaseController
     )
   end
 
-  def insert_pagination_headers
-    set_pagination_headers(next_path, prev_path)
-  end
-
   def pagination_params(core_params)
     params.slice(:local, :remote, :limit, :only_media).permit(:local, :remote, :limit, :only_media).merge(core_params)
   end

--- a/app/controllers/api/v1/timelines/tag_controller.rb
+++ b/app/controllers/api/v1/timelines/tag_controller.rb
@@ -55,10 +55,10 @@ class Api::V1::Timelines::TagController < Api::V1::Timelines::BaseController
   end
 
   def next_path
-    api_v1_timelines_tag_url params[:id], pagination_params(max_id: pagination_max_id)
+    api_v1_timelines_tag_url params[:id], next_path_params
   end
 
   def prev_path
-    api_v1_timelines_tag_url params[:id], pagination_params(min_id: pagination_since_id)
+    api_v1_timelines_tag_url params[:id], prev_path_params
   end
 end

--- a/app/controllers/api/v1/timelines/tag_controller.rb
+++ b/app/controllers/api/v1/timelines/tag_controller.rb
@@ -3,7 +3,6 @@
 class Api::V1::Timelines::TagController < Api::V1::Timelines::BaseController
   before_action -> { doorkeeper_authorize! :read, :'read:statuses' }, only: :show, if: :require_auth?
   before_action :load_tag
-  after_action :insert_pagination_headers, unless: -> { @statuses.empty? }
 
   def show
     cache_if_unauthenticated!

--- a/app/controllers/api/v1/timelines/tag_controller.rb
+++ b/app/controllers/api/v1/timelines/tag_controller.rb
@@ -61,12 +61,4 @@ class Api::V1::Timelines::TagController < Api::V1::Timelines::BaseController
   def prev_path
     api_v1_timelines_tag_url params[:id], pagination_params(min_id: pagination_since_id)
   end
-
-  def pagination_max_id
-    @statuses.last.id
-  end
-
-  def pagination_since_id
-    @statuses.first.id
-  end
 end

--- a/app/controllers/api/v1/timelines/tag_controller.rb
+++ b/app/controllers/api/v1/timelines/tag_controller.rb
@@ -4,6 +4,8 @@ class Api::V1::Timelines::TagController < Api::V1::Timelines::BaseController
   before_action -> { doorkeeper_authorize! :read, :'read:statuses' }, only: :show, if: :require_auth?
   before_action :load_tag
 
+  PERMITTED_PARAMS = %i(local limit only_media).freeze
+
   def show
     cache_if_unauthenticated!
     @statuses = load_statuses
@@ -51,7 +53,7 @@ class Api::V1::Timelines::TagController < Api::V1::Timelines::BaseController
   end
 
   def pagination_params(core_params)
-    params.slice(:local, :limit, :only_media).permit(:local, :limit, :only_media).merge(core_params)
+    params.slice(PERMITTED_PARAMS).permit(PERMITTED_PARAMS).merge(core_params)
   end
 
   def next_path

--- a/app/controllers/api/v1/timelines/tag_controller.rb
+++ b/app/controllers/api/v1/timelines/tag_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Api::V1::Timelines::TagController < Api::BaseController
+class Api::V1::Timelines::TagController < Api::V1::Timelines::BaseController
   before_action -> { doorkeeper_authorize! :read, :'read:statuses' }, only: :show, if: :require_auth?
   before_action :load_tag
   after_action :insert_pagination_headers, unless: -> { @statuses.empty? }

--- a/app/controllers/api/v1/timelines/tag_controller.rb
+++ b/app/controllers/api/v1/timelines/tag_controller.rb
@@ -52,10 +52,6 @@ class Api::V1::Timelines::TagController < Api::V1::Timelines::BaseController
     )
   end
 
-  def pagination_params(core_params)
-    params.slice(*PERMITTED_PARAMS).permit(*PERMITTED_PARAMS).merge(core_params)
-  end
-
   def next_path
     api_v1_timelines_tag_url params[:id], next_path_params
   end

--- a/app/controllers/api/v1/timelines/tag_controller.rb
+++ b/app/controllers/api/v1/timelines/tag_controller.rb
@@ -53,7 +53,7 @@ class Api::V1::Timelines::TagController < Api::V1::Timelines::BaseController
   end
 
   def pagination_params(core_params)
-    params.slice(PERMITTED_PARAMS).permit(PERMITTED_PARAMS).merge(core_params)
+    params.slice(*PERMITTED_PARAMS).permit(*PERMITTED_PARAMS).merge(core_params)
   end
 
   def next_path

--- a/app/controllers/api/v1/timelines/tag_controller.rb
+++ b/app/controllers/api/v1/timelines/tag_controller.rb
@@ -50,10 +50,6 @@ class Api::V1::Timelines::TagController < Api::V1::Timelines::BaseController
     )
   end
 
-  def insert_pagination_headers
-    set_pagination_headers(next_path, prev_path)
-  end
-
   def pagination_params(core_params)
     params.slice(:local, :limit, :only_media).permit(:local, :limit, :only_media).merge(core_params)
   end


### PR DESCRIPTION
Similar to https://github.com/mastodon/mastodon/pull/27797 for `api/v1/instances` and https://github.com/mastodon/mastodon/pull/27794 for `api/v1/statuses` this pulls out some common setup within the `api/v1/timelines/*` controllers.

Most of the shared behaviour here is around pagination of the api response. I think there might be opportunity here for further extraction of a shared controller concern for pagination across all the API controllers, but starting small here with a few base class extractions.

Coverage stays at 100% across controllers, behavior should not change.