### PR TITLE
Further Prettier ESLint cleanup

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -61,9 +61,6 @@ module.exports = defineConfig({
     'consistent-return': 'error',
     'dot-notation': 'error',
     eqeqeq: ['error', 'always', { 'null': 'ignore' }],
-    'indent': ['error', 2],
-    'jsx-quotes': ['error', 'prefer-single'],
-    'semi': ['error', 'always'],
     'no-case-declarations': 'off',
     'no-catch-shadow': 'error',
     'no-console': [
@@ -107,13 +104,10 @@ module.exports = defineConfig({
     'react/jsx-boolean-value': 'error',
     'react/display-name': 'off',
     'react/jsx-fragments': ['error', 'syntax'],
-    'react/jsx-equals-spacing': 'error',
     'react/jsx-no-bind': 'error',
     'react/jsx-no-useless-fragment': 'error',
     'react/jsx-no-target-blank': 'off',
-    'react/jsx-tag-spacing': 'error',
     'react/jsx-uses-react': 'off', // not needed with new JSX transform
-    'react/jsx-wrap-multilines': 'error',
     'react/react-in-jsx-scope': 'off', // not needed with new JSX transform
     'react/self-closing-comp': 'error',
 
@@ -321,9 +315,6 @@ module.exports = defineConfig({
       },
 
       rules: {
-        // Disable formatting rules that have been enabled in the base config
-        'indent': 'off',
-
         // This is not needed as we use noImplicitReturns, which handles this in addition to understanding types
         'consistent-return': 'off',
 


### PR DESCRIPTION
Was going to start opting the JS/JSX in smaller batches, but found there were some round-trip issues running `yarn format` and `yarn fix:js`. I cleared out the remaining rules that were disabled in https://github.com/prettier/eslint-config-prettier/blob/main/index.js to go back to the defaults.