### PR TITLE
Migrate `form_tag` to `form_with` in admin and auth views

### DIFF
--- a/app/views/admin/accounts/index.html.haml
+++ b/app/views/admin/accounts/index.html.haml
@@ -1,7 +1,7 @@
 - content_for :page_title do
   = t('admin.accounts.title')
 
-= form_tag admin_accounts_url, method: 'GET', class: 'simple_form' do
+= form_with url: admin_accounts_url, method: :get, class: :simple_form do
   .filters
     .filter-subset.filter-subset--with-select
       %strong= t('admin.accounts.location.title')

--- a/app/views/admin/accounts/index.html.haml
+++ b/app/views/admin/accounts/index.html.haml
@@ -1,38 +1,41 @@
 - content_for :page_title do
   = t('admin.accounts.title')
 
-= form_with url: admin_accounts_url, method: :get, class: :simple_form do
+= form_with url: admin_accounts_url, method: :get, class: :simple_form do |form|
   .filters
     .filter-subset.filter-subset--with-select
       %strong= t('admin.accounts.location.title')
       .input.select.optional
-        = select_tag :origin,
-                     options_for_select([[t('admin.accounts.location.local'), 'local'], [t('admin.accounts.location.remote'), 'remote']], params[:origin]),
-                     prompt: I18n.t('generic.all')
+        = form.select :origin,
+                      options_for_select([[t('admin.accounts.location.local'), 'local'], [t('admin.accounts.location.remote'), 'remote']], params[:origin]),
+                      prompt: I18n.t('generic.all')
     .filter-subset.filter-subset--with-select
       %strong= t('admin.accounts.moderation.title')
       .input.select.optional
-        = select_tag :status,
-                     options_for_select(admin_accounts_moderation_options, params[:status]),
-                     prompt: I18n.t('generic.all')
+        = form.select :status,
+                      options_for_select(admin_accounts_moderation_options, params[:status]),
+                      prompt: I18n.t('generic.all')
     .filter-subset.filter-subset--with-select
       %strong= t('admin.accounts.role')
       .input.select.optional
-        = select_tag :role_ids,
-                     options_from_collection_for_select(UserRole.assignable, :id, :name, params[:role_ids]),
-                     prompt: I18n.t('admin.accounts.moderation.all')
+        = form.select :role_ids,
+                      options_from_collection_for_select(UserRole.assignable, :id, :name, params[:role_ids]),
+                      prompt: I18n.t('admin.accounts.moderation.all')
     .filter-subset.filter-subset--with-select
       %strong= t 'generic.order_by'
       .input.select
-        = select_tag :order,
-                     options_for_select([[t('relationships.most_recent'), 'recent'], [t('relationships.last_active'), 'active']], params[:order])
+        = form.select :order,
+                      options_for_select([[t('relationships.most_recent'), 'recent'], [t('relationships.last_active'), 'active']], params[:order])
 
   .fields-group
     - %i(username by_domain display_name email ip).each do |key|
       - next if key == :by_domain && params[:origin] != 'remote'
 
       .input.string.optional
-        = text_field_tag key, params[key], class: 'string optional', placeholder: I18n.t("admin.accounts.#{key}")
+        = form.text_field key,
+                          value: params[key],
+                          class: 'string optional',
+                          placeholder: I18n.t("admin.accounts.#{key}")
 
   .actions
     %button.button= t('admin.accounts.search')

--- a/app/views/admin/action_logs/index.html.haml
+++ b/app/views/admin/action_logs/index.html.haml
@@ -1,7 +1,7 @@
 - content_for :page_title do
   = t('admin.action_logs.title')
 
-= form_tag admin_action_logs_url, method: 'GET', class: 'simple_form' do
+= form_with url: admin_action_logs_url, method: :get, class: :simple_form do
   = hidden_field_tag :target_account_id, params[:target_account_id] if params[:target_account_id].present?
 
   .filters

--- a/app/views/admin/action_logs/index.html.haml
+++ b/app/views/admin/action_logs/index.html.haml
@@ -1,19 +1,23 @@
 - content_for :page_title do
   = t('admin.action_logs.title')
 
