### PR TITLE
Inline what remains of the rails-settings-cached gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,7 +75,6 @@ gem 'premailer-rails'
 gem 'rack-attack', '~> 6.6'
 gem 'rack-cors', '~> 2.0', require: 'rack/cors'
 gem 'rails-i18n', '~> 7.0'
-gem 'rails-settings-cached', '~> 0.6', git: 'https://github.com/mastodon/rails-settings-cached.git', branch: 'v0.6.6-aliases-true'
 gem 'redcarpet', '~> 3.6'
 gem 'redis', '~> 4.5', require: ['redis', 'redis/connection/hiredis']
 gem 'mario-redis-lock', '~> 1.2', require: 'redis_lock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,14 +19,6 @@ GIT
       statsd-ruby (~> 1.4, >= 1.4.0)
 
 GIT
-  remote: https://github.com/mastodon/rails-settings-cached.git
-  revision: 86328ef0bd04ce21cc0504ff5e334591e8c2ccab
-  branch: v0.6.6-aliases-true
-  specs:
-    rails-settings-cached (0.6.6)
-      rails (>= 4.2.0)
-
-GIT
   remote: https://github.com/stanhu/omniauth-cas.git
   revision: 4211e6d05941b4a981f9a36b49ec166cecd0e271
   ref: 4211e6d05941b4a981f9a36b49ec166cecd0e271
@@ -922,7 +914,6 @@ DEPENDENCIES
   rails (~> 7.1.1)
   rails-controller-testing (~> 1.0)
   rails-i18n (~> 7.0)
-  rails-settings-cached (~> 0.6)!
   rdf-normalize (~> 0.5)
   redcarpet (~> 3.6)
   redis (~> 4.5)

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -130,15 +130,8 @@ class Setting < ActiveRecord::Base
       @cache_prefix_by_startup = Digest::MD5.hexdigest(Default.instance.to_s)
     end
 
-    def cache_prefix(&block)
-      @cache_prefix = block
-    end
-
     def cache_key(var_name)
-      scope = ['rails_settings_cached', cache_prefix_by_startup]
-      scope << @cache_prefix.call if @cache_prefix
-      scope << var_name.to_s
-      scope.join('/')
+      "rails_settings_cached/#{cache_prefix_by_startup}/#{var_name}"
     end
 
     def [](key)
@@ -180,7 +173,6 @@ class Setting < ActiveRecord::Base
       record.value = value
       record.save!
 
-      Rails.cache.write(cache_key(var_name), value)
       value
     end
 

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -13,6 +13,244 @@
 #  thing_id   :bigint(8)
 #
 
