### PR TITLE
Extract spec helper for verifing to/from public AP collection namespace

### DIFF
--- a/spec/controllers/activitypub/outboxes_controller_spec.rb
+++ b/spec/controllers/activitypub/outboxes_controller_spec.rb
@@ -79,8 +79,7 @@ RSpec.describe ActivityPub::OutboxesController do
         it 'returns orderedItems with public or unlisted statuses' do
           expect(body[:orderedItems]).to be_an Array
           expect(body[:orderedItems].size).to eq 2
-          public_collection = ActivityPub::TagManager::COLLECTIONS[:public]
-          expect(body[:orderedItems].all? { |item| item[:to].include?(public_collection) || item[:cc].include?(public_collection) }).to be true
+          expect(body[:orderedItems].all? { |item| item[:to].include?(ap_public_collection) || item[:cc].include?(ap_public_collection) }).to be true
         end
 
         it_behaves_like 'cacheable response'
@@ -133,9 +132,7 @@ RSpec.describe ActivityPub::OutboxesController do
           json = body_as_json
           expect(json[:orderedItems]).to be_an Array
           expect(json[:orderedItems].size).to eq 2
-          public_collection = ActivityPub::TagManager::COLLECTIONS[:public]
-
-          expect(json[:orderedItems].all? { |item| item[:to].include?(public_collection) || item[:cc].include?(public_collection) }).to be true
+          expect(json[:orderedItems].all? { |item| item[:to].include?(ap_public_collection) || item[:cc].include?(ap_public_collection) }).to be true
         end
 
         it 'returns private Cache-Control header' do
@@ -161,8 +158,7 @@ RSpec.describe ActivityPub::OutboxesController do
           json = body_as_json
           expect(json[:orderedItems]).to be_an Array
           expect(json[:orderedItems].size).to eq 3
-          public_collection = ActivityPub::TagManager::COLLECTIONS[:public]
-          expect(json[:orderedItems].all? { |item| item[:to].include?(public_collection) || item[:cc].include?(public_collection) || item[:to].include?(account_followers_url(account, ActionMailer::Base.default_url_options)) }).to be true
+          expect(json[:orderedItems].all? { |item| item[:to].include?(ap_public_collection) || item[:cc].include?(ap_public_collection) || item[:to].include?(account_followers_url(account, ActionMailer::Base.default_url_options)) }).to be true
         end
 
         it 'returns private Cache-Control header' do
@@ -220,5 +216,11 @@ RSpec.describe ActivityPub::OutboxesController do
         end
       end
     end
+  end
+
+  private
+
+  def ap_public_collection
+    ActivityPub::TagManager::COLLECTIONS[:public]
   end
 end

--- a/spec/controllers/activitypub/outboxes_controller_spec.rb
+++ b/spec/controllers/activitypub/outboxes_controller_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe ActivityPub::OutboxesController do
           json = body_as_json
           expect(json[:orderedItems]).to be_an Array
           expect(json[:orderedItems].size).to eq 3
-          expect(json[:orderedItems].all? { |item| targets_public_collection?(item) || item[:to].include?(account_followers_url(account, ActionMailer::Base.default_url_options)) }).to be true
+          expect(json[:orderedItems].all? { |item| targets_public_collection?(item) || targets_followers_collection?(item, account) }).to be true
         end
 
         it 'returns private Cache-Control header' do
@@ -226,5 +226,9 @@ RSpec.describe ActivityPub::OutboxesController do
 
   def targets_public_collection?(item)
     item[:to].include?(ap_public_collection) || item[:cc].include?(ap_public_collection)
+  end
+
+  def targets_followers_collection?(item, account)
+    item[:to].include?(account_followers_url(account, ActionMailer::Base.default_url_options))
   end
 end

--- a/spec/controllers/activitypub/outboxes_controller_spec.rb
+++ b/spec/controllers/activitypub/outboxes_controller_spec.rb
@@ -79,7 +79,8 @@ RSpec.describe ActivityPub::OutboxesController do
         it 'returns orderedItems with public or unlisted statuses' do
           expect(body[:orderedItems]).to be_an Array
           expect(body[:orderedItems].size).to eq 2
-          expect(body[:orderedItems].all? { |item| item[:to].include?(ActivityPub::TagManager::COLLECTIONS[:public]) || item[:cc].include?(ActivityPub::TagManager::COLLECTIONS[:public]) }).to be true
+          public_collection = ActivityPub::TagManager::COLLECTIONS[:public]
+          expect(body[:orderedItems].all? { |item| item[:to].include?(public_collection) || item[:cc].include?(public_collection) }).to be true
         end
 
         it_behaves_like 'cacheable response'
