### PR TITLE
Fix `Rails/ThreeStateBooleanColumn` cop

### DIFF
--- a/db/migrate/.rubocop.yml
+++ b/db/migrate/.rubocop.yml
@@ -7,3 +7,8 @@ Naming/VariableNumber:
 Rails/CreateTableWithTimestamps:
   Include:
     - '*.rb'
+
+# Enabled here as workaround for https://docs.rubocop.org/rubocop/configuration.html#path-relativity
+Rails/ThreeStateBooleanColumn:
+  Include:
+    - '*.rb'

--- a/db/migrate/20160325130944_add_admin_to_users.rb
+++ b/db/migrate/20160325130944_add_admin_to_users.rb
@@ -2,6 +2,6 @@
 
 class AddAdminToUsers < ActiveRecord::Migration[4.2]
   def change
-    add_column :users, :admin, :boolean, default: false
+    add_column :users, :admin, :boolean, default: false # rubocop:disable Rails/ThreeStateBooleanColumn
   end
 end

--- a/db/migrate/20161123093447_add_sensitive_to_statuses.rb
+++ b/db/migrate/20161123093447_add_sensitive_to_statuses.rb
@@ -2,6 +2,6 @@
 
 class AddSensitiveToStatuses < ActiveRecord::Migration[5.0]
   def change
-    add_column :statuses, :sensitive, :boolean, default: false
+    add_column :statuses, :sensitive, :boolean, default: false # rubocop:disable Rails/ThreeStateBooleanColumn
   end
 end

--- a/db/migrate/20170123203248_add_reject_media_to_domain_blocks.rb
+++ b/db/migrate/20170123203248_add_reject_media_to_domain_blocks.rb
@@ -2,6 +2,6 @@
 
 class AddRejectMediaToDomainBlocks < ActiveRecord::Migration[5.0]
   def change
-    add_column :domain_blocks, :reject_media, :boolean
+    add_column :domain_blocks, :reject_media, :boolean # rubocop:disable Rails/ThreeStateBooleanColumn
   end
 end

--- a/db/migrate/20170127165745_add_devise_two_factor_to_users.rb
+++ b/db/migrate/20170127165745_add_devise_two_factor_to_users.rb
@@ -7,7 +7,7 @@ class AddDeviseTwoFactorToUsers < ActiveRecord::Migration[5.0]
       t.column :encrypted_otp_secret_iv, :string
       t.column :encrypted_otp_secret_salt, :string
       t.column :consumed_timestep, :integer
-      t.column :otp_required_for_login, :boolean
+      t.column :otp_required_for_login, :boolean # rubocop:disable Rails/ThreeStateBooleanColumn
     end
   end
 end

--- a/db/migrate/20170209184350_add_reply_to_statuses.rb
+++ b/db/migrate/20170209184350_add_reply_to_statuses.rb
@@ -2,7 +2,7 @@
 
 class AddReplyToStatuses < ActiveRecord::Migration[5.0]
   def up
-    add_column :statuses, :reply, :boolean, nil: false, default: false
+    add_column :statuses, :reply, :boolean, default: false # rubocop:disable Rails/ThreeStateBooleanColumn
     Status.unscoped.update_all('reply = (in_reply_to_id IS NOT NULL)')
   end
 

--- a/db/migrate/20170330163835_create_imports.rb
+++ b/db/migrate/20170330163835_create_imports.rb
@@ -5,7 +5,7 @@ class CreateImports < ActiveRecord::Migration[5.0]
     create_table :imports do |t|
       t.integer :account_id, null: false
       t.integer :type, null: false
-      t.boolean :approved
+      t.boolean :approved # rubocop:disable Rails/ThreeStateBooleanColumn
 
       t.timestamps
     end

--- a/db/migrate/20170905165803_add_local_to_statuses.rb
+++ b/db/migrate/20170905165803_add_local_to_statuses.rb
@@ -2,6 +2,6 @@
 
 class AddLocalToStatuses < ActiveRecord::Migration[5.1]
   def change