+# Vendored from a fork of the `rails-settings-cached` gem that has diverged
+# significantly. To refactored inside the `Setting` class.
+module RailsSettings
+  class Default < ::Hash
+    class MissingKey < StandardError; end
+
+    if Psych::VERSION.split('.').first >= '4'
+      YAML_load_opts = { aliases: true }
+    else
+      YAML_load_opts = {}
+    end
+
+    class << self
+
+      def enabled?
+        source_path && File.exist?(source_path)
+      end
+
+      def source(value = nil)
+        @source ||= value
+      end
+
+      def source_path
+        @source || Rails.root.join('config/app.yml')
+      end
+
+      def [](key)
+        # foo.bar.dar Nested fetch value
+        return instance[key] if instance.key?(key)
+        keys = key.to_s.split('.')
+        val = instance
+        keys.each do |k|
+          val = val.fetch(k.to_s, nil)
+          break if val.nil?
+        end
+        val
+      end
+
+      def instance
+        return @instance if defined? @instance
+        @instance = new
+        @instance
+      end
+    end
+
+    def initialize
+      content = open(self.class.source_path).read
+      hash = content.empty? ? {} : YAML.load(ERB.new(content).result, **YAML_load_opts).to_hash
+      hash = hash[Rails.env] || {}
+      replace hash
+    end
+  end
+
+  class Settings < ActiveRecord::Base
+    unless YAML.respond_to?(:unsafe_load)
+      class << YAML
+        alias :unsafe_load :load
+      end
+    end
+
+    self.table_name = table_name_prefix + 'settings'
+
+    class SettingNotFound < RuntimeError; end
+
+    belongs_to :thing, polymorphic: true, required: false
+
+    # get the value field, YAML decoded
+    def value
+      YAML.unsafe_load(self[:value]) if self[:value].present?
+    end
+
+    # set the value field, YAML encoded
+    def value=(new_value)
+      self[:value] = new_value.to_yaml
+    end
+
+    class << self
+      # get or set a variable with the variable as the called method
+      # rubocop:disable Style/MethodMissing
+      def method_missing(method, *args)
+        method_name = method.to_s
+        super(method, *args)
+      rescue NoMethodError
+        # set a value for a variable
+        if method_name[-1] == '='
+          var_name = method_name.sub('=', '')
+          value = args.first
+          self[var_name] = value
+        else
+          # retrieve a value
+          self[method_name]
+        end
+      end
+
+      # destroy the specified settings record
+      def destroy(var_name)
+        var_name = var_name.to_s
+        obj = object(var_name)
+        raise SettingNotFound, "Setting variable \"#{var_name}\" not found" if obj.nil?
+
+        obj.destroy
+        true
+      end
+
+      # retrieve all settings as a hash (optionally starting with a given namespace)
+      def get_all(starting_with = nil)
+        vars = thing_scoped.select('var, value')
+        vars = vars.where("var LIKE '#{starting_with}%'") if starting_with
+        result = {}
+        vars.each { |record| result[record.var] = record.value }
+        result.reverse_merge!(default_settings(starting_with))
+        result.with_indifferent_access
+      end
+
+      def where(sql = nil)
+        vars = thing_scoped.where(sql) if sql
+        vars
+      end
+
+      # get a setting value by [] notation
+      def [](var_name)
+        val = object(var_name)
+        return val.value if val
+        return Default[var_name] if Default.enabled?
+      end
+
+      # set a setting value by [] notation
+      def []=(var_name, value)
+        var_name = var_name.to_s
+
+        record = object(var_name) || thing_scoped.new(var: var_name)
+        record.value = value
+        record.save!
+
+        value
+      end
+
+      def merge!(var_name, hash_value)
+        raise ArgumentError unless hash_value.is_a?(Hash)
+
+        old_value = self[var_name] || {}
+        raise TypeError, "Existing value is not a hash, can't merge!" unless old_value.is_a?(Hash)
+
+        new_value = old_value.merge(hash_value)
+        self[var_name] = new_value if new_value != old_value
+
+        new_value
+      end
+
+      def object(var_name)
+        return nil unless rails_initialized?
+        return nil unless table_exists?
+        thing_scoped.where(var: var_name.to_s).first
+      end
+
+      def thing_scoped
+        unscoped.where('thing_type is NULL and thing_id is NULL')
+      end
+
+      def source(filename)
+        Default.source(filename)
+      end
+
+      def rails_initialized?
+        Rails.application && Rails.application.initialized?
+      end
+
+      private
+
+      def default_settings(starting_with = nil)
+        return {} unless Default.enabled?
+        return Default.instance if starting_with.nil?
+        Default.instance.select { |key, _| key.to_s.start_with?(starting_with) }
+      end
+    end
+  end
+
+  class Base < Settings
+    after_commit :rewrite_cache, on: %i(create update)
+    after_commit :expire_cache, on: %i(destroy)
+
+    def rewrite_cache
+      Rails.cache.write(cache_key, value)
+    end
+
+    def expire_cache
+      Rails.cache.delete(cache_key)
+    end
+
+    def cache_key
+      self.class.cache_key(var, thing)
+    end
+
+    class << self
+      def cache_prefix_by_startup
+        return @cache_prefix_by_startup if defined? @cache_prefix_by_startup
+        return '' unless Default.enabled?
+        @cache_prefix_by_startup = Digest::MD5.hexdigest(Default.instance.to_s)
+      end
+
+      def cache_prefix(&block)
+        @cache_prefix = block
+      end
+
+      def cache_key(var_name, scope_object)
+        scope = ['rails_settings_cached', cache_prefix_by_startup]
+        scope << @cache_prefix.call if @cache_prefix
+        scope << "#{scope_object.class.name}-#{scope_object.id}" if scope_object
+        scope << var_name.to_s
+        scope.join('/')
+      end
+
+      def [](key)
+        return super(key) unless rails_initialized?
+        val = Rails.cache.fetch(cache_key(key, @object)) do
+          super(key)
+        end
+        val
+      end
+
+      # set a setting value by [] notation
+      def []=(var_name, value)
+        super
+        Rails.cache.write(cache_key(var_name, @object), value)
+        value
+      end
+
+      def save_default(key, value)
+        Kernel.warn 'DEPRECATION WARNING: RailsSettings save_default is deprecated ' \
+                    'and it will removed in 0.7.0. ' \
+                    'Please use YAML file for default setting.'
+        return false unless self[key].nil?
+        self[key] = value
+      end
+    end
+  end
+end
+
 class Setting < RailsSettings::Base
   source Rails.root.join('config', 'settings.yml')
 

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -13,6 +13,35 @@
 #  thing_id   :bigint(8)
 #
 
