### PR TITLE
Add `User.recently_active` scope

### DIFF
--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -18,7 +18,7 @@ class FeedManager
   # @yield [Account]
   # @return [void]
   def with_active_accounts(&block)
-    Account.joins(:user).where('users.current_sign_in_at > ?', User::ACTIVE_DURATION.ago).find_each(&block)
+    Account.joins(:user).merge(User.recently_active).find_each(&block)
   end
 
   # Redis key of a feed

--- a/app/models/concerns/account/interactions.rb
+++ b/app/models/concerns/account/interactions.rb
@@ -250,13 +250,13 @@ module Account::Interactions
   def followers_for_local_distribution
     followers.local
              .joins(:user)
-             .where('users.current_sign_in_at > ?', User::ACTIVE_DURATION.ago)
+             .merge(User.recently_active)
   end
 
   def lists_for_local_distribution
     scope = lists.joins(account: :user)
     scope.where.not(list_accounts: { follow_id: nil }).or(scope.where(account_id: id))
-         .where('users.current_sign_in_at > ?', User::ACTIVE_DURATION.ago)
+         .merge(User.recently_active)
   end
 
   def remote_followers_hash(url)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -115,10 +115,11 @@ class User < ApplicationRecord
   scope :confirmed, -> { where.not(confirmed_at: nil) }
   scope :enabled, -> { where(disabled: false) }
   scope :disabled, -> { where(disabled: true) }
-  scope :inactive, -> { where(arel_table[:current_sign_in_at].lt(ACTIVE_DURATION.ago)) }
-  scope :active, -> { confirmed.where(arel_table[:current_sign_in_at].gteq(ACTIVE_DURATION.ago)).joins(:account).where(accounts: { suspended_at: nil }) }
+  scope :inactive, -> { where(current_sign_in_at: ...ACTIVE_DURATION.ago) }
+  scope :active, -> { confirmed.recently_active.joins(:account).where(accounts: { suspended_at: nil }) }
   scope :matches_email, ->(value) { where(arel_table[:email].matches("#{value}%")) }
   scope :matches_ip, ->(value) { left_joins(:ips).where('user_ips.ip <<= ?', value).group('users.id') }
+  scope :recently_active, -> { where(current_sign_in_at: ACTIVE_DURATION.ago..) }
 
   before_validation :sanitize_role
   before_create :set_approved


### PR DESCRIPTION
Changes: 

- In usage outside the User-class (one in feed manager, two in account interactions) merge in the scope instead of repeating the query conditions.
- In the User class itself -- an existing `active` scope was also repeating this logic, so replace it with the new scope.
- While in there, update `inactive` to match style of new scope since they are opposites

I believe this brings all references to the active duration constant back into User class. Other than changed quoting on the generated queries from the framework, the generated sql for the existing usage is the same.

Possible future thing here -- I did not look at how much usage of the existing `active` scope there is. The name here is sort of misleading, but something like `confirmed_and_recently_active_and_account_not_suspended` is excessive. Maybe there's a better alternative.