### PR TITLE
Extract `PERMITTED_PARAMS` constant from `admin/domain_blocks` controller

### DIFF
--- a/app/controllers/admin/domain_blocks_controller.rb
+++ b/app/controllers/admin/domain_blocks_controller.rb
@@ -4,6 +4,18 @@ module Admin
   class DomainBlocksController < BaseController
     before_action :set_domain_block, only: [:destroy, :edit, :update]
 
+    PERMITTED_PARAMS = %i(
+      domain
+      obfuscate
+      private_comment
+      public_comment
+      reject_media
+      reject_reports
+      severity
+    ).freeze
+
+    PERMITTED_UPDATE_PARAMS = PERMITTED_PARAMS.without(:domain).freeze
+
     def batch
       authorize :domain_block, :create?
       @form = Form::DomainBlockBatch.new(form_domain_block_batch_params.merge(current_account: current_account, action: action_from_button))
@@ -88,11 +100,17 @@ module Admin
     end
 
     def update_params
-      params.require(:domain_block).permit(:severity, :reject_media, :reject_reports, :private_comment, :public_comment, :obfuscate)
+      params
+        .require(:domain_block)
+        .slice(*PERMITTED_UPDATE_PARAMS)
+        .permit(*PERMITTED_UPDATE_PARAMS)
     end
 
     def resource_params
-      params.require(:domain_block).permit(:domain, :severity, :reject_media, :reject_reports, :private_comment, :public_comment, :obfuscate)
+      params
+        .require(:domain_block)
+        .slice(*PERMITTED_PARAMS)
+        .permit(*PERMITTED_PARAMS)
     end
 
     def form_domain_block_batch_params


### PR DESCRIPTION
Related to https://github.com/mastodon/mastodon/pull/30377

A few changes here:

- The core change related to linked issue is the addition of `slice` in both _params methods, which limits the params passed in to the create or update to just those relevant to the operation (without that, there is a failure related to the presence of the `:domain` param on the update action in the linked PR
- Extract the list of repeated param names to constant in controller
- Since the create/update lists only differ by one value, call that out more explicitly (better future proofing to adding a param)

This PR is representative of the whole bunch of them in the branch for solving the linked PR errors. I'm going to open just this one for now, and will only open the others if/when we work through review/merge for this one.