### PR TITLE
Catch encoding errors when creating link previews.

### DIFF
--- a/app/services/fetch_link_card_service.rb
+++ b/app/services/fetch_link_card_service.rb
@@ -29,7 +29,7 @@ class FetchLinkCardService < BaseService
     end
 
     attach_card if @card&.persisted?
-  rescue HTTP::Error, OpenSSL::SSL::SSLError, Addressable::URI::InvalidURIError, Mastodon::HostValidationError, Mastodon::LengthValidationError => e
+  rescue HTTP::Error, OpenSSL::SSL::SSLError, Addressable::URI::InvalidURIError, Mastodon::HostValidationError, Mastodon::LengthValidationError, Encoding::UndefinedConversionError => e
     Rails.logger.debug { "Error fetching link #{@original_url}: #{e}" }
     nil
   end

--- a/spec/fixtures/requests/redirect_with_utf8_url.txt
+++ b/spec/fixtures/requests/redirect_with_utf8_url.txt
@@ -1,0 +1,5 @@
+HTTP/1.1 301 Moved Permanently
+server: nginx
+date: Thu, 27 Jun 2024 11:04:53 GMT
+content-type: text/html; charset=UTF-8
+location: http://example.com/ärgerliche-umlaute.html

--- a/spec/services/fetch_link_card_service_spec.rb
+++ b/spec/services/fetch_link_card_service_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe FetchLinkCardService do
     stub_request(:get, 'http://example.com/koi8-r').to_return(request_fixture('koi8-r.txt'))
     stub_request(:get, 'http://example.com/windows-1251').to_return(request_fixture('windows-1251.txt'))
     stub_request(:get, 'http://example.com/low_confidence_latin1').to_return(request_fixture('low_confidence_latin1.txt'))
+    stub_request(:get, 'http://example.com/aergerliche-umlaute').to_return(request_fixture('redirect_with_utf8_url.txt'))
 
     Rails.cache.write('oembed_endpoint:example.com', oembed_cache) if oembed_cache
 
@@ -95,6 +96,14 @@ RSpec.describe FetchLinkCardService do
         expect(a_request(:get, 'http://example.com/redirect-to-404')).to have_been_made.once
         expect(a_request(:get, 'http://example.com/not-found')).to have_been_made.once
       end
+
+      it 'does not create a preview card' do
+        expect(status.preview_card).to be_nil
+      end
+    end
+
+    context 'with a redirect URL with faulty encoding' do
+      let(:status) { Fabricate(:status, text: 'http://example.com/aergerliche-umlaute') }
 
       it 'does not create a preview card' do
         expect(status.preview_card).to be_nil


### PR DESCRIPTION
See #30792 for background.

tl;dr: When a link is posted that leads to a redirect and the redirect includes a non-ASCII URL, the `http` gem will raise an error.

I do not think this is something we can (or should) fix. I am not even sure, if this is worth reporting as a "bug" to the `http` gem. At the end of the day, there are only so many broken encoding problems you can handle :shrug: 

Since we already talked about preventing link previews from being generated in case of encoding errors, I prepared this. It  just adds the error type from the issue mentioned above to the list of errors we already rescue from.

The only downside I can see, is that this might "swallow" other encoding errors which we _could_ fix on our end, so we never learn about them.