### PR TITLE
Add `Api::ErrorHandling` concern for api/base controller

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -8,6 +8,7 @@ class Api::BaseController < ApplicationController
   include Api::AccessTokenTrackingConcern
   include Api::CachingConcern
   include Api::ContentSecurityPolicy
+  include Api::ErrorHandling
 
   skip_before_action :require_functional!, unless: :limited_federation_mode?
 
@@ -17,51 +18,6 @@ class Api::BaseController < ApplicationController
   vary_by 'Authorization'
 
   protect_from_forgery with: :null_session
-
-  rescue_from ActiveRecord::RecordInvalid, Mastodon::ValidationError do |e|
-    render json: { error: e.to_s }, status: 422
-  end
-
-  rescue_from ActiveRecord::RecordNotUnique do
-    render json: { error: 'Duplicate record' }, status: 422
-  end
-
-  rescue_from Date::Error do
-    render json: { error: 'Invalid date supplied' }, status: 422
-  end
-
-  rescue_from ActiveRecord::RecordNotFound do
-    render json: { error: 'Record not found' }, status: 404
-  end
-
-  rescue_from HTTP::Error, Mastodon::UnexpectedResponseError do
-    render json: { error: 'Remote data could not be fetched' }, status: 503
-  end
-
-  rescue_from OpenSSL::SSL::SSLError do
-    render json: { error: 'Remote SSL certificate could not be verified' }, status: 503
-  end
-
-  rescue_from Mastodon::NotPermittedError do
-    render json: { error: 'This action is not allowed' }, status: 403
-  end
-
-  rescue_from Seahorse::Client::NetworkingError do |e|
-    Rails.logger.warn "Storage server error: #{e}"
-    render json: { error: 'There was a temporary problem serving your request, please try again' }, status: 503
-  end
-
-  rescue_from Mastodon::RaceConditionError, Stoplight::Error::RedLight do
-    render json: { error: 'There was a temporary problem serving your request, please try again' }, status: 503
-  end
-
-  rescue_from Mastodon::RateLimitExceededError do
-    render json: { error: I18n.t('errors.429') }, status: 429
-  end
-
-  rescue_from ActionController::ParameterMissing, Mastodon::InvalidParameterError do |e|
-    render json: { error: e.to_s }, status: 400
-  end
 
   def doorkeeper_unauthorized_render_options(error: nil)
     { json: { error: error.try(:description) || 'Not authorized' } }

--- a/app/controllers/concerns/api/error_handling.rb
+++ b/app/controllers/concerns/api/error_handling.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Api::ErrorHandling
+  extend ActiveSupport::Concern
+
+  included do
+    rescue_from ActiveRecord::RecordInvalid, Mastodon::ValidationError do |e|
+      render json: { error: e.to_s }, status: 422
+    end
+
+    rescue_from ActiveRecord::RecordNotUnique do
+      render json: { error: 'Duplicate record' }, status: 422
+    end
+
+    rescue_from Date::Error do
+      render json: { error: 'Invalid date supplied' }, status: 422
+    end
+
+    rescue_from ActiveRecord::RecordNotFound do
+      render json: { error: 'Record not found' }, status: 404
+    end
+
+    rescue_from HTTP::Error, Mastodon::UnexpectedResponseError do
+      render json: { error: 'Remote data could not be fetched' }, status: 503
+    end
+
+    rescue_from OpenSSL::SSL::SSLError do
+      render json: { error: 'Remote SSL certificate could not be verified' }, status: 503
+    end
+
+    rescue_from Mastodon::NotPermittedError do
+      render json: { error: 'This action is not allowed' }, status: 403
+    end
+
+    rescue_from Seahorse::Client::NetworkingError do |e|
+      Rails.logger.warn "Storage server error: #{e}"
+      render json: { error: 'There was a temporary problem serving your request, please try again' }, status: 503
+    end
+
+    rescue_from Mastodon::RaceConditionError, Stoplight::Error::RedLight do
+      render json: { error: 'There was a temporary problem serving your request, please try again' }, status: 503
+    end
+
+    rescue_from Mastodon::RateLimitExceededError do
+      render json: { error: I18n.t('errors.429') }, status: 429
+    end
+
+    rescue_from ActionController::ParameterMissing, Mastodon::InvalidParameterError do |e|
+      render json: { error: e.to_s }, status: 400
+    end
+  end
+end

