### PR TITLE
Improve match in AP move distribution worker spec

### DIFF
--- a/spec/workers/activitypub/move_distribution_worker_spec.rb
+++ b/spec/workers/activitypub/move_distribution_worker_spec.rb
@@ -16,12 +16,16 @@ describe ActivityPub::MoveDistributionWorker do
     end
 
     it 'delivers to followers and known blockers' do
-      expect_push_bulk_to_match(ActivityPub::DeliveryWorker, [
-                                  [kind_of(String), migration.account.id, 'http://example.com'],
-                                  [kind_of(String), migration.account.id, 'http://example2.com'],
-                                ]) do
+      expect_push_bulk_to_match(ActivityPub::DeliveryWorker, expected_migration_deliveries) do
         subject.perform(migration.id)
       end
+    end
+
+    def expected_migration_deliveries
+      [
+        [match(/"type":"Move"/), migration.account.id, 'http://example.com'],
+        [match(/"type":"Move"/), migration.account.id, 'http://example2.com'],
+      ]
     end
   end
 end


### PR DESCRIPTION
Instead of just checking for `kind_of(String)`, look for something specific to the json being move/migration json.

Future imrovement here -- build custom matcher for more details about what we expect in the payload/json.

Many of the other AP worker specs also have similar checks ... may do those and/or custom matcher in future PR.