### PR TITLE
Remove unused CI env vars

### DIFF
--- a/.github/workflows/test-migrations-one-step.yml
+++ b/.github/workflows/test-migrations-one-step.yml
@@ -57,7 +57,6 @@ jobs:
           - 6379:6379
 
     env:
-      CONTINUOUS_INTEGRATION: true
       DB_HOST: localhost
       DB_USER: postgres
       DB_PASS: postgres

--- a/.github/workflows/test-migrations-two-step.yml
+++ b/.github/workflows/test-migrations-two-step.yml
@@ -57,7 +57,6 @@ jobs:
           - 6379:6379
 
     env:
-      CONTINUOUS_INTEGRATION: true
       DB_HOST: localhost
       DB_USER: postgres
       DB_PASS: postgres


### PR DESCRIPTION
Added here for use on Circle CI:
https://github.com/mastodon/mastodon/pull/7447

Survived migration here:
https://github.com/mastodon/mastodon/pull/23624/files#diff-54ea9e988193aab0ff00b85f35bca44c015e1dd693ab559cd5d5a164fac70794R51

I think these are not actually used anywhere at this point.

GH Actions *does* set a `CI` env var, which we check in a few spots.