### PR TITLE
Fix post deletion not being deferred when those are part of an account warning

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -266,7 +266,7 @@ class Status < ApplicationRecord
   end
 
   def reported?
-    @reported ||= Report.where(target_account: account).unresolved.exists?(['? = ANY(status_ids)', id]) || AccountWarning.where(target_account: account).exists?(['? = ANY(status_ids)', id.to_s])
+    @reported ||= account.targeted_reports.unresolved.exists?(['? = ANY(status_ids)', id]) || account.strikes.exists?(['? = ANY(status_ids)', id.to_s])
   end
 
   def emojis

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -266,7 +266,7 @@ class Status < ApplicationRecord
   end
 
   def reported?
-    @reported ||= Report.where(target_account: account).unresolved.exists?(['? = ANY(status_ids)', id])
+    @reported ||= Report.where(target_account: account).unresolved.exists?(['? = ANY(status_ids)', id]) || AccountWarning.where(target_account: account).exists?(['? = ANY(status_ids)', id.to_s])
   end
 
   def emojis

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -205,6 +205,48 @@ RSpec.describe Status do
     end
   end
 
+  describe '#reported?' do
+    context 'when the status is not reported' do
+      it 'returns false' do
+        expect(subject.reported?).to be false
+      end
+    end
+
+    context 'when the status is part of an open report' do
+      before do
+        Fabricate(:report, target_account: subject.account, status_ids: [subject.id])
+      end
+
+      it 'returns true' do
+        expect(subject.reported?).to be true
+      end
+    end
+
+    context 'when the status is part of a closed report with an account warning mentioning the account' do
+      before do
+        report = Fabricate(:report, target_account: subject.account, status_ids: [subject.id])
+        report.resolve!(Fabricate(:account))
+        Fabricate(:account_warning, target_account: subject.account, status_ids: [subject.id], report: report)
+      end
+
+      it 'returns true' do
+        expect(subject.reported?).to be true
+      end
+    end
+
+    context 'when the status is part of a closed report with an account warning not mentioning the account' do
+      before do
+        report = Fabricate(:report, target_account: subject.account, status_ids: [subject.id])
+        report.resolve!(Fabricate(:account))
+        Fabricate(:account_warning, target_account: subject.account, report: report)
+      end
+
+      it 'returns false' do
+        expect(subject.reported?).to be false
+      end
+    end
+  end
+
   describe '.mutes_map' do
     subject { described_class.mutes_map([status.conversation.id], account) }
 


### PR DESCRIPTION
Fixes #30142

Currently, deleted statuses that are part of an open report are not actually immediately deleted, but kept for 30 days to allow reviewing.

This change extends the check to allow prevent immediate deletion of posts that occur in an account warning, as the posts are relevant to the appeal process.