### PR TITLE
Configure elastic search integration with rspec tag

### DIFF
--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -227,7 +227,7 @@ jobs:
           path: tmp/screenshots/
 
   test-search:
-    name: Testing search
+    name: Elastic Search integration testing
     runs-on: ubuntu-latest
 
     needs:
@@ -314,7 +314,7 @@ jobs:
       - name: Load database schema
         run: './bin/rails db:create db:schema:load db:seed'
 
-      - run: bundle exec rake spec:search
+      - run: bin/rspec --tag search
 
       - name: Archive logs
         uses: actions/upload-artifact@v3

--- a/lib/tasks/spec.rake
+++ b/lib/tasks/spec.rake
@@ -9,13 +9,3 @@ if Rake::Task.task_defined?('spec:system')
 
   Rake::Task['spec:system'].enhance ['spec:enable_system_specs']
 end
-
-if Rake::Task.task_defined?('spec:search')
-  namespace :spec do
-    task :enable_search_specs do # rubocop:disable Rails/RakeEnvironment
-      ENV['RUN_SEARCH_SPECS'] = 'true'
-    end
-  end
-
-  Rake::Task['spec:search'].enhance ['spec:enable_search_specs']
-end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,7 +4,6 @@ ENV['RAILS_ENV'] ||= 'test'
 
 # This needs to be defined before Rails is initialized
 RUN_SYSTEM_SPECS = ENV.fetch('RUN_SYSTEM_SPECS', false)
-RUN_SEARCH_SPECS = ENV.fetch('RUN_SEARCH_SPECS', false)
 
 if RUN_SYSTEM_SPECS
   STREAMING_PORT = ENV.fetch('TEST_STREAMING_PORT', '4020')
@@ -54,18 +53,26 @@ RSpec.configure do |config|
     case type
     when :system
       !RUN_SYSTEM_SPECS
-    when :search
-      !RUN_SEARCH_SPECS
     end
   }
+
+  # By default, skip the elastic search integration specs
+  config.filter_run_excluding search: true
+
   config.fixture_path = Rails.root.join('spec', 'fixtures')
   config.use_transactional_fixtures = true
   config.order = 'random'
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
 
+  # Set type to `cli` for all CLI specs
   config.define_derived_metadata(file_path: Regexp.new('spec/lib/mastodon/cli')) do |metadata|
     metadata[:type] = :cli
+  end
+
+  # Set `search` metadata true for all specs in spec/search/
+  config.define_derived_metadata(file_path: Regexp.new('spec/search/*')) do |metadata|
+    metadata[:search] = true
   end
 
   config.include Devise::Test::ControllerHelpers, type: :controller

--- a/spec/support/search_data_manager.rb
+++ b/spec/support/search_data_manager.rb
@@ -60,7 +60,7 @@ RSpec.configure do |config|
     end
   end
 
-  config.around :each, type: :search do |example|
+  config.around :each, :search do |example|
     search_data_manager.populate_indexes
     example.run
     search_data_manager.remove_indexes
@@ -73,6 +73,6 @@ RSpec.configure do |config|
   end
 
   def search_examples_present?
-    RUN_SEARCH_SPECS
+    RSpec.world.filtered_examples.values.flatten.any? { |example| example.metadata[:search] == true }
   end
 end


### PR DESCRIPTION
Related to https://github.com/mastodon/mastodon/pull/27732 and https://github.com/mastodon/mastodon/pull/27727 and from the same WIP branch, this updates how we run the ES integration specs in CI and locally...

- Instead of passing ENV var around, use rspec built-in tag approach
- Configure all of `spec/search` to be tagged with `search`
- Configure `search` tag to exclude by default from spec runs
- Update CI command to opt in to running search specs in the job where ES is running

I have similar work for the streaming server end-to-end system specs as well, but that's at least partially dependent on the linked capybara config PR. Next steps here would be to:

- Continue to make what specs are running less about what type of rspec thing they are (features vs system specs) or what dir they are in or what env vars are set, and more about what tags they have and thus what capabilities they need to have present (ie, run on a JS-enabled browser vs rack_test, run with streaming server on, run with ES enabled, etc). We can then pick and choose how CI is configured from amongst this menu.
- Migrate all the current feature specs to be system specs, and opt in/out of JS/streaming as appropriate per-spec (I have WIP branch for this as well)