### PR TITLE
Update enum syntax to use the new Rails 7.0 style

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -85,8 +85,8 @@ class Account < ApplicationRecord
   include DomainNormalizable
   include Paginable
 
-  enum protocol: { ostatus: 0, activitypub: 1 }
-  enum suspension_origin: { local: 0, remote: 1 }, _prefix: true
+  enum :protocol, { ostatus: 0, activitypub: 1 }
+  enum :suspension_origin, { local: 0, remote: 1 }, prefix: true
 
   validates :username, presence: true
   validates_with UniqueUsernameValidator, if: -> { will_save_change_to_username? }

--- a/app/models/account_warning.rb
+++ b/app/models/account_warning.rb
@@ -17,7 +17,7 @@
 #
 
 class AccountWarning < ApplicationRecord
-  enum action: {
+  enum :action, {
     none: 0,
     disable: 1_000,
     mark_statuses_as_sensitive: 1_250,
@@ -25,7 +25,7 @@ class AccountWarning < ApplicationRecord
     sensitive: 2_000,
     silence: 3_000,
     suspend: 4_000,
-  }, _suffix: :action
+  }, suffix: :action
 
   normalizes :text, with: ->(text) { text.to_s }, apply_to_nil: true
 

--- a/app/models/bulk_import.rb
+++ b/app/models/bulk_import.rb
@@ -24,7 +24,7 @@ class BulkImport < ApplicationRecord
   belongs_to :account
   has_many :rows, class_name: 'BulkImportRow', inverse_of: :bulk_import, dependent: :delete_all
 
