### PR TITLE
Use Arel `nulls_first` method in ordering CustomEmojiFilter scope

### DIFF
--- a/app/models/custom_emoji_filter.rb
+++ b/app/models/custom_emoji_filter.rb
@@ -31,7 +31,7 @@ class CustomEmojiFilter
   def scope_for(key, value)
     case key.to_s
     when 'local'
-      CustomEmoji.local.left_joins(:category).reorder(Arel.sql('custom_emoji_categories.name ASC NULLS FIRST, custom_emojis.shortcode ASC'))
+      CustomEmoji.local.left_joins(:category).reorder(CustomEmojiCategory.arel_table[:name].asc.nulls_first).order(shortcode: :asc)
     when 'remote'
       CustomEmoji.remote
     when 'by_domain'


### PR DESCRIPTION
With exception of quoting details, generated SQL is not changed.

I think the "nulls" order methods were added  in rails 6.x?