### PR TITLE
Retry 401 errors on replies fetching

### DIFF
--- a/app/services/activitypub/fetch_replies_service.rb
+++ b/app/services/activitypub/fetch_replies_service.rb
@@ -37,7 +37,13 @@ class ActivityPub::FetchRepliesService < BaseService
     return unless @allow_synchronous_requests
     return if non_matching_uri_hosts?(@account.uri, collection_or_uri)
 
-    fetch_resource_without_id_validation(collection_or_uri, nil, true)
+    begin
+      fetch_resource_without_id_validation(collection_or_uri, nil, true)
+    rescue Mastodon::UnexpectedResponseError => e
+      raise unless e.response && e.response.code == 401
+
+      fetch_resource_without_id_validation(collection_or_uri, nil, true, request_options: {with_query_string: true})
+    end
   end
 
   def filtered_replies

--- a/app/services/activitypub/fetch_replies_service.rb
+++ b/app/services/activitypub/fetch_replies_service.rb
@@ -42,7 +42,7 @@ class ActivityPub::FetchRepliesService < BaseService
     rescue Mastodon::UnexpectedResponseError => e
       raise unless e.response && e.response.code == 401
 
-      fetch_resource_without_id_validation(collection_or_uri, nil, true, request_options: {with_query_string: true})
+      fetch_resource_without_id_validation(collection_or_uri, nil, true, request_options: { with_query_string: true })
     end
   end
 

--- a/app/services/activitypub/fetch_replies_service.rb
+++ b/app/services/activitypub/fetch_replies_service.rb
@@ -37,10 +37,17 @@ class ActivityPub::FetchRepliesService < BaseService
     return unless @allow_synchronous_requests
     return if non_matching_uri_hosts?(@account.uri, collection_or_uri)
 
+    # NOTE: For backward compatibility reasons, Mastodon signs outgoing
+    # queries incorrectly by default.
+    #
+    # While this is relevant for all URLs with query strings, this is
+    # the only code path where this happens in practice.
+    #
+    # Therefore, retry with correct signatures if this fails.
     begin
       fetch_resource_without_id_validation(collection_or_uri, nil, true)
     rescue Mastodon::UnexpectedResponseError => e
-      raise unless e.response && e.response.code == 401
+      raise unless e.response && e.response.code == 401 && Addressable::URI.parse(collection_or_uri).query.present?
 
       fetch_resource_without_id_validation(collection_or_uri, nil, true, request_options: { with_query_string: true })
     end


### PR DESCRIPTION
This addresses https://github.com/superseriousbusiness/gotosocial/issues/894, and follows up on https://github.com/mastodon/mastodon/pull/28476 by using the introduced parameters

To do that, some extra arguments are added to jsonld_helper.rb functions to allow the parameter to be passed down to `Request.new`

(Please give snippets when suggesting improvements, im not too versed with ruby, and so im not too sure about this etiquette)