### PR TITLE
Change behavior of privacy dropdown to only change value on validation

### DIFF
--- a/app/javascript/mastodon/features/compose/components/language_dropdown.jsx
+++ b/app/javascript/mastodon/features/compose/components/language_dropdown.jsx
@@ -141,6 +141,7 @@ class LanguageDropdownMenu extends PureComponent {
     case 'Escape':
       onClose();
       break;
+    case ' ':
     case 'Enter':
       this.handleClick(e);
       break;

--- a/app/javascript/mastodon/features/compose/components/privacy_dropdown.jsx
+++ b/app/javascript/mastodon/features/compose/components/privacy_dropdown.jsx
@@ -13,7 +13,7 @@ import PublicIcon from '@/material-icons/400-24px/public.svg?react';
 import QuietTimeIcon from '@/material-icons/400-24px/quiet_time.svg?react';
 import { Icon }  from 'mastodon/components/icon';
 
-import PrivacyDropdownMenu from './privacy_dropdown_menu';
+import { PrivacyDropdownMenu } from './privacy_dropdown_menu';
 
 const messages = defineMessages({
   public_short: { id: 'privacy.public.short', defaultMessage: 'Public' },

--- a/app/javascript/mastodon/features/compose/components/privacy_dropdown.jsx
+++ b/app/javascript/mastodon/features/compose/components/privacy_dropdown.jsx
@@ -5,15 +5,15 @@ import { injectIntl, defineMessages } from 'react-intl';
 
 import classNames from 'classnames';
 
-import { supportsPassiveEvents } from 'detect-passive-events';
 import Overlay from 'react-overlays/Overlay';
 
 import AlternateEmailIcon from '@/material-icons/400-24px/alternate_email.svg?react';
-import InfoIcon from '@/material-icons/400-24px/info.svg?react';
 import LockIcon from '@/material-icons/400-24px/lock.svg?react';
 import PublicIcon from '@/material-icons/400-24px/public.svg?react';
 import QuietTimeIcon from '@/material-icons/400-24px/quiet_time.svg?react';
 import { Icon }  from 'mastodon/components/icon';
+
+import PrivacyDropdownMenu from './privacy_dropdown_menu';
 
 const messages = defineMessages({
   public_short: { id: 'privacy.public.short', defaultMessage: 'Public' },
@@ -27,126 +27,6 @@ const messages = defineMessages({
   change_privacy: { id: 'privacy.change', defaultMessage: 'Change post privacy' },
   unlisted_extra: { id: 'privacy.unlisted.additional', defaultMessage: 'This behaves exactly like public, except the post will not appear in live feeds or hashtags, explore, or Mastodon search, even if you are opted-in account-wide.' },
 });
-
-const listenerOptions = supportsPassiveEvents ? { passive: true, capture: true } : true;
-
-class PrivacyDropdownMenu extends PureComponent {
-
-  static propTypes = {
-    style: PropTypes.object,
-    items: PropTypes.array.isRequired,
-    value: PropTypes.string.isRequired,
-    onClose: PropTypes.func.isRequired,
-    onChange: PropTypes.func.isRequired,
-  };
-
-  handleDocumentClick = e => {
-    if (this.node && !this.node.contains(e.target)) {
-      this.props.onClose();
-      e.stopPropagation();
-    }
-  };
-
-  handleKeyDown = e => {
-    const { items } = this.props;
-    const value = e.currentTarget.getAttribute('data-index');
-    const index = items.findIndex(item => {
-      return (item.value === value);
-    });
-    let element = null;
-
-    switch(e.key) {
-    case 'Escape':
-      this.props.onClose();
-      break;
-    case 'Enter':
-      this.handleClick(e);
-      break;
-    case 'ArrowDown':
-      element = this.node.childNodes[index + 1] || this.node.firstChild;
-      break;
-    case 'ArrowUp':
-      element = this.node.childNodes[index - 1] || this.node.lastChild;
-      break;
-    case 'Tab':
-      if (e.shiftKey) {
-        element = this.node.childNodes[index - 1] || this.node.lastChild;
-      } else {
-        element = this.node.childNodes[index + 1] || this.node.firstChild;
-      }
-      break;
-    case 'Home':
-      element = this.node.firstChild;
-      break;
-    case 'End':
-      element = this.node.lastChild;
-      break;
-    }
-
-    if (element) {
-      element.focus();
-      this.props.onChange(element.getAttribute('data-index'));
-      e.preventDefault();
-      e.stopPropagation();
-    }
-  };
-
-  handleClick = e => {
-    const value = e.currentTarget.getAttribute('data-index');
-
-    e.preventDefault();
-
-    this.props.onClose();
-    this.props.onChange(value);
-  };
-
-  componentDidMount () {
-    document.addEventListener('click', this.handleDocumentClick, { capture: true });
-    document.addEventListener('touchend', this.handleDocumentClick, listenerOptions);
-    if (this.focusedItem) this.focusedItem.focus({ preventScroll: true });
-  }
-
-  componentWillUnmount () {
-    document.removeEventListener('click', this.handleDocumentClick, { capture: true });
-    document.removeEventListener('touchend', this.handleDocumentClick, listenerOptions);
-  }
-
-  setRef = c => {
-    this.node = c;
-  };
-
-  setFocusRef = c => {
-    this.focusedItem = c;
-  };
-
-  render () {
-    const { style, items, value } = this.props;
-
-    return (
-      <div style={{ ...style }} role='listbox' ref={this.setRef}>
-        {items.map(item => (
-          <div role='option' tabIndex={0} key={item.value} data-index={item.value} onKeyDown={this.handleKeyDown} onClick={this.handleClick} className={classNames('privacy-dropdown__option', { active: item.value === value })} aria-selected={item.value === value} ref={item.value === value ? this.setFocusRef : null}>
-            <div className='privacy-dropdown__option__icon'>
-              <Icon id={item.icon} icon={item.iconComponent} />
-            </div>
-
-            <div className='privacy-dropdown__option__content'>
-              <strong>{item.text}</strong>
-              {item.meta}
-            </div>
-
-            {item.extra && (
-              <div className='privacy-dropdown__option__additional' title={item.extra}>
-                <Icon id='info-circle' icon={InfoIcon} />
-              </div>
-            )}
-          </div>
-        ))}
-      </div>
-    );
-  }
-
-}
 
 class PrivacyDropdown extends PureComponent {
 

--- a/app/javascript/mastodon/features/compose/components/privacy_dropdown_menu.jsx
+++ b/app/javascript/mastodon/features/compose/components/privacy_dropdown_menu.jsx
@@ -1,0 +1,131 @@
+import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
+import classNames from 'classnames';
+
+import { supportsPassiveEvents } from 'detect-passive-events';
+
+import InfoIcon from '@/material-icons/400-24px/info.svg?react';
+import { Icon } from 'mastodon/components/icon';
+
+const listenerOptions = supportsPassiveEvents ? { passive: true, capture: true } : true;
+
+class PrivacyDropdownMenu extends PureComponent {
+
+  static propTypes = {
+    style: PropTypes.object,
+    items: PropTypes.array.isRequired,
+    value: PropTypes.string.isRequired,
+    onClose: PropTypes.func.isRequired,
+    onChange: PropTypes.func.isRequired,
+  };
+
+  handleDocumentClick = e => {
+    if (this.node && !this.node.contains(e.target)) {
+      this.props.onClose();
+      e.stopPropagation();
+    }
+  };
+
+  handleKeyDown = e => {
+    const { items } = this.props;
+    const value = e.currentTarget.getAttribute('data-index');
+    const index = items.findIndex(item => {
+      return (item.value === value);
+    });
+    let element = null;
+
+    switch(e.key) {
+    case 'Escape':
+      this.props.onClose();
+      break;
+    case 'Enter':
+      this.handleClick(e);
+      break;
+    case 'ArrowDown':
+      element = this.node.childNodes[index + 1] || this.node.firstChild;
+      break;
+    case 'ArrowUp':
+      element = this.node.childNodes[index - 1] || this.node.lastChild;
+      break;
+    case 'Tab':
+      if (e.shiftKey) {
+        element = this.node.childNodes[index - 1] || this.node.lastChild;
+      } else {
+        element = this.node.childNodes[index + 1] || this.node.firstChild;
+      }
+      break;
+    case 'Home':
+      element = this.node.firstChild;
+      break;
+    case 'End':
+      element = this.node.lastChild;
+      break;
+    }
+
+    if (element) {
+      element.focus();
+      this.props.onChange(element.getAttribute('data-index'));
+      e.preventDefault();
+      e.stopPropagation();
+    }
+  };
+
+  handleClick = e => {
+    const value = e.currentTarget.getAttribute('data-index');
+
+    e.preventDefault();
+
+    this.props.onClose();
+    this.props.onChange(value);
+  };
+
+  componentDidMount () {
+    document.addEventListener('click', this.handleDocumentClick, { capture: true });
+    document.addEventListener('touchend', this.handleDocumentClick, listenerOptions);
+    if (this.focusedItem) this.focusedItem.focus({ preventScroll: true });
+  }
+
+  componentWillUnmount () {
+    document.removeEventListener('click', this.handleDocumentClick, { capture: true });
+    document.removeEventListener('touchend', this.handleDocumentClick, listenerOptions);
+  }
+
+  setRef = c => {
+    this.node = c;
+  };
+
+  setFocusRef = c => {
+    this.focusedItem = c;
+  };
+
+  render () {
+    const { style, items, value } = this.props;
+
+    return (
+      <div style={{ ...style }} role='listbox' ref={this.setRef}>
+        {items.map(item => (
+          <div role='option' tabIndex={0} key={item.value} data-index={item.value} onKeyDown={this.handleKeyDown} onClick={this.handleClick} className={classNames('privacy-dropdown__option', { active: item.value === value })} aria-selected={item.value === value} ref={item.value === value ? this.setFocusRef : null}>
+            <div className='privacy-dropdown__option__icon'>
+              <Icon id={item.icon} icon={item.iconComponent} />
+            </div>
+
+            <div className='privacy-dropdown__option__content'>
+              <strong>{item.text}</strong>
+              {item.meta}
+            </div>
+
+            {item.extra && (
+              <div className='privacy-dropdown__option__additional' title={item.extra}>
+                <Icon id='info-circle' icon={InfoIcon} />
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+}
+
+export default PrivacyDropdownMenu;

--- a/app/javascript/mastodon/features/compose/components/privacy_dropdown_menu.jsx
+++ b/app/javascript/mastodon/features/compose/components/privacy_dropdown_menu.jsx
@@ -86,9 +86,9 @@ export const PrivacyDropdownMenu = ({ style, items, value, onClose, onChange }) 
   }, [handleDocumentClick]);
 
   return (
-    <div style={{ ...style }} role='listbox' ref={nodeRef}>
+    <ul style={{ ...style }} role='listbox' ref={nodeRef}>
       {items.map(item => (
-        <div
+        <li
           role='option'
           tabIndex={0}
           key={item.value}
@@ -113,9 +113,9 @@ export const PrivacyDropdownMenu = ({ style, items, value, onClose, onChange }) 
               <Icon id='info-circle' icon={InfoIcon} />
             </div>
           )}
-        </div>
+        </li>
       ))}
-    </div>
+    </ul>
   );
 };
 

--- a/app/javascript/mastodon/features/compose/components/privacy_dropdown_menu.jsx
+++ b/app/javascript/mastodon/features/compose/components/privacy_dropdown_menu.jsx
@@ -41,6 +41,7 @@ export const PrivacyDropdownMenu = ({ style, items, value, onClose, onChange }) 
     case 'Escape':
       onClose();
       break;
+    case ' ':
     case 'Enter':
       handleClick(e);
       break;

--- a/app/javascript/mastodon/features/compose/components/privacy_dropdown_menu.jsx
+++ b/app/javascript/mastodon/features/compose/components/privacy_dropdown_menu.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import classNames from 'classnames';
 
@@ -13,6 +13,7 @@ const listenerOptions = supportsPassiveEvents ? { passive: true, capture: true }
 export const PrivacyDropdownMenu = ({ style, items, value, onClose, onChange }) => {
   const nodeRef = useRef(null);
   const focusedItemRef = useRef(null);
+  const [currentValue, setCurrentValue] = useState(value);
 
   const handleDocumentClick = useCallback((e) => {
     if (nodeRef.current && !nodeRef.current.contains(e.target)) {
@@ -66,11 +67,11 @@ export const PrivacyDropdownMenu = ({ style, items, value, onClose, onChange }) 
 
     if (element) {
       element.focus();
-      onChange(element.getAttribute('data-index'));
+      setCurrentValue(element.getAttribute('data-index'));
       e.preventDefault();
       e.stopPropagation();
     }
-  }, [nodeRef, items, onClose, handleClick, onChange]);
+  }, [nodeRef, items, onClose, handleClick, setCurrentValue]);
 
   useEffect(() => {
     document.addEventListener('click', handleDocumentClick, { capture: true });
@@ -86,7 +87,17 @@ export const PrivacyDropdownMenu = ({ style, items, value, onClose, onChange }) 
   return (
     <div style={{ ...style }} role='listbox' ref={nodeRef}>
       {items.map(item => (
-        <div role='option' tabIndex={0} key={item.value} data-index={item.value} onKeyDown={handleKeyDown} onClick={handleClick} className={classNames('privacy-dropdown__option', { active: item.value === value })} aria-selected={item.value === value} ref={item.value === value ? focusedItemRef : null}>
+        <div
+          role='option'
+          tabIndex={0}
+          key={item.value}
+          data-index={item.value}
+          onKeyDown={handleKeyDown}
+          onClick={handleClick}
+          className={classNames('privacy-dropdown__option', { active: item.value === currentValue })}
+          aria-selected={item.value === currentValue}
+          ref={item.value === currentValue ? focusedItemRef : null}
+        >
           <div className='privacy-dropdown__option__icon'>
             <Icon id={item.icon} icon={item.iconComponent} />
           </div>


### PR DESCRIPTION
This changes the post privacy settings to only update when clicking or pressing “Enter” or “space” on an option, as opposed to changing on keyboard validation (tab/up/down/home/end when the menu is open).

This allows exploring options without mistakenly selecting them, avoids the UI changing below the menu (addition of warnings) while navigating it, and provides consistency with the language picker menu.

Additionally, I noticed that neither of these menus handled the “space” key as validating the selection, and fixed that.

Finally, I took the opportunity to split the dropdown menu component to its own file and rewrite it as a functional component (which will also allow reuse of code in a fork I maintain).