### PR TITLE
Add change assertion to invites destroy spec

### DIFF
--- a/spec/controllers/invites_controller_spec.rb
+++ b/spec/controllers/invites_controller_spec.rb
@@ -69,19 +69,16 @@ describe InvitesController do
     end
   end
 
-  describe 'DELETE #create' do
+  describe 'DELETE #destroy' do
+    subject { delete :destroy, params: { id: invite.id } }
+
     let(:invite) { Fabricate(:invite, user: user, expires_at: nil) }
 
-    before do
-      delete :destroy, params: { id: invite.id }
-    end
-
-    it 'redirects' do
-      expect(response).to redirect_to invites_path
-    end
-
-    it 'expires invite' do
-      expect(invite.reload).to be_expired
+    it 'expires invite and redirects' do
+      expect { subject }
+        .to(change { invite.reload.expired? }.to(true))
+      expect(response)
+        .to redirect_to invites_path
     end
   end
 end


### PR DESCRIPTION
We were asserting that its expired, but not that it wasnt already expired.

Also noticed a typo in description (create -> destroy).