### PR TITLE
Add base class for `api/v1/trends/*` controllers

### DIFF
--- a/app/controllers/api/v1/trends/base_controller.rb
+++ b/app/controllers/api/v1/trends/base_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Api::V1::Trends::BaseController < Api::BaseController
+end

--- a/app/controllers/api/v1/trends/base_controller.rb
+++ b/app/controllers/api/v1/trends/base_controller.rb
@@ -8,4 +8,8 @@ class Api::V1::Trends::BaseController < Api::BaseController
   def insert_pagination_headers
     set_pagination_headers(next_path, prev_path)
   end
+
+  def offset_param
+    params[:offset].to_i
+  end
 end

--- a/app/controllers/api/v1/trends/base_controller.rb
+++ b/app/controllers/api/v1/trends/base_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class Api::V1::Trends::BaseController < Api::BaseController
+  after_action :insert_pagination_headers
 end

--- a/app/controllers/api/v1/trends/base_controller.rb
+++ b/app/controllers/api/v1/trends/base_controller.rb
@@ -16,4 +16,8 @@ class Api::V1::Trends::BaseController < Api::BaseController
   def offset_param
     params[:offset].to_i
   end
+
+  def pagination_params(core_params)
+    params.slice(:limit).permit(:limit).merge(core_params)
+  end
 end

--- a/app/controllers/api/v1/trends/base_controller.rb
+++ b/app/controllers/api/v1/trends/base_controller.rb
@@ -5,6 +5,10 @@ class Api::V1::Trends::BaseController < Api::BaseController
 
   private
 
+  def enabled?
+    Setting.trends
+  end
+
   def insert_pagination_headers
     set_pagination_headers(next_path, prev_path)
   end

--- a/app/controllers/api/v1/trends/base_controller.rb
+++ b/app/controllers/api/v1/trends/base_controller.rb
@@ -5,8 +5,12 @@ class Api::V1::Trends::BaseController < Api::BaseController
 
   private
 
-  def enabled?
+  def trends_enabled?
     Setting.trends
+  end
+
+  def record_collection_when_trends_enabled
+    trends_enabled? ? offset_and_limited_collection : []
   end
 
   def insert_pagination_headers

--- a/app/controllers/api/v1/trends/base_controller.rb
+++ b/app/controllers/api/v1/trends/base_controller.rb
@@ -2,4 +2,10 @@
 
 class Api::V1::Trends::BaseController < Api::BaseController
   after_action :insert_pagination_headers
+
+  private
+
+  def insert_pagination_headers
+    set_pagination_headers(next_path, prev_path)
+  end
 end

--- a/app/controllers/api/v1/trends/base_controller.rb
+++ b/app/controllers/api/v1/trends/base_controller.rb
@@ -22,10 +22,14 @@ class Api::V1::Trends::BaseController < Api::BaseController
   end
 
   def next_path_params
-    pagination_params(offset: offset_param + limit_param(DEFAULT_RECORDS_LIMIT))
+    pagination_params(offset: offset_param + default_records_limit_param)
   end
 
   def prev_path_params
-    pagination_params(offset: offset_param - limit_param(DEFAULT_RECORDS_LIMIT))
+    pagination_params(offset: offset_param - default_records_limit_param)
+  end
+
+  def default_records_limit_param
+    limit_param(self.class::DEFAULT_RECORDS_LIMIT)
   end
 end

--- a/app/controllers/api/v1/trends/base_controller.rb
+++ b/app/controllers/api/v1/trends/base_controller.rb
@@ -22,10 +22,10 @@ class Api::V1::Trends::BaseController < Api::BaseController
   end
 
   def next_path_params
-    pagination_params(offset: offset_param + limit_param(DEFAULT_TAGS_LIMIT))
+    pagination_params(offset: offset_param + limit_param(DEFAULT_RECORDS_LIMIT))
   end
 
   def prev_path_params
-    pagination_params(offset: offset_param - limit_param(DEFAULT_LINKS_LIMIT))
+    pagination_params(offset: offset_param - limit_param(DEFAULT_RECORDS_LIMIT))
   end
 end

--- a/app/controllers/api/v1/trends/base_controller.rb
+++ b/app/controllers/api/v1/trends/base_controller.rb
@@ -37,6 +37,10 @@ class Api::V1::Trends::BaseController < Api::BaseController
     limit_param(self.class::DEFAULT_RECORDS_LIMIT)
   end
 
