### PR TITLE
Model concerns organization into module namespaces

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -373,7 +373,7 @@ Style/HashAsLastArrayItem:
     - 'app/controllers/admin/statuses_controller.rb'
     - 'app/controllers/api/v1/statuses_controller.rb'
     - 'app/models/concerns/account/counters.rb'
-    - 'app/models/concerns/status_threading_concern.rb'
+    - 'app/models/concerns/status/threading_concern.rb'
     - 'app/models/status.rb'
     - 'app/services/batched_remove_status_service.rb'
     - 'app/services/notify_service.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -107,7 +107,7 @@ Rails/ApplicationController:
 # Include: app/models/**/*.rb
 Rails/HasAndBelongsToMany:
   Exclude:
-    - 'app/models/concerns/account_associations.rb'
+    - 'app/models/concerns/account/associations.rb'
     - 'app/models/preview_card.rb'
     - 'app/models/status.rb'
     - 'app/models/tag.rb'
@@ -116,7 +116,7 @@ Rails/HasAndBelongsToMany:
 # Include: app/models/**/*.rb
 Rails/HasManyOrHasOneDependent:
   Exclude:
-    - 'app/models/concerns/account_counters.rb'
+    - 'app/models/concerns/account/counters.rb'
     - 'app/models/conversation.rb'
     - 'app/models/custom_emoji.rb'
     - 'app/models/custom_emoji_category.rb'
@@ -172,7 +172,7 @@ Rails/SkipsModelValidations:
   Exclude:
     - 'app/controllers/admin/invites_controller.rb'
     - 'app/controllers/concerns/session_tracking_concern.rb'
-    - 'app/models/concerns/account_merging.rb'
+    - 'app/models/concerns/account/merging.rb'
     - 'app/models/concerns/expireable.rb'
     - 'app/models/status.rb'
     - 'app/models/trends/links.rb'
@@ -252,7 +252,7 @@ Rails/WhereExists:
     - 'app/lib/feed_manager.rb'
     - 'app/lib/status_cache_hydrator.rb'
     - 'app/lib/suspicious_sign_in_detector.rb'
-    - 'app/models/concerns/account_interactions.rb'
+    - 'app/models/concerns/account/interactions.rb'
     - 'app/models/featured_tag.rb'
     - 'app/models/poll.rb'
     - 'app/models/session_activation.rb'
@@ -342,7 +342,7 @@ Style/GuardClause:
     - 'app/lib/request_pool.rb'
     - 'app/lib/webfinger.rb'
     - 'app/lib/webfinger_resource.rb'
-    - 'app/models/concerns/account_counters.rb'
+    - 'app/models/concerns/account/counters.rb'
     - 'app/models/concerns/ldap_authenticable.rb'
     - 'app/models/tag.rb'
     - 'app/models/user.rb'
@@ -372,7 +372,7 @@ Style/HashAsLastArrayItem:
   Exclude:
     - 'app/controllers/admin/statuses_controller.rb'
     - 'app/controllers/api/v1/statuses_controller.rb'
-    - 'app/models/concerns/account_counters.rb'
+    - 'app/models/concerns/account/counters.rb'
     - 'app/models/concerns/status_threading_concern.rb'
     - 'app/models/status.rb'
     - 'app/services/batched_remove_status_service.rb'
@@ -486,7 +486,7 @@ Style/RedundantReturn:
 # AllowedMethods: present?, blank?, presence, try, try!
 Style/SafeNavigation:
   Exclude:
-    - 'app/models/concerns/account_finder_concern.rb'
+    - 'app/models/concerns/account/finder_concern.rb'
 
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -343,7 +343,7 @@ Style/GuardClause:
     - 'app/lib/webfinger.rb'
     - 'app/lib/webfinger_resource.rb'
     - 'app/models/concerns/account/counters.rb'
