### PR TITLE
Fix upper border radius of onboarding columns

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2299,8 +2299,7 @@ $ui-header-height: 55px;
 
   > .scrollable {
     background: $ui-base-color;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-radius: 0 0 4px 4px;
   }
 }
 


### PR DESCRIPTION
The upper border of the scrollable component had a slight border-radius:
![image](https://github.com/mastodon/mastodon/assets/384364/0df0c201-e74e-4a31-bb23-6defaa121803)

This PR fixes it:
![image](https://github.com/mastodon/mastodon/assets/384364/5e7a5001-2c54-4710-8ef1-c107b732a4ed)