### PR TITLE
Use rubocop `DisplayCopNames` and `UseCache` defaults (true)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,6 @@
 ---
 AllCops:
   CacheRootDirectory: tmp
-  DisplayCopNames: true
   DisplayStyleGuide: true
   Exclude:
     - Vagrantfile
@@ -10,7 +9,6 @@ AllCops:
   ExtraDetails: true
   NewCops: enable
   TargetRubyVersion: 3.1 # Oldest supported ruby version
-  UseCache: true
 
 inherit_from:
   - .rubocop/layout.yml


### PR DESCRIPTION
Follow-up on https://github.com/mastodon/mastodon/pull/30741 - these values are also true by default.

I think this is the last one for the config file itself -- the rest of the values in here either are changing a default, or it defaults to nil and our override is useful/needed.