### PR TITLE
Add sleep statement to nudge thread scheduler in request pool spec

### DIFF
--- a/spec/lib/request_pool_spec.rb
+++ b/spec/lib/request_pool_spec.rb
@@ -33,11 +33,13 @@ describe RequestPool do
 
       subject
 
-      threads = Array.new(20) do |_i|
+      threads = Array.new(3) do
         Thread.new do
-          20.times do
+          2.times do
             subject.with('http://example.com') do |http_client|
               http_client.get('/').flush
+              # Nudge scheduler to yield and exercise the full pool
+              sleep(0)
             end
           end
         end


### PR DESCRIPTION
Based on some discussion here - https://github.com/mastodon/mastodon/pull/28013#issuecomment-1876832460 - this is an attempt to get ruby 3.3.0 thread scheduler to exercise this spec as prior versions were doing. The insight on that discussion was that since we're stubbing out the request, the thread scheduler may not be switching between threads as often as in prior rubies, and so we are not getting the collection of connections we expect.

The proposal there was to add some short sleep statements within the inner loop of the spec so that the scheduler would move to another thread -- this works, but it increases the time of running just this one example to ~2.5s. I had another idea, included in this PR, to just add a debugging line, which a) might actually be useful to see execution, b) might function similarly to the `sleep` calls in nudging the scheduler, while not slowing down the spec as much.

I believe this change preserves the original intent of the spec, and that actually doing something with the result of the http call (logging in this case) is probably a truer reflection of actual usage than just stubbing the response and doing nothing with it.

Separately -- we could contemplate stubbing out the constants which dictate the pool size here, and reducing the number of both inner/outer loops here to be just enough to exercise the pooling, but not more than needed. Let me know if that's desired as well.

Assuming we like this or a similar approach, I can rebase the 3.3 PR after this is in.