### PR TITLE
Expand spec coverage for "measure" and "dimension" reporting classes

### DIFF
--- a/spec/lib/admin/metrics/dimension/instance_accounts_dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension/instance_accounts_dimension_spec.rb
@@ -8,11 +8,27 @@ describe Admin::Metrics::Dimension::InstanceAccountsDimension do
   let(:start_at) { 2.days.ago }
   let(:end_at) { Time.now.utc }
   let(:limit) { 10 }
-  let(:params) { ActionController::Parameters.new }
+  let(:params) { ActionController::Parameters.new(domain: domain) }
 
   describe '#data' do
-    it 'runs data query without error' do
-      expect { subject.data }.to_not raise_error
+    let(:domain) { 'host.example' }
+    let(:alice) { Fabricate(:account, domain: domain) }
+    let(:bob) { Fabricate(:account) }
+
+    before do
+      Fabricate :follow, target_account: alice
+      Fabricate :follow, target_account: bob
+      Fabricate :status, account: alice
+      Fabricate :status, account: bob
+    end
+
+    it 'returns instances with follow counts' do
+      expect(subject.data.size)
+        .to eq(1)
+      expect(subject.data.map(&:symbolize_keys))
+        .to contain_exactly(
+          include(key: alice.username, value: '1')
+        )
     end
   end
 end

--- a/spec/lib/admin/metrics/dimension/instance_accounts_dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension/instance_accounts_dimension_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe Admin::Metrics::Dimension::InstanceAccountsDimension do
-  subject(:dimension) { described_class.new(start_at, end_at, limit, params) }
+  subject { described_class.new(start_at, end_at, limit, params) }
 
   let(:start_at) { 2.days.ago }
   let(:end_at) { Time.now.utc }
@@ -12,7 +12,7 @@ describe Admin::Metrics::Dimension::InstanceAccountsDimension do
 
   describe '#data' do
     it 'runs data query without error' do
-      expect { dimension.data }.to_not raise_error
+      expect { subject.data }.to_not raise_error
     end
   end
 end

--- a/spec/lib/admin/metrics/dimension/instance_languages_dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension/instance_languages_dimension_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe Admin::Metrics::Dimension::InstanceLanguagesDimension do
-  subject(:dimension) { described_class.new(start_at, end_at, limit, params) }
+  subject { described_class.new(start_at, end_at, limit, params) }
 
   let(:start_at) { 2.days.ago }
   let(:end_at) { Time.now.utc }
@@ -12,7 +12,7 @@ describe Admin::Metrics::Dimension::InstanceLanguagesDimension do
 
   describe '#data' do
     it 'runs data query without error' do
-      expect { dimension.data }.to_not raise_error
+      expect { subject.data }.to_not raise_error
     end
   end
 end

--- a/spec/lib/admin/metrics/dimension/instance_languages_dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension/instance_languages_dimension_spec.rb
@@ -8,11 +8,25 @@ describe Admin::Metrics::Dimension::InstanceLanguagesDimension do
   let(:start_at) { 2.days.ago }
   let(:end_at) { Time.now.utc }
   let(:limit) { 10 }
-  let(:params) { ActionController::Parameters.new }
+  let(:params) { ActionController::Parameters.new(domain: domain) }
 
   describe '#data' do
-    it 'runs data query without error' do
-      expect { subject.data }.to_not raise_error
+    let(:domain) { 'host.example' }
+    let(:alice) { Fabricate(:account, domain: domain) }
+    let(:bob) { Fabricate(:account) }
+
+    before do
+      Fabricate :status, account: alice, language: 'en'
+      Fabricate :status, account: bob, language: 'es'
+    end
+
+    it 'returns locales with status counts' do
+      expect(subject.data.size)
+        .to eq(1)
+      expect(subject.data.map(&:symbolize_keys))
+        .to contain_exactly(
+          include(key: 'en', value: '1')
+        )
     end
   end
 end

--- a/spec/lib/admin/metrics/dimension/servers_dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension/servers_dimension_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe Admin::Metrics::Dimension::ServersDimension do
-  subject(:dimension) { described_class.new(start_at, end_at, limit, params) }
+  subject { described_class.new(start_at, end_at, limit, params) }
 
   let(:start_at) { 2.days.ago }
   let(:end_at) { Time.now.utc }
@@ -12,7 +12,7 @@ describe Admin::Metrics::Dimension::ServersDimension do
 
   describe '#data' do
     it 'runs data query without error' do
-      expect { dimension.data }.to_not raise_error
+      expect { subject.data }.to_not raise_error
     end
   end
 end

--- a/spec/lib/admin/metrics/dimension/servers_dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension/servers_dimension_spec.rb
@@ -11,8 +11,24 @@ describe Admin::Metrics::Dimension::ServersDimension do
   let(:params) { ActionController::Parameters.new }
 
   describe '#data' do
-    it 'runs data query without error' do
-      expect { subject.data }.to_not raise_error
+    let(:domain) { 'host.example' }
+    let(:alice) { Fabricate(:account, domain: domain) }
+    let(:bob) { Fabricate(:account) }
+
+    before do
+      Fabricate :status, account: alice, created_at: 1.day.ago
+      Fabricate :status, account: alice, created_at: 30.days.ago
+      Fabricate :status, account: bob, created_at: 1.day.ago
+    end
+
+    it 'returns domains with status counts' do
+      expect(subject.data.size)
+        .to eq(2)
+      expect(subject.data.map(&:symbolize_keys))
+        .to contain_exactly(
+          include(key: domain, value: '1'),
+          include(key: Rails.configuration.x.local_domain, value: '1')
+        )
     end
   end
 end

--- a/spec/lib/admin/metrics/dimension/software_versions_dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension/software_versions_dimension_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe Admin::Metrics::Dimension::SoftwareVersionsDimension do
-  subject(:dimension) { described_class.new(start_at, end_at, limit, params) }
+  subject { described_class.new(start_at, end_at, limit, params) }
 
   let(:start_at) { 2.days.ago }
   let(:end_at) { Time.now.utc }
@@ -12,7 +12,7 @@ describe Admin::Metrics::Dimension::SoftwareVersionsDimension do
 
   describe '#data' do
     it 'runs data query without error' do
-      expect { dimension.data }.to_not raise_error
+      expect { subject.data }.to_not raise_error
     end
   end
 end

--- a/spec/lib/admin/metrics/dimension/software_versions_dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension/software_versions_dimension_spec.rb
@@ -11,8 +11,12 @@ describe Admin::Metrics::Dimension::SoftwareVersionsDimension do
   let(:params) { ActionController::Parameters.new }
 
   describe '#data' do
-    it 'runs data query without error' do
-      expect { subject.data }.to_not raise_error
+    it 'reports on the running software' do
+      expect(subject.data.map(&:symbolize_keys))
+        .to include(
+          include(key: 'mastodon', value: Mastodon::Version.to_s),
+          include(key: 'ruby', value: include(RUBY_VERSION))
+        )
     end
   end
 end

--- a/spec/lib/admin/metrics/dimension/sources_dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension/sources_dimension_spec.rb
@@ -11,8 +11,21 @@ describe Admin::Metrics::Dimension::SourcesDimension do
   let(:params) { ActionController::Parameters.new }
 
   describe '#data' do
-    it 'runs data query without error' do
-      expect { subject.data }.to_not raise_error
+    let(:app) { Fabricate(:application) }
+    let(:alice) { Fabricate(:user) }
+    let(:bob) { Fabricate(:user) }
+
+    before do
+      alice.update(created_by_application: app)
+    end
+
+    it 'returns OAuth applications with user counts' do
+      expect(subject.data.size)
+        .to eq(1)
+      expect(subject.data.map(&:symbolize_keys))
+        .to contain_exactly(
+          include(key: app.name, value: '1')
+        )
     end
   end
 end

