### PR TITLE
Reduced repeated setup in `PurgeDomainService` spec

### DIFF
--- a/spec/services/purge_domain_service_spec.rb
+++ b/spec/services/purge_domain_service_spec.rb
@@ -12,19 +12,18 @@ RSpec.describe PurgeDomainService, type: :service do
   let!(:old_attachment) { Fabricate(:media_attachment, account: old_account, status: old_status_with_attachment, file: attachment_fixture('attachment.jpg')) }
 
   describe 'for a suspension' do
-    before do
-      subject.call(domain)
-    end
+    it 'refreshes instance view and removes associated records' do
+      expect { subject.call(domain) }
+        .to change { domain_instance_exists }.from(true).to(false)
 
-    it 'removes the remote accounts\'s statuses and media attachments' do
       expect { old_account.reload }.to raise_exception ActiveRecord::RecordNotFound
       expect { old_status_plain.reload }.to raise_exception ActiveRecord::RecordNotFound
       expect { old_status_with_attachment.reload }.to raise_exception ActiveRecord::RecordNotFound
       expect { old_attachment.reload }.to raise_exception ActiveRecord::RecordNotFound
     end
 
-    it 'refreshes instances view' do
-      expect(Instance.where(domain: domain).exists?).to be false
+    def domain_instance_exists
+      Instance.exists?(domain: domain)
     end
   end
 end

--- a/spec/services/purge_domain_service_spec.rb
+++ b/spec/services/purge_domain_service_spec.rb
@@ -5,14 +5,15 @@ require 'rails_helper'
 RSpec.describe PurgeDomainService, type: :service do
   subject { described_class.new }
 
-  let!(:old_account) { Fabricate(:account, domain: 'obsolete.org') }
+  let(:domain) { 'obsolete.org' }
+  let!(:old_account) { Fabricate(:account, domain: domain) }
   let!(:old_status_plain) { Fabricate(:status, account: old_account) }
   let!(:old_status_with_attachment) { Fabricate(:status, account: old_account) }
   let!(:old_attachment) { Fabricate(:media_attachment, account: old_account, status: old_status_with_attachment, file: attachment_fixture('attachment.jpg')) }
 
   describe 'for a suspension' do
     before do
-      subject.call('obsolete.org')
+      subject.call(domain)
     end
 
     it 'removes the remote accounts\'s statuses and media attachments' do
@@ -23,7 +24,7 @@ RSpec.describe PurgeDomainService, type: :service do
     end
 
     it 'refreshes instances view' do
-      expect(Instance.where(domain: 'obsolete.org').exists?).to be false
+      expect(Instance.where(domain: domain).exists?).to be false
     end
   end
 end

--- a/spec/services/purge_domain_service_spec.rb
+++ b/spec/services/purge_domain_service_spec.rb
@@ -6,20 +6,20 @@ RSpec.describe PurgeDomainService, type: :service do
   subject { described_class.new }
 
   let(:domain) { 'obsolete.org' }
-  let!(:old_account) { Fabricate(:account, domain: domain) }
-  let!(:old_status_plain) { Fabricate(:status, account: old_account) }
-  let!(:old_status_with_attachment) { Fabricate(:status, account: old_account) }
-  let!(:old_attachment) { Fabricate(:media_attachment, account: old_account, status: old_status_with_attachment, file: attachment_fixture('attachment.jpg')) }
+  let!(:account) { Fabricate(:account, domain: domain) }
+  let!(:status_plain) { Fabricate(:status, account: account) }
+  let!(:status_with_attachment) { Fabricate(:status, account: account) }
+  let!(:attachment) { Fabricate(:media_attachment, account: account, status: status_with_attachment, file: attachment_fixture('attachment.jpg')) }
 
   describe 'for a suspension' do
     it 'refreshes instance view and removes associated records' do
       expect { subject.call(domain) }
         .to change { domain_instance_exists }.from(true).to(false)
 
-      expect { old_account.reload }.to raise_exception ActiveRecord::RecordNotFound
-      expect { old_status_plain.reload }.to raise_exception ActiveRecord::RecordNotFound
-      expect { old_status_with_attachment.reload }.to raise_exception ActiveRecord::RecordNotFound
-      expect { old_attachment.reload }.to raise_exception ActiveRecord::RecordNotFound
+      expect { account.reload }.to raise_exception ActiveRecord::RecordNotFound
+      expect { status_plain.reload }.to raise_exception ActiveRecord::RecordNotFound
+      expect { status_with_attachment.reload }.to raise_exception ActiveRecord::RecordNotFound
+      expect { attachment.reload }.to raise_exception ActiveRecord::RecordNotFound
     end
 
     def domain_instance_exists


### PR DESCRIPTION
Changes:

- Pull out repeated string var to let var
- Combine two examples with same setup into one
- Pull out helper method for instance exists check
- There were no variables WITHOUT an `old_` prefix, so remove it from all vars