### PR TITLE
Remove `fuubar` gem and custom rspec `--format` setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ docker-compose.override.yml
 
 # Ignore dotenv .local files
 .env*.local
+
+# Ignore local-only rspec configuration
+.rspec-local

--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,2 @@
 --color
 --require spec_helper
---format Fuubar

--- a/Gemfile
+++ b/Gemfile
@@ -126,9 +126,6 @@ group :test do
   # Adds RSpec Error/Warning annotations to GitHub PRs on the Files tab
   gem 'rspec-github', '~> 2.4', require: false
 
-  # RSpec progress bar formatter
-  gem 'fuubar', '~> 2.5'
-
   # RSpec helpers for email specs
   gem 'email_spec'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -284,9 +284,6 @@ GEM
     fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
-    fuubar (2.5.1)
-      rspec-core (~> 3.0)
-      ruby-progressbar (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
     google-protobuf (3.25.4)
@@ -943,7 +940,6 @@ DEPENDENCIES
   flatware-rspec
   fog-core (<= 2.5.0)
   fog-openstack (~> 1.0)
-  fuubar (~> 2.5)
   haml-rails (~> 2.0)
   haml_lint
   hcaptcha (~> 7.1)


### PR DESCRIPTION
Instead of specifying this at the project level, we can stick to rspec defaults.

Developers can install custom formatting gems and specify that format in their `.rspec-local` (added to gitignore here) if desired.

We get a *slight* bundle size reduction from removing the gem.