### PR TITLE
Fix `Style/RedundantParentheses` cop

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -64,7 +64,7 @@ class Api::BaseController < ApplicationController
   end
 
   def doorkeeper_unauthorized_render_options(error: nil)
-    { json: { error: (error.try(:description) || 'Not authorized') } }
+    { json: { error: error.try(:description) || 'Not authorized' } }
   end
 
   def doorkeeper_forbidden_render_options(*)

--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -49,7 +49,7 @@ class Api::V1::AccountsController < Api::BaseController
   end
 
   def mute
-    MuteService.new.call(current_user.account, @account, notifications: truthy_param?(:notifications), duration: (params[:duration]&.to_i || 0))
+    MuteService.new.call(current_user.account, @account, notifications: truthy_param?(:notifications), duration: params[:duration].to_i)
     render json: @account, serializer: REST::RelationshipSerializer, relationships: relationships
   end
 

--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -420,8 +420,8 @@ class FeedManager
     check_for_blocks = status.active_mentions.pluck(:account_id)
     check_for_blocks.push(status.in_reply_to_account) if status.reply? && !status.in_reply_to_account_id.nil?
 
-    should_filter   = blocks_or_mutes?(receiver_id, check_for_blocks, :mentions)                                                         # Filter if it's from someone I blocked, in reply to someone I blocked, or mentioning someone I blocked (or muted)
-    should_filter ||= (status.account.silenced? && !Follow.where(account_id: receiver_id, target_account_id: status.account_id).exists?) # of if the account is silenced and I'm not following them
+    should_filter   = blocks_or_mutes?(receiver_id, check_for_blocks, :mentions)                                                       # Filter if it's from someone I blocked, in reply to someone I blocked, or mentioning someone I blocked (or muted)
+    should_filter ||= status.account.silenced? && !Follow.where(account_id: receiver_id, target_account_id: status.account_id).exists? # of if the account is silenced and I'm not following them
 
     should_filter
   end

--- a/lib/mastodon/cli/media.rb
+++ b/lib/mastodon/cli/media.rb
@@ -48,8 +48,8 @@ module Mastodon::CLI
           next if account.avatar.blank? && account.header.blank?
           next if options[:remove_headers] && account.header.blank?
 
-          size = (account.header_file_size || 0)
-          size += (account.avatar_file_size || 0) if options[:prune_profiles]
+          size = account.header_file_size || 0
+          size += account.avatar_file_size || 0 if options[:prune_profiles]
 
           unless dry_run?
             account.header.destroy


### PR DESCRIPTION
Pre-requisite for https://github.com/mastodon/mastodon/pull/28170

Out of this whole batch for the rubocop upgrade this is the only one I'm kind of iffy on. I think it's probably fine as-is in this PR, but could also see pulling these out to private methods instead.