### PR TITLE
Fix TypeError: wrong argument type strio (expected strio), restricting gem's version

### DIFF
--- a/.github/actions/setup-ruby/action.yml
+++ b/.github/actions/setup-ruby/action.yml
@@ -20,4 +20,22 @@ runs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ inputs.ruby-version }}
-        bundler-cache: true
+        bundler-cache: false
+
+    - run: bundle update stringio
+
+    - uses: actions/cache@v4
+      with:
+        path: ./vendor/bundle
+        key: ${{ runner.os }}-${{ inputs.ruby-version }}-gems-${{ github.ref }}-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ inputs.ruby-version }}-gems-${{ github.ref }}
+          ${{ runner.os }}-${{ inputs.ruby-version }}-gems-master
+          ${{ runner.os }}-${{ inputs.ruby-version }}-gems-
+
+    - name: bundle install
+      run: |
+        bundle config --local path $PWD/vendor/bundle
+        bundle config --local deployment true
+        bundle install --jobs 4 --retry 3
+        bundle clean

--- a/.github/actions/setup-ruby/action.yml
+++ b/.github/actions/setup-ruby/action.yml
@@ -20,22 +20,4 @@ runs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ inputs.ruby-version }}
-        bundler-cache: false
-
-    - run: bundle update stringio
-
-    - uses: actions/cache@v4
-      with:
-        path: ./vendor/bundle
-        key: ${{ runner.os }}-${{ inputs.ruby-version }}-gems-${{ github.ref }}-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ inputs.ruby-version }}-gems-${{ github.ref }}
-          ${{ runner.os }}-${{ inputs.ruby-version }}-gems-master
-          ${{ runner.os }}-${{ inputs.ruby-version }}-gems-
-
-    - name: bundle install
-      run: |
-        bundle config --local path $PWD/vendor/bundle
-        bundle config --local deployment true
-        bundle install --jobs 4 --retry 3
-        bundle clean
+        bundler-cache: true

--- a/Gemfile
+++ b/Gemfile
@@ -89,6 +89,7 @@ gem 'sidekiq-unique-jobs', '~> 7.1'
 gem 'simple_form', '~> 5.2'
 gem 'simple-navigation', '~> 4.4'
 gem 'stoplight', '~> 4.1'
+gem 'stringio', '3.0.4'
 gem 'strong_migrations', '1.8.0'
 gem 'tty-prompt', '~> 0.23', require: false
 gem 'twitter-text', '~> 3.1.0'

--- a/Gemfile
+++ b/Gemfile
@@ -89,7 +89,20 @@ gem 'sidekiq-unique-jobs', '~> 7.1'
 gem 'simple_form', '~> 5.2'
 gem 'simple-navigation', '~> 4.4'
 gem 'stoplight', '~> 4.1'
-gem 'stringio', '3.0.4'
+
+# TODO: This is because though currently Ruby has the StringIO embedded, `irb` is requiring `rdoc` which has the
+# `stringio` gem as a dependency without constraints on the Ruby version. Using a gem with a version different from
+# the one, embedded in Ruby,can lead tospurios errors, like <TypeError: wrong argument type strio (expected strio)>,
+# see https://github.com/mastodon/mastodon/pull/30013
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.4.0')
+  gem 'stringio', '3.1.1'
+elsif Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.3.0')
+  gem 'stringio', '3.1.0'
+elsif Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.2.0')
+  gem 'stringio', '3.0.4'
+elsif Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1.0')
+  gem 'stringio', '3.0.1'
+end
 gem 'strong_migrations', '1.8.0'
 gem 'tty-prompt', '~> 0.23', require: false
 gem 'twitter-text', '~> 3.1.0'

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,9 @@ gem 'thor', '~> 1.2'
 
 # For why irb is in the Gemfile, see: https://ruby.social/@st0012/111444685161478182
 gem 'irb', '~> 1.8'
+# The last RDoc version, which doesn't require Psych, which causes troubles with StringIO
+# See https://github.com/mastodon/mastodon/pull/30013
+gem 'rdoc', '6.3.3'
 
 gem 'dotenv'
 gem 'haml-rails', '~>2.0'
@@ -89,20 +92,6 @@ gem 'sidekiq-unique-jobs', '~> 7.1'
 gem 'simple_form', '~> 5.2'
 gem 'simple-navigation', '~> 4.4'
 gem 'stoplight', '~> 4.1'
