### PR TITLE
Fix not all legal images showing in file picker when uploading custom emoji

### DIFF
--- a/app/views/admin/custom_emojis/new.html.haml
+++ b/app/views/admin/custom_emojis/new.html.haml
@@ -7,7 +7,7 @@
   .fields-group
     = f.input :shortcode, wrapper: :with_label, label: t('admin.custom_emojis.shortcode'), hint: t('admin.custom_emojis.shortcode_hint')
   .fields-group
-    = f.input :image, wrapper: :with_label, input_html: { accept: CustomEmoji::IMAGE_MIME_TYPES.join(' ') }, hint: t('admin.custom_emojis.image_hint', size: number_to_human_size(CustomEmoji::LIMIT))
+    = f.input :image, wrapper: :with_label, input_html: { accept: CustomEmoji::IMAGE_MIME_TYPES.join(',') }, hint: t('admin.custom_emojis.image_hint', size: number_to_human_size(CustomEmoji::LIMIT))
 
   .actions
     = f.button :button, t('admin.custom_emojis.upload'), type: :submit


### PR DESCRIPTION
The filetypes listed in the `accept` attribute need to be joined using commas. See [here](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept).
At least for Firefox on Linux this fixes the file picker not showing all legal images.