### PR TITLE
Add instrumentation to the search services

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,6 +103,8 @@ gem 'rdf-normalize', '~> 0.5'
 
 gem 'private_address_check', '~> 0.5'
 
+gem 'opentelemetry-api', '~> 1.2.5'
+
 group :opentelemetry do
   gem 'opentelemetry-exporter-otlp', '~> 0.26.3', require: false
   gem 'opentelemetry-instrumentation-active_job', '~> 0.7.1', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -975,6 +975,7 @@ DEPENDENCIES
   omniauth-rails_csrf_protection (~> 1.0)
   omniauth-saml (~> 2.0)
   omniauth_openid_connect (~> 0.6.1)
+  opentelemetry-api (~> 1.2.5)
   opentelemetry-exporter-otlp (~> 0.26.3)
   opentelemetry-instrumentation-active_job (~> 0.7.1)
   opentelemetry-instrumentation-active_model_serializers (~> 0.20.1)

--- a/app/services/tag_search_service.rb
+++ b/app/services/tag_search_service.rb
@@ -2,15 +2,25 @@
 
 class TagSearchService < BaseService
   def call(query, options = {})
-    @query   = query.strip.delete_prefix('#')
-    @offset  = options.delete(:offset).to_i
-    @limit   = options.delete(:limit).to_i
-    @options = options
+    MastodonOTELTracer.in_span('TagSearchService#call') do |span|
+      @query   = query.strip.delete_prefix('#')
+      @offset  = options.delete(:offset).to_i
+      @limit   = options.delete(:limit).to_i
+      @options = options
 
-    results   = from_elasticsearch if Chewy.enabled?
-    results ||= from_database
+      span.add_attributes(
+        'search.offset' => @offset,
+        'search.limit' => @limit,
+        'search.backend' => Chewy.enabled? ? 'elasticsearch' : 'database'
+      )
 
-    results
+      results   = from_elasticsearch if Chewy.enabled?
+      results ||= from_database
+
+      span.set_attribute('search.results.count', results.size)
+
+      results
+    end
   end
 
   private

--- a/config/initializers/opentelemetry.rb
+++ b/config/initializers/opentelemetry.rb
@@ -63,3 +63,5 @@ if ENV.keys.any? { |name| name.match?(/OTEL_.*_ENDPOINT/) }
     c.service_version = Mastodon::Version.to_s
   end
 end
+
+MastodonOTELTracer = OpenTelemetry.tracer_provider.tracer('mastodon')


### PR DESCRIPTION
This is a start at adding custom spans to the app code. I started on this one as I noticed some weird traces when doing searches, and I wanted to have a better visibility on which kind of search was triggering this.

<img width="1505" alt="image" src="https://github.com/mastodon/mastodon/assets/42070/70312a27-2fdf-4c0d-acc9-9af00b58b621">

We need the `opentelemetry-api` to be loaded so we can call the various instrumentations methods, but if OTEL is not configured then those methods are no-ops.

I created a custom `mastodon` tracer. At some point we may want to have multiple tracers to split the various parts of the app into their own instrumentations, but this can be done later once we have a better vision of what we want.

cc @robbkidd 