### PR TITLE
Use `capture_emails` helper to improve email assertions in specs

### DIFF
--- a/spec/controllers/admin/disputes/appeals_controller_spec.rb
+++ b/spec/controllers/admin/disputes/appeals_controller_spec.rb
@@ -43,6 +43,8 @@ RSpec.describe Admin::Disputes::AppealsController do
       expect(target_account.reload)
         .to_not be_suspended
 
+      expect(emails.size)
+        .to eq(1)
       expect(emails.first)
         .to have_attributes(
           to: contain_exactly(target_account.user.email),
@@ -61,6 +63,9 @@ RSpec.describe Admin::Disputes::AppealsController do
 
       expect(response)
         .to redirect_to(disputes_strike_path(appeal.strike))
+
+      expect(emails.size)
+        .to eq(1)
 
       expect(emails.first)
         .to have_attributes(

--- a/spec/controllers/admin/disputes/appeals_controller_spec.rb
+++ b/spec/controllers/admin/disputes/appeals_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Admin::Disputes::AppealsController do
     let(:current_user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
 
     it 'redirects back to the strike page and notifies target account about approved appeal', :sidekiq_inline do
-      subject
+      emails = capture_emails { subject }
 
       expect(response)
         .to redirect_to(disputes_strike_path(appeal.strike))
@@ -43,9 +43,11 @@ RSpec.describe Admin::Disputes::AppealsController do
       expect(target_account.reload)
         .to_not be_suspended
 
-      expect(UserMailer.deliveries.size).to eq(1)
-      expect(UserMailer.deliveries.first.to.first).to eq(target_account.user.email)
-      expect(UserMailer.deliveries.first.subject).to eq(I18n.t('user_mailer.appeal_approved.subject', date: I18n.l(appeal.created_at)))
+      expect(emails.first)
+        .to have_attributes(
+          to: contain_exactly(target_account.user.email),
+          subject: eq(I18n.t('user_mailer.appeal_approved.subject', date: I18n.l(appeal.created_at)))
+        )
     end
   end
 
@@ -55,14 +57,16 @@ RSpec.describe Admin::Disputes::AppealsController do
     let(:current_user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
 
     it 'redirects back to the strike page and notifies target account about rejected appeal', :sidekiq_inline do
-      subject
+      emails = capture_emails { subject }
 
       expect(response)
         .to redirect_to(disputes_strike_path(appeal.strike))
 
-      expect(UserMailer.deliveries.size).to eq(1)
-      expect(UserMailer.deliveries.first.to.first).to eq(target_account.user.email)
-      expect(UserMailer.deliveries.first.subject).to eq(I18n.t('user_mailer.appeal_rejected.subject', date: I18n.l(appeal.created_at)))
+      expect(emails.first)
+        .to have_attributes(
+          to: contain_exactly(target_account.user.email),
+          subject: eq(I18n.t('user_mailer.appeal_rejected.subject', date: I18n.l(appeal.created_at)))
+        )
     end
   end
 end

--- a/spec/controllers/admin/resets_controller_spec.rb
+++ b/spec/controllers/admin/resets_controller_spec.rb
@@ -5,6 +5,8 @@ require 'rails_helper'
 describe Admin::ResetsController do
   render_views
 
+  subject { post :create, params: { account_id: account.id } }
+
   let(:account) { Fabricate(:account) }
 
   before do
@@ -13,11 +15,9 @@ describe Admin::ResetsController do
 
   describe 'POST #create', :sidekiq_inline do
     it 'redirects to admin accounts page' do
-      expect do
-        post :create, params: { account_id: account.id }
-      end.to change(Devise.mailer.deliveries, :size).by(2)
+      emails = capture_emails { subject }
 
-      expect(Devise.mailer.deliveries).to have_attributes(
+      expect(emails).to have_attributes(
         first: have_attributes(
           to: include(account.user.email),
           subject: I18n.t('devise.mailer.password_change.subject')

--- a/spec/controllers/admin/resets_controller_spec.rb
+++ b/spec/controllers/admin/resets_controller_spec.rb
@@ -17,6 +17,8 @@ describe Admin::ResetsController do
     it 'redirects to admin accounts page' do
       emails = capture_emails { subject }
 
+      expect(emails.size)
+        .to eq(2)
       expect(emails).to have_attributes(
         first: have_attributes(
           to: include(account.user.email),

--- a/spec/controllers/auth/sessions_controller_spec.rb
+++ b/spec/controllers/auth/sessions_controller_spec.rb
@@ -132,6 +132,8 @@ RSpec.describe Auth::SessionsController do
           expect(controller.current_user)
             .to eq user
 
+          expect(emails.size)
+            .to eq(1)
           expect(emails.first)
             .to have_attributes(
               to: contain_exactly(user.email),
@@ -276,6 +278,8 @@ RSpec.describe Auth::SessionsController do
             expect(flash[:alert])
               .to match I18n.t('users.rate_limited')
 
+            expect(emails.size)
+              .to eq(1)
             expect(emails.first)
               .to have_attributes(
                 to: contain_exactly(user.email),

--- a/spec/controllers/auth/sessions_controller_spec.rb
+++ b/spec/controllers/auth/sessions_controller_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe Auth::SessionsController do
         end
 
         it 'logs the user in and sends suspicious email and redirects home', :sidekiq_inline do
-          subject
+          emails = capture_emails { subject }
 
           expect(response)
             .to redirect_to(root_path)
@@ -132,9 +132,11 @@ RSpec.describe Auth::SessionsController do
           expect(controller.current_user)
             .to eq user
 
-          expect(UserMailer.deliveries.size).to eq(1)
-          expect(UserMailer.deliveries.first.to.first).to eq(user.email)
-          expect(UserMailer.deliveries.first.subject).to eq(I18n.t('user_mailer.suspicious_sign_in.subject'))
+          expect(emails.first)
+            .to have_attributes(
+              to: contain_exactly(user.email),
+              subject: eq(I18n.t('user_mailer.suspicious_sign_in.subject'))
+            )
         end
       end
 
@@ -260,21 +262,25 @@ RSpec.describe Auth::SessionsController do
           end
 
           it 'does not log the user in, sets a flash message, and sends a suspicious sign in email', :sidekiq_inline do
-            Auth::SessionsController::MAX_2FA_ATTEMPTS_PER_HOUR.times do
-              post :create, params: { user: { otp_attempt: '1234' } }, session: { attempt_user_id: user.id, attempt_user_updated_at: user.updated_at.to_s }
-              expect(controller.current_user).to be_nil
+            emails = capture_emails do
+              Auth::SessionsController::MAX_2FA_ATTEMPTS_PER_HOUR.times do
+                post :create, params: { user: { otp_attempt: '1234' } }, session: { attempt_user_id: user.id, attempt_user_updated_at: user.updated_at.to_s }
+                expect(controller.current_user).to be_nil
+              end
+              post :create, params: { user: { otp_attempt: user.current_otp } }, session: { attempt_user_id: user.id, attempt_user_updated_at: user.updated_at.to_s }
             end
-
-            post :create, params: { user: { otp_attempt: user.current_otp } }, session: { attempt_user_id: user.id, attempt_user_updated_at: user.updated_at.to_s }
 
             expect(controller.current_user)
               .to be_nil
+
             expect(flash[:alert])
               .to match I18n.t('users.rate_limited')
 
-            expect(UserMailer.deliveries.size).to eq(1)
-            expect(UserMailer.deliveries.first.to.first).to eq(user.email)
-            expect(UserMailer.deliveries.first.subject).to eq(I18n.t('user_mailer.failed_2fa.subject'))
+            expect(emails.first)
+              .to have_attributes(
+                to: contain_exactly(user.email),
+                subject: eq(I18n.t('user_mailer.failed_2fa.subject'))
+              )
           end
         end
 

--- a/spec/controllers/disputes/appeals_controller_spec.rb
+++ b/spec/controllers/disputes/appeals_controller_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe Disputes::AppealsController do
       it 'notifies staff about new appeal and redirects back to strike page', :sidekiq_inline do
         emails = capture_emails { subject }
 
+        expect(emails.size)
+          .to eq(1)
         expect(emails.first)
           .to have_attributes(
             to: contain_exactly(admin.email),

--- a/spec/controllers/disputes/appeals_controller_spec.rb
+++ b/spec/controllers/disputes/appeals_controller_spec.rb
@@ -18,9 +18,13 @@ RSpec.describe Disputes::AppealsController do
       let(:params) { { strike_id: strike.id, appeal: { text: 'Foo' } } }
 
       it 'notifies staff about new appeal and redirects back to strike page', :sidekiq_inline do
-        subject
+        emails = capture_emails { subject }
 
-        expect(ActionMailer::Base.deliveries.first.to).to eq([admin.email])
+        expect(emails.first)
+          .to have_attributes(
+            to: contain_exactly(admin.email),
+            subject: eq(I18n.t('admin_mailer.new_appeal.subject', username: current_user.account.acct, instance: Rails.configuration.x.local_domain))
+          )
         expect(response).to redirect_to(disputes_strike_path(strike.id))
       end
     end
@@ -31,9 +35,9 @@ RSpec.describe Disputes::AppealsController do
       let(:params) { { strike_id: strike.id, appeal: { text: '' } } }
 
       it 'does not send email and renders strike show page', :sidekiq_inline do
-        subject
+        emails = capture_emails { subject }
 
-        expect(ActionMailer::Base.deliveries.size).to eq(0)
+        expect(emails).to be_empty
         expect(response).to render_template('disputes/strikes/show')
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -462,6 +462,8 @@ RSpec.describe User do
         emails = capture_emails { subject }
 
         expect(user.confirmed_at).to be_present
+        expect(emails.size)
+          .to eq(1)
         expect(emails.first)
           .to have_attributes(
             to: contain_exactly(user.email),

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -455,18 +455,18 @@ RSpec.describe User do
 
     let!(:user) { Fabricate(:user, confirmed_at: confirmed_at) }
 
-    before { ActionMailer::Base.deliveries.clear }
-
-    after { ActionMailer::Base.deliveries.clear }
-
     context 'when user is new' do
       let(:confirmed_at) { nil }
 
       it 'confirms user and delivers welcome email', :sidekiq_inline do
-        subject
+        emails = capture_emails { subject }
 
         expect(user.confirmed_at).to be_present
-        expect(ActionMailer::Base.deliveries.count).to eq 1
+        expect(emails.first)
+          .to have_attributes(
+            to: contain_exactly(user.email),
+            subject: eq(I18n.t('user_mailer.welcome.subject'))
+          )
       end
     end
 
@@ -474,10 +474,10 @@ RSpec.describe User do
       let(:confirmed_at) { Time.zone.now }
 
       it 'confirms user but does not deliver welcome email' do
-        subject
+        emails = capture_emails { subject }
 
         expect(user.confirmed_at).to be_present
-        expect(ActionMailer::Base.deliveries.count).to eq 0
+        expect(emails).to be_empty
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -82,6 +82,7 @@ RSpec.configure do |config|
   config.include Devise::Test::ControllerHelpers, type: :view
   config.include Devise::Test::IntegrationHelpers, type: :feature
   config.include Devise::Test::IntegrationHelpers, type: :request
+  config.include ActionMailer::TestHelper
   config.include Paperclip::Shoulda::Matchers
   config.include ActiveSupport::Testing::TimeHelpers
   config.include Chewy::Rspec::Helpers

--- a/spec/requests/api/v1/reports_spec.rb
+++ b/spec/requests/api/v1/reports_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Reports' do
 
     it 'creates a report', :aggregate_failures do
       perform_enqueued_jobs do
-        subject
+        emails = capture_emails { subject }
 
         expect(response).to have_http_status(200)
         expect(body_as_json).to match(
@@ -49,7 +49,11 @@ RSpec.describe 'Reports' do
         expect(target_account.targeted_reports).to_not be_empty
         expect(target_account.targeted_reports.first.comment).to eq 'reasons'
 
-        expect(ActionMailer::Base.deliveries.first.to).to eq([admin.email])
+        expect(emails.first)
+          .to have_attributes(
+            to: contain_exactly(admin.email),
+            subject: eq(I18n.t('admin_mailer.new_report.subject', instance: Rails.configuration.x.local_domain, id: target_account.targeted_reports.first.id))
+          )
       end
     end
 

--- a/spec/requests/api/v1/reports_spec.rb
+++ b/spec/requests/api/v1/reports_spec.rb
@@ -49,6 +49,8 @@ RSpec.describe 'Reports' do
         expect(target_account.targeted_reports).to_not be_empty
         expect(target_account.targeted_reports.first.comment).to eq 'reasons'
 
+        expect(emails.size)
+          .to eq(1)
         expect(emails.first)
           .to have_attributes(
             to: contain_exactly(admin.email),

--- a/spec/services/notify_service_spec.rb
+++ b/spec/services/notify_service_spec.rb
@@ -167,6 +167,8 @@ RSpec.describe NotifyService, type: :service do
       it 'sends email', :sidekiq_inline do
         emails = capture_emails { subject }
 
+        expect(emails.size)
+          .to eq(1)
         expect(emails.first)
           .to have_attributes(
             to: contain_exactly(user.email),

--- a/spec/services/notify_service_spec.rb
+++ b/spec/services/notify_service_spec.rb
@@ -157,8 +157,6 @@ RSpec.describe NotifyService, type: :service do
 
   describe 'email' do
     before do
-      ActionMailer::Base.deliveries.clear
-
       user.settings.update('notification_emails.follow': enabled)
       user.save
     end
@@ -167,7 +165,13 @@ RSpec.describe NotifyService, type: :service do
       let(:enabled) { true }
 
       it 'sends email', :sidekiq_inline do
-        expect { subject }.to change(ActionMailer::Base.deliveries, :count).by(1)
+        emails = capture_emails { subject }
+
+        expect(emails.first)
+          .to have_attributes(
+            to: contain_exactly(user.email),
+            subject: eq(I18n.t('notification_mailer.follow.subject', name: sender.acct))
+          )
       end
     end
 
@@ -175,7 +179,9 @@ RSpec.describe NotifyService, type: :service do
       let(:enabled) { false }
 
       it "doesn't send email" do
-        expect { subject }.to_not change(ActionMailer::Base.deliveries, :count).from(0)
+        emails = capture_emails { subject }
+
+        expect(emails).to be_empty
       end
     end
   end

--- a/spec/services/report_service_spec.rb
+++ b/spec/services/report_service_spec.rb
@@ -158,13 +158,14 @@ RSpec.describe ReportService, type: :service do
 
     before do
       Fabricate(:report, target_account: target_account)
-      ActionMailer::Base.deliveries.clear
       source_account.user.settings['notification_emails.report'] = true
       source_account.user.save
     end
 
     it 'does not send an e-mail' do
-      expect { subject.call }.to_not change(ActionMailer::Base.deliveries, :count).from(0)
+      emails = capture_emails { subject.call }
+
+      expect(emails).to be_empty
     end
   end
 end

--- a/spec/workers/backup_worker_spec.rb
+++ b/spec/workers/backup_worker_spec.rb
@@ -19,6 +19,8 @@ describe BackupWorker do
 
       expect(service).to have_received(:call).with(backup)
       expect { other_backup.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect(emails.size)
+        .to eq(1)
       expect(emails.first)
         .to have_attributes(
           to: contain_exactly(backup.user.email),

--- a/spec/workers/backup_worker_spec.rb
+++ b/spec/workers/backup_worker_spec.rb
@@ -15,12 +15,15 @@ describe BackupWorker do
     let!(:other_backup) { Fabricate(:backup, user: backup.user) }
 
     it 'sends the backup to the service and removes other backups', :sidekiq_inline do
-      expect do
-        worker.perform(backup.id)
-      end.to change(UserMailer.deliveries, :size).by(1)
+      emails = capture_emails { worker.perform(backup.id) }
 
       expect(service).to have_received(:call).with(backup)
       expect { other_backup.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect(emails.first)
+        .to have_attributes(
+          to: contain_exactly(backup.user.email),
+          subject: I18n.t('user_mailer.backup_ready.subject')
+        )
     end
 
     context 'when sidekiq retries are exhausted' do


### PR DESCRIPTION
Related changes here:

- Add `ActionMailer::TestHelper` to spec config, to make this helper method available
- Remove before/after where we were explicitly resetting the `deliveries` collection
- Wrap the code that we expect to generate emails with the `capture_emails` helper
- Update the assertions to be on this set of captured emails
- In a few cases where we were just checking for emails at all, expand coverage a bit more to specify the `to` recipient and the `subject`

Main benefit here is increased confidence that the emails we are asserting against came from where we expected them. I think there's a small but nice readability improvement on the assertions as well. Possible future improvements here:

- The auth/sessions block where we exceed the 2FA rate limit is a little awkward/repetitive, might be good to extract methods here at some point
- We are using the email_spec gem helpers in our mailer specs, but not in these controller specs. I did not do this here because I recall some issue with them not being fully chainable -- but this might be good future improvement as well.