### PR TITLE
Use Rails `upsert` to generate update_count! query in Counters concern

### DIFF
--- a/app/models/concerns/account/counters.rb
+++ b/app/models/concerns/account/counters.rb
@@ -35,40 +35,11 @@ module Account::Counters
     raise ArgumentError, "Invalid key #{key}" unless ALLOWED_COUNTER_KEYS.include?(key)
     raise ArgumentError, 'Do not call update_count! on dirty objects' if association(:account_stat).loaded? && account_stat&.changed? && account_stat.changed_attribute_names_to_save == %w(id)
 
-    value = value.to_i
-    default_value = value.positive? ? value : 0
-
-    # We do an upsert using manually written SQL, as Rails' upsert method does
-    # not seem to support writing expressions in the UPDATE clause, but only
-    # re-insert the provided values instead.
-    # Even ARel seem to be missing proper handling of upserts.
-    sql = if value.positive? && key == :statuses_count
-            <<-SQL.squish
-              INSERT INTO account_stats(account_id, #{key}, created_at, updated_at, last_status_at)
-                VALUES (:account_id, :default_value, now(), now(), now())
-              ON CONFLICT (account_id) DO UPDATE
-              SET #{key} = account_stats.#{key} + :value,
-                  last_status_at = now(),
-                  updated_at = now()
-              RETURNING id;
-            SQL
-          else
-            <<-SQL.squish
-              INSERT INTO account_stats(account_id, #{key}, created_at, updated_at)
-                VALUES (:account_id, :default_value, now(), now())
-              ON CONFLICT (account_id) DO UPDATE
-              SET #{key} = account_stats.#{key} + :value,
-                  updated_at = now()
-              RETURNING id;
-            SQL
-          end
-
-    sql = AccountStat.sanitize_sql([sql, account_id: id, default_value: default_value, value: value])
-    account_stat_id = AccountStat.connection.exec_query(sql)[0]['id']
+    result = updated_account_stat(key, value)
 
     # Reload account_stat if it was loaded, taking into account newly-created unsaved records
     if association(:account_stat).loaded?
-      account_stat.id = account_stat_id if account_stat.new_record?
+      account_stat.id = result.first['id'] if account_stat.new_record?
       account_stat.reload
     end
   end
@@ -78,6 +49,28 @@ module Account::Counters
   end
 
   private
+
+  def updated_account_stat(key, value)
+    AccountStat.upsert(
+      initial_values(key, value),
+      on_duplicate: duplicate_values(key, value),
+      unique_by: :account_id
+    )
+  end
+
+  def initial_values(key, value)
+    { :account_id => id, key => [value, 0].max }.tap do |values|
+      values.merge!(last_status_at: Time.current) if key == :statuses_count
+    end
+  end
+
+  def duplicate_values(key, value)
+    Arel.sql(
+      ["#{key} = (account_stats.#{key} + #{value})", 'updated_at = CURRENT_TIMESTAMP'].tap do |values|
+        values << 'last_status_at = CURRENT_TIMESTAMP' if key == :statuses_count
+      end.join(', ')
+    )
+  end
 
   def save_account_stat
     return unless association(:account_stat).loaded? && account_stat&.changed?

--- a/app/models/concerns/account/counters.rb
+++ b/app/models/concerns/account/counters.rb
@@ -67,7 +67,7 @@ module Account::Counters
   def duplicate_values(key, value)
     Arel.sql(
       ["#{key} = (account_stats.#{key} + #{value})", 'updated_at = CURRENT_TIMESTAMP'].tap do |values|
-        values << 'last_status_at = CURRENT_TIMESTAMP' if key == :statuses_count
+        values << 'last_status_at = CURRENT_TIMESTAMP' if key == :statuses_count && value.positive?
       end.join(', ')
     )
   end

--- a/app/models/concerns/account/counters.rb
+++ b/app/models/concerns/account/counters.rb
@@ -35,7 +35,7 @@ module Account::Counters
     raise ArgumentError, "Invalid key #{key}" unless ALLOWED_COUNTER_KEYS.include?(key)
     raise ArgumentError, 'Do not call update_count! on dirty objects' if association(:account_stat).loaded? && account_stat&.changed? && account_stat.changed_attribute_names_to_save == %w(id)
 
-    result = updated_account_stat(key, value)
+    result = updated_account_stat(key, value.to_i)
 
     # Reload account_stat if it was loaded, taking into account newly-created unsaved records
     if association(:account_stat).loaded?

--- a/spec/models/concerns/account/counters_spec.rb
+++ b/spec/models/concerns/account/counters_spec.rb
@@ -44,5 +44,18 @@ describe Account::Counters do
 
       expect(account.statuses_count).to eq 5
     end
+
+    it 'preserves last_status_at when decrementing statuses_count' do
+      account_stat = Fabricate(
+        :account_stat,
+        account: account,
+        last_status_at: 3.days.ago,
+        statuses_count: 10
+      )
+
+      expect { account.decrement_count!(:statuses_count) }
+        .to change(account_stat.reload, :statuses_count).by(-1)
+        .and not_change(account_stat.reload, :last_status_at)
+    end
   end
 end


### PR DESCRIPTION
Rails upsert support has improved (see notes in original impl here about lack of full support) and there now are options to support this operation via the framework.

There are specs for the `increment_count!` and `decrement_count!` methods in this class, which are the main users of the method and I think cover the two basic paths (with and without statuses_count being present).

Here's the before/after SQL for the general case when `statuses_count` is not present (formatting modified for comparison, but generated syntax not edited)...

Before:

```sql
INSERT INTO account_stats(account_id, followers_count, created_at, updated_at)
  VALUES (111760098696776148, 1, now(), now())
ON CONFLICT (account_id) DO UPDATE
  SET followers_count = account_stats.followers_count + 1, updated_at = now()
RETURNING id
```

After:

```sql
INSERT INTO "account_stats" ("account_id","followers_count","created_at","updated_at")
  VALUES (111760113389768635, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
ON CONFLICT ("account_id") DO UPDATE
  SET followers_count = (account_stats.followers_count + 1), updated_at = CURRENT_TIMESTAMP
RETURNING "id"
```

And when `statuses_count` is present...

Before:

```sql
INSERT INTO account_stats(account_id, statuses_count, created_at, updated_at, last_status_at)
  VALUES (111760098650761743, 1, now(), now(), now())
ON CONFLICT (account_id) DO UPDATE
  SET statuses_count = account_stats.statuses_count + 1, last_status_at = now(), updated_at = now()
RETURNING id
```

After:

```sql
INSERT INTO "account_stats" ("account_id","statuses_count","last_status_at","created_at","updated_at")
  VALUES (111760118307840353, 1, '2024-01-15 13:07:51.355159', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
ON CONFLICT ("account_id") DO UPDATE
  SET statuses_count = (account_stats.statuses_count + 1), updated_at = CURRENT_TIMESTAMP, last_status_at = CURRENT_TIMESTAMP
RETURNING "id"
```

Differences here:

- Quoting around columns/tables
- The framework generates `CURRENT_TIMESTAMP` instead of `NOW()`, but I believe these are equivalent. I've used the former in the code so it matches framework.
- We previously sent `last_status_at = NOW()` in our sql string for the scenario where we are creating the record for the first time and updating statuses_count and need a value for the status timestamp ... but I can't figure out how to do this in the hash args style, so I'm using `Time.current` on the ruby side. I suspect this is fine, since the previous implementation also allowed for possible gaps between the written value for the status and the value in this field, but just wanted to note it as a difference. We could potentially improve this by finding the status first, at the cost of an additional query.