### PR TITLE
Add `change` block expectation to `admin/invites#deactivate_all` spec

### DIFF
--- a/spec/controllers/admin/invites_controller_spec.rb
+++ b/spec/controllers/admin/invites_controller_spec.rb
@@ -44,14 +44,13 @@ describe Admin::InvitesController do
   end
 
   describe 'POST #deactivate_all' do
+    before { Fabricate(:invite, expires_at: nil) }
+
     it 'expires all invites, then redirects to admin_invites_path' do
-      invites = Fabricate.times(1, :invite, expires_at: nil)
-
-      post :deactivate_all
-
-      invites.each do |invite|
-        expect(invite.reload).to be_expired
-      end
+      expect { post :deactivate_all }
+        .to change { Invite.exists?(expires_at: nil) }
+        .from(true)
+        .to(false)
 
       expect(response).to redirect_to admin_invites_path
     end


### PR DESCRIPTION
Changes here:

- We were looping through an `invites` collection that only had one record ... drop that loop
- We were checking the post-request value of the reloaded invite, but not that it change ... switch to expect/change block
- After those changes, pull what became an unreferenced data setup out to before block