### PR TITLE
Add test configuration file to webpack

### DIFF
--- a/bin/webpack
+++ b/bin/webpack
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 ENV["RAILS_ENV"] ||= ENV["RACK_ENV"] || "development"
-ENV["NODE_ENV"]  ||= "development"
+ENV["NODE_ENV"]  ||= ENV["RAILS_ENV"]
 
 require "pathname"
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",

--- a/config/webpack/test.js
+++ b/config/webpack/test.js
@@ -1,0 +1,8 @@
+const { merge } = require('webpack-merge');
+
+const sharedConfig = require('./shared');
+
+module.exports = merge(sharedConfig, {
+  mode: 'development',
+  cache: false,
+});


### PR DESCRIPTION
Resolve #28752

On Codespaces, running `RAILS_ENV=test . /bin/rails assets:precompile` on Codespaces will load the development configuration file and the build will fail. This is because `NODE_ENV` is set to development in Codespaces. It is rare for the values of `RAILS_ENV` and `NODE_ENV` to be different, and the values should be changed to be constant at build time.

```console
@ykzts ➜ /workspaces/mastodon (main) $ RAILS_ENV=test ./bin/rails assets:precompile
Compiling...
Compilation failed:
/workspaces/mastodon/node_modules/webpack-cli/bin/cli.js:93
                                throw err;
                                ^

TypeError: Cannot read properties of undefined (reading 'compress')
    at Object.<anonymous> (/workspaces/mastodon/config/webpack/development.js:32:35)
    at Module._compile (/workspaces/mastodon/node_modules/v8-compile-cache/v8-compile-cache.js:192:30)
    at Module._extensions..js (node:internal/modules/cjs/loader:1435:10)
    at Module.load (node:internal/modules/cjs/loader:1207:32)
    at Module._load (node:internal/modules/cjs/loader:1023:12)
    at Module.require (node:internal/modules/cjs/loader:1235:19)
    at require (/workspaces/mastodon/node_modules/v8-compile-cache/v8-compile-cache.js:159:20)
    at WEBPACK_OPTIONS (/workspaces/mastodon/node_modules/webpack-cli/bin/utils/convert-argv.js:114:13)
    at requireConfig (/workspaces/mastodon/node_modules/webpack-cli/bin/utils/convert-argv.js:116:6)
    at /workspaces/mastodon/node_modules/webpack-cli/bin/utils/convert-argv.js:123:17
    at Array.forEach (<anonymous>)
    at module.exports (/workspaces/mastodon/node_modules/webpack-cli/bin/utils/convert-argv.js:121:15)
    at /workspaces/mastodon/node_modules/webpack-cli/bin/cli.js:71:45
    at Object.parse (/workspaces/mastodon/node_modules/webpack-cli/node_modules/yargs/yargs.js:576:18)
    at /workspaces/mastodon/node_modules/webpack-cli/bin/cli.js:49:8
    at Object.<anonymous> (/workspaces/mastodon/node_modules/webpack-cli/bin/cli.js:366:3)
    at Module._compile (node:internal/modules/cjs/loader:1376:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1435:10)
    at Module.load (node:internal/modules/cjs/loader:1207:32)
    at Module._load (node:internal/modules/cjs/loader:1023:12)
    at Module.require (node:internal/modules/cjs/loader:1235:19)
    at require (node:internal/modules/helpers:176:18)
    at Object.<anonymous> (/workspaces/mastodon/node_modules/webpack/bin/webpack.js:156:2)
    at Module._compile (node:internal/modules/cjs/loader:1376:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1435:10)
    at Module.load (node:internal/modules/cjs/loader:1207:32)
    at Module._load (node:internal/modules/cjs/loader:1023:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:135:12)
    at node:internal/main/run_main_module:28:49

Node.js v20.11.0
```