### PR TITLE
Status associations concern

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -54,7 +54,7 @@ RSpec/NestedGroups:
 Rails/HasAndBelongsToMany:
   Exclude:
     - 'app/models/concerns/account/associations.rb'
-    - 'app/models/status.rb'
+    - 'app/models/concerns/status/associations.rb'
     - 'app/models/tag.rb'
 
 Rails/OutputSafety:

--- a/app/models/concerns/status/associations.rb
+++ b/app/models/concerns/status/associations.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Status::Associations
+  extend ActiveSupport::Concern
+
+  included do
+    belongs_to :application, class_name: 'Doorkeeper::Application', optional: true
+
+    belongs_to :account, inverse_of: :statuses
+    belongs_to :in_reply_to_account, class_name: 'Account', optional: true
+    belongs_to :conversation, optional: true
+    belongs_to :preloadable_poll, class_name: 'Poll', foreign_key: 'poll_id', optional: true, inverse_of: false
+
+    with_options class_name: 'Status', optional: true do
+      belongs_to :thread, foreign_key: 'in_reply_to_id', inverse_of: :replies
+      belongs_to :reblog, foreign_key: 'reblog_of_id', inverse_of: :reblogs
+    end
+
+    has_many :favourites, inverse_of: :status, dependent: :destroy
+    has_many :bookmarks, inverse_of: :status, dependent: :destroy
+    has_many :reblogs, foreign_key: 'reblog_of_id', class_name: 'Status', inverse_of: :reblog, dependent: :destroy
+    has_many :reblogged_by_accounts, through: :reblogs, class_name: 'Account', source: :account
+    has_many :replies, foreign_key: 'in_reply_to_id', class_name: 'Status', inverse_of: :thread, dependent: nil
+    has_many :mentions, dependent: :destroy, inverse_of: :status
+    has_many :mentioned_accounts, through: :mentions, source: :account, class_name: 'Account'
+    has_many :media_attachments, dependent: :nullify
+
+    # The `dependent` option is enabled by the initial `mentions` association declaration
+    has_many :active_mentions, -> { active }, class_name: 'Mention', inverse_of: :status # rubocop:disable Rails/HasManyOrHasOneDependent
+
+    # Those associations are used for the private search index
+    has_many :local_mentioned, -> { merge(Account.local) }, through: :active_mentions, source: :account
+    has_many :local_favorited, -> { merge(Account.local) }, through: :favourites, source: :account
+    has_many :local_reblogged, -> { merge(Account.local) }, through: :reblogs, source: :account
+    has_many :local_bookmarked, -> { merge(Account.local) }, through: :bookmarks, source: :account
+
+    has_and_belongs_to_many :tags
+
+    has_one :preview_cards_status, inverse_of: :status, dependent: :delete
+
+    has_one :notification, as: :activity, dependent: :destroy
+    has_one :status_stat, inverse_of: :status, dependent: nil
+    has_one :poll, inverse_of: :status, dependent: :destroy
+    has_one :trend, class_name: 'StatusTrend', inverse_of: :status, dependent: nil
+  end
+end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -34,6 +34,7 @@ class Status < ApplicationRecord
   include Discard::Model
   include Paginable
   include RateLimitable
+  include Status::Associations
   include Status::SafeReblogInsert
   include Status::SearchConcern
   include Status::SnapshotConcern
@@ -51,45 +52,6 @@ class Status < ApplicationRecord
   update_index('public_statuses', :proper)
 
   enum :visibility, { public: 0, unlisted: 1, private: 2, direct: 3, limited: 4 }, suffix: :visibility
-
-  belongs_to :application, class_name: 'Doorkeeper::Application', optional: true
-
-  belongs_to :account, inverse_of: :statuses
-  belongs_to :in_reply_to_account, class_name: 'Account', optional: true
-  belongs_to :conversation, optional: true
-  belongs_to :preloadable_poll, class_name: 'Poll', foreign_key: 'poll_id', optional: true, inverse_of: false
-
-  with_options class_name: 'Status', optional: true do
-    belongs_to :thread, foreign_key: 'in_reply_to_id', inverse_of: :replies
-    belongs_to :reblog, foreign_key: 'reblog_of_id', inverse_of: :reblogs
-  end
-
-  has_many :favourites, inverse_of: :status, dependent: :destroy
-  has_many :bookmarks, inverse_of: :status, dependent: :destroy
-  has_many :reblogs, foreign_key: 'reblog_of_id', class_name: 'Status', inverse_of: :reblog, dependent: :destroy
-  has_many :reblogged_by_accounts, through: :reblogs, class_name: 'Account', source: :account
-  has_many :replies, foreign_key: 'in_reply_to_id', class_name: 'Status', inverse_of: :thread, dependent: nil
-  has_many :mentions, dependent: :destroy, inverse_of: :status
-  has_many :mentioned_accounts, through: :mentions, source: :account, class_name: 'Account'
-  has_many :media_attachments, dependent: :nullify
-
-  # The `dependent` option is enabled by the initial `mentions` association declaration
-  has_many :active_mentions, -> { active }, class_name: 'Mention', inverse_of: :status # rubocop:disable Rails/HasManyOrHasOneDependent
-
-  # Those associations are used for the private search index
-  has_many :local_mentioned, -> { merge(Account.local) }, through: :active_mentions, source: :account
-  has_many :local_favorited, -> { merge(Account.local) }, through: :favourites, source: :account
-  has_many :local_reblogged, -> { merge(Account.local) }, through: :reblogs, source: :account
-  has_many :local_bookmarked, -> { merge(Account.local) }, through: :bookmarks, source: :account
-
-  has_and_belongs_to_many :tags
-
-  has_one :preview_cards_status, inverse_of: :status, dependent: :delete
-
-  has_one :notification, as: :activity, dependent: :destroy
-  has_one :status_stat, inverse_of: :status, dependent: nil
-  has_one :poll, inverse_of: :status, dependent: :destroy
-  has_one :trend, class_name: 'StatusTrend', inverse_of: :status, dependent: nil
 
   validates :uri, uniqueness: true, presence: true, unless: :local?
   validates :text, presence: true, unless: -> { with_media? || reblog? }


### PR DESCRIPTION
This is the same concept as what already exists for `Account` -- pull out a long list of associations to a concern.

The first commit is a straight copy with no re-org, the next few commits do a bit of cleanup to hopefully improve clarity/readability and sort of group conceptually related associations with each other.
