### PR TITLE
Add active animation to header settings button

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -4366,9 +4366,9 @@ a.status-card {
   }
 
   .no-reduce-motion .icon {
-    transition: transform .15s ease-in-out;
+    transition: transform 0.15s ease-in-out;
   }
-  
+
   &.active {
     color: $primary-text-color;
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -4365,7 +4365,7 @@ a.status-card {
     outline: $ui-button-focus-outline;
   }
 
-  .icon {
+  .no-reduce-motion .icon {
     transition: transform .15s ease-in-out;
   }
   

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -4365,11 +4365,19 @@ a.status-card {
     outline: $ui-button-focus-outline;
   }
 
+  .icon {
+    transition: transform .15s ease-in-out;
+  }
+  
   &.active {
     color: $primary-text-color;
 
     &:hover {
       color: $primary-text-color;
+    }
+
+    .icon {
+      transform: rotate(60deg);
     }
   }
 


### PR DESCRIPTION
Currently toggling the settings button in header only changes the color which feels a bit boring, subtle animation makes it more fun.

[Screencast from 2024-05-08 21-53-58.webm](https://github.com/mastodon/mastodon/assets/77155297/4797b239-e28e-41da-b7ca-8be6ffad41cb)

Similar animation is already present in the search box so it's not a new concept.

[Screencast from 2024-05-08 21-55-07.webm](https://github.com/mastodon/mastodon/assets/77155297/1ee772b4-af16-4f26-8513-26789aa26819)