### PR TITLE
Simplify account model username presence validation spec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -154,6 +154,8 @@ group :test do
   # Test harness fo rack components
   gem 'rack-test', '~> 2.1'
 
+  gem 'shoulda-matchers'
+
   # Coverage formatter for RSpec test if DISABLE_SIMPLECOV is false
   gem 'simplecov', '~> 0.22', require: false
   gem 'simplecov-lcov', '~> 0.8', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -787,7 +787,7 @@ GEM
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
     semantic_range (3.0.0)
-    shoulda-matchers (6.3.0)
+    shoulda-matchers (6.3.1)
       activesupport (>= 5.2.0)
     sidekiq (6.5.12)
       connection_pool (>= 2.2.5, < 3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -787,7 +787,7 @@ GEM
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
     semantic_range (3.0.0)
-    shoulda-matchers (6.2.0)
+    shoulda-matchers (6.3.0)
       activesupport (>= 5.2.0)
     sidekiq (6.5.12)
       connection_pool (>= 2.2.5, < 3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -787,6 +787,8 @@ GEM
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
     semantic_range (3.0.0)
+    shoulda-matchers (6.2.0)
+      activesupport (>= 5.2.0)
     sidekiq (6.5.12)
       connection_pool (>= 2.2.5, < 3)
       rack (~> 2.0)
@@ -1033,6 +1035,7 @@ DEPENDENCIES
   sanitize (~> 6.0)
   scenic (~> 1.7)
   selenium-webdriver
+  shoulda-matchers
   sidekiq (~> 6.5)
   sidekiq-bulk (~> 0.2.0)
   sidekiq-scheduler (~> 5.0)

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -722,11 +722,7 @@ RSpec.describe Account do
   end
 
   describe 'validations' do
-    it 'is invalid without a username' do
-      account = Fabricate.build(:account, username: nil)
-      account.valid?
-      expect(account).to model_have_error_on_field(:username)
-    end
+    it { is_expected.to validate_presence_of(:username) }
 
     it 'squishes the username before validation' do
       account = Fabricate(:account, domain: nil, username: " \u3000bob \t \u00a0 \n ")

--- a/spec/support/shoulda_matchers.rb
+++ b/spec/support/shoulda_matchers.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end


### PR DESCRIPTION
https://github.com/mastodon/mastodon/pull/29664 has been open for a while without feedback. On the assumption that the diff size being large is part of the delay, opening this one here which is just the gem addition and ONE of the validation spec changes from that PR.

If this smaller diffs makes the general idea/direction easier to contemplate and review, I can rebase the other one and/or pull out more/smaller PRs from that original one to continue to simplify/condense the various relevant validation specs.

I think we can get significant LOC reduction and simplifcation out of this gem -- the majority of the matchers have implementations that are essentially the same (with more flexibility if needed) than much of what they would replace.