### PR TITLE
Use "cacheable response" shared example in more places

### DIFF
--- a/spec/controllers/custom_css_controller_spec.rb
+++ b/spec/controllers/custom_css_controller_spec.rb
@@ -14,17 +14,6 @@ describe CustomCssController do
       expect(response).to have_http_status(200)
     end
 
-    it 'returns public cache control header' do
-      expect(response.headers['Cache-Control']).to include('public')
-    end
-
-    it 'does not set cookies' do
-      expect(response.cookies).to be_empty
-      expect(response.headers['Set-Cookies']).to be_nil
-    end
-
-    it 'does not set sessions' do
-      expect(session).to be_empty
-    end
+    it_behaves_like 'cacheable response'
   end
 end

--- a/spec/controllers/instance_actors_controller_spec.rb
+++ b/spec/controllers/instance_actors_controller_spec.rb
@@ -12,23 +12,18 @@ RSpec.describe InstanceActorsController do
           get :show, params: { format: format }
         end
 
-        it 'returns http success with correct media type, headers, and session values' do
+        it 'returns http success with correct media type and body' do
           expect(response)
             .to have_http_status(200)
             .and have_attributes(
-              media_type: eq('application/activity+json'),
-              cookies: be_empty
+              media_type: eq('application/activity+json')
             )
-
-          expect(response.headers)
-            .to include('Cache-Control' => include('public'))
-            .and not_include('Set-Cookies')
-
-          expect(session).to be_empty
 
           expect(body_as_json)
             .to include(:id, :type, :preferredUsername, :inbox, :publicKey, :inbox, :outbox, :url)
         end
+
+        it_behaves_like 'cacheable response'
       end
 
       before do

--- a/spec/controllers/manifests_controller_spec.rb
+++ b/spec/controllers/manifests_controller_spec.rb
@@ -14,17 +14,6 @@ describe ManifestsController do
       expect(response).to have_http_status(200)
     end
 
-    it 'returns public cache control header' do
-      expect(response.headers['Cache-Control']).to include('public')
-    end
-
-    it 'does not set cookies' do
-      expect(response.cookies).to be_empty
-      expect(response.headers['Set-Cookies']).to be_nil
-    end
-
-    it 'does not set sessions' do
-      expect(session).to be_empty
-    end
+    it_behaves_like 'cacheable response'
   end
 end

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -20,13 +20,7 @@ RSpec.describe TagsController do
           expect(response).to have_http_status(200)
         end
 
-        it 'returns Vary header' do
-          expect(response.headers['Vary']).to eq 'Accept, Accept-Language, Cookie'
-        end
-
-        it 'returns public Cache-Control header' do
-          expect(response.headers['Cache-Control']).to include 'public'
-        end
+        it_behaves_like 'cacheable response', expects_vary: 'Accept, Accept-Language, Cookie'
       end
 
       context 'when requested as JSON' do
@@ -36,13 +30,7 @@ RSpec.describe TagsController do
           expect(response).to have_http_status(200)
         end
 
-        it 'returns Vary header' do
-          expect(response.headers['Vary']).to eq 'Accept, Accept-Language, Cookie'
-        end
-
-        it 'returns public Cache-Control header' do
-          expect(response.headers['Cache-Control']).to include 'public'
-        end
+        it_behaves_like 'cacheable response', expects_vary: 'Accept, Accept-Language, Cookie'
       end
     end
 

--- a/spec/support/examples/cache.rb
+++ b/spec/support/examples/cache.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 shared_examples 'cacheable response' do |expects_vary: false|
-  it 'sets correct cache and vary headers and does not set cookies or session' do
+  it 'sets correct cache and vary headers and does not set cookies or session', :aggregate_failures do
     expect(response.cookies).to be_empty
     expect(response.headers['Set-Cookies']).to be_nil
 


### PR DESCRIPTION
Some examples were repeating either the exact assertions from, or a subset of, this already existing shared example. Update them to use it. Update the example itself to turn on `aggregate_failures`.