### PR TITLE
Feature: Expose report categories via an API

### DIFF
--- a/app/presenters/instance_presenter.rb
+++ b/app/presenters/instance_presenter.rb
@@ -2,7 +2,7 @@
 
 class InstancePresenter < ActiveModelSerializers::Model
   attributes :domain, :title, :version, :source_url,
-             :description, :languages, :rules, :contact
+             :description, :languages, :rules, :report_categories, :contact
 
   class ContactPresenter < ActiveModelSerializers::Model
     attributes :email, :account
@@ -48,6 +48,13 @@ class InstancePresenter < ActiveModelSerializers::Model
 
   def rules
     Rule.ordered
+  end
+
+  def report_categories
+    # We only return the `violation` category if we have rules to violate:
+    Report.categories.filter_map do |category, _value|
+      { name: category } unless category == 'violation' && Rule.count.zero?
+    end
   end
 
   def user_count

--- a/app/serializers/rest/instance_serializer.rb
+++ b/app/serializers/rest/instance_serializer.rb
@@ -15,6 +15,7 @@ class REST::InstanceSerializer < ActiveModel::Serializer
 
   has_one :contact, serializer: ContactSerializer
   has_many :rules, serializer: REST::RuleSerializer
+  has_many :report_categories, serializer: REST::ReportCategorySerializer
 
   def thumbnail
     if object.thumbnail

--- a/app/serializers/rest/report_category_serializer.rb
+++ b/app/serializers/rest/report_category_serializer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class REST::ReportCategorySerializer < ActiveModel::Serializer
+  attributes :name
+
+  def name
+    object[:name]
+  end
+end


### PR DESCRIPTION
For now, I've just added to the `/api/v2/instance` endpoint, however, we may want to actually move the localisation to the server-side, which would give us an API more like: `/api/v1/report_categories` or `/api/v2/instance/report_categories` which could then negotiate locale based on requesting user.

In this WIP iteration, this looks like the following in the response:

```json
{
  // ...ommited the rest of the instance response
  "rules": [
    {
      "id": "1",
      "text": "Test Rule",
      "hint": ""
    }
  ],
  "report_categories": [
    {
      "name": "other"
    },
    {
      "name": "spam"
    },
    {
      "name": "legal"
    },
    {
      "name": "violation"
    }
  ]
}
```

The `violation` category is dynamically present based on whether or not the server has any rules defined.