### PR TITLE
Add `include_pagination_headers` matcher to check `Link` header in api specs

### DIFF
--- a/spec/requests/api/v1/blocks_spec.rb
+++ b/spec/requests/api/v1/blocks_spec.rb
@@ -38,16 +38,14 @@ RSpec.describe 'Blocks' do
         expect(body_as_json.size).to eq(params[:limit])
       end
 
-      it 'sets the correct pagination header for the prev path' do
+      it 'sets correct link header pagination' do
         subject
 
-        expect(response.headers['Link'].find_link(%w(rel prev)).href).to eq(api_v1_blocks_url(limit: params[:limit], since_id: blocks.last.id))
-      end
-
-      it 'sets the correct pagination header for the next path' do
-        subject
-
-        expect(response.headers['Link'].find_link(%w(rel next)).href).to eq(api_v1_blocks_url(limit: params[:limit], max_id: blocks[1].id))
+        expect(response)
+          .to include_pagination_headers(
+            prev: api_v1_blocks_url(limit: params[:limit], since_id: blocks.last.id),
+            next: api_v1_blocks_url(limit: params[:limit], max_id: blocks.second.id)
+          )
       end
     end
 

--- a/spec/requests/api/v1/bookmarks_spec.rb
+++ b/spec/requests/api/v1/bookmarks_spec.rb
@@ -42,9 +42,14 @@ RSpec.describe 'Bookmarks' do
       it 'paginates correctly', :aggregate_failures do
         subject
 
-        expect(body_as_json.size).to eq(params[:limit])
-        expect(response.headers['Link'].find_link(%w(rel prev)).href).to eq(api_v1_bookmarks_url(limit: params[:limit], min_id: bookmarks.last.id))
-        expect(response.headers['Link'].find_link(%w(rel next)).href).to eq(api_v1_bookmarks_url(limit: params[:limit], max_id: bookmarks[1].id))
+        expect(body_as_json.size)
+          .to eq(params[:limit])
+
+        expect(response)
+          .to include_pagination_headers(
+            prev: api_v1_bookmarks_url(limit: params[:limit], min_id: bookmarks.last.id),
+            next: api_v1_bookmarks_url(limit: params[:limit], max_id: bookmarks.second.id)
+          )
       end
     end
 

--- a/spec/requests/api/v1/favourites_spec.rb
+++ b/spec/requests/api/v1/favourites_spec.rb
@@ -45,16 +45,14 @@ RSpec.describe 'Favourites' do
         expect(body_as_json.size).to eq(params[:limit])
       end
 
-      it 'sets the correct pagination header for the prev path' do
+      it 'sets the correct pagination headers' do
         subject
 
-        expect(response.headers['Link'].find_link(%w(rel prev)).href).to eq(api_v1_favourites_url(limit: params[:limit], min_id: favourites.last.id))
-      end
-
-      it 'sets the correct pagination header for the next path' do
-        subject
-
-        expect(response.headers['Link'].find_link(%w(rel next)).href).to eq(api_v1_favourites_url(limit: params[:limit], max_id: favourites[1].id))
+        expect(response)
+          .to include_pagination_headers(
+            prev: api_v1_favourites_url(limit: params[:limit], min_id: favourites.last.id),
+            next: api_v1_favourites_url(limit: params[:limit], max_id: favourites.second.id)
+          )
       end
     end
 

--- a/spec/requests/api/v1/followed_tags_spec.rb
+++ b/spec/requests/api/v1/followed_tags_spec.rb
@@ -49,16 +49,14 @@ RSpec.describe 'Followed tags' do
         expect(body_as_json.size).to eq(params[:limit])
       end
 
-      it 'sets the correct pagination header for the prev path' do
+      it 'sets the correct pagination headers' do
         subject
 
-        expect(response.headers['Link'].find_link(%w(rel prev)).href).to eq(api_v1_followed_tags_url(limit: params[:limit], since_id: tag_follows.last.id))
-      end
-
-      it 'sets the correct pagination header for the next path' do
-        subject
-
-        expect(response.headers['Link'].find_link(%w(rel next)).href).to eq(api_v1_followed_tags_url(limit: params[:limit], max_id: tag_follows.last.id))
+        expect(response)
+          .to include_pagination_headers(
+            prev: api_v1_followed_tags_url(limit: params[:limit], since_id: tag_follows.last.id),
+            next: api_v1_followed_tags_url(limit: params[:limit], max_id: tag_follows.last.id)
+          )
       end
     end
   end

--- a/spec/requests/api/v1/mutes_spec.rb
+++ b/spec/requests/api/v1/mutes_spec.rb
@@ -44,10 +44,11 @@ RSpec.describe 'Mutes' do
       it 'sets the correct pagination headers', :aggregate_failures do
         subject
 
