### PR TITLE
Use "lazy lookup" for i18n values in mailer views

### DIFF
--- a/app/views/admin_mailer/new_appeal.text.erb
+++ b/app/views/admin_mailer/new_appeal.text.erb
@@ -1,7 +1,7 @@
-<%= raw t('admin_mailer.new_appeal.body', target: @appeal.account.username, action_taken_by: @appeal.strike.account.username, date: l(@appeal.strike.created_at, format: :with_time_zone), type: t(@appeal.strike.action, scope: 'admin_mailer.new_appeal.actions')) %>
+<%= raw t('.body', target: @appeal.account.username, action_taken_by: @appeal.strike.account.username, date: l(@appeal.strike.created_at, format: :with_time_zone), type: t(@appeal.strike.action, scope: 'admin_mailer.new_appeal.actions')) %>
 
 > <%= raw word_wrap(@appeal.text, break_sequence: "\n> ") %>
 
-<%= raw t('admin_mailer.new_appeal.next_steps') %>
+<%= raw t('.next_steps') %>
 
 <%= raw t('application_mailer.view')%> <%= disputes_strike_url(@appeal.strike) %>

--- a/app/views/admin_mailer/new_critical_software_updates.text.erb
+++ b/app/views/admin_mailer/new_critical_software_updates.text.erb
@@ -1,3 +1,3 @@
-<%= raw t('admin_mailer.new_critical_software_updates.body') %>
+<%= raw t('.body') %>
 
 <%= raw t('application_mailer.view')%> <%= admin_software_updates_url %>

--- a/app/views/admin_mailer/new_pending_account.text.erb
+++ b/app/views/admin_mailer/new_pending_account.text.erb
@@ -1,4 +1,4 @@
-<%= raw t('admin_mailer.new_pending_account.body') %>
+<%= raw t('.body') %>
 
 <%= @account.user_email %> (@<%= @account.username %>)
 <%= @account.user_sign_up_ip %>

--- a/app/views/admin_mailer/new_report.text.erb
+++ b/app/views/admin_mailer/new_report.text.erb
@@ -1,3 +1,3 @@
-<%= raw(@report.account.local? ? t('admin_mailer.new_report.body', target: @report.target_account.pretty_acct, reporter: @report.account.pretty_acct) : t('admin_mailer.new_report.body_remote', target: @report.target_account.acct, domain: @report.account.domain)) %>
+<%= raw(@report.account.local? ? t('.body', target: @report.target_account.pretty_acct, reporter: @report.account.pretty_acct) : t('.body_remote', target: @report.target_account.acct, domain: @report.account.domain)) %>
 
 <%= raw t('application_mailer.view')%> <%= admin_report_url(@report) %>

--- a/app/views/admin_mailer/new_software_updates.text.erb
+++ b/app/views/admin_mailer/new_software_updates.text.erb
@@ -1,3 +1,3 @@
-<%= raw t('admin_mailer.new_software_updates.body') %>
+<%= raw t('.body') %>
 
 <%= raw t('application_mailer.view')%> <%= admin_software_updates_url %>

--- a/app/views/admin_mailer/new_trends.text.erb
+++ b/app/views/admin_mailer/new_trends.text.erb
@@ -1,4 +1,4 @@
-<%= raw t('admin_mailer.new_trends.body') %>
+<%= raw t('.body') %>
 
 <%= render partial: 'new_trending_links', object: @links unless @links.empty? %>
 <%= render partial: 'new_trending_tags', object: @tags unless @tags.empty? %>

--- a/app/views/notification_mailer/favourite.html.haml
+++ b/app/views/notification_mailer/favourite.html.haml
@@ -1,5 +1,5 @@
 = content_for :heading do
-  = render 'application/mailer/heading', heading_title: t('notification_mailer.favourite.title'), heading_subtitle: t('notification_mailer.favourite.body', name: @account.pretty_acct), heading_image_url: frontend_asset_url('images/mailer-new/heading/favorite.png')
+  = render 'application/mailer/heading', heading_title: t('.title'), heading_subtitle: t('.body', name: @account.pretty_acct), heading_image_url: frontend_asset_url('images/mailer-new/heading/favorite.png')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/notification_mailer/favourite.text.erb
+++ b/app/views/notification_mailer/favourite.text.erb
@@ -1,5 +1,5 @@
 <%= raw t('application_mailer.salutation', name: display_name(@me)) %>
 
