### PR TITLE
Add `Account` migration-related scopes

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -119,8 +119,10 @@ class Account < ApplicationRecord
   scope :silenced, -> { where.not(silenced_at: nil) }
   scope :suspended, -> { where.not(suspended_at: nil) }
   scope :sensitized, -> { where.not(sensitized_at: nil) }
+  scope :migrated, -> { where.not(moved_to_account_id: nil) }
   scope :without_suspended, -> { where(suspended_at: nil) }
   scope :without_silenced, -> { where(silenced_at: nil) }
+  scope :without_migrated, -> { where(moved_to_account_id: nil) }
   scope :without_instance_actor, -> { where.not(id: INSTANCE_ACTOR_ID) }
   scope :recent, -> { reorder(id: :desc) }
   scope :bots, -> { where(actor_type: %w(Application Service)) }
@@ -131,7 +133,7 @@ class Account < ApplicationRecord
   scope :matches_display_name, ->(value) { where(arel_table[:display_name].matches("#{value}%")) }
   scope :without_unapproved, -> { left_outer_joins(:user).merge(User.approved.confirmed).or(remote) }
   scope :auditable, -> { where(id: Admin::ActionLog.select(:account_id).distinct) }
-  scope :searchable, -> { without_unapproved.without_suspended.where(moved_to_account_id: nil) }
+  scope :searchable, -> { without_unapproved.without_suspended.without_migrated }
   scope :discoverable, -> { searchable.without_silenced.where(discoverable: true).joins(:account_stat) }
   scope :by_recent_status, -> { includes(:account_stat).merge(AccountStat.by_recent_status).references(:account_stat) }
   scope :by_recent_activity, -> { left_joins(:user, :account_stat).order(coalesced_activity_timestamps.desc).order(id: :desc) }

--- a/app/models/relationship_filter.rb
+++ b/app/models/relationship_filter.rb
@@ -92,9 +92,9 @@ class RelationshipFilter
   def status_scope(value)
     case value
     when 'moved'
-      Account.where.not(moved_to_account_id: nil)
+      Account.migrated
     when 'primary'
-      Account.where(moved_to_account_id: nil)
+      Account.without_migrated
     else
       raise Mastodon::InvalidParameterError, "Unknown status: #{value}"
     end


### PR DESCRIPTION
Separately from these scopes, this is another candidate for a concern extraction (there are also instance methods) if we went the route from the other sensitize/suspend/silence PRs. Each one is small, but combined it would be a nice cleanup of the class.