### PR TITLE
Add coverage for custom filters

### DIFF
--- a/spec/system/filters_spec.rb
+++ b/spec/system/filters_spec.rb
@@ -28,7 +28,7 @@ describe 'Filters' do
 
       click_on filter_title
 
-      fill_in 'Title', with: new_title
+      fill_in filter_title_field, with: new_title
       click_on I18n.t('generic.save_changes')
 
       expect(page).to have_content(new_title)
@@ -58,11 +58,15 @@ describe 'Filters' do
   end
 
   def fill_in_filter_form
-    fill_in 'Title', with: filter_title
+    fill_in filter_title_field, with: filter_title
     check I18n.t('filters.contexts.home')
     within('.custom_filter_keywords_keyword') do
       fill_in with: 'Keyword'
     end
     click_on I18n.t('filters.new.save')
+  end
+
+  def filter_title_field
+    I18n.t('simple_form.labels.defaults.title')
   end
 end

--- a/spec/system/filters_spec.rb
+++ b/spec/system/filters_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Filters' do
+  let(:user) { Fabricate(:user) }
+  let(:filter_title) { 'Filter of fun and games' }
+
+  before { sign_in(user) }
+
+  describe 'Creating a filter' do
+    it 'Populates a new filter from form' do
+      navigate_to_filters
+
+      click_on I18n.t('filters.new.title')
+      fill_in_filter_form
+      expect(page).to have_content(filter_title)
+    end
+  end
+
+  describe 'Editing an existing filter' do
+    let(:new_title) { 'Change title value' }
+
+    before { Fabricate :custom_filter, account: user.account, title: filter_title }
+
+    it 'Updates the saved filter' do
+      navigate_to_filters
+
+      click_on filter_title
+
+      fill_in 'Title', with: new_title
+      click_on I18n.t('generic.save_changes')
+
+      expect(page).to have_content(new_title)
+    end
+  end
+
+  describe 'Destroying an existing filter' do
+    before { Fabricate :custom_filter, account: user.account, title: filter_title }
+
+    it 'Deletes the filter' do
+      navigate_to_filters
+
+      expect(page).to have_content filter_title
+      expect do
+        click_on I18n.t('filters.index.delete')
+      end.to change(CustomFilter, :count).by(-1)
+
+      expect(page).to_not have_content(filter_title)
+    end
+  end
+
+  def navigate_to_filters
+    visit settings_path
+
+    click_on I18n.t('filters.index.title')
+    expect(page).to have_content I18n.t('filters.index.title')
+  end
+
+  def fill_in_filter_form
+    fill_in 'Title', with: filter_title
+    check I18n.t('filters.contexts.home')
+    within('.custom_filter_keywords_keyword') do
+      fill_in with: 'Keyword'
+    end
+    click_on I18n.t('filters.new.save')
+  end
+end


### PR DESCRIPTION
There is existing controller spec that just hits the index action for signed in/out scenarios, but nothing for create/edit/update flows. This adds the "happy path" for those flows, but does not yet handle the error conditions on create/update.

May do followup to add those error paths, and also maybe merge the controller spec into here and then delete it.