### PR TITLE
docker-compose.yml  `version` is obsolete

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   db:
     restart: always


### PR DESCRIPTION
Minor PR.

WARN[0000] /home/shlee/mastodon-aussocial/docker-compose.yml: `version` is obsolete