### PR TITLE
WIP: Add system:{account_id} channels for blocks, domain_blocks and mutes

### DIFF
--- a/app/services/after_block_service.rb
+++ b/app/services/after_block_service.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class AfterBlockService < BaseService
+  include Redisable
+
   def call(account, target_account)
     @account        = account
     @target_account = target_account
@@ -9,6 +11,7 @@ class AfterBlockService < BaseService
     clear_list_feeds!
     clear_notifications!
     clear_conversations!
+    notify_streaming!
   end
 
   private
@@ -27,5 +30,10 @@ class AfterBlockService < BaseService
 
   def clear_notifications!
     Notification.where(account: @account).where(from_account: @target_account).in_batches.delete_all
+  end
+
+  def notify_streaming!
+    redis.publish("system:#{@account.id}", Oj.dump(event: :blocks_changed))
+    redis.publish("system:#{@target_account.id}", Oj.dump(event: :blocks_changed)) if @target_account.local?
   end
 end

--- a/app/services/unmute_service.rb
+++ b/app/services/unmute_service.rb
@@ -7,5 +7,14 @@ class UnmuteService < BaseService
     account.unmute!(target_account)
 
     MergeWorker.perform_async(target_account.id, account.id) if account.following?(target_account)
+
+    notify_streaming!
+  end
+
+  private
+
+  def notify_streaming!
+    redis.publish("system:#{@account.id}", Oj.dump(event: :mutes_changed))
+    redis.publish("system:#{@target_account.id}", Oj.dump(event: :mutes_changed)) if @target_account.local?
   end
 end

--- a/app/workers/mute_worker.rb
+++ b/app/workers/mute_worker.rb
@@ -2,10 +2,26 @@
 
 class MuteWorker
   include Sidekiq::Worker
+  include Redisable
 
   def perform(account_id, target_account_id)
-    FeedManager.instance.clear_from_home(Account.find(account_id), Account.find(target_account_id))
+    @account        = Account.find(account_id)
+    @target_account = Account.find(target_account_id)
+
+    clear_home_feed!
+    notify_streaming!
   rescue ActiveRecord::RecordNotFound
     true
+  end
+
+  private
+
+  def clear_home_feed!
+    FeedManager.instance.clear_from_home(@account, @target_account)
+  end
+
+  def notify_streaming!
+    redis.publish("system:#{@account.id}", Oj.dump(event: :mutes_changed))
+    redis.publish("system:#{@target_account.id}", Oj.dump(event: :mutes_changed)) if @target_account.local?
   end
 end


### PR DESCRIPTION
**Note: this is not meant to be merged, I'm just looking for early feedback. This is part of a [larger change planned](https://github.com/mastodon/mastodon/issues/28010), I just wanna check I'm on the right track.**

Questions:
- Should there be some logic in the Account Interactions model concern?
- The unblocking of a domain at account level appears to only happen in Account Interactions model concern, should there be a service + worker for notifying streaming?
- Should the events send across data about the account IDs or domains that were affected? e.g., ```redis.publish("system:#{@account.id}", Oj.dump(event: :blocks_changed, target: @target_account.id ))``` and ```redis.publish("system:#{@target_account.id}", Oj.dump(event: :blocks_changed, source: @account.id ))``` \
or would it be better to just receive the event notice and refetch for the database?

Notes:
- I'm using a `system:{account.id}` channel, as to differentiate from the "timeline" channels which to me are events that could be made public. In my opinion the `timeline:system` prefix should be discontinued, and we should only have a single internal channel per account.
- For `"timeline:access_token:#{id}"` I also envision this to be moved to the `system:{account.id}` channel, where it'd be based on the `oauth_access_token`'s `resource_owner_id` or something, or just compacted into a single `system` channel.
- I haven't introduced the `Streaming` module yet here, but we can definitely see why it becomes necessary!