### PR TITLE
Add support for specifying custom CA cert for Elasticsearch

### DIFF
--- a/config/initializers/chewy.rb
+++ b/config/initializers/chewy.rb
@@ -7,6 +7,9 @@ user            = ENV.fetch('ES_USER', nil).presence
 password        = ENV.fetch('ES_PASS', nil).presence
 fallback_prefix = ENV.fetch('REDIS_NAMESPACE', nil).presence
 prefix          = ENV.fetch('ES_PREFIX') { fallback_prefix }
+ca_file         = ENV.fetch('ES_CA_CERT', nil).presence
+
+transport_options = { ssl: { ca_file: ca_file } } if ca_file.present?
 
 Chewy.settings = {
   host: "#{host}:#{port}",
@@ -18,6 +21,7 @@ Chewy.settings = {
   index: {
     number_of_replicas: ['single_node_cluster', nil].include?(ENV['ES_PRESET'].presence) ? 0 : 1,
   },
+  transport_options: transport_options,
 }
 
 # We use our own async strategy even outside the request-response


### PR DESCRIPTION
This is configured through the `ES_CA_CERT` environment variable.