### PR TITLE
Add `Account#unavailable?` and `Account#permanently_unavailable?` aliases

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -105,7 +105,7 @@ class Api::BaseController < ApplicationController
   end
 
   def require_not_suspended!
-    render json: { error: 'Your login is currently disabled' }, status: 403 if current_user&.account&.suspended?
+    render json: { error: 'Your login is currently disabled' }, status: 403 if current_user&.account&.unavailable?
   end
 
   def require_user!

--- a/app/controllers/api/v1/accounts/follower_accounts_controller.rb
+++ b/app/controllers/api/v1/accounts/follower_accounts_controller.rb
@@ -26,7 +26,7 @@ class Api::V1::Accounts::FollowerAccountsController < Api::BaseController
   end
 
   def hide_results?
-    @account.suspended? || (@account.hides_followers? && current_account&.id != @account.id) || (current_account && @account.blocking?(current_account))
+    @account.unavailable? || (@account.hides_followers? && current_account&.id != @account.id) || (current_account && @account.blocking?(current_account))
   end
 
   def default_accounts

--- a/app/controllers/api/v1/accounts/following_accounts_controller.rb
+++ b/app/controllers/api/v1/accounts/following_accounts_controller.rb
@@ -26,7 +26,7 @@ class Api::V1::Accounts::FollowingAccountsController < Api::BaseController
   end
 
   def hide_results?
-    @account.suspended? || (@account.hides_following? && current_account&.id != @account.id) || (current_account && @account.blocking?(current_account))
+    @account.unavailable? || (@account.hides_following? && current_account&.id != @account.id) || (current_account && @account.blocking?(current_account))
   end
 
   def default_accounts

--- a/app/controllers/api/v1/accounts/statuses_controller.rb
+++ b/app/controllers/api/v1/accounts/statuses_controller.rb
@@ -19,7 +19,7 @@ class Api::V1::Accounts::StatusesController < Api::BaseController
   end
 
   def load_statuses
-    @account.suspended? ? [] : cached_account_statuses
+    @account.unavailable? ? [] : cached_account_statuses
   end
 
   def cached_account_statuses

--- a/app/controllers/auth/registrations_controller.rb
+++ b/app/controllers/auth/registrations_controller.rb
@@ -120,7 +120,7 @@ class Auth::RegistrationsController < Devise::RegistrationsController
   end
 
   def require_not_suspended!
-    forbidden if current_account.suspended?
+    forbidden if current_account.unavailable?
   end
 
   def set_rules

--- a/app/controllers/concerns/account_owned_concern.rb
+++ b/app/controllers/concerns/account_owned_concern.rb
@@ -34,8 +34,8 @@ module AccountOwnedConcern
   end
 
   def check_account_suspension
-    if @account.suspended_permanently?
-      permanent_suspension_response
+    if @account.permanently_unavailable?
+      permanent_unavailability_response
     elsif @account.suspended? && !skip_temporary_suspension_response?
       temporary_suspension_response
     end
@@ -45,7 +45,7 @@ module AccountOwnedConcern
     false
   end
 
-  def permanent_suspension_response
+  def permanent_unavailability_response
     expires_in(3.minutes, public: true)
     gone
   end

--- a/app/controllers/oauth/authorized_applications_controller.rb
+++ b/app/controllers/oauth/authorized_applications_controller.rb
@@ -31,7 +31,7 @@ class Oauth::AuthorizedApplicationsController < Doorkeeper::AuthorizedApplicatio
   end
 
   def require_not_suspended!
-    forbidden if current_account.suspended?
+    forbidden if current_account.unavailable?
   end
 
   def set_cache_headers

--- a/app/controllers/settings/base_controller.rb
+++ b/app/controllers/settings/base_controller.rb
@@ -18,6 +18,6 @@ class Settings::BaseController < ApplicationController
   end
 
   def require_not_suspended!
-    forbidden if current_account.suspended?
+    forbidden if current_account.unavailable?
   end
 end

--- a/app/controllers/settings/deletes_controller.rb
+++ b/app/controllers/settings/deletes_controller.rb
@@ -25,7 +25,7 @@ class Settings::DeletesController < Settings::BaseController
   end
 
   def require_not_suspended!
-    forbidden if current_account.suspended?
+    forbidden if current_account.unavailable?
   end
 
   def challenge_passed?

