### PR TITLE
Improve separation of query helper and report classes in metrics/measure area

### DIFF
--- a/app/lib/admin/metrics/measure/instance_accounts_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_accounts_measure.rb
@@ -34,10 +34,10 @@ class Admin::Metrics::Measure::InstanceAccountsMeasure < Admin::Metrics::Measure
   def data_source_query
     Account
       .select(:id)
+      .where(account_domain_sql(params[:include_subdomains]))
       .where(
         <<~SQL.squish
           DATE_TRUNC('day', accounts.created_at)::date = axis.period
-            AND #{account_domain_sql(params[:include_subdomains])}
         SQL
       ).to_sql
   end

--- a/app/lib/admin/metrics/measure/instance_accounts_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_accounts_measure.rb
@@ -36,7 +36,6 @@ class Admin::Metrics::Measure::InstanceAccountsMeasure < Admin::Metrics::Measure
       .select(:id)
       .where(account_domain_sql(params[:include_subdomains]))
       .where(daily_period(:accounts))
-      .to_sql
   end
 
   def params

--- a/app/lib/admin/metrics/measure/instance_accounts_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_accounts_measure.rb
@@ -35,11 +35,8 @@ class Admin::Metrics::Measure::InstanceAccountsMeasure < Admin::Metrics::Measure
     Account
       .select(:id)
       .where(account_domain_sql(params[:include_subdomains]))
-      .where(
-        <<~SQL.squish
-          DATE_TRUNC('day', accounts.created_at)::date = axis.period
-        SQL
-      ).to_sql
+      .where(daily_period(:accounts))
+      .to_sql
   end
 
   def params

--- a/app/lib/admin/metrics/measure/instance_accounts_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_accounts_measure.rb
@@ -27,7 +27,7 @@ class Admin::Metrics::Measure::InstanceAccountsMeasure < Admin::Metrics::Measure
     nil
   end
 
-  def data_source_query
+  def data_source
     Account
       .select(:id)
       .where(account_domain_sql, domain: params[:domain])

--- a/app/lib/admin/metrics/measure/instance_accounts_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_accounts_measure.rb
@@ -34,7 +34,7 @@ class Admin::Metrics::Measure::InstanceAccountsMeasure < Admin::Metrics::Measure
   def data_source_query
     Account
       .select(:id)
-      .where(account_domain_sql(params[:include_subdomains]))
+      .where(account_domain_sql)
       .where(daily_period(:accounts))
   end
 

--- a/app/lib/admin/metrics/measure/instance_accounts_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_accounts_measure.rb
@@ -31,21 +31,15 @@ class Admin::Metrics::Measure::InstanceAccountsMeasure < Admin::Metrics::Measure
     [sql_query_string, { start_at: @start_at, end_at: @end_at, domain: params[:domain] }]
   end
 
-  def sql_query_string
-    <<~SQL.squish
-      SELECT axis.*, (
-        WITH new_accounts AS (
-          SELECT accounts.id
-          FROM accounts
-          WHERE date_trunc('day', accounts.created_at)::date = axis.period
+  def data_source_query
+    Account
+      .select(:id)
+      .where(
+        <<~SQL.squish
+          DATE_TRUNC('day', accounts.created_at)::date = axis.period
             AND #{account_domain_sql(params[:include_subdomains])}
-        )
-        SELECT count(*) FROM new_accounts
-      ) AS value
-      FROM (
-        #{generated_series_days}
-      ) AS axis
-    SQL
+        SQL
+      ).to_sql
   end
 
   def params

--- a/app/lib/admin/metrics/measure/instance_accounts_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_accounts_measure.rb
@@ -27,14 +27,10 @@ class Admin::Metrics::Measure::InstanceAccountsMeasure < Admin::Metrics::Measure
     nil
   end
 
-  def sql_array
-    [sql_query_string, { start_at: @start_at, end_at: @end_at, domain: params[:domain] }]
-  end
-
   def data_source_query
     Account
       .select(:id)
-      .where(account_domain_sql)
+      .where(account_domain_sql, domain: params[:domain])
       .where(daily_period(:accounts))
   end
 

--- a/app/lib/admin/metrics/measure/instance_accounts_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_accounts_measure.rb
@@ -31,7 +31,7 @@ class Admin::Metrics::Measure::InstanceAccountsMeasure < Admin::Metrics::Measure
     Account
       .select(:id)
       .merge(account_domain_scope)
-      .where(daily_period(:accounts))
+      .where(matching_day(Account, :created_at))
   end
 
   def params

--- a/app/lib/admin/metrics/measure/instance_accounts_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_accounts_measure.rb
@@ -30,7 +30,7 @@ class Admin::Metrics::Measure::InstanceAccountsMeasure < Admin::Metrics::Measure
   def data_source
     Account
       .select(:id)
-      .where(account_domain_sql, domain: params[:domain])
+      .merge(account_domain_scope)
       .where(daily_period(:accounts))
   end
 

--- a/app/lib/admin/metrics/measure/instance_followers_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_followers_measure.rb
@@ -36,11 +36,8 @@ class Admin::Metrics::Measure::InstanceFollowersMeasure < Admin::Metrics::Measur
       .select(:id)
       .joins(:account)
       .where(account_domain_sql(params[:include_subdomains]))
-      .where(
-        <<~SQL.squish
-          DATE_TRUNC('day', follows.created_at)::date = axis.period
-        SQL
-      ).to_sql
+      .where(daily_period(:follows))
+      .to_sql
   end
 
   def params

--- a/app/lib/admin/metrics/measure/instance_followers_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_followers_measure.rb
@@ -31,22 +31,16 @@ class Admin::Metrics::Measure::InstanceFollowersMeasure < Admin::Metrics::Measur
     [sql_query_string, { start_at: @start_at, end_at: @end_at, domain: params[:domain] }]
   end
 
-  def sql_query_string
-    <<~SQL.squish
-      SELECT axis.*, (
-        WITH new_followers AS (
-          SELECT follows.id
-          FROM follows
-          INNER JOIN accounts ON follows.account_id = accounts.id
-          WHERE date_trunc('day', follows.created_at)::date = axis.period
+  def data_source_query
+    Follow
+      .select(:id)
+      .joins(:account)
+      .where(
+        <<~SQL.squish
+          DATE_TRUNC('day', follows.created_at)::date = axis.period
             AND #{account_domain_sql(params[:include_subdomains])}
-        )
-        SELECT count(*) FROM new_followers
-      ) AS value
-      FROM (
-        #{generated_series_days}
-      ) AS axis
-    SQL
+        SQL
+      ).to_sql
   end
 
   def params

--- a/app/lib/admin/metrics/measure/instance_followers_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_followers_measure.rb
@@ -27,7 +27,7 @@ class Admin::Metrics::Measure::InstanceFollowersMeasure < Admin::Metrics::Measur
     nil
   end
 
-  def data_source_query
+  def data_source
     Follow
       .select(:id)
       .joins(:account)

--- a/app/lib/admin/metrics/measure/instance_followers_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_followers_measure.rb
@@ -35,7 +35,7 @@ class Admin::Metrics::Measure::InstanceFollowersMeasure < Admin::Metrics::Measur
     Follow
       .select(:id)
       .joins(:account)
-      .where(account_domain_sql(params[:include_subdomains]))
+      .where(account_domain_sql)
       .where(daily_period(:follows))
   end
 

