### PR TITLE
Add `Account.auditable` scope, fix N+1 in admin/action_logs#index

### DIFF
--- a/app/controllers/admin/action_logs_controller.rb
+++ b/app/controllers/admin/action_logs_controller.rb
@@ -6,7 +6,7 @@ module Admin
 
     def index
       authorize :audit_log, :index?
-      @auditable_accounts = Account.where(id: Admin::ActionLog.select('distinct account_id')).select(:id, :username)
+      @auditable_accounts = Account.auditable.select(:id, :username)
     end
 
     private

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -126,6 +126,7 @@ class Account < ApplicationRecord
   scope :matches_username, ->(value) { where('lower((username)::text) LIKE lower(?)', "#{value}%") }
   scope :matches_display_name, ->(value) { where(arel_table[:display_name].matches("#{value}%")) }
   scope :without_unapproved, -> { left_outer_joins(:user).merge(User.approved.confirmed).or(remote) }
+  scope :auditable, -> { where(id: Admin::ActionLog.select(:account_id).distinct) }
   scope :searchable, -> { without_unapproved.without_suspended.where(moved_to_account_id: nil) }
   scope :discoverable, -> { searchable.without_silenced.where(discoverable: true).joins(:account_stat) }
   scope :by_recent_status, -> { includes(:account_stat).merge(AccountStat.order('last_status_at DESC NULLS LAST')).references(:account_stat) }

--- a/app/models/admin/action_log_filter.rb
+++ b/app/models/admin/action_log_filter.rb
@@ -72,7 +72,7 @@ class Admin::ActionLogFilter
   end
 
   def results
-    scope = latest_action_logs.includes(:target)
+    scope = latest_action_logs.includes(:target, :account)
 
     params.each do |key, value|
       next if key.to_s == 'page'

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -835,6 +835,25 @@ RSpec.describe Account do
   end
 
   describe 'scopes' do
+    describe 'auditable' do
+      let!(:alice) { Fabricate :account }
+      let!(:bob) { Fabricate :account }
+
+      before do
+        2.times { Fabricate :action_log, account: alice }
+      end
+
+      it 'returns distinct accounts with action log records' do
+        results = described_class.auditable
+
+        expect(results.size)
+          .to eq(1)
+        expect(results)
+          .to include(alice)
+          .and not_include(bob)
+      end
+    end
+
     describe 'alphabetic' do
       it 'sorts by alphabetic order of domain and username' do
         matches = [


### PR DESCRIPTION
Main change -- add an `auditable` scope to Account which finds (distinct) accounts that have `Admin::ActionLog` records.

While reviewing queries from usage here, I noticed an N+1 in the controller -- theres a loop of _action_log partial which call out to the account for each one. Added account to includes in the filter to fix the N+1 there.