### PR TITLE
Add i18n strings for instance favicon and logo settings label

### DIFF
--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -243,11 +243,13 @@ en:
           warn: Hide with a warning
       form_admin_settings:
         activity_api_enabled: Publish aggregate statistics about user activity in the API
+        app_icon: App icon
         backups_retention_period: User archive retention period
         bootstrap_timeline_accounts: Always recommend these accounts to new users
         closed_registrations_message: Custom message when sign-ups are not available
         content_cache_retention_period: Remote content retention period
         custom_css: Custom CSS
+        favicon: Favicon
         mascot: Custom mascot (legacy)
         media_cache_retention_period: Media cache retention period
         peers_api_enabled: Publish list of discovered servers in the API


### PR DESCRIPTION
This adds translation strings for "Favicon" and "App icon" label in `/admin/settings/branding`.

![Screenshot 2024-07-13 at 06-02-06 Branding - Mastodon (Dev)](https://github.com/user-attachments/assets/d77296b5-4d6f-4643-91b4-7b9345f4c000)
