### PR TITLE
Update the bundler-audit vulnerability DB when running

### DIFF
--- a/.github/workflows/bundler-audit.yml
+++ b/.github/workflows/bundler-audit.yml
@@ -31,4 +31,4 @@ jobs:
         uses: ./.github/actions/setup-ruby
 
       - name: Run bundler-audit
-        run: bundle exec bundler-audit
+        run: bundle exec bundler-audit check --update


### PR DESCRIPTION
Related to https://github.com/mastodon/mastodon/pull/30657

I assume the way this works is that when it's running from cron it will run with the last version it has - seems preferable to get updates?