### PR TITLE
Case correction `Github` -> `GitHub`

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -3,9 +3,9 @@ coverage:
   status:
     project:
       default:
-        # Github status check is not blocking
+        # GitHub status check is not blocking
         informational: true
     patch:
       default:
-        # Github status check is not blocking
+        # GitHub status check is not blocking
         informational: true

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -59,7 +59,7 @@
       dependencyDashboardApproval: true,
     },
     {
-      // Update Github Actions and Docker images weekly
+      // Update GitHub Actions and Docker images weekly
       matchManagers: ['github-actions', 'dockerfile', 'docker-compose'],
       extends: ['schedule:weekly'],
     },

--- a/.github/workflows/build-container-image.yml
+++ b/.github/workflows/build-container-image.yml
@@ -68,7 +68,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Log in to the Github Container registry
+      - name: Log in to the GitHub Container registry
         if: contains(inputs.push_to_images, 'ghcr.io')
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/crowdin-download.yml
+++ b/.github/workflows/crowdin-download.yml
@@ -58,13 +58,13 @@ jobs:
           title: 'New Crowdin Translations (automated)'
           author: 'GitHub Actions <noreply@github.com>'
           body: |
-            New Crowdin translations, automated with Github Actions
+            New Crowdin translations, automated with GitHub Actions
 
             See `.github/workflows/crowdin-download.yml`
 
             This PR will be updated every day with new translations.
 
-            Due to a limitation in Github Actions, checks are not running on this PR without manual action.
+            Due to a limitation in GitHub Actions, checks are not running on this PR without manual action.
             If you want to run the checks, then close and re-open it.
           branch: i18n/crowdin/translations
           base: main

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 If you believe you've identified a security vulnerability in Mastodon (a bug that allows something to happen that shouldn't be possible), you can either:
 
-- open a [Github security issue on the Mastodon project](https://github.com/mastodon/mastodon/security/advisories/new)
+- open a [GitHub security issue on the Mastodon project](https://github.com/mastodon/mastodon/security/advisories/new)
 - reach us at <security@joinmastodon.org>
 
 You should _not_ report such issues on public GitHub issues or in other public spaces to give us time to publish a fix for the issue without exposing Mastodon's users to increased risk.

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,4 +1,4 @@
-# This is needed for the Github Action
+# This is needed for the GitHub Action
 project_id_env: CROWDIN_PROJECT_ID
 api_token_env: CROWDIN_PERSONAL_TOKEN
 


### PR DESCRIPTION
This PR seemed abandoned - https://github.com/mastodon/mastodon/pull/28039 - but was pretty trivial (just a lint failure).

Rebased it and re-opening here. I've preserved author info on the original commits ... not sure if you can merge with that info, but please credit to original person if possible.