### PR TITLE
Fix custom filters to correctly handle hashtag filters

### DIFF
--- a/app/models/custom_filter.rb
+++ b/app/models/custom_filter.rb
@@ -70,8 +70,8 @@ class CustomFilter < ApplicationRecord
       scope.to_a.group_by(&:custom_filter).each do |filter, keywords|
         keywords.map! do |keyword|
           if keyword.whole_word
-            sb = /\A[[:word:]]/.match?(keyword.keyword) ? '\b' : ''
-            eb = /[[:word:]]\z/.match?(keyword.keyword) ? '\b' : ''
+            sb = /\A|^[[:word:]]/.match?(keyword.keyword) ? '\b' : ''
+            eb = /[[:word:]]\z|$/.match?(keyword.keyword) ? '\b' : ''
 
             /(?mix:#{sb}#{Regexp.escape(keyword.keyword)}#{eb})/
           else

--- a/streaming/index.js
+++ b/streaming/index.js
@@ -891,11 +891,11 @@ const startServer = async () => {
                 let expr = keyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
                 if (whole_word) {
-                  if (/^[\w]/.test(expr)) {
+                  if (/^[\S]/.test(expr)) {
                     expr = `\\b${expr}`;
                   }
 
-                  if (/[\w]$/.test(expr)) {
+                  if (/[\S]$/.test(expr)) {
                     expr = `${expr}\\b`;
                   }
                 }


### PR DESCRIPTION
The previous logic didn't match keywords that started with hashtags correctly. Fixes #27990.