### PR TITLE
Disable `Style/HashAsLastArrayItem` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -182,6 +182,11 @@ Style/FormatStringToken:
   AllowedMethods:
     - redirect_with_vary
 
+# Reason: Prevailing style choice
+# https://docs.rubocop.org/rubocop/cops_style.html#stylehashaslastarrayitem
+Style/HashAsLastArrayItem:
+  Enabled: false
+
 # Reason: Enforce modern Ruby style
 # https://docs.rubocop.org/rubocop/cops_style.html#stylehashsyntax
 Style/HashSyntax:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -128,19 +128,6 @@ Style/GuardClause:
     - 'lib/mastodon/cli/media.rb'
     - 'lib/tasks/repo.rake'
 
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: braces, no_braces
-Style/HashAsLastArrayItem:
-  Exclude:
-    - 'app/controllers/admin/statuses_controller.rb'
-    - 'app/controllers/api/v1/statuses_controller.rb'
-    - 'app/models/concerns/account/counters.rb'
-    - 'app/models/concerns/status/threading_concern.rb'
-    - 'app/models/status.rb'
-    - 'app/services/batched_remove_status_service.rb'
-    - 'app/services/notify_service.rb'
-
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Style/HashTransformValues:
   Exclude:


### PR DESCRIPTION
Going through a few of these remaining todo cops - there are a bunch where, in my opinion, the guidance really just doesn't matter that much and where opening a PR with the autocorrect feels sort of pointless. Makes more sense to disable those cops, I think.