### PR TITLE
Add display_name to push notification payload

### DIFF
--- a/app/serializers/web/notification_serializer.rb
+++ b/app/serializers/web/notification_serializer.rb
@@ -6,7 +6,7 @@ class Web::NotificationSerializer < ActiveModel::Serializer
   include ActionView::Helpers::SanitizeHelper
 
   attributes :access_token, :preferred_locale, :notification_id,
-             :notification_type, :icon, :title, :body
+             :notification_type, :icon, :display_name, :title, :body
 
   def access_token
     current_push_subscription.associated_access_token

--- a/app/serializers/web/notification_serializer.rb
+++ b/app/serializers/web/notification_serializer.rb
@@ -28,8 +28,12 @@ class Web::NotificationSerializer < ActiveModel::Serializer
     full_asset_url(object.from_account.avatar_static_url)
   end
 
+  def display_name
+    object.from_account.display_name.presence || object.from_account.username
+  end
+
   def title
-    I18n.t("notification_mailer.#{object.type}.subject", name: object.from_account.display_name.presence || object.from_account.username)
+    I18n.t("notification_mailer.#{object.type}.subject", name: display_name)
   end
 
   def body


### PR DESCRIPTION
## Context

iOS has a special type of notifications called [communication notifications](https://developer.apple.com/documentation/usernotifications/implementing-communication-notifications), it looks like this:

![IMG_1069](https://github.com/mastodon/mastodon/assets/6008854/dd027d8c-019d-4b47-8ea8-8857cdbb0f80)

Its minimal requirements are:
- an profile image
- an display name

With current implementation of Web::NotificationSerializer, profile image can be get from `icon`, and notification body can be construct from `notification_type` and `body`. But there's no proper way to extract display name from `title`. Therefore iOS apps with communication notifications enabled need send an extra request to the server to get display name.

## Proposal 

I'd like to add display name to push notification payload directly. Doing this can both speed up push notification processing on clients, and reduce server loads by remove the extra request from clients.