### PR TITLE
Combine `CLI::...` spec example subjects

### DIFF
--- a/spec/lib/mastodon/cli/accounts_spec.rb
+++ b/spec/lib/mastodon/cli/accounts_spec.rb
@@ -620,22 +620,17 @@ describe Mastodon::CLI::Accounts do
       let(:user) { account.user }
       let(:arguments) { [account.username] }
 
-      it 'creates a new backup for the specified user' do
-        expect { subject }.to change { user.backups.count }.by(1)
-      end
+      before { allow(BackupWorker).to receive(:perform_async) }
 
-      it 'creates a backup job' do
-        allow(BackupWorker).to receive(:perform_async)
-
-        subject
-        latest_backup = user.backups.last
-
+      it 'creates a new backup and backup job for the specified user and outputs success message' do
+        expect { subject }
+          .to change { user.backups.count }.by(1)
+          .and output_results('OK')
         expect(BackupWorker).to have_received(:perform_async).with(latest_backup.id).once
       end
 
-      it 'displays a successful message' do
-        expect { subject }
-          .to output_results('OK')
+      def latest_backup
+        user.backups.last
       end
     end
   end

--- a/spec/lib/mastodon/cli/accounts_spec.rb
+++ b/spec/lib/mastodon/cli/accounts_spec.rb
@@ -496,15 +496,10 @@ describe Mastodon::CLI::Accounts do
       context 'when the given number is greater than the number of users' do
         let(:options) { { number: total_users * 2 } }
 
-        it 'approves all users' do
-          subject
-
-          expect(User.pluck(:approved).all?(true)).to be(true)
-        end
-
-        it 'does not raise any error' do
+        it 'approves all users and does not raise any error' do
           expect { subject }
             .to_not raise_error
+          expect(User.pluck(:approved).all?(true)).to be(true)
         end
       end
     end

--- a/spec/lib/mastodon/cli/accounts_spec.rb
+++ b/spec/lib/mastodon/cli/accounts_spec.rb
@@ -1215,25 +1215,14 @@ describe Mastodon::CLI::Accounts do
 
         before do
           accounts.each { |account| target_account.follow!(account) }
-        end
-
-        it 'resets all "following" relationships from the target account' do
-          subject
-
-          expect(target_account.reload.following).to be_empty
-        end
-
-        it 'calls BootstrapTimelineWorker once to rebuild the timeline' do
           allow(BootstrapTimelineWorker).to receive(:perform_async)
-
-          subject
-
-          expect(BootstrapTimelineWorker).to have_received(:perform_async).with(target_account.id).once
         end
 
-        it 'displays a successful message' do
+        it 'resets following relationships and displays a successful message and rebuilds timeline' do
           expect { subject }
             .to output_results("Processed #{total_relationships} relationships")
+          expect(target_account.reload.following).to be_empty
+          expect(BootstrapTimelineWorker).to have_received(:perform_async).with(target_account.id).once
         end
       end
 
@@ -1244,15 +1233,10 @@ describe Mastodon::CLI::Accounts do
           accounts.each { |account| account.follow!(target_account) }
         end
 
-        it 'resets all "followers" relationships from the target account' do
-          subject
-
-          expect(target_account.reload.followers).to be_empty
-        end
-
-        it 'displays a successful message' do
+        it 'resets followers relationships and displays a successful message' do
           expect { subject }
             .to output_results("Processed #{total_relationships} relationships")
+          expect(target_account.reload.followers).to be_empty
         end
       end
 
@@ -1262,31 +1246,15 @@ describe Mastodon::CLI::Accounts do
         before do
           accounts.first(2).each { |account| account.follow!(target_account) }
           accounts.last(1).each  { |account| target_account.follow!(account) }
-        end
-
-        it 'resets all "followers" relationships from the target account' do
-          subject
-
-          expect(target_account.reload.followers).to be_empty
-        end
-
-        it 'resets all "following" relationships from the target account' do
-          subject
-
-          expect(target_account.reload.following).to be_empty
-        end
-
-        it 'calls BootstrapTimelineWorker once to rebuild the timeline' do
           allow(BootstrapTimelineWorker).to receive(:perform_async)
