### PR TITLE
Fix language and emoji search field background colors on light theme

### DIFF
--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -480,7 +480,8 @@ html {
 .compose-form,
 .spoiler-input__input,
 .search__input,
-.search__popout {
+.search__popout,
+.emoji-mart-search {
   color: lighten($ui-highlight-color, 8%);
 }
 
@@ -488,6 +489,7 @@ html {
 .compose-form__highlightable,
 .search__input,
 .search__popout,
+.emoji-mart-search,
 .poll__option input[type='text'] {
   background: darken($ui-base-color, 10%);
 }

--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -486,6 +486,7 @@ html {
 .search__input,
 .search__popout,
 .emoji-mart-search input,
+.language-dropdown__dropdown .emoji-mart-search input,
 .poll__option input[type='text'] {
   background: darken($ui-base-color, 10%);
 }

--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -485,7 +485,7 @@ html {
 .compose-form__highlightable,
 .search__input,
 .search__popout,
-.emoji-mart-search__input input[type='search'],
+.emoji-mart-search input,
 .poll__option input[type='text'] {
   background: darken($ui-base-color, 10%);
 }

--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -477,11 +477,7 @@ html {
   color: $white;
 }
 
-.compose-form,
-.spoiler-input__input,
-.search__input,
-.search__popout,
-.emoji-mart-search__input {
+.compose-form .spoiler-input__input {
   color: lighten($ui-highlight-color, 8%);
 }
 

--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -481,7 +481,7 @@ html {
 .spoiler-input__input,
 .search__input,
 .search__popout,
-.emoji-mart-search {
+.emoji-mart-search__input {
   color: lighten($ui-highlight-color, 8%);
 }
 
@@ -489,7 +489,7 @@ html {
 .compose-form__highlightable,
 .search__input,
 .search__popout,
-.emoji-mart-search,
+.emoji-mart-search__input,
 .poll__option input[type='text'] {
   background: darken($ui-base-color, 10%);
 }

--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -485,7 +485,7 @@ html {
 .compose-form__highlightable,
 .search__input,
 .search__popout,
-.emoji-mart-search__input,
+.emoji-mart-search__input input[type='search'],
 .poll__option input[type='text'] {
   background: darken($ui-base-color, 10%);
 }


### PR DESCRIPTION
Applies same coloring scheme to `.emoji-mart-search` input that was done in #29808