### PR TITLE
Remove unused `show_landing_strip?` helper method

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -32,10 +32,6 @@ module ApplicationHelper
     paths.any? { |path| current_page?(path) } ? 'active' : ''
   end
 
-  def show_landing_strip?
-    !user_signed_in? && !single_user_mode?
-  end
-
   def open_registrations?
     Setting.registrations_mode == 'open'
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -99,36 +99,6 @@ describe ApplicationHelper do
     end
   end
 
-  describe 'show_landing_strip?', :without_verify_partial_doubles do
-    describe 'when signed in' do
-      before do
-        allow(helper).to receive(:user_signed_in?).and_return(true)
-      end
-
-      it 'does not show landing strip' do
-        expect(helper.show_landing_strip?).to be false
-      end
-    end
-
-    describe 'when signed out' do
-      before do
-        allow(helper).to receive(:user_signed_in?).and_return(false)
-      end
-
-      it 'does not show landing strip on single user instance' do
-        allow(helper).to receive(:single_user_mode?).and_return(true)
-
-        expect(helper.show_landing_strip?).to be false
-      end
-
-      it 'shows landing strip on multi user instance' do
-        allow(helper).to receive(:single_user_mode?).and_return(false)
-
-        expect(helper.show_landing_strip?).to be true
-      end
-    end
-  end
-
   describe 'available_sign_up_path' do
     context 'when registrations are closed' do
       before do

--- a/spec/views/statuses/show.html.haml_spec.rb
+++ b/spec/views/statuses/show.html.haml_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe 'statuses/show.html.haml', :without_verify_partial_doubles do
   before do
-    allow(view).to receive_messages(api_oembed_url: '', show_landing_strip?: true, site_title: 'example site', site_hostname: 'example.com', full_asset_url: '//asset.host/image.svg', current_account: nil, single_user_mode?: false)
+    allow(view).to receive_messages(api_oembed_url: '', site_title: 'example site', site_hostname: 'example.com', full_asset_url: '//asset.host/image.svg', current_account: nil, single_user_mode?: false)
     allow(view).to receive(:local_time)
     allow(view).to receive(:local_time_ago)
     assign(:instance_presenter, InstancePresenter.new)


### PR DESCRIPTION
Last usage in https://github.com/mastodon/mastodon/commit/bb71538bb503159177d46d8956bd466973c0876b#diff-008f6f39e1453f70aacd986993be7faab4211207b57d5480f68c45da8aa8f311L20 I believe