### PR TITLE
Add note to install libidn on MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ To set up **MacOS** for native development, complete the following steps:
 - Run `brew install postgresql@14`
 - Run `brew install redis`
 - Run `brew install imagemagick`
+- Run `brew install libidn`
 - Install Foreman or a similar tool (such as [overmind](https://github.com/DarthSim/overmind)) to handle multiple process launching.
 - Navigate to Mastodon's root directory and run `brew install nvm` then `nvm use` to use the version from .nvmrc
 - Run `corepack enable && corepack prepare`


### PR DESCRIPTION
Hey team,

When running bundle I got the following error:

```
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /Users/kgreeff/.rvm/gems/ruby-3.2.2@mastodon/gems/idn-ruby-0.1.5/ext
/Users/kgreeff/.rvm/rubies/ruby-3.2.2/bin/ruby extconf.rb
checking for -lidn... no
ERROR: could not find idn library!

  Please install the GNU IDN library or alternatively specify at least one
  of the following options if the library can only be found in a non-standard
  location:
    --with-idn-dir=/path/to/non/standard/location
        or
    --with-idn-lib=/path/to/non/standard/location/lib
    --with-idn-include=/path/to/non/standard/location/include
```

To fix I simply ran:

`brew install libidn`

So I have added to the readme.

Please let me know if this is required or if I made a mistake somewhere else along the line.