### PR TITLE
filter home when boosts are hidden

### DIFF
--- a/app/javascript/mastodon/actions/accounts.js
+++ b/app/javascript/mastodon/actions/accounts.js
@@ -147,7 +147,7 @@ export function followAccount(id, options = { reblogs: true }) {
     dispatch(followAccountRequest({ id, locked }));
 
     api(getState).post(`/api/v1/accounts/${id}/follow`, options).then(response => {
-      dispatch(followAccountSuccess({relationship: response.data, alreadyFollowing}));
+      dispatch(followAccountSuccess({relationship: response.data, statuses: getState().get('statuses'), alreadyFollowing}));
     }).catch(error => {
       dispatch(followAccountFail({ id, error, locked }));
     });

--- a/app/javascript/mastodon/actions/accounts_typed.ts
+++ b/app/javascript/mastodon/actions/accounts_typed.ts
@@ -24,6 +24,7 @@ export const followAccountSuccess = createAction(
   'accounts/followAccount/SUCCESS',
   actionWithSkipLoadingTrue<{
     relationship: ApiRelationshipJSON;
+    statuses: unknown;
     alreadyFollowing: boolean;
   }>,
 );

--- a/app/javascript/mastodon/reducers/timelines.js
+++ b/app/javascript/mastodon/reducers/timelines.js
@@ -3,7 +3,8 @@ import { Map as ImmutableMap, List as ImmutableList, OrderedSet as ImmutableOrde
 import {
   blockAccountSuccess,
   muteAccountSuccess,
-  unfollowAccountSuccess
+  unfollowAccountSuccess,
+  followAccountSuccess
 } from '../actions/accounts';
 import {
   TIMELINE_UPDATE,
@@ -203,6 +204,7 @@ export default function timelines(state = initialState, action) {
   case blockAccountSuccess.type:
   case muteAccountSuccess.type:
     return filterTimelines(state, action.payload.relationship, action.payload.statuses);
+  case followAccountSuccess.type:
   case unfollowAccountSuccess.type:
     return filterTimeline('home', state, action.payload.relationship, action.payload.statuses);
   case TIMELINE_SCROLL_TOP:


### PR DESCRIPTION
Filter the home timeline when someone wants to hide a user's boosts. Currently, the boosts stay in the timeline. This is extremely annoying when you want to hide the boosts of someone who boosts indiscriminately.