### PR TITLE
Update `json-jwt` gem to fix CVE-2023-51774

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -357,7 +357,7 @@ GEM
     jmespath (1.6.2)
     json (2.7.1)
     json-canonicalization (1.0.0)
-    json-jwt (1.15.3)
+    json-jwt (1.15.3.1)
       activesupport (>= 4.2)
       aes_key_wrap
       bindata


### PR DESCRIPTION
See nov/json-jwt#121 and https://github.com/nov/json-jwt/commits/v1.15.3/ for the code

https://github.com/rubysec/ruby-advisory-db/pull/762 for the advisory DB udpate