### PR TITLE
Fix exclusive lists interfering with notifications

### DIFF
--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -32,12 +32,12 @@ class FeedManager
     "feed:#{type}:#{id}:#{subtype}"
   end
 
-  # Check if the status should not be added to a feed
+  # The filter result of the status to a particular feed
   # @param [Symbol] timeline_type
   # @param [Status] status
   # @param [Account|List] receiver
   # @return [void|Symbol] nil, :filter, or :skip_home
-  def filter?(timeline_type, status, receiver)
+  def filter(timeline_type, status, receiver)
     case timeline_type
     when :home
       filter_from_home(status, receiver.id, build_crutches(receiver.id, [status]), :home)
@@ -48,6 +48,15 @@ class FeedManager
     when :tags
       filter_from_tags?(status, receiver.id, build_crutches(receiver.id, [status])) ? :filter : nil
     end
+  end
+
+  # Check if the status should not be added to a feed
+  # @param [Symbol] timeline_type
+  # @param [Status] status
+  # @param [Account|List] receiver
+  # @return [Boolean]
+  def filter?(timeline_type, status, receiver)
+    !!filter(timeline_type, status, receiver)
   end
 
   # Add a status to a home feed and send a streaming API update

--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -36,19 +36,17 @@ class FeedManager
   # @param [Symbol] timeline_type
   # @param [Status] status
   # @param [Account|List] receiver
-  # @return [Boolean]
+  # @return [void|Symbol] nil, :filter, or :skip_home
   def filter?(timeline_type, status, receiver)
     case timeline_type
     when :home
-      filter_from_home?(status, receiver.id, build_crutches(receiver.id, [status]), :home)
+      filter_from_home(status, receiver.id, build_crutches(receiver.id, [status]), :home)
     when :list
-      filter_from_list?(status, receiver) || filter_from_home?(status, receiver.account_id, build_crutches(receiver.account_id, [status]), :list)
+      (filter_from_list?(status, receiver) ? :filter : nil) || filter_from_home(status, receiver.account_id, build_crutches(receiver.account_id, [status]), :list)
     when :mentions
-      filter_from_mentions?(status, receiver.id)
+      filter_from_mentions?(status, receiver.id) ? :filter : nil
     when :tags
-      filter_from_tags?(status, receiver.id, build_crutches(receiver.id, [status]))
-    else
-      false
+      filter_from_tags?(status, receiver.id, build_crutches(receiver.id, [status])) ? :filter : nil
     end
   end
 
@@ -120,7 +118,7 @@ class FeedManager
     crutches = build_crutches(into_account.id, statuses)
 
     statuses.each do |status|
-      next if filter_from_home?(status, into_account.id, crutches)
+      next if filter_from_home(status, into_account.id, crutches)
 
       add_to_feed(:home, into_account.id, status, aggregate_reblogs: aggregate)
     end
@@ -146,7 +144,7 @@ class FeedManager
     crutches = build_crutches(list.account_id, statuses)
 
     statuses.each do |status|
-      next if filter_from_home?(status, list.account_id, crutches) || filter_from_list?(status, list)
+      next if filter_from_home(status, list.account_id, crutches) || filter_from_list?(status, list)
 
       add_to_feed(:list, list.id, status, aggregate_reblogs: aggregate)
     end
@@ -278,7 +276,7 @@ class FeedManager
       crutches = build_crutches(account.id, statuses)
 
       statuses.each do |status|
-        next if filter_from_home?(status, account.id, crutches)
+        next if filter_from_home(status, account.id, crutches)
 
         add_to_feed(:home, account.id, status, aggregate_reblogs: aggregate)
       end
@@ -371,12 +369,12 @@ class FeedManager
   # @param [Status] status
   # @param [Integer] receiver_id
   # @param [Hash] crutches
-  # @return [Boolean]
-  def filter_from_home?(status, receiver_id, crutches, timeline_type = :home)
-    return false if receiver_id == status.account_id
-    return true  if status.reply? && (status.in_reply_to_id.nil? || status.in_reply_to_account_id.nil?)
-    return true if timeline_type != :list && crutches[:exclusive_list_users][status.account_id].present?
-    return true if crutches[:languages][status.account_id].present? && status.language.present? && !crutches[:languages][status.account_id].include?(status.language)
+  # @return [void|Symbol] nil, :skip_home, or :filter
+  def filter_from_home(status, receiver_id, crutches, timeline_type = :home)
+    return            if receiver_id == status.account_id
+    return :filter    if status.reply? && (status.in_reply_to_id.nil? || status.in_reply_to_account_id.nil?)
+    return :skip_home if timeline_type != :list && crutches[:exclusive_list_users][status.account_id].present?
+    return :filter    if crutches[:languages][status.account_id].present? && status.language.present? && !crutches[:languages][status.account_id].include?(status.language)
 
     check_for_blocks = crutches[:active_mentions][status.id] || []
     check_for_blocks.push(status.account_id)
