### PR TITLE
Change width breakpoint for modal placement behavior

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -5616,7 +5616,7 @@ a.status-card {
   user-select: text;
   display: flex;
 
-  @media screen and (max-width: $no-gap-breakpoint) {
+  @media screen and (width <= 630px) {
     margin-top: auto;
   }
 }


### PR DESCRIPTION
Fixes #30123

Changed the breakpoint from 1175px (what we use to hide the leftmost panel in the single-column interface) to 630px (what we use to forcibly enforce mobile layout even when advanced interface is enabled).

We might want to use other heuristics, like whether a touchscreen is enabled, or whether the viewport is vertical, but those could have other issues.