### PR TITLE
Fix `/admin/accounts/:account_id/statuses/:id` for edited posts with media attachments

### DIFF
--- a/app/models/status_edit.rb
+++ b/app/models/status_edit.rb
@@ -42,7 +42,7 @@ class StatusEdit < ApplicationRecord
   scope :ordered, -> { order(id: :asc) }
 
   delegate :local?, :application, :edited?, :edited_at,
-           :discarded?, :visibility, to: :status
+           :discarded?, :visibility, :language, to: :status
 
   def emojis
     return @emojis if defined?(@emojis)

--- a/spec/controllers/admin/statuses_controller_spec.rb
+++ b/spec/controllers/admin/statuses_controller_spec.rb
@@ -44,6 +44,11 @@ describe Admin::StatusesController do
 
   describe 'GET #show' do
     before do
+      status.media_attachments << Fabricate(:media_attachment, type: :image, account: status.account)
+      status.save!
+      status.snapshot!(at_time: status.created_at, rate_limit: false)
+      status.update!(text: 'Hello, this is an edited post')
+      status.snapshot!(rate_limit: false)
       get :show, params: { account_id: account.id, id: status.id }
     end
 


### PR DESCRIPTION
This needs to be backported to 4.2 as well.