### PR TITLE
Refactor login activity partial (remove inline ruby)

### DIFF
--- a/app/helpers/admin/settings_helper.rb
+++ b/app/helpers/admin/settings_helper.rb
@@ -4,4 +4,21 @@ module Admin::SettingsHelper
   def captcha_available?
     ENV['HCAPTCHA_SECRET_KEY'].present? && ENV['HCAPTCHA_SITE_KEY'].present?
   end
+
+  def login_activity_title(login_activity)
+    t (login_activity.success? ? 'successful_sign_in_html' : 'failed_sign_in_html'),
+      scope: :login_activities,
+      method: content_tag(:span,
+                          login_activity.omniauth? ? t(login_activity.provider, scope: 'auth.providers') : t(login_activity.authentication_method, scope: 'login_activities.authentication_methods'),
+                          class: 'target'),
+      ip: content_tag(:span,
+                      login_activity.ip,
+                      class: 'target'),
+      browser: content_tag(:span,
+                           t('sessions.description',
+                             browser: t("sessions.browsers.#{login_activity.browser}", default: login_activity.browser.to_s),
+                             platform: t("sessions.platforms.#{login_activity.platform}", default: login_activity.platform.to_s)),
+                           class: 'target',
+                           title: login_activity.user_agent)
+  end
 end

--- a/app/helpers/admin/settings_helper.rb
+++ b/app/helpers/admin/settings_helper.rb
@@ -5,20 +5,60 @@ module Admin::SettingsHelper
     ENV['HCAPTCHA_SECRET_KEY'].present? && ENV['HCAPTCHA_SITE_KEY'].present?
   end
 
-  def login_activity_title(login_activity)
-    t (login_activity.success? ? 'successful_sign_in_html' : 'failed_sign_in_html'),
+  def login_activity_title(activity)
+    t(
+      login_activity_key(activity),
       scope: :login_activities,
-      method: content_tag(:span,
-                          login_activity.omniauth? ? t(login_activity.provider, scope: 'auth.providers') : t(login_activity.authentication_method, scope: 'login_activities.authentication_methods'),
-                          class: 'target'),
-      ip: content_tag(:span,
-                      login_activity.ip,
-                      class: 'target'),
-      browser: content_tag(:span,
-                           t('sessions.description',
-                             browser: t("sessions.browsers.#{login_activity.browser}", default: login_activity.browser.to_s),
-                             platform: t("sessions.platforms.#{login_activity.platform}", default: login_activity.platform.to_s)),
-                           class: 'target',
-                           title: login_activity.user_agent)
+      method: login_activity_method(activity),
+      ip: login_activity_ip(activity),
+      browser: login_activity_browser(activity)
+    )
+  end
+
+  private
+
+  def login_activity_key(activity)
+    activity.success? ? 'successful_sign_in_html' : 'failed_sign_in_html'
+  end
+
+  def login_activity_method(activity)
+    content_tag(
+      :span,
+      login_activity_method_string(activity),
+      class: 'target'
+    )
+  end
+
+  def login_activity_ip(activity)
+    content_tag(
+      :span,
+      activity.ip,
+      class: 'target'
+    )
+  end
+
+  def login_activity_browser(activity)
+    content_tag(
+      :span,
+      login_activity_browser_description(activity),
+      class: 'target',
+      title: activity.user_agent
+    )
+  end
+
+  def login_activity_method_string(activity)
+    if activity.omniauth?
+      t(activity.provider, scope: 'auth.providers')
+    else
+      t(activity.authentication_method, scope: 'login_activities.authentication_methods')
+    end
+  end
+
+  def login_activity_browser_description(activity)
+    t(
+      'sessions.description',
+      browser: t(activity.browser, scope: 'sessions.browsers', default: activity.browser.to_s),
+      platform: t(activity.platform, scope: 'sessions.platforms', default: activity.platform.to_s)
+    )
   end
 end

