### PR TITLE
Rename jobs/attachments rspec tag names

### DIFF
--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -223,7 +223,7 @@ jobs:
       - name: Load database schema
         run: './bin/rails db:create db:schema:load db:seed'
 
-      - run: bin/rspec --tag paperclip_processing
+      - run: bin/rspec --tag attachment_processing
 
       - name: Upload coverage reports to Codecov
         if: matrix.ruby-version == '.ruby-version'

--- a/spec/controllers/admin/disputes/appeals_controller_spec.rb
+++ b/spec/controllers/admin/disputes/appeals_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Admin::Disputes::AppealsController do
 
     let(:current_user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
 
-    it 'redirects back to the strike page and notifies target account about approved appeal', :sidekiq_inline do
+    it 'redirects back to the strike page and notifies target account about approved appeal', :inline_jobs do
       emails = capture_emails { subject }
 
       expect(response)
@@ -58,7 +58,7 @@ RSpec.describe Admin::Disputes::AppealsController do
 
     let(:current_user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
 
-    it 'redirects back to the strike page and notifies target account about rejected appeal', :sidekiq_inline do
+    it 'redirects back to the strike page and notifies target account about rejected appeal', :inline_jobs do
       emails = capture_emails { subject }
 
       expect(response)

--- a/spec/controllers/admin/domain_blocks_controller_spec.rb
+++ b/spec/controllers/admin/domain_blocks_controller_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe Admin::DomainBlocksController do
     end
   end
 
-  describe 'PUT #update', :sidekiq_inline do
+  describe 'PUT #update', :inline_jobs do
     subject do
       post :update, params: { :id => domain_block.id, :domain_block => { domain: 'example.com', severity: new_severity }, 'confirm' => '' }
     end

--- a/spec/controllers/admin/resets_controller_spec.rb
+++ b/spec/controllers/admin/resets_controller_spec.rb
@@ -13,7 +13,7 @@ describe Admin::ResetsController do
     sign_in Fabricate(:user, role: UserRole.find_by(name: 'Admin')), scope: :user
   end
 
-  describe 'POST #create', :sidekiq_inline do
+  describe 'POST #create', :inline_jobs do
     it 'redirects to admin accounts page' do
       emails = capture_emails { subject }
 

--- a/spec/controllers/auth/sessions_controller_spec.rb
+++ b/spec/controllers/auth/sessions_controller_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe Auth::SessionsController do
           user.update(current_sign_in_at: 1.month.ago)
         end
 
-        it 'logs the user in and sends suspicious email and redirects home', :sidekiq_inline do
+        it 'logs the user in and sends suspicious email and redirects home', :inline_jobs do
           emails = capture_emails { subject }
 
           expect(response)
@@ -263,7 +263,7 @@ RSpec.describe Auth::SessionsController do
             travel_to '2023-12-20T10:00:00Z'
           end
 
-          it 'does not log the user in, sets a flash message, and sends a suspicious sign in email', :sidekiq_inline do
+          it 'does not log the user in, sets a flash message, and sends a suspicious sign in email', :inline_jobs do
             emails = capture_emails do
               Auth::SessionsController::MAX_2FA_ATTEMPTS_PER_HOUR.times do
                 post :create, params: { user: { otp_attempt: '1234' } }, session: { attempt_user_id: user.id, attempt_user_updated_at: user.updated_at.to_s }

--- a/spec/controllers/concerns/user_tracking_concern_spec.rb
+++ b/spec/controllers/concerns/user_tracking_concern_spec.rb
@@ -75,7 +75,7 @@ describe UserTrackingConcern do
         expect(redis.ttl("account:#{user.account_id}:regeneration")).to be >= 0
       end
 
-      it 'regenerates feed when sign in is older than two weeks', :sidekiq_inline do
+      it 'regenerates feed when sign in is older than two weeks', :inline_jobs do
         get :show
 
         expect_updated_sign_in_at(user)

--- a/spec/controllers/disputes/appeals_controller_spec.rb
+++ b/spec/controllers/disputes/appeals_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Disputes::AppealsController do
       let(:strike) { Fabricate(:account_warning, target_account: current_user.account) }
       let(:params) { { strike_id: strike.id, appeal: { text: 'Foo' } } }
 
-      it 'notifies staff about new appeal and redirects back to strike page', :sidekiq_inline do
+      it 'notifies staff about new appeal and redirects back to strike page', :inline_jobs do
         emails = capture_emails { subject }
 
         expect(emails.size)
@@ -36,7 +36,7 @@ RSpec.describe Disputes::AppealsController do
       let(:strike) { Fabricate(:account_warning, target_account: current_user.account) }
       let(:params) { { strike_id: strike.id, appeal: { text: '' } } }
 
-      it 'does not send email and renders strike show page', :sidekiq_inline do
+      it 'does not send email and renders strike show page', :inline_jobs do
         emails = capture_emails { subject }
 
         expect(emails).to be_empty

--- a/spec/controllers/settings/deletes_controller_spec.rb
+++ b/spec/controllers/settings/deletes_controller_spec.rb
@@ -50,7 +50,7 @@ describe Settings::DeletesController do
           delete :destroy, params: { form_delete_confirmation: { password: 'petsmoldoggos' } }
         end
 
-        it 'removes user record and redirects', :aggregate_failures, :sidekiq_inline do
+        it 'removes user record and redirects', :aggregate_failures, :inline_jobs do
           expect(response).to redirect_to '/auth/sign_in'
           expect(User.find_by(id: user.id)).to be_nil
           expect(user.account.reload).to be_suspended

--- a/spec/lib/activitypub/activity/delete_spec.rb
+++ b/spec/lib/activitypub/activity/delete_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe ActivityPub::Activity::Delete do
         expect(Status.find_by(id: status.id)).to be_nil
       end
 
-      it 'sends delete activity to followers of rebloggers', :sidekiq_inline do
+      it 'sends delete activity to followers of rebloggers', :inline_jobs do
         expect(a_request(:post, 'http://example.com/inbox')).to have_been_made.once
       end
 

--- a/spec/lib/activitypub/activity/move_spec.rb
+++ b/spec/lib/activitypub/activity/move_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe ActivityPub::Activity::Move do
       subject.perform
     end
 
-    context 'when all conditions are met', :sidekiq_inline do
+    context 'when all conditions are met', :inline_jobs do
       it 'sets moved account on old account' do
         expect(old_account.reload.moved_to_account_id).to eq new_account.id
       end

--- a/spec/models/admin/account_action_spec.rb
+++ b/spec/models/admin/account_action_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Admin::AccountAction do
       end
     end
 
-    it 'sends email to target account user', :sidekiq_inline do
+    it 'sends email to target account user', :inline_jobs do
       emails = capture_emails { subject }
 
       expect(emails).to contain_exactly(

--- a/spec/models/custom_emoji_spec.rb
+++ b/spec/models/custom_emoji_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe CustomEmoji, :paperclip_processing do
+RSpec.describe CustomEmoji, :attachment_processing do
   describe '#search' do
     subject { described_class.search(search_term) }
 

--- a/spec/models/media_attachment_spec.rb
+++ b/spec/models/media_attachment_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe MediaAttachment, :paperclip_processing do
+RSpec.describe MediaAttachment, :attachment_processing do
   describe 'local?' do
     subject { media_attachment.local? }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe User do
     end
   end
 
-  describe 'scopes', :sidekiq_inline do
+  describe 'scopes', :inline_jobs do
     describe 'recent' do
       it 'returns an array of recent users ordered by id' do
         first_user = Fabricate(:user)
@@ -507,7 +507,7 @@ RSpec.describe User do
     context 'when user is new' do
       let(:confirmed_at) { nil }
 
-      it 'confirms user and delivers welcome email', :sidekiq_inline do
+      it 'confirms user and delivers welcome email', :inline_jobs do
         emails = capture_emails { subject }
 
         expect(user.confirmed_at).to be_present

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -137,7 +137,7 @@ RSpec.configure do |config|
   end
 
   config.before do |example|
-    unless example.metadata[:paperclip_processing]
+    unless example.metadata[:attachment_processing]
       allow_any_instance_of(Paperclip::Attachment).to receive(:post_process).and_return(true) # rubocop:disable RSpec/AnyInstance
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -120,7 +120,7 @@ RSpec.configure do |config|
   end
 
   config.around do |example|
-    if example.metadata[:sidekiq_inline] == true
+    if example.metadata[:inline_jobs] == true
       Sidekiq::Testing.inline!
     else
       Sidekiq::Testing.fake!

--- a/spec/requests/api/v1/admin/account_actions_spec.rb
+++ b/spec/requests/api/v1/admin/account_actions_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Account actions' do
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
 
   shared_examples 'a successful notification delivery' do
-    it 'notifies the user about the action taken', :sidekiq_inline do
+    it 'notifies the user about the action taken', :inline_jobs do
       emails = capture_emails { subject }
 
       expect(emails.size)

--- a/spec/requests/api/v1/conversations_spec.rb
+++ b/spec/requests/api/v1/conversations_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'API V1 Conversations' do
 
   let(:other) { Fabricate(:user) }
 
-  describe 'GET /api/v1/conversations', :sidekiq_inline do
+  describe 'GET /api/v1/conversations', :inline_jobs do
     before do
       user.account.follow!(other.account)
       PostStatusService.new.call(other.account, text: 'Hey @alice', visibility: 'direct')

--- a/spec/requests/api/v1/featured_tags_spec.rb
+++ b/spec/requests/api/v1/featured_tags_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe 'FeaturedTags' do
       expect(body).to be_empty
     end
 
-    it 'deletes the featured tag', :sidekiq_inline do
+    it 'deletes the featured tag', :inline_jobs do
       delete "/api/v1/featured_tags/#{id}", headers: headers
 
       featured_tag = FeaturedTag.find_by(id: id)

--- a/spec/requests/api/v1/media_spec.rb
+++ b/spec/requests/api/v1/media_spec.rb
@@ -121,19 +121,19 @@ RSpec.describe 'Media' do
       end
     end
 
-    context 'with image/jpeg', :paperclip_processing do
+    context 'with image/jpeg', :attachment_processing do
       let(:params) { { file: fixture_file_upload('attachment.jpg', 'image/jpeg'), description: 'jpeg image' } }
 
       it_behaves_like 'a successful media upload', 'image'
     end
 
-    context 'with image/gif', :paperclip_processing do
+    context 'with image/gif', :attachment_processing do
       let(:params) { { file: fixture_file_upload('attachment.gif', 'image/gif') } }
 
       it_behaves_like 'a successful media upload', 'image'
     end
 
-    context 'with video/webm', :paperclip_processing do
+    context 'with video/webm', :attachment_processing do
       let(:params) { { file: fixture_file_upload('attachment.webm', 'video/webm') } }
 
       it_behaves_like 'a successful media upload', 'gifv'

--- a/spec/requests/api/v1/notifications/policies_spec.rb
+++ b/spec/requests/api/v1/notifications/policies_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Policies' do
   let(:scopes)  { 'read:notifications write:notifications' }
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
 
-  describe 'GET /api/v1/notifications/policy', :sidekiq_inline do
+  describe 'GET /api/v1/notifications/policy', :inline_jobs do
     subject do
       get '/api/v1/notifications/policy', headers: headers, params: params
     end

--- a/spec/requests/api/v1/notifications/requests_spec.rb
+++ b/spec/requests/api/v1/notifications/requests_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Requests' do
   let(:scopes)  { 'read:notifications write:notifications' }
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
 
-  describe 'GET /api/v1/notifications/requests', :sidekiq_inline do
+  describe 'GET /api/v1/notifications/requests', :inline_jobs do
     subject do
       get '/api/v1/notifications/requests', headers: headers, params: params
     end

--- a/spec/requests/api/v1/notifications_spec.rb
+++ b/spec/requests/api/v1/notifications_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Notifications' do
   let(:scopes)  { 'read:notifications write:notifications' }
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
 
-  describe 'GET /api/v1/notifications', :sidekiq_inline do
+  describe 'GET /api/v1/notifications', :inline_jobs do
     subject do
       get '/api/v1/notifications', headers: headers, params: params
     end

--- a/spec/requests/api/v1/reports_spec.rb
+++ b/spec/requests/api/v1/reports_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'Reports' do
 
     it_behaves_like 'forbidden for wrong scope', 'read read:reports'
 
-    it 'creates a report', :aggregate_failures, :sidekiq_inline do
+    it 'creates a report', :aggregate_failures, :inline_jobs do
       emails = capture_emails { subject }
 
       expect(response).to have_http_status(200)

--- a/spec/requests/api/v1/statuses/favourites_spec.rb
+++ b/spec/requests/api/v1/statuses/favourites_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Favourites', :sidekiq_inline do
+RSpec.describe 'Favourites', :inline_jobs do
   let(:user)    { Fabricate(:user) }
   let(:scopes)  { 'write:favourites' }
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }

--- a/spec/requests/api/v1/statuses/reblogs_spec.rb
+++ b/spec/requests/api/v1/statuses/reblogs_spec.rb
@@ -41,7 +41,7 @@ describe 'API V1 Statuses Reblogs' do
       end
     end
 
-    describe 'POST /api/v1/statuses/:status_id/unreblog', :sidekiq_inline do
+    describe 'POST /api/v1/statuses/:status_id/unreblog', :inline_jobs do
       context 'with public status' do
         let(:status) { Fabricate(:status, account: user.account) }
 

--- a/spec/requests/api/v1/timelines/home_spec.rb
+++ b/spec/requests/api/v1/timelines/home_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Home', :sidekiq_inline do
+describe 'Home', :inline_jobs do
   let(:user)    { Fabricate(:user) }
   let(:scopes)  { 'read:statuses' }
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }

--- a/spec/requests/api/v2/media_spec.rb
+++ b/spec/requests/api/v2/media_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Media API', :paperclip_processing do
+RSpec.describe 'Media API', :attachment_processing do
   let(:user)    { Fabricate(:user) }
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:scopes)  { 'write' }

