### PR TITLE
Update `enum` away from deprecated

### DIFF
--- a/app/models/relationship_severance_event.rb
+++ b/app/models/relationship_severance_event.rb
@@ -16,7 +16,7 @@ class RelationshipSeveranceEvent < ApplicationRecord
 
   has_many :severed_relationships, inverse_of: :relationship_severance_event, dependent: :delete_all
 
-  enum type: {
+  enum :type, {
     domain_block: 0,
     user_domain_block: 1,
     account_suspension: 2,

--- a/app/models/severed_relationship.rb
+++ b/app/models/severed_relationship.rb
@@ -20,7 +20,7 @@ class SeveredRelationship < ApplicationRecord
   belongs_to :local_account, class_name: 'Account'
   belongs_to :remote_account, class_name: 'Account'
 
-  enum direction: {
+  enum :direction, {
     passive: 0, # analogous to `local_account.passive_relationships`
     active: 1, # analogous to `local_account.active_relationships`
   }

--- a/lib/mastodon/cli/maintenance.rb
+++ b/lib/mastodon/cli/maintenance.rb
@@ -42,7 +42,7 @@ module Mastodon::CLI
     class SeveredRelationship < ApplicationRecord; end
 
     class DomainBlock < ApplicationRecord
-      enum severity: { silence: 0, suspend: 1, noop: 2 }
+      enum :severity, { silence: 0, suspend: 1, noop: 2 }
       scope :by_severity, -> { in_order_of(:severity, %w(noop silence suspend)).order(:domain) }
     end
 


### PR DESCRIPTION
I think the one in the maintenance script was missed in the previous pass, and the other two are from a PR which pre-dates https://github.com/mastodon/mastodon/pull/29217