### PR TITLE
Remove custom emoji from `page_title`

### DIFF
--- a/app/views/accounts/show.html.haml
+++ b/app/views/accounts/show.html.haml
@@ -1,5 +1,5 @@
 - content_for :page_title do
-  display_name(@account).gsub(/:\w+:/, '') + " (#{acct(@account)})"
+  "#{display_name(@account).gsub(/:\w+:/, '').strip} (#{acct(@account)})".gsub(/\s+/, ' ')
 
 - content_for :header_tags do
   - if @account.user_prefers_noindex?

--- a/app/views/accounts/show.html.haml
+++ b/app/views/accounts/show.html.haml
@@ -1,6 +1,5 @@
 - content_for :page_title do
-  - display_name = display_name(@account).gsub(/:\w+:/, '')
-  = #{display_name(@account)} (#{acct(@account)})
+  display_name(@account).gsub(/:\w+:/, '') + " (#{acct(@account)})"
 
 - content_for :header_tags do
   - if @account.user_prefers_noindex?

--- a/app/views/accounts/show.html.haml
+++ b/app/views/accounts/show.html.haml
@@ -1,5 +1,6 @@
 - content_for :page_title do
-  #{display_name(@account)} (#{acct(@account)})
+  - display_name = display_name(@account).gsub(/:\w+:/, '')
+  = #{display_name(@account)} (#{acct(@account)})
 
 - content_for :header_tags do
   - if @account.user_prefers_noindex?


### PR DESCRIPTION
I edited the code in `app/views/accounts/show.html.haml` to remove custom emoji from the `page_title` of user profile by using the regex `:\w+:`.