### PR TITLE
Change `ids` param to `id` in `/api/v1/statuses` and `/api/v1/accounts` for consistency

### DIFF
--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -106,11 +106,11 @@ class Api::V1::AccountsController < Api::BaseController
   end
 
   def account_ids
-    Array(accounts_params[:ids]).uniq.map(&:to_i)
+    Array(accounts_params[:id]).uniq.map(&:to_i)
   end
 
   def accounts_params
-    params.permit(ids: [])
+    params.permit(id: [])
   end
 
   def account_params

--- a/app/controllers/api/v1/statuses_controller.rb
+++ b/app/controllers/api/v1/statuses_controller.rb
@@ -141,11 +141,11 @@ class Api::V1::StatusesController < Api::BaseController
   end
 
   def status_ids
-    Array(statuses_params[:ids]).uniq.map(&:to_i)
+    Array(statuses_params[:id]).uniq.map(&:to_i)
   end
 
   def statuses_params
-    params.permit(ids: [])
+    params.permit(id: [])
   end
 
   def status_params

--- a/spec/requests/api/v1/accounts_spec.rb
+++ b/spec/requests/api/v1/accounts_spec.rb
@@ -8,13 +8,13 @@ describe '/api/v1/accounts' do
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
 
-  describe 'GET /api/v1/accounts?ids[]=:id' do
+  describe 'GET /api/v1/accounts?id[]=:id' do
     let(:account) { Fabricate(:account) }
     let(:other_account) { Fabricate(:account) }
     let(:scopes) { 'read:accounts' }
 
     it 'returns expected response' do
-      get '/api/v1/accounts', headers: headers, params: { ids: [account.id, other_account.id, 123_123] }
+      get '/api/v1/accounts', headers: headers, params: { id: [account.id, other_account.id, 123_123] }
 
       expect(response).to have_http_status(200)
       expect(body_as_json).to contain_exactly(

--- a/spec/requests/api/v1/statuses_spec.rb
+++ b/spec/requests/api/v1/statuses_spec.rb
@@ -9,13 +9,13 @@ describe '/api/v1/statuses' do
     let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, application: client_app, scopes: scopes) }
     let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
 
-    describe 'GET /api/v1/statuses?ids[]=:id' do
+    describe 'GET /api/v1/statuses?id[]=:id' do
       let(:status) { Fabricate(:status) }
       let(:other_status) { Fabricate(:status) }
       let(:scopes) { 'read:statuses' }
 
       it 'returns expected response' do
-        get '/api/v1/statuses', headers: headers, params: { ids: [status.id, other_status.id, 123_123] }
+        get '/api/v1/statuses', headers: headers, params: { id: [status.id, other_status.id, 123_123] }
 
         expect(response).to have_http_status(200)
         expect(body_as_json).to contain_exactly(


### PR DESCRIPTION
Change `ids` to `id` for consistency with `/api/v1/accounts/relationships`