### PR TITLE
Fix issue with post-create scripts failing on local docker

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3'
 
 services:
   app:
+    working_dir: /workspaces/mastodon/
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
There was an issue with running the two scripts described in the docker-instructions under development caused by a missing `working_dir` key in the docker-compose. This should fix the issue, as the two scripts may now be executed from the working directory instead of the root.

An alternative would be to change the readme to reflect running the scripts with a `-w` flag.