### PR TITLE
Move repeated `insert_pagination_headers` method to api base class

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -104,6 +104,10 @@ class Api::BaseController < ApplicationController
 
   private
 
+  def insert_pagination_headers
+    set_pagination_headers(next_path, prev_path)
+  end
+
   def pagination_options_invalid?
     params.slice(:limit, :offset).values.map(&:to_i).any?(&:negative?)
   end

--- a/app/controllers/api/v1/accounts/follower_accounts_controller.rb
+++ b/app/controllers/api/v1/accounts/follower_accounts_controller.rb
@@ -41,10 +41,6 @@ class Api::V1::Accounts::FollowerAccountsController < Api::BaseController
     )
   end
 
-  def insert_pagination_headers
-    set_pagination_headers(next_path, prev_path)
-  end
-
   def next_path
     api_v1_account_followers_url pagination_params(max_id: pagination_max_id) if records_continue?
   end

--- a/app/controllers/api/v1/accounts/following_accounts_controller.rb
+++ b/app/controllers/api/v1/accounts/following_accounts_controller.rb
@@ -41,10 +41,6 @@ class Api::V1::Accounts::FollowingAccountsController < Api::BaseController
     )
   end
 
-  def insert_pagination_headers
-    set_pagination_headers(next_path, prev_path)
-  end
-
   def next_path
     api_v1_account_following_index_url pagination_params(max_id: pagination_max_id) if records_continue?
   end

--- a/app/controllers/api/v1/accounts/statuses_controller.rb
+++ b/app/controllers/api/v1/accounts/statuses_controller.rb
@@ -35,10 +35,6 @@ class Api::V1::Accounts::StatusesController < Api::BaseController
     params.slice(:limit, *AccountStatusesFilter::KEYS).permit(:limit, *AccountStatusesFilter::KEYS).merge(core_params)
   end
 
-  def insert_pagination_headers
-    set_pagination_headers(next_path, prev_path)
-  end
-
   def next_path
     api_v1_account_statuses_url pagination_params(max_id: pagination_max_id) if records_continue?
   end

--- a/app/controllers/api/v1/admin/accounts_controller.rb
+++ b/app/controllers/api/v1/admin/accounts_controller.rb
@@ -125,10 +125,6 @@ class Api::V1::Admin::AccountsController < Api::BaseController
     translated_params
   end
 
-  def insert_pagination_headers
-    set_pagination_headers(next_path, prev_path)
-  end
-
   def next_path
     api_v1_admin_accounts_url(pagination_params(max_id: pagination_max_id)) if records_continue?
   end

--- a/app/controllers/api/v1/admin/canonical_email_blocks_controller.rb
+++ b/app/controllers/api/v1/admin/canonical_email_blocks_controller.rb
@@ -65,10 +65,6 @@ class Api::V1::Admin::CanonicalEmailBlocksController < Api::BaseController
     @canonical_email_block = CanonicalEmailBlock.find(params[:id])
   end
 
-  def insert_pagination_headers
-    set_pagination_headers(next_path, prev_path)
-  end
-
   def next_path
     api_v1_admin_canonical_email_blocks_url(pagination_params(max_id: pagination_max_id)) if records_continue?
   end

--- a/app/controllers/api/v1/admin/domain_allows_controller.rb
+++ b/app/controllers/api/v1/admin/domain_allows_controller.rb
@@ -61,10 +61,6 @@ class Api::V1::Admin::DomainAllowsController < Api::BaseController
     DomainAllow.all
   end
 
-  def insert_pagination_headers
-    set_pagination_headers(next_path, prev_path)
-  end
-
   def next_path
     api_v1_admin_domain_allows_url(pagination_params(max_id: pagination_max_id)) if records_continue?
   end

--- a/app/controllers/api/v1/admin/domain_blocks_controller.rb
+++ b/app/controllers/api/v1/admin/domain_blocks_controller.rb
@@ -72,10 +72,6 @@ class Api::V1::Admin::DomainBlocksController < Api::BaseController
     params.permit(:severity, :reject_media, :reject_reports, :private_comment, :public_comment, :obfuscate)
   end
 
-  def insert_pagination_headers
-    set_pagination_headers(next_path, prev_path)
-  end
-
   def next_path
     api_v1_admin_domain_blocks_url(pagination_params(max_id: pagination_max_id)) if records_continue?
   end

