### PR TITLE
Fix a leftover argument to `api()`

### DIFF
--- a/app/javascript/mastodon/features/hashtag_timeline/containers/column_settings_container.js
+++ b/app/javascript/mastodon/features/hashtag_timeline/containers/column_settings_container.js
@@ -15,7 +15,7 @@ const mapStateToProps = (state, { columnId }) => {
   return {
     settings: columns.get(index).get('params'),
     onLoad (value) {
-      return api(() => state).get('/api/v2/search', { params: { q: value, type: 'hashtags' } }).then(response => {
+      return api().get('/api/v2/search', { params: { q: value, type: 'hashtags' } }).then(response => {
         return (response.data.hashtags || []).map((tag) => {
           return { value: tag.name, label: `#${tag.name}` };
         });


### PR DESCRIPTION
Forgot this one. It does not create a bug as a function is equivalent to `true`.

I went through all the calls to `api()` that my editor found and they should all be good.