### PR TITLE
Move suggestions account gatherer to private method

### DIFF
--- a/app/controllers/api/v1/suggestions_controller.rb
+++ b/app/controllers/api/v1/suggestions_controller.rb
@@ -6,20 +6,31 @@ class Api::V1::SuggestionsController < Api::BaseController
   before_action -> { doorkeeper_authorize! :read, :'read:accounts' }, only: :index
   before_action -> { doorkeeper_authorize! :write, :'write:accounts' }, except: :index
   before_action :require_user!
-  before_action :set_suggestions
+  before_action :set_suggestions_accounts
 
   def index
-    render json: @suggestions.get(limit_param(DEFAULT_ACCOUNTS_LIMIT), params[:offset].to_i).map(&:account), each_serializer: REST::AccountSerializer
+    render json: @accounts, each_serializer: REST::AccountSerializer
   end
 
   def destroy
-    @suggestions.remove(params[:id])
+    account_suggestions.remove(params[:id])
     render_empty
   end
 
   private
 
-  def set_suggestions
-    @suggestions = AccountSuggestions.new(current_account)
+  def account_suggestions
+    AccountSuggestions.new(current_account)
+  end
+
+  def set_suggestions_accounts
+    @accounts = limited_account_suggestions.map(&:account)
+  end
+
+  def limited_account_suggestions
+    account_suggestions.get(
+      limit_param(DEFAULT_ACCOUNTS_LIMIT),
+      params[:offset].to_i
+    )
   end
 end

--- a/app/controllers/api/v2/suggestions_controller.rb
+++ b/app/controllers/api/v2/suggestions_controller.rb
@@ -9,17 +9,24 @@ class Api::V2::SuggestionsController < Api::BaseController
   before_action :set_suggestions
 
   def index
-    render json: @suggestions.get(limit_param(DEFAULT_ACCOUNTS_LIMIT), params[:offset].to_i), each_serializer: REST::SuggestionSerializer
+    render json: @suggestions, each_serializer: REST::SuggestionSerializer
   end
 
   def destroy
-    @suggestions.remove(params[:id])
+    account_suggestions.remove(params[:id])
     render_empty
   end
 
   private
 
   def set_suggestions
-    @suggestions = AccountSuggestions.new(current_account)
+    @suggestions = account_suggestions.get(
+      limit_param(DEFAULT_ACCOUNTS_LIMIT),
+      params[:offset].to_i
+    )
+  end
+
+  def account_suggestions
+    AccountSuggestions.new(current_account)
   end
 end


### PR DESCRIPTION
In both the api/v1 and api/v1 suggestions controllers, we had a sort of over-complicated `render json: ...` line due to how the accounts (in v1) or suggestsions (in v2) were being gathered. This updates both of them to build up more correctly named (relative to the serializer we are using) instance vars to pass in, and adds the same private method to both for use by the existing destroy action.

_Extracted from serializer update branch_