### PR TITLE
Use Arel `in_order_of` method to generate CASE for `DomainBlock.by_severity`

### DIFF
--- a/app/models/domain_block.rb
+++ b/app/models/domain_block.rb
@@ -31,7 +31,7 @@ class DomainBlock < ApplicationRecord
   scope :matches_domain, ->(value) { where(arel_table[:domain].matches("%#{value}%")) }
   scope :with_user_facing_limitations, -> { where(severity: [:silence, :suspend]) }
   scope :with_limitations, -> { where(severity: [:silence, :suspend]).or(where(reject_media: true)) }
-  scope :by_severity, -> { order(Arel.sql('(CASE severity WHEN 0 THEN 1 WHEN 1 THEN 2 WHEN 2 THEN 0 END), domain')) }
+  scope :by_severity, -> { in_order_of(:severity, %w(noop silence suspend)).order(:domain) }
 
   def to_log_human_identifier
     domain

--- a/lib/mastodon/cli/maintenance.rb
+++ b/lib/mastodon/cli/maintenance.rb
@@ -41,7 +41,8 @@ module Mastodon::CLI
     class SoftwareUpdate < ApplicationRecord; end
 
     class DomainBlock < ApplicationRecord
-      scope :by_severity, -> { order(Arel.sql('(CASE severity WHEN 0 THEN 1 WHEN 1 THEN 2 WHEN 2 THEN 0 END), domain')) }
+      enum severity: { silence: 0, suspend: 1, noop: 2 }
+      scope :by_severity, -> { in_order_of(:severity, %w(noop silence suspend)).order(:domain) }
     end
 
     class PreviewCard < ApplicationRecord


### PR DESCRIPTION
The underlying SQL generated here is not exactly the same -- our prior code was using 0/1/2, the Rails-generated is using 1/2/3 -- but the underlying approach of using a sql `CASE` statement to map the enum values to numbers to be sorted is the same.