--- a/app/controllers/api/v1/admin/email_domain_blocks_controller.rb
+++ b/app/controllers/api/v1/admin/email_domain_blocks_controller.rb
@@ -58,10 +58,6 @@ class Api::V1::Admin::EmailDomainBlocksController < Api::BaseController
     params.permit(:domain, :allow_with_approval)
   end
 
-  def insert_pagination_headers
-    set_pagination_headers(next_path, prev_path)
-  end
-
   def next_path
     api_v1_admin_email_domain_blocks_url(pagination_params(max_id: pagination_max_id)) if records_continue?
   end

--- a/app/controllers/api/v1/admin/ip_blocks_controller.rb
+++ b/app/controllers/api/v1/admin/ip_blocks_controller.rb
@@ -63,10 +63,6 @@ class Api::V1::Admin::IpBlocksController < Api::BaseController
     params.permit(:ip, :severity, :comment, :expires_in)
   end
 
-  def insert_pagination_headers
-    set_pagination_headers(next_path, prev_path)
-  end
-
   def next_path
     api_v1_admin_ip_blocks_url(pagination_params(max_id: pagination_max_id)) if records_continue?
   end

--- a/app/controllers/api/v1/admin/reports_controller.rb
+++ b/app/controllers/api/v1/admin/reports_controller.rb
@@ -89,10 +89,6 @@ class Api::V1::Admin::ReportsController < Api::BaseController
     params.permit(*FILTER_PARAMS)
   end
 
-  def insert_pagination_headers
-    set_pagination_headers(next_path, prev_path)
-  end
-
   def next_path
     api_v1_admin_reports_url(pagination_params(max_id: pagination_max_id)) if records_continue?
   end

--- a/app/controllers/api/v1/admin/tags_controller.rb
+++ b/app/controllers/api/v1/admin/tags_controller.rb
@@ -44,10 +44,6 @@ class Api::V1::Admin::TagsController < Api::BaseController
     params.permit(:display_name, :trendable, :usable, :listable)
   end
 
-  def insert_pagination_headers
-    set_pagination_headers(next_path, prev_path)
-  end
-
   def next_path
     api_v1_admin_tags_url(pagination_params(max_id: pagination_max_id)) if records_continue?
   end

--- a/app/controllers/api/v1/admin/trends/links/preview_card_providers_controller.rb
+++ b/app/controllers/api/v1/admin/trends/links/preview_card_providers_controller.rb
@@ -42,10 +42,6 @@ class Api::V1::Admin::Trends::Links::PreviewCardProvidersController < Api::BaseC
     @providers = PreviewCardProvider.all.to_a_paginated_by_id(limit_param(LIMIT), params_slice(:max_id, :since_id, :min_id))
   end
 
-  def insert_pagination_headers
-    set_pagination_headers(next_path, prev_path)
-  end
-
   def next_path
     api_v1_admin_trends_links_preview_card_providers_url(pagination_params(max_id: pagination_max_id)) if records_continue?
   end

--- a/app/controllers/api/v1/blocks_controller.rb
+++ b/app/controllers/api/v1/blocks_controller.rb
@@ -28,10 +28,6 @@ class Api::V1::BlocksController < Api::BaseController
                                )
   end
 
-  def insert_pagination_headers
-    set_pagination_headers(next_path, prev_path)
-  end
-
   def next_path
     api_v1_blocks_url pagination_params(max_id: pagination_max_id) if records_continue?
   end

--- a/app/controllers/api/v1/bookmarks_controller.rb
+++ b/app/controllers/api/v1/bookmarks_controller.rb
@@ -31,10 +31,6 @@ class Api::V1::BookmarksController < Api::BaseController
     current_account.bookmarks
   end
 
-  def insert_pagination_headers
-    set_pagination_headers(next_path, prev_path)
-  end
-
   def next_path
     api_v1_bookmarks_url pagination_params(max_id: pagination_max_id) if records_continue?
   end

--- a/app/controllers/api/v1/conversations_controller.rb
+++ b/app/controllers/api/v1/conversations_controller.rb
@@ -53,10 +53,6 @@ class Api::V1::ConversationsController < Api::BaseController
                        .to_a_paginated_by_id(limit_param(LIMIT), params_slice(:max_id, :since_id, :min_id))
   end
 
-  def insert_pagination_headers
-    set_pagination_headers(next_path, prev_path)
-  end
-
   def next_path
     api_v1_conversations_url pagination_params(max_id: pagination_max_id) if records_continue?
   end

