### PR TITLE
Remove double subject call in `services/delete_account_service` spec

### DIFF
--- a/spec/services/delete_account_service_spec.rb
+++ b/spec/services/delete_account_service_spec.rb
@@ -27,8 +27,15 @@ RSpec.describe DeleteAccountService, type: :service do
 
     let!(:account_note) { Fabricate(:account_note, account: account) }
 
-    it 'deletes associated owned records' do
-      expect { subject }.to change {
+    it 'deletes associated owned and target records and target notifications' do
+      expect { subject }
+        .to delete_associated_owned_records
+        .and delete_associated_target_records
+        .and delete_associated_target_notifications
+    end
+
+    def delete_associated_owned_records
+      change do
         [
           account.statuses,
           account.media_attachments,
@@ -39,23 +46,23 @@ RSpec.describe DeleteAccountService, type: :service do
           account.polls,
           account.account_notes,
         ].map(&:count)
-      }.from([2, 1, 1, 1, 1, 1, 1, 1]).to([0, 0, 0, 0, 0, 0, 0, 0])
+      end.from([2, 1, 1, 1, 1, 1, 1, 1]).to([0, 0, 0, 0, 0, 0, 0, 0])
     end
 
-    it 'deletes associated target records' do
-      expect { subject }.to change {
+    def delete_associated_target_records
+      change do
         [
           AccountPin.where(target_account: account),
         ].map(&:count)
-      }.from([1]).to([0])
+      end.from([1]).to([0])
     end
 
-    it 'deletes associated target notifications' do
-      expect { subject }.to change {
+    def delete_associated_target_notifications
+      change do
         %w(
           poll favourite status mention follow
         ).map { |type| Notification.where(type: type).count }
-      }.from([1, 1, 1, 1, 1]).to([0, 0, 0, 0, 0])
+      end.from([1, 1, 1, 1, 1]).to([0, 0, 0, 0, 0])
     end
   end
 


### PR DESCRIPTION
Similar to others -- try to reduce the number of times the exercise portion of the test is running when we're asserting multiple things against same result.

The specs here are sort of awkward with the mapping through many things. May clean that up in future change, for now just trying to reduce duplicate subject.