### PR TITLE
Reduced repeated setup in `UnallowDomainService` spec

### DIFF
--- a/spec/services/unallow_domain_service_spec.rb
+++ b/spec/services/unallow_domain_service_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe UnallowDomainService, type: :service do
     end
   end
 
-  def bad_domain_account_exists?
+  def bad_domain_account_exists
     Account.exists?(domain: bad_domain)
   end
 end

--- a/spec/services/unallow_domain_service_spec.rb
+++ b/spec/services/unallow_domain_service_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe UnallowDomainService, type: :service do
         expect(Account.where(domain: bad_domain).exists?).to be true
       end
 
-      it 'removes the remote accounts\'s statuses and media attachments' do
+      it 'does not remove the remote accounts\'s statuses and media attachments' do
         expect { bad_status_harassment.reload }.to_not raise_error
         expect { bad_status_mean.reload }.to_not raise_error
         expect { bad_attachment.reload }.to_not raise_error

--- a/spec/services/unallow_domain_service_spec.rb
+++ b/spec/services/unallow_domain_service_spec.rb
@@ -23,13 +23,10 @@ RSpec.describe UnallowDomainService, type: :service do
         subject.call(domain_allow)
       end
 
-      it 'removes the allowed domain' do
+      it 'makes the domain not allowed and removes accounts from that domain' do
         expect(bad_domain_allowed).to be false
-      end
-
-      it 'removes remote accounts from that domain' do
-        expect { already_banned_account.reload }.to raise_error(ActiveRecord::RecordNotFound)
         expect(bad_domain_account_exists).to be false
+        expect { already_banned_account.reload }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
       it 'removes the remote accounts\'s statuses and media attachments' do
@@ -50,11 +47,8 @@ RSpec.describe UnallowDomainService, type: :service do
         subject.call(domain_allow)
       end
 
-      it 'removes the allowed domain' do
+      it 'makes the domain not allowed but preserves accounts from the domain' do
         expect(bad_domain_allowed).to be false
-      end
-
-      it 'does not remove accounts from that domain' do
         expect(bad_domain_account_exists).to be true
       end
 

--- a/spec/services/unallow_domain_service_spec.rb
+++ b/spec/services/unallow_domain_service_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe UnallowDomainService, type: :service do
       end
 
       it 'removes the allowed domain' do
-        expect(DomainAllow.allowed?(bad_domain)).to be false
+        expect(bad_domain_allowed).to be false
       end
 
       it 'removes remote accounts from that domain' do
@@ -51,7 +51,7 @@ RSpec.describe UnallowDomainService, type: :service do
       end
 
       it 'removes the allowed domain' do
-        expect(DomainAllow.allowed?(bad_domain)).to be false
+        expect(bad_domain_allowed).to be false
       end
 
       it 'does not remove accounts from that domain' do
@@ -64,6 +64,10 @@ RSpec.describe UnallowDomainService, type: :service do
         expect { bad_attachment.reload }.to_not raise_error
       end
     end
+  end
+
+  def bad_domain_allowed
+    DomainAllow.allowed?(bad_domain)
   end
 
   def bad_domain_account_exists

--- a/spec/services/unallow_domain_service_spec.rb
+++ b/spec/services/unallow_domain_service_spec.rb
@@ -25,9 +25,9 @@ RSpec.describe UnallowDomainService, type: :service do
           .and change { bad_domain_account_exists }.from(true).to(false)
 
         expect { already_banned_account.reload }.to raise_error(ActiveRecord::RecordNotFound)
-        expect { bad_status_harassment.reload }.to raise_exception ActiveRecord::RecordNotFound
-        expect { bad_status_mean.reload }.to raise_exception ActiveRecord::RecordNotFound
-        expect { bad_attachment.reload }.to raise_exception ActiveRecord::RecordNotFound
+        expect { bad_status_harassment.reload }.to raise_error(ActiveRecord::RecordNotFound)
+        expect { bad_status_mean.reload }.to raise_error(ActiveRecord::RecordNotFound)
+        expect { bad_attachment.reload }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
   end

