### PR TITLE
Remove unused `Account::Interactions#endorsed?` method

### DIFF
--- a/app/models/concerns/account/interactions.rb
+++ b/app/models/concerns/account/interactions.rb
@@ -242,10 +242,6 @@ module Account::Interactions
     status_pins.exists?(status: status)
   end
 
-  def endorsed?(account)
-    account_pins.exists?(target_account: account)
-  end
-
   def status_matches_filters(status)
     active_filters = CustomFilter.cached_filters_for(id)
     CustomFilter.apply_cached_filters(active_filters, status)


### PR DESCRIPTION
Looks like this was added - https://github.com/mastodon/mastodon/commit/f2404de871f0bdfda5c9aeeeb4c6c4d10a8da8ab#diff-cec0186b2c799e5e23826310a664e009697fbb40ac87f20e0199be4948fac09dR197-R199 - but never actually used?