### PR TITLE
Pull out one level of shared html from mailer views

### DIFF
--- a/app/views/layouts/mailer.html.haml
+++ b/app/views/layouts/mailer.html.haml
@@ -60,8 +60,11 @@
                     %table.email-body-table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
                       %tr
                         %td.email-body-td
-                          -# Content
-                          = yield
+                          %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+                            %tr
+                              %td.email-body-padding-td
+                                -# Content
+                                = yield
 
               /[if mso]
                 </td></tr></table>

--- a/app/views/notification_mailer/favourite.html.haml
+++ b/app/views/notification_mailer/favourite.html.haml
@@ -1,13 +1,10 @@
 = content_for :heading do
   = render 'application/mailer/heading', heading_title: t('notification_mailer.favourite.title'), heading_subtitle: t('notification_mailer.favourite.body', name: @account.pretty_acct), heading_image_url: frontend_asset_url('images/mailer-new/heading/favorite.png')
-%table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+%table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
-    %td.email-body-padding-td
-      %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+    %td.email-inner-card-td
+      = render 'status', status: @status, time_zone: @me.user_time_zone
+      %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
         %tr
-          %td.email-inner-card-td
-            = render 'status', status: @status, time_zone: @me.user_time_zone
-            %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-              %tr
-                %td.email-padding-top-24
-                  = render 'application/mailer/button', text: t('application_mailer.view_status'), url: web_url("@#{@status.account.pretty_acct}/#{@status.id}")
+          %td.email-padding-top-24
+            = render 'application/mailer/button', text: t('application_mailer.view_status'), url: web_url("@#{@status.account.pretty_acct}/#{@status.id}")

--- a/app/views/notification_mailer/follow.html.haml
+++ b/app/views/notification_mailer/follow.html.haml
@@ -1,13 +1,10 @@
 = content_for :heading do
   = render 'application/mailer/heading', heading_title: t('notification_mailer.follow.title'), heading_subtitle: t('notification_mailer.follow.body', name: @account.pretty_acct), heading_image_url: frontend_asset_url('images/mailer-new/heading/user.png')
-%table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+%table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
-    %td.email-body-padding-td
-      %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+    %td.email-inner-card-td-without-padding
+      = render 'application/mailer/account', account: @account
+      %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
         %tr
-          %td.email-inner-card-td-without-padding
-            = render 'application/mailer/account', account: @account
-            %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-              %tr
-                %td.email-padding-24.email-padding-top-0
-                  = render 'application/mailer/button', text: t('application_mailer.view_profile'), url: web_url("@#{@account.pretty_acct}")
+          %td.email-padding-24.email-padding-top-0
+            = render 'application/mailer/button', text: t('application_mailer.view_profile'), url: web_url("@#{@account.pretty_acct}")

--- a/app/views/notification_mailer/follow_request.html.haml
+++ b/app/views/notification_mailer/follow_request.html.haml
@@ -1,13 +1,10 @@
 = content_for :heading do
   = render 'application/mailer/heading', heading_title: t('notification_mailer.follow_request.title'), heading_subtitle: t('notification_mailer.follow_request.body', name: @account.pretty_acct), heading_image_url: frontend_asset_url('images/mailer-new/heading/follow.png')
-%table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+%table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
-    %td.email-body-padding-td
-      %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+    %td.email-inner-card-td-without-padding
+      = render 'application/mailer/account', account: @account
+      %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
         %tr
-          %td.email-inner-card-td-without-padding
-            = render 'application/mailer/account', account: @account
-            %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-              %tr
-                %td.email-padding-24.email-padding-top-0
-                  = render 'application/mailer/button', text: t('notification_mailer.follow_request.action'), url: web_url('follow_requests')
+          %td.email-padding-24.email-padding-top-0
+            = render 'application/mailer/button', text: t('notification_mailer.follow_request.action'), url: web_url('follow_requests')

--- a/app/views/notification_mailer/mention.html.haml
+++ b/app/views/notification_mailer/mention.html.haml
@@ -1,13 +1,10 @@
 = content_for :heading do
   = render 'application/mailer/heading', heading_title: t('notification_mailer.mention.title'), heading_subtitle: t('notification_mailer.mention.body', name: @status.account.pretty_acct), heading_image_url: frontend_asset_url('images/mailer-new/heading/mention.png')
