### PR TITLE
Fix missing prop warning for `<Account>`

### DIFF
--- a/app/javascript/mastodon/components/account.jsx
+++ b/app/javascript/mastodon/components/account.jsx
@@ -172,7 +172,6 @@ Account.propTypes = {
   onBlock: PropTypes.func,
   onMute: PropTypes.func,
   onMuteNotifications: PropTypes.func,
-  intl: PropTypes.object.isRequired,
   hidden: PropTypes.bool,
   minimal: PropTypes.bool,
   defaultAction: PropTypes.string,


### PR DESCRIPTION
This component has been transformed to a functional component but the `intl` prop was left in Prop Types, causing a warning (it is now obtained through a hook)