### PR TITLE
Fix: Mark redirect uris field in Development > Application form as required

### DIFF
--- a/app/controllers/settings/applications_controller.rb
+++ b/app/controllers/settings/applications_controller.rb
@@ -13,7 +13,7 @@ class Settings::ApplicationsController < Settings::BaseController
   def new
     @application = Doorkeeper::Application.new(
       redirect_uri: Doorkeeper.configuration.native_redirect_uri,
-      scopes: 'read write follow'
+      scopes: 'read:me'
     )
   end
 

--- a/app/views/settings/applications/_fields.html.haml
+++ b/app/views/settings/applications/_fields.html.haml
@@ -11,6 +11,7 @@
 .fields-group
   = f.input :redirect_uri,
             label: t('activerecord.attributes.doorkeeper/application.redirect_uri'), hint: t('doorkeeper.applications.help.redirect_uri'),
+            required: true,
             wrapper: :with_block_label
 
   %p.hint= t('doorkeeper.applications.help.native_redirect_uri', native_redirect_uri: content_tag(:code, Doorkeeper.configuration.native_redirect_uri)).html_safe

--- a/config/navigation.rb
+++ b/config/navigation.rb
@@ -36,7 +36,7 @@ SimpleNavigation::Configuration.run do |navigation|
     end
 
     n.item :invites, safe_join([fa_icon('user-plus fw'), t('invites.title')]), invites_path, if: -> { current_user.can?(:invite_users) && current_user.functional? && !self_destruct }
-    n.item :development, safe_join([fa_icon('code fw'), t('settings.development')]), settings_applications_path, if: -> { current_user.functional? && !self_destruct }
+    n.item :development, safe_join([fa_icon('code fw'), t('settings.development')]), settings_applications_path, highlights_on: %r{/settings/applications}, if: -> { current_user.functional? && !self_destruct }
 
     n.item :trends, safe_join([fa_icon('fire fw'), t('admin.trends.title')]), admin_trends_statuses_path, if: -> { current_user.can?(:manage_taxonomies) && !self_destruct } do |s|
       s.item :statuses, safe_join([fa_icon('comments-o fw'), t('admin.trends.statuses.title')]), admin_trends_statuses_path, highlights_on: %r{/admin/trends/statuses}


### PR DESCRIPTION
This field was actually required, however, the simple form code doesn't seem to pick this up when rendering.

Additionally, I noticed:
- We were defaulting to read, write and follow scopes — all of which are pretty powerful and potentially dangerous to use, so I've changed to just defaulting to `read:me` (introduced in #29087)
- The "Development" item in the navigation wasn't correctly highlighting when creating or editing applications.

<img width="1153" alt="Screenshot 2024-05-15 at 18 58 28" src="https://github.com/mastodon/mastodon/assets/30827/328f449a-f567-4261-a70f-93bc0e50b821">