### PR TITLE
Remove unneeded `controller` option in routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,7 +94,7 @@ Rails.application.routes.draw do
 
     namespace :auth do
       resource :setup, only: [:show, :update], controller: :setup
-      resource :challenge, only: [:create], controller: :challenges
+      resource :challenge, only: [:create]
       get 'sessions/security_key_options', to: 'sessions#webauthn_options'
       post 'captcha_confirmation', to: 'confirmations#confirm_captcha', as: :captcha_confirmation
     end

--- a/config/routes/settings.rb
+++ b/config/routes/settings.rb
@@ -26,9 +26,9 @@ namespace :settings do
     resources :follows, only: :index, controller: :following_accounts
     resources :blocks, only: :index, controller: :blocked_accounts
     resources :mutes, only: :index, controller: :muted_accounts
-    resources :lists, only: :index, controller: :lists
+    resources :lists, only: :index
     resources :domain_blocks, only: :index, controller: :blocked_domains
-    resources :bookmarks, only: :index, controller: :bookmarks
+    resources :bookmarks, only: :index
   end
 
   resources :two_factor_authentication_methods, only: [:index] do


### PR DESCRIPTION
For the first one, `resource` now defaults to the plural form so we dont need to specify. I suspect this line pre-dates that change in Rails.

The latter group I suspect were just copy/pasted from their surrounding group, but also dont need to be specified.