### PR TITLE
Use `include_pagination_headers` in more places

### DIFF
--- a/spec/requests/api/v1/accounts/statuses_spec.rb
+++ b/spec/requests/api/v1/accounts/statuses_spec.rb
@@ -60,7 +60,7 @@ describe 'API V1 Accounts Statuses' do
 
         expect(response)
           .to have_http_status(200)
-          .and have_http_link_header(:prev, api_v1_account_statuses_url(pinned: true, min_id: Status.first.id))
+          .and include_pagination_headers(prev: api_v1_account_statuses_url(pinned: true, min_id: Status.first.id))
       end
     end
 

--- a/spec/requests/api/v1/accounts/statuses_spec.rb
+++ b/spec/requests/api/v1/accounts/statuses_spec.rb
@@ -10,12 +10,15 @@ describe 'API V1 Accounts Statuses' do
 
   describe 'GET /api/v1/accounts/:account_id/statuses' do
     it 'returns expected headers', :aggregate_failures do
-      Fabricate(:status, account: user.account)
+      status = Fabricate(:status, account: user.account)
       get "/api/v1/accounts/#{user.account.id}/statuses", params: { limit: 1 }, headers: headers
 
-      expect(response).to have_http_status(200)
-      expect(links_from_header.size)
-        .to eq(2)
+      expect(response)
+        .to have_http_status(200)
+        .and include_pagination_headers(
+          prev: api_v1_account_statuses_url(limit: 1, min_id: status.id),
+          next: api_v1_account_statuses_url(limit: 1, max_id: status.id)
+        )
     end
 
     context 'with only media' do
@@ -55,16 +58,9 @@ describe 'API V1 Accounts Statuses' do
       it 'returns http success and includes a header link' do
         get "/api/v1/accounts/#{user.account.id}/statuses", params: { pinned: true }, headers: headers
 
-        expect(response).to have_http_status(200)
-        expect(links_from_header.size)
-          .to eq(1)
-        expect(links_from_header)
-          .to contain_exactly(
-            have_attributes(
-              href: /pinned=true/,
-              attr_pairs: contain_exactly(['rel', 'prev'])
-            )
-          )
+        expect(response)
+          .to have_http_status(200)
+          .and have_http_link_header(:prev, api_v1_account_statuses_url(pinned: true, min_id: Status.first.id))
       end
     end
 
@@ -77,19 +73,11 @@ describe 'API V1 Accounts Statuses' do
       it 'returns http success and header pagination links to prev and next' do
         get "/api/v1/accounts/#{user.account.id}/statuses", params: { pinned: true }, headers: headers
 
-        expect(response).to have_http_status(200)
-        expect(links_from_header.size)
-          .to eq(2)
-        expect(links_from_header)
-          .to contain_exactly(
-            have_attributes(
-              href: /pinned=true/,
-              attr_pairs: contain_exactly(['rel', 'next'])
-            ),
-            have_attributes(
-              href: /pinned=true/,
-              attr_pairs: contain_exactly(['rel', 'prev'])
-            )
+        expect(response)
+          .to have_http_status(200)
+          .and include_pagination_headers(
+            prev: api_v1_account_statuses_url(pinned: true, min_id: Status.first.id),
+            next: api_v1_account_statuses_url(pinned: true, max_id: Status.first.id)
           )
       end
     end
@@ -137,13 +125,5 @@ describe 'API V1 Accounts Statuses' do
         end
       end
     end
-  end
-
-  private
-
-  def links_from_header
-    response
-      .headers['Link']
-      .links
   end
 end

--- a/spec/requests/api/v1/conversations_spec.rb
+++ b/spec/requests/api/v1/conversations_spec.rb
@@ -20,8 +20,12 @@ RSpec.describe 'API V1 Conversations' do
     it 'returns pagination headers', :aggregate_failures do
       get '/api/v1/conversations', params: { limit: 1 }, headers: headers
 
-      expect(response).to have_http_status(200)
-      expect(response.headers['Link'].links.size).to eq(2)
+      expect(response)
+        .to have_http_status(200)
+        .and include_pagination_headers(
+          prev: api_v1_conversations_url(limit: 1, min_id: Status.first.id),
+          next: api_v1_conversations_url(limit: 1, max_id: Status.first.id)
+        )
     end
 
     it 'returns conversations', :aggregate_failures do

--- a/spec/requests/api/v1/statuses/favourited_by_accounts_spec.rb
+++ b/spec/requests/api/v1/statuses/favourited_by_accounts_spec.rb
@@ -29,8 +29,10 @@ RSpec.describe 'API V1 Statuses Favourited by Accounts' do
 
         expect(response)
           .to have_http_status(200)
-        expect(response.headers['Link'].links.size)
-          .to eq(2)
+          .and include_pagination_headers(
+            prev: api_v1_status_favourited_by_index_url(limit: 2, since_id: Favourite.last.id),
+            next: api_v1_status_favourited_by_index_url(limit: 2, max_id: Favourite.first.id)
+          )
 
         expect(body_as_json.size)
           .to eq(2)

--- a/spec/requests/api/v1/statuses/reblogged_by_accounts_spec.rb
+++ b/spec/requests/api/v1/statuses/reblogged_by_accounts_spec.rb
@@ -28,8 +28,10 @@ RSpec.describe 'API V1 Statuses Reblogged by Accounts' do
 
         expect(response)
           .to have_http_status(200)
-        expect(response.headers['Link'].links.size)
-          .to eq(2)
+          .and include_pagination_headers(
+            prev: api_v1_status_reblogged_by_index_url(limit: 2, since_id: bob.statuses.first.id),
+            next: api_v1_status_reblogged_by_index_url(limit: 2, max_id: alice.statuses.first.id)
+          )
 
         expect(body_as_json.size)
           .to eq(2)

--- a/spec/requests/api/v2/admin/accounts_spec.rb
+++ b/spec/requests/api/v2/admin/accounts_spec.rb
@@ -83,7 +83,8 @@ RSpec.describe 'API V2 Admin Accounts' do
       let(:params) { { limit: 1 } }
 
       it 'sets the correct pagination headers' do
-        expect(response.headers['Link'].find_link(%w(rel next)).href).to eq api_v2_admin_accounts_url(limit: 1, max_id: admin_account.id)
+        expect(response)
+          .to include_pagination_headers(next: api_v2_admin_accounts_url(limit: 1, max_id: admin_account.id))
       end
     end
   end


### PR DESCRIPTION
This matcher was introduced a while ago, and I'm guessing that I missed some of this in the initial pass.

Basically all of these changes are just adding some detail about what we are looking for to what were previously less precise assertions.

Extracted from WIP branch that adds another matcher for generic http link headers (not pagination specific).