### PR TITLE
Remove unused `cached_filtered_status_page` method from accounts controller

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -96,8 +96,4 @@ class AccountsController < ApplicationController
   def tag_requested?
     request.path.split('.').first.end_with?(Addressable::URI.parse("/tagged/#{params[:tag]}").normalize)
   end
-
-  def params_slice(*keys)
-    params.slice(*keys).permit(*keys)
-  end
 end

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -97,15 +97,6 @@ class AccountsController < ApplicationController
     request.path.split('.').first.end_with?(Addressable::URI.parse("/tagged/#{params[:tag]}").normalize)
   end
 
-  def cached_filtered_status_page
-    cache_collection_paginated_by_id(
-      filtered_statuses,
-      Status,
-      PAGE_SIZE,
-      params_slice(:max_id, :min_id, :since_id)
-    )
-  end
-
   def params_slice(*keys)
     params.slice(*keys).permit(*keys)
   end


### PR DESCRIPTION
Looks like last usage was removed in https://github.com/mastodon/mastodon/commit/839f893168ab221b08fa439012189e6c29a2721a#diff-25fe163085ea55de795324d01f141d5e4de00c6a2d3035d75c6e0768af679a2eL32 when that view was moved out of html views and into JS.