### PR TITLE
Improve handling of libvips failures

### DIFF
--- a/lib/paperclip/blurhash_transcoder.rb
+++ b/lib/paperclip/blurhash_transcoder.rb
@@ -12,6 +12,8 @@ module Paperclip
       attachment.instance.blurhash = Blurhash.encode(width, height, data, **(options[:blurhash] || {}))
 
       @file
+    rescue Vips::Error => e
+      raise Paperclip::Error, "Error while generating blurhash for #{@basename}: #{e}"
     end
 
     private

--- a/lib/paperclip/color_extractor.rb
+++ b/lib/paperclip/color_extractor.rb
@@ -69,6 +69,8 @@ module Paperclip
       attachment.instance.file.instance_write(:meta, (attachment.instance.file.instance_read(:meta) || {}).merge(meta))
 
       @file
+    rescue Vips::Error => e
+      raise Paperclip::Error, "Error while extracting colors for #{@basename}: #{e}"
     end
 
     private

--- a/lib/paperclip/vips_lazy_thumbnail.rb
+++ b/lib/paperclip/vips_lazy_thumbnail.rb
@@ -68,7 +68,7 @@ module Paperclip
       end
 
       dst
-    rescue Terrapin::ExitStatusError => e
+    rescue Vips::Error, Terrapin::ExitStatusError => e
       raise Paperclip::Error, "Error while optimizing #{@basename}: #{e}"
     rescue Terrapin::CommandNotFoundError
       raise Paperclip::Errors::CommandNotFoundError, 'Could not run the `ffmpeg` command. Please install ffmpeg.'


### PR DESCRIPTION
Treat libvips failures as paperclip failures so that they are caught and handled like other media processing failures.