### PR TITLE
Consolidate configuration of `Sidekiq::Testing.fake!` setup

### DIFF
--- a/spec/controllers/api/v1/statuses/reblogs_controller_spec.rb
+++ b/spec/controllers/api/v1/statuses/reblogs_controller_spec.rb
@@ -9,13 +9,7 @@ describe Api::V1::Statuses::ReblogsController do
   let(:app)   { Fabricate(:application, name: 'Test app', website: 'http://testapp.com') }
   let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'write:statuses', application: app) }
 
-  context 'with an oauth token' do
-    around do |example|
-      Sidekiq::Testing.fake! do
-        example.run
-      end
-    end
-
+  context 'with an oauth token', :sidekiq_fake do
     before do
       allow(controller).to receive(:doorkeeper_token) { token }
     end

--- a/spec/controllers/settings/exports_controller_spec.rb
+++ b/spec/controllers/settings/exports_controller_spec.rb
@@ -38,12 +38,10 @@ describe Settings::ExportsController do
       expect(response).to redirect_to(settings_export_path)
     end
 
-    it 'queues BackupWorker job by 1' do
-      Sidekiq::Testing.fake! do
-        expect do
-          post :create
-        end.to change(BackupWorker.jobs, :size).by(1)
-      end
+    it 'queues BackupWorker job by 1', :sidekiq_fake do
+      expect do
+        post :create
+      end.to change(BackupWorker.jobs, :size).by(1)
     end
   end
 end

--- a/spec/lib/activitypub/activity/create_spec.rb
+++ b/spec/lib/activitypub/activity/create_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe ActivityPub::Activity::Create do
     stub_request(:get, 'http://example.com/emojib.png').to_return(body: attachment_fixture('emojo.png'), headers: { 'Content-Type' => 'application/octet-stream' })
   end
 
-  describe 'processing posts received out of order' do
+  describe 'processing posts received out of order', :sidekiq_fake do
     let(:follower) { Fabricate(:account, username: 'bob') }
 
     let(:object_json) do
@@ -75,13 +75,6 @@ RSpec.describe ActivityPub::Activity::Create do
 
     before do
       follower.follow!(sender)
-    end
-
-    around do |example|
-      Sidekiq::Testing.fake! do
-        example.run
-        Sidekiq::Worker.clear_all
-      end
     end
 
     it 'correctly processes posts and inserts them in timelines', :aggregate_failures do

--- a/spec/models/admin/account_action_spec.rb
+++ b/spec/models/admin/account_action_spec.rb
@@ -46,12 +46,10 @@ RSpec.describe Admin::AccountAction do
         expect(target_account).to be_suspended
       end
 
-      it 'queues Admin::SuspensionWorker by 1' do
-        Sidekiq::Testing.fake! do
-          expect do
-            subject
-          end.to change { Admin::SuspensionWorker.jobs.size }.by 1
-        end
+      it 'queues Admin::SuspensionWorker by 1', :sidekiq_fake do
+        expect do
+          subject
+        end.to change { Admin::SuspensionWorker.jobs.size }.by 1
       end
     end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -95,6 +95,13 @@ RSpec.configure do |config|
     self.use_transactional_tests = true
   end
 
+  config.around(:each, :sidekiq_fake) do |example|
+    Sidekiq::Testing.fake! do
+      example.run
+      Sidekiq::Worker.clear_all
+    end
+  end
+
   config.before :each, type: :cli do
     stub_stdout
     stub_reset_connection_pools

--- a/spec/requests/api/v1/statuses/favourites_spec.rb
+++ b/spec/requests/api/v1/statuses/favourites_spec.rb
@@ -70,18 +70,12 @@ RSpec.describe 'Favourites' do
     end
   end
 
-  describe 'POST /api/v1/statuses/:status_id/unfavourite' do
+  describe 'POST /api/v1/statuses/:status_id/unfavourite', :sidekiq_fake do
     subject do
       post "/api/v1/statuses/#{status.id}/unfavourite", headers: headers
     end
 
     let(:status) { Fabricate(:status) }
-
-    around do |example|
-      Sidekiq::Testing.fake! do
-        example.run
-      end
-    end
 
     it_behaves_like 'forbidden for wrong scope', 'read read:favourites'
 

