### PR TITLE
Move `pagination_params` into `API::BaseController`

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -4,8 +4,6 @@ class Api::BaseController < ApplicationController
   DEFAULT_STATUSES_LIMIT = 20
   DEFAULT_ACCOUNTS_LIMIT = 40
 
-  PAGINATION_PARAMS = %i(limit).freeze
-
   include Api::RateLimitHeaders
   include Api::AccessTokenTrackingConcern
   include Api::CachingConcern
@@ -36,13 +34,6 @@ class Api::BaseController < ApplicationController
     return default_limit unless params[:limit]
 
     [params[:limit].to_i.abs, default_limit * 2].min
-  end
-
-  def pagination_params(core_params)
-    params
-      .slice(*PAGINATION_PARAMS)
-      .permit(*PAGINATION_PARAMS)
-      .merge(core_params)
   end
 
   def params_slice(*keys)

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -4,6 +4,8 @@ class Api::BaseController < ApplicationController
   DEFAULT_STATUSES_LIMIT = 20
   DEFAULT_ACCOUNTS_LIMIT = 40
 
+  PAGINATION_PARAMS = %i(limit).freeze
+
   include Api::RateLimitHeaders
   include Api::AccessTokenTrackingConcern
   include Api::CachingConcern
@@ -34,6 +36,13 @@ class Api::BaseController < ApplicationController
     return default_limit unless params[:limit]
 
     [params[:limit].to_i.abs, default_limit * 2].min
+  end
+
+  def pagination_params(core_params)
+    params
+      .slice(*PAGINATION_PARAMS)
+      .permit(*PAGINATION_PARAMS)
+      .merge(core_params)
   end
 
   def params_slice(*keys)

--- a/app/controllers/api/v1/accounts/follower_accounts_controller.rb
+++ b/app/controllers/api/v1/accounts/follower_accounts_controller.rb
@@ -60,8 +60,4 @@ class Api::V1::Accounts::FollowerAccountsController < Api::BaseController
   def records_continue?
     @accounts.size == limit_param(DEFAULT_ACCOUNTS_LIMIT)
   end
-
-  def pagination_params(core_params)
-    params.slice(:limit).permit(:limit).merge(core_params)
-  end
 end

--- a/app/controllers/api/v1/accounts/following_accounts_controller.rb
+++ b/app/controllers/api/v1/accounts/following_accounts_controller.rb
@@ -60,8 +60,4 @@ class Api::V1::Accounts::FollowingAccountsController < Api::BaseController
   def records_continue?
     @accounts.size == limit_param(DEFAULT_ACCOUNTS_LIMIT)
   end
-
-  def pagination_params(core_params)
-    params.slice(:limit).permit(:limit).merge(core_params)
-  end
 end

--- a/app/controllers/api/v1/admin/canonical_email_blocks_controller.rb
+++ b/app/controllers/api/v1/admin/canonical_email_blocks_controller.rb
@@ -16,8 +16,6 @@ class Api::V1::Admin::CanonicalEmailBlocksController < Api::BaseController
   after_action :verify_authorized
   after_action :insert_pagination_headers, only: :index
 
-  PAGINATION_PARAMS = %i(limit).freeze
-
   def index
     authorize :canonical_email_block, :index?
     render json: @canonical_email_blocks, each_serializer: REST::Admin::CanonicalEmailBlockSerializer
@@ -79,9 +77,5 @@ class Api::V1::Admin::CanonicalEmailBlocksController < Api::BaseController
 
   def records_continue?
     @canonical_email_blocks.size == limit_param(LIMIT)
-  end
-
-  def pagination_params(core_params)
-    params.slice(*PAGINATION_PARAMS).permit(*PAGINATION_PARAMS).merge(core_params)
   end
 end

--- a/app/controllers/api/v1/admin/domain_allows_controller.rb
+++ b/app/controllers/api/v1/admin/domain_allows_controller.rb
@@ -14,8 +14,6 @@ class Api::V1::Admin::DomainAllowsController < Api::BaseController
   after_action :verify_authorized
   after_action :insert_pagination_headers, only: :index
 
