### PR TITLE
Streaming: refactor to custom Error classes

### DIFF
--- a/streaming/errors.js
+++ b/streaming/errors.js
@@ -1,0 +1,51 @@
+// @ts-check
+
+/**
+ * Typed as a string because otherwise it's a const string, which means we can't
+ * override it in let statements.
+ * @type {string}
+ */
+const UNEXPECTED_ERROR_MESSAGE = 'An unexpected error occurred';
+exports.UNKNOWN_ERROR_MESSAGE = UNEXPECTED_ERROR_MESSAGE;
+
+/**
+ * Extracts the status and message properties from the error object, if
+ * available for public use. The `unknown` is for catch statements
+ * @param {Error | AuthenticationError | RequestError | unknown} err
+ */
+exports.extractStatusAndMessage = function(err) {
+  let statusCode = 500;
+  let errorMessage = UNEXPECTED_ERROR_MESSAGE;
+  if (err instanceof AuthenticationError || err instanceof RequestError) {
+    statusCode = err.status;
+    errorMessage = err.message;
+  }
+
+  return { statusCode, errorMessage };
+};
+
+class RequestError extends Error {
+  /**
+   * @param {string} message
+   */
+  constructor(message) {
+    super(message);
+    this.name = "RequestError";
+    this.status = 400;
+  }
+}
+
+exports.RequestError = RequestError;
+
+class AuthenticationError extends Error {
+  /**
+   * @param {string} message
+   */
+  constructor(message) {
+    super(message);
+    this.name = "AuthenticationError";
+    this.status = 401;
+  }
+}
+
+exports.AuthenticationError = AuthenticationError;

--- a/streaming/index.js
+++ b/streaming/index.js
@@ -14,6 +14,8 @@ const pg = require('pg');
 const dbUrlToConfig = require('pg-connection-string').parse;
 const WebSocket = require('ws');
 
+const errors = require('./errors');
+const { AuthenticationError, RequestError } = require('./errors');
 const { logger, httpLogger, initializeLogLevel, attachWebsocketHttpLogger, createWebsocketLogger } = require('./logging');
 const { setupMetrics } = require('./metrics');
 const { isTruthy } = require("./utils");
@@ -241,7 +243,7 @@ const startServer = async () => {
       // Unfortunately for using the on('upgrade') setup, we need to manually
       // write a HTTP Response to the Socket to close the connection upgrade
       // attempt, so the following code is to handle all of that.
-      const statusCode = err.status ?? 401;
+      const {statusCode, errorMessage } = errors.extractStatusAndMessage(err);
 
       /** @type {Record<string, string | number | import('pino-http').ReqId>} */
       const headers = {
@@ -249,7 +251,7 @@ const startServer = async () => {
         'Content-Type': 'text/plain',
         'Content-Length': 0,
         'X-Request-Id': request.id,
-        'X-Error-Message': err.status ? err.toString() : 'An unexpected error occurred'
+        'X-Error-Message': errorMessage
       };
 
       // Ensure the socket is closed once we've finished writing to it:
@@ -267,7 +269,7 @@ const startServer = async () => {
           statusCode,
           headers
         }
-      }, err.toString());
+      }, errorMessage);
 
       return;
     }
@@ -452,11 +454,7 @@ const startServer = async () => {
         }
 
         if (result.rows.length === 0) {
-          err = new Error('Invalid access token');
-          // @ts-ignore
-          err.status = 401;
-
-          reject(err);
+          reject(new AuthenticationError('Invalid access token'));
           return;
         }
 
