### PR TITLE
Reduce expectations for `RSpec/MultipleExpectations` cop in `controllers/statuses` spec

### DIFF
--- a/spec/controllers/statuses_controller_spec.rb
+++ b/spec/controllers/statuses_controller_spec.rb
@@ -57,13 +57,14 @@ describe StatusesController do
         let(:format) { 'html' }
 
         it 'renders status successfully', :aggregate_failures do
-          expect(response).to have_http_status(200)
-          expect(response.headers['Link'].to_s).to include 'activity+json'
+          expect(response)
+            .to have_http_status(200)
+            .and render_template(:show)
           expect(response.headers).to include(
             'Vary' => 'Accept, Accept-Language, Cookie',
-            'Cache-Control' => include('public')
+            'Cache-Control' => include('public'),
+            'Link' => satisfy { |header| header.to_s.include?('activity+json') }
           )
-          expect(response).to render_template(:show)
           expect(response.body).to include status.text
         end
       end
@@ -75,10 +76,10 @@ describe StatusesController do
 
         it 'renders ActivityPub Note object successfully', :aggregate_failures do
           expect(response).to have_http_status(200)
-          expect(response.headers['Link'].to_s).to include 'activity+json'
           expect(response.headers).to include(
             'Vary' => 'Accept, Accept-Language, Cookie',
-            'Content-Type' => include('application/activity+json')
+            'Content-Type' => include('application/activity+json'),
+            'Link' => satisfy { |header| header.to_s.include?('activity+json') }
           )
           expect(body_as_json[:content]).to include status.text
         end
@@ -160,13 +161,14 @@ describe StatusesController do
           let(:format) { 'html' }
 
           it 'renders status successfully', :aggregate_failures do
-            expect(response).to have_http_status(200)
-            expect(response.headers['Link'].to_s).to include 'activity+json'
+            expect(response)
+              .to have_http_status(200)
+              .and render_template(:show)
             expect(response.headers).to include(
               'Vary' => 'Accept, Accept-Language, Cookie',
-              'Cache-Control' => include('private')
+              'Cache-Control' => include('private'),
+              'Link' => satisfy { |header| header.to_s.include?('activity+json') }
             )
-            expect(response).to render_template(:show)
             expect(response.body).to include status.text
           end
         end
@@ -176,11 +178,11 @@ describe StatusesController do
 
           it 'renders ActivityPub Note object successfully', :aggregate_failures do
             expect(response).to have_http_status(200)
-            expect(response.headers['Link'].to_s).to include 'activity+json'
             expect(response.headers).to include(
               'Vary' => 'Accept, Accept-Language, Cookie',
               'Cache-Control' => include('private'),
-              'Content-Type' => include('application/activity+json')
+              'Content-Type' => include('application/activity+json'),
+              'Link' => satisfy { |header| header.to_s.include?('activity+json') }
             )
             expect(body_as_json[:content]).to include status.text
           end
@@ -200,13 +202,15 @@ describe StatusesController do
             let(:format) { 'html' }
 
             it 'renders status successfully', :aggregate_failures do
-              expect(response).to have_http_status(200)
-              expect(response.headers['Link'].to_s).to include 'activity+json'
+              expect(response)
+                .to have_http_status(200)
+                .and render_template(:show)
+
               expect(response.headers).to include(
                 'Vary' => 'Accept, Accept-Language, Cookie',
-                'Cache-Control' => include('private')
+                'Cache-Control' => include('private'),
+                'Link' => satisfy { |header| header.to_s.include?('activity+json') }
               )
-              expect(response).to render_template(:show)
               expect(response.body).to include status.text
             end
           end
@@ -216,11 +220,11 @@ describe StatusesController do
 
             it 'renders ActivityPub Note object successfully', :aggregate_failures do
               expect(response).to have_http_status(200)
-              expect(response.headers['Link'].to_s).to include 'activity+json'
               expect(response.headers).to include(
                 'Vary' => 'Accept, Accept-Language, Cookie',
                 'Cache-Control' => include('private'),
-                'Content-Type' => include('application/activity+json')
+                'Content-Type' => include('application/activity+json'),
+                'Link' => satisfy { |header| header.to_s.include?('activity+json') }
               )
               expect(body_as_json[:content]).to include status.text
             end
@@ -263,13 +267,14 @@ describe StatusesController do
             let(:format) { 'html' }
 
             it 'renders status successfully', :aggregate_failures do
