### PR TITLE
Lock `i18n` gem to version `1.14.1`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ gem 'htmlentities', '~> 4.3'
 gem 'http', '~> 5.1'
 gem 'http_accept_language', '~> 2.1'
 gem 'httplog', '~> 1.6.2'
+gem 'i18n', '1.14.1' # TODO: Remove version when resolved: https://github.com/glebm/i18n-tasks/issues/552 / https://github.com/ruby-i18n/i18n/pull/688
 gem 'idn-ruby', require: 'idn'
 gem 'inline_svg'
 gem 'kaminari', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -866,6 +866,7 @@ DEPENDENCIES
   http (~> 5.1)
   http_accept_language (~> 2.1)
   httplog (~> 1.6.2)
+  i18n (= 1.14.1)
   i18n-tasks (~> 1.0)
   idn-ruby
   inline_svg


### PR DESCRIPTION
Should allow some misc renovate PRs to rebase/merge if this stops getting bumped as side effect.