### PR TITLE
Combine repeated subject in `cacheable response` shared example

### DIFF
--- a/spec/support/examples/cache.rb
+++ b/spec/support/examples/cache.rb
@@ -1,22 +1,14 @@
 # frozen_string_literal: true
 
 shared_examples 'cacheable response' do |expects_vary: false|
-  it 'does not set cookies' do
+  it 'sets correct cache and vary headers and does not set cookies or session' do
     expect(response.cookies).to be_empty
     expect(response.headers['Set-Cookies']).to be_nil
-  end
 
-  it 'does not set sessions' do
     expect(session).to be_empty
-  end
 
-  if expects_vary
-    it 'returns Vary header' do
-      expect(response.headers['Vary']).to include(expects_vary)
-    end
-  end
+    expect(response.headers['Vary']).to include(expects_vary) if expects_vary
 
-  it 'returns public Cache-Control header' do
     expect(response.headers['Cache-Control']).to include('public')
   end
 end


### PR DESCRIPTION
These shared examples are used in a number of other specs, so good request reduction here.