### PR TITLE
Expand CLI `--verbose` options available to accounts command

### DIFF
--- a/lib/mastodon/cli/accounts.rb
+++ b/lib/mastodon/cli/accounts.rb
@@ -251,6 +251,7 @@ module Mastodon::CLI
     end
 
     option :force, type: :boolean, aliases: [:f], description: 'Override public key check'
+    option :verbose, type: :boolean, aliases: [:v]
     desc 'merge FROM TO', 'Merge two remote accounts into one'
     long_desc <<-LONG_DESC
       Merge two remote accounts specified by their username@domain
@@ -264,11 +265,13 @@ module Mastodon::CLI
     def merge(from_acct, to_acct)
       username, domain = from_acct.split('@')
       from_account = Account.find_remote(username, domain)
+      say "Found remote account for removal `#{from_account.acct}`" if options[:verbose]
 
       fail_with_message "No such account (#{from_acct})" if from_account.nil? || from_account.local?
 
       username, domain = to_acct.split('@')
       to_account = Account.find_remote(username, domain)
+      say "Found remote account to preserve `#{to_account.acct}`" if options[:verbose]
 
       fail_with_message "No such account (#{to_acct})" if to_account.nil? || to_account.local?
 
@@ -280,7 +283,10 @@ module Mastodon::CLI
       end
 
       to_account.merge_with!(from_account)
+      say "Merged `#{from_account.acct}` into `#{to_account.acct}`" if options[:verbose]
+
       from_account.destroy
+      say "Destroyed the `#{from_account.acct}` account" if options[:verbose]
 
       say('OK', :green)
     end

--- a/lib/mastodon/cli/accounts.rb
+++ b/lib/mastodon/cli/accounts.rb
@@ -311,6 +311,7 @@ module Mastodon::CLI
     end
 
     desc 'backup USERNAME', 'Request a backup for a user'
+    option :verbose, type: :boolean, aliases: [:v]
     long_desc <<-LONG_DESC
       Request a new backup for an account with a given USERNAME.
 
@@ -322,9 +323,14 @@ module Mastodon::CLI
       account = Account.find_local(username)
 
       fail_with_message 'No user with such username' if account.nil?
+      say "Found local account `#{account.acct}`" if options[:verbose]
 
       backup = account.user.backups.create!
+      say "Backup created for `#{account.acct}`" if options[:verbose]
+
       BackupWorker.perform_async(backup.id)
+      say 'Backup delivery added to queue' if options[:verbose]
+
       say('OK', :green)
     end
 

--- a/lib/mastodon/cli/accounts.rb
+++ b/lib/mastodon/cli/accounts.rb
@@ -558,6 +558,7 @@ module Mastodon::CLI
 
     option :concurrency, type: :numeric, default: 5, aliases: [:c]
     option :dry_run, type: :boolean
+    option :verbose, type: :boolean, aliases: [:v]
     desc 'prune', 'Prune remote accounts that never interacted with local users'
     long_desc <<-LONG_DESC
       Prune remote account that
@@ -584,6 +585,7 @@ module Mastodon::CLI
         next if account.suspended?
         next if account.silenced?
 
+        say "Destroying account `#{account.acct}`" if options[:verbose]
         account.destroy unless dry_run?
         1
       end

--- a/lib/mastodon/cli/accounts.rb
+++ b/lib/mastodon/cli/accounts.rb
@@ -446,6 +446,7 @@ module Mastodon::CLI
 
       processed, = parallelize_with_progress(Account.local.without_suspended) do |account|
         FollowService.new.call(account, target_account, bypass_limit: true)
+        say "Local account `#{account.acct}` now follows `#{target_account.acct}`" if options[:verbose]
       end
 
       say("OK, followed target from #{processed} accounts", :green)

--- a/lib/mastodon/cli/accounts.rb
+++ b/lib/mastodon/cli/accounts.rb
@@ -407,6 +407,7 @@ module Mastodon::CLI
           account.reset_avatar!
           account.reset_header!
           account.save
+          say "Refreshed remote assets for `#{account.acct}`" if options[:verbose]
         end
 
         say("Refreshed #{processed} accounts#{dry_run_mode_suffix}", :green, true)
@@ -423,6 +424,7 @@ module Mastodon::CLI
             account.reset_avatar!
             account.reset_header!
             account.save
+            say "Refreshed remote assets for `#{account.acct}`" if options[:verbose]
           rescue Mastodon::UnexpectedResponseError
             say("Account failed: #{user}@#{domain}", :red)
           end

--- a/lib/mastodon/cli/accounts.rb
+++ b/lib/mastodon/cli/accounts.rb
@@ -216,8 +216,9 @@ module Mastodon::CLI
       end
     end
 
-    option :email
     option :dry_run, type: :boolean
+    option :email
+    option :verbose, type: :boolean, aliases: [:v]
     desc 'delete [USERNAME]', 'Delete a user'
     long_desc <<-LONG_DESC
       Remove a user account with a given USERNAME.
@@ -237,9 +238,11 @@ module Mastodon::CLI
       if username.present?
         account = Account.find_local(username)
         fail_with_message 'No user with such username' if account.nil?
+        say "Found local account with `#{username}` username" if options[:verbose]
       else
         account = Account.left_joins(:user).find_by(user: { email: options[:email] })
         fail_with_message 'No user with such email' if account.nil?
