### PR TITLE
Add purple border to active compose field search inputs

### DIFF
--- a/app/javascript/styles/mastodon/emoji_picker.scss
+++ b/app/javascript/styles/mastodon/emoji_picker.scss
@@ -113,8 +113,7 @@
     }
 
     &:active,
-    &:focus,
-    &:hover {
+    &:focus {
       outline: none !important;
       border-width: 1px !important;
       border-color: $ui-button-background-color;

--- a/app/javascript/styles/mastodon/emoji_picker.scss
+++ b/app/javascript/styles/mastodon/emoji_picker.scss
@@ -115,8 +115,9 @@
     &:active,
     &:focus,
     &:hover {
-      border-width: 4px !important;
-      border-color: lighten($inverted-text-color, 15%);
+      outline: none !important;
+      border-width: 1px !important;
+      border-color: $ui-button-background-color;
     }
 
     &::-webkit-search-cancel-button {

--- a/app/javascript/styles/mastodon/emoji_picker.scss
+++ b/app/javascript/styles/mastodon/emoji_picker.scss
@@ -112,10 +112,10 @@
       border: 0;
     }
 
-    &::-moz-focus-inner,
     &:focus,
     &:active {
       outline: 0 !important;
+      border-color: lighten($inverted-text-color, 15%);
     }
 
     &::-webkit-search-cancel-button {

--- a/app/javascript/styles/mastodon/emoji_picker.scss
+++ b/app/javascript/styles/mastodon/emoji_picker.scss
@@ -112,9 +112,10 @@
       border: 0;
     }
 
+    &:active,
     &:focus,
-    &:active {
-      outline: 0 !important;
+    &:hover {
+      border-width: 4px !important;
       border-color: lighten($inverted-text-color, 15%);
     }
 


### PR DESCRIPTION
Feedback from #29832 was that the search fields in the emoji and language pop-outs should have a consistent highlight for accessibility and consistency with the rest of the interface. This adds those, consistent across tested browsers of Firefox, Safari and Chrome/Edge in light and dark mode.

![CleanShot 2024-04-03 at 10 53 44](https://github.com/mastodon/mastodon/assets/3002053/b2406823-f843-4049-ba90-26a25538d490)
![CleanShot 2024-04-03 at 11 05 40](https://github.com/mastodon/mastodon/assets/3002053/60432266-8d65-4060-8b84-fce657e171b7)