-<%= raw t('notification_mailer.favourite.body', name: @account.pretty_acct) %>
+<%= raw t('.body', name: @account.pretty_acct) %>
 
 <%= render 'status', status: @status %>

--- a/app/views/notification_mailer/follow.html.haml
+++ b/app/views/notification_mailer/follow.html.haml
@@ -1,5 +1,5 @@
 = content_for :heading do
-  = render 'application/mailer/heading', heading_title: t('notification_mailer.follow.title'), heading_subtitle: t('notification_mailer.follow.body', name: @account.pretty_acct), heading_image_url: frontend_asset_url('images/mailer-new/heading/user.png')
+  = render 'application/mailer/heading', heading_title: t('.title'), heading_subtitle: t('.body', name: @account.pretty_acct), heading_image_url: frontend_asset_url('images/mailer-new/heading/user.png')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/notification_mailer/follow.text.erb
+++ b/app/views/notification_mailer/follow.text.erb
@@ -1,5 +1,5 @@
 <%= raw t('application_mailer.salutation', name: display_name(@me)) %>
 
-<%= raw t('notification_mailer.follow.body', name: @account.pretty_acct) %>
+<%= raw t('.body', name: @account.pretty_acct) %>
 
 <%= raw t('application_mailer.view')%> <%= web_url("@#{@account.pretty_acct}") %>

--- a/app/views/notification_mailer/follow_request.html.haml
+++ b/app/views/notification_mailer/follow_request.html.haml
@@ -1,5 +1,5 @@
 = content_for :heading do
-  = render 'application/mailer/heading', heading_title: t('notification_mailer.follow_request.title'), heading_subtitle: t('notification_mailer.follow_request.body', name: @account.pretty_acct), heading_image_url: frontend_asset_url('images/mailer-new/heading/follow.png')
+  = render 'application/mailer/heading', heading_title: t('.title'), heading_subtitle: t('.body', name: @account.pretty_acct), heading_image_url: frontend_asset_url('images/mailer-new/heading/follow.png')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/notification_mailer/follow_request.text.erb
+++ b/app/views/notification_mailer/follow_request.text.erb
@@ -1,5 +1,5 @@
 <%= raw t('application_mailer.salutation', name: display_name(@me)) %>
 
-<%= raw t('notification_mailer.follow_request.body', name: @account.pretty_acct) %>
+<%= raw t('.body', name: @account.pretty_acct) %>
 
 <%= raw t('application_mailer.view')%> <%= web_url("follow_requests") %>

--- a/app/views/notification_mailer/mention.html.haml
+++ b/app/views/notification_mailer/mention.html.haml
@@ -1,5 +1,5 @@
 = content_for :heading do
-  = render 'application/mailer/heading', heading_title: t('notification_mailer.mention.title'), heading_subtitle: t('notification_mailer.mention.body', name: @status.account.pretty_acct), heading_image_url: frontend_asset_url('images/mailer-new/heading/mention.png')
+  = render 'application/mailer/heading', heading_title: t('.title'), heading_subtitle: t('.body', name: @status.account.pretty_acct), heading_image_url: frontend_asset_url('images/mailer-new/heading/mention.png')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/notification_mailer/mention.text.erb
+++ b/app/views/notification_mailer/mention.text.erb
@@ -1,5 +1,5 @@
 <%= raw t('application_mailer.salutation', name: display_name(@me)) %>
 
-<%= raw t('notification_mailer.mention.body', name: @status.account.pretty_acct) %>
+<%= raw t('.body', name: @status.account.pretty_acct) %>
 
 <%= render 'status', status: @status %>

--- a/app/views/notification_mailer/reblog.html.haml
+++ b/app/views/notification_mailer/reblog.html.haml
@@ -1,5 +1,5 @@
 = content_for :heading do
