### PR TITLE
Add url validation to Web::PushSubscription endpoints

### DIFF
--- a/app/models/web/push_subscription.rb
+++ b/app/models/web/push_subscription.rb
@@ -21,7 +21,7 @@ class Web::PushSubscription < ApplicationRecord
 
   has_one :session_activation, foreign_key: 'web_push_subscription_id', inverse_of: :web_push_subscription, dependent: nil
 
-  validates :endpoint, presence: true
+  validates :endpoint, presence: true, url: true
   validates :key_p256dh, presence: true
   validates :key_auth, presence: true
 

--- a/spec/requests/api/v1/push/subscriptions_spec.rb
+++ b/spec/requests/api/v1/push/subscriptions_spec.rb
@@ -4,10 +4,11 @@ require 'rails_helper'
 
 describe 'API V1 Push Subscriptions' do
   let(:user) { Fabricate(:user) }
+  let(:endpoint) { 'https://fcm.googleapis.com/fcm/send/fiuH06a27qE:APA91bHnSiGcLwdaxdyqVXNDR9w1NlztsHb6lyt5WDKOC_Z_Q8BlFxQoR8tWFSXUIDdkyw0EdvxTu63iqamSaqVSevW5LfoFwojws8XYDXv_NRRLH6vo2CdgiN4jgHv5VLt2A8ah6lUX' }
   let(:create_payload) do
     {
       subscription: {
-        endpoint: 'https://fcm.googleapis.com/fcm/send/fiuH06a27qE:APA91bHnSiGcLwdaxdyqVXNDR9w1NlztsHb6lyt5WDKOC_Z_Q8BlFxQoR8tWFSXUIDdkyw0EdvxTu63iqamSaqVSevW5LfoFwojws8XYDXv_NRRLH6vo2CdgiN4jgHv5VLt2A8ah6lUX',
+        endpoint: endpoint,
         keys: {
           p256dh: 'BEm_a0bdPDhf0SOsrnB2-ategf1hHoCnpXgQsFj5JCkcoMrMt2WHoPfEYOYPzOIs9mZE8ZUaD7VA5vouy0kEkr8=',
           auth: 'eH_C8rq2raXqlcBVDa1gLg==',
@@ -62,6 +63,18 @@ describe 'API V1 Push Subscriptions' do
 
       expect(endpoint_push_subscriptions.count)
         .to eq(1)
+    end
+
+    context 'with invalid endpoint URL' do
+      let(:endpoint) { 'app://example.foo' }
+
+      it 'returns a validation error' do
+        subject
+
+        expect(response).to have_http_status(422)
+        expect(endpoint_push_subscriptions.count).to eq(0)
+        expect(endpoint_push_subscription).to be_nil
+      end
     end
   end
 


### PR DESCRIPTION
Previously it was possible to create a webpush subscription with an invalid endpoint URL which we could not call from PushNotificationWorker.

I think this is the source of sidekiq errors like: `ArgumentError: expected :endpoint to be a HTTP or HTTPS endpoint`

We may even want to use `Request.valid_url?` here, though that would likely require a custom validator, I think?

Another error that can occur here is that the `key_p256dh` isn't actually a point on an elliptical curve, perhaps the simplest validation might be to try and do an encrypt with the supplied properties?