### PR TITLE
Reduce `LineLength` for `react_admin_component` helpers

### DIFF
--- a/.haml-lint.yml
+++ b/.haml-lint.yml
@@ -14,3 +14,5 @@ linters:
     enabled: true
   LineLength:
     max: 320
+  ViewLength:
+    max: 200 # Override default value of 100 inherited from rubocop

--- a/app/views/admin/dashboard/index.html.haml
+++ b/app/views/admin/dashboard/index.html.haml
@@ -16,19 +16,43 @@
 
 .dashboard
   .dashboard__item
-    = react_admin_component :counter, measure: 'new_users', start_at: @time_period.first, end_at: @time_period.last, label: t('admin.dashboard.new_users'), href: admin_accounts_path(origin: 'local')
+    = react_admin_component :counter,
+                            end_at: @time_period.last,
+                            href: admin_accounts_path(origin: 'local'),
+                            label: t('admin.dashboard.new_users'),
+                            measure: 'new_users',
+                            start_at: @time_period.first
 
   .dashboard__item
-    = react_admin_component :counter, measure: 'active_users', start_at: @time_period.first, end_at: @time_period.last, label: t('admin.dashboard.active_users'), href: admin_accounts_path(origin: 'local')
+    = react_admin_component :counter,
+                            end_at: @time_period.last,
+                            href: admin_accounts_path(origin: 'local'),
+                            label: t('admin.dashboard.active_users'),
+                            measure: 'active_users',
+                            start_at: @time_period.first
 
   .dashboard__item
-    = react_admin_component :counter, measure: 'interactions', start_at: @time_period.first, end_at: @time_period.last, label: t('admin.dashboard.interactions')
+    = react_admin_component :counter,
+                            end_at: @time_period.last,
+                            label: t('admin.dashboard.interactions'),
+                            measure: 'interactions',
+                            start_at: @time_period.first
 
   .dashboard__item
-    = react_admin_component :counter, measure: 'opened_reports', start_at: @time_period.first, end_at: @time_period.last, label: t('admin.dashboard.opened_reports'), href: admin_reports_path
+    = react_admin_component :counter,
+                            end_at: @time_period.last,
+                            href: admin_reports_path,
+                            label: t('admin.dashboard.opened_reports'),
+                            measure: 'opened_reports',
+                            start_at: @time_period.first
 
   .dashboard__item
-    = react_admin_component :counter, measure: 'resolved_reports', start_at: @time_period.first, end_at: @time_period.last, label: t('admin.dashboard.resolved_reports'), href: admin_reports_path(resolved: '1')
+    = react_admin_component :counter,
+                            end_at: @time_period.last,
+                            href: admin_reports_path(resolved: '1'),
+                            label: t('admin.dashboard.resolved_reports'),
+                            measure: 'resolved_reports',
+                            start_at: @time_period.first
 
   .dashboard__item
     = link_to admin_reports_path, class: 'dashboard__quick-access' do
@@ -47,22 +71,51 @@
       %span= t('admin.dashboard.pending_appeals_html', count: @pending_appeals_count)
       = fa_icon 'chevron-right fw'
   .dashboard__item
-    = react_admin_component :dimension, dimension: 'sources', start_at: @time_period.first, end_at: @time_period.last, limit: 8, label: t('admin.dashboard.sources')
+    = react_admin_component :dimension,
+                            dimension: 'sources',
+                            end_at: @time_period.last,
+                            label: t('admin.dashboard.sources'),
+                            limit: 8,
+                            start_at: @time_period.first
 
   .dashboard__item
-    = react_admin_component :dimension, dimension: 'languages', start_at: @time_period.first, end_at: @time_period.last, limit: 8, label: t('admin.dashboard.top_languages')
+    = react_admin_component :dimension,
+                            dimension: 'languages',
+                            end_at: @time_period.last,
+                            label: t('admin.dashboard.top_languages'),
+                            limit: 8,
+                            start_at: @time_period.first
 
   .dashboard__item
-    = react_admin_component :dimension, dimension: 'servers', start_at: @time_period.first, end_at: @time_period.last, limit: 8, label: t('admin.dashboard.top_servers')
+    = react_admin_component :dimension,
+                            dimension: 'servers',
+                            end_at: @time_period.last,
+                            label: t('admin.dashboard.top_servers'),
+                            limit: 8,
+                            start_at: @time_period.first
 
   .dashboard__item.dashboard__item--span-double-column
-    = react_admin_component :retention, start_at: @time_period.last - 6.months, end_at: @time_period.last, frequency: 'month'
+    = react_admin_component :retention,
+                            end_at: @time_period.last,
+                            frequency: 'month',
+                            start_at: @time_period.last - 6.months
 
   .dashboard__item.dashboard__item--span-double-row
-    = react_admin_component :trends, limit: 7
+    = react_admin_component :trends,
+                            limit: 7
 
   .dashboard__item
