### PR TITLE
Extract `SIGN_COUNT_LIMIT` constant in `WebauthnCredential` class

### DIFF
--- a/app/models/webauthn_credential.rb
+++ b/app/models/webauthn_credential.rb
@@ -15,9 +15,11 @@
 #
 
 class WebauthnCredential < ApplicationRecord
+  SIGN_COUNT_LIMIT = (2**63)
+
   validates :external_id, :public_key, :nickname, :sign_count, presence: true
   validates :external_id, uniqueness: true
   validates :nickname, uniqueness: { scope: :user_id }
   validates :sign_count,
-            numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: (2**63) - 1 }
+            numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: SIGN_COUNT_LIMIT - 1 }
 end

--- a/spec/models/webauthn_credential_spec.rb
+++ b/spec/models/webauthn_credential_spec.rb
@@ -71,8 +71,8 @@ RSpec.describe WebauthnCredential do
       expect(webauthn_credential).to model_have_error_on_field(:sign_count)
     end
 
-    it 'is invalid if sign_count is greater 2**63 - 1' do
-      webauthn_credential = Fabricate.build(:webauthn_credential, sign_count: 2**63)
+    it 'is invalid if sign_count is greater than the limit' do
+      webauthn_credential = Fabricate.build(:webauthn_credential, sign_count: (described_class::SIGN_COUNT_LIMIT * 2))
 
       webauthn_credential.valid?
 


### PR DESCRIPTION
Two changes:

- Pull out constant for pg col value limit
- The model spec file was mis-named (webauthn_credentials_spec), moved to singular-name after model name

