### PR TITLE
Enable authorized fetch for individual users who block remote domains

### DIFF
--- a/app/controllers/concerns/account_owned_concern.rb
+++ b/app/controllers/concerns/account_owned_concern.rb
@@ -54,4 +54,8 @@ module AccountOwnedConcern
     expires_in(3.minutes, public: true)
     forbidden
   end
+
+  def authorized_fetch_mode?
+    super || @account.domain_blocks.exists?
+  end
 end

--- a/app/services/concerns/payloadable.rb
+++ b/app/services/concerns/payloadable.rb
@@ -11,20 +11,20 @@ module Payloadable
   # @option options [Boolean] :always_sign
   # @return [Hash]
   def serialize_payload(record, serializer, options = {})
-    signer      = options.delete(:signer)
+    @signer     = options.delete(:signer)
     sign_with   = options.delete(:sign_with)
     always_sign = options.delete(:always_sign)
     payload     = ActiveModelSerializers::SerializableResource.new(record, options.merge(serializer: serializer, adapter: ActivityPub::Adapter)).as_json
     object      = record.respond_to?(:virtual_object) ? record.virtual_object : record
 
-    if (object.respond_to?(:sign?) && object.sign?) && signer && (always_sign || signing_enabled?)
-      ActivityPub::LinkedDataSignature.new(payload).sign!(signer, sign_with: sign_with)
+    if (object.respond_to?(:sign?) && object.sign?) && @signer && (always_sign || signing_enabled?)
+      ActivityPub::LinkedDataSignature.new(payload).sign!(@signer, sign_with: sign_with)
     else
       payload
     end
   end
 
   def signing_enabled?
-    !authorized_fetch_mode?
+    !authorized_fetch_mode? && !@signer.domain_blocks.exists?
   end
 end


### PR DESCRIPTION
This enables authorized fetch for users who have blocked at least one domain. This still has drawbacks such as:
- increased resources consumption because of systematic request caching and inability to have reverse proxy caching
- replies and post edits from users for which authorized fetch is enabled do not get forwarded