### PR TITLE
Ignore error if mentioned account was not processable

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -194,7 +194,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
     account = account_from_uri(tag['href'])
     begin
       account = ActivityPub::FetchRemoteAccountService.new.call(tag['href'], request_id: @options[:request_id]) if account.nil?
-    rescue Mastodon::UnexpectedResponseError, HTTP::TimeoutError, HTTP::ConnectionError, HTTP::OpenSSL::SSLError
+    rescue Mastodon::UnexpectedResponseError, HTTP::TimeoutError, HTTP::ConnectionError, OpenSSL::SSL::SSLError
       account = nil
     end
 

--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -192,7 +192,11 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
     return if tag['href'].blank?
 
     account = account_from_uri(tag['href'])
-    account = ActivityPub::FetchRemoteAccountService.new.call(tag['href'], request_id: @options[:request_id]) if account.nil?
+    begin
+      account = ActivityPub::FetchRemoteAccountService.new.call(tag['href'], request_id: @options[:request_id]) if account.nil?
+    rescue Mastodon::UnexpectedResponseError, HTTP::TimeoutError, HTTP::ConnectionError, HTTP::OpenSSL::SSLError
+      account = nil
+    end
 
     return if account.nil?
 

--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -42,6 +42,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
   def process_status
     @tags                 = []
     @mentions             = []
+    @unresolved_mentions  = []
     @silenced_account_ids = []
     @params               = {}
 
@@ -55,6 +56,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
     end
 
     resolve_thread(@status)
+    resolve_unresolved_mentions(@status)
     fetch_replies(@status)
     distribute
     forward_for_reply
@@ -192,15 +194,13 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
     return if tag['href'].blank?
 
     account = account_from_uri(tag['href'])
-    begin
-      account = ActivityPub::FetchRemoteAccountService.new.call(tag['href'], request_id: @options[:request_id]) if account.nil?
-    rescue Mastodon::UnexpectedResponseError, HTTP::TimeoutError, HTTP::ConnectionError, OpenSSL::SSL::SSLError
-      account = nil
-    end
+    account = ActivityPub::FetchRemoteAccountService.new.call(tag['href'], request_id: @options[:request_id]) if account.nil?
 
     return if account.nil?
 
     @mentions << Mention.new(account: account, silent: false)
+  rescue Mastodon::UnexpectedResponseError, HTTP::TimeoutError, HTTP::ConnectionError, OpenSSL::SSL::SSLError
+    @unresolved_mentions << tag['href']
   end
 
   def process_emoji(tag)
@@ -303,6 +303,12 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
     return unless status.reply? && status.thread.nil? && Request.valid_url?(in_reply_to_uri)
 
     ThreadResolveWorker.perform_async(status.id, in_reply_to_uri, { 'request_id' => @options[:request_id] })
+  end
+
+  def resolve_unresolved_mentions(status)
+    @unresolved_mentions.uniq.each do |uri|
+      MentionResolveWorker.perform_in(rand(30...600).seconds, status.id, uri, { 'request_id' => @options[:request_id] })
+    end
   end
 
   def fetch_replies(status)

--- a/app/workers/mention_resolve_worker.rb
+++ b/app/workers/mention_resolve_worker.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class MentionResolveWorker
+  include Sidekiq::Worker
+  include ExponentialBackoff
+  include JsonLdHelper
+
+  sidekiq_options queue: 'pull', retry: 7
+
+  def perform(status_id, uri, options = {})
+    status = Status.find_by(id: status_id)
+    return if status.nil?
+
+    account = account_from_uri(uri)
+    account = ActivityPub::FetchRemoteAccountService.new.call(uri, request_id: options[:request_id]) if account.nil?
+
+    return if account.nil?
+
+    status.mentions.create!(account: account, silent: false)
+  rescue ActiveRecord::RecordNotFound
+    # Do nothing
+  rescue Mastodon::UnexpectedResponseError => e
+    response = e.response
+
+    if response_error_unsalvageable?(response)
+      # Give up
+    else
+      raise e
+    end
+  end
+
+  private
+
+  def account_from_uri(uri)
+    ActivityPub::TagManager.instance.uri_to_resource(uri, Account)
+  end
+end

