### PR TITLE
Fix `RSpec/LetSetup` cop in api/v1/timelines/tag spec

### DIFF
--- a/spec/requests/api/v1/timelines/tag_spec.rb
+++ b/spec/requests/api/v1/timelines/tag_spec.rb
@@ -8,22 +8,25 @@ RSpec.describe 'Tag' do
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
 
-  shared_examples 'a successful request to the tag timeline' do
-    it 'returns the expected statuses', :aggregate_failures do
-      subject
-
-      expect(response).to have_http_status(200)
-      expect(body_as_json.pluck(:id)).to match_array(expected_statuses.map { |status| status.id.to_s })
-    end
-  end
-
   describe 'GET /api/v1/timelines/tag/:hashtag' do
     subject do
       get "/api/v1/timelines/tag/#{hashtag}", headers: headers, params: params
     end
 
+    shared_examples 'a successful request to the tag timeline' do
+      it 'returns the expected statuses', :aggregate_failures do
+        subject
+
+        expect(response)
+          .to have_http_status(200)
+        expect(body_as_json.pluck(:id))
+          .to match_array(expected_statuses.map { |status| status.id.to_s })
+          .and not_include(private_status.id)
+      end
+    end
+
     let(:account)         { Fabricate(:account) }
-    let!(:private_status) { PostStatusService.new.call(account, visibility: :private, text: '#life could be a dream') } # rubocop:disable RSpec/LetSetup
+    let!(:private_status) { PostStatusService.new.call(account, visibility: :private, text: '#life could be a dream') }
     let!(:life_status)    { PostStatusService.new.call(account, text: 'tell me what is my #life without your #love') }
     let!(:war_status)     { PostStatusService.new.call(user.account, text: '#war, war never changes') }
     let!(:love_status)    { PostStatusService.new.call(account, text: 'what is #love?') }


### PR DESCRIPTION
I believe this is the final inline-disabled `RSpec/*` rule in codebase.

I had to move the shared example down into the describe block to have the correct context/access. The change is just the explicit use of the `private_status` (it should not be in results in any of the examples).