### PR TITLE
Fix `Style/FormatStringToken` cop in paperclip color extractor

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -79,7 +79,6 @@ Style/FetchEnvVar:
 Style/FormatStringToken:
   Exclude:
     - 'config/initializers/devise.rb'
-    - 'lib/paperclip/color_extractor.rb'
 
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Style/GlobalStdStream:

--- a/lib/paperclip/color_extractor.rb
+++ b/lib/paperclip/color_extractor.rb
@@ -183,7 +183,7 @@ module Paperclip
     end
 
     def rgb_to_hex(rgb)
-      format('#%02x%02x%02x', rgb.r, rgb.g, rgb.b)
+      format('#%<red>02x%<green>02x%<blue>02x', red: rgb.r, green: rgb.g, blue: rgb.b)
     end
   end
 end


### PR DESCRIPTION
Replaces https://github.com/mastodon/mastodon/pull/28364