### PR TITLE
Fix word breaking in filtered notifications badge

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -10145,6 +10145,7 @@ noscript {
     font-weight: 500;
     font-size: 11px;
     line-height: 16px;
+    word-break: keep-all;
 
     &__badge {
       background: $ui-button-background-color;


### PR DESCRIPTION
In some locales like CJK, the filtered notifications badge getting a bit weird within narrow screen because of many browsers breaks their words regardless of the morphemes.

This fixes it by adding a style which prevents word breaking in badge.

![](https://github.com/mastodon/mastodon/assets/5103195/e17ea6a1-9549-40f0-b92e-7588e884bd5a)
