### PR TITLE
Fix `Rails/ReversibleMigration` cop for `remove`

### DIFF
--- a/db/migrate/20170520145338_change_language_filter_to_opt_out.rb
+++ b/db/migrate/20170520145338_change_language_filter_to_opt_out.rb
@@ -5,7 +5,7 @@ class ChangeLanguageFilterToOptOut < ActiveRecord::Migration[5.0]
     remove_index :users, :allowed_languages
 
     change_table(:users, bulk: true) do |t|
-      t.remove :allowed_languages
+      t.remove :allowed_languages, type: :string, array: true, default: [], null: false
       t.column :filtered_languages, :string, array: true, default: [], null: false
     end
 


### PR DESCRIPTION
Related to https://github.com/mastodon/mastodon/pull/30830

Same deal as previous - does not impact full-migration-generated schema.rb, but fixes reversible cop.