### PR TITLE
Unpluralize mistakenly changed privacy template

### DIFF
--- a/config/templates/privacy-policy.md
+++ b/config/templates/privacy-policy.md
@@ -1,10 +1,10 @@
-This privacy policy describes how %{domain}s ("%{domain}s", "we", "us")
-collects, protects and uses the personally identifiable information you may
-provide through the %{domain}s website or its API. The policy also
-describes the choices available to you regarding our use of your personal
-information and how you can access and update this information. This policy
-does not apply to the practices of companies that %{domain}s does not own
-or control, or to individuals that %{domain}s does not employ or manage.
+This privacy policy describes how %{domain} ("%{domain}", "we", "us") collects,
+protects and uses the personally identifiable information you may provide
+through the %{domain} website or its API. The policy also describes the choices
+available to you regarding our use of your personal information and how you can
+access and update this information. This policy does not apply to the practices
+of companies that %{domain} does not own or control, or to individuals that
+%{domain} does not employ or manage.
 
 # What information do we collect?
 


### PR DESCRIPTION
In https://github.com/mastodon/mastodon/pull/28699 I erroneously added a pluralization to the privacy policy template when moving it out of ruby into markdown.

I suspect what happened is that during a lint correction step which was eventually rolled back (see discussion on PR), I converted these to look like `<domain>s` to appease the linter ... but then when we removed the lint changes (since in .md files, we didnt need), I must have missed that portion.

The only change here is removing the trailing `s` - rest of the diff is just re-wrap.