### PR TITLE
Fix notification policy migration not preserving `filter_private_mentions` correctly

### DIFF
--- a/db/migrate/20240304090449_migrate_interaction_settings_to_policy.rb
+++ b/db/migrate/20240304090449_migrate_interaction_settings_to_policy.rb
@@ -36,8 +36,8 @@ class MigrateInteractionSettingsToPolicy < ActiveRecord::Migration[7.1]
         requires_new_policy = true
       end
 
-      if deserialized_settings['interactions.must_be_following_dm']
-        policy.filter_private_mentions = true
+      unless deserialized_settings['interactions.must_be_following_dm']
+        policy.filter_private_mentions = false
         requires_new_policy = true
       end
 

--- a/db/post_migrate/20240321160706_migrate_interaction_settings_to_policy_again.rb
+++ b/db/post_migrate/20240321160706_migrate_interaction_settings_to_policy_again.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class MigrateInteractionSettingsToPolicyAgain < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  # Dummy classes, to make migration possible across version changes
+  class Account < ApplicationRecord
+    has_one :user, inverse_of: :account
+    has_one :notification_policy, inverse_of: :account
+  end
+
+  class User < ApplicationRecord
+    belongs_to :account
+  end
+
+  class NotificationPolicy < ApplicationRecord
+    belongs_to :account
+  end
+
+  def up
+    User.includes(account: :notification_policy).find_each do |user|
+      deserialized_settings = Oj.load(user.attributes_before_type_cast['settings'])
+
+      next if deserialized_settings.nil?
+
+      # If the user has configured a notification policy, don't override it
+      next if user.account.notification_policy.present?
+
+      policy = user.account.build_notification_policy
+      requires_new_policy = false
+
+      if deserialized_settings['interactions.must_be_follower']
+        policy.filter_not_followers = true
+        requires_new_policy = true
+      end
+
+      if deserialized_settings['interactions.must_be_following']
+        policy.filter_not_following = true
+        requires_new_policy = true
+      end
+
+      unless deserialized_settings['interactions.must_be_following_dm']
+        policy.filter_private_mentions = false
+        requires_new_policy = true
+      end
+
+      policy.save if requires_new_policy && policy.changed?
+    rescue ActiveRecord::RecordNotUnique
+      next
+    end
+  end
+
+  def down; end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_20_163441) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_21_160706) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/lib/tasks/tests.rake
+++ b/lib/tasks/tests.rake
@@ -105,6 +105,12 @@ namespace :tests do
         exit(1)
       end
 
+      policy = NotificationPolicy.find_by(account: User.find(1).account)
+      unless policy.filter_private_mentions == false && policy.filter_not_following == true
+        puts 'Notification policy not migrated as expected'
+        exit(1)
+      end
+
       puts 'No errors found. Database state is consistent with a successful migration process.'
     end
 
@@ -181,7 +187,8 @@ namespace :tests do
         INSERT INTO "settings"
           (id, thing_type, thing_id, var, value, created_at, updated_at)
         VALUES
-          (5, 'User', 4, 'default_language', E'--- kmr\n', now(), now());
+          (5, 'User', 4, 'default_language', E'--- kmr\n', now(), now()),
+          (6, 'User', 1, 'interactions', E'--- !ruby/hash:ActiveSupport::HashWithIndifferentAccess\nmust_be_follower: false\nmust_be_following: true\nmust_be_following_dm: false\n', now(), now());
       SQL
     end
 


### PR DESCRIPTION
Fix the old migration and run a new one to fix mis-migrated settings.

The issue was that we only changed from the new defaults for people who opted in the new defaults, instead of the opposite.