### PR TITLE
Eliminate double subject call in admin/ controller specs

### DIFF
--- a/spec/controllers/admin/account_moderation_notes_controller_spec.rb
+++ b/spec/controllers/admin/account_moderation_notes_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Admin::AccountModerationNotesController do
 
       it 'successfully creates a note' do
         expect { subject }.to change(AccountModerationNote, :count).by(1)
-        expect(subject).to redirect_to admin_account_path(target_account.id)
+        expect(response).to redirect_to admin_account_path(target_account.id)
       end
     end
 
@@ -29,7 +29,7 @@ RSpec.describe Admin::AccountModerationNotesController do
 
       it 'falls to create a note' do
         expect { subject }.to_not change(AccountModerationNote, :count)
-        expect(subject).to render_template 'admin/accounts/show'
+        expect(response).to render_template 'admin/accounts/show'
       end
     end
   end
@@ -42,7 +42,7 @@ RSpec.describe Admin::AccountModerationNotesController do
 
     it 'destroys note' do
       expect { subject }.to change(AccountModerationNote, :count).by(-1)
-      expect(subject).to redirect_to admin_account_path(target_account.id)
+      expect(response).to redirect_to admin_account_path(target_account.id)
     end
   end
 end

--- a/spec/controllers/admin/custom_emojis_controller_spec.rb
+++ b/spec/controllers/admin/custom_emojis_controller_spec.rb
@@ -12,24 +12,24 @@ describe Admin::CustomEmojisController do
   end
 
   describe 'GET #index' do
-    subject { get :index }
-
     before do
       Fabricate(:custom_emoji)
     end
 
     it 'renders index page' do
-      expect(subject).to have_http_status 200
-      expect(subject).to render_template :index
+      get :index
+
+      expect(response).to have_http_status 200
+      expect(response).to render_template :index
     end
   end
 
   describe 'GET #new' do
-    subject { get :new }
-
     it 'renders new page' do
-      expect(subject).to have_http_status 200
-      expect(subject).to render_template :new
+      get :new
+
+      expect(response).to have_http_status 200
+      expect(response).to render_template :new
     end
   end
 

--- a/spec/controllers/admin/report_notes_controller_spec.rb
+++ b/spec/controllers/admin/report_notes_controller_spec.rb
@@ -27,7 +27,7 @@ describe Admin::ReportNotesController do
           it 'creates a report note and resolves report' do
             expect { subject }.to change(ReportNote, :count).by(1)
             expect(report.reload).to be_action_taken
-            expect(subject).to redirect_to admin_reports_path
+            expect(response).to redirect_to admin_reports_path
           end
         end
 
@@ -37,7 +37,7 @@ describe Admin::ReportNotesController do
           it 'creates a report note and does not resolve report' do
             expect { subject }.to change(ReportNote, :count).by(1)
             expect(report.reload).to_not be_action_taken
-            expect(subject).to redirect_to admin_report_path(report)
+            expect(response).to redirect_to admin_report_path(report)
           end
         end
       end
@@ -52,7 +52,7 @@ describe Admin::ReportNotesController do
           it 'creates a report note and unresolves report' do
             expect { subject }.to change(ReportNote, :count).by(1)
             expect(report.reload).to_not be_action_taken
-            expect(subject).to redirect_to admin_report_path(report)
+            expect(response).to redirect_to admin_report_path(report)
           end
         end
 
@@ -62,7 +62,7 @@ describe Admin::ReportNotesController do
           it 'creates a report note and does not unresolve report' do
             expect { subject }.to change(ReportNote, :count).by(1)
             expect(report.reload).to be_action_taken
-            expect(subject).to redirect_to admin_report_path(report)
+            expect(response).to redirect_to admin_report_path(report)
           end
         end
       end
@@ -86,7 +86,7 @@ describe Admin::ReportNotesController do
 
     it 'deletes note' do
       expect { subject }.to change(ReportNote, :count).by(-1)
-      expect(subject).to redirect_to admin_report_path(report_note.report)
+      expect(response).to redirect_to admin_report_path(report_note.report)
     end
   end
 end


### PR DESCRIPTION
Extracted from https://github.com/mastodon/mastodon/pull/27896 which got a bit sidetracked with style-only changes. This attempts to pull out some of the double-subject-calling fixes from that larger PR. Hopefully easier to review.