### PR TITLE
Align schema.rb definition order with `db:migrate` generation

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -181,8 +181,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_10_123453) do
     t.integer "avatar_storage_schema_version"
     t.integer "header_storage_schema_version"
     t.string "devices_url"
-    t.integer "suspension_origin"
     t.datetime "sensitized_at", precision: nil
+    t.integer "suspension_origin"
     t.boolean "trendable"
     t.datetime "reviewed_at", precision: nil
     t.datetime "requested_review_at", precision: nil
@@ -564,12 +564,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_10_123453) do
   end
 
   create_table "ip_blocks", force: :cascade do |t|
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
-    t.datetime "expires_at", precision: nil
     t.inet "ip", default: "0.0.0.0", null: false
     t.integer "severity", default: 0, null: false
+    t.datetime "expires_at", precision: nil
     t.text "comment", default: "", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["ip"], name: "index_ip_blocks_on_ip", unique: true
   end
 


### PR DESCRIPTION
I'm trying to eliminate the diff between what is held in the schema.rb in the repo and what the output of a full/fresh `db:migrate` run is. These columns have the same definition, but get dumped in a different order.

I'm guessing this is a side effect either of a framework change, or some historical manual editing or rebasing or something.

I'd be curious to have someone else run a local `db:migrate` first before merging this, and confirm that you also see these differences and its not local to my db version/config/something (There may be other column type changes, but these are for me the only order-only changes).