### PR TITLE
Remove unused `matches_domain` scopes on Account, DomainAllow, DomainBlock

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -125,7 +125,6 @@ class Account < ApplicationRecord
   scope :alphabetic, -> { order(domain: :asc, username: :asc) }
   scope :matches_username, ->(value) { where('lower((username)::text) LIKE lower(?)', "#{value}%") }
   scope :matches_display_name, ->(value) { where(arel_table[:display_name].matches("#{value}%")) }
-  scope :matches_domain, ->(value) { where(arel_table[:domain].matches("%#{value}%")) }
   scope :without_unapproved, -> { left_outer_joins(:user).merge(User.approved.confirmed).or(remote) }
   scope :searchable, -> { without_unapproved.without_suspended.where(moved_to_account_id: nil) }
   scope :discoverable, -> { searchable.without_silenced.where(discoverable: true).joins(:account_stat) }

--- a/app/models/domain_allow.rb
+++ b/app/models/domain_allow.rb
@@ -17,8 +17,6 @@ class DomainAllow < ApplicationRecord
 
   validates :domain, presence: true, uniqueness: true, domain: true
 
-  scope :matches_domain, ->(value) { where(arel_table[:domain].matches("%#{value}%")) }
-
   def to_log_human_identifier
     domain
   end

--- a/app/models/domain_block.rb
+++ b/app/models/domain_block.rb
@@ -28,7 +28,6 @@ class DomainBlock < ApplicationRecord
   has_many :accounts, foreign_key: :domain, primary_key: :domain, inverse_of: false, dependent: nil
   delegate :count, to: :accounts, prefix: true
 
-  scope :matches_domain, ->(value) { where(arel_table[:domain].matches("%#{value}%")) }
   scope :with_user_facing_limitations, -> { where(severity: [:silence, :suspend]) }
   scope :with_limitations, -> { where(severity: [:silence, :suspend]).or(where(reject_media: true)) }
   scope :by_severity, -> { in_order_of(:severity, %w(noop silence suspend)).order(:domain) }

--- a/spec/models/domain_allow_spec.rb
+++ b/spec/models/domain_allow_spec.rb
@@ -3,16 +3,18 @@
 require 'rails_helper'
 
 describe DomainAllow do
-  describe 'scopes' do
-    describe 'matches_domain' do
-      let(:domain) { Fabricate(:domain_allow, domain: 'example.com') }
-      let(:other_domain) { Fabricate(:domain_allow, domain: 'example.biz') }
+  describe 'Validations' do
+    it 'is invalid without a domain' do
+      domain_allow = Fabricate.build(:domain_allow, domain: nil)
+      domain_allow.valid?
+      expect(domain_allow).to model_have_error_on_field(:domain)
+    end
 
-      it 'returns the correct records' do
-        results = described_class.matches_domain('example.com')
-
-        expect(results).to eq([domain])
-      end
+    it 'is invalid if the same normalized domain already exists' do
+      _domain_allow = Fabricate(:domain_allow, domain: 'にゃん')
+      domain_allow_with_normalized_value = Fabricate.build(:domain_allow, domain: 'xn--r9j5b5b')
+      domain_allow_with_normalized_value.valid?
+      expect(domain_allow_with_normalized_value).to model_have_error_on_field(:domain)
     end
   end
 end


### PR DESCRIPTION
The DomainBlock and DomainAllow were originally added to use in the InstanceFilter - https://github.com/mastodon/mastodon/commit/24552b5160a5090e7d6056fb69a209aa48fe4fce#diff-8da415cf19c82e1283b141675cf9aec67ff23d48aa6bf7e0b54f4fa06eaa4875R17

The Account one was also added to help with InstanceFilter - https://github.com/mastodon/mastodon/commit/da77f65c4684a8a9ee25c3e18f6f09824c765c2d#diff-8da415cf19c82e1283b141675cf9aec67ff23d48aa6bf7e0b54f4fa06eaa4875R23

They were all replaced with a method directly on Instance - https://github.com/mastodon/mastodon/commit/216b85b053d091306e3311a21f5b050f70a75130#diff-8da415cf19c82e1283b141675cf9aec67ff23d48aa6bf7e0b54f4fa06eaa4875R34 - which is still in use (referenced in other recent PR: https://github.com/mastodon/mastodon/pull/28795#issuecomment-1898434912 )

The spec for this scope was the only thing in the DomainAllow spec. Instead of deleting it, I added a basic validation spec (basically copied from DomainBlock spec).