### PR TITLE
Fix limit handling in grouped notifications CTE

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -152,6 +152,7 @@ class Notification < ApplicationRecord
               .limit(1),
             query
               .joins('CROSS JOIN grouped_notifications')
+              .where('array_length(grouped_notifications.groups, 1) < :limit', limit: limit)
               .where('notifications.id < grouped_notifications.id')
               .where.not("COALESCE(notifications.group_key, 'ungrouped-' || notifications.id) = ANY(grouped_notifications.groups)")
               .select('notifications.*', "array_append(grouped_notifications.groups, COALESCE(notifications.group_key, 'ungrouped-' || notifications.id))")
@@ -179,6 +180,7 @@ class Notification < ApplicationRecord
               .limit(1),
             query
               .joins('CROSS JOIN grouped_notifications')
+              .where('array_length(grouped_notifications.groups, 1) < :limit', limit: limit)
               .where('notifications.id > grouped_notifications.id')
               .where.not("COALESCE(notifications.group_key, 'ungrouped-' || notifications.id) = ANY(grouped_notifications.groups)")
               .select('notifications.*', "array_append(grouped_notifications.groups, COALESCE(notifications.group_key, 'ungrouped-' || notifications.id))")


### PR DESCRIPTION
Basically the CTE was grouping all of the user's notifications before limiting them.