-    add_column :statuses, :local, :boolean, null: true, default: nil
+    add_column :statuses, :local, :boolean, null: true, default: nil # rubocop:disable Rails/ThreeStateBooleanColumn
   end
 end

--- a/db/migrate/20181203021853_add_discoverable_to_accounts.rb
+++ b/db/migrate/20181203021853_add_discoverable_to_accounts.rb
@@ -2,6 +2,6 @@
 
 class AddDiscoverableToAccounts < ActiveRecord::Migration[5.2]
   def change
-    add_column :accounts, :discoverable, :boolean
+    add_column :accounts, :discoverable, :boolean # rubocop:disable Rails/ThreeStateBooleanColumn
   end
 end

--- a/db/migrate/20190509164208_add_by_moderator_to_tombstone.rb
+++ b/db/migrate/20190509164208_add_by_moderator_to_tombstone.rb
@@ -2,6 +2,6 @@
 
 class AddByModeratorToTombstone < ActiveRecord::Migration[5.2]
   def change
-    add_column :tombstones, :by_moderator, :boolean
+    add_column :tombstones, :by_moderator, :boolean # rubocop:disable Rails/ThreeStateBooleanColumn
   end
 end

--- a/db/migrate/20190805123746_add_capabilities_to_tags.rb
+++ b/db/migrate/20190805123746_add_capabilities_to_tags.rb
@@ -4,9 +4,11 @@ class AddCapabilitiesToTags < ActiveRecord::Migration[5.2]
   def change
     safety_assured do
       change_table(:tags, bulk: true) do |t|
+        # rubocop:disable Rails/ThreeStateBooleanColumn
         t.column :usable, :boolean
         t.column :trendable, :boolean
         t.column :listable, :boolean
+        # rubocop:enable Rails/ThreeStateBooleanColumn
         t.column :reviewed_at, :datetime
         t.column :requested_review_at, :datetime
       end

--- a/db/migrate/20191212163405_add_hide_collections_to_accounts.rb
+++ b/db/migrate/20191212163405_add_hide_collections_to_accounts.rb
@@ -2,6 +2,6 @@
 
 class AddHideCollectionsToAccounts < ActiveRecord::Migration[5.2]
   def change
-    add_column :accounts, :hide_collections, :boolean
+    add_column :accounts, :hide_collections, :boolean # rubocop:disable Rails/ThreeStateBooleanColumn
   end
 end

--- a/db/migrate/20200309150742_add_forwarded_to_reports.rb
+++ b/db/migrate/20200309150742_add_forwarded_to_reports.rb
@@ -2,6 +2,6 @@
 
 class AddForwardedToReports < ActiveRecord::Migration[5.2]
   def change
-    add_column :reports, :forwarded, :boolean
+    add_column :reports, :forwarded, :boolean # rubocop:disable Rails/ThreeStateBooleanColumn
   end
 end

--- a/db/migrate/20210609202149_create_login_activities.rb
+++ b/db/migrate/20210609202149_create_login_activities.rb
@@ -6,7 +6,7 @@ class CreateLoginActivities < ActiveRecord::Migration[6.1]
       t.belongs_to :user, null: false, foreign_key: { on_delete: :cascade }
       t.string :authentication_method
       t.string :provider
-      t.boolean :success
+      t.boolean :success # rubocop:disable Rails/ThreeStateBooleanColumn
       t.string :failure_reason
       t.inet :ip
       t.string :user_agent

--- a/db/migrate/20210621221010_add_skip_sign_in_token_to_users.rb
+++ b/db/migrate/20210621221010_add_skip_sign_in_token_to_users.rb
@@ -2,6 +2,6 @@
 
 class AddSkipSignInTokenToUsers < ActiveRecord::Migration[6.1]
   def change
