### PR TITLE
Formalize some patterns in cli specs

### DIFF
--- a/spec/lib/mastodon/cli/accounts_spec.rb
+++ b/spec/lib/mastodon/cli/accounts_spec.rb
@@ -49,9 +49,8 @@ describe Mastodon::CLI::Accounts do
       it 'returns "OK" and newly generated password' do
         allow(SecureRandom).to receive(:hex).and_return('test_password')
 
-        expect { subject }.to output(
-          a_string_including("OK\nNew password: test_password")
-        ).to_stdout
+        expect { subject }
+          .to output_results("OK\nNew password: test_password")
       end
     end
 
@@ -67,9 +66,8 @@ describe Mastodon::CLI::Accounts do
           let(:options) { { email: 'invalid' } }
 
           it 'exits with an error message' do
-            expect { subject }.to output(
-              a_string_including('Failure/Error: email')
-            ).to_stdout
+            expect { subject }
+              .to output_results('Failure/Error: email')
               .and raise_error(SystemExit)
           end
         end
@@ -127,9 +125,8 @@ describe Mastodon::CLI::Accounts do
           let(:options) { { email: 'tootctl@example.com', role: '404' } }
 
           it 'exits with an error message indicating the role name was not found' do
-            expect { subject }.to output(
-              a_string_including('Cannot find user role with that name')
-            ).to_stdout
+            expect { subject }
+              .to output_results('Cannot find user role with that name')
               .and raise_error(SystemExit)
           end
         end
@@ -145,9 +142,8 @@ describe Mastodon::CLI::Accounts do
           end
 
           it 'returns an error message indicating the username is already taken' do
-            expect { subject }.to output(
-              a_string_including("The chosen username is currently in use\nUse --force to reattach it anyway and delete the other user")
-            ).to_stdout
+            expect { subject }
+              .to output_results("The chosen username is currently in use\nUse --force to reattach it anyway and delete the other user")
           end
 
           context 'with --force option' do
@@ -192,9 +188,8 @@ describe Mastodon::CLI::Accounts do
       let(:arguments) { ['non_existent_username'] }
 
       it 'exits with an error message indicating the user was not found' do
-        expect { subject }.to output(
-          a_string_including('No user with such username')
-        ).to_stdout
+        expect { subject }
+          .to output_results('No user with such username')
           .and raise_error(SystemExit)
       end
     end
@@ -205,9 +200,8 @@ describe Mastodon::CLI::Accounts do
 
       context 'when no option is provided' do
         it 'returns a successful message' do
-          expect { subject }.to output(
-            a_string_including('OK')
-          ).to_stdout
+          expect { subject }
+            .to output_results('OK')
         end
 
         it 'does not modify the user' do
@@ -222,9 +216,8 @@ describe Mastodon::CLI::Accounts do
           let(:options) { { role: '404' } }
 
           it 'exits with an error message indicating the role was not found' do
-            expect { subject }.to output(
-              a_string_including('Cannot find user role with that name')
-            ).to_stdout
+            expect { subject }
+              .to output_results('Cannot find user role with that name')
               .and raise_error(SystemExit)
           end
         end
@@ -339,9 +332,8 @@ describe Mastodon::CLI::Accounts do
         it 'returns a new password for the user' do
           allow(SecureRandom).to receive(:hex).and_return('new_password')
 
-          expect { subject }.to output(
-            a_string_including('new_password')
-          ).to_stdout
+          expect { subject }
+            .to output_results('new_password')
         end
       end
 
@@ -359,9 +351,8 @@ describe Mastodon::CLI::Accounts do
         let(:options) { { email: 'invalid' } }
 
         it 'exits with an error message' do
-          expect { subject }.to output(
-            a_string_including('Failure/Error: email')
-          ).to_stdout
+          expect { subject }
+            .to output_results('Failure/Error: email')
             .and raise_error(SystemExit)
         end
       end
@@ -371,8 +362,6 @@ describe Mastodon::CLI::Accounts do
   describe '#delete' do
     let(:action) { :delete }
     let(:account) { Fabricate(:account) }
-    let(:arguments) { [account.username] }
-    let(:options) { { email: account.user.email } }
     let(:delete_account_service) { instance_double(DeleteAccountService) }
 
     before do
@@ -381,24 +370,27 @@ describe Mastodon::CLI::Accounts do
     end
 
     context 'when both username and --email are provided' do
+      let(:arguments) { [account.username] }
+      let(:options) { { email: account.user.email } }
+
       it 'exits with an error message indicating that only one should be used' do
-        expect { subject }.to output(
-          a_string_including('Use username or --email, not both')
-        ).to_stdout
+        expect { subject }
+          .to output_results('Use username or --email, not both')
           .and raise_error(SystemExit)
       end
     end
 
     context 'when neither username nor --email are provided' do
       it 'exits with an error message indicating that no username was provided' do
-        expect { subject }.to output(
-          a_string_including('No username provided')
-        ).to_stdout
+        expect { subject }
+          .to output_results('No username provided')
           .and raise_error(SystemExit)
       end
     end
 
     context 'when username is provided' do
+      let(:arguments) { [account.username] }
+
       it 'deletes the specified user successfully' do
         subject
 
@@ -415,9 +407,8 @@ describe Mastodon::CLI::Accounts do
         end
 
         it 'outputs a successful message in dry run mode' do
-          expect { subject }.to output(
-            a_string_including('OK (DRY RUN)')
-          ).to_stdout
+          expect { subject }
+            .to output_results('OK (DRY RUN)')
         end
       end
 
@@ -425,15 +416,16 @@ describe Mastodon::CLI::Accounts do
         let(:arguments) { ['non_existent_username'] }
 
         it 'exits with an error message indicating that no user was found' do
-          expect { subject }.to output(
-            a_string_including('No user with such username')
-          ).to_stdout
+          expect { subject }
+            .to output_results('No user with such username')
             .and raise_error(SystemExit)
         end
       end
     end
 
     context 'when --email is provided' do
+      let(:options) { { email: account.user.email } }
+
       it 'deletes the specified user successfully' do
         subject
 
@@ -450,9 +442,8 @@ describe Mastodon::CLI::Accounts do
         end
 
         it 'outputs a successful message in dry run mode' do
-          expect { subject }.to output(
-            a_string_including('OK (DRY RUN)')
-          ).to_stdout
+          expect { subject }
+            .to output_results('OK (DRY RUN)')
         end
       end
 
@@ -460,9 +451,8 @@ describe Mastodon::CLI::Accounts do
         let(:options) { { email: '404@example.com' } }
 
         it 'exits with an error message indicating that no user was found' do
-          expect { subject }.to output(
-            a_string_including('No user with such email')
-          ).to_stdout
+          expect { subject }
+            .to output_results('No user with such email')
             .and raise_error(SystemExit)
         end
       end
@@ -511,9 +501,8 @@ describe Mastodon::CLI::Accounts do
         let(:options) { { number: -1 } }
 
         it 'exits with an error message indicating that the number must be positive' do
-          expect { subject }.to output(
-            a_string_including('Number must be positive')
-          ).to_stdout
+          expect { subject }
+            .to output_results('Number must be positive')
             .and raise_error(SystemExit)
         end
       end
@@ -550,9 +539,8 @@ describe Mastodon::CLI::Accounts do
         let(:arguments) { ['non_existent_username'] }
 
         it 'exits with an error message indicating that no such account was found' do
-          expect { subject }.to output(
-            a_string_including('No such account')
-          ).to_stdout
+          expect { subject }
+            .to output_results('No such account')
             .and raise_error(SystemExit)
         end
       end
@@ -566,9 +554,8 @@ describe Mastodon::CLI::Accounts do
       let(:arguments) { ['non_existent_username'] }
 
       it 'exits with an error message indicating that no account with the given username was found' do
-        expect { subject }.to output(
-          a_string_including('No such account')
-        ).to_stdout
+        expect { subject }
+          .to output_results('No such account')
           .and raise_error(SystemExit)
       end
     end
@@ -594,9 +581,8 @@ describe Mastodon::CLI::Accounts do
       end
 
       it 'displays a successful message' do
-        expect { cli.follow(target_account.username) }.to output(
-          a_string_including("OK, followed target from #{Account.local.count} accounts")
-        ).to_stdout
+        expect { cli.follow(target_account.username) }
+          .to output_results("OK, followed target from #{Account.local.count} accounts")
       end
     end
   end
@@ -608,9 +594,8 @@ describe Mastodon::CLI::Accounts do
       let(:arguments) { ['non_existent_username'] }
 
       it 'exits with an error message indicating that no account with the given username was found' do
-        expect { subject }.to output(
-          a_string_including('No such account')
-        ).to_stdout
+        expect { subject }
+          .to output_results('No such account')
           .and raise_error(SystemExit)
       end
     end
@@ -638,9 +623,8 @@ describe Mastodon::CLI::Accounts do
       end
 
       it 'displays a successful message' do
-        expect { cli.unfollow(target_account.username) }.to output(
-          a_string_including('OK, unfollowed target from 3 accounts')
-        ).to_stdout
+        expect { cli.unfollow(target_account.username) }
+          .to output_results('OK, unfollowed target from 3 accounts')
       end
     end
   end
@@ -652,9 +636,8 @@ describe Mastodon::CLI::Accounts do
       let(:arguments) { ['non_existent_username'] }
 
       it 'exits with an error message indicating that there is no such account' do
-        expect { subject }.to output(
-          a_string_including('No user with such username')
-        ).to_stdout
+        expect { subject }
+          .to output_results('No user with such username')
           .and raise_error(SystemExit)
       end
     end
@@ -678,9 +661,8 @@ describe Mastodon::CLI::Accounts do
       end
 
       it 'displays a successful message' do
-        expect { subject }.to output(
-          a_string_including('OK')
-        ).to_stdout
+        expect { subject }
+          .to output_results('OK')
       end
     end
   end
@@ -742,9 +724,8 @@ describe Mastodon::CLI::Accounts do
       end
 
       it 'displays a successful message' do
-        expect { cli.refresh }.to output(
-          a_string_including('Refreshed 2 accounts')
-        ).to_stdout
+        expect { cli.refresh }
+          .to output_results('Refreshed 2 accounts')
       end
 
       context 'with --dry-run option' do
@@ -779,9 +760,8 @@ describe Mastodon::CLI::Accounts do
         end
 
         it 'displays a successful message with (DRY RUN)' do
-          expect { cli.refresh }.to output(
-            a_string_including('Refreshed 2 accounts (DRY RUN)')
-          ).to_stdout
+          expect { cli.refresh }
+            .to output_results('Refreshed 2 accounts (DRY RUN)')
         end
       end
     end
@@ -841,9 +821,7 @@ describe Mastodon::CLI::Accounts do
           allow(account_example_com_a).to receive(:reset_avatar!).and_raise(Mastodon::UnexpectedResponseError)
 
           expect { cli.refresh(*arguments) }
