### PR TITLE
Extract permitted params constant in v1/admin/tags

### DIFF
--- a/app/controllers/api/v1/admin/tags_controller.rb
+++ b/app/controllers/api/v1/admin/tags_controller.rb
@@ -13,6 +13,13 @@ class Api::V1::Admin::TagsController < Api::BaseController
 
   LIMIT = 100
 
+  PERMITTED_PARAMS = %i(
+    display_name
+    listable
+    trendable
+    usable
+  ).freeze
+
   def index
     authorize :tag, :index?
     render json: @tags, each_serializer: REST::Admin::TagSerializer
@@ -40,7 +47,9 @@ class Api::V1::Admin::TagsController < Api::BaseController
   end
 
   def tag_params
-    params.permit(:display_name, :trendable, :usable, :listable)
+    params
+      .slice(*PERMITTED_PARAMS)
+      .permit(*PERMITTED_PARAMS)
   end
 
   def next_path


### PR DESCRIPTION
Related to https://github.com/mastodon/mastodon/pull/30377 and following up on https://github.com/mastodon/mastodon/pull/30379 and https://github.com/mastodon/mastodon/pull/30378

I have a branch that solves all or close to all of the errors we get from enabling the unpermitted raise behavior in test env, but its pretty large. Pulling this one out as an initial example to get the approach sorted. Will open slightly larger PRs to work through all changes if we're good with the approach.

The specific things here are:

- Style only - move the symbol list out of method params and into constant
- Related to unpermitted - add the `slice`. Without this, there's an `id` param coming in which gets passed in to the update method in this controller and raises the unpermitted error.

For many of the API controllers, you'd typically do something like `params.require(:tag).permit(...)`, but we have all the atributes right at the top level, so this `params.slice(...).permit(...)` pattern I think will be needed.