### PR TITLE
Use `with_options` for shared settings options in routes

### DIFF
--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -40,8 +40,10 @@ namespace :admin do
     end
   end
 
-  get '/settings', to: redirect('/admin/settings/branding')
-  get '/settings/edit', to: redirect('/admin/settings/branding')
+  with_options to: redirect('/admin/settings/branding') do
+    get '/settings'
+    get '/settings/edit'
+  end
 
   namespace :settings do
     resource :branding, only: [:show, :update], controller: 'branding'

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -44,8 +44,10 @@ namespace :api, format: false do
       resources :list, only: :show
     end
 
-    get '/streaming', to: 'streaming#index'
-    get '/streaming/(*any)', to: 'streaming#index'
+    with_options to: 'streaming#index' do
+      get '/streaming'
+      get '/streaming/(*any)'
+    end
 
     resources :custom_emojis, only: [:index]
     resources :suggestions, only: [:index, :destroy]


### PR DESCRIPTION
Noticed while doing something else. Just a tiny DRY up, route output preserved.