### PR TITLE
Fix race condition in `POST /api/v1/push/subscription`

### DIFF
--- a/app/controllers/api/v1/push/subscriptions_controller.rb
+++ b/app/controllers/api/v1/push/subscriptions_controller.rb
@@ -15,7 +15,7 @@ class Api::V1::Push::SubscriptionsController < Api::BaseController
 
   def create
     with_redis_lock("push_subscription:#{current_user.id}") do
-      Web::PushSubscription.where(access_token_id: doorkeeper_token.id).destroy_all
+      destroy_web_push_subscriptions!
 
       @push_subscription = Web::PushSubscription.create!(
         endpoint: subscription_params[:endpoint],
@@ -36,11 +36,15 @@ class Api::V1::Push::SubscriptionsController < Api::BaseController
   end
 
   def destroy
-    Web::PushSubscription.where(access_token_id: doorkeeper_token.id).destroy_all
+    destroy_web_push_subscriptions!
     render_empty
   end
 
   private
+
+  def destroy_web_push_subscriptions!
+    Web::PushSubscription.where(access_token_id: doorkeeper_token.id).destroy_all
+  end
 
   def set_push_subscription
     @push_subscription = Web::PushSubscription.find_by(access_token_id: doorkeeper_token.id)

--- a/app/controllers/api/v1/push/subscriptions_controller.rb
+++ b/app/controllers/api/v1/push/subscriptions_controller.rb
@@ -43,11 +43,11 @@ class Api::V1::Push::SubscriptionsController < Api::BaseController
   private
 
   def destroy_web_push_subscriptions!
-    Web::PushSubscription.where(access_token_id: doorkeeper_token.id).destroy_all
+    doorkeeper_token.web_push_subscriptions.destroy_all
   end
 
   def set_push_subscription
-    @push_subscription = Web::PushSubscription.find_by(access_token_id: doorkeeper_token.id)
+    @push_subscription = doorkeeper_token.web_push_subscriptions.first
   end
 
   def check_push_subscription

--- a/app/controllers/api/v1/push/subscriptions_controller.rb
+++ b/app/controllers/api/v1/push/subscriptions_controller.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
 class Api::V1::Push::SubscriptionsController < Api::BaseController
+  include Redisable
+  include Lockable
+
   before_action -> { doorkeeper_authorize! :push }
   before_action :require_user!
-  before_action :set_push_subscription
+  before_action :set_push_subscription, only: [:show, :update]
   before_action :check_push_subscription, only: [:show, :update]
 
   def show
@@ -11,16 +14,18 @@ class Api::V1::Push::SubscriptionsController < Api::BaseController
   end
 
   def create
-    @push_subscription&.destroy!
+    with_redis_lock("push_subscription:#{current_user.id}") do
+      Web::PushSubscription.where(access_token_id: doorkeeper_token.id).destroy_all
 
-    @push_subscription = Web::PushSubscription.create!(
-      endpoint: subscription_params[:endpoint],
-      key_p256dh: subscription_params[:keys][:p256dh],
-      key_auth: subscription_params[:keys][:auth],
-      data: data_params,
-      user_id: current_user.id,
-      access_token_id: doorkeeper_token.id
-    )
+      @push_subscription = Web::PushSubscription.create!(
+        endpoint: subscription_params[:endpoint],
+        key_p256dh: subscription_params[:keys][:p256dh],
+        key_auth: subscription_params[:keys][:auth],
+        data: data_params,
+        user_id: current_user.id,
+        access_token_id: doorkeeper_token.id
+      )
+    end
 
     render json: @push_subscription, serializer: REST::WebPushSubscriptionSerializer
   end
@@ -31,7 +36,7 @@ class Api::V1::Push::SubscriptionsController < Api::BaseController
   end
 
   def destroy
-    @push_subscription&.destroy!
+    Web::PushSubscription.where(access_token_id: doorkeeper_token.id).destroy_all
     render_empty
   end
 

--- a/app/lib/access_token_extension.rb
+++ b/app/lib/access_token_extension.rb
@@ -6,6 +6,8 @@ module AccessTokenExtension
   included do
     include Redisable
 
+    has_many :web_push_subscriptions, class_name: 'Web::PushSubscription', inverse_of: :access_token
+
     after_commit :push_to_streaming_api
   end
 


### PR DESCRIPTION
Fixes #30103

Ideally, we probably would have a unique constraint at the database level. However, I decided to leave that out for now because:
- it is unclear how we should treat existing duplicates: if there are duplicate registrations for an authentication token, we don't know which the application is actually able to process, so deduplicating may break existing legitimate notifications (those are very unlikely though)
- I haven't dug into `/api/web/push_subscriptions` which has no deduplication logic whatsoever, so I'm not completely sure the uniqueness constraint is something we always want