### PR TITLE
Rely on built-in ruby private IP detection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -100,8 +100,6 @@ gem 'json-ld'
 gem 'json-ld-preloaded', '~> 3.2'
 gem 'rdf-normalize', '~> 0.5'
 
-gem 'private_address_check', '~> 0.5'
-
 gem 'opentelemetry-api', '~> 1.2.5'
 
 group :opentelemetry do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -595,7 +595,6 @@ GEM
       actionmailer (>= 3)
       net-smtp
       premailer (~> 1.7, >= 1.7.9)
-    private_address_check (0.5.0)
     propshaft (0.9.0)
       actionpack (>= 7.0.0)
       activesupport (>= 7.0.0)
@@ -994,7 +993,6 @@ DEPENDENCIES
   pg (~> 1.5)
   pghero
   premailer-rails
-  private_address_check (~> 0.5)
   propshaft
   public_suffix (~> 6.0)
   puma (~> 6.3)

--- a/app/lib/private_address_check.rb
+++ b/app/lib/private_address_check.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module PrivateAddressCheck
+  module_function
+
+  CIDR_LIST = [
+    IPAddr.new('0.0.0.0/8'),       # Current network (only valid as source address)
+    IPAddr.new('100.64.0.0/10'),   # Shared Address Space
+    IPAddr.new('172.16.0.0/12'),   # Private network
+    IPAddr.new('192.0.0.0/24'),    # IETF Protocol Assignments
+    IPAddr.new('192.0.2.0/24'),    # TEST-NET-1, documentation and examples
+    IPAddr.new('192.88.99.0/24'),  # IPv6 to IPv4 relay (includes 2002::/16)
+    IPAddr.new('198.18.0.0/15'),   # Network benchmark tests
+    IPAddr.new('198.51.100.0/24'), # TEST-NET-2, documentation and examples
+    IPAddr.new('203.0.113.0/24'),  # TEST-NET-3, documentation and examples
+    IPAddr.new('224.0.0.0/4'),     # IP multicast (former Class D network)
+    IPAddr.new('240.0.0.0/4'),     # Reserved (former Class E network)
+    IPAddr.new('255.255.255.255'), # Broadcast
+    IPAddr.new('64:ff9b::/96'),    # IPv4/IPv6 translation (RFC 6052)
+    IPAddr.new('100::/64'),        # Discard prefix (RFC 6666)
+    IPAddr.new('2001::/32'),       # Teredo tunneling
+    IPAddr.new('2001:10::/28'),    # Deprecated (previously ORCHID)
+    IPAddr.new('2001:20::/28'),    # ORCHIDv2
+    IPAddr.new('2001:db8::/32'),   # Addresses used in documentation and example source code
+    IPAddr.new('2002::/16'),       # 6to4
+    IPAddr.new('fc00::/7'),        # Unique local address
+    IPAddr.new('ff00::/8'),        # Multicast
+  ].freeze
+
+  def private_address?(address)
+    address.private? || address.loopback? || address.link_local? || CIDR_LIST.any? { |cidr| cidr.include?(address) }
+  end
+end


### PR DESCRIPTION
Many of the private IP checks done by the gem were added as built-in ruby methods in `IPAddr` class in the late ruby 2.x series, and replace much of the gem functionality. Some other gem features (block wrapper, tcp socket patch) we were not making use of. Background: https://github.com/jtdowney/private_address_check/pull/8

This drops the gem and uses the built-in ruby class checks for private/loopback/link-local, and then preserves the rest of the list from the gem in a final check (I'm not sure we need ALL of these, I've chosen to keep them all for now). I've preserved the same module-method interface from the gem with a local version. If we actually DONT want/need these additional checks, and only care about the local/loopback/private CIDR collection, this could become even simpler (probably lose the module, just move to private class method on `Request`).

There is some existing basic coverage around private addresses (which should still pass here). Curious what sort of logging we have around what scenarios `Mastodon::PrivateNetworkAddressError` is raised from here and what's typically caught/stopped.