### PR TITLE
nodeinfo: add instance name and description

### DIFF
--- a/app/serializers/node_info/serializer.rb
+++ b/app/serializers/node_info/serializer.rb
@@ -38,7 +38,10 @@ class NodeInfo::Serializer < ActiveModel::Serializer
   end
 
   def metadata
-    {}
+    {
+      nodeName: Setting.site_title,
+      nodeDescription: Setting.site_short_description,
+    }
   end
 
   private


### PR DESCRIPTION

As noted at https://codeberg.org/thefederationinfo/nodeinfo_extension,
a lot of other software do expose it in this way.