-
-          subject
-
-          expect(BootstrapTimelineWorker).to have_received(:perform_async).with(target_account.id).once
         end
 
-        it 'displays a successful message' do
+        it 'resets followers and following and displays a successful message and rebuilds timeline' do
           expect { subject }
             .to output_results("Processed #{total_relationships} relationships")
+          expect(target_account.reload.followers).to be_empty
+          expect(target_account.reload.following).to be_empty
+          expect(BootstrapTimelineWorker).to have_received(:perform_async).with(target_account.id).once
         end
       end
     end

--- a/spec/lib/mastodon/cli/accounts_spec.rb
+++ b/spec/lib/mastodon/cli/accounts_spec.rb
@@ -1035,15 +1035,10 @@ describe Mastodon::CLI::Accounts do
           allow(from_account).to receive(:destroy)
         end
 
-        it 'merges "from_account" into "to_account"' do
+        it 'merges `from_account` into `to_account` and deletes `from_account`' do
           subject
 
           expect(to_account).to have_received(:merge_with!).with(from_account).once
-        end
-
-        it 'deletes "from_account"' do
-          subject
-
           expect(from_account).to have_received(:destroy).once
         end
       end

--- a/spec/lib/mastodon/cli/accounts_spec.rb
+++ b/spec/lib/mastodon/cli/accounts_spec.rb
@@ -554,17 +554,12 @@ describe Mastodon::CLI::Accounts do
         stub_parallelize_with_progress!
       end
 
-      it 'makes all local accounts follow the target account' do
-        subject
-
+      it 'displays a successful message and makes all local accounts follow the target account' do
+        expect { subject }
+          .to output_results("OK, followed target from #{Account.local.count} accounts")
         expect(follow_service).to have_received(:call).with(follower_bob, target_account, any_args).once
         expect(follow_service).to have_received(:call).with(follower_rony, target_account, any_args).once
         expect(follow_service).to have_received(:call).with(follower_charles, target_account, any_args).once
-      end
-
-      it 'displays a successful message' do
-        expect { subject }
-          .to output_results("OK, followed target from #{Account.local.count} accounts")
       end
     end
   end

--- a/spec/lib/mastodon/cli/accounts_spec.rb
+++ b/spec/lib/mastodon/cli/accounts_spec.rb
@@ -467,20 +467,19 @@ describe Mastodon::CLI::Accounts do
       context 'when the number is positive' do
         let(:options) { { number: 2 } }
 
-        it 'approves the earliest n pending registrations' do
+        it 'approves the earliest n pending registrations but not the remaining ones' do
           subject
-
-          n_earliest_pending_registrations = User.order(created_at: :asc).first(options[:number])
 
           expect(n_earliest_pending_registrations.all?(&:approved?)).to be(true)
+          expect(pending_registrations.all?(&:approved?)).to be(false)
         end
 
-        it 'does not approve the remaining pending registrations' do
-          subject
+        def n_earliest_pending_registrations
+          User.order(created_at: :asc).first(options[:number])
+        end
 
-          pending_registrations = User.order(created_at: :asc).last(total_users - options[:number])
-
-          expect(pending_registrations.all?(&:approved?)).to be(false)
+        def pending_registrations
+          User.order(created_at: :asc).last(total_users - options[:number])
         end
       end
 

--- a/spec/lib/mastodon/cli/accounts_spec.rb
+++ b/spec/lib/mastodon/cli/accounts_spec.rb
@@ -1117,16 +1117,15 @@ describe Mastodon::CLI::Accounts do
         stub_request(:head, 'https://example.net/users/tales').to_return(status: 404)
       end
 
-      it 'deletes inactive remote accounts that longer exist in the specified domain' do
-        subject
-
+      def expect_delete_inactive_remote_accounts
         expect(delete_account_service).to have_received(:call).with(gon, reserve_username: false).once
         expect(delete_account_service).to have_received(:call).with(tales, reserve_username: false).once
       end
 
-      it 'displays the summary correctly' do
+      it 'displays the summary correctly and deletes inactive remote accounts' do
         expect { subject }
           .to output_results('Visited 2 accounts, removed 2')