--- a/spec/controllers/api/base_controller_spec.rb
+++ b/spec/controllers/api/base_controller_spec.rb
@@ -3,10 +3,6 @@
 require 'rails_helper'
 
 describe Api::BaseController do
-  before do
-    stub_const('FakeService', Class.new)
-  end
-
   controller do
     def success
       head 200
@@ -70,38 +66,6 @@ describe Api::BaseController do
       user.account.suspend!
       post :success
       expect(response).to have_http_status(403)
-    end
-  end
-
-  describe 'error handling' do
-    before do
-      routes.draw { get 'failure' => 'api/base#failure' }
-    end
-
-    {
-      ActiveRecord::RecordInvalid => 422,
-      ActiveRecord::RecordNotFound => 404,
-      ActiveRecord::RecordNotUnique => 422,
-      Date::Error => 422,
-      HTTP::Error => 503,
-      Mastodon::InvalidParameterError => 400,
-      Mastodon::NotPermittedError => 403,
-      Mastodon::RaceConditionError => 503,
-      Mastodon::RateLimitExceededError => 429,
-      Mastodon::UnexpectedResponseError => 503,
-      Mastodon::ValidationError => 422,
-      OpenSSL::SSL::SSLError => 503,
-      Seahorse::Client::NetworkingError => 503,
-      Stoplight::Error::RedLight => 503,
-    }.each do |error, code|
-      it "Handles error class of #{error}" do
-        allow(FakeService).to receive(:new).and_raise(error)
-
-        get :failure
-
-        expect(response).to have_http_status(code)
-        expect(FakeService).to have_received(:new)
-      end
     end
   end
 end

--- a/spec/controllers/concerns/api/error_handling_spec.rb
+++ b/spec/controllers/concerns/api/error_handling_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Api::ErrorHandling do
+  before do
+    stub_const('FakeService', Class.new)
+  end
+
+  controller(Api::BaseController) do
+    def failure
+      FakeService.new
+    end
+  end
+
+  describe 'error handling' do
+    before do
+      routes.draw { get 'failure' => 'api/base#failure' }
+    end
+
+    {
+      ActiveRecord::RecordInvalid => 422,
+      ActiveRecord::RecordNotFound => 404,
+      ActiveRecord::RecordNotUnique => 422,
+      Date::Error => 422,
+      HTTP::Error => 503,
+      Mastodon::InvalidParameterError => 400,
+      Mastodon::NotPermittedError => 403,
+      Mastodon::RaceConditionError => 503,
+      Mastodon::RateLimitExceededError => 429,
+      Mastodon::UnexpectedResponseError => 503,
+      Mastodon::ValidationError => 422,
+      OpenSSL::SSL::SSLError => 503,
+      Seahorse::Client::NetworkingError => 503,
+      Stoplight::Error::RedLight => 503,
+    }.each do |error, code|
+      it "Handles error class of #{error}" do
+        allow(FakeService)
+          .to receive(:new)
+          .and_raise(error)
+
+        get :failure
+
+        expect(response)
+          .to have_http_status(code)
+        expect(FakeService)
+          .to have_received(:new)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a subset of https://github.com/mastodon/mastodon/pull/27925

- Includes JUST the extraction of the error handling methods into a concern, with zero modification to the controller code and as small a change as I could think of to the spec
- Does not include the i18n changes, the string method changes, or the spec refactor (to add response message check in addition to code checks) from the original

Will rebase that other and continue to pull out anything valuable (I think at least the string check in the specs is useful, even if the i18n and string method are not desired) from it if this is merged.