### PR TITLE
Fix unhandled nullable attachments limitation counter

### DIFF
--- a/app/javascript/mastodon/features/compose/containers/upload_button_container.js
+++ b/app/javascript/mastodon/features/compose/containers/upload_button_container.js
@@ -1,16 +1,26 @@
-import { connect } from 'react-redux';
+import {connect} from 'react-redux';
 
-import { uploadCompose } from '../../../actions/compose';
+import {uploadCompose} from '../../../actions/compose';
 import UploadButton from '../components/upload_button';
 
-const mapStateToProps = state => ({
-  disabled: state.getIn(['compose', 'poll']) !== null || state.getIn(['compose', 'is_uploading']) || (state.getIn(['compose', 'media_attachments']).size + state.getIn(['compose', 'pending_media_attachments']) > 3 || state.getIn(['compose', 'media_attachments']).some(m => ['video', 'audio'].includes(m.get('type')))),
-  resetFileKey: state.getIn(['compose', 'resetFileKey']),
-});
+const mapStateToProps = state => {
+  const isPoll = state.getIn(['compose', 'poll']) !== null;
+  const isUploading = state.getIn(['compose', 'is_uploading']);
+  const readyAttachmentsSize = state.getIn(['compose', 'media_attachments']).size ?? 0;
+  const pendingAttachmentsSize = state.getIn(['compose', 'pending_media_attachments']).size ?? 0;
+  const attachmentsSize = readyAttachmentsSize + pendingAttachmentsSize;
+  const isOverLimit = attachmentsSize > 3;
+  const hasVideoOrAudio = state.getIn(['compose', 'media_attachments']).some(m => ['video', 'audio'].includes(m.get('type')));
+
+  return {
+    disabled: isPoll || isUploading || isOverLimit || hasVideoOrAudio,
+    resetFileKey: state.getIn(['compose', 'resetFileKey']),
+  };
+};
 
 const mapDispatchToProps = dispatch => ({
 
-  onSelectFile (files) {
+  onSelectFile(files) {
     dispatch(uploadCompose(files));
   },
 

--- a/app/javascript/mastodon/features/compose/containers/upload_button_container.js
+++ b/app/javascript/mastodon/features/compose/containers/upload_button_container.js
@@ -1,6 +1,6 @@
-import {connect} from 'react-redux';
+import { connect } from 'react-redux';
 
-import {uploadCompose} from '../../../actions/compose';
+import { uploadCompose } from '../../../actions/compose';
 import UploadButton from '../components/upload_button';
 
 const mapStateToProps = state => {


### PR DESCRIPTION
user should not be allowed to continue upload with more than 4
<img width="559" alt="image" src="https://github.com/mastodon/mastodon/assets/16148054/b0c4a4a5-731e-4ac3-95a6-5c1fa294e9c6">
