### PR TITLE
Fix leaking Elasticsearch connections in Sidekiq processes

### DIFF
--- a/lib/mastodon/sidekiq_middleware.rb
+++ b/lib/mastodon/sidekiq_middleware.rb
@@ -8,6 +8,7 @@ class Mastodon::SidekiqMiddleware
   rescue Mastodon::HostValidationError
     # Do not retry
   rescue => e
+    clean_up_elasticsearch_connections!
     limit_backtrace_and_raise(e)
   ensure
     clean_up_sockets!
@@ -23,6 +24,32 @@ class Mastodon::SidekiqMiddleware
   def clean_up_sockets!
     clean_up_redis_socket!
     clean_up_statsd_socket!
+  end
+
+  # This is a hack to immediately free up unused Elasticsearch connections.
+  #
+  # Indeed, Chewy creates one `Elasticsearch::Client` instance per thread,
+  # and each such client manages its long-lasting connection to
+  # Elasticsearch.
+  #
+  # As far as I know, neither `chewy`,  `elasticsearch-transport` or even
+  # `faraday` provide a reliable way to immediately close a connection, and
+  # rely on the underlying object to be garbage-collected instead.
+  #
+  # Furthermore, `sidekiq` creates a new thread each time a job throws an
+  # exception, meaning that each failure will create a new connection, and
+  # the old one will only be closed on full garbage collection.
+  def clean_up_elasticsearch_connections!
+    return unless Chewy.enabled? && Chewy.current[:chewy_client].present?
+
+    Chewy.client.transport.transport.connections.each do |connection|
+      # NOTE: This bit of code is tailored for the HTTPClient Faraday adapter
+      connection.connection.app.instance_variable_get(:@client)&.reset_all
+    end
+
+    Chewy.current.delete(:chewy_client)
+  rescue
+    nil
   end
 
   def clean_up_redis_socket!


### PR DESCRIPTION
Fixes #18063

This is an alternative to #27138

My understanding of the issue is that whenever a Sidekiq job fails, its thread is killed and replaced with a new one, which may eventually lead to a new Elasticsearch connection, while the old one will only be closed when the garbage collector decides to claim the connection object.

To address this, this PR adds some cleanup code in the Sidekiq error handler.

Since neither `chewy`, nor `elasticsearch-transport` or even `faraday` seem to provide a clean and reliable way to close the connections, this cleanup method breaks several layers of abstraction to call `HTTPClient#reset_all` on the underlying connections.