### PR TITLE
Disable codecov comments on PRs

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,3 +1,4 @@
+comment: false # Do not leave PR comments
 coverage:
   status:
     project:
@@ -8,6 +9,3 @@ coverage:
       default:
         # Github status check is not blocking
         informational: true
-comment:
-  # Only write a comment in PR if there are changes
-  require_changes: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,1 +1,0 @@
-comment: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false


### PR DESCRIPTION
Related to https://github.com/mastodon/mastodon/pull/23868#issuecomment-1971883286

I believe this will leave the annotations and web UI access as-is, but just stop the PR comments.