### PR TITLE
Fixed rendering of excess whitespace in status card titles

### DIFF
--- a/app/javascript/mastodon/features/status/components/card.jsx
+++ b/app/javascript/mastodon/features/status/components/card.jsx
@@ -144,7 +144,7 @@ export default class Card extends PureComponent {
           {card.get('published_at') && <> · <RelativeTimestamp timestamp={card.get('published_at')} /></>}
         </span>
 
-        <strong className='status-card__title' title={card.get('title')} lang={language}>{card.get('title')}</strong>
+        <strong className='status-card__title' title={card.get('title').trim()} lang={language}>{card.get('title').trim()}</strong>
 
         {card.get('author_name').length > 0 ? <span className='status-card__author'><FormattedMessage id='link_preview.author' defaultMessage='By {name}' values={{ name: <strong>{card.get('author_name')}</strong> }} /></span> : <span className='status-card__description' lang={language}>{card.get('description')}</span>}
       </div>

--- a/app/javascript/mastodon/features/status/components/card.jsx
+++ b/app/javascript/mastodon/features/status/components/card.jsx
@@ -144,7 +144,7 @@ export default class Card extends PureComponent {
           {card.get('published_at') && <> · <RelativeTimestamp timestamp={card.get('published_at')} /></>}
         </span>
 
-        <strong className='status-card__title' title={card.get('title').trim()} lang={language}>{card.get('title').trim()}</strong>
+        <strong className='status-card__title' title={card.get('title')} lang={language}>{card.get('title')}</strong>
 
         {card.get('author_name').length > 0 ? <span className='status-card__author'><FormattedMessage id='link_preview.author' defaultMessage='By {name}' values={{ name: <strong>{card.get('author_name')}</strong> }} /></span> : <span className='status-card__description' lang={language}>{card.get('description')}</span>}
       </div>

--- a/app/lib/link_details_extractor.rb
+++ b/app/lib/link_details_extractor.rb
@@ -156,7 +156,7 @@ class LinkDetailsExtractor
   end
 
   def title
-    html_entities.decode(structured_data&.headline || opengraph_tag('og:title') || document.xpath('//title').map(&:content).first)
+    html_entities.decode(structured_data&.headline || opengraph_tag('og:title') || document.xpath('//title').map(&:content).first).strip
   end
 
   def description


### PR DESCRIPTION
Fixes #29993

When link details are extracted any excess whitespace contained in the source HTML `title` element gets included in the status record. Some browsers then display the card content and/or tooltip with that extraneous whitespace which puts the content out of normal alignment. This change trims off that whitespace prior to rendering, however it does not change the behavior when saving the link details in the status record.