### PR TITLE
Move account suspension-related methods to concern

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -89,6 +89,7 @@ class Account < ApplicationRecord
   include Account::Merging
   include Account::Search
   include Account::StatusesSearch
+  include Account::Suspensions
   include Account::AttributionDomains
   include DomainMaterializable
   include DomainNormalizable
@@ -127,9 +128,7 @@ class Account < ApplicationRecord
   scope :local, -> { where(domain: nil) }
   scope :partitioned, -> { order(Arel.sql('row_number() over (partition by domain)')) }
   scope :silenced, -> { where.not(silenced_at: nil) }
-  scope :suspended, -> { where.not(suspended_at: nil) }
   scope :sensitized, -> { where.not(sensitized_at: nil) }
-  scope :without_suspended, -> { where(suspended_at: nil) }
   scope :without_silenced, -> { where(silenced_at: nil) }
   scope :without_instance_actor, -> { where.not(id: INSTANCE_ACTOR_ID) }
   scope :recent, -> { reorder(id: :desc) }
@@ -253,41 +252,6 @@ class Account < ApplicationRecord
 
   def unsilence!
     update!(silenced_at: nil)
-  end
-
-  def suspended?
-    suspended_at.present? && !instance_actor?
-  end
-
-  def suspended_locally?
-    suspended? && suspension_origin_local?
-  end
-
-  def suspended_permanently?
-    suspended? && deletion_request.nil?
-  end
-
-  def suspended_temporarily?
-    suspended? && deletion_request.present?
-  end
-
-  alias unavailable? suspended?
-  alias permanently_unavailable? suspended_permanently?
-
-  def suspend!(date: Time.now.utc, origin: :local, block_email: true)
-    transaction do
-      create_deletion_request!
-      update!(suspended_at: date, suspension_origin: origin)
-      create_canonical_email_block! if block_email
-    end
-  end
-
-  def unsuspend!
-    transaction do
-      deletion_request&.destroy!
-      update!(suspended_at: nil, suspension_origin: nil)
-      destroy_canonical_email_block!
-    end
   end
 
   def sensitized?

--- a/app/models/concerns/account/suspensions.rb
+++ b/app/models/concerns/account/suspensions.rb
@@ -20,11 +20,11 @@ module Account::Suspensions
   def suspended_permanently?
     suspended? && deletion_request.nil?
   end
+  alias permanently_unavailable? suspended_permanently?
 
   def suspended_temporarily?
     suspended? && deletion_request.present?
   end
-  alias permanently_unavailable? suspended_permanently?
 
   def suspend!(date: Time.now.utc, origin: :local, block_email: true)
     transaction do

--- a/app/models/concerns/account/suspensions.rb
+++ b/app/models/concerns/account/suspensions.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Account::Suspensions
+  extend ActiveSupport::Concern
+
+  included do
+    scope :suspended, -> { where.not(suspended_at: nil) }
+    scope :without_suspended, -> { where(suspended_at: nil) }
+  end
+
+  def suspended?
+    suspended_at.present? && !instance_actor?
+  end
+  alias unavailable? suspended?
+
+  def suspended_locally?
+    suspended? && suspension_origin_local?
+  end
+
+  def suspended_permanently?
+    suspended? && deletion_request.nil?
+  end
+
+  def suspended_temporarily?
+    suspended? && deletion_request.present?
+  end
+  alias permanently_unavailable? suspended_permanently?
+
+  def suspend!(date: Time.now.utc, origin: :local, block_email: true)
+    transaction do
+      create_deletion_request!
+      update!(suspended_at: date, suspension_origin: origin)
+      create_canonical_email_block! if block_email
+    end
+  end
+
+  def unsuspend!
+    transaction do
+      deletion_request&.destroy!
+      update!(suspended_at: nil, suspension_origin: nil)
+      destroy_canonical_email_block!
+    end
+  end
+end


### PR DESCRIPTION
I've been looking for areas to reduce LOC and/or class size in the "god classes" in the app -- User, Status, Account, MediaAttachment, etc -- and though of this as one possibility.

We could potentially do similar for sensitize/silencing in this class, but I wanted to start with just one idea, will add others if we like this.