### PR TITLE
Fix call to inefficient `delete_matched` cache method in domain blocks

### DIFF
--- a/app/controllers/api/v1/accounts/notes_controller.rb
+++ b/app/controllers/api/v1/accounts/notes_controller.rb
@@ -25,6 +25,6 @@ class Api::V1::Accounts::NotesController < Api::BaseController
   end
 
   def relationships_presenter
-    AccountRelationshipsPresenter.new([@account.id], current_user.account_id)
+    AccountRelationshipsPresenter.new([@account], current_user.account_id)
   end
 end

--- a/app/controllers/api/v1/accounts/pins_controller.rb
+++ b/app/controllers/api/v1/accounts/pins_controller.rb
@@ -25,6 +25,6 @@ class Api::V1::Accounts::PinsController < Api::BaseController
   end
 
   def relationships_presenter
-    AccountRelationshipsPresenter.new([@account.id], current_user.account_id)
+    AccountRelationshipsPresenter.new([@account], current_user.account_id)
   end
 end

--- a/app/controllers/api/v1/accounts/relationships_controller.rb
+++ b/app/controllers/api/v1/accounts/relationships_controller.rb
@@ -5,7 +5,7 @@ class Api::V1::Accounts::RelationshipsController < Api::BaseController
   before_action :require_user!
 
   def index
-    @accounts = Account.where(id: account_ids).select('id')
+    @accounts = Account.where(id: account_ids).select(:id, :domain)
     @accounts.merge!(Account.without_suspended) unless truthy_param?(:with_suspended)
     render json: @accounts, each_serializer: REST::RelationshipSerializer, relationships: relationships
   end

--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -88,7 +88,7 @@ class Api::V1::AccountsController < Api::BaseController
   end
 
   def relationships(**options)
-    AccountRelationshipsPresenter.new([@account.id], current_user.account_id, **options)
+    AccountRelationshipsPresenter.new([@account], current_user.account_id, **options)
   end
 
   def account_params

--- a/app/controllers/api/v1/follow_requests_controller.rb
+++ b/app/controllers/api/v1/follow_requests_controller.rb
@@ -25,11 +25,11 @@ class Api::V1::FollowRequestsController < Api::BaseController
   private
 
   def account
-    Account.find(params[:id])
+    @account ||= Account.find(params[:id])
   end
 
   def relationships(**options)
-    AccountRelationshipsPresenter.new([params[:id]], current_user.account_id, **options)
+    AccountRelationshipsPresenter.new([account], current_user.account_id, **options)
   end
 
   def load_accounts

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -33,7 +33,7 @@ class RelationshipsController < ApplicationController
   end
 
   def set_relationships
-    @relationships = AccountRelationshipsPresenter.new(@accounts.pluck(:id), current_user.account_id)
+    @relationships = AccountRelationshipsPresenter.new(@accounts, current_user.account_id)
   end
 
   def form_account_batch_params

--- a/app/models/account_domain_block.rb
+++ b/app/models/account_domain_block.rb
@@ -18,11 +18,12 @@ class AccountDomainBlock < ApplicationRecord
   belongs_to :account
   validates :domain, presence: true, uniqueness: { scope: :account_id }, domain: true
 
-  after_commit :remove_blocking_cache
+  after_commit :invalidate_domain_blocking_cache
 
   private
 
-  def remove_blocking_cache
+  def invalidate_domain_blocking_cache
     Rails.cache.delete("exclude_domains_for:#{account_id}")
+    Rails.cache.delete("exclude_domains:#{account_id}:#{domain}")
   end
 end

--- a/app/models/account_domain_block.rb
+++ b/app/models/account_domain_block.rb
@@ -19,15 +19,10 @@ class AccountDomainBlock < ApplicationRecord
   validates :domain, presence: true, uniqueness: { scope: :account_id }, domain: true
 
   after_commit :remove_blocking_cache
-  after_commit :remove_relationship_cache
 
   private
 
   def remove_blocking_cache
     Rails.cache.delete("exclude_domains_for:#{account_id}")
-  end
-
-  def remove_relationship_cache
-    Rails.cache.delete_matched("relationship:#{account_id}:*")
   end
 end

