### PR TITLE
Add `not_featured_by` scope to Tag

### DIFF
--- a/app/controllers/api/v1/featured_tags/suggestions_controller.rb
+++ b/app/controllers/api/v1/featured_tags/suggestions_controller.rb
@@ -12,6 +12,6 @@ class Api::V1::FeaturedTags::SuggestionsController < Api::BaseController
   private
 
   def set_recently_used_tags
-    @recently_used_tags = Tag.recently_used(current_account).not_featured_by(current_account).limit(10)
+    @recently_used_tags = Tag.suggestions_for_account(current_account).limit(10)
   end
 end

--- a/app/controllers/api/v1/featured_tags/suggestions_controller.rb
+++ b/app/controllers/api/v1/featured_tags/suggestions_controller.rb
@@ -12,10 +12,6 @@ class Api::V1::FeaturedTags::SuggestionsController < Api::BaseController
   private
 
   def set_recently_used_tags
-    @recently_used_tags = Tag.recently_used(current_account).where.not(id: featured_tag_ids).limit(10)
-  end
-
-  def featured_tag_ids
-    current_account.featured_tags.pluck(:tag_id)
+    @recently_used_tags = Tag.recently_used(current_account).not_featured_by(current_account).limit(10)
   end
 end

--- a/app/controllers/settings/featured_tags_controller.rb
+++ b/app/controllers/settings/featured_tags_controller.rb
@@ -38,7 +38,7 @@ class Settings::FeaturedTagsController < Settings::BaseController
   end
 
   def set_recently_used_tags
-    @recently_used_tags = Tag.recently_used(current_account).not_featured_by(current_account).limit(10)
+    @recently_used_tags = Tag.suggestions_for_account(current_account).limit(10)
   end
 
   def featured_tag_params

--- a/app/controllers/settings/featured_tags_controller.rb
+++ b/app/controllers/settings/featured_tags_controller.rb
@@ -38,7 +38,7 @@ class Settings::FeaturedTagsController < Settings::BaseController
   end
 
   def set_recently_used_tags
-    @recently_used_tags = Tag.recently_used(current_account).where.not(id: @featured_tags.map(&:id)).limit(10)
+    @recently_used_tags = Tag.recently_used(current_account).not_featured_by(current_account).limit(10)
   end
 
   def featured_tag_params

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -53,6 +53,7 @@ class Tag < ApplicationRecord
   scope :listable, -> { where(listable: [true, nil]) }
   scope :trendable, -> { Setting.trendable_by_default ? where(trendable: [true, nil]) : where(trendable: true) }
   scope :not_trendable, -> { where(trendable: false) }
+  scope :not_featured_by, ->(account) { where.not(id: account.featured_tags.select(:tag_id)) }
   scope :recently_used, lambda { |account|
                           joins(:statuses)
                             .where(statuses: { id: account.statuses.select(:id).limit(RECENT_STATUS_LIMIT) })

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -53,6 +53,7 @@ class Tag < ApplicationRecord
   scope :listable, -> { where(listable: [true, nil]) }
   scope :trendable, -> { Setting.trendable_by_default ? where(trendable: [true, nil]) : where(trendable: true) }
   scope :not_trendable, -> { where(trendable: false) }
+  scope :suggestions_for_account, ->(account) { recently_used(account).not_featured_by(account) }
   scope :not_featured_by, ->(account) { where.not(id: account.featured_tags.select(:tag_id)) }
   scope :recently_used, lambda { |account|
                           joins(:statuses)

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -142,6 +142,25 @@ RSpec.describe Tag do
     end
   end
 
+  describe '.not_featured_by' do
+    let!(:account) { Fabricate(:account) }
+    let!(:fun) { Fabricate(:tag, name: 'fun') }
+    let!(:games) { Fabricate(:tag, name: 'games') }
+
+    before do
+      Fabricate :featured_tag, account: account, name: 'games'
+      Fabricate :featured_tag, name: 'fun'
+    end
+
+    it 'returns tags not featured by the account' do
+      results = described_class.not_featured_by(account)
+
+      expect(results)
+        .to include(fun)
+        .and not_include(games)
+    end
+  end
+
   describe '.matches_name' do
     it 'returns tags for multibyte case-insensitive names' do
       upcase_string   = 'abcABCａｂｃＡＢＣやゆよ'


### PR DESCRIPTION
A few changes here:

- Because of how FeaturedTag model sets the tag value (doing a lookup on name in a callback), setting the tag at all in the fabricator was making it hard to work with the fabricators. Setting this to nil and passing in a name works better.
- There are two controller locations which are doing the same logic of "get tags which  were used recently by this account and are not in their featured tags". They already had a scope for the first part, this adds a scope for the second part.
- I _think_ there's a bug fix in here as well -- the previous queries were doing something like "where tags.id not IN ?", but the source of that `?` was coming from the `id` of a `FeaturedTag` association. I believe it should be coming from the `tag_id` of the featured tag association? The new scope does this. If this is not correct I may be misunderstanding how this works.

Possible future refactor here: I believe these two uses are the only uses of these two scopes. Usage could be shortened to like `Tag.suggestions_for(account)` or something, which would then call these two scopes internally.