### PR TITLE
Only attempt to remove indexes that exist in `CLI::Maintenance` script

### DIFF
--- a/lib/mastodon/cli/maintenance.rb
+++ b/lib/mastodon/cli/maintenance.rb
@@ -712,7 +712,7 @@ module Mastodon::CLI
     end
 
     def remove_index_if_exists!(table, name)
-      ActiveRecord::Base.connection.remove_index(table, name: name)
+      ActiveRecord::Base.connection.remove_index(table, name: name) if ActiveRecord::Base.connection.index_name_exists?(table, name)
     rescue ArgumentError, ActiveRecord::StatementInvalid
       nil
     end


### PR DESCRIPTION
We're currently always attempting to remove the index and relying on catching a sql db error when the index does not exist to move on in the code ... this adds a guard clause to not attempt the index removal if we know in advance that the index does not exist, while preserving the error catching in case something else is wrong with the query.