+        say "Found local account with `#{account.user.email}` email" if options[:verbose]
       end
 
       say("Deleting user with #{account.statuses_count} statuses, this might take a while...#{dry_run_mode_suffix}")

--- a/lib/mastodon/cli/accounts.rb
+++ b/lib/mastodon/cli/accounts.rb
@@ -336,6 +336,7 @@ module Mastodon::CLI
 
     option :concurrency, type: :numeric, default: 5, aliases: [:c]
     option :dry_run, type: :boolean
+    option :verbose, type: :boolean, aliases: [:v]
     desc 'cull [DOMAIN...]', 'Remove remote accounts that no longer exist'
     long_desc <<-LONG_DESC
       Query every single remote account in the database to determine
@@ -364,6 +365,7 @@ module Mastodon::CLI
         end
 
         if [404, 410].include?(code)
+          say "Account `#{account.acct}` no longer exists and will be deleted" if options[:verbose]
           DeleteAccountService.new.call(account, reserve_username: false) unless dry_run?
           1
         else

--- a/lib/mastodon/cli/accounts.rb
+++ b/lib/mastodon/cli/accounts.rb
@@ -463,6 +463,7 @@ module Mastodon::CLI
 
       processed, = parallelize_with_progress(target_account.followers.local) do |account|
         UnfollowService.new.call(account, target_account)
+        say "Local account `#{account.acct}` will stop following `#{target_account.acct}`" if options[:verbose]
       end
 
       say("OK, unfollowed target from #{processed} accounts", :green)

--- a/lib/mastodon/cli/accounts.rb
+++ b/lib/mastodon/cli/accounts.rb
@@ -596,6 +596,7 @@ module Mastodon::CLI
     option :force, type: :boolean
     option :replay, type: :boolean
     option :target
+    option :verbose, type: :boolean, aliases: [:v]
     desc 'migrate USERNAME', 'Migrate a local user to another account'
     long_desc <<~LONG_DESC
       With --replay, replay the last migration of the specified account, in
@@ -634,12 +635,14 @@ module Mastodon::CLI
 
         begin
           migration = account.migrations.create!(acct: target_account.acct)
+          say "Created migration for `#{account.acct}` to move to `#{target_account.acct}`" if options[:verbose]
         rescue ActiveRecord::RecordInvalid => e
           fail_with_message "Error: #{e.message}"
         end
       end
 
       MoveService.new.call(migration)
+      say 'Called move service to perform the migration' if options[:verbose]
 
       say("OK, migrated #{account.acct} to #{migration.target_account.acct}", :green)
     end

--- a/lib/mastodon/cli/accounts.rb
+++ b/lib/mastodon/cli/accounts.rb
@@ -6,6 +6,7 @@ require_relative 'base'
 module Mastodon::CLI
   class Accounts < Base
     option :all, type: :boolean
+    option :verbose, type: :boolean, aliases: [:v]
     desc 'rotate [USERNAME]', 'Generate and broadcast new keys'
     long_desc <<-LONG_DESC
       Generate and broadcast new RSA keys as part of security
@@ -26,6 +27,7 @@ module Mastodon::CLI
         scope.find_in_batches do |accounts|
           accounts.each do |account|
             rotate_keys_for_account(account, delay)
+            progress.log("Keys rotated for account: #{account.username}") if options[:verbose]
             progress.increment
             processed += 1
           end
@@ -37,6 +39,7 @@ module Mastodon::CLI
         say("OK, rotated keys for #{processed} accounts", :green)
       elsif username.present?
         rotate_keys_for_account(Account.find_local(username))
+        say "Keys rotated for account: #{username}" if options[:verbose]
         say('OK', :green)
       else
         fail_with_message 'No account(s) given'

--- a/lib/mastodon/cli/cache.rb
+++ b/lib/mastodon/cli/cache.rb
@@ -49,22 +49,30 @@ module Mastodon::CLI
     end
 
     def recount_account_stats(account)
+      say "Recalculating account stats for `#{account.acct}`" if options[:verbose]
       account.account_stat.tap do |account_stat|
         account_stat.following_count = account.active_relationships.count
         account_stat.followers_count = account.passive_relationships.count
         account_stat.statuses_count  = account.statuses.where.not(visibility: :direct).count
 
-        account_stat.save if account_stat.changed?
+        if account_stat.changed?
+          say "Account stats for `#{account.acct}` changed and will be updated" if options[:verbose]
+          account_stat.save
+        end
       end
     end
 
     def recount_status_stats(status)
+      say "Recalculating status stats for `#{status.id}`" if options[:verbose]
       status.status_stat.tap do |status_stat|
         status_stat.replies_count    = status.replies.where.not(visibility: :direct).count
         status_stat.reblogs_count    = status.reblogs.count
         status_stat.favourites_count = status.favourites.count
 
-        status_stat.save if status_stat.changed?
+        if status_stat.changed?
+          say "Status stats for `#{status.id}` changed and will be updated" if options[:verbose]
+          status_stat.save
+        end
       end
     end
   end


### PR DESCRIPTION
Either expand on existing or adds new verbose output to some of these commands. Will continue down this path for more commands if this is ok.