### PR TITLE
Fix some unpermitted params methods

### DIFF
--- a/app/controllers/api/v1/admin/account_actions_controller.rb
+++ b/app/controllers/api/v1/admin/account_actions_controller.rb
@@ -26,7 +26,7 @@ class Api::V1::Admin::AccountActionsController < Api::BaseController
   end
 
   def resource_params
-    params.permit(
+    params_slice(
       :type,
       :report_id,
       :warning_preset_id,

--- a/app/controllers/api/v1/admin/accounts_controller.rb
+++ b/app/controllers/api/v1/admin/accounts_controller.rb
@@ -108,7 +108,7 @@ class Api::V1::Admin::AccountsController < Api::BaseController
   end
 
   def filter_params
-    params.permit(*FILTER_PARAMS)
+    params_slice(*FILTER_PARAMS)
   end
 
   def translated_filter_params

--- a/app/controllers/api/v1/admin/domain_blocks_controller.rb
+++ b/app/controllers/api/v1/admin/domain_blocks_controller.rb
@@ -68,7 +68,7 @@ class Api::V1::Admin::DomainBlocksController < Api::BaseController
   end
 
   def domain_block_params
-    params.permit(:severity, :reject_media, :reject_reports, :private_comment, :public_comment, :obfuscate)
+    params_slice(:severity, :reject_media, :reject_reports, :private_comment, :public_comment, :obfuscate)
   end
 
   def next_path

--- a/app/controllers/api/v1/admin/ip_blocks_controller.rb
+++ b/app/controllers/api/v1/admin/ip_blocks_controller.rb
@@ -56,7 +56,7 @@ class Api::V1::Admin::IpBlocksController < Api::BaseController
   end
 
   def resource_params
-    params.permit(:ip, :severity, :comment, :expires_in)
+    params_slice(:ip, :severity, :comment, :expires_in)
   end
 
   def next_path

--- a/app/controllers/api/v1/admin/reports_controller.rb
+++ b/app/controllers/api/v1/admin/reports_controller.rb
@@ -86,7 +86,7 @@ class Api::V1::Admin::ReportsController < Api::BaseController
   end
 
   def filter_params
-    params.permit(*FILTER_PARAMS)
+    params_slice(*FILTER_PARAMS)
   end
 
   def next_path

--- a/app/controllers/api/v1/admin/reports_controller.rb
+++ b/app/controllers/api/v1/admin/reports_controller.rb
@@ -82,7 +82,9 @@ class Api::V1::Admin::ReportsController < Api::BaseController
   end
 
   def report_params
-    params.permit(:category, rule_ids: [])
+    params
+      .slice(:category, :rule_ids)
+      .permit(:category, rule_ids: [])
   end
 
   def filter_params

--- a/app/controllers/api/v1/apps_controller.rb
+++ b/app/controllers/api/v1/apps_controller.rb
@@ -20,10 +20,12 @@ class Api::V1::AppsController < Api::BaseController
   end
 
   def app_scopes_or_default
-    app_params[:scopes] || Doorkeeper.configuration.default_scopes
+    Array(app_params[:scopes]).first || Doorkeeper.configuration.default_scopes
   end
 
   def app_params
-    params.permit(:client_name, :scopes, :website, :redirect_uris, redirect_uris: [])
+    params
+      .slice(:client_name, :scopes, :website, :redirect_uris, :redirect_uris)
+      .permit(:client_name, :scopes, :website, :redirect_uris, redirect_uris: [], scopes: [])
   end
 end

--- a/app/controllers/api/v1/filters_controller.rb
+++ b/app/controllers/api/v1/filters_controller.rb
@@ -52,7 +52,9 @@ class Api::V1::FiltersController < Api::BaseController
   end
 
   def resource_params
-    params.permit(:phrase, :expires_in, :irreversible, :whole_word, context: [])
+    params
+      .slice(:phrase, :expires_in, :irreversible, :whole_word, :context)
+      .permit(:phrase, :expires_in, :irreversible, :whole_word, context: [])
   end
 
   def filter_params

--- a/app/controllers/api/v1/lists/accounts_controller.rb
+++ b/app/controllers/api/v1/lists/accounts_controller.rb
@@ -52,7 +52,7 @@ class Api::V1::Lists::AccountsController < Api::BaseController
   end
 
   def resource_params
-    params.permit(account_ids: [])
+    params.slice(:account_ids).permit(account_ids: [])
   end
 
   def next_path

--- a/app/controllers/api/v1/lists_controller.rb
+++ b/app/controllers/api/v1/lists_controller.rb
@@ -42,6 +42,6 @@ class Api::V1::ListsController < Api::BaseController
   end
 
   def list_params
-    params.permit(:title, :replies_policy, :exclusive)
+    params_slice(:title, :replies_policy, :exclusive)
   end
 end

--- a/app/controllers/api/v1/media_controller.rb
+++ b/app/controllers/api/v1/media_controller.rb
@@ -40,11 +40,11 @@ class Api::V1::MediaController < Api::BaseController
   end
 
   def media_attachment_params
-    params.permit(:file, :thumbnail, :description, :focus)
+    params_slice(:file, :thumbnail, :description, :focus)
   end
 
   def updateable_media_attachment_params
-    params.permit(:thumbnail, :description, :focus)
+    params_slice(:thumbnail, :description, :focus)
   end
 
   def file_type_error

--- a/app/controllers/api/v1/notifications_controller.rb
+++ b/app/controllers/api/v1/notifications_controller.rb
@@ -85,7 +85,9 @@ class Api::V1::NotificationsController < Api::BaseController
   end
 
   def browserable_params
-    params.permit(:account_id, :include_filtered, types: [], exclude_types: [])
+    params
+      .slice(:account_id, :include_filtered, :types, :exclude_types)
+      .permit(:account_id, :include_filtered, types: [], exclude_types: [])
   end
 
   def pagination_params(core_params)

--- a/app/controllers/api/v1/reports_controller.rb
+++ b/app/controllers/api/v1/reports_controller.rb
@@ -23,6 +23,8 @@ class Api::V1::ReportsController < Api::BaseController
   end
 
   def report_params
-    params.permit(:account_id, :comment, :category, :forward, forward_to_domains: [], status_ids: [], rule_ids: [])
+    params
+      .slice(:account_id, :comment, :category, :forward, :forward_to_domains, :status_ids, :rule_ids)
+      .permit(:account_id, :comment, :category, :forward, :rule_ids, forward_to_domains: [], status_ids: [], rule_ids: [])
   end
 end

--- a/app/controllers/api/v1/statuses/reblogs_controller.rb
+++ b/app/controllers/api/v1/statuses/reblogs_controller.rb
@@ -50,6 +50,6 @@ class Api::V1::Statuses::ReblogsController < Api::V1::Statuses::BaseController
   end
 
   def reblog_params
-    params.permit(:visibility)
+    params_slice(:visibility)
   end
 end

--- a/app/controllers/api/v2/admin/accounts_controller.rb
+++ b/app/controllers/api/v2/admin/accounts_controller.rb
@@ -12,6 +12,7 @@ class Api::V2::Admin::AccountsController < Api::V1::Admin::AccountsController
     ip
     invited_by
     role_ids
+    role_ids: []
   ).freeze
 
   PAGINATION_PARAMS = (%i(limit) + FILTER_PARAMS).freeze
@@ -39,7 +40,7 @@ class Api::V2::Admin::AccountsController < Api::V1::Admin::AccountsController
   end
 
   def filter_params
-    params.permit(*FILTER_PARAMS, role_ids: [])
+    params_slice(*FILTER_PARAMS)
   end
 
   def pagination_params(core_params)

--- a/app/controllers/api/v2/filters/keywords_controller.rb
+++ b/app/controllers/api/v2/filters/keywords_controller.rb
@@ -45,6 +45,6 @@ class Api::V2::Filters::KeywordsController < Api::BaseController
   end
 
   def resource_params
-    params.permit(:keyword, :whole_word)
+    params_slice(:keyword, :whole_word)
   end
 end

--- a/app/controllers/api/v2/filters/statuses_controller.rb
+++ b/app/controllers/api/v2/filters/statuses_controller.rb
@@ -39,6 +39,6 @@ class Api::V2::Filters::StatusesController < Api::BaseController
   end
 
   def resource_params
-    params.permit(:status_id)
+    params_slice(:status_id)
   end
 end

--- a/app/controllers/api/v2/filters_controller.rb
+++ b/app/controllers/api/v2/filters_controller.rb
@@ -43,6 +43,8 @@ class Api::V2::FiltersController < Api::BaseController
   end
 
   def resource_params
-    params.permit(:title, :expires_in, :filter_action, context: [], keywords_attributes: [:id, :keyword, :whole_word, :_destroy])
+    params
+      .slice(:title, :expires_in, :filter_action, :context, :keywords_attributes)
+      .permit(:title, :expires_in, :filter_action, context: [], keywords_attributes: [:id, :keyword, :whole_word, :_destroy])
   end
 end

--- a/app/controllers/api/v2/search_controller.rb
+++ b/app/controllers/api/v2/search_controller.rb
@@ -63,6 +63,6 @@ class Api::V2::SearchController < Api::BaseController
   end
 
   def search_params
-    params.permit(:type, :offset, :min_id, :max_id, :account_id, :following)
+    params.permit(:q, :resolve, :type, :offset, :min_id, :max_id, :account_id, :following)
   end
 end

--- a/app/controllers/api/v2_alpha/notifications_controller.rb
+++ b/app/controllers/api/v2_alpha/notifications_controller.rb
@@ -125,11 +125,16 @@ class Api::V2Alpha::NotificationsController < Api::BaseController
   end
 
   def browserable_params
-    params.slice(:include_filtered, :types, :exclude_types, :grouped_types).permit(:include_filtered, types: [], exclude_types: [], grouped_types: [])
+    params
+      .slice(:include_filtered, :types, :exclude_types, :grouped_types)
+      .permit(:include_filtered, types: [], exclude_types: [], grouped_types: [])
   end
 
   def pagination_params(core_params)
-    params.slice(:limit, :include_filtered, :types, :exclude_types, :grouped_types).permit(:limit, :include_filtered, types: [], exclude_types: [], grouped_types: []).merge(core_params)
+    params
+      .slice(:limit, :include_filtered, :types, :exclude_types, :grouped_types)
+      .permit(:limit, :include_filtered, types: [], exclude_types: [], grouped_types: [])
+      .merge(core_params)
   end
 
   def expand_accounts_param

--- a/app/helpers/admin/filter_helper.rb
+++ b/app/helpers/admin/filter_helper.rb
@@ -15,7 +15,7 @@ module Admin::FilterHelper
     AnnouncementFilter::KEYS,
     Admin::ActionLogFilter::KEYS,
     Admin::StatusFilter::KEYS,
-  ].flatten.freeze
+  ].flatten.uniq.freeze
 
   def filter_link_to(text, link_to_params, link_class_params = link_to_params)
     new_url   = filtered_url_for(link_to_params)
@@ -48,6 +48,6 @@ module Admin::FilterHelper
   end
 
   def controller_request_params
-    params.permit(FILTERS)
+    params.slice(FILTERS).permit(FILTERS)
   end
 end


### PR DESCRIPTION
Variation on https://github.com/mastodon/mastodon/pull/30656 and in support of https://github.com/mastodon/mastodon/pull/30377

This attempt is doing as little as possible in the way of pulling out constants, refactors, cleanups, etc -- just re-using our existing `params_slice` or a normal `slice` when that wont work. We can do some of that as followup.

This gets us ALMOST to the point where the setting in linked issue could be enabled. There are still a few failures that dont exactly fit this pattern and I will do as one-offs.

Will leave some inline comments on this one for the few cases here which are sightly different than the rest.