### PR TITLE
Align root/vscode user dynamic for codespaces with non-codespaces config

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,7 +5,7 @@ FROM mcr.microsoft.com/devcontainers/ruby:1-3.3-bookworm
 # RUN gem install rails webdrivers
 
 ARG NODE_VERSION="20"
-RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"
+RUN . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1
 
 # [Optional] Uncomment this section to install additional OS packages.
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
@@ -15,6 +15,6 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 RUN gem install foreman
 
 # [Optional] Uncomment this line to install global node packages.
-RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && corepack enable" 2>&1
+RUN . /usr/local/share/nvm/nvm.sh && corepack enable 2>&1
 
 COPY welcome-message.txt /usr/local/etc/vscode-dev-containers/first-run-notice.txt

--- a/.devcontainer/codespaces/devcontainer.json
+++ b/.devcontainer/codespaces/devcontainer.json
@@ -23,6 +23,8 @@
     }
   },
 
+  "remoteUser": "root",
+
   "otherPortsAttributes": {
     "onAutoForward": "silent"
   },


### PR DESCRIPTION
Extracted from https://github.com/mastodon/mastodon/pull/30582 and also a follow-up on https://github.com/mastodon/mastodon/pull/30574 including changes which should have been there as well.

Part of ongoing attempt to make the entire container config less broken, and make the "local docker compose", "local vscode devcontainer" and "remote codespaces devcontainer" all work basically the same way as each other.

As noted in the first PR, we may eventually want to migrate all of this to use a "mastodon" user like the main production Dockerfile approach, but for now trying to go for "less broken" before "perfect".