### PR TITLE
Add `context` and `before` to lengthy tag manager spec examples

### DIFF
--- a/spec/lib/activitypub/tag_manager_spec.rb
+++ b/spec/lib/activitypub/tag_manager_spec.rb
@@ -52,20 +52,27 @@ RSpec.describe ActivityPub::TagManager do
       expect(subject.to(status)).to include(subject.followers_uri_for(mentioned))
     end
 
-    it "returns URIs of mentions for direct silenced author's status only if they are followers or requesting to be" do
-      bob    = Fabricate(:account, username: 'bob')
-      alice  = Fabricate(:account, username: 'alice')
-      foo    = Fabricate(:account)
-      author = Fabricate(:account, username: 'author', silenced: true)
-      status = Fabricate(:status, visibility: :direct, account: author)
-      bob.follow!(author)
-      FollowRequest.create!(account: foo, target_account: author)
-      status.mentions.create(account: alice)
-      status.mentions.create(account: bob)
-      status.mentions.create(account: foo)
-      expect(subject.to(status)).to include(subject.uri_for(bob))
-      expect(subject.to(status)).to include(subject.uri_for(foo))
-      expect(subject.to(status)).to_not include(subject.uri_for(alice))
+    context 'with followers and requested followers' do
+      let!(:bob) { Fabricate(:account, username: 'bob') }
+      let!(:alice) { Fabricate(:account, username: 'alice') }
+      let!(:foo) { Fabricate(:account) }
+      let!(:author) { Fabricate(:account, username: 'author', silenced: true) }
+      let!(:status) { Fabricate(:status, visibility: :direct, account: author) }
+
+      before do
+        bob.follow!(author)
+        FollowRequest.create!(account: foo, target_account: author)
+        status.mentions.create(account: alice)
+        status.mentions.create(account: bob)
+        status.mentions.create(account: foo)
+      end
+
+      it "returns URIs of mentions for direct silenced author's status only if they are followers or requesting to be" do
+        expect(subject.to(status))
+          .to include(subject.uri_for(bob))
+          .and include(subject.uri_for(foo))
+          .and not_include(subject.uri_for(alice))
+      end
     end
   end
 
@@ -97,20 +104,27 @@ RSpec.describe ActivityPub::TagManager do
       expect(subject.cc(status)).to include(subject.uri_for(mentioned))
     end
 
-    it "returns URIs of mentions for silenced author's non-direct status only if they are followers or requesting to be" do
-      bob    = Fabricate(:account, username: 'bob')
-      alice  = Fabricate(:account, username: 'alice')
-      foo    = Fabricate(:account)
-      author = Fabricate(:account, username: 'author', silenced: true)
-      status = Fabricate(:status, visibility: :public, account: author)
-      bob.follow!(author)
-      FollowRequest.create!(account: foo, target_account: author)
-      status.mentions.create(account: alice)
-      status.mentions.create(account: bob)
-      status.mentions.create(account: foo)
-      expect(subject.cc(status)).to include(subject.uri_for(bob))
-      expect(subject.cc(status)).to include(subject.uri_for(foo))
-      expect(subject.cc(status)).to_not include(subject.uri_for(alice))
+    context 'with followers and requested followers' do
+      let!(:bob) { Fabricate(:account, username: 'bob') }
+      let!(:alice) { Fabricate(:account, username: 'alice') }
+      let!(:foo) { Fabricate(:account) }
+      let!(:author) { Fabricate(:account, username: 'author', silenced: true) }
+      let!(:status) { Fabricate(:status, visibility: :public, account: author) }
+
+      before do
+        bob.follow!(author)
+        FollowRequest.create!(account: foo, target_account: author)
+        status.mentions.create(account: alice)
+        status.mentions.create(account: bob)
+        status.mentions.create(account: foo)
+      end
+
+      it "returns URIs of mentions for silenced author's non-direct status only if they are followers or requesting to be" do
+        expect(subject.cc(status))
+          .to include(subject.uri_for(bob))
+          .and include(subject.uri_for(foo))
+          .and not_include(subject.uri_for(alice))
+      end
     end
 
     it 'returns poster of reblogged post, if reblog' do


### PR DESCRIPTION
_Dependency of https://github.com/mastodon/mastodon/pull/29139_