### PR TITLE
Fix `Style/GlobalStdStream` cop in environments/* files

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,7 +37,7 @@ Rails.application.configure do
 
   config.action_controller.forgery_protection_origin_check = ENV['DISABLE_FORGERY_REQUEST_PROTECTION'].nil?
 
-  ActiveSupport::Logger.new(STDOUT).tap do |logger|
+  ActiveSupport::Logger.new($stdout).tap do |logger|
     logger.formatter = config.log_formatter
     config.logger = ActiveSupport::TaggedLogging.new(logger)
   end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -94,7 +94,7 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new "app-name")
 
   # Log to STDOUT by default
-  config.logger = ActiveSupport::Logger.new(STDOUT)
+  config.logger = ActiveSupport::Logger.new($stdout)
                                        .tap  { |logger| logger.formatter = ::Logger::Formatter.new }
                                        .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
 


### PR DESCRIPTION
Part of a followup on https://github.com/mastodon/mastodon/pull/30407, and pulled out of a (large) WIP branch that has a few more config/fix changes not in that initial PR.