### PR TITLE
Remove `CacheBuster` default options

### DIFF
--- a/app/lib/cache_buster.rb
+++ b/app/lib/cache_buster.rb
@@ -2,13 +2,8 @@
 
 class CacheBuster
   def initialize(options = {})
-    Rails.application.deprecators[:mastodon].warn('Default values for the cache buster secret header name and values will be removed in Mastodon 4.3. Please set them explicitely if you rely on those.') unless options[:http_method] || (options[:secret] && options[:secret_header])
-
-    @secret_header = options[:secret_header] ||
-                     (options[:http_method] ? nil : 'Secret-Header')
-    @secret = options[:secret] ||
-              (options[:http_method] ? nil : 'True')
-
+    @secret_header = options[:secret_header]
+    @secret = options[:secret]
     @http_method = options[:http_method] || 'GET'
   end
 

--- a/spec/lib/cache_buster_spec.rb
+++ b/spec/lib/cache_buster_spec.rb
@@ -28,14 +28,6 @@ describe CacheBuster do
     end
 
     context 'when using default options' do
-      around do |example|
-        # Disables the CacheBuster.new deprecation warning about default arguments.
-        # Remove this `silence` block when default arg support is removed from CacheBuster
-        Rails.application.deprecators[:mastodon].silence do
-          example.run
-        end
-      end
-
       include_examples 'makes_request'
     end
 


### PR DESCRIPTION
Bumped into this while looking at something else. This seems safe to remove - as any further 4.2.x work would happen on stable 4-2 branch?