### PR TITLE
Extract `by_domain_length` scope in `DomainNormalizable` concern

### DIFF
--- a/app/models/concerns/domain_normalizable.rb
+++ b/app/models/concerns/domain_normalizable.rb
@@ -5,6 +5,18 @@ module DomainNormalizable
 
   included do
     before_validation :normalize_domain
+
+    scope :by_domain_length, -> { order(domain_char_length.desc) }
+  end
+
+  class_methods do
+    def domain_char_length
+      Arel.sql(
+        <<~SQL.squish
+          CHAR_LENGTH(domain)
+        SQL
+      )
+    end
   end
 
   private

--- a/app/models/domain_block.rb
+++ b/app/models/domain_block.rb
@@ -70,7 +70,7 @@ class DomainBlock < ApplicationRecord
       segments = uri.normalized_host.split('.')
       variants = segments.map.with_index { |_, i| segments[i..].join('.') }
 
-      where(domain: variants).order(Arel.sql('char_length(domain) desc')).first
+      where(domain: variants).by_domain_length.first
     rescue Addressable::URI::InvalidURIError, IDN::Idna::IdnaError
       nil
     end

--- a/app/models/email_domain_block.rb
+++ b/app/models/email_domain_block.rb
@@ -56,7 +56,7 @@ class EmailDomainBlock < ApplicationRecord
     end
 
     def blocking?(allow_with_approval: false)
-      blocks = EmailDomainBlock.where(domain: domains_with_variants, allow_with_approval: allow_with_approval).order(Arel.sql('char_length(domain) desc'))
+      blocks = EmailDomainBlock.where(domain: domains_with_variants, allow_with_approval: allow_with_approval).by_domain_length
       blocks.each { |block| block.history.add(@attempt_ip) } if @attempt_ip.present?
       blocks.any?
     end

--- a/app/models/preview_card_provider.rb
+++ b/app/models/preview_card_provider.rb
@@ -54,6 +54,6 @@ class PreviewCardProvider < ApplicationRecord
 
   def self.matching_domain(domain)
     segments = domain.split('.')
-    where(domain: segments.map.with_index { |_, i| segments[i..].join('.') }).order(Arel.sql('char_length(domain) desc')).first
+    where(domain: segments.map.with_index { |_, i| segments[i..].join('.') }).by_domain_length.first
   end
 end


### PR DESCRIPTION
These models all already include this concern, and each use this exact same ordering scope.