### PR TITLE
Improve `createdataLoadingThunk`

### DIFF
--- a/app/javascript/mastodon/store/typed_functions.ts
+++ b/app/javascript/mastodon/store/typed_functions.ts
@@ -89,6 +89,11 @@ type OnData<LoadDataResult, ReturnedData> = (
   },
 ) => ReturnedData | DiscardLoadData | Promise<ReturnedData | DiscardLoadData>;
 
+type LoadData<Args, LoadDataResult> = (
+  args: Args,
+  api: AppThunkApi,
+) => Promise<LoadDataResult>;
+
 type ArgsType = Record<string, unknown> | undefined;
 
 // Overload when there is no `onData` method, the payload is the `onData` result
@@ -101,7 +106,7 @@ export function createDataLoadingThunk<LoadDataResult, Args extends ArgsType>(
 // Overload when the `onData` method returns discardLoadDataInPayload, then the payload is empty
 export function createDataLoadingThunk<LoadDataResult, Args extends ArgsType>(
   name: string,
-  loadData: (args: Args) => Promise<LoadDataResult>,
+  loadData: LoadData<Args, LoadDataResult>,
   onDataOrThunkOptions?:
     | AppThunkOptions
     | OnData<LoadDataResult, DiscardLoadData>,
@@ -111,7 +116,7 @@ export function createDataLoadingThunk<LoadDataResult, Args extends ArgsType>(
 // Overload when the `onData` method returns nothing, then the mayload is the `onData` result
 export function createDataLoadingThunk<LoadDataResult, Args extends ArgsType>(
   name: string,
-  loadData: (args: Args) => Promise<LoadDataResult>,
+  loadData: LoadData<Args, LoadDataResult>,
   onDataOrThunkOptions?: AppThunkOptions | OnData<LoadDataResult, void>,
   thunkOptions?: AppThunkOptions,
 ): ReturnType<typeof createThunk<Args, LoadDataResult>>;
@@ -123,7 +128,7 @@ export function createDataLoadingThunk<
   Returned,
 >(
   name: string,
-  loadData: (args: Args) => Promise<LoadDataResult>,
+  loadData: LoadData<Args, LoadDataResult>,
   onDataOrThunkOptions?: AppThunkOptions | OnData<LoadDataResult, Returned>,
   thunkOptions?: AppThunkOptions,
 ): ReturnType<typeof createThunk<Args, Returned>>;
@@ -159,7 +164,7 @@ export function createDataLoadingThunk<
   Returned,
 >(
   name: string,
-  loadData: (args: Args) => Promise<LoadDataResult>,
+  loadData: LoadData<Args, LoadDataResult>,
   onDataOrThunkOptions?: AppThunkOptions | OnData<LoadDataResult, Returned>,
   maybeThunkOptions?: AppThunkOptions,
 ) {
@@ -177,7 +182,10 @@ export function createDataLoadingThunk<
   return createThunk<Args, Returned>(
     name,
     async (arg, { getState, dispatch }) => {
-      const data = await loadData(arg);
+      const data = await loadData(arg, {
+        dispatch,
+        getState,
+      });
 
       if (!onData) return data as Returned;
 

--- a/app/javascript/mastodon/store/typed_functions.ts
+++ b/app/javascript/mastodon/store/typed_functions.ts
@@ -82,9 +82,10 @@ export function createThunk<Arg = void, Returned = void>(
 const discardLoadDataInPayload = Symbol('discardLoadDataInPayload');
 type DiscardLoadData = typeof discardLoadDataInPayload;
 
-type OnData<LoadDataResult, ReturnedData> = (
+type OnData<ActionArg, LoadDataResult, ReturnedData> = (
   data: LoadDataResult,
   api: AppThunkApi & {
+    actionArg: ActionArg;
     discardLoadData: DiscardLoadData;
   },
 ) => ReturnedData | DiscardLoadData | Promise<ReturnedData | DiscardLoadData>;
@@ -109,7 +110,7 @@ export function createDataLoadingThunk<LoadDataResult, Args extends ArgsType>(
   loadData: LoadData<Args, LoadDataResult>,
   onDataOrThunkOptions?:
     | AppThunkOptions
-    | OnData<LoadDataResult, DiscardLoadData>,
+    | OnData<Args, LoadDataResult, DiscardLoadData>,
   thunkOptions?: AppThunkOptions,
 ): ReturnType<typeof createThunk<Args, void>>;
 
@@ -117,7 +118,7 @@ export function createDataLoadingThunk<LoadDataResult, Args extends ArgsType>(
 export function createDataLoadingThunk<LoadDataResult, Args extends ArgsType>(
   name: string,
   loadData: LoadData<Args, LoadDataResult>,
-  onDataOrThunkOptions?: AppThunkOptions | OnData<LoadDataResult, void>,
+  onDataOrThunkOptions?: AppThunkOptions | OnData<Args, LoadDataResult, void>,
   thunkOptions?: AppThunkOptions,
 ): ReturnType<typeof createThunk<Args, LoadDataResult>>;
 
@@ -129,7 +130,9 @@ export function createDataLoadingThunk<
 >(
   name: string,
   loadData: LoadData<Args, LoadDataResult>,
-  onDataOrThunkOptions?: AppThunkOptions | OnData<LoadDataResult, Returned>,
+  onDataOrThunkOptions?:
+    | AppThunkOptions
+    | OnData<Args, LoadDataResult, Returned>,
   thunkOptions?: AppThunkOptions,
 ): ReturnType<typeof createThunk<Args, Returned>>;
 
@@ -165,10 +168,12 @@ export function createDataLoadingThunk<
 >(
   name: string,
   loadData: LoadData<Args, LoadDataResult>,
-  onDataOrThunkOptions?: AppThunkOptions | OnData<LoadDataResult, Returned>,
+  onDataOrThunkOptions?:
+    | AppThunkOptions
+    | OnData<Args, LoadDataResult, Returned>,
   maybeThunkOptions?: AppThunkOptions,
 ) {
-  let onData: OnData<LoadDataResult, Returned> | undefined;
+  let onData: OnData<Args, LoadDataResult, Returned> | undefined;
   let thunkOptions: AppThunkOptions | undefined;
 
   if (typeof onDataOrThunkOptions === 'function') onData = onDataOrThunkOptions;
@@ -193,6 +198,7 @@ export function createDataLoadingThunk<
         dispatch,
         getState,
         discardLoadData: discardLoadDataInPayload,
+        actionArg: arg,
       });
 
       // if there is no return in `onData`, we return the `onData` result


### PR DESCRIPTION
This is in part extracted from #30440

- `loadData` now has a access to the thunk API, allowing it to use `getState` and `dispatch`. This can be useful if the API request relies on the state for example
- `onData` now has access to the action arguments