--- a/spec/requests/api/v2_alpha/notifications_spec.rb
+++ b/spec/requests/api/v2_alpha/notifications_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Notifications' do
   let(:scopes)  { 'read:notifications write:notifications' }
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
 
-  describe 'GET /api/v2_alpha/notifications', :sidekiq_inline do
+  describe 'GET /api/v2_alpha/notifications', :inline_jobs do
     subject do
       get '/api/v2_alpha/notifications', headers: headers, params: params
     end

--- a/spec/search/models/concerns/account/statuses_search_spec.rb
+++ b/spec/search/models/concerns/account/statuses_search_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Account::StatusesSearch, :sidekiq_inline do
+describe Account::StatusesSearch, :inline_jobs do
   describe 'a non-indexable account becoming indexable' do
     let(:account) { Account.find_by(username: 'search_test_account_1') }
 

--- a/spec/services/activitypub/fetch_remote_status_service_spec.rb
+++ b/spec/services/activitypub/fetch_remote_status_service_spec.rb
@@ -225,7 +225,7 @@ RSpec.describe ActivityPub::FetchRemoteStatusService do
     end
   end
 
-  context 'with statuses referencing other statuses', :sidekiq_inline do
+  context 'with statuses referencing other statuses', :inline_jobs do
     before do
       stub_const 'ActivityPub::FetchRemoteStatusService::DISCOVERIES_PER_REQUEST', 5
     end

