### PR TITLE
Fix `RSpec/LetSetup` cop in auth controller specs

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,9 +47,6 @@ RSpec/ExampleLength:
 
 RSpec/LetSetup:
   Exclude:
-    - 'spec/controllers/auth/confirmations_controller_spec.rb'
-    - 'spec/controllers/auth/passwords_controller_spec.rb'
-    - 'spec/controllers/auth/sessions_controller_spec.rb'
     - 'spec/models/account_statuses_cleanup_policy_spec.rb'
     - 'spec/models/status_spec.rb'
     - 'spec/services/activitypub/fetch_featured_collection_service_spec.rb'

--- a/spec/controllers/auth/confirmations_controller_spec.rb
+++ b/spec/controllers/auth/confirmations_controller_spec.rb
@@ -41,8 +41,9 @@ describe Auth::ConfirmationsController do
         get :show, params: { confirmation_token: 'foobar' }
       end
 
-      it 'redirects to login' do
+      it 'redirects to login and confirms user' do
         expect(response).to redirect_to(new_user_session_path)
+        expect(user.reload.confirmed_at).to_not be_nil
       end
     end
 
@@ -87,8 +88,9 @@ describe Auth::ConfirmationsController do
         get :show, params: { confirmation_token: 'foobar' }
       end
 
-      it 'redirects to login' do
+      it 'redirects to login and confirms email' do
         expect(response).to redirect_to(new_user_session_path)
+        expect(user.reload.unconfirmed_email).to be_nil
       end
 
       it 'does not queue up bootstrapping of home timeline' do

--- a/spec/controllers/auth/passwords_controller_spec.rb
+++ b/spec/controllers/auth/passwords_controller_spec.rb
@@ -70,6 +70,7 @@ describe Auth::PasswordsController do
 
       it 'deactivates all sessions' do
         expect(user.session_activations.count).to eq 0
+        expect { session_activation.reload }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
       it 'revokes all access tokens' do
@@ -78,6 +79,7 @@ describe Auth::PasswordsController do
 
       it 'removes push subscriptions' do
         expect(Web::PushSubscription.where(user: user).or(Web::PushSubscription.where(access_token: access_token)).count).to eq 0
+        expect { web_push_subscription.reload }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 


### PR DESCRIPTION
Use the relevant vars, move rest to before blocks when pure setup.