-  = render 'application/mailer/heading', heading_title: t('notification_mailer.reblog.title'), heading_subtitle: t('notification_mailer.reblog.body', name: @account.pretty_acct), heading_image_url: frontend_asset_url('images/mailer-new/heading/boost.png')
+  = render 'application/mailer/heading', heading_title: t('.title'), heading_subtitle: t('.body', name: @account.pretty_acct), heading_image_url: frontend_asset_url('images/mailer-new/heading/boost.png')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/notification_mailer/reblog.text.erb
+++ b/app/views/notification_mailer/reblog.text.erb
@@ -1,5 +1,5 @@
 <%= raw t('application_mailer.salutation', name: display_name(@me)) %>
 
-<%= raw t('notification_mailer.reblog.body', name: @account.pretty_acct) %>
+<%= raw t('.body', name: @account.pretty_acct) %>
 
 <%= render 'status', status: @status %>

--- a/app/views/user_mailer/appeal_approved.html.haml
+++ b/app/views/user_mailer/appeal_approved.html.haml
@@ -1,12 +1,12 @@
 = content_for :heading do
-  = render 'application/mailer/heading', heading_title: t('user_mailer.appeal_approved.title'), heading_subtitle: t('user_mailer.appeal_approved.subtitle'), heading_image_url: frontend_asset_url('images/mailer-new/heading/appeal-approved.png')
+  = render 'application/mailer/heading', heading_title: t('.title'), heading_subtitle: t('.subtitle'), heading_image_url: frontend_asset_url('images/mailer-new/heading/appeal-approved.png')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td
       %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
         %tr
           %td.email-inner-card-td.email-prose
-            %p= t 'user_mailer.appeal_approved.explanation',
+            %p= t '.explanation',
                   appeal_date: l(@appeal.created_at.in_time_zone(@resource.time_zone.presence), format: :with_time_zone),
                   strike_date: l(@appeal.strike.created_at.in_time_zone(@resource.time_zone.presence), format: :with_time_zone)
-            = render 'application/mailer/button', text: t('user_mailer.appeal_approved.action'), url: root_url
+            = render 'application/mailer/button', text: t('.action'), url: root_url

--- a/app/views/user_mailer/appeal_approved.text.erb
+++ b/app/views/user_mailer/appeal_approved.text.erb
@@ -1,7 +1,7 @@
-<%= t 'user_mailer.appeal_approved.title' %>
+<%= t '.title' %>
 
 ===
 
-<%= t 'user_mailer.appeal_approved.explanation', appeal_date: l(@appeal.created_at.in_time_zone(@resource.time_zone.presence), format: :with_time_zone), strike_date: l(@appeal.strike.created_at.in_time_zone(@resource.time_zone.presence), format: :with_time_zone) %>
+<%= t '.explanation', appeal_date: l(@appeal.created_at.in_time_zone(@resource.time_zone.presence), format: :with_time_zone), strike_date: l(@appeal.strike.created_at.in_time_zone(@resource.time_zone.presence), format: :with_time_zone) %>
 
 => <%= root_url %>

--- a/app/views/user_mailer/appeal_rejected.html.haml
+++ b/app/views/user_mailer/appeal_rejected.html.haml
@@ -1,12 +1,12 @@
 = content_for :heading do
-  = render 'application/mailer/heading', heading_title: t('user_mailer.appeal_rejected.title'), heading_subtitle: t('user_mailer.appeal_rejected.subtitle'), heading_image_url: frontend_asset_url('images/mailer-new/heading/appeal-rejected.png')
+  = render 'application/mailer/heading', heading_title: t('.title'), heading_subtitle: t('.subtitle'), heading_image_url: frontend_asset_url('images/mailer-new/heading/appeal-rejected.png')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td
       %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
         %tr
           %td.email-inner-card-td.email-prose
-            %p= t 'user_mailer.appeal_rejected.explanation',
+            %p= t '.explanation',
                   appeal_date: l(@appeal.created_at.in_time_zone(@resource.time_zone.presence), format: :with_time_zone),
                   strike_date: l(@appeal.strike.created_at.in_time_zone(@resource.time_zone.presence), format: :with_time_zone)
             = render 'application/mailer/button', text: t('user_mailer.appeal_approved.action'), url: root_url

