### PR TITLE
Add base class for `REST::...` serializer classes

### DIFF
--- a/app/serializers/rest/account_serializer.rb
+++ b/app/serializers/rest/account_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::AccountSerializer < ActiveModel::Serializer
+class REST::AccountSerializer < REST::BaseSerializer
   include RoutingHelper
   include FormattingHelper
 
@@ -30,7 +30,7 @@ class REST::AccountSerializer < ActiveModel::Serializer
     end
   end
 
-  class RoleSerializer < ActiveModel::Serializer
+  class RoleSerializer < REST::BaseSerializer
     attributes :id, :name, :color
 
     def id
@@ -40,7 +40,7 @@ class REST::AccountSerializer < ActiveModel::Serializer
 
   has_many :roles, serializer: RoleSerializer, if: :local?
 
-  class FieldSerializer < ActiveModel::Serializer
+  class FieldSerializer < REST::BaseSerializer
     include FormattingHelper
 
     attributes :name, :value, :verified_at

--- a/app/serializers/rest/admin/account_serializer.rb
+++ b/app/serializers/rest/admin/account_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::Admin::AccountSerializer < ActiveModel::Serializer
+class REST::Admin::AccountSerializer < REST::BaseSerializer
   attributes :id, :username, :domain, :created_at,
              :email, :ip, :confirmed, :suspended,
              :silenced, :sensitized, :disabled, :approved, :locale,

--- a/app/serializers/rest/admin/canonical_email_block_serializer.rb
+++ b/app/serializers/rest/admin/canonical_email_block_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::Admin::CanonicalEmailBlockSerializer < ActiveModel::Serializer
+class REST::Admin::CanonicalEmailBlockSerializer < REST::BaseSerializer
   attributes :id, :canonical_email_hash
 
   def id

--- a/app/serializers/rest/admin/cohort_serializer.rb
+++ b/app/serializers/rest/admin/cohort_serializer.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-class REST::Admin::CohortSerializer < ActiveModel::Serializer
+class REST::Admin::CohortSerializer < REST::BaseSerializer
   attributes :period, :frequency
 
-  class CohortDataSerializer < ActiveModel::Serializer
+  class CohortDataSerializer < REST::BaseSerializer
     attributes :date, :rate, :value
 
     def date

--- a/app/serializers/rest/admin/dimension_serializer.rb
+++ b/app/serializers/rest/admin/dimension_serializer.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-class REST::Admin::DimensionSerializer < ActiveModel::Serializer
+class REST::Admin::DimensionSerializer < REST::BaseSerializer
   attributes :key, :data
 end

--- a/app/serializers/rest/admin/domain_allow_serializer.rb
+++ b/app/serializers/rest/admin/domain_allow_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::Admin::DomainAllowSerializer < ActiveModel::Serializer
+class REST::Admin::DomainAllowSerializer < REST::BaseSerializer
   attributes :id, :domain, :created_at
 
   def id

--- a/app/serializers/rest/admin/domain_block_serializer.rb
+++ b/app/serializers/rest/admin/domain_block_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::Admin::DomainBlockSerializer < ActiveModel::Serializer
+class REST::Admin::DomainBlockSerializer < REST::BaseSerializer
   attributes :id, :domain, :digest, :created_at, :severity,
              :reject_media, :reject_reports,
              :private_comment, :public_comment, :obfuscate

--- a/app/serializers/rest/admin/email_domain_block_serializer.rb
+++ b/app/serializers/rest/admin/email_domain_block_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::Admin::EmailDomainBlockSerializer < ActiveModel::Serializer
+class REST::Admin::EmailDomainBlockSerializer < REST::BaseSerializer
   attributes :id, :domain, :created_at, :history, :allow_with_approval
 
   def id

--- a/app/serializers/rest/admin/existing_domain_block_error_serializer.rb
+++ b/app/serializers/rest/admin/existing_domain_block_error_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::Admin::ExistingDomainBlockErrorSerializer < ActiveModel::Serializer
+class REST::Admin::ExistingDomainBlockErrorSerializer < REST::BaseSerializer
   attributes :error
 
   has_one :existing_domain_block, serializer: REST::Admin::DomainBlockSerializer

--- a/app/serializers/rest/admin/ip_block_serializer.rb
+++ b/app/serializers/rest/admin/ip_block_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::Admin::IpBlockSerializer < ActiveModel::Serializer
+class REST::Admin::IpBlockSerializer < REST::BaseSerializer
   attributes :id, :ip, :severity, :comment,
              :created_at, :expires_at
 

