### PR TITLE
Change Sidekiq readiness file to use an environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,9 @@ ENV \
 # Optimize jemalloc 5.x performance
   MALLOC_CONF="narenas:2,background_thread:true,thp:never,dirty_decay_ms:1000,muzzy_decay_ms:0" \
 # Enable libvips, should not be changed
-  MASTODON_USE_LIBVIPS=true
+  MASTODON_USE_LIBVIPS=true \
+# Sidekiq will touch tmp/sidekiq_process_has_started_and_will_begin_processing_jobs to indicate it is ready. This can be used for a readiness check in Kubernetes
+  MASTODON_SIDEKIQ_READY_FILENAME=sidekiq_process_has_started_and_will_begin_processing_jobs
 
 # Set default shell used for running commands
 SHELL ["/bin/bash", "-o", "pipefail", "-o", "errexit", "-c"]

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -2,19 +2,24 @@
 
 require_relative '../../lib/mastodon/sidekiq_middleware'
 
-SIDEKIQ_WILL_PROCESSES_JOBS_FILE = Rails.root.join('tmp', 'sidekiq_process_has_started_and_will_begin_processing_jobs').freeze
-
 Sidekiq.configure_server do |config|
   config.redis = REDIS_SIDEKIQ_PARAMS
 
   # This is used in Kubernetes setups, to signal that the Sidekiq process has started and will begin processing jobs
   # This comes from https://github.com/sidekiq/sidekiq/wiki/Kubernetes#sidekiq
-  config.on(:startup) do
-    FileUtils.touch(SIDEKIQ_WILL_PROCESSES_JOBS_FILE)
-  end
+  ready_filename = ENV.fetch('MASTODON_SIDEKIQ_READY_FILENAME', nil)
+  if ready_filename
+    raise 'MASTODON_SIDEKIQ_READY_FILENAME is not a valid filename' if File.basename(ready_filename) != ready_filename
 
-  config.on(:shutdown) do
-    FileUtils.rm_f(SIDEKIQ_WILL_PROCESSES_JOBS_FILE)
+    ready_path = Rails.root.join('tmp', ready_filename)
+
+    config.on(:startup) do
+      FileUtils.touch(ready_path)
+    end
+
+    config.on(:shutdown) do
+      FileUtils.rm_f(ready_path)
+    end
   end
 
   config.server_middleware do |chain|


### PR DESCRIPTION
This allows the filename to be customized, for example if you run multiple Sidekiq processes in the same host, so they each have their own readiness file.