### PR TITLE
Pull out full `li` element into admin/status_edits/status_edit partial

### DIFF
--- a/app/views/admin/status_edits/_status_edit.html.haml
+++ b/app/views/admin/status_edits/_status_edit.html.haml
@@ -1,20 +1,30 @@
-.status
-  .status__content><
-    - if status_edit.spoiler_text.blank?
-      = prerender_custom_emojis(status_content_format(status_edit), status_edit.emojis)
-    - else
-      %details<
-        %summary><
-          %strong> Content warning: #{prerender_custom_emojis(h(status_edit.spoiler_text), status_edit.emojis)}
-        = prerender_custom_emojis(status_content_format(status_edit), status_edit.emojis)
-
-  - unless status_edit.ordered_media_attachments.empty?
-    = render partial: 'admin/reports/media_attachments', locals: { status: status_edit }
-
-  .detailed-status__meta
-    %time.formatted{ datetime: status_edit.created_at.iso8601, title: l(status_edit.created_at) }= l(status_edit.created_at)
-
-    - if status_edit.sensitive?
+%li
+  .history__entry
+    %h5
+      - if status_edit_iteration.first?
+        = t('admin.statuses.original_status')
+      - else
+        = t('admin.statuses.status_changed')
       ·
-      = fa_icon('eye-slash fw')
-      = t('stream_entries.sensitive_content')
+      %time.formatted{ datetime: status_edit.created_at.iso8601, title: l(status_edit.created_at) }= l(status_edit.created_at)
+
+    .status
+      .status__content><
+        - if status_edit.spoiler_text.blank?
+          = prerender_custom_emojis(status_content_format(status_edit), status_edit.emojis)
+        - else
+          %details<
+            %summary><
+              %strong> Content warning: #{prerender_custom_emojis(h(status_edit.spoiler_text), status_edit.emojis)}
+            = prerender_custom_emojis(status_content_format(status_edit), status_edit.emojis)
+
+      - unless status_edit.ordered_media_attachments.empty?
+        = render partial: 'admin/reports/media_attachments', locals: { status: status_edit }
+
+      .detailed-status__meta
+        %time.formatted{ datetime: status_edit.created_at.iso8601, title: l(status_edit.created_at) }= l(status_edit.created_at)
+
+        - if status_edit.sensitive?
+          ·
+          = fa_icon('eye-slash fw')
+          = t('stream_entries.sensitive_content')

--- a/app/views/admin/statuses/show.html.haml
+++ b/app/views/admin/statuses/show.html.haml
@@ -47,15 +47,4 @@
 %h3= t('admin.statuses.history')
 
 %ol.history
-  - batched_ordered_status_edits.with_index do |status_edit, i|
-    %li
-      .history__entry
-        %h5
-          - if i.zero?
-            = t('admin.statuses.original_status')
-          - else
-            = t('admin.statuses.status_changed')
-          ·
-          %time.formatted{ datetime: status_edit.created_at.iso8601, title: l(status_edit.created_at) }= l(status_edit.created_at)
-
-        = render status_edit
+  = render partial: 'admin/status_edits/status_edit', collection: batched_ordered_status_edits


### PR DESCRIPTION
Changes here:

- Previously the outer show view was looping through a list of status edits and creating `li` element for each one. The first `.history__entry` portion of the `li` was rendered in the show view, and then the rest was rendered in a partial. This PR moves that initial portion into the partial as well, and then does a `collection:` render from the show view.
- Use the partial iteration object, similar to approach on https://github.com/mastodon/mastodon/pull/29497, so that the previous `i.zero?` check is retained in the partial as well.

Because of indentation changes this diff looks more substantial than it really is.