### PR TITLE
Fix `Rails/ReversibleMigrationMethodDefinition` cop

### DIFF
--- a/db/migrate/20160227230233_add_attachment_avatar_to_accounts.rb
+++ b/db/migrate/20160227230233_add_attachment_avatar_to_accounts.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AddAttachmentAvatarToAccounts < ActiveRecord::Migration[4.2]
-  def self.up
+  def up
     change_table :accounts do |t|
       # The following corresponds to `t.attachment :avatar` in an older version of Paperclip
       t.string :avatar_file_name
@@ -11,7 +11,7 @@ class AddAttachmentAvatarToAccounts < ActiveRecord::Migration[4.2]
     end
   end
 
-  def self.down
+  def down
     remove_attachment :accounts, :avatar
   end
 end

--- a/db/migrate/20160305115639_add_devise_to_users.rb
+++ b/db/migrate/20160305115639_add_devise_to_users.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AddDeviseToUsers < ActiveRecord::Migration[4.2]
-  def self.up
+  def up
     change_table(:users, bulk: true) do |t|
       ## Database authenticatable
       t.string :encrypted_password, null: false, default: ''
@@ -24,7 +24,7 @@ class AddDeviseToUsers < ActiveRecord::Migration[4.2]
     add_index :users, :reset_password_token, unique: true
   end
 
-  def self.down
+  def down
     remove_index :users, :reset_password_token
 
     remove_column :users, :encrypted_password

--- a/db/migrate/20160312193225_add_attachment_header_to_accounts.rb
+++ b/db/migrate/20160312193225_add_attachment_header_to_accounts.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AddAttachmentHeaderToAccounts < ActiveRecord::Migration[4.2]
-  def self.up
+  def up
     change_table :accounts do |t|
       # The following corresponds to `t.attachment :header` in an older version of Paperclip
       t.string :header_file_name
@@ -11,7 +11,7 @@ class AddAttachmentHeaderToAccounts < ActiveRecord::Migration[4.2]
     end
   end
 
-  def self.down
+  def down
     remove_attachment :accounts, :header
   end
 end

--- a/db/migrate/20161006213403_rails_settings_migration.rb
+++ b/db/migrate/20161006213403_rails_settings_migration.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class RailsSettingsMigration < ActiveRecord::Migration[5.0]
-  def self.up
+  def up
     create_table :settings do |t|
       t.string     :var, null: false
       t.text       :value
@@ -11,7 +11,7 @@ class RailsSettingsMigration < ActiveRecord::Migration[5.0]
     add_index :settings, [:target_type, :target_id, :var], unique: true
   end
 
-  def self.down
+  def down
     drop_table :settings
   end
 end

--- a/db/migrate/20170330164118_add_attachment_data_to_imports.rb
+++ b/db/migrate/20170330164118_add_attachment_data_to_imports.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AddAttachmentDataToImports < ActiveRecord::Migration[4.2]
-  def self.up
+  def up
     change_table :imports do |t|
       # The following corresponds to `t.attachment :data` in an older version of Paperclip
       t.string :data_file_name
@@ -11,7 +11,7 @@ class AddAttachmentDataToImports < ActiveRecord::Migration[4.2]
     end
   end
 
-  def self.down
+  def down
     remove_attachment :imports, :data
   end
 end


### PR DESCRIPTION
Early rails versions used the class method style, but instance style has been supported/preferred for a while, including in the migrations being changed here.

_(The cop in question here looks specifically for either a change method, OR both up/down methods - but does not find the class methods)_