+# This file is derived from a fork of the `rails-settings-cached` gem available at
+# https://github.com/mastodon/rails-settings-cached/tree/v0.6.6-aliases-true, with
+# the original available at:
+# https://github.com/huacnlee/rails-settings-cached/tree/0.x
+
+# It is licensed as follows:
+
+# Copyright (c) 2006 Alex Wayne
+# Some additional features added 2009 by Georg Ledermann
+
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOa AND
+# NONINFRINGEMENT. IN NO EVENT SaALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 class Setting < ActiveRecord::Base
   class Default < ::Hash
     class MissingKey < StandardError; end

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -73,27 +73,10 @@ RSpec.describe Setting do
         context 'when Setting.object returns truthy' do
           let(:object) { db_val }
           let(:db_val) { instance_double(described_class, value: 'db_val') }
+          let(:default_value) { 'default_value' }
 
-          context 'when default_value is a Hash' do
-            let(:default_value) { { default_value: 'default_value' } }
-
-            it 'calls default_value.with_indifferent_access.merge!' do
-              indifferent_hash = instance_double(Hash, merge!: nil)
-              allow(default_value).to receive(:with_indifferent_access).and_return(indifferent_hash)
-
-              described_class[key]
-
-              expect(default_value).to have_received(:with_indifferent_access)
-              expect(indifferent_hash).to have_received(:merge!).with(db_val.value)
-            end
-          end
-
-          context 'when default_value is not a Hash' do
-            let(:default_value) { 'default_value' }
-
-            it 'returns db_val.value' do
-              expect(described_class[key]).to be db_val.value
-            end
+          it 'returns db_val.value' do
+            expect(described_class[key]).to be db_val.value
           end
         end
 
@@ -122,55 +105,6 @@ RSpec.describe Setting do
 
         it 'returns the cached value' do
           expect(described_class[key]).to eq cache_value
