### PR TITLE
Show language name of statuses

### DIFF
--- a/app/javascript/mastodon/components/status.jsx
+++ b/app/javascript/mastodon/components/status.jsx
@@ -371,6 +371,7 @@ class Status extends ImmutablePureComponent {
     };
 
     let media, statusAvatar, prepend, rebloggedByText;
+    let localisedLanguageName;
 
     if (hidden) {
       return (
@@ -541,6 +542,24 @@ class Status extends ImmutablePureComponent {
 
     const {statusContentProps, hashtagBar} = getHashtagBarForStatus(status);
     const expanded = !status.get('hidden') || status.get('spoiler_text').length === 0;
+    const language = status.get('language');
+    if (language !== undefined && language !== null && Intl !== undefined) {
+      try {
+        localisedLanguageName = (
+          <span className='status__language-code' aria-hidden='true'>
+            {new Intl.DisplayNames([intl.locale], { type: 'language' }).of(language)}
+          </span>
+        );
+      } catch {
+        localisedLanguageName = (
+          <span className='status__language-code' aria-hidden='true'>
+            {language}
+          </span>
+        );
+      }
+    } else {
+      localisedLanguageName = null;
+    }
 
     return (
       <HotKeys handlers={handlers}>
@@ -555,6 +574,7 @@ class Status extends ImmutablePureComponent {
               <a href={`/@${status.getIn(['account', 'acct'])}/${status.get('id')}`} className='status__relative-time' target='_blank' rel='noopener noreferrer'>
                 <span className='status__visibility-icon'><VisibilityIcon visibility={status.get('visibility')} /></span>
                 <RelativeTimestamp timestamp={status.get('created_at')} />{status.get('edited_at') && <abbr title={intl.formatMessage(messages.edited, { date: intl.formatDate(status.get('edited_at'), { hour12: false, year: 'numeric', month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit' }) })}> *</abbr>}
+                {localisedLanguageName}
               </a>
 
               <a onClick={this.handleAccountClick} href={`/@${status.getIn(['account', 'acct'])}`} title={status.getIn(['account', 'acct'])} className='status__display-name' target='_blank' rel='noopener noreferrer'>

--- a/app/javascript/mastodon/features/status/components/detailed_status.jsx
+++ b/app/javascript/mastodon/features/status/components/detailed_status.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 
-import { FormattedDate, FormattedMessage } from 'react-intl';
+import { injectIntl, FormattedDate, FormattedMessage } from 'react-intl';
 
 import classNames from 'classnames';
 import { Link, withRouter } from 'react-router-dom';
@@ -33,6 +33,7 @@ import Card from './card';
 class DetailedStatus extends ImmutablePureComponent {
 
   static propTypes = {
+    intl: PropTypes.object.isRequired,
     status: ImmutablePropTypes.map,
     onOpenMedia: PropTypes.func.isRequired,
     onOpenVideo: PropTypes.func.isRequired,
@@ -135,7 +136,7 @@ class DetailedStatus extends ImmutablePureComponent {
   render () {
     const status = this._properStatus();
     const outerStyle = { boxSizing: 'border-box' };
-    const { compact, pictureInPicture } = this.props;
+    const { intl, compact, pictureInPicture } = this.props;
 
     if (!status) {
       return null;
@@ -342,4 +343,4 @@ class DetailedStatus extends ImmutablePureComponent {
 
 }
 
-export default withRouter(DetailedStatus);
+export default withRouter(injectIntl(DetailedStatus));

--- a/app/javascript/mastodon/features/status/components/detailed_status.jsx
+++ b/app/javascript/mastodon/features/status/components/detailed_status.jsx
@@ -148,6 +148,7 @@ class DetailedStatus extends ImmutablePureComponent {
     const reblogIconComponent = RepeatIcon;
     let favouriteLink = '';
     let edited = '';
+    let localisedLanguageName = '';
 
     if (this.props.measureHeight) {
       outerStyle.height = `${this.state.height}px`;
@@ -281,6 +282,25 @@ class DetailedStatus extends ImmutablePureComponent {
       );
     }
 
+    const originalLanguage = status.get('language');
+    if (language !== undefined && originalLanguage !== null && Intl) {
+      try {
+        localisedLanguageName = (
+          <>
+            {' · '}
+            <>{new Intl.DisplayNames([intl.locale], { type: 'language' }).of(originalLanguage)}</>
+          </>
+        );
+      } catch {
+        localisedLanguageName = (
+          <>
+            {' · '}
+            {originalLanguage}
+          </>
+        );
+      }
+    }
+
     const {statusContentProps, hashtagBar} = getHashtagBarForStatus(status);
     const expanded = !status.get('hidden') || status.get('spoiler_text').length === 0;
 
@@ -313,7 +333,7 @@ class DetailedStatus extends ImmutablePureComponent {
           <div className='detailed-status__meta'>
             <a className='detailed-status__datetime' href={`/@${status.getIn(['account', 'acct'])}/${status.get('id')}`} target='_blank' rel='noopener noreferrer'>
               <FormattedDate value={new Date(status.get('created_at'))} hour12={false} year='numeric' month='short' day='2-digit' hour='2-digit' minute='2-digit' />
-            </a>{edited}{visibilityLink}{applicationLink}{reblogLink} · {favouriteLink}
+            </a>{edited}{visibilityLink}{localisedLanguageName}{applicationLink}{reblogLink} · {favouriteLink}
           </div>
         </div>
       </div>

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1199,6 +1199,15 @@ body > [data-popper-placement] {
   order: 2;
   flex: 0 0 auto;
   color: $dark-text-color;
+  text-align: end;
+
+  &:hover > :not(span) {
+    text-decoration: underline;
+  }
+
+  .status__language-code {
+    display: block;
+  }
 }
 
 .notification__relative_time {
@@ -1868,7 +1877,6 @@ a.account__display-name {
   font-weight: 500;
 }
 
-.status__relative-time,
 .detailed-status__datetime {
   &:hover {
     text-decoration: underline;


### PR DESCRIPTION
I am refining the patch I applied to my own instance and submitting it as a Pull Request.

The writing language of each post is displayed in UI language below the writing time.

This PR resolves #28054.

![스크린샷 2023-12-01 09 47 54](https://github.com/mastodon/mastodon/assets/2531397/3a11f78e-87ef-49e8-9287-b2c52a2c87cc)
