### PR TITLE
Fix user creation failure handling in OmniAuth paths

### DIFF
--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -17,6 +17,9 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
         session["devise.#{provider}_data"] = request.env['omniauth.auth']
         redirect_to new_user_registration_url
       end
+    rescue ActiveRecord::RecordInvalid
+      flash[:alert] = I18n.t('devise.failure.omniauth_user_creation_failure') if is_navigational_format?
+      redirect_to new_user_session_url
     end
   end
 

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -12,6 +12,7 @@ en:
       last_attempt: You have one more attempt before your account is locked.
       locked: Your account is locked.
       not_found_in_database: Invalid %{authentication_keys} or password.
+      omniauth_user_creation_failure: Error creating an account for this identity.
       pending: Your account is still under review.
       timeout: Your session expired. Please login again to continue.
       unauthenticated: You need to login or sign up before continuing.

--- a/spec/requests/omniauth_callbacks_spec.rb
+++ b/spec/requests/omniauth_callbacks_spec.rb
@@ -60,11 +60,13 @@ describe 'OmniAuth callbacks' do
         end
 
         context 'when ALLOW_UNSAFE_AUTH_PROVIDER_REATTACH is not set to true' do
-          it 'does not match the existing user or create an identity' do
+          it 'does not match the existing user or create an identity, and redirects to login page' do
             expect { subject }
               .to not_change(User, :count)
               .and not_change(Identity, :count)
               .and not_change(LoginActivity, :count)
+
+            expect(response).to redirect_to(new_user_session_url)
           end
         end
       end


### PR DESCRIPTION
Redirect to log-in with a flash message instead of returning a generic error