### PR TITLE
Simplify basic presence validations

### DIFF
--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -64,14 +64,7 @@ RSpec.describe Announcement do
   end
 
   describe 'Validations' do
-    describe 'text' do
-      it 'validates presence of attribute' do
-        record = Fabricate.build(:announcement, text: nil)
-
-        expect(record).to_not be_valid
-        expect(record.errors[:text]).to be_present
-      end
-    end
+    it { is_expected.to validate_presence_of(:text) }
 
     describe 'ends_at' do
       it 'validates presence when starts_at is present' do

--- a/spec/models/block_spec.rb
+++ b/spec/models/block_spec.rb
@@ -4,17 +4,8 @@ require 'rails_helper'
 
 RSpec.describe Block do
   describe 'validations' do
-    it 'is invalid without an account' do
-      block = Fabricate.build(:block, account: nil)
-      block.valid?
-      expect(block).to model_have_error_on_field(:account)
-    end
-
-    it 'is invalid without a target_account' do
-      block = Fabricate.build(:block, target_account: nil)
-      block.valid?
-      expect(block).to model_have_error_on_field(:target_account)
-    end
+    it { is_expected.to belong_to(:account) }
+    it { is_expected.to belong_to(:target_account) }
   end
 
   it 'removes blocking cache after creation' do

--- a/spec/models/block_spec.rb
+++ b/spec/models/block_spec.rb
@@ -4,8 +4,8 @@ require 'rails_helper'
 
 RSpec.describe Block do
   describe 'validations' do
-    it { is_expected.to belong_to(:account) }
-    it { is_expected.to belong_to(:target_account) }
+    it { is_expected.to belong_to(:account).required }
+    it { is_expected.to belong_to(:target_account).required }
   end
 
   it 'removes blocking cache after creation' do

--- a/spec/models/custom_emoji_category_spec.rb
+++ b/spec/models/custom_emoji_category_spec.rb
@@ -4,11 +4,6 @@ require 'rails_helper'
 
 RSpec.describe CustomEmojiCategory do
   describe 'validations' do
-    it 'validates name presence' do
-      record = described_class.new(name: nil)
-
-      expect(record).to_not be_valid
-      expect(record).to model_have_error_on_field(:name)
-    end
+    it { is_expected.to validate_presence_of(:name) }
   end
 end

--- a/spec/models/custom_filter_spec.rb
+++ b/spec/models/custom_filter_spec.rb
@@ -4,19 +4,8 @@ require 'rails_helper'
 
 RSpec.describe CustomFilter do
   describe 'Validations' do
-    it 'requires presence of title' do
-      record = described_class.new(title: '')
-      record.valid?
-
-      expect(record).to model_have_error_on_field(:title)
-    end
-
-    it 'requires presence of context' do
-      record = described_class.new(context: nil)
-      record.valid?
-
-      expect(record).to model_have_error_on_field(:context)
-    end
+    it { is_expected.to validate_presence_of(:title) }
+    it { is_expected.to validate_presence_of(:context) }
 
     it 'requires non-empty of context' do
       record = described_class.new(context: [])

--- a/spec/models/domain_allow_spec.rb
+++ b/spec/models/domain_allow_spec.rb
@@ -4,11 +4,7 @@ require 'rails_helper'
 
 RSpec.describe DomainAllow do
   describe 'Validations' do
-    it 'is invalid without a domain' do
-      domain_allow = Fabricate.build(:domain_allow, domain: nil)
-      domain_allow.valid?
-      expect(domain_allow).to model_have_error_on_field(:domain)
-    end
+    it { is_expected.to validate_presence_of(:domain) }
 
     it 'is invalid if the same normalized domain already exists' do
       _domain_allow = Fabricate(:domain_allow, domain: 'にゃん')

--- a/spec/models/domain_block_spec.rb
+++ b/spec/models/domain_block_spec.rb
@@ -4,11 +4,7 @@ require 'rails_helper'
 
 RSpec.describe DomainBlock do
   describe 'validations' do
-    it 'is invalid without a domain' do
-      domain_block = Fabricate.build(:domain_block, domain: nil)
-      domain_block.valid?
-      expect(domain_block).to model_have_error_on_field(:domain)
-    end
+    it { is_expected.to validate_presence_of(:domain) }
 
     it 'is invalid if the same normalized domain already exists' do
       _domain_block = Fabricate(:domain_block, domain: 'にゃん')

--- a/spec/models/follow_spec.rb
+++ b/spec/models/follow_spec.rb
@@ -9,17 +9,8 @@ RSpec.describe Follow do
   describe 'validations' do
     subject { described_class.new(account: alice, target_account: bob, rate_limit: true) }
 
