### PR TITLE
nodeinfo: expose admin contact

### DIFF
--- a/app/serializers/node_info/serializer.rb
+++ b/app/serializers/node_info/serializer.rb
@@ -41,6 +41,13 @@ class NodeInfo::Serializer < ActiveModel::Serializer
     {
       nodeName: Setting.site_title,
       nodeDescription: Setting.site_short_description,
+      nodeAdmins: [
+        {
+          mail: instance_presenter.contact&.email,
+          account: instance_presenter.contact&.account&.username,
+          name: instance_presenter.contact&.account&.acct,
+        },
+      ],
     }
   end
 


### PR DESCRIPTION
with this one dont need to handle mastodon as edgecase

ref: https://codeberg.org/thefederationinfo/nodeinfo-go/src/commit/4bb03bed8c8d88bfae21511267c051e0a5102d6b/extension/mastodon.go#L45