### PR TITLE
Change light mode to apply CSS variables to the body

### DIFF
--- a/app/javascript/styles/mastodon-light/variables.scss
+++ b/app/javascript/styles/mastodon-light/variables.scss
@@ -56,11 +56,11 @@ $account-background-color: $white !default;
 
 $emojis-requiring-inversion: 'chains';
 
-.theme-mastodon-light {
+body {
   --dropdown-border-color: #d9e1e8;
   --dropdown-background-color: #fff;
   --background-border-color: #d9e1e8;
   --background-color: #fff;
-  --background-color-tint: rgba(255, 255, 255, 90%);
+  --background-color-tint: rgba(255, 255, 255, 80%);
   --background-filter: blur(10px);
 }


### PR DESCRIPTION
When using the automatic theme, there is no `.theme-mastodon-light`. But we know that the light theme CSS file will only be loaded when the light theme is enabled, so we can set the variables to `body` directly.

Also adjusted the alpha on modal background as it was near invisible.