### PR TITLE
Fix search being partially obscured by an icon in mobile layout

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2649,7 +2649,6 @@ $ui-header-height: 55px;
   .search__input {
     line-height: 18px;
     font-size: 16px;
-    padding: 15px;
     padding-inline-end: 30px;
   }
 
@@ -8280,7 +8279,8 @@ noscript {
 
   .search__input {
     border: 1px solid lighten($ui-base-color, 8%);
-    padding: 10px;
+    padding-top: 9px;
+    padding-bottom: 9px;
     padding-inline-end: 28px;
   }
 


### PR DESCRIPTION
Proposed fix to #29219

With this patch, on Firefox:

![image](https://github.com/mastodon/mastodon/assets/55913800/e54e5172-70af-410f-9602-4c4a83a78713)
![image](https://github.com/mastodon/mastodon/assets/55913800/6598acb6-7f73-480a-8b4a-499767189b34)

I decided to delete `padding: 15px` since it does not seem to affect either of the search fields (explore and list edit). In the mobile layout, padding from `.columns-area--mobile .search__input` is overshadowed by `.explore__search-header .search__input`. In the desktop layout it seems to be completely unused.