-        end
-      end
-    end
-  end
-
-  describe '.all_as_records' do
-    before do
-      settings_double = instance_double(Settings::ScopedSettings, thing_scoped: records)
-      allow(Settings::ScopedSettings).to receive(:new).and_return(settings_double)
-      allow(described_class).to receive(:default_settings).and_return(default_settings)
-    end
-
-    let(:key)              { 'key' }
-    let(:default_value)    { 'default_value' }
-    let(:default_settings) { { key => default_value } }
-    let(:original_setting) { Fabricate(:setting, var: key, value: nil) }
-    let(:records)          { [original_setting] }
-
-    it 'returns a Hash' do
-      expect(described_class.all_as_records).to be_a Hash
-    end
-
-    context 'when records includes Setting with var as the key' do
-      let(:records) { [original_setting] }
-
-      it 'includes the original Setting' do
-        setting = described_class.all_as_records[key]
-        expect(setting).to eq original_setting
-      end
-    end
-
-    context 'when records includes nothing' do
-      let(:records) { [] }
-
-      context 'when default_value is not a Hash' do
-        it 'includes Setting with value of default_value' do
-          setting = described_class.all_as_records[key]
-
-          expect(setting).to be_a described_class
-          expect(setting).to have_attributes(var: key)
-          expect(setting).to have_attributes(value: 'default_value')
-        end
-      end
-
-      context 'when default_value is a Hash' do
-        let(:default_value) { { 'foo' => 'fuga' } }
-
-        it 'returns {}' do
-          expect(described_class.all_as_records).to eq({})
         end
       end
     end

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -175,28 +175,4 @@ RSpec.describe Setting do
       end
     end
   end
-
-  describe '.default_settings' do
-    subject { described_class.default_settings }
-
-    before do
-      allow(Setting::Default).to receive(:enabled?).and_return(enabled)
-    end
-
-    context 'when Setting::Default.enabled? is false' do
-      let(:enabled) { false }
-
-      it 'returns {}' do
-        expect(subject).to eq({})
-      end
-    end
-
-    context 'when Setting::Default.enabled? is true' do
-      let(:enabled) { true }
-
-      it 'returns instance of Setting::Default' do
-        expect(subject).to be_a Setting::Default
-      end
-    end
-  end
 end

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -13,99 +13,71 @@ RSpec.describe Setting do
   end
 
   describe '.[]' do
+    let(:key)         { 'key' }
+    let(:cache_key)   { 'cache-key' }
+    let(:cache_value) { 'cache-value' }
+
     before do
-      allow(described_class).to receive(:rails_initialized?).and_return(rails_initialized)
+      allow(described_class).to receive(:cache_key).with(key).and_return(cache_key)
     end
 
-    let(:key) { 'key' }
-
-    context 'when rails_initialized? is falsey' do
-      let(:rails_initialized) { false }
-
-      it 'calls Setting.[]' do
-        allow(described_class).to receive(:[]).with(key)
-
-        described_class[key]
-
-        expect(described_class).to have_received(:[]).with(key)
-      end
-    end
-
-    context 'when rails_initialized? is truthy' do
+    context 'when Rails.cache does not exists' do
       before do
-        allow(described_class).to receive(:cache_key).with(key).and_return(cache_key)
+        allow(described_class).to receive(:object).with(key).and_return(object)
+        allow(described_class).to receive(:default_settings).and_return(default_settings)
+
+        Fabricate(:setting, var: key, value: nil)
+
+        Rails.cache.delete(cache_key)
       end
 
-      let(:rails_initialized) { true }
-      let(:cache_key)         { 'cache-key' }
-      let(:cache_value)       { 'cache-value' }
+      let(:object)           { nil }
+      let(:default_value)    { 'default_value' }
+      let(:default_settings) { { key => default_value } }
 
-      it 'does not call Setting.get' do
-        allow(described_class).to receive(:get).with(key)
+      it 'calls Setting.object' do
+        allow(described_class).to receive(:object).with(key)
 
         described_class[key]
 
-        expect(described_class).to_not have_received(:get).with(key)
+        expect(described_class).to have_received(:object).with(key)
       end
 
