### PR TITLE
Add condition to only parse redis port and redis db vars if REDIS_URL is not set

### DIFF
--- a/streaming/index.js
+++ b/streaming/index.js
@@ -241,20 +241,18 @@ const redisConfigFromEnv = (env) => {
   // which means we can't use it. But this is something that should be looked into.
   const redisPrefix = env.REDIS_NAMESPACE ? `${env.REDIS_NAMESPACE}:` : '';
 
-  let redisPort = parseIntFromEnv(env.REDIS_PORT, 6379, 'REDIS_PORT');
-  let redisDatabase = parseIntFromEnv(env.REDIS_DB, 0, 'REDIS_DB');
-
   /** @type {import('ioredis').RedisOptions} */
-  const redisParams = {
+  const redisParams = typeof env.REDIS_URL !== 'string' ? {
     host: env.REDIS_HOST || '127.0.0.1',
-    port: redisPort,
+    port: parseIntFromEnv(env.REDIS_PORT, 6379, 'REDIS_PORT'),
     // Force support for both IPv6 and IPv4, by default ioredis sets this to 4,
     // only allowing IPv4 connections:
     // https://github.com/redis/ioredis/issues/1576
     family: 0,
-    db: redisDatabase,
+    db: parseIntFromEnv(env.REDIS_DB, 0, 'REDIS_DB'),
     password: env.REDIS_PASSWORD || undefined,
-  };
+  } : {};
+  
 
   // redisParams.path takes precedence over host and port.
   if (env.REDIS_URL && env.REDIS_URL.startsWith('unix://')) {


### PR DESCRIPTION
Addresses #29770 by only requiring REDIS_PORT/DB to be set to number if REDIS_URL is not set.