### PR TITLE
Add API to get multiple accounts and statuses

### DIFF
--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -22,7 +22,7 @@ class Api::V1::AccountsController < Api::BaseController
   override_rate_limit_headers :follow, family: :follows
 
   def index
-    render json: @accounts.map { |account| ActiveModelSerializers::SerializableResource.new(account, serializer: REST::AccountSerializer, scope: current_user, scope_name: :current_user).as_json }.index_by { |account| account[:id] }
+    render json: @accounts, each_serializer: REST::AccountSerializer
   end
 
   def show

--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -22,7 +22,7 @@ class Api::V1::AccountsController < Api::BaseController
   override_rate_limit_headers :follow, family: :follows
 
   def index
-    render json: @accounts, each_serializer: REST::AccountSerializer
+    render json: @accounts.map { |account| ActiveModelSerializers::SerializableResource.new(account, serializer: REST::AccountSerializer, scope: current_user, scope_name: :current_user).as_json }.index_by { |account| account[:id] }
   end
 
   def show

--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -9,15 +9,20 @@ class Api::V1::AccountsController < Api::BaseController
   before_action -> { doorkeeper_authorize! :follow, :write, :'write:blocks' }, only: [:block, :unblock]
   before_action -> { doorkeeper_authorize! :write, :'write:accounts' }, only: [:create]
 
-  before_action :require_user!, except: [:show, :create]
-  before_action :set_account, except: [:create]
-  before_action :check_account_approval, except: [:create]
-  before_action :check_account_confirmation, except: [:create]
+  before_action :require_user!, except: [:index, :show, :create]
+  before_action :set_account, except: [:index, :create]
+  before_action :set_accounts, only: [:index]
+  before_action :check_account_approval, except: [:index, :create]
+  before_action :check_account_confirmation, except: [:index, :create]
   before_action :check_enabled_registrations, only: [:create]
 
   skip_before_action :require_authenticated_user!, only: :create
 
   override_rate_limit_headers :follow, family: :follows
+
+  def index
+    render json: @accounts, each_serializer: REST::AccountSerializer
+  end
 
   def show
     cache_if_unauthenticated!
@@ -79,6 +84,10 @@ class Api::V1::AccountsController < Api::BaseController
     @account = Account.find(params[:id])
   end
 
+  def set_accounts
+    @accounts = Account.where(id: account_ids).without_unapproved
+  end
+
   def check_account_approval
     raise(ActiveRecord::RecordNotFound) if @account.local? && @account.user_pending?
   end
@@ -89,6 +98,14 @@ class Api::V1::AccountsController < Api::BaseController
 
   def relationships(**options)
     AccountRelationshipsPresenter.new([@account], current_user.account_id, **options)
+  end
+
+  def account_ids
+    Array(accounts_params[:ids]).uniq.map(&:to_i)
+  end
+
+  def accounts_params
+    params.permit(ids: [])
   end
 
   def account_params

--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -15,6 +15,7 @@ class Api::V1::AccountsController < Api::BaseController
   before_action :check_account_approval, except: [:index, :create]
   before_action :check_account_confirmation, except: [:index, :create]
   before_action :check_enabled_registrations, only: [:create]
+  before_action :check_accounts_limit, only: [:index]
 
   skip_before_action :require_authenticated_user!, only: :create
 
@@ -94,6 +95,10 @@ class Api::V1::AccountsController < Api::BaseController
 
   def check_account_confirmation
     raise(ActiveRecord::RecordNotFound) if @account.local? && !@account.user_confirmed?
+  end
+
+  def check_accounts_limit
+    raise(Mastodon::ValidationError) if account_ids.size > DEFAULT_ACCOUNTS_LIMIT
   end
 
   def relationships(**options)

--- a/app/controllers/api/v1/statuses_controller.rb
+++ b/app/controllers/api/v1/statuses_controller.rb
@@ -27,7 +27,7 @@ class Api::V1::StatusesController < Api::BaseController
 
   def index
     @statuses = cache_collection(@statuses, Status)
-    render json: @statuses.map { |status| ActiveModelSerializers::SerializableResource.new(status, serializer: REST::StatusSerializer, scope: current_user, scope_name: :current_user).as_json }.index_by { |status| status[:id] }
+    render json: @statuses, each_serializer: REST::StatusSerializer
   end
 
   def show

--- a/app/controllers/api/v1/statuses_controller.rb
+++ b/app/controllers/api/v1/statuses_controller.rb
@@ -27,7 +27,7 @@ class Api::V1::StatusesController < Api::BaseController
 
   def index
     @statuses = cache_collection(@statuses, Status)
