### PR TITLE
Remove unneeded `type: :service` from spec/services files

### DIFF
--- a/spec/services/account_search_service_spec.rb
+++ b/spec/services/account_search_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe AccountSearchService, type: :service do
+describe AccountSearchService do
   describe '#call' do
     context 'with a query to ignore' do
       it 'returns empty array for missing query' do

--- a/spec/services/account_statuses_cleanup_service_spec.rb
+++ b/spec/services/account_statuses_cleanup_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe AccountStatusesCleanupService, type: :service do
+describe AccountStatusesCleanupService do
   let(:account)           { Fabricate(:account, username: 'alice', domain: nil) }
   let(:account_policy)    { Fabricate(:account_statuses_cleanup_policy, account: account) }
   let!(:unrelated_status) { Fabricate(:status, created_at: 3.years.ago) }

--- a/spec/services/activitypub/fetch_featured_collection_service_spec.rb
+++ b/spec/services/activitypub/fetch_featured_collection_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe ActivityPub::FetchFeaturedCollectionService, type: :service do
+RSpec.describe ActivityPub::FetchFeaturedCollectionService do
   subject { described_class.new }
 
   let(:actor) { Fabricate(:account, domain: 'example.com', uri: 'https://example.com/account', featured_collection_url: 'https://example.com/account/pinned') }

--- a/spec/services/activitypub/fetch_featured_tags_collection_service_spec.rb
+++ b/spec/services/activitypub/fetch_featured_tags_collection_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe ActivityPub::FetchFeaturedTagsCollectionService, type: :service do
+RSpec.describe ActivityPub::FetchFeaturedTagsCollectionService do
   subject { described_class.new }
 
   let(:collection_url) { 'https://example.com/account/tags' }

--- a/spec/services/activitypub/fetch_remote_account_service_spec.rb
+++ b/spec/services/activitypub/fetch_remote_account_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe ActivityPub::FetchRemoteAccountService, type: :service do
+RSpec.describe ActivityPub::FetchRemoteAccountService do
   subject { described_class.new }
 
   let!(:actor) do

--- a/spec/services/activitypub/fetch_remote_actor_service_spec.rb
+++ b/spec/services/activitypub/fetch_remote_actor_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe ActivityPub::FetchRemoteActorService, type: :service do
+RSpec.describe ActivityPub::FetchRemoteActorService do
   subject { described_class.new }
 
   let!(:actor) do

--- a/spec/services/activitypub/fetch_remote_key_service_spec.rb
+++ b/spec/services/activitypub/fetch_remote_key_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe ActivityPub::FetchRemoteKeyService, type: :service do
+RSpec.describe ActivityPub::FetchRemoteKeyService do
   subject { described_class.new }
 
   let(:webfinger) { { subject: 'acct:alice@example.com', links: [{ rel: 'self', href: 'https://example.com/alice' }] } }

--- a/spec/services/activitypub/fetch_remote_status_service_spec.rb
+++ b/spec/services/activitypub/fetch_remote_status_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe ActivityPub::FetchRemoteStatusService, type: :service do
+RSpec.describe ActivityPub::FetchRemoteStatusService do
   include ActionView::Helpers::TextHelper
 
   subject { described_class.new }

--- a/spec/services/activitypub/fetch_replies_service_spec.rb
+++ b/spec/services/activitypub/fetch_replies_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe ActivityPub::FetchRepliesService, type: :service do
+RSpec.describe ActivityPub::FetchRepliesService do
   subject { described_class.new }
 
   let(:actor)          { Fabricate(:account, domain: 'example.com', uri: 'http://example.com/account') }

--- a/spec/services/activitypub/process_account_service_spec.rb
+++ b/spec/services/activitypub/process_account_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe ActivityPub::ProcessAccountService, type: :service do
+RSpec.describe ActivityPub::ProcessAccountService do
   subject { described_class.new }
 
   context 'with property values, an avatar, and a profile header' do

--- a/spec/services/activitypub/process_collection_service_spec.rb
+++ b/spec/services/activitypub/process_collection_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe ActivityPub::ProcessCollectionService, type: :service do
+RSpec.describe ActivityPub::ProcessCollectionService do
   subject { described_class.new }
 
   let(:actor) { Fabricate(:account, domain: 'example.com', uri: 'http://example.com/account') }