-              expect(response).to have_http_status(200)
-              expect(response.headers['Link'].to_s).to include 'activity+json'
+              expect(response)
+                .to have_http_status(200)
+                .and render_template(:show)
               expect(response.headers).to include(
                 'Vary' => 'Accept, Accept-Language, Cookie',
-                'Cache-Control' => include('private')
+                'Cache-Control' => include('private'),
+                'Link' => satisfy { |header| header.to_s.include?('activity+json') }
               )
-              expect(response).to render_template(:show)
               expect(response.body).to include status.text
             end
           end
@@ -279,11 +284,11 @@ describe StatusesController do
 
             it 'renders ActivityPub Note object successfully' do
               expect(response).to have_http_status(200)
-              expect(response.headers['Link'].to_s).to include 'activity+json'
               expect(response.headers).to include(
                 'Vary' => 'Accept, Accept-Language, Cookie',
                 'Cache-Control' => include('private'),
-                'Content-Type' => include('application/activity+json')
+                'Content-Type' => include('application/activity+json'),
+                'Link' => satisfy { |header| header.to_s.include?('activity+json') }
               )
               expect(body_as_json[:content]).to include status.text
             end
@@ -352,13 +357,14 @@ describe StatusesController do
           let(:format) { 'html' }
 
           it 'renders status successfully', :aggregate_failures do
-            expect(response).to have_http_status(200)
-            expect(response.headers['Link'].to_s).to include 'activity+json'
+            expect(response)
+              .to have_http_status(200)
+              .and render_template(:show)
             expect(response.headers).to include(
               'Vary' => 'Accept, Accept-Language, Cookie',
-              'Cache-Control' => include('private')
+              'Cache-Control' => include('private'),
+              'Link' => satisfy { |header| header.to_s.include?('activity+json') }
             )
-            expect(response).to render_template(:show)
             expect(response.body).to include status.text
           end
         end
@@ -370,10 +376,10 @@ describe StatusesController do
 
           it 'renders ActivityPub Note object successfully', :aggregate_failures do
             expect(response).to have_http_status(200)
-            expect(response.headers['Link'].to_s).to include 'activity+json'
             expect(response.headers).to include(
               'Vary' => 'Accept, Accept-Language, Cookie',
-              'Content-Type' => include('application/activity+json')
+              'Content-Type' => include('application/activity+json'),
+              'Link' => satisfy { |header| header.to_s.include?('activity+json') }
             )
             expect(body_as_json[:content]).to include status.text
           end
@@ -393,13 +399,14 @@ describe StatusesController do
             let(:format) { 'html' }
 
             it 'renders status successfully', :aggregate_failures do
-              expect(response).to have_http_status(200)
-              expect(response.headers['Link'].to_s).to include 'activity+json'
+              expect(response)
+                .to have_http_status(200)
+                .and render_template(:show)
               expect(response.headers).to include(
                 'Vary' => 'Accept, Accept-Language, Cookie',
-                'Cache-Control' => include('private')
+                'Cache-Control' => include('private'),
+                'Link' => satisfy { |header| header.to_s.include?('activity+json') }
               )
-              expect(response).to render_template(:show)
               expect(response.body).to include status.text
             end
           end
@@ -408,13 +415,17 @@ describe StatusesController do
             let(:format) { 'json' }
 
             it 'renders ActivityPub Note object successfully' do
-              expect(response).to have_http_status(200)
-              expect(response.headers['Link'].to_s).to include 'activity+json'
-              expect(response.headers).to include(
-                'Vary' => 'Accept, Accept-Language, Cookie',
-                'Cache-Control' => include('private'),
-                'Content-Type' => include('application/activity+json')
-              )
+              expect(response)
+                .to have_http_status(200)
+                .and have_attributes(
+                  headers: include(
+                    'Vary' => 'Accept, Accept-Language, Cookie',
+                    'Cache-Control' => include('private'),
+                    'Content-Type' => include('application/activity+json'),
+                    'Link' => satisfy { |header| header.to_s.include?('activity+json') }
+                  )
+                )
+
               expect(body_as_json[:content]).to include status.text
             end
           end
@@ -456,13 +467,14 @@ describe StatusesController do
             let(:format) { 'html' }
 
             it 'renders status successfully', :aggregate_failures do
-              expect(response).to have_http_status(200)
-              expect(response.headers['Link'].to_s).to include 'activity+json'
+              expect(response)
+                .to have_http_status(200)
+                .and render_template(:show)
               expect(response.headers).to include(
                 'Vary' => 'Accept, Accept-Language, Cookie',
-                'Cache-Control' => include('private')
+                'Cache-Control' => include('private'),
+                'Link' => satisfy { |header| header.to_s.include?('activity+json') }
               )