--- a/spec/services/activitypub/process_account_service_spec.rb
+++ b/spec/services/activitypub/process_account_service_spec.rb
@@ -224,7 +224,7 @@ RSpec.describe ActivityPub::ProcessAccountService do
       end
     end
 
-    it 'creates accounts without exceeding rate limit', :sidekiq_inline do
+    it 'creates accounts without exceeding rate limit', :inline_jobs do
       expect { subject.call('user1', 'foo.test', payload) }
         .to create_some_remote_accounts
         .and create_fewer_than_rate_limit_accounts

--- a/spec/services/appeal_service_spec.rb
+++ b/spec/services/appeal_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe AppealService, :sidekiq_inline do
+RSpec.describe AppealService, :inline_jobs do
   describe '#call' do
     let!(:admin) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
 

--- a/spec/services/authorize_follow_service_spec.rb
+++ b/spec/services/authorize_follow_service_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe AuthorizeFollowService do
       expect(bob.following?(sender)).to be true
     end
 
-    it 'sends an accept activity', :sidekiq_inline do
+    it 'sends an accept activity', :inline_jobs do
       expect(a_request(:post, bob.inbox_url)).to have_been_made.once
     end
   end

--- a/spec/services/batched_remove_status_service_spec.rb
+++ b/spec/services/batched_remove_status_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe BatchedRemoveStatusService, :sidekiq_inline do
+RSpec.describe BatchedRemoveStatusService, :inline_jobs do
   subject { described_class.new }
 
   let!(:alice)  { Fabricate(:account) }

