### PR TITLE
Add `not_allowed` and `allowed` scope for `StatusTrend`

### DIFF
--- a/app/models/status_trend.rb
+++ b/app/models/status_trend.rb
@@ -19,5 +19,22 @@ class StatusTrend < ApplicationRecord
   belongs_to :status
   belongs_to :account
 
-  scope :allowed, -> { joins('INNER JOIN (SELECT account_id, MAX(score) AS max_score FROM status_trends GROUP BY account_id) AS grouped_status_trends ON status_trends.account_id = grouped_status_trends.account_id AND status_trends.score = grouped_status_trends.max_score').where(allowed: true) }
+  scope :allowed, -> { where(allowed: true) }
+  scope :not_allowed, -> { where(allowed: false) }
+  scope :with_account_constraint, -> { joins(account_score_constraint) }
+
+  def self.account_score_constraint
+    Arel.sql(<<~SQL.squish)
+      INNER JOIN (
+        SELECT
+          account_id,
+          MAX(score) AS max_score
+        FROM
+          status_trends
+        GROUP BY
+          account_id
+      ) AS grouped_status_trends ON status_trends.account_id = grouped_status_trends.account_id
+      AND status_trends.score = grouped_status_trends.max_score
+    SQL
+  end
 end

--- a/app/models/trends/status_filter.rb
+++ b/app/models/trends/status_filter.rb
@@ -49,7 +49,7 @@ class Trends::StatusFilter
   def trending_scope(value)
     case value
     when 'allowed'
-      StatusTrend.allowed
+      StatusTrend.with_account_constraint.allowed
     else
       StatusTrend.all
     end

--- a/app/models/trends/statuses.rb
+++ b/app/models/trends/statuses.rb
@@ -25,7 +25,7 @@ class Trends::Statuses < Trends::Base
     def to_arel
       scope = Status.joins(:trend).reorder(score: :desc)
       scope = scope.reorder(language_order_clause.desc, score: :desc) if preferred_languages.present?
-      scope = scope.merge(StatusTrend.allowed) if @allowed
+      scope = scope.merge(StatusTrend.with_account_constraint.allowed) if @allowed
       scope = scope.not_excluded_by_account(@account).not_domain_blocked_by_account(@account) if @account.present?
       scope = scope.offset(@offset) if @offset.present?
       scope = scope.limit(@limit) if @limit.present?
@@ -79,8 +79,8 @@ class Trends::Statuses < Trends::Base
 
   def request_review
     StatusTrend.locales.flat_map do |language|
-      score_at_threshold = StatusTrend.where(language: language, allowed: true).by_rank.ranked_below(options[:review_threshold]).first&.score || 0
-      status_trends      = StatusTrend.where(language: language, allowed: false).joins(:status).includes(status: :account)
+      score_at_threshold = StatusTrend.where(language: language).allowed.by_rank.ranked_below(options[:review_threshold]).first&.score || 0
+      status_trends      = StatusTrend.where(language: language).not_allowed.joins(:status).includes(status: :account)
 
       status_trends.filter_map do |trend|
         status = trend.status


### PR DESCRIPTION
Extracted from https://github.com/mastodon/mastodon/pull/29408 - but just includes the changes for this model.

This one is slightly more complex than the other one, since there was a pre-existing extra condition on top of the already existing `allowed` scope. I chose to pull that out into a simpler version to use in the trends/statuses class, and then add back in the other conditions via another scope, where they were previously in place.