### PR TITLE
Change disabled buttons color in light mode to make it more visible

### DIFF
--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -48,6 +48,10 @@ html {
   }
 }
 
+.icon-button:disabled {
+  color: darken($action-button-color, 25%);
+}
+
 .account__header__bar .avatar .account__avatar {
   border-color: $white;
 }


### PR DESCRIPTION
Before:
<img width="597" alt="image" src="https://github.com/mastodon/mastodon/assets/42070/b8db0d95-773f-4a3f-a55e-758d531500f8">


After:
<img width="603" alt="image" src="https://github.com/mastodon/mastodon/assets/42070/0c688d35-221c-4562-a7ed-cdef5336335c">
