### PR TITLE
Extract `relationships` helper for api controllers missing one

### DIFF
--- a/app/controllers/api/v1/accounts/statuses_controller.rb
+++ b/app/controllers/api/v1/accounts/statuses_controller.rb
@@ -9,7 +9,7 @@ class Api::V1::Accounts::StatusesController < Api::BaseController
   def index
     cache_if_unauthenticated!
     @statuses = load_statuses
-    render json: @statuses, each_serializer: REST::StatusSerializer, relationships: StatusRelationshipsPresenter.new(@statuses, current_user&.account_id)
+    render json: @statuses, each_serializer: REST::StatusSerializer, relationships: relationships
   end
 
   private
@@ -29,6 +29,10 @@ class Api::V1::Accounts::StatusesController < Api::BaseController
       limit_param(DEFAULT_STATUSES_LIMIT),
       params_slice(:max_id, :since_id, :min_id)
     )
+  end
+
+  def relationships
+    StatusRelationshipsPresenter.new(@statuses, current_user&.account_id)
   end
 
   def pagination_params(core_params)

--- a/app/controllers/api/v1/annual_reports_controller.rb
+++ b/app/controllers/api/v1/annual_reports_controller.rb
@@ -9,12 +9,11 @@ class Api::V1::AnnualReportsController < Api::BaseController
   def index
     with_read_replica do
       @presenter = AnnualReportsPresenter.new(GeneratedAnnualReport.where(account_id: current_account.id).pending)
-      @relationships = StatusRelationshipsPresenter.new(@presenter.statuses, current_account.id)
     end
 
     render json: @presenter,
            serializer: REST::AnnualReportsSerializer,
-           relationships: @relationships
+           relationships: relationships
   end
 
   def read
@@ -23,6 +22,10 @@ class Api::V1::AnnualReportsController < Api::BaseController
   end
 
   private
+
+  def relationships
+    StatusRelationshipsPresenter.new(@presenter.statuses, current_account.id)
+  end
 
   def set_annual_report
     @annual_report = GeneratedAnnualReport.find_by!(account_id: current_account.id, year: params[:id])

--- a/app/controllers/api/v1/bookmarks_controller.rb
+++ b/app/controllers/api/v1/bookmarks_controller.rb
@@ -7,7 +7,7 @@ class Api::V1::BookmarksController < Api::BaseController
 
   def index
     @statuses = load_statuses
-    render json: @statuses, each_serializer: REST::StatusSerializer, relationships: StatusRelationshipsPresenter.new(@statuses, current_user&.account_id)
+    render json: @statuses, each_serializer: REST::StatusSerializer, relationships: relationships
   end
 
   private
@@ -29,6 +29,10 @@ class Api::V1::BookmarksController < Api::BaseController
 
   def account_bookmarks
     current_account.bookmarks
+  end
+
+  def relationships
+    StatusRelationshipsPresenter.new(@statuses, current_user&.account_id)
   end
 
   def next_path

--- a/app/controllers/api/v1/conversations_controller.rb
+++ b/app/controllers/api/v1/conversations_controller.rb
@@ -11,7 +11,7 @@ class Api::V1::ConversationsController < Api::BaseController
 
   def index
     @conversations = paginated_conversations
-    render json: @conversations, each_serializer: REST::ConversationSerializer, relationships: StatusRelationshipsPresenter.new(@conversations.map(&:last_status), current_user&.account_id)
+    render json: @conversations, each_serializer: REST::ConversationSerializer, relationships: relationships
   end
 
   def read
@@ -51,6 +51,10 @@ class Api::V1::ConversationsController < Api::BaseController
                          ]
                        )
                        .to_a_paginated_by_id(limit_param(LIMIT), params_slice(:max_id, :since_id, :min_id))
+  end
+
+  def relationships
+    StatusRelationshipsPresenter.new(@conversations.map(&:last_status), current_user&.account_id)
   end
 
   def next_path

--- a/app/controllers/api/v1/favourites_controller.rb
+++ b/app/controllers/api/v1/favourites_controller.rb
@@ -7,7 +7,7 @@ class Api::V1::FavouritesController < Api::BaseController
 
   def index
     @statuses = load_statuses
-    render json: @statuses, each_serializer: REST::StatusSerializer, relationships: StatusRelationshipsPresenter.new(@statuses, current_user&.account_id)
+    render json: @statuses, each_serializer: REST::StatusSerializer, relationships: relationships
   end
 
   private
