### PR TITLE
Move storage enabled config to `config_for` yml

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -106,6 +106,7 @@ module Mastodon
 
     config.x.captcha = config_for(:captcha)
     config.x.mastodon = config_for(:mastodon)
+    config.x.storage = config_for(:storage)
     config.x.translation = config_for(:translation)
 
     config.to_prepare do

--- a/config/initializers/1_hosts.rb
+++ b/config/initializers/1_hosts.rb
@@ -12,8 +12,8 @@ Rails.application.configure do
   config.x.local_domain = host
   config.x.web_domain   = web_host
   config.x.use_https    = https
-  config.x.use_s3       = ENV['S3_ENABLED'] == 'true'
-  config.x.use_swift    = ENV['SWIFT_ENABLED'] == 'true'
+  config.x.use_s3       = Rails.configuration.x.storage.s3_enabled
+  config.x.use_swift    = Rails.configuration.x.storage.swift_enabled
 
   config.x.alternate_domains = alternate_domains
 

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -35,7 +35,7 @@ Paperclip::Attachment.default_options.merge!(
   storage: :fog
 )
 
-if ENV['S3_ENABLED'] == 'true'
+if Rails.configuration.x.storage.s3_enabled
   require 'aws-sdk-s3'
 
   s3_region   = ENV.fetch('S3_REGION')   { 'us-east-1' }
@@ -115,7 +115,7 @@ if ENV['S3_ENABLED'] == 'true'
   end
 
   Paperclip::Storage::S3.prepend(Paperclip::Storage::S3Extensions)
-elsif ENV['SWIFT_ENABLED'] == 'true'
+elsif Rails.configuration.x.storage.swift_enabled
   require 'fog/openstack'
 
   Paperclip::Attachment.default_options.merge!(
@@ -139,7 +139,7 @@ elsif ENV['SWIFT_ENABLED'] == 'true'
     fog_host: ENV['SWIFT_OBJECT_URL'],
     fog_public: true
   )
-elsif ENV['AZURE_ENABLED'] == 'true'
+elsif Rails.configuration.x.storage.azure_enabled
   require 'paperclip-azure'
 
   Paperclip::Attachment.default_options.merge!(

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -1,0 +1,4 @@
+shared:
+  azure_enabled: <%= ENV.fetch('AZURE_ENABLED', 'false') %>
+  s3_enabled: <%= ENV.fetch('S3_ENABLED', 'false') %>
+  swift_enabled: <%= ENV.fetch('SWIFT_ENABLED', 'false') %>

--- a/spec/lib/content_security_policy_spec.rb
+++ b/spec/lib/content_security_policy_spec.rb
@@ -116,8 +116,11 @@ RSpec.describe ContentSecurityPolicy do
 
     context 'when s3_enabled is configured' do
       around do |example|
-        ClimateControl.modify S3_ENABLED: 'true', S3_HOSTNAME: 'asset-host.s3.example' do
+        ClimateControl.modify S3_HOSTNAME: 'asset-host.s3.example' do
+          original = Rails.configuration.x.storage.s3_enabled
+          Rails.configuration.x.storage.s3_enabled = true
           example.run
+          Rails.configuration.x.storage.s3_enabled = original
         end
       end
 


### PR DESCRIPTION
Similar approach to https://github.com/mastodon/mastodon/pull/30650 -- start just with top-level "enabled?" checks, and leave a section-by-section migration for each service as followup.

There is probably opportunity here to replace the existing `x.use_*` values with what will be these `x.storage.*_enabled` values as followup as well.