-= form_with url: admin_action_logs_url, method: :get, class: :simple_form do
+= form_with url: admin_action_logs_url, method: :get, class: :simple_form do |form|
   = hidden_field_tag :target_account_id, params[:target_account_id] if params[:target_account_id].present?
 
   .filters
     .filter-subset.filter-subset--with-select
       %strong= t('admin.action_logs.filter_by_user')
       .input.select.optional
-        = select_tag :account_id, options_from_collection_for_select(@auditable_accounts, :id, :username, params[:account_id]), prompt: I18n.t('admin.accounts.moderation.all')
+        = form.select :account_id,
+                      options_from_collection_for_select(@auditable_accounts, :id, :username, params[:account_id]),
+                      prompt: I18n.t('admin.accounts.moderation.all')
 
     .filter-subset.filter-subset--with-select
       %strong= t('admin.action_logs.filter_by_action')
       .input.select.optional
-        = select_tag :action_type, options_for_select(Admin::ActionLogFilter::ACTION_TYPE_MAP.keys.map { |key| [I18n.t("admin.action_logs.action_types.#{key}"), key] }, params[:action_type]), prompt: I18n.t('admin.accounts.moderation.all')
+        = form.select :action_type,
+                      options_for_select(Admin::ActionLogFilter::ACTION_TYPE_MAP.keys.map { |key| [I18n.t("admin.action_logs.action_types.#{key}"), key] }, params[:action_type]),
+                      prompt: I18n.t('admin.accounts.moderation.all')
 
 - if @action_logs.empty?
   .muted-hint.center-text

--- a/app/views/admin/custom_emojis/index.html.haml
+++ b/app/views/admin/custom_emojis/index.html.haml
@@ -21,7 +21,7 @@
         - else
           = filter_link_to t('admin.accounts.location.remote'), remote: '1', local: nil
 
-= form_tag admin_custom_emojis_url, method: 'GET', class: 'simple_form' do
+= form_with url: admin_custom_emojis_url, method: :get, class: :simple_form do
   .fields-group
     - CustomEmojiFilter::KEYS.each do |key|
       = hidden_field_tag key, params[key] if params[key].present?

--- a/app/views/admin/custom_emojis/index.html.haml
+++ b/app/views/admin/custom_emojis/index.html.haml
@@ -21,14 +21,17 @@
         - else
           = filter_link_to t('admin.accounts.location.remote'), remote: '1', local: nil
 
-= form_with url: admin_custom_emojis_url, method: :get, class: :simple_form do
+= form_with url: admin_custom_emojis_url, method: :get, class: :simple_form do |form|
   .fields-group
     - CustomEmojiFilter::KEYS.each do |key|
-      = hidden_field_tag key, params[key] if params[key].present?
+      = form.hidden_field key, value: params[key] if params[key].present?
 
     - %i(shortcode by_domain).each do |key|
       .input.string.optional
-        = text_field_tag key, params[key], class: 'string optional', placeholder: I18n.t("admin.custom_emojis.#{key}")
+        = form.text_field key,
+                          value: params[key],
+                          class: 'string optional',
+                          placeholder: I18n.t("admin.custom_emojis.#{key}")
 
     .actions
       %button.button= t('admin.accounts.search')

--- a/app/views/admin/follow_recommendations/show.html.haml
+++ b/app/views/admin/follow_recommendations/show.html.haml
@@ -5,16 +5,16 @@
 
 %hr.spacer/
 
-= form_with url: admin_follow_recommendations_path, method: :get, class: :simple_form do
+= form_with url: admin_follow_recommendations_path, method: :get, class: :simple_form do |form|
   - RelationshipFilter::KEYS.each do |key|
-    = hidden_field_tag key, params[key] if params[key].present?
+    = form.hidden_field key, value: params[key] if params[key].present?
 
   .filters
     .filter-subset.filter-subset--with-select
       %strong= t('admin.follow_recommendations.language')
       .input.select.optional
-        = select_tag :language,
-                     options_for_select(Trends.available_locales.map { |key| [standard_locale_name(key), key] }, @language)
+        = form.select :language,
+                      options_for_select(Trends.available_locales.map { |key| [standard_locale_name(key), key] }, @language)
     .filter-subset
       %strong= t('admin.follow_recommendations.status')
       %ul

--- a/app/views/admin/follow_recommendations/show.html.haml
+++ b/app/views/admin/follow_recommendations/show.html.haml
@@ -5,7 +5,7 @@
 
 %hr.spacer/
 
