### PR TITLE
Add pry-rails and pry-byebug gems for debugging in dev and test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -187,6 +187,10 @@ group :development, :test do
 
   # RSpec runner for rails
   gem 'rspec-rails', '~> 6.0'
+
+  # REPL for debugging
+  gem 'pry-byebug'
+  gem 'pry-rails'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,6 +184,7 @@ GEM
     bundler-audit (0.9.1)
       bundler (>= 1.2.0, < 3)
       thor (~> 1.0)
+    byebug (11.1.3)
     capybara (3.39.2)
       addressable
       matrix
@@ -204,6 +205,7 @@ GEM
     chunky_png (1.4.0)
     climate_control (0.2.0)
     cocoon (1.2.15)
+    coderay (1.1.3)
     color_diff (0.1)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
@@ -453,6 +455,7 @@ GEM
       azure-storage-blob (~> 2.0.1)
       hashie (~> 5.0)
     memory_profiler (1.0.1)
+    method_source (1.0.0)
     mime-types (3.5.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2023.1003)
@@ -531,6 +534,14 @@ GEM
       net-smtp
       premailer (~> 1.7, >= 1.7.9)
     private_address_check (0.5.0)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.10.1)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     psych (5.1.1.1)
       stringio
     public_suffix (5.0.3)
@@ -905,6 +916,8 @@ DEPENDENCIES
   posix-spawn
   premailer-rails
   private_address_check (~> 0.5)
+  pry-byebug
+  pry-rails
   public_suffix (~> 5.0)
   puma (~> 6.3)
   pundit (~> 2.3)


### PR DESCRIPTION
Extracted from https://github.com/mastodon/mastodon/pull/27982#pullrequestreview-1738724813, I thought other contributors of this repo could benefit from these helpful debugging tools:

- https://github.com/pry/pry-rails as a powerful Ruby REPL
- https://github.com/deivid-rodriguez/pry-byebug for easily navigating between frames

In case this helps anyone, I put the following in a `~/.pryrc` file to navigate the Ruby code:

```ruby
Pry.commands.alias_command 'c', 'continue'
Pry.commands.alias_command 'f', 'finish'
Pry.commands.alias_command 'n', 'next'
Pry.commands.alias_command 's', 'step'
Pry.commands.alias_command 'q', 'quit'
Pry.commands.alias_command 'w', 'whereami'
Pry.history.load
```