### PR TITLE
Fix `user_mailer.welcome.hashtags_recent_count` not having plural form

### DIFF
--- a/app/views/application/mailer/_hashtag.html.haml
+++ b/app/views/application/mailer/_hashtag.html.haml
@@ -17,4 +17,4 @@
                           %span.email-mini-hashtag-img-span
                             = image_tag full_asset_url(account.avatar.url), alt: '', width: 16, height: 16
                       %td
-                        %p= t('user_mailer.welcome.hashtags_recent_count', people: number_with_delimiter(hashtag.history.aggregate(2.days.ago.to_date..Time.zone.today).accounts), days: 2)
+                        %p= t('user_mailer.welcome.hashtags_recent_count', people: number_with_delimiter(hashtag.history.aggregate(2.days.ago.to_date..Time.zone.today).accounts))

--- a/app/views/user_mailer/welcome.text.erb
+++ b/app/views/user_mailer/welcome.text.erb
@@ -53,7 +53,7 @@
 <%= t('user_mailer.welcome.hashtags_subtitle') %>
 
 <%- @tags.each do |tag| %>
-* #<%= tag.display_name %> · <%= t('user_mailer.welcome.hashtags_recent_count', people: number_with_delimiter(tag.history.aggregate(2.days.ago.to_date..Time.zone.today).accounts), days: 2) %>
+* #<%= tag.display_name %> · <%= t('user_mailer.welcome.hashtags_recent_count', people: number_with_delimiter(tag.history.aggregate(2.days.ago.to_date..Time.zone.today).accounts)) %>
   <%= tag_url(tag) %>
 <%- end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1868,7 +1868,9 @@ en:
       follows_subtitle: Follow well-known accounts
       follows_title: Who to follow
       follows_view_more: View more people to follow
-      hashtags_recent_count: "%{people} people in the past %{days} days"
+      hashtags_recent_count:
+        one: "%{people} person in the past 2 days"
+        other: "%{people} people in the past 2 days"
       hashtags_subtitle: Explore what’s trending since past 2 days
       hashtags_title: Trending hashtags
       hashtags_view_more: View more trending hashtags


### PR DESCRIPTION
Fixes #29535

I decided to hardcode the 2 days value to have only one variable that can change, the value being already hardcoded in the views and the related `hashtags_subtitle` translatable string.