### PR TITLE
Move `RSpec/ExampleLength` out of todo file

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -132,6 +132,7 @@ Rails/NegateInclude:
 # https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecexamplelength
 RSpec/ExampleLength:
   CountAsOne: ['array', 'heredoc', 'method_call']
+  Max: 10 # Override default of 5
 
 # Reason: Deprecated cop, will be removed in 3.0, replaced by SpecFilePathFormat
 # https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecfilepath

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -34,10 +34,6 @@ Metrics/CyclomaticComplexity:
 Metrics/PerceivedComplexity:
   Max: 27
 
-# Configuration parameters: CountAsOne.
-RSpec/ExampleLength:
-  Max: 20 # Override default of 5
-
 RSpec/MultipleExpectations:
   Max: 7
 


### PR DESCRIPTION
With https://github.com/mastodon/mastodon/pull/29115 merged, we have a limited number of these left to work through. This PR moves this value out of todo, and into the main config, with a value relaxed from the default.

Opening as draft because this will fail right now, and requires a few more updates first. Will link back to this issue from the dependencies and rebase this as they are solved, then convert when ready.