### PR TITLE
Move omniauth feature enabled checks to `config_for` yml

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -79,7 +79,7 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sign_out_path_for(_resource_or_scope)
-    if ENV['OMNIAUTH_ONLY'] == 'true' && ENV['OIDC_ENABLED'] == 'true'
+    if Rails.configuration.x.omniauth.only && Rails.configuration.x.omniauth.oidc_enabled
       '/auth/auth/openid_connect/logout'
     else
       new_user_session_path

--- a/app/controllers/concerns/web_app_controller_concern.rb
+++ b/app/controllers/concerns/web_app_controller_concern.rb
@@ -21,7 +21,7 @@ module WebAppControllerConcern
   end
 
   def skip_csrf_meta_tags?
-    !(ENV['ONE_CLICK_SSO_LOGIN'] == 'true' && ENV['OMNIAUTH_ONLY'] == 'true' && Devise.omniauth_providers.length == 1) && current_user.nil?
+    !(ENV['ONE_CLICK_SSO_LOGIN'] == 'true' && Rails.configuration.x.omniauth.only && Devise.omniauth_providers.length == 1) && current_user.nil?
   end
 
   def set_app_body_class

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -43,7 +43,7 @@ module ApplicationHelper
   end
 
   def omniauth_only?
-    ENV['OMNIAUTH_ONLY'] == 'true'
+    Rails.configuration.x.omniauth.only
   end
 
   def link_to_login(name = nil, html_options = nil, &block)

--- a/app/helpers/registration_helper.rb
+++ b/app/helpers/registration_helper.rb
@@ -12,7 +12,7 @@ module RegistrationHelper
   end
 
   def omniauth_only?
-    ENV['OMNIAUTH_ONLY'] == 'true'
+    Rails.configuration.x.omniauth.only
   end
 
   def ip_blocked?(remote_ip)

--- a/app/lib/content_security_policy.rb
+++ b/app/lib/content_security_policy.rb
@@ -14,7 +14,7 @@ class ContentSecurityPolicy
   end
 
   def sso_host
-    return unless ENV['ONE_CLICK_SSO_LOGIN'] == 'true' && ENV['OMNIAUTH_ONLY'] == 'true' && Devise.omniauth_providers.length == 1
+    return unless ENV['ONE_CLICK_SSO_LOGIN'] == 'true' && Rails.configuration.omniauth.only && Devise.omniauth_providers.length == 1
 
     provider = Devise.omniauth_configs[Devise.omniauth_providers[0]]
     @sso_host ||= begin

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -125,6 +125,6 @@ class InitialStateSerializer < ActiveModel::Serializer
   end
 
   def sso_redirect
-    "/auth/auth/#{Devise.omniauth_providers[0]}" if ENV['ONE_CLICK_SSO_LOGIN'] == 'true' && ENV['OMNIAUTH_ONLY'] == 'true' && Devise.omniauth_providers.length == 1
+    "/auth/auth/#{Devise.omniauth_providers[0]}" if ENV['ONE_CLICK_SSO_LOGIN'] == 'true' && Rails.configuration.x.omniauth.only && Devise.omniauth_providers.length == 1
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -106,6 +106,7 @@ module Mastodon
 
     config.x.captcha = config_for(:captcha)
     config.x.mastodon = config_for(:mastodon)
+    config.x.omniauth = config_for(:omniauth)
     config.x.translation = config_for(:translation)
 
     config.to_prepare do

--- a/config/initializers/3_omniauth.rb
+++ b/config/initializers/3_omniauth.rb
@@ -10,7 +10,7 @@ end
 
 Devise.setup do |config|
   # CAS strategy
-  if ENV['CAS_ENABLED'] == 'true'
+  if Rails.configuration.x.omniauth.cas_enabled
     cas_options = {}
     cas_options[:display_name] = ENV['CAS_DISPLAY_NAME']
     cas_options[:url] = ENV['CAS_URL'] if ENV['CAS_URL']
@@ -39,7 +39,7 @@ Devise.setup do |config|
   end
 
   # SAML strategy
