### PR TITLE
Use partial collection render for welcome mailer features

### DIFF
--- a/app/views/application/mailer/_feature.html.haml
+++ b/app/views/application/mailer/_feature.html.haml
@@ -4,7 +4,7 @@
       %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
         %tr
           %td.email-feature-td
-            .email-desktop-flex{ class: ('email-dir-rtl' if defined?(text_first_on_desktop) && !text_first_on_desktop) }
+            .email-desktop-flex{ class: ('email-dir-rtl' if feature_iteration.index.odd?) }
               /[if mso]
                 <table border="0" cellpadding="0" cellspacing="0" align="center" style="width:100%;" role="presentation"><tr><td style="width:50%; vertical-align:top;">
               .email-desktop-column
@@ -24,7 +24,7 @@
                   %tr
                     %td.email-column-td
                       - if defined?(feature)
-                        %p{ class: ('email-desktop-text-right' if defined?(text_first_on_desktop) && text_first_on_desktop) }
+                        %p{ class: ('email-desktop-text-right' if feature_iteration.index.even?) }
                           = image_tag frontend_asset_url("images/mailer-new/welcome/feature_#{feature}.png"), alt: '', width: 240, height: 230
               /[if mso]
                 </td></tr></table>

--- a/app/views/user_mailer/welcome.html.haml
+++ b/app/views/user_mailer/welcome.html.haml
@@ -68,7 +68,4 @@
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-extra-td
-      = render 'application/mailer/feature', feature: 'control', text_first_on_desktop: true
-      = render 'application/mailer/feature', feature: 'audience', text_first_on_desktop: false
-      = render 'application/mailer/feature', feature: 'moderation', text_first_on_desktop: true
-      = render 'application/mailer/feature', feature: 'creativity', text_first_on_desktop: false
+      = render partial: 'application/mailer/feature', collection: %w(control audience moderation creativity)


### PR DESCRIPTION
Follow up on https://github.com/mastodon/mastodon/pull/29760 - two changes:

- Use a partial collection render in the main welcome mailer, looping through the list of features (could move this to the mailer itself or a presenter in future)
- Since we're using collection loop, we can get rid of the alternating true/false text first on desktop variable, and use the internal loop iterator instead to move the text/image back and forth alignment wise