### PR TITLE
Use shared `form` partial for `admin/announcements` views

### DIFF
--- a/app/views/admin/announcements/_form.html.haml
+++ b/app/views/admin/announcements/_form.html.haml
@@ -1,0 +1,28 @@
+.fields-group
+  = form.input :starts_at,
+               html5: true,
+               include_blank: true,
+               input_html: { pattern: datetime_pattern, placeholder: datetime_placeholder },
+               wrapper: :with_block_label
+  = form.input :ends_at,
+               html5: true,
+               include_blank: true,
+               input_html: { pattern: datetime_pattern, placeholder: datetime_placeholder },
+               wrapper: :with_block_label
+
+.fields-group
+  = form.input :all_day,
+               as: :boolean,
+               wrapper: :with_label
+
+.fields-group
+  = form.input :text,
+               wrapper: :with_block_label
+
+- unless form.object.published?
+  .fields-group
+    = form.input :scheduled_at,
+                 html5: true,
+                 include_blank: true,
+                 input_html: { pattern: datetime_pattern, placeholder: datetime_placeholder },
+                 wrapper: :with_block_label

--- a/app/views/admin/announcements/edit.html.haml
+++ b/app/views/admin/announcements/edit.html.haml
@@ -1,7 +1,7 @@
 - content_for :page_title do
   = t('.title')
 
-= simple_form_for [:admin, @announcement], html: { novalidate: false } do |form|
+= simple_form_for @announcement, url: admin_announcement_path(@announcement), html: { novalidate: false } do |form|
   = render 'shared/error_messages', object: @announcement
 
   = render form

--- a/app/views/admin/announcements/edit.html.haml
+++ b/app/views/admin/announcements/edit.html.haml
@@ -1,37 +1,12 @@
 - content_for :page_title do
   = t('.title')
 
-= simple_form_for @announcement, url: admin_announcement_path(@announcement), html: { novalidate: false } do |f|
+= simple_form_for [:admin, @announcement], html: { novalidate: false } do |form|
   = render 'shared/error_messages', object: @announcement
 
-  .fields-group
-    = f.input :starts_at,
-              html5: true,
-              include_blank: true,
-              input_html: { pattern: datetime_pattern, placeholder: datetime_placeholder },
-              wrapper: :with_block_label
-    = f.input :ends_at,
-              html5: true,
-              include_blank: true,
-              input_html: { pattern: datetime_pattern, placeholder: datetime_placeholder },
-              wrapper: :with_block_label
-
-  .fields-group
-    = f.input :all_day,
-              as: :boolean,
-              wrapper: :with_label
-
-  .fields-group
-    = f.input :text,
-              wrapper: :with_block_label
-
-  - unless @announcement.published?
-    .fields-group
-      = f.input :scheduled_at,
-                html5: true,
-                include_blank: true,
-                input_html: { pattern: datetime_pattern, placeholder: datetime_placeholder },
-                wrapper: :with_block_label
+  = render form
 
   .actions
-    = f.button :button, t('generic.save_changes'), type: :submit
+    = form.button :button,
+                  t('generic.save_changes'),
+                  type: :submit

--- a/app/views/admin/announcements/new.html.haml
+++ b/app/views/admin/announcements/new.html.haml
@@ -1,7 +1,7 @@
 - content_for :page_title do
   = t('.title')
 
-= simple_form_for [:admin, @announcement], html: { novalidate: false } do |form|
+= simple_form_for @announcement, url: admin_announcements_path, html: { novalidate: false } do |form|
   = render 'shared/error_messages', object: @announcement
 
   = render form

--- a/app/views/admin/announcements/new.html.haml
+++ b/app/views/admin/announcements/new.html.haml
@@ -1,38 +1,12 @@
 - content_for :page_title do
   = t('.title')
 
-= simple_form_for @announcement, url: admin_announcements_path, html: { novalidate: false } do |f|
+= simple_form_for [:admin, @announcement], html: { novalidate: false } do |form|
   = render 'shared/error_messages', object: @announcement
 
-  .fields-group
-    = f.input :starts_at,
-              html5: true,
-              include_blank: true,
-              input_html: { pattern: datetime_pattern, placeholder: datetime_placeholder },
-              wrapper: :with_block_label
-    = f.input :ends_at,
-              html5: true,
-              include_blank: true,
-              input_html: { pattern: datetime_pattern, placeholder: datetime_placeholder },
-              wrapper: :with_block_label
-
-  .fields-group
-    = f.input :all_day,
-              as: :boolean,
-              wrapper: :with_label
-
-  .fields-group
-    = f.input :text,
-              wrapper: :with_block_label
-
-  .fields-group
-    = f.input :scheduled_at,
-              html5: true,
-              include_blank: true,
-              input_html: { pattern: datetime_pattern, placeholder: datetime_placeholder },
-              wrapper: :with_block_label
+  = render form
 
   .actions
-    = f.button :button,
-               t('.create'),
-               type: :submit
+    = form.button :button,
+                  t('.create'),
+                  type: :submit


### PR DESCRIPTION
Both of these views had repeated markup to generate the form. Changes:

- Pull out the common form tags to a new partial - the only difference here was the check for `published?` in the edit view. This is preserved in the form partial, and since published? will always be false on the new view, it works there too.
- In both views, switch the inner form variable from `f` to `form` which lets us do a nicer shorthand `render form` for the partial (auto-chooses file name and assigns correct local var)
- In both views, instead of doing the explicit path/method setup on the form, use the array/namespace option to simple_for and generate it that way. This puts the correct http method in the form as well.