### PR TITLE
Remove `lockfileMaintenance` setting

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,9 +14,6 @@
   // to `null` after any other rule set it to something.
   dependencyDashboardHeader: 'This issue lists Renovate updates and detected dependencies. Read the [Dependency Dashboard](https://docs.renovatebot.com/key-concepts/dashboard/) docs to learn more. Before approving any upgrade: read the description and comments in the [`renovate.json5` file](https://github.com/mastodon/mastodon/blob/main/.github/renovate.json5).',
   postUpdateOptions: ['yarnDedupeHighest'],
-  lockFileMaintenance: {
-    enabled: true,
-  },
   packageRules: [
     {
       // Require Dependency Dashboard Approval for major version bumps of these node packages


### PR DESCRIPTION
Result of https://github.com/mastodon/mastodon/pull/30765 was that this is both excessive (yarn) and potentially duplicative (other one-off PRs).