### PR TITLE
Use top-level `warn` in JS errors check

### DIFF
--- a/spec/support/javascript_errors.rb
+++ b/spec/support/javascript_errors.rb
@@ -9,8 +9,8 @@ RSpec.configure do |config|
           expect(error.level).to_not eq('SEVERE'), error.message
           next unless error.level == 'WARNING'
 
-          $stderr.warn 'WARN: javascript warning'
-          $stderr.warn error.message
+          warn 'WARN: javascript warning'
+          warn error.message
         end
       end
     end


### PR DESCRIPTION
In the initial version of this I was using `puts`. In correcting a linter error I did the wrong thing here and didn't verify it worked.

Tested this one locally and this works as expected.