### PR TITLE
Fix `Style/SingleArgumentDig` cop in webpacker/manifest_extensions

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -251,11 +251,6 @@ Style/SignalException:
     - 'lib/devise/strategies/two_factor_pam_authenticatable.rb'
 
 # This cop supports unsafe autocorrection (--autocorrect-all).
-Style/SingleArgumentDig:
-  Exclude:
-    - 'lib/webpacker/manifest_extensions.rb'
-
-# This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: Mode.
 Style/StringConcatenation:
   Exclude:

--- a/lib/webpacker/manifest_extensions.rb
+++ b/lib/webpacker/manifest_extensions.rb
@@ -5,9 +5,9 @@ module Webpacker::ManifestExtensions
     asset = super
 
     if pack_type[:with_integrity] && asset.respond_to?(:dig)
-      [asset.dig('src'), asset.dig('integrity')]
+      [asset['src'], asset['integrity']]
     elsif asset.respond_to?(:dig)
-      asset.dig('src')
+      asset['src']
     else
       asset
     end


### PR DESCRIPTION
In advance of https://github.com/mastodon/mastodon/pull/24981

That PR will *delete* this file, so the extraction here is essentially to get rid of the rubocop lines in advance.