### PR TITLE
Dont include peer dirs in devcontainer compose config

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: .
       dockerfile: Dockerfile
     volumes:
-      - ../..:/workspaces:cached
+      - ..:/workspaces/mastodon:cached
     environment:
       RAILS_ENV: development
       NODE_ENV: development


### PR DESCRIPTION
This is just the directory change portion of https://github.com/mastodon/mastodon/pull/30582

Will continue to iterate on style/doc changes in that one.

This fixes the issue where all peer directories are included in the resulting image from the devcontainers/docker/compose build.