### PR TITLE
Add coverage for `api/v1/peers/search` endpoint and extract controller query to Instance scope

### DIFF
--- a/app/controllers/api/v1/peers/search_controller.rb
+++ b/app/controllers/api/v1/peers/search_controller.rb
@@ -33,7 +33,7 @@ class Api::V1::Peers::SearchController < Api::BaseController
       database_query_domains
     end
   rescue Addressable::URI::InvalidURIError
-    []
+    Instance.none
   end
 
   def search_index_query_domains

--- a/app/models/instance.rb
+++ b/app/models/instance.rb
@@ -23,6 +23,7 @@ class Instance < ApplicationRecord
 
   scope :searchable, -> { where.not(domain: DomainBlock.select(:domain)) }
   scope :matches_domain, ->(value) { where(arel_table[:domain].matches("%#{value}%")) }
+  scope :domain_starts_with, ->(value) { where(arel_table[:domain].matches("#{sanitize_sql_like(value)}%", false, true)) }
   scope :by_domain_and_subdomains, ->(domain) { where("reverse('.' || domain) LIKE reverse(?)", "%.#{domain}") }
 
   def self.refresh

--- a/spec/requests/api/v1/peers/search_spec.rb
+++ b/spec/requests/api/v1/peers/search_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'API Peers Search' do
+  describe 'GET /api/v1/peers/search' do
+    context 'with no search param' do
+      it 'returns http success and empty response' do
+        get '/api/v1/peers/search'
+
+        expect(response)
+          .to have_http_status(200)
+        expect(body_as_json)
+          .to be_blank
+      end
+    end
+
+    context 'with search param' do
+      let!(:account) { Fabricate(:account, domain: 'host.example') }
+
+      before { Instance.refresh }
+
+      it 'returns http success and json with known domains' do
+        get '/api/v1/peers/search', params: { q: 'host.example' }
+
+        expect(response)
+          .to have_http_status(200)
+        expect(body_as_json.size)
+          .to eq(1)
+        expect(body_as_json.first)
+          .to eq(account.domain)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/peers/search_spec.rb
+++ b/spec/requests/api/v1/peers/search_spec.rb
@@ -4,6 +4,19 @@ require 'rails_helper'
 
 describe 'API Peers Search' do
   describe 'GET /api/v1/peers/search' do
+    context 'when peers api is disabled' do
+      before do
+        Setting.peers_api_enabled = false
+      end
+
+      it 'returns http not found response' do
+        get '/api/v1/peers/search'
+
+        expect(response)
+          .to have_http_status(404)
+      end
+    end
+
     context 'with no search param' do
       it 'returns http success and empty response' do
         get '/api/v1/peers/search'

--- a/spec/requests/api/v1/peers/search_spec.rb
+++ b/spec/requests/api/v1/peers/search_spec.rb
@@ -28,6 +28,17 @@ describe 'API Peers Search' do
       end
     end
 
+    context 'with invalid search param' do
+      it 'returns http success and empty response' do
+        get '/api/v1/peers/search', params: { q: 'ftp://Invalid-Host!!.valüe' }
+
+        expect(response)
+          .to have_http_status(200)
+        expect(body_as_json)
+          .to be_blank
+      end
+    end
+
     context 'with search param' do
       let!(:account) { Fabricate(:account, domain: 'host.example') }
 


### PR DESCRIPTION
This started out simple -- I noticed the query in the controller here and was going to move it to a scope on Instance. Alas, like so many other great PRs of our time, it kept expanding from there, and here we are.

While doing that, I also:

- Realized there was no spec for this api endpoint, so added one for basic scenarios
- Realized that the "use chewy" and "use db" paths both repeated the same normalization of the params, so pulled out to helper methods
- Realized that both paths were calling limit/pluck - so pulled out the scope generation to methods and then called limit/pluck just once

In any event, I believe the API endpoint behavior in general, and the generated query specifically, should not have changed.