@@ -386,24 +384,22 @@ class FeedManager
       check_for_blocks.concat(crutches[:active_mentions][status.reblog_of_id] || [])
     end
 
-    return true if check_for_blocks.any? { |target_account_id| crutches[:blocking][target_account_id] || crutches[:muting][target_account_id] }
-    return true if crutches[:blocked_by][status.account_id]
+    return :filter if check_for_blocks.any? { |target_account_id| crutches[:blocking][target_account_id] || crutches[:muting][target_account_id] }
+    return :filter if crutches[:blocked_by][status.account_id]
 
     if status.reply? && !status.in_reply_to_account_id.nil?                                                                      # Filter out if it's a reply
       should_filter   = !crutches[:following][status.in_reply_to_account_id]                                                     # and I'm not following the person it's a reply to
       should_filter &&= receiver_id != status.in_reply_to_account_id                                                             # and it's not a reply to me
       should_filter &&= status.account_id != status.in_reply_to_account_id                                                       # and it's not a self-reply
-
-      return !!should_filter
     elsif status.reblog?                                                                                                         # Filter out a reblog
       should_filter   = crutches[:hiding_reblogs][status.account_id]                                                             # if the reblogger's reblogs are suppressed
       should_filter ||= crutches[:blocked_by][status.reblog.account_id]                                                          # or if the author of the reblogged status is blocking me
       should_filter ||= crutches[:domain_blocking][status.reblog.account.domain]                                                 # or the author's domain is blocked
-
-      return !!should_filter
+    else
+      should_filter = false
     end
 
-    false
+    should_filter ? :filter : nil
   end
 
   # Check if status should not be added to the mentions feed

--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -126,7 +126,7 @@ class NotifyService < BaseService
     private
 
     def blocked_mention?
-      !!FeedManager.instance.filter?(:mentions, @notification.target_status, @recipient)
+      FeedManager.instance.filter?(:mentions, @notification.target_status, @recipient)
     end
 
     def message?

--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -126,7 +126,7 @@ class NotifyService < BaseService
     private
 
     def blocked_mention?
-      FeedManager.instance.filter?(:mentions, @notification.target_status, @recipient)
+      !!FeedManager.instance.filter?(:mentions, @notification.target_status, @recipient)
     end
 
     def message?

--- a/app/workers/feed_insert_worker.rb
+++ b/app/workers/feed_insert_worker.rb
@@ -29,7 +29,7 @@ class FeedInsertWorker
   private
 
   def check_and_insert
-    filter_result = feed_filtered?
+    filter_result = feed_filter
 
     if filter_result
       perform_unpush if update?
@@ -40,14 +40,14 @@ class FeedInsertWorker
     perform_notify if notify?(filter_result)
   end
 
-  def feed_filtered?
+  def feed_filter
     case @type
     when :home
-      FeedManager.instance.filter?(:home, @status, @follower)
+      FeedManager.instance.filter(:home, @status, @follower)
     when :tags
-      FeedManager.instance.filter?(:tags, @status, @follower)
+      FeedManager.instance.filter(:tags, @status, @follower)
     when :list
-      FeedManager.instance.filter?(:list, @status, @list)
+      FeedManager.instance.filter(:list, @status, @list)
     end
   end
 

--- a/spec/lib/feed_manager_spec.rb
+++ b/spec/lib/feed_manager_spec.rb
@@ -31,194 +31,194 @@ RSpec.describe FeedManager do
     let(:list) { Fabricate(:list, account: alice) }
 
     context 'with home feed' do
-      it 'returns false for followee\'s status' do
+      it 'returns nil for followee\'s status' do
         status = Fabricate(:status, text: 'Hello world', account: alice)
         bob.follow!(alice)
-        expect(subject.filter?(:home, status, bob)).to be false
+        expect(subject.filter?(:home, status, bob)).to be_nil
       end
 