@@ -29,6 +29,10 @@ class Api::V1::FavouritesController < Api::BaseController
 
   def account_favourites
     current_account.favourites
+  end
+
+  def relationships
+    StatusRelationshipsPresenter.new(@statuses, current_user&.account_id)
   end
 
   def next_path

--- a/app/controllers/api/v1/featured_tags/suggestions_controller.rb
+++ b/app/controllers/api/v1/featured_tags/suggestions_controller.rb
@@ -6,10 +6,14 @@ class Api::V1::FeaturedTags::SuggestionsController < Api::BaseController
   before_action :set_recently_used_tags, only: :index
 
   def index
-    render json: @recently_used_tags, each_serializer: REST::TagSerializer, relationships: TagRelationshipsPresenter.new(@recently_used_tags, current_user&.account_id)
+    render json: @recently_used_tags, each_serializer: REST::TagSerializer, relationships: relationships
   end
 
   private
+
+  def relationships
+    TagRelationshipsPresenter.new(@recently_used_tags, current_user&.account_id)
+  end
 
   def set_recently_used_tags
     @recently_used_tags = Tag.recently_used(current_account).where.not(id: featured_tag_ids).limit(10)

--- a/app/controllers/api/v1/followed_tags_controller.rb
+++ b/app/controllers/api/v1/followed_tags_controller.rb
@@ -10,7 +10,7 @@ class Api::V1::FollowedTagsController < Api::BaseController
   after_action :insert_pagination_headers
 
   def index
-    render json: @results.map(&:tag), each_serializer: REST::TagSerializer, relationships: TagRelationshipsPresenter.new(@results.map(&:tag), current_user&.account_id)
+    render json: @results.map(&:tag), each_serializer: REST::TagSerializer, relationships: relationships
   end
 
   private
@@ -20,6 +20,10 @@ class Api::V1::FollowedTagsController < Api::BaseController
       limit_param(TAGS_LIMIT),
       params_slice(:max_id, :since_id, :min_id)
     )
+  end
+
+  def relationships
+    TagRelationshipsPresenter.new(@results.map(&:tag), current_user&.account_id)
   end
 
   def next_path

--- a/app/controllers/api/v1/notifications/requests_controller.rb
+++ b/app/controllers/api/v1/notifications/requests_controller.rb
@@ -12,10 +12,9 @@ class Api::V1::Notifications::RequestsController < Api::BaseController
   def index
     with_read_replica do
       @requests = load_requests
-      @relationships = relationships
     end
 
-    render json: @requests, each_serializer: REST::NotificationRequestSerializer, relationships: @relationships
+    render json: @requests, each_serializer: REST::NotificationRequestSerializer, relationships: relationships
   end
 
   def show

--- a/app/controllers/api/v1/statuses/bookmarks_controller.rb
+++ b/app/controllers/api/v1/statuses/bookmarks_controller.rb
@@ -22,8 +22,14 @@ class Api::V1::Statuses::BookmarksController < Api::V1::Statuses::BaseController
 
     bookmark&.destroy!
 
-    render json: @status, serializer: REST::StatusSerializer, relationships: StatusRelationshipsPresenter.new([@status], current_account.id, bookmarks_map: { @status.id => false })
+    render json: @status, serializer: REST::StatusSerializer, relationships: relationships
   rescue Mastodon::NotPermittedError
     not_found
+  end
+
+  private
+
+  def relationships
+    StatusRelationshipsPresenter.new([@status], current_account.id, bookmarks_map: { @status.id => false })
   end
 end

--- a/app/controllers/api/v1/statuses_controller.rb
+++ b/app/controllers/api/v1/statuses_controller.rb
@@ -48,9 +48,8 @@ class Api::V1::StatusesController < Api::BaseController
     loaded_descendants  = cache_collection(descendants_results, Status)
 
     @context = Context.new(ancestors: loaded_ancestors, descendants: loaded_descendants)
-    statuses = [@status] + @context.ancestors + @context.descendants
 
-    render json: @context, serializer: REST::ContextSerializer, relationships: StatusRelationshipsPresenter.new(statuses, current_user&.account_id)
+    render json: @context, serializer: REST::ContextSerializer, relationships: relationships
   end
 
   def create
@@ -164,6 +163,14 @@ class Api::V1::StatusesController < Api::BaseController
 
   def serialized_accounts(accounts)
     ActiveModel::Serializer::CollectionSerializer.new(accounts, serializer: REST::AccountSerializer)
