### PR TITLE
Use `class_names` in admin/account_moderation_notes helper

### DIFF
--- a/app/helpers/admin/account_moderation_notes_helper.rb
+++ b/app/helpers/admin/account_moderation_notes_helper.rb
@@ -4,27 +4,42 @@ module Admin::AccountModerationNotesHelper
   def admin_account_link_to(account, path: nil)
     return if account.nil?
 
-    link_to path || admin_account_path(account.id), class: name_tag_classes(account), title: account.acct do
-      safe_join([
-                  image_tag(account.avatar.url, width: 15, height: 15, alt: '', class: 'avatar'),
-                  content_tag(:span, account.acct, class: 'username'),
-                ], ' ')
-    end
+    link_to(
+      labeled_account_avatar(account),
+      path || admin_account_path(account.id),
+      class: class_names('name-tag', suspended: suspended_account?(account)),
+      title: account.acct
+    )
   end
 
   def admin_account_inline_link_to(account)
     return if account.nil?
 
-    link_to admin_account_path(account.id), class: name_tag_classes(account, true), title: account.acct do
-      content_tag(:span, account.acct, class: 'username')
-    end
+    link_to(
+      account_inline_text(account),
+      admin_account_path(account.id),
+      class: class_names('inline-name-tag', suspended: suspended_account?(account)),
+      title: account.acct
+    )
   end
 
   private
 
-  def name_tag_classes(account, inline = false)
-    classes = [inline ? 'inline-name-tag' : 'name-tag']
-    classes << 'suspended' if account.suspended? || (account.local? && account.user.nil?)
-    classes.join(' ')
+  def labeled_account_avatar(account)
+    safe_join(
+      [
+        image_tag(account.avatar.url, width: 15, height: 15, alt: '', class: 'avatar'),
+        account_inline_text(account),
+      ],
+      ' '
+    )
+  end
+
+  def account_inline_text(account)
+    content_tag(:span, account.acct, class: 'username')
+  end
+
+  def suspended_account?(account)
+    account.suspended? || (account.local? && account.user.nil?)
   end
 end

--- a/spec/helpers/admin/account_moderation_notes_helper_spec.rb
+++ b/spec/helpers/admin/account_moderation_notes_helper_spec.rb
@@ -6,50 +6,50 @@ RSpec.describe Admin::AccountModerationNotesHelper do
   include AccountsHelper
 
   describe '#admin_account_link_to' do
+    subject { helper.admin_account_link_to(account) }
+
     context 'when Account is nil' do
       let(:account) { nil }
 
       it 'returns nil' do
-        expect(helper.admin_account_link_to(account)).to be_nil
+        expect(subject).to be_nil
       end
     end
 
     context 'with account' do
       let(:account) { Fabricate(:account) }
 
-      it 'calls #link_to' do
-        allow(helper).to receive(:link_to)
-
-        helper.admin_account_link_to(account)
-
-        expect(helper).to have_received(:link_to).with(
-          admin_account_path(account.id),
-          class: name_tag_classes(account),
-          title: account.acct
-        )
+      it 'returns a labeled avatar link to the account' do
+        expect(parsed_html.a[:href]).to eq admin_account_path(account.id)
+        expect(parsed_html.a[:class]).to eq 'name-tag'
+        expect(parsed_html.a.span.text).to eq account.acct
       end
     end
   end
 
   describe '#admin_account_inline_link_to' do
+    subject { helper.admin_account_inline_link_to(account) }
+
     context 'when Account is nil' do
       let(:account) { nil }
 
       it 'returns nil' do
-        expect(helper.admin_account_inline_link_to(account)).to be_nil
+        expect(subject).to be_nil
       end
     end
 
     context 'with account' do
       let(:account) { Fabricate(:account) }
 
-      it 'calls #link_to' do
-        result = helper.admin_account_inline_link_to(account)
-
-        expect(result).to match(name_tag_classes(account, true))
-        expect(result).to match(account.acct)
-        expect(result).to match(admin_account_path(account.id))
+      it 'returns an inline link to the account' do
+        expect(parsed_html.a[:href]).to eq admin_account_path(account.id)
+        expect(parsed_html.a[:class]).to eq 'inline-name-tag'
+        expect(parsed_html.a.span.text).to eq account.acct
       end
     end
+  end
+
+  def parsed_html
+    Nokogiri::Slop(subject)
   end
 end


### PR DESCRIPTION
There's a `class_names` helper which takes a list of args, and then removes any blank/nil/etc values, and also treats any hash values as "include the key as a class string if the value is true" - https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-class_names

This started as simply replacing the class name builder, and then sort of grew. Opening altogether since I think it all makes sense:

In the helper...

- Use class_names instead of array loop (calls `suspended_account?`)
- Pull out `account_inline_text` for repeated code
- Also pull out method for the "avatar version" so that the two non-private methods sort of match each other

In the spec...

- Use subject to DRY up repeated helper calls
- Dont stub out link_to, just assert on results
- Use Nokogiri to get more narrow about what we are asserting, instead of just string matching

