### PR TITLE
Change `img-src` and `media-src` CSP directives to not include `https:`

### DIFF
--- a/app/lib/content_security_policy.rb
+++ b/app/lib/content_security_policy.rb
@@ -9,8 +9,8 @@ class ContentSecurityPolicy
     url_from_configured_asset_host || url_from_base_host
   end
 
-  def media_host
-    cdn_host_value || assets_host
+  def media_hosts
+    [assets_host, cdn_host_value].compact
   end
 
   private

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -10,7 +10,7 @@ require_relative '../../app/lib/content_security_policy'
 
 policy = ContentSecurityPolicy.new
 assets_host = policy.assets_host
-media_host = policy.media_host
+media_hosts = policy.media_hosts
 
 def sso_host
   return unless ENV['ONE_CLICK_SSO_LOGIN'] == 'true'
@@ -35,9 +35,9 @@ Rails.application.config.content_security_policy do |p|
   p.default_src     :none
   p.frame_ancestors :none
   p.font_src        :self, assets_host
-  p.img_src         :self, :https, :data, :blob, assets_host
+  p.img_src         :self, :data, :blob, *media_hosts
   p.style_src       :self, assets_host
-  p.media_src       :self, :https, :data, assets_host
+  p.media_src       :self, :data, *media_hosts
   p.frame_src       :self, :https
   p.manifest_src    :self, assets_host
 
@@ -54,10 +54,10 @@ Rails.application.config.content_security_policy do |p|
     webpacker_public_host = ENV.fetch('WEBPACKER_DEV_SERVER_PUBLIC', Webpacker.config.dev_server[:public])
     webpacker_urls = %w(ws http).map { |protocol| "#{protocol}#{Webpacker.dev_server.https? ? 's' : ''}://#{webpacker_public_host}" }
 
-    p.connect_src :self, :data, :blob, assets_host, media_host, Rails.configuration.x.streaming_api_base_url, *webpacker_urls
+    p.connect_src :self, :data, :blob, *media_hosts, Rails.configuration.x.streaming_api_base_url, *webpacker_urls
     p.script_src  :self, :unsafe_inline, :unsafe_eval, assets_host
   else
-    p.connect_src :self, :data, :blob, assets_host, media_host, Rails.configuration.x.streaming_api_base_url
+    p.connect_src :self, :data, :blob, *media_hosts, Rails.configuration.x.streaming_api_base_url
     p.script_src  :self, assets_host, "'wasm-unsafe-eval'"
   end
 end

--- a/spec/lib/content_security_policy_spec.rb
+++ b/spec/lib/content_security_policy_spec.rb
@@ -59,10 +59,10 @@ describe ContentSecurityPolicy do
     end
   end
 
-  describe '#media_host' do
+  describe '#media_hosts' do
     context 'when there is no configured CDN' do
       it 'defaults to using the assets_host value' do
-        expect(subject.media_host).to eq(subject.assets_host)
+        expect(subject.media_hosts).to contain_exactly(subject.assets_host)
       end
     end
 
@@ -74,7 +74,7 @@ describe ContentSecurityPolicy do
       end
 
       it 'uses the s3 alias host value' do
-        expect(subject.media_host).to eq 'https://asset-host.s3-alias.example'
+        expect(subject.media_hosts).to contain_exactly(subject.assets_host, 'https://asset-host.s3-alias.example')
       end
     end
 
@@ -86,7 +86,7 @@ describe ContentSecurityPolicy do
       end
 
       it 'uses the s3 alias host value and preserves the path' do
-        expect(subject.media_host).to eq 'https://asset-host.s3-alias.example/pathname/'
+        expect(subject.media_hosts).to contain_exactly(subject.assets_host, 'https://asset-host.s3-alias.example/pathname/')
       end
     end
 
@@ -98,7 +98,7 @@ describe ContentSecurityPolicy do
       end
 
       it 'uses the s3 cloudfront host value' do
-        expect(subject.media_host).to eq 'https://asset-host.s3-cloudfront.example'
+        expect(subject.media_hosts).to contain_exactly(subject.assets_host, 'https://asset-host.s3-cloudfront.example')
       end
     end
 
@@ -110,7 +110,7 @@ describe ContentSecurityPolicy do
       end
 
       it 'uses the azure alias host value' do
-        expect(subject.media_host).to eq 'https://asset-host.azure-alias.example'
+        expect(subject.media_hosts).to contain_exactly(subject.assets_host, 'https://asset-host.azure-alias.example')
       end
     end
 
@@ -122,7 +122,7 @@ describe ContentSecurityPolicy do
       end
 
       it 'uses the s3 hostname host value' do
-        expect(subject.media_host).to eq 'https://asset-host.s3.example'
+        expect(subject.media_hosts).to contain_exactly(subject.assets_host, 'https://asset-host.s3.example')
       end
     end
   end

--- a/spec/requests/content_security_policy_spec.rb
+++ b/spec/requests/content_security_policy_spec.rb
@@ -12,15 +12,15 @@ describe 'Content-Security-Policy' do
       "default-src 'none'",
       "frame-ancestors 'none'",
       "font-src 'self' https://cb6e6126.ngrok.io",
-      "img-src 'self' https: data: blob: https://cb6e6126.ngrok.io",
+      "img-src 'self' data: blob: https://cb6e6126.ngrok.io",
       "style-src 'self' https://cb6e6126.ngrok.io 'nonce-ZbA+JmE7+bK8F5qvADZHuQ=='",
-      "media-src 'self' https: data: https://cb6e6126.ngrok.io",
+      "media-src 'self' data: https://cb6e6126.ngrok.io",
       "frame-src 'self' https:",
       "manifest-src 'self' https://cb6e6126.ngrok.io",
       "form-action 'self'",
       "child-src 'self' blob: https://cb6e6126.ngrok.io",
       "worker-src 'self' blob: https://cb6e6126.ngrok.io",
-      "connect-src 'self' data: blob: https://cb6e6126.ngrok.io https://cb6e6126.ngrok.io ws://localhost:4000",
+      "connect-src 'self' data: blob: https://cb6e6126.ngrok.io ws://localhost:4000",
       "script-src 'self' https://cb6e6126.ngrok.io 'wasm-unsafe-eval'"
     )
   end


### PR DESCRIPTION
Include the media host instead, and ensure there is no duplicate in `img-src`, `media-src` or `connect-src`.