### PR TITLE
Check both before/after state in `AccountDomainBlock` spec

### DIFF
--- a/spec/models/account_domain_block_spec.rb
+++ b/spec/models/account_domain_block_spec.rb
@@ -3,8 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe AccountDomainBlock do
+  let(:account) { Fabricate(:account) }
+
   it 'removes blocking cache after creation' do
-    account = Fabricate(:account)
     Rails.cache.write("exclude_domains_for:#{account.id}", 'a.domain.already.blocked')
 
     described_class.create!(account: account, domain: 'a.domain.blocked.later')
@@ -13,7 +14,6 @@ RSpec.describe AccountDomainBlock do
   end
 
   it 'removes blocking cache after destruction' do
-    account = Fabricate(:account)
     block = described_class.create!(account: account, domain: 'domain')
     Rails.cache.write("exclude_domains_for:#{account.id}", 'domain')
 

--- a/spec/models/account_domain_block_spec.rb
+++ b/spec/models/account_domain_block_spec.rb
@@ -8,13 +8,13 @@ RSpec.describe AccountDomainBlock do
   it 'removes blocking cache after creation' do
     Rails.cache.write("exclude_domains_for:#{account.id}", 'a.domain.already.blocked')
 
-    described_class.create!(account: account, domain: 'a.domain.blocked.later')
+    Fabricate(:account_domain_block, account: account, domain: 'a.domain.blocked.later')
 
     expect(account_has_exclude_domains_cache?).to be false
   end
 
   it 'removes blocking cache after destruction' do
-    block = described_class.create!(account: account, domain: 'domain')
+    block = Fabricate(:account_domain_block, account: account, domain: 'domain')
     Rails.cache.write("exclude_domains_for:#{account.id}", 'domain')
 
     block.destroy!

--- a/spec/models/account_domain_block_spec.rb
+++ b/spec/models/account_domain_block_spec.rb
@@ -8,21 +8,22 @@ RSpec.describe AccountDomainBlock do
   it 'removes blocking cache after creation' do
     Rails.cache.write("exclude_domains_for:#{account.id}", 'a.domain.already.blocked')
 
-    expect do
-      Fabricate(
-        :account_domain_block,
-        account: account,
-        domain: 'a.domain.blocked.later'
-      )
-    end.to change { account_has_exclude_domains_cache? }.to(false)
+    expect { build_account_domain_block('a.domain.blocked.later') }
+      .to change { account_has_exclude_domains_cache? }.to(false)
   end
 
   it 'removes blocking cache after destruction' do
-    block = Fabricate(:account_domain_block, account: account, domain: 'domain')
+    block = build_account_domain_block('domain')
     Rails.cache.write("exclude_domains_for:#{account.id}", 'domain')
 
     expect { block.destroy! }
       .to change { account_has_exclude_domains_cache? }.to(false)
+  end
+
+  private
+
+  def build_account_domain_block(domain)
+    Fabricate(:account_domain_block, account: account, domain: domain)
   end
 
   def account_has_exclude_domains_cache?

--- a/spec/models/account_domain_block_spec.rb
+++ b/spec/models/account_domain_block_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe AccountDomainBlock do
 
     described_class.create!(account: account, domain: 'a.domain.blocked.later')
 
-    expect(Rails.cache.exist?("exclude_domains_for:#{account.id}")).to be false
+    expect(account_has_exclude_domains_cache?).to be false
   end
 
   it 'removes blocking cache after destruction' do
@@ -19,6 +19,10 @@ RSpec.describe AccountDomainBlock do
 
     block.destroy!
 
-    expect(Rails.cache.exist?("exclude_domains_for:#{account.id}")).to be false
+    expect(account_has_exclude_domains_cache?).to be false
+  end
+
+  def account_has_exclude_domains_cache?
+    Rails.cache.exist?("exclude_domains_for:#{account.id}")
   end
 end

--- a/spec/models/account_domain_block_spec.rb
+++ b/spec/models/account_domain_block_spec.rb
@@ -8,18 +8,21 @@ RSpec.describe AccountDomainBlock do
   it 'removes blocking cache after creation' do
     Rails.cache.write("exclude_domains_for:#{account.id}", 'a.domain.already.blocked')
 
-    Fabricate(:account_domain_block, account: account, domain: 'a.domain.blocked.later')
-
-    expect(account_has_exclude_domains_cache?).to be false
+    expect do
+      Fabricate(
+        :account_domain_block,
+        account: account,
+        domain: 'a.domain.blocked.later'
+      )
+    end.to change { account_has_exclude_domains_cache? }.to(false)
   end
 
   it 'removes blocking cache after destruction' do
     block = Fabricate(:account_domain_block, account: account, domain: 'domain')
     Rails.cache.write("exclude_domains_for:#{account.id}", 'domain')
 
-    block.destroy!
-
-    expect(account_has_exclude_domains_cache?).to be false
+    expect { block.destroy! }
+      .to change { account_has_exclude_domains_cache? }.to(false)
   end
 
   def account_has_exclude_domains_cache?

--- a/spec/models/account_domain_block_spec.rb
+++ b/spec/models/account_domain_block_spec.rb
@@ -8,12 +8,12 @@ RSpec.describe AccountDomainBlock do
   it 'removes blocking cache after creation' do
     Rails.cache.write("exclude_domains_for:#{account.id}", 'a.domain.already.blocked')
 
-    expect { build_account_domain_block('a.domain.blocked.later') }
+    expect { block_domain_for_account('a.domain.blocked.later') }
       .to change { account_has_exclude_domains_cache? }.to(false)
   end
 
   it 'removes blocking cache after destruction' do
-    block = build_account_domain_block('domain')
+    block = block_domain_for_account('domain')
     Rails.cache.write("exclude_domains_for:#{account.id}", 'domain')
 
     expect { block.destroy! }
@@ -22,7 +22,7 @@ RSpec.describe AccountDomainBlock do
 
   private
 
-  def build_account_domain_block(domain)
+  def block_domain_for_account(domain)
     Fabricate(:account_domain_block, account: account, domain: domain)
   end
 


### PR DESCRIPTION
Diff is a little messy here, but individual commits should be obvious.

Changes:

- Use fabricator instead of model `create`
- Both examples had common setup (account), moved to `let`
- Updated both examples to use `change` so we can be sure we're actually asserting something happened
- Added convenience query method to check the state of the cache from both examples