### PR TITLE
Remove `image_pack_tag` usage

### DIFF
--- a/app/helpers/branding_helper.rb
+++ b/app/helpers/branding_helper.rb
@@ -19,6 +19,6 @@ module BrandingHelper
   end
 
   def render_logo
-    image_pack_tag('logo.svg', alt: 'Mastodon', class: 'logo logo--icon')
+    image_tag(frontend_asset_path('images/logo.svg'), alt: 'Mastodon', class: 'logo logo--icon')
   end
 end

--- a/app/views/shared/_web_app.html.haml
+++ b/app/views/shared/_web_app.html.haml
@@ -12,7 +12,7 @@
 
 .notranslate.app-holder#mastodon{ data: { props: Oj.dump(default_props) } }
   %noscript
-    = image_pack_tag 'logo.svg', alt: 'Mastodon'
+    = image_tag frontend_asset_path('images/logo.svg'), alt: 'Mastodon'
 
     %div
       = t('errors.noscript_html', apps_path: 'https://joinmastodon.org/apps')


### PR DESCRIPTION
This is equivalent to `image_tag(frontend_asset_path(…))` and will reduce the changes needed to migrate to Vite