### PR TITLE
Add html views to `AdminMailer`

### DIFF
--- a/app/views/admin_mailer/_new_trending_links.html.erb
+++ b/app/views/admin_mailer/_new_trending_links.html.erb
@@ -1,0 +1,15 @@
+<p>
+  <%= raw t('admin_mailer.new_trends.new_trending_links.title') %>
+</p>
+<ul>
+  <% new_trending_links.each do |link| %>
+    <li>
+      <%= link.title %> · <%= link.url %>
+      <br />
+      <%= standard_locale_name(link.language) %> · <%= raw t('admin.trends.links.usage_comparison', today: link.history.get(Time.now.utc).accounts, yesterday: link.history.get(Time.now.utc - 1.day).accounts) %> · <%= t('admin.trends.tags.current_score', score: link.trend.score.round(2)) %>
+    </li>
+  <% end %>
+</ul>
+<p>
+  <%= raw t('application_mailer.view')%> <%= link_to admin_trends_links_url, admin_trends_links_url %>
+</p>

--- a/app/views/admin_mailer/_new_trending_statuses.html.erb
+++ b/app/views/admin_mailer/_new_trending_statuses.html.erb
@@ -1,0 +1,15 @@
+<p>
+  <%= raw t('admin_mailer.new_trends.new_trending_statuses.title') %>
+</p>
+<ul>
+  <% new_trending_statuses.each do |status| %>
+    <li>
+      <%= ActivityPub::TagManager.instance.url_for(status) %>
+      <br />
+      <%= standard_locale_name(status.language) %> · <%= raw t('admin.trends.tags.current_score', score: status.trend.score.round(2)) %>
+    </li>
+  <% end %>
+</ul>
+<p>
+  <%= raw t('application_mailer.view')%> <%= admin_trends_statuses_url %>
+</p>

--- a/app/views/admin_mailer/_new_trending_tags.html.erb
+++ b/app/views/admin_mailer/_new_trending_tags.html.erb
@@ -1,0 +1,15 @@
+<p>
+  <%= raw t('admin_mailer.new_trends.new_trending_tags.title') %>
+</p>
+<ul>
+  <% new_trending_tags.each do |tag| %>
+    <li>
+      #<%= tag.display_name %>
+      <br />
+      <%= raw t('admin.trends.tags.usage_comparison', today: tag.history.get(Time.now.utc).accounts, yesterday: tag.history.get(Time.now.utc - 1.day).accounts) %> · <%= t('admin.trends.tags.current_score', score: Trends.tags.score(tag.id).round(2)) %>
+    </li>
+  <% end %>
+</ul>
+<p>
+  <%= raw t('application_mailer.view')%> <%= admin_trends_tags_url(status: 'pending_review') %>
+</p>

--- a/app/views/admin_mailer/new_appeal.html.erb
+++ b/app/views/admin_mailer/new_appeal.html.erb
@@ -1,0 +1,17 @@
+<p>
+  <%= raw t('application_mailer.salutation', name: display_name(@me)) %>
+</p>
+<p>
+  <%= raw t('admin_mailer.new_appeal.body', target: @appeal.account.username, action_taken_by: @appeal.strike.account.username, date: l(@appeal.strike.created_at, format: :with_time_zone), type: t(@appeal.strike.action, scope: 'admin_mailer.new_appeal.actions')) %>
+</p>
+<blockquote>
+  <p>
+    <%= raw word_wrap(@appeal.text, break_sequence: "\n> ") %>
+  </p>
+</blockquote>
+<p>
+  <%= raw t('admin_mailer.new_appeal.next_steps') %>
+</p>
+<p>
+  <%= raw t('application_mailer.view')%> <%= link_to disputes_strike_url(@appeal.strike), disputes_strike_url(@appeal.strike) %>
+</p>

--- a/app/views/admin_mailer/new_critical_software_updates.html.erb
+++ b/app/views/admin_mailer/new_critical_software_updates.html.erb
@@ -1,0 +1,9 @@
+<p>
+  <%= raw t('application_mailer.salutation', name: display_name(@me)) %>
+</p>
+<p>
+  <%= raw t('admin_mailer.new_critical_software_updates.body') %>
+</p>
+<p>
+  <%= raw t('application_mailer.view')%> <%= link_to admin_software_updates_url, admin_software_updates_url %>
+</p>