-      context 'when Rails.cache does not exists' do
-        before do
-          allow(described_class).to receive(:object).with(key).and_return(object)
-          allow(described_class).to receive(:default_settings).and_return(default_settings)
-          settings_double = instance_double(Settings::ScopedSettings, thing_scoped: records)
-          allow(Settings::ScopedSettings).to receive(:new).and_return(settings_double)
-          Rails.cache.delete(cache_key)
+      context 'when Setting.object returns truthy' do
+        let(:object) { db_val }
+        let(:db_val) { instance_double(described_class, value: 'db_val') }
+        let(:default_value) { 'default_value' }
+
+        it 'returns db_val.value' do
+          expect(described_class[key]).to be db_val.value
         end
+      end
 
-        let(:object)           { nil }
-        let(:default_value)    { 'default_value' }
-        let(:default_settings) { { key => default_value } }
-        let(:records)          { [Fabricate(:setting, var: key, value: nil)] }
+      context 'when Setting.object returns falsey' do
+        let(:object) { nil }
 
-        it 'calls Setting.object' do
-          allow(described_class).to receive(:object).with(key)
+        it 'returns default_settings[key]' do
+          expect(described_class[key]).to be default_settings[key]
+        end
+      end
+    end
 
+    context 'when Rails.cache exists' do
+      before do
+        Rails.cache.write(cache_key, cache_value)
+      end
+
+      it 'does not query the database' do
+        callback = double
+        allow(callback).to receive(:call)
+        ActiveSupport::Notifications.subscribed callback, 'sql.active_record' do
           described_class[key]
-
-          expect(described_class).to have_received(:object).with(key)
         end
-
-        context 'when Setting.object returns truthy' do
-          let(:object) { db_val }
-          let(:db_val) { instance_double(described_class, value: 'db_val') }
-          let(:default_value) { 'default_value' }
-
-          it 'returns db_val.value' do
-            expect(described_class[key]).to be db_val.value
-          end
-        end
-
-        context 'when Setting.object returns falsey' do
-          let(:object) { nil }
-
-          it 'returns default_settings[key]' do
-            expect(described_class[key]).to be default_settings[key]
-          end
-        end
+        expect(callback).to_not have_received(:call)
       end
 
-      context 'when Rails.cache exists' do
-        before do
-          Rails.cache.write(cache_key, cache_value)
-        end
-
-        it 'does not query the database' do
-          callback = double
-          allow(callback).to receive(:call)
-          ActiveSupport::Notifications.subscribed callback, 'sql.active_record' do
-            described_class[key]
-          end
-          expect(callback).to_not have_received(:call)
-        end
-
-        it 'returns the cached value' do
-          expect(described_class[key]).to eq cache_value
-        end
+      it 'returns the cached value' do
+        expect(described_class[key]).to eq cache_value
       end
     end
   end

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -22,35 +22,35 @@ RSpec.describe Setting do
     context 'when rails_initialized? is falsey' do
       let(:rails_initialized) { false }
 
-      it 'calls RailsSettings::Base#[]' do
-        allow(RailsSettings::Base).to receive(:[]).with(key)
+      it 'calls Setting.[]' do
+        allow(Setting).to receive(:[]).with(key)
 
         described_class[key]
 
-        expect(RailsSettings::Base).to have_received(:[]).with(key)
+        expect(Setting).to have_received(:[]).with(key)
       end
     end
 
     context 'when rails_initialized? is truthy' do
       before do
-        allow(RailsSettings::Base).to receive(:cache_key).with(key).and_return(cache_key)
+        allow(Setting).to receive(:cache_key).with(key).and_return(cache_key)
       end
 
       let(:rails_initialized) { true }
       let(:cache_key)         { 'cache-key' }
       let(:cache_value)       { 'cache-value' }
 
-      it 'calls not RailsSettings::Base#[]' do
-        allow(RailsSettings::Base).to receive(:[]).with(key)
+      it 'calls not Setting.get' do
+        allow(Setting).to receive(:get).with(key)
 
         described_class[key]
 
