### PR TITLE
Use the server setting to get the max number of poll options in UI

### DIFF
--- a/app/javascript/mastodon/actions/compose.js
+++ b/app/javascript/mastodon/actions/compose.js
@@ -786,11 +786,12 @@ export function addPollOption(title) {
   };
 }
 
-export function changePollOption(index, title) {
+export function changePollOption(index, title, maxOptions) {
   return {
     type: COMPOSE_POLL_OPTION_CHANGE,
     index,
     title,
+    maxOptions,
   };
 }
 

--- a/app/javascript/mastodon/features/compose/components/poll_form.jsx
+++ b/app/javascript/mastodon/features/compose/components/poll_form.jsx
@@ -58,10 +58,11 @@ const Option = ({ multipleChoice, index, title, autoFocus }) => {
   const dispatch = useDispatch();
   const suggestions = useSelector(state => state.getIn(['compose', 'suggestions']));
   const lang = useSelector(state => state.getIn(['compose', 'language']));
+  const maxOptions = useSelector(state => state.getIn(['server', 'server', 'configuration', 'polls', 'max_options']));
 
   const handleChange = useCallback(({ target: { value } }) => {
-    dispatch(changePollOption(index, value));
-  }, [dispatch, index]);
+    dispatch(changePollOption(index, value, maxOptions));
+  }, [dispatch, index, maxOptions]);
 
   const handleSuggestionsFetchRequested = useCallback(token => {
     dispatch(fetchComposeSuggestions(token));

--- a/app/javascript/mastodon/reducers/compose.js
+++ b/app/javascript/mastodon/reducers/compose.js
@@ -280,12 +280,12 @@ const updateSuggestionTags = (state, token) => {
   });
 };
 
-const updatePoll = (state, index, value) => state.updateIn(['poll', 'options'], options => {
+const updatePoll = (state, index, value, maxOptions) => state.updateIn(['poll', 'options'], options => {
   const tmp = options.set(index, value).filterNot(x => x.trim().length === 0);
 
   if (tmp.size === 0) {
     return tmp.push('').push('');
-  } else if (tmp.size < 4) {
+  } else if (tmp.size < maxOptions) {
     return tmp.push('');
   }
 
@@ -529,7 +529,7 @@ export default function compose(state = initialState, action) {
   case COMPOSE_POLL_REMOVE:
     return state.set('poll', null);
   case COMPOSE_POLL_OPTION_CHANGE:
-    return updatePoll(state, action.index, action.title);
+    return updatePoll(state, action.index, action.title, action.maxOptions);
   case COMPOSE_POLL_SETTINGS_CHANGE:
     return state.update('poll', poll => poll.set('expires_in', action.expiresIn).set('multiple', action.isMultiple));
   case COMPOSE_LANGUAGE_CHANGE:


### PR DESCRIPTION
This option is in a different sub-state, so it needs to be fetched from the action call, it cant be read from the reducer directly