### PR TITLE
Remove `add_column_with_default` migration helper

### DIFF
--- a/db/migrate/20170716191202_add_hide_notifications_to_mute.rb
+++ b/db/migrate/20170716191202_add_hide_notifications_to_mute.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require Rails.root.join('lib', 'mastodon', 'migration_helpers')
-
 class AddHideNotificationsToMute < ActiveRecord::Migration[5.1]
-  include Mastodon::MigrationHelpers
-
   disable_ddl_transaction!
 
   def up
-    add_column_with_default :mutes, :hide_notifications, :boolean, default: true, allow_null: false
+    add_column :mutes, :hide_notifications, :boolean, default: true, null: false
   end
 
   def down

--- a/db/migrate/20171005171936_add_disabled_to_custom_emojis.rb
+++ b/db/migrate/20171005171936_add_disabled_to_custom_emojis.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require Rails.root.join('lib', 'mastodon', 'migration_helpers')
-
 class AddDisabledToCustomEmojis < ActiveRecord::Migration[5.2]
-  include Mastodon::MigrationHelpers
-
   disable_ddl_transaction!
 
   def up
-    safety_assured { add_column_with_default :custom_emojis, :disabled, :bool, default: false }
+    safety_assured { add_column :custom_emojis, :disabled, :bool, default: false, null: false }
   end
 
   def down

--- a/db/migrate/20171028221157_add_reblogs_to_follows.rb
+++ b/db/migrate/20171028221157_add_reblogs_to_follows.rb
@@ -1,16 +1,12 @@
 # frozen_string_literal: true
 
-require Rails.root.join('lib', 'mastodon', 'migration_helpers')
-
 class AddReblogsToFollows < ActiveRecord::Migration[5.2]
-  include Mastodon::MigrationHelpers
-
   disable_ddl_transaction!
 
   def up
     safety_assured do
-      add_column_with_default :follows, :show_reblogs, :boolean, default: true, allow_null: false
-      add_column_with_default :follow_requests, :show_reblogs, :boolean, default: true, allow_null: false
+      add_column :follows, :show_reblogs, :boolean, default: true, null: false
+      add_column :follow_requests, :show_reblogs, :boolean, default: true, null: false
     end
   end
 

--- a/db/migrate/20171107143332_add_memorial_to_accounts.rb
+++ b/db/migrate/20171107143332_add_memorial_to_accounts.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require Rails.root.join('lib', 'mastodon', 'migration_helpers')
-
 class AddMemorialToAccounts < ActiveRecord::Migration[5.2]
-  include Mastodon::MigrationHelpers
-
   disable_ddl_transaction!
 
   def up
-    safety_assured { add_column_with_default :accounts, :memorial, :bool, default: false }
+    safety_assured { add_column :accounts, :memorial, :bool, default: false, null: false }
   end
 
   def down

--- a/db/migrate/20171107143624_add_disabled_to_users.rb
+++ b/db/migrate/20171107143624_add_disabled_to_users.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require Rails.root.join('lib', 'mastodon', 'migration_helpers')
-
 class AddDisabledToUsers < ActiveRecord::Migration[5.2]
-  include Mastodon::MigrationHelpers
-
   disable_ddl_transaction!
 
   def up
-    safety_assured { add_column_with_default :users, :disabled, :bool, default: false }
+    safety_assured { add_column :users, :disabled, :bool, default: false, null: false }
   end
 
   def down

--- a/db/migrate/20171109012327_add_moderator_to_accounts.rb
+++ b/db/migrate/20171109012327_add_moderator_to_accounts.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require Rails.root.join('lib', 'mastodon', 'migration_helpers')
-
 class AddModeratorToAccounts < ActiveRecord::Migration[5.2]
-  include Mastodon::MigrationHelpers
-
   disable_ddl_transaction!
 
   def up
-    safety_assured { add_column_with_default :users, :moderator, :bool, default: false }
+    safety_assured { add_column :users, :moderator, :bool, default: false, null: false }
   end
 
   def down

--- a/db/migrate/20171130000000_add_embed_url_to_preview_cards.rb
+++ b/db/migrate/20171130000000_add_embed_url_to_preview_cards.rb
@@ -1,15 +1,11 @@
 # frozen_string_literal: true
 
-require Rails.root.join('lib', 'mastodon', 'migration_helpers')
-
 class AddEmbedURLToPreviewCards < ActiveRecord::Migration[5.2]
-  include Mastodon::MigrationHelpers
-
   disable_ddl_transaction!
 
   def up
     safety_assured do
