### PR TITLE
Hide media by default in notification requests

### DIFF
--- a/app/javascript/mastodon/components/status.jsx
+++ b/app/javascript/mastodon/components/status.jsx
@@ -22,6 +22,7 @@ import Card from '../features/status/components/card';
 // to use the progress bar to show download progress
 import Bundle from '../features/ui/components/bundle';
 import { MediaGallery, Video, Audio } from '../features/ui/util/async-components';
+import { SensitiveMediaContext } from '../features/ui/util/sensitive_media_context';
 import { displayMedia } from '../initial_state';
 
 import { Avatar } from './avatar';
@@ -78,6 +79,8 @@ const messages = defineMessages({
 
 class Status extends ImmutablePureComponent {
 
+  static contextType = SensitiveMediaContext;
+
   static propTypes = {
     status: ImmutablePropTypes.map,
     account: ImmutablePropTypes.record,
@@ -133,19 +136,21 @@ class Status extends ImmutablePureComponent {
   ];
 
   state = {
-    showMedia: defaultMediaVisibility(this.props.status),
-    statusId: undefined,
+    showMedia: defaultMediaVisibility(this.props.status) && !(this.context?.hideMediaByDefault),
     forceFilter: undefined,
   };
 
-  static getDerivedStateFromProps(nextProps, prevState) {
-    if (nextProps.status && nextProps.status.get('id') !== prevState.statusId) {
-      return {
-        showMedia: defaultMediaVisibility(nextProps.status),
-        statusId: nextProps.status.get('id'),
-      };
-    } else {
-      return null;
+  componentDidUpdate (prevProps) {
+    // This will potentially cause a wasteful redraw, but in most cases `Status` components are used
+    // with a `key` directly depending on their `id`, preventing re-use of the component across
+    // different IDs.
+    // But just in case this does change, reset the state on status change.
+
+    if (this.props.status?.get('id') !== prevProps.status?.get('id')) {
+      this.setState({
+        showMedia: defaultMediaVisibility(this.props.status) && !(this.context?.hideMediaByDefault),
+        forceFilter: undefined,
+      });
     }
   }
 

--- a/app/javascript/mastodon/features/notifications/request.jsx
+++ b/app/javascript/mastodon/features/notifications/request.jsx
@@ -15,6 +15,7 @@ import Column from 'mastodon/components/column';
 import ColumnHeader from 'mastodon/components/column_header';
 import { IconButton } from 'mastodon/components/icon_button';
 import ScrollableList from 'mastodon/components/scrollable_list';
+import { SensitiveMediaContextProvider } from 'mastodon/features/ui/util/sensitive_media_context';
 
 import NotificationContainer from './containers/notification_container';
 
@@ -106,25 +107,27 @@ export const NotificationRequest = ({ multiColumn, params: { id } }) => {
         )}
       />
 
-      <ScrollableList
-        scrollKey={`notification_requests/${id}`}
-        trackScroll={!multiColumn}
-        bindToDocument={!multiColumn}
-        isLoading={isLoading}
-        showLoading={isLoading && notifications.size === 0}
-        hasMore={hasMore}
-        onLoadMore={handleLoadMore}
-      >
-        {notifications.map(item => (
-          item && <NotificationContainer
-            key={item.get('id')}
-            notification={item}
-            accountId={item.get('account')}
-            onMoveUp={handleMoveUp}
-            onMoveDown={handleMoveDown}
-          />
-        ))}
-      </ScrollableList>
+      <SensitiveMediaContextProvider hideMediaByDefault>
+        <ScrollableList
+          scrollKey={`notification_requests/${id}`}
+          trackScroll={!multiColumn}
+          bindToDocument={!multiColumn}
+          isLoading={isLoading}
+          showLoading={isLoading && notifications.size === 0}
+          hasMore={hasMore}
+          onLoadMore={handleLoadMore}
+        >
+          {notifications.map(item => (
+            item && <NotificationContainer
+              key={item.get('id')}
+              notification={item}
+              accountId={item.get('account')}
+              onMoveUp={handleMoveUp}
+              onMoveDown={handleMoveDown}
+            />
+          ))}
+        </ScrollableList>
+      </SensitiveMediaContextProvider>
 
       <Helmet>
         <title>{columnTitle}</title>

--- a/app/javascript/mastodon/features/ui/util/sensitive_media_context.tsx
+++ b/app/javascript/mastodon/features/ui/util/sensitive_media_context.tsx
@@ -1,0 +1,28 @@
+import { createContext, useContext, useMemo } from 'react';
+
+export const SensitiveMediaContext = createContext<{
+  hideMediaByDefault: boolean;
+}>({
+  hideMediaByDefault: false,
+});
+
+export function useSensitiveMediaContext() {
+  return useContext(SensitiveMediaContext);
+}
+
+type ContextValue = React.ContextType<typeof SensitiveMediaContext>;
+
+export const SensitiveMediaContextProvider: React.FC<
+  React.PropsWithChildren<{ hideMediaByDefault: boolean }>
+> = ({ hideMediaByDefault, children }) => {
+  const contextValue = useMemo<ContextValue>(
+    () => ({ hideMediaByDefault }),
+    [hideMediaByDefault],
+  );
+
+  return (
+    <SensitiveMediaContext.Provider value={contextValue}>
+      {children}
+    </SensitiveMediaContext.Provider>
+  );
+};


### PR DESCRIPTION
Notification requests are typically used for people you do not trust yet. Hiding media by default in this case lessens the risk of exposure to unwanted images.

I have moved away from `getDerivedStateFromProps` to `componentDidUpdate` because the former does not have access to the context.

Furthermore, `getDerivedStateFromProps` was there purely to handle an unlikely scenario that I have not been able to reproduce. I could have removed, but decided against it, because the risk of such a scenario occurring is incorrectly exposing a user to media marked as sensitive.