### PR TITLE
Do not pass unknown encoding names to nokogiri.

### DIFF
--- a/app/lib/link_details_extractor.rb
+++ b/app/lib/link_details_extractor.rb
@@ -274,7 +274,7 @@ class LinkDetailsExtractor
   end
 
   def detect_encoding_and_parse_document
-    [detect_encoding, nil, @html_charset].uniq.each do |encoding|
+    [detect_encoding, nil, header_encoding].uniq.each do |encoding|
       document = Nokogiri::HTML(@html, nil, encoding)
       return document if document.to_s.valid_encoding?
     end
@@ -284,6 +284,13 @@ class LinkDetailsExtractor
   def detect_encoding
     guess = detector.detect(@html, @html_charset)
     guess&.fetch(:confidence, 0).to_i > 60 ? guess&.fetch(:encoding, nil) : nil
+  end
+
+  def header_encoding
+    Encoding.find(@html_charset).name if @html_charset
+  rescue ArgumentError
+    # Encoding from HTTP header is not recognized by ruby
+    nil
   end
 
   def detector

--- a/spec/fixtures/requests/alternative_utf8_spelling_in_header.txt
+++ b/spec/fixtures/requests/alternative_utf8_spelling_in_header.txt
@@ -1,0 +1,18 @@
+HTTP/1.1 200 OK
+server: nginx
+date: Thu, 13 Jun 2024 14:33:13 GMT
+content-type: text/html; charset=utf8
+content-length: 192
+accept-ranges: bytes
+
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Webserver Configs R Us</title>
+</head>
+<body>
+  <h2>Welcome</h2>
+  <p>Sneaky non-UTF character: á</p>
+</body>
+</html>

--- a/spec/services/fetch_link_card_service_spec.rb
+++ b/spec/services/fetch_link_card_service_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe FetchLinkCardService do
     stub_request(:get, 'http://example.com/aergerliche-umlaute').to_return(request_fixture('redirect_with_utf8_url.txt'))
     stub_request(:get, 'http://example.com/page_without_title').to_return(request_fixture('page_without_title.txt'))
     stub_request(:get, 'http://example.com/long_canonical_url').to_return(request_fixture('long_canonical_url.txt'))
+    stub_request(:get, 'http://example.com/alternative_utf8_spelling_in_header').to_return(request_fixture('alternative_utf8_spelling_in_header.txt'))
 
     Rails.cache.write('oembed_endpoint:example.com', oembed_cache) if oembed_cache
 
@@ -290,6 +291,14 @@ RSpec.describe FetchLinkCardService do
 
       it 'does not create a preview card' do
         expect(status.preview_card).to be_nil
+      end
+    end
+
+    context 'with a URL where the `Content-Type` header uses `utf8` instead of `utf-8`' do
+      let(:status) { Fabricate(:status, text: 'test http://example.com/alternative_utf8_spelling_in_header') }
+
+      it 'does not create a preview card' do
+        expect(status.preview_card.title).to eq 'Webserver Configs R Us'
       end
     end
   end


### PR DESCRIPTION
This is a follow-up to #30780 and another case brought up in discord:

In the PR mentioned we introduced fallbacks for when no encoding can be detected while analyzing web pages to create link previews. The first fallback is the encoding given in HTTP headers.

We pass this to nokogiri to see if this will work. As it turns out, nokogiri will not validate this encoding. So if it is one ruby does not recognize, it will raise an `ArgumentError` somewhere down the line.

This is consistent with people seeing `ArgumentError`s complaining about `utf8` and `UTF8`, which are both common enough alternative spellings of `UTF-8` that ruby does not recognize.

This change makes sure we only pass encoding names to nokogiri that ruby actually recognizes.

(I briefly thought about making support for these alternative spellings explicit, but `UTF-8` is already the very next fallback, so we would gain nothing except making the code more confusing.)

Sadly, I had no real-world example this time and it took me quite a while to construct a test case for this. As such, the test might not be very realisitic, but it does trigger the problematic case. The code change itself is definitely an improvement though in my opinion.