### PR TITLE
Clean up `theme_helper` style builders

### DIFF
--- a/app/helpers/theme_helper.rb
+++ b/app/helpers/theme_helper.rb
@@ -3,8 +3,10 @@
 module ThemeHelper
   def theme_style_tags(theme)
     if theme == 'system'
-      stylesheet_pack_tag('mastodon-light', media: 'not all and (prefers-color-scheme: dark)', crossorigin: 'anonymous') +
-        stylesheet_pack_tag('default', media: '(prefers-color-scheme: dark)', crossorigin: 'anonymous')
+      ''.html_safe.tap do |tags|
+        tags << stylesheet_pack_tag('mastodon-light', media: 'not all and (prefers-color-scheme: dark)', crossorigin: 'anonymous')
+        tags << stylesheet_pack_tag('default', media: '(prefers-color-scheme: dark)', crossorigin: 'anonymous')
+      end
     else
       stylesheet_pack_tag theme, media: 'all', crossorigin: 'anonymous'
     end
@@ -12,8 +14,10 @@ module ThemeHelper
 
   def theme_color_tags(theme)
     if theme == 'system'
-      tag.meta(name: 'theme-color', content: Themes::THEME_COLORS[:dark], media: '(prefers-color-scheme: dark)') +
-        tag.meta(name: 'theme-color', content: Themes::THEME_COLORS[:light], media: '(prefers-color-scheme: light)')
+      ''.html_safe.tap do |tags|
+        tags << tag.meta(name: 'theme-color', content: Themes::THEME_COLORS[:dark], media: '(prefers-color-scheme: dark)')
+        tags << tag.meta(name: 'theme-color', content: Themes::THEME_COLORS[:light], media: '(prefers-color-scheme: light)')
+      end
     else
       tag.meta name: 'theme-color', content: theme_color_for(theme)
     end


### PR DESCRIPTION
History:

- Methods added in https://github.com/mastodon/mastodon/pull/29795/files
- Separated theme/color methods (and moved to own helper file) in https://github.com/mastodon/mastodon/pull/29802/files
- Discovered a bug where the `concat` approach was producing multiple html outputs
- Fixed (with spec) in https://github.com/mastodon/mastodon/pull/29918/files

Change here is to loop through the options and build an html safe string to return. This is slightly more elegant than the current approach of multiple method calls combined with `+`, I think - while still passing the spec.

As noted in the previous PR that fixed the issue, that spec is sort of in a weird spot, good improvement would be to move to a view spec for the layout or just the `head` section or something.

Separately, there are some other helpers (account_link_to most notably, maybe more) that are a bit unwiedly now might benefit from similar changes.