### PR TITLE
Remove unused `link_to_older` and `link_to_newer` helper methods

### DIFF
--- a/app/helpers/statuses_helper.rb
+++ b/app/helpers/statuses_helper.rb
@@ -4,14 +4,6 @@ module StatusesHelper
   EMBEDDED_CONTROLLER = 'statuses'
   EMBEDDED_ACTION = 'embed'
 
-  def link_to_newer(url)
-    link_to t('statuses.show_newer'), url, class: 'load-more load-gap'
-  end
-
-  def link_to_older(url)
-    link_to t('statuses.show_older'), url, class: 'load-more load-gap'
-  end
-
   def nothing_here(extra_classes = '')
     content_tag(:div, class: "nothing-here #{extra_classes}") do
       t('accounts.nothing_here')

--- a/config/locales/an.yml
+++ b/config/locales/an.yml
@@ -1468,8 +1468,6 @@ an:
         other: "%{count} votos"
       vote: Vota
     show_more: Amostrar mas
-    show_newer: Amostrar mas recients
-    show_older: Amostrar mas antigos
     show_thread: Amostrar discusión
     title: "%{name}: «%{quote}»"
     visibilities:

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -1820,8 +1820,6 @@ ar:
         zero: بدون صوت %{count}
       vote: صوّت
     show_more: أظهر المزيد
-    show_newer: إظهار أحدث
-    show_older: إظهار أقدم
     show_thread: اعرض خيط المحادثة
     title: '%{name}: "%{quote}"'
     visibilities:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -1761,8 +1761,6 @@ be:
         other: "%{count} голасу"
       vote: Прагаласаваць
     show_more: Паказаць больш
-    show_newer: Паказаць навейшыя
-    show_older: Паказаць старэйшыя
     show_thread: Паказаць ланцуг
     title: '%{name}: "%{quote}"'
     visibilities:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -1697,8 +1697,6 @@ bg:
         other: "%{count} гласа"
       vote: Гласуване
     show_more: Покажи повече
-    show_newer: Показване на по-нови
-    show_older: Показване на по-стари
     show_thread: Показване на нишката
     title: "%{name}: „%{quote}“"
     visibilities:

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -1697,8 +1697,6 @@ ca:
         other: "%{count} vots"
       vote: Vota
     show_more: Mostra'n més
-    show_newer: Mostra els més nous
-    show_older: Mostra els més vells
     show_thread: Mostra el fil
     title: '%{name}: "%{quote}"'
     visibilities:

--- a/config/locales/ckb.yml
+++ b/config/locales/ckb.yml
@@ -982,8 +982,6 @@ ckb:
         other: "%{count} دەنگەکان"
       vote: دەنگ
     show_more: زیاتر پیشان بدە
-    show_newer: نوێتر پیشان بدە
-    show_older: پیشاندانی کۆنتر
     show_thread: نیشاندانی ڕشتە
     visibilities:
       private: شوێنکەوتوانی تەنها

--- a/config/locales/co.yml
+++ b/config/locales/co.yml
@@ -966,8 +966,6 @@ co:
         other: "%{count} voti"
       vote: Vutà
     show_more: Vede di più
-    show_newer: Vede i più ricenti
-    show_older: Vede i più anziani
     show_thread: Vede u filu
     title: '%{name}: "%{quote}"'
     visibilities:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -1761,8 +1761,6 @@ cs:
         other: "%{count} hlasů"
       vote: Hlasovat
     show_more: Zobrazit více
-    show_newer: Zobrazit novější
-    show_older: Zobrazit starší
     show_thread: Zobrazit vlákno
     title: "%{name}: „%{quote}“"
     visibilities:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -1825,8 +1825,6 @@ cy:
         zero: "%{count} o bleidleisiau"
       vote: Pleidlais
     show_more: Dangos mwy
-    show_newer: Dangos y diweddaraf
-    show_older: Dangos pethau hŷn
     show_thread: Dangos edefyn
     title: '%{name}: "%{quote}"'
     visibilities:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -1697,8 +1697,6 @@ da:
         other: "%{count} stemmer"
       vote: Stem
     show_more: Vis flere
-    show_newer: Vis nyere
-    show_older: Vis ældre
     show_thread: Vis tråd
     title: '%{name}: "%{quote}"'
     visibilities:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1697,8 +1697,6 @@ de:
         other: "%{count} Stimmen"
       vote: Abstimmen
     show_more: Mehr anzeigen
