### PR TITLE
Support multiple redirect_uris when creating OAuth 2.0 Applications

### DIFF
--- a/app/controllers/api/v1/apps/credentials_controller.rb
+++ b/app/controllers/api/v1/apps/credentials_controller.rb
@@ -4,6 +4,6 @@ class Api::V1::Apps::CredentialsController < Api::BaseController
   def show
     return doorkeeper_render_error unless valid_doorkeeper_token?
 
-    render json: doorkeeper_token.application, serializer: REST::ApplicationSerializer, fields: %i(name website vapid_key client_id scopes redirect_uris)
+    render json: doorkeeper_token.application, serializer: REST::ApplicationSerializer
   end
 end

--- a/app/controllers/api/v1/apps/credentials_controller.rb
+++ b/app/controllers/api/v1/apps/credentials_controller.rb
@@ -4,6 +4,6 @@ class Api::V1::Apps::CredentialsController < Api::BaseController
   def show
     return doorkeeper_render_error unless valid_doorkeeper_token?
 
-    render json: doorkeeper_token.application, serializer: REST::ApplicationSerializer, fields: %i(name website vapid_key client_id scopes)
+    render json: doorkeeper_token.application, serializer: REST::ApplicationSerializer, fields: %i(name website vapid_key client_id scopes redirect_uris)
   end
 end

--- a/app/controllers/api/v1/apps_controller.rb
+++ b/app/controllers/api/v1/apps_controller.rb
@@ -5,7 +5,7 @@ class Api::V1::AppsController < Api::BaseController
 
   def create
     @app = Doorkeeper::Application.create!(application_options)
-    render json: @app, serializer: REST::ApplicationSerializer
+    render json: @app, serializer: REST::CredentialApplicationSerializer
   end
 
   private

--- a/app/controllers/api/v1/apps_controller.rb
+++ b/app/controllers/api/v1/apps_controller.rb
@@ -24,6 +24,6 @@ class Api::V1::AppsController < Api::BaseController
   end
 
   def app_params
-    params.permit(:client_name, :redirect_uris, :scopes, :website)
+    params.permit(:client_name, :scopes, :website, :redirect_uris, redirect_uris: [])
   end
 end

--- a/app/lib/application_extension.rb
+++ b/app/lib/application_extension.rb
@@ -23,6 +23,12 @@ module ApplicationExtension
     redirect_uri.lines.first.strip
   end
 
+  def redirect_uris
+    # Doorkeeper stores the redirect_uri value as a newline delimeted list in
+    # the database:
+    redirect_uri.split
+  end
+
   def push_to_streaming_api
     # TODO: #28793 Combine into a single topic
     payload = Oj.dump(event: :kill)

--- a/app/serializers/rest/application_serializer.rb
+++ b/app/serializers/rest/application_serializer.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 class REST::ApplicationSerializer < ActiveModel::Serializer
-  attributes :id, :name, :website, :scopes, :redirect_uris,
-             :client_id
+  attributes :id, :name, :website, :scopes, :redirect_uris
 
   # NOTE: Deprecated in 4.3.0, needs to be removed in 5.0.0
   attribute :vapid_key
@@ -12,10 +11,6 @@ class REST::ApplicationSerializer < ActiveModel::Serializer
 
   def id
     object.id.to_s
-  end
-
-  def client_id
-    object.uid
   end
 
   def website

--- a/app/serializers/rest/application_serializer.rb
+++ b/app/serializers/rest/application_serializer.rb
@@ -20,11 +20,7 @@ class REST::ApplicationSerializer < ActiveModel::Serializer
   end
 
   # We should consider this property deprecated for 4.3.0
-  def redirect_uri
-    # Doorkeeper stores the redirect_uri value as a newline delimeted list in
-    # the database, as we may have more than one redirect URI, return the first:
-    object.redirect_uri.split.first
-  end
+  delegate :redirect_uri, to: :object
 
   def redirect_uris
     # Doorkeeper stores the redirect_uri value as a newline delimeted list in

--- a/app/serializers/rest/application_serializer.rb
+++ b/app/serializers/rest/application_serializer.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 class REST::ApplicationSerializer < ActiveModel::Serializer
-  attributes :id, :name, :website, :scopes, :redirect_uri, :redirect_uris,
+  attributes :id, :name, :website, :scopes, :redirect_uris,
              :client_id, :client_secret
 
   # NOTE: Deprecated in 4.3.0, needs to be removed in 5.0.0
   attribute :vapid_key
+
+  # We should consider this property deprecated for 4.3.0
+  attribute :redirect_uri
 
   def id
     object.id.to_s