-            .to output(
-              a_string_including("Account failed: #{account_example_com_a.username}@#{account_example_com_a.domain}")
-            ).to_stdout
+            .to output_results("Account failed: #{account_example_com_a.username}@#{account_example_com_a.domain}")
         end
       end
 
@@ -851,9 +829,8 @@ describe Mastodon::CLI::Accounts do
         it 'exits with an error message' do
           allow(Account).to receive(:find_remote).with(account_example_com_b.username, account_example_com_b.domain).and_return(nil)
 
-          expect { cli.refresh(*arguments) }.to output(
-            a_string_including('No such account')
-          ).to_stdout
+          expect { cli.refresh(*arguments) }
+            .to output_results('No such account')
             .and raise_error(SystemExit)
         end
       end
@@ -943,9 +920,8 @@ describe Mastodon::CLI::Accounts do
 
     context 'when neither a list of accts nor options are provided' do
       it 'exits with an error message' do
-        expect { cli.refresh }.to output(
-          a_string_including('No account(s) given')
-        ).to_stdout
+        expect { cli.refresh }
+          .to output_results('No account(s) given')
           .and raise_error(SystemExit)
       end
     end
@@ -954,9 +930,8 @@ describe Mastodon::CLI::Accounts do
   describe '#rotate' do
     context 'when neither username nor --all option are given' do
       it 'exits with an error message' do
-        expect { cli.rotate }.to output(
-          a_string_including('No account(s) given')
-        ).to_stdout
+        expect { cli.rotate }
+          .to output_results('No account(s) given')
           .and raise_error(SystemExit)
       end
     end
@@ -985,9 +960,8 @@ describe Mastodon::CLI::Accounts do
 
       context 'when the given username is not found' do
         it 'exits with an error message when the specified username is not found' do
-          expect { cli.rotate('non_existent_username') }.to output(
-            a_string_including('No such account')
-          ).to_stdout
+          expect { cli.rotate('non_existent_username') }
+            .to output_results('No such account')
             .and raise_error(SystemExit)
         end
       end
@@ -1029,9 +1003,8 @@ describe Mastodon::CLI::Accounts do
 
     shared_examples 'an account not found' do |acct|
       it 'exits with an error message indicating that there is no such account' do
-        expect { subject }.to output(
-          a_string_including("No such account (#{acct})")
-        ).to_stdout
+        expect { subject }
+          .to output_results("No such account (#{acct})")
           .and raise_error(SystemExit)
       end
     end
@@ -1081,9 +1054,8 @@ describe Mastodon::CLI::Accounts do
       end
 
       it 'exits with an error message indicating that the accounts do not have the same pub key' do
-        expect { subject }.to output(
-          a_string_including("Accounts don't have the same public key, might not be duplicates!\nOverride with --force")
-        ).to_stdout
+        expect { subject }
+          .to output_results("Accounts don't have the same public key, might not be duplicates!\nOverride with --force")
           .and raise_error(SystemExit)
       end
 
@@ -1178,14 +1150,13 @@ describe Mastodon::CLI::Accounts do
       end
 
       it 'displays the summary correctly' do
-        expect { subject }.to output(
-          a_string_including('Visited 5 accounts, removed 2')
-        ).to_stdout
+        expect { subject }
+          .to output_results('Visited 5 accounts, removed 2')
       end
     end
 
     context 'when a domain is specified' do
-      let(:arguments) { 'example.net' }
+      let(:arguments) { ['example.net'] }
 
       before do
         stub_parallelize_with_progress!
@@ -1201,9 +1172,8 @@ describe Mastodon::CLI::Accounts do
       end
 
       it 'displays the summary correctly' do
-        expect { subject }.to output(
-          a_string_including('Visited 2 accounts, removed 2')
-        ).to_stdout
+        expect { subject }
+          .to output_results('Visited 2 accounts, removed 2')
       end
     end
 
@@ -1222,9 +1192,8 @@ describe Mastodon::CLI::Accounts do
         end
 
         it 'displays the summary correctly' do
-          expect { subject }.to output(
-            a_string_including("Visited 5 accounts, removed 0\nThe following domains were not available during the check:\n    example.net")
-          ).to_stdout
+          expect { subject }
+            .to output_results("Visited 5 accounts, removed 0\nThe following domains were not available during the check:\n    example.net")
         end
       end
 
@@ -1269,9 +1238,8 @@ describe Mastodon::CLI::Accounts do
 
     context 'when no option is given' do
       it 'exits with an error message indicating that at least one option is required' do
-        expect { subject }.to output(
-          a_string_including('Please specify either --follows or --followers, or both')
-        ).to_stdout
+        expect { subject }
+          .to output_results('Please specify either --follows or --followers, or both')
           .and raise_error(SystemExit)
       end
     end
@@ -1281,9 +1249,8 @@ describe Mastodon::CLI::Accounts do
       let(:options) { { follows: true } }
 
       it 'exits with an error message indicating that there is no such account' do
-        expect { subject }.to output(
-          a_string_including('No such account')
-        ).to_stdout
+        expect { subject }
+          .to output_results('No such account')
           .and raise_error(SystemExit)
       end
     end
@@ -1314,9 +1281,8 @@ describe Mastodon::CLI::Accounts do
         end
 
         it 'displays a successful message' do
-          expect { subject }.to output(
-            a_string_including("Processed #{total_relationships} relationships")
-          ).to_stdout
+          expect { subject }
+            .to output_results("Processed #{total_relationships} relationships")
         end
       end
 
@@ -1334,9 +1300,8 @@ describe Mastodon::CLI::Accounts do
         end
 
         it 'displays a successful message' do
-          expect { subject }.to output(
-            a_string_including("Processed #{total_relationships} relationships")
-          ).to_stdout
+          expect { subject }
+            .to output_results("Processed #{total_relationships} relationships")
         end
       end
 
@@ -1369,9 +1334,8 @@ describe Mastodon::CLI::Accounts do
         end
 
         it 'displays a successful message' do
-          expect { subject }.to output(
-            a_string_including("Processed #{total_relationships} relationships")
-          ).to_stdout
+          expect { subject }
+            .to output_results("Processed #{total_relationships} relationships")
         end
       end
     end
@@ -1400,9 +1364,8 @@ describe Mastodon::CLI::Accounts do
     end
 
     it 'displays a successful message' do
-      expect { cli.prune }.to output(
-        a_string_including("OK, pruned #{prunable_accounts.size} accounts")
-      ).to_stdout
+      expect { cli.prune }
+        .to output_results("OK, pruned #{prunable_accounts.size} accounts")
     end
 
     it 'does not prune local accounts' do
@@ -1443,9 +1406,8 @@ describe Mastodon::CLI::Accounts do
       end
 
       it 'displays a successful message with (DRY RUN)' do
-        expect { cli.prune }.to output(
-          a_string_including("OK, pruned #{prunable_accounts.size} accounts (DRY RUN)")
-        ).to_stdout
+        expect { cli.prune }
+          .to output_results("OK, pruned #{prunable_accounts.size} accounts (DRY RUN)")
       end
     end
   end
@@ -1473,9 +1435,8 @@ describe Mastodon::CLI::Accounts do
       end
 
       it 'displays a successful message' do
-        expect { subject }.to output(
-          a_string_including("OK, migrated #{source_account.acct} to #{target_account.acct}")
-        ).to_stdout
+        expect { subject }
+          .to output_results("OK, migrated #{source_account.acct} to #{target_account.acct}")
       end
     end
 
@@ -1483,18 +1444,16 @@ describe Mastodon::CLI::Accounts do
       let(:options) { { replay: true, target: "#{target_account.username}@example.com" } }
 
       it 'exits with an error message indicating that using both options is not possible' do
-        expect { subject }.to output(
-          a_string_including('Use --replay or --target, not both')
-        ).to_stdout
+        expect { subject }
+          .to output_results('Use --replay or --target, not both')
           .and raise_error(SystemExit)
       end
     end
 
     context 'when no option is given' do
       it 'exits with an error message indicating that at least one option must be used' do
-        expect { subject }.to output(
-          a_string_including('Use either --replay or --target')
-        ).to_stdout
+        expect { subject }
+          .to output_results('Use either --replay or --target')
           .and raise_error(SystemExit)
       end
     end
@@ -1504,9 +1463,8 @@ describe Mastodon::CLI::Accounts do
       let(:options) { { replay: true } }
 
       it 'exits with an error message indicating that there is no such account' do
-        expect { subject }.to output(
-          a_string_including("No such account: #{arguments.first}")
-        ).to_stdout
+        expect { subject }
+          .to output_results("No such account: #{arguments.first}")
           .and raise_error(SystemExit)
       end
     end
@@ -1516,9 +1474,8 @@ describe Mastodon::CLI::Accounts do
 
       context 'when the specified account has no previous migrations' do
         it 'exits with an error message indicating that the given account has no previous migrations' do
-          expect { subject }.to output(
-            a_string_including('The specified account has not performed any migration')
-          ).to_stdout
+          expect { subject }
+            .to output_results('The specified account has not performed any migration')
             .and raise_error(SystemExit)
         end
       end
@@ -1540,9 +1497,8 @@ describe Mastodon::CLI::Accounts do
           end
 
           it 'exits with an error message' do
-            expect { subject }.to output(
-              a_string_including('The specified account is not redirecting to its last migration target. Use --force if you want to replay the migration anyway')
-            ).to_stdout
+            expect { subject }
+              .to output_results('The specified account is not redirecting to its last migration target. Use --force if you want to replay the migration anyway')
               .and raise_error(SystemExit)
           end
         end
@@ -1569,9 +1525,8 @@ describe Mastodon::CLI::Accounts do
         end
 
         it 'exits with an error message indicating that there is no such account' do
-          expect { subject }.to output(
-            a_string_including("The specified target account could not be found: #{options[:target]}")
-          ).to_stdout
+          expect { subject }
+            .to output_results("The specified target account could not be found: #{options[:target]}")
             .and raise_error(SystemExit)
         end
       end
@@ -1594,9 +1549,8 @@ describe Mastodon::CLI::Accounts do
 
       context 'when the migration record is invalid' do
         it 'exits with an error indicating that the validation failed' do
-          expect { subject }.to output(
-            a_string_including('Error: Validation failed')
-          ).to_stdout
+          expect { subject }
+            .to output_results('Error: Validation failed')
             .and raise_error(SystemExit)
         end
       end
@@ -1607,9 +1561,8 @@ describe Mastodon::CLI::Accounts do
         end
 
         it 'exits with an error message' do
-          expect { subject }.to output(
-            a_string_including('The specified account is redirecting to a different target account. Use --force if you want to change the migration target')
-          ).to_stdout
+          expect { subject }
+            .to output_results('The specified account is redirecting to a different target account. Use --force if you want to change the migration target')
             .and raise_error(SystemExit)
         end
       end

