### PR TITLE
Fix OCR when using S3/CDN for assets

### DIFF
--- a/app/javascript/mastodon/features/ui/components/focal_point_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/focal_point_modal.jsx
@@ -222,7 +222,7 @@ class FocalPointModal extends ImmutablePureComponent {
       const worker = createWorker({
         workerPath: tesseractWorkerPath,
         corePath: tesseractCorePath,
-        langPath: `${assetHost}/ocr/lang-data/`,
+        langPath: `${assetHost}/ocr/lang-data`,
         logger: ({ status, progress }) => {
           if (status === 'recognizing text') {
             this.setState({ ocrStatus: 'detecting', progress });


### PR DESCRIPTION
There is an extra slash present on the URL to load the language models for Tesseract/OCR. This stops the browser from being able to load the model when it's stored on S3/CDN and not being served from Nginx or Rails cache locally.

Not working via Digital Ocean Spaces vs working without double `/`
```
vmstan@Sovereign ~/Downloads $ curl https://assets.vmst.io/ocr/lang-data//eng.traineddata.gz
<?xml version="1.0" encoding="UTF-8"?><Error><Code>NoSuchKey</Code><Message></Message><BucketName>vmstio-assets</BucketName><RequestId>tx00000f786c1f58238817f-0065932700-50599-nyc3d</RequestId><HostId>50599-nyc3d-nyc3-zg04</HostId></Error>%
vmstan@Sovereign ~/Downloads $ curl https://assets.vmst.io/ocr/lang-data/eng.traineddata.gz
Warning: Binary output can mess up your terminal. Use "--output -" to tell
Warning: curl to output it to your terminal anyway, or consider "--output
Warning: <FILE>" to save to a file.
```

Working via served from Rails
```
vmstan@Sovereign ~/Downloads $ curl https://vmst.io/ocr/lang-data//eng.traineddata.gz
Warning: Binary output can mess up your terminal. Use "--output -" to tell
Warning: curl to output it to your terminal anyway, or consider "--output
Warning: <FILE>" to save to a file.
```

Working as served on Mastodon.online
```
vmstan@Sovereign ~/Downloads $ curl https://mastodon.online/ocr/lang-data//eng.traineddata.gz
Warning: Binary output can mess up your terminal. Use "--output -" to tell
Warning: curl to output it to your terminal anyway, or consider "--output
Warning: <FILE>" to save to a file.
vmstan@Sovereign ~/Downloads $ curl https://mastodon.online/ocr/lang-data/eng.traineddata.gz
Warning: Binary output can mess up your terminal. Use "--output -" to tell
Warning: curl to output it to your terminal anyway, or consider "--output
Warning: <FILE>" to save to a file.
```

I also tested against a couple of other folks who use Cloudflare and other S3 providers, and the `//`doesn't work there.

Error in JavaScript console during OCR operation:
<img width="1566" alt="Screenshot 2024-01-01 at 3 14 15 PM" src="https://github.com/mastodon/mastodon/assets/3002053/6b8a9483-6c71-46a7-a28c-099c3026f37a">