### PR TITLE
Allow pagination `Link` headers on API accounts/statuses when pinned true

### DIFF
--- a/app/controllers/api/v1/accounts/statuses_controller.rb
+++ b/app/controllers/api/v1/accounts/statuses_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::Accounts::StatusesController < Api::BaseController
   before_action -> { authorize_if_got_token! :read, :'read:statuses' }
   before_action :set_account
 
-  after_action :insert_pagination_headers, unless: -> { truthy_param?(:pinned) }
+  after_action :insert_pagination_headers
 
   def index
     cache_if_unauthenticated!


### PR DESCRIPTION
Resolves https://github.com/mastodon/mastodon/issues/25555

The previous behavior when the `pinned` param was either not included or was false should be unchanged here -- any pinned statuses would be included as normal within the larger statuses collection and paginatable. This changes the scenario where `pinned` is set to true. Previously the paginated `Link` headers were explicitly removed (presumably because with the default limit, you'd never have more than one page of them) ... but as noted on linked issue, you can pass in a `limit` as well, which makes this odd.

Totally separately from that -- it strikes me that the link header usage checking across the full request spec suite might be a good thing to audit and/or add a custom matcher for verifying they are as expected. I suspect it's done thoroughly/consistently everywhere. May take a crack at this after the remaining api controller->request spec PRs are merged.