### PR TITLE
Clean up `two_factor_authentication/confirmations` controller spec

### DIFF
--- a/spec/controllers/settings/two_factor_authentication/confirmations_controller_spec.rb
+++ b/spec/controllers/settings/two_factor_authentication/confirmations_controller_spec.rb
@@ -60,7 +60,7 @@ describe Settings::TwoFactorAuthentication::ConfirmationsController do
 
           it 'renders page with success' do
             prepare_user_otp_generation
-            prepare_user_otp_consumption
+            prepare_user_otp_consumption_response(true)
             allow(controller).to receive(:current_user).and_return(user)
 
             expect do
@@ -74,29 +74,11 @@ describe Settings::TwoFactorAuthentication::ConfirmationsController do
             expect(response).to have_http_status(200)
             expect(response).to render_template('settings/two_factor_authentication/recovery_codes/index')
           end
-
-          def prepare_user_otp_generation
-            allow(user)
-              .to receive(:generate_otp_backup_codes!)
-              .and_return(otp_backup_codes)
-          end
-
-          def prepare_user_otp_consumption
-            options = { otp_secret: 'thisisasecretforthespecofnewview' }
-            allow(user)
-              .to receive(:validate_and_consume_otp!)
-              .with('123456', options)
-              .and_return(true)
-          end
         end
 
         describe 'when creation fails' do
           subject do
-            options = { otp_secret: 'thisisasecretforthespecofnewview' }
-            allow(user)
-              .to receive(:validate_and_consume_otp!)
-              .with('123456', options)
-              .and_return(false)
+            prepare_user_otp_consumption_response(false)
             allow(controller).to receive(:current_user).and_return(user)
 
             expect do
@@ -112,6 +94,22 @@ describe Settings::TwoFactorAuthentication::ConfirmationsController do
           end
 
           include_examples 'renders :new'
+        end
+
+        private
+
+        def prepare_user_otp_generation
+          allow(user)
+            .to receive(:generate_otp_backup_codes!)
+            .and_return(otp_backup_codes)
+        end
+
+        def prepare_user_otp_consumption_response(result)
+          options = { otp_secret: 'thisisasecretforthespecofnewview' }
+          allow(user)
+            .to receive(:validate_and_consume_otp!)
+            .with('123456', options)
+            .and_return(result)
         end
       end
 

--- a/spec/controllers/settings/two_factor_authentication/confirmations_controller_spec.rb
+++ b/spec/controllers/settings/two_factor_authentication/confirmations_controller_spec.rb
@@ -112,13 +112,13 @@ describe Settings::TwoFactorAuthentication::ConfirmationsController do
             .and_return(result)
         end
       end
+    end
+  end
 
-      context 'when not signed in' do
-        it 'redirects if not signed in' do
-          post :create, params: { form_two_factor_confirmation: { otp_attempt: '123456' } }
-          expect(response).to redirect_to('/auth/sign_in')
-        end
-      end
+  context 'when not signed in' do
+    it 'redirects if not signed in' do
+      post :create, params: { form_two_factor_confirmation: { otp_attempt: '123456' } }
+      expect(response).to redirect_to('/auth/sign_in')
     end
   end
 end

--- a/spec/controllers/settings/two_factor_authentication/confirmations_controller_spec.rb
+++ b/spec/controllers/settings/two_factor_authentication/confirmations_controller_spec.rb
@@ -63,11 +63,8 @@ describe Settings::TwoFactorAuthentication::ConfirmationsController do
             prepare_user_otp_consumption_response(true)
             allow(controller).to receive(:current_user).and_return(user)
 
-            expect do
-              post :create,
-                   params: { form_two_factor_confirmation: { otp_attempt: '123456' } },
-                   session: { challenge_passed_at: Time.now.utc, new_otp_secret: 'thisisasecretforthespecofnewview' }
-            end.to change { user.reload.otp_secret }.to 'thisisasecretforthespecofnewview'
+            expect { post_create_with_options }
+              .to change { user.reload.otp_secret }.to 'thisisasecretforthespecofnewview'
 
             expect(assigns(:recovery_codes)).to eq otp_backup_codes
             expect(flash[:notice]).to eq 'Two-factor authentication successfully enabled'
@@ -81,11 +78,8 @@ describe Settings::TwoFactorAuthentication::ConfirmationsController do
             prepare_user_otp_consumption_response(false)
             allow(controller).to receive(:current_user).and_return(user)
 
-            expect do
-              post :create,
-                   params: { form_two_factor_confirmation: { otp_attempt: '123456' } },
-                   session: { challenge_passed_at: Time.now.utc, new_otp_secret: 'thisisasecretforthespecofnewview' }
-            end.to(not_change { user.reload.otp_secret })
+            expect { post_create_with_options }
+              .to(not_change { user.reload.otp_secret })
           end
 
           it 'renders the new view' do
@@ -97,6 +91,12 @@ describe Settings::TwoFactorAuthentication::ConfirmationsController do
         end
 
         private
+
+        def post_create_with_options
+          post :create,
+               params: { form_two_factor_confirmation: { otp_attempt: '123456' } },
+               session: { challenge_passed_at: Time.now.utc, new_otp_secret: 'thisisasecretforthespecofnewview' }
+        end
 
         def prepare_user_otp_generation
           allow(user)


### PR DESCRIPTION
This might requiring stepping commit by commit since the ending diff is a bit messy, but in summary:

- There are two examples for not signed which don't need to flex the values from the surrounding true/false loop, moved them out of the loop
- Moved some examples of "setup" type code to `before` and out of `subject`
- Extracted common stubbing setup to a `prepare_user_otp_consumption_response` method which takes a value to return for the stub it sets up
- Extracted method to make the actual request, since its options are the same for the different stubbed success/failure cases