### PR TITLE
Add webhooks: `block.created`, `mute.created`, `follow.created`

### DIFF
--- a/app/models/follow_request.rb
+++ b/app/models/follow_request.rb
@@ -35,6 +35,9 @@ class FollowRequest < ApplicationRecord
     follow = account.follow!(target_account, reblogs: show_reblogs, notify: notify, languages: languages, uri: uri, bypass_limit: true)
     ListAccount.where(follow_request: self).update_all(follow_request_id: nil, follow_id: follow.id)
     MergeWorker.perform_async(target_account.id, account.id) if account.local?
+
+    TriggerWebhookWorker.perform_async('follow.created', 'Follow', follow.id)
+
     destroy!
   end
 

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -23,6 +23,12 @@ class Webhook < ApplicationRecord
     report.updated
     status.created
     status.updated
+    block.created
+    block.removed
+    follow.created
+    follow.removed
+    mute.created
+    mute.removed
   ).freeze
 
   attr_writer :current_account
@@ -62,7 +68,7 @@ class Webhook < ApplicationRecord
       :manage_users
     when 'report.created', 'report.updated'
       :manage_reports
-    when 'status.created', 'status.updated'
+    when 'status.created', 'status.updated', 'block.created', 'block.removed', 'follow.created', 'follow.removed', 'mute.created', 'mute.removed' # TODO: find the correct permission
       :view_devops
     end
   end

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -24,11 +24,8 @@ class Webhook < ApplicationRecord
     status.created
     status.updated
     block.created
-    block.removed
     follow.created
-    follow.removed
     mute.created
-    mute.removed
   ).freeze
 
   attr_writer :current_account
@@ -64,11 +61,13 @@ class Webhook < ApplicationRecord
 
   def self.permission_for_event(event)
     case event
-    when 'account.approved', 'account.created', 'account.updated'
+    when 'account.approved', 'account.created', 'account.updated', 'follow.created'
       :manage_users
     when 'report.created', 'report.updated'
       :manage_reports
-    when 'status.created', 'status.updated', 'block.created', 'block.removed', 'follow.created', 'follow.removed', 'mute.created', 'mute.removed' # TODO: find the correct permission
+    when 'block.created', 'mute.created'
+      :manage_blocks
+    when 'status.created', 'status.updated'
       :view_devops
     end
   end

--- a/app/serializers/rest/admin/webhook_event_serializer.rb
+++ b/app/serializers/rest/admin/webhook_event_serializer.rb
@@ -9,6 +9,12 @@ class REST::Admin::WebhookEventSerializer < ActiveModel::Serializer
       REST::Admin::ReportSerializer
     when 'Status'
       REST::StatusSerializer
+    when 'Follow'
+      REST::FollowSerializer
+    when 'Mute'
+      REST::MuteSerializer
+    when 'Block'
+      REST::BlockSerializer
     else
       super
     end

--- a/app/serializers/rest/block_serializer.rb
+++ b/app/serializers/rest/block_serializer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class REST::BlockSerializer < ActiveModel::Serializer
+  attributes :id, :created_at, :updated_at, :account_id, :target_account_id, :uri
+
+  def id
+    object.id.to_s
+  end
+end

--- a/app/serializers/rest/follow_serializer.rb
+++ b/app/serializers/rest/follow_serializer.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class REST::FollowSerializer < ActiveModel::Serializer
+  attributes :id, :created_at, :updated_at, :account_id,
+             :target_account_id, :show_reblogs, :uri,
+             :notify, :languages
+
+  def id
+    object.id.to_s
+  end
+end

--- a/app/serializers/rest/mute_serializer.rb
+++ b/app/serializers/rest/mute_serializer.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class REST::MuteSerializer < ActiveModel::Serializer
+  attributes :id, :created_at, :updated_at, :hide_notifications,
+             :account_id, :target_account_id, :expires_at
+
+  def id
+    object.id.to_s
+  end
+end

--- a/app/services/mute_service.rb
+++ b/app/services/mute_service.rb
@@ -6,6 +6,8 @@ class MuteService < BaseService
 
     mute = account.mute!(target_account, notifications: notifications, duration: duration)
 
+    TriggerWebhookWorker.perform_async('mute.created', 'Mute', mute.id)
+
     if mute.hide_notifications?
       BlockWorker.perform_async(account.id, target_account.id)
     else


### PR DESCRIPTION
This PR adds Webhooks for when certain user interactions take place on an instance. 

The permissions required for these webhooks are based on my best guess and I'm open to changing them. 

Example bodies sent to a Webhook Endpoint (for future documentation and app developers reference):

#### `block.created`
```json
{
    "event": "block.created",
    "created_at": "2024-01-15T19:22:28.134Z",
    "object": {
        "id": 1,
        "created_at": "2024-01-15T19:22:28.025Z",
        "updated_at": "2024-01-15T19:22:28.025Z",
        "account_id": 110482205265885150,
        "target_account_id": 111484398945680759,
        "uri": "https://<mastodon.example>/68e9cf81-ec5e-40ab-a775-1e510c83fcea"
    }
}
```

#### `follow.created`
```json
{
    "event": "follow.created",
    "created_at": "2024-01-15T19:22:46.080Z",
    "object": {
        "id": 1,
        "created_at": "2024-01-15T19:22:46.014Z",
        "updated_at": "2024-01-15T19:22:46.014Z",
        "account_id": 110482205265885150,
        "target_account_id": 111484398945680759,
        "show_reblogs": true,
        "uri": "https://<mastodon.example>/8cbcffcc-14a2-4f1f-baa9-15cb42af78a2",
        "notify": false,
        "languages": null
    }
}
```

#### `mute.created`
```json
{
    "event": "mute.created",
    "created_at": "2024-01-15T19:22:59.911Z",
    "object": {
        "id": 1,
        "created_at": "2024-01-15T19:22:59.899Z",
        "updated_at": "2024-01-15T19:22:59.899Z",
        "hide_notifications": true,
        "account_id": 110482205265885150,
        "target_account_id": 111484398945680759,
        "expires_at": null
    }
}
```

I'm working on creating Webhooks for the inverse of these actions: `block.removed`, `follow.removed` and `mute.removed` but am separating these out as they work more like the other already implemented Webhooks.