### PR TITLE
Add `most_recent_notification_id` to `NotificationGroup`

### DIFF
--- a/app/models/notification_group.rb
+++ b/app/models/notification_group.rb
@@ -1,14 +1,17 @@
 # frozen_string_literal: true
 
 class NotificationGroup < ActiveModelSerializers::Model
-  attributes :group_key, :sample_accounts, :notifications_count, :notification
+  attributes :group_key, :sample_accounts, :notifications_count, :notification, :most_recent_notification_id
 
   def self.from_notification(notification)
     if notification.group_key.present?
       # TODO: caching and preloading
-      sample_accounts = notification.account.notifications.where(group_key: notification.group_key).order(id: :desc).limit(3).map(&:from_account)
+      most_recent_notifications = notification.account.notifications.where(group_key: notification.group_key).order(id: :desc).take(3)
+      most_recent_id = most_recent_notifications.first.id
+      sample_accounts = most_recent_notifications.map(&:from_account)
       notifications_count = notification.account.notifications.where(group_key: notification.group_key).count
     else
+      most_recent_id = notification.id
       sample_accounts = [notification.from_account]
       notifications_count = 1
     end
@@ -17,7 +20,8 @@ class NotificationGroup < ActiveModelSerializers::Model
       notification: notification,
       group_key: notification.group_key || "ungrouped-#{notification.id}",
       sample_accounts: sample_accounts,
-      notifications_count: notifications_count
+      notifications_count: notifications_count,
+      most_recent_notification_id: most_recent_id
     )
   end
 

--- a/app/serializers/rest/notification_group_serializer.rb
+++ b/app/serializers/rest/notification_group_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class REST::NotificationGroupSerializer < ActiveModel::Serializer
-  attributes :group_key, :notifications_count, :type
+  attributes :group_key, :notifications_count, :type, :most_recent_notification_id
 
   attribute :page_min_id, if: :paginated?
   attribute :page_max_id, if: :paginated?


### PR DESCRIPTION
Add a `most_recent_notification_id` attribute to notification groups that is independent of pagination.