### PR TITLE
Upgrade the node version in the vagrant file

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
 sudo apt-add-repository 'deb https://dl.yarnpkg.com/debian/ stable main'
 
 # Add repo for NodeJS
-curl -sL https://deb.nodesource.com/setup_16.x | sudo bash -
+curl -sL https://deb.nodesource.com/setup_20.x | sudo bash -
 
 # Add firewall rule to redirect 80 to PORT and save
 sudo iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to-port #{ENV["PORT"]}


### PR DESCRIPTION
I think this was missed during https://github.com/mastodon/mastodon/pull/27073

Currently I am seeing the following when you start up a new VM
```
vagrant@mastodon:/vagrant$ foreman start
22:33:34 web.1     | started with pid 43916
22:33:34 sidekiq.1 | started with pid 43917
22:33:34 stream.1  | started with pid 43918
22:33:34 webpack.1 | started with pid 43919
22:33:34 stream.1  | Usage Error: This tool requires a Node version compatible with >=18.12.0 (got 16.20.2). Upgrade Node, or set `YARN_IGNORE_NODE=1` in your environment.
22:33:34 stream.1  | 
22:33:34 stream.1  | ━━━ Yarn Package Manager - 4.0.2 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
22:33:34 stream.1  | 
22:33:34 stream.1  |   $ yarn <command>
22:33:34 stream.1  | 
22:33:34 stream.1  | You can also print more details about any of these commands by calling them with 
22:33:34 stream.1  | the `-h,--help` flag right after the command name.
22:33:34 web.1     | [43916] Puma starting in cluster mode...
22:33:34 web.1     | [43916] * Puma version: 6.4.0 (ruby 3.2.2-p53) ("The Eagle of Durango")
22:33:34 web.1     | [43916] *  Min threads: 5
22:33:34 web.1     | [43916] *  Max threads: 5
22:33:34 web.1     | [43916] *  Environment: development
22:33:34 web.1     | [43916] *   Master PID: 43916
22:33:34 web.1     | [43916] *      Workers: 2
22:33:34 web.1     | [43916] *     Restarts: (✔) hot (✖) phased
22:33:34 web.1     | [43916] * Preloading application
22:33:35 stream.1  | exited with code 0
22:33:35 system    | sending SIGTERM to all processes
22:33:35 web.1     | [43916] ! Unable to load application: SignalException: SIGTERM
22:33:35 webpack.1 | node:events:491
22:33:35 webpack.1 |       throw er; // Unhandled 'error' event
22:33:35 webpack.1 |       ^
22:33:35 webpack.1 | 
22:33:35 webpack.1 | Error: write EPIPE
22:33:35 webpack.1 |     at afterWriteDispatched (node:internal/stream_base_commons:160:15)
22:33:35 webpack.1 |     at writeGeneric (node:internal/stream_base_commons:151:3)
22:33:35 webpack.1 |     at Socket._writeGeneric (node:net:905:11)
22:33:35 webpack.1 |     at Socket._write (node:net:917:8)
22:33:35 webpack.1 |     at writeOrBuffer (node:internal/streams/writable:391:12)
22:33:35 webpack.1 |     at _write (node:internal/streams/writable:332:10)
22:33:35 webpack.1 |     at Socket.Writable.write (node:internal/streams/writable:336:10)
22:33:35 webpack.1 |     at rPt (/home/vagrant/.cache/node/corepack/yarn/4.0.2/yarn.js:734:9512)
22:33:35 webpack.1 |     at oPt (/home/vagrant/.cache/node/corepack/yarn/4.0.2/yarn.js:734:10919)
22:33:35 webpack.1 |     at sk (/home/vagrant/.cache/node/corepack/yarn/4.0.2/yarn.js:734:11631)
22:33:35 webpack.1 | Emitted 'error' event on Socket instance at:
22:33:35 webpack.1 |     at emitErrorNT (node:internal/streams/destroy:157:8)
22:33:35 webpack.1 |     at emitErrorCloseNT (node:internal/streams/destroy:122:3)
22:33:35 webpack.1 |     at processTicksAndRejections (node:internal/process/task_queues:83:21) {
22:33:35 webpack.1 |   errno: -32,
22:33:35 webpack.1 |   code: 'EPIPE',
22:33:35 webpack.1 |   syscall: 'write'
22:33:35 webpack.1 | }
22:33:35 web.1     | terminated by SIGTERM
22:33:35 sidekiq.1 | terminated by SIGTERM
22:33:35 webpack.1 | terminated by SIGTERM
vagrant@mastodon:/vagrant$ 
```

This goes away with this change.