### PR TITLE
MAX_POST_CHARS Env Part 2

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -75,3 +75,7 @@ S3_ALIAS_HOST=files.example.com
 # -----------------------
 IP_RETENTION_PERIOD=31556952
 SESSION_RETENTION_PERIOD=31556952
+
+# Instance Tweaks
+# ---------------
+MAX_POST_CHARS=500

--- a/app/validators/status_length_validator.rb
+++ b/app/validators/status_length_validator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class StatusLengthValidator < ActiveModel::Validator
-  MAX_CHARS = 500
+  MAX_CHARS = (ENV['MAX_POST_CHARS'] || 500).to_i
   URL_PLACEHOLDER_CHARS = 23
   URL_PLACEHOLDER = 'x' * 23
 

--- a/spec/validators/status_length_validator_spec.rb
+++ b/spec/validators/status_length_validator_spec.rb
@@ -4,6 +4,8 @@ require 'rails_helper'
 
 describe StatusLengthValidator do
   describe '#validate' do
+    before { stub_const("#{described_class}::MAX_CHARS", 500) } # Example values below are relative to this baseline
+
     it 'does not add errors onto remote statuses' do
       status = instance_double(Status, local?: false)
       allow(status).to receive(:errors)
@@ -22,32 +24,27 @@ describe StatusLengthValidator do
       expect(status).to_not have_received(:errors)
     end
 
-    it 'adds an error when content warning is over MAX_CHARS characters' do
-      chars = StatusLengthValidator::MAX_CHARS + 1
-      status = instance_double(Status, spoiler_text: 'a' * chars, text: '', errors: activemodel_errors, local?: true, reblog?: false)
+    it 'adds an error when content warning is over character limit' do
+      status = status_double(spoiler_text: 'a' * 520)
       subject.validate(status)
       expect(status.errors).to have_received(:add)
     end
 
-    it 'adds an error when text is over MAX_CHARS characters' do
-      chars = StatusLengthValidator::MAX_CHARS + 1
-      status = instance_double(Status, spoiler_text: '', text: 'a' * chars, errors: activemodel_errors, local?: true, reblog?: false)
+    it 'adds an error when text is over character limit' do
+      status = status_double(text: 'a' * 520)
       subject.validate(status)
       expect(status.errors).to have_received(:add)
     end
 
-    it 'adds an error when text and content warning are over MAX_CHARS characters total' do
-      chars1 = 20
-      chars2 = StatusLengthValidator::MAX_CHARS + 1 - chars1
-      status = instance_double(Status, spoiler_text: 'a' * chars1, text: 'b' * chars2, errors: activemodel_errors, local?: true, reblog?: false)
+    it 'adds an error when text and content warning are over character limit total' do
+      status = status_double(spoiler_text: 'a' * 250, text: 'b' * 251)
       subject.validate(status)
       expect(status.errors).to have_received(:add)
     end
 
     it 'counts URLs as 23 characters flat' do
-      chars = StatusLengthValidator::MAX_CHARS - 1 - 23
-      text   = ('a' * chars) + " http://#{'b' * 30}.com/example"
-      status = instance_double(Status, spoiler_text: '', text: text, errors: activemodel_errors, local?: true, reblog?: false)
+      text   = ('a' * 476) + " http://#{'b' * 30}.com/example"
+      status = status_double(text: text)
 
       subject.validate(status)
       expect(status.errors).to_not have_received(:add)
@@ -55,7 +52,7 @@ describe StatusLengthValidator do
 
     it 'does not count non-autolinkable URLs as 23 characters flat' do
       text   = ('a' * 476) + "http://#{'b' * 30}.com/example"
-      status = instance_double(Status, spoiler_text: '', text: text, errors: activemodel_errors, local?: true, reblog?: false)
+      status = status_double(text: text)
 
       subject.validate(status)
       expect(status.errors).to have_received(:add)
@@ -63,16 +60,14 @@ describe StatusLengthValidator do
 
     it 'does not count overly long URLs as 23 characters flat' do
       text = "http://example.com/valid?#{'#foo?' * 1000}"
-      status = instance_double(Status, spoiler_text: '', text: text, errors: activemodel_errors, local?: true, reblog?: false)
+      status = status_double(text: text)
       subject.validate(status)
       expect(status.errors).to have_received(:add)
     end
 
     it 'counts only the front part of remote usernames' do
-      username = '@alice'
-      chars = StatusLengthValidator::MAX_CHARS - 1 - username.length
-      text   = ('a' * chars) + " #{username}@#{'b' * 30}.com"
-      status = instance_double(Status, spoiler_text: '', text: text, errors: activemodel_errors, local?: true, reblog?: false)
+      text   = ('a' * 475) + " @alice@#{'b' * 30}.com"
+      status = status_double(text: text)
 
       subject.validate(status)
       expect(status.errors).to_not have_received(:add)
