### PR TITLE
Downgrade `rack-cors` to version 2.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ gem 'public_suffix', '~> 5.0'
 gem 'pundit', '~> 2.3'
 gem 'premailer-rails'
 gem 'rack-attack', '~> 6.6'
-gem 'rack-cors', '~> 2.0', require: 'rack/cors'
+gem 'rack-cors', '2.0', require: 'rack/cors' # TODO: Remove version lock when resolved: https://github.com/cyu/rack-cors/issues/274
 gem 'rails-i18n', '~> 7.0'
 gem 'redcarpet', '~> 3.6'
 gem 'redis', '~> 4.5', require: ['redis', 'redis/connection/hiredis']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -535,7 +535,7 @@ GEM
     rack (2.2.8.1)
     rack-attack (6.7.0)
       rack (>= 1.0, < 4)
-    rack-cors (2.0.1)
+    rack-cors (2.0.0)
       rack (>= 2.0.0)
     rack-oauth2 (1.21.3)
       activesupport
@@ -901,7 +901,7 @@ DEPENDENCIES
   pundit (~> 2.3)
   rack (~> 2.2.7)
   rack-attack (~> 6.6)
-  rack-cors (~> 2.0)
+  rack-cors (= 2.0)
   rack-test (~> 2.1)
   rails (~> 7.1.1)
   rails-controller-testing (~> 1.0)


### PR DESCRIPTION
This is a hopefully temporary bump down to fix the bundler audit failures on CI blocking the updates of other dependencies. I believe this is safe to do and that the changes between 2.0.0 and 2.0.1 releases were not critical to us.

2.0.1 has file permissions issues in the gem, which is the background to the CVE.