### PR TITLE
Fix devcontainer by not forcing `NODE_ENV`

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -24,4 +24,4 @@ RAILS_ENV=development ./bin/rails db:setup
 RAILS_ENV=development ./bin/rails assets:precompile
 
 # Precompile assets for test
-RAILS_ENV=test NODE_ENV=tests ./bin/rails assets:precompile
+RAILS_ENV=test ./bin/rails assets:precompile


### PR DESCRIPTION
`NODE_ENV` should be picked from `.env.test`

Fixes #27678