### PR TITLE
Add ruby 3.3 to CI test matrix

### DIFF
--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -114,6 +114,7 @@ jobs:
           - '3.0'
           - '3.1'
           - '.ruby-version'
+          - '3.3'
     steps:
       - uses: actions/checkout@v4
 
@@ -189,6 +190,7 @@ jobs:
           - '3.0'
           - '3.1'
           - '.ruby-version'
+          - '3.3'
 
     steps:
       - uses: actions/checkout@v4
@@ -288,6 +290,7 @@ jobs:
           - '3.0'
           - '3.1'
           - '.ruby-version'
+          - '3.3'
         search-image:
           - docker.elastic.co/elasticsearch/elasticsearch:7.17.13
         include:


### PR DESCRIPTION
As discussed: https://github.com/mastodon/mastodon/pull/28013#issuecomment-2013201972

This leaves 3.2 as the default in Dockerfile and local envs, and should not otherwise impact production envs.

Future change here is to revert back to using `.ruby-version` as latest whenever the linked 3.3 PR merges.