### PR TITLE
Add module `accounts` route scope in api routes

### DIFF
--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -181,12 +181,14 @@ namespace :api, format: false do
     end
 
     resources :accounts, only: [:create, :show] do
-      resources :statuses, only: :index, controller: 'accounts/statuses'
-      resources :followers, only: :index, controller: 'accounts/follower_accounts'
-      resources :following, only: :index, controller: 'accounts/following_accounts'
-      resources :lists, only: :index, controller: 'accounts/lists'
-      resources :identity_proofs, only: :index, controller: 'accounts/identity_proofs'
-      resources :featured_tags, only: :index, controller: 'accounts/featured_tags'
+      scope module: :accounts do
+        resources :statuses, only: :index
+        resources :followers, only: :index, controller: :follower_accounts
+        resources :following, only: :index, controller: :following_accounts
+        resources :lists, only: :index
+        resources :identity_proofs, only: :index
+        resources :featured_tags, only: :index
+      end
 
       member do
         post :follow


### PR DESCRIPTION
The accounts portion of https://github.com/mastodon/mastodon/pull/28107 - but only with the scope, does not also do `with_options` blocks. The output of `bin/rails routes -g api/v1/accounts` is same between main and this branch.