### PR TITLE
Remove hard reference from status pin validator spec

### DIFF
--- a/spec/validators/status_pin_validator_spec.rb
+++ b/spec/validators/status_pin_validator_spec.rb
@@ -45,8 +45,8 @@ RSpec.describe StatusPinValidator do
       end
     end
 
-    context 'when pin.account.status_pins.count > 4 && pin.account.local?' do
-      let(:count) { 5 }
+    context 'when pin account is local and has too many pins' do
+      let(:count) { described_class::PIN_LIMIT + 1 }
       let(:local) { true }
 
       it 'calls errors.add' do


### PR DESCRIPTION
Previous PR moved this to constant but failed to update naming here.