### PR TITLE
Specs for minimal CSP policy in `Api::` controllers

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -7,6 +7,7 @@ class Api::BaseController < ApplicationController
   include RateLimitHeaders
   include AccessTokenTrackingConcern
   include ApiCachingConcern
+  include Api::ContentSecurityPolicy
 
   skip_before_action :require_functional!, unless: :limited_federation_mode?
 
@@ -16,26 +17,6 @@ class Api::BaseController < ApplicationController
   vary_by 'Authorization'
 
   protect_from_forgery with: :null_session
-
-  content_security_policy do |p|
-    # Set every directive that does not have a fallback
-    p.default_src :none
-    p.frame_ancestors :none
-    p.form_action :none
-
-    # Disable every directive with a fallback to cut on response size
-    p.base_uri false
-    p.font_src false
-    p.img_src false
-    p.style_src false
-    p.media_src false
-    p.frame_src false
-    p.manifest_src false
-    p.connect_src false
-    p.script_src false
-    p.child_src false
-    p.worker_src false
-  end
 
   rescue_from ActiveRecord::RecordInvalid, Mastodon::ValidationError do |e|
     render json: { error: e.to_s }, status: 422

--- a/app/controllers/concerns/api/content_security_policy.rb
+++ b/app/controllers/concerns/api/content_security_policy.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Api::ContentSecurityPolicy
+  extend ActiveSupport::Concern
+
+  included do
+    content_security_policy do |policy|
+      # Set every directive that does not have a fallback
+      policy.default_src :none
+      policy.frame_ancestors :none
+      policy.form_action :none
+
+      # Disable every directive with a fallback to cut on response size
+      policy.base_uri false
+      policy.font_src false
+      policy.img_src false
+      policy.style_src false
+      policy.media_src false
+      policy.frame_src false
+      policy.manifest_src false
+      policy.connect_src false
+      policy.script_src false
+      policy.child_src false
+      policy.worker_src false
+    end
+  end
+end

--- a/app/controllers/concerns/api/content_security_policy.rb
+++ b/app/controllers/concerns/api/content_security_policy.rb
@@ -3,25 +3,35 @@
 module Api::ContentSecurityPolicy
   extend ActiveSupport::Concern
 
+  FALLBACK_DIRECTIVES = %i(
+    base_uri
+    font_src
+    img_src
+    style_src
+    media_src
+    frame_src
+    manifest_src
+    connect_src
+    script_src
+    child_src
+    worker_src
+  ).freeze
+
+  NON_FALLBACK_DIRECTIVES = %i(
+    default_src
+    frame_ancestors
+    form_action
+  ).freeze
+
   included do
     content_security_policy do |policy|
-      # Set every directive that does not have a fallback
-      policy.default_src :none
-      policy.frame_ancestors :none
-      policy.form_action :none
+      NON_FALLBACK_DIRECTIVES.each do |directive|
+        policy.send directive, :none
+      end
 
-      # Disable every directive with a fallback to cut on response size
-      policy.base_uri false
-      policy.font_src false
-      policy.img_src false
-      policy.style_src false
-      policy.media_src false
-      policy.frame_src false
-      policy.manifest_src false
-      policy.connect_src false
-      policy.script_src false
-      policy.child_src false
-      policy.worker_src false
+      FALLBACK_DIRECTIVES.each do |directive|
+        policy.send directive, false
+      end
     end
   end
 end

--- a/app/controllers/concerns/api/content_security_policy.rb
+++ b/app/controllers/concerns/api/content_security_policy.rb
@@ -3,35 +3,27 @@
 module Api::ContentSecurityPolicy
   extend ActiveSupport::Concern
 
-  FALLBACK_DIRECTIVES = %i(
-    base_uri
-    font_src
-    img_src
-    style_src
-    media_src
-    frame_src
-    manifest_src
-    connect_src
-    script_src
-    child_src
-    worker_src
-  ).freeze
-
-  NON_FALLBACK_DIRECTIVES = %i(
-    default_src
-    frame_ancestors
-    form_action
-  ).freeze
-
   included do
     content_security_policy do |policy|
