### PR TITLE
Status length validation spec updates

### DIFF
--- a/spec/validators/status_length_validator_spec.rb
+++ b/spec/validators/status_length_validator_spec.rb
@@ -4,6 +4,8 @@ require 'rails_helper'
 
 describe StatusLengthValidator do
   describe '#validate' do
+    before { stub_const("#{described_class}::MAX_CHARS", 500) } # Example values below are relative to this baseline
+
     it 'does not add errors onto remote statuses' do
       status = instance_double(Status, local?: false)
       allow(status).to receive(:errors)

--- a/spec/validators/status_length_validator_spec.rb
+++ b/spec/validators/status_length_validator_spec.rb
@@ -23,26 +23,26 @@ describe StatusLengthValidator do
     end
 
     it 'adds an error when content warning is over character limit' do
-      status = instance_double(Status, spoiler_text: 'a' * 520, text: '', errors: activemodel_errors, local?: true, reblog?: false)
+      status = status_double(spoiler_text: 'a' * 520)
       subject.validate(status)
       expect(status.errors).to have_received(:add)
     end
 
     it 'adds an error when text is over character limit' do
-      status = instance_double(Status, spoiler_text: '', text: 'a' * 520, errors: activemodel_errors, local?: true, reblog?: false)
+      status = status_double(text: 'a' * 520)
       subject.validate(status)
       expect(status.errors).to have_received(:add)
     end
 
     it 'adds an error when text and content warning are over character limit total' do
-      status = instance_double(Status, spoiler_text: 'a' * 250, text: 'b' * 251, errors: activemodel_errors, local?: true, reblog?: false)
+      status = status_double(spoiler_text: 'a' * 250, text: 'b' * 251)
       subject.validate(status)
       expect(status.errors).to have_received(:add)
     end
 
     it 'counts URLs as 23 characters flat' do
       text   = ('a' * 476) + " http://#{'b' * 30}.com/example"
-      status = instance_double(Status, spoiler_text: '', text: text, errors: activemodel_errors, local?: true, reblog?: false)
+      status = status_double(text: text)
 
       subject.validate(status)
       expect(status.errors).to_not have_received(:add)
@@ -50,7 +50,7 @@ describe StatusLengthValidator do
 
     it 'does not count non-autolinkable URLs as 23 characters flat' do
       text   = ('a' * 476) + "http://#{'b' * 30}.com/example"
-      status = instance_double(Status, spoiler_text: '', text: text, errors: activemodel_errors, local?: true, reblog?: false)
+      status = status_double(text: text)
 
       subject.validate(status)
       expect(status.errors).to have_received(:add)
@@ -58,14 +58,14 @@ describe StatusLengthValidator do
 
     it 'does not count overly long URLs as 23 characters flat' do
       text = "http://example.com/valid?#{'#foo?' * 1000}"
-      status = instance_double(Status, spoiler_text: '', text: text, errors: activemodel_errors, local?: true, reblog?: false)
+      status = status_double(text: text)
       subject.validate(status)
       expect(status.errors).to have_received(:add)
     end
 
     it 'counts only the front part of remote usernames' do
       text   = ('a' * 475) + " @alice@#{'b' * 30}.com"
-      status = instance_double(Status, spoiler_text: '', text: text, errors: activemodel_errors, local?: true, reblog?: false)
+      status = status_double(text: text)
 
       subject.validate(status)
       expect(status.errors).to_not have_received(:add)
@@ -73,7 +73,7 @@ describe StatusLengthValidator do
 
     it 'does count both parts of remote usernames for overly long domains' do
       text   = "@alice@#{'b' * 500}.com"
-      status = instance_double(Status, spoiler_text: '', text: text, errors: activemodel_errors, local?: true, reblog?: false)
+      status = status_double(text: text)
 
       subject.validate(status)
       expect(status.errors).to have_received(:add)
@@ -81,6 +81,17 @@ describe StatusLengthValidator do
   end
 
   private
+
+  def status_double(spoiler_text: '', text: '')
+    instance_double(
+      Status,
+      spoiler_text: spoiler_text,
+      text: text,
+      errors: activemodel_errors,
+      local?: true,
+      reblog?: false
+    )
+  end
 
   def activemodel_errors
     instance_double(ActiveModel::Errors, add: nil)

--- a/spec/validators/status_length_validator_spec.rb
+++ b/spec/validators/status_length_validator_spec.rb
@@ -22,19 +22,19 @@ describe StatusLengthValidator do
       expect(status).to_not have_received(:errors)
     end
 
-    it 'adds an error when content warning is over 500 characters' do
+    it 'adds an error when content warning is over character limit' do
       status = instance_double(Status, spoiler_text: 'a' * 520, text: '', errors: activemodel_errors, local?: true, reblog?: false)
       subject.validate(status)
       expect(status.errors).to have_received(:add)
     end
 
-    it 'adds an error when text is over 500 characters' do
+    it 'adds an error when text is over character limit' do
       status = instance_double(Status, spoiler_text: '', text: 'a' * 520, errors: activemodel_errors, local?: true, reblog?: false)
       subject.validate(status)
       expect(status.errors).to have_received(:add)
     end
 
-    it 'adds an error when text and content warning are over 500 characters total' do
+    it 'adds an error when text and content warning are over character limit total' do
       status = instance_double(Status, spoiler_text: 'a' * 250, text: 'b' * 251, errors: activemodel_errors, local?: true, reblog?: false)
       subject.validate(status)
       expect(status.errors).to have_received(:add)


### PR DESCRIPTION
This is a slightly different approach to the spec portion of https://github.com/mastodon/mastodon/pull/30091

- Pull out a helper method to DRY up what was repeated setup/double calls for the statuses
- Change example titles to reference character limit, not specific amount
- Add explicit const stub for the max_chars value, so that the spec remains relevant to that value even if the version in the validator were changed or made dependent on env var

I think in theory that other could be rebased against this and remove all it's spec changes and be reviewed just on the merits of the configurability.

Separately, I noticed while in here we sort of have a mix of styles in validator specs, with some doing this stub out of the activemodel errors object, and some doing a (what I think is preferred) more native usage of the validator via an in-spec class. Might do a round of updating there to align them all style wise to that latter approach.