### PR TITLE
Set Devcontainer to Ruby 3.3 Bookworm

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # For details, see https://github.com/devcontainers/images/tree/main/src/ruby
-FROM mcr.microsoft.com/devcontainers/ruby:1-3.2-bullseye
+FROM mcr.microsoft.com/devcontainers/ruby:1-3.3-bookworm
 
 # Install Rails
 # RUN gem install rails webdrivers


### PR DESCRIPTION
This adjusts the devcontainer to use Ruby 3.3 on Debian Bookworm, consistent with the production container.