### PR TITLE
Remove unused `active_nav_class` helper method

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,10 +28,6 @@ module ApplicationHelper
     number_to_human(number, **options)
   end
 
-  def active_nav_class(*paths)
-    paths.any? { |path| current_page?(path) } ? 'active' : ''
-  end
-
   def open_registrations?
     Setting.registrations_mode == 'open'
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -3,30 +3,6 @@
 require 'rails_helper'
 
 describe ApplicationHelper do
-  describe 'active_nav_class' do
-    it 'returns active when on the current page' do
-      allow(helper).to receive(:current_page?).and_return(true)
-
-      result = helper.active_nav_class('/test')
-      expect(result).to eq 'active'
-    end
-
-    it 'returns active when on a current page' do
-      allow(helper).to receive(:current_page?).with('/foo').and_return(false)
-      allow(helper).to receive(:current_page?).with('/test').and_return(true)
-
-      result = helper.active_nav_class('/foo', '/test')
-      expect(result).to eq 'active'
-    end
-
-    it 'returns empty string when not on current page' do
-      allow(helper).to receive(:current_page?).and_return(false)
-
-      result = helper.active_nav_class('/test')
-      expect(result).to eq ''
-    end
-  end
-
   describe 'body_classes' do
     context 'with a body class string from a controller' do
       before { helper.extend controller_helpers }


### PR DESCRIPTION
I think the last usage was removed in https://github.com/mastodon/mastodon/commit/839f893168ab221b08fa439012189e6c29a2721a#diff-9f1b1db8cc7a64f408b8610120ea57801ce6857f3bd1f3a8f9a61c50c2f51030L15-L29