### PR TITLE
Revert "Change default ruby version to 3.3.2 (#30478)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,22 +7,22 @@
 ARG TARGETPLATFORM=${TARGETPLATFORM}
 ARG BUILDPLATFORM=${BUILDPLATFORM}
 
-# Ruby image to use for base image, change with [--build-arg RUBY_VERSION="3.3.x"]
-ARG RUBY_VERSION="3.3.2"
+# Ruby image to use for base image, change with [--build-arg RUBY_VERSION="3.3.1"]
+ARG RUBY_VERSION="3.3.1"
 # # Node version to use in base image, change with [--build-arg NODE_MAJOR_VERSION="20"]
 ARG NODE_MAJOR_VERSION="20"
 # Debian image to use for base image, change with [--build-arg DEBIAN_VERSION="bookworm"]
 ARG DEBIAN_VERSION="bookworm"
 # Node image to use for base image based on combined variables (ex: 20-bookworm-slim)
 FROM docker.io/node:${NODE_MAJOR_VERSION}-${DEBIAN_VERSION}-slim as node
-# Ruby image to use for base image based on combined variables (ex: 3.3.x-slim-bookworm)
+# Ruby image to use for base image based on combined variables (ex: 3.3.1-slim-bookworm)
 FROM docker.io/ruby:${RUBY_VERSION}-slim-${DEBIAN_VERSION} as ruby
 
 # Resulting version string is vX.X.X-MASTODON_VERSION_PRERELEASE+MASTODON_VERSION_METADATA
 # Example: v4.2.0-nightly.2023.11.09+something
 # Overwrite existence of 'alpha.0' in version.rb [--build-arg MASTODON_VERSION_PRERELEASE="nightly.2023.11.09"]
 ARG MASTODON_VERSION_PRERELEASE=""
-# Append build metadata or fork information to version.rb [--build-arg MASTODON_VERSION_METADATA="PR-12345"]
+# Append build metadata or fork information to version.rb [--build-arg MASTODON_VERSION_METADATA="something"]
 ARG MASTODON_VERSION_METADATA=""
 
 # Allow Ruby on Rails to serve static files


### PR DESCRIPTION
The 3.3.2 image has not been build & pushed on arm64 platform

See https://github.com/docker-library/ruby/issues/461

This reverts commit 64d69eb95b7f149d10c03059f8c79b24499f461d.