### PR TITLE
Change counters to be displayed on profile timelines in web UI

### DIFF
--- a/app/javascript/mastodon/features/account_timeline/index.jsx
+++ b/app/javascript/mastodon/features/account_timeline/index.jsx
@@ -199,6 +199,7 @@ class AccountTimeline extends ImmutablePureComponent {
           emptyMessage={emptyMessage}
           bindToDocument={!multiColumn}
           timelineId='account'
+          withCounters
         />
       </Column>
     );


### PR DESCRIPTION
I forget who asked me (they didn't file an issue) but it seemed like a very reasonable request. This allows you to more easily see how your recent posts are performing. I see no downside to just enabling this for all profiles rather than just your own.