### PR TITLE
Fix typo

### DIFF
--- a/app/javascript/mastodon/features/notifications/components/notification.jsx
+++ b/app/javascript/mastodon/features/notifications/components/notification.jsx
@@ -41,7 +41,7 @@ const messages = defineMessages({
   adminSignUp: { id: 'notification.admin.sign_up', defaultMessage: '{name} signed up' },
   adminReport: { id: 'notification.admin.report', defaultMessage: '{name} reported {target}' },
   relationshipsSevered: { id: 'notification.relationships_severance_event', defaultMessage: 'Lost connections with {name}' },
-  moderationWarning: { id: 'notification.moderation_warning', defaultMessage: 'Your have received a moderation warning' },
+  moderationWarning: { id: 'notification.moderation_warning', defaultMessage: 'You have received a moderation warning' },
 });
 
 const notificationForScreenReader = (intl, message, timestamp) => {

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -474,7 +474,7 @@
   "notification.follow_request": "{name} has requested to follow you",
   "notification.mention": "{name} mentioned you",
   "notification.moderation-warning.learn_more": "Learn more",
-  "notification.moderation_warning": "Your have received a moderation warning",
+  "notification.moderation_warning": "You have received a moderation warning",
   "notification.moderation_warning.action_delete_statuses": "Some of your posts have been removed.",
   "notification.moderation_warning.action_disable": "Your account has been disabled.",
   "notification.moderation_warning.action_mark_statuses_as_sensitive": "Some of your posts have been marked as sensitive.",


### PR DESCRIPTION
The "**Your** have received a moderation warning" message looks like a typo. I'm not sure if this is used or shown in the UI (seems like the other more detailed messages are shown instead). Randomly saw this when checking out the new notifications.