### PR TITLE
Fix og:image requests when html in a web page is over 1.megabyte

### DIFF
--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -235,13 +235,11 @@ class Request
 
     def body_with_limit(limit = 1.megabyte)
       contents = truncated_body(limit)
-
       begin
         raise Mastodon::LengthValidationError if contents.bytesize > limit
       rescue Mastodon::LengthValidationError
-        # Raise but continue
+        # Raise but continue and return contents
       end
-    
       contents
     end
   end

--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -224,10 +224,10 @@ class Request
       contents = String.new(encoding: encoding)
 
       while (chunk = readpartial)
-        break if contents.bytesize + chunk.bytesize > limit
-
         contents << chunk
         chunk.clear
+
+        break if contents.bytesize > limit
       end
 
       contents

--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -234,12 +234,11 @@ class Request
     end
 
     def body_with_limit(limit = 1.megabyte)
+      raise Mastodon::LengthValidationError if content_length.present? && content_length > limit
+
       contents = truncated_body(limit)
-      begin
-        raise Mastodon::LengthValidationError if contents.bytesize > limit
-      rescue Mastodon::LengthValidationError
-        # Raise but continue and return contents
-      end
+      raise Mastodon::LengthValidationError if contents.bytesize > limit
+
       contents
     end
   end

--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -235,8 +235,13 @@ class Request
 
     def body_with_limit(limit = 1.megabyte)
       contents = truncated_body(limit)
-      raise Mastodon::LengthValidationError if contents.bytesize > limit
 
+      begin
+        raise Mastodon::LengthValidationError if contents.bytesize > limit
+      rescue Mastodon::LengthValidationError
+        # Raise but continue
+      end
+    
       contents
     end
   end

--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -224,18 +224,16 @@ class Request
       contents = String.new(encoding: encoding)
 
       while (chunk = readpartial)
+        break if contents.bytesize + chunk.bytesize > limit
+
         contents << chunk
         chunk.clear
-
-        break if contents.bytesize > limit
       end
 
       contents
     end
 
     def body_with_limit(limit = 1.megabyte)
-      raise Mastodon::LengthValidationError if content_length.present? && content_length > limit
-
       contents = truncated_body(limit)
       raise Mastodon::LengthValidationError if contents.bytesize > limit
 

--- a/app/services/fetch_link_card_service.rb
+++ b/app/services/fetch_link_card_service.rb
@@ -56,7 +56,7 @@ class FetchLinkCardService < BaseService
 
       @html_charset = res.charset
 
-      res.body_with_limit
+      res.truncated_body
     end
   end
 


### PR DESCRIPTION
When truncating we were adding the chunk and then checking if it was over 1MB. This meant that it was always over 1MB with that included chunk. You need to check before adding the chunk, otherwise it will always fail. Sites like the New Yorker and Wired often have 1MB + html in their articles now (not good but what can you do).

This seems to fix a bunch of issues dealing with preview images not loading which were originally thought to be webp or avif errors: #18762 #14983 #27370 (but not all of them ie. The Guardian images seem to be having issues with a certain CDN key or something. Anyway, this should fix bunch of stuff because it won't raise the error and stop the return.)

ps. I haven't written much Ruby before so feel free to make any changes etc.