### PR TITLE
Add ability to require approval when users sign up using specific email domains

### DIFF
--- a/app/controllers/admin/email_domain_blocks_controller.rb
+++ b/app/controllers/admin/email_domain_blocks_controller.rb
@@ -40,7 +40,7 @@ module Admin
           (@email_domain_block.other_domains || []).uniq.each do |domain|
             next if EmailDomainBlock.where(domain: domain).exists?
 
-            other_email_domain_block = EmailDomainBlock.create!(domain: domain, parent: @email_domain_block)
+            other_email_domain_block = EmailDomainBlock.create!(domain: domain, allow_with_approval: @email_domain_block.allow_with_approval, parent: @email_domain_block)
             log_action :create, other_email_domain_block
           end
         end
@@ -65,7 +65,7 @@ module Admin
     end
 
     def resource_params
-      params.require(:email_domain_block).permit(:domain, other_domains: [])
+      params.require(:email_domain_block).permit(:domain, :allow_with_approval, other_domains: [])
     end
 
     def form_email_domain_block_batch_params

--- a/app/controllers/api/v1/admin/email_domain_blocks_controller.rb
+++ b/app/controllers/api/v1/admin/email_domain_blocks_controller.rb
@@ -55,7 +55,7 @@ class Api::V1::Admin::EmailDomainBlocksController < Api::BaseController
   end
 
   def resource_params
-    params.permit(:domain)
+    params.permit(:domain, :allow_with_approval)
   end
 
   def insert_pagination_headers

--- a/app/models/email_domain_block.rb
+++ b/app/models/email_domain_block.rb
@@ -4,11 +4,12 @@
 #
 # Table name: email_domain_blocks
 #
-#  id         :bigint(8)        not null, primary key
-#  domain     :string           default(""), not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  parent_id  :bigint(8)
+#  id                  :bigint(8)        not null, primary key
+#  domain              :string           default(""), not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  parent_id           :bigint(8)
+#  allow_with_approval :boolean          default(FALSE), not null
 #
 
 class EmailDomainBlock < ApplicationRecord
@@ -42,8 +43,8 @@ class EmailDomainBlock < ApplicationRecord
       @attempt_ip = attempt_ip
     end
 
-    def match?
-      blocking? || invalid_uri?
+    def match?(...)
+      blocking?(...) || invalid_uri?
     end
 
     private
@@ -52,8 +53,8 @@ class EmailDomainBlock < ApplicationRecord
       @uris.any?(&:nil?)
     end
 
-    def blocking?
-      blocks = EmailDomainBlock.where(domain: domains_with_variants).order(Arel.sql('char_length(domain) desc'))
+    def blocking?(allow_with_approval: false)
+      blocks = EmailDomainBlock.where(domain: domains_with_variants, allow_with_approval: allow_with_approval).order(Arel.sql('char_length(domain) desc'))
       blocks.each { |block| block.history.add(@attempt_ip) } if @attempt_ip.present?
       blocks.any?
     end
@@ -85,5 +86,9 @@ class EmailDomainBlock < ApplicationRecord
 
   def self.block?(domain_or_domains, attempt_ip: nil)
     Matcher.new(domain_or_domains, attempt_ip: attempt_ip).match?
+  end
+
+  def self.requires_approval?(domain_or_domains, attempt_ip: nil)
+    Matcher.new(domain_or_domains, attempt_ip: attempt_ip).match?(allow_with_approval: true)
   end
 end

--- a/app/serializers/rest/admin/email_domain_block_serializer.rb
+++ b/app/serializers/rest/admin/email_domain_block_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class REST::Admin::EmailDomainBlockSerializer < ActiveModel::Serializer
-  attributes :id, :domain, :created_at, :history
+  attributes :id, :domain, :created_at, :history, :allow_with_approval
 
   def id
     object.id.to_s

--- a/app/views/admin/email_domain_blocks/_email_domain_block.html.haml
+++ b/app/views/admin/email_domain_blocks/_email_domain_block.html.haml
@@ -12,3 +12,7 @@
         ·
 
       = t('admin.email_domain_blocks.attempts_over_week', count: email_domain_block.history.reduce(0) { |sum, day| sum + day.accounts })
+
+      - if email_domain_block.allow_with_approval?
+        ·
+        = t('admin.email_domain_blocks.allow_registrations_with_approval')

--- a/app/views/admin/email_domain_blocks/new.html.haml
+++ b/app/views/admin/email_domain_blocks/new.html.haml
@@ -7,6 +7,9 @@
   .fields-group
     = f.input :domain, wrapper: :with_block_label, label: t('admin.email_domain_blocks.domain'), input_html: { readonly: defined?(@resolved_records) }
 
+  .fields-group
+    = f.input :allow_with_approval, wrapper: :with_label, hint: false, label: I18n.t('admin.email_domain_blocks.allow_registrations_with_approval')
+
   - if defined?(@resolved_records)
     %p.hint= t('admin.email_domain_blocks.resolved_dns_records_hint_html')
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -425,6 +425,7 @@ en:
       view: View domain block
     email_domain_blocks:
       add_new: Add new
+      allow_registrations_with_approval: Allow registrations with approval
       attempts_over_week:
         one: "%{count} attempt over the last week"
         other: "%{count} sign-up attempts over the last week"

--- a/db/migrate/20231222100226_add_allow_with_approval_to_email_domain_blocks.rb
+++ b/db/migrate/20231222100226_add_allow_with_approval_to_email_domain_blocks.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAllowWithApprovalToEmailDomainBlocks < ActiveRecord::Migration[7.1]
+  def change
+    add_column :email_domain_blocks, :allow_with_approval, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_12_12_073317) do
+ActiveRecord::Schema[7.1].define(version: 2023_12_22_100226) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -435,6 +435,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_12_073317) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.bigint "parent_id"
+    t.boolean "allow_with_approval", default: false, null: false
     t.index ["domain"], name: "index_email_domain_blocks_on_domain", unique: true
   end
 

--- a/spec/controllers/admin/email_domain_blocks_controller_spec.rb
+++ b/spec/controllers/admin/email_domain_blocks_controller_spec.rb
@@ -12,13 +12,14 @@ RSpec.describe Admin::EmailDomainBlocksController do
   describe 'GET #index' do
     around do |example|
       default_per_page = EmailDomainBlock.default_per_page
-      EmailDomainBlock.paginates_per 1
+      EmailDomainBlock.paginates_per 2
       example.run
       EmailDomainBlock.paginates_per default_per_page
     end
 
     it 'returns http success' do
       2.times { Fabricate(:email_domain_block) }
+      Fabricate(:email_domain_block, allow_with_approval: true)
       get :index, params: { page: 2 }
       expect(response).to have_http_status(200)
     end


### PR DESCRIPTION
This PR allows adding relaxed email domain blocks which allow people to register but requiring approval.

![image](https://github.com/mastodon/mastodon/assets/384364/9a4e2781-026a-46f2-a00c-07558bfdff0a)

![image](https://github.com/mastodon/mastodon/assets/384364/506e85fa-0263-4df9-8c2d-d72afa49b658)

---

Fixes MAS-210