### PR TITLE
Use existing config access to `local_domain` value

### DIFF
--- a/app/views/auth/registrations/edit.html.haml
+++ b/app/views/auth/registrations/edit.html.haml
@@ -3,7 +3,7 @@
 
 - if self_destruct?
   .flash-message.warning
-    = t('auth.status.self_destruct', domain: ENV.fetch('LOCAL_DOMAIN'))
+    = t('auth.status.self_destruct', domain: Rails.configuration.x.local_domain)
 - else
   = render partial: 'status', locals: { user: @user, strikes: @strikes }
 

--- a/app/views/errors/self_destruct.html.haml
+++ b/app/views/errors/self_destruct.html.haml
@@ -3,7 +3,7 @@
 
 .simple_form
   %h1.title= t('self_destruct.title')
-  %p.lead= t('self_destruct.lead_html', domain: ENV.fetch('LOCAL_DOMAIN'))
+  %p.lead= t('self_destruct.lead_html', domain: Rails.configuration.x.local_domain)
 
 .form-footer
   %ul.no-list

--- a/spec/requests/well_known/oauth_metadata_spec.rb
+++ b/spec/requests/well_known/oauth_metadata_spec.rb
@@ -6,7 +6,7 @@ describe 'The /.well-known/oauth-authorization-server request' do
   let(:protocol) { ENV.fetch('LOCAL_HTTPS', true) ? :https : :http }
 
   before do
-    host! ENV.fetch('LOCAL_DOMAIN')
+    host! Rails.configuration.x.local_domain
   end
 
   it 'returns http success with valid JSON response' do

--- a/spec/support/signed_request_helpers.rb
+++ b/spec/support/signed_request_helpers.rb
@@ -6,7 +6,7 @@ module SignedRequestHelpers
 
     headers ||= {}
     headers['Date'] = Time.now.utc.httpdate
-    headers['Host'] = ENV.fetch('LOCAL_DOMAIN')
+    headers['Host'] = Rails.configuration.x.local_domain
     signed_headers = headers.merge('(request-target)' => "get #{path}").slice('(request-target)', 'Host', 'Date')
 
     key_id = ActivityPub::TagManager.instance.key_uri_for(sign_with)

--- a/spec/system/profile_spec.rb
+++ b/spec/system/profile_spec.rb
@@ -7,7 +7,7 @@ describe 'Profile' do
 
   subject { page }
 
-  let(:local_domain) { ENV['LOCAL_DOMAIN'] }
+  let(:local_domain) { Rails.configuration.x.local_domain }
 
   before do
     as_a_logged_in_user


### PR DESCRIPTION
Noticed this while looking for other areas to apply the pattern from https://github.com/mastodon/mastodon/pull/30507

In this case we already have this value being loaded into the configuration object in an initializer, but were not referring to it that way everywhere.

There are still some usages in OTHER initializers or db/seeds for this one - did not want to think through load order stuff for purposes of this PR, may return to those if we do indeed make this a pattern.