### PR TITLE
Group association declaration `inverse_of` blocks using `with_options`

### DIFF
--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -16,8 +16,10 @@ class Bookmark < ApplicationRecord
 
   update_index('statuses', :status) if Chewy.enabled?
 
-  belongs_to :account, inverse_of: :bookmarks
-  belongs_to :status,  inverse_of: :bookmarks
+  with_options inverse_of: :bookmarks do
+    belongs_to :account
+    belongs_to :status
+  end
 
   validates :status_id, uniqueness: { scope: :account_id }
 

--- a/app/models/custom_filter.rb
+++ b/app/models/custom_filter.rb
@@ -34,8 +34,12 @@ class CustomFilter < ApplicationRecord
   enum :action, { warn: 0, hide: 1 }, suffix: :action
 
   belongs_to :account
-  has_many :keywords, class_name: 'CustomFilterKeyword', inverse_of: :custom_filter, dependent: :destroy
-  has_many :statuses, class_name: 'CustomFilterStatus', inverse_of: :custom_filter, dependent: :destroy
+
+  with_options inverse_of: :custom_filter, dependent: :destroy do
+    has_many :keywords, class_name: 'CustomFilterKeyword'
+    has_many :statuses, class_name: 'CustomFilterStatus'
+  end
+
   accepts_nested_attributes_for :keywords, reject_if: :all_blank, allow_destroy: true
 
   validates :title, :context, presence: true

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -19,8 +19,10 @@ class Device < ApplicationRecord
   belongs_to :access_token, class_name: 'Doorkeeper::AccessToken'
   belongs_to :account
 
-  has_many :one_time_keys, dependent: :destroy, inverse_of: :device
-  has_many :encrypted_messages, dependent: :destroy, inverse_of: :device
+  with_options dependent: :destroy, inverse_of: :device do
+    has_many :one_time_keys
+    has_many :encrypted_messages
+  end
 
   validates :name, :fingerprint_key, :identity_key, presence: true
   validates :fingerprint_key, :identity_key, ed25519_key: true

--- a/app/models/favourite.rb
+++ b/app/models/favourite.rb
@@ -16,8 +16,10 @@ class Favourite < ApplicationRecord
 
   update_index('statuses', :status)
 
-  belongs_to :account, inverse_of: :favourites
-  belongs_to :status,  inverse_of: :favourites
+  with_options inverse_of: :favourites do
+    belongs_to :account
+    belongs_to :status
+  end
 
   has_one :notification, as: :activity, dependent: :destroy
 

--- a/app/models/featured_tag.rb
+++ b/app/models/featured_tag.rb
@@ -15,8 +15,10 @@
 #
 
 class FeaturedTag < ApplicationRecord
-  belongs_to :account, inverse_of: :featured_tags
-  belongs_to :tag, inverse_of: :featured_tags, optional: true # Set after validation
+  with_options inverse_of: :featured_tags do
+    belongs_to :account
+    belongs_to :tag, optional: true # Set after validation
+  end
 
   validates :name, presence: true, format: { with: Tag::HASHTAG_NAME_RE }, on: :create
 

--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -174,9 +174,11 @@ class MediaAttachment < ApplicationRecord
     all: '-quality 90 +profile "!icc,*" +set date:modify +set date:create +set date:timestamp -define jpeg:dct-method=float',
   }.freeze
 
-  belongs_to :account,          inverse_of: :media_attachments, optional: true
-  belongs_to :status,           inverse_of: :media_attachments, optional: true
-  belongs_to :scheduled_status, inverse_of: :media_attachments, optional: true
+  with_options inverse_of: :media_attachments, optional: true do
+    belongs_to :account
+    belongs_to :status
+    belongs_to :scheduled_status
+  end
 
   has_attached_file :file,
                     styles: ->(f) { file_styles f },

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -79,13 +79,18 @@ class Notification < ApplicationRecord
   belongs_to :activity, polymorphic: true, optional: true
 
   with_options foreign_key: 'activity_id', optional: true do
-    belongs_to :mention, inverse_of: :notification
-    belongs_to :status, inverse_of: :notification
-    belongs_to :follow, inverse_of: :notification
-    belongs_to :follow_request, inverse_of: :notification
-    belongs_to :favourite, inverse_of: :notification
-    belongs_to :poll, inverse_of: false
-    belongs_to :report, inverse_of: false
+    with_options inverse_of: :notification do
+      belongs_to :mention
+      belongs_to :status
+      belongs_to :follow
+      belongs_to :follow_request
+      belongs_to :favourite
+    end
+
+    with_options inverse_of: false do
+      belongs_to :poll
+      belongs_to :report
+    end
   end
 
   validates :type, inclusion: { in: TYPES }

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -24,8 +24,11 @@ class Tag < ApplicationRecord
   has_and_belongs_to_many :statuses
   has_and_belongs_to_many :accounts
 
-  has_many :passive_relationships, class_name: 'TagFollow', inverse_of: :tag, dependent: :destroy
-  has_many :featured_tags, dependent: :destroy, inverse_of: :tag
+  with_options inverse_of: :tag, dependent: :destroy do
+    has_many :passive_relationships, class_name: 'TagFollow'
+    has_many :featured_tags
+  end
+
   has_many :followers, through: :passive_relationships, source: :account
 
   HASHTAG_SEPARATORS = "_\u00B7\u30FB\u200c"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -87,13 +87,17 @@ class User < ApplicationRecord
   accepts_nested_attributes_for :account
 
   has_many :applications, class_name: 'Doorkeeper::Application', as: :owner, dependent: nil
-  has_many :backups, inverse_of: :user, dependent: nil
-  has_many :invites, inverse_of: :user, dependent: nil
-  has_many :markers, inverse_of: :user, dependent: :destroy
   has_many :webauthn_credentials, dependent: :destroy
-  has_many :ips, class_name: 'UserIp', inverse_of: :user, dependent: nil
 
-  has_one :invite_request, class_name: 'UserInviteRequest', inverse_of: :user, dependent: :destroy
+  with_options inverse_of: :user do
+    has_many :backups, dependent: nil
+    has_many :invites, dependent: nil
+    has_many :markers, dependent: :destroy
+    has_many :ips, class_name: 'UserIp', dependent: nil
+
+    has_one :invite_request, class_name: 'UserInviteRequest', dependent: :destroy
+  end
+
   accepts_nested_attributes_for :invite_request, reject_if: ->(attributes) { attributes['text'].blank? && !Setting.require_invite_text }
   validates :invite_request, presence: true, on: :create, if: :invite_text_required?
 


### PR DESCRIPTION
Similar to the recent PRs which did this sort of thing with `class_name`, this is another grouping where it made sense and there were similar associations near each other.