-    show_newer: Neuere anzeigen
-    show_older: Ältere anzeigen
     show_thread: Thread anzeigen
     title: "%{name}: „%{quote}“"
     visibilities:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -1569,8 +1569,6 @@ el:
         other: "%{count} ψήφοι"
       vote: Ψήφισε
     show_more: Δείξε περισσότερα
-    show_newer: Εμφάνιση νεότερων
-    show_older: Εμφάνιση παλαιότερων
     show_thread: Εμφάνιση νήματος
     title: '%{name}: "%{quote}"'
     visibilities:

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -1692,8 +1692,6 @@ en-GB:
         other: "%{count} votes"
       vote: Vote
     show_more: Show more
-    show_newer: Show newer
-    show_older: Show older
     show_thread: Show thread
     title: '%{name}: "%{quote}"'
     visibilities:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1698,8 +1698,6 @@ en:
         other: "%{count} votes"
       vote: Vote
     show_more: Show more
-    show_newer: Show newer
-    show_older: Show older
     show_thread: Show thread
     title: '%{name}: "%{quote}"'
     visibilities:

--- a/config/locales/eo.yml
+++ b/config/locales/eo.yml
@@ -1624,8 +1624,6 @@ eo:
         other: "%{count} voĉdonoj"
       vote: Voĉdoni
     show_more: Montri pli
-    show_newer: Montri pli novajn
-    show_older: Montri pli malnovajn
     show_thread: Montri la mesaĝaron
     title: "%{name}: “%{quote}”"
     visibilities:

--- a/config/locales/es-AR.yml
+++ b/config/locales/es-AR.yml
@@ -1697,8 +1697,6 @@ es-AR:
         other: "%{count} votos"
       vote: Votar
     show_more: Mostrar más
-    show_newer: Mostrar más recientes
-    show_older: Mostrar más antiguos
     show_thread: Mostrar hilo
     title: '%{name}: "%{quote}"'
     visibilities:

--- a/config/locales/es-MX.yml
+++ b/config/locales/es-MX.yml
@@ -1697,8 +1697,6 @@ es-MX:
         other: "%{count} votos"
       vote: Vota
     show_more: Mostrar más
-    show_newer: Mostrar más recientes
-    show_older: Mostrar más antiguos
     show_thread: Mostrar discusión
     title: "%{name}: «%{quote}»"
     visibilities:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1697,8 +1697,6 @@ es:
         other: "%{count} votos"
       vote: Vota
     show_more: Mostrar más
-    show_newer: Mostrar más recientes
-    show_older: Mostrar más antiguos
     show_thread: Mostrar discusión
     title: "%{name}: «%{quote}»"
     visibilities:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -1697,8 +1697,6 @@ et:
         other: "%{count} häält"
       vote: Hääleta
     show_more: Näita rohkem
-    show_newer: Uuemate kuvamine
-    show_older: Vanemate kuvamine
     show_thread: Kuva lõim
     title: '%{name}: "%{quote}"'
     visibilities:

--- a/config/locales/eu.yml
+++ b/config/locales/eu.yml
@@ -1701,8 +1701,6 @@ eu:
         other: "%{count} boto"
       vote: Bozkatu
     show_more: Erakutsi gehiago
-    show_newer: Erakutsi berriagoak
-    show_older: Erakutsi zaharragoak
     show_thread: Erakutsi haria
     title: '%{name}: "%{quote}"'
     visibilities:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -1461,8 +1461,6 @@ fa:
         other: "%{count} رأی"
       vote: رأی
     show_more: نمایش
-    show_newer: نمایش جدیدتر
-    show_older: نمایش قدیمی‌تر
     show_thread: نمایش رشته
     title: "%{name}: «%{quote}»"
     visibilities:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -1697,8 +1697,6 @@ fi:
         other: "%{count} ääntä"
       vote: Äänestä
     show_more: Näytä lisää
-    show_newer: Näytä uudemmat
-    show_older: Näytä vanhempi
     show_thread: Näytä ketju
     title: "%{name}: ”%{quote}”"
     visibilities:

--- a/config/locales/fo.yml
+++ b/config/locales/fo.yml
@@ -1697,8 +1697,6 @@ fo:
         other: "%{count} atkvøður"
       vote: Atkvøð
     show_more: Vís meira
