### PR TITLE
Fix `Rails/ReversibleMigration` cop for `drop_table`

### DIFF
--- a/db/migrate/20170205175257_remove_devices.rb
+++ b/db/migrate/20170205175257_remove_devices.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 class RemoveDevices < ActiveRecord::Migration[5.0]
-  def change
+  def up
     drop_table :devices if table_exists?(:devices)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
   end
 end


### PR DESCRIPTION
This is a little different. In the spot this was added - https://github.com/mastodon/mastodon/pull/13820/files#diff-73d85b4be93d1518ebb78b8a2358de82f9e323b3634f9b1332cca4bd4170529dR3 - it looks like the migration which previously added the table was deleted for some reason (maybe to reuse the class name on another migration re-adding the same table name?) ... so instead of making this reversible within `change` by restoring the table def, just make it not reversible (this is consistent with what most other migrations using `drop_table` are doing).