### PR TITLE
Build libvips from source in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -187,6 +187,7 @@ RUN \
 # Download and install required Gems
   bundle install -j"$(nproc)";
 
+# Create temporary libvibs specific build layer from build layer
 FROM build as libvips
 
 # libvips version to compile, change with [--build-arg VIPS_VERSION="8.15.2"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -159,6 +159,25 @@ RUN \
     libwebp-dev \
   ;
 
+# libvips version to compile, change with [--build-arg VIPS_VERSION="8.15.2"]
+# renovate: datasource=github-releases depName=libvips packageName=libvips/libvips
+ARG VIPS_VERSION=8.15.2
+# libvips download URL, change with [--build-arg VIPS_URL="https://github.com/libvips/libvips/releases/download"]
+ARG VIPS_URL=https://github.com/libvips/libvips/releases/download
+
+WORKDIR /usr/local/src
+
+RUN \
+  curl -sSL -o vips-${VIPS_VERSION}.tar.xz ${VIPS_URL}/v${VIPS_VERSION}/vips-${VIPS_VERSION}.tar.xz; \
+  tar xf vips-${VIPS_VERSION}.tar.xz; \
+  cd vips-${VIPS_VERSION}; \
+  meson setup build --libdir=lib -Ddeprecated=false -Dintrospection=disabled -Dmodules=disabled -Dexamples=false; \
+  cd build; \
+  ninja; \
+  ninja install;
+
+WORKDIR /opt/mastodon
+
 RUN \
 # Configure Corepack
   rm /usr/local/bin/yarn*; \
@@ -186,25 +205,6 @@ RUN \
   bundle config set silence_root_warning "true"; \
 # Download and install required Gems
   bundle install -j"$(nproc)";
-
-FROM build as libvips
-
-# libvips version to compile, change with [--build-arg VIPS_VERSION="8.15.2"]
-# renovate: datasource=github-releases depName=libvips packageName=libvips/libvips
-ARG VIPS_VERSION=8.15.2
-# libvips download URL, change with [--build-arg VIPS_URL="https://github.com/libvips/libvips/releases/download"]
-ARG VIPS_URL=https://github.com/libvips/libvips/releases/download
-
-WORKDIR /usr/local/src
-
-RUN \
-  curl -sSL -o vips-${VIPS_VERSION}.tar.xz ${VIPS_URL}/v${VIPS_VERSION}/vips-${VIPS_VERSION}.tar.xz; \
-  tar xf vips-${VIPS_VERSION}.tar.xz; \
-  cd vips-${VIPS_VERSION}; \
-  meson setup build --libdir=lib -Ddeprecated=false -Dintrospection=disabled -Dmodules=disabled -Dexamples=false; \
-  cd build; \
-  ninja; \
-  ninja install;
 
 # Create temporary node specific build layer from build layer
 FROM build as yarn
@@ -294,9 +294,9 @@ COPY --from=precompiler /opt/mastodon/public/assets /opt/mastodon/public/assets
 # Copy bundler components to layer
 COPY --from=bundler /usr/local/bundle/ /usr/local/bundle/
 # Copy libvips components to layer
-COPY --from=libvips /usr/local/bin/vips* /usr/local/bin
-COPY --from=libvips /usr/local/lib/libvips* /usr/local/lib
-COPY --from=libvips /usr/local/lib/pkgconfig/vips* /usr/local/lib/pkgconfig
+COPY --from=build /usr/local/bin/vips* /usr/local/bin
+COPY --from=build /usr/local/lib/libvips* /usr/local/lib
+COPY --from=build /usr/local/lib/pkgconfig/vips* /usr/local/lib/pkgconfig
 
 RUN \
 # Symlink libvips components

--- a/Dockerfile
+++ b/Dockerfile
@@ -174,9 +174,13 @@ ARG VIPS_VERSION=8.15.2
 # libvips download URL, change with [--build-arg VIPS_URL="https://github.com/libvips/libvips/releases/download"]
 ARG VIPS_URL=https://github.com/libvips/libvips/releases/download
 
+ARG TARGETPLATFORM
+
 WORKDIR /usr/local/libvips/src
 
 RUN \
