### PR TITLE
Add option to use native Ruby driver for Redis

### DIFF
--- a/app/lib/redis_configuration.rb
+++ b/app/lib/redis_configuration.rb
@@ -43,7 +43,7 @@ class RedisConfiguration
   end
 
   def redis_driver
-    ENV.fetch('REDIS_DRIVER', 'ruby') == 'hiredis' ? :hiredis : :ruby
+    ENV.fetch('REDIS_DRIVER', 'hiredis') == 'ruby' ? :ruby : :hiredis
   end
 
   private

--- a/app/lib/redis_configuration.rb
+++ b/app/lib/redis_configuration.rb
@@ -42,9 +42,18 @@ class RedisConfiguration
     ENV['REDIS_URL']
   end
 
+  def redis_driver
+    ENV['REDIS_DRIVER']
+    when 'hiredis'
+      :hiredis
+    else
+      :ruby
+    end
+  end
+
   private
 
   def raw_connection
-    Redis.new(url: url, driver: :hiredis)
+    Redis.new(url: url, driver: redis_driver)
   end
 end

--- a/app/lib/redis_configuration.rb
+++ b/app/lib/redis_configuration.rb
@@ -43,12 +43,7 @@ class RedisConfiguration
   end
 
   def redis_driver
-    ENV['REDIS_DRIVER']
-    when 'hiredis'
-      :hiredis
-    else
-      :ruby
-    end
+    ENV.fetch('REDIS_DRIVER', 'ruby') == 'hiredis' ? :hiredis : :ruby
   end
 
   private

--- a/lib/mastodon/redis_config.rb
+++ b/lib/mastodon/redis_config.rb
@@ -30,8 +30,10 @@ namespace         = ENV.fetch('REDIS_NAMESPACE', nil)
 cache_namespace   = namespace ? "#{namespace}_cache" : 'cache'
 sidekiq_namespace = namespace
 
+redis_driver = ENV.fetch('REDIS_DRIVER', 'ruby') == 'hiredis' ? :hiredis : :ruby
+
 REDIS_CACHE_PARAMS = {
-  driver: :hiredis,
+  driver: redis_driver,
   url: ENV['CACHE_REDIS_URL'],
   expires_in: 10.minutes,
   namespace: "#{cache_namespace}:7.1",
@@ -43,7 +45,7 @@ REDIS_CACHE_PARAMS = {
 }.freeze
 
 REDIS_SIDEKIQ_PARAMS = {
-  driver: :hiredis,
+  driver: :redis_driver,
   url: ENV['SIDEKIQ_REDIS_URL'],
   namespace: sidekiq_namespace,
 }.freeze

--- a/lib/mastodon/redis_config.rb
+++ b/lib/mastodon/redis_config.rb
@@ -30,7 +30,7 @@ namespace         = ENV.fetch('REDIS_NAMESPACE', nil)
 cache_namespace   = namespace ? "#{namespace}_cache" : 'cache'
 sidekiq_namespace = namespace
 
-redis_driver = ENV.fetch('REDIS_DRIVER', 'ruby') == 'hiredis' ? :hiredis : :ruby
+redis_driver = ENV.fetch('REDIS_DRIVER', 'hiredis') == 'ruby' ? :ruby : :hiredis
 
 REDIS_CACHE_PARAMS = {
   driver: redis_driver,

--- a/lib/mastodon/redis_config.rb
+++ b/lib/mastodon/redis_config.rb
@@ -45,7 +45,7 @@ REDIS_CACHE_PARAMS = {
 }.freeze
 
 REDIS_SIDEKIQ_PARAMS = {
-  driver: :redis_driver,
+  driver: redis_driver,
   url: ENV['SIDEKIQ_REDIS_URL'],
   namespace: sidekiq_namespace,
 }.freeze

--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -140,7 +140,7 @@ namespace :mastodon do
           host: env['REDIS_HOST'],
           port: env['REDIS_PORT'],
           password: env['REDIS_PASSWORD'],
-          # driver: :hiredis,
+          driver: :hiredis,
         }
 
         begin

--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -140,7 +140,7 @@ namespace :mastodon do
           host: env['REDIS_HOST'],
           port: env['REDIS_PORT'],
           password: env['REDIS_PASSWORD'],
-          driver: :hiredis,
+          # driver: :hiredis,
         }
 
         begin


### PR DESCRIPTION
Mastodon currently uses the `hiredis` driver for connections to Redis. Historically this was for performance reasons compared to the native driver. Unfortunately `hiredis` does not support TLS/SSL connections to the Redis server. While this is generally not configured when Redis is running on the same localhost as Mastodon, administrators running Redis on external systems may want to enable this for security. 

Additionally, a number of managed Redis offering from providers like Digital Ocean, _require_ TLS connections, resulting in the need to either use a proxy like Stunnel to communicate between Mastodon and Redis, or modify the code to bypass the `hiredis` driver.

This PR would continue to use `hiredis` by default but allow administrators to set an environmental variable called `REDIS_DRIVER` with the value of `ruby` to direct Mastodon to use the native Ruby driver.

Providing this option would also allow easier testing against production workloads of the native driver, and to allow evaluating changing the default in a future version of Mastodon (or removing `hiredis` altogether) as it also may be a blocker in adoption of other Redis features like clustering.

_I've personally removed `hiredis` in my container builds for vmst.io for over a year and not seen any performance issues that I can link back, but I'm far from m.s scale._