### PR TITLE
fix: List streaming API URL at documented place

### DIFF
--- a/app/serializers/rest/instance_serializer.rb
+++ b/app/serializers/rest/instance_serializer.rb
@@ -44,7 +44,7 @@ class REST::InstanceSerializer < ActiveModel::Serializer
   def configuration
     {
       urls: {
-        streaming: Rails.configuration.x.streaming_api_base_url,
+        streaming_api: Rails.configuration.x.streaming_api_base_url,
         status: object.status_page_url,
       },
 


### PR DESCRIPTION
https://docs.joinmastodon.org/entities/Instance/#streaming_api notes that this property is called `streaming_api`, not `streaming`.