### PR TITLE
Add badge on account card in report moderation interface when account is already suspended

### DIFF
--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -1380,6 +1380,19 @@ a.sparkline {
 .account-card {
   border-radius: 4px;
   border: 1px solid lighten($ui-base-color, 8%);
+  position: relative;
+
+  &__warning-badge {
+    position: absolute;
+    padding: 4px 10px;
+    top: 10px;
+    inset-inline-start: 10px;
+    border-radius: 4px;
+    background:
+      url('../images/warning-stripes.svg') repeat-y left,
+      url('../images/warning-stripes.svg') repeat-y right,
+      var(--background-color);
+  }
 
   &__permalink {
     color: inherit;

--- a/app/views/admin/reports/_header_card.html.haml
+++ b/app/views/admin/reports/_header_card.html.haml
@@ -1,5 +1,11 @@
 .report-header__card
   .account-card
+    - if report.target_account.suspended?
+      .account-card__warning-badge
+        - if report.target_account.suspension_origin_local?
+          = t('admin.reports.already_suspended_badges.local')
+        - else
+          = t('admin.reports.already_suspended_badges.remote')
     .account-card__header
       = image_tag report.target_account.header.url, alt: ''
     .account-card__title

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -597,6 +597,9 @@ en:
       actions_description_html: Decide which action to take to resolve this report. If you take a punitive action against the reported account, an e-mail notification will be sent to them, except when the <strong>Spam</strong> category is selected.
       actions_description_remote_html: Decide which action to take to resolve this report. This will only affect how <strong>your</strong> server communicates with this remote account and handle its content.
       add_to_report: Add more to report
+      already_suspended_badges:
+        local: Already suspended on this server
+        remote: Already suspended on their server
       are_you_sure: Are you sure?
       assign_to_self: Assign to me
       assigned: Assigned moderator


### PR DESCRIPTION
![image](https://github.com/mastodon/mastodon/assets/384364/ee805994-965e-4a50-b024-e4c5089ea739)
![image](https://github.com/mastodon/mastodon/assets/384364/82472cfe-5fa3-4ab1-a137-bbaffadff3f6)

---

Fixes MAS-208