### PR TITLE
Add support for preview cards for local posts/accounts

### DIFF
--- a/app/models/preview_card.rb
+++ b/app/models/preview_card.rb
@@ -32,6 +32,8 @@
 #  link_type                    :integer
 #  published_at                 :datetime
 #  image_description            :string           default(""), not null
+#  target_status_id             :bigint(8)
+#  target_account_id            :bigint(8)
 #
 
 class PreviewCard < ApplicationRecord
@@ -49,6 +51,9 @@ class PreviewCard < ApplicationRecord
 
   enum :type, { link: 0, photo: 1, video: 2, rich: 3 }
   enum :link_type, { unknown: 0, article: 1 }
+
+  belongs_to :target_status, class_name: 'Status', optional: true, dependent: :destroy
+  belongs_to :target_account, class_name: 'Account', optional: true, dependent: :destroy
 
   has_many :preview_cards_statuses, dependent: :delete_all, inverse_of: :preview_card
   has_many :statuses, through: :preview_cards_statuses

--- a/db/migrate/20240326155335_add_target_status_id_to_preview_cards.rb
+++ b/db/migrate/20240326155335_add_target_status_id_to_preview_cards.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddTargetStatusIdToPreviewCards < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_belongs_to :preview_cards, :target_status, null: true, index: { algorithm: :concurrently, where: 'target_status_id IS NOT NULL' }
+  end
+end

--- a/db/migrate/20240326160308_add_target_status_foreign_key_to_preview_cards.rb
+++ b/db/migrate/20240326160308_add_target_status_foreign_key_to_preview_cards.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddTargetStatusForeignKeyToPreviewCards < ActiveRecord::Migration[7.1]
+  def change
+    add_foreign_key :preview_cards, :statuses, column: :target_status_id, on_delete: :cascade, validate: false
+  end
+end

--- a/db/migrate/20240326160903_validate_target_status_foreign_key_on_preview_cards.rb
+++ b/db/migrate/20240326160903_validate_target_status_foreign_key_on_preview_cards.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateTargetStatusForeignKeyOnPreviewCards < ActiveRecord::Migration[7.1]
+  def change
+    validate_foreign_key :preview_cards, column: :target_status_id
+  end
+end

--- a/db/migrate/20240326161252_add_target_account_id_to_preview_cards.rb
+++ b/db/migrate/20240326161252_add_target_account_id_to_preview_cards.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddTargetAccountIdToPreviewCards < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_belongs_to :preview_cards, :target_account, null: true, index: { algorithm: :concurrently, where: 'target_account_id IS NOT NULL' }
+  end
+end

--- a/db/migrate/20240326161607_add_target_account_foreign_key_to_preview_cards.rb
+++ b/db/migrate/20240326161607_add_target_account_foreign_key_to_preview_cards.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddTargetAccountForeignKeyToPreviewCards < ActiveRecord::Migration[7.1]
+  def change
+    add_foreign_key :preview_cards, :accounts, column: :target_account_id, on_delete: :cascade, validate: false
+  end
+end

--- a/db/migrate/20240326161740_validate_target_account_foreign_key_on_preview_cards.rb
+++ b/db/migrate/20240326161740_validate_target_account_foreign_key_on_preview_cards.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateTargetAccountForeignKeyOnPreviewCards < ActiveRecord::Migration[7.1]
+  def change
+    validate_foreign_key :preview_cards, column: :target_account_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_22_161611) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_26_161740) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -874,6 +874,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_22_161611) do
     t.integer "link_type"
     t.datetime "published_at"
     t.string "image_description", default: "", null: false
+    t.bigint "target_status_id"
+    t.bigint "target_account_id"
+    t.index ["target_account_id"], name: "index_preview_cards_on_target_account_id", where: "(target_account_id IS NOT NULL)"
+    t.index ["target_status_id"], name: "index_preview_cards_on_target_status_id", where: "(target_status_id IS NOT NULL)"
     t.index ["url"], name: "index_preview_cards_on_url", unique: true
   end
 
@@ -1347,6 +1351,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_22_161611) do
   add_foreign_key "polls", "accounts", on_delete: :cascade
   add_foreign_key "polls", "statuses", on_delete: :cascade
   add_foreign_key "preview_card_trends", "preview_cards", on_delete: :cascade
+  add_foreign_key "preview_cards", "accounts", column: "target_account_id", on_delete: :cascade
+  add_foreign_key "preview_cards", "statuses", column: "target_status_id", on_delete: :cascade
   add_foreign_key "report_notes", "accounts", on_delete: :cascade
   add_foreign_key "report_notes", "reports", on_delete: :cascade
   add_foreign_key "reports", "accounts", column: "action_taken_by_account_id", name: "fk_bca45b75fd", on_delete: :nullify


### PR DESCRIPTION
Alternative take on #29459

This works by having the server perform HTTP requests against itself. This is a bit wasteful, and will not work on certain configurations, but this will spare us from duplicating the logic in different places. Allowed HTTP requests are filtered to avoid arbitrary queries.

In addition, add `target_status_id` and `target_account_id` foreign keys so that preview cards get automatically cleaned up as needed. For now, this only works for local content, but this could be expanded to known remote posts as long as we find a way to efficiently identify them from the URL.