### PR TITLE
Remove CLI exclusions for `Metrics/AbcSize` & `Metrics/CyclomaticComplexity`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -69,18 +69,6 @@ Metrics/ModuleLength:
 
 ## End Disable Metrics/*Length cops
 
-# Reason: Currently disabled in .rubocop_todo.yml
-# https://docs.rubocop.org/rubocop/cops_metrics.html#metricsabcsize
-Metrics/AbcSize:
-  Exclude:
-    - 'lib/mastodon/cli/*.rb'
-
-# Reason: Currently disabled in .rubocop_todo.yml
-# https://docs.rubocop.org/rubocop/cops_metrics.html#metricscyclomaticcomplexity
-Metrics/CyclomaticComplexity:
-  Exclude:
-    - lib/mastodon/cli/*.rb
-
 # Reason:
 # https://docs.rubocop.org/rubocop/cops_metrics.html#metricsparameterlists
 Metrics/ParameterLists:


### PR DESCRIPTION
I believe this will fail the lint right now, but there are two open PRs...

- https://github.com/mastodon/mastodon/pull/28028
- https://github.com/mastodon/mastodon/pull/28369

...which will get them very close. For the domains one, I have follow-on PR which will get it all the way there. For media, it's a much larger diff, but we can also get that one.

Going to leave this open as draft and rebase it as those are merged in, hopefully removing these exclusions once we get the last few things there.