### PR TITLE
Reduce `.times` usage in request and controller specs

### DIFF
--- a/spec/controllers/admin/invites_controller_spec.rb
+++ b/spec/controllers/admin/invites_controller_spec.rb
@@ -45,7 +45,7 @@ describe Admin::InvitesController do
 
   describe 'POST #deactivate_all' do
     it 'expires all invites, then redirects to admin_invites_path' do
-      invites = Fabricate.times(2, :invite, expires_at: nil)
+      invites = Fabricate.times(1, :invite, expires_at: nil)
 
       post :deactivate_all
 

--- a/spec/requests/api/v1/admin/domain_allows_spec.rb
+++ b/spec/requests/api/v1/admin/domain_allows_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Domain Allows' do
     end
 
     context 'when there are allowed domains' do
-      let!(:domain_allows) { Fabricate.times(5, :domain_allow) }
+      let!(:domain_allows) { Fabricate.times(2, :domain_allow) }
       let(:expected_response) do
         domain_allows.map do |domain_allow|
           {
@@ -53,7 +53,7 @@ RSpec.describe 'Domain Allows' do
       end
 
       context 'with limit param' do
-        let(:params) { { limit: 2 } }
+        let(:params) { { limit: 1 } }
 
         it 'returns only the requested number of allowed domains' do
           subject

--- a/spec/requests/api/v1/bookmarks_spec.rb
+++ b/spec/requests/api/v1/bookmarks_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Bookmarks' do
     end
 
     let(:params)     { {} }
-    let!(:bookmarks) { Fabricate.times(3, :bookmark, account: user.account) }
+    let!(:bookmarks) { Fabricate.times(2, :bookmark, account: user.account) }
 
     let(:expected_response) do
       bookmarks.map do |bookmark|
@@ -37,7 +37,7 @@ RSpec.describe 'Bookmarks' do
     end
 
     context 'with limit param' do
-      let(:params) { { limit: 2 } }
+      let(:params) { { limit: 1 } }
 
       it 'paginates correctly', :aggregate_failures do
         subject

--- a/spec/requests/api/v1/favourites_spec.rb
+++ b/spec/requests/api/v1/favourites_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Favourites' do
     end
 
     let(:params)      { {} }
-    let!(:favourites) { Fabricate.times(3, :favourite, account: user.account) }
+    let!(:favourites) { Fabricate.times(2, :favourite, account: user.account) }
 
     let(:expected_response) do
       favourites.map do |favourite|
@@ -37,7 +37,7 @@ RSpec.describe 'Favourites' do
     end
 
     context 'with limit param' do
-      let(:params) { { limit: 2 } }
+      let(:params) { { limit: 1 } }
 
       it 'returns only the requested number of favourites' do
         subject

--- a/spec/requests/api/v1/featured_tags_spec.rb
+++ b/spec/requests/api/v1/featured_tags_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'FeaturedTags' do
     end
 
     context 'when the requesting user has no featured tag' do
-      before { Fabricate.times(3, :featured_tag) }
+      before { Fabricate(:featured_tag) }
 
       it 'returns an empty body' do
         get '/api/v1/featured_tags', headers: headers
@@ -44,7 +44,7 @@ RSpec.describe 'FeaturedTags' do
     end
 
     context 'when the requesting user has featured tags' do
-      let!(:user_featured_tags) { Fabricate.times(5, :featured_tag, account: user.account) }
+      let!(:user_featured_tags) { Fabricate.times(1, :featured_tag, account: user.account) }
 
       it 'returns only the featured tags belonging to the requesting user' do
         get '/api/v1/featured_tags', headers: headers

--- a/spec/requests/api/v1/follow_requests_spec.rb
+++ b/spec/requests/api/v1/follow_requests_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Follow requests' do
       get '/api/v1/follow_requests', headers: headers, params: params
     end
 
-    let(:accounts) { Fabricate.times(5, :account) }
+    let(:accounts) { Fabricate.times(2, :account) }
     let(:params)   { {} }
 
     let(:expected_response) do
@@ -40,7 +40,7 @@ RSpec.describe 'Follow requests' do
     end
 
     context 'with limit param' do
-      let(:params) { { limit: 2 } }
+      let(:params) { { limit: 1 } }
 
       it 'returns only the requested number of follow requests' do
         subject

--- a/spec/requests/api/v1/followed_tags_spec.rb
+++ b/spec/requests/api/v1/followed_tags_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Followed tags' do
       get '/api/v1/followed_tags', headers: headers, params: params
     end
 
-    let!(:tag_follows) { Fabricate.times(5, :tag_follow, account: user.account) }
+    let!(:tag_follows) { Fabricate.times(2, :tag_follow, account: user.account) }
     let(:params)       { {} }
 
     let(:expected_response) do
@@ -41,7 +41,7 @@ RSpec.describe 'Followed tags' do
     end
 
     context 'with limit param' do
-      let(:params) { { limit: 3 } }
+      let(:params) { { limit: 1 } }
 
       it 'returns only the requested number of follow tags' do
         subject
@@ -58,7 +58,7 @@ RSpec.describe 'Followed tags' do
       it 'sets the correct pagination header for the next path' do
         subject
 
-        expect(response.headers['Link'].find_link(%w(rel next)).href).to eq(api_v1_followed_tags_url(limit: params[:limit], max_id: tag_follows[2].id))
+        expect(response.headers['Link'].find_link(%w(rel next)).href).to eq(api_v1_followed_tags_url(limit: params[:limit], max_id: tag_follows.last.id))
       end
     end
   end

--- a/spec/requests/api/v1/lists/accounts_spec.rb
+++ b/spec/requests/api/v1/lists/accounts_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Accounts' do
 
     let(:params)   { { limit: 0 } }
     let(:list)     { Fabricate(:list, account: user.account) }
-    let(:accounts) { Fabricate.times(3, :account) }
+    let(:accounts) { Fabricate.times(2, :account) }
 
     let(:expected_response) do
       accounts.map do |account|

--- a/spec/requests/api/v1/mutes_spec.rb
+++ b/spec/requests/api/v1/mutes_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Mutes' do
       get '/api/v1/mutes', headers: headers, params: params
     end
 
-    let!(:mutes) { Fabricate.times(3, :mute, account: user.account) }
+    let!(:mutes) { Fabricate.times(2, :mute, account: user.account) }
     let(:params) { {} }
 
     it_behaves_like 'forbidden for wrong scope', 'write write:mutes'
@@ -33,7 +33,7 @@ RSpec.describe 'Mutes' do
     end
 
     context 'with limit param' do
-      let(:params) { { limit: 2 } }
+      let(:params) { { limit: 1 } }
 
       it 'returns only the requested number of muted accounts' do
         subject
@@ -46,8 +46,8 @@ RSpec.describe 'Mutes' do
 
         headers = response.headers['Link']
 
-        expect(headers.find_link(%w(rel prev)).href).to eq(api_v1_mutes_url(limit: params[:limit], since_id: mutes[2].id.to_s))
-        expect(headers.find_link(%w(rel next)).href).to eq(api_v1_mutes_url(limit: params[:limit], max_id: mutes[1].id.to_s))
+        expect(headers.find_link(%w(rel prev)).href).to eq(api_v1_mutes_url(limit: params[:limit], since_id: mutes.last.id.to_s))
+        expect(headers.find_link(%w(rel next)).href).to eq(api_v1_mutes_url(limit: params[:limit], max_id: mutes.last.id.to_s))
       end
     end
 
@@ -72,8 +72,8 @@ RSpec.describe 'Mutes' do
 
         body = body_as_json
 
-        expect(body.size).to eq 2
-        expect(body[0][:id]).to eq mutes[2].target_account_id.to_s
+        expect(body.size).to eq 1
+        expect(body[0][:id]).to eq mutes[1].target_account_id.to_s
       end
     end
 

--- a/spec/requests/api/v1/notifications_spec.rb
+++ b/spec/requests/api/v1/notifications_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe 'Notifications' do
     end
 
     before do
-      Fabricate.times(3, :notification, account: user.account)
+      Fabricate(:notification, account: user.account)
     end
 
     it_behaves_like 'forbidden for wrong scope', 'read read:notifications'

--- a/spec/requests/api/v1/statuses_spec.rb
+++ b/spec/requests/api/v1/statuses_spec.rb
@@ -156,7 +156,7 @@ describe '/api/v1/statuses' do
       context 'when exceeding rate limit' do
         before do
           rate_limiter = RateLimiter.new(user.account, family: :statuses)
-          300.times { rate_limiter.record! }
+          RateLimiter::FAMILIES[:statuses][:limit].times { rate_limiter.record! }
         end
 
         it 'returns rate limit headers', :aggregate_failures do

--- a/spec/requests/api/v2/filters_spec.rb
+++ b/spec/requests/api/v2/filters_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Filters' do
       get '/api/v2/filters', headers: headers
     end
 
-    let!(:filters) { Fabricate.times(3, :custom_filter, account: user.account) }
+    let!(:filters) { Fabricate.times(2, :custom_filter, account: user.account) }
 
     it_behaves_like 'forbidden for wrong scope', 'write write:filters'
     it_behaves_like 'unauthorized for invalid token'


### PR DESCRIPTION
A mix of changes to controller/request specs where there was room to reduce the number of factories created in the spec.