@@ -487,11 +485,7 @@ const startServer = async () => {
     const accessToken   = location.query.access_token || req.headers['sec-websocket-protocol'];
 
     if (!authorization && !accessToken) {
-      const err = new Error('Missing access token');
-      // @ts-ignore
-      err.status = 401;
-
-      reject(err);
+      reject(new AuthenticationError('Missing access token'));
       return;
     }
 
@@ -568,11 +562,7 @@ const startServer = async () => {
       return;
     }
 
-    const err = new Error('Access token does not cover required scopes');
-    // @ts-ignore
-    err.status = 401;
-
-    reject(err);
+    reject(new AuthenticationError('Access token does not have the required scopes'));
   });
 
   /**
@@ -648,11 +638,7 @@ const startServer = async () => {
     // If no channelName can be found for the request, then we should terminate
     // the connection, as there's nothing to stream back
     if (!channelName) {
-      const err = new Error('Unknown channel requested');
-      // @ts-ignore
-      err.status = 400;
-
-      next(err);
+      next(new RequestError('Unknown channel requested'));
       return;
     }
 
@@ -679,10 +665,7 @@ const startServer = async () => {
       return;
     }
 
-    const hasStatusCode = Object.hasOwnProperty.call(err, 'status');
-    // @ts-ignore
-    const statusCode = hasStatusCode ? err.status : 500;
-    const errorMessage = hasStatusCode ? err.toString() : 'An unexpected error occurred';
+    const {statusCode, errorMessage } = errors.extractStatusAndMessage(err);
 
     res.writeHead(statusCode, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({ error: errorMessage }));
@@ -1057,7 +1040,7 @@ const startServer = async () => {
   };
 
   /**
-   * @param {any} res
+   * @param {http.ServerResponse} res
    */
   const httpNotFound = res => {
     res.writeHead(404, { 'Content-Type': 'application/json' });
@@ -1072,16 +1055,29 @@ const startServer = async () => {
   api.use(errorMiddleware);
 
   api.get('/api/v1/streaming/*', (req, res) => {
-    // @ts-ignore
-    channelNameToIds(req, channelNameFromPath(req), req.query).then(({ channelIds, options }) => {
+    const channelName = channelNameFromPath(req);
+
+    // FIXME: In theory we'd never actually reach here due to
+    // authenticationMiddleware catching this case, however, we need to refactor
+    // how those middlewares work, so I'm adding the extra check in here.
+    if (!channelName) {
+      httpNotFound(res);
+      return;
+    }
+
+    channelNameToIds(req, channelName, req.query).then(({ channelIds, options }) => {
       const onSend = streamToHttp(req, res);
       const onEnd = streamHttpEnd(req, subscriptionHeartbeat(channelIds));
 
       // @ts-ignore
       streamFrom(channelIds, req, req.log, onSend, onEnd, 'eventsource', options.needsFiltering);
     }).catch(err => {
-      res.log.info({ err }, 'Subscription error:', err.toString());
-      httpNotFound(res);
+      const {statusCode, errorMessage } = errors.extractStatusAndMessage(err);
+
+      res.log.info({ err }, 'Eventsource subscription error');
+
+      res.writeHead(statusCode, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: errorMessage }));
     });
   });
 
@@ -1210,8 +1206,8 @@ const startServer = async () => {
 
       break;
     case 'hashtag':
-      if (!params.tag || params.tag.length === 0) {
-        reject('No tag for stream provided');
+      if (!params.tag) {
+        reject(new RequestError('Missing tag name parameter'));
       } else {
         resolve({
           channelIds: [`timeline:hashtag:${normalizeHashtag(params.tag)}`],
@@ -1221,8 +1217,8 @@ const startServer = async () => {
 
       break;
     case 'hashtag:local':
-      if (!params.tag || params.tag.length === 0) {
-        reject('No tag for stream provided');
+      if (!params.tag) {
+        reject(new RequestError('Missing tag name parameter'));
       } else {
         resolve({
           channelIds: [`timeline:hashtag:${normalizeHashtag(params.tag)}:local`],
@@ -1232,19 +1228,23 @@ const startServer = async () => {
 
       break;
     case 'list':
-      // @ts-ignore
+      if (!params.list) {
+        reject(new RequestError('Missing list name parameter'));
+        return;
+      }
+
       authorizeListAccess(params.list, req).then(() => {
         resolve({
           channelIds: [`timeline:list:${params.list}`],
           options: { needsFiltering: false },
         });
       }).catch(() => {
-        reject('Not authorized to stream this list');
+        reject(new AuthenticationError('Not authorized to stream this list'));
       });
 
       break;
     default:
-      reject('Unknown stream type');
+      reject(new RequestError('Unknown stream type'));
     }
   });
 
@@ -1298,8 +1298,17 @@ const startServer = async () => {
         stopHeartbeat,
       };
     }).catch(err => {
-      logger.error({ err }, 'Subscription error');
-      websocket.send(JSON.stringify({ error: err.toString() }));
+      const {statusCode, errorMessage } = errors.extractStatusAndMessage(err);
+
+      logger.error({ err }, 'Websocket subscription error');
+
+      // If we have a socket that is alive and open still, send the error back to the client:
+      if (websocket.isAlive && websocket.readyState === websocket.OPEN) {
+        websocket.send(JSON.stringify({
+          error: errorMessage,
+          status: statusCode
+        }));
+      }
     });
   };
 
@@ -1338,11 +1347,12 @@ const startServer = async () => {
     channelNameToIds(request, channelName, params).then(({ channelIds }) => {
       removeSubscription(session, channelIds);
     }).catch(err => {
-      logger.error({err}, 'Unsubscribe error');
+      logger.error({err}, 'Websocket unsubscribe error');
 
       // If we have a socket that is alive and open still, send the error back to the client:
       if (websocket.isAlive && websocket.readyState === websocket.OPEN) {
-        websocket.send(JSON.stringify({ error: "Error unsubscribing from channel" }));
+        // TODO: Use a better error response here
+        websocket.send(JSON.stringify({error: "Error unsubscribing from channel" }));
       }
     });
   };

--- a/streaming/index.js
+++ b/streaming/index.js
@@ -1352,7 +1352,7 @@ const startServer = async () => {
       // If we have a socket that is alive and open still, send the error back to the client:
       if (websocket.isAlive && websocket.readyState === websocket.OPEN) {
         // TODO: Use a better error response here
-        websocket.send(JSON.stringify({error: "Error unsubscribing from channel" }));
+        websocket.send(JSON.stringify({ error: "Error unsubscribing from channel" }));
       }
     });
   };


### PR DESCRIPTION
This enables better handling of the errors rather than just adding properties to the Error instance. This is currently a draft until #27828 is merged.

We also need to take a deeper look at the `on("error")` handlers for websockets and eventstreams to double check that we're not accidentally sending confidential information about errors to the clients.

I will also note that we're approaching the time to do a reorganisation of the `streaming/` directory into a `streaming/src/*` and `streaming/index.js` that just starts the server listening, however, due to other inflight work, I don't wish to do this reorganisation yet, as it'd create merge and rebase conflicts. 