### PR TITLE
Remove unused `Account.popular` scope

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -135,7 +135,6 @@ class Account < ApplicationRecord
   scope :discoverable, -> { searchable.without_silenced.where(discoverable: true).joins(:account_stat) }
   scope :by_recent_status, -> { includes(:account_stat).merge(AccountStat.by_recent_status).references(:account_stat) }
   scope :by_recent_activity, -> { left_joins(:user, :account_stat).order(coalesced_activity_timestamps.desc).order(id: :desc) }
-  scope :popular, -> { order('account_stats.followers_count desc') }
   scope :by_domain_and_subdomains, ->(domain) { where(domain: Instance.by_domain_and_subdomains(domain).select(:domain)) }
   scope :not_excluded_by_account, ->(account) { where.not(id: account.excluded_from_timeline_account_ids) }
   scope :not_domain_blocked_by_account, ->(account) { where(arel_table[:domain].eq(nil).or(arel_table[:domain].not_in(account.excluded_from_timeline_domains))) }


### PR DESCRIPTION
Last usage was removed in  https://github.com/mastodon/mastodon/pull/23900

That was in turn removing a previous usage removal from https://github.com/mastodon/mastodon/commit/74081433d0078784b7c2139f6caaa812740632b2#diff-175888239adc2b81ed2e4e82f0ee0663be0677f376e1aa1d9151baa69596e546L23