-    show_newer: Vís nýggjari
-    show_older: Vís eldri
     show_thread: Vís tráð
     title: '%{name}: "%{quote}"'
     visibilities:

--- a/config/locales/fr-CA.yml
+++ b/config/locales/fr-CA.yml
@@ -1697,8 +1697,6 @@ fr-CA:
         other: "%{count} votes"
       vote: Voter
     show_more: Déplier
-    show_newer: Plus récents
-    show_older: Plus anciens
     show_thread: Afficher le fil de discussion
     title: "%{name} : « %{quote} »"
     visibilities:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1697,8 +1697,6 @@ fr:
         other: "%{count} votes"
       vote: Voter
     show_more: Déplier
-    show_newer: Plus récents
-    show_older: Plus anciens
     show_thread: Afficher le fil de discussion
     title: "%{name} : « %{quote} »"
     visibilities:

--- a/config/locales/fy.yml
+++ b/config/locales/fy.yml
@@ -1692,8 +1692,6 @@ fy:
         other: "%{count} stimmen"
       vote: Stimme
     show_more: Mear toane
-    show_newer: Nijere toane
-    show_older: Aldere toane
     show_thread: Petear toane
     title: '%{name}: "%{quote}"'
     visibilities:

--- a/config/locales/ga.yml
+++ b/config/locales/ga.yml
@@ -471,7 +471,6 @@ ga:
     poll:
       vote: Vótáil
     show_more: Taispeáin níos mó
-    show_newer: Taispeáin níos nuaí
     show_thread: Taispeáin snáithe
     visibilities:
       private: Leantóirí amháin

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -1761,8 +1761,6 @@ gd:
         two: "%{count} bhòt"
       vote: Bhòt
     show_more: Seall barrachd dheth
-    show_newer: Seall feadhainn as ùire
-    show_older: Seall feadhainn as sine
     show_thread: Seall an snàithlean
     title: "%{name}: “%{quote}”"
     visibilities:

--- a/config/locales/gl.yml
+++ b/config/locales/gl.yml
@@ -1697,8 +1697,6 @@ gl:
         other: "%{count} votos"
       vote: Votar
     show_more: Mostrar máis
-    show_newer: Mostrar o máis novo
-    show_older: Mostrar o máis vello
     show_thread: Amosar fío
     title: '%{name}: "%{quote}"'
     visibilities:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1761,8 +1761,6 @@ he:
         two: "%{count} קולות"
       vote: הצבעה
     show_more: עוד
-    show_newer: הצג חדשים יותר
-    show_older: הצג ישנים יותר
     show_thread: הצג שרשור
     title: '%{name}: "%{quote}"'
     visibilities:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -1697,8 +1697,6 @@ hu:
         other: "%{count} szavazat"
       vote: Szavazás
     show_more: Több megjelenítése
-    show_newer: Újabbak mutatása
-    show_older: Régebbiek mutatása
     show_thread: Szál mutatása
     title: "%{name}: „%{quote}”"
     visibilities:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -808,8 +808,6 @@ hy:
         other: "%{count} ձայներ"
       vote: Քուէարկել
     show_more: Աւելին
-    show_newer: Ցուցադրել նորերը
-    show_older: Ցուցադրել հները
     show_thread: Բացել շղթան
     title: '%{name}: "%{quote}"'
     visibilities:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -1428,8 +1428,6 @@ id:
         other: "%{count} memilih"
       vote: Pilih
     show_more: Tampilkan selengkapnya
-    show_newer: Tampilkan lebih baru
-    show_older: Tampilkan lebih lama
     show_thread: Tampilkan utas
     title: '%{name}: "%{quote}"'
     visibilities:

--- a/config/locales/ie.yml
+++ b/config/locales/ie.yml
@@ -1697,8 +1697,6 @@ ie:
         other: "%{count} votes"
       vote: Votar
     show_more: Monstrar plu
-    show_newer: Monstrar plu nov
-    show_older: Monstrar plu old
     show_thread: Monstrar fil
     title: "%{name}: «%{quote}»"
     visibilities:

--- a/config/locales/io.yml
+++ b/config/locales/io.yml
@@ -1666,8 +1666,6 @@ io:
         other: "%{count} voti"
       vote: Votez
     show_more: Montrar plue
