### PR TITLE
Speedup and style cleanup through `spec/controllers/admin/*` specs

### DIFF
--- a/spec/controllers/admin/account_moderation_notes_controller_spec.rb
+++ b/spec/controllers/admin/account_moderation_notes_controller_spec.rb
@@ -19,8 +19,11 @@ RSpec.describe Admin::AccountModerationNotesController do
       let(:params) { { account_moderation_note: { target_account_id: target_account.id, content: 'test content' } } }
 
       it 'successfully creates a note' do
-        expect { subject }.to change(AccountModerationNote, :count).by(1)
-        expect(response).to redirect_to admin_account_path(target_account.id)
+        expect { subject }
+          .to change(AccountModerationNote, :count).by(1)
+
+        expect(response)
+          .to redirect_to admin_account_path(target_account.id)
       end
     end
 
@@ -28,8 +31,12 @@ RSpec.describe Admin::AccountModerationNotesController do
       let(:params) { { account_moderation_note: { target_account_id: target_account.id, content: '' } } }
 
       it 'falls to create a note' do
-        expect { subject }.to_not change(AccountModerationNote, :count)
-        expect(response).to render_template 'admin/accounts/show'
+        expect { subject }
+          .to_not change(AccountModerationNote, :count)
+
+        expect(response)
+          .to have_http_status(200)
+          .and render_template('admin/accounts/show')
       end
     end
   end
@@ -41,8 +48,11 @@ RSpec.describe Admin::AccountModerationNotesController do
     let(:account) { Fabricate(:account) }
 
     it 'destroys note' do
-      expect { subject }.to change(AccountModerationNote, :count).by(-1)
-      expect(response).to redirect_to admin_account_path(target_account.id)
+      expect { subject }
+        .to change(AccountModerationNote, :count).by(-1)
+
+      expect(response)
+        .to redirect_to admin_account_path(target_account.id)
     end
   end
 end

--- a/spec/controllers/admin/accounts_controller_spec.rb
+++ b/spec/controllers/admin/accounts_controller_spec.rb
@@ -40,14 +40,19 @@ RSpec.describe Admin::AccountsController do
 
       get :index, params: { page: 2 }
 
-      accounts = assigns(:accounts)
-      expect(accounts.count).to eq 1
-      expect(accounts.klass).to be Account
+      expect(assigns(:accounts))
+        .to have_attributes(
+          count: 1,
+          klass: be(Account)
+        )
     end
 
     it 'returns http success' do
       get :index
-      expect(response).to have_http_status(200)
+
+      expect(response)
+        .to have_http_status(200)
+        .and render_template(:index)
     end
   end
 
@@ -57,7 +62,10 @@ RSpec.describe Admin::AccountsController do
 
     it 'returns http success' do
       get :show, params: { id: account.id }
-      expect(response).to have_http_status(200)
+
+      expect(response)
+        .to have_http_status(200)
+        .and render_template(:show)
     end
   end
 
@@ -159,16 +167,16 @@ RSpec.describe Admin::AccountsController do
       end
 
       it 'logs action' do
-        expect(subject).to have_http_status 302
+        expect(subject)
+          .to have_http_status(302)
 
-        log_item = Admin::ActionLog.last
-
-        expect(log_item).to_not be_nil
-        expect(log_item).to have_attributes(
-          action: :approve,
-          account_id: current_user.account_id,
-          target_id: account.user.id
-        )
+        expect(Admin::ActionLog.last)
+          .to be_present
+          .and have_attributes(
+            action: :approve,
+            account_id: current_user.account_id,
+            target_id: account.user.id
+          )
       end
     end
 
@@ -201,16 +209,16 @@ RSpec.describe Admin::AccountsController do
       end
 
       it 'logs action' do
-        expect(subject).to have_http_status 302
+        expect(subject)
+          .to have_http_status 302
 
-        log_item = Admin::ActionLog.last
-
-        expect(log_item).to_not be_nil
-        expect(log_item).to have_attributes(
-          action: :reject,
-          account_id: current_user.account_id,
-          target_id: account.user.id
-        )
+        expect(Admin::ActionLog.last)
+          .to be_present
+          .and have_attributes(
+            action: :reject,
+            account_id: current_user.account_id,
+            target_id: account.user.id
+          )
       end
     end
 
@@ -288,13 +296,12 @@ RSpec.describe Admin::AccountsController do
     context 'when user is admin' do
       let(:role) { UserRole.find_by(name: 'Admin') }
 
-      it 'succeeds in removing email blocks' do
-        expect { subject }.to change { CanonicalEmailBlock.where(reference_account: account).count }.from(1).to(0)
-      end
+      it 'succeeds in removing email blocks and redirects to admin account path' do
+        expect { subject }
+          .to change { CanonicalEmailBlock.where(reference_account: account).count }.from(1).to(0)
 
-      it 'redirects to admin account path' do
-        subject
-        expect(response).to redirect_to admin_account_path(account.id)
+        expect(response)
+          .to redirect_to admin_account_path(account.id)
       end
     end
 

--- a/spec/controllers/admin/accounts_controller_spec.rb
+++ b/spec/controllers/admin/accounts_controller_spec.rb
@@ -164,9 +164,11 @@ RSpec.describe Admin::AccountsController do
         log_item = Admin::ActionLog.last
 
         expect(log_item).to_not be_nil
-        expect(log_item.action).to eq :approve
-        expect(log_item.account_id).to eq current_user.account_id
-        expect(log_item.target_id).to eq account.user.id
+        expect(log_item).to have_attributes(
+          action: :approve,
+          account_id: current_user.account_id,
+          target_id: account.user.id
+        )
       end
     end
 
@@ -204,9 +206,11 @@ RSpec.describe Admin::AccountsController do
         log_item = Admin::ActionLog.last
 
         expect(log_item).to_not be_nil
-        expect(log_item.action).to eq :reject
-        expect(log_item.account_id).to eq current_user.account_id
-        expect(log_item.target_id).to eq account.user.id
+        expect(log_item).to have_attributes(
+          action: :reject,
+          account_id: current_user.account_id,
+          target_id: account.user.id
+        )
       end
     end
 

--- a/spec/controllers/admin/action_logs_controller_spec.rb
+++ b/spec/controllers/admin/action_logs_controller_spec.rb
@@ -9,19 +9,43 @@ describe Admin::ActionLogsController do
   let!(:account) { Fabricate(:account) }
 
   before do
