### PR TITLE
Use `EXPIRATION_DURATIONS` constant in `CustomFilter` class

### DIFF
--- a/app/models/custom_filter.rb
+++ b/app/models/custom_filter.rb
@@ -28,6 +28,8 @@ class CustomFilter < ApplicationRecord
     account
   ).freeze
 
+  EXPIRATION_DURATIONS = [30.minutes, 1.hour, 6.hours, 12.hours, 1.day, 1.week].freeze
+
   include Expireable
   include Redisable
 
@@ -52,7 +54,7 @@ class CustomFilter < ApplicationRecord
     return @expires_in if defined?(@expires_in)
     return nil if expires_at.nil?
 
-    [30.minutes, 1.hour, 6.hours, 12.hours, 1.day, 1.week].find { |expires_in| expires_in.from_now >= expires_at }
+    EXPIRATION_DURATIONS.find { |expires_in| expires_in.from_now >= expires_at }
   end
 
   def irreversible=(value)

--- a/app/views/filters/_filter_fields.html.haml
+++ b/app/views/filters/_filter_fields.html.haml
@@ -6,7 +6,7 @@
               wrapper: :with_label
   .fields-row__column.fields-row__column-6.fields-group
     = f.input :expires_in,
-              collection: [30.minutes, 1.hour, 6.hours, 12.hours, 1.day, 1.week].map(&:to_i),
+              collection: CustomFilter::EXPIRATION_DURATIONS.map(&:to_i),
               include_blank: I18n.t('invites.expires_in_prompt'),
               label_method: ->(i) { I18n.t("invites.expires_in.#{i}") },
               wrapper: :with_label


### PR DESCRIPTION
Adds constant to the class, and updates a form partial using the same collection to use the constant.

Possible future work here ... the `Invite` form and model have similar dynamic, but use a helper method ... we could do one/both of:

- Pull out the options into the class as a constant and update invite model to have similar "use shortest option" logic as CustomFilter does
- Add a helper method for this filter case to be used in the view and avoid using the class/constant directly in view