### PR TITLE
Change instructions to use `bundle exec rails` instead of `rake`

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -1,5 +1,5 @@
 # This is a sample configuration file. You can generate your configuration
-# with the `rake mastodon:setup` interactive setup wizard, but to customize
+# with the `bundle exec rails mastodon:setup` interactive setup wizard, but to customize
 # your setup even further, you'll need to edit it manually. This sample does
 # not demonstrate all available configuration options. Please look at
 # https://docs.joinmastodon.org/admin/config/ for the full documentation.
@@ -40,14 +40,14 @@ ES_PASS=password
 
 # Secrets
 # -------
-# Make sure to use `rake secret` to generate secrets
+# Make sure to use `bundle exec rails secret` to generate secrets
 # -------
 SECRET_KEY_BASE=
 OTP_SECRET=
 
 # Web Push
 # --------
-# Generate with `rake mastodon:webpush:generate_vapid_key`
+# Generate with `bundle exec rails mastodon:webpush:generate_vapid_key`
 # --------
 VAPID_PRIVATE_KEY=
 VAPID_PUBLIC_KEY=

--- a/config/initializers/vapid.rb
+++ b/config/initializers/vapid.rb
@@ -5,7 +5,7 @@ Rails.application.configure do
   # You should only generate this once per instance. If you later decide to change it, all push subscription will
   # be invalidated, requiring the users to access the website again to resubscribe.
   #
-  # Generate with `rake mastodon:webpush:generate_vapid_key` task (`docker-compose run --rm web rake mastodon:webpush:generate_vapid_key` if you use docker compose)
+  # Generate with `bundle exec rails mastodon:webpush:generate_vapid_key` task (`docker-compose run --rm web bundle exec rails mastodon:webpush:generate_vapid_key` if you use docker compose)
   #
   # For more information visit https://rossta.net/blog/using-the-web-push-api-with-vapid.html
 


### PR DESCRIPTION
The `secret` rake task does not exist anymore and has been moved to a rails command, so we need to switch from `rake secrets` to `rails secrets`.

Also remove other uses of `rake` for consistency.