### PR TITLE
Fix PostCSS config

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,7 +1,10 @@
-module.exports = ({ env }) => ({
+/** @type {import('postcss-load-config').Config} */
+const config = ({ env }) => ({
   plugins: [
-    'postcss-preset-env',
-    'autoprefixer',
-    env === 'production' ? 'cssnano' : '',
+    require('postcss-preset-env'),
+    require('autoprefixer'),
+    env === 'production' ? require('cssnano') : '',
   ],
 });
+
+module.exports = config;


### PR DESCRIPTION
According to [PostCSS documentation](https://github.com/postcss/postcss?tab=readme-ov-file#webpack), we should use `require()` for plugins, not simply their name.

With Vite, not doing so makes the build fail, so let's do it properly in `main` as this is the recommended way.