-%table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+%table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
-    %td.email-body-padding-td
-      %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+    %td.email-inner-card-td
+      = render 'status', status: @status, time_zone: @me.user_time_zone
+      %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
         %tr
-          %td.email-inner-card-td
-            = render 'status', status: @status, time_zone: @me.user_time_zone
-            %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-              %tr
-                %td.email-padding-top-24
-                  = render 'application/mailer/button', text: t('notification_mailer.mention.action'), url: web_url("@#{@status.account.pretty_acct}/#{@status.id}")
+          %td.email-padding-top-24
+            = render 'application/mailer/button', text: t('notification_mailer.mention.action'), url: web_url("@#{@status.account.pretty_acct}/#{@status.id}")

--- a/app/views/notification_mailer/reblog.html.haml
+++ b/app/views/notification_mailer/reblog.html.haml
@@ -1,13 +1,10 @@
 = content_for :heading do
   = render 'application/mailer/heading', heading_title: t('notification_mailer.reblog.title'), heading_subtitle: t('notification_mailer.reblog.body', name: @account.pretty_acct), heading_image_url: frontend_asset_url('images/mailer-new/heading/boost.png')
-%table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+%table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
-    %td.email-body-padding-td
-      %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+    %td.email-inner-card-td
+      = render 'status', status: @status, time_zone: @me.user_time_zone
+      %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
         %tr
-          %td.email-inner-card-td
-            = render 'status', status: @status, time_zone: @me.user_time_zone
-            %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-              %tr
-                %td.email-padding-top-24
-                  = render 'application/mailer/button', text: t('application_mailer.view_status'), url: web_url("@#{@status.account.pretty_acct}/#{@status.id}")
+          %td.email-padding-top-24
+            = render 'application/mailer/button', text: t('application_mailer.view_status'), url: web_url("@#{@status.account.pretty_acct}/#{@status.id}")

--- a/app/views/user_mailer/appeal_approved.html.haml
+++ b/app/views/user_mailer/appeal_approved.html.haml
@@ -1,12 +1,9 @@
 = content_for :heading do
   = render 'application/mailer/heading', heading_title: t('user_mailer.appeal_approved.title'), heading_subtitle: t('user_mailer.appeal_approved.subtitle'), heading_image_url: frontend_asset_url('images/mailer-new/heading/appeal-approved.png')
-%table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+%table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
-    %td.email-body-padding-td
-      %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-        %tr
-          %td.email-inner-card-td.email-prose
-            %p= t 'user_mailer.appeal_approved.explanation',
-                  appeal_date: l(@appeal.created_at.in_time_zone(@resource.time_zone.presence), format: :with_time_zone),
-                  strike_date: l(@appeal.strike.created_at.in_time_zone(@resource.time_zone.presence), format: :with_time_zone)
-            = render 'application/mailer/button', text: t('user_mailer.appeal_approved.action'), url: root_url
+    %td.email-inner-card-td.email-prose
+      %p= t 'user_mailer.appeal_approved.explanation',
+            appeal_date: l(@appeal.created_at.in_time_zone(@resource.time_zone.presence), format: :with_time_zone),
+            strike_date: l(@appeal.strike.created_at.in_time_zone(@resource.time_zone.presence), format: :with_time_zone)
+      = render 'application/mailer/button', text: t('user_mailer.appeal_approved.action'), url: root_url

--- a/app/views/user_mailer/appeal_rejected.html.haml
+++ b/app/views/user_mailer/appeal_rejected.html.haml
@@ -1,12 +1,9 @@
 = content_for :heading do
   = render 'application/mailer/heading', heading_title: t('user_mailer.appeal_rejected.title'), heading_subtitle: t('user_mailer.appeal_rejected.subtitle'), heading_image_url: frontend_asset_url('images/mailer-new/heading/appeal-rejected.png')
