### PR TITLE
Extend coverage of the test suite

### DIFF
--- a/spec/controllers/auth/sessions_controller_spec.rb
+++ b/spec/controllers/auth/sessions_controller_spec.rb
@@ -434,14 +434,16 @@ RSpec.describe Auth::SessionsController do
   end
 
   describe 'GET #webauthn_options' do
+    subject { get :webauthn_options, session: { attempt_user_id: user.id } }
+
+    let!(:user) do
+      Fabricate(:user, email: 'x@y.com', password: 'abcdefgh', otp_required_for_login: true, otp_secret: User.generate_otp_secret(32))
+    end
+
     context 'with WebAuthn and OTP enabled as second factor' do
       let(:domain) { "#{Rails.configuration.x.use_https ? 'https' : 'http'}://#{Rails.configuration.x.web_domain}" }
 
       let(:fake_client) { WebAuthn::FakeClient.new(domain) }
-
-      let!(:user) do
-        Fabricate(:user, email: 'x@y.com', password: 'abcdefgh', otp_required_for_login: true, otp_secret: User.generate_otp_secret(32))
-      end
 
       before do
         user.update(webauthn_id: WebAuthn.generate_user_id)
@@ -456,8 +458,17 @@ RSpec.describe Auth::SessionsController do
       end
 
       it 'returns http success' do
-        get :webauthn_options
+        subject
+
         expect(response).to have_http_status 200
+      end
+    end
+
+    context 'when WebAuthn not enabled' do
+      it 'returns http unauthorized' do
+        subject
+
+        expect(response).to have_http_status 401
       end
     end
   end

--- a/spec/requests/api/v1/statuses_spec.rb
+++ b/spec/requests/api/v1/statuses_spec.rb
@@ -119,17 +119,12 @@ describe '/api/v1/statuses' do
       it_behaves_like 'forbidden for wrong scope', 'read read:statuses'
 
       context 'with a basic status body' do
-        it 'returns rate limit headers', :aggregate_failures do
+        it 'returns rate limit headers and the expected status', :aggregate_failures do
           subject
 
           expect(response).to have_http_status(200)
           expect(response.headers['X-RateLimit-Limit']).to eq RateLimiter::FAMILIES[:statuses][:limit].to_s
           expect(response.headers['X-RateLimit-Remaining']).to eq (RateLimiter::FAMILIES[:statuses][:limit] - 1).to_s
-        end
-
-        it 'returns expected status', :aggregate_failures do
-          subject
-
           expect(body_as_json).to match a_hash_including(
             {
               content: '<p>Hello world</p>',


### PR DESCRIPTION
This PR will add an example to `Api::V1::StatusesController#create` for when a thread is missing on create. See Report URI: https://app.codecov.io/gh/mastodon/mastodon/pull/29158/blob/app/controllers/api/v1/statuses_controller.rb#L125

There was also a missing example in `Auth::SessionsController#webauthn_options` for when WebAuthn is not enabled in the sessions controller spec file. This commit adds the missing test. See Report URI: https://app.codecov.io/gh/mastodon/mastodon/pull/29158/blob/app/controllers/auth/sessions_controller.rb#L61

Just for the sake of completeness, I've added an example for when  `Api::V1::StatusesController#create` succeeds.