### PR TITLE
Reduce request/response round-trips in ap/collections controller spec

### DIFF
--- a/spec/controllers/activitypub/collections_controller_spec.rb
+++ b/spec/controllers/activitypub/collections_controller_spec.rb
@@ -17,10 +17,12 @@ RSpec.describe ActivityPub::CollectionsController do
   end
 
   describe 'GET #show' do
-    context 'when id is "featured"' do
-      context 'without signature' do
-        subject(:response) { get :show, params: { id: 'featured', account_username: account.username } }
+    subject(:response) { get :show, params: { id: id, account_username: account.username } }
 
+    context 'when id is "featured"' do
+      let(:id) { 'featured' }
+
+      context 'without signature' do
         let(:remote_account) { nil }
 
         it 'returns http success and correct media type' do
@@ -131,8 +133,9 @@ RSpec.describe ActivityPub::CollectionsController do
     end
 
     context 'when id is not "featured"' do
+      let(:id) { 'hoge' }
+
       it 'returns http not found' do
-        get :show, params: { id: 'hoge', account_username: account.username }
         expect(response).to have_http_status(404)
       end
     end

--- a/spec/controllers/activitypub/collections_controller_spec.rb
+++ b/spec/controllers/activitypub/collections_controller_spec.rb
@@ -23,11 +23,9 @@ RSpec.describe ActivityPub::CollectionsController do
 
         let(:remote_account) { nil }
 
-        it 'returns http success' do
+        it 'returns http success and correct media type' do
           expect(response).to have_http_status(200)
-        end
 
-        it 'returns application/activity+json' do
           expect(response.media_type).to eq 'application/activity+json'
         end
 
@@ -76,11 +74,8 @@ RSpec.describe ActivityPub::CollectionsController do
             get :show, params: { id: 'featured', account_username: account.username }
           end
 
-          it 'returns http success' do
+          it 'returns http success and correct media type' do
             expect(response).to have_http_status(200)
-          end
-
-          it 'returns application/activity+json' do
             expect(response.media_type).to eq 'application/activity+json'
           end
 
@@ -111,11 +106,8 @@ RSpec.describe ActivityPub::CollectionsController do
               get :show, params: { id: 'featured', account_username: account.username }
             end
 
-            it 'returns http success' do
+            it 'returns http success and correct media type' do
               expect(response).to have_http_status(200)
-            end
-
-            it 'returns application/activity+json' do
               expect(response.media_type).to eq 'application/activity+json'
             end
 
@@ -135,11 +127,8 @@ RSpec.describe ActivityPub::CollectionsController do
               get :show, params: { id: 'featured', account_username: account.username }
             end
 
-            it 'returns http success' do
+            it 'returns http success and correct media type' do
               expect(response).to have_http_status(200)
-            end
-
-            it 'returns application/activity+json' do
               expect(response.media_type).to eq 'application/activity+json'
             end
 

--- a/spec/controllers/activitypub/collections_controller_spec.rb
+++ b/spec/controllers/activitypub/collections_controller_spec.rb
@@ -25,15 +25,15 @@ RSpec.describe ActivityPub::CollectionsController do
 
         it 'returns http success and correct media type' do
           expect(response).to have_http_status(200)
-
           expect(response.media_type).to eq 'application/activity+json'
         end
 
         it_behaves_like 'cacheable response'
 
         it 'returns orderedItems with pinned statuses' do
-          expect(body_as_json[:orderedItems]).to be_an Array
-          expect(body_as_json[:orderedItems].size).to eq 3
+          expect(body_as_json[:orderedItems])
+            .to be_an(Array)
+            .and have_attributes(size: 3)
         end
 
         it 'includes URI of private pinned status' do
@@ -82,8 +82,9 @@ RSpec.describe ActivityPub::CollectionsController do
           it_behaves_like 'cacheable response'
 
           it 'returns orderedItems with pinned statuses' do
-            expect(body_as_json[:orderedItems]).to be_an Array
-            expect(body_as_json[:orderedItems].size).to eq 3
+            expect(body_as_json[:orderedItems])
+              .to be_an(Array)
+              .and have_attributes(size: 3)
           end
 
           it 'includes URI of private pinned status' do
