### PR TITLE
Fix streaming eslint configuration

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -197,7 +197,6 @@ module.exports = defineConfig({
       {
         devDependencies: [
           '.eslintrc.js',
-          'streaming/.eslintrc.js',
           'config/webpack/**',
           'app/javascript/mastodon/performance.js',
           'app/javascript/mastodon/test_setup.js',
@@ -305,7 +304,6 @@ module.exports = defineConfig({
     {
       files: [
         '.eslintrc.js',
-        'streaming/.eslintrc.js',
         '*.config.js',
         '.*rc.js',
         'ide-helper.js',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,7 @@
 // @ts-check
-/** @type {import('eslint-define-config').ESLintConfig} */
-module.exports = {
+const { defineConfig } = require('eslint-define-config');
+
+module.exports = defineConfig({
   root: true,
 
   extends: [
@@ -195,6 +196,8 @@ module.exports = {
       'error',
       {
         devDependencies: [
+          '.eslintrc.js',
+          'streaming/.eslintrc.js',
           'config/webpack/**',
           'app/javascript/mastodon/performance.js',
           'app/javascript/mastodon/test_setup.js',
@@ -301,6 +304,8 @@ module.exports = {
   overrides: [
     {
       files: [
+        '.eslintrc.js',
+        'streaming/.eslintrc.js',
         '*.config.js',
         '.*rc.js',
         'ide-helper.js',
@@ -376,4 +381,4 @@ module.exports = {
       },
     }
   ],
-};
+});

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,5 @@
+// @ts-check
+/** @type {import('eslint-define-config').ESLintConfig} */
 module.exports = {
   root: true,
 
@@ -372,14 +374,6 @@ module.exports = {
       env: {
         jest: true,
       },
-    },
-    {
-      files: [
-        'streaming/**/*',
-      ],
-      rules: {
-        'import/no-commonjs': 'off',
-      },
-    },
+    }
   ],
 };

--- a/package.json
+++ b/package.json
@@ -184,6 +184,7 @@
     "babel-jest": "^29.5.0",
     "eslint": "^8.41.0",
     "eslint-config-prettier": "^9.0.0",
+    "eslint-define-config": "^1.24.1",
     "eslint-import-resolver-typescript": "^3.5.5",
     "eslint-plugin-formatjs": "^4.10.1",
     "eslint-plugin-import": "~2.29.0",

--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
     "babel-jest": "^29.5.0",
     "eslint": "^8.41.0",
     "eslint-config-prettier": "^9.0.0",
-    "eslint-define-config": "^1.24.1",
+    "eslint-define-config": "^2.0.0",
     "eslint-import-resolver-typescript": "^3.5.5",
     "eslint-plugin-formatjs": "^4.10.1",
     "eslint-plugin-import": "~2.29.0",

--- a/streaming/.eslintrc.js
+++ b/streaming/.eslintrc.js
@@ -3,11 +3,11 @@ const { defineConfig } = require('eslint-define-config');
 
 module.exports = defineConfig({
   extends: ['../.eslintrc.js'],
+  env: {
+    browser: false,
+  },
   parserOptions: {
     project: true,
-    env: {
-      browser: false,
-    },
     tsconfigRootDir: __dirname,
     ecmaFeatures: {
       jsx: false,

--- a/streaming/.eslintrc.js
+++ b/streaming/.eslintrc.js
@@ -5,6 +5,9 @@ module.exports = defineConfig({
   extends: ['../.eslintrc.js'],
   parserOptions: {
     project: true,
+    env: {
+      browser: false,
+    },
     tsconfigRootDir: __dirname,
     ecmaFeatures: {
       jsx: false,

--- a/streaming/.eslintrc.js
+++ b/streaming/.eslintrc.js
@@ -1,6 +1,7 @@
 // @ts-check
-/** @type {import('eslint-define-config').ESLintConfig} */
-module.exports = {
+const { defineConfig } = require('eslint-define-config');
+
+module.exports = defineConfig({
   extends: ['../.eslintrc.js'],
   parserOptions: {
     project: true,
@@ -15,7 +16,9 @@ module.exports = {
     'import/no-extraneous-dependencies': [
       'error',
       {
-        devDependencies: false,
+        devDependencies: [
+          'streaming/.eslintrc.js',
+        ],
         optionalDependencies: false,
         peerDependencies: false,
         includeTypes: true,
@@ -23,4 +26,4 @@ module.exports = {
       },
     ],
   },
-};
+});

--- a/streaming/.eslintrc.js
+++ b/streaming/.eslintrc.js
@@ -1,0 +1,26 @@
+// @ts-check
+/** @type {import('eslint-define-config').ESLintConfig} */
+module.exports = {
+  extends: ['../.eslintrc.js'],
+  parserOptions: {
+    project: true,
+    tsconfigRootDir: __dirname,
+    ecmaFeatures: {
+      jsx: false,
+    },
+    ecmaVersion: 2021,
+  },
+  rules: {
+    'import/no-commonjs': 'off',
+    'import/no-extraneous-dependencies': [
+      'error',
+      {
+        devDependencies: false,
+        optionalDependencies: false,
+        peerDependencies: false,
+        includeTypes: true,
+        packageDir: __dirname,
+      },
+    ],
+  },
+};

--- a/streaming/package.json
+++ b/streaming/package.json
@@ -30,7 +30,8 @@
     "@types/express": "^4.17.17",
     "@types/npmlog": "^7.0.0",
     "@types/pg": "^8.6.6",
-    "@types/uuid": "^9.0.0"
+    "@types/uuid": "^9.0.0",
+    "@types/ws": "^8.5.9"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.7",

--- a/streaming/package.json
+++ b/streaming/package.json
@@ -12,7 +12,8 @@
     "url": "https://github.com/mastodon/mastodon.git"
   },
   "scripts": {
-    "start": "node ./index.js"
+    "start": "node ./index.js",
+    "check:types": "tsc --noEmit"
   },
   "dependencies": {
     "dotenv": "^16.0.3",
@@ -32,7 +33,8 @@
     "@types/pg": "^8.6.6",
     "@types/uuid": "^9.0.0",
     "@types/ws": "^8.5.9",
-    "eslint-define-config": "^2.0.0"
+    "eslint-define-config": "^2.0.0",
+    "typescript": "^5.0.4"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.7",

--- a/streaming/package.json
+++ b/streaming/package.json
@@ -31,7 +31,8 @@
     "@types/npmlog": "^7.0.0",
     "@types/pg": "^8.6.6",
     "@types/uuid": "^9.0.0",
-    "@types/ws": "^8.5.9"
+    "@types/ws": "^8.5.9",
+    "eslint-define-config": "^2.0.0"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.7",

--- a/streaming/tsconfig.json
+++ b/streaming/tsconfig.json
@@ -4,6 +4,7 @@
     "target": "esnext",
     "module": "CommonJS",
     "moduleResolution": "node",
+    "allowUnusedLabels": true,
     "paths": {}
   },
   "include": ["./*.js", "./.eslintrc.js"],

--- a/streaming/tsconfig.json
+++ b/streaming/tsconfig.json
@@ -4,9 +4,8 @@
     "target": "esnext",
     "module": "CommonJS",
     "moduleResolution": "node",
-    "allowUnusedLabels": true,
+    "noUnusedParameters": false,
     "paths": {}
   },
-  "include": ["./*.js", "./.eslintrc.js"],
-  "exclude": []
+  "include": ["./*.js", "./.eslintrc.js"]
 }

--- a/streaming/tsconfig.json
+++ b/streaming/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "paths": {}
+  },
+  "include": ["./*.js", "./.eslintrc.js"],
+  "exclude": []
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,5 +19,6 @@
     "app/javascript/mastodon",
     "app/javascript/packs",
     "app/javascript/types"
-  ]
+  ],
+  "exclude": ["streaming/"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,5 @@
     "app/javascript/mastodon",
     "app/javascript/packs",
     "app/javascript/types"
-  ],
-  "exclude": ["streaming/"]
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2362,6 +2362,7 @@ __metadata:
     escape-html: "npm:^1.0.3"
     eslint: "npm:^8.41.0"
     eslint-config-prettier: "npm:^9.0.0"
+    eslint-define-config: "npm:^1.24.1"
     eslint-import-resolver-typescript: "npm:^3.5.5"
     eslint-plugin-formatjs: "npm:^4.10.1"
     eslint-plugin-import: "npm:~2.29.0"
@@ -2469,6 +2470,7 @@ __metadata:
     "@types/npmlog": "npm:^7.0.0"
     "@types/pg": "npm:^8.6.6"
     "@types/uuid": "npm:^9.0.0"
+    "@types/ws": "npm:^8.5.9"
     bufferutil: "npm:^4.0.7"
     dotenv: "npm:^16.0.3"
     express: "npm:^4.18.2"
@@ -3641,6 +3643,15 @@ __metadata:
     anymatch: "npm:^3.0.0"
     source-map: "npm:^0.6.0"
   checksum: 9e9021049b8f7482ec7c45e95d7c1da3604ee04481d7550421ed58f201f66edb8eb6c26b85be94ce3f761874cdbb8b570827becdaf5acdb1897aba9b7f226252
+  languageName: node
+  linkType: hard
+
+"@types/ws@npm:^8.5.9":
+  version: 8.5.9
+  resolution: "@types/ws@npm:8.5.9"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 678bdd6461c4653f2975c537fb673cb1918c331558e2d2422b69761c9ced67200bb07c664e2593f3864077a891cb7c13ef2a40d303b4aacb06173d095d8aa3ce
   languageName: node
   linkType: hard
 
@@ -7300,6 +7311,13 @@ __metadata:
   bin:
     eslint-config-prettier: bin/cli.js
   checksum: bc1f661915845c631824178942e5d02f858fe6d0ea796f0050d63e0f681927b92696e81139dd04714c08c3e7de580fd079c66162e40070155ba79eaee78ab5d0
+  languageName: node
+  linkType: hard
+
+"eslint-define-config@npm:^1.24.1":
+  version: 1.24.1
+  resolution: "eslint-define-config@npm:1.24.1"
+  checksum: f02873a388d8030d5300f58efe59ef9762b7d2c4edeba4fae25a020db29791eacd48dd17f52f44be1098a18bd3e09b2475f417e22c581818017563792273e7c6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2362,7 +2362,7 @@ __metadata:
     escape-html: "npm:^1.0.3"
     eslint: "npm:^8.41.0"
     eslint-config-prettier: "npm:^9.0.0"
-    eslint-define-config: "npm:^1.24.1"
+    eslint-define-config: "npm:^2.0.0"
     eslint-import-resolver-typescript: "npm:^3.5.5"
     eslint-plugin-formatjs: "npm:^4.10.1"
     eslint-plugin-import: "npm:~2.29.0"
@@ -2473,6 +2473,7 @@ __metadata:
     "@types/ws": "npm:^8.5.9"
     bufferutil: "npm:^4.0.7"
     dotenv: "npm:^16.0.3"
+    eslint-define-config: "npm:^2.0.0"
     express: "npm:^4.18.2"
     ioredis: "npm:^5.3.2"
     jsdom: "npm:^22.1.0"
@@ -7314,10 +7315,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-define-config@npm:^1.24.1":
-  version: 1.24.1
-  resolution: "eslint-define-config@npm:1.24.1"
-  checksum: f02873a388d8030d5300f58efe59ef9762b7d2c4edeba4fae25a020db29791eacd48dd17f52f44be1098a18bd3e09b2475f417e22c581818017563792273e7c6
+"eslint-define-config@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "eslint-define-config@npm:2.0.0"
+  checksum: 617c3143bc1ed8df0b20ae632d428d5f241dbb04483631e1410c58fe65ba3e503cf94631c5973115482b58ba464d052422a718c0f4d49182f8d13ffbb36bf1d6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2481,6 +2481,7 @@ __metadata:
     pg: "npm:^8.5.0"
     pg-connection-string: "npm:^2.6.0"
     prom-client: "npm:^15.0.0"
+    typescript: "npm:^5.0.4"
     utf-8-validate: "npm:^6.0.3"
     uuid: "npm:^9.0.0"
     ws: "npm:^8.12.1"


### PR DESCRIPTION
This fixes some issues I noticed whilst working on #27828, whilst these didn't cause type-checking errors via linting, the issues were definitely present within rich IDEs such as VS Code.

This also gives us configuration completely independent of the frontend, allowing us to migrate streaming to typescript at a later date to the frontend or migrate streaming to ESM before the frontend.