@@ -80,7 +75,7 @@ describe StatusLengthValidator do
 
     it 'does count both parts of remote usernames for overly long domains' do
       text   = "@alice@#{'b' * 500}.com"
-      status = instance_double(Status, spoiler_text: '', text: text, errors: activemodel_errors, local?: true, reblog?: false)
+      status = status_double(text: text)
 
       subject.validate(status)
       expect(status.errors).to have_received(:add)
@@ -88,6 +83,17 @@ describe StatusLengthValidator do
   end
 
   private
+
+  def status_double(spoiler_text: '', text: '')
+    instance_double(
+      Status,
+      spoiler_text: spoiler_text,
+      text: text,
+      errors: activemodel_errors,
+      local?: true,
+      reblog?: false
+    )
+  end
 
   def activemodel_errors
     instance_double(ActiveModel::Errors, add: nil)

--- a/spec/validators/status_length_validator_spec.rb
+++ b/spec/validators/status_length_validator_spec.rb
@@ -22,26 +22,31 @@ describe StatusLengthValidator do
       expect(status).to_not have_received(:errors)
     end
 
-    it 'adds an error when content warning is over 500 characters' do
-      status = instance_double(Status, spoiler_text: 'a' * 520, text: '', errors: activemodel_errors, local?: true, reblog?: false)
+    it 'adds an error when content warning is over MAX_CHARS characters' do
+      chars = StatusLengthValidator::MAX_CHARS + 1
+      status = instance_double(Status, spoiler_text: 'a' * chars, text: '', errors: activemodel_errors, local?: true, reblog?: false)
       subject.validate(status)
       expect(status.errors).to have_received(:add)
     end
 
-    it 'adds an error when text is over 500 characters' do
-      status = instance_double(Status, spoiler_text: '', text: 'a' * 520, errors: activemodel_errors, local?: true, reblog?: false)
+    it 'adds an error when text is over MAX_CHARS characters' do
+      chars = StatusLengthValidator::MAX_CHARS + 1
+      status = instance_double(Status, spoiler_text: '', text: 'a' * chars, errors: activemodel_errors, local?: true, reblog?: false)
       subject.validate(status)
       expect(status.errors).to have_received(:add)
     end
 
-    it 'adds an error when text and content warning are over 500 characters total' do
-      status = instance_double(Status, spoiler_text: 'a' * 250, text: 'b' * 251, errors: activemodel_errors, local?: true, reblog?: false)
+    it 'adds an error when text and content warning are over MAX_CHARS characters total' do
+      chars1 = 20
+      chars2 = StatusLengthValidator::MAX_CHARS + 1 - chars1
+      status = instance_double(Status, spoiler_text: 'a' * chars1, text: 'b' * chars2, errors: activemodel_errors, local?: true, reblog?: false)
       subject.validate(status)
       expect(status.errors).to have_received(:add)
     end
 
     it 'counts URLs as 23 characters flat' do
-      text   = ('a' * 476) + " http://#{'b' * 30}.com/example"
+      chars = StatusLengthValidator::MAX_CHARS - 1 - 23
+      text   = ('a' * chars) + " http://#{'b' * 30}.com/example"
       status = instance_double(Status, spoiler_text: '', text: text, errors: activemodel_errors, local?: true, reblog?: false)
 
       subject.validate(status)
@@ -64,7 +69,9 @@ describe StatusLengthValidator do
     end
 
     it 'counts only the front part of remote usernames' do
-      text   = ('a' * 475) + " @alice@#{'b' * 30}.com"
+      username = '@alice'
+      chars = StatusLengthValidator::MAX_CHARS - 1 - username.length
+      text   = ('a' * chars) + " #{username}@#{'b' * 30}.com"
       status = instance_double(Status, spoiler_text: '', text: text, errors: activemodel_errors, local?: true, reblog?: false)
 
       subject.validate(status)


### PR DESCRIPTION
This rebases #27629 onto a current mastodon version. This commit is made in the contexts of [discussions](https://www.loomio.com/d/C4HKmTOa/proposal-to-revisit-extending-the-character-limit-for-posts) around increasing the character limit at social.coop.

Modifying a docker container is considerably difficult. Mastodon already has facilities to collapse large posts. It federates with software that has no post limits. Recently, @ClearlyClaire authored https://github.com/mastodon/mastodon/commit/805dba7f8d2a2d5f910ec1396247b36417170345, which means there is only one codepath that needs to be updated. Instance admins modifying source code makes it more prone to breakage. They do it anyway. Splitting up posts disrupts the flow of conversation. It can even be an accessibility concern. 

The cat has left the bag a long time ago. Its time.

Closes #12265