@@ -116,8 +117,9 @@ RSpec.describe ActivityPub::CollectionsController do
             end
 
             it 'returns empty orderedItems' do
-              expect(body_as_json[:orderedItems]).to be_an Array
-              expect(body_as_json[:orderedItems].size).to eq 0
+              expect(body_as_json[:orderedItems])
+                .to be_an(Array)
+                .and have_attributes(size: 0)
             end
           end
 
@@ -137,8 +139,9 @@ RSpec.describe ActivityPub::CollectionsController do
             end
 
             it 'returns empty orderedItems' do
-              expect(body_as_json[:orderedItems]).to be_an Array
-              expect(body_as_json[:orderedItems].size).to eq 0
+              expect(body_as_json[:orderedItems])
+                .to be_an(Array)
+                .and have_attributes(size: 0)
             end
           end
         end

--- a/spec/controllers/activitypub/collections_controller_spec.rb
+++ b/spec/controllers/activitypub/collections_controller_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe ActivityPub::CollectionsController do
       context 'without signature' do
         subject(:response) { get :show, params: { id: 'featured', account_username: account.username } }
 
-        let(:body) { body_as_json }
         let(:remote_account) { nil }
 
         it 'returns http success' do
@@ -35,16 +34,16 @@ RSpec.describe ActivityPub::CollectionsController do
         it_behaves_like 'cacheable response'
 
         it 'returns orderedItems with pinned statuses' do
-          expect(body[:orderedItems]).to be_an Array
-          expect(body[:orderedItems].size).to eq 3
+          expect(body_as_json[:orderedItems]).to be_an Array
+          expect(body_as_json[:orderedItems].size).to eq 3
         end
 
         it 'includes URI of private pinned status' do
-          expect(body[:orderedItems]).to include(ActivityPub::TagManager.instance.uri_for(private_pinned))
+          expect(body_as_json[:orderedItems]).to include(ActivityPub::TagManager.instance.uri_for(private_pinned))
         end
 
         it 'does not include contents of private pinned status' do
-          expect(response.body).to_not include(private_pinned.text)
+          expect(body_as_json).to_not include(private_pinned.text)
         end
 
         context 'when account is permanently suspended' do
@@ -88,18 +87,16 @@ RSpec.describe ActivityPub::CollectionsController do
           it_behaves_like 'cacheable response'
 
           it 'returns orderedItems with pinned statuses' do
-            json = body_as_json
-            expect(json[:orderedItems]).to be_an Array
-            expect(json[:orderedItems].size).to eq 3
+            expect(body_as_json[:orderedItems]).to be_an Array
+            expect(body_as_json[:orderedItems].size).to eq 3
           end
 
           it 'includes URI of private pinned status' do
-            json = body_as_json
-            expect(json[:orderedItems]).to include(ActivityPub::TagManager.instance.uri_for(private_pinned))
+            expect(body_as_json[:orderedItems]).to include(ActivityPub::TagManager.instance.uri_for(private_pinned))
           end
 
           it 'does not include contents of private pinned status' do
-            expect(response.body).to_not include(private_pinned.text)
+            expect(body_as_json).to_not include(private_pinned.text)
           end
         end
 
@@ -127,9 +124,8 @@ RSpec.describe ActivityPub::CollectionsController do
             end
 
             it 'returns empty orderedItems' do
-              json = body_as_json
-              expect(json[:orderedItems]).to be_an Array
-              expect(json[:orderedItems].size).to eq 0
+              expect(body_as_json[:orderedItems]).to be_an Array
+              expect(body_as_json[:orderedItems].size).to eq 0
             end
           end
 
@@ -152,9 +148,8 @@ RSpec.describe ActivityPub::CollectionsController do
             end
 
             it 'returns empty orderedItems' do
-              json = body_as_json
-              expect(json[:orderedItems]).to be_an Array
-              expect(json[:orderedItems].size).to eq 0
+              expect(body_as_json[:orderedItems]).to be_an Array
+              expect(body_as_json[:orderedItems].size).to eq 0
             end
           end
         end

--- a/spec/controllers/activitypub/collections_controller_spec.rb
+++ b/spec/controllers/activitypub/collections_controller_spec.rb
@@ -95,12 +95,9 @@ RSpec.describe ActivityPub::CollectionsController do
               get :show, params: { id: 'featured', account_username: account.username }
             end
 
