### PR TITLE
Use composite primary key for `PreviewCardsStatus` model

### DIFF
--- a/app/models/preview_cards_status.rb
+++ b/app/models/preview_cards_status.rb
@@ -9,9 +9,7 @@
 #  url             :string
 #
 class PreviewCardsStatus < ApplicationRecord
-  # Composite primary keys are not properly supported in Rails. However,
-  # we shouldn't need this anyway...
-  self.primary_key = nil
+  self.primary_key = [:preview_card_id, :status_id]
 
   belongs_to :preview_card
   belongs_to :status

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -232,6 +232,10 @@ class Status < ApplicationRecord
     preview_cards_status&.preview_card&.tap { |x| x.original_url = preview_cards_status.url }
   end
 
+  def reset_preview_card!
+    PreviewCardsStatus.where(status_id: id).delete_all
+  end
+
   def hidden?
     !distributable?
   end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -82,8 +82,7 @@ class Status < ApplicationRecord
 
   has_and_belongs_to_many :tags
 
-  # Because of a composite primary key, the `dependent` option cannot be used on this association
-  has_one :preview_cards_status, inverse_of: :status # rubocop:disable Rails/HasManyOrHasOneDependent
+  has_one :preview_cards_status, inverse_of: :status, dependent: :delete
 
   has_one :notification, as: :activity, dependent: :destroy
   has_one :status_stat, inverse_of: :status, dependent: nil
@@ -146,7 +145,6 @@ class Status < ApplicationRecord
   # The `prepend: true` option below ensures this runs before
   # the `dependent: destroy` callbacks remove relevant records
   before_destroy :unlink_from_conversations!, prepend: true
-  before_destroy :reset_preview_card!
 
   cache_associated :application,
                    :media_attachments,
@@ -232,10 +230,6 @@ class Status < ApplicationRecord
 
   def preview_card
     preview_cards_status&.preview_card&.tap { |x| x.original_url = preview_cards_status.url }
-  end
-
-  def reset_preview_card!
-    PreviewCardsStatus.where(status_id: id).delete_all
   end
 
   def hidden?


### PR DESCRIPTION
This `primary_key` value was previously set to `nil` because the class has a composite primary key and Rails did not support that DB design. Rails now does have (limited) supported for composite primary keys, which is sufficient enough for our one use case: letting the `destroy` callbacks on `Status` and `PreviewCard` models correctly connect to their associated records and run (because they are associations, they don't even need the new composite key array finder syntax, they just find the record with their side of the association).

As far as I can tell this class is not used anywhere independently of these associations, so I don't think there's anywhere else to update. I guess hypothetically if people we doing something in the rails console, the way you interact with the class might change.

This also refactors what was previously a `before_destroy` callback to just use the built-in `dependent: :delete` approach on the association.

The generated SQL for the delete is slightly different, primarily because the previous method was doing a `delete_all` via the associated class. The new query continues to delete the connect PreviewCardsStatus record for the Status being destroyed, but issues a query with the full composite key of the connected record now, similar to what happens on normal declared `dependent...` on a `has_one` other places.

<details>
<summary>Generated SQL before change</summary>

```
PreviewCardsStatus Delete All (0.2ms)  DELETE FROM "preview_cards_statuses" WHERE "preview_cards_statuses"."status_id" = $1  [["status_id", 111518058715735722]]
```

</details>

<details>
<summary>Generated SQL after change</summary>

```
PreviewCardsStatus Destroy (0.2ms)  DELETE FROM "preview_cards_statuses" WHERE "preview_cards_statuses"."preview_card_id" = $1 AND "preview_cards_statuses"."status_id" = $2  [["preview_card_id", 1], ["status_id", 111518074769262341]]
```

</details>

We already have the relevant CPK index in place as the primary key from a previous migration done after this table was converted from just a join table to actually having a model.