### PR TITLE
Reduced bundle size by 300kb with emoji-mart fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "css-loader": "^5.2.7",
     "cssnano": "^6.0.1",
     "detect-passive-events": "^2.0.3",
-    "emoji-mart": "npm:emoji-mart-lazyload@latest",
+    "emoji-mart": "npm:emoji-mart-mastodon@3.0.1-mastodon",
     "escape-html": "^1.0.3",
     "file-loader": "^6.2.0",
     "font-awesome": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "css-loader": "^5.2.7",
     "cssnano": "^6.0.1",
     "detect-passive-events": "^2.0.3",
-    "emoji-mart": "npm:emoji-mart-mastodon@3.0.1-mastodon",
+    "emoji-mart": "npm:emoji-mart-mastodon@3.0.1-mastodon-1",
     "escape-html": "^1.0.3",
     "file-loader": "^6.2.0",
     "font-awesome": "^4.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2369,7 +2369,7 @@ __metadata:
     css-loader: "npm:^5.2.7"
     cssnano: "npm:^6.0.1"
     detect-passive-events: "npm:^2.0.3"
-    emoji-mart: "npm:emoji-mart-lazyload@latest"
+    emoji-mart: "npm:emoji-mart-mastodon@3.0.1-mastodon-1"
     escape-html: "npm:^1.0.3"
     eslint: "npm:^8.41.0"
     eslint-config-prettier: "npm:^9.0.0"
@@ -7001,16 +7001,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"emoji-mart@npm:emoji-mart-lazyload@latest":
-  version: 3.0.1-j
-  resolution: "emoji-mart-lazyload@npm:3.0.1-j"
+"emoji-mart@npm:emoji-mart-mastodon@3.0.1-mastodon-1":
+  version: 3.0.1-mastodon-1
+  resolution: "emoji-mart-mastodon@npm:3.0.1-mastodon-1"
   dependencies:
     "@babel/runtime": "npm:^7.0.0"
     intersection-observer: "npm:^0.12.0"
     prop-types: "npm:^15.6.0"
   peerDependencies:
-    react: ^0.14.0 || ^15.0.0-0 || ^16.0.0 || ^17.0.0
-  checksum: be673a03292d6a79db38fa0f5ad525a82a642ee5211b8ff32630dfce70988627bb9724695c60f11d635a5631a539beabbddd1185f0986f06890f4266e9cedee2
+    react: ^0.14.0 || ^15.0.0-0 || ^16.0.0 || ^17.0.0 || ^18.0.0
+  checksum: e55f3fc31709d413204880045294c0c0af9141ef6a33a3f2b4d5124ef6557b20a9430c666f6b30207561b0fd0da755a081faebd0d53ba6bfc6e00f348e9f8b0d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
![before](https://github.com/mastodon/mastodon/assets/18673584/b2305fd5-2dc4-4d20-aea1-73c4361de233)

![after](https://github.com/mastodon/mastodon/assets/18673584/d38e0db0-a6de-462d-b646-6e24442e3686)

This is my fork of emoji-mart-lazyload, with better compression/minification of the json that gets embedded in the bundle. There were many data fields that were not used but transferred to the end user on-load.

Changes made from emoji-mart-lazyload -> my emoji-mart-mastoon can be seen at: https://github.com/mashirozx/emoji-mart/compare/release...ryan-augustinsky:emoji-mart-mastodon:release

The big thing is that the all.json data was being loaded by default into the Picker and Emoji components. Now a new optimised mastodon.json file will be loaded instead, which is less than half the size. The original all.json is kept accessible and similar-enough to keep compatibility with the emoji_compressed.js script that reads it at app/javascript/mastodon/features/emoji/emoji_compressed.js.