### PR TITLE
Move followable_by coverage to suggestions

### DIFF
--- a/spec/fabricators/follow_recommendation_mute_fabricator.rb
+++ b/spec/fabricators/follow_recommendation_mute_fabricator.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+Fabricator(:follow_recommendation_mute) do
+  account { Fabricate.build(:account) }
+  target_account { Fabricate.build(:account) }
+end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -1011,27 +1011,4 @@ RSpec.describe Account do
       expect(subject.reload.followers_count).to eq 15
     end
   end
-
-  describe '.followable_by' do
-    context 'with follows and follow requests' do
-      let!(:account) { Fabricate(:account) }
-      let!(:eligible_account) { Fabricate(:account) }
-      let!(:following_account) { Fabricate(:account) }
-      let!(:follow_requested_account) { Fabricate(:account) }
-
-      before do
-        Fabricate :follow, account: account, target_account: following_account
-        Fabricate :follow_request, account: account, target_account: follow_requested_account
-      end
-
-      it 'returns accounts not already following or requested to follow' do
-        results = described_class.followable_by(account)
-
-        expect(results)
-          .to include(eligible_account)
-          .and not_include(following_account)
-          .and not_include(follow_requested_account)
-      end
-    end
-  end
 end

--- a/spec/models/account_suggestions/source_spec.rb
+++ b/spec/models/account_suggestions/source_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AccountSuggestions::Source do
+  describe '#base_account_scope' do
+    subject { FakeSource.new }
+
+    before do
+      stub_const 'FakeSource', fake_source_class
+    end
+
+    context 'with follows and follow requests' do
+      let!(:account_domain_blocked_account) { Fabricate(:account, domain: 'blocked.host') }
+      let!(:account) { Fabricate(:account) }
+      let!(:blocked_account) { Fabricate(:account) }
+      let!(:eligible_account) { Fabricate(:account) }
+      let!(:follow_recommendation_muted_account) { Fabricate(:account) }
+      let!(:follow_requested_account) { Fabricate(:account) }
+      let!(:following_account) { Fabricate(:account) }
+
+      before do
+        Fabricate :account_domain_block, account: account, domain: account_domain_blocked_account.domain
+        Fabricate :block, account: account, target_account: blocked_account
+        Fabricate :follow_recommendation_mute, account: account, target_account: follow_recommendation_muted_account
+        Fabricate :follow_request, account: account, target_account: follow_requested_account
+        Fabricate :follow, account: account, target_account: following_account
+      end
+
+      it 'returns eligible accounts' do
+        results = subject.get(account)
+
+        expect(results)
+          .to include(eligible_account)
+          .and not_include(account_domain_blocked_account)
+          .and not_include(account)
+          .and not_include(blocked_account)
+          .and not_include(follow_recommendation_muted_account)
+          .and not_include(follow_requested_account)
+          .and not_include(following_account)
+      end
+    end
+  end
+
+  private
+
+  def fake_source_class
+    Class.new described_class do
+      def get(account, limit: 10)
+        base_account_scope(account)
+          .limit(limit)
+      end
+    end
+  end
+end

--- a/spec/models/account_suggestions/source_spec.rb
+++ b/spec/models/account_suggestions/source_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe AccountSuggestions::Source do
       let!(:follow_recommendation_muted_account) { Fabricate(:account) }
       let!(:follow_requested_account) { Fabricate(:account) }
       let!(:following_account) { Fabricate(:account) }
+      let!(:moved_account) { Fabricate(:account, moved_to_account: Fabricate(:account)) }
 
       before do
         Fabricate :account_domain_block, account: account, domain: account_domain_blocked_account.domain
@@ -38,6 +39,7 @@ RSpec.describe AccountSuggestions::Source do
           .and not_include(follow_recommendation_muted_account)
           .and not_include(follow_requested_account)
           .and not_include(following_account)
+          .and not_include(moved_account)
       end
     end
   end


### PR DESCRIPTION
Discussed in https://github.com/mastodon/mastodon/pull/26179#issuecomment-1887355722

The `Account.followable_by` scope is only used by `AccountSuggestions::Source`. This change moves the previously added spec coverage there, and adds coverage for more of the base-case conditions handled by the `base_account_scope`. I'm not sure its fully exhaustive, but its an improvement on the current lack of coverage.

Will follow this up with another change idea along lines of linked comment.