### PR TITLE
Use `db_table_exists?` method in new cli/maintenance area

### DIFF
--- a/lib/mastodon/cli/maintenance.rb
+++ b/lib/mastodon/cli/maintenance.rb
@@ -131,7 +131,7 @@ module Mastodon::CLI
           end
         end
 
-        if ActiveRecord::Base.connection.table_exists?(:severed_relationships)
+        if db_table_exists?(:severed_relationships)
           SeveredRelationship.where(local_account_id: other_account.id).reorder(nil).find_each do |record|
             record.update_attribute(:local_account_id, id)
           rescue ActiveRecord::RecordNotUnique


### PR DESCRIPTION
I think the PR that added the new section pre-dates the existence of this method, so it makes sense why not used. Update is just to use the method.