### PR TITLE
Clean up `activitypub` module route scope near instance actor

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,8 +77,10 @@ Rails.application.routes.draw do
   get 'remote_interaction_helper', to: 'remote_interaction_helper#index'
 
   resource :instance_actor, path: 'actor', only: [:show] do
-    resource :inbox, only: [:create], module: :activitypub
-    resource :outbox, only: [:show], module: :activitypub
+    scope module: :activitypub do
+      resource :inbox, only: [:create]
+      resource :outbox, only: [:show]
+    end
   end
 
   get '/invite/:invite_code', constraints: ->(req) { req.format == :json }, to: 'api/v1/invites#show'


### PR DESCRIPTION
First portion of https://github.com/mastodon/mastodon/pull/28104

Output from `bin/rails routes -g instance_actor`...

Before:

```
               Prefix Verb URI Pattern             Controller#Action
 instance_actor_inbox POST /actor/inbox(.:format)  activitypub/inboxes#create
instance_actor_outbox GET  /actor/outbox(.:format) activitypub/outboxes#show
       instance_actor GET  /actor(.:format)        instance_actors#show
                           /*unmatched_route       application#raise_not_found
```

After:

```
               Prefix Verb URI Pattern             Controller#Action
 instance_actor_inbox POST /actor/inbox(.:format)  activitypub/inboxes#create
instance_actor_outbox GET  /actor/outbox(.:format) activitypub/outboxes#show
       instance_actor GET  /actor(.:format)        instance_actors#show
                           /*unmatched_route       application#raise_not_found
```

