### PR TITLE
Fix test description in hashtag_bar

### DIFF
--- a/app/javascript/mastodon/components/__tests__/hashtag_bar.tsx
+++ b/app/javascript/mastodon/components/__tests__/hashtag_bar.tsx
@@ -165,7 +165,7 @@ describe('computeHashtagBarForStatus', () => {
     );
   });
 
-  it('puts the hashtags in the bar if a status content has hashtags in the only line and has a media', () => {
+  it('does not put the hashtags in the bar if a status content has hashtags in the only line and has a media', () => {
     const status = createStatus(
       '<p>This is my content! <a href="test">#hashtag</a></p>',
       ['hashtag'],


### PR DESCRIPTION
The test description was the opposite of what the test is checking. Take a look at ```expect(hashtagsInBar).toEqual([]);``` below.