### PR TITLE
Use `SECRET_KEY_BASE_DUMMY` feature as placeholder during asset compilation

### DIFF
--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -28,11 +28,7 @@ jobs:
     env:
       RAILS_ENV: ${{ matrix.mode }}
       BUNDLE_WITH: ${{ matrix.mode }}
-      ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY: precompile_placeholder
-      ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT: precompile_placeholder
-      ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY: precompile_placeholder
-      OTP_SECRET: precompile_placeholder
-      SECRET_KEY_BASE: precompile_placeholder
+      SECRET_KEY_BASE_DUMMY: 1
 
     steps:
       - uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -212,11 +212,7 @@ ARG TARGETPLATFORM
 
 RUN \
 # Use Ruby on Rails to create Mastodon assets
-  ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY=precompile_placeholder \
-  ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT=precompile_placeholder \
-  ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY=precompile_placeholder \
-  OTP_SECRET=precompile_placeholder \
-  SECRET_KEY_BASE=precompile_placeholder \
+  SECRET_KEY_BASE_DUMMY=1 \
   bundle exec rails assets:precompile; \
 # Cleanup temporary files
   rm -fr /opt/mastodon/tmp;

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -156,7 +156,11 @@ Rails.application.configure do
   }
 
   # TODO: Remove once devise-two-factor data migration complete
-  config.x.otp_secret = ENV.fetch('OTP_SECRET')
+  config.x.otp_secret = if ENV['SECRET_KEY_BASE_DUMMY']
+                          SecureRandom.hex(64)
+                        else
+                          ENV.fetch('OTP_SECRET')
+                        end
 
   # Enable DNS rebinding protection and other `Host` header attacks.
   # config.hosts = [

--- a/config/initializers/active_record_encryption.rb
+++ b/config/initializers/active_record_encryption.rb
@@ -5,6 +5,11 @@
   ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT
   ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY
 ).each do |key|
+  if ENV['SECRET_KEY_BASE_DUMMY']
+    # Use placeholder value during production env asset compilation
+    ENV[key] = SecureRandom.hex(64)
+  end
+
   value = ENV.fetch(key) do
     abort <<~MESSAGE
 


### PR DESCRIPTION
There is a feature introduced in Rails 7.1 - [docs](https://guides.rubyonrails.org/asset_pipeline.html#local-precompilation), [pr](https://github.com/rails/rails/pull/46760) - which basically formalizes the pattern we are already doing here by allowing a specific env variable to effectively put the secret key base check into its test/dev mode where it will just a generate a value to use as a placeholder during asset compilation in production env.

The additional changes here are to also lean on this env var presence to trigger our other placeholder behaviour for the ar encryption values and otp value.