### PR TITLE
Fix muted user list being broken in the multi-column layout and on smartphones

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1829,6 +1829,8 @@ body > [data-popper-placement] {
 
 .account__wrapper {
   display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
   gap: 10px;
   align-items: center;
 }


### PR DESCRIPTION
currently, muted users list in the multi-column layout is broken, and probably the same on most smartphones.

![ss-003199](https://github.com/mastodon/mastodon/assets/32974885/5b0e6a94-609b-4370-94e0-2145bee01f56)

this PR causes the line to wrap.

![ss-003196](https://github.com/mastodon/mastodon/assets/32974885/5b6209f9-0e4a-402f-92a4-5c5175fe3a8f)

however, this PR has a side effect. line is wrapped if the usename is longlong, even in the blocked users list. 

before:
![ss-003198](https://github.com/mastodon/mastodon/assets/32974885/7394df80-4a11-427c-bdc5-4d9d52cd2f63)

after:
![ss-003197](https://github.com/mastodon/mastodon/assets/32974885/36abdac4-6187-4174-9e55-130078058e33)


but I think this is the way it should be.