### PR TITLE
Fix reply icon display in picture-in-picture footer

### DIFF
--- a/app/javascript/mastodon/features/picture_in_picture/components/footer.jsx
+++ b/app/javascript/mastodon/features/picture_in_picture/components/footer.jsx
@@ -179,7 +179,7 @@ class Footer extends ImmutablePureComponent {
 
     if (status.get('in_reply_to_id', null) === null) {
       replyIcon = 'reply';
-      replyIconComponent = RepeatIcon;
+      replyIconComponent = ReplyIcon;
       replyTitle = intl.formatMessage(messages.reply);
     } else {
       replyIcon = 'reply-all';


### PR DESCRIPTION
Currently when opening a picture in the web interface a retoot icon is shown instead of the reply icon, this PR fixes this.
![image](https://github.com/mastodon/mastodon/assets/36609914/82d0679e-36e2-49c0-8a89-5358fdbe1e25)
