### PR TITLE
Use more accurate `redirect_uri` in oauth spec

### DIFF
--- a/spec/system/oauth_spec.rb
+++ b/spec/system/oauth_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe 'Using OAuth from an external app' do
-  let(:client_app) { Doorkeeper::Application.create!(name: 'test', redirect_uri: 'http://localhost/health', scopes: 'read') }
+  let(:client_app) { Doorkeeper::Application.create!(name: 'test', redirect_uri: about_url(host: Rails.application.config.x.local_domain), scopes: 'read') }
 
   context 'when the user is already logged in' do
     let!(:user) { Fabricate(:user) }


### PR DESCRIPTION
While working on https://github.com/mastodon/mastodon/pull/30206 and related things I kept seeing failures locally for the oauth system spec. These were not intermittent, and would happen for me all of the time locally, but would never happen on CI. I didn't know what was going on for a while, but finally looked into it...

The spec here us putting a dummy redirect uri in place in the factory client_app, just so that there's something there for the browser to go to throughout the examples. Other than needing to be a location that won't error, I don't think it matters what the value is.

The failures I was seeing were from the JS console error check code, and would always be a 500 error on the request, and then some missing favicon errors as well (presumably the browser auto-requested those).

What I think is happening is that the for the `http://localhost/health` URL on CI this is an immediate 404 (which again, for purposes of the spec is not a failure condition) and so the specs pass w/out JS error. I'm running `puma-dev` locally which means this is a valid URL to request (listens on port 80 locally), but it goes nowehere, hence the 500 responses.

Seperately, I noticed there a bunch of CSP failures if you access the `/health` endpoint with a browser (it's mean as an http only status check).

Update here changes the page from the health page to the about page, and the host value to whatever the server knows about, which currently is `localhost:3000` in the system specs.

This fixes the failures I saw locally, and feels more correct to me to use a url that we "control" in the spec suite? I assume this will be fine on CI as well.
