### PR TITLE
Remove unused `EmojiFormatter#count_tag_nesting` method

### DIFF
--- a/app/lib/emoji_formatter.rb
+++ b/app/lib/emoji_formatter.rb
@@ -66,16 +66,6 @@ class EmojiFormatter
     @emoji_map ||= custom_emojis.each_with_object({}) { |e, h| h[e.shortcode] = [full_asset_url(e.image.url), full_asset_url(e.image.url(:static))] }
   end
 
-  def count_tag_nesting(tag)
-    if tag[1] == '/'
-      -1
-    elsif tag[-2] == '/'
-      0
-    else
-      1
-    end
-  end
-
   def tag_for_emoji(shortcode, emoji)
     return content_tag(:span, ":#{shortcode}:", translate: 'no') if raw_shortcode?
 


### PR DESCRIPTION
Last usage removed in https://github.com/mastodon/mastodon/commit/71c92d3f56580f7020a86cc2b8179fdc2ffebded#diff-2a0ea6d39f814177b2f0eb886d73452bfc536b887c6593f52c79cb9cbe6e47ccL52