### PR TITLE
Use correct params in `settings/preferences/appearance` spec

### DIFF
--- a/spec/controllers/settings/preferences/appearance_controller_spec.rb
+++ b/spec/controllers/settings/preferences/appearance_controller_spec.rb
@@ -23,8 +23,11 @@ describe Settings::Preferences::AppearanceController do
   end
 
   describe 'PUT #update' do
+    subject { put :update, params: { user: { settings_attributes: { theme: 'contrast' } } } }
+
     it 'redirects correctly' do
-      put :update, params: { user: { setting_theme: 'contrast' } }
+      expect { subject }
+        .to change { user.reload.settings.theme }.to('contrast')
 
       expect(response).to redirect_to(settings_preferences_appearance_path)
     end


### PR DESCRIPTION
Related to https://github.com/mastodon/mastodon/pull/30377

This spec was sending the wrong params based on how the form works (maybe this changed at some point? maybe this spec was never useful?), but since there was no assertion other than the redirect that happens in all cases, it passed.

Changed the params sent to match what the view generates and controller expects (side note: this issue is part of the motivation to move more of these to be system specs); and added an assertion which checks more than just the redirect.