### PR TITLE
Revert "Allow unblocking email addresses from any matching account (#29305)"

### DIFF
--- a/app/controllers/admin/accounts_controller.rb
+++ b/app/controllers/admin/accounts_controller.rb
@@ -128,7 +128,7 @@ module Admin
     def unblock_email
       authorize @account, :unblock_email?
 
-      CanonicalEmailBlock.matching_account(@account).delete_all
+      CanonicalEmailBlock.where(reference_account: @account).delete_all
 
       log_action :unblock_email, @account
 

--- a/app/models/canonical_email_block.rb
+++ b/app/models/canonical_email_block.rb
@@ -20,7 +20,6 @@ class CanonicalEmailBlock < ApplicationRecord
   validates :canonical_email_hash, presence: true, uniqueness: true
 
   scope :matching_email, ->(email) { where(canonical_email_hash: email_to_canonical_email_hash(email)) }
-  scope :matching_account, ->(account) { matching_email(account&.user_email).or(where(reference_account: account)) }
 
   def to_log_human_identifier
     canonical_email_hash

--- a/app/views/admin/accounts/show.html.haml
+++ b/app/views/admin/accounts/show.html.haml
@@ -30,7 +30,7 @@
 = render 'admin/accounts/counters', account: @account
 
 - if @account.local? && @account.user.nil?
-  = link_to t('admin.accounts.unblock_email'), unblock_email_admin_account_path(@account.id), method: :post, class: 'button' if can?(:unblock_email, @account) && CanonicalEmailBlock.matching_account(@account).exists?
+  = link_to t('admin.accounts.unblock_email'), unblock_email_admin_account_path(@account.id), method: :post, class: 'button' if can?(:unblock_email, @account) && CanonicalEmailBlock.exists?(reference_account_id: @account.id)
 - else
   .table-wrapper
     %table.table.inline-table

--- a/spec/fabricators/canonical_email_block_fabricator.rb
+++ b/spec/fabricators/canonical_email_block_fabricator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 Fabricator(:canonical_email_block) do
-  email { |attrs| attrs[:reference_account] ? attrs[:reference_account].user_email : sequence(:email) { |i| "#{i}#{Faker::Internet.email}" } }
+  email { sequence(:email) { |i| "#{i}#{Faker::Internet.email}" } }
   reference_account { Fabricate.build(:account) }
 end


### PR DESCRIPTION
This reverts commit 8a1423a47425dd67615e94bdfd13d64b53676da4.

Fixes #29807

The implementation of #29305 was misguided and caused an error, while bringing no functionality. There are other ways to fix the error, but implementing the actual feature the PR aimed to will require more work.