### PR TITLE
Use `response_vary_headers` method in requests/cache_spec

### DIFF
--- a/spec/requests/cache_spec.rb
+++ b/spec/requests/cache_spec.rb
@@ -184,7 +184,7 @@ describe 'Caching behavior' do
         get '/users/alice'
 
         expect(response).to redirect_to('/@alice')
-        expect(response.headers['Vary']&.split(',')&.map { |x| x.strip.downcase }).to include('accept')
+        expect(response_vary_headers).to include('accept')
       end
     end
 


### PR DESCRIPTION
The method here (defined lower in file, same exact code as replaced) already existed but we must have missed a spot.