### PR TITLE
Use async count in admin dashboard

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -7,12 +7,12 @@ module Admin
     def index
       authorize :dashboard, :index?
 
+      @pending_appeals_count = Appeal.pending.async_count
+      @pending_reports_count = Report.unresolved.async_count
+      @pending_tags_count    = Tag.pending_review.async_count
+      @pending_users_count   = User.pending.async_count
       @system_checks         = Admin::SystemCheck.perform(current_user)
       @time_period           = (29.days.ago.to_date...Time.now.utc.to_date)
-      @pending_users_count   = User.pending.count
-      @pending_reports_count = Report.unresolved.count
-      @pending_tags_count    = Tag.pending_review.count
-      @pending_appeals_count = Appeal.pending.count
     end
   end
 end

--- a/app/views/admin/dashboard/index.html.haml
+++ b/app/views/admin/dashboard/index.html.haml
@@ -56,19 +56,19 @@
 
   .dashboard__item
     = link_to admin_reports_path, class: 'dashboard__quick-access' do
-      %span= t('admin.dashboard.pending_reports_html', count: @pending_reports_count)
+      %span= t('admin.dashboard.pending_reports_html', count: @pending_reports_count.value)
       = material_symbol 'chevron_right'
 
     = link_to admin_accounts_path(status: 'pending'), class: 'dashboard__quick-access' do
-      %span= t('admin.dashboard.pending_users_html', count: @pending_users_count)
+      %span= t('admin.dashboard.pending_users_html', count: @pending_users_count.value)
       = material_symbol 'chevron_right'
 
     = link_to admin_trends_tags_path(status: 'pending_review'), class: 'dashboard__quick-access' do
-      %span= t('admin.dashboard.pending_tags_html', count: @pending_tags_count)
+      %span= t('admin.dashboard.pending_tags_html', count: @pending_tags_count.value)
       = material_symbol 'chevron_right'
 
     = link_to admin_disputes_appeals_path(status: 'pending'), class: 'dashboard__quick-access' do
-      %span= t('admin.dashboard.pending_appeals_html', count: @pending_appeals_count)
+      %span= t('admin.dashboard.pending_appeals_html', count: @pending_appeals_count.value)
       = material_symbol 'chevron_right'
   .dashboard__item
     = react_admin_component :dimension,


### PR DESCRIPTION
This has basic changes to add async counting.

Running `bin/rspec spec/controllers/admin/dashboard_controller_spec.rb` passes in main and should pass here.

Related to: https://github.com/rails/rails/issues/50776#issuecomment-2148308441

Once Rails 7.1.4 (or 7.2) released, this can rebase and should work.