### PR TITLE
Add i18n-task rspec tests

### DIFF
--- a/.github/workflows/check-i18n.yml
+++ b/.github/workflows/check-i18n.yml
@@ -30,19 +30,10 @@ jobs:
           yarn i18n:extract --throws
           git diff --exit-code
 
-      - name: Check locale file normalization
-        run: bundle exec i18n-tasks check-normalized
-
-      - name: Check for unused strings
-        run: bundle exec i18n-tasks unused
-
       - name: Check for missing strings in English YML
         run: |
           bundle exec i18n-tasks add-missing -l en
           git diff --exit-code
-
-      - name: Check for wrong string interpolations
-        run: bundle exec i18n-tasks check-consistent-interpolations
 
       - name: Check that all required locale files exist
         run: bundle exec rake repo:check_locales_files

--- a/.github/workflows/check-i18n.yml
+++ b/.github/workflows/check-i18n.yml
@@ -30,10 +30,5 @@ jobs:
           yarn i18n:extract --throws
           git diff --exit-code
 
-      - name: Check for missing strings in English YML
-        run: |
-          bundle exec i18n-tasks add-missing -l en
-          git diff --exit-code
-
       - name: Check that all required locale files exist
         run: bundle exec rake repo:check_locales_files

--- a/spec/locales/i18n_spec.rb
+++ b/spec/locales/i18n_spec.rb
@@ -1,8 +1,41 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'i18n/tasks'
 
 describe 'I18n' do
+  # Copied from $(bundle exec i18n-tasks gem-path)/templates/rspec/i18n_spec.rb
+  describe I18n do
+    let(:i18n) { I18n::Tasks::BaseTask.new }
+    let(:missing_keys) { i18n.missing_keys }
+    let(:unused_keys) { i18n.unused_keys }
+    let(:inconsistent_interpolations) { i18n.inconsistent_interpolations }
+
+    it 'does not have missing keys' do
+      expect(missing_keys).to be_empty,
+                              "Missing #{missing_keys.leaves.count} i18n keys, run `i18n-tasks missing' to show them"
+    end
+
+    it 'does not have unused keys' do
+      expect(unused_keys).to be_empty,
+                             "#{unused_keys.leaves.count} unused i18n keys, run `i18n-tasks unused' to show them"
+    end
+
+    it 'files are normalized' do
+      non_normalized = i18n.non_normalized_paths
+      error_message = "The following files need to be normalized:\n" \
+                      "#{non_normalized.map { |path| "  #{path}" }.join("\n")}\n" \
+                      "Please run `i18n-tasks normalize' to fix"
+      expect(non_normalized).to be_empty, error_message
+    end
+
+    it 'does not have inconsistent interpolations' do
+      error_message = "#{inconsistent_interpolations.leaves.count} i18n keys have inconsistent interpolations.\n" \
+                      "Run `i18n-tasks check-consistent-interpolations' to show them"
+      expect(inconsistent_interpolations).to be_empty, error_message
+    end
+  end
+
   describe 'Pluralizing locale translations' do
     subject { I18n.t('generic.validation_errors', count: 1) }
 

--- a/spec/locales/i18n_spec.rb
+++ b/spec/locales/i18n_spec.rb
@@ -11,10 +11,11 @@ describe 'I18n' do
     let(:unused_keys) { i18n.unused_keys }
     let(:inconsistent_interpolations) { i18n.inconsistent_interpolations }
 
-    it 'does not have missing keys' do
-      expect(missing_keys).to be_empty,
-                              "Missing #{missing_keys.leaves.count} i18n keys, run `i18n-tasks missing' to show them"
-    end
+    # Fails because only EN files are currently enforced
+    # it 'does not have missing keys' do
+    #   expect(missing_keys).to be_empty,
+    #                           "Missing #{missing_keys.leaves.count} i18n keys, run `i18n-tasks missing' to show them"
+    # end
 
     it 'does not have unused keys' do
       expect(unused_keys).to be_empty,

--- a/spec/locales/i18n_spec.rb
+++ b/spec/locales/i18n_spec.rb
@@ -5,17 +5,16 @@ require 'i18n/tasks'
 
 describe 'I18n' do
   # Copied from $(bundle exec i18n-tasks gem-path)/templates/rspec/i18n_spec.rb
-  describe I18n do
+  describe 'i18n-tasks' do
     let(:i18n) { I18n::Tasks::BaseTask.new }
-    let(:missing_keys) { i18n.missing_keys }
+    let(:missing_keys_en) { i18n.missing_keys(locales: ['en']) }
     let(:unused_keys) { i18n.unused_keys }
     let(:inconsistent_interpolations) { i18n.inconsistent_interpolations }
 
-    # Fails because only EN files are currently enforced
-    # it 'does not have missing keys' do
-    #   expect(missing_keys).to be_empty,
-    #                           "Missing #{missing_keys.leaves.count} i18n keys, run `i18n-tasks missing' to show them"
-    # end
+    it 'does not have missing keys in English' do
+      expect(missing_keys_en).to be_empty,
+                                 "Missing #{missing_keys_en.leaves.count} i18n keys, run `i18n-tasks missing' to show them"
+    end
 
     it 'does not have unused keys' do
       expect(unused_keys).to be_empty,


### PR DESCRIPTION
Notice during a bundle install
```
# Install default configuration:
cp $(bundle exec i18n-tasks gem-path)/templates/config/i18n-tasks.yml config/
# Add an RSpec for missing and unused keys:
cp $(bundle exec i18n-tasks gem-path)/templates/rspec/i18n_spec.rb spec/
# Or for minitest:
cp $(bundle exec i18n-tasks gem-path)/templates/minitest/i18n_test.rb test/
1 installed gem you directly depend on is looking for funding.
  Run `bundle fund` for details
```
The task part is already there, and there is the `check-i18n.yml` Action that does some of this and may be able to be dropped.