### PR TITLE
Remove the media and replies methods from accounts controller

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -39,22 +39,12 @@ class AccountsController < ApplicationController
 
   def filtered_statuses
     default_statuses.tap do |statuses|
-      statuses.merge!(hashtag_scope)    if tag_requested?
-      statuses.merge!(only_media_scope) if media_requested?
-      statuses.merge!(no_replies_scope) unless replies_requested?
+      statuses.merge!(hashtag_scope) if tag_requested?
     end
   end
 
   def default_statuses
     @account.statuses.where(visibility: [:public, :unlisted])
-  end
-
-  def only_media_scope
-    Status.joins(:media_attachments).merge(@account.media_attachments).group(:id)
-  end
-
-  def no_replies_scope
-    Status.without_replies
   end
 
   def hashtag_scope
@@ -83,14 +73,6 @@ class AccountsController < ApplicationController
     end
   end
   helper_method :rss_url
-
-  def media_requested?
-    path_without_format.end_with?('/media') && !tag_requested?
-  end
-
-  def replies_requested?
-    path_without_format.end_with?('/with_replies') && !tag_requested?
-  end
 
   def tag_requested?
     path_without_format.end_with?(Addressable::URI.parse("/tagged/#{params[:tag]}").normalize)

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -44,7 +44,10 @@ class AccountsController < ApplicationController
   end
 
   def default_statuses
-    @account.statuses.where(visibility: [:public, :unlisted])
+    @account
+      .statuses
+      .without_replies
+      .where(visibility: [:public, :unlisted])
   end
 
   def hashtag_scope

--- a/spec/requests/accounts_spec.rb
+++ b/spec/requests/accounts_spec.rb
@@ -82,22 +82,6 @@ describe 'Accounts show response' do
           it_behaves_like 'common HTML response'
         end
 
-        context 'with replies' do
-          before do
-            get short_account_with_replies_path(username: account.username), as: format
-          end
-
-          it_behaves_like 'common HTML response'
-        end
-
-        context 'with media' do
-          before do
-            get short_account_media_path(username: account.username), as: format
-          end
-
-          it_behaves_like 'common HTML response'
-        end
-
         context 'with tag' do
           let(:tag) { Fabricate(:tag) }
 
@@ -226,44 +210,6 @@ describe 'Accounts show response' do
             expect(response.body).to_not include(status_tag_for(status_private))
             expect(response.body).to_not include(status_tag_for(status_reblog.reblog))
             expect(response.body).to_not include(status_tag_for(status_reply))
-          end
-        end
-
-        context 'with replies' do
-          before do
-            get short_account_with_replies_path(username: account.username, format: format)
-          end
-
-          it_behaves_like 'cacheable response', expects_vary: 'Accept, Accept-Language, Cookie'
-
-          it 'responds with correct statuses with replies', :aggregate_failures do
-            expect(response).to have_http_status(200)
-            expect(response.body).to include(status_tag_for(status_media))
-            expect(response.body).to include(status_tag_for(status_reply))
-            expect(response.body).to include(status_tag_for(status_self_reply))
-            expect(response.body).to include(status_tag_for(status))
-            expect(response.body).to_not include(status_tag_for(status_direct))
-            expect(response.body).to_not include(status_tag_for(status_private))
-            expect(response.body).to_not include(status_tag_for(status_reblog.reblog))
-          end
-        end
-
-        context 'with media' do
-          before do
-            get short_account_media_path(username: account.username, format: format)
-          end
-
-          it_behaves_like 'cacheable response', expects_vary: 'Accept, Accept-Language, Cookie'
-
-          it 'responds with correct statuses with media', :aggregate_failures do
-            expect(response).to have_http_status(200)
-            expect(response.body).to include(status_tag_for(status_media))
-            expect(response.body).to_not include(status_tag_for(status_direct))
-            expect(response.body).to_not include(status_tag_for(status_private))
-            expect(response.body).to_not include(status_tag_for(status_reblog.reblog))
-            expect(response.body).to_not include(status_tag_for(status_reply))
-            expect(response.body).to_not include(status_tag_for(status_self_reply))
-            expect(response.body).to_not include(status_tag_for(status))
           end
         end
 


### PR DESCRIPTION
These are handled by the JS UI now, and go through the API to get data.

We had previously discussed preserving the "tags" page here for RSS feeds, because even though they are not advertised they get traffic, so I left that alone.