### PR TITLE
Implement RFC 8414 for OAuth 2.0 server metadata

### DIFF
--- a/app/controllers/well_known/oauth_metadata_controller.rb
+++ b/app/controllers/well_known/oauth_metadata_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module WellKnown
+  class OauthMetadataController < ActionController::Base # rubocop:disable Rails/ApplicationController
+    include CacheConcern
+
+    # Prevent `active_model_serializer`'s `ActionController::Serialization` from calling `current_user`
+    # and thus re-issuing session cookies
+    serialization_scope nil
+
+    def show
+      expires_in 3.days, public: true
+      render_with_cache json: ::OauthMetadataPresenter.new, serializer: ::OauthMetadataSerializer, content_type: 'application/json'
+    end
+  end
+end

--- a/app/controllers/well_known/oauth_metadata_controller.rb
+++ b/app/controllers/well_known/oauth_metadata_controller.rb
@@ -9,8 +9,15 @@ module WellKnown
     serialization_scope nil
 
     def show
-      expires_in 3.days, public: true
-      render_with_cache json: ::OauthMetadataPresenter.new, serializer: ::OauthMetadataSerializer, content_type: 'application/json'
+      # Due to this document potentially changing between Mastodon versions (as
+      # new OAuth scopes are added), we don't use expires_in to cache upstream,
+      # instead just caching in the rails cache:
+      render_with_cache(
+        json: ::OauthMetadataPresenter.new,
+        serializer: ::OauthMetadataSerializer,
+        content_type: 'application/json',
+        expires_in: 15.minutes
+      )
     end
   end
 end

--- a/app/presenters/oauth_metadata_presenter.rb
+++ b/app/presenters/oauth_metadata_presenter.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+class OauthMetadataPresenter < ActiveModelSerializers::Model
+  include RoutingHelper
+
+  attributes :issuer, :authorization_endpoint, :token_endpoint,
+             :registration_endpoint, :revocation_endpoint, :scopes_supported,
+             :response_types_supported, :response_modes_supported,
+             :grant_types_supported, :token_endpoint_auth_methods_supported
+
+  def issuer
+    "http#{Rails.configuration.x.use_https ? 's' : ''}://#{Rails.configuration.x.web_domain}/"
+  end
+
+  def authorization_endpoint
+    oauth_authorization_url
+  end
+
+  def token_endpoint
+    oauth_token_url
+  end
+
+  # NOTE: the api_v1_apps route doesn't technically conform to the
+  # specification for OAuth 2.0 Dynamic Client Registration defined in
+  # https://datatracker.ietf.org/doc/html/rfc7591
+  # But for Mastodon, this is the API Endpoint that you would want for this property
+  def registration_endpoint
+    api_v1_apps_url
+  end
+
+  def revocation_endpoint
+    oauth_revoke_url
+  end
+
+  def scopes_supported
+    doorkeeper.scopes
+  end
+
+  def response_types_supported
+    doorkeeper.authorization_response_types
+  end
+
+  def response_modes_supported
+    doorkeeper.authorization_response_flows.flat_map(&:response_mode_matches).uniq
+  end
+
+  def grant_types_supported
+    grant_types_supported = doorkeeper.grant_flows.dup
+    grant_types_supported << 'refresh_token' if doorkeeper.refresh_token_enabled?
+    grant_types_supported
+  end
+
+  def token_endpoint_auth_methods_supported
+    %w(client_secret_basic client_secret_post)
+  end
+
+  private
+
+  def doorkeeper
+    @doorkeeper ||= Doorkeeper.configuration
+  end
+end

--- a/app/presenters/oauth_metadata_presenter.rb
+++ b/app/presenters/oauth_metadata_presenter.rb
@@ -9,7 +9,7 @@ class OauthMetadataPresenter < ActiveModelSerializers::Model
              :grant_types_supported, :token_endpoint_auth_methods_supported
 
   def issuer
-    "http#{Rails.configuration.x.use_https ? 's' : ''}://#{Rails.configuration.x.web_domain}/"
+    root_url
   end
 
   def authorization_endpoint

--- a/app/presenters/oauth_metadata_presenter.rb
+++ b/app/presenters/oauth_metadata_presenter.rb
@@ -4,12 +4,17 @@ class OauthMetadataPresenter < ActiveModelSerializers::Model
   include RoutingHelper
 
   attributes :issuer, :authorization_endpoint, :token_endpoint,
