### PR TITLE
Restore advanced filter bar setting

### DIFF
--- a/app/javascript/mastodon/features/notifications/components/column_settings.jsx
+++ b/app/javascript/mastodon/features/notifications/components/column_settings.jsx
@@ -54,6 +54,7 @@ export default class ColumnSettings extends PureComponent {
   render () {
     const { settings, pushSettings, onChange, onClear, alertsEnabled, browserSupport, browserPermission, onRequestNotificationPermission, notificationPolicy } = this.props;
 
+    const filterAdvancedStr = <FormattedMessage id='notifications.column_settings.filter_bar.advanced' defaultMessage='Display all categories' />;
     const unreadMarkersShowStr = <FormattedMessage id='notifications.column_settings.unread_notifications.highlight' defaultMessage='Highlight unread notifications' />;
     const alertStr = <FormattedMessage id='notifications.column_settings.alert' defaultMessage='Desktop notifications' />;
     const showStr = <FormattedMessage id='notifications.column_settings.show' defaultMessage='Show in column' />;
@@ -113,6 +114,16 @@ export default class ColumnSettings extends PureComponent {
 
           <div className='column-settings__row'>
             <SettingToggle id='unread-notification-markers' prefix='notifications' settings={settings} settingPath={['showUnread']} onChange={onChange} label={unreadMarkersShowStr} />
+          </div>
+        </section>
+
+        <section role='group' aria-labelledby='notifications-filter-bar'>
+          <h3 id='notifications-filter-bar'>
+            <FormattedMessage id='notifications.column_settings.filter_bar.category' defaultMessage='Quick filter bar' />
+          </h3>
+
+          <div className='column-settings__row'>
+            <SettingToggle id='advanced-filter-bar' prefix='notifications' settings={settings} settingPath={['quickFilter', 'advanced']} onChange={onChange} label={filterAdvancedStr} />
           </div>
         </section>
 

--- a/app/javascript/mastodon/features/notifications/containers/filter_bar_container.js
+++ b/app/javascript/mastodon/features/notifications/containers/filter_bar_container.js
@@ -5,7 +5,7 @@ import FilterBar from '../components/filter_bar';
 
 const makeMapStateToProps = state => ({
   selectedFilter: state.getIn(['settings', 'notifications', 'quickFilter', 'active']),
-  advancedMode: false,
+  advancedMode: state.getIn(['settings', 'notifications', 'quickFilter', 'advanced']),
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -484,6 +484,8 @@
   "notifications.column_settings.admin.sign_up": "New sign-ups:",
   "notifications.column_settings.alert": "Desktop notifications",
   "notifications.column_settings.favourite": "Favorites:",
+  "notifications.column_settings.filter_bar.advanced": "Display all categories",
+  "notifications.column_settings.filter_bar.category": "Quick filter bar",
   "notifications.column_settings.follow": "New followers:",
   "notifications.column_settings.follow_request": "New follow requests:",
   "notifications.column_settings.mention": "Mentions:",


### PR DESCRIPTION
It was removed in #29433

I chose to not restore the "show filter bar" setting as this does not seem useful. Users will either have the default filter bar (all / mentions), or the advanced one with icons.

Disabled:
<img width="618" alt="image" src="https://github.com/mastodon/mastodon/assets/42070/c93636d3-5bde-4ebe-aeee-7674bde7b5eb">

Setting:
<img width="615" alt="image" src="https://github.com/mastodon/mastodon/assets/42070/ea2ce210-1a18-48fc-8113-ef04a8f6057c">


Enabled:
<img width="617" alt="image" src="https://github.com/mastodon/mastodon/assets/42070/f64fda38-242f-4d81-9628-4903528573bf">
