### PR TITLE
Wrap common http-level errors into array constant

### DIFF
--- a/app/controllers/concerns/api/error_handling.rb
+++ b/app/controllers/concerns/api/error_handling.rb
@@ -20,12 +20,12 @@ module Api::ErrorHandling
       render json: { error: 'Record not found' }, status: 404
     end
 
-    rescue_from(*Mastodon::HTTP_CONNECTION_ERRORS, Mastodon::UnexpectedResponseError) do
-      render json: { error: 'Remote data could not be fetched' }, status: 503
-    end
-
     rescue_from OpenSSL::SSL::SSLError do
       render json: { error: 'Remote SSL certificate could not be verified' }, status: 503
+    end
+
+    rescue_from(*Mastodon::HTTP_CONNECTION_ERRORS) do
+      render json: { error: 'Remote data could not be fetched' }, status: 503
     end
 
     rescue_from Mastodon::NotPermittedError do

--- a/app/controllers/concerns/signature_verification.rb
+++ b/app/controllers/concerns/signature_verification.rb
@@ -80,12 +80,12 @@ module SignatureVerification
     fail_with! "Verification failed for #{actor.to_log_human_identifier} #{actor.uri} using rsa-sha256 (RSASSA-PKCS1-v1_5 with SHA-256)", signed_string: compare_signed_string, signature: signature_params['signature']
   rescue SignatureVerificationError => e
     fail_with! e.message
-  rescue *Mastodon::HTTP_CONNECTION_ERRORS => e
-    fail_with! "Failed to fetch remote data: #{e.message}"
   rescue Mastodon::UnexpectedResponseError
     fail_with! 'Failed to fetch remote data (got unexpected reply from server)'
   rescue Stoplight::Error::RedLight
     fail_with! 'Fetching attempt skipped because of recent connection failure'
+  rescue *Mastodon::HTTP_CONNECTION_ERRORS => e
+    fail_with! "Failed to fetch remote data: #{e.message}"
   end
 
   def request_body

--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -250,7 +250,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
         media_attachment.download_file!
         media_attachment.download_thumbnail!
         media_attachment.save
-      rescue Mastodon::UnexpectedResponseError, *Mastodon::HTTP_CONNECTION_ERRORS
+      rescue *Mastodon::HTTP_CONNECTION_ERRORS
         RedownloadMediaWorker.perform_in(rand(30..600).seconds, media_attachment.id)
       rescue Seahorse::Client::NetworkingError => e
         Rails.logger.warn "Error storing media attachment: #{e}"

--- a/app/models/account_alias.rb
+++ b/app/models/account_alias.rb
@@ -35,7 +35,7 @@ class AccountAlias < ApplicationRecord
   def set_uri
     target_account = ResolveAccountService.new.call(acct)
     self.uri       = ActivityPub::TagManager.instance.uri_for(target_account) unless target_account.nil?
-  rescue Webfinger::Error, *Mastodon::HTTP_CONNECTION_ERRORS, Mastodon::Error
+  rescue Webfinger::Error, *Mastodon::HTTP_CONNECTION_ERRORS
     # Validation will take care of it
   end
 

--- a/app/models/account_migration.rb
+++ b/app/models/account_migration.rb
@@ -61,7 +61,7 @@ class AccountMigration < ApplicationRecord
 
   def set_target_account
     self.target_account = ResolveAccountService.new.call(acct, skip_cache: true)
-  rescue Webfinger::Error, *Mastodon::HTTP_CONNECTION_ERRORS, Mastodon::Error, Addressable::URI::InvalidURIError
+  rescue Webfinger::Error, Mastodon::Error, *Mastodon::HTTP_CONNECTION_ERRORS
     # Validation will take care of it
   end
 

--- a/app/models/concerns/remotable.rb
+++ b/app/models/concerns/remotable.rb
@@ -26,7 +26,7 @@ module Remotable
 
             public_send(:"#{attachment_name}=", ResponseWithLimit.new(response, limit))
           end
-        rescue Mastodon::UnexpectedResponseError, *Mastodon::HTTP_CONNECTION_ERRORS => e
+        rescue *Mastodon::HTTP_CONNECTION_ERRORS => e
           Rails.logger.debug { "Error fetching remote #{attachment_name}: #{e}" }
           public_send(:"#{attachment_name}=", nil) if public_send(:"#{attachment_name}_file_name").present?
           raise e unless suppress_errors

--- a/app/models/form/redirect.rb
+++ b/app/models/form/redirect.rb
@@ -32,7 +32,7 @@ class Form::Redirect
 
   def set_target_account
     @target_account = ResolveAccountService.new.call(acct, skip_cache: true)
