### PR TITLE
Fix incorrect apt-get install block in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -177,28 +177,6 @@ FROM build as yarn
 ARG TARGETPLATFORM
 
 # Copy Node package configuration files into working directory
-RUN apt-get update && \
-    apt-get -yq dist-upgrade && \
-    apt-get install -y --no-install-recommends build-essential \
-        git \
-        libicu-dev \
-        libidn-dev \
-        libpq-dev \
-        libjemalloc-dev \
-        zlib1g-dev \
-        libgdbm-dev \
-        libgmp-dev \
-        libssl-dev \
-        libyaml-dev \
-        ca-certificates \
-        libreadline8 \
-        python3 \
-        shared-mime-info && \
-    bundle config set --local deployment 'true' && \
-    bundle config set --local without 'development test' && \
-    bundle config set silence_root_warning true && \
-    corepack enable
-
 COPY Gemfile* package.json yarn.lock .yarnrc.yml /opt/mastodon/
 COPY streaming/package.json /opt/mastodon/streaming/
 COPY .yarn /opt/mastodon/.yarn

--- a/Dockerfile
+++ b/Dockerfile
@@ -177,7 +177,7 @@ FROM build as yarn
 ARG TARGETPLATFORM
 
 # Copy Node package configuration files into working directory
-COPY Gemfile* package.json yarn.lock .yarnrc.yml /opt/mastodon/
+COPY package.json yarn.lock .yarnrc.yml /opt/mastodon/
 COPY streaming/package.json /opt/mastodon/streaming/
 COPY .yarn /opt/mastodon/.yarn
 


### PR DESCRIPTION
There was a block of apt install commands that was incorrectly retained in an edit of the Dockerfile for #26850, this removes that block.