### PR TITLE
Speedup and style cleanup through `spec/controllers/settings/*` specs

### DIFF
--- a/spec/controllers/settings/aliases_controller_spec.rb
+++ b/spec/controllers/settings/aliases_controller_spec.rb
@@ -13,13 +13,17 @@ describe Settings::AliasesController do
   end
 
   describe 'GET #index' do
-    before do
-      get :index
-    end
-
     it 'returns http success with private cache control headers', :aggregate_failures do
-      expect(response).to have_http_status(200)
-      expect(response.headers['Cache-Control']).to include('private, no-store')
+      get :index
+
+      expect(response)
+        .to have_http_status(200)
+        .and render_template(:index)
+        .and have_attributes(
+          headers: hash_including(
+            'Cache-Control' => include('private, no-store')
+          )
+        )
     end
   end
 
@@ -32,7 +36,8 @@ describe Settings::AliasesController do
           post :create, params: { account_alias: { acct: 'new@example.com' } }
         end.to change(AccountAlias, :count).by(1)
 
-        expect(response).to redirect_to(settings_aliases_path)
+        expect(response)
+          .to redirect_to(settings_aliases_path)
       end
     end
 
@@ -42,7 +47,8 @@ describe Settings::AliasesController do
           post :create, params: { account_alias: { acct: 'format-wrong' } }
         end.to_not change(AccountAlias, :count)
 
-        expect(response).to have_http_status(200)
+        expect(response)
+          .to have_http_status(200)
       end
     end
   end
@@ -57,8 +63,11 @@ describe Settings::AliasesController do
     it 'removes an alias' do
       delete :destroy, params: { id: account_alias.id }
 
