### PR TITLE
Replace more `font-awesome` icons in `views/settings`

### DIFF
--- a/app/views/settings/featured_tags/index.html.haml
+++ b/app/views/settings/featured_tags/index.html.haml
@@ -24,7 +24,7 @@
   .directory__tag
     %div
       %h4
-        = fa_icon 'hashtag'
+        = material_symbol 'tag'
         = featured_tag.display_name
         %small
           - if featured_tag.last_status_at.nil?

--- a/app/views/settings/login_activities/_login_activity.html.haml
+++ b/app/views/settings/login_activities/_login_activity.html.haml
@@ -2,7 +2,7 @@
   .log-entry__header
     .log-entry__avatar
       .indicator-icon{ class: login_activity.success? ? 'success' : 'failure' }
-        = fa_icon login_activity.success? ? 'check' : 'times'
+        = material_symbol login_activity.success? ? 'check' : 'close'
     .log-entry__content
       .log-entry__title
         = login_activity_title(login_activity)

--- a/app/views/settings/profiles/show.html.haml
+++ b/app/views/settings/profiles/show.html.haml
@@ -43,7 +43,7 @@
         = image_tag @account.avatar.url, class: 'fields-group__thumbnail', id: 'account_avatar-preview'
         - if @account.avatar.present?
           = link_to settings_profile_picture_path('avatar'), data: { method: :delete }, class: 'link-button link-button--destructive' do
-            = fa_icon 'trash fw'
+            = material_symbol 'delete'
             = t('generic.delete')
 
   .fields-row
@@ -59,7 +59,7 @@
         = image_tag @account.header.url, class: 'fields-group__thumbnail', id: 'account_header-preview'
         - if @account.header.present?
           = link_to settings_profile_picture_path('header'), data: { method: :delete }, class: 'link-button link-button--destructive' do
-            = fa_icon 'trash fw'
+            = material_symbol 'delete'
             = t('generic.delete')
 
   %h4= t('edit_profile.other')

--- a/app/views/settings/shared/_profile_navigation.html.haml
+++ b/app/views/settings/shared/_profile_navigation.html.haml
@@ -1,7 +1,7 @@
 .content__heading__tabs
   = render_navigation renderer: :links do |primary|
     :ruby
-      primary.item :profile, safe_join([fa_icon('user fw'), t('settings.edit_profile')]), settings_profile_path
-      primary.item :privacy, safe_join([fa_icon('lock fw'), t('privacy.title')]), settings_privacy_path
-      primary.item :verification, safe_join([fa_icon('check fw'), t('verification.verification')]), settings_verification_path
-      primary.item :featured_tags, safe_join([fa_icon('hashtag fw'), t('settings.featured_tags')]), settings_featured_tags_path
+      primary.item :profile, safe_join([material_symbol('person'), t('settings.edit_profile')]), settings_profile_path
+      primary.item :privacy, safe_join([material_symbol('lock'), t('privacy.title')]), settings_privacy_path
+      primary.item :verification, safe_join([material_symbol('check'), t('verification.verification')]), settings_verification_path
+      primary.item :featured_tags, safe_join([material_symbol('tag'), t('settings.featured_tags')]), settings_featured_tags_path

--- a/app/views/settings/two_factor_authentication_methods/index.html.haml
+++ b/app/views/settings/two_factor_authentication_methods/index.html.haml
@@ -6,7 +6,7 @@
 
 %p.hint
   %span.positive-hint
-    = fa_icon 'check'
+    = material_symbol 'check'
     &nbsp;
     = t 'two_factor_authentication.enabled'
 

--- a/app/views/settings/verifications/show.html.haml
+++ b/app/views/settings/verifications/show.html.haml
@@ -26,5 +26,5 @@
       - @verified_links.each do |field|
         %li
           %span.verified-badge
-            = fa_icon 'check', class: 'verified-badge__mark'
+            = material_symbol 'check', class: 'verified-badge__mark'
             %span= field.value


### PR DESCRIPTION
Similar to other areas -- small changes, but nudging it forward.

<img width="719" alt="Screenshot 2024-07-08 at 16 35 11" src="https://github.com/mastodon/mastodon/assets/225/917d37a6-78bf-4255-a28f-0d8d0b9589eb">
<img width="721" alt="Screenshot 2024-07-08 at 16 35 45" src="https://github.com/mastodon/mastodon/assets/225/c0c497f5-e022-4a1d-bc35-40bea9d54851">
