### PR TITLE
Replace `jest` with `test:js` in package scripts

### DIFF
--- a/.github/workflows/test-js.yml
+++ b/.github/workflows/test-js.yml
@@ -39,4 +39,4 @@ jobs:
         uses: ./.github/actions/setup-javascript
 
       - name: JavaScript testing
-        run: yarn jest --reporters github-actions summary
+        run: yarn test:js --reporters github-actions summary

--- a/package.json
+++ b/package.json
@@ -18,14 +18,14 @@
     "format": "prettier --write --log-level warn .",
     "format:check": "prettier --check --ignore-unknown .",
     "i18n:extract": "formatjs extract 'app/javascript/**/*.{js,jsx,ts,tsx}' '--ignore=**/*.d.ts' --out-file app/javascript/mastodon/locales/en.json --format config/formatjs-formatter.js",
-    "jest": "cross-env NODE_ENV=test jest",
     "lint:js": "eslint . --ext=.js,.jsx,.ts,.tsx --cache --report-unused-disable-directives",
     "lint:css": "stylelint \"**/*.{css,scss}\"",
     "lint": "yarn lint:js && yarn lint:css",
     "postversion": "git push --tags",
     "prepare": "husky",
     "start": "node ./streaming/index.js",
-    "test": "yarn lint && yarn run typecheck && yarn jest",
+    "test:js": "cross-env NODE_ENV=test jest",
+    "test": "yarn lint && yarn run typecheck && yarn test:js",
     "typecheck": "tsc --noEmit"
   },
   "repository": {


### PR DESCRIPTION
In advance of https://github.com/mastodon/mastodon/pull/24981

Actual commands run stay the same, just changing naming in advance of vite changes.