-      it 'returns false for reblog by followee' do
+      it 'returns nil for reblog by followee' do
         status = Fabricate(:status, text: 'Hello world', account: jeff)
         reblog = Fabricate(:status, reblog: status, account: alice)
         bob.follow!(alice)
-        expect(subject.filter?(:home, reblog, bob)).to be false
+        expect(subject.filter?(:home, reblog, bob)).to be_nil
       end
 
-      it 'returns true for post from account who blocked me' do
+      it 'returns :filter for post from account who blocked me' do
         status = Fabricate(:status, text: 'Hello, World', account: alice)
         alice.block!(bob)
-        expect(subject.filter?(:home, status, bob)).to be true
+        expect(subject.filter?(:home, status, bob)).to be :filter
       end
 
-      it 'returns true for post from blocked account' do
+      it 'returns :filter for post from blocked account' do
         status = Fabricate(:status, text: 'Hello, World', account: alice)
         bob.block!(alice)
-        expect(subject.filter?(:home, status, bob)).to be true
+        expect(subject.filter?(:home, status, bob)).to be :filter
       end
 
-      it 'returns true for reblog by followee of blocked account' do
+      it 'returns :filter for reblog by followee of blocked account' do
         status = Fabricate(:status, text: 'Hello world', account: jeff)
         reblog = Fabricate(:status, reblog: status, account: alice)
         bob.follow!(alice)
         bob.block!(jeff)
-        expect(subject.filter?(:home, reblog, bob)).to be true
+        expect(subject.filter?(:home, reblog, bob)).to be :filter
       end
 
-      it 'returns true for reblog by followee of muted account' do
+      it 'returns :filter for reblog by followee of muted account' do
         status = Fabricate(:status, text: 'Hello world', account: jeff)
         reblog = Fabricate(:status, reblog: status, account: alice)
         bob.follow!(alice)
         bob.mute!(jeff)
-        expect(subject.filter?(:home, reblog, bob)).to be true
+        expect(subject.filter?(:home, reblog, bob)).to be :filter
       end
 
-      it 'returns true for reblog by followee of someone who is blocking recipient' do
+      it 'returns :filter for reblog by followee of someone who is blocking recipient' do
         status = Fabricate(:status, text: 'Hello world', account: jeff)
         reblog = Fabricate(:status, reblog: status, account: alice)
         bob.follow!(alice)
         jeff.block!(bob)
-        expect(subject.filter?(:home, reblog, bob)).to be true
+        expect(subject.filter?(:home, reblog, bob)).to be :filter
       end
 
-      it 'returns true for reblog from account with reblogs disabled' do
+      it 'returns :filter for reblog from account with reblogs disabled' do
         status = Fabricate(:status, text: 'Hello world', account: jeff)
         reblog = Fabricate(:status, reblog: status, account: alice)
         bob.follow!(alice, reblogs: false)
-        expect(subject.filter?(:home, reblog, bob)).to be true
+        expect(subject.filter?(:home, reblog, bob)).to be :filter
       end
 
-      it 'returns false for reply by followee to another followee' do
+      it 'returns nil for reply by followee to another followee' do
         status = Fabricate(:status, text: 'Hello world', account: jeff)
         reply  = Fabricate(:status, text: 'Nay', thread: status, account: alice)
         bob.follow!(alice)
         bob.follow!(jeff)
-        expect(subject.filter?(:home, reply, bob)).to be false
+        expect(subject.filter?(:home, reply, bob)).to be_nil
       end
 
-      it 'returns false for reply by followee to recipient' do
+      it 'returns nil for reply by followee to recipient' do
         status = Fabricate(:status, text: 'Hello world', account: bob)
         reply  = Fabricate(:status, text: 'Nay', thread: status, account: alice)
         bob.follow!(alice)
-        expect(subject.filter?(:home, reply, bob)).to be false
+        expect(subject.filter?(:home, reply, bob)).to be_nil
       end
 
-      it 'returns false for reply by followee to self' do
+      it 'returns nil for reply by followee to self' do
         status = Fabricate(:status, text: 'Hello world', account: alice)
         reply  = Fabricate(:status, text: 'Nay', thread: status, account: alice)
         bob.follow!(alice)
-        expect(subject.filter?(:home, reply, bob)).to be false
+        expect(subject.filter?(:home, reply, bob)).to be_nil
       end
 