+  def records_continue?
+    record_collection_when_trends_enabled.size == default_records_limit_param
+  end
+
   def records_precede?
     offset_param > default_records_limit_param
   end

--- a/app/controllers/api/v1/trends/base_controller.rb
+++ b/app/controllers/api/v1/trends/base_controller.rb
@@ -32,4 +32,8 @@ class Api::V1::Trends::BaseController < Api::BaseController
   def default_records_limit_param
     limit_param(self.class::DEFAULT_RECORDS_LIMIT)
   end
+
+  def records_precede?
+    offset_param > default_records_limit_param
+  end
 end

--- a/app/controllers/api/v1/trends/base_controller.rb
+++ b/app/controllers/api/v1/trends/base_controller.rb
@@ -20,4 +20,12 @@ class Api::V1::Trends::BaseController < Api::BaseController
   def pagination_params(core_params)
     params.slice(:limit).permit(:limit).merge(core_params)
   end
+
+  def next_path_params
+    pagination_params(offset: offset_param + limit_param(DEFAULT_TAGS_LIMIT))
+  end
+
+  def prev_path_params
+    pagination_params(offset: offset_param - limit_param(DEFAULT_LINKS_LIMIT))
+  end
 end

--- a/app/controllers/api/v1/trends/links_controller.rb
+++ b/app/controllers/api/v1/trends/links_controller.rb
@@ -14,10 +14,6 @@ class Api::V1::Trends::LinksController < Api::BaseController
 
   private
 
-  def enabled?
-    Setting.trends
-  end
-
   def set_links
     @links = if enabled?
                links_from_trends.offset(offset_param).limit(limit_param(DEFAULT_LINKS_LIMIT))

--- a/app/controllers/api/v1/trends/links_controller.rb
+++ b/app/controllers/api/v1/trends/links_controller.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-class Api::V1::Trends::LinksController < Api::BaseController
+class Api::V1::Trends::LinksController < Api::V1::Trends::BaseController
   vary_by 'Authorization, Accept-Language'
 
   before_action :set_links
 
-  DEFAULT_LINKS_LIMIT = 10
+  DEFAULT_RECORDS_LIMIT = 10
 
   def index
     cache_if_unauthenticated!
@@ -16,7 +16,7 @@ class Api::V1::Trends::LinksController < Api::BaseController
 
   def set_links
     @links = if enabled?
-               links_from_trends.offset(offset_param).limit(limit_param(DEFAULT_LINKS_LIMIT))
+               links_from_trends.offset(offset_param).limit(limit_param(DEFAULT_RECORDS_LIMIT))
              else
                []
              end
@@ -33,10 +33,10 @@ class Api::V1::Trends::LinksController < Api::BaseController
   end
 
   def prev_path
-    api_v1_trends_links_url prev_path_params if offset_param > limit_param(DEFAULT_LINKS_LIMIT)
+    api_v1_trends_links_url prev_path_params if offset_param > limit_param(DEFAULT_RECORDS_LIMIT)
   end
 
   def records_continue?
-    @links.size == limit_param(DEFAULT_LINKS_LIMIT)
+    @links.size == limit_param(DEFAULT_RECORDS_LIMIT)
   end
 end

--- a/app/controllers/api/v1/trends/links_controller.rb
+++ b/app/controllers/api/v1/trends/links_controller.rb
@@ -32,10 +32,6 @@ class Api::V1::Trends::LinksController < Api::BaseController
     scope
   end
 
-  def insert_pagination_headers
-    set_pagination_headers(next_path, prev_path)
-  end
-
   def pagination_params(core_params)
     params.slice(:limit).permit(:limit).merge(core_params)
   end

--- a/app/controllers/api/v1/trends/links_controller.rb
+++ b/app/controllers/api/v1/trends/links_controller.rb
@@ -47,8 +47,4 @@ class Api::V1::Trends::LinksController < Api::BaseController
   def records_continue?
     @links.size == limit_param(DEFAULT_LINKS_LIMIT)
   end
-
-  def offset_param
-    params[:offset].to_i
-  end
 end

--- a/app/controllers/api/v1/trends/links_controller.rb
+++ b/app/controllers/api/v1/trends/links_controller.rb
@@ -37,8 +37,4 @@ class Api::V1::Trends::LinksController < Api::V1::Trends::BaseController
   def prev_path
     api_v1_trends_links_url prev_path_params if records_precede?
   end
