### PR TITLE
Fix yarn.lock diff

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -15344,7 +15344,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"scheduler@npm:^0.23.0, scheduler@npm:^0.23.2":
+"scheduler@npm:^0.23.2":
   version: 0.23.2
   resolution: "scheduler@npm:0.23.2"
   dependencies:


### PR DESCRIPTION
CI is failing from a minor lockfile issue. Ran `yarn` locally to fix the minor diff