### PR TITLE
Add `bin/dev` script to launch foreman

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ To set up **MacOS** for native development, complete the following steps:
 - Navigate to Mastodon's root directory and run `brew install nvm` then `nvm use` to use the version from `.nvmrc`
 - Run `corepack enable && corepack prepare`
 - Run `bundle exec rails db:setup` (optionally prepend `RAILS_ENV=development` to target the dev environment)
-- Finally, run `bin/dev` which will launch the development server.
+- Finally, run `bin/dev` which will launch the local services via `overmind` (if installed) or `foreman`.
 
 ### Docker
 

--- a/README.md
+++ b/README.md
@@ -83,23 +83,19 @@ A **Vagrant** configuration is included for development purposes. To use it, com
 - Install Vagrant and Virtualbox
 - Install the `vagrant-hostsupdater` plugin: `vagrant plugin install vagrant-hostsupdater`
 - Run `vagrant up`
-- Run `vagrant ssh -c "cd /vagrant && foreman start"`
+- Run `vagrant ssh -c "cd /vagrant && bin/dev"`
 - Open `http://mastodon.local` in your browser
 
 ### MacOS
 
 To set up **MacOS** for native development, complete the following steps:
 
-- Install the latest stable Ruby version (use a Ruby version manager for easy installation and management of Ruby versions)
-- Run `brew install postgresql@14`
-- Run `brew install redis`
-- Run `brew install imagemagick`
-- Run `brew install libidn`
-- Install Foreman or a similar tool (such as [overmind](https://github.com/DarthSim/overmind)) to handle multiple process launching.
-- Navigate to Mastodon's root directory and run `brew install nvm` then `nvm use` to use the version from .nvmrc
+- Use a Ruby version manager to install the specified version from `.ruby-version`
+- Run `brew install postgresql@14 redis imagemagick libidn` to install required libraries
+- Navigate to Mastodon's root directory and run `brew install nvm` then `nvm use` to use the version from `.nvmrc`
 - Run `corepack enable && corepack prepare`
 - Run `bundle exec rails db:setup` (optionally prepend `RAILS_ENV=development` to target the dev environment)
-- Finally, run `overmind start -f Procfile.dev`
+- Finally, run `bin/dev` which will launch the development server.
 
 ### Docker
 
@@ -108,7 +104,7 @@ For development with **Docker**, complete the following steps:
 - Install Docker Desktop
 - Run `docker compose -f .devcontainer/docker-compose.yml up -d`
 - Run `docker compose -f .devcontainer/docker-compose.yml exec app .devcontainer/post-create.sh`
-- Finally, run `docker compose -f .devcontainer/docker-compose.yml exec app foreman start -f Procfile.dev`
+- Finally, run `docker compose -f .devcontainer/docker-compose.yml exec app bin/dev`
 
 If you are using an IDE with [support for the Development Container specification](https://containers.dev/supporting), it will run the above `docker compose` commands automatically. For **Visual Studio Code** this requires the [Dev Container extension](https://containers.dev/supporting#dev-containers).
 
@@ -119,7 +115,7 @@ To get you coding in just a few minutes, GitHub Codespaces provides a web-based 
 - Click this button to create a new codespace:<br>
   [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=52281283&devcontainer_path=.devcontainer%2Fcodespaces%2Fdevcontainer.json)
 - Wait for the environment to build. This will take a few minutes.
-- When the editor is ready, run `foreman start -f Procfile.dev` in the terminal.
+- When the editor is ready, run `bin/dev` in the terminal.
 - After a few seconds, a popup will appear with a button labeled _Open in Browser_. This will open Mastodon.
 - On the _Ports_ tab, right click on the “stream” row and select _Port visibility_ → _Public_.
 

--- a/README.md
+++ b/README.md
@@ -91,11 +91,11 @@ A **Vagrant** configuration is included for development purposes. To use it, com
 To set up **MacOS** for native development, complete the following steps:
 
 - Use a Ruby version manager to install the specified version from `.ruby-version`
-- Run `brew install postgresql@14 redis imagemagick libidn` to install required libraries
+- Run `brew install postgresql@14 redis imagemagick libidn` to install required dependencies
 - Navigate to Mastodon's root directory and run `brew install nvm` then `nvm use` to use the version from `.nvmrc`
 - Run `corepack enable && corepack prepare`
 - Run `bundle exec rails db:setup` (optionally prepend `RAILS_ENV=development` to target the dev environment)
-- Finally, run `bin/dev` which will launch the local services via `overmind` (if installed) or `foreman`.
+- Finally, run `bin/dev` which will launch the local services via `overmind` (if installed) or `foreman`
 
 ### Docker
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -188,7 +188,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.post_up_message = <<MESSAGE
 To start server
-  $ vagrant ssh -c "cd /vagrant && foreman start"
+  $ vagrant ssh -c "cd /vagrant && bin/dev"
 MESSAGE
 
 end

--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+
+if ! gem list foreman -i --silent; then
+  echo "Installing foreman..."
+  gem install foreman
+fi
+
+# Default to port 3000 if not specified
+export PORT="${PORT:-3000}"
+
+exec foreman start -f Procfile.dev "$@"

--- a/bin/dev
+++ b/bin/dev
@@ -9,7 +9,7 @@ then
   exit $?
 fi
 
-if ! gem list foreman -i --silent; then
+if gem list --no-installed --exact --silent foreman; then
   echo "Installing foreman..."
   gem install foreman
 fi

--- a/bin/dev
+++ b/bin/dev
@@ -1,11 +1,17 @@
 #!/usr/bin/env sh
 
+# Default to port 3000 if not specified
+export PORT="${PORT:-3000}"
+
+if command -v overmind &> /dev/null
+then
+  overmind start -f Procfile.dev "$@"
+  exit $?
+fi
+
 if ! gem list foreman -i --silent; then
   echo "Installing foreman..."
   gem install foreman
 fi
 
-# Default to port 3000 if not specified
-export PORT="${PORT:-3000}"
-
-exec foreman start -f Procfile.dev "$@"
+foreman start -f Procfile.dev "$@"

--- a/bin/dev
+++ b/bin/dev
@@ -3,6 +3,9 @@
 # Default to port 3000 if not specified
 export PORT="${PORT:-3000}"
 
+# Get around our boot.rb ENV check
+export RAILS_ENV="${RAILS_ENV:-development}"
+
 if command -v overmind &> /dev/null
 then
   overmind start -f Procfile.dev "$@"


### PR DESCRIPTION
Extracted from a WIP propshaft/webpack/etc upgrade branch ... just a little wrapper script around using foreman to launch with the Procfile.dev script.

Also noticed some documentation inconsistency with a few places not specifying the Procfile.dev option, and updated those to use the script.