### PR TITLE
Use unchanging github links in docs/comments

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -123,7 +123,7 @@ module.exports = defineConfig({
     'react/react-in-jsx-scope': 'off', // not needed with new JSX transform
     'react/self-closing-comp': 'error',
 
-    // recommended values found in https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/src/index.js
+    // recommended values found in https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.8.0/src/index.js#L46
     'jsx-a11y/accessible-emoji': 'warn',
     'jsx-a11y/click-events-have-key-events': 'off',
     'jsx-a11y/label-has-associated-control': 'off',
@@ -176,7 +176,7 @@ module.exports = defineConfig({
       },
     ],
 
-    // See https://github.com/import-js/eslint-plugin-import/blob/main/config/recommended.js
+    // See https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/config/recommended.js
     'import/extensions': [
       'error',
       'always',

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ ARG MASTODON_VERSION_METADATA=""
 # See: https://docs.joinmastodon.org/admin/config/#rails_serve_static_files
 ARG RAILS_SERVE_STATIC_FILES="true"
 # Allow to use YJIT compiler
-# See: https://github.com/ruby/ruby/blob/master/doc/yjit/yjit.md
+# See: https://github.com/ruby/ruby/blob/v3_2_3/doc/yjit/yjit.md
 ARG RUBY_YJIT_ENABLE="1"
 # Timezone used by the Docker container and runtime, change with [--build-arg TZ=Europe/Berlin]
 ARG TZ="Etc/UTC"

--- a/config/initializers/open_redirects.rb
+++ b/config/initializers/open_redirects.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: true
 
-# TODO
-# Starting with Rails 7.0, the framework default here is to set this true.
-# However, we have a location in devise that redirects where we don't have an
-# easy ability to override the method or set a config option, and where the
-# redirect does not supply this option itself.
-# https://github.com/heartcombo/devise/blob/v4.9.2/app/controllers/devise/confirmations_controller.rb#L28
-# Once a solution is found, this line can be removed.
+# TODO: Starting with Rails 7.0, the framework default is true for this setting.
+# This location in devise redirects and we can't hook in or override:
+# https://github.com/heartcombo/devise/blob/v4.9.3/app/controllers/devise/confirmations_controller.rb#L28
+# When solution is found, this setting can go back to default.
 Rails.application.config.action_controller.raise_on_open_redirects = false

--- a/lib/mastodon/migration_helpers.rb
+++ b/lib/mastodon/migration_helpers.rb
@@ -743,7 +743,8 @@ into similar problems in the future (e.g. when new tables are created).
 
     private
 
-    # https://github.com/rails/rails/blob/v5.2.0/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb#L678-L684
+    # Private method copied from:
+    # https://github.com/rails/rails/blob/v7.1.3.2/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb#L974-L980
     def extract_foreign_key_action(specifier)
       case specifier
       when 'c'; :cascade

--- a/spec/config/initializers/rack/attack_spec.rb
+++ b/spec/config/initializers/rack/attack_spec.rb
@@ -13,7 +13,7 @@ describe Rack::Attack, type: :request do
       # to avoid crossing period boundaries.
 
       # The code Rack::Attack uses to set periods is the following:
-      # https://github.com/rack/rack-attack/blob/v6.6.1/lib/rack/attack/cache.rb#L64-L66
+      # https://github.com/rack/rack-attack/blob/v6.7.0/lib/rack/attack/cache.rb#L70-L72
       # So we want to minimize `Time.now.to_i % period`
 
       travel_to Time.zone.at(counter_prefix * period.seconds)

--- a/spec/controllers/.rubocop.yml
+++ b/spec/controllers/.rubocop.yml
@@ -1,6 +1,6 @@
 inherit_from: ../../.rubocop.yml
 
-# Anonymous controllers in specs cannot access described_class
-# https://github.com/rubocop/rubocop-rspec/blob/master/lib/rubocop/cop/rspec/described_class.rb#L36-L39
+# Anonymous controllers in specs cannot access `described_class`, explanation:
+# https://github.com/rubocop/rubocop-rspec/blob/v2.26.1/lib/rubocop/cop/rspec/described_class.rb#L36-L56
 RSpec/DescribedClass:
   SkipBlocks: true


### PR DESCRIPTION
I noticed the link in one of the rubocop config files was no longer pointing to the relevant spot, and did a once-over on other things to update links to main/master branches to instead be to a fixed tag branch, preferably of the version we are using. These should be less likely to break/shift.