### PR TITLE
Fix Vagrant failure to sync dangling symlinks

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -174,7 +174,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   if config.vm.networks.any? { |type, options| type == :private_network }
     config.vm.synced_folder ".", "/vagrant", type: "nfs", mount_options: ['rw', 'actimeo=1']
   else
-    config.vm.synced_folder ".", "/vagrant"
+    config.vm.synced_folder ".", "/vagrant", type: "rsync", create: true, rsync__args: ["--verbose", "--archive", "--delete", "-z"]
   end
 
   # Otherwise, you can access the site at http://localhost:3000 and http://localhost:4000 , http://localhost:8080


### PR DESCRIPTION
rsync 3.2.7 was failing for me on syncing folders with "symlink has no referent" error. Specifically symlinks in public/ are dangling at sync time, and that is expected as far as I can tell.

I lifted the fix from the commit below, which also provides more references/context:

https://github.com/cockpit-project/cockpit/commit/b1f4523e6daed155350f72f23c190ebbcf7c9e0d