### PR TITLE
Use enum-generated `public_visibility` scope on Status

### DIFF
--- a/app/models/concerns/account/statuses_search.rb
+++ b/app/models/concerns/account/statuses_search.rb
@@ -31,7 +31,7 @@ module Account::StatusesSearch
   def add_to_public_statuses_index!
     return unless Chewy.enabled?
 
-    statuses.without_reblogs.where(visibility: :public).reorder(nil).find_in_batches do |batch|
+    statuses.without_reblogs.public_visibility.reorder(nil).find_in_batches do |batch|
       PublicStatusesIndex.import(batch)
     end
   end

--- a/app/models/concerns/status/search_concern.rb
+++ b/app/models/concerns/status/search_concern.rb
@@ -4,7 +4,7 @@ module Status::SearchConcern
   extend ActiveSupport::Concern
 
   included do
-    scope :indexable, -> { without_reblogs.where(visibility: :public).joins(:account).where(account: { indexable: true }) }
+    scope :indexable, -> { without_reblogs.public_visibility.joins(:account).where(account: { indexable: true }) }
   end
 
   def searchable_by

--- a/app/models/public_feed.rb
+++ b/app/models/public_feed.rb
@@ -61,7 +61,7 @@ class PublicFeed
   end
 
   def public_scope
-    Status.with_public_visibility.joins(:account).merge(Account.without_suspended.without_silenced)
+    Status.public_visibility.joins(:account).merge(Account.without_suspended.without_silenced)
   end
 
   def local_only_scope

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -108,7 +108,6 @@ class Status < ApplicationRecord
   scope :with_accounts, ->(ids) { where(id: ids).includes(:account) }
   scope :without_replies, -> { where('statuses.reply = FALSE OR statuses.in_reply_to_account_id = statuses.account_id') }
   scope :without_reblogs, -> { where(statuses: { reblog_of_id: nil }) }
-  scope :with_public_visibility, -> { where(visibility: :public) }
   scope :tagged_with, ->(tag_ids) { joins(:statuses_tags).where(statuses_tags: { tag_id: tag_ids }) }
   scope :not_excluded_by_account, ->(account) { where.not(account_id: account.excluded_from_timeline_account_ids) }
   scope :not_domain_blocked_by_account, ->(account) { account.excluded_from_timeline_domains.blank? ? left_outer_joins(:account) : left_outer_joins(:account).where('accounts.domain IS NULL OR accounts.domain NOT IN (?)', account.excluded_from_timeline_domains) }

--- a/spec/search/models/concerns/account/statuses_search_spec.rb
+++ b/spec/search/models/concerns/account/statuses_search_spec.rb
@@ -21,7 +21,7 @@ describe Account::StatusesSearch, :sidekiq_inline do
         account.indexable = true
         account.save!
 
-        expect(PublicStatusesIndex.filter(term: { account_id: account.id }).count).to eq(account.statuses.where(visibility: :public).count)
+        expect(PublicStatusesIndex.filter(term: { account_id: account.id }).count).to eq(account.statuses.public_visibility.count)
         expect(StatusesIndex.filter(term: { account_id: account.id }).count).to eq(account.statuses.count)
       end
     end
@@ -32,7 +32,7 @@ describe Account::StatusesSearch, :sidekiq_inline do
 
     context 'when picking an indexable account' do
       it 'has statuses in the PublicStatusesIndex' do
-        expect(PublicStatusesIndex.filter(term: { account_id: account.id }).count).to eq(account.statuses.where(visibility: :public).count)
+        expect(PublicStatusesIndex.filter(term: { account_id: account.id }).count).to eq(account.statuses.public_visibility.count)
       end
 
       it 'has statuses in the StatusesIndex' do


### PR DESCRIPTION
We had a custom scope repeating what the generated one already does, and a few spots that could have used it but were not.