### PR TITLE
Fix Mastodon relying on ImageMagick even with `MASTODON_USE_LIBVIPS`

### DIFF
--- a/app/models/custom_emoji.rb
+++ b/app/models/custom_emoji.rb
@@ -39,7 +39,7 @@ class CustomEmoji < ApplicationRecord
 
   has_one :local_counterpart, -> { where(domain: nil) }, class_name: 'CustomEmoji', primary_key: :shortcode, foreign_key: :shortcode, inverse_of: false, dependent: nil
 
-  has_attached_file :image, styles: { static: { format: 'png', convert_options: '-coalesce +profile "!icc,*" +set date:modify +set date:create +set date:timestamp' } }, validate_media_type: false
+  has_attached_file :image, styles: { static: { format: 'png', convert_options: '-coalesce +profile "!icc,*" +set date:modify +set date:create +set date:timestamp', file_geometry_parser: FastGeometryParser } }, validate_media_type: false, processors: [:lazy_thumbnail]
 
   normalizes :domain, with: ->(domain) { domain.downcase }
 

--- a/spec/models/custom_emoji_spec.rb
+++ b/spec/models/custom_emoji_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe CustomEmoji do
+RSpec.describe CustomEmoji, :paperclip_processing do
   describe '#search' do
     subject { described_class.search(search_term) }
 


### PR DESCRIPTION
Fixes #30578