--- a/app/views/user_mailer/appeal_rejected.text.erb
+++ b/app/views/user_mailer/appeal_rejected.text.erb
@@ -1,7 +1,7 @@
-<%= t 'user_mailer.appeal_rejected.title' %>
+<%= t '.title' %>
 
 ===
 
-<%= t 'user_mailer.appeal_rejected.explanation', appeal_date: l(@appeal.created_at.in_time_zone(@resource.time_zone.presence), format: :with_time_zone), strike_date: l(@appeal.strike.created_at.in_time_zone(@resource.time_zone.presence), format: :with_time_zone) %>
+<%= t '.explanation', appeal_date: l(@appeal.created_at.in_time_zone(@resource.time_zone.presence), format: :with_time_zone), strike_date: l(@appeal.strike.created_at.in_time_zone(@resource.time_zone.presence), format: :with_time_zone) %>
 
 => <%= root_url %>

--- a/app/views/user_mailer/backup_ready.html.haml
+++ b/app/views/user_mailer/backup_ready.html.haml
@@ -1,10 +1,10 @@
 = content_for :heading do
-  = render 'application/mailer/heading', heading_title: t('user_mailer.backup_ready.title'), heading_subtitle: t('user_mailer.backup_ready.explanation'), heading_image_url: frontend_asset_url('images/mailer-new/heading/archive.png')
+  = render 'application/mailer/heading', heading_title: t('.title'), heading_subtitle: t('.explanation'), heading_image_url: frontend_asset_url('images/mailer-new/heading/archive.png')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td
       %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
         %tr
           %td.email-inner-card-td.email-prose
-            %p= t 'user_mailer.backup_ready.extra'
+            %p= t '.extra'
             = render 'application/mailer/button', text: t('exports.archive_takeout.download'), url: download_backup_url(@backup)

--- a/app/views/user_mailer/backup_ready.text.erb
+++ b/app/views/user_mailer/backup_ready.text.erb
@@ -1,7 +1,7 @@
-<%= t 'user_mailer.backup_ready.title' %>
+<%= t '.title' %>
 
 ===
 
-<%= t 'user_mailer.backup_ready.explanation' %>
+<%= t '.explanation' %>
 
 => <%= download_backup_url(@backup) %>

--- a/app/views/user_mailer/suspicious_sign_in.html.haml
+++ b/app/views/user_mailer/suspicious_sign_in.html.haml
@@ -1,12 +1,12 @@
 = content_for :heading do
-  = render 'application/mailer/heading', heading_title: t('user_mailer.suspicious_sign_in.title'), heading_subtitle: t('user_mailer.suspicious_sign_in.explanation'), heading_image_url: frontend_asset_url('images/mailer-new/heading/login.png')
+  = render 'application/mailer/heading', heading_title: t('.title'), heading_subtitle: t('.explanation'), heading_image_url: frontend_asset_url('images/mailer-new/heading/login.png')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td
       %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
         %tr
           %td.email-inner-card-td.email-prose
-            %p= t 'user_mailer.suspicious_sign_in.details'
+            %p= t '.details'
             %p
               %strong #{t('sessions.ip')}:
               = @remote_ip
@@ -20,5 +20,5 @@
               %strong #{t('sessions.date')}:
               = l(@timestamp.in_time_zone(@resource.time_zone.presence), format: :with_time_zone)
             = render 'application/mailer/button', text: t('settings.account_settings'), url: edit_user_registration_url
-      %p= t 'user_mailer.suspicious_sign_in.further_actions_html',
+      %p= t '.further_actions_html',
             action: link_to(t('user_mailer.suspicious_sign_in.change_password'), edit_user_registration_url)

--- a/app/views/user_mailer/suspicious_sign_in.text.erb
+++ b/app/views/user_mailer/suspicious_sign_in.text.erb
@@ -1,15 +1,15 @@
-<%= t 'user_mailer.suspicious_sign_in.title' %>
+<%= t '.title' %>
 
 ===
 
