### PR TITLE
Fix webpack warnings due to unhandled extensions (`LICENCE` and `README.md`)

### DIFF
--- a/app/javascript/mastodon/common.js
+++ b/app/javascript/mastodon/common.js
@@ -2,7 +2,7 @@ import Rails from '@rails/ujs';
 import 'font-awesome/css/font-awesome.css';
 
 export function start() {
-  require.context('../images/', true);
+  require.context('../images/', true, /\.(jpg|png|svg)$/);
 
   try {
     Rails.start();


### PR DESCRIPTION
Prior to this fix, Webpack is showing those warnings because it does not know how to handle the `README.md` and `LICENCE` files in `app/javascript/images`.

The fix here is to use an allow list when requiring those. From what I understand, the `require.context` call here is to cause those assets to be processed by Webpack so they can be used without being references in a JS or CSS file.

```
WARNING in ./app/javascript/images/mailer-new/heading/README.md 1:15
Module parse failed: Unexpected token (1:15)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
> Images in this folder are based on [Tabler.io icons](https://tabler.io/icons).
| 
 @ ./app/javascript/images sync ^\.\/.*$ ./mailer-new/heading/README.md
 @ ./app/javascript/mastodon/common.js
 @ ./app/javascript/packs/share.jsx

WARNING in ./app/javascript/images/mailer-new/welcome-icons/README.md 1:15
Module parse failed: Unexpected token (1:15)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
> Images in this folder are based on [Tabler.io icons](https://tabler.io/icons).
| 
 @ ./app/javascript/images sync ^\.\/.*$ ./mailer-new/welcome-icons/README.md
 @ ./app/javascript/mastodon/common.js
 @ ./app/javascript/packs/share.jsx

WARNING in ./app/javascript/images/mailer-new/heading/LICENSE 1:4
Module parse failed: Unexpected token (1:4)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
> MIT License
| 
| Copyright (c) 2020-2024 Paweł Kuna
 @ ./app/javascript/images sync ^\.\/.*$ ./mailer-new/heading/LICENSE
 @ ./app/javascript/mastodon/common.js
 @ ./app/javascript/packs/share.jsx

WARNING in ./app/javascript/images/mailer-new/welcome-icons/LICENSE 1:4
Module parse failed: Unexpected token (1:4)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
> MIT License
| 
| Copyright (c) 2020-2024 Paweł Kuna
 @ ./app/javascript/images sync ^\.\/.*$ ./mailer-new/welcome-icons/LICENSE
 @ ./app/javascript/mastodon/common.js
 @ ./app/javascript/packs/share.jsx

```