### PR TITLE
Improve data setup in admin mailer preview

### DIFF
--- a/spec/mailers/previews/admin_mailer_preview.rb
+++ b/spec/mailers/previews/admin_mailer_preview.rb
@@ -5,31 +5,73 @@
 class AdminMailerPreview < ActionMailer::Preview
   # Preview this email at http://localhost:3000/rails/mailers/admin_mailer/new_report
   def new_report
-    AdminMailer.with(recipient: Account.first).new_report(Report.first)
+    admin_mail.new_report(latest_report)
   end
 
   # Preview this email at http://localhost:3000/rails/mailers/admin_mailer/new_appeal
   def new_appeal
-    AdminMailer.with(recipient: Account.first).new_appeal(Appeal.first)
+    admin_mail.new_appeal(latest_appeal)
   end
 
   # Preview this email at http://localhost:3000/rails/mailers/admin_mailer/new_pending_account
   def new_pending_account
-    AdminMailer.with(recipient: Account.first).new_pending_account(User.pending.first)
+    admin_mail.new_pending_account(latest_pending_user)
   end
 
   # Preview this email at http://localhost:3000/rails/mailers/admin_mailer/new_trends
   def new_trends
-    AdminMailer.with(recipient: Account.first).new_trends(PreviewCard.joins(:trend).limit(3), Tag.limit(3), Status.joins(:trend).where(reblog_of_id: nil).limit(3))
+    admin_mail.new_trends(latest_trending_links, latest_trending_tags, latest_trending_statuses)
   end
 
   # Preview this email at http://localhost:3000/rails/mailers/admin_mailer/new_software_updates
-  def new_software_updates
-    AdminMailer.with(recipient: Account.first).new_software_updates
-  end
+  delegate :new_software_updates, to: :admin_mail
 
   # Preview this email at http://localhost:3000/rails/mailers/admin_mailer/new_critical_software_updates
-  def new_critical_software_updates
-    AdminMailer.with(recipient: Account.first).new_critical_software_updates
+  delegate :new_critical_software_updates, to: :admin_mail
+
+  private
+
+  def latest_trending_links
+    PreviewCard.joins(:trend).limit(3)
+  end
+
+  def latest_trending_tags
+    Tag.limit(3)
+  end
+
+  def latest_trending_statuses
+    Status.joins(:trend).where(reblog_of_id: nil).limit(3)
+  end
+
+  def latest_pending_user
+    User.pending.first || Fabricate(:user, approved: false)
+  end
+
+  def latest_report
+    Report.order(created_at: :desc).first || Fabricate(:report)
+  end
+
+  def latest_appeal
+    Appeal.where.associated(:account).order(created_at: :desc).first || Fabricate(:appeal)
+  end
+
+  def admin_mail
+    AdminMailer.with(recipient: admin_account)
+  end
+
+  def admin_account
+    load_admin_account || fabricate_admin_account
+  end
+
+  def load_admin_account
+    Account.joins(user: :role).where(user: { role: admin_user_role }).first
+  end
+
+  def fabricate_admin_account
+    Fabricate(:account, user: Fabricate(:user, role: admin_user_role))
+  end
+
+  def admin_user_role
+    UserRole.find_by(name: 'Admin')
   end
 end


### PR DESCRIPTION
With this change - https://github.com/mastodon/mastodon/pull/28969/files - we now have access to factories in the dev environment. This PR is two groups of changes, both in the admin mailer preview:

- For every preview, there was a common setup like `AdminMailer.with(recipient: Account.first)` -- move that common setup down to a private method. Also change it so that the "to" in the mailer always is an admin account (I don't think this matters for the previews, but its consistent with what always happens from within the app)
- For the data setup for each one, we previously had scenarios where on a fresh db setup there would not be every record -- ie appeals, reports, etc - so you'd get an app error on the preview and have to generate in the console and then refresh. This changes it to first look for an appropriate existing record (preserving previous ability to create specific things to preview if desired), but if none exist create a factory right in the mailer and show that. The admin user role is created in seed data, so that's left as just a find.

For the "Trends" preview here - there was some complexity here in the interaction between the fabrication definitions, attached files, making things trending, etc - so I did not update that one specific mailer preview.

Assuming this is fine, future work here would be to update the other mailer previews along these lines, and finish out the trends one on this one.