### PR TITLE
Move common module inclusion in sub classes to `ActivityPub::BaseController`

### DIFF
--- a/app/controllers/activitypub/base_controller.rb
+++ b/app/controllers/activitypub/base_controller.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class ActivityPub::BaseController < Api::BaseController
+  include SignatureVerification
+  include AccountOwnedConcern
+
   skip_before_action :require_authenticated_user!
   skip_before_action :require_not_suspended!
   skip_around_action :set_locale

--- a/app/controllers/activitypub/claims_controller.rb
+++ b/app/controllers/activitypub/claims_controller.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 class ActivityPub::ClaimsController < ActivityPub::BaseController
-  include SignatureVerification
-  include AccountOwnedConcern
-
   skip_before_action :authenticate_user!
 
   before_action :require_account_signature!

--- a/app/controllers/activitypub/collections_controller.rb
+++ b/app/controllers/activitypub/collections_controller.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 class ActivityPub::CollectionsController < ActivityPub::BaseController
-  include SignatureVerification
-  include AccountOwnedConcern
-
   vary_by -> { 'Signature' if authorized_fetch_mode? }
 
   before_action :require_account_signature!, if: :authorized_fetch_mode?

--- a/app/controllers/activitypub/followers_synchronizations_controller.rb
+++ b/app/controllers/activitypub/followers_synchronizations_controller.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 class ActivityPub::FollowersSynchronizationsController < ActivityPub::BaseController
-  include SignatureVerification
-  include AccountOwnedConcern
-
   vary_by -> { 'Signature' if authorized_fetch_mode? }
 
   before_action :require_account_signature!

--- a/app/controllers/activitypub/inboxes_controller.rb
+++ b/app/controllers/activitypub/inboxes_controller.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 class ActivityPub::InboxesController < ActivityPub::BaseController
-  include SignatureVerification
   include JsonLdHelper
-  include AccountOwnedConcern
 
   before_action :skip_unknown_actor_activity
   before_action :require_actor_signature!

--- a/app/controllers/activitypub/outboxes_controller.rb
+++ b/app/controllers/activitypub/outboxes_controller.rb
@@ -3,9 +3,6 @@
 class ActivityPub::OutboxesController < ActivityPub::BaseController
   LIMIT = 20
 
-  include SignatureVerification
-  include AccountOwnedConcern
-
   vary_by -> { 'Signature' if authorized_fetch_mode? || page_requested? }
 
   before_action :require_account_signature!, if: :authorized_fetch_mode?

--- a/app/controllers/activitypub/replies_controller.rb
+++ b/app/controllers/activitypub/replies_controller.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 class ActivityPub::RepliesController < ActivityPub::BaseController
-  include SignatureVerification
   include Authorization
-  include AccountOwnedConcern
 
   DESCENDANTS_LIMIT = 60
 

--- a/app/controllers/instance_actors_controller.rb
+++ b/app/controllers/instance_actors_controller.rb
@@ -6,6 +6,8 @@ class InstanceActorsController < ActivityPub::BaseController
   serialization_scope nil
 
   before_action :set_account
+
+  skip_before_action :authenticate_user! # From `AccountOwnedConcern`
   skip_before_action :require_functional!
   skip_before_action :update_user_sign_in
 
@@ -16,7 +18,7 @@ class InstanceActorsController < ActivityPub::BaseController
 
   private
 
-  # TODO: Interacts with `AccountOwnedConcern`, included by AP::BaseController
+  # Skips various `before_action` from `AccountOwnedConcern`
   def account_required?
     false
   end

--- a/app/controllers/instance_actors_controller.rb
+++ b/app/controllers/instance_actors_controller.rb
@@ -16,6 +16,11 @@ class InstanceActorsController < ActivityPub::BaseController
 
   private
 
+  # TODO: Interacts with `AccountOwnedConcern`, included by AP::BaseController
+  def account_required?
+    false
+  end
+
   def set_account
     @account = Account.representative
   end


### PR DESCRIPTION
Every controller under `controllers/activitypub/*` includes these same concerns -- so we can move the include to their shared base class.

Once thing I'm not sure about is the `instance_actors` controller, which is not in the same dir as the rest, but does inherit from the AP Base class. That change was here - https://github.com/mastodon/mastodon/pull/24664 - but there's no spec added there and I can't tell from the commit message and changes alone which behavior its getting from the ap base class that we need to keep -vs- behavior it was previously getting from the application controller and the switch to ap/base was sort of arbitrary. Should sort that out during review and I'll update that portion of the change as needed here.