### PR TITLE
Add coverage/bugfix for invalid appeal submission

### DIFF
--- a/app/views/disputes/strikes/show.html.haml
+++ b/app/views/disputes/strikes/show.html.haml
@@ -21,7 +21,7 @@
 
 .report-header
   .report-header__card
-    = render 'card', strike: @strike
+    = render 'disputes/strikes/card', strike: @strike
 
   .report-header__details
     .report-header__details__item

--- a/spec/controllers/disputes/appeals_controller_spec.rb
+++ b/spec/controllers/disputes/appeals_controller_spec.rb
@@ -10,19 +10,38 @@ RSpec.describe Disputes::AppealsController do
   let!(:admin) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
 
   describe '#create' do
-    let(:current_user) { Fabricate(:user) }
-    let(:strike) { Fabricate(:account_warning, target_account: current_user.account) }
+    context 'with valid params' do
+      let(:current_user) { Fabricate(:user) }
+      let(:strike) { Fabricate(:account_warning, target_account: current_user.account) }
 
-    before do
-      post :create, params: { strike_id: strike.id, appeal: { text: 'Foo' } }
+      before do
+        post :create, params: { strike_id: strike.id, appeal: { text: 'Foo' } }
+      end
+
+      it 'notifies staff about new appeal', :sidekiq_inline do
+        expect(ActionMailer::Base.deliveries.first.to).to eq([admin.email])
+      end
+
+      it 'redirects back to the strike page' do
+        expect(response).to redirect_to(disputes_strike_path(strike.id))
+      end
     end
 
-    it 'notifies staff about new appeal', :sidekiq_inline do
-      expect(ActionMailer::Base.deliveries.first.to).to eq([admin.email])
-    end
+    context 'with invalid params' do
+      let(:current_user) { Fabricate(:user) }
+      let(:strike) { Fabricate(:account_warning, target_account: current_user.account) }
 
-    it 'redirects back to the strike page' do
-      expect(response).to redirect_to(disputes_strike_path(strike.id))
+      before do
+        post :create, params: { strike_id: strike.id, appeal: { text: '' } }
+      end
+
+      it 'does not send email', :sidekiq_inline do
+        expect(ActionMailer::Base.deliveries.size).to eq(0)
+      end
+
+      it 'renders the strike show page' do
+        expect(response).to render_template('disputes/strikes/show')
+      end
     end
   end
 end


### PR DESCRIPTION
When the appeals controller runs here, the view path does not find this file but does find an application/_card partial (in view path all the time) and currently errors out on an invalid data submission.

Spec here exposes the issue, code change is to just be explicit about the partial and not rely on view path since we potentially use it from multiple controllers.