-    render json: @statuses, each_serializer: REST::StatusSerializer
+    render json: @statuses.map { |status| ActiveModelSerializers::SerializableResource.new(status, serializer: REST::StatusSerializer, scope: current_user, scope_name: :current_user).as_json }.index_by { |status| status[:id] }
   end
 
   def show

--- a/app/controllers/api/v1/statuses_controller.rb
+++ b/app/controllers/api/v1/statuses_controller.rb
@@ -5,7 +5,8 @@ class Api::V1::StatusesController < Api::BaseController
 
   before_action -> { authorize_if_got_token! :read, :'read:statuses' }, except: [:create, :update, :destroy]
   before_action -> { doorkeeper_authorize! :write, :'write:statuses' }, only:   [:create, :update, :destroy]
-  before_action :require_user!, except:  [:show, :context]
+  before_action :require_user!, except:  [:index, :show, :context]
+  before_action :set_statuses, only:     [:index]
   before_action :set_status, only:       [:show, :context]
   before_action :set_thread, only:       [:create]
 
@@ -22,6 +23,11 @@ class Api::V1::StatusesController < Api::BaseController
   ANCESTORS_LIMIT         = 40
   DESCENDANTS_LIMIT       = 60
   DESCENDANTS_DEPTH_LIMIT = 20
+
+  def index
+    @statuses = cache_collection(@statuses, Status)
+    render json: @statuses, each_serializer: REST::StatusSerializer
+  end
 
   def show
     cache_if_unauthenticated!
@@ -111,6 +117,10 @@ class Api::V1::StatusesController < Api::BaseController
 
   private
 
+  def set_statuses
+    @statuses = Status.permitted_statuses_from_ids(status_ids, current_account)
+  end
+
   def set_status
     @status = Status.find(params[:id])
     authorize @status, :show?
@@ -123,6 +133,14 @@ class Api::V1::StatusesController < Api::BaseController
     authorize(@thread, :show?) if @thread.present?
   rescue ActiveRecord::RecordNotFound, Mastodon::NotPermittedError
     render json: { error: I18n.t('statuses.errors.in_reply_not_found') }, status: 404
+  end
+
+  def status_ids
+    Array(statuses_params[:ids]).uniq.map(&:to_i)
+  end
+
+  def statuses_params
+    params.permit(ids: [])
   end
 
   def status_params

--- a/app/controllers/api/v1/statuses_controller.rb
+++ b/app/controllers/api/v1/statuses_controller.rb
@@ -5,10 +5,11 @@ class Api::V1::StatusesController < Api::BaseController
 
   before_action -> { authorize_if_got_token! :read, :'read:statuses' }, except: [:create, :update, :destroy]
   before_action -> { doorkeeper_authorize! :write, :'write:statuses' }, only:   [:create, :update, :destroy]
-  before_action :require_user!, except:  [:index, :show, :context]
-  before_action :set_statuses, only:     [:index]
-  before_action :set_status, only:       [:show, :context]
-  before_action :set_thread, only:       [:create]
+  before_action :require_user!, except:      [:index, :show, :context]
+  before_action :set_statuses, only:         [:index]
+  before_action :set_status, only:           [:show, :context]
+  before_action :set_thread, only:           [:create]
+  before_action :check_statuses_limit, only: [:index]
 
   override_rate_limit_headers :create, family: :statuses
   override_rate_limit_headers :update, family: :statuses
@@ -133,6 +134,10 @@ class Api::V1::StatusesController < Api::BaseController
     authorize(@thread, :show?) if @thread.present?
   rescue ActiveRecord::RecordNotFound, Mastodon::NotPermittedError
     render json: { error: I18n.t('statuses.errors.in_reply_not_found') }, status: 404
+  end
+
+  def check_statuses_limit
+    raise(Mastodon::ValidationError) if status_ids.size > DEFAULT_STATUSES_LIMIT
   end
 
   def status_ids

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -6,7 +6,7 @@ namespace :api, format: false do
 
   # JSON / REST API
   namespace :v1 do
-    resources :statuses, only: [:create, :show, :update, :destroy] do
+    resources :statuses, only: [:index, :create, :show, :update, :destroy] do
       scope module: :statuses do
         resources :reblogged_by, controller: :reblogged_by_accounts, only: :index
         resources :favourited_by, controller: :favourited_by_accounts, only: :index
@@ -182,7 +182,7 @@ namespace :api, format: false do
       resources :familiar_followers, only: :index
     end
 
