### PR TITLE
Error handling for attachment batch delete process

### DIFF
--- a/app/lib/attachment_batch.rb
+++ b/app/lib/attachment_batch.rb
@@ -106,7 +106,7 @@ class AttachmentBatch
       })
     rescue => e
       retries += 1
- 
+
       if retries < MAX_RETRY
         logger.debug "Retry #{retries}/#{MAX_RETRY} after #{e.message}"
         sleep 2**retries

--- a/app/lib/attachment_batch.rb
+++ b/app/lib/attachment_batch.rb
@@ -97,23 +97,23 @@ class AttachmentBatch
     # separate them into multiple calls.
 
     retries = 0
-    begin
-      keys.each_slice(LIMIT) do |keys_slice|
+    keys.each_slice(LIMIT) do |keys_slice|
+      begin
         logger.debug { "Deleting #{keys_slice.size} objects" }
         bucket.delete_objects(delete: {
           objects: keys_slice.map { |key| { key: key } },
           quiet: true,
         })
-      end
-    rescue => e
-      retries += 1
-      if retries < MAX_RETRY
-        logger.debug "Retry #{retries}/#{MAX_RETRY} after #{e.message}"
-        sleep 2**retries
-        retry
-      else
-        logger.error "Batch deletion from S3 failed after #{e.message}"
-        raise e
+      rescue => e
+        retries += 1
+        if retries < MAX_RETRY
+          logger.debug "Retry #{retries}/#{MAX_RETRY} after #{e.message}"
+          sleep 2**retries
+          retry
+        else
+          logger.error "Batch deletion from S3 failed after #{e.message}"
+          raise e
+        end
       end
     end
   end

--- a/app/lib/attachment_batch.rb
+++ b/app/lib/attachment_batch.rb
@@ -105,14 +105,14 @@ class AttachmentBatch
           quiet: true,
         })
       end
-    rescue => error
+    rescue => e
       retries += 1
       if retries < MAX_RETRY
-        logger.debug "Retry #{retries}/#{MAX_RETRY} after #{error.message}"
+        logger.debug "Retry #{retries}/#{MAX_RETRY} after #{e.message}"
         sleep 2**retries
         retry
       else
-        logger.error "Batch deletion from S3 failed"
+        logger.error "Batch deletion from S3 failed after #{e.message}"
         raise e
       end
     end

--- a/app/lib/attachment_batch.rb
+++ b/app/lib/attachment_batch.rb
@@ -98,22 +98,22 @@ class AttachmentBatch
 
     retries = 0
     keys.each_slice(LIMIT) do |keys_slice|
-      begin
-        logger.debug { "Deleting #{keys_slice.size} objects" }
-        bucket.delete_objects(delete: {
-          objects: keys_slice.map { |key| { key: key } },
-          quiet: true,
-        })
-      rescue => e
-        retries += 1
-        if retries < MAX_RETRY
-          logger.debug "Retry #{retries}/#{MAX_RETRY} after #{e.message}"
-          sleep 2**retries
-          retry
-        else
-          logger.error "Batch deletion from S3 failed after #{e.message}"
-          raise e
-        end
+      logger.debug { "Deleting #{keys_slice.size} objects" }
+
+      bucket.delete_objects(delete: {
+        objects: keys_slice.map { |key| { key: key } },
+        quiet: true,
+      })
+    rescue => e
+      retries += 1
+ 
+      if retries < MAX_RETRY
+        logger.debug "Retry #{retries}/#{MAX_RETRY} after #{e.message}"
+        sleep 2**retries
+        retry
+      else
+        logger.error "Batch deletion from S3 failed after #{e.message}"
+        raise e
       end
     end
   end


### PR DESCRIPTION
Fixes #27752 

- Allows batch sizes to be sent with ENV variable: `S3_BATCH_DELETE_LIMIT`
- Error handling is set to retry failed S3 batch request 3 times, can be customized with `S3_BATCH_DELETE_RETRY`
- On first error, will back off 2 seconds before attempting to try again and then scale up based on the number of retries