### PR TITLE
Fix author names as arrays in linked data.

### DIFF
--- a/app/lib/link_details_extractor.rb
+++ b/app/lib/link_details_extractor.rb
@@ -62,7 +62,8 @@ class LinkDetailsExtractor
     end
 
     def author_name
-      author['name']
+      name = author['name']
+      name.is_a?(Array) ? name.join(', ') : name
     end
 
     def author_url
@@ -294,7 +295,7 @@ class LinkDetailsExtractor
   def html_entities_decode(string)
     return if string.nil?
 
-    unicode_string = string.encode('UTF-8')
+    unicode_string = string.to_s.encode('UTF-8')
     raise EncodingError, 'cannot convert string to valid UTF-8' unless unicode_string.valid_encoding?
 
     html_entities.decode(unicode_string)

--- a/spec/lib/link_details_extractor_spec.rb
+++ b/spec/lib/link_details_extractor_spec.rb
@@ -192,6 +192,35 @@ RSpec.describe LinkDetailsExtractor do
 
       include_examples 'structured data'
     end
+
+    context 'with author names as array' do
+      let(:ld_json) do
+        {
+          '@context' => 'https://schema.org',
+          '@type' => 'NewsArticle',
+          'headline' => 'A lot of authors',
+          'description' => 'But we decided to cram them into one',
+          'author' => {
+            '@type' => 'Person',
+            'name' => ['Author 1', 'Author 2'],
+          },
+        }.to_json
+      end
+      let(:html) { <<~HTML }
+        <!doctype html>
+        <html>
+        <body>
+          <script type="application/ld+json">
+            #{ld_json}
+          </script>
+        </body>
+        </html>
+      HTML
+
+      it 'joins author names' do
+        expect(subject.author_name).to eq 'Author 1, Author 2'
+      end
+    end
   end
 
   context 'when Open Graph protocol data is present' do


### PR DESCRIPTION
Fixes #30937

Some websites seem to wrap author names in their linked data in arrays.

There are two seperate problems here:

#30929 introduced a change where we "preprocess" data before we pass it to `htmlentities`. `htmlentities` is pretty clear about wanting a string here, but what I overlooked is that it will call `#to_s` on any value it gets passed and thus silently accept any object. I fixed this but then realized there is a longer-standing issue with these cases here.

`Array#to_s` does not return the most human-readable output. So for URLs as the ones reported in the issue, we would persist author names like `["John Doe"]` (with the brackets and quotation marks) and display those on the preview cards. I can confirm that I have a couple of those on my tiny instance.

So I decided to fix this as well.