-  PAGINATION_PARAMS = %i(limit).freeze
-
   def index
     authorize :domain_allow, :index?
     render json: @domain_allows, each_serializer: REST::Admin::DomainAllowSerializer
@@ -75,10 +73,6 @@ class Api::V1::Admin::DomainAllowsController < Api::BaseController
 
   def records_continue?
     @domain_allows.size == limit_param(LIMIT)
-  end
-
-  def pagination_params(core_params)
-    params.slice(*PAGINATION_PARAMS).permit(*PAGINATION_PARAMS).merge(core_params)
   end
 
   def resource_params

--- a/app/controllers/api/v1/admin/domain_blocks_controller.rb
+++ b/app/controllers/api/v1/admin/domain_blocks_controller.rb
@@ -14,8 +14,6 @@ class Api::V1::Admin::DomainBlocksController < Api::BaseController
   after_action :verify_authorized
   after_action :insert_pagination_headers, only: :index
 
-  PAGINATION_PARAMS = %i(limit).freeze
-
   def index
     authorize :domain_block, :index?
     render json: @domain_blocks, each_serializer: REST::Admin::DomainBlockSerializer
@@ -91,10 +89,6 @@ class Api::V1::Admin::DomainBlocksController < Api::BaseController
 
   def records_continue?
     @domain_blocks.size == limit_param(LIMIT)
-  end
-
-  def pagination_params(core_params)
-    params.slice(*PAGINATION_PARAMS).permit(*PAGINATION_PARAMS).merge(core_params)
   end
 
   def resource_params

--- a/app/controllers/api/v1/admin/email_domain_blocks_controller.rb
+++ b/app/controllers/api/v1/admin/email_domain_blocks_controller.rb
@@ -14,10 +14,6 @@ class Api::V1::Admin::EmailDomainBlocksController < Api::BaseController
   after_action :verify_authorized
   after_action :insert_pagination_headers, only: :index
 
-  PAGINATION_PARAMS = %i(
-    limit
-  ).freeze
-
   def index
     authorize :email_domain_block, :index?
     render json: @email_domain_blocks, each_serializer: REST::Admin::EmailDomainBlockSerializer
@@ -72,9 +68,5 @@ class Api::V1::Admin::EmailDomainBlocksController < Api::BaseController
 
   def records_continue?
     @email_domain_blocks.size == limit_param(LIMIT)
-  end
-
-  def pagination_params(core_params)
-    params.slice(*PAGINATION_PARAMS).permit(*PAGINATION_PARAMS).merge(core_params)
   end
 end

--- a/app/controllers/api/v1/admin/ip_blocks_controller.rb
+++ b/app/controllers/api/v1/admin/ip_blocks_controller.rb
@@ -14,10 +14,6 @@ class Api::V1::Admin::IpBlocksController < Api::BaseController
   after_action :verify_authorized
   after_action :insert_pagination_headers, only: :index
 
-  PAGINATION_PARAMS = %i(
-    limit
-  ).freeze
-
   def index
     authorize :ip_block, :index?
     render json: @ip_blocks, each_serializer: REST::Admin::IpBlockSerializer
@@ -77,9 +73,5 @@ class Api::V1::Admin::IpBlocksController < Api::BaseController
 
   def records_continue?
     @ip_blocks.size == limit_param(LIMIT)
-  end
-
-  def pagination_params(core_params)
-    params.slice(*PAGINATION_PARAMS).permit(*PAGINATION_PARAMS).merge(core_params)
   end
 end

--- a/app/controllers/api/v1/admin/tags_controller.rb
+++ b/app/controllers/api/v1/admin/tags_controller.rb
@@ -12,7 +12,6 @@ class Api::V1::Admin::TagsController < Api::BaseController
   after_action :verify_authorized
 
   LIMIT = 100
