### PR TITLE
Use ruby language constants to build version string in software version dimension

### DIFF
--- a/app/lib/admin/metrics/dimension/software_versions_dimension.rb
+++ b/app/lib/admin/metrics/dimension/software_versions_dimension.rb
@@ -25,14 +25,11 @@ class Admin::Metrics::Dimension::SoftwareVersionsDimension < Admin::Metrics::Dim
   end
 
   def ruby_version
-    yjit = defined?(RubyVM::YJIT) && RubyVM::YJIT.enabled?
-    value = "#{RUBY_VERSION}p#{RUBY_PATCHLEVEL}#{yjit ? ' +YJIT' : ''}"
-
     {
       key: 'ruby',
       human_key: 'Ruby',
-      value: value,
-      human_value: value,
+      value: "#{RUBY_VERSION}p#{RUBY_PATCHLEVEL}",
+      human_value: RUBY_DESCRIPTION,
     }
   end
 


### PR DESCRIPTION
The relevant data in the class winds up as:

```ruby
{
  :key=>"ruby",
  :human_key=>"Ruby",
  :value=>"3.3.1p55",
  :human_value=>"ruby 3.3.1 (2024-04-23 revision c56cd86388) [arm64-darwin23]"
}
```

When JYIT (or other options) are enabled, they will be in the human value string.