+        expect_delete_inactive_remote_accounts
       end
     end
 

--- a/spec/lib/mastodon/cli/accounts_spec.rb
+++ b/spec/lib/mastodon/cli/accounts_spec.rb
@@ -1058,15 +1058,10 @@ describe Mastodon::CLI::Accounts do
         allow(from_account).to receive(:destroy)
       end
 
-      it 'merges "from_account" into "to_account"' do
+      it 'merges "from_account" into "to_account" and deletes from_account' do
         subject
 
         expect(to_account).to have_received(:merge_with!).with(from_account).once
-      end
-
-      it 'deletes "from_account"' do
-        subject
-
         expect(from_account).to have_received(:destroy)
       end
     end

--- a/spec/lib/mastodon/cli/accounts_spec.rb
+++ b/spec/lib/mastodon/cli/accounts_spec.rb
@@ -34,23 +34,21 @@ describe Mastodon::CLI::Accounts do
     let(:action) { :create }
 
     shared_examples 'a new user with given email address and username' do
-      it 'creates a new user with the specified email address' do
-        subject
-
-        expect(User.find_by(email: options[:email])).to be_present
-      end
-
-      it 'creates a new local account with the specified username' do
-        subject
-
-        expect(Account.find_local('tootctl_username')).to be_present
-      end
-
-      it 'returns "OK" and newly generated password' do
+      it 'creates user and accounts from options and displays success message' do
         allow(SecureRandom).to receive(:hex).and_return('test_password')
 
         expect { subject }
-          .to output_results("OK\nNew password: test_password")
+          .to output_results('OK', 'New password: test_password')
+        expect(user_from_options).to be_present
+        expect(account_from_options).to be_present
+      end
+
+      def user_from_options
+        User.find_by(email: options[:email])
+      end
+
+      def account_from_options
+        Account.find_local('tootctl_username')
       end
     end
 

--- a/spec/lib/mastodon/cli/accounts_spec.rb
+++ b/spec/lib/mastodon/cli/accounts_spec.rb
@@ -1103,13 +1103,10 @@ describe Mastodon::CLI::Accounts do
         expect(delete_account_service).to_not have_received(:call).with(tales, reserve_username: false)
       end
 
-      it 'touches inactive remote accounts that have not been deleted' do
-        expect { subject }.to(change { tales.reload.updated_at })
-      end
-
-      it 'displays the summary correctly' do
+      it 'touches inactive remote accounts that have not been deleted and summarizes activity' do
         expect { subject }
-          .to output_results('Visited 5 accounts, removed 2')
+          .to change { tales.reload.updated_at }
+          .and output_results('Visited 5 accounts, removed 2')
       end
     end
 

--- a/spec/lib/mastodon/cli/accounts_spec.rb
+++ b/spec/lib/mastodon/cli/accounts_spec.rb
@@ -1275,57 +1275,51 @@ describe Mastodon::CLI::Accounts do
       stub_parallelize_with_progress!
     end
 
-    it 'prunes all remote accounts with no interactions with local users' do
-      subject
-
+    def expect_prune_remote_accounts_without_interaction
       prunable_account_ids = prunable_accounts.pluck(:id)
 
       expect(Account.where(id: prunable_account_ids).count).to eq(0)
     end
 
-    it 'displays a successful message' do
+    it 'displays a successful message and handles accounts correctly' do
       expect { subject }
         .to output_results("OK, pruned #{prunable_accounts.size} accounts")
+      expect_prune_remote_accounts_without_interaction
+      expect_not_prune_local_accounts
+      expect_not_prune_bot_accounts
+      expect_not_prune_group_accounts
+      expect_not_prune_mentioned_accounts
     end
 
-    it 'does not prune local accounts' do
-      subject
-
+    def expect_not_prune_local_accounts
       expect(Account.exists?(id: local_account.id)).to be(true)
     end
 
-    it 'does not prune bot accounts' do
-      subject
-
+    def expect_not_prune_bot_accounts
       expect(Account.exists?(id: bot_account.id)).to be(true)
     end
 
-    it 'does not prune group accounts' do
-      subject
-
+    def expect_not_prune_group_accounts
       expect(Account.exists?(id: group_account.id)).to be(true)
     end
 
