### PR TITLE
Use vips setting instead of env var in media processing spec

### DIFF
--- a/spec/models/media_attachment_spec.rb
+++ b/spec/models/media_attachment_spec.rb
@@ -210,9 +210,13 @@ RSpec.describe MediaAttachment, :paperclip_processing do
       expect(media.file.meta['original']['duration']).to be_within(0.05).of(0.235102)
       expect(media.thumbnail.present?).to be true
 
-      # NOTE: Our libvips and ImageMagick implementations currently have different results
-      expect(media.file.meta['colors']['background']).to eq(ENV['MASTODON_USE_LIBVIPS'] ? '#268cd9' : '#3088d4')
+      expect(media.file.meta['colors']['background']).to eq(expected_background_color)
       expect(media.file_file_name).to_not eq 'boop.ogg'
+    end
+
+    def expected_background_color
+      # The libvips and ImageMagick implementations produce different results
+      Rails.configuration.x.use_vips ? '#268cd9' : '#3088d4'
     end
   end
 


### PR DESCRIPTION
Uses the already-set config value instead of the env var directly.

As a side effect, makes this specific situation more resilient to values which are present, but not true (ie, setting the env var to "false" or something)