### PR TITLE
Update partials for the `AdminMailer.new_trends` mailer

### DIFF
--- a/app/views/admin_mailer/_new_trending_links.text.erb
+++ b/app/views/admin_mailer/_new_trending_links.text.erb
@@ -1,6 +1,6 @@
 <%= raw t('admin_mailer.new_trends.new_trending_links.title') %>
 
-<% @links.each do |link| %>
+<% new_trending_links.each do |link| %>
 - <%= link.title %> · <%= link.url %>
   <%= standard_locale_name(link.language) %> · <%= raw t('admin.trends.links.usage_comparison', today: link.history.get(Time.now.utc).accounts, yesterday: link.history.get(Time.now.utc - 1.day).accounts) %> · <%= t('admin.trends.tags.current_score', score: link.trend.score.round(2)) %>
 <% end %>

--- a/app/views/admin_mailer/_new_trending_statuses.text.erb
+++ b/app/views/admin_mailer/_new_trending_statuses.text.erb
@@ -1,6 +1,6 @@
 <%= raw t('admin_mailer.new_trends.new_trending_statuses.title') %>
 
-<% @statuses.each do |status| %>
+<% new_trending_statuses.each do |status| %>
 - <%= ActivityPub::TagManager.instance.url_for(status) %>
   <%= standard_locale_name(status.language) %> · <%= raw t('admin.trends.tags.current_score', score: status.trend.score.round(2)) %>
 <% end %>

--- a/app/views/admin_mailer/_new_trending_tags.text.erb
+++ b/app/views/admin_mailer/_new_trending_tags.text.erb
@@ -1,14 +1,8 @@
 <%= raw t('admin_mailer.new_trends.new_trending_tags.title') %>
 
-<% @tags.each do |tag| %>
+<% new_trending_tags.each do |tag| %>
 - #<%= tag.display_name %>
   <%= raw t('admin.trends.tags.usage_comparison', today: tag.history.get(Time.now.utc).accounts, yesterday: tag.history.get(Time.now.utc - 1.day).accounts) %> · <%= t('admin.trends.tags.current_score', score: Trends.tags.score(tag.id).round(2)) %>
-<% end %>
-
-<% if @lowest_trending_tag %>
-<%= raw t('admin_mailer.new_trends.new_trending_tags.requirements', lowest_tag_name: @lowest_trending_tag.display_name, lowest_tag_score: Trends.tags.score(@lowest_trending_tag.id).round(2), rank: Trends.tags.options[:review_threshold]) %>
-<% else %>
-<%= raw t('admin_mailer.new_trends.new_trending_tags.no_approved_tags') %>
 <% end %>
 
 <%= raw t('application_mailer.view')%> <%= admin_trends_tags_url(status: 'pending_review') %>

--- a/app/views/admin_mailer/new_trends.text.erb
+++ b/app/views/admin_mailer/new_trends.text.erb
@@ -2,12 +2,6 @@
 
 <%= raw t('admin_mailer.new_trends.body') %>
 
-<% unless @links.empty? %>
-<%= render 'new_trending_links' %>
-<% end %>
-<% unless @tags.empty? %>
-<%= render 'new_trending_tags' unless @tags.empty? %>
-<% end %>
-<% unless @statuses.empty? %>
-<%= render 'new_trending_statuses' unless @statuses.empty? %>
-<% end %>
+<%= render partial: 'new_trending_links', object: @links unless @links.empty? %>
+<%= render partial: 'new_trending_tags', object: @tags unless @tags.empty? %>
+<%= render partial: 'new_trending_statuses', object: @statuses unless @statuses.empty? %>

--- a/config/locales/an.yml
+++ b/config/locales/an.yml
@@ -900,8 +900,6 @@ an:
       new_trending_statuses:
         title: Publicacions en tendencia
       new_trending_tags:
-        no_approved_tags: Actualment no i hai garra etiqueta en tendencia aprebada.
-        requirements: 'Qualsequiera d''estes candidatos podría superar lo hashtag en tendencia aprebau per #%{rank}, que actualment ye #%{lowest_tag_name} con una puntuación de %{lowest_tag_score}.'
         title: Etiquetas en tendencia
       subject: Nuevas tendencias asperando estar revisadas en %{instance}
   aliases:

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -1068,8 +1068,6 @@ ar:
       new_trending_statuses:
         title: المنشورات الشائعة
       new_trending_tags:
-        no_approved_tags: لا توجد حاليًا وسوم شائعة موافق عليها.
-        requirements: 'يمكن لأي من هؤلاء المرشحين أن يتجاوز علامة #%{rank} من الوسوم الموافق عليها، وهي حاليا #%{lowest_tag_name} مع نتيجة %{lowest_tag_score}.'
         title: الوسوم المتداولة
       subject: تداولات جديدة في انتظار المراجعة على %{instance}
   aliases:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -1033,8 +1033,6 @@ be:
       new_trending_statuses:
         title: Папулярныя допісы
       new_trending_tags:
