### PR TITLE
Unpin peter-evans/create-pull-request to v7

### DIFF
--- a/.github/workflows/crowdin-download.yml
+++ b/.github/workflows/crowdin-download.yml
@@ -52,7 +52,7 @@ jobs:
 
       # Create or update the pull request
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7.0.6
+        uses: peter-evans/create-pull-request@v7
         with:
           commit-message: 'New Crowdin translations'
           title: 'New Crowdin Translations (automated)'


### PR DESCRIPTION
This is the only action that is pinned to a minor release.
Alternate would be to move all the versions to hash pinning and then let renovate take care of them all more frequently