-
-  def records_continue?
-    @links.size == default_records_limit_param
-  end
 end

--- a/app/controllers/api/v1/trends/links_controller.rb
+++ b/app/controllers/api/v1/trends/links_controller.rb
@@ -29,11 +29,11 @@ class Api::V1::Trends::LinksController < Api::BaseController
   end
 
   def next_path
-    api_v1_trends_links_url pagination_params(offset: offset_param + limit_param(DEFAULT_LINKS_LIMIT)) if records_continue?
+    api_v1_trends_links_url next_path_params if records_continue?
   end
 
   def prev_path
-    api_v1_trends_links_url pagination_params(offset: offset_param - limit_param(DEFAULT_LINKS_LIMIT)) if offset_param > limit_param(DEFAULT_LINKS_LIMIT)
+    api_v1_trends_links_url prev_path_params if offset_param > limit_param(DEFAULT_LINKS_LIMIT)
   end
 
   def records_continue?

--- a/app/controllers/api/v1/trends/links_controller.rb
+++ b/app/controllers/api/v1/trends/links_controller.rb
@@ -16,7 +16,7 @@ class Api::V1::Trends::LinksController < Api::V1::Trends::BaseController
 
   def set_links
     @links = if enabled?
-               links_from_trends.offset(offset_param).limit(limit_param(DEFAULT_RECORDS_LIMIT))
+               links_from_trends.offset(offset_param).limit(default_records_limit_param)
              else
                []
              end
@@ -33,10 +33,10 @@ class Api::V1::Trends::LinksController < Api::V1::Trends::BaseController
   end
 
   def prev_path
-    api_v1_trends_links_url prev_path_params if offset_param > limit_param(DEFAULT_RECORDS_LIMIT)
+    api_v1_trends_links_url prev_path_params if offset_param > default_records_limit_param
   end
 
   def records_continue?
-    @links.size == limit_param(DEFAULT_RECORDS_LIMIT)
+    @links.size == default_records_limit_param
   end
 end

--- a/app/controllers/api/v1/trends/links_controller.rb
+++ b/app/controllers/api/v1/trends/links_controller.rb
@@ -15,11 +15,13 @@ class Api::V1::Trends::LinksController < Api::V1::Trends::BaseController
   private
 
   def set_links
-    @links = if enabled?
-               links_from_trends.offset(offset_param).limit(default_records_limit_param)
-             else
-               []
-             end
+    @links = record_collection_when_trends_enabled
+  end
+
+  def offset_and_limited_collection
+    links_from_trends
+      .offset(offset_param)
+      .limit(default_records_limit_param)
   end
 
   def links_from_trends

--- a/app/controllers/api/v1/trends/links_controller.rb
+++ b/app/controllers/api/v1/trends/links_controller.rb
@@ -5,8 +5,6 @@ class Api::V1::Trends::LinksController < Api::BaseController
 
   before_action :set_links
 
-  after_action :insert_pagination_headers
-
   DEFAULT_LINKS_LIMIT = 10
 
   def index

--- a/app/controllers/api/v1/trends/links_controller.rb
+++ b/app/controllers/api/v1/trends/links_controller.rb
@@ -28,10 +28,6 @@ class Api::V1::Trends::LinksController < Api::BaseController
     scope
   end
 
-  def pagination_params(core_params)
-    params.slice(:limit).permit(:limit).merge(core_params)
-  end
-
   def next_path
     api_v1_trends_links_url pagination_params(offset: offset_param + limit_param(DEFAULT_LINKS_LIMIT)) if records_continue?
   end

--- a/app/controllers/api/v1/trends/links_controller.rb
+++ b/app/controllers/api/v1/trends/links_controller.rb
@@ -33,7 +33,7 @@ class Api::V1::Trends::LinksController < Api::V1::Trends::BaseController
   end
 
   def prev_path
-    api_v1_trends_links_url prev_path_params if offset_param > default_records_limit_param
+    api_v1_trends_links_url prev_path_params if records_precede?
   end
 
   def records_continue?

--- a/app/controllers/api/v1/trends/statuses_controller.rb
+++ b/app/controllers/api/v1/trends/statuses_controller.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
-class Api::V1::Trends::StatusesController < Api::BaseController
+class Api::V1::Trends::StatusesController < Api::V1::Trends::BaseController
   vary_by 'Authorization, Accept-Language'
 
   before_action :set_statuses
