### PR TITLE
Add a missing thread example to the statuses spec

### DIFF
--- a/spec/requests/api/v1/statuses_spec.rb
+++ b/spec/requests/api/v1/statuses_spec.rb
@@ -167,6 +167,16 @@ describe '/api/v1/statuses' do
           expect(response.headers['X-RateLimit-Remaining']).to eq '0'
         end
       end
+
+      context 'with missing thread' do
+        let(:params) { { status: 'Hello world', in_reply_to_id: 0 } }
+
+        it 'returns http not found' do
+          subject
+
+          expect(response).to have_http_status(404)
+        end
+      end
     end
 
     describe 'DELETE /api/v1/statuses/:id' do


### PR DESCRIPTION
This PR adds a missing example[1] to the statuses spec that demonstrates that when the thread is not found, a 404 status is returned.

[1] https://app.codecov.io/gh/mastodon/mastodon/pull/29158/blob/app/controllers/api/v1/statuses_controller.rb#L125