### PR TITLE
Remove unused `DomainBlock#affected_accounts_count` method

### DIFF
--- a/app/models/domain_block.rb
+++ b/app/models/domain_block.rb
@@ -85,11 +85,6 @@ class DomainBlock < ApplicationRecord
     (reject_media || !other_block.reject_media) && (reject_reports || !other_block.reject_reports)
   end
 
-  def affected_accounts_count
-    scope = suspend? ? accounts.where(suspended_at: created_at) : accounts.where(silenced_at: created_at)
-    scope.count
-  end
-
   def public_domain
     return domain unless obfuscate?
 


### PR DESCRIPTION
Last usage removed in https://github.com/mastodon/mastodon/commit/bd53dd521064b12261b82105624cf5f8b9ca9d69#diff-6149248d78854f502dda47e089dabaea3093f13b15efcc26ea0b38fa756d5529L22