### PR TITLE
Clean up `activitypub` module route scope near collections/boxes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -126,11 +126,13 @@ Rails.application.routes.draw do
     resources :followers, only: [:index], controller: :follower_accounts
     resources :following, only: [:index], controller: :following_accounts
 
-    resource :outbox, only: [:show], module: :activitypub
-    resource :inbox, only: [:create], module: :activitypub
-    resource :claim, only: [:create], module: :activitypub
-    resources :collections, only: [:show], module: :activitypub
-    resource :followers_synchronization, only: [:show], module: :activitypub
+    scope module: :activitypub do
+      resource :outbox, only: [:show]
+      resource :inbox, only: [:create]
+      resource :claim, only: [:create]
+      resources :collections, only: [:show]
+      resource :followers_synchronization, only: [:show]
+    end
   end
 
   resource :inbox, only: [:create], module: :activitypub


### PR DESCRIPTION
The portion of https://github.com/mastodon/mastodon/pull/28104 which is not in https://github.com/mastodon/mastodon/pull/29579 - only change from original is to only change the wrapping scope and not also pull out the action groups with `with_options`. Output from `bin/rails -g account_username | grep activitypub`...

Before:

```
           account_status_replies GET  /users/:account_username/statuses/:status_id/replies(.:format) activitypub/replies#index
                   account_outbox GET  /users/:account_username/outbox(.:format)                      activitypub/outboxes#show
                    account_inbox POST /users/:account_username/inbox(.:format)                       activitypub/inboxes#create
                    account_claim POST /users/:account_username/claim(.:format)                       activitypub/claims#create
               account_collection GET  /users/:account_username/collections/:id(.:format)             activitypub/collections#show
account_followers_synchronization GET  /users/:account_username/followers_synchronization(.:format)   activitypub/followers_synchronizations#show
```

After:
```
           account_status_replies GET  /users/:account_username/statuses/:status_id/replies(.:format) activitypub/replies#index
                   account_outbox GET  /users/:account_username/outbox(.:format)                      activitypub/outboxes#show
                    account_inbox POST /users/:account_username/inbox(.:format)                       activitypub/inboxes#create
                    account_claim POST /users/:account_username/claim(.:format)                       activitypub/claims#create
               account_collection GET  /users/:account_username/collections/:id(.:format)             activitypub/collections#show
account_followers_synchronization GET  /users/:account_username/followers_synchronization(.:format)   activitypub/followers_synchronizations#show
```
