### PR TITLE
Silence warning about requiring `rubocop-rspec_rails`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,7 @@ inherit_mode:
 require:
   - rubocop-rails
   - rubocop-rspec
+  - rubocop-rspec_rails
   - rubocop-performance
   - rubocop-capybara
   - ./lib/linter/rubocop_middle_dot


### PR DESCRIPTION
Current runs contain output:

```
The following RuboCop extension libraries are installed but not loaded in config:
  * rubocop-rspec_rails
```

I think this is part of the ongoing migration to break these out to subgems on the rubocop side. Adding this to the list silences the warning.