### PR TITLE
Use `module: :auth` to wrap `devise_for` routes config

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -104,13 +104,9 @@ Rails.application.routes.draw do
     end
   end
 
-  devise_for :users, path: 'auth', format: false, controllers: {
-    omniauth_callbacks: 'auth/omniauth_callbacks',
-    sessions: 'auth/sessions',
-    registrations: 'auth/registrations',
-    passwords: 'auth/passwords',
-    confirmations: 'auth/confirmations',
-  }
+  scope module: :auth do
+    devise_for :users, path: 'auth', format: false
+  end
 
   with_options constraints: ->(req) { req.format.nil? || req.format.html? } do
     get '/users/:username', to: redirect_with_vary('/@%{username}')


### PR DESCRIPTION
Since we're overriding every controller and they are all in the `auth` module space, we can wrap this from the outside and devise knows what we mean.

I thought I might be able to use `namespace :auth, as: nil` or something similar here and also get rid of the `path: ...` option to the `devise_for` call, but it seems like that has the effect of resetting some route generation and we get different results that way. Maybe future research there.

Verified same way as others like this ... running `bin/rails routes -g /auth/ | shasum` for main and this branch have same result.