### PR TITLE
Add support for OAuth Public Clients with Token Expiry

### DIFF
--- a/app/controllers/api/v1/apps_controller.rb
+++ b/app/controllers/api/v1/apps_controller.rb
@@ -2,6 +2,9 @@
 
 class Api::V1::AppsController < Api::BaseController
   skip_before_action :require_authenticated_user!
+  before_action :validate_token_endpoint_auth_method!
+
+  TOKEN_ENDPOINT_AUTH_METHODS = %w(none client_secret_basic client_secret_post).freeze
 
   def create
     @app = Doorkeeper::Application.create!(application_options)
@@ -16,12 +19,18 @@ class Api::V1::AppsController < Api::BaseController
       redirect_uri: app_params[:redirect_uris],
       scopes: app_scopes_or_default,
       website: app_params[:website],
-      confidential: app_confidential?,
+      confidential: !app_public?,
     }
   end
 
-  def app_confidential?
-    !app_params[:token_endpoint_auth_method] || app_params[:token_endpoint_auth_method] != 'none'
+  def validate_token_endpoint_auth_method!
+    return unless app_params.include? :token_endpoint_auth_method
+
+    bad_request unless TOKEN_ENDPOINT_AUTH_METHODS.include? app_params[:token_endpoint_auth_method]
+  end
+
+  def app_public?
+    app_params[:token_endpoint_auth_method] == 'none'
   end
 
   def app_scopes_or_default

--- a/app/controllers/api/v1/apps_controller.rb
+++ b/app/controllers/api/v1/apps_controller.rb
@@ -16,7 +16,12 @@ class Api::V1::AppsController < Api::BaseController
       redirect_uri: app_params[:redirect_uris],
       scopes: app_scopes_or_default,
       website: app_params[:website],
+      confidential: app_confidential?,
     }
+  end
+
+  def app_confidential?
+    !app_params[:token_endpoint_auth_method] || app_params[:token_endpoint_auth_method] != 'none'
   end
 
   def app_scopes_or_default
@@ -24,6 +29,6 @@ class Api::V1::AppsController < Api::BaseController
   end
 
   def app_params
-    params.permit(:client_name, :scopes, :website, :redirect_uris, redirect_uris: [])
+    params.permit(:client_name, :scopes, :website, :token_endpoint_auth_method, :redirect_uris, redirect_uris: [])
   end
 end

--- a/app/lib/scope_transformer.rb
+++ b/app/lib/scope_transformer.rb
@@ -14,6 +14,8 @@ class ScopeTransformer < Parslet::Transform
 
       # # override for profile scope which is read only
       @access = %w(read) if @term == 'profile'
+      # Override offline_access since it doesn't imply read or write access:
+      @access = %w(offline) if @term == 'offline_access'
     end
 
     def key

