### PR TITLE
Disable `Style/ArgumentsForwarding` cop until we are on 3.1+ target version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -155,6 +155,12 @@ RSpec/SpecFilePathFormat:
     OEmbedController: oembed_controller
     OStatus: ostatus
 
+# Reason: Disable until we are at 3.1+ for version target
+# TODO: When we bump to 3.1, first correct Naming/BlockForwarding cops, then enable this
+# https://docs.rubocop.org/rubocop/cops_style.html#styleargumentsforwarding
+Style/ArgumentsForwarding:
+  Enabled: false
+
 # Reason:
 # https://docs.rubocop.org/rubocop/cops_style.html#styleclassandmodulechildren
 Style/ClassAndModuleChildren:


### PR DESCRIPTION
This rubocop bump - https://github.com/mastodon/mastodon/pull/28731 - wants us to fix all the `Style/ArgumentsForwarding` cops. Example of this is like:

```
def method(&block); other(&block); end
```

Would fix to:

```
def method(...); other(...); end
```

While we do have this style in a few places, in my opinion some of these would be better fixed with anonymous block forwarding first (and then the remainder fixed by this cop), which is not available until 3.1.

Given that 3.0 is EOL in a few months, I'd propose disabling this for now, then at whatever point we enable 3.1 as rubocop target, we first put anonymous block forwarding in place, then turn on this cop and see what it wants at that point.