-%table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+%table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
-    %td.email-body-padding-td
-      %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-        %tr
-          %td.email-inner-card-td.email-prose
-            %p= t 'user_mailer.appeal_rejected.explanation',
-                  appeal_date: l(@appeal.created_at.in_time_zone(@resource.time_zone.presence), format: :with_time_zone),
-                  strike_date: l(@appeal.strike.created_at.in_time_zone(@resource.time_zone.presence), format: :with_time_zone)
-            = render 'application/mailer/button', text: t('user_mailer.appeal_approved.action'), url: root_url
+    %td.email-inner-card-td.email-prose
+      %p= t 'user_mailer.appeal_rejected.explanation',
+            appeal_date: l(@appeal.created_at.in_time_zone(@resource.time_zone.presence), format: :with_time_zone),
+            strike_date: l(@appeal.strike.created_at.in_time_zone(@resource.time_zone.presence), format: :with_time_zone)
+      = render 'application/mailer/button', text: t('user_mailer.appeal_approved.action'), url: root_url

--- a/app/views/user_mailer/backup_ready.html.haml
+++ b/app/views/user_mailer/backup_ready.html.haml
@@ -1,10 +1,7 @@
 = content_for :heading do
   = render 'application/mailer/heading', heading_title: t('user_mailer.backup_ready.title'), heading_subtitle: t('user_mailer.backup_ready.explanation'), heading_image_url: frontend_asset_url('images/mailer-new/heading/archive.png')
-%table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+%table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
-    %td.email-body-padding-td
-      %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-        %tr
-          %td.email-inner-card-td.email-prose
-            %p= t 'user_mailer.backup_ready.extra'
-            = render 'application/mailer/button', text: t('exports.archive_takeout.download'), url: download_backup_url(@backup)
+    %td.email-inner-card-td.email-prose
+      %p= t 'user_mailer.backup_ready.extra'
+      = render 'application/mailer/button', text: t('exports.archive_takeout.download'), url: download_backup_url(@backup)

--- a/app/views/user_mailer/confirmation_instructions.html.haml
+++ b/app/views/user_mailer/confirmation_instructions.html.haml
@@ -1,14 +1,11 @@
 = content_for :heading do
   = render 'application/mailer/heading', heading_title: t('devise.mailer.confirmation_instructions.title'), heading_image_url: frontend_asset_url('images/mailer-new/heading/email.png')
-%table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+%table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
-    %td.email-body-padding-td
-      %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-        %tr
-          %td.email-inner-card-td.email-prose
-            %p= t @resource.approved? ? 'devise.mailer.confirmation_instructions.explanation' : 'devise.mailer.confirmation_instructions.explanation_when_pending', host: site_hostname
-            - if @resource.created_by_application
-              = render 'application/mailer/button', text: t('devise.mailer.confirmation_instructions.action_with_app', app: @resource.created_by_application.name), url: confirmation_url(@resource, confirmation_token: @token, redirect_to_app: 'true')
-            - else
-              = render 'application/mailer/button', text: t('devise.mailer.confirmation_instructions.action'), url: confirmation_url(@resource, confirmation_token: @token)
-            %p= t 'devise.mailer.confirmation_instructions.extra_html', terms_path: about_more_url, policy_path: privacy_policy_url
+    %td.email-inner-card-td.email-prose
+      %p= t @resource.approved? ? 'devise.mailer.confirmation_instructions.explanation' : 'devise.mailer.confirmation_instructions.explanation_when_pending', host: site_hostname
+      - if @resource.created_by_application
+        = render 'application/mailer/button', text: t('devise.mailer.confirmation_instructions.action_with_app', app: @resource.created_by_application.name), url: confirmation_url(@resource, confirmation_token: @token, redirect_to_app: 'true')
+      - else
+        = render 'application/mailer/button', text: t('devise.mailer.confirmation_instructions.action'), url: confirmation_url(@resource, confirmation_token: @token)
+      %p= t 'devise.mailer.confirmation_instructions.extra_html', terms_path: about_more_url, policy_path: privacy_policy_url

--- a/app/views/user_mailer/email_changed.html.haml
+++ b/app/views/user_mailer/email_changed.html.haml
@@ -1,11 +1,8 @@
 = content_for :heading do
   = render 'application/mailer/heading', heading_title: t('devise.mailer.email_changed.title'), heading_subtitle: t('devise.mailer.email_changed.explanation'), heading_image_url: frontend_asset_url('images/mailer-new/heading/email.png')
-%table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+%table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
-    %td.email-body-padding-td
-      %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-        %tr
-          %td.email-inner-card-td.email-prose
-            = render 'application/mailer/frame', text: @resource.unconfirmed_email
-            %p= t 'devise.mailer.email_changed.extra'
-            = render 'application/mailer/button', text: t('settings.account_settings'), url: edit_user_registration_url
+    %td.email-inner-card-td.email-prose
+      = render 'application/mailer/frame', text: @resource.unconfirmed_email
+      %p= t 'devise.mailer.email_changed.extra'
+      = render 'application/mailer/button', text: t('settings.account_settings'), url: edit_user_registration_url

