### PR TITLE
Cache asset compilation results on CI

### DIFF
--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -42,11 +42,24 @@ jobs:
         with:
           onlyProduction: 'true'
 
+      - name: Cache assets from compilation
+        uses: actions/cache@v4
+        with:
+          path: |
+            public/assets
+            public/packs
+            public/packs-test
+            tmp/cache/webpacker
+          key: ${{ matrix.mode }}-assets-${{ github.head_ref || github.ref_name }}-${{ github.sha }}
+          restore-keys: |
+            ${{ matrix.mode }}-assets-${{ github.head_ref || github.ref_name }}-${{ github.sha }}
+            ${{ matrix.mode }}-assets-${{ github.head_ref || github.ref_name }}
+            ${{ matrix.mode }}-assets-main
+            ${{ matrix.mode }}-assets
+
       - name: Precompile assets
-        # Previously had set this, but it's not supported
-        # export NODE_OPTIONS=--openssl-legacy-provider
         run: |-
-          ./bin/rails assets:precompile
+          bin/rails assets:precompile
 
       - name: Archive asset artifacts
         run: |


### PR DESCRIPTION
The `test-ruby` CI workflow hsa an initial `build` job which all of the other test jobs rely on, and therefore which must run first before any of them start. Within this job there's a matrix that has separate production and test modes.

The jobs are setting up ruby envs, JS envs, and then running the asset compilation step. The production mode is just a smoke test to make sure it runs successfully. The test mode uses artifact upload to make the compiled assets available to the subsequent jobs, which download them at their start.

However, within the job itself, there's no caching from run-to-run, which means that we have a ~1+ minute compilation step (the rails propshaft compile is part of this, but is pretty fast; the webpack compile step is the bulk of it) which runs every single time even if nothing assets-related has changed. I've heard that upcoming vite changes make this step a lot faster, but it's not clear to me how imminent that is.

This change adds a cache to the compilation step which uses the webpack native cache check (uses a digest of files in the manifest) so that if there's not actually any changes that need a new compile, it will just re-use whatever it already has. This is similar to how the stock local testing webpack config would work. On my fork this drops the step from ~1:20 or so down to < 10s on cache hits.

Configuration based in part on a sample config in the webpack docs and some related configs I saw in the wild. Would love a review here of the cache keys and dirs included to make sure this will work like I think it does.

Possible future work here - remove the artifact upload step and just rely on the cache entirely? This may not matter much - in the grand scheme of things that is a tiny fraction of the time in the run - but it does seem weird to move the same stuff two different ways. I wanted to keep this PR as just the speed-up of the compilation step.