### PR TITLE
Move `human_value` to `title` attribute in admin dashboard software version component

### DIFF
--- a/app/javascript/mastodon/components/admin/Dimension.jsx
+++ b/app/javascript/mastodon/components/admin/Dimension.jsx
@@ -1,8 +1,6 @@
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 
-import { FormattedNumber } from 'react-intl';
-
 import api from 'mastodon/api';
 import { Skeleton } from 'mastodon/components/skeleton';
 import { roundTo10 } from 'mastodon/utils/numbers';
@@ -74,7 +72,7 @@ export default class Dimension extends PureComponent {
                 </td>
 
                 <td className='dimension__item__value'>
-                  {typeof item.human_value !== 'undefined' ? item.human_value : <FormattedNumber value={item.value} />}
+                  <span title={item.human_value}>{item.value}</span>
                 </td>
               </tr>
             ))}

--- a/app/lib/admin/metrics/dimension/software_versions_dimension.rb
+++ b/app/lib/admin/metrics/dimension/software_versions_dimension.rb
@@ -14,13 +14,11 @@ class Admin::Metrics::Dimension::SoftwareVersionsDimension < Admin::Metrics::Dim
   end
 
   def mastodon_version
-    value = Mastodon::Version.to_s
-
     {
       key: 'mastodon',
       human_key: 'Mastodon',
-      value: value,
-      human_value: value,
+      value: Mastodon::Version.gem_version.to_s,
+      human_value: Mastodon::Version.to_s,
     }
   end
 
@@ -34,24 +32,27 @@ class Admin::Metrics::Dimension::SoftwareVersionsDimension < Admin::Metrics::Dim
   end
 
   def postgresql_version
-    value = ActiveRecord::Base.connection.execute('SELECT VERSION()').first['version'].match(/\A(?:PostgreSQL |)([^\s]+).*\z/)[1]
-
     {
       key: 'postgresql',
       human_key: 'PostgreSQL',
-      value: value,
-      human_value: value,
+      value: ActiveRecord::Base
+        .connection
+        .execute('SELECT VERSION()')
+        .first['version']
+        .match(/\A(?:PostgreSQL |)([^\s]+).*\z/)[1],
+      human_value: ActiveRecord::Base
+        .connection
+        .execute('SHOW server_version')
+        .first['server_version'],
     }
   end
 
   def redis_version
-    value = redis_info['redis_version']
-
     {
       key: 'redis',
       human_key: 'Redis',
-      value: value,
-      human_value: value,
+      value: redis_info['redis_version'],
+      human_value: "#{redis_info['redis_version']} (build #{redis_info['redis_build_id']})",
     }
   end
 

--- a/spec/lib/admin/metrics/dimension/software_versions_dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension/software_versions_dimension_spec.rb
@@ -14,8 +14,16 @@ describe Admin::Metrics::Dimension::SoftwareVersionsDimension do
     it 'reports on the running software' do
       expect(subject.data.map(&:symbolize_keys))
         .to include(
-          include(key: 'mastodon', value: Mastodon::Version.to_s),
-          include(key: 'ruby', value: include(RUBY_VERSION))
+          include(
+            human_value: Mastodon::Version.to_s,
+            key: 'mastodon',
+            value: Mastodon::Version.gem_version.to_s
+          ),
+          include(
+            human_value: include(RUBY_DESCRIPTION),
+            key: 'ruby',
+            value: include(RUBY_VERSION)
+          )
         )
     end
   end


### PR DESCRIPTION
Sort of a follow-up on https://github.com/mastodon/mastodon/pull/30309

That PR simplified how we build the ruby version string, but is also a bit more verbose than what was previously in place. This changes:

- The admin/dimension component to display the (generally smaller) `value` attribute in the table, and move the `human_value` to a title attribute
- Once over on all the value/human_value pairs in the dimension to have them all align with that approach

Before:

![CleanShot_2024-05-24_at_11 06 402x](https://github.com/mastodon/mastodon/assets/225/b2498dcb-3d88-4ccd-92ef-d8144e026bff)

After:

<img width="306" alt="Screenshot 2024-05-24 at 16 25 04" src="https://github.com/mastodon/mastodon/assets/225/d552dfaf-4093-48b7-a657-787371d7487a">

