### PR TITLE
Fix blue border on emoji/language search in Safari & Chrome

### DIFF
--- a/app/javascript/styles/mastodon/emoji_picker.scss
+++ b/app/javascript/styles/mastodon/emoji_picker.scss
@@ -112,10 +112,9 @@
       border: 0;
     }
 
-    &::-moz-focus-inner,
     &:focus,
     &:active {
-      outline: 0 !important;
+      outline: none !important;
     }
 
     &::-webkit-search-cancel-button {


### PR DESCRIPTION
While working on #29828 I noticed that the emoji/language search fields always have a thick blue border around them when none of the text input boxes have this behavior. This is seen in both light and dark themes but only in Safari and Chrome. Firefox previously rendered it correctly.

Before, Mozilla:
![CleanShot 2024-04-02 at 15 21 18@2x](https://github.com/mastodon/mastodon/assets/3002053/1ecaf773-2f50-4eeb-8ac7-2f203c2911e4)

Before, Safari/Chrome:
![CleanShot 2024-04-02 at 15 21 57@2x](https://github.com/mastodon/mastodon/assets/3002053/7c0caaae-2264-4363-8803-1512a4f739a7)

This is resolved by setting the outline for the active/focus view of the input field to `none` instead of `0`

After, Mozilla:
![CleanShot 2024-04-02 at 15 25 05@2x](https://github.com/mastodon/mastodon/assets/3002053/a9995b55-679d-4b03-9ba9-42c5c0d60b2d)

After, Safari:
![CleanShot 2024-04-02 at 15 24 34@2x](https://github.com/mastodon/mastodon/assets/3002053/810b792c-1778-47e9-8cef-96b38f76fe49)
