### PR TITLE
Move `RSpec/MultipleExpectations` out of todo file

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -138,6 +138,11 @@ RSpec/ExampleLength:
 RSpec/FilePath:
   Enabled: false
 
+# Reason: Enforce a limit while allowing for more complex examples to exist
+# https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecmultipleexpectations
+RSpec/MultipleExpectations:
+  Max: 5 # Override default of 1
+
 # Reason:
 # https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecnamedsubject
 RSpec/NamedSubject:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -38,9 +38,6 @@ Metrics/PerceivedComplexity:
 RSpec/ExampleLength:
   Max: 20 # Override default of 5
 
-RSpec/MultipleExpectations:
-  Max: 7
-
 # Configuration parameters: AllowSubject.
 RSpec/MultipleMemoizedHelpers:
   Max: 17


### PR DESCRIPTION
Similar to https://github.com/mastodon/mastodon/pull/29139 but for this rule. Opening as draft, and will link dependent PRs back to this one, rebase, and mark ready as review when others are all set.