### PR TITLE
Update markers API spec for error case

### DIFF
--- a/spec/requests/api/v1/markers_spec.rb
+++ b/spec/requests/api/v1/markers_spec.rb
@@ -52,5 +52,19 @@ RSpec.describe 'API Markers' do
         expect(user.markers.first.last_read_id).to eq 70_120
       end
     end
+
+    context 'when database object becomes stale' do
+      before do
+        allow(Marker).to receive(:transaction).and_raise(ActiveRecord::StaleObjectError)
+        post '/api/v1/markers', headers: headers, params: { home: { last_read_id: '69420' } }
+      end
+
+      it 'returns error json' do
+        expect(response)
+          .to have_http_status(409)
+        expect(body_as_json)
+          .to include(error: /Conflict during update/)
+      end
+    end
   end
 end


### PR DESCRIPTION
I have a separate branch working on how the serializers work in this controller (they are different from most of the other api controllers, something I noticed in my serializers perf branch). Pulling this out ahead of time -- just adds coverage for the errors json path in this api controller.