### PR TITLE
Only enable chewy in search-tagged specs

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -55,6 +55,8 @@ Sidekiq.logger = nil
 
 DatabaseCleaner.strategy = [:deletion]
 
+Chewy.settings[:enabled] = false
+
 Devise::Test::ControllerHelpers.module_eval do
   alias_method :original_sign_in, :sign_in
 
@@ -126,6 +128,12 @@ RSpec.configure do |config|
       Sidekiq::Testing.fake!
     end
     example.run
+  end
+
+  config.around(:each, type: :search) do |example|
+    Chewy.settings[:enabled] = true
+    example.run
+    Chewy.settings[:enabled] = false
   end
 
   config.before :each, type: :cli do


### PR DESCRIPTION
This is also related to devcontainer.

In the devcontainers docker compose setup we are setting `ES_ENABLED: 'true'`

In the chewy initializer this gets set via `Chewy.settings[:enabled'` and that in turn gets checked around the codebase for whether or not to use chewy.

On CI runs we explicitly enabled ES/chewy, but that only run specs tagged `search` in that section of CI.

In the container now when you run the whole spec suite, Chewy is enabled for all the specs.

This change disables by default, and then wraps the search-tagged specs only with a enable/disable block.

This fixes the (ES-related) failures from running the container ... and I think is what we want to happen here?