### PR TITLE
block scheduled status from frozen users

### DIFF
--- a/app/workers/publish_scheduled_status_worker.rb
+++ b/app/workers/publish_scheduled_status_worker.rb
@@ -9,6 +9,8 @@ class PublishScheduledStatusWorker
     scheduled_status = ScheduledStatus.find(scheduled_status_id)
     scheduled_status.destroy!
 
+    return true if scheduled_status.account.user.disabled?
+
     PostStatusService.new.call(
       scheduled_status.account,
       options_with_objects(scheduled_status.params.with_indifferent_access)

--- a/spec/workers/publish_scheduled_status_worker_spec.rb
+++ b/spec/workers/publish_scheduled_status_worker_spec.rb
@@ -12,12 +12,26 @@ describe PublishScheduledStatusWorker do
       subject.perform(scheduled_status.id)
     end
 
-    it 'creates a status' do
-      expect(scheduled_status.account.statuses.first.text).to eq 'Hello world, future!'
+    context 'when the account is not disabled' do
+      it 'creates a status' do
+        expect(scheduled_status.account.statuses.first.text).to eq 'Hello world, future!'
+      end
+
+      it 'removes the scheduled status' do
+        expect(ScheduledStatus.find_by(id: scheduled_status.id)).to be_nil
+      end
     end
 
-    it 'removes the scheduled status' do
-      expect(ScheduledStatus.find_by(id: scheduled_status.id)).to be_nil
+    context 'when the account is disabled' do
+      let(:scheduled_status) { Fabricate(:scheduled_status, account: Fabricate(:account, user: Fabricate(:user, disabled: true))) }
+
+      it 'does not create a status' do
+        expect(Status.count).to eq 0
+      end
+
+      it 'removes the scheduled status' do
+        expect(ScheduledStatus.find_by(id: scheduled_status.id)).to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
closes #28532

this makes so that frozen accounts scheduled posts are not posted