-  PAGINATION_PARAMS = %i(limit).freeze
 
   def index
     authorize :tag, :index?
@@ -58,9 +57,5 @@ class Api::V1::Admin::TagsController < Api::BaseController
 
   def records_continue?
     @tags.size == limit_param(LIMIT)
-  end
-
-  def pagination_params(core_params)
-    params.slice(*PAGINATION_PARAMS).permit(*PAGINATION_PARAMS).merge(core_params)
   end
 end

--- a/app/controllers/api/v1/admin/trends/links/preview_card_providers_controller.rb
+++ b/app/controllers/api/v1/admin/trends/links/preview_card_providers_controller.rb
@@ -12,8 +12,6 @@ class Api::V1::Admin::Trends::Links::PreviewCardProvidersController < Api::BaseC
   after_action :verify_authorized
   after_action :insert_pagination_headers, only: :index
 
-  PAGINATION_PARAMS = %i(limit).freeze
-
   def index
     authorize :preview_card_provider, :index?
 
@@ -56,9 +54,5 @@ class Api::V1::Admin::Trends::Links::PreviewCardProvidersController < Api::BaseC
 
   def records_continue?
     @providers.size == limit_param(LIMIT)
-  end
-
-  def pagination_params(core_params)
-    params.slice(*PAGINATION_PARAMS).permit(*PAGINATION_PARAMS).merge(core_params)
   end
 end

--- a/app/controllers/api/v1/blocks_controller.rb
+++ b/app/controllers/api/v1/blocks_controller.rb
@@ -43,8 +43,4 @@ class Api::V1::BlocksController < Api::BaseController
   def records_continue?
     paginated_blocks.size == limit_param(DEFAULT_ACCOUNTS_LIMIT)
   end
-
-  def pagination_params(core_params)
-    params.slice(:limit).permit(:limit).merge(core_params)
-  end
 end

--- a/app/controllers/api/v1/bookmarks_controller.rb
+++ b/app/controllers/api/v1/bookmarks_controller.rb
@@ -46,8 +46,4 @@ class Api::V1::BookmarksController < Api::BaseController
   def records_continue?
     results.size == limit_param(DEFAULT_STATUSES_LIMIT)
   end
-
-  def pagination_params(core_params)
-    params.slice(:limit).permit(:limit).merge(core_params)
-  end
 end

--- a/app/controllers/api/v1/conversations_controller.rb
+++ b/app/controllers/api/v1/conversations_controller.rb
@@ -72,8 +72,4 @@ class Api::V1::ConversationsController < Api::BaseController
   def records_continue?
     @conversations.size == limit_param(LIMIT)
   end
-
-  def pagination_params(core_params)
-    params.slice(:limit).permit(:limit).merge(core_params)
-  end
 end

--- a/app/controllers/api/v1/crypto/encrypted_messages_controller.rb
+++ b/app/controllers/api/v1/crypto/encrypted_messages_controller.rb
@@ -44,8 +44,4 @@ class Api::V1::Crypto::EncryptedMessagesController < Api::BaseController
   def records_continue?
     @encrypted_messages.size == limit_param(LIMIT)
   end
-
-  def pagination_params(core_params)
-    params.slice(:limit).permit(:limit).merge(core_params)
-  end
 end

--- a/app/controllers/api/v1/domain_blocks_controller.rb
+++ b/app/controllers/api/v1/domain_blocks_controller.rb
@@ -54,10 +54,6 @@ class Api::V1::DomainBlocksController < Api::BaseController
     @blocks.size == limit_param(BLOCK_LIMIT)
   end
 
-  def pagination_params(core_params)
-    params.slice(:limit).permit(:limit).merge(core_params)
-  end
-
   def domain_block_params
     params.permit(:domain)
   end

