### PR TITLE
Fix regression with search bar icon position

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -5210,10 +5210,6 @@ a.status-card {
       pointer-events: auto;
       opacity: 1;
     }
-
-    @media screen and (min-width: $no-gap-breakpoint) {
-      inset-inline-start: 16px - 2px;
-    }
   }
 
   .icon-search {
@@ -8265,7 +8261,7 @@ noscript {
   .search__input {
     border: 1px solid lighten($ui-base-color, 8%);
     padding: 10px;
-    padding-inline-end: 28px;
+    padding-inline-end: 30px;
   }
 
   .search__popout {


### PR DESCRIPTION
Follow-up to #29417

Sorry I did not properly try #29417 after my change suggestion, but there was an issue due to both `inset-inline-start` and `margin-inline-start` applying to the icon under certain conditions.

## Before

![image](https://github.com/mastodon/mastodon/assets/384364/56a9edc6-61d6-4306-bc47-6c238204f0df)

## After

![image](https://github.com/mastodon/mastodon/assets/384364/a165a714-86c9-472d-add3-31ee6244615d)

cc @ronilaukkarinen
