### PR TITLE
Add the functionality to filter my own posts in Home

### DIFF
--- a/app/javascript/mastodon/components/status.jsx
+++ b/app/javascript/mastodon/components/status.jsx
@@ -394,7 +394,7 @@ class Status extends ImmutablePureComponent {
     const interacted = status.get("reblogged") || status.get("favourited") ||
           status.get("bookmarked");
     if (this.state.forceFilter === undefined ?
-      (interacted || matchedFilters || postAcct === forUser) :
+      ((forUser && interacted) || matchedFilters || postAcct === forUser) :
       this.state.forceFilter) {
       const minHandlers = this.props.muted ? {} : {
         moveUp: this.handleHotkeyMoveUp,

--- a/app/javascript/mastodon/components/status.jsx
+++ b/app/javascript/mastodon/components/status.jsx
@@ -390,20 +390,24 @@ class Status extends ImmutablePureComponent {
     const matchedFilters = status.get('matched_filters');
 
     const forUser = this.props.forUser && this.props.forUser.get('acct');
-    const postAcct = status.get('account').get('acct');
+    const postAcct = status.getIn(['account', 'acct']);
+    const interacted = status.get("reblogged") || status.get("favourited") ||
+          status.get("bookmarked");
     if (this.state.forceFilter === undefined ?
-        (matchedFilters || postAcct === forUser) :
-        this.state.forceFilter) {
+      (interacted || matchedFilters || postAcct === forUser) :
+      this.state.forceFilter) {
       const minHandlers = this.props.muted ? {} : {
         moveUp: this.handleHotkeyMoveUp,
         moveDown: this.handleHotkeyMoveDown,
       };
 
+      const message = interacted ? "Interacted" :
+        (postAcct === forUser ? "Self" : matchedFilters.join(', '));
+
       return (
         <HotKeys handlers={minHandlers}>
           <div className='status__wrapper status__wrapper--filtered focusable' tabIndex={0} ref={this.handleRef}>
-            <FormattedMessage id='status.filtered' defaultMessage='Filtered' />: {postAcct === forUser ? "Self" : matchedFilters.join(', ')}.
-            {' '}
+            <FormattedMessage id='status.filtered' defaultMessage='Filtered' />: {message}.{' '}
             <button className='status__wrapper--filtered__button' onClick={this.handleUnfilterClick}>
               <FormattedMessage id='status.show_filter_reason' defaultMessage='Show anyway' />
             </button>

--- a/app/javascript/mastodon/components/status.jsx
+++ b/app/javascript/mastodon/components/status.jsx
@@ -79,6 +79,7 @@ const messages = defineMessages({
 class Status extends ImmutablePureComponent {
 
   static propTypes = {
+    forUser: ImmutablePropTypes.map,
     status: ImmutablePropTypes.map,
     account: ImmutablePropTypes.record,
     previousId: PropTypes.string,
@@ -388,7 +389,11 @@ class Status extends ImmutablePureComponent {
     const connectReply = nextInReplyToId && nextInReplyToId === status.get('id');
     const matchedFilters = status.get('matched_filters');
 
-    if (this.state.forceFilter === undefined ? matchedFilters : this.state.forceFilter) {
+    const forUser = this.props.forUser && this.props.forUser.get('acct');
+    const postAcct = status.get('account').get('acct');
+    if (this.state.forceFilter === undefined ?
+        (matchedFilters || postAcct === forUser) :
+        this.state.forceFilter) {
       const minHandlers = this.props.muted ? {} : {
         moveUp: this.handleHotkeyMoveUp,
         moveDown: this.handleHotkeyMoveDown,
@@ -397,7 +402,7 @@ class Status extends ImmutablePureComponent {
       return (
         <HotKeys handlers={minHandlers}>
           <div className='status__wrapper status__wrapper--filtered focusable' tabIndex={0} ref={this.handleRef}>
-            <FormattedMessage id='status.filtered' defaultMessage='Filtered' />: {matchedFilters.join(', ')}.
+            <FormattedMessage id='status.filtered' defaultMessage='Filtered' />: {postAcct === forUser ? "Self" : matchedFilters.join(', ')}.
             {' '}
             <button className='status__wrapper--filtered__button' onClick={this.handleUnfilterClick}>
               <FormattedMessage id='status.show_filter_reason' defaultMessage='Show anyway' />
@@ -406,6 +411,7 @@ class Status extends ImmutablePureComponent {
         </HotKeys>
       );
     }
+
 
     if (featured) {
       prepend = (

--- a/app/javascript/mastodon/components/status_list.jsx
+++ b/app/javascript/mastodon/components/status_list.jsx
@@ -15,6 +15,7 @@ import ScrollableList from './scrollable_list';
 export default class StatusList extends ImmutablePureComponent {
 
   static propTypes = {
+    forUser: ImmutablePropTypes.map,
     scrollKey: PropTypes.string.isRequired,
     statusIds: ImmutablePropTypes.list.isRequired,
     featuredStatusIds: ImmutablePropTypes.list,
@@ -100,6 +101,7 @@ export default class StatusList extends ImmutablePureComponent {
         />
       ) : (
         <StatusContainer
+          forUser={this.props.forUser}
           key={statusId}
           id={statusId}
           onMoveUp={this.handleMoveUp}
@@ -115,6 +117,7 @@ export default class StatusList extends ImmutablePureComponent {
     if (scrollableContent && featuredStatusIds) {
       scrollableContent = featuredStatusIds.map(statusId => (
         <StatusContainer
+          forUser={this.props.forUser}
           key={`f-${statusId}`}
           id={statusId}
           featured

--- a/app/javascript/mastodon/containers/status_container.jsx
+++ b/app/javascript/mastodon/containers/status_container.jsx
@@ -67,6 +67,7 @@ const makeMapStateToProps = () => {
   const getPictureInPicture = makeGetPictureInPicture();
 
   const mapStateToProps = (state, props) => ({
+    forUser: props.forUser,
     status: getStatus(state, props),
     nextInReplyToId: props.nextId ? state.getIn(['statuses', props.nextId, 'in_reply_to_id']) : null,
     pictureInPicture: getPictureInPicture(state, props),

--- a/app/javascript/mastodon/features/home_timeline/index.jsx
+++ b/app/javascript/mastodon/features/home_timeline/index.jsx
@@ -8,6 +8,7 @@ import { Helmet } from 'react-helmet';
 
 import { createSelector } from '@reduxjs/toolkit';
 import { List as ImmutableList } from 'immutable';
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
 
 import CampaignIcon from 'mastodon/../material-icons/400-24px/campaign.svg?react';
@@ -73,6 +74,7 @@ const homeTooSlow = createSelector([
 );
 
 const mapStateToProps = state => ({
+  forUser: state.getIn(['accounts', me]),
   hasUnread: state.getIn(['timelines', 'home', 'unread']) > 0,
   isPartial: state.getIn(['timelines', 'home', 'isPartial']),
   hasAnnouncements: !state.getIn(['announcements', 'items']).isEmpty(),
@@ -88,6 +90,7 @@ class HomeTimeline extends PureComponent {
   };
 
   static propTypes = {
+    forUser: ImmutablePropTypes.map,
     dispatch: PropTypes.func.isRequired,
     intl: PropTypes.object.isRequired,
     hasUnread: PropTypes.bool,
@@ -167,7 +170,7 @@ class HomeTimeline extends PureComponent {
   };
 
   render () {
-    const { intl, hasUnread, columnId, multiColumn, tooSlow, hasAnnouncements, unreadAnnouncements, showAnnouncements } = this.props;
+    const { intl, hasUnread, columnId, forUser, multiColumn, tooSlow, hasAnnouncements, unreadAnnouncements, showAnnouncements } = this.props;
     const pinned = !!columnId;
     const { signedIn } = this.context.identity;
     const banners = [];
@@ -216,6 +219,7 @@ class HomeTimeline extends PureComponent {
 
         {signedIn ? (
           <StatusListContainer
+            forUser={forUser}
             prepend={banners}
             alwaysPrepend
             trackScroll={!pinned}

--- a/app/javascript/mastodon/features/ui/containers/status_list_container.js
+++ b/app/javascript/mastodon/features/ui/containers/status_list_container.js
@@ -37,7 +37,8 @@ const makeMapStateToProps = () => {
   const getStatusIds = makeGetStatusIds();
   const getPendingStatusIds = makeGetStatusIds(true);
 
-  const mapStateToProps = (state, { timelineId }) => ({
+  const mapStateToProps = (state, { timelineId, forUser }) => ({
+    forUser: forUser,
     statusIds: getStatusIds(state, { type: timelineId }),
     lastId:    state.getIn(['timelines', timelineId, 'items'])?.last(),
     isLoading: state.getIn(['timelines', timelineId, 'isLoading'], true),


### PR DESCRIPTION
This is experimental, and I'm sure will need some discussion.

This patch hides my own posts from the Home timeline as if a proper Mastodon filter had been set up to hide them. It makes my timeline less culttered.

![image](https://github.com/mastodon/mastodon/assets/136482210/aabfa937-5bd9-4e36-9e3a-230f3c00588f)
