### PR TITLE
Change `have_enqueued_sidekiq_job` usage to always make argument expectations explicit

### DIFF
--- a/spec/services/create_featured_tag_service_spec.rb
+++ b/spec/services/create_featured_tag_service_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe CreateFeaturedTagService do
         expect { subject.call(account, tag) }
           .to change(FeaturedTag, :count).by(1)
         expect(ActivityPub::AccountRawDistributionWorker)
-          .to_not have_enqueued_sidekiq_job
+          .to_not have_enqueued_sidekiq_job(any_args)
       end
     end
   end

--- a/spec/services/unmute_service_spec.rb
+++ b/spec/services/unmute_service_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe UnmuteService do
         it 'removes the account mute and does not create a merge' do
           expect { subject.call(account, target_account) }
             .to remove_account_mute
-          expect(MergeWorker).to_not have_enqueued_sidekiq_job
+          expect(MergeWorker).to_not have_enqueued_sidekiq_job(any_args)
         end
       end
 
@@ -39,7 +39,7 @@ RSpec.describe UnmuteService do
       it 'does nothing and returns' do
         expect { subject.call(account, target_account) }
           .to_not(change { account.reload.muting?(target_account) })
-        expect(MergeWorker).to_not have_enqueued_sidekiq_job
+        expect(MergeWorker).to_not have_enqueued_sidekiq_job(any_args)
       end
     end
   end


### PR DESCRIPTION
In preparation of #29964