### PR TITLE
Fix announcements icon rotating like settings one

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -4372,7 +4372,7 @@ a.status-card {
       color: $primary-text-color;
     }
 
-    .icon {
+    .icon-sliders {
       transform: rotate(60deg);
     }
   }
@@ -4383,7 +4383,7 @@ a.status-card {
   }
 }
 
-.no-reduce-motion .column-header__button .icon {
+.no-reduce-motion .column-header__button .icon-sliders {
   transition: transform 150ms ease-in-out;
 }
 


### PR DESCRIPTION
One more issue raised with the rotating settings button: announcements icon rotates as well. Changed the selector from `.icon` to `.icon-sliders` to fix this

![Screenshot from 2024-05-21 16-42-03](https://github.com/mastodon/mastodon/assets/77155297/5ee4559c-1eed-4aad-bcc0-f81625b3e298)