### PR TITLE
Move OAuth flow tests from feature tests to system tests

### DIFF
--- a/spec/system/oauth_spec.rb
+++ b/spec/system/oauth_spec.rb
@@ -10,9 +10,7 @@ describe 'Using OAuth from an external app' do
 
     before do
       visit new_user_session_path
-      fill_in 'user_email', with: user.email
-      fill_in 'user_password', with: user.password
-      click_on I18n.t('auth.login')
+      fill_in_auth_details(user.email, user.password)
     end
 
     it 'when accepting the authorization request' do
@@ -167,20 +165,19 @@ describe 'Using OAuth from an external app' do
         expect(Doorkeeper::AccessGrant.exists?(application: client_app, resource_owner_id: user.id)).to be false
       end
     end
-
-    private
-
-    def fill_in_auth_details(email, password)
-      fill_in 'user_email', with: email
-      fill_in 'user_password', with: password
-      click_on I18n.t('auth.login')
-    end
-
-    def fill_in_otp_details(value)
-      fill_in 'user_otp_attempt', with: value
-      click_on I18n.t('auth.login')
-    end
-
     # TODO: external auth
+  end
+
+  private
+
+  def fill_in_auth_details(email, password)
+    fill_in 'user_email', with: email
+    fill_in 'user_password', with: password
+    click_on I18n.t('auth.login')
+  end
+
+  def fill_in_otp_details(value)
+    fill_in 'user_otp_attempt', with: value
+    click_on I18n.t('auth.login')
   end
 end

--- a/spec/system/oauth_spec.rb
+++ b/spec/system/oauth_spec.rb
@@ -3,13 +3,16 @@
 require 'rails_helper'
 
 describe 'Using OAuth from an external app' do
-  let(:client_app) { Doorkeeper::Application.create!(name: 'test', redirect_uri: 'http://localhost/', scopes: 'read') }
+  let(:client_app) { Doorkeeper::Application.create!(name: 'test', redirect_uri: 'http://localhost/health', scopes: 'read') }
 
   context 'when the user is already logged in' do
     let!(:user) { Fabricate(:user) }
 
     before do
-      sign_in user, scope: :user
+      visit new_user_session_path
+      fill_in 'user_email', with: user.email
+      fill_in 'user_password', with: user.password
+      click_on I18n.t('auth.login')
     end
 
     it 'when accepting the authorization request' do


### PR DESCRIPTION
Attempt to run in these tests in a real browser, since browsers may possibly behave differently than Capybara regarding redirects and cookies.

Changed the callback address to `http://localhost/health` so that it's accessible to Capybara and different from the default redirect. Ideally, we want something entirely distinct from the Rails app here.