### PR TITLE
Move the Posts/Following/Followers line further up the profile

### DIFF
--- a/app/javascript/mastodon/features/account/components/header.jsx
+++ b/app/javascript/mastodon/features/account/components/header.jsx
@@ -448,6 +448,29 @@ class Header extends ImmutablePureComponent {
             </h1>
           </div>
 
+          <div className='account__header__extra__links'>
+                <NavLink isActive={this.isStatusesPageActive} activeClassName='active' to={`/@${account.get('acct')}`} title={intl.formatNumber(account.get('statuses_count'))}>
+                  <ShortNumber
+                    value={account.get('statuses_count')}
+                    renderer={StatusesCounter}
+                  />
+                </NavLink>
+
+                <NavLink exact activeClassName='active' to={`/@${account.get('acct')}/following`} title={intl.formatNumber(account.get('following_count'))}>
+                  <ShortNumber
+                    value={account.get('following_count')}
+                    renderer={FollowingCounter}
+                  />
+                </NavLink>
+
+                <NavLink exact activeClassName='active' to={`/@${account.get('acct')}/followers`} title={intl.formatNumber(account.get('followers_count'))}>
+                  <ShortNumber
+                    value={account.get('followers_count')}
+                    renderer={FollowersCounter}
+                  />
+                </NavLink>
+              </div>
+              
           {badges.length > 0 && (
             <div className='account__header__badges'>
               {badges}
@@ -477,29 +500,6 @@ class Header extends ImmutablePureComponent {
                     </dl>
                   ))}
                 </div>
-              </div>
-
-              <div className='account__header__extra__links'>
-                <NavLink isActive={this.isStatusesPageActive} activeClassName='active' to={`/@${account.get('acct')}`} title={intl.formatNumber(account.get('statuses_count'))}>
-                  <ShortNumber
-                    value={account.get('statuses_count')}
-                    renderer={StatusesCounter}
-                  />
-                </NavLink>
-
-                <NavLink exact activeClassName='active' to={`/@${account.get('acct')}/following`} title={intl.formatNumber(account.get('following_count'))}>
-                  <ShortNumber
-                    value={account.get('following_count')}
-                    renderer={FollowingCounter}
-                  />
-                </NavLink>
-
-                <NavLink exact activeClassName='active' to={`/@${account.get('acct')}/followers`} title={intl.formatNumber(account.get('followers_count'))}>
-                  <ShortNumber
-                    value={account.get('followers_count')}
-                    renderer={FollowersCounter}
-                  />
-                </NavLink>
               </div>
             </div>
           )}


### PR DESCRIPTION
Solves https://github.com/mastodon/mastodon/issues/29177. All I've done is move `account__header__extra__links` further up the page. 

I hope the existing padding works with this component in a new location but I don't know so please check. The padding height between this component  and `account__header__tabs__name` and `account__header__badges` (the two components above and below this one in its new location) should be equal.

This is literally my first ever code change and PR (yay!) so *please* review this carefully. Apologies in advance if I've done anything incorrectly.