-              expect(response).to render_template(:show)
               expect(response.body).to include status.text
             end
           end
@@ -472,11 +484,11 @@ describe StatusesController do
 
             it 'renders ActivityPub Note object', :aggregate_failures do
               expect(response).to have_http_status(200)
-              expect(response.headers['Link'].to_s).to include 'activity+json'
               expect(response.headers).to include(
                 'Vary' => 'Accept, Accept-Language, Cookie',
                 'Cache-Control' => include('private'),
-                'Content-Type' => include('application/activity+json')
+                'Content-Type' => include('application/activity+json'),
+                'Link' => satisfy { |header| header.to_s.include?('activity+json') }
               )
               expect(body_as_json[:content]).to include status.text
             end
@@ -753,13 +765,14 @@ describe StatusesController do
       end
 
       it 'renders status successfully', :aggregate_failures do
-        expect(response).to have_http_status(200)
-        expect(response.headers['Link'].to_s).to include 'activity+json'
+        expect(response)
+          .to have_http_status(200)
+          .and render_template(:embed)
         expect(response.headers).to include(
           'Vary' => 'Accept, Accept-Language, Cookie',
-          'Cache-Control' => include('public')
+          'Cache-Control' => include('public'),
+          'Link' => satisfy { |header| header.to_s.include?('activity+json') }
         )
-        expect(response).to render_template(:embed)
         expect(response.body).to include status.text
       end
     end

--- a/spec/controllers/statuses_controller_spec.rb
+++ b/spec/controllers/statuses_controller_spec.rb
@@ -59,8 +59,10 @@ describe StatusesController do
         it 'renders status successfully', :aggregate_failures do
           expect(response).to have_http_status(200)
           expect(response.headers['Link'].to_s).to include 'activity+json'
-          expect(response.headers['Vary']).to eq 'Accept, Accept-Language, Cookie'
-          expect(response.headers['Cache-Control']).to include 'public'
+          expect(response.headers).to include(
+            'Vary' => 'Accept, Accept-Language, Cookie',
+            'Cache-Control' => include('public')
+          )
           expect(response).to render_template(:show)
           expect(response.body).to include status.text
         end
@@ -74,10 +76,11 @@ describe StatusesController do
         it 'renders ActivityPub Note object successfully', :aggregate_failures do
           expect(response).to have_http_status(200)
           expect(response.headers['Link'].to_s).to include 'activity+json'
-          expect(response.headers['Vary']).to eq 'Accept, Accept-Language, Cookie'
-          expect(response.headers['Content-Type']).to include 'application/activity+json'
-          json = body_as_json
-          expect(json[:content]).to include status.text
+          expect(response.headers).to include(
+            'Vary' => 'Accept, Accept-Language, Cookie',
+            'Content-Type' => include('application/activity+json')
+          )
+          expect(body_as_json[:content]).to include status.text
         end
       end
     end
@@ -159,8 +162,10 @@ describe StatusesController do
           it 'renders status successfully', :aggregate_failures do
             expect(response).to have_http_status(200)
             expect(response.headers['Link'].to_s).to include 'activity+json'
-            expect(response.headers['Vary']).to eq 'Accept, Accept-Language, Cookie'
-            expect(response.headers['Cache-Control']).to include 'private'
+            expect(response.headers).to include(
+              'Vary' => 'Accept, Accept-Language, Cookie',
+              'Cache-Control' => include('private')
+            )
             expect(response).to render_template(:show)
             expect(response.body).to include status.text
           end
@@ -172,11 +177,12 @@ describe StatusesController do
           it 'renders ActivityPub Note object successfully', :aggregate_failures do
             expect(response).to have_http_status(200)
             expect(response.headers['Link'].to_s).to include 'activity+json'
-            expect(response.headers['Vary']).to eq 'Accept, Accept-Language, Cookie'
-            expect(response.headers['Cache-Control']).to include 'private'
-            expect(response.headers['Content-Type']).to include 'application/activity+json'
-            json = body_as_json
-            expect(json[:content]).to include status.text
+            expect(response.headers).to include(
+              'Vary' => 'Accept, Accept-Language, Cookie',
+              'Cache-Control' => include('private'),
+              'Content-Type' => include('application/activity+json')
+            )
+            expect(body_as_json[:content]).to include status.text
           end
         end
       end
