### PR TITLE
Fixes dropdown target without a `buttonRef` (edit history)

### DIFF
--- a/app/javascript/mastodon/components/dropdown_menu.jsx
+++ b/app/javascript/mastodon/components/dropdown_menu.jsx
@@ -257,7 +257,7 @@ class Dropdown extends PureComponent {
   };
 
   findTarget = () => {
-    return this.target?.buttonRef?.current;
+    return this.target?.buttonRef?.current ?? this.target;
   };
 
   componentWillUnmount = () => {


### PR DESCRIPTION
Fixes #27685

Using the fix suggested by @mgmn in the issue above