### PR TITLE
Combine double subjects in application controller shared example

### DIFF
--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -22,13 +22,10 @@ describe ApplicationController do
   end
 
   shared_examples 'respond_with_error' do |code|
-    it "returns http #{code} for http" do
-      subject
-      expect(response).to have_http_status(code)
-    end
-
-    it 'renders template for http' do
+    it "returns http #{code} for http and renders template" do
       expect(subject).to render_template("errors/#{code}", layout: 'error')
+
+      expect(response).to have_http_status(code)
     end
   end
 


### PR DESCRIPTION
This is called a few times throughout the spec so the savings multiply a little here.