### PR TITLE
Update text description for the language filter setting to make it clear the setting doesn't affect Home and Lists

### DIFF
--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -126,7 +126,7 @@ en:
       tag:
         name: You can only change the casing of the letters, for example, to make it more readable
       user:
-        chosen_languages: When checked, only posts in selected languages will be displayed in public timelines
+        chosen_languages: When checked, only posts in selected languages will be displayed in public timelines. This setting does not affect posts in your Home timeline and lists
         role: The role controls which permissions the user has
       user_role:
         color: Color to be used for the role throughout the UI, as RGB in hex format

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -126,7 +126,7 @@ en:
       tag:
         name: You can only change the casing of the letters, for example, to make it more readable
       user:
-        chosen_languages: When checked, only posts in selected languages will be displayed in public timelines. This setting does not affect posts in your Home timeline and lists
+        chosen_languages: When checked, only posts in selected languages will be displayed in public timelines. This setting does not affect your Home timeline and lists.
         role: The role controls which permissions the user has
       user_role:
         color: Color to be used for the role throughout the UI, as RGB in hex format


### PR DESCRIPTION
Adds one sentence to the language filter setting. Aim is to make people less likely to think this setting missing boosts and hashtags in Home is a bug, like reported in https://github.com/mastodon/mastodon/issues/20241 and https://github.com/mastodon/mastodon/issues/20937.