### PR TITLE
Fix auto-close email being sent to users with devops permissions instead of settings permissions

### DIFF
--- a/app/workers/scheduler/auto_close_registrations_scheduler.rb
+++ b/app/workers/scheduler/auto_close_registrations_scheduler.rb
@@ -26,7 +26,7 @@ class Scheduler::AutoCloseRegistrationsScheduler
   def switch_to_approval_mode!
     Setting.registrations_mode = 'approved'
 
-    User.those_who_can(:view_devops).includes(:account).find_each do |user|
+    User.those_who_can(:manage_settings).includes(:account).find_each do |user|
       AdminMailer.with(recipient: user.account).auto_close_registrations.deliver_later
     end
   end


### PR DESCRIPTION
Backport #29355 to 4.2