### PR TITLE
Unset Rails/UnusedIgnoredColumns

### DIFF
--- a/.rubocop/rails.yml
+++ b/.rubocop/rails.yml
@@ -18,6 +18,3 @@ Rails/RakeEnvironment:
 
 Rails/SkipsModelValidations:
   Enabled: false
-
-Rails/UnusedIgnoredColumns:
-  Enabled: false # Preserve ability to migrate from arbitrary old versions


### PR DESCRIPTION
This was disabled because the rule was flagging the issue mentioned in the comment around the comment, but this rule was removed from the defaults due to the false positives