### PR TITLE
improve nginx.conf by setting gzip_static to on

### DIFF
--- a/dist/nginx.conf
+++ b/dist/nginx.conf
@@ -63,6 +63,7 @@ server {
   gzip_buffers 16 8k;
   gzip_http_version 1.1;
   gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript image/svg+xml image/x-icon;
+  gzip_static on;
 
   location / {
     try_files $uri @proxy;


### PR DESCRIPTION
This improves response time and reduces response sizes.

According to https://github.com/webpack-contrib/compression-webpack-plugin?tab=readme-ov-file#compressionoptions the static files are compressed using level 9. So that improves a lot. It probably should also be documented somewhere. 