--- a/app/controllers/api/v1/endorsements_controller.rb
+++ b/app/controllers/api/v1/endorsements_controller.rb
@@ -48,10 +48,6 @@ class Api::V1::EndorsementsController < Api::BaseController
     @accounts.size == limit_param(DEFAULT_ACCOUNTS_LIMIT)
   end
 
-  def pagination_params(core_params)
-    params.slice(:limit).permit(:limit).merge(core_params)
-  end
-
   def unlimited?
     params[:limit] == '0'
   end

--- a/app/controllers/api/v1/favourites_controller.rb
+++ b/app/controllers/api/v1/favourites_controller.rb
@@ -46,8 +46,4 @@ class Api::V1::FavouritesController < Api::BaseController
   def records_continue?
     results.size == limit_param(DEFAULT_STATUSES_LIMIT)
   end
-
-  def pagination_params(core_params)
-    params.slice(:limit).permit(:limit).merge(core_params)
-  end
 end

--- a/app/controllers/api/v1/follow_requests_controller.rb
+++ b/app/controllers/api/v1/follow_requests_controller.rb
@@ -67,8 +67,4 @@ class Api::V1::FollowRequestsController < Api::BaseController
   def records_continue?
     @accounts.size == limit_param(DEFAULT_ACCOUNTS_LIMIT)
   end
-
-  def pagination_params(core_params)
-    params.slice(:limit).permit(:limit).merge(core_params)
-  end
 end

--- a/app/controllers/api/v1/followed_tags_controller.rb
+++ b/app/controllers/api/v1/followed_tags_controller.rb
@@ -37,8 +37,4 @@ class Api::V1::FollowedTagsController < Api::BaseController
   def records_continue?
     @results.size == limit_param(TAGS_LIMIT)
   end
-
-  def pagination_params(core_params)
-    params.slice(:limit).permit(:limit).merge(core_params)
-  end
 end

--- a/app/controllers/api/v1/lists/accounts_controller.rb
+++ b/app/controllers/api/v1/lists/accounts_controller.rb
@@ -75,10 +75,6 @@ class Api::V1::Lists::AccountsController < Api::BaseController
     @accounts.size == limit_param(DEFAULT_ACCOUNTS_LIMIT)
   end
 
-  def pagination_params(core_params)
-    params.slice(:limit).permit(:limit).merge(core_params)
-  end
-
   def unlimited?
     params[:limit] == '0'
   end

--- a/app/controllers/api/v1/mutes_controller.rb
+++ b/app/controllers/api/v1/mutes_controller.rb
@@ -43,8 +43,4 @@ class Api::V1::MutesController < Api::BaseController
   def records_continue?
     paginated_mutes.size == limit_param(DEFAULT_ACCOUNTS_LIMIT)
   end
-
-  def pagination_params(core_params)
-    params.slice(:limit).permit(:limit).merge(core_params)
-  end
 end

--- a/app/controllers/api/v1/scheduled_statuses_controller.rb
+++ b/app/controllers/api/v1/scheduled_statuses_controller.rb
@@ -43,10 +43,6 @@ class Api::V1::ScheduledStatusesController < Api::BaseController
     params.permit(:scheduled_at)
   end
 
-  def pagination_params(core_params)
-    params.slice(:limit).permit(:limit).merge(core_params)
-  end
-
   def next_path
     api_v1_scheduled_statuses_url pagination_params(max_id: pagination_max_id) if records_continue?
   end

--- a/app/controllers/api/v1/statuses/favourited_by_accounts_controller.rb
+++ b/app/controllers/api/v1/statuses/favourited_by_accounts_controller.rb
@@ -53,8 +53,4 @@ class Api::V1::Statuses::FavouritedByAccountsController < Api::V1::Statuses::Bas
   def records_continue?
     @accounts.size == limit_param(DEFAULT_ACCOUNTS_LIMIT)
   end
-
-  def pagination_params(core_params)
-    params.slice(:limit).permit(:limit).merge(core_params)
-  end
 end

