### PR TITLE
Implement HTML ruby tags for east-asian languages

### DIFF
--- a/lib/sanitize_ext/sanitize_config.rb
+++ b/lib/sanitize_ext/sanitize_config.rb
@@ -65,7 +65,7 @@ class Sanitize
     end
 
     MASTODON_STRICT = freeze_config(
-      elements: %w(p br span a del pre blockquote code b strong u i em ul ol li),
+      elements: %w(p br span a del pre blockquote code b strong u i em ul ol li ruby rt rp),
 
       attributes: {
         'a' => %w(href rel class translate),

--- a/spec/lib/html_aware_formatter_spec.rb
+++ b/spec/lib/html_aware_formatter_spec.rb
@@ -41,6 +41,14 @@ RSpec.describe HtmlAwareFormatter do
           expect(subject).to_not include 'status__content__spoiler-link'
         end
       end
+
+      context 'when given text containing ruby tags for east-asian languages' do
+        let(:text) { '<ruby>明日 <rp>(</rp><rt>Ashita</rt><rp>)</rp></ruby>' }
+
+        it 'keeps the ruby tags' do
+          expect(subject).to eq '<ruby>明日 <rp>(</rp><rt>Ashita</rt><rp>)</rp></ruby>'
+        end
+      end
     end
   end
 end

--- a/spec/lib/plain_text_formatter_spec.rb
+++ b/spec/lib/plain_text_formatter_spec.rb
@@ -72,6 +72,14 @@ RSpec.describe PlainTextFormatter do
           expect(subject).to eq 'Lorem ipsum'
         end
       end
+
+      context 'when text contains HTML ruby tags' do
+        let(:status) { Fabricate(:status, account: remote_account, text: '<p>Lorem <ruby>明日 <rp>(</rp><rt>Ashita</rt><rp>)</rp></ruby> ipsum</p>') }
+
+        it 'strips the comment' do
+          expect(subject).to eq 'Lorem 明日 (Ashita) ipsum'
+        end
+      end
     end
   end
 end

--- a/spec/lib/sanitize/config_spec.rb
+++ b/spec/lib/sanitize/config_spec.rb
@@ -18,6 +18,10 @@ describe Sanitize::Config do
       expect(Sanitize.fragment('<p>Check out:</p><ol start="3" reversed=""><li>Foo</li><li>Bar</li></ol>', subject)).to eq '<p>Check out:</p><ol start="3" reversed=""><li>Foo</li><li>Bar</li></ol>'
     end
 
+    it 'keeps ruby tags' do
+      expect(Sanitize.fragment('<p><ruby>明日 <rp>(</rp><rt>Ashita</rt><rp>)</rp></ruby></p>', subject)).to eq '<p><ruby>明日 <rp>(</rp><rt>Ashita</rt><rp>)</rp></ruby></p>'
+    end
+
     it 'removes a without href' do
       expect(Sanitize.fragment('<a>Test</a>', subject)).to eq 'Test'
     end


### PR DESCRIPTION
I'm working on implementing #26592, so far I've just focused on the "getting the tags kept", I haven't yet tested how these display in the web UI.