### PR TITLE
Solve remaining `db/*migrate*` cops

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -165,7 +165,6 @@ Rails/WhereExists:
     - 'app/validators/reaction_validator.rb'
     - 'app/validators/vote_validator.rb'
     - 'app/workers/move_worker.rb'
-    - 'db/migrate/20190529143559_preserve_old_layout_for_existing_users.rb'
     - 'lib/tasks/tests.rake'
     - 'spec/models/account_spec.rb'
     - 'spec/services/activitypub/process_collection_service_spec.rb'
@@ -253,8 +252,6 @@ Style/GuardClause:
     - 'app/workers/redownload_media_worker.rb'
     - 'app/workers/remote_account_refresh_worker.rb'
     - 'config/initializers/devise.rb'
-    - 'db/migrate/20170901141119_truncate_preview_cards.rb'
-    - 'db/post_migrate/20220704024901_migrate_settings_to_user_roles.rb'
     - 'lib/devise/strategies/two_factor_ldap_authenticatable.rb'
     - 'lib/devise/strategies/two_factor_pam_authenticatable.rb'
     - 'lib/mastodon/cli/accounts.rb'
@@ -275,7 +272,6 @@ Style/HashAsLastArrayItem:
     - 'app/models/status.rb'
     - 'app/services/batched_remove_status_service.rb'
     - 'app/services/notify_service.rb'
-    - 'db/migrate/20181024224956_migrate_account_conversations.rb'
 
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Style/HashTransformValues:

--- a/db/migrate/20170901141119_truncate_preview_cards.rb
+++ b/db/migrate/20170901141119_truncate_preview_cards.rb
@@ -22,11 +22,9 @@ class TruncatePreviewCards < ActiveRecord::Migration[5.1]
   end
 
   def down
-    if ActiveRecord::Base.connection.table_exists? 'deprecated_preview_cards'
-      drop_table :preview_cards
-      rename_table :deprecated_preview_cards, :preview_cards
-    else
-      raise ActiveRecord::IrreversibleMigration, 'Previous preview cards table has already been removed'
-    end
+    raise ActiveRecord::IrreversibleMigration, 'Previous preview cards table has already been removed' unless ActiveRecord::Base.connection.table_exists? 'deprecated_preview_cards'
+
+    drop_table :preview_cards
+    rename_table :deprecated_preview_cards, :preview_cards
   end
 end

--- a/db/migrate/20181024224956_migrate_account_conversations.rb
+++ b/db/migrate/20181024224956_migrate_account_conversations.rb
@@ -105,7 +105,7 @@ class MigrateAccountConversations < ActiveRecord::Migration[5.2]
       end
     end
 
-    notifications_about_direct_statuses.includes(:account, mention: { status: [:account, mentions: :account] }).find_each do |notification|
+    notifications_about_direct_statuses.includes(:account, mention: { status: [:account, { mentions: :account }] }).find_each do |notification|
       MigrationAccountConversation.add_status(notification.account, notification.target_status)
       migrated += 1
 

--- a/db/migrate/20190529143559_preserve_old_layout_for_existing_users.rb
+++ b/db/migrate/20190529143559_preserve_old_layout_for_existing_users.rb
@@ -9,7 +9,7 @@ class PreserveOldLayoutForExistingUsers < ActiveRecord::Migration[5.2]
     # on the to-be-changed default
 
     User.where(User.arel_table[:current_sign_in_at].gteq(1.month.ago)).find_each do |user|
-      next if Setting.unscoped.where(thing_type: 'User', thing_id: user.id, var: 'advanced_layout').exists?
+      next if Setting.unscoped.exists?(thing_type: 'User', thing_id: user.id, var: 'advanced_layout')
 
       user.settings.advanced_layout = true
     end

--- a/db/post_migrate/20220704024901_migrate_settings_to_user_roles.rb
+++ b/db/post_migrate/20220704024901_migrate_settings_to_user_roles.rb
@@ -6,36 +6,55 @@ class MigrateSettingsToUserRoles < ActiveRecord::Migration[6.1]
   class UserRole < ApplicationRecord; end
 
   def up
-    owner_role     = UserRole.find_by(name: 'Owner')
-    admin_role     = UserRole.find_by(name: 'Admin')
-    moderator_role = UserRole.find_by(name: 'Moderator')
-    everyone_role  = UserRole.find_by(id: -99)
-
-    min_invite_role  = Setting.min_invite_role
-    show_staff_badge = Setting.show_staff_badge
-
-    if everyone_role
-      everyone_role.permissions &= ~::UserRole::FLAGS[:invite_users] unless min_invite_role == 'user'
-      everyone_role.save
-    end
-
-    if owner_role
-      owner_role.highlighted = show_staff_badge
-      owner_role.save
-    end
-
-    if admin_role
-      admin_role.permissions |= ::UserRole::FLAGS[:invite_users] if %w(admin moderator).include?(min_invite_role)
-      admin_role.highlighted  = show_staff_badge
-      admin_role.save
-    end
-
-    if moderator_role
-      moderator_role.permissions |= ::UserRole::FLAGS[:invite_users] if %w(moderator).include?(min_invite_role)
-      moderator_role.highlighted  = show_staff_badge
-      moderator_role.save
-    end
+    process_role_everyone
+    process_role_owner
+    process_role_admin
+    process_role_moderator
   end
 
   def down; end
+
+  private
+
+  def process_role_everyone
+    everyone_role = UserRole.find_by(id: -99)
+    return unless everyone_role
+
+    everyone_role.permissions &= ~::UserRole::FLAGS[:invite_users] unless min_invite_role == 'user'
+    everyone_role.save
+  end
+
+  def process_role_owner
+    owner_role = UserRole.find_by(name: 'Owner')
+    return unless owner_role
+
+    owner_role.highlighted = show_staff_badge
+    owner_role.save
+  end
+
+  def process_role_admin
+    admin_role = UserRole.find_by(name: 'Admin')
+    return unless admin_role
+
+    admin_role.permissions |= ::UserRole::FLAGS[:invite_users] if %w(admin moderator).include?(min_invite_role)
+    admin_role.highlighted  = show_staff_badge
+    admin_role.save
+  end
+
+  def process_role_moderator
+    moderator_role = UserRole.find_by(name: 'Moderator')
+    return unless moderator_role
+
+    moderator_role.permissions |= ::UserRole::FLAGS[:invite_users] if %w(moderator).include?(min_invite_role)
+    moderator_role.highlighted  = show_staff_badge
+    moderator_role.save
+  end
+
+  def min_invite_role
+    Setting.min_invite_role
+  end
+
+  def show_staff_badge
+    Setting.show_staff_badge
+  end
 end


### PR DESCRIPTION
Two guard clauses, a Rails/exists, and a hash style.

3 of the 4 are autocorrected, the final one I chose to use `tap` approach instead of adding JUST a guard clause for the final conditional set when the first three would not have them (looked weird).