### PR TITLE
Remove deprecated `RSpec/FilePath` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -118,15 +118,10 @@ Rails/UnusedIgnoredColumns:
 Rails/NegateInclude:
   Enabled: false
 
-# Reason: Some single letter camel case files shouldn't be split
+# Reason: Deprecated cop, will be removed in 3.0, replaced by SpecFilePathFormat
 # https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecfilepath
 RSpec/FilePath:
-  CustomTransform:
-    ActivityPub: activitypub
-    DeepL: deepl
-    FetchOEmbedService: fetch_oembed_service
-    OEmbedController: oembed_controller
-    OStatus: ostatus
+  Enabled: false
 
 # Reason:
 # https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecnamedsubject


### PR DESCRIPTION
This has been deprecated and will be removed in future. It was split into two cops, and we already have custom definitions lower in the file for the relevant one to us - `RSpec/SpecFilePathFormat`.