### PR TITLE
Add VAPID public key to v1 instance serializer

### DIFF
--- a/app/serializers/rest/v1/instance_serializer.rb
+++ b/app/serializers/rest/v1/instance_serializer.rb
@@ -62,6 +62,10 @@ class REST::V1::InstanceSerializer < ActiveModel::Serializer
         max_featured_tags: FeaturedTag::LIMIT,
       },
 
+      vapid: {
+        public_key: Rails.configuration.x.vapid_public_key,
+      },
+
       statuses: {
         max_characters: StatusLengthValidator::MAX_CHARS,
         max_media_attachments: 4,


### PR DESCRIPTION
This increases the likelihood of applications switching across to a VAPID public key from the instance endpoints.

In #28006 we added the VAPID public key to `/api/v2/instance` only, I think a lot of applications probably haven't migrated to `/api/v2/instance`, so to help easy that migration, I've added the VAPID public key at the same path for v1.

`configuration.vapid.public_key` is the path in both v1 and v2 endpoints now with this PR. I'm guessing I didn't add to v1 originally due to it being technically deprecated as of Mastodon v4.0.0