### PR TITLE
Remove the media and replies methods from accounts controller

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -39,22 +39,15 @@ class AccountsController < ApplicationController
 
   def filtered_statuses
     default_statuses.tap do |statuses|
-      statuses.merge!(hashtag_scope)    if tag_requested?
-      statuses.merge!(only_media_scope) if media_requested?
-      statuses.merge!(no_replies_scope) unless replies_requested?
+      statuses.merge!(hashtag_scope) if tag_requested?
     end
   end
 
   def default_statuses
-    @account.statuses.where(visibility: [:public, :unlisted])
-  end
-
-  def only_media_scope
-    Status.joins(:media_attachments).merge(@account.media_attachments.reorder(nil)).group(:id)
-  end
-
-  def no_replies_scope
-    Status.without_replies
+    @account
+      .statuses
+      .where(visibility: [:public, :unlisted])
+      .without_replies
   end
 
   def hashtag_scope
@@ -83,14 +76,6 @@ class AccountsController < ApplicationController
     end
   end
   helper_method :rss_url
-
-  def media_requested?
-    path_without_format.end_with?('/media') && !tag_requested?
-  end
-
-  def replies_requested?
-    path_without_format.end_with?('/with_replies') && !tag_requested?
-  end
 
   def tag_requested?
     path_without_format.end_with?(Addressable::URI.parse("/tagged/#{params[:tag]}").normalize)

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -82,31 +82,12 @@ RSpec.describe AccountsController do
           it_behaves_like 'common HTML response'
         end
 
-        context 'with replies' do
-          before do
-            allow(controller).to receive(:replies_requested?).and_return(true)
-            get :show, params: { username: account.username, format: format }
-          end
-
-          it_behaves_like 'common HTML response'
-        end
-
-        context 'with media' do
-          before do
-            allow(controller).to receive(:media_requested?).and_return(true)
-            get :show, params: { username: account.username, format: format }
-          end
-
-          it_behaves_like 'common HTML response'
-        end
-
         context 'with tag' do
           let(:tag) { Fabricate(:tag) }
 
           let!(:status_tag) { Fabricate(:status, account: account) }
 
           before do
-            allow(controller).to receive(:tag_requested?).and_return(true)
             status_tag.tags << tag
             get :show, params: { username: account.username, format: format, tag: tag.to_param }
           end
@@ -224,53 +205,12 @@ RSpec.describe AccountsController do
           end
         end
 
-        context 'with replies' do
-          before do
-            allow(controller).to receive(:replies_requested?).and_return(true)
-            get :show, params: { username: account.username, format: format }
-          end
-
-          it_behaves_like 'cacheable response', expects_vary: 'Accept, Accept-Language, Cookie'
-
-          it 'responds with correct statuses with replies', :aggregate_failures do
-            expect(response).to have_http_status(200)
-            expect(response.body).to include_status_tag(status_media)
-            expect(response.body).to include_status_tag(status_reply)
-            expect(response.body).to include_status_tag(status_self_reply)
-            expect(response.body).to include_status_tag(status)
-            expect(response.body).to_not include_status_tag(status_direct)
-            expect(response.body).to_not include_status_tag(status_private)
-            expect(response.body).to_not include_status_tag(status_reblog.reblog)
-          end
-        end
-
-        context 'with media' do
-          before do
-            allow(controller).to receive(:media_requested?).and_return(true)
-            get :show, params: { username: account.username, format: format }
-          end
-
-          it_behaves_like 'cacheable response', expects_vary: 'Accept, Accept-Language, Cookie'
-
-          it 'responds with correct statuses with media', :aggregate_failures do
-            expect(response).to have_http_status(200)
-            expect(response.body).to include_status_tag(status_media)
-            expect(response.body).to_not include_status_tag(status_direct)
-            expect(response.body).to_not include_status_tag(status_private)
-            expect(response.body).to_not include_status_tag(status_reblog.reblog)
-            expect(response.body).to_not include_status_tag(status_reply)
-            expect(response.body).to_not include_status_tag(status_self_reply)
-            expect(response.body).to_not include_status_tag(status)
-          end
-        end
-
         context 'with tag' do
           let(:tag) { Fabricate(:tag) }
 
           let!(:status_tag) { Fabricate(:status, account: account) }
 
           before do
-            allow(controller).to receive(:tag_requested?).and_return(true)
             status_tag.tags << tag
             get :show, params: { username: account.username, format: format, tag: tag.to_param }
           end


### PR DESCRIPTION
After removing this method - https://github.com/mastodon/mastodon/pull/28090 - I realized that with the previous changes to move this page out of the rails controller and into the react app, there are also more things unused.

Previously this page was loading statuses because the main account page needed them, and the `/media` and `/with_replies` and `/tags/:tag` pages also needed them, with scopes applied.

With the change to move the html into the react app, none of these are needed for the `html` format response.

Separately, I believe the `rss` response only supports the default account scope, and the tags scope, but does not  support (or link to anywhere?) the media or replies adjustments.

This change removes the media and replies special cases from the rss response, and updates the default scope to be `without_replies` (same behavior as before).

I think this is all safe to remove unless I'm misunderstanding the rss responses.