--- a/app/serializers/rest/admin/ip_serializer.rb
+++ b/app/serializers/rest/admin/ip_serializer.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-class REST::Admin::IpSerializer < ActiveModel::Serializer
+class REST::Admin::IpSerializer < REST::BaseSerializer
   attributes :ip, :used_at
 end

--- a/app/serializers/rest/admin/measure_serializer.rb
+++ b/app/serializers/rest/admin/measure_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::Admin::MeasureSerializer < ActiveModel::Serializer
+class REST::Admin::MeasureSerializer < REST::BaseSerializer
   attributes :key, :unit, :total
 
   attribute :human_value, if: -> { object.respond_to?(:value_to_human_value) }

--- a/app/serializers/rest/admin/report_serializer.rb
+++ b/app/serializers/rest/admin/report_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::Admin::ReportSerializer < ActiveModel::Serializer
+class REST::Admin::ReportSerializer < REST::BaseSerializer
   attributes :id, :action_taken, :action_taken_at, :category, :comment,
              :forwarded, :created_at, :updated_at
 

--- a/app/serializers/rest/admin/trends/links/preview_card_provider_serializer.rb
+++ b/app/serializers/rest/admin/trends/links/preview_card_provider_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::Admin::Trends::Links::PreviewCardProviderSerializer < ActiveModel::Serializer
+class REST::Admin::Trends::Links::PreviewCardProviderSerializer < REST::BaseSerializer
   attributes :id, :domain, :trendable, :reviewed_at,
              :requested_review_at, :requires_review
 

--- a/app/serializers/rest/admin/webhook_event_serializer.rb
+++ b/app/serializers/rest/admin/webhook_event_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::Admin::WebhookEventSerializer < ActiveModel::Serializer
+class REST::Admin::WebhookEventSerializer < REST::BaseSerializer
   def self.serializer_for(model, options)
     case model.class.name
     when 'Account'

--- a/app/serializers/rest/announcement_serializer.rb
+++ b/app/serializers/rest/announcement_serializer.rb
@@ -14,10 +14,6 @@ class REST::AnnouncementSerializer < REST::BaseSerializer
   has_many :emojis, serializer: REST::CustomEmojiSerializer
   has_many :reactions, serializer: REST::ReactionSerializer
 
-  def current_user?
-    !current_user.nil?
-  end
-
   def id
     object.id.to_s
   end

--- a/app/serializers/rest/announcement_serializer.rb
+++ b/app/serializers/rest/announcement_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::AnnouncementSerializer < ActiveModel::Serializer
+class REST::AnnouncementSerializer < REST::BaseSerializer
   include FormattingHelper
 
   attributes :id, :content, :starts_at, :ends_at, :all_day,
@@ -34,7 +34,7 @@ class REST::AnnouncementSerializer < ActiveModel::Serializer
     object.reactions(current_user&.account)
   end
 
-  class AccountSerializer < ActiveModel::Serializer
+  class AccountSerializer < REST::BaseSerializer
     attributes :id, :username, :url, :acct
 
     def id

--- a/app/serializers/rest/annual_report_serializer.rb
+++ b/app/serializers/rest/annual_report_serializer.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-class REST::AnnualReportSerializer < ActiveModel::Serializer
+class REST::AnnualReportSerializer < REST::BaseSerializer
   attributes :year, :data, :schema_version
 end

--- a/app/serializers/rest/annual_reports_serializer.rb
+++ b/app/serializers/rest/annual_reports_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::AnnualReportsSerializer < ActiveModel::Serializer
+class REST::AnnualReportsSerializer < REST::BaseSerializer
   has_many :annual_reports, serializer: REST::AnnualReportSerializer
   has_many :accounts, serializer: REST::AccountSerializer
   has_many :statuses, serializer: REST::StatusSerializer

--- a/app/serializers/rest/application_serializer.rb
+++ b/app/serializers/rest/application_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::ApplicationSerializer < ActiveModel::Serializer
+class REST::ApplicationSerializer < REST::BaseSerializer
   attributes :id, :name, :website, :scopes, :redirect_uri,
              :client_id, :client_secret
 

--- a/app/serializers/rest/base_serializer.rb
+++ b/app/serializers/rest/base_serializer.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class REST::BaseSerializer < ActiveModel::Serializer
+end

--- a/app/serializers/rest/base_serializer.rb
+++ b/app/serializers/rest/base_serializer.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 class REST::BaseSerializer < ActiveModel::Serializer
+  def current_user?
+    !current_user.nil?
+  end
 end

