### PR TITLE
Fix `sensitive` flag not being removed when removing CW in new compose form

### DIFF
--- a/app/javascript/mastodon/reducers/compose.js
+++ b/app/javascript/mastodon/reducers/compose.js
@@ -315,8 +315,8 @@ export default function compose(state = initialState, action) {
       map.set('spoiler', !state.get('spoiler'));
       map.set('idempotencyKey', uuid());
 
-      if (!state.get('sensitive') && state.get('media_attachments').size >= 1) {
-        map.set('sensitive', true);
+      if (state.get('media_attachments').size >= 1 && !state.get('default_sensitive')) {
+        map.set('sensitive', !state.get('spoiler'));
       }
     });
   case COMPOSE_SPOILER_TEXT_CHANGE:


### PR DESCRIPTION
In the new Compose UI (#28119), the option to set the sensitive (NSFW) flag has gone and the sensitivity can only be changed in time with the spoiler flag.
Despite this, the sensitive flag is always on when attaching an image and toggling the spoiler flag. This will be fixed.

Of course, this change in the UI may not always be favourable.