--- a/spec/services/block_domain_service_spec.rb
+++ b/spec/services/block_domain_service_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe BlockDomainService do
   end
 
   describe 'for a silence with reject media' do
-    it 'does not mark the domain as blocked, but silences accounts with an appropriate silencing date, clears media', :aggregate_failures, :sidekiq_inline do
+    it 'does not mark the domain as blocked, but silences accounts with an appropriate silencing date, clears media', :aggregate_failures, :inline_jobs do
       subject.call(DomainBlock.create!(domain: 'evil.org', severity: :silence, reject_media: true))
 
       expect(DomainBlock.blocked?('evil.org')).to be false

--- a/spec/services/block_service_spec.rb
+++ b/spec/services/block_service_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe BlockService do
       expect(sender.blocking?(bob)).to be true
     end
 
-    it 'sends a block activity', :sidekiq_inline do
+    it 'sends a block activity', :inline_jobs do
       expect(a_request(:post, 'http://example.com/inbox')).to have_been_made.once
     end
   end

--- a/spec/services/delete_account_service_spec.rb
+++ b/spec/services/delete_account_service_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe DeleteAccountService do
     end
   end
 
-  describe '#call on local account', :sidekiq_inline do
+  describe '#call on local account', :inline_jobs do
     before do
       stub_request(:post, remote_alice.inbox_url).to_return(status: 201)
       stub_request(:post, remote_bob.inbox_url).to_return(status: 201)