--- a/app/lib/admin/metrics/measure/instance_followers_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_followers_measure.rb
@@ -27,15 +27,11 @@ class Admin::Metrics::Measure::InstanceFollowersMeasure < Admin::Metrics::Measur
     nil
   end
 
-  def sql_array
-    [sql_query_string, { start_at: @start_at, end_at: @end_at, domain: params[:domain] }]
-  end
-
   def data_source_query
     Follow
       .select(:id)
       .joins(:account)
-      .where(account_domain_sql)
+      .where(account_domain_sql, domain: params[:domain])
       .where(daily_period(:follows))
   end
 

--- a/app/lib/admin/metrics/measure/instance_followers_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_followers_measure.rb
@@ -37,7 +37,6 @@ class Admin::Metrics::Measure::InstanceFollowersMeasure < Admin::Metrics::Measur
       .joins(:account)
       .where(account_domain_sql(params[:include_subdomains]))
       .where(daily_period(:follows))
-      .to_sql
   end
 
   def params

--- a/app/lib/admin/metrics/measure/instance_followers_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_followers_measure.rb
@@ -35,10 +35,10 @@ class Admin::Metrics::Measure::InstanceFollowersMeasure < Admin::Metrics::Measur
     Follow
       .select(:id)
       .joins(:account)
+      .where(account_domain_sql(params[:include_subdomains]))
       .where(
         <<~SQL.squish
           DATE_TRUNC('day', follows.created_at)::date = axis.period
-            AND #{account_domain_sql(params[:include_subdomains])}
         SQL
       ).to_sql
   end

--- a/app/lib/admin/metrics/measure/instance_followers_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_followers_measure.rb
@@ -31,7 +31,7 @@ class Admin::Metrics::Measure::InstanceFollowersMeasure < Admin::Metrics::Measur
     Follow
       .select(:id)
       .joins(:account)
-      .where(account_domain_sql, domain: params[:domain])
+      .merge(account_domain_scope)
       .where(daily_period(:follows))
   end
 

--- a/app/lib/admin/metrics/measure/instance_followers_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_followers_measure.rb
@@ -32,7 +32,7 @@ class Admin::Metrics::Measure::InstanceFollowersMeasure < Admin::Metrics::Measur
       .select(:id)
       .joins(:account)
       .merge(account_domain_scope)
-      .where(daily_period(:follows))
+      .where(matching_day(Follow, :created_at))
   end
 
   def params

--- a/app/lib/admin/metrics/measure/instance_follows_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_follows_measure.rb
@@ -35,7 +35,7 @@ class Admin::Metrics::Measure::InstanceFollowsMeasure < Admin::Metrics::Measure:
     Follow
       .select(:id)
       .joins(:target_account)
-      .where(account_domain_sql(params[:include_subdomains]))
+      .where(account_domain_sql)
       .where(daily_period(:follows))
   end
 

--- a/app/lib/admin/metrics/measure/instance_follows_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_follows_measure.rb
@@ -37,7 +37,6 @@ class Admin::Metrics::Measure::InstanceFollowsMeasure < Admin::Metrics::Measure:
       .joins(:target_account)
       .where(account_domain_sql(params[:include_subdomains]))
       .where(daily_period(:follows))
-      .to_sql
   end
 
   def params

--- a/app/lib/admin/metrics/measure/instance_follows_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_follows_measure.rb
@@ -36,11 +36,8 @@ class Admin::Metrics::Measure::InstanceFollowsMeasure < Admin::Metrics::Measure:
       .select(:id)
       .joins(:target_account)
       .where(account_domain_sql(params[:include_subdomains]))
-      .where(
-        <<~SQL.squish
-          DATE_TRUNC('day', follows.created_at)::date = axis.period
-        SQL
-      ).to_sql
+      .where(daily_period(:follows))
+      .to_sql
   end
 
   def params

--- a/app/lib/admin/metrics/measure/instance_follows_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_follows_measure.rb
@@ -27,7 +27,7 @@ class Admin::Metrics::Measure::InstanceFollowsMeasure < Admin::Metrics::Measure:
     nil
   end
 
-  def data_source_query
+  def data_source
     Follow
       .select(:id)
       .joins(:target_account)

--- a/app/lib/admin/metrics/measure/instance_follows_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_follows_measure.rb
@@ -27,15 +27,11 @@ class Admin::Metrics::Measure::InstanceFollowsMeasure < Admin::Metrics::Measure:
     nil
   end
 
-  def sql_array
-    [sql_query_string, { start_at: @start_at, end_at: @end_at, domain: params[:domain] }]
-  end
-
   def data_source_query
     Follow
       .select(:id)
       .joins(:target_account)
-      .where(account_domain_sql)
+      .where(account_domain_sql, domain: params[:domain])
       .where(daily_period(:follows))
   end
 

--- a/app/lib/admin/metrics/measure/instance_follows_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_follows_measure.rb
@@ -35,10 +35,10 @@ class Admin::Metrics::Measure::InstanceFollowsMeasure < Admin::Metrics::Measure:
     Follow
       .select(:id)
       .joins(:target_account)
+      .where(account_domain_sql(params[:include_subdomains]))
       .where(
         <<~SQL.squish
           DATE_TRUNC('day', follows.created_at)::date = axis.period
-            AND #{account_domain_sql(params[:include_subdomains])}
         SQL
       ).to_sql
   end

--- a/app/lib/admin/metrics/measure/instance_follows_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_follows_measure.rb
@@ -31,7 +31,7 @@ class Admin::Metrics::Measure::InstanceFollowsMeasure < Admin::Metrics::Measure:
     Follow
       .select(:id)
       .joins(:target_account)
-      .where(account_domain_sql, domain: params[:domain])
+      .merge(account_domain_scope)
       .where(daily_period(:follows))
   end
 

--- a/app/lib/admin/metrics/measure/instance_follows_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_follows_measure.rb
@@ -32,7 +32,7 @@ class Admin::Metrics::Measure::InstanceFollowsMeasure < Admin::Metrics::Measure:
       .select(:id)
       .joins(:target_account)
       .merge(account_domain_scope)
-      .where(daily_period(:follows))
+      .where(matching_day(Follow, :created_at))
   end
 
   def params

--- a/app/lib/admin/metrics/measure/instance_media_attachments_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_media_attachments_measure.rb
@@ -45,11 +45,8 @@ class Admin::Metrics::Measure::InstanceMediaAttachmentsMeasure < Admin::Metrics:
       .select('COALESCE(media_attachments.file_file_size, 0) + COALESCE(media_attachments.thumbnail_file_size, 0) AS size')
       .joins(:account)
       .where(account_domain_sql(params[:include_subdomains]))
-      .where(
-        <<~SQL.squish
-          DATE_TRUNC('day', media_attachments.created_at)::date = axis.period
-        SQL
-      ).to_sql
+      .where(daily_period(:media_attachments))
+      .to_sql
   end
 
   def select_target

--- a/app/lib/admin/metrics/measure/instance_media_attachments_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_media_attachments_measure.rb
@@ -38,7 +38,11 @@ class Admin::Metrics::Measure::InstanceMediaAttachmentsMeasure < Admin::Metrics:
 
   def data_source_query
     MediaAttachment
