### PR TITLE
Fix random `NoMethodError` errors on cached `CustomFilter` objects

### DIFF
--- a/app/models/custom_filter.rb
+++ b/app/models/custom_filter.rb
@@ -17,8 +17,23 @@
 class CustomFilter < ApplicationRecord
   self.ignored_columns += %w(whole_word irreversible)
 
-  alias_attribute :title, :phrase
-  alias_attribute :filter_action, :action
+  # NOTE: We previously used `alias_attribute` but this does not play nicely
+  # with cache
+  def title
+    phrase
+  end
+
+  def title=(value)
+    self.phrase = value
+  end
+
+  def filter_action
+    action
+  end
+
+  def filter_action=(value)
+    self.action = value
+  end
 
   VALID_CONTEXTS = %w(
     home

--- a/app/models/custom_filter_keyword.rb
+++ b/app/models/custom_filter_keyword.rb
@@ -17,7 +17,15 @@ class CustomFilterKeyword < ApplicationRecord
 
   validates :keyword, presence: true
 
-  alias_attribute :phrase, :keyword
+  # NOTE: We previously used `alias_attribute` but this does not play nicely
+  # with cache
+  def phrase
+    keyword
+  end
+
+  def phrase=(value)
+    self.keyword = value
+  end
 
   before_save :prepare_cache_invalidation!
   before_destroy :prepare_cache_invalidation!


### PR DESCRIPTION
Fixes #27622

For some reason, `alias_attribute`-generated methods do not get generated when loading from the Rails cache. So instead, explicitly define just the methods we need as a workaround.