### PR TITLE
Change ActiveRecordEncryption variable to be more explicit

### DIFF
--- a/config/initializers/active_record_encryption.rb
+++ b/config/initializers/active_record_encryption.rb
@@ -6,9 +6,9 @@
   ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY
 ).each do |key|
   ENV.fetch(key) do
-    raise <<~MESSAGE
+    abort <<~MESSAGE
 
-      The ActiveRecord encryption feature requires that these variables are set:
+      Mastodon now requires that these variables are set:
 
         - ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY
         - ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,6 +1,22 @@
 # frozen_string_literal: true
 
+# We are providing our own task with our own format
+Rake::Task['db:encryption:init'].clear
+
 namespace :db do
+  namespace :encryption do
+    desc 'Generate a set of keys for configuring Active Record encryption in a given environment'
+    task init: :environment do
+      puts <<~MSG
+        Add these environment variables to your Mastodon environment:#{' '}
+
+        ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY=#{SecureRandom.alphanumeric(32)}
+        ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT=#{SecureRandom.alphanumeric(32)}
+        ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY=#{SecureRandom.alphanumeric(32)}
+      MSG
+    end
+  end
+
   namespace :migrate do
     desc 'Setup the db or migrate depending on state of db'
     task setup: :environment do


### PR DESCRIPTION
- change the error to mention Mastodon rather than ActiveRecord encryption, making it explicit that it is a Mastodon requirement and not something random in the stack
- `abort` instead of `raise`ing, to avoid printing a confusing stack trace
- override the `db:encryption:init` task to output something that can be copied under the right format