### PR TITLE
Use `mastodon` config namespace to load software update default value via `config_for`

### DIFF
--- a/app/models/software_update.rb
+++ b/app/models/software_update.rb
@@ -24,7 +24,7 @@ class SoftwareUpdate < ApplicationRecord
 
   class << self
     def check_enabled?
-      ENV['UPDATE_CHECK_URL'] != ''
+      Rails.configuration.x.mastodon.software_update_url.present?
     end
 
     def pending_to_a

--- a/app/services/software_update_check_service.rb
+++ b/app/services/software_update_check_service.rb
@@ -27,7 +27,7 @@ class SoftwareUpdateCheckService < BaseService
   end
 
   def api_url
-    ENV.fetch('UPDATE_CHECK_URL', 'https://api.joinmastodon.org/update-check')
+    Rails.configuration.x.mastodon.software_update_url
   end
 
   def version

--- a/config/application.rb
+++ b/config/application.rb
@@ -110,6 +110,7 @@ module Mastodon
     end
 
     config.x.captcha = config_for(:captcha)
+    config.x.mastodon = config_for(:mastodon)
     config.x.translation = config_for(:translation)
 
     config.to_prepare do

--- a/config/mastodon.yml
+++ b/config/mastodon.yml
@@ -1,0 +1,3 @@
+---
+shared:
+  software_update_url: <%= ENV.fetch('UPDATE_CHECK_URL', 'https://api.joinmastodon.org/update-check') %>

--- a/config/navigation.rb
+++ b/config/navigation.rb
@@ -6,7 +6,11 @@ SimpleNavigation::Configuration.run do |navigation|
   navigation.items do |n|
     n.item :web, safe_join([material_symbol('chevron_left'), t('settings.back')]), root_path
 
-    n.item :software_updates, safe_join([material_symbol('report'), t('admin.critical_update_pending')]), admin_software_updates_path, if: -> { ENV['UPDATE_CHECK_URL'] != '' && current_user.can?(:view_devops) && SoftwareUpdate.urgent_pending? }, html: { class: 'warning' }
+    n.item :software_updates,
+           safe_join([material_symbol('report'), t('admin.critical_update_pending')]),
+           admin_software_updates_path,
+           if: -> { Rails.configuration.x.mastodon.software_update_url.present? && current_user.can?(:view_devops) && SoftwareUpdate.urgent_pending? },
+           html: { class: 'warning' }
 
     n.item :profile, safe_join([material_symbol('person'), t('settings.profile')]), settings_profile_path, if: -> { current_user.functional? && !self_destruct }, highlights_on: %r{/settings/profile|/settings/featured_tags|/settings/verification|/settings/privacy}
 

--- a/spec/lib/admin/system_check/software_version_check_spec.rb
+++ b/spec/lib/admin/system_check/software_version_check_spec.rb
@@ -27,9 +27,10 @@ RSpec.describe Admin::SystemCheck::SoftwareVersionCheck do
 
       context 'when checks are disabled' do
         around do |example|
-          ClimateControl.modify UPDATE_CHECK_URL: '' do
-            example.run
-          end
+          original = Rails.configuration.x.mastodon.software_update_url
+          Rails.configuration.x.mastodon.software_update_url = ''
+          example.run
+          Rails.configuration.x.mastodon.software_update_url = original
         end
 
         it 'returns true' do

--- a/spec/services/software_update_check_service_spec.rb
+++ b/spec/services/software_update_check_service_spec.rb
@@ -124,9 +124,10 @@ RSpec.describe SoftwareUpdateCheckService do
 
   context 'when update checking is disabled' do
     around do |example|
-      ClimateControl.modify UPDATE_CHECK_URL: '' do
-        example.run
-      end
+      original = Rails.configuration.x.mastodon.software_update_url
+      Rails.configuration.x.mastodon.software_update_url = ''
+      example.run
+      Rails.configuration.x.mastodon.software_update_url = original
     end
 
     before do
@@ -148,9 +149,10 @@ RSpec.describe SoftwareUpdateCheckService do
     let(:update_check_url) { 'https://api.example.com/update_check' }
 
     around do |example|
-      ClimateControl.modify UPDATE_CHECK_URL: 'https://api.example.com/update_check' do
-        example.run
-      end
+      original = Rails.configuration.x.mastodon.software_update_url
+      Rails.configuration.x.mastodon.software_update_url = 'https://api.example.com/update_check'
+      example.run
+      Rails.configuration.x.mastodon.software_update_url = original
     end
 
     it_behaves_like 'when the feature is enabled'


### PR DESCRIPTION
Opening for a few purposes:

- This is a much simpler example of the approach in https://github.com/mastodon/mastodon/pull/30507 - may be easier to review/finalize an approach with fewer changes first, then keep using that approach in future PRs.
- As a namespace alternative to that linked issue, this one uses `configuration.x.mastodon` namespace (as opposed to putting `configuration.omniauth` right on top-level config in other PR)

Will leave a few inline comments here for things to contemplate.