-    it 'does not prune accounts that have been mentioned' do
-      subject
-
+    def expect_not_prune_mentioned_accounts
       expect(Account.exists?(id: mentioned_account.id)).to be true
     end
 
     context 'with --dry-run option' do
       let(:options) { { dry_run: true } }
 
-      it 'does not prune any account' do
-        subject
-
+      def expect_no_account_prunes
         prunable_account_ids = prunable_accounts.pluck(:id)
 
         expect(Account.where(id: prunable_account_ids).count).to eq(prunable_accounts.size)
       end
 
-      it 'displays a successful message with (DRY RUN)' do
+      it 'displays a successful message with (DRY RUN) and doesnt prune anything' do
         expect { subject }
           .to output_results("OK, pruned #{prunable_accounts.size} accounts (DRY RUN)")
+        expect_no_account_prunes
       end
     end
   end

--- a/spec/lib/mastodon/cli/accounts_spec.rb
+++ b/spec/lib/mastodon/cli/accounts_spec.rb
@@ -592,17 +592,12 @@ describe Mastodon::CLI::Accounts do
         stub_parallelize_with_progress!
       end
 
-      it 'makes all local accounts unfollow the target account' do
-        subject
-
+      it 'displays a successful message and makes all local accounts unfollow the target account' do
+        expect { subject }
+          .to output_results('OK, unfollowed target from 3 accounts')
         expect(unfollow_service).to have_received(:call).with(follower_chris, target_account).once
         expect(unfollow_service).to have_received(:call).with(follower_rambo, target_account).once
         expect(unfollow_service).to have_received(:call).with(follower_ana, target_account).once
-      end
-
-      it 'displays a successful message' do
-        expect { subject }
-          .to output_results('OK, unfollowed target from 3 accounts')
       end
     end
   end

--- a/spec/lib/mastodon/cli/accounts_spec.rb
+++ b/spec/lib/mastodon/cli/accounts_spec.rb
@@ -393,15 +393,10 @@ describe Mastodon::CLI::Accounts do
       context 'with --dry-run option' do
         let(:options) { { dry_run: true } }
 
-        it 'does not delete the specified user' do
-          subject
-
-          expect(delete_account_service).to_not have_received(:call).with(account, reserve_email: false)
-        end
-
-        it 'outputs a successful message in dry run mode' do
+        it 'outputs a successful message in dry run mode and does not delete the user' do
           expect { subject }
             .to output_results('OK (DRY RUN)')
+          expect(delete_account_service).to_not have_received(:call).with(account, reserve_email: false)
         end
       end
 

--- a/spec/lib/mastodon/cli/accounts_spec.rb
+++ b/spec/lib/mastodon/cli/accounts_spec.rb
@@ -1088,16 +1088,12 @@ describe Mastodon::CLI::Accounts do
         stub_request(:head, 'https://example.net/users/tales').to_return(status: 200)
       end
 
-      it 'deletes all inactive remote accounts that longer exist in the origin server' do
-        subject
-
+      def expect_delete_inactive_remote_accounts
         expect(delete_account_service).to have_received(:call).with(bob, reserve_username: false).once
         expect(delete_account_service).to have_received(:call).with(gon, reserve_username: false).once
       end
 
-      it 'does not delete any active remote account that still exists in the origin server' do
-        subject
-
+      def expect_not_delete_active_accounts
         expect(delete_account_service).to_not have_received(:call).with(tom, reserve_username: false)
         expect(delete_account_service).to_not have_received(:call).with(ana, reserve_username: false)
         expect(delete_account_service).to_not have_received(:call).with(tales, reserve_username: false)
@@ -1107,6 +1103,8 @@ describe Mastodon::CLI::Accounts do
         expect { subject }
           .to change { tales.reload.updated_at }
           .and output_results('Visited 5 accounts, removed 2')
+        expect_delete_inactive_remote_accounts
+        expect_not_delete_active_accounts
       end
     end
 

