### PR TITLE
Expand coverage for admin/metrics/dimension/* classes

### DIFF
--- a/spec/lib/admin/metrics/dimension/instance_accounts_dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension/instance_accounts_dimension_spec.rb
@@ -3,16 +3,32 @@
 require 'rails_helper'
 
 describe Admin::Metrics::Dimension::InstanceAccountsDimension do
-  subject(:dimension) { described_class.new(start_at, end_at, limit, params) }
+  subject { described_class.new(start_at, end_at, limit, params) }
 
   let(:start_at) { 2.days.ago }
   let(:end_at) { Time.now.utc }
   let(:limit) { 10 }
-  let(:params) { ActionController::Parameters.new }
+  let(:params) { ActionController::Parameters.new(domain: domain) }
 
   describe '#data' do
-    it 'runs data query without error' do
-      expect { dimension.data }.to_not raise_error
+    let(:domain) { 'host.example' }
+    let(:alice) { Fabricate(:account, domain: domain) }
+    let(:bob) { Fabricate(:account) }
+
+    before do
+      Fabricate :follow, target_account: alice
+      Fabricate :follow, target_account: bob
+      Fabricate :status, account: alice
+      Fabricate :status, account: bob
+    end
+
+    it 'returns instances with follow counts' do
+      expect(subject.data.size)
+        .to eq(1)
+      expect(subject.data.map(&:symbolize_keys))
+        .to contain_exactly(
+          include(key: alice.username, value: '1')
+        )
     end
   end
 end

--- a/spec/lib/admin/metrics/dimension/instance_languages_dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension/instance_languages_dimension_spec.rb
@@ -3,16 +3,30 @@
 require 'rails_helper'
 
 describe Admin::Metrics::Dimension::InstanceLanguagesDimension do
-  subject(:dimension) { described_class.new(start_at, end_at, limit, params) }
+  subject { described_class.new(start_at, end_at, limit, params) }
 
   let(:start_at) { 2.days.ago }
   let(:end_at) { Time.now.utc }
   let(:limit) { 10 }
-  let(:params) { ActionController::Parameters.new }
+  let(:params) { ActionController::Parameters.new(domain: domain) }
 
   describe '#data' do
-    it 'runs data query without error' do
-      expect { dimension.data }.to_not raise_error
+    let(:domain) { 'host.example' }
+    let(:alice) { Fabricate(:account, domain: domain) }
+    let(:bob) { Fabricate(:account) }
+
+    before do
+      Fabricate :status, account: alice, language: 'en'
+      Fabricate :status, account: bob, language: 'es'
+    end
+
+    it 'returns locales with status counts' do
+      expect(subject.data.size)
+        .to eq(1)
+      expect(subject.data.map(&:symbolize_keys))
+        .to contain_exactly(
+          include(key: 'en', value: '1')
+        )
     end
   end
 end

--- a/spec/lib/admin/metrics/dimension/servers_dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension/servers_dimension_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe Admin::Metrics::Dimension::ServersDimension do
-  subject(:dimension) { described_class.new(start_at, end_at, limit, params) }
+  subject { described_class.new(start_at, end_at, limit, params) }
 
   let(:start_at) { 2.days.ago }
   let(:end_at) { Time.now.utc }
@@ -11,8 +11,24 @@ describe Admin::Metrics::Dimension::ServersDimension do
   let(:params) { ActionController::Parameters.new }
 
   describe '#data' do
-    it 'runs data query without error' do
-      expect { dimension.data }.to_not raise_error
+    let(:domain) { 'host.example' }
+    let(:alice) { Fabricate(:account, domain: domain) }
+    let(:bob) { Fabricate(:account) }
+
+    before do
+      Fabricate :status, account: alice, created_at: 1.day.ago
+      Fabricate :status, account: alice, created_at: 30.days.ago
+      Fabricate :status, account: bob, created_at: 1.day.ago
+    end
+
+    it 'returns domains with status counts' do
+      expect(subject.data.size)
+        .to eq(2)
+      expect(subject.data.map(&:symbolize_keys))
+        .to contain_exactly(
+          include(key: domain, value: '1'),
+          include(key: Rails.configuration.x.local_domain, value: '1')
+        )
     end
   end
 end

--- a/spec/lib/admin/metrics/dimension/software_versions_dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension/software_versions_dimension_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe Admin::Metrics::Dimension::SoftwareVersionsDimension do
-  subject(:dimension) { described_class.new(start_at, end_at, limit, params) }
+  subject { described_class.new(start_at, end_at, limit, params) }
 
   let(:start_at) { 2.days.ago }
   let(:end_at) { Time.now.utc }
@@ -11,8 +11,12 @@ describe Admin::Metrics::Dimension::SoftwareVersionsDimension do
   let(:params) { ActionController::Parameters.new }
 
   describe '#data' do
-    it 'runs data query without error' do
-      expect { dimension.data }.to_not raise_error
+    it 'reports on the running software' do
+      expect(subject.data.map(&:symbolize_keys))
+        .to include(
+          include(key: 'mastodon', value: Mastodon::Version.to_s),
+          include(key: 'ruby', value: include(RUBY_VERSION))
+        )
     end
   end
 end

--- a/spec/lib/admin/metrics/dimension/sources_dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension/sources_dimension_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe Admin::Metrics::Dimension::SourcesDimension do
-  subject(:dimension) { described_class.new(start_at, end_at, limit, params) }
+  subject { described_class.new(start_at, end_at, limit, params) }
 
   let(:start_at) { 2.days.ago }
   let(:end_at) { Time.now.utc }
@@ -11,8 +11,21 @@ describe Admin::Metrics::Dimension::SourcesDimension do
   let(:params) { ActionController::Parameters.new }
 
   describe '#data' do
-    it 'runs data query without error' do
-      expect { dimension.data }.to_not raise_error
+    let(:app) { Fabricate(:application) }
+    let(:alice) { Fabricate(:user) }
+    let(:bob) { Fabricate(:user) }
+
+    before do
+      alice.update(created_by_application: app)
+    end
+
+    it 'returns OAuth applications with user counts' do
+      expect(subject.data.size)
+        .to eq(1)
+      expect(subject.data.map(&:symbolize_keys))
+        .to contain_exactly(
+          include(key: app.name, value: '1')
+        )
     end
   end
 end

--- a/spec/lib/admin/metrics/dimension/space_usage_dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension/space_usage_dimension_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe Admin::Metrics::Dimension::SpaceUsageDimension do
-  subject(:dimension) { described_class.new(start_at, end_at, limit, params) }
+  subject { described_class.new(start_at, end_at, limit, params) }
 
   let(:start_at) { 2.days.ago }
   let(:end_at) { Time.now.utc }
@@ -11,8 +11,13 @@ describe Admin::Metrics::Dimension::SpaceUsageDimension do
   let(:params) { ActionController::Parameters.new }
 
   describe '#data' do
-    it 'runs data query without error' do
-      expect { dimension.data }.to_not raise_error
+    it 'reports on used storage space' do
+      expect(subject.data.map(&:symbolize_keys))
+        .to include(
+          include(key: 'media', value: /\d/),
+          include(key: 'postgresql', value: /\d/),
+          include(key: 'redis', value: /\d/)
+        )
     end
   end
 end

--- a/spec/lib/admin/metrics/dimension/tag_languages_dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension/tag_languages_dimension_spec.rb
@@ -3,16 +3,36 @@
 require 'rails_helper'
 
 describe Admin::Metrics::Dimension::TagLanguagesDimension do
-  subject(:dimension) { described_class.new(start_at, end_at, limit, params) }
+  subject { described_class.new(start_at, end_at, limit, params) }
 
   let(:start_at) { 2.days.ago }
   let(:end_at) { Time.now.utc }
   let(:limit) { 10 }
-  let(:params) { ActionController::Parameters.new }
+  let(:params) { ActionController::Parameters.new(id: tag.id) }
 
   describe '#data' do
-    it 'runs data query without error' do
-      expect { dimension.data }.to_not raise_error
+    let(:alice) { Fabricate(:account) }
+    let(:bob) { Fabricate(:account) }
+    let(:tag) { Fabricate(:tag) }
+
+    before do
+      alice_status_recent = Fabricate :status, account: alice, created_at: 1.day.ago, language: 'en'
+      alice_status_older = Fabricate :status, account: alice, created_at: 30.days.ago, language: 'en'
+      bob_status_recent = Fabricate :status, account: bob, created_at: 1.day.ago, language: 'es'
+
+      alice_status_older.tags << tag
+      alice_status_recent.tags << tag
+      bob_status_recent.tags << tag
+    end
+
+    it 'returns languages with tag usage counts' do
+      expect(subject.data.size)
+        .to eq(2)
+      expect(subject.data.map(&:symbolize_keys))
+        .to contain_exactly(
+          include(key: 'en', value: '1'),
+          include(key: 'es', value: '1')
+        )
     end
   end
 end

--- a/spec/lib/admin/metrics/dimension/tag_servers_dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension/tag_servers_dimension_spec.rb
@@ -3,16 +3,37 @@
 require 'rails_helper'
 
 describe Admin::Metrics::Dimension::TagServersDimension do
-  subject(:dimension) { described_class.new(start_at, end_at, limit, params) }
+  subject { described_class.new(start_at, end_at, limit, params) }
 
   let(:start_at) { 2.days.ago }
   let(:end_at) { Time.now.utc }
   let(:limit) { 10 }
-  let(:params) { ActionController::Parameters.new }
+  let(:params) { ActionController::Parameters.new(id: tag.id) }
 
   describe '#data' do
-    it 'runs data query without error' do
-      expect { dimension.data }.to_not raise_error
+    let(:alice) { Fabricate(:account, domain: domain) }
+    let(:bob) { Fabricate(:account) }
+    let(:domain) { 'host.example' }
+    let(:tag) { Fabricate(:tag) }
+
+    before do
+      alice_status_recent = Fabricate :status, account: alice, created_at: 1.day.ago
+      alice_status_older = Fabricate :status, account: alice, created_at: 30.days.ago
+      bob_status_recent = Fabricate :status, account: bob, created_at: 1.day.ago
+
+      alice_status_older.tags << tag
+      alice_status_recent.tags << tag
+      bob_status_recent.tags << tag
+    end
+
+    it 'returns servers with tag usage counts' do
+      expect(subject.data.size)
+        .to eq(2)
+      expect(subject.data.map(&:symbolize_keys))
+        .to contain_exactly(
+          include(key: domain, value: '1'),
+          include(key: Rails.configuration.x.local_domain, value: '1')
+        )
     end
   end
 end


### PR DESCRIPTION
Extracted from https://github.com/mastodon/mastodon/pull/28736 but contains only the "dimension" specs.