### PR TITLE
Update `rubocop-rspec` to version 3.0.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -133,11 +133,6 @@ Rails/NegateInclude:
 RSpec/ExampleLength:
   CountAsOne: ['array', 'heredoc', 'method_call']
 
-# Reason: Deprecated cop, will be removed in 3.0, replaced by SpecFilePathFormat
-# https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecfilepath
-RSpec/FilePath:
-  Enabled: false
-
 # Reason:
 # https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecnamedsubject
 RSpec/NamedSubject:

--- a/Gemfile
+++ b/Gemfile
@@ -171,6 +171,7 @@ group :development do
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false
   gem 'rubocop-rspec', require: false
+  gem 'rubocop-rspec_rails', require: false
 
   # Annotates modules with schema
   gem 'annotate', '~> 3.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -698,8 +698,8 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    rexml (3.2.8)
-      strscan (>= 3.0.9)
+    rexml (3.3.0)
+      strscan
     rotp (6.3.0)
     rouge (4.2.1)
     rpam2 (4.0.2)
@@ -746,8 +746,6 @@ GEM
       parser (>= 3.3.1.0)
     rubocop-capybara (2.21.0)
       rubocop (~> 1.41)
-    rubocop-factory_bot (2.25.1)
-      rubocop (~> 1.41)
     rubocop-performance (1.21.0)
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
@@ -756,13 +754,11 @@ GEM
       rack (>= 1.1)
       rubocop (>= 1.33.0, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
-    rubocop-rspec (2.31.0)
-      rubocop (~> 1.40)
-      rubocop-capybara (~> 2.17)
-      rubocop-factory_bot (~> 2.22)
-      rubocop-rspec_rails (~> 2.28)
-    rubocop-rspec_rails (2.28.3)
-      rubocop (~> 1.40)
+    rubocop-rspec (3.0.1)
+      rubocop (~> 1.61)
+    rubocop-rspec_rails (2.30.0)
+      rubocop (~> 1.61)
+      rubocop-rspec (~> 3, >= 3.0.1)
     ruby-prof (1.7.0)
     ruby-progressbar (1.13.0)
     ruby-saml (1.16.0)
@@ -1028,6 +1024,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rspec
+  rubocop-rspec_rails
   ruby-prof
   ruby-progressbar (~> 1.13)
   ruby-vips (~> 2.2)


### PR DESCRIPTION
This is open https://github.com/mastodon/mastodon/pull/30649 but I think is not going to also pull in rubocop-rspec_rails, which we need to keep things working.

We had preemptively disabled a deprecated cop and are using its replacement already, this just removed the reference to it entirely as well.