### PR TITLE
Fix results/query in `api/v1/featured_tags/suggestions`

### DIFF
--- a/app/controllers/api/v1/featured_tags/suggestions_controller.rb
+++ b/app/controllers/api/v1/featured_tags/suggestions_controller.rb
@@ -12,6 +12,10 @@ class Api::V1::FeaturedTags::SuggestionsController < Api::BaseController
   private
 
   def set_recently_used_tags
-    @recently_used_tags = Tag.recently_used(current_account).where.not(id: current_account.featured_tags).limit(10)
+    @recently_used_tags = Tag.recently_used(current_account).where.not(id: featured_tag_ids).limit(10)
+  end
+
+  def featured_tag_ids
+    current_account.featured_tags.pluck(:tag_id)
   end
 end

--- a/spec/fabricators/featured_tag_fabricator.rb
+++ b/spec/fabricators/featured_tag_fabricator.rb
@@ -2,6 +2,6 @@
 
 Fabricator(:featured_tag) do
   account { Fabricate.build(:account) }
-  tag { Fabricate.build(:tag) }
+  tag { nil }
   name { sequence(:name) { |i| "Tag#{i}" } }
 end

--- a/spec/requests/api/v1/featured_tags/suggestions_spec.rb
+++ b/spec/requests/api/v1/featured_tags/suggestions_spec.rb
@@ -7,13 +7,35 @@ describe 'Featured Tags Suggestions API' do
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:scopes)  { 'read:accounts' }
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
-  let(:account) { Fabricate(:account) }
+  let(:account) { Fabricate(:account, user: user) }
 
   describe 'GET /api/v1/featured_tags/suggestions' do
-    it 'returns http success' do
-      get '/api/v1/featured_tags/suggestions', params: { account_id: account.id, limit: 2 }, headers: headers
+    let!(:unused_featured_tag) { Fabricate(:tag, name: 'unused_featured_tag') }
+    let!(:used_tag) { Fabricate(:tag, name: 'used_tag') }
+    let!(:used_featured_tag) { Fabricate(:tag, name: 'used_featured_tag') }
 
-      expect(response).to have_http_status(200)
+    before do
+      _unused_tag = Fabricate(:tag, name: 'unused_tag')
+
+      # Make relevant tags used by account
+      status = Fabricate(:status, account: account)
+      status.tags << used_tag
+      status.tags << used_featured_tag
+
+      # Feature the relevant tags
+      Fabricate :featured_tag, account: account, name: unused_featured_tag.name
+      Fabricate :featured_tag, account: account, name: used_featured_tag.name
+    end
+
+    it 'returns http success and recently used but not featured tags' do
+      get '/api/v1/featured_tags/suggestions', params: { limit: 2 }, headers: headers
+
+      expect(response)
+        .to have_http_status(200)
+      expect(body_as_json)
+        .to contain_exactly(
+          include(name: used_tag.name)
+        )
     end
   end
 end


### PR DESCRIPTION
The bug fix here is pulled from https://github.com/mastodon/mastodon/pull/28815 which found it as a side effect, but did not fully flesh out a spec to show the issue. Changes here:

- Remove the tag from the featured tag fabricator - this class sets this internally from the name of the tag
- Remove extraneous/unused account_id in params in the request spec
- Connect the account and user in request spec
- Add assertions about which tag is found in the results (the recently used but not featured one), verify this fails
- Update controller query to match tag ids with tag ids. The previous query was something like "where tag id is not in featured tags", but this was comparing against the `id` of the featuredtag records, not the tag_id connected to them.

Will rebase that other one after this, as I think this (and the other usage) would still read better as scopes.