### PR TITLE
Tidy up association declaration in `Instance` model

### DIFF
--- a/app/models/instance.rb
+++ b/app/models/instance.rb
@@ -13,12 +13,12 @@ class Instance < ApplicationRecord
 
   attr_accessor :failure_days
 
-  has_many :accounts, foreign_key: :domain, primary_key: :domain, inverse_of: false
-
   with_options foreign_key: :domain, primary_key: :domain, inverse_of: false do
     belongs_to :domain_block
     belongs_to :domain_allow
-    belongs_to :unavailable_domain # skipcq: RB-RL1031
+    belongs_to :unavailable_domain
+
+    has_many :accounts, dependent: nil
   end
 
   scope :searchable, -> { where.not(domain: DomainBlock.select(:domain)) }


### PR DESCRIPTION
Pulled out from https://github.com/mastodon/mastodon/pull/28111 (view concern thing)

The `skipqc` comment is about an issue that has since been handled; the other change is just moving it inside the with_options block with all the options.