### PR TITLE
Fix the regression with the search icon position

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -5195,7 +5195,6 @@ a.status-card {
   .icon {
     position: absolute;
     top: 12px + 2px;
-    inset-inline-start: 16px - 2px;
     display: inline-block;
     opacity: 0;
     transition: all 100ms linear;
@@ -5209,6 +5208,10 @@ a.status-card {
     &.active {
       pointer-events: auto;
       opacity: 1;
+    }
+
+    @media screen and (min-width: $no-gap-breakpoint) {
+      inset-inline-start: 16px - 2px;
     }
   }
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -5204,14 +5204,11 @@ a.status-card {
     color: $darker-text-color;
     cursor: default;
     pointer-events: none;
+    margin-left: 16px - 2px;
 
     &.active {
       pointer-events: auto;
       opacity: 1;
-    }
-
-    @media screen and (min-width: $no-gap-breakpoint) {
-      inset-inline-start: 16px - 2px;
     }
   }
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -5204,7 +5204,7 @@ a.status-card {
     color: $darker-text-color;
     cursor: default;
     pointer-events: none;
-    margin-left: 16px - 2px;
+    margin-inline-start: 16px - 2px;
 
     &.active {
       pointer-events: auto;


### PR DESCRIPTION
Fixes the regression caused by #29384 where advanced web UI under certain viewport resets the margin before the search icon. 

This PR uses another approach. Because the element is already absolute positioned, we are using margin-left here. When the icon moves to right on other breakpoints, margin-left does nothing and the icon doesn't really move because no relative positioning is used. If we use `inset-inline-start`, `left` or `right`, we are dooming the icon on certain place. Margin--left just pushes the icon from left _if_ the icon is on the left side.