### PR TITLE
Fix `Rails/ReversibleMigration` cop for `remove_index`

### DIFF
--- a/db/migrate/20161122163057_remove_unneeded_indexes.rb
+++ b/db/migrate/20161122163057_remove_unneeded_indexes.rb
@@ -2,8 +2,8 @@
 
 class RemoveUnneededIndexes < ActiveRecord::Migration[5.0]
   def change
-    remove_index :notifications, name: 'index_notifications_on_account_id'
-    remove_index :settings, name: 'index_settings_on_target_type_and_target_id'
-    remove_index :statuses_tags, name: 'index_statuses_tags_on_tag_id'
+    remove_index :notifications, :account_id, name: 'index_notifications_on_account_id'
+    remove_index :settings, [:target_type, :target_id], name: 'index_settings_on_target_type_and_target_id'
+    remove_index :statuses_tags, :tag_id, name: 'index_statuses_tags_on_tag_id'
   end
 end

--- a/db/migrate/20171129172043_add_index_on_stream_entries.rb
+++ b/db/migrate/20171129172043_add_index_on_stream_entries.rb
@@ -5,6 +5,6 @@ class AddIndexOnStreamEntries < ActiveRecord::Migration[5.2]
 
   def change
     add_index :stream_entries, [:account_id, :activity_type, :id], algorithm: :concurrently
-    remove_index :stream_entries, name: :index_stream_entries_on_account_id
+    remove_index :stream_entries, :account_id, name: :index_stream_entries_on_account_id
   end
 end

--- a/db/migrate/20171212195226_remove_duplicate_indexes_in_lists.rb
+++ b/db/migrate/20171212195226_remove_duplicate_indexes_in_lists.rb
@@ -2,7 +2,7 @@
 
 class RemoveDuplicateIndexesInLists < ActiveRecord::Migration[5.2]
   def change
-    remove_index :list_accounts, name: 'index_list_accounts_on_account_id'
-    remove_index :list_accounts, name: 'index_list_accounts_on_list_id'
+    remove_index :list_accounts, :account_id, name: 'index_list_accounts_on_account_id'
+    remove_index :list_accounts, :list_id, name: 'index_list_accounts_on_list_id'
   end
 end

--- a/db/migrate/20171226094803_more_faster_index_on_notifications.rb
+++ b/db/migrate/20171226094803_more_faster_index_on_notifications.rb
@@ -5,6 +5,6 @@ class MoreFasterIndexOnNotifications < ActiveRecord::Migration[5.2]
 
   def change
     add_index :notifications, [:account_id, :id], order: { id: :desc }, algorithm: :concurrently
-    remove_index :notifications, name: :index_notifications_on_id_and_account_id_and_activity_type
+    remove_index :notifications, [:id, :account_id, :activity_type], name: :index_notifications_on_id_and_account_id_and_activity_type
   end
 end

--- a/db/migrate/20180106000232_add_index_on_statuses_for_api_v1_accounts_account_id_statuses.rb
+++ b/db/migrate/20180106000232_add_index_on_statuses_for_api_v1_accounts_account_id_statuses.rb
@@ -7,6 +7,6 @@ class AddIndexOnStatusesForApiV1AccountsAccountIdStatuses < ActiveRecord::Migrat
     safety_assured do
       add_index :statuses, [:account_id, :id, :visibility, :updated_at], order: { id: :desc }, algorithm: :concurrently, name: :index_statuses_20180106
     end
-    remove_index :statuses, name: :index_statuses_on_account_id_id
+    remove_index :statuses, [:account_id, :id], name: :index_statuses_on_account_id_id
   end
 end

--- a/db/migrate/20180617162849_remove_unused_indexes.rb
+++ b/db/migrate/20180617162849_remove_unused_indexes.rb
@@ -2,8 +2,8 @@
 
 class RemoveUnusedIndexes < ActiveRecord::Migration[5.2]
   def change
-    remove_index :statuses, name: 'index_statuses_on_conversation_id'
-    remove_index :users, name: 'index_users_on_filtered_languages'
-    remove_index :backups, name: 'index_backups_on_user_id'
+    remove_index :statuses, :conversation_id, name: 'index_statuses_on_conversation_id'
+    remove_index :users, :filtered_languages, name: 'index_users_on_filtered_languages'
+    remove_index :backups, :user_id, name: 'index_backups_on_user_id'
   end
 end


### PR DESCRIPTION
Rleated to https://github.com/mastodon/mastodon/pull/30830

There are still other ReversibleMigration offenses, but these are the remove_index ones lumped together.

Like other old-migration changes, verified that the resulting schema.rb does not change after full migrate.