### PR TITLE
Adjust magick version detection in admin panel 

### DIFF
--- a/app/lib/admin/metrics/dimension/software_versions_dimension.rb
+++ b/app/lib/admin/metrics/dimension/software_versions_dimension.rb
@@ -85,7 +85,8 @@ class Admin::Metrics::Dimension::SoftwareVersionsDimension < Admin::Metrics::Dim
   def imagemagick_version
     return if Rails.configuration.x.use_vips
 
-    version = `convert -version`.match(/Version: ImageMagick ([\d\.]+)/)[1]
+    command = %w[magick convert].find { |cmd| system("which #{cmd} > /dev/null 2>&1") }
+    version = `#{command} -version`.match(/Version: ImageMagick ([\d\.]+)/)[1]
 
     {
       key: 'imagemagick',

--- a/app/lib/admin/metrics/dimension/software_versions_dimension.rb
+++ b/app/lib/admin/metrics/dimension/software_versions_dimension.rb
@@ -86,7 +86,7 @@ class Admin::Metrics::Dimension::SoftwareVersionsDimension < Admin::Metrics::Dim
     return if Rails.configuration.x.use_vips
 
     command = %w(magick convert).find { |cmd| system("which #{cmd} > /dev/null 2>&1") }
-    
+
     version_output = `#{command} -version`
     version_match = version_output.match(/Version: ImageMagick ([\d\.]+|[^\s]+)/)
 

--- a/app/lib/admin/metrics/dimension/software_versions_dimension.rb
+++ b/app/lib/admin/metrics/dimension/software_versions_dimension.rb
@@ -86,7 +86,11 @@ class Admin::Metrics::Dimension::SoftwareVersionsDimension < Admin::Metrics::Dim
     return if Rails.configuration.x.use_vips
 
     command = %w(magick convert).find { |cmd| system("which #{cmd} > /dev/null 2>&1") }
-    version = `#{command} -version`.match(/Version: ImageMagick ([\d\.]+)/)[1]
+    
+    version_output = `#{command} -version`
+    version_match = version_output.match(/Version: ImageMagick ([\d\.]+|[^\s]+)/)
+
+    version = version_match ? version_match[1] : '0.0.0'
 
     {
       key: 'imagemagick',

--- a/app/lib/admin/metrics/dimension/software_versions_dimension.rb
+++ b/app/lib/admin/metrics/dimension/software_versions_dimension.rb
@@ -85,19 +85,7 @@ class Admin::Metrics::Dimension::SoftwareVersionsDimension < Admin::Metrics::Dim
   def imagemagick_version
     return if Rails.configuration.x.use_vips
 
-    imagemagick_binary = nil
-
-    %w(magick convert).each do |cmd|
-      begin
-        Terrapin::CommandLine.new('which', cmd).run
-        imagemagick_binary = cmd
-        break
-      rescue Terrapin::CommandNotFoundError, Terrapin::ExitStatusError
-        next
-      end
-    end
-
-    return nil unless imagemagick_binary
+    imagemagick_binary = Paperclip.options[:is_windows] ? 'magick convert' : 'convert'
 
     version_output = Terrapin::CommandLine.new(imagemagick_binary, '-version').run
     version_match = version_output.match(/Version: ImageMagick (\S+)/)[1].strip
@@ -112,7 +100,7 @@ class Admin::Metrics::Dimension::SoftwareVersionsDimension < Admin::Metrics::Dim
       value: version,
       human_value: version,
     }
-  rescue Terrapin::CommandNotFoundError, Terrapin::ExitStatusError
+  rescue Terrapin::CommandNotFoundError, Terrapin::ExitStatusError, Paperclip::Errors::CommandNotFoundError, Paperclip::Errors::CommandFailedError
     nil
   end
 

--- a/app/lib/admin/metrics/dimension/software_versions_dimension.rb
+++ b/app/lib/admin/metrics/dimension/software_versions_dimension.rb
@@ -85,7 +85,7 @@ class Admin::Metrics::Dimension::SoftwareVersionsDimension < Admin::Metrics::Dim
   def imagemagick_version
     return if Rails.configuration.x.use_vips
 
-    command = %w[magick convert].find { |cmd| system("which #{cmd} > /dev/null 2>&1") }
+    command = %w(magick convert).find { |cmd| system("which #{cmd} > /dev/null 2>&1") }
     version = `#{command} -version`.match(/Version: ImageMagick ([\d\.]+)/)[1]
 
     {


### PR DESCRIPTION
Alternative to #30822

Should cycle through `magick` (IM7) and then `convert` (IM6) and return the first result to perform the version detection.