### PR TITLE
Ignore Style/WordArray in languages_helper

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -103,10 +103,3 @@ Style/RedundantConstantBase:
   Exclude:
     - 'config/environments/production.rb'
     - 'config/initializers/sidekiq.rb'
-
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: WordRegex.
-# SupportedStyles: percent, brackets
-Style/WordArray:
-  EnforcedStyle: percent
-  MinSize: 3

--- a/app/helpers/languages_helper.rb
+++ b/app/helpers/languages_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module LanguagesHelper
+  # rubocop:disable Style/WordArray
   ISO_639_1 = {
     aa: ['Afar', 'Afaraf'].freeze,
     ab: ['Abkhaz', 'аҧсуа бызшәа'].freeze,
@@ -221,6 +222,8 @@ module LanguagesHelper
     'zh-TW': ['Chinese (Taiwan)', '繁體中文（臺灣）'].freeze,
     'zh-YUE': ['Cantonese', '廣東話'].freeze,
   }.freeze
+
+  # rubocop:enable Style/WordArray
 
   SUPPORTED_LOCALES = {}.merge(ISO_639_1).merge(ISO_639_1_REGIONAL).merge(ISO_639_3).freeze
 

--- a/app/models/concerns/attachmentable.rb
+++ b/app/models/concerns/attachmentable.rb
@@ -69,7 +69,7 @@ module Attachmentable
     original_extension       = Paperclip::Interpolations.extension(attachment, :original)
     proper_extension         = extensions_for_mime_type.first.to_s
     extension                = extensions_for_mime_type.include?(original_extension) ? original_extension : proper_extension
-    extension                = 'jpeg' if ['jpe', 'jfif'].include?(extension)
+    extension                = 'jpeg' if %w(jpe jfif).include?(extension)
 
     extension
   end

--- a/spec/requests/api/v1/apps_spec.rb
+++ b/spec/requests/api/v1/apps_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'Apps' do
             client_secret_expires_at: 0,
             name: client_name,
             website: website,
-            scopes: ['read', 'write'],
+            scopes: %w(read write),
             redirect_uris: redirect_uris,
             # Deprecated properties as of 4.3:
             redirect_uri: redirect_uri,

--- a/spec/serializers/rest/account_warning_serializer_spec.rb
+++ b/spec/serializers/rest/account_warning_serializer_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe REST::AccountWarningSerializer do
       expect(subject)
         .to include(
           'id' => be_a(String).and(eq('123')),
-          'status_ids' => be_a(Array).and(eq(['456', '789'])),
+          'status_ids' => be_a(Array).and(eq(%w(456 789))),
           'created_at' => match_api_datetime_format
         )
     end

--- a/spec/services/translate_status_service_spec.rb
+++ b/spec/services/translate_status_service_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe TranslateStatusService do
   describe '#call' do
     before do
       translation_service = TranslationService.new
-      allow(translation_service).to receive(:languages).and_return({ 'en' => ['es', 'es-MX'] })
+      allow(translation_service).to receive(:languages).and_return({ 'en' => %w(es es-MX) })
       allow(translation_service).to receive(:translate) do |texts|
         texts.map do |text|
           TranslationService::Translation.new(

--- a/spec/support/examples/models/concerns/ranked_trend.rb
+++ b/spec/support/examples/models/concerns/ranked_trend.rb
@@ -34,7 +34,7 @@ RSpec.shared_examples 'RankedTrend' do
 
     it 'returns unique set of languages' do
       expect(described_class.locales)
-        .to eq(['en', 'es'])
+        .to eq(%w(en es))
     end
   end
 


### PR DESCRIPTION
I regenerated the TODO and noticed the detection for the Style/WordArray had changed, so I just moved it to in inline ignore.