### PR TITLE
Rename deprecated config option to `enable_reloading` in dev env

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -8,7 +8,7 @@ Rails.application.configure do
   # In the development environment your application's code is reloaded any time
   # it changes. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.
-  config.cache_classes = false
+  config.enable_reloading = true
 
   # Do not eager load code on boot.
   config.eager_load = false


### PR DESCRIPTION
We renamed this in production and test in the Rails 7.1 update, but somehow missed this one.

This is in part an extraction from the Rails 7.2 PR `app:update` changes.