--- a/spec/services/bulk_import_service_spec.rb
+++ b/spec/services/bulk_import_service_spec.rb
@@ -12,14 +12,7 @@ RSpec.describe BulkImportService do
     import.update(total_items: import.rows.count)
   end
 
-  describe '#call' do
-    around do |example|
-      Sidekiq::Testing.fake! do
-        example.run
-        Sidekiq::Worker.clear_all
-      end
-    end
-
+  describe '#call', :sidekiq_fake do
     context 'when importing follows' do
       let(:import_type) { 'following' }
       let(:overwrite)   { false }

--- a/spec/services/update_status_service_spec.rb
+++ b/spec/services/update_status_service_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe UpdateStatusService, type: :service do
     end
   end
 
-  context 'when poll changes' do
+  context 'when poll changes', :sidekiq_fake do
     let(:account) { Fabricate(:account) }
     let!(:status) { Fabricate(:status, text: 'Foo', account: account, poll_attributes: { options: %w(Foo Bar), account: account, multiple: false, hide_totals: false, expires_at: 7.days.from_now }) }
     let!(:poll)   { status.poll }
@@ -120,9 +120,7 @@ RSpec.describe UpdateStatusService, type: :service do
     before do
       status.update(poll: poll)
       VoteService.new.call(voter, poll, [0])
-      Sidekiq::Testing.fake! do
-        subject.call(status, status.account_id, text: 'Foo', poll: { options: %w(Bar Baz Foo), expires_in: 5.days.to_i })
-      end
+      subject.call(status, status.account_id, text: 'Foo', poll: { options: %w(Bar Baz Foo), expires_in: 5.days.to_i })
     end
 
     it 'updates poll' do

--- a/spec/workers/move_worker_spec.rb
+++ b/spec/workers/move_worker_spec.rb
@@ -159,12 +159,9 @@ describe MoveWorker do
 
   describe '#perform' do
     context 'when both accounts are distant' do
-      it 'calls UnfollowFollowWorker' do
-        Sidekiq::Testing.fake! do
-          subject.perform(source_account.id, target_account.id)
-          expect(UnfollowFollowWorker).to have_enqueued_sidekiq_job(local_follower.id, source_account.id, target_account.id, false)
-          Sidekiq::Worker.drain_all
-        end
+      it 'calls UnfollowFollowWorker', :sidekiq_fake do
+        subject.perform(source_account.id, target_account.id)
+        expect(UnfollowFollowWorker).to have_enqueued_sidekiq_job(local_follower.id, source_account.id, target_account.id, false)
       end
 
       include_examples 'common tests'
@@ -173,12 +170,9 @@ describe MoveWorker do
     context 'when target account is local' do
       let(:target_account) { Fabricate(:account) }
 
-      it 'calls UnfollowFollowWorker' do
-        Sidekiq::Testing.fake! do
-          subject.perform(source_account.id, target_account.id)
-          expect(UnfollowFollowWorker).to have_enqueued_sidekiq_job(local_follower.id, source_account.id, target_account.id, true)
-          Sidekiq::Worker.clear_all
-        end
+      it 'calls UnfollowFollowWorker', :sidekiq_fake do
+        subject.perform(source_account.id, target_account.id)
+        expect(UnfollowFollowWorker).to have_enqueued_sidekiq_job(local_follower.id, source_account.id, target_account.id, true)
       end
 
       include_examples 'common tests'

--- a/spec/workers/poll_expiration_notify_worker_spec.rb
+++ b/spec/workers/poll_expiration_notify_worker_spec.rb
@@ -10,13 +10,7 @@ describe PollExpirationNotifyWorker do
   let(:remote?) { false }
   let(:poll_vote) { Fabricate(:poll_vote, poll: poll) }
 
-  describe '#perform' do
-    around do |example|
-      Sidekiq::Testing.fake! do
-        example.run
-      end
-    end
-
+  describe '#perform', :sidekiq_fake do
     it 'runs without error for missing record' do
       expect { worker.perform(nil) }.to_not raise_error
     end


### PR DESCRIPTION
In advance of https://github.com/mastodon/mastodon/pull/25369 being ready, I noticed this repeated configuration in various places. This PR consolidates to central setup.

Assuming this is accepted I can rebase the other larger change, which I suspect will mean deleting some of these changes. That said, if we can't get that other one sorted soon or ever, this is beneficial by itself as well.