### PR TITLE
Fix repetitive database queries from #30040

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -240,11 +240,16 @@ module ApplicationHelper
     EmojiFormatter.new(html, custom_emojis, other_options.merge(animate: prefers_autoplay?)).to_s
   end
 
-  def site_icon_path(type, size = '48')
-    icon = SiteUpload.find_by(var: type)
-    return nil unless icon
+  def instance_presenter
+    @instance_presenter ||= InstancePresenter.new
+  end
 
-    icon.file.url(size)
+  def favicon_path(size = '48')
+    instance_presenter.favicon&.file&.url(size)
+  end
+
+  def app_icon_path(size = '48')
+    instance_presenter.app_icon&.file&.url(size)
   end
 
   private

--- a/app/presenters/instance_presenter.rb
+++ b/app/presenters/instance_presenter.rb
@@ -81,4 +81,16 @@ class InstancePresenter < ActiveModelSerializers::Model
   def mascot
     @mascot ||= Rails.cache.fetch('site_uploads/mascot') { SiteUpload.find_by(var: 'mascot') }
   end
+
+  def favicon
+    return @favicon if defined?(@favicon)
+
+    @favicon ||= Rails.cache.fetch('site_uploads/favicon') { SiteUpload.find_by(var: 'favicon') }
+  end
+
+  def app_icon
+    return @app_icon if defined?(@app_icon)
+
+    @app_icon ||= Rails.cache.fetch('site_uploads/app_icon') { SiteUpload.find_by(var: 'app_icon') }
+  end
 end

--- a/app/serializers/manifest_serializer.rb
+++ b/app/serializers/manifest_serializer.rb
@@ -27,7 +27,7 @@ class ManifestSerializer < ActiveModel::Serializer
 
   def icons
     SiteUpload::ANDROID_ICON_SIZES.map do |size|
-      src = site_icon_path('app_icon', size.to_i)
+      src = app_icon_path(size.to_i)
       src = URI.join(root_url, src).to_s if src.present?
 
       {

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -11,13 +11,13 @@
     - if storage_host?
       %link{ rel: 'dns-prefetch', href: storage_host }/
 
-    %link{ rel: 'icon', href: site_icon_path('favicon', 'ico') || '/favicon.ico', type: 'image/x-icon' }/
+    %link{ rel: 'icon', href: favicon_path || '/favicon.ico', type: 'image/x-icon' }/
 
     - SiteUpload::FAVICON_SIZES.each do |size|
-      %link{ rel: 'icon', sizes: "#{size}x#{size}", href: site_icon_path('favicon', size.to_i) || frontend_asset_path("icons/favicon-#{size}x#{size}.png"), type: 'image/png' }/
+      %link{ rel: 'icon', sizes: "#{size}x#{size}", href: favicon_path(size.to_i) || frontend_asset_path("icons/favicon-#{size}x#{size}.png"), type: 'image/png' }/
 
     - SiteUpload::APPLE_ICON_SIZES.each do |size|
-      %link{ rel: 'apple-touch-icon', sizes: "#{size}x#{size}", href: site_icon_path('app_icon', size.to_i) || frontend_asset_path("icons/apple-touch-icon-#{size}x#{size}.png") }/
+      %link{ rel: 'apple-touch-icon', sizes: "#{size}x#{size}", href: app_icon_path(size.to_i) || frontend_asset_path("icons/apple-touch-icon-#{size}x#{size}.png") }/
 
     %link{ rel: 'mask-icon', href: frontend_asset_path('images/logo-symbol-icon.svg'), color: '#6364FF' }/
     %link{ rel: 'manifest', href: manifest_path(format: :json) }/

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -11,7 +11,7 @@
     - if storage_host?
       %link{ rel: 'dns-prefetch', href: storage_host }/
 
-    %link{ rel: 'icon', href: favicon_path || '/favicon.ico', type: 'image/x-icon' }/
+    %link{ rel: 'icon', href: favicon_path('ico') || '/favicon.ico', type: 'image/x-icon' }/
 
     - SiteUpload::FAVICON_SIZES.each do |size|
       %link{ rel: 'icon', sizes: "#{size}x#{size}", href: favicon_path(size.to_i) || frontend_asset_path("icons/favicon-#{size}x#{size}.png"), type: 'image/png' }/

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -286,26 +286,31 @@ describe ApplicationHelper do
     end
   end
 
-  describe '#site_icon_path' do
+  describe 'favicon' do
     context 'when an icon exists' do
       let!(:favicon) { Fabricate(:site_upload, var: 'favicon') }
+      let!(:app_icon) { Fabricate(:site_upload, var: 'app_icon') }
 
       it 'returns the URL of the icon' do
-        expect(helper.site_icon_path('favicon')).to eq(favicon.file.url('48'))
+        expect(helper.favicon_path).to eq(favicon.file.url('48'))
+        expect(helper.app_icon_path).to eq(app_icon.file.url('48'))
       end
 
       it 'returns the URL of the icon with size parameter' do
-        expect(helper.site_icon_path('favicon', 16)).to eq(favicon.file.url('16'))
+        expect(helper.favicon_path(16)).to eq(favicon.file.url('16'))
+        expect(helper.app_icon_path(16)).to eq(app_icon.file.url('16'))
       end
     end
 
     context 'when an icon does not exist' do
       it 'returns nil' do
-        expect(helper.site_icon_path('favicon')).to be_nil
+        expect(helper.favicon_path).to be_nil
+        expect(helper.app_icon_path).to be_nil
       end
 
       it 'returns nil with size parameter' do
-        expect(helper.site_icon_path('favicon', 16)).to be_nil
+        expect(helper.favicon_path(16)).to be_nil
+        expect(helper.app_icon_path(16)).to be_nil
       end
     end
   end


### PR DESCRIPTION
This implements a fix for #30250 that Claire described [here](https://github.com/mastodon/mastodon/issues/30250#issuecomment-2105077586). 

After the changes, a cache miss will happen once every ten minutes and incur just two hits to the db.

<img width="1074" alt="The rails log showing two queries to the site_uploads table on a cache miss." src="https://github.com/mastodon/mastodon/assets/157782/177762fd-a990-499c-a2a2-daec7e4ffdd6">

And a cache hit incurs zero hits to the db.

<img width="1027" alt="The rails log showing zero queries to the db on a cache hit." src="https://github.com/mastodon/mastodon/assets/157782/f741e81f-6e48-4e52-a1ba-e487848d119a">