+
+  DEFAULT_RECORDS_LIMIT = 20
 
   def index
     cache_if_unauthenticated!
@@ -14,7 +16,7 @@ class Api::V1::Trends::StatusesController < Api::BaseController
 
   def set_statuses
     @statuses = if enabled?
-                  cache_collection(statuses_from_trends.offset(offset_param).limit(limit_param(DEFAULT_STATUSES_LIMIT)), Status)
+                  cache_collection(statuses_from_trends.offset(offset_param).limit(limit_param(DEFAULT_RECORDS_LIMIT)), Status)
                 else
                   []
                 end
@@ -31,10 +33,10 @@ class Api::V1::Trends::StatusesController < Api::BaseController
   end
 
   def prev_path
-    api_v1_trends_statuses_url prev_path_params if offset_param > limit_param(DEFAULT_STATUSES_LIMIT)
+    api_v1_trends_statuses_url prev_path_params if offset_param > limit_param(DEFAULT_RECORDS_LIMIT)
   end
 
   def records_continue?
-    @statuses.size == limit_param(DEFAULT_STATUSES_LIMIT)
+    @statuses.size == limit_param(DEFAULT_RECORDS_LIMIT)
   end
 end

--- a/app/controllers/api/v1/trends/statuses_controller.rb
+++ b/app/controllers/api/v1/trends/statuses_controller.rb
@@ -42,10 +42,6 @@ class Api::V1::Trends::StatusesController < Api::BaseController
     api_v1_trends_statuses_url pagination_params(offset: offset_param - limit_param(DEFAULT_STATUSES_LIMIT)) if offset_param > limit_param(DEFAULT_STATUSES_LIMIT)
   end
 
-  def offset_param
-    params[:offset].to_i
-  end
-
   def records_continue?
     @statuses.size == limit_param(DEFAULT_STATUSES_LIMIT)
   end

--- a/app/controllers/api/v1/trends/statuses_controller.rb
+++ b/app/controllers/api/v1/trends/statuses_controller.rb
@@ -30,10 +30,6 @@ class Api::V1::Trends::StatusesController < Api::BaseController
     scope
   end
 
-  def insert_pagination_headers
-    set_pagination_headers(next_path, prev_path)
-  end
-
   def pagination_params(core_params)
     params.slice(:limit).permit(:limit).merge(core_params)
   end

--- a/app/controllers/api/v1/trends/statuses_controller.rb
+++ b/app/controllers/api/v1/trends/statuses_controller.rb
@@ -40,8 +40,4 @@ class Api::V1::Trends::StatusesController < Api::V1::Trends::BaseController
   def prev_path
     api_v1_trends_statuses_url prev_path_params if records_precede?
   end
-
-  def records_continue?
-    @statuses.size == default_records_limit_param
-  end
 end

--- a/app/controllers/api/v1/trends/statuses_controller.rb
+++ b/app/controllers/api/v1/trends/statuses_controller.rb
@@ -27,11 +27,11 @@ class Api::V1::Trends::StatusesController < Api::BaseController
   end
 
   def next_path
-    api_v1_trends_statuses_url pagination_params(offset: offset_param + limit_param(DEFAULT_STATUSES_LIMIT)) if records_continue?
+    api_v1_trends_statuses_url next_path_params if records_continue?
   end
 
   def prev_path
-    api_v1_trends_statuses_url pagination_params(offset: offset_param - limit_param(DEFAULT_STATUSES_LIMIT)) if offset_param > limit_param(DEFAULT_STATUSES_LIMIT)
+    api_v1_trends_statuses_url prev_path_params if offset_param > limit_param(DEFAULT_STATUSES_LIMIT)
   end
 
   def records_continue?

--- a/app/controllers/api/v1/trends/statuses_controller.rb
+++ b/app/controllers/api/v1/trends/statuses_controller.rb
@@ -12,10 +12,6 @@ class Api::V1::Trends::StatusesController < Api::BaseController
 
   private
 
-  def enabled?
-    Setting.trends
-  end
-
   def set_statuses
     @statuses = if enabled?
                   cache_collection(statuses_from_trends.offset(offset_param).limit(limit_param(DEFAULT_STATUSES_LIMIT)), Status)

