### PR TITLE
Fix (relax) remaining `RSpec/*` cops

### DIFF
--- a/.rubocop/rspec.yml
+++ b/.rubocop/rspec.yml
@@ -1,9 +1,19 @@
 ---
 RSpec/ExampleLength:
   CountAsOne: ['array', 'heredoc', 'method_call']
+  Max: 20 # Override default of 5
+
+RSpec/MultipleExpectations:
+  Max: 10 # Overrides default of 1
+
+RSpec/MultipleMemoizedHelpers:
+  Max: 20 # Overrides default of 5
 
 RSpec/NamedSubject:
   EnforcedStyle: named_only
+
+RSpec/NestedGroups:
+  Max: 10 # Overrides default of 3
 
 RSpec/NotToNot:
   EnforcedStyle: to_not

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -27,21 +27,6 @@ Metrics/CyclomaticComplexity:
 Metrics/PerceivedComplexity:
   Max: 27
 
-# Configuration parameters: CountAsOne.
-RSpec/ExampleLength:
-  Max: 18
-
-RSpec/MultipleExpectations:
-  Max: 7
-
-# Configuration parameters: AllowSubject.
-RSpec/MultipleMemoizedHelpers:
-  Max: 17
-
-# Configuration parameters: AllowedGroups.
-RSpec/NestedGroups:
-  Max: 6
-
 Rails/OutputSafety:
   Exclude:
     - 'config/initializers/simple_form.rb'


### PR DESCRIPTION
I've done a few rounds on all of these, and there's just not an obvious way to solve/handle the remaining things in the todo in a way that makes sense. Seems reasonable to just embrace where we're at now (I rounded up a bit from the todo in new values).


Part of a followup on https://github.com/mastodon/mastodon/pull/30407, and pulled out of a (large) WIP branch that has a few more config/fix changes not in that initial PR.