### PR TITLE
Use `subject` in blacklist email validator spec

### DIFF
--- a/spec/validators/blacklisted_email_validator_spec.rb
+++ b/spec/validators/blacklisted_email_validator_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe BlacklistedEmailValidator do
   describe '#validate' do
-    subject { described_class.new.validate(user); errors }
+    subject { described_class.new.validate(user) }
 
     let(:user)   { instance_double(User, email: 'info@mail.com', sign_up_ip: '1.2.3.4', errors: errors) }
     let(:errors) { instance_double(ActiveModel::Errors, add: nil) }
@@ -18,7 +18,8 @@ RSpec.describe BlacklistedEmailValidator do
       let(:blocked_email) { true }
 
       it 'adds error' do
-        described_class.new.validate(user)
+        subject
+
         expect(errors).to have_received(:add).with(:email, :blocked).once
       end
     end
@@ -27,7 +28,8 @@ RSpec.describe BlacklistedEmailValidator do
       let(:blocked_email) { false }
 
       it 'does not add errors' do
-        described_class.new.validate(user)
+        subject
+
         expect(errors).to_not have_received(:add)
       end
 
@@ -39,7 +41,8 @@ RSpec.describe BlacklistedEmailValidator do
         end
 
         it 'adds error' do
-          described_class.new.validate(user)
+          subject
+
           expect(errors).to have_received(:add).with(:email, :taken).once
         end
       end


### PR DESCRIPTION
There was a `subject` defined here, but not used. I think the history here is that a previous update fixed an issue where the subject (note previous `errors` value, removed here) was being stubbed, but didn't also either remove or use the subject.