--- a/app/serializers/rest/context_serializer.rb
+++ b/app/serializers/rest/context_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::ContextSerializer < ActiveModel::Serializer
+class REST::ContextSerializer < REST::BaseSerializer
   has_many :ancestors,   serializer: REST::StatusSerializer
   has_many :descendants, serializer: REST::StatusSerializer
 end

--- a/app/serializers/rest/conversation_serializer.rb
+++ b/app/serializers/rest/conversation_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::ConversationSerializer < ActiveModel::Serializer
+class REST::ConversationSerializer < REST::BaseSerializer
   attributes :id, :unread
 
   has_many :participant_accounts, key: :accounts, serializer: REST::AccountSerializer

--- a/app/serializers/rest/custom_emoji_serializer.rb
+++ b/app/serializers/rest/custom_emoji_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::CustomEmojiSerializer < ActiveModel::Serializer
+class REST::CustomEmojiSerializer < REST::BaseSerializer
   include RoutingHelper
 
   # Please update `app/javascript/mastodon/api_types/custom_emoji.ts` when making changes to the attributes

--- a/app/serializers/rest/domain_block_serializer.rb
+++ b/app/serializers/rest/domain_block_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::DomainBlockSerializer < ActiveModel::Serializer
+class REST::DomainBlockSerializer < REST::BaseSerializer
   attributes :domain, :digest, :severity, :comment
 
   def domain

--- a/app/serializers/rest/encrypted_message_serializer.rb
+++ b/app/serializers/rest/encrypted_message_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::EncryptedMessageSerializer < ActiveModel::Serializer
+class REST::EncryptedMessageSerializer < REST::BaseSerializer
   attributes :id, :account_id, :device_id,
              :type, :body, :digest, :message_franking,
              :created_at

--- a/app/serializers/rest/extended_description_serializer.rb
+++ b/app/serializers/rest/extended_description_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::ExtendedDescriptionSerializer < ActiveModel::Serializer
+class REST::ExtendedDescriptionSerializer < REST::BaseSerializer
   attributes :updated_at, :content
 
   def updated_at

--- a/app/serializers/rest/familiar_followers_serializer.rb
+++ b/app/serializers/rest/familiar_followers_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::FamiliarFollowersSerializer < ActiveModel::Serializer
+class REST::FamiliarFollowersSerializer < REST::BaseSerializer
   attribute :id
 
   has_many :accounts, serializer: REST::AccountSerializer

--- a/app/serializers/rest/featured_tag_serializer.rb
+++ b/app/serializers/rest/featured_tag_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::FeaturedTagSerializer < ActiveModel::Serializer
+class REST::FeaturedTagSerializer < REST::BaseSerializer
   include RoutingHelper
 
   attributes :id, :name, :url, :statuses_count, :last_status_at

--- a/app/serializers/rest/filter_keyword_serializer.rb
+++ b/app/serializers/rest/filter_keyword_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::FilterKeywordSerializer < ActiveModel::Serializer
+class REST::FilterKeywordSerializer < REST::BaseSerializer
   attributes :id, :keyword, :whole_word
 
   def id

--- a/app/serializers/rest/filter_result_serializer.rb
+++ b/app/serializers/rest/filter_result_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::FilterResultSerializer < ActiveModel::Serializer
+class REST::FilterResultSerializer < REST::BaseSerializer
   belongs_to :filter, serializer: REST::FilterSerializer
   has_many :keyword_matches
   has_many :status_matches

--- a/app/serializers/rest/filter_serializer.rb
+++ b/app/serializers/rest/filter_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::FilterSerializer < ActiveModel::Serializer
+class REST::FilterSerializer < REST::BaseSerializer
   attributes :id, :title, :context, :expires_at, :filter_action
   has_many :keywords, serializer: REST::FilterKeywordSerializer, if: :rules_requested?
   has_many :statuses, serializer: REST::FilterStatusSerializer, if: :rules_requested?

--- a/app/serializers/rest/filter_status_serializer.rb
+++ b/app/serializers/rest/filter_status_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::FilterStatusSerializer < ActiveModel::Serializer
+class REST::FilterStatusSerializer < REST::BaseSerializer
   attributes :id, :status_id
 
   def id

--- a/app/serializers/rest/instance_serializer.rb
+++ b/app/serializers/rest/instance_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-class REST::InstanceSerializer < ActiveModel::Serializer
-  class ContactSerializer < ActiveModel::Serializer
+class REST::InstanceSerializer < REST::BaseSerializer
+  class ContactSerializer < REST::BaseSerializer
     attributes :email
 
     has_one :account, serializer: REST::AccountSerializer