-= form_tag admin_follow_recommendations_path, method: 'GET', class: 'simple_form' do
+= form_with url: admin_follow_recommendations_path, method: :get, class: :simple_form do
   - RelationshipFilter::KEYS.each do |key|
     = hidden_field_tag key, params[key] if params[key].present?
 

--- a/app/views/admin/instances/index.html.haml
+++ b/app/views/admin/instances/index.html.haml
@@ -28,14 +28,17 @@
       %li= filter_link_to t('admin.instances.delivery.unavailable'), availability: 'unavailable'
 
 - unless limited_federation_mode?
-  = form_with url: admin_instances_url, method: :get, class: :simple_form do
+  = form_with url: admin_instances_url, method: :get, class: :simple_form do |form|
     .fields-group
       - InstanceFilter::KEYS.each do |key|
-        = hidden_field_tag key, params[key] if params[key].present?
+        = form.hidden_field key, value: params[key] if params[key].present?
 
       - %i(by_domain).each do |key|
         .input.string.optional
-          = text_field_tag key, params[key], class: 'string optional', placeholder: I18n.t("admin.instances.#{key}")
+          = form.text_field key,
+                            value: params[key],
+                            class: 'string optional',
+                            placeholder: I18n.t("admin.instances.#{key}")
 
       .actions
         %button.button= t('admin.accounts.search')

--- a/app/views/admin/instances/index.html.haml
+++ b/app/views/admin/instances/index.html.haml
@@ -28,7 +28,7 @@
       %li= filter_link_to t('admin.instances.delivery.unavailable'), availability: 'unavailable'
 
 - unless limited_federation_mode?
-  = form_tag admin_instances_url, method: 'GET', class: 'simple_form' do
+  = form_with url: admin_instances_url, method: :get, class: :simple_form do
     .fields-group
       - InstanceFilter::KEYS.each do |key|
         = hidden_field_tag key, params[key] if params[key].present?

--- a/app/views/admin/reports/_actions.html.haml
+++ b/app/views/admin/reports/_actions.html.haml
@@ -1,4 +1,4 @@
-= form_with url: preview_admin_report_actions_path(report), method: :post do
+= form_with url: preview_admin_report_actions_path(report), method: :post do |form|
   .report-actions
     .report-actions__item
       .report-actions__item__button
@@ -8,26 +8,36 @@
     - if statuses.any? { |status| (status.with_media? || status.with_preview_card?) && !status.discarded? }
       .report-actions__item
         .report-actions__item__button
-          = button_tag t('admin.reports.mark_as_sensitive'), name: :mark_as_sensitive, class: 'button'
+          = form.button t('admin.reports.mark_as_sensitive'),
+                        name: :mark_as_sensitive,
+                        class: 'button'
         .report-actions__item__description
           = t('admin.reports.actions.mark_as_sensitive_description_html')
     .report-actions__item
       .report-actions__item__button
-        = button_tag t('admin.reports.delete_and_resolve'), name: :delete, class: 'button button--destructive'
+        = form.button t('admin.reports.delete_and_resolve'),
+                      name: :delete,
+                      class: 'button button--destructive'
       .report-actions__item__description
         = t('admin.reports.actions.delete_description_html')
     .report-actions__item
       .report-actions__item__button
-        = button_tag t('admin.accounts.silence'), name: :silence, class: 'button button--destructive'
+        = form.button t('admin.accounts.silence'),
+                      name: :silence,
+                      class: 'button button--destructive'
       .report-actions__item__description
         = t('admin.reports.actions.silence_description_html')
     .report-actions__item
       .report-actions__item__button
-        = button_tag t('admin.accounts.suspend'), name: :suspend, class: 'button button--destructive'
+        = form.button t('admin.accounts.suspend'),
+                      name: :suspend,
+                      class: 'button button--destructive'
       .report-actions__item__description
         = t('admin.reports.actions.suspend_description_html')
     .report-actions__item
       .report-actions__item__button
-        = link_to t('admin.accounts.custom'), new_admin_account_action_path(report.target_account_id, report_id: report.id), class: 'button'
+        = link_to t('admin.accounts.custom'),
+                  new_admin_account_action_path(report.target_account_id, report_id: report.id),
+                  class: 'button'
       .report-actions__item__description
         = t('admin.reports.actions.other_description_html')

