### PR TITLE
Handle missing links in Webfinger response

### DIFF
--- a/app/lib/webfinger.rb
+++ b/app/lib/webfinger.rb
@@ -26,7 +26,7 @@ class Webfinger
     private
 
     def links
-      @links ||= @json['links'].index_by { |link| link['rel'] }
+      @links ||= @json.fetch('links', []).index_by { |link| link['rel'] }
     end
 
     def validate_response!


### PR DESCRIPTION
This PR improves the behaviour for the case when the Webfinger response is missing the "links" attribute.

### Before

Undefined method "index_by" for NilClass and error 503 returned from the controller.

### After

https://github.com/mastodon/mastodon/blob/9d0bce40724eb77b7cc3917091b62e4ab159e29e/app/services/resolve_account_service.rb#L125

`activitypub_ready?` returns `false` and the code recovers gracefully.