### PR TITLE
More duplicates in cli maintenance spec, misc bug fixes

### DIFF
--- a/lib/mastodon/cli/maintenance.rb
+++ b/lib/mastodon/cli/maintenance.rb
@@ -577,7 +577,7 @@ module Mastodon::CLI
 
       say 'Deduplicating webhooks…'
       ActiveRecord::Base.connection.select_all("SELECT string_agg(id::text, ',') AS ids FROM webhooks GROUP BY url HAVING count(*) > 1").each do |row|
-        Webhooks.where(id: row['ids'].split(',')).sort_by(&:id).reverse.drop(1).each(&:destroy)
+        Webhook.where(id: row['ids'].split(',')).sort_by(&:id).reverse.drop(1).each(&:destroy)
       end
 
       say 'Restoring webhooks indexes…'

--- a/lib/mastodon/cli/maintenance.rb
+++ b/lib/mastodon/cli/maintenance.rb
@@ -610,11 +610,7 @@ module Mastodon::CLI
 
       say 'Please chose the one to keep unchanged, other ones will be automatically renamed.'
 
-      ref_id = ask('Account to keep unchanged:') do |q|
-        q.required true
-        q.default 0
-        q.convert :int
-      end
+      ref_id = ask('Account to keep unchanged:', required: true, default: 0).to_i
 
       accounts.delete_at(ref_id)
 

--- a/lib/mastodon/cli/maintenance.rb
+++ b/lib/mastodon/cli/maintenance.rb
@@ -40,6 +40,10 @@ module Mastodon::CLI
     class BulkImport < ApplicationRecord; end
     class SoftwareUpdate < ApplicationRecord; end
 
+    class DomainBlock < ApplicationRecord
+      scope :by_severity, -> { order(Arel.sql('(CASE severity WHEN 0 THEN 1 WHEN 1 THEN 2 WHEN 2 THEN 0 END), domain')) }
+    end
+
     class PreviewCard < ApplicationRecord
       self.inheritance_column = false
     end

--- a/spec/lib/mastodon/cli/maintenance_spec.rb
+++ b/spec/lib/mastodon/cli/maintenance_spec.rb
@@ -204,6 +204,36 @@ describe Mastodon::CLI::Maintenance do
         end
       end
 
+      context 'with duplicate announcement_reactions' do
+        before do
+          prepare_duplicate_data
+        end
+
+        let(:account) { Fabricate(:account) }
+        let(:announcement) { Fabricate(:announcement) }
+        let(:name) { Fabricate(:custom_emoji).shortcode }
+
+        it 'runs the deduplication process' do
+          expect { subject }
+            .to output_results(
+              'Removing duplicate announcement reactions',
+              'Restoring announcement_reactions indexes',
+              'Finished!'
+            )
+            .and change(duplicate_announcement_reactions, :count).from(2).to(1)
+        end
+
+        def duplicate_announcement_reactions
+          AnnouncementReaction.where(account: account, announcement: announcement, name: name)
+        end
+
+        def prepare_duplicate_data
+          ActiveRecord::Base.connection.remove_index :announcement_reactions, [:account_id, :announcement_id, :name]
+          Fabricate(:announcement_reaction, account: account, announcement: announcement, name: name)
+          Fabricate.build(:announcement_reaction, account: account, announcement: announcement, name: name).save(validate: false)
+        end
+      end
+
       def agree_to_backup_warning
         allow(cli.shell)
           .to receive(:yes?)

--- a/spec/lib/mastodon/cli/maintenance_spec.rb
+++ b/spec/lib/mastodon/cli/maintenance_spec.rb
@@ -484,7 +484,11 @@ describe Mastodon::CLI::Maintenance do
         def prepare_duplicate_data
           ActiveRecord::Base.connection.remove_index :statuses, :uri
           Fabricate(:status, account: account, uri: uri)
-          Fabricate.build(:status, account: account, uri: uri).save(validate: false)
+          duplicate = Fabricate.build(:status, account: account, uri: uri)
+          duplicate.save(validate: false)
+          Fabricate(:status_pin, account: account, status: duplicate)
+          Fabricate(:status, in_reply_to_id: duplicate.id)
+          Fabricate(:status, reblog_of_id: duplicate.id)
         end
       end
 

--- a/spec/lib/mastodon/cli/maintenance_spec.rb
+++ b/spec/lib/mastodon/cli/maintenance_spec.rb
@@ -465,6 +465,7 @@ describe Mastodon::CLI::Maintenance do
         end
 
         let(:uri) { 'https://example.host/path' }
+        let(:account) { Fabricate(:account) }
 
         it 'runs the deduplication process' do
           expect { subject }
@@ -482,8 +483,8 @@ describe Mastodon::CLI::Maintenance do
 
         def prepare_duplicate_data
           ActiveRecord::Base.connection.remove_index :statuses, :uri
-          Fabricate(:status, uri: uri)
-          Fabricate.build(:status, uri: uri).save(validate: false)
+          Fabricate(:status, account: account, uri: uri)
+          Fabricate.build(:status, account: account, uri: uri).save(validate: false)
         end
       end
 


### PR DESCRIPTION
Bug fixes described as inline comments.

Refactor:

- In the actual CLI task, we had separated methods for all the "user duplicate" scenarios except for email -- so pull that one out as well

Spec coverage:

- In the spec, continue to add the various duplicate data scenarios for more tables -- this gets us to basically full "happy path" coverage for all tables.