### PR TITLE
Implement FEP-2677 allowing discovery of the instance application actor

### DIFF
--- a/app/serializers/node_info/discovery_serializer.rb
+++ b/app/serializers/node_info/discovery_serializer.rb
@@ -6,6 +6,9 @@ class NodeInfo::DiscoverySerializer < ActiveModel::Serializer
   attribute :links
 
   def links
-    [{ rel: 'http://nodeinfo.diaspora.software/ns/schema/2.0', href: nodeinfo_schema_url }]
+    [
+      { rel: 'http://nodeinfo.diaspora.software/ns/schema/2.0', href: nodeinfo_schema_url },
+      { rel: 'https://www.w3.org/ns/activitystreams#Application', href: instance_actor_url },
+    ]
   end
 end

--- a/spec/requests/well_known/node_info_spec.rb
+++ b/spec/requests/well_known/node_info_spec.rb
@@ -19,6 +19,10 @@ describe 'The well-known node-info endpoints' do
             include(
               rel: 'http://nodeinfo.diaspora.software/ns/schema/2.0',
               href: include('nodeinfo/2.0')
+            ),
+            include(
+              rel: 'https://www.w3.org/ns/activitystreams#Application',
+              href: end_with('/actor')
             )
           )
         )

--- a/spec/routing/well_known_routes_spec.rb
+++ b/spec/routing/well_known_routes_spec.rb
@@ -16,4 +16,16 @@ describe 'Well Known routes' do
         .to route_to('well_known/webfinger#show')
     end
   end
+
+  describe 'the nodeinfo routes' do
+    it 'routes to discovery (index) route' do
+      expect(get('/.well-known/nodeinfo'))
+        .to route_to('well_known/node_info#index', format: 'json')
+    end
+
+    it 'routes to the show route' do
+      expect(get('/nodeinfo/2.0'))
+        .to route_to('well_known/node_info#show')
+    end
+  end
 end


### PR DESCRIPTION
This PR implements the proposal of [FEP-2677](https://codeberg.org/fediverse/fep/src/branch/main/fep/2677/fep-2677.md), there's discussion of this FEP on [socialhub](https://socialhub.activitypub.rocks/t/fep-2677-identifying-the-application-actor/3646/).

This allows remote clients to quickly and easily discover the instance actor of the mastodon server, this helps with identifying the instance (application) actor, with the goal of making it usable for further tasks, e.g.

- Allowing for application to application communication by having application actor send activities to another application actor's
- Having an object one can attach further information to. This means, one could attach a list of implemented FEPs to the application actor.

In order to implement, I've gone with `instance_actor_url` instead of going through `ActivityPub::TagManager.instance.uri_for(Account.representative)` since this is a hard-coded route in mastodon, and hence should be well supported.

(I do note that there currently are not request specs for the instance_actor controller, only controller tests, but converting those to request specs seemed to be outside of the scope of this pull request).

I did however, add in routing specs for the nodeinfo endpoints.