### PR TITLE
Update cancel_follow_request from "Cancel follow" to "Cancel request"

### DIFF
--- a/app/javascript/mastodon/locales/en-GB.json
+++ b/app/javascript/mastodon/locales/en-GB.json
@@ -20,7 +20,7 @@
   "account.block_short": "Block",
   "account.blocked": "Blocked",
   "account.browse_more_on_origin_server": "Browse more on the original profile",
-  "account.cancel_follow_request": "Cancel follow",
+  "account.cancel_follow_request": "Cancel request",
   "account.copy": "Copy link to profile",
   "account.direct": "Privately mention @{name}",
   "account.disable_notifications": "Stop notifying me when @{name} posts",

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -20,7 +20,7 @@
   "account.block_short": "Block",
   "account.blocked": "Blocked",
   "account.browse_more_on_origin_server": "Browse more on the original profile",
-  "account.cancel_follow_request": "Cancel Request",
+  "account.cancel_follow_request": "Cancel request",
   "account.copy": "Copy link to profile",
   "account.direct": "Privately mention @{name}",
   "account.disable_notifications": "Stop notifying me when @{name} posts",

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -20,7 +20,7 @@
   "account.block_short": "Block",
   "account.blocked": "Blocked",
   "account.browse_more_on_origin_server": "Browse more on the original profile",
-  "account.cancel_follow_request": "Cancel follow",
+  "account.cancel_follow_request": "Cancel Request",
   "account.copy": "Copy link to profile",
   "account.direct": "Privately mention @{name}",
   "account.disable_notifications": "Stop notifying me when @{name} posts",


### PR DESCRIPTION
Cancel Follow is confusing.
![image](https://github.com/mastodon/mastodon/assets/17537000/36299a06-6452-4308-aa35-d1cdf7317f93)

to

![image](https://github.com/mastodon/mastodon/assets/17537000/daaf4511-9a64-4267-9e8f-079380aba825)

