### PR TITLE
Add `Account.matches_uri_prefix` scope and use in activitypub/followers_synchronizations controller

### DIFF
--- a/app/controllers/activitypub/followers_synchronizations_controller.rb
+++ b/app/controllers/activitypub/followers_synchronizations_controller.rb
@@ -24,7 +24,7 @@ class ActivityPub::FollowersSynchronizationsController < ActivityPub::BaseContro
   end
 
   def set_items
-    @items = @account.followers.where(Account.arel_table[:uri].matches("#{Account.sanitize_sql_like(uri_prefix)}/%", false, true)).or(@account.followers.where(uri: uri_prefix)).pluck(:uri)
+    @items = @account.followers.matches_uri(uri_prefix).pluck(:uri)
   end
 
   def collection_presenter

--- a/app/controllers/activitypub/followers_synchronizations_controller.rb
+++ b/app/controllers/activitypub/followers_synchronizations_controller.rb
@@ -24,7 +24,7 @@ class ActivityPub::FollowersSynchronizationsController < ActivityPub::BaseContro
   end
 
   def set_items
-    @items = @account.followers.matches_uri(uri_prefix).pluck(:uri)
+    @items = @account.followers.matches_uri_prefix(uri_prefix).pluck(:uri)
   end
 
   def collection_presenter

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -123,7 +123,7 @@ class Account < ApplicationRecord
   scope :bots, -> { where(actor_type: %w(Application Service)) }
   scope :groups, -> { where(actor_type: 'Group') }
   scope :alphabetic, -> { order(domain: :asc, username: :asc) }
-  scope :matches_uri, ->(value) { where(arel_table[:uri].matches("#{sanitize_sql_like(value)}/%", false, true)).or(where(uri: value)) }
+  scope :matches_uri_prefix, ->(value) { where(arel_table[:uri].matches("#{sanitize_sql_like(value)}/%", false, true)).or(where(uri: value)) }
   scope :matches_username, ->(value) { where('lower((username)::text) LIKE lower(?)', "#{value}%") }
   scope :matches_display_name, ->(value) { where(arel_table[:display_name].matches("#{value}%")) }
   scope :without_unapproved, -> { left_outer_joins(:user).merge(User.approved.confirmed).or(remote) }

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -123,6 +123,7 @@ class Account < ApplicationRecord
   scope :bots, -> { where(actor_type: %w(Application Service)) }
   scope :groups, -> { where(actor_type: 'Group') }
   scope :alphabetic, -> { order(domain: :asc, username: :asc) }
+  scope :matches_uri, ->(value) { where(arel_table[:uri].matches("#{sanitize_sql_like(value)}/%", false, true)).or(where(uri: value)) }
   scope :matches_username, ->(value) { where('lower((username)::text) LIKE lower(?)', "#{value}%") }
   scope :matches_display_name, ->(value) { where(arel_table[:display_name].matches("#{value}%")) }
   scope :without_unapproved, -> { left_outer_joins(:user).merge(User.approved.confirmed).or(remote) }

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -835,6 +835,31 @@ RSpec.describe Account do
   end
 
   describe 'scopes' do
+    describe 'matches_uri' do
+      let!(:alice) { Fabricate :account, domain: 'host.example', uri: 'https://host.example/user/a' }
+      let!(:bob) { Fabricate :account, domain: 'top-level.example', uri: 'https://top-level.example' }
+
+      it 'returns accounts which start with the value' do
+        results = described_class.matches_uri('https://host.example')
+
+        expect(results.size)
+          .to eq(1)
+        expect(results)
+          .to include(alice)
+          .and not_include(bob)
+      end
+
+      it 'returns accounts which equal the value' do
+        results = described_class.matches_uri('https://top-level.example')
+
+        expect(results.size)
+          .to eq(1)
+        expect(results)
+          .to include(bob)
+          .and not_include(alice)
+      end
+    end
+
     describe 'auditable' do
       let!(:alice) { Fabricate :account }
       let!(:bob) { Fabricate :account }

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -835,12 +835,12 @@ RSpec.describe Account do
   end
 
   describe 'scopes' do
-    describe 'matches_uri' do
+    describe 'matches_uri_prefix' do
       let!(:alice) { Fabricate :account, domain: 'host.example', uri: 'https://host.example/user/a' }
       let!(:bob) { Fabricate :account, domain: 'top-level.example', uri: 'https://top-level.example' }
 
       it 'returns accounts which start with the value' do
-        results = described_class.matches_uri('https://host.example')
+        results = described_class.matches_uri_prefix('https://host.example')
 
         expect(results.size)
           .to eq(1)
@@ -850,7 +850,7 @@ RSpec.describe Account do
       end
 
       it 'returns accounts which equal the value' do
-        results = described_class.matches_uri('https://top-level.example')
+        results = described_class.matches_uri_prefix('https://top-level.example')
 
         expect(results.size)
           .to eq(1)


### PR DESCRIPTION
Before/after query looks the same...

```
irb(main):009> account.followers.where(Account.arel_table[:uri].matches("#{Account.sanitize_sql_like(uri_prefix)}/%", false, true)).or(account.followers.where(uri: uri_prefix)).p
luck(:uri)
  Account Pluck (1.0ms)  SELECT "accounts"."uri" FROM "accounts" INNER JOIN "follows" ON "accounts"."id" = "follows"."account_id" WHERE "follows"."target_account_id" = $1 AND ("accounts"."uri" LIKE 'http://test.host/%' OR "accounts"."uri" = $2) ORDER BY follows.id desc  [["target_account_id", 111783301978440596], ["uri", "http://test.host"]]
=> []
irb(main):010> account.followers.matches_uri(uri_prefix).pluck(:uri)
  Account Pluck (0.6ms)  SELECT "accounts"."uri" FROM "accounts" INNER JOIN "follows" ON "accounts"."id" = "follows"."account_id" WHERE "follows"."target_account_id" = $1 AND ("accounts"."uri" LIKE 'http://test.host/%' OR "accounts"."uri" = $2) ORDER BY follows.id desc  [["target_account_id", 111783301978440596], ["uri", "http://test.host"]]
=> []
```
