### PR TITLE
Use normalizes to prepare `Status#sensitive` value

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -123,6 +123,8 @@ class Status < ApplicationRecord
     where('NOT EXISTS (SELECT * FROM statuses_tags forbidden WHERE forbidden.status_id = statuses.id AND forbidden.tag_id IN (?))', tag_ids)
   }
 
+  normalizes :sensitive, with: ->(sensitive) { sensitive.present? }, apply_to_nil: true
+
   after_create_commit :trigger_create_webhooks
   after_update_commit :trigger_update_webhooks
 
@@ -443,7 +445,6 @@ class Status < ApplicationRecord
   def set_visibility
     self.visibility = reblog.visibility if reblog? && visibility.nil?
     self.visibility = (account.locked? ? :private : :public) if visibility.nil?
-    self.sensitive  = false if sensitive.nil?
   end
 
   def set_conversation

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -410,4 +410,26 @@ RSpec.describe Status do
       expect(status.uri).to start_with('https://')
     end
   end
+
+  describe 'Normalizations' do
+    describe 'sensitive' do
+      it 'preserves true value' do
+        status = Fabricate.build(:status, sensitive: true)
+
+        expect(status.sensitive).to be(true)
+      end
+
+      it 'preserves false value' do
+        status = Fabricate.build(:status, sensitive: false)
+
+        expect(status.sensitive).to be(false)
+      end
+
+      it 'converts nil value to false' do
+        status = Fabricate.build(:status, sensitive: nil)
+
+        expect(status.sensitive).to be(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
The improvement here is both to use the normalizes feature, but also the method naming where this was previously being done is not totally accurate.

Separately - I don't fully understand why this line is actually needed. The history here shows that in very early versions we were not encorcing NOT NULL on some boolean columns. That was fixed when this line was added - https://github.com/mastodon/mastodon/commit/880a5eb25cc62d2181b34a21985addee847cbb49 - and we have both a) fixed old data in that migration, b) currently enforce not null and false default.

Given those, I'm not sure the full use. I guess in a scenario where it's explicitly passed in (either purposefully or side effect) as nil, and we want to make sure it's always boolean for other areas that use the value, this still is needed.