### PR TITLE
Fix remaining `RSpec/LetSetup` cops

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -64,7 +64,6 @@ RSpec/LetSetup:
     - 'spec/services/suspend_account_service_spec.rb'
     - 'spec/services/unallow_domain_service_spec.rb'
     - 'spec/services/unsuspend_account_service_spec.rb'
-    - 'spec/workers/scheduler/user_cleanup_scheduler_spec.rb'
 
 RSpec/MultipleExpectations:
   Max: 8

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,7 +47,6 @@ RSpec/ExampleLength:
 
 RSpec/LetSetup:
   Exclude:
-    - 'spec/models/status_spec.rb'
     - 'spec/models/user_spec.rb'
     - 'spec/services/account_statuses_cleanup_service_spec.rb'
     - 'spec/services/activitypub/fetch_featured_collection_service_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,7 +47,6 @@ RSpec/ExampleLength:
 
 RSpec/LetSetup:
   Exclude:
-    - 'spec/controllers/settings/imports_controller_spec.rb'
     - 'spec/lib/activitypub/activity/delete_spec.rb'
     - 'spec/lib/vacuum/applications_vacuum_spec.rb'
     - 'spec/lib/vacuum/preview_cards_vacuum_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,7 +47,6 @@ RSpec/ExampleLength:
 
 RSpec/LetSetup:
   Exclude:
-    - 'spec/models/canonical_email_block_spec.rb'
     - 'spec/models/status_spec.rb'
     - 'spec/models/user_spec.rb'
     - 'spec/services/account_statuses_cleanup_service_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,7 +47,6 @@ RSpec/ExampleLength:
 
 RSpec/LetSetup:
   Exclude:
-    - 'spec/services/block_domain_service_spec.rb'
     - 'spec/services/bulk_import_service_spec.rb'
     - 'spec/services/delete_account_service_spec.rb'
     - 'spec/services/import_service_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,7 +47,6 @@ RSpec/ExampleLength:
 
 RSpec/LetSetup:
   Exclude:
-    - 'spec/services/batched_remove_status_service_spec.rb'
     - 'spec/services/block_domain_service_spec.rb'
     - 'spec/services/bulk_import_service_spec.rb'
     - 'spec/services/delete_account_service_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,7 +47,6 @@ RSpec/ExampleLength:
 
 RSpec/LetSetup:
   Exclude:
-    - 'spec/services/import_service_spec.rb'
     - 'spec/services/notify_service_spec.rb'
     - 'spec/services/remove_status_service_spec.rb'
     - 'spec/services/report_service_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,8 +47,6 @@ RSpec/ExampleLength:
 
 RSpec/LetSetup:
   Exclude:
-    - 'spec/controllers/oauth/authorized_applications_controller_spec.rb'
-    - 'spec/controllers/oauth/tokens_controller_spec.rb'
     - 'spec/controllers/settings/imports_controller_spec.rb'
     - 'spec/lib/activitypub/activity/delete_spec.rb'
     - 'spec/lib/vacuum/applications_vacuum_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,7 +47,6 @@ RSpec/ExampleLength:
 
 RSpec/LetSetup:
   Exclude:
-    - 'spec/services/unallow_domain_service_spec.rb'
     - 'spec/services/unsuspend_account_service_spec.rb'
 
 RSpec/MultipleExpectations:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,7 +47,6 @@ RSpec/ExampleLength:
 
 RSpec/LetSetup:
   Exclude:
-    - 'spec/models/account_statuses_cleanup_policy_spec.rb'
     - 'spec/models/canonical_email_block_spec.rb'
     - 'spec/models/status_spec.rb'
     - 'spec/models/user_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -45,10 +45,6 @@ Metrics/PerceivedComplexity:
 RSpec/ExampleLength:
   Max: 22
 
-RSpec/LetSetup:
-  Exclude:
-    - 'spec/services/unsuspend_account_service_spec.rb'
-
 RSpec/MultipleExpectations:
   Max: 8
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,7 +47,6 @@ RSpec/ExampleLength:
 
 RSpec/LetSetup:
   Exclude:
-    - 'spec/controllers/api/v2/filters/keywords_controller_spec.rb'
     - 'spec/controllers/api/v2/filters/statuses_controller_spec.rb'
     - 'spec/controllers/auth/confirmations_controller_spec.rb'
     - 'spec/controllers/auth/passwords_controller_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,7 +47,6 @@ RSpec/ExampleLength:
 
 RSpec/LetSetup:
   Exclude:
-    - 'spec/services/report_service_spec.rb'
     - 'spec/services/resolve_account_service_spec.rb'
     - 'spec/services/suspend_account_service_spec.rb'
     - 'spec/services/unallow_domain_service_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,7 +47,6 @@ RSpec/ExampleLength:
 
 RSpec/LetSetup:
   Exclude:
-    - 'spec/controllers/api/v1/filters_controller_spec.rb'
     - 'spec/controllers/api/v2/admin/accounts_controller_spec.rb'
     - 'spec/controllers/api/v2/filters/keywords_controller_spec.rb'
     - 'spec/controllers/api/v2/filters/statuses_controller_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,10 +47,6 @@ RSpec/ExampleLength:
 
 RSpec/LetSetup:
   Exclude:
-    - 'spec/services/activitypub/fetch_featured_collection_service_spec.rb'
-    - 'spec/services/activitypub/fetch_remote_status_service_spec.rb'
-    - 'spec/services/activitypub/process_account_service_spec.rb'
-    - 'spec/services/activitypub/process_collection_service_spec.rb'
     - 'spec/services/batched_remove_status_service_spec.rb'
     - 'spec/services/block_domain_service_spec.rb'
     - 'spec/services/bulk_import_service_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,7 +47,6 @@ RSpec/ExampleLength:
 
 RSpec/LetSetup:
   Exclude:
-    - 'spec/controllers/following_accounts_controller_spec.rb'
     - 'spec/controllers/oauth/authorized_applications_controller_spec.rb'
     - 'spec/controllers/oauth/tokens_controller_spec.rb'
     - 'spec/controllers/settings/imports_controller_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,7 +47,6 @@ RSpec/ExampleLength:
 
 RSpec/LetSetup:
   Exclude:
-    - 'spec/controllers/api/v2/filters/statuses_controller_spec.rb'
     - 'spec/controllers/auth/confirmations_controller_spec.rb'
     - 'spec/controllers/auth/passwords_controller_spec.rb'
     - 'spec/controllers/auth/sessions_controller_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,7 +47,6 @@ RSpec/ExampleLength:
 
 RSpec/LetSetup:
   Exclude:
-    - 'spec/lib/vacuum/applications_vacuum_spec.rb'
     - 'spec/lib/vacuum/preview_cards_vacuum_spec.rb'
     - 'spec/models/account_spec.rb'
     - 'spec/models/account_statuses_cleanup_policy_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,7 +47,6 @@ RSpec/ExampleLength:
 
 RSpec/LetSetup:
   Exclude:
