### PR TITLE
Fix 'focus the compose textarea' shortcut is not working

### DIFF
--- a/app/javascript/mastodon/features/ui/index.jsx
+++ b/app/javascript/mastodon/features/ui/index.jsx
@@ -438,7 +438,7 @@ class UI extends PureComponent {
   handleHotkeyNew = e => {
     e.preventDefault();
 
-    const element = this.node.querySelector('.compose-form__autosuggest-wrapper textarea');
+    const element = this.node.querySelector('.autosuggest-textarea__textarea');
 
     if (element) {
       element.focus();


### PR DESCRIPTION
Due to changes made in #28119, `.compose-form__autosuggest-wrapper` has been removed. As a result, the shortcut key to move to the post input field is not working. This is because we relied on the class name mentioned above to get the input field for the post.

When I read the code, it seems that the input field always has the class name `.autosuggest-textarea__textarea`, so I'll change it to use this to look for the input field.

I know this is not an elegant fix, but it should work.