-  enum type: {
+  enum :type, {
     following: 0,
     blocking: 1,
     muting: 2,
@@ -33,7 +33,7 @@ class BulkImport < ApplicationRecord
     lists: 5,
   }
 
-  enum state: {
+  enum :state, {
     unconfirmed: 0,
     scheduled: 1,
     in_progress: 2,

--- a/app/models/custom_filter.rb
+++ b/app/models/custom_filter.rb
@@ -31,7 +31,7 @@ class CustomFilter < ApplicationRecord
   include Expireable
   include Redisable
 
-  enum action: { warn: 0, hide: 1 }, _suffix: :action
+  enum :action, { warn: 0, hide: 1 }, suffix: :action
 
   belongs_to :account
   has_many :keywords, class_name: 'CustomFilterKeyword', inverse_of: :custom_filter, dependent: :destroy

--- a/app/models/domain_block.rb
+++ b/app/models/domain_block.rb
@@ -21,7 +21,7 @@ class DomainBlock < ApplicationRecord
   include DomainNormalizable
   include DomainMaterializable
 
-  enum severity: { silence: 0, suspend: 1, noop: 2 }
+  enum :severity, { silence: 0, suspend: 1, noop: 2 }
 
   validates :domain, presence: true, uniqueness: true, domain: true
 

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -28,7 +28,7 @@ class Import < ApplicationRecord
 
   belongs_to :account
 
-  enum type: { following: 0, blocking: 1, muting: 2, domain_blocking: 3, bookmarks: 4 }
+  enum :type, { following: 0, blocking: 1, muting: 2, domain_blocking: 3, bookmarks: 4 }
 
   validates :type, presence: true
 

--- a/app/models/ip_block.rb
+++ b/app/models/ip_block.rb
@@ -19,7 +19,7 @@ class IpBlock < ApplicationRecord
   include Expireable
   include Paginable
 
-  enum severity: {
+  enum :severity, {
     sign_up_requires_approval: 5000,
     sign_up_block: 5500,
     no_access: 9999,

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -18,7 +18,7 @@ class List < ApplicationRecord
 
   PER_ACCOUNT_LIMIT = 50
 
-  enum replies_policy: { list: 0, followed: 1, none: 2 }, _prefix: :show
+  enum :replies_policy, { list: 0, followed: 1, none: 2 }, prefix: :show
 
   belongs_to :account, optional: true
 

--- a/app/models/login_activity.rb
+++ b/app/models/login_activity.rb
@@ -16,7 +16,7 @@
 #
 
 class LoginActivity < ApplicationRecord
-  enum authentication_method: { password: 'password', otp: 'otp', webauthn: 'webauthn', sign_in_token: 'sign_in_token', omniauth: 'omniauth' }
+  enum :authentication_method, { password: 'password', otp: 'otp', webauthn: 'webauthn', sign_in_token: 'sign_in_token', omniauth: 'omniauth' }
 
   belongs_to :user
 

--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -34,8 +34,8 @@ class MediaAttachment < ApplicationRecord
 
   include Attachmentable
 
-  enum type: { image: 0, gifv: 1, video: 2, unknown: 3, audio: 4 }
-  enum processing: { queued: 0, in_progress: 1, complete: 2, failed: 3 }, _prefix: true
+  enum :type, { image: 0, gifv: 1, video: 2, unknown: 3, audio: 4 }
+  enum :processing, { queued: 0, in_progress: 1, complete: 2, failed: 3 }, prefix: true
 
   MAX_DESCRIPTION_LENGTH = 1_500
 

--- a/app/models/preview_card.rb
+++ b/app/models/preview_card.rb
@@ -47,8 +47,8 @@ class PreviewCard < ApplicationRecord
 
   self.inheritance_column = false
 
-  enum type: { link: 0, photo: 1, video: 2, rich: 3 }
-  enum link_type: { unknown: 0, article: 1 }
+  enum :type, { link: 0, photo: 1, video: 2, rich: 3 }
+  enum :link_type, { unknown: 0, article: 1 }
 
   has_many :preview_cards_statuses, dependent: :delete_all, inverse_of: :preview_card
   has_many :statuses, through: :preview_cards_statuses

--- a/app/models/relay.rb
+++ b/app/models/relay.rb
@@ -15,7 +15,7 @@
 class Relay < ApplicationRecord
   validates :inbox_url, presence: true, uniqueness: true, url: true, if: :will_save_change_to_inbox_url?
 
-  enum state: { idle: 0, pending: 1, accepted: 2, rejected: 3 }
+  enum :state, { idle: 0, pending: 1, accepted: 2, rejected: 3 }
 
   scope :enabled, -> { accepted }
 

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -55,7 +55,7 @@ class Report < ApplicationRecord
   # - app/javascript/mastodon/features/notifications/components/report.jsx
   # - app/javascript/mastodon/features/report/category.jsx
   # - app/javascript/mastodon/components/admin/ReportReasonSelector.jsx
-  enum category: {
+  enum :category, {
     other: 0,
     spam: 1_000,
     legal: 1_500,

--- a/app/models/software_update.rb
+++ b/app/models/software_update.rb
@@ -16,7 +16,7 @@
 class SoftwareUpdate < ApplicationRecord
   self.inheritance_column = nil
 
-  enum type: { patch: 0, minor: 1, major: 2 }, _suffix: :type
+  enum :type, { patch: 0, minor: 1, major: 2 }, suffix: :type
 
   def gem_version
     Gem::Version.new(version)

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -50,7 +50,7 @@ class Status < ApplicationRecord
   update_index('statuses', :proper)
   update_index('public_statuses', :proper)
 
-  enum visibility: { public: 0, unlisted: 1, private: 2, direct: 3, limited: 4 }, _suffix: :visibility
+  enum :visibility, { public: 0, unlisted: 1, private: 2, direct: 3, limited: 4 }, suffix: :visibility
 
   belongs_to :application, class_name: 'Doorkeeper::Application', optional: true
 


### PR DESCRIPTION
As of Rails 7.0, the enum syntax has been updated [1] to positional arguments without the prefix `_`. The old syntax is still supported [2], but it is recommended to use the new one.

[1] https://github.com/rails/rails/pull/41328
[2] https://github.com/rails/rails/pull/50987