### PR TITLE
Add follow/mute/block.removed webhook events

### DIFF
--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -23,6 +23,9 @@ class Webhook < ApplicationRecord
     report.updated
     status.created
     status.updated
+    follow.removed
+    block.removed
+    mute.removed
   ).freeze
 
   attr_writer :current_account
@@ -58,10 +61,12 @@ class Webhook < ApplicationRecord
 
   def self.permission_for_event(event)
     case event
-    when 'account.approved', 'account.created', 'account.updated'
+    when 'account.approved', 'account.created', 'account.updated', 'follow.removed'
       :manage_users
     when 'report.created', 'report.updated'
       :manage_reports
+    when 'block.removed', 'mute.removed'
+      :manage_blocks
     when 'status.created', 'status.updated'
       :view_devops
     end

--- a/app/services/unblock_service.rb
+++ b/app/services/unblock_service.rb
@@ -7,6 +7,9 @@ class UnblockService < BaseService
     return unless account.blocking?(target_account)
 
     unblock = account.unblock!(target_account)
+
+    TriggerWebhookWithObjectWorker.perform_async('block.removed', Oj.to_json({ 'account_id': unblock.account_id, 'target_account_id': unblock.target_account_id, 'id': unblock.id }))
+
     create_notification(unblock) if !target_account.local? && target_account.activitypub?
     unblock
   end

--- a/app/services/unblock_service.rb
+++ b/app/services/unblock_service.rb
@@ -8,7 +8,10 @@ class UnblockService < BaseService
 
     unblock = account.unblock!(target_account)
 
-    TriggerWebhookWithObjectWorker.perform_async('block.removed', Oj.to_json({ 'account_id': unblock.account_id, 'target_account_id': unblock.target_account_id, 'id': unblock.id }))
+    TriggerWebhookWithObjectWorker.perform_async('block.removed',
+                                                 Oj.to_json({ account_id: unblock.account_id,
+                                                              target_account_id: unblock.target_account_id,
+                                                              id: unblock.id }))
 
     create_notification(unblock) if !target_account.local? && target_account.activitypub?
     unblock

--- a/app/services/unfollow_service.rb
+++ b/app/services/unfollow_service.rb
@@ -29,6 +29,8 @@ class UnfollowService < BaseService
 
     follow.destroy!
 
+    TriggerWebhookWithObjectWorker.perform_async('follow.removed', Oj.to_json({ 'account_id': follow.account_id, 'target_account_id': follow.target_account_id, 'id': follow.id }))
+
     create_notification(follow) if !@target_account.local? && @target_account.activitypub?
     create_reject_notification(follow) if @target_account.local? && !@source_account.local? && @source_account.activitypub?
     UnmergeWorker.perform_async(@target_account.id, @source_account.id) unless @options[:skip_unmerge]

--- a/app/services/unfollow_service.rb
+++ b/app/services/unfollow_service.rb
@@ -29,7 +29,10 @@ class UnfollowService < BaseService
 
     follow.destroy!
 
-    TriggerWebhookWithObjectWorker.perform_async('follow.removed', Oj.to_json({ 'account_id': follow.account_id, 'target_account_id': follow.target_account_id, 'id': follow.id }))
+    TriggerWebhookWithObjectWorker.perform_async('follow.removed',
+                                                 Oj.to_json({ account_id: follow.account_id,
+                                                              target_account_id: follow.target_account_id,
+                                                              id: follow.id }))
 
     create_notification(follow) if !@target_account.local? && @target_account.activitypub?
     create_reject_notification(follow) if @target_account.local? && !@source_account.local? && @source_account.activitypub?

--- a/app/services/unmute_service.rb
+++ b/app/services/unmute_service.rb
@@ -4,7 +4,12 @@ class UnmuteService < BaseService
   def call(account, target_account)
     return unless account.muting?(target_account)
 
-    account.unmute!(target_account)
+    unmute = account.unmute!(target_account)
+
+    TriggerWebhookWithObjectWorker.perform_async('mute.removed',
+                                                 Oj.to_json({ account_id: unmute.account_id,
+                                                              target_account_id: unmute.target_account_id,
+                                                              id: unmute.id }))
 
     MergeWorker.perform_async(target_account.id, account.id) if account.following?(target_account)
   end

--- a/app/workers/trigger_webhook_with_object_worker.rb
+++ b/app/workers/trigger_webhook_with_object_worker.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class TriggerWebhookWithObjectWorker
+  include Sidekiq::Worker
+
+  # Triggers a webhook for a destructive event (e.g. an unfollow),
+  # where the object cannot be queried from the database.
+  # @param event [String] type of the event
+  # @param object [String] event payload serialized with JSON
+  def perform(event, object)
+    WebhookService.new.call(event, Oj.load(object))
+  end
+end


### PR DESCRIPTION
This PR provides the inverse Webhook events to #28744:

As all present Webhook events are triggered by the creation of some object in the database, the logic to trigger a webhook used for these passes on solely the ID of the database entry. 

Because the events here are about the deletion of some database entry, I've added another Sidekiq Worker to trigger webhooks that can be passed JSON instead of a primary key. This also means that the formats for these webhooks is custom and kept as concise as possible to prevent putting too big blobs into the Sidekiq queue.

### `follow.removed`
```json
{
    "event": "follow.removed",
    "created_at": "2024-01-26T20:38:33.163Z",
    "object": {
        "account_id": 111824124643125311,
        "target_account_id": 111824112819598830,
        "id": 3
    }
}
```

### `mute.removed`
```json
{
    "event": "mute.removed",
    "created_at": "2024-01-26T20:38:33.163Z",
    "object": {
        "account_id": 111824124643125311,
        "target_account_id": 111824112819598830,
        "id": 1
    }
}
```
### `block.removed`
```json
{
    "event": "block.removed",
    "created_at": "2024-01-26T20:38:33.163Z",
    "object": {
        "account_id": 111824124643125311,
        "target_account_id": 111824112819598830,
        "id": 1
    }
}
```