--- a/spec/services/activitypub/process_status_update_service_spec.rb
+++ b/spec/services/activitypub/process_status_update_service_spec.rb
@@ -6,7 +6,7 @@ def poll_option_json(name, votes)
   { type: 'Note', name: name, replies: { type: 'Collection', totalItems: votes } }
 end
 
-RSpec.describe ActivityPub::ProcessStatusUpdateService, type: :service do
+RSpec.describe ActivityPub::ProcessStatusUpdateService do
   subject { described_class.new }
 
   let!(:status) { Fabricate(:status, text: 'Hello world', account: Fabricate(:account, domain: 'example.com')) }

--- a/spec/services/activitypub/synchronize_followers_service_spec.rb
+++ b/spec/services/activitypub/synchronize_followers_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe ActivityPub::SynchronizeFollowersService, type: :service do
+RSpec.describe ActivityPub::SynchronizeFollowersService do
   subject { described_class.new }
 
   let(:actor)          { Fabricate(:account, domain: 'example.com', uri: 'http://example.com/account', inbox_url: 'http://example.com/inbox') }

--- a/spec/services/after_block_domain_from_account_service_spec.rb
+++ b/spec/services/after_block_domain_from_account_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe AfterBlockDomainFromAccountService, type: :service do
+RSpec.describe AfterBlockDomainFromAccountService do
   subject { described_class.new }
 
   let!(:wolf) { Fabricate(:account, username: 'wolf', domain: 'evil.org', inbox_url: 'https://evil.org/inbox', protocol: :activitypub) }

--- a/spec/services/after_block_service_spec.rb
+++ b/spec/services/after_block_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe AfterBlockService, type: :service do
+RSpec.describe AfterBlockService do
   subject { described_class.new.call(account, target_account) }
 
   let(:account)              { Fabricate(:account) }

--- a/spec/services/app_sign_up_service_spec.rb
+++ b/spec/services/app_sign_up_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe AppSignUpService, type: :service do
+RSpec.describe AppSignUpService do
   subject { described_class.new }
 
   let(:app) { Fabricate(:application, scopes: 'read write') }

--- a/spec/services/authorize_follow_service_spec.rb
+++ b/spec/services/authorize_follow_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe AuthorizeFollowService, type: :service do
+RSpec.describe AuthorizeFollowService do
   subject { described_class.new }
 
   let(:sender) { Fabricate(:account, username: 'alice') }

--- a/spec/services/backup_service_spec.rb
+++ b/spec/services/backup_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe BackupService, type: :service do
+RSpec.describe BackupService do
   subject(:service_call) { described_class.new.call(backup) }
 
   let!(:user)           { Fabricate(:user) }

--- a/spec/services/batched_remove_status_service_spec.rb
+++ b/spec/services/batched_remove_status_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe BatchedRemoveStatusService, :sidekiq_inline, type: :service do
+RSpec.describe BatchedRemoveStatusService, :sidekiq_inline do
   subject { described_class.new }
 
   let!(:alice)  { Fabricate(:account) }

--- a/spec/services/block_domain_service_spec.rb
+++ b/spec/services/block_domain_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe BlockDomainService, type: :service do
+RSpec.describe BlockDomainService do
   subject { described_class.new }
 
   let!(:bad_account) { Fabricate(:account, username: 'badguy666', domain: 'evil.org') }

--- a/spec/services/block_service_spec.rb
+++ b/spec/services/block_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe BlockService, type: :service do
+RSpec.describe BlockService do
   subject { described_class.new }
 
   let(:sender) { Fabricate(:account, username: 'alice') }

--- a/spec/services/bootstrap_timeline_service_spec.rb
+++ b/spec/services/bootstrap_timeline_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe BootstrapTimelineService, type: :service do
+RSpec.describe BootstrapTimelineService do
   subject { described_class.new }
 
   context 'when the new user has registered from an invite' do

--- a/spec/services/clear_domain_media_service_spec.rb
+++ b/spec/services/clear_domain_media_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe ClearDomainMediaService, type: :service do
+RSpec.describe ClearDomainMediaService do
   subject { described_class.new }
 
   let!(:bad_account) { Fabricate(:account, username: 'badguy666', domain: 'evil.org') }

--- a/spec/services/delete_account_service_spec.rb
+++ b/spec/services/delete_account_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe DeleteAccountService, type: :service do
+RSpec.describe DeleteAccountService do
   shared_examples 'common behavior' do
     subject { described_class.new.call(account) }
 

