### PR TITLE
Fix contrast in notification request badge

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -10104,9 +10104,10 @@ noscript {
     }
 
     .filtered-notifications-banner__badge {
-      background-color: $highlight-text-color;
+      background: $ui-button-background-color;
       border-radius: 4px;
       padding: 1px 6px;
+      color: $white;
     }
   }
 


### PR DESCRIPTION
## Before

![image](https://github.com/mastodon/mastodon/assets/384364/edea25cb-68d2-46cf-858d-26ba8930e04e)
![image](https://github.com/mastodon/mastodon/assets/384364/f0fc8a72-9138-42fe-b15b-187f7033812e)

## After

![image](https://github.com/mastodon/mastodon/assets/384364/f811cf7e-9207-44cc-8021-51a35cf5b063)
![image](https://github.com/mastodon/mastodon/assets/384364/4ae770a1-2053-493b-9d68-f2fbf379fdc3)