### PR TITLE
Extract more size methods in media CLI

### DIFF
--- a/lib/mastodon/cli/media.rb
+++ b/lib/mastodon/cli/media.rb
@@ -278,13 +278,13 @@ module Mastodon::CLI
     desc 'usage', 'Calculate disk space consumed by Mastodon'
     def usage
       say("Attachments:\t#{number_to_human_size(media_attachment_storage_size)} (#{number_to_human_size(local_media_attachment_storage_size)} local)")
-      say("Custom emoji:\t#{number_to_human_size(CustomEmoji.sum(:image_file_size))} (#{number_to_human_size(CustomEmoji.local.sum(:image_file_size))} local)")
-      say("Preview cards:\t#{number_to_human_size(PreviewCard.sum(:image_file_size))}")
-      say("Avatars:\t#{number_to_human_size(Account.sum(:avatar_file_size))} (#{number_to_human_size(Account.local.sum(:avatar_file_size))} local)")
-      say("Headers:\t#{number_to_human_size(Account.sum(:header_file_size))} (#{number_to_human_size(Account.local.sum(:header_file_size))} local)")
-      say("Backups:\t#{number_to_human_size(Backup.sum(:dump_file_size))}")
-      say("Imports:\t#{number_to_human_size(Import.sum(:data_file_size))}")
-      say("Settings:\t#{number_to_human_size(SiteUpload.sum(:file_file_size))}")
+      say("Custom emoji:\t#{number_to_human_size(custom_emoji_storage_size)} (#{number_to_human_size(local_custom_emoji_storage_size)} local)")
+      say("Preview cards:\t#{number_to_human_size(preview_card_storage_size)}")
+      say("Avatars:\t#{number_to_human_size(avatar_storage_size)} (#{number_to_human_size(local_avatar_storage_size)} local)")
+      say("Headers:\t#{number_to_human_size(header_storage_size)} (#{number_to_human_size(local_header_storage_size)} local)")
+      say("Backups:\t#{number_to_human_size(backups_storage_size)}")
+      say("Imports:\t#{number_to_human_size(imports_storage_size)}")
+      say("Settings:\t#{number_to_human_size(settings_storage_size)}")
     end
 
     desc 'lookup URL', 'Lookup where media is displayed by passing a media URL'
@@ -331,6 +331,46 @@ module Mastodon::CLI
           COALESCE(file_file_size, 0) + COALESCE(thumbnail_file_size, 0)
         SQL
       )
+    end
+
+    def custom_emoji_storage_size
+      CustomEmoji.sum(:image_file_size)
+    end
+
+    def local_custom_emoji_storage_size
+      CustomEmoji.local.sum(:image_file_size)
+    end
+
+    def preview_card_storage_size
+      PreviewCard.sum(:image_file_size)
+    end
+
+    def avatar_storage_size
+      Account.sum(:avatar_file_size)
+    end
+
+    def local_avatar_storage_size
+      Account.local.sum(:avatar_file_size)
+    end
+
+    def header_storage_size
+      Account.sum(:header_file_size)
+    end
+
+    def local_header_storage_size
+      Account.local.sum(:header_file_size)
+    end
+
+    def backups_storage_size
+      Backup.sum(:dump_file_size)
+    end
+
+    def imports_storage_size
+      Import.sum(:data_file_size)
+    end
+
+    def settings_storage_size
+      SiteUpload.sum(:file_file_size)
     end
 
     PRELOAD_MODEL_WHITELIST = %w(


### PR DESCRIPTION
This is just the size methods portion of https://github.com/mastodon/mastodon/pull/28145 without the string reporting changes. Going to close that in favor of this, and then may pursue a combination string-improvement and json option output thing separately.