### PR TITLE
Use correct params in `v1/admin/domain_allows` spec

### DIFF
--- a/spec/requests/api/v1/admin/domain_allows_spec.rb
+++ b/spec/requests/api/v1/admin/domain_allows_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe 'Domain Allows' do
     end
 
     context 'with invalid domain name' do
-      let(:params) { 'foo bar' }
+      let(:params) { { domain: 'foo bar' } }
 
       it 'returns http unprocessable entity' do
         subject


### PR DESCRIPTION
Related to https://github.com/mastodon/mastodon/pull/30377

In this case, the request spec is effectively sending `{ foo: 'bar' }` which it turns out is also invalid and gets the same code - but I believe the intention is to send a valid param with an invalid domain value.