### PR TITLE
Use stock ruby environment on CI lint tasks

### DIFF
--- a/.github/workflows/bundler-audit.yml
+++ b/.github/workflows/bundler-audit.yml
@@ -23,12 +23,17 @@ jobs:
   security:
     runs-on: ubuntu-latest
 
+    env:
+      BUNDLE_ONLY: development
+
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
 
-      - name: Set up Ruby environment
-        uses: ./.github/actions/setup-ruby
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
 
       - name: Run bundler-audit
         run: bundle exec bundler-audit check --update

--- a/.github/workflows/check-i18n.yml
+++ b/.github/workflows/check-i18n.yml
@@ -16,11 +16,16 @@ jobs:
   check-i18n:
     runs-on: ubuntu-22.04
 
+    env:
+      BUNDLE_ONLY: development
+
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Ruby environment
-        uses: ./.github/actions/setup-ruby
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
 
       - name: Set up Javascript environment
         uses: ./.github/actions/setup-javascript

--- a/.github/workflows/check-i18n.yml
+++ b/.github/workflows/check-i18n.yml
@@ -16,16 +16,11 @@ jobs:
   check-i18n:
     runs-on: ubuntu-22.04
 
-    env:
-      BUNDLE_ONLY: development
-
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
+      - name: Set up Ruby environment
+        uses: ./.github/actions/setup-ruby
 
       - name: Set up Javascript environment
         uses: ./.github/actions/setup-javascript

--- a/.github/workflows/lint-haml.yml
+++ b/.github/workflows/lint-haml.yml
@@ -26,12 +26,18 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+
+    env:
+      BUNDLE_ONLY: development
+
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
 
-      - name: Set up Ruby environment
-        uses: ./.github/actions/setup-ruby
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
 
       - name: Run haml-lint
         run: |

--- a/.github/workflows/lint-ruby.yml
+++ b/.github/workflows/lint-ruby.yml
@@ -27,12 +27,17 @@ jobs:
   lint:
     runs-on: ubuntu-latest
 
+    env:
+      BUNDLE_ONLY: development
+
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
 
-      - name: Set up Ruby environment
-        uses: ./.github/actions/setup-ruby
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
 
       - name: Set-up RuboCop Problem Matcher
         uses: r7kamura/rubocop-problem-matchers-action@v1


### PR DESCRIPTION
The in-repo setup-ruby workflow runs some custom `apt-get` commands, which take a while to setup.

I think it's safe, the for the linter workflows only, to just use the stock ruby from ruby/setup-ruby, which I suspect will be much faster to setup. Opening this in part to get some sense of by how much.

Other ideas I've had:

- Consolidate all/most of the linter tasks into one workflow. Generally speaking they all run very fast, but they are all repeating the entirety of the image/packages/etc set up for every run. For many of them the setup is far far longer than the actual linting step. It seems like an obvious improvement for them to share setup and then run one after another?
- Merge the two migration check workflows ... same idea

Will update with numbers after the run here.