### PR TITLE
Reduce expectation count in example from `ProcessAccountService` spec

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -39,7 +39,7 @@ RSpec/ExampleLength:
   Max: 22
 
 RSpec/MultipleExpectations:
-  Max: 8
+  Max: 7
 
 # Configuration parameters: AllowSubject.
 RSpec/MultipleMemoizedHelpers:

--- a/spec/services/activitypub/process_account_service_spec.rb
+++ b/spec/services/activitypub/process_account_service_spec.rb
@@ -21,14 +21,22 @@ RSpec.describe ActivityPub::ProcessAccountService, type: :service do
 
     it 'parses out of attachment' do
       account = subject.call('alice', 'example.com', payload)
-      expect(account.fields).to be_a Array
-      expect(account.fields.size).to eq 2
-      expect(account.fields[0]).to be_a Account::Field
-      expect(account.fields[0].name).to eq 'Pronouns'
-      expect(account.fields[0].value).to eq 'They/them'
-      expect(account.fields[1]).to be_a Account::Field
-      expect(account.fields[1].name).to eq 'Occupation'
-      expect(account.fields[1].value).to eq 'Unit test'
+
+      expect(account.fields)
+        .to be_an(Array)
+        .and have_attributes(size: 2)
+      expect(account.fields.first)
+        .to be_an(Account::Field)
+        .and have_attributes(
+          name: eq('Pronouns'),
+          value: eq('They/them')
+        )
+      expect(account.fields.last)
+        .to be_an(Account::Field)
+        .and have_attributes(
+          name: eq('Occupation'),
+          value: eq('Unit test')
+        )
     end
   end
 


### PR DESCRIPTION
Reduces needed todo value of `RSpec/MultipleExpectations` cop.

This was the only spec requiring this value (default of 1, our override was 8, reduced to 7 in this PR) to be at the level it is.

I feel like I may have previously had this or something like it in another PR and it got lost. I may also have previously attempted to combine into one big example, which we could still do here, but for purposes of this PR, chose to go from 8 down to 3 for now.