-    - 'spec/controllers/auth/passwords_controller_spec.rb'
     - 'spec/controllers/auth/sessions_controller_spec.rb'
     - 'spec/controllers/follower_accounts_controller_spec.rb'
     - 'spec/controllers/following_accounts_controller_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,7 +47,6 @@ RSpec/ExampleLength:
 
 RSpec/LetSetup:
   Exclude:
-    - 'spec/models/account_spec.rb'
     - 'spec/models/account_statuses_cleanup_policy_spec.rb'
     - 'spec/models/canonical_email_block_spec.rb'
     - 'spec/models/status_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,7 +47,6 @@ RSpec/ExampleLength:
 
 RSpec/LetSetup:
   Exclude:
-    - 'spec/controllers/auth/sessions_controller_spec.rb'
     - 'spec/controllers/follower_accounts_controller_spec.rb'
     - 'spec/controllers/following_accounts_controller_spec.rb'
     - 'spec/controllers/oauth/authorized_applications_controller_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,7 +47,6 @@ RSpec/ExampleLength:
 
 RSpec/LetSetup:
   Exclude:
-    - 'spec/services/account_statuses_cleanup_service_spec.rb'
     - 'spec/services/activitypub/fetch_featured_collection_service_spec.rb'
     - 'spec/services/activitypub/fetch_remote_status_service_spec.rb'
     - 'spec/services/activitypub/process_account_service_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,7 +47,6 @@ RSpec/ExampleLength:
 
 RSpec/LetSetup:
   Exclude:
-    - 'spec/controllers/follower_accounts_controller_spec.rb'
     - 'spec/controllers/following_accounts_controller_spec.rb'
     - 'spec/controllers/oauth/authorized_applications_controller_spec.rb'
     - 'spec/controllers/oauth/tokens_controller_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,7 +47,6 @@ RSpec/ExampleLength:
 
 RSpec/LetSetup:
   Exclude:
-    - 'spec/services/suspend_account_service_spec.rb'
     - 'spec/services/unallow_domain_service_spec.rb'
     - 'spec/services/unsuspend_account_service_spec.rb'
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,7 +47,6 @@ RSpec/ExampleLength:
 
 RSpec/LetSetup:
   Exclude:
-    - 'spec/controllers/api/v2/admin/accounts_controller_spec.rb'
     - 'spec/controllers/api/v2/filters/keywords_controller_spec.rb'
     - 'spec/controllers/api/v2/filters/statuses_controller_spec.rb'
     - 'spec/controllers/auth/confirmations_controller_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,7 +47,6 @@ RSpec/ExampleLength:
 
 RSpec/LetSetup:
   Exclude:
-    - 'spec/lib/vacuum/preview_cards_vacuum_spec.rb'
     - 'spec/models/account_spec.rb'
     - 'spec/models/account_statuses_cleanup_policy_spec.rb'
     - 'spec/models/canonical_email_block_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,7 +47,6 @@ RSpec/ExampleLength:
 
 RSpec/LetSetup:
   Exclude:
-    - 'spec/models/user_spec.rb'
     - 'spec/services/account_statuses_cleanup_service_spec.rb'
     - 'spec/services/activitypub/fetch_featured_collection_service_spec.rb'
     - 'spec/services/activitypub/fetch_remote_status_service_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,7 +47,6 @@ RSpec/ExampleLength:
 
 RSpec/LetSetup:
   Exclude:
-    - 'spec/controllers/api/v1/accounts/statuses_controller_spec.rb'
     - 'spec/controllers/api/v1/filters_controller_spec.rb'
     - 'spec/controllers/api/v2/admin/accounts_controller_spec.rb'
     - 'spec/controllers/api/v2/filters/keywords_controller_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,7 +47,6 @@ RSpec/ExampleLength:
 
 RSpec/LetSetup:
   Exclude:
-    - 'spec/services/delete_account_service_spec.rb'
     - 'spec/services/import_service_spec.rb'
     - 'spec/services/notify_service_spec.rb'
     - 'spec/services/remove_status_service_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,7 +47,6 @@ RSpec/ExampleLength:
 
 RSpec/LetSetup:
   Exclude:
-    - 'spec/lib/activitypub/activity/delete_spec.rb'
     - 'spec/lib/vacuum/applications_vacuum_spec.rb'
     - 'spec/lib/vacuum/preview_cards_vacuum_spec.rb'
     - 'spec/models/account_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,7 +47,6 @@ RSpec/ExampleLength:
 
 RSpec/LetSetup:
   Exclude:
-    - 'spec/services/notify_service_spec.rb'
     - 'spec/services/remove_status_service_spec.rb'
     - 'spec/services/report_service_spec.rb'
     - 'spec/services/resolve_account_service_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,7 +47,6 @@ RSpec/ExampleLength:
 
 RSpec/LetSetup:
   Exclude:
-    - 'spec/services/resolve_account_service_spec.rb'
     - 'spec/services/suspend_account_service_spec.rb'
     - 'spec/services/unallow_domain_service_spec.rb'
     - 'spec/services/unsuspend_account_service_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,7 +47,6 @@ RSpec/ExampleLength:
 
 RSpec/LetSetup:
   Exclude:
-    - 'spec/controllers/auth/confirmations_controller_spec.rb'
     - 'spec/controllers/auth/passwords_controller_spec.rb'
     - 'spec/controllers/auth/sessions_controller_spec.rb'
     - 'spec/controllers/follower_accounts_controller_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,7 +47,6 @@ RSpec/ExampleLength:
 
 RSpec/LetSetup:
   Exclude:
-    - 'spec/services/bulk_import_service_spec.rb'
     - 'spec/services/delete_account_service_spec.rb'
     - 'spec/services/import_service_spec.rb'
     - 'spec/services/notify_service_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,7 +47,6 @@ RSpec/ExampleLength:
 
 RSpec/LetSetup:
   Exclude:
-    - 'spec/services/remove_status_service_spec.rb'
     - 'spec/services/report_service_spec.rb'
     - 'spec/services/resolve_account_service_spec.rb'
     - 'spec/services/suspend_account_service_spec.rb'

--- a/spec/controllers/api/v1/accounts/statuses_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/statuses_controller_spec.rb
@@ -10,11 +10,11 @@ describe Api::V1::Accounts::StatusesController do
 
   before do
     allow(controller).to receive(:doorkeeper_token) { token }
-    Fabricate(:status, account: user.account)
   end
 
   describe 'GET #index' do
     it 'returns expected headers', :aggregate_failures do
+      Fabricate(:status, account: user.account)
       get :index, params: { account_id: user.account.id, limit: 1 }
 
       expect(response).to have_http_status(200)