@@ -18,9 +21,6 @@ class REST::ApplicationSerializer < ActiveModel::Serializer
   def client_secret
     object.secret
   end
-
-  # We should consider this property deprecated for 4.3.0
-  delegate :redirect_uri, to: :object
 
   def website
     object.website.presence

--- a/app/serializers/rest/application_serializer.rb
+++ b/app/serializers/rest/application_serializer.rb
@@ -19,6 +19,7 @@ class REST::ApplicationSerializer < ActiveModel::Serializer
     object.secret
   end
 
+  # We should consider this property deprecated for 4.3.0
   def redirect_uri
     # Doorkeeper stores the redirect_uri value as a newline delimeted list in
     # the database, as we may have more than one redirect URI, return the first:

--- a/app/serializers/rest/application_serializer.rb
+++ b/app/serializers/rest/application_serializer.rb
@@ -22,12 +22,6 @@ class REST::ApplicationSerializer < ActiveModel::Serializer
   # We should consider this property deprecated for 4.3.0
   delegate :redirect_uri, to: :object
 
-  def redirect_uris
-    # Doorkeeper stores the redirect_uri value as a newline delimeted list in
-    # the database:
-    object.redirect_uri.split
-  end
-
   def website
     object.website.presence
   end

--- a/app/serializers/rest/application_serializer.rb
+++ b/app/serializers/rest/application_serializer.rb
@@ -2,7 +2,7 @@
 
 class REST::ApplicationSerializer < ActiveModel::Serializer
   attributes :id, :name, :website, :scopes, :redirect_uris,
-             :client_id, :client_secret
+             :client_id
 
   # NOTE: Deprecated in 4.3.0, needs to be removed in 5.0.0
   attribute :vapid_key
@@ -16,10 +16,6 @@ class REST::ApplicationSerializer < ActiveModel::Serializer
 
   def client_id
     object.uid
-  end
-
-  def client_secret
-    object.secret
   end
 
   def website

--- a/app/serializers/rest/application_serializer.rb
+++ b/app/serializers/rest/application_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class REST::ApplicationSerializer < ActiveModel::Serializer
-  attributes :id, :name, :website, :scopes, :redirect_uri,
+  attributes :id, :name, :website, :scopes, :redirect_uri, :redirect_uris,
              :client_id, :client_secret
 
   # NOTE: Deprecated in 4.3.0, needs to be removed in 5.0.0
@@ -17,6 +17,18 @@ class REST::ApplicationSerializer < ActiveModel::Serializer
 
   def client_secret
     object.secret
+  end
+
+  def redirect_uri
+    # Doorkeeper stores the redirect_uri value as a newline delimeted list in
+    # the database, as we may have more than one redirect URI, return the first:
+    object.redirect_uri.split.first
+  end
+
+  def redirect_uris
+    # Doorkeeper stores the redirect_uri value as a newline delimeted list in
+    # the database:
+    object.redirect_uri.split
   end
 
   def website

--- a/app/serializers/rest/credential_application_serializer.rb
+++ b/app/serializers/rest/credential_application_serializer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class REST::CredentialApplicationSerializer < REST::ApplicationSerializer
+  attributes :client_secret
+
+  def client_secret
+    object.secret
+  end
+end

--- a/app/serializers/rest/credential_application_serializer.rb
+++ b/app/serializers/rest/credential_application_serializer.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 class REST::CredentialApplicationSerializer < REST::ApplicationSerializer
-  attributes :client_secret
+  attributes :client_id, :client_secret
+
+  def client_id
+    object.uid
+  end
 
   def client_secret
     object.secret

--- a/spec/requests/api/v1/apps/credentials_spec.rb
+++ b/spec/requests/api/v1/apps/credentials_spec.rb
@@ -20,12 +20,15 @@ describe 'Credentials' do
 
         expect(body_as_json).to match(
           a_hash_including(
+            id: token.application.id.to_s,
+            client_id: token.application.uid,
             name: token.application.name,
             website: token.application.website,
-            vapid_key: Rails.configuration.x.vapid_public_key,
             scopes: token.application.scopes.map(&:to_s),
             redirect_uris: token.application.redirect_uris,
-            client_id: token.application.uid
+            # Deprecated properties as of 4.3:
+            redirect_uri: token.application.redirect_uri.split.first,
+            vapid_key: Rails.configuration.x.vapid_public_key
           )
         )
       end