--- a/app/views/user_mailer/password_change.html.haml
+++ b/app/views/user_mailer/password_change.html.haml
@@ -1,10 +1,7 @@
 = content_for :heading do
   = render 'application/mailer/heading', heading_title: t('devise.mailer.password_change.title'), heading_subtitle: t('devise.mailer.password_change.explanation'), heading_image_url: frontend_asset_url('images/mailer-new/heading/password.png')
-%table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+%table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
-    %td.email-body-padding-td
-      %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-        %tr
-          %td.email-inner-card-td.email-prose
-            %p= t 'devise.mailer.password_change.extra'
-            = render 'application/mailer/button', text: t('settings.account_settings'), url: edit_user_registration_url
+    %td.email-inner-card-td.email-prose
+      %p= t 'devise.mailer.password_change.extra'
+      = render 'application/mailer/button', text: t('settings.account_settings'), url: edit_user_registration_url

--- a/app/views/user_mailer/reconfirmation_instructions.html.haml
+++ b/app/views/user_mailer/reconfirmation_instructions.html.haml
@@ -1,11 +1,8 @@
 = content_for :heading do
   = render 'application/mailer/heading', heading_title: t('devise.mailer.reconfirmation_instructions.title'), heading_image_url: frontend_asset_url('images/mailer-new/heading/email.png')
-%table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+%table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
-    %td.email-body-padding-td
-      %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-        %tr
-          %td.email-inner-card-td.email-prose
-            %p= t('devise.mailer.reconfirmation_instructions.explanation')
-            = render 'application/mailer/button', text: t('devise.mailer.confirmation_instructions.action'), url: confirmation_url(@resource, confirmation_token: @token)
-            %p= t 'devise.mailer.reconfirmation_instructions.extra'
+    %td.email-inner-card-td.email-prose
+      %p= t('devise.mailer.reconfirmation_instructions.explanation')
+      = render 'application/mailer/button', text: t('devise.mailer.confirmation_instructions.action'), url: confirmation_url(@resource, confirmation_token: @token)
+      %p= t 'devise.mailer.reconfirmation_instructions.extra'

--- a/app/views/user_mailer/reset_password_instructions.html.haml
+++ b/app/views/user_mailer/reset_password_instructions.html.haml
@@ -1,10 +1,7 @@
 = content_for :heading do
   = render 'application/mailer/heading', heading_title: t('devise.mailer.reset_password_instructions.title'), heading_subtitle: t('devise.mailer.reset_password_instructions.explanation'), heading_image_url: frontend_asset_url('images/mailer-new/heading/password.png')
-%table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+%table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
-    %td.email-body-padding-td
-      %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-        %tr
-          %td.email-inner-card-td.email-prose
-            %p= t 'devise.mailer.reset_password_instructions.extra'
-            = render 'application/mailer/button', text: t('devise.mailer.reset_password_instructions.action'), url: edit_password_url(@resource, reset_password_token: @token)
+    %td.email-inner-card-td.email-prose
+      %p= t 'devise.mailer.reset_password_instructions.extra'
+      = render 'application/mailer/button', text: t('devise.mailer.reset_password_instructions.action'), url: edit_password_url(@resource, reset_password_token: @token)

--- a/app/views/user_mailer/suspicious_sign_in.html.haml
+++ b/app/views/user_mailer/suspicious_sign_in.html.haml
@@ -1,24 +1,21 @@
 = content_for :heading do
   = render 'application/mailer/heading', heading_title: t('user_mailer.suspicious_sign_in.title'), heading_subtitle: t('user_mailer.suspicious_sign_in.explanation'), heading_image_url: frontend_asset_url('images/mailer-new/heading/login.png')
