### PR TITLE
Move test migrations paths check to workflow level

### DIFF
--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -6,25 +6,24 @@ on:
     branches:
       - 'main'
       - 'stable-*'
+    paths:
+      - 'Gemfile*'
+      - '.ruby-version'
+      - '**/*.rb'
+      - '.github/workflows/test-migrations.yml'
+      - 'lib/tasks/tests.rake'
+
   pull_request:
+    paths:
+      - 'Gemfile*'
+      - '.ruby-version'
+      - '**/*.rb'
+      - '.github/workflows/test-migrations.yml'
+      - 'lib/tasks/tests.rake'
 
 jobs:
-  pre_job:
-    runs-on: ubuntu-latest
-
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-
-    steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@v5
-        with:
-          paths: '["Gemfile*", ".ruby-version", "**/*.rb", ".github/workflows/test-migrations.yml", "lib/tasks/tests.rake"]'
-
   test:
     runs-on: ubuntu-latest
-    needs: pre_job
-    if: needs.pre_job.outputs.should_skip != 'true'
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Sort of a followup on https://github.com/mastodon/mastodon/pull/30661

The previous configuration here looked like:

- The `pre_job` step uses a GH action that enables filtering on paths at the job/step level (the built in GH action feature only allows this filter at whole file workflow level)
- The test (migration check) job required this to run first and determine to not skip the job (until the linked PR, this was two jobs, one for each migration check)

By moving this check to the workflow level, I don't think we lose anything? (the gh actions path filter works the same, and I think the other features of the action I'm removing here we are not using in this scenario) -- and we gain a slight speedup, becauset the GH workflow-level filter happens higher up and bails sooner when it doesn't need to run ... and goes right into running the jobs in the matrix when it does need to run. The job itself isn't super long running (2-5s), but there's almost always an unlogged "between jobs" delay of ~10s or so as you move from the pre_job check into the action test runs.

It's also possible that I'm completely missing something about why the config here does need to exist at the job level!