### PR TITLE
Fix rendering of images with too small aspect ratios (#29310)

### DIFF
--- a/app/javascript/mastodon/components/media_gallery.jsx
+++ b/app/javascript/mastodon/components/media_gallery.jsx
@@ -287,7 +287,9 @@ class MediaGallery extends PureComponent {
 
   isFullSizeEligible() {
     const { media } = this.props;
-    return media.size === 1 && media.getIn([0, 'meta', 'small', 'aspect']);
+    const aspect = media.getIn([0, 'meta', 'small', 'aspect']);
+    const minAspectRatioThreshold = 3/2;
+    return media.size === 1 && typeof aspect === 'number' && aspect >= minAspectRatioThreshold;
   }
 
   render () {


### PR DESCRIPTION
When posting a picture with a very small aspect ratio, it can block the rest of the app by being rendered in full.
Fixed by checking for a minimum aspect ratio before rendering images, fixing #29310