### PR TITLE
Ignore intermittent chrome/manifest/icon interaction failure

### DIFF
--- a/spec/support/javascript_errors.rb
+++ b/spec/support/javascript_errors.rb
@@ -2,7 +2,13 @@
 
 RSpec.configure do |config|
   config.after(:each, :js, type: :system) do
-    errors = page.driver.browser.logs.get(:browser)
+    ignored_errors = [
+      /icon from the Manifest/,
+    ]
+    errors = page.driver.browser.logs.get(:browser).reject do |error|
+      ignored_errors.any? { |pattern| pattern.match(error.message) }
+    end
+
     if errors.present?
       aggregate_failures 'javascript errrors' do
         errors.each do |error|

--- a/spec/support/javascript_errors.rb
+++ b/spec/support/javascript_errors.rb
@@ -2,8 +2,9 @@
 
 RSpec.configure do |config|
   config.after(:each, :js, type: :system) do
+    # Classes of intermittent ignorable errors
     ignored_errors = [
-      /icon from the Manifest/,
+      /Error while trying to use the following icon from the Manifest/, # https://github.com/mastodon/mastodon/pull/30793
     ]
     errors = page.driver.browser.logs.get(:browser).reject do |error|
       ignored_errors.any? { |pattern| pattern.match(error.message) }


### PR DESCRIPTION
Example of intermittent failure - https://github.com/mastodon/mastodon/actions/runs/9600925911/job/26478418560

If this file was actually missing, there's a different JS 404 error we would get which would NOT be filtered/ignored by this change (which is what we'd want).
