### PR TITLE
Change startup command for Puma in Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
     image: ghcr.io/mastodon/mastodon:v4.2.0
     restart: always
     env_file: .env.production
-    command: bash -c "rm -f /mastodon/tmp/pids/server.pid; bundle exec rails s -p 3000"
+    command: bundle exec puma -C config/puma.rb
     networks:
       - external_network
       - internal_network


### PR DESCRIPTION
Related to #28137 and #28134 

- The current `docker-compose.yml` uses a different startup method than both the systemd templates and the project Helm chart for Kubernetes (https://github.com/mastodon/chart/blob/main/templates/deployment-web.yaml)
- This changes Docker Compose to be consistent with those deployment methods.