### PR TITLE
Fix browser window color on light theme

### DIFF
--- a/app/lib/themes.rb
+++ b/app/lib/themes.rb
@@ -8,7 +8,7 @@ class Themes
 
   THEME_COLORS = {
     dark: '#191b22',
-    light: '#f3f5f7',
+    light: '#ffffff',
   }.freeze
 
   def initialize


### PR DESCRIPTION
Change browser window color to match white/light theme

Before
<img width="1485" alt="Screenshot 2024-06-27 at 11 32 31 AM" src="https://github.com/mastodon/mastodon/assets/3002053/0af29d50-1e18-4472-8a50-91cda0b2dfcb">

After
<img width="1485" alt="Screenshot 2024-06-27 at 11 32 19 AM" src="https://github.com/mastodon/mastodon/assets/3002053/84300fee-f002-4f79-8049-1c8e375a3b77">