### PR TITLE
Fixed the toggle emoji dropdown bug 

### DIFF
--- a/app/javascript/mastodon/features/compose/components/emoji_picker_dropdown.jsx
+++ b/app/javascript/mastodon/features/compose/components/emoji_picker_dropdown.jsx
@@ -164,6 +164,7 @@ class EmojiPickerMenuImpl extends PureComponent {
     intl: PropTypes.object.isRequired,
     skinTone: PropTypes.number.isRequired,
     onSkinTone: PropTypes.func.isRequired,
+    pickerButtonRef: PropTypes.func.isRequired
   };
 
   static defaultProps = {
@@ -178,7 +179,7 @@ class EmojiPickerMenuImpl extends PureComponent {
   };
 
   handleDocumentClick = e => {
-    if (this.node && !this.node.contains(e.target)) {
+    if (this.node && !this.node.contains(e.target) && !this.props.pickerButtonRef.contains(e.target)) {
       this.props.onClose();
     }
   };
@@ -233,6 +234,7 @@ class EmojiPickerMenuImpl extends PureComponent {
       emoji.native = emoji.colons;
     }
     if (!(event.ctrlKey || event.metaKey)) {
+
       this.props.onClose();
     }
     this.props.onPick(emoji);
@@ -407,6 +409,7 @@ class EmojiPickerDropdown extends PureComponent {
                   onSkinTone={onSkinTone}
                   skinTone={skinTone}
                   frequentlyUsedEmojis={frequentlyUsedEmojis}
+                  pickerButtonRef={this.target}
                 />
               </div>
             </div>


### PR DESCRIPTION
The toggle function gets broken by the `handleDocumentClick` in `EmojiPickerMenuImpl`. 

### 🐞 Current behaviour
At present, whenever you press the emoji picker icon, it opens up the emoji picker, but if you want to close it by pressing that same button, it closes and re-opens again.

If you debug it, you will find that the `if (this.state.active)` portion of `EmojiPickerDropdown`'s `onToggle` function is completely broken. This is because the "toggle" behaviour is being disrupted by the `handleDocumentClick` function within the `EmojiPickerMenu` component. 

Because the handleDocumentClick sees the emoji picker button as outside of the dropdown, it will hide it, setting the `active` state in `EmojiPickerDropdown` to `false`, which means when you click it, it will just re-open again because `active` has been set to `false` in the wrong place.

### ✅ Expected behaviour
You should be able to click the emoji picker icon while the drop down is open, and have it close the dropdown. Much like the behaviour you get when you click away from the emoji picker dropdown somewhere else on the page to close it.

`EmojiPickerMenu` needs to recognise that the `emoji-picker-dropdown` `IconButton` isnt a valid case for the `handleDocumentClick` function to trigger, and to leave that up to the `onToggle` function.

### 🛠️ My fix
To fix this, I passed through the `ref` of the emoji picker button in `EmojiPickerDropdown` as the `pickerButtonRef` prop into the `EmojiPickerMenu` component. From there, in the `handleDocumentClick` function, I add to the `if` statement logic to check if the element of `pickerButtonRef` contains anything that the user has clicked on. If it does, I stop it from triggering, as that behaviour needs to be handled by `EmojiPickerDropdown`'s `onToggle` function.

This is in reference to issue #28927 .

Please let me know if I need to change my variable names or anything for it to be a valid contribution. Thanks <3