--- a/spec/services/fan_out_on_write_service_spec.rb
+++ b/spec/services/fan_out_on_write_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe FanOutOnWriteService, type: :service do
+RSpec.describe FanOutOnWriteService do
   subject { described_class.new }
 
   let(:last_active_at) { Time.now.utc }

--- a/spec/services/favourite_service_spec.rb
+++ b/spec/services/favourite_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe FavouriteService, type: :service do
+RSpec.describe FavouriteService do
   subject { described_class.new }
 
   let(:sender) { Fabricate(:account, username: 'alice') }

--- a/spec/services/fetch_link_card_service_spec.rb
+++ b/spec/services/fetch_link_card_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe FetchLinkCardService, type: :service do
+RSpec.describe FetchLinkCardService do
   subject { described_class.new }
 
   let(:html) { '<!doctype html><title>Hello world</title>' }

--- a/spec/services/fetch_oembed_service_spec.rb
+++ b/spec/services/fetch_oembed_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe FetchOEmbedService, type: :service do
+describe FetchOEmbedService do
   subject { described_class.new }
 
   before do

--- a/spec/services/fetch_remote_status_service_spec.rb
+++ b/spec/services/fetch_remote_status_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe FetchRemoteStatusService, type: :service do
+RSpec.describe FetchRemoteStatusService do
   let(:account) { Fabricate(:account, domain: 'example.org', uri: 'https://example.org/foo') }
   let(:prefetched_body) { nil }
 

--- a/spec/services/fetch_resource_service_spec.rb
+++ b/spec/services/fetch_resource_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe FetchResourceService, type: :service do
+RSpec.describe FetchResourceService do
   describe '#call' do
     subject { described_class.new.call(url) }
 

--- a/spec/services/follow_service_spec.rb
+++ b/spec/services/follow_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe FollowService, type: :service do
+RSpec.describe FollowService do
   subject { described_class.new }
 
   let(:sender) { Fabricate(:account, username: 'alice') }

--- a/spec/services/import_service_spec.rb
+++ b/spec/services/import_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe ImportService, :sidekiq_inline, type: :service do
+RSpec.describe ImportService, :sidekiq_inline do
   include RoutingHelper
 
   let!(:account) { Fabricate(:account, locked: false) }

--- a/spec/services/mute_service_spec.rb
+++ b/spec/services/mute_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe MuteService, type: :service do
+RSpec.describe MuteService do
   subject { described_class.new.call(account, target_account) }
 
   let(:account) { Fabricate(:account) }

--- a/spec/services/notify_service_spec.rb
+++ b/spec/services/notify_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe NotifyService, type: :service do
+RSpec.describe NotifyService do
   subject { described_class.new.call(recipient, type, activity) }
 
   let(:user) { Fabricate(:user) }

--- a/spec/services/post_status_service_spec.rb
+++ b/spec/services/post_status_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe PostStatusService, type: :service do
+RSpec.describe PostStatusService do
   subject { described_class.new }
 
   it 'creates a new status' do

--- a/spec/services/precompute_feed_service_spec.rb
+++ b/spec/services/precompute_feed_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe PrecomputeFeedService, type: :service do
+RSpec.describe PrecomputeFeedService do
   subject { described_class.new }
 
   describe 'call' do

--- a/spec/services/process_mentions_service_spec.rb
+++ b/spec/services/process_mentions_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe ProcessMentionsService, type: :service do
+RSpec.describe ProcessMentionsService do
   subject { described_class.new }
 
   let(:account) { Fabricate(:account, username: 'alice') }

--- a/spec/services/purge_domain_service_spec.rb
+++ b/spec/services/purge_domain_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe PurgeDomainService, type: :service do
+RSpec.describe PurgeDomainService do
   subject { described_class.new }
 
   let(:domain) { 'obsolete.org' }

--- a/spec/services/reblog_service_spec.rb
+++ b/spec/services/reblog_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe ReblogService, type: :service do
+RSpec.describe ReblogService do
   let(:alice)  { Fabricate(:account, username: 'alice') }
 
   context 'when creates a reblog with appropriate visibility' do

--- a/spec/services/reject_follow_service_spec.rb
+++ b/spec/services/reject_follow_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe RejectFollowService, type: :service do
+RSpec.describe RejectFollowService do
   subject { described_class.new }
 
   let(:sender) { Fabricate(:account, username: 'alice') }

--- a/spec/services/remove_from_followers_service_spec.rb
+++ b/spec/services/remove_from_followers_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe RemoveFromFollowersService, type: :service do
+RSpec.describe RemoveFromFollowersService do
   subject { described_class.new }
 
   let(:bob) { Fabricate(:account, username: 'bob') }