--- a/spec/lib/mastodon/cli/cache_spec.rb
+++ b/spec/lib/mastodon/cli/cache_spec.rb
@@ -4,15 +4,21 @@ require 'rails_helper'
 require 'mastodon/cli/cache'
 
 describe Mastodon::CLI::Cache do
+  subject { cli.invoke(action, arguments, options) }
+
   let(:cli) { described_class.new }
+  let(:arguments) { [] }
+  let(:options) { {} }
 
   it_behaves_like 'CLI Command'
 
   describe '#clear' do
+    let(:action) { :clear }
+
     before { allow(Rails.cache).to receive(:clear) }
 
     it 'clears the Rails cache' do
-      expect { cli.invoke(:clear) }.to output(
+      expect { subject }.to output(
         a_string_including('OK')
       ).to_stdout
       expect(Rails.cache).to have_received(:clear)
@@ -20,6 +26,8 @@ describe Mastodon::CLI::Cache do
   end
 
   describe '#recount' do
+    let(:action) { :recount }
+
     context 'with the `accounts` argument' do
       let(:arguments) { ['accounts'] }
       let(:account_stat) { Fabricate(:account_stat) }
@@ -29,7 +37,7 @@ describe Mastodon::CLI::Cache do
       end
 
       it 're-calculates account records in the cache' do
-        expect { cli.invoke(:recount, arguments) }.to output(
+        expect { subject }.to output(
           a_string_including('OK')
         ).to_stdout
 
@@ -46,7 +54,7 @@ describe Mastodon::CLI::Cache do
       end
 
       it 're-calculates account records in the cache' do
-        expect { cli.invoke(:recount, arguments) }.to output(
+        expect { subject }.to output(
           a_string_including('OK')
         ).to_stdout
 
@@ -58,7 +66,7 @@ describe Mastodon::CLI::Cache do
       let(:arguments) { ['other-type'] }
 
       it 'Exits with an error message' do
-        expect { cli.invoke(:recount, arguments) }.to output(
+        expect { subject }.to output(
           a_string_including('Unknown')
         ).to_stdout.and raise_error(SystemExit)
       end

--- a/spec/lib/mastodon/cli/cache_spec.rb
+++ b/spec/lib/mastodon/cli/cache_spec.rb
@@ -18,9 +18,8 @@ describe Mastodon::CLI::Cache do
     before { allow(Rails.cache).to receive(:clear) }
 
     it 'clears the Rails cache' do
-      expect { subject }.to output(
-        a_string_including('OK')
-      ).to_stdout
+      expect { subject }
+        .to output_results('OK')
       expect(Rails.cache).to have_received(:clear)
     end
   end
@@ -37,9 +36,8 @@ describe Mastodon::CLI::Cache do
       end
 
       it 're-calculates account records in the cache' do
-        expect { subject }.to output(
-          a_string_including('OK')
-        ).to_stdout
+        expect { subject }
+          .to output_results('OK')
 
         expect(account_stat.reload.statuses_count).to be_zero
       end
@@ -54,9 +52,8 @@ describe Mastodon::CLI::Cache do
       end
 
       it 're-calculates account records in the cache' do
-        expect { subject }.to output(
-          a_string_including('OK')
-        ).to_stdout
+        expect { subject }
+          .to output_results('OK')
 
         expect(status_stat.reload.replies_count).to be_zero
       end
@@ -66,9 +63,9 @@ describe Mastodon::CLI::Cache do
       let(:arguments) { ['other-type'] }
 
       it 'Exits with an error message' do
-        expect { subject }.to output(
-          a_string_including('Unknown')
-        ).to_stdout.and raise_error(SystemExit)
+        expect { subject }
+          .to output_results('Unknown')
+          .and raise_error(SystemExit)
       end
     end
   end

--- a/spec/lib/mastodon/cli/canonical_email_blocks_spec.rb
+++ b/spec/lib/mastodon/cli/canonical_email_blocks_spec.rb
@@ -20,17 +20,15 @@ describe Mastodon::CLI::CanonicalEmailBlocks do
       before { Fabricate(:canonical_email_block, email: 'user@example.com') }
 
       it 'announces the presence of the block' do
-        expect { subject }.to output(
-          a_string_including('user@example.com is blocked')
-        ).to_stdout
+        expect { subject }
+          .to output_results('user@example.com is blocked')
       end
     end
 
     context 'when a block is not present' do
       it 'announces the absence of the block' do
-        expect { subject }.to output(
-          a_string_including('user@example.com is not blocked')
-        ).to_stdout
+        expect { subject }
+          .to output_results('user@example.com is not blocked')
       end
     end
   end
@@ -43,9 +41,8 @@ describe Mastodon::CLI::CanonicalEmailBlocks do
       before { Fabricate(:canonical_email_block, email: 'user@example.com') }
 
       it 'removes the block' do
-        expect { subject }.to output(
-          a_string_including('Unblocked user@example.com')
-        ).to_stdout
+        expect { subject }
+          .to output_results('Unblocked user@example.com')
 
         expect(CanonicalEmailBlock.matching_email('user@example.com')).to be_empty
       end
@@ -53,9 +50,8 @@ describe Mastodon::CLI::CanonicalEmailBlocks do
 
     context 'when a block is not present' do
       it 'announces the absence of the block' do
-        expect { subject }.to output(
-          a_string_including('user@example.com is not blocked')
-        ).to_stdout
+        expect { subject }
+          .to output_results('user@example.com is not blocked')
       end
     end
   end

--- a/spec/lib/mastodon/cli/canonical_email_blocks_spec.rb
+++ b/spec/lib/mastodon/cli/canonical_email_blocks_spec.rb
@@ -4,18 +4,23 @@ require 'rails_helper'
 require 'mastodon/cli/canonical_email_blocks'
 
 describe Mastodon::CLI::CanonicalEmailBlocks do
+  subject { cli.invoke(action, arguments, options) }
+
   let(:cli) { described_class.new }
+  let(:arguments) { [] }
+  let(:options) { {} }
 
   it_behaves_like 'CLI Command'
 
   describe '#find' do
+    let(:action) { :find }
     let(:arguments) { ['user@example.com'] }
 
     context 'when a block is present' do
       before { Fabricate(:canonical_email_block, email: 'user@example.com') }
 
       it 'announces the presence of the block' do
-        expect { cli.invoke(:find, arguments) }.to output(
+        expect { subject }.to output(
           a_string_including('user@example.com is blocked')
         ).to_stdout
       end
@@ -23,7 +28,7 @@ describe Mastodon::CLI::CanonicalEmailBlocks do
 
     context 'when a block is not present' do
       it 'announces the absence of the block' do
-        expect { cli.invoke(:find, arguments) }.to output(
+        expect { subject }.to output(
           a_string_including('user@example.com is not blocked')
         ).to_stdout
       end
@@ -31,13 +36,14 @@ describe Mastodon::CLI::CanonicalEmailBlocks do
   end
 
   describe '#remove' do
+    let(:action) { :remove }
     let(:arguments) { ['user@example.com'] }
 
     context 'when a block is present' do
       before { Fabricate(:canonical_email_block, email: 'user@example.com') }
 
       it 'removes the block' do
-        expect { cli.invoke(:remove, arguments) }.to output(
+        expect { subject }.to output(
           a_string_including('Unblocked user@example.com')
         ).to_stdout
 
@@ -47,7 +53,7 @@ describe Mastodon::CLI::CanonicalEmailBlocks do
 
     context 'when a block is not present' do
       it 'announces the absence of the block' do
-        expect { cli.invoke(:remove, arguments) }.to output(
+        expect { subject }.to output(
           a_string_including('user@example.com is not blocked')
         ).to_stdout
       end

--- a/spec/lib/mastodon/cli/domains_spec.rb
+++ b/spec/lib/mastodon/cli/domains_spec.rb
@@ -4,18 +4,24 @@ require 'rails_helper'
 require 'mastodon/cli/domains'
 
 describe Mastodon::CLI::Domains do
+  subject { cli.invoke(action, arguments, options) }
+
   let(:cli) { described_class.new }
+  let(:arguments) { [] }
+  let(:options) { {} }
 
   it_behaves_like 'CLI Command'
 
   describe '#purge' do
+    let(:action) { :purge }
+
     context 'with accounts from the domain' do
-      let(:options) { {} }
       let(:domain) { 'host.example' }
       let!(:account) { Fabricate(:account, domain: domain) }
+      let(:arguments) { [domain] }
 
       it 'removes the account' do
-        expect { cli.invoke(:purge, [domain], options) }.to output(
+        expect { subject }.to output(
           a_string_including('Removed 1 accounts')
         ).to_stdout
         expect { account.reload }.to raise_error(ActiveRecord::RecordNotFound)

--- a/spec/lib/mastodon/cli/domains_spec.rb
+++ b/spec/lib/mastodon/cli/domains_spec.rb
@@ -21,9 +21,9 @@ describe Mastodon::CLI::Domains do
       let(:arguments) { [domain] }
 
       it 'removes the account' do
-        expect { subject }.to output(
-          a_string_including('Removed 1 accounts')
-        ).to_stdout
+        expect { subject }
+          .to output_results('Removed 1 accounts')
+
         expect { account.reload }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end

--- a/spec/lib/mastodon/cli/email_domain_blocks_spec.rb
+++ b/spec/lib/mastodon/cli/email_domain_blocks_spec.rb
@@ -4,18 +4,23 @@ require 'rails_helper'
 require 'mastodon/cli/email_domain_blocks'
 
 describe Mastodon::CLI::EmailDomainBlocks do
+  subject { cli.invoke(action, arguments, options) }
+
   let(:cli) { described_class.new }
+  let(:arguments) { [] }
+  let(:options) { {} }
 
   it_behaves_like 'CLI Command'
 
   describe '#list' do
+    let(:action) { :list }
+
     context 'with email domain block records' do
       let!(:parent_block) { Fabricate(:email_domain_block) }
       let!(:child_block) { Fabricate(:email_domain_block, parent: parent_block) }
-      let(:options) { {} }
 
       it 'lists the blocks' do
-        expect { cli.invoke(:list, [], options) }.to output(
+        expect { subject }.to output(
           a_string_including(parent_block.domain)
           .and(a_string_including(child_block.domain))
         ).to_stdout
@@ -24,11 +29,11 @@ describe Mastodon::CLI::EmailDomainBlocks do
   end
 
   describe '#add' do
-    context 'without any options' do
-      let(:options) { {} }
+    let(:action) { :add }
 
+    context 'without any options' do
       it 'warns about usage and exits' do
-        expect { cli.invoke(:add, [], options) }.to output(
+        expect { subject }.to output(
           a_string_including('No domain(s) given')
         ).to_stdout.and raise_error(SystemExit)
       end
@@ -37,11 +42,12 @@ describe Mastodon::CLI::EmailDomainBlocks do
     context 'when blocks exist' do
       let(:options) { {} }
       let(:domain) { 'host.example' }
+      let(:arguments) { [domain] }
 
       before { Fabricate(:email_domain_block, domain: domain) }
 
       it 'does not add a new block' do
-        expect { cli.invoke(:add, [domain], options) }.to output(
+        expect { subject }.to output(
           a_string_including('is already blocked')
         ).to_stdout
           .and(not_change(EmailDomainBlock, :count))
@@ -49,11 +55,11 @@ describe Mastodon::CLI::EmailDomainBlocks do
     end
 
     context 'when no blocks exist' do
-      let(:options) { {} }
       let(:domain) { 'host.example' }
+      let(:arguments) { [domain] }
 
       it 'adds a new block' do
-        expect { cli.invoke(:add, [domain], options) }.to output(
+        expect { subject }.to output(
           a_string_including('Added 1')
         ).to_stdout
           .and(change(EmailDomainBlock, :count).by(1))
@@ -62,24 +68,24 @@ describe Mastodon::CLI::EmailDomainBlocks do
   end
 
   describe '#remove' do
-    context 'without any options' do
-      let(:options) { {} }
+    let(:action) { :remove }
 
+    context 'without any options' do
       it 'warns about usage and exits' do
-        expect { cli.invoke(:remove, [], options) }.to output(
+        expect { subject }.to output(
           a_string_including('No domain(s) given')
         ).to_stdout.and raise_error(SystemExit)
       end
     end
 
     context 'when blocks exist' do
-      let(:options) { {} }
       let(:domain) { 'host.example' }
+      let(:arguments) { [domain] }
 
       before { Fabricate(:email_domain_block, domain: domain) }
 
       it 'removes the block' do
-        expect { cli.invoke(:remove, [domain], options) }.to output(
+        expect { subject }.to output(
           a_string_including('Removed 1')
         ).to_stdout
           .and(change(EmailDomainBlock, :count).by(-1))
@@ -87,11 +93,11 @@ describe Mastodon::CLI::EmailDomainBlocks do
     end
 
     context 'when no blocks exist' do
-      let(:options) { {} }
       let(:domain) { 'host.example' }
+      let(:arguments) { [domain] }
 
       it 'does not remove a block' do
-        expect { cli.invoke(:remove, [domain], options) }.to output(
+        expect { subject }.to output(
           a_string_including('is not yet blocked')
         ).to_stdout
           .and(not_change(EmailDomainBlock, :count))

--- a/spec/lib/mastodon/cli/email_domain_blocks_spec.rb
+++ b/spec/lib/mastodon/cli/email_domain_blocks_spec.rb
@@ -20,10 +20,11 @@ describe Mastodon::CLI::EmailDomainBlocks do
       let!(:child_block) { Fabricate(:email_domain_block, parent: parent_block) }
 
       it 'lists the blocks' do
-        expect { subject }.to output(
-          a_string_including(parent_block.domain)
-          .and(a_string_including(child_block.domain))
-        ).to_stdout
+        expect { subject }
+          .to output_results(
+            parent_block.domain,
+            child_block.domain
+          )
       end
     end
   end
@@ -33,9 +34,9 @@ describe Mastodon::CLI::EmailDomainBlocks do
 
     context 'without any options' do
       it 'warns about usage and exits' do
-        expect { subject }.to output(
-          a_string_including('No domain(s) given')
-        ).to_stdout.and raise_error(SystemExit)
+        expect { subject }
+          .to output_results('No domain(s) given')
+          .and raise_error(SystemExit)
       end
     end
 
@@ -47,9 +48,8 @@ describe Mastodon::CLI::EmailDomainBlocks do
       before { Fabricate(:email_domain_block, domain: domain) }
 
       it 'does not add a new block' do
-        expect { subject }.to output(
-          a_string_including('is already blocked')
-        ).to_stdout
+        expect { subject }
+          .to output_results('is already blocked')
           .and(not_change(EmailDomainBlock, :count))
       end
     end
@@ -59,9 +59,8 @@ describe Mastodon::CLI::EmailDomainBlocks do
       let(:arguments) { [domain] }
 
       it 'adds a new block' do
-        expect { subject }.to output(
-          a_string_including('Added 1')
-        ).to_stdout
+        expect { subject }
+          .to output_results('Added 1')
           .and(change(EmailDomainBlock, :count).by(1))
       end
     end
@@ -72,9 +71,9 @@ describe Mastodon::CLI::EmailDomainBlocks do
 
     context 'without any options' do
       it 'warns about usage and exits' do
-        expect { subject }.to output(
-          a_string_including('No domain(s) given')
-        ).to_stdout.and raise_error(SystemExit)
+        expect { subject }
+          .to output_results('No domain(s) given')
+          .and raise_error(SystemExit)
       end
     end
 
@@ -85,9 +84,8 @@ describe Mastodon::CLI::EmailDomainBlocks do
       before { Fabricate(:email_domain_block, domain: domain) }
 
       it 'removes the block' do
-        expect { subject }.to output(
-          a_string_including('Removed 1')
-        ).to_stdout
+        expect { subject }
+          .to output_results('Removed 1')
           .and(change(EmailDomainBlock, :count).by(-1))
       end
     end
@@ -97,9 +95,8 @@ describe Mastodon::CLI::EmailDomainBlocks do
       let(:arguments) { [domain] }
 
       it 'does not remove a block' do
-        expect { subject }.to output(
-          a_string_including('is not yet blocked')
-        ).to_stdout
+        expect { subject }
+          .to output_results('is not yet blocked')
           .and(not_change(EmailDomainBlock, :count))
       end
     end

--- a/spec/lib/mastodon/cli/emoji_spec.rb
+++ b/spec/lib/mastodon/cli/emoji_spec.rb
@@ -4,10 +4,10 @@ require 'rails_helper'
 require 'mastodon/cli/emoji'
 
 describe Mastodon::CLI::Emoji do
-  subject { cli.invoke(action, args, options) }
+  subject { cli.invoke(action, arguments, options) }
 
   let(:cli) { described_class.new }
-  let(:args) { [] }
+  let(:arguments) { [] }
   let(:options) { {} }
 
   it_behaves_like 'CLI Command'
@@ -29,7 +29,7 @@ describe Mastodon::CLI::Emoji do
     context 'with existing custom emoji' do
       let(:import_path) { Rails.root.join('spec', 'fixtures', 'files', 'elite-assets.tar.gz') }
       let(:action) { :import }
-      let(:args) { [import_path] }
+      let(:arguments) { [import_path] }
 
       it 'reports about imported emoji' do
         expect { subject }
@@ -51,7 +51,7 @@ describe Mastodon::CLI::Emoji do
       after { FileUtils.rm_rf(export_path.dirname) }
 
       let(:export_path) { Rails.root.join('tmp', 'cli-tests', 'export.tar.gz') }
-      let(:args) { [export_path.dirname.to_s] }
+      let(:arguments) { [export_path.dirname.to_s] }
       let(:action) { :export }
 
       it 'reports about exported emoji' do

--- a/spec/lib/mastodon/cli/emoji_spec.rb
+++ b/spec/lib/mastodon/cli/emoji_spec.rb
@@ -61,8 +61,4 @@ describe Mastodon::CLI::Emoji do
       end
     end
   end
-
-  def output_results(string)
-    output(a_string_including(string)).to_stdout
-  end
 end

--- a/spec/lib/mastodon/cli/feeds_spec.rb
+++ b/spec/lib/mastodon/cli/feeds_spec.rb
@@ -21,9 +21,8 @@ describe Mastodon::CLI::Feeds do
       let(:options) { { all: true } }
 
       it 'regenerates feeds for all accounts' do
-        expect { subject }.to output(
-          a_string_including('Regenerated feeds')
-        ).to_stdout
+        expect { subject }
+          .to output_results('Regenerated feeds')
       end
     end
 
@@ -33,9 +32,8 @@ describe Mastodon::CLI::Feeds do
       let(:arguments) { ['alice'] }
 
       it 'regenerates feeds for the account' do
-        expect { subject }.to output(
-          a_string_including('OK')
-        ).to_stdout
+        expect { subject }
+          .to output_results('OK')
       end
     end
 
@@ -43,9 +41,9 @@ describe Mastodon::CLI::Feeds do
       let(:arguments) { ['invalid-username'] }
 
       it 'displays an error and exits' do
-        expect { subject }.to output(
-          a_string_including('No such account')
-        ).to_stdout.and raise_error(SystemExit)
+        expect { subject }
+          .to output_results('No such account')
+          .and raise_error(SystemExit)
       end
     end
   end
@@ -58,9 +56,8 @@ describe Mastodon::CLI::Feeds do
     end
 
     it 'clears the redis `feed:*` namespace' do
-      expect { subject }.to output(
-        a_string_including('OK')
-      ).to_stdout
+      expect { subject }
+        .to output_results('OK')
 
       expect(redis).to have_received(:del).with(key_namespace).once
     end

--- a/spec/lib/mastodon/cli/feeds_spec.rb
+++ b/spec/lib/mastodon/cli/feeds_spec.rb
@@ -4,18 +4,24 @@ require 'rails_helper'
 require 'mastodon/cli/feeds'
 
 describe Mastodon::CLI::Feeds do
+  subject { cli.invoke(action, arguments, options) }
+
   let(:cli) { described_class.new }
+  let(:arguments) { [] }
+  let(:options) { {} }
 
   it_behaves_like 'CLI Command'
 
   describe '#build' do
+    let(:action) { :build }
+
     before { Fabricate(:account) }
 
     context 'with --all option' do
       let(:options) { { all: true } }
 
       it 'regenerates feeds for all accounts' do
-        expect { cli.invoke(:build, [], options) }.to output(
+        expect { subject }.to output(
           a_string_including('Regenerated feeds')
         ).to_stdout
       end
@@ -27,7 +33,7 @@ describe Mastodon::CLI::Feeds do
       let(:arguments) { ['alice'] }
 
       it 'regenerates feeds for the account' do
-        expect { cli.invoke(:build, arguments) }.to output(
+        expect { subject }.to output(
           a_string_including('OK')
         ).to_stdout
       end
@@ -37,7 +43,7 @@ describe Mastodon::CLI::Feeds do
       let(:arguments) { ['invalid-username'] }
 
       it 'displays an error and exits' do
-        expect { cli.invoke(:build, arguments) }.to output(
+        expect { subject }.to output(
           a_string_including('No such account')
         ).to_stdout.and raise_error(SystemExit)
       end
@@ -45,12 +51,14 @@ describe Mastodon::CLI::Feeds do
   end
 
   describe '#clear' do
+    let(:action) { :clear }
+
     before do
       allow(redis).to receive(:del).with(key_namespace)
     end
 
     it 'clears the redis `feed:*` namespace' do
-      expect { cli.invoke(:clear) }.to output(
+      expect { subject }.to output(
         a_string_including('OK')
       ).to_stdout
 

--- a/spec/lib/mastodon/cli/ip_blocks_spec.rb
+++ b/spec/lib/mastodon/cli/ip_blocks_spec.rb
@@ -287,7 +287,7 @@ describe Mastodon::CLI::IpBlocks do
 
     context 'when --format option is not provided' do
       it 'exports blocked IPs in plain format by default' do
-        expect { cli.export }
+        expect { subject }
           .to output_results("#{first_ip_range_block.ip}/#{first_ip_range_block.ip.prefix}\n#{second_ip_range_block.ip}/#{second_ip_range_block.ip.prefix}")
       end
     end

--- a/spec/lib/mastodon/cli/ip_blocks_spec.rb
+++ b/spec/lib/mastodon/cli/ip_blocks_spec.rb
@@ -4,11 +4,16 @@ require 'rails_helper'
 require 'mastodon/cli/ip_blocks'
 
 describe Mastodon::CLI::IpBlocks do
+  subject { cli.invoke(action, arguments, options) }
+
   let(:cli) { described_class.new }
+  let(:arguments) { [] }
+  let(:options) { {} }
 
   it_behaves_like 'CLI Command'
 
   describe '#add' do
+    let(:action) { :add }
     let(:ip_list) do
       [
         '192.0.2.1',
@@ -25,10 +30,11 @@ describe Mastodon::CLI::IpBlocks do
       ]
     end
     let(:options) { { severity: 'no_access' } }
+    let(:arguments) { ip_list }
 
     shared_examples 'ip address blocking' do
       it 'blocks all specified IP addresses' do
-        cli.invoke(:add, ip_list, options)
+        subject
 
         blocked_ip_addresses = IpBlock.where(ip: ip_list).pluck(:ip)
         expected_ip_addresses = ip_list.map { |ip| IPAddr.new(ip) }
@@ -37,7 +43,7 @@ describe Mastodon::CLI::IpBlocks do
       end
 
       it 'sets the severity for all blocked IP addresses' do
-        cli.invoke(:add, ip_list, options)
+        subject
 
         blocked_ips_severity = IpBlock.where(ip: ip_list).pluck(:severity).all?(options[:severity])
 
@@ -45,7 +51,7 @@ describe Mastodon::CLI::IpBlocks do
       end
 
       it 'displays a success message with a summary' do
-        expect { cli.invoke(:add, ip_list, options) }.to output(
+        expect { subject }.to output(
           a_string_including("Added #{ip_list.size}, skipped 0, failed 0")
         ).to_stdout
       end
@@ -57,17 +63,18 @@ describe Mastodon::CLI::IpBlocks do
 
     context 'when a specified IP address is already blocked' do
       let!(:blocked_ip) { IpBlock.create(ip: ip_list.last, severity: options[:severity]) }
+      let(:arguments) { ip_list }
 
       it 'skips the already blocked IP address' do
         allow(IpBlock).to receive(:new).and_call_original
 
-        cli.invoke(:add, ip_list, options)
+        subject
 
         expect(IpBlock).to_not have_received(:new).with(ip: ip_list.last)
       end
 
       it 'displays the correct summary' do
-        expect { cli.invoke(:add, ip_list, options) }.to output(
+        expect { subject }.to output(
           a_string_including("#{ip_list.last} is already blocked\nAdded #{ip_list.size - 1}, skipped 1, failed 0")
         ).to_stdout
       end
@@ -77,7 +84,7 @@ describe Mastodon::CLI::IpBlocks do
         let(:options) { { severity: 'sign_up_requires_approval', force: true } }
 
         it 'overwrites the existing IP block record' do
-          expect { cli.invoke(:add, ip_list, options) }
+          expect { subject }
             .to change { blocked_ip.reload.severity }
             .from('no_access')
             .to('sign_up_requires_approval')
@@ -89,9 +96,10 @@ describe Mastodon::CLI::IpBlocks do
 
     context 'when a specified IP address is invalid' do
       let(:ip_list) { ['320.15.175.0', '9.5.105.255', '0.0.0.0'] }
+      let(:arguments) { ip_list }
 
       it 'displays the correct summary' do
-        expect { cli.invoke(:add, ip_list, options) }.to output(
+        expect { subject }.to output(
           a_string_including("#{ip_list.first} is invalid\nAdded #{ip_list.size - 1}, skipped 0, failed 1")
         ).to_stdout
       end
@@ -124,6 +132,7 @@ describe Mastodon::CLI::IpBlocks do
     context 'when a specified IP address fails to be blocked' do
       let(:ip_address) { '127.0.0.1' }
       let(:ip_block) { instance_double(IpBlock, ip: ip_address, save: false) }
+      let(:arguments) { [ip_address] }
 
       before do
         allow(IpBlock).to receive(:new).and_return(ip_block)
@@ -132,7 +141,7 @@ describe Mastodon::CLI::IpBlocks do
       end
 
       it 'displays an error message' do
-        expect { cli.invoke(:add, [ip_address], options) }
+        expect { subject }
           .to output(
             a_string_including("#{ip_address} could not be saved")
           ).to_stdout
@@ -140,8 +149,10 @@ describe Mastodon::CLI::IpBlocks do
     end
 
     context 'when no IP address is provided' do
+      let(:arguments) { [] }
+
       it 'exits with an error message' do
-        expect { cli.add }.to output(
+        expect { subject }.to output(
           a_string_including('No IP(s) given')
         ).to_stdout
           .and raise_error(SystemExit)
@@ -150,6 +161,8 @@ describe Mastodon::CLI::IpBlocks do
   end
 
   describe '#remove' do
+    let(:action) { :remove }
+
     context 'when removing exact matches' do
       let(:ip_list) do
         [
@@ -166,19 +179,20 @@ describe Mastodon::CLI::IpBlocks do
           '::/128',
         ]
       end
+      let(:arguments) { ip_list }
 
       before do
         ip_list.each { |ip| IpBlock.create(ip: ip, severity: :no_access) }
       end
 
       it 'removes exact IP blocks' do
-        cli.invoke(:remove, ip_list)
+        subject
 
         expect(IpBlock.where(ip: ip_list)).to_not exist
       end
 
       it 'displays success message with a summary' do
-        expect { cli.invoke(:remove, ip_list) }.to output(
+        expect { subject }.to output(
           a_string_including("Removed #{ip_list.size}, skipped 0")
         ).to_stdout
       end
@@ -192,13 +206,13 @@ describe Mastodon::CLI::IpBlocks do
       let(:options) { { force: true } }
 
       it 'removes blocks for IP ranges that cover given IP(s)' do
-        cli.invoke(:remove, arguments, options)
+        subject
 
         expect(IpBlock.where(id: [first_ip_range_block.id, second_ip_range_block.id])).to_not exist
       end
 
       it 'does not remove other IP ranges' do
-        cli.invoke(:remove, arguments, options)
+        subject
 
         expect(IpBlock.where(id: third_ip_range_block.id)).to exist
       end
@@ -206,15 +220,16 @@ describe Mastodon::CLI::IpBlocks do
 
     context 'when a specified IP address is not blocked' do
       let(:unblocked_ip) { '192.0.2.1' }
+      let(:arguments) { [unblocked_ip] }
 
       it 'skips the IP address' do
-        expect { cli.invoke(:remove, [unblocked_ip]) }.to output(
+        expect { subject }.to output(
           a_string_including("#{unblocked_ip} is not yet blocked")
         ).to_stdout
       end
 
       it 'displays the summary correctly' do
-        expect { cli.invoke(:remove, [unblocked_ip]) }.to output(
+        expect { subject }.to output(
           a_string_including('Removed 0, skipped 1')
         ).to_stdout
       end
@@ -222,15 +237,16 @@ describe Mastodon::CLI::IpBlocks do
 
     context 'when a specified IP address is invalid' do
       let(:invalid_ip) { '320.15.175.0' }
+      let(:arguments) { [invalid_ip] }
 
       it 'skips the invalid IP address' do
-        expect { cli.invoke(:remove, [invalid_ip]) }.to output(
+        expect { subject }.to output(
           a_string_including("#{invalid_ip} is invalid")
         ).to_stdout
       end
 
       it 'displays the summary correctly' do
-        expect { cli.invoke(:remove, [invalid_ip]) }.to output(
+        expect { subject }.to output(
           a_string_including('Removed 0, skipped 1')
         ).to_stdout
       end
@@ -238,7 +254,7 @@ describe Mastodon::CLI::IpBlocks do
 
     context 'when no IP address is provided' do
       it 'exits with an error message' do
-        expect { cli.remove }.to output(
+        expect { subject }.to output(
           a_string_including('No IP(s) given')
         ).to_stdout
           .and raise_error(SystemExit)
@@ -247,6 +263,8 @@ describe Mastodon::CLI::IpBlocks do
   end
 
   describe '#export' do
+    let(:action) { :export }
+
     let(:first_ip_range_block) { IpBlock.create(ip: '192.168.0.0/24', severity: :no_access) }
     let(:second_ip_range_block) { IpBlock.create(ip: '10.0.0.0/16', severity: :no_access) }
     let(:third_ip_range_block) { IpBlock.create(ip: '127.0.0.1', severity: :sign_up_block) }
@@ -255,13 +273,13 @@ describe Mastodon::CLI::IpBlocks do
       let(:options) { { format: 'plain' } }
 
       it 'exports blocked IPs with "no_access" severity in plain format' do
-        expect { cli.invoke(:export, nil, options) }.to output(
+        expect { subject }.to output(
           a_string_including("#{first_ip_range_block.ip}/#{first_ip_range_block.ip.prefix}\n#{second_ip_range_block.ip}/#{second_ip_range_block.ip.prefix}")
         ).to_stdout
       end
 
       it 'does not export bloked IPs with different severities' do
-        expect { cli.invoke(:export, nil, options) }.to_not output(
+        expect { subject }.to_not output(
           a_string_including("#{third_ip_range_block.ip}/#{first_ip_range_block.ip.prefix}")
         ).to_stdout
       end
@@ -271,13 +289,13 @@ describe Mastodon::CLI::IpBlocks do
       let(:options) { { format: 'nginx' } }
 
       it 'exports blocked IPs with "no_access" severity in plain format' do
-        expect { cli.invoke(:export, nil, options) }.to output(
+        expect { subject }.to output(
           a_string_including("deny #{first_ip_range_block.ip}/#{first_ip_range_block.ip.prefix};\ndeny #{second_ip_range_block.ip}/#{second_ip_range_block.ip.prefix};")
         ).to_stdout
       end
 
       it 'does not export bloked IPs with different severities' do
-        expect { cli.invoke(:export, nil, options) }.to_not output(
+        expect { subject }.to_not output(
           a_string_including("deny #{third_ip_range_block.ip}/#{first_ip_range_block.ip.prefix};")
         ).to_stdout
       end

--- a/spec/lib/mastodon/cli/ip_blocks_spec.rb
+++ b/spec/lib/mastodon/cli/ip_blocks_spec.rb
@@ -51,9 +51,8 @@ describe Mastodon::CLI::IpBlocks do
       end
 
       it 'displays a success message with a summary' do
-        expect { subject }.to output(
-          a_string_including("Added #{ip_list.size}, skipped 0, failed 0")
-        ).to_stdout
+        expect { subject }
+          .to output_results("Added #{ip_list.size}, skipped 0, failed 0")
       end
     end
 
@@ -74,9 +73,8 @@ describe Mastodon::CLI::IpBlocks do
       end
 
       it 'displays the correct summary' do
-        expect { subject }.to output(
-          a_string_including("#{ip_list.last} is already blocked\nAdded #{ip_list.size - 1}, skipped 1, failed 0")
-        ).to_stdout
+        expect { subject }
+          .to output_results("#{ip_list.last} is already blocked\nAdded #{ip_list.size - 1}, skipped 1, failed 0")
       end
 
       context 'with --force option' do
@@ -99,9 +97,8 @@ describe Mastodon::CLI::IpBlocks do
       let(:arguments) { ip_list }
 
       it 'displays the correct summary' do
-        expect { subject }.to output(
-          a_string_including("#{ip_list.first} is invalid\nAdded #{ip_list.size - 1}, skipped 0, failed 1")
-        ).to_stdout
+        expect { subject }
+          .to output_results("#{ip_list.first} is invalid\nAdded #{ip_list.size - 1}, skipped 0, failed 1")
       end
     end
 
@@ -142,9 +139,7 @@ describe Mastodon::CLI::IpBlocks do
 
       it 'displays an error message' do
         expect { subject }
-          .to output(
-            a_string_including("#{ip_address} could not be saved")
-          ).to_stdout
+          .to output_results("#{ip_address} could not be saved")
       end
     end
 
@@ -152,9 +147,8 @@ describe Mastodon::CLI::IpBlocks do
       let(:arguments) { [] }
 
       it 'exits with an error message' do
-        expect { subject }.to output(
-          a_string_including('No IP(s) given')
-        ).to_stdout
+        expect { subject }
+          .to output_results('No IP(s) given')
           .and raise_error(SystemExit)
       end
     end
@@ -192,9 +186,8 @@ describe Mastodon::CLI::IpBlocks do
       end
 
       it 'displays success message with a summary' do
-        expect { subject }.to output(
-          a_string_including("Removed #{ip_list.size}, skipped 0")
-        ).to_stdout
+        expect { subject }
+          .to output_results("Removed #{ip_list.size}, skipped 0")
       end
     end
 
@@ -223,15 +216,13 @@ describe Mastodon::CLI::IpBlocks do
       let(:arguments) { [unblocked_ip] }
 
       it 'skips the IP address' do
-        expect { subject }.to output(
-          a_string_including("#{unblocked_ip} is not yet blocked")
-        ).to_stdout
+        expect { subject }
+          .to output_results("#{unblocked_ip} is not yet blocked")
       end
 
       it 'displays the summary correctly' do
-        expect { subject }.to output(
-          a_string_including('Removed 0, skipped 1')
-        ).to_stdout
+        expect { subject }
+          .to output_results('Removed 0, skipped 1')
       end
     end
 
@@ -240,23 +231,20 @@ describe Mastodon::CLI::IpBlocks do
       let(:arguments) { [invalid_ip] }
 
       it 'skips the invalid IP address' do
-        expect { subject }.to output(
-          a_string_including("#{invalid_ip} is invalid")
-        ).to_stdout
+        expect { subject }
+          .to output_results("#{invalid_ip} is invalid")
       end
 
       it 'displays the summary correctly' do
-        expect { subject }.to output(
-          a_string_including('Removed 0, skipped 1')
-        ).to_stdout
+        expect { subject }
+          .to output_results('Removed 0, skipped 1')
       end
     end
 
     context 'when no IP address is provided' do
       it 'exits with an error message' do
-        expect { subject }.to output(
-          a_string_including('No IP(s) given')
-        ).to_stdout
+        expect { subject }
+          .to output_results('No IP(s) given')
           .and raise_error(SystemExit)
       end
     end
@@ -273,15 +261,13 @@ describe Mastodon::CLI::IpBlocks do
       let(:options) { { format: 'plain' } }
 
       it 'exports blocked IPs with "no_access" severity in plain format' do
-        expect { subject }.to output(
-          a_string_including("#{first_ip_range_block.ip}/#{first_ip_range_block.ip.prefix}\n#{second_ip_range_block.ip}/#{second_ip_range_block.ip.prefix}")
-        ).to_stdout
+        expect { subject }
+          .to output_results("#{first_ip_range_block.ip}/#{first_ip_range_block.ip.prefix}\n#{second_ip_range_block.ip}/#{second_ip_range_block.ip.prefix}")
       end
 
       it 'does not export bloked IPs with different severities' do
-        expect { subject }.to_not output(
-          a_string_including("#{third_ip_range_block.ip}/#{first_ip_range_block.ip.prefix}")
-        ).to_stdout
+        expect { subject }
+          .to_not output_results("#{third_ip_range_block.ip}/#{first_ip_range_block.ip.prefix}")
       end
     end
 
@@ -289,23 +275,20 @@ describe Mastodon::CLI::IpBlocks do
       let(:options) { { format: 'nginx' } }
 
       it 'exports blocked IPs with "no_access" severity in plain format' do
-        expect { subject }.to output(
-          a_string_including("deny #{first_ip_range_block.ip}/#{first_ip_range_block.ip.prefix};\ndeny #{second_ip_range_block.ip}/#{second_ip_range_block.ip.prefix};")
-        ).to_stdout
+        expect { subject }
+          .to output_results("deny #{first_ip_range_block.ip}/#{first_ip_range_block.ip.prefix};\ndeny #{second_ip_range_block.ip}/#{second_ip_range_block.ip.prefix};")
       end
 
       it 'does not export bloked IPs with different severities' do
-        expect { subject }.to_not output(
-          a_string_including("deny #{third_ip_range_block.ip}/#{first_ip_range_block.ip.prefix};")
-        ).to_stdout
+        expect { subject }
+          .to_not output_results("deny #{third_ip_range_block.ip}/#{first_ip_range_block.ip.prefix};")
       end
     end
 
     context 'when --format option is not provided' do
       it 'exports blocked IPs in plain format by default' do
-        expect { cli.export }.to output(
-          a_string_including("#{first_ip_range_block.ip}/#{first_ip_range_block.ip.prefix}\n#{second_ip_range_block.ip}/#{second_ip_range_block.ip.prefix}")
-        ).to_stdout
+        expect { cli.export }
+          .to output_results("#{first_ip_range_block.ip}/#{first_ip_range_block.ip.prefix}\n#{second_ip_range_block.ip}/#{second_ip_range_block.ip.prefix}")
       end
     end
   end

--- a/spec/lib/mastodon/cli/main_spec.rb
+++ b/spec/lib/mastodon/cli/main_spec.rb
@@ -4,11 +4,19 @@ require 'rails_helper'
 require 'mastodon/cli/main'
 
 describe Mastodon::CLI::Main do
+  subject { cli.invoke(action, arguments, options) }
+
+  let(:cli) { described_class.new }
+  let(:arguments) { [] }
+  let(:options) { {} }
+
   it_behaves_like 'CLI Command'
 
-  describe 'version' do
+  describe '#version' do
+    let(:action) { :version }
+
     it 'returns the Mastodon version' do
-      expect { described_class.new.invoke(:version) }.to output(
+      expect { subject }.to output(
         a_string_including(Mastodon::Version.to_s)
       ).to_stdout
     end

--- a/spec/lib/mastodon/cli/main_spec.rb
+++ b/spec/lib/mastodon/cli/main_spec.rb
@@ -16,9 +16,8 @@ describe Mastodon::CLI::Main do
     let(:action) { :version }
 
     it 'returns the Mastodon version' do
-      expect { subject }.to output(
-        a_string_including(Mastodon::Version.to_s)
-      ).to_stdout
+      expect { subject }
+        .to output_results(Mastodon::Version.to_s)
     end
   end
 end

--- a/spec/lib/mastodon/cli/maintenance_spec.rb
+++ b/spec/lib/mastodon/cli/maintenance_spec.rb
@@ -4,18 +4,24 @@ require 'rails_helper'
 require 'mastodon/cli/maintenance'
 
 describe Mastodon::CLI::Maintenance do
+  subject { cli.invoke(action, arguments, options) }
+
   let(:cli) { described_class.new }
+  let(:arguments) { [] }
+  let(:options) { {} }
 
   it_behaves_like 'CLI Command'
 
   describe '#fix_duplicates' do
+    let(:action) { :fix_duplicates }
+
     context 'when the database version is too old' do
       before do
         allow(ActiveRecord::Migrator).to receive(:current_version).and_return(2000_01_01_000000) # Earlier than minimum
       end
 
       it 'Exits with error message' do
-        expect { cli.invoke :fix_duplicates }.to output(
+        expect { subject }.to output(
           a_string_including('is too old')
         ).to_stdout.and raise_error(SystemExit)
       end
@@ -28,7 +34,7 @@ describe Mastodon::CLI::Maintenance do
       end
 
       it 'Exits with error message' do
-        expect { cli.invoke :fix_duplicates }.to output(
+        expect { subject }.to output(
           a_string_including('more recent')
         ).to_stdout.and raise_error(SystemExit)
       end
@@ -41,7 +47,7 @@ describe Mastodon::CLI::Maintenance do
       end
 
       it 'Exits with error message' do
-        expect { cli.invoke :fix_duplicates }.to output(
+        expect { subject }.to output(
           a_string_including('Sidekiq is running')
         ).to_stdout.and raise_error(SystemExit)
       end

--- a/spec/lib/mastodon/cli/maintenance_spec.rb
+++ b/spec/lib/mastodon/cli/maintenance_spec.rb
@@ -21,9 +21,9 @@ describe Mastodon::CLI::Maintenance do
       end
 
       it 'Exits with error message' do
-        expect { subject }.to output(
-          a_string_including('is too old')
-        ).to_stdout.and raise_error(SystemExit)
+        expect { subject }
+          .to output_results('is too old')
+          .and raise_error(SystemExit)
       end
     end
 
@@ -34,9 +34,9 @@ describe Mastodon::CLI::Maintenance do
       end
 
       it 'Exits with error message' do
-        expect { subject }.to output(
-          a_string_including('more recent')
-        ).to_stdout.and raise_error(SystemExit)
+        expect { subject }
+          .to output_results('more recent')
+          .and raise_error(SystemExit)
       end
     end
 
@@ -47,9 +47,9 @@ describe Mastodon::CLI::Maintenance do
       end
 
       it 'Exits with error message' do
-        expect { subject }.to output(
-          a_string_including('Sidekiq is running')
-        ).to_stdout.and raise_error(SystemExit)
+        expect { subject }
+          .to output_results('Sidekiq is running')
+          .and raise_error(SystemExit)
       end
     end
   end

--- a/spec/lib/mastodon/cli/media_spec.rb
+++ b/spec/lib/mastodon/cli/media_spec.rb
@@ -4,16 +4,22 @@ require 'rails_helper'
 require 'mastodon/cli/media'
 
 describe Mastodon::CLI::Media do
+  subject { cli.invoke(action, arguments, options) }
+
   let(:cli) { described_class.new }
+  let(:arguments) { [] }
+  let(:options) { {} }
 
   it_behaves_like 'CLI Command'
 
   describe '#remove' do
+    let(:action) { :remove }
+
     context 'with --prune-profiles and --remove-headers' do
       let(:options) { { prune_profiles: true, remove_headers: true } }
 
       it 'warns about usage and exits' do
-        expect { cli.invoke(:remove, [], options) }.to output(
+        expect { subject }.to output(
           a_string_including('--prune-profiles and --remove-headers should not be specified simultaneously')
         ).to_stdout.and raise_error(SystemExit)
       end
@@ -23,7 +29,7 @@ describe Mastodon::CLI::Media do
       let(:options) { { include_follows: true } }
 
       it 'warns about usage and exits' do
-        expect { cli.invoke(:remove, [], options) }.to output(
+        expect { subject }.to output(
           a_string_including('--include-follows can only be used with --prune-profiles or --remove-headers')
         ).to_stdout.and raise_error(SystemExit)
       end
@@ -38,7 +44,7 @@ describe Mastodon::CLI::Media do
         let(:options) { { prune_profiles: true } }
 
         it 'removes account avatars' do
-          expect { cli.invoke(:remove, [], options) }.to output(
+          expect { subject }.to output(
             a_string_including('Visited 1')
           ).to_stdout
 
@@ -50,7 +56,7 @@ describe Mastodon::CLI::Media do
         let(:options) { { remove_headers: true } }
 
         it 'removes account header' do
-          expect { cli.invoke(:remove, [], options) }.to output(
+          expect { subject }.to output(
             a_string_including('Visited 1')
           ).to_stdout
 
@@ -64,7 +70,7 @@ describe Mastodon::CLI::Media do
 
       context 'without options' do
         it 'removes account avatars' do
-          expect { cli.invoke(:remove) }.to output(
+          expect { subject }.to output(
             a_string_including('Removed 1')
           ).to_stdout
 
@@ -76,11 +82,11 @@ describe Mastodon::CLI::Media do
   end
 
   describe '#usage' do
-    context 'without options' do
-      let(:options) { {} }
+    let(:action) { :usage }
 
+    context 'without options' do
       it 'reports about storage size' do
-        expect { cli.invoke(:usage, [], options) }.to output(
+        expect { subject }.to output(
           a_string_including('0 Bytes')
         ).to_stdout
       end
@@ -88,11 +94,11 @@ describe Mastodon::CLI::Media do
   end
 
   describe '#refresh' do
-    context 'without any options' do
-      let(:options) { {} }
+    let(:action) { :refresh }
 
+    context 'without any options' do
       it 'warns about usage and exits' do
-        expect { cli.invoke(:refresh, [], options) }.to output(
+        expect { subject }.to output(
           a_string_including('Specify the source')
         ).to_stdout.and raise_error(SystemExit)
       end
@@ -108,7 +114,7 @@ describe Mastodon::CLI::Media do
       let(:status) { Fabricate(:status) }
 
       it 'redownloads the attachment file' do
-        expect { cli.invoke(:refresh, [], options) }.to output(
+        expect { subject }.to output(
           a_string_including('Downloaded 1 media')
         ).to_stdout
       end
@@ -119,7 +125,7 @@ describe Mastodon::CLI::Media do
         let(:options) { { account: 'not-real-user@example.host' } }
 
         it 'warns about usage and exits' do
-          expect { cli.invoke(:refresh, [], options) }.to output(
+          expect { subject }.to output(
             a_string_including('No such account')
           ).to_stdout.and raise_error(SystemExit)
         end
@@ -135,7 +141,7 @@ describe Mastodon::CLI::Media do
         let(:account) { Fabricate(:account) }
 
         it 'redownloads the attachment file' do
-          expect { cli.invoke(:refresh, [], options) }.to output(
+          expect { subject }.to output(
             a_string_including('Downloaded 1 media')
           ).to_stdout
         end
@@ -153,7 +159,7 @@ describe Mastodon::CLI::Media do
       let(:account) { Fabricate(:account, domain: domain) }
 
       it 'redownloads the attachment file' do
-        expect { cli.invoke(:refresh, [], options) }.to output(
+        expect { subject }.to output(
           a_string_including('Downloaded 1 media')
         ).to_stdout
       end

--- a/spec/lib/mastodon/cli/media_spec.rb
+++ b/spec/lib/mastodon/cli/media_spec.rb
@@ -19,9 +19,9 @@ describe Mastodon::CLI::Media do
       let(:options) { { prune_profiles: true, remove_headers: true } }
 
       it 'warns about usage and exits' do
-        expect { subject }.to output(
-          a_string_including('--prune-profiles and --remove-headers should not be specified simultaneously')
-        ).to_stdout.and raise_error(SystemExit)
+        expect { subject }
+          .to output_results('--prune-profiles and --remove-headers should not be specified simultaneously')
+          .and raise_error(SystemExit)
       end
     end
 
@@ -29,9 +29,9 @@ describe Mastodon::CLI::Media do
       let(:options) { { include_follows: true } }
 
       it 'warns about usage and exits' do
-        expect { subject }.to output(
-          a_string_including('--include-follows can only be used with --prune-profiles or --remove-headers')
-        ).to_stdout.and raise_error(SystemExit)
+        expect { subject }
+          .to output_results('--include-follows can only be used with --prune-profiles or --remove-headers')
+          .and raise_error(SystemExit)
       end
     end
 
@@ -44,9 +44,8 @@ describe Mastodon::CLI::Media do
         let(:options) { { prune_profiles: true } }
 
         it 'removes account avatars' do
-          expect { subject }.to output(
-            a_string_including('Visited 1')
-          ).to_stdout
+          expect { subject }
+            .to output_results('Visited 1')
 
           expect(account.reload.avatar).to be_blank
         end
@@ -56,9 +55,8 @@ describe Mastodon::CLI::Media do
         let(:options) { { remove_headers: true } }
 
         it 'removes account header' do
-          expect { subject }.to output(
-            a_string_including('Visited 1')
-          ).to_stdout
+          expect { subject }
+            .to output_results('Visited 1')
 
           expect(account.reload.header).to be_blank
         end
@@ -70,9 +68,8 @@ describe Mastodon::CLI::Media do
 
       context 'without options' do
         it 'removes account avatars' do
-          expect { subject }.to output(
-            a_string_including('Removed 1')
-          ).to_stdout
+          expect { subject }
+            .to output_results('Removed 1')
 
           expect(media_attachment.reload.file).to be_blank
           expect(media_attachment.reload.thumbnail).to be_blank
@@ -86,9 +83,8 @@ describe Mastodon::CLI::Media do
 
     context 'without options' do
       it 'reports about storage size' do
-        expect { subject }.to output(
-          a_string_including('0 Bytes')
-        ).to_stdout
+        expect { subject }
+          .to output_results('0 Bytes')
       end
     end
   end
@@ -98,9 +94,9 @@ describe Mastodon::CLI::Media do
 
     context 'without any options' do
       it 'warns about usage and exits' do
-        expect { subject }.to output(
-          a_string_including('Specify the source')
-        ).to_stdout.and raise_error(SystemExit)
+        expect { subject }
+          .to output_results('Specify the source')
+          .and raise_error(SystemExit)
       end
     end
 
@@ -114,9 +110,8 @@ describe Mastodon::CLI::Media do
       let(:status) { Fabricate(:status) }
 
       it 'redownloads the attachment file' do
-        expect { subject }.to output(
-          a_string_including('Downloaded 1 media')
-        ).to_stdout
+        expect { subject }
+          .to output_results('Downloaded 1 media')
       end
     end
 
@@ -125,9 +120,9 @@ describe Mastodon::CLI::Media do
         let(:options) { { account: 'not-real-user@example.host' } }
 
         it 'warns about usage and exits' do
-          expect { subject }.to output(
-            a_string_including('No such account')
-          ).to_stdout.and raise_error(SystemExit)
+          expect { subject }
+            .to output_results('No such account')
+            .and raise_error(SystemExit)
         end
       end
 
@@ -141,9 +136,8 @@ describe Mastodon::CLI::Media do
         let(:account) { Fabricate(:account) }
 
         it 'redownloads the attachment file' do
-          expect { subject }.to output(
-            a_string_including('Downloaded 1 media')
-          ).to_stdout
+          expect { subject }
+            .to output_results('Downloaded 1 media')
         end
       end
     end
@@ -159,9 +153,8 @@ describe Mastodon::CLI::Media do
       let(:account) { Fabricate(:account, domain: domain) }
 
       it 'redownloads the attachment file' do
-        expect { subject }.to output(
-          a_string_including('Downloaded 1 media')
-        ).to_stdout
+        expect { subject }
+          .to output_results('Downloaded 1 media')
       end
     end
   end

--- a/spec/lib/mastodon/cli/preview_cards_spec.rb
+++ b/spec/lib/mastodon/cli/preview_cards_spec.rb
@@ -4,11 +4,17 @@ require 'rails_helper'
 require 'mastodon/cli/preview_cards'
 
 describe Mastodon::CLI::PreviewCards do
+  subject { cli.invoke(action, arguments, options) }
+
   let(:cli) { described_class.new }
+  let(:arguments) { [] }
+  let(:options) { {} }
 
   it_behaves_like 'CLI Command'
 
   describe '#remove' do
+    let(:action) { :remove }
+
     context 'with relevant preview cards' do
       before do
         Fabricate(:preview_card, updated_at: 10.years.ago, type: :link)
@@ -18,7 +24,7 @@ describe Mastodon::CLI::PreviewCards do
 
       context 'with no arguments' do
         it 'deletes thumbnails for local preview cards' do
-          expect { cli.invoke(:remove) }.to output(
+          expect { subject }.to output(
             a_string_including('Removed 2 preview cards')
               .and(a_string_including('approx. 119 KB'))
           ).to_stdout
@@ -29,7 +35,7 @@ describe Mastodon::CLI::PreviewCards do
         let(:options) { { link: true } }
 
         it 'deletes thumbnails for local preview cards' do
-          expect { cli.invoke(:remove, [], options) }.to output(
+          expect { subject }.to output(
             a_string_including('Removed 1 link-type preview cards')
               .and(a_string_including('approx. 59.6 KB'))
           ).to_stdout
@@ -40,7 +46,7 @@ describe Mastodon::CLI::PreviewCards do
         let(:options) { { days: 365 } }
 
         it 'deletes thumbnails for local preview cards' do
-          expect { cli.invoke(:remove, [], options) }.to output(
+          expect { subject }.to output(
             a_string_including('Removed 1 preview cards')
               .and(a_string_including('approx. 59.6 KB'))
           ).to_stdout

--- a/spec/lib/mastodon/cli/preview_cards_spec.rb
+++ b/spec/lib/mastodon/cli/preview_cards_spec.rb
@@ -24,10 +24,11 @@ describe Mastodon::CLI::PreviewCards do
 
       context 'with no arguments' do
         it 'deletes thumbnails for local preview cards' do
-          expect { subject }.to output(
-            a_string_including('Removed 2 preview cards')
-              .and(a_string_including('approx. 119 KB'))
-          ).to_stdout
+          expect { subject }
+            .to output_results(
+              'Removed 2 preview cards',
+              'approx. 119 KB'
+            )
         end
       end
 
@@ -35,10 +36,11 @@ describe Mastodon::CLI::PreviewCards do
         let(:options) { { link: true } }
 
         it 'deletes thumbnails for local preview cards' do
-          expect { subject }.to output(
-            a_string_including('Removed 1 link-type preview cards')
-              .and(a_string_including('approx. 59.6 KB'))
-          ).to_stdout
+          expect { subject }
+            .to output_results(
+              'Removed 1 link-type preview cards',
+              'approx. 59.6 KB'
+            )
         end
       end
 
@@ -46,10 +48,11 @@ describe Mastodon::CLI::PreviewCards do
         let(:options) { { days: 365 } }
 
         it 'deletes thumbnails for local preview cards' do
-          expect { subject }.to output(
-            a_string_including('Removed 1 preview cards')
-              .and(a_string_including('approx. 59.6 KB'))
-          ).to_stdout
+          expect { subject }
+            .to output_results(
+              'Removed 1 preview cards',
+              'approx. 59.6 KB'
+            )
         end
       end
     end

--- a/spec/lib/mastodon/cli/settings_spec.rb
+++ b/spec/lib/mastodon/cli/settings_spec.rb
@@ -25,9 +25,8 @@ describe Mastodon::CLI::Settings do
       end
 
       it 'displays success message' do
-        expect { subject }.to output(
-          a_string_including('OK')
-        ).to_stdout
+        expect { subject }
+          .to output_results('OK')
       end
     end
 
@@ -39,9 +38,8 @@ describe Mastodon::CLI::Settings do
       end
 
       it 'displays success message' do
-        expect { subject }.to output(
-          a_string_including('OK')
-        ).to_stdout
+        expect { subject }
+          .to output_results('OK')
       end
 
       context 'with --require-reason' do
@@ -65,9 +63,8 @@ describe Mastodon::CLI::Settings do
       end
 
       it 'displays success message' do
-        expect { subject }.to output(
-          a_string_including('OK')
-        ).to_stdout
+        expect { subject }
+          .to output_results('OK')
       end
     end
   end

--- a/spec/lib/mastodon/cli/settings_spec.rb
+++ b/spec/lib/mastodon/cli/settings_spec.rb
@@ -7,57 +7,65 @@ describe Mastodon::CLI::Settings do
   it_behaves_like 'CLI Command'
 
   describe 'subcommand "registrations"' do
+    subject { cli.invoke(action, arguments, options) }
+
     let(:cli) { Mastodon::CLI::Registrations.new }
+    let(:arguments) { [] }
+    let(:options) { {} }
 
     before do
       Setting.registrations_mode = nil
     end
 
     describe '#open' do
+      let(:action) { :open }
+
       it 'changes "registrations_mode" to "open"' do
-        expect { cli.open }.to change(Setting, :registrations_mode).from(nil).to('open')
+        expect { subject }.to change(Setting, :registrations_mode).from(nil).to('open')
       end
 
       it 'displays success message' do
-        expect { cli.open }.to output(
+        expect { subject }.to output(
           a_string_including('OK')
         ).to_stdout
       end
     end
 
     describe '#approved' do
+      let(:action) { :approved }
+
       it 'changes "registrations_mode" to "approved"' do
-        expect { cli.approved }.to change(Setting, :registrations_mode).from(nil).to('approved')
+        expect { subject }.to change(Setting, :registrations_mode).from(nil).to('approved')
       end
 
       it 'displays success message' do
-        expect { cli.approved }.to output(
+        expect { subject }.to output(
           a_string_including('OK')
         ).to_stdout
       end
 
       context 'with --require-reason' do
-        before do
-          cli.options = { require_reason: true }
-        end
+        let(:options) { { require_reason: true } }
 
         it 'changes "registrations_mode" to "approved"' do
-          expect { cli.approved }.to change(Setting, :registrations_mode).from(nil).to('approved')
+          expect { subject }.to change(Setting, :registrations_mode).from(nil).to('approved')
         end
 
         it 'sets "require_invite_text" to "true"' do
-          expect { cli.approved }.to change(Setting, :require_invite_text).from(false).to(true)
+          expect { subject }.to change(Setting, :require_invite_text).from(false).to(true)
         end
       end
     end
 
     describe '#close' do
+      let(:action) { :close }
+
       it 'changes "registrations_mode" to "none"' do
-        expect { cli.close }.to change(Setting, :registrations_mode).from(nil).to('none')
+        expect { subject }.to change(Setting, :registrations_mode).from(nil).to('none')
       end
 
       it 'displays success message' do
-        expect { cli.close }.to output(
+        expect { subject }.to output(
           a_string_including('OK')
         ).to_stdout
       end

--- a/spec/lib/mastodon/cli/statuses_spec.rb
+++ b/spec/lib/mastodon/cli/statuses_spec.rb
@@ -19,17 +19,16 @@ describe Mastodon::CLI::Statuses do
       let(:options) { { batch_size: 0 } }
 
       it 'exits with error message' do
-        expect { subject }.to output(
-          a_string_including('Cannot run')
-        ).to_stdout.and raise_error(SystemExit)
+        expect { subject }
+          .to output_results('Cannot run')
+          .and raise_error(SystemExit)
       end
     end
 
     context 'with default batch size' do
       it 'removes unreferenced statuses' do
-        expect { subject }.to output(
-          a_string_including('Done after')
-        ).to_stdout
+        expect { subject }
+          .to output_results('Done after')
       end
     end
   end

--- a/spec/lib/mastodon/cli/statuses_spec.rb
+++ b/spec/lib/mastodon/cli/statuses_spec.rb
@@ -4,16 +4,22 @@ require 'rails_helper'
 require 'mastodon/cli/statuses'
 
 describe Mastodon::CLI::Statuses do
+  subject { cli.invoke(action, arguments, options) }
+
   let(:cli) { described_class.new }
+  let(:arguments) { [] }
+  let(:options) { {} }
 
   it_behaves_like 'CLI Command'
 
   describe '#remove', use_transactional_tests: false do
+    let(:action) { :remove }
+
     context 'with small batch size' do
       let(:options) { { batch_size: 0 } }
 
       it 'exits with error message' do
-        expect { cli.invoke :remove, [], options }.to output(
+        expect { subject }.to output(
           a_string_including('Cannot run')
         ).to_stdout.and raise_error(SystemExit)
       end
@@ -21,7 +27,7 @@ describe Mastodon::CLI::Statuses do
 
     context 'with default batch size' do
       it 'removes unreferenced statuses' do
-        expect { cli.invoke :remove }.to output(
+        expect { subject }.to output(
           a_string_including('Done after')
         ).to_stdout
       end

--- a/spec/lib/mastodon/cli/upgrade_spec.rb
+++ b/spec/lib/mastodon/cli/upgrade_spec.rb
@@ -4,21 +4,25 @@ require 'rails_helper'
 require 'mastodon/cli/upgrade'
 
 describe Mastodon::CLI::Upgrade do
+  subject { cli.invoke(action, arguments, options) }
+
   let(:cli) { described_class.new }
+  let(:arguments) { [] }
+  let(:options) { {} }
 
   it_behaves_like 'CLI Command'
 
   describe '#storage_schema' do
-    context 'with records that dont need upgrading' do
-      let(:options) { {} }
+    let(:action) { :storage_schema }
 
+    context 'with records that dont need upgrading' do
       before do
         Fabricate(:account)
         Fabricate(:media_attachment)
       end
 
       it 'does not upgrade storage for the attachments' do
-        expect { cli.invoke(:storage_schema, [], options) }.to output(
+        expect { subject }.to output(
           a_string_including('Upgraded storage schema of 0 records')
         ).to_stdout
       end

--- a/spec/lib/mastodon/cli/upgrade_spec.rb
+++ b/spec/lib/mastodon/cli/upgrade_spec.rb
@@ -22,9 +22,8 @@ describe Mastodon::CLI::Upgrade do
       end
 
       it 'does not upgrade storage for the attachments' do
-        expect { subject }.to output(
-          a_string_including('Upgraded storage schema of 0 records')
-        ).to_stdout
+        expect { subject }
+          .to output_results('Upgraded storage schema of 0 records')
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -88,6 +88,7 @@ RSpec.configure do |config|
   config.include Chewy::Rspec::Helpers
   config.include Redisable
   config.include SignedRequestHelpers, type: :request
+  config.include CommandLineHelpers, type: :cli
 
   config.around(:each, use_transactional_tests: false) do |example|
     self.use_transactional_tests = false

--- a/spec/support/command_line_helpers.rb
+++ b/spec/support/command_line_helpers.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module CommandLineHelpers
-  def output_results(string)
+  def output_results(*args)
     output(
-      a_string_including(string)
+      include(*args)
     ).to_stdout
   end
 end

--- a/spec/support/command_line_helpers.rb
+++ b/spec/support/command_line_helpers.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module CommandLineHelpers
+  def output_results(string)
+    output(
+      a_string_including(string)
+    ).to_stdout
+  end
+end


### PR DESCRIPTION
Having added a bunch of CLI specs recently, this is sort of a consistency once over to align them all on approach. Changes in here:

- There was previously a variety of calling methods used, subjects, etc -- this unifies all the CLI specs to have a common setup approach with `subject` being the thor invoke signature, and then separate `action`, `arguments`, and `options` variables available to override the default (empty) configuration. Each describe/context sets its `action` and any relevant other setup, then invokes the tasks
- Extracted a helper I had recently added in the emoji cli spec and moved it to shared module, and included it by default in all `:cli` type specs
- Updated all the other specs to use this `output_results` helper, which wraps the rspec `output ... stdout` block and checks the contents for what was expected.
- Updated the helper to accept multiple args, so we don't need to run the same setup phase multiple times to assert different things against it.

I tried to keep this as straightforward as possible to keep the diff more reviewable, but there are some obvious follow-on work if accepted:

- There's an area in accounts cli spec which has a comment TODO about using a different stub approach ... I did NOT update this part to new style because it would have required doing that TODO work as well. I can do both of those things in separate PR.
- There are opportunities in a few of the specs to further consolidate/chain some things together (I started to do this and realized it would make the diff harder to review), similar to some of the recent controller perf changes

Overall I think this is pretty safe -- there are not many open CLI spec PRs now (maybe none?) and I'd love to have this pattern and updated helper in place before doing more of them myself.