-        no_approved_tags: Зараз няма зацверджаных папулярных хэштэгаў.
-        requirements: 'Кожны з гэтых кандыдатаў можа перавысіць #%{rank} зацверджаных папулярных хэштэгаў. Зараз гэта #%{lowest_tag_name} з лікам %{lowest_tag_score}.'
         title: Папулярныя хэштэгі
       subject: Новае ў папулярным для разгляду %{instance}
   aliases:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -997,8 +997,6 @@ bg:
       new_trending_statuses:
         title: Налагащи се публикации
       new_trending_tags:
-        no_approved_tags: Сега няма одобрени налагащи се хаштагове.
-        requirements: 'Всеки от тези кандидати може да надмине #%{rank} одобрен актуален хаштаг, който в момента е #%{lowest_tag_name} с резултат %{lowest_tag_score}.'
         title: Налагащи се хаштагове
       subject: Нови нашумели, готови за преглед в %{instance}
   aliases:

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -995,8 +995,6 @@ ca:
       new_trending_statuses:
         title: Tuts en tendència
       new_trending_tags:
-        no_approved_tags: Actualment no hi ha etiquetes en tendència aprovades.
-        requirements: 'Qualsevol d''aquests candidats podria superar el #%{rank} de la etiqueta en tendència aprovada, que actualment és "%{lowest_tag_name}" amb una puntuació de %{lowest_tag_score}.'
         title: Etiquetes en tendència
       subject: Noves tendències pendents de revisar a %{instance}
   aliases:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -1029,8 +1029,6 @@ cs:
       new_trending_statuses:
         title: Populární příspěvky
       new_trending_tags:
-        no_approved_tags: Momentálně nejsou žádné schválené populární hashtagy.
-        requirements: 'Kterýkoliv z těchto kandidátů by mohl předehnat schválený populární hashtag #%{rank}, kterým je momentálně #%{lowest_tag_name} se skóre %{lowest_tag_score}.'
         title: Populární hashtagy
       subject: Nové trendy k posouzení na %{instance}
   aliases:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -1068,8 +1068,6 @@ cy:
       new_trending_statuses:
         title: Postiadau sy'n trendio
       new_trending_tags:
-        no_approved_tags: Ar hyn o bryd nid oes unrhyw hashnodau trendio cymeradwy.
-        requirements: 'Gallai unrhyw un o''r ymgeiswyr hyn ragori ar yr hashnod trendio cymeradwy #%{rank}, sef #%{lowest_tag_name} gyda sgôr o %{lowest_tag_score} ar hyn o bryd.'
         title: Hashnodau sy'n trendio
       subject: Trendiau newydd i'w hadolygu ar %{instance}
   aliases:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -997,8 +997,6 @@ da:
       new_trending_statuses:
         title: Populære opslag
       new_trending_tags:
-        no_approved_tags: Der er pt. ingen godkendte populære hashtags.
-        requirements: 'Enhver af disse kandidater vil kunne overgå #%{rank} godkendte populære hastag, der med en score på #%{lowest_tag_score} pt. er %{lowest_tag_name}.'
         title: Populære hashtags
       subject: Nye tendenser klar til revision på %{instance}
   aliases:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -997,8 +997,6 @@ de:
       new_trending_statuses:
         title: Angesagte Beiträge
       new_trending_tags:
-        no_approved_tags: Es gibt keine genehmigten Hashtags, die gerade im Trend liegen.
-        requirements: 'Jeder dieser Kandidaten könnte den #%{rank} genehmigten angesagten Hashtag übertreffen, der derzeit #%{lowest_tag_name} mit einer Punktzahl von %{lowest_tag_score} ist.'
         title: Angesagte Hashtags
       subject: Neue Trends zur Überprüfung auf %{instance}
   aliases:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -938,8 +938,6 @@ el:
       new_trending_statuses:
         title: Αναρτήσεις σε τάση
       new_trending_tags:
-        no_approved_tags: Προς το παρόν δεν υπάρχουν εγκεκριμένες ετικέτεςσε τάση.
-        requirements: 'Οποιοσδήποτε από αυτούς τους υποψηφίους θα μπορούσε να ξεπεράσει την #%{rank} εγκεκριμένη ετικέτα σε τάση, που επί του παρόντος είναι #%{lowest_tag_name} με βαθμολογία %{lowest_tag_score}.'
         title: Ετικέτες σε τάση
       subject: Νέες τάσεις προς αξιολόγηση στο %{instance}
   aliases:

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -995,8 +995,6 @@ en-GB:
       new_trending_statuses:
         title: Trending posts
       new_trending_tags:
