### PR TITLE
Fix follow recommendations for less used languages

### DIFF
--- a/app/models/account_summary.rb
+++ b/app/models/account_summary.rb
@@ -15,7 +15,7 @@ class AccountSummary < ApplicationRecord
   has_many :follow_recommendation_suppressions, primary_key: :account_id, foreign_key: :account_id, inverse_of: false
 
   scope :safe, -> { where(sensitive: false) }
-  scope :localized, ->(locale) { where(language: locale) }
+  scope :localized, ->(locale) { order(Arel::Nodes::Case.new.when(arel_table[:language].eq(locale)).then(1).else(0).desc) }
   scope :filtered, -> { where.missing(:follow_recommendation_suppressions) }
 
   def self.refresh


### PR DESCRIPTION
Follow recommendations are generated based on the user's language. If the language has no results, no recommendations were returned. This changes it so that language-specific results are returned first, but if there's not enough, it falls back to all languages.