### PR TITLE
Show comments in the admin/instances page

### DIFF
--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -324,6 +324,14 @@ $content-width: 840px;
       padding-bottom: 0;
       margin-bottom: 0;
       border-bottom: 0;
+
+      .private-comment {
+        color: $darker-text-color;
+      }
+
+      .public-comment {
+        color: $secondary-text-color;
+      }
     }
 
     & > p {

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -325,12 +325,21 @@ $content-width: 840px;
       margin-bottom: 0;
       border-bottom: 0;
 
-      .private-comment {
-        color: $darker-text-color;
-      }
+      .comment {
+        display: block;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        margin-top: 4px;
 
-      .public-comment {
-        color: $secondary-text-color;
+        &.private-comment {
+          display: block;
+          color: $darker-text-color;
+        }
+
+        &.public-comment {
+          display: block;
+          color: $secondary-text-color;
+        }
       }
     }
 

--- a/app/views/admin/instances/_instance.html.haml
+++ b/app/views/admin/instances/_instance.html.haml
@@ -8,9 +8,9 @@
         - if instance.domain_block
           = instance.domain_block.policies.map { |policy| t(policy, scope: 'admin.instances.content_policies.policies') }.join(' · ')
           - if instance.domain_block.public_comment.present?
-            %span.comment.public-comment "#{t('admin.domain_blocks.public_comment')}: #{instance.domain_block.public_comment}"
+            %span.comment.public-comment #{t('admin.domain_blocks.public_comment')}: #{instance.domain_block.public_comment}
           - if instance.domain_block.private_comment.present?
-            %span.comment.private-comment "#{t('admin.domain_blocks.private_comment')}: #{instance.domain_block.private_comment}"
+            %span.comment.private-comment #{t('admin.domain_blocks.private_comment')}: #{instance.domain_block.private_comment}
         - elsif instance.domain_allow
           = t('admin.accounts.whitelisted')
         - else

--- a/app/views/admin/instances/_instance.html.haml
+++ b/app/views/admin/instances/_instance.html.haml
@@ -7,8 +7,8 @@
       %small
         - if instance.domain_block
           = instance.domain_block.policies.map { |policy| t(policy, scope: 'admin.instances.content_policies.policies') }.join(' · ')
-          %span.public-comment= t(instance.domain_block.public_comment) if instance.domain_block.public_comment.present?
-          %span.private-comment= t(instance.domain_block.private_comment) if instance.domain_block.private_comment.present?
+          %span.comment.public-comment= t('admin.domain_blocks.public_comment') + ': ' + instance.domain_block.public_comment if instance.domain_block.public_comment.present?
+          %span.comment.private-comment= t('admin.domain_blocks.private_comment') + ': ' + instance.domain_block.private_comment if instance.domain_block.private_comment.present?
         - elsif instance.domain_allow
           = t('admin.accounts.whitelisted')
         - else

--- a/app/views/admin/instances/_instance.html.haml
+++ b/app/views/admin/instances/_instance.html.haml
@@ -7,6 +7,8 @@
       %small
         - if instance.domain_block
           = instance.domain_block.policies.map { |policy| t(policy, scope: 'admin.instances.content_policies.policies') }.join(' · ')
+          %span.public-comment= t(instance.domain_block.public_comment) if instance.domain_block.public_comment.present?
+          %span.private-comment= t(instance.domain_block.private_comment) if instance.domain_block.private_comment.present?
         - elsif instance.domain_allow
           = t('admin.accounts.whitelisted')
         - else

--- a/app/views/admin/instances/_instance.html.haml
+++ b/app/views/admin/instances/_instance.html.haml
@@ -7,8 +7,10 @@
       %small
         - if instance.domain_block
           = instance.domain_block.policies.map { |policy| t(policy, scope: 'admin.instances.content_policies.policies') }.join(' · ')
-          %span.comment.public-comment= t('admin.domain_blocks.public_comment') + ': ' + instance.domain_block.public_comment if instance.domain_block.public_comment.present?
-          %span.comment.private-comment= t('admin.domain_blocks.private_comment') + ': ' + instance.domain_block.private_comment if instance.domain_block.private_comment.present?
+          - if instance.domain_block.public_comment.present?
+            %span.comment.public-comment "#{t('admin.domain_blocks.public_comment')}: #{instance.domain_block.public_comment}"
+          - if instance.domain_block.private_comment.present?
+            %span.comment.private-comment "#{t('admin.domain_blocks.private_comment')}: #{instance.domain_block.private_comment}"
         - elsif instance.domain_allow
           = t('admin.accounts.whitelisted')
         - else


### PR DESCRIPTION
We have lots of spaces on admin/instances page. Show internal, public comment will be useful when managing instance blocks
![image](https://github.com/mastodon/mastodon/assets/5047683/566530a0-e061-41b0-bcd7-9c167102d515)
