### PR TITLE
Eager loading fixes for `api/` controllers

### DIFF
--- a/app/controllers/api/v1/accounts/follower_accounts_controller.rb
+++ b/app/controllers/api/v1/accounts/follower_accounts_controller.rb
@@ -22,7 +22,7 @@ class Api::V1::Accounts::FollowerAccountsController < Api::BaseController
 
     scope = default_accounts
     scope = scope.not_excluded_by_account(current_account) unless current_account.nil? || current_account.id == @account.id
-    scope.merge(paginated_follows).includes(:user).to_a
+    scope.merge(paginated_follows).to_a
   end
 
   def hide_results?
@@ -30,7 +30,7 @@ class Api::V1::Accounts::FollowerAccountsController < Api::BaseController
   end
 
   def default_accounts
-    Account.includes(:active_relationships, :account_stat).references(:active_relationships)
+    Account.includes(:active_relationships, :account_stat, :user).references(:active_relationships)
   end
 
   def paginated_follows

--- a/app/controllers/api/v1/accounts/follower_accounts_controller.rb
+++ b/app/controllers/api/v1/accounts/follower_accounts_controller.rb
@@ -22,7 +22,7 @@ class Api::V1::Accounts::FollowerAccountsController < Api::BaseController
 
     scope = default_accounts
     scope = scope.not_excluded_by_account(current_account) unless current_account.nil? || current_account.id == @account.id
-    scope.merge(paginated_follows).to_a
+    scope.merge(paginated_follows).includes(:user).to_a
   end
 
   def hide_results?

--- a/app/controllers/api/v1/accounts/following_accounts_controller.rb
+++ b/app/controllers/api/v1/accounts/following_accounts_controller.rb
@@ -22,7 +22,7 @@ class Api::V1::Accounts::FollowingAccountsController < Api::BaseController
 
     scope = default_accounts
     scope = scope.not_excluded_by_account(current_account) unless current_account.nil? || current_account.id == @account.id
-    scope.merge(paginated_follows).to_a
+    scope.merge(paginated_follows).includes(:user).to_a
   end
 
   def hide_results?

--- a/app/controllers/api/v1/accounts/following_accounts_controller.rb
+++ b/app/controllers/api/v1/accounts/following_accounts_controller.rb
@@ -22,7 +22,7 @@ class Api::V1::Accounts::FollowingAccountsController < Api::BaseController
 
     scope = default_accounts
     scope = scope.not_excluded_by_account(current_account) unless current_account.nil? || current_account.id == @account.id
-    scope.merge(paginated_follows).includes(:user).to_a
+    scope.merge(paginated_follows).to_a
   end
 
   def hide_results?
@@ -30,7 +30,7 @@ class Api::V1::Accounts::FollowingAccountsController < Api::BaseController
   end
 
   def default_accounts
-    Account.includes(:passive_relationships, :account_stat).references(:passive_relationships)
+    Account.includes(:passive_relationships, :account_stat, :user).references(:passive_relationships)
   end
 
   def paginated_follows

--- a/app/controllers/api/v1/blocks_controller.rb
+++ b/app/controllers/api/v1/blocks_controller.rb
@@ -17,7 +17,7 @@ class Api::V1::BlocksController < Api::BaseController
   end
 
   def paginated_blocks
-    @paginated_blocks ||= Block.eager_load(target_account: :account_stat)
+    @paginated_blocks ||= Block.eager_load(target_account: [:account_stat, :user])
                                .joins(:target_account)
                                .merge(Account.without_suspended)
                                .where(account: current_account)

--- a/app/controllers/api/v1/directories_controller.rb
+++ b/app/controllers/api/v1/directories_controller.rb
@@ -27,7 +27,7 @@ class Api::V1::DirectoriesController < Api::BaseController
       scope.merge!(local_account_scope) if local_accounts?
       scope.merge!(account_exclusion_scope) if current_account
       scope.merge!(account_domain_block_scope) if current_account && !local_accounts?
-    end
+    end.includes(:account_stat, user: :role)
   end
 
   def local_accounts?

--- a/app/controllers/api/v1/endorsements_controller.rb
+++ b/app/controllers/api/v1/endorsements_controller.rb
@@ -25,7 +25,7 @@ class Api::V1::EndorsementsController < Api::BaseController
   end
 
   def endorsed_accounts
-    current_account.endorsed_accounts.includes(:account_stat).without_suspended
+    current_account.endorsed_accounts.includes(:account_stat, :user).without_suspended
   end
 
   def insert_pagination_headers

--- a/app/controllers/api/v1/follow_requests_controller.rb
+++ b/app/controllers/api/v1/follow_requests_controller.rb
@@ -37,7 +37,7 @@ class Api::V1::FollowRequestsController < Api::BaseController
   end
 
   def default_accounts
