### PR TITLE
Improve spec for dimension/languages admin metric

### DIFF
--- a/spec/lib/admin/metrics/dimension/languages_dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension/languages_dimension_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe Admin::Metrics::Dimension::LanguagesDimension do
-  subject(:dimension) { described_class.new(start_at, end_at, limit, params) }
+  subject { described_class.new(start_at, end_at, limit, params) }
 
   let(:start_at) { 2.days.ago }
   let(:end_at) { Time.now.utc }
@@ -11,8 +11,21 @@ describe Admin::Metrics::Dimension::LanguagesDimension do
   let(:params) { ActionController::Parameters.new }
 
   describe '#data' do
-    it 'runs data query without error' do
-      expect { dimension.data }.to_not raise_error
+    let(:alice) { Fabricate(:user, locale: 'en', current_sign_in_at: 1.day.ago) }
+    let(:bob) { Fabricate(:user, locale: 'en', current_sign_in_at: 30.days.ago) }
+
+    before do
+      alice.update(current_sign_in_at: 1.day.ago)
+      bob.update(current_sign_in_at: 30.days.ago)
+    end
+
+    it 'returns locales with sign in counts' do
+      expect(subject.data.size)
+        .to eq(1)
+      expect(subject.data.map(&:symbolize_keys))
+        .to contain_exactly(
+          include(key: 'en', value: '1')
+        )
     end
   end
 end


### PR DESCRIPTION
Previously this spec was just running the query without any data to make sure we didn't throw an error (that coverage was an improvement on the previous scenario where the code was not exercised at all). This PR updates the spec to add a basic set of data and assert that the results are as expected.

This is just one of the spec improvements pulled out from https://github.com/mastodon/mastodon/pull/28736 - opening this on the hope that if we have a smaller target (just one spec) to review, it may then be easier to review the whole thing (which is just repeating this pattern over and over) without needing to do ~20 PRs for all of them (of course, if that's preferred, tell me and I'll do that).