### PR TITLE
Update temple to version 0.10.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -755,7 +755,7 @@ GEM
       attr_required (>= 0.0.5)
       httpclient (>= 2.4)
     sysexits (1.2.0)
-    temple (0.10.2)
+    temple (0.10.3)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     terrapin (0.6.0)


### PR DESCRIPTION
Similar to https://github.com/mastodon/mastodon/pull/28084, the gem was previously distributed with unneeded spec files, this release removes that from packaged gem.