### PR TITLE
Add fallback redirection when getting a webfinger query `WEB_DOMAIN@WEB_DOMAIN`

### DIFF
--- a/app/controllers/well_known/webfinger_controller.rb
+++ b/app/controllers/well_known/webfinger_controller.rb
@@ -21,7 +21,7 @@ module WellKnown
       username = username_from_resource
 
       @account = begin
-        if username == Rails.configuration.x.local_domain
+        if username == Rails.configuration.x.local_domain || username == Rails.configuration.x.web_domain
           Account.representative
         else
           Account.find_local!(username)


### PR DESCRIPTION
Follow-up to #23600