### PR TITLE
Correcting Typos

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -2,11 +2,11 @@ coverage:
   status:
     project:
       default:
-        # Github status check is not blocking
+        # GitHub status check is not blocking
         informational: true
     patch:
       default:
-        # Github status check is not blocking
+        # GitHub status check is not blocking
         informational: true
 comment:
   # Only write a comment in PR if there are changes

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -59,7 +59,7 @@
       dependencyDashboardApproval: true,
     },
     {
-      // Update Github Actions and Docker images weekly
+      // Update GitHub Actions and Docker images weekly
       matchManagers: ['github-actions', 'dockerfile', 'docker-compose'],
       extends: ['schedule:weekly'],
     },

--- a/.github/workflows/crowdin-download.yml
+++ b/.github/workflows/crowdin-download.yml
@@ -58,13 +58,13 @@ jobs:
           title: 'New Crowdin Translations (automated)'
           author: 'GitHub Actions <noreply@github.com>'
           body: |
-            New Crowdin translations, automated with Github Actions
+            New Crowdin translations, automated with GitHub Actions
 
             See `.github/workflows/crowdin-download.yml`
 
             This PR will be updated every day with new translations.
 
-            Due to a limitation in Github Actions, checks are not running on this PR without manual action.
+            Due to a limitation in GitHub Actions, checks are not running on this PR without manual action.
             If you want to run the checks, then close and re-open it.
           branch: i18n/crowdin/translations
           base: main

--- a/README.md
+++ b/README.md
@@ -113,14 +113,14 @@ If you are using an IDE with [support for the Development Container specificatio
 
 ### GitHub Codespaces
 
-To get you coding in just a few minutes, GitHub Codespaces provides a web-based version of Visual Studio Code and a cloud-hosted development environment fully configured with the software needed for this project..
+To get you coding in just a few minutes, GitHub Codespaces provides a web-based version of Visual Studio Code and a cloud-hosted development environment fully configured with the software needed for this project.
 
 - Click this button to create a new codespace:<br>
   [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=52281283&devcontainer_path=.devcontainer%2Fcodespaces%2Fdevcontainer.json)
 - Wait for the environment to build. This will take a few minutes.
 - When the editor is ready, run `foreman start -f Procfile.dev` in the terminal.
 - After a few seconds, a popup will appear with a button labeled _Open in Browser_. This will open Mastodon.
-- On the _Ports_ tab, right click on the “stream” row and select _Port visibility_ → _Public_.
+- On the _Ports_ tab, right-click on the “stream” row and select _Port visibility_ → _Public_.
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ A "vulnerability in Mastodon" is a vulnerability in the code distributed through
 ## Supported Versions
 
 | Version | Supported        |
-| ------- | ---------------- |
+|---------|------------------|
 | 4.2.x   | Yes              |
 | 4.1.x   | Yes              |
 | 4.0.x   | No               |

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,4 +1,4 @@
-# This is needed for the Github Action
+# This is needed for the GitHub Action
 project_id_env: CROWDIN_PROJECT_ID
 api_token_env: CROWDIN_PERSONAL_TOKEN
 


### PR DESCRIPTION
- corrected the use of "GitHub" in documentation and comments to keep it consistent and following platform's preferred naming scheme.

- corrected other small typos: doubled full stop, table formatting, right click > right-click