### PR TITLE
Use vanilla JS to get Rails CSRF values

### DIFF
--- a/app/javascript/mastodon/utils/log_out.ts
+++ b/app/javascript/mastodon/utils/log_out.ts
@@ -1,5 +1,3 @@
-import Rails from '@rails/ujs';
-
 export const logOut = () => {
   const form = document.createElement('form');
 
@@ -9,13 +7,18 @@ export const logOut = () => {
   methodInput.setAttribute('type', 'hidden');
   form.appendChild(methodInput);
 
-  const csrfToken = Rails.csrfToken();
-  const csrfParam = Rails.csrfParam();
+  const csrfToken = document.querySelector<HTMLMetaElement>(
+    'meta[name=csrf-token]',
+  );
+
+  const csrfParam = document.querySelector<HTMLMetaElement>(
+    'meta[name=csrf-param]',
+  );
 
   if (csrfParam && csrfToken) {
     const csrfInput = document.createElement('input');
-    csrfInput.setAttribute('name', csrfParam);
-    csrfInput.setAttribute('value', csrfToken);
+    csrfInput.setAttribute('name', csrfParam.content);
+    csrfInput.setAttribute('value', csrfToken.content);
     csrfInput.setAttribute('type', 'hidden');
     form.appendChild(csrfInput);
   }


### PR DESCRIPTION
The approach here is same as what the rails/ujs lib does - https://github.com/rails/rails/blob/7-1-stable/actionview/app/javascript/rails-ujs/utils/csrf.js#L3-L13 - modified with the TS autocorrections.

This is only useful if we want to move away from rails/ujs ... if not, it makes more sense to let the lib do this.