### PR TITLE
Change `/api/v2_alpha/notifications` to only return historical data in pages

### DIFF
--- a/app/controllers/api/v2_alpha/notifications_controller.rb
+++ b/app/controllers/api/v2_alpha/notifications_controller.rb
@@ -15,7 +15,7 @@ class Api::V2Alpha::NotificationsController < Api::BaseController
       @relationships = StatusRelationshipsPresenter.new(target_statuses_from_notifications, current_user&.account_id)
     end
 
-    render json: @notifications.map { |notification| NotificationGroup.from_notification(notification) }, each_serializer: REST::NotificationGroupSerializer, relationships: @relationships, group_metadata: @group_metadata
+    render json: @notifications.map { |notification| NotificationGroup.from_notification(notification, max_id: @group_metadata.dig(notification.group_key, :max_id)) }, each_serializer: REST::NotificationGroupSerializer, relationships: @relationships, group_metadata: @group_metadata
   end
 
   def show


### PR DESCRIPTION
Only return data that is at least as recent as the page.

This change was made when working on disconnection gap-filling logic for the web interface, as the existing version of the API is not exactly useful to maintain any meaningful invariant when filling in historical data.