### PR TITLE
Disable `consistent-return` eslint rule for Typescript files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -349,6 +349,9 @@ module.exports = defineConfig({
         // Disable formatting rules that have been enabled in the base config
         'indent': 'off',
 
+        // This is not needed as we use noImplicitReturns, which handles this in addition to understanding types
+        'consistent-return': 'off',
+
         'import/consistent-type-specifier-style': ['error', 'prefer-top-level'],
 
         '@typescript-eslint/consistent-type-definitions': ['warn', 'interface'],


### PR DESCRIPTION
This rule is not used if we are using `noImplicitReturns`  (which we do).

Having this rule causes issues if we have functions that handle every case and do not return a default value (because this cant happened as determined by the static analysis), then this check will falsely return an error (see https://stackoverflow.com/a/75526496/1377358).