### PR TITLE
Fix `RSpec/LetSetup` cop in api/v1/timelines/public spec

### DIFF
--- a/spec/requests/api/v1/timelines/public_spec.rb
+++ b/spec/requests/api/v1/timelines/public_spec.rb
@@ -22,12 +22,14 @@ describe 'Public' do
       get '/api/v1/timelines/public', headers: headers, params: params
     end
 
-    let!(:private_status) { Fabricate(:status, visibility: :private) } # rubocop:disable RSpec/LetSetup
     let!(:local_status)   { Fabricate(:status, account: Fabricate.build(:account, domain: nil)) }
     let!(:remote_status)  { Fabricate(:status, account: Fabricate.build(:account, domain: 'example.com')) }
     let!(:media_status)   { Fabricate(:status, media_attachments: [Fabricate.build(:media_attachment)]) }
-
     let(:params) { {} }
+
+    before do
+      Fabricate(:status, visibility: :private)
+    end
 
     context 'when the instance allows public preview' do
       let(:expected_statuses) { [local_status, remote_status, media_status] }


### PR DESCRIPTION
I tried to find something to assert about this one - but the way it's used in interaction with a shared example that doesn't have it in context makes that challenging. Instead, just move to a before block.