### PR TITLE
Fix `Style/FormatStringToken` cop

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -102,15 +102,6 @@ Style/FetchEnvVar:
     - 'lib/tasks/repo.rake'
     - 'spec/features/profile_spec.rb'
 
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle, MaxUnannotatedPlaceholdersAllowed, AllowedMethods, AllowedPatterns.
-# SupportedStyles: annotated, template, unannotated
-# AllowedMethods: redirect
-Style/FormatStringToken:
-  Exclude:
-    - 'config/initializers/devise.rb'
-    - 'lib/paperclip/color_extractor.rb'
-
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Style/GlobalStdStream:
   Exclude:

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -411,7 +411,7 @@ Devise.setup do |config|
     config.ldap_uid            = ENV.fetch('LDAP_UID', 'cn')
     config.ldap_mail           = ENV.fetch('LDAP_MAIL', 'mail')
     config.ldap_tls_no_verify  = ENV['LDAP_TLS_NO_VERIFY'] == 'true'
-    config.ldap_search_filter  = ENV.fetch('LDAP_SEARCH_FILTER', '(|(%{uid}=%{email})(%{mail}=%{email}))')
+    config.ldap_search_filter  = ENV.fetch('LDAP_SEARCH_FILTER', '(|(%<uid>s=%<email>s)(%<mail>s=%<email>s))')
     config.ldap_uid_conversion_enabled  = ENV['LDAP_UID_CONVERSION_ENABLED'] == 'true'
     config.ldap_uid_conversion_search   = ENV.fetch('LDAP_UID_CONVERSION_SEARCH', '.,- ')
     config.ldap_uid_conversion_replace  = ENV.fetch('LDAP_UID_CONVERSION_REPLACE', '_')

--- a/lib/paperclip/color_extractor.rb
+++ b/lib/paperclip/color_extractor.rb
@@ -183,7 +183,7 @@ module Paperclip
     end
 
     def rgb_to_hex(rgb)
-      format('#%02x%02x%02x', rgb.r, rgb.g, rgb.b)
+      format('#%<red>02x%<green>02x%<blue>02x', red: rgb.r, green: rgb.g, blue: rgb.b)
     end
   end
 end


### PR DESCRIPTION
I did a little console verification to confirm they all have same output...

```shell
irb(main):004> format('#%02x%02x%02x', 100, 100, 100)
=> "#646464"
irb(main):005> format '(|(%{uid}=%{email})(%{mail}=%{email}))', uid: 'erd', email: 'sdf', mail: 'sdf'
=> "(|(erd=sdf)(sdf=sdf))"
irb(main):006> format 'This privacy policy describes how %{domain} ("%{domain}", "we", "us") collects', domain: 'sdfsdf'
=> "This privacy policy describes how sdfsdf (\"sdfsdf\", \"we\", \"us\") collects"
irb(main):007> format 'This privacy policy describes how %<domain>s ("%<domain>s", "we", "us") collects', domain: 'sdfsdf'
=> "This privacy policy describes how sdfsdf (\"sdfsdf\", \"we\", \"us\") collects"
irb(main):008> format '(|(%<uid>s=%<email>s)(%<mail>s=%<email>s))', uid: 'erd', email: 'sdf', mail: 'sdf'
=> "(|(erd=sdf)(sdf=sdf))"
irb(main):009> format('#%<red>02x%<green>02x%<blue>02x', red: 100, green: 100, blue: 100)
=> "#646464"
```
