### PR TITLE
Ignore RecordNotUnique errors in LinkCrawlWorker

### DIFF
--- a/app/workers/link_crawl_worker.rb
+++ b/app/workers/link_crawl_worker.rb
@@ -7,7 +7,7 @@ class LinkCrawlWorker
 
   def perform(status_id)
     FetchLinkCardService.new.call(Status.find(status_id))
-  rescue ActiveRecord::RecordNotFound
+  rescue ActiveRecord::RecordNotFound, ActiveRecord::RecordNotUnique
     true
   end
 end


### PR DESCRIPTION
Somehow(I think it is race condition), LinkCrawlWorker raises `RecordNotUnique` error. But it is safe to ignore and don't leave trace on sidekiq dashboard