### PR TITLE
Use implicit dotenv load

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -51,11 +51,7 @@ require_relative '../lib/active_record/database_tasks_extensions'
 require_relative '../lib/active_record/batches'
 require_relative '../lib/simple_navigation/item_extensions'
 
-Dotenv::Rails.load
-
 Bundler.require(:pam_authentication) if ENV['PAM_ENABLED'] == 'true'
-
-require_relative '../lib/mastodon/redis_config'
 
 module Mastodon
   class Application < Rails::Application
@@ -96,6 +92,10 @@ module Mastodon
 
     initializer :deprecator do |app|
       app.deprecators[:mastodon] = ActiveSupport::Deprecation.new('4.3', 'mastodon/mastodon')
+    end
+
+    config.before_configuration do
+      require 'mastodon/redis_config'
     end
 
     config.to_prepare do


### PR DESCRIPTION
This is a follow up on https://github.com/mastodon/mastodon/pull/30028 which reverted https://github.com/mastodon/mastodon/commit/18737aad49911f00b94f9cf6fc582670cbdeda93

The original (reverted) commit was solving an issue where the dotenv load process was running twice -- once from the gem's own load process, and once via the explicit load call in application.rb in the app.

The issue was that the load ORDER accidentally changed with that commit. Before that, the explicit load call made sure that all the env vars were in place before the redis config file (required just below that line in application.rb) was called. After that, the file was required and set up a bunch of constants based on missing env values, since the dotenv files were not loaded yet. The dotenv files were then loaded during the initialization process so that the other (not redis config) things that rely on them were fine, and thus no specs broke, etc.

This PR repeats the removal of the dotenv load line, and moves the redis config require to a `before_configuration` block. I believe this creates a scenario where a) we get rid of the double load, relying just on the one from the dotenv gem, b) we make the env vars as loaded by dotenv available at the point the redis config is being loaded.

This is sort of tricky to write spec for because a) the usage/breakage is only in the development and production environments, b) the specs can only possibly run later/after the initialization phase.

I did some local experimentation with putting redis config related values into .env files and confirming via console that the relevant config was assigned -- but it would be useful to get a better specified version of "when we ran this on m.s here's what broke, and here's how to verify that in a console or server session in dev/prod environment" or something, to be sure.