-  rescue Webfinger::Error, *Mastodon::HTTP_CONNECTION_ERRORS, Mastodon::Error, Addressable::URI::InvalidURIError
+  rescue Webfinger::Error, Mastodon::Error, *Mastodon::HTTP_CONNECTION_ERRORS
     # Validation will take care of it
   end
 

--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -127,13 +127,13 @@ class ActivityPub::ProcessAccountService < BaseService
     begin
       @account.avatar_remote_url = image_url('icon') || '' unless skip_download?
       @account.avatar = nil if @account.avatar_remote_url.blank?
-    rescue Mastodon::UnexpectedResponseError, *Mastodon::HTTP_CONNECTION_ERRORS
+    rescue *Mastodon::HTTP_CONNECTION_ERRORS
       RedownloadAvatarWorker.perform_in(rand(30..600).seconds, @account.id)
     end
     begin
       @account.header_remote_url = image_url('image') || '' unless skip_download?
       @account.header = nil if @account.header_remote_url.blank?
-    rescue Mastodon::UnexpectedResponseError, *Mastodon::HTTP_CONNECTION_ERRORS
+    rescue *Mastodon::HTTP_CONNECTION_ERRORS
       RedownloadHeaderWorker.perform_in(rand(30..600).seconds, @account.id)
     end
     @account.statuses_count    = outbox_total_items    if outbox_total_items.present?
@@ -276,7 +276,7 @@ class ActivityPub::ProcessAccountService < BaseService
     total_items = collection.is_a?(Hash) && collection['totalItems'].present? && collection['totalItems'].is_a?(Numeric) ? collection['totalItems'] : nil
     has_first_page = collection.is_a?(Hash) && collection['first'].present?
     @collections[type] = [total_items, has_first_page]
-  rescue *Mastodon::HTTP_CONNECTION_ERRORS, Mastodon::LengthValidationError
+  rescue *Mastodon::HTTP_CONNECTION_ERRORS
     @collections[type] = [nil, nil]
   end
 

--- a/app/services/activitypub/process_status_update_service.rb
+++ b/app/services/activitypub/process_status_update_service.rb
@@ -109,7 +109,7 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
       media_attachment.download_file! if media_attachment.remote_url_previously_changed?
       media_attachment.download_thumbnail! if media_attachment.thumbnail_remote_url_previously_changed?
       media_attachment.save
-    rescue Mastodon::UnexpectedResponseError, *Mastodon::HTTP_CONNECTION_ERRORS
+    rescue *Mastodon::HTTP_CONNECTION_ERRORS
       RedownloadMediaWorker.perform_in(rand(30..600).seconds, media_attachment.id)
     rescue Seahorse::Client::NetworkingError => e
       Rails.logger.warn "Error storing media attachment: #{e}"

--- a/app/services/fetch_link_card_service.rb
+++ b/app/services/fetch_link_card_service.rb
@@ -29,7 +29,7 @@ class FetchLinkCardService < BaseService
     end
 
     attach_card if @card&.persisted?
-  rescue *Mastodon::HTTP_CONNECTION_ERRORS, Addressable::URI::InvalidURIError, Mastodon::HostValidationError, Mastodon::LengthValidationError, Encoding::UndefinedConversionError, ActiveRecord::RecordInvalid => e
+  rescue *Mastodon::HTTP_CONNECTION_ERRORS, Encoding::UndefinedConversionError, ActiveRecord::RecordInvalid => e
     Rails.logger.debug { "Error fetching link #{@original_url}: #{e}" }
     nil
   end

--- a/app/services/fetch_resource_service.rb
+++ b/app/services/fetch_resource_service.rb
@@ -12,7 +12,7 @@ class FetchResourceService < BaseService
     return if url.blank?
 
     process(url)
-  rescue *Mastodon::HTTP_CONNECTION_ERRORS, Addressable::URI::InvalidURIError, Mastodon::HostValidationError, Mastodon::LengthValidationError => e
+  rescue *Mastodon::HTTP_CONNECTION_ERRORS => e
     Rails.logger.debug { "Error fetching resource #{@url}: #{e}" }
     nil
   end

--- a/app/services/import_service.rb
+++ b/app/services/import_service.rb
@@ -115,7 +115,7 @@ class ImportService < BaseService
       next if status.nil? && ActivityPub::TagManager.instance.local_uri?(uri)
 
       status || ActivityPub::FetchRemoteStatusService.new.call(uri)
-    rescue *Mastodon::HTTP_CONNECTION_ERRORS, Mastodon::UnexpectedResponseError
+    rescue *Mastodon::HTTP_CONNECTION_ERRORS
       nil
     rescue => e
       Rails.logger.warn "Unexpected error when importing bookmark: #{e}"

