### PR TITLE
Finish up the CLI spec area pattern adoption for `CLI::Accounts#refresh` specs

### DIFF
--- a/spec/lib/mastodon/cli/accounts_spec.rb
+++ b/spec/lib/mastodon/cli/accounts_spec.rb
@@ -660,6 +660,8 @@ describe Mastodon::CLI::Accounts do
   end
 
   describe '#refresh' do
+    let(:action) { :refresh }
+
     context 'with --all option' do
       let!(:local_account)              { Fabricate(:account, domain: nil) }
       let!(:remote_account_example_com) { Fabricate(:account, domain: 'example.com') }
@@ -927,7 +929,7 @@ describe Mastodon::CLI::Accounts do
 
     context 'when neither a list of accts nor options are provided' do
       it 'exits with an error message' do
-        expect { cli.refresh }
+        expect { subject }
           .to output_results('No account(s) given')
           .and raise_error(SystemExit)
       end

--- a/spec/lib/mastodon/cli/accounts_spec.rb
+++ b/spec/lib/mastodon/cli/accounts_spec.rb
@@ -787,7 +787,7 @@ describe Mastodon::CLI::Accounts do
         allow(account_example_com_a).to receive(:reset_avatar!)
         allow(account_example_com_b).to receive(:reset_avatar!)
 
-        expect { cli.refresh(*arguments) }
+        expect { subject }
           .to output_results('OK')
 
         expect(account_example_com_a).to have_received(:reset_avatar!).once
@@ -797,7 +797,7 @@ describe Mastodon::CLI::Accounts do
       it 'does not reset the avatar for unspecified accounts' do
         allow(account_example_net).to receive(:reset_avatar!)
 
-        expect { cli.refresh(*arguments) }
+        expect { subject }
           .to output_results('OK')
 
         expect(account_example_net).to_not have_received(:reset_avatar!)
@@ -807,7 +807,7 @@ describe Mastodon::CLI::Accounts do
         allow(account_example_com_a).to receive(:reset_header!)
         allow(account_example_com_b).to receive(:reset_header!)
 
-        expect { cli.refresh(*arguments) }
+        expect { subject }
           .to output_results('OK')
 
         expect(account_example_com_a).to have_received(:reset_header!).once
@@ -817,7 +817,7 @@ describe Mastodon::CLI::Accounts do
       it 'does not reset the header for unspecified accounts' do
         allow(account_example_net).to receive(:reset_header!)
 
-        expect { cli.refresh(*arguments) }
+        expect { subject }
           .to output_results('OK')
 
         expect(account_example_net).to_not have_received(:reset_header!)
@@ -827,7 +827,7 @@ describe Mastodon::CLI::Accounts do
         it 'displays a failure message' do
           allow(account_example_com_a).to receive(:reset_avatar!).and_raise(Mastodon::UnexpectedResponseError)
 
-          expect { cli.refresh(*arguments) }
+          expect { subject }
             .to output_results("Account failed: #{account_example_com_a.username}@#{account_example_com_a.domain}")
         end
       end
@@ -836,7 +836,7 @@ describe Mastodon::CLI::Accounts do
         it 'exits with an error message' do
           allow(Account).to receive(:find_remote).with(account_example_com_b.username, account_example_com_b.domain).and_return(nil)
 
-          expect { cli.refresh(*arguments) }
+          expect { subject }
             .to output_results('No such account')
             .and raise_error(SystemExit)
         end
@@ -853,7 +853,7 @@ describe Mastodon::CLI::Accounts do
           allow(account_example_com_a).to receive(:reset_avatar!)
           allow(account_example_com_b).to receive(:reset_avatar!)
 
-          expect { cli.refresh(*arguments) }
+          expect { subject }
             .to output_results('OK (DRY RUN)')
 
           expect(account_example_com_a).to_not have_received(:reset_avatar!)
@@ -864,7 +864,7 @@ describe Mastodon::CLI::Accounts do
           allow(account_example_com_a).to receive(:reset_header!)
           allow(account_example_com_b).to receive(:reset_header!)
 
-          expect { cli.refresh(*arguments) }
+          expect { subject }
             .to output_results('OK (DRY RUN)')
 
           expect(account_example_com_a).to_not have_received(:reset_header!)