-%table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+%table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
-    %td.email-body-padding-td
-      %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-        %tr
-          %td.email-inner-card-td.email-prose
-            %p= t 'user_mailer.suspicious_sign_in.details'
-            %p
-              %strong #{t('sessions.ip')}:
-              = @remote_ip
-              %br/
-              %strong #{t('sessions.browser')}:
-              %span{ title: @user_agent }
-                = t 'sessions.description',
-                    browser: t("sessions.browsers.#{@detection.id}", default: @detection.id.to_s),
-                    platform: t("sessions.platforms.#{@detection.platform.id}", default: @detection.platform.id.to_s)
-              %br/
-              %strong #{t('sessions.date')}:
-              = l(@timestamp.in_time_zone(@resource.time_zone.presence), format: :with_time_zone)
-            = render 'application/mailer/button', text: t('settings.account_settings'), url: edit_user_registration_url
-      %p= t 'user_mailer.suspicious_sign_in.further_actions_html',
-            action: link_to(t('user_mailer.suspicious_sign_in.change_password'), edit_user_registration_url)
+    %td.email-inner-card-td.email-prose
+      %p= t 'user_mailer.suspicious_sign_in.details'
+      %p
+        %strong #{t('sessions.ip')}:
+        = @remote_ip
+        %br/
+        %strong #{t('sessions.browser')}:
+        %span{ title: @user_agent }
+          = t 'sessions.description',
+              browser: t("sessions.browsers.#{@detection.id}", default: @detection.id.to_s),
+              platform: t("sessions.platforms.#{@detection.platform.id}", default: @detection.platform.id.to_s)
+        %br/
+        %strong #{t('sessions.date')}:
+        = l(@timestamp.in_time_zone(@resource.time_zone.presence), format: :with_time_zone)
+      = render 'application/mailer/button', text: t('settings.account_settings'), url: edit_user_registration_url
+%p= t 'user_mailer.suspicious_sign_in.further_actions_html',
+      action: link_to(t('user_mailer.suspicious_sign_in.change_password'), edit_user_registration_url)

--- a/app/views/user_mailer/two_factor_disabled.html.haml
+++ b/app/views/user_mailer/two_factor_disabled.html.haml
@@ -1,10 +1,7 @@
 = content_for :heading do
   = render 'application/mailer/heading', heading_title: t('devise.mailer.two_factor_disabled.title'), heading_subtitle: t('devise.mailer.two_factor_disabled.subtitle'), heading_image_url: frontend_asset_url('images/mailer-new/heading/2fa-disabled.png')
-%table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+%table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
-    %td.email-body-padding-td
-      %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-        %tr
-          %td.email-inner-card-td.email-prose
-            %p= t 'devise.mailer.two_factor_disabled.explanation'
-            = render 'application/mailer/button', text: t('settings.account_settings'), url: edit_user_registration_url
+    %td.email-inner-card-td.email-prose
+      %p= t 'devise.mailer.two_factor_disabled.explanation'
+      = render 'application/mailer/button', text: t('settings.account_settings'), url: edit_user_registration_url

--- a/app/views/user_mailer/two_factor_enabled.html.haml
+++ b/app/views/user_mailer/two_factor_enabled.html.haml
@@ -1,10 +1,7 @@
 = content_for :heading do
   = render 'application/mailer/heading', heading_title: t('devise.mailer.two_factor_enabled.title'), heading_subtitle: t('devise.mailer.two_factor_enabled.subtitle'), heading_image_url: frontend_asset_url('images/mailer-new/heading/2fa-enabled.png')
-%table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+%table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
-    %td.email-body-padding-td
-      %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-        %tr
-          %td.email-inner-card-td.email-prose
-            %p= t 'devise.mailer.two_factor_enabled.explanation'
-            = render 'application/mailer/button', text: t('settings.account_settings'), url: edit_user_registration_url
+    %td.email-inner-card-td.email-prose
+      %p= t 'devise.mailer.two_factor_enabled.explanation'
+      = render 'application/mailer/button', text: t('settings.account_settings'), url: edit_user_registration_url

--- a/app/views/user_mailer/two_factor_recovery_codes_changed.html.haml
+++ b/app/views/user_mailer/two_factor_recovery_codes_changed.html.haml
@@ -1,10 +1,7 @@
 = content_for :heading do
   = render 'application/mailer/heading', heading_title: t('devise.mailer.two_factor_recovery_codes_changed.title'), heading_subtitle: t('devise.mailer.two_factor_recovery_codes_changed.subtitle'), heading_image_url: frontend_asset_url('images/mailer-new/heading/2fa-recovery.png')
