### PR TITLE
Enable renovate `lockFileMaintenance` setting

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,6 +14,9 @@
   // to `null` after any other rule set it to something.
   dependencyDashboardHeader: 'This issue lists Renovate updates and detected dependencies. Read the [Dependency Dashboard](https://docs.renovatebot.com/key-concepts/dashboard/) docs to learn more. Before approving any upgrade: read the description and comments in the [`renovate.json5` file](https://github.com/mastodon/mastodon/blob/main/.github/renovate.json5).',
   postUpdateOptions: ['yarnDedupeHighest'],
+  lockFileMaintenance: {
+    enabled: true,
+  },
   packageRules: [
     {
       // Require Dependency Dashboard Approval for major version bumps of these node packages


### PR DESCRIPTION
I apparently closed this previous PR? https://github.com/mastodon/mastodon/pull/30012 - and can't reopen it.

We have once again falled a bit behind on "update minor indirect dependencies" -- I think we should enable this for a week or two to see if it works how we think. Prior discussion linked from that original PR.