### PR TITLE
Add optional OAuth application to reports

### DIFF
--- a/app/controllers/api/v1/reports_controller.rb
+++ b/app/controllers/api/v1/reports_controller.rb
@@ -10,7 +10,7 @@ class Api::V1::ReportsController < Api::BaseController
     @report = ReportService.new.call(
       current_account,
       reported_account,
-      report_params
+      report_params.merge(application: doorkeeper_token.application)
     )
 
     render json: @report, serializer: REST::ReportSerializer

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -18,6 +18,7 @@
 #  category                   :integer          default("other"), not null
 #  action_taken_at            :datetime
 #  rule_ids                   :bigint(8)        is an Array
+#  application_id             :bigint(8)
 #
 
 class Report < ApplicationRecord
@@ -31,6 +32,7 @@ class Report < ApplicationRecord
   rate_limit by: :account, family: :reports
 
   belongs_to :account
+  belongs_to :application, class_name: 'Doorkeeper::Application', optional: true
 
   with_options class_name: 'Account' do
     belongs_to :target_account

--- a/app/services/report_service.rb
+++ b/app/services/report_service.rb
@@ -10,6 +10,7 @@ class ReportService < BaseService
     @comment        = options.delete(:comment).presence || ''
     @category       = options[:rule_ids].present? ? 'violation' : (options.delete(:category).presence || 'other')
     @rule_ids       = options.delete(:rule_ids).presence
+    @application    = options.delete(:application).presence
     @options        = options
 
     raise ActiveRecord::RecordNotFound if @target_account.unavailable?
@@ -35,7 +36,8 @@ class ReportService < BaseService
       uri: @options[:uri],
       forwarded: forward_to_origin?,
       category: @category,
-      rule_ids: @rule_ids
+      rule_ids: @rule_ids,
+      application: @application
     )
   end
 

--- a/app/views/admin/reports/_header_details.html.haml
+++ b/app/views/admin/reports/_header_details.html.haml
@@ -14,6 +14,12 @@
         = admin_account_link_to report.account
       - else
         = report.account.domain
+  - if report.application.present?
+    .report-header__details__item
+      .report-header__details__item__header
+        %strong= t('admin.reports.reported_with_application')
+      .report-header__details__item__content
+        = report.application.name
   .report-header__details__item
     .report-header__details__item__header
       %strong= t('admin.reports.status')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -638,6 +638,7 @@ en:
       report: 'Report #%{id}'
       reported_account: Reported account
       reported_by: Reported by
+      reported_with_application: Reported with application
       resolved: Resolved
       resolved_msg: Report successfully resolved!
       skip_to_actions: Skip to actions

--- a/db/migrate/20240713171841_add_application_to_reports.rb
+++ b/db/migrate/20240713171841_add_application_to_reports.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddApplicationToReports < ActiveRecord::Migration[7.1]
+  def change
+    add_column :reports, :application_id, :bigint, null: true
+    add_foreign_key :reports, :oauth_applications, column: :application_id, on_delete: :nullify, validate: false
+  end
+end

--- a/db/migrate/20240713171909_validate_add_application_to_reports.rb
+++ b/db/migrate/20240713171909_validate_add_application_to_reports.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateAddApplicationToReports < ActiveRecord::Migration[7.1]
+  def change
+    validate_foreign_key :reports, :oauth_applications
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_12_064044) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_13_171909) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -929,6 +929,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_12_064044) do
     t.integer "category", default: 0, null: false
     t.datetime "action_taken_at", precision: nil
     t.bigint "rule_ids", array: true
+    t.bigint "application_id"
     t.index ["account_id"], name: "index_reports_on_account_id"
     t.index ["action_taken_by_account_id"], name: "index_reports_on_action_taken_by_account_id", where: "(action_taken_by_account_id IS NOT NULL)"
     t.index ["assigned_account_id"], name: "index_reports_on_assigned_account_id", where: "(assigned_account_id IS NOT NULL)"
@@ -1361,6 +1362,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_12_064044) do
   add_foreign_key "reports", "accounts", column: "assigned_account_id", on_delete: :nullify
   add_foreign_key "reports", "accounts", column: "target_account_id", name: "fk_eb37af34f0", on_delete: :cascade
   add_foreign_key "reports", "accounts", name: "fk_4b81f7522c", on_delete: :cascade
+  add_foreign_key "reports", "oauth_applications", column: "application_id", on_delete: :nullify
   add_foreign_key "scheduled_statuses", "accounts", on_delete: :cascade
   add_foreign_key "session_activations", "oauth_access_tokens", column: "access_token_id", name: "fk_957e5bda89", on_delete: :cascade
   add_foreign_key "session_activations", "users", name: "fk_e5fda67334", on_delete: :cascade

--- a/spec/lib/activitypub/activity/flag_spec.rb
+++ b/spec/lib/activitypub/activity/flag_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe ActivityPub::Activity::Flag do
         expect(report).to_not be_nil
         expect(report.comment).to eq 'Boo!!'
         expect(report.status_ids).to eq [status.id]
+        expect(report.application).to be_nil
       end
     end
 

--- a/spec/requests/api/v1/reports_spec.rb
+++ b/spec/requests/api/v1/reports_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe 'Reports' do
 
       expect(target_account.targeted_reports).to_not be_empty
       expect(target_account.targeted_reports.first.comment).to eq 'reasons'
+      expect(target_account.targeted_reports.first.application).to eq token.application
 
       expect(emails.size)
         .to eq(1)

--- a/spec/services/report_service_spec.rb
+++ b/spec/services/report_service_spec.rb
@@ -23,6 +23,11 @@ RSpec.describe ReportService do
       stub_request(:post, 'http://example.com/inbox').to_return(status: 200)
     end
 
+    it 'does not have an application' do
+      report = subject.call(source_account, remote_account)
+      expect(report.application).to be_nil
+    end
+
     context 'when forward is true', :inline_jobs do
       let(:forward) { true }
 
@@ -93,6 +98,15 @@ RSpec.describe ReportService do
         subject.call(source_account, remote_account, forward: forward)
         expect(a_request(:post, 'http://example.com/inbox')).to_not have_been_made
       end
+    end
+  end
+
+  context 'when passed an application' do
+    let(:application) { Fabricate(:application) }
+
+    it 'has an application' do
+      report = subject.call(source_account, target_account, application: application)
+      expect(report.application).to eq application
     end
   end
 


### PR DESCRIPTION
This allows moderators to see the OAuth Application name that was used to create the report, helping to identify applications that are not implementing the reports API fully, causing low-quality reports. For now, we can only display the name as we do not have any way for moderators or administrators to interact with OAuth Applications

Note: Reports created from the Mastodon Web UI will only have an application associated if there is a `superapp` `Doorkeeper::Application` in existence. In my testing environment, I'd deleted that oauth_application, and consequently was seeing no application for the web UI.

UI in the Admin Reports interface looks like the following, if an Application is set:
<img width="869" alt="Screenshot 2024-06-03 at 23 23 31" src="https://github.com/mastodon/mastodon/assets/30827/6b2bb6dc-dc4b-4b50-83ef-83c21f993584">


Fixes #30510