### PR TITLE
Add common `ThreadingHelper` module for specs

### DIFF
--- a/spec/lib/request_pool_spec.rb
+++ b/spec/lib/request_pool_spec.rb
@@ -33,17 +33,13 @@ describe RequestPool do
 
       subject
 
-      threads = Array.new(5) do
-        Thread.new do
-          subject.with('http://example.com') do |http_client|
-            http_client.get('/').flush
-            # Nudge scheduler to yield and exercise the full pool
-            sleep(0.01)
-          end
+      multi_threaded_execution(5) do
+        subject.with('http://example.com') do |http_client|
+          http_client.get('/').flush
+          # Nudge scheduler to yield and exercise the full pool
+          sleep(0.01)
         end
       end
-
-      threads.map(&:join)
 
       expect(subject.size).to be > 1
     end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -1035,18 +1035,9 @@ RSpec.describe Account do
     it 'increments the count in multi-threaded an environment when account_stat is not yet initialized' do
       subject
 
-      increment_by   = 15
-      wait_for_start = true
-
-      threads = Array.new(increment_by) do
-        Thread.new do
-          true while wait_for_start
-          described_class.find(subject.id).increment_count!(:followers_count)
-        end
+      multi_threaded_execution(15) do
+        described_class.find(subject.id).increment_count!(:followers_count)
       end
-
-      wait_for_start = false
-      threads.each(&:join)
 
       expect(subject.reload.followers_count).to eq 15
     end

--- a/spec/models/concerns/account/counters_spec.rb
+++ b/spec/models/concerns/account/counters_spec.rb
@@ -6,6 +6,8 @@ describe Account::Counters do
   let!(:account) { Fabricate(:account) }
 
   describe '#increment_count!' do
+    let(:increment_by) { 15 }
+
     it 'increments the count' do
       expect(account.followers_count).to eq 0
       account.increment_count!(:followers_count)
@@ -13,24 +15,17 @@ describe Account::Counters do
     end
 
     it 'increments the count in multi-threaded an environment' do
-      increment_by   = 15
-      wait_for_start = true
-
-      threads = Array.new(increment_by) do
-        Thread.new do
-          true while wait_for_start
-          account.increment_count!(:statuses_count)
-        end
+      multi_threaded_execution(increment_by) do
+        account.increment_count!(:statuses_count)
       end
-
-      wait_for_start = false
-      threads.each(&:join)
 
       expect(account.statuses_count).to eq increment_by
     end
   end
 
   describe '#decrement_count!' do
+    let(:decrement_by) { 10 }
+
     it 'decrements the count' do
       account.followers_count = 15
       account.save!
@@ -40,21 +35,12 @@ describe Account::Counters do
     end
 
     it 'decrements the count in multi-threaded an environment' do
-      decrement_by   = 10
-      wait_for_start = true
-
       account.statuses_count = 15
       account.save!
 
-      threads = Array.new(decrement_by) do
-        Thread.new do
-          true while wait_for_start
-          account.decrement_count!(:statuses_count)
-        end
+      multi_threaded_execution(decrement_by) do
+        account.decrement_count!(:statuses_count)
       end
-
-      wait_for_start = false
-      threads.each(&:join)
 
       expect(account.statuses_count).to eq 5
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -86,6 +86,7 @@ RSpec.configure do |config|
   config.include ActiveSupport::Testing::TimeHelpers
   config.include Chewy::Rspec::Helpers
   config.include Redisable
+  config.include ThreadingHelpers
   config.include SignedRequestHelpers, type: :request
   config.include CommandLineHelpers, type: :cli
 

--- a/spec/services/resolve_account_service_spec.rb
+++ b/spec/services/resolve_account_service_spec.rb
@@ -219,26 +219,18 @@ RSpec.describe ResolveAccountService, type: :service do
   end
 
   it 'processes one remote account at a time using locks' do
-    wait_for_start = true
     fail_occurred  = false
     return_values  = Concurrent::Array.new
 
-    threads = Array.new(5) do
-      Thread.new do
-        true while wait_for_start
-
-        begin
-          return_values << described_class.new.call('foo@ap.example.com')
-        rescue ActiveRecord::RecordNotUnique
-          fail_occurred = true
-        ensure
-          RedisConfiguration.pool.checkin if Thread.current[:redis]
-        end
+    multi_threaded_execution(5) do
+      begin
+        return_values << described_class.new.call('foo@ap.example.com')
+      rescue ActiveRecord::RecordNotUnique
+        fail_occurred = true
+      ensure
+        RedisConfiguration.pool.checkin if Thread.current[:redis]
       end
     end
-
-    wait_for_start = false
-    threads.each(&:join)
 
     expect(fail_occurred).to be false
     expect(return_values).to_not include(nil)

--- a/spec/support/threading_helpers.rb
+++ b/spec/support/threading_helpers.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module ThreadingHelpers
+  def multi_threaded_execution(thread_count)
+    wait_for_start = true
+
+    threads = Array.new(thread_count) do
+      Thread.new do
+        true while wait_for_start
+        yield
+      end
+    end
+
+    wait_for_start = false
+    threads.each(&:join)
+  end
+end


### PR DESCRIPTION
We have a bunch of specs with this same pattern of building an n-sized array of threads, waiting/joining them, running same code inside, asserting changes after.

This pulls out the thread setup/running portion of that pattern into reusable helper, and updates the relevant specs.