### PR TITLE
Automatically switch from open to approved registrations in absence of moderators

### DIFF
--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -61,6 +61,12 @@ class AdminMailer < ApplicationMailer
     end
   end
 
+  def auto_close_registrations
+    locale_for_account(@me) do
+      mail subject: default_i18n_subject(instance: @instance)
+    end
+  end
+
   private
 
   def process_params

--- a/app/views/admin_mailer/auto_close_registrations.text.erb
+++ b/app/views/admin_mailer/auto_close_registrations.text.erb
@@ -1,3 +1,3 @@
-<%= raw t('admin_mailer.auto_close_registrations.body') %>
+<%= raw t('admin_mailer.auto_close_registrations.body', instance: @instance) %>
 
 <%= raw t('application_mailer.view')%> <%= admin_settings_registrations_url %>

--- a/app/views/admin_mailer/auto_close_registrations.text.erb
+++ b/app/views/admin_mailer/auto_close_registrations.text.erb
@@ -1,0 +1,3 @@
+<%= raw t('admin_mailer.auto_close_registrations.body') %>
+
+<%= raw t('application_mailer.view')%> <%= admin_settings_registrations_url %>

--- a/app/workers/scheduler/auto_close_registrations_scheduler.rb
+++ b/app/workers/scheduler/auto_close_registrations_scheduler.rb
@@ -14,12 +14,20 @@ class Scheduler::AutoCloseRegistrationsScheduler
     return if Rails.configuration.x.email_domains_whitelist.present? || ENV['DISABLE_AUTOMATIC_SWITCHING_TO_APPROVED_REGISTRATIONS'] == 'true'
     return unless Setting.registrations_mode == 'open'
 
-    Setting.registrations_mode = 'approved' unless active_moderators?
+    switch_to_approval_mode! unless active_moderators?
   end
 
   private
 
   def active_moderators?
     User.those_who_can(:manage_reports).exists?(current_sign_in_at: OPEN_REGISTRATIONS_MODERATOR_THRESHOLD.ago...)
+  end
+
+  def switch_to_approval_mode!
+    Setting.registrations_mode = 'approved'
+
+    User.those_who_can(:view_devops).includes(:account).find_each do |user|
+      AdminMailer.with(recipient: user.account).auto_close_registrations.deliver_later
+    end
   end
 end

--- a/app/workers/scheduler/auto_close_registrations_scheduler.rb
+++ b/app/workers/scheduler/auto_close_registrations_scheduler.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class Scheduler::AutoCloseRegistrationsScheduler
+  include Sidekiq::Worker
+  include Redisable
+
+  sidekiq_options retry: 0
+
+  # Automatically switch away from open registrations if no
+  # moderator had any activity in that period of time
+  OPEN_REGISTRATIONS_MODERATOR_THRESHOLD = 1.week + UserTrackingConcern::SIGN_IN_UPDATE_FREQUENCY
+
+  def perform
+    return if Rails.configuration.x.email_domains_whitelist.present? || ENV['DISABLE_AUTOMATIC_SWITCHING_TO_APPROVED_REGISTRATIONS'] == 'true'
+    return unless Setting.registrations_mode == 'open'
+
+    Setting.registrations_mode = 'approved' unless active_moderators?
+  end
+
+  private
+
+  def active_moderators?
+    User.those_who_can(:manage_reports).exists?(current_sign_in_at: OPEN_REGISTRATIONS_MODERATOR_THRESHOLD.ago...)
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -967,7 +967,7 @@ en:
       webhook: Webhook
   admin_mailer:
     auto_close_registrations:
-      body: Considering no moderator has recently been active on your your server, its settings have been automatically changed to not allow new user registrations without approvals.
+      body: Due to a lack of recent moderator activity, registrations on %{instance} have been automatically switched to requiring manual review, to prevent %{instance} from being used as a platform for potential bad actors. You can switch it back to open registrations at any time.
       subject: Registrations for %{instance} have been automatically switched to requiring approval
     new_appeal:
       actions:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -966,6 +966,9 @@ en:
       title: Webhooks
       webhook: Webhook
   admin_mailer:
+    auto_close_registrations:
+      body: Considering no moderator has recently been active on your your server, its settings have been automatically changed to not allow new user registrations without approvals.
+      subject: Registrations for %{instance} have been automatically switched to requiring approval
     new_appeal:
       actions:
         delete_statuses: to delete their posts

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -63,3 +63,7 @@
       interval: 30 minutes
       class: Scheduler::SoftwareUpdateCheckScheduler
       queue: scheduler
+    auto_close_registrations_scheduler:
+      interval: 1 hour
+      class: Scheduler::AutoCloseRegistrationsScheduler
+      queue: scheduler

--- a/spec/workers/scheduler/auto_close_registrations_scheduler_spec.rb
+++ b/spec/workers/scheduler/auto_close_registrations_scheduler_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Scheduler::AutoCloseRegistrationsScheduler do
+  subject { described_class.new }
+
+  describe '#perform' do
+    let(:moderator_activity_date) { Time.now.utc }
+
+    before do
+      Fabricate(:user, role: UserRole.find_by(name: 'Owner'), current_sign_in_at: 10.years.ago)
+      Fabricate(:user, role: UserRole.find_by(name: 'Moderator'), current_sign_in_at: moderator_activity_date)
+    end
+
+    context 'when registrations are open' do
+      before do
+        Setting.registrations_mode = 'open'
+      end
+
+      context 'when a moderator has logged in recently' do
+        let(:moderator_activity_date) { Time.now.utc }
+
+        it 'does not change registrations mode' do
+          expect { subject.perform }.to_not change(Setting, :registrations_mode)
+        end
+      end
+
+      context 'when a moderator has not recently signed in' do
+        let(:moderator_activity_date) { 1.year.ago }
+
+        it 'changes registrations mode from open to approved' do
+          expect { subject.perform }.to change(Setting, :registrations_mode).from('open').to('approved')
+        end
+      end
+    end
+
+    context 'when registrations are closed' do
+      before do
+        Setting.registrations_mode = 'none'
+      end
+
+      context 'when a moderator has logged in recently' do
+        let(:moderator_activity_date) { Time.now.utc }
+
+        it 'does not change registrations mode' do
+          expect { subject.perform }.to_not change(Setting, :registrations_mode)
+        end
+      end
+
+      context 'when a moderator has not recently signed in' do
+        let(:moderator_activity_date) { 1.year.ago }
+
+        it 'does not change registrations mode' do
+          expect { subject.perform }.to_not change(Setting, :registrations_mode)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is not meant to replace #29280, but supplement it to avoid unmonitored servers keeping open registrations indefinitely.

Automatically switch away from open registrations if no user with the permission to view reports has had any activity (authenticated request to the server) in over a week.

Can be disabled with the `DISABLE_AUTOMATIC_SWITCHING_TO_APPROVED_REGISTRATIONS` environment variable if you are for instance using external tools for moderation. It's also disabled when using an email domain allow-list (`EMAIL_DOMAIN_ALLOWLIST`).