### PR TITLE
Rename deprecated `convert` command

### DIFF
--- a/app/lib/admin/metrics/dimension/software_versions_dimension.rb
+++ b/app/lib/admin/metrics/dimension/software_versions_dimension.rb
@@ -85,7 +85,7 @@ class Admin::Metrics::Dimension::SoftwareVersionsDimension < Admin::Metrics::Dim
   def imagemagick_version
     return if Rails.configuration.x.use_vips
 
-    version = `convert -version`.match(/Version: ImageMagick ([\d\.]+)/)[1]
+    version = `magick -version`.match(/Version: ImageMagick ([\d\.]+)/)[1]
 
     {
       key: 'imagemagick',


### PR DESCRIPTION
Currently output like...

```
WARNING: The convert command is deprecated in IMv7, use "magick"
```

...when running this method.

Seems like the output format did not change, so the version extraction here works the same.