### PR TITLE
Accept extra args that we wont verify in `ap/activity/add_spec`

### DIFF
--- a/spec/lib/activitypub/activity/add_spec.rb
+++ b/spec/lib/activitypub/activity/add_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe ActivityPub::Activity::Add do
         end
 
         it 'fetches the status and pins it' do
-          allow(service_stub).to receive(:call) do |uri, id: true, on_behalf_of: nil, request_id: nil| # rubocop:disable Lint/UnusedBlockArgument
+          allow(service_stub).to receive(:call) do |uri, id: true, on_behalf_of: nil, **|
             expect(uri).to eq 'https://example.com/unknown'
             expect(id).to be true
             expect(on_behalf_of&.following?(sender)).to be true
@@ -64,7 +64,7 @@ RSpec.describe ActivityPub::Activity::Add do
 
       context 'when there is no local follower' do
         it 'tries to fetch the status' do
-          allow(service_stub).to receive(:call) do |uri, id: true, on_behalf_of: nil, request_id: nil| # rubocop:disable Lint/UnusedBlockArgument
+          allow(service_stub).to receive(:call) do |uri, id: true, on_behalf_of: nil, **|
             expect(uri).to eq 'https://example.com/unknown'
             expect(id).to be true
             expect(on_behalf_of).to be_nil


### PR DESCRIPTION
The `request_id` was added here as part of changing method signature - https://github.com/mastodon/mastodon/commit/0c9eac80d887cdf7f1efa582b21006248d2f83eb#diff-f918f3f5d672c7265848bce00b3c7896b0e307d070651eb64d51d178071857a6R51

The rubocop ignore was added in autofix here - https://github.com/mastodon/mastodon/commit/dbc6d7b276aa1ccc085f76caa43cc091311af6b7#diff-f918f3f5d672c7265848bce00b3c7896b0e307d070651eb64d51d178071857a6R51

The way we are doing setup in this spec, this value is not sent in and won't be present in the class, so there's nothing to assert about it.