### PR TITLE
Extract `allowed` & `not_allowed` scopes for `PreviewCardTrend` & `StatusTrend`

### DIFF
--- a/app/models/preview_card_trend.rb
+++ b/app/models/preview_card_trend.rb
@@ -15,5 +15,7 @@ class PreviewCardTrend < ApplicationRecord
   include RankedTrend
 
   belongs_to :preview_card
+
   scope :allowed, -> { where(allowed: true) }
+  scope :not_allowed, -> { where(allowed: false) }
 end

--- a/app/models/status_trend.rb
+++ b/app/models/status_trend.rb
@@ -19,5 +19,19 @@ class StatusTrend < ApplicationRecord
   belongs_to :status
   belongs_to :account
 
-  scope :allowed, -> { joins('INNER JOIN (SELECT account_id, MAX(score) AS max_score FROM status_trends GROUP BY account_id) AS grouped_status_trends ON status_trends.account_id = grouped_status_trends.account_id AND status_trends.score = grouped_status_trends.max_score').where(allowed: true) }
+  scope :allowed, -> { where(allowed: true) }
+  scope :not_allowed, -> { where(allowed: false) }
+  scope :with_account_constraint, -> { joins(account_constraint_joins_sql) }
+
+  def self.account_constraint_joins_sql
+    <<~SQL.squish
+      INNER JOIN (
+        SELECT account_id, MAX(score) AS max_score
+        FROM status_trends
+        GROUP BY account_id
+      ) AS grouped_status_trends
+      ON status_trends.account_id = grouped_status_trends.account_id
+        AND status_trends.score = grouped_status_trends.max_score
+    SQL
+  end
 end

--- a/app/models/trends/links.rb
+++ b/app/models/trends/links.rb
@@ -86,8 +86,8 @@ class Trends::Links < Trends::Base
 
   def request_review
     PreviewCardTrend.pluck('distinct language').flat_map do |language|
-      score_at_threshold  = PreviewCardTrend.where(language: language, allowed: true).by_rank.ranked_below(options[:review_threshold]).first&.score || 0
-      preview_card_trends = PreviewCardTrend.where(language: language, allowed: false).joins(:preview_card)
+      score_at_threshold  = PreviewCardTrend.where(language: language).allowed.by_rank.ranked_below(options[:review_threshold]).first&.score || 0
+      preview_card_trends = PreviewCardTrend.where(language: language).not_allowed.joins(:preview_card)
 
       preview_card_trends.filter_map do |trend|
         preview_card = trend.preview_card

--- a/app/models/trends/status_filter.rb
+++ b/app/models/trends/status_filter.rb
@@ -49,7 +49,7 @@ class Trends::StatusFilter
   def trending_scope(value)
     case value
     when 'allowed'
-      StatusTrend.allowed
+      StatusTrend.with_account_constraint.allowed
     else
       StatusTrend.all
     end


### PR DESCRIPTION
Followup from https://github.com/mastodon/mastodon/pull/29388

This changes two models and their respective usage in `models/trends/*` classes.

- For `PreviewCardTrend`, there was an already an `allowed` scope not being used in `Trends::Links`. Change that to use the existing scope. Also add a new `not_allowed` scope and use that as well on the second line in `Trends::Links`.
- For `StatusTrend`, same exact change for `not_allowed` (add it, use it) and similar change with small difference for `allowed`.

The existing `allowed` on `StatusTrend` here had extra conditions around doing a distinct-per-account join. I updated the `allowed` to be just the allowed:true condition, and added a new scope that preserves the previous constraint sql. In the places which were previously using  `StatusTrend.allowed` (and had both conditions), I updated to also call the new scope.

