### PR TITLE
Convert the streaming server to ESM

### DIFF
--- a/streaming/.eslintrc.cjs
+++ b/streaming/.eslintrc.cjs
@@ -2,7 +2,7 @@
 
 // @ts-check
 
-// @ts-ignore - This needs to be a CJS file (eslint does not yet support ESM configd), and TS is complaining we use require
+// @ts-ignore - This needs to be a CJS file (eslint does not yet support ESM configs), and TS is complaining we use require
 const { defineConfig } = require('eslint-define-config');
 
 module.exports = defineConfig({

--- a/streaming/.eslintrc.cjs
+++ b/streaming/.eslintrc.cjs
@@ -1,4 +1,8 @@
+/* eslint-disable import/no-commonjs */
+
 // @ts-check
+
+// @ts-ignore - This needs to be a CJS file (eslint does not yet support ESM configd), and TS is complaining we use require
 const { defineConfig } = require('eslint-define-config');
 
 module.exports = defineConfig({
@@ -22,22 +26,18 @@ module.exports = defineConfig({
     // to maintain.
     'no-delete-var': 'off',
 
-    // The streaming server is written in commonjs, not ESM for now:
-    'import/no-commonjs': 'off',
-
     // This overrides the base configuration for this rule to pick up
     // dependencies for the streaming server from the correct package.json file.
     'import/no-extraneous-dependencies': [
       'error',
       {
-        devDependencies: [
-          'streaming/.eslintrc.js',
-        ],
+        devDependencies: ['streaming/.eslintrc.cjs'],
         optionalDependencies: false,
         peerDependencies: false,
         includeTypes: true,
         packageDir: __dirname,
       },
     ],
+    'import/extensions': ['error', 'always'],
   },
 });

--- a/streaming/errors.js
+++ b/streaming/errors.js
@@ -5,15 +5,14 @@
  * override it in let statements.
  * @type {string}
  */
-const UNEXPECTED_ERROR_MESSAGE = 'An unexpected error occurred';
-exports.UNKNOWN_ERROR_MESSAGE = UNEXPECTED_ERROR_MESSAGE;
+export const UNEXPECTED_ERROR_MESSAGE = 'An unexpected error occurred';
 
 /**
  * Extracts the status and message properties from the error object, if
  * available for public use. The `unknown` is for catch statements
  * @param {Error | AuthenticationError | RequestError | unknown} err
  */
-exports.extractStatusAndMessage = function(err) {
+export function extractStatusAndMessage(err) {
   let statusCode = 500;
   let errorMessage = UNEXPECTED_ERROR_MESSAGE;
   if (err instanceof AuthenticationError || err instanceof RequestError) {
@@ -22,9 +21,9 @@ exports.extractStatusAndMessage = function(err) {
   }
 
   return { statusCode, errorMessage };
-};
+}
 
-class RequestError extends Error {
+export class RequestError extends Error {
   /**
    * @param {string} message
    */
@@ -35,9 +34,7 @@ class RequestError extends Error {
   }
 }
 
-exports.RequestError = RequestError;
-
-class AuthenticationError extends Error {
+export class AuthenticationError extends Error {
   /**
    * @param {string} message
    */
@@ -47,5 +44,3 @@ class AuthenticationError extends Error {
     this.status = 401;
   }
 }
-
-exports.AuthenticationError = AuthenticationError;

--- a/streaming/logging.js
+++ b/streaming/logging.js
@@ -1,6 +1,6 @@
-const { pino } = require('pino');
-const { pinoHttp, stdSerializers: pinoHttpSerializers } = require('pino-http');
-const uuid = require('uuid');
+import { pino } from 'pino';
+import { pinoHttp, stdSerializers as pinoHttpSerializers } from 'pino-http';
+import * as uuid from 'uuid';
 
 /**
  * Generates the Request ID for logging and setting on responses
@@ -36,7 +36,7 @@ function sanitizeRequestLog(req) {
   return log;
 }
 
-const logger = pino({
+export const logger = pino({
   name: "streaming",
   // Reformat the log level to a string:
   formatters: {
@@ -59,7 +59,7 @@ const logger = pino({
   }
 });
 
-const httpLogger = pinoHttp({
+export const httpLogger = pinoHttp({
   logger,
   genReqId: generateRequestId,
   serializers: {
@@ -71,7 +71,7 @@ const httpLogger = pinoHttp({
  * Attaches a logger to the request object received by http upgrade handlers
  * @param {http.IncomingMessage} request
  */
-function attachWebsocketHttpLogger(request) {
+export function attachWebsocketHttpLogger(request) {
   generateRequestId(request);
 
   request.log = logger.child({
@@ -84,7 +84,7 @@ function attachWebsocketHttpLogger(request) {
  * @param {http.IncomingMessage} request
  * @param {import('./index.js').ResolvedAccount} resolvedAccount
  */
-function createWebsocketLogger(request, resolvedAccount) {
+export function createWebsocketLogger(request, resolvedAccount) {
   // ensure the request.id is always present.
   generateRequestId(request);
 
@@ -98,17 +98,12 @@ function createWebsocketLogger(request, resolvedAccount) {
   });
 }
 
-exports.logger = logger;
-exports.httpLogger = httpLogger;
-exports.attachWebsocketHttpLogger = attachWebsocketHttpLogger;
-exports.createWebsocketLogger = createWebsocketLogger;
-
 /**
  * Initializes the log level based on the environment
  * @param {Object<string, any>} env
  * @param {string} environment
  */
-exports.initializeLogLevel = function initializeLogLevel(env, environment) {
+export function initializeLogLevel(env, environment) {
   if (env.LOG_LEVEL && Object.keys(logger.levels.values).includes(env.LOG_LEVEL)) {
     logger.level = env.LOG_LEVEL;
   } else if (environment === 'development') {
@@ -116,4 +111,4 @@ exports.initializeLogLevel = function initializeLogLevel(env, environment) {
   } else {
     logger.level = 'info';
   }
-};
+}

--- a/streaming/metrics.js
+++ b/streaming/metrics.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-const metrics = require('prom-client');
+import metrics from 'prom-client';
 
 /**
  * @typedef StreamingMetrics
@@ -18,7 +18,7 @@ const metrics = require('prom-client');
  * @param {import('pg').Pool} pgPool
  * @returns {StreamingMetrics}
  */
-function setupMetrics(channels, pgPool) {
+export function setupMetrics(channels, pgPool) {
   // Collect metrics from Node.js
   metrics.collectDefaultMetrics();
 
@@ -101,5 +101,3 @@ function setupMetrics(channels, pgPool) {
     messagesSent,
   };
 }
-
-exports.setupMetrics = setupMetrics;

--- a/streaming/package.json
+++ b/streaming/package.json
@@ -7,6 +7,7 @@
   },
   "description": "Mastodon's Streaming Server",
   "private": true,
+  "type": "module",
   "repository": {
     "type": "git",
     "url": "https://github.com/mastodon/mastodon.git"

--- a/streaming/tsconfig.json
+++ b/streaming/tsconfig.json
@@ -2,11 +2,11 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "target": "esnext",
-    "module": "CommonJS",
-    "moduleResolution": "node",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "noUnusedParameters": false,
     "tsBuildInfoFile": "../tmp/cache/streaming/tsconfig.tsbuildinfo",
     "paths": {},
   },
-  "include": ["./*.js", "./.eslintrc.js"],
+  "include": ["./*.js", "./.eslintrc.cjs"],
 }

--- a/streaming/utils.js
+++ b/streaming/utils.js
@@ -16,11 +16,9 @@ const FALSE_VALUES = [
  * @param {any} value
  * @returns {boolean}
  */
-const isTruthy = value =>
-  value && !FALSE_VALUES.includes(value);
-
-exports.isTruthy = isTruthy;
-
+export function isTruthy(value) {
+  return value && !FALSE_VALUES.includes(value);
+}
 
 /**
  * See app/lib/ascii_folder.rb for the canon definitions
@@ -33,7 +31,7 @@ const EQUIVALENT_ASCII_CHARS = 'AAAAAAaaaaaaAaAaAaCcCcCcCcCcDdDdDdEEEEeeeeEeEeEe
  * @param {string} str
  * @returns {string}
  */
-function foldToASCII(str) {
+export function foldToASCII(str) {
   const regex = new RegExp(NON_ASCII_CHARS.split('').join('|'), 'g');
 
   return str.replace(regex, function(match) {
@@ -42,28 +40,22 @@ function foldToASCII(str) {
   });
 }
 
-exports.foldToASCII = foldToASCII;
-
 /**
  * @param {string} str
  * @returns {string}
  */
-function normalizeHashtag(str) {
+export function normalizeHashtag(str) {
   return foldToASCII(str.normalize('NFKC').toLowerCase()).replace(/[^\p{L}\p{N}_\u00b7\u200c]/gu, '');
 }
-
-exports.normalizeHashtag = normalizeHashtag;
 
 /**
  * @param {string|string[]} arrayOrString
  * @returns {string}
  */
-function firstParam(arrayOrString) {
+export function firstParam(arrayOrString) {
   if (Array.isArray(arrayOrString)) {
     return arrayOrString[0];
   } else {
     return arrayOrString;
   }
 }
-
-exports.firstParam = firstParam;


### PR DESCRIPTION
This is supported by Node 16+

Some notes:
- `__dirname` does not work in ES modules, but you can get the same result
- `delete session` was a no-op, because `delete` can only operate on object properties. Using ESM forces strict-mode, which fails at parsing on this rather than silently ignoring the statement. Added a comment to fix this in a future refactor.
- eslint does not support yet ESM configs (this will be supported in eslint 9), so the file has been kept as cjs