-    it 'is invalid without an account' do
-      follow = Fabricate.build(:follow, account: nil)
-      follow.valid?
-      expect(follow).to model_have_error_on_field(:account)
-    end
-
-    it 'is invalid without a target_account' do
-      follow = Fabricate.build(:follow, target_account: nil)
-      follow.valid?
-      expect(follow).to model_have_error_on_field(:target_account)
-    end
+    it { is_expected.to belong_to(:account) }
+    it { is_expected.to belong_to(:target_account) }
 
     it 'is invalid if account already follows too many people' do
       alice.update(following_count: FollowLimitValidator::LIMIT)

--- a/spec/models/follow_spec.rb
+++ b/spec/models/follow_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Follow do
   describe 'validations' do
     subject { described_class.new(account: alice, target_account: bob, rate_limit: true) }
 
-    it { is_expected.to belong_to(:account) }
-    it { is_expected.to belong_to(:target_account) }
+    it { is_expected.to belong_to(:account).required }
+    it { is_expected.to belong_to(:target_account).required }
 
     it 'is invalid if account already follows too many people' do
       alice.update(following_count: FollowLimitValidator::LIMIT)

--- a/spec/models/import_spec.rb
+++ b/spec/models/import_spec.rb
@@ -3,19 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Import do
-  let(:account) { Fabricate(:account) }
-  let(:type) { 'following' }
-  let(:data) { attachment_fixture('imports.txt') }
-
-  describe 'validations' do
-    it 'is invalid without an type' do
-      import = described_class.create(account: account, data: data)
-      expect(import).to model_have_error_on_field(:type)
-    end
-
-    it 'is invalid without a data' do
-      import = described_class.create(account: account, type: type)
-      expect(import).to model_have_error_on_field(:data)
-    end
+  describe 'Validations' do
+    it { is_expected.to validate_presence_of(:type) }
+    it { is_expected.to validate_presence_of(:data) }
   end
 end

--- a/spec/models/ip_block_spec.rb
+++ b/spec/models/ip_block_spec.rb
@@ -4,19 +4,8 @@ require 'rails_helper'
 
 RSpec.describe IpBlock do
   describe 'validations' do
-    it 'validates ip presence', :aggregate_failures do
-      ip_block = described_class.new(ip: nil, severity: :no_access)
-
-      expect(ip_block).to_not be_valid
-      expect(ip_block).to model_have_error_on_field(:ip)
-    end
-
-    it 'validates severity presence', :aggregate_failures do
-      ip_block = described_class.new(ip: '127.0.0.1', severity: nil)
-
-      expect(ip_block).to_not be_valid
-      expect(ip_block).to model_have_error_on_field(:severity)
-    end
+    it { is_expected.to validate_presence_of(:ip) }
+    it { is_expected.to validate_presence_of(:severity) }
 
     it 'validates ip uniqueness', :aggregate_failures do
       described_class.create!(ip: '127.0.0.1', severity: :no_access)

--- a/spec/models/marker_spec.rb
+++ b/spec/models/marker_spec.rb
@@ -3,14 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Marker do
-  describe 'validations' do
-    describe 'timeline' do
-      it 'must be included in valid list' do
-        record = described_class.new(timeline: 'not real timeline')
-
-        expect(record).to_not be_valid
-        expect(record).to model_have_error_on_field(:timeline)
-      end
-    end
+  describe 'Validations' do
+    it { is_expected.to validate_inclusion_of(:timeline).in_array(described_class::TIMELINES) }
   end
 end

--- a/spec/models/media_attachment_spec.rb
+++ b/spec/models/media_attachment_spec.rb
@@ -257,12 +257,7 @@ RSpec.describe MediaAttachment, :attachment_processing do
     end
   end
 
-  it 'is invalid without file' do
-    media = described_class.new
-
-    expect(media.valid?).to be false
-    expect(media).to model_have_error_on_field(:file)
-  end
+  it { is_expected.to validate_presence_of(:file) }
 
   describe 'size limit validation' do
     it 'rejects video files that are too large' do

--- a/spec/models/mention_spec.rb
+++ b/spec/models/mention_spec.rb
@@ -4,16 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Mention do
   describe 'validations' do
-    it 'is invalid without an account' do
-      mention = Fabricate.build(:mention, account: nil)
-      mention.valid?
-      expect(mention).to model_have_error_on_field(:account)
-    end
-
-    it 'is invalid without a status' do
-      mention = Fabricate.build(:mention, status: nil)
-      mention.valid?
-      expect(mention).to model_have_error_on_field(:status)
-    end
+    it { is_expected.to belong_to(:account) }
+    it { is_expected.to belong_to(:status) }
   end
 end

--- a/spec/models/mention_spec.rb
+++ b/spec/models/mention_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Mention do
   describe 'validations' do