--- a/spec/lib/admin/metrics/dimension/sources_dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension/sources_dimension_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe Admin::Metrics::Dimension::SourcesDimension do
-  subject(:dimension) { described_class.new(start_at, end_at, limit, params) }
+  subject { described_class.new(start_at, end_at, limit, params) }
 
   let(:start_at) { 2.days.ago }
   let(:end_at) { Time.now.utc }
@@ -12,7 +12,7 @@ describe Admin::Metrics::Dimension::SourcesDimension do
 
   describe '#data' do
     it 'runs data query without error' do
-      expect { dimension.data }.to_not raise_error
+      expect { subject.data }.to_not raise_error
     end
   end
 end

--- a/spec/lib/admin/metrics/dimension/space_usage_dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension/space_usage_dimension_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe Admin::Metrics::Dimension::SpaceUsageDimension do
-  subject(:dimension) { described_class.new(start_at, end_at, limit, params) }
+  subject { described_class.new(start_at, end_at, limit, params) }
 
   let(:start_at) { 2.days.ago }
   let(:end_at) { Time.now.utc }
@@ -12,7 +12,7 @@ describe Admin::Metrics::Dimension::SpaceUsageDimension do
 
   describe '#data' do
     it 'runs data query without error' do
-      expect { dimension.data }.to_not raise_error
+      expect { subject.data }.to_not raise_error
     end
   end
 end

--- a/spec/lib/admin/metrics/dimension/space_usage_dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension/space_usage_dimension_spec.rb
@@ -11,8 +11,13 @@ describe Admin::Metrics::Dimension::SpaceUsageDimension do
   let(:params) { ActionController::Parameters.new }
 
   describe '#data' do
-    it 'runs data query without error' do
-      expect { subject.data }.to_not raise_error
+    it 'reports on used storage space' do
+      expect(subject.data.map(&:symbolize_keys))
+        .to include(
+          include(key: 'media', value: /\d/),
+          include(key: 'postgresql', value: /\d/),
+          include(key: 'redis', value: /\d/)
+        )
     end
   end
 end

--- a/spec/lib/admin/metrics/dimension/tag_languages_dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension/tag_languages_dimension_spec.rb
@@ -8,11 +8,31 @@ describe Admin::Metrics::Dimension::TagLanguagesDimension do
   let(:start_at) { 2.days.ago }
   let(:end_at) { Time.now.utc }
   let(:limit) { 10 }
-  let(:params) { ActionController::Parameters.new }
+  let(:params) { ActionController::Parameters.new(id: tag.id) }
 
   describe '#data' do
-    it 'runs data query without error' do
-      expect { subject.data }.to_not raise_error
+    let(:alice) { Fabricate(:account) }
+    let(:bob) { Fabricate(:account) }
+    let(:tag) { Fabricate(:tag) }
+
+    before do
+      alice_status_recent = Fabricate :status, account: alice, created_at: 1.day.ago, language: 'en'
+      alice_status_older = Fabricate :status, account: alice, created_at: 30.days.ago, language: 'en'
+      bob_status_recent = Fabricate :status, account: bob, created_at: 1.day.ago, language: 'es'
+
+      alice_status_older.tags << tag
+      alice_status_recent.tags << tag
+      bob_status_recent.tags << tag
+    end
+
+    it 'returns languages with tag usage counts' do
+      expect(subject.data.size)
+        .to eq(2)
+      expect(subject.data.map(&:symbolize_keys))
+        .to contain_exactly(
+          include(key: 'en', value: '1'),
+          include(key: 'es', value: '1')
+        )
     end
   end
 end

--- a/spec/lib/admin/metrics/dimension/tag_languages_dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension/tag_languages_dimension_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe Admin::Metrics::Dimension::TagLanguagesDimension do
-  subject(:dimension) { described_class.new(start_at, end_at, limit, params) }
+  subject { described_class.new(start_at, end_at, limit, params) }
 
   let(:start_at) { 2.days.ago }
   let(:end_at) { Time.now.utc }
@@ -12,7 +12,7 @@ describe Admin::Metrics::Dimension::TagLanguagesDimension do
 
   describe '#data' do
     it 'runs data query without error' do
-      expect { dimension.data }.to_not raise_error
+      expect { subject.data }.to_not raise_error
     end
   end
 end

--- a/spec/lib/admin/metrics/dimension/tag_servers_dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension/tag_servers_dimension_spec.rb
@@ -8,11 +8,32 @@ describe Admin::Metrics::Dimension::TagServersDimension do
   let(:start_at) { 2.days.ago }
   let(:end_at) { Time.now.utc }
   let(:limit) { 10 }
-  let(:params) { ActionController::Parameters.new }
+  let(:params) { ActionController::Parameters.new(id: tag.id) }
 
   describe '#data' do
-    it 'runs data query without error' do
-      expect { subject.data }.to_not raise_error
+    let(:alice) { Fabricate(:account, domain: domain) }
+    let(:bob) { Fabricate(:account) }
+    let(:domain) { 'host.example' }
+    let(:tag) { Fabricate(:tag) }
+
+    before do
+      alice_status_recent = Fabricate :status, account: alice, created_at: 1.day.ago
+      alice_status_older = Fabricate :status, account: alice, created_at: 30.days.ago
+      bob_status_recent = Fabricate :status, account: bob, created_at: 1.day.ago
+
+      alice_status_older.tags << tag
+      alice_status_recent.tags << tag
+      bob_status_recent.tags << tag
+    end
+
+    it 'returns servers with tag usage counts' do
+      expect(subject.data.size)
+        .to eq(2)
+      expect(subject.data.map(&:symbolize_keys))
+        .to contain_exactly(
+          include(key: domain, value: '1'),
+          include(key: Rails.configuration.x.local_domain, value: '1')
+        )
     end
   end
 end

--- a/spec/lib/admin/metrics/dimension/tag_servers_dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension/tag_servers_dimension_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe Admin::Metrics::Dimension::TagServersDimension do
-  subject(:dimension) { described_class.new(start_at, end_at, limit, params) }
+  subject { described_class.new(start_at, end_at, limit, params) }
 
   let(:start_at) { 2.days.ago }
   let(:end_at) { Time.now.utc }
@@ -12,7 +12,7 @@ describe Admin::Metrics::Dimension::TagServersDimension do
 
   describe '#data' do
     it 'runs data query without error' do
-      expect { dimension.data }.to_not raise_error
+      expect { subject.data }.to_not raise_error
     end
   end
 end

--- a/spec/lib/admin/metrics/measure/active_users_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/active_users_measure_spec.rb
@@ -17,18 +17,12 @@ describe Admin::Metrics::Measure::ActiveUsersMeasure do
     context 'with activity tracking records' do
       before do
         3.times do
-          travel_to 2.days.ago do
-            ActivityTracker.record('activity:logins', Fabricate(:user).id)
-          end
+          travel_to(2.days.ago) { record_login_activity }
         end
         2.times do
-          travel_to 1.day.ago do
-            ActivityTracker.record('activity:logins', Fabricate(:user).id)
-          end
+          travel_to(1.day.ago) { record_login_activity }
         end
-        travel_to 0.days.ago do
-          ActivityTracker.record('activity:logins', Fabricate(:user).id)
-        end
+        travel_to(0.days.ago) { record_login_activity }
       end
 
       it 'returns correct activity tracker counts' do
@@ -40,6 +34,10 @@ describe Admin::Metrics::Measure::ActiveUsersMeasure do
             include(date: 1.day.ago.midnight.to_time, value: '2'),
             include(date: 0.days.ago.midnight.to_time, value: '1')
           )
