### PR TITLE
Refactor: fix streaming postgresql and redis typing issues

### DIFF
--- a/streaming/index.js
+++ b/streaming/index.js
@@ -159,8 +159,7 @@ const pgConfigFromEnv = (env) => {
     if (typeof parsedUrl.port === 'string') {
       const parsedPort = parseInt(parsedUrl.port, 10);
       if (isNaN(parsedPort)) {
-        const safeDbUrl = parsedUrl.password ? env.DATABASE_URL.replace(parsedUrl.password, '********') : env.DATABASE_URL;
-        throw new Error(`Invalid port specified in DATABASE_URL environment variable: ${safeDbUrl}`);
+        throw new Error('Invalid port specified in DATABASE_URL environment variable');
       }
       baseConfig.port = parsedPort;
     }


### PR DESCRIPTION
A lot of our environment variable handling wasn't safe, and didn't actually work with the types that were expected of `ioredis` and `pg`. This will be updated shortly to move all the redis configuration into a separate `db/redis.js` file and the postgresql code into `db/postgresql.js` files, which further reduces the complexity of `index.js`