### PR TITLE
Use ESLint to replace double quotes

### DIFF
--- a/app/javascript/mastodon/actions/domain_blocks.js
+++ b/app/javascript/mastodon/actions/domain_blocks.js
@@ -1,10 +1,10 @@
 import api, { getLinks } from '../api';
 
-import { blockDomainSuccess, unblockDomainSuccess } from "./domain_blocks_typed";
+import { blockDomainSuccess, unblockDomainSuccess } from './domain_blocks_typed';
 import { openModal } from './modal';
 
 
-export * from "./domain_blocks_typed";
+export * from './domain_blocks_typed';
 
 export const DOMAIN_BLOCK_REQUEST = 'DOMAIN_BLOCK_REQUEST';
 export const DOMAIN_BLOCK_FAIL    = 'DOMAIN_BLOCK_FAIL';

--- a/app/javascript/mastodon/actions/interactions.js
+++ b/app/javascript/mastodon/actions/interactions.js
@@ -47,7 +47,7 @@ export const UNBOOKMARK_REQUEST = 'UNBOOKMARKED_REQUEST';
 export const UNBOOKMARK_SUCCESS = 'UNBOOKMARKED_SUCCESS';
 export const UNBOOKMARK_FAIL    = 'UNBOOKMARKED_FAIL';
 