-%table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+%table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
-    %td.email-body-padding-td
-      %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-        %tr
-          %td.email-inner-card-td.email-prose
-            %p= t 'devise.mailer.two_factor_recovery_codes_changed.explanation'
-            = render 'application/mailer/button', text: t('settings.account_settings'), url: edit_user_registration_url
+    %td.email-inner-card-td.email-prose
+      %p= t 'devise.mailer.two_factor_recovery_codes_changed.explanation'
+      = render 'application/mailer/button', text: t('settings.account_settings'), url: edit_user_registration_url

--- a/app/views/user_mailer/warning.html.haml
+++ b/app/views/user_mailer/warning.html.haml
@@ -1,46 +1,43 @@
 = content_for :heading do
   = render 'application/mailer/heading', heading_title: t("user_mailer.warning.title.#{@warning.action}"), heading_image_url: frontend_asset_url('images/mailer-new/heading/warning.png')
-%table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+%table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
-    %td.email-body-padding-td
-      %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+    %td.email-inner-card-td-without-padding
+      %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
         %tr
-          %td.email-inner-card-td-without-padding
-            %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-              %tr
-                %td.email-prose.email-padding-24
-                  - unless @warning.none_action?
-                    %p= t "user_mailer.warning.explanation.#{@warning.action}", instance: @instance
+          %td.email-prose.email-padding-24
+            - unless @warning.none_action?
+              %p= t "user_mailer.warning.explanation.#{@warning.action}", instance: @instance
 
-                  - if @warning.text.present?
-                    = linkify(@warning.text)
+            - if @warning.text.present?
+              = linkify(@warning.text)
 
-                  - if @warning.report && !@warning.report.other?
-                    %p
-                      %strong= t('user_mailer.warning.reason')
-                      = t("user_mailer.warning.categories.#{@warning.report.category}")
+            - if @warning.report && !@warning.report.other?
+              %p
+                %strong= t('user_mailer.warning.reason')
+                = t("user_mailer.warning.categories.#{@warning.report.category}")
 
-                    - if @warning.report.violation? && @warning.report.rule_ids.present?
-                      %ul.rules-list
-                        - @warning.report.rules.each do |rule|
-                          %li= rule.text
-
-                  - unless @statuses.empty?
-                    %p
-                      %strong= t('user_mailer.warning.statuses')
+              - if @warning.report.violation? && @warning.report.rule_ids.present?
+                %ul.rules-list
+                  - @warning.report.rules.each do |rule|
+                    %li= rule.text
 
             - unless @statuses.empty?
-              %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-                %tr
-                  %td.email-border-top
-                    - @statuses.each_with_index do |status, i|
-                      %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-                        %tr
-                          %td.email-border-bottom.email-padding-24
-                            = render 'notification_mailer/status', status: status, i: i + 1, highlighted: true, time_zone: @resource.time_zone.presence
+              %p
+                %strong= t('user_mailer.warning.statuses')
 
-            %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-              %tr
-                %td.email-prose.email-padding-24
-                  %p= t 'user_mailer.warning.appeal_description', instance: @instance
-                  = render 'application/mailer/button', text: t('user_mailer.warning.appeal'), url: disputes_strike_url(@warning)
+      - unless @statuses.empty?
+        %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+          %tr
+            %td.email-border-top
+              - @statuses.each_with_index do |status, i|
+                %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+                  %tr
+                    %td.email-border-bottom.email-padding-24
+                      = render 'notification_mailer/status', status: status, i: i + 1, highlighted: true, time_zone: @resource.time_zone.presence
+
+      %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+        %tr
+          %td.email-prose.email-padding-24
+            %p= t 'user_mailer.warning.appeal_description', instance: @instance
+            = render 'application/mailer/button', text: t('user_mailer.warning.appeal'), url: disputes_strike_url(@warning)

--- a/app/views/user_mailer/webauthn_credential_added.html.haml
+++ b/app/views/user_mailer/webauthn_credential_added.html.haml
@@ -1,13 +1,10 @@
 = content_for :heading do
   = render 'application/mailer/heading', heading_title: t('devise.mailer.webauthn_credential.added.title'), heading_subtitle: t('devise.mailer.webauthn_credential.added.explanation'), heading_image_url: frontend_asset_url('images/mailer-new/heading/key-added.png')
