### PR TITLE
Remove unused account record in api/v2/admin/accounts spec

### DIFF
--- a/spec/requests/api/v2/admin/accounts_spec.rb
+++ b/spec/requests/api/v2/admin/accounts_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe 'API V2 Admin Accounts' do
   let(:scopes) { 'admin:read admin:write' }
   let(:token)  { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
-  let(:account) { Fabricate(:account) }
 
   describe 'GET #index' do
     let!(:remote_account)       { Fabricate(:account, domain: 'example.org') }


### PR DESCRIPTION
While looking at - https://github.com/mastodon/mastodon/pull/30354#issuecomment-2120394984 - for intermittent failure causes, I noticed that this record is never used in the spec (and never has been since introduced in https://github.com/mastodon/mastodon/pull/17887)

Still haven't been able to replicate the failure from that CI run.