### PR TITLE
Improve `api/v1/markers#create` performance against simultaneous requests

### DIFF
--- a/app/controllers/api/v1/markers_controller.rb
+++ b/app/controllers/api/v1/markers_controller.rb
@@ -15,13 +15,11 @@ class Api::V1::MarkersController < Api::BaseController
   end
 
   def create
-    Marker.transaction do
-      @markers = {}
+    @markers = {}
 
-      resource_params.each_pair do |timeline, timeline_params|
-        @markers[timeline] = current_user.markers.find_or_initialize_by(timeline: timeline)
-        @markers[timeline].update!(timeline_params)
-      end
+    resource_params.each_pair do |timeline, timeline_params|
+      @markers[timeline] = current_user.markers.find_or_create_by(timeline: timeline)
+      @markers[timeline].update!(timeline_params)
     end
 
     render json: serialize_map(@markers)

--- a/app/controllers/api/v1/markers_controller.rb
+++ b/app/controllers/api/v1/markers_controller.rb
@@ -15,11 +15,13 @@ class Api::V1::MarkersController < Api::BaseController
   end
 
   def create
-    @markers = {}
+    Marker.transaction do
+      @markers = {}
 
-    resource_params.each_pair do |timeline, timeline_params|
-      @markers[timeline] = current_user.markers.find_or_create_by(timeline: timeline)
-      @markers[timeline].update!(timeline_params)
+      resource_params.each_pair do |timeline, timeline_params|
+        @markers[timeline] = current_user.markers.find_or_create_by(timeline: timeline)
+        @markers[timeline].update!(timeline_params)
+      end
     end
 
     render json: serialize_map(@markers)

--- a/spec/requests/api/v1/markers_spec.rb
+++ b/spec/requests/api/v1/markers_spec.rb
@@ -2,20 +2,18 @@
 
 require 'rails_helper'
 
-RSpec.describe Api::V1::MarkersController do
-  render_views
+RSpec.describe 'API Markers' do
+  let(:user)    { Fabricate(:user) }
+  let(:scopes)  { 'read:statuses write:statuses' }
+  let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
+  let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
 
-  let!(:user)  { Fabricate(:user) }
-  let!(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'read:statuses write:statuses') }
-
-  before { allow(controller).to receive(:doorkeeper_token) { token } }
-
-  describe 'GET #index' do
+  describe 'GET /api/v1/markers' do
     before do
       Fabricate(:marker, timeline: 'home', last_read_id: 123, user: user)
       Fabricate(:marker, timeline: 'notifications', last_read_id: 456, user: user)
 
-      get :index, params: { timeline: %w(home notifications) }
+      get '/api/v1/markers', headers: headers, params: { timeline: %w(home notifications) }
     end
 
     it 'returns markers', :aggregate_failures do
@@ -29,10 +27,10 @@ RSpec.describe Api::V1::MarkersController do
     end
   end
 
-  describe 'POST #create' do
+  describe 'POST /api/v1/markers' do
     context 'when no marker exists' do
       before do
-        post :create, params: { home: { last_read_id: '69420' } }
+        post '/api/v1/markers', headers: headers, params: { home: { last_read_id: '69420' } }
       end
 
       it 'creates a marker', :aggregate_failures do
@@ -44,8 +42,8 @@ RSpec.describe Api::V1::MarkersController do
 
     context 'when a marker exists' do
       before do
-        post :create, params: { home: { last_read_id: '69420' } }
-        post :create, params: { home: { last_read_id: '70120' } }
+        post '/api/v1/markers', headers: headers, params: { home: { last_read_id: '69420' } }
+        post '/api/v1/markers', headers: headers, params: { home: { last_read_id: '70120' } }
       end
 
       it 'updates a marker', :aggregate_failures do


### PR DESCRIPTION
First change here is just moving the controller spec to a request spec.

Second change is result of various debugging around the intermittent failure issue we are seeing for this endpoint. I think what's happening is that in the system spec where the rails app server is actually a multi-threaded server handling browser reqs, the JS UI is making multiple requests to create markers and they are sometimes causing a unique index violation.

It's hard to replicate this locally and it's hard to write specs for this - because in the normal rspec runner for request specs for example, the threading/transactions/etc don't mirror that scenario exactly.

I was able to use this spec to replicate the condition...

```ruby
# frozen_string_literal: true

require 'rails_helper'

RSpec.describe 'Marker threaded inserts' do
  context 'with simultaneous requests' do
    let!(:user) { Fabricate(:user) }
    let(:timeline) { 'home' }

    it 'is there' do
      threads = []
      wait_for_it = true

      timeline_params = { last_read_id: 999_999 }

      20.times do
        threads << Thread.new do
          # A loop to make threads busy until we `join` them
          true while wait_for_it

          # A - Existing controller
          # marker = user.markers.find_or_initialize_by(timeline: timeline)
          # marker.update!(timeline_params)

          # B - Switch to find_or_create_by
          marker = user.markers.find_or_create_by(timeline: timeline)
          marker.update!(timeline_params)

          # C - Also use create_with
          # user.markers.create_with(timeline_params).find_or_create_by(timeline: timeline)

          # D - Use create_or_find_by
          # user.markers.create_with(timeline_params).create_or_find_by(timeline: timeline)

          # E - Upsert
          # user.markers.upsert(timeline_params.merge(timeline: timeline), unique_by: %i(user_id timeline))

          # Above are equivalent of...
          # post '/api/v1/markers', headers: headers, params: { home: { last_read_id: '999999' } }
        end
      end

      wait_for_it = false

      threads.each(&:join)

      expect(Marker.count)
        .to eq(1)
      expect(Marker.last)
        .to have_attributes(
          timeline: eq('home'),
          last_read_id: eq(999_999),
          user: eq(user)
        )

      puts Marker.all.map(&:inspect)
    end
  end
end
```

This comes close to simulating an exagerrated case of what I think is happening in that failure. I considered various replacement options, described in comments above. The "A" scenario is the current controller code, while the others are alternatives.

The "A" option fails this spec, all the rest pass -- but of the rest, C and D fail the "when a marker exists" scenario in the converted requests spec, and E does not return AR instances so even though it passes this spec, the controller json response doesn't work.

Thus, I chose "B" here to update the controller (convert from `find_or_initialize_` to `find_or_create_` style). In some of these variations I was also able to remove the previous wrapping transaction block in the controller -- because I think the built-in transactions AR generates effectively the same result - but for options where it's still two separate lines I think we need to keep the transaction to reduce chances that another thread changes the marker before it can update (and we hit the 409 scenario).

I think there is likely still a race condition possibility here that we can't fully eliminate without locks, but this change will make it less frequent, I suspect.




