### PR TITLE
Handle scenario when webfinger response `subject` is missing host value

### DIFF
--- a/app/services/resolve_account_service.rb
+++ b/app/services/resolve_account_service.rb
@@ -100,7 +100,9 @@ class ResolveAccountService < BaseService
   end
 
   def split_acct(acct)
-    acct.delete_prefix('acct:').split('@')
+    acct.delete_prefix('acct:').split('@').tap do |parts|
+      raise Webfinger::Error, 'Webfinger response is missing user or host value' unless parts.size == 2
+    end
   end
 
   def fetch_account!

--- a/spec/services/resolve_account_service_spec.rb
+++ b/spec/services/resolve_account_service_spec.rb
@@ -144,6 +144,19 @@ RSpec.describe ResolveAccountService, type: :service do
     end
   end
 
+  context 'with webfinger response subject missing a host value' do
+    let(:body) { Oj.dump({ subject: 'user@' }) }
+    let(:url) { 'https://host.example/.well-known/webfinger?resource=acct:user@host.example' }
+
+    before do
+      stub_request(:get, url).to_return(status: 200, body: body)
+    end
+
+    it 'returns nil with incomplete subject in response' do
+      expect(subject.call('user@host.example')).to be_nil
+    end
+  end
+
   context 'with an ActivityPub account' do
     it 'returns new remote account' do
       account = subject.call('foo@ap.example.com')


### PR DESCRIPTION
Handles scenario in https://github.com/mastodon/mastodon/issues/28012

I chose to rely on the existing `rescue` at the bottom of `call` to swallow the error here and return nil, instead of blowing up by trying to work with non-existent values.