### PR TITLE
Disable `Rails/LexicallyScopedActionFilter` for inherited auth controllers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -103,6 +103,12 @@ Rails/Exit:
     - 'config/boot.rb'
     - 'lib/mastodon/cli/*.rb'
 
+# Reason: Conflicts with `Lint/UselessMethodDefinition` for inherited controller actions
+# https://docs.rubocop.org/rubocop-rails/cops_rails.html#railslexicallyscopedactionfilter
+Rails/LexicallyScopedActionFilter:
+  Exclude:
+    - 'app/controllers/auth/*'
+
 Rails/SkipsModelValidations:
   Exclude:
     - 'db/*migrate/**/*'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -64,13 +64,6 @@ Rails/HasAndBelongsToMany:
     - 'app/models/status.rb'
     - 'app/models/tag.rb'
 
-# Configuration parameters: Include.
-# Include: app/controllers/**/*.rb, app/mailers/**/*.rb
-Rails/LexicallyScopedActionFilter:
-  Exclude:
-    - 'app/controllers/auth/passwords_controller.rb'
-    - 'app/controllers/auth/registrations_controller.rb'
-
 Rails/OutputSafety:
   Exclude:
     - 'config/initializers/simple_form.rb'


### PR DESCRIPTION
What this cop wants is to explicitly define inherited methods (just call super) when they are referenced in before_action or other callbacks. However, this rule conflicts with another - https://github.com/rubocop/rubocop/issues/8667 - so when you defined methods that way you satisfy the lexicallyscoped cop, but violate the uselessmethod one.

Instead, lets disable this just for the directory where controllers are inheriting from devise.