### PR TITLE
Add timeline of public posts about a trending link to REST API

### DIFF
--- a/app/controllers/api/v1/timelines/link_controller.rb
+++ b/app/controllers/api/v1/timelines/link_controller.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+class Api::V1::Timelines::LinkController < Api::V1::Timelines::BaseController
+  before_action -> { doorkeeper_authorize! :read, :'read:statuses' }, only: :show, if: :require_auth?
+  before_action :set_preview_card
+  before_action :set_statuses
+
+  PERMITTED_PARAMS = %i(
+    url
+    limit
+  ).freeze
+
+  def show
+    cache_if_unauthenticated!
+    render json: @statuses, each_serializer: REST::StatusSerializer, relationships: StatusRelationshipsPresenter.new(@statuses, current_user&.account_id)
+  end
+
+  private
+
+  def require_auth?
+    !Setting.timeline_preview
+  end
+
+  def set_preview_card
+    @preview_card = PreviewCard.joins(:trend).merge(PreviewCardTrend.allowed).find_by!(url: params[:url])
+  end
+
+  def set_statuses
+    @statuses = @preview_card.nil? ? [] : preload_collection(link_timeline_statuses, Status)
+  end
+
+  def link_timeline_statuses
+    link_feed.get(
+      limit_param(DEFAULT_STATUSES_LIMIT),
+      params[:max_id],
+      params[:since_id],
+      params[:min_id]
+    )
+  end
+
+  def link_feed
+    LinkFeed.new(@preview_card, current_account)
+  end
+
+  def next_path
+    api_v1_timelines_link_url next_path_params
+  end
+
+  def prev_path
+    api_v1_timelines_link_url prev_path_params
+  end
+end

--- a/app/models/link_feed.rb
+++ b/app/models/link_feed.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class LinkFeed < PublicFeed
+  # @param [PreviewCard] preview_card
+  # @param [Account] account
+  # @param [Hash] options
+  def initialize(preview_card, account, options = {})
+    @preview_card = preview_card
+    super(account, options)
+  end
+
+  # @param [Integer] limit
+  # @param [Integer] max_id
+  # @param [Integer] since_id
+  # @param [Integer] min_id
+  # @return [Array<Status>]
+  def get(limit, max_id = nil, since_id = nil, min_id = nil)
+    scope = public_scope
+
+    scope.merge!(discoverable)
+    scope.merge!(attached_to_preview_card)
+
+    scope.to_a_paginated_by_id(limit, max_id: max_id, since_id: since_id, min_id: min_id)
+  end
+
+  private
+
+  def attached_to_preview_card
+    Status.joins(:preview_cards_status).where(preview_cards_status: { preview_card_id: @preview_card.id })
+  end
+
+  def discoverable
+    Account.discoverable
+  end
+end

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -39,6 +39,7 @@ namespace :api, format: false do
     namespace :timelines do
       resource :home, only: :show, controller: :home
       resource :public, only: :show, controller: :public
+      resource :link, only: :show, controller: :link
       resources :tag, only: :show
       resources :list, only: :show
     end

--- a/spec/requests/api/v1/timelines/link_spec.rb
+++ b/spec/requests/api/v1/timelines/link_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Link' do
+  let(:user)    { Fabricate(:user) }
+  let(:scopes)  { 'read:statuses' }
+  let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
+  let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
+
+  shared_examples 'a successful request to the link timeline' do
+    it 'returns the expected statuses successfully', :aggregate_failures do
+      subject
+
+      expect(response).to have_http_status(200)
+      expect(body_as_json.pluck(:id)).to match_array(expected_statuses.map { |status| status.id.to_s })
+    end
+  end
+
+  describe 'GET /api/v1/timelines/link' do
+    subject do
+      get '/api/v1/timelines/link', headers: headers, params: params
+    end
+
+    let(:url) { 'https://example.com/' }
+    let(:private_status) { Fabricate(:status, visibility: :private) }
+    let(:undiscoverable_status) { Fabricate(:status, account: Fabricate.build(:account, domain: nil, discoverable: false)) }
+    let(:local_status) { Fabricate(:status, account: Fabricate.build(:account, domain: nil, discoverable: true)) }
+    let(:remote_status) { Fabricate(:status, account: Fabricate.build(:account, domain: 'example.com', discoverable: true)) }
+    let(:params) { { url: url } }
+    let(:expected_statuses) { [local_status, remote_status] }
+    let(:preview_card) { Fabricate(:preview_card, url: url) }
+
+    before do
+      if preview_card.present?
+        preview_card.create_trend!(allowed: true)
+
+        [private_status, undiscoverable_status, remote_status, local_status].each do |status|
+          PreviewCardsStatus.create(status: status, preview_card: preview_card, url: url)
+        end
+      end
+    end
+
+    context 'when there is no preview card' do
+      let(:preview_card) { nil }
+
+      it 'returns http not found' do
+        subject
+
+        expect(response).to have_http_status(404)
+      end
+    end
+
+    context 'when preview card is not trending' do
+      before do
+        preview_card.trend.destroy!
+      end
+
+      it 'returns http not found' do
+        subject
+
+        expect(response).to have_http_status(404)
+      end
+    end
+
+    context 'when preview card is trending but not approved' do
+      before do
+        preview_card.trend.update(allowed: false)
+      end
+
+      it 'returns http not found' do
+        subject
+
+        expect(response).to have_http_status(404)
+      end
+    end
+
+    context 'when the instance does not allow public preview' do
+      before do
+        Form::AdminSettings.new(timeline_preview: false).save
+      end
+
+      context 'when the user is not authenticated' do
+        let(:headers) { {} }
+
+        it 'returns http unauthorized' do
+          subject
+
+          expect(response).to have_http_status(401)
+        end
+      end
+
+      context 'when the user is authenticated' do
+        it_behaves_like 'a successful request to the link timeline'
+      end
+    end
+
+    context 'when the instance allows public preview' do
+      context 'with an authorized user' do
+        it_behaves_like 'a successful request to the link timeline'
+      end
+
+      context 'with an anonymous user' do
+        let(:headers) { {} }
+
+        it_behaves_like 'a successful request to the link timeline'
+      end
+
+      context 'with limit param' do
+        let(:params) { { limit: 1, url: url } }
+
+        it 'returns only the requested number of statuses', :aggregate_failures do
+          subject
+
+          expect(response).to have_http_status(200)
+          expect(body_as_json.size).to eq(params[:limit])
+        end
+
+        it 'sets the correct pagination headers', :aggregate_failures do
+          subject
+
+          expect(response)
+            .to include_pagination_headers(
+              prev: api_v1_timelines_link_url(limit: params[:limit], url: url, min_id: local_status.id),
+              next: api_v1_timelines_link_url(limit: params[:limit], url: url, max_id: local_status.id)
+            )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
While a link is trending, allow browsing posts that include it, as long as the authors are opted-in to being discoverable.

The endpoint is `GET /api/v1/timelines/link?url=:url`

___

Fixes MAS-19