### PR TITLE
Remove migration base class switcher from `RailsSettingsMigration`

### DIFF
--- a/db/migrate/20161006213403_rails_settings_migration.rb
+++ b/db/migrate/20161006213403_rails_settings_migration.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 
-MIGRATION_BASE_CLASS = if ActiveRecord::VERSION::MAJOR >= 5
-                         ActiveRecord::Migration[5.0]
-                       else
-                         ActiveRecord::Migration[4.2]
-                       end
-
-class RailsSettingsMigration < MIGRATION_BASE_CLASS
+class RailsSettingsMigration < ActiveRecord::Migration[5.0]
   def self.up
     create_table :settings do |t|
       t.string     :var, null: false


### PR DESCRIPTION
There's not really an explanation where this was added - https://github.com/mastodon/mastodon/commit/06016453bd91882a53e91c11fc80f2c75fd474bb#diff-2f2e70138c9bc8749d6ebafb4ef23dc8b9eaae557c39f4d937296afd3911a68eR1-R7 - my guess would be a desire to (at the time) maybe support multiple rails versions or something.

In any case, at this point in time only the first path will ever be taken, so we can skip this check.