### PR TITLE
Add detail about running version on vips error failure

### DIFF
--- a/config/initializers/vips.rb
+++ b/config/initializers/vips.rb
@@ -5,7 +5,11 @@ if Rails.configuration.x.use_vips
 
   require 'vips'
 
-  abort('Incompatible libvips version, please install libvips >= 8.13') unless Vips.at_least_libvips?(8, 13)
+  unless Vips.at_least_libvips?(8, 13)
+    abort <<~ERROR.squish
+      Incompatible libvips version (#{Vips.version_string}), please install libvips >= 8.13
+    ERROR
+  end
 
   Vips.block('VipsForeign', true)
 


### PR DESCRIPTION
Makes it slightly easier to review whatever you think you have installed -vs- what the ruby lib thinks it has access to.

Future idea - move this min version config to a constant/config or read from dockerfile or something?