-<%= t 'user_mailer.suspicious_sign_in.explanation' %>
+<%= t '.explanation' %>
 
-<%= t 'user_mailer.suspicious_sign_in.details' %>
+<%= t '.details' %>
 
 <%= t('sessions.ip') %>: <%= @remote_ip %>
 <%= t('sessions.browser') %>: <%= t('sessions.description', browser: t("sessions.browsers.#{@detection.id}", default: "#{@detection.id}"), platform: t("sessions.platforms.#{@detection.platform.id}", default: "#{@detection.platform.id}")) %>
 <%= l(@timestamp.in_time_zone(@resource.time_zone.presence), format: :with_time_zone) %>
 
-<%= t 'user_mailer.suspicious_sign_in.further_actions_html', action: t('user_mailer.suspicious_sign_in.change_password') %>
+<%= t '.further_actions_html', action: t('.change_password') %>
 
 => <%= edit_user_registration_url %>

--- a/app/views/user_mailer/warning.html.haml
+++ b/app/views/user_mailer/warning.html.haml
@@ -1,5 +1,5 @@
 = content_for :heading do
-  = render 'application/mailer/heading', heading_title: t("user_mailer.warning.title.#{@warning.action}"), heading_image_url: frontend_asset_url('images/mailer-new/heading/warning.png')
+  = render 'application/mailer/heading', heading_title: t(".title.#{@warning.action}"), heading_image_url: frontend_asset_url('images/mailer-new/heading/warning.png')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td
@@ -10,15 +10,15 @@
               %tr
                 %td.email-prose.email-padding-24
                   - unless @warning.none_action?
-                    %p= t "user_mailer.warning.explanation.#{@warning.action}", instance: @instance
+                    %p= t ".explanation.#{@warning.action}", instance: @instance
 
                   - if @warning.text.present?
                     = linkify(@warning.text)
 
                   - if @warning.report && !@warning.report.other?
                     %p
-                      %strong= t('user_mailer.warning.reason')
-                      = t("user_mailer.warning.categories.#{@warning.report.category}")
+                      %strong= t('.reason')
+                      = t(".categories.#{@warning.report.category}")
 
                     - if @warning.report.violation? && @warning.report.rule_ids.present?
                       %ul.rules-list
@@ -27,7 +27,7 @@
 
                   - unless @statuses.empty?
                     %p
-                      %strong= t('user_mailer.warning.statuses')
+                      %strong= t('.statuses')
 
             - unless @statuses.empty?
               %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
@@ -42,5 +42,5 @@
             %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
               %tr
                 %td.email-prose.email-padding-24
-                  %p= t 'user_mailer.warning.appeal_description', instance: @instance
-                  = render 'application/mailer/button', text: t('user_mailer.warning.appeal'), url: disputes_strike_url(@warning)
+                  %p= t '.appeal_description', instance: @instance
+                  = render 'application/mailer/button', text: t('.appeal'), url: disputes_strike_url(@warning)

--- a/app/views/user_mailer/warning.text.erb
+++ b/app/views/user_mailer/warning.text.erb
@@ -1,9 +1,9 @@
-<%= t "user_mailer.warning.title.#{@warning.action}" %>
+<%= t ".title.#{@warning.action}" %>
 
 ===
 
 <% unless @warning.none_action? %>
-<%= t "user_mailer.warning.explanation.#{@warning.action}", instance: @instance %>
+<%= t ".explanation.#{@warning.action}", instance: @instance %>
 
 <% end %>
 <% if @warning.text.present? %>
@@ -11,7 +11,7 @@
 
 <% end %>
 <% if @warning.report && !@warning.report.other? %>
-**<%= t('user_mailer.warning.reason') %>** <%= t("user_mailer.warning.categories.#{@warning.report.category}") %>
+**<%= t('.reason') %>** <%= t(".categories.#{@warning.report.category}") %>
 
 <% if @warning.report.violation? && @warning.report.rule_ids.present? %>
 <% @warning.report.rules.each do |rule| %>
