### PR TITLE
Simplify feature loop in welcome mailer

### DIFF
--- a/app/views/application/mailer/_feature.html.haml
+++ b/app/views/application/mailer/_feature.html.haml
@@ -11,10 +11,8 @@
                 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
                   %tr
                     %td.email-column-td
-                      - if defined?(feature_title)
-                        %h2.email-h2= feature_title
-                      - if defined?(feature_text)
-                        %p.email-p= feature_text
+                      %h2.email-h2= t("user_mailer.welcome.feature_#{feature}_title")
+                      %p.email-p= t("user_mailer.welcome.feature_#{feature}")
                       - if defined?(feature_btn_url)
                         = link_to '', href: feature_btn_url, class: 'email-link-with-arrow' do
                           #{t('user_mailer.welcome.feature_action')} 
@@ -25,8 +23,8 @@
                 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
                   %tr
                     %td.email-column-td
-                      - if defined?(key)
+                      - if defined?(feature)
                         %p{ class: ('email-desktop-text-right' if defined?(text_first_on_desktop) && text_first_on_desktop) }
-                          = image_tag frontend_asset_url("images/mailer-new/welcome/#{key}.png"), alt: '', width: 240, height: 230
+                          = image_tag frontend_asset_url("images/mailer-new/welcome/feature_#{feature}.png"), alt: '', width: 240, height: 230
               /[if mso]
                 </td></tr></table>

--- a/app/views/user_mailer/welcome.html.haml
+++ b/app/views/user_mailer/welcome.html.haml
@@ -70,7 +70,7 @@
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-extra-td
-      = render 'application/mailer/feature', key: 'feature_control', feature_title: t('user_mailer.welcome.feature_control_title'), feature_text: t('user_mailer.welcome.feature_control'), text_first_on_desktop: true
-      = render 'application/mailer/feature', key: 'feature_audience', feature_title: t('user_mailer.welcome.feature_audience_title'), feature_text: t('user_mailer.welcome.feature_audience'), text_first_on_desktop: false
-      = render 'application/mailer/feature', key: 'feature_moderation', feature_title: t('user_mailer.welcome.feature_moderation_title'), feature_text: t('user_mailer.welcome.feature_moderation'), text_first_on_desktop: true
-      = render 'application/mailer/feature', key: 'feature_creativity', feature_title: t('user_mailer.welcome.feature_creativity_title'), feature_text: t('user_mailer.welcome.feature_creativity'), text_first_on_desktop: false
+      = render 'application/mailer/feature', feature: 'control', text_first_on_desktop: true
+      = render 'application/mailer/feature', feature: 'audience', text_first_on_desktop: false
+      = render 'application/mailer/feature', feature: 'moderation', text_first_on_desktop: true
+      = render 'application/mailer/feature', feature: 'creativity', text_first_on_desktop: false


### PR DESCRIPTION
I think there's further improvement here:

- Replace the true/false alternation in the last option here with something like https://github.com/mastodon/mastodon/pull/29476
- After that PR and this PR are merged, convert this block to use render collection instead of the current repetition

Similar benefits for the checklist thing higher up in the template, will open separate for that area.