### PR TITLE
Refactor `CLI::Maintenance` eligibility checking magic numbers

### DIFF
--- a/lib/mastodon/cli/maintenance.rb
+++ b/lib/mastodon/cli/maintenance.rb
@@ -189,16 +189,12 @@ module Mastodon::CLI
     end
 
     def deduplication_cleanup_tasks
-      refresh_instances_view if schema_has_instances_view?
+      refresh_instances_view if migrator_version_after?(:adds_instance_view)
       Rails.cache.clear
     end
 
     def refresh_instances_view
       Scenic.database.refresh_materialized_view('instances', concurrently: true, cascade: false)
-    end
-
-    def schema_has_instances_view?
-      migrator_version_after?(:adds_instance_view)
     end
 
     def verify_schema_version!

--- a/lib/mastodon/cli/maintenance.rb
+++ b/lib/mastodon/cli/maintenance.rb
@@ -4,9 +4,6 @@ require_relative 'base'
 
 module Mastodon::CLI
   class Maintenance < Base
-    MIN_SUPPORTED_VERSION = 2019_10_01_213028
-    MAX_SUPPORTED_VERSION = 2023_09_07_150100
-
     MIGRATION_CHANGES = {
       adds_case_insensitive_btree_index_tags: 2021_04_21_121431,
       adds_fixed_lowercase_index_accounts: 2020_06_20_164023,
@@ -18,6 +15,8 @@ module Mastodon::CLI
       optimizes_null_index_statuses_uri: 2022_03_10_060706,
       optimizes_null_index_users_reset_password_token: 2022_03_10_060641,
       removes_index_users_remember_token: 2022_01_18_183010,
+      version_support_maximum: 2023_09_07_150100,
+      version_support_minimum: 2019_10_01_213028,
     }.freeze
 
     # Stubs to enjoy ActiveRecord queries while not depending on a particular
@@ -198,11 +197,11 @@ module Mastodon::CLI
     end
 
     def verify_schema_version!
-      if migrator_version < MIN_SUPPORTED_VERSION
+      if migrator_version_before?(:version_support_minimum)
         say 'Your version of the database schema is too old and is not supported by this script.', :red
         say 'Please update to at least Mastodon 3.0.0 before running this script.', :red
         exit(1)
-      elsif migrator_version > MAX_SUPPORTED_VERSION
+      elsif migrator_version_after?(:version_support_maximum)
         say 'Your version of the database schema is more recent than this script, this may cause unexpected errors.', :yellow
         exit(1) unless yes?('Continue anyway? (Yes/No)')
       end

--- a/lib/mastodon/cli/maintenance.rb
+++ b/lib/mastodon/cli/maintenance.rb
@@ -188,7 +188,7 @@ module Mastodon::CLI
     end
 
     def deduplication_cleanup_tasks
-      refresh_instances_view if migrator_version_after?(:adds_instance_view)
+      refresh_instances_view if migrator_version_at_least?(:adds_instance_view)
       Rails.cache.clear
     end
 
@@ -285,7 +285,7 @@ module Mastodon::CLI
         ActiveRecord::Base.connection.add_index :users, ['reset_password_token'], name: 'index_users_on_reset_password_token', unique: true, where: 'reset_password_token IS NOT NULL', opclass: :text_pattern_ops
       end
 
-      ActiveRecord::Base.connection.execute('REINDEX INDEX index_users_on_unconfirmed_email;') if migrator_version_after?(:adds_index_users_unconfirmed_email)
+      ActiveRecord::Base.connection.execute('REINDEX INDEX index_users_on_unconfirmed_email;') if migrator_version_at_least?(:adds_index_users_unconfirmed_email)
     end
 
     def deduplicate_users_process_confirmation_token

--- a/lib/mastodon/cli/maintenance.rb
+++ b/lib/mastodon/cli/maintenance.rb
@@ -198,7 +198,7 @@ module Mastodon::CLI
     end
 
     def schema_has_instances_view?
