### PR TITLE
Fix `Performance/StringIdentifierArgument` cop

### DIFF
--- a/app/models/concerns/remotable.rb
+++ b/app/models/concerns/remotable.rb
@@ -46,7 +46,7 @@ module Remotable
         public_send(:"download_#{attachment_name}!", url) if download_on_assign
       end
 
-      alias_method(:"reset_#{attachment_name}!", "download_#{attachment_name}!")
+      alias_method(:"reset_#{attachment_name}!", :"download_#{attachment_name}!")
     end
   end
 end


### PR DESCRIPTION
We fixed the bulk of these previously (https://github.com/mastodon/mastodon/pull/28399) - but the version bump - https://github.com/mastodon/mastodon/pull/28395 - had a false negative which missed the one changed in this PR. I believe with this merged, this will be fine after renovate rebase - https://github.com/mastodon/mastodon/pull/28492