### PR TITLE
Move `pagination_max_id` and `pagination_since_id` into api/base controller

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -73,6 +73,14 @@ class Api::BaseController < ApplicationController
 
   protected
 
+  def pagination_max_id
+    pagination_collection.last.id
+  end
+
+  def pagination_since_id
+    pagination_collection.first.id
+  end
+
   def set_pagination_headers(next_path = nil, prev_path = nil)
     links = []
     links << [next_path, [%w(rel next)]] if next_path

--- a/app/controllers/api/v1/accounts/statuses_controller.rb
+++ b/app/controllers/api/v1/accounts/statuses_controller.rb
@@ -51,11 +51,7 @@ class Api::V1::Accounts::StatusesController < Api::BaseController
     @statuses.size == limit_param(DEFAULT_STATUSES_LIMIT)
   end
 
-  def pagination_max_id
-    @statuses.last.id
-  end
-
-  def pagination_since_id
-    @statuses.first.id
+  def pagination_collection
+    @statuses
   end
 end

--- a/app/controllers/api/v1/admin/accounts_controller.rb
+++ b/app/controllers/api/v1/admin/accounts_controller.rb
@@ -137,12 +137,8 @@ class Api::V1::Admin::AccountsController < Api::BaseController
     api_v1_admin_accounts_url(pagination_params(min_id: pagination_since_id)) unless @accounts.empty?
   end
 
-  def pagination_max_id
-    @accounts.last.id
-  end
-
-  def pagination_since_id
-    @accounts.first.id
+  def pagination_collection
+    @accounts
   end
 
   def records_continue?

--- a/app/controllers/api/v1/admin/canonical_email_blocks_controller.rb
+++ b/app/controllers/api/v1/admin/canonical_email_blocks_controller.rb
@@ -77,12 +77,8 @@ class Api::V1::Admin::CanonicalEmailBlocksController < Api::BaseController
     api_v1_admin_canonical_email_blocks_url(pagination_params(min_id: pagination_since_id)) unless @canonical_email_blocks.empty?
   end
 
-  def pagination_max_id
-    @canonical_email_blocks.last.id
-  end
-
-  def pagination_since_id
-    @canonical_email_blocks.first.id
+  def pagination_collection
+    @canonical_email_blocks
   end
 
   def records_continue?

--- a/app/controllers/api/v1/admin/domain_allows_controller.rb
+++ b/app/controllers/api/v1/admin/domain_allows_controller.rb
@@ -73,12 +73,8 @@ class Api::V1::Admin::DomainAllowsController < Api::BaseController
     api_v1_admin_domain_allows_url(pagination_params(min_id: pagination_since_id)) unless @domain_allows.empty?
   end
 
-  def pagination_max_id
-    @domain_allows.last.id
-  end
-
-  def pagination_since_id
-    @domain_allows.first.id
+  def pagination_collection
+    @domain_allows
   end
 
   def records_continue?

--- a/app/controllers/api/v1/admin/domain_blocks_controller.rb
+++ b/app/controllers/api/v1/admin/domain_blocks_controller.rb
@@ -84,12 +84,8 @@ class Api::V1::Admin::DomainBlocksController < Api::BaseController
     api_v1_admin_domain_blocks_url(pagination_params(min_id: pagination_since_id)) unless @domain_blocks.empty?
   end
 
-  def pagination_max_id
-    @domain_blocks.last.id
-  end
-
-  def pagination_since_id
-    @domain_blocks.first.id
+  def pagination_collection
+    @domain_blocks
   end
 
   def records_continue?

--- a/app/controllers/api/v1/admin/email_domain_blocks_controller.rb
+++ b/app/controllers/api/v1/admin/email_domain_blocks_controller.rb
@@ -70,12 +70,8 @@ class Api::V1::Admin::EmailDomainBlocksController < Api::BaseController
     api_v1_admin_email_domain_blocks_url(pagination_params(min_id: pagination_since_id)) unless @email_domain_blocks.empty?
   end
 
-  def pagination_max_id
-    @email_domain_blocks.last.id
-  end
-
-  def pagination_since_id
-    @email_domain_blocks.first.id
+  def pagination_collection
+    @email_domain_blocks
   end
 
   def records_continue?

--- a/app/controllers/api/v1/admin/ip_blocks_controller.rb
+++ b/app/controllers/api/v1/admin/ip_blocks_controller.rb
@@ -75,12 +75,8 @@ class Api::V1::Admin::IpBlocksController < Api::BaseController
     api_v1_admin_ip_blocks_url(pagination_params(min_id: pagination_since_id)) unless @ip_blocks.empty?
   end
 
