### PR TITLE
Remove `LOCAL_HTTPS` override in `.env.test`

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -2,7 +2,6 @@
 NODE_ENV=production
 # Federation
 LOCAL_DOMAIN=cb6e6126.ngrok.io
-LOCAL_HTTPS=true
 
 # Required by ActiveRecord encryption feature
 ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY=fkSxKD2bF396kdQbrP1EJ7WbU7ZgNokR

--- a/lib/tasks/spec.rake
+++ b/lib/tasks/spec.rake
@@ -4,7 +4,6 @@ if Rake::Task.task_defined?('spec:system')
   namespace :spec do
     task :enable_system_specs do # rubocop:disable Rails/RakeEnvironment
       ENV['LOCAL_DOMAIN'] = 'localhost:3000'
-      ENV['LOCAL_HTTPS'] = 'false'
       ENV['RUN_SYSTEM_SPECS'] = 'true'
     end
   end

--- a/spec/controllers/concerns/account_controller_concern_spec.rb
+++ b/spec/controllers/concerns/account_controller_concern_spec.rb
@@ -62,7 +62,7 @@ describe AccountControllerConcern do
     def expected_link_headers
       [
         '<http://test.host/.well-known/webfinger?resource=acct%3Ausername%40cb6e6126.ngrok.io>; rel="lrdd"; type="application/jrd+json"',
-        '<https://cb6e6126.ngrok.io/users/username>; rel="alternate"; type="application/activity+json"',
+        '<http://cb6e6126.ngrok.io/users/username>; rel="alternate"; type="application/activity+json"',
       ].join(', ')
     end
   end

--- a/spec/lib/content_security_policy_spec.rb
+++ b/spec/lib/content_security_policy_spec.rb
@@ -74,7 +74,7 @@ describe ContentSecurityPolicy do
       end
 
       it 'uses the s3 alias host value' do
-        expect(subject.media_hosts).to contain_exactly(subject.assets_host, 'https://asset-host.s3-alias.example')
+        expect(subject.media_hosts).to contain_exactly(subject.assets_host, 'http://asset-host.s3-alias.example')
       end
     end
 
@@ -86,7 +86,7 @@ describe ContentSecurityPolicy do
       end
 
       it 'uses the s3 alias host value and preserves the path' do
-        expect(subject.media_hosts).to contain_exactly(subject.assets_host, 'https://asset-host.s3-alias.example/pathname/')
+        expect(subject.media_hosts).to contain_exactly(subject.assets_host, 'http://asset-host.s3-alias.example/pathname/')
       end
     end
 
@@ -98,7 +98,7 @@ describe ContentSecurityPolicy do
       end
 
       it 'uses the s3 cloudfront host value' do
-        expect(subject.media_hosts).to contain_exactly(subject.assets_host, 'https://asset-host.s3-cloudfront.example')
+        expect(subject.media_hosts).to contain_exactly(subject.assets_host, 'http://asset-host.s3-cloudfront.example')
       end
     end
 
@@ -110,7 +110,7 @@ describe ContentSecurityPolicy do
       end
 
       it 'uses the azure alias host value' do
-        expect(subject.media_hosts).to contain_exactly(subject.assets_host, 'https://asset-host.azure-alias.example')
+        expect(subject.media_hosts).to contain_exactly(subject.assets_host, 'http://asset-host.azure-alias.example')
       end
     end
 
@@ -122,7 +122,7 @@ describe ContentSecurityPolicy do
       end
 
       it 'uses the s3 hostname host value' do
-        expect(subject.media_hosts).to contain_exactly(subject.assets_host, 'https://asset-host.s3.example')
+        expect(subject.media_hosts).to contain_exactly(subject.assets_host, 'http://asset-host.s3.example')
       end
     end
 

