### PR TITLE
Rename `PremailerWebpackStrategy` -> `PremailerBundledAssetStrategy`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -97,7 +97,6 @@ Style/FetchEnvVar:
     - 'config/initializers/paperclip.rb'
     - 'config/initializers/vapid.rb'
     - 'lib/mastodon/redis_config.rb'
-    - 'lib/premailer_webpack_strategy.rb'
     - 'lib/tasks/repo.rake'
     - 'spec/features/profile_spec.rb'
 

--- a/config/initializers/premailer_rails.rb
+++ b/config/initializers/premailer_rails.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require_relative '../../lib/premailer_webpack_strategy'
+require_relative '../../lib/premailer_bundled_asset_strategy'
 
 Premailer::Rails.config.merge!(remove_ids: true,
                                adapter: :nokogiri,
                                generate_text_part: false,
                                css_to_attributes: false,
-                               strategies: [PremailerWebpackStrategy])
+                               strategies: [PremailerBundledAssetStrategy])

--- a/lib/premailer_bundled_asset_strategy.rb
+++ b/lib/premailer_bundled_asset_strategy.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-module PremailerWebpackStrategy
+module PremailerBundledAssetStrategy
   def load(url)
-    asset_host = ENV['CDN_HOST'] || ENV['WEB_DOMAIN'] || ENV['LOCAL_DOMAIN']
+    asset_host = ENV['CDN_HOST'] || ENV['WEB_DOMAIN'] || ENV.fetch('LOCAL_DOMAIN', nil)
 
     if Webpacker.dev_server.running?
       asset_host = "#{Webpacker.dev_server.protocol}://#{Webpacker.dev_server.host_with_port}"


### PR DESCRIPTION
In advance of https://github.com/mastodon/mastodon/pull/24981

Renames the strategy class to get webpack out of the name, fixes a cop.