### PR TITLE
Add a missing spec to `SessionsController#webauthn_options` 

### DIFF
--- a/spec/controllers/auth/sessions_controller_spec.rb
+++ b/spec/controllers/auth/sessions_controller_spec.rb
@@ -434,14 +434,16 @@ RSpec.describe Auth::SessionsController do
   end
 
   describe 'GET #webauthn_options' do
+    subject { get :webauthn_options, session: { attempt_user_id: user.id } }
+
+    let!(:user) do
+      Fabricate(:user, email: 'x@y.com', password: 'abcdefgh', otp_required_for_login: true, otp_secret: User.generate_otp_secret(32))
+    end
+
     context 'with WebAuthn and OTP enabled as second factor' do
       let(:domain) { "#{Rails.configuration.x.use_https ? 'https' : 'http'}://#{Rails.configuration.x.web_domain}" }
 
       let(:fake_client) { WebAuthn::FakeClient.new(domain) }
-
-      let!(:user) do
-        Fabricate(:user, email: 'x@y.com', password: 'abcdefgh', otp_required_for_login: true, otp_secret: User.generate_otp_secret(32))
-      end
 
       before do
         user.update(webauthn_id: WebAuthn.generate_user_id)
@@ -456,8 +458,17 @@ RSpec.describe Auth::SessionsController do
       end
 
       it 'returns http success' do
-        get :webauthn_options
+        subject
+
         expect(response).to have_http_status 200
+      end
+    end
+
+    context 'when WebAuthn not enabled' do
+      it 'returns http unauthorized' do
+        subject
+
+        expect(response).to have_http_status 401
       end
     end
   end


### PR DESCRIPTION
There was a missing test [1] for `SessionsController#webauthn_options` for when webauthn is not enabled on a user. This PR will make sure that the 401 Error is rendered in the Test suite.

[1] https://app.codecov.io/gh/mastodon/mastodon/pull/29158/blob/app/controllers/auth/sessions_controller.rb#L61