### PR TITLE
Implement system channel for streaming

### DIFF
--- a/app/lib/access_token_extension.rb
+++ b/app/lib/access_token_extension.rb
@@ -24,6 +24,9 @@ module AccessTokenExtension
   end
 
   def push_to_streaming_api
-    redis.publish("timeline:access_token:#{id}", Oj.dump(event: :kill)) if revoked? || destroyed?
+    if revoked? || destroyed?
+      redis.publish("timeline:access_token:#{id}", Oj.dump(event: :kill))
+      redis.publish('system', Oj.dump(event: :terminate, access_tokens: [id]))
+    end
   end
 end

--- a/app/lib/application_extension.rb
+++ b/app/lib/application_extension.rb
@@ -40,6 +40,8 @@ module ApplicationExtension
           pipeline.publish("timeline:access_token:#{id}", payload)
         end
       end
+
+      redis.publish('system', Oj.dump(event: :terminate, access_tokens: tokens.ids))
     end
   end
 end

--- a/app/models/account_domain_block.rb
+++ b/app/models/account_domain_block.rb
@@ -18,6 +18,8 @@ class AccountDomainBlock < ApplicationRecord
   belongs_to :account
   validates :domain, presence: true, uniqueness: { scope: :account_id }, domain: true
 
+  after_destroy :notify_streaming
+
   after_commit :invalidate_domain_blocking_cache
   after_commit :invalidate_follow_recommendations_cache
 
@@ -30,5 +32,9 @@ class AccountDomainBlock < ApplicationRecord
 
   def invalidate_follow_recommendations_cache
     Rails.cache.delete("follow_recommendations/#{account_id}")
+  end
+
+  def notify_streaming
+    AfterUnblockDomainFromAccountService.call(account_id, domain)
   end
 end

--- a/app/models/custom_filter.rb
+++ b/app/models/custom_filter.rb
@@ -114,6 +114,8 @@ class CustomFilter < ApplicationRecord
     Rails.cache.delete("filters:v3:#{account_id}")
     redis.publish("timeline:#{account_id}", Oj.dump(event: :filters_changed))
     redis.publish("timeline:system:#{account_id}", Oj.dump(event: :filters_changed))
+
+    redis.publish('system', Oj.dump(event: :filters_changed, account_id: account_id))
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -341,19 +341,21 @@ class User < ApplicationRecord
   def revoke_access!
     Doorkeeper::AccessGrant.by_resource_owner(self).update_all(revoked_at: Time.now.utc)
 
-    Doorkeeper::AccessToken.by_resource_owner(self).in_batches do |batch|
-      batch.update_all(revoked_at: Time.now.utc)
-      Web::PushSubscription.where(access_token_id: batch).delete_all
+    Doorkeeper::AccessToken.by_resource_owner(self).in_batches do |tokens|
+      tokens.update_all(revoked_at: Time.now.utc)
+      Web::PushSubscription.where(access_token_id: tokens).delete_all
 
       # Revoke each access token for the Streaming API, since `update_all``
       # doesn't trigger ActiveRecord Callbacks:
       # TODO: #28793 Combine into a single topic
       payload = Oj.dump(event: :kill)
       redis.pipelined do |pipeline|
-        batch.ids.each do |id|
+        tokens.ids.each do |id|
           pipeline.publish("timeline:access_token:#{id}", payload)
         end
       end
+
+      redis.publish('system', Oj.dump(event: :terminate, access_tokens: tokens.ids))
     end
   end
 

--- a/app/services/after_block_domain_from_account_service.rb
+++ b/app/services/after_block_domain_from_account_service.rb
@@ -2,6 +2,7 @@
 
 class AfterBlockDomainFromAccountService < BaseService
   include Payloadable
+  include Redisable
 
   # This service does not create an AccountDomainBlock record,
   # it's meant to be called after such a record has been created

--- a/app/services/after_block_domain_from_account_service.rb
+++ b/app/services/after_block_domain_from_account_service.rb
@@ -16,7 +16,9 @@ class AfterBlockDomainFromAccountService < BaseService
     remove_follows!
     reject_existing_followers!
     reject_pending_follow_requests!
+
     notify_of_severed_relationships!
+    notify_streaming!
   end
 
   private
@@ -66,5 +68,9 @@ class AfterBlockDomainFromAccountService < BaseService
 
   def domain_block_event
     @domain_block_event ||= RelationshipSeveranceEvent.create!(type: :user_domain_block, target_name: @domain)