--- a/app/controllers/api/v1/crypto/encrypted_messages_controller.rb
+++ b/app/controllers/api/v1/crypto/encrypted_messages_controller.rb
@@ -29,10 +29,6 @@ class Api::V1::Crypto::EncryptedMessagesController < Api::BaseController
     @encrypted_messages = @current_device.encrypted_messages.to_a_paginated_by_id(limit_param(LIMIT), params_slice(:max_id, :since_id, :min_id))
   end
 
-  def insert_pagination_headers
-    set_pagination_headers(next_path, prev_path)
-  end
-
   def next_path
     api_v1_crypto_encrypted_messages_url pagination_params(max_id: pagination_max_id) if records_continue?
   end

--- a/app/controllers/api/v1/domain_blocks_controller.rb
+++ b/app/controllers/api/v1/domain_blocks_controller.rb
@@ -38,10 +38,6 @@ class Api::V1::DomainBlocksController < Api::BaseController
     current_account.domain_blocks
   end
 
-  def insert_pagination_headers
-    set_pagination_headers(next_path, prev_path)
-  end
-
   def next_path
     api_v1_domain_blocks_url pagination_params(max_id: pagination_max_id) if records_continue?
   end

--- a/app/controllers/api/v1/endorsements_controller.rb
+++ b/app/controllers/api/v1/endorsements_controller.rb
@@ -28,10 +28,6 @@ class Api::V1::EndorsementsController < Api::BaseController
     current_account.endorsed_accounts.includes(:account_stat, :user).without_suspended
   end
 
-  def insert_pagination_headers
-    set_pagination_headers(next_path, prev_path)
-  end
-
   def next_path
     return if unlimited?
 

--- a/app/controllers/api/v1/favourites_controller.rb
+++ b/app/controllers/api/v1/favourites_controller.rb
@@ -31,10 +31,6 @@ class Api::V1::FavouritesController < Api::BaseController
     current_account.favourites
   end
 
-  def insert_pagination_headers
-    set_pagination_headers(next_path, prev_path)
-  end
-
   def next_path
     api_v1_favourites_url pagination_params(max_id: pagination_max_id) if records_continue?
   end

--- a/app/controllers/api/v1/follow_requests_controller.rb
+++ b/app/controllers/api/v1/follow_requests_controller.rb
@@ -48,10 +48,6 @@ class Api::V1::FollowRequestsController < Api::BaseController
     )
   end
 
-  def insert_pagination_headers
-    set_pagination_headers(next_path, prev_path)
-  end
-
   def next_path
     api_v1_follow_requests_url pagination_params(max_id: pagination_max_id) if records_continue?
   end

--- a/app/controllers/api/v1/followed_tags_controller.rb
+++ b/app/controllers/api/v1/followed_tags_controller.rb
@@ -22,10 +22,6 @@ class Api::V1::FollowedTagsController < Api::BaseController
     )
   end
 
-  def insert_pagination_headers
-    set_pagination_headers(next_path, prev_path)
-  end
-
   def next_path
     api_v1_followed_tags_url pagination_params(max_id: pagination_max_id) if records_continue?
   end

--- a/app/controllers/api/v1/lists/accounts_controller.rb
+++ b/app/controllers/api/v1/lists/accounts_controller.rb
@@ -55,10 +55,6 @@ class Api::V1::Lists::AccountsController < Api::BaseController
     params.permit(account_ids: [])
   end
 
-  def insert_pagination_headers
-    set_pagination_headers(next_path, prev_path)
-  end
-
   def next_path
     return if unlimited?
 

--- a/app/controllers/api/v1/mutes_controller.rb
+++ b/app/controllers/api/v1/mutes_controller.rb
@@ -28,10 +28,6 @@ class Api::V1::MutesController < Api::BaseController
                              )
   end
 
-  def insert_pagination_headers
-    set_pagination_headers(next_path, prev_path)
-  end
-
   def next_path
     api_v1_mutes_url pagination_params(max_id: pagination_max_id) if records_continue?
   end

--- a/app/controllers/api/v1/notifications/requests_controller.rb
+++ b/app/controllers/api/v1/notifications/requests_controller.rb
@@ -53,10 +53,6 @@ class Api::V1::Notifications::RequestsController < Api::BaseController
     @request = NotificationRequest.where(account: current_account).find(params[:id])
   end
 
-  def insert_pagination_headers
-    set_pagination_headers(next_path, prev_path)
-  end
-
   def next_path
     api_v1_notifications_requests_url pagination_params(max_id: pagination_max_id) unless @requests.empty?
   end

