### PR TITLE
install "wget" in streaming Dockerfile

### DIFF
--- a/streaming/Dockerfile
+++ b/streaming/Dockerfile
@@ -69,6 +69,7 @@ RUN \
     ca-certificates \
     curl \
     tzdata \
+    wget \
   ;
 
 # Set /opt/mastodon as working directory


### PR DESCRIPTION
"wget" is used by the [docker-compose health-check](https://github.com/mastodon/mastodon/blob/main/docker-compose.yml#L89) and is currently not installed.

The same health check can be achieved with `curl` (which is installed), but thought simply installing wget would be sufficient and avoid breaking any existing docker-compose based servers (like my own) when they upgrade to 4.3

Happy to update to using `curl` instead if preferred