-            it 'returns http success and correct media type' do
+            it 'returns http success and correct media type and cache headers' do
               expect(response).to have_http_status(200)
               expect(response.media_type).to eq 'application/activity+json'
-            end
-
-            it 'returns private Cache-Control header' do
               expect(response.headers['Cache-Control']).to include 'private'
             end
 
@@ -117,12 +114,9 @@ RSpec.describe ActivityPub::CollectionsController do
               get :show, params: { id: 'featured', account_username: account.username }
             end
 
-            it 'returns http success and correct media type' do
+            it 'returns http success and correct media type and cache headers' do
               expect(response).to have_http_status(200)
               expect(response.media_type).to eq 'application/activity+json'
-            end
-
-            it 'returns private Cache-Control header' do
               expect(response.headers['Cache-Control']).to include 'private'
             end
 

--- a/spec/controllers/activitypub/collections_controller_spec.rb
+++ b/spec/controllers/activitypub/collections_controller_spec.rb
@@ -66,10 +66,6 @@ RSpec.describe ActivityPub::CollectionsController do
         let(:remote_account) { Fabricate(:account, domain: 'example.com') }
 
         context 'when getting a featured resource' do
-          before do
-            get :show, params: { id: 'featured', account_username: account.username }
-          end
-
           it 'returns http success and correct media type' do
             expect(response).to have_http_status(200)
             expect(response.media_type).to eq 'application/activity+json'
@@ -94,7 +90,6 @@ RSpec.describe ActivityPub::CollectionsController do
           context 'when signed request account is blocked' do
             before do
               account.block!(remote_account)
-              get :show, params: { id: 'featured', account_username: account.username }
             end
 
             it 'returns http success and correct media type and cache headers' do
@@ -113,7 +108,6 @@ RSpec.describe ActivityPub::CollectionsController do
           context 'when signed request account is domain blocked' do
             before do
               account.block_domain!(remote_account.domain)
-              get :show, params: { id: 'featured', account_username: account.username }
             end
 
             it 'returns http success and correct media type and cache headers' do

--- a/spec/controllers/activitypub/collections_controller_spec.rb
+++ b/spec/controllers/activitypub/collections_controller_spec.rb
@@ -30,18 +30,12 @@ RSpec.describe ActivityPub::CollectionsController do
 
         it_behaves_like 'cacheable response'
 
-        it 'returns orderedItems with pinned statuses' do
+        it 'returns orderedItems with correct items' do
           expect(body_as_json[:orderedItems])
             .to be_an(Array)
             .and have_attributes(size: 3)
-        end
-
-        it 'includes URI of private pinned status' do
-          expect(body_as_json[:orderedItems]).to include(ActivityPub::TagManager.instance.uri_for(private_pinned))
-        end
-
-        it 'does not include contents of private pinned status' do
-          expect(body_as_json).to_not include(private_pinned.text)
+            .and include(ActivityPub::TagManager.instance.uri_for(private_pinned))
+            .and not_include(private_pinned.text)
         end
 
         context 'when account is permanently suspended' do
@@ -81,18 +75,12 @@ RSpec.describe ActivityPub::CollectionsController do
 
           it_behaves_like 'cacheable response'
 
-          it 'returns orderedItems with pinned statuses' do
+          it 'returns orderedItems with expected items' do
             expect(body_as_json[:orderedItems])
               .to be_an(Array)
               .and have_attributes(size: 3)
-          end
-
-          it 'includes URI of private pinned status' do
-            expect(body_as_json[:orderedItems]).to include(ActivityPub::TagManager.instance.uri_for(private_pinned))
-          end
-
-          it 'does not include contents of private pinned status' do
-            expect(body_as_json).to_not include(private_pinned.text)
+              .and include(ActivityPub::TagManager.instance.uri_for(private_pinned))
+              .and not_include(private_pinned.text)
           end
         end
 


### PR DESCRIPTION
The main thing here is to combine assertions about different aspects of the http response into fewer. I chose to keep the http response code, media type, and cache headers checks together, and the json body stuff together.

Other changes:

- Just use body_as_json directly instead of assigning local vars
- Every example had the same request subject being performed - move this to shared subject, and use `id` depending which variation we are checking.