--- a/app/controllers/api/v1/notifications_controller.rb
+++ b/app/controllers/api/v1/notifications_controller.rb
@@ -58,10 +58,6 @@ class Api::V1::NotificationsController < Api::BaseController
     @notifications.reject { |notification| notification.target_status.nil? }.map(&:target_status)
   end
 
-  def insert_pagination_headers
-    set_pagination_headers(next_path, prev_path)
-  end
-
   def next_path
     api_v1_notifications_url pagination_params(max_id: pagination_max_id) unless @notifications.empty?
   end

--- a/app/controllers/api/v1/scheduled_statuses_controller.rb
+++ b/app/controllers/api/v1/scheduled_statuses_controller.rb
@@ -47,10 +47,6 @@ class Api::V1::ScheduledStatusesController < Api::BaseController
     params.slice(:limit).permit(:limit).merge(core_params)
   end
 
-  def insert_pagination_headers
-    set_pagination_headers(next_path, prev_path)
-  end
-
   def next_path
     api_v1_scheduled_statuses_url pagination_params(max_id: pagination_max_id) if records_continue?
   end

--- a/app/controllers/api/v1/statuses/favourited_by_accounts_controller.rb
+++ b/app/controllers/api/v1/statuses/favourited_by_accounts_controller.rb
@@ -34,10 +34,6 @@ class Api::V1::Statuses::FavouritedByAccountsController < Api::V1::Statuses::Bas
     )
   end
 
-  def insert_pagination_headers
-    set_pagination_headers(next_path, prev_path)
-  end
-
   def next_path
     api_v1_status_favourited_by_index_url pagination_params(max_id: pagination_max_id) if records_continue?
   end

--- a/app/controllers/api/v1/statuses/reblogged_by_accounts_controller.rb
+++ b/app/controllers/api/v1/statuses/reblogged_by_accounts_controller.rb
@@ -30,10 +30,6 @@ class Api::V1::Statuses::RebloggedByAccountsController < Api::V1::Statuses::Base
     )
   end
 
-  def insert_pagination_headers
-    set_pagination_headers(next_path, prev_path)
-  end
-
   def next_path
     api_v1_status_reblogged_by_index_url pagination_params(max_id: pagination_max_id) if records_continue?
   end

--- a/app/controllers/api/v1/timelines/base_controller.rb
+++ b/app/controllers/api/v1/timelines/base_controller.rb
@@ -5,10 +5,6 @@ class Api::V1::Timelines::BaseController < Api::BaseController
 
   private
 
-  def insert_pagination_headers
-    set_pagination_headers(next_path, prev_path)
-  end
-
   def pagination_collection
     @statuses
   end

--- a/app/controllers/api/v1/trends/links_controller.rb
+++ b/app/controllers/api/v1/trends/links_controller.rb
@@ -34,10 +34,6 @@ class Api::V1::Trends::LinksController < Api::BaseController
     scope
   end
 
-  def insert_pagination_headers
-    set_pagination_headers(next_path, prev_path)
-  end
-
   def pagination_params(core_params)
     params.slice(:limit).permit(:limit).merge(core_params)
   end

--- a/app/controllers/api/v1/trends/statuses_controller.rb
+++ b/app/controllers/api/v1/trends/statuses_controller.rb
@@ -32,10 +32,6 @@ class Api::V1::Trends::StatusesController < Api::BaseController
     scope
   end
 
-  def insert_pagination_headers
-    set_pagination_headers(next_path, prev_path)
-  end
-
   def pagination_params(core_params)
     params.slice(:limit).permit(:limit).merge(core_params)
   end

--- a/app/controllers/api/v1/trends/tags_controller.rb
+++ b/app/controllers/api/v1/trends/tags_controller.rb
@@ -30,10 +30,6 @@ class Api::V1::Trends::TagsController < Api::BaseController
     Trends.tags.query.allowed
   end
 
-  def insert_pagination_headers
-    set_pagination_headers(next_path, prev_path)
-  end
-
   def pagination_params(core_params)
     params.slice(:limit).permit(:limit).merge(core_params)
   end


### PR DESCRIPTION
One more extraction from https://github.com/mastodon/mastodon/pull/28826

This is an `after_action` callback used by most of the api controllers to insert the pagination headers. It has the same definition in every class, so move to base class here (and possible concern after rebase in linked PR).