+# Mount libvips from Docker buildx caches
+--mount=type=cache,id=libvips-cache-${TARGETPLATFORM},target=/usr/local/libvips,sharing=locked \
   curl -sSL -o vips-${VIPS_VERSION}.tar.xz ${VIPS_URL}/v${VIPS_VERSION}/vips-${VIPS_VERSION}.tar.xz; \
   tar xf vips-${VIPS_VERSION}.tar.xz; \
   cd vips-${VIPS_VERSION}; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -160,9 +160,8 @@ RUN \
   ;
 
 # libvips version to compile, change with [--build-arg VIPS_VERSION="8.15.2"]
+# renovate: datasource=github-releases depName=libvips packageName=libvips/libvips
 ARG VIPS_VERSION=8.15.2
-# libvips sha256 hash of downloaded archive, change with [--build-arg VIPS_SHA256="a1b2c3..."]
-ARG VIPS_SHA256=a2ab15946776ca7721d11cae3215f20f1f097b370ff580cd44fc0f19387aee84
 # libvips download URL, change with [--build-arg VIPS_URL="https://github.com/libvips/libvips/releases/download"]
 ARG VIPS_URL=https://github.com/libvips/libvips/releases/download
 
@@ -170,9 +169,6 @@ WORKDIR /usr/local/src
 
 RUN \
   curl -sSL -o vips-${VIPS_VERSION}.tar.xz ${VIPS_URL}/v${VIPS_VERSION}/vips-${VIPS_VERSION}.tar.xz; \
-  echo "$VIPS_SHA256 vips-${VIPS_VERSION}.tar.xz" | sha256sum --check || exit 1;
-
-RUN \
   tar xf vips-${VIPS_VERSION}.tar.xz; \
   cd vips-${VIPS_VERSION}; \
   meson setup build --libdir=lib -Ddeprecated=false -Dintrospection=disabled -Dmodules=disabled -Dexamples=false; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -171,7 +171,7 @@ RUN \
   curl -sSL -o vips-${VIPS_VERSION}.tar.xz ${VIPS_URL}/v${VIPS_VERSION}/vips-${VIPS_VERSION}.tar.xz; \
   tar xf vips-${VIPS_VERSION}.tar.xz; \
   cd vips-${VIPS_VERSION}; \
-  meson setup build --libdir=lib -Ddeprecated=false -Dintrospection=disabled -Dmodules=disabled -Dexamples=false; \
+  meson setup build --prefix /usr/local/libvips --libdir=lib -Ddeprecated=false -Dintrospection=disabled -Dmodules=disabled -Dexamples=false; \
   cd build; \
   ninja; \
   ninja install;
@@ -294,25 +294,16 @@ COPY --from=precompiler /opt/mastodon/public/assets /opt/mastodon/public/assets
 # Copy bundler components to layer
 COPY --from=bundler /usr/local/bundle/ /usr/local/bundle/
 # Copy libvips components to layer
-COPY --from=build /usr/local/bin/vips* /usr/local/bin
-COPY --from=build /usr/local/lib/libvips* /usr/local/lib
-COPY --from=build /usr/local/lib/pkgconfig/vips* /usr/local/lib/pkgconfig
+COPY --from=build /usr/local/libvips/bin /usr/local/bin
+COPY --from=build /usr/local/libvips/lib /usr/local/lib
 
 RUN \
-# Symlink libvips components
-  ln -sf /usr/local/lib/libvips.so.42.17.2 /usr/local/lib/libvips.so.42; \
-  ln -sf /usr/local/lib/libvips.so.42.17.2 /usr/local/lib/libvips.so; \
-  ln -sf /usr/local/lib/libvips-cpp.so.42.17.2 /usr/local/lib/libvips-cpp.so.42; \
-  ln -sf /usr/local/lib/libvips-cpp.so.42.17.2 /usr/local/lib/libvips-cpp.so; \
-  ldconfig \
-  ;
-
-RUN \
+  ldconfig; \
 # Smoketest media processors
   vips -v;
 
 RUN \
-# Precompile bootsnap code for faster Rails startup
+  # Precompile bootsnap code for faster Rails startup
   bundle exec bootsnap precompile --gemfile app/ lib/;
 
 RUN \

