### PR TITLE
Improve codecov config

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,13 @@
+coverage:
+  status:
+    project:
+      default:
+        # Github status check is not blocking
+        informational: true
+    patch:
+      default:
+        # Github status check is not blocking
+        informational: true
+comment:
+  # Only write a comment in PR if there are changes
+  require_changes: true


### PR DESCRIPTION
We do not want the status checks to be blocking the PR at the moment, as we probably need to see how they go over some time before making them mandatory.

The Codecov comment should also only be written when it matters. Maybe we want to disable it entirely instead for now?