--- a/spec/lib/activitypub/activity/create_spec.rb
+++ b/spec/lib/activitypub/activity/create_spec.rb
@@ -137,6 +137,7 @@ RSpec.describe ActivityPub::Activity::Create do
     end
 
     it 'ignores unprocessable mention', :aggregate_failures do
+      stub_request(:get, invalid_mention_json[:tag][:href]).to_return(status: 500)
       # When receiving the post that contains an invalid mention…
       described_class.new(activity_for_object(invalid_mention_json), sender, delivery: true).perform
 

--- a/spec/lib/activitypub/activity/create_spec.rb
+++ b/spec/lib/activitypub/activity/create_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe ActivityPub::Activity::Create do
     end
 
     it 'ignores unprocessable mention', :aggregate_failures do
-      stub_request(:get, invalid_mention_json[:tag][:href]).to_return(status: 500)
+      stub_request(:get, invalid_mention_json[:tag][:href]).to_raise(HTTP::ConnectionError)
       # When receiving the post that contains an invalid mention…
       described_class.new(activity_for_object(invalid_mention_json), sender, delivery: true).perform
 

--- a/spec/lib/activitypub/activity/create_spec.rb
+++ b/spec/lib/activitypub/activity/create_spec.rb
@@ -63,6 +63,24 @@ RSpec.describe ActivityPub::Activity::Create do
       }
     end
 
