### PR TITLE
Use full snowflake range in `admin/metrics` classes

### DIFF
--- a/app/lib/admin/metrics/dimension/instance_languages_dimension.rb
+++ b/app/lib/admin/metrics/dimension/instance_languages_dimension.rb
@@ -37,11 +37,11 @@ class Admin::Metrics::Dimension::InstanceLanguagesDimension < Admin::Metrics::Di
   end
 
   def earliest_status_id
-    Mastodon::Snowflake.id_at(@start_at, with_random: false)
+    Mastodon::Snowflake.id_at(@start_at.beginning_of_day, with_random: false)
   end
 
   def latest_status_id
-    Mastodon::Snowflake.id_at(@end_at, with_random: false)
+    Mastodon::Snowflake.id_at(@end_at.end_of_day, with_random: false)
   end
 
   def params

--- a/app/lib/admin/metrics/dimension/servers_dimension.rb
+++ b/app/lib/admin/metrics/dimension/servers_dimension.rb
@@ -30,10 +30,10 @@ class Admin::Metrics::Dimension::ServersDimension < Admin::Metrics::Dimension::B
   end
 
   def earliest_status_id
-    Mastodon::Snowflake.id_at(@start_at)
+    Mastodon::Snowflake.id_at(@start_at.beginning_of_day, with_random: false)
   end
 
   def latest_status_id
-    Mastodon::Snowflake.id_at(@end_at)
+    Mastodon::Snowflake.id_at(@end_at.end_of_day, with_random: false)
   end
 end

--- a/app/lib/admin/metrics/dimension/tag_languages_dimension.rb
+++ b/app/lib/admin/metrics/dimension/tag_languages_dimension.rb
@@ -40,11 +40,11 @@ class Admin::Metrics::Dimension::TagLanguagesDimension < Admin::Metrics::Dimensi
   end
 
   def earliest_status_id
-    Mastodon::Snowflake.id_at(@start_at, with_random: false)
+    Mastodon::Snowflake.id_at(@start_at.beginning_of_day, with_random: false)
   end
 
   def latest_status_id
-    Mastodon::Snowflake.id_at(@end_at, with_random: false)
+    Mastodon::Snowflake.id_at(@end_at.end_of_day, with_random: false)
   end
 
   def params

--- a/app/lib/admin/metrics/dimension/tag_servers_dimension.rb
+++ b/app/lib/admin/metrics/dimension/tag_servers_dimension.rb
@@ -40,11 +40,11 @@ class Admin::Metrics::Dimension::TagServersDimension < Admin::Metrics::Dimension
   end
 
   def earliest_status_id
-    Mastodon::Snowflake.id_at(@start_at, with_random: false)
+    Mastodon::Snowflake.id_at(@start_at.beginning_of_day, with_random: false)
   end
 
   def latest_status_id
-    Mastodon::Snowflake.id_at(@end_at, with_random: false)
+    Mastodon::Snowflake.id_at(@end_at.end_of_day, with_random: false)
   end
 
   def params

--- a/app/lib/admin/metrics/measure/instance_statuses_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_statuses_measure.rb
@@ -51,11 +51,11 @@ class Admin::Metrics::Measure::InstanceStatusesMeasure < Admin::Metrics::Measure
   end
 
   def earliest_status_id
-    Mastodon::Snowflake.id_at(@start_at, with_random: false)
+    Mastodon::Snowflake.id_at(@start_at.beginning_of_day, with_random: false)
   end
 
   def latest_status_id
-    Mastodon::Snowflake.id_at(@end_at, with_random: false)
+    Mastodon::Snowflake.id_at(@end_at.end_of_day, with_random: false)
   end
 
   def time_period


### PR DESCRIPTION
The snowflake ID works by mapping a timestamp to a numeric value to use for database IDs, with or without randomness.

When we are gathering IDs to use as the beginning or end of a report range, we want to include all statuses after the smallest possible ID and before the largest possible ID.

The previous code could lead to "partial day" status ID ranges, since the passing in a value which was not already nudged to the beginning/end of a day would only include some of the possible IDs for that day.

The change here forces the dates to beginning/end of day before asking snowflake for the IDs.

_Extracted from https://github.com/mastodon/mastodon/pull/28736 (which also includes specs that require these changes)_