### PR TITLE
Indirect deps gem version bumps

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -589,7 +589,7 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
-    rake (13.1.0)
+    rake (13.2.1)
     rdf (3.3.1)
       bcp47_spec (~> 0.2)
       link_header (~> 0.0, >= 0.0.8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -543,7 +543,7 @@ GEM
     rack-protection (3.2.0)
       base64 (>= 0.1.0)
       rack (~> 2.2, >= 2.2.4)
-    rack-proxy (0.7.6)
+    rack-proxy (0.7.7)
       rack
     rack-session (1.0.2)
       rack (< 3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -773,7 +773,7 @@ GEM
       unf_ext
     unf_ext (0.0.9.1)
     unicode-display_width (2.5.0)
-    uri (0.12.2)
+    uri (0.13.0)
     validate_email (0.1.6)
       activemodel (>= 3.0)
       mail (>= 2.2.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,7 +102,7 @@ GEM
     attr_required (1.0.2)
     awrence (1.2.1)
     aws-eventstream (1.3.0)
-    aws-partitions (1.915.0)
+    aws-partitions (1.916.0)
     aws-sdk-core (3.192.1)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.651.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,7 +102,7 @@ GEM
     attr_required (1.0.2)
     awrence (1.2.1)
     aws-eventstream (1.3.0)
-    aws-partitions (1.914.0)
+    aws-partitions (1.915.0)
     aws-sdk-core (3.192.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.651.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -238,7 +238,7 @@ GEM
       mail (~> 2.7)
     encryptor (3.0.0)
     erubi (1.12.0)
-    et-orbi (1.2.10)
+    et-orbi (1.2.11)
       tzinfo
     excon (0.110.0)
     fabrication (2.31.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -432,7 +432,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2024.0305)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.5)
+    mini_portile2 (2.8.6)
     minitest (5.22.3)
     msgpack (1.7.2)
     multi_json (1.15.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -272,8 +272,8 @@ GEM
     fast_blank (1.0.1)
     fastimage (2.3.1)
     ffi (1.16.3)
-    ffi-compiler (1.0.1)
-      ffi (>= 1.0.0)
+    ffi-compiler (1.3.2)
+      ffi (>= 1.15.5)
       rake
     fog-core (2.4.0)
       builder

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -604,7 +604,7 @@ GEM
     redlock (1.3.2)
       redis (>= 3.0.0, < 6.0)
     regexp_parser (2.9.0)
-    reline (0.5.1)
+    reline (0.5.2)
       io-console (~> 0.5)
     request_store (1.6.0)
       rack (>= 1.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -436,7 +436,7 @@ GEM
     minitest (5.22.3)
     msgpack (1.7.2)
     multi_json (1.15.0)
-    multipart-post (2.3.0)
+    multipart-post (2.4.0)
     mutex_m (0.2.0)
     net-http (0.4.1)
       uri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -677,7 +677,7 @@ GEM
       rubocop (~> 1.40)
     ruby-prof (1.7.0)
     ruby-progressbar (1.13.0)
-    ruby-saml (1.15.0)
+    ruby-saml (1.16.0)
       nokogiri (>= 1.13.10)
       rexml
     ruby2_keywords (0.0.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -314,7 +314,7 @@ GEM
     hashie (5.0.0)
     hcaptcha (7.1.0)
       json
-    highline (2.1.0)
+    highline (3.0.1)
     hiredis (0.6.3)
     hkdf (0.3.0)
     htmlentities (4.3.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -606,7 +606,7 @@ GEM
     regexp_parser (2.9.0)
     reline (0.5.1)
       io-console (~> 0.5)
-    request_store (1.5.1)
+    request_store (1.6.0)
       rack (>= 1.4)
     responders (3.1.1)
       actionpack (>= 5.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -450,7 +450,7 @@ GEM
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.4.0.1)
+    net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.1)
     nokogiri (1.16.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,7 +186,7 @@ GEM
       bigdecimal
       rexml
     crass (1.0.6)
-    css_parser (1.16.0)
+    css_parser (1.17.1)
       addressable
     csv (3.3.0)
     database_cleaner-active_record (2.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,7 +103,7 @@ GEM
     awrence (1.2.1)
     aws-eventstream (1.3.0)
     aws-partitions (1.915.0)
-    aws-sdk-core (3.192.0)
+    aws-sdk-core (3.192.1)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.651.0)
       aws-sigv4 (~> 1.8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -673,7 +673,7 @@ GEM
       rubocop-capybara (~> 2.17)
       rubocop-factory_bot (~> 2.22)
       rubocop-rspec_rails (~> 2.28)
-    rubocop-rspec_rails (2.28.2)
+    rubocop-rspec_rails (2.28.3)
       rubocop (~> 1.40)
     ruby-prof (1.7.0)
     ruby-progressbar (1.13.0)


### PR DESCRIPTION
I'd like to experiment with the renovate setting discussed in last month's version of this PR - https://github.com/mastodon/mastodon/pull/29717#issuecomment-2019932962 - but before doing so, did another pass on these various minor dependency bumps. I'll follow this up with a PR enabling that setting ... my suspicion is that enabling might get us more regular review of these small minor/patch bumps, and may also expose some deps that we actually want to be more tightly locked down. Will open that next.

Within this one, all the minor/patch bumps are like small bugfixes, doc changes, tweaks, etc. The one major bump (highline) is just dropping support for ruby 3.0, which we also recently dropped support for.

As before, this is one version per commit, so I can easily remove one of these if we're unsure about something.