@@ -83,7 +83,7 @@ RSpec.describe DeleteAccountService do
     end
   end
 
-  describe '#call on remote account', :sidekiq_inline do
+  describe '#call on remote account', :inline_jobs do
     before do
       stub_request(:post, account.inbox_url).to_return(status: 201)
     end

--- a/spec/services/fan_out_on_write_service_spec.rb
+++ b/spec/services/fan_out_on_write_service_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe FanOutOnWriteService do
       expect(home_feed_of(alice)).to include status.id
     end
 
-    it 'is added to the home feed of a follower', :sidekiq_inline do
+    it 'is added to the home feed of a follower', :inline_jobs do
       expect(home_feed_of(bob)).to include status.id
       expect(home_feed_of(tom)).to include status.id
     end
@@ -62,7 +62,7 @@ RSpec.describe FanOutOnWriteService do
       expect(home_feed_of(alice)).to include status.id
     end
 
-    it 'is added to the home feed of the mentioned follower', :sidekiq_inline do
+    it 'is added to the home feed of the mentioned follower', :inline_jobs do
       expect(home_feed_of(bob)).to include status.id
     end
 
@@ -83,7 +83,7 @@ RSpec.describe FanOutOnWriteService do
       expect(home_feed_of(alice)).to include status.id
     end
 
