### PR TITLE
Remove column defaults for `status_pins` timestamp columns

### DIFF
--- a/db/migrate/20240217171534_remove_defaults_for_status_pins_timestamps.rb
+++ b/db/migrate/20240217171534_remove_defaults_for_status_pins_timestamps.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class RemoveDefaultsForStatusPinsTimestamps < ActiveRecord::Migration[7.1]
+  def change
+    change_column_default :status_pins, :created_at, from: -> { 'CURRENT_TIMESTAMP' }, to: nil
+    change_column_default :status_pins, :updated_at, from: -> { 'CURRENT_TIMESTAMP' }, to: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1030,8 +1030,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_22_161611) do
   create_table "status_pins", force: :cascade do |t|
     t.bigint "account_id", null: false
     t.bigint "status_id", null: false
-    t.datetime "created_at", precision: nil, default: -> { "now()" }, null: false
-    t.datetime "updated_at", precision: nil, default: -> { "now()" }, null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["account_id", "status_id"], name: "index_status_pins_on_account_id_and_status_id", unique: true
     t.index ["status_id"], name: "index_status_pins_on_status_id"
   end


### PR DESCRIPTION
These seem to be the only timestamps pair that have this set (the framework will set them by default) and I don't think there's a reason why (Added in: https://github.com/mastodon/mastodon/pull/4690). Update here is just for consistency with other tables, and to reduce the diff between a full `db:migrate` run output -vs- the schema.rb in the repo (there's a `NOW()` vs `CURRENT_TIMESTAMP` change currently).