### PR TITLE
Expand coverage for admin/metrics/measure/* classes

### DIFF
--- a/spec/lib/admin/metrics/measure/active_users_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/active_users_measure_spec.rb
@@ -3,15 +3,38 @@
 require 'rails_helper'
 
 describe Admin::Metrics::Measure::ActiveUsersMeasure do
-  subject(:measure) { described_class.new(start_at, end_at, params) }
+  subject { described_class.new(start_at, end_at, params) }
 
   let(:start_at) { 2.days.ago }
   let(:end_at)   { Time.now.utc }
   let(:params) { ActionController::Parameters.new }
 
   describe '#data' do
-    it 'runs data query without error' do
-      expect { measure.data }.to_not raise_error
+    context 'with activity tracking records' do
+      before do
+        3.times do
+          travel_to(2.days.ago) { record_login_activity }
+        end
+        2.times do
+          travel_to(1.day.ago) { record_login_activity }
+        end
+        travel_to(0.days.ago) { record_login_activity }
+      end
+
+      it 'returns correct activity tracker counts' do
+        expect(subject.data.size)
+          .to eq(3)
+        expect(subject.data.map(&:symbolize_keys))
+          .to contain_exactly(
+            include(date: 2.days.ago.midnight.to_time, value: '3'),
+            include(date: 1.day.ago.midnight.to_time, value: '2'),
+            include(date: 0.days.ago.midnight.to_time, value: '1')
+          )
+      end
+
+      def record_login_activity
+        ActivityTracker.record('activity:logins', Fabricate(:user).id)
+      end
     end
   end
 end

--- a/spec/lib/admin/metrics/measure/instance_accounts_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/instance_accounts_measure_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe Admin::Metrics::Measure::InstanceAccountsMeasure do
-  subject(:measure) { described_class.new(start_at, end_at, params) }
+  subject { described_class.new(start_at, end_at, params) }
 
   let(:domain) { 'example.com' }
 
@@ -20,12 +20,13 @@ describe Admin::Metrics::Measure::InstanceAccountsMeasure do
     Fabricate(:account, domain: "foo.#{domain}", created_at: 1.year.ago)
     Fabricate(:account, domain: "foo.#{domain}")
     Fabricate(:account, domain: "bar.#{domain}")
+    Fabricate(:account, domain: 'other-host.example')
   end
 
-  describe 'total' do
+  describe '#total' do
     context 'without include_subdomains' do
       it 'returns the expected number of accounts' do
-        expect(measure.total).to eq 3
+        expect(subject.total).to eq 3
       end
     end
 
@@ -33,14 +34,21 @@ describe Admin::Metrics::Measure::InstanceAccountsMeasure do
       let(:params) { ActionController::Parameters.new(domain: domain, include_subdomains: 'true') }
 
       it 'returns the expected number of accounts' do
-        expect(measure.total).to eq 6
+        expect(subject.total).to eq 6
       end
     end
   end
 
   describe '#data' do
-    it 'runs data query without error' do
-      expect { measure.data }.to_not raise_error
+    it 'returns correct instance_accounts counts' do
+      expect(subject.data.size)
+        .to eq(3)
+      expect(subject.data.map(&:symbolize_keys))
+        .to contain_exactly(
+          include(date: 2.days.ago.midnight.to_time, value: '0'),
+          include(date: 1.day.ago.midnight.to_time, value: '0'),
+          include(date: 0.days.ago.midnight.to_time, value: '1')
+        )
     end
   end
 end

--- a/spec/lib/admin/metrics/measure/instance_followers_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/instance_followers_measure_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe Admin::Metrics::Measure::InstanceFollowersMeasure do
-  subject(:measure) { described_class.new(start_at, end_at, params) }
+  subject { described_class.new(start_at, end_at, params) }
 
   let(:domain) { 'example.com' }
 
@@ -22,12 +22,14 @@ describe Admin::Metrics::Measure::InstanceFollowersMeasure do
     Fabricate(:account, domain: "foo.#{domain}").follow!(local_account)
     Fabricate(:account, domain: "foo.#{domain}").follow!(local_account)
     Fabricate(:account, domain: "bar.#{domain}")
+
+    Fabricate(:account, domain: 'other.example').follow!(local_account)
   end
 
-  describe 'total' do
+  describe '#total' do
     context 'without include_subdomains' do
       it 'returns the expected number of accounts' do
-        expect(measure.total).to eq 2
+        expect(subject.total).to eq 2
       end
     end
 
@@ -35,14 +37,21 @@ describe Admin::Metrics::Measure::InstanceFollowersMeasure do
       let(:params) { ActionController::Parameters.new(domain: domain, include_subdomains: 'true') }
 
       it 'returns the expected number of accounts' do
-        expect(measure.total).to eq 4
+        expect(subject.total).to eq 4
       end
     end
   end
 
   describe '#data' do
-    it 'runs data query without error' do
-      expect { measure.data }.to_not raise_error
+    it 'returns correct instance_followers counts' do
+      expect(subject.data.size)
+        .to eq(3)
+      expect(subject.data.map(&:symbolize_keys))
+        .to contain_exactly(
+          include(date: 2.days.ago.midnight.to_time, value: '0'),
+          include(date: 1.day.ago.midnight.to_time, value: '0'),
+          include(date: 0.days.ago.midnight.to_time, value: '2')
+        )
     end
   end
 end

--- a/spec/lib/admin/metrics/measure/instance_follows_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/instance_follows_measure_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe Admin::Metrics::Measure::InstanceFollowsMeasure do
-  subject(:measure) { described_class.new(start_at, end_at, params) }
+  subject { described_class.new(start_at, end_at, params) }
 
   let(:domain) { 'example.com' }
 
@@ -24,10 +24,10 @@ describe Admin::Metrics::Measure::InstanceFollowsMeasure do
     Fabricate(:account, domain: "bar.#{domain}")
   end
 
-  describe 'total' do
+  describe '#total' do
     context 'without include_subdomains' do
       it 'returns the expected number of accounts' do
-        expect(measure.total).to eq 2
+        expect(subject.total).to eq 2
       end
     end
 
@@ -35,14 +35,21 @@ describe Admin::Metrics::Measure::InstanceFollowsMeasure do
       let(:params) { ActionController::Parameters.new(domain: domain, include_subdomains: 'true') }
 
       it 'returns the expected number of accounts' do
-        expect(measure.total).to eq 4
+        expect(subject.total).to eq 4
       end
     end
   end
 
   describe '#data' do
-    it 'runs data query without error' do
-      expect { measure.data }.to_not raise_error
+    it 'returns correct instance_followers counts' do
+      expect(subject.data.size)
+        .to eq(3)
+      expect(subject.data.map(&:symbolize_keys))
+        .to contain_exactly(
+          include(date: 2.days.ago.midnight.to_time, value: '0'),
+          include(date: 1.day.ago.midnight.to_time, value: '0'),
+          include(date: 0.days.ago.midnight.to_time, value: '2')
+        )
     end
   end
 end

--- a/spec/lib/admin/metrics/measure/instance_reports_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/instance_reports_measure_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe Admin::Metrics::Measure::InstanceReportsMeasure do
-  subject(:measure) { described_class.new(start_at, end_at, params) }
+  subject { described_class.new(start_at, end_at, params) }
 
   let(:domain) { 'example.com' }
 
@@ -21,10 +21,10 @@ describe Admin::Metrics::Measure::InstanceReportsMeasure do
     Fabricate(:report, target_account: Fabricate(:account, domain: "bar.#{domain}"))
   end
 
-  describe 'total' do
+  describe '#total' do
     context 'without include_subdomains' do
       it 'returns the expected number of accounts' do
-        expect(measure.total).to eq 2
+        expect(subject.total).to eq 2
       end
     end
 
@@ -32,14 +32,21 @@ describe Admin::Metrics::Measure::InstanceReportsMeasure do
       let(:params) { ActionController::Parameters.new(domain: domain, include_subdomains: 'true') }
 
       it 'returns the expected number of accounts' do
-        expect(measure.total).to eq 5
+        expect(subject.total).to eq 5
       end
     end
   end
 
   describe '#data' do
-    it 'runs data query without error' do
-      expect { measure.data }.to_not raise_error
+    it 'returns correct instance_reports counts' do
+      expect(subject.data.size)
+        .to eq(3)
+      expect(subject.data.map(&:symbolize_keys))
+        .to contain_exactly(
+          include(date: 2.days.ago.midnight.to_time, value: '0'),
+          include(date: 1.day.ago.midnight.to_time, value: '0'),
+          include(date: 0.days.ago.midnight.to_time, value: '2')
+        )
     end
   end
 end

--- a/spec/lib/admin/metrics/measure/instance_statuses_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/instance_statuses_measure_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe Admin::Metrics::Measure::InstanceStatusesMeasure do
-  subject(:measure) { described_class.new(start_at, end_at, params) }
+  subject { described_class.new(start_at, end_at, params) }
 
   let(:domain) { 'example.com' }
 
@@ -21,10 +21,10 @@ describe Admin::Metrics::Measure::InstanceStatusesMeasure do
     Fabricate(:status, account: Fabricate(:account, domain: "bar.#{domain}"))
   end
 
-  describe 'total' do
+  describe '#total' do
     context 'without include_subdomains' do
       it 'returns the expected number of accounts' do
-        expect(measure.total).to eq 2
+        expect(subject.total).to eq 2
       end
     end
 
@@ -32,14 +32,21 @@ describe Admin::Metrics::Measure::InstanceStatusesMeasure do
       let(:params) { ActionController::Parameters.new(domain: domain, include_subdomains: 'true') }
 
       it 'returns the expected number of accounts' do
-        expect(measure.total).to eq 5
+        expect(subject.total).to eq 5
       end
     end
   end
 
   describe '#data' do
-    it 'runs data query without error' do
-      expect { measure.data }.to_not raise_error
+    it 'returns correct instance_statuses counts' do
+      expect(subject.data.size)
+        .to eq(3)
+      expect(subject.data.map(&:symbolize_keys))
+        .to contain_exactly(
+          include(date: 2.days.ago.midnight.to_time, value: '0'),
+          include(date: 1.day.ago.midnight.to_time, value: '0'),
+          include(date: 0.days.ago.midnight.to_time, value: '2')
+        )
     end
   end
 end

--- a/spec/lib/admin/metrics/measure/interactions_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/interactions_measure_spec.rb
@@ -3,15 +3,38 @@
 require 'rails_helper'
 
 describe Admin::Metrics::Measure::InteractionsMeasure do
-  subject(:measure) { described_class.new(start_at, end_at, params) }
+  subject { described_class.new(start_at, end_at, params) }
 
   let(:start_at) { 2.days.ago }
   let(:end_at)   { Time.now.utc }
   let(:params) { ActionController::Parameters.new }
 
   describe '#data' do
-    it 'runs data query without error' do
-      expect { measure.data }.to_not raise_error
+    context 'with activity tracking records' do
+      before do
+        3.times do
+          travel_to(2.days.ago) { record_interaction_activity }
+        end
+        2.times do
+          travel_to(1.day.ago) { record_interaction_activity }
+        end
+        travel_to(0.days.ago) { record_interaction_activity }
+      end
+
+      it 'returns correct activity tracker counts' do
+        expect(subject.data.size)
+          .to eq(3)
+        expect(subject.data.map(&:symbolize_keys))
+          .to contain_exactly(
+            include(date: 2.days.ago.midnight.to_time, value: '3'),
+            include(date: 1.day.ago.midnight.to_time, value: '2'),
+            include(date: 0.days.ago.midnight.to_time, value: '1')
+          )
+      end
+
+      def record_interaction_activity
+        ActivityTracker.increment('activity:interactions')
+      end
     end
   end
 end

--- a/spec/lib/admin/metrics/measure/new_users_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/new_users_measure_spec.rb
@@ -3,15 +3,30 @@
 require 'rails_helper'
 
 describe Admin::Metrics::Measure::NewUsersMeasure do
-  subject(:measure) { described_class.new(start_at, end_at, params) }
+  subject { described_class.new(start_at, end_at, params) }
 
   let(:start_at) { 2.days.ago }
   let(:end_at)   { Time.now.utc }
   let(:params) { ActionController::Parameters.new }
 
   describe '#data' do
-    it 'runs data query without error' do
-      expect { measure.data }.to_not raise_error
+    context 'with user records' do
+      before do
+        3.times { Fabricate :user, created_at: 2.days.ago }
+        2.times { Fabricate :user, created_at: 1.day.ago }
+        Fabricate :user, created_at: 0.days.ago
+      end
+
+      it 'returns correct user counts' do
+        expect(subject.data.size)
+          .to eq(3)
+        expect(subject.data.map(&:symbolize_keys))
+          .to contain_exactly(
+            include(date: 2.days.ago.midnight.to_time, value: '3'),
+            include(date: 1.day.ago.midnight.to_time, value: '2'),
+            include(date: 0.days.ago.midnight.to_time, value: '1')
+          )
+      end
     end
   end
 end

--- a/spec/lib/admin/metrics/measure/opened_reports_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/opened_reports_measure_spec.rb
@@ -3,15 +3,30 @@
 require 'rails_helper'
 
 describe Admin::Metrics::Measure::OpenedReportsMeasure do
-  subject(:measure) { described_class.new(start_at, end_at, params) }
+  subject { described_class.new(start_at, end_at, params) }
 
   let(:start_at) { 2.days.ago }
   let(:end_at)   { Time.now.utc }
   let(:params) { ActionController::Parameters.new }
 
   describe '#data' do
-    it 'runs data query without error' do
-      expect { measure.data }.to_not raise_error
+    context 'with report records' do
+      before do
+        3.times { Fabricate :report, created_at: 2.days.ago }
+        2.times { Fabricate :report, created_at: 1.day.ago }
+        Fabricate :report, created_at: 0.days.ago
+      end
+
+      it 'returns correct report counts' do
+        expect(subject.data.size)
+          .to eq(3)
+        expect(subject.data.map(&:symbolize_keys))
+          .to contain_exactly(
+            include(date: 2.days.ago.midnight.to_time, value: '3'),
+            include(date: 1.day.ago.midnight.to_time, value: '2'),
+            include(date: 0.days.ago.midnight.to_time, value: '1')
+          )
+      end
     end
   end
 end

--- a/spec/lib/admin/metrics/measure/resolved_reports_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/resolved_reports_measure_spec.rb
@@ -3,15 +3,30 @@
 require 'rails_helper'
 
 describe Admin::Metrics::Measure::ResolvedReportsMeasure do
-  subject(:measure) { described_class.new(start_at, end_at, params) }
+  subject { described_class.new(start_at, end_at, params) }
 
   let(:start_at) { 2.days.ago }
   let(:end_at)   { Time.now.utc }
   let(:params) { ActionController::Parameters.new }
 
   describe '#data' do
-    it 'runs data query without error' do
-      expect { measure.data }.to_not raise_error
+    context 'with report records' do
+      before do
+        3.times { Fabricate :report, action_taken_at: 2.days.ago }
+        2.times { Fabricate :report, action_taken_at: 1.day.ago }
+        Fabricate :report, action_taken_at: 0.days.ago
+      end
+
+      it 'returns correct report counts' do
+        expect(subject.data.size)
+          .to eq(3)
+        expect(subject.data.map(&:symbolize_keys))
+          .to contain_exactly(
+            include(date: 2.days.ago.midnight.to_time, value: '3'),
+            include(date: 1.day.ago.midnight.to_time, value: '2'),
+            include(date: 0.days.ago.midnight.to_time, value: '1')
+          )
+      end
     end
   end
 end

--- a/spec/lib/admin/metrics/measure/tag_servers_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/tag_servers_measure_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe Admin::Metrics::Measure::TagServersMeasure do
-  subject(:measure) { described_class.new(start_at, end_at, params) }
+  subject { described_class.new(start_at, end_at, params) }
 
   let!(:tag) { Fabricate(:tag) }
 
@@ -12,8 +12,38 @@ describe Admin::Metrics::Measure::TagServersMeasure do
   let(:params) { ActionController::Parameters.new(id: tag.id) }
 
   describe '#data' do
-    it 'runs data query without error' do
-      expect { measure.data }.to_not raise_error
+    context 'with tagged statuses' do
+      let(:alice) { Fabricate(:account, domain: 'alice.example') }
+      let(:bob) { Fabricate(:account, domain: 'bob.example') }
+
+      before do
+        3.times do
+          status_alice = Fabricate(:status, account: alice, created_at: 2.days.ago)
+          status_alice.tags << tag
+        end
+
+        2.times do
+          status_alice = Fabricate(:status, account: alice, created_at: 1.day.ago)
+          status_alice.tags << tag
+
+          status_bob = Fabricate(:status, account: bob, created_at: 1.day.ago)
+          status_bob.tags << tag
+        end
+
+        status_bob = Fabricate(:status, account: bob, created_at: 0.days.ago)
+        status_bob.tags << tag
+      end
+
+      it 'returns correct tag counts' do
+        expect(subject.data.size)
+          .to eq(3)
+        expect(subject.data.map(&:symbolize_keys))
+          .to contain_exactly(
+            include(date: 2.days.ago.midnight.to_time, value: '1'),
+            include(date: 1.day.ago.midnight.to_time, value: '2'),
+            include(date: 0.days.ago.midnight.to_time, value: '1')
+          )
+      end
     end
   end
 end

--- a/spec/lib/admin/metrics/measure/tag_uses_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/tag_uses_measure_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe Admin::Metrics::Measure::TagUsesMeasure do
-  subject(:measure) { described_class.new(start_at, end_at, params) }
+  subject { described_class.new(start_at, end_at, params) }
 
   let!(:tag) { Fabricate(:tag) }
 
@@ -12,8 +12,39 @@ describe Admin::Metrics::Measure::TagUsesMeasure do
   let(:params) { ActionController::Parameters.new(id: tag.id) }
 
   describe '#data' do
-    it 'runs data query without error' do
-      expect { measure.data }.to_not raise_error
+    context 'with tagged accounts' do
+      let(:alice) { Fabricate(:account, domain: 'alice.example') }
+      let(:bob) { Fabricate(:account, domain: 'bob.example') }
+
+      before do
+        3.times do
+          travel_to(2.days.ago) { add_tag_history(alice) }
+        end
+
+        2.times do
+          travel_to(1.day.ago) do
+            add_tag_history(alice)
+            add_tag_history(bob)
+          end
+        end
+
+        add_tag_history(bob)
+      end
+
+      it 'returns correct tag_uses counts' do
+        expect(subject.data.size)
+          .to eq(3)
+        expect(subject.data.map(&:symbolize_keys))
+          .to contain_exactly(
+            include(date: 2.days.ago.midnight.to_time, value: '3'),
+            include(date: 1.day.ago.midnight.to_time, value: '4'),
+            include(date: 0.days.ago.midnight.to_time, value: '1')
+          )
+      end
+
+      def add_tag_history(account)
+        tag.history.add(account.id)
+      end
     end
   end
 end


### PR DESCRIPTION
Extracted from https://github.com/mastodon/mastodon/pull/28736 but contains only the "measure" specs.