### PR TITLE
Add `Account.without_internal` scope

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -129,7 +129,7 @@ class ApplicationController < ActionController::Base
   end
 
   def single_user_mode?
-    @single_user_mode ||= Rails.configuration.x.single_user_mode && Account.non_internal.exists?
+    @single_user_mode ||= Rails.configuration.x.single_user_mode && Account.without_internal.exists?
   end
 
   def use_seamless_external_login?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -129,7 +129,7 @@ class ApplicationController < ActionController::Base
   end
 
   def single_user_mode?
-    @single_user_mode ||= Rails.configuration.x.single_user_mode && Account.where('id > 0').exists?
+    @single_user_mode ||= Rails.configuration.x.single_user_mode && Account.non_internal.exists?
   end
 
   def use_seamless_external_login?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -213,7 +213,7 @@ module ApplicationHelper
       state_params[:moved_to_account] = current_account.moved_to_account
     end
 
-    state_params[:owner] = Account.local.without_suspended.where('id > 0').first if single_user_mode?
+    state_params[:owner] = Account.local.without_suspended.non_internal.first if single_user_mode?
 
     json = ActiveModelSerializers::SerializableResource.new(InitialStatePresenter.new(state_params), serializer: InitialStateSerializer).to_json
     # rubocop:disable Rails/OutputSafety

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -213,7 +213,7 @@ module ApplicationHelper
       state_params[:moved_to_account] = current_account.moved_to_account
     end
 
-    state_params[:owner] = Account.local.without_suspended.non_internal.first if single_user_mode?
+    state_params[:owner] = Account.local.without_suspended.without_internal.first if single_user_mode?
 
     json = ActiveModelSerializers::SerializableResource.new(InitialStatePresenter.new(state_params), serializer: InitialStateSerializer).to_json
     # rubocop:disable Rails/OutputSafety

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -111,6 +111,7 @@ class Account < ApplicationRecord
 
   normalizes :username, with: ->(username) { username.squish }
 
+  scope :non_internal, -> { where(arel_table[:id].gt(0)) }
   scope :remote, -> { where.not(domain: nil) }
   scope :local, -> { where(domain: nil) }
   scope :partitioned, -> { order(Arel.sql('row_number() over (partition by domain)')) }

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -111,7 +111,7 @@ class Account < ApplicationRecord
 
   normalizes :username, with: ->(username) { username.squish }
 
-  scope :non_internal, -> { where(id: 1...) }
+  scope :without_internal, -> { where(id: 1...) }
   scope :remote, -> { where.not(domain: nil) }
   scope :local, -> { where(domain: nil) }
   scope :partitioned, -> { order(Arel.sql('row_number() over (partition by domain)')) }

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -111,7 +111,7 @@ class Account < ApplicationRecord
 
   normalizes :username, with: ->(username) { username.squish }
 
-  scope :non_internal, -> { where(arel_table[:id].gt(0)) }
+  scope :non_internal, -> { where(id: 1...) }
   scope :remote, -> { where.not(domain: nil) }
   scope :local, -> { where(domain: nil) }
   scope :partitioned, -> { order(Arel.sql('row_number() over (partition by domain)')) }

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -888,7 +888,7 @@ RSpec.describe Account do
           { username: 'b', domain: 'b' },
         ].map(&method(:Fabricate).curry(2).call(:account))
 
-        expect(described_class.non_internal.alphabetic).to eq matches
+        expect(described_class.without_internal.alphabetic).to eq matches
       end
     end
 
@@ -939,7 +939,7 @@ RSpec.describe Account do
       it 'returns an array of accounts who do not have a domain' do
         local_account = Fabricate(:account, domain: nil)
         _account_with_domain = Fabricate(:account, domain: 'example.com')
-        expect(described_class.non_internal.local).to contain_exactly(local_account)
+        expect(described_class.without_internal.local).to contain_exactly(local_account)
       end
     end
 
@@ -950,14 +950,14 @@ RSpec.describe Account do
           matches[index] = Fabricate(:account, domain: matches[index])
         end
 
-        expect(described_class.non_internal.partitioned).to match_array(matches)
+        expect(described_class.without_internal.partitioned).to match_array(matches)
       end
     end
 
     describe 'recent' do
       it 'returns a relation of accounts sorted by recent creation' do
         matches = Array.new(2) { Fabricate(:account) }
-        expect(described_class.non_internal.recent).to match_array(matches)
+        expect(described_class.without_internal.recent).to match_array(matches)
       end
     end
 

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -888,7 +888,7 @@ RSpec.describe Account do
           { username: 'b', domain: 'b' },
         ].map(&method(:Fabricate).curry(2).call(:account))
 
-        expect(described_class.where('id > 0').alphabetic).to eq matches
+        expect(described_class.non_internal.alphabetic).to eq matches
       end
     end
 
@@ -939,7 +939,7 @@ RSpec.describe Account do
       it 'returns an array of accounts who do not have a domain' do
         local_account = Fabricate(:account, domain: nil)
         _account_with_domain = Fabricate(:account, domain: 'example.com')
-        expect(described_class.where('id > 0').local).to contain_exactly(local_account)
+        expect(described_class.non_internal.local).to contain_exactly(local_account)
       end
     end
 
@@ -950,14 +950,14 @@ RSpec.describe Account do
           matches[index] = Fabricate(:account, domain: matches[index])
         end
 
-        expect(described_class.where('id > 0').partitioned).to match_array(matches)
+        expect(described_class.non_internal.partitioned).to match_array(matches)
       end
     end
 
     describe 'recent' do
       it 'returns a relation of accounts sorted by recent creation' do
         matches = Array.new(2) { Fabricate(:account) }
-        expect(described_class.where('id > 0').recent).to match_array(matches)
+        expect(described_class.non_internal.recent).to match_array(matches)
       end
     end
 


### PR DESCRIPTION
Consolidates a condition used in a few places. Used arel-style instead of string to better match style of existing scopes in the model, and for in-theory easier composability if we need to chain it.

I thought about `external` as a name here ... but I suspect that "remote" and "external" may be confusing to encounter, so went with `non_internal` instead. Open to other suggestions there if there are strong feelings.