### PR TITLE
Fix some API calls that should not use an API token

### DIFF
--- a/app/javascript/mastodon/api.ts
+++ b/app/javascript/mastodon/api.ts
@@ -40,11 +40,11 @@ const authorizationTokenFromInitialState = (): RawAxiosRequestHeaders => {
 };
 
 // eslint-disable-next-line import/no-default-export
-export default function api() {
+export default function api(withAuthorization = true) {
   return axios.create({
     headers: {
       ...csrfHeader,
-      ...authorizationTokenFromInitialState(),
+      ...(withAuthorization ? authorizationTokenFromInitialState() : {}),
     },
 
     transformResponse: [

--- a/app/javascript/mastodon/components/admin/Counter.jsx
+++ b/app/javascript/mastodon/components/admin/Counter.jsx
@@ -48,7 +48,7 @@ export default class Counter extends PureComponent {
   componentDidMount () {
     const { measure, start_at, end_at, params } = this.props;
 
-    api().post('/api/v1/admin/measures', { keys: [measure], start_at, end_at, [measure]: params }).then(res => {
+    api(false).post('/api/v1/admin/measures', { keys: [measure], start_at, end_at, [measure]: params }).then(res => {
       this.setState({
         loading: false,
         data: res.data,

--- a/app/javascript/mastodon/components/admin/Dimension.jsx
+++ b/app/javascript/mastodon/components/admin/Dimension.jsx
@@ -26,7 +26,7 @@ export default class Dimension extends PureComponent {
   componentDidMount () {
     const { start_at, end_at, dimension, limit, params } = this.props;
 
-    api().post('/api/v1/admin/dimensions', { keys: [dimension], start_at, end_at, limit, [dimension]: params }).then(res => {
+    api(false).post('/api/v1/admin/dimensions', { keys: [dimension], start_at, end_at, limit, [dimension]: params }).then(res => {
       this.setState({
         loading: false,
         data: res.data,

--- a/app/javascript/mastodon/components/admin/ImpactReport.jsx
+++ b/app/javascript/mastodon/components/admin/ImpactReport.jsx
@@ -27,7 +27,7 @@ export default class ImpactReport extends PureComponent {
       include_subdomains: true,
     };
 
-    api().post('/api/v1/admin/measures', {
+    api(false).post('/api/v1/admin/measures', {
       keys: ['instance_accounts', 'instance_follows', 'instance_followers'],
       start_at: null,
       end_at: null,

--- a/app/javascript/mastodon/components/admin/ReportReasonSelector.jsx
+++ b/app/javascript/mastodon/components/admin/ReportReasonSelector.jsx
@@ -105,7 +105,7 @@ class ReportReasonSelector extends PureComponent {
   };
 
   componentDidMount() {
-    api().get('/api/v1/instance').then(res => {
+    api(false).get('/api/v1/instance').then(res => {
       this.setState({
         rules: res.data.rules,
       });
@@ -122,7 +122,7 @@ class ReportReasonSelector extends PureComponent {
       return;
     }
 
-    api().put(`/api/v1/admin/reports/${id}`, {
+    api(false).put(`/api/v1/admin/reports/${id}`, {
       category,
       rule_ids: category === 'violation' ? rule_ids : [],
     }).catch(err => {

--- a/app/javascript/mastodon/components/admin/Retention.jsx
+++ b/app/javascript/mastodon/components/admin/Retention.jsx
@@ -34,7 +34,7 @@ export default class Retention extends PureComponent {
   componentDidMount () {
     const { start_at, end_at, frequency } = this.props;
 
-    api().post('/api/v1/admin/retention', { start_at, end_at, frequency }).then(res => {
+    api(false).post('/api/v1/admin/retention', { start_at, end_at, frequency }).then(res => {
       this.setState({
         loading: false,
         data: res.data,

--- a/app/javascript/mastodon/components/admin/Trends.jsx
+++ b/app/javascript/mastodon/components/admin/Trends.jsx
@@ -22,7 +22,7 @@ export default class Trends extends PureComponent {
   componentDidMount () {
     const { limit } = this.props;
 
-    api().get('/api/v1/admin/trends/tags', { params: { limit } }).then(res => {
+    api(false).get('/api/v1/admin/trends/tags', { params: { limit } }).then(res => {
       this.setState({
         loading: false,
         data: res.data,


### PR DESCRIPTION
When in the admin panel, calls to the API should not pass an `authorization` token, because the token is not valid for this scope. They should not pass a token, so the cookie authentication is used and they have access to the full scope.

I prefered a `withAuthorization` parameter rather than `skipAuthorization`, so the callsite is `api(false)` rather than `api(true)` when you dont want to use the token.

This was introduced in https://github.com/mastodon/mastodon/pull/30275