### PR TITLE
fix: disable "post" button when no text was entered, and no other media is attached

### DIFF
--- a/app/javascript/mastodon/features/compose/components/compose_form.jsx
+++ b/app/javascript/mastodon/features/compose/components/compose_form.jsx
@@ -104,9 +104,9 @@ class ComposeForm extends ImmutablePureComponent {
   canSubmit = () => {
     const { isSubmitting, isChangingUpload, isUploading, anyMedia, maxChars } = this.props;
     const fulltext = this.getFulltextForCharacterCounting();
-    const isOnlyWhitespace = fulltext.length !== 0 && fulltext.trim().length === 0;
+    const hasNoTextContent = fulltext.trim().length === 0;
 
-    return !(isSubmitting || isUploading || isChangingUpload || length(fulltext) > maxChars || (isOnlyWhitespace && !anyMedia));
+    return !(isSubmitting || isUploading || isChangingUpload || length(fulltext) > maxChars || (hasNoTextContent && !anyMedia));
   };
 
   handleSubmit = (e) => {


### PR DESCRIPTION
fixes #30512