### PR TITLE
Add read:me OAuth 2.0 scope, allowing more limited access to user data

### DIFF
--- a/app/controllers/api/v1/accounts/credentials_controller.rb
+++ b/app/controllers/api/v1/accounts/credentials_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Api::V1::Accounts::CredentialsController < Api::BaseController
-  before_action -> { doorkeeper_authorize! :read, :'read:accounts' }, except: [:update]
+  before_action -> { doorkeeper_authorize! :read, :'read:accounts', :'read:me' }, except: [:update]
   before_action -> { doorkeeper_authorize! :write, :'write:accounts' }, only: [:update]
   before_action :require_user!
 

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -89,6 +89,7 @@ Doorkeeper.configure do
                   :'write:reports',
                   :'write:statuses',
                   :read,
+                  :'read:me',
                   :'read:accounts',
                   :'read:blocks',
                   :'read:bookmarks',

--- a/config/locales/doorkeeper.en.yml
+++ b/config/locales/doorkeeper.en.yml
@@ -174,6 +174,7 @@ en:
       read:filters: see your filters
       read:follows: see your follows
       read:lists: see your lists
+      read:me: read only your account's basic information
       read:mutes: see your mutes
       read:notifications: see your notifications
       read:reports: see your reports

--- a/spec/requests/api/v1/accounts/credentials_spec.rb
+++ b/spec/requests/api/v1/accounts/credentials_spec.rb
@@ -28,6 +28,20 @@ RSpec.describe 'credentials API' do
         locked: true,
       })
     end
+
+    describe 'allows the read:me scope' do
+      let(:scopes) { 'read:me' }
+
+      it 'returns the response successfully' do
+        subject
+
+        expect(response).to have_http_status(200)
+
+        expect(body_as_json).to include({
+          locked: true,
+        })
+      end
+    end
   end
 
   describe 'PATCH /api/v1/accounts/update_credentials' do


### PR DESCRIPTION
This allows applications to request a much more limited scope of information about the current user than that which the scopes of `read` or `read:accounts` would give.

**NOTE:** We don't currently allow `GET /api/v1/accounts/:id` where `:id` is the current users' `id`, since this would require asserting permissions in the `AccountsController#show` method.

My thinking here is to land this in 4.3, and then in 4.4, we can make that the default OAuth 2.0 scope, so by default applications only get access to `GET /api/v1/accounts/verify_credentials` nothing more.