### PR TITLE
Add `AccountStat.by_recent_status`, use in `Account`

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -132,12 +132,13 @@ class Account < ApplicationRecord
   scope :auditable, -> { where(id: Admin::ActionLog.select(:account_id).distinct) }
   scope :searchable, -> { without_unapproved.without_suspended.where(moved_to_account_id: nil) }
   scope :discoverable, -> { searchable.without_silenced.where(discoverable: true).joins(:account_stat) }
-  scope :by_recent_status, -> { includes(:account_stat).merge(AccountStat.order('last_status_at DESC NULLS LAST')).references(:account_stat) }
+  scope :by_recent_status, -> { includes(:account_stat).merge(AccountStat.by_recent_status).references(:account_stat) }
   scope :by_recent_activity, -> { left_joins(:user, :account_stat).order(coalesced_activity_timestamps.desc).order(id: :desc) }
   scope :popular, -> { order('account_stats.followers_count desc') }
   scope :by_domain_and_subdomains, ->(domain) { where(domain: Instance.by_domain_and_subdomains(domain).select(:domain)) }
   scope :not_excluded_by_account, ->(account) { where.not(id: account.excluded_from_timeline_account_ids) }
   scope :not_domain_blocked_by_account, ->(account) { where(arel_table[:domain].eq(nil).or(arel_table[:domain].not_in(account.excluded_from_timeline_domains))) }
+  scope :dormant, -> { joins(:account_stat).merge(AccountStat.without_recent_activity) }
 
   after_update_commit :trigger_update_webhooks
 

--- a/app/models/account_stat.rb
+++ b/app/models/account_stat.rb
@@ -20,6 +20,9 @@ class AccountStat < ApplicationRecord
 
   belongs_to :account, inverse_of: :account_stat
 
+  scope :by_recent_status, -> { order(arel_table[:last_status_at].desc.nulls_last) }
+  scope :without_recent_activity, -> { where(last_status_at: [nil, ...1.month.ago]) }
+
   update_index('accounts', :account)
 
   def following_count

--- a/app/models/relationship_filter.rb
+++ b/app/models/relationship_filter.rb
@@ -114,7 +114,7 @@ class RelationshipFilter
   def activity_scope(value)
     case value
     when 'dormant'
-      Account.joins(:account_stat).where(account_stat: { last_status_at: [nil, ...1.month.ago] })
+      Account.dormant
     else
       raise Mastodon::InvalidParameterError, "Unknown activity: #{value}"
     end


### PR DESCRIPTION
The arel/nulls_last style here matches what we do in a few other places with similar dynamic where getting a relation object gives you a more composable/changeable query that the string does not.