### PR TITLE
Feature: allow unchecking sending of account action email notifications via querystring

### DIFF
--- a/app/controllers/admin/account_actions_controller.rb
+++ b/app/controllers/admin/account_actions_controller.rb
@@ -7,7 +7,12 @@ module Admin
     def new
       authorize @account, :show?
 
-      @account_action  = Admin::AccountAction.new(type: params[:type], report_id: params[:report_id], send_email_notification: true, include_statuses: true)
+      @account_action = Admin::AccountAction.new(
+        type: params[:type],
+        report_id: params[:report_id],
+        send_email_notification: (params[:send_email_notification].presence || true),
+        include_statuses: (params[:include_statuses].presence || true)
+      )
       @warning_presets = AccountWarningPreset.all
     end
 


### PR DESCRIPTION
Noticed this whilst experimenting with the account actions UI, and specifically using it from third-party tools where you may want to take a person directly to this page and know that you don't accidentally want to send the user an email (e.g., cases where the account was participating in illegal activities.

(I'd originally written this as a ternary, but rubocop says `presence || true`, so not the code I'd intended but it works none the less as far as I can tell. There doesn't seem to be any test coverage here.)