### PR TITLE
Change emoji shortcode validation to allow i18n non-ASCII characters

### DIFF
--- a/app/models/custom_emoji.rb
+++ b/app/models/custom_emoji.rb
@@ -26,7 +26,7 @@ class CustomEmoji < ApplicationRecord
 
   LIMIT = 256.kilobytes
 
-  SHORTCODE_RE_FRAGMENT = '[a-zA-Z0-9_]{2,}'
+  SHORTCODE_RE_FRAGMENT = '(([[:alnum:]])|_){2,}'
 
   SCAN_RE = /(?<=[^[:alnum:]:]|\n|^)
     :(#{SHORTCODE_RE_FRAGMENT}):


### PR DESCRIPTION
This is a re-submission of a PR by @casuallyblue, #27809.
It tweaks emoji name-validation to allow emoji names with non-ASCII alphanumerics.

It fixes #26305.