-    add_column :users, :skip_sign_in_token, :boolean
+    add_column :users, :skip_sign_in_token, :boolean # rubocop:disable Rails/ThreeStateBooleanColumn
   end
 end

--- a/db/migrate/20211031031021_create_preview_card_providers.rb
+++ b/db/migrate/20211031031021_create_preview_card_providers.rb
@@ -5,7 +5,7 @@ class CreatePreviewCardProviders < ActiveRecord::Migration[6.1]
     create_table :preview_card_providers do |t|
       t.string :domain, null: false, default: '', index: { unique: true }
       t.attachment :icon
-      t.boolean :trendable
+      t.boolean :trendable # rubocop:disable Rails/ThreeStateBooleanColumn
       t.datetime :reviewed_at
       t.datetime :requested_review_at
       t.timestamps

--- a/db/migrate/20211115032527_add_trendable_to_preview_cards.rb
+++ b/db/migrate/20211115032527_add_trendable_to_preview_cards.rb
@@ -2,6 +2,6 @@
 
 class AddTrendableToPreviewCards < ActiveRecord::Migration[6.1]
   def change
-    add_column :preview_cards, :trendable, :boolean
+    add_column :preview_cards, :trendable, :boolean # rubocop:disable Rails/ThreeStateBooleanColumn
   end
 end

--- a/db/migrate/20220202200743_add_trendable_to_accounts.rb
+++ b/db/migrate/20220202200743_add_trendable_to_accounts.rb
@@ -4,7 +4,7 @@ class AddTrendableToAccounts < ActiveRecord::Migration[6.1]
   def change
     safety_assured do
       change_table(:accounts, bulk: true) do |t|
-        t.column :trendable, :boolean
+        t.column :trendable, :boolean # rubocop:disable Rails/ThreeStateBooleanColumn
         t.column :reviewed_at, :datetime
         t.column :requested_review_at, :datetime
       end

--- a/db/migrate/20220202200926_add_trendable_to_statuses.rb
+++ b/db/migrate/20220202200926_add_trendable_to_statuses.rb
@@ -2,6 +2,6 @@
 
 class AddTrendableToStatuses < ActiveRecord::Migration[6.1]
   def change
-    add_column :statuses, :trendable, :boolean
+    add_column :statuses, :trendable, :boolean # rubocop:disable Rails/ThreeStateBooleanColumn
   end
 end

--- a/db/migrate/20220303000827_add_ordered_media_attachment_ids_to_status_edits.rb
+++ b/db/migrate/20220303000827_add_ordered_media_attachment_ids_to_status_edits.rb
@@ -7,7 +7,7 @@ class AddOrderedMediaAttachmentIdsToStatusEdits < ActiveRecord::Migration[6.1]
         t.column :ordered_media_attachment_ids, :bigint, array: true
         t.column :media_descriptions, :text, array: true
         t.column :poll_options, :string, array: true
-        t.column :sensitive, :boolean
+        t.column :sensitive, :boolean # rubocop:disable Rails/ThreeStateBooleanColumn
       end
     end
   end

--- a/db/migrate/20240312105620_create_severed_relationships.rb
+++ b/db/migrate/20240312105620_create_severed_relationships.rb
@@ -14,8 +14,10 @@ class CreateSeveredRelationships < ActiveRecord::Migration[7.0]
       t.integer :direction, null: false
 
       # Those attributes are carried over from the `follows` table
+      # rubocop:disable Rails/ThreeStateBooleanColumn
       t.boolean :show_reblogs
       t.boolean :notify
+      # rubocop:enable Rails/ThreeStateBooleanColumn
       t.string :languages, array: true
 
       t.timestamps


### PR DESCRIPTION
Similar to https://github.com/mastodon/mastodon/pull/30836 we don't actually want to fix this behaviour in old migrations - so this is just a collection of disables.

It might make sense to review whether any of these still violate the intention of this cop (allow nulls and/or dont have default value) and were not corrected in future migrations, and handle those.