### PR TITLE
Regenerate rubocop todo, removes last `Layout/LineLength` violation

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,13 +13,6 @@ Bundler/OrderedGems:
   Exclude:
     - 'Gemfile'
 
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: Max, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, AllowedPatterns.
-# URISchemes: http, https
-Layout/LineLength:
-  Exclude:
-    - 'app/models/account.rb'
-
 Lint/NonLocalExitFromIterator:
   Exclude:
     - 'app/helpers/jsonld_helper.rb'


### PR DESCRIPTION
This was fixed during the `followable_by` extraction, but not regen'd.