### PR TITLE
Remove "Top Active Servers" from Admin Dashboard

### DIFF
--- a/app/views/admin/dashboard/index.html.haml
+++ b/app/views/admin/dashboard/index.html.haml
@@ -86,14 +86,6 @@
                             limit: 8,
                             start_at: @time_period.first
 
-  .dashboard__item
-    = react_admin_component :dimension,
-                            dimension: 'servers',
-                            end_at: @time_period.last,
-                            label: t('admin.dashboard.top_servers'),
-                            limit: 8,
-                            start_at: @time_period.first
-
   .dashboard__item.dashboard__item--span-double-column
     = react_admin_component :retention,
                             end_at: @time_period.last,


### PR DESCRIPTION
As per https://github.com/mastodon/mastodon/issues/31017, this dimension was particularly expensive to calculate, and as the admin dashboard is very frequently hit by moderators, we likely don't want to be re-calculating an expensive query on this screen often.

I've just removed the widget for now, rather than removing the dimension entirely, as I think we can probably improve it's performance or calculation in some way later.