-    show_newer: Montrez plu nova kozo
-    show_older: Montrez plu olda kozo
     show_thread: Montrez postaro
     title: '%{name}: "%{quote}"'
     visibilities:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -1701,8 +1701,6 @@ is:
         other: "%{count} atkvæði"
       vote: Greiða atkvæði
     show_more: Sýna meira
-    show_newer: Sýna nýrri
-    show_older: Sýna eldri
     show_thread: Birta þráð
     title: "%{name}: „%{quote}‟"
     visibilities:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1699,8 +1699,6 @@ it:
         other: "%{count} voti"
       vote: Vota
     show_more: Mostra di più
-    show_newer: Mostra più nuovi
-    show_older: Mostra più vecchi
     show_thread: Mostra thread
     title: '%{name}: "%{quote}"'
     visibilities:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1665,8 +1665,6 @@ ja:
         other: "%{count}票"
       vote: 投票
     show_more: もっと見る
-    show_newer: 新しいものを表示
-    show_older: 古いものを表示
     show_thread: スレッドを表示
     title: '%{name}: "%{quote}"'
     visibilities:

--- a/config/locales/kab.yml
+++ b/config/locales/kab.yml
@@ -813,8 +813,6 @@ kab:
         other: "%{count} n yedɣaren"
       vote: Dɣeṛ
     show_more: Ssken-d ugar
-    show_newer: Ssken-d timaynutin
-    show_older: Ssken-d tiqburin
     show_thread: Ssken-d lxiḍ
     title: '%{name} : "%{quote}"'
     visibilities:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -1667,8 +1667,6 @@ ko:
         other: "%{count}명 투표함"
       vote: 투표
     show_more: 더 보기
-    show_newer: 새로운 것 표시
-    show_older: 오래된 것 표시
     show_thread: 글타래 보기
     title: '%{name}: "%{quote}"'
     visibilities:

--- a/config/locales/ku.yml
+++ b/config/locales/ku.yml
@@ -1462,8 +1462,6 @@ ku:
         other: "%{count} deng"
       vote: Deng bide
     show_more: Bêtir nîşan bide
-    show_newer: Nûtirîn nîşan bide
-    show_older: Kevntirîn nîşan bide
     show_thread: Mijarê nîşan bide
     title: "%{name}%{quote}"
     visibilities:

--- a/config/locales/lad.yml
+++ b/config/locales/lad.yml
@@ -1697,8 +1697,6 @@ lad:
         other: "%{count} votos"
       vote: Vota
     show_more: Amostra mas
-    show_newer: Amostra mas muevos
-    show_older: Amostra mas viejos
     show_thread: Amostra diskusyon
     title: '%{name}: "%{quote}"'
     visibilities:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -1718,8 +1718,6 @@ lv:
         zero: "%{count} balsu"
       vote: Balsu skaits
     show_more: Rādīt vairāk
-    show_newer: Nekad nerādīt
-    show_older: Rādīt senākus
     show_thread: Rādīt tematu
     title: "%{name}: “%{quote}”"
     visibilities:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -1634,8 +1634,6 @@ ms:
         other: "%{count} undi"
       vote: Undi
     show_more: Tunjuk lebih banyak
-    show_newer: Tunjuk lebih baharu
-    show_older: Tunjuk lebih tua
     show_thread: Tunjuk bebenang
     title: '%{name}: "%{quote}"'
     visibilities:

--- a/config/locales/my.yml
+++ b/config/locales/my.yml
@@ -1633,8 +1633,6 @@ my:
         other: မဲအရေအတွက် %{count} မဲ
       vote: မဲပေးမည်
     show_more: ပိုမိုပြရန်
-    show_newer: ပို့စ်အသစ်များပြရန်
-    show_older: ပို့စ်အဟောင်းများပြရန်
     show_thread: Thread ကို ပြပါ
     title: '%{name}: "%{quote}"'
     visibilities:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1697,8 +1697,6 @@ nl:
         other: "%{count} stemmen"
       vote: Stemmen
     show_more: Meer tonen
-    show_newer: Nieuwere tonen
-    show_older: Oudere tonen
     show_thread: Gesprek tonen
     title: '%{name}: "%{quote}"'
     visibilities:

--- a/config/locales/nn.yml
+++ b/config/locales/nn.yml
@@ -1697,8 +1697,6 @@ nn:
         other: "%{count} røyster"
       vote: Røyst
     show_more: Vis meir
