### PR TITLE
Fix `friends_of_friends` sometimes suggesting already-followed accounts

### DIFF
--- a/app/models/account_suggestions/friends_of_friends_source.rb
+++ b/app/models/account_suggestions/friends_of_friends_source.rb
@@ -16,7 +16,7 @@ class AccountSuggestions::FriendsOfFriendsSource < AccountSuggestions::Source
       JOIN account_stats ON account_stats.account_id = accounts.id
       LEFT OUTER JOIN follow_recommendation_mutes ON follow_recommendation_mutes.target_account_id = accounts.id AND follow_recommendation_mutes.account_id = :id
       WHERE follows.account_id IN (SELECT * FROM first_degree)
-        AND follows.target_account_id NOT IN (SELECT * FROM first_degree)
+        AND NOT EXISTS (SELECT 1 FROM follows f WHERE f.target_account_id = follows.target_account_id AND f.account_id = :id)
         AND follows.target_account_id <> :id
         AND accounts.discoverable
         AND accounts.suspended_at IS NULL


### PR DESCRIPTION
Note that I am not too sure about the performance implications of this implementation.

Alternatively, we could have the following:
```ruby
    Account.find_by_sql([<<~SQL.squish, { id: account.id, limit: limit }]).map { |row| [row.id, key] }
      WITH first_degree AS (
          SELECT target_account_id AS id, target_accounts.hide_collections AS hide_collections
          FROM follows
          JOIN accounts AS target_accounts ON follows.target_account_id = target_accounts.id
          WHERE account_id = :id
            AND NOT target_accounts.hide_collections
      )
      SELECT accounts.id, COUNT(*) AS frequency
      FROM accounts
      JOIN follows ON follows.target_account_id = accounts.id
      JOIN account_stats ON account_stats.account_id = accounts.id
      LEFT OUTER JOIN follow_recommendation_mutes ON follow_recommendation_mutes.target_account_id = accounts.id AND follow_recommendation_mutes.account_id = :id
      WHERE follows.account_id IN (SELECT id FROM first_degree WHERE NOT hide_collections)
        AND follows.target_account_id NOT IN (SELECT id FROM first_degree)
        AND follows.target_account_id <> :id
        AND accounts.discoverable
        AND accounts.suspended_at IS NULL
        AND accounts.silenced_at IS NULL
        AND accounts.moved_to_account_id IS NULL
        AND follow_recommendation_mutes.target_account_id IS NULL
      GROUP BY accounts.id, account_stats.id
      ORDER BY frequency DESC, account_stats.followers_count ASC
      LIMIT :limit
    SQL
```