--- a/Dockerfile
+++ b/Dockerfile
@@ -159,25 +159,6 @@ RUN \
     libwebp-dev \
   ;
 
-# libvips version to compile, change with [--build-arg VIPS_VERSION="8.15.2"]
-# renovate: datasource=github-releases depName=libvips packageName=libvips/libvips
-ARG VIPS_VERSION=8.15.2
-# libvips download URL, change with [--build-arg VIPS_URL="https://github.com/libvips/libvips/releases/download"]
-ARG VIPS_URL=https://github.com/libvips/libvips/releases/download
-
-WORKDIR /usr/local/src
-
-RUN \
-  curl -sSL -o vips-${VIPS_VERSION}.tar.xz ${VIPS_URL}/v${VIPS_VERSION}/vips-${VIPS_VERSION}.tar.xz; \
-  tar xf vips-${VIPS_VERSION}.tar.xz; \
-  cd vips-${VIPS_VERSION}; \
-  meson setup build --libdir=lib -Ddeprecated=false -Dintrospection=disabled -Dmodules=disabled -Dexamples=false; \
-  cd build; \
-  ninja; \
-  ninja install;
-
-WORKDIR /opt/mastodon
-
 RUN \
 # Configure Corepack
   rm /usr/local/bin/yarn*; \
@@ -205,6 +186,25 @@ RUN \
   bundle config set silence_root_warning "true"; \
 # Download and install required Gems
   bundle install -j"$(nproc)";
+
+FROM build as libvips
+
+# libvips version to compile, change with [--build-arg VIPS_VERSION="8.15.2"]
+# renovate: datasource=github-releases depName=libvips packageName=libvips/libvips
+ARG VIPS_VERSION=8.15.2
+# libvips download URL, change with [--build-arg VIPS_URL="https://github.com/libvips/libvips/releases/download"]
+ARG VIPS_URL=https://github.com/libvips/libvips/releases/download
+
+WORKDIR /usr/local/src
+
+RUN \
+  curl -sSL -o vips-${VIPS_VERSION}.tar.xz ${VIPS_URL}/v${VIPS_VERSION}/vips-${VIPS_VERSION}.tar.xz; \
+  tar xf vips-${VIPS_VERSION}.tar.xz; \
+  cd vips-${VIPS_VERSION}; \
+  meson setup build --libdir=lib -Ddeprecated=false -Dintrospection=disabled -Dmodules=disabled -Dexamples=false; \
+  cd build; \
+  ninja; \
+  ninja install;
 
 # Create temporary node specific build layer from build layer
 FROM build as yarn
@@ -294,9 +294,9 @@ COPY --from=precompiler /opt/mastodon/public/assets /opt/mastodon/public/assets
 # Copy bundler components to layer
 COPY --from=bundler /usr/local/bundle/ /usr/local/bundle/
 # Copy libvips components to layer
-COPY --from=build /usr/local/bin/vips* /usr/local/bin
-COPY --from=build /usr/local/lib/libvips* /usr/local/lib
-COPY --from=build /usr/local/lib/pkgconfig/vips* /usr/local/lib/pkgconfig
+COPY --from=libvips /usr/local/bin/vips* /usr/local/bin
+COPY --from=libvips /usr/local/lib/libvips* /usr/local/lib
+COPY --from=libvips /usr/local/lib/pkgconfig/vips* /usr/local/lib/pkgconfig
 
 RUN \
 # Symlink libvips components

--- a/Dockerfile
+++ b/Dockerfile
@@ -187,7 +187,6 @@ RUN \
 # Download and install required Gems
   bundle install -j"$(nproc)";
 
-# Create temporary libvibs specific build layer from build layer
 FROM build as libvips
 
 # libvips version to compile, change with [--build-arg VIPS_VERSION="8.15.2"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -174,13 +174,9 @@ ARG VIPS_VERSION=8.15.2
 # libvips download URL, change with [--build-arg VIPS_URL="https://github.com/libvips/libvips/releases/download"]
 ARG VIPS_URL=https://github.com/libvips/libvips/releases/download
 
-ARG TARGETPLATFORM
-
 WORKDIR /usr/local/libvips/src
 
 RUN \
