### PR TITLE
Pass the CodeCov token from the secret to the action

### DIFF
--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -145,6 +145,8 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           files: coverage/lcov/mastodon.lcov
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   test-e2e:
     name: End to End testing


### PR DESCRIPTION
This was a breaking change in the v4 action: https://github.com/codecov/codecov-action?tab=readme-ov-file#v4-release

Due to this, coverage for many PRs and for `main` was no longer uploaded.