@@ -30,7 +30,6 @@ describe Api::V1::Accounts::StatusesController do
     end
 
     context 'with exclude replies' do
-      let!(:older_statuses) { user.account.statuses.destroy_all }
       let!(:status) { Fabricate(:status, account: user.account) }
       let!(:status_self_reply) { Fabricate(:status, account: user.account, thread: status) }
 

--- a/spec/controllers/api/v1/filters_controller_spec.rb
+++ b/spec/controllers/api/v1/filters_controller_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe Api::V1::FiltersController do
 
   describe 'GET #index' do
     let(:scopes) { 'read:filters' }
-    let!(:filter) { Fabricate(:custom_filter, account: user.account) }
 
     it 'returns http success' do
       get :index

--- a/spec/controllers/api/v2/filters/keywords_controller_spec.rb
+++ b/spec/controllers/api/v2/filters/keywords_controller_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe Api::V2::Filters::KeywordsController do
 
   describe 'GET #index' do
     let(:scopes) { 'read:filters' }
-    let!(:keyword) { Fabricate(:custom_filter_keyword, custom_filter: filter) }
+
+    before { Fabricate(:custom_filter_keyword, custom_filter: filter) }
 
     it 'returns http success' do
       get :index, params: { filter_id: filter.id }

--- a/spec/controllers/api/v2/filters/statuses_controller_spec.rb
+++ b/spec/controllers/api/v2/filters/statuses_controller_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe Api::V2::Filters::StatusesController do
 
   describe 'GET #index' do
     let(:scopes) { 'read:filters' }
-    let!(:status_filter) { Fabricate(:custom_filter_status, custom_filter: filter) }
+
+    before { Fabricate(:custom_filter_status, custom_filter: filter) }
 
     it 'returns http success' do
       get :index, params: { filter_id: filter.id }

--- a/spec/controllers/auth/confirmations_controller_spec.rb
+++ b/spec/controllers/auth/confirmations_controller_spec.rb
@@ -43,6 +43,7 @@ describe Auth::ConfirmationsController do
 
       it 'redirects to login' do
         expect(response).to redirect_to(new_user_session_path)
+        expect(BootstrapTimelineWorker).to have_received(:perform_async).with(user.account_id)
       end
     end
 
@@ -92,7 +93,7 @@ describe Auth::ConfirmationsController do
       end
 
       it 'does not queue up bootstrapping of home timeline' do
-        expect(BootstrapTimelineWorker).to_not have_received(:perform_async)
+        expect(BootstrapTimelineWorker).to_not have_received(:perform_async).with(user.account_id)
       end
     end
   end

--- a/spec/controllers/auth/passwords_controller_spec.rb
+++ b/spec/controllers/auth/passwords_controller_spec.rb
@@ -47,11 +47,11 @@ describe Auth::PasswordsController do
     end
 
     context 'with valid reset_password_token' do
-      let!(:session_activation) { Fabricate(:session_activation, user: user) }
       let!(:access_token) { Fabricate(:access_token, resource_owner_id: user.id) }
-      let!(:web_push_subscription) { Fabricate(:web_push_subscription, access_token: access_token) }
 
       before do
+        _session_activation = Fabricate(:session_activation, user: user)
+        _web_push_subscription = Fabricate(:web_push_subscription, access_token: access_token)
         token = user.send_reset_password_instructions
 
         post :update, params: { user: { password: password, password_confirmation: password, reset_password_token: token } }

--- a/spec/controllers/auth/sessions_controller_spec.rb
+++ b/spec/controllers/auth/sessions_controller_spec.rb
@@ -123,11 +123,11 @@ RSpec.describe Auth::SessionsController do
         let(:previous_ip) { '1.2.3.4' }
         let(:current_ip)  { '4.3.2.1' }
 
-        let!(:previous_login) { Fabricate(:login_activity, user: user, ip: previous_ip) }
-
         before do
+          _previous_login = Fabricate(:login_activity, user: user, ip: previous_ip)
           allow(controller.request).to receive(:remote_ip).and_return(current_ip)
           user.update(current_sign_in_at: 1.month.ago)
+
           post :create, params: { user: { email: user.email, password: user.password } }
         end
 
@@ -327,13 +327,6 @@ RSpec.describe Auth::SessionsController do
         let!(:user) do
           Fabricate(:user, email: 'x@y.com', password: 'abcdefgh', otp_required_for_login: true, otp_secret: User.generate_otp_secret(32))
         end
-
-        let!(:recovery_codes) do
-          codes = user.generate_otp_backup_codes!
-          user.save
-          return codes
-        end
-
         let!(:webauthn_credential) do
           user.update(webauthn_id: WebAuthn.generate_user_id)
           public_key_credential = WebAuthn::Credential.from_create(fake_client.create)
@@ -345,16 +338,16 @@ RSpec.describe Auth::SessionsController do
           )
           user.webauthn_credentials.take
         end
-
         let(:domain) { "#{Rails.configuration.x.use_https ? 'https' : 'http'}://#{Rails.configuration.x.web_domain}" }
-
         let(:fake_client) { WebAuthn::FakeClient.new(domain) }
-
         let(:challenge) { WebAuthn::Credential.options_for_get.challenge }
-
         let(:sign_count) { 1234 }
-
         let(:fake_credential) { fake_client.get(challenge: challenge, sign_count: sign_count) }
+
+        before do
+          user.generate_otp_backup_codes!
+          user.save
+        end
 
         context 'when using email and password' do
           before do

--- a/spec/controllers/follower_accounts_controller_spec.rb
+++ b/spec/controllers/follower_accounts_controller_spec.rb
@@ -10,8 +10,10 @@ describe FollowerAccountsController do
   let(:follower_chris) { Fabricate(:account, username: 'curt') }
 
   describe 'GET #index' do
-    let!(:follow_from_bob) { follower_bob.follow!(alice) }
-    let!(:follow_from_chris) { follower_chris.follow!(alice) }
+    before do
+      follower_bob.follow!(alice)
+      follower_chris.follow!(alice)
+    end
 
     context 'when format is html' do
       subject(:response) { get :index, params: { account_username: alice.username, format: :html } }

--- a/spec/controllers/following_accounts_controller_spec.rb
+++ b/spec/controllers/following_accounts_controller_spec.rb
@@ -10,8 +10,10 @@ describe FollowingAccountsController do
   let(:followee_chris) { Fabricate(:account, username: 'chris') }
 
   describe 'GET #index' do
-    let!(:follow_of_bob) { alice.follow!(followee_bob) }
-    let!(:follow_of_chris) { alice.follow!(followee_chris) }
+    before do
+      alice.follow!(followee_bob)
+      alice.follow!(followee_chris)
+    end
 
     context 'when format is html' do
       subject(:response) { get :index, params: { account_username: alice.username, format: :html } }

