### PR TITLE
Extract capybara config and improve headless_chrome driver config

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -108,8 +108,6 @@ RSpec.configure do |config|
   end
 
   config.around :each, type: :system do |example|
-    driven_by :selenium, using: :headless_chrome, screen_size: [1600, 1200]
-
     # The streaming server needs access to the database
     # but with use_transactional_tests every transaction
     # is rolled-back, so the streaming server never sees the data

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+Capybara.server_host = 'localhost'
+Capybara.server_port = 3000
+Capybara.app_host = "http://#{Capybara.server_host}:#{Capybara.server_port}"
+
+require 'selenium/webdriver'
+
+Capybara.register_driver :chrome do |app|
+  Capybara::Selenium::Driver.new(app, browser: :chrome)
+end
+
+Capybara.register_driver :headless_chrome do |app|
+  options = Selenium::WebDriver::Chrome::Options.new
+  options.add_argument '--headless=new'
+  options.add_argument '--window-size=1680,1050'
+
+  Capybara::Selenium::Driver.new(
+    app,
+    browser: :chrome,
+    options: options
+  )
+end
+
+Capybara.javascript_driver = :headless_chrome
+
+RSpec.configure do |config|
+  config.before(:each, type: :system) do
+    driven_by Capybara.javascript_driver
+  end
+end


### PR DESCRIPTION
This is basically JUST the config/file changes from https://github.com/mastodon/mastodon/pull/27732, but not also the system/js/tag re-org.

The other PR was preemptively introducing a `js` rspec tag in advance of other anticipated changes -- but for now anyway, every spec in spec/system does in fact need to run with the full JS selenium config, so this is fine.

The `headless_chrome` definition that ships with selenium by default does not let us do the "catch and raise on JS errors" portion (See other PR), which is why it's defined again here. Once we get this config change in I'll open another PR to add the errors thing, and then we can revisit the other tags/directories/naming stuff.