### PR TITLE
Opt-in root javascript files to Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -80,4 +80,4 @@ app/javascript/styles/mastodon/reset.scss
 AUTHORS.md
 
 # Process a few selected JS files
-!lint-staged.config.js
+!/*.js

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,4 +1,4 @@
 module.exports = {
   singleQuote: true,
-  jsxSingleQuote: true
+  jsxSingleQuote: true,
 };

--- a/ide-helper.js
+++ b/ide-helper.js
@@ -6,7 +6,7 @@ jetbrains://WebStorm/settings?name=Languages+%26+Frameworks--JavaScript--Webpack
 module.exports = {
   resolve: {
     alias: {
-      'mastodon': path.resolve(__dirname, 'app/javascript/mastodon'),
+      mastodon: path.resolve(__dirname, 'app/javascript/mastodon'),
     },
   },
 };

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -31,14 +31,13 @@ module.exports = {
   },
   overrides: [
     {
-      'files': ['app/javascript/styles/entrypoints/mailer.scss'],
+      files: ['app/javascript/styles/entrypoints/mailer.scss'],
       rules: {
         'property-no-unknown': [
           true,
           {
-            ignoreProperties: [
-              '/^mso-/',
-            ] },
+            ignoreProperties: ['/^mso-/'],
+          },
         ],
       },
     },


### PR DESCRIPTION
Instead of just running on the one config file, runs on all of them sitting in the root. Also had a conflict with the case statements requiring a file level ignore for now.