### PR TITLE
Add `by_latest_used` scope, move admin area recent IPs to partial

### DIFF
--- a/app/models/user_ip.rb
+++ b/app/models/user_ip.rb
@@ -15,4 +15,6 @@ class UserIp < ApplicationRecord
   self.primary_key = :user_id
 
   belongs_to :user
+
+  scope :by_latest_used, -> { order(used_at: :desc) }
 end

--- a/app/views/admin/accounts/_local_account.html.haml
+++ b/app/views/admin/accounts/_local_account.html.haml
@@ -62,13 +62,7 @@
   %td
     %time.formatted{ datetime: account.created_at.iso8601, title: l(account.created_at) }= l account.created_at
   %td
-- recent_ips = account.user.ips.by_latest_used.to_a
-- recent_ips.each_with_index do |recent_ip, i|
-  %tr
-    - if i.zero?
-      %th{ rowspan: recent_ips.size }= t('admin.accounts.most_recent_ip')
-    %td= recent_ip.ip
-    %td= table_link_to 'search', t('admin.accounts.search_same_ip'), admin_accounts_path(ip: recent_ip.ip)
+  = render partial: 'admin/accounts/user_ip', collection: account.user.ips.by_latest_used
 %tr
   %th= t('admin.accounts.most_recent_activity')
   %td

--- a/app/views/admin/accounts/_local_account.html.haml
+++ b/app/views/admin/accounts/_local_account.html.haml
@@ -62,7 +62,7 @@
   %td
     %time.formatted{ datetime: account.created_at.iso8601, title: l(account.created_at) }= l account.created_at
   %td
-- recent_ips = account.user.ips.order(used_at: :desc).to_a
+- recent_ips = account.user.ips.by_latest_used.to_a
 - recent_ips.each_with_index do |recent_ip, i|
   %tr
     - if i.zero?

--- a/app/views/admin/accounts/_user_ip.html.haml
+++ b/app/views/admin/accounts/_user_ip.html.haml
@@ -1,0 +1,5 @@
+%tr
+  - if user_ip_iteration.first?
+    %th{ rowspan: user_ip_iteration.size }= t('admin.accounts.most_recent_ip')
+  %td= user_ip.ip
+  %td= table_link_to 'search', t('admin.accounts.search_same_ip'), admin_accounts_path(ip: user_ip.ip)


### PR DESCRIPTION
A few changes here:

- Add `by_latest_used` scope to `UserIp`, which cleans up the collection loading in the view
- Move the user_ip listing loop into a partial
- There was a `recent_ips` local variable used here for the sole purposes of being able to refer to the size of the collection to expand the `rowspan` of the `th` element, and to check whether the `UserIp` record in the loop was the first (`zero?`) element of that set -- we can replace both of those with the iteration object internal to the partial loop and remove the local var from the view.

Possible future improvement here would be to pass in the user_ips collection either as an i-var from controller level, or as a local var to the `_local_account` partial when it's called from the `show` view.