### PR TITLE
Raise exceptions on unpermitted parameters errors in test environment

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -21,6 +21,9 @@ Rails.application.configure do
 
   config.assets_digest = false
 
+  # Raise exceptions on unpermitted parameters errors
+  config.action_controller.action_on_unpermitted_parameters = :raise
+
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false


### PR DESCRIPTION
The default here is `:log` for all envs - which means right now in the logs during local dev, spec runs, etc - there are various areas where we have params issues and they sort of just silently go by in the log without more attention called to them.

This PR is going to fail CI, and I'm going to open up some follow-up PRs linking back to this with the various changes needed to enable this setting for test env. If we get them all in, I'll rebase this and we can contemplate merge for the setting itself.