### PR TITLE
Add `API::Pagination` concern

### DIFF
--- a/app/controllers/concerns/api/pagination.rb
+++ b/app/controllers/concerns/api/pagination.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Api::Pagination
+  extend ActiveSupport::Concern
+
+  protected
+
+  def pagination_max_id
+    pagination_collection.last.id
+  end
+
+  def pagination_since_id
+    pagination_collection.first.id
+  end
+
+  def set_pagination_headers(next_path = nil, prev_path = nil)
+    links = []
+    links << [next_path, [%w(rel next)]] if next_path
+    links << [prev_path, [%w(rel prev)]] if prev_path
+    response.headers['Link'] = LinkHeader.new(links) unless links.empty?
+  end
+
+  def require_valid_pagination_options!
+    render json: { error: 'Pagination values for `offset` and `limit` must be positive' }, status: 400 if pagination_options_invalid?
+  end
+
+  private
+
+  def insert_pagination_headers
+    set_pagination_headers(next_path, prev_path)
+  end
+
+  def pagination_options_invalid?
+    params.slice(:limit, :offset).values.map(&:to_i).any?(&:negative?)
+  end
+end

--- a/app/controllers/concerns/api/pagination.rb
+++ b/app/controllers/concerns/api/pagination.rb
@@ -13,6 +13,10 @@ module Api::Pagination
     pagination_collection.first.id
   end
 
+  def insert_pagination_headers
+    set_pagination_headers(next_path, prev_path)
+  end
+
   def set_pagination_headers(next_path = nil, prev_path = nil)
     links = []
     links << [next_path, [%w(rel next)]] if next_path

--- a/app/controllers/concerns/api/pagination.rb
+++ b/app/controllers/concerns/api/pagination.rb
@@ -13,10 +13,6 @@ module Api::Pagination
     pagination_collection.first.id
   end
 
-  def insert_pagination_headers
-    set_pagination_headers(next_path, prev_path)
-  end
-
   def set_pagination_headers(next_path = nil, prev_path = nil)
     links = []
     links << [next_path, [%w(rel next)]] if next_path


### PR DESCRIPTION
Several related changes:

- Add an `API::Pagination` concern, and put the existing pagination methods from the api base controller into it
- Add an rspec matcher which wraps up the logic of comparing expected url values to the prev/next header link values, and replace previous specs with this approach -- in some cases this served to remove what was basically a double request call when the checks were in different examples
- Basically every API conrtoller that supports pagination had the same exact method definition of the `insert_pagination_headers` before_action. Move this to the newly created concern.

I think there is room for more future improvement in this area, but didn't want to go much further than this in first pass.