### PR TITLE
Remove unused `Announcement#time_range?`

### DIFF
--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -45,10 +45,6 @@ class Announcement < ApplicationRecord
     update!(published: false, scheduled_at: nil)
   end
 
-  def time_range?
-    starts_at? && ends_at?
-  end
-
   def mentions
     @mentions ||= Account.from_text(text)
   end

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -129,32 +129,6 @@ describe Announcement do
     end
   end
 
-  describe '#time_range?' do
-    it 'returns false when starts_at and ends_at are missing' do
-      record = Fabricate.build(:announcement, starts_at: nil, ends_at: nil)
-
-      expect(record.time_range?).to be(false)
-    end
-
-    it 'returns false when starts_at is present and ends_at is missing' do
-      record = Fabricate.build(:announcement, starts_at: 5.days.from_now, ends_at: nil)
-
-      expect(record.time_range?).to be(false)
-    end
-
-    it 'returns false when starts_at is missing and ends_at is present' do
-      record = Fabricate.build(:announcement, starts_at: nil, ends_at: 5.days.from_now)
-
-      expect(record.time_range?).to be(false)
-    end
-
-    it 'returns true when starts_at and ends_at are present' do
-      record = Fabricate.build(:announcement, starts_at: 5.days.from_now, ends_at: 10.days.from_now)
-
-      expect(record.time_range?).to be(true)
-    end
-  end
-
   describe '#reactions' do
     context 'with announcement_reactions present' do
       let!(:account) { Fabricate(:account) }


### PR DESCRIPTION
Last usage removed: https://github.com/mastodon/mastodon/commit/305abc9e05ddb2db6a40a6eda01578e01e58791f#diff-79699598f5a5711046fae31a4d6c6b9e5b8700fdfcc6ca5c83f7f790d4be7bcdL5