-        headers = response.headers['Link']
-
-        expect(headers.find_link(%w(rel prev)).href).to eq(api_v1_mutes_url(limit: params[:limit], since_id: mutes.last.id.to_s))
-        expect(headers.find_link(%w(rel next)).href).to eq(api_v1_mutes_url(limit: params[:limit], max_id: mutes.last.id.to_s))
+        expect(response)
+          .to include_pagination_headers(
+            prev: api_v1_mutes_url(limit: params[:limit], since_id: mutes.last.id),
+            next: api_v1_mutes_url(limit: params[:limit], max_id: mutes.last.id)
+          )
       end
     end
 

--- a/spec/requests/api/v1/notifications_spec.rb
+++ b/spec/requests/api/v1/notifications_spec.rb
@@ -98,9 +98,14 @@ RSpec.describe 'Notifications' do
 
         notifications = user.account.notifications
 
-        expect(body_as_json.size).to eq(params[:limit])
-        expect(response.headers['Link'].find_link(%w(rel prev)).href).to eq(api_v1_notifications_url(limit: params[:limit], min_id: notifications.last.id.to_s))
-        expect(response.headers['Link'].find_link(%w(rel next)).href).to eq(api_v1_notifications_url(limit: params[:limit], max_id: notifications[2].id.to_s))
+        expect(body_as_json.size)
+          .to eq(params[:limit])
+
+        expect(response)
+          .to include_pagination_headers(
+            prev: api_v1_notifications_url(limit: params[:limit], min_id: notifications.last.id),
+            next: api_v1_notifications_url(limit: params[:limit], max_id: notifications[2].id)
+          )
       end
     end
 

--- a/spec/requests/api/v1/timelines/home_spec.rb
+++ b/spec/requests/api/v1/timelines/home_spec.rb
@@ -55,10 +55,11 @@ describe 'Home', :sidekiq_inline do
         it 'sets the correct pagination headers', :aggregate_failures do
           subject
 
-          headers = response.headers['Link']
-
-          expect(headers.find_link(%w(rel prev)).href).to eq(api_v1_timelines_home_url(limit: 1, min_id: ana.statuses.first.id.to_s))
-          expect(headers.find_link(%w(rel next)).href).to eq(api_v1_timelines_home_url(limit: 1, max_id: ana.statuses.first.id.to_s))
+          expect(response)
+            .to include_pagination_headers(
+              prev: api_v1_timelines_home_url(limit: params[:limit], min_id: ana.statuses.first.id),
+              next: api_v1_timelines_home_url(limit: params[:limit], max_id: ana.statuses.first.id)
+            )
         end
       end
     end

--- a/spec/requests/api/v1/timelines/public_spec.rb
+++ b/spec/requests/api/v1/timelines/public_spec.rb
@@ -83,10 +83,11 @@ describe 'Public' do
         it 'sets the correct pagination headers', :aggregate_failures do
           subject
 
-          headers = response.headers['Link']
-
-          expect(headers.find_link(%w(rel prev)).href).to eq(api_v1_timelines_public_url(limit: 1, min_id: media_status.id.to_s))
-          expect(headers.find_link(%w(rel next)).href).to eq(api_v1_timelines_public_url(limit: 1, max_id: media_status.id.to_s))
+          expect(response)
+            .to include_pagination_headers(
+              prev: api_v1_timelines_public_url(limit: params[:limit], min_id: media_status.id),
+              next: api_v1_timelines_public_url(limit: params[:limit], max_id: media_status.id)
+            )
         end
       end
     end

--- a/spec/requests/api/v1/timelines/tag_spec.rb
+++ b/spec/requests/api/v1/timelines/tag_spec.rb
@@ -71,10 +71,11 @@ RSpec.describe 'Tag' do
       it 'sets the correct pagination headers', :aggregate_failures do
         subject
 
-        headers = response.headers['Link']
-
-        expect(headers.find_link(%w(rel prev)).href).to eq(api_v1_timelines_tag_url(limit: 1, min_id: love_status.id.to_s))
-        expect(headers.find_link(%w(rel next)).href).to eq(api_v1_timelines_tag_url(limit: 1, max_id: love_status.id.to_s))
+        expect(response)
+          .to include_pagination_headers(
+            prev: api_v1_timelines_tag_url(limit: params[:limit], min_id: love_status.id),
+            next: api_v1_timelines_tag_url(limit: params[:limit], max_id: love_status.id)
+          )
       end
     end
 

--- a/spec/support/matchers/api_pagination.rb
+++ b/spec/support/matchers/api_pagination.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+RSpec::Matchers.define :include_pagination_headers do |links|
+  match do |response|
+    links.map do |key, value|
+      response.headers['Link'].find_link(['rel', key.to_s]).href == value
+    end.all?
+  end
+
+  failure_message do |header|
+    "expected that #{header} would have the same values as #{links}."
+  end
+end


### PR DESCRIPTION
This is the spec changes and matcher addition from https://github.com/mastodon/mastodon/pull/28826

I think this is a slight improvement/streamlining of these specs even if we don't pull in that concern change from the PR -- and it may make that one easier to review if this is in first.

The matcher here is in theory flexible enough to use on other Link headers if we have them, but for now I'm just using it in the api specs to check for the next/prev url values.

In a few spots, this let us combine what were previously multi-request examples into single ones, so there may be a marginal speedup here too.