### PR TITLE
Use WebSocketServer instead of WebSocket.Server in streaming

### DIFF
--- a/streaming/index.js
+++ b/streaming/index.js
@@ -12,7 +12,7 @@ import { Redis } from 'ioredis';
 import { JSDOM } from 'jsdom';
 import pg from 'pg';
 import pgConnectionString from 'pg-connection-string';
-import WebSocket from 'ws';
+import { WebSocketServer } from 'ws';
 
 import { AuthenticationError, RequestError, extractStatusAndMessage as extractErrorStatusAndMessage } from './errors.js';
 import { logger, httpLogger, initializeLogLevel, attachWebsocketHttpLogger, createWebsocketLogger } from './logging.js';
@@ -289,7 +289,7 @@ const CHANNEL_NAMES = [
 const startServer = async () => {
   const pgPool = new pg.Pool(pgConfigFromEnv(process.env));
   const server = http.createServer();
-  const wss = new WebSocket.Server({ noServer: true });
+  const wss = new WebSocketServer({ noServer: true });
 
   // Set the X-Request-Id header on WebSockets:
   wss.on("headers", function onHeaders(headers, req) {


### PR DESCRIPTION
It looks like a recent update to the source tree (I couldn't track down the exact commit, possibly a yarn update?) is starting to cause issues with the streaming server, throwing the following error and crashing on start in two completely different environments:
```
file:///home/mastodon/live/streaming/index.js:292
  const wss = new WebSocket.Server({ noServer: true });
              ^
TypeError: WebSocket.Server is not a constructor
    at startServer (file:///home/mastodon/live/streaming/index.js:292:15)
    at file:///home/mastodon/live/streaming/index.js:1620:1
    at ModuleJob.run (node:internal/modules/esm/module_job:218:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:329:24)
    at async loadESM (node:internal/process/esm_loader:28:7)
    at async handleMainPromise (node:internal/modules/run_main:113:12)
Node.js v20.11.0
```
After a quick look, it seems like `WebSocket.Server` is completely undefined, and judging by another look at the ws source it seems that it wasn't meant to be accessible from ES modules anyways. The documentation almost always uses the `WebSocketServer` import in relation to ES modules, so I've gone ahead and changed that import to fix the above issue. This change should not break compatibility or introduce behavioral differences.