### PR TITLE
Replace `render_symbol` method with `inline_svg_tag` usage

### DIFF
--- a/app/helpers/branding_helper.rb
+++ b/app/helpers/branding_helper.rb
@@ -21,15 +21,4 @@ module BrandingHelper
   def render_logo
     image_pack_tag('logo.svg', alt: 'Mastodon', class: 'logo logo--icon')
   end
-
-  def render_symbol(version = :icon)
-    path = case version
-           when :icon
-             'logo-symbol-icon.svg'
-           when :wordmark
-             'logo-symbol-wordmark.svg'
-           end
-
-    render(file: Rails.root.join('app', 'javascript', 'images', path)).html_safe # rubocop:disable Rails/OutputSafety
-  end
 end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -44,5 +44,5 @@
     = content_for?(:content) ? yield(:content) : yield
 
     .logo-resources{ 'tabindex' => '-1', 'inert' => true, 'aria-hidden' => true }
-      = render_symbol :icon
-      = render_symbol :wordmark
+      = inline_svg_tag 'logo-symbol-icon.svg'
+      = inline_svg_tag 'logo-symbol-wordmark.svg'

--- a/app/views/layouts/embedded.html.haml
+++ b/app/views/layouts/embedded.html.haml
@@ -21,4 +21,4 @@
     = yield
 
     .logo-resources{ 'tabindex' => '-1', 'inert' => true, 'aria-hidden' => true }
-      = render_symbol :icon
+      = inline_svg_tag 'logo-symbol-icon.svg'


### PR DESCRIPTION
With https://github.com/mastodon/mastodon/pull/29612 merged, we can replace what is essentially a custom implementation of what the gem does with direct usage from gem. The output here (svg file read, output directly into html) should be the same.

Will continue to look for more of these in advance of material icons thing.