--- a/app/models/session_activation.rb
+++ b/app/models/session_activation.rb
@@ -76,7 +76,7 @@ class SessionActivation < ApplicationRecord
     )
 
     {
-      application_id: context.client,
+      application_id: context.client.id,
       resource_owner_id: context.resource_owner,
       scopes: context.scopes,
       expires_in: Doorkeeper::OAuth::Authorization::Token.access_token_expires_in(Doorkeeper.config, context),

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -310,9 +310,9 @@ class User < ApplicationRecord
   def token_for_app(app)
     return nil if app.nil? || app.owner != self
 
-    context = Doorkeeper::OAuth::Authorization::Token.build_context(app, Doorkeeper::OAuth::AUTHORIZATION_CODE, app.scopes, app.owner)
+    context = Doorkeeper::OAuth::Authorization::Token.build_context(app, Doorkeeper::OAuth::AUTHORIZATION_CODE, app.scopes, app.owner.id)
 
-    Doorkeeper::AccessToken.find_or_create_by(application_id: context.client.id, resource_owner_id: context.resource_owner.id) do |t|
+    Doorkeeper::AccessToken.find_or_create_by(application_id: context.client.id, resource_owner_id: context.resource_owner) do |t|
       t.scopes            = context.scopes
       t.expires_in        = Doorkeeper::OAuth::Authorization::Token.access_token_expires_in(Doorkeeper.config, context)
       t.use_refresh_token = Doorkeeper::OAuth::Authorization::Token.refresh_token_enabled?(Doorkeeper.config, context)

--- a/app/presenters/oauth_metadata_presenter.rb
+++ b/app/presenters/oauth_metadata_presenter.rb
@@ -61,7 +61,7 @@ class OauthMetadataPresenter < ActiveModelSerializers::Model
   end
 
   def token_endpoint_auth_methods_supported
-    %w(client_secret_basic client_secret_post)
+    %w(none client_secret_basic client_secret_post)
   end
 
   def code_challenge_methods_supported

--- a/app/serializers/rest/credential_application_serializer.rb
+++ b/app/serializers/rest/credential_application_serializer.rb
@@ -8,7 +8,7 @@ class REST::CredentialApplicationSerializer < REST::ApplicationSerializer
   end
 
   def client_secret
-    object.secret
+    object.secret if object.confidential?
   end
 
   # Added for future forwards compatibility when we may decide to expire OAuth

--- a/app/services/app_sign_up_service.rb
+++ b/app/services/app_sign_up_service.rb
@@ -27,12 +27,14 @@ class AppSignUpService < BaseService
   end
 
   def create_access_token!
+    context = Doorkeeper::OAuth::Authorization::Token.build_context(@app, Doorkeeper::OAuth::AUTHORIZATION_CODE, @app.scopes, @user.id)
+
     @access_token = Doorkeeper::AccessToken.create!(
-      application: @app,
-      resource_owner_id: @user.id,
-      scopes: @app.scopes,
-      expires_in: Doorkeeper.configuration.access_token_expires_in,
-      use_refresh_token: Doorkeeper.configuration.refresh_token_enabled?
+      application: context.client,
+      resource_owner_id: context.resource_owner,
+      scopes: context.scopes,
+      expires_in: Doorkeeper::OAuth::Authorization::Token.access_token_expires_in(Doorkeeper.config, context),
+      use_refresh_token: Doorkeeper::OAuth::Authorization::Token.refresh_token_enabled?(Doorkeeper.config, context)
     )
   end
 

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -129,7 +129,9 @@ Doorkeeper.configure do
   # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then
   # falls back to the `:client_id` and `:client_secret` params from the `params` object.
   # Check out the wiki for more information on customization
-  # client_credentials :from_basic, :from_params
+  #
+  # This is the default value:
+  client_credentials :from_basic, :from_params
 
   # Change the way access token is authenticated from the request object.
   # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -181,7 +181,7 @@ Doorkeeper.configure do
   #   http://tools.ietf.org/html/rfc6819#section-4.4.3
   #
 
-  grant_flows %w(authorization_code client_credentials)
+  grant_flows %w(authorization_code client_credentials refresh_token)
 
   # If the client is not a confidential client, it should not be able to use the
   # client_credentials grant flow, since it cannot keep a secret.

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -49,6 +49,13 @@ Doorkeeper.configure do
     context.scopes.exists?('offline_access')
   end
 
+  after_successful_strategy_response do |request, _response|
+    if request.is_a? Doorkeeper::OAuth::RefreshTokenRequest
+      Web::PushSubscription.where(access_token_id: request.refresh_token.id).update!(access_token_id: request.access_token.id)
+      SessionActivation.where(access_token_id: request.refresh_token.id).update!(access_token_id: request.access_token.id)
+    end
+  end
+
   # Use a custom class for generating the access token.
   # https://github.com/doorkeeper-gem/doorkeeper#custom-access-token-generator
   # access_token_generator "::Doorkeeper::JWT"

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -31,10 +31,19 @@ Doorkeeper.configure do
   # If you want to disable expiration, set this to nil.
   access_token_expires_in nil
 
-  # Assign a custom TTL for implicit grants.
-  # custom_access_token_expires_in do |oauth_client|
-  #   oauth_client.application.additional_settings.implicit_oauth_expiration
-  # end
+  # context.grant_type to compare with Doorkeeper::OAUTH grant type constants
+  # context.client for client (Doorkeeper::Application)
+  # context.scopes for scopes
+  custom_access_token_expires_in do |context|
+    # If the client is confidential (all clients pre 4.3), then we don't want to
+    # expire access tokens. Applications created by users are also considered
+    # confidential.
+    if context.client.confidential?
+      nil
+    else
+      15.minutes.to_i
+    end
+  end
 
   # Use a custom class for generating the access token.
   # https://github.com/doorkeeper-gem/doorkeeper#custom-access-token-generator

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -45,6 +45,10 @@ Doorkeeper.configure do
     end
   end
 
+  use_refresh_token do |context|
+    context.scopes.exists?('offline_access')
+  end
+
   # Use a custom class for generating the access token.
   # https://github.com/doorkeeper-gem/doorkeeper#custom-access-token-generator
   # access_token_generator "::Doorkeeper::JWT"

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -35,10 +35,10 @@ Doorkeeper.configure do
   # context.client for client (Doorkeeper::Application)
   # context.scopes for scopes
   custom_access_token_expires_in do |context|
-    # If the client is confidential (all clients pre 4.3), then we don't want to
-    # expire access tokens. Applications created by users are also considered
-    # confidential.
-    if context.client.confidential?
+    # If the client is confidential (all clients pre 4.3) and it hasn't
+    # requested offline_access, then we don't want to expire access tokens.
+    # Applications created by users are also considered confidential.
+    if context.client.confidential? && !context.scopes.exists?('offline_access')
       nil
     else
       15.minutes.to_i
@@ -80,6 +80,7 @@ Doorkeeper.configure do
   # https://github.com/doorkeeper-gem/doorkeeper/wiki/Using-Scopes
   default_scopes  :read
   optional_scopes :profile,
+                  :offline_access,
                   :write,
                   :'write:accounts',
                   :'write:blocks',

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -167,6 +167,16 @@ Doorkeeper.configure do
 
   grant_flows %w(authorization_code client_credentials)
 
+  # If the client is not a confidential client, it should not be able to use the
+  # client_credentials grant flow, since it cannot keep a secret.
+  allow_grant_flow_for_client do |grant_flow, client|
+    if grant_flow == Doorkeeper::OAuth::CLIENT_CREDENTIALS
+      client.confidential?
+    else
+      true
+    end
+  end
+
   # Under some circumstances you might want to have applications auto-approved,
   # so that the user skips the authorization step.
   # For example if dealing with a trusted application.

--- a/config/locales/doorkeeper.en.yml
+++ b/config/locales/doorkeeper.en.yml
@@ -89,6 +89,7 @@ en:
         invalid_request:
           missing_param: 'Missing required parameter: %{value}.'
           request_not_authorized: Request need to be authorized. Required parameter for authorizing request is missing or invalid.
+          offline_access_only: The offline_access scope can only be used with other scopes.
           unknown: The request is missing a required parameter, includes an unsupported parameter value, or is otherwise malformed.
         invalid_resource_owner: The provided resource owner credentials are not valid, or resource owner cannot be found
         invalid_scope: The requested scope is invalid, unknown, or malformed.
@@ -118,6 +119,7 @@ en:
         read: Read-only access
         read/write: Read and write access
         write: Write-only access
+        offline: Access for an extended period of time
       title:
         accounts: Accounts
         admin/accounts: Administration of accounts
@@ -138,6 +140,7 @@ en:
         notifications: Notifications
         profile: Your Mastodon profile
         push: Push notifications
+        offline_access: Offline access
         reports: Reports
         search: Search
         statuses: Posts

--- a/spec/controllers/oauth/authorizations_controller_spec.rb
+++ b/spec/controllers/oauth/authorizations_controller_spec.rb
@@ -30,12 +30,19 @@ RSpec.describe Oauth::AuthorizationsController do
 
       context 'when app is already authorized' do
         before do
+          context = Doorkeeper::OAuth::Authorization::Token.build_context(
+            app,
+            Doorkeeper::OAuth::AUTHORIZATION_CODE,
+            app.scopes,
+            user.id
+          )
+
           Doorkeeper::AccessToken.find_or_create_for(
-            application: app,
-            resource_owner: user.id,
-            scopes: app.scopes,
-            expires_in: Doorkeeper.configuration.access_token_expires_in,
-            use_refresh_token: Doorkeeper.configuration.refresh_token_enabled?
+            application: context.client,
+            resource_owner: context.resource_owner,
+            scopes: context.scopes,
+            expires_in: Doorkeeper::OAuth::Authorization::Token.access_token_expires_in(Doorkeeper.config, context),
+            use_refresh_token: Doorkeeper::OAuth::Authorization::Token.refresh_token_enabled?(Doorkeeper.config, context)
           )
         end
 

--- a/spec/fabricators/application_fabricator.rb
+++ b/spec/fabricators/application_fabricator.rb
@@ -3,5 +3,5 @@
 Fabricator(:application, from: Doorkeeper::Application) do
   name         'Example'
   website      'http://example.com'
-  redirect_uri 'http://example.com/callback'
+  redirect_uri 'urn:ietf:wg:oauth:2.0:oob'
 end

--- a/spec/lib/scope_transformer_spec.rb
+++ b/spec/lib/scope_transformer_spec.rb
@@ -23,6 +23,12 @@ RSpec.describe ScopeTransformer do
       it_behaves_like 'a scope', nil, 'profile', 'read'
     end
 
+    context 'with scope "offline_access"' do
+      let(:input) { 'offline_access' }
+
+      it_behaves_like 'a scope', nil, 'offline_access', 'offline'
+    end
+
     context 'with scope "read"' do
       let(:input) { 'read' }
 

--- a/spec/requests/oauth/token_spec.rb
+++ b/spec/requests/oauth/token_spec.rb
@@ -5,17 +5,19 @@ require 'rails_helper'
 RSpec.describe 'Managing OAuth Tokens' do
   describe 'POST /oauth/token' do
     subject do
-      post '/oauth/token', params: params
+      post '/oauth/token', params: params, headers: {
+        # This is using the OAuth client_secret_basic client authentication method
+        Authorization: ActionController::HttpAuthentication::Basic.encode_credentials(application.uid, application.secret),
+      }
     end
 
     let(:application) do
       Fabricate(:application, scopes: 'read write follow', redirect_uri: 'urn:ietf:wg:oauth:2.0:oob')
     end
+
     let(:params) do
       {
         grant_type: grant_type,
-        client_id: application.uid,
-        client_secret: application.secret,
         redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
         code: code,
         scope: scope,

--- a/spec/requests/well_known/oauth_metadata_spec.rb
+++ b/spec/requests/well_known/oauth_metadata_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'The /.well-known/oauth-authorization-server request' do
       scopes_supported: Doorkeeper.configuration.scopes.map(&:to_s),
       response_types_supported: Doorkeeper.configuration.authorization_response_types,
       response_modes_supported: Doorkeeper.configuration.authorization_response_flows.flat_map(&:response_mode_matches).uniq,
-      token_endpoint_auth_methods_supported: %w(client_secret_basic client_secret_post),
+      token_endpoint_auth_methods_supported: %w(none client_secret_basic client_secret_post),
       grant_types_supported: grant_types_supported,
       code_challenge_methods_supported: Doorkeeper.configuration.pkce_code_challenge_methods_supported,
       # non-standard extension:


### PR DESCRIPTION
This is a heavy work in progress, but from what I can tell so far, it is fully backwards compatible with what we currently have in Mastodon 4.2.x and main. **This will of course need a TONNE of test coverage and integration tests, which I'm still to have time to write.**

This gives us a _much_ better way to solve #30316 and #24871, as majority of OAuth Applications being registered at the moment are likely from public clients, such as web clients like Phanpy, Pinafore, and Semaphore, and mobile clients such as Ivory, Mastodon's official mobile apps, etc.

This PR would also pair nicely with #27948, since we'd want public clients to be able to regularly refresh their access tokens. I might rolling that into this PR, and then have more comprehensive tests for everything.

We would probably want to extend the Apps API with support for `software_id` and `software_version` to help with grouping applications together, which would be an additional two columns on the oauth_applications table.

You do still need to use dynamic client registration since you need a `client_id` to interact with `/oauth/authorize`, but this paves the way for in the future accepting either `client_id` of IRIs to a public identifier document, or for IndieAuth or FedCM.