### PR TITLE
Use `scope module: ...` for more API routes

### DIFF
--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -203,9 +203,11 @@ namespace :api, format: false do
         post :unmute
       end
 
-      resource :pin, only: :create, controller: 'accounts/pins'
-      post :unpin, to: 'accounts/pins#destroy'
-      resource :note, only: :create, controller: 'accounts/notes'
+      scope module: :accounts do
+        resource :pin, only: :create
+        post :unpin, to: 'pins#destroy'
+        resource :note, only: :create
+      end
     end
 
     resources :tags, only: [:show] do
@@ -218,7 +220,7 @@ namespace :api, format: false do
     resources :followed_tags, only: [:index]
 
     resources :lists, only: [:index, :create, :show, :update, :destroy] do
-      resource :accounts, only: [:show, :create, :destroy], controller: 'lists/accounts'
+      resource :accounts, only: [:show, :create, :destroy], module: :lists
     end
 
     namespace :featured_tags do
@@ -228,7 +230,7 @@ namespace :api, format: false do
     resources :featured_tags, only: [:index, :create, :destroy]
 
     resources :polls, only: [:create, :show] do
-      resources :votes, only: :create, controller: 'polls/votes'
+      resources :votes, only: :create, module: :polls
     end
 
     namespace :push do
@@ -314,8 +316,10 @@ namespace :api, format: false do
     resources :suggestions, only: [:index]
     resource :instance, only: [:show]
     resources :filters, only: [:index, :create, :show, :update, :destroy] do
-      resources :keywords, only: [:index, :create], controller: 'filters/keywords'
-      resources :statuses, only: [:index, :create], controller: 'filters/statuses'
+      scope module: :filters do
+        resources :keywords, only: [:index, :create]
+        resources :statuses, only: [:index, :create]
+      end
     end
 
     namespace :filters do


### PR DESCRIPTION
Basically repeats what https://github.com/mastodon/mastodon/pull/30919 did for the settings routes, but in the api routes.

For most of these its just a small tidy-up improvement to let the controller name derive from the resource method, and/or DRY up a declaration.

Like the other one - route output from main to PR doesnt change.