### PR TITLE
Fix `Style/GuardClause` cop in app/controllers

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -220,10 +220,6 @@ Style/GlobalStdStream:
 # Configuration parameters: MinBodyLength, AllowConsecutiveConditionals.
 Style/GuardClause:
   Exclude:
-    - 'app/controllers/admin/confirmations_controller.rb'
-    - 'app/controllers/auth/confirmations_controller.rb'
-    - 'app/controllers/auth/passwords_controller.rb'
-    - 'app/controllers/settings/two_factor_authentication/webauthn_credentials_controller.rb'
     - 'app/lib/activitypub/activity/block.rb'
     - 'app/lib/request.rb'
     - 'app/lib/request_pool.rb'

--- a/app/controllers/admin/confirmations_controller.rb
+++ b/app/controllers/admin/confirmations_controller.rb
@@ -3,7 +3,7 @@
 module Admin
   class ConfirmationsController < BaseController
     before_action :set_user
-    before_action :check_confirmation, only: [:resend]
+    before_action :redirect_confirmed_user, only: [:resend], if: :user_confirmed?
 
     def create
       authorize @user, :confirm?
@@ -25,11 +25,13 @@ module Admin
 
     private
 
-    def check_confirmation
-      if @user.confirmed?
-        flash[:error] = I18n.t('admin.accounts.resend_confirmation.already_confirmed')
-        redirect_to admin_accounts_path
-      end
+    def redirect_confirmed_user
+      flash[:error] = I18n.t('admin.accounts.resend_confirmation.already_confirmed')
+      redirect_to admin_accounts_path
+    end
+
+    def user_confirmed?
+      @user.confirmed?
     end
   end
 end

--- a/app/controllers/auth/confirmations_controller.rb
+++ b/app/controllers/auth/confirmations_controller.rb
@@ -7,7 +7,7 @@ class Auth::ConfirmationsController < Devise::ConfirmationsController
 
   before_action :set_body_classes
   before_action :set_confirmation_user!, only: [:show, :confirm_captcha]
-  before_action :require_unconfirmed!
+  before_action :redirect_confirmed_user, if: :signed_in_confirmed_user?
 
   before_action :extend_csp_for_captcha!, only: [:show, :confirm_captcha]
   before_action :require_captcha_if_needed!, only: [:show]
@@ -65,10 +65,12 @@ class Auth::ConfirmationsController < Devise::ConfirmationsController
     @confirmation_user.nil? || @confirmation_user.confirmed?
   end
 
-  def require_unconfirmed!
-    if user_signed_in? && current_user.confirmed? && current_user.unconfirmed_email.blank?
-      redirect_to(current_user.approved? ? root_path : edit_user_registration_path)
-    end
+  def redirect_confirmed_user
+    redirect_to(current_user.approved? ? root_path : edit_user_registration_path)
+  end
+
+  def signed_in_confirmed_user?
+    user_signed_in? && current_user.confirmed? && current_user.unconfirmed_email.blank?
   end
 
   def set_body_classes

--- a/app/controllers/auth/passwords_controller.rb
+++ b/app/controllers/auth/passwords_controller.rb
@@ -2,7 +2,7 @@
 
 class Auth::PasswordsController < Devise::PasswordsController
   skip_before_action :check_self_destruct!
-  before_action :check_validity_of_reset_password_token, only: :edit
+  before_action :redirect_invalid_reset_token, only: :edit, unless: :reset_password_token_is_valid?
   before_action :set_body_classes
 
   layout 'auth'
@@ -19,11 +19,9 @@ class Auth::PasswordsController < Devise::PasswordsController
 
   private
 
-  def check_validity_of_reset_password_token
-    unless reset_password_token_is_valid?
-      flash[:error] = I18n.t('auth.invalid_reset_password_token')
-      redirect_to new_password_path(resource_name)
-    end
+  def redirect_invalid_reset_token
+    flash[:error] = I18n.t('auth.invalid_reset_password_token')
+    redirect_to new_password_path(resource_name)
   end
 
   def set_body_classes

--- a/app/controllers/settings/two_factor_authentication/webauthn_credentials_controller.rb
+++ b/app/controllers/settings/two_factor_authentication/webauthn_credentials_controller.rb
@@ -6,8 +6,8 @@ module Settings
       skip_before_action :check_self_destruct!
       skip_before_action :require_functional!
 
-      before_action :require_otp_enabled
-      before_action :require_webauthn_enabled, only: [:index, :destroy]
+      before_action :redirect_invalid_otp, unless: -> { current_user.otp_enabled? }
+      before_action :redirect_invalid_webauthn, only: [:index, :destroy], unless: -> { current_user.webauthn_enabled? }
 
       def index; end
       def new; end
@@ -85,18 +85,14 @@ module Settings
 
       private
 
-      def require_otp_enabled
-        unless current_user.otp_enabled?
-          flash[:error] = t('webauthn_credentials.otp_required')
-          redirect_to settings_two_factor_authentication_methods_path
-        end
+      def redirect_invalid_otp
+        flash[:error] = t('webauthn_credentials.otp_required')
+        redirect_to settings_two_factor_authentication_methods_path
       end
 
-      def require_webauthn_enabled
-        unless current_user.webauthn_enabled?
-          flash[:error] = t('webauthn_credentials.not_enabled')
-          redirect_to settings_two_factor_authentication_methods_path
-        end
+      def redirect_invalid_webauthn
+        flash[:error] = t('webauthn_credentials.not_enabled')
+        redirect_to settings_two_factor_authentication_methods_path
       end
     end
   end


### PR DESCRIPTION
The proposed autocorrect on these ones (guard clauses with explicit `return unless...` sort of thing near top of method) look worse to me, at least in these controller cases. Have not looked at the other ones yet. Instead of autocorrect, went with this approach instead to separate the action from the conditional on the controller ones.