@@ -59,12 +62,15 @@ describe 'Credentials' do
 
         expect(body_as_json).to match(
           a_hash_including(
+            id: token.application.id.to_s,
+            client_id: token.application.uid,
             name: token.application.name,
             website: token.application.website,
-            vapid_key: Rails.configuration.x.vapid_public_key,
             scopes: token.application.scopes.map(&:to_s),
             redirect_uris: token.application.redirect_uris,
-            client_id: token.application.uid
+            # Deprecated properties as of 4.3:
+            redirect_uri: token.application.redirect_uri.split.first,
+            vapid_key: Rails.configuration.x.vapid_public_key
           )
         )
       end

--- a/spec/requests/api/v1/apps/credentials_spec.rb
+++ b/spec/requests/api/v1/apps/credentials_spec.rb
@@ -24,6 +24,7 @@ describe 'Credentials' do
             website: token.application.website,
             vapid_key: Rails.configuration.x.vapid_public_key,
             scopes: token.application.scopes.map(&:to_s),
+            redirect_uris: token.application.redirect_uris,
             client_id: token.application.uid
           )
         )
@@ -50,6 +51,7 @@ describe 'Credentials' do
             website: token.application.website,
             vapid_key: Rails.configuration.x.vapid_public_key,
             scopes: token.application.scopes.map(&:to_s),
+            redirect_uris: token.application.redirect_uris,
             client_id: token.application.uid
           )
         )