--- a/app/controllers/api/v1/trends/statuses_controller.rb
+++ b/app/controllers/api/v1/trends/statuses_controller.rb
@@ -15,11 +15,16 @@ class Api::V1::Trends::StatusesController < Api::V1::Trends::BaseController
   private
 
   def set_statuses
-    @statuses = if enabled?
-                  cache_collection(statuses_from_trends.offset(offset_param).limit(default_records_limit_param), Status)
-                else
-                  []
-                end
+    @statuses = record_collection_when_trends_enabled
+  end
+
+  def offset_and_limited_collection
+    cache_collection(
+      statuses_from_trends
+        .offset(offset_param)
+        .limit(default_records_limit_param),
+      Status
+    )
   end
 
   def statuses_from_trends

--- a/app/controllers/api/v1/trends/statuses_controller.rb
+++ b/app/controllers/api/v1/trends/statuses_controller.rb
@@ -16,7 +16,7 @@ class Api::V1::Trends::StatusesController < Api::V1::Trends::BaseController
 
   def set_statuses
     @statuses = if enabled?
-                  cache_collection(statuses_from_trends.offset(offset_param).limit(limit_param(DEFAULT_RECORDS_LIMIT)), Status)
+                  cache_collection(statuses_from_trends.offset(offset_param).limit(default_records_limit_param), Status)
                 else
                   []
                 end
@@ -33,10 +33,10 @@ class Api::V1::Trends::StatusesController < Api::V1::Trends::BaseController
   end
 
   def prev_path
-    api_v1_trends_statuses_url prev_path_params if offset_param > limit_param(DEFAULT_RECORDS_LIMIT)
+    api_v1_trends_statuses_url prev_path_params if offset_param > default_records_limit_param
   end
 
   def records_continue?
-    @statuses.size == limit_param(DEFAULT_RECORDS_LIMIT)
+    @statuses.size == default_records_limit_param
   end
 end

--- a/app/controllers/api/v1/trends/statuses_controller.rb
+++ b/app/controllers/api/v1/trends/statuses_controller.rb
@@ -26,10 +26,6 @@ class Api::V1::Trends::StatusesController < Api::BaseController
     scope
   end
 
-  def pagination_params(core_params)
-    params.slice(:limit).permit(:limit).merge(core_params)
-  end
-
   def next_path
     api_v1_trends_statuses_url pagination_params(offset: offset_param + limit_param(DEFAULT_STATUSES_LIMIT)) if records_continue?
   end

--- a/app/controllers/api/v1/trends/statuses_controller.rb
+++ b/app/controllers/api/v1/trends/statuses_controller.rb
@@ -33,7 +33,7 @@ class Api::V1::Trends::StatusesController < Api::V1::Trends::BaseController
   end
 
   def prev_path
-    api_v1_trends_statuses_url prev_path_params if offset_param > default_records_limit_param
+    api_v1_trends_statuses_url prev_path_params if records_precede?
   end
 
   def records_continue?

--- a/app/controllers/api/v1/trends/statuses_controller.rb
+++ b/app/controllers/api/v1/trends/statuses_controller.rb
@@ -5,8 +5,6 @@ class Api::V1::Trends::StatusesController < Api::BaseController
 
   before_action :set_statuses
 
-  after_action :insert_pagination_headers
-
   def index
     cache_if_unauthenticated!
     render json: @statuses, each_serializer: REST::StatusSerializer

--- a/app/controllers/api/v1/trends/tags_controller.rb
+++ b/app/controllers/api/v1/trends/tags_controller.rb
@@ -14,7 +14,7 @@ class Api::V1::Trends::TagsController < Api::V1::Trends::BaseController
 
   def set_tags
     @tags = if enabled?
-              tags_from_trends.offset(offset_param).limit(limit_param(DEFAULT_RECORDS_LIMIT))
+              tags_from_trends.offset(offset_param).limit(default_records_limit_param)
             else
               []
             end
@@ -29,10 +29,10 @@ class Api::V1::Trends::TagsController < Api::V1::Trends::BaseController
   end
 
   def prev_path
-    api_v1_trends_tags_url prev_path_params if offset_param > limit_param(DEFAULT_RECORDS_LIMIT)
+    api_v1_trends_tags_url prev_path_params if offset_param > default_records_limit_param
   end
 
   def records_continue?
-    @tags.size == limit_param(DEFAULT_RECORDS_LIMIT)
+    @tags.size == default_records_limit_param
   end
 end

