### PR TITLE
Move filtered notifications bar in scrollable area

### DIFF
--- a/app/javascript/mastodon/features/notifications/index.jsx
+++ b/app/javascript/mastodon/features/notifications/index.jsx
@@ -216,7 +216,7 @@ class Notifications extends PureComponent {
         />
       ));
     } else {
-      scrollableContent = null;
+      scrollableContent = <> </>;
     }
 
     this.scrollableContent = scrollableContent;

--- a/app/javascript/mastodon/features/notifications/index.jsx
+++ b/app/javascript/mastodon/features/notifications/index.jsx
@@ -216,7 +216,7 @@ class Notifications extends PureComponent {
         />
       ));
     } else {
-      scrollableContent = <> </>;
+      scrollableContent = null;
     }
 
     this.scrollableContent = scrollableContent;

--- a/app/javascript/mastodon/features/notifications/index.jsx
+++ b/app/javascript/mastodon/features/notifications/index.jsx
@@ -223,6 +223,13 @@ class Notifications extends PureComponent {
 
     let scrollContainer;
 
+    const prepend = (
+      <>
+        {needsNotificationPermission && <NotificationsPermissionBanner />}
+        <FilteredNotificationsBanner />
+      </>
+    );
+
     if (signedIn) {
       scrollContainer = (
         <ScrollableList
@@ -232,7 +239,7 @@ class Notifications extends PureComponent {
           showLoading={isLoading && notifications.size === 0}
           hasMore={hasMore}
           numPending={numPending}
-          prepend={needsNotificationPermission && <NotificationsPermissionBanner />}
+          prepend={prepend}
           alwaysPrepend
           emptyMessage={emptyMessage}
           onLoadMore={this.handleLoadOlder}
@@ -241,8 +248,6 @@ class Notifications extends PureComponent {
           onScroll={this.handleScroll}
           bindToDocument={!multiColumn}
         >
-          <FilteredNotificationsBanner />
-
           {scrollableContent}
         </ScrollableList>
       );

--- a/app/javascript/mastodon/features/notifications/index.jsx
+++ b/app/javascript/mastodon/features/notifications/index.jsx
@@ -241,6 +241,8 @@ class Notifications extends PureComponent {
           onScroll={this.handleScroll}
           bindToDocument={!multiColumn}
         >
+          <FilteredNotificationsBanner />
+
           {scrollableContent}
         </ScrollableList>
       );
@@ -281,8 +283,6 @@ class Notifications extends PureComponent {
         </ColumnHeader>
 
         {filterBarContainer}
-
-        <FilteredNotificationsBanner />
 
         {scrollContainer}
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -10192,8 +10192,7 @@ noscript {
 .filtered-notifications-banner {
   display: flex;
   align-items: center;
-  border: 1px solid var(--background-border-color);
-  border-top: 0;
+  border-bottom: 1px solid var(--background-border-color);
   padding: 24px 32px;
   gap: 16px;
   color: $darker-text-color;


### PR DESCRIPTION
Fixes MAS-276

This is my totally naive attempt to fix the disparity between regular and advanced interface, where the new "filtered notifications bar" would scroll away in the former but not in the latter.

I have absolutely no idea how the different components that are affected here interact and so might have overlooked a lot of problems this change might create. Feel free to discard this :slightly_smiling_face: