### PR TITLE
Ensure unique values in fabricators

### DIFF
--- a/spec/fabrication/fabricators_spec.rb
+++ b/spec/fabrication/fabricators_spec.rb
@@ -6,9 +6,9 @@ Fabrication.manager.load_definitions if Fabrication.manager.empty?
 
 Fabrication.manager.schematics.map(&:first).each do |factory_name|
   describe "The #{factory_name} factory" do
-    it 'is valid' do
-      factory = Fabricate(factory_name)
-      expect(factory).to be_valid
+    it 'is able to create valid records' do
+      records = Fabricate.times(2, factory_name) # Create multiple of each to uncover uniqueness issues
+      expect(records).to all(be_valid)
     end
   end
 end

--- a/spec/fabricators/identity_fabricator.rb
+++ b/spec/fabricators/identity_fabricator.rb
@@ -3,5 +3,5 @@
 Fabricator(:identity) do
   user { Fabricate.build(:user) }
   provider 'MyString'
-  uid      'MyString'
+  uid { sequence(:uid) { |i| "uid_string_#{i}" } }
 end

--- a/spec/fabricators/relay_fabricator.rb
+++ b/spec/fabricators/relay_fabricator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 Fabricator(:relay) do
-  inbox_url 'https://example.com/inbox'
+  inbox_url { sequence(:inbox_url) { |i| "https://example.com/inboxes/#{i}" } }
   state :idle
 end

--- a/spec/fabricators/site_upload_fabricator.rb
+++ b/spec/fabricators/site_upload_fabricator.rb
@@ -2,5 +2,5 @@
 
 Fabricator(:site_upload) do
   file { Rails.root.join('spec', 'fabricators', 'assets', 'utah_teapot.png').open }
-  var 'thumbnail'
+  var { sequence(:var) { |i| "thumbnail_#{i}" } }
 end


### PR DESCRIPTION
Follow-up on https://github.com/mastodon/mastodon/pull/29438/files - two changes:

- Update the fabricator spec to create 2x of each factory, so that we catch any uniqueness issues. I'm sure there are edge cases beyond this, but I think this is a decent trade-off for catching issues -vs- the increased factory load of the spec.
- Update the three factories which had issues similar to linked PR so that they can create more than just one valid record.