### PR TITLE
Extract `time_ago` helper from CLI classes

### DIFF
--- a/lib/mastodon/cli/base.rb
+++ b/lib/mastodon/cli/base.rb
@@ -29,6 +29,14 @@ module Mastodon
         dry_run? ? ' (DRY RUN)' : ''
       end
 
+      def time_ago
+        options[:days].days.ago
+      end
+
+      def days_option_present?
+        options[:days].present?
+      end
+
       def reset_connection_pools!
         ActiveRecord::Base.establish_connection(
           ActiveRecord::Base.configurations.configs_for(env_name: Rails.env).first.configuration_hash

--- a/lib/mastodon/cli/media.rb
+++ b/lib/mastodon/cli/media.rb
@@ -350,14 +350,6 @@ module Mastodon::CLI
       SiteUpload
     ).freeze
 
-    def time_ago
-      options[:days].days.ago
-    end
-
-    def days_option_present?
-      options[:days].present?
-    end
-
     def preload_records_from_mixed_objects(objects)
       preload_map = Hash.new { |hash, key| hash[key] = [] }
 

--- a/lib/mastodon/cli/preview_cards.rb
+++ b/lib/mastodon/cli/preview_cards.rb
@@ -46,11 +46,5 @@ module Mastodon::CLI
 
       say("Removed #{processed} #{link}preview cards (approx. #{number_to_human_size(aggregate)})#{dry_run_mode_suffix}", :green, true)
     end
-
-    private
-
-    def time_ago
-      options[:days].days.ago
-    end
   end
 end

--- a/lib/mastodon/cli/preview_cards.rb
+++ b/lib/mastodon/cli/preview_cards.rb
@@ -26,7 +26,6 @@ module Mastodon::CLI
       leaving video and photo cards untouched.
     DESC
     def remove
-      time_ago = options[:days].days.ago
       link     = options[:link] ? 'link-type ' : ''
       scope    = PreviewCard.cached
       scope    = scope.where(type: :link) if options[:link]
@@ -46,6 +45,12 @@ module Mastodon::CLI
       end
 
       say("Removed #{processed} #{link}preview cards (approx. #{number_to_human_size(aggregate)})#{dry_run_mode_suffix}", :green, true)
+    end
+
+    private
+
+    def time_ago
+      options[:days].days.ago
     end
   end
 end

--- a/lib/mastodon/cli/statuses.rb
+++ b/lib/mastodon/cli/statuses.rb
@@ -215,9 +215,5 @@ module Mastodon::CLI
         ActiveRecord::Base.connection.execute('ANALYZE conversations')
       end
     end
-
-    def time_ago
-      options[:days].days.ago
-    end
   end
 end

--- a/lib/mastodon/cli/statuses.rb
+++ b/lib/mastodon/cli/statuses.rb
@@ -47,7 +47,7 @@ module Mastodon::CLI
 
       ActiveRecord::Base.connection.add_index(:media_attachments, :remote_url, name: :index_media_attachments_remote_url, where: 'remote_url is not null', algorithm: :concurrently, if_not_exists: true)
 
-      max_id   = Mastodon::Snowflake.id_at(options[:days].days.ago, with_random: false)
+      max_id   = Mastodon::Snowflake.id_at(time_ago, with_random: false)
       start_at = Time.now.to_f
 
       unless options[:continue] && ActiveRecord::Base.connection.table_exists?('statuses_to_be_deleted')
@@ -214,6 +214,10 @@ module Mastodon::CLI
         say('Run ANALYZE to conversations...')
         ActiveRecord::Base.connection.execute('ANALYZE conversations')
       end
+    end
+
+    def time_ago
+      options[:days].days.ago
     end
   end
 end


### PR DESCRIPTION
_Extracted from https://github.com/mastodon/mastodon/pull/25320 and https://github.com/mastodon/mastodon/pull/25249_

The linked PRs initially had a mix of spec changes and refactoring, but the refactoring proved excessive to review in one pass. The specs were extracted and merged. This is an extraction of some of the refactor, which is hopefully more reviewable.