### PR TITLE
Remove already configured excludes from .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,14 +4,9 @@ AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
   Exclude:
-    - db/schema.rb
-    - bin/*
-    - node_modules/**/*
     - Vagrantfile
-    - vendor/**/*
     - config/initializers/json_ld*
     - lib/mastodon/migration_helpers.rb
-    - lib/templates/**/*
   ExtraDetails: true
   NewCops: enable
   TargetRubyVersion: 3.1 # Oldest supported ruby version


### PR DESCRIPTION
The default rubocop config already excludes `node_modules` and `vendor`.

The default rubocop-rails config adds `bin/` and `db/*schema.rb`

We dont have any violations in lib/templates at this point.

Continued followup on https://github.com/mastodon/mastodon/pull/30407