### PR TITLE
Use `with_options` for shared values in admin dashboards

### DIFF
--- a/app/views/admin/dashboard/index.html.haml
+++ b/app/views/admin/dashboard/index.html.haml
@@ -15,20 +15,21 @@
           = link_to t("admin.system_checks.#{message.key}.action"), message.action
 
 .dashboard
-  .dashboard__item
-    = react_admin_component :counter, measure: 'new_users', start_at: @time_period.first, end_at: @time_period.last, label: t('admin.dashboard.new_users'), href: admin_accounts_path(origin: 'local')
+  - with_options start_at: @time_period.first, end_at: @time_period.last do |options|
+    .dashboard__item
+      = options.react_admin_component :counter, measure: 'new_users', label: t('admin.dashboard.new_users'), href: admin_accounts_path(origin: 'local')
 
-  .dashboard__item
-    = react_admin_component :counter, measure: 'active_users', start_at: @time_period.first, end_at: @time_period.last, label: t('admin.dashboard.active_users'), href: admin_accounts_path(origin: 'local')
+    .dashboard__item
+      = options.react_admin_component :counter, measure: 'active_users', label: t('admin.dashboard.active_users'), href: admin_accounts_path(origin: 'local')
 
-  .dashboard__item
-    = react_admin_component :counter, measure: 'interactions', start_at: @time_period.first, end_at: @time_period.last, label: t('admin.dashboard.interactions')
+    .dashboard__item
+      = options.react_admin_component :counter, measure: 'interactions', label: t('admin.dashboard.interactions')
 
-  .dashboard__item
-    = react_admin_component :counter, measure: 'opened_reports', start_at: @time_period.first, end_at: @time_period.last, label: t('admin.dashboard.opened_reports'), href: admin_reports_path
+    .dashboard__item
+      = options.react_admin_component :counter, measure: 'opened_reports', label: t('admin.dashboard.opened_reports'), href: admin_reports_path
 
-  .dashboard__item
-    = react_admin_component :counter, measure: 'resolved_reports', start_at: @time_period.first, end_at: @time_period.last, label: t('admin.dashboard.resolved_reports'), href: admin_reports_path(resolved: '1')
+    .dashboard__item
+      = options.react_admin_component :counter, measure: 'resolved_reports', label: t('admin.dashboard.resolved_reports'), href: admin_reports_path(resolved: '1')
 
   .dashboard__item
     = link_to admin_reports_path, class: 'dashboard__quick-access' do
@@ -46,23 +47,24 @@
     = link_to admin_disputes_appeals_path(status: 'pending'), class: 'dashboard__quick-access' do
       %span= t('admin.dashboard.pending_appeals_html', count: @pending_appeals_count)
       = fa_icon 'chevron-right fw'
-  .dashboard__item
-    = react_admin_component :dimension, dimension: 'sources', start_at: @time_period.first, end_at: @time_period.last, limit: 8, label: t('admin.dashboard.sources')
+  - with_options start_at: @time_period.first, end_at: @time_period.last do |options|
+    .dashboard__item
+      = options.react_admin_component :dimension, dimension: 'sources', limit: 8, label: t('admin.dashboard.sources')
 
-  .dashboard__item
-    = react_admin_component :dimension, dimension: 'languages', start_at: @time_period.first, end_at: @time_period.last, limit: 8, label: t('admin.dashboard.top_languages')
+    .dashboard__item
+      = options.react_admin_component :dimension, dimension: 'languages', limit: 8, label: t('admin.dashboard.top_languages')
 
-  .dashboard__item
-    = react_admin_component :dimension, dimension: 'servers', start_at: @time_period.first, end_at: @time_period.last, limit: 8, label: t('admin.dashboard.top_servers')
+    .dashboard__item
+      = options.react_admin_component :dimension, dimension: 'servers', limit: 8, label: t('admin.dashboard.top_servers')
 
-  .dashboard__item.dashboard__item--span-double-column
-    = react_admin_component :retention, start_at: @time_period.last - 6.months, end_at: @time_period.last, frequency: 'month'
+    .dashboard__item.dashboard__item--span-double-column
+      = react_admin_component :retention, start_at: @time_period.last - 6.months, end_at: @time_period.last, frequency: 'month'
 
