### PR TITLE
Improve `lint-staged` config

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -73,3 +73,5 @@ app/javascript/styles/mastodon/reset.scss
 
 # Ignore the generated AUTHORS.md
 AUTHORS.md
+
+!lint-staged.config.js

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,0 +1,11 @@
+const config = {
+  '*': 'prettier --ignore-unknown --write',
+  'Capfile|Gemfile|*.{rb,ruby,ru,rake}':
+    'bundle exec rubocop --force-exclusion -a',
+  '*.{js,jsx,ts,tsx}': 'eslint --fix',
+  '*.{css,scss}': 'stylelint --fix',
+  '*.haml': 'bundle exec haml-lint -a',
+  '**/*.ts?(x)': () => 'tsc -p tsconfig.json --noEmit',
+};
+
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -218,11 +218,5 @@
     "react-router-dom": {
       "optional": true
     }
-  },
-  "lint-staged": {
-    "*": "prettier --ignore-unknown --write",
-    "Capfile|Gemfile|*.{rb,ruby,ru,rake}": "bundle exec rubocop --force-exclusion -a",
-    "*.{js,jsx,ts,tsx}": "eslint --fix",
-    "*.{css,scss}": "stylelint --fix"
   }
 }

--- a/streaming/package.json
+++ b/streaming/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "start": "node ./index.js",
-    "check:types": "tsc --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/streaming/tsconfig.json
+++ b/streaming/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "CommonJS",
     "moduleResolution": "node",
     "noUnusedParameters": false,
+    "tsBuildInfoFile": "../tmp/cache/streaming/tsconfig.tsbuildinfo",
     "paths": {}
   },
   "include": ["./*.js", "./.eslintrc.js"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "baseUrl": "./",
+    "incremental": true,
+    "tsBuildInfoFile": "tmp/cache/tsconfig.tsbuildinfo",
     "paths": {
       "mastodon": ["app/javascript/mastodon"],
       "mastodon/*": ["app/javascript/mastodon/*"]


### PR DESCRIPTION
- Have a dedicaced configuration file, which allows the JS syntax (needed for `tsc` as you cant give it a list of files)
- Run type checks if a Typescript file has been changed
- Use `incremental` Typescript option, to have a local cache (typecheck goes from 11s to 3s on my macbook when there is a cache)
- Run `haml-lint` when an HAML file is modified