### PR TITLE
Use `sidekiq_inline` in requests/api/v1/admin/account_actions spec

### DIFF
--- a/spec/requests/api/v1/admin/account_actions_spec.rb
+++ b/spec/requests/api/v1/admin/account_actions_spec.rb
@@ -10,10 +10,16 @@ RSpec.describe 'Account actions' do
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
 
   shared_examples 'a successful notification delivery' do
-    it 'notifies the user about the action taken' do
-      expect { subject }
-        .to have_enqueued_job(ActionMailer::MailDeliveryJob)
-        .with('UserMailer', 'warning', 'deliver_now!', args: [User, AccountWarning])
+    it 'notifies the user about the action taken', :sidekiq_inline do
+      emails = capture_emails { subject }
+
+      expect(emails.size)
+        .to eq(1)
+
+      expect(emails.first)
+        .to have_attributes(
+          to: contain_exactly(target_account.user.email)
+        )
     end
   end
 


### PR DESCRIPTION
Extracted from https://github.com/mastodon/mastodon/pull/30494 and required for Rails 7.2 PR - https://github.com/mastodon/mastodon/pull/30391

Side effect of fixed queue adapter behavior - https://github.com/rails/rails/blob/7-2-stable/activejob/CHANGELOG.md#rails-720beta1-may-29-2024

For this one, the previous (wrong) behavior of populating the test adapter that we were relying on is now populating sidekiq, so we need to assert that way instead.