### PR TITLE
Redirect back after site upload deletion

### DIFF
--- a/app/controllers/admin/site_uploads_controller.rb
+++ b/app/controllers/admin/site_uploads_controller.rb
@@ -9,7 +9,7 @@ module Admin
 
       @site_upload.destroy!
 
-      redirect_to admin_settings_path, notice: I18n.t('admin.site_uploads.destroyed_msg')
+      redirect_back fallback_location: admin_settings_path, notice: I18n.t('admin.site_uploads.destroyed_msg')
     end
 
     private


### PR DESCRIPTION
This pull request updates the functionality of the `Admin::SiteUploadsController` to improve user experience when deleting a site upload. Previously, upon deletion of a site upload, the user was redirected to the admin settings branding page regardless of which page you're deleting the site upload from 

For example, going to "Administration > Server settings > Appearance" and deleting an uploaded Mascot file redirects you to the "Branding" page instead of back to the "Appearance" page.

With this change, after successfully deleting a site upload, the user will now be redirected back to the page from which the deletion was initiated.

<img width="600" alt="Screenshot 2024-05-01 at 5 15 09 PM" src="https://github.com/mastodon/mastodon/assets/17722450/c2281507-bf5c-4f5d-9637-b82046af0447">
