### PR TITLE
feat(emoji-picker): add emoji preview support

### DIFF
--- a/app/javascript/mastodon/features/compose/components/emoji_picker_dropdown.jsx
+++ b/app/javascript/mastodon/features/compose/components/emoji_picker_dropdown.jsx
@@ -293,7 +293,7 @@ class EmojiPickerMenuImpl extends PureComponent {
           include={categoriesSort}
           recent={frequentlyUsedEmojis}
           skin={skinTone}
-          showPreview={false}
+          showPreview
           showSkinTones={false}
           backgroundImageFn={backgroundImageFn}
           notFound={notFoundFn}

--- a/app/javascript/styles/mastodon/emoji_picker.scss
+++ b/app/javascript/styles/mastodon/emoji_picker.scss
@@ -27,7 +27,6 @@
     border-top-width: 1px;
     border-bottom-left-radius: 5px;
     border-bottom-right-radius: 5px;
-    display: none;
   }
 }
 
@@ -255,5 +254,164 @@
 }
 
 .emoji-mart-preview {
-  display: none;
+  position: relative;
+}
+
+@media only screen and (width <= 499px) {
+  .emoji-mart-preview {
+    width: 100%;
+    height: fit-content;
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+    align-items: center;
+
+    .emoji-mart-preview-emoji,
+    .emoji-mart-preview-data {
+      position: relative;
+      top: unset;
+      transform: unset;
+    }
+
+    .emoji-mart-preview-emoji {
+      left: unset;
+    }
+
+    .emoji-mart-preview-data {
+      position: relative;
+      right: unset;
+      left: unset;
+    }
+  }
+
+  .emoji-mart-title-label {
+    display: none;
+  }
+}
+
+.emoji-mart-preview-emoji,
+.emoji-mart-preview-data,
+.emoji-mart-preview-skins {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.emoji-mart-preview-emoji {
+  left: 12px;
+}
+
+.emoji-mart-preview-data {
+  left: 68px;
+  right: 12px;
+  word-break: break-all;
+}
+
+.emoji-mart-preview-skins {
+  right: 30px;
+  text-align: right;
+}
+
+.emoji-mart-preview-skins.custom {
+  right: 10px;
+  text-align: right;
+}
+
+.emoji-mart-preview-name {
+  font-size: 14px;
+}
+
+.emoji-mart-preview-shortname {
+  font-size: 12px;
+}
+
+.emoji-mart-preview-shortname + .emoji-mart-preview-shortname,
+.emoji-mart-preview-shortname + .emoji-mart-preview-emoticon,
+.emoji-mart-preview-emoticon + .emoji-mart-preview-emoticon {
+  margin-left: 0.5em;
+}
+
+.emoji-mart-preview-emoticon {
+  font-size: 11px;
+  color: #bbb;
+}
+
+.emoji-mart-bar:last-child {
+  background: var(--dropdown-background-color);
+}
+
+@media only screen and (width >= 500px) {
+  .emoji-mart-title-label {
+    display: none;
+  }
+
+  .emoji-mart-preview-shortnames {
+    display: flex;
+    flex-direction: column;
+
+    .emoji-mart-preview-shortname {
+      max-width: 120px;
+    }
+  }
+
+  .emoji-mart-preview-emoji,
+  .emoji-mart-preview-data,
+  .emoji-mart-preview-skins {
+    position: relative;
+    top: 0;
+    transform: unset;
+  }
+
+  .emoji-mart-preview-emoji {
+    height: fit-content;
+    left: 4px !important;
+
+    .emoji-mart-emoji {
+      span {
+        width: 100px !important;
+        height: 100px !important;
+      }
+
+      span[style*='url("/emoji/sheet_'] {
+        width: 32px !important;
+        height: 32px !important;
+        margin: 34px;
+      }
+    }
+  }
+
+  .emoji-mart-bar:last-child {
+    position: absolute;
+    top: 0;
+    width: fit-content;
+    height: fit-content;
+    border-radius: 5px;
+    right: -125px !important;
+    box-shadow: 4px 4px 6px rgb(0 0 0 / 40%);
+  }
+
+  .emoji-mart-preview {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .emoji-mart-preview-data {
+    left: 0 !important;
+    right: 0 !important;
+    text-align: center;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    position: relative;
+    top: 100%;
+    background: var(--dropdown-background-color);
+    color: var(--dropdown-text-color) !important;
+    height: fit-content;
+    border-bottom-right-radius: 5px;
+    border-bottom-left-radius: 5px;
+  }
+
+  .emoji-mart-preview-name {
+    display: none;
+  }
 }


### PR DESCRIPTION
The default emoji thumbnail in picker list is too small to read, so we enable emoji mart's preview function and add necessary stylesheets for them in this commit.

On large screen:
<img width="494" alt="image" src="https://github.com/mastodon/mastodon/assets/16148054/005062cd-f3f7-44bc-b7d5-39c2096082ff">

On small scrreeeen:
<img width="175" alt="image" src="https://github.com/mastodon/mastodon/assets/16148054/12451f99-7230-491f-8798-e7398ea2d0fc">

Light theme:
<img width="386" alt="image" src="https://github.com/mastodon/mastodon/assets/16148054/1103b598-b7b6-42bb-a2db-7fb98e20012e">

<img width="860" alt="image" src="https://github.com/mastodon/mastodon/assets/16148054/be05acbc-a6a9-47b6-9ffb-9ab340ea638c">

