### PR TITLE
Fix already-invalid reports failing to resolve

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -47,9 +47,9 @@ class Report < ApplicationRecord
   delegate :local?, to: :account
 
   validates :comment, length: { maximum: 1_000 }, if: :local?
-  validates :rule_ids, absence: true, unless: :violation?
+  validates :rule_ids, absence: true, if: -> { (category_changed? || rule_ids_changed?) && !violation? }
 
-  validate :validate_rule_ids
+  validate :validate_rule_ids, if: -> { (category_changed? || rule_ids_changed?) && violation? }
 
   # entries here need to be kept in sync with the front-end:
   # - app/javascript/mastodon/features/notifications/components/report.jsx
@@ -162,8 +162,6 @@ class Report < ApplicationRecord
   end
 
   def validate_rule_ids
-    return unless violation?
-
     errors.add(:rule_ids, I18n.t('reports.errors.invalid_rules')) unless rules.size == rule_ids&.size
   end
 

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -133,5 +133,18 @@ describe Report do
       report = Fabricate.build(:report, account: remote_account, comment: Faker::Lorem.characters(number: 1001))
       expect(report.valid?).to be true
     end
+
+    it 'is invalid if it references invalid rules' do
+      report = Fabricate.build(:report, category: :violation, rule_ids: [-1])
+      expect(report.valid?).to be false
+      expect(report).to model_have_error_on_field(:rule_ids)
+    end
+
+    it 'is invalid if it references rules but category is not "violation"' do
+      rule = Fabricate(:rule)
+      report = Fabricate.build(:report, category: :spam, rule_ids: rule.id)
+      expect(report.valid?).to be false
+      expect(report).to model_have_error_on_field(:rule_ids)
+    end
   end
 end


### PR DESCRIPTION
We've got a case of a report that had selected rules but a `spam` category, triggering unexpected validation errors on resolve.

I have been unable to figure out how this report has ended up in such a state to begin with, but such validations make sense when the category/rule IDs are changed, not when resolving a report.