### PR TITLE
Change media “ALT” label to a specific class

### DIFF
--- a/app/javascript/mastodon/components/media_gallery.jsx
+++ b/app/javascript/mastodon/components/media_gallery.jsx
@@ -103,7 +103,7 @@ class Item extends PureComponent {
     }
 
     if (attachment.get('description')?.length > 0) {
-      badges.push(<span key='alt' className='media-gallery__gifv__label'>ALT</span>);
+      badges.push(<span key='alt' className='media-gallery__alt__label'>ALT</span>);
     }
 
     const description = attachment.getIn(['translation', 'description']) || attachment.get('description');

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -6097,6 +6097,7 @@ a.status-card {
   gap: 2px;
 }
 
+.media-gallery__alt__label,
 .media-gallery__gifv__label {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Fixes #24969

This makes the “ALT” label easier to distinguish for custom styles.