### PR TITLE
Reduce `RSpec/MultipleExpectations` in post_status_service spec

### DIFF
--- a/spec/services/post_status_service_spec.rb
+++ b/spec/services/post_status_service_spec.rb
@@ -32,27 +32,27 @@ RSpec.describe PostStatusService, type: :service do
     let!(:future)          { Time.now.utc + 2.hours }
     let!(:previous_status) { Fabricate(:status, account: account) }
 
-    it 'schedules a status' do
-      status = subject.call(account, text: 'Hi future!', scheduled_at: future)
-      expect(status).to be_a ScheduledStatus
-      expect(status.scheduled_at).to eq future
-      expect(status.params['text']).to eq 'Hi future!'
-    end
-
-    it 'does not immediately create a status' do
+    it 'schedules a status for future creation and does not create one immediately' do
       media = Fabricate(:media_attachment, account: account)
       status = subject.call(account, text: 'Hi future!', media_ids: [media.id], scheduled_at: future)
 
-      expect(status).to be_a ScheduledStatus
-      expect(status.scheduled_at).to eq future
-      expect(status.params['text']).to eq 'Hi future!'
-      expect(status.params['media_ids']).to eq [media.id]
+      expect(status)
+        .to be_a(ScheduledStatus)
+        .and have_attributes(
+          scheduled_at: eq(future),
+          params: include(
+            'text' => eq('Hi future!'),
+            'media_ids' => contain_exactly(media.id)
+          )
+        )
       expect(media.reload.status).to be_nil
       expect(Status.where(text: 'Hi future!')).to_not exist
     end
 
-    it 'does not change statuses count' do
-      expect { subject.call(account, text: 'Hi future!', scheduled_at: future, thread: previous_status) }.to_not(change { [account.statuses_count, previous_status.replies_count] })
+    it 'does not change statuses_count of account or replies_count of thread previous status' do
+      expect { subject.call(account, text: 'Hi future!', scheduled_at: future, thread: previous_status) }
+        .to not_change { account.statuses_count }
+        .and(not_change { previous_status.replies_count })
     end
   end
 


### PR DESCRIPTION
_Requirement of https://github.com/mastodon/mastodon/pull/29223_

For this one, in addition to reducing expectations, I also:

- Converted the bottom example into a chained change expectation, rather than using the array values
- In the top part, noticed two examples which were doing basically the same setup, and combined them