--- a/app/views/admin/reports/_actions.html.haml
+++ b/app/views/admin/reports/_actions.html.haml
@@ -1,4 +1,4 @@
-= form_with url: preview_admin_report_actions_path(report), method: :post do |form|
+= form_with url: preview_admin_report_actions_path(report) do |form|
   .report-actions
     .report-actions__item
       .report-actions__item__button

--- a/app/views/admin/reports/_actions.html.haml
+++ b/app/views/admin/reports/_actions.html.haml
@@ -1,4 +1,4 @@
-= form_tag preview_admin_report_actions_path(report), method: :post do
+= form_with url: preview_admin_report_actions_path(report), method: :post do
   .report-actions
     .report-actions__item
       .report-actions__item__button

--- a/app/views/admin/reports/actions/preview.html.haml
+++ b/app/views/admin/reports/actions/preview.html.haml
@@ -4,8 +4,8 @@
 - content_for :page_title do
   = t('admin.reports.confirm_action', acct: target_acct)
 
-= form_with url: admin_report_actions_path(@report), method: :post, class: :simple_form do
-  = hidden_field_tag :moderation_action, @moderation_action
+= form_with url: admin_report_actions_path(@report), method: :post, class: :simple_form do |form|
+  = form.hidden_field :moderation_action, value: @moderation_action
 
   %p.hint= t("admin.reports.summary.action_preambles.#{@moderation_action}_html", acct: target_acct)
   %ul.hint
@@ -30,7 +30,9 @@
         %p= t "user_mailer.warning.explanation.#{warning_action}", instance: Rails.configuration.x.local_domain
 
       .fields-group
-        = text_area_tag :text, nil, placeholder: t('admin.reports.summary.warning_placeholder')
+        = form.text_area :text,
+                         value: nil,
+                         placeholder: t('admin.reports.summary.warning_placeholder')
 
       - unless @report.other?
         %p
@@ -75,4 +77,7 @@
 
   .actions
     = link_to t('admin.reports.cancel'), admin_report_path(@report), class: 'button button-tertiary'
-    = button_tag t('admin.reports.confirm'), name: :confirm, class: 'button', type: :submit
+    = form.button t('admin.reports.confirm'),
+                  name: :confirm,
+                  class: 'button',
+                  type: :submit

--- a/app/views/admin/reports/actions/preview.html.haml
+++ b/app/views/admin/reports/actions/preview.html.haml
@@ -4,7 +4,7 @@
 - content_for :page_title do
   = t('admin.reports.confirm_action', acct: target_acct)
 
-= form_tag admin_report_actions_path(@report), class: 'simple_form', method: :post do
+= form_with url: admin_report_actions_path(@report), method: :post, class: :simple_form do
   = hidden_field_tag :moderation_action, @moderation_action
 
   %p.hint= t("admin.reports.summary.action_preambles.#{@moderation_action}_html", acct: target_acct)

--- a/app/views/admin/reports/actions/preview.html.haml
+++ b/app/views/admin/reports/actions/preview.html.haml
@@ -4,7 +4,7 @@
 - content_for :page_title do
   = t('admin.reports.confirm_action', acct: target_acct)
 
-= form_with url: admin_report_actions_path(@report), method: :post, class: :simple_form do |form|
+= form_with url: admin_report_actions_path(@report), class: :simple_form do |form|
   = form.hidden_field :moderation_action, value: @moderation_action
 
   %p.hint= t("admin.reports.summary.action_preambles.#{@moderation_action}_html", acct: target_acct)

--- a/app/views/admin/reports/index.html.haml
+++ b/app/views/admin/reports/index.html.haml
@@ -14,14 +14,17 @@
       %li= filter_link_to t('admin.accounts.location.local'), target_origin: 'local'
       %li= filter_link_to t('admin.accounts.location.remote'), target_origin: 'remote'
 
-= form_with url: admin_reports_url, method: :get, class: :simple_form do
+= form_with url: admin_reports_url, method: :get, class: :simple_form do |form|
   .fields-group
     - ReportFilter::KEYS.each do |key|
-      = hidden_field_tag key, params[key] if params[key].present?
+      = form.hidden_field key, value: params[key] if params[key].present?
 
     - %i(by_target_domain).each do |key|
       .input.string.optional
