### PR TITLE
Fix FamiliarFollowersController test response comparison

### DIFF
--- a/spec/controllers/api/v1/accounts/familiar_followers_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/familiar_followers_controller_spec.rb
@@ -28,7 +28,7 @@ describe Api::V1::Accounts::FamiliarFollowersController do
         account_ids = [account_a, account_b, account_b, account_a, account_a].map { |a| a.id.to_s }
         get :index, params: { id: account_ids }
 
-        expect(body_as_json.pluck(:id)).to eq [account_a.id.to_s, account_b.id.to_s]
+        expect(body_as_json.pluck(:id)).to contain_exactly(account_a.id.to_s, account_b.id.to_s)
       end
     end
   end


### PR DESCRIPTION
I have experienced a test failure like the following:

    Failure/Error: expect(body_as_json.pluck(:id)).to eq [account_a.id.to_s, account_b.id.to_s]

      expected: ["111493050738338028", "111493050738338029"]
           got: ["111493050738338029", "111493050738338028"]

      (compared using ==)

As far as I can tell the order shouldn't matter in this case.