-    = react_admin_component :dimension, dimension: 'software_versions', start_at: @time_period.first, end_at: @time_period.last, limit: 4, label: t('admin.dashboard.software')
+    = react_admin_component :dimension,
+                            dimension: 'software_versions',
+                            end_at: @time_period.last,
+                            label: t('admin.dashboard.software'),
+                            limit: 4,
+                            start_at: @time_period.first
 
   .dashboard__item
-    = react_admin_component :dimension, dimension: 'space_usage', start_at: @time_period.first, end_at: @time_period.last, limit: 3, label: t('admin.dashboard.space')
+    = react_admin_component :dimension,
+                            dimension: 'space_usage',
+                            end_at: @time_period.last,
+                            label: t('admin.dashboard.space'),
+                            limit: 3,
+                            start_at: @time_period.first

--- a/app/views/admin/domain_blocks/confirm_suspension.html.haml
+++ b/app/views/admin/domain_blocks/confirm_suspension.html.haml
@@ -14,7 +14,8 @@
 
   %hr.spacer
 
-  = react_admin_component :impact_report, domain: @domain_block.domain
+  = react_admin_component :impact_report,
+                          domain: @domain_block.domain
 
   .actions
     = link_to t('.cancel'), admin_instances_path, class: 'button button-tertiary'

--- a/app/views/admin/instances/show.html.haml
+++ b/app/views/admin/instances/show.html.haml
@@ -14,21 +14,66 @@
 
     .dashboard
       .dashboard__item
-        = react_admin_component :counter, measure: 'instance_accounts', start_at: @time_period.first, end_at: @time_period.last, params: { domain: @instance.domain }, label: t('admin.instances.dashboard.instance_accounts_measure'), href: admin_accounts_path(origin: 'remote', by_domain: @instance.domain)
+        = react_admin_component :counter,
+                                end_at: @time_period.last,
+                                href: admin_accounts_path(origin: 'remote', by_domain: @instance.domain),
+                                label: t('admin.instances.dashboard.instance_accounts_measure'),
+                                measure: 'instance_accounts',
+                                params: { domain: @instance.domain },
+                                start_at: @time_period.first
       .dashboard__item
-        = react_admin_component :counter, measure: 'instance_statuses', start_at: @time_period.first, end_at: @time_period.last, params: { domain: @instance.domain }, label: t('admin.instances.dashboard.instance_statuses_measure')
+        = react_admin_component :counter,
+                                end_at: @time_period.last,
+                                label: t('admin.instances.dashboard.instance_statuses_measure'),
+                                measure: 'instance_statuses',
+                                params: { domain: @instance.domain },
+                                start_at: @time_period.first
       .dashboard__item
-        = react_admin_component :counter, measure: 'instance_media_attachments', start_at: @time_period.first, end_at: @time_period.last, params: { domain: @instance.domain }, label: t('admin.instances.dashboard.instance_media_attachments_measure')
+        = react_admin_component :counter,
+                                end_at: @time_period.last,
+                                label: t('admin.instances.dashboard.instance_media_attachments_measure'),
+                                measure: 'instance_media_attachments',
+                                params: { domain: @instance.domain },
+                                start_at: @time_period.first
       .dashboard__item
-        = react_admin_component :counter, measure: 'instance_follows', start_at: @time_period.first, end_at: @time_period.last, params: { domain: @instance.domain }, label: t('admin.instances.dashboard.instance_follows_measure')
+        = react_admin_component :counter,
+                                end_at: @time_period.last,
+                                label: t('admin.instances.dashboard.instance_follows_measure'),
+                                measure: 'instance_follows',
+                                params: { domain: @instance.domain },
+                                start_at: @time_period.first
       .dashboard__item
-        = react_admin_component :counter, measure: 'instance_followers', start_at: @time_period.first, end_at: @time_period.last, params: { domain: @instance.domain }, label: t('admin.instances.dashboard.instance_followers_measure')
+        = react_admin_component :counter,
+                                end_at: @time_period.last,
+                                label: t('admin.instances.dashboard.instance_followers_measure'),
+                                measure: 'instance_followers',
+                                params: { domain: @instance.domain },
+                                start_at: @time_period.first
       .dashboard__item
-        = react_admin_component :counter, measure: 'instance_reports', start_at: @time_period.first, end_at: @time_period.last, params: { domain: @instance.domain }, label: t('admin.instances.dashboard.instance_reports_measure'), href: admin_reports_path(by_target_domain: @instance.domain)
+        = react_admin_component :counter,
+                                end_at: @time_period.last,
+                                href: admin_reports_path(by_target_domain: @instance.domain),
+                                label: t('admin.instances.dashboard.instance_reports_measure'),
+                                measure: 'instance_reports',
+                                params: { domain: @instance.domain },
+                                start_at: @time_period.first
       .dashboard__item
-        = react_admin_component :dimension, dimension: 'instance_accounts', start_at: @time_period.first, end_at: @time_period.last, params: { domain: @instance.domain }, limit: 8, label: t('admin.instances.dashboard.instance_accounts_dimension')
+        = react_admin_component :dimension,
+                                dimension: 'instance_accounts',
+                                end_at: @time_period.last,
+                                label: t('admin.instances.dashboard.instance_accounts_dimension'),
+                                limit: 8,
+                                params: { domain: @instance.domain },
+                                start_at: @time_period.first
       .dashboard__item
