### PR TITLE
Install from nvmrc during devcontainer Dockerfile build

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,17 +1,15 @@
 # For details, see https://github.com/devcontainers/images/tree/main/src/ruby
 FROM mcr.microsoft.com/devcontainers/ruby:1-3.3-bookworm
 
-# Update existing node version, keep in sync with .nvmrc
-ARG NODE_VERSION="20"
-RUN . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1
+# Install node version from .nvmrc
+WORKDIR /app
+COPY .nvmrc .
+RUN /bin/bash --login -i -c "nvm install"
 
 # Install additional OS packages
 RUN apt-get update && \
     export DEBIAN_FRONTEND=noninteractive && \
     apt-get -y install --no-install-recommends libicu-dev libidn11-dev ffmpeg imagemagick libvips42 libpam-dev
 
-# Install global node packages
-RUN . /usr/local/share/nvm/nvm.sh && corepack enable 2>&1
-
 # Move welcome message to where VS Code expects it
-COPY welcome-message.txt /usr/local/etc/vscode-dev-containers/first-run-notice.txt
+COPY .devcontainer/welcome-message.txt /usr/local/etc/vscode-dev-containers/first-run-notice.txt

--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -2,8 +2,8 @@ services:
   app:
     working_dir: /workspaces/mastodon/
     build:
-      context: .
-      dockerfile: Dockerfile
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
     volumes:
       - ..:/workspaces/mastodon:cached
     environment:

--- a/bin/setup
+++ b/bin/setup
@@ -18,7 +18,7 @@ FileUtils.chdir APP_ROOT do
   system('bundle check') || system!('bundle install')
 
   puts "\n== Installing JS dependencies =="
-  system! 'corepack prepare'
+  system! 'corepack enable'
   system! 'bin/yarn install --immutable'
 
   puts "\n== Preparing database =="


### PR DESCRIPTION
One more extraction from https://github.com/mastodon/mastodon/pull/30582

This one removes a few unused commands from the devcontainer Dockerfile, and does a little style/formatting/comment cleanup while in there.

Should leave that other PR as just the compose.yaml file move, and README doc changes.

I left the "read from .nvmrc" out of this one, because doing that exceeds my (barebones) Docker-best-practices knowledge. Will leave as followup for someone else, or when I learn the best way to do that 4 days from now.