### PR TITLE
Remove usage of deprecated `defaultTypes` on React functional components

### DIFF
--- a/app/javascript/mastodon/components/badge.jsx
+++ b/app/javascript/mastodon/components/badge.jsx
@@ -7,7 +7,7 @@ import PersonIcon from '@/material-icons/400-24px/person.svg?react';
 import SmartToyIcon from '@/material-icons/400-24px/smart_toy.svg?react';
 
 
-export const Badge = ({ icon, label, domain, roleId }) => (
+export const Badge = ({ icon = <PersonIcon />, label, domain, roleId }) => (
   <div className='account-role' data-account-role-id={roleId}>
     {icon}
     {label}
@@ -20,10 +20,6 @@ Badge.propTypes = {
   label: PropTypes.node,
   domain: PropTypes.node,
   roleId: PropTypes.string
-};
-
-Badge.defaultProps = {
-  icon: <PersonIcon />,
 };
 
 export const GroupBadge = () => (


### PR DESCRIPTION
This has been deprecated in React 18.3 and will be removed in React 19.

We can use a default value in JS to replace it.