### PR TITLE
Fix custom emoji width

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1054,8 +1054,7 @@ body > [data-popper-placement] {
   font-size: inherit;
   vertical-align: middle;
   object-fit: contain;
-  margin: -0.2ex 0.15em 0.2ex;
-  width: 16px;
+  margin: -0.2ex 0.15em 0;
   height: 16px;
 
   img {
@@ -1097,7 +1096,6 @@ body > [data-popper-placement] {
   }
 
   .emojione {
-    width: 20px;
     height: 20px;
     margin: -3px 0 0;
   }
@@ -1320,7 +1318,6 @@ body > [data-popper-placement] {
   overflow-y: auto;
 
   .emojione {
-    width: 20px;
     height: 20px;
     margin: -3px 0 0;
   }
@@ -1730,7 +1727,6 @@ body > [data-popper-placement] {
     line-height: 24px;
 
     .emojione {
-      width: 24px;
       height: 24px;
       margin: -1px 0 0;
     }
@@ -6812,7 +6808,6 @@ a.status-card {
     line-height: 24px;
 
     .emojione {
-      width: 24px;
       height: 24px;
       margin: -1px 0 0;
     }
@@ -8168,7 +8163,6 @@ noscript {
       margin-bottom: 16px;
 
       .emojione {
-        width: 22px;
         height: 22px;
       }
 


### PR DESCRIPTION
I've made a small adjustment to the CSS to address an issue with wide emojis not displaying properly.

Before
![chrome_2023-11-18_18-29-03](https://github.com/mastodon/mastodon/assets/61333854/2b877aa6-f131-4a5f-8bf0-ce527ff77d4c)

After
![chrome_2023-11-18_18-45-31](https://github.com/mastodon/mastodon/assets/61333854/4c9eb9f1-9a2b-4acb-9e26-359c423bb97e)