--- a/app/controllers/api/v1/statuses/reblogged_by_accounts_controller.rb
+++ b/app/controllers/api/v1/statuses/reblogged_by_accounts_controller.rb
@@ -49,8 +49,4 @@ class Api::V1::Statuses::RebloggedByAccountsController < Api::V1::Statuses::Base
   def records_continue?
     @accounts.size == limit_param(DEFAULT_ACCOUNTS_LIMIT)
   end
-
-  def pagination_params(core_params)
-    params.slice(:limit).permit(:limit).merge(core_params)
-  end
 end

--- a/app/controllers/api/v1/statuses_controller.rb
+++ b/app/controllers/api/v1/statuses_controller.rb
@@ -188,8 +188,4 @@ class Api::V1::StatusesController < Api::BaseController
   def serialized_accounts(accounts)
     ActiveModel::Serializer::CollectionSerializer.new(accounts, serializer: REST::AccountSerializer)
   end
-
-  def pagination_params(core_params)
-    params.slice(:limit).permit(:limit).merge(core_params)
-  end
 end

--- a/app/controllers/api/v1/trends/links_controller.rb
+++ b/app/controllers/api/v1/trends/links_controller.rb
@@ -34,10 +34,6 @@ class Api::V1::Trends::LinksController < Api::BaseController
     scope
   end
 
-  def pagination_params(core_params)
-    params.slice(:limit).permit(:limit).merge(core_params)
-  end
-
   def next_path
     api_v1_trends_links_url pagination_params(offset: offset_param + limit_param(DEFAULT_LINKS_LIMIT)) if records_continue?
   end

--- a/app/controllers/api/v1/trends/statuses_controller.rb
+++ b/app/controllers/api/v1/trends/statuses_controller.rb
@@ -32,10 +32,6 @@ class Api::V1::Trends::StatusesController < Api::BaseController
     scope
   end
 
-  def pagination_params(core_params)
-    params.slice(:limit).permit(:limit).merge(core_params)
-  end
-
   def next_path
     api_v1_trends_statuses_url pagination_params(offset: offset_param + limit_param(DEFAULT_STATUSES_LIMIT)) if records_continue?
   end

--- a/app/controllers/api/v1/trends/tags_controller.rb
+++ b/app/controllers/api/v1/trends/tags_controller.rb
@@ -30,10 +30,6 @@ class Api::V1::Trends::TagsController < Api::BaseController
     Trends.tags.query.allowed
   end
 
-  def pagination_params(core_params)
-    params.slice(:limit).permit(:limit).merge(core_params)
-  end
-
   def next_path
     api_v1_trends_tags_url pagination_params(offset: offset_param + limit_param(DEFAULT_TAGS_LIMIT)) if records_continue?
   end

--- a/app/controllers/concerns/api/pagination.rb
+++ b/app/controllers/concerns/api/pagination.rb
@@ -3,6 +3,8 @@
 module Api::Pagination
   extend ActiveSupport::Concern
 
+  PAGINATION_PARAMS = %i(limit).freeze
+
   protected
 
   def pagination_max_id
@@ -22,6 +24,13 @@ module Api::Pagination
 
   def require_valid_pagination_options!
     render json: { error: 'Pagination values for `offset` and `limit` must be positive' }, status: 400 if pagination_options_invalid?
+  end
+
+  def pagination_params(core_params)
+    params
+      .slice(*PAGINATION_PARAMS)
+      .permit(*PAGINATION_PARAMS)
+      .merge(core_params)
   end
 
   private


### PR DESCRIPTION
Many controllers have this method and are just passing the same argument, `:limit`, either directly in the method, or indirectly via a defined constant. This pulls that default case out to the base controller class.

There are some controllers which have this method but have something different enough about it (typically merging other params first) that it was not an obvious extraction in this first pass. May revisit those.

This would be fine on it's own as-is right now -- but if https://github.com/mastodon/mastodon/pull/28826 merges first, this should be rebased and the methods added to base controller here should be moved to the pagination concern added in that one.