-        expect(RailsSettings::Base).to_not have_received(:[]).with(key)
+        expect(Setting).to_not have_received(:get).with(key)
       end
 
       context 'when Rails.cache does not exists' do
         before do
-          allow(RailsSettings::Base).to receive(:object).with(key).and_return(object)
+          allow(Setting).to receive(:object).with(key).and_return(object)
           allow(described_class).to receive(:default_settings).and_return(default_settings)
           settings_double = instance_double(Settings::ScopedSettings, thing_scoped: records)
           allow(Settings::ScopedSettings).to receive(:new).and_return(settings_double)
@@ -62,15 +62,15 @@ RSpec.describe Setting do
         let(:default_settings) { { key => default_value } }
         let(:records)          { [Fabricate(:setting, var: key, value: nil)] }
 
-        it 'calls RailsSettings::Base.object' do
-          allow(RailsSettings::Base).to receive(:object).with(key)
+        it 'calls Setting.object' do
+          allow(Setting).to receive(:object).with(key)
 
           described_class[key]
 
-          expect(RailsSettings::Base).to have_received(:object).with(key)
+          expect(Setting).to have_received(:object).with(key)
         end
 
-        context 'when RailsSettings::Base.object returns truthy' do
+        context 'when Setting.object returns truthy' do
           let(:object) { db_val }
           let(:db_val) { instance_double(described_class, value: 'db_val') }
 
@@ -97,7 +97,7 @@ RSpec.describe Setting do
           end
         end
 
-        context 'when RailsSettings::Base.object returns falsey' do
+        context 'when Setting.object returns falsey' do
           let(:object) { nil }
 
           it 'returns default_settings[key]' do
@@ -180,10 +180,10 @@ RSpec.describe Setting do
     subject { described_class.default_settings }
 
     before do
-      allow(RailsSettings::Default).to receive(:enabled?).and_return(enabled)
+      allow(Setting::Default).to receive(:enabled?).and_return(enabled)
     end
 
-    context 'when RailsSettings::Default.enabled? is false' do
+    context 'when Setting::Default.enabled? is false' do
       let(:enabled) { false }
 
       it 'returns {}' do
@@ -191,11 +191,11 @@ RSpec.describe Setting do
       end
     end
 
-    context 'when RailsSettings::Base.enabled? is true' do
+    context 'when Setting::Default.enabled? is true' do
       let(:enabled) { true }
 
-      it 'returns instance of RailsSettings::Default' do
-        expect(subject).to be_a RailsSettings::Default
+      it 'returns instance of Setting::Default' do
+        expect(subject).to be_a Setting::Default
       end
     end
   end

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Setting do
 
     context 'when rails_initialized? is truthy' do
       before do
-        allow(RailsSettings::Base).to receive(:cache_key).with(key, nil).and_return(cache_key)
+        allow(RailsSettings::Base).to receive(:cache_key).with(key).and_return(cache_key)
       end
 
       let(:rails_initialized) { true }
@@ -50,7 +50,7 @@ RSpec.describe Setting do
 
       context 'when Rails.cache does not exists' do
         before do
-          allow(RailsSettings::Settings).to receive(:object).with(key).and_return(object)
+          allow(RailsSettings::Base).to receive(:object).with(key).and_return(object)
           allow(described_class).to receive(:default_settings).and_return(default_settings)
           settings_double = instance_double(Settings::ScopedSettings, thing_scoped: records)
           allow(Settings::ScopedSettings).to receive(:new).and_return(settings_double)
@@ -62,15 +62,15 @@ RSpec.describe Setting do
         let(:default_settings) { { key => default_value } }
         let(:records)          { [Fabricate(:setting, var: key, value: nil)] }
 
-        it 'calls RailsSettings::Settings.object' do
-          allow(RailsSettings::Settings).to receive(:object).with(key)
+        it 'calls RailsSettings::Base.object' do
+          allow(RailsSettings::Base).to receive(:object).with(key)
 
           described_class[key]
 
