### PR TITLE
Add spec coverage for `CLI::Media#remove_orphans` command

### DIFF
--- a/lib/mastodon/cli/base.rb
+++ b/lib/mastodon/cli/base.rb
@@ -4,6 +4,7 @@ require_relative '../../../config/boot'
 require_relative '../../../config/environment'
 
 require 'thor'
+require 'pastel'
 require_relative 'progress_helper'
 
 module Mastodon

--- a/spec/lib/mastodon/cli/media_spec.rb
+++ b/spec/lib/mastodon/cli/media_spec.rb
@@ -225,6 +225,7 @@ describe Mastodon::CLI::Media do
 
     context 'when in filesystem mode' do
       before do
+        allow(File).to receive(:delete).and_return(true)
         media_attachment.delete
       end
 
@@ -233,7 +234,7 @@ describe Mastodon::CLI::Media do
       it 'removes the unlinked files' do
         expect { subject }
           .to output_results('Removed', 'orphans (approx')
-          .and(change { File.exist?(media_attachment.file.path) }.from(true).to(false))
+        expect(File).to have_received(:delete).with(media_attachment.file.path)
       end
     end
   end

--- a/spec/lib/mastodon/cli/media_spec.rb
+++ b/spec/lib/mastodon/cli/media_spec.rb
@@ -188,6 +188,10 @@ describe Mastodon::CLI::Media do
   describe '#remove_orphans' do
     let(:action) { :remove_orphans }
 
+    before do
+      FileUtils.mkdir_p Rails.public_path.join('system')
+    end
+
     context 'without any options' do
       it 'runs without error' do
         expect { subject }


### PR DESCRIPTION
The before block is here is needed because other example create records which wind up effectively having orphans, so we want to wipe that clean first when asserting about the orphans command itself.