### PR TITLE
Fix cutoff of instance name

### DIFF
--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -613,9 +613,10 @@ code {
       font-family: inherit;
       pointer-events: none;
       cursor: default;
-      max-width: 140px;
+      max-width: 50%;
       white-space: nowrap;
       overflow: hidden;
+      text-overflow: ellipsis;
 
       &::after {
         content: '';


### PR DESCRIPTION
This is an attempt to prove the situation mentioned in #10327. Long instance names get cutoff very early in the sign up form:

![image](https://github.com/mastodon/mastodon/assets/68106/0aef77ee-ac15-4f03-bb8d-fb40609db202)

I do not think there is a definitive "fix" for this, as the cutoff has to happen somewhere, or there will not be any space left to enter the desired username. Also, since the username is the important thing here, it would look strange to me if the instance name took a lot of space.

So this PR is a suggestions for how to improve the situation for most if not all cases. I am not a designer but I thought that granting at the most half the available space to the instance name has a nice symmetry. So for a really long name it would look like this:

![image](https://github.com/mastodon/mastodon/assets/68106/fd23a710-792a-40ca-b4d4-df6d2b69c0fa)

And I added `text-overflow` to at least somewhat improve the situation for instance names that are even longer:

![image](https://github.com/mastodon/mastodon/assets/68106/248c05de-5ffa-4abc-8f1f-42c552c1023c)