--- a/spec/services/remove_status_service_spec.rb
+++ b/spec/services/remove_status_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe RemoveStatusService, :sidekiq_inline, type: :service do
+RSpec.describe RemoveStatusService, :sidekiq_inline do
   subject { described_class.new }
 
   let!(:alice)  { Fabricate(:account) }

--- a/spec/services/report_service_spec.rb
+++ b/spec/services/report_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe ReportService, type: :service do
+RSpec.describe ReportService do
   subject { described_class.new }
 
   let(:source_account) { Fabricate(:account) }

--- a/spec/services/resolve_account_service_spec.rb
+++ b/spec/services/resolve_account_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe ResolveAccountService, type: :service do
+RSpec.describe ResolveAccountService do
   subject { described_class.new }
 
   before do

--- a/spec/services/resolve_url_service_spec.rb
+++ b/spec/services/resolve_url_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe ResolveURLService, type: :service do
+describe ResolveURLService do
   subject { described_class.new }
 
   describe '#call' do

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe SearchService, type: :service do
+describe SearchService do
   subject { described_class.new }
 
   describe '#call' do

--- a/spec/services/software_update_check_service_spec.rb
+++ b/spec/services/software_update_check_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe SoftwareUpdateCheckService, type: :service do
+RSpec.describe SoftwareUpdateCheckService do
   subject { described_class.new }
 
   shared_examples 'when the feature is enabled' do

--- a/spec/services/suspend_account_service_spec.rb
+++ b/spec/services/suspend_account_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe SuspendAccountService, :sidekiq_inline, type: :service do
+RSpec.describe SuspendAccountService, :sidekiq_inline do
   shared_examples 'common behavior' do
     subject { described_class.new.call(account) }
 

--- a/spec/services/translate_status_service_spec.rb
+++ b/spec/services/translate_status_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe TranslateStatusService, type: :service do
+RSpec.describe TranslateStatusService do
   subject(:service) { described_class.new }
 
   let(:status) { Fabricate(:status, text: text, spoiler_text: spoiler_text, language: 'en', preloadable_poll: poll, media_attachments: media_attachments) }

--- a/spec/services/unallow_domain_service_spec.rb
+++ b/spec/services/unallow_domain_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe UnallowDomainService, type: :service do
+RSpec.describe UnallowDomainService do
   subject { described_class.new }
 
   let(:bad_domain) { 'evil.org' }

--- a/spec/services/unblock_domain_service_spec.rb
+++ b/spec/services/unblock_domain_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe UnblockDomainService, type: :service do
+describe UnblockDomainService do
   subject { described_class.new }
 
   describe 'call' do

--- a/spec/services/unblock_service_spec.rb
+++ b/spec/services/unblock_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe UnblockService, type: :service do
+RSpec.describe UnblockService do
   subject { described_class.new }
 
   let(:sender) { Fabricate(:account, username: 'alice') }

--- a/spec/services/unfollow_service_spec.rb
+++ b/spec/services/unfollow_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe UnfollowService, type: :service do
+RSpec.describe UnfollowService do
   subject { described_class.new }
 
   let(:sender) { Fabricate(:account, username: 'alice') }

--- a/spec/services/unsuspend_account_service_spec.rb
+++ b/spec/services/unsuspend_account_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe UnsuspendAccountService, type: :service do
+RSpec.describe UnsuspendAccountService do
   shared_context 'with common context' do
     subject { described_class.new.call(account) }
 

--- a/spec/services/update_account_service_spec.rb
+++ b/spec/services/update_account_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe UpdateAccountService, type: :service do
+RSpec.describe UpdateAccountService do
   subject { described_class.new }
 
   describe 'switching form locked to unlocked accounts', :sidekiq_inline do

--- a/spec/services/update_status_service_spec.rb
+++ b/spec/services/update_status_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe UpdateStatusService, type: :service do
+RSpec.describe UpdateStatusService do
   subject { described_class.new }
 
   context 'when nothing changes' do

--- a/spec/services/verify_link_service_spec.rb
+++ b/spec/services/verify_link_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe VerifyLinkService, type: :service do
+RSpec.describe VerifyLinkService do
   subject { described_class.new }
 
   context 'when given a local account' do


### PR DESCRIPTION
We have `infer_spec_type_from_file_location!` enabled and don't need the explicit tagging (we also don't currently have any behavior based on this tag, I don't think).