### PR TITLE
Fix Docker buildx warnings about casing and undefined variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,9 @@ ARG NODE_MAJOR_VERSION="20"
 # Debian image to use for base image, change with [--build-arg DEBIAN_VERSION="bookworm"]
 ARG DEBIAN_VERSION="bookworm"
 # Node image to use for base image based on combined variables (ex: 20-bookworm-slim)
-FROM docker.io/node:${NODE_MAJOR_VERSION}-${DEBIAN_VERSION}-slim as node
+FROM docker.io/node:${NODE_MAJOR_VERSION}-${DEBIAN_VERSION}-slim AS node
 # Ruby image to use for base image based on combined variables (ex: 3.3.x-slim-bookworm)
-FROM docker.io/ruby:${RUBY_VERSION}-slim-${DEBIAN_VERSION} as ruby
+FROM docker.io/ruby:${RUBY_VERSION}-slim-${DEBIAN_VERSION} AS ruby
 
 # Resulting version string is vX.X.X-MASTODON_VERSION_PRERELEASE+MASTODON_VERSION_METADATA
 # Example: v4.3.0-nightly.2023.11.09+pr-123456
@@ -117,7 +117,7 @@ RUN \
   ;
 
 # Create temporary build layer from base image
-FROM ruby as build
+FROM ruby AS build
 
 # Copy Node package configuration files into working directory
 COPY package.json yarn.lock .yarnrc.yml /opt/mastodon/
@@ -185,7 +185,7 @@ RUN \
   corepack prepare --activate;
 
 # Create temporary libvips specific build layer from build layer
-FROM build as libvips
+FROM build AS libvips
 
 # libvips version to compile, change with [--build-arg VIPS_VERSION="8.15.2"]
 # renovate: datasource=github-releases depName=libvips packageName=libvips/libvips
@@ -205,7 +205,7 @@ RUN \
   ninja install;
 
 # Create temporary ffmpeg specific build layer from build layer
-FROM build as ffmpeg
+FROM build AS ffmpeg
 
 # ffmpeg version to compile, change with [--build-arg FFMPEG_VERSION="7.0.x"]
 # renovate: datasource=repology depName=ffmpeg packageName=openpkg_current/ffmpeg
@@ -247,7 +247,7 @@ RUN \
   make install;
 
 # Create temporary bundler specific build layer from build layer
-FROM build as bundler
+FROM build AS bundler
 
 ARG TARGETPLATFORM
 
@@ -269,7 +269,7 @@ RUN \
   bundle install -j"$(nproc)";
 
 # Create temporary node specific build layer from build layer
-FROM build as yarn
+FROM build AS yarn
 
 ARG TARGETPLATFORM
 
@@ -286,7 +286,7 @@ RUN \
   yarn workspaces focus --production @mastodon/mastodon;
 
 # Create temporary assets build layer from build layer
-FROM build as precompiler
+FROM build AS precompiler
 
 # Copy Mastodon sources into precompiler layer
 COPY . /opt/mastodon/
@@ -310,7 +310,7 @@ RUN \
   rm -fr /opt/mastodon/tmp;
 
 # Prep final Mastodon Ruby layer
-FROM ruby as mastodon
+FROM ruby AS mastodon
 
 ARG TARGETPLATFORM
 

--- a/streaming/Dockerfile
+++ b/streaming/Dockerfile
@@ -13,7 +13,14 @@ ARG NODE_MAJOR_VERSION="20"
 # Debian image to use for base image, change with [--build-arg DEBIAN_VERSION="bookworm"]
 ARG DEBIAN_VERSION="bookworm"
 # Node image to use for base image based on combined variables (ex: 20-bookworm-slim)
-FROM docker.io/node:${NODE_MAJOR_VERSION}-${DEBIAN_VERSION}-slim as streaming
+FROM docker.io/node:${NODE_MAJOR_VERSION}-${DEBIAN_VERSION}-slim AS streaming
+
+# Resulting version string is vX.X.X-MASTODON_VERSION_PRERELEASE+MASTODON_VERSION_METADATA
+# Example: v4.3.0-nightly.2023.11.09+pr-123456
+# Overwrite existence of 'alpha.X' in version.rb [--build-arg MASTODON_VERSION_PRERELEASE="nightly.2023.11.09"]
+ARG MASTODON_VERSION_PRERELEASE=""
+# Append build metadata or fork information to version.rb [--build-arg MASTODON_VERSION_METADATA="pr-123456"]
+ARG MASTODON_VERSION_METADATA=""
 
 # Timezone used by the Docker container and runtime, change with [--build-arg TZ=Europe/Berlin]
 ARG TZ="Etc/UTC"