-        = text_field_tag key, params[key], class: 'string optional', placeholder: I18n.t("admin.reports.#{key}")
+        = form.text_field key,
+                          value: params[key],
+                          class: 'string optional',
+                          placeholder: I18n.t("admin.reports.#{key}")
 
     .actions
       %button.button= t('admin.accounts.search')

--- a/app/views/admin/reports/index.html.haml
+++ b/app/views/admin/reports/index.html.haml
@@ -14,7 +14,7 @@
       %li= filter_link_to t('admin.accounts.location.local'), target_origin: 'local'
       %li= filter_link_to t('admin.accounts.location.remote'), target_origin: 'remote'
 
-= form_tag admin_reports_url, method: 'GET', class: 'simple_form' do
+= form_with url: admin_reports_url, method: :get, class: :simple_form do
   .fields-group
     - ReportFilter::KEYS.each do |key|
       = hidden_field_tag key, params[key] if params[key].present?

--- a/app/views/admin/trends/links/index.html.haml
+++ b/app/views/admin/trends/links/index.html.haml
@@ -5,17 +5,17 @@
 
 %hr.spacer/
 
-= form_with url: admin_trends_links_path, method: :get, class: :simple_form do
+= form_with url: admin_trends_links_path, method: :get, class: :simple_form do |form|
   - Trends::PreviewCardFilter::KEYS.each do |key|
-    = hidden_field_tag key, params[key] if params[key].present?
+    = form.hidden_field key, value: params[key] if params[key].present?
 
   .filters
     .filter-subset.filter-subset--with-select
       %strong= t('admin.follow_recommendations.language')
       .input.select.optional
-        = select_tag :locale,
-                     options_for_select(@locales.map { |key| [standard_locale_name(key), key] }, params[:locale]),
-                     include_blank: true
+        = form.select :locale,
+                      options_for_select(@locales.map { |key| [standard_locale_name(key), key] }, params[:locale]),
+                      include_blank: true
     .filter-subset
       %strong= t('admin.trends.trending')
       %ul

--- a/app/views/admin/trends/links/index.html.haml
+++ b/app/views/admin/trends/links/index.html.haml
@@ -5,7 +5,7 @@
 
 %hr.spacer/
 
-= form_tag admin_trends_links_path, method: 'GET', class: 'simple_form' do
+= form_with url: admin_trends_links_path, method: :get, class: :simple_form do
   - Trends::PreviewCardFilter::KEYS.each do |key|
     = hidden_field_tag key, params[key] if params[key].present?
 

--- a/app/views/admin/trends/statuses/index.html.haml
+++ b/app/views/admin/trends/statuses/index.html.haml
@@ -5,7 +5,7 @@
 
 %hr.spacer/
 
-= form_tag admin_trends_statuses_path, method: 'GET', class: 'simple_form' do
+= form_with url: admin_trends_statuses_path, method: :get, class: :simple_form do
   - Trends::StatusFilter::KEYS.each do |key|
     = hidden_field_tag key, params[key] if params[key].present?
 

--- a/app/views/admin/trends/statuses/index.html.haml
+++ b/app/views/admin/trends/statuses/index.html.haml
@@ -5,15 +5,17 @@
 
 %hr.spacer/
 
-= form_with url: admin_trends_statuses_path, method: :get, class: :simple_form do
+= form_with url: admin_trends_statuses_path, method: :get, class: :simple_form do |form|
   - Trends::StatusFilter::KEYS.each do |key|
-    = hidden_field_tag key, params[key] if params[key].present?
+    = form.hidden_field key, value: params[key] if params[key].present?
 
   .filters
     .filter-subset.filter-subset--with-select
       %strong= t('admin.follow_recommendations.language')
       .input.select.optional
-        = select_tag :locale, options_for_select(@locales.map { |key| [standard_locale_name(key), key] }, params[:locale]), include_blank: true
+        = form.select :locale,
+                      options_for_select(@locales.map { |key| [standard_locale_name(key), key] }, params[:locale]),
+                      include_blank: true
     .filter-subset
       %strong= t('admin.trends.trending')
       %ul

--- a/app/views/auth/confirmations/captcha.html.haml
+++ b/app/views/auth/confirmations/captcha.html.haml
@@ -1,7 +1,7 @@
 - content_for :page_title do
   = t('auth.captcha_confirmation.title')
 
