### PR TITLE
Move length value mapping to constant in ids to bigints migration

### DIFF
--- a/db/migrate/20170918125918_ids_to_bigints.rb
+++ b/db/migrate/20170918125918_ids_to_bigints.rb
@@ -7,80 +7,73 @@ class IdsToBigints < ActiveRecord::Migration[5.1]
   include Mastodon::MigrationHelpers
   include Mastodon::MigrationWarning
 
+  TABLE_COLUMN_MAPPING = [
+    [:account_domain_blocks, :account_id],
+    [:account_domain_blocks, :id],
+    [:accounts, :id],
+    [:blocks, :account_id],
+    [:blocks, :id],
+    [:blocks, :target_account_id],
+    [:conversation_mutes, :account_id],
+    [:conversation_mutes, :id],
+    [:domain_blocks, :id],
+    [:favourites, :account_id],
+    [:favourites, :id],
+    [:favourites, :status_id],
+    [:follow_requests, :account_id],
+    [:follow_requests, :id],
+    [:follow_requests, :target_account_id],
+    [:follows, :account_id],
+    [:follows, :id],
+    [:follows, :target_account_id],
+    [:imports, :account_id],
+    [:imports, :id],
+    [:media_attachments, :account_id],
+    [:media_attachments, :id],
+    [:mentions, :account_id],
+    [:mentions, :id],
+    [:mutes, :account_id],
+    [:mutes, :id],
+    [:mutes, :target_account_id],
+    [:notifications, :account_id],
+    [:notifications, :from_account_id],
+    [:notifications, :id],
+    [:oauth_access_grants, :application_id],
+    [:oauth_access_grants, :id],
+    [:oauth_access_grants, :resource_owner_id],
+    [:oauth_access_tokens, :application_id],
+    [:oauth_access_tokens, :id],
+    [:oauth_access_tokens, :resource_owner_id],
+    [:oauth_applications, :id],
+    [:oauth_applications, :owner_id],
+    [:reports, :account_id],
+    [:reports, :action_taken_by_account_id],
+    [:reports, :id],
+    [:reports, :target_account_id],
+    [:session_activations, :access_token_id],
+    [:session_activations, :user_id],
+    [:session_activations, :web_push_subscription_id],
+    [:settings, :id],
+    [:settings, :thing_id],
+    [:statuses, :account_id],
+    [:statuses, :application_id],
+    [:statuses, :in_reply_to_account_id],
+    [:stream_entries, :account_id],
+    [:stream_entries, :id],
+    [:subscriptions, :account_id],
+    [:subscriptions, :id],
+    [:tags, :id],
+    [:users, :account_id],
+    [:users, :id],
+    [:web_settings, :id],
+    [:web_settings, :user_id],
+  ].freeze
+
   disable_ddl_transaction!
 
   def migrate_columns(to_type)
-    included_columns = [
-      [:account_domain_blocks, :account_id],
-      [:account_domain_blocks, :id],
-      [:accounts, :id],
-      [:blocks, :account_id],
-      [:blocks, :id],
-      [:blocks, :target_account_id],
-      [:conversation_mutes, :account_id],
-      [:conversation_mutes, :id],
-      [:domain_blocks, :id],
-      [:favourites, :account_id],
-      [:favourites, :id],
-      [:favourites, :status_id],
-      [:follow_requests, :account_id],
-      [:follow_requests, :id],
-      [:follow_requests, :target_account_id],
-      [:follows, :account_id],
-      [:follows, :id],
-      [:follows, :target_account_id],
-      [:imports, :account_id],
-      [:imports, :id],
-      [:media_attachments, :account_id],
-      [:media_attachments, :id],
-      [:mentions, :account_id],
-      [:mentions, :id],
-      [:mutes, :account_id],
-      [:mutes, :id],
-      [:mutes, :target_account_id],
-      [:notifications, :account_id],
-      [:notifications, :from_account_id],
-      [:notifications, :id],
-      [:oauth_access_grants, :application_id],
-      [:oauth_access_grants, :id],
-      [:oauth_access_grants, :resource_owner_id],
-      [:oauth_access_tokens, :application_id],
-      [:oauth_access_tokens, :id],
-      [:oauth_access_tokens, :resource_owner_id],
-      [:oauth_applications, :id],
-      [:oauth_applications, :owner_id],
-      [:reports, :account_id],
-      [:reports, :action_taken_by_account_id],
-      [:reports, :id],
-      [:reports, :target_account_id],
-      [:session_activations, :access_token_id],
-      [:session_activations, :user_id],
-      [:session_activations, :web_push_subscription_id],
-      [:settings, :id],
-      [:settings, :thing_id],
-      [:statuses, :account_id],
-      [:statuses, :application_id],
-      [:statuses, :in_reply_to_account_id],
-      [:stream_entries, :account_id],
-      [:stream_entries, :id],
-      [:subscriptions, :account_id],
-      [:subscriptions, :id],
-      [:tags, :id],
-      [:users, :account_id],
-      [:users, :id],
-      [:web_settings, :id],
-      [:web_settings, :user_id],
-    ]
-    included_columns << [:deprecated_preview_cards, :id] if table_exists?(:deprecated_preview_cards)
+    display_warning
 
-    migration_duration_warning(<<~EXPLANATION)
-      This migration has some sections that can be safely interrupted
-      and restarted later, and will tell you when those are occurring.
-
-      For more information, see https://github.com/mastodon/mastodon/pull/5088
-    EXPLANATION
-
-    tables = included_columns.map(&:first).uniq
     table_sizes = {}
 
     # Sort tables by their size
@@ -100,6 +93,25 @@ class IdsToBigints < ActiveRecord::Migration[5.1]
 
       change_column_type_concurrently table, column, to_type
       cleanup_concurrent_column_type_change table, column
+    end
+  end
+
+  def display_warning
+    migration_duration_warning(<<~EXPLANATION)
+      This migration has some sections that can be safely interrupted
+      and restarted later, and will tell you when those are occurring.
+
+      For more information, see https://github.com/mastodon/mastodon/pull/5088
+    EXPLANATION
+  end
+
+  def tables
+    included_columns.map(&:first).uniq
+  end
+
+  def included_columns
+    TABLE_COLUMN_MAPPING.dup.tap do |included_columns|
+      included_columns << [:deprecated_preview_cards, :id] if table_exists?(:deprecated_preview_cards)
     end
   end
 


### PR DESCRIPTION
We currently have the `Metrics/MethodLength` cop (and some others) disabled. The default value is 10.

I'd like to re-enable it (just method length to start... we can leave class/module/etc disabled for now) but use something comically high like 60 or 80 or something. There are a few methods bad enough that they would still flag even at those relaxed numbers. Going to attempt to chop a few of those down.

For this one, we have what is essentially a big constant value set up as a local var instead. This pulls it out to constant and then builds what the migration needs in private method.