### PR TITLE
Remove unused scope `Announcement.without_muted`

### DIFF
--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -20,7 +20,6 @@
 class Announcement < ApplicationRecord
   scope :unpublished, -> { where(published: false) }
   scope :published, -> { where(published: true) }
-  scope :without_muted, ->(account) { joins("LEFT OUTER JOIN announcement_mutes ON announcement_mutes.announcement_id = announcements.id AND announcement_mutes.account_id = #{account.id}").where(announcement_mutes: { id: nil }) }
   scope :chronological, -> { order(coalesced_chronology_timestamps.asc) }
   scope :reverse_chronological, -> { order(coalesced_chronology_timestamps.desc) }
 

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -25,22 +25,6 @@ describe Announcement do
       end
     end
 
-    describe '#without_muted' do
-      let!(:announcement) { Fabricate(:announcement) }
-      let(:account) { Fabricate(:account) }
-      let(:muted_announcement) { Fabricate(:announcement) }
-
-      before do
-        Fabricate(:announcement_mute, account: account, announcement: muted_announcement)
-      end
-
-      it 'returns the announcements not muted by the account' do
-        results = described_class.without_muted(account)
-        expect(results).to include(announcement)
-        expect(results).to_not include(muted_announcement)
-      end
-    end
-
     context 'with timestamped announcements' do
       let!(:adam_announcement) { Fabricate(:announcement, starts_at: 100.days.ago, scheduled_at: 10.days.ago, published_at: 10.days.ago, ends_at: 5.days.from_now) }
       let!(:brenda_announcement) { Fabricate(:announcement, starts_at: 10.days.ago, scheduled_at: 100.days.ago, published_at: 10.days.ago, ends_at: 5.days.from_now) }


### PR DESCRIPTION
Last usage removed: https://github.com/mastodon/mastodon/commit/3adc722d1cdd28d87d2724b8952d7ec52d241b52#diff-2bf471f30b2a771e297ce812409cdf04b5e2501657760293e9d0b621f0b75df0L24