-# Mount libvips from Docker buildx caches
---mount=type=cache,id=libvips-cache-${TARGETPLATFORM},target=/usr/local/libvips,sharing=locked \
   curl -sSL -o vips-${VIPS_VERSION}.tar.xz ${VIPS_URL}/v${VIPS_VERSION}/vips-${VIPS_VERSION}.tar.xz; \
   tar xf vips-${VIPS_VERSION}.tar.xz; \
   cd vips-${VIPS_VERSION}; \


### PR DESCRIPTION
Extraction of libvips only components from from #30569

This preserves all of the benefits of compiling libvips individually (Controlled version adoption & Optimized library selection) however Docker image size remains at around 1GB due to inclusion of X11 as required by ffmpeg still being loaded by Debian repos.

- **Removal of ImageMagick:** When installed from the Debian repos as `libvips42`, ImageMagick core is also installed as a fallback for some image formats, when the ultimate goal of #30090 is to ultimately remove IM from the codebase entirely for all the reasons why Vips is superior.
- **Controlled version adoption:** Vips should be considered as essential as Ruby, Node, Postgres, or any other Mastodon dependency given the importance of image processing. The Debian repos are notoriously slow in adoption of upgrades.
- **Optimized library selection:** Compiling these packages from source allows us to use only the libraries that are necessary for Mastodon. For example there is no support included for things like PDF, JXL, JPEG2000, NIfTI, FITS, Matlab, or SVG. Not only is this more size efficient as noted above, it could be considered more secure by lowering the attack surface of the container through removal of unnecessary components but ultimately it is to allow more granular control where there are multiple choices, especially for Vips as further noted below. 
 
### Vips compile/library settings
- Versions can be controlled in a similar method as Ruby/Node through Docker build arguments, to enable easier local testing and customized version deployments. `[--build-arg VIPS_VERSION="8.15.2"]`
- Source code is downloaded directly from GitHub and includes a sha256 hash check as part of the process to insure package integrity.
- Building deprecated components is disabled, building example programs is disabled, building GObject introspection is disabled,  building dynamic modules is disabled. (Full list of libvips build options https://github.com/libvips/libvips/blob/master/meson_options.txt)
- `libjpeg-turbo` is used for JPEG processing which is 2-6x faster than standard `libjpeg`. Another option would be to use `mozjpeg` but this library is not available in Debian and would required another direct compilation.
- `cgif` is used for GIF processing, which if not present would require Vips to fallback to ImageMagick.
- `libspng` is used for PNG processing, which is similarly more performant than the standard `libpng` package.
- `libwebp` is used for WebP processing.
- `libheif` is used for processing HEIC/HEIF images.
- `orc-0.4` is used for some SIMD operations instead of `highway` due to the Debian repos not containing a version that is suitable for `libvips` but this could either be compiled directly or evaluated later if Debian packages are updated.
- `libimagequant` is used for libvips to write 8-bit PNG and GIF files, with an alternative being `quantizr` that is not available in Debian repos but could be built directly. 

```
$ vips --vips-config
enable debug: false
enable deprecated: false
enable modules: false
enable cplusplus: true
enable RAD load/save: true
enable Analyze7 load/save: true
enable PPM load/save: true
enable GIF load: true
use fftw for FFTs: false
SIMD support with highway: false
accelerate loops with ORC: true
ICC profile support with lcms: true
zlib: true
text rendering with pangocairo: false
font file support with fontconfig: false
EXIF metadata support with libexif: true
JPEG load/save with libjpeg: true
JXL load/save with libjxl: false (dynamic module: false)
JPEG2000 load/save with OpenJPEG: false
PNG load/save with libspng: true
PNG load/save with libpng: false
selected quantisation package: imagequant
TIFF load/save with libtiff: true
image pyramid save with libarchive: false
HEIC/AVIF load/save with libheif: true (dynamic module: false)
WebP load/save with libwebp: true
PDF load with PDFium: false
PDF load with poppler-glib: false (dynamic module: false)
SVG load with librsvg: false
EXR load with OpenEXR: false
OpenSlide load: false (dynamic module: false)
Matlab load with libmatio: false
NIfTI load/save with niftiio: false
FITS load/save with cfitsio: false
GIF save with cgif: true
selected Magick package: none (dynamic module: false)
Magick API version: none
Magick load: false
Magick save: false
```
