### PR TITLE
Makes the star icon rotate around its actual centre axis

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2244,14 +2244,14 @@ a.account__display-name {
   &.activate {
     & > .icon {
       animation: spring-rotate-in 1s linear;
-      transform-origin: 50% 55%;
+      transform-origin: 50% 52%;
     }
   }
 
   &.deactivate {
     & > .icon {
       animation: spring-rotate-out 1s linear;
-      transform-origin: 50% 55%;
+      transform-origin: 50% 52%;
     }
   }
 }


### PR DESCRIPTION
The 55% value is slightly too low visually, meaning the star wiggles a bit. Measured 52% (rounded from 52.0833333) with the icon file opened in a vector editing software from the top of the icon canvas to the actual geometrical centre of the star shape. Tried it out in dev tools, and it’s smoother :)