### PR TITLE
Fix intmermittent failure in `api/v1/accounts/statuses` controller spec

### DIFF
--- a/spec/controllers/api/v1/accounts/statuses_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/statuses_controller_spec.rb
@@ -39,11 +39,14 @@ describe Api::V1::Accounts::StatusesController do
       end
 
       it 'returns posts along with self replies', :aggregate_failures do
-        json = body_as_json
-        post_ids = json.map { |item| item[:id].to_i }.sort
-
-        expect(response).to have_http_status(200)
-        expect(post_ids).to eq [status.id, status_self_reply.id]
+        expect(response)
+          .to have_http_status(200)
+        expect(body_as_json)
+          .to have_attributes(size: 2)
+          .and contain_exactly(
+            include(id: status.id.to_s),
+            include(id: status_self_reply.id.to_s)
+          )
       end
     end
 


### PR DESCRIPTION
Failure in unrelated PR https://github.com/mastodon/mastodon/actions/runs/7427240060/job/20212618059?pr=27602