### PR TITLE
Improve spec coverage for `api/web/push_subscriptions` controller

### DIFF
--- a/app/controllers/api/web/push_subscriptions_controller.rb
+++ b/app/controllers/api/web/push_subscriptions_controller.rb
@@ -20,7 +20,7 @@ class Api::Web::PushSubscriptionsController < Api::Web::BaseController
   private
 
   def active_session
-    @active_session || current_session
+    @active_session ||= current_session
   end
 
   def destroy_previous_subscriptions

--- a/app/controllers/api/web/push_subscriptions_controller.rb
+++ b/app/controllers/api/web/push_subscriptions_controller.rb
@@ -6,10 +6,7 @@ class Api::Web::PushSubscriptionsController < Api::Web::BaseController
   before_action :destroy_previous_subscriptions, only: :create, if: :prior_subscriptions?
 
   def create
-    data = {
-      policy: 'all',
-      alerts: Notification::TYPES.index_with { alerts_enabled },
-    }
+    data = default_subscription_data
 
     data.deep_merge!(data_params) if params[:data]
 
@@ -45,6 +42,13 @@ class Api::Web::PushSubscriptionsController < Api::Web::BaseController
 
   def prior_subscriptions?
     active_session.web_push_subscription.present?
+  end
+
+  def default_subscription_data
+    {
+      policy: 'all',
+      alerts: Notification::TYPES.index_with { alerts_enabled },
+    }
   end
 
   def alerts_enabled

--- a/app/controllers/api/web/push_subscriptions_controller.rb
+++ b/app/controllers/api/web/push_subscriptions_controller.rb
@@ -7,14 +7,7 @@ class Api::Web::PushSubscriptionsController < Api::Web::BaseController
   after_action :update_session_with_subscription, only: :create
 
   def create
-    @push_subscription = ::Web::PushSubscription.create!(
-      endpoint: subscription_params[:endpoint],
-      key_p256dh: subscription_params[:keys][:p256dh],
-      key_auth: subscription_params[:keys][:auth],
-      data: subscription_data,
-      user_id: active_session.user_id,
-      access_token_id: active_session.access_token_id
-    )
+    @push_subscription = ::Web::PushSubscription.create!(web_push_subscription_params)
 
     render json: @push_subscription, serializer: REST::WebPushSubscriptionSerializer
   end
@@ -67,6 +60,17 @@ class Api::Web::PushSubscriptionsController < Api::Web::BaseController
 
   def subscription_params
     @subscription_params ||= params.require(:subscription).permit(:endpoint, keys: [:auth, :p256dh])
+  end
+
+  def web_push_subscription_params
+    {
+      access_token_id: active_session.access_token_id,
+      data: subscription_data,
+      endpoint: subscription_params[:endpoint],
+      key_auth: subscription_params[:keys][:auth],
+      key_p256dh: subscription_params[:keys][:p256dh],
+      user_id: active_session.user_id,
+    }
   end
 
   def data_params

--- a/app/controllers/api/web/push_subscriptions_controller.rb
+++ b/app/controllers/api/web/push_subscriptions_controller.rb
@@ -3,13 +3,9 @@
 class Api::Web::PushSubscriptionsController < Api::Web::BaseController
   before_action :require_user!
   before_action :set_push_subscription, only: :update
+  before_action :destroy_previous_subscriptions, only: :create, if: :prior_subscriptions?
 
   def create
-    unless active_session.web_push_subscription.nil?
-      active_session.web_push_subscription.destroy!
-      active_session.update!(web_push_subscription: nil)
-    end
-
     # Mobile devices do not support regular notifications, so we enable push notifications by default
     alerts_enabled = active_session.detection.device.mobile? || active_session.detection.device.tablet?
 
@@ -43,6 +39,15 @@ class Api::Web::PushSubscriptionsController < Api::Web::BaseController
 
   def active_session
     @active_session || current_session
