### PR TITLE
Change disallowed hashtags validator to also apply to remote status and boosts

### DIFF
--- a/app/validators/disallowed_hashtags_validator.rb
+++ b/app/validators/disallowed_hashtags_validator.rb
@@ -2,8 +2,6 @@
 
 class DisallowedHashtagsValidator < ActiveModel::Validator
   def validate(status)
-    return unless status.local? && !status.reblog?
-
     disallowed_hashtags = Tag.matching_name(Extractor.extract_hashtags(status.text)).reject(&:usable?)
     status.errors.add(:text, I18n.t('statuses.disallowed_hashtags', tags: disallowed_hashtags.map(&:name).join(', '), count: disallowed_hashtags.size)) unless disallowed_hashtags.empty?
   end


### PR DESCRIPTION
There are several cases where instance admins may wish to not allow certain hashtags on to their instance (e.g., #caturday because for whatever reason they hate cats)

This change would allow for entirely prohibiting these hashtags. Whilst this feature was originally designed around prevent members of your instance from publishing to certain hashtags, I think given what we know now, just preventing your members from using those tags may not be enough, and you may wish to prevent all mention of those hashtags from reaching your server.

I do note that this would cause ActivityPub::Activity::* to throw potentially, and there doesn't seem to be a rescue from validation errors in place, I'm not sure how we should handle this, and I am aware existing tests may fail (doing this quickly via the GitHub UI to start conversation)

## NOTE: This is untested at scale, and could cause sidekiq queues to grow with failures due to the error scenario described above
## You probably want #29264 instead