### PR TITLE
Pull out repeated setup to shared setup in statusus/show view spec

### DIFF
--- a/spec/views/statuses/show.html.haml_spec.rb
+++ b/spec/views/statuses/show.html.haml_spec.rb
@@ -3,6 +3,9 @@
 require 'rails_helper'
 
 describe 'statuses/show.html.haml', :without_verify_partial_doubles do
+  let(:alice) { Fabricate(:account, username: 'alice', display_name: 'Alice') }
+  let(:status) { Fabricate(:status, account: alice, text: 'Hello World') }
+
   before do
     allow(view).to receive_messages(api_oembed_url: '', site_title: 'example site', site_hostname: 'example.com', full_asset_url: '//asset.host/image.svg', current_account: nil, single_user_mode?: false)
     allow(view).to receive(:local_time)
@@ -15,9 +18,6 @@ describe 'statuses/show.html.haml', :without_verify_partial_doubles do
     assign(:account, alice)
     assign(:descendant_threads, [])
   end
-
-  let(:alice) { Fabricate(:account, username: 'alice', display_name: 'Alice') }
-  let(:status) { Fabricate(:status, account: alice, text: 'Hello World') }
 
   it 'has valid opengraph tags' do
     render

--- a/spec/views/statuses/show.html.haml_spec.rb
+++ b/spec/views/statuses/show.html.haml_spec.rb
@@ -8,18 +8,18 @@ describe 'statuses/show.html.haml', :without_verify_partial_doubles do
     allow(view).to receive(:local_time)
     allow(view).to receive(:local_time_ago)
     assign(:instance_presenter, InstancePresenter.new)
+
+    Fabricate(:media_attachment, account: alice, status: status, type: :video)
+
+    assign(:status, status)
+    assign(:account, alice)
+    assign(:descendant_threads, [])
   end
 
   let(:alice) { Fabricate(:account, username: 'alice', display_name: 'Alice') }
   let(:status) { Fabricate(:status, account: alice, text: 'Hello World') }
 
   it 'has valid opengraph tags' do
-    Fabricate(:media_attachment, account: alice, status: status, type: :video)
-
-    assign(:status, status)
-    assign(:account, alice)
-    assign(:descendant_threads, [])
-
     render
 
     expect(header_tags)
@@ -30,12 +30,6 @@ describe 'statuses/show.html.haml', :without_verify_partial_doubles do
   end
 
   it 'has twitter player tag' do
-    Fabricate(:media_attachment, account: alice, status: status, type: :video)
-
-    assign(:status, status)
-    assign(:account, alice)
-    assign(:descendant_threads, [])
-
     render
 
     expect(header_tags)

--- a/spec/views/statuses/show.html.haml_spec.rb
+++ b/spec/views/statuses/show.html.haml_spec.rb
@@ -10,9 +10,10 @@ describe 'statuses/show.html.haml', :without_verify_partial_doubles do
     assign(:instance_presenter, InstancePresenter.new)
   end
 
+  let(:alice) { Fabricate(:account, username: 'alice', display_name: 'Alice') }
+  let(:status) { Fabricate(:status, account: alice, text: 'Hello World') }
+
   it 'has valid opengraph tags' do
-    alice  = Fabricate(:account, username: 'alice', display_name: 'Alice')
-    status = Fabricate(:status, account: alice, text: 'Hello World')
     Fabricate(:media_attachment, account: alice, status: status, type: :video)
 
     assign(:status, status)
@@ -29,8 +30,6 @@ describe 'statuses/show.html.haml', :without_verify_partial_doubles do
   end
 
   it 'has twitter player tag' do
-    alice  = Fabricate(:account, username: 'alice', display_name: 'Alice')
-    status = Fabricate(:status, account: alice, text: 'Hello World')
     Fabricate(:media_attachment, account: alice, status: status, type: :video)
 
     assign(:status, status)


### PR DESCRIPTION
Another extraction from https://github.com/mastodon/mastodon/pull/29132

- Pulls out repeated setup from two examples into the higher level shared setup block
- Pulls out two factory setups into `let`

I think with this merged and the linked PR rebased, it should be more reviewable for the narrower change of removing the `without_verify_partial_doubles` usage.