### PR TITLE
Use sender's `username` to column title in notification request if it's `display_name` is not set

### DIFF
--- a/app/javascript/mastodon/features/notifications/request.jsx
+++ b/app/javascript/mastodon/features/notifications/request.jsx
@@ -87,7 +87,7 @@ export const NotificationRequest = ({ multiColumn, params: { id } }) => {
     }
   }, [dispatch, accountId]);
 
-  const columnTitle = intl.formatMessage(messages.title, { name: account?.get('display_name') });
+  const columnTitle = intl.formatMessage(messages.title, { name: account?.get('display_name') || account?.get('username') });
 
   return (
     <Column bindToDocument={!multiColumn} ref={columnRef} label={columnTitle}>


### PR DESCRIPTION
To prevent empty `display_name` of notification sender causes incomplete sentence of the column title `Notification from {name}` in `notifications/requests/*`, alternatively display it's `username` to `{name}` if `display_name` is not set.

![Screenshot](https://github.com/mastodon/mastodon/assets/5103195/c4049b09-c7e6-4b4f-8022-c3aef6233a5f)
