### PR TITLE
Enable "low risk" Rails 7.1 setting defaults

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -62,7 +62,7 @@ Rails.application.config.active_record.run_commit_callbacks_on_first_saved_insta
 Rails.application.config.active_record.sqlite3_adapter_strict_strings_by_default = true
 
 # Disable deprecated singular associations names
-# Rails.application.config.active_record.allow_deprecated_singular_associations_name = false
+Rails.application.config.active_record.allow_deprecated_singular_associations_name = false
 
 # Enable the Active Job `BigDecimal` argument serializer, which guarantees
 # roundtripping. Without this serializer, some queue adapters may serialize

--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -188,7 +188,7 @@ Rails.application.config.active_record.generate_secure_token_on = :initialize
 #
 # In previous versions of Rails, Action View always used `Rails::HTML4::Sanitizer` as its vendor.
 #
-# Rails.application.config.action_view.sanitizer_vendor = Rails::HTML::Sanitizer.best_supported_vendor
+Rails.application.config.action_view.sanitizer_vendor = Rails::HTML::Sanitizer.best_supported_vendor
 
 # Configure Action Text to use an HTML5 standards-compliant sanitizer when it is supported on your
 # platform.
@@ -198,7 +198,7 @@ Rails.application.config.active_record.generate_secure_token_on = :initialize
 #
 # In previous versions of Rails, Action Text always used `Rails::HTML4::Sanitizer` as its vendor.
 #
-# Rails.application.config.action_text.sanitizer_vendor = Rails::HTML::Sanitizer.best_supported_vendor
+Rails.application.config.action_text.sanitizer_vendor = Rails::HTML::Sanitizer.best_supported_vendor
 
 # Configure the log level used by the DebugExceptions middleware when logging
 # uncaught exceptions during requests

--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -50,7 +50,7 @@ Rails.application.config.add_autoload_paths_to_load_path = false
 # Instead, run these callbacks on the instance most likely to have internal
 # state which matches what was committed to the database, typically the last
 # instance to save.
-# Rails.application.config.active_record.run_commit_callbacks_on_first_saved_instances_in_transaction = false
+Rails.application.config.active_record.run_commit_callbacks_on_first_saved_instances_in_transaction = false
 
 # Configures SQLite with a strict strings mode, which disables double-quoted string literals.
 #
@@ -59,7 +59,7 @@ Rails.application.config.add_autoload_paths_to_load_path = false
 # it then considers them as string literals. Because of this, typos can silently go unnoticed.
 # For example, it is possible to create an index for a non existing column.
 # See https://www.sqlite.org/quirks.html#double_quoted_string_literals_are_accepted for more details.
-# Rails.application.config.active_record.sqlite3_adapter_strict_strings_by_default = true
+Rails.application.config.active_record.sqlite3_adapter_strict_strings_by_default = true
 
 # Disable deprecated singular associations names
 # Rails.application.config.active_record.allow_deprecated_singular_associations_name = false
@@ -83,7 +83,7 @@ Rails.application.config.add_autoload_paths_to_load_path = false
 # Specify whether Query Logs will format tags using the SQLCommenter format
 # (https://open-telemetry.github.io/opentelemetry-sqlcommenter/), or using the legacy format.
 # Options are `:legacy` and `:sqlcommenter`.
-# Rails.application.config.active_record.query_log_tags_format = :sqlcommenter
+Rails.application.config.active_record.query_log_tags_format = :sqlcommenter
 
 # Specify the default serializer used by `MessageEncryptor` and `MessageVerifier`
 # instances.
@@ -129,14 +129,12 @@ Rails.application.config.add_autoload_paths_to_load_path = false
 # `config.load_defaults 7.1` does not set this value for environments other than
 # development and test.
 #
-# if Rails.env.local?
-#   Rails.application.config.log_file_size = 100 * 1024 * 1024
-# end
+Rails.application.config.log_file_size = 100 * 1024 * 1024 if Rails.env.local?
 
 # Enable raising on assignment to attr_readonly attributes. The previous
 # behavior would allow assignment but silently not persist changes to the
 # database.
-# Rails.application.config.active_record.raise_on_assign_to_attr_readonly = true
+Rails.application.config.active_record.raise_on_assign_to_attr_readonly = true
 
 # Enable validating only parent-related columns for presence when the parent is mandatory.
 # The previous behavior was to validate the presence of the parent record, which performed an extra query
@@ -145,7 +143,7 @@ Rails.application.config.add_autoload_paths_to_load_path = false
 
 # Enable precompilation of `config.filter_parameters`. Precompilation can
 # improve filtering performance, depending on the quantity and types of filters.
-# Rails.application.config.precompile_filter_parameters = true
+Rails.application.config.precompile_filter_parameters = true
 
 # Enable before_committed! callbacks on all enrolled records in a transaction.
 # The previous behavior was to only run the callbacks on the first copy of a record
@@ -161,7 +159,7 @@ Rails.application.config.add_autoload_paths_to_load_path = false
 # Run `after_commit` and `after_*_commit` callbacks in the order they are defined in a model.
 # This matches the behaviour of all other callbacks.
 # In previous versions of Rails, they ran in the inverse order.
-# Rails.application.config.active_record.run_after_transaction_callbacks_in_order_defined = true
+Rails.application.config.active_record.run_after_transaction_callbacks_in_order_defined = true
 
 # Whether a `transaction` block is committed or rolled back when exited via `return`, `break` or `throw`.
 #
@@ -169,7 +167,7 @@ Rails.application.config.add_autoload_paths_to_load_path = false
 
 # Controls when to generate a value for <tt>has_secure_token</tt> declarations.
 #
