### PR TITLE
Remove the access token from Redux & context

### DIFF
--- a/app/javascript/mastodon/actions/account_notes.ts
+++ b/app/javascript/mastodon/actions/account_notes.ts
@@ -5,8 +5,8 @@ import api from '../api';
 
 export const submitAccountNote = createAppAsyncThunk(
   'account_note/submit',
-  async (args: { id: string; value: string }, { getState }) => {
-    const response = await api(getState).post<ApiRelationshipJSON>(
+  async (args: { id: string; value: string }) => {
+    const response = await api().post<ApiRelationshipJSON>(
       `/api/v1/accounts/${args.id}/note`,
       {
         comment: args.value,

--- a/app/javascript/mastodon/actions/accounts.js
+++ b/app/javascript/mastodon/actions/accounts.js
@@ -76,11 +76,11 @@ export const ACCOUNT_REVEAL = 'ACCOUNT_REVEAL';
 export * from './accounts_typed';
 
 export function fetchAccount(id) {
-  return (dispatch, getState) => {
+  return (dispatch) => {
     dispatch(fetchRelationships([id]));
     dispatch(fetchAccountRequest(id));
 
-    api(getState).get(`/api/v1/accounts/${id}`).then(response => {
+    api().get(`/api/v1/accounts/${id}`).then(response => {
       dispatch(importFetchedAccount(response.data));
       dispatch(fetchAccountSuccess());
     }).catch(error => {
@@ -89,10 +89,10 @@ export function fetchAccount(id) {
   };
 }
 
-export const lookupAccount = acct => (dispatch, getState) => {
+export const lookupAccount = acct => (dispatch) => {
   dispatch(lookupAccountRequest(acct));
 
-  api(getState).get('/api/v1/accounts/lookup', { params: { acct } }).then(response => {
+  api().get('/api/v1/accounts/lookup', { params: { acct } }).then(response => {
     dispatch(fetchRelationships([response.data.id]));
     dispatch(importFetchedAccount(response.data));
     dispatch(lookupAccountSuccess());
@@ -146,7 +146,7 @@ export function followAccount(id, options = { reblogs: true }) {
 
     dispatch(followAccountRequest({ id, locked }));
 
-    api(getState).post(`/api/v1/accounts/${id}/follow`, options).then(response => {
+    api().post(`/api/v1/accounts/${id}/follow`, options).then(response => {
       dispatch(followAccountSuccess({relationship: response.data, alreadyFollowing}));
     }).catch(error => {
       dispatch(followAccountFail({ id, error, locked }));
@@ -158,7 +158,7 @@ export function unfollowAccount(id) {
   return (dispatch, getState) => {
     dispatch(unfollowAccountRequest(id));
 
-    api(getState).post(`/api/v1/accounts/${id}/unfollow`).then(response => {
+    api().post(`/api/v1/accounts/${id}/unfollow`).then(response => {
       dispatch(unfollowAccountSuccess({relationship: response.data, statuses: getState().get('statuses')}));
     }).catch(error => {
       dispatch(unfollowAccountFail({ id, error }));
@@ -170,7 +170,7 @@ export function blockAccount(id) {
   return (dispatch, getState) => {
     dispatch(blockAccountRequest(id));
 
-    api(getState).post(`/api/v1/accounts/${id}/block`).then(response => {
+    api().post(`/api/v1/accounts/${id}/block`).then(response => {
       // Pass in entire statuses map so we can use it to filter stuff in different parts of the reducers
       dispatch(blockAccountSuccess({ relationship: response.data, statuses: getState().get('statuses') }));
     }).catch(error => {
@@ -180,10 +180,10 @@ export function blockAccount(id) {
 }
 
 export function unblockAccount(id) {
-  return (dispatch, getState) => {
+  return (dispatch) => {
     dispatch(unblockAccountRequest(id));
 
-    api(getState).post(`/api/v1/accounts/${id}/unblock`).then(response => {
+    api().post(`/api/v1/accounts/${id}/unblock`).then(response => {
       dispatch(unblockAccountSuccess({ relationship: response.data }));
     }).catch(error => {
       dispatch(unblockAccountFail({ id, error }));
@@ -223,7 +223,7 @@ export function muteAccount(id, notifications, duration=0) {
   return (dispatch, getState) => {
     dispatch(muteAccountRequest(id));
 
-    api(getState).post(`/api/v1/accounts/${id}/mute`, { notifications, duration }).then(response => {
+    api().post(`/api/v1/accounts/${id}/mute`, { notifications, duration }).then(response => {
       // Pass in entire statuses map so we can use it to filter stuff in different parts of the reducers
       dispatch(muteAccountSuccess({ relationship: response.data, statuses: getState().get('statuses') }));
     }).catch(error => {
@@ -233,10 +233,10 @@ export function muteAccount(id, notifications, duration=0) {
 }
 
 export function unmuteAccount(id) {
-  return (dispatch, getState) => {
+  return (dispatch) => {
     dispatch(unmuteAccountRequest(id));
 
-    api(getState).post(`/api/v1/accounts/${id}/unmute`).then(response => {
+    api().post(`/api/v1/accounts/${id}/unmute`).then(response => {
       dispatch(unmuteAccountSuccess({ relationship: response.data }));
     }).catch(error => {
       dispatch(unmuteAccountFail({ id, error }));
@@ -274,10 +274,10 @@ export function unmuteAccountFail(error) {
 
 
 export function fetchFollowers(id) {
-  return (dispatch, getState) => {
+  return (dispatch) => {
     dispatch(fetchFollowersRequest(id));
 
-    api(getState).get(`/api/v1/accounts/${id}/followers`).then(response => {
+    api().get(`/api/v1/accounts/${id}/followers`).then(response => {
       const next = getLinks(response).refs.find(link => link.rel === 'next');
 
       dispatch(importFetchedAccounts(response.data));
@@ -324,7 +324,7 @@ export function expandFollowers(id) {
 
     dispatch(expandFollowersRequest(id));
 
-    api(getState).get(url).then(response => {
+    api().get(url).then(response => {
       const next = getLinks(response).refs.find(link => link.rel === 'next');
 
       dispatch(importFetchedAccounts(response.data));
@@ -361,10 +361,10 @@ export function expandFollowersFail(id, error) {
 }
 
 export function fetchFollowing(id) {
-  return (dispatch, getState) => {
+  return (dispatch) => {
     dispatch(fetchFollowingRequest(id));
 
-    api(getState).get(`/api/v1/accounts/${id}/following`).then(response => {
+    api().get(`/api/v1/accounts/${id}/following`).then(response => {
       const next = getLinks(response).refs.find(link => link.rel === 'next');
 
       dispatch(importFetchedAccounts(response.data));
@@ -411,7 +411,7 @@ export function expandFollowing(id) {
 
     dispatch(expandFollowingRequest(id));
 
-    api(getState).get(url).then(response => {
+    api().get(url).then(response => {
       const next = getLinks(response).refs.find(link => link.rel === 'next');
 
       dispatch(importFetchedAccounts(response.data));
@@ -460,7 +460,7 @@ export function fetchRelationships(accountIds) {
 
     dispatch(fetchRelationshipsRequest(newAccountIds));
 
-    api(getState).get(`/api/v1/accounts/relationships?with_suspended=true&${newAccountIds.map(id => `id[]=${id}`).join('&')}`).then(response => {
+    api().get(`/api/v1/accounts/relationships?with_suspended=true&${newAccountIds.map(id => `id[]=${id}`).join('&')}`).then(response => {
       dispatch(fetchRelationshipsSuccess({ relationships: response.data }));
     }).catch(error => {
       dispatch(fetchRelationshipsFail(error));
@@ -486,10 +486,10 @@ export function fetchRelationshipsFail(error) {
 }
 
 export function fetchFollowRequests() {
-  return (dispatch, getState) => {
+  return (dispatch) => {
     dispatch(fetchFollowRequestsRequest());
 
-    api(getState).get('/api/v1/follow_requests').then(response => {
+    api().get('/api/v1/follow_requests').then(response => {
       const next = getLinks(response).refs.find(link => link.rel === 'next');
       dispatch(importFetchedAccounts(response.data));
       dispatch(fetchFollowRequestsSuccess(response.data, next ? next.uri : null));
@@ -528,7 +528,7 @@ export function expandFollowRequests() {
 
     dispatch(expandFollowRequestsRequest());
 
-    api(getState).get(url).then(response => {
+    api().get(url).then(response => {
       const next = getLinks(response).refs.find(link => link.rel === 'next');
       dispatch(importFetchedAccounts(response.data));
       dispatch(expandFollowRequestsSuccess(response.data, next ? next.uri : null));
@@ -558,10 +558,10 @@ export function expandFollowRequestsFail(error) {
 }
 
 export function authorizeFollowRequest(id) {
-  return (dispatch, getState) => {
+  return (dispatch) => {
     dispatch(authorizeFollowRequestRequest(id));
 
-    api(getState)
+    api()
       .post(`/api/v1/follow_requests/${id}/authorize`)
       .then(() => dispatch(authorizeFollowRequestSuccess({ id })))
       .catch(error => dispatch(authorizeFollowRequestFail(id, error)));
@@ -585,10 +585,10 @@ export function authorizeFollowRequestFail(id, error) {
 
 
 export function rejectFollowRequest(id) {
-  return (dispatch, getState) => {
+  return (dispatch) => {
     dispatch(rejectFollowRequestRequest(id));
 
-    api(getState)
+    api()
       .post(`/api/v1/follow_requests/${id}/reject`)
       .then(() => dispatch(rejectFollowRequestSuccess({ id })))
       .catch(error => dispatch(rejectFollowRequestFail(id, error)));
@@ -611,10 +611,10 @@ export function rejectFollowRequestFail(id, error) {
 }
 
 export function pinAccount(id) {
-  return (dispatch, getState) => {
+  return (dispatch) => {
     dispatch(pinAccountRequest(id));
 
-    api(getState).post(`/api/v1/accounts/${id}/pin`).then(response => {
+    api().post(`/api/v1/accounts/${id}/pin`).then(response => {
       dispatch(pinAccountSuccess({ relationship: response.data }));
     }).catch(error => {
       dispatch(pinAccountFail(error));
@@ -623,10 +623,10 @@ export function pinAccount(id) {
 }
 
 export function unpinAccount(id) {
-  return (dispatch, getState) => {
+  return (dispatch) => {
     dispatch(unpinAccountRequest(id));
 
-    api(getState).post(`/api/v1/accounts/${id}/unpin`).then(response => {
+    api().post(`/api/v1/accounts/${id}/unpin`).then(response => {
       dispatch(unpinAccountSuccess({ relationship: response.data }));
     }).catch(error => {
       dispatch(unpinAccountFail(error));
@@ -662,7 +662,7 @@ export function unpinAccountFail(error) {
   };
 }
 
-export const updateAccount = ({ displayName, note, avatar, header, discoverable, indexable }) => (dispatch, getState) => {
+export const updateAccount = ({ displayName, note, avatar, header, discoverable, indexable }) => (dispatch) => {
   const data = new FormData();
 
   data.append('display_name', displayName);
@@ -672,7 +672,7 @@ export const updateAccount = ({ displayName, note, avatar, header, discoverable,
   data.append('discoverable', discoverable);
   data.append('indexable', indexable);
 
-  return api(getState).patch('/api/v1/accounts/update_credentials', data).then(response => {
+  return api().patch('/api/v1/accounts/update_credentials', data).then(response => {
     dispatch(importFetchedAccount(response.data));
   });
 };

--- a/app/javascript/mastodon/actions/announcements.js
+++ b/app/javascript/mastodon/actions/announcements.js
@@ -26,10 +26,10 @@ export const ANNOUNCEMENTS_TOGGLE_SHOW = 'ANNOUNCEMENTS_TOGGLE_SHOW';
 
 const noOp = () => {};
 
-export const fetchAnnouncements = (done = noOp) => (dispatch, getState) => {
+export const fetchAnnouncements = (done = noOp) => (dispatch) => {
   dispatch(fetchAnnouncementsRequest());
 
-  api(getState).get('/api/v1/announcements').then(response => {
+  api().get('/api/v1/announcements').then(response => {
     dispatch(fetchAnnouncementsSuccess(response.data.map(x => normalizeAnnouncement(x))));
   }).catch(error => {
     dispatch(fetchAnnouncementsFail(error));
@@ -61,10 +61,10 @@ export const updateAnnouncements = announcement => ({
   announcement: normalizeAnnouncement(announcement),
 });
 
-export const dismissAnnouncement = announcementId => (dispatch, getState) => {
+export const dismissAnnouncement = announcementId => (dispatch) => {
   dispatch(dismissAnnouncementRequest(announcementId));
 
-  api(getState).post(`/api/v1/announcements/${announcementId}/dismiss`).then(() => {
+  api().post(`/api/v1/announcements/${announcementId}/dismiss`).then(() => {
     dispatch(dismissAnnouncementSuccess(announcementId));
   }).catch(error => {
     dispatch(dismissAnnouncementFail(announcementId, error));
@@ -103,7 +103,7 @@ export const addReaction = (announcementId, name) => (dispatch, getState) => {
     dispatch(addReactionRequest(announcementId, name, alreadyAdded));
   }
 
-  api(getState).put(`/api/v1/announcements/${announcementId}/reactions/${encodeURIComponent(name)}`).then(() => {
+  api().put(`/api/v1/announcements/${announcementId}/reactions/${encodeURIComponent(name)}`).then(() => {
     dispatch(addReactionSuccess(announcementId, name, alreadyAdded));
   }).catch(err => {
     if (!alreadyAdded) {
@@ -134,10 +134,10 @@ export const addReactionFail = (announcementId, name, error) => ({
   skipLoading: true,
 });
 
-export const removeReaction = (announcementId, name) => (dispatch, getState) => {
+export const removeReaction = (announcementId, name) => (dispatch) => {
   dispatch(removeReactionRequest(announcementId, name));
 
-  api(getState).delete(`/api/v1/announcements/${announcementId}/reactions/${encodeURIComponent(name)}`).then(() => {
+  api().delete(`/api/v1/announcements/${announcementId}/reactions/${encodeURIComponent(name)}`).then(() => {
     dispatch(removeReactionSuccess(announcementId, name));
   }).catch(err => {
     dispatch(removeReactionFail(announcementId, name, err));

--- a/app/javascript/mastodon/actions/blocks.js
+++ b/app/javascript/mastodon/actions/blocks.js
@@ -13,10 +13,10 @@ export const BLOCKS_EXPAND_SUCCESS = 'BLOCKS_EXPAND_SUCCESS';
 export const BLOCKS_EXPAND_FAIL    = 'BLOCKS_EXPAND_FAIL';
 
 export function fetchBlocks() {
-  return (dispatch, getState) => {
+  return (dispatch) => {
     dispatch(fetchBlocksRequest());
 
-    api(getState).get('/api/v1/blocks').then(response => {
+    api().get('/api/v1/blocks').then(response => {
       const next = getLinks(response).refs.find(link => link.rel === 'next');
       dispatch(importFetchedAccounts(response.data));
       dispatch(fetchBlocksSuccess(response.data, next ? next.uri : null));
@@ -56,7 +56,7 @@ export function expandBlocks() {
 
     dispatch(expandBlocksRequest());
 
-    api(getState).get(url).then(response => {
+    api().get(url).then(response => {
       const next = getLinks(response).refs.find(link => link.rel === 'next');
       dispatch(importFetchedAccounts(response.data));
       dispatch(expandBlocksSuccess(response.data, next ? next.uri : null));

--- a/app/javascript/mastodon/actions/bookmarks.js
+++ b/app/javascript/mastodon/actions/bookmarks.js
@@ -18,7 +18,7 @@ export function fetchBookmarkedStatuses() {
 
     dispatch(fetchBookmarkedStatusesRequest());
 
-    api(getState).get('/api/v1/bookmarks').then(response => {
+    api().get('/api/v1/bookmarks').then(response => {
       const next = getLinks(response).refs.find(link => link.rel === 'next');
       dispatch(importFetchedStatuses(response.data));
       dispatch(fetchBookmarkedStatusesSuccess(response.data, next ? next.uri : null));
@@ -59,7 +59,7 @@ export function expandBookmarkedStatuses() {
 
     dispatch(expandBookmarkedStatusesRequest());
 
-    api(getState).get(url).then(response => {
+    api().get(url).then(response => {
       const next = getLinks(response).refs.find(link => link.rel === 'next');
       dispatch(importFetchedStatuses(response.data));
       dispatch(expandBookmarkedStatusesSuccess(response.data, next ? next.uri : null));

--- a/app/javascript/mastodon/actions/compose.js
+++ b/app/javascript/mastodon/actions/compose.js
@@ -196,7 +196,7 @@ export function submitCompose(routerHistory) {
       });
     }
 
-    api(getState).request({
+    api().request({
       url: statusId === null ? '/api/v1/statuses' : `/api/v1/statuses/${statusId}`,
       method: statusId === null ? 'post' : 'put',
       data: {
@@ -304,7 +304,7 @@ export function uploadCompose(files) {
       const data = new FormData();
       data.append('file', file);
 
-      api(getState).post('/api/v2/media', data, {
+      api().post('/api/v2/media', data, {
         onUploadProgress: function({ loaded }){
           progress[i] = loaded;
           dispatch(uploadComposeProgress(progress.reduce((a, v) => a + v, 0), total));
@@ -321,7 +321,7 @@ export function uploadCompose(files) {
           let tryCount = 1;
 
           const poll = () => {
-            api(getState).get(`/api/v1/media/${data.id}`).then(response => {
+            api().get(`/api/v1/media/${data.id}`).then(response => {
               if (response.status === 200) {
                 dispatch(uploadComposeSuccess(response.data, file));
               } else if (response.status === 206) {
@@ -343,7 +343,7 @@ export const uploadComposeProcessing = () => ({
   type: COMPOSE_UPLOAD_PROCESSING,
 });
 
-export const uploadThumbnail = (id, file) => (dispatch, getState) => {
+export const uploadThumbnail = (id, file) => (dispatch) => {
   dispatch(uploadThumbnailRequest());
 
   const total = file.size;
@@ -351,7 +351,7 @@ export const uploadThumbnail = (id, file) => (dispatch, getState) => {
 
   data.append('thumbnail', file);
 
-  api(getState).put(`/api/v1/media/${id}`, data, {
+  api().put(`/api/v1/media/${id}`, data, {
     onUploadProgress: ({ loaded }) => {
       dispatch(uploadThumbnailProgress(loaded, total));
     },
@@ -434,7 +434,7 @@ export function changeUploadCompose(id, params) {
 
       dispatch(changeUploadComposeSuccess(data, true));
     } else {
-      api(getState).put(`/api/v1/media/${id}`, params).then(response => {
+      api().put(`/api/v1/media/${id}`, params).then(response => {
         dispatch(changeUploadComposeSuccess(response.data, false));
       }).catch(error => {
         dispatch(changeUploadComposeFail(id, error));
@@ -522,7 +522,7 @@ const fetchComposeSuggestionsAccounts = throttle((dispatch, getState, token) => 
 
   fetchComposeSuggestionsAccountsController = new AbortController();
 
-  api(getState).get('/api/v1/accounts/search', {
+  api().get('/api/v1/accounts/search', {
     signal: fetchComposeSuggestionsAccountsController.signal,
 
     params: {
@@ -556,7 +556,7 @@ const fetchComposeSuggestionsTags = throttle((dispatch, getState, token) => {
 
   fetchComposeSuggestionsTagsController = new AbortController();
 
-  api(getState).get('/api/v2/search', {
+  api().get('/api/v2/search', {
     signal: fetchComposeSuggestionsTagsController.signal,
 
     params: {

--- a/app/javascript/mastodon/actions/conversations.js
+++ b/app/javascript/mastodon/actions/conversations.js
@@ -28,13 +28,13 @@ export const unmountConversations = () => ({
   type: CONVERSATIONS_UNMOUNT,
 });
 
-export const markConversationRead = conversationId => (dispatch, getState) => {
+export const markConversationRead = conversationId => (dispatch) => {
   dispatch({
     type: CONVERSATIONS_READ,
     id: conversationId,
   });
 
-  api(getState).post(`/api/v1/conversations/${conversationId}/read`);
+  api().post(`/api/v1/conversations/${conversationId}/read`);
 };
 
 export const expandConversations = ({ maxId } = {}) => (dispatch, getState) => {
@@ -48,7 +48,7 @@ export const expandConversations = ({ maxId } = {}) => (dispatch, getState) => {
 
   const isLoadingRecent = !!params.since_id;
 
-  api(getState).get('/api/v1/conversations', { params })
+  api().get('/api/v1/conversations', { params })
     .then(response => {
       const next = getLinks(response).refs.find(link => link.rel === 'next');
 
@@ -88,10 +88,10 @@ export const updateConversations = conversation => dispatch => {
   });
 };
 
-export const deleteConversation = conversationId => (dispatch, getState) => {
+export const deleteConversation = conversationId => (dispatch) => {
   dispatch(deleteConversationRequest(conversationId));
 
-  api(getState).delete(`/api/v1/conversations/${conversationId}`)
+  api().delete(`/api/v1/conversations/${conversationId}`)
     .then(() => dispatch(deleteConversationSuccess(conversationId)))
     .catch(error => dispatch(deleteConversationFail(conversationId, error)));
 };

--- a/app/javascript/mastodon/actions/custom_emojis.js
+++ b/app/javascript/mastodon/actions/custom_emojis.js
@@ -5,10 +5,10 @@ export const CUSTOM_EMOJIS_FETCH_SUCCESS = 'CUSTOM_EMOJIS_FETCH_SUCCESS';
 export const CUSTOM_EMOJIS_FETCH_FAIL = 'CUSTOM_EMOJIS_FETCH_FAIL';
 
 export function fetchCustomEmojis() {
-  return (dispatch, getState) => {
+  return (dispatch) => {
     dispatch(fetchCustomEmojisRequest());
 
-    api(getState).get('/api/v1/custom_emojis').then(response => {
+    api().get('/api/v1/custom_emojis').then(response => {
       dispatch(fetchCustomEmojisSuccess(response.data));
     }).catch(error => {
       dispatch(fetchCustomEmojisFail(error));

--- a/app/javascript/mastodon/actions/directory.js
+++ b/app/javascript/mastodon/actions/directory.js
@@ -11,10 +11,10 @@ export const DIRECTORY_EXPAND_REQUEST = 'DIRECTORY_EXPAND_REQUEST';
 export const DIRECTORY_EXPAND_SUCCESS = 'DIRECTORY_EXPAND_SUCCESS';
 export const DIRECTORY_EXPAND_FAIL    = 'DIRECTORY_EXPAND_FAIL';
 
-export const fetchDirectory = params => (dispatch, getState) => {
+export const fetchDirectory = params => (dispatch) => {
   dispatch(fetchDirectoryRequest());
 
-  api(getState).get('/api/v1/directory', { params: { ...params, limit: 20 } }).then(({ data }) => {
+  api().get('/api/v1/directory', { params: { ...params, limit: 20 } }).then(({ data }) => {
     dispatch(importFetchedAccounts(data));
     dispatch(fetchDirectorySuccess(data));
     dispatch(fetchRelationships(data.map(x => x.id)));
@@ -40,7 +40,7 @@ export const expandDirectory = params => (dispatch, getState) => {
 
   const loadedItems = getState().getIn(['user_lists', 'directory', 'items']).size;
 
-  api(getState).get('/api/v1/directory', { params: { ...params, offset: loadedItems, limit: 20 } }).then(({ data }) => {
+  api().get('/api/v1/directory', { params: { ...params, offset: loadedItems, limit: 20 } }).then(({ data }) => {
     dispatch(importFetchedAccounts(data));
     dispatch(expandDirectorySuccess(data));
     dispatch(fetchRelationships(data.map(x => x.id)));

--- a/app/javascript/mastodon/actions/domain_blocks.js
+++ b/app/javascript/mastodon/actions/domain_blocks.js
@@ -24,7 +24,7 @@ export function blockDomain(domain) {
   return (dispatch, getState) => {
     dispatch(blockDomainRequest(domain));
 
-    api(getState).post('/api/v1/domain_blocks', { domain }).then(() => {
+    api().post('/api/v1/domain_blocks', { domain }).then(() => {
       const at_domain = '@' + domain;
       const accounts = getState().get('accounts').filter(item => item.get('acct').endsWith(at_domain)).valueSeq().map(item => item.get('id'));
 
@@ -54,7 +54,7 @@ export function unblockDomain(domain) {
   return (dispatch, getState) => {
     dispatch(unblockDomainRequest(domain));
 
-    api(getState).delete('/api/v1/domain_blocks', { params: { domain } }).then(() => {
+    api().delete('/api/v1/domain_blocks', { params: { domain } }).then(() => {
       const at_domain = '@' + domain;
       const accounts = getState().get('accounts').filter(item => item.get('acct').endsWith(at_domain)).valueSeq().map(item => item.get('id'));
       dispatch(unblockDomainSuccess({ domain, accounts }));
@@ -80,10 +80,10 @@ export function unblockDomainFail(domain, error) {
 }
 
 export function fetchDomainBlocks() {
-  return (dispatch, getState) => {
+  return (dispatch) => {
     dispatch(fetchDomainBlocksRequest());
 
-    api(getState).get('/api/v1/domain_blocks').then(response => {
+    api().get('/api/v1/domain_blocks').then(response => {
       const next = getLinks(response).refs.find(link => link.rel === 'next');
       dispatch(fetchDomainBlocksSuccess(response.data, next ? next.uri : null));
     }).catch(err => {
@@ -123,7 +123,7 @@ export function expandDomainBlocks() {
 
     dispatch(expandDomainBlocksRequest());
 
-    api(getState).get(url).then(response => {
+    api().get(url).then(response => {
       const next = getLinks(response).refs.find(link => link.rel === 'next');
       dispatch(expandDomainBlocksSuccess(response.data, next ? next.uri : null));
     }).catch(err => {

--- a/app/javascript/mastodon/actions/favourites.js
+++ b/app/javascript/mastodon/actions/favourites.js
@@ -18,7 +18,7 @@ export function fetchFavouritedStatuses() {
 
     dispatch(fetchFavouritedStatusesRequest());
 
-    api(getState).get('/api/v1/favourites').then(response => {
+    api().get('/api/v1/favourites').then(response => {
       const next = getLinks(response).refs.find(link => link.rel === 'next');
       dispatch(importFetchedStatuses(response.data));
       dispatch(fetchFavouritedStatusesSuccess(response.data, next ? next.uri : null));
@@ -62,7 +62,7 @@ export function expandFavouritedStatuses() {
 
     dispatch(expandFavouritedStatusesRequest());
 
-    api(getState).get(url).then(response => {
+    api().get(url).then(response => {
       const next = getLinks(response).refs.find(link => link.rel === 'next');
       dispatch(importFetchedStatuses(response.data));
       dispatch(expandFavouritedStatusesSuccess(response.data, next ? next.uri : null));

--- a/app/javascript/mastodon/actions/featured_tags.js
+++ b/app/javascript/mastodon/actions/featured_tags.js
@@ -11,7 +11,7 @@ export const fetchFeaturedTags = (id) => (dispatch, getState) => {
 
   dispatch(fetchFeaturedTagsRequest(id));
 
-  api(getState).get(`/api/v1/accounts/${id}/featured_tags`)
+  api().get(`/api/v1/accounts/${id}/featured_tags`)
     .then(({ data }) => dispatch(fetchFeaturedTagsSuccess(id, data)))
     .catch(err => dispatch(fetchFeaturedTagsFail(id, err)));
 };

--- a/app/javascript/mastodon/actions/filters.js
+++ b/app/javascript/mastodon/actions/filters.js
@@ -23,13 +23,13 @@ export const initAddFilter = (status, { contextType }) => dispatch =>
     },
   }));
 
-export const fetchFilters = () => (dispatch, getState) => {
+export const fetchFilters = () => (dispatch) => {
   dispatch({
     type: FILTERS_FETCH_REQUEST,
     skipLoading: true,
   });
 
-  api(getState)
+  api()
     .get('/api/v2/filters')
     .then(({ data }) => dispatch({
       type: FILTERS_FETCH_SUCCESS,
@@ -44,10 +44,10 @@ export const fetchFilters = () => (dispatch, getState) => {
     }));
 };
 
-export const createFilterStatus = (params, onSuccess, onFail) => (dispatch, getState) => {
+export const createFilterStatus = (params, onSuccess, onFail) => (dispatch) => {
   dispatch(createFilterStatusRequest());
 
-  api(getState).post(`/api/v2/filters/${params.filter_id}/statuses`, params).then(response => {
+  api().post(`/api/v2/filters/${params.filter_id}/statuses`, params).then(response => {
     dispatch(createFilterStatusSuccess(response.data));
     if (onSuccess) onSuccess();
   }).catch(error => {
@@ -70,10 +70,10 @@ export const createFilterStatusFail = error => ({
   error,
 });
 
-export const createFilter = (params, onSuccess, onFail) => (dispatch, getState) => {
+export const createFilter = (params, onSuccess, onFail) => (dispatch) => {
   dispatch(createFilterRequest());
 
-  api(getState).post('/api/v2/filters', params).then(response => {
+  api().post('/api/v2/filters', params).then(response => {
     dispatch(createFilterSuccess(response.data));
     if (onSuccess) onSuccess(response.data);
   }).catch(error => {

--- a/app/javascript/mastodon/actions/history.js
+++ b/app/javascript/mastodon/actions/history.js
@@ -15,7 +15,7 @@ export const fetchHistory = statusId => (dispatch, getState) => {
 
   dispatch(fetchHistoryRequest(statusId));
 
-  api(getState).get(`/api/v1/statuses/${statusId}/history`).then(({ data }) => {
+  api().get(`/api/v1/statuses/${statusId}/history`).then(({ data }) => {
     dispatch(importFetchedAccounts(data.map(x => x.account)));
     dispatch(fetchHistorySuccess(statusId, data));
   }).catch(error => dispatch(fetchHistoryFail(error)));

--- a/app/javascript/mastodon/actions/interactions.js
+++ b/app/javascript/mastodon/actions/interactions.js
@@ -52,10 +52,10 @@ export const UNBOOKMARK_SUCCESS = 'UNBOOKMARKED_SUCCESS';
 export const UNBOOKMARK_FAIL    = 'UNBOOKMARKED_FAIL';
 
 export function reblog(status, visibility) {
-  return function (dispatch, getState) {
+  return function (dispatch) {
     dispatch(reblogRequest(status));
 
-    api(getState).post(`/api/v1/statuses/${status.get('id')}/reblog`, { visibility }).then(function (response) {
+    api().post(`/api/v1/statuses/${status.get('id')}/reblog`, { visibility }).then(function (response) {
       // The reblog API method returns a new status wrapped around the original. In this case we are only
       // interested in how the original is modified, hence passing it skipping the wrapper
       dispatch(importFetchedStatus(response.data.reblog));
@@ -67,10 +67,10 @@ export function reblog(status, visibility) {
 }
 
 export function unreblog(status) {
-  return (dispatch, getState) => {
+  return (dispatch) => {
     dispatch(unreblogRequest(status));
 
-    api(getState).post(`/api/v1/statuses/${status.get('id')}/unreblog`).then(response => {
+    api().post(`/api/v1/statuses/${status.get('id')}/unreblog`).then(response => {
       dispatch(importFetchedStatus(response.data));
       dispatch(unreblogSuccess(status));
     }).catch(error => {
@@ -130,10 +130,10 @@ export function unreblogFail(status, error) {
 }
 
 export function favourite(status) {
-  return function (dispatch, getState) {
+  return function (dispatch) {
     dispatch(favouriteRequest(status));
 
-    api(getState).post(`/api/v1/statuses/${status.get('id')}/favourite`).then(function (response) {
+    api().post(`/api/v1/statuses/${status.get('id')}/favourite`).then(function (response) {
       dispatch(importFetchedStatus(response.data));
       dispatch(favouriteSuccess(status));
     }).catch(function (error) {
@@ -143,10 +143,10 @@ export function favourite(status) {
 }
 
 export function unfavourite(status) {
-  return (dispatch, getState) => {
+  return (dispatch) => {
     dispatch(unfavouriteRequest(status));
 
-    api(getState).post(`/api/v1/statuses/${status.get('id')}/unfavourite`).then(response => {
+    api().post(`/api/v1/statuses/${status.get('id')}/unfavourite`).then(response => {
       dispatch(importFetchedStatus(response.data));
       dispatch(unfavouriteSuccess(status));
     }).catch(error => {
@@ -206,10 +206,10 @@ export function unfavouriteFail(status, error) {
 }
 
 export function bookmark(status) {
-  return function (dispatch, getState) {
+  return function (dispatch) {
     dispatch(bookmarkRequest(status));
 
-    api(getState).post(`/api/v1/statuses/${status.get('id')}/bookmark`).then(function (response) {
+    api().post(`/api/v1/statuses/${status.get('id')}/bookmark`).then(function (response) {
       dispatch(importFetchedStatus(response.data));
       dispatch(bookmarkSuccess(status, response.data));
     }).catch(function (error) {
@@ -219,10 +219,10 @@ export function bookmark(status) {
 }
 
 export function unbookmark(status) {
-  return (dispatch, getState) => {
+  return (dispatch) => {
     dispatch(unbookmarkRequest(status));
 
-    api(getState).post(`/api/v1/statuses/${status.get('id')}/unbookmark`).then(response => {
+    api().post(`/api/v1/statuses/${status.get('id')}/unbookmark`).then(response => {
       dispatch(importFetchedStatus(response.data));
       dispatch(unbookmarkSuccess(status, response.data));
     }).catch(error => {
@@ -278,10 +278,10 @@ export function unbookmarkFail(status, error) {
 }
 
 export function fetchReblogs(id) {
-  return (dispatch, getState) => {
+  return (dispatch) => {
     dispatch(fetchReblogsRequest(id));
 
-    api(getState).get(`/api/v1/statuses/${id}/reblogged_by`).then(response => {
+    api().get(`/api/v1/statuses/${id}/reblogged_by`).then(response => {
       const next = getLinks(response).refs.find(link => link.rel === 'next');
       dispatch(importFetchedAccounts(response.data));
       dispatch(fetchReblogsSuccess(id, response.data, next ? next.uri : null));
@@ -325,7 +325,7 @@ export function expandReblogs(id) {
 
     dispatch(expandReblogsRequest(id));
 
-    api(getState).get(url).then(response => {
+    api().get(url).then(response => {
       const next = getLinks(response).refs.find(link => link.rel === 'next');
 
       dispatch(importFetchedAccounts(response.data));
@@ -360,10 +360,10 @@ export function expandReblogsFail(id, error) {
 }
 
 export function fetchFavourites(id) {
-  return (dispatch, getState) => {
+  return (dispatch) => {
     dispatch(fetchFavouritesRequest(id));
 
-    api(getState).get(`/api/v1/statuses/${id}/favourited_by`).then(response => {
+    api().get(`/api/v1/statuses/${id}/favourited_by`).then(response => {
       const next = getLinks(response).refs.find(link => link.rel === 'next');
       dispatch(importFetchedAccounts(response.data));
       dispatch(fetchFavouritesSuccess(id, response.data, next ? next.uri : null));
@@ -407,7 +407,7 @@ export function expandFavourites(id) {
 
     dispatch(expandFavouritesRequest(id));
 
-    api(getState).get(url).then(response => {
+    api().get(url).then(response => {
       const next = getLinks(response).refs.find(link => link.rel === 'next');
 
       dispatch(importFetchedAccounts(response.data));
@@ -442,10 +442,10 @@ export function expandFavouritesFail(id, error) {
 }
 
 export function pin(status) {
-  return (dispatch, getState) => {
+  return (dispatch) => {
     dispatch(pinRequest(status));
 
-    api(getState).post(`/api/v1/statuses/${status.get('id')}/pin`).then(response => {
+    api().post(`/api/v1/statuses/${status.get('id')}/pin`).then(response => {
       dispatch(importFetchedStatus(response.data));
       dispatch(pinSuccess(status));
     }).catch(error => {
@@ -480,10 +480,10 @@ export function pinFail(status, error) {
 }
 
 export function unpin (status) {
-  return (dispatch, getState) => {
+  return (dispatch) => {
     dispatch(unpinRequest(status));
 
-    api(getState).post(`/api/v1/statuses/${status.get('id')}/unpin`).then(response => {
+    api().post(`/api/v1/statuses/${status.get('id')}/unpin`).then(response => {
       dispatch(importFetchedStatus(response.data));
       dispatch(unpinSuccess(status));
     }).catch(error => {

--- a/app/javascript/mastodon/actions/lists.js
+++ b/app/javascript/mastodon/actions/lists.js
@@ -57,7 +57,7 @@ export const fetchList = id => (dispatch, getState) => {
 
   dispatch(fetchListRequest(id));
 
-  api(getState).get(`/api/v1/lists/${id}`)
+  api().get(`/api/v1/lists/${id}`)
     .then(({ data }) => dispatch(fetchListSuccess(data)))
     .catch(err => dispatch(fetchListFail(id, err)));
 };
@@ -78,10 +78,10 @@ export const fetchListFail = (id, error) => ({
   error,
 });
 
-export const fetchLists = () => (dispatch, getState) => {
+export const fetchLists = () => (dispatch) => {
   dispatch(fetchListsRequest());
 
-  api(getState).get('/api/v1/lists')
+  api().get('/api/v1/lists')
     .then(({ data }) => dispatch(fetchListsSuccess(data)))
     .catch(err => dispatch(fetchListsFail(err)));
 };
@@ -125,10 +125,10 @@ export const changeListEditorTitle = value => ({
   value,
 });
 
-export const createList = (title, shouldReset) => (dispatch, getState) => {
+export const createList = (title, shouldReset) => (dispatch) => {
   dispatch(createListRequest());
 
-  api(getState).post('/api/v1/lists', { title }).then(({ data }) => {
+  api().post('/api/v1/lists', { title }).then(({ data }) => {
     dispatch(createListSuccess(data));
 
     if (shouldReset) {
@@ -151,10 +151,10 @@ export const createListFail = error => ({
   error,
 });
 
-export const updateList = (id, title, shouldReset, isExclusive, replies_policy) => (dispatch, getState) => {
+export const updateList = (id, title, shouldReset, isExclusive, replies_policy) => (dispatch) => {
   dispatch(updateListRequest(id));
 
-  api(getState).put(`/api/v1/lists/${id}`, { title, replies_policy, exclusive: typeof isExclusive === 'undefined' ? undefined : !!isExclusive }).then(({ data }) => {
+  api().put(`/api/v1/lists/${id}`, { title, replies_policy, exclusive: typeof isExclusive === 'undefined' ? undefined : !!isExclusive }).then(({ data }) => {
     dispatch(updateListSuccess(data));
 
     if (shouldReset) {
@@ -183,10 +183,10 @@ export const resetListEditor = () => ({
   type: LIST_EDITOR_RESET,
 });
 
-export const deleteList = id => (dispatch, getState) => {
+export const deleteList = id => (dispatch) => {
   dispatch(deleteListRequest(id));
 
-  api(getState).delete(`/api/v1/lists/${id}`)
+  api().delete(`/api/v1/lists/${id}`)
     .then(() => dispatch(deleteListSuccess(id)))
     .catch(err => dispatch(deleteListFail(id, err)));
 };
@@ -207,10 +207,10 @@ export const deleteListFail = (id, error) => ({
   error,
 });
 
-export const fetchListAccounts = listId => (dispatch, getState) => {
+export const fetchListAccounts = listId => (dispatch) => {
   dispatch(fetchListAccountsRequest(listId));
 
-  api(getState).get(`/api/v1/lists/${listId}/accounts`, { params: { limit: 0 } }).then(({ data }) => {
+  api().get(`/api/v1/lists/${listId}/accounts`, { params: { limit: 0 } }).then(({ data }) => {
     dispatch(importFetchedAccounts(data));
     dispatch(fetchListAccountsSuccess(listId, data));
   }).catch(err => dispatch(fetchListAccountsFail(listId, err)));
@@ -234,7 +234,7 @@ export const fetchListAccountsFail = (id, error) => ({
   error,
 });
 
-export const fetchListSuggestions = q => (dispatch, getState) => {
+export const fetchListSuggestions = q => (dispatch) => {
   const params = {
     q,
     resolve: false,
@@ -242,7 +242,7 @@ export const fetchListSuggestions = q => (dispatch, getState) => {
     following: true,
   };
 
-  api(getState).get('/api/v1/accounts/search', { params }).then(({ data }) => {
+  api().get('/api/v1/accounts/search', { params }).then(({ data }) => {
     dispatch(importFetchedAccounts(data));
     dispatch(fetchListSuggestionsReady(q, data));
   }).catch(error => dispatch(showAlertForError(error)));
@@ -267,10 +267,10 @@ export const addToListEditor = accountId => (dispatch, getState) => {
   dispatch(addToList(getState().getIn(['listEditor', 'listId']), accountId));
 };
 
-export const addToList = (listId, accountId) => (dispatch, getState) => {
+export const addToList = (listId, accountId) => (dispatch) => {
   dispatch(addToListRequest(listId, accountId));
 
-  api(getState).post(`/api/v1/lists/${listId}/accounts`, { account_ids: [accountId] })
+  api().post(`/api/v1/lists/${listId}/accounts`, { account_ids: [accountId] })
     .then(() => dispatch(addToListSuccess(listId, accountId)))
     .catch(err => dispatch(addToListFail(listId, accountId, err)));
 };
@@ -298,10 +298,10 @@ export const removeFromListEditor = accountId => (dispatch, getState) => {
   dispatch(removeFromList(getState().getIn(['listEditor', 'listId']), accountId));
 };
 
-export const removeFromList = (listId, accountId) => (dispatch, getState) => {
+export const removeFromList = (listId, accountId) => (dispatch) => {
   dispatch(removeFromListRequest(listId, accountId));
 
-  api(getState).delete(`/api/v1/lists/${listId}/accounts`, { params: { account_ids: [accountId] } })
+  api().delete(`/api/v1/lists/${listId}/accounts`, { params: { account_ids: [accountId] } })
     .then(() => dispatch(removeFromListSuccess(listId, accountId)))
     .catch(err => dispatch(removeFromListFail(listId, accountId, err)));
 };
@@ -338,10 +338,10 @@ export const setupListAdder = accountId => (dispatch, getState) => {
   dispatch(fetchAccountLists(accountId));
 };
 
-export const fetchAccountLists = accountId => (dispatch, getState) => {
+export const fetchAccountLists = accountId => (dispatch) => {
   dispatch(fetchAccountListsRequest(accountId));
 
-  api(getState).get(`/api/v1/accounts/${accountId}/lists`)
+  api().get(`/api/v1/accounts/${accountId}/lists`)
     .then(({ data }) => dispatch(fetchAccountListsSuccess(accountId, data)))
     .catch(err => dispatch(fetchAccountListsFail(accountId, err)));
 };
@@ -370,4 +370,3 @@ export const addToListAdder = listId => (dispatch, getState) => {
 export const removeFromListAdder = listId => (dispatch, getState) => {
   dispatch(removeFromList(listId, getState().getIn(['listAdder', 'accountId'])));
 };
-

--- a/app/javascript/mastodon/actions/markers.ts
+++ b/app/javascript/mastodon/actions/markers.ts
@@ -1,19 +1,24 @@
 import { debounce } from 'lodash';
 
 import type { MarkerJSON } from 'mastodon/api_types/markers';
+import { getAccessToken } from 'mastodon/initial_state';
 import type { AppDispatch, RootState } from 'mastodon/store';
 import { createAppAsyncThunk } from 'mastodon/store/typed_functions';
 
-import api, { authorizationTokenFromState } from '../api';
+import api from '../api';
 import { compareId } from '../compare_id';
 
 export const synchronouslySubmitMarkers = createAppAsyncThunk(
   'markers/submit',
   async (_args, { getState }) => {
-    const accessToken = authorizationTokenFromState(getState);
+    const accessToken = getAccessToken();
     const params = buildPostMarkersParams(getState());
 
-    if (Object.keys(params).length === 0 || !accessToken) {
+    if (
+      Object.keys(params).length === 0 ||
+      !accessToken ||
+      accessToken === ''
+    ) {
       return;
     }
 
@@ -96,14 +101,14 @@ export const submitMarkersAction = createAppAsyncThunk<{
   home: string | undefined;
   notifications: string | undefined;
 }>('markers/submitAction', async (_args, { getState }) => {
-  const accessToken = authorizationTokenFromState(getState);
+  const accessToken = getAccessToken();
   const params = buildPostMarkersParams(getState());
 
-  if (Object.keys(params).length === 0 || accessToken === '') {
+  if (Object.keys(params).length === 0 || !accessToken || accessToken === '') {
     return { home: undefined, notifications: undefined };
   }
 
-  await api(getState).post<MarkerJSON>('/api/v1/markers', params);
+  await api().post<MarkerJSON>('/api/v1/markers', params);
 
   return {
     home: params.home?.last_read_id,
@@ -133,14 +138,11 @@ export const submitMarkers = createAppAsyncThunk(
   },
 );
 
-export const fetchMarkers = createAppAsyncThunk(
-  'markers/fetch',
-  async (_args, { getState }) => {
-    const response = await api(getState).get<Record<string, MarkerJSON>>(
-      `/api/v1/markers`,
-      { params: { timeline: ['notifications'] } },
-    );
+export const fetchMarkers = createAppAsyncThunk('markers/fetch', async () => {
+  const response = await api().get<Record<string, MarkerJSON>>(
+    `/api/v1/markers`,
+    { params: { timeline: ['notifications'] } },
+  );
 
-    return { markers: response.data };
-  },
-);
+  return { markers: response.data };
+});

--- a/app/javascript/mastodon/actions/mutes.js
+++ b/app/javascript/mastodon/actions/mutes.js
@@ -13,10 +13,10 @@ export const MUTES_EXPAND_SUCCESS = 'MUTES_EXPAND_SUCCESS';
 export const MUTES_EXPAND_FAIL    = 'MUTES_EXPAND_FAIL';
 
 export function fetchMutes() {
-  return (dispatch, getState) => {
+  return (dispatch) => {
     dispatch(fetchMutesRequest());
 
-    api(getState).get('/api/v1/mutes').then(response => {
+    api().get('/api/v1/mutes').then(response => {
       const next = getLinks(response).refs.find(link => link.rel === 'next');
       dispatch(importFetchedAccounts(response.data));
       dispatch(fetchMutesSuccess(response.data, next ? next.uri : null));
@@ -56,7 +56,7 @@ export function expandMutes() {
 
     dispatch(expandMutesRequest());
 
-    api(getState).get(url).then(response => {
+    api().get(url).then(response => {
       const next = getLinks(response).refs.find(link => link.rel === 'next');
       dispatch(importFetchedAccounts(response.data));
       dispatch(expandMutesSuccess(response.data, next ? next.uri : null));

--- a/app/javascript/mastodon/actions/notifications.js
+++ b/app/javascript/mastodon/actions/notifications.js
@@ -216,7 +216,7 @@ export function expandNotifications({ maxId, forceLoad } = {}, done = noOp) {
 
     dispatch(expandNotificationsRequest(isLoadingMore));
 
-    api(getState).get('/api/v1/notifications', { params, signal: expandNotificationsController.signal }).then(response => {
+    api().get('/api/v1/notifications', { params, signal: expandNotificationsController.signal }).then(response => {
       const next = getLinks(response).refs.find(link => link.rel === 'next');
 
       dispatch(importFetchedAccounts(response.data.map(item => item.account)));
@@ -262,12 +262,12 @@ export function expandNotificationsFail(error, isLoadingMore) {
 }
 
 export function clearNotifications() {
-  return (dispatch, getState) => {
+  return (dispatch) => {
     dispatch({
       type: NOTIFICATIONS_CLEAR,
     });
 
-    api(getState).post('/api/v1/notifications/clear');
+    api().post('/api/v1/notifications/clear');
   };
 }
 
@@ -346,10 +346,10 @@ export function setBrowserPermission (value) {
   };
 }
 
-export const fetchNotificationPolicy = () => (dispatch, getState) => {
+export const fetchNotificationPolicy = () => (dispatch) => {
   dispatch(fetchNotificationPolicyRequest());
 
-  api(getState).get('/api/v1/notifications/policy').then(({ data }) => {
+  api().get('/api/v1/notifications/policy').then(({ data }) => {
     dispatch(fetchNotificationPolicySuccess(data));
   }).catch(err => {
     dispatch(fetchNotificationPolicyFail(err));
@@ -370,10 +370,10 @@ export const fetchNotificationPolicyFail = error => ({
   error,
 });
 
-export const updateNotificationsPolicy = params => (dispatch, getState) => {
+export const updateNotificationsPolicy = params => (dispatch) => {
   dispatch(fetchNotificationPolicyRequest());
 
-  api(getState).put('/api/v1/notifications/policy', params).then(({ data }) => {
+  api().put('/api/v1/notifications/policy', params).then(({ data }) => {
     dispatch(fetchNotificationPolicySuccess(data));
   }).catch(err => {
     dispatch(fetchNotificationPolicyFail(err));
@@ -393,7 +393,7 @@ export const fetchNotificationRequests = () => (dispatch, getState) => {
 
   dispatch(fetchNotificationRequestsRequest());
 
-  api(getState).get('/api/v1/notifications/requests', { params }).then(response => {
+  api().get('/api/v1/notifications/requests', { params }).then(response => {
     const next = getLinks(response).refs.find(link => link.rel === 'next');
     dispatch(importFetchedAccounts(response.data.map(x => x.account)));
     dispatch(fetchNotificationRequestsSuccess(response.data, next ? next.uri : null));
@@ -426,7 +426,7 @@ export const expandNotificationRequests = () => (dispatch, getState) => {
 
   dispatch(expandNotificationRequestsRequest());
 
-  api(getState).get(url).then(response => {
+  api().get(url).then(response => {
     const next = getLinks(response).refs.find(link => link.rel === 'next');
     dispatch(importFetchedAccounts(response.data.map(x => x.account)));
     dispatch(expandNotificationRequestsSuccess(response.data, next?.uri));
@@ -459,7 +459,7 @@ export const fetchNotificationRequest = id => (dispatch, getState) => {
 
   dispatch(fetchNotificationRequestRequest(id));
 
-  api(getState).get(`/api/v1/notifications/requests/${id}`).then(({ data }) => {
+  api().get(`/api/v1/notifications/requests/${id}`).then(({ data }) => {
     dispatch(fetchNotificationRequestSuccess(data));
   }).catch(err => {
     dispatch(fetchNotificationRequestFail(id, err));
@@ -482,10 +482,10 @@ export const fetchNotificationRequestFail = (id, error) => ({
   error,
 });
 
-export const acceptNotificationRequest = id => (dispatch, getState) => {
+export const acceptNotificationRequest = id => (dispatch) => {
   dispatch(acceptNotificationRequestRequest(id));
 
-  api(getState).post(`/api/v1/notifications/requests/${id}/accept`).then(() => {
+  api().post(`/api/v1/notifications/requests/${id}/accept`).then(() => {
     dispatch(acceptNotificationRequestSuccess(id));
   }).catch(err => {
     dispatch(acceptNotificationRequestFail(id, err));
@@ -508,10 +508,10 @@ export const acceptNotificationRequestFail = (id, error) => ({
   error,
 });
 
-export const dismissNotificationRequest = id => (dispatch, getState) => {
+export const dismissNotificationRequest = id => (dispatch) => {
   dispatch(dismissNotificationRequestRequest(id));
 
-  api(getState).post(`/api/v1/notifications/requests/${id}/dismiss`).then(() =>{
+  api().post(`/api/v1/notifications/requests/${id}/dismiss`).then(() =>{
     dispatch(dismissNotificationRequestSuccess(id));
   }).catch(err => {
     dispatch(dismissNotificationRequestFail(id, err));
@@ -550,7 +550,7 @@ export const fetchNotificationsForRequest = accountId => (dispatch, getState) =>
 
   dispatch(fetchNotificationsForRequestRequest());
 
-  api(getState).get('/api/v1/notifications', { params }).then(response => {
+  api().get('/api/v1/notifications', { params }).then(response => {
     const next = getLinks(response).refs.find(link => link.rel === 'next');
     dispatch(importFetchedAccounts(response.data.map(item => item.account)));
     dispatch(importFetchedStatuses(response.data.map(item => item.status).filter(status => !!status)));
@@ -586,7 +586,7 @@ export const expandNotificationsForRequest = () => (dispatch, getState) => {
 
   dispatch(expandNotificationsForRequestRequest());
 
-  api(getState).get(url).then(response => {
+  api().get(url).then(response => {
     const next = getLinks(response).refs.find(link => link.rel === 'next');
     dispatch(importFetchedAccounts(response.data.map(item => item.account)));
     dispatch(importFetchedStatuses(response.data.map(item => item.status).filter(status => !!status)));

--- a/app/javascript/mastodon/actions/pin_statuses.js
+++ b/app/javascript/mastodon/actions/pin_statuses.js
@@ -8,10 +8,10 @@ export const PINNED_STATUSES_FETCH_SUCCESS = 'PINNED_STATUSES_FETCH_SUCCESS';
 export const PINNED_STATUSES_FETCH_FAIL = 'PINNED_STATUSES_FETCH_FAIL';
 
 export function fetchPinnedStatuses() {
-  return (dispatch, getState) => {
+  return (dispatch) => {
     dispatch(fetchPinnedStatusesRequest());
 
-    api(getState).get(`/api/v1/accounts/${me}/statuses`, { params: { pinned: true } }).then(response => {
+    api().get(`/api/v1/accounts/${me}/statuses`, { params: { pinned: true } }).then(response => {
       dispatch(importFetchedStatuses(response.data));
       dispatch(fetchPinnedStatusesSuccess(response.data, null));
     }).catch(error => {

--- a/app/javascript/mastodon/actions/polls.js
+++ b/app/javascript/mastodon/actions/polls.js
@@ -10,10 +10,10 @@ export const POLL_FETCH_REQUEST = 'POLL_FETCH_REQUEST';
 export const POLL_FETCH_SUCCESS = 'POLL_FETCH_SUCCESS';
 export const POLL_FETCH_FAIL    = 'POLL_FETCH_FAIL';
 
-export const vote = (pollId, choices) => (dispatch, getState) => {
+export const vote = (pollId, choices) => (dispatch) => {
   dispatch(voteRequest());
 
-  api(getState).post(`/api/v1/polls/${pollId}/votes`, { choices })
+  api().post(`/api/v1/polls/${pollId}/votes`, { choices })
     .then(({ data }) => {
       dispatch(importFetchedPoll(data));
       dispatch(voteSuccess(data));
@@ -21,10 +21,10 @@ export const vote = (pollId, choices) => (dispatch, getState) => {
     .catch(err => dispatch(voteFail(err)));
 };
 
-export const fetchPoll = pollId => (dispatch, getState) => {
+export const fetchPoll = pollId => (dispatch) => {
   dispatch(fetchPollRequest());
 
-  api(getState).get(`/api/v1/polls/${pollId}`)
+  api().get(`/api/v1/polls/${pollId}`)
     .then(({ data }) => {
       dispatch(importFetchedPoll(data));
       dispatch(fetchPollSuccess(data));

--- a/app/javascript/mastodon/actions/reports.js
+++ b/app/javascript/mastodon/actions/reports.js
@@ -15,10 +15,10 @@ export const initReport = (account, status) => dispatch =>
     },
   }));
 
-export const submitReport = (params, onSuccess, onFail) => (dispatch, getState) => {
+export const submitReport = (params, onSuccess, onFail) => (dispatch) => {
   dispatch(submitReportRequest());
 
-  api(getState).post('/api/v1/reports', params).then(response => {
+  api().post('/api/v1/reports', params).then(response => {
     dispatch(submitReportSuccess(response.data));
     if (onSuccess) onSuccess();
   }).catch(error => {

--- a/app/javascript/mastodon/actions/search.js
+++ b/app/javascript/mastodon/actions/search.js
@@ -46,7 +46,7 @@ export function submitSearch(type) {
 
     dispatch(fetchSearchRequest(type));
 
-    api(getState).get('/api/v2/search', {
+    api().get('/api/v2/search', {
       params: {
         q: value,
         resolve: signedIn,
@@ -99,7 +99,7 @@ export const expandSearch = type => (dispatch, getState) => {
 
   dispatch(expandSearchRequest(type));
 
-  api(getState).get('/api/v2/search', {
+  api().get('/api/v2/search', {
     params: {
       q: value,
       type,
@@ -156,7 +156,7 @@ export const openURL = (value, history, onFailure) => (dispatch, getState) => {
 
   dispatch(fetchSearchRequest());
 
-  api(getState).get('/api/v2/search', { params: { q: value, resolve: true } }).then(response => {
+  api().get('/api/v2/search', { params: { q: value, resolve: true } }).then(response => {
     if (response.data.accounts?.length > 0) {
       dispatch(importFetchedAccounts(response.data.accounts));
       history.push(`/@${response.data.accounts[0].acct}`);

--- a/app/javascript/mastodon/actions/server.js
+++ b/app/javascript/mastodon/actions/server.js
@@ -25,7 +25,7 @@ export const fetchServer = () => (dispatch, getState) => {
 
   dispatch(fetchServerRequest());
 
-  api(getState)
+  api()
     .get('/api/v2/instance').then(({ data }) => {
       if (data.contact.account) dispatch(importFetchedAccount(data.contact.account));
       dispatch(fetchServerSuccess(data));
@@ -46,10 +46,10 @@ const fetchServerFail = error => ({
   error,
 });
 
-export const fetchServerTranslationLanguages = () => (dispatch, getState) => {
+export const fetchServerTranslationLanguages = () => (dispatch) => {
   dispatch(fetchServerTranslationLanguagesRequest());
 
-  api(getState)
+  api()
     .get('/api/v1/instance/translation_languages').then(({ data }) => {
       dispatch(fetchServerTranslationLanguagesSuccess(data));
     }).catch(err => dispatch(fetchServerTranslationLanguagesFail(err)));
@@ -76,7 +76,7 @@ export const fetchExtendedDescription = () => (dispatch, getState) => {
 
   dispatch(fetchExtendedDescriptionRequest());
 
-  api(getState)
+  api()
     .get('/api/v1/instance/extended_description')
     .then(({ data }) => dispatch(fetchExtendedDescriptionSuccess(data)))
     .catch(err => dispatch(fetchExtendedDescriptionFail(err)));
@@ -103,7 +103,7 @@ export const fetchDomainBlocks = () => (dispatch, getState) => {
 
   dispatch(fetchDomainBlocksRequest());
 
-  api(getState)
+  api()
     .get('/api/v1/instance/domain_blocks')
     .then(({ data }) => dispatch(fetchDomainBlocksSuccess(true, data)))
     .catch(err => {

--- a/app/javascript/mastodon/actions/statuses.js
+++ b/app/javascript/mastodon/actions/statuses.js
@@ -59,7 +59,7 @@ export function fetchStatus(id, forceFetch = false) {
 
     dispatch(fetchStatusRequest(id, skipLoading));
 
-    api(getState).get(`/api/v1/statuses/${id}`).then(response => {
+    api().get(`/api/v1/statuses/${id}`).then(response => {
       dispatch(importFetchedStatus(response.data));
       dispatch(fetchStatusSuccess(skipLoading));
     }).catch(error => {
@@ -102,7 +102,7 @@ export const editStatus = (id, routerHistory) => (dispatch, getState) => {
 
   dispatch(fetchStatusSourceRequest());
 
-  api(getState).get(`/api/v1/statuses/${id}/source`).then(response => {
+  api().get(`/api/v1/statuses/${id}/source`).then(response => {
     dispatch(fetchStatusSourceSuccess());
     ensureComposeIsVisible(getState, routerHistory);
     dispatch(setComposeToStatus(status, response.data.text, response.data.spoiler_text));
@@ -134,7 +134,7 @@ export function deleteStatus(id, routerHistory, withRedraft = false) {
 
     dispatch(deleteStatusRequest(id));
 
-    api(getState).delete(`/api/v1/statuses/${id}`).then(response => {
+    api().delete(`/api/v1/statuses/${id}`).then(response => {
       dispatch(deleteStatusSuccess(id));
       dispatch(deleteFromTimelines(id));
       dispatch(importFetchedAccount(response.data.account));
@@ -175,10 +175,10 @@ export const updateStatus = status => dispatch =>
   dispatch(importFetchedStatus(status));
 
 export function fetchContext(id) {
-  return (dispatch, getState) => {
+  return (dispatch) => {
     dispatch(fetchContextRequest(id));
 
-    api(getState).get(`/api/v1/statuses/${id}/context`).then(response => {
+    api().get(`/api/v1/statuses/${id}/context`).then(response => {
       dispatch(importFetchedStatuses(response.data.ancestors.concat(response.data.descendants)));
       dispatch(fetchContextSuccess(id, response.data.ancestors, response.data.descendants));
 
@@ -219,10 +219,10 @@ export function fetchContextFail(id, error) {
 }
 
 export function muteStatus(id) {
-  return (dispatch, getState) => {
+  return (dispatch) => {
     dispatch(muteStatusRequest(id));
 
-    api(getState).post(`/api/v1/statuses/${id}/mute`).then(() => {
+    api().post(`/api/v1/statuses/${id}/mute`).then(() => {
       dispatch(muteStatusSuccess(id));
     }).catch(error => {
       dispatch(muteStatusFail(id, error));
@@ -253,10 +253,10 @@ export function muteStatusFail(id, error) {
 }
 
 export function unmuteStatus(id) {
-  return (dispatch, getState) => {
+  return (dispatch) => {
     dispatch(unmuteStatusRequest(id));
 
-    api(getState).post(`/api/v1/statuses/${id}/unmute`).then(() => {
+    api().post(`/api/v1/statuses/${id}/unmute`).then(() => {
       dispatch(unmuteStatusSuccess(id));
     }).catch(error => {
       dispatch(unmuteStatusFail(id, error));
@@ -316,10 +316,10 @@ export function toggleStatusCollapse(id, isCollapsed) {
   };
 }
 
-export const translateStatus = id => (dispatch, getState) => {
+export const translateStatus = id => (dispatch) => {
   dispatch(translateStatusRequest(id));
 
-  api(getState).post(`/api/v1/statuses/${id}/translate`).then(response => {
+  api().post(`/api/v1/statuses/${id}/translate`).then(response => {
     dispatch(translateStatusSuccess(id, response.data));
   }).catch(error => {
     dispatch(translateStatusFail(id, error));

--- a/app/javascript/mastodon/actions/suggestions.js
+++ b/app/javascript/mastodon/actions/suggestions.js
@@ -10,10 +10,10 @@ export const SUGGESTIONS_FETCH_FAIL    = 'SUGGESTIONS_FETCH_FAIL';
 export const SUGGESTIONS_DISMISS = 'SUGGESTIONS_DISMISS';
 
 export function fetchSuggestions(withRelationships = false) {
-  return (dispatch, getState) => {
+  return (dispatch) => {
     dispatch(fetchSuggestionsRequest());
 
-    api(getState).get('/api/v2/suggestions', { params: { limit: 20 } }).then(response => {
+    api().get('/api/v2/suggestions', { params: { limit: 20 } }).then(response => {
       dispatch(importFetchedAccounts(response.data.map(x => x.account)));
       dispatch(fetchSuggestionsSuccess(response.data));
 
@@ -48,11 +48,11 @@ export function fetchSuggestionsFail(error) {
   };
 }
 
-export const dismissSuggestion = accountId => (dispatch, getState) => {
+export const dismissSuggestion = accountId => (dispatch) => {
   dispatch({
     type: SUGGESTIONS_DISMISS,
     id: accountId,
   });
 
-  api(getState).delete(`/api/v1/suggestions/${accountId}`).catch(() => {});
+  api().delete(`/api/v1/suggestions/${accountId}`).catch(() => {});
 };

--- a/app/javascript/mastodon/actions/tags.js
+++ b/app/javascript/mastodon/actions/tags.js
@@ -20,10 +20,10 @@ export const HASHTAG_UNFOLLOW_REQUEST = 'HASHTAG_UNFOLLOW_REQUEST';
 export const HASHTAG_UNFOLLOW_SUCCESS = 'HASHTAG_UNFOLLOW_SUCCESS';
 export const HASHTAG_UNFOLLOW_FAIL    = 'HASHTAG_UNFOLLOW_FAIL';
 
-export const fetchHashtag = name => (dispatch, getState) => {
+export const fetchHashtag = name => (dispatch) => {
   dispatch(fetchHashtagRequest());
 
-  api(getState).get(`/api/v1/tags/${name}`).then(({ data }) => {
+  api().get(`/api/v1/tags/${name}`).then(({ data }) => {
     dispatch(fetchHashtagSuccess(name, data));
   }).catch(err => {
     dispatch(fetchHashtagFail(err));
@@ -45,10 +45,10 @@ export const fetchHashtagFail = error => ({
   error,
 });
 
-export const fetchFollowedHashtags = () => (dispatch, getState) => {
+export const fetchFollowedHashtags = () => (dispatch) => {
   dispatch(fetchFollowedHashtagsRequest());
 
-  api(getState).get('/api/v1/followed_tags').then(response => {
+  api().get('/api/v1/followed_tags').then(response => {
     const next = getLinks(response).refs.find(link => link.rel === 'next');
     dispatch(fetchFollowedHashtagsSuccess(response.data, next ? next.uri : null));
   }).catch(err => {
@@ -87,7 +87,7 @@ export function expandFollowedHashtags() {
 
     dispatch(expandFollowedHashtagsRequest());
 
-    api(getState).get(url).then(response => {
+    api().get(url).then(response => {
       const next = getLinks(response).refs.find(link => link.rel === 'next');
       dispatch(expandFollowedHashtagsSuccess(response.data, next ? next.uri : null));
     }).catch(error => {
@@ -117,10 +117,10 @@ export function expandFollowedHashtagsFail(error) {
   };
 }
 
-export const followHashtag = name => (dispatch, getState) => {
+export const followHashtag = name => (dispatch) => {
   dispatch(followHashtagRequest(name));
 
-  api(getState).post(`/api/v1/tags/${name}/follow`).then(({ data }) => {
+  api().post(`/api/v1/tags/${name}/follow`).then(({ data }) => {
     dispatch(followHashtagSuccess(name, data));
   }).catch(err => {
     dispatch(followHashtagFail(name, err));
@@ -144,10 +144,10 @@ export const followHashtagFail = (name, error) => ({
   error,
 });
 
-export const unfollowHashtag = name => (dispatch, getState) => {
+export const unfollowHashtag = name => (dispatch) => {
   dispatch(unfollowHashtagRequest(name));
 
-  api(getState).post(`/api/v1/tags/${name}/unfollow`).then(({ data }) => {
+  api().post(`/api/v1/tags/${name}/unfollow`).then(({ data }) => {
     dispatch(unfollowHashtagSuccess(name, data));
   }).catch(err => {
     dispatch(unfollowHashtagFail(name, err));

--- a/app/javascript/mastodon/actions/timelines.js
+++ b/app/javascript/mastodon/actions/timelines.js
@@ -114,7 +114,7 @@ export function expandTimeline(timelineId, path, params = {}, done = noOp) {
 
     dispatch(expandTimelineRequest(timelineId, isLoadingMore));
 
-    api(getState).get(path, { params }).then(response => {
+    api().get(path, { params }).then(response => {
       const next = getLinks(response).refs.find(link => link.rel === 'next');
 
       dispatch(importFetchedStatuses(response.data));

--- a/app/javascript/mastodon/actions/trends.js
+++ b/app/javascript/mastodon/actions/trends.js
@@ -18,10 +18,10 @@ export const TRENDS_STATUSES_EXPAND_REQUEST = 'TRENDS_STATUSES_EXPAND_REQUEST';
 export const TRENDS_STATUSES_EXPAND_SUCCESS = 'TRENDS_STATUSES_EXPAND_SUCCESS';
 export const TRENDS_STATUSES_EXPAND_FAIL    = 'TRENDS_STATUSES_EXPAND_FAIL';
 
-export const fetchTrendingHashtags = () => (dispatch, getState) => {
+export const fetchTrendingHashtags = () => (dispatch) => {
   dispatch(fetchTrendingHashtagsRequest());
 
-  api(getState)
+  api()
     .get('/api/v1/trends/tags')
     .then(({ data }) => dispatch(fetchTrendingHashtagsSuccess(data)))
     .catch(err => dispatch(fetchTrendingHashtagsFail(err)));
@@ -45,10 +45,10 @@ export const fetchTrendingHashtagsFail = error => ({
   skipAlert: true,
 });
 
-export const fetchTrendingLinks = () => (dispatch, getState) => {
+export const fetchTrendingLinks = () => (dispatch) => {
   dispatch(fetchTrendingLinksRequest());
 
-  api(getState)
+  api()
     .get('/api/v1/trends/links')
     .then(({ data }) => dispatch(fetchTrendingLinksSuccess(data)))
     .catch(err => dispatch(fetchTrendingLinksFail(err)));
@@ -79,7 +79,7 @@ export const fetchTrendingStatuses = () => (dispatch, getState) => {
 
   dispatch(fetchTrendingStatusesRequest());
 
-  api(getState).get('/api/v1/trends/statuses').then(response => {
+  api().get('/api/v1/trends/statuses').then(response => {
     const next = getLinks(response).refs.find(link => link.rel === 'next');
     dispatch(importFetchedStatuses(response.data));
     dispatch(fetchTrendingStatusesSuccess(response.data, next ? next.uri : null));
@@ -115,7 +115,7 @@ export const expandTrendingStatuses = () => (dispatch, getState) => {
 
   dispatch(expandTrendingStatusesRequest());
 
-  api(getState).get(url).then(response => {
+  api().get(url).then(response => {
     const next = getLinks(response).refs.find(link => link.rel === 'next');
     dispatch(importFetchedStatuses(response.data));
     dispatch(expandTrendingStatusesSuccess(response.data, next ? next.uri : null));

--- a/app/javascript/mastodon/api.ts
+++ b/app/javascript/mastodon/api.ts
@@ -2,8 +2,8 @@ import type { AxiosResponse, RawAxiosRequestHeaders } from 'axios';
 import axios from 'axios';
 import LinkHeader from 'http-link-header';
 
+import { getAccessToken } from './initial_state';
 import ready from './ready';
-import type { GetState } from './store';
 
 export const getLinks = (response: AxiosResponse) => {
   const value = response.headers.link as string | undefined;
@@ -29,30 +29,22 @@ const setCSRFHeader = () => {
 
 void ready(setCSRFHeader);
 
-export const authorizationTokenFromState = (getState?: GetState) => {
-  return (
-    getState && (getState().meta.get('access_token', '') as string | false)
-  );
-};
+const authorizationTokenFromInitialState = (): RawAxiosRequestHeaders => {
+  const accessToken = getAccessToken();
 
-const authorizationHeaderFromState = (getState?: GetState) => {
-  const accessToken = authorizationTokenFromState(getState);
-
-  if (!accessToken) {
-    return {};
-  }
+  if (!accessToken) return {};
 
   return {
     Authorization: `Bearer ${accessToken}`,
-  } as RawAxiosRequestHeaders;
+  };
 };
 
 // eslint-disable-next-line import/no-default-export
-export default function api(getState: GetState) {
+export default function api() {
   return axios.create({
     headers: {
       ...csrfHeader,
-      ...authorizationHeaderFromState(getState),
+      ...authorizationTokenFromInitialState(),
     },
 
     transformResponse: [

--- a/app/javascript/mastodon/identity_context.tsx
+++ b/app/javascript/mastodon/identity_context.tsx
@@ -9,7 +9,6 @@ export interface IdentityContextType {
   signedIn: boolean;
   accountId: string | undefined;
   disabledAccountId: string | undefined;
-  accessToken: string | undefined;
   permissions: number;
 }
 
@@ -17,14 +16,12 @@ export const identityContextPropShape = PropTypes.shape({
   signedIn: PropTypes.bool.isRequired,
   accountId: PropTypes.string,
   disabledAccountId: PropTypes.string,
-  accessToken: PropTypes.string,
 }).isRequired;
 
 export const createIdentityContext = (state: InitialState) => ({
   signedIn: !!state.meta.me,
   accountId: state.meta.me,
   disabledAccountId: state.meta.disabled_account_id,
-  accessToken: state.meta.access_token,
   permissions: state.role?.permissions ?? 0,
 });
 
@@ -33,7 +30,6 @@ export const IdentityContext = createContext<IdentityContextType>({
   permissions: 0,
   accountId: undefined,
   disabledAccountId: undefined,
-  accessToken: undefined,
 });
 
 export const useIdentity = () => useContext(IdentityContext);

--- a/app/javascript/mastodon/initial_state.js
+++ b/app/javascript/mastodon/initial_state.js
@@ -117,4 +117,11 @@ export const criticalUpdatesPending = initialState?.critical_updates_pending;
 export const statusPageUrl = getMeta('status_page_url');
 export const sso_redirect = getMeta('sso_redirect');
 
+/**
+ * @returns {string | undefined}
+ */
+export function getAccessToken() {
+  return getMeta('access_token');
+}
+
 export default initialState;

--- a/app/javascript/mastodon/reducers/meta.js
+++ b/app/javascript/mastodon/reducers/meta.js
@@ -6,7 +6,6 @@ import { layoutFromWindow } from 'mastodon/is_mobile';
 
 const initialState = ImmutableMap({
   streaming_api_base_url: null,
-  access_token: null,
   layout: layoutFromWindow(),
   permissions: '0',
 });
@@ -14,7 +13,8 @@ const initialState = ImmutableMap({
 export default function meta(state = initialState, action) {
   switch(action.type) {
   case STORE_HYDRATE:
-    return state.merge(action.state.get('meta')).set('permissions', action.state.getIn(['role', 'permissions']));
+    // we do not want `access_token` to be stored in the state
+    return state.merge(action.state.get('meta')).delete('access_token').set('permissions', action.state.getIn(['role', 'permissions']));
   case changeLayout.type:
     return state.set('layout', action.payload.layout);
   default:

--- a/app/javascript/mastodon/stream.js
+++ b/app/javascript/mastodon/stream.js
@@ -2,6 +2,8 @@
 
 import WebSocketClient from '@gamestdio/websocket';
 
+import { getAccessToken } from './initial_state';
+
 /**
  * @type {WebSocketClient | undefined}
  */
@@ -145,8 +147,10 @@ const channelNameWithInlineParams = (channelName, params) => {
 // @ts-expect-error
 export const connectStream = (channelName, params, callbacks) => (dispatch, getState) => {
   const streamingAPIBaseURL = getState().getIn(['meta', 'streaming_api_base_url']);
-  const accessToken = getState().getIn(['meta', 'access_token']);
+  const accessToken = getAccessToken();
   const { onConnect, onReceive, onDisconnect } = callbacks(dispatch, getState);
+
+  if(!accessToken) throw new Error("Trying to connect to the streaming server but no access token is available.");
 
   // If we cannot use a websockets connection, we must fall back
   // to using individual connections for each channel

--- a/app/javascript/mastodon/test_helpers.tsx
+++ b/app/javascript/mastodon/test_helpers.tsx
@@ -14,7 +14,6 @@ function render(
   const fakeIdentity = {
     signedIn: signedIn,
     accountId: '123',
-    accessToken: 'test-access-token',
     disabledAccountId: undefined,
     permissions: 0,
   };


### PR DESCRIPTION
This is not mutable once initially loaded, and it does not make sense to store it into Redux, and this makes it easy to expose it (when dumping the Redux content for troubleshooting, dev extension…).

It is also very unpractical to require access to `store.getState` to make an API request where the only thing you need is the token.

This PR:
- disallows `access_token` to be stored in Redux
- removes `access_token` from the identity context (this was not used)
- creates a new `getAccessToken` accessor from the initial state
- changes all the places using `accessToken` to use the new function
- changes the `api(getState)` interface to `api()`, and update all the callsites