### PR TITLE
Fix logo pushing header buttons out of view on certain conditions in mobile layout

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2612,6 +2612,7 @@ a.account__display-name {
 }
 
 $ui-header-height: 55px;
+$ui-header-logo-wordmark-width: 99px;
 
 .ui__header {
   display: none;
@@ -2627,6 +2628,10 @@ $ui-header-height: 55px;
   &__logo {
     display: inline-flex;
     padding: 15px;
+    flex-grow: 1;
+    flex-shrink: 1;
+    overflow: hidden;
+    container: header-logo / inline-size;
 
     .logo {
       height: $ui-header-height - 30px;
@@ -2637,7 +2642,7 @@ $ui-header-height: 55px;
       display: none;
     }
 
-    @media screen and (width >= 320px) {
+    @container header-logo (min-width: #{$ui-header-logo-wordmark-width}) {
       .logo--wordmark {
         display: block;
       }
@@ -2654,6 +2659,7 @@ $ui-header-height: 55px;
     gap: 10px;
     padding: 0 10px;
     overflow: hidden;
+    flex-shrink: 0;
 
     .button {
       flex: 0 0 auto;


### PR DESCRIPTION
This changes the logo container so it is able to grow and shrink, and changes logo variant switching from a media query to a container query. This allows appropriate switching regardless of language, at the cost of one hardcoded value (expected width of the wordmark variant of the logo) in the CSS and use of relatively newer CSS features.

According to https://caniuse.com/css-container-queries, CSS container queries are supported by a little over 90% of the browsers. In the case where they are not supported, this PR will use the wordless variant of the logo, maximizing usability.