+      end
+
+      def record_login_activity
+        ActivityTracker.record('activity:logins', Fabricate(:user).id)
       end
     end
   end

--- a/spec/lib/admin/metrics/measure/active_users_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/active_users_measure_spec.rb
@@ -13,5 +13,34 @@ describe Admin::Metrics::Measure::ActiveUsersMeasure do
     it 'runs data query without error' do
       expect { measure.data }.to_not raise_error
     end
+
+    context 'with activity tracking records' do
+      before do
+        3.times do
+          travel_to 2.days.ago do
+            ActivityTracker.record('activity:logins', Fabricate(:user).id)
+          end
+        end
+        2.times do
+          travel_to 1.day.ago do
+            ActivityTracker.record('activity:logins', Fabricate(:user).id)
+          end
+        end
+        travel_to 0.days.ago do
+          ActivityTracker.record('activity:logins', Fabricate(:user).id)
+        end
+      end
+
+      it 'returns correct activity tracker counts' do
+        expect(measure.data.size)
+          .to eq(3)
+        expect(measure.data.map(&:symbolize_keys))
+          .to contain_exactly(
+            include(date: 2.days.ago.midnight.to_time, value: '3'),
+            include(date: 1.day.ago.midnight.to_time, value: '2'),
+            include(date: 0.days.ago.midnight.to_time, value: '1')
+          )
+      end
+    end
   end
 end

--- a/spec/lib/admin/metrics/measure/active_users_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/active_users_measure_spec.rb
@@ -10,10 +10,6 @@ describe Admin::Metrics::Measure::ActiveUsersMeasure do
   let(:params) { ActionController::Parameters.new }
 
   describe '#data' do
-    it 'runs data query without error' do
-      expect { subject.data }.to_not raise_error
-    end
-
     context 'with activity tracking records' do
       before do
         3.times do

--- a/spec/lib/admin/metrics/measure/active_users_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/active_users_measure_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe Admin::Metrics::Measure::ActiveUsersMeasure do
-  subject(:measure) { described_class.new(start_at, end_at, params) }
+  subject { described_class.new(start_at, end_at, params) }
 
   let(:start_at) { 2.days.ago }
   let(:end_at)   { Time.now.utc }
@@ -11,7 +11,7 @@ describe Admin::Metrics::Measure::ActiveUsersMeasure do
 
   describe '#data' do
     it 'runs data query without error' do
-      expect { measure.data }.to_not raise_error
+      expect { subject.data }.to_not raise_error
     end
 
     context 'with activity tracking records' do
@@ -32,9 +32,9 @@ describe Admin::Metrics::Measure::ActiveUsersMeasure do
       end
 
       it 'returns correct activity tracker counts' do
-        expect(measure.data.size)
+        expect(subject.data.size)
           .to eq(3)
