### PR TITLE
Add JS console errors check

### DIFF
--- a/lib/tasks/spec.rake
+++ b/lib/tasks/spec.rake
@@ -3,6 +3,8 @@
 if Rake::Task.task_defined?('spec:system')
   namespace :spec do
     task :enable_system_specs do # rubocop:disable Rails/RakeEnvironment
+      ENV['LOCAL_DOMAIN'] = 'localhost:3000'
+      ENV['LOCAL_HTTPS'] = 'false'
       ENV['RUN_SYSTEM_SPECS'] = 'true'
     end
   end

--- a/spec/support/javascript_errors.rb
+++ b/spec/support/javascript_errors.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  config.after(:each, type: :system) do
+    errors = page.driver.browser.logs.get(:browser)
+    if errors.present?
+      aggregate_failures 'javascript errrors' do
+        errors.each do |error|
+          expect(error.level).to_not eq('SEVERE'), error.message
+          next unless error.level == 'WARNING'
+
+          $stderr.warn 'WARN: javascript warning'
+          $stderr.warn error.message
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Pulls out just the JS errors catching portions of https://github.com/mastodon/mastodon/pull/27732

For this initial version I've had it only care about `SEVERE` level JS errors. This would have caught some of the recent JS issues we've had ... in the future if we want to tighten this up even further we could have it raise on `WARNING` as well ... but I know there actually are a bunch of those now, so we'd have to clean up as well.

Like the last PR adjusting capybara config, I've updated this to just apply to ALL system specs for now, since they all use the JS driver.

The constants are needed to align the capybara driver hostname expectations with the running rails server. A good future refactor here would be to further align this so that we don't need a setting just for the system specs, and can use the same value in the whole suite.