### PR TITLE
Opt out of `Rails/UnusedIgnoredColumns` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -109,6 +109,12 @@ Rails/SkipsModelValidations:
   Exclude:
     - 'db/*migrate/**/*'
 
+# Reason: We want to preserve the ability to migrate from arbitrary old versions,
+# and cannot guarantee that every installation has run every migration as they upgrade.
+# https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsunusedignoredcolumns
+Rails/UnusedIgnoredColumns:
+  Enabled: false
+
 # Reason: Some single letter camel case files shouldn't be split
 # https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecfilepath
 RSpec/FilePath:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -196,19 +196,6 @@ Rails/UniqueValidationWithoutIndex:
     - 'app/models/identity.rb'
     - 'app/models/webauthn_credential.rb'
 
-# Configuration parameters: Include.
-# Include: app/models/**/*.rb
-Rails/UnusedIgnoredColumns:
-  Exclude:
-    - 'app/models/account.rb'
-    - 'app/models/account_stat.rb'
-    - 'app/models/admin/action_log.rb'
-    - 'app/models/custom_filter.rb'
-    - 'app/models/email_domain_block.rb'
-    - 'app/models/report.rb'
-    - 'app/models/status_edit.rb'
-    - 'app/models/user.rb'
-
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: exists, where


### PR DESCRIPTION
You would typically leave these in place just to run the migration, then remove on subsequent deploy/release.

However, as explained here - https://github.com/mastodon/mastodon/pull/23806#issuecomment-1440370263 - we want to essentially preserve the ability to migrate from any arbitrary old version, and/or handle cases where people may have failed to fully migrate, etc ... so this is not relevant in our case.