### PR TITLE
Fix: Ensure "With Media" is highlighted from Admin Accounts page

### DIFF
--- a/app/views/admin/statuses/index.html.haml
+++ b/app/views/admin/statuses/index.html.haml
@@ -8,7 +8,7 @@
     %strong= t('admin.statuses.media.title')
     %ul
       %li= filter_link_to t('generic.all'), media: nil, id: nil
-      %li= filter_link_to t('admin.statuses.with_media'), media: '1'
+      %li= filter_link_to t('admin.statuses.with_media'), media: true
   .back-link
     - if params[:report_id]
       = link_to admin_report_path(params[:report_id].to_i) do

--- a/spec/controllers/admin/statuses_controller_spec.rb
+++ b/spec/controllers/admin/statuses_controller_spec.rb
@@ -33,7 +33,7 @@ describe Admin::StatusesController do
 
     context 'when filtering by media' do
       before do
-        get :index, params: { account_id: account.id, media: '1' }
+        get :index, params: { account_id: account.id, media: true }
       end
 
       it 'returns http success' do


### PR DESCRIPTION
When going from `/admin/accounts/:id` via the counters for Media Attachments, the generated URL was `/admin/accounts/:id/statuses?media=true` which doesn't highlight the link, because `filter_link_to` in `app/views/admin/statuses/index.html.haml` is `media: '1'`. I've changed to use `media: true`.

Arguably the `filter_link_to` should be smarter with `'1'` vs `true`