-        no_approved_tags: There are currently no approved trending hashtags.
-        requirements: 'Any of these candidates could surpass the #%{rank} approved trending hashtag, which is currently #%{lowest_tag_name} with a score of %{lowest_tag_score}.'
         title: Trending hashtags
       subject: New trends up for review on %{instance}
   aliases:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -997,8 +997,6 @@ en:
       new_trending_statuses:
         title: Trending posts
       new_trending_tags:
-        no_approved_tags: There are currently no approved trending hashtags.
-        requirements: 'Any of these candidates could surpass the #%{rank} approved trending hashtag, which is currently #%{lowest_tag_name} with a score of %{lowest_tag_score}.'
         title: Trending hashtags
       subject: New trends up for review on %{instance}
   aliases:

--- a/config/locales/eo.yml
+++ b/config/locales/eo.yml
@@ -950,8 +950,6 @@ eo:
       new_trending_statuses:
         title: Popularaĝaj mesaĝoj
       new_trending_tags:
-        no_approved_tags: Nun ne havas aprobitajn popularajn kradvortojn.
-        requirements: Ajn ĉi tiu eroj povas superi la %{rank}an kradvorton kiu estas %{lowest_tag_name} kun %{lowest_tag_score} puentoj.
         title: Tendencantaj kradvortoj
       subject: Novaj popularaĵoj bezonas kontrolitis ĉe %{instance}
   aliases:

--- a/config/locales/es-AR.yml
+++ b/config/locales/es-AR.yml
@@ -997,8 +997,6 @@ es-AR:
       new_trending_statuses:
         title: Mensajes en tendencia
       new_trending_tags:
-        no_approved_tags: Actualmente no hay etiquetas en tendencia aprobadas.
-        requirements: 'Cualquiera de estos candidatos podría superar la etiqueta en tendencia aprobada de #%{rank}, que actualmente es #%{lowest_tag_name} con una puntuación de %{lowest_tag_score}.'
         title: Etiquetas en tendencia
       subject: Nuevas tendencias para revisar en %{instance}
   aliases:

--- a/config/locales/es-MX.yml
+++ b/config/locales/es-MX.yml
@@ -997,8 +997,6 @@ es-MX:
       new_trending_statuses:
         title: Publicaciones en tendencia
       new_trending_tags:
-        no_approved_tags: Actualmente no hay ninguna etiqueta en tendencia aprobada.
-        requirements: 'Cualquiera de estos candidatos podría superar el hashtag en tendencia aprobado por #%{rank}, que actualmente es #%{lowest_tag_name} con una puntuación de %{lowest_tag_score}.'
         title: Etiquetas en tendencia
       subject: Nuevas tendencias esperando ser revisadas en %{instance}
   aliases:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -997,8 +997,6 @@ es:
       new_trending_statuses:
         title: Publicaciones en tendencia
       new_trending_tags:
-        no_approved_tags: Actualmente no hay ninguna etiqueta en tendencia aprobada.
-        requirements: 'Cualquiera de estos candidatos podría superar el hashtag en tendencia aprobado por #%{rank}, que actualmente es #%{lowest_tag_name} con una puntuación de %{lowest_tag_score}.'
         title: Etiquetas en tendencia
       subject: Nuevas tendencias esperando ser revisadas en %{instance}
   aliases:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -981,8 +981,6 @@ et:
       new_trending_statuses:
         title: Trendikad postitused
       new_trending_tags:
-        no_approved_tags: Hetkel ei ole ühtegi heaks kiidetud populaarset silti.
-        requirements: 'Need on siltide kandidaadid mille hulgast ükskõik milline võib järjekorras mööda jõuda #%{rank} kohal olevast heaks kiidetud sildist. See on hetkel #%{lowest_tag_name} mille seis on %{lowest_tag_score}.'
         title: Trendikad sildid
       subject: Uued %{instance} trendid ülevaatuseks
   aliases:

--- a/config/locales/eu.yml
+++ b/config/locales/eu.yml
@@ -994,8 +994,6 @@ eu:
       new_trending_statuses:
         title: Bidalketen joerak
       new_trending_tags:
-        no_approved_tags: Ez dago onartutako traolen joerarik une honetan.
-        requirements: 'Hautagai hauek joeretan onartutako %{rank}. traola gainditu dezakete: une honetan #%{lowest_tag_name} da, %{lowest_tag_score} puntuazioarekin.'
         title: Traolak joeran
       subject: Joera berriak daude berrikusteko %{instance} instantzian
   aliases:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -848,7 +848,6 @@ fa:
       new_trending_statuses:
         title: فرسته‌های داغ
       new_trending_tags:
-        no_approved_tags: در حال حاضر هیچ برچسب پرطرفداری پذیرفته نشده است.
         title: برچسب‌های داغ
       subject: موضوغ داغ تازه‌ای در %{instance} نیازمند بررسی است
   aliases:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -997,8 +997,6 @@ fi:
       new_trending_statuses:
         title: Suositut julkaisut
       new_trending_tags:
