### PR TITLE
Fix language picker and privacy picker not having a backdrop filter

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -5084,6 +5084,7 @@ a.status-card {
 .language-dropdown__dropdown {
   box-shadow: var(--dropdown-shadow);
   background: var(--dropdown-background-color);
+  backdrop-filter: var(--background-filter);
   border: 1px solid var(--dropdown-border-color);
   padding: 4px;
   border-radius: 4px;


### PR DESCRIPTION
#29522 changed those dropdowns to have a semi-transparent background, but unlike other dropdowns did not add the backdrop blur filter, causing inconsistency and minor legibility issues.