### PR TITLE
Add spec coverage for media CLI `refresh` command

### DIFF
--- a/lib/mastodon/cli/media.rb
+++ b/lib/mastodon/cli/media.rb
@@ -265,6 +265,7 @@ module Mastodon::CLI
       elsif options[:days].present?
         scope = MediaAttachment.remote
       else
+        say('Specify the source of media attachments', :red)
         exit(1)
       end
 

--- a/spec/lib/mastodon/cli/media_spec.rb
+++ b/spec/lib/mastodon/cli/media_spec.rb
@@ -86,4 +86,77 @@ describe Mastodon::CLI::Media do
       end
     end
   end
+
+  describe '#refresh' do
+    context 'without any options' do
+      let(:options) { {} }
+
+      it 'warns about usage and exits' do
+        expect { cli.invoke(:refresh, [], options) }.to output(
+          a_string_including('Specify the source')
+        ).to_stdout.and raise_error(SystemExit)
+      end
+    end
+
+    context 'with --status option' do
+      before do
+        media_attachment.update(file_file_name: nil)
+      end
+
+      let(:media_attachment) { Fabricate(:media_attachment, status: status, remote_url: 'https://host.example/asset.jpg') }
+      let(:options) { { status: status.id } }
+      let(:status) { Fabricate(:status) }
+
+      it 'redownloads the attachment file' do
+        expect { cli.invoke(:refresh, [], options) }.to output(
+          a_string_including('Downloaded 1 media')
+        ).to_stdout
+      end
+    end
+
+    context 'with --account option' do
+      context 'when the account does not exist' do
+        let(:options) { { account: 'not-real-user@example.host' } }
+
+        it 'warns about usage and exits' do
+          expect { cli.invoke(:refresh, [], options) }.to output(
+            a_string_including('No such account')
+          ).to_stdout.and raise_error(SystemExit)
+        end
+      end
+
+      context 'when the account exists' do
+        before do
+          media_attachment.update(file_file_name: nil)
+        end
+
+        let(:media_attachment) { Fabricate(:media_attachment, account: account) }
+        let(:options) { { account: account.acct } }
+        let(:account) { Fabricate(:account) }
+
+        it 'redownloads the attachment file' do
+          expect { cli.invoke(:refresh, [], options) }.to output(
+            a_string_including('Downloaded 1 media')
+          ).to_stdout
+        end
+      end
+    end
+
+    context 'with --domain option' do
+      before do
+        media_attachment.update(file_file_name: nil)
+      end
+
+      let(:domain) { 'example.host' }
+      let(:media_attachment) { Fabricate(:media_attachment, account: account) }
+      let(:options) { { domain: domain } }
+      let(:account) { Fabricate(:account, domain: domain) }
+
+      it 'redownloads the attachment file' do
+        expect { cli.invoke(:refresh, [], options) }.to output(
+          a_string_including('Downloaded 1 media')
+        ).to_stdout
+      end
+    end
+  end
 end


### PR DESCRIPTION
Added error output for the no-options case, and some basic coverage for some of the options.

I noticed while in here that the `days` option is just calling `remote`, and not anything to do with days ... is this correct? If not, should the fix be to change the option name to mention remote, or change the code to actually do what the option says?