### PR TITLE
Limit CI push triggers to `main` and `stable-*` branches

### DIFF
--- a/.github/workflows/bundler-audit.yml
+++ b/.github/workflows/bundler-audit.yml
@@ -2,7 +2,9 @@ name: Bundler Audit
 on:
   merge_group:
   push:
-    branches: [main]
+    branches:
+      - 'main'
+      - 'stable-*'
     paths:
       - 'Gemfile*'
       - '.ruby-version'

--- a/.github/workflows/bundler-audit.yml
+++ b/.github/workflows/bundler-audit.yml
@@ -1,8 +1,7 @@
 name: Bundler Audit
 on:
   push:
-    branches-ignore:
-      - 'dependabot/**'
+    branches: [main]
     paths:
       - 'Gemfile*'
       - '.ruby-version'

--- a/.github/workflows/bundler-audit.yml
+++ b/.github/workflows/bundler-audit.yml
@@ -1,5 +1,6 @@
 name: Bundler Audit
 on:
+  merge_group:
   push:
     branches: [main]
     paths:

--- a/.github/workflows/check-i18n.yml
+++ b/.github/workflows/check-i18n.yml
@@ -2,9 +2,13 @@ name: Check i18n
 
 on:
   push:
-    branches: [main]
+    branches:
+      - 'main'
+      - 'stable-*'
   pull_request:
-    branches: [main]
+    branches:
+      - 'main'
+      - 'stable-*'
 
 env:
   RAILS_ENV: test

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,9 +3,13 @@ name: 'CodeQL'
 on:
   merge_group:
   push:
-    branches: [main]
+    branches:
+      - 'main'
+      - 'stable-*'
   pull_request:
-    branches: [main]
+    branches:
+      - 'main'
+      - 'stable-*'
   schedule:
     - cron: '22 6 * * 1'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,7 @@
 name: 'CodeQL'
 
 on:
+  merge_group:
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,10 +2,9 @@ name: 'CodeQL'
 
 on:
   push:
-    branches: ['main']
+    branches: [main]
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: ['main']
+    branches: [main]
   schedule:
     - cron: '22 6 * * 1'
 

--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -2,8 +2,7 @@ name: Crowdin / Upload translations
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
     paths:
       - crowdin.yml
       - app/javascript/mastodon/locales/en.json

--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -1,6 +1,7 @@
 name: Crowdin / Upload translations
 
 on:
+  merge_group:
   push:
     branches: [main]
     paths:

--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -3,7 +3,9 @@ name: Crowdin / Upload translations
 on:
   merge_group:
   push:
-    branches: [main]
+    branches:
+      - 'main'
+      - 'stable-*'
     paths:
       - crowdin.yml
       - app/javascript/mastodon/locales/en.json

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -2,7 +2,9 @@ name: Check formatting
 on:
   merge_group:
   push:
-    branches: [main]
+    branches:
+      - 'main'
+      - 'stable-*'
   pull_request:
 
 jobs:

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -1,6 +1,7 @@
 name: Check formatting
 on:
   push:
+    branches: [main]
   pull_request:
 
 jobs:

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -1,5 +1,6 @@
 name: Check formatting
 on:
+  merge_group:
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/lint-css.yml
+++ b/.github/workflows/lint-css.yml
@@ -1,5 +1,6 @@
 name: CSS Linting
 on:
+  merge_group:
   push:
     branches: [main]
     paths:

--- a/.github/workflows/lint-css.yml
+++ b/.github/workflows/lint-css.yml
@@ -1,9 +1,7 @@
 name: CSS Linting
 on:
   push:
-    branches-ignore:
-      - 'dependabot/**'
-      - 'renovate/**'
+    branches: [main]
     paths:
       - 'package.json'
       - 'yarn.lock'

--- a/.github/workflows/lint-css.yml
+++ b/.github/workflows/lint-css.yml
@@ -2,7 +2,9 @@ name: CSS Linting
 on:
   merge_group:
   push:
-    branches: [main]
+    branches:
+      - 'main'
+      - 'stable-*'
     paths:
       - 'package.json'
       - 'yarn.lock'

--- a/.github/workflows/lint-haml.yml
+++ b/.github/workflows/lint-haml.yml
@@ -1,9 +1,7 @@
 name: Haml Linting
 on:
   push:
-    branches-ignore:
-      - 'dependabot/**'
-      - 'renovate/**'
+    branches: [main]
     paths:
       - '.github/workflows/haml-lint-problem-matcher.json'
       - '.github/workflows/lint-haml.yml'