@@ -21,7 +21,7 @@
 <% end %>
 <% end %>
 <% if !@statuses.empty? %>
-<%= t('user_mailer.warning.statuses') %>
+<%= t('.statuses') %>
 
 <% @statuses.each do |status| %>
 
@@ -32,5 +32,5 @@
 ---
 <% end %>
 
-<%= t 'user_mailer.warning.appeal_description', instance: @instance %>
+<%= t '.appeal_description', instance: @instance %>
 <%= disputes_strike_url(@warning) %>

--- a/app/views/user_mailer/welcome.html.haml
+++ b/app/views/user_mailer/welcome.html.haml
@@ -3,7 +3,7 @@
 = content_for :heading do
   .email-desktop-flex
     .email-header-left
-      = render 'application/mailer/heading', heading_title: t('user_mailer.welcome.title', name: @resource.account.username), heading_subtitle: t('user_mailer.welcome.explanation')
+      = render 'application/mailer/heading', heading_title: t('.title', name: @resource.account.username), heading_subtitle: t('.explanation')
     .email-header-right
       .email-header-card
         %table.email-header-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
@@ -18,18 +18,18 @@
                     %p.email-header-card-instance= @instance
                     - if instance_presenter.description.present?
                       %p.email-header-card-description= instance_presenter.description
-                    = render 'application/mailer/button', text: t('user_mailer.welcome.sign_in_action'), url: new_user_session_url, has_arrow: false
+                    = render 'application/mailer/button', text: t('.sign_in_action'), url: new_user_session_url, has_arrow: false
 
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-huge-padding-td
-      %h2.email-h2= t('user_mailer.welcome.checklist_title')
-      %p.email-h-sub= t('user_mailer.welcome.checklist_subtitle')
-      = render 'application/mailer/checklist', key: 'edit_profile_step', title: t('user_mailer.welcome.edit_profile_title'), text: t('user_mailer.welcome.edit_profile_step'), checked: @has_account_fields, button_text: t('user_mailer.welcome.edit_profile_action'), button_url: web_url('start/profile')
-      = render 'application/mailer/checklist', key: 'follow_step', title: t('user_mailer.welcome.follow_title'), text: t('user_mailer.welcome.follow_step'), checked: @has_active_relationships, button_text: t('user_mailer.welcome.follow_action'), button_url: web_url('start/follows')
-      = render 'application/mailer/checklist', key: 'post_step', title: t('user_mailer.welcome.post_title'), text: t('user_mailer.welcome.post_step'), checked: @has_statuses, button_text: t('user_mailer.welcome.post_action'), button_url: web_url
-      = render 'application/mailer/checklist', key: 'share_step', title: t('user_mailer.welcome.share_title'), text: t('user_mailer.welcome.share_step'), checked: false, button_text: t('user_mailer.welcome.share_action'), button_url: web_url('start/share')
-      = render 'application/mailer/checklist', key: 'apps_step', title: t('user_mailer.welcome.apps_title'), text: t('user_mailer.welcome.apps_step'), checked: false, show_apps_buttons: true
+      %h2.email-h2= t('.checklist_title')
+      %p.email-h-sub= t('.checklist_subtitle')
+      = render 'application/mailer/checklist', key: 'edit_profile_step', title: t('.edit_profile_title'), text: t('.edit_profile_step'), checked: @has_account_fields, button_text: t('.edit_profile_action'), button_url: web_url('start/profile')
+      = render 'application/mailer/checklist', key: 'follow_step', title: t('.follow_title'), text: t('.follow_step'), checked: @has_active_relationships, button_text: t('.follow_action'), button_url: web_url('start/follows')
+      = render 'application/mailer/checklist', key: 'post_step', title: t('.post_title'), text: t('.post_step'), checked: @has_statuses, button_text: t('.post_action'), button_url: web_url
+      = render 'application/mailer/checklist', key: 'share_step', title: t('.share_title'), text: t('.share_step'), checked: false, button_text: t('.share_action'), button_url: web_url('start/share')
+      = render 'application/mailer/checklist', key: 'apps_step', title: t('.apps_title'), text: t('.apps_step'), checked: false, show_apps_buttons: true
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-columns-td
@@ -40,14 +40,14 @@
           %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
             %tr
               %td.email-column-td
