### PR TITLE
Reduce `.times` usage in AccountSearch spec, use constant for default limit

### DIFF
--- a/app/models/concerns/account_search.rb
+++ b/app/models/concerns/account_search.rb
@@ -106,6 +106,8 @@ module AccountSearch
     LIMIT :limit OFFSET :offset
   SQL
 
+  DEFAULT_LIMIT = 10
+
   def searchable_text
     PlainTextFormatter.new(note, local?).to_s if discoverable?
   end
@@ -118,7 +120,7 @@ module AccountSearch
   end
 
   class_methods do
-    def search_for(terms, limit: 10, offset: 0)
+    def search_for(terms, limit: DEFAULT_LIMIT, offset: 0)
       tsquery = generate_query_for_search(terms)
 
       find_by_sql([BASIC_SEARCH_SQL, { limit: limit, offset: offset, tsquery: tsquery }]).tap do |records|
@@ -126,7 +128,7 @@ module AccountSearch
       end
     end
 
-    def advanced_search_for(terms, account, limit: 10, following: false, offset: 0)
+    def advanced_search_for(terms, account, limit: DEFAULT_LIMIT, following: false, offset: 0)
       tsquery = generate_query_for_search(terms)
       sql_template = following ? ADVANCED_SEARCH_WITH_FOLLOWING : ADVANCED_SEARCH_WITHOUT_FOLLOWING
 

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -450,10 +450,11 @@ RSpec.describe Account do
       expect(results).to eq [match]
     end
 
-    it 'limits by 10 by default' do
-      11.times.each { Fabricate(:account, display_name: 'Display Name') }
+    it 'limits via constant by default' do
+      stub_const('AccountSearch::DEFAULT_LIMIT', 1)
+      2.times.each { Fabricate(:account, display_name: 'Display Name') }
       results = described_class.search_for('display')
-      expect(results.size).to eq 10
+      expect(results.size).to eq 1
     end
 
     it 'accepts arbitrary limits' do
@@ -594,9 +595,10 @@ RSpec.describe Account do
     end
 
     it 'limits by 10 by default' do
-      11.times { Fabricate(:account, display_name: 'Display Name') }
+      stub_const('AccountSearch::DEFAULT_LIMIT', 1)
+      2.times { Fabricate(:account, display_name: 'Display Name') }
       results = described_class.advanced_search_for('display', account)
-      expect(results.size).to eq 10
+      expect(results.size).to eq 1
     end
 
     it 'accepts arbitrary limits' do


### PR DESCRIPTION
Related changes:

- Replace magic number of 10 in `AccountSearch` with an appropriately named constant
- Stub this constant in the search specs to reduce factory creation