### PR TITLE
Improve timeline tests when the instance does not allow public preview

### DIFF
--- a/spec/requests/api/v1/timelines/public_spec.rb
+++ b/spec/requests/api/v1/timelines/public_spec.rb
@@ -105,6 +105,18 @@ describe 'Public' do
         it_behaves_like 'a successful request to the public timeline'
       end
 
+      context 'with an authenticated application' do
+        let(:client_app) { Fabricate(:application) }
+        let(:token) { Fabricate(:accessible_access_token, application: client_app, scopes: scopes) }
+
+        # it_behaves_like 'a successful request to the public timeline'
+        it 'returns http unprocessable entity' do
+          subject
+
+          expect(response).to have_http_status(422)
+        end
+      end
+
       context 'with an unauthenticated user' do
         let(:headers) { {} }
 

--- a/spec/requests/api/v1/timelines/public_spec.rb
+++ b/spec/requests/api/v1/timelines/public_spec.rb
@@ -95,37 +95,28 @@ describe 'Public' do
     end
 
     context 'when the instance does not allow public preview' do
+      let(:expected_statuses) { [local_status, remote_status, media_status] }
+
       before do
         Form::AdminSettings.new(timeline_preview: false).save
       end
 
       context 'with an authenticated user' do
-        let(:expected_statuses) { [local_status, remote_status, media_status] }
-
         it_behaves_like 'a successful request to the public timeline'
+      end
+
+      context 'with an authenticated user but using the wrong scope' do
+        it_behaves_like 'forbidden for wrong scope', 'follow'
       end
 
       context 'with an authenticated application' do
         let(:client_app) { Fabricate(:application) }
         let(:token) { Fabricate(:accessible_access_token, application: client_app, scopes: scopes) }
 
-        # it_behaves_like 'a successful request to the public timeline'
-        it 'returns http unprocessable entity' do
-          subject
-
-          expect(response).to have_http_status(422)
-        end
+        it_behaves_like 'a successful request to the public timeline'
       end
 
-      context 'with an unauthenticated user' do
-        let(:headers) { {} }
-
-        it 'returns http unprocessable entity' do
-          subject
-
-          expect(response).to have_http_status(422)
-        end
-      end
+      it_behaves_like 'unauthorized for invalid token'
     end
   end
 end

--- a/spec/requests/api/v2/filters_spec.rb
+++ b/spec/requests/api/v2/filters_spec.rb
@@ -8,16 +8,6 @@ RSpec.describe 'Filters' do
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
 
-  shared_examples 'unauthorized for invalid token' do
-    let(:headers) { { 'Authorization' => '' } }
-
-    it 'returns http unauthorized' do
-      subject
-
-      expect(response).to have_http_status(401)
-    end
-  end
-
   describe 'GET /api/v2/filters' do
     subject do
       get '/api/v2/filters', headers: headers

--- a/spec/support/examples/api.rb
+++ b/spec/support/examples/api.rb
@@ -21,3 +21,35 @@ shared_examples 'forbidden for wrong role' do |wrong_role|
     expect(response).to have_http_status(403)
   end
 end
+
+shared_examples 'unprocessable entity' do
+  it 'returns http unprocessable entity' do
+    # Some examples have a subject which needs to be called to make a request
+    subject if request.nil?
+
+    expect(response).to have_http_status(422)
+  end
+end
+
+shared_examples 'unauthorized for invalid token' do
+  context 'with empty Authorization header' do
+    let(:headers) { { 'Authorization' => '' } }
+
+    it 'returns http unauthorized' do
+      # Some examples have a subject which needs to be called to make a request
+      subject if request.nil?
+
+      expect(response).to have_http_status(401)
+    end
+  end
+
+  context 'without Authorization header' do
+    let(:headers) { {} }
+
+    it 'returns http unprocessable entity' do
+      subject
+
+      expect(response).to have_http_status(401)
+    end
+  end
+end


### PR DESCRIPTION
Currently the documentation says that `GET /api/v1/timelines/public`:
> OAuth: Public. Requires app token + read:statuses if the instance has disabled public preview.

However, it seems the code is explicitly asserting that a User token is used via `require_user!`, additionally the OAuth scopes are not asserted correctly as being `read` and `read:statuses`.

These new test cases are intended to fail until the correct behaviour is decided upon, cc @ClearlyClaire 

I think we need to change [the controller](https://github.com/ClearlyClaire/mastodon/blob/master/app/controllers/api/v1/timelines/public_controller.rb) to use:
```
before_action -> { authorize_if_got_token! :read, :'read:statuses' }
```

And change the documentation to say that it requires a User token, not an App token (much like how streaming since 4.2 doesn't allow App tokens or Public access).

### Note: this issue is semi-present or divergent in all `/api/v1/timelines` endpoints:
- `GET /api/v1/timelines/tag/:hashtag`
- `GET /api/v1/timelines/link`
- `GET /api/v1/timelines/public`

However, `GET /api/v1/timelines/public` is the more problematic one of the three.