### PR TITLE
Use heredoc on the `HTML` blocks in verify link spec

### DIFF
--- a/spec/services/verify_link_service_spec.rb
+++ b/spec/services/verify_link_service_spec.rb
@@ -77,11 +77,11 @@ RSpec.describe VerifyLinkService, type: :service do
 
     context 'when a document is truncated but the link back is valid' do
       let(:html) do
-        "
+        <<-HTML
           <!doctype html>
           <body>
-            <a rel=\"me\" href=\"#{ActivityPub::TagManager.instance.url_for(account)}\">
-        "
+            <a rel="me" href="#{ActivityPub::TagManager.instance.url_for(account)}">
+        HTML
       end
 
       it 'marks the field as verified' do
@@ -91,11 +91,11 @@ RSpec.describe VerifyLinkService, type: :service do
 
     context 'when a link tag might be truncated' do
       let(:html) do
-        "
+        <<-HTML_TRUNCATED
           <!doctype html>
           <body>
-            <a rel=\"me\" href=\"#{ActivityPub::TagManager.instance.url_for(account)}\"
-        "
+            <a rel="me" href="#{ActivityPub::TagManager.instance.url_for(account)}"
+        HTML_TRUNCATED
       end
 
       it 'marks the field as not verified' do
@@ -166,7 +166,11 @@ RSpec.describe VerifyLinkService, type: :service do
       #
       # apparently github allows the user to enter website URLs with a single
       # slash and makes no attempts to correct that.
-      let(:html) { '<a href="http:/unrelated.example">Hello</a>' }
+      let(:html) do
+        <<-HTML
+          <a href="http:/unrelated.example">Hello</a>
+        HTML
+      end
 
       it 'does not crash' do
         # We could probably put more effort into perhaps auto-correcting the


### PR DESCRIPTION
Tiny followup on https://github.com/mastodon/mastodon/pull/29358 where I noticed this but didn't leave feedback before merge. There are 9 examples here and 6 use heredoc and 3 don't.

Updated for consistency across the file.