### PR TITLE
Use modern ES syntax rather than `.call`

### DIFF
--- a/app/javascript/mastodon/containers/media_container.jsx
+++ b/app/javascript/mastodon/containers/media_container.jsx
@@ -80,7 +80,7 @@ export default class MediaContainer extends PureComponent {
     return (
       <IntlProvider>
         <>
-          {components.map((component, i) => {
+          {Array.from(components).map((component, i) => {
             const componentName = component.getAttribute('data-component');
             const Component = MEDIA_COMPONENTS[componentName];
             const { media, card, poll, hashtag, ...props } = JSON.parse(component.getAttribute('data-props'));

--- a/app/javascript/mastodon/containers/media_container.jsx
+++ b/app/javascript/mastodon/containers/media_container.jsx
@@ -80,7 +80,7 @@ export default class MediaContainer extends PureComponent {
     return (
       <IntlProvider>
         <>
-          {[].map.call(components, (component, i) => {
+          {components.map((component, i) => {
             const componentName = component.getAttribute('data-component');
             const Component = MEDIA_COMPONENTS[componentName];
             const { media, card, poll, hashtag, ...props } = JSON.parse(component.getAttribute('data-props'));

--- a/app/javascript/mastodon/features/emoji/emoji_compressed.js
+++ b/app/javascript/mastodon/features/emoji/emoji_compressed.js
@@ -36,7 +36,7 @@ Object.keys(emojiIndex.emojis).forEach(key => {
   let emoji = emojiIndex.emojis[key];
 
   // Emojis with skin tone modifiers are stored like this
-  if (Object.prototype.hasOwnProperty.call(emoji, '1')) {
+  if (Object.hasOwn(emoji, '1')) {
     emoji = emoji['1'];
   }
 
@@ -88,7 +88,7 @@ Object.keys(emojiIndex.emojis).forEach(key => {
   let emoji = emojiIndex.emojis[key];
 
   // Emojis with skin tone modifiers are stored like this
-  if (Object.prototype.hasOwnProperty.call(emoji, '1')) {
+  if (Object.hasOwn(emoji, '1')) {
     emoji = emoji['1'];
   }
 

--- a/app/javascript/mastodon/features/emoji/emoji_utils.js
+++ b/app/javascript/mastodon/features/emoji/emoji_utils.js
@@ -135,19 +135,19 @@ function getData(emoji, skin, set) {
       }
     }
 
-    if (Object.prototype.hasOwnProperty.call(data.short_names, emoji)) {
+    if (Object.hasOwn(data.short_names, emoji)) {
       emoji = data.short_names[emoji];
     }
 
-    if (Object.prototype.hasOwnProperty.call(data.emojis, emoji)) {
+    if (Object.hasOwn(data.emojis, emoji)) {
       emojiData = data.emojis[emoji];
     }
   } else if (emoji.id) {
-    if (Object.prototype.hasOwnProperty.call(data.short_names, emoji.id)) {
+    if (Object.hasOwn(data.short_names, emoji.id)) {
       emoji.id = data.short_names[emoji.id];
     }
 
-    if (Object.prototype.hasOwnProperty.call(data.emojis, emoji.id)) {
+    if (Object.hasOwn(data.emojis, emoji.id)) {
       emojiData = data.emojis[emoji.id];
       skin = skin || emoji.skin;
     }
@@ -216,7 +216,7 @@ function deepMerge(a, b) {
     let originalValue = a[key],
       value = originalValue;
 
-    if (Object.prototype.hasOwnProperty.call(b, key)) {
+    if (Object.hasOwn(b, key)) {
       value = b[key];
     }
 

--- a/app/javascript/packs/admin.jsx
+++ b/app/javascript/packs/admin.jsx
@@ -81,8 +81,11 @@ Rails.delegate(document, batchCheckboxClassName, 'change', () => {
   const selectAllMatchingElement = document.querySelector('.batch-table__select-all');
 
   if (checkAllElement) {
-    checkAllElement.checked = document.querySelectorAll(batchCheckboxClassName).every((content) => content.checked);
-    checkAllElement.indeterminate = !checkAllElement.checked && document.querySelectorAll(batchCheckboxClassName).some((content) => content.checked);
+    const allCheckboxes = Array.from(
+      document.querySelectorAll(batchCheckboxClassName)
+    );
+    checkAllElement.checked = allCheckboxes.every((content) => content.checked);
+    checkAllElement.indeterminate = !checkAllElement.checked && allCheckboxes.some((content) => content.checked);
 
     if (selectAllMatchingElement) {
       if (checkAllElement.checked) {
@@ -183,8 +186,9 @@ ready(() => {
 
   const checkAllElement = document.querySelector('#batch_checkbox_all');
   if (checkAllElement) {
-    checkAllElement.checked = document.querySelectorAll(batchCheckboxClassName).every( (content) => content.checked);
-    checkAllElement.indeterminate = !checkAllElement.checked && document.querySelectorAll(batchCheckboxClassName).some((content) => content.checked);
+    const allCheckboxes = Array.from(document.querySelectorAll(batchCheckboxClassName));
+    checkAllElement.checked = allCheckboxes.every( (content) => content.checked);
+    checkAllElement.indeterminate = !checkAllElement.checked && allCheckboxes.some((content) => content.checked);
   }
 
   document.querySelector('a#add-instance-button')?.addEventListener('click', (e) => {
@@ -207,7 +211,7 @@ ready(() => {
   });
 
   Rails.delegate(document, 'form', 'submit', ({ target }) => {
-    target.querySelectorAll('input[type="datetime-local"]').foreach(element => {
+    target.querySelectorAll('input[type="datetime-local"]').forEach(element => {
       if (element.value && element.validity.valid) {
         element.value = convertLocalDatetimeToUTC(element.value);
       }

--- a/app/javascript/packs/admin.jsx
+++ b/app/javascript/packs/admin.jsx
@@ -46,7 +46,7 @@ const hideSelectAll = () => {
 Rails.delegate(document, '#batch_checkbox_all', 'change', ({ target }) => {
   const selectAllMatchingElement = document.querySelector('.batch-table__select-all');
 
-  [].forEach.call(document.querySelectorAll(batchCheckboxClassName), (content) => {
+  document.querySelectorAll(batchCheckboxClassName).forEach((content) => {
     content.checked = target.checked;
   });
 
@@ -81,8 +81,8 @@ Rails.delegate(document, batchCheckboxClassName, 'change', () => {
   const selectAllMatchingElement = document.querySelector('.batch-table__select-all');
 
   if (checkAllElement) {
-    checkAllElement.checked = [].every.call(document.querySelectorAll(batchCheckboxClassName), (content) => content.checked);
-    checkAllElement.indeterminate = !checkAllElement.checked && [].some.call(document.querySelectorAll(batchCheckboxClassName), (content) => content.checked);
+    checkAllElement.checked = document.querySelectorAll(batchCheckboxClassName).every((content) => content.checked);
+    checkAllElement.indeterminate = !checkAllElement.checked && document.querySelectorAll(batchCheckboxClassName).some((content) => content.checked);
 
     if (selectAllMatchingElement) {
       if (checkAllElement.checked) {
@@ -133,11 +133,11 @@ Rails.delegate(document, '#form_admin_settings_enable_bootstrap_timeline_account
 const onChangeRegistrationMode = (target) => {
   const enabled = target.value === 'approved';
 
-  [].forEach.call(document.querySelectorAll('.form_admin_settings_registrations_mode .warning-hint'), (warning_hint) => {
+  document.querySelectorAll('.form_admin_settings_registrations_mode .warning-hint').forEach((warning_hint) => {
     warning_hint.style.display = target.value === 'open' ? 'inline' : 'none';
   });
 
-  [].forEach.call(document.querySelectorAll('#form_admin_settings_require_invite_text'), (input) => {
+  document.querySelectorAll('#form_admin_settings_require_invite_text').forEach((input) => {
     input.disabled = !enabled;
     if (enabled) {
       let element = input;
@@ -183,8 +183,8 @@ ready(() => {
 
   const checkAllElement = document.querySelector('#batch_checkbox_all');
   if (checkAllElement) {
-    checkAllElement.checked = [].every.call(document.querySelectorAll(batchCheckboxClassName), (content) => content.checked);
-    checkAllElement.indeterminate = !checkAllElement.checked && [].some.call(document.querySelectorAll(batchCheckboxClassName), (content) => content.checked);
+    checkAllElement.checked = document.querySelectorAll(batchCheckboxClassName).every( (content) => content.checked);
+    checkAllElement.indeterminate = !checkAllElement.checked && document.querySelectorAll(batchCheckboxClassName).some((content) => content.checked);
   }
 
   document.querySelector('a#add-instance-button')?.addEventListener('click', (e) => {
@@ -197,7 +197,7 @@ ready(() => {
     }
   });
 
-  [].forEach.call(document.querySelectorAll('input[type="datetime-local"]'), element => {
+  document.querySelectorAll('input[type="datetime-local"]').forEach(element => {
     if (element.value) {
       element.value = convertUTCDateTimeToLocal(element.value);
     }
@@ -207,7 +207,7 @@ ready(() => {
   });
 
   Rails.delegate(document, 'form', 'submit', ({ target }) => {
-    [].forEach.call(target.querySelectorAll('input[type="datetime-local"]'), element => {
+    target.querySelectorAll('input[type="datetime-local"]').foreach(element => {
       if (element.value && element.validity.valid) {
         element.value = convertLocalDatetimeToUTC(element.value);
       }
@@ -219,7 +219,7 @@ ready(() => {
     setAnnouncementEndsAttributes(announcementStartsAt);
   }
 
-  [].forEach.call(document.querySelectorAll('[data-admin-component]'), element => {
+  document.querySelectorAll('[data-admin-component]').forEach(element => {
     const componentName  = element.getAttribute('data-admin-component');
     const componentProps = JSON.parse(element.getAttribute('data-props'));
 

--- a/app/javascript/packs/public.jsx
+++ b/app/javascript/packs/public.jsx
@@ -129,7 +129,7 @@ function loaded() {
     import(/* webpackChunkName: "containers/media_container" */ '../mastodon/containers/media_container')
       .then(({ default: MediaContainer }) => {
         reactComponents.forEach((component) => {
-          component.children.forEach((child) => {
+          Array.from(component.children).forEach((child) => {
             component.removeChild(child);
           });
         });

--- a/app/javascript/packs/public.jsx
+++ b/app/javascript/packs/public.jsx
@@ -73,11 +73,11 @@ function loaded() {
     return messageFormat.format(values);
   };
 
-  [].forEach.call(document.querySelectorAll('.emojify'), (content) => {
+  document.querySelectorAll('.emojify').forEach((content) => {
     content.innerHTML = emojify(content.innerHTML);
   });
 
-  [].forEach.call(document.querySelectorAll('time.formatted'), (content) => {
+  document.querySelectorAll('time.formatted').forEach((content) => {
     const datetime = new Date(content.getAttribute('datetime'));
     const formattedDate = dateTimeFormat.format(datetime);
 
@@ -94,7 +94,7 @@ function loaded() {
   };
   const todayFormat = new IntlMessageFormat(localeData['relative_format.today'] || 'Today at {time}', locale);
 
-  [].forEach.call(document.querySelectorAll('time.relative-formatted'), (content) => {
+  document.querySelectorAll('time.relative-formatted').forEach((content) => {
     const datetime = new Date(content.getAttribute('datetime'));
 
     let formattedContent;
@@ -111,7 +111,7 @@ function loaded() {
     content.textContent = formattedContent;
   });
 
-  [].forEach.call(document.querySelectorAll('time.time-ago'), (content) => {
+  document.querySelectorAll('time.time-ago').forEach((content) => {
     const datetime = new Date(content.getAttribute('datetime'));
     const now      = new Date();
 
@@ -128,8 +128,8 @@ function loaded() {
   if (reactComponents.length > 0) {
     import(/* webpackChunkName: "containers/media_container" */ '../mastodon/containers/media_container')
       .then(({ default: MediaContainer }) => {
-        [].forEach.call(reactComponents, (component) => {
-          [].forEach.call(component.children, (child) => {
+        reactComponents.forEach((component) => {
+          component.children.forEach((child) => {
             component.removeChild(child);
           });
         });
@@ -185,7 +185,7 @@ function loaded() {
     return false;
   });
 
-  [].forEach.call(document.querySelectorAll('.status__content__spoiler-link'), (spoilerLink) => {
+  document.querySelectorAll('.status__content__spoiler-link').forEach((spoilerLink) => {
     const statusEl = spoilerLink.parentNode.parentNode;
     const message = (statusEl.dataset.spoiler === 'expanded') ? (localeData['status.show_less'] || 'Show less') : (localeData['status.show_more'] || 'Show more');
     spoilerLink.textContent = (new IntlMessageFormat(message, locale)).format();

--- a/public/embed.js
+++ b/public/embed.js
@@ -31,6 +31,8 @@
 
       var iframe = iframes.get(data.id);
 
+      if(!iframe) return;
+
       if ('source' in e && iframe.contentWindow !== e.source) {
         return;
       }
@@ -38,7 +40,7 @@
       iframe.height = data.height;
     });
 
-    [].forEach.call(document.querySelectorAll('iframe.mastodon-embed'), function (iframe) {
+    document.querySelectorAll('iframe.mastodon-embed').forEach(iframe => {
       // select unique id for each iframe
       var id = 0, failCount = 0, idBuffer = new Uint32Array(1);
       while (id === 0 || iframes.has(id)) {

--- a/streaming/index.js
+++ b/streaming/index.js
@@ -192,7 +192,7 @@ const pgConfigFromEnv = (env) => {
     if (!baseConfig.password && env.DB_PASS) {
       baseConfig.password = env.DB_PASS;
     }
-  } else if (Object.hasOwnProperty.call(pgConfigs, environment)) {
+  } else if (Object.hasOwn(pgConfigs, environment)) {
     baseConfig = pgConfigs[environment];
 
     if (env.DB_SSLMODE) {
@@ -912,7 +912,7 @@ const startServer = async () => {
           // If the payload already contains the `filtered` property, it means
           // that filtering has been applied on the ruby on rails side, as
           // such, we don't need to construct or apply the filters in streaming:
-          if (Object.prototype.hasOwnProperty.call(payload, "filtered")) {
+          if (Object.hasOwn(payload, "filtered")) {
             transmit(event, payload);
             return;
           }


### PR DESCRIPTION
I replaced `Object.prototype.hasOwnProperty.call` with the new ES2022 `Object.hasOwn`.

It is not transpiled by Babel in the final files, because this function is supported by all the browsers our BrowsersList is targetting.

If this causes issues, then we can change our supported browsers list and target earlier versions, then it will be polyfilled accordingly.