### PR TITLE
Use `admin_mailer` layout with initial salutation

### DIFF
--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class AdminMailer < ApplicationMailer
+  layout 'admin_mailer'
+
   helper :accounts
   helper :languages
 

--- a/app/views/admin_mailer/new_appeal.text.erb
+++ b/app/views/admin_mailer/new_appeal.text.erb
@@ -1,5 +1,3 @@
-<%= raw t('application_mailer.salutation', name: display_name(@me)) %>
-
 <%= raw t('admin_mailer.new_appeal.body', target: @appeal.account.username, action_taken_by: @appeal.strike.account.username, date: l(@appeal.strike.created_at, format: :with_time_zone), type: t(@appeal.strike.action, scope: 'admin_mailer.new_appeal.actions')) %>
 
 > <%= raw word_wrap(@appeal.text, break_sequence: "\n> ") %>

--- a/app/views/admin_mailer/new_critical_software_updates.text.erb
+++ b/app/views/admin_mailer/new_critical_software_updates.text.erb
@@ -1,5 +1,3 @@
-<%= raw t('application_mailer.salutation', name: display_name(@me)) %>
-
 <%= raw t('admin_mailer.new_critical_software_updates.body') %>
 
 <%= raw t('application_mailer.view')%> <%= admin_software_updates_url %>

--- a/app/views/admin_mailer/new_pending_account.text.erb
+++ b/app/views/admin_mailer/new_pending_account.text.erb
@@ -1,5 +1,3 @@
-<%= raw t('application_mailer.salutation', name: display_name(@me)) %>
-
 <%= raw t('admin_mailer.new_pending_account.body') %>
 
 <%= @account.user_email %> (@<%= @account.username %>)

--- a/app/views/admin_mailer/new_report.text.erb
+++ b/app/views/admin_mailer/new_report.text.erb
@@ -1,5 +1,3 @@
-<%= raw t('application_mailer.salutation', name: display_name(@me)) %>
-
 <%= raw(@report.account.local? ? t('admin_mailer.new_report.body', target: @report.target_account.pretty_acct, reporter: @report.account.pretty_acct) : t('admin_mailer.new_report.body_remote', target: @report.target_account.acct, domain: @report.account.domain)) %>
 
 <%= raw t('application_mailer.view')%> <%= admin_report_url(@report) %>

--- a/app/views/admin_mailer/new_software_updates.text.erb
+++ b/app/views/admin_mailer/new_software_updates.text.erb
@@ -1,5 +1,3 @@
-<%= raw t('application_mailer.salutation', name: display_name(@me)) %>
-
 <%= raw t('admin_mailer.new_software_updates.body') %>
 
 <%= raw t('application_mailer.view')%> <%= admin_software_updates_url %>

--- a/app/views/admin_mailer/new_trends.text.erb
+++ b/app/views/admin_mailer/new_trends.text.erb
@@ -1,5 +1,3 @@
-<%= raw t('application_mailer.salutation', name: display_name(@me)) %>
-
 <%= raw t('admin_mailer.new_trends.body') %>
 
 <%= render partial: 'new_trending_links', object: @links unless @links.empty? %>

--- a/app/views/layouts/admin_mailer.text.erb
+++ b/app/views/layouts/admin_mailer.text.erb
@@ -1,0 +1,3 @@
+<%= raw t('application_mailer.salutation', name: display_name(@me)) %>
+
+<%= yield %>


### PR DESCRIPTION
After removing the unused html layout for adminmailer, I realized that the text views actually do have some commonality that a layout could help with.