### PR TITLE
Slightly increase font weight of favorite/boost numbers in detailed statuses

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1688,6 +1688,7 @@ body > [data-popper-placement] {
 
   .animated-number {
     color: $secondary-text-color;
+    font-weight: 500;
   }
 }
 


### PR DESCRIPTION
Follow-up to #29585 to make it easier to scan for those numbers

## Before

![image](https://github.com/mastodon/mastodon/assets/384364/bbd8022b-4f83-43eb-a1b6-55fe26b3dd63)

## After

![image](https://github.com/mastodon/mastodon/assets/384364/69e6a4ac-1796-4ce8-acc7-28b99738a106)
