### PR TITLE
Opt out of `Rails/NegateInclude` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -115,6 +115,11 @@ Rails/SkipsModelValidations:
 Rails/UnusedIgnoredColumns:
   Enabled: false
 
+# Reason: Prevailing style choice
+# https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsnegateinclude
+Rails/NegateInclude:
+  Enabled: false
+
 # Reason: Some single letter camel case files shouldn't be split
 # https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecfilepath
 RSpec/FilePath:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -119,23 +119,6 @@ Rails/LexicallyScopedActionFilter:
     - 'app/controllers/auth/passwords_controller.rb'
     - 'app/controllers/auth/registrations_controller.rb'
 
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Rails/NegateInclude:
-  Exclude:
-    - 'app/controllers/concerns/signature_verification.rb'
-    - 'app/helpers/jsonld_helper.rb'
-    - 'app/lib/activitypub/activity/create.rb'
-    - 'app/lib/activitypub/activity/move.rb'
-    - 'app/lib/feed_manager.rb'
-    - 'app/lib/link_details_extractor.rb'
-    - 'app/models/concerns/attachmentable.rb'
-    - 'app/models/concerns/remotable.rb'
-    - 'app/models/custom_filter.rb'
-    - 'app/services/activitypub/process_status_update_service.rb'
-    - 'app/services/fetch_link_card_service.rb'
-    - 'app/workers/web/push_notification_worker.rb'
-    - 'lib/paperclip/color_extractor.rb'
-
 Rails/OutputSafety:
   Exclude:
     - 'config/initializers/simple_form.rb'


### PR DESCRIPTION
I started to correct these and disagreed with (or at least wasn't totally sold on) many of them ... maybe just disable this one?

This cop finds things like `![1,2,3].include?(x)` and wants to replace with `[1,2,3].exclude?(x)` - which sounds fine for a simple example but in lots of the actual usage I'm less sure.