--- a/spec/services/unallow_domain_service_spec.rb
+++ b/spec/services/unallow_domain_service_spec.rb
@@ -22,8 +22,7 @@ RSpec.describe UnallowDomainService, type: :service do
       it 'makes the domain not allowed and removes accounts from that domain' do
         expect { subject.call(domain_allow) }
           .to change { bad_domain_allowed }.from(true).to(false)
-
-        expect(bad_domain_account_exists).to be false
+          .and change { bad_domain_account_exists }.from(true).to(false)
 
         expect { already_banned_account.reload }.to raise_error(ActiveRecord::RecordNotFound)
         expect { bad_status_harassment.reload }.to raise_exception ActiveRecord::RecordNotFound
@@ -42,8 +41,7 @@ RSpec.describe UnallowDomainService, type: :service do
       it 'makes the domain not allowed but preserves accounts from the domain' do
         expect { subject.call(domain_allow) }
           .to change { bad_domain_allowed }.from(true).to(false)
-
-        expect(bad_domain_account_exists).to be true
+          .and not_change { bad_domain_account_exists }.from(true)
 
         expect { bad_status_harassment.reload }.to_not raise_error
         expect { bad_status_mean.reload }.to_not raise_error

--- a/spec/services/unallow_domain_service_spec.rb
+++ b/spec/services/unallow_domain_service_spec.rb
@@ -19,12 +19,10 @@ RSpec.describe UnallowDomainService, type: :service do
     end
 
     describe '#call' do
-      before do
-        subject.call(domain_allow)
-      end
-
       it 'makes the domain not allowed and removes accounts from that domain' do
-        expect(bad_domain_allowed).to be false
+        expect { subject.call(domain_allow) }
+          .to change { bad_domain_allowed }.from(true).to(false)
+
         expect(bad_domain_account_exists).to be false
 
         expect { already_banned_account.reload }.to raise_error(ActiveRecord::RecordNotFound)
@@ -41,12 +39,10 @@ RSpec.describe UnallowDomainService, type: :service do
     end
 
     describe '#call' do
-      before do
-        subject.call(domain_allow)
-      end
-
       it 'makes the domain not allowed but preserves accounts from the domain' do
-        expect(bad_domain_allowed).to be false
+        expect { subject.call(domain_allow) }
+          .to change { bad_domain_allowed }.from(true).to(false)
+
         expect(bad_domain_account_exists).to be true
 
         expect { bad_status_harassment.reload }.to_not raise_error

--- a/spec/services/unallow_domain_service_spec.rb
+++ b/spec/services/unallow_domain_service_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe UnallowDomainService, type: :service do
 
       it 'removes remote accounts from that domain' do
         expect { already_banned_account.reload }.to raise_error(ActiveRecord::RecordNotFound)
-        expect(Account.where(domain: bad_domain).exists?).to be false
+        expect(bad_domain_account_exists).to be false
       end
 
       it 'removes the remote accounts\'s statuses and media attachments' do
@@ -55,7 +55,7 @@ RSpec.describe UnallowDomainService, type: :service do
       end
 
       it 'does not remove accounts from that domain' do
-        expect(Account.where(domain: bad_domain).exists?).to be true
+        expect(bad_domain_account_exists).to be true
       end
 
       it 'does not remove the remote accounts\'s statuses and media attachments' do
@@ -64,5 +64,9 @@ RSpec.describe UnallowDomainService, type: :service do
         expect { bad_attachment.reload }.to_not raise_error
       end
     end
+  end
+
+  def bad_domain_account_exists?
+    Account.exists?(domain: bad_domain)
   end
 end

--- a/spec/services/unallow_domain_service_spec.rb
+++ b/spec/services/unallow_domain_service_spec.rb
@@ -5,12 +5,13 @@ require 'rails_helper'
 RSpec.describe UnallowDomainService, type: :service do
   subject { described_class.new }
 
