### PR TITLE
Fix intermittent failure from unspecified order in `api/v1/accounts/relationships` spec

### DIFF
--- a/spec/requests/api/v1/accounts/relationships_spec.rb
+++ b/spec/requests/api/v1/accounts/relationships_spec.rb
@@ -31,8 +31,8 @@ describe 'GET /api/v1/accounts/relationships' do
         .to have_http_status(200)
       expect(body_as_json)
         .to be_an(Enumerable)
-        .and have_attributes(
-          first: include(
+        .and contain_exactly(
+          include(
             following: true,
             followed_by: false
           )
@@ -53,9 +53,11 @@ describe 'GET /api/v1/accounts/relationships' do
           expect(body_as_json)
             .to be_an(Enumerable)
             .and have_attributes(
-              size: 2,
-              first: include(simon_item),
-              second: include(lewis_item)
+              size: 2
+            )
+            .and contain_exactly(
+              include(simon_item),
+              include(lewis_item)
             )
         end
       end
@@ -71,10 +73,12 @@ describe 'GET /api/v1/accounts/relationships' do
           expect(body_as_json)
             .to be_an(Enumerable)
             .and have_attributes(
-              size: 3,
-              first: include(simon_item),
-              second: include(lewis_item),
-              third: include(bob_item)
+              size: 3
+            )
+            .and contain_exactly(
+              include(simon_item),
+              include(lewis_item),
+              include(bob_item)
             )
         end
       end
@@ -88,9 +92,11 @@ describe 'GET /api/v1/accounts/relationships' do
           expect(body_as_json)
             .to be_an(Enumerable)
             .and have_attributes(
-              size: 2,
-              first: include(simon_item),
-              second: include(lewis_item)
+              size: 2
+            )
+            .and contain_exactly(
+              include(simon_item),
+              include(lewis_item)
             )
         end
       end
@@ -116,7 +122,6 @@ describe 'GET /api/v1/accounts/relationships' do
           muting: false,
           requested: false,
           domain_blocking: false,
-
         }
       end
 
@@ -129,7 +134,6 @@ describe 'GET /api/v1/accounts/relationships' do
           muting: false,
           requested: false,
           domain_blocking: false,
-
         }
       end
     end
@@ -149,8 +153,10 @@ describe 'GET /api/v1/accounts/relationships' do
       expect(body_as_json)
         .to be_an(Enumerable)
         .and have_attributes(
-          size: 1,
-          first: include(
+          size: 1
+        )
+        .and contain_exactly(
+          include(
             following: true,
             showing_reblogs: true
           )
@@ -168,8 +174,8 @@ describe 'GET /api/v1/accounts/relationships' do
 
       expect(body_as_json)
         .to be_an(Enumerable)
-        .and have_attributes(
-          first: include(
+        .and contain_exactly(
+          include(
             following: false,
             showing_reblogs: false
           )


### PR DESCRIPTION
There is no `order` provided in the response here on the controller side, so I think on some runs the order of creating the factory data and/or the return order of the sql/controller is different than what's expected.

Another option here would be to change the API to specify an order, but this fix seems like it probably needs less discussion, so went this route.