### PR TITLE
Move Rails/HABTM cop out of todo

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -42,14 +42,6 @@ RSpec/MultipleMemoizedHelpers:
 RSpec/NestedGroups:
   Max: 6
 
-# Configuration parameters: Include.
-# Include: app/models/**/*.rb
-Rails/HasAndBelongsToMany:
-  Exclude:
-    - 'app/models/concerns/account/associations.rb'
-    - 'app/models/status.rb'
-    - 'app/models/tag.rb'
-
 Rails/OutputSafety:
   Exclude:
     - 'config/initializers/simple_form.rb'

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -62,7 +62,7 @@ module Account::Associations
     has_many :aliases, class_name: 'AccountAlias', dependent: :destroy, inverse_of: :account
 
     # Hashtags
-    has_and_belongs_to_many :tags
+    has_and_belongs_to_many :tags # rubocop:disable Rails/HasAndBelongsToMany
     has_many :featured_tags, -> { includes(:tag) }, dependent: :destroy, inverse_of: :account
 
     # Account deletion requests

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -82,7 +82,7 @@ class Status < ApplicationRecord
   has_many :local_reblogged, -> { merge(Account.local) }, through: :reblogs, source: :account
   has_many :local_bookmarked, -> { merge(Account.local) }, through: :bookmarks, source: :account
 
-  has_and_belongs_to_many :tags
+  has_and_belongs_to_many :tags # rubocop:disable Rails/HasAndBelongsToMany
 
   has_one :preview_cards_status, inverse_of: :status, dependent: :delete
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -21,8 +21,10 @@
 
 class Tag < ApplicationRecord
   include Paginable
+  # rubocop:disable Rails/HasAndBelongsToMany
   has_and_belongs_to_many :statuses
   has_and_belongs_to_many :accounts
+  # rubocop:enable Rails/HasAndBelongsToMany
 
   has_many :passive_relationships, class_name: 'TagFollow', inverse_of: :tag, dependent: :destroy
   has_many :featured_tags, dependent: :destroy, inverse_of: :tag


### PR DESCRIPTION
Assuming here that we don't actually want to do this migration and are fine with the HABTM for these specific cases but do want the rule enabled for any future associations.

If that's not the case, and we actually do plan on doing this migration I can close this and work on the migration path there (likely a `Tagging` HMT model and relevant changes elsewhere).