-  .dashboard__item.dashboard__item--span-double-row
-    = react_admin_component :trends, limit: 7
+    .dashboard__item.dashboard__item--span-double-row
+      = react_admin_component :trends, limit: 7
 
-  .dashboard__item
-    = react_admin_component :dimension, dimension: 'software_versions', start_at: @time_period.first, end_at: @time_period.last, limit: 4, label: t('admin.dashboard.software')
+    .dashboard__item
+      = options.react_admin_component :dimension, dimension: 'software_versions', limit: 4, label: t('admin.dashboard.software')
 
-  .dashboard__item
-    = react_admin_component :dimension, dimension: 'space_usage', start_at: @time_period.first, end_at: @time_period.last, limit: 3, label: t('admin.dashboard.space')
+    .dashboard__item
+      = options.react_admin_component :dimension, dimension: 'space_usage', limit: 3, label: t('admin.dashboard.space')

--- a/app/views/admin/instances/show.html.haml
+++ b/app/views/admin/instances/show.html.haml
@@ -13,22 +13,23 @@
       = t('admin.instances.totals_time_period_hint_html')
 
     .dashboard
-      .dashboard__item
-        = react_admin_component :counter, measure: 'instance_accounts', start_at: @time_period.first, end_at: @time_period.last, params: { domain: @instance.domain }, label: t('admin.instances.dashboard.instance_accounts_measure'), href: admin_accounts_path(origin: 'remote', by_domain: @instance.domain)
-      .dashboard__item
-        = react_admin_component :counter, measure: 'instance_statuses', start_at: @time_period.first, end_at: @time_period.last, params: { domain: @instance.domain }, label: t('admin.instances.dashboard.instance_statuses_measure')
-      .dashboard__item
-        = react_admin_component :counter, measure: 'instance_media_attachments', start_at: @time_period.first, end_at: @time_period.last, params: { domain: @instance.domain }, label: t('admin.instances.dashboard.instance_media_attachments_measure')
-      .dashboard__item
-        = react_admin_component :counter, measure: 'instance_follows', start_at: @time_period.first, end_at: @time_period.last, params: { domain: @instance.domain }, label: t('admin.instances.dashboard.instance_follows_measure')
-      .dashboard__item
-        = react_admin_component :counter, measure: 'instance_followers', start_at: @time_period.first, end_at: @time_period.last, params: { domain: @instance.domain }, label: t('admin.instances.dashboard.instance_followers_measure')
-      .dashboard__item
-        = react_admin_component :counter, measure: 'instance_reports', start_at: @time_period.first, end_at: @time_period.last, params: { domain: @instance.domain }, label: t('admin.instances.dashboard.instance_reports_measure'), href: admin_reports_path(by_target_domain: @instance.domain)
-      .dashboard__item
-        = react_admin_component :dimension, dimension: 'instance_accounts', start_at: @time_period.first, end_at: @time_period.last, params: { domain: @instance.domain }, limit: 8, label: t('admin.instances.dashboard.instance_accounts_dimension')
-      .dashboard__item
-        = react_admin_component :dimension, dimension: 'instance_languages', start_at: @time_period.first, end_at: @time_period.last, params: { domain: @instance.domain }, limit: 8, label: t('admin.instances.dashboard.instance_languages_dimension')
+      - with_options start_at: @time_period.first, end_at: @time_period.last, params: { domain: @instance.domain } do |options|
+        .dashboard__item
+          = options.react_admin_component :counter, measure: 'instance_accounts', label: t('admin.instances.dashboard.instance_accounts_measure'), href: admin_accounts_path(origin: 'remote', by_domain: @instance.domain)
+        .dashboard__item
+          = options.react_admin_component :counter, measure: 'instance_statuses', label: t('admin.instances.dashboard.instance_statuses_measure')
+        .dashboard__item
+          = options.react_admin_component :counter, measure: 'instance_media_attachments', label: t('admin.instances.dashboard.instance_media_attachments_measure')
+        .dashboard__item
+          = options.react_admin_component :counter, measure: 'instance_follows', label: t('admin.instances.dashboard.instance_follows_measure')
+        .dashboard__item
+          = options.react_admin_component :counter, measure: 'instance_followers', label: t('admin.instances.dashboard.instance_followers_measure')
+        .dashboard__item
+          = options.react_admin_component :counter, measure: 'instance_reports', label: t('admin.instances.dashboard.instance_reports_measure'), href: admin_reports_path(by_target_domain: @instance.domain)
+        .dashboard__item
+          = options.react_admin_component :dimension, dimension: 'instance_accounts', limit: 8, label: t('admin.instances.dashboard.instance_accounts_dimension')
+        .dashboard__item
+          = options.react_admin_component :dimension, dimension: 'instance_languages', limit: 8, label: t('admin.instances.dashboard.instance_languages_dimension')
   - else
     %p
       = t('admin.instances.unknown_instance')

