### PR TITLE
Ignore legacy moderator and admin columns on User model

### DIFF
--- a/app/models/concerns/user/ldap_authenticable.rb
+++ b/app/models/concerns/user/ldap_authenticable.rb
@@ -25,7 +25,15 @@ module User::LdapAuthenticable
       resource = joins(:account).find_by(accounts: { username: safe_username })
 
       if resource.blank?
-        resource = new(email: attributes[Devise.ldap_mail.to_sym].first, agreement: true, account_attributes: { username: safe_username }, admin: false, external: true, confirmed_at: Time.now.utc)
+        resource = new(
+          email: attributes[Devise.ldap_mail.to_sym].first,
+          agreement: true,
+          account_attributes: {
+            username: safe_username,
+          },
+          external: true,
+          confirmed_at: Time.now.utc
+        )
         resource.save!
       end
 

--- a/app/models/concerns/user/pam_authenticable.rb
+++ b/app/models/concerns/user/pam_authenticable.rb
@@ -32,7 +32,6 @@ module User::PamAuthenticable
 
       self.email        = "#{account.username}@#{find_pam_suffix}" if email.nil? && find_pam_suffix
       self.confirmed_at = Time.now.utc
-      self.admin        = false
       self.account      = account
       self.external     = true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -51,6 +51,8 @@ class User < ApplicationRecord
     last_sign_in_ip
     skip_sign_in_token
     filtered_languages
+    admin
+    moderator
   )
 
   include LanguagesHelper


### PR DESCRIPTION
@ClearlyClaire as requested, since we've moved to the User Roles setup, and these columns are considered legacy and shouldn't be used.

There are several tests that are labelled as checking `admin?`, but they appear to be using user roles under the hood.

```
spec/policies/invite_policy_spec.rb:
spec/policies/relay_policy_spec.rb:
spec/policies/report_note_policy_spec.rb:
spec/policies/settings_policy_spec.rb:
spec/policies/user_policy_spec.rb:
```
