### PR TITLE
Remove useless `reorder(nil)` call in `tootctl statuses`

### DIFF
--- a/lib/mastodon/cli/statuses.rb
+++ b/lib/mastodon/cli/statuses.rb
@@ -120,12 +120,11 @@ module Mastodon::CLI
 
       say('Beginning removal of now-orphaned media attachments to free up disk space...')
 
-      scope     = MediaAttachment.reorder(nil).unattached.where('created_at < ?', options[:days].pred.days.ago)
       processed = 0
       removed   = 0
-      progress  = create_progress_bar(scope.count)
+      progress  = create_progress_bar(aged_media_attachments.count)
 
-      scope.find_each do |media_attachment|
+      aged_media_attachments.find_each do |media_attachment|
         media_attachment.destroy!
 
         removed += 1
@@ -139,6 +138,10 @@ module Mastodon::CLI
       progress.stop
 
       say("Done after #{Time.now.to_f - start_at}s, removed #{removed} out of #{processed} media_attachments.", :green)
+    end
+
+    def aged_media_attachments
+      MediaAttachment.reorder(nil).unattached.where('created_at < ?', options[:days].pred.days.ago)
     end
 
     def remove_orphans_conversations

--- a/lib/mastodon/cli/statuses.rb
+++ b/lib/mastodon/cli/statuses.rb
@@ -141,7 +141,7 @@ module Mastodon::CLI
     end
 
     def aged_media_attachments
-      MediaAttachment.reorder(nil).unattached.where('created_at < ?', options[:days].pred.days.ago)
+      MediaAttachment.unattached.where('created_at < ?', options[:days].pred.days.ago)
     end
 
     def remove_orphans_conversations

--- a/lib/mastodon/cli/statuses.rb
+++ b/lib/mastodon/cli/statuses.rb
@@ -120,11 +120,12 @@ module Mastodon::CLI
 
       say('Beginning removal of now-orphaned media attachments to free up disk space...')
 
+      scope     = MediaAttachment.unattached.where('created_at < ?', options[:days].pred.days.ago)
       processed = 0
       removed   = 0
-      progress  = create_progress_bar(aged_media_attachments.count)
+      progress  = create_progress_bar(scope.count)
 
-      aged_media_attachments.find_each do |media_attachment|
+      scope.find_each do |media_attachment|
         media_attachment.destroy!
 
         removed += 1
@@ -138,10 +139,6 @@ module Mastodon::CLI
       progress.stop
 
       say("Done after #{Time.now.to_f - start_at}s, removed #{removed} out of #{processed} media_attachments.", :green)
-    end
-
-    def aged_media_attachments
-      MediaAttachment.unattached.where('created_at < ?', options[:days].pred.days.ago)
     end
 
     def remove_orphans_conversations


### PR DESCRIPTION
Adds a well named private method instead of the `scope` local variable, and removes a `reorder` that I must have missed in the recent MediaAttachment default_scope PR.