--- a/spec/requests/api/v1/apps/credentials_spec.rb
+++ b/spec/requests/api/v1/apps/credentials_spec.rb
@@ -21,7 +21,6 @@ describe 'Credentials' do
         expect(body_as_json).to match(
           a_hash_including(
             id: token.application.id.to_s,
-            client_id: token.application.uid,
             name: token.application.name,
             website: token.application.website,
             scopes: token.application.scopes.map(&:to_s),
@@ -33,11 +32,12 @@ describe 'Credentials' do
         )
       end
 
-      it 'does not expose the client_secret' do
+      it 'does not expose the client_id or client_secret' do
         subject
 
         expect(response).to have_http_status(200)
 
+        expect(body_as_json[:client_id]).to_not be_present
         expect(body_as_json[:client_secret]).to_not be_present
       end
     end
@@ -59,7 +59,6 @@ describe 'Credentials' do
         expect(body_as_json).to match(
           a_hash_including(
             id: token.application.id.to_s,
-            client_id: token.application.uid,
             name: token.application.name,
             website: token.application.website,
             scopes: token.application.scopes.map(&:to_s),

--- a/spec/requests/api/v1/apps/credentials_spec.rb
+++ b/spec/requests/api/v1/apps/credentials_spec.rb
@@ -29,6 +29,18 @@ describe 'Credentials' do
           )
         )
       end
+
+      it 'does not expose the client_secret' do
+        subject
+
+        expect(response).to have_http_status(200)
+
+        expect(body_as_json).to_not match(
+          a_hash_including(
+            client_secret: token.application.secret
+          )
+        )
+      end
     end
 
     context 'with a non-read scoped oauth token' do

--- a/spec/requests/api/v1/apps/credentials_spec.rb
+++ b/spec/requests/api/v1/apps/credentials_spec.rb
@@ -38,11 +38,7 @@ describe 'Credentials' do
 
         expect(response).to have_http_status(200)
 
-        expect(body_as_json).to_not match(
-          a_hash_including(
-            client_secret: token.application.secret
-          )
-        )
+        expect(body_as_json[:client_secret]).to_not be_present
       end
     end
 

--- a/spec/requests/api/v1/apps_spec.rb
+++ b/spec/requests/api/v1/apps_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe 'Apps' do
 
         body = body_as_json
 
+        expect(body[:id]).to eq app.id.to_s
         expect(body[:client_id]).to be_present
         expect(body[:client_secret]).to be_present
         expect(body[:scopes]).to eq ['read', 'write']
@@ -119,8 +120,19 @@ RSpec.describe 'Apps' do
       end
     end
 
-    context 'with a too-long redirect_uris' do
-      let(:redirect_uris) { "https://foo.bar/#{'hoge' * 2_000}" }
+    context 'with a too-long redirect_uri' do
+      let(:redirect_uris) { "https://app.example/#{'hoge' * 2_000}" }
+
+      it 'returns http unprocessable entity' do
+        subject
+
+        expect(response).to have_http_status(422)
+      end
+    end
+
+    # NOTE: This spec currently tests the same as the "with a too-long redirect_uri test case"
+    context 'with too many redirect_uris' do
+      let(:redirect_uris) { (0...500).map { |i| "https://app.example/#{i}/callback" } }
 
       it 'returns http unprocessable entity' do
         subject

--- a/spec/requests/api/v1/apps_spec.rb
+++ b/spec/requests/api/v1/apps_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe 'Apps' do
 
     let(:client_name)   { 'Test app' }
     let(:scopes)        { 'read write' }
-    let(:redirect_uris) { 'urn:ietf:wg:oauth:2.0:oob' }
+    let(:redirect_uri)  { 'urn:ietf:wg:oauth:2.0:oob' }
+    let(:redirect_uris) { [redirect_uri] }
     let(:website)       { nil }
 
     let(:params) do
@@ -31,16 +32,23 @@ RSpec.describe 'Apps' do
         app = Doorkeeper::Application.find_by(name: client_name)
 
         expect(app).to be_present
-        expect(app.scopes.to_s).to eq 'read write'
-        expect(app.redirect_uris).to eq [redirect_uris]
+        expect(app.scopes.to_s).to eq scopes
+        expect(app.redirect_uris).to eq redirect_uris
 
-        body = body_as_json
-
-        expect(body[:id]).to eq app.id.to_s
-        expect(body[:client_id]).to be_present
-        expect(body[:client_secret]).to be_present
-        expect(body[:scopes]).to eq ['read', 'write']
-        expect(body[:redirect_uris]).to eq [redirect_uris]
+        expect(body_as_json).to match(
+          a_hash_including(
+            id: app.id.to_s,
+            client_id: app.uid,
+            client_secret: app.secret,
+            name: client_name,
+            website: website,
+            scopes: ['read', 'write'],
+            redirect_uris: redirect_uris,
+            # Deprecated properties as of 4.3:
+            redirect_uri: redirect_uri,
+            vapid_key: Rails.configuration.x.vapid_public_key
+          )
+        )
       end
     end
 

--- a/spec/requests/api/v1/apps_spec.rb
+++ b/spec/requests/api/v1/apps_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Apps' do
     end
 
     let(:client_name)   { 'Test app' }
-    let(:scopes)        { nil }
+    let(:scopes)        { 'read write' }
     let(:redirect_uris) { 'urn:ietf:wg:oauth:2.0:oob' }
     let(:website)       { nil }
 
@@ -28,11 +28,49 @@ RSpec.describe 'Apps' do
 
         expect(response).to have_http_status(200)
         expect(Doorkeeper::Application.find_by(name: client_name)).to be_present
+        expect(Doorkeeper::Application.find_by(name: client_name).scopes.to_s).to eq 'read write'
 
         body = body_as_json
 
         expect(body[:client_id]).to be_present
         expect(body[:client_secret]).to be_present
+        expect(body[:scopes]).to eq ['read', 'write']
+        expect(body[:redirect_uris]).to eq [redirect_uris]
+      end
+    end
+
+    context 'without scopes being supplied' do
+      let(:scopes) { nil }
+
+      it 'creates an OAuth App with the default scope' do
+        subject
+
+        expect(response).to have_http_status(200)
+        expect(Doorkeeper::Application.find_by(name: client_name)).to be_present
+
+        body = body_as_json
+
+        expect(body[:scopes]).to eq Doorkeeper.config.default_scopes.to_a
+      end
+    end
+
+    # FIXME: This is a bug: https://github.com/mastodon/mastodon/issues/30152
+    context 'with scopes as an array' do
+      let(:scopes) { %w(read write follow) }
+
+      it 'creates an OAuth App with the default scope' do
+        subject
+
+        expect(response).to have_http_status(200)
+
+        app = Doorkeeper::Application.find_by(name: client_name)
+
+        expect(app).to be_present
+        expect(app.scopes.to_s).to eq 'read'
+
+        body = body_as_json
+
+        expect(body[:scopes]).to eq ['read']
       end
     end
 
@@ -87,14 +125,98 @@ RSpec.describe 'Apps' do
       end
     end
 
-    context 'without required params' do
-      let(:client_name)   { '' }
+    context 'with multiple redirect_uris as a string' do
+      let(:redirect_uris) { "https://redirect1.example/\napp://redirect2.example/" }
+
+      it 'creates an OAuth application with multiple redirect URIs' do
+        subject
+
+        expect(response).to have_http_status(200)
+
+        app = Doorkeeper::Application.find_by(name: client_name)
+
+        expect(app).to be_present
+        expect(app.redirect_uri).to eq redirect_uris
+
+        body = body_as_json
+
+        expect(body[:redirect_uri]).to eq 'https://redirect1.example/'
+        expect(body[:redirect_uris]).to eq redirect_uris.split
+      end
+    end
+
+    context 'with multiple redirect_uris as an array' do
+      let(:redirect_uris) { ['https://redirect1.example/', 'app://redirect2.example/'] }
+
+      it 'creates an OAuth application with multiple redirect URIs' do
+        subject
+
+        expect(response).to have_http_status(200)
+
+        app = Doorkeeper::Application.find_by(name: client_name)
+
+        expect(app).to be_present
+        expect(app.redirect_uri).to eq redirect_uris.join "\n"
+
+        body = body_as_json
+
+        expect(body[:redirect_uri]).to eq 'https://redirect1.example/'
+        expect(body[:redirect_uris]).to eq redirect_uris
+      end
+    end
+
+    context 'with an empty redirect_uris array' do
+      let(:redirect_uris) { [] }
+
+      it 'returns http unprocessable entity' do
+        subject
+
+        expect(response).to have_http_status(422)
+      end
+    end
+
+    context 'with just a newline as the redirect_uris string' do
+      let(:redirect_uris) { "\n" }
+
+      it 'returns http unprocessable entity' do
+        subject
+
+        expect(response).to have_http_status(422)
+      end
+    end
+
+    context 'with an empty redirect_uris string' do
       let(:redirect_uris) { '' }
 
       it 'returns http unprocessable entity' do
         subject
 
         expect(response).to have_http_status(422)
+      end
+    end
+
+    context 'without a required param' do
+      let(:client_name) { '' }
+
+      it 'returns http unprocessable entity' do
+        subject
+
+        expect(response).to have_http_status(422)
+      end
+    end
+
+    context 'with a website' do
+      let(:website) { 'https://app.example/' }
+
+      it 'creates an OAuth application with the website specified' do
+        subject
+
+        expect(response).to have_http_status(200)
+
+        app = Doorkeeper::Application.find_by(name: client_name)
+
+        expect(app).to be_present
+        expect(app.website).to eq website
       end
     end
   end

--- a/spec/requests/api/v1/apps_spec.rb
+++ b/spec/requests/api/v1/apps_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe 'Apps' do
 
         body = body_as_json
 
-        expect(body[:redirect_uri]).to eq 'https://redirect1.example/'
+        expect(body[:redirect_uri]).to eq redirect_uris
         expect(body[:redirect_uris]).to eq redirect_uris.split
       end
     end
@@ -160,7 +160,7 @@ RSpec.describe 'Apps' do
 
         body = body_as_json
 
-        expect(body[:redirect_uri]).to eq 'https://redirect1.example/'
+        expect(body[:redirect_uri]).to eq redirect_uris.join "\n"
         expect(body[:redirect_uris]).to eq redirect_uris
       end
     end

--- a/spec/requests/api/v1/apps_spec.rb
+++ b/spec/requests/api/v1/apps_spec.rb
@@ -27,8 +27,12 @@ RSpec.describe 'Apps' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(Doorkeeper::Application.find_by(name: client_name)).to be_present
-        expect(Doorkeeper::Application.find_by(name: client_name).scopes.to_s).to eq 'read write'
+
+        app = Doorkeeper::Application.find_by(name: client_name)
+
+        expect(app).to be_present
+        expect(app.scopes.to_s).to eq 'read write'
+        expect(app.redirect_uris).to eq [redirect_uris]
 
         body = body_as_json
 
@@ -137,6 +141,7 @@ RSpec.describe 'Apps' do
 
         expect(app).to be_present
         expect(app.redirect_uri).to eq redirect_uris
+        expect(app.redirect_uris).to eq redirect_uris.split
 
         body = body_as_json
 
@@ -157,6 +162,7 @@ RSpec.describe 'Apps' do
 
         expect(app).to be_present
         expect(app.redirect_uri).to eq redirect_uris.join "\n"
+        expect(app.redirect_uris).to eq redirect_uris
 
         body = body_as_json
 


### PR DESCRIPTION
This brings us more inline with the dynamic client registration specification, where you can create a single application with multiple redirect URIs, see the example request at: https://datatracker.ietf.org/doc/html/rfc7591#section-3.1

This works around some weirdness in doorkeeper, where it only has a `redirect_uri` field on an Application, but it does some weird "join multiple values with a \n for the database" thing.

Arguably, this could be considered a breaking change because it introduces some kinda weird behavior, but it is technically the "correct" behavior with regards to OAuth 2.0...

This is currently a draft as it requires test coverage to be written, and I have had the time to write said tests yet.