### PR TITLE
Fix `Rails/RakeEnvironment` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -109,6 +109,16 @@ Rails/LexicallyScopedActionFilter:
   Exclude:
     - 'app/controllers/auth/*'
 
+# Reason: These tasks are doing local work which do not need full env loaded
+# https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsrakeenvironment
+Rails/RakeEnvironment:
+  Exclude:
+    - 'lib/tasks/auto_annotate_models.rake'
+    - 'lib/tasks/emojis.rake'
+    - 'lib/tasks/mastodon.rake'
+    - 'lib/tasks/repo.rake'
+    - 'lib/tasks/statistics.rake'
+
 # Reason: There are appropriate times to use these features
 # https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsskipsmodelvalidations
 Rails/SkipsModelValidations:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -61,18 +61,6 @@ Rails/OutputSafety:
   Exclude:
     - 'config/initializers/simple_form.rb'
 
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: Include.
-# Include: **/Rakefile, **/*.rake
-Rails/RakeEnvironment:
-  Exclude:
-    - 'lib/tasks/auto_annotate_models.rake'
-    - 'lib/tasks/db.rake'
-    - 'lib/tasks/emojis.rake'
-    - 'lib/tasks/mastodon.rake'
-    - 'lib/tasks/repo.rake'
-    - 'lib/tasks/statistics.rake'
-
 # Configuration parameters: Include.
 # Include: app/models/**/*.rb
 Rails/UniqueValidationWithoutIndex:

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -15,7 +15,7 @@ namespace :db do
     end
   end
 
-  task :pre_migration_check do
+  task pre_migration_check: :environment do
     version = ActiveRecord::Base.connection.select_one("SELECT current_setting('server_version_num') AS v")['v'].to_i
     abort 'This version of Mastodon requires PostgreSQL 9.5 or newer. Please update PostgreSQL before updating Mastodon' if version < 90_500
   end


### PR DESCRIPTION
The todo exclusions here were almost all on rake tasks which don't actually do framework interaction, they do other local processing. Thus, this cop is not relevant to them.

Separately - while in here I noticed that the postgres version check in `db.rake` is out of date -- should this be bumped to 12+?