### PR TITLE
Unwind `map` on single-item array in `spec/services/delete_account_service` spec

### DIFF
--- a/spec/services/delete_account_service_spec.rb
+++ b/spec/services/delete_account_service_spec.rb
@@ -50,11 +50,11 @@ RSpec.describe DeleteAccountService, type: :service do
     end
 
     def delete_associated_target_records
-      change do
-        [
-          AccountPin.where(target_account: account),
-        ].map(&:count)
-      end.from([1]).to([0])
+      change(account_pins_for_account, :count).from(1).to(0)
+    end
+
+    def account_pins_for_account
+      AccountPin.where(target_account: account)
     end
 
     def delete_associated_target_notifications

--- a/spec/services/delete_account_service_spec.rb
+++ b/spec/services/delete_account_service_spec.rb
@@ -100,28 +100,34 @@ RSpec.describe DeleteAccountService, type: :service do
       it 'sends expected activities to followed and follower inboxes' do
         subject
 
-        expect(a_request(:post, account.inbox_url).with(
-                 body:
-                   hash_including({
-                     'type' => 'Reject',
-                     'object' => hash_including({
-                       'type' => 'Follow',
-                       'actor' => account.uri,
-                       'object' => ActivityPub::TagManager.instance.uri_for(local_follower),
-                     }),
-                   })
-               )).to have_been_made.once
+        expect(post_to_inbox_with_reject).to have_been_made.once
+        expect(post_to_inbox_with_undo).to have_been_made.once
+      end
 
-        expect(a_request(:post, account.inbox_url).with(
-                 body: hash_including({
-                   'type' => 'Undo',
-                   'object' => hash_including({
-                     'type' => 'Follow',
-                     'actor' => ActivityPub::TagManager.instance.uri_for(local_follower),
-                     'object' => account.uri,
-                   }),
-                 })
-               )).to have_been_made.once
+      def post_to_inbox_with_undo
+        a_request(:post, account.inbox_url).with(
+          body: hash_including({
+            'type' => 'Undo',
+            'object' => hash_including({
+              'type' => 'Follow',
+              'actor' => ActivityPub::TagManager.instance.uri_for(local_follower),
+              'object' => account.uri,
+            }),
+          })
+        )
+      end
+
+      def post_to_inbox_with_reject
+        a_request(:post, account.inbox_url).with(
+          body: hash_including({
+            'type' => 'Reject',
+            'object' => hash_including({
+              'type' => 'Follow',
+              'actor' => account.uri,
+              'object' => ActivityPub::TagManager.instance.uri_for(local_follower),
+            }),
+          })
+        )
       end
     end
   end


### PR DESCRIPTION
This matches some of the other current examples, but doesn't make sense for just one thing.

Pulled out other methods for readability in the inbox post data checks.