### PR TITLE
Use composable query in `Status.without_replies` scope

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -106,7 +106,9 @@ class Status < ApplicationRecord
   scope :remote, -> { where(local: false).where.not(uri: nil) }
   scope :local,  -> { where(local: true).or(where(uri: nil)) }
   scope :with_accounts, ->(ids) { where(id: ids).includes(:account) }
-  scope :without_replies, -> { where('statuses.reply = FALSE OR statuses.in_reply_to_account_id = statuses.account_id') }
+  scope :without_replies, -> { not_reply.or(reply_to_account) }
+  scope :not_reply, -> { where(reply: false) }
+  scope :reply_to_account, -> { where(arel_table[:in_reply_to_account_id].eq arel_table[:account_id]) }
   scope :without_reblogs, -> { where(statuses: { reblog_of_id: nil }) }
   scope :tagged_with, ->(tag_ids) { joins(:statuses_tags).where(statuses_tags: { tag_id: tag_ids }) }
   scope :not_excluded_by_account, ->(account) { where.not(account_id: account.excluded_from_timeline_account_ids) }


### PR DESCRIPTION
Splitting up the scope to make more composable/readable, avoid string programming.

SQL is basically the same...

In `main` now:

```
irb(main):001> Status.without_replies
  Status Load (5.1ms)  SELECT "statuses".* FROM "statuses" WHERE "statuses"."deleted_at" IS NULL AND (statuses.reply = FALSE OR statuses.in_reply_to_account_id = statuses.account_id) /* loading for pp */ ORDER BY "statuses"."id" DESC LIMIT $1  [["LIMIT", 11]]
=> []
```

With this change:

```
irb(main):001> Status.without_replies
  Status Load (4.9ms)  SELECT "statuses".* FROM "statuses" WHERE "statuses"."deleted_at" IS NULL AND ("statuses"."reply" = $1 OR "statuses"."in_reply_to_account_id" = "statuses"."account_id") /* loading for pp */ ORDER BY "statuses"."id" DESC LIMIT $2  [["reply", false], ["LIMIT", 11]]
=> []
```
