### PR TITLE
Stop calling Webpacker in full-stack tests

### DIFF
--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -285,8 +285,12 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          path: './public'
+          path: './'
           name: ${{ github.sha }}
+
+      - name: Expand archived asset artifacts
+        run: |
+          tar xvzf artifacts.tar.gz
 
       - name: Set up Ruby environment
         uses: ./.github/actions/setup-ruby
@@ -405,7 +409,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          path: './public'
+          path: './'
           name: ${{ github.sha }}
 
       - name: Set up Ruby environment

--- a/spec/support/streaming_server_manager.rb
+++ b/spec/support/streaming_server_manager.rb
@@ -80,9 +80,6 @@ end
 RSpec.configure do |config|
   config.before :suite do
     if streaming_examples_present?
-      # Compile assets
-      Webpacker.compile
-
       # Start the node streaming server
       streaming_server_manager.start(port: STREAMING_PORT)
     end


### PR DESCRIPTION
Re-use the pre-compiled assets instead of building them as part of the end-to-end tests. This should reduce the tests run time and possibly avoid some of the flakiness of such tests.

In addition, assets are required for other test types as well, so having them built for the `system` test tags was inconsistent.