### PR TITLE
Change unconfirmed user retention from 2 to 7 days

### DIFF
--- a/app/workers/scheduler/user_cleanup_scheduler.rb
+++ b/app/workers/scheduler/user_cleanup_scheduler.rb
@@ -3,6 +3,9 @@
 class Scheduler::UserCleanupScheduler
   include Sidekiq::Worker
 
+  UNCONFIRMED_ACCOUNTS_MAX_AGE_DAYS = 7
+  DISCARDED_STATUSES_MAX_AGE_DAYS = 30
+
   sidekiq_options retry: 0, lock: :until_executed, lock_ttl: 1.day.to_i
 
   def perform
@@ -13,7 +16,7 @@ class Scheduler::UserCleanupScheduler
   private
 
   def clean_unconfirmed_accounts!
-    User.where('confirmed_at is NULL AND confirmation_sent_at <= ?', 2.days.ago).reorder(nil).find_in_batches do |batch|
+    User.where('confirmed_at is NULL AND confirmation_sent_at <= ?', UNCONFIRMED_ACCOUNTS_MAX_AGE_DAYS.days.ago).reorder(nil).find_in_batches do |batch|
       # We have to do it separately because of missing database constraints
       AccountModerationNote.where(target_account_id: batch.map(&:account_id)).delete_all
       Account.where(id: batch.map(&:account_id)).delete_all
@@ -22,7 +25,7 @@ class Scheduler::UserCleanupScheduler
   end
 
   def clean_discarded_statuses!
-    Status.unscoped.discarded.where('deleted_at <= ?', 30.days.ago).find_in_batches do |statuses|
+    Status.unscoped.discarded.where('deleted_at <= ?', DISCARDED_STATUSES_MAX_AGE_DAYS.days.ago).find_in_batches do |statuses|
       RemovalWorker.push_bulk(statuses) do |status|
         [status.id, { 'immediate' => true, 'skip_streaming' => true }]
       end

--- a/spec/workers/scheduler/user_cleanup_scheduler_spec.rb
+++ b/spec/workers/scheduler/user_cleanup_scheduler_spec.rb
@@ -14,7 +14,7 @@ describe Scheduler::UserCleanupScheduler do
     before do
       # Need to update the already-existing users because their initialization overrides confirmation_sent_at
       new_unconfirmed_user.update!(confirmed_at: nil, confirmation_sent_at: Time.now.utc)
-      old_unconfirmed_user.update!(confirmed_at: nil, confirmation_sent_at: 1.week.ago)
+      old_unconfirmed_user.update!(confirmed_at: nil, confirmation_sent_at: 10.days.ago)
       confirmed_user.update!(confirmed_at: 1.day.ago)
     end
 


### PR DESCRIPTION
This is especially useful on instances with a CAPTCHA configured, otherwise if people that email you because they can not complete the captcha you might be too slow to process the request and the account might have already be deleted. 7 days instead of 2 provides some leeway.

I also extracted the durations to constantes to make them more explicit.