### PR TITLE
Fix search icon position on mobile

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -5195,7 +5195,6 @@ a.status-card {
   .icon {
     position: absolute;
     top: 12px + 2px;
-    inset-inline-start: 16px - 2px;
     display: inline-block;
     opacity: 0;
     transition: all 100ms linear;
@@ -5209,6 +5208,10 @@ a.status-card {
     &.active {
       pointer-events: auto;
       opacity: 1;
+    }
+
+    @media screen and (min-width: $no-gap-breakpoint) {
+      inset-inline-start: 16px - 2px;
     }
   }
 


### PR DESCRIPTION
This bug is currently live on mastodon.social v4.3.0-nightly.2024-02-23 and aca6917. Caused by a regression in #28119.

Before:

<img alt="screenshot" src="https://github.com/mastodon/mastodon/assets/1534150/4da302d8-1bb4-47ca-a752-545fbfbfb73e" width="340px">

After:

<img alt="screenshot mementomori test_explore(iPhone 6_7_8) (1)" src="https://github.com/mastodon/mastodon/assets/1534150/17078977-6b52-476b-8e53-9859ee3a56ca" width="340px">