### PR TITLE
Disable `Rails/ApplicationController` for `HealthController`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -56,11 +56,6 @@ RSpec/MultipleMemoizedHelpers:
 RSpec/NestedGroups:
   Max: 6
 
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Rails/ApplicationController:
-  Exclude:
-    - 'app/controllers/health_controller.rb'
-
 # Configuration parameters: Include.
 # Include: app/models/**/*.rb
 Rails/HasAndBelongsToMany:

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class HealthController < ActionController::Base
+class HealthController < ActionController::Base # rubocop:disable Rails/ApplicationController
   def show
     render plain: 'OK'
   end


### PR DESCRIPTION
Discussion about preserving health controller instead of framework version: https://github.com/mastodon/mastodon/pull/27520#issuecomment-1831573561

If we're going to keep this, we do want it to descend directly from AC::Base, and can ignore this cop. This matches what we do in `CustomCss` and a few other similar spots.