### PR TITLE
Fix compatibility with Redis <6.2

### DIFF
--- a/app/controllers/auth/sessions_controller.rb
+++ b/app/controllers/auth/sessions_controller.rb
@@ -183,7 +183,9 @@ class Auth::SessionsController < Devise::SessionsController
     )
 
     # Only send a notification email every hour at most
-    return if redis.set("2fa_failure_notification:#{user.id}", '1', ex: 1.hour, get: true).present?
+    return if redis.get("2fa_failure_notification:#{user.id}").present?
+
+    redis.set("2fa_failure_notification:#{user.id}", '1', ex: 1.hour)
 
     UserMailer.failed_2fa(user, request.remote_ip, request.user_agent, Time.now.utc).deliver_later!
   end


### PR DESCRIPTION
Note that this leaves the possibility of a race condition in which multiple second-factor authentication attempts are performed at the same time and all triggering a mail. This is relatively improbable, though, and would only result in (limited) spam, it would not allow an attacker to avoid sending the mail.