### PR TITLE
Fix various icon alignment issues

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1398,8 +1398,7 @@ body > [data-popper-placement] {
   .icon {
     width: 15px;
     height: 15px;
-    position: relative;
-    top: 0.145em;
+    vertical-align: middle;
   }
 }
 
@@ -5544,6 +5543,10 @@ a.status-card {
     padding-inline-end: 10px;
   }
 
+  .icon {
+    vertical-align: middle;
+  }
+
   .button {
     flex: 0 0 auto;
   }
@@ -6170,6 +6173,7 @@ a.status-card {
 
     .icon {
       color: $dark-text-color;
+      vertical-align: middle;
     }
   }
 }


### PR DESCRIPTION
I did not put `vertical-align: middle` at the `.icon` level because that caused alignment issues in other places (e.g. status visibility icon besides the timestamp) and I did not want to spend time tracking them down.

## Before

![image](https://github.com/mastodon/mastodon/assets/384364/5f52d3b9-4e79-4422-9102-0a2528365cce)
![image](https://github.com/mastodon/mastodon/assets/384364/08b18159-4fd5-4a52-95fc-f991cb70b854)


## After

![image](https://github.com/mastodon/mastodon/assets/384364/37afadf3-7ae3-409c-b828-547a2e3d4d50)
![image](https://github.com/mastodon/mastodon/assets/384364/3e02f932-7cfd-442e-ad33-7984ae19c65d)