-= form_tag auth_captcha_confirmation_url, method: 'POST', class: 'simple_form' do
+= form_with url: auth_captcha_confirmation_url, method: :post, class: :simple_form do
   = render 'auth/shared/progress', stage: 'confirm'
 
   = hidden_field_tag :confirmation_token, params[:confirmation_token]

--- a/app/views/auth/confirmations/captcha.html.haml
+++ b/app/views/auth/confirmations/captcha.html.haml
@@ -1,11 +1,13 @@
 - content_for :page_title do
   = t('auth.captcha_confirmation.title')
 
-= form_with url: auth_captcha_confirmation_url, method: :post, class: :simple_form do
+= form_with url: auth_captcha_confirmation_url, method: :post, class: :simple_form do |form|
   = render 'auth/shared/progress', stage: 'confirm'
 
-  = hidden_field_tag :confirmation_token, params[:confirmation_token]
-  = hidden_field_tag :redirect_to_app, params[:redirect_to_app]
+  = form.hidden_field :confirmation_token,
+                      value: params[:confirmation_token]
+  = form.hidden_field :redirect_to_app,
+                      value: params[:redirect_to_app]
 
   %h1.title= t('auth.captcha_confirmation.title')
   %p.lead= t('auth.captcha_confirmation.hint_html')
@@ -15,4 +17,6 @@
   %p.lead= t('auth.captcha_confirmation.help_html', email: mail_to(Setting.site_contact_email, nil))
 
   .actions
-    = button_tag t('challenge.confirm'), class: 'button', type: :submit
+    = form.button t('challenge.confirm'),
+                  class: 'button',
+                  type: :submit

--- a/app/views/auth/confirmations/captcha.html.haml
+++ b/app/views/auth/confirmations/captcha.html.haml
@@ -1,7 +1,7 @@
 - content_for :page_title do
   = t('auth.captcha_confirmation.title')
 
-= form_with url: auth_captcha_confirmation_url, method: :post, class: :simple_form do |form|
+= form_with url: auth_captcha_confirmation_url, class: :simple_form do |form|
   = render 'auth/shared/progress', stage: 'confirm'
 
   = form.hidden_field :confirmation_token,

--- a/app/views/mail_subscriptions/show.html.haml
+++ b/app/views/mail_subscriptions/show.html.haml
@@ -10,7 +10,7 @@
         email: content_tag(:strong, @user.email),
         settings_path: settings_preferences_notifications_path
 
-  = form_tag unsubscribe_path, method: :post do
+  = form_with url: unsubscribe_path, method: :post do
     = hidden_field_tag :token, params[:token]
     = hidden_field_tag :type, params[:type]
     = button_tag t('mail_subscriptions.unsubscribe.action'), type: :submit

--- a/app/views/mail_subscriptions/show.html.haml
+++ b/app/views/mail_subscriptions/show.html.haml
@@ -10,7 +10,7 @@
         email: content_tag(:strong, @user.email),
         settings_path: settings_preferences_notifications_path
 
-  = form_with url: unsubscribe_path, method: :post do |form|
+  = form_with url: unsubscribe_path do |form|
     = form.hidden_field :token,
                         value: params[:token]
     = form.hidden_field :type,

--- a/app/views/mail_subscriptions/show.html.haml
+++ b/app/views/mail_subscriptions/show.html.haml
@@ -10,7 +10,10 @@
         email: content_tag(:strong, @user.email),
         settings_path: settings_preferences_notifications_path
 
-  = form_with url: unsubscribe_path, method: :post do
-    = hidden_field_tag :token, params[:token]
-    = hidden_field_tag :type, params[:type]
-    = button_tag t('mail_subscriptions.unsubscribe.action'), type: :submit
+  = form_with url: unsubscribe_path, method: :post do |form|
+    = form.hidden_field :token,
+                        value: params[:token]
+    = form.hidden_field :type,
+                        value: params[:type]
+    = form.button t('mail_subscriptions.unsubscribe.action'),
+                  type: :submit

--- a/app/views/oauth/authorizations/new.html.haml
+++ b/app/views/oauth/authorizations/new.html.haml
@@ -21,7 +21,7 @@
               = t(scope.access, scope: [:doorkeeper, :grouped_scopes, :access])
 
     .actions
