### PR TITLE
Fix filters title and keywords overflow

### DIFF
--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -1054,6 +1054,7 @@ a.name-tag,
     display: flex;
     justify-content: space-between;
     margin-bottom: 0;
+    word-break: break-word;
   }
 
   &__permissions {

--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -1078,6 +1078,7 @@ code {
 
       &__type {
         color: $darker-text-color;
+        word-break: break-word;
       }
     }
 


### PR DESCRIPTION
Before:

![image](https://github.com/mastodon/mastodon/assets/18014039/91007fd4-92a2-4662-ac9d-ad66e998d02c)

After:

![image](https://github.com/mastodon/mastodon/assets/18014039/fe8533bf-5cb9-4225-9c88-b3538eb06e99)
