### PR TITLE
Add Interlingue to available_locales

### DIFF
--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -42,6 +42,7 @@ Rails.application.configure do
     :hu,
     :hy,
     :id,
+    :ie,
     :ig,
     :io,
     :is,


### PR DESCRIPTION
Resolves https://github.com/mastodon/mastodon/issues/28628

Hi,

The Interlingue translation [reached 100% today](https://crowdin.com/project/mastodon) and apparently a PR updating [app/helpers/languages_helper.rb and config/initializers/i18n.rb](https://crowdin.com/project/mastodon/discussions/307) is all that's needed...and looks like Interlingue is already in the former. So I think this is all that needs to be done?

Thanks!