-             :registration_endpoint, :revocation_endpoint, :scopes_supported,
+             :revocation_endpoint, :scopes_supported,
              :response_types_supported, :response_modes_supported,
-             :grant_types_supported, :token_endpoint_auth_methods_supported
+             :grant_types_supported, :token_endpoint_auth_methods_supported,
+             :service_documentation, :app_registration_endpoint
 
   def issuer
     root_url
+  end
+
+  def service_documentation
+    'https://docs.joinmastodon.org/'
   end
 
   def authorization_endpoint
@@ -20,11 +25,11 @@ class OauthMetadataPresenter < ActiveModelSerializers::Model
     oauth_token_url
   end
 
-  # NOTE: the api_v1_apps route doesn't technically conform to the
-  # specification for OAuth 2.0 Dynamic Client Registration defined in
-  # https://datatracker.ietf.org/doc/html/rfc7591
-  # But for Mastodon, this is the API Endpoint that you would want for this property
-  def registration_endpoint
+  # As the api_v1_apps route doesn't technically conform to the specification
+  # for OAuth 2.0 Dynamic Client Registration defined in RFC 7591 we use a
+  # non-standard property for now to indicate the mastodon specific registration
+  # endpoint. See: https://datatracker.ietf.org/doc/html/rfc7591
+  def app_registration_endpoint
     api_v1_apps_url
   end
 

--- a/app/serializers/oauth_metadata_serializer.rb
+++ b/app/serializers/oauth_metadata_serializer.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class OauthMetadataSerializer < ActiveModel::Serializer
+  attributes :issuer, :authorization_endpoint, :token_endpoint,
+             :registration_endpoint, :revocation_endpoint, :scopes_supported,
+             :response_types_supported, :response_modes_supported,
+             :grant_types_supported, :token_endpoint_auth_methods_supported
+end

--- a/app/serializers/oauth_metadata_serializer.rb
+++ b/app/serializers/oauth_metadata_serializer.rb
@@ -2,7 +2,8 @@
 
 class OauthMetadataSerializer < ActiveModel::Serializer
   attributes :issuer, :authorization_endpoint, :token_endpoint,
-             :registration_endpoint, :revocation_endpoint, :scopes_supported,
+             :revocation_endpoint, :scopes_supported,
              :response_types_supported, :response_modes_supported,
-             :grant_types_supported, :token_endpoint_auth_methods_supported
+             :grant_types_supported, :token_endpoint_auth_methods_supported,
+             :service_documentation, :app_registration_endpoint
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,6 +62,7 @@ Rails.application.routes.draw do
                 tokens: 'oauth/tokens'
   end
 
+  get '.well-known/oauth-authorization-server', to: 'well_known/oauth_metadata#show', as: :oauth_metadata, defaults: { format: 'json' }
   get '.well-known/host-meta', to: 'well_known/host_meta#show', as: :host_meta, defaults: { format: 'xml' }
   get '.well-known/nodeinfo', to: 'well_known/node_info#index', as: :nodeinfo, defaults: { format: 'json' }
   get '.well-known/webfinger', to: 'well_known/webfinger#show', as: :webfinger

--- a/spec/requests/well_known/oauth_metadata_spec.rb
+++ b/spec/requests/well_known/oauth_metadata_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'The /.well-known/oauth-authorization-server request' do
+  it 'returns http success with valid JSON response' do
+    get '/.well-known/oauth-authorization-server'
+
+    expect(response)
+      .to have_http_status(200)
+      .and have_attributes(
+        media_type: 'application/json'
+      )
+
+    expect(body_as_json).to match(
+      a_hash_including(
+        # FIXME: Include tests for the important URLs (for some reason routing
+        # was generating mismatching URLs between the serializer and the tests)
+        scopes_supported: Doorkeeper.configuration.scopes.map(&:to_s)
+      )
+    )
+  end
+end

