### PR TITLE
Use integers and not numbers in notification policy API counters

### DIFF
--- a/app/javascript/mastodon/features/notifications/components/filtered_notifications_banner.jsx
+++ b/app/javascript/mastodon/features/notifications/components/filtered_notifications_banner.jsx
@@ -27,7 +27,7 @@ export const FilteredNotificationsBanner = () => {
     };
   }, [dispatch]);
 
-  if (policy === null || policy.getIn(['summary', 'pending_notifications_count']) * 1 === 0) {
+  if (policy === null || policy.getIn(['summary', 'pending_notifications_count']) === 0) {
     return null;
   }
 

--- a/app/javascript/mastodon/utils/numbers.ts
+++ b/app/javascript/mastodon/utils/numbers.ts
@@ -70,10 +70,10 @@ export function roundTo10(num: number): number {
   return Math.round(num * 0.1) / 0.1;
 }
 
-export function toCappedNumber(num: string): string {
-  if (parseInt(num) > 99) {
-    return '99+';
+export function toCappedNumber(num: number, max = 99): string {
+  if (num > max) {
+    return `${max}+`;
   } else {
-    return num;
+    return num.toString();
   }
 }

--- a/app/serializers/rest/notification_policy_serializer.rb
+++ b/app/serializers/rest/notification_policy_serializer.rb
@@ -9,8 +9,8 @@ class REST::NotificationPolicySerializer < ActiveModel::Serializer
 
   def summary
     {
-      pending_requests_count: object.pending_requests_count.to_s,
-      pending_notifications_count: object.pending_notifications_count.to_s,
+      pending_requests_count: object.pending_requests_count.to_i,
+      pending_notifications_count: object.pending_notifications_count.to_i,
     }
   end
 end

--- a/spec/requests/api/v1/notifications/policies_spec.rb
+++ b/spec/requests/api/v1/notifications/policies_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe 'Policies' do
           filter_new_accounts: false,
           filter_private_mentions: true,
           summary: a_hash_including(
-            pending_requests_count: '1',
-            pending_notifications_count: '0'
+            pending_requests_count: 1,
+            pending_notifications_count: 0
           )
         )
       end
@@ -60,8 +60,8 @@ RSpec.describe 'Policies' do
         filter_new_accounts: false,
         filter_private_mentions: true,
         summary: a_hash_including(
-          pending_requests_count: '0',
-          pending_notifications_count: '0'
+          pending_requests_count: 0,
+          pending_notifications_count: 0
         )
       )
     end


### PR DESCRIPTION
I could not find a reason for those to be strings. They will never be large enough to not fit an integer, and this is a cleaner interface