### PR TITLE
Use `sanitize_sql_like` on `Instance.matches_domain` query

### DIFF
--- a/app/models/instance.rb
+++ b/app/models/instance.rb
@@ -22,7 +22,7 @@ class Instance < ApplicationRecord
   end
 
   scope :searchable, -> { where.not(domain: DomainBlock.select(:domain)) }
-  scope :matches_domain, ->(value) { where(arel_table[:domain].matches("%#{value}%")) }
+  scope :matches_domain, ->(value) { where(arel_table[:domain].matches("%#{sanitize_sql_like(value)}%")) }
   scope :by_domain_and_subdomains, ->(domain) { where("reverse('.' || domain) LIKE reverse(?)", "%.#{domain}") }
 
   def self.refresh


### PR DESCRIPTION
While working on a different scope, I noticed this one was not sanitizing the value sent to LIKE here.

In a data set with two accounts with domains of `host.example` and `host_under.example`:

- The previous non-sanitized query, when sent a value of `host_` - would treat the `_` as a sql wildcard, and return both Instance records as a result
- The new sanitized version, when sent the same `host_` query, escapes the underscore, and then only matches against the `host_under.example` instance

My assumption is that the latter is the preferred behavior? I don't think there's an injection risk here, I just think there's an excessive results risk. Assuming the spec portion of https://github.com/mastodon/mastodon/pull/28767 gets merged, I can both a) rebase this against that to make sure it's good with specs, b) add coverage for this specific handling ... but wanted to confirm my assumption here about how we want to handle this is correct first.
