### PR TITLE
Fix right-to-left text in preview cards

### DIFF
--- a/app/javascript/mastodon/features/status/components/card.jsx
+++ b/app/javascript/mastodon/features/status/components/card.jsx
@@ -141,7 +141,7 @@ export default class Card extends PureComponent {
     const showAuthor  = !!card.getIn(['authors', 0, 'accountId']);
 
     const description = (
-      <div className='status-card__content'>
+      <div className='status-card__content' dir='auto'>
         <span className='status-card__host'>
           <span lang={language}>{provider}</span>
           {card.get('published_at') && <> · <RelativeTimestamp timestamp={card.get('published_at')} /></>}


### PR DESCRIPTION
Fixes #30922

I am not completely sure this is the right solution, but this is consistent with our handling of paragraphs in statuses themselves.