### PR TITLE
Add spec for `CLI::Maintenance#fix_duplicates`

### DIFF
--- a/lib/mastodon/cli/maintenance.rb
+++ b/lib/mastodon/cli/maintenance.rb
@@ -267,7 +267,7 @@ module Mastodon::CLI
       deduplicate_users_process_password_token
 
       say 'Restoring users indexes…'
-      ActiveRecord::Base.connection.add_index :users, ['confirmation_token'], name: 'index_users_on_confirmation_token', unique: true
+      ActiveRecord::Base.connection.add_index :users, ['confirmation_token'], name: 'index_users_on_confirmation_token', unique: true unless ActiveRecord::Base.connection.index_name_exists?(:users, :index_users_on_confirmation_token)
       ActiveRecord::Base.connection.add_index :users, ['email'], name: 'index_users_on_email', unique: true
       ActiveRecord::Base.connection.add_index :users, ['remember_token'], name: 'index_users_on_remember_token', unique: true if migrator_version < 2022_01_18_183010
 
@@ -546,7 +546,7 @@ module Mastodon::CLI
       if migrator_version < 2021_04_21_121431
         ActiveRecord::Base.connection.add_index :tags, 'lower((name)::text)', name: 'index_tags_on_name_lower', unique: true
       else
-        ActiveRecord::Base.connection.execute 'CREATE UNIQUE INDEX CONCURRENTLY index_tags_on_name_lower_btree ON tags (lower(name) text_pattern_ops)'
+        ActiveRecord::Base.connection.execute 'CREATE UNIQUE INDEX index_tags_on_name_lower_btree ON tags (lower(name) text_pattern_ops)'
       end
     end
 

--- a/lib/mastodon/cli/maintenance.rb
+++ b/lib/mastodon/cli/maintenance.rb
@@ -267,7 +267,7 @@ module Mastodon::CLI
       deduplicate_users_process_password_token
 
       say 'Restoring users indexes…'
-      ActiveRecord::Base.connection.add_index :users, ['confirmation_token'], name: 'index_users_on_confirmation_token', unique: true unless ActiveRecord::Base.connection.index_name_exists?(:users, :index_users_on_confirmation_token)
+      ActiveRecord::Base.connection.add_index :users, ['confirmation_token'], name: 'index_users_on_confirmation_token', unique: true
       ActiveRecord::Base.connection.add_index :users, ['email'], name: 'index_users_on_email', unique: true
       ActiveRecord::Base.connection.add_index :users, ['remember_token'], name: 'index_users_on_remember_token', unique: true if migrator_version < 2022_01_18_183010
 

--- a/spec/lib/mastodon/cli/maintenance_spec.rb
+++ b/spec/lib/mastodon/cli/maintenance_spec.rb
@@ -64,10 +64,12 @@ describe Mastodon::CLI::Maintenance do
           prepare_duplicate_data
         end
 
+        let(:duplicate_account_username) { 'username' }
+        let(:duplicate_account_domain) { 'host.example' }
+
         it 'runs the deduplication process' do
           expect { subject }
             .to output_results(
-              'will take a long time',
               'Deduplicating accounts',
               'Restoring index_accounts_on_username_and_domain_lower',
               'Reindexing textual indexes on accounts…',
@@ -77,13 +79,13 @@ describe Mastodon::CLI::Maintenance do
         end
 
         def duplicate_accounts
-          Account.where(username: 'one', domain: 'host.example')
+          Account.where(username: duplicate_account_username, domain: duplicate_account_domain)
         end
 
         def prepare_duplicate_data
           ActiveRecord::Base.connection.remove_index :accounts, name: :index_accounts_on_username_and_domain_lower
-          Fabricate(:account, username: 'one', domain: 'host.example')
-          Fabricate.build(:account, username: 'one', domain: 'host.example').save(validate: false)
+          Fabricate(:account, username: duplicate_account_username, domain: duplicate_account_domain)
+          Fabricate.build(:account, username: duplicate_account_username, domain: duplicate_account_domain).save(validate: false)
         end
       end
 
@@ -92,10 +94,11 @@ describe Mastodon::CLI::Maintenance do
           prepare_duplicate_data
         end
 
+        let(:duplicate_email) { 'duplicate@example.host' }
+
         it 'runs the deduplication process' do
           expect { subject }
             .to output_results(
-              'will take a long time',
               'Deduplicating user records',
               'Restoring users indexes',
               'Finished!'
@@ -104,13 +107,13 @@ describe Mastodon::CLI::Maintenance do
         end
 
         def duplicate_users
-          User.where(email: 'duplicate@example.host')
+          User.where(email: duplicate_email)
         end
 
         def prepare_duplicate_data
           ActiveRecord::Base.connection.remove_index :users, :email
-          Fabricate(:user, email: 'duplicate@example.host')
-          Fabricate.build(:user, email: 'duplicate@example.host').save(validate: false)
+          Fabricate(:user, email: duplicate_email)
+          Fabricate.build(:user, email: duplicate_email).save(validate: false)
         end
       end
 

--- a/spec/lib/mastodon/cli/maintenance_spec.rb
+++ b/spec/lib/mastodon/cli/maintenance_spec.rb
@@ -53,7 +53,7 @@ describe Mastodon::CLI::Maintenance do
       end
     end
 
-    context 'when requirements are met', use_transactional_tests: false do
+    context 'when requirements are met' do
       before do
         allow(ActiveRecord::Migrator).to receive(:current_version).and_return(2023_08_22_081029) # The latest migration before the cutoff
         allow(Sidekiq::ProcessSet).to receive(:new).and_return []

--- a/spec/lib/mastodon/cli/maintenance_spec.rb
+++ b/spec/lib/mastodon/cli/maintenance_spec.rb
@@ -57,7 +57,6 @@ describe Mastodon::CLI::Maintenance do
       before do
         prepare_duplicate_data
         allow(ActiveRecord::Migrator).to receive(:current_version).and_return(2023_08_22_081029) # The latest migration before the cutoff
-        allow(Sidekiq::ProcessSet).to receive(:new).and_return []
         agree_to_backup_warning
       end
 


### PR DESCRIPTION
As mentioned here - https://github.com/mastodon/mastodon/pull/28289#issuecomment-1850329071 - I had previously attempted (https://github.com/mastodon/mastodon/pull/25252#issuecomment-1792814199) to add some coverage for this method, but with the approach I had at the time I had to disable transactions for the specs, and we viewed that as too awkward to possibly mess around with db schema when not safely in a transaction-wrapped example. I had removed those portions from the PR and the rest was merged.

This is another pass at getting some coverage in place here, but without disabling transactions.

For this first effort, I've just added accounts/users to show the general approach, but if we like this version better I can work after merge to add more of the model cases.

There's one thing here I could not work around that I'll leave an inline comment about to figure out a direction.