### PR TITLE
Update stoplight to version 4.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,7 +88,7 @@ gem 'sidekiq-unique-jobs', '~> 7.1'
 gem 'sidekiq-bulk', '~> 0.2.0'
 gem 'simple-navigation', '~> 4.4'
 gem 'simple_form', '~> 5.2'
-gem 'stoplight', '~> 3.0.1'
+gem 'stoplight'
 gem 'strong_migrations', '1.8.0'
 gem 'tty-prompt', '~> 0.23', require: false
 gem 'twitter-text', '~> 3.1.0'

--- a/Gemfile
+++ b/Gemfile
@@ -88,7 +88,7 @@ gem 'sidekiq-unique-jobs', '~> 7.1'
 gem 'sidekiq-bulk', '~> 0.2.0'
 gem 'simple-navigation', '~> 4.4'
 gem 'simple_form', '~> 5.2'
-gem 'stoplight'
+gem 'stoplight', '~> 4.1'
 gem 'strong_migrations', '1.8.0'
 gem 'tty-prompt', '~> 0.23', require: false
 gem 'twitter-text', '~> 3.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -732,7 +732,7 @@ GEM
     smart_properties (1.17.0)
     stackprof (0.2.26)
     statsd-ruby (1.5.0)
-    stoplight (3.0.2)
+    stoplight (4.1.0)
       redlock (~> 1.0)
     stringio (3.1.0)
     strong_migrations (1.8.0)
@@ -939,7 +939,7 @@ DEPENDENCIES
   simplecov (~> 0.22)
   simplecov-lcov (~> 0.8)
   stackprof
-  stoplight (~> 3.0.1)
+  stoplight
   strong_migrations (= 1.8.0)
   test-prof
   thor (~> 1.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -939,7 +939,7 @@ DEPENDENCIES
   simplecov (~> 0.22)
   simplecov-lcov (~> 0.8)
   stackprof
-  stoplight
+  stoplight (~> 4.1)
   strong_migrations (= 1.8.0)
   test-prof
   thor (~> 1.2)

--- a/app/workers/import/relationship_worker.rb
+++ b/app/workers/import/relationship_worker.rb
@@ -11,7 +11,7 @@ class Import::RelationshipWorker
   def perform(account_id, target_account_uri, relationship, options)
     from_account   = Account.find(account_id)
     target_domain  = domain(target_account_uri)
-    target_account = stoplight_wrap_request(target_domain) { ResolveAccountService.new.call(target_account_uri, { check_delivery_availability: true }) }
+    target_account = stoplight_wrapper(target_domain).run { ResolveAccountService.new.call(target_account_uri, { check_delivery_availability: true }) }
     options.symbolize_keys!
 
     return if target_account.nil?
@@ -43,16 +43,15 @@ class Import::RelationshipWorker
     TagManager.instance.local_domain?(domain) ? nil : TagManager.instance.normalize_domain(domain)
   end
 
-  def stoplight_wrap_request(domain, &block)
+  def stoplight_wrapper(domain)
     if domain.present?
-      Stoplight("source:#{domain}", &block)
+      Stoplight("source:#{domain}")
         .with_fallback { nil }
         .with_threshold(1)
         .with_cool_off_time(5.minutes.seconds)
         .with_error_handler { |error, handle| error.is_a?(HTTP::Error) || error.is_a?(OpenSSL::SSL::SSLError) ? handle.call(error) : raise(error) }
-        .run
     else
-      yield
+      Stoplight('domain-blank')
     end
   end
 end

--- a/config/initializers/stoplight.rb
+++ b/config/initializers/stoplight.rb
@@ -3,6 +3,6 @@
 require 'stoplight'
 
 Rails.application.reloader.to_prepare do
-  Stoplight::Light.default_data_store = Stoplight::DataStore::Redis.new(RedisConfiguration.new.connection)
-  Stoplight::Light.default_notifiers  = [Stoplight::Notifier::Logger.new(Rails.logger)]
+  Stoplight.default_data_store = Stoplight::DataStore::Redis.new(RedisConfiguration.new.connection)
+  Stoplight.default_notifiers  = [Stoplight::Notifier::Logger.new(Rails.logger)]
 end


### PR DESCRIPTION
Changes:

- Bump gem version in gemfile
- The main calling signature changed from `Stoplight(name, block).run` to `Stoplight(name).run { block }` - updated our usage to that approach
- The configuration via `Spotlight::Light` moved to the top-level `Spotlight`

The 4.0 release seems like mostly an internal refactor and version-dropping release, but there are a few new features. That said, I did not attempt to use/improve any code using new features, focusing narrowly on the upgrade and handling deprecations by making the changes from their upgrade guide - https://github.com/bolshakov/stoplight/blob/master/UPGRADING.md