### PR TITLE
Flatten `olm` section of context helper extension map

### DIFF
--- a/app/helpers/context_helper.rb
+++ b/app/helpers/context_helper.rb
@@ -24,12 +24,21 @@ module ContextHelper
     memorial: { 'toot' => 'http://joinmastodon.org/ns#', 'memorial' => 'toot:memorial' },
     voters_count: { 'toot' => 'http://joinmastodon.org/ns#', 'votersCount' => 'toot:votersCount' },
     olm: {
-      'toot' => 'http://joinmastodon.org/ns#', 'Device' => 'toot:Device', 'Ed25519Signature' => 'toot:Ed25519Signature', 'Ed25519Key' => 'toot:Ed25519Key', 'Curve25519Key' => 'toot:Curve25519Key', 'EncryptedMessage' => 'toot:EncryptedMessage', 'publicKeyBase64' => 'toot:publicKeyBase64', 'deviceId' => 'toot:deviceId',
+      'toot' => 'http://joinmastodon.org/ns#',
+      'Device' => 'toot:Device',
+      'Ed25519Signature' => 'toot:Ed25519Signature',
+      'Ed25519Key' => 'toot:Ed25519Key',
+      'Curve25519Key' => 'toot:Curve25519Key',
+      'EncryptedMessage' => 'toot:EncryptedMessage',
+      'publicKeyBase64' => 'toot:publicKeyBase64',
+      'deviceId' => 'toot:deviceId',
       'claim' => { '@type' => '@id', '@id' => 'toot:claim' },
       'fingerprintKey' => { '@type' => '@id', '@id' => 'toot:fingerprintKey' },
       'identityKey' => { '@type' => '@id', '@id' => 'toot:identityKey' },
       'devices' => { '@type' => '@id', '@id' => 'toot:devices' },
-      'messageFranking' => 'toot:messageFranking', 'messageType' => 'toot:messageType', 'cipherText' => 'toot:cipherText'
+      'messageFranking' => 'toot:messageFranking',
+      'messageType' => 'toot:messageType',
+      'cipherText' => 'toot:cipherText',
     },
     suspended: { 'toot' => 'http://joinmastodon.org/ns#', 'suspended' => 'toot:suspended' },
   }.freeze


### PR DESCRIPTION
Small formatting-only change, required by https://github.com/mastodon/mastodon/pull/29636