-    it { is_expected.to belong_to(:account) }
-    it { is_expected.to belong_to(:status) }
+    it { is_expected.to belong_to(:account).required }
+    it { is_expected.to belong_to(:status).required }
   end
 end

--- a/spec/models/poll_spec.rb
+++ b/spec/models/poll_spec.rb
@@ -32,12 +32,9 @@ RSpec.describe Poll do
 
   describe 'validations' do
     context 'when not valid' do
-      let(:poll) { Fabricate.build(:poll, expires_at: nil) }
+      subject { Fabricate.build(:poll) }
 
-      it 'is invalid without an expire date' do
-        poll.valid?
-        expect(poll).to model_have_error_on_field(:expires_at)
-      end
+      it { is_expected.to validate_presence_of(:expires_at) }
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -32,11 +32,7 @@ RSpec.describe User do
   end
 
   describe 'validations' do
-    it 'is invalid without an account' do
-      user = Fabricate.build(:user, account: nil)
-      user.valid?
-      expect(user).to model_have_error_on_field(:account)
-    end
+    it { is_expected.to belong_to(:account) }
 
     it 'is invalid without a valid email' do
       user = Fabricate.build(:user, email: 'john@')

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe User do
   end
 
   describe 'validations' do
-    it { is_expected.to belong_to(:account) }
+    it { is_expected.to belong_to(:account).required }
 
     it 'is invalid without a valid email' do
       user = Fabricate.build(:user, email: 'john@')

--- a/spec/models/webauthn_credential_spec.rb
+++ b/spec/models/webauthn_credential_spec.rb
@@ -4,37 +4,10 @@ require 'rails_helper'
 
 RSpec.describe WebauthnCredential do
   describe 'validations' do
-    it 'is invalid without an external id' do
-      webauthn_credential = Fabricate.build(:webauthn_credential, external_id: nil)
-
-      webauthn_credential.valid?
-
-      expect(webauthn_credential).to model_have_error_on_field(:external_id)
-    end
-
-    it 'is invalid without a public key' do
-      webauthn_credential = Fabricate.build(:webauthn_credential, public_key: nil)
-
-      webauthn_credential.valid?
-
-      expect(webauthn_credential).to model_have_error_on_field(:public_key)
-    end
-
-    it 'is invalid without a nickname' do
-      webauthn_credential = Fabricate.build(:webauthn_credential, nickname: nil)
-
-      webauthn_credential.valid?
-
-      expect(webauthn_credential).to model_have_error_on_field(:nickname)
-    end
-
-    it 'is invalid without a sign_count' do
-      webauthn_credential = Fabricate.build(:webauthn_credential, sign_count: nil)
-
-      webauthn_credential.valid?
-
-      expect(webauthn_credential).to model_have_error_on_field(:sign_count)
-    end
+    it { is_expected.to validate_presence_of(:external_id) }
+    it { is_expected.to validate_presence_of(:public_key) }
+    it { is_expected.to validate_presence_of(:nickname) }
+    it { is_expected.to validate_presence_of(:sign_count) }
 
     it 'is invalid if already exist a webauthn credential with the same external id' do
       Fabricate(:webauthn_credential, external_id: '_Typ0ygudDnk9YUVWLQayw')

--- a/spec/models/webhook_spec.rb
+++ b/spec/models/webhook_spec.rb
@@ -6,12 +6,7 @@ RSpec.describe Webhook do
   let(:webhook) { Fabricate(:webhook) }
 
   describe 'Validations' do
-    it 'requires presence of events' do
-      record = described_class.new(events: nil)
-      record.valid?
-
-      expect(record).to model_have_error_on_field(:events)
-    end
+    it { is_expected.to validate_presence_of(:events) }
 
     it 'requires non-empty events value' do
       record = described_class.new(events: [])


### PR DESCRIPTION
I noticed throughout many of the model specs we are doing this same pattern of setting up a valid factory with a missing attribute, and then running validations and using a custom matcher to check for errors on the attribute. This PR changes:

- Add the `shoulda-matchers` gem, configure it for rspec integration
- Do a once-over on model specs to replace the very most basic presence validations with one-liners using the gem matcher

There are many more that are slightly more complicated and may need closer review -- for this PR I tried to stick to just the very straightforward one-to-one simplifications, and just did presence validations. Will do more in future PRs -- there are a bunch of obvious "allow values" and "inclusion" type replacements that will have a similar line count reduction, while preserving coverage.

I also noticed many of the model specs have a validation spec which is basically just building a factory and confirm it's valid ... but we actually have a separate fabricator spec which does this for ALL the fabricators -- I may do a once over to try to remove what are effectively duplicate specs for that scenario.