### PR TITLE
Use `has_many through` instead of `delegate` for ARSE<>SR

### DIFF
--- a/app/models/account_relationship_severance_event.rb
+++ b/app/models/account_relationship_severance_event.rb
@@ -16,8 +16,9 @@ class AccountRelationshipSeveranceEvent < ApplicationRecord
   belongs_to :account
   belongs_to :relationship_severance_event
 
-  delegate :severed_relationships,
-           :type,
+  has_many :severed_relationships, through: :relationship_severance_event
+
+  delegate :type,
            :target_name,
            :purged,
            :purged?,


### PR DESCRIPTION
I think this is functionally equivalent (?) and uses fewer queries in the most common use cases:

- Calling `severed_relationships.first` on an instance of the class - just one query in this PR, but two in main (one for the RSE, one for the SR
- Calling the `set_relationships_count!` method - three queries in main (load the RSE, load the Account, load the SR); but just two in this branch (load Account, then load SR directly)