### PR TITLE
Clean up of `RSpec/LetSetup` within `api/`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,11 +47,6 @@ RSpec/ExampleLength:
 
 RSpec/LetSetup:
   Exclude:
-    - 'spec/controllers/api/v1/accounts/statuses_controller_spec.rb'
-    - 'spec/controllers/api/v1/filters_controller_spec.rb'
-    - 'spec/controllers/api/v2/admin/accounts_controller_spec.rb'
-    - 'spec/controllers/api/v2/filters/keywords_controller_spec.rb'
-    - 'spec/controllers/api/v2/filters/statuses_controller_spec.rb'
     - 'spec/controllers/auth/confirmations_controller_spec.rb'
     - 'spec/controllers/auth/passwords_controller_spec.rb'
     - 'spec/controllers/auth/sessions_controller_spec.rb'

--- a/spec/controllers/api/v1/accounts/statuses_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/statuses_controller_spec.rb
@@ -10,11 +10,11 @@ describe Api::V1::Accounts::StatusesController do
 
   before do
     allow(controller).to receive(:doorkeeper_token) { token }
-    Fabricate(:status, account: user.account)
   end
 
   describe 'GET #index' do
     it 'returns expected headers', :aggregate_failures do
+      Fabricate(:status, account: user.account)
       get :index, params: { account_id: user.account.id, limit: 1 }
 
       expect(response).to have_http_status(200)
@@ -30,7 +30,6 @@ describe Api::V1::Accounts::StatusesController do
     end
 
     context 'with exclude replies' do
-      let!(:older_statuses) { user.account.statuses.destroy_all }
       let!(:status) { Fabricate(:status, account: user.account) }
       let!(:status_self_reply) { Fabricate(:status, account: user.account, thread: status) }
 

--- a/spec/controllers/api/v1/filters_controller_spec.rb
+++ b/spec/controllers/api/v1/filters_controller_spec.rb
@@ -15,10 +15,15 @@ RSpec.describe Api::V1::FiltersController do
   describe 'GET #index' do
     let(:scopes) { 'read:filters' }
     let!(:filter) { Fabricate(:custom_filter, account: user.account) }
+    let!(:custom_filter_keyword) { Fabricate(:custom_filter_keyword, custom_filter: filter) }
 
     it 'returns http success' do
       get :index
       expect(response).to have_http_status(200)
+      expect(body_as_json)
+        .to contain_exactly(
+          include(id: custom_filter_keyword.id.to_s)
+        )
     end
   end
 

--- a/spec/controllers/api/v2/filters/keywords_controller_spec.rb
+++ b/spec/controllers/api/v2/filters/keywords_controller_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe Api::V2::Filters::KeywordsController do
     it 'returns http success' do
       get :index, params: { filter_id: filter.id }
       expect(response).to have_http_status(200)
+      expect(body_as_json)
+        .to contain_exactly(
+          include(id: keyword.id.to_s)
+        )
     end
 
     context "when trying to access another's user filters" do

--- a/spec/controllers/api/v2/filters/statuses_controller_spec.rb
+++ b/spec/controllers/api/v2/filters/statuses_controller_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe Api::V2::Filters::StatusesController do
     it 'returns http success' do
       get :index, params: { filter_id: filter.id }
       expect(response).to have_http_status(200)
+      expect(body_as_json)
+        .to contain_exactly(
+          include(id: status_filter.id.to_s)
+        )
     end
 
     context "when trying to access another's user filters" do


### PR DESCRIPTION
This is another approach to the previously closed https://github.com/mastodon/mastodon/pull/28368 focused just on the api controller specs, and attempting to not just move things to before blocks unless that made sense. Summary:

- In v1/accounts/statuses, there is a record create in a parent block which is not used by - but is being removed by - the interior block which is using a `let!` to remove that record before it makes the other needed records. The change here is to move the outside Fabrication into the example that actually needs it, so that the removal isn't needed any longer, and remove the removal.
- In v1/filters and the two v2/filters/* specs, add an assertion about the existing let vars
- In v2/admin/accounts, unfurl the metaprogramming and just list the scenarios directly.