### PR TITLE
File cleanup/organization in `controllers/concerns`

### DIFF
--- a/app/controllers/admin/export_domain_allows_controller.rb
+++ b/app/controllers/admin/export_domain_allows_controller.rb
@@ -4,7 +4,7 @@ require 'csv'
 
 module Admin
   class ExportDomainAllowsController < BaseController
-    include AdminExportControllerConcern
+    include Admin::ExportControllerConcern
 
     before_action :set_dummy_import!, only: [:new]
 

--- a/app/controllers/admin/export_domain_blocks_controller.rb
+++ b/app/controllers/admin/export_domain_blocks_controller.rb
@@ -4,7 +4,7 @@ require 'csv'
 
 module Admin
   class ExportDomainBlocksController < BaseController
-    include AdminExportControllerConcern
+    include Admin::ExportControllerConcern
 
     before_action :set_dummy_import!, only: [:new]
 

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -5,7 +5,7 @@ class Api::BaseController < ApplicationController
   DEFAULT_ACCOUNTS_LIMIT = 40
 
   include RateLimitHeaders
-  include AccessTokenTrackingConcern
+  include Api::AccessTokenTrackingConcern
   include Api::CachingConcern
   include Api::ContentSecurityPolicy
 

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -4,7 +4,7 @@ class Api::BaseController < ApplicationController
   DEFAULT_STATUSES_LIMIT = 20
   DEFAULT_ACCOUNTS_LIMIT = 40
 
-  include RateLimitHeaders
+  include Api::RateLimitHeaders
   include Api::AccessTokenTrackingConcern
   include Api::CachingConcern
   include Api::ContentSecurityPolicy

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -6,7 +6,7 @@ class Api::BaseController < ApplicationController
 
   include RateLimitHeaders
   include AccessTokenTrackingConcern
-  include ApiCachingConcern
+  include Api::CachingConcern
   include Api::ContentSecurityPolicy
 
   skip_before_action :require_functional!, unless: :limited_federation_mode?

--- a/app/controllers/auth/confirmations_controller.rb
+++ b/app/controllers/auth/confirmations_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Auth::ConfirmationsController < Devise::ConfirmationsController
-  include CaptchaConcern
+  include Auth::CaptchaConcern
 
   layout 'auth'
 

--- a/app/controllers/auth/registrations_controller.rb
+++ b/app/controllers/auth/registrations_controller.rb
@@ -2,7 +2,7 @@
 
 class Auth::RegistrationsController < Devise::RegistrationsController
   include RegistrationHelper
-  include RegistrationSpamConcern
+  include Auth::RegistrationSpamConcern
 
   layout :determine_layout
 

--- a/app/controllers/auth/sessions_controller.rb
+++ b/app/controllers/auth/sessions_controller.rb
@@ -10,7 +10,7 @@ class Auth::SessionsController < Devise::SessionsController
 
   prepend_before_action :check_suspicious!, only: [:create]
 
-  include TwoFactorAuthenticationConcern
+  include Auth::TwoFactorAuthenticationConcern
 
   before_action :set_body_classes
 

--- a/app/controllers/concerns/admin/export_controller_concern.rb
+++ b/app/controllers/concerns/admin/export_controller_concern.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module AdminExportControllerConcern
+module Admin::ExportControllerConcern
   extend ActiveSupport::Concern
 
   private

--- a/app/controllers/concerns/api/access_token_tracking_concern.rb
+++ b/app/controllers/concerns/api/access_token_tracking_concern.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module AccessTokenTrackingConcern
+module Api::AccessTokenTrackingConcern
   extend ActiveSupport::Concern
 
   ACCESS_TOKEN_UPDATE_FREQUENCY = 24.hours.freeze

--- a/app/controllers/concerns/api/caching_concern.rb
+++ b/app/controllers/concerns/api/caching_concern.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module ApiCachingConcern
+module Api::CachingConcern
   extend ActiveSupport::Concern
 
   def cache_if_unauthenticated!

--- a/app/controllers/concerns/api/rate_limit_headers.rb
+++ b/app/controllers/concerns/api/rate_limit_headers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module RateLimitHeaders
+module Api::RateLimitHeaders
   extend ActiveSupport::Concern
 
   class_methods do

--- a/app/controllers/concerns/auth/captcha_concern.rb
+++ b/app/controllers/concerns/auth/captcha_concern.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module CaptchaConcern
+module Auth::CaptchaConcern
   extend ActiveSupport::Concern
 
   include Hcaptcha::Adapters::ViewMethods

