### PR TITLE
Remove unused `media-spoiler-*` JS/CSS

### DIFF
--- a/app/javascript/packs/admin.jsx
+++ b/app/javascript/packs/admin.jsx
@@ -94,18 +94,6 @@ Rails.delegate(document, batchCheckboxClassName, 'change', () => {
   }
 });
 
-Rails.delegate(document, '.media-spoiler-show-button', 'click', () => {
-  [].forEach.call(document.querySelectorAll('button.media-spoiler'), (element) => {
-    element.click();
-  });
-});
-
-Rails.delegate(document, '.media-spoiler-hide-button', 'click', () => {
-  [].forEach.call(document.querySelectorAll('.spoiler-button.spoiler-button--visible button'), (element) => {
-    element.click();
-  });
-});
-
 Rails.delegate(document, '.filter-subset--with-select select', 'change', ({ target }) => {
   target.form.submit();
 });

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -622,16 +622,6 @@ body,
   input.button {
     margin: 0 5px 5px 0;
   }
-
-  .media-spoiler-toggle-buttons {
-    margin-inline-start: auto;
-
-    .button {
-      overflow: visible;
-      margin: 0 0 5px 5px;
-      float: right;
-    }
-  }
 }
 
 .back-link {


### PR DESCRIPTION
The relevant markup elements were removed previously: https://github.com/mastodon/mastodon/commit/c7d1a2e400cd6677057a8af90fff866207576098#diff-a498979c47b5e3501451587d668c6bb356939d21853614967c98eb2d7ec7efa0L31-L33