### PR TITLE
Fix notifications from limited users being outright dropped

### DIFF
--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -420,10 +420,7 @@ class FeedManager
     check_for_blocks = status.active_mentions.pluck(:account_id)
     check_for_blocks.push(status.in_reply_to_account) if status.reply? && !status.in_reply_to_account_id.nil?
 
-    should_filter   = blocks_or_mutes?(receiver_id, check_for_blocks, :mentions) # Filter if it's from someone I blocked, in reply to someone I blocked, or mentioning someone I blocked (or muted)
-    should_filter ||= status.account.silenced? && !Follow.exists?(account_id: receiver_id, target_account_id: status.account_id) # Filter if the account is silenced and I'm not following them
-
-    should_filter
+    blocks_or_mutes?(receiver_id, check_for_blocks, :mentions) # Filter if it's from someone I blocked, in reply to someone I blocked, or mentioning someone I blocked (or muted)
   end
 
   # Check if status should not be added to the list feed

--- a/spec/lib/feed_manager_spec.rb
+++ b/spec/lib/feed_manager_spec.rb
@@ -206,13 +206,13 @@ RSpec.describe FeedManager do
         expect(described_class.instance.filter?(:mentions, reply, bob)).to be true
       end
 
-      it 'returns true for status by silenced account who recipient is not following' do
+      it 'returns false for status by limited account who recipient is not following' do
         status = Fabricate(:status, text: 'Hello world', account: alice)
         alice.silence!
-        expect(described_class.instance.filter?(:mentions, status, bob)).to be true
+        expect(described_class.instance.filter?(:mentions, status, bob)).to be false
       end
 
-      it 'returns false for status by followed silenced account' do
+      it 'returns false for status by followed limited account' do
         status = Fabricate(:status, text: 'Hello world', account: alice)
         alice.silence!
         bob.follow!(alice)

--- a/spec/services/notify_service_spec.rb
+++ b/spec/services/notify_service_spec.rb
@@ -129,6 +129,35 @@ RSpec.describe NotifyService do
     end
   end
 
+  describe NotifyService::DismissCondition do
+    subject { described_class.new(notification) }
+
+    let(:activity) { Fabricate(:mention, status: Fabricate(:status)) }
+    let(:notification) { Fabricate(:notification, type: :mention, activity: activity, from_account: activity.status.account, account: activity.account) }
+
+    describe '#dismiss?' do
+      context 'when sender is silenced' do
+        before do
+          notification.from_account.silence!
+        end
+
+        it 'returns false' do
+          expect(subject.dismiss?).to be false
+        end
+      end
+
+      context 'when recipient has blocked sender' do
+        before do
+          notification.account.block!(notification.from_account)
+        end
+
+        it 'returns true' do
+          expect(subject.dismiss?).to be true
+        end
+      end
+    end
+  end
+
   describe NotifyService::FilterCondition do
     subject { described_class.new(notification) }
 


### PR DESCRIPTION
In #29366, it was intended that notifications from limited non-followed users would end up in filtered notifications instead of being outright dropped.

However, those notifications were still dropped in an earlier check.

Note that this introduces a pretty significant behavior change that may make limiting servers less effective. I believe that something like https://github.com/mastodon/mastodon/pull/26904 would help, but I'm not too sure where the setting should live, as there's a bit of overlap between notification filtering and that.