-%table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+%table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
-    %td.email-body-padding-td
-      %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+    %td.email-inner-card-td.email-prose
+      %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
         %tr
-          %td.email-inner-card-td.email-prose
-            %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-              %tr
-                %td.email-frame-wrapper-td
-                  = render 'application/mailer/frame', text: @webauthn_credential.nickname
-            = render 'application/mailer/button', text: t('settings.account_settings'), url: edit_user_registration_url
+          %td.email-frame-wrapper-td
+            = render 'application/mailer/frame', text: @webauthn_credential.nickname
+      = render 'application/mailer/button', text: t('settings.account_settings'), url: edit_user_registration_url

--- a/app/views/user_mailer/webauthn_credential_deleted.html.haml
+++ b/app/views/user_mailer/webauthn_credential_deleted.html.haml
@@ -1,13 +1,10 @@
 = content_for :heading do
   = render 'application/mailer/heading', heading_title: t('devise.mailer.webauthn_credential.deleted.title'), heading_subtitle: t('devise.mailer.webauthn_credential.deleted.explanation'), heading_image_url: frontend_asset_url('images/mailer-new/heading/key-deleted.png')
-%table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+%table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
-    %td.email-body-padding-td
-      %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+    %td.email-inner-card-td.email-prose
+      %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
         %tr
-          %td.email-inner-card-td.email-prose
-            %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-              %tr
-                %td.email-frame-wrapper-td
-                  = render 'application/mailer/frame', text: @webauthn_credential.nickname
-            = render 'application/mailer/button', text: t('settings.account_settings'), url: edit_user_registration_url
+          %td.email-frame-wrapper-td
+            = render 'application/mailer/frame', text: @webauthn_credential.nickname
+      = render 'application/mailer/button', text: t('settings.account_settings'), url: edit_user_registration_url

--- a/app/views/user_mailer/webauthn_disabled.html.haml
+++ b/app/views/user_mailer/webauthn_disabled.html.haml
@@ -1,10 +1,7 @@
 = content_for :heading do
   = render 'application/mailer/heading', heading_title: t('devise.mailer.webauthn_disabled.title'), heading_subtitle: t('devise.mailer.webauthn_disabled.explanation'), heading_image_url: frontend_asset_url('images/mailer-new/heading/key-disabled.png')
-%table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+%table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
-    %td.email-body-padding-td
-      %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-        %tr
-          %td.email-inner-card-td.email-prose
-            %p= t 'devise.mailer.webauthn_disabled.extra'
-            = render 'application/mailer/button', text: t('settings.account_settings'), url: edit_user_registration_url
+    %td.email-inner-card-td.email-prose
+      %p= t 'devise.mailer.webauthn_disabled.extra'
+      = render 'application/mailer/button', text: t('settings.account_settings'), url: edit_user_registration_url

--- a/app/views/user_mailer/webauthn_enabled.html.haml
+++ b/app/views/user_mailer/webauthn_enabled.html.haml
@@ -1,10 +1,7 @@
 = content_for :heading do
   = render 'application/mailer/heading', heading_title: t('devise.mailer.webauthn_enabled.title'), heading_subtitle: t('devise.mailer.webauthn_enabled.explanation'), heading_image_url: frontend_asset_url('images/mailer-new/heading/key-enabled.png')
-%table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+%table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
-    %td.email-body-padding-td
-      %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-        %tr
-          %td.email-inner-card-td.email-prose
-            %p= t 'devise.mailer.webauthn_enabled.extra'
-            = render 'application/mailer/button', text: t('settings.account_settings'), url: edit_user_registration_url
+    %td.email-inner-card-td.email-prose
+      %p= t 'devise.mailer.webauthn_enabled.extra'
+      = render 'application/mailer/button', text: t('settings.account_settings'), url: edit_user_registration_url


### PR DESCRIPTION
With the email redesign merged, I was rebasing a few PRs and while looking into https://github.com/mastodon/mastodon/pull/28083#issuecomment-1892719478 I realized that the mailer views have a few levels of markup common to every single view -- this PR moves that out to the layout level.

I think the only reason to not do this would be if there were planned emails where the html WAS going to vary between emails at this level.

I'm not sure how to improve the diff here -- it looks massive because of re-indentation ... but all that's happening here is that the 3 lines which were added to the layout are also removed from the top of the mailer views. I believe all generated html should be the same.
