### PR TITLE
Add specs for `Instance` model scopes and add `with_domain_follows` scope

### DIFF
--- a/app/controllers/admin/export_domain_blocks_controller.rb
+++ b/app/controllers/admin/export_domain_blocks_controller.rb
@@ -49,7 +49,7 @@ module Admin
         next
       end
 
-      @warning_domains = Instance.where(domain: @domain_blocks.map(&:domain)).where('EXISTS (SELECT 1 FROM follows JOIN accounts ON follows.account_id = accounts.id OR follows.target_account_id = accounts.id WHERE accounts.domain = instances.domain)').pluck(:domain)
+      @warning_domains = instances_from_imported_blocks.pluck(:domain)
     rescue ActionController::ParameterMissing
       flash.now[:alert] = I18n.t('admin.export_domain_blocks.no_file')
       set_dummy_import!
@@ -57,6 +57,10 @@ module Admin
     end
 
     private
+
+    def instances_from_imported_blocks
+      Instance.with_domain_follows(@domain_blocks.map(&:domain))
+    end
 
     def export_filename
       'domain_blocks.csv'

--- a/spec/models/instance_spec.rb
+++ b/spec/models/instance_spec.rb
@@ -97,5 +97,37 @@ RSpec.describe Instance do
         described_class.where(domain: 'grexample.com').first
       end
     end
+
+    describe '#with_domain_follows' do
+      before do
+        example_account = Fabricate(:account, domain: 'example.host')
+        other_account = Fabricate(:account, domain: 'other.host')
+        Fabricate(:account, domain: 'none.host')
+
+        Fabricate :follow, account: example_account
+        Fabricate :follow, target_account: other_account
+      end
+
+      it 'returns instances with domain accounts that have follows' do
+        results = described_class.with_domain_follows(['example.host', 'other.host', 'none.host'])
+
+        expect(results)
+          .to include(example_instance)
+          .and include(other_instance)
+          .and not_include(none_instance)
+      end
+
+      def example_instance
+        described_class.where(domain: 'example.host').first
+      end
+
+      def other_instance
+        described_class.where(domain: 'other.host').first
+      end
+
+      def none_instance
+        described_class.where(domain: 'none.host').first
+      end
+    end
   end
 end

--- a/spec/models/instance_spec.rb
+++ b/spec/models/instance_spec.rb
@@ -22,11 +22,11 @@ RSpec.describe Instance do
       end
 
       def expected_instance
-        described_class.where(domain: 'host.example').first
+        described_class.find_by(domain: 'host.example')
       end
 
       def not_expected_instance
-        described_class.where(domain: 'other.example').first
+        described_class.find_by(domain: 'other.example')
       end
     end
 
@@ -57,15 +57,15 @@ RSpec.describe Instance do
       end
 
       def host_instance
-        described_class.where(domain: 'host.example.com').first
+        described_class.find_by(domain: 'host.example.com')
       end
 
       def host_under_instance
-        described_class.where(domain: 'host_under.example.com').first
+        described_class.find_by(domain: 'host_under.example.com')
       end
 
       def other_instance
-        described_class.where(domain: 'other.example').first
+        described_class.find_by(domain: 'other.example')
       end
     end
 
@@ -86,15 +86,15 @@ RSpec.describe Instance do
       end
 
       def exact_match_instance
-        described_class.where(domain: 'example.com').first
+        described_class.find_by(domain: 'example.com')
       end
 
       def subdomain_instance
-        described_class.where(domain: 'foo.example.com').first
+        described_class.find_by(domain: 'foo.example.com')
       end
 
       def partial_instance
-        described_class.where(domain: 'grexample.com').first
+        described_class.find_by(domain: 'grexample.com')
       end
     end
 
@@ -118,15 +118,15 @@ RSpec.describe Instance do
       end
 
       def example_instance
-        described_class.where(domain: 'example.host').first
+        described_class.find_by(domain: 'example.host')
       end
 
       def other_instance
-        described_class.where(domain: 'other.host').first
+        described_class.find_by(domain: 'other.host')
       end
 
       def none_instance
-        described_class.where(domain: 'none.host').first
+        described_class.find_by(domain: 'none.host')
       end
     end
   end

--- a/spec/models/instance_spec.rb
+++ b/spec/models/instance_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Instance do
+  describe 'Scopes' do
+    before { described_class.refresh }
+
+    describe '#searchable' do
+      before do
+        Fabricate :account, domain: 'host.example'
+        Fabricate :account, domain: 'other.example'
+        Fabricate :domain_block, domain: 'other.example'
+      end
+
+      it 'returns records not domain blocked' do
+        results = described_class.searchable
+
+        expect(results)
+          .to include(expected_instance)
+          .and not_include(not_expected_instance)
+      end
+
+      def expected_instance
+        described_class.where(domain: 'host.example').first
+      end
+
+      def not_expected_instance
+        described_class.where(domain: 'other.example').first
+      end
+    end
+
+    describe '#matches_domain' do
+      before do
+        Fabricate :account, domain: 'host.example.com'
+        Fabricate :account, domain: 'host_under.example.com'
+        Fabricate :account, domain: 'other.example'
+      end
+
+      it 'returns matching records' do
+        expect(described_class.matches_domain('host.exa'))
+          .to include(host_instance)
+          .and not_include(other_instance)
+
+        expect(described_class.matches_domain('ple.com'))
+          .to include(host_instance)
+          .and not_include(other_instance)
+
+        expect(described_class.matches_domain('example'))
+          .to include(host_instance)
+          .and include(other_instance)
+
+        expect(described_class.matches_domain('host_')) # Preserve SQL wildcards
+          .to include(host_instance)
+          .and include(host_under_instance)
+          .and not_include(other_instance)
+      end
+
+      def host_instance
+        described_class.where(domain: 'host.example.com').first
+      end
+
+      def host_under_instance
+        described_class.where(domain: 'host_under.example.com').first
+      end
+
+      def other_instance
+        described_class.where(domain: 'other.example').first
+      end
+    end
+
+    describe '#by_domain_and_subdomains' do
+      before do
+        Fabricate(:account, domain: 'example.com')
+        Fabricate(:account, domain: 'foo.example.com')
+        Fabricate(:account, domain: 'grexample.com')
+      end
+
+      it 'returns matching instances' do
+        results = described_class.by_domain_and_subdomains('example.com')
+
+        expect(results)
+          .to include(exact_match_instance)
+          .and include(subdomain_instance)
+          .and not_include(partial_instance)
+      end
+
+      def exact_match_instance
+        described_class.where(domain: 'example.com').first
+      end
+
+      def subdomain_instance
+        described_class.where(domain: 'foo.example.com').first
+      end
+
+      def partial_instance
+        described_class.where(domain: 'grexample.com').first
+      end
+    end
+  end
+end


### PR DESCRIPTION
A few things here:

- Add spec coverage for the three previously existing scopes on Instance
- Add a new scope, `with_domain_follows`, which moves the logic from the admin/export_domain_blocks controller to a scope
- Update the controller to use this new method