### PR TITLE
Change audio volume state when slider moves on audio player

### DIFF
--- a/app/javascript/mastodon/features/audio/index.jsx
+++ b/app/javascript/mastodon/features/audio/index.jsx
@@ -239,6 +239,15 @@ class Audio extends PureComponent {
     });
   };
 
+  _syncAudioToVolumeState = (volume = null, muted = null) => {
+    if (!this.audio) {
+      return;
+    }
+
+    this.audio.volume = volume ?? this.state.volume;
+    this.audio.muted = muted ?? this.state.muted;
+  };
+
   toggleReveal = () => {
     if (this.props.onToggleVisibility) {
       this.props.onToggleVisibility();
@@ -316,6 +325,7 @@ class Audio extends PureComponent {
         if (this.gainNode) {
           this.gainNode.gain.value = this.state.muted ? 0 : x;
         }
+        this._syncAudioToVolumeState(x);
       });
     }
   }, 15);


### PR DESCRIPTION
While trial-and-erroring locally to make sure this didn't break anything - https://github.com/mastodon/mastodon/pull/28217 - I noticed that the AUDIO slider (unrelated to that PR) did not have any effect on the actual volume of the playing audio.

Borrowed/renamed this method from the (working) video version, seems to restore the behavior (moving the volume slider adjusts volume). There are some other differences between the audio/video files that I didn't look at exhaustively, so there could be more things like this, but this is the one I noticed in that testing.