@@ -196,8 +202,10 @@ describe StatusesController do
             it 'renders status successfully', :aggregate_failures do
               expect(response).to have_http_status(200)
               expect(response.headers['Link'].to_s).to include 'activity+json'
-              expect(response.headers['Vary']).to eq 'Accept, Accept-Language, Cookie'
-              expect(response.headers['Cache-Control']).to include 'private'
+              expect(response.headers).to include(
+                'Vary' => 'Accept, Accept-Language, Cookie',
+                'Cache-Control' => include('private')
+              )
               expect(response).to render_template(:show)
               expect(response.body).to include status.text
             end
@@ -209,11 +217,12 @@ describe StatusesController do
             it 'renders ActivityPub Note object successfully', :aggregate_failures do
               expect(response).to have_http_status(200)
               expect(response.headers['Link'].to_s).to include 'activity+json'
-              expect(response.headers['Vary']).to eq 'Accept, Accept-Language, Cookie'
-              expect(response.headers['Cache-Control']).to include 'private'
-              expect(response.headers['Content-Type']).to include 'application/activity+json'
-              json = body_as_json
-              expect(json[:content]).to include status.text
+              expect(response.headers).to include(
+                'Vary' => 'Accept, Accept-Language, Cookie',
+                'Cache-Control' => include('private'),
+                'Content-Type' => include('application/activity+json')
+              )
+              expect(body_as_json[:content]).to include status.text
             end
           end
         end
@@ -256,8 +265,10 @@ describe StatusesController do
             it 'renders status successfully', :aggregate_failures do
               expect(response).to have_http_status(200)
               expect(response.headers['Link'].to_s).to include 'activity+json'
-              expect(response.headers['Vary']).to eq 'Accept, Accept-Language, Cookie'
-              expect(response.headers['Cache-Control']).to include 'private'
+              expect(response.headers).to include(
+                'Vary' => 'Accept, Accept-Language, Cookie',
+                'Cache-Control' => include('private')
+              )
               expect(response).to render_template(:show)
               expect(response.body).to include status.text
             end
@@ -269,11 +280,12 @@ describe StatusesController do
             it 'renders ActivityPub Note object successfully' do
               expect(response).to have_http_status(200)
               expect(response.headers['Link'].to_s).to include 'activity+json'
-              expect(response.headers['Vary']).to eq 'Accept, Accept-Language, Cookie'
-              expect(response.headers['Cache-Control']).to include 'private'
-              expect(response.headers['Content-Type']).to include 'application/activity+json'
-              json = body_as_json
-              expect(json[:content]).to include status.text
+              expect(response.headers).to include(
+                'Vary' => 'Accept, Accept-Language, Cookie',
+                'Cache-Control' => include('private'),
+                'Content-Type' => include('application/activity+json')
+              )
+              expect(body_as_json[:content]).to include status.text
             end
           end
         end
@@ -342,8 +354,10 @@ describe StatusesController do
           it 'renders status successfully', :aggregate_failures do
             expect(response).to have_http_status(200)
             expect(response.headers['Link'].to_s).to include 'activity+json'
-            expect(response.headers['Vary']).to eq 'Accept, Accept-Language, Cookie'
-            expect(response.headers['Cache-Control']).to include 'private'
+            expect(response.headers).to include(
+              'Vary' => 'Accept, Accept-Language, Cookie',
+              'Cache-Control' => include('private')
+            )
             expect(response).to render_template(:show)
             expect(response.body).to include status.text
           end
@@ -357,10 +371,11 @@ describe StatusesController do
           it 'renders ActivityPub Note object successfully', :aggregate_failures do
             expect(response).to have_http_status(200)
             expect(response.headers['Link'].to_s).to include 'activity+json'
-            expect(response.headers['Vary']).to eq 'Accept, Accept-Language, Cookie'
-            expect(response.headers['Content-Type']).to include 'application/activity+json'
-            json = body_as_json
-            expect(json[:content]).to include status.text
+            expect(response.headers).to include(
+              'Vary' => 'Accept, Accept-Language, Cookie',
+              'Content-Type' => include('application/activity+json')
+            )
+            expect(body_as_json[:content]).to include status.text
           end
         end
       end
@@ -380,8 +395,10 @@ describe StatusesController do
             it 'renders status successfully', :aggregate_failures do
               expect(response).to have_http_status(200)
               expect(response.headers['Link'].to_s).to include 'activity+json'