-      migrator_version >= MIGRATION_CHANGES[:adds_instance_view]
+      migrator_version_after?(:adds_instance_view)
     end
 
     def verify_schema_version!
@@ -241,7 +241,7 @@ module Mastodon::CLI
       end
 
       say 'Restoring index_accounts_on_username_and_domain_lower…'
-      if migrator_version < MIGRATION_CHANGES[:adds_fixed_lowercase_index_accounts]
+      if migrator_version_before?(:adds_fixed_lowercase_index_accounts)
         ActiveRecord::Base.connection.add_index :accounts, 'lower (username), lower(domain)', name: 'index_accounts_on_username_and_domain_lower', unique: true
       else
         ActiveRecord::Base.connection.add_index :accounts, "lower (username), COALESCE(lower(domain), '')", name: 'index_accounts_on_username_and_domain_lower', unique: true
@@ -251,7 +251,7 @@ module Mastodon::CLI
       ActiveRecord::Base.connection.execute('REINDEX INDEX search_index;')
       ActiveRecord::Base.connection.execute('REINDEX INDEX index_accounts_on_uri;')
       ActiveRecord::Base.connection.execute('REINDEX INDEX index_accounts_on_url;')
-      ActiveRecord::Base.connection.execute('REINDEX INDEX index_accounts_on_domain_and_id;') if migrator_version >= MIGRATION_CHANGES[:adds_index_accounts_domain_id]
+      ActiveRecord::Base.connection.execute('REINDEX INDEX index_accounts_on_domain_and_id;') if migrator_version_at_least?(:adds_index_accounts_domain_id)
     end
 
     def deduplicate_users!
@@ -282,15 +282,15 @@ module Mastodon::CLI
       say 'Restoring users indexes…'
       ActiveRecord::Base.connection.add_index :users, ['confirmation_token'], name: 'index_users_on_confirmation_token', unique: true
       ActiveRecord::Base.connection.add_index :users, ['email'], name: 'index_users_on_email', unique: true
-      ActiveRecord::Base.connection.add_index :users, ['remember_token'], name: 'index_users_on_remember_token', unique: true if migrator_version < MIGRATION_CHANGES[:remove_index_users_remember_token]
+      ActiveRecord::Base.connection.add_index :users, ['remember_token'], name: 'index_users_on_remember_token', unique: true if migrator_version_before?(:remove_index_users_remember_token)
 
-      if migrator_version < MIGRATION_CHANGES[:optimizes_null_index_users_reset_password_token]
+      if migrator_version_before?(:optimizes_null_index_users_reset_password_token)
         ActiveRecord::Base.connection.add_index :users, ['reset_password_token'], name: 'index_users_on_reset_password_token', unique: true
       else
         ActiveRecord::Base.connection.add_index :users, ['reset_password_token'], name: 'index_users_on_reset_password_token', unique: true, where: 'reset_password_token IS NOT NULL', opclass: :text_pattern_ops
       end
 
-      ActiveRecord::Base.connection.execute('REINDEX INDEX index_users_on_unconfirmed_email;') if migrator_version >= MIGRATION_CHANGES[:adds_index_users_unconfirmed_email]
+      ActiveRecord::Base.connection.execute('REINDEX INDEX index_users_on_unconfirmed_email;') if migrator_version_after?(:adds_index_users_unconfirmed_email)
     end
 
     def deduplicate_users_process_confirmation_token
@@ -305,7 +305,7 @@ module Mastodon::CLI
     end
 
     def deduplicate_users_process_remember_token
-      if migrator_version < MIGRATION_CHANGES[:removes_index_users_remember_token]
+      if migrator_version_before?(:removes_index_users_remember_token)
         ActiveRecord::Base.connection.select_all("SELECT string_agg(id::text, ',') AS ids FROM users WHERE remember_token IS NOT NULL GROUP BY remember_token HAVING count(*) > 1").each do |row|
           users = User.where(id: row['ids'].split(',')).sort_by(&:updated_at).reverse.drop(1)
           say "Unsetting remember token for those accounts: #{users.map { |user| user.account.acct }.join(', ')}", :yellow
