### PR TITLE
Switched HTMLEntities to the expanded flavor which supports a larger list of HTML entity names

### DIFF
--- a/app/lib/link_details_extractor.rb
+++ b/app/lib/link_details_extractor.rb
@@ -282,6 +282,6 @@ class LinkDetailsExtractor
   end
 
   def html_entities
-    @html_entities ||= HTMLEntities.new
+    @html_entities ||= HTMLEntities.new(:expanded)
   end
 end


### PR DESCRIPTION
Fixes #30161

This PR updates the HTML entity flavor used by HTMLEntities to `:expanded`, as described in their [README](https://github.com/threedaymonk/htmlentities/tree/f4d759e2bdd30afaa209d8bf43d1b67f91accc7a). This allows for extracted link details to be stored and rendered more appropriately when the link details contain HTML entity names not found in the XHTML1 and HTML4 specs which HTMLEntities use by default.