### PR TITLE
Remove OAuth Password Grant Type support

### DIFF
--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -9,16 +9,9 @@ Doorkeeper.configure do
     current_user || redirect_to(new_user_session_url)
   end
 
-  resource_owner_from_credentials do |_routes|
-    user   = User.authenticate_with_ldap(email: request.params[:username], password: request.params[:password]) if Devise.ldap_authentication
-    user ||= User.authenticate_with_pam(email: request.params[:username], password: request.params[:password]) if Devise.pam_authentication
-
-    if user.nil?
-      user = User.find_by(email: request.params[:username])
-      user = nil unless user&.valid_password?(request.params[:password])
-    end
-
-    user unless user&.otp_required_for_login?
+  # Disable Resource Owner Password Credentials Grant Flow
+  resource_owner_from_credentials do
+    nil
   end
 
   # Doorkeeper provides some administrative interfaces for managing OAuth
@@ -170,7 +163,7 @@ Doorkeeper.configure do
   #   http://tools.ietf.org/html/rfc6819#section-4.4.3
   #
 
-  grant_flows %w(authorization_code password client_credentials)
+  grant_flows %w(authorization_code client_credentials)
 
   # Under some circumstances you might want to have applications auto-approved,
   # so that the user skips the authorization step.


### PR DESCRIPTION
As of OAuth 2.1, the password grant type is no longer even defined due to security risks involved, and it's usage has been strongly discouraged for several years.

This may be considered a breaking change, however, I think it's for the best.