### PR TITLE
Add home feed status method in `api/v1/timelines/home`

### DIFF
--- a/app/controllers/api/v1/timelines/home_controller.rb
+++ b/app/controllers/api/v1/timelines/home_controller.rb
@@ -15,7 +15,7 @@ class Api::V1::Timelines::HomeController < Api::V1::Timelines::BaseController
     render json: @statuses,
            each_serializer: REST::StatusSerializer,
            relationships: @relationships,
-           status: account_home_feed.regenerating? ? 206 : 200
+           status: home_feed_http_status
   end
 
   private
@@ -39,6 +39,10 @@ class Api::V1::Timelines::HomeController < Api::V1::Timelines::BaseController
 
   def account_home_feed
     HomeFeed.new(current_account)
+  end
+
+  def home_feed_http_status
+    account_home_feed.regenerating? ? 206 : 200
   end
 
   def next_path


### PR DESCRIPTION
Another one extracted from serializers perf branch, aimed at reducing eventual diff size of that branch.