### PR TITLE
Add ffmpeg and ImageMagick versions to admin dashboard

### DIFF
--- a/app/lib/admin/metrics/dimension/software_versions_dimension.rb
+++ b/app/lib/admin/metrics/dimension/software_versions_dimension.rb
@@ -84,6 +84,7 @@ class Admin::Metrics::Dimension::SoftwareVersionsDimension < Admin::Metrics::Dim
 
   def imagemagick_version
     return if Rails.configuration.x.use_vips
+  
     version = `convert -version`.match(/Version: ImageMagick ([\d\.]+)/)[1]
 
     {

--- a/app/lib/admin/metrics/dimension/software_versions_dimension.rb
+++ b/app/lib/admin/metrics/dimension/software_versions_dimension.rb
@@ -10,7 +10,7 @@ class Admin::Metrics::Dimension::SoftwareVersionsDimension < Admin::Metrics::Dim
   protected
 
   def perform_query
-    [mastodon_version, ruby_version, postgresql_version, redis_version, elasticsearch_version, libvips_version].compact
+    [mastodon_version, ruby_version, postgresql_version, redis_version, elasticsearch_version, libvips_version, imagemagick_version, ffmpeg_version].compact
   end
 
   def mastodon_version
@@ -80,6 +80,33 @@ class Admin::Metrics::Dimension::SoftwareVersionsDimension < Admin::Metrics::Dim
       value: Vips.version_string,
       human_value: Vips.version_string,
     }
+  end
+
+  def imagemagick_version
+    return if Rails.configuration.x.use_vips
+    version = `convert -version`.match(/Version: ImageMagick ([\d\.]+)/)[1]
+
+    {
+      key: 'imagemagick',
+      human_key: 'ImageMagick',
+      value: version,
+      human_value: version,
+    }
+  rescue Errno::ENOENT
+    nil
+  end
+
+  def ffmpeg_version
+    version = `ffmpeg -version`.match(/ffmpeg version ([\d\.]+)/)[1]
+
+    {
+      key: 'ffmpeg',
+      human_key: 'FFmpeg',
+      value: version,
+      human_value: version,
+    }
+  rescue Errno::ENOENT
+    nil
   end
 
   def redis_info

--- a/app/lib/admin/metrics/dimension/software_versions_dimension.rb
+++ b/app/lib/admin/metrics/dimension/software_versions_dimension.rb
@@ -84,7 +84,7 @@ class Admin::Metrics::Dimension::SoftwareVersionsDimension < Admin::Metrics::Dim
 
   def imagemagick_version
     return if Rails.configuration.x.use_vips
-  
+
     version = `convert -version`.match(/Version: ImageMagick ([\d\.]+)/)[1]
 
     {


### PR DESCRIPTION
Adds version output for ffmpeg and ImageMagick to the admin dashboard, similar to libvips version output was added in #30090

![CleanShot 2024-06-14 at 09 41 58@2x](https://github.com/mastodon/mastodon/assets/3002053/2aa853e5-c83f-4817-b69a-fff8260911c7)