-      add_column_with_default :preview_cards, :embed_url, :string, default: '', allow_null: false
+      add_column :preview_cards, :embed_url, :string, default: '', null: false
     end
   end
 

--- a/db/migrate/20180615122121_add_autofollow_to_invites.rb
+++ b/db/migrate/20180615122121_add_autofollow_to_invites.rb
@@ -1,15 +1,11 @@
 # frozen_string_literal: true
 
-require Rails.root.join('lib', 'mastodon', 'migration_helpers')
-
 class AddAutofollowToInvites < ActiveRecord::Migration[5.2]
-  include Mastodon::MigrationHelpers
-
   disable_ddl_transaction!
 
   def up
     safety_assured do
-      add_column_with_default :invites, :autofollow, :bool, default: false, allow_null: false
+      add_column :invites, :autofollow, :bool, default: false, null: false
     end
   end
 

--- a/db/migrate/20180707154237_add_whole_word_to_custom_filter.rb
+++ b/db/migrate/20180707154237_add_whole_word_to_custom_filter.rb
@@ -1,15 +1,11 @@
 # frozen_string_literal: true
 
-require Rails.root.join('lib', 'mastodon', 'migration_helpers')
-
 class AddWholeWordToCustomFilter < ActiveRecord::Migration[5.2]
-  include Mastodon::MigrationHelpers
-
   disable_ddl_transaction!
 
   def change
     safety_assured do
-      add_column_with_default :custom_filters, :whole_word, :boolean, default: true, allow_null: false
+      add_column :custom_filters, :whole_word, :boolean, default: true, null: false
     end
   end
 

--- a/db/migrate/20180814171349_add_confidential_to_doorkeeper_application.rb
+++ b/db/migrate/20180814171349_add_confidential_to_doorkeeper_application.rb
@@ -1,19 +1,15 @@
 # frozen_string_literal: true
 
-require Rails.root.join('lib', 'mastodon', 'migration_helpers')
-
 class AddConfidentialToDoorkeeperApplication < ActiveRecord::Migration[5.2]
-  include Mastodon::MigrationHelpers
-
   disable_ddl_transaction!
 
   def up
     safety_assured do