--- a/spec/lib/mastodon/cli/accounts_spec.rb
+++ b/spec/lib/mastodon/cli/accounts_spec.rb
@@ -832,62 +832,64 @@ describe Mastodon::CLI::Accounts do
     end
 
     context 'with --domain option' do
-      let!(:account_example_com_a) { Fabricate(:account, domain: 'example.com') }
-      let!(:account_example_com_b) { Fabricate(:account, domain: 'example.com') }
-      let!(:account_example_net)   { Fabricate(:account, domain: 'example.net') }
-      let(:domain)                 { 'example.com' }
-      let(:scope)                  { Account.remote.where(domain: domain) }
+      let(:domain) { 'example.com' }
       let(:options) { { domain: domain } }
 
+      let(:com_a_avatar_url) { 'https://example.host/avatar/a' }
+      let(:com_a_header_url) { 'https://example.host/header/a' }
+      let(:account_example_com_a) { Fabricate(:account, domain: domain, avatar_remote_url: com_a_avatar_url, header_remote_url: com_a_header_url) }
+
+      let(:com_b_avatar_url) { 'https://example.host/avatar/b' }
+      let(:com_b_header_url) { 'https://example.host/header/b' }
+      let(:account_example_com_b) { Fabricate(:account, domain: domain, avatar_remote_url: com_b_avatar_url, header_remote_url: com_b_header_url) }
+
+      let(:net_avatar_url) { 'https://example.host/avatar/net' }
+      let(:net_header_url) { 'https://example.host/header/net' }
+      let(:account_example_net) { Fabricate(:account, domain: 'example.net', avatar_remote_url: net_avatar_url, header_remote_url: net_header_url) }
+
       before do
-        allow(cli).to receive(:parallelize_with_progress).and_yield(account_example_com_a)
-                                                         .and_yield(account_example_com_b)
-                                                         .and_return([2, nil])
-        cli.options = options
+        stub_parallelize_with_progress!
+
+        stub_request(:get, com_a_avatar_url)
+          .to_return request_fixture('avatar.txt')
+        stub_request(:get, com_a_header_url)
+          .to_return request_fixture('avatar.txt')
+        stub_request(:get, com_b_avatar_url)
+          .to_return request_fixture('avatar.txt')
+        stub_request(:get, com_b_header_url)
+          .to_return request_fixture('avatar.txt')
+        stub_request(:get, net_avatar_url)
+          .to_return request_fixture('avatar.txt')
+        stub_request(:get, net_header_url)
+          .to_return request_fixture('avatar.txt')
+
+        account_example_com_a
+          .update_column(:avatar_file_name, nil)
+        account_example_com_b
+          .update_column(:avatar_file_name, nil)
+        account_example_net
+          .update_column(:avatar_file_name, nil)
       end
 
-      it 'refreshes the avatar for all accounts on specified domain' do
-        allow(account_example_com_a).to receive(:reset_avatar!)
-        allow(account_example_com_b).to receive(:reset_avatar!)
-
-        expect { cli.refresh }
+      it 'refreshes the avatar and header for all accounts on specified domain' do
+        expect { subject }
           .to output_results('Refreshed 2 accounts')
 
-        expect(cli).to have_received(:parallelize_with_progress).with(scope).once
-        expect(account_example_com_a).to have_received(:reset_avatar!).once
-        expect(account_example_com_b).to have_received(:reset_avatar!).once
-      end
+        # One request from factory creation, one more from task
+        expect(a_request(:get, com_a_avatar_url))
+          .to have_been_made.at_least_times(2)
+        expect(a_request(:get, com_a_header_url))
+          .to have_been_made.at_least_times(2)
+        expect(a_request(:get, com_b_avatar_url))
+          .to have_been_made.at_least_times(2)
+        expect(a_request(:get, com_b_header_url))
+          .to have_been_made.at_least_times(2)
 
