### PR TITLE
Add `icon` field to instance endpoint

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -237,22 +237,6 @@ module ApplicationHelper
     full_asset_url(instance_presenter.mascot&.file&.url || frontend_asset_path('images/elephant_ui_plane.svg'))
   end
 
-  def instance_presenter
-    @instance_presenter ||= InstancePresenter.new
-  end
-
-  def favicon_path(size = '48')
-    instance_presenter.favicon&.file&.url(size)
-  end
-
-  def app_icon_path(size = '48')
-    instance_presenter.app_icon&.file&.url(size)
-  end
-
-  def use_mask_icon?
-    instance_presenter.app_icon.blank?
-  end
-
   private
 
   def storage_host_var

--- a/app/helpers/instance_helper.rb
+++ b/app/helpers/instance_helper.rb
@@ -13,6 +13,22 @@ module InstanceHelper
     safe_join([description_prefix(invite), I18n.t('auth.description.suffix')], ' ')
   end
 
+  def instance_presenter
+    @instance_presenter ||= InstancePresenter.new
+  end
+
+  def favicon_path(size = '48')
+    instance_presenter.favicon&.file&.url(size)
+  end
+
+  def app_icon_path(size = '48')
+    instance_presenter.app_icon&.file&.url(size)
+  end
+
+  def use_mask_icon?
+    instance_presenter.app_icon.blank?
+  end
+
   private
 
   def description_prefix(invite)

--- a/app/serializers/manifest_serializer.rb
+++ b/app/serializers/manifest_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ManifestSerializer < ActiveModel::Serializer
-  include ApplicationHelper
+  include InstanceHelper
   include RoutingHelper
   include ActionView::Helpers::TextHelper
 

--- a/app/serializers/rest/instance_serializer.rb
+++ b/app/serializers/rest/instance_serializer.rb
@@ -8,7 +8,6 @@ class REST::InstanceSerializer < ActiveModel::Serializer
   end
 
   include InstanceHelper
-  include ApplicationHelper
   include RoutingHelper
 
   attributes :domain, :title, :version, :source_url, :description,

--- a/app/serializers/rest/instance_serializer.rb
+++ b/app/serializers/rest/instance_serializer.rb
@@ -7,10 +7,12 @@ class REST::InstanceSerializer < ActiveModel::Serializer
     has_one :account, serializer: REST::AccountSerializer
   end
 
+  include InstanceHelper
+  include ApplicationHelper
   include RoutingHelper
 
   attributes :domain, :title, :version, :source_url, :description,
-             :usage, :thumbnail, :languages, :configuration,
+             :usage, :thumbnail, :icon, :languages, :configuration,
              :registrations, :api_versions
 
   has_one :contact, serializer: ContactSerializer
@@ -29,6 +31,18 @@ class REST::InstanceSerializer < ActiveModel::Serializer
     else
       {
         url: frontend_asset_url('images/preview.png'),
+      }
+    end
+  end
+
+  def icon
+    SiteUpload::ANDROID_ICON_SIZES.map do |size|
+      src = app_icon_path(size.to_i)
+      src = URI.join(root_url, src).to_s if src.present?
+
+      {
+        src: src || frontend_asset_url("icons/android-chrome-#{size}x#{size}.png"),
+        size: "#{size}x#{size}",
       }
     end
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -288,33 +288,4 @@ describe ApplicationHelper do
       end
     end
   end
-
-  describe 'favicon' do
-    context 'when an icon exists' do
-      let!(:favicon) { Fabricate(:site_upload, var: 'favicon') }
-      let!(:app_icon) { Fabricate(:site_upload, var: 'app_icon') }
-
-      it 'returns the URL of the icon' do
-        expect(helper.favicon_path).to eq(favicon.file.url('48'))
-        expect(helper.app_icon_path).to eq(app_icon.file.url('48'))
-      end
-
-      it 'returns the URL of the icon with size parameter' do
-        expect(helper.favicon_path(16)).to eq(favicon.file.url('16'))
-        expect(helper.app_icon_path(16)).to eq(app_icon.file.url('16'))
-      end
-    end
-
-    context 'when an icon does not exist' do
-      it 'returns nil' do
-        expect(helper.favicon_path).to be_nil
-        expect(helper.app_icon_path).to be_nil
-      end
-
-      it 'returns nil with size parameter' do
-        expect(helper.favicon_path(16)).to be_nil
-        expect(helper.app_icon_path(16)).to be_nil
-      end
-    end
-  end
 end

--- a/spec/helpers/instance_helper_spec.rb
+++ b/spec/helpers/instance_helper_spec.rb
@@ -24,4 +24,33 @@ describe InstanceHelper do
       expect(helper.site_hostname).to eq 'example.com'
     end
   end
+
+  describe 'favicon' do
+    context 'when an icon exists' do
+      let!(:favicon) { Fabricate(:site_upload, var: 'favicon') }
+      let!(:app_icon) { Fabricate(:site_upload, var: 'app_icon') }
+
+      it 'returns the URL of the icon' do
+        expect(helper.favicon_path).to eq(favicon.file.url('48'))
+        expect(helper.app_icon_path).to eq(app_icon.file.url('48'))
+      end
+
+      it 'returns the URL of the icon with size parameter' do
+        expect(helper.favicon_path(16)).to eq(favicon.file.url('16'))
+        expect(helper.app_icon_path(16)).to eq(app_icon.file.url('16'))
+      end
+    end
+
+    context 'when an icon does not exist' do
+      it 'returns nil' do
+        expect(helper.favicon_path).to be_nil
+        expect(helper.app_icon_path).to be_nil
+      end
+
+      it 'returns nil with size parameter' do
+        expect(helper.favicon_path(16)).to be_nil
+        expect(helper.app_icon_path(16)).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
As we now allow admins to customize their app icon, it may be useful to expose it so apps can use it in the UI.

This is using the Android icons as they provide a good range of sizes.