-          expect(RailsSettings::Settings).to have_received(:object).with(key)
+          expect(RailsSettings::Base).to have_received(:object).with(key)
         end
 
-        context 'when RailsSettings::Settings.object returns truthy' do
+        context 'when RailsSettings::Base.object returns truthy' do
           let(:object) { db_val }
           let(:db_val) { instance_double(described_class, value: 'db_val') }
 
@@ -97,7 +97,7 @@ RSpec.describe Setting do
           end
         end
 
-        context 'when RailsSettings::Settings.object returns falsey' do
+        context 'when RailsSettings::Base.object returns falsey' do
           let(:object) { nil }
 
           it 'returns default_settings[key]' do
@@ -191,7 +191,7 @@ RSpec.describe Setting do
       end
     end
 
-    context 'when RailsSettings::Settings.enabled? is true' do
+    context 'when RailsSettings::Base.enabled? is true' do
       let(:enabled) { true }
 
       it 'returns instance of RailsSettings::Default' do

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -23,34 +23,34 @@ RSpec.describe Setting do
       let(:rails_initialized) { false }
 
       it 'calls Setting.[]' do
-        allow(Setting).to receive(:[]).with(key)
+        allow(described_class).to receive(:[]).with(key)
 
         described_class[key]
 
-        expect(Setting).to have_received(:[]).with(key)
+        expect(described_class).to have_received(:[]).with(key)
       end
     end
 
     context 'when rails_initialized? is truthy' do
       before do
-        allow(Setting).to receive(:cache_key).with(key).and_return(cache_key)
+        allow(described_class).to receive(:cache_key).with(key).and_return(cache_key)
       end
 
       let(:rails_initialized) { true }
       let(:cache_key)         { 'cache-key' }
       let(:cache_value)       { 'cache-value' }
 
-      it 'calls not Setting.get' do
-        allow(Setting).to receive(:get).with(key)
+      it 'does not call Setting.get' do
+        allow(described_class).to receive(:get).with(key)
 
         described_class[key]
 
-        expect(Setting).to_not have_received(:get).with(key)
+        expect(described_class).to_not have_received(:get).with(key)
       end
 
       context 'when Rails.cache does not exists' do
         before do
-          allow(Setting).to receive(:object).with(key).and_return(object)
+          allow(described_class).to receive(:object).with(key).and_return(object)
           allow(described_class).to receive(:default_settings).and_return(default_settings)
           settings_double = instance_double(Settings::ScopedSettings, thing_scoped: records)
           allow(Settings::ScopedSettings).to receive(:new).and_return(settings_double)
@@ -63,11 +63,11 @@ RSpec.describe Setting do
         let(:records)          { [Fabricate(:setting, var: key, value: nil)] }
 
         it 'calls Setting.object' do
-          allow(Setting).to receive(:object).with(key)
+          allow(described_class).to receive(:object).with(key)
 
           described_class[key]
 
-          expect(Setting).to have_received(:object).with(key)
+          expect(described_class).to have_received(:object).with(key)
         end
 
         context 'when Setting.object returns truthy' do


### PR DESCRIPTION
Previous discussion in https://github.com/mastodon/mastodon/pull/28609

Mastodon uses an old forked version of the gem, and upstream has diverged very significantly. That gem also cause Active Record to be loaded too early, and to not apply some settings.

Given that it's not used much, it seems better to vendor the small part that is used and get rid of an outdated dependency.

After vendoring it, I made some minor simplifications, but I'm certain it can be simplified much further, I just don't want to go too far given my limited knowledge of mastodon. The table could also be migrated to drop `thing_type` and `thing_id` as they are not used.

It's also interesting to note that a similar thing was done with `ScopedSettings` in https://github.com/mastodon/mastodon/pull/3213.

cc @ClearlyClaire 