### PR TITLE
Fix Accept headers when fetching AP objects to match spec

### DIFF
--- a/app/lib/activitypub/dereferencer.rb
+++ b/app/lib/activitypub/dereferencer.rb
@@ -44,7 +44,7 @@ class ActivityPub::Dereferencer
 
     req = Request.new(:get, uri)
 
-    req.add_headers('Accept' => 'application/activity+json, application/ld+json')
+    req.add_headers('Accept' => 'application/ld+json; profile="https://www.w3.org/ns/activitystreams", application/activity+json')
     req.add_headers(headers) if headers
     req.on_behalf_of(@signature_actor) if @signature_actor
 

--- a/app/services/fetch_resource_service.rb
+++ b/app/services/fetch_resource_service.rb
@@ -3,7 +3,7 @@
 class FetchResourceService < BaseService
   include JsonLdHelper
 
-  ACCEPT_HEADER = 'application/activity+json, application/ld+json; profile="https://www.w3.org/ns/activitystreams", text/html;q=0.1'
+  ACCEPT_HEADER = 'application/ld+json; profile="https://www.w3.org/ns/activitystreams", application/activity+json, text/html;q=0.1'
   ACTIVITY_STREAM_LINK_TYPES = ['application/activity+json', 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'].freeze
 
   attr_reader :response_code

--- a/app/views/accounts/show.html.haml
+++ b/app/views/accounts/show.html.haml
@@ -6,6 +6,7 @@
 
   %link{ rel: 'alternate', type: 'application/rss+xml', href: rss_url }/
   %link{ rel: 'alternate', type: 'application/activity+json', href: ActivityPub::TagManager.instance.uri_for(@account) }/
+  %link{ rel: 'alternate', type: 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"', href: ActivityPub::TagManager.instance.uri_for(@account) }/
 
   - @account.fields.select(&:verifiable?).each do |field|
     %link{ rel: 'me', type: 'text/html', href: field.value }/

--- a/app/views/statuses/show.html.haml
+++ b/app/views/statuses/show.html.haml
@@ -8,6 +8,7 @@
 
   %link{ rel: 'alternate', type: 'application/json+oembed', href: api_oembed_url(url: short_account_status_url(@account, @status), format: 'json') }/
   %link{ rel: 'alternate', type: 'application/activity+json', href: ActivityPub::TagManager.instance.uri_for(@status) }/
+  %link{ rel: 'alternate', type: 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"', href: ActivityPub::TagManager.instance.uri_for(@status) }/
 
   = opengraph 'og:site_name', site_title
   = opengraph 'og:type', 'article'

--- a/app/views/tags/show.html.haml
+++ b/app/views/tags/show.html.haml
@@ -1,6 +1,7 @@
 - content_for :header_tags do
   %link{ rel: :alternate, type: 'application/rss+xml', href: tag_url(@tag) }/
   %link{ rel: :alternate, type: 'application/activity+json', href: tag_url(@tag) }/
+  %link{ rel: :alternate, type: 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"', href: tag_url(@tag) }/
   %meta{ name: 'robots', content: 'noindex' }/
   = render partial: 'shared/og'
 


### PR DESCRIPTION
ActivityPub spec section 3.2 reads
> The client MUST specify an Accept header with the
> `application/ld+json; profile="https://www.w3.org/ns/activitystreams"`
> media type in order to retrieve the activity.

Currently Mastodon omits the profile in its dereferences (but not the fetch service) and only lists application/ld+json as one of several possible types. This breaks spec and allows spec-compliant implementations to refuse any such fetch requests.

Resolve this by adding the required profile and while at it, make the only spec-compliant type the first listed choice in all relevant places.  
While unlikely to be a problem due to other parts already including a profile, also keep a profile-less JSON-LD type where it existed before to ensure this doesn't break federation with a hypothetical buggy implemenetation relying on this current Mastodon quirk.

Section 7 also specifies the same media type MUST be used in the Content-Type header of for POST requests, but here we can't specify alternatives, so for now keep the current type.

Fixes a part of https://github.com/mastodon/mastodon/issues/22720

---

This is a more conservative alternative to #22722.
- no Accept types are removed *(keeping them is imho a good idea anyway)*
- AP S2S `POST` requests are left with the non-compliant `application/acitivity+json`; i believe those should be changed to match spec too but afaik there’s no way to do this without fully removing the current type. If there’s any interest in doing so anyway, i’d be happy to add changes for them too

With the proper spec-compliant type now being the first choice on fetches at least, hopefully we’ll get less cases like https://github.com/mastodon/mastodon/pull/22722#issuecomment-1453434362