### PR TITLE
Revert "Rely on dotenv autoload instead of explicit call (#30007)"

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -52,6 +52,8 @@ require_relative '../lib/active_record/batches'
 require_relative '../lib/simple_navigation/item_extensions'
 require_relative '../lib/http_extensions'
 
+Dotenv::Rails.load
+
 Bundler.require(:pam_authentication) if ENV['PAM_ENABLED'] == 'true'
 
 require_relative '../lib/mastodon/redis_config'


### PR DESCRIPTION
This reverts commit 18737aad49911f00b94f9cf6fc582670cbdeda93.

Redis configuration variables are read from `ENV` in `lib/mastodon/redis_config.rb`, before initializers run, so this caused the Redis configuration from `.env.production` to be effectively ignored.