+  end
+
+  def notify_streaming!
+    redis.publish('system', Oj.dump(event: :domain_blocks_changed, account: @account.id, target_domain: @domain))
   end
 end

--- a/app/services/after_block_service.rb
+++ b/app/services/after_block_service.rb
@@ -11,6 +11,7 @@ class AfterBlockService < BaseService
     clear_list_feeds!
     clear_notifications!
     clear_conversations!
+
     notify_streaming!
   end
 

--- a/app/services/after_unblock_domain_from_account_service.rb
+++ b/app/services/after_unblock_domain_from_account_service.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AfterUnblockDomainFromAccountService < BaseService
+  include Redisable
+
+  # This service does not delete an AccountDomainBlock record,
+  # it's meant to be called after such a record has been created
+  # synchronously, to "clean up"
+  def call(account, domain)
+    redis.publish('system', Oj.dump(event: :domain_blocks_changed, account: account.id, target_domain: domain))
+  end
+end

--- a/app/services/unblock_service.rb
+++ b/app/services/unblock_service.rb
@@ -8,6 +8,9 @@ class UnblockService < BaseService
 
     unblock = account.unblock!(target_account)
     create_notification(unblock) if !target_account.local? && target_account.activitypub?
+
+    notify_streaming!
+
     unblock
   end
 
@@ -19,5 +22,9 @@ class UnblockService < BaseService
 
   def build_json(unblock)
     Oj.dump(serialize_payload(unblock, ActivityPub::UndoBlockSerializer))
+  end
+
+  def notify_streaming!
+    redis.publish('system', Oj.dump(event: :blocks_changed, account: @account.id, target_account: @target_account.id))
   end
 end

--- a/app/services/unmute_service.rb
+++ b/app/services/unmute_service.rb
@@ -7,5 +7,13 @@ class UnmuteService < BaseService
     account.unmute!(target_account)
 
     MergeWorker.perform_async(target_account.id, account.id) if account.following?(target_account)
+
+    notify_streaming!
+  end
+
+  private
+
+  def notify_streaming!
+    redis.publish('system', Oj.dump(event: :mutes_changed, account: @account.id, target_account: @target_account.id))
   end
 end

--- a/app/services/unmute_service.rb
+++ b/app/services/unmute_service.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class UnmuteService < BaseService
+  include Redisable
+
   def call(account, target_account)
     return unless account.muting?(target_account)
 
@@ -8,12 +10,6 @@ class UnmuteService < BaseService
 
     MergeWorker.perform_async(target_account.id, account.id) if account.following?(target_account)
 
-    notify_streaming!
-  end
-
-  private
-
-  def notify_streaming!
-    redis.publish('system', Oj.dump(event: :mutes_changed, account: @account.id, target_account: @target_account.id))
+    redis.publish('system', Oj.dump(event: :mutes_changed, account: account.id, target_account: target_account.id))
   end
 end

--- a/app/workers/mute_worker.rb
+++ b/app/workers/mute_worker.rb
@@ -2,10 +2,25 @@
 
 class MuteWorker
   include Sidekiq::Worker
+  include Redisable
 
   def perform(account_id, target_account_id)
-    FeedManager.instance.clear_from_home(Account.find(account_id), Account.find(target_account_id))
+    @account        = Account.find(account_id)
+    @target_account = Account.find(target_account_id)
+
+    clear_home_feed!
+    notify_streaming!
   rescue ActiveRecord::RecordNotFound
     true
+  end
+
+  private
+
+  def clear_home_feed!
+    FeedManager.instance.clear_from_home(@account, @target_account)
+  end
+
+  def notify_streaming!
+    redis.publish('system', Oj.dump(event: :mutes_changed, account: @account.id, target_account: @target_account.id))
   end
 end

--- a/spec/controllers/settings/applications_controller_spec.rb
+++ b/spec/controllers/settings/applications_controller_spec.rb
@@ -148,10 +148,12 @@ describe Settings::ApplicationsController do
 
   describe 'destroy' do
     let(:redis_pipeline_stub) { instance_double(Redis::Namespace, publish: nil) }
-    let!(:access_token) { Fabricate(:accessible_access_token, application: app) }
+    let!(:access_tokens) { Fabricate.times(3, :accessible_access_token, application: app) }
 
     before do
       allow(redis).to receive(:pipelined).and_yield(redis_pipeline_stub)
+      allow(redis).to receive(:publish)
+
       post :destroy, params: { id: app.id }
     end
 