-# Rails.application.config.active_record.generate_secure_token_on = :initialize
+Rails.application.config.active_record.generate_secure_token_on = :initialize
 
 # ** Please read carefully, this must be configured in config/application.rb **
 # Change the format of the cache entry.
@@ -213,4 +211,4 @@ Rails.application.config.add_autoload_paths_to_load_path = false
 #
 # In previous versions of Rails, these test helpers always used an HTML4 parser.
 #
-# Rails.application.config.dom_testing_default_html_version = :html5
+Rails.application.config.dom_testing_default_html_version = :html5

--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -78,7 +78,7 @@ Rails.application.config.active_job.use_big_decimal_serializer = true
 # `write` are given an invalid `expires_at` or `expires_in` time.
 # Options are `true`, and `false`. If `false`, the exception will be reported
 # as `handled` and logged instead.
-# Rails.application.config.active_support.raise_on_invalid_cache_expiration_time = true
+Rails.application.config.active_support.raise_on_invalid_cache_expiration_time = true
 
 # Specify whether Query Logs will format tags using the SQLCommenter format
 # (https://open-telemetry.github.io/opentelemetry-sqlcommenter/), or using the legacy format.

--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -148,7 +148,7 @@ Rails.application.config.precompile_filter_parameters = true
 # Enable before_committed! callbacks on all enrolled records in a transaction.
 # The previous behavior was to only run the callbacks on the first copy of a record
 # if there were multiple copies of the same record enrolled in the transaction.
-# Rails.application.config.active_record.before_committed_on_all_records = true
+Rails.application.config.active_record.before_committed_on_all_records = true
 
 # Disable automatic column serialization into YAML.
 # To keep the historic behavior, you can set it to `YAML`, however it is

--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -154,7 +154,7 @@ Rails.application.config.precompile_filter_parameters = true
 # To keep the historic behavior, you can set it to `YAML`, however it is
 # recommended to explicitly define the serialization method for each column
 # rather than to rely on a global default.
-# Rails.application.config.active_record.default_column_serializer = nil
+Rails.application.config.active_record.default_column_serializer = nil
 
 # Run `after_commit` and `after_*_commit` callbacks in the order they are defined in a model.
 # This matches the behaviour of all other callbacks.

--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -72,7 +72,7 @@ Rails.application.config.active_record.sqlite3_adapter_strict_strings_by_default
 # replicas will not be able to deserialize `BigDecimal` arguments from this
 # serializer. Therefore, this setting should only be enabled after all replicas
 # have been successfully upgraded to Rails 7.1.
-# Rails.application.config.active_job.use_big_decimal_serializer = true
+Rails.application.config.active_job.use_big_decimal_serializer = true
 
 # Specify if an `ArgumentError` should be raised if `Rails.cache` `fetch` or
 # `write` are given an invalid `expires_at` or `expires_in` time.

--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -29,7 +29,7 @@ Rails.application.config.add_autoload_paths_to_load_path = false
 
 # Do not treat an `ActionController::Parameters` instance
 # as equal to an equivalent `Hash` by default.
-# Rails.application.config.action_controller.allow_deprecated_parameters_hash_equality = false
+Rails.application.config.action_controller.allow_deprecated_parameters_hash_equality = false
 
 # Active Record Encryption now uses SHA-256 as its hash digest algorithm. Important: If you have
 # data encrypted with previous Rails versions, there are two scenarios to consider:

--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -139,7 +139,7 @@ Rails.application.config.active_record.raise_on_assign_to_attr_readonly = true
 # Enable validating only parent-related columns for presence when the parent is mandatory.
 # The previous behavior was to validate the presence of the parent record, which performed an extra query
 # to get the parent every time the child record was updated, even when parent has not changed.
-# Rails.application.config.active_record.belongs_to_required_validates_foreign_key = false
+Rails.application.config.active_record.belongs_to_required_validates_foreign_key = false
 
 # Enable precompilation of `config.filter_parameters`. Precompilation can
 # improve filtering performance, depending on the quantity and types of filters.

--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -198,7 +198,7 @@ Rails.application.config.action_view.sanitizer_vendor = Rails::HTML::Sanitizer.b
 #
 # In previous versions of Rails, Action Text always used `Rails::HTML4::Sanitizer` as its vendor.
 #
-Rails.application.config.action_text.sanitizer_vendor = Rails::HTML::Sanitizer.best_supported_vendor
+# Rails.application.config.action_text.sanitizer_vendor = Rails::HTML::Sanitizer.best_supported_vendor
 
 # Configure the log level used by the DebugExceptions middleware when logging
 # uncaught exceptions during requests

--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -72,7 +72,7 @@ Rails.application.config.active_record.allow_deprecated_singular_associations_na
 # replicas will not be able to deserialize `BigDecimal` arguments from this
 # serializer. Therefore, this setting should only be enabled after all replicas
 # have been successfully upgraded to Rails 7.1.
-Rails.application.config.active_job.use_big_decimal_serializer = true
+# Rails.application.config.active_job.use_big_decimal_serializer = true
 
 # Specify if an `ArgumentError` should be raised if `Rails.cache` `fetch` or
 # `write` are given an invalid `expires_at` or `expires_in` time.


### PR DESCRIPTION
I want to start working through this file and either enabling or figuring out a migration path for the various settings here.

This PR is the result of doing a quick scan through the file -- I turned on anything which either I was pretty sure is not relevant to the app, reflects a practice we already had in place, or just otherwise seemed low-risk/sensible change.

I stayed away from anything which I either know needs a migration path or more contemplation first. Hoping to work through those in separate PRs.

Once they're all enabled and we're convinced all is well,  we can delete the file and toggle application.rb to 7.1 defaults.