### PR TITLE
Fix invalid `mask-icon` when a custom instance icon is configured

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -256,6 +256,10 @@ module ApplicationHelper
     instance_presenter.app_icon&.file&.url(size)
   end
 
+  def use_mask_icon?
+    instance_presenter.app_icon.blank?
+  end
+
   private
 
   def storage_host_var

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -19,7 +19,8 @@
     - SiteUpload::APPLE_ICON_SIZES.each do |size|
       %link{ rel: 'apple-touch-icon', sizes: "#{size}x#{size}", href: app_icon_path(size.to_i) || frontend_asset_path("icons/apple-touch-icon-#{size}x#{size}.png") }/
 
-    %link{ rel: 'mask-icon', href: frontend_asset_path('images/logo-symbol-icon.svg'), color: '#6364FF' }/
+    - if use_mask_icon?
+      %link{ rel: 'mask-icon', href: frontend_asset_path('images/logo-symbol-icon.svg'), color: '#6364FF' }/
     %link{ rel: 'manifest', href: manifest_path(format: :json) }/
     = theme_color_tags current_theme
     %meta{ name: 'apple-mobile-web-app-capable', content: 'yes' }/


### PR DESCRIPTION
According to https://evilmartians.com/chronicles/how-to-favicon-in-2021-six-files-that-fit-most-needs we no longer need `mask-icon` for any modern browser.

Rathen than always removing it, I opted to not show it when a custom app icon is used, in case thats still needed for old browsers.

Fixes #30728