--- a/app/controllers/well_known/webfinger_controller.rb
+++ b/app/controllers/well_known/webfinger_controller.rb
@@ -42,7 +42,7 @@ module WellKnown
     end
 
     def check_account_suspension
-      gone if @account.suspended_permanently?
+      gone if @account.permanently_unavailable?
     end
 
     def gone

--- a/app/lib/account_statuses_filter.rb
+++ b/app/lib/account_statuses_filter.rb
@@ -32,7 +32,7 @@ class AccountStatusesFilter
   private
 
   def initial_scope
-    return Status.none if suspended?
+    return Status.none if account.unavailable?
 
     if anonymous?
       account.statuses.where(visibility: %i(public unlisted))
@@ -93,10 +93,6 @@ class AccountStatusesFilter
     else
       Status.none
     end
-  end
-
-  def suspended?
-    account.suspended?
   end
 
   def anonymous?

--- a/app/lib/activitypub/activity/move.rb
+++ b/app/lib/activitypub/activity/move.rb
@@ -9,7 +9,7 @@ class ActivityPub::Activity::Move < ActivityPub::Activity
 
     target_account = ActivityPub::FetchRemoteAccountService.new.call(target_uri)
 
-    if target_account.nil? || target_account.suspended? || !target_account.also_known_as.include?(origin_account.uri)
+    if target_account.nil? || target_account.unavailable? || !target_account.also_known_as.include?(origin_account.uri)
       unmark_as_processing!
       return
     end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -246,6 +246,9 @@ class Account < ApplicationRecord
     suspended? && deletion_request.present?
   end
 
+  alias unavailable? suspended?
+  alias permanently_unavailable? suspended_permanently?
+
   def suspend!(date: Time.now.utc, origin: :local, block_email: true)
     transaction do
       create_deletion_request!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -250,7 +250,7 @@ class User < ApplicationRecord
   end
 
   def functional_or_moved?
-    confirmed? && approved? && !disabled? && !account.suspended? && !account.memorial?
+    confirmed? && approved? && !disabled? && !account.unavailable? && !account.memorial?
   end
 
   def unconfirmed?

--- a/app/policies/status_policy.rb
+++ b/app/policies/status_policy.rb
@@ -8,7 +8,7 @@ class StatusPolicy < ApplicationPolicy
   end
 
   def show?
-    return false if author.suspended?
+    return false if author.unavailable?
 
     if requires_mention?
       owned? || mention_exists?

--- a/app/serializers/activitypub/actor_serializer.rb
+++ b/app/serializers/activitypub/actor_serializer.rb
@@ -96,19 +96,19 @@ class ActivityPub::ActorSerializer < ActivityPub::Serializer
   end
 
   def discoverable
-    object.suspended? ? false : (object.discoverable || false)
+    object.unavailable? ? false : (object.discoverable || false)
   end
 
   def indexable
-    object.suspended? ? false : (object.indexable || false)
+    object.unavailable? ? false : (object.indexable || false)
   end
 
   def name
-    object.suspended? ? object.username : (object.display_name.presence || object.username)
+    object.unavailable? ? object.username : (object.display_name.presence || object.username)
   end
 
   def summary
-    object.suspended? ? '' : account_bio_format(object)
+    object.unavailable? ? '' : account_bio_format(object)
   end
 
   def icon
@@ -132,23 +132,23 @@ class ActivityPub::ActorSerializer < ActivityPub::Serializer
   end
 
   def avatar_exists?
-    !object.suspended? && object.avatar?
+    !object.unavailable? && object.avatar?
   end
 
   def header_exists?
-    !object.suspended? && object.header?
+    !object.unavailable? && object.header?
   end
 
   def manually_approves_followers
-    object.suspended? ? false : object.locked
+    object.unavailable? ? false : object.locked
   end
 
   def virtual_tags
-    object.suspended? ? [] : (object.emojis + object.tags)
+    object.unavailable? ? [] : (object.emojis + object.tags)
   end
 
   def virtual_attachments
-    object.suspended? ? [] : object.fields
+    object.unavailable? ? [] : object.fields
   end
 
   def moved_to
@@ -156,11 +156,11 @@ class ActivityPub::ActorSerializer < ActivityPub::Serializer
   end
 
   def moved?
-    !object.suspended? && object.moved?
+    !object.unavailable? && object.moved?
   end
 
   def also_known_as?
