### PR TITLE
Fix light theme header on mobile

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2899,7 +2899,7 @@ $ui-header-logo-wordmark-width: 99px;
   .layout-single-column {
     .ui__header {
       display: flex;
-      background: var(--background-color-tint);
+      background: var(--background-color);
       border-bottom: 1px solid var(--background-border-color);
     }
 


### PR DESCRIPTION
Follow up to #29803

Previous PR did not account for UI view on narrow width desktop or mobile devices. Now light theme will be consistent with dark on both.

Before
![image](https://github.com/mastodon/mastodon/assets/3002053/f9ed3644-4d73-437f-bb58-3c903a9740d0)

After
![image](https://github.com/mastodon/mastodon/assets/3002053/9d73e20a-3b4e-4e83-92be-0e58f2330acc)
