### PR TITLE
Improve display of lock icon in account headers

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -7419,6 +7419,13 @@ noscript {
           span {
             user-select: all;
           }
+
+          .icon-lock {
+            height: 16px;
+            width: 16px;
+            position: relative;
+            top: 3px;
+          }
         }
       }
     }


### PR DESCRIPTION
I modified the display of the lock icon which is displayed on locked accounts so that its size matches the username font size

Before:
![Screenshot 2024-01-17 121947](https://github.com/mastodon/mastodon/assets/36609914/7010246c-34da-4ee9-8574-77dfb6b9034c)
After:
![Screenshot 2024-01-17 124122](https://github.com/mastodon/mastodon/assets/36609914/079cabe4-a232-4c55-9c2c-e6c219472ae5)
