### PR TITLE
Remove extraneous `Lint/UselessAccessModifier` config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,12 +41,6 @@ Layout/FirstHashElementIndentation:
 Layout/LineLength:
   Max: 320 # Default of 120 causes a duplicate entry in generated todo file
 
-# Reason:
-# https://docs.rubocop.org/rubocop/cops_lint.html#lintuselessaccessmodifier
-Lint/UselessAccessModifier:
-  ContextCreatingMethods:
-    - class_methods
-
 ## Disable most Metrics/*Length cops
 # Reason: those are often triggered and force significant refactors when this happend
 #         but the team feel they are not really improving the code quality.


### PR DESCRIPTION
The original PR which added this rule - https://github.com/mastodon/mastodon/pull/14288 - was fixing a few rubocop issues all at once. The specific thing handled by this setting was subsequently identified as a false positive (handling access declrations inside/outside a context) and fixed in subsequent release. Removing this causes no failures, so I think we are safe with current defaults on this specific cop.