### PR TITLE
Use bundler version 2.5.11

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1053,4 +1053,4 @@ RUBY VERSION
    ruby 3.3.1p55
 
 BUNDLED WITH
-   2.5.9
+   2.5.11

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1050,7 +1050,7 @@ DEPENDENCIES
   xorcist (~> 1.1)
 
 RUBY VERSION
-   ruby 3.3.1p55
+   ruby 3.3.2p78
 
 BUNDLED WITH
    2.5.11


### PR DESCRIPTION
Ran into this during ruby 3.3.1/3.3.2 switch. Can we configure renovate to bump this, or only gems?