### PR TITLE
Fix onboarding step descriptions being truncated on narrow screens

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2732,22 +2732,16 @@ $ui-header-height: 55px;
     &__description {
       flex: 1 1 auto;
       line-height: 20px;
-      white-space: nowrap;
-      text-overflow: ellipsis;
-      overflow: hidden;
 
       h6 {
         color: $highlight-text-color;
         font-weight: 500;
         font-size: 14px;
-        overflow: hidden;
-        text-overflow: ellipsis;
       }
 
       p {
         color: $darker-text-color;
         overflow: hidden;
-        text-overflow: ellipsis;
       }
     }
   }


### PR DESCRIPTION
Fixes #27974

## Before

![image](https://github.com/mastodon/mastodon/assets/384364/4f1cd9b9-beed-4f2f-a49d-d4a1845c7b14)

## After

![image](https://github.com/mastodon/mastodon/assets/384364/35bb00a2-8a3c-4e97-a349-8630cbf916f0)