### PR TITLE
Simplify `AccountSummary.filtered` query generation

### DIFF
--- a/app/models/account_summary.rb
+++ b/app/models/account_summary.rb
@@ -12,9 +12,11 @@
 class AccountSummary < ApplicationRecord
   self.primary_key = :account_id
 
+  has_many :follow_recommendation_suppressions, primary_key: :account_id, foreign_key: :account_id, inverse_of: false
+
   scope :safe, -> { where(sensitive: false) }
   scope :localized, ->(locale) { where(language: locale) }
-  scope :filtered, -> { joins(arel_table.join(FollowRecommendationSuppression.arel_table, Arel::Nodes::OuterJoin).on(arel_table[:account_id].eq(FollowRecommendationSuppression.arel_table[:account_id])).join_sources).where(FollowRecommendationSuppression.arel_table[:id].eq(nil)) }
+  scope :filtered, -> { where.missing(:follow_recommendation_suppressions) }
 
   def self.refresh
     Scenic.database.refresh_materialized_view(table_name, concurrently: false, cascade: false)


### PR DESCRIPTION
The previous (replaced here) series of arel joins was creating the same connection as this association.

Before/after sql from console...

```
irb(main):016> AccountSummary.filtered
  AccountSummary Load (0.4ms)  SELECT "account_summaries".* FROM "account_summaries" LEFT OUTER JOIN "follow_recommendation_suppressions" ON "account_summaries"."account_id" = "follow_recommendation_suppressions"."account_id" WHERE "follow_recommendation_suppressions"."id" IS NULL /* loading for pp */ LIMIT $1  [["LIMIT", 11]]
=> [#<AccountSummary:0x0000000126093d60 account_id: 111806206616699553, language: nil, sensitive: false>]
irb(main):017> AccountSummary.where.missing(:follow_recommendation_suppressions)
  AccountSummary Load (0.5ms)  SELECT "account_summaries".* FROM "account_summaries" LEFT OUTER JOIN "follow_recommendation_suppressions" ON "follow_recommendation_suppressions"."account_id" = "account_summaries"."account_id" WHERE "follow_recommendation_suppressions"."id" IS NULL /* loading for pp */ LIMIT $1  [["LIMIT", 11]]
=> [#<AccountSummary:0x0000000127f73988 account_id: 111806206616699553, language: nil, sensitive: false>]
```