### PR TITLE
Fix hashtag string interpolation in welcome email

### DIFF
--- a/app/views/application/mailer/_hashtag.html.haml
+++ b/app/views/application/mailer/_hashtag.html.haml
@@ -17,4 +17,5 @@
                           %span.email-mini-hashtag-img-span
                             = image_tag full_asset_url(account.avatar.url), alt: '', width: 16, height: 16
                       %td
-                        %p= t('user_mailer.welcome.hashtags_recent_count', people: number_with_delimiter(hashtag.history.aggregate(2.days.ago.to_date..Time.zone.today).accounts))
+                        - people = hashtag.history.aggregate(2.days.ago.to_date..Time.zone.today).accounts
+                        %p= t('user_mailer.welcome.hashtags_recent_count', people: number_with_delimiter(people), count: people)


### PR DESCRIPTION
Fixes #29867

There were two issues:
- `I18n.t` uses the `count` parameter for pluralized keys
- `people` was a formatted string, and not a number