-    _orphaned_logs = %w(
-      Account User UserRole Report DomainBlock DomainAllow
-      EmailDomainBlock UnavailableDomain Status AccountWarning
-      Announcement IpBlock Instance CustomEmoji CanonicalEmailBlock Appeal
-    ).map { |type| Admin::ActionLog.new(account: account, action: 'destroy', target_type: type, target_id: 1312).save! }
+    orphaned_log_types.map do |type|
+      Admin::ActionLog.new(account: account, action: 'destroy', target_type: type, target_id: 1312).save!
+    end
   end
 
   describe 'GET #index' do
+    before { sign_in Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+
     it 'returns 200' do
-      sign_in Fabricate(:user, role: UserRole.find_by(name: 'Admin'))
       get :index, params: { page: 1 }
 
-      expect(response).to have_http_status(200)
+      expect(response)
+        .to have_http_status(200)
+        .and render_template(:index)
     end
+  end
+
+  private
+
+  def orphaned_log_types
+    %w(
+      Account
+      AccountWarning
+      Announcement
+      Appeal
+      CanonicalEmailBlock
+      CustomEmoji
+      DomainAllow
+      DomainBlock
+      EmailDomainBlock
+      Instance
+      IpBlock
+      Report
+      Status
+      UnavailableDomain
+      User
+      UserRole
+    )
   end
 end

--- a/spec/controllers/admin/announcements_controller_spec.rb
+++ b/spec/controllers/admin/announcements_controller_spec.rb
@@ -23,8 +23,9 @@ describe Admin::AnnouncementsController do
     it 'returns http success and renders new' do
       get :new
 
-      expect(response).to have_http_status(:success)
-      expect(response).to render_template(:new)
+      expect(response)
+        .to have_http_status(:success)
+        .and render_template(:new)
     end
   end
 
@@ -34,8 +35,9 @@ describe Admin::AnnouncementsController do
     it 'returns http success and renders edit' do
       get :edit, params: { id: announcement.id }
 
-      expect(response).to have_http_status(:success)
-      expect(response).to render_template(:edit)
+      expect(response)
+        .to have_http_status(:success)
+        .and render_template(:edit)
     end
   end
 

--- a/spec/controllers/admin/change_emails_controller_spec.rb
+++ b/spec/controllers/admin/change_emails_controller_spec.rb
@@ -36,9 +36,11 @@ RSpec.describe Admin::ChangeEmailsController do
 
       user.reload
 
-      expect(user.email).to eq previous_email
-      expect(user.unconfirmed_email).to eq 'test@example.com'
-      expect(user.confirmation_token).to_not be_nil
+      expect(user).to have_attributes(
+        email: previous_email,
+        unconfirmed_email: 'test@example.com',
+        confirmation_token: be_present
+      )
 
       expect(UserMailer).to have_received(:confirmation_instructions).with(user, user.confirmation_token, { to: 'test@example.com' })
 

--- a/spec/controllers/admin/change_emails_controller_spec.rb
+++ b/spec/controllers/admin/change_emails_controller_spec.rb
@@ -17,7 +17,9 @@ RSpec.describe Admin::ChangeEmailsController do
 
       get :show, params: { account_id: user.account.id }
 
-      expect(response).to have_http_status(200)
+      expect(response)
+        .to have_http_status(200)
+        .and render_template(:show)
     end
   end
 
@@ -34,9 +36,7 @@ RSpec.describe Admin::ChangeEmailsController do
 
       post :update, params: { account_id: user.account.id, user: { unconfirmed_email: 'test@example.com' } }
 
-      user.reload
-
-      expect(user).to have_attributes(
+      expect(user.reload).to have_attributes(
         email: previous_email,
         unconfirmed_email: 'test@example.com',
         confirmation_token: be_present

--- a/spec/controllers/admin/custom_emojis_controller_spec.rb
+++ b/spec/controllers/admin/custom_emojis_controller_spec.rb
@@ -19,8 +19,9 @@ describe Admin::CustomEmojisController do
     it 'renders index page' do
       get :index
 
-      expect(response).to have_http_status 200
-      expect(response).to render_template :index
+      expect(response)
+        .to have_http_status(200)
+        .and render_template(:index)
     end
   end
 
@@ -28,8 +29,9 @@ describe Admin::CustomEmojisController do
     it 'renders new page' do
       get :new
 
-      expect(response).to have_http_status 200
-      expect(response).to render_template :new
+      expect(response)
+        .to have_http_status(200)
+        .and render_template(:new)
     end
   end
 
@@ -50,7 +52,9 @@ describe Admin::CustomEmojisController do
       let(:params) { { shortcode: 't', image: image } }
 
       it 'renders new' do
-        expect(subject).to render_template :new
+        expect(subject)
+          .to have_http_status(200)
+          .and render_template(:new)
       end
     end
   end

--- a/spec/controllers/admin/dashboard_controller_spec.rb
+++ b/spec/controllers/admin/dashboard_controller_spec.rb
@@ -6,19 +6,29 @@ describe Admin::DashboardController do
   render_views
 
   describe 'GET #index' do
+    let(:admin_user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+
     before do
-      allow(Admin::SystemCheck).to receive(:perform).and_return([
-                                                                  Admin::SystemCheck::Message.new(:database_schema_check),
-                                                                  Admin::SystemCheck::Message.new(:rules_check, nil, admin_rules_path),
-                                                                  Admin::SystemCheck::Message.new(:sidekiq_process_check, 'foo, bar'),
-                                                                ])
-      sign_in Fabricate(:user, role: UserRole.find_by(name: 'Admin'))
+      allow(Admin::SystemCheck).to receive(:perform).and_return(system_check_messages)
+      sign_in admin_user
     end
 
     it 'returns 200' do
       get :index
 
-      expect(response).to have_http_status(200)
+      expect(response)
+        .to have_http_status(200)
+        .and render_template(:index)
+    end
+
+    private
+
+    def system_check_messages
+      [
+        Admin::SystemCheck::Message.new(:database_schema_check),
+        Admin::SystemCheck::Message.new(:rules_check, nil, admin_rules_path),
+        Admin::SystemCheck::Message.new(:sidekiq_process_check, 'foo, bar'),
+      ]
     end
   end
 end

--- a/spec/controllers/admin/domain_allows_controller_spec.rb
+++ b/spec/controllers/admin/domain_allows_controller_spec.rb
@@ -13,8 +13,12 @@ RSpec.describe Admin::DomainAllowsController do
     it 'assigns a new domain allow' do
       get :new
 
-      expect(assigns(:domain_allow)).to be_instance_of(DomainAllow)
-      expect(response).to have_http_status(200)
+      expect(assigns(:domain_allow))
+        .to be_instance_of(DomainAllow)
+
+      expect(response)
+        .to have_http_status(200)
+        .and render_template(:new)
     end
   end
 

--- a/spec/controllers/admin/email_domain_blocks_controller_spec.rb
+++ b/spec/controllers/admin/email_domain_blocks_controller_spec.rb
@@ -20,39 +20,51 @@ RSpec.describe Admin::EmailDomainBlocksController do
     it 'returns http success' do
       2.times { Fabricate(:email_domain_block) }
       get :index, params: { page: 2 }
-      expect(response).to have_http_status(200)
+
+      expect(response)
+        .to have_http_status(200)
+        .and render_template(:index)
     end
   end
 
   describe 'GET #new' do
     it 'returns http success' do
       get :new
-      expect(response).to have_http_status(200)
+
+      expect(response)
+        .to have_http_status(200)
+        .and render_template(:new)
     end
   end
 
   describe 'POST #create' do
+    let(:domain) { 'example.com' }
+
     context 'when resolve button is pressed' do
       before do
-        post :create, params: { email_domain_block: { domain: 'example.com' } }
+        post :create, params: { email_domain_block: { domain: domain } }
       end
 
       it 'renders new template' do
-        expect(response).to render_template(:new)
+        expect(response)
+          .to render_template(:new)
       end
     end
 
     context 'when save button is pressed' do
       before do
-        post :create, params: { email_domain_block: { domain: 'example.com' }, save: '' }
+        post :create, params: { email_domain_block: { domain: domain }, save: '' }
       end
 
-      it 'blocks the domain' do
-        expect(EmailDomainBlock.find_by(domain: 'example.com')).to_not be_nil
+      it 'blocks the domain and redirects' do
+        expect(created_domain_block).to_not be_nil
+
+        expect(response)
+          .to redirect_to(admin_email_domain_blocks_path)
       end
 
-      it 'redirects to e-mail domain blocks' do
-        expect(response).to redirect_to(admin_email_domain_blocks_path)
+      def created_domain_block
+        EmailDomainBlock.find_by(domain: domain)
       end
     end
   end

--- a/spec/controllers/admin/export_domain_allows_controller_spec.rb
+++ b/spec/controllers/admin/export_domain_allows_controller_spec.rb
@@ -13,7 +13,9 @@ RSpec.describe Admin::ExportDomainAllowsController do
     it 'returns http success' do
       get :new
 
-      expect(response).to have_http_status(200)
+      expect(response)
+        .to have_http_status(200)
+        .and render_template(:new)
     end
   end
 
@@ -23,8 +25,12 @@ RSpec.describe Admin::ExportDomainAllowsController do
       Fabricate(:domain_allow, domain: 'better.domain')
 
       get :export, params: { format: :csv }
-      expect(response).to have_http_status(200)
-      expect(response.body).to eq(File.read(File.join(file_fixture_path, 'domain_allows.csv')))
+
+      expect(response)
+        .to have_http_status(200)
+        .and have_attributes(
+          body: eq(domain_allows_csv_file)
+        )
     end
   end
 
@@ -35,18 +41,40 @@ RSpec.describe Admin::ExportDomainAllowsController do
       expect(response).to redirect_to(admin_instances_path)
 
       # Header should not be imported
-      expect(DomainAllow.where(domain: '#domain').present?).to be(false)
+      expect(header_domain_allow).to_not be_present
 
       # Domains should now be added
       get :export, params: { format: :csv }
-      expect(response).to have_http_status(200)
-      expect(response.body).to eq(File.read(File.join(file_fixture_path, 'domain_allows.csv')))
+
+      expect(response)
+        .to have_http_status(200)
+        .and have_attributes(
+          body: eq(domain_allows_csv_file)
+        )
     end
 
     it 'displays error on no file selected' do
       post :import, params: { admin_import: {} }
-      expect(response).to redirect_to(admin_instances_path)
-      expect(flash[:error]).to eq(I18n.t('admin.export_domain_allows.no_file'))
+
+      expect(response)
+        .to redirect_to(admin_instances_path)
+
+      expect(flash.to_h.symbolize_keys)
+        .to include(
+          error: eq(I18n.t('admin.export_domain_allows.no_file'))
+        )
     end
+
+    private
+
+    def header_domain_allow
+      DomainAllow.where(domain: '#domain')
+    end
+  end
+
+  private
+
+  def domain_allows_csv_file
+    File.read(File.join(file_fixture_path, 'domain_allows.csv'))
   end
 end

--- a/spec/controllers/admin/instances_controller_spec.rb
+++ b/spec/controllers/admin/instances_controller_spec.rb
@@ -26,11 +26,17 @@ RSpec.describe Admin::InstancesController do
     it 'renders instances' do
       get :index, params: { page: 2 }
 
-      instances = assigns(:instances).to_a
-      expect(instances.size).to eq 1
-      expect(instances[0].domain).to eq 'less.popular'
+      expect(assigns(:instances).to_a)
+        .to have_attributes(
+          size: 1,
+          first: have_attributes(
+            domain: eq('less.popular')
+          )
+        )
 
-      expect(response).to have_http_status(200)
+      expect(response)
+        .to have_http_status(200)
+        .and render_template(:index)
     end
   end
 
@@ -38,7 +44,9 @@ RSpec.describe Admin::InstancesController do
     it 'shows an instance page' do
       get :show, params: { id: account_popular_main.domain }
 
-      expect(response).to have_http_status(200)
+      expect(response)
+        .to have_http_status(200)
+        .and render_template(:show)
     end
   end
 
@@ -50,8 +58,11 @@ RSpec.describe Admin::InstancesController do
     it 'clears instance delivery errors' do
       post :clear_delivery_errors, params: { id: account_popular_main.domain }
 
-      expect(response).to redirect_to(admin_instance_path(account_popular_main.domain))
-      expect(tracker).to have_received(:clear_failures!)
+      expect(response)
+        .to redirect_to(admin_instance_path(account_popular_main.domain))
+
+      expect(tracker)
+        .to have_received(:clear_failures!)
     end
   end
 
@@ -66,8 +77,11 @@ RSpec.describe Admin::InstancesController do
       it 'tracks success on the instance' do
         post :restart_delivery, params: { id: account_popular_main.domain }
 
-        expect(response).to redirect_to(admin_instance_path(account_popular_main.domain))
-        expect(tracker).to have_received(:track_success!)
+        expect(response)
+          .to redirect_to(admin_instance_path(account_popular_main.domain))
+
+        expect(tracker)
+          .to have_received(:track_success!)
       end
     end
 
@@ -75,8 +89,11 @@ RSpec.describe Admin::InstancesController do
       it 'does not track success on the instance' do
         post :restart_delivery, params: { id: account_popular_main.domain }
 
-        expect(response).to redirect_to(admin_instance_path(account_popular_main.domain))
-        expect(tracker).to_not have_received(:track_success!)
+        expect(response)
+          .to redirect_to(admin_instance_path(account_popular_main.domain))
+
+        expect(tracker)
+          .to_not have_received(:track_success!)
       end
     end
   end
@@ -87,7 +104,8 @@ RSpec.describe Admin::InstancesController do
         post :stop_delivery, params: { id: account_popular_main.domain }
       end.to change(UnavailableDomain, :count).by(1)
 
-      expect(response).to redirect_to(admin_instance_path(account_popular_main.domain))
+      expect(response)
+        .to redirect_to(admin_instance_path(account_popular_main.domain))
     end
   end
 
@@ -101,7 +119,8 @@ RSpec.describe Admin::InstancesController do
       let(:role) { UserRole.find_by(name: 'Admin') }
 
       it 'succeeds in purging instance' do
-        expect(subject).to redirect_to admin_instances_path
+        expect(subject)
+          .to redirect_to admin_instances_path
       end
     end
 
@@ -109,7 +128,8 @@ RSpec.describe Admin::InstancesController do
       let(:role) { nil }
 
       it 'fails to purge instance' do
-        expect(subject).to have_http_status 403
+        expect(subject)
+          .to have_http_status 403
       end
     end
   end

--- a/spec/controllers/admin/invites_controller_spec.rb
+++ b/spec/controllers/admin/invites_controller_spec.rb
@@ -12,34 +12,45 @@ describe Admin::InvitesController do
   end
 
   describe 'GET #index' do
-    subject { get :index, params: { available: true } }
-
     let!(:invite) { Fabricate(:invite) }
 
     it 'renders index page' do
-      expect(subject).to render_template :index
-      expect(assigns(:invites)).to include invite
+      get :index, params: { available: true }
+
+      expect(response)
+        .to have_http_status(200)
+        .and render_template(:index)
+
+      expect(assigns(:invites))
+        .to include invite
     end
   end
 
   describe 'POST #create' do
-    subject { post :create, params: { invite: { max_uses: '10', expires_in: 1800 } } }
-
     it 'succeeds to create a invite' do
-      expect { subject }.to change(Invite, :count).by(1)
-      expect(subject).to redirect_to admin_invites_path
-      expect(Invite.last).to have_attributes(user_id: user.id, max_uses: 10)
+      expect do
+        post :create, params: { invite: { max_uses: '10', expires_in: 1800 } }
+      end.to change(Invite, :count).by(1)
+
+      expect(response)
+        .to redirect_to admin_invites_path
+
+      expect(Invite.last)
+        .to have_attributes(user_id: user.id, max_uses: 10)
     end
   end
 
   describe 'DELETE #destroy' do
-    subject { delete :destroy, params: { id: invite.id } }
-
     let!(:invite) { Fabricate(:invite, expires_at: nil) }
 
     it 'expires invite' do
-      expect(subject).to redirect_to admin_invites_path
-      expect(invite.reload).to be_expired
+      delete :destroy, params: { id: invite.id }
+
+      expect(response)
+        .to redirect_to admin_invites_path
+
+      expect(invite.reload)
+        .to be_expired
     end
   end
 
@@ -49,11 +60,11 @@ describe Admin::InvitesController do
 
       post :deactivate_all
 
-      invites.each do |invite|
-        expect(invite.reload).to be_expired
-      end
+      expect(invites.each(&:reload))
+        .to all(be_expired)
 
-      expect(response).to redirect_to admin_invites_path
+      expect(response)
+        .to redirect_to admin_invites_path
     end
   end
 end

--- a/spec/controllers/admin/ip_blocks_controller_spec.rb
+++ b/spec/controllers/admin/ip_blocks_controller_spec.rb
@@ -15,7 +15,9 @@ describe Admin::IpBlocksController do
     it 'returns http success' do
       get :index
 
-      expect(response).to have_http_status(:success)
+      expect(response)
+        .to have_http_status(:success)
+        .and render_template(:index)
     end
   end
 
@@ -23,8 +25,9 @@ describe Admin::IpBlocksController do
     it 'returns http success and renders view' do
       get :new
 
-      expect(response).to have_http_status(:success)
-      expect(response).to render_template(:new)
+      expect(response)
+        .to have_http_status(:success)
+        .and render_template(:new)
     end
   end
 
@@ -35,7 +38,9 @@ describe Admin::IpBlocksController do
           post :create, params: { ip_block: { ip: '1.1.1.1', severity: 'no_access', expires_in: 1.day.to_i.to_s } }
         end.to change(IpBlock, :count).by(1)
 
-        expect(response).to redirect_to(admin_ip_blocks_path)
+        expect(response)
+          .to redirect_to(admin_ip_blocks_path)
+
         expect(flash.notice).to match(I18n.t('admin.ip_blocks.created_msg'))
       end
     end
@@ -46,8 +51,9 @@ describe Admin::IpBlocksController do
           post :create, params: { ip_block: { ip: '1.1.1.1' } }
         end.to_not change(IpBlock, :count)
 
-        expect(response).to have_http_status(:success)
-        expect(response).to render_template(:new)
+        expect(response)
+          .to have_http_status(:success)
+          .and render_template(:new)
       end
     end
   end

--- a/spec/controllers/admin/relationships_controller_spec.rb
+++ b/spec/controllers/admin/relationships_controller_spec.rb
@@ -17,7 +17,9 @@ describe Admin::RelationshipsController do
     it 'returns http success' do
       get :index, params: { account_id: account.id }
 
-      expect(response).to have_http_status(:success)
+      expect(response)
+        .to have_http_status(:success)
+        .and render_template(:index)
     end
   end
 end

--- a/spec/controllers/admin/relays_controller_spec.rb
+++ b/spec/controllers/admin/relays_controller_spec.rb
@@ -15,7 +15,9 @@ describe Admin::RelaysController do
     it 'returns http success' do
       get :index
 
-      expect(response).to have_http_status(:success)
+      expect(response)
+        .to have_http_status(:success)
+        .and render_template(:index)
     end
   end
 
@@ -23,8 +25,9 @@ describe Admin::RelaysController do
     it 'returns http success and renders view' do
       get :new
 
-      expect(response).to have_http_status(:success)
-      expect(response).to render_template(:new)
+      expect(response)
+        .to have_http_status(:success)
+        .and render_template(:new)
     end
   end
 
@@ -51,8 +54,9 @@ describe Admin::RelaysController do
           post :create, params: { relay: { inbox_url: 'invalid' } }
         end.to_not change(Relay, :count)
 
-        expect(response).to have_http_status(:success)
-        expect(response).to render_template(:new)
+        expect(response)
+          .to have_http_status(:success)
+          .and render_template(:new)
       end
     end
   end

--- a/spec/controllers/admin/report_notes_controller_spec.rb
+++ b/spec/controllers/admin/report_notes_controller_spec.rb
@@ -25,9 +25,14 @@ describe Admin::ReportNotesController do
           let(:params) { { report_note: { content: 'test content', report_id: report.id }, create_and_resolve: nil } }
 
           it 'creates a report note and resolves report' do
-            expect { subject }.to change(ReportNote, :count).by(1)
-            expect(report.reload).to be_action_taken
-            expect(response).to redirect_to admin_reports_path
+            expect { subject }
+              .to change(ReportNote, :count).by(1)
+
+            expect(report.reload)
+              .to be_action_taken
+
+            expect(response)
+              .to redirect_to admin_reports_path
           end
         end
 
@@ -35,9 +40,14 @@ describe Admin::ReportNotesController do
           let(:params) { { report_note: { content: 'test content', report_id: report.id } } }
 
           it 'creates a report note and does not resolve report' do
-            expect { subject }.to change(ReportNote, :count).by(1)
-            expect(report.reload).to_not be_action_taken
-            expect(response).to redirect_to admin_report_path(report)
+            expect { subject }
+              .to change(ReportNote, :count).by(1)
+
+            expect(report.reload)
+              .to_not be_action_taken
+
+            expect(response)
+              .to redirect_to admin_report_path(report)
           end
         end
       end
@@ -50,9 +60,14 @@ describe Admin::ReportNotesController do
           let(:params) { { report_note: { content: 'test content', report_id: report.id }, create_and_unresolve: nil } }
 
           it 'creates a report note and unresolves report' do
-            expect { subject }.to change(ReportNote, :count).by(1)
-            expect(report.reload).to_not be_action_taken
-            expect(response).to redirect_to admin_report_path(report)
+            expect { subject }
+              .to change(ReportNote, :count).by(1)
+
+            expect(report.reload)
+              .to_not be_action_taken
+
+            expect(response)
+              .to redirect_to admin_report_path(report)
           end
         end
 
@@ -60,9 +75,14 @@ describe Admin::ReportNotesController do
           let(:params) { { report_note: { content: 'test content', report_id: report.id } } }
 
           it 'creates a report note and does not unresolve report' do
-            expect { subject }.to change(ReportNote, :count).by(1)
-            expect(report.reload).to be_action_taken
-            expect(response).to redirect_to admin_report_path(report)
+            expect { subject }
+              .to change(ReportNote, :count).by(1)
+
+            expect(report.reload)
+              .to be_action_taken
+
+            expect(response)
+              .to redirect_to admin_report_path(report)
           end
         end
       end
@@ -74,7 +94,8 @@ describe Admin::ReportNotesController do
       let(:account_id) { nil }
 
       it 'renders admin/reports/show' do
-        expect(subject).to render_template 'admin/reports/show'
+        expect(subject)
+          .to render_template 'admin/reports/show'
       end
     end
   end
@@ -85,8 +106,11 @@ describe Admin::ReportNotesController do
     let!(:report_note) { Fabricate(:report_note) }
 
     it 'deletes note' do
-      expect { subject }.to change(ReportNote, :count).by(-1)
-      expect(response).to redirect_to admin_report_path(report_note.report)
+      expect { subject }
+        .to change(ReportNote, :count).by(-1)
+
+      expect(response)
+        .to redirect_to admin_report_path(report_note.report)
     end
   end
 end

--- a/spec/controllers/admin/reports_controller_spec.rb
+++ b/spec/controllers/admin/reports_controller_spec.rb
@@ -18,10 +18,14 @@ describe Admin::ReportsController do
 
       get :index
 
-      reports = assigns(:reports).to_a
-      expect(reports.size).to eq 1
-      expect(reports[0]).to eq specified
-      expect(response).to have_http_status(200)
+      expect(assigns(:reports).to_a).to have_attributes(
+        size: 1,
+        first: eq(specified)
+      )
+
+      expect(response)
+        .to have_http_status(200)
+        .and render_template(:index)
     end
 
     it 'returns http success with resolved filter' do
@@ -30,11 +34,14 @@ describe Admin::ReportsController do
 
       get :index, params: { resolved: '1' }
 
-      reports = assigns(:reports).to_a
-      expect(reports.size).to eq 1
-      expect(reports[0]).to eq specified
+      expect(assigns(:reports).to_a).to have_attributes(
+        size: 1,
+        first: eq(specified)
+      )
 
-      expect(response).to have_http_status(200)
+      expect(response)
+        .to have_http_status(200)
+        .and render_template(:index)
     end
   end
 
@@ -45,7 +52,10 @@ describe Admin::ReportsController do
       get :show, params: { id: report }
 
       expect(assigns(:report)).to eq report
-      expect(response).to have_http_status(200)
+
+      expect(response)
+        .to have_http_status(200)
+        .and render_template(:show)
     end
   end
 
@@ -54,10 +64,14 @@ describe Admin::ReportsController do
       report = Fabricate(:report)
 
       put :resolve, params: { id: report }
-      expect(response).to redirect_to(admin_reports_path)
-      report.reload
-      expect(report.action_taken_by_account).to eq user.account
-      expect(report.action_taken?).to be true
+
+      expect(response)
+        .to redirect_to(admin_reports_path)
+
+      expect(report.reload).to have_attributes(
+        action_taken_by_account: eq(user.account),
+        action_taken?: be(true)
+      )
     end
   end
 
@@ -66,10 +80,14 @@ describe Admin::ReportsController do
       report = Fabricate(:report)
 
       put :reopen, params: { id: report }
-      expect(response).to redirect_to(admin_report_path(report))
-      report.reload
-      expect(report.action_taken_by_account).to be_nil
-      expect(report.action_taken?).to be false
+
+      expect(response)
+        .to redirect_to(admin_report_path(report))
+
+      expect(report.reload).to have_attributes(
+        action_taken_by_account: be_nil,
+        action_taken?: be(false)
+      )
     end
   end
 
@@ -78,9 +96,10 @@ describe Admin::ReportsController do
       report = Fabricate(:report)
 
       put :assign_to_self, params: { id: report }
-      expect(response).to redirect_to(admin_report_path(report))
-      report.reload
-      expect(report.assigned_account).to eq user.account
+      expect(response)
+        .to redirect_to(admin_report_path(report))
+
+      expect(report.reload.assigned_account).to eq(user.account)
     end
   end
 
@@ -89,9 +108,11 @@ describe Admin::ReportsController do
       report = Fabricate(:report)
 
       put :unassign, params: { id: report }
-      expect(response).to redirect_to(admin_report_path(report))
-      report.reload
-      expect(report.assigned_account).to be_nil
+
+      expect(response)
+        .to redirect_to(admin_report_path(report))
+
+      expect(report.reload.assigned_account).to be_nil
     end
   end
 end

--- a/spec/controllers/admin/rules_controller_spec.rb
+++ b/spec/controllers/admin/rules_controller_spec.rb
@@ -15,7 +15,9 @@ describe Admin::RulesController do
     it 'returns http success' do
       get :index
 
-      expect(response).to have_http_status(:success)
+      expect(response)
+        .to have_http_status(:success)
+        .and render_template(:index)
     end
   end
 
@@ -25,8 +27,9 @@ describe Admin::RulesController do
     it 'returns http success and renders edit' do
       get :edit, params: { id: rule.id }
 
-      expect(response).to have_http_status(:success)
-      expect(response).to render_template(:edit)
+      expect(response)
+        .to have_http_status(:success)
+        .and render_template(:edit)
     end
   end
 
@@ -37,7 +40,8 @@ describe Admin::RulesController do
           post :create, params: { rule: { text: 'The rule text.' } }
         end.to change(Rule, :count).by(1)
 
-        expect(response).to redirect_to(admin_rules_path)
+        expect(response)
+          .to redirect_to(admin_rules_path)
       end
     end
 
@@ -47,7 +51,8 @@ describe Admin::RulesController do
           post :create, params: { rule: { text: '' } }
         end.to_not change(Rule, :count)
 
-        expect(response).to render_template(:index)
+        expect(response)
+          .to render_template(:index)
       end
     end
   end
@@ -59,7 +64,8 @@ describe Admin::RulesController do
       it 'updates the rule and redirects' do
         put :update, params: { id: rule.id, rule: { text: 'Updated text.' } }
 
-        expect(response).to redirect_to(admin_rules_path)
+        expect(response)
+          .to redirect_to(admin_rules_path)
       end
     end
 
@@ -67,7 +73,8 @@ describe Admin::RulesController do
       it 'does not update the rule and renders index' do
         put :update, params: { id: rule.id, rule: { text: '' } }
 
-        expect(response).to render_template(:edit)
+        expect(response)
+          .to render_template(:edit)
       end
     end
   end
@@ -79,7 +86,9 @@ describe Admin::RulesController do
       delete :destroy, params: { id: rule.id }
 
       expect(rule.reload).to be_discarded
-      expect(response).to redirect_to(admin_rules_path)
+
+      expect(response)
+        .to redirect_to(admin_rules_path)
     end
   end
 end

--- a/spec/controllers/admin/statuses_controller_spec.rb
+++ b/spec/controllers/admin/statuses_controller_spec.rb
@@ -22,56 +22,52 @@ describe Admin::StatusesController do
 
   describe 'GET #index' do
     context 'with a valid account' do
-      before do
-        get :index, params: { account_id: account.id }
-      end
-
       it 'returns http success' do
-        expect(response).to have_http_status(200)
+        get :index, params: { account_id: account.id }
+
+        expect(response)
+          .to have_http_status(200)
+          .and render_template(:index)
       end
     end
 
     context 'when filtering by media' do
-      before do
-        get :index, params: { account_id: account.id, media: '1' }
-      end
-
       it 'returns http success' do
-        expect(response).to have_http_status(200)
+        get :index, params: { account_id: account.id, media: '1' }
+
+        expect(response)
+          .to have_http_status(200)
+          .and render_template(:index)
       end
     end
   end
 
   describe 'GET #show' do
-    before do
-      get :show, params: { account_id: account.id, id: status.id }
-    end
-
     it 'returns http success' do
-      expect(response).to have_http_status(200)
+      get :show, params: { account_id: account.id, id: status.id }
+
+      expect(response)
+        .to have_http_status(200)
+        .and render_template(:show)
     end
   end
 
   describe 'POST #batch' do
-    subject { post :batch, params: { :account_id => account.id, action => '', :admin_status_batch_action => { status_ids: status_ids } } }
-
     let(:status_ids) { [media_attached_status.id] }
 
     shared_examples 'when action is report' do
       let(:action) { 'report' }
 
-      it 'creates a report' do
-        subject
+      it 'creates a report and redirects to report page' do
+        post :batch, params: { :account_id => account.id, action => '', :admin_status_batch_action => { status_ids: status_ids } }
 
-        report = Report.last
-        expect(report.target_account_id).to eq account.id
-        expect(report.status_ids).to eq status_ids
-      end
+        expect(Report.last).to have_attributes(
+          target_account_id: account.id,
+          status_ids: status_ids
+        )
 
-      it 'redirects to report page' do
-        subject
-
-        expect(response).to redirect_to(admin_report_path(Report.last.id))
+        expect(response)
+          .to redirect_to(admin_report_path(Report.last.id))
       end
     end
 

--- a/spec/controllers/admin/tags_controller_spec.rb
+++ b/spec/controllers/admin/tags_controller_spec.rb
@@ -12,12 +12,12 @@ RSpec.describe Admin::TagsController do
   describe 'GET #show' do
     let!(:tag) { Fabricate(:tag) }
 
-    before do
-      get :show, params: { id: tag.id }
-    end
-
     it 'returns status 200' do
-      expect(response).to have_http_status(200)
+      get :show, params: { id: tag.id }
+
+      expect(response)
+        .to have_http_status(200)
+        .and render_template(:show)
     end
   end
 
@@ -28,8 +28,11 @@ RSpec.describe Admin::TagsController do
       it 'updates the tag' do
         put :update, params: { id: tag.id, tag: { listable: '1' } }
 
-        expect(response).to redirect_to(admin_tag_path(tag.id))
-        expect(tag.reload).to be_listable
+        expect(response)
+          .to redirect_to(admin_tag_path(tag.id))
+
+        expect(tag.reload)
+          .to be_listable
       end
     end
 
@@ -37,8 +40,9 @@ RSpec.describe Admin::TagsController do
       it 'does not update the tag' do
         put :update, params: { id: tag.id, tag: { name: 'cant-change-name' } }
 
-        expect(response).to have_http_status(200)
-        expect(response).to render_template(:show)
+        expect(response)
+          .to have_http_status(200)
+          .and render_template(:show)
       end
     end
   end

--- a/spec/controllers/admin/users/roles_controller_spec.rb
+++ b/spec/controllers/admin/users/roles_controller_spec.rb
@@ -44,12 +44,14 @@ describe Admin::Users::RolesController do
       let(:permissions) { UserRole::FLAGS[:manage_roles] }
       let(:position) { 1 }
 
-      it 'updates user role' do
-        expect(user.reload.role_id).to eq selected_role&.id
-      end
+      it 'updates user role and redirects back to account page' do
+        expect(user.reload)
+          .to have_attributes(
+            role_id: eq(selected_role&.id)
+          )
 
-      it 'redirects back to account page' do
-        expect(response).to redirect_to(admin_account_path(user.account_id))
+        expect(response)
+          .to redirect_to(admin_account_path(user.account_id))
       end
     end
 
@@ -58,11 +60,14 @@ describe Admin::Users::RolesController do
       let(:position) { 100 }
 
       it 'does not update user role' do
-        expect(user.reload.role_id).to eq previous_role&.id
-      end
+        expect(user.reload)
+          .to have_attributes(
+            role_id: eq(previous_role&.id)
+          )
 
-      it 'renders edit form' do
-        expect(response).to render_template(:show)
+        expect(response)
+          .to have_http_status(200)
+          .and render_template(:show)
       end
     end
 
@@ -71,12 +76,14 @@ describe Admin::Users::RolesController do
       let(:permissions) { UserRole::FLAGS[:manage_roles] }
       let(:position) { 1 }
 
-      it 'does not update user role' do
-        expect(user.reload.role_id).to eq previous_role&.id
-      end
+      it 'does not update user role and return forbidden' do
+        expect(user.reload)
+          .to have_attributes(
+            role_id: eq(previous_role&.id)
+          )
 
-      it 'returns http forbidden' do
-        expect(response).to have_http_status(403)
+        expect(response)
+          .to have_http_status(403)
       end
     end
   end

--- a/spec/controllers/admin/users/two_factor_authentications_controller_spec.rb
+++ b/spec/controllers/admin/users/two_factor_authentications_controller_spec.rb
@@ -21,9 +21,13 @@ describe Admin::Users::TwoFactorAuthenticationsController do
       it 'redirects to admin account page' do
         delete :destroy, params: { user_id: user.id }
 
-        user.reload
-        expect(user.otp_enabled?).to be false
-        expect(response).to redirect_to(admin_account_path(user.account_id))
+        expect(user.reload)
+          .to have_attributes(
+            otp_enabled?: false
+          )
+
+        expect(response)
+          .to redirect_to(admin_account_path(user.account_id))
       end
     end
 
@@ -44,10 +48,14 @@ describe Admin::Users::TwoFactorAuthenticationsController do
       it 'redirects to admin account page' do
         delete :destroy, params: { user_id: user.id }
 
-        user.reload
-        expect(user.otp_enabled?).to be false
-        expect(user.webauthn_enabled?).to be false
-        expect(response).to redirect_to(admin_account_path(user.account_id))
+        expect(user.reload)
+          .to have_attributes(
+            otp_enabled?: false,
+            webauthn_enabled?: false
+          )
+
+        expect(response)
+          .to redirect_to(admin_account_path(user.account_id))
       end
     end
   end

--- a/spec/controllers/admin/warning_presets_controller_spec.rb
+++ b/spec/controllers/admin/warning_presets_controller_spec.rb
@@ -15,7 +15,9 @@ describe Admin::WarningPresetsController do
     it 'returns http success' do
       get :index
 
-      expect(response).to have_http_status(:success)
+      expect(response)
+        .to have_http_status(:success)
+        .and render_template(:index)
     end
   end
 
@@ -25,8 +27,9 @@ describe Admin::WarningPresetsController do
     it 'returns http success and renders edit' do
       get :edit, params: { id: account_warning_preset.id }
 
-      expect(response).to have_http_status(:success)
-      expect(response).to render_template(:edit)
+      expect(response)
+        .to have_http_status(:success)
+        .and render_template(:edit)
     end
   end
 
@@ -37,7 +40,8 @@ describe Admin::WarningPresetsController do
           post :create, params: { account_warning_preset: { text: 'The account_warning_preset text.' } }
         end.to change(AccountWarningPreset, :count).by(1)
 
-        expect(response).to redirect_to(admin_warning_presets_path)
+        expect(response)
+          .to redirect_to(admin_warning_presets_path)
       end
     end
 
@@ -47,7 +51,9 @@ describe Admin::WarningPresetsController do
           post :create, params: { account_warning_preset: { text: '' } }
         end.to_not change(AccountWarningPreset, :count)
 
-        expect(response).to render_template(:index)
+        expect(response)
+          .to have_http_status(:success)
+          .and render_template(:index)
       end
     end
   end
@@ -59,7 +65,8 @@ describe Admin::WarningPresetsController do
       it 'updates the account_warning_preset and redirects' do
         put :update, params: { id: account_warning_preset.id, account_warning_preset: { text: 'Updated text.' } }
 
-        expect(response).to redirect_to(admin_warning_presets_path)
+        expect(response)
+          .to redirect_to(admin_warning_presets_path)
       end
     end
 
@@ -67,7 +74,9 @@ describe Admin::WarningPresetsController do
       it 'does not update the account_warning_preset and renders index' do
         put :update, params: { id: account_warning_preset.id, account_warning_preset: { text: '' } }
 
-        expect(response).to render_template(:edit)
+        expect(response)
+          .to have_http_status(:success)
+          .and render_template(:edit)
       end
     end
   end
@@ -78,8 +87,11 @@ describe Admin::WarningPresetsController do
     it 'destroys the account_warning_preset and redirects' do
       delete :destroy, params: { id: account_warning_preset.id }
 
-      expect { account_warning_preset.reload }.to raise_error(ActiveRecord::RecordNotFound)
-      expect(response).to redirect_to(admin_warning_presets_path)
+      expect { account_warning_preset.reload }
+        .to raise_error(ActiveRecord::RecordNotFound)
+
+      expect(response)
+        .to redirect_to(admin_warning_presets_path)
     end
   end
 end

--- a/spec/controllers/admin/webhooks_controller_spec.rb
+++ b/spec/controllers/admin/webhooks_controller_spec.rb
@@ -15,7 +15,9 @@ describe Admin::WebhooksController do
     it 'returns http success' do
       get :index
 
-      expect(response).to have_http_status(:success)
+      expect(response)
+        .to have_http_status(:success)
+        .and render_template(:index)
     end
   end
 
@@ -23,8 +25,9 @@ describe Admin::WebhooksController do
     it 'returns http success and renders view' do
       get :new
 
-      expect(response).to have_http_status(:success)
-      expect(response).to render_template(:new)
+      expect(response)
+        .to have_http_status(:success)
+        .and render_template(:new)
     end
   end
 
@@ -34,7 +37,8 @@ describe Admin::WebhooksController do
         post :create, params: { webhook: { url: 'https://example.com/hook', events: ['account.approved'] } }
       end.to change(Webhook, :count).by(1)
 
-      expect(response).to be_redirect
+      expect(response)
+        .to be_redirect
     end
 
     it 'does not create a new webhook record with invalid data' do
@@ -42,8 +46,9 @@ describe Admin::WebhooksController do
         post :create, params: { webhook: { url: 'https://example.com/hook', events: [] } }
       end.to_not change(Webhook, :count)
 
-      expect(response).to have_http_status(:success)
-      expect(response).to render_template(:new)
+      expect(response)
+        .to have_http_status(:success)
+        .and render_template(:new)
     end
   end
 
@@ -54,8 +59,9 @@ describe Admin::WebhooksController do
       it 'returns http success and renders view' do
         get :show, params: { id: webhook.id }
 
-        expect(response).to have_http_status(:success)
-        expect(response).to render_template(:show)
+        expect(response)
+          .to have_http_status(:success)
+          .and render_template(:show)
       end
     end
 
@@ -63,8 +69,9 @@ describe Admin::WebhooksController do
       it 'returns http success and renders view' do
         get :edit, params: { id: webhook.id }
 
-        expect(response).to have_http_status(:success)
-        expect(response).to render_template(:edit)
+        expect(response)
+          .to have_http_status(:success)
+          .and render_template(:edit)
       end
     end
 
@@ -72,8 +79,11 @@ describe Admin::WebhooksController do
       it 'updates the record with valid data' do
         put :update, params: { id: webhook.id, webhook: { url: 'https://example.com/new/location' } }
 
-        expect(webhook.reload.url).to match(%r{new/location})
-        expect(response).to redirect_to(admin_webhook_path(webhook))
+        expect(webhook.reload.url)
+          .to match(%r{new/location})
+
+        expect(response)
+          .to redirect_to(admin_webhook_path(webhook))
       end
 
       it 'does not update the record with invalid data' do
@@ -81,8 +91,9 @@ describe Admin::WebhooksController do
           put :update, params: { id: webhook.id, webhook: { url: '' } }
         end.to_not change(webhook, :url)
 
-        expect(response).to have_http_status(:success)
-        expect(response).to render_template(:edit)
+        expect(response)
+          .to have_http_status(:success)
+          .and render_template(:edit)
       end
     end
 
@@ -90,8 +101,11 @@ describe Admin::WebhooksController do
       it 'enables the webhook' do
         post :enable, params: { id: webhook.id }
 
-        expect(webhook.reload).to be_enabled
-        expect(response).to redirect_to(admin_webhook_path(webhook))
+        expect(webhook.reload)
+          .to be_enabled
+
+        expect(response)
+          .to redirect_to(admin_webhook_path(webhook))
       end
     end
 
@@ -99,8 +113,11 @@ describe Admin::WebhooksController do
       it 'disables the webhook' do
         post :disable, params: { id: webhook.id }
 
-        expect(webhook.reload).to_not be_enabled
-        expect(response).to redirect_to(admin_webhook_path(webhook))
+        expect(webhook.reload)
+          .to_not be_enabled
+
+        expect(response)
+          .to redirect_to(admin_webhook_path(webhook))
       end
     end
 
@@ -110,7 +127,8 @@ describe Admin::WebhooksController do
           delete :destroy, params: { id: webhook.id }
         end.to change(Webhook, :count).by(-1)
 
-        expect(response).to redirect_to(admin_webhooks_path)
+        expect(response)
+          .to redirect_to(admin_webhooks_path)
       end
     end
   end


### PR DESCRIPTION
In the spirit of https://github.com/mastodon/mastodon/pull/27875 and other controller spec performance improvements, this does a few things within the `spec/controllers/admin` area:

- Like that last one, this looks for things which lower the `RSpec/MultipleExpectations` number and uses different matchers to DRY up various expectations
- There were some cases where we were calling `subject` multiple times within an example (essentially repeating a setup block) ... where I found these and they could be easily changed to one call, I did that. Not sure I got every one, but probably close.
- Where there were multiple expectations against the same `response`, consolidated them into fewer examples to avoid running setup multiple times.
- Small handful of refactor/tidy/naming improvements where I stumbled across them working on the other stuff. Various style consistency changes where I saw them as well.

Overall, reduced from 270 to 234 examples, speed up from ~28s to ~25s; but coverage stays the same vs main.
