### PR TITLE
Align `TagServersMeasure` query style with other classes

### DIFF
--- a/app/lib/admin/metrics/measure/tag_servers_measure.rb
+++ b/app/lib/admin/metrics/measure/tag_servers_measure.rb
@@ -34,10 +34,10 @@ class Admin::Metrics::Measure::TagServersMeasure < Admin::Metrics::Measure::Base
         INNER JOIN accounts ON statuses.account_id = accounts.id
         WHERE statuses_tags.tag_id = :tag_id
           AND statuses.id BETWEEN :earliest_status_id AND :latest_status_id
-          AND date_trunc('day', statuses.created_at)::date = axis.day
+          AND date_trunc('day', statuses.created_at)::date = axis.period
       )
       FROM (
-        SELECT generate_series(date_trunc('day', :start_at::timestamp)::date, date_trunc('day', :end_at::timestamp)::date, ('1 day')::interval) AS day
+        SELECT generate_series(date_trunc('day', :start_at::timestamp)::date, date_trunc('day', :end_at::timestamp)::date, interval '1 day') AS period
       ) as axis
     SQL
   end


### PR DESCRIPTION
Two changes in here:

- Use the `interval '1 day'` style instead of previous `('1 day')::interval` to cast the type. This is stylistic only and matches this class with the other classes, in advance of further changes.
- Change the selected column from `axis.day` to `axis.period` (and change matching component in other portion of query). This is both stylistic matching of other classes which all use `period`, but this is also a bugfix -- I believe the `axis.day` value here was colliding with the `date_trunc('day')...` usage.

_Extracted from https://github.com/mastodon/mastodon/pull/28736 (which also includes specs that require these changes)_