### PR TITLE
Fix repeated Delete/Undo assertion in remove status service spec

### DIFF
--- a/spec/services/remove_status_service_spec.rb
+++ b/spec/services/remove_status_service_spec.rb
@@ -48,36 +48,38 @@ RSpec.describe RemoveStatusService, :sidekiq_inline do
 
     it 'sends Delete activity to followers' do
       subject.call(status)
-      expect(a_request(:post, hank.inbox_url).with(
-               body: hash_including({
-                 'type' => 'Delete',
-                 'object' => {
-                   'type' => 'Tombstone',
-                   'id' => ActivityPub::TagManager.instance.uri_for(status),
-                   'atomUri' => OStatus::TagManager.instance.uri_for(status),
-                 },
-               })
-             )).to have_been_made.once
+
+      expect(delete_delivery(hank, status))
+        .to have_been_made.once
     end
 
     it 'sends Delete activity to rebloggers' do
       subject.call(status)
-      expect(a_request(:post, bill.inbox_url).with(
-               body: hash_including({
-                 'type' => 'Delete',
-                 'object' => {
-                   'type' => 'Tombstone',
-                   'id' => ActivityPub::TagManager.instance.uri_for(status),
-                   'atomUri' => OStatus::TagManager.instance.uri_for(status),
-                 },
-               })
-             )).to have_been_made.once
+
+      expect(delete_delivery(bill, status))
+        .to have_been_made.once
     end
 
     it 'remove status from notifications' do
       expect { subject.call(status) }.to change {
         Notification.where(activity_type: 'Favourite', from_account: jeff, account: alice).count
       }.from(1).to(0)
+    end
+
+    def delete_delivery(target, status)
+      a_request(:post, target.inbox_url)
+        .with(body: delete_activity_for(status))
+    end
+
+    def delete_activity_for(status)
+      hash_including(
+        'type' => 'Delete',
+        'object' => {
+          'type' => 'Tombstone',
+          'id' => ActivityPub::TagManager.instance.uri_for(status),
+          'atomUri' => OStatus::TagManager.instance.uri_for(status),
+        }
+      )
     end
   end
 
@@ -87,15 +89,9 @@ RSpec.describe RemoveStatusService, :sidekiq_inline do
 
     it 'sends Undo activity to followers' do
       subject.call(status)
-      expect(a_request(:post, hank.inbox_url).with(
-               body: hash_including({
-                 'type' => 'Undo',
-                 'object' => hash_including({
-                   'type' => 'Announce',
-                   'object' => ActivityPub::TagManager.instance.uri_for(original_status),
-                 }),
-               })
-             )).to have_been_made.once
+
+      expect(undo_delivery(hank, original_status))
+        .to have_been_made.once
     end
   end
 
@@ -105,15 +101,9 @@ RSpec.describe RemoveStatusService, :sidekiq_inline do
 
     it 'sends Undo activity to followers' do
       subject.call(status)
-      expect(a_request(:post, hank.inbox_url).with(
-               body: hash_including({
-                 'type' => 'Undo',
-                 'object' => hash_including({
-                   'type' => 'Announce',
-                   'object' => ActivityPub::TagManager.instance.uri_for(original_status),
-                 }),
-               })
-             )).to have_been_made.once
+
+      expect(undo_delivery(hank, original_status))
+        .to have_been_made.once
     end
   end
 
@@ -123,15 +113,24 @@ RSpec.describe RemoveStatusService, :sidekiq_inline do
 
     it 'sends Undo activity to followers' do
       subject.call(status)
-      expect(a_request(:post, bill.inbox_url).with(
-               body: hash_including({
-                 'type' => 'Undo',
-                 'object' => hash_including({
-                   'type' => 'Announce',
-                   'object' => ActivityPub::TagManager.instance.uri_for(original_status),
-                 }),
-               })
-             )).to have_been_made.once
+
+      expect(undo_delivery(bill, original_status))
+        .to have_been_made.once
     end
+  end
+
+  def undo_delivery(target, status)
+    a_request(:post, target.inbox_url)
+      .with(body: undo_activity_for(status))
+  end
+
+  def undo_activity_for(status)
+    hash_including(
+      'type' => 'Undo',
+      'object' => hash_including(
+        'type' => 'Announce',
+        'object' => ActivityPub::TagManager.instance.uri_for(status)
+      )
+    )
   end
 end


### PR DESCRIPTION
The 5 `Undo` and `Delete` examples here had a lot of repetition around the request being made and the expected payload -- pull those out to helpers.

Part of a followup on https://github.com/mastodon/mastodon/pull/30407, and pulled out of a (large) WIP branch that has a few more config/fix changes not in that initial PR.