@@ -384,7 +384,7 @@ module Mastodon::CLI
       end
 
       say 'Restoring conversations indexes…'
-      if migrator_version < MIGRATION_CHANGES[:optimizes_null_index_conversations_uri]
+      if migrator_version_before?(:optimizes_null_index_conversations_uri)
         ActiveRecord::Base.connection.add_index :conversations, ['uri'], name: 'index_conversations_on_uri', unique: true
       else
         ActiveRecord::Base.connection.add_index :conversations, ['uri'], name: 'index_conversations_on_uri', unique: true, where: 'uri IS NOT NULL', opclass: :text_pattern_ops
@@ -501,7 +501,7 @@ module Mastodon::CLI
       end
 
       say 'Restoring media_attachments indexes…'
-      if migrator_version < MIGRATION_CHANGES[:optimizes_null_index_media_attachments_shortcode]
+      if migrator_version_before?(:optimizes_null_index_media_attachments_shortcode)
         ActiveRecord::Base.connection.add_index :media_attachments, ['shortcode'], name: 'index_media_attachments_on_shortcode', unique: true
       else
         ActiveRecord::Base.connection.add_index :media_attachments, ['shortcode'], name: 'index_media_attachments_on_shortcode', unique: true, where: 'shortcode IS NOT NULL', opclass: :text_pattern_ops
@@ -534,7 +534,7 @@ module Mastodon::CLI
       end
 
       say 'Restoring statuses indexes…'
-      if migrator_version < MIGRATION_CHANGES[:optimizes_null_index_statuses_uri]
+      if migrator_version_before?(:optimizes_null_index_statuses_uri)
         ActiveRecord::Base.connection.add_index :statuses, ['uri'], name: 'index_statuses_on_uri', unique: true
       else
         ActiveRecord::Base.connection.add_index :statuses, ['uri'], name: 'index_statuses_on_uri', unique: true, where: 'uri IS NOT NULL', opclass: :text_pattern_ops
@@ -556,7 +556,7 @@ module Mastodon::CLI
       end
 
       say 'Restoring tags indexes…'
-      if migrator_version < MIGRATION_CHANGES[:adds_case_insensitive_btree_index_tags]
+      if migrator_version_before?(:adds_case_insensitive_btree_index_tags)
         ActiveRecord::Base.connection.add_index :tags, 'lower((name)::text)', name: 'index_tags_on_name_lower', unique: true
       else
         ActiveRecord::Base.connection.execute 'CREATE UNIQUE INDEX CONCURRENTLY index_tags_on_name_lower_btree ON tags (lower(name) text_pattern_ops)'
@@ -722,6 +722,18 @@ module Mastodon::CLI
 
     def migrator_version
       ActiveRecord::Migrator.current_version
+    end
+
+    def migrator_version_before?(migration)
+      migrator_version < MIGRATION_CHANGES[migration]
+    end
+
+    def migrator_version_after?(migration)
+      migrator_version > MIGRATION_CHANGES[migration]
+    end
+
+    def migrator_version_at_least?(migration)
+      migrator_version >= MIGRATION_CHANGES[migration]
     end
 
     def find_duplicate_accounts

--- a/lib/mastodon/cli/maintenance.rb
+++ b/lib/mastodon/cli/maintenance.rb
@@ -198,15 +198,15 @@ module Mastodon::CLI
     end
 
     def schema_has_instances_view?
-      ActiveRecord::Migrator.current_version >= MIGRATION_CHANGES[:adds_instance_view]
+      migrator_version >= MIGRATION_CHANGES[:adds_instance_view]
     end
 
     def verify_schema_version!
-      if ActiveRecord::Migrator.current_version < MIN_SUPPORTED_VERSION
+      if migrator_version < MIN_SUPPORTED_VERSION
         say 'Your version of the database schema is too old and is not supported by this script.', :red
         say 'Please update to at least Mastodon 3.0.0 before running this script.', :red
         exit(1)
