### PR TITLE
Use `Account.activitypub` generated scope

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -441,7 +441,7 @@ class Account < ApplicationRecord
     end
 
     def inboxes
-      urls = reorder(nil).where(protocol: :activitypub).group(:preferred_inbox_url).pluck(Arel.sql("coalesce(nullif(accounts.shared_inbox_url, ''), accounts.inbox_url) AS preferred_inbox_url"))
+      urls = reorder(nil).activitypub.group(:preferred_inbox_url).pluck(Arel.sql("coalesce(nullif(accounts.shared_inbox_url, ''), accounts.inbox_url) AS preferred_inbox_url"))
       DeliveryFailureTracker.without_unavailable(urls)
     end
 

--- a/lib/mastodon/cli/accounts.rb
+++ b/lib/mastodon/cli/accounts.rb
@@ -295,7 +295,7 @@ module Mastodon::CLI
       skip_threshold = 7.days.ago
       skip_domains   = Concurrent::Set.new
 
-      query = Account.remote.where(protocol: :activitypub)
+      query = Account.remote.activitypub
       query = query.where(domain: domains) unless domains.empty?
 
       processed, culled = parallelize_with_progress(query.partitioned) do |account|


### PR DESCRIPTION
I think using this scope is a net-win here, but readability-wise I really prefer using the `_prefix` or `_suffix` options with these enums. I can update this to use that style instead if that's ok. (I personally like the prefix style better (ie `protocol_activitypub` in this scenario), but I think either of them is better than nothing).