-      it 'returns true for reply by followee to non-followed account' do
+      it 'returns :filter for reply by followee to non-followed account' do
         status = Fabricate(:status, text: 'Hello world', account: jeff)
         reply  = Fabricate(:status, text: 'Nay', thread: status, account: alice)
         bob.follow!(alice)
-        expect(subject.filter?(:home, reply, bob)).to be true
+        expect(subject.filter?(:home, reply, bob)).to be :filter
       end
 
-      it 'returns true for the second reply by followee to a non-federated status' do
+      it 'returns :filter for the second reply by followee to a non-federated status' do
         reply        = Fabricate(:status, text: 'Reply 1', reply: true, account: alice)
         second_reply = Fabricate(:status, text: 'Reply 2', thread: reply, account: alice)
         bob.follow!(alice)
-        expect(subject.filter?(:home, second_reply, bob)).to be true
+        expect(subject.filter?(:home, second_reply, bob)).to be :filter
       end
 
-      it 'returns false for status by followee mentioning another account' do
+      it 'returns nil for status by followee mentioning another account' do
         bob.follow!(alice)
         jeff.follow!(alice)
         status = PostStatusService.new.call(alice, text: 'Hey @jeff')
-        expect(subject.filter?(:home, status, bob)).to be false
+        expect(subject.filter?(:home, status, bob)).to be_nil
       end
 
-      it 'returns true for status by followee mentioning blocked account' do
+      it 'returns :filter for status by followee mentioning blocked account' do
         bob.block!(jeff)
         bob.follow!(alice)
         status = PostStatusService.new.call(alice, text: 'Hey @jeff')
-        expect(subject.filter?(:home, status, bob)).to be true
+        expect(subject.filter?(:home, status, bob)).to be :filter
       end
 
-      it 'returns true for reblog of a personally blocked domain' do
+      it 'returns :filter for reblog of a personally blocked domain' do
         alice.block_domain!('example.com')
         alice.follow!(jeff)
         status = Fabricate(:status, text: 'Hello world', account: bob)
         reblog = Fabricate(:status, reblog: status, account: jeff)
-        expect(subject.filter?(:home, reblog, alice)).to be true
+        expect(subject.filter?(:home, reblog, alice)).to be :filter
       end
 
-      it 'returns true for German post when follow is set to English only' do
+      it 'returns :filter for German post when follow is set to English only' do
         alice.follow!(bob, languages: %w(en))
         status = Fabricate(:status, text: 'Hallo Welt', account: bob, language: 'de')
-        expect(subject.filter?(:home, status, alice)).to be true
+        expect(subject.filter?(:home, status, alice)).to be :filter
       end
 
-      it 'returns false for German post when follow is set to German' do
+      it 'returns nil for German post when follow is set to German' do
         alice.follow!(bob, languages: %w(de))
         status = Fabricate(:status, text: 'Hallo Welt', account: bob, language: 'de')
-        expect(subject.filter?(:home, status, alice)).to be false
+        expect(subject.filter?(:home, status, alice)).to be_nil
       end
 
-      it 'returns true for post from followee on exclusive list' do
+      it 'returns :skip_home for post from followee on exclusive list' do
         list.exclusive = true
         alice.follow!(bob)
         list.accounts << bob
         allow(List).to receive(:where).and_return(list)
         status = Fabricate(:status, text: 'I post a lot', account: bob)
-        expect(subject.filter?(:home, status, alice)).to be true
+        expect(subject.filter?(:home, status, alice)).to be :skip_home
       end
 
-      it 'returns true for reblog from followee on exclusive list' do
+      it 'returns :skip_home for reblog from followee on exclusive list' do
         list.exclusive = true
         alice.follow!(jeff)
         list.accounts << jeff
         allow(List).to receive(:where).and_return(list)
         status = Fabricate(:status, text: 'I post a lot', account: bob)
         reblog = Fabricate(:status, reblog: status, account: jeff)
-        expect(subject.filter?(:home, reblog, alice)).to be true
+        expect(subject.filter?(:home, reblog, alice)).to be :skip_home
       end
 
-      it 'returns false for post from followee on non-exclusive list' do
+      it 'returns nil for post from followee on non-exclusive list' do
         list.exclusive = false
         alice.follow!(bob)
         list.accounts << bob
         status = Fabricate(:status, text: 'I post a lot', account: bob)
-        expect(subject.filter?(:home, status, alice)).to be false
+        expect(subject.filter?(:home, status, alice)).to be_nil
       end
 
