### PR TITLE
Change compose form background colors in light theme

### DIFF
--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -572,3 +572,9 @@ html {
 .compose-form .spoiler-input__input {
   color: lighten($ui-highlight-color, 8%);
 }
+
+.compose-form .autosuggest-textarea__textarea,
+.compose-form__highlightable,
+.poll__option input[type='text'] {
+  background: darken($ui-base-color, 10%);
+}


### PR DESCRIPTION
A full-blown redesign of the light theme is planned, but this will be much more work.

## Before

![image](https://github.com/mastodon/mastodon/assets/384364/bfabfbb4-2769-421a-9332-57a7a325ba37)

## After

![image](https://github.com/mastodon/mastodon/assets/384364/ffdfd0a6-8373-45da-9d11-2e0d35b59e22)
