### PR TITLE
Remove unused scope `User.emailable`

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -117,7 +117,6 @@ class User < ApplicationRecord
   scope :active, -> { confirmed.where(arel_table[:current_sign_in_at].gteq(ACTIVE_DURATION.ago)).joins(:account).where(accounts: { suspended_at: nil }) }
   scope :matches_email, ->(value) { where(arel_table[:email].matches("#{value}%")) }
   scope :matches_ip, ->(value) { left_joins(:ips).where('user_ips.ip <<= ?', value).group('users.id') }
-  scope :emailable, -> { confirmed.enabled.joins(:account).merge(Account.searchable) }
 
   before_validation :sanitize_languages
   before_validation :sanitize_role


### PR DESCRIPTION
Last usage removed: https://github.com/mastodon/mastodon/commit/0b3e4fd5de392969b624719b2eb3f86277b6ac1f#diff-cfa790db9fff474454cf739012b3b72e71c96cde59407d1a4a67f86e897bc33eL21