### PR TITLE
Remove `default_scope` from `Admin::ActionLog`

### DIFF
--- a/app/controllers/admin/action_logs_controller.rb
+++ b/app/controllers/admin/action_logs_controller.rb
@@ -6,7 +6,7 @@ module Admin
 
     def index
       authorize :audit_log, :index?
-      @auditable_accounts = Account.where(id: Admin::ActionLog.reorder(nil).select('distinct account_id')).select(:id, :username)
+      @auditable_accounts = Account.where(id: Admin::ActionLog.select('distinct account_id')).select(:id, :username)
     end
 
     private

--- a/app/models/admin/action_log.rb
+++ b/app/models/admin/action_log.rb
@@ -28,6 +28,8 @@ class Admin::ActionLog < ApplicationRecord
   before_validation :set_route_param
   before_validation :set_permalink
 
+  scope :latest, -> { order(id: :desc) }
+
   def action
     super.to_sym
   end

--- a/app/models/admin/action_log.rb
+++ b/app/models/admin/action_log.rb
@@ -24,8 +24,6 @@ class Admin::ActionLog < ApplicationRecord
   belongs_to :account
   belongs_to :target, polymorphic: true, optional: true
 
-  default_scope -> { order('id desc') }
-
   before_validation :set_human_identifier
   before_validation :set_route_param
   before_validation :set_permalink

--- a/app/models/admin/action_log_filter.rb
+++ b/app/models/admin/action_log_filter.rb
@@ -72,7 +72,7 @@ class Admin::ActionLogFilter
   end
 
   def results
-    scope = Admin::ActionLog.includes(:target)
+    scope = latest_action_logs.includes(:target)
 
     params.each do |key, value|
       next if key.to_s == 'page'
@@ -88,14 +88,18 @@ class Admin::ActionLogFilter
   def scope_for(key, value)
     case key
     when 'action_type'
-      Admin::ActionLog.where(ACTION_TYPE_MAP[value.to_sym])
+      latest_action_logs.where(ACTION_TYPE_MAP[value.to_sym])
     when 'account_id'
-      Admin::ActionLog.where(account_id: value)
+      latest_action_logs.where(account_id: value)
     when 'target_account_id'
       account = Account.find_or_initialize_by(id: value)
-      Admin::ActionLog.where(target: [account, account.user].compact)
+      latest_action_logs.where(target: [account, account.user].compact)
     else
       raise Mastodon::InvalidParameterError, "Unknown filter: #{key}"
     end
+  end
+
+  def latest_action_logs
+    Admin::ActionLog.latest
   end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -131,22 +131,22 @@ class Report < ApplicationRecord
       Admin::ActionLog.where(
         target_type: 'Report',
         target_id: id
-      ).unscope(:order).arel,
+      ).arel,
 
       Admin::ActionLog.where(
         target_type: 'Account',
         target_id: target_account_id
-      ).unscope(:order).arel,
+      ).arel,
 
       Admin::ActionLog.where(
         target_type: 'Status',
         target_id: status_ids
-      ).unscope(:order).arel,
+      ).arel,
 
       Admin::ActionLog.where(
         target_type: 'AccountWarning',
         target_id: AccountWarning.where(report_id: id).select(:id)
-      ).unscope(:order).arel,
+      ).arel,
     ].reduce { |union, query| Arel::Nodes::UnionAll.new(union, query) }
 
     Admin::ActionLog.from(Arel::Nodes::As.new(subquery, Admin::ActionLog.arel_table))

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -149,7 +149,7 @@ class Report < ApplicationRecord
       ).arel,
     ].reduce { |union, query| Arel::Nodes::UnionAll.new(union, query) }
 
-    Admin::ActionLog.from(Arel::Nodes::As.new(subquery, Admin::ActionLog.arel_table))
+    Admin::ActionLog.latest.from(Arel::Nodes::As.new(subquery, Admin::ActionLog.arel_table))
   end
 
   private

--- a/spec/fabricators/action_log_fabricator.rb
+++ b/spec/fabricators/action_log_fabricator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-Fabricator('Admin::ActionLog') do
+Fabricator(:action_log, from: Admin::ActionLog) do
   account { Fabricate.build(:account) }
   action  'MyString'
   target  nil

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -110,9 +110,9 @@ describe Report do
     let(:status) { Fabricate(:status) }
 
     before do
-      Fabricate('Admin::ActionLog', target_type: 'Report', account_id: target_account.id, target_id: report.id, created_at: 2.days.ago)
-      Fabricate('Admin::ActionLog', target_type: 'Account', account_id: target_account.id, target_id: report.target_account_id, created_at: 2.days.ago)
-      Fabricate('Admin::ActionLog', target_type: 'Status', account_id: target_account.id, target_id: status.id, created_at: 2.days.ago)
+      Fabricate(:action_log, target_type: 'Report', account_id: target_account.id, target_id: report.id, created_at: 2.days.ago)
+      Fabricate(:action_log, target_type: 'Account', account_id: target_account.id, target_id: report.target_account_id, created_at: 2.days.ago)
+      Fabricate(:action_log, target_type: 'Status', account_id: target_account.id, target_id: status.id, created_at: 2.days.ago)
     end
 
     it 'returns right logs' do


### PR DESCRIPTION
I think we should avoid `default_scope` in general (there are few uses left after this one) but for this one specifically, I think we are over-riding it more than benefitting from it.

This removes the default_scope from the class, un-does the removal of it which is not needed now. I also noticed that the fabricator for this class was the only one of all the fabricator using the string-class approach (instead of a `from` option for its class), and updated that.