### PR TITLE
Use the `Admin::ActionLog` fabricator in admin/action_logs spec

### DIFF
--- a/spec/controllers/admin/accounts_controller_spec.rb
+++ b/spec/controllers/admin/accounts_controller_spec.rb
@@ -161,12 +161,13 @@ RSpec.describe Admin::AccountsController do
       it 'logs action' do
         expect(subject).to have_http_status 302
 
-        log_item = Admin::ActionLog.last
-
-        expect(log_item).to_not be_nil
-        expect(log_item.action).to eq :approve
-        expect(log_item.account_id).to eq current_user.account_id
-        expect(log_item.target_id).to eq account.user.id
+        expect(latest_admin_action_log)
+          .to be_present
+          .and have_attributes(
+            action: eq(:approve),
+            account_id: eq(current_user.account_id),
+            target_id: eq(account.user.id)
+          )
       end
     end
 
@@ -201,12 +202,13 @@ RSpec.describe Admin::AccountsController do
       it 'logs action' do
         expect(subject).to have_http_status 302
 
-        log_item = Admin::ActionLog.last
-
-        expect(log_item).to_not be_nil
-        expect(log_item.action).to eq :reject
-        expect(log_item.account_id).to eq current_user.account_id
-        expect(log_item.target_id).to eq account.user.id
+        expect(latest_admin_action_log)
+          .to be_present
+          .and have_attributes(
+            action: eq(:reject),
+            account_id: eq(current_user.account_id),
+            target_id: eq(account.user.id)
+          )
       end
     end
 
@@ -426,5 +428,11 @@ RSpec.describe Admin::AccountsController do
         expect(response).to have_http_status 403
       end
     end
+  end
+
+  private
+
+  def latest_admin_action_log
+    Admin::ActionLog.last
   end
 end

--- a/spec/controllers/admin/action_logs_controller_spec.rb
+++ b/spec/controllers/admin/action_logs_controller_spec.rb
@@ -9,11 +9,9 @@ describe Admin::ActionLogsController do
   let!(:account) { Fabricate(:account) }
 
   before do
-    _orphaned_logs = %w(
-      Account User UserRole Report DomainBlock DomainAllow
-      EmailDomainBlock UnavailableDomain Status AccountWarning
-      Announcement IpBlock Instance CustomEmoji CanonicalEmailBlock Appeal
-    ).map { |type| Admin::ActionLog.new(account: account, action: 'destroy', target_type: type, target_id: 1312).save! }
+    orphaned_log_types.map do |type|
+      Fabricate(:action_log, account: account, action: 'destroy', target_type: type, target_id: 1312)
+    end
   end
 
   describe 'GET #index' do
@@ -23,5 +21,28 @@ describe Admin::ActionLogsController do
 
       expect(response).to have_http_status(200)
     end
+  end
+
+  private
+
+  def orphaned_log_types
+    %w(
+      Account
+      AccountWarning
+      Announcement
+      Appeal
+      CanonicalEmailBlock
+      CustomEmoji
+      DomainAllow
+      DomainBlock
+      EmailDomainBlock
+      Instance
+      IpBlock
+      Report
+      Status
+      UnavailableDomain
+      User
+      UserRole
+    )
   end
 end

--- a/spec/requests/api/v1/admin/account_actions_spec.rb
+++ b/spec/requests/api/v1/admin/account_actions_spec.rb
@@ -21,12 +21,19 @@ RSpec.describe 'Account actions' do
     it 'logs action' do
       subject
 
-      log_item = Admin::ActionLog.last
+      expect(latest_admin_action_log)
+        .to be_present
+        .and have_attributes(
+          action: eq(action_type),
+          account_id: eq(user.account_id),
+          target_id: eq(target_type == :user ? target_account.user.id : target_account.id)
+        )
+    end
 
-      expect(log_item).to be_present
-      expect(log_item.action).to eq(action_type)
-      expect(log_item.account_id).to eq(user.account_id)
-      expect(log_item.target_id).to eq(target_type == :user ? target_account.user.id : target_account.id)
+    private
+
+    def latest_admin_action_log
+      Admin::ActionLog.last
     end
   end
 

--- a/spec/requests/api/v1/admin/accounts_spec.rb
+++ b/spec/requests/api/v1/admin/accounts_spec.rb
@@ -151,12 +151,13 @@ RSpec.describe 'Accounts' do
       it 'logs action', :aggregate_failures do
         subject
 
-        log_item = Admin::ActionLog.last
-
-        expect(log_item).to be_present
-        expect(log_item.action).to eq :approve
-        expect(log_item.account_id).to eq user.account_id
-        expect(log_item.target_id).to eq account.user.id
+        expect(latest_admin_action_log)
+          .to be_present
+          .and have_attributes(
+            action: eq(:approve),
+            account_id: eq(user.account_id),
+            target_id: eq(account.user.id)
+          )
       end
     end
 
@@ -202,12 +203,13 @@ RSpec.describe 'Accounts' do
       it 'logs action', :aggregate_failures do
         subject
 
-        log_item = Admin::ActionLog.last
-
-        expect(log_item).to be_present
-        expect(log_item.action).to eq :reject
-        expect(log_item.account_id).to eq user.account_id
-        expect(log_item.target_id).to eq account.user.id
+        expect(latest_admin_action_log)
+          .to be_present
+          .and have_attributes(
+            action: eq(:reject),
+            account_id: eq(user.account_id),
+            target_id: eq(account.user.id)
+          )
       end
     end
 
@@ -397,5 +399,11 @@ RSpec.describe 'Accounts' do
         expect(response).to have_http_status(404)
       end
     end
+  end
+
+  private
+
+  def latest_admin_action_log
+    Admin::ActionLog.last
   end
 end


### PR DESCRIPTION
Two changes here:

- Use the fabricator where it was not used (and extract a private method to loop through classes)
- Pull out private method for some "find the last action log" local vars