### PR TITLE
Fix inconsistent interpolation escaping

### DIFF
--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -671,7 +671,7 @@ uk:
           delete_html: 'Ви збираєтеся <strong>вилучити</strong> деякі з дописів <strong>@%{acct}</strong>. Це буде:'
           mark_as_sensitive_html: 'Ви збираєтеся <strong>позначити</strong> деякі з дописів <strong>@%{acct}</strong> <strong>делікатними</strong>. Це буде:'
           silence_html: 'Ви збираєтеся <strong>обмежити</strong> обліковий запис <strong>@%{acct}</strong>. Це буде:'
-          suspend_html: 'Ви збираєтесь <strong>призупинити</strong> обліковий запис <strong>@%%{acct}</strong>. Це буде:'
+          suspend_html: 'Ви збираєтесь <strong>призупинити</strong> обліковий запис <strong>@%{acct}</strong>. Це буде:'
         actions:
           delete_html: Вилучити образливі дописи
           mark_as_sensitive_html: Позначити медіа образливих дописів делікатними


### PR DESCRIPTION
Extracted from https://github.com/mastodon/mastodon/pull/30198 - discovered an accidentally escaped interpolation value while doing those version bumps. The other PR is waiting on official version release.