--- a/app/views/admin_mailer/new_pending_account.html.erb
+++ b/app/views/admin_mailer/new_pending_account.html.erb
@@ -1,0 +1,19 @@
+<p>
+  <%= raw t('application_mailer.salutation', name: display_name(@me)) %>
+</p>
+<p>
+  <%= raw t('admin_mailer.new_pending_account.body') %>
+</p>
+<p>
+  <%= @account.user_email %> (@<%= @account.username %>)
+  <br />
+  <%= @account.user_sign_up_ip %>
+</p>
+<% if @account.user&.invite_request&.text.present? %>
+  <blockquote>
+    <%= quote_wrap(@account.user&.invite_request&.text) %>
+  </blockquote>
+<% end %>
+<p>
+  <%= raw t('application_mailer.view')%> <%= link_to admin_accounts_url(status: 'pending'), admin_accounts_url(status: 'pending') %>
+</p>

--- a/app/views/admin_mailer/new_report.html.erb
+++ b/app/views/admin_mailer/new_report.html.erb
@@ -1,0 +1,9 @@
+<p>
+  <%= raw t('application_mailer.salutation', name: display_name(@me)) %>
+</p>
+<p>
+  <%= raw(@report.account.local? ? t('admin_mailer.new_report.body', target: @report.target_account.pretty_acct, reporter: @report.account.pretty_acct) : t('admin_mailer.new_report.body_remote', target: @report.target_account.acct, domain: @report.account.domain)) %>
+</p>
+<p>
+  <%= raw t('application_mailer.view')%> <%= link_to admin_report_url(@report), admin_report_url(@report) %>
+</p>

--- a/app/views/admin_mailer/new_software_updates.html.erb
+++ b/app/views/admin_mailer/new_software_updates.html.erb
@@ -1,0 +1,9 @@
+<p>
+  <%= raw t('application_mailer.salutation', name: display_name(@me)) %>
+</p>
+<p>
+  <%= raw t('admin_mailer.new_software_updates.body') %>
+</p>
+<p>
+  <%= raw t('application_mailer.view')%> <%= link_to admin_software_updates_url, admin_software_updates_url %>
+</p>

--- a/app/views/admin_mailer/new_trends.html.erb
+++ b/app/views/admin_mailer/new_trends.html.erb
@@ -1,0 +1,9 @@
+<p>
+  <%= raw t('application_mailer.salutation', name: display_name(@me)) %>
+</p>
+<p>
+  <%= raw t('admin_mailer.new_trends.body') %>
+</p>
+<%= render partial: 'new_trending_links', object: @links unless @links.empty? %>
+<%= render partial: 'new_trending_tags', object: @tags unless @tags.empty? %>
+<%= render partial: 'new_trending_statuses', object: @statuses unless @statuses.empty? %>

--- a/app/views/layouts/plain_mailer.html.haml
+++ b/app/views/layouts/plain_mailer.html.haml
@@ -1,1 +1,7 @@
-= yield
+!!!
+%html{ lang: I18n.locale }
+  %head
+    %meta{ 'http-equiv' => 'Content-Type', 'content' => 'text/html; charset=utf-8' }/
+    %meta{ name: 'viewport', content: 'width=device-width, initial-scale=1.0, shrink-to-fit=no' }
+  %body{ dir: locale_direction }
+    = yield

--- a/spec/mailers/admin_mailer_spec.rb
+++ b/spec/mailers/admin_mailer_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe AdminMailer do
         .and(deliver_to(recipient.user_email))
         .and(deliver_from('notifications@localhost'))
         .and(have_subject("New report for cb6e6126.ngrok.io (##{report.id})"))
-        .and(have_body_text("Mike,\r\n\r\nJohn has reported Mike\r\n\r\nView: https://cb6e6126.ngrok.io/admin/reports/#{report.id}\r\n"))
+        .and(have_body_text('John has reported Mike'))
+        .and(have_body_text(admin_report_url(report)))
     end
   end
 


### PR DESCRIPTION
Follow-up on https://github.com/mastodon/mastodon/pull/28044 which added the missing previews, in this one...

I noticed there is an unused `plain_mailer` layout which is only used by the `AdminMailer` ... but none of the AdminMailer views have html versions which I think means its not actually being used.

I updated the `plain_mailer` layout to have an html head and body (copied from the regular mailer template), but purposefully did not add anything more in the way of style/structure/etc

I then added html views for all existing admin mailer views -- tried to just 1:1 copy the text version as best as possible; not changing information in the emails, or layout really.

If we actively *do not want* html versions of the admin mailers (and this was not an oversight, but purposeful) the other thing to do here would be just delete the unused plain_mailer layout.