### PR TITLE
Extract shared behavior methods in oauth feature spec

### DIFF
--- a/spec/features/oauth_spec.rb
+++ b/spec/features/oauth_spec.rb
@@ -61,15 +61,11 @@ describe 'Using OAuth from an external app' do
       expect(page).to have_content(I18n.t('auth.login'))
 
       # Failing to log-in presents the form again
-      fill_in 'user_email', with: email
-      fill_in 'user_password', with: 'wrong password'
-      click_on I18n.t('auth.login')
+      fill_in_auth_details(email, 'wrong password')
       expect(page).to have_content(I18n.t('auth.login'))
 
       # Logging in redirects to an authorization page
-      fill_in 'user_email', with: email
-      fill_in 'user_password', with: password
-      click_on I18n.t('auth.login')
+      fill_in_auth_details(email, password)
       expect(page).to have_content(I18n.t('doorkeeper.authorizations.buttons.authorize'))
 
       # Upon authorizing, it redirects to the apps' callback URL
@@ -88,15 +84,11 @@ describe 'Using OAuth from an external app' do
       expect(page).to have_content(I18n.t('auth.login'))
 
       # Failing to log-in presents the form again
-      fill_in 'user_email', with: email
-      fill_in 'user_password', with: 'wrong password'
-      click_on I18n.t('auth.login')
+      fill_in_auth_details(email, 'wrong password')
       expect(page).to have_content(I18n.t('auth.login'))
 
       # Logging in redirects to an authorization page
-      fill_in 'user_email', with: email
-      fill_in 'user_password', with: password
-      click_on I18n.t('auth.login')
+      fill_in_auth_details(email, password)
       expect(page).to have_content(I18n.t('doorkeeper.authorizations.buttons.authorize'))
 
       # Upon denying, it redirects to the apps' callback URL
@@ -118,25 +110,19 @@ describe 'Using OAuth from an external app' do
         expect(page).to have_content(I18n.t('auth.login'))
 
         # Failing to log-in presents the form again
-        fill_in 'user_email', with: email
-        fill_in 'user_password', with: 'wrong password'
-        click_on I18n.t('auth.login')
+        fill_in_auth_details(email, 'wrong password')
         expect(page).to have_content(I18n.t('auth.login'))
 
         # Logging in redirects to a two-factor authentication page
-        fill_in 'user_email', with: email
-        fill_in 'user_password', with: password
-        click_on I18n.t('auth.login')
+        fill_in_auth_details(email, password)
         expect(page).to have_content(I18n.t('simple_form.hints.sessions.otp'))
 
         # Filling in an incorrect two-factor authentication code presents the form again
-        fill_in 'user_otp_attempt', with: 'wrong'
-        click_on I18n.t('auth.login')
+        fill_in_otp_details('wrong')
         expect(page).to have_content(I18n.t('simple_form.hints.sessions.otp'))
 
         # Filling in the correct TOTP code redirects to an app authorization page
-        fill_in 'user_otp_attempt', with: user.current_otp
-        click_on I18n.t('auth.login')
+        fill_in_otp_details(user.current_otp)
         expect(page).to have_content(I18n.t('doorkeeper.authorizations.buttons.authorize'))
 
         # Upon authorizing, it redirects to the apps' callback URL
@@ -155,25 +141,19 @@ describe 'Using OAuth from an external app' do
         expect(page).to have_content(I18n.t('auth.login'))
 
         # Failing to log-in presents the form again
-        fill_in 'user_email', with: email
-        fill_in 'user_password', with: 'wrong password'
-        click_on I18n.t('auth.login')
+        fill_in_auth_details(email, 'wrong password')
         expect(page).to have_content(I18n.t('auth.login'))
 
         # Logging in redirects to a two-factor authentication page
-        fill_in 'user_email', with: email
-        fill_in 'user_password', with: password
-        click_on I18n.t('auth.login')
+        fill_in_auth_details(email, password)
         expect(page).to have_content(I18n.t('simple_form.hints.sessions.otp'))
 
         # Filling in an incorrect two-factor authentication code presents the form again
-        fill_in 'user_otp_attempt', with: 'wrong'
-        click_on I18n.t('auth.login')
+        fill_in_otp_details('wrong')
         expect(page).to have_content(I18n.t('simple_form.hints.sessions.otp'))
 
         # Filling in the correct TOTP code redirects to an app authorization page
-        fill_in 'user_otp_attempt', with: user.current_otp
-        click_on I18n.t('auth.login')
+        fill_in_otp_details(user.current_otp)
         expect(page).to have_content(I18n.t('doorkeeper.authorizations.buttons.authorize'))
 
         # Upon denying, it redirects to the apps' callback URL
@@ -183,6 +163,19 @@ describe 'Using OAuth from an external app' do
         # It does not grant the app access to the account
         expect(Doorkeeper::AccessGrant.exists?(application: client_app, resource_owner_id: user.id)).to be false
       end
+    end
+
+    private
+
+    def fill_in_auth_details(email, password)
+      fill_in 'user_email', with: email
+      fill_in 'user_password', with: password
+      click_on I18n.t('auth.login')
+    end
+
+    def fill_in_otp_details(value)
+      fill_in 'user_otp_attempt', with: value
+      click_on I18n.t('auth.login')
     end
 
     # TODO: external auth


### PR DESCRIPTION
These were all repeating the same block of behavior in each one.

_Dependency of https://github.com/mastodon/mastodon/pull/29139 and https://github.com/mastodon/mastodon/pull/29223_