### PR TITLE
Group artifact actions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -100,6 +100,13 @@
       groupName: 'eslint (non-major)',
     },
     {
+      // Group actions/*-artifact in the same PR
+      matchManagers: ['github-actions'],
+      matchPackageNames: ['actions/download-artifact', 'actions/upload-artifact'],
+      matchUpdateTypes: ['major'],
+      groupName: 'artifact actions (major)'
+    },
+    {
       // Update @types/* packages every week, with one grouped PR
       matchPackagePrefixes: '@types/',
       matchUpdateTypes: ['patch', 'minor'],


### PR DESCRIPTION
`actions/*-artifact` cannot be upgraded individually as can be seen in #28410 and #28411, they should be grouped by Renovate so they can be upgraded simultaneously.