### PR TITLE
Bump version to 4.3.0-alpha.1

### DIFF
--- a/lib/mastodon/version.rb
+++ b/lib/mastodon/version.rb
@@ -17,7 +17,7 @@ module Mastodon
     end
 
     def default_prerelease
-      'alpha.0'
+      'alpha.1'
     end
 
     def prerelease


### PR DESCRIPTION
To be merged after the security fixes, for the update checker.