### PR TITLE
Add libvirt provider parameters to Vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -147,6 +147,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     vb.customize ["modifyvm", :id, "--nictype2", "virtio"]
   end
 
+  config.vm.provider :libvirt do |libvirt|
+    libvirt.cpus = 3
+    libvirt.memory = 8192
+  end
+
+
   # This uses the vagrant-hostsupdater plugin, and lets you
   # access the development site at http://mastodon.local.
   # If you change it, also change it in .env.vagrant before provisioning


### PR DESCRIPTION
I'm using libvirt locally to run Vagrant, I thought the parameters will come handy for other folks also running libvirt.

Even though Ubuntu Vagrant boxes don't support libvirt officially, getting the images to run is as simple as:

  vagrant migrate ubuntu/focal64 libvirt

The vagrant-migrate plugin can be found at https://github.com/sciurus/vagrant-mutate