### PR TITLE
Extract shared tagged statuses method in `FeaturedTag`

### DIFF
--- a/app/models/featured_tag.rb
+++ b/app/models/featured_tag.rb
@@ -45,7 +45,7 @@ class FeaturedTag < ApplicationRecord
   end
 
   def decrement(deleted_status_id)
-    update(statuses_count: [0, statuses_count - 1].max, last_status_at: account.statuses.where(visibility: %i(public unlisted)).tagged_with(tag).where.not(id: deleted_status_id).select(:created_at).first&.created_at)
+    update(statuses_count: [0, statuses_count - 1].max, last_status_at: visible_tagged_account_statuses.where.not(id: deleted_status_id).select(:created_at).first&.created_at)
   end
 
   private
@@ -55,8 +55,8 @@ class FeaturedTag < ApplicationRecord
   end
 
   def reset_data
-    self.statuses_count = account.statuses.where(visibility: %i(public unlisted)).tagged_with(tag).count
-    self.last_status_at = account.statuses.where(visibility: %i(public unlisted)).tagged_with(tag).select(:created_at).first&.created_at
+    self.statuses_count = visible_tagged_account_statuses.count
+    self.last_status_at = visible_tagged_account_statuses.select(:created_at).first&.created_at
   end
 
   def validate_featured_tags_limit
@@ -71,5 +71,9 @@ class FeaturedTag < ApplicationRecord
 
   def tag_already_featured_for_account?
     FeaturedTag.by_name(name).exists?(account_id: account_id)
+  end
+
+  def visible_tagged_account_statuses
+    account.statuses.where(visibility: %i(public unlisted)).tagged_with(tag)
   end
 end


### PR DESCRIPTION
Noticed this duplication while doing https://github.com/mastodon/mastodon/pull/28791

Possible future additional improvement here - turn this into association(s) on the model.