### PR TITLE
Use normalizes to prepare CustomEmoji `domain` value

### DIFF
--- a/app/models/custom_emoji.rb
+++ b/app/models/custom_emoji.rb
@@ -41,7 +41,7 @@ class CustomEmoji < ApplicationRecord
 
   has_attached_file :image, styles: { static: { format: 'png', convert_options: '-coalesce +profile "!icc,*" +set date:modify +set date:create +set date:timestamp' } }, validate_media_type: false
 
-  before_validation :downcase_domain
+  normalizes :domain, with: ->(domain) { domain.downcase }
 
   validates_attachment :image, content_type: { content_type: IMAGE_MIME_TYPES }, presence: true, size: { less_than: LIMIT }
   validates :shortcode, uniqueness: { scope: :domain }, format: { with: SHORTCODE_ONLY_RE }, length: { minimum: 2 }
@@ -94,9 +94,5 @@ class CustomEmoji < ApplicationRecord
 
   def remove_entity_cache
     Rails.cache.delete(EntityCache.instance.to_key(:emoji, shortcode, domain))
-  end
-
-  def downcase_domain
-    self.domain = domain.downcase unless domain.nil?
   end
 end

--- a/spec/models/custom_emoji_spec.rb
+++ b/spec/models/custom_emoji_spec.rb
@@ -78,12 +78,23 @@ RSpec.describe CustomEmoji do
     end
   end
 
-  describe 'pre_validation' do
-    let(:custom_emoji) { Fabricate(:custom_emoji, domain: 'wWw.MaStOdOn.CoM') }
+  describe 'Normalizations' do
+    describe 'downcase domain value' do
+      context 'with a mixed case domain value' do
+        it 'normalizes the value to downcased' do
+          custom_emoji = Fabricate.build(:custom_emoji, domain: 'wWw.MaStOdOn.CoM')
 
-    it 'downcases' do
-      custom_emoji.valid?
-      expect(custom_emoji.domain).to eq('www.mastodon.com')
+          expect(custom_emoji.domain).to eq('www.mastodon.com')
+        end
+      end
+
+      context 'with a nil domain value' do
+        it 'leaves the value as nil' do
+          custom_emoji = Fabricate.build(:custom_emoji, domain: nil)
+
+          expect(custom_emoji.domain).to be_nil
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This one is cached, so also needs the new Marshall format.