-        no_approved_tags: Tällä hetkellä ei ole hyväksyttyjä suosittuja aihetunnisteita.
-        requirements: 'Mikä tahansa näistä ehdokkaista voisi ylittää #%{rank} hyväksytyn suositun aihetunnisteen, joka on tällä hetkellä #%{lowest_tag_name} %{lowest_tag_score} pisteellä.'
         title: Suositut aihetunnisteet
       subject: Uusia trendejä tarkistettavaksi instanssissa %{instance}
   aliases:

--- a/config/locales/fo.yml
+++ b/config/locales/fo.yml
@@ -996,8 +996,6 @@ fo:
       new_trending_statuses:
         title: Vælumtóktir postar
       new_trending_tags:
-        no_approved_tags: Í løtuni eru eingi góðkend vælumtókt frámerki.
-        requirements: 'Einhvør av hesum kandidatum kunnu fara framum #%{rank} góðkenda vælumtókta frámerki, sum í løtuni er #%{lowest_tag_name} við stigatali %{lowest_tag_score}.'
         title: Vælumtókt frámerki
       subject: Nýggj rák til gjøgnumgongd á %{instance}
   aliases:

--- a/config/locales/fr-QC.yml
+++ b/config/locales/fr-QC.yml
@@ -996,8 +996,6 @@ fr-QC:
       new_trending_statuses:
         title: Messages tendance
       new_trending_tags:
-        no_approved_tags: Il n'y a pas de hashtag tendance approuvé actuellement.
-        requirements: 'N''importe quel élément de la sélection pourrait surpasser le hashtag tendance approuvé n°%{rank}, qui est actuellement #%{lowest_tag_name} avec un résultat de %{lowest_tag_score}.'
         title: Hashtags tendance
       subject: Nouvelles tendances à examiner sur %{instance}
   aliases:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -996,8 +996,6 @@ fr:
       new_trending_statuses:
         title: Messages tendance
       new_trending_tags:
-        no_approved_tags: Il n'y a pas de hashtag tendance approuvé actuellement.
-        requirements: 'N''importe quel élément de la sélection pourrait surpasser le hashtag tendance approuvé n°%{rank}, qui est actuellement #%{lowest_tag_name} avec un résultat de %{lowest_tag_score}.'
         title: Hashtags tendance
       subject: Nouvelles tendances à examiner sur %{instance}
   aliases:

--- a/config/locales/fy.yml
+++ b/config/locales/fy.yml
@@ -996,8 +996,6 @@ fy:
       new_trending_statuses:
         title: Trending berjochten
       new_trending_tags:
-        no_approved_tags: Op dit stuit binne der gjin goedkarre hashtags.
-        requirements: 'Elk fan dizze kandidaten kin de #%{rank} goedkarre trending hashtag oertreffe, dy’t op dit stuit #%{lowest_tag_name} is mei in skoare fan %{lowest_tag_score}.'
         title: Trending hashtags
       subject: Nije trends te beoardielen op %{instance}
   aliases:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -1032,8 +1032,6 @@ gd:
       new_trending_statuses:
         title: Postaichean a’ treandadh
       new_trending_tags:
-        no_approved_tags: Chan eil taga hais a’ treandadh le aontachadh ann.
-        requirements: "’S urrainn do ghin dhe na tagraichean seo dol thairis air #%{rank} a tha aig an taga hais #%{lowest_tag_name} a’ treandadh as ìsle le aontachadh agus sgòr de %{lowest_tag_score} air."
         title: Tagaichean hais a’ treandadh
       subject: Tha treandaichean ùra a’ feitheamh air lèirmheas air %{instance}
   aliases:

--- a/config/locales/gl.yml
+++ b/config/locales/gl.yml
@@ -997,8 +997,6 @@ gl:
       new_trending_statuses:
         title: Publicacións en voga
       new_trending_tags:
-        no_approved_tags: Non hai etiquetas en voga aprobadas.
-        requirements: 'Calquera destos candidatos podería superar o #%{rank} dos cancelos en voga aprobados, que actualmente é #%{lowest_tag_name} cunha puntuación de %{lowest_tag_score}.'
         title: Cancelos en voga
       subject: Novas tendencias para revisar en %{instance}
   aliases:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1033,8 +1033,6 @@ he:
       new_trending_statuses:
         title: הודעות חמות
       new_trending_tags:
-        no_approved_tags: אין כרגע שום תגיות חמות מאושרות.
-        requirements: כל אחת מהמועמדות האלו עשויה לעבור את התגית החמה המאושרת מדרגה %{rank}, שהיא כרגע %{lowest_tag_name} עם ציון של %{lowest_tag_score}.
         title: תגיות חמות
       subject: נושאים חמים חדשים מוכנים לסקירה ב-%{instance}
   aliases:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -997,8 +997,6 @@ hu:
       new_trending_statuses:
         title: Felkapott bejegyzések
       new_trending_tags:
-        no_approved_tags: Jelenleg nincsenek jóváhagyott felkapott hashtagek.
-        requirements: 'Ezek közül bármelyik jelölt lehagyná a %{rank}. jóváhagyott felkapott hashtaget, amely jelenleg a(z) #%{lowest_tag_name} ezzel a pontszámmal: %{lowest_tag_score}.'
         title: Felkapott hashtagek
       subject: 'Új jóváhagyandó trendek ezen: %{instance}'
   aliases:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -878,8 +878,6 @@ id:
       new_trending_statuses:
         title: Kiriman yang sedang tren
       new_trending_tags:
-        no_approved_tags: Saat ini tidak ada tagar tren yang disetujui.
-        requirements: 'Kandidat yang ada di sini bisa saja melewati peringkat #%{rank} tagar sedang tren yang disetujui, yang kini #%{lowest_tag_name} memiliki nilai %{lowest_tag_score}.'
         title: Tagar sedang tren
       subject: Tren baru yang perlu ditinjau di %{instance}
   aliases:

--- a/config/locales/io.yml
+++ b/config/locales/io.yml
@@ -857,8 +857,6 @@ io:
       new_trending_statuses:
         title: Tendencoza posti
       new_trending_tags:
-        no_approved_tags: Nun ne existas aprobita tendencoza hashtagi.
-        requirements: 'Irga ca probanti povas ecesar la #%{rank} aprobita tendencoligilo, quale nun esas %{lowest_tag_name} kun punto %{lowest_tag_score}.'
         title: Tendencoza hashtagi
       subject: Nova tendenci bezonas kontrolesar che %{instance}
   aliases:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -999,8 +999,6 @@ is:
       new_trending_statuses:
         title: Vinsælar færslur
       new_trending_tags:
-        no_approved_tags: Það eru í augnablikinu engin samþykkt vinsæl myllumerki.
-        requirements: 'Hver af þessum tillögum gætu farið yfir samþykkta vinsæla myllumerkið númer #%{rank}, sem í augnablikinu er %{lowest_tag_name} með %{lowest_tag_score} stig'
         title: Vinsæl myllumerki
       subject: Nýtt vinsælt til yfirferðar á %{instance}
   aliases:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -997,8 +997,6 @@ it:
       new_trending_statuses:
         title: Post di tendenza
       new_trending_tags:
-        no_approved_tags: Attualmente non ci sono hashtag di tendenza approvati.
-        requirements: 'Ognuno di questi candidati potrebbe superare il #%{rank} hashtag di tendenza approvato, che è attualmente "%{lowest_tag_name}" con un punteggio di %{lowest_tag_score}.'
         title: Hashtag di tendenza
       subject: Nuove tendenze in attesa di controllo su %{instance}
   aliases:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -979,8 +979,6 @@ ja:
       new_trending_statuses:
         title: トレンド投稿
       new_trending_tags:
-        no_approved_tags: 承認されたトレンドハッシュタグはありません。
-        requirements: 'これらの候補はいずれも %{rank} 位の承認済みトレンドハッシュタグのスコアを上回ります。現在 #%{lowest_tag_name} のスコアは %{lowest_tag_score} です。'
         title: トレンドハッシュタグ
       subject: "%{instance}で新しいトレンドが審査待ちです"
   aliases:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -981,8 +981,6 @@ ko:
       new_trending_statuses:
         title: 유행하는 게시물
       new_trending_tags:
-        no_approved_tags: 현재 승인된 유행 중인 해시태그가 없습니다.
-        requirements: '이 후보들 중 어떤 것이라도 #%{rank}위의 승인된 유행 중인 해시태그를 앞지를 수 있으며, 이것은 현재 #%{lowest_tag_name}이고 %{lowest_tag_score}점을 기록하고 있습니다.'
         title: 유행하는 해시태그
       subject: 새 트렌드가 %{instance}에서 심사 대기 중입니다
   aliases:

--- a/config/locales/ku.yml
+++ b/config/locales/ku.yml
@@ -897,8 +897,6 @@ ku:
       new_trending_statuses:
         title: Şandiyên rojevê
       new_trending_tags:
-        no_approved_tags: Niha hashtagên rojevê pejirandî tune ne.
-        requirements: 'Yek ji namzedên li jêr dikare ji #%{rank} hashtagaa diyarkirî ya pejirandî derbas bibe, niha ku #%{lowest_tag_name} bi %{lowest_tag_score} puan e.'
         title: Hashtagên rojevê
       subject: Rojevên nû ji bo nirxandinê li ser %{instance} derdikevin
   aliases:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -1014,8 +1014,6 @@ lv:
       new_trending_statuses:
         title: Populārākās ziņas
       new_trending_tags:
