### PR TITLE
Add coverage for `api/v2/media` endpoint

### DIFF
--- a/app/controllers/api/v2/media_controller.rb
+++ b/app/controllers/api/v2/media_controller.rb
@@ -2,12 +2,22 @@
 
 class Api::V2::MediaController < Api::V1::MediaController
   def create
-    @media_attachment = current_account.media_attachments.create!({ delay_processing: true }.merge(media_attachment_params))
-    render json: @media_attachment, serializer: REST::MediaAttachmentSerializer, status: @media_attachment.not_processed? ? 202 : 200
+    @media_attachment = current_account.media_attachments.create!(media_and_delay_params)
+    render json: @media_attachment, serializer: REST::MediaAttachmentSerializer, status: status_from_media_processing
   rescue Paperclip::Errors::NotIdentifiedByImageMagickError
     render json: file_type_error, status: 422
   rescue Paperclip::Error => e
     Rails.logger.error "#{e.class}: #{e.message}"
     render json: processing_error, status: 500
+  end
+
+  private
+
+  def media_and_delay_params
+    { delay_processing: true }.merge(media_attachment_params)
+  end
+
+  def status_from_media_processing
+    @media_attachment.not_processed? ? 202 : 200
   end
 end

--- a/spec/requests/api/v2/media_spec.rb
+++ b/spec/requests/api/v2/media_spec.rb
@@ -9,10 +9,82 @@ RSpec.describe 'Media API', :paperclip_processing do
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
 
   describe 'POST /api/v2/media' do
-    it 'returns http success' do
-      post '/api/v2/media', headers: headers, params: { file: fixture_file_upload('attachment-jpg.123456_abcd', 'image/jpeg') }
-      expect(File.exist?(user.account.media_attachments.first.file.path(:small))).to be true
-      expect(response).to have_http_status(200)
+    context 'when small media format attachment is processed immediately' do
+      let(:params) { { file: fixture_file_upload('attachment-jpg.123456_abcd', 'image/jpeg') } }
+
+      it 'returns http success' do
+        post '/api/v2/media', headers: headers, params: params
+
+        expect(File.exist?(user.account.media_attachments.first.file.path(:small)))
+          .to be true
+
+        expect(response)
+          .to have_http_status(200)
+
+        expect(body_as_json)
+          .to be_a(Hash)
+      end
+    end
+
+    context 'when large format media attachment has not been processed' do
+      let(:params) { { file: fixture_file_upload('attachment.webm', 'video/webm') } }
+
+      it 'returns http accepted' do
+        post '/api/v2/media', headers: headers, params: params
+
+        expect(File.exist?(user.account.media_attachments.first.file.path(:small)))
+          .to be true
+
+        expect(response)
+          .to have_http_status(202)
+
+        expect(body_as_json)
+          .to be_a(Hash)
+      end
+    end
+
+    describe 'when paperclip errors occur' do
+      let(:media_attachments) { double }
+      let(:params)            { { file: fixture_file_upload('attachment.jpg', 'image/jpeg') } }
+
+      before do
+        allow(User).to receive(:find).with(token.resource_owner_id).and_return(user)
+        allow(user.account).to receive(:media_attachments).and_return(media_attachments)
+      end
+
+      context 'when imagemagick cannot identify the file type' do
+        before do
+          allow(media_attachments).to receive(:create!).and_raise(Paperclip::Errors::NotIdentifiedByImageMagickError)
+        end
+
+        it 'returns http unprocessable entity' do
+          post '/api/v2/media', headers: headers, params: params
+
+          expect(response)
+            .to have_http_status(422)
+
+          expect(body_as_json)
+            .to be_a(Hash)
+            .and include(error: /File type/)
+        end
+      end
+
+      context 'when there is a generic error' do
+        before do
+          allow(media_attachments).to receive(:create!).and_raise(Paperclip::Error)
+        end
+
+        it 'returns http 500' do
+          post '/api/v2/media', headers: headers, params: params
+
+          expect(response)
+            .to have_http_status(500)
+
+          expect(body_as_json)
+            .to be_a(Hash)
+            .and include(error: /processing/)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
The prior coverage only hit the "processing done" scenario and not the "still processing" scenario, and did not hit either of the error paths. Borrowed some of the error stubbing from the v1 request spec, and added the still processing flow.

Tiny private method extraction from the controller while reviewing coverage.