-      it 'returns false for reblog from followee on non-exclusive list' do
+      it 'returns nil for reblog from followee on non-exclusive list' do
         list.exclusive = false
         alice.follow!(jeff)
         list.accounts << jeff
         status = Fabricate(:status, text: 'I post a lot', account: bob)
         reblog = Fabricate(:status, reblog: status, account: jeff)
-        expect(subject.filter?(:home, reblog, alice)).to be false
+        expect(subject.filter?(:home, reblog, alice)).to be_nil
       end
     end
 
     context 'with mentions feed' do
-      it 'returns true for status that mentions blocked account' do
+      it 'returns :filter for status that mentions blocked account' do
         bob.block!(jeff)
         status = PostStatusService.new.call(alice, text: 'Hey @jeff')
-        expect(subject.filter?(:mentions, status, bob)).to be true
+        expect(subject.filter?(:mentions, status, bob)).to be :filter
       end
 
-      it 'returns true for status that replies to a blocked account' do
+      it 'returns :filter for status that replies to a blocked account' do
         status = Fabricate(:status, text: 'Hello world', account: jeff)
         reply  = Fabricate(:status, text: 'Nay', thread: status, account: alice)
         bob.block!(jeff)
-        expect(subject.filter?(:mentions, reply, bob)).to be true
+        expect(subject.filter?(:mentions, reply, bob)).to be :filter
       end
 
-      it 'returns false for status by limited account who recipient is not following' do
+      it 'returns nil for status by limited account who recipient is not following' do
         status = Fabricate(:status, text: 'Hello world', account: alice)
         alice.silence!
-        expect(subject.filter?(:mentions, status, bob)).to be false
+        expect(subject.filter?(:mentions, status, bob)).to be_nil
       end
 
-      it 'returns false for status by followed limited account' do
+      it 'returns nil for status by followed limited account' do
         status = Fabricate(:status, text: 'Hello world', account: alice)
         alice.silence!
         bob.follow!(alice)
-        expect(subject.filter?(:mentions, status, bob)).to be false
+        expect(subject.filter?(:mentions, status, bob)).to be_nil
       end
     end
   end

--- a/spec/workers/feed_insert_worker_spec.rb
+++ b/spec/workers/feed_insert_worker_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe FeedInsertWorker do
 
     context 'when there are real records' do
       it 'skips the push when there is a filter' do
-        instance = instance_double(FeedManager, push_to_home: nil, filter?: true)
+        instance = instance_double(FeedManager, push_to_home: nil, filter?: :filter)
         allow(FeedManager).to receive(:instance).and_return(instance)
         result = subject.perform(status.id, follower.id)
 
@@ -41,7 +41,7 @@ RSpec.describe FeedInsertWorker do
       end
 
       it 'pushes the status onto the home timeline without filter' do
-        instance = instance_double(FeedManager, push_to_home: nil, filter?: false)
+        instance = instance_double(FeedManager, push_to_home: nil, filter?: nil)
         allow(FeedManager).to receive(:instance).and_return(instance)
         result = subject.perform(status.id, follower.id, :home)
 
@@ -50,7 +50,7 @@ RSpec.describe FeedInsertWorker do
       end
 
       it 'pushes the status onto the tags timeline without filter' do
-        instance = instance_double(FeedManager, push_to_home: nil, filter?: false)
+        instance = instance_double(FeedManager, push_to_home: nil, filter?: nil)
         allow(FeedManager).to receive(:instance).and_return(instance)
         result = subject.perform(status.id, follower.id, :tags)
 
@@ -59,7 +59,7 @@ RSpec.describe FeedInsertWorker do
       end
 
       it 'pushes the status onto the list timeline without filter' do
-        instance = instance_double(FeedManager, push_to_list: nil, filter?: false)
+        instance = instance_double(FeedManager, push_to_list: nil, filter?: nil)
         allow(FeedManager).to receive(:instance).and_return(instance)
         result = subject.perform(status.id, list.id, :list)
 

--- a/spec/workers/feed_insert_worker_spec.rb
+++ b/spec/workers/feed_insert_worker_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe FeedInsertWorker do
 
     context 'when there are real records' do
       it 'skips the push when there is a filter' do
-        instance = instance_double(FeedManager, push_to_home: nil, filter?: :filter)
+        instance = instance_double(FeedManager, push_to_home: nil, filter?: true)
         allow(FeedManager).to receive(:instance).and_return(instance)
         result = subject.perform(status.id, follower.id)
 
