### PR TITLE
Update `codedoc/codecov-action` to v4

### DIFF
--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -139,7 +139,7 @@ jobs:
 
       - name: Upload coverage reports to Codecov
         if: matrix.ruby-version == '.ruby-version'
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           files: coverage/lcov/mastodon.lcov
 


### PR DESCRIPTION
Same change as earlier ones -- support node 20 due to GH actions deprecation notice.