### PR TITLE
Add module `instances` route scope in api routes

### DIFF
--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -125,14 +125,16 @@ namespace :api, format: false do
     end
 
     resource :instance, only: [:show] do
-      resources :peers, only: [:index], controller: 'instances/peers'
-      resources :rules, only: [:index], controller: 'instances/rules'
-      resources :domain_blocks, only: [:index], controller: 'instances/domain_blocks'
-      resource :privacy_policy, only: [:show], controller: 'instances/privacy_policies'
-      resource :extended_description, only: [:show], controller: 'instances/extended_descriptions'
-      resource :translation_languages, only: [:show], controller: 'instances/translation_languages'
-      resource :languages, only: [:show], controller: 'instances/languages'
-      resource :activity, only: [:show], controller: 'instances/activity'
+      scope module: :instances do
+        resources :peers, only: [:index]
+        resources :rules, only: [:index]
+        resources :domain_blocks, only: [:index]
+        resource :privacy_policy, only: [:show]
+        resource :extended_description, only: [:show]
+        resource :translation_languages, only: [:show]
+        resource :languages, only: [:show]
+        resource :activity, only: [:show], controller: :activity
+      end
     end
 
     namespace :peers do


### PR DESCRIPTION
The instances portion of https://github.com/mastodon/mastodon/pull/28107 - but only with the scope, does not also do `with_options` blocks. The output of `bin/rails routes -g api/v1/instances` is same between main and this branch.