### PR TITLE
Use `github` reporter on `haml-lint` runs on CI

### DIFF
--- a/.github/workflows/lint-haml.yml
+++ b/.github/workflows/lint-haml.yml
@@ -36,4 +36,4 @@ jobs:
       - name: Run haml-lint
         run: |
           echo "::add-matcher::.github/workflows/haml-lint-problem-matcher.json"
-          bundle exec haml-lint
+          bundle exec haml-lint --reporter github


### PR DESCRIPTION
Including a violation in this PR to see annotation/logs output. Will remove before merge.

Related https://github.com/mastodon/mastodon/pull/29181#issuecomment-1959253912