### PR TITLE
Fix repeated concat output buffer duplicating layout markup

### DIFF
--- a/app/helpers/theme_helper.rb
+++ b/app/helpers/theme_helper.rb
@@ -3,8 +3,8 @@
 module ThemeHelper
   def theme_style_tags(theme)
     if theme == 'system'
-      concat stylesheet_pack_tag('mastodon-light', media: 'not all and (prefers-color-scheme: dark)', crossorigin: 'anonymous')
-      concat stylesheet_pack_tag('default', media: '(prefers-color-scheme: dark)', crossorigin: 'anonymous')
+      stylesheet_pack_tag('mastodon-light', media: 'not all and (prefers-color-scheme: dark)', crossorigin: 'anonymous') +
+        stylesheet_pack_tag('default', media: '(prefers-color-scheme: dark)', crossorigin: 'anonymous')
     else
       stylesheet_pack_tag theme, media: 'all', crossorigin: 'anonymous'
     end
@@ -12,8 +12,8 @@ module ThemeHelper
 
   def theme_color_tags(theme)
     if theme == 'system'
-      concat tag.meta(name: 'theme-color', content: Themes::THEME_COLORS[:dark], media: '(prefers-color-scheme: dark)')
-      concat tag.meta(name: 'theme-color', content: Themes::THEME_COLORS[:light], media: '(prefers-color-scheme: light)')
+      tag.meta(name: 'theme-color', content: Themes::THEME_COLORS[:dark], media: '(prefers-color-scheme: dark)') +
+        tag.meta(name: 'theme-color', content: Themes::THEME_COLORS[:light], media: '(prefers-color-scheme: light)')
     else
       tag.meta name: 'theme-color', content: theme_color_for(theme)
     end

--- a/spec/requests/account_show_page_spec.rb
+++ b/spec/requests/account_show_page_spec.rb
@@ -9,10 +9,16 @@ describe 'The account show page' do
 
     get '/@alice'
 
+    expect(head_link_icons.size).to eq(4) # One general favicon and three with sizes
+
     expect(head_meta_content('og:title')).to match alice.display_name
     expect(head_meta_content('og:type')).to eq 'profile'
     expect(head_meta_content('og:image')).to match '.+'
     expect(head_meta_content('og:url')).to match 'http://.+'
+  end
+
+  def head_link_icons
+    head_section.css('link[rel=icon]')
   end
 
   def head_meta_content(property)


### PR DESCRIPTION
Current main is repeating some of the layout markup due to how the theme helpers use concat.

The spec added here is what helped me track down where the issue was from, but is admittedly a sort of arbitrary spec to keep that check in. Not sure how high risk another regression is here, but I left it in for this PR.