### PR TITLE
Fix CMD syntax in streaming Dockerfile

### DIFF
--- a/streaming/Dockerfile
+++ b/streaming/Dockerfile
@@ -103,4 +103,4 @@ USER mastodon
 # Expose default Streaming ports
 EXPOSE 4000
 # Run streaming when started
-CMD [ node ./streaming/index.js ]
+CMD [ "node", "./streaming/index.js" ]


### PR DESCRIPTION
It appears that attempting to start nearly every published `mastodon-streaming` Docker image since the split in a80530d1df39f549b3fa2e4f84669c4851bea443 results in the following error due to a syntax issue:
```
/bin/bash: line 1: [: node: unary operator expected
```
When wrapping the command in `[]` without properly separating and putting the arguments in quotes, the entire thing is treated as if it's a single shell command, including the brackets. This fixes the issue and should allow the streaming images to start properly.