### PR TITLE
Add `BackupMailer#ready` mailer with parameterization

### DIFF
--- a/app/mailers/backup_mailer.rb
+++ b/app/mailers/backup_mailer.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class BackupMailer < ApplicationMailer
+  before_action :set_user
+  before_action :set_backup
+
+  default to: -> { @user.email }
+
+  helper :routing
+
+  def ready
+    return unless @user.active_for_authentication?
+
+    I18n.with_locale(user_locale_or_default) do
+      # TODO: Restore `default_i18n_subject` after full mailer move
+      mail subject: t('user_mailer.backup_ready.subject') # default_i18n_subject
+    end
+  end
+
+  private
+
+  def user_locale_or_default
+    @user.locale.presence || I18n.default_locale
+  end
+
+  def set_user
+    @user = params[:user]
+  end
+
+  def set_backup
+    @backup = params[:backup]
+  end
+end

--- a/app/views/backup_mailer/ready.html.haml
+++ b/app/views/backup_mailer/ready.html.haml
@@ -1,0 +1,59 @@
+%table.email-table{ cellspacing: 0, cellpadding: 0 }
+  %tbody
+    %tr
+      %td.email-body
+        .email-container
+          %table.content-section{ cellspacing: 0, cellpadding: 0 }
+            %tbody
+              %tr
+                %td.content-cell.hero
+                  .email-row
+                    .col-6
+                      %table.column{ cellspacing: 0, cellpadding: 0 }
+                        %tbody
+                          %tr
+                            %td.column-cell.text-center.padded
+                              %table.hero-icon{ align: 'center', cellspacing: 0, cellpadding: 0 }
+                                %tbody
+                                  %tr
+                                    %td
+                                      = image_tag full_pack_url('media/images/mailer/icon_file_download.png'), alt: ''
+
+                              %h1= t 'user_mailer.backup_ready.title'
+
+%table.email-table{ cellspacing: 0, cellpadding: 0 }
+  %tbody
+    %tr
+      %td.email-body
+        .email-container
+          %table.content-section{ cellspacing: 0, cellpadding: 0 }
+            %tbody
+              %tr
+                %td.content-cell.content-start
+                  .email-row
+                    .col-6
+                      %table.column{ cellspacing: 0, cellpadding: 0 }
+                        %tbody
+                          %tr
+                            %td.column-cell.text-center
+                              %p= t 'user_mailer.backup_ready.explanation'
+
+%table.email-table{ cellspacing: 0, cellpadding: 0 }
+  %tbody
+    %tr
+      %td.email-body
+        .email-container
+          %table.content-section{ cellspacing: 0, cellpadding: 0 }
+            %tbody
+              %tr
+                %td.content-cell
+                  %table.column{ cellspacing: 0, cellpadding: 0 }
+                    %tbody
+                      %tr
+                        %td.column-cell.button-cell
+                          %table.button{ align: 'center', cellspacing: 0, cellpadding: 0 }
+                            %tbody
+                              %tr
+                                %td.button-primary
+                                  = link_to download_backup_url(@backup) do
+                                    %span= t 'exports.archive_takeout.download'

--- a/app/views/backup_mailer/ready.html.haml
+++ b/app/views/backup_mailer/ready.html.haml
@@ -1,59 +1,10 @@
-%table.email-table{ cellspacing: 0, cellpadding: 0 }
-  %tbody
-    %tr
-      %td.email-body
-        .email-container
-          %table.content-section{ cellspacing: 0, cellpadding: 0 }
-            %tbody
-              %tr
-                %td.content-cell.hero
-                  .email-row
-                    .col-6
-                      %table.column{ cellspacing: 0, cellpadding: 0 }
-                        %tbody
-                          %tr
-                            %td.column-cell.text-center.padded
-                              %table.hero-icon{ align: 'center', cellspacing: 0, cellpadding: 0 }
-                                %tbody
-                                  %tr
-                                    %td
-                                      = image_tag full_pack_url('media/images/mailer/icon_file_download.png'), alt: ''
-
-                              %h1= t 'user_mailer.backup_ready.title'
-
-%table.email-table{ cellspacing: 0, cellpadding: 0 }
-  %tbody
-    %tr
-      %td.email-body
-        .email-container
-          %table.content-section{ cellspacing: 0, cellpadding: 0 }
-            %tbody
-              %tr
-                %td.content-cell.content-start
-                  .email-row
-                    .col-6
-                      %table.column{ cellspacing: 0, cellpadding: 0 }
-                        %tbody
-                          %tr
-                            %td.column-cell.text-center
-                              %p= t 'user_mailer.backup_ready.explanation'
-
-%table.email-table{ cellspacing: 0, cellpadding: 0 }
-  %tbody
-    %tr
-      %td.email-body
-        .email-container
-          %table.content-section{ cellspacing: 0, cellpadding: 0 }
-            %tbody
-              %tr
-                %td.content-cell
-                  %table.column{ cellspacing: 0, cellpadding: 0 }
-                    %tbody
-                      %tr
-                        %td.column-cell.button-cell
-                          %table.button{ align: 'center', cellspacing: 0, cellpadding: 0 }
-                            %tbody
-                              %tr
-                                %td.button-primary
-                                  = link_to download_backup_url(@backup) do
-                                    %span= t 'exports.archive_takeout.download'
+= content_for :heading do
+  = render 'application/mailer/heading', heading_title: t('user_mailer.backup_ready.title'), heading_subtitle: t('user_mailer.backup_ready.explanation'), heading_image_url: full_pack_url('media/images/mailer-new/heading/archive.png')
+%table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+  %tr
+    %td.email-body-padding-td
+      %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+        %tr
+          %td.email-inner-card-td.email-prose
+            %p= t 'user_mailer.backup_ready.extra'
+            = render 'application/mailer/button', text: t('exports.archive_takeout.download'), url: download_backup_url(@backup)