-      = form_tag oauth_authorization_path, method: :post do
+      = form_with url: oauth_authorization_path, method: :post do
         = hidden_field_tag :client_id, @pre_auth.client.uid
         = hidden_field_tag :redirect_uri, @pre_auth.redirect_uri
         = hidden_field_tag :state, @pre_auth.state
@@ -29,7 +29,7 @@
         = hidden_field_tag :scope, @pre_auth.scope
         = button_tag t('doorkeeper.authorizations.buttons.authorize'), type: :submit
 
-      = form_tag oauth_authorization_path, method: :delete do
+      = form_with url: oauth_authorization_path, method: :delete do
         = hidden_field_tag :client_id, @pre_auth.client.uid
         = hidden_field_tag :redirect_uri, @pre_auth.redirect_uri
         = hidden_field_tag :state, @pre_auth.state

--- a/app/views/oauth/authorizations/new.html.haml
+++ b/app/views/oauth/authorizations/new.html.haml
@@ -21,7 +21,7 @@
               = t(scope.access, scope: [:doorkeeper, :grouped_scopes, :access])
 
     .actions
-      = form_with url: oauth_authorization_path, method: :post do |form|
+      = form_with url: oauth_authorization_path do |form|
         = form.hidden_field :client_id,
                             value: @pre_auth.client.uid
         = form.hidden_field :redirect_uri,

--- a/app/views/oauth/authorizations/new.html.haml
+++ b/app/views/oauth/authorizations/new.html.haml
@@ -21,18 +21,31 @@
               = t(scope.access, scope: [:doorkeeper, :grouped_scopes, :access])
 
     .actions
-      = form_with url: oauth_authorization_path, method: :post do
-        = hidden_field_tag :client_id, @pre_auth.client.uid
-        = hidden_field_tag :redirect_uri, @pre_auth.redirect_uri
-        = hidden_field_tag :state, @pre_auth.state
-        = hidden_field_tag :response_type, @pre_auth.response_type
-        = hidden_field_tag :scope, @pre_auth.scope
-        = button_tag t('doorkeeper.authorizations.buttons.authorize'), type: :submit
+      = form_with url: oauth_authorization_path, method: :post do |form|
+        = form.hidden_field :client_id,
+                            value: @pre_auth.client.uid
+        = form.hidden_field :redirect_uri,
+                            value: @pre_auth.redirect_uri
+        = form.hidden_field :state,
+                            value: @pre_auth.state
+        = form.hidden_field :response_type,
+                            value: @pre_auth.response_type
+        = form.hidden_field :scope,
+                            value: @pre_auth.scope
+        = form.button t('doorkeeper.authorizations.buttons.authorize'),
+                      type: :submit
 
-      = form_with url: oauth_authorization_path, method: :delete do
-        = hidden_field_tag :client_id, @pre_auth.client.uid
-        = hidden_field_tag :redirect_uri, @pre_auth.redirect_uri
-        = hidden_field_tag :state, @pre_auth.state
-        = hidden_field_tag :response_type, @pre_auth.response_type
-        = hidden_field_tag :scope, @pre_auth.scope
-        = button_tag t('doorkeeper.authorizations.buttons.deny'), type: :submit, class: 'negative'
+      = form_with url: oauth_authorization_path, method: :delete do |form|
+        = form.hidden_field :client_id,
+                            value: @pre_auth.client.uid
+        = form.hidden_field :redirect_uri,
+                            value: @pre_auth.redirect_uri
+        = form.hidden_field :state,
+                            value: @pre_auth.state
+        = form.hidden_field :response_type,
+                            value: @pre_auth.response_type
+        = form.hidden_field :scope,
+                            value: @pre_auth.scope
+        = form.button t('doorkeeper.authorizations.buttons.deny'),
+                      type: :submit,
+                      class: 'negative'


### PR DESCRIPTION
Since Rails 5.x, the `form_tag` and `form_for` form helpers have been "soft deprecated" in favor of the unified `form_with` method, which can handled both model-backed and generic non-model forms with the same builder. This PR handles only the `form_tag` cases. I'll do `form_for` separately.

Other than the rename, there's some lightweight line cleanup to match what we previously did during some of the haml lint cleanup work. There are also a few forms using `POST` which no longer need the option (it's the default action for `form_with`).

I did not literally line-by-line compare every single generated page view here, but I did look at a handful to be confident in the changes, and it seemed ok. We have reasonable coverage on these as well, although not all of it "uses" the forms.