### PR TITLE
Configure selenium to use Chrome version 120

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -14,6 +14,7 @@ Capybara.register_driver :headless_chrome do |app|
   options = Selenium::WebDriver::Chrome::Options.new
   options.add_argument '--headless=new'
   options.add_argument '--window-size=1680,1050'
+  options.browser_version = '120'
 
   Capybara::Selenium::Driver.new(
     app,


### PR DESCRIPTION
We've had a series of recently failing system specs, which seem to be failing intermittently. Example: https://github.com/mastodon/mastodon/actions/runs/7702475975/job/20990932105

The failures are always one of the two spec/system/new_statuses_spec examples.

I did some digging and what seems to be happening is that the browser window is losing its configured default size during the spec run, resizing to be smaller, and so the spec fails because it can't find the element on the screen that it's looking for due to responsive design at smaller size. We could probably "fix" this by making the spec work at the smaller size, but that seems silly.

I'm not sure on exact cause. Maybe relevant changes:

- The github running image used on CI did recently update the version of chrome installed by default. Notes: https://github.com/actions/runner-images/commit/726bf03613d53e12f82ec04e35a01011e6181eb9
- We updated capybara earlier today, but the failures pre-date this. The capybara release DID change the default chrome settings to a new `--headless=new` style in the release, but we were already using that style in our own config.
- We updated selenium-webdriver on 1/24 - https://github.com/mastodon/mastodon/pull/28858 - this release did include changes related to both a) interacting over CDP with chrome 121, b) headless mode with chrome 120 -- https://github.com/SeleniumHQ/selenium/blob/trunk/rb/CHANGES -- and it looks like the failures started after this

Unfortunately the "we updated selenium" and "GH runner image updated chrome" changes were near each other, and both right before our failures started. Random things maybe related:

- GH version runner changes - https://github.com/actions/runner-images/commit/726bf03613d53e12f82ec04e35a01011e6181eb9
- Failing CI run on my fork with downloadable artifact links to show the diff images - https://github.com/mjankowski/mastodon/actions/runs/7731317263/job/21078747450
- Similar capybara issue (similar only in that its related to headless setting) - https://github.com/teamcapybara/capybara/issues/2742 - included here on off chance that whatever conversation they have there winds up being relevant.
-  Selenium discussion of support old/new headless - https://github.com/SeleniumHQ/selenium/pull/13271

I have not been able to reproduce this locally at all, and only sometimes on CI runs. That said, I did identify:

- When I downgraded selenium-webdriver (but left chrome at 121), I was able to produce a failure. This tells me its more chrome and less our selenium upgrade.
- I have NOT been able to produce a failure with chrome 120, with either selenium version. Doesn't mean it won't happen, just that I couldn't do it in many runs.

Because of that, my proposed short term fix in this PR is to set an exact version of chrome in the capybara setup. The correct long term solution is probably to monitor selenium/capybara/chromedriver and see if this gets identified/fixed by those teams, then re-update things accordingly.
