### PR TITLE
Fix `Performance/StringIdentifierArgument` cop

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -110,7 +110,7 @@ module ApplicationHelper
   def can?(action, record)
     return false if record.nil?
 
-    policy(record).public_send("#{action}?")
+    policy(record).public_send(:"#{action}?")
   end
 
   def fa_icon(icon, attributes = {})

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -457,8 +457,8 @@ class Account < ApplicationRecord
     end
 
     def inverse_alias(key, original_key)
-      define_method("#{key}=") do |value|
-        public_send("#{original_key}=", !ActiveModel::Type::Boolean.new.cast(value))
+      define_method(:"#{key}=") do |value|
+        public_send(:"#{original_key}=", !ActiveModel::Type::Boolean.new.cast(value))
       end
 
       define_method(key) do

--- a/app/models/concerns/remotable.rb
+++ b/app/models/concerns/remotable.rb
@@ -7,7 +7,7 @@ module Remotable
     def remotable_attachment(attachment_name, limit, suppress_errors: true, download_on_assign: true, attribute_name: nil)
       attribute_name ||= :"#{attachment_name}_remote_url"
 
-      define_method("download_#{attachment_name}!") do |url = nil|
+      define_method(:"download_#{attachment_name}!") do |url = nil|
         url ||= self[attribute_name]
 
         return if url.blank?
@@ -24,29 +24,29 @@ module Remotable
           Request.new(:get, url).perform do |response|
             raise Mastodon::UnexpectedResponseError, response unless (200...300).cover?(response.code)
 
-            public_send("#{attachment_name}=", ResponseWithLimit.new(response, limit))
+            public_send(:"#{attachment_name}=", ResponseWithLimit.new(response, limit))
           end
         rescue Mastodon::UnexpectedResponseError, HTTP::TimeoutError, HTTP::ConnectionError, OpenSSL::SSL::SSLError => e
           Rails.logger.debug { "Error fetching remote #{attachment_name}: #{e}" }
-          public_send("#{attachment_name}=", nil) if public_send("#{attachment_name}_file_name").present?
+          public_send(:"#{attachment_name}=", nil) if public_send(:"#{attachment_name}_file_name").present?
           raise e unless suppress_errors
         rescue Paperclip::Errors::NotIdentifiedByImageMagickError, Addressable::URI::InvalidURIError, Mastodon::HostValidationError, Mastodon::LengthValidationError, Paperclip::Error, Mastodon::DimensionsValidationError, Mastodon::StreamValidationError => e
           Rails.logger.debug { "Error fetching remote #{attachment_name}: #{e}" }
-          public_send("#{attachment_name}=", nil) if public_send("#{attachment_name}_file_name").present?
+          public_send(:"#{attachment_name}=", nil) if public_send(:"#{attachment_name}_file_name").present?
         end
 
         nil
       end
 
-      define_method("#{attribute_name}=") do |url|
-        return if self[attribute_name] == url && public_send("#{attachment_name}_file_name").present?
+      define_method(:"#{attribute_name}=") do |url|
+        return if self[attribute_name] == url && public_send(:"#{attachment_name}_file_name").present?
 
         self[attribute_name] = url if has_attribute?(attribute_name)
 
-        public_send("download_#{attachment_name}!", url) if download_on_assign
+        public_send(:"download_#{attachment_name}!", url) if download_on_assign
       end
 
-      alias_method("reset_#{attachment_name}!", "download_#{attachment_name}!")
+      alias_method(:"reset_#{attachment_name}!", "download_#{attachment_name}!")
     end
   end
 end

--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -84,7 +84,7 @@ class Form::AdminSettings
 
   KEYS.each do |key|
     define_method(key) do
-      return instance_variable_get("@#{key}") if instance_variable_defined?("@#{key}")
+      return instance_variable_get(:"@#{key}") if instance_variable_defined?(:"@#{key}")
 
       stored_value = if UPLOAD_KEYS.include?(key)
                        SiteUpload.where(var: key).first_or_initialize(var: key)
@@ -94,12 +94,12 @@ class Form::AdminSettings
                        Setting.public_send(key)
                      end
 
-      instance_variable_set("@#{key}", stored_value)
+      instance_variable_set(:"@#{key}", stored_value)
     end
   end
 
   UPLOAD_KEYS.each do |key|
-    define_method("#{key}=") do |file|
+    define_method(:"#{key}=") do |file|
       value = public_send(key)
       value.file = file
     rescue Mastodon::DimensionsValidationError => e
@@ -114,13 +114,13 @@ class Form::AdminSettings
     return false unless errors.empty? && valid?
 
     KEYS.each do |key|
-      next unless instance_variable_defined?("@#{key}")
+      next unless instance_variable_defined?(:"@#{key}")
 
       if UPLOAD_KEYS.include?(key)
         public_send(key).save
       else
         setting = Setting.where(var: key).first_or_initialize(var: key)
-        setting.update(value: typecast_value(key, instance_variable_get("@#{key}")))
+        setting.update(value: typecast_value(key, instance_variable_get(:"@#{key}")))
       end
     end
   end
@@ -139,9 +139,9 @@ class Form::AdminSettings
 
   def validate_site_uploads
     UPLOAD_KEYS.each do |key|
-      next unless instance_variable_defined?("@#{key}")
+      next unless instance_variable_defined?(:"@#{key}")
 
-      upload = instance_variable_get("@#{key}")
+      upload = instance_variable_get(:"@#{key}")
       next if upload.valid?
 
       upload.errors.each do |error|

--- a/spec/models/concerns/remotable_spec.rb
+++ b/spec/models/concerns/remotable_spec.rb
@@ -178,11 +178,11 @@ RSpec.describe Remotable do
 
             allow(foo).to receive(:public_send)
             foo.hoge_remote_url = url
-            expect(foo).to have_received(:public_send).with("download_#{hoge}!", url)
+            expect(foo).to have_received(:public_send).with(:"download_#{hoge}!", url)
 
             allow(foo).to receive(:public_send)
             foo.download_hoge!(url)
-            expect(foo).to have_received(:public_send).with("#{hoge}=", response_with_limit)
+            expect(foo).to have_received(:public_send).with(:"#{hoge}=", response_with_limit)
           end
         end
       end

--- a/spec/requests/omniauth_callbacks_spec.rb
+++ b/spec/requests/omniauth_callbacks_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe 'OmniAuth callbacks' do
   shared_examples 'omniauth provider callbacks' do |provider|
-    subject { post send "user_#{provider}_omniauth_callback_path" }
+    subject { post send :"user_#{provider}_omniauth_callback_path" }
 
     context 'with full information in response' do
       before do


### PR DESCRIPTION
Should fix the lint failure here - https://github.com/mastodon/mastodon/actions/runs/7229257108/job/19699870443?pr=28395 - and allow that PR to merge after renovate rebases it.

This rule was added in a previous version and we had it enabled, but there was a false negative situation for interpolated strings where these were not detected which was fixed in the latest release. There is a small but measurable improvement in using symbols instead of strings here.