### PR TITLE
Remove deprecated version value from `.devcontainer/docker-compose.yml`

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   app:
     working_dir: /workspaces/mastodon/


### PR DESCRIPTION
Currently running `docker compose ...` emits warning/notice about this line.