### PR TITLE
Fix `Style/RedundantReturn` cop

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -426,15 +426,6 @@ Style/RedundantFetchBlock:
     - 'config/initializers/paperclip.rb'
     - 'config/puma.rb'
 
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: AllowMultipleReturnValues.
-Style/RedundantReturn:
-  Exclude:
-    - 'app/controllers/api/v1/directories_controller.rb'
-    - 'app/controllers/auth/confirmations_controller.rb'
-    - 'app/lib/ostatus/tag_manager.rb'
-    - 'app/models/form/import.rb'
-
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: ConvertCodeThatCanStartToReturnNil, AllowedMethods, MaxChainLength.
 # AllowedMethods: present?, blank?, presence, try, try!

--- a/app/controllers/api/v1/directories_controller.rb
+++ b/app/controllers/api/v1/directories_controller.rb
@@ -12,7 +12,7 @@ class Api::V1::DirectoriesController < Api::BaseController
   private
 
   def require_enabled!
-    return not_found unless Setting.profile_directory
+    not_found unless Setting.profile_directory
   end
 
   def set_accounts

--- a/app/controllers/auth/confirmations_controller.rb
+++ b/app/controllers/auth/confirmations_controller.rb
@@ -62,7 +62,7 @@ class Auth::ConfirmationsController < Devise::ConfirmationsController
   end
 
   def captcha_user_bypass?
-    return true if @confirmation_user.nil? || @confirmation_user.confirmed?
+    @confirmation_user.nil? || @confirmation_user.confirmed?
   end
 
   def require_unconfirmed!

--- a/app/lib/ostatus/tag_manager.rb
+++ b/app/lib/ostatus/tag_manager.rb
@@ -52,7 +52,7 @@ class OStatus::TagManager
       ActivityPub::TagManager.instance.uri_to_local_id(tag)
     else
       matches = Regexp.new("objectId=([\\d]+):objectType=#{expected_type}").match(tag)
-      return matches[1] unless matches.nil?
+      matches[1] unless matches.nil?
     end
   end
 

--- a/app/models/form/import.rb
+++ b/app/models/form/import.rb
@@ -43,14 +43,19 @@ class Form::Import
   validate :validate_data
 
   def guessed_type
-    return :muting if csv_headers_match?('Hide notifications')
-    return :following if csv_headers_match?('Show boosts') || csv_headers_match?('Notify on new posts') || csv_headers_match?('Languages')
-    return :following if file_name_matches?('follows') || file_name_matches?('following_accounts')
-    return :blocking if file_name_matches?('blocks') || file_name_matches?('blocked_accounts')
-    return :muting if file_name_matches?('mutes') || file_name_matches?('muted_accounts')
-    return :domain_blocking if file_name_matches?('domain_blocks') || file_name_matches?('blocked_domains')
-    return :bookmarks if file_name_matches?('bookmarks')
-    return :lists if file_name_matches?('lists')
+    if csv_headers_match?('Hide notifications') || file_name_matches?('mutes') || file_name_matches?('muted_accounts')
+      :muting
+    elsif csv_headers_match?('Show boosts') || csv_headers_match?('Notify on new posts') || csv_headers_match?('Languages') || file_name_matches?('follows') || file_name_matches?('following_accounts')
+      :following
+    elsif file_name_matches?('blocks') || file_name_matches?('blocked_accounts')
+      :blocking
+    elsif file_name_matches?('domain_blocks') || file_name_matches?('blocked_domains')
+      :domain_blocking
+    elsif file_name_matches?('bookmarks')
+      :bookmarks
+    elsif file_name_matches?('lists')
+      :lists
+    end
   end
 
   # Whether the uploaded CSV file seems to correspond to a different import type than the one selected


### PR DESCRIPTION
The controller cases may have been left over from early rails versions where you did need an explicit return? Not sure.

The tag_manager I basically let auto-correct.

The Form::Import one I took opportunity to refactor -- there were multiple paths for each of :following and :muting ... but they were all or'd together, so combined into one.