--- a/spec/controllers/oauth/authorized_applications_controller_spec.rb
+++ b/spec/controllers/oauth/authorized_applications_controller_spec.rb
@@ -49,9 +49,9 @@ describe Oauth::AuthorizedApplicationsController do
     let!(:user) { Fabricate(:user) }
     let!(:application) { Fabricate(:application) }
     let!(:access_token) { Fabricate(:accessible_access_token, application: application, resource_owner_id: user.id) }
-    let!(:web_push_subscription) { Fabricate(:web_push_subscription, user: user, access_token: access_token) }
 
     before do
+      Fabricate(:web_push_subscription, user: user, access_token: access_token)
       sign_in user, scope: :user
       post :destroy, params: { id: application.id }
     end

--- a/spec/controllers/oauth/tokens_controller_spec.rb
+++ b/spec/controllers/oauth/tokens_controller_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe Oauth::TokensController do
     let!(:user) { Fabricate(:user) }
     let!(:application) { Fabricate(:application, confidential: false) }
     let!(:access_token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, application: application) }
-    let!(:web_push_subscription) { Fabricate(:web_push_subscription, user: user, access_token: access_token) }
 
     before do
+      Fabricate(:web_push_subscription, user: user, access_token: access_token)
       post :revoke, params: { client_id: application.uid, token: access_token.token }
     end
 

--- a/spec/controllers/settings/imports_controller_spec.rb
+++ b/spec/controllers/settings/imports_controller_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe Settings::ImportsController do
 
   describe 'GET #index' do
     let!(:import)       { Fabricate(:bulk_import, account: user.account) }
-    let!(:other_import) { Fabricate(:bulk_import) }
 
     before do
+      Fabricate(:bulk_import)
       get :index
     end
 
@@ -152,7 +152,7 @@ RSpec.describe Settings::ImportsController do
     context 'with follows' do
       let(:import_type) { 'following' }
 
