### PR TITLE
Add checks about response body content to admin/dash spec

### DIFF
--- a/spec/controllers/admin/dashboard_controller_spec.rb
+++ b/spec/controllers/admin/dashboard_controller_spec.rb
@@ -6,19 +6,30 @@ describe Admin::DashboardController do
   render_views
 
   describe 'GET #index' do
+    let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Owner')) }
+
     before do
-      allow(Admin::SystemCheck).to receive(:perform).and_return([
-                                                                  Admin::SystemCheck::Message.new(:database_schema_check),
-                                                                  Admin::SystemCheck::Message.new(:rules_check, nil, admin_rules_path),
-                                                                  Admin::SystemCheck::Message.new(:sidekiq_process_check, 'foo, bar'),
-                                                                ])
-      sign_in Fabricate(:user, role: UserRole.find_by(name: 'Admin'))
+      stub_system_checks
+      Fabricate :software_update
+      sign_in(user)
     end
 
-    it 'returns 200' do
+    it 'returns http success and body with system check messages' do
       get :index
 
-      expect(response).to have_http_status(200)
+      expect(response)
+        .to have_http_status(200)
+        .and have_attributes(
+          body: include(I18n.t('admin.system_checks.software_version_patch_check.message_html'))
+        )
+    end
+
+    private
+
+    def stub_system_checks
+      stub_const 'Admin::SystemCheck::ACTIVE_CHECKS', [
+        Admin::SystemCheck::SoftwareVersionCheck,
+      ]
     end
   end
 end


### PR DESCRIPTION
Two changes:

- We were previously only asserting response code - add something about body content
- We were previously stubbing the `perform` method ... which is not "in" the SUT here, but did mean we were not executing that code. Instead, use `stub_const` to limit the number of checks we are running. Makes specs less couple to what the systemcheck<>message interface looks like.