### PR TITLE
Use AR `database_version` in PG version checks in migrations

### DIFF
--- a/db/migrate/20180812173710_copy_status_stats.rb
+++ b/db/migrate/20180812173710_copy_status_stats.rb
@@ -20,8 +20,7 @@ class CopyStatusStats < ActiveRecord::Migration[5.2]
   private
 
   def supports_upsert?
-    version = select_one("SELECT current_setting('server_version_num') AS v")['v'].to_i
-    version >= 90_500
+    ActiveRecord::Base.connection.database_version >= 90_500
   end
 
   def up_fast

--- a/db/migrate/20181116173541_copy_account_stats.rb
+++ b/db/migrate/20181116173541_copy_account_stats.rb
@@ -24,8 +24,7 @@ class CopyAccountStats < ActiveRecord::Migration[5.2]
   private
 
   def supports_upsert?
-    version = select_one("SELECT current_setting('server_version_num') AS v")['v'].to_i
-    version >= 90_500
+    ActiveRecord::Base.connection.database_version >= 90_500
   end
 
   def up_fast

--- a/db/post_migrate/20230803082451_add_unique_index_on_preview_cards_statuses.rb
+++ b/db/post_migrate/20230803082451_add_unique_index_on_preview_cards_statuses.rb
@@ -17,8 +17,7 @@ class AddUniqueIndexOnPreviewCardsStatuses < ActiveRecord::Migration[6.1]
 
   def supports_concurrent_reindex?
     @supports_concurrent_reindex ||= begin
-      version = select_one("SELECT current_setting('server_version_num') AS v")['v'].to_i
-      version >= 120_000
+      ActiveRecord::Base.connection.database_version >= 120_000
     end
   end
 


### PR DESCRIPTION
Noticed this shortcut over the full query while doing https://github.com/mastodon/mastodon/pull/28800

Underlying method - https://github.com/rails/rails/blob/v7.1.3/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L614-L618 - calls down to the pg gem and will return an integer in the expected PG version format.