### PR TITLE
Fix incorrect frequency value in `FriendsOfFriendsSource` data

### DIFF
--- a/app/models/account_suggestions/friends_of_friends_source.rb
+++ b/app/models/account_suggestions/friends_of_friends_source.rb
@@ -3,7 +3,7 @@
 class AccountSuggestions::FriendsOfFriendsSource < AccountSuggestions::Source
   def get(account, limit: DEFAULT_LIMIT)
     source_query(account, limit)
-      .map { |id, _frequency| [id, key] }
+      .map { |id, _frequency, _followers_count| [id, key] }
   end
 
   def source_query(account, limit)
@@ -14,7 +14,7 @@ class AccountSuggestions::FriendsOfFriendsSource < AccountSuggestions::Source
       .group('accounts.id, account_stats.id')
       .reorder('frequency DESC, followers_count DESC')
       .limit(limit)
-      .pluck(Arel.sql('accounts.id, COUNT(*) AS frequency'))
+      .pluck(Arel.sql('accounts.id, COUNT(*) AS frequency, followers_count'))
   end
 
   private

--- a/app/models/account_suggestions/friends_of_friends_source.rb
+++ b/app/models/account_suggestions/friends_of_friends_source.rb
@@ -2,6 +2,11 @@
 
 class AccountSuggestions::FriendsOfFriendsSource < AccountSuggestions::Source
   def get(account, limit: DEFAULT_LIMIT)
+    source_query(account, limit)
+      .map { |id, _frequency| [id, key] }
+  end
+
+  def source_query(account, limit)
     first_degree = account.following.where.not(hide_collections: true).select(:id).reorder(nil)
     base_account_scope(account)
       .joins(:account_stat)
@@ -10,7 +15,6 @@ class AccountSuggestions::FriendsOfFriendsSource < AccountSuggestions::Source
       .reorder('frequency DESC, followers_count DESC')
       .limit(limit)
       .pluck(Arel.sql('accounts.id, COUNT(*) AS frequency'))
-      .map { |id, _frequency| [id, key] }
   end
 
   private

--- a/app/models/account_suggestions/friends_of_friends_source.rb
+++ b/app/models/account_suggestions/friends_of_friends_source.rb
@@ -12,7 +12,7 @@ class AccountSuggestions::FriendsOfFriendsSource < AccountSuggestions::Source
       .joins(:account_stat)
       .joins(:passive_relationships).where(passive_relationships: { account_id: first_degree })
       .group('accounts.id, account_stats.id')
-      .reorder('frequency DESC, followers_count DESC')
+      .reorder(frequency: :desc, followers_count: :desc)
       .limit(limit)
       .pluck(Arel.sql('accounts.id, COUNT(*) AS frequency, followers_count'))
   end

--- a/app/models/account_suggestions/friends_of_friends_source.rb
+++ b/app/models/account_suggestions/friends_of_friends_source.rb
@@ -2,15 +2,15 @@
 
 class AccountSuggestions::FriendsOfFriendsSource < AccountSuggestions::Source
   def get(account, limit: DEFAULT_LIMIT)
-    source_query(account, limit)
+    source_query(account, limit: limit)
       .map { |id, _frequency, _followers_count| [id, key] }
   end
 
-  def source_query(account, limit)
+  def source_query(account, limit: DEFAULT_LIMIT)
     first_degree = account.following.where.not(hide_collections: true).select(:id).reorder(nil)
     base_account_scope(account)
       .joins(:account_stat)
-      .where(id: Follow.where(account_id: first_degree).select(:target_account_id))
+      .joins(:passive_relationships).where(passive_relationships: { account_id: first_degree })
       .group('accounts.id, account_stats.id')
       .reorder('frequency DESC, followers_count DESC')
       .limit(limit)

--- a/spec/models/account_suggestions/friends_of_friends_source_spec.rb
+++ b/spec/models/account_suggestions/friends_of_friends_source_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe AccountSuggestions::FriendsOfFriendsSource do
     let!(:eve) { Fabricate(:account, discoverable: true, hide_collections: false) }
     let!(:mallory) { Fabricate(:account, discoverable: false, hide_collections: false) }
     let!(:eugen) { Fabricate(:account, discoverable: true, hide_collections: false) }
+    let!(:neil) { Fabricate(:account, discoverable: true, hide_collections: false) }
     let!(:john) { Fabricate(:account, discoverable: true, hide_collections: false) }
     let!(:jerk) { Fabricate(:account, discoverable: true, hide_collections: false) }
