### PR TITLE
Remove duplicate fabricator validity checks

### DIFF
--- a/spec/models/import_spec.rb
+++ b/spec/models/import_spec.rb
@@ -8,11 +8,6 @@ RSpec.describe Import do
   let(:data) { attachment_fixture('imports.txt') }
 
   describe 'validations' do
-    it 'has a valid parameters' do
-      import = described_class.create(account: account, type: type, data: data)
-      expect(import).to be_valid
-    end
-
     it 'is invalid without an type' do
       import = described_class.create(account: account, data: data)
       expect(import).to model_have_error_on_field(:type)

--- a/spec/models/poll_spec.rb
+++ b/spec/models/poll_spec.rb
@@ -31,14 +31,6 @@ describe Poll do
   end
 
   describe 'validations' do
-    context 'when valid' do
-      let(:poll) { Fabricate.build(:poll) }
-
-      it 'is valid with valid attributes' do
-        expect(poll).to be_valid
-      end
-    end
-
     context 'when not valid' do
       let(:poll) { Fabricate.build(:poll, expires_at: nil) }
 


### PR DESCRIPTION
As noted here https://github.com/mastodon/mastodon/pull/29664#issue-2197880806 these are a few specs which are effectively duplicating the check we are already doing in this spec https://github.com/mastodon/mastodon/blob/v4.2.8/spec/fabrication/fabricators_spec.rb

Unrelated -- should we delete `Import` at this point? There's an almost one year old note in there that the model is not needed/used anymore .. I assume its only still around to not break jobs in sidekiq queues, which presumably by now are wound down?