### PR TITLE
Use shorter `render` call in `admin/webhooks` view

### DIFF
--- a/app/views/admin/webhooks/edit.html.haml
+++ b/app/views/admin/webhooks/edit.html.haml
@@ -2,6 +2,6 @@
   = t('admin.webhooks.edit')
 
 = simple_form_for @webhook, url: admin_webhook_path(@webhook) do |form|
-  = render partial: 'form', object: form
+  = render form
   .actions
     = form.button :button, t('generic.save_changes'), type: :submit

--- a/app/views/admin/webhooks/new.html.haml
+++ b/app/views/admin/webhooks/new.html.haml
@@ -2,6 +2,6 @@
   = t('admin.webhooks.new')
 
 = simple_form_for @webhook, url: admin_webhooks_path do |form|
-  = render partial: 'form', object: form
+  = render form
   .actions
     = form.button :button, t('admin.webhooks.add_new'), type: :submit


### PR DESCRIPTION
This partial was already pulled out, just updating call style to match other areas.