### PR TITLE
Fix rack attack `match_type` value typo in logging config

### DIFF
--- a/config/initializers/rack_attack_logging.rb
+++ b/config/initializers/rack_attack_logging.rb
@@ -3,7 +3,7 @@
 ActiveSupport::Notifications.subscribe(/rack_attack/) do |_name, _start, _finish, _request_id, payload|
   req = payload[:request]
 
-  next unless [:throttle, :blacklist].include? req.env['rack.attack.match_type']
+  next unless [:throttle, :blocklist].include? req.env['rack.attack.match_type']
 
   Rails.logger.info("Rate limit hit (#{req.env['rack.attack.match_type']}): #{req.ip} #{req.request_method} #{req.fullpath}")
 end


### PR DESCRIPTION
This line was added in https://github.com/mastodon/mastodon/pull/7096/files#diff-a3d2f5eaa68210d1d6cf3c24c23d190e0e1d2dffdc571acce216e57ec78e9002R2 and I think may have been a typo from the start?

I think the `match_type` value here corresponds to the top-level rack attack method used to do the filtering, which in our configuration includes both `throttle` and `blocklist`?