### PR TITLE
Remove unused `*_silenced_accounts` scopes on Status

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -108,8 +108,6 @@ class Status < ApplicationRecord
   scope :without_reblogs, -> { where(statuses: { reblog_of_id: nil }) }
   scope :with_public_visibility, -> { where(visibility: :public) }
   scope :tagged_with, ->(tag_ids) { joins(:statuses_tags).where(statuses_tags: { tag_id: tag_ids }) }
-  scope :excluding_silenced_accounts, -> { left_outer_joins(:account).where(accounts: { silenced_at: nil }) }
-  scope :including_silenced_accounts, -> { left_outer_joins(:account).where.not(accounts: { silenced_at: nil }) }
   scope :not_excluded_by_account, ->(account) { where.not(account_id: account.excluded_from_timeline_account_ids) }
   scope :not_domain_blocked_by_account, ->(account) { account.excluded_from_timeline_domains.blank? ? left_outer_joins(:account) : left_outer_joins(:account).where('accounts.domain IS NULL OR accounts.domain NOT IN (?)', account.excluded_from_timeline_domains) }
   scope :tagged_with_all, lambda { |tag_ids|


### PR DESCRIPTION
Last use of `excluding_` removed in:  https://github.com/mastodon/mastodon/commit/6e50134a42cb303e6e42f89f9ddb5aacf83e7a6d#diff-9d5b6d0caeda71959a83a8b81cdb379e48987473b753ab9b66232565ab6c268cL58

Last use of `including_` removed in: https://github.com/mastodon/mastodon/commit/4bdab203ac5ca06d757d08af8a2bc184c86e3bbe#diff-b8b0d989b8031e6690947f5a1117fa51873f60a213b202a7e97b15bd873c2f08L387