-    show_newer: Vis nyere
-    show_older: Vis eldre
     show_thread: Vis tråden
     title: "%{name}: «%{quote}»"
     visibilities:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -1694,8 +1694,6 @@
         other: "%{count} stemmer"
       vote: Stem
     show_more: Vis mer
-    show_newer: Vis nyere
-    show_older: Vis eldre
     show_thread: Vis tråden
     title: "%{name}: «%{quote}»"
     visibilities:

--- a/config/locales/oc.yml
+++ b/config/locales/oc.yml
@@ -875,8 +875,6 @@ oc:
         other: "%{count} vòtes"
       vote: Votar
     show_more: Ne veire mai
-    show_newer: Veire mai recents
-    show_older: Veire mai ancians
     show_thread: Mostrar lo fil
     title: '%{name} : "%{quote}"'
     visibilities:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -1761,8 +1761,6 @@ pl:
         other: "%{count} głosy"
       vote: Głosuj
     show_more: Pokaż więcej
-    show_newer: Pokaż nowsze
-    show_older: Pokaż starsze
     show_thread: Pokaż wątek
     title: '%{name}: "%{quote}"'
     visibilities:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -1697,8 +1697,6 @@ pt-BR:
         other: "%{count} votos"
       vote: Votar
     show_more: Mostrar mais
-    show_newer: Mostrar mais recentes
-    show_older: Mostrar mais antigos
     show_thread: Mostrar conversa
     title: '%{name}: "%{quote}"'
     visibilities:

--- a/config/locales/pt-PT.yml
+++ b/config/locales/pt-PT.yml
@@ -1697,8 +1697,6 @@ pt-PT:
         other: "%{count} votos"
       vote: Votar
     show_more: Mostrar mais
-    show_newer: Mostrar mais recentes
-    show_older: Mostrar mais antigos
     show_thread: Mostrar conversa
     title: '%{name}: "%{quote}"'
     visibilities:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -1756,8 +1756,6 @@ ru:
         other: "%{count} голосов"
       vote: Голосовать
     show_more: Развернуть
-    show_newer: Показать более новое
-    show_older: Показать старые
     show_thread: Открыть обсуждение
     title: '%{name}: "%{quote}"'
     visibilities:

--- a/config/locales/sc.yml
+++ b/config/locales/sc.yml
@@ -1025,8 +1025,6 @@ sc:
         other: "%{count} votos"
       vote: Vota
     show_more: Ammustra·nde prus
-    show_newer: Ammustra is prus noos
-    show_older: Ammustra is prus betzos
     show_thread: Ammustra su tema
     title: '%{name}: "%{quote}"'
     visibilities:

--- a/config/locales/sco.yml
+++ b/config/locales/sco.yml
@@ -1452,8 +1452,6 @@ sco:
         other: "%{count} votes"
       vote: Vote
     show_more: Shaw mair
-    show_newer: Shaw newer
-    show_older: Shaw aulder
     show_thread: Shaw threid
     title: '%{name}: "%{quote}"'
     visibilities:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -1316,8 +1316,6 @@ si:
         other: ඡන්ද %{count} යි
       vote: ඡන්දය
     show_more: තව පෙන්වන්න
-    show_newer: අලුත්ම පෙන්වන්න
-    show_older: පැරණි පෙන්වන්න
     show_thread: නූල් පෙන්වන්න
     title: '%{name}: "%{quote}"'
     visibilities:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -1761,8 +1761,6 @@ sl:
         two: "%{count} glasova"
       vote: Glasuj
     show_more: Pokaži več
-    show_newer: Pokaži novejše
-    show_older: Pokaži starejše
     show_thread: Pokaži nit
     title: "%{name}: »%{quote}«"
     visibilities:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -1693,8 +1693,6 @@ sq:
         other: "%{count} vota"
       vote: Votë
     show_more: Shfaq më tepër
-    show_newer: Shfaq më të reja
-    show_older: Shfaq më të vjetra
     show_thread: Shfaq rrjedhën
     title: '%{name}: "%{quote}"'
     visibilities:

--- a/config/locales/sr-Latn.yml
+++ b/config/locales/sr-Latn.yml
@@ -1729,8 +1729,6 @@ sr-Latn:
         other: "%{count} glasova"
       vote: Glasajte
     show_more: Prikaži još