+    let(:invalid_mention_json) do
+      {
+        id: [ActivityPub::TagManager.instance.uri_for(sender), 'post2'].join('/'),
+        type: 'Note',
+        to: [
+          'https://www.w3.org/ns/activitystreams#Public',
+          ActivityPub::TagManager.instance.uri_for(follower),
+        ],
+        content: '@bob lorem ipsum',
+        published: 1.hour.ago.utc.iso8601,
+        updated: 1.hour.ago.utc.iso8601,
+        tag: {
+          type: 'Mention',
+          href: 'http://notexisting.dontexistingtld/actor',
+        },
+      }
+    end
+
     def activity_for_object(json)
       {
         '@context': 'https://www.w3.org/ns/activitystreams',
@@ -116,6 +134,21 @@ RSpec.describe ActivityPub::Activity::Create do
 
       # Creates two notifications
       expect(Notification.count).to eq 2
+    end
+
+    it 'ignores unprocessable mention', :aggregate_failures do
+      # When receiving the post that contains an invalid mention…
+      described_class.new(activity_for_object(invalid_mention_json), sender, delivery: true).perform
+
+      # NOTE: Refering explicitly to the workers is a bit awkward
+      DistributionWorker.drain
+      FeedInsertWorker.drain
+
+      # …it creates a status with an unknown parent
+      status = Status.find_by(uri: invalid_mention_json[:id])
+
+      # Check the process did not crash
+      expect(status.nil?).to be false
     end
   end
 

--- a/spec/lib/activitypub/activity/create_spec.rb
+++ b/spec/lib/activitypub/activity/create_spec.rb
@@ -145,11 +145,14 @@ RSpec.describe ActivityPub::Activity::Create do
       DistributionWorker.drain
       FeedInsertWorker.drain
 
-      # …it creates a status with an unknown parent
+      # …it creates a status
       status = Status.find_by(uri: invalid_mention_json[:id])
 
       # Check the process did not crash
       expect(status.nil?).to be false
+
+      # It has queued a mention resolve job
+      expect(MentionResolveWorker).to have_enqueued_sidekiq_job(status.id, invalid_mention_json[:tag][:href], anything)
     end
   end
 

--- a/spec/workers/mention_resolve_worker_spec.rb
+++ b/spec/workers/mention_resolve_worker_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MentionResolveWorker do
+  let(:status_id) { -42 }
+  let(:uri) { 'https://example.com/users/unknown' }
+
+  describe '#perform' do
+    subject { described_class.new.perform(status_id, uri, {}) }
+
+    context 'with a non-existent status' do
+      it 'returns nil' do
+        expect(subject).to be_nil
+      end
+    end
+
+    context 'with a valid user' do
+      let(:status) { Fabricate(:status) }
+      let(:status_id) { status.id }
+
+      let(:service_double) { instance_double(ActivityPub::FetchRemoteAccountService) }
+
+      before do
+        allow(ActivityPub::FetchRemoteAccountService).to receive(:new).and_return(service_double)
+
+        allow(service_double).to receive(:call).with(uri, anything) { Fabricate(:account, domain: 'example.com', uri: uri) }
+      end
+
+      it 'resolves the account and adds a new mention', :aggregate_failures do
+        expect { subject }
+          .to change { status.reload.mentions }.from([]).to(a_collection_including(having_attributes(account: having_attributes(uri: uri), silent: false)))
+
+        expect(service_double).to have_received(:call).once
+      end
+    end
+  end
+end


### PR DESCRIPTION
Sometimes, A post contain mentions that are not processable (The server is gone, server is hidden service only, whatever etc)
This PR makes mastodon can ignore unprocessable mentions and process it without raising an error

For an example, [This](https://hoto.moe/notes/9po3i1z5tz) post:

```json
{
    "@context": [
        "https://www.w3.org/ns/activitystreams",
        "https://w3id.org/security/v1",
        {
            "Emoji": "toot:Emoji",
            "Hashtag": "as:Hashtag",
            "PropertyValue": "schema:PropertyValue",
            "_misskey_content": "misskey:_misskey_content",
            "_misskey_quote": "misskey:_misskey_quote",
            "_misskey_reaction": "misskey:_misskey_reaction",
            "_misskey_summary": "misskey:_misskey_summary",
            "_misskey_votes": "misskey:_misskey_votes",
            "discoverable": "toot:discoverable",
            "featured": "toot:featured",
            "isCat": "misskey:isCat",
            "manuallyApprovesFollowers": "as:manuallyApprovesFollowers",
            "misskey": "https://misskey-hub.net/ns#",
            "quoteUrl": "as:quoteUrl",
            "schema": "http://schema.org#",
            "sensitive": "as:sensitive",
            "toot": "http://joinmastodon.org/ns#",
            "value": "schema:value",
            "vcard": "http://www.w3.org/2006/vcard/ns#"
        }
    ],
    "_misskey_content": "@cocoa@ap-test-1.hotous.net <- 이 계정은 다른 인스턴스에서 절대 조회 불가능",
    "attachment": [],
    "attributedTo": "https://hoto.moe/users/9grmnf69zx",
    "cc": [
        "https://hoto.moe/users/9grmnf69zx/followers",
        "https://ap-test-1.hotous.net/users/9k68563nozk00001"
    ],
    "content": "<p><a href=\"https://ap-test-1.hotous.net/@cocoa\" class=\"u-url mention\">@cocoa@ap-test-1.hotous.net</a><span> <- 이 계정은 다른 인스턴스에서 절대 조회 불가능</span></p>",
    "id": "https://hoto.moe/notes/9po3i1z5tz",
    "inReplyTo": "https://hoto.moe/notes/9po3efr8sv",
    "published": "2024-02-13T15:41:44.705Z",
    "sensitive": false,
    "source": {
        "content": "@cocoa@ap-test-1.hotous.net <- 이 계정은 다른 인스턴스에서 절대 조회 불가능",
        "mediaType": "text/x.misskeymarkdown"
    },
    "tag": [
        {
            "href": "https://ap-test-1.hotous.net/users/9k68563nozk00001",
            "name": "@cocoa@ap-test-1.hotous.net",
            "type": "Mention"
        }
    ],
    "to": [
        "https://www.w3.org/ns/activitystreams#Public"
    ],
    "type": "Note"
}
```

Mentions `cocoa@ap-test-1.hotous.net` which Don't have public DNS record