-        expect(measure.data.map(&:symbolize_keys))
+        expect(subject.data.map(&:symbolize_keys))
           .to contain_exactly(
             include(date: 2.days.ago.midnight.to_time, value: '3'),
             include(date: 1.day.ago.midnight.to_time, value: '2'),

--- a/spec/lib/admin/metrics/measure/instance_accounts_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/instance_accounts_measure_spec.rb
@@ -20,6 +20,7 @@ describe Admin::Metrics::Measure::InstanceAccountsMeasure do
     Fabricate(:account, domain: "foo.#{domain}", created_at: 1.year.ago)
     Fabricate(:account, domain: "foo.#{domain}")
     Fabricate(:account, domain: "bar.#{domain}")
+    Fabricate(:account, domain: 'other-host.example')
   end
 
   describe 'total' do
@@ -39,8 +40,15 @@ describe Admin::Metrics::Measure::InstanceAccountsMeasure do
   end
 
   describe '#data' do
-    it 'runs data query without error' do
-      expect { measure.data }.to_not raise_error
+    it 'returns correct user counts' do
+      expect(measure.data.size)
+        .to eq(3)
+      expect(measure.data.map(&:symbolize_keys))
+        .to contain_exactly(
+          include(date: 2.days.ago.midnight.to_time, value: '0'),
+          include(date: 1.day.ago.midnight.to_time, value: '0'),
+          include(date: 0.days.ago.midnight.to_time, value: '1')
+        )
     end
   end
 end

--- a/spec/lib/admin/metrics/measure/instance_accounts_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/instance_accounts_measure_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe Admin::Metrics::Measure::InstanceAccountsMeasure do
-  subject(:measure) { described_class.new(start_at, end_at, params) }
+  subject { described_class.new(start_at, end_at, params) }
 
   let(:domain) { 'example.com' }
 
@@ -26,7 +26,7 @@ describe Admin::Metrics::Measure::InstanceAccountsMeasure do
   describe '#total' do
     context 'without include_subdomains' do
       it 'returns the expected number of accounts' do
-        expect(measure.total).to eq 3
+        expect(subject.total).to eq 3
       end
     end
 
@@ -34,16 +34,16 @@ describe Admin::Metrics::Measure::InstanceAccountsMeasure do
       let(:params) { ActionController::Parameters.new(domain: domain, include_subdomains: 'true') }
 
       it 'returns the expected number of accounts' do
-        expect(measure.total).to eq 6
+        expect(subject.total).to eq 6
       end
     end
   end
 
   describe '#data' do
     it 'returns correct instance_accounts counts' do
-      expect(measure.data.size)
+      expect(subject.data.size)
         .to eq(3)
-      expect(measure.data.map(&:symbolize_keys))
+      expect(subject.data.map(&:symbolize_keys))
         .to contain_exactly(
           include(date: 2.days.ago.midnight.to_time, value: '0'),
           include(date: 1.day.ago.midnight.to_time, value: '0'),

--- a/spec/lib/admin/metrics/measure/instance_accounts_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/instance_accounts_measure_spec.rb
@@ -23,7 +23,7 @@ describe Admin::Metrics::Measure::InstanceAccountsMeasure do
     Fabricate(:account, domain: 'other-host.example')
   end
 
-  describe 'total' do
+  describe '#total' do
     context 'without include_subdomains' do
       it 'returns the expected number of accounts' do
         expect(measure.total).to eq 3

--- a/spec/lib/admin/metrics/measure/instance_accounts_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/instance_accounts_measure_spec.rb
@@ -40,7 +40,7 @@ describe Admin::Metrics::Measure::InstanceAccountsMeasure do
   end
 
   describe '#data' do
-    it 'returns correct user counts' do
+    it 'returns correct instance_accounts counts' do
       expect(measure.data.size)
         .to eq(3)
       expect(measure.data.map(&:symbolize_keys))

--- a/spec/lib/admin/metrics/measure/instance_followers_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/instance_followers_measure_spec.rb
@@ -22,6 +22,8 @@ describe Admin::Metrics::Measure::InstanceFollowersMeasure do
     Fabricate(:account, domain: "foo.#{domain}").follow!(local_account)
     Fabricate(:account, domain: "foo.#{domain}").follow!(local_account)
     Fabricate(:account, domain: "bar.#{domain}")
+
+    Fabricate(:account, domain: 'other.example').follow!(local_account)
   end
 
   describe 'total' do
@@ -41,8 +43,15 @@ describe Admin::Metrics::Measure::InstanceFollowersMeasure do
   end
 
   describe '#data' do
-    it 'runs data query without error' do
-      expect { measure.data }.to_not raise_error
+    it 'returns correct user counts' do
+      expect(measure.data.size)
+        .to eq(3)
+      expect(measure.data.map(&:symbolize_keys))
+        .to contain_exactly(
+          include(date: 2.days.ago.midnight.to_time, value: '0'),
+          include(date: 1.day.ago.midnight.to_time, value: '0'),
+          include(date: 0.days.ago.midnight.to_time, value: '2')
+        )
     end
   end
 end

--- a/spec/lib/admin/metrics/measure/instance_followers_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/instance_followers_measure_spec.rb
@@ -43,7 +43,7 @@ describe Admin::Metrics::Measure::InstanceFollowersMeasure do
   end
 
   describe '#data' do
-    it 'returns correct user counts' do
+    it 'returns correct instance_followers counts' do
       expect(measure.data.size)
         .to eq(3)
       expect(measure.data.map(&:symbolize_keys))

--- a/spec/lib/admin/metrics/measure/instance_followers_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/instance_followers_measure_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe Admin::Metrics::Measure::InstanceFollowersMeasure do
-  subject(:measure) { described_class.new(start_at, end_at, params) }
+  subject { described_class.new(start_at, end_at, params) }
 
   let(:domain) { 'example.com' }
 
@@ -29,7 +29,7 @@ describe Admin::Metrics::Measure::InstanceFollowersMeasure do
   describe '#total' do
     context 'without include_subdomains' do
       it 'returns the expected number of accounts' do
-        expect(measure.total).to eq 2
+        expect(subject.total).to eq 2
       end
     end
 
@@ -37,16 +37,16 @@ describe Admin::Metrics::Measure::InstanceFollowersMeasure do
       let(:params) { ActionController::Parameters.new(domain: domain, include_subdomains: 'true') }
 
       it 'returns the expected number of accounts' do
-        expect(measure.total).to eq 4
+        expect(subject.total).to eq 4
       end
     end
   end
 
   describe '#data' do
     it 'returns correct instance_followers counts' do
-      expect(measure.data.size)
+      expect(subject.data.size)
         .to eq(3)
-      expect(measure.data.map(&:symbolize_keys))
+      expect(subject.data.map(&:symbolize_keys))
         .to contain_exactly(
           include(date: 2.days.ago.midnight.to_time, value: '0'),
           include(date: 1.day.ago.midnight.to_time, value: '0'),

--- a/spec/lib/admin/metrics/measure/instance_followers_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/instance_followers_measure_spec.rb
@@ -26,7 +26,7 @@ describe Admin::Metrics::Measure::InstanceFollowersMeasure do
     Fabricate(:account, domain: 'other.example').follow!(local_account)
   end
 
-  describe 'total' do
+  describe '#total' do
     context 'without include_subdomains' do
       it 'returns the expected number of accounts' do
         expect(measure.total).to eq 2

--- a/spec/lib/admin/metrics/measure/instance_follows_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/instance_follows_measure_spec.rb
@@ -41,8 +41,15 @@ describe Admin::Metrics::Measure::InstanceFollowsMeasure do
   end
 
   describe '#data' do
-    it 'runs data query without error' do
-      expect { measure.data }.to_not raise_error
+    it 'returns correct instance_followers counts' do
+      expect(measure.data.size)
+        .to eq(3)
+      expect(measure.data.map(&:symbolize_keys))
+        .to contain_exactly(
+          include(date: 2.days.ago.midnight.to_time, value: '0'),
+          include(date: 1.day.ago.midnight.to_time, value: '0'),
+          include(date: 0.days.ago.midnight.to_time, value: '2')
+        )
     end
   end
 end

--- a/spec/lib/admin/metrics/measure/instance_follows_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/instance_follows_measure_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe Admin::Metrics::Measure::InstanceFollowsMeasure do
-  subject(:measure) { described_class.new(start_at, end_at, params) }
+  subject { described_class.new(start_at, end_at, params) }
 
   let(:domain) { 'example.com' }
 
@@ -27,7 +27,7 @@ describe Admin::Metrics::Measure::InstanceFollowsMeasure do
   describe '#total' do
     context 'without include_subdomains' do
       it 'returns the expected number of accounts' do
-        expect(measure.total).to eq 2
+        expect(subject.total).to eq 2
       end
     end
 
@@ -35,16 +35,16 @@ describe Admin::Metrics::Measure::InstanceFollowsMeasure do
       let(:params) { ActionController::Parameters.new(domain: domain, include_subdomains: 'true') }
 
       it 'returns the expected number of accounts' do
-        expect(measure.total).to eq 4
+        expect(subject.total).to eq 4
       end
     end
   end
 
   describe '#data' do
     it 'returns correct instance_followers counts' do
-      expect(measure.data.size)
+      expect(subject.data.size)
         .to eq(3)
-      expect(measure.data.map(&:symbolize_keys))
+      expect(subject.data.map(&:symbolize_keys))
         .to contain_exactly(
           include(date: 2.days.ago.midnight.to_time, value: '0'),
           include(date: 1.day.ago.midnight.to_time, value: '0'),

--- a/spec/lib/admin/metrics/measure/instance_follows_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/instance_follows_measure_spec.rb
@@ -24,7 +24,7 @@ describe Admin::Metrics::Measure::InstanceFollowsMeasure do
     Fabricate(:account, domain: "bar.#{domain}")
   end
 
-  describe 'total' do
+  describe '#total' do
     context 'without include_subdomains' do
       it 'returns the expected number of accounts' do
         expect(measure.total).to eq 2

--- a/spec/lib/admin/metrics/measure/instance_media_attachments_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/instance_media_attachments_measure_spec.rb
@@ -20,7 +20,7 @@ describe Admin::Metrics::Measure::InstanceMediaAttachmentsMeasure do
     remote_account_on_subdomain.media_attachments.create!(file: attachment_fixture('attachment.jpg'))
   end
 
-  describe 'total' do
+  describe '#total' do
     context 'without include_subdomains' do
       it 'returns the expected number of accounts' do
         expected_total = remote_account.media_attachments.sum(:file_file_size) + remote_account.media_attachments.sum(:thumbnail_file_size)

--- a/spec/lib/admin/metrics/measure/instance_media_attachments_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/instance_media_attachments_measure_spec.rb
@@ -42,8 +42,19 @@ describe Admin::Metrics::Measure::InstanceMediaAttachmentsMeasure do
   end
 
   describe '#data' do
-    it 'runs data query without error' do
-      expect { measure.data }.to_not raise_error
+    it 'returns correct media_attachments counts' do
+      expect(measure.data.size)
+        .to eq(3)
+      expect(measure.data.map(&:symbolize_keys))
+        .to contain_exactly(
+          include(date: 2.days.ago.midnight.to_time, value: '0'),
+          include(date: 1.day.ago.midnight.to_time, value: '0'),
+          include(date: 0.days.ago.midnight.to_time, value: expected_domain_only_total.to_s)
+        )
+    end
+
+    def expected_domain_only_total
+      remote_account.media_attachments.sum(:file_file_size) + remote_account.media_attachments.sum(:thumbnail_file_size)
     end
   end
 end

--- a/spec/lib/admin/metrics/measure/instance_media_attachments_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/instance_media_attachments_measure_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe Admin::Metrics::Measure::InstanceMediaAttachmentsMeasure do
-  subject(:measure) { described_class.new(start_at, end_at, params) }
+  subject { described_class.new(start_at, end_at, params) }
 
   let(:domain) { 'example.com' }
 
@@ -24,7 +24,7 @@ describe Admin::Metrics::Measure::InstanceMediaAttachmentsMeasure do
     context 'without include_subdomains' do
       it 'returns the expected number of accounts' do
         expected_total = remote_account.media_attachments.sum(:file_file_size) + remote_account.media_attachments.sum(:thumbnail_file_size)
-        expect(measure.total).to eq expected_total
+        expect(subject.total).to eq expected_total
       end
     end
 
@@ -36,16 +36,16 @@ describe Admin::Metrics::Measure::InstanceMediaAttachmentsMeasure do
           account.media_attachments.sum(:file_file_size) + account.media_attachments.sum(:thumbnail_file_size)
         end
 
-        expect(measure.total).to eq expected_total
+        expect(subject.total).to eq expected_total
       end
     end
   end
 
   describe '#data' do
     it 'returns correct media_attachments counts' do
-      expect(measure.data.size)
+      expect(subject.data.size)
         .to eq(3)
-      expect(measure.data.map(&:symbolize_keys))
+      expect(subject.data.map(&:symbolize_keys))
         .to contain_exactly(
           include(date: 2.days.ago.midnight.to_time, value: '0'),
           include(date: 1.day.ago.midnight.to_time, value: '0'),

--- a/spec/lib/admin/metrics/measure/instance_reports_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/instance_reports_measure_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe Admin::Metrics::Measure::InstanceReportsMeasure do
-  subject(:measure) { described_class.new(start_at, end_at, params) }
+  subject { described_class.new(start_at, end_at, params) }
 
   let(:domain) { 'example.com' }
 
@@ -24,7 +24,7 @@ describe Admin::Metrics::Measure::InstanceReportsMeasure do
   describe '#total' do
     context 'without include_subdomains' do
       it 'returns the expected number of accounts' do
-        expect(measure.total).to eq 2
+        expect(subject.total).to eq 2
       end
     end
 
@@ -32,16 +32,16 @@ describe Admin::Metrics::Measure::InstanceReportsMeasure do
       let(:params) { ActionController::Parameters.new(domain: domain, include_subdomains: 'true') }
 
       it 'returns the expected number of accounts' do
-        expect(measure.total).to eq 5
+        expect(subject.total).to eq 5
       end
     end
   end
 
   describe '#data' do
     it 'returns correct instance_reports counts' do
-      expect(measure.data.size)
+      expect(subject.data.size)
         .to eq(3)
-      expect(measure.data.map(&:symbolize_keys))
+      expect(subject.data.map(&:symbolize_keys))
         .to contain_exactly(
           include(date: 2.days.ago.midnight.to_time, value: '0'),
           include(date: 1.day.ago.midnight.to_time, value: '0'),

--- a/spec/lib/admin/metrics/measure/instance_reports_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/instance_reports_measure_spec.rb
@@ -38,7 +38,7 @@ describe Admin::Metrics::Measure::InstanceReportsMeasure do
   end
 
   describe '#data' do
-    it 'returns correct media_attachments counts' do
+    it 'returns correct instance_reports counts' do
       expect(measure.data.size)
         .to eq(3)
       expect(measure.data.map(&:symbolize_keys))

--- a/spec/lib/admin/metrics/measure/instance_reports_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/instance_reports_measure_spec.rb
@@ -38,8 +38,15 @@ describe Admin::Metrics::Measure::InstanceReportsMeasure do
   end
 
   describe '#data' do
-    it 'runs data query without error' do
-      expect { measure.data }.to_not raise_error
+    it 'returns correct media_attachments counts' do
+      expect(measure.data.size)
+        .to eq(3)
+      expect(measure.data.map(&:symbolize_keys))
+        .to contain_exactly(
+          include(date: 2.days.ago.midnight.to_time, value: '0'),
+          include(date: 1.day.ago.midnight.to_time, value: '0'),
+          include(date: 0.days.ago.midnight.to_time, value: '2')
+        )
     end
   end
 end

--- a/spec/lib/admin/metrics/measure/instance_reports_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/instance_reports_measure_spec.rb
@@ -21,7 +21,7 @@ describe Admin::Metrics::Measure::InstanceReportsMeasure do
     Fabricate(:report, target_account: Fabricate(:account, domain: "bar.#{domain}"))
   end
 
-  describe 'total' do
+  describe '#total' do
     context 'without include_subdomains' do
       it 'returns the expected number of accounts' do
         expect(measure.total).to eq 2

--- a/spec/lib/admin/metrics/measure/instance_statuses_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/instance_statuses_measure_spec.rb
@@ -38,8 +38,15 @@ describe Admin::Metrics::Measure::InstanceStatusesMeasure do
   end
 
   describe '#data' do
-    it 'runs data query without error' do
-      expect { measure.data }.to_not raise_error
+    it 'returns correct instance_statuses counts' do
+      expect(measure.data.size)
+        .to eq(3)
+      expect(measure.data.map(&:symbolize_keys))
+        .to contain_exactly(
+          include(date: 2.days.ago.midnight.to_time, value: '0'),
+          include(date: 1.day.ago.midnight.to_time, value: '0'),
+          include(date: 0.days.ago.midnight.to_time, value: '2')
+        )
     end
   end
 end

--- a/spec/lib/admin/metrics/measure/instance_statuses_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/instance_statuses_measure_spec.rb
@@ -21,7 +21,7 @@ describe Admin::Metrics::Measure::InstanceStatusesMeasure do
     Fabricate(:status, account: Fabricate(:account, domain: "bar.#{domain}"))
   end
 
-  describe 'total' do
+  describe '#total' do
     context 'without include_subdomains' do
       it 'returns the expected number of accounts' do
         expect(measure.total).to eq 2

--- a/spec/lib/admin/metrics/measure/instance_statuses_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/instance_statuses_measure_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe Admin::Metrics::Measure::InstanceStatusesMeasure do
-  subject(:measure) { described_class.new(start_at, end_at, params) }
+  subject { described_class.new(start_at, end_at, params) }
 
   let(:domain) { 'example.com' }
 
@@ -24,7 +24,7 @@ describe Admin::Metrics::Measure::InstanceStatusesMeasure do
   describe '#total' do
     context 'without include_subdomains' do
       it 'returns the expected number of accounts' do
-        expect(measure.total).to eq 2
+        expect(subject.total).to eq 2
       end
     end
 
@@ -32,16 +32,16 @@ describe Admin::Metrics::Measure::InstanceStatusesMeasure do
       let(:params) { ActionController::Parameters.new(domain: domain, include_subdomains: 'true') }
 
       it 'returns the expected number of accounts' do
-        expect(measure.total).to eq 5
+        expect(subject.total).to eq 5
       end
     end
   end
 
   describe '#data' do
     it 'returns correct instance_statuses counts' do
-      expect(measure.data.size)
+      expect(subject.data.size)
         .to eq(3)
-      expect(measure.data.map(&:symbolize_keys))
+      expect(subject.data.map(&:symbolize_keys))
         .to contain_exactly(
           include(date: 2.days.ago.midnight.to_time, value: '0'),
           include(date: 1.day.ago.midnight.to_time, value: '0'),

--- a/spec/lib/admin/metrics/measure/interactions_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/interactions_measure_spec.rb
@@ -17,18 +17,12 @@ describe Admin::Metrics::Measure::InteractionsMeasure do
     context 'with activity tracking records' do
       before do
         3.times do
-          travel_to 2.days.ago do
-            ActivityTracker.increment('activity:interactions')
-          end
+          travel_to(2.days.ago) { record_interaction_activity }
         end
         2.times do
-          travel_to 1.day.ago do
-            ActivityTracker.increment('activity:interactions')
-          end
+          travel_to(1.day.ago) { record_interaction_activity }
         end
-        travel_to 0.days.ago do
-          ActivityTracker.increment('activity:interactions')
-        end
+        travel_to(0.days.ago) { record_interaction_activity }
       end
 
       it 'returns correct activity tracker counts' do
@@ -40,6 +34,10 @@ describe Admin::Metrics::Measure::InteractionsMeasure do
             include(date: 1.day.ago.midnight.to_time, value: '2'),
             include(date: 0.days.ago.midnight.to_time, value: '1')
           )
+      end
+
+      def record_interaction_activity
+        ActivityTracker.increment('activity:interactions')
       end
     end
   end

--- a/spec/lib/admin/metrics/measure/interactions_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/interactions_measure_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe Admin::Metrics::Measure::InteractionsMeasure do
-  subject(:measure) { described_class.new(start_at, end_at, params) }
+  subject { described_class.new(start_at, end_at, params) }
 
   let(:start_at) { 2.days.ago }
   let(:end_at)   { Time.now.utc }
@@ -11,7 +11,7 @@ describe Admin::Metrics::Measure::InteractionsMeasure do
 
   describe '#data' do
     it 'runs data query without error' do
-      expect { measure.data }.to_not raise_error
+      expect { subject.data }.to_not raise_error
     end
 
     context 'with activity tracking records' do
@@ -32,9 +32,9 @@ describe Admin::Metrics::Measure::InteractionsMeasure do
       end
 
       it 'returns correct activity tracker counts' do
-        expect(measure.data.size)
+        expect(subject.data.size)
           .to eq(3)
-        expect(measure.data.map(&:symbolize_keys))
+        expect(subject.data.map(&:symbolize_keys))
           .to contain_exactly(
             include(date: 2.days.ago.midnight.to_time, value: '3'),
             include(date: 1.day.ago.midnight.to_time, value: '2'),

--- a/spec/lib/admin/metrics/measure/interactions_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/interactions_measure_spec.rb
@@ -10,10 +10,6 @@ describe Admin::Metrics::Measure::InteractionsMeasure do
   let(:params) { ActionController::Parameters.new }
 
   describe '#data' do
-    it 'runs data query without error' do
-      expect { subject.data }.to_not raise_error
-    end
-
     context 'with activity tracking records' do
       before do
         3.times do

--- a/spec/lib/admin/metrics/measure/interactions_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/interactions_measure_spec.rb
@@ -13,5 +13,34 @@ describe Admin::Metrics::Measure::InteractionsMeasure do
     it 'runs data query without error' do
       expect { measure.data }.to_not raise_error
     end
+
+    context 'with activity tracking records' do
+      before do
+        3.times do
+          travel_to 2.days.ago do
+            ActivityTracker.increment('activity:interactions')
+          end
+        end
+        2.times do
+          travel_to 1.day.ago do
+            ActivityTracker.increment('activity:interactions')
+          end
+        end
+        travel_to 0.days.ago do
+          ActivityTracker.increment('activity:interactions')
+        end
+      end
+
+      it 'returns correct activity tracker counts' do
+        expect(measure.data.size)
+          .to eq(3)
+        expect(measure.data.map(&:symbolize_keys))
+          .to contain_exactly(
+            include(date: 2.days.ago.midnight.to_time, value: '3'),
+            include(date: 1.day.ago.midnight.to_time, value: '2'),
+            include(date: 0.days.ago.midnight.to_time, value: '1')
+          )
+      end
+    end
   end
 end

--- a/spec/lib/admin/metrics/measure/new_users_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/new_users_measure_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe Admin::Metrics::Measure::NewUsersMeasure do
-  subject(:measure) { described_class.new(start_at, end_at, params) }
+  subject { described_class.new(start_at, end_at, params) }
 
   let(:start_at) { 2.days.ago }
   let(:end_at)   { Time.now.utc }
@@ -11,7 +11,7 @@ describe Admin::Metrics::Measure::NewUsersMeasure do
 
   describe '#data' do
     it 'runs data query without error' do
-      expect { measure.data }.to_not raise_error
+      expect { subject.data }.to_not raise_error
     end
 
     context 'with user records' do
@@ -22,9 +22,9 @@ describe Admin::Metrics::Measure::NewUsersMeasure do
       end
 
       it 'returns correct user counts' do
-        expect(measure.data.size)
+        expect(subject.data.size)
           .to eq(3)
-        expect(measure.data.map(&:symbolize_keys))
+        expect(subject.data.map(&:symbolize_keys))
           .to contain_exactly(
             include(date: 2.days.ago.midnight.to_time, value: '3'),
             include(date: 1.day.ago.midnight.to_time, value: '2'),

--- a/spec/lib/admin/metrics/measure/new_users_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/new_users_measure_spec.rb
@@ -13,5 +13,24 @@ describe Admin::Metrics::Measure::NewUsersMeasure do
     it 'runs data query without error' do
       expect { measure.data }.to_not raise_error
     end
+
+    context 'with user records' do
+      before do
+        3.times { Fabricate :user, created_at: 2.days.ago }
+        2.times { Fabricate :user, created_at: 1.day.ago }
+        Fabricate :user, created_at: 0.days.ago
+      end
+
+      it 'returns correct user counts' do
+        expect(measure.data.size)
+          .to eq(3)
+        expect(measure.data.map(&:symbolize_keys))
+          .to contain_exactly(
+            include(date: 2.days.ago.midnight.to_time, value: '3'),
+            include(date: 1.day.ago.midnight.to_time, value: '2'),
+            include(date: 0.days.ago.midnight.to_time, value: '1')
+          )
+      end
+    end
   end
 end

--- a/spec/lib/admin/metrics/measure/new_users_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/new_users_measure_spec.rb
@@ -10,10 +10,6 @@ describe Admin::Metrics::Measure::NewUsersMeasure do
   let(:params) { ActionController::Parameters.new }
 
   describe '#data' do
-    it 'runs data query without error' do
-      expect { subject.data }.to_not raise_error
-    end
-
     context 'with user records' do
       before do
         3.times { Fabricate :user, created_at: 2.days.ago }

--- a/spec/lib/admin/metrics/measure/opened_reports_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/opened_reports_measure_spec.rb
@@ -10,10 +10,6 @@ describe Admin::Metrics::Measure::OpenedReportsMeasure do
   let(:params) { ActionController::Parameters.new }
 
   describe '#data' do
-    it 'runs data query without error' do
-      expect { subject.data }.to_not raise_error
-    end
-
     context 'with report records' do
       before do
         3.times { Fabricate :report, created_at: 2.days.ago }

--- a/spec/lib/admin/metrics/measure/opened_reports_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/opened_reports_measure_spec.rb
@@ -13,5 +13,24 @@ describe Admin::Metrics::Measure::OpenedReportsMeasure do
     it 'runs data query without error' do
       expect { measure.data }.to_not raise_error
     end
+
+    context 'with report records' do
+      before do
+        3.times { Fabricate :report, created_at: 2.days.ago }
+        2.times { Fabricate :report, created_at: 1.day.ago }
+        Fabricate :report, created_at: 0.days.ago
+      end
+
+      it 'returns correct report counts' do
+        expect(measure.data.size)
+          .to eq(3)
+        expect(measure.data.map(&:symbolize_keys))
+          .to contain_exactly(
+            include(date: 2.days.ago.midnight.to_time, value: '3'),
+            include(date: 1.day.ago.midnight.to_time, value: '2'),
+            include(date: 0.days.ago.midnight.to_time, value: '1')
+          )
+      end
+    end
   end
 end

--- a/spec/lib/admin/metrics/measure/opened_reports_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/opened_reports_measure_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe Admin::Metrics::Measure::OpenedReportsMeasure do
-  subject(:measure) { described_class.new(start_at, end_at, params) }
+  subject { described_class.new(start_at, end_at, params) }
 
   let(:start_at) { 2.days.ago }
   let(:end_at)   { Time.now.utc }
@@ -11,7 +11,7 @@ describe Admin::Metrics::Measure::OpenedReportsMeasure do
 
   describe '#data' do
     it 'runs data query without error' do
-      expect { measure.data }.to_not raise_error
+      expect { subject.data }.to_not raise_error
     end
 
     context 'with report records' do
@@ -22,9 +22,9 @@ describe Admin::Metrics::Measure::OpenedReportsMeasure do
       end
 
       it 'returns correct report counts' do
-        expect(measure.data.size)
+        expect(subject.data.size)
           .to eq(3)
-        expect(measure.data.map(&:symbolize_keys))
+        expect(subject.data.map(&:symbolize_keys))
           .to contain_exactly(
             include(date: 2.days.ago.midnight.to_time, value: '3'),
             include(date: 1.day.ago.midnight.to_time, value: '2'),

--- a/spec/lib/admin/metrics/measure/resolved_reports_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/resolved_reports_measure_spec.rb
@@ -10,10 +10,6 @@ describe Admin::Metrics::Measure::ResolvedReportsMeasure do
   let(:params) { ActionController::Parameters.new }
 
   describe '#data' do
-    it 'runs data query without error' do
-      expect { subject.data }.to_not raise_error
-    end
-
     context 'with report records' do
       before do
         3.times { Fabricate :report, action_taken_at: 2.days.ago }

--- a/spec/lib/admin/metrics/measure/resolved_reports_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/resolved_reports_measure_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe Admin::Metrics::Measure::ResolvedReportsMeasure do
-  subject(:measure) { described_class.new(start_at, end_at, params) }
+  subject { described_class.new(start_at, end_at, params) }
 
   let(:start_at) { 2.days.ago }
   let(:end_at)   { Time.now.utc }
@@ -11,7 +11,7 @@ describe Admin::Metrics::Measure::ResolvedReportsMeasure do
 
   describe '#data' do
     it 'runs data query without error' do
-      expect { measure.data }.to_not raise_error
+      expect { subject.data }.to_not raise_error
     end
 
     context 'with report records' do
@@ -22,9 +22,9 @@ describe Admin::Metrics::Measure::ResolvedReportsMeasure do
       end
 
       it 'returns correct report counts' do
-        expect(measure.data.size)
+        expect(subject.data.size)
           .to eq(3)
-        expect(measure.data.map(&:symbolize_keys))
+        expect(subject.data.map(&:symbolize_keys))
           .to contain_exactly(
             include(date: 2.days.ago.midnight.to_time, value: '3'),
             include(date: 1.day.ago.midnight.to_time, value: '2'),

--- a/spec/lib/admin/metrics/measure/resolved_reports_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/resolved_reports_measure_spec.rb
@@ -13,5 +13,24 @@ describe Admin::Metrics::Measure::ResolvedReportsMeasure do
     it 'runs data query without error' do
       expect { measure.data }.to_not raise_error
     end
+
+    context 'with report records' do
+      before do
+        3.times { Fabricate :report, action_taken_at: 2.days.ago }
+        2.times { Fabricate :report, action_taken_at: 1.day.ago }
+        Fabricate :report, action_taken_at: 0.days.ago
+      end
+
+      it 'returns correct report counts' do
+        expect(measure.data.size)
+          .to eq(3)
+        expect(measure.data.map(&:symbolize_keys))
+          .to contain_exactly(
+            include(date: 2.days.ago.midnight.to_time, value: '3'),
+            include(date: 1.day.ago.midnight.to_time, value: '2'),
+            include(date: 0.days.ago.midnight.to_time, value: '1')
+          )
+      end
+    end
   end
 end

--- a/spec/lib/admin/metrics/measure/tag_accounts_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/tag_accounts_measure_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe Admin::Metrics::Measure::TagAccountsMeasure do
-  subject(:measure) { described_class.new(start_at, end_at, params) }
+  subject { described_class.new(start_at, end_at, params) }
 
   let!(:tag) { Fabricate(:tag) }
 
@@ -13,7 +13,7 @@ describe Admin::Metrics::Measure::TagAccountsMeasure do
 
   describe '#data' do
     it 'runs data query without error' do
-      expect { measure.data }.to_not raise_error
+      expect { subject.data }.to_not raise_error
     end
 
     context 'with tagged accounts' do
@@ -38,9 +38,9 @@ describe Admin::Metrics::Measure::TagAccountsMeasure do
       end
 
       it 'returns correct tag_accounts counts' do
-        expect(measure.data.size)
+        expect(subject.data.size)
           .to eq(3)
-        expect(measure.data.map(&:symbolize_keys))
+        expect(subject.data.map(&:symbolize_keys))
           .to contain_exactly(
             include(date: 2.days.ago.midnight.to_time, value: '1'),
             include(date: 1.day.ago.midnight.to_time, value: '2'),

--- a/spec/lib/admin/metrics/measure/tag_accounts_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/tag_accounts_measure_spec.rb
@@ -15,5 +15,38 @@ describe Admin::Metrics::Measure::TagAccountsMeasure do
     it 'runs data query without error' do
       expect { measure.data }.to_not raise_error
     end
+
+    context 'with tagged accounts' do
+      let(:alice) { Fabricate(:account, domain: 'alice.example') }
+      let(:bob) { Fabricate(:account, domain: 'bob.example') }
+
+      before do
+        3.times do
+          travel_to 2.days.ago do
+            tag.history.add(alice.id)
+          end
+        end
+
+        2.times do
+          travel_to 1.day.ago do
+            tag.history.add(alice.id)
+            tag.history.add(bob.id)
+          end
+        end
+
+        tag.history.add(bob.id)
+      end
+
+      it 'returns correct tag_accounts counts' do
+        expect(measure.data.size)
+          .to eq(3)
+        expect(measure.data.map(&:symbolize_keys))
+          .to contain_exactly(
+            include(date: 2.days.ago.midnight.to_time, value: '1'),
+            include(date: 1.day.ago.midnight.to_time, value: '2'),
+            include(date: 0.days.ago.midnight.to_time, value: '1')
+          )
+      end
+    end
   end
 end

--- a/spec/lib/admin/metrics/measure/tag_accounts_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/tag_accounts_measure_spec.rb
@@ -22,19 +22,17 @@ describe Admin::Metrics::Measure::TagAccountsMeasure do
 
       before do
         3.times do
-          travel_to 2.days.ago do
-            tag.history.add(alice.id)
-          end
+          travel_to(2.days.ago) { add_tag_history(alice) }
         end
 
         2.times do
-          travel_to 1.day.ago do
-            tag.history.add(alice.id)
-            tag.history.add(bob.id)
+          travel_to(1.day.ago) do
+            add_tag_history(alice)
+            add_tag_history(bob)
           end
         end
 
-        tag.history.add(bob.id)
+        add_tag_history(bob)
       end
 
       it 'returns correct tag_accounts counts' do
@@ -46,6 +44,10 @@ describe Admin::Metrics::Measure::TagAccountsMeasure do
             include(date: 1.day.ago.midnight.to_time, value: '2'),
             include(date: 0.days.ago.midnight.to_time, value: '1')
           )
+      end
+
+      def add_tag_history(account)
+        tag.history.add(account.id)
       end
     end
   end

--- a/spec/lib/admin/metrics/measure/tag_accounts_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/tag_accounts_measure_spec.rb
@@ -12,10 +12,6 @@ describe Admin::Metrics::Measure::TagAccountsMeasure do
   let(:params) { ActionController::Parameters.new(id: tag.id) }
 
   describe '#data' do
-    it 'runs data query without error' do
-      expect { subject.data }.to_not raise_error
-    end
-
     context 'with tagged accounts' do
       let(:alice) { Fabricate(:account, domain: 'alice.example') }
       let(:bob) { Fabricate(:account, domain: 'bob.example') }

--- a/spec/lib/admin/metrics/measure/tag_servers_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/tag_servers_measure_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe Admin::Metrics::Measure::TagServersMeasure do
-  subject(:measure) { described_class.new(start_at, end_at, params) }
+  subject { described_class.new(start_at, end_at, params) }
 
   let!(:tag) { Fabricate(:tag) }
 
@@ -13,7 +13,7 @@ describe Admin::Metrics::Measure::TagServersMeasure do
 
   describe '#data' do
     it 'runs data query without error' do
-      expect { measure.data }.to_not raise_error
+      expect { subject.data }.to_not raise_error
     end
 
     context 'with tagged statuses' do
@@ -39,9 +39,9 @@ describe Admin::Metrics::Measure::TagServersMeasure do
       end
 
       it 'returns correct tag counts' do
-        expect(measure.data.size)
+        expect(subject.data.size)
           .to eq(3)
-        expect(measure.data.map(&:symbolize_keys))
+        expect(subject.data.map(&:symbolize_keys))
           .to contain_exactly(
             include(date: 2.days.ago.midnight.to_time, value: '1'),
             include(date: 1.day.ago.midnight.to_time, value: '2'),

--- a/spec/lib/admin/metrics/measure/tag_servers_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/tag_servers_measure_spec.rb
@@ -12,10 +12,6 @@ describe Admin::Metrics::Measure::TagServersMeasure do
   let(:params) { ActionController::Parameters.new(id: tag.id) }
 
   describe '#data' do
-    it 'runs data query without error' do
-      expect { subject.data }.to_not raise_error
-    end
-
     context 'with tagged statuses' do
       let(:alice) { Fabricate(:account, domain: 'alice.example') }
       let(:bob) { Fabricate(:account, domain: 'bob.example') }

--- a/spec/lib/admin/metrics/measure/tag_servers_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/tag_servers_measure_spec.rb
@@ -15,5 +15,39 @@ describe Admin::Metrics::Measure::TagServersMeasure do
     it 'runs data query without error' do
       expect { measure.data }.to_not raise_error
     end
+
+    context 'with tagged statuses' do
+      let(:alice) { Fabricate(:account, domain: 'alice.example') }
+      let(:bob) { Fabricate(:account, domain: 'bob.example') }
+
+      before do
+        3.times do
+          status_alice = Fabricate(:status, account: alice, created_at: 2.days.ago)
+          status_alice.tags << tag
+        end
+
+        2.times do
+          status_alice = Fabricate(:status, account: alice, created_at: 1.day.ago)
+          status_alice.tags << tag
+
+          status_bob = Fabricate(:status, account: bob, created_at: 1.day.ago)
+          status_bob.tags << tag
+        end
+
+        status_bob = Fabricate(:status, account: bob, created_at: 0.days.ago)
+        status_bob.tags << tag
+      end
+
+      it 'returns correct tag counts' do
+        expect(measure.data.size)
+          .to eq(3)
+        expect(measure.data.map(&:symbolize_keys))
+          .to contain_exactly(
+            include(date: 2.days.ago.midnight.to_time, value: '1'),
+            include(date: 1.day.ago.midnight.to_time, value: '2'),
+            include(date: 0.days.ago.midnight.to_time, value: '1')
+          )
+      end
+    end
   end
 end

--- a/spec/lib/admin/metrics/measure/tag_uses_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/tag_uses_measure_spec.rb
@@ -12,10 +12,6 @@ describe Admin::Metrics::Measure::TagUsesMeasure do
   let(:params) { ActionController::Parameters.new(id: tag.id) }
 
   describe '#data' do
-    it 'runs data query without error' do
-      expect { subject.data }.to_not raise_error
-    end
-
     context 'with tagged accounts' do
       let(:alice) { Fabricate(:account, domain: 'alice.example') }
       let(:bob) { Fabricate(:account, domain: 'bob.example') }

--- a/spec/lib/admin/metrics/measure/tag_uses_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/tag_uses_measure_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe Admin::Metrics::Measure::TagUsesMeasure do
-  subject(:measure) { described_class.new(start_at, end_at, params) }
+  subject { described_class.new(start_at, end_at, params) }
 
   let!(:tag) { Fabricate(:tag) }
 
@@ -13,7 +13,7 @@ describe Admin::Metrics::Measure::TagUsesMeasure do
 
   describe '#data' do
     it 'runs data query without error' do
-      expect { measure.data }.to_not raise_error
+      expect { subject.data }.to_not raise_error
     end
 
     context 'with tagged accounts' do
@@ -38,9 +38,9 @@ describe Admin::Metrics::Measure::TagUsesMeasure do
       end
 
       it 'returns correct tag_uses counts' do
-        expect(measure.data.size)
+        expect(subject.data.size)
           .to eq(3)
-        expect(measure.data.map(&:symbolize_keys))
+        expect(subject.data.map(&:symbolize_keys))
           .to contain_exactly(
             include(date: 2.days.ago.midnight.to_time, value: '3'),
             include(date: 1.day.ago.midnight.to_time, value: '4'),

--- a/spec/lib/admin/metrics/measure/tag_uses_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/tag_uses_measure_spec.rb
@@ -22,19 +22,17 @@ describe Admin::Metrics::Measure::TagUsesMeasure do
 
       before do
         3.times do
-          travel_to 2.days.ago do
-            tag.history.add(alice.id)
-          end
+          travel_to(2.days.ago) { add_tag_history(alice) }
         end
 
         2.times do
-          travel_to 1.day.ago do
-            tag.history.add(alice.id)
-            tag.history.add(bob.id)
+          travel_to(1.day.ago) do
+            add_tag_history(alice)
+            add_tag_history(bob)
           end
         end
 
-        tag.history.add(bob.id)
+        add_tag_history(bob)
       end
 
       it 'returns correct tag_uses counts' do
@@ -46,6 +44,10 @@ describe Admin::Metrics::Measure::TagUsesMeasure do
             include(date: 1.day.ago.midnight.to_time, value: '4'),
             include(date: 0.days.ago.midnight.to_time, value: '1')
           )
+      end
+
+      def add_tag_history(account)
+        tag.history.add(account.id)
       end
     end
   end


### PR DESCRIPTION
As part of a previous change we had added very basic spec coverage for all of these to just assert that their `data` methods could run without error. I believe this was during the Rails 7 upgrade and we did run into changing method signature for some of the sql methods they rely on. The coverage added at the time was very barebones and really just meant to exercise the code.

This PR expands coverage a bit for all of the `Dimension::` and `Measure::` classes. It is not fully exhaustive, but in every case I attempted to either add some basic data or expand on what was there already, and add some assertions about the results. The changes in spec should all be easy to review, and are all very similar in each file.

Notes on a mix of enhancements/bug-fixes within `app` that I discovered while adding the spec coverage:

- In activity_tracker, updated a ruby range to use `..` instead of `...` - this was previously dropping the final date from the expected range.
- In a number of classes where we use the snowflake to get the earliest/latest status ID, I was running into spec failures and realized that sometimes the difference in timestamp from my test data to the range in the measurement class was putting the spec data out of the range. I updated the timestamp calculations here to use the very beginning of the earliest day and very end of the last day, to ensure that the full range was included.
- The media attachment query had scenarios where it would return NULL instead of 0 -- added a COALESCE here to ensure an integer value comes out.
- The tag servers measure was selecting `AS day` which was colliding with the generate_series value and leading to `nil` keys in the resulting hash. Updated this to use `AS period` like the other class queries do.
- Also in tag servers, minor syntax change to the interval section of the generate_series to match other classes
- Also in tag servers, modified the overall query to use sql `WITH ...` syntax to match the other queries -- this one specifically is in advance of what I intend as a followup refactor here to simplify  most of the queries in the measures/ classes.

