### PR TITLE
Add `RankedTrend` concern for trends classes

### DIFF
--- a/app/models/concerns/ranked_trend.rb
+++ b/app/models/concerns/ranked_trend.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module RankedTrend
+  extend ActiveSupport::Concern
+
+  included do
+    scope :by_rank, -> { order(rank: :desc) }
+    scope :ranked_below, ->(value) { where(rank: ..value) }
+  end
+
+  class_methods do
+    def recalculate_ordered_rank
+      connection
+        .exec_update(<<~SQL.squish)
+          UPDATE #{table_name}
+          SET rank = inner_ordered.calculated_rank
+          FROM (
+            SELECT id, row_number() OVER w AS calculated_rank
+            FROM #{table_name}
+            WINDOW w AS (
+              PARTITION BY language
+              ORDER BY score DESC
+            )
+          ) inner_ordered
+          WHERE #{table_name}.id = inner_ordered.id
+        SQL
+    end
+  end
+end

--- a/app/models/preview_card_trend.rb
+++ b/app/models/preview_card_trend.rb
@@ -12,6 +12,8 @@
 #  language        :string
 #
 class PreviewCardTrend < ApplicationRecord
+  include RankedTrend
+
   belongs_to :preview_card
   scope :allowed, -> { where(allowed: true) }
 end

--- a/app/models/status_trend.rb
+++ b/app/models/status_trend.rb
@@ -14,6 +14,8 @@
 #
 
 class StatusTrend < ApplicationRecord
+  include RankedTrend
+
   belongs_to :status
   belongs_to :account
 


### PR DESCRIPTION
There was some overlapping behavior for `StatusTrend` and `PreviewCardTrend` in their respective `app/models/trends/*` classes. Add a concern module which they both include, which adds:

- A `by_rank` scope which pulls out the repeated logic from the `request_review` method in those classes
- A `ranked_below` scope which does the same from the same method
- A `recalculate_ordered_rank` class method which pulls out the sql update statement from the `refresh` method in those classes. With the except of a) using interpolation to get the relevant table name, b) renaming `t0` to be `inner_ordered` - the sql here should be the same, although I also pulled it out to a SQL heredoc for readability.

I have two other WIP branches around other shared behavior here, but this was the smallest/simplest bit to grab first.