### PR TITLE
Fix admin/accounts/:id page when user is deleted locally

### DIFF
--- a/app/helpers/email_helper.rb
+++ b/app/helpers/email_helper.rb
@@ -6,6 +6,8 @@ module EmailHelper
   end
 
   def email_to_canonical_email(str)
+    return nil if str.nil?
+
     username, domain = str.downcase.split('@', 2)
     username, = username.delete('.').split('+', 2)
 
@@ -13,6 +15,8 @@ module EmailHelper
   end
 
   def email_to_canonical_email_hash(str)
+    return nil if str.nil?
+
     Digest::SHA2.new(256).hexdigest(email_to_canonical_email(str))
   end
 end


### PR DESCRIPTION
admin/accounts/:id page was broken on deleted local user.
This PR will fix that