@@ -132,7 +133,9 @@ RSpec.describe ActivityPub::OutboxesController do
           json = body_as_json
           expect(json[:orderedItems]).to be_an Array
           expect(json[:orderedItems].size).to eq 2
-          expect(json[:orderedItems].all? { |item| item[:to].include?(ActivityPub::TagManager::COLLECTIONS[:public]) || item[:cc].include?(ActivityPub::TagManager::COLLECTIONS[:public]) }).to be true
+          public_collection = ActivityPub::TagManager::COLLECTIONS[:public]
+
+          expect(json[:orderedItems].all? { |item| item[:to].include?(public_collection) || item[:cc].include?(public_collection) }).to be true
         end
 
         it 'returns private Cache-Control header' do
@@ -158,7 +161,8 @@ RSpec.describe ActivityPub::OutboxesController do
           json = body_as_json
           expect(json[:orderedItems]).to be_an Array
           expect(json[:orderedItems].size).to eq 3
-          expect(json[:orderedItems].all? { |item| item[:to].include?(ActivityPub::TagManager::COLLECTIONS[:public]) || item[:cc].include?(ActivityPub::TagManager::COLLECTIONS[:public]) || item[:to].include?(account_followers_url(account, ActionMailer::Base.default_url_options)) }).to be true
+          public_collection = ActivityPub::TagManager::COLLECTIONS[:public]
+          expect(json[:orderedItems].all? { |item| item[:to].include?(public_collection) || item[:cc].include?(public_collection) || item[:to].include?(account_followers_url(account, ActionMailer::Base.default_url_options)) }).to be true
         end
 
         it 'returns private Cache-Control header' do

--- a/spec/controllers/activitypub/outboxes_controller_spec.rb
+++ b/spec/controllers/activitypub/outboxes_controller_spec.rb
@@ -229,6 +229,8 @@ RSpec.describe ActivityPub::OutboxesController do
   end
 
   def targets_followers_collection?(item, account)
-    item[:to].include?(account_followers_url(account, ActionMailer::Base.default_url_options))
+    item[:to].include?(
+      account_followers_url(account, ActionMailer::Base.default_url_options)
+    )
   end
 end

--- a/spec/controllers/activitypub/outboxes_controller_spec.rb
+++ b/spec/controllers/activitypub/outboxes_controller_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe ActivityPub::OutboxesController do
         it 'returns orderedItems with public or unlisted statuses' do
           expect(body[:orderedItems]).to be_an Array
           expect(body[:orderedItems].size).to eq 2
-          expect(body[:orderedItems].all? { |item| item[:to].include?(ap_public_collection) || item[:cc].include?(ap_public_collection) }).to be true
+          expect(body[:orderedItems].all? { |item| targets_public_collection?(item) }).to be true
         end
 
         it_behaves_like 'cacheable response'
@@ -132,7 +132,7 @@ RSpec.describe ActivityPub::OutboxesController do
           json = body_as_json
           expect(json[:orderedItems]).to be_an Array
           expect(json[:orderedItems].size).to eq 2
-          expect(json[:orderedItems].all? { |item| item[:to].include?(ap_public_collection) || item[:cc].include?(ap_public_collection) }).to be true
+          expect(json[:orderedItems].all? { |item| targets_public_collection?(item) }).to be true
         end
 
         it 'returns private Cache-Control header' do
@@ -158,7 +158,7 @@ RSpec.describe ActivityPub::OutboxesController do
           json = body_as_json
           expect(json[:orderedItems]).to be_an Array
           expect(json[:orderedItems].size).to eq 3
-          expect(json[:orderedItems].all? { |item| item[:to].include?(ap_public_collection) || item[:cc].include?(ap_public_collection) || item[:to].include?(account_followers_url(account, ActionMailer::Base.default_url_options)) }).to be true
+          expect(json[:orderedItems].all? { |item| targets_public_collection?(item) || item[:to].include?(account_followers_url(account, ActionMailer::Base.default_url_options)) }).to be true
         end
 
         it 'returns private Cache-Control header' do
@@ -222,5 +222,9 @@ RSpec.describe ActivityPub::OutboxesController do
 
   def ap_public_collection
     ActivityPub::TagManager::COLLECTIONS[:public]
