### PR TITLE
Work around test environment queue adapter changes

### DIFF
--- a/spec/requests/api/v1/admin/account_actions_spec.rb
+++ b/spec/requests/api/v1/admin/account_actions_spec.rb
@@ -10,10 +10,16 @@ RSpec.describe 'Account actions' do
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
 
   shared_examples 'a successful notification delivery' do
-    it 'notifies the user about the action taken' do
-      expect { subject }
-        .to have_enqueued_job(ActionMailer::MailDeliveryJob)
-        .with('UserMailer', 'warning', 'deliver_now!', args: [User, AccountWarning])
+    it 'notifies the user about the action taken', :sidekiq_inline do
+      emails = capture_emails { subject }
+
+      expect(emails.size)
+        .to eq(1)
+
+      expect(emails.first)
+        .to have_attributes(
+          to: contain_exactly(target_account.user.email)
+        )
     end
   end
 

--- a/spec/services/appeal_service_spec.rb
+++ b/spec/services/appeal_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe AppealService do
+RSpec.describe AppealService, :sidekiq_inline do
   describe '#call' do
     let!(:admin) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
 


### PR DESCRIPTION
Extracted from https://github.com/mastodon/mastodon/pull/30391

Rails 7.2 fixes an issue where the `queue_adapter` setting in the test environment was not consistently handled:

https://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#all-tests-now-respect-the-active-job-queue-adapter-config

In our case, we were apparently relying on this behavior. The fix here is to explicitly enable sidekiq (which we set and use as queue adapter in all envs) where we need to assert things about sent emails.