### PR TITLE
Specify 410 for code when responding as json while self-destruction

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -178,7 +178,7 @@ class ApplicationController < ActionController::Base
 
     respond_to do |format|
       format.any  { render 'errors/self_destruct', layout: 'auth', status: 410, formats: [:html] }
-      format.json { render json: { error: Rack::Utils::HTTP_STATUS_CODES[410] }, status: code }
+      format.json { render json: { error: Rack::Utils::HTTP_STATUS_CODES[410] }, status: 410 }
     end
   end
 


### PR DESCRIPTION
To avoid the error like below while self-destructing:

```
NameError (undefined local variable or method `code' for an instance of AccountsController):

app/controllers/application_controller.rb:181:in `block (2 levels) in check_self_destruct!'
app/controllers/application_controller.rb:179:in `check_self_destruct!'
lib/request_logger.rb:19:in `call'
lib/mastodon/rack_middleware.rb:9:in `call'
lib/public_file_server_middleware.rb:18:in `call'
```