--- a/app/serializers/rest/keys/claim_result_serializer.rb
+++ b/app/serializers/rest/keys/claim_result_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::Keys::ClaimResultSerializer < ActiveModel::Serializer
+class REST::Keys::ClaimResultSerializer < REST::BaseSerializer
   attributes :account_id, :device_id, :key_id, :key, :signature
 
   def account_id

--- a/app/serializers/rest/keys/device_serializer.rb
+++ b/app/serializers/rest/keys/device_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::Keys::DeviceSerializer < ActiveModel::Serializer
+class REST::Keys::DeviceSerializer < REST::BaseSerializer
   attributes :device_id, :name, :identity_key,
              :fingerprint_key
 end

--- a/app/serializers/rest/keys/query_result_serializer.rb
+++ b/app/serializers/rest/keys/query_result_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::Keys::QueryResultSerializer < ActiveModel::Serializer
+class REST::Keys::QueryResultSerializer < REST::BaseSerializer
   attributes :account_id
 
   has_many :devices, serializer: REST::Keys::DeviceSerializer

--- a/app/serializers/rest/language_serializer.rb
+++ b/app/serializers/rest/language_serializer.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-class REST::LanguageSerializer < ActiveModel::Serializer
+class REST::LanguageSerializer < REST::BaseSerializer
   attributes :code, :name
 end

--- a/app/serializers/rest/list_serializer.rb
+++ b/app/serializers/rest/list_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::ListSerializer < ActiveModel::Serializer
+class REST::ListSerializer < REST::BaseSerializer
   attributes :id, :title, :replies_policy, :exclusive
 
   def id

--- a/app/serializers/rest/marker_serializer.rb
+++ b/app/serializers/rest/marker_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::MarkerSerializer < ActiveModel::Serializer
+class REST::MarkerSerializer < REST::BaseSerializer
   # Please update `app/javascript/mastodon/api_types/markers.ts` when making changes to the attributes
 
   attributes :last_read_id, :version, :updated_at

--- a/app/serializers/rest/media_attachment_serializer.rb
+++ b/app/serializers/rest/media_attachment_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::MediaAttachmentSerializer < ActiveModel::Serializer
+class REST::MediaAttachmentSerializer < REST::BaseSerializer
   include RoutingHelper
 
   # Please update `app/javascript/mastodon/api_types/media_attachments.ts` when making changes to the attributes

--- a/app/serializers/rest/notification_serializer.rb
+++ b/app/serializers/rest/notification_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::NotificationSerializer < ActiveModel::Serializer
+class REST::NotificationSerializer < REST::BaseSerializer
   attributes :id, :type, :created_at
 
   belongs_to :from_account, key: :account, serializer: REST::AccountSerializer

--- a/app/serializers/rest/poll_serializer.rb
+++ b/app/serializers/rest/poll_serializer.rb
@@ -28,10 +28,6 @@ class REST::PollSerializer < REST::BaseSerializer
     object.own_votes(current_user.account)
   end
 
-  def current_user?
-    !current_user.nil?
-  end
-
   class OptionSerializer < REST::BaseSerializer
     attributes :title, :votes_count
   end

--- a/app/serializers/rest/poll_serializer.rb
+++ b/app/serializers/rest/poll_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::PollSerializer < ActiveModel::Serializer
+class REST::PollSerializer < REST::BaseSerializer
   # Please update `app/javascript/mastodon/api_types/polls.ts` when making changes to the attributes
 
   attributes :id, :expires_at, :expired,
@@ -32,7 +32,7 @@ class REST::PollSerializer < ActiveModel::Serializer
     !current_user.nil?
   end
 
-  class OptionSerializer < ActiveModel::Serializer
+  class OptionSerializer < REST::BaseSerializer
     attributes :title, :votes_count
   end
 end

--- a/app/serializers/rest/preferences_serializer.rb
+++ b/app/serializers/rest/preferences_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::PreferencesSerializer < ActiveModel::Serializer
+class REST::PreferencesSerializer < REST::BaseSerializer
   attribute :posting_default_privacy, key: 'posting:default:visibility'
   attribute :posting_default_sensitive, key: 'posting:default:sensitive'
   attribute :posting_default_language, key: 'posting:default:language'

