### PR TITLE
Fix Redux Middleware types

### DIFF
--- a/app/javascript/mastodon/store/middlewares/errors.ts
+++ b/app/javascript/mastodon/store/middlewares/errors.ts
@@ -19,7 +19,8 @@ function isActionWithmaybeAlertParams(
   return isAction(action);
 }
 
-export const errorsMiddleware: Middleware<Record<string, never>, RootState> =
+// eslint-disable-next-line @typescript-eslint/ban-types -- we need to use `{}` here to ensure the dispatch types can be merged
+export const errorsMiddleware: Middleware<{}, RootState> =
   ({ dispatch }) =>
   (next) =>
   (action) => {

--- a/app/javascript/mastodon/store/middlewares/sounds.ts
+++ b/app/javascript/mastodon/store/middlewares/sounds.ts
@@ -51,7 +51,8 @@ const play = (audio: HTMLAudioElement) => {
 };
 
 export const soundsMiddleware = (): Middleware<
-  Record<string, never>,
+  // eslint-disable-next-line @typescript-eslint/ban-types -- we need to use `{}` here to ensure the dispatch types can be merged
+  {},
   RootState
 > => {
   const soundCache: Record<string, HTMLAudioElement> = {};


### PR DESCRIPTION
Even if ESLint complains about using `{}` here, this is needed for the `AppDispatch` types to be merged correctly.

See https://github.com/reduxjs/redux-toolkit/discussions/4312#discussioncomment-8950910 for the full explanation


Needed for #29789