### PR TITLE
Use `module: :users` in routes/admin section

### DIFF
--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -144,8 +144,10 @@ namespace :admin do
   end
 
   resources :users, only: [] do
-    resource :two_factor_authentication, only: [:destroy], controller: 'users/two_factor_authentications'
-    resource :role, only: [:show, :update], controller: 'users/roles'
+    scope module: :users do
+      resource :two_factor_authentication, only: [:destroy]
+      resource :role, only: [:show, :update]
+    end
   end
 
   resources :custom_emojis, only: [:index, :new, :create] do


### PR DESCRIPTION
Removes need for `controller` option for both (they'll be scoped by module added here, they'll get pluralized automatically).

Tested by verifying output of `bin/rails routes -g admin/users | sha256sum` does not change between branches.