### PR TITLE
Add `sidekiq_inline` to appeal service spec

### DIFF
--- a/spec/services/appeal_service_spec.rb
+++ b/spec/services/appeal_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe AppealService do
+RSpec.describe AppealService, :sidekiq_inline do
   describe '#call' do
     let!(:admin) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
 


### PR DESCRIPTION
Extracted from https://github.com/mastodon/mastodon/pull/30494 and required for Rails 7.2 PR - https://github.com/mastodon/mastodon/pull/30391

Side effect of fixed queue adapter behavior - https://github.com/rails/rails/blob/7-2-stable/activejob/CHANGELOG.md#rails-720beta1-may-29-2024