--- a/spec/lib/mastodon/cli/accounts_spec.rb
+++ b/spec/lib/mastodon/cli/accounts_spec.rb
@@ -927,15 +927,15 @@ describe Mastodon::CLI::Accounts do
 
         expect(ActivityPub::UpdateDistributionWorker).to have_received(:perform_in).with(anything, account.id, anything).once
       end
+    end
 
-      context 'when the given username is not found' do
-        let(:arguments) { ['non_existent_username'] }
+    context 'when the given username is not found' do
+      let(:arguments) { ['non_existent_username'] }
 
-        it 'exits with an error message when the specified username is not found' do
-          expect { subject }
-            .to output_results('No such account')
-            .and raise_error(SystemExit)
-        end
+      it 'exits with an error message when the specified username is not found' do
+        expect { subject }
+          .to output_results('No such account')
+          .and raise_error(SystemExit)
       end
     end
 

--- a/spec/lib/mastodon/cli/accounts_spec.rb
+++ b/spec/lib/mastodon/cli/accounts_spec.rb
@@ -423,15 +423,12 @@ describe Mastodon::CLI::Accounts do
       context 'with --dry-run option' do
         let(:options) { { email: account.user.email, dry_run: true } }
 
-        it 'does not delete the user' do
-          subject
-
-          expect(delete_account_service).to_not have_received(:call).with(account, reserve_email: false)
-        end
-
-        it 'outputs a successful message in dry run mode' do
+        it 'outputs a successful message in dry run mode and does not delete the user' do
           expect { subject }
             .to output_results('OK (DRY RUN)')
+          expect(delete_account_service)
+            .to_not have_received(:call)
+            .with(account, reserve_email: false)
         end
       end
 

--- a/spec/lib/mastodon/cli/accounts_spec.rb
+++ b/spec/lib/mastodon/cli/accounts_spec.rb
@@ -197,14 +197,9 @@ describe Mastodon::CLI::Accounts do
       let(:arguments) { [user.account.username] }
 
       context 'when no option is provided' do
-        it 'returns a successful message' do
+        it 'returns a successful message and preserves user' do
           expect { subject }
             .to output_results('OK')
-        end
-
-        it 'does not modify the user' do
-          subject
-
           expect(user).to eq(user.reload)
         end
       end

--- a/spec/lib/mastodon/cli/accounts_spec.rb
+++ b/spec/lib/mastodon/cli/accounts_spec.rb
@@ -1137,15 +1137,14 @@ describe Mastodon::CLI::Accounts do
           stub_request(:head, 'https://example.net/users/gon').to_return(status: 200)
         end
 
-        it 'skips accounts from the unavailable domain' do
-          subject
-
+        def expect_skip_accounts_from_unavailable_domain
           expect(delete_account_service).to_not have_received(:call).with(tales, reserve_username: false)
         end
 
-        it 'displays the summary correctly' do
+        it 'displays the summary correctly and skip accounts from unavailable domains' do
           expect { subject }
             .to output_results("Visited 5 accounts, removed 0\nThe following domains were not available during the check:\n    example.net")
+          expect_skip_accounts_from_unavailable_domain
         end
       end
 

--- a/spec/lib/mastodon/cli/ip_blocks_spec.rb
+++ b/spec/lib/mastodon/cli/ip_blocks_spec.rb
@@ -33,26 +33,25 @@ describe Mastodon::CLI::IpBlocks do
     let(:arguments) { ip_list }
 
     shared_examples 'ip address blocking' do
-      it 'blocks all specified IP addresses' do
-        subject
-
-        blocked_ip_addresses = IpBlock.where(ip: ip_list).pluck(:ip)
-        expected_ip_addresses = ip_list.map { |ip| IPAddr.new(ip) }
-
-        expect(blocked_ip_addresses).to match_array(expected_ip_addresses)
+      def blocked_ip_addresses
+        IpBlock.where(ip: ip_list).pluck(:ip)
       end
 
-      it 'sets the severity for all blocked IP addresses' do
-        subject
-
-        blocked_ips_severity = IpBlock.where(ip: ip_list).pluck(:severity).all?(options[:severity])
-
-        expect(blocked_ips_severity).to be(true)
+      def expected_ip_addresses
+        ip_list.map { |ip| IPAddr.new(ip) }
       end
 