-              expect(response.headers['Vary']).to eq 'Accept, Accept-Language, Cookie'
-              expect(response.headers['Cache-Control']).to include 'private'
+              expect(response.headers).to include(
+                'Vary' => 'Accept, Accept-Language, Cookie',
+                'Cache-Control' => include('private')
+              )
               expect(response).to render_template(:show)
               expect(response.body).to include status.text
             end
@@ -393,11 +410,12 @@ describe StatusesController do
             it 'renders ActivityPub Note object successfully' do
               expect(response).to have_http_status(200)
               expect(response.headers['Link'].to_s).to include 'activity+json'
-              expect(response.headers['Vary']).to eq 'Accept, Accept-Language, Cookie'
-              expect(response.headers['Cache-Control']).to include 'private'
-              expect(response.headers['Content-Type']).to include 'application/activity+json'
-              json = body_as_json
-              expect(json[:content]).to include status.text
+              expect(response.headers).to include(
+                'Vary' => 'Accept, Accept-Language, Cookie',
+                'Cache-Control' => include('private'),
+                'Content-Type' => include('application/activity+json')
+              )
+              expect(body_as_json[:content]).to include status.text
             end
           end
         end
@@ -440,8 +458,10 @@ describe StatusesController do
             it 'renders status successfully', :aggregate_failures do
               expect(response).to have_http_status(200)
               expect(response.headers['Link'].to_s).to include 'activity+json'
-              expect(response.headers['Vary']).to eq 'Accept, Accept-Language, Cookie'
-              expect(response.headers['Cache-Control']).to include 'private'
+              expect(response.headers).to include(
+                'Vary' => 'Accept, Accept-Language, Cookie',
+                'Cache-Control' => include('private')
+              )
               expect(response).to render_template(:show)
               expect(response.body).to include status.text
             end
@@ -453,11 +473,12 @@ describe StatusesController do
             it 'renders ActivityPub Note object', :aggregate_failures do
               expect(response).to have_http_status(200)
               expect(response.headers['Link'].to_s).to include 'activity+json'
-              expect(response.headers['Vary']).to eq 'Accept, Accept-Language, Cookie'
-              expect(response.headers['Cache-Control']).to include 'private'
-              expect(response.headers['Content-Type']).to include 'application/activity+json'
-              json = body_as_json
-              expect(json[:content]).to include status.text
+              expect(response.headers).to include(
+                'Vary' => 'Accept, Accept-Language, Cookie',
+                'Cache-Control' => include('private'),
+                'Content-Type' => include('application/activity+json')
+              )
+              expect(body_as_json[:content]).to include status.text
             end
           end
         end
@@ -734,8 +755,10 @@ describe StatusesController do
       it 'renders status successfully', :aggregate_failures do
         expect(response).to have_http_status(200)
         expect(response.headers['Link'].to_s).to include 'activity+json'
-        expect(response.headers['Vary']).to eq 'Accept, Accept-Language, Cookie'
-        expect(response.headers['Cache-Control']).to include 'public'
+        expect(response.headers).to include(
+          'Vary' => 'Accept, Accept-Language, Cookie',
+          'Cache-Control' => include('public')
+        )
         expect(response).to render_template(:embed)
         expect(response.body).to include status.text
       end

--- a/spec/controllers/statuses_controller_spec.rb
+++ b/spec/controllers/statuses_controller_spec.rb
@@ -75,13 +75,15 @@ describe StatusesController do
         it_behaves_like 'cacheable response', expects_vary: 'Accept, Accept-Language, Cookie'
 
         it 'renders ActivityPub Note object successfully', :aggregate_failures do
-          expect(response).to have_http_status(200)
+          expect(response)
+            .to have_http_status(200)
           expect(response.headers).to include(
             'Vary' => 'Accept, Accept-Language, Cookie',
             'Content-Type' => include('application/activity+json'),
             'Link' => satisfy { |header| header.to_s.include?('activity+json') }
           )
-          expect(body_as_json[:content]).to include status.text
+          expect(body_as_json)
+            .to include(content: include(status.text))
         end
       end
     end
@@ -177,14 +179,16 @@ describe StatusesController do
           let(:format) { 'json' }
 
           it 'renders ActivityPub Note object successfully', :aggregate_failures do
