### PR TITLE
Fix blockquote color in reply indicator

### DIFF
--- a/app/javascript/styles/mastodon/rich_text.scss
+++ b/app/javascript/styles/mastodon/rich_text.scss
@@ -1,5 +1,6 @@
 .status__content__text,
 .e-content,
+.edit-indicator__content,
 .reply-indicator__content {
   pre,
   blockquote {
@@ -53,12 +54,5 @@
 
   ol {
     list-style-type: decimal;
-  }
-}
-
-.reply-indicator__content {
-  blockquote {
-    border-left-color: $inverted-text-color;
-    color: $inverted-text-color;
   }
 }


### PR DESCRIPTION
Also fix advanced formatting in edit indicator.

## Before

![image](https://github.com/mastodon/mastodon/assets/384364/f2e5083c-25af-4096-861c-29288d5c9bb4)

## After

![image](https://github.com/mastodon/mastodon/assets/384364/b1631e77-ddad-46eb-90e5-a2140206c10b)