--- a/.github/workflows/lint-haml.yml
+++ b/.github/workflows/lint-haml.yml
@@ -1,5 +1,6 @@
 name: Haml Linting
 on:
+  merge_group:
   push:
     branches: [main]
     paths:

--- a/.github/workflows/lint-haml.yml
+++ b/.github/workflows/lint-haml.yml
@@ -2,7 +2,9 @@ name: Haml Linting
 on:
   merge_group:
   push:
-    branches: [main]
+    branches:
+      - 'main'
+      - 'stable-*'
     paths:
       - '.github/workflows/haml-lint-problem-matcher.json'
       - '.github/workflows/lint-haml.yml'

--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -2,7 +2,9 @@ name: JavaScript Linting
 on:
   merge_group:
   push:
-    branches: [main]
+    branches:
+      - 'main'
+      - 'stable-*'
     paths:
       - 'package.json'
       - 'yarn.lock'

--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -1,5 +1,6 @@
 name: JavaScript Linting
 on:
+  merge_group:
   push:
     branches: [main]
     paths:

--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -1,9 +1,7 @@
 name: JavaScript Linting
 on:
   push:
-    branches-ignore:
-      - 'dependabot/**'
-      - 'renovate/**'
+    branches: [main]
     paths:
       - 'package.json'
       - 'yarn.lock'

--- a/.github/workflows/lint-ruby.yml
+++ b/.github/workflows/lint-ruby.yml
@@ -1,5 +1,6 @@
 name: Ruby Linting
 on:
+  merge_group:
   push:
     branches: [main]
     paths:

--- a/.github/workflows/lint-ruby.yml
+++ b/.github/workflows/lint-ruby.yml
@@ -1,9 +1,7 @@
 name: Ruby Linting
 on:
   push:
-    branches-ignore:
-      - 'dependabot/**'
-      - 'renovate/**'
+    branches: [main]
     paths:
       - 'Gemfile*'
       - '.rubocop*.yml'

--- a/.github/workflows/lint-ruby.yml
+++ b/.github/workflows/lint-ruby.yml
@@ -2,7 +2,9 @@ name: Ruby Linting
 on:
   merge_group:
   push:
-    branches: [main]
+    branches:
+      - 'main'
+      - 'stable-*'
     paths:
       - 'Gemfile*'
       - '.rubocop*.yml'

--- a/.github/workflows/test-js.yml
+++ b/.github/workflows/test-js.yml
@@ -2,7 +2,9 @@ name: JavaScript Testing
 on:
   merge_group:
   push:
-    branches: [main]
+    branches:
+      - 'main'
+      - 'stable-*'
     paths:
       - 'package.json'
       - 'yarn.lock'

--- a/.github/workflows/test-js.yml
+++ b/.github/workflows/test-js.yml
@@ -1,5 +1,6 @@
 name: JavaScript Testing
 on:
+  merge_group:
   push:
     branches: [main]
     paths:

--- a/.github/workflows/test-js.yml
+++ b/.github/workflows/test-js.yml
@@ -1,9 +1,7 @@
 name: JavaScript Testing
 on:
   push:
-    branches-ignore:
-      - 'dependabot/**'
-      - 'renovate/**'
+    branches: [main]
     paths:
       - 'package.json'
       - 'yarn.lock'

--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -3,7 +3,9 @@ name: Historical data migration test
 on:
   merge_group:
   push:
-    branches: [main]
+    branches:
+      - 'main'
+      - 'stable-*'
   pull_request:
 
 jobs:

--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -2,9 +2,7 @@ name: Historical data migration test
 
 on:
   push:
-    branches-ignore:
-      - 'dependabot/**'
-      - 'renovate/**'
+    branches: [main]
   pull_request:
 
 jobs:

--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -1,6 +1,7 @@
 name: Historical data migration test
 
 on:
+  merge_group:
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -3,7 +3,9 @@ name: Ruby Testing
 on:
   merge_group:
   push:
-    branches: [main]
+    branches:
+      - 'main'
+      - 'stable-*'
   pull_request:
 
 env:

--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -1,6 +1,7 @@
 name: Ruby Testing
 
 on:
+  merge_group:
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -2,9 +2,7 @@ name: Ruby Testing
 
 on:
   push:
-    branches-ignore:
-      - 'dependabot/**'
-      - 'renovate/**'
+    branches: [main]
   pull_request:
 
 env:


### PR DESCRIPTION
Changes CI behavior to only run on non-PR pushes to either `main` branch or `stable-*` branches. Previously when any non-fork development feature work was opened as PR we'd get a "double run" from the branch push trigger and also the PR trigger.