### PR TITLE
Update sprockets to version 4.2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby '>= 3.0.0'
 
 gem 'puma', '~> 6.3'
 gem 'rails', '~> 7.1.1'
-gem 'sprockets', '~> 3.7.2'
+gem 'sprockets'
 gem 'thor', '~> 1.2'
 gem 'rack', '~> 2.2.7'
 
@@ -89,7 +89,7 @@ gem 'sidekiq-unique-jobs', '~> 7.1'
 gem 'sidekiq-bulk', '~> 0.2.0'
 gem 'simple-navigation', '~> 4.4'
 gem 'simple_form', '~> 5.2'
-gem 'sprockets-rails', '~> 3.4', require: 'sprockets/railtie'
+gem 'sprockets-rails', require: 'sprockets/railtie'
 gem 'stoplight', '~> 3.0.1'
 gem 'strong_migrations', '1.6.4'
 gem 'tty-prompt', '~> 0.23', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -558,7 +558,7 @@ GEM
       rack
     rack-proxy (0.7.6)
       rack
-    rack-session (1.0.1)
+    rack-session (1.0.2)
       rack (< 3)
     rack-test (2.1.0)
       rack (>= 1.3)
@@ -736,9 +736,9 @@ GEM
     simplecov-lcov (0.8.0)
     simplecov_json_formatter (0.1.4)
     smart_properties (1.17.0)
-    sprockets (3.7.2)
+    sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
-      rack (> 1, < 3)
+      rack (>= 2.2.4, < 4)
     sprockets-rails (3.4.2)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
@@ -949,8 +949,8 @@ DEPENDENCIES
   simple_form (~> 5.2)
   simplecov (~> 0.22)
   simplecov-lcov (~> 0.8)
-  sprockets (~> 3.7.2)
-  sprockets-rails (~> 3.4)
+  sprockets
+  sprockets-rails
   stackprof
   stoplight (~> 3.0.1)
   strong_migrations (= 1.6.4)


### PR DESCRIPTION
We were previously at the latest in the 3.x series.

I know that we are planning to update/replace much of the asset/js/css packaging/compiling tooling (there's an open Vite PR, etc) ... but this might be a stop-gap update in the interim until those are ready. Opening this in part because it relaxes the `rack` dependency requirement.

I did not bother to configure anything in the manifest, but the file does need to be present, so I added it. I also did not bother to use any of the features added in 4.x -- the goal here is merely to do the update and get the relaxed version req, while more or less preserving our currente usage. At some time in the future likely remove sprockets.

Opening as draft to see what CI says, and because I need much more thorough review of what assets were previously expected to be present and may need configuration now.