### PR TITLE
Use fabrication sequence in domain values

### DIFF
--- a/spec/fabricators/preview_card_provider_fabricator.rb
+++ b/spec/fabricators/preview_card_provider_fabricator.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 Fabricator(:preview_card_provider) do
-  domain { Faker::Internet.domain_name }
+  domain { sequence(:domain) { |i| "#{i}#{Faker::Internet.domain_name}" } }
 end

--- a/spec/fabricators/unavailable_domain_fabricator.rb
+++ b/spec/fabricators/unavailable_domain_fabricator.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 Fabricator(:unavailable_domain) do
-  domain { Faker::Internet.domain_name }
+  domain { sequence(:domain) { |i| "#{i}#{Faker::Internet.domain_name}" } }
 end


### PR DESCRIPTION
I'm assuming this intermittent failure was from a value duplication - https://github.com/mastodon/mastodon/actions/runs/8635114963/job/23672237736?pr=29878

The other fabricators with domain columns already had this approach, just copy/pasted from those.