### PR TITLE
Move direct serializer usage out of admin view partial

### DIFF
--- a/app/helpers/react_component_helper.rb
+++ b/app/helpers/react_component_helper.rb
@@ -15,9 +15,20 @@ module ReactComponentHelper
     div_tag_with_data(data)
   end
 
+  def serialized_media_attachments(media_attachments)
+    media_attachments.map { |attachment| serialized_attachment(attachment) }
+  end
+
   private
 
   def div_tag_with_data(data)
     content_tag(:div, nil, data: data)
+  end
+
+  def serialized_attachment(attachment)
+    ActiveModelSerializers::SerializableResource.new(
+      attachment,
+      serializer: REST::MediaAttachmentSerializer
+    ).as_json
   end
 end

--- a/app/views/admin/reports/_media_attachments.html.haml
+++ b/app/views/admin/reports/_media_attachments.html.haml
@@ -12,6 +12,6 @@
   = react_component :media_gallery,
                     height: 343,
                     lang: status.language,
-                    media: status.ordered_media_attachments.map { |a| ActiveModelSerializers::SerializableResource.new(a, serializer: REST::MediaAttachmentSerializer).as_json },
+                    media: serialized_media_attachments(status.ordered_media_attachments),
                     sensitive: status.sensitive?,
                     visible: false


### PR DESCRIPTION
Extracted from an "things to update in advance of swapping out serializers library" branch I have going.

This moves the direct usage of the AM:S constants from a view into helper method in existing helper module (which provides the other nearby methods already).