### PR TITLE
Ensure case-insensitive fields are converted to lowercase in user imports

### DIFF
--- a/app/models/form/import.rb
+++ b/app/models/form/import.rb
@@ -111,12 +111,14 @@ class Form::Import
     csv_converter = lambda do |field, field_info|
       case field_info.header
       when 'Show boosts', 'Notify on new posts', 'Hide notifications'
-        ActiveModel::Type::Boolean.new.cast(field)
+        ActiveModel::Type::Boolean.new.cast(field&.downcase)
       when 'Languages'
         field&.split(',')&.map(&:strip)&.presence
       when 'Account address'
         field.strip.gsub(/\A@/, '')
-      when '#domain', '#uri', 'List name'
+      when '#domain'
+        field&.strip&.downcase
+      when '#uri', 'List name'
         field.strip
       else
         field


### PR DESCRIPTION
This change is for the same reasons as https://github.com/mastodon/mastodon/pull/29739

Note: `uri` fields are **not** converted to lowercase since URIs are case-sensitive potentially (per spec).