### PR TITLE
Set `WEB_DOMAIN` value in `.env.test`

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -3,3 +3,4 @@ NODE_ENV=production
 # Federation
 LOCAL_DOMAIN=cb6e6126.ngrok.io
 LOCAL_HTTPS=true
+WEB_DOMAIN=cb6e6126.ngrok.io

--- a/lib/tasks/spec.rake
+++ b/lib/tasks/spec.rake
@@ -6,6 +6,7 @@ if Rake::Task.task_defined?('spec:system')
       ENV['LOCAL_DOMAIN'] = 'localhost:3000'
       ENV['LOCAL_HTTPS'] = 'false'
       ENV['RUN_SYSTEM_SPECS'] = 'true'
+      ENV['WEB_DOMAIN'] = 'localhost:3000'
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -116,7 +116,7 @@ RSpec.configure do |config|
   end
 
   config.before :each, type: :request do
-    host! ENV.fetch('LOCAL_DOMAIN')
+    host! ENV.fetch('WEB_DOMAIN')
   end
 
   config.before do |example|

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -115,6 +115,10 @@ RSpec.configure do |config|
     Capybara.current_driver = :rack_test
   end
 
+  config.before :each, type: :request do
+    host! ENV.fetch('LOCAL_DOMAIN')
+  end
+
   config.before do |example|
     allow(Resolv::DNS).to receive(:open).and_raise('Real DNS queries are disabled, stub Resolv::DNS as needed') unless example.metadata[:type] == :system
   end

--- a/spec/requests/link_headers_spec.rb
+++ b/spec/requests/link_headers_spec.rb
@@ -13,7 +13,7 @@ describe 'Link headers' do
     it 'contains webfinger url in link header' do
       link_header = link_header_with_type('application/jrd+json')
 
-      expect(link_header.href).to eq 'http://www.example.com/.well-known/webfinger?resource=acct%3Atest%40cb6e6126.ngrok.io'
+      expect(link_header.href).to eq 'http://cb6e6126.ngrok.io/.well-known/webfinger?resource=acct%3Atest%40cb6e6126.ngrok.io'
       expect(link_header.attr_pairs.first).to eq %w(rel lrdd)
     end
 


### PR DESCRIPTION
See background discussion here: https://github.com/mastodon/mastodon/pull/29191#pullrequestreview-1878818127

There are basically three changes here:

- Add a `WEB_DOMAIN` value (matches existing `LOCAL_DOMAIN` value) to the `.env.test` file to be more specific about what host configuration we want the test http server to act as.
- Add an rspec `before` callback to always set this value with `host!` (could be overridden/replaced on individual examples if needed)
- Update one request spec which was hard-coded to the default request spec hostname value to use the new `host!` value instead

The first of these alone (adding WEB_DOMAIN) might have mitigated the linked issue, and the third one (updated spec) is only needed if we add the `before`.