--- a/app/controllers/api/v1/trends/tags_controller.rb
+++ b/app/controllers/api/v1/trends/tags_controller.rb
@@ -12,10 +12,6 @@ class Api::V1::Trends::TagsController < Api::BaseController
 
   private
 
-  def enabled?
-    Setting.trends
-  end
-
   def set_tags
     @tags = if enabled?
               tags_from_trends.offset(offset_param).limit(limit_param(DEFAULT_TAGS_LIMIT))

--- a/app/controllers/api/v1/trends/tags_controller.rb
+++ b/app/controllers/api/v1/trends/tags_controller.rb
@@ -3,8 +3,6 @@
 class Api::V1::Trends::TagsController < Api::BaseController
   before_action :set_tags
 
-  after_action :insert_pagination_headers
-
   DEFAULT_TAGS_LIMIT = 10
 
   def index

--- a/app/controllers/api/v1/trends/tags_controller.rb
+++ b/app/controllers/api/v1/trends/tags_controller.rb
@@ -29,7 +29,7 @@ class Api::V1::Trends::TagsController < Api::V1::Trends::BaseController
   end
 
   def prev_path
-    api_v1_trends_tags_url prev_path_params if offset_param > default_records_limit_param
+    api_v1_trends_tags_url prev_path_params if records_precede?
   end
 
   def records_continue?

--- a/app/controllers/api/v1/trends/tags_controller.rb
+++ b/app/controllers/api/v1/trends/tags_controller.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-class Api::V1::Trends::TagsController < Api::BaseController
+class Api::V1::Trends::TagsController < Api::V1::Trends::BaseController
   before_action :set_tags
 
-  DEFAULT_TAGS_LIMIT = 10
+  DEFAULT_RECORDS_LIMIT = 10
 
   def index
     cache_if_unauthenticated!
@@ -14,7 +14,7 @@ class Api::V1::Trends::TagsController < Api::BaseController
 
   def set_tags
     @tags = if enabled?
-              tags_from_trends.offset(offset_param).limit(limit_param(DEFAULT_TAGS_LIMIT))
+              tags_from_trends.offset(offset_param).limit(limit_param(DEFAULT_RECORDS_LIMIT))
             else
               []
             end
@@ -29,10 +29,10 @@ class Api::V1::Trends::TagsController < Api::BaseController
   end
 
   def prev_path
-    api_v1_trends_tags_url prev_path_params if offset_param > limit_param(DEFAULT_TAGS_LIMIT)
+    api_v1_trends_tags_url prev_path_params if offset_param > limit_param(DEFAULT_RECORDS_LIMIT)
   end
 
   def records_continue?
-    @tags.size == limit_param(DEFAULT_TAGS_LIMIT)
+    @tags.size == limit_param(DEFAULT_RECORDS_LIMIT)
   end
 end

--- a/app/controllers/api/v1/trends/tags_controller.rb
+++ b/app/controllers/api/v1/trends/tags_controller.rb
@@ -40,10 +40,6 @@ class Api::V1::Trends::TagsController < Api::BaseController
     api_v1_trends_tags_url pagination_params(offset: offset_param - limit_param(DEFAULT_TAGS_LIMIT)) if offset_param > limit_param(DEFAULT_TAGS_LIMIT)
   end
 
-  def offset_param
-    params[:offset].to_i
-  end
-
   def records_continue?
     @tags.size == limit_param(DEFAULT_TAGS_LIMIT)
   end

--- a/app/controllers/api/v1/trends/tags_controller.rb
+++ b/app/controllers/api/v1/trends/tags_controller.rb
@@ -13,11 +13,13 @@ class Api::V1::Trends::TagsController < Api::V1::Trends::BaseController
   private
 
   def set_tags
-    @tags = if enabled?
-              tags_from_trends.offset(offset_param).limit(default_records_limit_param)
-            else
-              []
-            end
+    @tags = record_collection_when_trends_enabled
+  end
+
+  def offset_and_limited_collection
+    tags_from_trends
+      .offset(offset_param)
+      .limit(default_records_limit_param)
   end
 
   def tags_from_trends

--- a/app/controllers/api/v1/trends/tags_controller.rb
+++ b/app/controllers/api/v1/trends/tags_controller.rb
@@ -25,11 +25,11 @@ class Api::V1::Trends::TagsController < Api::BaseController
   end
 
   def next_path
