### PR TITLE
Fix being able to retrieve unusable hashtags through the API

### DIFF
--- a/app/controllers/api/v1/tags_controller.rb
+++ b/app/controllers/api/v1/tags_controller.rb
@@ -29,5 +29,7 @@ class Api::V1::TagsController < Api::BaseController
     return not_found unless Tag::HASHTAG_NAME_RE.match?(params[:id])
 
     @tag = Tag.find_normalized(params[:id]) || Tag.new(name: Tag.normalize(params[:id]), display_name: params[:id])
+
+    not_found unless @tag.usable?
   end
 end

--- a/app/controllers/api/v1/timelines/tag_controller.rb
+++ b/app/controllers/api/v1/timelines/tag_controller.rb
@@ -19,7 +19,7 @@ class Api::V1::Timelines::TagController < Api::V1::Timelines::BaseController
   end
 
   def load_tag
-    @tag = Tag.find_normalized(params[:id])
+    @tag = Tag.usable.find_normalized(params[:id])
   end
 
   def load_statuses

--- a/app/services/tag_search_service.rb
+++ b/app/services/tag_search_service.rb
@@ -41,7 +41,7 @@ class TagSearchService < BaseService
 
     normalized_query = Tag.normalize(@query)
     exact_match = results.find { |tag| tag.name.downcase == normalized_query }
-    exact_match ||= Tag.find_normalized(normalized_query)
+    exact_match ||= Tag.listable.find_normalized(normalized_query)
     unless exact_match.nil?
       results.delete(exact_match)
       results = [exact_match] + results


### PR DESCRIPTION
If a hashtag is marked as unusable, do not return posts with the hashtag through the API, do not return information about the hashtag in the API, do not return the hashtag from hashtag search, and prevent full-text search if a search query contains it.