-    it 'is added to the home feed of a follower', :sidekiq_inline do
+    it 'is added to the home feed of a follower', :inline_jobs do
       expect(home_feed_of(bob)).to include status.id
       expect(home_feed_of(tom)).to include status.id
     end
@@ -101,7 +101,7 @@ RSpec.describe FanOutOnWriteService do
       expect(home_feed_of(alice)).to include status.id
     end
 
-    it 'is added to the home feed of the mentioned follower', :sidekiq_inline do
+    it 'is added to the home feed of the mentioned follower', :inline_jobs do
       expect(home_feed_of(bob)).to include status.id
     end
 

--- a/spec/services/favourite_service_spec.rb
+++ b/spec/services/favourite_service_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe FavouriteService do
       expect(status.favourites.first).to_not be_nil
     end
 
-    it 'sends a like activity', :sidekiq_inline do
+    it 'sends a like activity', :inline_jobs do
       expect(a_request(:post, 'http://example.com/inbox')).to have_been_made.once
     end
   end

--- a/spec/services/follow_service_spec.rb
+++ b/spec/services/follow_service_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe FollowService do
       expect(FollowRequest.find_by(account: sender, target_account: bob)).to_not be_nil
     end
 
-    it 'sends a follow activity to the inbox', :sidekiq_inline do
+    it 'sends a follow activity to the inbox', :inline_jobs do
       expect(a_request(:post, 'http://example.com/inbox')).to have_been_made.once
     end
   end

--- a/spec/services/import_service_spec.rb
+++ b/spec/services/import_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe ImportService, :sidekiq_inline do
+RSpec.describe ImportService, :inline_jobs do
   include RoutingHelper
 
   let!(:account) { Fabricate(:account, locked: false) }

--- a/spec/services/mute_service_spec.rb
+++ b/spec/services/mute_service_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe MuteService do
       redis.del(home_timeline_key)
     end
 
-    it "clears account's statuses", :sidekiq_inline do
+    it "clears account's statuses", :inline_jobs do
       FeedManager.instance.push_to_home(account, status)
       FeedManager.instance.push_to_home(account, other_account_status)
 

--- a/spec/services/notify_service_spec.rb
+++ b/spec/services/notify_service_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe NotifyService do
     context 'when email notification is enabled' do
       let(:enabled) { true }
 
-      it 'sends email', :sidekiq_inline do
+      it 'sends email', :inline_jobs do
         emails = capture_emails { subject }
 
         expect(emails.size)

--- a/spec/services/reject_follow_service_spec.rb
+++ b/spec/services/reject_follow_service_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe RejectFollowService do
       expect(bob.following?(sender)).to be false
     end
 
-    it 'sends a reject activity', :sidekiq_inline do
+    it 'sends a reject activity', :inline_jobs do
       expect(a_request(:post, bob.inbox_url)).to have_been_made.once
     end
   end

--- a/spec/services/remove_from_followers_service_spec.rb
+++ b/spec/services/remove_from_followers_service_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe RemoveFromFollowersService do
       expect(bob.followed_by?(sender)).to be false
     end
 
-    it 'sends a reject activity', :sidekiq_inline do
+    it 'sends a reject activity', :inline_jobs do
       expect(a_request(:post, sender.inbox_url)).to have_been_made.once
     end
   end

--- a/spec/services/remove_status_service_spec.rb
+++ b/spec/services/remove_status_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe RemoveStatusService, :sidekiq_inline do
+RSpec.describe RemoveStatusService, :inline_jobs do
   subject { described_class.new }
 
   let!(:alice)  { Fabricate(:account) }

--- a/spec/services/report_service_spec.rb
+++ b/spec/services/report_service_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe ReportService do
       stub_request(:post, 'http://example.com/inbox').to_return(status: 200)
     end
 
-    context 'when forward is true', :sidekiq_inline do
+    context 'when forward is true', :inline_jobs do
       let(:forward) { true }
 
       it 'sends ActivityPub payload when forward is true' do

--- a/spec/services/resolve_account_service_spec.rb
+++ b/spec/services/resolve_account_service_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe ResolveAccountService do
       expect(account.uri).to eq 'https://ap.example.com/users/foo'
     end
 
