### PR TITLE
Remove un-needed `action` and `template` options to `render` in controllers

### DIFF
--- a/app/controllers/admin/account_moderation_notes_controller.rb
+++ b/app/controllers/admin/account_moderation_notes_controller.rb
@@ -16,7 +16,7 @@ module Admin
         @moderation_notes = @account.targeted_moderation_notes.latest
         @warnings         = @account.strikes.custom.latest
 
-        render template: 'admin/accounts/show'
+        render 'admin/accounts/show'
       end
     end
 

--- a/app/controllers/admin/relays_controller.rb
+++ b/app/controllers/admin/relays_controller.rb
@@ -24,7 +24,7 @@ module Admin
         @relay.enable!
         redirect_to admin_relays_path
       else
-        render action: :new
+        render :new
       end
     end
 

--- a/app/controllers/admin/report_notes_controller.rb
+++ b/app/controllers/admin/report_notes_controller.rb
@@ -26,7 +26,7 @@ module Admin
         @form         = Admin::StatusBatchAction.new
         @statuses     = @report.statuses.with_includes
 
-        render template: 'admin/reports/show'
+        render 'admin/reports/show'
       end
     end
 

--- a/app/controllers/concerns/challengable_concern.rb
+++ b/app/controllers/concerns/challengable_concern.rb
@@ -43,7 +43,7 @@ module ChallengableConcern
 
   def render_challenge
     @body_classes = 'lighter'
-    render template: 'auth/challenges/new', layout: 'auth'
+    render 'auth/challenges/new', layout: 'auth'
   end
 
   def challenge_passed?

--- a/app/controllers/disputes/appeals_controller.rb
+++ b/app/controllers/disputes/appeals_controller.rb
@@ -11,7 +11,7 @@ class Disputes::AppealsController < Disputes::BaseController
     redirect_to disputes_strike_path(@strike), notice: I18n.t('disputes.strikes.appealed_msg')
   rescue ActiveRecord::RecordInvalid => e
     @appeal = e.record
-    render template: 'disputes/strikes/show'
+    render 'disputes/strikes/show'
   end
 
   private

--- a/app/controllers/filters_controller.rb
+++ b/app/controllers/filters_controller.rb
@@ -25,7 +25,7 @@ class FiltersController < ApplicationController
     if @filter.save
       redirect_to filters_path
     else
-      render action: :new
+      render :new
     end
   end
 
@@ -33,7 +33,7 @@ class FiltersController < ApplicationController
     if @filter.update(resource_params)
       redirect_to filters_path
     else
-      render action: :edit
+      render :edit
     end
   end
 

--- a/app/controllers/statuses_cleanup_controller.rb
+++ b/app/controllers/statuses_cleanup_controller.rb
@@ -14,7 +14,7 @@ class StatusesCleanupController < ApplicationController
     if @policy.update(resource_params)
       redirect_to statuses_cleanup_path, notice: I18n.t('generic.changes_saved_msg')
     else
-      render action: :show
+      render :show
     end
   rescue ActionController::ParameterMissing
     # Do nothing

--- a/spec/controllers/concerns/challengable_concern_spec.rb
+++ b/spec/controllers/concerns/challengable_concern_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe ChallengableConcern do
       before { get :foo }
 
       it 'renders challenge' do
-        expect(response).to render_template('auth/challenges/new')
+        expect(response).to render_template('auth/challenges/new', layout: :auth)
       end
 
       # See Auth::ChallengesControllerSpec
@@ -95,7 +95,7 @@ RSpec.describe ChallengableConcern do
       before { post :bar }
 
       it 'renders challenge' do
-        expect(response).to render_template('auth/challenges/new')
+        expect(response).to render_template('auth/challenges/new', layout: :auth)
       end
 
       it 'accepts correct password' do
@@ -106,7 +106,7 @@ RSpec.describe ChallengableConcern do
 
       it 'rejects wrong password' do
         post :bar, params: { form_challenge: { current_password: 'dddfff888123' } }
-        expect(response.body).to render_template('auth/challenges/new')
+        expect(response.body).to render_template('auth/challenges/new', layout: :auth)
         expect(session[:challenge_passed_at]).to be_nil
       end
     end


### PR DESCRIPTION
These were required in very early rails versions but haven't been for some time.