-      elsif ActiveRecord::Migrator.current_version > MAX_SUPPORTED_VERSION
+      elsif migrator_version > MAX_SUPPORTED_VERSION
         say 'Your version of the database schema is more recent than this script, this may cause unexpected errors.', :yellow
         exit(1) unless yes?('Continue anyway? (Yes/No)')
       end
@@ -241,7 +241,7 @@ module Mastodon::CLI
       end
 
       say 'Restoring index_accounts_on_username_and_domain_lower…'
-      if ActiveRecord::Migrator.current_version < MIGRATION_CHANGES[:adds_fixed_lowercase_index_accounts]
+      if migrator_version < MIGRATION_CHANGES[:adds_fixed_lowercase_index_accounts]
         ActiveRecord::Base.connection.add_index :accounts, 'lower (username), lower(domain)', name: 'index_accounts_on_username_and_domain_lower', unique: true
       else
         ActiveRecord::Base.connection.add_index :accounts, "lower (username), COALESCE(lower(domain), '')", name: 'index_accounts_on_username_and_domain_lower', unique: true
@@ -251,7 +251,7 @@ module Mastodon::CLI
       ActiveRecord::Base.connection.execute('REINDEX INDEX search_index;')
       ActiveRecord::Base.connection.execute('REINDEX INDEX index_accounts_on_uri;')
       ActiveRecord::Base.connection.execute('REINDEX INDEX index_accounts_on_url;')
-      ActiveRecord::Base.connection.execute('REINDEX INDEX index_accounts_on_domain_and_id;') if ActiveRecord::Migrator.current_version >= MIGRATION_CHANGES[:adds_index_accounts_domain_id]
+      ActiveRecord::Base.connection.execute('REINDEX INDEX index_accounts_on_domain_and_id;') if migrator_version >= MIGRATION_CHANGES[:adds_index_accounts_domain_id]
     end
 
     def deduplicate_users!
@@ -282,15 +282,15 @@ module Mastodon::CLI
       say 'Restoring users indexes…'
       ActiveRecord::Base.connection.add_index :users, ['confirmation_token'], name: 'index_users_on_confirmation_token', unique: true
       ActiveRecord::Base.connection.add_index :users, ['email'], name: 'index_users_on_email', unique: true
-      ActiveRecord::Base.connection.add_index :users, ['remember_token'], name: 'index_users_on_remember_token', unique: true if ActiveRecord::Migrator.current_version < MIGRATION_CHANGES[:remove_index_users_remember_token]
+      ActiveRecord::Base.connection.add_index :users, ['remember_token'], name: 'index_users_on_remember_token', unique: true if migrator_version < MIGRATION_CHANGES[:remove_index_users_remember_token]
 
-      if ActiveRecord::Migrator.current_version < MIGRATION_CHANGES[:optimizes_null_index_users_reset_password_token]
+      if migrator_version < MIGRATION_CHANGES[:optimizes_null_index_users_reset_password_token]
         ActiveRecord::Base.connection.add_index :users, ['reset_password_token'], name: 'index_users_on_reset_password_token', unique: true
       else
         ActiveRecord::Base.connection.add_index :users, ['reset_password_token'], name: 'index_users_on_reset_password_token', unique: true, where: 'reset_password_token IS NOT NULL', opclass: :text_pattern_ops
       end
 
-      ActiveRecord::Base.connection.execute('REINDEX INDEX index_users_on_unconfirmed_email;') if ActiveRecord::Migrator.current_version >= MIGRATION_CHANGES[:adds_index_users_unconfirmed_email]
+      ActiveRecord::Base.connection.execute('REINDEX INDEX index_users_on_unconfirmed_email;') if migrator_version >= MIGRATION_CHANGES[:adds_index_users_unconfirmed_email]
     end
 
     def deduplicate_users_process_confirmation_token
@@ -305,7 +305,7 @@ module Mastodon::CLI
     end
 
     def deduplicate_users_process_remember_token
