### PR TITLE
Use the devise sign_in helper instead of a custom one

### DIFF
--- a/spec/features/profile_spec.rb
+++ b/spec/features/profile_spec.rb
@@ -10,7 +10,7 @@ describe 'Profile' do
   let(:local_domain) { ENV['LOCAL_DOMAIN'] }
 
   before do
-    as_a_logged_in_user
+    sign_in as_a_registered_user
     with_alice_as_local_user
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -81,6 +81,7 @@ RSpec.configure do |config|
   config.include Devise::Test::ControllerHelpers, type: :helper
   config.include Devise::Test::ControllerHelpers, type: :view
   config.include Devise::Test::IntegrationHelpers, type: :feature
+  config.include Devise::Test::IntegrationHelpers, type: :system
   config.include Devise::Test::IntegrationHelpers, type: :request
   config.include Paperclip::Shoulda::Matchers
   config.include ActiveSupport::Testing::TimeHelpers

--- a/spec/support/stories/profile_stories.rb
+++ b/spec/support/stories/profile_stories.rb
@@ -11,14 +11,7 @@ module ProfileStories
     )
 
     Web::Setting.where(user: bob).first_or_initialize(user: bob).update!(data: { introductionVersion: 2018_12_16_044202 }) if finished_onboarding
-  end
-
-  def as_a_logged_in_user
-    as_a_registered_user
-    visit new_user_session_path
-    fill_in 'user_email', with: email
-    fill_in 'user_password', with: password
-    click_on I18n.t('auth.login')
+    @bob
   end
 
   def with_alice_as_local_user

--- a/spec/system/new_statuses_spec.rb
+++ b/spec/system/new_statuses_spec.rb
@@ -13,7 +13,7 @@ describe 'NewStatuses', :sidekiq_inline do
   let(:finished_onboarding) { true }
 
   before do
-    as_a_logged_in_user
+    sign_in as_a_registered_user
     visit root_path
   end
 

--- a/spec/system/ocr_spec.rb
+++ b/spec/system/ocr_spec.rb
@@ -11,7 +11,7 @@ describe 'OCR', :paperclip_processing, :sidekiq_inline do
   let(:finished_onboarding) { true }
 
   before do
-    as_a_logged_in_user
+    sign_in as_a_registered_user
     visit root_path
   end
 

--- a/spec/system/share_entrypoint_spec.rb
+++ b/spec/system/share_entrypoint_spec.rb
@@ -13,7 +13,7 @@ describe 'ShareEntrypoint' do
   let(:finished_onboarding) { true }
 
   before do
-    as_a_logged_in_user
+    sign_in as_a_registered_user
     visit share_path
   end
 


### PR DESCRIPTION
Devise provides a `sign_in` helper to sign users in integration tests, so there's no need to use a custom one.