### PR TITLE
Normalize serializer usage in `api/v1/markers` controller

### DIFF
--- a/app/controllers/api/v1/markers_controller.rb
+++ b/app/controllers/api/v1/markers_controller.rb
@@ -7,7 +7,9 @@ class Api::V1::MarkersController < Api::BaseController
   before_action :require_user!
 
   def index
-    @markers = current_user_markers
+    with_read_replica do
+      @markers = current_user_markers
+    end
     render json: marker_timeline_presenter, serializer: REST::MarkerTimelineSerializer
   end
 
@@ -25,9 +27,7 @@ class Api::V1::MarkersController < Api::BaseController
   end
 
   def current_user_markers
-    with_read_replica do
-      current_user.markers.where(timeline: Array(params[:timeline]))
-    end
+    current_user.markers.where(timeline: Array(params[:timeline]))
   end
 
   def create_markers_from_params

--- a/app/controllers/api/v1/markers_controller.rb
+++ b/app/controllers/api/v1/markers_controller.rb
@@ -7,38 +7,40 @@ class Api::V1::MarkersController < Api::BaseController
   before_action :require_user!
 
   def index
-    with_read_replica do
-      @markers = current_user.markers.where(timeline: Array(params[:timeline])).index_by(&:timeline)
-    end
-
-    render json: serialize_map(@markers)
+    @markers = current_user_markers
+    render json: marker_timeline_presenter, serializer: REST::MarkerTimelineSerializer
   end
 
   def create
-    Marker.transaction do
-      @markers = {}
-
-      resource_params.each_pair do |timeline, timeline_params|
-        @markers[timeline] = current_user.markers.find_or_create_by(timeline: timeline)
-        @markers[timeline].update!(timeline_params)
-      end
-    end
-
-    render json: serialize_map(@markers)
+    @markers = create_markers_from_params
+    render json: marker_timeline_presenter, serializer: REST::MarkerTimelineSerializer
   rescue ActiveRecord::StaleObjectError
     render json: { error: 'Conflict during update, please try again' }, status: 409
   end
 
   private
 
-  def serialize_map(map)
-    serialized = {}
+  def marker_timeline_presenter
+    MarkerTimelinePresenter.new(@markers)
+  end
 
-    map.each_pair do |key, value|
-      serialized[key] = ActiveModelSerializers::SerializableResource.new(value, serializer: REST::MarkerSerializer).as_json
+  def current_user_markers
+    with_read_replica do
+      current_user.markers.where(timeline: Array(params[:timeline]))
     end
+  end
 
-    Oj.dump(serialized)
+  def create_markers_from_params
+    [].tap do |markers|
+      Marker.transaction do
+        resource_params.each_pair do |timeline, timeline_params|
+          current_user.markers.find_or_create_by(timeline: timeline).tap do |marker|
+            marker.update!(timeline_params)
+            markers << marker
+          end
+        end
+      end
+    end
   end
 
   def resource_params

--- a/app/presenters/marker_timeline_presenter.rb
+++ b/app/presenters/marker_timeline_presenter.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class MarkerTimelinePresenter
+  include ActiveModel::Model
+
+  alias read_attribute_for_serialization send
+
+  attr_reader :markers
+
+  def initialize(markers)
+    @markers = markers
+  end
+
+  Marker::TIMELINES.each do |timeline|
+    define_method timeline.to_sym do
+      markers.find { |marker| marker.timeline == timeline }
+    end
+  end
+
+  def timeline_present?(value)
+    markers.map(&:timeline).include?(value)
+  end
+end

--- a/app/serializers/rest/marker_timeline_serializer.rb
+++ b/app/serializers/rest/marker_timeline_serializer.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class REST::MarkerTimelineSerializer < ActiveModel::Serializer
+  Marker::TIMELINES.each do |timeline|
+    has_one timeline.to_sym,
+            if: -> { timeline_present?(timeline) },
+            serializer: REST::MarkerSerializer
+  end
+
+  delegate :timeline_present?, to: :object
+end


### PR DESCRIPTION
This is not an extraction from the serializers perf branch, but something I noticed while in there. This controller serialization is different than most of the others in how it builds the json response (note the `serialize_map`, replaced in this PR, which builds up things into a hash).

The background here is that the desired API response looks like:

```ruby
{
  "home":{"last_read_id":"123","version":0,"updated_at":"2024-02-06T18:11:38.372Z"},
  "notifications":{"last_read_id":"456","version":0,"updated_at":"2024-02-06T18:11:38.375Z"}
}
```

(One hash, with a key for each timeline, pointing to serialized `Marker` instance)

If we just used the serializer like we do everywhere else (without the `to_index` and `serialize_map`), we'd get something like:

```ruby
[
  {"last_read_id":"123","version":0,"updated_at":"2024-02-06T18:12:59.921Z"},
  {"last_read_id":"456","version":0,"updated_at":"2024-02-06T18:12:59.923Z"}
]
```

(Outer array, two inner hash elements, without timeline keys, but with correct attributes in each)

The change here is to add in a presenter and a serializer for that presenter, such that we can use "normal" serializer calling style at the controller level, and preserve the outer hash style since we are serializing a single item (the presenter). The presenter serializer than knows to create the hash keys for the timelines, and we re-use the existing Marker serializer to build  the attributes.

The spec coverage here is actually pretty good and I did some local logging for verification as well -- but if I'm overlooking something I can add more coverage for whatever cases we don't have first.

I've left the metaprogramming in for this PR, but one thing I considered here, since there are only two possible timeline values (home, notifications), would be to just hard-code those directly into the new presenter and serializer. In the event this number grows in the future we could go back to something like I've started with here, or otherwise generalize it.

