### PR TITLE
Fix streaming API redirection ignoring the port of `streaming_api_base_url`

### DIFF
--- a/app/controllers/api/v1/streaming_controller.rb
+++ b/app/controllers/api/v1/streaming_controller.rb
@@ -13,7 +13,9 @@ class Api::V1::StreamingController < Api::BaseController
 
   def streaming_api_url
     Addressable::URI.parse(request.url).tap do |uri|
-      uri.host = Addressable::URI.parse(Rails.configuration.x.streaming_api_base_url).host
+      base_url = Addressable::URI.parse(Rails.configuration.x.streaming_api_base_url)
+      uri.host = base_url.host
+      uri.port = base_url.port
     end.to_s
   end
 end


### PR DESCRIPTION
See https://github.com/mastodon/mastodon/issues/28539#issuecomment-1873857554