### PR TITLE
Fix `mentions.account_id` and `mentions.status_id` not having `NOT NULL` database constraints

### DIFF
--- a/app/models/mention.rb
+++ b/app/models/mention.rb
@@ -5,10 +5,10 @@
 # Table name: mentions
 #
 #  id         :bigint(8)        not null, primary key
-#  status_id  :bigint(8)
+#  status_id  :bigint(8)        not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  account_id :bigint(8)
+#  account_id :bigint(8)        not null
 #  silent     :boolean          default(FALSE), not null
 #
 

--- a/db/migrate/20240607093446_change_mention_status_id_non_nullable.rb
+++ b/db/migrate/20240607093446_change_mention_status_id_non_nullable.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ChangeMentionStatusIdNonNullable < ActiveRecord::Migration[7.1]
+  def change
+    add_check_constraint :mentions, 'status_id IS NOT NULL', name: 'mentions_status_id_null', validate: false
+  end
+end

--- a/db/migrate/20240607093954_validate_change_mention_status_id_non_nullable.rb
+++ b/db/migrate/20240607093954_validate_change_mention_status_id_non_nullable.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class ValidateChangeMentionStatusIdNonNullable < ActiveRecord::Migration[7.1]
+  def up
+    validate_check_constraint :mentions, name: 'mentions_status_id_null'
+    change_column_null :mentions, :status_id, false
+    remove_check_constraint :mentions, name: 'mentions_status_id_null'
+  end
+
+  def down
+    add_check_constraint :mentions, 'status_id IS NOT NULL', name: 'mentions_status_id_null', validate: false
+    change_column_null :mentions, :status_id, true
+  end
+end

--- a/db/migrate/20240607094603_change_mention_account_id_non_nullable.rb
+++ b/db/migrate/20240607094603_change_mention_account_id_non_nullable.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ChangeMentionAccountIdNonNullable < ActiveRecord::Migration[7.1]
+  def change
+    add_check_constraint :mentions, 'account_id IS NOT NULL', name: 'mentions_account_id_null', validate: false
+  end
+end

--- a/db/migrate/20240607094856_validate_change_mention_account_id_non_nullable.rb
+++ b/db/migrate/20240607094856_validate_change_mention_account_id_non_nullable.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class ValidateChangeMentionAccountIdNonNullable < ActiveRecord::Migration[7.1]
+  def up
+    validate_check_constraint :mentions, name: 'mentions_account_id_null'
+    change_column_null :mentions, :account_id, false
+    remove_check_constraint :mentions, name: 'mentions_account_id_null'
+  end
+
+  def down
+    add_check_constraint :mentions, 'account_id IS NOT NULL', name: 'mentions_account_id_null', validate: false
+    change_column_null :mentions, :account_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_03_195202) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_07_094856) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -661,10 +661,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_03_195202) do
   end
 
   create_table "mentions", force: :cascade do |t|
-    t.bigint "status_id"
+    t.bigint "status_id", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
-    t.bigint "account_id"
+    t.bigint "account_id", null: false
     t.boolean "silent", default: false, null: false
     t.index ["account_id", "status_id"], name: "index_mentions_on_account_id_and_status_id", unique: true
     t.index ["status_id"], name: "index_mentions_on_status_id"


### PR DESCRIPTION
They have Ruby-side validation and postgres-side cascading deletes, so those should never be null, but adding a database constraint doesn't hurt.