### PR TITLE
Change the `theme-color` value automatically when using a built-in theme

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -164,8 +164,11 @@ module ApplicationHelper
     if theme == 'system'
       concat stylesheet_pack_tag('mastodon-light', media: 'not all and (prefers-color-scheme: dark)', crossorigin: 'anonymous')
       concat stylesheet_pack_tag('default', media: '(prefers-color-scheme: dark)', crossorigin: 'anonymous')
+      concat tag.meta name: 'theme-color', content: Themes::MASTODON_DARK_THEME_COLOR, media: '(prefers-color-scheme: dark)'
+      concat tag.meta name: 'theme-color', content: Themes::MASTODON_LIGHT_THEME_COLOR, media: '(prefers-color-scheme: light)'
     else
-      stylesheet_pack_tag theme, media: 'all', crossorigin: 'anonymous'
+      concat stylesheet_pack_tag theme, media: 'all', crossorigin: 'anonymous'
+      concat tag.meta name: 'theme-color', content: theme == 'mastodon-light' ? Themes::MASTODON_LIGHT_THEME_COLOR : Themes::MASTODON_DARK_THEME_COLOR
     end
   end
 

--- a/app/lib/themes.rb
+++ b/app/lib/themes.rb
@@ -6,6 +6,9 @@ require 'yaml'
 class Themes
   include Singleton
 
+  MASTODON_DARK_THEME_COLOR = '#191b22'
+  MASTODON_LIGHT_THEME_COLOR = '#f3f5f7'
+
   def initialize
     @conf = YAML.load_file(Rails.root.join('config', 'themes.yml'))
   end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -21,7 +21,6 @@
 
     %link{ rel: 'mask-icon', href: frontend_asset_path('images/logo-symbol-icon.svg'), color: '#6364FF' }/
     %link{ rel: 'manifest', href: manifest_path(format: :json) }/
-    %meta{ name: 'theme-color', content: '#191b22' }/
     %meta{ name: 'apple-mobile-web-app-capable', content: 'yes' }/
 
     %title= html_title


### PR DESCRIPTION
This can probably be improved when using third-party themes, but this will not be worse than what currently exists.

Fixes #29793