--- a/spec/lib/ostatus/tag_manager_spec.rb
+++ b/spec/lib/ostatus/tag_manager_spec.rb
@@ -63,7 +63,7 @@ describe OStatus::TagManager do
 
       it 'returns the URL for account' do
         expect(target.object_type).to eq :person
-        expect(subject).to eq 'https://cb6e6126.ngrok.io/users/alice'
+        expect(subject).to eq 'http://cb6e6126.ngrok.io/users/alice'
       end
     end
   end

--- a/spec/lib/text_formatter_spec.rb
+++ b/spec/lib/text_formatter_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe TextFormatter do
       let(:text) { '@alice' }
 
       it 'creates a mention link' do
-        expect(subject).to include '<a href="https://cb6e6126.ngrok.io/@alice" class="u-url mention">@<span>alice</span></a></span>'
+        expect(subject).to include '<a href="http://cb6e6126.ngrok.io/@alice" class="u-url mention">@<span>alice</span></a></span>'
       end
     end
 

--- a/spec/mailers/admin_mailer_spec.rb
+++ b/spec/mailers/admin_mailer_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe AdminMailer do
         .and(deliver_to(recipient.user_email))
         .and(deliver_from('notifications@localhost'))
         .and(have_subject("New report for cb6e6126.ngrok.io (##{report.id})"))
-        .and(have_body_text("Mike,\r\n\r\nJohn has reported Mike\r\n\r\nView: https://cb6e6126.ngrok.io/admin/reports/#{report.id}\r\n"))
+        .and(have_body_text("Mike,\r\n\r\nJohn has reported Mike\r\n\r\nView: http://cb6e6126.ngrok.io/admin/reports/#{report.id}\r\n"))
     end
   end
 

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe NotificationMailer do
         .to be_present
         .and(have_header('To', "#{receiver.account.username} <#{receiver.email}>"))
         .and(have_header('List-ID', "<#{type}.alice.cb6e6126.ngrok.io>"))
