### PR TITLE
Additional logging for flaky end-to-end tests

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -14,6 +14,7 @@ Capybara.register_driver :headless_chrome do |app|
   options = Selenium::WebDriver::Chrome::Options.new
   options.add_argument '--headless=new'
   options.add_argument '--window-size=1680,1050'
+  options.add_option('goog:loggingPrefs', { performance: 'ALL' })
 
   Capybara::Selenium::Driver.new(
     app,

--- a/spec/support/javascript_errors.rb
+++ b/spec/support/javascript_errors.rb
@@ -2,7 +2,18 @@
 
 RSpec.configure do |config|
   config.after(:each, :js, type: :system) do
+    performance_logs = page.driver.browser.logs.get(:performance).map(&:message)
     errors = page.driver.browser.logs.get(:browser)
+
+    # Save performance logs to capybara directory for further inspection
+    if performance_logs.present? && errors.present? && errors.any? { |error| error.level == 'SEVERE' }
+      path = File.join(Capybara.save_path, "performance-log-#{SecureRandom.hex(10)}.json")
+
+      warn "WARN: saving performance logs to #{path}"
+
+      File.write(path, "[#{performance_logs.join(',')}]")
+    end
+
     if errors.present?
       aggregate_failures 'javascript errrors' do
         errors.each do |error|


### PR DESCRIPTION
Related to #30793, this is an attempt to get some more information on the flaky tests.

To do so, this PR enables full performance logging, and exports the log to `tmp/capybara/` if any SEVERE javascript error is encountered.