--- a/app/controllers/concerns/auth/registration_spam_concern.rb
+++ b/app/controllers/concerns/auth/registration_spam_concern.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module RegistrationSpamConcern
+module Auth::RegistrationSpamConcern
   extend ActiveSupport::Concern
 
   def set_registration_form_time

--- a/app/controllers/concerns/auth/two_factor_authentication_concern.rb
+++ b/app/controllers/concerns/auth/two_factor_authentication_concern.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module TwoFactorAuthenticationConcern
+module Auth::TwoFactorAuthenticationConcern
   extend ActiveSupport::Concern
 
   included do

--- a/app/controllers/concerns/settings/export_controller_concern.rb
+++ b/app/controllers/concerns/settings/export_controller_concern.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module ExportControllerConcern
+module Settings::ExportControllerConcern
   extend ActiveSupport::Concern
 
   included do

--- a/app/controllers/settings/exports/blocked_accounts_controller.rb
+++ b/app/controllers/settings/exports/blocked_accounts_controller.rb
@@ -3,7 +3,7 @@
 module Settings
   module Exports
     class BlockedAccountsController < BaseController
-      include ExportControllerConcern
+      include Settings::ExportControllerConcern
 
       def index
         send_export_file

--- a/app/controllers/settings/exports/blocked_domains_controller.rb
+++ b/app/controllers/settings/exports/blocked_domains_controller.rb
@@ -3,7 +3,7 @@
 module Settings
   module Exports
     class BlockedDomainsController < BaseController
-      include ExportControllerConcern
+      include Settings::ExportControllerConcern
 
       def index
         send_export_file

--- a/app/controllers/settings/exports/bookmarks_controller.rb
+++ b/app/controllers/settings/exports/bookmarks_controller.rb
@@ -3,7 +3,7 @@
 module Settings
   module Exports
     class BookmarksController < BaseController
-      include ExportControllerConcern
+      include Settings::ExportControllerConcern
 
       def index
         send_export_file

--- a/app/controllers/settings/exports/following_accounts_controller.rb
+++ b/app/controllers/settings/exports/following_accounts_controller.rb
@@ -3,7 +3,7 @@
 module Settings
   module Exports
     class FollowingAccountsController < BaseController
-      include ExportControllerConcern
+      include Settings::ExportControllerConcern
 
       def index
         send_export_file

--- a/app/controllers/settings/exports/lists_controller.rb
+++ b/app/controllers/settings/exports/lists_controller.rb
@@ -3,7 +3,7 @@
 module Settings
   module Exports
     class ListsController < BaseController
-      include ExportControllerConcern
+      include Settings::ExportControllerConcern
 
       def index
         send_export_file

--- a/app/controllers/settings/exports/muted_accounts_controller.rb
+++ b/app/controllers/settings/exports/muted_accounts_controller.rb
@@ -3,7 +3,7 @@
 module Settings
   module Exports
     class MutedAccountsController < BaseController
-      include ExportControllerConcern
+      include Settings::ExportControllerConcern
 
       def index
         send_export_file

--- a/spec/controllers/concerns/api/rate_limit_headers_spec.rb
+++ b/spec/controllers/concerns/api/rate_limit_headers_spec.rb
@@ -2,9 +2,9 @@
 
 require 'rails_helper'
 
-describe RateLimitHeaders do
+describe Api::RateLimitHeaders do
   controller(ApplicationController) do
-    include RateLimitHeaders
+    include Api::RateLimitHeaders
 
     def show
       head 200

--- a/spec/controllers/concerns/settings/export_controller_concern_spec.rb
+++ b/spec/controllers/concerns/settings/export_controller_concern_spec.rb
@@ -2,9 +2,9 @@
 
 require 'rails_helper'
 
-describe ExportControllerConcern do
+describe Settings::ExportControllerConcern do
   controller(ApplicationController) do
-    include ExportControllerConcern
+    include Settings::ExportControllerConcern
 
     def index
       send_export_file


### PR DESCRIPTION
I noticed a few of the controller concerns were only used in the API area, and was going to move them into an `Api::` namespace. Once I started that I noticed a similar dynamic with some `Settings::` and `Auth::` and `Admin::` concerns as well.

This is just a file/module move to stop `concerns` from becoming junk drawer; should not be behavior change.

There may be room for similar org/cleanup in the models concerns, since many of those are only used in one spot. Will do that next if we like this.