### PR TITLE
Fix `Style/RedundantArgument` cop

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -114,7 +114,7 @@ module ApplicationHelper
   end
 
   def fa_icon(icon, attributes = {})
-    class_names = attributes[:class]&.split(' ') || []
+    class_names = attributes[:class]&.split || []
     class_names << 'fa'
     class_names += icon.split.map { |cl| "fa-#{cl}" }
 


### PR DESCRIPTION
This is the only issue from this run - https://github.com/mastodon/mastodon/actions/runs/7168303837/job/19516178343?pr=28320 - I believe after this and a renovate rebase, that 1.59.0 bump will be fine.