### PR TITLE
Use the assets pipeline to load `inert.css`

### DIFF
--- a/app/javascript/packs/inert.js
+++ b/app/javascript/packs/inert.js
@@ -1,0 +1,4 @@
+/* Placeholder file to have `inert.scss` compiled by Webpack
+   This is used by the `wicg-inert` polyfill */
+
+import '../styles/inert.scss';

--- a/app/javascript/styles/inert.scss
+++ b/app/javascript/styles/inert.scss
@@ -1,3 +1,5 @@
+/* This is needed for the wicg-inert polyfill */
+
 [inert] {
   pointer-events: none;
   cursor: default;

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -28,12 +28,14 @@
 
     = stylesheet_pack_tag 'common', media: 'all', crossorigin: 'anonymous'
     = stylesheet_pack_tag current_theme, media: 'all', crossorigin: 'anonymous'
+    -# Needed for the wicg-inert polyfill. It needs to be on it's own <style> tag, with this `id`
+    = stylesheet_pack_tag 'inert', media: 'all', id: 'inert-style'
+
     = javascript_pack_tag 'common', crossorigin: 'anonymous'
     = preload_pack_asset "locale/#{I18n.locale}-json.js"
     = csrf_meta_tags unless skip_csrf_meta_tags?
     %meta{ name: 'style-nonce', content: request.content_security_policy_nonce }
 
-    = stylesheet_link_tag '/inert.css', skip_pipeline: true, media: 'all', id: 'inert-style'
     = stylesheet_link_tag custom_css_path, skip_pipeline: true, host: root_url, media: 'all'
 
     = yield :header_tags


### PR DESCRIPTION
It standardizes it with the other stylesheets, makes it loaded from the assets domain (if configured), have the correct headers (as it is with the other stylesheets) and have SRI attributes.