### PR TITLE
Use `Lcov` simplecov formatter on CI and `HTML` elsewhere

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,9 +2,14 @@
 
 if ENV['DISABLE_SIMPLECOV'] != 'true'
   require 'simplecov'
-  require 'simplecov-lcov'
-  SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true
-  SimpleCov.formatter = SimpleCov::Formatter::LcovFormatter
+
+  if ENV['CI']
+    require 'simplecov-lcov'
+    SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true
+    SimpleCov.formatter = SimpleCov::Formatter::LcovFormatter
+  else
+    SimpleCov.formatter = SimpleCov::Formatter::HTMLFormatter
+  end
   SimpleCov.start 'rails' do
     enable_coverage :branch
     enable_coverage_for_eval


### PR DESCRIPTION
One side effect of https://github.com/mastodon/mastodon/pull/23868 is to turn off the default formatter (HTML) when simplecov runs. This updates the config to preserve the changes from that PR and use the `Lcov` formatter on CI, while restoring the previous local behavior of using the `HTMLFormatter` locally.

If for whatever reasons it's useful to run the `Lcov` one locally as well, we can enable multiple formatters.

I think this is the right way to do this but will watch CI output as well.