### PR TITLE
Add optional `filtered` attribute to notification entities in REST API

### DIFF
--- a/app/serializers/rest/notification_serializer.rb
+++ b/app/serializers/rest/notification_serializer.rb
@@ -3,6 +3,8 @@
 class REST::NotificationSerializer < ActiveModel::Serializer
   attributes :id, :type, :created_at, :group_key
 
+  attribute :filtered, if: :filtered?
+
   belongs_to :from_account, key: :account, serializer: REST::AccountSerializer
   belongs_to :target_status, key: :status, if: :status_type?, serializer: REST::StatusSerializer
   belongs_to :report, if: :report_type?, serializer: REST::ReportSerializer
@@ -32,4 +34,6 @@ class REST::NotificationSerializer < ActiveModel::Serializer
   def moderation_warning_event?
     object.type == :moderation_warning
   end
+
+  delegate :filtered?, to: :object
 end

--- a/spec/requests/api/v1/notifications_spec.rb
+++ b/spec/requests/api/v1/notifications_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe 'Notifications' do
     before do
       first_status = PostStatusService.new.call(user.account, text: 'Test')
       ReblogService.new.call(bob.account, first_status)
-      mentioning_status = PostStatusService.new.call(bob.account, text: 'Hello @alice')
-      mentioning_status.mentions.first
+      PostStatusService.new.call(bob.account, text: 'Hello @alice')
+      PostStatusService.new.call(tom.account, text: 'Hello @alice', visibility: :direct) # Filtered by default
       FavouriteService.new.call(bob.account, first_status)
       FavouriteService.new.call(tom.account, first_status)
       FollowService.new.call(bob.account, user.account)
@@ -34,10 +34,20 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_json_types).to include 'reblog'
-        expect(body_json_types).to include 'mention'
-        expect(body_json_types).to include 'favourite'
-        expect(body_json_types).to include 'follow'
+        expect(body_as_json.size).to eq 5
+        expect(body_json_types).to include('reblog', 'mention', 'favourite', 'follow')
+      end
+    end
+
+    context 'with include_filtered' do
+      let(:params) { { include_filtered: true } }
+
+      it 'returns expected notification types, including filtered notifications' do
+        subject
+
+        expect(response).to have_http_status(200)
+        expect(body_as_json.size).to eq 6
+        expect(body_json_types).to include('reblog', 'mention', 'favourite', 'follow')
       end
     end
 
@@ -96,7 +106,7 @@ RSpec.describe 'Notifications' do
       it 'returns the requested number of notifications paginated', :aggregate_failures do
         subject
 
-        notifications = user.account.notifications
+        notifications = user.account.notifications.browserable
 
         expect(body_as_json.size)
           .to eq(params[:limit])

--- a/spec/requests/api/v1/notifications_spec.rb
+++ b/spec/requests/api/v1/notifications_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe 'Notifications' do
         expect(response).to have_http_status(200)
         expect(body_as_json.size).to eq 5
         expect(body_json_types).to include('reblog', 'mention', 'favourite', 'follow')
+        expect(body_as_json.any? { |x| x[:filtered] }).to be false
       end
     end
 
@@ -48,6 +49,7 @@ RSpec.describe 'Notifications' do
         expect(response).to have_http_status(200)
         expect(body_as_json.size).to eq 6
         expect(body_json_types).to include('reblog', 'mention', 'favourite', 'follow')
+        expect(body_as_json.any? { |x| x[:filtered] }).to be true
       end
     end
 


### PR DESCRIPTION
`GET /api/v1/notifications?include_filtered=true` allows getting filtered notifications, but before this PR did not allow distinguishing filtered notifications from non-filtered ones in the result.

This PR adds a `"filtered": true` attribute to filtered notifications in the REST API.