### PR TITLE
Refactor notification filtering behavior definition

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -29,18 +29,40 @@ class Notification < ApplicationRecord
     'Poll' => :poll,
   }.freeze
 
-  TYPES = %i(
-    mention
-    status
-    reblog
-    follow
-    follow_request
-    favourite
-    poll
-    update
-    admin.sign_up
-    admin.report
-  ).freeze
+  PROPERTIES = {
+    mention: {
+      filterable: true,
+    }.freeze,
+    status: {
+      filterable: false,
+    }.freeze,
+    reblog: {
+      filterable: true,
+    }.freeze,
+    follow: {
+      filterable: true,
+    }.freeze,
+    follow_request: {
+      filterable: true,
+    }.freeze,
+    favourite: {
+      filterable: true,
+    }.freeze,
+    poll: {
+      filterable: false,
+    }.freeze,
+    update: {
+      filterable: false,
+    }.freeze,
+    'admin.sign_up': {
+      filterable: false,
+    }.freeze,
+    'admin.report': {
+      filterable: false,
+    }.freeze,
+  }.freeze
+
+  TYPES = PROPERTIES.keys.freeze
 
   TARGET_STATUS_INCLUDES_BY_TYPE = {
     status: :status,

--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -83,7 +83,7 @@ class NotifyService < BaseService
     end
 
     def filter?
-      return false if NON_FILTERABLE_TYPES.include?(@notification.type)
+      return false unless Notification::PROPERTIES[@notification.type][:filterable]
       return false if override_for_sender?
 
       from_limited? ||


### PR DESCRIPTION
This makes the behavior explicit in the same place as notification type definitions, so that we don't forget to set it when adding new notification types.