### PR TITLE
Move streaming `around` config into manager class

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -107,21 +107,6 @@ RSpec.configure do |config|
     Capybara.current_driver = :rack_test
   end
 
-  config.around :each, type: :system do |example|
-    # The streaming server needs access to the database
-    # but with use_transactional_tests every transaction
-    # is rolled-back, so the streaming server never sees the data
-    # So we disable this feature for system tests, and use DatabaseCleaner to clean
-    # the database tables between each test
-    self.use_transactional_tests = false
-
-    DatabaseCleaner.cleaning do
-      example.run
-    end
-
-    self.use_transactional_tests = true
-  end
-
   config.before do |example|
     allow(Resolv::DNS).to receive(:open).and_raise('Real DNS queries are disabled, stub Resolv::DNS as needed') unless example.metadata[:type] == :system
   end

--- a/spec/support/streaming_server_manager.rb
+++ b/spec/support/streaming_server_manager.rb
@@ -95,6 +95,19 @@ RSpec.configure do |config|
     end
   end
 
+  config.around :each, type: :system do |example|
+    # Streaming server needs DB access but `use_transactional_tests` rolls back
+    # every transaction. Disable this feature for streaming tests, and use
+    # DatabaseCleaner to clean the database tables between each test.
+    self.use_transactional_tests = false
+
+    DatabaseCleaner.cleaning do
+      example.run
+    end
+
+    self.use_transactional_tests = true
+  end
+
   private
 
   def streaming_server_manager


### PR DESCRIPTION
This is another element pulled out from https://github.com/mastodon/mastodon/pull/27932 which does not make the tags/naming changes.

This basically aligns how we configure this for the streaming manager to align with how the search manager works.