-      let!(:rows) do
+      before do
         [
           { 'acct' => 'foo@bar' },
           { 'acct' => 'user@bar', 'show_reblogs' => false, 'notify' => true, 'languages' => %w(fr de) },
@@ -165,7 +165,7 @@ RSpec.describe Settings::ImportsController do
     context 'with blocks' do
       let(:import_type) { 'blocking' }
 
-      let!(:rows) do
+      before do
         [
           { 'acct' => 'foo@bar' },
           { 'acct' => 'user@bar' },
@@ -178,7 +178,7 @@ RSpec.describe Settings::ImportsController do
     context 'with mutes' do
       let(:import_type) { 'muting' }
 
-      let!(:rows) do
+      before do
         [
           { 'acct' => 'foo@bar' },
           { 'acct' => 'user@bar', 'hide_notifications' => false },
@@ -191,7 +191,7 @@ RSpec.describe Settings::ImportsController do
     context 'with domain blocks' do
       let(:import_type) { 'domain_blocking' }
 
-      let!(:rows) do
+      before do
         [
           { 'domain' => 'bad.domain' },
           { 'domain' => 'evil.domain' },
@@ -204,7 +204,7 @@ RSpec.describe Settings::ImportsController do
     context 'with bookmarks' do
       let(:import_type) { 'bookmarks' }
 
-      let!(:rows) do
+      before do
         [
           { 'uri' => 'https://foo.com/1' },
           { 'uri' => 'https://foo.com/2' },
@@ -217,7 +217,7 @@ RSpec.describe Settings::ImportsController do
     context 'with lists' do
       let(:import_type) { 'lists' }
 
-      let!(:rows) do
+      before do
         [
           { 'list_name' => 'Amigos', 'acct' => 'user@example.com' },
           { 'list_name' => 'Frenemies', 'acct' => 'user@org.org' },

--- a/spec/lib/activitypub/activity/delete_spec.rb
+++ b/spec/lib/activitypub/activity/delete_spec.rb
@@ -35,9 +35,9 @@ RSpec.describe ActivityPub::Activity::Delete do
 
       let!(:reblogger) { Fabricate(:account) }
       let!(:follower)  { Fabricate(:account, username: 'follower', protocol: :activitypub, domain: 'example.com', inbox_url: 'http://example.com/inbox') }
-      let!(:reblog)    { Fabricate(:status, account: reblogger, reblog: status) }
 
       before do
+        Fabricate(:status, account: reblogger, reblog: status)
         stub_request(:post, 'http://example.com/inbox').to_return(status: 200)
         follower.follow!(reblogger)
         subject.perform

--- a/spec/lib/vacuum/applications_vacuum_spec.rb
+++ b/spec/lib/vacuum/applications_vacuum_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe Vacuum::ApplicationsVacuum do
     let!(:unused_app)      { Fabricate(:application, created_at: 1.month.ago) }
     let!(:recent_app)      { Fabricate(:application, created_at: 1.hour.ago) }
 
-    let!(:active_access_token) { Fabricate(:access_token, application: app_with_token) }
-    let!(:active_access_grant) { Fabricate(:access_grant, application: app_with_grant) }
-    let!(:user) { Fabricate(:user, created_by_application: app_with_signup) }
-
     before do
+      Fabricate(:access_token, application: app_with_token)
+      Fabricate(:access_grant, application: app_with_grant)
+      Fabricate(:user, created_by_application: app_with_signup)
+
       subject.perform
     end
 

--- a/spec/lib/vacuum/preview_cards_vacuum_spec.rb
+++ b/spec/lib/vacuum/preview_cards_vacuum_spec.rb
@@ -8,16 +8,15 @@ RSpec.describe Vacuum::PreviewCardsVacuum do
   let(:retention_period) { 7.days }
 
   describe '#perform' do
-    let!(:orphaned_preview_card) { Fabricate(:preview_card, created_at: 2.days.ago) }
-    let!(:old_preview_card) { Fabricate(:preview_card, updated_at: (retention_period + 1.day).ago) }
-    let!(:new_preview_card) { Fabricate(:preview_card) }
-
     before do
+      Fabricate(:preview_card, created_at: 2.days.ago)
       old_preview_card.statuses << Fabricate(:status)
       new_preview_card.statuses << Fabricate(:status)
-
       subject.perform
     end
+
+    let!(:old_preview_card) { Fabricate(:preview_card, updated_at: (retention_period + 1.day).ago) }
+    let!(:new_preview_card) { Fabricate(:preview_card) }
 
     it 'deletes cache of preview cards last updated before the retention period' do
       expect(old_preview_card.reload.image).to be_blank

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -936,21 +936,21 @@ RSpec.describe Account do
     end
 
     describe 'searchable' do
-      let!(:suspended_local)        { Fabricate(:account, suspended: true, username: 'suspended_local') }
-      let!(:suspended_remote)       { Fabricate(:account, suspended: true, domain: 'example.org', username: 'suspended_remote') }
+      before do
+        Fabricate(:account, suspended: true, username: 'suspended_local')
+        Fabricate(:account, suspended: true, domain: 'example.org', username: 'suspended_remote')
+        Fabricate(:user, confirmed_at: nil).account
+
+        unapproved.user.update(approved: false)
+        unconfirmed_unapproved.user.update(approved: false)
+      end
+
       let!(:silenced_local)         { Fabricate(:account, silenced: true, username: 'silenced_local') }
-      let!(:silenced_remote)        { Fabricate(:account, silenced: true, domain: 'example.org', username: 'silenced_remote') }
-      let!(:unconfirmed)            { Fabricate(:user, confirmed_at: nil).account }
       let!(:unapproved)             { Fabricate(:user, approved: false).account }
       let!(:unconfirmed_unapproved) { Fabricate(:user, confirmed_at: nil, approved: false).account }
       let!(:local_account)          { Fabricate(:account, username: 'local_account') }
       let!(:remote_account)         { Fabricate(:account, domain: 'example.org', username: 'remote_account') }
-
-      before do
-        # Accounts get automatically-approved depending on settings, so ensure they aren't approved
-        unapproved.user.update(approved: false)
-        unconfirmed_unapproved.user.update(approved: false)
-      end
+      let!(:silenced_remote)        { Fabricate(:account, silenced: true, domain: 'example.org', username: 'silenced_remote') }
 
       it 'returns every usable non-suspended account' do
         expect(described_class.searchable).to contain_exactly(silenced_local, silenced_remote, local_account, remote_account)

--- a/spec/models/account_statuses_cleanup_policy_spec.rb
+++ b/spec/models/account_statuses_cleanup_policy_spec.rb
@@ -235,13 +235,17 @@ RSpec.describe AccountStatusesCleanupPolicy do
   describe '#compute_cutoff_id' do
     subject { account_statuses_cleanup_policy.compute_cutoff_id }
 
-    let!(:unrelated_status) { Fabricate(:status, created_at: 3.years.ago) }
+    before { Fabricate(:status, created_at: 3.years.ago) }
+
     let(:account_statuses_cleanup_policy) { Fabricate(:account_statuses_cleanup_policy, account: account) }
 
     context 'when the account has posted multiple toots' do
-      let!(:very_old_status)   { Fabricate(:status, created_at: 3.years.ago, account: account) }
-      let!(:old_status)        { Fabricate(:status, created_at: 3.weeks.ago, account: account) }
-      let!(:recent_status)     { Fabricate(:status, created_at: 2.days.ago, account: account) }
+      before do
+        Fabricate(:status, created_at: 3.years.ago, account: account)
+        Fabricate(:status, created_at: 2.days.ago, account: account)
+      end
+
+      let!(:old_status) { Fabricate(:status, created_at: 3.weeks.ago, account: account) }
 
       it 'returns the most recent id that is still below policy age' do
         expect(subject).to eq old_status.id
@@ -258,7 +262,8 @@ RSpec.describe AccountStatusesCleanupPolicy do
   describe '#statuses_to_delete' do
     subject { account_statuses_cleanup_policy.statuses_to_delete }
 
-    let!(:unrelated_status)  { Fabricate(:status, created_at: 3.years.ago) }
+    let!(:unrelated_status) { Fabricate(:status, created_at: 3.years.ago) }
+    let(:account_statuses_cleanup_policy) { Fabricate(:account_statuses_cleanup_policy, account: account) }
     let!(:very_old_status)   { Fabricate(:status, created_at: 3.years.ago, account: account) }
     let!(:pinned_status)     { Fabricate(:status, created_at: 1.year.ago, account: account) }
     let!(:direct_message)    { Fabricate(:status, created_at: 1.year.ago, account: account, visibility: :direct) }
@@ -270,16 +275,14 @@ RSpec.describe AccountStatusesCleanupPolicy do
     let!(:faved_secondary) { Fabricate(:status, created_at: 1.year.ago, account: account) }
     let!(:reblogged_primary) { Fabricate(:status, created_at: 1.year.ago, account: account) }
     let!(:reblogged_secondary) { Fabricate(:status, created_at: 1.year.ago, account: account) }
-    let!(:recent_status)     { Fabricate(:status, created_at: 2.days.ago, account: account) }
-
-    let!(:media_attachment)  { Fabricate(:media_attachment, account: account, status: status_with_media) }
-    let!(:status_pin)        { Fabricate(:status_pin, account: account, status: pinned_status) }
-    let!(:favourite)         { Fabricate(:favourite, account: account, status: self_faved) }
-    let!(:bookmark)          { Fabricate(:bookmark, account: account, status: self_bookmarked) }
-
-    let(:account_statuses_cleanup_policy) { Fabricate(:account_statuses_cleanup_policy, account: account) }
+    let!(:recent_status) { Fabricate(:status, created_at: 2.days.ago, account: account) }
 
     before do
+      Fabricate(:media_attachment, account: account, status: status_with_media)
+      Fabricate(:status_pin, account: account, status: pinned_status)
+      Fabricate(:favourite, account: account, status: self_faved)
+      Fabricate(:bookmark, account: account, status: self_bookmarked)
+
       faved_primary.status_stat.update(favourites_count: 4)
       faved_secondary.status_stat.update(favourites_count: 5)
       reblogged_primary.status_stat.update(reblogs_count: 4)

--- a/spec/models/canonical_email_block_spec.rb
+++ b/spec/models/canonical_email_block_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe CanonicalEmailBlock do
   end
 
   describe '.block?' do
-    let!(:canonical_email_block) { Fabricate(:canonical_email_block, email: 'foo@bar.com') }
+    before { Fabricate(:canonical_email_block, email: 'foo@bar.com') }
 
     it 'returns true for the same email' do
       expect(described_class.block?('foo@bar.com')).to be true

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -255,13 +255,14 @@ RSpec.describe Status do
 
   describe '.tagged_with' do
     let(:tag_cats) { Fabricate(:tag, name: 'cats') }
+    let!(:status_with_all_tags) { Fabricate(:status, tags: [tag_cats, tag_dogs, tag_zebras]) }
     let(:tag_dogs) { Fabricate(:tag, name: 'dogs') }
     let(:tag_zebras) { Fabricate(:tag, name: 'zebras') }
     let!(:status_with_tag_cats) { Fabricate(:status, tags: [tag_cats]) }
     let!(:status_with_tag_dogs) { Fabricate(:status, tags: [tag_dogs]) }
     let!(:status_tagged_with_zebras) { Fabricate(:status, tags: [tag_zebras]) }
-    let!(:status_without_tags) { Fabricate(:status, tags: []) }
-    let!(:status_with_all_tags) { Fabricate(:status, tags: [tag_cats, tag_dogs, tag_zebras]) }
+
+    before { Fabricate(:status, tags: []) }
 
     context 'when given one tag' do
       it 'returns the expected statuses' do
@@ -282,13 +283,14 @@ RSpec.describe Status do
 
   describe '.tagged_with_all' do
     let(:tag_cats) { Fabricate(:tag, name: 'cats') }
+    let!(:status_with_all_tags) { Fabricate(:status, tags: [tag_cats, tag_dogs]) }
     let(:tag_dogs) { Fabricate(:tag, name: 'dogs') }
     let(:tag_zebras) { Fabricate(:tag, name: 'zebras') }
     let!(:status_with_tag_cats) { Fabricate(:status, tags: [tag_cats]) }
     let!(:status_with_tag_dogs) { Fabricate(:status, tags: [tag_dogs]) }
     let!(:status_tagged_with_zebras) { Fabricate(:status, tags: [tag_zebras]) }
-    let!(:status_without_tags) { Fabricate(:status, tags: []) }
-    let!(:status_with_all_tags) { Fabricate(:status, tags: [tag_cats, tag_dogs]) }
+
+    before { Fabricate(:status, tags: []) }
 
     context 'when given one tag' do
       it 'returns the expected statuses' do
@@ -315,7 +317,8 @@ RSpec.describe Status do
     let!(:status_with_tag_dogs) { Fabricate(:status, tags: [tag_dogs]) }
     let!(:status_tagged_with_zebras) { Fabricate(:status, tags: [tag_zebras]) }
     let!(:status_without_tags) { Fabricate(:status, tags: []) }
-    let!(:status_with_all_tags) { Fabricate(:status, tags: [tag_cats, tag_dogs, tag_zebras]) }
+
+    before { Fabricate(:status, tags: [tag_cats, tag_dogs, tag_zebras]) }
 
     context 'when given one tag' do
       it 'returns the expected statuses' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -434,13 +434,14 @@ RSpec.describe User do
   describe '#reset_password!' do
     subject(:user) { Fabricate(:user, password: 'foobar12345') }
 
-    let!(:session_activation) { Fabricate(:session_activation, user: user) }
-    let!(:access_token) { Fabricate(:access_token, resource_owner_id: user.id) }
-    let!(:web_push_subscription) { Fabricate(:web_push_subscription, access_token: access_token) }
-
     before do
+      Fabricate(:session_activation, user: user)
+      Fabricate(:web_push_subscription, access_token: access_token)
+
       user.reset_password!
     end
+
+    let!(:access_token) { Fabricate(:access_token, resource_owner_id: user.id) }
 
     it 'changes the password immediately' do
       expect(user.external_or_valid_password?('foobar12345')).to be false

--- a/spec/services/account_statuses_cleanup_service_spec.rb
+++ b/spec/services/account_statuses_cleanup_service_spec.rb
@@ -5,7 +5,8 @@ require 'rails_helper'
 describe AccountStatusesCleanupService, type: :service do
   let(:account)           { Fabricate(:account, username: 'alice', domain: nil) }
   let(:account_policy)    { Fabricate(:account_statuses_cleanup_policy, account: account) }
-  let!(:unrelated_status) { Fabricate(:status, created_at: 3.years.ago) }
+
+  before { Fabricate(:status, created_at: 3.years.ago) }
 
   describe '#call' do
     context 'when the account has not posted anything' do
@@ -18,7 +19,8 @@ describe AccountStatusesCleanupService, type: :service do
       let!(:very_old_status)    { Fabricate(:status, created_at: 3.years.ago, account: account) }
       let!(:old_status)         { Fabricate(:status, created_at: 1.year.ago, account: account) }
       let!(:another_old_status) { Fabricate(:status, created_at: 1.year.ago, account: account) }
-      let!(:recent_status)      { Fabricate(:status, created_at: 1.day.ago, account: account) }
+
+      before { Fabricate(:status, created_at: 1.day.ago, account: account) }
 
       context 'when given a budget of 1' do
         it 'reports 1 deleted toot' do

--- a/spec/services/activitypub/fetch_featured_collection_service_spec.rb
+++ b/spec/services/activitypub/fetch_featured_collection_service_spec.rb
@@ -7,8 +7,6 @@ RSpec.describe ActivityPub::FetchFeaturedCollectionService, type: :service do
 
   let(:actor) { Fabricate(:account, domain: 'example.com', uri: 'https://example.com/account', featured_collection_url: 'https://example.com/account/pinned') }
 
-  let!(:known_status) { Fabricate(:status, account: actor, uri: 'https://example.com/account/pinned/1') }
-
   let(:status_json_pinned_known) do
     {
       '@context': 'https://www.w3.org/ns/activitystreams',
@@ -69,6 +67,8 @@ RSpec.describe ActivityPub::FetchFeaturedCollectionService, type: :service do
       items: items,
     }.with_indifferent_access
   end
+
+  before { Fabricate(:status, account: actor, uri: 'https://example.com/account/pinned/1') }
 
   shared_examples 'sets pinned posts' do
     before do

--- a/spec/services/activitypub/fetch_remote_status_service_spec.rb
+++ b/spec/services/activitypub/fetch_remote_status_service_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe ActivityPub::FetchRemoteStatusService, type: :service do
   subject { described_class.new }
 
   let!(:sender) { Fabricate(:account, domain: 'foo.bar', uri: 'https://foo.bar') }
-  let!(:recipient) { Fabricate(:account) }
 
   let(:existing_status) { nil }
 
@@ -23,6 +22,7 @@ RSpec.describe ActivityPub::FetchRemoteStatusService, type: :service do
   end
 
   before do
+    Fabricate(:account)
     stub_request(:get, 'https://foo.bar/watch?v=12345').to_return(status: 404, body: '')
     stub_request(:get, object[:id]).to_return(body: Oj.dump(object))
   end

--- a/spec/services/activitypub/process_account_service_spec.rb
+++ b/spec/services/activitypub/process_account_service_spec.rb
@@ -35,8 +35,6 @@ RSpec.describe ActivityPub::ProcessAccountService, type: :service do
   context 'when account is not suspended' do
     subject { described_class.new.call('alice', 'example.com', payload) }
 
-    let!(:account) { Fabricate(:account, username: 'alice', domain: 'example.com') }
-
     let(:payload) do
       {
         id: 'https://foo.test',
@@ -47,6 +45,7 @@ RSpec.describe ActivityPub::ProcessAccountService, type: :service do
     end
 
     before do
+      Fabricate(:account, username: 'alice', domain: 'example.com')
       allow(Admin::SuspensionWorker).to receive(:perform_async)
     end
 

--- a/spec/services/activitypub/process_collection_service_spec.rb
+++ b/spec/services/activitypub/process_collection_service_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe ActivityPub::ProcessCollectionService, type: :service do
       end
 
       context 'when receiving a fabricated status' do
-        let!(:actor) do
+        before do
           Fabricate(:account,
                     username: 'bob',
                     domain: 'example.com',

--- a/spec/services/batched_remove_status_service_spec.rb
+++ b/spec/services/batched_remove_status_service_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe BatchedRemoveStatusService, type: :service do
   subject { described_class.new }
 
   let!(:alice)  { Fabricate(:account) }
-  let!(:bob)    { Fabricate(:account, username: 'bob', domain: 'example.com') }
   let!(:jeff)   { Fabricate(:account) }
   let!(:hank)   { Fabricate(:account, username: 'hank', protocol: :activitypub, domain: 'example.com', inbox_url: 'http://example.com/inbox') }
 
@@ -14,6 +13,7 @@ RSpec.describe BatchedRemoveStatusService, type: :service do
   let(:status_alice_other) { PostStatusService.new.call(alice, text: 'Another status') }
 
   before do
+    Fabricate(:account, username: 'bob', domain: 'example.com')
     allow(redis).to receive_messages(publish: nil)
 
     stub_request(:post, 'http://example.com/inbox').to_return(status: 200)
@@ -24,7 +24,6 @@ RSpec.describe BatchedRemoveStatusService, type: :service do
 
     status_alice_hello
     status_alice_other
-
     subject.call([status_alice_hello, status_alice_other])
   end
 

--- a/spec/services/block_domain_service_spec.rb
+++ b/spec/services/block_domain_service_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe BlockDomainService, type: :service do
   let!(:bad_status_plain) { Fabricate(:status, account: bad_account, text: 'You suck') }
   let!(:bad_status_with_attachment) { Fabricate(:status, account: bad_account, text: 'Hahaha') }
   let!(:bad_attachment) { Fabricate(:media_attachment, account: bad_account, status: bad_status_with_attachment, file: attachment_fixture('attachment.jpg')) }
-  let!(:already_banned_account) { Fabricate(:account, username: 'badguy', domain: 'evil.org', suspended: true, silenced: true) }
+
+  before { Fabricate(:account, username: 'badguy', domain: 'evil.org', suspended: true, silenced: true) }
 
   describe 'for a suspension' do
     before do

--- a/spec/services/bulk_import_service_spec.rb
+++ b/spec/services/bulk_import_service_spec.rb
@@ -271,14 +271,11 @@ RSpec.describe BulkImportService do
       let(:import_type) { 'domain_blocking' }
       let(:overwrite)   { false }
 
-      let!(:rows) do
+      before do
         [
           { 'domain' => 'blocked.com' },
           { 'domain' => 'to_block.com' },
         ].map { |data| import.rows.create!(data: data) }
-      end
-
-      before do
         account.block_domain!('alreadyblocked.com')
         account.block_domain!('blocked.com')
       end
@@ -298,14 +295,11 @@ RSpec.describe BulkImportService do
       let(:import_type) { 'domain_blocking' }
       let(:overwrite)   { true }
 
-      let!(:rows) do
+      before do
         [
           { 'domain' => 'blocked.com' },
           { 'domain' => 'to_block.com' },
         ].map { |data| import.rows.create!(data: data) }
-      end
-
-      before do
         account.block_domain!('alreadyblocked.com')
         account.block_domain!('blocked.com')
       end

--- a/spec/services/import_service_spec.rb
+++ b/spec/services/import_service_spec.rb
@@ -184,14 +184,15 @@ RSpec.describe ImportService, type: :service do
   context 'with a utf-8 encoded domains' do
     subject { described_class.new }
 
-    let!(:nare) { Fabricate(:account, username: 'nare', domain: 'թութ.հայ', locked: false, protocol: :activitypub, inbox_url: 'https://թութ.հայ/inbox') }
+    before do
+      Fabricate(:account, username: 'nare', domain: 'թութ.հայ', locked: false, protocol: :activitypub, inbox_url: 'https://թութ.հայ/inbox')
+      stub_request(:post, 'https://թութ.հայ/inbox').to_return(status: 200)
+    end
+
     let(:csv) { attachment_fixture('utf8-followers.txt') }
     let(:import) { Import.create(account: account, type: 'following', data: csv) }
 
     # Make sure to not actually go to the remote server
-    before do
-      stub_request(:post, 'https://թութ.հայ/inbox').to_return(status: 200)
-    end
 
     it 'follows the listed account' do
       expect(account.follow_requests.count).to eq 0

--- a/spec/services/notify_service_spec.rb
+++ b/spec/services/notify_service_spec.rb
@@ -67,8 +67,9 @@ RSpec.describe NotifyService, type: :service do
 
       context 'when the message chain is initiated by recipient, but is not direct message' do
         let(:reply_to) { Fabricate(:status, account: recipient) }
-        let!(:mention) { Fabricate(:mention, account: sender, status: reply_to) }
         let(:activity) { Fabricate(:mention, account: recipient, status: Fabricate(:status, account: sender, visibility: :direct, thread: reply_to)) }
+
+        before { Fabricate(:mention, account: sender, status: reply_to) }
 
         it 'does not notify' do
           expect { subject }.to_not change(Notification, :count)
@@ -77,9 +78,10 @@ RSpec.describe NotifyService, type: :service do
 
       context 'when the message chain is initiated by recipient, but without a mention to the sender, even if the sender sends multiple messages in a row' do
         let(:reply_to) { Fabricate(:status, account: recipient) }
-        let!(:mention) { Fabricate(:mention, account: sender, status: reply_to) }
         let(:dummy_reply) { Fabricate(:status, account: sender, visibility: :direct, thread: reply_to) }
         let(:activity) { Fabricate(:mention, account: recipient, status: Fabricate(:status, account: sender, visibility: :direct, thread: dummy_reply)) }
+
+        before { Fabricate(:mention, account: sender, status: reply_to) }
 
         it 'does not notify' do
           expect { subject }.to_not change(Notification, :count)
@@ -88,8 +90,9 @@ RSpec.describe NotifyService, type: :service do
 
       context 'when the message chain is initiated by the recipient with a mention to the sender' do
         let(:reply_to) { Fabricate(:status, account: recipient, visibility: :direct) }
-        let!(:mention) { Fabricate(:mention, account: sender, status: reply_to) }
         let(:activity) { Fabricate(:mention, account: recipient, status: Fabricate(:status, account: sender, visibility: :direct, thread: reply_to)) }
+
+        before { Fabricate(:mention, account: sender, status: reply_to) }
 
         it 'does notify' do
           expect { subject }.to change(Notification, :count)

--- a/spec/services/remove_status_service_spec.rb
+++ b/spec/services/remove_status_service_spec.rb
@@ -5,13 +5,13 @@ require 'rails_helper'
 RSpec.describe RemoveStatusService, type: :service do
   subject { described_class.new }
 
-  let!(:alice)  { Fabricate(:account) }
-  let!(:bob)    { Fabricate(:account, username: 'bob', domain: 'example.com') }
+  let!(:alice) { Fabricate(:account) }
   let!(:jeff)   { Fabricate(:account) }
   let!(:hank)   { Fabricate(:account, username: 'hank', protocol: :activitypub, domain: 'example.com', inbox_url: 'http://example.com/inbox') }
   let!(:bill)   { Fabricate(:account, username: 'bill', protocol: :activitypub, domain: 'example2.com', inbox_url: 'http://example2.com/inbox') }
 
   before do
+    Fabricate(:account, username: 'bob', domain: 'example.com')
     stub_request(:post, 'http://example.com/inbox').to_return(status: 200)
     stub_request(:post, 'http://example2.com/inbox').to_return(status: 200)
 

--- a/spec/services/report_service_spec.rb
+++ b/spec/services/report_service_spec.rb
@@ -156,9 +156,8 @@ RSpec.describe ReportService, type: :service do
       -> {  described_class.new.call(source_account, target_account) }
     end
 
-    let!(:other_report) { Fabricate(:report, target_account: target_account) }
-
     before do
+      Fabricate(:report, target_account: target_account)
       ActionMailer::Base.deliveries.clear
       source_account.user.settings['notification_emails.report'] = true
       source_account.user.save

--- a/spec/services/resolve_account_service_spec.rb
+++ b/spec/services/resolve_account_service_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe ResolveAccountService, type: :service do
       let!(:remote_account) { Fabricate(:account, username: 'foo', domain: 'ap.example.com', protocol: 'activitypub') }
 
       context 'when domain is banned' do
-        let!(:domain_block) { Fabricate(:domain_block, domain: 'ap.example.com', severity: :suspend) }
+        before { Fabricate(:domain_block, domain: 'ap.example.com', severity: :suspend) }
 
         it 'does not return an account' do
           expect(subject.call('foo@ap.example.com', skip_webfinger: true)).to be_nil
@@ -205,7 +205,8 @@ RSpec.describe ResolveAccountService, type: :service do
 
   context 'with an already-known acct: URI changing ActivityPub id' do
     let!(:old_account) { Fabricate(:account, username: 'foo', domain: 'ap.example.com', uri: 'https://old.example.com/users/foo', last_webfingered_at: nil) }
-    let!(:status) { Fabricate(:status, account: old_account, text: 'foo') }
+
+    before { Fabricate(:status, account: old_account, text: 'foo') }
 
     it 'returns new remote account' do
       account = subject.call('foo@ap.example.com')

--- a/spec/services/suspend_account_service_spec.rb
+++ b/spec/services/suspend_account_service_spec.rb
@@ -46,9 +46,9 @@ RSpec.describe SuspendAccountService, type: :service do
       let!(:account)         { Fabricate(:account) }
       let!(:remote_follower) { Fabricate(:account, uri: 'https://alice.com', inbox_url: 'https://alice.com/inbox', protocol: :activitypub, domain: 'alice.com') }
       let!(:remote_reporter) { Fabricate(:account, uri: 'https://bob.com', inbox_url: 'https://bob.com/inbox', protocol: :activitypub, domain: 'bob.com') }
-      let!(:report)          { Fabricate(:report, account: remote_reporter, target_account: account) }
 
       before do
+        Fabricate(:report, account: remote_reporter, target_account: account)
         remote_follower.follow!(account)
       end
 

--- a/spec/services/unallow_domain_service_spec.rb
+++ b/spec/services/unallow_domain_service_spec.rb
@@ -6,11 +6,12 @@ RSpec.describe UnallowDomainService, type: :service do
   subject { described_class.new }
 
   let!(:bad_account) { Fabricate(:account, username: 'badguy666', domain: 'evil.org') }
+  let!(:domain_allow) { Fabricate(:domain_allow, domain: 'evil.org') }
   let!(:bad_status_harassment) { Fabricate(:status, account: bad_account, text: 'You suck') }
   let!(:bad_status_mean) { Fabricate(:status, account: bad_account, text: 'Hahaha') }
   let!(:bad_attachment) { Fabricate(:media_attachment, account: bad_account, status: bad_status_mean, file: attachment_fixture('attachment.jpg')) }
-  let!(:already_banned_account) { Fabricate(:account, username: 'badguy', domain: 'evil.org', suspended: true, silenced: true) }
-  let!(:domain_allow) { Fabricate(:domain_allow, domain: 'evil.org') }
+
+  before { Fabricate(:account, username: 'badguy', domain: 'evil.org', suspended: true, silenced: true) }
 
   context 'with limited federation mode' do
     before do

--- a/spec/services/unsuspend_account_service_spec.rb
+++ b/spec/services/unsuspend_account_service_spec.rb
@@ -39,9 +39,9 @@ RSpec.describe UnsuspendAccountService, type: :service do
       let!(:account)         { Fabricate(:account) }
       let!(:remote_follower) { Fabricate(:account, uri: 'https://alice.com', inbox_url: 'https://alice.com/inbox', protocol: :activitypub, domain: 'alice.com') }
       let!(:remote_reporter) { Fabricate(:account, uri: 'https://bob.com', inbox_url: 'https://bob.com/inbox', protocol: :activitypub, domain: 'bob.com') }
-      let!(:report)          { Fabricate(:report, account: remote_reporter, target_account: account) }
 
       before do
+        Fabricate(:report, account: remote_reporter, target_account: account)
         remote_follower.follow!(account)
       end
 

--- a/spec/workers/scheduler/user_cleanup_scheduler_spec.rb
+++ b/spec/workers/scheduler/user_cleanup_scheduler_spec.rb
@@ -8,7 +8,8 @@ describe Scheduler::UserCleanupScheduler do
   let!(:new_unconfirmed_user) { Fabricate(:user) }
   let!(:old_unconfirmed_user) { Fabricate(:user) }
   let!(:confirmed_user)       { Fabricate(:user) }
-  let!(:moderation_note)      { Fabricate(:account_moderation_note, account: Fabricate(:account), target_account: old_unconfirmed_user.account) }
+
+  before { Fabricate(:account_moderation_note, account: Fabricate(:account), target_account: old_unconfirmed_user.account) }
 
   describe '#perform' do
     before do


### PR DESCRIPTION
The diff lengthy, but fortunately theres only 1-2 changes in most of the files. Changes in a few categories:

- The vast majority of these had some setup in a `let!` that could have been in a `before` or right in the example, so I just moved them in.
- One controller spec had a looping construct of hashes and expected results and was using `send` with a symbol so it was seen as not used. This struck me as more confusing than useful in terms of the compactness, so I unrolled the loop into multiple examples.
- A few of them actually had a use in the example, so I kept the `let` and added the usage
- In one scenario there was a local var being setup for a shared_examples usage, and I left inline comments disabling the cop. At some point I may do a pass at the all the disabled stuff and look for better approach.