+  end
+
+  def destroy_previous_subscriptions
+    active_session.web_push_subscription.destroy!
+    active_session.update!(web_push_subscription: nil)
+  end
+
+  def prior_subscriptions?
+    active_session.web_push_subscription.present?
   end
 
   def set_push_subscription

--- a/app/controllers/api/web/push_subscriptions_controller.rb
+++ b/app/controllers/api/web/push_subscriptions_controller.rb
@@ -5,8 +5,6 @@ class Api::Web::PushSubscriptionsController < Api::Web::BaseController
   before_action :set_push_subscription, only: :update
 
   def create
-    active_session = current_session
-
     unless active_session.web_push_subscription.nil?
       active_session.web_push_subscription.destroy!
       active_session.update!(web_push_subscription: nil)
@@ -42,6 +40,10 @@ class Api::Web::PushSubscriptionsController < Api::Web::BaseController
   end
 
   private
+
+  def active_session
+    @active_session || current_session
+  end
 
   def set_push_subscription
     @push_subscription = ::Web::PushSubscription.find(params[:id])

--- a/app/controllers/api/web/push_subscriptions_controller.rb
+++ b/app/controllers/api/web/push_subscriptions_controller.rb
@@ -6,9 +6,6 @@ class Api::Web::PushSubscriptionsController < Api::Web::BaseController
   before_action :destroy_previous_subscriptions, only: :create, if: :prior_subscriptions?
 
   def create
-    # Mobile devices do not support regular notifications, so we enable push notifications by default
-    alerts_enabled = active_session.detection.device.mobile? || active_session.detection.device.tablet?
-
     data = {
       policy: 'all',
       alerts: Notification::TYPES.index_with { alerts_enabled },
@@ -48,6 +45,11 @@ class Api::Web::PushSubscriptionsController < Api::Web::BaseController
 
   def prior_subscriptions?
     active_session.web_push_subscription.present?
+  end
+
+  def alerts_enabled
+    # Mobile devices do not support regular notifications, so we enable push notifications by default
+    active_session.detection.device.mobile? || active_session.detection.device.tablet?
   end
 
   def set_push_subscription

--- a/app/controllers/api/web/push_subscriptions_controller.rb
+++ b/app/controllers/api/web/push_subscriptions_controller.rb
@@ -6,15 +6,11 @@ class Api::Web::PushSubscriptionsController < Api::Web::BaseController
   before_action :destroy_previous_subscriptions, only: :create, if: :prior_subscriptions?
 
   def create
-    data = default_subscription_data
-
-    data.deep_merge!(data_params) if params[:data]
-
     push_subscription = ::Web::PushSubscription.create!(
       endpoint: subscription_params[:endpoint],
       key_p256dh: subscription_params[:keys][:p256dh],
       key_auth: subscription_params[:keys][:auth],
-      data: data,
+      data: subscription_data,
       user_id: active_session.user_id,
       access_token_id: active_session.access_token_id
     )
@@ -42,6 +38,12 @@ class Api::Web::PushSubscriptionsController < Api::Web::BaseController
 
   def prior_subscriptions?
     active_session.web_push_subscription.present?
+  end
+
+  def subscription_data
+    default_subscription_data.tap do |data|
+      data.deep_merge!(data_params) if params[:data]
+    end
   end
 
   def default_subscription_data

--- a/spec/controllers/api/web/push_subscriptions_controller_spec.rb
+++ b/spec/controllers/api/web/push_subscriptions_controller_spec.rb
@@ -47,6 +47,8 @@ describe Api::Web::PushSubscriptionsController do
     it 'saves push subscriptions' do
       post :create, format: :json, params: create_payload
 
+      expect(response).to have_http_status(200)
+
       user.reload
 
       push_subscription = Web::PushSubscription.find_by(endpoint: create_payload[:subscription][:endpoint])
@@ -59,6 +61,8 @@ describe Api::Web::PushSubscriptionsController do
     context 'with initial data' do
       it 'saves alert settings' do
         post :create, format: :json, params: create_payload.merge(alerts_payload)
+
+        expect(response).to have_http_status(200)
 
         push_subscription = Web::PushSubscription.find_by(endpoint: create_payload[:subscription][:endpoint])
 
@@ -74,6 +78,8 @@ describe Api::Web::PushSubscriptionsController do
   describe 'PUT #update' do
     it 'changes alert settings' do
       post :create, format: :json, params: create_payload
+
+      expect(response).to have_http_status(200)
 
       alerts_payload[:id] = Web::PushSubscription.find_by(endpoint: create_payload[:subscription][:endpoint]).id
 

--- a/spec/controllers/api/web/push_subscriptions_controller_spec.rb
+++ b/spec/controllers/api/web/push_subscriptions_controller_spec.rb
@@ -58,6 +58,17 @@ describe Api::Web::PushSubscriptionsController do
       )
     end
 