-      it 'displays a success message with a summary' do
+      def blocked_ips_severity
+        IpBlock.where(ip: ip_list).pluck(:severity).all?(options[:severity])
+      end
+
+      it 'blocks and sets severity for ip address and displays summary' do
         expect { subject }
           .to output_results("Added #{ip_list.size}, skipped 0, failed 0")
+        expect(blocked_ip_addresses)
+          .to match_array(expected_ip_addresses)
+        expect(blocked_ips_severity)
+          .to be(true)
       end
     end
 
@@ -64,17 +63,13 @@ describe Mastodon::CLI::IpBlocks do
       let!(:blocked_ip) { IpBlock.create(ip: ip_list.last, severity: options[:severity]) }
       let(:arguments) { ip_list }
 
-      it 'skips the already blocked IP address' do
-        allow(IpBlock).to receive(:new).and_call_original
+      before { allow(IpBlock).to receive(:new).and_call_original }
 
-        subject
-
-        expect(IpBlock).to_not have_received(:new).with(ip: ip_list.last)
-      end
-
-      it 'displays the correct summary' do
+      it 'skips already block ip and displays the correct summary' do
         expect { subject }
           .to output_results("#{ip_list.last} is already blocked\nAdded #{ip_list.size - 1}, skipped 1, failed 0")
+
+        expect(IpBlock).to_not have_received(:new).with(ip: ip_list.last)
       end
 
       context 'with --force option' do
@@ -179,15 +174,10 @@ describe Mastodon::CLI::IpBlocks do
         ip_list.each { |ip| IpBlock.create(ip: ip, severity: :no_access) }
       end
 
-      it 'removes exact IP blocks' do
-        subject
-
-        expect(IpBlock.where(ip: ip_list)).to_not exist
-      end
-
-      it 'displays success message with a summary' do
+      it 'removes exact ip blocks and displays success message with a summary' do
         expect { subject }
           .to output_results("Removed #{ip_list.size}, skipped 0")
+        expect(IpBlock.where(ip: ip_list)).to_not exist
       end
     end
 
@@ -198,16 +188,19 @@ describe Mastodon::CLI::IpBlocks do
       let(:arguments) { ['192.168.0.5', '10.0.1.50'] }
       let(:options) { { force: true } }
 
-      it 'removes blocks for IP ranges that cover given IP(s)' do
+      it 'removes blocks for IP ranges that cover given IP(s) and keeps other ranges' do
         subject
 
-        expect(IpBlock.where(id: [first_ip_range_block.id, second_ip_range_block.id])).to_not exist
+        expect(covered_ranges).to_not exist
+        expect(other_ranges).to exist
       end
 
-      it 'does not remove other IP ranges' do
-        subject
+      def covered_ranges
+        IpBlock.where(id: [first_ip_range_block.id, second_ip_range_block.id])
+      end
 
-        expect(IpBlock.where(id: third_ip_range_block.id)).to exist
+      def other_ranges
+        IpBlock.where(id: third_ip_range_block.id)
       end
     end
 
@@ -215,14 +208,12 @@ describe Mastodon::CLI::IpBlocks do
       let(:unblocked_ip) { '192.0.2.1' }
       let(:arguments) { [unblocked_ip] }
 
-      it 'skips the IP address' do
+      it 'skips the IP address and displays summary' do
         expect { subject }
-          .to output_results("#{unblocked_ip} is not yet blocked")
-      end
-
-      it 'displays the summary correctly' do
-        expect { subject }
-          .to output_results('Removed 0, skipped 1')
+          .to output_results(
+            "#{unblocked_ip} is not yet blocked",
+            'Removed 0, skipped 1'
+          )
       end
     end
 
@@ -230,14 +221,12 @@ describe Mastodon::CLI::IpBlocks do
       let(:invalid_ip) { '320.15.175.0' }
       let(:arguments) { [invalid_ip] }
 
-      it 'skips the invalid IP address' do
+      it 'skips the invalid IP address and displays summary' do
         expect { subject }
