### PR TITLE
Use `abort` instead of `warn(); exit` in boot.rb env check

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -96,12 +96,6 @@ Rails/FilePath:
 Rails/HttpStatus:
   EnforcedStyle: numeric
 
-# Reason: Allowed in boot ENV checker
-# https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsexit
-Rails/Exit:
-  Exclude:
-    - 'config/boot.rb'
-
 # Reason: Conflicts with `Lint/UselessMethodDefinition` for inherited controller actions
 # https://docs.rubocop.org/rubocop-rails/cops_rails.html#railslexicallyscopedactionfilter
 Rails/LexicallyScopedActionFilter:

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,8 +1,15 @@
 # frozen_string_literal: true
 
 unless ENV.key?('RAILS_ENV')
-  warn 'ERROR: Missing RAILS_ENV environment variable, please set it to "production", "development", or "test".'
-  exit 1
+  abort <<~ERROR
+    The RAILS_ENV environment variable is not set.
+
+    Please set it correctly depending on context:
+
+      - Use "production" for a live deployment of the application
+      - Use "development" for local feature work
+      - Use "test" when running the automated spec suite
+  ERROR
 end
 
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)


### PR DESCRIPTION
Prior relevant PRs:

- Moved out of todo into main config - https://github.com/mastodon/mastodon/pull/24743
- Fixed the bulk of the other offenses (in CLI) - https://github.com/mastodon/mastodon/pull/28322

This approach is slightly different than the initial version of the first one linked there (which originall swapping in a raise for the exit), and instead:

- Uses `abort` instead of combination of `warn` + `exit`
- Preserves the `1` exit code
- Improves error message with more detail for anyone who sees this
- Solves the `Rails/Exit` cop with this change (there were previously a lot more left)