+    context 'with a user who has a session with a prior subscription' do
+      let!(:prior_subscription) { Fabricate(:web_push_subscription, session_activation: user.session_activations.last) }
+
+      it 'destroys prior subscription when creating new one' do
+        post :create, format: :json, params: create_payload
+
+        expect(response).to have_http_status(200)
+        expect { prior_subscription.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
     context 'with initial data' do
       it 'saves alert settings' do
         post :create, format: :json, params: create_payload.merge(alerts_payload)

--- a/spec/controllers/api/web/push_subscriptions_controller_spec.rb
+++ b/spec/controllers/api/web/push_subscriptions_controller_spec.rb
@@ -37,12 +37,14 @@ describe Api::Web::PushSubscriptionsController do
     }
   end
 
+  before do
+    sign_in(user)
+
+    stub_request(:post, create_payload[:subscription][:endpoint]).to_return(status: 200)
+  end
+
   describe 'POST #create' do
     it 'saves push subscriptions' do
-      sign_in(user)
-
-      stub_request(:post, create_payload[:subscription][:endpoint]).to_return(status: 200)
-
       post :create, format: :json, params: create_payload
 
       user.reload
@@ -56,10 +58,6 @@ describe Api::Web::PushSubscriptionsController do
 
     context 'with initial data' do
       it 'saves alert settings' do
-        sign_in(user)
-
-        stub_request(:post, create_payload[:subscription][:endpoint]).to_return(status: 200)
-
         post :create, format: :json, params: create_payload.merge(alerts_payload)
 
         push_subscription = Web::PushSubscription.find_by(endpoint: create_payload[:subscription][:endpoint])
@@ -75,10 +73,6 @@ describe Api::Web::PushSubscriptionsController do
 
   describe 'PUT #update' do
     it 'changes alert settings' do
-      sign_in(user)
-
-      stub_request(:post, create_payload[:subscription][:endpoint]).to_return(status: 200)
-
       post :create, format: :json, params: create_payload
 
       alerts_payload[:id] = Web::PushSubscription.find_by(endpoint: create_payload[:subscription][:endpoint]).id

--- a/spec/controllers/api/web/push_subscriptions_controller_spec.rb
+++ b/spec/controllers/api/web/push_subscriptions_controller_spec.rb
@@ -56,6 +56,7 @@ describe Api::Web::PushSubscriptionsController do
         key_p256dh: eq(create_payload[:subscription][:keys][:p256dh]),
         key_auth: eq(create_payload[:subscription][:keys][:auth])
       )
+      expect(user.session_activations.first.web_push_subscription).to eq(created_push_subscription)
     end
 
     context 'with a user who has a session with a prior subscription' do

--- a/spec/controllers/api/web/push_subscriptions_controller_spec.rb
+++ b/spec/controllers/api/web/push_subscriptions_controller_spec.rb
@@ -51,7 +51,7 @@ describe Api::Web::PushSubscriptionsController do
 
       user.reload
 
-      push_subscription = Web::PushSubscription.find_by(endpoint: create_payload[:subscription][:endpoint])
+      push_subscription = created_push_subscription
 
       expect(push_subscription['endpoint']).to eq(create_payload[:subscription][:endpoint])
       expect(push_subscription['key_p256dh']).to eq(create_payload[:subscription][:keys][:p256dh])
