### PR TITLE
Use existing `SeveredRelationship.about_local_account` scope in more places

### DIFF
--- a/app/controllers/severed_relationships_controller.rb
+++ b/app/controllers/severed_relationships_controller.rb
@@ -33,7 +33,7 @@ class SeveredRelationshipsController < ApplicationController
 
   def following_data
     CSV.generate(headers: ['Account address', 'Show boosts', 'Notify on new posts', 'Languages'], write_headers: true) do |csv|
-      @event.severed_relationships.active.where(local_account: current_account).includes(:remote_account).reorder(id: :desc).each do |follow|
+      @event.severed_relationships.active.about_local_account(current_account).includes(:remote_account).reorder(id: :desc).each do |follow|
         csv << [acct(follow.target_account), follow.show_reblogs, follow.notify, follow.languages&.join(', ')]
       end
     end
@@ -41,7 +41,7 @@ class SeveredRelationshipsController < ApplicationController
 
   def followers_data
     CSV.generate(headers: ['Account address'], write_headers: true) do |csv|
-      @event.severed_relationships.passive.where(local_account: current_account).includes(:remote_account).reorder(id: :desc).each do |follow|
+      @event.severed_relationships.passive.about_local_account(current_account).includes(:remote_account).reorder(id: :desc).each do |follow|
         csv << [acct(follow.account)]
       end
     end

--- a/app/models/account_relationship_severance_event.rb
+++ b/app/models/account_relationship_severance_event.rb
@@ -29,6 +29,6 @@ class AccountRelationshipSeveranceEvent < ApplicationRecord
   private
 
   def set_relationships_count!
-    self.relationships_count = severed_relationships.where(local_account: account).count
+    self.relationships_count = severed_relationships.about_local_account(account).count
   end
 end

--- a/app/models/concerns/account/merging.rb
+++ b/app/models/concerns/account/merging.rb
@@ -48,13 +48,13 @@ module Account::Merging
       record.update_attribute(:account_warning_id, id)
     end
 
-    SeveredRelationship.where(local_account_id: other_account.id).reorder(nil).find_each do |record|
+    SeveredRelationship.about_local_account(other_account).reorder(nil).find_each do |record|
       record.update_attribute(:local_account_id, id)
     rescue ActiveRecord::RecordNotUnique
       next
     end
 
-    SeveredRelationship.where(remote_account_id: other_account.id).reorder(nil).find_each do |record|
+    SeveredRelationship.about_remote_account(other_account).reorder(nil).find_each do |record|
       record.update_attribute(:remote_account_id, id)
     rescue ActiveRecord::RecordNotUnique
       next

--- a/app/models/severed_relationship.rb
+++ b/app/models/severed_relationship.rb
@@ -26,6 +26,7 @@ class SeveredRelationship < ApplicationRecord
   }
 
   scope :about_local_account, ->(account) { where(local_account: account) }
+  scope :about_remote_account, ->(account) { where(remote_account: account) }
 
   scope :active, -> { where(direction: :active) }
   scope :passive, -> { where(direction: :passive) }

--- a/app/views/severed_relationships/index.html.haml
+++ b/app/views/severed_relationships/index.html.haml
@@ -21,13 +21,13 @@
               %td{ rowspan: 2 }= t('severed_relationships.purged')
             - else
               %td
-                - count = event.severed_relationships.active.where(local_account: current_account).count
+                - count = event.severed_relationships.active.about_local_account(current_account).count
                 - if count.zero?
                   = t('generic.none')
                 - else
                   = table_link_to 'download', t('severed_relationships.download', count: count), following_severed_relationship_path(event, format: :csv)
               %td
-                - count = event.severed_relationships.passive.where(local_account: current_account).count
+                - count = event.severed_relationships.passive.about_local_account(current_account).count
                 - if count.zero?
                   = t('generic.none')
                 - else


### PR DESCRIPTION
The scope was already in place, just not used in all relevant spots.