### PR TITLE
Use shared form partial for `admin/warning_presets` views

### DIFF
--- a/app/views/admin/warning_presets/_form.html.haml
+++ b/app/views/admin/warning_presets/_form.html.haml
@@ -1,0 +1,7 @@
+.fields-group
+  = form.input :title,
+               wrapper: :with_block_label
+
+.fields-group
+  = form.input :text,
+               wrapper: :with_block_label

--- a/app/views/admin/warning_presets/edit.html.haml
+++ b/app/views/admin/warning_presets/edit.html.haml
@@ -1,14 +1,10 @@
 - content_for :page_title do
   = t('admin.warning_presets.edit_preset')
 
-= simple_form_for @warning_preset, url: admin_warning_preset_path(@warning_preset) do |f|
+= simple_form_for @warning_preset, url: admin_warning_preset_path(@warning_preset) do |form|
   = render 'shared/error_messages', object: @warning_preset
 
-  .fields-group
-    = f.input :title, wrapper: :with_block_label
-
-  .fields-group
-    = f.input :text, wrapper: :with_block_label
+  = render form
 
   .actions
-    = f.button :button, t('generic.save_changes'), type: :submit
+    = form.button :button, t('generic.save_changes'), type: :submit

--- a/app/views/admin/warning_presets/index.html.haml
+++ b/app/views/admin/warning_presets/index.html.haml
@@ -2,17 +2,13 @@
   = t('admin.warning_presets.title')
 
 - if can? :create, :account_warning_preset
-  = simple_form_for @warning_preset, url: admin_warning_presets_path do |f|
+  = simple_form_for @warning_preset, url: admin_warning_presets_path do |form|
     = render 'shared/error_messages', object: @warning_preset
 
-    .fields-group
-      = f.input :title, wrapper: :with_block_label
-
-    .fields-group
-      = f.input :text, wrapper: :with_block_label
+    = render form
 
     .actions
-      = f.button :button, t('admin.warning_presets.add_new'), type: :submit
+      = form.button :button, t('admin.warning_presets.add_new'), type: :submit
 
   %hr.spacer/
 


### PR DESCRIPTION
Similar to last few in this area, pulled out shared form markup to partial.