### PR TITLE
Add `API::Errors` concern for API controllers and add i18n values for strings

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -111,10 +111,4 @@ class Api::BaseController < ApplicationController
   def respond_with_error(code)
     render json: { error: Rack::Utils::HTTP_STATUS_CODES[code] }, status: code
   end
-
-  def error_message(key)
-    with_options scope: [:api, :errors] do
-      t(key)
-    end
-  end
 end

--- a/app/controllers/concerns/api/error_handling.rb
+++ b/app/controllers/concerns/api/error_handling.rb
@@ -49,4 +49,12 @@ module Api::ErrorHandling
       render json: { error: e.to_s }, status: 400
     end
   end
+
+  private
+
+  def error_message(key)
+    with_options scope: [:api, :errors] do
+      t(key)
+    end
+  end
 end

--- a/app/controllers/concerns/api/error_handling.rb
+++ b/app/controllers/concerns/api/error_handling.rb
@@ -53,8 +53,6 @@ module Api::ErrorHandling
   private
 
   def error_message(key)
-    with_options scope: [:api, :errors] do
-      t(key)
-    end
+    t("api.errors.#{key}")
   end
 end

--- a/app/controllers/concerns/api/error_handling.rb
+++ b/app/controllers/concerns/api/error_handling.rb
@@ -9,36 +9,36 @@ module Api::ErrorHandling
     end
 
     rescue_from ActiveRecord::RecordNotUnique do
-      render json: { error: 'Duplicate record' }, status: 422
+      render json: { error: error_message(:record_not_unique) }, status: 422
     end
 
     rescue_from Date::Error do
-      render json: { error: 'Invalid date supplied' }, status: 422
+      render json: { error: error_message(:invalid_date) }, status: 422
     end
 
     rescue_from ActiveRecord::RecordNotFound do
-      render json: { error: 'Record not found' }, status: 404
+      render json: { error: error_message(:record_not_found) }, status: 404
     end
 
     rescue_from HTTP::Error, Mastodon::UnexpectedResponseError do
-      render json: { error: 'Remote data could not be fetched' }, status: 503
+      render json: { error: error_message(:remote_data_fetch) }, status: 503
     end
 
     rescue_from OpenSSL::SSL::SSLError do
-      render json: { error: 'Remote SSL certificate could not be verified' }, status: 503
+      render json: { error: error_message(:ssl_error) }, status: 503
     end
 
     rescue_from Mastodon::NotPermittedError do
-      render json: { error: 'This action is not allowed' }, status: 403
+      render json: { error: error_message(:not_permitted) }, status: 403
     end
 
     rescue_from Seahorse::Client::NetworkingError do |e|
       Rails.logger.warn "Storage server error: #{e}"
-      render json: { error: 'There was a temporary problem serving your request, please try again' }, status: 503
+      render json: { error: error_message(:temporary_problem) }, status: 503
     end
 
     rescue_from Mastodon::RaceConditionError, Stoplight::Error::RedLight do
-      render json: { error: 'There was a temporary problem serving your request, please try again' }, status: 503
+      render json: { error: error_message(:temporary_problem) }, status: 503
     end
 
     rescue_from Mastodon::RateLimitExceededError do

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -48,7 +48,6 @@ ignore_unused:
   - 'activemodel.errors.*'
   - 'activerecord.attributes.*'
   - 'activerecord.errors.*'
-  - 'api.errors.*'
   - '{devise,pagination,doorkeeper}.*'
   - '{date,datetime,time,number}.*'
   - 'simple_form.{yes,no,recommended,not_recommended,overridden}'

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -48,6 +48,7 @@ ignore_unused:
   - 'activemodel.errors.*'
   - 'activerecord.attributes.*'
   - 'activerecord.errors.*'
+  - 'api.errors.*'
   - '{devise,pagination,doorkeeper}.*'
   - '{date,datetime,time,number}.*'
   - 'simple_form.{yes,no,recommended,not_recommended,overridden}'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1012,6 +1012,20 @@ en:
     empty: You have no aliases.
     hint_html: If you want to move from another account to this one, here you can create an alias, which is required before you can proceed with moving followers from the old account to this one. This action by itself is <strong>harmless and reversible</strong>. <strong>The account migration is initiated from the old account</strong>.
     remove: Unlink alias
+  api:
+    errors:
+      authentication_required: This method requires an authenticated user
+      email_not_confirmed: Your login is missing a confirmed e-mail address
+      invalid_date: Invalid date supplied
+      login_disabled: Your login is currently disabled
+      not_permitted: This action is not allowed
+      pending_approval: Your login is currently pending approval
+      record_not_found: Record not found
+      record_not_unique: Duplicate record
+      remote_data_fetch: Remote data could not be fetched
+      scope_not_authorized: This action is outside the authorized scopes
+      ssl_error: Remote SSL certificate could not be verified
+      temporary_problem: There was a temporary problem serving your request, please try again
   appearance:
     advanced_web_interface: Advanced web interface
     advanced_web_interface_hint: 'If you want to make use of your entire screen width, the advanced web interface allows you to configure many different columns to see as much information at the same time as you want: Home, notifications, federated timeline, any number of lists and hashtags.'

--- a/spec/controllers/api/base_controller_spec.rb
+++ b/spec/controllers/api/base_controller_spec.rb
@@ -7,10 +7,6 @@ describe Api::BaseController do
     def success
       head 200
     end
-
-    def failure
-      FakeService.new
-    end
   end
 
   it 'returns private cache control headers by default' do

--- a/spec/requests/api/v1/accounts_spec.rb
+++ b/spec/requests/api/v1/accounts_spec.rb
@@ -25,7 +25,7 @@ describe '/api/v1/accounts' do
         get '/api/v1/accounts/1'
 
         expect(response).to have_http_status(404)
-        expect(body_as_json[:error]).to eq('Record not found')
+        expect(body_as_json[:error]).to eq(I18n.t('api.errors.record_not_found'))
       end
     end
 


### PR DESCRIPTION
Changes to the `Api::BaseController` error handling:

- Some of the error classes handled by the controller were not in the spec, added them
- Added a check to the spec which asserts against the json error value in the response (previously only http response code was checked)
- Move the strings out of the controller class and into i18n yml
- Move the API error handling methods to an `Api::ErrorHandling` concern