### PR TITLE
Fix `Rails/BulkChangeTable` cop

### DIFF
--- a/db/migrate/20160227230233_add_attachment_avatar_to_accounts.rb
+++ b/db/migrate/20160227230233_add_attachment_avatar_to_accounts.rb
@@ -2,7 +2,7 @@
 
 class AddAttachmentAvatarToAccounts < ActiveRecord::Migration[4.2]
   def up
-    change_table :accounts do |t|
+    change_table :accounts, bulk: true do |t|
       # The following corresponds to `t.attachment :avatar` in an older version of Paperclip
       t.string :avatar_file_name
       t.string :avatar_content_type

--- a/db/migrate/20160305115639_add_devise_to_users.rb
+++ b/db/migrate/20160305115639_add_devise_to_users.rb
@@ -27,14 +27,16 @@ class AddDeviseToUsers < ActiveRecord::Migration[4.2]
   def down
     remove_index :users, :reset_password_token
 
-    remove_column :users, :encrypted_password
-    remove_column :users, :reset_password_token
-    remove_column :users, :reset_password_sent_at
-    remove_column :users, :remember_created_at
-    remove_column :users, :sign_in_count
-    remove_column :users, :current_sign_in_at
-    remove_column :users, :current_sign_in_ip
-    remove_column :users, :last_sign_in_at
-    remove_column :users, :last_sign_in_ip
+    change_table :users, bulk: true do |t|
+      t.remove :encrypted_password
+      t.remove :reset_password_token
+      t.remove :reset_password_sent_at
+      t.remove :remember_created_at
+      t.remove :sign_in_count
+      t.remove :current_sign_in_at
+      t.remove :current_sign_in_ip
+      t.remove :last_sign_in_at
+      t.remove :last_sign_in_ip
+    end
   end
 end

--- a/db/migrate/20160312193225_add_attachment_header_to_accounts.rb
+++ b/db/migrate/20160312193225_add_attachment_header_to_accounts.rb
@@ -2,7 +2,7 @@
 
 class AddAttachmentHeaderToAccounts < ActiveRecord::Migration[4.2]
   def up
-    change_table :accounts do |t|
+    change_table :accounts, bulk: true do |t|
       # The following corresponds to `t.attachment :header` in an older version of Paperclip
       t.string :header_file_name
       t.string :header_content_type

--- a/db/migrate/20170330164118_add_attachment_data_to_imports.rb
+++ b/db/migrate/20170330164118_add_attachment_data_to_imports.rb
@@ -2,7 +2,7 @@
 
 class AddAttachmentDataToImports < ActiveRecord::Migration[4.2]
   def up
-    change_table :imports do |t|
+    change_table :imports, bulk: true do |t|
       # The following corresponds to `t.attachment :data` in an older version of Paperclip
       t.string :data_file_name
       t.string :data_content_type

--- a/db/migrate/20200627125810_add_thumbnail_columns_to_media_attachments.rb
+++ b/db/migrate/20200627125810_add_thumbnail_columns_to_media_attachments.rb
@@ -3,12 +3,16 @@
 class AddThumbnailColumnsToMediaAttachments < ActiveRecord::Migration[5.2]
   def up
     # The following corresponds to `add_attachment :media_attachments, :thumbnail` in an older version of Paperclip
-    add_column :media_attachments, :thumbnail_file_name, :string
-    add_column :media_attachments, :thumbnail_content_type, :string
-    add_column :media_attachments, :thumbnail_file_size, :integer
-    add_column :media_attachments, :thumbnail_updated_at, :datetime
+    safety_assured do
+      change_table :media_attachments, bulk: true do |t|
+        t.string :thumbnail_file_name
+        t.string :thumbnail_content_type
+        t.integer :thumbnail_file_size
+        t.datetime :thumbnail_updated_at
 
-    add_column :media_attachments, :thumbnail_remote_url, :string
+        t.string :thumbnail_remote_url
+      end
+    end
   end
 
   def down

--- a/db/migrate/20240322125607_add_followers_and_following_counts_to_account_relationship_severance_events.rb
+++ b/db/migrate/20240322125607_add_followers_and_following_counts_to_account_relationship_severance_events.rb
@@ -2,7 +2,11 @@
 
 class AddFollowersAndFollowingCountsToAccountRelationshipSeveranceEvents < ActiveRecord::Migration[7.1]
   def change
-    add_column :account_relationship_severance_events, :followers_count, :integer, default: 0, null: false
-    add_column :account_relationship_severance_events, :following_count, :integer, default: 0, null: false
+    safety_assured do
+      change_table :account_relationship_severance_events, bulk: true do |t|
+        t.integer :followers_count, default: 0, null: false
+        t.integer :following_count, default: 0, null: false
+      end
+    end
   end
 end


### PR DESCRIPTION
This was done before - https://github.com/mastodon/mastodon/pull/26890 - and apparently missed some? I'm guessing this was like a parens/no-parens find/replace mistake. Weirdly, these missed ones are not failing on `main` right now, but are failing on a config refresh branch.

As noted in last PR, these are so old that they will almost definitely only ever run locally or on CI, so low risk despite changing older migrations. A full drop/create/migrate refresh does not change schema.rb after these changes.