-    api_v1_trends_tags_url pagination_params(offset: offset_param + limit_param(DEFAULT_TAGS_LIMIT)) if records_continue?
+    api_v1_trends_tags_url next_path_params if records_continue?
   end
 
   def prev_path
-    api_v1_trends_tags_url pagination_params(offset: offset_param - limit_param(DEFAULT_TAGS_LIMIT)) if offset_param > limit_param(DEFAULT_TAGS_LIMIT)
+    api_v1_trends_tags_url prev_path_params if offset_param > limit_param(DEFAULT_TAGS_LIMIT)
   end
 
   def records_continue?

--- a/app/controllers/api/v1/trends/tags_controller.rb
+++ b/app/controllers/api/v1/trends/tags_controller.rb
@@ -28,10 +28,6 @@ class Api::V1::Trends::TagsController < Api::BaseController
     Trends.tags.query.allowed
   end
 
-  def insert_pagination_headers
-    set_pagination_headers(next_path, prev_path)
-  end
-
   def pagination_params(core_params)
     params.slice(:limit).permit(:limit).merge(core_params)
   end

--- a/app/controllers/api/v1/trends/tags_controller.rb
+++ b/app/controllers/api/v1/trends/tags_controller.rb
@@ -24,10 +24,6 @@ class Api::V1::Trends::TagsController < Api::BaseController
     Trends.tags.query.allowed
   end
 
-  def pagination_params(core_params)
-    params.slice(:limit).permit(:limit).merge(core_params)
-  end
-
   def next_path
     api_v1_trends_tags_url pagination_params(offset: offset_param + limit_param(DEFAULT_TAGS_LIMIT)) if records_continue?
   end

--- a/app/controllers/api/v1/trends/tags_controller.rb
+++ b/app/controllers/api/v1/trends/tags_controller.rb
@@ -33,8 +33,4 @@ class Api::V1::Trends::TagsController < Api::V1::Trends::BaseController
   def prev_path
     api_v1_trends_tags_url prev_path_params if records_precede?
   end
-
-  def records_continue?
-    @tags.size == default_records_limit_param
-  end
 end

--- a/spec/requests/api/v1/trends/links_spec.rb
+++ b/spec/requests/api/v1/trends/links_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'API V1 Trends Links' do
 
       it 'returns http success' do
         prepare_trends
-        stub_const('Api::V1::Trends::LinksController::DEFAULT_LINKS_LIMIT', 2)
+        stub_const('Api::V1::Trends::LinksController::DEFAULT_RECORDS_LIMIT', 2)
         get '/api/v1/trends/links'
 
         expect(response).to have_http_status(200)

--- a/spec/requests/api/v1/trends/statuses_spec.rb
+++ b/spec/requests/api/v1/trends/statuses_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'API V1 Trends Statuses' do
 
       it 'returns http success' do
         prepare_trends
-        stub_const('Api::BaseController::DEFAULT_STATUSES_LIMIT', 2)
+        stub_const('Api::V1::Trends::StatusesController::DEFAULT_RECORDS_LIMIT', 2)
         get '/api/v1/trends/statuses'
 
         expect(response).to have_http_status(200)

--- a/spec/requests/api/v1/trends/tags_spec.rb
+++ b/spec/requests/api/v1/trends/tags_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'API V1 Trends Tags' do
 
       it 'returns http success' do
         prepare_trends
-        stub_const('Api::V1::Trends::TagsController::DEFAULT_TAGS_LIMIT', 2)
+        stub_const('Api::V1::Trends::TagsController::DEFAULT_RECORDS_LIMIT', 2)
         get '/api/v1/trends/tags'
 
         expect(response).to have_http_status(200)


### PR DESCRIPTION
Similar to https://github.com/mastodon/mastodon/pull/27797 for `api/v1/instances` and https://github.com/mastodon/mastodon/pull/27794 for `api/v1/statuses` this pulls out some common setup within the `api/v1/trends/*` controllers.

Most of the shared behaviour here is around pagination of the api response. I think there might be opportunity here for further extraction of a shared controller concern for pagination across all the API controllers, but starting small here with a few base class extractions.

With https://github.com/mastodon/mastodon/pull/27837 merged, we are at 100% coverage for these.  With changes, coverage stays at 100% across controllers, behavior should not change.