-        = react_admin_component :dimension, dimension: 'instance_languages', start_at: @time_period.first, end_at: @time_period.last, params: { domain: @instance.domain }, limit: 8, label: t('admin.instances.dashboard.instance_languages_dimension')
+        = react_admin_component :dimension,
+                                dimension: 'instance_languages',
+                                end_at: @time_period.last,
+                                label: t('admin.instances.dashboard.instance_languages_dimension'),
+                                limit: 8,
+                                params: { domain: @instance.domain },
+                                start_at: @time_period.first
+
   - else
     %p
       = t('admin.instances.unknown_instance')

--- a/app/views/admin/reports/show.html.haml
+++ b/app/views/admin/reports/show.html.haml
@@ -20,7 +20,11 @@
 
 %p= t 'admin.reports.category_description_html'
 
-= react_admin_component :report_reason_selector, id: @report.id, category: @report.category, rule_ids: @report.rule_ids&.map(&:to_s), disabled: @report.action_taken?
+= react_admin_component :report_reason_selector,
+                        category: @report.category,
+                        disabled: @report.action_taken?,
+                        id: @report.id,
+                        rule_ids: @report.rule_ids&.map(&:to_s)
 
 - if @report.comment.present?
   = render 'admin/reports/comment', report: @report

--- a/app/views/admin/tags/show.html.haml
+++ b/app/views/admin/tags/show.html.haml
@@ -9,15 +9,45 @@
 
   .dashboard
     .dashboard__item
-      = react_admin_component :counter, measure: 'tag_accounts', start_at: @time_period.first, end_at: @time_period.last, params: { id: @tag.id }, label: t('admin.trends.tags.dashboard.tag_accounts_measure'), href: tag_url(@tag), target: '_blank', rel: 'noopener noreferrer'
+      = react_admin_component :counter,
+                              end_at: @time_period.last,
+                              href: tag_url(@tag),
+                              label: t('admin.trends.tags.dashboard.tag_accounts_measure'),
+                              measure: 'tag_accounts',
+                              params: { id: @tag.id },
+                              rel: 'noopener noreferrer',
+                              start_at: @time_period.first,
+                              target: '_blank'
     .dashboard__item
-      = react_admin_component :counter, measure: 'tag_uses', start_at: @time_period.first, end_at: @time_period.last, params: { id: @tag.id }, label: t('admin.trends.tags.dashboard.tag_uses_measure')
+      = react_admin_component :counter,
+                              end_at: @time_period.last,
+                              label: t('admin.trends.tags.dashboard.tag_uses_measure'),
+                              measure: 'tag_uses',
+                              params: { id: @tag.id },
+                              start_at: @time_period.first
     .dashboard__item
-      = react_admin_component :counter, measure: 'tag_servers', start_at: @time_period.first, end_at: @time_period.last, params: { id: @tag.id }, label: t('admin.trends.tags.dashboard.tag_servers_measure')
+      = react_admin_component :counter,
+                              end_at: @time_period.last,
+                              label: t('admin.trends.tags.dashboard.tag_servers_measure'),
+                              measure: 'tag_servers',
+                              params: { id: @tag.id },
+                              start_at: @time_period.first
     .dashboard__item
-      = react_admin_component :dimension, dimension: 'tag_servers', start_at: @time_period.first, end_at: @time_period.last, params: { id: @tag.id }, limit: 8, label: t('admin.trends.tags.dashboard.tag_servers_dimension')
+      = react_admin_component :dimension,
+                              dimension: 'tag_servers',
+                              end_at: @time_period.last,
+                              label: t('admin.trends.tags.dashboard.tag_servers_dimension'),
+                              limit: 8,
+                              params: { id: @tag.id },
+                              start_at: @time_period.first
     .dashboard__item
-      = react_admin_component :dimension, dimension: 'tag_languages', start_at: @time_period.first, end_at: @time_period.last, params: { id: @tag.id }, limit: 8, label: t('admin.trends.tags.dashboard.tag_languages_dimension')
+      = react_admin_component :dimension,
+                              dimension: 'tag_languages',
+                              end_at: @time_period.last,
+                              label: t('admin.trends.tags.dashboard.tag_languages_dimension'),
+                              limit: 8,
+                              params: { id: @tag.id },
+                              start_at: @time_period.first
     .dashboard__item
       = link_to admin_tag_path(@tag.id), class: ['dashboard__quick-access', @tag.usable? ? 'positive' : 'negative'] do
         - if @tag.usable?


### PR DESCRIPTION
Two things in here:

- Basically repeating what we did in https://github.com/mastodon/mastodon/pull/28694 and elsewhere for the `react_component` formatting in views, but this time for `react_admin_component`
- Update haml lint config to allow longer (ie, more lines, not more columns) views. The default value here inherits from rubocop and is somewhat challenging to stay in for some longer views.

Dependency of https://github.com/mastodon/mastodon/pull/29636