### PR TITLE
Cleanup on `api/` routes generation

### DIFF
--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -301,9 +301,11 @@ namespace :api, format: false do
         end
       end
 
-      post :measures, to: 'measures#create'
-      post :dimensions, to: 'dimensions#create'
-      post :retention, to: 'retention#create'
+      with_options only: :create do
+        resource :measures
+        resource :dimensions
+        resource :retention, controller: :retention
+      end
 
       resources :canonical_email_blocks, only: [:index, :create, :show, :destroy] do
         collection do

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -125,14 +125,20 @@ namespace :api, format: false do
     end
 
     resource :instance, only: [:show] do
-      resources :peers, only: [:index], controller: 'instances/peers'
-      resources :rules, only: [:index], controller: 'instances/rules'
-      resources :domain_blocks, only: [:index], controller: 'instances/domain_blocks'
-      resource :privacy_policy, only: [:show], controller: 'instances/privacy_policies'
-      resource :extended_description, only: [:show], controller: 'instances/extended_descriptions'
-      resource :translation_languages, only: [:show], controller: 'instances/translation_languages'
-      resource :languages, only: [:show], controller: 'instances/languages'
-      resource :activity, only: [:show], controller: 'instances/activity'
+      scope module: :instances do
+        with_options only: :index do
+          resources :domain_blocks
+          resources :peers
+          resources :rules
+        end
+        with_options only: :show do
+          resource :activity, controller: :activity
+          resource :extended_description
+          resource :languages
+          resource :privacy_policy
+          resource :translation_languages
+        end
+      end
     end
 
     namespace :peers do

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -181,12 +181,23 @@ namespace :api, format: false do
     end
 
     resources :accounts, only: [:create, :show] do
-      resources :statuses, only: :index, controller: 'accounts/statuses'
-      resources :followers, only: :index, controller: 'accounts/follower_accounts'
-      resources :following, only: :index, controller: 'accounts/following_accounts'
-      resources :lists, only: :index, controller: 'accounts/lists'
-      resources :identity_proofs, only: :index, controller: 'accounts/identity_proofs'
-      resources :featured_tags, only: :index, controller: 'accounts/featured_tags'
+      scope module: :accounts do
+        with_options only: :index do
+          resources :featured_tags
+          resources :followers, controller: :follower_accounts
+          resources :following, controller: :following_accounts
+          resources :identity_proofs
+          resources :lists
+          resources :statuses
+        end
+
+        with_options only: :create do
+          resource :note
+          resource :pin
+        end
+
+        post :unpin, to: 'pins#destroy'
+      end
 
       member do
         post :follow
@@ -197,10 +208,6 @@ namespace :api, format: false do
         post :mute
         post :unmute
       end
-
-      resource :pin, only: :create, controller: 'accounts/pins'
-      post :unpin, to: 'accounts/pins#destroy'
-      resource :note, only: :create, controller: 'accounts/notes'
     end
 
     resources :tags, only: [:show] do


### PR DESCRIPTION
Similar to https://github.com/mastodon/mastodon/pull/28104 except within the api routes. Like the other one, I believe this preserves all the generated routes and just cleans up the declarations.