--- a/app/models/account_domain_block.rb
+++ b/app/models/account_domain_block.rb
@@ -24,6 +24,6 @@ class AccountDomainBlock < ApplicationRecord
 
   def invalidate_domain_blocking_cache
     Rails.cache.delete("exclude_domains_for:#{account_id}")
-    Rails.cache.delete("exclude_domains:#{account_id}:#{domain}")
+    Rails.cache.delete(['exclude_domains', account_id, domain])
   end
 end

--- a/app/models/concerns/account/interactions.rb
+++ b/app/models/concerns/account/interactions.rb
@@ -60,8 +60,8 @@ module Account::Interactions
       end
     end
 
-    def domain_blocking_map(target_account_ids, account_id)
-      accounts_map    = Account.where(id: target_account_ids).select('id, domain').each_with_object({}) { |a, h| h[a.id] = a.domain }
+    def domain_blocking_map(target_accounts, account_id)
+      accounts_map    = target_accounts.each_with_object({}) { |a, h| h[a.id] = a.domain }
       blocked_domains = domain_blocking_map_by_domain(accounts_map.values.compact, account_id)
       accounts_map.reduce({}) { |h, (id, domain)| h.merge(id => blocked_domains[domain]) }
     end

--- a/app/models/concerns/account/interactions.rb
+++ b/app/models/concerns/account/interactions.rb
@@ -60,12 +60,6 @@ module Account::Interactions
       end
     end
 
-    def domain_blocking_map(target_accounts, account_id)
-      accounts_map    = target_accounts.each_with_object({}) { |a, h| h[a.id] = a.domain }
-      blocked_domains = domain_blocking_map_by_domain(accounts_map.values.compact, account_id)
-      accounts_map.transform_values { |domain| blocked_domains[domain] }
-    end
-
     def domain_blocking_map_by_domain(target_domains, account_id)
       follow_mapping(AccountDomainBlock.where(account_id: account_id, domain: target_domains), :domain)
     end

--- a/app/models/concerns/account/interactions.rb
+++ b/app/models/concerns/account/interactions.rb
@@ -63,7 +63,7 @@ module Account::Interactions
     def domain_blocking_map(target_accounts, account_id)
       accounts_map    = target_accounts.each_with_object({}) { |a, h| h[a.id] = a.domain }
       blocked_domains = domain_blocking_map_by_domain(accounts_map.values.compact, account_id)
-      accounts_map.reduce({}) { |h, (id, domain)| h.merge(id => blocked_domains[domain]) }
+      accounts_map.transform_values { |domain| blocked_domains[domain] }
     end
 
     def domain_blocking_map_by_domain(target_domains, account_id)

--- a/app/models/concerns/relationship_cacheable.rb
+++ b/app/models/concerns/relationship_cacheable.rb
@@ -10,7 +10,7 @@ module RelationshipCacheable
   private
 
   def remove_relationship_cache
-    Rails.cache.delete("relationship:#{account_id}:#{target_account_id}")
-    Rails.cache.delete("relationship:#{target_account_id}:#{account_id}")
+    Rails.cache.delete(['relationship', account_id, target_account_id])
+    Rails.cache.delete(['relationship', target_account_id, account_id])
   end
 end

--- a/app/presenters/account_relationships_presenter.rb
+++ b/app/presenters/account_relationships_presenter.rb
@@ -55,9 +55,10 @@ class AccountRelationshipsPresenter
 
     @uncached_account_ids = []
 
-    @account_ids.each do |account_id|
-      maps_for_account = Rails.cache.read("relationship:#{@current_account_id}:#{account_id}")
+    return @cached if @account_ids.empty?
 
+    cache_ids = @account_ids.map { |account_id| "relationship:#{@current_account_id}:#{account_id}" }
+    @account_ids.zip(Rails.cache.read_multi(cache_ids)).each do |account_id, maps_for_account|
       if maps_for_account.is_a?(Hash)
         @cached.deep_merge!(maps_for_account)
       else

--- a/app/presenters/account_relationships_presenter.rb
+++ b/app/presenters/account_relationships_presenter.rb
@@ -5,8 +5,9 @@ class AccountRelationshipsPresenter
               :muting, :requested, :requested_by, :domain_blocking,
               :endorsed, :account_note
 