-        .and(have_header('List-Unsubscribe', %r{<https://cb6e6126.ngrok.io/unsubscribe\?token=.+>}))
+        .and(have_header('List-Unsubscribe', %r{<http://cb6e6126.ngrok.io/unsubscribe\?token=.+>}))
         .and(have_header('List-Unsubscribe', /&type=#{type}/))
         .and(have_header('List-Unsubscribe-Post', 'List-Unsubscribe=One-Click'))
         .and(deliver_to("#{receiver.account.username} <#{receiver.email}>"))

--- a/spec/models/remote_follow_spec.rb
+++ b/spec/models/remote_follow_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe RemoteFollow do
     let(:account) { Fabricate(:account, username: 'alice') }
 
     it 'returns subscribe address' do
-      expect(subject).to eq 'https://quitter.no/main/ostatussub?profile=https%3A%2F%2Fcb6e6126.ngrok.io%2Fusers%2Falice'
+      expect(subject).to eq 'https://quitter.no/main/ostatussub?profile=http%3A%2F%2Fcb6e6126.ngrok.io%2Fusers%2Falice'
     end
   end
 end

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -407,7 +407,7 @@ RSpec.describe Status do
     it 'saves ActivityPub uri as uri for local status' do
       status = described_class.create(account: alice, text: 'foo')
       status.reload
-      expect(status.uri).to start_with('https://')
+      expect(status.uri).to start_with('http://')
     end
   end
 end

--- a/spec/requests/api/v1/accounts/featured_tags_spec.rb
+++ b/spec/requests/api/v1/accounts/featured_tags_spec.rb
@@ -25,10 +25,10 @@ RSpec.describe 'account featured tags API' do
       expect(response).to have_http_status(200)
       expect(body_as_json).to contain_exactly(a_hash_including({
         name: 'bar',
-        url: "https://cb6e6126.ngrok.io/@#{account.username}/tagged/bar",
+        url: "http://cb6e6126.ngrok.io/@#{account.username}/tagged/bar",
       }), a_hash_including({
         name: 'foo',
-        url: "https://cb6e6126.ngrok.io/@#{account.username}/tagged/foo",
+        url: "http://cb6e6126.ngrok.io/@#{account.username}/tagged/foo",
       }))
     end
 
@@ -39,10 +39,10 @@ RSpec.describe 'account featured tags API' do
         expect(response).to have_http_status(200)
         expect(body_as_json).to contain_exactly(a_hash_including({
           name: 'bar',
-          url: "https://cb6e6126.ngrok.io/@#{account.pretty_acct}/tagged/bar",
+          url: "http://cb6e6126.ngrok.io/@#{account.pretty_acct}/tagged/bar",
         }), a_hash_including({
           name: 'foo',
-          url: "https://cb6e6126.ngrok.io/@#{account.pretty_acct}/tagged/foo",
+          url: "http://cb6e6126.ngrok.io/@#{account.pretty_acct}/tagged/foo",
         }))
       end
     end

--- a/spec/requests/content_security_policy_spec.rb
+++ b/spec/requests/content_security_policy_spec.rb
@@ -22,19 +22,19 @@ describe 'Content-Security-Policy' do
   def expected_csp_headers
     <<~CSP.split("\n").map(&:strip)
       base-uri 'none'
-      child-src 'self' blob: https://cb6e6126.ngrok.io
-      connect-src 'self' data: blob: https://cb6e6126.ngrok.io ws://cb6e6126.ngrok.io:4000
+      child-src 'self' blob: http://cb6e6126.ngrok.io
+      connect-src 'self' data: blob: http://cb6e6126.ngrok.io ws://cb6e6126.ngrok.io:4000
       default-src 'none'
-      font-src 'self' https://cb6e6126.ngrok.io
+      font-src 'self' http://cb6e6126.ngrok.io
       form-action 'self'
       frame-ancestors 'none'
       frame-src 'self' https:
-      img-src 'self' data: blob: https://cb6e6126.ngrok.io
-      manifest-src 'self' https://cb6e6126.ngrok.io
-      media-src 'self' data: https://cb6e6126.ngrok.io
-      script-src 'self' https://cb6e6126.ngrok.io 'wasm-unsafe-eval'
-      style-src 'self' https://cb6e6126.ngrok.io 'nonce-ZbA+JmE7+bK8F5qvADZHuQ=='
-      worker-src 'self' blob: https://cb6e6126.ngrok.io
+      img-src 'self' data: blob: http://cb6e6126.ngrok.io
+      manifest-src 'self' http://cb6e6126.ngrok.io
+      media-src 'self' data: http://cb6e6126.ngrok.io
+      script-src 'self' http://cb6e6126.ngrok.io 'wasm-unsafe-eval'
+      style-src 'self' http://cb6e6126.ngrok.io 'nonce-ZbA+JmE7+bK8F5qvADZHuQ=='
+      worker-src 'self' blob: http://cb6e6126.ngrok.io
     CSP
   end
 end

--- a/spec/requests/link_headers_spec.rb
+++ b/spec/requests/link_headers_spec.rb
@@ -20,7 +20,7 @@ describe 'Link headers' do
     it 'contains activitypub url in link header' do
       link_header = link_header_with_type('application/activity+json')
 
-      expect(link_header.href).to eq 'https://cb6e6126.ngrok.io/users/test'
+      expect(link_header.href).to eq 'http://cb6e6126.ngrok.io/users/test'
       expect(link_header.attr_pairs.first).to eq %w(rel alternate)
     end
 

--- a/spec/requests/remote_interaction_helper_spec.rb
+++ b/spec/requests/remote_interaction_helper_spec.rb
@@ -24,7 +24,7 @@ describe 'Remote Interaction Helper' do
 
   def expected_csp_headers
     <<~CSP.squish
-      default-src 'none'; frame-ancestors 'self'; form-action 'none'; script-src 'self' https://cb6e6126.ngrok.io 'wasm-unsafe-eval'; connect-src https:
+      default-src 'none'; frame-ancestors 'self'; form-action 'none'; script-src 'self' http://cb6e6126.ngrok.io 'wasm-unsafe-eval'; connect-src https:
     CSP
   end
 end

--- a/spec/requests/well_known/host_meta_spec.rb
+++ b/spec/requests/well_known/host_meta_spec.rb
@@ -20,7 +20,7 @@ describe 'The /.well-known/host-meta request' do
     <<~XML
       <?xml version="1.0" encoding="UTF-8"?>
       <XRD xmlns="http://docs.oasis-open.org/ns/xri/xrd-1.0">
-        <Link rel="lrdd" template="https://cb6e6126.ngrok.io/.well-known/webfinger?resource={uri}"/>
+        <Link rel="lrdd" template="http://cb6e6126.ngrok.io/.well-known/webfinger?resource={uri}"/>
       </XRD>
     XML
   end

--- a/spec/requests/well_known/webfinger_spec.rb
+++ b/spec/requests/well_known/webfinger_spec.rb
@@ -27,7 +27,7 @@ describe 'The /.well-known/webfinger endpoint' do
       expect(body_as_json)
         .to include(
           subject: eq('acct:alice@cb6e6126.ngrok.io'),
-          aliases: include('https://cb6e6126.ngrok.io/@alice', 'https://cb6e6126.ngrok.io/users/alice')
+          aliases: include('http://cb6e6126.ngrok.io/@alice', 'http://cb6e6126.ngrok.io/users/alice')
         )
     end
   end
@@ -131,7 +131,7 @@ describe 'The /.well-known/webfinger endpoint' do
     it 'returns links for the internal account' do
       json = body_as_json
       expect(json[:subject]).to eq 'acct:mastodon.internal@cb6e6126.ngrok.io'
-      expect(json[:aliases]).to eq ['https://cb6e6126.ngrok.io/actor']
+      expect(json[:aliases]).to eq ['http://cb6e6126.ngrok.io/actor']
     end
   end
 
@@ -169,7 +169,7 @@ describe 'The /.well-known/webfinger endpoint' do
       avatar_link = get_avatar_link(body_as_json)
       expect(avatar_link).to_not be_nil
       expect(avatar_link[:type]).to eq alice.avatar.content_type
-      expect(avatar_link[:href]).to eq Addressable::URI.new(host: Rails.configuration.x.local_domain, path: alice.avatar.to_s, scheme: 'https').to_s
+      expect(avatar_link[:href]).to eq Addressable::URI.new(host: Rails.configuration.x.local_domain, path: alice.avatar.to_s, scheme: 'http').to_s
     end
 
     context 'with limited federation mode' do


### PR DESCRIPTION
As described here - https://github.com/mastodon/mastodon/pull/30144/files#r1587562528

The idea here is to align the "full stack" "system specs" with the rest of the "test suite". Currently...

- The bulk of the suite uses the values from the `.env.test` setting `LOCAL_DOMAIN` to this ngrok host (I think this is a historical accident?) and setting `LOCAL_HTTPS` to true (maybe also a historical accident, or maybe to better align some ofthe string url generation with what production would look like?)
- The system specs have an override -- in main right now via a rake task with env vars, and in that linked PR via a CI env var setting -- to use `localhost:3000` for the `LOCAL_DOMAIN` value and disable `LOCAL_HTTPS`. This is necessary because that's what the selenium enabled chromedriver-driven portion of the suite needs to see (it hits real urls).

This PR handles just the https portion of the change, will have to do the hostname separately - which I will do if we like the idea of aligning these.

If this sits for a while, there are a few things in here which could either a) use url helpers instead of direct strings and still be valuable as specs, b) could use an around block and set the force_ssl value just for the context of the relevant specs regardless of what the larger setting is .... might pull some of those out and/or do them as followup.