### PR TITLE
Reduce `RSpec/ExampleLength` in CSP request spec

### DIFF
--- a/spec/requests/content_security_policy_spec.rb
+++ b/spec/requests/content_security_policy_spec.rb
@@ -8,28 +8,33 @@ describe 'Content-Security-Policy' do
   it 'sets the expected CSP headers' do
     get '/'
 
-    expect(response.headers)
-      .to include(
-        'Content-Security-Policy' => eq(expected_content_security_policy)
-      )
+    expect(response_csp_headers)
+      .to match_array(expected_csp_headers)
   end
 
-  def expected_content_security_policy
-    <<~CSP.squish
-      base-uri 'none';
-      default-src 'none';
-      frame-ancestors 'none';
-      font-src 'self' https://cb6e6126.ngrok.io;
-      img-src 'self' data: blob: https://cb6e6126.ngrok.io;
-      style-src 'self' https://cb6e6126.ngrok.io 'nonce-ZbA+JmE7+bK8F5qvADZHuQ==';
-      media-src 'self' data: https://cb6e6126.ngrok.io;
-      frame-src 'self' https:;
-      manifest-src 'self' https://cb6e6126.ngrok.io;
-      form-action 'self';
-      child-src 'self' blob: https://cb6e6126.ngrok.io;
-      worker-src 'self' blob: https://cb6e6126.ngrok.io;
-      connect-src 'self' data: blob: https://cb6e6126.ngrok.io ws://cb6e6126.ngrok.io:4000;
+  def response_csp_headers
+    response
+      .headers['Content-Security-Policy']
+      .split(';')
+      .map(&:strip)
+  end
+
+  def expected_csp_headers
+    <<~CSP.split("\n").map(&:strip)
+      base-uri 'none'
+      child-src 'self' blob: https://cb6e6126.ngrok.io
+      connect-src 'self' data: blob: https://cb6e6126.ngrok.io ws://cb6e6126.ngrok.io:4000
+      default-src 'none'
+      font-src 'self' https://cb6e6126.ngrok.io
+      form-action 'self'
+      frame-ancestors 'none'
+      frame-src 'self' https:
+      img-src 'self' data: blob: https://cb6e6126.ngrok.io
+      manifest-src 'self' https://cb6e6126.ngrok.io
+      media-src 'self' data: https://cb6e6126.ngrok.io
       script-src 'self' https://cb6e6126.ngrok.io 'wasm-unsafe-eval'
+      style-src 'self' https://cb6e6126.ngrok.io 'nonce-ZbA+JmE7+bK8F5qvADZHuQ=='
+      worker-src 'self' blob: https://cb6e6126.ngrok.io
     CSP
   end
 end

--- a/spec/requests/content_security_policy_spec.rb
+++ b/spec/requests/content_security_policy_spec.rb
@@ -3,25 +3,33 @@
 require 'rails_helper'
 
 describe 'Content-Security-Policy' do
-  it 'sets the expected CSP headers' do
-    allow(SecureRandom).to receive(:base64).with(16).and_return('ZbA+JmE7+bK8F5qvADZHuQ==')
+  before { allow(SecureRandom).to receive(:base64).with(16).and_return('ZbA+JmE7+bK8F5qvADZHuQ==') }
 
+  it 'sets the expected CSP headers' do
     get '/'
-    expect(response.headers['Content-Security-Policy'].split(';').map(&:strip)).to contain_exactly(
-      "base-uri 'none'",
-      "default-src 'none'",
-      "frame-ancestors 'none'",
-      "font-src 'self' https://cb6e6126.ngrok.io",
-      "img-src 'self' data: blob: https://cb6e6126.ngrok.io",
-      "style-src 'self' https://cb6e6126.ngrok.io 'nonce-ZbA+JmE7+bK8F5qvADZHuQ=='",
-      "media-src 'self' data: https://cb6e6126.ngrok.io",
-      "frame-src 'self' https:",
-      "manifest-src 'self' https://cb6e6126.ngrok.io",
-      "form-action 'self'",
-      "child-src 'self' blob: https://cb6e6126.ngrok.io",
-      "worker-src 'self' blob: https://cb6e6126.ngrok.io",
-      "connect-src 'self' data: blob: https://cb6e6126.ngrok.io ws://cb6e6126.ngrok.io:4000",
-      "script-src 'self' https://cb6e6126.ngrok.io 'wasm-unsafe-eval'"
-    )
+
+    expect(response.headers)
+      .to include(
+        'Content-Security-Policy' => eq(expected_content_security_policy)
+      )
+  end
+
+  def expected_content_security_policy
+    <<~CSP.squish
+      base-uri 'none';
+      default-src 'none';
+      frame-ancestors 'none';
+      font-src 'self' https://cb6e6126.ngrok.io;
+      img-src 'self' data: blob: https://cb6e6126.ngrok.io;
+      style-src 'self' https://cb6e6126.ngrok.io 'nonce-ZbA+JmE7+bK8F5qvADZHuQ==';
+      media-src 'self' data: https://cb6e6126.ngrok.io;
+      frame-src 'self' https:;
+      manifest-src 'self' https://cb6e6126.ngrok.io;
+      form-action 'self';
+      child-src 'self' blob: https://cb6e6126.ngrok.io;
+      worker-src 'self' blob: https://cb6e6126.ngrok.io;
+      connect-src 'self' data: blob: https://cb6e6126.ngrok.io ws://cb6e6126.ngrok.io:4000;
+      script-src 'self' https://cb6e6126.ngrok.io 'wasm-unsafe-eval'
+    CSP
   end
 end


### PR DESCRIPTION
Trying to nudge some of the various `RSpec/*` cops overriden max values down a number or two if we can.

In this one:

- Move the random stub to a before
- Move the expected value to helper method
- Slightly simplify how we are massaging the strings on both sides