### PR TITLE
Update artifact preservation to use `save_path` value

### DIFF
--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -224,7 +224,7 @@ jobs:
         if: failure()
         with:
           name: e2e-screenshots
-          path: tmp/screenshots/
+          path: tmp/capybara/
 
   test-search:
     name: Elastic Search integration testing
@@ -328,4 +328,4 @@ jobs:
         if: failure()
         with:
           name: test-search-screenshots
-          path: tmp/screenshots/
+          path: tmp/capybara/


### PR DESCRIPTION
This is currently attempting to upload an empty dir. Instead, if there are capybara screenshots available, upload those.