### PR TITLE
Fix `LineLength` haml-lint in `t` usage

### DIFF
--- a/app/views/admin/account_warnings/_account_warning.html.haml
+++ b/app/views/admin/account_warnings/_account_warning.html.haml
@@ -5,7 +5,10 @@
         = fa_icon 'warning'
     .log-entry__content
       .log-entry__title
-        = t(account_warning.action, scope: 'admin.strikes.actions', name: content_tag(:span, account_warning.account ? account_warning.account.username : I18n.t('admin.action_logs.deleted_account'), class: 'username'), target: content_tag(:span, account_warning.target_account.pretty_acct, class: 'target')).html_safe
+        = t(account_warning.action,
+            scope: 'admin.strikes.actions',
+            name: content_tag(:span, account_warning.account ? account_warning.account.username : I18n.t('admin.action_logs.deleted_account'), class: 'username'),
+            target: content_tag(:span, account_warning.target_account.pretty_acct, class: 'target')).html_safe
       .log-entry__timestamp
         %time.formatted{ datetime: account_warning.created_at.iso8601 }
           = l(account_warning.created_at)

--- a/app/views/admin/action_logs/_action_log.html.haml
+++ b/app/views/admin/action_logs/_action_log.html.haml
@@ -4,6 +4,8 @@
       = image_tag action_log.account.avatar.url(:original), alt: '', width: 40, height: 40, class: 'avatar'
     .log-entry__content
       .log-entry__title
-        = t("admin.action_logs.actions.#{action_log.action}_#{action_log.target_type.underscore}_html", name: content_tag(:span, action_log.account.username, class: 'username'), target: content_tag(:span, log_target(action_log), class: 'target'))
+        = t "admin.action_logs.actions.#{action_log.action}_#{action_log.target_type.underscore}_html",
+            name: content_tag(:span, action_log.account.username, class: 'username'),
+            target: content_tag(:span, log_target(action_log), class: 'target')
       .log-entry__timestamp
         %time.formatted{ datetime: action_log.created_at.iso8601 }

--- a/app/views/mail_subscriptions/show.html.haml
+++ b/app/views/mail_subscriptions/show.html.haml
@@ -4,7 +4,11 @@
 .simple_form
   %h1.title= t('mail_subscriptions.unsubscribe.title')
   %p.lead
-    = t('mail_subscriptions.unsubscribe.confirmation_html', domain: content_tag(:strong, site_hostname), type: content_tag(:strong, I18n.t(@type, scope: 'mail_subscriptions.unsubscribe.emails')), email: content_tag(:strong, @user.email), settings_path: settings_preferences_notifications_path)
+    = t 'mail_subscriptions.unsubscribe.confirmation_html',
+        domain: content_tag(:strong, site_hostname),
+        type: content_tag(:strong, I18n.t(@type, scope: 'mail_subscriptions.unsubscribe.emails')),
+        email: content_tag(:strong, @user.email),
+        settings_path: settings_preferences_notifications_path
 
   = form_tag unsubscribe_path, method: :post do
     = hidden_field_tag :token, params[:token]

--- a/app/views/user_mailer/appeal_approved.html.haml
+++ b/app/views/user_mailer/appeal_approved.html.haml
@@ -36,7 +36,9 @@
                         %tbody
                           %tr
                             %td.column-cell.text-center
-                              %p= t 'user_mailer.appeal_approved.explanation', appeal_date: l(@appeal.created_at.in_time_zone(@resource.time_zone.presence), format: :with_time_zone), strike_date: l(@appeal.strike.created_at.in_time_zone(@resource.time_zone.presence), format: :with_time_zone)
+                              %p= t 'user_mailer.appeal_approved.explanation',
+                                    appeal_date: l(@appeal.created_at.in_time_zone(@resource.time_zone.presence), format: :with_time_zone),
+                                    strike_date: l(@appeal.strike.created_at.in_time_zone(@resource.time_zone.presence), format: :with_time_zone)
 
 %table.email-table{ cellspacing: 0, cellpadding: 0 }
   %tbody

--- a/app/views/user_mailer/appeal_rejected.html.haml
+++ b/app/views/user_mailer/appeal_rejected.html.haml
@@ -36,7 +36,9 @@
                         %tbody
                           %tr
                             %td.column-cell.text-center
-                              %p= t 'user_mailer.appeal_rejected.explanation', appeal_date: l(@appeal.created_at.in_time_zone(@resource.time_zone.presence), format: :with_time_zone), strike_date: l(@appeal.strike.created_at.in_time_zone(@resource.time_zone.presence), format: :with_time_zone)
+                              %p= t 'user_mailer.appeal_rejected.explanation',
+                                    appeal_date: l(@appeal.created_at.in_time_zone(@resource.time_zone.presence), format: :with_time_zone),
+                                    strike_date: l(@appeal.strike.created_at.in_time_zone(@resource.time_zone.presence), format: :with_time_zone)
 
 %table.email-table{ cellspacing: 0, cellpadding: 0 }
   %tbody

--- a/app/views/user_mailer/suspicious_sign_in.html.haml
+++ b/app/views/user_mailer/suspicious_sign_in.html.haml
@@ -45,7 +45,10 @@
                                 = @remote_ip
                                 %br/
                                 %strong #{t('sessions.browser')}:
-                                %span{ title: @user_agent }= t 'sessions.description', browser: t("sessions.browsers.#{@detection.id}", default: @detection.id.to_s), platform: t("sessions.platforms.#{@detection.platform.id}", default: @detection.platform.id.to_s)
+                                %span{ title: @user_agent }
+                                  = t 'sessions.description',
+                                      browser: t("sessions.browsers.#{@detection.id}", default: @detection.id.to_s),
+                                      platform: t("sessions.platforms.#{@detection.platform.id}", default: @detection.platform.id.to_s)
                                 %br/
                                 = l(@timestamp.in_time_zone(@resource.time_zone.presence), format: :with_time_zone)
 
@@ -64,4 +67,5 @@
                         %tbody
                           %tr
                             %td.column-cell.text-center
-                              %p= t 'user_mailer.suspicious_sign_in.further_actions_html', action: link_to(t('user_mailer.suspicious_sign_in.change_password'), edit_user_registration_url)
+                              %p= t 'user_mailer.suspicious_sign_in.further_actions_html',
+                                    action: link_to(t('user_mailer.suspicious_sign_in.change_password'), edit_user_registration_url)


### PR DESCRIPTION
While working on https://github.com/mastodon/mastodon/pull/28680 and the few prior to that, I noticed a few of these lengthly translation lines which will need to be cleaned up if we want to further reduce the `LineLength` setting a bit more.

Markup should not have changed.