### PR TITLE
Use the job class as span name for Sidekiq root spans

### DIFF
--- a/config/initializers/opentelemetry.rb
+++ b/config/initializers/opentelemetry.rb
@@ -51,6 +51,9 @@ if ENV.keys.any? { |name| name.match?(/OTEL_.*_ENDPOINT/) }
         use_rack_events: false, # instead of events, use middleware; allows for untraced_endpoints to ignore child spans
         untraced_endpoints: ['/health'],
       },
+      'OpenTelemetry::Instrumentation::Sidekiq' => {
+        span_naming: :job_class, # Use the job class as the span name, otherwise this is the queue name and not very helpful
+      },
     })
 
     prefix = ENV.fetch('OTEL_SERVICE_NAME_PREFIX', 'mastodon')


### PR DESCRIPTION
Without this option, root span for jobs are the name of the queue, which is not very helpful.

Having the worker class name here makes it possible to have per-worker overviews which is much more useful.