-        no_approved_tags: Pašlaik nav apstiprinātu tendenču tēmturu.
-        requirements: 'Jebkurš no šiem kandidātiem varētu pārspēt #%{rank} apstiprināto populāro tēmturi, kas pašlaik ir #%{lowest_tag_name} ar rezultātu %{lowest_tag_score}.'
         title: Populārākie tēmturi
       subject: Tiek pārskatītas jaunas tendences %{instance}
   aliases:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -977,8 +977,6 @@ ms:
       new_trending_statuses:
         title: Pos sohor kini
       new_trending_tags:
-        no_approved_tags: Pada masa ini tiada hashtag sohor kini yang diluluskan.
-        requirements: 'Mana-mana calon ini boleh melepasi hashtag arah aliran #%{rank} yang diluluskan, yang pada masa ini ialah #%{lowest_tag_name} dengan markah %{lowest_tag_score}.'
         title: Hashtag sohor kini
       subject: Trend baharu untuk kesemakan pada %{instance}
   aliases:

--- a/config/locales/my.yml
+++ b/config/locales/my.yml
@@ -962,8 +962,6 @@ my:
       new_trending_statuses:
         title: လက်ရှိခေတ်စားနေသော ပို့စ်များ
       new_trending_tags:
-        no_approved_tags: လက်ရှိတွင် အတည်ပြုထားသော ခေတ်စားနေသည့် hashtag များမရှိပါ။
-        requirements: 'ဤလူများမှာ %{lowest_tag_score} ရမှတ်ဖြင့် လက်ရှိ #%{lowest_tag_name} ဖြစ်သည့် ခေတ်စားနေသော hashtag #%{rank} ကို ကျော်သွားနိုင်သည်။'
         title: လက်ရှိခေတ်စားနေသော hashtag များ
       subject: "%{instance} တွင် ပြန်လည်သုံးသပ်ရမည့် ခေတ်စားနေသောပို့စ်အသစ်များ"
   aliases:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -997,8 +997,6 @@ nl:
       new_trending_statuses:
         title: Trending berichten
       new_trending_tags:
-        no_approved_tags: Op dit moment zijn er geen goedgekeurde hashtags.
-        requirements: 'Elk van deze kandidaten kan de #%{rank} goedgekeurde trending hashtag overtreffen, die momenteel #%{lowest_tag_name} is met een score van %{lowest_tag_score}.'
         title: Trending hashtags
       subject: Nieuwe trends te beoordelen op %{instance}
   aliases:

--- a/config/locales/nn.yml
+++ b/config/locales/nn.yml
@@ -997,8 +997,6 @@ nn:
       new_trending_statuses:
         title: Populære innlegg
       new_trending_tags:
-        no_approved_tags: Det er ingen godkjende populære emneknaggar no.
-        requirements: 'Alle desse kandidatane kan stiga høgare enn den godkjende populære emneknaggen #%{rank}, som er #%{lowest_tag_name} med ei plassering på %{lowest_tag_score}.'
         title: Populære emneknaggar
       subject: Nye trendar å sjå gjennom på %{instance}
   aliases:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -997,8 +997,6 @@
       new_trending_statuses:
         title: Populære innlegg
       new_trending_tags:
-        no_approved_tags: Det er for øyeblikket ingen godkjente populære emneknagger.
-        requirements: 'Enhver av disse kandidatene kan overgå #%{rank} godkjent populære emneknagger, som for øyeblikket er #%{lowest_tag_name} med en poengsum på %{lowest_tag_score}.'
         title: Populære emneknagger
       subject: Ny trender for gjennomsyn av %{instance}
   aliases:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -1033,8 +1033,6 @@ pl:
       new_trending_statuses:
         title: Popularne teraz
       new_trending_tags:
-        no_approved_tags: Obecnie nie ma żadnych zatwierdzonych popularnych hasztagów.
-        requirements: 'Każdy z tych kandydatów może przekroczyć #%{rank} zatwierdzonych popularnych teraz hasztagów, który wynosi obecnie %{lowest_tag_name} z wynikiem %{lowest_tag_score}.'
         title: Popularne hasztagi
       subject: Nowe popularne do przeglądu na %{instance}
   aliases:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -997,8 +997,6 @@ pt-BR:
       new_trending_statuses:
         title: Publicações em alta
       new_trending_tags:
-        no_approved_tags: No momento, não há hashtags de tendências aprovadas.
-        requirements: 'Qualquer um desses candidatos poderia ultrapassar a hashtag de tendência aprovada #%{rank} , que é atualmente #%{lowest_tag_name} com uma pontuação de %{lowest_tag_score}.'
         title: Hashtags em alta
       subject: Novas tendências para revisão em %{instance}
   aliases:

