### PR TITLE
Use Warden before_failure callback to log failed login attempts

### DIFF
--- a/app/controllers/auth/sessions_controller.rb
+++ b/app/controllers/auth/sessions_controller.rb
@@ -24,8 +24,8 @@ class Auth::SessionsController < Devise::SessionsController
   end
 
   def create
-    Warden::Manager.before_failure do |env, opts|
-      logger.info("Login failed for user #{env["rack.request.form_hash"]["user"]["email"]} by #{env["HTTP_X_REAL_IP"]}")
+    Warden::Manager.before_failure do |env|
+      logger.info("Login failed for user #{env['rack.request.form_hash']['user']['email']} by #{env['HTTP_X_REAL_IP']}")
     end
 
     super do |resource|

--- a/app/controllers/auth/sessions_controller.rb
+++ b/app/controllers/auth/sessions_controller.rb
@@ -24,6 +24,10 @@ class Auth::SessionsController < Devise::SessionsController
   end
 
   def create
+    Warden::Manager.before_failure do |env, opts|
+      logger.info("Login failed for user #{env["rack.request.form_hash"]["user"]["email"]} by #{env["HTTP_X_REAL_IP"]}")
+    end
+
     super do |resource|
       # We only need to call this if this hasn't already been
       # called from one of the two-factor or sign-in token


### PR DESCRIPTION
Resolves https://github.com/mastodon/mastodon/issues/30756

---

Use `Warden::Manager.before_failure` to log failed logins, currently it will log the IP for the failed login and the email with info intensity

I'm not sure if this is the preferred way to do this though, I'm not a Ruby developer and mostly just a SysOp. Submitting this PR because it does work in my testing, but it might need some edits for it to be "release ready"? 

Let me know!