-      expect(response).to redirect_to(settings_aliases_path)
-      expect { account_alias.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect(response)
+        .to redirect_to(settings_aliases_path)
+
+      expect { account_alias.reload }
+        .to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 

--- a/spec/controllers/settings/applications_controller_spec.rb
+++ b/spec/controllers/settings/applications_controller_spec.rb
@@ -13,36 +13,49 @@ describe Settings::ApplicationsController do
   end
 
   describe 'GET #index' do
-    before do
-      Fabricate(:application)
-      get :index
-    end
+    before { Fabricate(:application) }
 
     it 'returns http success with private cache control headers', :aggregate_failures do
-      expect(response).to have_http_status(200)
-      expect(response.headers['Cache-Control']).to include('private, no-store')
+      get :index
+
+      expect(response)
+        .to have_http_status(200)
+        .and render_template(:index)
+        .and have_attributes(
+          headers: hash_including(
+            'Cache-Control' => include('private, no-store')
+          )
+        )
     end
   end
 
   describe 'GET #show' do
     it 'returns http success' do
       get :show, params: { id: app.id }
-      expect(response).to have_http_status(200)
-      expect(assigns[:application]).to eql(app)
+
+      expect(response)
+        .to have_http_status(200)
+
+      expect(assigns[:application])
+        .to eql(app)
     end
 
     it 'returns 404 if you dont own app' do
       app.update!(owner: nil)
 
       get :show, params: { id: app.id }
-      expect(response).to have_http_status 404
+
+      expect(response)
+        .to have_http_status 404
     end
   end
 
   describe 'GET #new' do
     it 'returns http success' do
       get :new
-      expect(response).to have_http_status(200)
+
+      expect(response)
+        .to have_http_status(200)
     end
   end
 
@@ -60,8 +73,11 @@ describe Settings::ApplicationsController do
       end
 
       it 'creates an entry in the database', :aggregate_failures do
-        expect { subject }.to change(Doorkeeper::Application, :count)
-        expect(response).to redirect_to(settings_applications_path)
+        expect { subject }
+          .to change(Doorkeeper::Application, :count)
+
+        expect(response)
+          .to redirect_to(settings_applications_path)
       end
     end
 
@@ -79,7 +95,8 @@ describe Settings::ApplicationsController do
 
       it 'creates an entry in the database', :aggregate_failures do
         expect { subject }.to change(Doorkeeper::Application, :count)
-        expect(response).to redirect_to(settings_applications_path)
+        expect(response)
+          .to redirect_to(settings_applications_path)
       end
     end
 
@@ -96,33 +113,25 @@ describe Settings::ApplicationsController do
       end
 
       it 'returns http success and renders form', :aggregate_failures do
-        expect(response).to have_http_status(200)
-        expect(response).to render_template(:new)
+        expect(response)
+          .to have_http_status(200)
+          .and render_template(:new)
       end
     end
   end
 
   describe 'PATCH #update' do
     context 'when success' do
-      subject do
+      it 'updates existing application' do
         patch :update, params: {
           id: app.id,
-          doorkeeper_application: opts,
+          doorkeeper_application: { website: 'https://foo.bar/' },
         }
-        response
-      end
 
-      let(:opts) do
-        {
-          website: 'https://foo.bar/',
-        }
-      end
-
-      it 'updates existing application' do
-        subject
-
-        expect(app.reload.website).to eql(opts[:website])
-        expect(response).to redirect_to(settings_application_path(app))
+        expect(app.reload.website)
+          .to eql('https://foo.bar/')
+        expect(response)
+          .to redirect_to(settings_application_path(app))
       end
     end
 
@@ -140,20 +149,22 @@ describe Settings::ApplicationsController do
       end
 
       it 'returns http success and renders form', :aggregate_failures do
-        expect(response).to have_http_status(200)
-        expect(response).to render_template(:show)
+        expect(response)
+          .to have_http_status(200)
+          .and render_template(:show)
       end
     end
   end
 
   describe 'destroy' do
-    before do
-      post :destroy, params: { id: app.id }
-    end
-
     it 'redirects back to applications page and removes the app' do
-      expect(response).to redirect_to(settings_applications_path)
-      expect(Doorkeeper::Application.find_by(id: app.id)).to be_nil
+      post :destroy, params: { id: app.id }
+
+      expect(response)
+        .to redirect_to(settings_applications_path)
+
+      expect(Doorkeeper::Application.find_by(id: app.id))
+        .to be_nil
     end
   end
 
@@ -164,7 +175,8 @@ describe Settings::ApplicationsController do
       expect(token).to_not be_nil
       post :regenerate, params: { id: app.id }
 
-      expect(user.token_for_app(app)).to_not eql(token)
+      expect(user.token_for_app(app))
+        .to_not eql(token)
     end
   end
 end

--- a/spec/controllers/settings/exports/blocked_accounts_controller_spec.rb
+++ b/spec/controllers/settings/exports/blocked_accounts_controller_spec.rb
@@ -6,14 +6,19 @@ describe Settings::Exports::BlockedAccountsController do
   render_views
 
   describe 'GET #index' do
-    it 'returns a csv of the blocking accounts' do
-      user = Fabricate(:user)
+    let(:user) { Fabricate(:user) }
+
+    before do
       user.account.block!(Fabricate(:account, username: 'username', domain: 'domain'))
 
       sign_in user, scope: :user
+    end
+
+    it 'returns a csv of the blocking accounts' do
       get :index, format: :csv
 
-      expect(response.body).to eq "username@domain\n"
+      expect(response.body)
+        .to eq "username@domain\n"
     end
   end
 end

--- a/spec/controllers/settings/exports/blocked_domains_controller_spec.rb
+++ b/spec/controllers/settings/exports/blocked_domains_controller_spec.rb
@@ -6,15 +6,20 @@ describe Settings::Exports::BlockedDomainsController do
   render_views
 
   describe 'GET #index' do
-    it 'returns a csv of the domains' do
-      account = Fabricate(:account, domain: 'example.com')
-      user = Fabricate(:user, account: account)
+    let(:user) { Fabricate(:user, account: account) }
+    let(:account) { Fabricate(:account, domain: 'example.com') }
+
+    before do
       Fabricate(:account_domain_block, domain: 'example.com', account: account)
 
       sign_in user, scope: :user
+    end
+
+    it 'returns a csv of the domains' do
       get :index, format: :csv
 
-      expect(response.body).to eq "example.com\n"
+      expect(response.body)
+        .to eq "example.com\n"
     end
   end
 end

--- a/spec/controllers/settings/exports/bookmarks_controller_spec.rb
+++ b/spec/controllers/settings/exports/bookmarks_controller_spec.rb
@@ -12,13 +12,14 @@ describe Settings::Exports::BookmarksController do
   describe 'GET #index' do
     before do
       user.account.bookmarks.create!(status: status)
+      sign_in user, scope: :user
     end
 
     it 'returns a csv of the bookmarked toots' do
-      sign_in user, scope: :user
       get :index, format: :csv
 
-      expect(response.body).to eq "https://foo.bar/statuses/1312\n"
+      expect(response.body)
+        .to eq "https://foo.bar/statuses/1312\n"
     end
   end
 end

--- a/spec/controllers/settings/exports/following_accounts_controller_spec.rb
+++ b/spec/controllers/settings/exports/following_accounts_controller_spec.rb
@@ -6,14 +6,27 @@ describe Settings::Exports::FollowingAccountsController do
   render_views
 
   describe 'GET #index' do
-    it 'returns a csv of the following accounts' do
-      user = Fabricate(:user)
-      user.account.follow!(Fabricate(:account, username: 'username', domain: 'domain'))
+    let(:user) { Fabricate(:user) }
 
+    before do
+      user.account.follow!(Fabricate(:account, username: 'username', domain: 'domain'))
       sign_in user, scope: :user
+    end
+
+    it 'returns a csv of the following accounts' do
       get :index, format: :csv
 
-      expect(response.body).to eq "Account address,Show boosts,Notify on new posts,Languages\nusername@domain,true,false,\n"
+      expect(response.body)
+        .to eq expected_csv_body
+    end
+
+    private
+
+    def expected_csv_body
+      <<~CSV
+        Account address,Show boosts,Notify on new posts,Languages
+        username@domain,true,false,
+      CSV
     end
   end
 end

--- a/spec/controllers/settings/exports/lists_controller_spec.rb
+++ b/spec/controllers/settings/exports/lists_controller_spec.rb
@@ -6,16 +6,20 @@ describe Settings::Exports::ListsController do
   render_views
 
   describe 'GET #index' do
-    it 'returns a csv of the domains' do
-      account = Fabricate(:account)
-      user = Fabricate(:user, account: account)
-      list = Fabricate(:list, account: account, title: 'The List')
-      Fabricate(:list_account, list: list, account: account)
+    let(:account) { Fabricate(:account) }
+    let(:user) { Fabricate(:user, account: account) }
+    let(:list) { Fabricate(:list, account: account, title: 'The List') }
 
+    before do
+      Fabricate(:list_account, list: list, account: account)
       sign_in user, scope: :user
+    end
+
+    it 'returns a csv of the domains' do
       get :index, format: :csv
 
-      expect(response.body).to match 'The List'
+      expect(response.body)
+        .to match 'The List'
     end
   end
 end

--- a/spec/controllers/settings/exports/muted_accounts_controller_spec.rb
+++ b/spec/controllers/settings/exports/muted_accounts_controller_spec.rb
@@ -6,14 +6,27 @@ describe Settings::Exports::MutedAccountsController do
   render_views
 
   describe 'GET #index' do
-    it 'returns a csv of the muting accounts' do
-      user = Fabricate(:user)
-      user.account.mute!(Fabricate(:account, username: 'username', domain: 'domain'))
+    let(:user) { Fabricate(:user) }
 
+    before do
+      user.account.mute!(Fabricate(:account, username: 'username', domain: 'domain'))
       sign_in user, scope: :user
+    end
+
+    it 'returns a csv of the muting accounts' do
       get :index, format: :csv
 
-      expect(response.body).to eq "Account address,Hide notifications\nusername@domain,true\n"
+      expect(response.body)
+        .to eq expected_csv_body
+    end
+
+    private
+
+    def expected_csv_body
+      <<~CSV
+        Account address,Hide notifications
+        username@domain,true
+      CSV
     end
   end
 end

--- a/spec/controllers/settings/featured_tags_controller_spec.rb
+++ b/spec/controllers/settings/featured_tags_controller_spec.rb
@@ -5,16 +5,13 @@ require 'rails_helper'
 describe Settings::FeaturedTagsController do
   render_views
 
-  shared_examples 'authenticate user' do
-    it 'redirects to sign_in page' do
-      expect(subject).to redirect_to new_user_session_path
-    end
-  end
-
   context 'when user is not signed in' do
-    subject { post :create }
+    it 'redirects to sign_in page' do
+      post :create
 
-    it_behaves_like 'authenticate user'
+      expect(subject)
+        .to redirect_to new_user_session_path
+    end
   end
 
   context 'when user is signed in' do
@@ -23,13 +20,13 @@ describe Settings::FeaturedTagsController do
     before { sign_in user, scope: :user }
 
     describe 'POST #create' do
-      subject { post :create, params: { featured_tag: params } }
-
       context 'when parameter is valid' do
         let(:params) { { name: 'test' } }
 
         it 'creates featured tag' do
-          expect { subject }.to change { user.account.featured_tags.count }.by(1)
+          expect { post :create, params: { featured_tag: params } }
+            .to change { user.account.featured_tags.count }
+            .by(1)
         end
       end
 
@@ -37,7 +34,10 @@ describe Settings::FeaturedTagsController do
         let(:params) { { name: 'test, #foo !bleh' } }
 
         it 'renders new' do
-          expect(subject).to render_template :index
+          post :create, params: { featured_tag: params }
+
+          expect(response)
+            .to render_template :index
         end
       end
     end
@@ -46,7 +46,8 @@ describe Settings::FeaturedTagsController do
       it 'responds with success' do
         get :index
 
-        expect(response).to have_http_status(200)
+        expect(response)
+          .to have_http_status(200)
       end
     end
 
@@ -56,8 +57,11 @@ describe Settings::FeaturedTagsController do
       it 'removes the featured tag' do
         delete :destroy, params: { id: featured_tag.id }
 
-        expect(response).to redirect_to(settings_featured_tags_path)
-        expect { featured_tag.reload }.to raise_error(ActiveRecord::RecordNotFound)
+        expect(response)
+          .to redirect_to(settings_featured_tags_path)
+
+        expect { featured_tag.reload }
+          .to raise_error(ActiveRecord::RecordNotFound)
       end
     end
   end

--- a/spec/controllers/settings/login_activities_controller_spec.rb
+++ b/spec/controllers/settings/login_activities_controller_spec.rb
@@ -12,13 +12,17 @@ describe Settings::LoginActivitiesController do
   end
 
   describe 'GET #index' do
-    before do
-      get :index
-    end
-
     it 'returns http success with private cache control headers', :aggregate_failures do
-      expect(response).to have_http_status(200)
-      expect(response.headers['Cache-Control']).to include('private, no-store')
+      get :index
+
+      expect(response)
+        .to have_http_status(200)
+        .and render_template(:index)
+        .and have_attributes(
+          headers: hash_including(
+            'Cache-Control' => include('private, no-store')
+          )
+        )
     end
   end
 end

--- a/spec/controllers/settings/migration/redirects_controller_spec.rb
+++ b/spec/controllers/settings/migration/redirects_controller_spec.rb
@@ -12,13 +12,16 @@ describe Settings::Migration::RedirectsController do
   end
 
   describe 'GET #new' do
-    before do
-      get :new
-    end
-
     it 'returns http success with private cache control headers', :aggregate_failures do
-      expect(response).to have_http_status(200)
-      expect(response.headers['Cache-Control']).to include('private, no-store')
+      get :new
+
+      expect(response)
+        .to have_http_status(200)
+        .and have_attributes(
+          headers: hash_including(
+            'Cache-Control' => include('private, no-store')
+          )
+        )
     end
   end
 
@@ -29,7 +32,8 @@ describe Settings::Migration::RedirectsController do
       it 'redirects to the settings migration path' do
         post :create, params: { form_redirect: { acct: 'new@host.com', current_password: 'testtest' } }
 
-        expect(response).to redirect_to(settings_migration_path)
+        expect(response)
+          .to redirect_to(settings_migration_path)
       end
     end
 
@@ -37,8 +41,9 @@ describe Settings::Migration::RedirectsController do
       it 'returns success and renders the new page' do
         post :create, params: { form_redirect: { acct: '' } }
 
-        expect(response).to have_http_status(200)
-        expect(response).to render_template(:new)
+        expect(response)
+          .to have_http_status(200)
+          .and render_template(:new)
       end
     end
   end
@@ -53,8 +58,11 @@ describe Settings::Migration::RedirectsController do
     it 'resets the account and sends an update' do
       delete :destroy
 
-      expect(response).to redirect_to(settings_migration_path)
-      expect(user.account.reload.moved_to_account).to be_nil
+      expect(response)
+        .to redirect_to(settings_migration_path)
+
+      expect(user.account.reload.moved_to_account)
+        .to be_nil
     end
   end
 

--- a/spec/controllers/settings/migrations_controller_spec.rb
+++ b/spec/controllers/settings/migrations_controller_spec.rb
@@ -5,22 +5,16 @@ require 'rails_helper'
 describe Settings::MigrationsController do
   render_views
 
-  shared_examples 'authenticate user' do
-    it 'redirects to sign_in page' do
-      expect(subject).to redirect_to new_user_session_path
-    end
-  end
-
   describe 'GET #show' do
-    context 'when user is not sign in' do
-      subject { get :show }
+    context 'when user is not signed in' do
+      it 'redirects to sign_in page' do
+        get :show
 
-      it_behaves_like 'authenticate user'
+        expect(subject).to redirect_to new_user_session_path
+      end
     end
 
-    context 'when user is sign in' do
-      subject { get :show }
-
+    context 'when user is signed in' do
       let(:user) { Fabricate(:account, moved_to_account: moved_to_account).user }
 
       before { sign_in user, scope: :user }
@@ -29,8 +23,11 @@ describe Settings::MigrationsController do
         let(:moved_to_account) { nil }
 
         it 'renders show page' do
-          expect(subject).to have_http_status 200
-          expect(subject).to render_template :show
+          get :show
+
+          expect(response)
+            .to have_http_status(200)
+            .and render_template(:show)
         end
       end
 
@@ -38,8 +35,11 @@ describe Settings::MigrationsController do
         let(:moved_to_account) { Fabricate(:account) }
 
         it 'renders show page' do
-          expect(subject).to have_http_status 200
-          expect(subject).to render_template :show
+          get :show
+
+          expect(response)
+            .to have_http_status(200)
+            .and render_template(:show)
         end
       end
     end
@@ -47,9 +47,12 @@ describe Settings::MigrationsController do
 
   describe 'POST #create' do
     context 'when user is not sign in' do
-      subject { post :create }
+      it 'redirects to sign_in page' do
+        post :create
 
-      it_behaves_like 'authenticate user'
+        expect(subject)
+          .to redirect_to new_user_session_path
+      end
     end
 
     context 'when user is signed in' do
@@ -63,8 +66,12 @@ describe Settings::MigrationsController do
         let(:acct) { Fabricate(:account, also_known_as: [ActivityPub::TagManager.instance.uri_for(user.account)]) }
 
         it 'updates moved to account' do
-          expect(subject).to redirect_to settings_migration_path
-          expect(user.account.reload.moved_to_account_id).to eq acct.id
+          subject
+
+          expect(response)
+            .to redirect_to settings_migration_path
+          expect(user.account.reload.moved_to_account_id)
+            .to eq acct.id
         end
       end
 
@@ -75,7 +82,8 @@ describe Settings::MigrationsController do
           subject
 
           expect(user.account.reload.moved_to_account_id).to be_nil
-          expect(response).to render_template :show
+          expect(response)
+            .to render_template :show
         end
       end
 
@@ -86,7 +94,8 @@ describe Settings::MigrationsController do
           subject
 
           expect(user.account.reload.moved_to_account_id).to be_nil
-          expect(response).to render_template :show
+          expect(response)
+            .to render_template :show
         end
       end
 
@@ -102,7 +111,8 @@ describe Settings::MigrationsController do
           subject
 
           expect(user.account.reload.moved_to_account_id).to be_nil
-          expect(response).to render_template :show
+          expect(response)
+            .to render_template :show
         end
       end
     end

--- a/spec/controllers/settings/pictures_controller_spec.rb
+++ b/spec/controllers/settings/pictures_controller_spec.rb
@@ -15,7 +15,9 @@ describe Settings::PicturesController do
     context 'with invalid picture id' do
       it 'returns http bad request' do
         delete :destroy, params: { id: 'invalid' }
-        expect(response).to have_http_status(400)
+
+        expect(response)
+          .to have_http_status(400)
       end
     end
 
@@ -29,8 +31,11 @@ describe Settings::PicturesController do
 
         it 'updates the account' do
           delete :destroy, params: { id: 'avatar' }
-          expect(response).to redirect_to(settings_profile_path)
-          expect(response).to have_http_status(303)
+
+          expect(response)
+            .to redirect_to(settings_profile_path)
+            .and have_http_status(303)
+
           expect(service).to have_received(:call).with(user.account, { 'avatar' => nil, 'avatar_remote_url' => '' })
         end
       end
@@ -44,7 +49,9 @@ describe Settings::PicturesController do
 
         it 'redirects to profile' do
           delete :destroy, params: { id: 'avatar' }
-          expect(response).to redirect_to(settings_profile_path)
+
+          expect(response)
+            .to redirect_to(settings_profile_path)
         end
       end
     end

--- a/spec/controllers/settings/preferences/appearance_controller_spec.rb
+++ b/spec/controllers/settings/preferences/appearance_controller_spec.rb
@@ -12,13 +12,16 @@ describe Settings::Preferences::AppearanceController do
   end
 
   describe 'GET #show' do
-    before do
-      get :show
-    end
-
     it 'returns http success with private cache control headers', :aggregate_failures do
-      expect(response).to have_http_status(200)
-      expect(response.headers['Cache-Control']).to include('private, no-store')
+      get :show
+
+      expect(response)
+        .to have_http_status(200)
+        .and have_attributes(
+          headers: hash_including(
+            'Cache-Control' => include('private, no-store')
+          )
+        )
     end
   end
 
@@ -26,7 +29,17 @@ describe Settings::Preferences::AppearanceController do
     it 'redirects correctly' do
       put :update, params: { user: { setting_theme: 'contrast' } }
 
-      expect(response).to redirect_to(settings_preferences_appearance_path)
+      expect(response)
+        .to redirect_to(settings_preferences_appearance_path)
+    end
+
+    it 'renders show on failure' do
+      allow(user).to receive(:update).and_return(false)
+      allow(controller).to receive(:current_user).and_return(user)
+      put :update, params: { user: { setting_theme: 'contrast' } }
+
+      expect(response)
+        .to render_template('preferences/appearance/show')
     end
   end
 end

--- a/spec/controllers/settings/preferences/base_controller_spec.rb
+++ b/spec/controllers/settings/preferences/base_controller_spec.rb
@@ -5,7 +5,14 @@ require 'rails_helper'
 describe Settings::Preferences::BaseController do
   describe 'after_update_redirect_path' do
     it 'raises error when called' do
-      expect { described_class.new.send(:after_update_redirect_path) }.to raise_error(/Override/)
+      expect { redirect_path_callback }
+        .to raise_error(/Override/)
+    end
+
+    private
+
+    def redirect_path_callback
+      described_class.new.send(:after_update_redirect_path)
     end
   end
 end

--- a/spec/controllers/settings/profiles_controller_spec.rb
+++ b/spec/controllers/settings/profiles_controller_spec.rb
@@ -13,39 +13,56 @@ RSpec.describe Settings::ProfilesController do
   end
 
   describe 'GET #show' do
-    before do
-      get :show
-    end
-
     it 'returns http success with private cache control headers', :aggregate_failures do
-      expect(response).to have_http_status(200)
-      expect(response.headers['Cache-Control']).to include('private, no-store')
+      get :show
+
+      expect(response)
+        .to have_http_status(200)
+        .and render_template(:show)
+        .and have_attributes(
+          headers: hash_including(
+            'Cache-Control' => include('private, no-store')
+          )
+        )
     end
   end
 
   describe 'PUT #update' do
     before do
       user.account.update(display_name: 'Old name')
+      allow(ActivityPub::UpdateDistributionWorker).to receive(:perform_async)
     end
 
     it 'updates the user profile' do
-      allow(ActivityPub::UpdateDistributionWorker).to receive(:perform_async)
       put :update, params: { account: { display_name: 'New name' } }
-      expect(account.reload.display_name).to eq 'New name'
-      expect(response).to redirect_to(settings_profile_path)
-      expect(ActivityPub::UpdateDistributionWorker).to have_received(:perform_async).with(account.id)
+
+      expect(account.reload.display_name)
+        .to eq 'New name'
+      expect(response)
+        .to redirect_to(settings_profile_path)
+      expect(ActivityPub::UpdateDistributionWorker)
+        .to have_received(:perform_async)
+        .with(account.id)
     end
   end
 
   describe 'PUT #update with new profile image' do
-    it 'updates profile image' do
+    before do
       allow(ActivityPub::UpdateDistributionWorker).to receive(:perform_async)
+    end
+
+    it 'updates profile image' do
       expect(account.avatar.instance.avatar_file_name).to be_nil
 
       put :update, params: { account: { avatar: fixture_file_upload('avatar.gif', 'image/gif') } }
-      expect(response).to redirect_to(settings_profile_path)
-      expect(account.reload.avatar.instance.avatar_file_name).to_not be_nil
-      expect(ActivityPub::UpdateDistributionWorker).to have_received(:perform_async).with(account.id)
+
+      expect(response)
+        .to redirect_to(settings_profile_path)
+      expect(account.reload.avatar.instance.avatar_file_name)
+        .to_not be_nil
+      expect(ActivityPub::UpdateDistributionWorker)
+        .to have_received(:perform_async)
+        .with(account.id)
     end
   end
 end

--- a/spec/controllers/settings/sessions_controller_spec.rb
+++ b/spec/controllers/settings/sessions_controller_spec.rb
@@ -11,13 +11,14 @@ describe Settings::SessionsController do
   before { sign_in user, scope: :user }
 
   describe 'DELETE #destroy' do
-    subject { delete :destroy, params: { id: id } }
-
     context 'when session activation exists' do
       let(:id) { session_activation.id }
 
       it 'destroys session activation' do
-        expect(subject).to redirect_to edit_user_registration_path
+        delete :destroy, params: { id: id }
+
+        expect(response)
+          .to redirect_to edit_user_registration_path
         expect(SessionActivation.find_by(id: id)).to be_nil
       end
     end
@@ -26,7 +27,10 @@ describe Settings::SessionsController do
       let(:id) { session_activation.id + 1000 }
 
       it 'destroys session activation' do
-        expect(subject).to have_http_status 404
+        delete :destroy, params: { id: id }
+
+        expect(response)
+          .to have_http_status 404
       end
     end
   end

--- a/spec/controllers/settings/two_factor_authentication/otp_authentication_controller_spec.rb
+++ b/spec/controllers/settings/two_factor_authentication/otp_authentication_controller_spec.rb
@@ -21,7 +21,8 @@ describe Settings::TwoFactorAuthentication::OtpAuthenticationController do
         it 'redirects to two factor authentication methods list page' do
           get :show
 
-          expect(response).to redirect_to settings_two_factor_authentication_methods_path
+          expect(response)
+            .to redirect_to settings_two_factor_authentication_methods_path
         end
       end
 
@@ -33,7 +34,8 @@ describe Settings::TwoFactorAuthentication::OtpAuthenticationController do
         it 'returns http success' do
           get :show
 
-          expect(response).to have_http_status(200)
+          expect(response)
+            .to have_http_status(200)
         end
       end
     end
@@ -42,7 +44,8 @@ describe Settings::TwoFactorAuthentication::OtpAuthenticationController do
       it 'redirects' do
         get :show
 
-        expect(response).to redirect_to new_user_session_path
+        expect(response)
+          .to redirect_to new_user_session_path
       end
     end
   end
@@ -65,7 +68,8 @@ describe Settings::TwoFactorAuthentication::OtpAuthenticationController do
             end.to not_change { user.reload.otp_secret }
                .and(change { session[:new_otp_secret] })
 
-            expect(response).to redirect_to(new_settings_two_factor_authentication_confirmation_path)
+            expect(response)
+              .to redirect_to(new_settings_two_factor_authentication_confirmation_path)
           end
         end
       end
@@ -82,7 +86,8 @@ describe Settings::TwoFactorAuthentication::OtpAuthenticationController do
             end.to not_change { user.reload.otp_secret }
                .and(change { session[:new_otp_secret] })
 
-            expect(response).to redirect_to(new_settings_two_factor_authentication_confirmation_path)
+            expect(response)
+              .to redirect_to(new_settings_two_factor_authentication_confirmation_path)
           end
         end
       end
@@ -92,7 +97,8 @@ describe Settings::TwoFactorAuthentication::OtpAuthenticationController do
       it 'redirects to login' do
         get :show
 
-        expect(response).to redirect_to new_user_session_path
+        expect(response)
+          .to redirect_to new_user_session_path
       end
     end
   end

--- a/spec/controllers/settings/two_factor_authentication/recovery_codes_controller_spec.rb
+++ b/spec/controllers/settings/two_factor_authentication/recovery_codes_controller_spec.rb
@@ -6,24 +6,34 @@ describe Settings::TwoFactorAuthentication::RecoveryCodesController do
   render_views
 
   describe 'POST #create' do
-    it 'updates the codes and shows them on a view when signed in' do
-      user = Fabricate(:user)
-      otp_backup_codes = user.generate_otp_backup_codes!
-      allow(user).to receive(:generate_otp_backup_codes!).and_return(otp_backup_codes)
-      allow(controller).to receive(:current_user).and_return(user)
+    context 'when signed in' do
+      let!(:user) { Fabricate(:user) }
+      let!(:otp_backup_codes) { user.generate_otp_backup_codes! }
 
-      sign_in user, scope: :user
-      post :create, session: { challenge_passed_at: Time.now.utc }
+      before do
+        allow(user).to receive(:generate_otp_backup_codes!).and_return(otp_backup_codes)
+        allow(controller).to receive(:current_user).and_return(user)
+        sign_in user, scope: :user
+      end
 
-      expect(assigns(:recovery_codes)).to eq otp_backup_codes
-      expect(flash[:notice]).to eq 'Recovery codes successfully regenerated'
-      expect(response).to have_http_status(200)
-      expect(response).to render_template(:index)
+      it 'updates the codes and shows them on a view when signed in' do
+        post :create, session: { challenge_passed_at: Time.now.utc }
+
+        expect(assigns(:recovery_codes))
+          .to eq otp_backup_codes
+        expect(flash[:notice])
+          .to eq I18n.t('two_factor_authentication.recovery_codes_regenerated')
+        expect(response)
+          .to have_http_status(200)
+          .and render_template(:index)
+      end
     end
 
     it 'redirects when not signed in' do
       post :create
-      expect(response).to redirect_to '/auth/sign_in'
+
+      expect(response)
+        .to redirect_to '/auth/sign_in'
     end
   end
 end

--- a/spec/controllers/settings/two_factor_authentication/webauthn_credentials_controller_spec.rb
+++ b/spec/controllers/settings/two_factor_authentication/webauthn_credentials_controller_spec.rb
@@ -28,7 +28,9 @@ describe Settings::TwoFactorAuthentication::WebauthnCredentialsController do
         it 'returns http success' do
           get :new
 
-          expect(response).to have_http_status(200)
+          expect(response)
+            .to have_http_status(200)
+            .and render_template(:new)
         end
       end
 
@@ -40,8 +42,11 @@ describe Settings::TwoFactorAuthentication::WebauthnCredentialsController do
         it 'requires otp enabled first' do
           get :new
 
-          expect(response).to redirect_to settings_two_factor_authentication_methods_path
-          expect(flash[:error]).to be_present
+          expect(response)
+            .to redirect_to settings_two_factor_authentication_methods_path
+
+          expect(flash[:error])
+            .to be_present
         end
       end
     end
@@ -67,7 +72,9 @@ describe Settings::TwoFactorAuthentication::WebauthnCredentialsController do
           it 'returns http success' do
             get :index
 
-            expect(response).to have_http_status(200)
+            expect(response)
+              .to have_http_status(200)
+              .and render_template(:index)
           end
         end
 
@@ -75,8 +82,10 @@ describe Settings::TwoFactorAuthentication::WebauthnCredentialsController do
           it 'redirects to 2FA methods list page' do
             get :index
 
-            expect(response).to redirect_to settings_two_factor_authentication_methods_path
-            expect(flash[:error]).to be_present
+            expect(response)
+              .to redirect_to settings_two_factor_authentication_methods_path
+            expect(flash[:error])
+              .to be_present
           end
         end
       end
@@ -89,8 +98,10 @@ describe Settings::TwoFactorAuthentication::WebauthnCredentialsController do
         it 'requires otp enabled first' do
           get :index
 
-          expect(response).to redirect_to settings_two_factor_authentication_methods_path
-          expect(flash[:error]).to be_present
+          expect(response)
+            .to redirect_to settings_two_factor_authentication_methods_path
+          expect(flash[:error])
+            .to be_present
         end
       end
     end
@@ -99,7 +110,8 @@ describe Settings::TwoFactorAuthentication::WebauthnCredentialsController do
       it 'redirects to login' do
         delete :index
 
-        expect(response).to redirect_to new_user_session_path
+        expect(response)
+          .to redirect_to new_user_session_path
       end
     end
   end
@@ -124,12 +136,18 @@ describe Settings::TwoFactorAuthentication::WebauthnCredentialsController do
           it 'includes existing credentials in list of excluded credentials', :aggregate_failures do
             expect { get :options }.to_not change(user, :webauthn_id)
 
-            expect(response).to have_http_status(200)
+            expect(response)
+              .to have_http_status(200)
 
-            expect(controller.session[:webauthn_challenge]).to be_present
+            expect(controller.session[:webauthn_challenge])
+              .to be_present
 
-            excluded_credentials_ids = response.parsed_body['excludeCredentials'].pluck('id')
-            expect(excluded_credentials_ids).to match_array(user.webauthn_credentials.pluck(:external_id))
+            expect(excluded_credentials_ids)
+              .to match_array(user.webauthn_credentials.pluck(:external_id))
+          end
+
+          def excluded_credentials_ids
+            response.parsed_body['excludeCredentials'].pluck('id')
           end
         end
 
@@ -137,9 +155,14 @@ describe Settings::TwoFactorAuthentication::WebauthnCredentialsController do
           it 'stores the challenge on the session and sets user webauthn_id', :aggregate_failures do
             get :options
 
-            expect(response).to have_http_status(200)
-            expect(controller.session[:webauthn_challenge]).to be_present
-            expect(user.reload.webauthn_id).to be_present
+            expect(response)
+              .to have_http_status(200)
+
+            expect(controller.session[:webauthn_challenge])
+              .to be_present
+
+            expect(user.reload.webauthn_id)
+              .to be_present
           end
         end
       end
@@ -152,8 +175,11 @@ describe Settings::TwoFactorAuthentication::WebauthnCredentialsController do
         it 'requires otp enabled first' do
           get :options
 
-          expect(response).to redirect_to settings_two_factor_authentication_methods_path
-          expect(flash[:error]).to be_present
+          expect(response)
+            .to redirect_to settings_two_factor_authentication_methods_path
+
+          expect(flash[:error])
+            .to be_present
         end
       end
     end
@@ -162,7 +188,8 @@ describe Settings::TwoFactorAuthentication::WebauthnCredentialsController do
       it 'redirects to login' do
         get :options
 
-        expect(response).to redirect_to new_user_session_path
+        expect(response)
+          .to redirect_to new_user_session_path
       end
     end
   end
@@ -200,10 +227,12 @@ describe Settings::TwoFactorAuthentication::WebauthnCredentialsController do
 
               expect do
                 post :create, params: { credential: new_webauthn_credential, nickname: nickname }
-              end.to change { user.webauthn_credentials.count }.by(1)
-                                                               .and not_change(user, :webauthn_id)
+              end.to change { user.webauthn_credentials.count }
+                .by(1)
+                .and not_change(user, :webauthn_id)
 
-              expect(response).to have_http_status(200)
+              expect(response)
+                .to have_http_status(200)
             end
           end
 
@@ -213,8 +242,11 @@ describe Settings::TwoFactorAuthentication::WebauthnCredentialsController do
 
               post :create, params: { credential: new_webauthn_credential, nickname: 'USB Key' }
 
-              expect(response).to have_http_status(422)
-              expect(flash[:error]).to be_present
+              expect(response)
+                .to have_http_status(422)
+
+              expect(flash[:error])
+                .to be_present
             end
           end
 
@@ -233,8 +265,10 @@ describe Settings::TwoFactorAuthentication::WebauthnCredentialsController do
 
               post :create, params: { credential: new_webauthn_credential, nickname: nickname }
 
-              expect(response).to have_http_status(422)
-              expect(flash[:error]).to be_present
+              expect(response)
+                .to have_http_status(422)
+              expect(flash[:error])
+                .to be_present
             end
           end
         end
@@ -260,7 +294,8 @@ describe Settings::TwoFactorAuthentication::WebauthnCredentialsController do
         it 'requires otp enabled first' do
           post :create, params: { credential: new_webauthn_credential, nickname: nickname }
 
-          expect(response).to redirect_to settings_two_factor_authentication_methods_path
+          expect(response)
+            .to redirect_to settings_two_factor_authentication_methods_path
           expect(flash[:error]).to be_present
         end
       end
@@ -270,7 +305,8 @@ describe Settings::TwoFactorAuthentication::WebauthnCredentialsController do
       it 'redirects to login' do
         post :create, params: { credential: new_webauthn_credential, nickname: nickname }
 
-        expect(response).to redirect_to new_user_session_path
+        expect(response)
+          .to redirect_to new_user_session_path
       end
     end
   end
@@ -298,8 +334,11 @@ describe Settings::TwoFactorAuthentication::WebauthnCredentialsController do
                 delete :destroy, params: { id: user.webauthn_credentials.take.id }
               end.to change { user.webauthn_credentials.count }.by(-1)
 
-              expect(response).to redirect_to settings_two_factor_authentication_methods_path
-              expect(flash[:success]).to be_present
+              expect(response)
+                .to redirect_to settings_two_factor_authentication_methods_path
+
+              expect(flash[:success])
+                .to be_present
             end
           end
         end
@@ -308,8 +347,10 @@ describe Settings::TwoFactorAuthentication::WebauthnCredentialsController do
           it 'redirects to 2FA methods list and shows flash error' do
             delete :destroy, params: { id: '1' }
 
-            expect(response).to redirect_to settings_two_factor_authentication_methods_path
-            expect(flash[:error]).to be_present
+            expect(response)
+              .to redirect_to settings_two_factor_authentication_methods_path
+            expect(flash[:error])
+              .to be_present
           end
         end
       end
@@ -318,8 +359,10 @@ describe Settings::TwoFactorAuthentication::WebauthnCredentialsController do
         it 'requires otp enabled first' do
           delete :destroy, params: { id: '1' }
 
-          expect(response).to redirect_to settings_two_factor_authentication_methods_path
-          expect(flash[:error]).to be_present
+          expect(response)
+            .to redirect_to settings_two_factor_authentication_methods_path
+          expect(flash[:error])
+            .to be_present
         end
       end
     end
@@ -328,7 +371,8 @@ describe Settings::TwoFactorAuthentication::WebauthnCredentialsController do
       it 'redirects to login' do
         delete :destroy, params: { id: '1' }
 
-        expect(response).to redirect_to new_user_session_path
+        expect(response)
+          .to redirect_to new_user_session_path
       end
     end
   end

--- a/spec/controllers/settings/two_factor_authentication_methods_controller_spec.rb
+++ b/spec/controllers/settings/two_factor_authentication_methods_controller_spec.rb
@@ -10,7 +10,8 @@ describe Settings::TwoFactorAuthenticationMethodsController do
       it 'redirects' do
         get :index
 
-        expect(response).to redirect_to '/auth/sign_in'
+        expect(response)
+          .to redirect_to '/auth/sign_in'
       end
     end
   end
@@ -26,23 +27,32 @@ describe Settings::TwoFactorAuthenticationMethodsController do
       describe 'when user has enabled otp' do
         before do
           user.update(otp_required_for_login: true)
-          get :index
         end
 
         it 'returns http success with private cache control headers', :aggregate_failures do
-          expect(response).to have_http_status(200)
-          expect(response.headers['Cache-Control']).to include('private, no-store')
+          get :index
+
+          expect(response)
+            .to have_http_status(200)
+            .and render_template(:index)
+            .and have_attributes(
+              headers: hash_including(
+                'Cache-Control' => include('private, no-store')
+              )
+            )
         end
       end
 
       describe 'when user has not enabled otp' do
         before do
           user.update(otp_required_for_login: false)
-          get :index
         end
 
         it 'redirects to enable otp' do
-          expect(response).to redirect_to(settings_otp_authentication_path)
+          get :index
+
+          expect(response)
+            .to redirect_to(settings_otp_authentication_path)
         end
       end
     end
@@ -56,8 +66,9 @@ describe Settings::TwoFactorAuthenticationMethodsController do
         it 'renders challenge page' do
           post :disable
 
-          expect(response).to have_http_status(200)
-          expect(response).to render_template('auth/challenges/new')
+          expect(response)
+            .to have_http_status(200)
+            .and render_template('auth/challenges/new')
         end
       end
 
@@ -70,8 +81,10 @@ describe Settings::TwoFactorAuthenticationMethodsController do
         it 'redirects to settings page' do
           post :disable, session: { challenge_passed_at: 10.minutes.ago }
 
-          expect(UserMailer).to have_received(:two_factor_disabled).with(user)
-          expect(response).to redirect_to(settings_otp_authentication_path)
+          expect(UserMailer)
+            .to have_received(:two_factor_disabled).with(user)
+          expect(response)
+            .to redirect_to(settings_otp_authentication_path)
         end
       end
     end


### PR DESCRIPTION
Similar approach as https://github.com/mastodon/mastodon/pull/27896, but for the `spec/settings` group.

The spec/settings group already had 100% coverage, execpt for the deletes controller. I rounded that out while doing this and that one is now at 100% as well.

The rest is similar in spirit to last few of these.