### PR TITLE
Remove bundler-audit ignore config

### DIFF
--- a/.bundler-audit.yml
+++ b/.bundler-audit.yml
@@ -1,6 +1,0 @@
----
-ignore:
-  # devise-two-factor advisory about brute-forcing TOTP
-  # We have rate-limits on authentication endpoints in place (including second
-  # factor verification) since Mastodon v3.2.0
-  - CVE-2024-0227

--- a/.github/workflows/bundler-audit.yml
+++ b/.github/workflows/bundler-audit.yml
@@ -6,14 +6,12 @@ on:
     paths:
       - 'Gemfile*'
       - '.ruby-version'
-      - '.bundler-audit.yml'
       - '.github/workflows/bundler-audit.yml'
 
   pull_request:
     paths:
       - 'Gemfile*'
       - '.ruby-version'
-      - '.bundler-audit.yml'
       - '.github/workflows/bundler-audit.yml'
 
   schedule:


### PR DESCRIPTION
The CVE we were ignoring was withdrawn:
https://github.com/advisories/GHSA-chcr-x7hc-8fp8