### PR TITLE
Replace deprecated `Sidekiq::Testing` block style

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -95,8 +95,13 @@ RSpec.configure do |config|
     self.use_transactional_tests = true
   end
 
-  config.around(:each, :sidekiq_inline) do |example|
-    Sidekiq::Testing.inline!(&example)
+  config.around do |example|
+    if example.metadata[:sidekiq_inline] == true
+      Sidekiq::Testing.inline!
+    else
+      Sidekiq::Testing.fake!
+    end
+    example.run
   end
 
   config.before :each, type: :cli do


### PR DESCRIPTION
This style of setting the testing mode has stopped working in 7.x versions, as a side effect of another change which improves the thread safety of the block form of setting the testing mode, but breaks the way we were setting this.

Reference: https://github.com/sidekiq/sidekiq/issues/6072

Extracted from https://github.com/mastodon/mastodon/pull/25988