### PR TITLE
Add coverage for admin/metrics base classes, simplify subclass generation

### DIFF
--- a/app/lib/admin/metrics/dimension.rb
+++ b/app/lib/admin/metrics/dimension.rb
@@ -2,15 +2,15 @@
 
 class Admin::Metrics::Dimension
   DIMENSIONS = {
-    languages: Admin::Metrics::Dimension::LanguagesDimension,
-    sources: Admin::Metrics::Dimension::SourcesDimension,
-    servers: Admin::Metrics::Dimension::ServersDimension,
-    space_usage: Admin::Metrics::Dimension::SpaceUsageDimension,
-    software_versions: Admin::Metrics::Dimension::SoftwareVersionsDimension,
-    tag_servers: Admin::Metrics::Dimension::TagServersDimension,
-    tag_languages: Admin::Metrics::Dimension::TagLanguagesDimension,
-    instance_accounts: Admin::Metrics::Dimension::InstanceAccountsDimension,
-    instance_languages: Admin::Metrics::Dimension::InstanceLanguagesDimension,
+    languages: LanguagesDimension,
+    sources: SourcesDimension,
+    servers: ServersDimension,
+    space_usage: SpaceUsageDimension,
+    software_versions: SoftwareVersionsDimension,
+    tag_servers: TagServersDimension,
+    tag_languages: TagLanguagesDimension,
+    instance_accounts: InstanceAccountsDimension,
+    instance_languages: InstanceLanguagesDimension,
   }.freeze
 
   def self.retrieve(dimension_keys, start_at, end_at, limit, params)

--- a/app/lib/admin/metrics/measure.rb
+++ b/app/lib/admin/metrics/measure.rb
@@ -2,20 +2,20 @@
 
 class Admin::Metrics::Measure
   MEASURES = {
-    active_users: Admin::Metrics::Measure::ActiveUsersMeasure,
-    new_users: Admin::Metrics::Measure::NewUsersMeasure,
-    interactions: Admin::Metrics::Measure::InteractionsMeasure,
-    opened_reports: Admin::Metrics::Measure::OpenedReportsMeasure,
-    resolved_reports: Admin::Metrics::Measure::ResolvedReportsMeasure,
-    tag_accounts: Admin::Metrics::Measure::TagAccountsMeasure,
-    tag_uses: Admin::Metrics::Measure::TagUsesMeasure,
-    tag_servers: Admin::Metrics::Measure::TagServersMeasure,
-    instance_accounts: Admin::Metrics::Measure::InstanceAccountsMeasure,
-    instance_media_attachments: Admin::Metrics::Measure::InstanceMediaAttachmentsMeasure,
-    instance_reports: Admin::Metrics::Measure::InstanceReportsMeasure,
-    instance_statuses: Admin::Metrics::Measure::InstanceStatusesMeasure,
-    instance_follows: Admin::Metrics::Measure::InstanceFollowsMeasure,
-    instance_followers: Admin::Metrics::Measure::InstanceFollowersMeasure,
+    active_users: ActiveUsersMeasure,
+    new_users: NewUsersMeasure,
+    interactions: InteractionsMeasure,
+    opened_reports: OpenedReportsMeasure,
+    resolved_reports: ResolvedReportsMeasure,
+    tag_accounts: TagAccountsMeasure,
+    tag_uses: TagUsesMeasure,
+    tag_servers: TagServersMeasure,
+    instance_accounts: InstanceAccountsMeasure,
+    instance_media_attachments: InstanceMediaAttachmentsMeasure,
+    instance_reports: InstanceReportsMeasure,
+    instance_statuses: InstanceStatusesMeasure,
+    instance_follows: InstanceFollowsMeasure,
+    instance_followers: InstanceFollowersMeasure,
   }.freeze
 
   def self.retrieve(measure_keys, start_at, end_at, params)

--- a/spec/lib/admin/metrics/dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Admin::Metrics::Dimension do
+  describe '.retrieve' do
+    subject { described_class.retrieve(reports, start_at, end_at, 5, params) }
+
+    let(:start_at) { 2.days.ago }
+    let(:end_at) { Time.now.utc }
+    let(:params) { ActionController::Parameters.new({ instance_accounts: [123], instance_languages: ['en'] }) }
+    let(:reports) { [:instance_accounts, :instance_languages] }
+
+    it 'returns instances of provided classes' do
+      expect(subject)
+        .to contain_exactly(
+          be_a(Admin::Metrics::Dimension::InstanceAccountsDimension),
+          be_a(Admin::Metrics::Dimension::InstanceLanguagesDimension)
+        )
+    end
+  end
+end

--- a/spec/lib/admin/metrics/measure_spec.rb
+++ b/spec/lib/admin/metrics/measure_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Admin::Metrics::Measure do
+  describe '.retrieve' do
+    subject { described_class.retrieve(reports, start_at, end_at, params) }
+
+    let(:start_at) { 2.days.ago }
+    let(:end_at) { Time.now.utc }
+    let(:params) { ActionController::Parameters.new({ instance_accounts: [123], instance_followers: [123] }) }
+    let(:reports) { [:instance_accounts, :instance_followers] }
+
+    it 'returns instances of provided classes' do
+      expect(subject)
+        .to contain_exactly(
+          be_a(Admin::Metrics::Measure::InstanceAccountsMeasure),
+          be_a(Admin::Metrics::Measure::InstanceFollowersMeasure)
+        )
+    end
+  end
+end


### PR DESCRIPTION
All the classes underneath these have at least some coverage (with more added in https://github.com/mastodon/mastodon/pull/28736) but these top-level `Dimension` and `Measure` classes didn't have their own specs. This change:

- Adds basic coverage to their `retrieve` methods to just show that some given arguments generate the expected reporting classes
- Small clean-up in the reporting classes to remove what I think are unnecessary namespace prefixes

Possible future improvement here:

- Further simplification of the class locator, given that every hash key could be camelized/constantized into the class ... we may be able to get away with an array of valid keys and do that instead
- The class names ending in `*Dimension` or `*Measure` despite already being namespaced could probably be dropped.