### PR TITLE
Remove unused `Extractor#extract_cashtags_with_indices` method

### DIFF
--- a/app/lib/extractor.rb
+++ b/app/lib/extractor.rb
@@ -86,10 +86,6 @@ module Extractor
     possible_entries
   end
 
-  def extract_cashtags_with_indices(_text)
-    []
-  end
-
   def extract_extra_uris_with_indices(text)
     return [] unless text&.index(':')
 

--- a/spec/lib/extractor_spec.rb
+++ b/spec/lib/extractor_spec.rb
@@ -69,10 +69,10 @@ describe Extractor do
     end
   end
 
-  describe 'extract_cashtags_with_indices' do
-    it 'returns []' do
+  describe 'extract_entities_with_indices' do
+    it 'returns empty array when cashtag present' do
       text = '$cashtag'
-      extracted = described_class.extract_cashtags_with_indices(text)
+      extracted = described_class.extract_entities_with_indices(text)
       expect(extracted).to eq []
     end
   end


### PR DESCRIPTION
Method originally added to override the method in the underlying twitter-text gem, as a way to avoid extracting cashtags from text: https://github.com/mastodon/mastodon/pull/3275/files

Subsequently, the top-level method which calls it was also overridden: https://github.com/mastodon/mastodon/pull/17828/files#diff-bbea6c6a6594c95c3de43213d551aff9b9b329001210a584d39dca9966ea0e1aR8-R21

Since that second change, we no longer need the original override.

Left the spec in place so that any future changes to that calling method don't break the behavior.