@@ -64,7 +64,7 @@ describe Api::Web::PushSubscriptionsController do
 
         expect(response).to have_http_status(200)
 
-        push_subscription = Web::PushSubscription.find_by(endpoint: create_payload[:subscription][:endpoint])
+        push_subscription = created_push_subscription
 
         expect(push_subscription.data['policy']).to eq 'all'
 
@@ -81,11 +81,11 @@ describe Api::Web::PushSubscriptionsController do
 
       expect(response).to have_http_status(200)
 
-      alerts_payload[:id] = Web::PushSubscription.find_by(endpoint: create_payload[:subscription][:endpoint]).id
+      alerts_payload[:id] = created_push_subscription.id
 
       put :update, format: :json, params: alerts_payload
 
-      push_subscription = Web::PushSubscription.find_by(endpoint: create_payload[:subscription][:endpoint])
+      push_subscription = created_push_subscription
 
       expect(push_subscription.data['policy']).to eq 'all'
 
@@ -93,5 +93,9 @@ describe Api::Web::PushSubscriptionsController do
         expect(push_subscription.data['alerts'][type]).to eq(alerts_payload[:data][:alerts][type.to_sym].to_s)
       end
     end
+  end
+
+  def created_push_subscription
+    Web::PushSubscription.find_by(endpoint: create_payload[:subscription][:endpoint])
   end
 end

--- a/spec/controllers/api/web/push_subscriptions_controller_spec.rb
+++ b/spec/controllers/api/web/push_subscriptions_controller_spec.rb
@@ -51,11 +51,11 @@ describe Api::Web::PushSubscriptionsController do
 
       user.reload
 
-      push_subscription = created_push_subscription
-
-      expect(push_subscription['endpoint']).to eq(create_payload[:subscription][:endpoint])
-      expect(push_subscription['key_p256dh']).to eq(create_payload[:subscription][:keys][:p256dh])
-      expect(push_subscription['key_auth']).to eq(create_payload[:subscription][:keys][:auth])
+      expect(created_push_subscription).to have_attributes(
+        endpoint: eq(create_payload[:subscription][:endpoint]),
+        key_p256dh: eq(create_payload[:subscription][:keys][:p256dh]),
+        key_auth: eq(create_payload[:subscription][:keys][:auth])
+      )
     end
 
     context 'with initial data' do
@@ -64,12 +64,10 @@ describe Api::Web::PushSubscriptionsController do
 
         expect(response).to have_http_status(200)
 
-        push_subscription = created_push_subscription
-
-        expect(push_subscription.data['policy']).to eq 'all'
+        expect(created_push_subscription.data['policy']).to eq 'all'
 
         %w(follow follow_request favourite reblog mention poll status).each do |type|
-          expect(push_subscription.data['alerts'][type]).to eq(alerts_payload[:data][:alerts][type.to_sym].to_s)
+          expect(created_push_subscription.data['alerts'][type]).to eq(alerts_payload[:data][:alerts][type.to_sym].to_s)
         end
       end
     end
@@ -85,12 +83,10 @@ describe Api::Web::PushSubscriptionsController do
 
       put :update, format: :json, params: alerts_payload
 
-      push_subscription = created_push_subscription
-
-      expect(push_subscription.data['policy']).to eq 'all'
+      expect(created_push_subscription.data['policy']).to eq 'all'
 
       %w(follow follow_request favourite reblog mention poll status).each do |type|
-        expect(push_subscription.data['alerts'][type]).to eq(alerts_payload[:data][:alerts][type.to_sym].to_s)
+        expect(created_push_subscription.data['alerts'][type]).to eq(alerts_payload[:data][:alerts][type.to_sym].to_s)
       end
     end
   end


### PR DESCRIPTION
The spec coverage was missing checks for the "prior subscription" path and around whether the session activation was correctly updated. Add coverage for those, and then refactored both the spec and the controller class a bit.