--- a/app/services/process_mentions_service.rb
+++ b/app/services/process_mentions_service.rb
@@ -44,7 +44,7 @@ class ProcessMentionsService < BaseService
       if mention_undeliverable?(mentioned_account)
         begin
           mentioned_account = ResolveAccountService.new.call(Regexp.last_match(1))
-        rescue Webfinger::Error, *Mastodon::HTTP_CONNECTION_ERRORS, Mastodon::UnexpectedResponseError
+        rescue Webfinger::Error, *Mastodon::HTTP_CONNECTION_ERRORS
           mentioned_account = nil
         end
       end

--- a/app/services/verify_link_service.rb
+++ b/app/services/verify_link_service.rb
@@ -10,7 +10,7 @@ class VerifyLinkService < BaseService
     return unless link_back_present?
 
     field.mark_verified!
-  rescue *Mastodon::HTTP_CONNECTION_ERRORS, Addressable::URI::InvalidURIError, Mastodon::HostValidationError, Mastodon::LengthValidationError, IPAddr::AddressFamilyError => e
+  rescue *Mastodon::HTTP_CONNECTION_ERRORS => e
     Rails.logger.debug { "Error fetching link #{@url}: #{e}" }
     nil
   end

--- a/app/workers/refollow_worker.rb
+++ b/app/workers/refollow_worker.rb
@@ -21,7 +21,7 @@ class RefollowWorker
       # Schedule re-follow
       begin
         FollowService.new.call(follower, target_account, reblogs: reblogs, notify: notify, languages: languages, bypass_limit: true)
-      rescue Mastodon::NotPermittedError, ActiveRecord::RecordNotFound, Mastodon::UnexpectedResponseError, *Mastodon::HTTP_CONNECTION_ERRORS
+      rescue Mastodon::NotPermittedError, ActiveRecord::RecordNotFound, *Mastodon::HTTP_CONNECTION_ERRORS
         next
       end
     end

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -39,14 +39,14 @@ module Mastodon
 
   HTTP_CONNECTION_ERRORS = [
     Addressable::URI::InvalidURIError,
+    HostValidationError,
     HTTP::ConnectionError,
     HTTP::Error,
     HTTP::TimeoutError,
     IPAddr::AddressFamilyError,
-    Mastodon::HostValidationError,
-    Mastodon::LengthValidationError,
-    Mastodon::PrivateNetworkAddressError,
-    Mastodon::UnexpectedResponseError,
+    LengthValidationError,
     OpenSSL::SSL::SSLError,
+    PrivateNetworkAddressError,
+    UnexpectedResponseError,
   ].freeze
 end

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -38,9 +38,15 @@ module Mastodon
   end
 
   HTTP_CONNECTION_ERRORS = [
+    Addressable::URI::InvalidURIError,
     HTTP::ConnectionError,
     HTTP::Error,
     HTTP::TimeoutError,
+    IPAddr::AddressFamilyError,
+    Mastodon::HostValidationError,
+    Mastodon::LengthValidationError,
+    Mastodon::PrivateNetworkAddressError,
+    Mastodon::UnexpectedResponseError,
     OpenSSL::SSL::SSLError,
   ].freeze
 end

--- a/lib/mastodon/cli/accounts.rb
+++ b/lib/mastodon/cli/accounts.rb
@@ -305,7 +305,7 @@ module Mastodon::CLI
 
         begin
           code = Request.new(:head, account.uri).perform(&:code)
-        rescue *Mastodon::HTTP_CONNECTION_ERRORS, Mastodon::PrivateNetworkAddressError
+        rescue *Mastodon::HTTP_CONNECTION_ERRORS
           skip_domains << account.domain
         end
 


### PR DESCRIPTION
Several motivations here:

- Many of these error catching locations have either an exact set or almost exact set of error classes in their list -- consolidate this down into a constant to DRY up and consolidate that list
- After discussion with renchap about possible HTTP.rb -> HTTPX migration, this is a first pass at reducing the number of spots across the codebase that various `HTTP::...` names are referenced directly

Some observations:

- This is sort of a first-pass at the approach, there are more places that may fit in here but I wanted to just do a quick high level pass to show the concept and only include most obvious spots at first.
- In a few places this leads to an effectivley larger list of caught error classes since not every location is the EXACT same list ... but in every spot here, I think it's actually harmless and (with a few exceptions) there's only one handling path
- In a few spots where we had a more narrow handling for one of the classes, I've changed the order to preserve the previous behavior and make sure the narrower rescue is first (one in api error handling, one in sig verification)
- Open to different naming or organizational ideas for the constant itself (ie, make it up of narrower different named groups? something else?)