### PR TITLE
Use shared `form` partial for `admin/domain_blocks` views

### DIFF
--- a/app/views/admin/domain_blocks/_form.html.haml
+++ b/app/views/admin/domain_blocks/_form.html.haml
@@ -1,0 +1,46 @@
+.fields-row
+  .fields-row__column.fields-row__column-6.fields-group
+    = form.input :domain,
+                 disabled: form.object.persisted?,
+                 hint: t('admin.domain_blocks.new.hint'),
+                 label: t('admin.domain_blocks.domain'),
+                 readonly: form.object.persisted?,
+                 required: true,
+                 wrapper: :with_label
+  .fields-row__column.fields-row__column-6.fields-group
+    = form.input :severity,
+                 collection: DomainBlock.severities.keys,
+                 hint: t('admin.domain_blocks.new.severity.desc_html'),
+                 include_blank: false,
+                 label_method: ->(type) { t("admin.domain_blocks.new.severity.#{type}") },
+                 wrapper: :with_label
+.fields-group
+  = form.input :reject_media,
+               as: :boolean,
+               hint: I18n.t('admin.domain_blocks.reject_media_hint'),
+               label: I18n.t('admin.domain_blocks.reject_media'),
+               wrapper: :with_label
+.fields-group
+  = form.input :reject_reports,
+               as: :boolean,
+               hint: I18n.t('admin.domain_blocks.reject_reports_hint'),
+               label: I18n.t('admin.domain_blocks.reject_reports'),
+               wrapper: :with_label
+.fields-group
+  = form.input :obfuscate,
+               as: :boolean,
+               hint: I18n.t('admin.domain_blocks.obfuscate_hint'),
+               label: I18n.t('admin.domain_blocks.obfuscate'),
+               wrapper: :with_label
+.field-group
+  = form.input :private_comment,
+               as: :string,
+               hint: t('admin.domain_blocks.private_comment_hint'),
+               label: I18n.t('admin.domain_blocks.private_comment'),
+               wrapper: :with_label
+.field-group
+  = form.input :public_comment,
+               as: :string,
+               hint: t('admin.domain_blocks.public_comment_hint'),
+               label: I18n.t('admin.domain_blocks.public_comment'),
+               wrapper: :with_label

--- a/app/views/admin/domain_blocks/edit.html.haml
+++ b/app/views/admin/domain_blocks/edit.html.haml
@@ -1,7 +1,7 @@
 - content_for :page_title do
   = t('admin.domain_blocks.edit')
 
-= simple_form_for [:admin, @domain_block] do |form|
+= simple_form_for @domain_block, url: admin_domain_block_path(@domain_block), method: :put do |form|
   = render 'shared/error_messages', object: @domain_block
 
   = render form

--- a/app/views/admin/domain_blocks/edit.html.haml
+++ b/app/views/admin/domain_blocks/edit.html.haml
@@ -1,63 +1,12 @@
 - content_for :page_title do
   = t('admin.domain_blocks.edit')
 
-= simple_form_for @domain_block, url: admin_domain_block_path(@domain_block), method: :put do |f|
+= simple_form_for [:admin, @domain_block] do |form|
   = render 'shared/error_messages', object: @domain_block
 
-  .fields-row
-    .fields-row__column.fields-row__column-6.fields-group
-      = f.input :domain,
-                disabled: true,
-                hint: t('admin.domain_blocks.new.hint'),
-                label: t('admin.domain_blocks.domain'),
-                readonly: true,
-                required: true,
-                wrapper: :with_label
-
-    .fields-row__column.fields-row__column-6.fields-group
-      = f.input :severity,
-                collection: DomainBlock.severities.keys,
-                hint: t('admin.domain_blocks.new.severity.desc_html'),
-                include_blank: false,
-                label_method: ->(type) { t("admin.domain_blocks.new.severity.#{type}") },
-                wrapper: :with_label
-
-  .fields-group
-    = f.input :reject_media,
-              as: :boolean,
-              hint: I18n.t('admin.domain_blocks.reject_media_hint'),
-              label: I18n.t('admin.domain_blocks.reject_media'),
-              wrapper: :with_label
-
-  .fields-group
-    = f.input :reject_reports,
-              as: :boolean,
-              hint: I18n.t('admin.domain_blocks.reject_reports_hint'),
-              label: I18n.t('admin.domain_blocks.reject_reports'),
-              wrapper: :with_label
-
-  .fields-group
-    = f.input :obfuscate,
-              as: :boolean,
-              hint: I18n.t('admin.domain_blocks.obfuscate_hint'),
-              label: I18n.t('admin.domain_blocks.obfuscate'),
-              wrapper: :with_label
-
-  .field-group
-    = f.input :private_comment,
-              as: :string,
-              hint: t('admin.domain_blocks.private_comment_hint'),
-              label: I18n.t('admin.domain_blocks.private_comment'),
-              wrapper: :with_label
-
-  .field-group
-    = f.input :public_comment,
-              as: :string,
-              hint: t('admin.domain_blocks.public_comment_hint'),
-              label: I18n.t('admin.domain_blocks.public_comment'),
-              wrapper: :with_label
+  = render form
 
   .actions
