### PR TITLE
Handle negative offset param in `api/v2/search`

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -109,7 +109,7 @@ class Api::BaseController < ApplicationController
   end
 
   def require_valid_pagination_options!
-    render json: { error: 'Pagination values for `offset` and `limit` must be positive' }, status: 400 if pagination_options.values.map(&:to_i).any?(&:negative?)
+    render json: { error: 'Pagination values for `offset` and `limit` must be positive' }, status: 400 if pagination_options_invalid?
   end
 
   def require_user!
@@ -140,8 +140,8 @@ class Api::BaseController < ApplicationController
 
   private
 
-  def pagination_options
-    params.slice(:limit, :offset)
+  def pagination_options_invalid?
+    params.slice(:limit, :offset).values.map(&:to_i).any?(&:negative?)
   end
 
   def respond_with_error(code)

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -108,6 +108,10 @@ class Api::BaseController < ApplicationController
     render json: { error: 'Your login is currently disabled' }, status: 403 if current_user&.account&.unavailable?
   end
 
+  def require_valid_pagination_options!
+    render json: { error: 'Pagination values for `offset` and `limit` must be positive' }, status: 400 if pagination_options.values.map(&:to_i).any?(&:negative?)
+  end
+
   def require_user!
     if !current_user
       render json: { error: 'This method requires an authenticated user' }, status: 422
@@ -135,6 +139,10 @@ class Api::BaseController < ApplicationController
   end
 
   private
+
+  def pagination_options
+    params.slice(:limit, :offset)
+  end
 
   def respond_with_error(code)
     render json: { error: Rack::Utils::HTTP_STATUS_CODES[code] }, status: code

--- a/app/controllers/api/v2/search_controller.rb
+++ b/app/controllers/api/v2/search_controller.rb
@@ -12,6 +12,7 @@ class Api::V2::SearchController < Api::BaseController
     before_action :query_pagination_error, if: :pagination_requested?
     before_action :remote_resolve_error, if: :remote_resolve_requested?
   end
+  before_action :query_offset_error, if: [:pagination_requested?, :invalid_offset_value?]
 
   def index
     @search = Search.new(search_results)
@@ -36,8 +37,16 @@ class Api::V2::SearchController < Api::BaseController
     render json: { error: 'Search queries that resolve remote resources are not supported without authentication' }, status: 401
   end
 
+  def query_offset_error
+    render json: { error: 'Offset values for query pagination must be positive' }, status: 400
+  end
+
   def remote_resolve_requested?
     truthy_param?(:resolve)
+  end
+
+  def invalid_offset_value?
+    params[:offset].to_i.negative?
   end
 
   def pagination_requested?

--- a/app/controllers/api/v2/search_controller.rb
+++ b/app/controllers/api/v2/search_controller.rb
@@ -12,7 +12,7 @@ class Api::V2::SearchController < Api::BaseController
     before_action :query_pagination_error, if: :pagination_requested?
     before_action :remote_resolve_error, if: :remote_resolve_requested?
   end
-  before_action :query_offset_error, if: [:pagination_requested?, :invalid_offset_value?]
+  before_action :require_valid_pagination_options!
 
   def index
     @search = Search.new(search_results)
@@ -37,16 +37,8 @@ class Api::V2::SearchController < Api::BaseController
     render json: { error: 'Search queries that resolve remote resources are not supported without authentication' }, status: 401
   end
 
-  def query_offset_error
-    render json: { error: 'Offset values for query pagination must be positive' }, status: 400
-  end
-
   def remote_resolve_requested?
     truthy_param?(:resolve)
-  end
-
-  def invalid_offset_value?
-    params[:offset].to_i.negative?
   end
 
   def pagination_requested?

--- a/spec/requests/api/v2/search_spec.rb
+++ b/spec/requests/api/v2/search_spec.rb
@@ -60,6 +60,16 @@ describe 'Search API' do
           end
         end
 
+        context 'with negative `limit` value' do
+          let(:params) { { q: 'test1', limit: '-100', type: 'accounts' } }
+
+          it 'returns http bad_request' do
+            get '/api/v2/search', headers: headers, params: params
+
+            expect(response).to have_http_status(400)
+          end
+        end
+
         context 'with following=true' do
           let(:params) { { q: 'test', type: 'accounts', following: 'true' } }
 

--- a/spec/requests/api/v2/search_spec.rb
+++ b/spec/requests/api/v2/search_spec.rb
@@ -40,13 +40,23 @@ describe 'Search API' do
           end
         end
 
-        context 'with `offset`' do
+        context 'with valid `offset` value' do
           let(:params) { { q: 'test1', offset: 1 } }
 
           it 'returns http unauthorized' do
             get '/api/v2/search', headers: headers, params: params
 
             expect(response).to have_http_status(200)
+          end
+        end
+
+        context 'with negative `offset` value' do
+          let(:params) { { q: 'test1', offset: '-100', type: 'accounts' } }
+
+          it 'returns http bad_request' do
+            get '/api/v2/search', headers: headers, params: params
+
+            expect(response).to have_http_status(400)
           end
         end
 


### PR DESCRIPTION
As alternative to https://github.com/mastodon/mastodon/pull/28256 this catches the offset error more narrowly just within the search controller, and returns 400 when invalid value present.

I put this directly in search because it's the most specific case ... but probably, this should actually live in the API::Base controller class? I guess the question there is can we safely assume that everywhere across the api that a `params[:offset]` is present, we want to check its value this way?