-    Account.without_suspended.includes(:follow_requests, :account_stat).references(:follow_requests)
+    Account.without_suspended.includes(:follow_requests, :account_stat, :user).references(:follow_requests)
   end
 
   def paginated_follow_requests

--- a/app/controllers/api/v1/lists/accounts_controller.rb
+++ b/app/controllers/api/v1/lists/accounts_controller.rb
@@ -37,9 +37,9 @@ class Api::V1::Lists::AccountsController < Api::BaseController
 
   def load_accounts
     if unlimited?
-      @list.accounts.without_suspended.includes(:account_stat).all
+      @list.accounts.without_suspended.includes(:account_stat, :user).all
     else
-      @list.accounts.without_suspended.includes(:account_stat).paginate_by_max_id(limit_param(DEFAULT_ACCOUNTS_LIMIT), params[:max_id], params[:since_id])
+      @list.accounts.without_suspended.includes(:account_stat, :user).paginate_by_max_id(limit_param(DEFAULT_ACCOUNTS_LIMIT), params[:max_id], params[:since_id])
     end
   end
 

--- a/app/controllers/api/v1/mutes_controller.rb
+++ b/app/controllers/api/v1/mutes_controller.rb
@@ -17,7 +17,7 @@ class Api::V1::MutesController < Api::BaseController
   end
 
   def paginated_mutes
-    @paginated_mutes ||= Mute.eager_load(:target_account)
+    @paginated_mutes ||= Mute.eager_load(target_account: [:account_stat, :user])
                              .joins(:target_account)
                              .merge(Account.without_suspended)
                              .where(account: current_account)

--- a/app/controllers/api/v1/statuses/favourited_by_accounts_controller.rb
+++ b/app/controllers/api/v1/statuses/favourited_by_accounts_controller.rb
@@ -21,7 +21,7 @@ class Api::V1::Statuses::FavouritedByAccountsController < Api::V1::Statuses::Bas
   def default_accounts
     Account
       .without_suspended
-      .includes(:favourites, :account_stat)
+      .includes(:favourites, :account_stat, :user)
       .references(:favourites)
       .where(favourites: { status_id: @status.id })
   end

--- a/app/controllers/api/v1/statuses/reblogged_by_accounts_controller.rb
+++ b/app/controllers/api/v1/statuses/reblogged_by_accounts_controller.rb
@@ -19,7 +19,7 @@ class Api::V1::Statuses::RebloggedByAccountsController < Api::V1::Statuses::Base
   end
 
   def default_accounts
-    Account.without_suspended.includes(:statuses, :account_stat).references(:statuses)
+    Account.without_suspended.includes(:statuses, :account_stat, :user).references(:statuses)
   end
 
   def paginated_statuses

--- a/app/controllers/api/v2/filters_controller.rb
+++ b/app/controllers/api/v2/filters_controller.rb
@@ -35,7 +35,7 @@ class Api::V2::FiltersController < Api::BaseController
   private
 
   def set_filters
-    @filters = current_account.custom_filters.includes(:keywords)
+    @filters = current_account.custom_filters.includes(:keywords, :statuses)
   end
 
   def set_filter

--- a/app/models/account_suggestions.rb
+++ b/app/models/account_suggestions.rb
@@ -29,7 +29,7 @@ class AccountSuggestions
       # a complicated query on this end.
 
       account_ids  = account_ids_with_sources[offset, limit]
-      accounts_map = Account.where(id: account_ids.map(&:first)).includes(:account_stat).index_by(&:id)
+      accounts_map = Account.where(id: account_ids.map(&:first)).includes(:account_stat, :user).index_by(&:id)
 
       account_ids.filter_map do |(account_id, source)|
         next unless accounts_map.key?(account_id)

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -41,7 +41,7 @@ class Report < ApplicationRecord
 
   scope :unresolved, -> { where(action_taken_at: nil) }
   scope :resolved,   -> { where.not(action_taken_at: nil) }
-  scope :with_accounts, -> { includes([:account, :target_account, :action_taken_by_account, :assigned_account].index_with({ user: [:invite_request, :invite] })) }
+  scope :with_accounts, -> { includes([:account, :target_account, :action_taken_by_account, :assigned_account].index_with([:account_stat, { user: [:invite_request, :invite, :ips] }])) }
 
   # A report is considered local if the reporter is local
   delegate :local?, to: :account


### PR DESCRIPTION
The vast majority of these are from records using the REST account serializer and not having account_stat and/or user loaded yet. The others are along those same lines for other serializers.

I have a local branch which adds the `bullet` gem and raises on issues like these in test mode. Opening a few of these ahead of time so that the PR to add the gem is just the gem w/out related failures or changes at same time.