### PR TITLE
Use `display_name` inside of custom `TagSerializer` used by `REST::StatusSerializer`

### DIFF
--- a/app/serializers/rest/status_serializer.rb
+++ b/app/serializers/rest/status_serializer.rb
@@ -196,5 +196,9 @@ class REST::StatusSerializer < ActiveModel::Serializer
     def url
       tag_url(object)
     end
+
+    def name
+      object.display_name
+    end
   end
 end

--- a/app/serializers/rest/status_serializer.rb
+++ b/app/serializers/rest/status_serializer.rb
@@ -194,7 +194,7 @@ class REST::StatusSerializer < ActiveModel::Serializer
     attributes :name, :url
 
     def url
-      tag_url(object)
+      tag_url(object.display_name)
     end
 
     def name

--- a/spec/serializers/rest/status_serializer_spec.rb
+++ b/spec/serializers/rest/status_serializer_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe REST::StatusSerializer do
+  let(:serialization) { JSON.parse serialized_resource }
+  let(:serialized_resource) do
+    ActiveModelSerializers::SerializableResource.new(
+      record,
+      scope_name: :current_user,
+      scope: nil,
+      serializer: described_class
+    ).to_json
+  end
+
+  let(:record) { Fabricate(:status, tags: tags) }
+  let(:tag_names) { ['España', 'Test'] }
+  let(:tags) { Tag.find_or_create_by_names(tag_names) }
+
+  describe 'tags' do
+    it 'returns tags including special characters' do
+      expect(serialization.deep_symbolize_keys)
+        .to include(
+          tags: contain_exactly(
+            include(name: 'España'),
+            include(name: 'Test')
+          )
+        )
+    end
+  end
+end

--- a/spec/serializers/rest/status_serializer_spec.rb
+++ b/spec/serializers/rest/status_serializer_spec.rb
@@ -13,17 +13,18 @@ describe REST::StatusSerializer do
     ).to_json
   end
 
-  let(:record) { Fabricate(:status, tags: tags) }
-  let(:tag_names) { ['España', 'Test'] }
-  let(:tags) { Tag.find_or_create_by_names(tag_names) }
+  let(:record) { PostStatusService.new.call(account, text: 'Status with special char tags #España') }
+  let(:account) { Fabricate(:account) }
 
   describe 'tags' do
-    it 'returns tags including special characters' do
+    it 'returns tags including special character versions of names and urls' do
       expect(serialization.deep_symbolize_keys)
         .to include(
           tags: contain_exactly(
-            include(name: 'España'),
-            include(name: 'Test')
+            include(
+              name: 'España',
+              url: include('/tags/Espa%C3%B1a')
+            )
           )
         )
     end


### PR DESCRIPTION
It looks like the top-level `REST::TagSerializer` uses `display_name` - https://github.com/mastodon/mastodon/blob/v4.2.8/app/serializers/rest/tag_serializer.rb#L14-L16 - but the custom `TagSerializer` defined inside of `REST::StatusSerializer` was using the (normalized) `name` value instead. Presumably they should match?

Resolves https://github.com/mastodon/mastodon/issues/26518