### PR TITLE
Restore `verbose` option to media remove cli

### DIFF
--- a/lib/mastodon/cli/media.rb
+++ b/lib/mastodon/cli/media.rb
@@ -13,6 +13,7 @@ module Mastodon::CLI
     option :remove_headers, type: :boolean, default: false
     option :include_follows, type: :boolean, default: false
     option :concurrency, type: :numeric, default: 5, aliases: [:c]
+    option :verbose, type: :boolean, default: false, aliases: [:v]
     option :dry_run, type: :boolean, default: false
     desc 'remove', 'Remove remote media files, headers or avatars'
     long_desc <<-DESC


### PR DESCRIPTION
Closes https://github.com/mastodon/mastodon/issues/24070

This was removed in error as part of https://github.com/mastodon/mastodon/pull/22149#issuecomment-1466005852

The media cli class remove method does not use verbose directly, but the progress parallelize method it calls does.

Extracted from https://github.com/mastodon/mastodon/pull/24143