@@ -161,7 +163,11 @@ describe Settings::ApplicationsController do
     end
 
     it 'sends a session kill payload to the streaming server' do
-      expect(redis_pipeline_stub).to have_received(:publish).with("timeline:access_token:#{access_token.id}", '{"event":"kill"}')
+      access_tokens.each do |access_token|
+        expect(redis_pipeline_stub).to have_received(:publish).with("timeline:access_token:#{access_token.id}", '{"event":"kill"}')
+      end
+
+      expect(redis).to have_received(:publish).with('system', Oj.dump({ event: :terminate, access_tokens: access_tokens.map(&:id) }))
     end
   end
 

--- a/spec/requests/api/v2/filters_spec.rb
+++ b/spec/requests/api/v2/filters_spec.rb
@@ -199,6 +199,7 @@ RSpec.describe 'Filters' do
         subject
 
         expect(redis).to have_received(:publish).with("timeline:#{user.account.id}", Oj.dump(event: :filters_changed)).once
+        expect(redis).to have_received(:publish).with('system', Oj.dump(event: :filters_changed, account_id: user.account.id)).once
       end
     end
 

--- a/spec/services/after_block_service_spec.rb
+++ b/spec/services/after_block_service_spec.rb
@@ -48,4 +48,16 @@ RSpec.describe AfterBlockService do
       }.from([status.id.to_s, other_account_status.id.to_s, other_account_reblog.id.to_s]).to([other_account_status.id.to_s])
     end
   end
+
+  describe 'streaming integration' do
+    before do
+      allow(redis).to receive(:publish)
+    end
+
+    it 'notifies streaming of the blocks change' do
+      subject
+
+      expect(redis).to have_received(:publish).with('system', Oj.dump(event: :blocks_changed, account: account.id, target_account: target_account.id)).once
+    end
+  end
 end

--- a/spec/workers/mute_worker_spec.rb
+++ b/spec/workers/mute_worker_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe MuteWorker do
+  subject { described_class.new.perform(account.id, target_account.id) }
+
+  let(:account)              { Fabricate(:account) }
+  let(:target_account)       { Fabricate(:account) }
+
+  describe '#perform' do
+    describe 'home timeline' do
+      before do
+        allow(FeedManager.instance).to receive(:clear_from_home)
+      end
+
+      it "clears target account's statuses" do
+        subject
+
+        expect(FeedManager.instance).to have_received(:clear_from_home).with(account, target_account)
+      end
+    end
+
+    describe 'streaming integration' do
+      before do
+        allow(redis).to receive(:publish)
+      end
+
+      it 'notifies streaming of the change in mutes' do
+        subject
+
+        expect(redis).to have_received(:publish).with('system', Oj.dump(event: :mutes_changed, account: account.id, target_account: target_account.id))
+      end
+    end
+  end
+end


### PR DESCRIPTION
The goal of this PR is to have the streaming server have a single pubsub channel in Redis through which it receives events that affect the state of the streaming server. This implements https://github.com/mastodon/mastodon/issues/28793

At present, we:
- have N*2 channels per connection for termination events and filter changes
- do not have a means to broadcast when account domain blocks, blocks, and mutes change, such that we cannot cache these anywhere in Streaming, increasing load on the database during the message processing loop.

So for instance, on Hachyderm, we regularly see ~1300 Redis subscriptions to so called "system channels" (`timeline:access_token:${request.accessTokenId}` and `timeline:system:${request.accountId}`), whilst we only have ~700 connected clients. These topics receive events such as filters being changed and the termination event if access is revoked.

We can significantly reduce the number of redis pub/sub channels and database load that Streaming server requires by having just a single "system" channel which is connected to independently of its clients on startup.

By publishing events related to account domain blocks, account blocks and account mutes, we can query these at connection time, and only re-query them if they have changed, meaning that for every message sent to streaming we don't need to hit the database with [1-2 queries](https://github.com/mastodon/mastodon/blob/main/streaming/index.js#L879-L895), one of which is [potentially expensive](https://github.com/mastodon/mastodon/blob/main/streaming/index.js#L881-L889) to calculate.

This change does mean that a streaming server may receive 'system' messages for access tokens and accounts that it does not have connections for, however, those can be fairly efficiently discarded, and the publish to redis will only happen once from Ruby. This allows us to do away with cases where we perform O(M) calls to publish via pipelineling to M channels.

Note: I've not yet removed the old code paths that are pipelining calls.

This is something of a precursor to #28010