### PR TITLE
Remove `http_extensions` (upstream support added)

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -50,7 +50,6 @@ require_relative '../lib/rails/engine_extensions'
 require_relative '../lib/active_record/database_tasks_extensions'
 require_relative '../lib/active_record/batches'
 require_relative '../lib/simple_navigation/item_extensions'
-require_relative '../lib/http_extensions'
 
 Dotenv::Railtie.load
 

--- a/lib/http_extensions.rb
+++ b/lib/http_extensions.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-# Monkey patching until https://github.com/httprb/http/pull/757 is merged
-unless HTTP::Request::METHODS.include?(:purge)
-  methods = HTTP::Request::METHODS.dup
-  HTTP::Request.send(:remove_const, :METHODS)
-  HTTP::Request.const_set(:METHODS, methods.push(:purge).freeze)
-end


### PR DESCRIPTION
Depends on https://github.com/mastodon/mastodon/pull/29093 merging first.