### PR TITLE
Normalize idna domain before account unblock domain

### DIFF
--- a/app/models/concerns/account/interactions.rb
+++ b/app/models/concerns/account/interactions.rb
@@ -178,7 +178,7 @@ module Account::Interactions
   end
 
   def unblock_domain!(other_domain)
-    block = domain_blocks.find_by(domain: other_domain)
+    block = domain_blocks.find_by(domain: normalized_domain(other_domain))
     block&.destroy
   end
 
@@ -299,5 +299,9 @@ module Account::Interactions
       muting: Account.muting_map(account_ids, id),
       domain_blocking_by_domain: Account.domain_blocking_map_by_domain(domains, id),
     })
+  end
+
+  def normalized_domain(domain)
+    TagManager.instance.normalize_domain(domain)
   end
 end

--- a/spec/models/concerns/account/interactions_spec.rb
+++ b/spec/models/concerns/account/interactions_spec.rb
@@ -251,19 +251,19 @@ describe Account::Interactions do
   end
 
   describe '#block_idna_domain!' do
-    subject { [
-      account.block_domain!(idna_domain),
-      account.block_domain!(punycode_domain),
-    ] }
+    subject do
+      [
+        account.block_domain!(idna_domain),
+        account.block_domain!(punycode_domain),
+      ]
+    end
 
     let(:idna_domain) { '대한민국.한국' }
     let(:punycode_domain) { 'xn--3e0bs9hfvinn1a.xn--3e0b707e' }
 
     it 'creates single AccountDomainBlock' do
       expect do
-        subject.each do |s|
-          expect(s).to be_a AccountDomainBlock
-        end
+        expect(subject).to all(be_a AccountDomainBlock)
       end.to change { account.domain_blocks.count }.by 1
     end
   end

--- a/spec/models/concerns/account/interactions_spec.rb
+++ b/spec/models/concerns/account/interactions_spec.rb
@@ -250,6 +250,24 @@ describe Account::Interactions do
     end
   end
 
+  describe '#block_idna_domain!' do
+    subject { [
+      account.block_domain!(idna_domain),
+      account.block_domain!(punycode_domain),
+    ] }
+
+    let(:idna_domain) { '대한민국.한국' }
+    let(:punycode_domain) { 'xn--3e0bs9hfvinn1a.xn--3e0b707e' }
+
+    it 'creates single AccountDomainBlock' do
+      expect do
+        subject.each do |s|
+          expect(s).to be_a AccountDomainBlock
+        end
+      end.to change { account.domain_blocks.count }.by 1
+    end
+  end
+
   describe '#unfollow!' do
     subject { account.unfollow!(target_account) }
 
@@ -339,6 +357,28 @@ describe Account::Interactions do
     end
 
     context 'when unblocking the domain' do
+      it 'returns nil' do
+        expect(subject).to be_nil
+      end
+    end
+  end
+
+  describe '#unblock_idna_domain!' do
+    subject { account.unblock_domain!(punycode_domain) }
+
+    let(:idna_domain) { '대한민국.한국' }
+    let(:punycode_domain) { 'xn--3e0bs9hfvinn1a.xn--3e0b707e' }
+
+    context 'when blocking the domain' do
+      it 'returns destroyed AccountDomainBlock' do
+        account_domain_block = Fabricate(:account_domain_block, domain: idna_domain)
+        account.domain_blocks << account_domain_block
+        expect(subject).to be_a AccountDomainBlock
+        expect(subject).to be_destroyed
+      end
+    end
+
+    context 'when unblocking idna domain' do
       it 'returns nil' do
         expect(subject).to be_nil
       end


### PR DESCRIPTION
Domain name should be normalized before find AccountDomainBlock to unblock to.

Additionally, If unblock domain from user profile's additional menu, It sends a domain which is not normalized. (Unlike on /domain_blocks page)