### PR TITLE
fix(bin/dev): makes conditional for launching overmind POSIX-compliant

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -6,7 +6,7 @@ export PORT="${PORT:-3000}"
 # Get around our boot.rb ENV check
 export RAILS_ENV="${RAILS_ENV:-development}"
 
-if command -v overmind &> /dev/null
+if command -v overmind 1> /dev/null 2>&1
 then
   overmind start -f Procfile.dev "$@"
   exit $?


### PR DESCRIPTION
The '&>' redirect directive is bash-specific. This makes the bin/dev script fail on systems where sh is not redirected to bash but to a different POSIX-compliant shell (e.g. dash) - this is common on several major linux distros. This replaces the redirect with a POSIX variant.

Tested on Linux Mint 21.3, no overmind installed, with both `bash` and `dash` as the executing shell.