+  end
+
+  def relationships
+    StatusRelationshipsPresenter.new(statuses_family_tree, current_user&.account_id)
+  end
+
+  def statuses_family_tree
+    [@status] + @context.ancestors + @context.descendants
   end
 
   def pagination_params(core_params)

--- a/app/controllers/api/v1/timelines/list_controller.rb
+++ b/app/controllers/api/v1/timelines/list_controller.rb
@@ -11,7 +11,7 @@ class Api::V1::Timelines::ListController < Api::V1::Timelines::BaseController
   def show
     render json: @statuses,
            each_serializer: REST::StatusSerializer,
-           relationships: StatusRelationshipsPresenter.new(@statuses, current_user.account_id)
+           relationships: relationships
   end
 
   private
@@ -39,6 +39,10 @@ class Api::V1::Timelines::ListController < Api::V1::Timelines::BaseController
 
   def list_feed
     ListFeed.new(@list)
+  end
+
+  def relationships
+    StatusRelationshipsPresenter.new(@statuses, current_user.account_id)
   end
 
   def next_path

--- a/app/controllers/api/v1/timelines/public_controller.rb
+++ b/app/controllers/api/v1/timelines/public_controller.rb
@@ -8,7 +8,7 @@ class Api::V1::Timelines::PublicController < Api::V1::Timelines::BaseController
   def show
     cache_if_unauthenticated!
     @statuses = load_statuses
-    render json: @statuses, each_serializer: REST::StatusSerializer, relationships: StatusRelationshipsPresenter.new(@statuses, current_user&.account_id)
+    render json: @statuses, each_serializer: REST::StatusSerializer, relationships: relationships
   end
 
   private
@@ -41,6 +41,10 @@ class Api::V1::Timelines::PublicController < Api::V1::Timelines::BaseController
       remote: truthy_param?(:remote),
       only_media: truthy_param?(:only_media)
     )
+  end
+
+  def relationships
+    StatusRelationshipsPresenter.new(@statuses, current_user&.account_id)
   end
 
   def next_path

--- a/app/controllers/api/v1/timelines/tag_controller.rb
+++ b/app/controllers/api/v1/timelines/tag_controller.rb
@@ -9,7 +9,7 @@ class Api::V1::Timelines::TagController < Api::V1::Timelines::BaseController
   def show
     cache_if_unauthenticated!
     @statuses = load_statuses
-    render json: @statuses, each_serializer: REST::StatusSerializer, relationships: StatusRelationshipsPresenter.new(@statuses, current_user&.account_id)
+    render json: @statuses, each_serializer: REST::StatusSerializer, relationships: relationships
   end
 
   private
@@ -50,6 +50,10 @@ class Api::V1::Timelines::TagController < Api::V1::Timelines::BaseController
       remote: truthy_param?(:remote),
       only_media: truthy_param?(:only_media)
     )
+  end
+
+  def relationships
+    StatusRelationshipsPresenter.new(@statuses, current_user&.account_id)
   end
 
   def next_path

--- a/app/controllers/api/v1/trends/tags_controller.rb
+++ b/app/controllers/api/v1/trends/tags_controller.rb
@@ -9,7 +9,7 @@ class Api::V1::Trends::TagsController < Api::BaseController
 
   def index
     cache_if_unauthenticated!
-    render json: @tags, each_serializer: REST::TagSerializer, relationships: TagRelationshipsPresenter.new(@tags, current_user&.account_id)
+    render json: @tags, each_serializer: REST::TagSerializer, relationships: relationships
   end
 
   private
@@ -28,6 +28,10 @@ class Api::V1::Trends::TagsController < Api::BaseController
 
   def tags_from_trends
     Trends.tags.query.allowed
+  end
+
+  def relationships
+    TagRelationshipsPresenter.new(@tags, current_user&.account_id)
   end
 
   def pagination_params(core_params)


### PR DESCRIPTION
Before this change, there was a mix of api controllers with helper methods and those with inline class/presenter/etc logic to pass values to the `relationships` option of serializers.

This change makes that consistent by adding a method to all the controllers which did not have one (this was the dominant pattern by a slight margin, just not universal).

With the exception of api/v1/statuses which also extracted a local var, these are just straight code copy from inline args to separate methods.

_Extracted from serializer update branch_ -- this one in particular will make an eventual diff against a serializer change easier to review.