### PR TITLE
Fix N+1s because of association preloaders not actually getting called

### DIFF
--- a/app/lib/inline_renderer.rb
+++ b/app/lib/inline_renderer.rb
@@ -37,13 +37,13 @@ class InlineRenderer
   private
 
   def preload_associations_for_status
-    ActiveRecord::Associations::Preloader.new(records: @object, associations: {
+    ActiveRecord::Associations::Preloader.new(records: [@object], associations: {
       active_mentions: :account,
 
       reblog: {
         active_mentions: :account,
       },
-    })
+    }).call
   end
 
   def current_user

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -78,9 +78,9 @@ class Announcement < ApplicationRecord
       else
         scope.select("name, custom_emoji_id, count(*) as count, exists(select 1 from announcement_reactions r where r.account_id = #{account.id} and r.announcement_id = announcement_reactions.announcement_id and r.name = announcement_reactions.name) as me")
       end
-    end
+    end.to_a
 
-    ActiveRecord::Associations::Preloader.new(records: records, associations: :custom_emoji)
+    ActiveRecord::Associations::Preloader.new(records: records, associations: :custom_emoji).call
     records
   end
 

--- a/app/models/concerns/account/search.rb
+++ b/app/models/concerns/account/search.rb
@@ -124,7 +124,7 @@ module Account::Search
       tsquery = generate_query_for_search(terms)
 
       find_by_sql([BASIC_SEARCH_SQL, { limit: limit, offset: offset, tsquery: tsquery }]).tap do |records|
-        ActiveRecord::Associations::Preloader.new(records: records, associations: :account_stat)
+        ActiveRecord::Associations::Preloader.new(records: records, associations: [:account_stat, { user: :role }]).call
       end
     end
 
@@ -133,7 +133,7 @@ module Account::Search
       sql_template = following ? ADVANCED_SEARCH_WITH_FOLLOWING : ADVANCED_SEARCH_WITHOUT_FOLLOWING
 
       find_by_sql([sql_template, { id: account.id, limit: limit, offset: offset, tsquery: tsquery }]).tap do |records|
-        ActiveRecord::Associations::Preloader.new(records: records, associations: :account_stat)
+        ActiveRecord::Associations::Preloader.new(records: records, associations: [:account_stat, { user: :role }]).call
       end
     end
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -111,7 +111,7 @@ class Notification < ApplicationRecord
 
         # Instead of using the usual `includes`, manually preload each type.
         # If polymorphic associations are loaded with the usual `includes`, other types of associations will be loaded more.
-        ActiveRecord::Associations::Preloader.new(records: grouped_notifications, associations: associations)
+        ActiveRecord::Associations::Preloader.new(records: grouped_notifications, associations: associations).call
       end
 
       unique_target_statuses = notifications.filter_map(&:target_status).uniq

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -86,8 +86,8 @@ class InitialStateSerializer < ActiveModel::Serializer
 
     ActiveRecord::Associations::Preloader.new(
       records: [object.current_account, object.admin, object.owner, object.disabled_account, object.moved_to_account].compact,
-      associations: [:account_stat, :user, { moved_to_account: [:account_stat, :user] }]
-    )
+      associations: [:account_stat, { user: :role, moved_to_account: [:account_stat, { user: :role }] }]
+    ).call
 
     store[object.current_account.id.to_s]  = serialized_account(object.current_account) if object.current_account
     store[object.admin.id.to_s]            = serialized_account(object.admin) if object.admin

--- a/app/services/account_search_service.rb
+++ b/app/services/account_search_service.rb
@@ -218,7 +218,7 @@ class AccountSearchService < BaseService
 
     records = query_builder.build.limit(limit_for_non_exact_results).offset(offset).objects.compact
 
-    ActiveRecord::Associations::Preloader.new(records: records, associations: :account_stat)
+    ActiveRecord::Associations::Preloader.new(records: records, associations: [:account_stat, { user: :role }]).call
 
     records
   rescue Faraday::ConnectionFailed, Parslet::ParseFailed

--- a/app/services/batched_remove_status_service.rb
+++ b/app/services/batched_remove_status_service.rb
@@ -11,7 +11,7 @@ class BatchedRemoveStatusService < BaseService
     ActiveRecord::Associations::Preloader.new(
       records: statuses,
       associations: options[:skip_side_effects] ? :reblogs : [:account, :tags, reblogs: :account]
-    )
+    ).call
 
     statuses_and_reblogs = statuses.flat_map { |status| [status] + status.reblogs }
 
@@ -23,7 +23,7 @@ class BatchedRemoveStatusService < BaseService
     ActiveRecord::Associations::Preloader.new(
       records: statuses_with_account_conversations,
       associations: [mentions: :account]
-    )
+    ).call
 
     statuses_with_account_conversations.each(&:unlink_from_conversations!)
 


### PR DESCRIPTION
Not sure if these never worked, or if they broke after a Rails update, but before this PR, associations were actually not getting preloaded as expected.