### PR TITLE
Move `api/v2/filters/*` to request spec

### DIFF
--- a/spec/requests/api/v2/filters/keywords_spec.rb
+++ b/spec/requests/api/v2/filters/keywords_spec.rb
@@ -2,25 +2,20 @@
 
 require 'rails_helper'
 
-RSpec.describe Api::V2::Filters::KeywordsController do
-  render_views
-
+RSpec.describe 'API V2 Filters Keywords' do
   let(:user)         { Fabricate(:user) }
   let(:token)        { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:filter)       { Fabricate(:custom_filter, account: user.account) }
   let(:other_user)   { Fabricate(:user) }
   let(:other_filter) { Fabricate(:custom_filter, account: other_user.account) }
+  let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
 
-  before do
-    allow(controller).to receive(:doorkeeper_token) { token }
-  end
-
-  describe 'GET #index' do
+  describe 'GET /api/v2/filters/:filter_id/keywords' do
     let(:scopes) { 'read:filters' }
     let!(:keyword) { Fabricate(:custom_filter_keyword, custom_filter: filter) }
 
     it 'returns http success' do
-      get :index, params: { filter_id: filter.id }
+      get "/api/v2/filters/#{filter.id}/keywords", headers: headers
       expect(response).to have_http_status(200)
       expect(body_as_json)
         .to contain_exactly(
@@ -30,18 +25,18 @@ RSpec.describe Api::V2::Filters::KeywordsController do
 
     context "when trying to access another's user filters" do
       it 'returns http not found' do
-        get :index, params: { filter_id: other_filter.id }
+        get "/api/v2/filters/#{other_filter.id}/keywords", headers: headers
         expect(response).to have_http_status(404)
       end
     end
   end
 
-  describe 'POST #create' do
+  describe 'POST /api/v2/filters/:filter_id/keywords' do
     let(:scopes)    { 'write:filters' }
     let(:filter_id) { filter.id }
 
     before do
-      post :create, params: { filter_id: filter_id, keyword: 'magic', whole_word: false }
+      post "/api/v2/filters/#{filter_id}/keywords", headers: headers, params: { keyword: 'magic', whole_word: false }
     end
 
     it 'creates a filter', :aggregate_failures do
@@ -65,12 +60,12 @@ RSpec.describe Api::V2::Filters::KeywordsController do
     end
   end
 
-  describe 'GET #show' do
+  describe 'GET /api/v2/filters/keywords/:id' do
     let(:scopes)  { 'read:filters' }
     let(:keyword) { Fabricate(:custom_filter_keyword, keyword: 'foo', whole_word: false, custom_filter: filter) }
 
     before do
-      get :show, params: { id: keyword.id }
+      get "/api/v2/filters/keywords/#{keyword.id}", headers: headers
     end
 
     it 'responds with the keyword', :aggregate_failures do
@@ -90,12 +85,12 @@ RSpec.describe Api::V2::Filters::KeywordsController do
     end
   end
 
-  describe 'PUT #update' do
+  describe 'PUT /api/v2/filters/keywords/:id' do
     let(:scopes)  { 'write:filters' }
     let(:keyword) { Fabricate(:custom_filter_keyword, custom_filter: filter) }
 
     before do
-      get :update, params: { id: keyword.id, keyword: 'updated' }
+      put "/api/v2/filters/keywords/#{keyword.id}", headers: headers, params: { keyword: 'updated' }
     end
 
     it 'updates the keyword', :aggregate_failures do
@@ -113,12 +108,12 @@ RSpec.describe Api::V2::Filters::KeywordsController do
     end
   end
 
-  describe 'DELETE #destroy' do
+  describe 'DELETE /api/v2/filters/keywords/:id' do
     let(:scopes)  { 'write:filters' }
     let(:keyword) { Fabricate(:custom_filter_keyword, custom_filter: filter) }
 
     before do
-      delete :destroy, params: { id: keyword.id }
+      delete "/api/v2/filters/keywords/#{keyword.id}", headers: headers
     end
 
     it 'destroys the keyword', :aggregate_failures do

--- a/spec/requests/api/v2/filters/statuses_spec.rb
+++ b/spec/requests/api/v2/filters/statuses_spec.rb
@@ -2,25 +2,20 @@
 
 require 'rails_helper'
 
-RSpec.describe Api::V2::Filters::StatusesController do
-  render_views
-
+RSpec.describe 'API V2 Filters Statuses' do
   let(:user)         { Fabricate(:user) }
   let(:token)        { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:filter)       { Fabricate(:custom_filter, account: user.account) }
   let(:other_user)   { Fabricate(:user) }
   let(:other_filter) { Fabricate(:custom_filter, account: other_user.account) }
+  let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
 
-  before do
-    allow(controller).to receive(:doorkeeper_token) { token }
-  end
-
-  describe 'GET #index' do
+  describe 'GET /api/v2/filters/:filter_id/statuses' do
     let(:scopes) { 'read:filters' }
     let!(:status_filter) { Fabricate(:custom_filter_status, custom_filter: filter) }
 
     it 'returns http success' do
-      get :index, params: { filter_id: filter.id }
+      get "/api/v2/filters/#{filter.id}/statuses", headers: headers
       expect(response).to have_http_status(200)
       expect(body_as_json)
         .to contain_exactly(
@@ -30,7 +25,7 @@ RSpec.describe Api::V2::Filters::StatusesController do
 
     context "when trying to access another's user filters" do
       it 'returns http not found' do
-        get :index, params: { filter_id: other_filter.id }
+        get "/api/v2/filters/#{other_filter.id}/statuses", headers: headers
         expect(response).to have_http_status(404)
       end
     end
@@ -42,7 +37,7 @@ RSpec.describe Api::V2::Filters::StatusesController do
     let!(:status)   { Fabricate(:status) }
 
     before do
-      post :create, params: { filter_id: filter_id, status_id: status.id }
+      post "/api/v2/filters/#{filter_id}/statuses", headers: headers, params: { status_id: status.id }
     end
 
     it 'creates a filter', :aggregate_failures do
@@ -65,12 +60,12 @@ RSpec.describe Api::V2::Filters::StatusesController do
     end
   end
 
-  describe 'GET #show' do
+  describe 'GET /api/v2/filters/statuses/:id' do
     let(:scopes) { 'read:filters' }
     let!(:status_filter) { Fabricate(:custom_filter_status, custom_filter: filter) }
 
     before do
-      get :show, params: { id: status_filter.id }
+      get "/api/v2/filters/statuses/#{status_filter.id}", headers: headers
     end
 
     it 'responds with the filter', :aggregate_failures do
@@ -89,12 +84,12 @@ RSpec.describe Api::V2::Filters::StatusesController do
     end
   end
 
-  describe 'DELETE #destroy' do
+  describe 'DELETE /api/v2/filters/statuses/:id' do
     let(:scopes) { 'write:filters' }
     let(:status_filter) { Fabricate(:custom_filter_status, custom_filter: filter) }
 
     before do
-      delete :destroy, params: { id: status_filter.id }
+      delete "/api/v2/filters/statuses/#{status_filter.id}", headers: headers
     end
 
     it 'destroys the filter', :aggregate_failures do


### PR DESCRIPTION
I believe this is the last of the `api/v2/*` group -- still many v1 remaining.