### PR TITLE
Run as root in devcontainer from vscode

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,6 +23,8 @@
     }
   },
 
+  "remoteUser": "root",
+
   "otherPortsAttributes": {
     "onAutoForward": "silent"
   },


### PR DESCRIPTION
I was seeing a disconnect in behavior from devcontainers when run directly via docker compose (generally working) and when running from within vscode (permissions issues).

I wound up tracking it down to this - https://github.com/microsoft/vscode-remote-release/issues/7307

Looks like at some point in time the starting user used in the base image for devcontainers in vscode changed from "root" to "vscode", so this override will set it back to root (which is what our current Dockerfile and other stuff assumes).

In future, if we wanted to do a more elaborate overhaul of this, we could try to better align the user/group/dirs/etc from the production Dockerfile here, and use a "mastodon" user ... but for now this fixes permissions issues I was seeing and seems easier than all that.