### PR TITLE
Update `bcrypt` to version 3.1.20

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,7 +156,7 @@ GEM
       nokogiri (~> 1, >= 1.10.8)
     base64 (0.2.0)
     bcp47_spec (0.2.1)
-    bcrypt (3.1.19)
+    bcrypt (3.1.20)
     better_errors (2.10.1)
       erubi (>= 1.0.0)
       rack (>= 0.9.0)


### PR DESCRIPTION
Gem was previously distributed with some spec/ and other unneeded files. This release descreases the distributed gem file size.