-      NON_FALLBACK_DIRECTIVES.each do |directive|
-        policy.send directive, :none
-      end
+      %i(
+        default_src
+        frame_ancestors
+        form_action
+      ).each { |directive| policy.send directive, :none }
 
-      FALLBACK_DIRECTIVES.each do |directive|
-        policy.send directive, false
-      end
+      %i(
+        base_uri
+        font_src
+        img_src
+        style_src
+        media_src
+        frame_src
+        manifest_src
+        connect_src
+        script_src
+        child_src
+        worker_src
+      ).each { |directive| policy.send directive, false }
     end
   end
 end

--- a/app/controllers/concerns/api/content_security_policy.rb
+++ b/app/controllers/concerns/api/content_security_policy.rb
@@ -5,25 +5,23 @@ module Api::ContentSecurityPolicy
 
   included do
     content_security_policy do |policy|
-      %i(
-        default_src
-        frame_ancestors
-        form_action
-      ).each { |directive| policy.send directive, :none }
+      # Set every directive that does not have a fallback
+      policy.default_src :none
+      policy.frame_ancestors :none
+      policy.form_action :none
 
-      %i(
-        base_uri
-        font_src
-        img_src
-        style_src
-        media_src
-        frame_src
-        manifest_src
-        connect_src
-        script_src
-        child_src
-        worker_src
-      ).each { |directive| policy.send directive, false }
+      # Disable every directive with a fallback to cut on response size
+      policy.base_uri false
+      policy.font_src false
+      policy.img_src false
+      policy.style_src false
+      policy.media_src false
+      policy.frame_src false
+      policy.manifest_src false
+      policy.connect_src false
+      policy.script_src false
+      policy.child_src false
+      policy.worker_src false
     end
   end
 end

--- a/spec/requests/api/v1/csp_spec.rb
+++ b/spec/requests/api/v1/csp_spec.rb
@@ -3,13 +3,12 @@
 require 'rails_helper'
 
 describe 'API namespace minimal Content-Security-Policy' do
-  before do
-    # Replaces an already-routed-to API controller
-    stub_const('Api::V1::SuggestionsController', test_controller)
-  end
+  before { stub_tests_controller }
+
+  after { Rails.application.reload_routes! }
 
   it 'returns the correct CSP headers' do
-    get '/api/v1/suggestions'
+    get '/api/v1/tests'
 
     expect(response).to have_http_status(200)
     expect(response.headers['Content-Security-Policy']).to eq(minimal_csp_headers)
@@ -17,11 +16,24 @@ describe 'API namespace minimal Content-Security-Policy' do
 
   private
 
-  def test_controller
+  def stub_tests_controller
+    stub_const('Api::V1::TestsController', api_tests_controller)
+
+    Rails.application.routes.draw do
+      get '/api/v1/tests', to: 'api/v1/tests#index'
+    end
+  end
+
+  def api_tests_controller
     Class.new(Api::BaseController) do
       def index
         head 200
       end
+
+      private
+
+      def user_signed_in? = false
+      def current_user = nil
     end
   end
 

--- a/spec/requests/api/v1/csp_spec.rb
+++ b/spec/requests/api/v1/csp_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'API namespace minimal Content-Security-Policy' do
+  before do
+    # Replaces an already-routed-to API controller
+    stub_const('Api::V1::SuggestionsController', test_controller)
+  end
+
+  it 'returns the correct CSP headers' do
+    get '/api/v1/suggestions'
+
+    expect(response).to have_http_status(200)
+    expect(response.headers['Content-Security-Policy']).to eq(minimal_csp_headers)
+  end
+
+  private
+
+  def test_controller
+    Class.new(Api::BaseController) do
+      def index
+        head 200
+      end
+    end
+  end
+
+  def minimal_csp_headers
+    "default-src 'none'; frame-ancestors 'none'; form-action 'none'"
+  end
+end


### PR DESCRIPTION
We previously added a change to the CSP policy in the `Api::` controllers to reduce the response size and minimize the policy there -- https://github.com/mastodon/mastodon/pull/20960

This adds spec coverage for that change (expects the minimal string of CSP, fails on base config) and then moves the whole CSP set up out of the `Api::BaseController` class and into a controller concern.