--- a/spec/requests/well_known/oauth_metadata_spec.rb
+++ b/spec/requests/well_known/oauth_metadata_spec.rb
@@ -22,6 +22,7 @@ describe 'The /.well-known/oauth-authorization-server request' do
     grant_types_supported << 'refresh_token' if Doorkeeper.configuration.refresh_token_enabled?
 
     expect(body_as_json).to include(
+      issuer: root_url(protocol: protocol),
       authorization_endpoint: oauth_authorization_url(protocol: protocol),
       token_endpoint: oauth_token_url(protocol: protocol),
       registration_endpoint: api_v1_apps_url(protocol: protocol),

--- a/spec/requests/well_known/oauth_metadata_spec.rb
+++ b/spec/requests/well_known/oauth_metadata_spec.rb
@@ -23,13 +23,15 @@ describe 'The /.well-known/oauth-authorization-server request' do
 
     expect(body_as_json).to include(
       issuer: root_url(protocol: protocol),
+      service_documentation: 'https://docs.joinmastodon.org/',
       authorization_endpoint: oauth_authorization_url(protocol: protocol),
       token_endpoint: oauth_token_url(protocol: protocol),
-      registration_endpoint: api_v1_apps_url(protocol: protocol),
       revocation_endpoint: oauth_revoke_url(protocol: protocol),
       scopes_supported: Doorkeeper.configuration.scopes.map(&:to_s),
       response_types_supported: Doorkeeper.configuration.authorization_response_types,
-      grant_types_supported: grant_types_supported
+      grant_types_supported: grant_types_supported,
+      # non-standard extension:
+      app_registration_endpoint: api_v1_apps_url(protocol: protocol)
     )
   end
 end


### PR DESCRIPTION
This implements #24099 by doing it directly in Mastodon's codebase, rather than trying to upstream it (upstream [were offered](https://github.com/doorkeeper-gem/doorkeeper/issues/1587#issuecomment-1816997549) and ignored the offer from me to implement it).

I've tried to emulate the code we have elsewhere, and used the [Doorkeeper OpenID Connect](https://github.com/doorkeeper-gem/doorkeeper-openid_connect/blob/master/app/controllers/doorkeeper/openid_connect/discovery_controller.rb) gem as a reference for some things that are common between RFC 8414 and OpenID Connect specifications.

We could additionally support `ui_locales_supported`, if we have BCP 47 values available for the languages the UI of Mastodon supports (note: we currently don't support localisation of OAuth 2.0 Application names or localised TOS/privacy URLs, as described in [RFC 7591 Section 2.2](https://datatracker.ietf.org/doc/html/rfc7591#section-2.2)), I'm not sure what the values returned from `LanguagesHelper::SUPPORTED_LOCALES` are and if they are BCP 47 compliant.

### Example Response:

```json
{
  "issuer": "http://mastodon.lan:3000/",
  "service_documentation": "https://docs.joinmastodon.org/",
  "authorization_endpoint": "http://mastodon.lan:3000/oauth/authorize",
  "token_endpoint": "http://mastodon.lan:3000/oauth/token",
  "app_registration_endpoint": "http://mastodon.lan:3000/api/v1/apps",
  "revocation_endpoint": "http://mastodon.lan:3000/oauth/revoke",
  "scopes_supported": [
    "read",
    "write",
    "write:accounts",
    "write:blocks",
    "write:bookmarks",
    "write:conversations",
    "write:favourites",
    "write:filters",
    "write:follows",
    "write:lists",
    "write:media",
    "write:mutes",
    "write:notifications",
    "write:reports",
    "write:statuses",
    "read:accounts",
    "read:blocks",
    "read:bookmarks",
    "read:favourites",
    "read:filters",
    "read:follows",
    "read:lists",
    "read:mutes",
    "read:notifications",
    "read:search",
    "read:statuses",
    "follow",
    "push",
    "admin:read",
    "admin:read:accounts",
    "admin:read:reports",
    "admin:read:domain_allows",
    "admin:read:domain_blocks",
    "admin:read:ip_blocks",
    "admin:read:email_domain_blocks",
    "admin:read:canonical_email_blocks",
    "admin:write",
    "admin:write:accounts",
    "admin:write:reports",
    "admin:write:domain_allows",
    "admin:write:domain_blocks",
    "admin:write:ip_blocks",
    "admin:write:email_domain_blocks",
    "admin:write:canonical_email_blocks",
    "crypto"
  ],
  "response_types_supported": [
    "code"
  ],
  "response_modes_supported": [
    "query",
    "fragment",
    "form_post"
  ],
  "grant_types_supported": [
    "authorization_code",
    "password",
    "client_credentials"
  ],
  "token_endpoint_auth_methods_supported": [
    "client_secret_basic",
    "client_secret_post"
  ]
}
```

We use the non-standard `app_registration_endpoint` as that endpoint isn't technically compliant with OAuth 2.0 Dynamic Client Registration. It's similar but not the same.