### PR TITLE
Add empty line after ✨magic✨ frozen string comment

### DIFF
--- a/config/initializers/application_controller_renderer.rb
+++ b/config/initializers/application_controller_renderer.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # ActiveSupport::Reloader.to_prepare do


### PR DESCRIPTION
Fixes https://github.com/mastodon/mastodon/actions/runs/8373618980/job/22927062080?pr=29692 needed by https://github.com/mastodon/mastodon/pull/29692