-            expect(response).to have_http_status(200)
+            expect(response)
+              .to have_http_status(200)
             expect(response.headers).to include(
               'Vary' => 'Accept, Accept-Language, Cookie',
               'Cache-Control' => include('private'),
               'Content-Type' => include('application/activity+json'),
               'Link' => satisfy { |header| header.to_s.include?('activity+json') }
             )
-            expect(body_as_json[:content]).to include status.text
+            expect(body_as_json)
+              .to include(content: include(status.text))
           end
         end
       end
@@ -219,14 +223,16 @@ describe StatusesController do
             let(:format) { 'json' }
 
             it 'renders ActivityPub Note object successfully', :aggregate_failures do
-              expect(response).to have_http_status(200)
+              expect(response)
+                .to have_http_status(200)
               expect(response.headers).to include(
                 'Vary' => 'Accept, Accept-Language, Cookie',
                 'Cache-Control' => include('private'),
                 'Content-Type' => include('application/activity+json'),
                 'Link' => satisfy { |header| header.to_s.include?('activity+json') }
               )
-              expect(body_as_json[:content]).to include status.text
+              expect(body_as_json)
+                .to include(content: include(status.text))
             end
           end
         end
@@ -283,14 +289,16 @@ describe StatusesController do
             let(:format) { 'json' }
 
             it 'renders ActivityPub Note object successfully' do
-              expect(response).to have_http_status(200)
+              expect(response)
+                .to have_http_status(200)
               expect(response.headers).to include(
                 'Vary' => 'Accept, Accept-Language, Cookie',
                 'Cache-Control' => include('private'),
                 'Content-Type' => include('application/activity+json'),
                 'Link' => satisfy { |header| header.to_s.include?('activity+json') }
               )
-              expect(body_as_json[:content]).to include status.text
+              expect(body_as_json)
+                .to include(content: include(status.text))
             end
           end
         end
@@ -375,13 +383,15 @@ describe StatusesController do
           it_behaves_like 'cacheable response', expects_vary: 'Accept, Accept-Language, Cookie'
 
           it 'renders ActivityPub Note object successfully', :aggregate_failures do
-            expect(response).to have_http_status(200)
+            expect(response)
+              .to have_http_status(200)
             expect(response.headers).to include(
               'Vary' => 'Accept, Accept-Language, Cookie',
               'Content-Type' => include('application/activity+json'),
               'Link' => satisfy { |header| header.to_s.include?('activity+json') }
             )
-            expect(body_as_json[:content]).to include status.text
+            expect(body_as_json)
+              .to include(content: include(status.text))
           end
         end
       end
@@ -417,16 +427,15 @@ describe StatusesController do
             it 'renders ActivityPub Note object successfully' do
               expect(response)
                 .to have_http_status(200)
-                .and have_attributes(
-                  headers: include(
-                    'Vary' => 'Accept, Accept-Language, Cookie',
-                    'Cache-Control' => include('private'),
-                    'Content-Type' => include('application/activity+json'),
-                    'Link' => satisfy { |header| header.to_s.include?('activity+json') }
-                  )
-                )
+              expect(response.headers).to include(
+                'Vary' => 'Accept, Accept-Language, Cookie',
+                'Cache-Control' => include('private'),
+                'Content-Type' => include('application/activity+json'),
+                'Link' => satisfy { |header| header.to_s.include?('activity+json') }
+              )
 
-              expect(body_as_json[:content]).to include status.text
+              expect(body_as_json)
+                .to include(content: include(status.text))
             end
           end
         end
@@ -483,14 +492,16 @@ describe StatusesController do
             let(:format) { 'json' }
 
             it 'renders ActivityPub Note object', :aggregate_failures do
-              expect(response).to have_http_status(200)
+              expect(response)
+                .to have_http_status(200)
               expect(response.headers).to include(
                 'Vary' => 'Accept, Accept-Language, Cookie',
                 'Cache-Control' => include('private'),
                 'Content-Type' => include('application/activity+json'),
                 'Link' => satisfy { |header| header.to_s.include?('activity+json') }
               )
-              expect(body_as_json[:content]).to include status.text
+              expect(body_as_json)
+                .to include(content: include(status.text))
             end
           end
         end


### PR DESCRIPTION
Similar approach as previously in https://github.com/mastodon/mastodon/pull/27838

This is a mix of starting to work on that cop, and a general DRY/tidy of some of these that are quite repetitive with the headers checks, mixed with some formatting changes to keep it consistent across at least this one file.

This is extracted from a larger branch making progress on `RSpec/MultipleExpectations` - if we like this approach there are more to come there, but wanted to start with a simpler one first.