--- a/app/serializers/rest/preview_card_serializer.rb
+++ b/app/serializers/rest/preview_card_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::PreviewCardSerializer < ActiveModel::Serializer
+class REST::PreviewCardSerializer < REST::BaseSerializer
   include RoutingHelper
 
   attributes :url, :title, :description, :language, :type,

--- a/app/serializers/rest/privacy_policy_serializer.rb
+++ b/app/serializers/rest/privacy_policy_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::PrivacyPolicySerializer < ActiveModel::Serializer
+class REST::PrivacyPolicySerializer < REST::BaseSerializer
   attributes :updated_at, :content
 
   def updated_at

--- a/app/serializers/rest/reaction_serializer.rb
+++ b/app/serializers/rest/reaction_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::ReactionSerializer < ActiveModel::Serializer
+class REST::ReactionSerializer < REST::BaseSerializer
   include RoutingHelper
 
   attributes :name, :count

--- a/app/serializers/rest/reaction_serializer.rb
+++ b/app/serializers/rest/reaction_serializer.rb
@@ -13,10 +13,6 @@ class REST::ReactionSerializer < REST::BaseSerializer
     object.respond_to?(:count) ? object.count : 0
   end
 
-  def current_user?
-    !current_user.nil?
-  end
-
   def custom_emoji?
     object.custom_emoji.present?
   end

--- a/app/serializers/rest/relationship_serializer.rb
+++ b/app/serializers/rest/relationship_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::RelationshipSerializer < ActiveModel::Serializer
+class REST::RelationshipSerializer < REST::BaseSerializer
   # Please update `app/javascript/mastodon/api_types/relationships.ts` when making changes to the attributes
 
   attributes :id, :following, :showing_reblogs, :notifying, :languages, :followed_by,

--- a/app/serializers/rest/report_serializer.rb
+++ b/app/serializers/rest/report_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::ReportSerializer < ActiveModel::Serializer
+class REST::ReportSerializer < REST::BaseSerializer
   attributes :id, :action_taken, :action_taken_at, :category, :comment,
              :forwarded, :created_at, :status_ids, :rule_ids
 

--- a/app/serializers/rest/role_serializer.rb
+++ b/app/serializers/rest/role_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::RoleSerializer < ActiveModel::Serializer
+class REST::RoleSerializer < REST::BaseSerializer
   attributes :id, :name, :permissions, :color, :highlighted
 
   def id

--- a/app/serializers/rest/rule_serializer.rb
+++ b/app/serializers/rest/rule_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::RuleSerializer < ActiveModel::Serializer
+class REST::RuleSerializer < REST::BaseSerializer
   attributes :id, :text, :hint
 
   def id

--- a/app/serializers/rest/scheduled_status_serializer.rb
+++ b/app/serializers/rest/scheduled_status_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::ScheduledStatusSerializer < ActiveModel::Serializer
+class REST::ScheduledStatusSerializer < REST::BaseSerializer
   attributes :id, :scheduled_at, :params
 
   has_many :media_attachments, serializer: REST::MediaAttachmentSerializer

--- a/app/serializers/rest/search_serializer.rb
+++ b/app/serializers/rest/search_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::SearchSerializer < ActiveModel::Serializer
+class REST::SearchSerializer < REST::BaseSerializer
   has_many :accounts, serializer: REST::AccountSerializer
   has_many :statuses, serializer: REST::StatusSerializer
   has_many :hashtags, serializer: REST::TagSerializer

--- a/app/serializers/rest/status_edit_serializer.rb
+++ b/app/serializers/rest/status_edit_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::StatusEditSerializer < ActiveModel::Serializer
+class REST::StatusEditSerializer < REST::BaseSerializer
   include FormattingHelper
 
   has_one :account, serializer: REST::AccountSerializer

--- a/app/serializers/rest/status_serializer.rb
+++ b/app/serializers/rest/status_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::StatusSerializer < ActiveModel::Serializer
+class REST::StatusSerializer < REST::BaseSerializer
   include FormattingHelper
 
   # Please update `app/javascript/mastodon/api_types/statuses.ts` when making changes to the attributes
@@ -160,7 +160,7 @@ class REST::StatusSerializer < ActiveModel::Serializer
     instance_options && instance_options[:relationships]
   end
 
-  class ApplicationSerializer < ActiveModel::Serializer
+  class ApplicationSerializer < REST::BaseSerializer
     attributes :name, :website
 
     def website
@@ -168,7 +168,7 @@ class REST::StatusSerializer < ActiveModel::Serializer
     end
   end
 
