### PR TITLE
Fix rails mailer preview not honouring locale

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -12,7 +12,7 @@ class ApplicationMailer < ActionMailer::Base
   protected
 
   def locale_for_account(account, &block)
-    I18n.with_locale(account.user_locale || I18n.default_locale, &block)
+    I18n.with_locale(account.user_locale || I18n.locale || I18n.default_locale, &block)
   end
 
   def set_autoreply_headers!

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -202,6 +202,6 @@ class UserMailer < Devise::Mailer
   end
 
   def locale
-    @resource.locale.presence || I18n.default_locale
+    @resource.locale.presence || I18n.locale || I18n.default_locale
   end
 end


### PR DESCRIPTION
The rails mailer preview feature has a locale dropdown which you can use to set the locale as a wrapper around a mailer preview. This feature works by setting a locale param, and then the rails-internal `Rails::MailersController` has an `around_action` which sees that param and wraps the mailer preview in a `with_locale` block which sets it from the param.

In our mailer classes we have custom logic to set the locale based on the user/account locale of the mail recipient. These mailer blocks wrap the sending of the email, and set either the user/account value, or the `default_locale` as a backup.

Previously, when the mailer preview set a locale from the params it was set in an outer block around the mailer preview, but then our logic overrode that and chose the `I18n.default_locale`, even though the rails mailers controller had set the locale already.

This changes that logic to try the user/account locale first, then just `I18n.locale` if it's been set, and then preserves the `default_locale` as a final backup.

This should fix the mailer previews not respecting the locale setter from the preview UI, while preserving our locale wrap feature in the mailers.

I think this fixes the preview issue described in https://github.com/mastodon/mastodon/pull/28416