### PR TITLE
Normalize before comparing hostname and scheme

### DIFF
--- a/spec/models/account/field_spec.rb
+++ b/spec/models/account/field_spec.rb
@@ -68,6 +68,14 @@ RSpec.describe Account::Field do
         end
       end
 
+      context 'with an HTTP URL' do
+        let(:value) { 'http://example.com' }
+
+        it 'returns false' do
+          expect(subject.verifiable?).to be false
+        end
+      end
+
       context 'with an IDN URL' do
         let(:value) { 'https://twitter.com∕dougallj∕status∕1590357240443437057.ê.cc/twitter.html' }
 


### PR DESCRIPTION
Scheme and hostname should be normalised to lowercase before comparing. [`URI#normalize`](https://github.com/ruby/uri/blob/b50d37f7a193991c56bda7f94e8dd6fec0bb3f7f/lib/uri/generic.rb#L1328-L1338) does just that.

Fixes #20944