### PR TITLE
Use SQL heredoc on long statement lines in migrations

### DIFF
--- a/db/migrate/20170317193015_add_search_index_to_accounts.rb
+++ b/db/migrate/20170317193015_add_search_index_to_accounts.rb
@@ -2,7 +2,17 @@
 
 class AddSearchIndexToAccounts < ActiveRecord::Migration[5.0]
   def up
-    execute 'CREATE INDEX search_index ON accounts USING gin((setweight(to_tsvector(\'simple\', accounts.display_name), \'A\') || setweight(to_tsvector(\'simple\', accounts.username), \'B\') || setweight(to_tsvector(\'simple\', coalesce(accounts.domain, \'\')), \'C\')));'
+    execute <<~SQL.squish
+      CREATE INDEX search_index
+      ON accounts
+      USING gin(
+        (
+          setweight(to_tsvector('simple', accounts.display_name), 'A') ||
+          setweight(to_tsvector('simple', accounts.username), 'B') ||
+          setweight(to_tsvector('simple', coalesce(accounts.domain, '')), 'C')
+        )
+      )
+    SQL
   end
 
   def down

--- a/db/migrate/20210630000137_fix_canonical_email_blocks_foreign_key.rb
+++ b/db/migrate/20210630000137_fix_canonical_email_blocks_foreign_key.rb
@@ -3,13 +3,26 @@
 class FixCanonicalEmailBlocksForeignKey < ActiveRecord::Migration[6.1]
   def up
     safety_assured do
-      execute 'ALTER TABLE canonical_email_blocks DROP CONSTRAINT fk_rails_1ecb262096, ADD CONSTRAINT fk_rails_1ecb262096 FOREIGN KEY (reference_account_id) REFERENCES accounts(id) ON DELETE CASCADE;'
+      execute <<~SQL.squish
+        ALTER TABLE canonical_email_blocks
+          DROP CONSTRAINT fk_rails_1ecb262096,
+          ADD CONSTRAINT fk_rails_1ecb262096
+            FOREIGN KEY (reference_account_id)
+            REFERENCES accounts(id)
+            ON DELETE CASCADE
+      SQL
     end
   end
 
   def down
     safety_assured do
-      execute 'ALTER TABLE canonical_email_blocks DROP CONSTRAINT fk_rails_1ecb262096, ADD CONSTRAINT fk_rails_1ecb262096 FOREIGN KEY (reference_account_id) REFERENCES accounts(id);'
+      execute <<~SQL.squish
+        ALTER TABLE canonical_email_blocks
+          DROP CONSTRAINT fk_rails_1ecb262096,
+          ADD CONSTRAINT fk_rails_1ecb262096
+            FOREIGN KEY (reference_account_id)
+            REFERENCES accounts(id)
+      SQL
     end
   end
 end

--- a/db/migrate/20220309213005_fix_reblog_deleted_at.rb
+++ b/db/migrate/20220309213005_fix_reblog_deleted_at.rb
@@ -4,7 +4,16 @@ class FixReblogDeletedAt < ActiveRecord::Migration[6.1]
   disable_ddl_transaction!
 
   def up
-    safety_assured { execute 'UPDATE statuses s SET deleted_at = r.deleted_at FROM statuses r WHERE s.reblog_of_id = r.id AND r.deleted_at IS NOT NULL' }
+    safety_assured do
+      execute <<~SQL.squish
+        UPDATE statuses s
+        SET deleted_at = r.deleted_at
+        FROM statuses r
+        WHERE
+          s.reblog_of_id = r.id
+          AND r.deleted_at IS NOT NULL
+      SQL
+    end
   end
 
   def down; end


### PR DESCRIPTION
This is some parts readability -- many editors will apply SQL syntax highlighting to these blocks -- and some parts pulled out from separate branch to eventually reduce the LineLength cop configuration lower. This is not exhaustive, just did a first pass at the longest lines.