### PR TITLE
Fix local account search on LDAP login being case-sensitive

### DIFF
--- a/app/models/concerns/user/ldap_authenticable.rb
+++ b/app/models/concerns/user/ldap_authenticable.rb
@@ -22,7 +22,7 @@ module User::LdapAuthenticable
         safe_username = safe_username.gsub(keys, replacement)
       end
 
-      resource = joins(:account).find_by('accounts.username ILIKE ?', safe_username)
+      resource = joins(:account).merge(Account.where(Account.arel_table[:username].lower.eq safe_username.downcase)).take
 
       if resource.blank?
         resource = new(

--- a/app/models/concerns/user/ldap_authenticable.rb
+++ b/app/models/concerns/user/ldap_authenticable.rb
@@ -22,7 +22,7 @@ module User::LdapAuthenticable
         safe_username = safe_username.gsub(keys, replacement)
       end
 
-      resource = joins(:account).find_by(accounts: { username: safe_username })
+      resource = joins(:account).find_by('accounts.username ILIKE ?', safe_username)
 
       if resource.blank?
         resource = new(


### PR DESCRIPTION
We recently migrated our Mastodon-only accounts to our LDAP directory, where all usernames are stored with lowercase letters.

However, upon trying to log in to an account with different-case letters in LDAP and Mastodon, it would fail to find the account and try to create a new one instead. For which the validation then also failed due to the username and email already existing in LDAP.

The validation exception is correct there, since the account does already exist. But since Mastodon usernames are case insensitive, the account lookup during login should also be. This commit changes the database query to use PostgreSQL's `ILIKE` matching function, which works like a case-insensitive equals matcher when used like this.