### PR TITLE
Forward 3035 port

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -173,6 +173,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Otherwise, you can access the site at http://localhost:3000 and http://localhost:4000 , http://localhost:8080
   config.vm.network :forwarded_port, guest: 3000, host: 3000
+  config.vm.network :forwarded_port, guest: 3035, host: 3035
   config.vm.network :forwarded_port, guest: 4000, host: 4000
   config.vm.network :forwarded_port, guest: 8080, host: 8080
   config.vm.network :forwarded_port, guest: 9200, host: 9200


### PR DESCRIPTION
This port is used by webpack and should be forwarded to ease the development for newscomers who start a dev mastodon instance via Vagrant.