### PR TITLE
Pull out constant from `AccountWarning.recent` scope

### DIFF
--- a/app/models/account_warning.rb
+++ b/app/models/account_warning.rb
@@ -27,6 +27,8 @@ class AccountWarning < ApplicationRecord
     suspend: 4_000,
   }, suffix: :action
 
+  RECENT_PERIOD = 3.months.freeze
+
   normalizes :text, with: ->(text) { text.to_s }, apply_to_nil: true
 
   belongs_to :account, inverse_of: :account_warnings
@@ -37,7 +39,7 @@ class AccountWarning < ApplicationRecord
 
   scope :latest, -> { order(id: :desc) }
   scope :custom, -> { where.not(text: '') }
-  scope :recent, -> { where('account_warnings.created_at >= ?', 3.months.ago) }
+  scope :recent, -> { where(created_at: RECENT_PERIOD.ago..) }
 
   def statuses
     Status.with_discarded.where(id: status_ids || [])


### PR DESCRIPTION
Similar to other recent PRs -- pulls out magic number to constant, updates query style for date range.