### PR TITLE
improve Elasticsearch configuration handling

### DIFF
--- a/config/initializers/chewy.rb
+++ b/config/initializers/chewy.rb
@@ -12,7 +12,8 @@ ca_file         = ENV.fetch('ES_CA_FILE', nil).presence
 transport_options = { ssl: { ca_file: ca_file } } if ca_file.present?
 
 Chewy.settings = {
-  host: "#{host}:#{port}",
+  host: host,
+  port: port.to_i,
   prefix: prefix,
   enabled: enabled,
   journal: false,


### PR DESCRIPTION
Concatenating the host and port like this leads to problems and caused multiple errors for me.
It's currently possible to configure multiple domains (all using ssl) by configuring ES_HOST to be
`https://es1.example.org:9200,https://es2.example.org:9200,https://es2.example.org`
but that's not really intuitive, the port needs to be missing for the last, but is required for the others


EDIT: wait, it seems like port gets ignored and only host gets used for the port
EDIT: maybe it's just something one has to know
EDIT: maybe it should just get documented better, but the documentation at https://github.com/toptal/chewy isn't better