### PR TITLE
Move mastodon version config to `config_for` yml

### DIFF
--- a/config/mastodon.yml
+++ b/config/mastodon.yml
@@ -1,3 +1,10 @@
 ---
 shared:
   software_update_url: <%= ENV.fetch('UPDATE_CHECK_URL', 'https://api.joinmastodon.org/update-check') %>
+  source:
+    base_url: <%= ENV.fetch('SOURCE_BASE_URL', nil) %>
+    repository: <%= ENV.fetch('GITHUB_REPOSITORY', 'mastodon/mastodon') %>
+    tag: <%= ENV.fetch('SOURCE_TAG', nil) %>
+  version:
+    metadata: <%= ENV.fetch('MASTODON_VERSION_METADATA', nil) %>
+    prerelease: <%= ENV.fetch('MASTODON_VERSION_PRERELEASE', nil) %>

--- a/lib/mastodon/version.rb
+++ b/lib/mastodon/version.rb
@@ -21,11 +21,11 @@ module Mastodon
     end
 
     def prerelease
-      ENV['MASTODON_VERSION_PRERELEASE'].presence || default_prerelease
+      configuration.version[:prerelease] || default_prerelease
     end
 
     def build_metadata
-      ENV.fetch('MASTODON_VERSION_METADATA', nil)
+      configuration.version[:metadata]
     end
 
     def to_a
@@ -50,16 +50,16 @@ module Mastodon
     end
 
     def repository
-      ENV.fetch('GITHUB_REPOSITORY', 'mastodon/mastodon')
+      configuration.source[:repository]
     end
 
     def source_base_url
-      ENV.fetch('SOURCE_BASE_URL', "https://github.com/#{repository}")
+      configuration.source[:base_url] || "https://github.com/#{repository}"
     end
 
     # specify git tag or commit hash here
     def source_tag
-      ENV.fetch('SOURCE_TAG', nil)
+      configuration.source[:tag]
     end
 
     def source_url
@@ -72,6 +72,10 @@ module Mastodon
 
     def user_agent
       @user_agent ||= "Mastodon/#{Version} (#{HTTP::Request::USER_AGENT}; +http#{Rails.configuration.x.use_https ? 's' : ''}://#{Rails.configuration.x.web_domain}/)"
+    end
+
+    def configuration
+      Rails.configuration.x.mastodon
     end
   end
 end

--- a/spec/presenters/instance_presenter_spec.rb
+++ b/spec/presenters/instance_presenter_spec.rb
@@ -65,11 +65,12 @@ RSpec.describe InstancePresenter do
   end
 
   describe '#source_url' do
-    context 'with the GITHUB_REPOSITORY env variable set' do
+    context 'with the github repository configured' do
       around do |example|
-        ClimateControl.modify GITHUB_REPOSITORY: 'other/repo' do
-          example.run
-        end
+        original = Rails.configuration.x.mastodon.source[:repository]
+        Rails.configuration.x.mastodon.source[:repository] = 'other/repo'
+        example.run
+        Rails.configuration.x.mastodon.source[:repository] = original
       end
 
       it 'uses the env variable to build a repo URL' do
@@ -77,13 +78,7 @@ RSpec.describe InstancePresenter do
       end
     end
 
-    context 'without the GITHUB_REPOSITORY env variable set' do
-      around do |example|
-        ClimateControl.modify GITHUB_REPOSITORY: nil do
-          example.run
-        end
-      end
-
+    context 'without the github repository configured' do
       it 'defaults to the core mastodon repo URL' do
         expect(instance_presenter.source_url).to eq('https://github.com/mastodon/mastodon')
       end


### PR DESCRIPTION
Similar to the other ones.

May need rebase/merge coordination with https://github.com/mastodon/mastodon/pull/30534 (they are adding same named file).