### PR TITLE
Use normalizes to prepare `Account#username` value

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -108,6 +108,8 @@ class Account < ApplicationRecord
   validates :shared_inbox_url, absence: true, if: :local?, on: :create
   validates :followers_url, absence: true, if: :local?, on: :create
 
+  normalizes :username, with: ->(username) { username.squish }
+
   scope :remote, -> { where.not(domain: nil) }
   scope :local, -> { where(domain: nil) }
   scope :partitioned, -> { order(Arel.sql('row_number() over (partition by domain)')) }
@@ -475,7 +477,6 @@ class Account < ApplicationRecord
   end
 
   before_validation :prepare_contents, if: :local?
-  before_validation :prepare_username, on: :create
   before_create :generate_keys
   before_destroy :clean_feed_manager
 
@@ -491,10 +492,6 @@ class Account < ApplicationRecord
   def prepare_contents
     display_name&.strip!
     note&.strip!
-  end
-
-  def prepare_username
-    username&.squish!
   end
 
   def generate_keys


### PR DESCRIPTION
This is technically a change ... I think it's safe but would like confirmation on that.

The previous behavior was `on: :change` which meant that the normalization only happened on non-persisted records being validation, but would NOT run on already saved record being updated, for example. However, there is a regex validation around username which would make a username with extra whitespace surrounding it not valid.

This change would make it so that a scenario where an update on a record which is trying to set the username value to an invalid value where the only validity issue is the extra whitespace would previously have been invalid but now would be normalized first and be valid (and be updated). That seems acceptable to me, but would like confirmation. It's not clear from the original commit why it was added on create only (https://github.com/mastodon/mastodon/commit/85537b00695b1091e2a147597ab7c3557b150b11)