### PR TITLE
Consolidate account scopes for `LOWER` (index using) username/domain queries

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -142,6 +142,9 @@ class Account < ApplicationRecord
   scope :not_excluded_by_account, ->(account) { where.not(id: account.excluded_from_timeline_account_ids) }
   scope :not_domain_blocked_by_account, ->(account) { where(arel_table[:domain].eq(nil).or(arel_table[:domain].not_in(account.excluded_from_timeline_domains))) }
   scope :dormant, -> { joins(:account_stat).merge(AccountStat.without_recent_activity) }
+  scope :with_username, ->(value) { where arel_table[:username].lower.eq(value.to_s.downcase) }
+  scope :with_domain, ->(value) { where arel_table[:domain].lower.eq(value&.to_s&.downcase) }
+  scope :without_blank_username, -> { where.not arel_table[:username].lower.eq('') }
 
   after_update_commit :trigger_update_webhooks
 

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -144,7 +144,6 @@ class Account < ApplicationRecord
   scope :dormant, -> { joins(:account_stat).merge(AccountStat.without_recent_activity) }
   scope :with_username, ->(value) { where arel_table[:username].lower.eq(value.to_s.downcase) }
   scope :with_domain, ->(value) { where arel_table[:domain].lower.eq(value&.to_s&.downcase) }
-  scope :without_blank_username, -> { where.not arel_table[:username].lower.eq('') }
 
   after_update_commit :trigger_update_webhooks
 

--- a/app/models/account_suggestions/setting_source.rb
+++ b/app/models/account_suggestions/setting_source.rb
@@ -26,8 +26,8 @@ class AccountSuggestions::SettingSource < AccountSuggestions::Source
   def setting_to_where_condition
     usernames_and_domains.map do |(username, domain)|
       Arel::Nodes::Grouping.new(
-        Account.with_username(username).and(
-          Account.with_domain(domain)
+        Account.arel_table[:username].lower.eq(username.downcase).and(
+          Account.arel_table[:domain].lower.eq(domain&.downcase)
         )
       )
     end.reduce(:or)

--- a/app/models/account_suggestions/setting_source.rb
+++ b/app/models/account_suggestions/setting_source.rb
@@ -26,8 +26,8 @@ class AccountSuggestions::SettingSource < AccountSuggestions::Source
   def setting_to_where_condition
     usernames_and_domains.map do |(username, domain)|
       Arel::Nodes::Grouping.new(
-        Account.arel_table[:username].lower.eq(username.downcase).and(
-          Account.arel_table[:domain].lower.eq(domain&.downcase)
+        Account.with_username(username).and(
+          Account.with_domain(domain)
         )
       )
     end.reduce(:or)

--- a/app/models/concerns/account/finder_concern.rb
+++ b/app/models/concerns/account/finder_concern.rb
@@ -25,42 +25,11 @@ module Account::FinderConcern
     end
 
     def find_remote(username, domain)
-      AccountFinder.new(username, domain).account
-    end
-  end
-
-  class AccountFinder
-    attr_reader :username, :domain
-
-    def initialize(username, domain)
-      @username = username
-      @domain = domain
-    end
-
-    def account
-      scoped_accounts.order(id: :asc).take
-    end
-
-    private
-
-    def scoped_accounts
-      Account.unscoped.tap do |scope|
-        scope.merge! with_usernames
-        scope.merge! matching_username
-        scope.merge! matching_domain
-      end
-    end
-
-    def with_usernames
-      Account.without_blank_username
-    end
-
-    def matching_username
-      Account.with_username(username)
-    end
-
-    def matching_domain
-      Account.with_domain(domain)
+      Account
+        .with_username(username)
+        .with_domain(domain)
+        .order(id: :asc)
+        .take
     end
   end
 end

--- a/app/models/concerns/account/finder_concern.rb
+++ b/app/models/concerns/account/finder_concern.rb
@@ -52,15 +52,15 @@ module Account::FinderConcern
     end
 
     def with_usernames
-      Account.where.not(Account.arel_table[:username].lower.eq '')
+      Account.without_blank_username
     end
 
     def matching_username
-      Account.where(Account.arel_table[:username].lower.eq username.to_s.downcase)
+      Account.with_username(username)
     end
 
     def matching_domain
-      Account.where(Account.arel_table[:domain].lower.eq(domain.nil? ? nil : domain.to_s.downcase))
+      Account.with_domain(domain)
     end
   end
 end

--- a/app/models/concerns/user/ldap_authenticable.rb
+++ b/app/models/concerns/user/ldap_authenticable.rb
@@ -22,7 +22,7 @@ module User::LdapAuthenticable
         safe_username = safe_username.gsub(keys, replacement)
       end
 
-      resource = joins(:account).merge(Account.where(Account.arel_table[:username].lower.eq safe_username.downcase)).take
+      resource = joins(:account).merge(Account.with_username(safe_username)).take
 
       if resource.blank?
         resource = new(

--- a/app/services/report_service.rb
+++ b/app/services/report_service.rb
@@ -81,7 +81,7 @@ class ReportService < BaseService
 
     # If the account making reports is remote, it is likely anonymized so we have to relax the requirements for attaching statuses.
     domain = @source_account.domain.to_s.downcase
-    has_followers = @target_account.followers.where(Account.arel_table[:domain].lower.eq(domain)).exists?
+    has_followers = @target_account.followers.with_domain(domain).exists?
     visibility = has_followers ? %i(public unlisted private) : %i(public unlisted)
     scope = @target_account.statuses.with_discarded
     scope.merge!(scope.where(visibility: visibility).or(scope.where('EXISTS (SELECT 1 FROM mentions m JOIN accounts a ON m.account_id = a.id WHERE lower(a.domain) = ?)', domain)))

--- a/app/validators/unique_username_validator.rb
+++ b/app/validators/unique_username_validator.rb
@@ -6,10 +6,7 @@ class UniqueUsernameValidator < ActiveModel::Validator
   def validate(account)
     return if account.username.blank?
 
-    normalized_username = account.username.downcase
-    normalized_domain = account.domain&.downcase
-
-    scope = Account.where(Account.arel_table[:username].lower.eq normalized_username).where(Account.arel_table[:domain].lower.eq normalized_domain)
+    scope = Account.with_username(account.username).with_domain(account.domain)
     scope = scope.where.not(id: account.id) if account.persisted?
 
     account.errors.add(:username, :taken) if scope.exists?


### PR DESCRIPTION
I was intending to pull out the index-using improvement from https://github.com/mastodon/mastodon/pull/18468#discussion_r880610618 - only to realize that the single-vs-array dynamic is different in these scenarios.

Putting this in as a first pass which consolidates what I think are all the arel-querying  index-using accounts.username and account.domain stuff down into scopes. May try to pull in that linked PR code area in followup.