-      add_column_with_default(
+      add_column(
         :oauth_applications,
         :confidential,
         :boolean,
-        allow_null: false,
+        null: false,
         default: true # maintaining backwards compatibility: require secrets
       )
     end

--- a/db/migrate/20181010141500_add_silent_to_mentions.rb
+++ b/db/migrate/20181010141500_add_silent_to_mentions.rb
@@ -1,19 +1,15 @@
 # frozen_string_literal: true
 
-require Rails.root.join('lib', 'mastodon', 'migration_helpers')
-
 class AddSilentToMentions < ActiveRecord::Migration[5.2]
-  include Mastodon::MigrationHelpers
-
   disable_ddl_transaction!
 
   def up
     safety_assured do
-      add_column_with_default(
+      add_column(
         :mentions,
         :silent,
         :boolean,
-        allow_null: false,
+        null: false,
         default: false
       )
     end

--- a/db/migrate/20181017170937_add_reject_reports_to_domain_blocks.rb
+++ b/db/migrate/20181017170937_add_reject_reports_to_domain_blocks.rb
@@ -1,15 +1,11 @@
 # frozen_string_literal: true
 
-require Rails.root.join('lib', 'mastodon', 'migration_helpers')
-
 class AddRejectReportsToDomainBlocks < ActiveRecord::Migration[5.2]
-  include Mastodon::MigrationHelpers
-
   disable_ddl_transaction!
 
   def up
     safety_assured do
-      add_column_with_default :domain_blocks, :reject_reports, :boolean, default: false, allow_null: false
+      add_column :domain_blocks, :reject_reports, :boolean, default: false, null: false
     end
   end
 

--- a/db/migrate/20181018205649_add_unread_to_account_conversations.rb
+++ b/db/migrate/20181018205649_add_unread_to_account_conversations.rb
@@ -1,19 +1,15 @@
 # frozen_string_literal: true
 
-require Rails.root.join('lib', 'mastodon', 'migration_helpers')
-
 class AddUnreadToAccountConversations < ActiveRecord::Migration[5.2]
-  include Mastodon::MigrationHelpers
-
   disable_ddl_transaction!
 
   def up
     safety_assured do
-      add_column_with_default(
+      add_column(
         :account_conversations,
         :unread,
         :boolean,
-        allow_null: false,
+        null: false,
         default: false
       )
     end

--- a/db/migrate/20181127165847_add_show_replies_to_lists.rb
+++ b/db/migrate/20181127165847_add_show_replies_to_lists.rb
@@ -1,19 +1,15 @@
 # frozen_string_literal: true
 
-require Rails.root.join('lib', 'mastodon', 'migration_helpers')
-
 class AddShowRepliesToLists < ActiveRecord::Migration[5.2]
-  include Mastodon::MigrationHelpers
-
   disable_ddl_transaction!
 
   def up
     safety_assured do
-      add_column_with_default(
+      add_column(
         :lists,
         :replies_policy,
         :integer,
-        allow_null: false,
+        null: false,
         default: 0
       )
     end

--- a/db/migrate/20190201012802_add_overwrite_to_imports.rb
+++ b/db/migrate/20190201012802_add_overwrite_to_imports.rb
@@ -1,15 +1,11 @@
 # frozen_string_literal: true
 
-require Rails.root.join('lib', 'mastodon', 'migration_helpers')
-
 class AddOverwriteToImports < ActiveRecord::Migration[5.2]
-  include Mastodon::MigrationHelpers
-
   disable_ddl_transaction!
 
   def up
     safety_assured do
-      add_column_with_default :imports, :overwrite, :boolean, default: false, allow_null: false
+      add_column :imports, :overwrite, :boolean, default: false, null: false
     end
   end
 

--- a/db/migrate/20190306145741_add_lock_version_to_polls.rb
+++ b/db/migrate/20190306145741_add_lock_version_to_polls.rb
@@ -1,19 +1,15 @@
 # frozen_string_literal: true
 
-require Rails.root.join('lib', 'mastodon', 'migration_helpers')
-
 class AddLockVersionToPolls < ActiveRecord::Migration[5.2]
-  include Mastodon::MigrationHelpers
-
   disable_ddl_transaction!
 
   def up
     safety_assured do
-      add_column_with_default(
+      add_column(
         :polls,
         :lock_version,
         :integer,
-        allow_null: false,
+        null: false,
         default: 0
       )
     end

--- a/db/migrate/20190307234537_add_approved_to_users.rb
+++ b/db/migrate/20190307234537_add_approved_to_users.rb
@@ -1,19 +1,15 @@
 # frozen_string_literal: true
 
-require Rails.root.join('lib', 'mastodon', 'migration_helpers')
-
 class AddApprovedToUsers < ActiveRecord::Migration[5.2]
-  include Mastodon::MigrationHelpers
-
   disable_ddl_transaction!
 
   def up
     safety_assured do
-      add_column_with_default(
+      add_column(
         :users,
         :approved,
         :bool,
-        allow_null: false,
+        null: false,
         default: true
       )
     end

--- a/db/migrate/20191001213028_add_lock_version_to_account_stats.rb
+++ b/db/migrate/20191001213028_add_lock_version_to_account_stats.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require Rails.root.join('lib', 'mastodon', 'migration_helpers')
-
 class AddLockVersionToAccountStats < ActiveRecord::Migration[5.2]
-  include Mastodon::MigrationHelpers
-
   disable_ddl_transaction!
 
   def up
-    safety_assured { add_column_with_default :account_stats, :lock_version, :integer, allow_null: false, default: 0 }
+    safety_assured { add_column :account_stats, :lock_version, :integer, null: false, default: 0 }
   end
 
   def down

--- a/db/migrate/20200312144258_add_title_to_account_warning_presets.rb
+++ b/db/migrate/20200312144258_add_title_to_account_warning_presets.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require Rails.root.join('lib', 'mastodon', 'migration_helpers')
-
 class AddTitleToAccountWarningPresets < ActiveRecord::Migration[5.2]
-  include Mastodon::MigrationHelpers
-
   disable_ddl_transaction!
 
   def up
-    safety_assured { add_column_with_default :account_warning_presets, :title, :string, default: '', allow_null: false }
+    safety_assured { add_column :account_warning_presets, :title, :string, default: '', null: false }
   end
 
   def down

--- a/db/migrate/20200917192924_add_notify_to_follows.rb
+++ b/db/migrate/20200917192924_add_notify_to_follows.rb
@@ -1,16 +1,12 @@
 # frozen_string_literal: true
 
-require Rails.root.join('lib', 'mastodon', 'migration_helpers')
-
 class AddNotifyToFollows < ActiveRecord::Migration[5.2]
-  include Mastodon::MigrationHelpers
-
   disable_ddl_transaction!
 
   def up
     safety_assured do
-      add_column_with_default :follows, :notify, :boolean, default: false, allow_null: false
-      add_column_with_default :follow_requests, :notify, :boolean, default: false, allow_null: false
+      add_column :follows, :notify, :boolean, default: false, null: false
+      add_column :follow_requests, :notify, :boolean, default: false, null: false
     end
   end
 

--- a/db/migrate/20201218054746_add_obfuscate_to_domain_blocks.rb
+++ b/db/migrate/20201218054746_add_obfuscate_to_domain_blocks.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require Rails.root.join('lib', 'mastodon', 'migration_helpers')
-
 class AddObfuscateToDomainBlocks < ActiveRecord::Migration[5.2]
-  include Mastodon::MigrationHelpers
-
   disable_ddl_transaction!
 
   def up
-    safety_assured { add_column_with_default :domain_blocks, :obfuscate, :boolean, default: false, allow_null: false }
+    safety_assured { add_column :domain_blocks, :obfuscate, :boolean, default: false, null: false }
   end
 
   def down

--- a/db/migrate/20211231080958_add_category_to_reports.rb
+++ b/db/migrate/20211231080958_add_category_to_reports.rb
@@ -1,15 +1,11 @@
 # frozen_string_literal: true
 
-require Rails.root.join('lib', 'mastodon', 'migration_helpers')
-
 class AddCategoryToReports < ActiveRecord::Migration[6.1]
-  include Mastodon::MigrationHelpers
-
   disable_ddl_transaction!
 
   def up
     safety_assured do
-      add_column_with_default :reports, :category, :int, default: 0, allow_null: false
+      add_column :reports, :category, :int, default: 0, null: false
       change_table(:reports, bulk: true) do |t|
         t.column :action_taken_at, :datetime
         t.column :rule_ids, :bigint, array: true

--- a/db/migrate/20220613110834_add_action_to_custom_filters.rb
+++ b/db/migrate/20220613110834_add_action_to_custom_filters.rb
@@ -1,15 +1,11 @@
 # frozen_string_literal: true
 
-require Rails.root.join('lib', 'mastodon', 'migration_helpers')
-
 class AddActionToCustomFilters < ActiveRecord::Migration[6.1]
-  include Mastodon::MigrationHelpers
-
   disable_ddl_transaction!
 
   def up
     safety_assured do
-      add_column_with_default :custom_filters, :action, :integer, allow_null: false, default: 0
+      add_column :custom_filters, :action, :integer, null: false, default: 0
       execute 'UPDATE custom_filters SET action = 1 WHERE irreversible IS TRUE'
     end
   end

--- a/db/migrate/20230605085710_add_exclusive_to_lists.rb
+++ b/db/migrate/20230605085710_add_exclusive_to_lists.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require Rails.root.join('lib', 'mastodon', 'migration_helpers')
-
 class AddExclusiveToLists < ActiveRecord::Migration[6.1]
-  include Mastodon::MigrationHelpers
-
   disable_ddl_transaction!
 
   def up
-    safety_assured { add_column_with_default :lists, :exclusive, :boolean, default: false, allow_null: false }
+    safety_assured { add_column :lists, :exclusive, :boolean, default: false, null: false }
   end
 
   def down

--- a/db/migrate/20230725213448_add_image_description_to_preview_cards.rb
+++ b/db/migrate/20230725213448_add_image_description_to_preview_cards.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require Rails.root.join('lib', 'mastodon', 'migration_helpers')
-
 class AddImageDescriptionToPreviewCards < ActiveRecord::Migration[7.0]
-  include Mastodon::MigrationHelpers
-
   disable_ddl_transaction!
 
   def up
-    safety_assured { add_column_with_default :preview_cards, :image_description, :string, default: '', allow_null: false }
+    safety_assured { add_column :preview_cards, :image_description, :string, default: '', null: false }
   end
 
   def down

--- a/db/migrate/20230814223300_add_indexable_to_accounts.rb
+++ b/db/migrate/20230814223300_add_indexable_to_accounts.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require Rails.root.join('lib', 'mastodon', 'migration_helpers')
-
 class AddIndexableToAccounts < ActiveRecord::Migration[7.0]
-  include Mastodon::MigrationHelpers
-
   disable_ddl_transaction!
 
   def up
-    safety_assured { add_column_with_default :accounts, :indexable, :boolean, default: false, allow_null: false }
+    safety_assured { add_column :accounts, :indexable, :boolean, default: false, null: false }
   end
 
   def down

--- a/db/post_migrate/20220613110802_remove_whole_word_from_custom_filters.rb
+++ b/db/post_migrate/20220613110802_remove_whole_word_from_custom_filters.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
-require Rails.root.join('lib', 'mastodon', 'migration_helpers')
-
 class RemoveWholeWordFromCustomFilters < ActiveRecord::Migration[6.1]
-  include Mastodon::MigrationHelpers
-
   disable_ddl_transaction!
 
   def up
@@ -15,7 +11,7 @@ class RemoveWholeWordFromCustomFilters < ActiveRecord::Migration[6.1]
 
   def down
     safety_assured do
-      add_column_with_default :custom_filters, :whole_word, :boolean, default: true, allow_null: false
+      add_column :custom_filters, :whole_word, :boolean, default: true, null: false
     end
   end
 end

--- a/db/post_migrate/20220613110903_remove_irreversible_from_custom_filters.rb
+++ b/db/post_migrate/20220613110903_remove_irreversible_from_custom_filters.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
-require Rails.root.join('lib', 'mastodon', 'migration_helpers')
-
 class RemoveIrreversibleFromCustomFilters < ActiveRecord::Migration[6.1]
-  include Mastodon::MigrationHelpers
-
   disable_ddl_transaction!
 
   def up
@@ -15,7 +11,7 @@ class RemoveIrreversibleFromCustomFilters < ActiveRecord::Migration[6.1]
 
   def down
     safety_assured do
-      add_column_with_default :custom_filters, :irreversible, :boolean, allow_null: false, default: false
+      add_column :custom_filters, :irreversible, :boolean, null: false, default: false
     end
   end
 end

--- a/lib/mastodon/migration_helpers.rb
+++ b/lib/mastodon/migration_helpers.rb
@@ -104,18 +104,7 @@ module Mastodon
             'in the body of your migration class'
         end
 
-        # If default value is presented, use `add_column_with_default` method instead.
-        if options[:default]
-          add_column_with_default(
-            table_name,
-            column_name,
-            :datetime_with_timezone,
-            default: options[:default],
-            allow_null: options[:null]
-          )
-        else
-          add_column(table_name, column_name, :datetime_with_timezone, **options)
-        end
+        add_column(table_name, column_name, :datetime_with_timezone, **options)
       end
     end
 
@@ -375,34 +364,6 @@ module Mastodon
         # There are no more rows left to update.
         break unless stop_row
       end
-    end
-
-    # Adds a column with a default value without locking an entire table.
-    #
-    # This method runs the following steps:
-    #
-    # 1. Add the column with a default value of NULL.
-    # 2. Change the default value of the column to the specified value.
-    # 3. Update all existing rows in batches.
-    # 4. Set a `NOT NULL` constraint on the column if desired (the default).
-    #
-    # These steps ensure a column can be added to a large and commonly used
-    # table without locking the entire table for the duration of the table
-    # modification.
-    #
-    # table - The name of the table to update.
-    # column - The name of the column to add.
-    # type - The column type (e.g. `:integer`).
-    # default - The default value for the column.
-    # limit - Sets a column limit. For example, for :integer, the default is
-    #         4-bytes. Set `limit: 8` to allow 8-byte integers.
-    # allow_null - When set to `true` the column will allow NULL values, the
-    #              default is to not allow NULL values.
-    #
-    # This method can also take a block which is passed directly to the
-    # `update_column_in_batches` method.
-    def add_column_with_default(table, column, type, default:, limit: nil, allow_null: false, &block)
-      add_column(table, column, type, default: default, limit: limit, null: allow_null)
     end
 
     # Renames a column without requiring downtime.


### PR DESCRIPTION
In a previous commit we removed the bulk of this method: https://github.com/mastodon/mastodon/commit/4aa05d45fc45b797e0a3b7d40885ef89c2161a73#diff-006ad05199b268fb6057c942a06c939ad2f1da6f43cdc1260e5cfb1806560cd5L423-L458

With the postgres 12+ requirement, we didn't need the conditional behavior anymore -- however, with all that removed, the method is just a thin wrapper (with almost the same signature) as the built-in framework method to do the same thing.

This updates all the migrations which were using that helper method to just use the method directly, and modifies their signatures to pass in `null` instead of `allow_null` (which the method was passing along to underlying as a `null` option) where they were doing so, or adding a `null: false` where they were relying on the default.

I believe that all generated SQL and migration logic should not change here (and confirmed by doing full migration and verifying db/schema is same) -- just a further clean-up of this method after the initial work.