### PR TITLE
Fix report reason selector in moderation interface not unselecting rules when changing category

### DIFF
--- a/app/javascript/mastodon/components/admin/ReportReasonSelector.jsx
+++ b/app/javascript/mastodon/components/admin/ReportReasonSelector.jsx
@@ -124,7 +124,7 @@ class ReportReasonSelector extends PureComponent {
 
     api().put(`/api/v1/admin/reports/${id}`, {
       category,
-      rule_ids,
+      rule_ids: category === 'violation' ? rule_ids : [],
     }).catch(err => {
       console.error(err);
     });


### PR DESCRIPTION
The server code requires rules to be set if and only if the chosen category is `violation`, but the front-end code does not uncheck the values.