### PR TITLE
Improve encoding detection for link cards

### DIFF
--- a/app/lib/link_details_extractor.rb
+++ b/app/lib/link_details_extractor.rb
@@ -269,14 +269,31 @@ class LinkDetailsExtractor
   end
 
   def document
-    @document ||= Nokogiri::HTML(@html, nil, encoding)
+    @document ||= begin
+      encoding = detect_encoding || parse_encoding || header_encoding || 'UTF-8'
+      @document || Nokogiri::HTML(@html, nil, encoding)
+    end
   end
 
-  def encoding
-    @encoding ||= begin
-      guess = detector.detect(@html, @html_charset)
-      guess&.fetch(:confidence, 0).to_i > 60 ? guess&.fetch(:encoding, nil) : nil
-    end
+  def detect_encoding
+    guess = detector.detect(@html, @html_charset)
+    guess&.fetch(:confidence, 0).to_i > 60 ? guess&.fetch(:encoding, nil) : nil
+  end
+
+  def parse_encoding
+    parsed_document = Nokogiri::HTML(@html)
+    source_with_detected_encoding = parsed_document.to_s
+    return unless source_with_detected_encoding.valid_encoding?
+
+    @document = parsed_document
+    source_with_detected_encoding.encoding.name
+  end
+
+  def header_encoding
+    return unless @html_charset
+
+    @html.force_encoding(@html_charset)
+    @html_charset if @html.valid_encoding?
   end
 
   def detector

--- a/spec/fixtures/requests/low_confidence_latin1.txt
+++ b/spec/fixtures/requests/low_confidence_latin1.txt
@@ -1,0 +1,17 @@
+HTTP/1.1 200 OK
+server: nginx
+date: Thu, 13 Jun 2024 14:33:13 GMT
+content-type: text/html; charset=ISO-8859-1
+content-length: 158
+accept-ranges: bytes
+
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Tofu á l'orange</title>
+</head>
+<body>
+  <h2>Tofu á l'orange</h2>
+</body>
+</html>

--- a/spec/services/fetch_link_card_service_spec.rb
+++ b/spec/services/fetch_link_card_service_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe FetchLinkCardService do
     stub_request(:get, 'http://example.com/sjis_with_wrong_charset').to_return(request_fixture('sjis_with_wrong_charset.txt'))
     stub_request(:get, 'http://example.com/koi8-r').to_return(request_fixture('koi8-r.txt'))
     stub_request(:get, 'http://example.com/windows-1251').to_return(request_fixture('windows-1251.txt'))
+    stub_request(:get, 'http://example.com/low_confidence_latin1').to_return(request_fixture('low_confidence_latin1.txt'))
 
     Rails.cache.write('oembed_endpoint:example.com', oembed_cache) if oembed_cache
 
@@ -145,6 +146,14 @@ RSpec.describe FetchLinkCardService do
 
       it 'decodes the HTML' do
         expect(status.preview_card.title).to eq('сэмпл текст')
+      end
+    end
+
+    context 'with a URL of a page in ISO-8859-1 encoding, that charlock_holmes cannot detect' do
+      let(:status) { Fabricate(:status, text: 'Check out http://example.com/low_confidence_latin1') }
+
+      it 'decodes the HTML' do
+        expect(status.preview_card.title).to eq("Tofu á l'orange")
       end
     end
 


### PR DESCRIPTION
Fixes #27230 

This was a nasty case, as encoding issues tend to be. Servers may use different vehicles to communicate the encoding of a HTML document. The `Content-Type` header may include an encoding of which the webserver thinks should be correct. Authors of HTML pages may include a `<meta>` tag to communicate what they think their encoding is. Of course, both may contradict each other and both can be totally wrong.

In the case of the issue, the HTTP header gives the correct encoding (`iso-8859-1`) while the HTML document itself announces itself incorrectly as `utf-8`.

We currently use the `charlock_holmes` gem to try to detect the encoding. It reports a confidence together with the result and we only accept results with a high enough confidence. In this case, `charlock_holmes` _does_ detect the correct encoding, but gives a very low confidence, so we ignore it. (This was to fix another encoding bug and is thus sensible.)

Next, the HTML gets parsed by `nokogiri`. `nokogiri` tries to get the encoding from meta tags and thus will report a wrong one here, leading to an exception later on.

In this PR I propose another, layered strategy:

1. First, we try the established way, using `charlock_holmes`. If we get a high confidence result, we can happily ignore all other, possibly erroneous, information.
2. Next, we let nokogiri parse the document and test if the encoding it detects is actually valid.
3. Next, we see if we have an encoding from the HTTP header and if yes, try if this is valid for the document we have.
4. If all other three steps fail, we just default to `utf-8`.

This fixes the case reported in the issue. It also works for all the existing test cases.

Additionally, I made sure that it does not raise any exceptions for ~30k URLs from actual statuses on my server.

This might still fail in some very weird cases, but I failed to construct such a case :frowning_face:, so I was not able to figure out how to better handle this.

In any case this should improve things imo.

Please also note that I restructured the code here a little bit to avoid having to parse the document twice in case that nokogiri sets a working encoding. I suspect that the parsing can be quite expensive.