### PR TITLE
Change registrations to be disabled by default for new servers

### DIFF
--- a/app/views/admin/settings/registrations/show.html.haml
+++ b/app/views/admin/settings/registrations/show.html.haml
@@ -13,6 +13,8 @@
 
   %p.lead= t('admin.settings.registrations.preamble')
 
+  .flash-message= t('admin.settings.registrations.moderation_recommandation')
+
   .fields-row
     .fields-row__column.fields-row__column-6.fields-group
       = f.input :registrations_mode, collection: %w(open approved none), wrapper: :with_label, include_blank: false, label_method: lambda { |mode| I18n.t("admin.settings.registrations_mode.modes.#{mode}") }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -745,6 +745,7 @@ en:
         disabled: To no one
         users: To logged-in local users
       registrations:
+        moderation_recommandation: Please make sure you have an adequate and reactive moderation team before you open registrations to everyone!
         preamble: Control who can create an account on your server.
         title: Registrations
       registrations_mode:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -9,7 +9,7 @@ defaults: &defaults
   site_terms: ''
   site_contact_username: ''
   site_contact_email: ''
-  registrations_mode: 'open'
+  registrations_mode: 'none'
   profile_directory: true
   closed_registrations_message: ''
   open_deletion: true

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -142,22 +142,12 @@ RSpec.describe Setting, type: :model do
     context 'records includes nothing' do
       let(:records) { [] }
 
-      context 'default_value is not a Hash' do
-        it 'includes Setting with value of default_value' do
-          setting = described_class.all_as_records[key]
+      it 'includes Setting with value of default_value' do
+        setting = described_class.all_as_records[key]
 
-          expect(setting).to be_kind_of Setting
-          expect(setting).to have_attributes(var: key)
-          expect(setting).to have_attributes(value: 'default_value')
-        end
-      end
-
-      context 'default_value is a Hash' do
-        let(:default_value) { { 'foo' => 'fuga' } }
-
-        it 'returns {}' do
-          expect(described_class.all_as_records).to eq({})
-        end
+        expect(setting).to be_a described_class
+        expect(setting).to have_attributes(var: key)
+        expect(setting).to have_attributes(value: default_value)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,6 +30,12 @@ RSpec.configure do |config|
   config.before :suite do
     Rails.application.load_seed
     Chewy.strategy(:bypass)
+
+    # NOTE: we switched registrations mode to closed by default, but the specs
+    # very heavily rely on having it enabled by default, as it relies on users
+    # being approved by default except in select cases where explicitly testing
+    # other registration modes
+    Setting.registrations_mode = 'open'
   end
 
   config.after :suite do


### PR DESCRIPTION
Partial backport of #29280 to 4.1

As the required styling and support code were did not exist in 4.1, the following conditional warning hint was left out:
> We recommend using “Approval required for sign up” unless you are confident your moderation team can handle spam and malicious registrations in a timely fashion.

The following banner is still present:
> Please make sure you have an adequate and reactive moderation team before you open registrations to everyone!