-  def pagination_max_id
-    @ip_blocks.last.id
-  end
-
-  def pagination_since_id
-    @ip_blocks.first.id
+  def pagination_collection
+    @ip_blocks
   end
 
   def records_continue?

--- a/app/controllers/api/v1/admin/reports_controller.rb
+++ b/app/controllers/api/v1/admin/reports_controller.rb
@@ -101,12 +101,8 @@ class Api::V1::Admin::ReportsController < Api::BaseController
     api_v1_admin_reports_url(pagination_params(min_id: pagination_since_id)) unless @reports.empty?
   end
 
-  def pagination_max_id
-    @reports.last.id
-  end
-
-  def pagination_since_id
-    @reports.first.id
+  def pagination_collection
+    @reports
   end
 
   def records_continue?

--- a/app/controllers/api/v1/admin/tags_controller.rb
+++ b/app/controllers/api/v1/admin/tags_controller.rb
@@ -56,12 +56,8 @@ class Api::V1::Admin::TagsController < Api::BaseController
     api_v1_admin_tags_url(pagination_params(min_id: pagination_since_id)) unless @tags.empty?
   end
 
-  def pagination_max_id
-    @tags.last.id
-  end
-
-  def pagination_since_id
-    @tags.first.id
+  def pagination_collection
+    @tags
   end
 
   def records_continue?

--- a/app/controllers/api/v1/admin/trends/links/preview_card_providers_controller.rb
+++ b/app/controllers/api/v1/admin/trends/links/preview_card_providers_controller.rb
@@ -54,12 +54,8 @@ class Api::V1::Admin::Trends::Links::PreviewCardProvidersController < Api::BaseC
     api_v1_admin_trends_links_preview_card_providers_url(pagination_params(min_id: pagination_since_id)) unless @providers.empty?
   end
 
-  def pagination_max_id
-    @providers.last.id
-  end
-
-  def pagination_since_id
-    @providers.first.id
+  def pagination_collection
+    @providers
   end
 
   def records_continue?

--- a/app/controllers/api/v1/blocks_controller.rb
+++ b/app/controllers/api/v1/blocks_controller.rb
@@ -40,12 +40,8 @@ class Api::V1::BlocksController < Api::BaseController
     api_v1_blocks_url pagination_params(since_id: pagination_since_id) unless paginated_blocks.empty?
   end
 
-  def pagination_max_id
-    paginated_blocks.last.id
-  end
-
-  def pagination_since_id
-    paginated_blocks.first.id
+  def pagination_collection
+    paginated_blocks
   end
 
   def records_continue?

--- a/app/controllers/api/v1/bookmarks_controller.rb
+++ b/app/controllers/api/v1/bookmarks_controller.rb
@@ -43,12 +43,8 @@ class Api::V1::BookmarksController < Api::BaseController
     api_v1_bookmarks_url pagination_params(min_id: pagination_since_id) unless results.empty?
   end
 
-  def pagination_max_id
-    results.last.id
-  end
-
-  def pagination_since_id
-    results.first.id
+  def pagination_collection
+    results
   end
 
   def records_continue?

--- a/app/controllers/api/v1/crypto/encrypted_messages_controller.rb
+++ b/app/controllers/api/v1/crypto/encrypted_messages_controller.rb
@@ -41,12 +41,8 @@ class Api::V1::Crypto::EncryptedMessagesController < Api::BaseController
     api_v1_crypto_encrypted_messages_url pagination_params(min_id: pagination_since_id) unless @encrypted_messages.empty?
   end
 
-  def pagination_max_id
-    @encrypted_messages.last.id
-  end
-
-  def pagination_since_id
-    @encrypted_messages.first.id
+  def pagination_collection
+    @encrypted_messages
   end
 
   def records_continue?

--- a/app/controllers/api/v1/domain_blocks_controller.rb
+++ b/app/controllers/api/v1/domain_blocks_controller.rb
@@ -50,12 +50,8 @@ class Api::V1::DomainBlocksController < Api::BaseController
     api_v1_domain_blocks_url pagination_params(since_id: pagination_since_id) unless @blocks.empty?
   end
 
-  def pagination_max_id
-    @blocks.last.id
-  end
-
-  def pagination_since_id
-    @blocks.first.id
+  def pagination_collection
+    @blocks
   end
 
   def records_continue?

--- a/app/controllers/api/v1/endorsements_controller.rb
+++ b/app/controllers/api/v1/endorsements_controller.rb
@@ -44,12 +44,8 @@ class Api::V1::EndorsementsController < Api::BaseController
     api_v1_endorsements_url pagination_params(since_id: pagination_since_id) unless @accounts.empty?
   end
 