-                %h2.email-h2= t('user_mailer.welcome.follows_title')
-                %p.email-h-sub= t('user_mailer.welcome.follows_subtitle')
+                %h2.email-h2= t('.follows_title')
+                %p.email-h-sub= t('.follows_subtitle')
                 = render partial: 'application/mailer/follow', collection: @suggestions
                 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
                   %tr
                     %td.email-column-action-td
                       = link_to '', href: web_url('explore/suggestions'), class: 'email-link-with-arrow' do
-                        = t('user_mailer.welcome.follows_view_more')
+                        = t('.follows_view_more')
                         %span= '❯'
         /[if mso]
           </td><td style="width:50%; vertical-align:top;">
@@ -55,14 +55,14 @@
           %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
             %tr
               %td.email-column-td
-                %h2.email-h2= t('user_mailer.welcome.hashtags_title')
-                %p.email-h-sub= t('user_mailer.welcome.hashtags_subtitle')
+                %h2.email-h2= t('.hashtags_title')
+                %p.email-h-sub= t('.hashtags_subtitle')
                 = render partial: 'application/mailer/hashtag', collection: @tags
                 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
                   %tr
                     %td.email-column-action-td
                       = link_to '', href: web_url('explore/tags'), class: 'email-link-with-arrow' do
-                        = t('user_mailer.welcome.hashtags_view_more')
+                        = t('.hashtags_view_more')
                         %span= '❯'
         /[if mso]
           </td></tr></table>
@@ -70,7 +70,7 @@
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-extra-td
-      = render 'application/mailer/feature', key: 'feature_control', feature_title: t('user_mailer.welcome.feature_control_title'), feature_text: t('user_mailer.welcome.feature_control'), text_first_on_desktop: true
-      = render 'application/mailer/feature', key: 'feature_audience', feature_title: t('user_mailer.welcome.feature_audience_title'), feature_text: t('user_mailer.welcome.feature_audience'), text_first_on_desktop: false
-      = render 'application/mailer/feature', key: 'feature_moderation', feature_title: t('user_mailer.welcome.feature_moderation_title'), feature_text: t('user_mailer.welcome.feature_moderation'), text_first_on_desktop: true
-      = render 'application/mailer/feature', key: 'feature_creativity', feature_title: t('user_mailer.welcome.feature_creativity_title'), feature_text: t('user_mailer.welcome.feature_creativity'), text_first_on_desktop: false
+      = render 'application/mailer/feature', key: 'feature_control', feature_title: t('.feature_control_title'), feature_text: t('.feature_control'), text_first_on_desktop: true
+      = render 'application/mailer/feature', key: 'feature_audience', feature_title: t('.feature_audience_title'), feature_text: t('.feature_audience'), text_first_on_desktop: false
+      = render 'application/mailer/feature', key: 'feature_moderation', feature_title: t('.feature_moderation_title'), feature_text: t('.feature_moderation'), text_first_on_desktop: true
+      = render 'application/mailer/feature', key: 'feature_creativity', feature_title: t('.feature_creativity_title'), feature_text: t('.feature_creativity'), text_first_on_desktop: false

--- a/app/views/user_mailer/welcome.text.erb
+++ b/app/views/user_mailer/welcome.text.erb
@@ -1,43 +1,43 @@
-<%= t 'user_mailer.welcome.title', name: @resource.account.username %> <%= t 'user_mailer.welcome.explanation' %>
+<%= t '.title', name: @resource.account.username %> <%= t '.explanation' %>
 
 ---
 
-<%= t('user_mailer.welcome.sign_in_action') %>
+<%= t('.sign_in_action') %>
 ===
 <%= new_user_session_url %>
 
 ---
 
-<%= t('user_mailer.welcome.checklist_title') %>
+<%= t('.checklist_title') %>
 ===
-<%= t('user_mailer.welcome.checklist_subtitle') %>
+<%= t('.checklist_subtitle') %>
 
