### PR TITLE
Assign a proc to `Rack::Request.ip_filter` instead of patching method

### DIFF
--- a/config/initializers/trusted_proxies.rb
+++ b/config/initializers/trusted_proxies.rb
@@ -1,13 +1,8 @@
 # frozen_string_literal: true
 
-module Rack
-  class Request
-    def trusted_proxy?(ip)
-      if Rails.application.config.action_dispatch.trusted_proxies.nil?
-        super
-      else
-        Rails.application.config.action_dispatch.trusted_proxies.any? { |proxy| proxy === ip }
-      end
-    end
-  end
+unless Rails.application.config.action_dispatch.trusted_proxies.nil?
+  # Rack is configured with a default collection of trusted proxies
+  # If Rails has been configured to use a specific list, configure
+  # Rack to use this Proc, which enforces the Rails-configured list.
+  Rack::Request.ip_filter = ->(ip) { Rails.application.config.action_dispatch.trusted_proxies.include?(ip) }
 end


### PR DESCRIPTION
In a previous version of rack they [added the ability](https://github.com/rack/rack/pull/1290) to provide a proc to an `ip_filter` setting, instead of patching the method.

I believe the logic describeds by the comment is both what was previously happening here, and what should continue to happen here. Because we're in an initializer and we don't (by default) have any values here, its challenging to add a spec for this ... but I did a little console work and it looks the same as before to me.