### PR TITLE
Fix link verifications when page size exceeds 1MB

### DIFF
--- a/app/services/verify_link_service.rb
+++ b/app/services/verify_link_service.rb
@@ -19,7 +19,7 @@ class VerifyLinkService < BaseService
 
   def perform_request!
     @body = Request.new(:get, @url).add_headers('Accept' => 'text/html').perform do |res|
-      res.code == 200 ? res.body_with_limit : nil
+      res.code == 200 ? res.truncated_body : nil
     end
   end
 

--- a/spec/services/verify_link_service_spec.rb
+++ b/spec/services/verify_link_service_spec.rb
@@ -80,24 +80,25 @@ RSpec.describe VerifyLinkService, type: :service do
         "
           <!doctype html>
           <body>
+            <a rel=\"me\" href=\"#{ActivityPub::TagManager.instance.url_for(account)}\">
+        "
+      end
+
+      it 'marks the field as verified' do
+        expect(field.verified?).to be true
+      end
+    end
+
+    context 'when a link tag might be truncated' do
+      let(:html) do
+        "
+          <!doctype html>
+          <body>
             <a rel=\"me\" href=\"#{ActivityPub::TagManager.instance.url_for(account)}\"
         "
       end
 
       it 'marks the field as not verified' do
-        expect(field.verified?).to be false
-      end
-    end
-
-    context 'when a link back might be truncated' do
-      let(:html) do
-        "
-          <!doctype html>
-          <body>
-            <a rel=\"me\" href=\"#{ActivityPub::TagManager.instance.url_for(account)}"
-      end
-
-      it 'does not mark the field as verified' do
         expect(field.verified?).to be false
       end
     end


### PR DESCRIPTION
Follow-up to #22879, which introduced `Request#truncated_body` but did not make use of it.