### PR TITLE
Add Specs for Scheduled Status Model Validations 

### DIFF
--- a/spec/models/scheduled_status_spec.rb
+++ b/spec/models/scheduled_status_spec.rb
@@ -29,12 +29,16 @@ RSpec.describe ScheduledStatus do
     end
 
     context 'when account has reached daily limit' do
-      subject { Fabricate.build(:scheduled_status, account: account, scheduled_at: Time.current.tomorrow + 10.minutes) }
+      subject { Fabricate.build(:scheduled_status, account: account, scheduled_at: base_time + 10.minutes) }
+
+      let(:base_time) { Time.current.change(hour: 12) }
 
       before do
         stub_const('ScheduledStatus::DAILY_LIMIT', 3)
 
-        Fabricate.times(ScheduledStatus::DAILY_LIMIT, :scheduled_status, account: account, scheduled_at: Time.current.tomorrow.beginning_of_day)
+        travel_to base_time do
+          Fabricate.times(ScheduledStatus::DAILY_LIMIT, :scheduled_status, account: account, scheduled_at: base_time + 1.hour)
+        end
       end
 
       it 'is not valid', :aggregate_failures do

--- a/spec/models/scheduled_status_spec.rb
+++ b/spec/models/scheduled_status_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ScheduledStatus do
+  let(:account) { Fabricate(:account) }
+
+  describe 'validations' do
+    context 'when scheduled_at is less than minimum offset' do
+      subject { Fabricate.build(:scheduled_status, scheduled_at: 4.minutes.from_now, account: account) }
+
+      it 'is not valid', :aggregate_failures do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:scheduled_at]).to include(I18n.t('scheduled_statuses.too_soon'))
+      end
+    end
+
+    context 'when account has reached total limit' do
+      subject { Fabricate.build(:scheduled_status, account: account) }
+
+      before do
+        allow(account.scheduled_statuses).to receive(:count).and_return(described_class::TOTAL_LIMIT)
+      end
+
+      it 'is not valid', :aggregate_failures do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:base]).to include(I18n.t('scheduled_statuses.over_total_limit', limit: ScheduledStatus::TOTAL_LIMIT))
+      end
+    end
+
+    context 'when account has reached daily limit' do
+      subject { Fabricate.build(:scheduled_status, account: account, scheduled_at: Time.current.tomorrow + 10.minutes) }
+
+      before do
+        stub_const('ScheduledStatus::DAILY_LIMIT', 3)
+
+        Fabricate.times(ScheduledStatus::DAILY_LIMIT, :scheduled_status, account: account, scheduled_at: Time.current.tomorrow.beginning_of_day)
+      end
+
+      it 'is not valid', :aggregate_failures do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:base]).to include(I18n.t('scheduled_statuses.over_daily_limit', limit: ScheduledStatus::DAILY_LIMIT))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds tests for the `ScheduledStatus` model validations, which is lacking coverage.

I'm  not sure about some of the tests implementations. So I'd appreciate suggestions on how to improve them. Mainly the test on the daily limit validation.