-    it 'merges accounts', :sidekiq_inline do
+    it 'merges accounts', :inline_jobs do
       account = subject.call('foo@ap.example.com')
 
       expect(status.reload.account_id).to eq account.id

--- a/spec/services/suspend_account_service_spec.rb
+++ b/spec/services/suspend_account_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe SuspendAccountService, :sidekiq_inline do
+RSpec.describe SuspendAccountService, :inline_jobs do
   shared_examples 'common behavior' do
     subject { described_class.new.call(account) }
 

--- a/spec/services/unallow_domain_service_spec.rb
+++ b/spec/services/unallow_domain_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe UnallowDomainService do
   let!(:already_banned_account) { Fabricate(:account, username: 'badguy', domain: bad_domain, suspended: true, silenced: true) }
   let!(:domain_allow) { Fabricate(:domain_allow, domain: bad_domain) }
 
-  context 'with limited federation mode', :sidekiq_inline do
+  context 'with limited federation mode', :inline_jobs do
     before do
       allow(Rails.configuration.x).to receive(:limited_federation_mode).and_return(true)
     end

--- a/spec/services/unblock_service_spec.rb
+++ b/spec/services/unblock_service_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe UnblockService do
       expect(sender.blocking?(bob)).to be false
     end
 
-    it 'sends an unblock activity', :sidekiq_inline do
+    it 'sends an unblock activity', :inline_jobs do
       expect(a_request(:post, 'http://example.com/inbox')).to have_been_made.once
     end
   end

--- a/spec/services/unfollow_service_spec.rb
+++ b/spec/services/unfollow_service_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe UnfollowService do
     end
   end
 
-  describe 'remote ActivityPub', :sidekiq_inline do
+  describe 'remote ActivityPub', :inline_jobs do
     let(:bob) { Fabricate(:account, username: 'bob', protocol: :activitypub, domain: 'example.com', inbox_url: 'http://example.com/inbox') }
 
     before do
@@ -38,7 +38,7 @@ RSpec.describe UnfollowService do
     end
   end
 
-  describe 'remote ActivityPub (reverse)', :sidekiq_inline do
+  describe 'remote ActivityPub (reverse)', :inline_jobs do
     let(:bob) { Fabricate(:account, username: 'bob', protocol: :activitypub, domain: 'example.com', inbox_url: 'http://example.com/inbox') }
 
     before do

--- a/spec/services/unsuspend_account_service_spec.rb
+++ b/spec/services/unsuspend_account_service_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe UnsuspendAccountService do
         remote_follower.follow!(account)
       end
 
-      it 'merges back into feeds of local followers and sends update', :sidekiq_inline do
+      it 'merges back into feeds of local followers and sends update', :inline_jobs do
         subject
 
         expect_feeds_merged

--- a/spec/services/update_account_service_spec.rb
+++ b/spec/services/update_account_service_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe UpdateAccountService do
   subject { described_class.new }
 
-  describe 'switching form locked to unlocked accounts', :sidekiq_inline do
+  describe 'switching form locked to unlocked accounts', :inline_jobs do
     let(:account) { Fabricate(:account, locked: true) }
     let(:alice)   { Fabricate(:account) }
     let(:bob)     { Fabricate(:account) }

--- a/spec/support/examples/models/concerns/account_avatar.rb
+++ b/spec/support/examples/models/concerns/account_avatar.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 shared_examples 'AccountAvatar' do |fabricator|
-  describe 'static avatars', :paperclip_processing do
+  describe 'static avatars', :attachment_processing do
     describe 'when GIF' do
       it 'creates a png static style' do
         account = Fabricate(fabricator, avatar: attachment_fixture('avatar.gif'))
@@ -17,7 +17,7 @@ shared_examples 'AccountAvatar' do |fabricator|
     end
   end
 
