### PR TITLE
Add coverage for `Account.followable_by` scope

### DIFF
--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -1009,4 +1009,27 @@ RSpec.describe Account do
       expect(subject.reload.followers_count).to eq 15
     end
   end
+
+  describe '.followable_by' do
+    context 'with follows and follow requests' do
+      let!(:account) { Fabricate(:account) }
+      let!(:eligible_account) { Fabricate(:account) }
+      let!(:following_account) { Fabricate(:account) }
+      let!(:follow_requested_account) { Fabricate(:account) }
+
+      before do
+        Fabricate :follow, account: account, target_account: following_account
+        Fabricate :follow_request, account: account, target_account: follow_requested_account
+      end
+
+      it 'returns accounts not already following or requested to follow' do
+        results = described_class.followable_by(account)
+
+        expect(results)
+          .to include(eligible_account)
+          .and not_include(following_account)
+          .and not_include(follow_requested_account)
+      end
+    end
+  end
 end


### PR DESCRIPTION
I'd like to do another round on https://github.com/mastodon/mastodon/pull/26179 and/or try another approach (multiple smaller scopes that combine), but figured having some basic coverage in place for the scope might assist in being confident when we change it.

No code change here yet, just spec.