### PR TITLE
Fix emoji picker dropdown background and borders

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -4847,6 +4847,11 @@ a.status-card {
   position: relative;
   margin-top: 5px;
   z-index: 2;
+  background: var(--dropdown-background-color);
+  backdrop-filter: var(--background-filter);
+  border: 1px solid var(--dropdown-border-color);
+  box-shadow: var(--dropdown-shadow);
+  border-radius: 5px;
 
   .emoji-mart-scroll {
     transition: opacity 200ms ease;

--- a/app/javascript/styles/mastodon/emoji_picker.scss
+++ b/app/javascript/styles/mastodon/emoji_picker.scss
@@ -14,20 +14,8 @@
 }
 
 .emoji-mart-bar {
-  border: 0 solid var(--dropdown-border-color);
-
   &:first-child {
-    border-bottom-width: 1px;
-    border-top-left-radius: 5px;
-    border-top-right-radius: 5px;
     background: var(--dropdown-border-color);
-  }
-
-  &:last-child {
-    border-top-width: 1px;
-    border-bottom-left-radius: 5px;
-    border-bottom-right-radius: 5px;
-    display: none;
   }
 }
 
@@ -94,7 +82,6 @@
   height: 270px;
   max-height: 35vh;
   padding: 0 6px 6px;
-  background: var(--dropdown-background-color);
   will-change: transform;
 
   &::-webkit-scrollbar-track:hover,
@@ -106,7 +93,6 @@
 .emoji-mart-search {
   padding: 10px;
   padding-inline-end: 45px;
-  background: var(--dropdown-background-color);
   position: relative;
 
   input {
@@ -195,7 +181,6 @@
     width: 100%;
     font-weight: 500;
     padding: 5px 6px;
-    background: var(--dropdown-background-color);
   }
 }
 


### PR DESCRIPTION
Follow-up to #29522

## Before

![image](https://github.com/mastodon/mastodon/assets/384364/39478b2a-8eb9-4a9a-95c2-8eb664f41a63)
![image](https://github.com/mastodon/mastodon/assets/384364/9c352f38-f4d6-4da9-b48a-d613e7e23258)

## After

![image](https://github.com/mastodon/mastodon/assets/384364/502e5da6-5f04-4570-8d3f-9211e436617a)
![image](https://github.com/mastodon/mastodon/assets/384364/63f06711-9ec6-4a9d-b8d1-65f60d411cb6)