### PR TITLE
Update macOS local dev setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,18 +86,18 @@ A **Vagrant** configuration is included for development purposes. To use it, com
 - Run `vagrant ssh -c "cd /vagrant && bin/dev"`
 - Open `http://mastodon.local` in your browser
 
-### MacOS
+### macOS
 
-To set up **MacOS** for native development, complete the following steps:
+To set up **macOS** for native development, complete the following steps:
 
-- Use a Ruby version manager to install the specified version from `.ruby-version`
-- Run `bundle` to install required gems
-- Run `brew install postgresql@14 redis imagemagick libidn` to install required dependencies
-- Navigate to Mastodon's root directory and run `brew install nvm` then `nvm use` to use the version from `.nvmrc`
-- Run `yarn` to install required packages
-- Run `corepack enable && corepack prepare`
-- Run `RAILS_ENV=development bundle exec rails db:setup`
-- Finally, run `bin/dev` which will launch the local services via `overmind` (if installed) or `foreman`
+- Install [Homebrew] and run `brew install postgresql@14 redis imagemagick
+libidn nvm` to install the required project dependencies
+- Use a Ruby version manager to activate the ruby in `.ruby-version` and run
+  `nvm use` to activate the node version from `.nvmrc`
+- Run the `bin/setup` script, which will install the required ruby gems and node
+  packages and prepare the database for local development
+- Finally, run the `bin/dev` script which will launch services via `overmind`
+  (if installed) or `foreman`
 
 ### Docker
 
@@ -155,3 +155,4 @@ You should have received a copy of the GNU Affero General Public License along w
 [Development Containers]: https://containers.dev/supporting
 [Docker]: https://docs.docker.com
 [GitHub Codespaces]: https://docs.github.com/en/codespaces
+[Homebrew]: https://brew.sh


### PR DESCRIPTION
Followup on https://github.com/mastodon/mastodon/pull/30582

Many of the things included in this section are done by the `bin/setup` script, so we can just instruct to use that.