### PR TITLE
Disable simplecov `enable_coverage_for_eval` option, move to standalone file

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 if ENV['CI']
   require 'simplecov-lcov'
   SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true

--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,20 @@
+if ENV['CI']
+  require 'simplecov-lcov'
+  SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true
+  SimpleCov.formatter = SimpleCov::Formatter::LcovFormatter
+else
+  SimpleCov.formatter = SimpleCov::Formatter::HTMLFormatter
+end
+
+SimpleCov.start 'rails' do
+  enable_coverage :branch
+
+  add_filter 'lib/linter'
+
+  add_group 'Libraries', 'lib'
+  add_group 'Policies', 'app/policies'
+  add_group 'Presenters', 'app/presenters'
+  add_group 'Serializers', 'app/serializers'
+  add_group 'Services', 'app/services'
+  add_group 'Validators', 'app/validators'
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,18 +10,18 @@ if ENV['DISABLE_SIMPLECOV'] != 'true'
   else
     SimpleCov.formatter = SimpleCov::Formatter::HTMLFormatter
   end
+
   SimpleCov.start 'rails' do
     enable_coverage :branch
-    enable_coverage_for_eval
 
     add_filter 'lib/linter'
+
+    add_group 'Libraries', 'lib'
     add_group 'Policies', 'app/policies'
     add_group 'Presenters', 'app/presenters'
     add_group 'Serializers', 'app/serializers'
     add_group 'Services', 'app/services'
     add_group 'Validators', 'app/validators'
-
-    add_group 'Libraries', 'lib'
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,28 +1,7 @@
 # frozen_string_literal: true
 
-if ENV['DISABLE_SIMPLECOV'] != 'true'
-  require 'simplecov'
-
-  if ENV['CI']
-    require 'simplecov-lcov'
-    SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true
-    SimpleCov.formatter = SimpleCov::Formatter::LcovFormatter
-  else
-    SimpleCov.formatter = SimpleCov::Formatter::HTMLFormatter
-  end
-
-  SimpleCov.start 'rails' do
-    enable_coverage :branch
-
-    add_filter 'lib/linter'
-
-    add_group 'Libraries', 'lib'
-    add_group 'Policies', 'app/policies'
-    add_group 'Presenters', 'app/presenters'
-    add_group 'Serializers', 'app/serializers'
-    add_group 'Services', 'app/services'
-    add_group 'Validators', 'app/validators'
-  end
+unless ENV['DISABLE_SIMPLECOV'] == 'true'
+  require 'simplecov' # Configuration details loaded from .simplecov
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
Two changes here:

- Move the simplecov config (which is getting large!) to a standalone file. The load order here stays the same - it's just reading from this file instead of the previous block right under the require.
- Remove the recently enabled `enable_coverage_for_eval` option for two reasons -- 1), there's a known issue with some haml/erb/etc files where you get warnings emitted that you can't actually do anything to silence or fix - https://github.com/simplecov-ruby/simplecov/issues/1057; 2) I suspect that we changed too many things at once when turning on codecov, and would prefer to give that a couple weeks of integration first to get it tuned correctly in our workflow before enabling this feature (which is potentially very useful, if we can fix those issues!)