+  end
+
+  def targets_public_collection?(item)
+    item[:to].include?(ap_public_collection) || item[:cc].include?(ap_public_collection)
   end
 end

--- a/spec/controllers/activitypub/replies_controller_spec.rb
+++ b/spec/controllers/activitypub/replies_controller_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe ActivityPub::RepliesController do
           expect(page_json).to be_a Hash
           expect(page_json[:items]).to be_an Array
           expect(page_json[:items].size).to eq 1
-          expect(page_json[:items].all? { |item| item[:to].include?(ap_public_collection) || item[:cc].include?(ap_public_collection) }).to be true
+          expect(page_json[:items].all? { |item| targets_public_collection?(item) }).to be true
         end
 
         context 'when there are few self-replies' do
@@ -117,7 +117,7 @@ RSpec.describe ActivityPub::RepliesController do
 
         it 'only inlines items that are local and public or unlisted replies' do
           inlined_replies = page_json[:items].select { |x| x.is_a?(Hash) }
-          expect(inlined_replies.all? { |item| item[:to].include?(ap_public_collection) || item[:cc].include?(ap_public_collection) }).to be true
+          expect(inlined_replies.all? { |item| targets_public_collection?(item) }).to be true
           expect(inlined_replies.all? { |item| ActivityPub::TagManager.instance.local_uri?(item[:id]) }).to be true
         end
 
@@ -198,5 +198,9 @@ RSpec.describe ActivityPub::RepliesController do
 
   def ap_public_collection
     ActivityPub::TagManager::COLLECTIONS[:public]
+  end
+
+  def targets_public_collection?(item)
+    item[:to].include?(ap_public_collection) || item[:cc].include?(ap_public_collection)
   end
 end

--- a/spec/controllers/activitypub/replies_controller_spec.rb
+++ b/spec/controllers/activitypub/replies_controller_spec.rb
@@ -84,8 +84,7 @@ RSpec.describe ActivityPub::RepliesController do
           expect(page_json).to be_a Hash
           expect(page_json[:items]).to be_an Array
           expect(page_json[:items].size).to eq 1
-          public_collection = ActivityPub::TagManager::COLLECTIONS[:public]
-          expect(page_json[:items].all? { |item| item[:to].include?(public_collection) || item[:cc].include?(public_collection) }).to be true
+          expect(page_json[:items].all? { |item| item[:to].include?(ap_public_collection) || item[:cc].include?(ap_public_collection) }).to be true
         end
 
         context 'when there are few self-replies' do
@@ -118,8 +117,7 @@ RSpec.describe ActivityPub::RepliesController do
 
         it 'only inlines items that are local and public or unlisted replies' do
           inlined_replies = page_json[:items].select { |x| x.is_a?(Hash) }
-          public_collection = ActivityPub::TagManager::COLLECTIONS[:public]
-          expect(inlined_replies.all? { |item| item[:to].include?(public_collection) || item[:cc].include?(public_collection) }).to be true
+          expect(inlined_replies.all? { |item| item[:to].include?(ap_public_collection) || item[:cc].include?(ap_public_collection) }).to be true
           expect(inlined_replies.all? { |item| ActivityPub::TagManager.instance.local_uri?(item[:id]) }).to be true
         end
 
@@ -194,5 +192,11 @@ RSpec.describe ActivityPub::RepliesController do
         it_behaves_like 'disallowed access'
       end
     end
+  end
+
+  private
+
+  def ap_public_collection
+    ActivityPub::TagManager::COLLECTIONS[:public]
   end
 end

--- a/spec/controllers/activitypub/replies_controller_spec.rb
+++ b/spec/controllers/activitypub/replies_controller_spec.rb
@@ -84,7 +84,8 @@ RSpec.describe ActivityPub::RepliesController do
           expect(page_json).to be_a Hash
           expect(page_json[:items]).to be_an Array
           expect(page_json[:items].size).to eq 1
-          expect(page_json[:items].all? { |item| item[:to].include?(ActivityPub::TagManager::COLLECTIONS[:public]) || item[:cc].include?(ActivityPub::TagManager::COLLECTIONS[:public]) }).to be true
+          public_collection = ActivityPub::TagManager::COLLECTIONS[:public]
+          expect(page_json[:items].all? { |item| item[:to].include?(public_collection) || item[:cc].include?(public_collection) }).to be true
         end
 
         context 'when there are few self-replies' do


### PR DESCRIPTION
Just consolidates the check for items having right values re: public collection ... diff should be clear, but going commit by commit will show progression.