### PR TITLE
Update merge conflict rebase action version (silences node version warning)

### DIFF
--- a/.github/workflows/rebase-needed.yml
+++ b/.github/workflows/rebase-needed.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Check for merge conflicts
-        uses: eps1lon/actions-label-merge-conflict@releases/2.x
+        uses: eps1lon/actions-label-merge-conflict@v3
         with:
           dirtyLabel: 'rebase needed :construction:'
           repoToken: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
Example run with warning output: https://github.com/mastodon/mastodon/actions/runs/9501083720