-  def initialize(account_ids, current_account_id, **options)
-    @account_ids        = account_ids.map { |a| a.is_a?(Account) ? a.id : a.to_i }
+  def initialize(accounts, current_account_id, **options)
+    @accounts = accounts.to_a
+    @account_ids        = @accounts.pluck(:id)
     @current_account_id = current_account_id
 
     @following       = cached[:following].merge(Account.following_map(@uncached_account_ids, @current_account_id))
@@ -16,9 +17,10 @@ class AccountRelationshipsPresenter
     @muting          = cached[:muting].merge(Account.muting_map(@uncached_account_ids, @current_account_id))
     @requested       = cached[:requested].merge(Account.requested_map(@uncached_account_ids, @current_account_id))
     @requested_by    = cached[:requested_by].merge(Account.requested_by_map(@uncached_account_ids, @current_account_id))
-    @domain_blocking = cached[:domain_blocking].merge(Account.domain_blocking_map(@uncached_account_ids, @current_account_id))
     @endorsed        = cached[:endorsed].merge(Account.endorsed_map(@uncached_account_ids, @current_account_id))
     @account_note    = cached[:account_note].merge(Account.account_note_map(@uncached_account_ids, @current_account_id))
+
+    @domain_blocking = Account.domain_blocking_map(@accounts, @current_account_id)
 
     cache_uncached!
 
@@ -47,7 +49,6 @@ class AccountRelationshipsPresenter
       muting: {},
       requested: {},
       requested_by: {},
-      domain_blocking: {},
       endorsed: {},
       account_note: {},
     }
@@ -77,7 +78,6 @@ class AccountRelationshipsPresenter
         muting: { account_id => muting[account_id] },
         requested: { account_id => requested[account_id] },
         requested_by: { account_id => requested_by[account_id] },
-        domain_blocking: { account_id => domain_blocking[account_id] },
         endorsed: { account_id => endorsed[account_id] },
         account_note: { account_id => account_note[account_id] },
       }

--- a/spec/presenters/account_relationships_presenter_spec.rb
+++ b/spec/presenters/account_relationships_presenter_spec.rb
@@ -5,18 +5,18 @@ require 'rails_helper'
 RSpec.describe AccountRelationshipsPresenter do
   describe '.initialize' do
     before do
-      allow(Account).to receive(:following_map).with(account_ids, current_account_id).and_return(default_map)
-      allow(Account).to receive(:followed_by_map).with(account_ids, current_account_id).and_return(default_map)
-      allow(Account).to receive(:blocking_map).with(account_ids, current_account_id).and_return(default_map)
-      allow(Account).to receive(:muting_map).with(account_ids, current_account_id).and_return(default_map)
-      allow(Account).to receive(:requested_map).with(account_ids, current_account_id).and_return(default_map)
-      allow(Account).to receive(:requested_by_map).with(account_ids, current_account_id).and_return(default_map)
-      allow(Account).to receive(:domain_blocking_map).with(account_ids, current_account_id).and_return(default_map)
+      allow(Account).to receive(:following_map).with(accounts.pluck(:id), current_account_id).and_return(default_map)
+      allow(Account).to receive(:followed_by_map).with(accounts.pluck(:id), current_account_id).and_return(default_map)
+      allow(Account).to receive(:blocking_map).with(accounts.pluck(:id), current_account_id).and_return(default_map)
+      allow(Account).to receive(:muting_map).with(accounts.pluck(:id), current_account_id).and_return(default_map)
+      allow(Account).to receive(:requested_map).with(accounts.pluck(:id), current_account_id).and_return(default_map)
+      allow(Account).to receive(:requested_by_map).with(accounts.pluck(:id), current_account_id).and_return(default_map)
+      allow(Account).to receive(:domain_blocking_map).with(accounts, current_account_id).and_return(default_map)
     end
 
-    let(:presenter)          { described_class.new(account_ids, current_account_id, **options) }
+    let(:presenter)          { described_class.new(accounts, current_account_id, **options) }
     let(:current_account_id) { Fabricate(:account).id }
