### PR TITLE
Use inclusive range in `ActivityTracker#get`

### DIFF
--- a/app/lib/activity_tracker.rb
+++ b/app/lib/activity_tracker.rb
@@ -24,7 +24,7 @@ class ActivityTracker
   end
 
   def get(start_at, end_at = Time.now.utc)
-    (start_at.to_date...end_at.to_date).map do |date|
+    (start_at.to_date..end_at.to_date).map do |date|
       key = key_at(date.to_time(:utc))
 
       value = case @type


### PR DESCRIPTION
This method accepts a start and end value, and returns a mapping of date=>value pairs for all dates in the range.

Previously this code was using the three dot (`...`) range style, which exludes the final element in the range from the set operated on by the Enumerable methods like map, used here.

The change to the two dot (`..`) syntax is the inclusive style, and will include the final date in the range in the returned data set, which I believe is the desired

Some irb to demonstrate:

```
irb(main):023> start_date = 1.days.ago
=> Sun, 25 Feb 2024 19:23:16.448698000 UTC +00:00
irb(main):024> end_date = 1.days.from_now
=> Tue, 27 Feb 2024 19:23:22.814281000 UTC +00:00
irb(main):025> set = start_date.to_date...end_date.to_date
=> Sun, 25 Feb 2024...Tue, 27 Feb 2024
irb(main):026> set.map(&:to_s)
=> ["2024-02-25", "2024-02-26"]
irb(main):027> set = start_date.to_date..end_date.to_date
=> Sun, 25 Feb 2024..Tue, 27 Feb 2024
irb(main):028> set.map(&:to_s)
=> ["2024-02-25", "2024-02-26", "2024-02-27"]
```

_Extracted from https://github.com/mastodon/mastodon/pull/28736 (which also includes specs that require these changes)_