-      .select('COALESCE(media_attachments.file_file_size, 0) + COALESCE(media_attachments.thumbnail_file_size, 0) AS size')
+      .select(
+        <<~SQL.squish
+          COALESCE(media_attachments.file_file_size, 0) + COALESCE(media_attachments.thumbnail_file_size, 0) AS size
+        SQL
+      )
       .joins(:account)
       .where(account_domain_sql, domain: params[:domain])
       .where(daily_period(:media_attachments))

--- a/app/lib/admin/metrics/measure/instance_media_attachments_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_media_attachments_measure.rb
@@ -44,7 +44,7 @@ class Admin::Metrics::Measure::InstanceMediaAttachmentsMeasure < Admin::Metrics:
     MediaAttachment
       .select('COALESCE(media_attachments.file_file_size, 0) + COALESCE(media_attachments.thumbnail_file_size, 0) AS size')
       .joins(:account)
-      .where(account_domain_sql(params[:include_subdomains]))
+      .where(account_domain_sql)
       .where(daily_period(:media_attachments))
   end
 

--- a/app/lib/admin/metrics/measure/instance_media_attachments_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_media_attachments_measure.rb
@@ -46,7 +46,6 @@ class Admin::Metrics::Measure::InstanceMediaAttachmentsMeasure < Admin::Metrics:
       .joins(:account)
       .where(account_domain_sql(params[:include_subdomains]))
       .where(daily_period(:media_attachments))
-      .to_sql
   end
 
   def select_target

--- a/app/lib/admin/metrics/measure/instance_media_attachments_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_media_attachments_measure.rb
@@ -36,7 +36,7 @@ class Admin::Metrics::Measure::InstanceMediaAttachmentsMeasure < Admin::Metrics:
     nil
   end
 