-  if ENV['SAML_ENABLED'] == 'true'
+  if Rails.configuration.x.omniauth.saml_enabled
     saml_options = {}
     saml_options[:display_name] = ENV['SAML_DISPLAY_NAME']
     saml_options[:assertion_consumer_service_url] = ENV['SAML_ACS_URL'] if ENV['SAML_ACS_URL']
@@ -71,7 +71,7 @@ Devise.setup do |config|
   end
 
   # OpenID Connect Strategy
-  if ENV['OIDC_ENABLED'] == 'true'
+  if Rails.configuration.x.omniauth.oidc_enabled
     oidc_options = {}
     oidc_options[:display_name] = ENV['OIDC_DISPLAY_NAME'] # OPTIONAL
     oidc_options[:issuer] = ENV['OIDC_ISSUER'] if ENV['OIDC_ISSUER'] # NEED

--- a/config/omniauth.yml
+++ b/config/omniauth.yml
@@ -1,0 +1,6 @@
+---
+shared:
+  only: <%= ENV.fetch('OMNIAUTH_ONLY', 'false') == 'true' %>
+  cas_enabled: <%= ENV.fetch('CAS_ENABLED', 'false') == 'true' %>
+  oidc_enabled: <%= ENV.fetch('OIDC_ENABLED', 'false') == 'true' %>
+  saml_enabled: <%= ENV.fetch('SAML_ENABLED', 'false') == 'true' %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -100,9 +100,10 @@ RSpec.describe ApplicationHelper do
 
     context 'when in omniauth only mode' do
       around do |example|
-        ClimateControl.modify OMNIAUTH_ONLY: 'true' do
-          example.run
-        end
+        original = Rails.configuration.x.omniauth.only
+        Rails.configuration.x.omniauth.only = true
+        example.run
+        Rails.configuration.x.omniauth.only = original
       end
 
       it 'redirects to joinmastodon site' do
@@ -118,11 +119,12 @@ RSpec.describe ApplicationHelper do
   end
 
   describe 'omniauth_only?' do
-    context 'when env var is set to true' do
+    context 'when configuration is set to true' do
       around do |example|
-        ClimateControl.modify OMNIAUTH_ONLY: 'true' do
-          example.run
-        end
+        original = Rails.configuration.x.omniauth.only
+        Rails.configuration.x.omniauth.only = true
+        example.run
+        Rails.configuration.x.omniauth.only = original
       end
 
       it 'returns true' do
@@ -130,11 +132,12 @@ RSpec.describe ApplicationHelper do
       end
     end
 
-    context 'when env var is not set' do
+    context 'when configuration is false' do
       around do |example|
-        ClimateControl.modify OMNIAUTH_ONLY: nil do
-          example.run
-        end
+        original = Rails.configuration.x.omniauth.only
+        Rails.configuration.x.omniauth.only = false
+        example.run
+        Rails.configuration.x.omniauth.only = original
       end
 
       it 'returns false' do

--- a/spec/requests/omniauth_callbacks_spec.rb
+++ b/spec/requests/omniauth_callbacks_spec.rb
@@ -129,15 +129,15 @@ RSpec.describe 'OmniAuth callbacks' do
     end
   end
 
-  describe '#openid_connect', if: ENV['OIDC_ENABLED'] == 'true' && ENV['OIDC_SCOPE'].present? do
+  describe '#openid_connect', if: Rails.configuration.x.omniauth.oidc_enabled && ENV['OIDC_SCOPE'].present? do
     include_examples 'omniauth provider callbacks', :openid_connect
   end
 
-  describe '#cas', if: ENV['CAS_ENABLED'] == 'true' do
+  describe '#cas', if: Rails.configuration.x.omniauth.cas_enabled do
     include_examples 'omniauth provider callbacks', :cas
   end
 
-  describe '#saml', if: ENV['SAML_ENABLED'] == 'true' do
+  describe '#saml', if: Rails.configuration.x.omniauth.saml_enabled do
     include_examples 'omniauth provider callbacks', :saml
   end
 end


### PR DESCRIPTION
Extracted from https://github.com/mastodon/mastodon/pull/30507 but includes only the migration of the top level "is this enabled?" checks. Leaves the bulk of the actual config value migration for later changes.