### PR TITLE
Replace unused `by_recent_sign_in` scope

### DIFF
--- a/app/models/account_filter.rb
+++ b/app/models/account_filter.rb
@@ -104,15 +104,7 @@ class AccountFilter
   def order_scope(value)
     case value.to_s
     when 'active'
-      accounts_with_users
-        .left_joins(:account_stat)
-        .order(
-          Arel.sql(
-            <<~SQL.squish
-              COALESCE(users.current_sign_in_at, account_stats.last_status_at, to_timestamp(0)) DESC, accounts.id DESC
-            SQL
-          )
-        )
+      Account.by_recent_activity
     when 'recent'
       Account.recent
     else


### PR DESCRIPTION
This scope's last usage was removed in https://github.com/mastodon/mastodon/commit/0fb9536d3888cd7b6013c239d5be85f095a6e8ad#diff-2681fe966d1db9197fa9abab875cbe2412f2623c0fb5f88ae44d48890f44ceeaL83

I was going to just delete it, but then realized the thing it was removed for could be extracted into a scope as well, so did that instead of just removing.

With the exception of exact quoting output, the generated sql by something like `AccountFilter.new(order: 'active', ...).results` stays the same.