### PR TITLE
Reduce docker service container health check wait times

### DIFF
--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -41,9 +41,9 @@ jobs:
           POSTGRES_USER: postgres
         options: >-
           --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+          --health-interval 10ms
+          --health-timeout 3s
+          --health-retries 50
         ports:
           - 5432:5432
 
@@ -51,9 +51,9 @@ jobs:
         image: redis:7-alpine
         options: >-
           --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+          --health-interval 10ms
+          --health-timeout 3s
+          --health-retries 50
         ports:
           - 6379:6379
 

--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -73,9 +73,9 @@ jobs:
           POSTGRES_USER: postgres
         options: >-
           --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+          --health-interval 10ms
+          --health-timeout 3s
+          --health-retries 50
         ports:
           - 5432:5432
 
@@ -83,9 +83,9 @@ jobs:
         image: redis:7-alpine
         options: >-
           --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+          --health-interval 10ms
+          --health-timeout 3s
+          --health-retries 50
         ports:
           - 6379:6379
 
@@ -159,9 +159,9 @@ jobs:
           POSTGRES_USER: postgres
         options: >-
           --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+          --health-interval 10ms
+          --health-timeout 3s
+          --health-retries 50
         ports:
           - 5432:5432
 
@@ -169,9 +169,9 @@ jobs:
         image: redis:7-alpine
         options: >-
           --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+          --health-interval 10ms
+          --health-timeout 3s
+          --health-retries 50
         ports:
           - 6379:6379
 
@@ -246,9 +246,9 @@ jobs:
           POSTGRES_USER: postgres
         options: >-
           --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+          --health-interval 10ms
+          --health-timeout 3s
+          --health-retries 50
         ports:
           - 5432:5432
 
@@ -256,9 +256,9 @@ jobs:
         image: redis:7-alpine
         options: >-
           --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+          --health-interval 10ms
+          --health-timeout 3s
+          --health-retries 50
         ports:
           - 6379:6379
 
@@ -331,9 +331,9 @@ jobs:
           POSTGRES_USER: postgres
         options: >-
           --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+          --health-interval 10ms
+          --health-timeout 3s
+          --health-retries 50
         ports:
           - 5432:5432
 
@@ -341,9 +341,9 @@ jobs:
         image: redis:7-alpine
         options: >-
           --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+          --health-interval 10ms
+          --health-timeout 3s
+          --health-retries 50
         ports:
           - 6379:6379
 
@@ -354,9 +354,9 @@ jobs:
           xpack.security.enabled: false
         options: >-
           --health-cmd "curl http://localhost:9200/_cluster/health"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 10
+          --health-interval 2s
+          --health-timeout 3s
+          --health-retries 50
         ports:
           - 9200:9200
 
@@ -368,9 +368,9 @@ jobs:
           DISABLE_SECURITY_PLUGIN: true
         options: >-
           --health-cmd "curl http://localhost:9200/_cluster/health"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 10
+          --health-interval 2s
+          --health-timeout 3s
+          --health-retries 50
         ports:
           - 9200:9200
 


### PR DESCRIPTION
Yet another in a series of little CI mini optimizations.

The idea here is to reduce the "waiting for service containers" (usuall pg/redis, sometimes ES) times in CI runs.

This PR reduces the interval (ie, check health more often), reduces the timeout (bail on a given check sooner), increases the retries (since we're checking more often, we may need more attempts).

This is not super precise benchmarking, but I enabled CI on my fork and see roughly:

- On main and other PRs with current settings -- about 20-25s on normal redis/pg waiting and 45-50s when ES is also needed. This is pretty consistent across runs.
- On this branch -- around ~7/8s on redis/pg wait, still ~45s when needing ES

I'm not really sure how to find a sweet spot on this ... if we make it too low, we'll get timeouts while waiting. I guess we could try some numbers and iterate over time if we're hitting failures often.

I left ES a bit higher than pg/redis because it seems to need longer to be ready.

Finally, it's somewhat maddening that we can't re-use this config between these jobs?