-export * from "./interactions_typed";
+export * from './interactions_typed';
 
 export function favourite(status) {
   return function (dispatch) {

--- a/app/javascript/mastodon/actions/notifications.js
+++ b/app/javascript/mastodon/actions/notifications.js
@@ -9,10 +9,10 @@ import {
   importFetchedAccount,
 } from './importer';
 import { submitMarkers } from './markers';
-import { notificationsUpdate } from "./notifications_typed";
+import { notificationsUpdate } from './notifications_typed';
 import { register as registerPushNotifications } from './push_notifications';
 
-export * from "./notifications_typed";
+export * from './notifications_typed';
 
 export const NOTIFICATIONS_FILTER_SET = 'NOTIFICATIONS_FILTER_SET';
 

--- a/app/javascript/mastodon/actions/timelines.js
+++ b/app/javascript/mastodon/actions/timelines.js
@@ -152,7 +152,7 @@ export const expandAccountTimeline         = (accountId, { maxId, withReplies, t
 export const expandAccountFeaturedTimeline = (accountId, { tagged } = {}) => expandTimeline(`account:${accountId}:pinned${tagged ? `:${tagged}` : ''}`, `/api/v1/accounts/${accountId}/statuses`, { pinned: true, tagged });
 export const expandAccountMediaTimeline    = (accountId, { maxId } = {}) => expandTimeline(`account:${accountId}:media`, `/api/v1/accounts/${accountId}/statuses`, { max_id: maxId, only_media: true, limit: 40 });
 export const expandListTimeline            = (id, { maxId } = {}) => expandTimeline(`list:${id}`, `/api/v1/timelines/list/${id}`, { max_id: maxId });
-export const expandLinkTimeline            = (url, { maxId } = {}) => expandTimeline(`link:${url}`, `/api/v1/timelines/link`, { url, max_id: maxId });
+export const expandLinkTimeline            = (url, { maxId } = {}) => expandTimeline(`link:${url}`, '/api/v1/timelines/link', { url, max_id: maxId });
 export const expandHashtagTimeline         = (hashtag, { maxId, tags, local } = {}) => {
   return expandTimeline(`hashtag:${hashtag}${local ? ':local' : ''}`, `/api/v1/timelines/tag/${hashtag}`, {
     max_id: maxId,

--- a/app/javascript/mastodon/features/compose/components/compose_form.jsx
+++ b/app/javascript/mastodon/features/compose/components/compose_form.jsx
@@ -26,7 +26,7 @@ import { CharacterCounter } from './character_counter';
 import { EditIndicator } from './edit_indicator';
 import { LanguageDropdown } from './language_dropdown';
 import { NavigationBar } from './navigation_bar';
-import { PollForm } from "./poll_form";
+import { PollForm } from './poll_form';
 import { ReplyIndicator } from './reply_indicator';
 import { UploadForm } from './upload_form';
 import { Warning } from './warning';

--- a/app/javascript/mastodon/features/emoji/emoji.js
+++ b/app/javascript/mastodon/features/emoji/emoji.js
@@ -23,7 +23,7 @@ const lightEmoji = emojiFilenames(['👽', '⚾', '🐔', '☁️', '💨', '�
  * @returns {string}
  */
 const emojiFilename = (filename, colorScheme) => {
-  const borderedEmoji = colorScheme === "light" ? lightEmoji : darkEmoji;
+  const borderedEmoji = colorScheme === 'light' ? lightEmoji : darkEmoji;
   return borderedEmoji.includes(filename) ? (filename + '_border') : filename;
 };
 

--- a/app/javascript/mastodon/features/status/components/card.jsx
+++ b/app/javascript/mastodon/features/status/components/card.jsx
@@ -158,7 +158,7 @@ export default class Card extends PureComponent {
     };
 
     if (largeImage && card.get('type') === 'video') {
-      thumbnailStyle.aspectRatio = `16 / 9`;
+      thumbnailStyle.aspectRatio = '16 / 9';
     } else if (largeImage) {
       thumbnailStyle.aspectRatio = '1.91 / 1';
     } else {

--- a/app/javascript/mastodon/features/ui/components/navigation_panel.jsx
+++ b/app/javascript/mastodon/features/ui/components/navigation_panel.jsx
@@ -124,7 +124,7 @@ class NavigationPanel extends Component {
       banner = (
         <div className='switch-to-advanced'>
           {intl.formatMessage(messages.openedInClassicInterface)}
-          {" "}
+          {' '}
           <a href={`/deck${location.pathname}`} className='switch-to-advanced__toggle'>
             {intl.formatMessage(messages.advancedInterface)}
           </a>

--- a/app/javascript/mastodon/initial_state.js
+++ b/app/javascript/mastodon/initial_state.js
@@ -71,7 +71,7 @@ const element = document.getElementById('initial-state');
 const initialState = element?.textContent && JSON.parse(element.textContent);
 
 /** @type {string} */
-const initialPath = document.querySelector("head meta[name=initialPath]")?.getAttribute("content") ?? '';
+const initialPath = document.querySelector('head meta[name=initialPath]')?.getAttribute('content') ?? '';
 /** @type {boolean} */
 export const hasMultiColumnPath = initialPath === '/'
   || initialPath === '/getting-started'

--- a/app/javascript/mastodon/selectors/index.js
+++ b/app/javascript/mastodon/selectors/index.js
@@ -5,8 +5,8 @@ import { me } from '../initial_state';
 
 import { getFilters } from './filters';
 
-export { makeGetAccount } from "./accounts";
-export { getStatusList } from "./statuses";
+export { makeGetAccount } from './accounts';
+export { getStatusList } from './statuses';
 
 export const makeGetStatus = () => {
   return createSelector(

--- a/app/javascript/mastodon/service_worker/web_push_notifications.js
+++ b/app/javascript/mastodon/service_worker/web_push_notifications.js
@@ -4,7 +4,7 @@ import { unescape } from 'lodash';
 // see config/vite/plugins/sw-locales
 // it needs to be updated when new locale keys are used in this file
 // eslint-disable-next-line import/no-unresolved
-import locales from "virtual:mastodon-sw-locales";
+import locales from 'virtual:mastodon-sw-locales';
 
 const MAX_NOTIFICATIONS = 5;
 const GROUP_TAG = 'tag';

--- a/app/javascript/mastodon/stream.js
+++ b/app/javascript/mastodon/stream.js
@@ -150,7 +150,7 @@ export const connectStream = (channelName, params, callbacks) => (dispatch, getS
   const accessToken = getAccessToken();
   const { onConnect, onReceive, onDisconnect } = callbacks(dispatch, getState);
 
-  if(!accessToken) throw new Error("Trying to connect to the streaming server but no access token is available.");
+  if(!accessToken) throw new Error('Trying to connect to the streaming server but no access token is available.');
 
   // If we cannot use a websockets connection, we must fall back
   // to using individual connections for each channel

--- a/config/formatjs-formatter.js
+++ b/config/formatjs-formatter.js
@@ -1,6 +1,6 @@
 const path = require('path');
 
-const currentTranslations = require(path.join(__dirname, "../app/javascript/mastodon/locales/en.json"));
+const currentTranslations = require(path.join(__dirname, '../app/javascript/mastodon/locales/en.json'));
 
 exports.format = (msgs) => {
   const results = {};

--- a/streaming/errors.js
+++ b/streaming/errors.js
@@ -29,7 +29,7 @@ export class RequestError extends Error {
    */
   constructor(message) {
     super(message);
-    this.name = "RequestError";
+    this.name = 'RequestError';
     this.status = 400;
   }
 }
@@ -40,7 +40,7 @@ export class AuthenticationError extends Error {
    */
   constructor(message) {
     super(message);
-    this.name = "AuthenticationError";
+    this.name = 'AuthenticationError';
     this.status = 401;
   }
 }

--- a/streaming/index.js
+++ b/streaming/index.js
@@ -72,7 +72,7 @@ const parseJSON = (json, req) => {
         req.log.error({ err }, `Error parsing message from ${req.remoteAddress}`);
       }
     } else {
-      logger.error({ err }, `Error parsing message from redis`);
+      logger.error({ err }, 'Error parsing message from redis');
     }
     return null;
   }
@@ -131,7 +131,7 @@ const startServer = async () => {
    * @returns {string}
    */
   function redisUnnamespaced(channel) {
-    if (typeof redisConfig.namespace === "string") {
+    if (typeof redisConfig.namespace === 'string') {
       // Note: this removes the configured namespace and the colon that is used
       // to separate it:
       return channel.slice(redisConfig.namespace.length + 1);
@@ -141,7 +141,7 @@ const startServer = async () => {
   }
 
   // Set the X-Request-Id header on WebSockets:
-  wss.on("headers", function onHeaders(headers, req) {
+  wss.on('headers', function onHeaders(headers, req) {
     headers.push(`X-Request-Id: ${req.id}`);
   });
 
@@ -161,7 +161,7 @@ const startServer = async () => {
     // logger. This decorates the `request` object.
     attachWebsocketHttpLogger(request);
 
-    request.log.info("HTTP Upgrade Requested");
+    request.log.info('HTTP Upgrade Requested');
 
     /** @param {Error} err */
     const onSocketError = (err) => {
@@ -214,7 +214,7 @@ const startServer = async () => {
     socket.removeListener('error', onSocketError);
 
     wss.handleUpgrade(request, socket, head, function done(ws) {
-      request.log.info("Authenticated request & upgraded to WebSocket connection");
+      request.log.info('Authenticated request & upgraded to WebSocket connection');
 
       const wsLogger = createWebsocketLogger(request, resolvedAccount);
 
@@ -281,7 +281,7 @@ const startServer = async () => {
 
     callbacks.forEach(callback => callback(json));
   };
-  redisSubscribeClient.on("message", onRedisMessage);
+  redisSubscribeClient.on('message', onRedisMessage);
 
   /**
    * @callback SubscriptionListener
@@ -604,7 +604,7 @@ const startServer = async () => {
    * @returns {SubscriptionListener}
    */
   const streamFrom = (channelIds, req, log, output, attachCloseHandler, destinationType, needsFiltering = false) => {
-    log.info({ channelIds }, `Starting stream`);
+    log.info({ channelIds }, 'Starting stream');
 
     /**
      * @param {string} event
@@ -711,7 +711,7 @@ const startServer = async () => {
           // If the payload already contains the `filtered` property, it means
           // that filtering has been applied on the ruby on rails side, as
           // such, we don't need to construct or apply the filters in streaming:
-          if (Object.hasOwn(payload, "filtered")) {
+          if (Object.hasOwn(payload, 'filtered')) {
             transmit(event, payload);
             return;
           }
@@ -867,7 +867,7 @@ const startServer = async () => {
     const heartbeat = setInterval(() => res.write(':thump\n'), 15000);
 
     req.on('close', () => {
-      req.log.info({ accountId: req.accountId }, `Ending stream`);
+      req.log.info({ accountId: req.accountId }, 'Ending stream');
 
       // We decrement these counters here instead of in streamHttpEnd as in that
       // method we don't have knowledge of the channel names
@@ -920,7 +920,7 @@ const startServer = async () => {
 
     ws.send(message, (/** @type {Error|undefined} */ err) => {
       if (err) {
-        req.log.error({err}, `Failed to send to websocket`);
+        req.log.error({err}, 'Failed to send to websocket');
       }
     });
   };
@@ -1171,7 +1171,7 @@ const startServer = async () => {
    * @param {string[]} channelIds
    */
   const removeSubscription = ({ request, logger, subscriptions }, channelIds) => {
-    logger.info({ channelIds, accountId: request.accountId }, `Ending stream`);
+    logger.info({ channelIds, accountId: request.accountId }, 'Ending stream');
 
     const subscription = subscriptions[channelIds.join(';')];
 
@@ -1206,7 +1206,7 @@ const startServer = async () => {
       // If we have a socket that is alive and open still, send the error back to the client:
       if (websocket.isAlive && websocket.readyState === websocket.OPEN) {
         // TODO: Use a better error response here
-        websocket.send(JSON.stringify({ error: "Error unsubscribing from channel" }));
+        websocket.send(JSON.stringify({ error: 'Error unsubscribing from channel' }));
       }
     });
   };

--- a/streaming/logging.js
+++ b/streaming/logging.js
@@ -37,7 +37,7 @@ function sanitizeRequestLog(req) {
 }
 
 export const logger = pino({
-  name: "streaming",
+  name: 'streaming',
   // Reformat the log level to a string:
   formatters: {
     level: (label) => {


### PR DESCRIPTION
Thought this might be easier since the Prettier way makes many more changes.
Ran `npx eslint --fix --rule 'quotes: [error, "single", {"avoidEscape": true}]' "**/*.jsx"` and `npx eslint --fix --rule 'quotes: [error, "single", {"avoidEscape": true}]' "**/*.js"` to just fix the quotes that aren't used to avoid escaping