-    show_newer: Nikad ne prikazuj
-    show_older: Prikaži starije
     show_thread: Prikaži niz
     title: "%{name}: „%{quote}”"
     visibilities:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -1729,8 +1729,6 @@ sr:
         other: "%{count} гласова"
       vote: Гласајте
     show_more: Прикажи још
-    show_newer: Никад не приказуј
-    show_older: Прикажи старије
     show_thread: Прикажи низ
     title: "%{name}: „%{quote}”"
     visibilities:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -1697,8 +1697,6 @@ sv:
         other: "%{count} röster"
       vote: Rösta
     show_more: Visa mer
-    show_newer: Visa nyare
-    show_older: Visa äldre
     show_thread: Visa tråd
     title: '%{name}: "%{quote}"'
     visibilities:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -1665,8 +1665,6 @@ th:
         other: "%{count} การลงคะแนน"
       vote: ลงคะแนน
     show_more: แสดงเพิ่มเติม
-    show_newer: แสดงที่ใหม่กว่า
-    show_older: แสดงที่เก่ากว่า
     show_thread: แสดงกระทู้
     title: '%{name}: "%{quote}"'
     visibilities:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -1697,8 +1697,6 @@ tr:
         other: "%{count} oylar"
       vote: Oy Ver
     show_more: Daha fazlasını göster
-    show_newer: Yenileri göster
-    show_older: Eskileri göster
     show_thread: Konuyu göster
     title: '%{name}: "%{quote}"'
     visibilities:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -1761,8 +1761,6 @@ uk:
         other: "%{count} голоси"
       vote: Проголосувати
     show_more: Розгорнути
-    show_newer: Показати новіші
-    show_older: Показати давніші
     show_thread: Відкрити обговорення
     title: '%{name}: "%{quote}"'
     visibilities:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -1665,8 +1665,6 @@ vi:
         other: "%{count} người bình chọn"
       vote: Bình chọn
     show_more: Đọc thêm
-    show_newer: Mới hơn
-    show_older: Cũ hơn
     show_thread: Nội dung gốc
     title: '%{name}: "%{quote}"'
     visibilities:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -1665,8 +1665,6 @@ zh-CN:
         other: "%{count} 票"
       vote: 投票
     show_more: 显示更多
-    show_newer: 显示更新内容
-    show_older: 显示更早内容
     show_thread: 显示全部对话
     title: "%{name}：“%{quote}”"
     visibilities:

--- a/config/locales/zh-HK.yml
+++ b/config/locales/zh-HK.yml
@@ -1660,8 +1660,6 @@ zh-HK:
         other: "%{count} 票"
       vote: 投票
     show_more: 顯示更多
-    show_newer: 顯示較新嘟文
-    show_older: 顯示較舊嘟文
     show_thread: 顯示討論串
     title: "%{name}：「%{quote}」"
     visibilities:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -1667,8 +1667,6 @@ zh-TW:
         other: "%{count} 票"
       vote: 投票
     show_more: 顯示更多
-    show_newer: 顯示較新嘟文
-    show_older: 顯示較舊嘟文
     show_thread: 顯示討論串
     title: "%{name}：「%{quote}」"
     visibilities:

--- a/spec/helpers/statuses_helper_spec.rb
+++ b/spec/helpers/statuses_helper_spec.rb
@@ -29,26 +29,6 @@ describe StatusesHelper do
     I18n.t('statuses.content_warning', warning: status.spoiler_text)
   end
 
-  describe 'link_to_newer' do
-    it 'returns a link to newer content' do
-      url = 'https://example.com'
-      result = helper.link_to_newer(url)
-
-      expect(result).to match('load-more')
-      expect(result).to match(I18n.t('statuses.show_newer'))
-    end
-  end
-
-  describe 'link_to_older' do
-    it 'returns a link to older content' do
-      url = 'https://example.com'
-      result = helper.link_to_older(url)
-
-      expect(result).to match('load-more')
-      expect(result).to match(I18n.t('statuses.show_older'))
-    end
-  end
-
   describe 'fa_visibility_icon' do
     context 'with a status that is public' do
       let(:status) { Status.new(visibility: 'public') }


### PR DESCRIPTION
Last usage removed: https://github.com/mastodon/mastodon/commit/839f893168ab221b08fa439012189e6c29a2721a#diff-38cff727247ad179dcb42f2b82c4ad39d3d0b1a74dda85d7752cc4c14c34e907L37-L47