### PR TITLE
Drop compatibility with Redis < 6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Mastodon is a **free, open-source social network server** based on ActivityPub w
 ### Requirements
 
 - **PostgreSQL** 12+
-- **Redis** 4+
+- **Redis** 6.2+
 - **Ruby** 3.2+
 - **Node.js** 18+
 

--- a/app/controllers/auth/sessions_controller.rb
+++ b/app/controllers/auth/sessions_controller.rb
@@ -177,9 +177,7 @@ class Auth::SessionsController < Devise::SessionsController
     )
 
     # Only send a notification email every hour at most
-    return if redis.get("2fa_failure_notification:#{user.id}").present?
-
-    redis.set("2fa_failure_notification:#{user.id}", '1', ex: 1.hour)
+    return if redis.set("2fa_failure_notification:#{user.id}", '1', ex: 1.hour, get: true).present?
 
     UserMailer.failed_2fa(user, request.remote_ip, request.user_agent, Time.now.utc).deliver_later!
   end


### PR DESCRIPTION
Alternative to #30412

On the one hand, some major distributions, like Ubuntu 22.04 LTS, still ship earlier versions of Redis, so this may be a relatively disruptive change for many server administrators.

On the other hand, Redis versions earlier to 6.2 are not officially maintained anymore, and at least one of our dependencies (Stoplight) has silently dropped support for it, so maintaining compatibility with Redis < 6.2 is becoming harder.