### PR TITLE
Add client_secret_expires_at to OAuth Applications

### DIFF
--- a/app/serializers/rest/credential_application_serializer.rb
+++ b/app/serializers/rest/credential_application_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class REST::CredentialApplicationSerializer < REST::ApplicationSerializer
-  attributes :client_id, :client_secret
+  attributes :client_id, :client_secret, :client_secret_expires_at
 
   def client_id
     object.uid
@@ -9,5 +9,11 @@ class REST::CredentialApplicationSerializer < REST::ApplicationSerializer
 
   def client_secret
     object.secret
+  end
+
+  # Added for future forwards compatibility when we may decide to expire OAuth
+  # Applications. Set to zero means that the client_secret never expires.
+  def client_secret_expires_at
+    0
   end
 end

--- a/spec/requests/api/v1/apps/credentials_spec.rb
+++ b/spec/requests/api/v1/apps/credentials_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe 'Credentials' do
         expect(response.parsed_body)
           .to not_include(client_id: be_present)
           .and not_include(client_secret: be_present)
+          .and not_include(client_secret_expires_at: be_present)
       end
     end
 

--- a/spec/requests/api/v1/apps_spec.rb
+++ b/spec/requests/api/v1/apps_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe 'Apps' do
             id: app.id.to_s,
             client_id: app.uid,
             client_secret: app.secret,
+            client_secret_expires_at: 0,
             name: client_name,
             website: website,
             scopes: ['read', 'write'],


### PR DESCRIPTION
This allows us to support future `client_secret` expiry, whilst also advertising that clients do not currently expire automatically. This is inspired by [Auth0's Open Dynamic Client Registration](https://auth0.com/docs/get-started/applications/dynamic-client-registration) documentation.

> Time at which the client_secret will expire or 0 if it will not expire.  The time is represented as the number of seconds from 1970-01-01T00:00:00Z as measured in UTC until the date/time of expiration.

— OAuth 2.0 Dynamic Registration, [RFC 7591](https://datatracker.ietf.org/doc/html/rfc7591), Section 3.2.1

This PR requires #30316 to be merged, since the OAuth Application vacuuming currently does not have any predictable expiration properties. So if we leave OAuth Application vacuuming in as currently existing, the value of `0` would not be correct, since the client could be vacuumed at any point in time after 1 day.

This allows Application developers to prepare and be adaptive to when we may introduce client_secret expiry in the future, such that they can know when their application would expire. (Supporting this would require a database migration to add a column to the oauth_applications table for expiry).