### PR TITLE
Change log level in test environment to speed up tests

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -77,6 +77,9 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
+
+  # disable logging in tests, for speed increases. Set to :info to bring back logging
+  config.log_level = :warn
 end
 
 Paperclip::Attachment.default_options[:path] = Rails.root.join('spec', 'test_files', ':class', ':id_partition', ':style.:extension')

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -79,7 +79,7 @@ Rails.application.configure do
   config.action_controller.raise_on_missing_callback_actions = true
 
   # disable logging in tests, for speed increases. Set to :info to bring back logging
-  config.log_level = :warn
+  config.log_level = ENV.fetch('RAILS_LOG_LEVEL', 'warn').to_sym
 end
 
 Paperclip::Attachment.default_options[:path] = Rails.root.join('spec', 'test_files', ':class', ':id_partition', ':style.:extension')


### PR DESCRIPTION
I'm bechmarking/profiling the mastodon test suite, to see what sort of speed increases I can get from the test suite directly, and the build process indirectly.

I [did something similar](https://github.com/openstreetmap/openstreetmap-website/pull/4708) with the OpenStreetMap Website rails app.

Commit 1: Turn off logging in test for small speed increase

I'm still running the tests - it's a very large suite, I'm curious to see how it develops. 

Long and detailed 'dev notes' [here](https://gist.github.com/josh-works/63e57445035d1dd3beb604114ea2caac)

Creating this PR so I can centralize the work, and start understanding the build process. The first commit is nothing more than disabling logging during testing. Half way through the first test run, `log/test.log` is 142k lines long. Can't hurt to turn it off!

I've not yet gotten the full results I want, so I propose merging this one, just to get the faster results available to others.