### PR TITLE
Fix `Rails/CreateTableWithTimestamps` cop

### DIFF
--- a/db/migrate/.rubocop.yml
+++ b/db/migrate/.rubocop.yml
@@ -2,3 +2,8 @@ inherit_from: ../../.rubocop.yml
 
 Naming/VariableNumber:
   CheckSymbols: false
+
+# Enabled here as workaround for https://docs.rubocop.org/rubocop/configuration.html#path-relativity
+Rails/CreateTableWithTimestamps:
+  Include:
+    - '*.rb'

--- a/db/migrate/20170508230434_create_conversation_mutes.rb
+++ b/db/migrate/20170508230434_create_conversation_mutes.rb
@@ -2,7 +2,7 @@
 
 class CreateConversationMutes < ActiveRecord::Migration[5.0]
   def change
-    create_table :conversation_mutes do |t|
+    create_table :conversation_mutes do |t| # rubocop:disable Rails/CreateTableWithTimestamps
       t.integer :account_id, null: false
       t.bigint :conversation_id, null: false
     end

--- a/db/migrate/20170823162448_create_status_pins.rb
+++ b/db/migrate/20170823162448_create_status_pins.rb
@@ -2,7 +2,7 @@
 
 class CreateStatusPins < ActiveRecord::Migration[5.1]
   def change
-    create_table :status_pins do |t|
+    create_table :status_pins do |t| # rubocop:disable Rails/CreateTableWithTimestamps
       t.belongs_to :account, foreign_key: { on_delete: :cascade }, null: false
       t.belongs_to :status, foreign_key: { on_delete: :cascade }, null: false
     end

--- a/db/migrate/20171116161857_create_list_accounts.rb
+++ b/db/migrate/20171116161857_create_list_accounts.rb
@@ -2,7 +2,7 @@
 
 class CreateListAccounts < ActiveRecord::Migration[5.2]
   def change
-    create_table :list_accounts do |t|
+    create_table :list_accounts do |t| # rubocop:disable Rails/CreateTableWithTimestamps
       t.belongs_to :list, foreign_key: { on_delete: :cascade }, null: false
       t.belongs_to :account, foreign_key: { on_delete: :cascade }, null: false
       t.belongs_to :follow, foreign_key: { on_delete: :cascade }, null: false

--- a/db/migrate/20180929222014_create_account_conversations.rb
+++ b/db/migrate/20180929222014_create_account_conversations.rb
@@ -2,7 +2,7 @@
 
 class CreateAccountConversations < ActiveRecord::Migration[5.2]
   def change
-    create_table :account_conversations do |t|
+    create_table :account_conversations do |t| # rubocop:disable Rails/CreateTableWithTimestamps
       t.belongs_to :account, foreign_key: { on_delete: :cascade }
       t.belongs_to :conversation, foreign_key: { on_delete: :cascade }
       t.bigint :participant_account_ids, array: true, null: false, default: []

--- a/db/migrate/20181007025445_create_pghero_space_stats.rb
+++ b/db/migrate/20181007025445_create_pghero_space_stats.rb
@@ -2,7 +2,7 @@
 
 class CreatePgheroSpaceStats < ActiveRecord::Migration[5.2]
   def change
-    create_table :pghero_space_stats do |t|
+    create_table :pghero_space_stats do |t| # rubocop:disable Rails/CreateTableWithTimestamps
       t.text :database
       t.text :schema
       t.text :relation

--- a/db/migrate/20190103124649_create_scheduled_statuses.rb
+++ b/db/migrate/20190103124649_create_scheduled_statuses.rb
@@ -2,7 +2,7 @@
 
 class CreateScheduledStatuses < ActiveRecord::Migration[5.2]
   def change
-    create_table :scheduled_statuses do |t|
+    create_table :scheduled_statuses do |t| # rubocop:disable Rails/CreateTableWithTimestamps
       t.belongs_to :account, foreign_key: { on_delete: :cascade }
       t.datetime :scheduled_at, index: true
       t.jsonb :params

--- a/db/migrate/20220824233535_create_status_trends.rb
+++ b/db/migrate/20220824233535_create_status_trends.rb
@@ -2,7 +2,7 @@
 
 class CreateStatusTrends < ActiveRecord::Migration[6.1]
   def change
-    create_table :status_trends do |t|
+    create_table :status_trends do |t| # rubocop:disable Rails/CreateTableWithTimestamps
       t.references :status, null: false, foreign_key: { on_delete: :cascade }, index: { unique: true }
       t.references :account, null: false, foreign_key: { on_delete: :cascade }
       t.float :score, null: false, default: 0

--- a/db/migrate/20221006061337_create_preview_card_trends.rb
+++ b/db/migrate/20221006061337_create_preview_card_trends.rb
@@ -2,7 +2,7 @@
 
 class CreatePreviewCardTrends < ActiveRecord::Migration[6.1]
   def change
-    create_table :preview_card_trends do |t|
+    create_table :preview_card_trends do |t| # rubocop:disable Rails/CreateTableWithTimestamps
       t.references :preview_card, null: false, foreign_key: { on_delete: :cascade }, index: { unique: true }
       t.float :score, null: false, default: 0
       t.integer :rank, null: false, default: 0


### PR DESCRIPTION
Another in support of https://github.com/mastodon/mastodon/pull/30830

In this case we don't want to actually retroactively add timestamp columns to old migrations. If any of these still don't have them and adding them would be useful, we can do that in new migrations. The change here ignores the old issues, but allows us to enable this rule for future migrations.