### PR TITLE
Use `scope module: ...` for settings/2FA routes

### DIFF
--- a/config/routes/settings.rb
+++ b/config/routes/settings.rb
@@ -37,13 +37,13 @@ namespace :settings do
     end
   end
 
-  resource :otp_authentication, only: [:show, :create], controller: 'two_factor_authentication/otp_authentication'
+  scope module: :two_factor_authentication do
+    resource :otp_authentication, only: [:show, :create], controller: :otp_authentication
 
-  resources :webauthn_credentials, only: [:index, :new, :create, :destroy],
-                                   path: 'security_keys',
-                                   controller: 'two_factor_authentication/webauthn_credentials' do
-    collection do
-      get :options
+    resources :webauthn_credentials, only: [:index, :new, :create, :destroy], path: 'security_keys' do
+      collection do
+        get :options
+      end
     end
   end
 


### PR DESCRIPTION
Similar to https://github.com/mastodon/mastodon/pull/30767 - just small route generation cleanup.

The output from `bin/rails routes -g settings/two_factor_ | sha256sum` from main is preserved in this PR.