-      if ActiveRecord::Migrator.current_version < MIGRATION_CHANGES[:removes_index_users_remember_token]
+      if migrator_version < MIGRATION_CHANGES[:removes_index_users_remember_token]
         ActiveRecord::Base.connection.select_all("SELECT string_agg(id::text, ',') AS ids FROM users WHERE remember_token IS NOT NULL GROUP BY remember_token HAVING count(*) > 1").each do |row|
           users = User.where(id: row['ids'].split(',')).sort_by(&:updated_at).reverse.drop(1)
           say "Unsetting remember token for those accounts: #{users.map { |user| user.account.acct }.join(', ')}", :yellow
@@ -384,7 +384,7 @@ module Mastodon::CLI
       end
 
       say 'Restoring conversations indexes…'
-      if ActiveRecord::Migrator.current_version < MIGRATION_CHANGES[:optimizes_null_index_conversations_uri]
+      if migrator_version < MIGRATION_CHANGES[:optimizes_null_index_conversations_uri]
         ActiveRecord::Base.connection.add_index :conversations, ['uri'], name: 'index_conversations_on_uri', unique: true
       else
         ActiveRecord::Base.connection.add_index :conversations, ['uri'], name: 'index_conversations_on_uri', unique: true, where: 'uri IS NOT NULL', opclass: :text_pattern_ops
@@ -501,7 +501,7 @@ module Mastodon::CLI
       end
 
       say 'Restoring media_attachments indexes…'
-      if ActiveRecord::Migrator.current_version < MIGRATION_CHANGES[:optimizes_null_index_media_attachments_shortcode]
+      if migrator_version < MIGRATION_CHANGES[:optimizes_null_index_media_attachments_shortcode]
         ActiveRecord::Base.connection.add_index :media_attachments, ['shortcode'], name: 'index_media_attachments_on_shortcode', unique: true
       else
         ActiveRecord::Base.connection.add_index :media_attachments, ['shortcode'], name: 'index_media_attachments_on_shortcode', unique: true, where: 'shortcode IS NOT NULL', opclass: :text_pattern_ops
@@ -534,7 +534,7 @@ module Mastodon::CLI
       end
 
       say 'Restoring statuses indexes…'
-      if ActiveRecord::Migrator.current_version < MIGRATION_CHANGES[:optimizes_null_index_statuses_uri]
+      if migrator_version < MIGRATION_CHANGES[:optimizes_null_index_statuses_uri]
         ActiveRecord::Base.connection.add_index :statuses, ['uri'], name: 'index_statuses_on_uri', unique: true
       else
         ActiveRecord::Base.connection.add_index :statuses, ['uri'], name: 'index_statuses_on_uri', unique: true, where: 'uri IS NOT NULL', opclass: :text_pattern_ops
@@ -556,7 +556,7 @@ module Mastodon::CLI
       end
 
       say 'Restoring tags indexes…'
-      if ActiveRecord::Migrator.current_version < MIGRATION_CHANGES[:adds_case_insensitive_btree_index_tags]
+      if migrator_version < MIGRATION_CHANGES[:adds_case_insensitive_btree_index_tags]
         ActiveRecord::Base.connection.add_index :tags, 'lower((name)::text)', name: 'index_tags_on_name_lower', unique: true
       else
         ActiveRecord::Base.connection.execute 'CREATE UNIQUE INDEX CONCURRENTLY index_tags_on_name_lower_btree ON tags (lower(name) text_pattern_ops)'
@@ -718,6 +718,10 @@ module Mastodon::CLI
           next
         end
       end
+    end
+
+    def migrator_version
+      ActiveRecord::Migrator.current_version
     end
 
     def find_duplicate_accounts


### PR DESCRIPTION
When trying to reason through this class the numbers are sort of meaningless -- this adds some helper methods which replace the migration version numbers with their class names, and some wrapper query methods to make each condition (greater, less than, etc) slightly more sensible in context.