### PR TITLE
Extract options checks methods from `cli/media`

### DIFF
--- a/lib/mastodon/cli/media.rb
+++ b/lib/mastodon/cli/media.rb
@@ -328,7 +328,7 @@ module Mastodon::CLI
     def verify_remove_options!
       fail_with_message '--prune-profiles and --remove-headers should not be specified simultaneously' if options[:prune_profiles] && options[:remove_headers]
 
-      fail_with_message '--include-follows can only be used with --prune-profiles or --remove-headers' if options[:include_follows] && !(options[:prune_profiles] || options[:remove_headers])
+      fail_with_message '--include-follows can only be used with --prune-profiles or --remove-headers' if options[:include_follows] && !prune_profiles_or_remove_headers?
     end
 
     def prune_profiles_or_remove_headers?

--- a/lib/mastodon/cli/media.rb
+++ b/lib/mastodon/cli/media.rb
@@ -31,9 +31,7 @@ module Mastodon::CLI
       following anyone locally are pruned.
     DESC
     def remove
-      fail_with_message '--prune-profiles and --remove-headers should not be specified simultaneously' if options[:prune_profiles] && options[:remove_headers]
-
-      fail_with_message '--include-follows can only be used with --prune-profiles or --remove-headers' if options[:include_follows] && !(options[:prune_profiles] || options[:remove_headers])
+      verify_remove_options!
       time_ago = options[:days].days.ago
 
       if options[:prune_profiles] || options[:remove_headers]
@@ -326,6 +324,12 @@ module Mastodon::CLI
       PreviewCard
       SiteUpload
     ).freeze
+
+    def verify_remove_options!
+      fail_with_message '--prune-profiles and --remove-headers should not be specified simultaneously' if options[:prune_profiles] && options[:remove_headers]
+
+      fail_with_message '--include-follows can only be used with --prune-profiles or --remove-headers' if options[:include_follows] && !(options[:prune_profiles] || options[:remove_headers])
+    end
 
     def preload_records_from_mixed_objects(objects)
       preload_map = Hash.new { |hash, key| hash[key] = [] }


### PR DESCRIPTION
_Extracted from https://github.com/mastodon/mastodon/pull/25320 and https://github.com/mastodon/mastodon/pull/25249_

The linked PRs initially had a mix of spec changes and refactoring, but the refactoring proved excessive to review in one pass. The specs were extracted and merged. This is an extraction of some of the refactor, which is hopefully more reviewable.