### PR TITLE
[WIP] Change lock_open icon to more visually comparable icon for unlisted posting

### DIFF
--- a/app/javascript/mastodon/features/compose/components/privacy_dropdown.jsx
+++ b/app/javascript/mastodon/features/compose/components/privacy_dropdown.jsx
@@ -11,7 +11,7 @@ import Overlay from 'react-overlays/Overlay';
 
 import AlternateEmailIcon from '@/material-icons/400-24px/alternate_email.svg?react';
 import LockIcon from '@/material-icons/400-24px/lock.svg?react';
-import LockOpenIcon from '@/material-icons/400-24px/lock_open.svg?react';
+import LockOpenRightIcon from '@/material-icons/400-24px/lock_open_right.svg?react';
 import PublicIcon from '@/material-icons/400-24px/public.svg?react';
 import { Icon }  from 'mastodon/components/icon';
 
@@ -228,7 +228,7 @@ class PrivacyDropdown extends PureComponent {
 
     this.options = [
       { icon: 'globe', iconComponent: PublicIcon, value: 'public', text: formatMessage(messages.public_short), meta: formatMessage(messages.public_long) },
-      { icon: 'unlock', iconComponent: LockOpenIcon,  value: 'unlisted', text: formatMessage(messages.unlisted_short), meta: formatMessage(messages.unlisted_long) },
+      { icon: 'unlock', iconComponent: LockOpenRightIcon,  value: 'unlisted', text: formatMessage(messages.unlisted_short), meta: formatMessage(messages.unlisted_long) },
       { icon: 'lock', iconComponent: LockIcon, value: 'private', text: formatMessage(messages.private_short), meta: formatMessage(messages.private_long) },
     ];
 


### PR DESCRIPTION
![image](https://github.com/mastodon/mastodon/assets/5047683/c3bd9e57-adfd-4da8-8d4d-d4f33ef68f18)
After migrated to Material icons, lock and lock-open looks very very simillar.
I suggesst to use lock-open-right for unlisted option

![image](https://github.com/mastodon/mastodon/assets/5047683/3d20e718-8150-4c69-a8fd-d0122d07f831)
