### PR TITLE
Fix `<RelativeTimestamp>` types

### DIFF
--- a/app/javascript/mastodon/components/relative_timestamp.tsx
+++ b/app/javascript/mastodon/components/relative_timestamp.tsx
@@ -191,7 +191,7 @@ const timeRemainingString = (
 interface Props {
   intl: IntlShape;
   timestamp: string;
-  year: number;
+  year?: number;
   futureDate?: boolean;
   short?: boolean;
 }
@@ -201,11 +201,6 @@ interface States {
 class RelativeTimestamp extends Component<Props, States> {
   state = {
     now: Date.now(),
-  };
-
-  static defaultProps = {
-    year: new Date().getFullYear(),
-    short: true,
   };
 
   _timer: number | undefined;
@@ -257,7 +252,13 @@ class RelativeTimestamp extends Component<Props, States> {
   }
 
   render() {
-    const { timestamp, intl, year, futureDate, short } = this.props;
+    const {
+      timestamp,
+      intl,
+      futureDate,
+      year = new Date().getFullYear(),
+      short = true,
+    } = this.props;
 
     const timeGiven = timestamp.includes('T');
     const date = new Date(timestamp);


### PR DESCRIPTION
`defaultProps` is not easy to use with Typescript.

I switched it to default values in destructuring instead, which now allows to not provide a `year` prop without having a TS error.

Extracted from #29774