-  let!(:bad_account) { Fabricate(:account, username: 'badguy666', domain: 'evil.org') }
+  let(:bad_domain) { 'evil.org' }
+  let!(:bad_account) { Fabricate(:account, username: 'badguy666', domain: bad_domain) }
   let!(:bad_status_harassment) { Fabricate(:status, account: bad_account, text: 'You suck') }
   let!(:bad_status_mean) { Fabricate(:status, account: bad_account, text: 'Hahaha') }
   let!(:bad_attachment) { Fabricate(:media_attachment, account: bad_account, status: bad_status_mean, file: attachment_fixture('attachment.jpg')) }
-  let!(:already_banned_account) { Fabricate(:account, username: 'badguy', domain: 'evil.org', suspended: true, silenced: true) }
-  let!(:domain_allow) { Fabricate(:domain_allow, domain: 'evil.org') }
+  let!(:already_banned_account) { Fabricate(:account, username: 'badguy', domain: bad_domain, suspended: true, silenced: true) }
+  let!(:domain_allow) { Fabricate(:domain_allow, domain: bad_domain) }
 
   context 'with limited federation mode', :sidekiq_inline do
     before do
@@ -23,12 +24,12 @@ RSpec.describe UnallowDomainService, type: :service do
       end
 
       it 'removes the allowed domain' do
-        expect(DomainAllow.allowed?('evil.org')).to be false
+        expect(DomainAllow.allowed?(bad_domain)).to be false
       end
 
       it 'removes remote accounts from that domain' do
         expect { already_banned_account.reload }.to raise_error(ActiveRecord::RecordNotFound)
-        expect(Account.where(domain: 'evil.org').exists?).to be false
+        expect(Account.where(domain: bad_domain).exists?).to be false
       end
 
       it 'removes the remote accounts\'s statuses and media attachments' do
@@ -50,11 +51,11 @@ RSpec.describe UnallowDomainService, type: :service do
       end
 
       it 'removes the allowed domain' do
-        expect(DomainAllow.allowed?('evil.org')).to be false
+        expect(DomainAllow.allowed?(bad_domain)).to be false
       end
 
       it 'does not remove accounts from that domain' do
-        expect(Account.where(domain: 'evil.org').exists?).to be true
+        expect(Account.where(domain: bad_domain).exists?).to be true
       end
 
       it 'removes the remote accounts\'s statuses and media attachments' do

--- a/spec/services/unallow_domain_service_spec.rb
+++ b/spec/services/unallow_domain_service_spec.rb
@@ -26,10 +26,8 @@ RSpec.describe UnallowDomainService, type: :service do
       it 'makes the domain not allowed and removes accounts from that domain' do
         expect(bad_domain_allowed).to be false
         expect(bad_domain_account_exists).to be false
-        expect { already_banned_account.reload }.to raise_error(ActiveRecord::RecordNotFound)
-      end
 
-      it 'removes the remote accounts\'s statuses and media attachments' do
+        expect { already_banned_account.reload }.to raise_error(ActiveRecord::RecordNotFound)
         expect { bad_status_harassment.reload }.to raise_exception ActiveRecord::RecordNotFound
         expect { bad_status_mean.reload }.to raise_exception ActiveRecord::RecordNotFound
         expect { bad_attachment.reload }.to raise_exception ActiveRecord::RecordNotFound
@@ -50,9 +48,7 @@ RSpec.describe UnallowDomainService, type: :service do
       it 'makes the domain not allowed but preserves accounts from the domain' do
         expect(bad_domain_allowed).to be false
         expect(bad_domain_account_exists).to be true
-      end
 
-      it 'does not remove the remote accounts\'s statuses and media attachments' do
         expect { bad_status_harassment.reload }.to_not raise_error
         expect { bad_status_mean.reload }.to_not raise_error
         expect { bad_attachment.reload }.to_not raise_error


### PR DESCRIPTION
Changes:

- Pull repeated string out to let var
- Pull out some helper methods to perform the repeated checks
- In each section (federated and not), combine some examples that had the same setup