--- a/config/locales/pt-PT.yml
+++ b/config/locales/pt-PT.yml
@@ -997,8 +997,6 @@ pt-PT:
       new_trending_statuses:
         title: Publicações em alta
       new_trending_tags:
-        no_approved_tags: 'Neste momento, não existem #etiquetas aprovadas para destaque.'
-        requirements: 'Qualquer um destes candidatos pode ultrapassar a #%{rank} etiqueta aprovada em destaque, que é atualmente #%{lowest_tag_name} com uma pontuação de %{lowest_tag_score}.'
         title: Etiquetas em alta
       subject: Novas tendências para revisão em %{instance}
   aliases:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -1032,8 +1032,6 @@ ru:
       new_trending_statuses:
         title: Популярные посты
       new_trending_tags:
-        no_approved_tags: На данный момент популярные подтвержденные хэштеги отсутствуют.
-        requirements: 'Каждый из этих кандидатов может превысить #%{rank} одобренных популярных хештегов. Сейчас это #%{lowest_tag_name} с числом %{lowest_tag_score}.'
         title: Популярные хэштеги
       subject: Новые тренды для проверки на %{instance}
   aliases:

--- a/config/locales/sco.yml
+++ b/config/locales/sco.yml
@@ -890,8 +890,6 @@ sco:
       new_trending_statuses:
         title: Trendin posts
       new_trending_tags:
-        no_approved_tags: There nae approved trendin hashtags the noo.
-        requirements: 'Onie o thir candidates cuid surpass the #%{rank} approved trendin hashtag, thit''s #%{lowest_tag_name} the noo, wi a score o %{lowest_tag_score}.'
         title: Trendin hashtags
       subject: New trends up fir luikin ower on %{instance}
   aliases:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -768,8 +768,6 @@ si:
       new_trending_statuses:
         title: නැගී එන ලිපි
       new_trending_tags:
-        no_approved_tags: දැනට අනුමත ප්‍රවණතා හැෂ් ටැග් නොමැත.
-        requirements: 'මෙම ඕනෑම අපේක්ෂකයෙකුට #%{rank} අනුමත ප්‍රවණතා හැෂ් ටැගය අභිබවා යා හැකිය, එය දැනට ලකුණු %{lowest_tag_score}ක් සමඟ #%{lowest_tag_name} වේ.'
         title: ප්‍රවණතා හැෂ් ටැග්
       subject: "%{instance}හි සමාලෝචනය සඳහා නව ප්‍රවණතා"
   aliases:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -1033,8 +1033,6 @@ sl:
       new_trending_statuses:
         title: Trendne objave
       new_trending_tags:
-        no_approved_tags: Trenutno ni odobrenih ključnikov v trendu.
-        requirements: Vsak od teh kandidatov bi lahko presegel odobreni ključnik v trendu št. %{rank}, ki je trenutno %{lowest_tag_name} z rezultatom %{lowest_tag_score}.
         title: Ključniki v trendu
       subject: Novi trendi za pregled na %{instance}
   aliases:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -993,7 +993,6 @@ sq:
       new_trending_statuses:
         title: Postime në modë
       new_trending_tags:
-        no_approved_tags: Aktualisht s’ka hashtag-ë në modë të miratuar.
         title: Hashtag-ë në modë
       subject: Gjëra të reja në modë për shqyrtim te %{instance}
   aliases:

--- a/config/locales/sr-Latn.yml
+++ b/config/locales/sr-Latn.yml
@@ -1015,8 +1015,6 @@ sr-Latn:
       new_trending_statuses:
         title: Objave u trendu
       new_trending_tags:
-        no_approved_tags: Trenutno nema odobrenih heš oznaka u trendu.
-        requirements: 'Bilo koji od sledećih kandidata bi mogao prevazići #%{rank} odobrenu heš oznaku u trendu, koja je trenutno #%{lowest_tag_name} sa vrednošću %{lowest_tag_score}.'
         title: Heš oznake u trendu
       subject: Novi trendovi za pregled na %{instance}
   aliases:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -1015,8 +1015,6 @@ sr:
       new_trending_statuses:
         title: Објаве у тренду
       new_trending_tags:
-        no_approved_tags: Тренутно нема одобрених хеш ознака у тренду.
-        requirements: 'Било који од следећих кандидата би могао превазићи #%{rank} одобрену хеш ознаку у тренду, која је тренутно #%{lowest_tag_name} са вредношћу %{lowest_tag_score}.'
         title: Хеш ознаке у тренду
       subject: Нови трендови за преглед на %{instance}
   aliases:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -996,8 +996,6 @@ sv:
       new_trending_statuses:
         title: Trendande inlägg
       new_trending_tags:
