### PR TITLE
Use `chewy` which relaxes ES version reqs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'addressable', '~> 2.8'
 gem 'bootsnap', '~> 1.18.0', require: false
 gem 'browser'
 gem 'charlock_holmes', '~> 0.7.7'
-gem 'chewy', github: 'toptal/chewy', ref: '7e65698053b5d02403e33c7e49b382d6eaac7ec4' # TODO: Go back to releases
+gem 'chewy', '~> 7.3'
 gem 'devise', '~> 4.9'
 gem 'devise-two-factor'
 

--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'addressable', '~> 2.8'
 gem 'bootsnap', '~> 1.18.0', require: false
 gem 'browser'
 gem 'charlock_holmes', '~> 0.7.7'
-gem 'chewy', '~> 7.3'
+gem 'chewy', github: 'toptal/chewy', ref: '7e65698053b5d02403e33c7e49b382d6eaac7ec4' # TODO: Go back to releases
 gem 'devise', '~> 4.9'
 gem 'devise-two-factor'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,16 +7,6 @@ GIT
       hkdf (~> 0.2)
       jwt (~> 2.0)
 
-GIT
-  remote: https://github.com/toptal/chewy.git
-  revision: 7e65698053b5d02403e33c7e49b382d6eaac7ec4
-  ref: 7e65698053b5d02403e33c7e49b382d6eaac7ec4
-  specs:
-    chewy (7.5.1)
-      activesupport (>= 5.2)
-      elasticsearch (>= 7.14.0, < 8)
-      elasticsearch-dsl
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -177,6 +167,10 @@ GEM
       activesupport
     cbor (0.5.9.8)
     charlock_holmes (0.7.7)
+    chewy (7.6.0)
+      activesupport (>= 5.2)
+      elasticsearch (>= 7.14.0, < 8)
+      elasticsearch-dsl
     chunky_png (1.4.0)
     climate_control (1.2.0)
     cocoon (1.2.15)
@@ -834,7 +828,7 @@ DEPENDENCIES
   bundler-audit (~> 0.9)
   capybara (~> 3.39)
   charlock_holmes (~> 0.7.7)
-  chewy!
+  chewy (~> 7.3)
   climate_control
   cocoon (~> 1.2)
   color_diff (~> 0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,16 @@ GIT
       hkdf (~> 0.2)
       jwt (~> 2.0)
 
+GIT
+  remote: https://github.com/toptal/chewy.git
+  revision: 7e65698053b5d02403e33c7e49b382d6eaac7ec4
+  ref: 7e65698053b5d02403e33c7e49b382d6eaac7ec4
+  specs:
+    chewy (7.5.1)
+      activesupport (>= 5.2)
+      elasticsearch (>= 7.14.0, < 8)
+      elasticsearch-dsl
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -167,10 +177,6 @@ GEM
       activesupport
     cbor (0.5.9.8)
     charlock_holmes (0.7.7)
-    chewy (7.5.1)
-      activesupport (>= 5.2)
-      elasticsearch (>= 7.12.0, < 7.14.0)
-      elasticsearch-dsl
     chunky_png (1.4.0)
     climate_control (1.2.0)
     cocoon (1.2.15)
@@ -220,14 +226,14 @@ GEM
     dotenv (3.1.1)
     drb (2.2.1)
     ed25519 (1.3.0)
-    elasticsearch (7.13.3)
-      elasticsearch-api (= 7.13.3)
-      elasticsearch-transport (= 7.13.3)
-    elasticsearch-api (7.13.3)
+    elasticsearch (7.17.10)
+      elasticsearch-api (= 7.17.10)
+      elasticsearch-transport (= 7.17.10)
+    elasticsearch-api (7.17.10)
       multi_json
     elasticsearch-dsl (0.1.10)
-    elasticsearch-transport (7.13.3)
-      faraday (~> 1)
+    elasticsearch-transport (7.17.10)
+      faraday (>= 1, < 3)
       multi_json
     email_spec (2.2.2)
       htmlentities (~> 4.3.3)
@@ -828,7 +834,7 @@ DEPENDENCIES
   bundler-audit (~> 0.9)
   capybara (~> 3.39)
   charlock_holmes (~> 0.7.7)
-  chewy (~> 7.3)
+  chewy!
   climate_control
   cocoon (~> 1.2)
   color_diff (~> 0.1)

--- a/spec/lib/admin/system_check/elasticsearch_check_spec.rb
+++ b/spec/lib/admin/system_check/elasticsearch_check_spec.rb
@@ -127,7 +127,7 @@ describe Admin::SystemCheck::ElasticsearchCheck do
   end
 
   def stub_elasticsearch_error
-    client = instance_double(Elasticsearch::Transport::Client)
+    client = instance_double(Elasticsearch::Client)
     allow(client).to receive(:info).and_raise(Elasticsearch::Transport::Transport::Error)
     allow(Chewy).to receive(:client).and_return(client)
   end


### PR DESCRIPTION
Alternative to https://github.com/mastodon/mastodon/pull/26399

Recent chewy PR merged https://github.com/toptal/chewy/pull/933 which relaxes the allowed elasticsearch gem versions. Most interesting for our purposes, the ES gem update relaxes the faraday requirement, allowing either v1 or v2 to work, and does not require the full bump up to ES8 gems (Chewy still has open PR for these purposes).

Opening this with a github ref in the gemfile, will update when a Chewy version is released (soon, according to maintainer).