-    !object.suspended? && !object.also_known_as.empty?
+    !object.unavailable? && !object.also_known_as.empty?
   end
 
   def published

--- a/app/serializers/rest/account_serializer.rb
+++ b/app/serializers/rest/account_serializer.rb
@@ -61,7 +61,7 @@ class REST::AccountSerializer < ActiveModel::Serializer
   end
 
   def note
-    object.suspended? ? '' : account_bio_format(object)
+    object.unavailable? ? '' : account_bio_format(object)
   end
 
   def url
@@ -73,19 +73,19 @@ class REST::AccountSerializer < ActiveModel::Serializer
   end
 
   def avatar
-    full_asset_url(object.suspended? ? object.avatar.default_url : object.avatar_original_url)
+    full_asset_url(object.unavailable? ? object.avatar.default_url : object.avatar_original_url)
   end
 
   def avatar_static
-    full_asset_url(object.suspended? ? object.avatar.default_url : object.avatar_static_url)
+    full_asset_url(object.unavailable? ? object.avatar.default_url : object.avatar_static_url)
   end
 
   def header
-    full_asset_url(object.suspended? ? object.header.default_url : object.header_original_url)
+    full_asset_url(object.unavailable? ? object.header.default_url : object.header_original_url)
   end
 
   def header_static
-    full_asset_url(object.suspended? ? object.header.default_url : object.header_static_url)
+    full_asset_url(object.unavailable? ? object.header.default_url : object.header_static_url)
   end
 
   def created_at
@@ -97,39 +97,39 @@ class REST::AccountSerializer < ActiveModel::Serializer
   end
 
   def display_name
-    object.suspended? ? '' : object.display_name
+    object.unavailable? ? '' : object.display_name
   end
 
   def locked
-    object.suspended? ? false : object.locked
+    object.unavailable? ? false : object.locked
   end
 
   def bot
-    object.suspended? ? false : object.bot
+    object.unavailable? ? false : object.bot
   end
 
   def discoverable
-    object.suspended? ? false : object.discoverable
+    object.unavailable? ? false : object.discoverable
   end
 
   def indexable
-    object.suspended? ? false : object.indexable
+    object.unavailable? ? false : object.indexable
   end
 
   def moved_to_account
-    object.suspended? ? nil : AccountDecorator.new(object.moved_to_account)
+    object.unavailable? ? nil : AccountDecorator.new(object.moved_to_account)
   end
 
   def emojis
-    object.suspended? ? [] : object.emojis
+    object.unavailable? ? [] : object.emojis
   end
 
   def fields
-    object.suspended? ? [] : object.fields
+    object.unavailable? ? [] : object.fields
   end
 
   def suspended
-    object.suspended?
+    object.unavailable?
   end
 
   def silenced
@@ -141,7 +141,7 @@ class REST::AccountSerializer < ActiveModel::Serializer
   end
 
   def roles
-    if object.suspended? || object.user.nil?
+    if object.unavailable? || object.user.nil?
       []
     else
       [object.user.role].compact.filter(&:highlighted?)

--- a/app/services/follow_service.rb
+++ b/app/services/follow_service.rb
@@ -50,7 +50,7 @@ class FollowService < BaseService
   end
 
   def following_not_possible?
-    @target_account.nil? || @target_account.id == @source_account.id || @target_account.suspended?
+    @target_account.nil? || @target_account.id == @source_account.id || @target_account.unavailable?
   end
 
   def following_not_allowed?

--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -108,7 +108,7 @@ class NotifyService < BaseService
   end
 
   def blocked?
-    blocked   = @recipient.suspended?
+    blocked   = @recipient.unavailable?
     blocked ||= from_self? && @notification.type != :poll
 
     return blocked if message? && from_staff?

--- a/app/services/process_mentions_service.rb
+++ b/app/services/process_mentions_service.rb
@@ -51,7 +51,7 @@ class ProcessMentionsService < BaseService
 
       # If after resolving it still isn't found or isn't the right
       # protocol, then give up
-      next match if mention_undeliverable?(mentioned_account) || mentioned_account&.suspended?
+      next match if mention_undeliverable?(mentioned_account) || mentioned_account&.unavailable?
 
       mention   = @previous_mentions.find { |x| x.account_id == mentioned_account.id }
       mention ||= @current_mentions.find  { |x| x.account_id == mentioned_account.id }

