### PR TITLE
Add VAPID public key to instance serializer

### DIFF
--- a/app/serializers/rest/application_serializer.rb
+++ b/app/serializers/rest/application_serializer.rb
@@ -4,7 +4,7 @@ class REST::ApplicationSerializer < ActiveModel::Serializer
   attributes :id, :name, :website, :scopes, :redirect_uri,
              :client_id, :client_secret
 
-  # TODO: Deprecated in 4.3.0, needs to be removed in 5.0.0
+  # NOTE: Deprecated in 4.3.0, needs to be removed in 5.0.0
   attribute :vapid_key
 
   def id

--- a/app/serializers/rest/application_serializer.rb
+++ b/app/serializers/rest/application_serializer.rb
@@ -2,7 +2,10 @@
 
 class REST::ApplicationSerializer < ActiveModel::Serializer
   attributes :id, :name, :website, :scopes, :redirect_uri,
-             :client_id, :client_secret, :vapid_key
+             :client_id, :client_secret
+
+  # TODO: Deprecated in 4.3.0, needs to be removed in 5.0.0
+  attribute :vapid_key
 
   def id
     object.id.to_s

--- a/app/serializers/rest/instance_serializer.rb
+++ b/app/serializers/rest/instance_serializer.rb
@@ -48,6 +48,10 @@ class REST::InstanceSerializer < ActiveModel::Serializer
         status: object.status_page_url,
       },
 
+      vapid: {
+        public_key: Rails.configuration.x.vapid_public_key,
+      },
+
       accounts: {
         max_featured_tags: FeaturedTag::LIMIT,
       },

--- a/spec/serializers/rest/instance_serializer_spec.rb
+++ b/spec/serializers/rest/instance_serializer_spec.rb
@@ -10,5 +10,11 @@ describe REST::InstanceSerializer do
     it 'returns recent usage data' do
       expect(serialization['usage']).to eq({ 'users' => { 'active_month' => 0 } })
     end
+
+    it 'returns the VAPID public key' do
+      expect(serialization['configuration']['vapid']).to eq({
+        'public_key' => Rails.configuration.x.vapid_public_key,
+      })
+    end
   end
 end


### PR DESCRIPTION
When we were working on the ApplicationSerializer for OAuth Application creation for #27142, we noticed that the VAPID Public Key was being returned as part of the Application's credentials response, when it's actually not related to the application, but the instance as a whole. 

This change allows application developers to migrate to using the instance info endpoint instead to fetch the VAPID public key, allowing future removal of this unrelated data from  the `POST /api/v1/apps` endpoint

We noticed this here: https://github.com/mastodon/mastodon/pull/27142#discussion_r1336742173

This PR would allow us to mark the `vapid_key` in the `Application` entity returned by [`POST /api/v1/apps`](https://docs.joinmastodon.org/methods/apps/#create) endpoint as deprecated in 4.x, with removal in 5.0 or later, depending on how much work downstream developers need to do to migrate.