### PR TITLE
Provide richer failure information in `bin/setup`

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -5,7 +5,7 @@ require "fileutils"
 APP_ROOT = File.expand_path('..', __dir__)
 
 def system!(*args)
-  system(*args) || abort("\n== Command #{args} failed ==")
+  system(*args, exception: true)
 end
 
 FileUtils.chdir APP_ROOT do


### PR DESCRIPTION
Vaguely related to https://github.com/mastodon/mastodon/pull/30573 and other recent docker/devcontainer/setup PRs.

This adds more information to the failure output when a wrapped command does not succeed. I think the option was added in ruby 2.x, so we should be fine on everything supported.