### PR TITLE
Move chewy search config to `config_for` yml

### DIFF
--- a/app/lib/admin/system_check/elasticsearch_check.rb
+++ b/app/lib/admin/system_check/elasticsearch_check.rb
@@ -116,7 +116,7 @@ class Admin::SystemCheck::ElasticsearchCheck < Admin::SystemCheck::BaseCheck
   end
 
   def es_preset
-    ENV.fetch('ES_PRESET', 'single_node_cluster')
+    Rails.configuration.x.search.preset
   end
 
   def preset_matches?

--- a/config/application.rb
+++ b/config/application.rb
@@ -106,6 +106,7 @@ module Mastodon
 
     config.x.captcha = config_for(:captcha)
     config.x.mastodon = config_for(:mastodon)
+    config.x.search = config_for(:search)
     config.x.translation = config_for(:translation)
 
     config.to_prepare do

--- a/config/initializers/chewy.rb
+++ b/config/initializers/chewy.rb
@@ -1,27 +1,18 @@
 # frozen_string_literal: true
 
-enabled         = ENV['ES_ENABLED'] == 'true'
-host            = ENV.fetch('ES_HOST') { 'localhost' }
-port            = ENV.fetch('ES_PORT') { 9200 }
-user            = ENV.fetch('ES_USER', nil).presence
-password        = ENV.fetch('ES_PASS', nil).presence
-fallback_prefix = ENV.fetch('REDIS_NAMESPACE', nil).presence
-prefix          = ENV.fetch('ES_PREFIX') { fallback_prefix }
-ca_file         = ENV.fetch('ES_CA_FILE', nil).presence
-
-transport_options = { ssl: { ca_file: ca_file } } if ca_file.present?
+search_config = Rails.configuration.x.search
 
 Chewy.settings = {
-  host: "#{host}:#{port}",
-  prefix: prefix,
-  enabled: enabled,
+  host: search_config.host,
+  prefix: search_config.prefix,
+  enabled: search_config.enabled,
   journal: false,
-  user: user,
-  password: password,
+  user: search_config.user,
+  password: search_config.password,
   index: {
-    number_of_replicas: ['single_node_cluster', nil].include?(ENV['ES_PRESET'].presence) ? 0 : 1,
+    number_of_replicas: search_config.preset == 'single_node_cluster' ? 0 : 1,
   },
-  transport_options: transport_options,
+  transport_options: search_config.ca_file.present? ? { ssl: { ca_file: search_config.ca_file } } : nil,
 }
 
 # We use our own async strategy even outside the request-response

--- a/config/search.yml
+++ b/config/search.yml
@@ -1,0 +1,8 @@
+shared:
+  ca_file: <%= ENV.fetch('ES_CA_FILE', nil).presence %>
+  enabled: <%= ENV.fetch('ES_ENABLED', 'false') %>
+  host: <%= ENV.fetch('ES_HOST', 'localhost') %>:<%= ENV.fetch('ES_PORT', '9200') %>
+  password: <%= ENV.fetch('ES_PASS', nil).presence %>
+  prefix: <%= ENV.fetch('ES_PREFIX') { ENV.fetch('REDIS_NAMESPACE', nil).presence } %>
+  preset: <%= ENV.fetch('ES_PRESET', 'single_node_cluster') %>
+  user: <%= ENV.fetch('ES_USER', nil).presence %>

--- a/lib/chewy/index_extensions.rb
+++ b/lib/chewy/index_extensions.rb
@@ -3,8 +3,8 @@
 module Chewy
   module IndexExtensions
     def index_preset(base_options = {})
-      case ENV['ES_PRESET'].presence
-      when 'single_node_cluster', nil
+      case Rails.configuration.x.search.preset
+      when 'single_node_cluster'
         base_options.merge(number_of_replicas: 0)
       when 'small_cluster'
         base_options.merge(number_of_replicas: 1)


### PR DESCRIPTION
Similar to other recent changes like this.

I think there may be opportunity here to further clean up the chewy.rb hash setup options, but wanted to keep the diff smaller here as a first pass.