### PR TITLE
Return 422 when StatementInvalid at API level

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -18,7 +18,7 @@ class Api::BaseController < ApplicationController
 
   protect_from_forgery with: :null_session
 
-  rescue_from ActiveRecord::RecordInvalid, Mastodon::ValidationError do |e|
+  rescue_from ActiveRecord::RecordInvalid, ActiveRecord::StatementInvalid, Mastodon::ValidationError do |e|
     render json: { error: e.to_s }, status: 422
   end
 

--- a/spec/controllers/api/base_controller_spec.rb
+++ b/spec/controllers/api/base_controller_spec.rb
@@ -79,6 +79,7 @@ describe Api::BaseController do
     end
 
     {
+      ActiveRecord::StatementInvalid => 422,
       ActiveRecord::RecordInvalid => 422,
       Mastodon::ValidationError => 422,
       ActiveRecord::RecordNotFound => 404,


### PR DESCRIPTION
Resolves https://github.com/mastodon/mastodon/issues/28197

I took a catch-all approach instead of specifically targetting `offset`, `limit`, `page`, etc. This is easier to add, but comes with less narrowly targeted information in the response (its going to be something generic about an invalid statement, not about the specific param that had the issue).