-        no_approved_tags: Det finns för närvarande inga godkända trendande hashtaggar.
-        requirements: 'Någon av dessa kandidater skulle kunna överträffa #%{rank} godkända trendande hashtaggar, som för närvarande är #%{lowest_tag_name} med en poäng på %{lowest_tag_score}.'
         title: Trendande hashtaggar
       subject: Nya trender tillgängliga för granskning på %{instance}
   aliases:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -979,8 +979,6 @@ th:
       new_trending_statuses:
         title: โพสต์ที่กำลังนิยม
       new_trending_tags:
-        no_approved_tags: ไม่มีแฮชแท็กที่กำลังนิยมที่ได้รับอนุมัติในปัจจุบัน
-        requirements: 'ตัวเลือกใดก็ตามนี้สามารถแซงหน้าแฮชแท็กที่กำลังนิยมที่ได้รับอนุมัติ #%{rank} ซึ่งคือ #%{lowest_tag_name} ในปัจจุบันด้วยคะแนน %{lowest_tag_score}'
         title: แฮชแท็กที่กำลังนิยม
       subject: แนวโน้มใหม่สำหรับตรวจทานใน %{instance}
   aliases:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -997,8 +997,6 @@ tr:
       new_trending_statuses:
         title: Öne çıkan gönderiler
       new_trending_tags:
-        no_approved_tags: Şu anda onaylanmış öne çıkan etiket yok.
-        requirements: 'Aşağıdaki adaylardan herhangi biri, şu anda %{lowest_tag_score} skoruna sahip "%{lowest_tag_name}" olan #%{rank} onaylanmış öne çıkan etiketi geçebilir.'
         title: Öne çıkan etiketler
       subject: "%{instance}, inceleme bekleyen yeni öne çıkan öğelere sahip"
   aliases:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -1033,8 +1033,6 @@ uk:
       new_trending_statuses:
         title: Популярні дописи
       new_trending_tags:
-        no_approved_tags: На цей час немає схвалених популярних хештегів.
-        requirements: 'Кожен з цих кандидатів може перевершити #%{rank} затвердженого популярного хештеґу, який зараз на #%{lowest_tag_name} з рейтингом %{lowest_tag_score}.'
         title: Популярні хештеги
       subject: Нове популярне до розгляду на %{instance}
   aliases:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -979,8 +979,6 @@ vi:
       new_trending_statuses:
         title: Tút nổi bật
       new_trending_tags:
-        no_approved_tags: Hiện tại không có hashtag nổi bật nào được duyệt.
-        requirements: 'Bất kỳ ứng cử viên nào vượt qua #%{rank} duyệt hashtag nổi bật, với hiện tại là "%{lowest_tag_name}" với điểm số %{lowest_tag_score}.'
         title: Hashtag nổi bật
       subject: Nội dung nổi bật chờ duyệt trên %{instance}
   aliases:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -979,8 +979,6 @@ zh-CN:
       new_trending_statuses:
         title: 热门嘟文
       new_trending_tags:
-        no_approved_tags: 目前没有经批准的热门标签。
-        requirements: '这些候选人都可能会超过#%{rank} 批准的热门标签，目前是 #%{lowest_tag_name} ，分数为 %{lowest_tag_score}。'
         title: 热门标签
       subject: "%{instance} 上有新热门等待审核"
   aliases:

--- a/config/locales/zh-HK.yml
+++ b/config/locales/zh-HK.yml
@@ -979,8 +979,6 @@ zh-HK:
       new_trending_statuses:
         title: 熱門帖文
       new_trending_tags:
-        no_approved_tags: 目前沒有經核准的熱門標籤。
-        requirements: '任何一個候選都可能超過 #%{rank} 被核准的標籤。目前是 %{lowest_tag_name} 標籤，得分為 %{lowest_tag_score}。'
         title: 熱門標籤
       subject: "%{instance} 上有待審核的新熱門"
   aliases:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -981,8 +981,6 @@ zh-TW:
       new_trending_statuses:
         title: 熱門嘟文
       new_trending_tags:
-        no_approved_tags: 這些是目前仍未被審核之熱門主題標籤。
-        requirements: '這些候選中的任何一個都可能超過 #%{rank} 已批准的熱門主題標籤，該主題標籤目前是 #%{lowest_tag_name}，得分為 %{lowest_tag_score}。'
         title: 熱門主題標籤
       subject: "%{instance} 有待審核之新熱門"
   aliases:


### PR DESCRIPTION
Collection of changes:

- Add setup data to the mailer spec so that there are trending records for the mailer view to display
- Remove reference to previously delete i-var in tags partial - https://github.com/mastodon/mastodon/commit/45ebdb72ca1678eb30e6087f61bd019c7ea903f4#diff-15471f8ef646073845676abeea9b17a9fbae41f64d73a801663c041521605730L42
- Avoid referencing i-vars defined elsewhere in the partials, pass in locals vars instead
- Remove 'double checking' around partial rendering in main view logic