### PR TITLE
Add stub for trending tags in user mailer spec

### DIFF
--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -247,6 +247,12 @@ describe UserMailer do
   describe '#welcome' do
     let(:mail) { described_class.welcome(receiver) }
 
+    before do
+      # This is a bit hacky and low-level but this allows stubbing trending tags
+      tag_ids = Fabricate.times(5, :tag).pluck(:id)
+      allow(Trends.tags).to receive(:query).and_return(instance_double(Trends::Query, allowed: Tag.where(id: tag_ids)))
+    end
+
     it 'renders welcome mail' do
       expect(mail)
         .to be_present


### PR DESCRIPTION
Not completely satisfied with it, but it extends coverage and would have caught #29847