### PR TITLE
Fix SCSS mixed declarations deprecation

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1366,6 +1366,8 @@ body > [data-popper-placement] {
   min-height: 54px;
   border-bottom: 1px solid var(--background-border-color);
   cursor: auto;
+  opacity: 1;
+  animation: fade 150ms linear;
 
   @keyframes fade {
     0% {
@@ -1376,9 +1378,6 @@ body > [data-popper-placement] {
       opacity: 1;
     }
   }
-
-  opacity: 1;
-  animation: fade 150ms linear;
 
   .media-gallery,
   .video-player,
@@ -4851,8 +4850,10 @@ a.status-card {
     &__menu {
       @include search-popout;
 
-      padding: 0;
-      background: $ui-secondary-color;
+      & {
+        padding: 0;
+        background: $ui-secondary-color;
+      }
     }
 
     &__menu-list {


### PR DESCRIPTION
Details are here: https://sass-lang.com/documentation/breaking-changes/mixed-decls/

I do not think it the order matters for `.status`?

I am using the new recommended `& { … }` syntax for the second change, as we want to override those.