### PR TITLE
Enable YJIT when available

### DIFF
--- a/config/initializers/enable_yjit.rb
+++ b/config/initializers/enable_yjit.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Automatically enable YJIT as of Ruby 3.3, as it brings very
+# sizeable performance improvements.
+
+# If you are deploying to a memory constrained environment
+# you may want to delete this file, but otherwise it's free
+# performance.
+if defined?(RubyVM::YJIT.enable)
+  Rails.application.config.after_initialize do
+    RubyVM::YJIT.enable
+  end
+end


### PR DESCRIPTION
Pulled from Rails PR https://github.com/rails/rails/pull/49947 - this will presumably be a default generated initializer in Rails 8, but I think it's safe to pull in now.