-1. <%= t('user_mailer.welcome.edit_profile_title') %>
-   <%= t('user_mailer.welcome.edit_profile_step') %>
+1. <%= t('.edit_profile_title') %>
+   <%= t('.edit_profile_step') %>
    * <%= web_url('start/profile') %>
 
-2. <%= t('user_mailer.welcome.follow_title') %>
-   <%= t('user_mailer.welcome.follow_step') %>
+2. <%= t('.follow_title') %>
+   <%= t('.follow_step') %>
    * <%= web_url('start/follows') %>
 
-3. <%= t('user_mailer.welcome.post_title') %>
-   <%= t('user_mailer.welcome.post_step') %>
+3. <%= t('.post_title') %>
+   <%= t('.post_step') %>
    * <%= web_url %>
 
-4. <%= t('user_mailer.welcome.share_title') %>
-   <%= t('user_mailer.welcome.share_step') %>
+4. <%= t('.share_title') %>
+   <%= t('.share_step') %>
    * <%= web_url('start/share') %>
 
-5. <%= t('user_mailer.welcome.apps_title') %>
-   <%= t('user_mailer.welcome.apps_step') %>
+5. <%= t('.apps_title') %>
+   <%= t('.apps_step') %>
    * iOS: https://apps.apple.com/app/mastodon-for-iphone-and-ipad/id1571998974
    * Android: https://play.google.com/store/apps/details?id=org.joinmastodon.android
 
 ---
 
-<%= t('user_mailer.welcome.follows_title') %>
+<%= t('.follows_title') %>
 ===
-<%= t('user_mailer.welcome.follows_subtitle') %>
+<%= t('.follows_subtitle') %>
 
 <%- @suggestions.each do |suggestion| %>
 * <%= suggestion.account.display_name.presence || suggestion.account.username %> · @<%= suggestion.account.pretty_acct %>
@@ -48,12 +48,12 @@
 
 ---
 
-<%= t('user_mailer.welcome.hashtags_title') %>
+<%= t('.hashtags_title') %>
 ===
-<%= t('user_mailer.welcome.hashtags_subtitle') %>
+<%= t('.hashtags_subtitle') %>
 
 <%- @tags.each do |tag| %>
-* #<%= tag.display_name %> · <%= t('user_mailer.welcome.hashtags_recent_count', people: number_with_delimiter(tag.history.aggregate(2.days.ago.to_date..Time.zone.today).accounts), days: 2) %>
+* #<%= tag.display_name %> · <%= t('.hashtags_recent_count', people: number_with_delimiter(tag.history.aggregate(2.days.ago.to_date..Time.zone.today).accounts), days: 2) %>
   <%= tag_url(tag) %>
 <%- end %>
 
@@ -61,18 +61,18 @@
 
 ---
 
-<%= t('user_mailer.welcome.feature_control_title') %>
+<%= t('.feature_control_title') %>
 ===
-<%= word_wrap t('user_mailer.welcome.feature_control') %>
+<%= word_wrap t('.feature_control') %>
 
-<%= t('user_mailer.welcome.feature_audience_title') %>
+<%= t('.feature_audience_title') %>
 ===
-<%= word_wrap t('user_mailer.welcome.feature_audience') %>
+<%= word_wrap t('.feature_audience') %>
 
-<%= t('user_mailer.welcome.feature_moderation_title') %>
+<%= t('.feature_moderation_title') %>
 ===
-<%= word_wrap t('user_mailer.welcome.feature_moderation') %>
+<%= word_wrap t('.feature_moderation') %>
 
-<%= t('user_mailer.welcome.feature_creativity_title') %>
+<%= t('.feature_creativity_title') %>
 ===
-<%= word_wrap t('user_mailer.welcome.feature_creativity') %>
+<%= word_wrap t('.feature_creativity') %>


### PR DESCRIPTION
We currently have a mix of lazy lookup and full key lookup throughout the app. There are some places where the full key lookup is needed because it's pulling a value from a different controller/view/etc, but there are many where the lazy style would work and is just not used (sometimes in views where it is used in other places).

This PR is a once-over on just the mailer views and updates to use the lazy style where possible.