### PR TITLE
Enable rejection of Create Activities if the status includes unusable hashtags

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -82,6 +82,9 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
     process_tags
     process_audience
 
+    # Reject the status unless all the hashtags are usable:
+    return reject_payload! unless @tags.all?(&:usable?)
+
     ApplicationRecord.transaction do
       @status = Status.create!(@params)
       attach_tags(@status)


### PR DESCRIPTION
This allows servers to reject incoming activities that attempt to use known unusable hashtags. Similar code can be done with regards to mention counts.

### This pull request doesn't have unit tests, since I'm unfamiliar with how the tests are setup for processing incoming activities.

This does result in log lines like this: 
```Feb 17 20:39:03 mastodon bundle[223424]: I, [2024-02-17T20:39:03.426270 #223424]  INFO -- : Rejected Create activity https://hachyderm.io/users/thisismissem/statuses/111948744350334526>```
