### PR TITLE
Fix modal container bounds

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -5343,6 +5343,8 @@ a.status-card {
   inset-inline-start: 0;
   width: 100%;
   height: 100%;
+  max-width: 100vw;
+  max-height: 100vh;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Hey there!

I'm one of Proton Mail devs, we had exactly the same issue on our projects, and I spotted it on Mastodon: when plugin in a second screen (or restarting a computer), sometimes the modals/image preview is weirdly positionned. Container has some bigger height/width than expected.

Adding a `max-width`/`max-height` to the modal container fixes this issue.

**BEFORE**

![Capture d’écran 2024-02-13 à 13 20 01](https://github.com/mastodon/mastodon/assets/2578321/e85bf97f-5696-4372-89fb-2bd9ffd86b36)


**AFTER**

![Capture d’écran 2024-02-13 à 13 20 11](https://github.com/mastodon/mastodon/assets/2578321/a8b2219d-f244-438f-b121-d5f8f3882e0f)

Seeya!