### PR TITLE
Add `redirect_with_vary` to `AllowedMethods` for `Style/FormatStringToken` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -174,6 +174,15 @@ Style/ClassAndModuleChildren:
 Style/Documentation:
   Enabled: false
 
+# Reason: Route redirects are not token-formatted and must be skipped
+# https://docs.rubocop.org/rubocop/cops_style.html#styleformatstringtoken
+Style/FormatStringToken:
+  inherit_mode:
+    merge:
+      - AllowedMethods # The rubocop-rails config adds `redirect`
+  AllowedMethods:
+    - redirect_with_vary
+
 # Reason: Enforce modern Ruby style
 # https://docs.rubocop.org/rubocop/cops_style.html#stylehashsyntax
 Style/HashSyntax:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -104,10 +104,12 @@ Rails.application.routes.draw do
     confirmations: 'auth/confirmations',
   }
 
-  get '/users/:username', to: redirect_with_vary('/@%{username}'), constraints: ->(req) { req.format.nil? || req.format.html? }
-  get '/users/:username/following', to: redirect_with_vary('/@%{username}/following'), constraints: ->(req) { req.format.nil? || req.format.html? }
-  get '/users/:username/followers', to: redirect_with_vary('/@%{username}/followers'), constraints: ->(req) { req.format.nil? || req.format.html? }
-  get '/users/:username/statuses/:id', to: redirect_with_vary('/@%{username}/%{id}'), constraints: ->(req) { req.format.nil? || req.format.html? }
+  with_options constraints: ->(req) { req.format.nil? || req.format.html? } do
+    get '/users/:username', to: redirect_with_vary('/@%{username}')
+    get '/users/:username/following', to: redirect_with_vary('/@%{username}/following')
+    get '/users/:username/followers', to: redirect_with_vary('/@%{username}/followers')
+    get '/users/:username/statuses/:id', to: redirect_with_vary('/@%{username}/%{id}')
+  end
 
   get '/authorize_follow', to: redirect { |_, request| "/authorize_interaction?#{request.params.to_query}" }
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -104,12 +104,10 @@ Rails.application.routes.draw do
     confirmations: 'auth/confirmations',
   }
 
-  # rubocop:disable Style/FormatStringToken - those do not go through the usual formatting functions and are not safe to correct
   get '/users/:username', to: redirect_with_vary('/@%{username}'), constraints: ->(req) { req.format.nil? || req.format.html? }
   get '/users/:username/following', to: redirect_with_vary('/@%{username}/following'), constraints: ->(req) { req.format.nil? || req.format.html? }
   get '/users/:username/followers', to: redirect_with_vary('/@%{username}/followers'), constraints: ->(req) { req.format.nil? || req.format.html? }
   get '/users/:username/statuses/:id', to: redirect_with_vary('/@%{username}/%{id}'), constraints: ->(req) { req.format.nil? || req.format.html? }
-  # rubocop:enable Style/FormatStringToken
 
   get '/authorize_follow', to: redirect { |_, request| "/authorize_interaction?#{request.params.to_query}" }
 


### PR DESCRIPTION
We previously had an inline disable here -- but we can inherit the existing config (to preserve the `redirect` from rubocop-rails) and add our own methods to allow here.

Also moved the repeated constraint to a wrapping `with_options` call.