--- a/app/views/admin/tags/show.html.haml
+++ b/app/views/admin/tags/show.html.haml
@@ -8,16 +8,17 @@
     = l(@time_period.last)
 
   .dashboard
-    .dashboard__item
-      = react_admin_component :counter, measure: 'tag_accounts', start_at: @time_period.first, end_at: @time_period.last, params: { id: @tag.id }, label: t('admin.trends.tags.dashboard.tag_accounts_measure'), href: tag_url(@tag), target: '_blank', rel: 'noopener noreferrer'
-    .dashboard__item
-      = react_admin_component :counter, measure: 'tag_uses', start_at: @time_period.first, end_at: @time_period.last, params: { id: @tag.id }, label: t('admin.trends.tags.dashboard.tag_uses_measure')
-    .dashboard__item
-      = react_admin_component :counter, measure: 'tag_servers', start_at: @time_period.first, end_at: @time_period.last, params: { id: @tag.id }, label: t('admin.trends.tags.dashboard.tag_servers_measure')
-    .dashboard__item
-      = react_admin_component :dimension, dimension: 'tag_servers', start_at: @time_period.first, end_at: @time_period.last, params: { id: @tag.id }, limit: 8, label: t('admin.trends.tags.dashboard.tag_servers_dimension')
-    .dashboard__item
-      = react_admin_component :dimension, dimension: 'tag_languages', start_at: @time_period.first, end_at: @time_period.last, params: { id: @tag.id }, limit: 8, label: t('admin.trends.tags.dashboard.tag_languages_dimension')
+    - with_options start_at: @time_period.first, end_at: @time_period.last, params: { id: @tag.id } do |options|
+      .dashboard__item
+        = options.react_admin_component :counter, measure: 'tag_accounts', label: t('admin.trends.tags.dashboard.tag_accounts_measure'), href: tag_url(@tag), target: '_blank', rel: 'noopener noreferrer'
+      .dashboard__item
+        = options.react_admin_component :counter, measure: 'tag_uses', label: t('admin.trends.tags.dashboard.tag_uses_measure')
+      .dashboard__item
+        = options.react_admin_component :counter, measure: 'tag_servers', label: t('admin.trends.tags.dashboard.tag_servers_measure')
+      .dashboard__item
+        = options.react_admin_component :dimension, dimension: 'tag_servers', limit: 8, label: t('admin.trends.tags.dashboard.tag_servers_dimension')
+      .dashboard__item
+        = options.react_admin_component :dimension, dimension: 'tag_languages', limit: 8, label: t('admin.trends.tags.dashboard.tag_languages_dimension')
     .dashboard__item
       = link_to admin_tag_path(@tag.id), class: ['dashboard__quick-access', @tag.usable? ? 'positive' : 'negative'] do
         - if @tag.usable?


### PR DESCRIPTION
The main dashboard view, along with the instances and tags views have this repetitive hash option building in the section which render the small metrics blocks on the admin pages.

Use `with_options` to DRY up the options.

I haven't fully explored this, but possible future refactor here would be to give the measure/dimension classes the ability to just tell the helpers/views what their relevant options needed to be (a `to_data_options` method or something - which the hleper could use to populate the html `data` attributes...)