### PR TITLE
Fix `Rails/WhereExists` cop in User model

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -87,7 +87,6 @@ Rails/WhereExists:
     - 'app/models/poll.rb'
     - 'app/models/session_activation.rb'
     - 'app/models/status.rb'
-    - 'app/models/user.rb'
     - 'app/policies/status_policy.rb'
     - 'app/serializers/rest/announcement_serializer.rb'
     - 'app/serializers/rest/tag_serializer.rb'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -434,7 +434,7 @@ class User < ApplicationRecord
   end
 
   def sign_up_from_ip_requires_approval?
-    !sign_up_ip.nil? && IpBlock.where(severity: :sign_up_requires_approval).where('ip >>= ?', sign_up_ip.to_s).exists?
+    sign_up_ip.present? && IpBlock.sign_up_requires_approval.exists?(['ip >>= ?', sign_up_ip.to_s])
   end
 
   def sign_up_email_requires_approval?


### PR DESCRIPTION
Fixes the cop, also:

- Converted `!nil` to `present?` up front
- Used the enum-generated `sign_up_requires_approval` scope
- The array syntax is needed to generate the final where correctly
- Tried to remove it, but the `to_s` is still required on the `IPAddr` object

Generated sql is same after changes.