### PR TITLE
Improve handling of encoding problems when creating link previews

### DIFF
--- a/app/lib/link_details_extractor.rb
+++ b/app/lib/link_details_extractor.rb
@@ -156,11 +156,11 @@ class LinkDetailsExtractor
   end
 
   def title
-    html_entities.decode(structured_data&.headline || opengraph_tag('og:title') || document.xpath('//title').map(&:content).first).strip
+    html_entities_decode(structured_data&.headline || opengraph_tag('og:title') || document.xpath('//title').map(&:content).first).strip
   end
 
   def description
-    html_entities.decode(structured_data&.description || opengraph_tag('og:description') || meta_tag('description'))
+    html_entities_decode(structured_data&.description || opengraph_tag('og:description') || meta_tag('description'))
   end
 
   def published_at
@@ -180,7 +180,7 @@ class LinkDetailsExtractor
   end
 
   def provider_name
-    html_entities.decode(structured_data&.publisher_name || opengraph_tag('og:site_name'))
+    html_entities_decode(structured_data&.publisher_name || opengraph_tag('og:site_name'))
   end
 
   def provider_url
@@ -188,7 +188,7 @@ class LinkDetailsExtractor
   end
 
   def author_name
-    html_entities.decode(structured_data&.author_name || opengraph_tag('og:author') || opengraph_tag('og:author:username'))
+    html_entities_decode(structured_data&.author_name || opengraph_tag('og:author') || opengraph_tag('og:author:username'))
   end
 
   def author_url
@@ -257,7 +257,7 @@ class LinkDetailsExtractor
 
       next if json_ld.blank?
 
-      structured_data = StructuredData.new(html_entities.decode(json_ld))
+      structured_data = StructuredData.new(html_entities_decode(json_ld))
 
       next unless structured_data.valid?
 
@@ -273,10 +273,11 @@ class LinkDetailsExtractor
   end
 
   def detect_encoding_and_parse_document
-    [detect_encoding, nil, @html_charset, 'UTF-8'].uniq.each do |encoding|
+    [detect_encoding, nil, @html_charset].uniq.each do |encoding|
       document = Nokogiri::HTML(@html, nil, encoding)
       return document if document.to_s.valid_encoding?
     end
+    Nokogiri::HTML(@html, nil, 'UTF-8')
   end
 
   def detect_encoding
@@ -288,6 +289,15 @@ class LinkDetailsExtractor
     @detector ||= CharlockHolmes::EncodingDetector.new.tap do |detector|
       detector.strip_tags = true
     end
+  end
+
+  def html_entities_decode(string)
+    return if string.nil?
+
+    unicode_string = string.encode('UTF-8')
+    raise EncodingError, 'cannot convert string to valid UTF-8' unless unicode_string.valid_encoding?
+
+    html_entities.decode(unicode_string)
   end
 
   def html_entities

--- a/app/services/fetch_link_card_service.rb
+++ b/app/services/fetch_link_card_service.rb
@@ -32,7 +32,7 @@ class FetchLinkCardService < BaseService
     end
 
     attach_card if @card&.persisted?
-  rescue HTTP::Error, OpenSSL::SSL::SSLError, Addressable::URI::InvalidURIError, Mastodon::HostValidationError, Mastodon::LengthValidationError, Encoding::UndefinedConversionError => e
+  rescue HTTP::Error, OpenSSL::SSL::SSLError, Addressable::URI::InvalidURIError, Mastodon::HostValidationError, Mastodon::LengthValidationError, EncodingError => e
     Rails.logger.debug { "Error fetching link #{@original_url}: #{e}" }
     nil
   end

--- a/spec/fixtures/requests/latin1_posing_as_utf8_broken.txt
+++ b/spec/fixtures/requests/latin1_posing_as_utf8_broken.txt
@@ -1,0 +1,17 @@
+HTTP/1.1 200 OK
+server: nginx
+date: Thu, 13 Jun 2024 14:33:13 GMT
+content-type: text/html; charset=utf-8
+content-length: 158
+accept-ranges: bytes
+
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Tofu á l'orange</title>
+</head>
+<body>
+  <h2>Tofu á l'orange</h2>
+</body>
+</html>

--- a/spec/fixtures/requests/latin1_posing_as_utf8_recoverable.txt
+++ b/spec/fixtures/requests/latin1_posing_as_utf8_recoverable.txt
@@ -1,0 +1,17 @@
+HTTP/1.1 200 OK
+server: nginx
+date: Thu, 13 Jun 2024 14:33:13 GMT
+content-type: text/html; charset=utf-8
+content-length: 158
+accept-ranges: bytes
+
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Tofu with orange sauce</title>
+</head>
+<body>
+  <h2>Tofu á l'orange</h2>
+</body>
+</html>


### PR DESCRIPTION
Fixes #30841

In #30780 we improved handling of websites with broken encoding for _some_ cases, but introduced a new way for the process to fail. I overlooked that our solution did not provide a fallback, when none of the attempts at detecting an encoding is successful. Sorry :frowning_face:

#30841 includes examples of websites that declare to be UTF-8 encoded, but do in fact include non-UTF-8 characters. Encoding detection for these failed and the newly introduced `#detect_encoding_and_parse_document` did not return a document as expected.

One could argue that we should maybe raise in this case or otherwise skip the generation of the preview, but that might be too harsh. We use the _whole_ document when we try to detect the encoding. This makes sense because detection rates could improve when there is more input to analyze. But once detection has finished, we only need very few parts of the document. Those parts might be harmless and not include any invalid characters.

So I think a fallback makes sense. I changed 'UTF-8' to be the fallback in case the other attempts fail. This fixed the problem for the URLs reported in the issue, but still failed for a very simple test case I created.

In case the invalid characters _are_ in a tag we need, I still got `ArgumentError`s similar to the ones we fixed with #30780.

The problem is, that we run extracted strings through the `htmlentities` gem. `htmlentities` can only handle UTF-8. This is made clear in their docs and in their code they try to transcode the supplied strings. They do not however validate that there are no invalid characters. This will only blow up farther down when they call methods like `gsub` that sadly raise that rather generic `ArgumentError`.

So my idea is to wrap calls to `htmlentities`, make sure that they can succeed or raise the more appropriate `EncodingError` if they cannot. This works for all cases reported in #30841 _and_ my little test case.

It does come with a small performance hit (about 3% in a quick and quite unscientific benchmark), but I think that should be OK.