--- a/app/views/backup_mailer/ready.html.haml
+++ b/app/views/backup_mailer/ready.html.haml
@@ -1,5 +1,5 @@
 = content_for :heading do
-  = render 'application/mailer/heading', heading_title: t('user_mailer.backup_ready.title'), heading_subtitle: t('user_mailer.backup_ready.explanation'), heading_image_url: full_pack_url('media/images/mailer-new/heading/archive.png')
+  = render 'application/mailer/heading', heading_title: t('user_mailer.backup_ready.title'), heading_subtitle: t('user_mailer.backup_ready.explanation'), heading_image_url: frontend_asset_url('images/mailer-new/heading/archive.png')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/backup_mailer/ready.text.erb
+++ b/app/views/backup_mailer/ready.text.erb
@@ -1,0 +1,7 @@
+<%= t 'user_mailer.backup_ready.title' %>
+
+===
+
+<%= t 'user_mailer.backup_ready.explanation' %>
+
+=> <%= download_backup_url(@backup) %>

--- a/app/workers/backup_worker.rb
+++ b/app/workers/backup_worker.rb
@@ -23,6 +23,6 @@ class BackupWorker
     BackupService.new.call(backup)
 
     user.backups.where.not(id: backup.id).destroy_all
-    UserMailer.backup_ready(user, backup).deliver_later
+    BackupMailer.with(user: user, backup: backup).ready.deliver_later
   end
 end

--- a/spec/mailers/backup_mailer_spec.rb
+++ b/spec/mailers/backup_mailer_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe BackupMailer do
+  let(:user) { Fabricate(:user) }
+
+  describe '#ready' do
+    let(:backup) { Fabricate(:backup) }
+    let(:mail) { described_class.with(user: user, backup: backup).ready }
+
+    it 'renders backup ready email' do
+      expect(mail)
+        .to be_present
+        .and(have_subject(I18n.t('user_mailer.backup_ready.subject')))
+        .and(have_body_text(I18n.t('user_mailer.backup_ready.title')))
+        .and(have_body_text(I18n.t('user_mailer.backup_ready.explanation')))
+    end
+  end
+end

--- a/spec/mailers/previews/backup_mailer_preview.rb
+++ b/spec/mailers/previews/backup_mailer_preview.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Preview all emails at http://localhost:3000/rails/mailers/backup_mailer
+
+class BackupMailerPreview < ActionMailer::Preview
+  # Preview this email at http://localhost:3000/rails/mailers/backup_mailer/ready
+  def ready
+    BackupMailer.with(user: Backup.last.user, backup: Backup.last).ready
+  end
+end


### PR DESCRIPTION
This is related to idea discussed in https://github.com/mastodon/mastodon/pull/25884#issuecomment-1772914754

That original PR had been to use "parameterization" in the UserMailer, but we realized that even though the readability change was nice, the migration path there was awkward because all the mail sitting in a job queue to be retried would have the method signature change and possibly break those outgoing emails on deploy. This approach works around this by moving email (for now just backup mail) out of the UserMailer and into a new class, and then leaving the old method and  signature in place, but forwarding to the new location (mitigating migration issues).

The plan here would be to leave all the things which are overriding Devise mailers as-is within the UserMailer, and move the other things out. This would allow us to do a little clean up in the UserMailer as well once the others were removed, because there is more shared setup common only to the devise-mailer-overriding methods.

After all that was done, we'd have something like (maybe not exactly this, but roughly...):

- Existing UserMailer with more or less the first ~half of the file as-is, with slight refactors for shared devise setup
- New mailer(s) to house the backup (this PR), welcome, warning, appeal_approved, appeal_rejected, suspicious_sign_in mailers. I could see doing either just 2 mailer classes here (existing UserMailer for devise-overrides, and one new NoticeMailer or ActivityMailer or something generic which held all other non-devise ones), or like 3-5 more narrowly named ones (BackupMailer, AppealMailer, SessionMailer, etc...)

Separately - the timing of adding the new mailer layouts gives us a good moment to adjust the signatures here -- my thinking is that we can add new mailers/methods/parameterization and use the new layout on what we added, and (for one release only) leave the old mailers in place as well. The queues will wind down on any jobs already in there with the old mailers, but code creating new email with use the new mailers with new layout. We can remove the old mailers/layouts in future release.

Would love feedback on the general idea, and the specific naming/organization direction.