### PR TITLE
Fix flaky tests related to file creation

### DIFF
--- a/spec/generators/post_deployment_migration_generator_spec.rb
+++ b/spec/generators/post_deployment_migration_generator_spec.rb
@@ -12,7 +12,7 @@ describe PostDeploymentMigrationGenerator, type: :generator do
   include FileUtils
 
   tests described_class
-  destination File.expand_path('../../tmp', __dir__)
+  destination Rails.root.join('tmp', 'generator-test')
   before { prepare_destination }
   after { rm_rf(destination_root) }
 

--- a/spec/lib/mastodon/cli/emoji_spec.rb
+++ b/spec/lib/mastodon/cli/emoji_spec.rb
@@ -41,11 +41,17 @@ describe Mastodon::CLI::Emoji do
 
   describe '#export' do
     context 'with existing custom emoji' do
-      before { Fabricate(:custom_emoji) }
-      after { File.delete(export_path) }
+      before do
+        FileUtils.rm_rf(export_path.dirname)
+        FileUtils.mkdir_p(export_path.dirname)
 
-      let(:export_path) { Rails.root.join('tmp', 'export.tar.gz') }
-      let(:args) { [Rails.root.join('tmp')] }
+        Fabricate(:custom_emoji)
+      end
+
+      after { FileUtils.rm_rf(export_path.dirname) }
+
+      let(:export_path) { Rails.root.join('tmp', 'cli-tests', 'export.tar.gz') }
+      let(:args) { [export_path.dirname.to_s] }
       let(:action) { :export }
 
       it 'reports about exported emoji' do


### PR DESCRIPTION
The way the `PostDeploymentMigrationGenerator` spec prepares and cleans up the test environment causes the `tmp` directory to be deleted, while it's relied on by the emoji CLI spec.