### PR TITLE
Remove setting of `sensitive` value (default false, not null) in Status model

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -442,7 +442,6 @@ class Status < ApplicationRecord
   def set_visibility
     self.visibility = reblog.visibility if reblog? && visibility.nil?
     self.visibility = (account.locked? ? :private : :public) if visibility.nil?
-    self.sensitive  = false if sensitive.nil?
   end
 
   def set_conversation


### PR DESCRIPTION
As noted in comments on https://github.com/mastodon/mastodon/pull/28806 it's not clear why this is here or what the historical purpose was. This column has a default and is not null at db level, so this callback value setting doesn't seem useful (separately, the method is called `set_visibility` which is an unexpected place to find this).