### PR TITLE
Avoid unnecessary i-var for account rss page url generation

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -18,8 +18,6 @@ class AccountsController < ApplicationController
     respond_to do |format|
       format.html do
         expires_in(15.seconds, public: true, stale_while_revalidate: 30.seconds, stale_if_error: 1.hour) unless user_signed_in?
-
-        @rss_url = rss_url
       end
 
       format.rss do
@@ -84,6 +82,7 @@ class AccountsController < ApplicationController
       short_account_url(@account, format: 'rss')
     end
   end
+  helper_method :rss_url
 
   def media_requested?
     request.path.split('.').first.end_with?('/media') && !tag_requested?

--- a/app/views/accounts/show.html.haml
+++ b/app/views/accounts/show.html.haml
@@ -5,7 +5,7 @@
   - if @account.user_prefers_noindex?
     %meta{ name: 'robots', content: 'noindex, noarchive' }/
 
-  %link{ rel: 'alternate', type: 'application/rss+xml', href: @rss_url }/
+  %link{ rel: 'alternate', type: 'application/rss+xml', href: rss_url }/
   %link{ rel: 'alternate', type: 'application/activity+json', href: ActivityPub::TagManager.instance.uri_for(@account) }/
 
   - @account.fields.select(&:verifiable?).each do |field|


### PR DESCRIPTION
We have what is basically a route helper defined here, so use it as one.