--- a/streaming/Dockerfile
+++ b/streaming/Dockerfile
@@ -15,13 +15,6 @@ ARG DEBIAN_VERSION="bookworm"
 # Node image to use for base image based on combined variables (ex: 20-bookworm-slim)
 FROM docker.io/node:${NODE_MAJOR_VERSION}-${DEBIAN_VERSION}-slim AS streaming
 
-# Resulting version string is vX.X.X-MASTODON_VERSION_PRERELEASE+MASTODON_VERSION_METADATA
-# Example: v4.3.0-nightly.2023.11.09+pr-123456
-# Overwrite existence of 'alpha.X' in version.rb [--build-arg MASTODON_VERSION_PRERELEASE="nightly.2023.11.09"]
-ARG MASTODON_VERSION_PRERELEASE=""
-# Append build metadata or fork information to version.rb [--build-arg MASTODON_VERSION_METADATA="pr-123456"]
-ARG MASTODON_VERSION_METADATA=""
-
 # Timezone used by the Docker container and runtime, change with [--build-arg TZ=Europe/Berlin]
 ARG TZ="Etc/UTC"
 # Linux UID (user id) for the mastodon user, change with [--build-arg UID=1234]
@@ -31,9 +24,6 @@ ARG GID="991"
 
 # Apply Mastodon build options based on options above
 ENV \
-# Apply Mastodon version information
-  MASTODON_VERSION_PRERELEASE="${MASTODON_VERSION_PRERELEASE}" \
-  MASTODON_VERSION_METADATA="${MASTODON_VERSION_METADATA}" \
 # Apply timezone
   TZ=${TZ}
 

--- a/streaming/Dockerfile
+++ b/streaming/Dockerfile
@@ -15,6 +15,13 @@ ARG DEBIAN_VERSION="bookworm"
 # Node image to use for base image based on combined variables (ex: 20-bookworm-slim)
 FROM docker.io/node:${NODE_MAJOR_VERSION}-${DEBIAN_VERSION}-slim AS streaming
 
+# Resulting version string is vX.X.X-MASTODON_VERSION_PRERELEASE+MASTODON_VERSION_METADATA
+# Example: v4.3.0-nightly.2023.11.09+pr-123456
+# Overwrite existence of 'alpha.X' in version.rb [--build-arg MASTODON_VERSION_PRERELEASE="nightly.2023.11.09"]
+ARG MASTODON_VERSION_PRERELEASE=""
+# Append build metadata or fork information to version.rb [--build-arg MASTODON_VERSION_METADATA="pr-123456"]
+ARG MASTODON_VERSION_METADATA=""
+
 # Timezone used by the Docker container and runtime, change with [--build-arg TZ=Europe/Berlin]
 ARG TZ="Etc/UTC"
 # Linux UID (user id) for the mastodon user, change with [--build-arg UID=1234]
@@ -24,6 +31,9 @@ ARG GID="991"
 
 # Apply Mastodon build options based on options above
 ENV \
+# Apply Mastodon version information
+  MASTODON_VERSION_PRERELEASE="${MASTODON_VERSION_PRERELEASE}" \
+  MASTODON_VERSION_METADATA="${MASTODON_VERSION_METADATA}" \
 # Apply timezone
   TZ=${TZ}
 


### PR DESCRIPTION
Newer versions of Docker buildx have started throwing warnings related to mismatched casing of FROM and AS in the layers.

Additionally in the streaming file, there were undeclared variables.

```
9 warnings found (use --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 22)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 24)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 120)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 188)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 208)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 250)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 272)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 289)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 313)
 ```

```
3 warnings found (use --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 16)
 - UndefinedVar: Usage of undefined variable '$MASTODON_VERSION_PRERELEASE' (line 26)
 - UndefinedVar: Usage of undefined variable '$MASTODON_VERSION_METADATA' (line 26)
 ```