### PR TITLE
Fix mastodon user not being owner of tmp folder in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -247,7 +247,9 @@ RUN \
 RUN \
 # Pre-create and chown system volume to Mastodon user
   mkdir -p /opt/mastodon/public/system; \
-  chown mastodon:mastodon /opt/mastodon/public/system;
+  chown mastodon:mastodon /opt/mastodon/public/system; \
+# Set Mastodon user as owner of tmp folder
+  chown mastodon:mastodon /opt/mastodon/tmp;
 
 # Set the running user for resulting container
 USER mastodon

--- a/Dockerfile
+++ b/Dockerfile
@@ -249,7 +249,7 @@ RUN \
   mkdir -p /opt/mastodon/public/system; \
   chown mastodon:mastodon /opt/mastodon/public/system; \
 # Set Mastodon user as owner of tmp folder
-  chown mastodon:mastodon /opt/mastodon/tmp;
+  chown -R mastodon:mastodon /opt/mastodon/tmp;
 
 # Set the running user for resulting container
 USER mastodon


### PR DESCRIPTION
Fixes #28134

- Dockerfile rewrite in https://github.com/mastodon/mastodon/pull/26850 removes ownership of the Mastodon source code from the from the running Mastodon user for security.
- The current `docker-compose.yml` which is in use by many, has the system delete the file `rm -f /mastodon/tmp/pids/server.pid` before launching Puma.
- The `server.pid` file doesn't exist, and this command shouldn't be necessary and the `docker-compose.yml` will be modified in a separate PR to change the Puma startup command. However existing deployments will have the older startup command and need to be able to run this command without errors for the container to launch.