### PR TITLE
Reduce round trips in disputes/appeals spec

### DIFF
--- a/spec/controllers/disputes/appeals_controller_spec.rb
+++ b/spec/controllers/disputes/appeals_controller_spec.rb
@@ -10,19 +10,17 @@ RSpec.describe Disputes::AppealsController do
   let!(:admin) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
 
   describe '#create' do
+    subject { post :create, params: params }
+
     context 'with valid params' do
       let(:current_user) { Fabricate(:user) }
       let(:strike) { Fabricate(:account_warning, target_account: current_user.account) }
+      let(:params) { { strike_id: strike.id, appeal: { text: 'Foo' } } }
 
-      before do
-        post :create, params: { strike_id: strike.id, appeal: { text: 'Foo' } }
-      end
+      it 'notifies staff about new appeal and redirects back to strike page', :sidekiq_inline do
+        subject
 
-      it 'notifies staff about new appeal', :sidekiq_inline do
         expect(ActionMailer::Base.deliveries.first.to).to eq([admin.email])
-      end
-
-      it 'redirects back to the strike page' do
         expect(response).to redirect_to(disputes_strike_path(strike.id))
       end
     end
@@ -30,16 +28,12 @@ RSpec.describe Disputes::AppealsController do
     context 'with invalid params' do
       let(:current_user) { Fabricate(:user) }
       let(:strike) { Fabricate(:account_warning, target_account: current_user.account) }
+      let(:params) { { strike_id: strike.id, appeal: { text: '' } } }
 
-      before do
-        post :create, params: { strike_id: strike.id, appeal: { text: '' } }
-      end
+      it 'does not send email and renders strike show page', :sidekiq_inline do
+        subject
 
-      it 'does not send email', :sidekiq_inline do
         expect(ActionMailer::Base.deliveries.size).to eq(0)
-      end
-
-      it 'renders the strike show page' do
         expect(response).to render_template('disputes/strikes/show')
       end
     end


### PR DESCRIPTION
_Extracted from another branch in advance of separate PR which uses Rails 7.1 `capture_emails` feature_