--- a/app/services/report_service.rb
+++ b/app/services/report_service.rb
@@ -12,7 +12,7 @@ class ReportService < BaseService
     @rule_ids       = options.delete(:rule_ids).presence
     @options        = options
 
-    raise ActiveRecord::RecordNotFound if @target_account.suspended?
+    raise ActiveRecord::RecordNotFound if @target_account.unavailable?
 
     create_report!
     notify_staff!

--- a/app/views/admin/accounts/_account.html.haml
+++ b/app/views/admin/accounts/_account.html.haml
@@ -1,4 +1,4 @@
-.batch-table__row{ class: [!account.suspended? && account.user_pending? && 'batch-table__row--attention', (account.suspended? || account.user_unconfirmed?) && 'batch-table__row--muted'] }
+.batch-table__row{ class: [!account.unavailable? && account.user_pending? && 'batch-table__row--attention', (account.unavailable? || account.user_unconfirmed?) && 'batch-table__row--muted'] }
   %label.batch-table__row__select.batch-table__row__select--aligned.batch-checkbox
     = f.check_box :account_ids, { multiple: true, include_hidden: false }, account.id
   .batch-table__row__content.batch-table__row__content--unpadded
@@ -8,13 +8,13 @@
           %td
             = account_link_to account, path: admin_account_path(account.id)
           %td.accounts-table__count.optional
-            - if account.suspended? || account.user_pending?
+            - if account.unavailable? || account.user_pending?
               \-
             - else
               = friendly_number_to_human account.statuses_count
             %small= t('accounts.posts', count: account.statuses_count).downcase
           %td.accounts-table__count.optional
-            - if account.suspended? || account.user_pending?
+            - if account.unavailable? || account.user_pending?
               \-
             - else
               = friendly_number_to_human account.followers_count
@@ -30,6 +30,6 @@
                 \-
               %br/
               %samp.ellipsized-ip= relevant_account_ip(account, params[:ip])
-    - if !account.suspended? && account.user_pending? && account.user&.invite_request&.text.present?
+    - if !account.unavailable? && account.user_pending? && account.user&.invite_request&.text.present?
       .batch-table__row__content__quote
         %p= account.user&.invite_request&.text

--- a/app/views/oauth/authorized_applications/index.html.haml
+++ b/app/views/oauth/authorized_applications/index.html.haml
@@ -27,7 +27,7 @@
 
           = t('doorkeeper.authorized_applications.index.authorized_at', date: l(application.created_at.to_date))
 
-        - unless application.superapp? || current_account.suspended?
+        - unless application.superapp? || current_account.unavailable?
           %div
             = table_link_to 'times', t('doorkeeper.authorized_applications.buttons.revoke'), oauth_authorized_application_path(application), method: :delete, data: { confirm: t('doorkeeper.authorized_applications.confirmations.revoke') }
 

--- a/app/workers/account_deletion_worker.rb
+++ b/app/workers/account_deletion_worker.rb
@@ -7,7 +7,7 @@ class AccountDeletionWorker
 
   def perform(account_id, options = {})
     account = Account.find(account_id)
-    return unless account.suspended?
+    return unless account.unavailable?
 
     reserve_username = options.with_indifferent_access.fetch(:reserve_username, true)
     skip_activitypub = options.with_indifferent_access.fetch(:skip_activitypub, false)

--- a/app/workers/scheduler/suspended_user_cleanup_scheduler.rb
+++ b/app/workers/scheduler/suspended_user_cleanup_scheduler.rb
@@ -21,12 +21,12 @@ class Scheduler::SuspendedUserCleanupScheduler
   def perform
     return if Sidekiq::Queue.new('pull').size > MAX_PULL_SIZE
 
-    clean_suspended_accounts!
+    process_deletion_requests!
   end
 
   private
 
-  def clean_suspended_accounts!
+  def process_deletion_requests!
     # This should be fine because we only process a small amount of deletion requests at once and
     # `id` and `created_at` should follow the same order.
     AccountDeletionRequest.reorder(id: :asc).take(MAX_DELETIONS_PER_JOB).each do |deletion_request|


### PR DESCRIPTION
In preparation of splitting suspension and deletion into separate flags (#23617), add:
- `Account#permanently_unavailable?` to represent accounts that are permanently deleted or suspended
- `Account#unavailable?` to represent accounts that are deleted or suspended, either permanently or temporarily