### PR TITLE
Re-enable fixed `Style/Semicolon` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -210,11 +210,6 @@ Style/RedundantBegin:
 Style/RescueStandardError:
   EnforcedStyle: implicit
 
-# Reason: Simplify some spec layouts
-# https://docs.rubocop.org/rubocop/cops_style.html#stylesemicolon
-Style/Semicolon:
-  AllowAsExpressionSeparator: true
-
 # Reason: Originally disabled for CodeClimate, and no config consensus has been found
 # https://docs.rubocop.org/rubocop/cops_style.html#stylesymbolarray
 Style/SymbolArray:


### PR DESCRIPTION
Opening as draft. Contingent on...

- https://github.com/mastodon/mastodon/pull/29210
- https://github.com/mastodon/mastodon/pull/29211

...which were the only remaining violations here.