### PR TITLE
Enable the eslint `react/no-unknown-property` rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -120,7 +120,6 @@ module.exports = defineConfig({
     'react/jsx-uses-react': 'off', // not needed with new JSX transform
     'react/jsx-wrap-multilines': 'error',
     'react/no-deprecated': 'off',
-    'react/no-unknown-property': ['error', { ignore: ['volume'] }], // Valid attribute on `video` element, but not included in package defs
     'react/react-in-jsx-scope': 'off', // not needed with new JSX transform
     'react/self-closing-comp': 'error',
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -120,7 +120,7 @@ module.exports = defineConfig({
     'react/jsx-uses-react': 'off', // not needed with new JSX transform
     'react/jsx-wrap-multilines': 'error',
     'react/no-deprecated': 'off',
-    'react/no-unknown-property': 'off',
+    'react/no-unknown-property': ['error', { ignore: ['volume'] }], // Valid attribute on `video` element, but not included in package defs
     'react/react-in-jsx-scope': 'off', // not needed with new JSX transform
     'react/self-closing-comp': 'error',
 

--- a/app/javascript/mastodon/features/interaction_modal/index.jsx
+++ b/app/javascript/mastodon/features/interaction_modal/index.jsx
@@ -298,9 +298,9 @@ class LoginForm extends React.PureComponent {
             onFocus={this.handleFocus}
             onBlur={this.handleBlur}
             onKeyDown={this.handleKeyDown}
-            autocomplete='off'
-            autocapitalize='off'
-            spellcheck='false'
+            autoComplete='off'
+            autoCapitalize='off'
+            spellCheck='false'
           />
 
           <Button onClick={this.handleSubmit} disabled={isSubmitting || error}><FormattedMessage id='interaction_modal.login.action' defaultMessage='Take me home' /></Button>

--- a/app/javascript/mastodon/features/ui/components/navigation_panel.jsx
+++ b/app/javascript/mastodon/features/ui/components/navigation_panel.jsx
@@ -82,7 +82,7 @@ class NavigationPanel extends Component {
         </div>
 
         {banner &&
-          <div class='navigation-panel__banner'>
+          <div className='navigation-panel__banner'>
             {banner}
           </div>
         }

--- a/app/javascript/mastodon/features/video/index.jsx
+++ b/app/javascript/mastodon/features/video/index.jsx
@@ -612,7 +612,6 @@ class Video extends PureComponent {
             aria-label={alt}
             title={alt}
             lang={lang}
-            volume={volume}
             onClick={this.togglePlay}
             onKeyDown={this.handleVideoKeyDown}
             onPlay={this.handlePlay}

--- a/package.json
+++ b/package.json
@@ -193,7 +193,7 @@
     "eslint-plugin-jsx-a11y": "~6.8.0",
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-promise": "~6.1.1",
-    "eslint-plugin-react": "~7.33.0",
+    "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "husky": "^8.0.3",
     "jest": "^29.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2371,7 +2371,7 @@ __metadata:
     eslint-plugin-jsx-a11y: "npm:~6.8.0"
     eslint-plugin-prettier: "npm:^5.0.0"
     eslint-plugin-promise: "npm:~6.1.1"
-    eslint-plugin-react: "npm:~7.33.0"
+    eslint-plugin-react: "npm:^7.33.2"
     eslint-plugin-react-hooks: "npm:^4.6.0"
     file-loader: "npm:^6.2.0"
     font-awesome: "npm:^4.7.0"
@@ -7501,7 +7501,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react@npm:~7.33.0":
+"eslint-plugin-react@npm:^7.33.2":
   version: 7.33.2
   resolution: "eslint-plugin-react@npm:7.33.2"
   dependencies:


### PR DESCRIPTION
Alternate approach to https://github.com/mastodon/mastodon/pull/24425

- First, version bump the plugin (I was hoping this would included the `volume` attribute on video, but it does not
- Enable the lint rule, but allow *just* the one specific case through (catch others, instead of currently disabled)
- Fix the ~4 violations that had occurred between that original PR and now