### PR TITLE
Fix error when encountering malformed Tag objects from Kbin

### DIFF
--- a/app/services/activitypub/process_status_update_service.rb
+++ b/app/services/activitypub/process_status_update_service.rb
@@ -170,9 +170,9 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
 
     as_array(@json['tag']).each do |tag|
       if equals_or_includes?(tag['type'], 'Hashtag')
-        @raw_tags << tag['name']
+        @raw_tags << tag['name'] if tag['name'].present?
       elsif equals_or_includes?(tag['type'], 'Mention')
-        @raw_mentions << tag['href']
+        @raw_mentions << tag['href'] if tag['href'].present?
       elsif equals_or_includes?(tag['type'], 'Emoji')
         @raw_emojis << tag
       end


### PR DESCRIPTION
Kbin has malformed `HashTag` objects in their AP announce objects;

<details>
<summary>Long JSON</summary>

```json
{
    "@context": [
        "https:\/\/www.w3.org\/ns\/activitystreams",
        "https:\/\/w3id.org\/security\/v1"
    ],
    "id": "https:\/\/kbin.social\/f\/object\/b71c85cc-293d-4947-ba4c-d107fdc3a444",
    "type": "Update",
    "actor": "https:\/\/kbin.social\/u\/ForestOrca",
    "published": "2023-11-28T00:31:16+00:00",
    "to": [
        "https:\/\/www.w3.org\/ns\/activitystreams#Public",
        "https:\/\/kbin.social\/u\/livus"
    ],
    "cc": [
        "https:\/\/kbin.social\/m\/worldwithoutus",
        "https:\/\/kbin.social\/u\/ForestOrca\/followers"
    ],
    "object": {
        "type": "Note",
        "id": "https:\/\/kbin.social\/m\/worldwithoutus\/t\/658796\/-\/comment\/3811105",
        "attributedTo": "https:\/\/kbin.social\/u\/ForestOrca",
        "inReplyTo": "https:\/\/kbin.social\/m\/worldwithoutus\/t\/658796\/-\/comment\/3810738",
        "to": [
            "https:\/\/www.w3.org\/ns\/activitystreams#Public",
            "https:\/\/kbin.social\/u\/livus"
        ],
        "cc": [
            "https:\/\/kbin.social\/m\/worldwithoutus",
            "https:\/\/kbin.social\/u\/ForestOrca\/followers"
        ],
        "content": "<p>Excellent point!! I'll edit. TY!<\/p>\n",
        "mediaType": "text\/html",
        "url": "https:\/\/kbin.social\/m\/worldwithoutus\/t\/658796\/-\/comment\/3811105",
        "tag": [
            {
                "type": "Hashtag",
                "href": "https:\/\/kbin.social\/tag\/worldwithoutus",
                "tag": "#worldwithoutus"
            },
            {
                "type": "Mention",
                "href": "https:\/\/kbin.social\/u\/livus",
                "name": "@livus@kbin.social"
            }
        ],
        "published": "2023-11-28T00:31:16+00:00",
        "contentMap": {
            "en": "<p>Excellent point!! I'll edit. TY!<\/p>\n"
        },
        "updated": "2023-11-28T00:34:02+00:00"
    }
}
```

</details>

Precisely;

```json
{
    "type": "Hashtag",
    "href": "https:\/\/kbin.social\/tag\/worldwithoutus",
    "tag": "#worldwithoutus"
}
```

This `tag` has to be `name`, or else the following line will malform and add a `nil` to the array;

https://github.com/mastodon/mastodon/blob/89a8e6e6227eb901b5811d8417d81dc8ab1427a9/app/services/activitypub/process_status_update_service.rb#L173

Which then chokes on this line, after much processing;

https://github.com/mastodon/mastodon/blob/89a8e6e6227eb901b5811d8417d81dc8ab1427a9/app/lib/hashtag_normalizer.rb#L23

With the following error;

`NoMethodError: undefined method 'unicode_normalize' for nil:NilClass`

With the following backtrace;

<details>
<summary>Backtrace</summary>

```
app/lib/hashtag_normalizer.rb:23:in `cjk_width'
app/lib/hashtag_normalizer.rb:5:in `normalize'
app/models/tag.rb:157:in `normalize'
app/models/tag.rb:115:in `block in find_or_create_by_names'
app/models/tag.rb:115:in `map'
app/models/tag.rb:115:in `find_or_create_by_names'
app/services/activitypub/process_status_update_service.rb:187:in `update_tags!'
app/services/activitypub/process_status_update_service.rb:181:in `update_metadata!'
app/services/activitypub/process_status_update_service.rb:45:in `block (2 levels) in handle_explicit_update!'
vendor/bundle/ruby/3.0.0/gems/activerecord-7.1.1/lib/active_record/connection_adapters/abstract/transaction.rb:535:in `block in within_new_transaction'
vendor/bundle/ruby/3.0.0/gems/activesupport-7.1.1/lib/active_support/concurrency/null_lock.rb:9:in `synchronize'
vendor/bundle/ruby/3.0.0/gems/activerecord-7.1.1/lib/active_record/connection_adapters/abstract/transaction.rb:532:in `within_new_transaction'
vendor/bundle/ruby/3.0.0/gems/activerecord-7.1.1/lib/active_record/connection_adapters/abstract/database_statements.rb:342:in `transaction'
vendor/bundle/ruby/3.0.0/gems/activerecord-7.1.1/lib/active_record/transactions.rb:212:in `transaction'
app/services/activitypub/process_status_update_service.rb:40:in `block in handle_explicit_update!'
app/models/concerns/lockable.rb:12:in `block (2 levels) in with_redis_lock'
vendor/bundle/ruby/3.0.0/gems/mario-redis-lock-1.2.1/lib/redis_lock.rb:44:in `acquire'
app/models/concerns/lockable.rb:10:in `block in with_redis_lock'
vendor/bundle/ruby/3.0.0/gems/connection_pool-2.4.1/lib/connection_pool.rb:110:in `block (2 levels) in with'
vendor/bundle/ruby/3.0.0/gems/connection_pool-2.4.1/lib/connection_pool.rb:109:in `handle_interrupt'
vendor/bundle/ruby/3.0.0/gems/connection_pool-2.4.1/lib/connection_pool.rb:109:in `block in with'
vendor/bundle/ruby/3.0.0/gems/connection_pool-2.4.1/lib/connection_pool.rb:106:in `handle_interrupt'
vendor/bundle/ruby/3.0.0/gems/connection_pool-2.4.1/lib/connection_pool.rb:106:in `with'
app/lib/redis_configuration.rb:10:in `with'
app/models/concerns/redisable.rb:9:in `with_redis'
app/models/concerns/lockable.rb:9:in `with_redis_lock'
app/services/activitypub/process_status_update_service.rb:39:in `handle_explicit_update!'
app/services/activitypub/process_status_update_service.rb:25:in `call'
app/lib/activitypub/activity/update.rb:33:in `update_status'
app/lib/activitypub/activity/update.rb:12:in `perform'
app/services/activitypub/process_collection_service.rb:68:in `process_item'
app/services/activitypub/process_collection_service.rb:59:in `block in process_items'
app/services/activitypub/process_collection_service.rb:59:in `reverse_each'
app/services/activitypub/process_collection_service.rb:59:in `each'
app/services/activitypub/process_collection_service.rb:59:in `filter_map'
app/services/activitypub/process_collection_service.rb:59:in `process_items'
app/services/activitypub/process_collection_service.rb:38:in `call'
app/workers/activitypub/processing_worker.rb:16:in `perform'
(irb):141:in `<main>'
```

</details>