-  class MentionSerializer < ActiveModel::Serializer
+  class MentionSerializer < REST::BaseSerializer
     attributes :id, :username, :url, :acct
 
     def id
@@ -188,7 +188,7 @@ class REST::StatusSerializer < ActiveModel::Serializer
     end
   end
 
-  class TagSerializer < ActiveModel::Serializer
+  class TagSerializer < REST::BaseSerializer
     include RoutingHelper
 
     attributes :name, :url

--- a/app/serializers/rest/status_serializer.rb
+++ b/app/serializers/rest/status_serializer.rb
@@ -44,10 +44,6 @@ class REST::StatusSerializer < REST::BaseSerializer
     object.in_reply_to_account_id&.to_s
   end
 
-  def current_user?
-    !current_user.nil?
-  end
-
   def show_application?
     object.account.user_shows_application? || (current_user? && current_user.account_id == object.account_id)
   end

--- a/app/serializers/rest/status_source_serializer.rb
+++ b/app/serializers/rest/status_source_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::StatusSourceSerializer < ActiveModel::Serializer
+class REST::StatusSourceSerializer < REST::BaseSerializer
   attributes :id, :text, :spoiler_text
 
   def id

--- a/app/serializers/rest/suggestion_serializer.rb
+++ b/app/serializers/rest/suggestion_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::SuggestionSerializer < ActiveModel::Serializer
+class REST::SuggestionSerializer < REST::BaseSerializer
   attributes :source, :sources
 
   has_one :account, serializer: REST::AccountSerializer

--- a/app/serializers/rest/tag_serializer.rb
+++ b/app/serializers/rest/tag_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::TagSerializer < ActiveModel::Serializer
+class REST::TagSerializer < REST::BaseSerializer
   include RoutingHelper
 
   attributes :name, :url, :history

--- a/app/serializers/rest/tag_serializer.rb
+++ b/app/serializers/rest/tag_serializer.rb
@@ -22,8 +22,4 @@ class REST::TagSerializer < REST::BaseSerializer
       TagFollow.exists?(tag_id: object.id, account_id: current_user.account_id)
     end
   end
-
-  def current_user?
-    !current_user.nil?
-  end
 end

--- a/app/serializers/rest/translation_serializer.rb
+++ b/app/serializers/rest/translation_serializer.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-class REST::TranslationSerializer < ActiveModel::Serializer
+class REST::TranslationSerializer < REST::BaseSerializer
   attributes :detected_source_language, :language, :provider, :spoiler_text, :content
 
-  class PollSerializer < ActiveModel::Serializer
+  class PollSerializer < REST::BaseSerializer
     attribute :id
     has_many :options
 
@@ -15,14 +15,14 @@ class REST::TranslationSerializer < ActiveModel::Serializer
       object.poll_options
     end
 
-    class OptionSerializer < ActiveModel::Serializer
+    class OptionSerializer < REST::BaseSerializer
       attributes :title
     end
   end
 
   has_one :poll, serializer: PollSerializer
 
-  class MediaAttachmentSerializer < ActiveModel::Serializer
+  class MediaAttachmentSerializer < REST::BaseSerializer
     attributes :id, :description
 
     def id

--- a/app/serializers/rest/v1/filter_serializer.rb
+++ b/app/serializers/rest/v1/filter_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::V1::FilterSerializer < ActiveModel::Serializer
+class REST::V1::FilterSerializer < REST::BaseSerializer
   attributes :id, :phrase, :context, :whole_word, :expires_at,
              :irreversible
 

--- a/app/serializers/rest/v1/instance_serializer.rb
+++ b/app/serializers/rest/v1/instance_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::V1::InstanceSerializer < ActiveModel::Serializer
+class REST::V1::InstanceSerializer < REST::BaseSerializer
   include RoutingHelper
 
   attributes :uri, :title, :short_description, :description, :email,

--- a/app/serializers/rest/web_push_subscription_serializer.rb
+++ b/app/serializers/rest/web_push_subscription_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class REST::WebPushSubscriptionSerializer < ActiveModel::Serializer
+class REST::WebPushSubscriptionSerializer < REST::BaseSerializer
   attributes :id, :endpoint, :alerts, :server_key, :policy
 
   def alerts


### PR DESCRIPTION
_Extracted from serializer update branch_

This one is aimed very narrowly at making an eventual serializers-change diff easier to review, since all these class names would change. There is some benefit ahead of that in the consolidation (note the current_user method in the base class) ... but its mainly for a pre-serializer-swap-review benefit.