-          .to output_results("#{invalid_ip} is invalid")
-      end
-
-      it 'displays the summary correctly' do
-        expect { subject }
-          .to output_results('Removed 0, skipped 1')
+          .to output_results(
+            "#{invalid_ip} is invalid",
+            'Removed 0, skipped 1'
+          )
       end
     end
 
@@ -265,7 +254,7 @@ describe Mastodon::CLI::IpBlocks do
           .to output_results("#{first_ip_range_block.ip}/#{first_ip_range_block.ip.prefix}\n#{second_ip_range_block.ip}/#{second_ip_range_block.ip.prefix}")
       end
 
-      it 'does not export bloked IPs with different severities' do
+      it 'does not export blocked IPs with different severities' do
         expect { subject }
           .to_not output_results("#{third_ip_range_block.ip}/#{first_ip_range_block.ip.prefix}")
       end
@@ -279,7 +268,7 @@ describe Mastodon::CLI::IpBlocks do
           .to output_results("deny #{first_ip_range_block.ip}/#{first_ip_range_block.ip.prefix};\ndeny #{second_ip_range_block.ip}/#{second_ip_range_block.ip.prefix};")
       end
 
-      it 'does not export bloked IPs with different severities' do
+      it 'does not export blocked IPs with different severities' do
         expect { subject }
           .to_not output_results("deny #{third_ip_range_block.ip}/#{first_ip_range_block.ip.prefix};")
       end

--- a/spec/lib/mastodon/cli/settings_spec.rb
+++ b/spec/lib/mastodon/cli/settings_spec.rb
@@ -20,37 +20,29 @@ describe Mastodon::CLI::Settings do
     describe '#open' do
       let(:action) { :open }
 
-      it 'changes "registrations_mode" to "open"' do
-        expect { subject }.to change(Setting, :registrations_mode).from(nil).to('open')
-      end
-
-      it 'displays success message' do
+      it 'changes "registrations_mode" to "open" and displays success' do
         expect { subject }
-          .to output_results('OK')
+          .to change(Setting, :registrations_mode).from(nil).to('open')
+          .and output_results('OK')
       end
     end
 
     describe '#approved' do
       let(:action) { :approved }
 
-      it 'changes "registrations_mode" to "approved"' do
-        expect { subject }.to change(Setting, :registrations_mode).from(nil).to('approved')
-      end
-
-      it 'displays success message' do
+      it 'changes "registrations_mode" to "approved" and displays success' do
         expect { subject }
-          .to output_results('OK')
+          .to change(Setting, :registrations_mode).from(nil).to('approved')
+          .and output_results('OK')
       end
 
       context 'with --require-reason' do
         let(:options) { { require_reason: true } }
 
-        it 'changes "registrations_mode" to "approved"' do
-          expect { subject }.to change(Setting, :registrations_mode).from(nil).to('approved')
-        end
-
-        it 'sets "require_invite_text" to "true"' do
-          expect { subject }.to change(Setting, :require_invite_text).from(false).to(true)
+        it 'changes registrations_mode and require_invite_text' do
+          expect { subject }
+            .to change(Setting, :registrations_mode).from(nil).to('approved')
+            .and change(Setting, :require_invite_text).from(false).to(true)
         end
       end
     end
@@ -58,13 +50,10 @@ describe Mastodon::CLI::Settings do
     describe '#close' do
       let(:action) { :close }
 
-      it 'changes "registrations_mode" to "none"' do
-        expect { subject }.to change(Setting, :registrations_mode).from(nil).to('none')
-      end
-
-      it 'displays success message' do
+      it 'changes "registrations_mode" to "none" and displays success' do
         expect { subject }
-          .to output_results('OK')
+          .to change(Setting, :registrations_mode).from(nil).to('none')
+          .and output_results('OK')
       end
     end
   end


### PR DESCRIPTION
I started to do some of this as part of https://github.com/mastodon/mastodon/pull/28255 but the diff was unwieldy so I held off. This is basically another once over on the CLI specs to reduce the amount of double/triple `subject` calling where it makes sense.

Preserves coverage, but reduces runtime of the CLI specs alone from ~15s to ~11s.

Vast majority here are in accounts spec ... and I once again held off there on touching the `refresh` stuff, because it needs further update first.