-  describe 'base64-encoded files', :paperclip_processing do
+  describe 'base64-encoded files', :attachment_processing do
     let(:base64_attachment) { "data:image/jpeg;base64,#{Base64.encode64(attachment_fixture('attachment.jpg').read)}" }
     let(:account) { Fabricate(fabricator, avatar: base64_attachment) }
 

--- a/spec/support/examples/models/concerns/account_header.rb
+++ b/spec/support/examples/models/concerns/account_header.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 shared_examples 'AccountHeader' do |fabricator|
-  describe 'base64-encoded files', :paperclip_processing do
+  describe 'base64-encoded files', :attachment_processing do
     let(:base64_attachment) { "data:image/jpeg;base64,#{Base64.encode64(attachment_fixture('attachment.jpg').read)}" }
     let(:account) { Fabricate(fabricator, header: base64_attachment) }
 

--- a/spec/system/admin/accounts_spec.rb
+++ b/spec/system/admin/accounts_spec.rb
@@ -48,7 +48,7 @@ describe 'Admin::Accounts' do
       end
     end
 
-    context 'with action of `reject`', :sidekiq_inline do
+    context 'with action of `reject`', :inline_jobs do
       it 'rejects and removes the account' do
         batch_checkbox_for(unapproved_user_account).check
 

--- a/spec/system/new_statuses_spec.rb
+++ b/spec/system/new_statuses_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'NewStatuses', :js, :sidekiq_inline, :streaming do
+describe 'NewStatuses', :inline_jobs, :js, :streaming do
   include ProfileStories
 
   subject { page }

--- a/spec/system/ocr_spec.rb
+++ b/spec/system/ocr_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'OCR', :js, :paperclip_processing, :sidekiq_inline, :streaming do
+describe 'OCR', :attachment_processing, :js, :sidekiq_inline, :streaming do
   include ProfileStories
 
   let(:email)               { 'test@example.com' }

--- a/spec/system/ocr_spec.rb
+++ b/spec/system/ocr_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'OCR', :attachment_processing, :js, :sidekiq_inline, :streaming do
+describe 'OCR', :attachment_processing, :inline_jobs, :js, :streaming do
   include ProfileStories
 
   let(:email)               { 'test@example.com' }

--- a/spec/system/report_interface_spec.rb
+++ b/spec/system/report_interface_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'report interface', :js, :paperclip_processing, :streaming do
+describe 'report interface', :attachment_processing, :js, :streaming do
   include ProfileStories
 
   let(:email)               { 'admin@example.com' }

--- a/spec/workers/backup_worker_spec.rb
+++ b/spec/workers/backup_worker_spec.rb
@@ -14,7 +14,7 @@ describe BackupWorker do
     let(:backup) { Fabricate(:backup) }
     let!(:other_backup) { Fabricate(:backup, user: backup.user) }
 
-    it 'sends the backup to the service and removes other backups', :sidekiq_inline do
+    it 'sends the backup to the service and removes other backups', :inline_jobs do
       emails = capture_emails { worker.perform(backup.id) }
 
       expect(service).to have_received(:call).with(backup)

--- a/spec/workers/move_worker_spec.rb
+++ b/spec/workers/move_worker_spec.rb
@@ -104,7 +104,7 @@ describe MoveWorker do
   end
 
   shared_examples 'lists handling' do
-    it 'puts the new account on the list and makes valid lists', :sidekiq_inline do
+    it 'puts the new account on the list and makes valid lists', :inline_jobs do
       subject.perform(source_account.id, target_account.id)
 
       expect(list.accounts.include?(target_account)).to be true

--- a/spec/workers/post_process_media_worker_spec.rb
+++ b/spec/workers/post_process_media_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe PostProcessMediaWorker, :paperclip_processing do
+describe PostProcessMediaWorker, :attachment_processing do
   let(:worker) { described_class.new }
 
   describe '#perform' do


### PR DESCRIPTION
This is rename-only, no behavior change.

Goal here is to make the tag naming more aligned with the app concept we want to activate (file attachment process, running jobs sync/inline), and less coupled to the specific tool (paperclip, sidekiq) we use to implement that concept.