-    let(:account_ids)        { [Fabricate(:account).id] }
+    let(:accounts)           { [Fabricate(:account)] }
     let(:default_map)        { { 1 => true } }
 
     context 'when options are not set' do

--- a/spec/presenters/account_relationships_presenter_spec.rb
+++ b/spec/presenters/account_relationships_presenter_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe AccountRelationshipsPresenter do
       allow(Account).to receive(:muting_map).with(accounts.pluck(:id), current_account_id).and_return(default_map)
       allow(Account).to receive(:requested_map).with(accounts.pluck(:id), current_account_id).and_return(default_map)
       allow(Account).to receive(:requested_by_map).with(accounts.pluck(:id), current_account_id).and_return(default_map)
-      allow(Account).to receive(:domain_blocking_map).with(accounts, current_account_id).and_return(default_map)
     end
 
     let(:presenter)          { described_class.new(accounts, current_account_id, **options) }
@@ -29,7 +28,7 @@ RSpec.describe AccountRelationshipsPresenter do
           blocking: default_map,
           muting: default_map,
           requested: default_map,
-          domain_blocking: default_map
+          domain_blocking: { accounts[0].id => nil }
         )
       end
     end
@@ -86,7 +85,7 @@ RSpec.describe AccountRelationshipsPresenter do
       let(:options) { { domain_blocking_map: { 7 => true } } }
 
       it 'sets @domain_blocking merged with default_map and options[:domain_blocking_map]' do
-        expect(presenter.domain_blocking).to eq default_map.merge(options[:domain_blocking_map])
+        expect(presenter.domain_blocking).to eq({ accounts[0].id => nil }.merge(options[:domain_blocking_map]))
       end
     end
   end

--- a/spec/presenters/account_relationships_presenter_spec.rb
+++ b/spec/presenters/account_relationships_presenter_spec.rb
@@ -16,12 +16,38 @@ RSpec.describe AccountRelationshipsPresenter do
     let(:presenter)          { described_class.new(accounts, current_account_id, **options) }
     let(:current_account_id) { Fabricate(:account).id }
     let(:accounts)           { [Fabricate(:account)] }
-    let(:default_map)        { { 1 => true } }
+    let(:default_map)        { { accounts[0].id => true } }
 
     context 'when options are not set' do
       let(:options) { {} }
 
       it 'sets default maps' do
+        expect(presenter).to have_attributes(
+          following: default_map,
+          followed_by: default_map,
+          blocking: default_map,
+          muting: default_map,
+          requested: default_map,
+          domain_blocking: { accounts[0].id => nil }
+        )
+      end
+    end
+
+    context 'with a warm cache' do
+      let(:options) { {} }
+
+      before do
+        described_class.new(accounts, current_account_id, **options)
+
+        allow(Account).to receive(:following_map).with([], current_account_id).and_return({})
+        allow(Account).to receive(:followed_by_map).with([], current_account_id).and_return({})
+        allow(Account).to receive(:blocking_map).with([], current_account_id).and_return({})
+        allow(Account).to receive(:muting_map).with([], current_account_id).and_return({})
+        allow(Account).to receive(:requested_map).with([], current_account_id).and_return({})
+        allow(Account).to receive(:requested_by_map).with([], current_account_id).and_return({})
+      end
+
+      it 'sets returns expected values' do
         expect(presenter).to have_attributes(
           following: default_map,
           followed_by: default_map,


### PR DESCRIPTION
All cached relationships for an account were being cleared in bulk using `Rails.cache.delete_matched` when blocking an account. However, `delete_matched` iters through all cache keys and does not have any optimization for matching by prefix, which has a very significant performance impact.

The information of whether an account is domain-blocked by the current user has been moved outside of the relationships cache and is instead cached in a per-domain cache. In the worst case, this would double the number of cache keys used for a relationship cache, but it should slightly reduce the amount of data duplication throughout the cache.

The code has also been changed to use `read_multi` to request most cache keys at once and thus reduce the number of Redis queries per access to relationship caches. This also changes the relationship cache keys from `relationship:<account>:<second_account>` to `relationship/<account>/<second_account>` as it is how Rails internally splits cache key components.