-    - 'app/models/concerns/ldap_authenticable.rb'
+    - 'app/models/concerns/user/ldap_authenticable.rb'
     - 'app/models/tag.rb'
     - 'app/models/user.rb'
     - 'app/services/fan_out_on_write_service.rb'

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -70,19 +70,20 @@ class Account < ApplicationRecord
   URL_PREFIX_RE = %r{\Ahttp(s?)://[^/]+}
   USERNAME_ONLY_RE = /\A#{USERNAME_RE}\z/i
 
-  include Attachmentable
-  include AccountAssociations
-  include AccountAvatar
-  include AccountFinderConcern
-  include AccountHeader
-  include AccountInteractions
-  include Paginable
-  include AccountCounters
-  include DomainNormalizable
+  include Attachmentable # Load prior to Avatar & Header concerns
+
+  include Account::Associations
+  include Account::Avatar
+  include Account::Counters
+  include Account::FinderConcern
+  include Account::Header
+  include Account::Interactions
+  include Account::Merging
+  include Account::Search
+  include Account::StatusesSearch
   include DomainMaterializable
-  include AccountMerging
-  include AccountSearch
-  include AccountStatusesSearch
+  include DomainNormalizable
+  include Paginable
 
   enum protocol: { ostatus: 0, activitypub: 1 }
   enum suspension_origin: { local: 0, remote: 1 }, _prefix: true

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module AccountAssociations
+module Account::Associations
   extend ActiveSupport::Concern
 
   included do

--- a/app/models/concerns/account/avatar.rb
+++ b/app/models/concerns/account/avatar.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module AccountAvatar
+module Account::Avatar
   extend ActiveSupport::Concern
 
   IMAGE_MIME_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'].freeze

--- a/app/models/concerns/account/counters.rb
+++ b/app/models/concerns/account/counters.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module AccountCounters
+module Account::Counters
   extend ActiveSupport::Concern
 
   ALLOWED_COUNTER_KEYS = %i(statuses_count following_count followers_count).freeze

--- a/app/models/concerns/account/finder_concern.rb
+++ b/app/models/concerns/account/finder_concern.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module AccountFinderConcern
+module Account::FinderConcern
   extend ActiveSupport::Concern
 
   class_methods do

--- a/app/models/concerns/account/header.rb
+++ b/app/models/concerns/account/header.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module AccountHeader
+module Account::Header
   extend ActiveSupport::Concern
 
   IMAGE_MIME_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'].freeze

--- a/app/models/concerns/account/interactions.rb
+++ b/app/models/concerns/account/interactions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module AccountInteractions
+module Account::Interactions
   extend ActiveSupport::Concern
 
   class_methods do

--- a/app/models/concerns/account/merging.rb
+++ b/app/models/concerns/account/merging.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module AccountMerging
+module Account::Merging
   extend ActiveSupport::Concern
 
   def merge_with!(other_account)

--- a/app/models/concerns/account/search.rb
+++ b/app/models/concerns/account/search.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module AccountSearch
+module Account::Search
   extend ActiveSupport::Concern
 
   DISALLOWED_TSQUERY_CHARACTERS = /['?\\:‘’]/

--- a/app/models/concerns/account/statuses_search.rb
+++ b/app/models/concerns/account/statuses_search.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module AccountStatusesSearch
+module Account::StatusesSearch
   extend ActiveSupport::Concern
 
   included do

--- a/app/models/concerns/status/safe_reblog_insert.rb
+++ b/app/models/concerns/status/safe_reblog_insert.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module StatusSafeReblogInsert
+module Status::SafeReblogInsert
   extend ActiveSupport::Concern
 
   class_methods do

--- a/app/models/concerns/status/search_concern.rb
+++ b/app/models/concerns/status/search_concern.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module StatusSearchConcern
+module Status::SearchConcern
   extend ActiveSupport::Concern
 
   included do

--- a/app/models/concerns/status/snapshot_concern.rb
+++ b/app/models/concerns/status/snapshot_concern.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module StatusSnapshotConcern
+module Status::SnapshotConcern
   extend ActiveSupport::Concern
 
   included do

--- a/app/models/concerns/status/threading_concern.rb
+++ b/app/models/concerns/status/threading_concern.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module StatusThreadingConcern
+module Status::ThreadingConcern
   extend ActiveSupport::Concern
 
   def ancestors(limit, account = nil)

--- a/app/models/concerns/user/has_settings.rb
+++ b/app/models/concerns/user/has_settings.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module HasUserSettings
+module User::HasSettings
   extend ActiveSupport::Concern
 
   included do

--- a/app/models/concerns/user/ldap_authenticable.rb
+++ b/app/models/concerns/user/ldap_authenticable.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module LdapAuthenticable
+module User::LdapAuthenticable
   extend ActiveSupport::Concern
 
   class_methods do

--- a/app/models/concerns/user/omniauthable.rb
+++ b/app/models/concerns/user/omniauthable.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Omniauthable
+module User::Omniauthable
   extend ActiveSupport::Concern
 
   TEMP_EMAIL_PREFIX = 'change@me'

--- a/app/models/concerns/user/pam_authenticable.rb
+++ b/app/models/concerns/user/pam_authenticable.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module PamAuthenticable
+module User::PamAuthenticable
   extend ActiveSupport::Concern
 
   included do

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -30,14 +30,14 @@
 #
 
 class Status < ApplicationRecord
+  include Cacheable
   include Discard::Model
   include Paginable
-  include Cacheable
-  include StatusThreadingConcern
-  include StatusSnapshotConcern
   include RateLimitable
-  include StatusSafeReblogInsert
-  include StatusSearchConcern
+  include Status::SafeReblogInsert
+  include Status::SearchConcern
+  include Status::SnapshotConcern
+  include Status::ThreadingConcern
 
   rate_limit by: :account, family: :statuses
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -53,9 +53,12 @@ class User < ApplicationRecord
     filtered_languages
   )
 
-  include Redisable
   include LanguagesHelper
-  include HasUserSettings
+  include Redisable
+  include User::HasSettings
+  include User::LdapAuthenticable
+  include User::Omniauthable
+  include User::PamAuthenticable
 
   # The home and list feeds will be stored in Redis for this amount
   # of time, and status fan-out to followers will include only people
@@ -74,10 +77,6 @@ class User < ApplicationRecord
 
   devise :registerable, :recoverable, :validatable,
          :confirmable
-
-  include Omniauthable
-  include PamAuthenticable
-  include LdapAuthenticable
 
   belongs_to :account, inverse_of: :user
   belongs_to :invite, counter_cache: :uses, optional: true

--- a/app/views/settings/profiles/show.html.haml
+++ b/app/views/settings/profiles/show.html.haml
@@ -33,7 +33,7 @@
   .fields-row
     .fields-row__column.fields-row__column-6
       .fields-group
-        = f.input :avatar, wrapper: :with_block_label, input_html: { accept: AccountAvatar::IMAGE_MIME_TYPES.join(',') }, hint: t('simple_form.hints.defaults.avatar', dimensions: '400x400', size: number_to_human_size(AccountAvatar::LIMIT))
+        = f.input :avatar, wrapper: :with_block_label, input_html: { accept: Account::Avatar::IMAGE_MIME_TYPES.join(',') }, hint: t('simple_form.hints.defaults.avatar', dimensions: '400x400', size: number_to_human_size(Account::Avatar::LIMIT))
 
     .fields-row__column.fields-row__column-6
       .fields-group
@@ -46,7 +46,7 @@
   .fields-row
     .fields-row__column.fields-row__column-6
       .fields-group
-        = f.input :header, wrapper: :with_block_label, input_html: { accept: AccountHeader::IMAGE_MIME_TYPES.join(',') }, hint: t('simple_form.hints.defaults.header', dimensions: '1500x500', size: number_to_human_size(AccountHeader::LIMIT))
+        = f.input :header, wrapper: :with_block_label, input_html: { accept: Account::Header::IMAGE_MIME_TYPES.join(',') }, hint: t('simple_form.hints.defaults.header', dimensions: '1500x500', size: number_to_human_size(Account::Header::LIMIT))
 
     .fields-row__column.fields-row__column-6
       .fields-group

--- a/lib/mastodon/cli/maintenance.rb
+++ b/lib/mastodon/cli/maintenance.rb
@@ -67,8 +67,8 @@ module Mastodon::CLI
         local? ? username : "#{username}@#{domain}"
       end
 
-      # This is a duplicate of the AccountMerging concern because we need it to
-      # be independent from code version.
+      # This is a duplicate of the Account::Merging concern because we need it
+      # to be independent from code version.
       def merge_with!(other_account)
         # Since it's the same remote resource, the remote resource likely
         # already believes we are following/blocking, so it's safe to

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -451,7 +451,7 @@ RSpec.describe Account do
     end
 
     it 'limits via constant by default' do
-      stub_const('AccountSearch::DEFAULT_LIMIT', 1)
+      stub_const('Account::Search::DEFAULT_LIMIT', 1)
       2.times.each { Fabricate(:account, display_name: 'Display Name') }
       results = described_class.search_for('display')
       expect(results.size).to eq 1
@@ -595,7 +595,7 @@ RSpec.describe Account do
     end
 
     it 'limits by 10 by default' do
-      stub_const('AccountSearch::DEFAULT_LIMIT', 1)
+      stub_const('Account::Search::DEFAULT_LIMIT', 1)
       2.times { Fabricate(:account, display_name: 'Display Name') }
       results = described_class.advanced_search_for('display', account)
       expect(results.size).to eq 1

--- a/spec/models/concerns/account/counters_spec.rb
+++ b/spec/models/concerns/account/counters_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe AccountCounters do
+describe Account::Counters do
   let!(:account) { Fabricate(:account) }
 
   describe '#increment_count!' do

--- a/spec/models/concerns/account/finder_concern_spec.rb
+++ b/spec/models/concerns/account/finder_concern_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe AccountFinderConcern do
+describe Account::FinderConcern do
   describe 'local finders' do
     let!(:account) { Fabricate(:account, username: 'Alice') }
 

--- a/spec/models/concerns/account/interactions_spec.rb
+++ b/spec/models/concerns/account/interactions_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe AccountInteractions do
+describe Account::Interactions do
   let(:account)            { Fabricate(:account, username: 'account') }
   let(:account_id)         { account.id }
   let(:account_ids)        { [account_id] }

--- a/spec/models/concerns/account/statuses_search_spec.rb
+++ b/spec/models/concerns/account/statuses_search_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe AccountStatusesSearch do
+describe Account::StatusesSearch do
   let(:account) { Fabricate(:account, indexable: indexable) }
 
   before do

--- a/spec/models/concerns/status/threading_concern_spec.rb
+++ b/spec/models/concerns/status/threading_concern_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe StatusThreadingConcern do
+describe Status::ThreadingConcern do
   describe '#ancestors' do
     let!(:alice)  { Fabricate(:account, username: 'alice') }
     let!(:bob)    { Fabricate(:account, username: 'bob', domain: 'example.com') }

--- a/spec/search/models/concerns/account/search_spec.rb
+++ b/spec/search/models/concerns/account/search_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe AccountSearch do
+describe Account::Search do
   describe 'a non-discoverable account becoming discoverable' do
     let(:account) { Account.find_by(username: 'search_test_account_1') }
 

--- a/spec/search/models/concerns/account/statuses_search_spec.rb
+++ b/spec/search/models/concerns/account/statuses_search_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe AccountStatusesSearch do
+describe Account::StatusesSearch do
   describe 'a non-indexable account becoming indexable' do
     let(:account) { Account.find_by(username: 'search_test_account_1') }
 


### PR DESCRIPTION
As the [prophecy foretold](https://github.com/mastodon/mastodon/pull/27846#issue-1991494130), this PR follows up on the one which moved a bunch of controller concerns into namespaced modules, and does the same thing for the model concerns.

I only moved concerns when the model using them was the only model using them, and only for models which had at least two concerns like that. This turned out to be User, Status, Account. Looks like the diff picked basically everything up as file moves, so should be easy to see the few things which did change beyond moving files.