-      it 'does not refresh the avatar for accounts outside specified domain' do
-        allow(account_example_net).to receive(:reset_avatar!)
-
-        expect { cli.refresh }
-          .to output_results('Refreshed 2 accounts')
-
-        expect(cli).to have_received(:parallelize_with_progress).with(scope).once
-        expect(account_example_net).to_not have_received(:reset_avatar!)
-      end
-
-      it 'refreshes the header for all accounts on specified domain' do
-        allow(account_example_com_a).to receive(:reset_header!)
-        allow(account_example_com_b).to receive(:reset_header!)
-
-        expect { cli.refresh }
-          .to output_results('Refreshed 2 accounts')
-
-        expect(cli).to have_received(:parallelize_with_progress).with(scope)
-        expect(account_example_com_a).to have_received(:reset_header!).once
-        expect(account_example_com_b).to have_received(:reset_header!).once
-      end
-
-      it 'does not refresh the header for accounts outside specified domain' do
-        allow(account_example_net).to receive(:reset_header!)
-
-        expect { cli.refresh }
-          .to output_results('Refreshed 2 accounts')
-
-        expect(cli).to have_received(:parallelize_with_progress).with(scope).once
-        expect(account_example_net).to_not have_received(:reset_header!)
+        # One request from factory creation, none from task
+        expect(a_request(:get, net_avatar_url))
+          .to have_been_made.once
+        expect(a_request(:get, net_header_url))
+          .to have_been_made.once
       end
     end
 

--- a/spec/lib/mastodon/cli/accounts_spec.rb
+++ b/spec/lib/mastodon/cli/accounts_spec.rb
@@ -667,6 +667,7 @@ describe Mastodon::CLI::Accounts do
       let!(:remote_account_example_com) { Fabricate(:account, domain: 'example.com') }
       let!(:account_example_net)        { Fabricate(:account, domain: 'example.net') }
       let(:scope)                       { Account.remote }
+      let(:options) { { all: true } }
 
       before do
         # TODO: we should be using `stub_parallelize_with_progress!` but
@@ -674,7 +675,7 @@ describe Mastodon::CLI::Accounts do
         allow(cli).to receive(:parallelize_with_progress).and_yield(remote_account_example_com)
                                                          .and_yield(account_example_net)
                                                          .and_return([2, nil])
-        cli.options = { all: true }
+        cli.options = options
       end
 
       it 'refreshes the avatar for all remote accounts' do
@@ -727,8 +728,10 @@ describe Mastodon::CLI::Accounts do
       end
 
       context 'with --dry-run option' do
+        let(:options) { { all: true, dry_run: true } }
+
         before do
-          cli.options = { all: true, dry_run: true }
+          cli.options = options
         end
 
         it 'does not refresh the avatar for any account' do
@@ -840,8 +843,10 @@ describe Mastodon::CLI::Accounts do
       end
 
       context 'with --dry-run option' do
+        let(:options) { { dry_run: true } }
+
         before do
-          cli.options = { dry_run: true }
+          cli.options = options
         end
 
         it 'does not refresh the avatar for any account' do
@@ -874,12 +879,13 @@ describe Mastodon::CLI::Accounts do
       let!(:account_example_net)   { Fabricate(:account, domain: 'example.net') }
       let(:domain)                 { 'example.com' }
       let(:scope)                  { Account.remote.where(domain: domain) }
+      let(:options) { { domain: domain } }
 
       before do
         allow(cli).to receive(:parallelize_with_progress).and_yield(account_example_com_a)
                                                          .and_yield(account_example_com_b)
                                                          .and_return([2, nil])
-        cli.options = { domain: domain }
+        cli.options = options
       end
 
       it 'refreshes the avatar for all accounts on specified domain' do

--- a/spec/lib/mastodon/cli/accounts_spec.rb
+++ b/spec/lib/mastodon/cli/accounts_spec.rb
@@ -803,10 +803,6 @@ describe Mastodon::CLI::Accounts do
       context 'with --dry-run option' do
         let(:options) { { dry_run: true } }
 
-        before do
-          cli.options = options
-        end
-
         it 'does not refresh the avatar for any account' do
           allow(account_example_com_a).to receive(:reset_avatar!)
           allow(account_example_com_b).to receive(:reset_avatar!)


### PR DESCRIPTION
Previous PR cleaned these up https://github.com/mastodon/mastodon/pull/28255 - but stopped short on the `refresh` method due to the stubbing interaction with parallelize_with_progress. This is a followup on that which:

- Removes the final stubbing of parallelize_with_progress in favor of the `stub_parallelize_with_progress!` method used elsewhere in the class
- Updates the args/options/etc setup to match what's done elsewhere
- Invokes cli directly via `subject` like all other CLI spec examples
- Combines a few examples where they were all asserting against the same command, and there was a certain economy to be had from grouping them together.