-    = f.button :button,
-               t('generic.save_changes'),
-               type: :submit
+    = form.button :button,
+                  t('generic.save_changes'),
+                  type: :submit

--- a/app/views/admin/domain_blocks/new.html.haml
+++ b/app/views/admin/domain_blocks/new.html.haml
@@ -1,7 +1,7 @@
 - content_for :page_title do
   = t('.title')
 
-= simple_form_for [:admin, @domain_block] do |form|
+= simple_form_for @domain_block, url: admin_domain_blocks_path do |form|
   = render 'shared/error_messages', object: @domain_block
 
   = render form

--- a/app/views/admin/domain_blocks/new.html.haml
+++ b/app/views/admin/domain_blocks/new.html.haml
@@ -1,61 +1,12 @@
 - content_for :page_title do
   = t('.title')
 
-= simple_form_for @domain_block, url: admin_domain_blocks_path do |f|
+= simple_form_for [:admin, @domain_block] do |form|
   = render 'shared/error_messages', object: @domain_block
 
-  .fields-row
-    .fields-row__column.fields-row__column-6.fields-group
-      = f.input :domain,
-                hint: t('.hint'),
-                label: t('admin.domain_blocks.domain'),
-                required: true,
-                wrapper: :with_label
-
-    .fields-row__column.fields-row__column-6.fields-group
-      = f.input :severity,
-                collection: DomainBlock.severities.keys,
-                hint: t('.severity.desc_html'),
-                include_blank: false,
-                label_method: ->(type) { t(".severity.#{type}") },
-                wrapper: :with_label
-
-  .fields-group
-    = f.input :reject_media,
-              as: :boolean,
-              hint: I18n.t('admin.domain_blocks.reject_media_hint'),
-              label: I18n.t('admin.domain_blocks.reject_media'),
-              wrapper: :with_label
-
-  .fields-group
-    = f.input :reject_reports,
-              as: :boolean,
-              hint: I18n.t('admin.domain_blocks.reject_reports_hint'),
-              label: I18n.t('admin.domain_blocks.reject_reports'),
-              wrapper: :with_label
-
-  .fields-group
-    = f.input :obfuscate,
-              as: :boolean,
-              hint: I18n.t('admin.domain_blocks.obfuscate_hint'),
-              label: I18n.t('admin.domain_blocks.obfuscate'),
-              wrapper: :with_label
-
-  .field-group
-    = f.input :private_comment,
-              as: :string,
-              hint: t('admin.domain_blocks.private_comment_hint'),
-              label: I18n.t('admin.domain_blocks.private_comment'),
-              wrapper: :with_label
-
-  .field-group
-    = f.input :public_comment,
-              as: :string,
-              hint: t('admin.domain_blocks.public_comment_hint'),
-              label: I18n.t('admin.domain_blocks.public_comment'),
-              wrapper: :with_label
+  = render form
 
   .actions
-    = f.button :button,
-               t('.create'),
-               type: :submit
+    = form.button :button,
+                  t('.create'),
+                  type: :submit


### PR DESCRIPTION
These views had almost same exact form generation, so extract a partial.

The only difference was around the disabled/readonly properties in the edit view (we don't want to let the domain value be edited once the block is created). This is preserved by checking `persisted?` so the edit view will mark them disabled/readonly but the new view will keep the field open.

Also did same stuff with inner variable name and simple_form style as in https://github.com/mastodon/mastodon/pull/29608