### PR TITLE
Remove unused `without_verify_partial_doubles` config option

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,12 +12,6 @@ RSpec.configure do |config|
 
   config.mock_with :rspec do |mocks|
     mocks.verify_partial_doubles = true
-
-    config.around(:example, :without_verify_partial_doubles) do |example|
-      mocks.verify_partial_doubles = false
-      example.call
-      mocks.verify_partial_doubles = true
-    end
   end
 
   config.before :suite do


### PR DESCRIPTION
Opening as draft because this is contingent on https://github.com/mastodon/mastodon/pull/29132 and https://github.com/mastodon/mastodon/pull/29131

Assuming those merge, will rebase this and convert to ready.