### PR TITLE
Fix toggle button color for light (and dark/default) theme

### DIFF
--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -351,11 +351,11 @@ html {
 }
 
 .react-toggle-track {
-  background: $ui-secondary-color;
+  background: $ui-primary-color;
 }
 
 .react-toggle:hover:not(.react-toggle--disabled) .react-toggle-track {
-  background: darken($ui-secondary-color, 10%);
+  background: lighten($ui-primary-color, 10%);
 }
 
 .react-toggle.react-toggle--checked:hover:not(.react-toggle--disabled)

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -3361,7 +3361,7 @@ $ui-header-height: 55px;
   height: 20px;
   padding: 0;
   border-radius: 10px;
-  background-color: #626982;
+  background-color: $ui-primary-color;
 }
 
 .react-toggle--focus {
@@ -3384,7 +3384,7 @@ $ui-header-height: 55px;
   width: 16px;
   height: 16px;
   border-radius: 50%;
-  background-color: $primary-text-color;
+  background-color: $ui-button-color;
   box-sizing: border-box;
   transition: all 0.25s ease;
   transition-property: border-color, left;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -3404,7 +3404,6 @@ $ui-header-height: 55px;
   background: lighten($ui-highlight-color, 5%);
 }
 
-
 .switch-to-advanced {
   color: $light-text-color;
   background-color: $ui-base-color;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -3395,6 +3395,16 @@ $ui-header-height: 55px;
   border-color: $ui-highlight-color;
 }
 
+.react-toggle:hover:not(.react-toggle--disabled) .react-toggle-track {
+  background: darken($ui-primary-color, 5%);
+}
+
+.react-toggle.react-toggle--checked:hover:not(.react-toggle--disabled)
+  .react-toggle-track {
+  background: lighten($ui-highlight-color, 5%);
+}
+
+
 .switch-to-advanced {
   color: $light-text-color;
   background-color: $ui-base-color;


### PR DESCRIPTION
The toggle buttons looked wrong on the Mastodon light theme as the components.scss used a hex code and a variable not defined in mastodon-light's "variables.scss". TL;DR: the dark theme colors were still used for toggle buttons when the light theme was applied.

I changed the colors to existing UI color variables and added some hover-effect for checked and unchecked toggle buttons. 

The following images compare the changes in the three Mastodon themes:

**Light**
![Mastodon-Light-Before](https://github.com/mastodon/mastodon/assets/52011431/965e29cb-1ecd-4ccb-9458-b9845eb03928)
_Before_

![Mastodon-Light-After](https://github.com/mastodon/mastodon/assets/52011431/cba21ae5-e264-4030-94ba-605ef328c808)
_After_


**Dark**
![Mastodon-Dark-Before](https://github.com/mastodon/mastodon/assets/52011431/40f8b8e3-b848-453c-b10c-d1a096f818b7)
_Before_

![Mastodon-Dark-After](https://github.com/mastodon/mastodon/assets/52011431/2037040a-c709-4d47-8361-8ff6caadaa28)
_After_


**High Contrast**
![Mastodon-High-Contrast-Before](https://github.com/mastodon/mastodon/assets/52011431/fe806702-6d8b-47ca-a507-b73de98f6275)
_Before_

![Mastodon-High-Contrast-After](https://github.com/mastodon/mastodon/assets/52011431/0b806124-7c00-424a-a41e-022aba0a503f)
_After_



