### PR TITLE
Add coverage for last_status_at preservation in counters upsert

### DIFF
--- a/spec/models/concerns/account/counters_spec.rb
+++ b/spec/models/concerns/account/counters_spec.rb
@@ -44,5 +44,18 @@ describe Account::Counters do
 
       expect(account.statuses_count).to eq 5
     end
+
+    it 'preserves last_status_at when decrementing statuses_count' do
+      account_stat = Fabricate(
+        :account_stat,
+        account: account,
+        last_status_at: 3.days.ago,
+        statuses_count: 10
+      )
+
+      expect { account.decrement_count!(:statuses_count) }
+        .to change(account_stat.reload, :statuses_count).by(-1)
+        .and not_change(account_stat.reload, :last_status_at)
+    end
   end
 end


### PR DESCRIPTION
This is just the spec added in https://github.com/mastodon/mastodon/pull/28738

I'd love to get a review/merge on that one, but short of that, we can get this spec in if the other changes need more work.