### PR TITLE
Remove remaining `without_partial_double_verification` usage

### DIFF
--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -40,7 +40,11 @@ describe ApplicationHelper do
       def controller_helpers
         Module.new do
           def body_class_string = 'modal-layout compose-standalone'
-          def current_account = Fabricate(:account)
+
+          def current_account
+            @current_account ||= Fabricate(:account)
+          end
+
           def current_theme = 'default'
         end
       end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -128,9 +128,7 @@ describe ApplicationHelper do
   describe 'available_sign_up_path' do
     context 'when registrations are closed' do
       before do
-        without_partial_double_verification do
-          allow(Setting).to receive(:registrations_mode).and_return('none')
-        end
+        allow(Setting).to receive(:[]).with('registrations_mode').and_return 'none'
       end
 
       it 'redirects to joinmastodon site' do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -29,14 +29,20 @@ describe ApplicationHelper do
 
   describe 'body_classes' do
     context 'with a body class string from a controller' do
-      before do
-        without_partial_double_verification do
-          allow(helper).to receive_messages(body_class_string: 'modal-layout compose-standalone', current_theme: 'default', current_account: Fabricate(:account))
-        end
-      end
+      before { helper.extend controller_helpers }
 
       it 'uses the controller body classes in the result' do
         expect(helper.body_classes).to match(/modal-layout compose-standalone/)
+      end
+
+      private
+
+      def controller_helpers
+        Module.new do
+          def body_class_string = 'modal-layout compose-standalone'
+          def current_account = Fabricate(:account)
+          def current_theme = 'default'
+        end
       end
     end
   end

--- a/spec/helpers/home_helper_spec.rb
+++ b/spec/helpers/home_helper_spec.rb
@@ -23,12 +23,19 @@ RSpec.describe HomeHelper do
     context 'with a valid account' do
       let(:account) { Fabricate(:account) }
 
-      it 'returns a link to the account' do
-        without_partial_double_verification do
-          allow(helper).to receive_messages(current_account: account, prefers_autoplay?: false)
-          result = helper.account_link_to(account)
+      before { helper.extend controller_helpers }
 
-          expect(result).to match "@#{account.acct}"
+      it 'returns a link to the account' do
+        result = helper.account_link_to(account)
+
+        expect(result).to match "@#{account.acct}"
+      end
+
+      private
+
+      def controller_helpers
+        Module.new do
+          def current_account = Account.last
         end
       end
     end

--- a/spec/helpers/media_component_helper_spec.rb
+++ b/spec/helpers/media_component_helper_spec.rb
@@ -3,15 +3,11 @@
 require 'rails_helper'
 
 describe MediaComponentHelper do
+  before { helper.extend controller_helpers }
+
   describe 'render_video_component' do
     let(:media) { Fabricate(:media_attachment, type: :video, status: Fabricate(:status)) }
     let(:result) { helper.render_video_component(media.status) }
-
-    before do
-      without_partial_double_verification do
-        allow(helper).to receive(:current_account).and_return(media.account)
-      end
-    end
 
     it 'renders a react component for the video' do
       expect(parsed_html.div['data-component']).to eq('Video')
@@ -22,12 +18,6 @@ describe MediaComponentHelper do
     let(:media) { Fabricate(:media_attachment, type: :audio, status: Fabricate(:status)) }
     let(:result) { helper.render_audio_component(media.status) }
 
-    before do
-      without_partial_double_verification do
-        allow(helper).to receive(:current_account).and_return(media.account)
-      end
-    end
-
     it 'renders a react component for the audio' do
       expect(parsed_html.div['data-component']).to eq('Audio')
     end
@@ -36,12 +26,6 @@ describe MediaComponentHelper do
   describe 'render_media_gallery_component' do
     let(:media) { Fabricate(:media_attachment, type: :audio, status: Fabricate(:status)) }
     let(:result) { helper.render_media_gallery_component(media.status) }
-
-    before do
-      without_partial_double_verification do
-        allow(helper).to receive(:current_account).and_return(media.account)
-      end
-    end
 
     it 'renders a react component for the media gallery' do
       expect(parsed_html.div['data-component']).to eq('MediaGallery')
@@ -54,10 +38,6 @@ describe MediaComponentHelper do
 
     before do
       PreviewCardsStatus.create(status: status, preview_card: Fabricate(:preview_card))
-
-      without_partial_double_verification do
-        allow(helper).to receive(:current_account).and_return(status.account)
-      end
     end
 
     it 'returns the correct react component markup' do
@@ -69,12 +49,6 @@ describe MediaComponentHelper do
     let(:status) { Fabricate(:status, poll: Fabricate(:poll)) }
     let(:result) { helper.render_poll_component(status) }
 
-    before do
-      without_partial_double_verification do
-        allow(helper).to receive(:current_account).and_return(status.account)
-      end
-    end
-
     it 'returns the correct react component markup' do
       expect(parsed_html.div['data-component']).to eq('Poll')
     end
@@ -84,5 +58,11 @@ describe MediaComponentHelper do
 
   def parsed_html
     Nokogiri::Slop(result)
+  end
+
+  def controller_helpers
+    Module.new do
+      def current_account = Account.last
+    end
   end
 end


### PR DESCRIPTION
We still had a few of these lingering. Basically two styles of change here:

- In helper specs where we are stubbing methods that original in the controller, create a module with the needed methods and mix it into the helper context
- For one `Setting` scenario, stub out the hash key access instead of the method