### PR TITLE
Move followable by logic to suggestion class

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -129,7 +129,6 @@ class Account < ApplicationRecord
   scope :without_unapproved, -> { left_outer_joins(:user).merge(User.approved.confirmed).or(remote) }
   scope :searchable, -> { without_unapproved.without_suspended.where(moved_to_account_id: nil) }
   scope :discoverable, -> { searchable.without_silenced.where(discoverable: true).joins(:account_stat) }
-  scope :followable_by, ->(account) { joins(arel_table.join(Follow.arel_table, Arel::Nodes::OuterJoin).on(arel_table[:id].eq(Follow.arel_table[:target_account_id]).and(Follow.arel_table[:account_id].eq(account.id))).join_sources).where(Follow.arel_table[:id].eq(nil)).joins(arel_table.join(FollowRequest.arel_table, Arel::Nodes::OuterJoin).on(arel_table[:id].eq(FollowRequest.arel_table[:target_account_id]).and(FollowRequest.arel_table[:account_id].eq(account.id))).join_sources).where(FollowRequest.arel_table[:id].eq(nil)) }
   scope :by_recent_status, -> { includes(:account_stat).merge(AccountStat.order('last_status_at DESC NULLS LAST')).references(:account_stat) }
   scope :by_recent_activity, -> { left_joins(:user, :account_stat).order(coalesced_activity_timestamps.desc).order(id: :desc) }
   scope :popular, -> { order('account_stats.followers_count desc') }

--- a/app/models/account_suggestions/source.rb
+++ b/app/models/account_suggestions/source.rb
@@ -8,11 +8,31 @@ class AccountSuggestions::Source
   protected
 
   def base_account_scope(account)
-    Account.searchable
-           .followable_by(account)
-           .not_excluded_by_account(account)
-           .not_domain_blocked_by_account(account)
-           .where.not(id: account.id)
-           .joins("LEFT OUTER JOIN follow_recommendation_mutes ON follow_recommendation_mutes.target_account_id = accounts.id AND follow_recommendation_mutes.account_id = #{account.id}").where(follow_recommendation_mutes: { target_account_id: nil })
+    Account
+      .searchable
+      .where.not(follows_sql, id: account.id)
+      .where.not(follow_requests_sql, id: account.id)
+      .not_excluded_by_account(account)
+      .not_domain_blocked_by_account(account)
+      .where.not(id: account.id)
+      .where.not(follow_recommendation_mutes_sql, id: account.id)
+  end
+
+  def follows_sql
+    <<~SQL.squish
+      EXISTS (SELECT 1 FROM follows WHERE follows.target_account_id = accounts.id AND follows.account_id = :id)
+    SQL
+  end
+
+  def follow_requests_sql
+    <<~SQL.squish
+      EXISTS (SELECT 1 FROM follow_requests WHERE follow_requests.target_account_id = accounts.id AND follow_requests.account_id = :id)
+    SQL
+  end
+
+  def follow_recommendation_mutes_sql
+    <<~SQL.squish
+      EXISTS (SELECT 1 FROM follow_recommendation_mutes WHERE follow_recommendation_mutes.target_account_id = accounts.id AND follow_recommendation_mutes.account_id = :id)
+    SQL
   end
 end


### PR DESCRIPTION
This is the second part of https://github.com/mastodon/mastodon/pull/28697 (moved specs), as discussed in - https://github.com/mastodon/mastodon/pull/26179#issuecomment-1887355722

That other PR moves the scope into multiple scopes and moves the code into a concern.

This one as currently constructed moves the querying over to the suggestions source class, replaces the long Arel lines with terser AR/sql, and replaces a `left outer join` with an `EXISTS` approach (I believe these are similarly performant).

I tried some variations of more/less Arel-vs-SQL, tried a mix of some sql and some of the where chaining methods, etc - and figured I'd just start with a pretty pure sql approach and iterate if desired. I was hoping we could use AR `missing` to produce the left-join approach sql (or close), but I think that you can't keep the conditions on the JOIN with that method, so for our purposes here I could not get a version of that which passed the specs. Might play more in future with this, but maybe this is enough of an improvement for now.

I decided to also modify the follow recommendation mutes inline sql, for consistency with the other two.

