### PR TITLE
Configure `CountAsOne` value for `RSpec/ExampleLength` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -134,6 +134,11 @@ Rails/UnusedIgnoredColumns:
 Rails/NegateInclude:
   Enabled: false
 
+# Reason: Enforce default limit, but allow some elements to span lines
+# https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecexamplelength
+RSpec/ExampleLength:
+  CountAsOne: ['array', 'heredoc', 'method_call']
+
 # Reason: Deprecated cop, will be removed in 3.0, replaced by SpecFilePathFormat
 # https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecfilepath
 RSpec/FilePath:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -36,7 +36,7 @@ Metrics/PerceivedComplexity:
 
 # Configuration parameters: CountAsOne.
 RSpec/ExampleLength:
-  Max: 22
+  Max: 20 # Override default of 5
 
 RSpec/MultipleExpectations:
   Max: 7


### PR DESCRIPTION
Two changes here:

- Add some "count as one" configuration fo the `RSpec/ExampleLength` cop -- I think this better reflects what we actually want to catch here. A spec which has 20+ lines of actual method calls probably needs some improvement, or to be one-off disabled for the cop. But a spec which has 20+ lines, but only 3-5 methods calls, and the bulk of the lines are coming from stylistic choice to do a multi-line expectation or array or something, are actually fine.
- Given that change, we can drop the current _todo value down to 20.

This also makes the number of "outstanding" violations to work on to further reduce that 20 much more reasonable.