-
-# TODO: This is because though currently Ruby has the StringIO embedded, `irb` is requiring `rdoc` which has the
-# `stringio` gem as a dependency without constraints on the Ruby version. Using a gem with a version different from
-# the one, embedded in Ruby,can lead tospurios errors, like <TypeError: wrong argument type strio (expected strio)>,
-# see https://github.com/mastodon/mastodon/pull/30013
-if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.4.0')
-  gem 'stringio', '3.1.1'
-elsif Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.3.0')
-  gem 'stringio', '3.1.0'
-elsif Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.2.0')
-  gem 'stringio', '3.0.4'
-elsif Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1.0')
-  gem 'stringio', '3.0.1'
-end
 gem 'strong_migrations', '1.8.0'
 gem 'tty-prompt', '~> 0.23', require: false
 gem 'twitter-text', '~> 3.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -521,8 +521,6 @@ GEM
       activesupport (>= 7.0.0)
       rack
       railties (>= 7.0.0)
-    psych (5.1.2)
-      stringio
     public_suffix (5.0.5)
     puma (6.4.2)
       nio4r (~> 2.0)
@@ -596,8 +594,7 @@ GEM
       link_header (~> 0.0, >= 0.0.8)
     rdf-normalize (0.7.0)
       rdf (~> 3.3)
-    rdoc (6.6.3.1)
-      psych (>= 4.0.0)
+    rdoc (6.3.3)
     redcarpet (3.6.0)
     redis (4.8.1)
     redis-namespace (1.11.0)
@@ -732,7 +729,6 @@ GEM
     statsd-ruby (1.5.0)
     stoplight (4.1.0)
       redlock (~> 1.0)
-    stringio (3.0.4)
     strong_migrations (1.8.0)
       activerecord (>= 5.2)
     swd (1.3.0)
@@ -911,6 +907,7 @@ DEPENDENCIES
   rails-controller-testing (~> 1.0)
   rails-i18n (~> 7.0)
   rdf-normalize (~> 0.5)
+  rdoc (= 6.3.3)
   redcarpet (~> 3.6)
   redis (~> 4.5)
   redis-namespace (~> 1.10)
@@ -939,7 +936,6 @@ DEPENDENCIES
   simplecov-lcov (~> 0.8)
   stackprof
   stoplight (~> 4.1)
-  stringio (= 3.0.4)
   strong_migrations (= 1.8.0)
   test-prof
   thor (~> 1.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -732,7 +732,7 @@ GEM
     statsd-ruby (1.5.0)
     stoplight (4.1.0)
       redlock (~> 1.0)
-    stringio (3.1.0)
+    stringio (3.0.4)
     strong_migrations (1.8.0)
       activerecord (>= 5.2)
     swd (1.3.0)
@@ -939,6 +939,7 @@ DEPENDENCIES
   simplecov-lcov (~> 0.8)
   stackprof
   stoplight (~> 4.1)
+  stringio (= 3.0.4)
   strong_migrations (= 1.8.0)
   test-prof
   thor (~> 1.2)


### PR DESCRIPTION
Manually installed from source Mastodon Rails server for the development, when running in RubyMine, is not working at all. 

Every request in the browser results in connection timeout and weird errors in the log:

```
02:40:04 web.1     | 2024-04-20 02:40:04 +0300 Listen loop: #<TypeError: wrong argument type strio (expected strio)>
02:40:04 web.1     | 2024-04-20 02:40:04 +0300 Listen loop: #<TypeError: wrong argument type strio (expected strio)>
```

This is happening in `Puma::Client#initialize` when calling `IOBuffer.new`, `IOBuffer` being a `StringIO` descendant class.

Found this error on SO happening to Unicorn as well - https://stackoverflow.com/questions/77570131/unicorn-rails-7-1-typeerror-wrong-argument-type-strio-expected-strio-type, the culprit also being the `string.io` gem. Though, the guy on SO has proposed a very invasive fix - to restrict the `debug` and `irb` gems' versions, thus getting rid of the `rdoc` dependency, which has the `stringio` as a dependency.

The fix is actually much simpler - as this gem is embedded into Ruby, and is actually a C extension, the gem's version should stick to the embedded one. As the currently used Ruby 3.2.3 has the 3.0.4 `STRINGIO_VERSION` - see https://github.com/ruby/ruby/blob/v3_2_3/ext/stringio/stringio.c#L15, the version in the Gemfile.lock should be the same. Because Puma or Unicorn, when installed, are compiled with Ruby 3.2.3 with the 3.0.4 `STRINGIO_VERSION`, and there is no compatibility with the next versions of the gem - I have tried them all, one by one.

It is working when running from terminal, but better to ensure it is working everywhere.

## UPDATE

The simplest solution is to restrict the RDoc version to the last version, not requiring Psych -> StringIO

