### PR TITLE
Align `TagServersMeasure` to use `WITH` query style similar to others

### DIFF
--- a/app/lib/admin/metrics/measure/tag_servers_measure.rb
+++ b/app/lib/admin/metrics/measure/tag_servers_measure.rb
@@ -28,14 +28,17 @@ class Admin::Metrics::Measure::TagServersMeasure < Admin::Metrics::Measure::Base
   def sql_query_string
     <<~SQL.squish
       SELECT axis.*, (
-        SELECT count(distinct accounts.domain) AS value
-        FROM statuses
-        INNER JOIN statuses_tags ON statuses.id = statuses_tags.status_id
-        INNER JOIN accounts ON statuses.account_id = accounts.id
-        WHERE statuses_tags.tag_id = :tag_id
-          AND statuses.id BETWEEN :earliest_status_id AND :latest_status_id
-          AND date_trunc('day', statuses.created_at)::date = axis.period
-      )
+        WITH tag_servers AS (
+          SELECT DISTINCT accounts.domain
+          FROM statuses
+          INNER JOIN statuses_tags ON statuses.id = statuses_tags.status_id
+          INNER JOIN accounts ON statuses.account_id = accounts.id
+          WHERE statuses_tags.tag_id = :tag_id
+            AND statuses.id BETWEEN :earliest_status_id AND :latest_status_id
+            AND date_trunc('day', statuses.created_at)::date = axis.period
+        )
+        SELECT COUNT(*) FROM tag_servers
+      ) AS value
       FROM (
         SELECT generate_series(date_trunc('day', :start_at::timestamp)::date, date_trunc('day', :end_at::timestamp)::date, interval '1 day') AS period
       ) as axis


### PR DESCRIPTION
Following up on https://github.com/mastodon/mastodon/pull/29414, this is the final non-spec component of https://github.com/mastodon/mastodon/pull/28736

Within the `metrics/measure/*` classes, every other class has a query format like:

```sql
SELECT axis.*,
(WITH something AS ( <query unique to report> ) SELECT count(*) FROM something) AS value
FROM ( <generate day series> ) AS axis
```

The only exception was this class, which has a slightly different format. The change here is keep the same data selection, but wrap it in the `WITH (...) AS value` style used everywhere else.

Once they are all aligned, there's opportunity here to extract the standardized outer query wrapper either to the base class or query helper module, so that each class can just define the query that is narrowly related to it's reporting data.

Like the other PRs extracted from https://github.com/mastodon/mastodon/pull/28736 I believe the changes here are acceptable given the spec coverage added there.