### PR TITLE
Replace deprecated `dotenv-rails` gem with `dotenv` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'thor', '~> 1.2'
 # For why irb is in the Gemfile, see: https://ruby.social/@st0012/111444685161478182
 gem 'irb', '~> 1.8'
 
-gem 'dotenv-rails', '~> 2.8'
+gem 'dotenv'
 gem 'haml-rails', '~>2.0'
 gem 'pg', '~> 1.5'
 gem 'pghero'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -220,10 +220,7 @@ GEM
     domain_name (0.6.20240107)
     doorkeeper (5.6.9)
       railties (>= 5)
-    dotenv (2.8.1)
-    dotenv-rails (2.8.1)
-      dotenv (= 2.8.1)
-      railties (>= 3.2)
+    dotenv (3.1.0)
     drb (2.2.1)
     ed25519 (1.3.0)
     elasticsearch (7.13.3)
@@ -848,7 +845,7 @@ DEPENDENCIES
   devise_pam_authenticatable2 (~> 9.2)
   discard (~> 1.2)
   doorkeeper (~> 5.6)
-  dotenv-rails (~> 2.8)
+  dotenv
   ed25519 (~> 1.3)
   email_spec
   fabrication (~> 2.30)

--- a/config/application.rb
+++ b/config/application.rb
@@ -52,7 +52,7 @@ require_relative '../lib/active_record/batches'
 require_relative '../lib/simple_navigation/item_extensions'
 require_relative '../lib/http_extensions'
 
-Dotenv::Railtie.load
+Dotenv::Rails.load
 
 Bundler.require(:pam_authentication) if ENV['PAM_ENABLED'] == 'true'
 


### PR DESCRIPTION
This could be done either after or instead of https://github.com/mastodon/mastodon/pull/29171