### PR TITLE
Change streaming API host to not be overridden to localhost in development mode

### DIFF
--- a/config/initializers/1_hosts.rb
+++ b/config/initializers/1_hosts.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
     if Rails.env.production?
       "ws#{https ? 's' : ''}://#{web_host}"
     else
-      "ws://#{ENV['REMOTE_DEV'] == 'true' ? host.split(':').first : 'localhost'}:4000"
+      "ws://#{host.split(':').first}:4000"
     end
   end
 

--- a/spec/requests/content_security_policy_spec.rb
+++ b/spec/requests/content_security_policy_spec.rb
@@ -20,7 +20,7 @@ describe 'Content-Security-Policy' do
       "form-action 'self'",
       "child-src 'self' blob: https://cb6e6126.ngrok.io",
       "worker-src 'self' blob: https://cb6e6126.ngrok.io",
-      "connect-src 'self' data: blob: https://cb6e6126.ngrok.io ws://localhost:4000",
+      "connect-src 'self' data: blob: https://cb6e6126.ngrok.io ws://cb6e6126.ngrok.io:4000",
       "script-src 'self' https://cb6e6126.ngrok.io 'wasm-unsafe-eval'"
     )
   end


### PR DESCRIPTION
Fixes #28539

I'm not sure there are situations in which we don't want the code path where `REMOTE_DEV=true`.

cc @ykzts as you added this code path in #5942