### PR TITLE
Move `AccountSuggestions::Source` subclasses default limit value to constant

### DIFF
--- a/app/models/account_suggestions/friends_of_friends_source.rb
+++ b/app/models/account_suggestions/friends_of_friends_source.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AccountSuggestions::FriendsOfFriendsSource < AccountSuggestions::Source
-  def get(account, limit: 10)
+  def get(account, limit: DEFAULT_LIMIT)
     Account.find_by_sql([<<~SQL.squish, { id: account.id, limit: limit }]).map { |row| [row.id, key] }
       WITH first_degree AS (
           SELECT target_account_id

--- a/app/models/account_suggestions/global_source.rb
+++ b/app/models/account_suggestions/global_source.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AccountSuggestions::GlobalSource < AccountSuggestions::Source
-  def get(account, limit: 10)
+  def get(account, limit: DEFAULT_LIMIT)
     FollowRecommendation.localized(content_locale).joins(:account).merge(base_account_scope(account)).order(rank: :desc).limit(limit).pluck(:account_id, :reason)
   end
 

--- a/app/models/account_suggestions/setting_source.rb
+++ b/app/models/account_suggestions/setting_source.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AccountSuggestions::SettingSource < AccountSuggestions::Source
-  def get(account, limit: 10)
+  def get(account, limit: DEFAULT_LIMIT)
     if setting_enabled?
       base_account_scope(account).where(setting_to_where_condition).limit(limit).pluck(:id).zip([key].cycle)
     else

--- a/app/models/account_suggestions/similar_profiles_source.rb
+++ b/app/models/account_suggestions/similar_profiles_source.rb
@@ -47,7 +47,7 @@ class AccountSuggestions::SimilarProfilesSource < AccountSuggestions::Source
     end
   end
 
-  def get(account, limit: 10)
+  def get(account, limit: DEFAULT_LIMIT)
     recently_followed_account_ids = account.active_relationships.recent.limit(5).pluck(:target_account_id)
 
     if Chewy.enabled? && !recently_followed_account_ids.empty?

--- a/app/models/account_suggestions/source.rb
+++ b/app/models/account_suggestions/source.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class AccountSuggestions::Source
+  DEFAULT_LIMIT = 10
+
   def get(_account, **kwargs)
     raise NotImplementedError
   end


### PR DESCRIPTION
These all inherit from same base class and have same default value.