-  def pagination_max_id
-    @accounts.last.id
-  end
-
-  def pagination_since_id
-    @accounts.first.id
+  def pagination_collection
+    @accounts
   end
 
   def records_continue?

--- a/app/controllers/api/v1/favourites_controller.rb
+++ b/app/controllers/api/v1/favourites_controller.rb
@@ -43,12 +43,8 @@ class Api::V1::FavouritesController < Api::BaseController
     api_v1_favourites_url pagination_params(min_id: pagination_since_id) unless results.empty?
   end
 
-  def pagination_max_id
-    results.last.id
-  end
-
-  def pagination_since_id
-    results.first.id
+  def pagination_collection
+    results
   end
 
   def records_continue?

--- a/app/controllers/api/v1/followed_tags_controller.rb
+++ b/app/controllers/api/v1/followed_tags_controller.rb
@@ -34,12 +34,8 @@ class Api::V1::FollowedTagsController < Api::BaseController
     api_v1_followed_tags_url pagination_params(since_id: pagination_since_id) unless @results.empty?
   end
 
-  def pagination_max_id
-    @results.last.id
-  end
-
-  def pagination_since_id
-    @results.first.id
+  def pagination_collection
+    @results
   end
 
   def records_continue?

--- a/app/controllers/api/v1/lists/accounts_controller.rb
+++ b/app/controllers/api/v1/lists/accounts_controller.rb
@@ -71,12 +71,8 @@ class Api::V1::Lists::AccountsController < Api::BaseController
     api_v1_list_accounts_url pagination_params(since_id: pagination_since_id) unless @accounts.empty?
   end
 
-  def pagination_max_id
-    @accounts.last.id
-  end
-
-  def pagination_since_id
-    @accounts.first.id
+  def pagination_collection
+    @accounts
   end
 
   def records_continue?

--- a/app/controllers/api/v1/mutes_controller.rb
+++ b/app/controllers/api/v1/mutes_controller.rb
@@ -40,12 +40,8 @@ class Api::V1::MutesController < Api::BaseController
     api_v1_mutes_url pagination_params(since_id: pagination_since_id) unless paginated_mutes.empty?
   end
 
-  def pagination_max_id
-    paginated_mutes.last.id
-  end
-
-  def pagination_since_id
-    paginated_mutes.first.id
+  def pagination_collection
+    paginated_mutes
   end
 
   def records_continue?

--- a/app/controllers/api/v1/notifications_controller.rb
+++ b/app/controllers/api/v1/notifications_controller.rb
@@ -70,12 +70,8 @@ class Api::V1::NotificationsController < Api::BaseController
     api_v1_notifications_url pagination_params(min_id: pagination_since_id) unless @notifications.empty?
   end
 
-  def pagination_max_id
-    @notifications.last.id
-  end
-
-  def pagination_since_id
-    @notifications.first.id
+  def pagination_collection
+    @notifications
   end
 
   def browserable_params

--- a/app/controllers/api/v1/scheduled_statuses_controller.rb
+++ b/app/controllers/api/v1/scheduled_statuses_controller.rb
@@ -63,11 +63,7 @@ class Api::V1::ScheduledStatusesController < Api::BaseController
     @statuses.size == limit_param(DEFAULT_STATUSES_LIMIT)
   end
 
-  def pagination_max_id
-    @statuses.last.id
-  end
-
-  def pagination_since_id
-    @statuses.first.id
+  def pagination_collection
+    @statuses
   end
 end

--- a/app/controllers/api/v1/timelines/base_controller.rb
+++ b/app/controllers/api/v1/timelines/base_controller.rb
@@ -9,12 +9,8 @@ class Api::V1::Timelines::BaseController < Api::BaseController
     set_pagination_headers(next_path, prev_path)
   end
 
-  def pagination_max_id
-    @statuses.last.id
-  end
-
-  def pagination_since_id
-    @statuses.first.id
+  def pagination_collection
+    @statuses
   end
 
   def next_path_params


### PR DESCRIPTION
Many controllers have these methods and do the same exact thing -- whatever collection they are operating on they just call `.last.id` (for `_max_id` version) and `.first.id` (for `_min_id` version). This pulls those simple versions out to base class, and each controller defines what their pagination collection is.

There are some controllers which have these methods but are doing something different to arrive at values (typically going through another collection first) which I left in place to override this base version. Those might be good for future refactor but this pass is just the really straightforward ones.

This would be fine on it's own as-is right now -- but if https://github.com/mastodon/mastodon/pull/28826 merges first, this should be rebased and the methods added to base controller here should be moved to the pagination concern added in that one.