### PR TITLE
Fix incorrect element selector from #30221

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -4365,7 +4365,7 @@ a.status-card {
     outline: $ui-button-focus-outline;
   }
 
-  .no-reduce-motion .icon {
+  .no-reduce-motion & .icon {
     transition: transform 0.15s ease-in-out;
   }
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -4365,10 +4365,6 @@ a.status-card {
     outline: $ui-button-focus-outline;
   }
 
-  .no-reduce-motion & .icon {
-    transition: transform 0.15s ease-in-out;
-  }
-
   &.active {
     color: $primary-text-color;
 
@@ -4385,6 +4381,10 @@ a.status-card {
     color: $dark-text-color;
     cursor: default;
   }
+}
+
+.no-reduce-motion .column-header__button .icon {
+  transition: transform 0.15s ease-in-out;
 }
 
 .column-header__collapsible {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -4384,7 +4384,7 @@ a.status-card {
 }
 
 .no-reduce-motion .column-header__button .icon {
-  transition: transform 0.15s ease-in-out;
+  transition: transform 150ms ease-in-out;
 }
 
 .column-header__collapsible {


### PR DESCRIPTION
Apologize for my oversight in #30221. The element selector used `.no-reduce-motion` from inside the column header, which of course doesn't exist since it's set on `body`.

| #30221 | This PR |
|--------|--------|
| ![Screenshot from 2024-05-15 16-57-09](https://github.com/mastodon/mastodon/assets/77155297/6f6e656f-88c2-474f-8a6c-3322721c08f8) | ![Screenshot from 2024-05-15 16-56-59](https://github.com/mastodon/mastodon/assets/77155297/f70c45de-cbd9-4bee-8be4-306806684386) |
