### PR TITLE
Remove exclusion for `Rails/LexicallyScopedActionFilter` cop

### DIFF
--- a/.rubocop/rails.yml
+++ b/.rubocop/rails.yml
@@ -5,10 +5,6 @@ Rails/FilePath:
 Rails/HttpStatus:
   EnforcedStyle: numeric
 
-Rails/LexicallyScopedActionFilter:
-  Exclude:
-    - app/controllers/auth/* # Conflicts with `Lint/UselessMethodDefinition` for inherited controller actions
-
 Rails/NegateInclude:
   Enabled: false
 

--- a/app/controllers/auth/registrations_controller.rb
+++ b/app/controllers/auth/registrations_controller.rb
@@ -25,6 +25,14 @@ class Auth::RegistrationsController < Devise::RegistrationsController
     super(&:build_invite_request)
   end
 
+  def edit # rubocop:disable Lint/UselessMethodDefinition
+    super
+  end
+
+  def create # rubocop:disable Lint/UselessMethodDefinition
+    super
+  end
+
   def update
     super do |resource|
       resource.clear_other_sessions(current_session.session_id) if resource.saved_change_to_encrypted_password?


### PR DESCRIPTION
Part of a followup on https://github.com/mastodon/mastodon/pull/30407, and pulled out of a (large) WIP branch that has a few more config/fix changes not in that initial PR.

Probably the final one for now in this little series.

Future PR from WIP branch will fix the rule conflict here.