### PR TITLE
Fix off-by-one in `tootctl media` commands

### DIFF
--- a/lib/mastodon/cli/media.rb
+++ b/lib/mastodon/cli/media.rb
@@ -128,7 +128,7 @@ module Mastodon::CLI
 
             model_name      = path_segments.first.classify
             attachment_name = path_segments[1].singularize
-            record_id       = path_segments[2..-2].join.to_i
+            record_id       = path_segments[2...-2].join.to_i
             file_name       = path_segments.last
             record          = record_map.dig(model_name, record_id)
             attachment      = record&.public_send(attachment_name)
@@ -172,7 +172,7 @@ module Mastodon::CLI
           end
 
           model_name      = path_segments.first.classify
-          record_id       = path_segments[2..-2].join.to_i
+          record_id       = path_segments[2...-2].join.to_i
           attachment_name = path_segments[1].singularize
           file_name       = path_segments.last
 
@@ -297,7 +297,7 @@ module Mastodon::CLI
       fail_with_message 'Not a media URL' unless VALID_PATH_SEGMENTS_SIZE.include?(path_segments.size)
 
       model_name = path_segments.first.classify
-      record_id  = path_segments[2..-2].join.to_i
+      record_id  = path_segments[2...-2].join.to_i
 
       fail_with_message "Cannot find corresponding model: #{model_name}" unless PRELOAD_MODEL_WHITELIST.include?(model_name)
 
@@ -353,7 +353,7 @@ module Mastodon::CLI
         next unless VALID_PATH_SEGMENTS_SIZE.include?(segments.size)
 
         model_name = segments.first.classify
-        record_id  = segments[2..-2].join.to_i
+        record_id  = segments[2...-2].join.to_i
 
         next unless PRELOAD_MODEL_WHITELIST.include?(model_name)
 


### PR DESCRIPTION
Fixes #30281

File paths for attachments are of the form `:model_name/:attribute_name/:id_pt1/:id_pt2/…/:style/:filename` (e.g. `site_uploads/files/000/000/002/original/4919ef8c0b4e8d59.png`) and the `path_segments[2..-2]` returned `[':id_pt1', ':id_pt2', …, ':style']`, incorrectly including `:style`.

This did not get noticed up until now because `:style` was never a numeric, so calling `#to_i` always silently stripped it. However, icon styles are numeric, and thus were incorrectly added to the reconstructed identifier.