### PR TITLE
Update Gemfile.lock ruby and bundler versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -954,4 +954,4 @@ RUBY VERSION
    ruby 3.2.2p53
 
 BUNDLED WITH
-   2.5.7
+   2.5.9

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -951,7 +951,7 @@ DEPENDENCIES
   xorcist (~> 1.1)
 
 RUBY VERSION
-   ruby 3.2.2p53
+   ruby 3.2.3p157
 
 BUNDLED WITH
    2.5.9


### PR DESCRIPTION
Use latest bundler, align ruby with what's in `.ruby-version`.