### PR TITLE
Add missing action logging to `api/v1/admin/reports#update`

### DIFF
--- a/app/controllers/api/v1/admin/reports_controller.rb
+++ b/app/controllers/api/v1/admin/reports_controller.rb
@@ -35,6 +35,7 @@ class Api::V1::Admin::ReportsController < Api::BaseController
   def update
     authorize @report, :update?
     @report.update!(report_params)
+    log_action :update, @report
     render json: @report, serializer: REST::Admin::ReportSerializer
   end
 

--- a/spec/controllers/admin/reports_controller_spec.rb
+++ b/spec/controllers/admin/reports_controller_spec.rb
@@ -58,6 +58,7 @@ describe Admin::ReportsController do
       report.reload
       expect(report.action_taken_by_account).to eq user.account
       expect(report.action_taken?).to be true
+      expect(last_action_log.target).to eq(report)
     end
   end
 
@@ -70,6 +71,7 @@ describe Admin::ReportsController do
       report.reload
       expect(report.action_taken_by_account).to be_nil
       expect(report.action_taken?).to be false
+      expect(last_action_log.target).to eq(report)
     end
   end
 
@@ -81,6 +83,7 @@ describe Admin::ReportsController do
       expect(response).to redirect_to(admin_report_path(report))
       report.reload
       expect(report.assigned_account).to eq user.account
+      expect(last_action_log.target).to eq(report)
     end
   end
 
@@ -92,6 +95,13 @@ describe Admin::ReportsController do
       expect(response).to redirect_to(admin_report_path(report))
       report.reload
       expect(report.assigned_account).to be_nil
+      expect(last_action_log.target).to eq(report)
     end
+  end
+
+  private
+
+  def last_action_log
+    Admin::ActionLog.last
   end
 end

--- a/spec/requests/api/v1/admin/reports_spec.rb
+++ b/spec/requests/api/v1/admin/reports_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe 'Reports' do
     it 'updates the report category', :aggregate_failures do
       expect { subject }
         .to change { report.reload.category }.from('other').to('spam')
-        .and change(Admin::ActionLog, :count).by(1)
+        .and create_an_action_log
 
       expect(response).to have_http_status(200)
 
@@ -188,7 +188,7 @@ RSpec.describe 'Reports' do
     it 'marks report as resolved', :aggregate_failures do
       expect { subject }
         .to change { report.reload.unresolved? }.from(true).to(false)
-        .and change(Admin::ActionLog, :count).by(1)
+        .and create_an_action_log
       expect(response).to have_http_status(200)
     end
   end
@@ -206,7 +206,7 @@ RSpec.describe 'Reports' do
     it 'marks report as unresolved', :aggregate_failures do
       expect { subject }
         .to change { report.reload.unresolved? }.from(false).to(true)
-        .and change(Admin::ActionLog, :count).by(1)
+        .and create_an_action_log
       expect(response).to have_http_status(200)
     end
   end
@@ -224,7 +224,7 @@ RSpec.describe 'Reports' do
     it 'assigns report to the requesting user', :aggregate_failures do
       expect { subject }
         .to change { report.reload.assigned_account_id }.from(nil).to(user.account.id)
-        .and change(Admin::ActionLog, :count).by(1)
+        .and create_an_action_log
       expect(response).to have_http_status(200)
     end
   end
@@ -242,8 +242,14 @@ RSpec.describe 'Reports' do
     it 'unassigns report from assignee', :aggregate_failures do
       expect { subject }
         .to change { report.reload.assigned_account_id }.from(user.account.id).to(nil)
-        .and change(Admin::ActionLog, :count).by(1)
+        .and create_an_action_log
       expect(response).to have_http_status(200)
     end
+  end
+
+  private
+
+  def create_an_action_log
+    change(Admin::ActionLog, :count).by(1)
   end
 end

--- a/spec/requests/api/v1/admin/reports_spec.rb
+++ b/spec/requests/api/v1/admin/reports_spec.rb
@@ -151,7 +151,9 @@ RSpec.describe 'Reports' do
     let(:params)  { { category: 'spam' } }
 
     it 'updates the report category', :aggregate_failures do
-      expect { subject }.to change { report.reload.category }.from('other').to('spam')
+      expect { subject }
+        .to change { report.reload.category }.from('other').to('spam')
+        .and change(Admin::ActionLog, :count).by(1)
 
       expect(response).to have_http_status(200)
 

--- a/spec/requests/api/v1/admin/reports_spec.rb
+++ b/spec/requests/api/v1/admin/reports_spec.rb
@@ -184,7 +184,9 @@ RSpec.describe 'Reports' do
     it_behaves_like 'forbidden for wrong role', ''
 
     it 'marks report as resolved', :aggregate_failures do
-      expect { subject }.to change { report.reload.unresolved? }.from(true).to(false)
+      expect { subject }
+        .to change { report.reload.unresolved? }.from(true).to(false)
+        .and change(Admin::ActionLog, :count).by(1)
       expect(response).to have_http_status(200)
     end
   end
@@ -200,7 +202,9 @@ RSpec.describe 'Reports' do
     it_behaves_like 'forbidden for wrong role', ''
 
     it 'marks report as unresolved', :aggregate_failures do
-      expect { subject }.to change { report.reload.unresolved? }.from(false).to(true)
+      expect { subject }
+        .to change { report.reload.unresolved? }.from(false).to(true)
+        .and change(Admin::ActionLog, :count).by(1)
       expect(response).to have_http_status(200)
     end
   end
@@ -216,7 +220,9 @@ RSpec.describe 'Reports' do
     it_behaves_like 'forbidden for wrong role', ''
 
     it 'assigns report to the requesting user', :aggregate_failures do
-      expect { subject }.to change { report.reload.assigned_account_id }.from(nil).to(user.account.id)
+      expect { subject }
+        .to change { report.reload.assigned_account_id }.from(nil).to(user.account.id)
+        .and change(Admin::ActionLog, :count).by(1)
       expect(response).to have_http_status(200)
     end
   end
@@ -232,7 +238,9 @@ RSpec.describe 'Reports' do
     it_behaves_like 'forbidden for wrong role', ''
 
     it 'unassigns report from assignee', :aggregate_failures do
-      expect { subject }.to change { report.reload.assigned_account_id }.from(user.account.id).to(nil)
+      expect { subject }
+        .to change { report.reload.assigned_account_id }.from(user.account.id).to(nil)
+        .and change(Admin::ActionLog, :count).by(1)
       expect(response).to have_http_status(200)
     end
   end


### PR DESCRIPTION
A few things here:

- Add coverage for the previous actions in api/v1/admin/reports which were creating logs, to verify they are created
- Add coverage for the non-api admin/reports controller along same line
- Add (initially failing) coverage around the `update` action in api/v1/admin/reports
- Add the `log_action` line to make that last spec pass

@ThisIsMissEm - is that what you were looking at?