### PR TITLE
Add `BrowserDetection` model concern

### DIFF
--- a/app/models/concerns/browser_detection.rb
+++ b/app/models/concerns/browser_detection.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module BrowserDetection
+  extend ActiveSupport::Concern
+
+  included do
+    normalizes :user_agent, with: ->(value) { value || '' }
+  end
+
+  def detection
+    @detection ||= Browser.new(user_agent)
+  end
+
+  def browser
+    detection.id
+  end
+
+  def platform
+    detection.platform.id
+  end
+end

--- a/app/models/concerns/browser_detection.rb
+++ b/app/models/concerns/browser_detection.rb
@@ -4,7 +4,7 @@ module BrowserDetection
   extend ActiveSupport::Concern
 
   included do
-    normalizes :user_agent, with: ->(value) { value || '' }
+    before_save :assign_user_agent
   end
 
   def detection
@@ -17,5 +17,11 @@ module BrowserDetection
 
   def platform
     detection.platform.id
+  end
+
+  private
+
+  def assign_user_agent
+    self.user_agent ||= ''
   end
 end

--- a/app/models/login_activity.rb
+++ b/app/models/login_activity.rb
@@ -16,21 +16,11 @@
 #
 
 class LoginActivity < ApplicationRecord
+  include BrowserDetection
+
   enum :authentication_method, { password: 'password', otp: 'otp', webauthn: 'webauthn', sign_in_token: 'sign_in_token', omniauth: 'omniauth' }
 
   belongs_to :user
 
   validates :authentication_method, inclusion: { in: authentication_methods.keys }
-
-  def detection
-    @detection ||= Browser.new(user_agent)
-  end
-
-  def browser
-    detection.id
-  end
-
-  def platform
-    detection.platform.id
-  end
 end

--- a/app/models/session_activation.rb
+++ b/app/models/session_activation.rb
@@ -16,6 +16,8 @@
 #
 
 class SessionActivation < ApplicationRecord
+  include BrowserDetection
+
   belongs_to :user, inverse_of: :session_activations
   belongs_to :access_token, class_name: 'Doorkeeper::AccessToken', dependent: :destroy, optional: true
   belongs_to :web_push_subscription, class_name: 'Web::PushSubscription', dependent: :destroy, optional: true
@@ -24,19 +26,6 @@ class SessionActivation < ApplicationRecord
            to: :access_token,
            allow_nil: true
 
-  def detection
-    @detection ||= Browser.new(user_agent)
-  end
-
-  def browser
-    detection.id
-  end
-
-  def platform
-    detection.platform.id
-  end
-
-  before_save   :assign_user_agent
   before_create :assign_access_token
 
   class << self
@@ -66,10 +55,6 @@ class SessionActivation < ApplicationRecord
   end
 
   private
-
-  def assign_user_agent
-    self.user_agent = '' if user_agent.nil?
-  end
 
   def assign_access_token
     self.access_token = Doorkeeper::AccessToken.create!(access_token_attributes)


### PR DESCRIPTION
Both `LoginActivity` and `SessionActivation` has this same pattern of using the browser methods to wrap some user_agent parsing. Extracted to a concern.
