### PR TITLE
Update follow and follow_request emails

### DIFF
--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -27,20 +27,24 @@ module AccountsHelper
     end
   end
 
+  def account_formatted_stat(value)
+    number_to_human(value, precision: 3, strip_insignificant_zeros: true)
+  end
+
   def account_description(account)
     prepend_str = [
       [
-        number_to_human(account.statuses_count, precision: 3, strip_insignificant_zeros: true),
+        account_formatted_stat(account.statuses_count),
         I18n.t('accounts.posts', count: account.statuses_count),
       ].join(' '),
 
       [
-        number_to_human(account.following_count, precision: 3, strip_insignificant_zeros: true),
+        account_formatted_stat(account.following_count),
         I18n.t('accounts.following', count: account.following_count),
       ].join(' '),
 
       [
-        number_to_human(account.followers_count, precision: 3, strip_insignificant_zeros: true),
+        account_formatted_stat(account.followers_count),
         I18n.t('accounts.followers', count: account.followers_count),
       ].join(' '),
     ].join(', ')

--- a/app/javascript/styles/mailer.scss
+++ b/app/javascript/styles/mailer.scss
@@ -90,7 +90,7 @@ table + p {
 
 // Account
 .email-account-banner-table {
-  background-color: #F3F2F5;
+  background-color: #f3f2f5;
   border-top-left-radius: 12px;
   border-top-right-radius: 12px;
 }
@@ -100,7 +100,7 @@ table + p {
   border-top-right-radius: 12px;
   height: 140px;
   vertical-align: bottom;
-  background-color: #F3F2F5;
+  background-color: #f3f2f5;
   background-position: center;
   background-size: cover;
 }
@@ -140,7 +140,7 @@ table + p {
   font-size: 16px;
   font-weight: 600;
   line-height: 24px;
-  color: #17063B;
+  color: #17063b;
 }
 
 .email-account-handle {
@@ -159,7 +159,7 @@ table + p {
 
   b {
     font-weight: 600;
-    color: #17063B;
+    color: #17063b;
   }
 
   span {

--- a/app/javascript/styles/mailer.scss
+++ b/app/javascript/styles/mailer.scss
@@ -88,6 +88,85 @@ table + p {
   padding: 24px;
 }
 
+// Account
+.email-account-banner-table {
+  background-color: #F3F2F5;
+  border-top-left-radius: 12px;
+  border-top-right-radius: 12px;
+}
+
+.email-account-banner-td {
+  border-top-left-radius: 12px;
+  border-top-right-radius: 12px;
+  height: 140px;
+  vertical-align: bottom;
+  background-color: #F3F2F5;
+  background-position: center;
+  background-size: cover;
+}
+
+.email-account-banner-inner-td {
+  padding: 24px 24px 0;
+  mso-padding-alt: 24px;
+}
+
+.email-account-banner-overlap-div {
+  max-height: 42px;
+}
+
+.email-account-banner-icon-table {
+  width: auto;
+  margin: 0;
+  overflow: hidden;
+  border-radius: 8px;
+  border-collapse: separate;
+  background-color: #fff;
+  border: 2px solid #fff;
+
+  img {
+    display: block;
+    max-width: 100%;
+    border: none;
+    border-radius: 6px;
+  }
+}
+
+.email-account-body-td {
+  padding: 56px 24px 24px;
+  mso-padding-alt: 24px;
+}
+
+.email-account-name {
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 24px;
+  color: #17063B;
+}
+
+.email-account-handle {
+  font-size: 14px;
+  line-height: 20px;
+  color: #746a89;
+}
+
+.email-account-stats-table {
+  td {
+    padding-right: 16px;
+    font-size: 14px;
+    line-height: 20px;
+    color: #746a89;
+  }
+
+  b {
+    font-weight: 600;
+    color: #17063B;
+  }
+
+  span {
+    white-space: nowrap;
+  }
+}
+
 // Utility classes
 .email-w-full {
   width: 100%;
@@ -120,6 +199,14 @@ table + p {
 
 .email-padding-top-24 {
   padding-top: 24px;
+}
+
+.email-padding-top-16 {
+  padding-top: 16px;
+}
+
+.email-padding-top-0 {
+  padding-top: 0;
 }
 
 .email-border-top {

--- a/app/views/application/mailer/_account.html.haml
+++ b/app/views/application/mailer/_account.html.haml
@@ -1,6 +1,6 @@
 %table.email-w-full.email-account-banner-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
-    %td.email-account-banner-td{ height: 140, background: 'https://files.mastodon.social/accounts/headers/000/013/179/original/1375be116fbe0f1d.png' }
+    %td.email-account-banner-td{ height: 140, background: full_asset_url(account.header.url) }
       %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
         %tr
           %td.email-account-banner-inner-td
@@ -8,23 +8,23 @@
               %table.email-account-banner-icon-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
                 %tr
                   %td
-                    %img{ src: 'https://files.mastodon.social/accounts/avatars/000/013/179/original/b4ceb19c9c54ec7e.png', width: 80, height: 80, alt: '' }
+                    %img{ src: full_asset_url(account.avatar.url), width: 80, height: 80, alt: '' }
 %table.email-w-full.email-account-body-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-account-body-td
-      %p.email-account-name= 'Mastodon'
-      %p.email-account-handle= '@mastodon@mastodon.social'
+      %p.email-account-name= display_name(account)
+      %p.email-account-handle= acct(account)
       %table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
         %tr
           %td.email-padding-top-16
             %table.email-w-full.email-account-stats-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
               %tr
                 %td
-                  %b= '251'
-                  %span= 'Posts'
+                  %b= account_formatted_stat(account.statuses_count)
+                  %span= t('accounts.posts', count: account.statuses_count)
                 %td
-                  %b= '3'
-                  %span= 'Following'
+                  %b= account_formatted_stat(account.following_count)
+                  %span= t('accounts.following')
                 %td
-                  %b= '809K'
-                  %span= 'Followers'
+                  %b= account_formatted_stat(account.followers_count)
+                  %span= t('accounts.followers', count: account.followers_count)

--- a/app/views/application/mailer/_account.html.haml
+++ b/app/views/application/mailer/_account.html.haml
@@ -1,10 +1,10 @@
 %table.email-w-full.email-account-banner-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
-    %td.email-account-banner-td{ height: 140, style: 'background-image:url(https://files.mastodon.social/accounts/headers/000/013/179/original/1375be116fbe0f1d.png)' }
+    %td.email-account-banner-td{ height: 140, background: 'https://files.mastodon.social/accounts/headers/000/013/179/original/1375be116fbe0f1d.png' }
       %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
         %tr
           %td.email-account-banner-inner-td
-            %div.email-account-banner-overlap-div
+            .email-account-banner-overlap-div
               %table.email-account-banner-icon-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
                 %tr
                   %td
@@ -12,19 +12,19 @@
 %table.email-w-full.email-account-body-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-account-body-td
-      %p.email-account-name= "Mastodon"
-      %p.email-account-handle= "@mastodon@mastodon.social"
+      %p.email-account-name= 'Mastodon'
+      %p.email-account-handle= '@mastodon@mastodon.social'
       %table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
         %tr
           %td.email-padding-top-16
             %table.email-w-full.email-account-stats-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
               %tr
                 %td
-                  %b= "251"
-                  %span= "Posts"
+                  %b= '251'
+                  %span= 'Posts'
                 %td
-                  %b= "3"
-                  %span= "Following"
+                  %b= '3'
+                  %span= 'Following'
                 %td
-                  %b= "809K"
-                  %span= "Followers"
+                  %b= '809K'
+                  %span= 'Followers'

--- a/app/views/application/mailer/_account.html.haml
+++ b/app/views/application/mailer/_account.html.haml
@@ -1,0 +1,30 @@
+%table.email-w-full.email-account-banner-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+  %tr
+    %td.email-account-banner-td{ height: 140, style: 'background-image:url(https://files.mastodon.social/accounts/headers/000/013/179/original/1375be116fbe0f1d.png)' }
+      %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+        %tr
+          %td.email-account-banner-inner-td
+            %div.email-account-banner-overlap-div
+              %table.email-account-banner-icon-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+                %tr
+                  %td
+                    %img{ src: 'https://files.mastodon.social/accounts/avatars/000/013/179/original/b4ceb19c9c54ec7e.png', width: 80, height: 80, alt: '' }
+%table.email-w-full.email-account-body-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+  %tr
+    %td.email-account-body-td
+      %p.email-account-name= "Mastodon"
+      %p.email-account-handle= "@mastodon@mastodon.social"
+      %table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+        %tr
+          %td.email-padding-top-16
+            %table.email-w-full.email-account-stats-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+              %tr
+                %td
+                  %b= "251"
+                  %span= "Posts"
+                %td
+                  %b= "3"
+                  %span= "Following"
+                %td
+                  %b= "809K"
+                  %span= "Followers"

--- a/app/views/notification_mailer/follow.html.haml
+++ b/app/views/notification_mailer/follow.html.haml
@@ -5,5 +5,9 @@
     %td.email-body-padding-td
       %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
         %tr
-          %td.email-inner-card-td
-            = render 'application/mailer/button', text: t('application_mailer.view_profile'), url: web_url("@#{@account.pretty_acct}")
+          %td.email-inner-card-td-without-padding
+            = render 'application/mailer/account'
+            %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+              %tr
+                %td.email-padding-24.email-padding-top-0
+                  = render 'application/mailer/button', text: t('application_mailer.view_profile'), url: web_url("@#{@account.pretty_acct}")

--- a/app/views/notification_mailer/follow.html.haml
+++ b/app/views/notification_mailer/follow.html.haml
@@ -6,7 +6,7 @@
       %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
         %tr
           %td.email-inner-card-td-without-padding
-            = render 'application/mailer/account'
+            = render 'application/mailer/account', account: @account
             %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
               %tr
                 %td.email-padding-24.email-padding-top-0

--- a/app/views/notification_mailer/follow_request.html.haml
+++ b/app/views/notification_mailer/follow_request.html.haml
@@ -5,5 +5,9 @@
     %td.email-body-padding-td
       %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
         %tr
-          %td.email-inner-card-td
-            = render 'application/mailer/button', text: t('notification_mailer.follow_request.action'), url: web_url('follow_requests')
+          %td.email-inner-card-td-without-padding
+            = render 'application/mailer/account'
+            %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+              %tr
+                %td.email-padding-24.email-padding-top-0
+                  = render 'application/mailer/button', text: t('notification_mailer.follow_request.action'), url: web_url('follow_requests')

--- a/app/views/notification_mailer/follow_request.html.haml
+++ b/app/views/notification_mailer/follow_request.html.haml
@@ -6,7 +6,7 @@
       %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
         %tr
           %td.email-inner-card-td-without-padding
-            = render 'application/mailer/account'
+            = render 'application/mailer/account', account: @account
             %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
               %tr
                 %td.email-padding-24.email-padding-top-0


### PR DESCRIPTION
Update the `follow` and `follow_request` email templates with the full design and a new account section (with banner image, profile picture, name of account, handle, and the numbers of posts, following and followers).

This PR only adds static HTML and requires development to add the dynamic data.

![Screenshot of a follow request email](https://github.com/mastodon/mastodon/assets/3451753/4fdb700d-d645-4b9e-aeff-9577b6870582)
