### PR TITLE
Fix banner image not showing in follow emails

### DIFF
--- a/app/javascript/styles/mailer.scss
+++ b/app/javascript/styles/mailer.scss
@@ -100,9 +100,8 @@ table + p {
   border-top-right-radius: 12px;
   height: 140px;
   vertical-align: bottom;
-  background-color: #f3f2f5;
-  background-position: center;
-  background-size: cover;
+  background-position: center !important;
+  background-size: cover !important;
 }
 
 .email-account-banner-inner-td {


### PR DESCRIPTION
Fix banner image not showing up in follow emails due to Premailer replacing longhand CSS properties `background-size:cover; background-position:center` by shorthand CSS property `background:center / cover`, thus taking over the `background` image HTML attribute. Adding `!important` to the longhand properties is enough to fix this. (Would be a problem for Outlook on Windows but since this is related to background images and they're not supported there in the first place, that'll do it.)

![A screenshot of the follow email showing the background banner image working correctly.](https://github.com/mastodon/mastodon/assets/3451753/b79217a9-033e-4add-ac70-4138bbd3e3f4)