-    resources :accounts, only: [:create, :show] do
+    resources :accounts, only: [:index, :create, :show] do
       scope module: :accounts do
         resources :statuses, only: :index
         resources :followers, only: :index, controller: :follower_accounts

--- a/spec/requests/api/v1/accounts_spec.rb
+++ b/spec/requests/api/v1/accounts_spec.rb
@@ -17,9 +17,9 @@ describe '/api/v1/accounts' do
       get '/api/v1/accounts', headers: headers, params: { ids: [account.id, other_account.id, 123_123] }
 
       expect(response).to have_http_status(200)
-      expect(body_as_json.with_indifferent_access).to include(
-        account.id.to_s.to_s => include(id: account.id.to_s),
-        other_account.id.to_s => include(id: other_account.id.to_s)
+      expect(body_as_json).to contain_exactly(
+        hash_including(id: account.id.to_s),
+        hash_including(id: other_account.id.to_s)
       )
     end
   end

--- a/spec/requests/api/v1/accounts_spec.rb
+++ b/spec/requests/api/v1/accounts_spec.rb
@@ -8,6 +8,22 @@ describe '/api/v1/accounts' do
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
 
+  describe 'GET /api/v1/accounts?ids[]=:id' do
+    let(:account) { Fabricate(:account) }
+    let(:other_account) { Fabricate(:account) }
+    let(:scopes) { 'read:accounts' }
+
+    it 'returns expected response' do
+      get '/api/v1/accounts', headers: headers, params: { ids: [account.id, other_account.id, 123_123] }
+
+      expect(response).to have_http_status(200)
+      expect(body_as_json.with_indifferent_access).to include(
+        account.id.to_s.to_s => include(id: account.id.to_s),
+        other_account.id.to_s => include(id: other_account.id.to_s)
+      )
+    end
+  end
+
   describe 'GET /api/v1/accounts/:id' do
     context 'when logged out' do
       let(:account) { Fabricate(:account) }

--- a/spec/requests/api/v1/statuses_spec.rb
+++ b/spec/requests/api/v1/statuses_spec.rb
@@ -18,9 +18,9 @@ describe '/api/v1/statuses' do
         get '/api/v1/statuses', headers: headers, params: { ids: [status.id, other_status.id, 123_123] }
 
         expect(response).to have_http_status(200)
-        expect(body_as_json.with_indifferent_access).to include(
-          status.id.to_s => include(id: status.id.to_s),
-          other_status.id.to_s => include(id: other_status.id.to_s)
+        expect(body_as_json).to contain_exactly(
+          hash_including(id: status.id.to_s),
+          hash_including(id: other_status.id.to_s)
         )
       end
     end

--- a/spec/requests/api/v1/statuses_spec.rb
+++ b/spec/requests/api/v1/statuses_spec.rb
@@ -9,6 +9,22 @@ describe '/api/v1/statuses' do
     let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, application: client_app, scopes: scopes) }
     let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
 
+    describe 'GET /api/v1/statuses?ids[]=:id' do
+      let(:status) { Fabricate(:status) }
+      let(:other_status) { Fabricate(:status) }
+      let(:scopes) { 'read:statuses' }
+
+      it 'returns expected response' do
+        get '/api/v1/statuses', headers: headers, params: { ids: [status.id, other_status.id, 123_123] }
+
+        expect(response).to have_http_status(200)
+        expect(body_as_json.with_indifferent_access).to include(
+          status.id.to_s => include(id: status.id.to_s),
+          other_status.id.to_s => include(id: other_status.id.to_s)
+        )
+      end
+    end
+
     describe 'GET /api/v1/statuses/:id' do
       subject do
         get "/api/v1/statuses/#{status.id}", headers: headers


### PR DESCRIPTION
Add an API to get accounts and statuses by ID.

Documentation PR: https://github.com/mastodon/documentation/pull/1433

Rebase and update #24199 by @noellabo

```
GET /api/v1/accounts?ids[]=1&ids[]=2
GET /api/v1/statuses?ids[]=1&ids[]=2
```

- The `ids` parameter can request up to DEFAULT_ACCOUNTS_LIMIT (=40) for accounts and DEFAULT_STATUSES_LIMIT (=20) for statuses, and a 422 Mastodon::ValidationError will occur if exceeded.

I have multiple needs.

- We want to update the accounts and statuses we hold to the latest information, including additional information (favorites, boosts, edit history, etc.)
- To save resources, if we only keep the ID and purge other payloads, we want to retrieve it again when needed
- We want to get only what we need from an API response that only returns an ID

___

Fixes MAS-52