### PR TITLE
Rely on dotenv autoload instead of explicit call

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -52,8 +52,6 @@ require_relative '../lib/active_record/batches'
 require_relative '../lib/simple_navigation/item_extensions'
 require_relative '../lib/http_extensions'
 
-Dotenv::Rails.load
-
 Bundler.require(:pam_authentication) if ENV['PAM_ENABLED'] == 'true'
 
 require_relative '../lib/mastodon/redis_config'


### PR DESCRIPTION
The current version will automatically load the values that it finds. With this line in place we are loading twice.