### PR TITLE
Add Jawi Malay to posting languages

### DIFF
--- a/app/helpers/languages_helper.rb
+++ b/app/helpers/languages_helper.rb
@@ -109,6 +109,7 @@ module LanguagesHelper
     mn: ['Mongolian', 'Монгол хэл'].freeze,
     mr: ['Marathi', 'मराठी'].freeze,
     ms: ['Malay', 'Bahasa Melayu'].freeze,
+    'ms-Arab': ['Jawi Malay', 'بهاس ملايو'].freeze,
     mt: ['Maltese', 'Malti'].freeze,
     my: ['Burmese', 'ဗမာစာ'].freeze,
     na: ['Nauru', 'Ekakairũ Naoero'].freeze,


### PR DESCRIPTION
Requested via Mastodon: https://mastodon.social/@msiapublictransport/111818657390526946

I have chosen "Jawi Malay" as the English name, because I expect that this will be a more likely search term that users would try.

CLDR reference: https://www.unicode.org/cldr/charts/44/summary/ms_Arab.html