--- a/app/helpers/admin/settings_helper.rb
+++ b/app/helpers/admin/settings_helper.rb
@@ -7,8 +7,7 @@ module Admin::SettingsHelper
 
   def login_activity_title(activity)
     t(
-      login_activity_key(activity),
-      scope: :login_activities,
+      "login_activities.#{login_activity_key(activity)}",
       method: login_activity_method(activity),
       ip: login_activity_ip(activity),
       browser: login_activity_browser(activity)
@@ -48,9 +47,9 @@ module Admin::SettingsHelper
 
   def login_activity_method_string(activity)
     if activity.omniauth?
-      t(activity.provider, scope: 'auth.providers')
+      t("auth.providers.#{activity.provider}")
     else
-      t(activity.authentication_method, scope: 'login_activities.authentication_methods')
+      t("login_activities.authentication_methods.#{activity.authentication_method}")
     end
   end
 

--- a/app/views/settings/login_activities/_login_activity.html.haml
+++ b/app/views/settings/login_activities/_login_activity.html.haml
@@ -10,9 +10,10 @@
         = fa_icon login_activity.success? ? 'check' : 'times'
     .log-entry__content
       .log-entry__title
-        - if login_activity.success?
-          = t('login_activities.successful_sign_in_html', method: method_str, ip: ip_str, browser: browser_str)
-        - else
-          = t('login_activities.failed_sign_in_html', method: method_str, ip: ip_str, browser: browser_str)
+        = t (login_activity.success? ? 'successful_sign_in_html' : 'failed_sign_in_html'),
+            scope: :login_activities,
+            method: method_str,
+            ip: ip_str,
+            browser: browser_str
       .log-entry__timestamp
         %time.formatted{ datetime: login_activity.created_at.iso8601 }= l(login_activity.created_at)

--- a/app/views/settings/login_activities/_login_activity.html.haml
+++ b/app/views/settings/login_activities/_login_activity.html.haml
@@ -1,6 +1,5 @@
 :ruby
   method_str = content_tag(:span, login_activity.omniauth? ? t(login_activity.provider, scope: 'auth.providers') : t(login_activity.authentication_method, scope: 'login_activities.authentication_methods'), class: 'target')
-  browser_str = content_tag(:span, t('sessions.description', browser: t("sessions.browsers.#{login_activity.browser}", default: login_activity.browser.to_s), platform: t("sessions.platforms.#{login_activity.platform}", default: login_activity.platform.to_s)), class: 'target', title: login_activity.user_agent)
 
 .log-entry
   .log-entry__header
@@ -13,6 +12,6 @@
             scope: :login_activities,
             method: method_str,
             ip: content_tag(:span, login_activity.ip, class: 'target'),
-            browser: browser_str
+            browser: content_tag(:span, t('sessions.description', browser: t("sessions.browsers.#{login_activity.browser}", default: login_activity.browser.to_s), platform: t("sessions.platforms.#{login_activity.platform}", default: login_activity.platform.to_s)), class: 'target', title: login_activity.user_agent)
       .log-entry__timestamp
         %time.formatted{ datetime: login_activity.created_at.iso8601 }= l(login_activity.created_at)

--- a/app/views/settings/login_activities/_login_activity.html.haml
+++ b/app/views/settings/login_activities/_login_activity.html.haml
@@ -5,10 +5,6 @@
         = fa_icon login_activity.success? ? 'check' : 'times'
     .log-entry__content
       .log-entry__title
-        = t (login_activity.success? ? 'successful_sign_in_html' : 'failed_sign_in_html'),
-            scope: :login_activities,
-            method: content_tag(:span, login_activity.omniauth? ? t(login_activity.provider, scope: 'auth.providers') : t(login_activity.authentication_method, scope: 'login_activities.authentication_methods'), class: 'target'),
-            ip: content_tag(:span, login_activity.ip, class: 'target'),
-            browser: content_tag(:span, t('sessions.description', browser: t("sessions.browsers.#{login_activity.browser}", default: login_activity.browser.to_s), platform: t("sessions.platforms.#{login_activity.platform}", default: login_activity.platform.to_s)), class: 'target', title: login_activity.user_agent)
+        = login_activity_title(login_activity)
       .log-entry__timestamp
         %time.formatted{ datetime: login_activity.created_at.iso8601 }= l(login_activity.created_at)

--- a/app/views/settings/login_activities/_login_activity.html.haml
+++ b/app/views/settings/login_activities/_login_activity.html.haml
@@ -1,6 +1,5 @@
 :ruby
   method_str = content_tag(:span, login_activity.omniauth? ? t(login_activity.provider, scope: 'auth.providers') : t(login_activity.authentication_method, scope: 'login_activities.authentication_methods'), class: 'target')
-  ip_str = content_tag(:span, login_activity.ip, class: 'target')
   browser_str = content_tag(:span, t('sessions.description', browser: t("sessions.browsers.#{login_activity.browser}", default: login_activity.browser.to_s), platform: t("sessions.platforms.#{login_activity.platform}", default: login_activity.platform.to_s)), class: 'target', title: login_activity.user_agent)
 
 .log-entry
@@ -13,7 +12,7 @@
         = t (login_activity.success? ? 'successful_sign_in_html' : 'failed_sign_in_html'),
             scope: :login_activities,
             method: method_str,
-            ip: ip_str,
+            ip: content_tag(:span, login_activity.ip, class: 'target'),
             browser: browser_str
       .log-entry__timestamp
         %time.formatted{ datetime: login_activity.created_at.iso8601 }= l(login_activity.created_at)

--- a/app/views/settings/login_activities/_login_activity.html.haml
+++ b/app/views/settings/login_activities/_login_activity.html.haml
@@ -1,6 +1,3 @@
-:ruby
-  method_str = content_tag(:span, login_activity.omniauth? ? t(login_activity.provider, scope: 'auth.providers') : t(login_activity.authentication_method, scope: 'login_activities.authentication_methods'), class: 'target')
-
 .log-entry
   .log-entry__header
     .log-entry__avatar
@@ -10,7 +7,7 @@
       .log-entry__title
         = t (login_activity.success? ? 'successful_sign_in_html' : 'failed_sign_in_html'),
             scope: :login_activities,
-            method: method_str,
+            method: content_tag(:span, login_activity.omniauth? ? t(login_activity.provider, scope: 'auth.providers') : t(login_activity.authentication_method, scope: 'login_activities.authentication_methods'), class: 'target'),
             ip: content_tag(:span, login_activity.ip, class: 'target'),
             browser: content_tag(:span, t('sessions.description', browser: t("sessions.browsers.#{login_activity.browser}", default: login_activity.browser.to_s), platform: t("sessions.platforms.#{login_activity.platform}", default: login_activity.platform.to_s)), class: 'target', title: login_activity.user_agent)
       .log-entry__timestamp

--- a/spec/controllers/settings/login_activities_controller_spec.rb
+++ b/spec/controllers/settings/login_activities_controller_spec.rb
@@ -6,6 +6,7 @@ describe Settings::LoginActivitiesController do
   render_views
 
   let!(:user) { Fabricate(:user) }
+  let!(:login_activity) { Fabricate :login_activity, user: user }
 
   before do
     sign_in user, scope: :user
@@ -19,6 +20,10 @@ describe Settings::LoginActivitiesController do
     it 'returns http success with private cache control headers', :aggregate_failures do
       expect(response).to have_http_status(200)
       expect(response.headers['Cache-Control']).to include('private, no-store')
+      expect(response.body)
+        .to include(login_activity.user_agent)
+        .and include(login_activity.authentication_method)
+        .and include(login_activity.ip.to_s)
     end
   end
 end


### PR DESCRIPTION
Noticed this big block of ruby near top of this partial while working on https://github.com/mastodon/mastodon/pull/28680

The HAML guide recommends keeping logic like this out of views and putting into controllers/helpers where possible.

There was a spec here, but it was not loading any records. Added basic assertion about a new record there.

The commits here go step by step pretty small change each time if the diff here is large.