-  def data_source_query
+  def data_source
     MediaAttachment
       .select(
         <<~SQL.squish

--- a/app/lib/admin/metrics/measure/instance_media_attachments_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_media_attachments_measure.rb
@@ -38,11 +38,7 @@ class Admin::Metrics::Measure::InstanceMediaAttachmentsMeasure < Admin::Metrics:
 
   def data_source
     MediaAttachment
-      .select(
-        <<~SQL.squish
-          COALESCE(media_attachments.file_file_size, 0) + COALESCE(media_attachments.thumbnail_file_size, 0) AS size
-        SQL
-      )
+      .select(media_size_total)
       .joins(:account)
       .where(account_domain_sql, domain: params[:domain])
       .where(daily_period(:media_attachments))
@@ -51,6 +47,12 @@ class Admin::Metrics::Measure::InstanceMediaAttachmentsMeasure < Admin::Metrics:
   def select_target
     <<~SQL.squish
       COALESCE(SUM(size), 0)
+    SQL
+  end
+
+  def media_size_total
+    <<~SQL.squish
+      COALESCE(media_attachments.file_file_size, 0) + COALESCE(media_attachments.thumbnail_file_size, 0) AS size
     SQL
   end
 

--- a/app/lib/admin/metrics/measure/instance_media_attachments_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_media_attachments_measure.rb
@@ -36,15 +36,11 @@ class Admin::Metrics::Measure::InstanceMediaAttachmentsMeasure < Admin::Metrics:
     nil
   end
 
-  def sql_array
-    [sql_query_string, { start_at: @start_at, end_at: @end_at, domain: params[:domain] }]
-  end
-
   def data_source_query
     MediaAttachment
       .select('COALESCE(media_attachments.file_file_size, 0) + COALESCE(media_attachments.thumbnail_file_size, 0) AS size')
       .joins(:account)
-      .where(account_domain_sql)
+      .where(account_domain_sql, domain: params[:domain])
       .where(daily_period(:media_attachments))
   end
 

--- a/app/lib/admin/metrics/measure/instance_media_attachments_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_media_attachments_measure.rb
@@ -41,7 +41,7 @@ class Admin::Metrics::Measure::InstanceMediaAttachmentsMeasure < Admin::Metrics:
       .select(media_size_total)
       .joins(:account)
       .merge(account_domain_scope)
-      .where(daily_period(:media_attachments))
+      .where(matching_day(MediaAttachment, :created_at))
   end
 
   def select_target

--- a/app/lib/admin/metrics/measure/instance_media_attachments_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_media_attachments_measure.rb
@@ -40,7 +40,7 @@ class Admin::Metrics::Measure::InstanceMediaAttachmentsMeasure < Admin::Metrics:
     MediaAttachment
       .select(media_size_total)
       .joins(:account)
-      .where(account_domain_sql, domain: params[:domain])
+      .merge(account_domain_scope)
       .where(daily_period(:media_attachments))
   end
 

--- a/app/lib/admin/metrics/measure/instance_reports_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_reports_measure.rb
@@ -36,11 +36,8 @@ class Admin::Metrics::Measure::InstanceReportsMeasure < Admin::Metrics::Measure:
       .select(:id)
       .joins(:target_account)
       .where(account_domain_sql(params[:include_subdomains]))
-      .where(
-        <<~SQL.squish
-          DATE_TRUNC('day', reports.created_at)::date = axis.period
-        SQL
-      ).to_sql
+      .where(daily_period(:reports))
+      .to_sql
   end
 
   def params

--- a/app/lib/admin/metrics/measure/instance_reports_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_reports_measure.rb
@@ -27,7 +27,7 @@ class Admin::Metrics::Measure::InstanceReportsMeasure < Admin::Metrics::Measure:
     nil
   end
 
-  def data_source_query
+  def data_source
     Report
       .select(:id)
       .joins(:target_account)

--- a/app/lib/admin/metrics/measure/instance_reports_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_reports_measure.rb
@@ -35,10 +35,10 @@ class Admin::Metrics::Measure::InstanceReportsMeasure < Admin::Metrics::Measure:
     Report
       .select(:id)
       .joins(:target_account)
+      .where(account_domain_sql(params[:include_subdomains]))
       .where(
         <<~SQL.squish
           DATE_TRUNC('day', reports.created_at)::date = axis.period
-            AND #{account_domain_sql(params[:include_subdomains])}
         SQL
       ).to_sql
   end

--- a/app/lib/admin/metrics/measure/instance_reports_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_reports_measure.rb
@@ -35,7 +35,7 @@ class Admin::Metrics::Measure::InstanceReportsMeasure < Admin::Metrics::Measure:
     Report
       .select(:id)
       .joins(:target_account)
-      .where(account_domain_sql(params[:include_subdomains]))
+      .where(account_domain_sql)
       .where(daily_period(:reports))
   end
 

--- a/app/lib/admin/metrics/measure/instance_reports_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_reports_measure.rb
@@ -37,7 +37,6 @@ class Admin::Metrics::Measure::InstanceReportsMeasure < Admin::Metrics::Measure:
       .joins(:target_account)
       .where(account_domain_sql(params[:include_subdomains]))
       .where(daily_period(:reports))
-      .to_sql
   end
 
   def params

--- a/app/lib/admin/metrics/measure/instance_reports_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_reports_measure.rb
@@ -31,22 +31,16 @@ class Admin::Metrics::Measure::InstanceReportsMeasure < Admin::Metrics::Measure:
     [sql_query_string, { start_at: @start_at, end_at: @end_at, domain: params[:domain] }]
   end
 
-  def sql_query_string
-    <<~SQL.squish
-      SELECT axis.*, (
-        WITH new_reports AS (
-          SELECT reports.id
-          FROM reports
-          INNER JOIN accounts ON accounts.id = reports.target_account_id
-          WHERE date_trunc('day', reports.created_at)::date = axis.period
+  def data_source_query
+    Report
+      .select(:id)
+      .joins(:target_account)
+      .where(
+        <<~SQL.squish
+          DATE_TRUNC('day', reports.created_at)::date = axis.period
             AND #{account_domain_sql(params[:include_subdomains])}
-        )
-        SELECT count(*) FROM new_reports
-      ) AS value
-      FROM (
-        #{generated_series_days}
-      ) AS axis
-    SQL
+        SQL
+      ).to_sql
   end
 
   def params

--- a/app/lib/admin/metrics/measure/instance_reports_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_reports_measure.rb
@@ -27,15 +27,11 @@ class Admin::Metrics::Measure::InstanceReportsMeasure < Admin::Metrics::Measure:
     nil
   end
 
-  def sql_array
-    [sql_query_string, { start_at: @start_at, end_at: @end_at, domain: params[:domain] }]
-  end
-
   def data_source_query
     Report
       .select(:id)
       .joins(:target_account)
-      .where(account_domain_sql)
+      .where(account_domain_sql, domain: params[:domain])
       .where(daily_period(:reports))
   end
 

--- a/app/lib/admin/metrics/measure/instance_reports_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_reports_measure.rb
@@ -32,7 +32,7 @@ class Admin::Metrics::Measure::InstanceReportsMeasure < Admin::Metrics::Measure:
       .select(:id)
       .joins(:target_account)
       .merge(account_domain_scope)
-      .where(daily_period(:reports))
+      .where(matching_day(Report, :created_at))
   end
 
   def params

--- a/app/lib/admin/metrics/measure/instance_reports_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_reports_measure.rb
@@ -31,7 +31,7 @@ class Admin::Metrics::Measure::InstanceReportsMeasure < Admin::Metrics::Measure:
     Report
       .select(:id)
       .joins(:target_account)
-      .where(account_domain_sql, domain: params[:domain])
+      .merge(account_domain_scope)
       .where(daily_period(:reports))
   end
 

--- a/app/lib/admin/metrics/measure/instance_statuses_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_statuses_measure.rb
@@ -27,15 +27,15 @@ class Admin::Metrics::Measure::InstanceStatusesMeasure < Admin::Metrics::Measure
     nil
   end
 
-  def sql_array
-    [sql_query_string, { start_at: @start_at, end_at: @end_at, domain: params[:domain], earliest_status_id: earliest_status_id, latest_status_id: latest_status_id }]
+  def extra_sql_params
+    { earliest_status_id: earliest_status_id, latest_status_id: latest_status_id }
   end
 
   def data_source_query
     Status
       .select(:id)
       .joins(:account)
-      .where(account_domain_sql)
+      .where(account_domain_sql, domain: params[:domain])
       .where(
         <<~SQL.squish
           statuses.id BETWEEN :earliest_status_id AND :latest_status_id

--- a/app/lib/admin/metrics/measure/instance_statuses_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_statuses_measure.rb
@@ -35,7 +35,7 @@ class Admin::Metrics::Measure::InstanceStatusesMeasure < Admin::Metrics::Measure
     Status
       .select(:id)
       .joins(:account)
-      .where(account_domain_sql(params[:include_subdomains]))
+      .where(account_domain_sql)
       .where(
         <<~SQL.squish
           statuses.id BETWEEN :earliest_status_id AND :latest_status_id

--- a/app/lib/admin/metrics/measure/instance_statuses_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_statuses_measure.rb
@@ -41,11 +41,8 @@ class Admin::Metrics::Measure::InstanceStatusesMeasure < Admin::Metrics::Measure
           statuses.id BETWEEN :earliest_status_id AND :latest_status_id
         SQL
       )
-      .where(
-        <<~SQL.squish
-          date_trunc('day', statuses.created_at)::date = axis.period
-        SQL
-      ).to_sql
+      .where(daily_period(:statuses))
+      .to_sql
   end
 
   def earliest_status_id

--- a/app/lib/admin/metrics/measure/instance_statuses_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_statuses_measure.rb
@@ -32,11 +32,7 @@ class Admin::Metrics::Measure::InstanceStatusesMeasure < Admin::Metrics::Measure
       .select(:id)
       .joins(:account)
       .where(account_domain_sql, domain: params[:domain])
-      .where(
-        <<~SQL.squish, earliest_status_id: earliest_status_id, latest_status_id: latest_status_id
-          statuses.id BETWEEN :earliest_status_id AND :latest_status_id
-        SQL
-      )
+      .where(status_range_sql, earliest_status_id: earliest_status_id, latest_status_id: latest_status_id)
       .where(daily_period(:statuses))
   end
 

--- a/app/lib/admin/metrics/measure/instance_statuses_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_statuses_measure.rb
@@ -27,17 +27,13 @@ class Admin::Metrics::Measure::InstanceStatusesMeasure < Admin::Metrics::Measure
     nil
   end
 
-  def extra_sql_params
-    { earliest_status_id: earliest_status_id, latest_status_id: latest_status_id }
-  end
-
   def data_source_query
     Status
       .select(:id)
       .joins(:account)
       .where(account_domain_sql, domain: params[:domain])
       .where(
-        <<~SQL.squish
+        <<~SQL.squish, earliest_status_id: earliest_status_id, latest_status_id: latest_status_id
           statuses.id BETWEEN :earliest_status_id AND :latest_status_id
         SQL
       )

--- a/app/lib/admin/metrics/measure/instance_statuses_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_statuses_measure.rb
@@ -35,11 +35,15 @@ class Admin::Metrics::Measure::InstanceStatusesMeasure < Admin::Metrics::Measure
     Status
       .select(:id)
       .joins(:account)
+      .where(account_domain_sql(params[:include_subdomains]))
       .where(
         <<~SQL.squish
           statuses.id BETWEEN :earliest_status_id AND :latest_status_id
-          AND #{account_domain_sql(params[:include_subdomains])}
-          AND date_trunc('day', statuses.created_at)::date = axis.period
+        SQL
+      )
+      .where(
+        <<~SQL.squish
+          date_trunc('day', statuses.created_at)::date = axis.period
         SQL
       ).to_sql
   end

--- a/app/lib/admin/metrics/measure/instance_statuses_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_statuses_measure.rb
@@ -27,7 +27,7 @@ class Admin::Metrics::Measure::InstanceStatusesMeasure < Admin::Metrics::Measure
     nil
   end
 
-  def data_source_query
+  def data_source
     Status
       .select(:id)
       .joins(:account)

--- a/app/lib/admin/metrics/measure/instance_statuses_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_statuses_measure.rb
@@ -42,7 +42,6 @@ class Admin::Metrics::Measure::InstanceStatusesMeasure < Admin::Metrics::Measure
         SQL
       )
       .where(daily_period(:statuses))
-      .to_sql
   end
 
   def earliest_status_id

--- a/app/lib/admin/metrics/measure/instance_statuses_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_statuses_measure.rb
@@ -33,7 +33,7 @@ class Admin::Metrics::Measure::InstanceStatusesMeasure < Admin::Metrics::Measure
       .joins(:account)
       .merge(account_domain_scope)
       .where(id: earliest_status_id..latest_status_id)
-      .where(daily_period(:statuses))
+      .where(matching_day(Status, :created_at))
   end
 
   def earliest_status_id

--- a/app/lib/admin/metrics/measure/instance_statuses_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_statuses_measure.rb
@@ -31,7 +31,7 @@ class Admin::Metrics::Measure::InstanceStatusesMeasure < Admin::Metrics::Measure
     Status
       .select(:id)
       .joins(:account)
-      .where(account_domain_sql, domain: params[:domain])
+      .merge(account_domain_scope)
       .where(status_range_sql, earliest_status_id: earliest_status_id, latest_status_id: latest_status_id)
       .where(daily_period(:statuses))
   end

--- a/app/lib/admin/metrics/measure/instance_statuses_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_statuses_measure.rb
@@ -32,7 +32,7 @@ class Admin::Metrics::Measure::InstanceStatusesMeasure < Admin::Metrics::Measure
       .select(:id)
       .joins(:account)
       .merge(account_domain_scope)
-      .where(status_range_sql, earliest_status_id: earliest_status_id, latest_status_id: latest_status_id)
+      .where(id: earliest_status_id..latest_status_id)
       .where(daily_period(:statuses))
   end
 

--- a/app/lib/admin/metrics/measure/new_users_measure.rb
+++ b/app/lib/admin/metrics/measure/new_users_measure.rb
@@ -25,6 +25,5 @@ class Admin::Metrics::Measure::NewUsersMeasure < Admin::Metrics::Measure::BaseMe
     User
       .select(:id)
       .where(daily_period(:users))
-      .to_sql
   end
 end

--- a/app/lib/admin/metrics/measure/new_users_measure.rb
+++ b/app/lib/admin/metrics/measure/new_users_measure.rb
@@ -17,10 +17,6 @@ class Admin::Metrics::Measure::NewUsersMeasure < Admin::Metrics::Measure::BaseMe
     User.where(created_at: previous_time_period).count
   end
 
-  def sql_array
-    [sql_query_string, { start_at: @start_at, end_at: @end_at }]
-  end
-
   def data_source
     User
       .select(:id)

--- a/app/lib/admin/metrics/measure/new_users_measure.rb
+++ b/app/lib/admin/metrics/measure/new_users_measure.rb
@@ -21,19 +21,13 @@ class Admin::Metrics::Measure::NewUsersMeasure < Admin::Metrics::Measure::BaseMe
     [sql_query_string, { start_at: @start_at, end_at: @end_at }]
   end
 
-  def sql_query_string
-    <<~SQL.squish
-      SELECT axis.*, (
-        WITH new_users AS (
-          SELECT users.id
-          FROM users
-          WHERE date_trunc('day', users.created_at)::date = axis.period
-        )
-        SELECT count(*) FROM new_users
-      ) AS value
-      FROM (
-        #{generated_series_days}
-      ) AS axis
-    SQL
+  def data_source_query
+    User
+      .select(:id)
+      .where(
+        <<~SQL.squish
+          DATE_TRUNC('day', users.created_at)::date = axis.period
+        SQL
+      ).to_sql
   end
 end

--- a/app/lib/admin/metrics/measure/new_users_measure.rb
+++ b/app/lib/admin/metrics/measure/new_users_measure.rb
@@ -24,10 +24,7 @@ class Admin::Metrics::Measure::NewUsersMeasure < Admin::Metrics::Measure::BaseMe
   def data_source_query
     User
       .select(:id)
-      .where(
-        <<~SQL.squish
-          DATE_TRUNC('day', users.created_at)::date = axis.period
-        SQL
-      ).to_sql
+      .where(daily_period(:users))
+      .to_sql
   end
 end

--- a/app/lib/admin/metrics/measure/new_users_measure.rb
+++ b/app/lib/admin/metrics/measure/new_users_measure.rb
@@ -21,7 +21,7 @@ class Admin::Metrics::Measure::NewUsersMeasure < Admin::Metrics::Measure::BaseMe
     [sql_query_string, { start_at: @start_at, end_at: @end_at }]
   end
 
-  def data_source_query
+  def data_source
     User
       .select(:id)
       .where(daily_period(:users))

--- a/app/lib/admin/metrics/measure/new_users_measure.rb
+++ b/app/lib/admin/metrics/measure/new_users_measure.rb
@@ -20,6 +20,6 @@ class Admin::Metrics::Measure::NewUsersMeasure < Admin::Metrics::Measure::BaseMe
   def data_source
     User
       .select(:id)
-      .where(daily_period(:users))
+      .where(matching_day(User, :created_at))
   end
 end

--- a/app/lib/admin/metrics/measure/opened_reports_measure.rb
+++ b/app/lib/admin/metrics/measure/opened_reports_measure.rb
@@ -21,19 +21,13 @@ class Admin::Metrics::Measure::OpenedReportsMeasure < Admin::Metrics::Measure::B
     [sql_query_string, { start_at: @start_at, end_at: @end_at }]
   end
 
-  def sql_query_string
-    <<~SQL.squish
-      SELECT axis.*, (
-        WITH new_reports AS (
-          SELECT reports.id
-          FROM reports
-          WHERE date_trunc('day', reports.created_at)::date = axis.period
-        )
-        SELECT count(*) FROM new_reports
-      ) AS value
-      FROM (
-        #{generated_series_days}
-      ) AS axis
-    SQL
+  def data_source_query
+    Report
+      .select(:id)
+      .where(
+        <<~SQL.squish
+          DATE_TRUNC('day', reports.created_at)::date = axis.period
+        SQL
+      ).to_sql
   end
 end

--- a/app/lib/admin/metrics/measure/opened_reports_measure.rb
+++ b/app/lib/admin/metrics/measure/opened_reports_measure.rb
@@ -24,10 +24,7 @@ class Admin::Metrics::Measure::OpenedReportsMeasure < Admin::Metrics::Measure::B
   def data_source_query
     Report
       .select(:id)
-      .where(
-        <<~SQL.squish
-          DATE_TRUNC('day', reports.created_at)::date = axis.period
-        SQL
-      ).to_sql
+      .where(daily_period(:reports))
+      .to_sql
   end
 end

--- a/app/lib/admin/metrics/measure/opened_reports_measure.rb
+++ b/app/lib/admin/metrics/measure/opened_reports_measure.rb
@@ -25,6 +25,5 @@ class Admin::Metrics::Measure::OpenedReportsMeasure < Admin::Metrics::Measure::B
     Report
       .select(:id)
       .where(daily_period(:reports))
-      .to_sql
   end
 end

--- a/app/lib/admin/metrics/measure/opened_reports_measure.rb
+++ b/app/lib/admin/metrics/measure/opened_reports_measure.rb
@@ -17,10 +17,6 @@ class Admin::Metrics::Measure::OpenedReportsMeasure < Admin::Metrics::Measure::B
     Report.where(created_at: previous_time_period).count
   end
 
-  def sql_array
-    [sql_query_string, { start_at: @start_at, end_at: @end_at }]
-  end
-
   def data_source
     Report
       .select(:id)

--- a/app/lib/admin/metrics/measure/opened_reports_measure.rb
+++ b/app/lib/admin/metrics/measure/opened_reports_measure.rb
@@ -21,7 +21,7 @@ class Admin::Metrics::Measure::OpenedReportsMeasure < Admin::Metrics::Measure::B
     [sql_query_string, { start_at: @start_at, end_at: @end_at }]
   end
 
-  def data_source_query
+  def data_source
     Report
       .select(:id)
       .where(daily_period(:reports))

--- a/app/lib/admin/metrics/measure/opened_reports_measure.rb
+++ b/app/lib/admin/metrics/measure/opened_reports_measure.rb
@@ -20,6 +20,6 @@ class Admin::Metrics::Measure::OpenedReportsMeasure < Admin::Metrics::Measure::B
   def data_source
     Report
       .select(:id)
-      .where(daily_period(:reports))
+      .where(matching_day(Report, :created_at))
   end
 end

--- a/app/lib/admin/metrics/measure/query_helper.rb
+++ b/app/lib/admin/metrics/measure/query_helper.rb
@@ -41,9 +41,13 @@ module Admin::Metrics::Measure::QueryHelper
 
   def account_domain_sql
     if params[:include_subdomains]
-      "accounts.domain IN (SELECT domain FROM instances WHERE reverse('.' || domain) LIKE reverse('.' || :domain::text))"
+      <<~SQL.squish
+        accounts.domain IN (SELECT domain FROM instances WHERE reverse('.' || domain) LIKE reverse('.' || :domain::text))
+      SQL
     else
-      'accounts.domain = :domain::text'
+      <<~SQL.squish
+        accounts.domain = :domain::text
+      SQL
     end
   end
 end

--- a/app/lib/admin/metrics/measure/query_helper.rb
+++ b/app/lib/admin/metrics/measure/query_helper.rb
@@ -18,7 +18,7 @@ module Admin::Metrics::Measure::QueryHelper
   def sql_query_string
     <<~SQL.squish
       SELECT axis.*, (
-        WITH data_source AS (#{data_source_query})
+        WITH data_source AS (#{data_source_query.to_sql})
         SELECT #{select_target} FROM data_source
       ) AS value
       FROM (

--- a/app/lib/admin/metrics/measure/query_helper.rb
+++ b/app/lib/admin/metrics/measure/query_helper.rb
@@ -39,8 +39,8 @@ module Admin::Metrics::Measure::QueryHelper
     SQL
   end
 
-  def account_domain_sql(include_subdomains)
-    if include_subdomains
+  def account_domain_sql
+    if params[:include_subdomains]
       "accounts.domain IN (SELECT domain FROM instances WHERE reverse('.' || domain) LIKE reverse('.' || :domain::text))"
     else
       'accounts.domain = :domain::text'

--- a/app/lib/admin/metrics/measure/query_helper.rb
+++ b/app/lib/admin/metrics/measure/query_helper.rb
@@ -15,6 +15,14 @@ module Admin::Metrics::Measure::QueryHelper
     ActiveRecord::Base.sanitize_sql_array(sql_array)
   end
 
+  def sql_array
+    [sql_query_string, { start_at: @start_at, end_at: @end_at }.merge(extra_sql_params)]
+  end
+
+  def extra_sql_params
+    {}
+  end
+
   def sql_query_string
     <<~SQL.squish
       SELECT axis.*, (

--- a/app/lib/admin/metrics/measure/query_helper.rb
+++ b/app/lib/admin/metrics/measure/query_helper.rb
@@ -22,7 +22,7 @@ module Admin::Metrics::Measure::QueryHelper
   def sql_query_string
     <<~SQL.squish
       SELECT axis.*, (
-        WITH data_source AS (#{data_source_query.to_sql})
+        WITH data_source AS (#{data_source.to_sql})
         SELECT #{select_target} FROM data_source
       ) AS value
       FROM (

--- a/app/lib/admin/metrics/measure/query_helper.rb
+++ b/app/lib/admin/metrics/measure/query_helper.rb
@@ -15,12 +15,22 @@ module Admin::Metrics::Measure::QueryHelper
     ActiveRecord::Base.sanitize_sql_array(sql_array)
   end
 
-  def generated_series_days
-    Arel.sql(
-      <<~SQL.squish
+  def sql_query_string
+    <<~SQL.squish
+      SELECT axis.*, (
+        WITH data_source AS (#{data_source_query})
+        SELECT #{select_target} FROM data_source
+      ) AS value
+      FROM (
         SELECT generate_series(:start_at::timestamp, :end_at::timestamp, '1 day')::date AS period
-      SQL
-    )
+      ) AS axis
+    SQL
+  end
+
+  def select_target
+    <<~SQL.squish
+      COUNT(*)
+    SQL
   end
 
   def account_domain_sql(include_subdomains)

--- a/app/lib/admin/metrics/measure/query_helper.rb
+++ b/app/lib/admin/metrics/measure/query_helper.rb
@@ -33,6 +33,12 @@ module Admin::Metrics::Measure::QueryHelper
     SQL
   end
 
+  def daily_period(table, column = :created_at)
+    <<~SQL.squish
+      DATE_TRUNC('day', #{table}.#{column})::date = axis.period
+    SQL
+  end
+
   def account_domain_sql(include_subdomains)
     if include_subdomains
       "accounts.domain IN (SELECT domain FROM instances WHERE reverse('.' || domain) LIKE reverse('.' || :domain::text))"

--- a/app/lib/admin/metrics/measure/query_helper.rb
+++ b/app/lib/admin/metrics/measure/query_helper.rb
@@ -16,11 +16,7 @@ module Admin::Metrics::Measure::QueryHelper
   end
 
   def sql_array
-    [sql_query_string, { start_at: @start_at, end_at: @end_at }.merge(extra_sql_params)]
-  end
-
-  def extra_sql_params
-    {}
+    [sql_query_string, { start_at: @start_at, end_at: @end_at }]
   end
 
   def sql_query_string

--- a/app/lib/admin/metrics/measure/query_helper.rb
+++ b/app/lib/admin/metrics/measure/query_helper.rb
@@ -43,6 +43,12 @@ module Admin::Metrics::Measure::QueryHelper
     SQL
   end
 
+  def status_range_sql
+    <<~SQL.squish
+      statuses.id BETWEEN :earliest_status_id AND :latest_status_id
+    SQL
+  end
+
   def account_domain_sql
     if params[:include_subdomains]
       <<~SQL.squish

--- a/app/lib/admin/metrics/measure/query_helper.rb
+++ b/app/lib/admin/metrics/measure/query_helper.rb
@@ -47,15 +47,11 @@ module Admin::Metrics::Measure::QueryHelper
     SQL
   end
 
-  def account_domain_sql
+  def account_domain_scope
     if params[:include_subdomains]
-      <<~SQL.squish
-        accounts.domain IN (SELECT domain FROM instances WHERE reverse('.' || domain) LIKE reverse('.' || :domain::text))
-      SQL
+      Account.by_domain_and_subdomains(params[:domain])
     else
-      <<~SQL.squish
-        accounts.domain = :domain::text
-      SQL
+      Account.with_domain(params[:domain])
     end
   end
 end

--- a/app/lib/admin/metrics/measure/query_helper.rb
+++ b/app/lib/admin/metrics/measure/query_helper.rb
@@ -32,9 +32,7 @@ module Admin::Metrics::Measure::QueryHelper
   end
 
   def select_target
-    <<~SQL.squish
-      COUNT(*)
-    SQL
+    Arel.star.count.to_sql
   end
 
   def daily_period(table, column = :created_at)

--- a/app/lib/admin/metrics/measure/query_helper.rb
+++ b/app/lib/admin/metrics/measure/query_helper.rb
@@ -41,12 +41,6 @@ module Admin::Metrics::Measure::QueryHelper
     SQL
   end
 
-  def status_range_sql
-    <<~SQL.squish
-      statuses.id BETWEEN :earliest_status_id AND :latest_status_id
-    SQL
-  end
-
   def account_domain_scope
     if params[:include_subdomains]
       Account.by_domain_and_subdomains(params[:domain])

--- a/app/lib/admin/metrics/measure/query_helper.rb
+++ b/app/lib/admin/metrics/measure/query_helper.rb
@@ -35,9 +35,9 @@ module Admin::Metrics::Measure::QueryHelper
     Arel.star.count.to_sql
   end
 
-  def daily_period(table, column = :created_at)
+  def matching_day(model, column)
     <<~SQL.squish
-      DATE_TRUNC('day', #{table}.#{column})::date = axis.period
+      DATE_TRUNC('day', #{model.table_name}.#{column})::date = axis.period
     SQL
   end
 

--- a/app/lib/admin/metrics/measure/resolved_reports_measure.rb
+++ b/app/lib/admin/metrics/measure/resolved_reports_measure.rb
@@ -17,10 +17,6 @@ class Admin::Metrics::Measure::ResolvedReportsMeasure < Admin::Metrics::Measure:
     Report.resolved.where(action_taken_at: previous_time_period).count
   end
 
-  def sql_array
-    [sql_query_string, { start_at: @start_at, end_at: @end_at }]
-  end
-
   def data_source_query
     Report
       .select(:id)

--- a/app/lib/admin/metrics/measure/resolved_reports_measure.rb
+++ b/app/lib/admin/metrics/measure/resolved_reports_measure.rb
@@ -17,7 +17,7 @@ class Admin::Metrics::Measure::ResolvedReportsMeasure < Admin::Metrics::Measure:
     Report.resolved.where(action_taken_at: previous_time_period).count
   end
 
-  def data_source_query
+  def data_source
     Report
       .select(:id)
       .where(daily_period(:reports, :action_taken_at))

--- a/app/lib/admin/metrics/measure/resolved_reports_measure.rb
+++ b/app/lib/admin/metrics/measure/resolved_reports_measure.rb
@@ -25,6 +25,5 @@ class Admin::Metrics::Measure::ResolvedReportsMeasure < Admin::Metrics::Measure:
     Report
       .select(:id)
       .where(daily_period(:reports, :action_taken_at))
-      .to_sql
   end
 end

--- a/app/lib/admin/metrics/measure/resolved_reports_measure.rb
+++ b/app/lib/admin/metrics/measure/resolved_reports_measure.rb
@@ -21,19 +21,13 @@ class Admin::Metrics::Measure::ResolvedReportsMeasure < Admin::Metrics::Measure:
     [sql_query_string, { start_at: @start_at, end_at: @end_at }]
   end
 
-  def sql_query_string
-    <<~SQL.squish
-      SELECT axis.*, (
-        WITH resolved_reports AS (
-          SELECT reports.id
-          FROM reports
-          WHERE date_trunc('day', reports.action_taken_at)::date = axis.period
-        )
-        SELECT count(*) FROM resolved_reports
-      ) AS value
-      FROM (
-        #{generated_series_days}
-      ) AS axis
-    SQL
+  def data_source_query
+    Report
+      .select(:id)
+      .where(
+        <<~SQL.squish
+          DATE_TRUNC('day', reports.action_taken_at)::date = axis.period
+        SQL
+      ).to_sql
   end
 end

--- a/app/lib/admin/metrics/measure/resolved_reports_measure.rb
+++ b/app/lib/admin/metrics/measure/resolved_reports_measure.rb
@@ -24,10 +24,7 @@ class Admin::Metrics::Measure::ResolvedReportsMeasure < Admin::Metrics::Measure:
   def data_source_query
     Report
       .select(:id)
-      .where(
-        <<~SQL.squish
-          DATE_TRUNC('day', reports.action_taken_at)::date = axis.period
-        SQL
-      ).to_sql
+      .where(daily_period(:reports, :action_taken_at))
+      .to_sql
   end
 end

--- a/app/lib/admin/metrics/measure/resolved_reports_measure.rb
+++ b/app/lib/admin/metrics/measure/resolved_reports_measure.rb
@@ -20,6 +20,6 @@ class Admin::Metrics::Measure::ResolvedReportsMeasure < Admin::Metrics::Measure:
   def data_source
     Report
       .select(:id)
-      .where(daily_period(:reports, :action_taken_at))
+      .where(matching_day(Report, :action_taken_at))
   end
 end

--- a/app/lib/admin/metrics/measure/tag_servers_measure.rb
+++ b/app/lib/admin/metrics/measure/tag_servers_measure.rb
@@ -21,10 +21,6 @@ class Admin::Metrics::Measure::TagServersMeasure < Admin::Metrics::Measure::Base
     tag.statuses.where('statuses.id BETWEEN ? AND ?', Mastodon::Snowflake.id_at(@start_at - length_of_period, with_random: false), Mastodon::Snowflake.id_at(@end_at - length_of_period, with_random: false)).joins(:account).count('distinct accounts.domain')
   end
 
-  def extra_sql_params
-    { tag_id: tag.id, earliest_status_id: earliest_status_id, latest_status_id: latest_status_id }
-  end
-
   def data_source_query
     Status
       .select('accounts.domain')
@@ -32,7 +28,7 @@ class Admin::Metrics::Measure::TagServersMeasure < Admin::Metrics::Measure::Base
       .reorder(nil)
       .joins(:tags, :account)
       .where(
-        <<~SQL.squish
+        <<~SQL.squish, tag_id: tag.id, earliest_status_id: earliest_status_id, latest_status_id: latest_status_id
           statuses_tags.tag_id = :tag_id
           AND statuses.id BETWEEN :earliest_status_id AND :latest_status_id
         SQL

--- a/app/lib/admin/metrics/measure/tag_servers_measure.rb
+++ b/app/lib/admin/metrics/measure/tag_servers_measure.rb
@@ -28,11 +28,7 @@ class Admin::Metrics::Measure::TagServersMeasure < Admin::Metrics::Measure::Base
       .reorder(nil)
       .joins(:tags, :account)
       .where(statuses_tags: { tag_id: tag.id })
-      .where(
-        <<~SQL.squish, earliest_status_id: earliest_status_id, latest_status_id: latest_status_id
-          statuses.id BETWEEN :earliest_status_id AND :latest_status_id
-        SQL
-      )
+      .where(status_range_sql, earliest_status_id: earliest_status_id, latest_status_id: latest_status_id)
       .where(daily_period(:statuses))
   end
 

--- a/app/lib/admin/metrics/measure/tag_servers_measure.rb
+++ b/app/lib/admin/metrics/measure/tag_servers_measure.rb
@@ -37,11 +37,8 @@ class Admin::Metrics::Measure::TagServersMeasure < Admin::Metrics::Measure::Base
           AND statuses.id BETWEEN :earliest_status_id AND :latest_status_id
         SQL
       )
-      .where(
-        <<~SQL.squish
-          date_trunc('day', statuses.created_at)::date = axis.period
-        SQL
-      ).to_sql
+      .where(daily_period(:statuses))
+      .to_sql
   end
 
   def earliest_status_id

--- a/app/lib/admin/metrics/measure/tag_servers_measure.rb
+++ b/app/lib/admin/metrics/measure/tag_servers_measure.rb
@@ -28,9 +28,13 @@ class Admin::Metrics::Measure::TagServersMeasure < Admin::Metrics::Measure::Base
       .reorder(nil)
       .joins(:tags, :account)
       .where(
-        <<~SQL.squish, tag_id: tag.id, earliest_status_id: earliest_status_id, latest_status_id: latest_status_id
+        <<~SQL.squish, tag_id: tag.id
           statuses_tags.tag_id = :tag_id
-          AND statuses.id BETWEEN :earliest_status_id AND :latest_status_id
+        SQL
+      )
+      .where(
+        <<~SQL.squish, earliest_status_id: earliest_status_id, latest_status_id: latest_status_id
+          statuses.id BETWEEN :earliest_status_id AND :latest_status_id
         SQL
       )
       .where(daily_period(:statuses))

--- a/app/lib/admin/metrics/measure/tag_servers_measure.rb
+++ b/app/lib/admin/metrics/measure/tag_servers_measure.rb
@@ -21,7 +21,7 @@ class Admin::Metrics::Measure::TagServersMeasure < Admin::Metrics::Measure::Base
     tag.statuses.where('statuses.id BETWEEN ? AND ?', Mastodon::Snowflake.id_at(@start_at - length_of_period, with_random: false), Mastodon::Snowflake.id_at(@end_at - length_of_period, with_random: false)).joins(:account).count('distinct accounts.domain')
   end
 
-  def data_source_query
+  def data_source
     Status
       .select('accounts.domain')
       .distinct

--- a/app/lib/admin/metrics/measure/tag_servers_measure.rb
+++ b/app/lib/admin/metrics/measure/tag_servers_measure.rb
@@ -21,8 +21,8 @@ class Admin::Metrics::Measure::TagServersMeasure < Admin::Metrics::Measure::Base
     tag.statuses.where('statuses.id BETWEEN ? AND ?', Mastodon::Snowflake.id_at(@start_at - length_of_period, with_random: false), Mastodon::Snowflake.id_at(@end_at - length_of_period, with_random: false)).joins(:account).count('distinct accounts.domain')
   end
 
-  def sql_array
-    [sql_query_string, { start_at: @start_at, end_at: @end_at, tag_id: tag.id, earliest_status_id: earliest_status_id, latest_status_id: latest_status_id }]
+  def extra_sql_params
+    { tag_id: tag.id, earliest_status_id: earliest_status_id, latest_status_id: latest_status_id }
   end
 
   def data_source_query

--- a/app/lib/admin/metrics/measure/tag_servers_measure.rb
+++ b/app/lib/admin/metrics/measure/tag_servers_measure.rb
@@ -38,7 +38,6 @@ class Admin::Metrics::Measure::TagServersMeasure < Admin::Metrics::Measure::Base
         SQL
       )
       .where(daily_period(:statuses))
-      .to_sql
   end
 
   def earliest_status_id

--- a/app/lib/admin/metrics/measure/tag_servers_measure.rb
+++ b/app/lib/admin/metrics/measure/tag_servers_measure.rb
@@ -25,23 +25,15 @@ class Admin::Metrics::Measure::TagServersMeasure < Admin::Metrics::Measure::Base
     [sql_query_string, { start_at: @start_at, end_at: @end_at, tag_id: tag.id, earliest_status_id: earliest_status_id, latest_status_id: latest_status_id }]
   end
 
-  def sql_query_string
+  def data_source_query
     <<~SQL.squish
-      SELECT axis.*, (
-        WITH tag_servers AS (
-          SELECT DISTINCT accounts.domain
-          FROM statuses
-          INNER JOIN statuses_tags ON statuses.id = statuses_tags.status_id
-          INNER JOIN accounts ON statuses.account_id = accounts.id
-          WHERE statuses_tags.tag_id = :tag_id
-            AND statuses.id BETWEEN :earliest_status_id AND :latest_status_id
-            AND date_trunc('day', statuses.created_at)::date = axis.period
-        )
-        SELECT COUNT(*) FROM tag_servers
-      ) AS value
-      FROM (
-        #{generated_series_days}
-      ) as axis
+      SELECT DISTINCT accounts.domain
+      FROM statuses
+      INNER JOIN statuses_tags ON statuses.id = statuses_tags.status_id
+      INNER JOIN accounts ON statuses.account_id = accounts.id
+      WHERE statuses_tags.tag_id = :tag_id
+        AND statuses.id BETWEEN :earliest_status_id AND :latest_status_id
+        AND date_trunc('day', statuses.created_at)::date = axis.period
     SQL
   end
 

--- a/app/lib/admin/metrics/measure/tag_servers_measure.rb
+++ b/app/lib/admin/metrics/measure/tag_servers_measure.rb
@@ -27,11 +27,7 @@ class Admin::Metrics::Measure::TagServersMeasure < Admin::Metrics::Measure::Base
       .distinct
       .reorder(nil)
       .joins(:tags, :account)
-      .where(
-        <<~SQL.squish, tag_id: tag.id
-          statuses_tags.tag_id = :tag_id
-        SQL
-      )
+      .where(statuses_tags: { tag_id: tag.id })
       .where(
         <<~SQL.squish, earliest_status_id: earliest_status_id, latest_status_id: latest_status_id
           statuses.id BETWEEN :earliest_status_id AND :latest_status_id

--- a/app/lib/admin/metrics/measure/tag_servers_measure.rb
+++ b/app/lib/admin/metrics/measure/tag_servers_measure.rb
@@ -28,7 +28,7 @@ class Admin::Metrics::Measure::TagServersMeasure < Admin::Metrics::Measure::Base
       .reorder(nil)
       .joins(:tags, :account)
       .where(statuses_tags: { tag_id: tag.id })
-      .where(status_range_sql, earliest_status_id: earliest_status_id, latest_status_id: latest_status_id)
+      .where(id: earliest_status_id..latest_status_id)
       .where(daily_period(:statuses))
   end
 

--- a/app/lib/admin/metrics/measure/tag_servers_measure.rb
+++ b/app/lib/admin/metrics/measure/tag_servers_measure.rb
@@ -29,7 +29,7 @@ class Admin::Metrics::Measure::TagServersMeasure < Admin::Metrics::Measure::Base
       .joins(:tags, :account)
       .where(statuses_tags: { tag_id: tag.id })
       .where(id: earliest_status_id..latest_status_id)
-      .where(daily_period(:statuses))
+      .where(matching_day(Status, :created_at))
   end
 
   def earliest_status_id


### PR DESCRIPTION
Follow-up on https://github.com/mastodon/mastodon/pull/29928 and on various prior cleanup in this area. I think this is probably the last one, or close to it anyway.

Previously, the interface here was sort of blurry ... we were passing sql strings and arrays back and forth between the included query helper class and the various report classes. The diff here wound up being less bad than I thought it might, but I've also preserved commits if you want to step one piece at a time. Change summary:

- Close to every class was over-riding the `time_period` and `previous_time_period` methods from the base class; so just update the base defs with the override one, and remove the overrides (this could be it's own PR if desired)
- The basic structure of each report here is to have a sql query that looks like `SELECT axis.*, WITH (...) AS value FROM days`, where the part relevant to each report is the inner CTE/WITH contents, and the outer wrapper (consolidated in previous PRs) does not change. The main change here is to move the outer wrapper fully to the helper, and have each class define it's own `data_source` method which is a `Relation` that can be put into the WITH by the outer wrapper query.
- Eliminate the string/array building of `sql_array` in favor of just having each `where` used supply its own interpolation args where needed. The outer wrapper query still has one because every query needs the start/end values