@@ -41,7 +41,7 @@ RSpec.describe FeedInsertWorker do
       end
 
       it 'pushes the status onto the home timeline without filter' do
-        instance = instance_double(FeedManager, push_to_home: nil, filter?: nil)
+        instance = instance_double(FeedManager, push_to_home: nil, filter?: false)
         allow(FeedManager).to receive(:instance).and_return(instance)
         result = subject.perform(status.id, follower.id, :home)
 
@@ -50,7 +50,7 @@ RSpec.describe FeedInsertWorker do
       end
 
       it 'pushes the status onto the tags timeline without filter' do
-        instance = instance_double(FeedManager, push_to_home: nil, filter?: nil)
+        instance = instance_double(FeedManager, push_to_home: nil, filter?: false)
         allow(FeedManager).to receive(:instance).and_return(instance)
         result = subject.perform(status.id, follower.id, :tags)
 
@@ -59,7 +59,7 @@ RSpec.describe FeedInsertWorker do
       end
 
       it 'pushes the status onto the list timeline without filter' do
-        instance = instance_double(FeedManager, push_to_list: nil, filter?: nil)
+        instance = instance_double(FeedManager, push_to_list: nil, filter?: false)
         allow(FeedManager).to receive(:instance).and_return(instance)
         result = subject.perform(status.id, list.id, :list)
 

--- a/spec/workers/feed_insert_worker_spec.rb
+++ b/spec/workers/feed_insert_worker_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe FeedInsertWorker do
 
     context 'when there are real records' do
       it 'skips the push when there is a filter' do
-        instance = instance_double(FeedManager, push_to_home: nil, filter?: true)
+        instance = instance_double(FeedManager, push_to_home: nil, filter?: true, filter: :filter)
         allow(FeedManager).to receive(:instance).and_return(instance)
         result = subject.perform(status.id, follower.id)
 
@@ -41,7 +41,7 @@ RSpec.describe FeedInsertWorker do
       end
 
       it 'pushes the status onto the home timeline without filter' do
-        instance = instance_double(FeedManager, push_to_home: nil, filter?: false)
+        instance = instance_double(FeedManager, push_to_home: nil, filter?: false, filter: nil)
         allow(FeedManager).to receive(:instance).and_return(instance)
         result = subject.perform(status.id, follower.id, :home)
 
@@ -50,7 +50,7 @@ RSpec.describe FeedInsertWorker do
       end
 
       it 'pushes the status onto the tags timeline without filter' do
-        instance = instance_double(FeedManager, push_to_home: nil, filter?: false)
+        instance = instance_double(FeedManager, push_to_home: nil, filter?: false, filter: nil)
         allow(FeedManager).to receive(:instance).and_return(instance)
         result = subject.perform(status.id, follower.id, :tags)
 
@@ -59,7 +59,7 @@ RSpec.describe FeedInsertWorker do
       end
 
       it 'pushes the status onto the list timeline without filter' do
-        instance = instance_double(FeedManager, push_to_list: nil, filter?: false)
+        instance = instance_double(FeedManager, push_to_list: nil, filter?: false filter: nil)
         allow(FeedManager).to receive(:instance).and_return(instance)
         result = subject.perform(status.id, list.id, :list)
 

--- a/spec/workers/feed_insert_worker_spec.rb
+++ b/spec/workers/feed_insert_worker_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe FeedInsertWorker do
       end
 
       it 'pushes the status onto the list timeline without filter' do
-        instance = instance_double(FeedManager, push_to_list: nil, filter?: false filter: nil)
+        instance = instance_double(FeedManager, push_to_list: nil, filter?: false, filter: nil)
         allow(FeedManager).to receive(:instance).and_return(instance)
         result = subject.perform(status.id, list.id, :list)
 


### PR DESCRIPTION
Fixes https://github.com/mastodon/mastodon/issues/27316

I had to rename a parameter, and add a function, to make sure this didn't become too much of a messy hack, but i hope that this is at least still a similar level of cleanliness and understanding

The only annoyance is that this is now building crutches twice, the alternative for that would be to have some enum/flag/symbol kind of return ("hide from home, show notif", "don't show notif, hide from home", `:skip_home, :filter`), but that's a lot more refactoring

if that's the more clean solution, prompt me, then i'll try to refactor around it