### PR TITLE
Announcement reactions query spec improvement and refactor

### DIFF
--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -76,7 +76,7 @@ class Announcement < ApplicationRecord
 
   def reactions(account = nil)
     records = begin
-      scope = announcement_reactions.group(:announcement_id, :name, :custom_emoji_id).order(Arel.sql('MIN(created_at) ASC'))
+      scope = grouped_ordered_announcement_reactions
 
       if account.nil?
         scope.select('name, custom_emoji_id, count(*) as count, false as me')
@@ -90,6 +90,14 @@ class Announcement < ApplicationRecord
   end
 
   private
+
+  def grouped_ordered_announcement_reactions
+    announcement_reactions
+      .group(:announcement_id, :name, :custom_emoji_id)
+      .order(
+        Arel.sql('MIN(created_at)').asc
+      )
+  end
 
   def set_published
     return unless scheduled_at.blank? || scheduled_at.past?

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -75,16 +75,13 @@ class Announcement < ApplicationRecord
   end
 
   def reactions(account = nil)
-    records = begin
-      grouped_ordered_announcement_reactions.select(
-        [:name, :custom_emoji_id, 'COUNT(*) as count'].tap do |values|
-          values << value_for_reaction_me_column(account)
-        end
-      )
-    end.to_a
-
-    ActiveRecord::Associations::Preloader.new(records: records, associations: :custom_emoji).call
-    records
+    grouped_ordered_announcement_reactions.select(
+      [:name, :custom_emoji_id, 'COUNT(*) as count'].tap do |values|
+        values << value_for_reaction_me_column(account)
+      end
+    ).to_a.tap do |records|
+      ActiveRecord::Associations::Preloader.new(records: records, associations: :custom_emoji).call
+    end
   end
 
   private

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -104,7 +104,13 @@ class Announcement < ApplicationRecord
       'FALSE AS me'
     else
       <<~SQL.squish
-        EXISTS(SELECT 1 FROM announcement_reactions r WHERE r.account_id = #{account.id} AND r.announcement_id = announcement_reactions.announcement_id AND r.name = announcement_reactions.name) AS me
+        EXISTS(
+          SELECT 1
+          FROM announcement_reactions inner_reactions
+          WHERE inner_reactions.account_id = #{account.id}
+            AND inner_reactions.announcement_id = announcement_reactions.announcement_id
+            AND inner_reactions.name = announcement_reactions.name
+        ) AS me
       SQL
     end
   end

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -76,13 +76,11 @@ class Announcement < ApplicationRecord
 
   def reactions(account = nil)
     records = begin
-      scope = grouped_ordered_announcement_reactions
-
-      selected_values = [:name, :custom_emoji_id, 'COUNT(*) as count'].tap do |values|
-        values << value_for_reaction_me_column(account)
-      end
-
-      scope.select(selected_values)
+      grouped_ordered_announcement_reactions.select(
+        [:name, :custom_emoji_id, 'COUNT(*) as count'].tap do |values|
+          values << value_for_reaction_me_column(account)
+        end
+      )
     end.to_a
 
     ActiveRecord::Associations::Preloader.new(records: records, associations: :custom_emoji).call


### PR DESCRIPTION
In the previous coverage I added for this we do exercise both account-present and account-not-present paths -- but we didn't have an assertion about the difference between those paths (the value of the `me` column in the query). This adds that coverage, and a few other details in coverage to get more precise.

The method change mainly pulls both the starting scope and the sql out to private methods, and tightens up return values with `tap`. I verified in console logs that the preloader still runs correctly here.