-    let!(:neil) { Fabricate(:account, discoverable: true, hide_collections: false) }
     let!(:larry) { Fabricate(:account, discoverable: true, hide_collections: false) }
 
     context 'with follows and blocks' do

--- a/spec/models/account_suggestions/friends_of_friends_source_spec.rb
+++ b/spec/models/account_suggestions/friends_of_friends_source_spec.rb
@@ -69,26 +69,31 @@ RSpec.describe AccountSuggestions::FriendsOfFriendsSource do
         john.follow!(neil)
       end
 
-      it 'returns eligible accounts in the expected order', :aggregate_failures do
-        expect(subject.get(bob))
-          .to eq expected_results
+      it 'returns eligible accounts in the expected order' do
+        expect(subject.get(bob)).to eq expected_results
+      end
 
-        expect(subject.source_query(bob, 5).to_a)
+      it 'contains correct underlying source data' do
+        expect(source_query_values)
           .to contain_exactly(
-            [eugen.id, 2, 3],
-            [john.id, 2, 2],
-            [neil.id, 1, 2],
-            [jerk.id, 1, 1]
+            [eugen.id, 2, 3], # Followed by 2 friends of bob (eve, mallory), 3 followers total (breaks tie)
+            [john.id, 2, 2],  # Followed by 2 friends of bob (eve, mallory), 2 followers total
+            [neil.id, 1, 2],  # Followed by 1 friends of bob (mallory), 2 followers total (breaks tie)
+            [jerk.id, 1, 1]   # Followed by 1 friends of bob (eve), 1 followers total
           )
       end
 
       def expected_results
         [
-          [eugen.id, :friends_of_friends], # followed by 2 friends, 3 followers total
-          [john.id, :friends_of_friends], # followed by 2 friends, 2 followers total
-          [neil.id, :friends_of_friends], # followed by 1 friend, 2 followers total
-          [jerk.id, :friends_of_friends], # followed by 1 friend, 1 follower total
+          [eugen.id, :friends_of_friends],
+          [john.id, :friends_of_friends],
+          [neil.id, :friends_of_friends],
+          [jerk.id, :friends_of_friends],
         ]
+      end
+
+      def source_query_values
+        subject.source_query(bob).to_a
       end
     end
   end

--- a/spec/models/account_suggestions/friends_of_friends_source_spec.rb
+++ b/spec/models/account_suggestions/friends_of_friends_source_spec.rb
@@ -69,9 +69,17 @@ RSpec.describe AccountSuggestions::FriendsOfFriendsSource do
         john.follow!(neil)
       end
 
-      it 'returns eligible accounts in the expected order' do
+      it 'returns eligible accounts in the expected order', :aggregate_failures do
         expect(subject.get(bob))
           .to eq expected_results
+
+        expect(subject.source_query(bob, 5).to_a)
+          .to contain_exactly(
+            [eugen.id, 2, 3],
+            [john.id, 2, 2],
+            [neil.id, 1, 2],
+            [jerk.id, 1, 1]
+          )
       end
 
       def expected_results

--- a/spec/models/account_suggestions/friends_of_friends_source_spec.rb
+++ b/spec/models/account_suggestions/friends_of_friends_source_spec.rb
@@ -70,7 +70,12 @@ RSpec.describe AccountSuggestions::FriendsOfFriendsSource do
       end
 
       it 'returns eligible accounts in the expected order' do
-        expect(subject.get(bob)).to eq [
+        expect(subject.get(bob))
+          .to eq expected_results
+      end
+
+      def expected_results
+        [
           [eugen.id, :friends_of_friends], # followed by 2 friends, 3 followers total
           [john.id, :friends_of_friends], # followed by 2 friends, 2 followers total
           [neil.id, :friends_of_friends], # followed by 1 friend, 2 followers total


### PR DESCRIPTION
Noted here - https://github.com/mastodon/mastodon/pull/29306#discussion_r1519951830 - possible issue with this query leading to many intermittent failures on CI recently. Changes here:

- Change the spec to create accounts in different order - that was enough to trigger consistent failure
- Separate the "running the query" and "mapping the results" methods in the class
- With a separate query method, add specs with more detail around expect return values, confirmed that we were not getting proper count value
- Update class with a join
- Added even more clarity in spec comments about the values
- Tiny style thing on the order to use symbols

Desired feedback here:

- Am I correct in thinking this is an actual issue, or is something else going on?
- If that's correct, is this the best change to the query (adding the join) or is there another path here
- Having these two public methods feels kind of awkward, but was the easiest way I thought of to get access from the spec to the actual results (without needing to spec private methods). Maybe this is fine, and in theory we could do this to the couple other "source" classes as well to match.

