### PR TITLE
Update i18n to version 1.14.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,7 @@ gem 'htmlentities', '~> 4.3'
 gem 'http', '~> 5.2.0'
 gem 'http_accept_language', '~> 2.1'
 gem 'httplog', '~> 1.6.2'
-gem 'i18n', '1.14.1' # TODO: Remove version when resolved: https://github.com/glebm/i18n-tasks/issues/552 / https://github.com/ruby-i18n/i18n/pull/688
+gem 'i18n'
 gem 'idn-ruby', require: 'idn'
 gem 'inline_svg'
 gem 'kaminari', '~> 1.2'

--- a/Gemfile
+++ b/Gemfile
@@ -170,7 +170,7 @@ group :development do
   gem 'haml_lint', require: false
 
   # Validate missing i18n keys
-  gem 'i18n-tasks', github: 'glebm/i18n-tasks', ref: 'dffd911391cc366779a6c0b119d927a8dfd41be7', require: false
+  gem 'i18n-tasks', '~> 1.0', require: false
 end
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -170,7 +170,7 @@ group :development do
   gem 'haml_lint', require: false
 
   # Validate missing i18n keys
-  gem 'i18n-tasks', '~> 1.0', require: false
+  gem 'i18n-tasks', github: 'glebm/i18n-tasks', ref: 'dffd911391cc366779a6c0b119d927a8dfd41be7', require: false
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -328,7 +328,7 @@ GEM
     httplog (1.6.3)
       rack (>= 2.0)
       rainbow (>= 2.0.0)
-    i18n (1.14.1)
+    i18n (1.14.5)
       concurrent-ruby (~> 1.0)
     i18n-tasks (1.0.13)
       activesupport (>= 4.0.2)
@@ -860,7 +860,7 @@ DEPENDENCIES
   http (~> 5.2.0)
   http_accept_language (~> 2.1)
   httplog (~> 1.6.2)
-  i18n (= 1.14.1)
+  i18n
   i18n-tasks (~> 1.0)
   idn-ruby
   inline_svg

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,22 +7,6 @@ GIT
       hkdf (~> 0.2)
       jwt (~> 2.0)
 
-GIT
-  remote: https://github.com/glebm/i18n-tasks.git
-  revision: dffd911391cc366779a6c0b119d927a8dfd41be7
-  ref: dffd911391cc366779a6c0b119d927a8dfd41be7
-  specs:
-    i18n-tasks (1.0.13)
-      activesupport (>= 4.0.2)
-      ast (>= 2.1.0)
-      erubi
-      highline (>= 2.0.0)
-      i18n
-      parser (>= 3.2.2.1)
-      rails-i18n
-      rainbow (>= 2.2.2, < 4.0)
-      terminal-table (>= 1.5.1)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -146,7 +130,7 @@ GEM
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
       rouge (>= 1.0.0)
-    bigdecimal (3.1.7)
+    bigdecimal (3.1.8)
     bindata (2.5.0)
     binding_of_caller (1.0.1)
       debug_inspector (>= 1.2.0)
@@ -339,6 +323,16 @@ GEM
       rainbow (>= 2.0.0)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
+    i18n-tasks (1.0.14)
+      activesupport (>= 4.0.2)
+      ast (>= 2.1.0)
+      erubi
+      highline (>= 2.0.0)
+      i18n
+      parser (>= 3.2.2.1)
+      rails-i18n
+      rainbow (>= 2.2.2, < 4.0)
+      terminal-table (>= 1.5.1)
     idn-ruby (0.1.5)
     inline_svg (1.9.0)
       activesupport (>= 3.0)
@@ -599,7 +593,7 @@ GEM
     redlock (1.3.2)
       redis (>= 3.0.0, < 6.0)
     regexp_parser (2.9.0)
-    reline (0.5.5)
+    reline (0.5.6)
       io-console (~> 0.5)
     request_store (1.6.0)
       rack (>= 1.4)
@@ -858,7 +852,7 @@ DEPENDENCIES
   http_accept_language (~> 2.1)
   httplog (~> 1.6.2)
   i18n
-  i18n-tasks!
+  i18n-tasks (~> 1.0)
   idn-ruby
   inline_svg
   irb (~> 1.8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,22 @@ GIT
       hkdf (~> 0.2)
       jwt (~> 2.0)
 
+GIT
+  remote: https://github.com/glebm/i18n-tasks.git
+  revision: dffd911391cc366779a6c0b119d927a8dfd41be7
+  ref: dffd911391cc366779a6c0b119d927a8dfd41be7
+  specs:
+    i18n-tasks (1.0.13)
+      activesupport (>= 4.0.2)
+      ast (>= 2.1.0)
+      erubi
+      highline (>= 2.0.0)
+      i18n
+      parser (>= 3.2.2.1)
+      rails-i18n
+      rainbow (>= 2.2.2, < 4.0)
+      terminal-table (>= 1.5.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -130,13 +146,6 @@ GEM
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
       rouge (>= 1.0.0)
-    better_html (2.1.1)
-      actionview (>= 6.0)
-      activesupport (>= 6.0)
-      ast (~> 2.0)
-      erubi (~> 1.4)
-      parser (>= 2.4)
-      smart_properties
     bigdecimal (3.1.7)
     bindata (2.5.0)
     binding_of_caller (1.0.1)
@@ -330,17 +339,6 @@ GEM
       rainbow (>= 2.0.0)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
-    i18n-tasks (1.0.13)
-      activesupport (>= 4.0.2)
-      ast (>= 2.1.0)
-      better_html (>= 1.0, < 3.0)
-      erubi
-      highline (>= 2.0.0)
-      i18n
-      parser (>= 3.2.2.1)
-      rails-i18n
-      rainbow (>= 2.2.2, < 4.0)
-      terminal-table (>= 1.5.1)
     idn-ruby (0.1.5)
     inline_svg (1.9.0)
       activesupport (>= 3.0)
@@ -723,7 +721,6 @@ GEM
     simplecov-html (0.12.3)
     simplecov-lcov (0.8.0)
     simplecov_json_formatter (0.1.4)
-    smart_properties (1.17.0)
     stackprof (0.2.26)
     statsd-ruby (1.5.0)
     stoplight (4.1.0)
@@ -861,7 +858,7 @@ DEPENDENCIES
   http_accept_language (~> 2.1)
   httplog (~> 1.6.2)
   i18n
-  i18n-tasks (~> 1.0)
+  i18n-tasks!
   idn-ruby
   inline_svg
   irb (~> 1.8)


### PR DESCRIPTION
Removes version lock from https://github.com/mastodon/mastodon/pull/29674

Issue https://github.com/ruby-i18n/i18n/pull/688 was resolved in the release.

Previous failure example https://github.com/mastodon/mastodon/actions/runs/8337855263/job/22817285160