### PR TITLE
Restore short Ruby version on admin dashboard

### DIFF
--- a/app/lib/admin/metrics/dimension/software_versions_dimension.rb
+++ b/app/lib/admin/metrics/dimension/software_versions_dimension.rb
@@ -28,8 +28,8 @@ class Admin::Metrics::Dimension::SoftwareVersionsDimension < Admin::Metrics::Dim
     {
       key: 'ruby',
       human_key: 'Ruby',
-      value: "#{RUBY_VERSION}p#{RUBY_PATCHLEVEL}",
-      human_value: RUBY_DESCRIPTION,
+      value: RUBY_DESCRIPTION,
+      human_value: "#{RUBY_VERSION}p#{RUBY_PATCHLEVEL}",
     }
   end
 


### PR DESCRIPTION
#30309 changed the way the Ruby version was displayed in the admin dashboard to show the full description string, which led to inconsistencies in how the version was displayed compared to other components and a severely broken table layout that looked sloppy.

#30422 proposed changes that would fix this but also made other changes and ultimately closed.

This would swap the `human_value` to the shorter version.

![CleanShot 2024-06-14 at 10 24 10@2x](https://github.com/mastodon/mastodon/assets/3002053/1122e374-4ad7-4138-8027-8ae3f9abf3ac)
