### PR TITLE
Allow instance API without auth on limited federation mode

### DIFF
--- a/app/controllers/api/v1/instances/extended_descriptions_controller.rb
+++ b/app/controllers/api/v1/instances/extended_descriptions_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Api::V1::Instances::ExtendedDescriptionsController < Api::V1::Instances::BaseController
+  skip_before_action :require_authenticated_user!
   skip_around_action :set_locale
 
   before_action :set_extended_description

--- a/app/controllers/api/v1/instances_controller.rb
+++ b/app/controllers/api/v1/instances_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Api::V1::InstancesController < Api::BaseController
-  skip_before_action :require_authenticated_user!, unless: :limited_federation_mode?
+  skip_before_action :require_authenticated_user!
   skip_around_action :set_locale
 
   vary_by ''


### PR DESCRIPTION
Limited federation mode is almost forgotten feature for mastoton after v4
`/api/v{1,2}/instance` endpoint need to be public because
- It is required on `/about/` page to render instance information
- It is required on Mastodon official app to determine the server is mastodon or not, and retreive server informations
  Else, Users cannot login through offical app if the server is in limited federation mode

Downside of this PR:
- Contact account will be exposed through this API. But it was public before v4.0.0(which removes static pages and turn into a single PWA)