### PR TITLE
Ensure case-insensitive fields are converted to lowercase in Admin Imports

### DIFF
--- a/app/models/admin/import.rb
+++ b/app/models/admin/import.rb
@@ -30,12 +30,14 @@ class Admin::Import
 
     csv_converter = lambda do |field, field_info|
       case field_info.header
-      when '#domain', '#public_comment'
+      when '#domain'
+        field&.downcase&.strip
+      when '#public_comment'
         field&.strip
       when '#severity'
-        field&.strip&.to_sym
+        field&.downcase&.strip&.to_sym
       when '#reject_media', '#reject_reports', '#obfuscate'
-        ActiveModel::Type::Boolean.new.cast(field)
+        ActiveModel::Type::Boolean.new.cast(field&.downcase)
       else
         field
       end


### PR DESCRIPTION
The previous code meant that CSV files generated from Python would fail to import, since in Python boolean values when output in CSV as either True or False, not "true" or "false" as Ruby expects.

Additionally there's no difference between 'Suspend' and 'suspend', both should be handled the same, and likewise, domains are case-insensitive.

This fixes #26253

There are currently no tests at all for Admin::Import, and adding them feels out of scope of this minor fix.