### PR TITLE
Update paperclip and climate_control gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -123,7 +123,7 @@ group :test do
   gem 'database_cleaner-active_record'
 
   # Used to mock environment variables
-  gem 'climate_control', '~> 0.2'
+  gem 'climate_control'
 
   # Generating fake data for specs
   gem 'faker', '~> 3.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,7 +185,7 @@ GEM
       elasticsearch (>= 7.12.0, < 7.14.0)
       elasticsearch-dsl
     chunky_png (1.4.0)
-    climate_control (0.2.0)
+    climate_control (1.2.0)
     cocoon (1.2.15)
     color_diff (0.1)
     concurrent-ruby (1.2.3)
@@ -745,8 +745,8 @@ GEM
     temple (0.10.3)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
-    terrapin (0.6.0)
-      climate_control (>= 0.0.3, < 1.0)
+    terrapin (1.0.1)
+      climate_control
     test-prof (1.3.1)
     thor (1.3.0)
     tilt (2.3.0)
@@ -835,7 +835,7 @@ DEPENDENCIES
   capybara (~> 3.39)
   charlock_holmes (~> 0.7.7)
   chewy (~> 7.3)
-  climate_control (~> 0.2)
+  climate_control
   cocoon (~> 1.2)
   color_diff (~> 0.1)
   concurrent-ruby


### PR DESCRIPTION
Opening as draft and will rebase assuming there's an actual kt-paperclip version bump soon.

The `kt-paperclip` gem had a dependency lock to keep `terrapin` low enough that `terrapin` would not allow us to update `climate_control` gem. A recent terrapin release relaxed that version, and this kt-paperclip commit https://github.com/kreeti/kt-paperclip/pull/130 relaxes the terrapin req on their side.