### PR TITLE
Extract constants for column size length validation limits

### DIFF
--- a/app/models/account_moderation_note.rb
+++ b/app/models/account_moderation_note.rb
@@ -13,10 +13,12 @@
 #
 
 class AccountModerationNote < ApplicationRecord
+  CONTENT_SIZE_LIMIT = 500
+
   belongs_to :account
   belongs_to :target_account, class_name: 'Account'
 
   scope :latest, -> { reorder('created_at DESC') }
 
-  validates :content, presence: true, length: { maximum: 500 }
+  validates :content, presence: true, length: { maximum: CONTENT_SIZE_LIMIT }
 end

--- a/app/models/account_note.rb
+++ b/app/models/account_note.rb
@@ -14,9 +14,11 @@
 class AccountNote < ApplicationRecord
   include RelationshipCacheable
 
+  COMMENT_SIZE_LIMIT = 2_000
+
   belongs_to :account
   belongs_to :target_account, class_name: 'Account'
 
   validates :account_id, uniqueness: { scope: :target_account_id }
-  validates :comment, length: { maximum: 2_000 }
+  validates :comment, length: { maximum: COMMENT_SIZE_LIMIT }
 end

--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -19,12 +19,14 @@
 class Invite < ApplicationRecord
   include Expireable
 
+  COMMENT_SIZE_LIMIT = 420
+
   belongs_to :user, inverse_of: :invites
   has_many :users, inverse_of: :invite, dependent: nil
 
   scope :available, -> { where(expires_at: nil).or(where('expires_at >= ?', Time.now.utc)) }
 
-  validates :comment, length: { maximum: 420 }
+  validates :comment, length: { maximum: COMMENT_SIZE_LIMIT }
 
   before_validation :set_code
 

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -26,6 +26,8 @@ class Report < ApplicationRecord
   include Paginable
   include RateLimitable
 
+  COMMENT_SIZE_LIMIT = 1_000
+
   rate_limit by: :account, family: :reports
 
   belongs_to :account
@@ -46,7 +48,7 @@ class Report < ApplicationRecord
   # A report is considered local if the reporter is local
   delegate :local?, to: :account
 
-  validates :comment, length: { maximum: 1_000 }, if: :local?
+  validates :comment, length: { maximum: COMMENT_SIZE_LIMIT }, if: :local?
   validates :rule_ids, absence: true, if: -> { (category_changed? || rule_ids_changed?) && !violation? }
 
   validate :validate_rule_ids, if: -> { (category_changed? || rule_ids_changed?) && violation? }

--- a/app/models/report_note.rb
+++ b/app/models/report_note.rb
@@ -13,10 +13,12 @@
 #
 
 class ReportNote < ApplicationRecord
+  CONTENT_SIZE_LIMIT = 500
+
   belongs_to :account
   belongs_to :report, inverse_of: :notes, touch: true
 
   scope :latest, -> { reorder(created_at: :desc) }
 
-  validates :content, presence: true, length: { maximum: 500 }
+  validates :content, presence: true, length: { maximum: CONTENT_SIZE_LIMIT }
 end

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -15,9 +15,11 @@
 class Rule < ApplicationRecord
   include Discard::Model
 
+  TEXT_SIZE_LIMIT = 300
+
   self.discard_column = :deleted_at
 
-  validates :text, presence: true, length: { maximum: 300 }
+  validates :text, presence: true, length: { maximum: TEXT_SIZE_LIMIT }
 
   scope :ordered, -> { kept.order(priority: :asc, id: :asc) }
 end

--- a/app/models/user_invite_request.rb
+++ b/app/models/user_invite_request.rb
@@ -12,6 +12,8 @@
 #
 
 class UserInviteRequest < ApplicationRecord
+  TEXT_SIZE_LIMIT = 420
+
   belongs_to :user, inverse_of: :invite_request
-  validates :text, presence: true, length: { maximum: 420 }
+  validates :text, presence: true, length: { maximum: TEXT_SIZE_LIMIT }
 end


### PR DESCRIPTION
Same pattern in each one, similar to other recent PRs -- just pull out validation-related magic number to named constant, simplify customization/fork/etc.

Grouping a few of these to reduce PR count.