### PR TITLE
Fix `Style/StderrPuts` cop

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -455,11 +455,6 @@ Style/SingleArgumentDig:
   Exclude:
     - 'lib/webpacker/manifest_extensions.rb'
 
-# This cop supports safe autocorrection (--autocorrect).
-Style/StderrPuts:
-  Exclude:
-    - 'config/boot.rb'
-
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: Mode.
 Style/StringConcatenation:

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 unless ENV.key?('RAILS_ENV')
-  STDERR.puts 'ERROR: Missing RAILS_ENV environment variable, please set it to "production", "development", or "test".'
+  warn 'ERROR: Missing RAILS_ENV environment variable, please set it to "production", "development", or "test".'
   exit 1
 end
 


### PR DESCRIPTION
I confirmed locally that the previous behavior of 1) an exit code of `1` is used, 2) the string displays in console - are both preserved.

The cop wants it this way so that you could potentially configure a log-level around this and avoid the output, which seems fine.