### PR TITLE
Recolor Preferences/Admin UI to better match main design

### DIFF
--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -140,7 +140,6 @@ html {
 .actions-modal ul li:not(:empty) a:focus button,
 .actions-modal ul li:not(:empty) a:hover,
 .actions-modal ul li:not(:empty) a:hover button,
-.admin-wrapper .sidebar ul .simple-navigation-active-leaf a,
 .simple_form .block-button,
 .simple_form .button,
 .simple_form button {

--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -510,6 +510,7 @@ html {
 .search__popout,
 .emoji-mart-search input,
 .language-dropdown__dropdown .emoji-mart-search input,
+.strike-card,
 .poll__option input[type='text'] {
   background: darken($ui-base-color, 10%);
 }

--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -306,18 +306,6 @@ html {
   }
 }
 
-.simple_form {
-  input[type='text'],
-  input[type='number'],
-  input[type='email'],
-  input[type='password'],
-  textarea {
-    &:hover {
-      border-color: lighten($ui-base-color, 12%);
-    }
-  }
-}
-
 .picture-in-picture-placeholder {
   background: $white;
   border-color: lighten($ui-base-color, 8%);

--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -548,3 +548,15 @@ a.sparkline {
     }
   }
 }
+
+.directory {
+  &__tag {
+    & > a {
+      &:hover,
+      &:active,
+      &:focus {
+        background: darken($ui-base-color, 10%);
+      }
+    }
+  }
+}

--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -398,6 +398,22 @@ html {
     color: $ui-highlight-color;
     background-color: rgba($ui-highlight-color, 0.1);
   }
+
+  input[type='text'],
+  input[type='number'],
+  input[type='email'],
+  input[type='password'],
+  input[type='url'],
+  input[type='datetime-local'],
+  textarea {
+    background: darken($ui-base-color, 10%);
+  }
+
+  select {
+    background: darken($ui-base-color, 10%)
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14.933 18.467' height='19.698' width='15.929'><path d='M3.467 14.967l-3.393-3.5H14.86l-3.392 3.5c-1.866 1.925-3.666 3.5-4 3.5-.335 0-2.135-1.575-4-3.5zm.266-11.234L7.467 0 11.2 3.733l3.733 3.734H0l3.733-3.734z' fill='#{hex-color(lighten($ui-base-color, 12%))}'/></svg>")
+    no-repeat right 8px center / auto 14px;
+  }
 }
 
 .compose-form .compose-form__warning {
@@ -442,6 +458,8 @@ html {
     url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14.933 18.467' height='19.698' width='15.929'><path d='M3.467 14.967l-3.393-3.5H14.86l-3.392 3.5c-1.866 1.925-3.666 3.5-4 3.5-.335 0-2.135-1.575-4-3.5zm.266-11.234L7.467 0 11.2 3.733l3.733 3.734H0l3.733-3.734z' fill='#{hex-color(lighten($ui-base-color, 8%))}'/></svg>")
     no-repeat right 8px center / auto 16px;
 }
+
+
 
 .status__wrapper-direct {
   background-color: rgba($ui-highlight-color, 0.1);

--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -452,6 +452,12 @@ html {
   box-shadow: none;
 }
 
+.card {
+  &__img {
+    background: darken($ui-base-color, 10%);
+  }
+}
+
 .mute-modal select {
   border: 1px solid lighten($ui-base-color, 8%);
   background: $simple-background-color

--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -23,7 +23,7 @@ html {
 // Change default background colors of columns
 .interaction-modal {
   background: $white;
-  border: 1px solid lighten($ui-base-color, 8%);
+  border: 1px solid var(--background-border-color);
 }
 
 .rules-list li::before {
@@ -75,8 +75,8 @@ html {
 }
 
 .getting-started .navigation-bar {
-  border-top: 1px solid lighten($ui-base-color, 8%);
-  border-bottom: 1px solid lighten($ui-base-color, 8%);
+  border-top: 1px solid var(--background-border-color);
+  border-bottom: 1px solid var(--background-border-color);
 
   @media screen and (max-width: $no-gap-breakpoint) {
     border-top: 0;
@@ -88,7 +88,7 @@ html {
 .setting-text,
 .report-dialog-modal__textarea,
 .audio-player {
-  border: 1px solid lighten($ui-base-color, 8%);
+  border: 1px solid var(--background-border-color);
 }
 
 .report-dialog-modal .dialog-option .poll__input {
@@ -174,7 +174,7 @@ html {
 .picture-in-picture__footer,
 .reactions-bar__item {
   background: $white;
-  border: 1px solid lighten($ui-base-color, 8%);
+  border: 1px solid var(--background-border-color);
 }
 
 .reactions-bar__item:hover,
@@ -216,7 +216,7 @@ html {
 
 .column-header__collapsible-inner {
   background: darken($ui-base-color, 4%);
-  border: 1px solid lighten($ui-base-color, 8%);
+  border: 1px solid var(--background-border-color);
   border-bottom: 0;
 }
 
@@ -258,7 +258,7 @@ html {
 
 .embed-modal .embed-modal__container .embed-modal__html {
   background: $white;
-  border: 1px solid lighten($ui-base-color, 8%);
+  border: 1px solid var(--background-border-color);
 
   &:focus {
     border-color: lighten($ui-base-color, 12%);
@@ -297,7 +297,7 @@ html {
 .directory__tag > a,
 .directory__tag > div {
   background: $white;
-  border: 1px solid lighten($ui-base-color, 8%);
+  border: 1px solid var(--background-border-color);
 
   @media screen and (max-width: $no-gap-breakpoint) {
     border-left: 0;
@@ -333,7 +333,7 @@ html {
 }
 
 .activity-stream {
-  border: 1px solid lighten($ui-base-color, 8%);
+  border: 1px solid var(--background-border-color);
 
   &--under-tabs {
     border-top: 0;
@@ -469,7 +469,7 @@ html {
 }
 
 .mute-modal select {
-  border: 1px solid lighten($ui-base-color, 8%);
+  border: 1px solid var(--background-border-color);
   background: $simple-background-color
     url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14.933 18.467' height='19.698' width='15.929'><path d='M3.467 14.967l-3.393-3.5H14.86l-3.392 3.5c-1.866 1.925-3.666 3.5-4 3.5-.335 0-2.135-1.575-4-3.5zm.266-11.234L7.467 0 11.2 3.733l3.733 3.734H0l3.733-3.734z' fill='#{hex-color(lighten($ui-base-color, 8%))}'/></svg>")
     no-repeat right 8px center / auto 16px;

--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -510,7 +510,7 @@ html {
 .search__popout,
 .emoji-mart-search input,
 .language-dropdown__dropdown .emoji-mart-search input,
-.strike-card,
+// .strike-card,
 .poll__option input[type='text'] {
   background: darken($ui-base-color, 10%);
 }
@@ -552,10 +552,18 @@ a.sparkline {
   &__tag {
     & > a {
       &:hover,
-      &:active,
-      &:focus {
+      &:focus,
+      &:active, {
         background: darken($ui-base-color, 10%);
       }
     }
+  }
+}
+
+.strike-entry {
+  &:hover,
+  &:focus,
+  &:active {
+    background: darken($ui-base-color, 10%);
   }
 }

--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -411,8 +411,8 @@ html {
 
   select {
     background: darken($ui-base-color, 10%)
-    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14.933 18.467' height='19.698' width='15.929'><path d='M3.467 14.967l-3.393-3.5H14.86l-3.392 3.5c-1.866 1.925-3.666 3.5-4 3.5-.335 0-2.135-1.575-4-3.5zm.266-11.234L7.467 0 11.2 3.733l3.733 3.734H0l3.733-3.734z' fill='#{hex-color(lighten($ui-base-color, 12%))}'/></svg>")
-    no-repeat right 8px center / auto 14px;
+      url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14.933 18.467' height='19.698' width='15.929'><path d='M3.467 14.967l-3.393-3.5H14.86l-3.392 3.5c-1.866 1.925-3.666 3.5-4 3.5-.335 0-2.135-1.575-4-3.5zm.266-11.234L7.467 0 11.2 3.733l3.733 3.734H0l3.733-3.734z' fill='#{hex-color(lighten($ui-base-color, 12%))}'/></svg>")
+      no-repeat right 8px center / auto 14px;
   }
 }
 
@@ -474,8 +474,6 @@ html {
     url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14.933 18.467' height='19.698' width='15.929'><path d='M3.467 14.967l-3.393-3.5H14.86l-3.392 3.5c-1.866 1.925-3.666 3.5-4 3.5-.335 0-2.135-1.575-4-3.5zm.266-11.234L7.467 0 11.2 3.733l3.733 3.734H0l3.733-3.734z' fill='#{hex-color(lighten($ui-base-color, 8%))}'/></svg>")
     no-repeat right 8px center / auto 16px;
 }
-
-
 
 .status__wrapper-direct {
   background-color: rgba($ui-highlight-color, 0.1);

--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -553,7 +553,7 @@ a.sparkline {
     & > a {
       &:hover,
       &:focus,
-      &:active, {
+      &:active {
         background: darken($ui-base-color, 10%);
       }
     }

--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -518,3 +518,11 @@ html {
 .inline-follow-suggestions__body__scroll-button__icon {
   color: $white;
 }
+
+a.sparkline {
+  &:hover,
+  &:focus,
+  &:active {
+    background: darken($ui-base-color, 10%);
+  }
+}

--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -456,6 +456,16 @@ html {
   &__img {
     background: darken($ui-base-color, 10%);
   }
+
+  & > a {
+    &:hover,
+    &:active,
+    &:focus {
+      .card__bar {
+        background: darken($ui-base-color, 10%);
+      }
+    }
+  }
 }
 
 .mute-modal select {
@@ -524,5 +534,17 @@ a.sparkline {
   &:focus,
   &:active {
     background: darken($ui-base-color, 10%);
+  }
+}
+
+.dashboard__counters {
+  & > div {
+    & > a {
+      &:hover,
+      &:focus,
+      &:active {
+        background: darken($ui-base-color, 10%);
+      }
+    }
   }
 }

--- a/app/javascript/styles/mastodon/accounts.scss
+++ b/app/javascript/styles/mastodon/accounts.scss
@@ -18,7 +18,7 @@
   &__img {
     height: 130px;
     position: relative;
-    background: darken($ui-base-color, 4%);
+    background: $ui-base-color;
     border: 1px solid lighten($ui-base-color, 8%);
     border-bottom: none;
 

--- a/app/javascript/styles/mastodon/accounts.scss
+++ b/app/javascript/styles/mastodon/accounts.scss
@@ -6,13 +6,13 @@
     overflow: hidden;
     border-radius: 4px;
 
-    // &:hover,
-    // &:active,
-    // &:focus {
-    //   .card__bar {
-    //     background: lighten($ui-base-color, 8%);
-    //   }
-    // }
+    &:hover,
+    &:active,
+    &:focus {
+      .card__bar {
+        background: $ui-base-color;
+      }
+    }
   }
 
   &__img {

--- a/app/javascript/styles/mastodon/accounts.scss
+++ b/app/javascript/styles/mastodon/accounts.scss
@@ -18,7 +18,9 @@
   &__img {
     height: 130px;
     position: relative;
-    background: darken($ui-base-color, 12%);
+    background: darken($ui-base-color, 4%);
+    border: 1px solid lighten($ui-base-color, 8%);
+    border-bottom: none;
 
     img {
       display: block;
@@ -41,6 +43,7 @@
     align-items: center;
     background: var(--background-color);
     border: 1px solid lighten($ui-base-color, 8%);
+    border-top: none;
 
     .avatar {
       flex: 0 0 auto;

--- a/app/javascript/styles/mastodon/accounts.scss
+++ b/app/javascript/styles/mastodon/accounts.scss
@@ -19,7 +19,7 @@
     height: 130px;
     position: relative;
     background: $ui-base-color;
-    border: 1px solid lighten($ui-base-color, 8%);
+    border: 1px solid var(--background-border-color);
     border-bottom: none;
 
     img {
@@ -42,7 +42,7 @@
     justify-content: flex-start;
     align-items: center;
     background: var(--background-color);
-    border: 1px solid lighten($ui-base-color, 8%);
+    border: 1px solid var(--background-border-color);
     border-top: none;
 
     .avatar {

--- a/app/javascript/styles/mastodon/accounts.scss
+++ b/app/javascript/styles/mastodon/accounts.scss
@@ -6,13 +6,13 @@
     overflow: hidden;
     border-radius: 4px;
 
-    &:hover,
-    &:active,
-    &:focus {
-      .card__bar {
-        background: lighten($ui-base-color, 8%);
-      }
-    }
+    // &:hover,
+    // &:active,
+    // &:focus {
+    //   .card__bar {
+    //     background: lighten($ui-base-color, 8%);
+    //   }
+    // }
   }
 
   &__img {
@@ -39,7 +39,8 @@
     display: flex;
     justify-content: flex-start;
     align-items: center;
-    background: lighten($ui-base-color, 4%);
+    background: var(--background-color);
+    border: 1px solid lighten($ui-base-color, 8%);
 
     .avatar {
       flex: 0 0 auto;

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -1695,7 +1695,7 @@ a.sparkline {
 
 .strike-card {
   padding: 15px;
-  border: 1px solid $gold-star;
+  border: 1px solid lighten($ui-base-color, 8%);
   border-radius: 4px;
   background: $ui-base-color;
   font-size: 15px;
@@ -1745,14 +1745,14 @@ a.sparkline {
 
   &__statuses-list {
     border-radius: 4px;
-    border: 1px solid darken($ui-base-color, 8%);
+    border: 1px solid lighten($ui-base-color, 8%);
     font-size: 13px;
     line-height: 18px;
     overflow: hidden;
 
     &__item {
       padding: 16px;
-      border-bottom: 1px solid darken($ui-base-color, 8%);
+      border-bottom: 1px solid lighten($ui-base-color, 8%);
 
       &:last-child {
         border-bottom: 0;

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -140,7 +140,7 @@ $content-width: 840px;
       }
 
       ul {
-        background: darken($ui-base-color, 4%);
+        background: var(--background-color);
         border-radius: 0 0 0 4px;
         margin: 0;
 

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -286,7 +286,7 @@ $content-width: 840px;
       color: $darker-text-color;
       padding-bottom: 8px;
       margin-bottom: 8px;
-      border-bottom: 1px solid lighten($ui-base-color, 8%);
+      border-bottom: 1px solid var(--background-border-color);
     }
 
     h6 {
@@ -671,9 +671,9 @@ body,
   padding: 15px;
   padding-inline-start: 15px * 2 + 40px;
   background: var(--background-color);
-  border-right: 1px solid lighten($ui-base-color, 8%);
-  border-left: 1px solid lighten($ui-base-color, 8%);
-  border-bottom: 1px solid lighten($ui-base-color, 8%);
+  border-right: 1px solid var(--background-border-color);
+  border-left: 1px solid var(--background-border-color);
+  border-bottom: 1px solid var(--background-border-color);
   position: relative;
   text-decoration: none;
   color: $darker-text-color;
@@ -682,13 +682,13 @@ body,
   &:first-child {
     border-top-left-radius: 4px;
     border-top-right-radius: 4px;
-    border-top: 1px solid lighten($ui-base-color, 8%);
+    border-top: 1px solid var(--background-border-color);
   }
 
   &:last-child {
     border-bottom-left-radius: 4px;
     border-bottom-right-radius: 4px;
-    border-bottom: 1px solid lighten($ui-base-color, 8%);
+    border-bottom: 1px solid var(--background-border-color);
   }
 
   &__avatar {
@@ -734,7 +734,7 @@ body,
   padding: 15px;
   padding-inline-start: 15px * 2 + 40px;
   background: var(--background-color);
-  border: 1px solid lighten($ui-base-color, 8%);
+  border: 1px solid var(--background-border-color);
   border-radius: 4px;
   position: relative;
   text-decoration: none;
@@ -860,7 +860,7 @@ a.name-tag,
 
 .report-card {
   background: var(--background-color);
-  border: 1px solid lighten($ui-base-color, 8%);
+  border: 1px solid var(--background-border-color);
   border-radius: 4px;
   margin-bottom: 20px;
 
@@ -981,14 +981,14 @@ a.name-tag,
   .account__header__fields,
   .account__header__content {
     background: var(--background-color);
-    border: 1px solid lighten($ui-base-color, 8%);
+    border: 1px solid var(--background-border-color);
     border-radius: 4px;
     height: 100%;
   }
 
   .account__header__fields {
     margin: 0;
-    border: 1px solid lighten($ui-base-color, 8%);
+    border: 1px solid var(--background-border-color);
 
     a {
       color: $highlight-text-color;
@@ -1018,7 +1018,7 @@ a.name-tag,
 .filters-list__item {
   padding: 15px 0;
   background: var(--background-color);
-  border: 1px solid lighten($ui-base-color, 8%);
+  border: 1px solid var(--background-border-color);
   border-radius: 4px;
   margin-top: 15px;
 }
@@ -1029,13 +1029,13 @@ a.name-tag,
 
 .announcements-list,
 .filters-list {
-  border: 1px solid lighten($ui-base-color, 8%);
+  border: 1px solid var(--background-border-color);
   border-radius: 4px;
   border-bottom: none;
 
   &__item {
     padding: 15px 0;
-    border-bottom: 1px solid lighten($ui-base-color, 8%);
+    border-bottom: 1px solid var(--background-border-color);
 
     &__title {
       padding: 0 15px;
@@ -1189,7 +1189,7 @@ a.name-tag,
   text-decoration: none;
   background: var(--background-color);
   border-radius: 4px;
-  border: 1px solid lighten($ui-base-color, 8%);
+  border: 1px solid var(--background-border-color);
   padding: 0;
   position: relative;
   padding-bottom: 55px + 20px;
@@ -1381,7 +1381,7 @@ a.sparkline {
 
   &__details {
     &__item {
-      border-bottom: 1px solid lighten($ui-base-color, 8%);
+      border-bottom: 1px solid var(--background-border-color);
       padding: 15px 0;
 
       &:last-child {
@@ -1412,7 +1412,7 @@ a.sparkline {
 
 .account-card {
   border-radius: 4px;
-  border: 1px solid lighten($ui-base-color, 8%);
+  border: 1px solid var(--background-border-color);
   position: relative;
 
   &__warning-badge {
@@ -1579,7 +1579,7 @@ a.sparkline {
     position: relative;
     padding: 15px;
     padding-inline-start: 15px * 2 + 40px;
-    border: 1px solid lighten($ui-base-color, 8%);
+    border: 1px solid var(--background-border-color);
 
     &:first-child {
       border-top-left-radius: 4px;
@@ -1742,7 +1742,7 @@ a.sparkline {
   color: $primary-text-color;
   box-sizing: border-box;
   min-height: 100%;
-  padding-left: 0;
+  border: 1px solid var(--background-border-color);
 
   a {
     color: $highlight-text-color;
@@ -1783,14 +1783,14 @@ a.sparkline {
 
   &__statuses-list {
     border-radius: 4px;
-    border: 1px solid lighten($ui-base-color, 8%);
+    border: 1px solid var(--background-border-color);
     font-size: 13px;
     line-height: 18px;
     overflow: hidden;
 
     &__item {
       padding: 16px;
-      border-bottom: 1px solid lighten($ui-base-color, 8%);
+      border-bottom: 1px solid var(--background-border-color);
 
       &:last-child {
         border-bottom: 0;

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -906,7 +906,7 @@ a.name-tag,
     &__item {
       display: flex;
       justify-content: flex-start;
-      border-top: 1px solid darken($ui-base-color, 8%);
+      border-top: 1px solid var(--background-border-color);
 
       &__reported-by,
       &__assigned {

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -26,7 +26,7 @@ $content-width: 840px;
     &__inner {
       display: flex;
       justify-content: flex-end;
-      background: $ui-base-color;
+      background: var(--background-color);
       height: 100%;
     }
   }
@@ -38,7 +38,7 @@ $content-width: 840px;
 
     &__toggle {
       display: none;
-      background: darken($ui-base-color, 4%);
+      background: var(--background-color);
       border-bottom: 1px solid lighten($ui-base-color, 4%);
       align-items: center;
 
@@ -103,7 +103,6 @@ $content-width: 840px;
 
     ul {
       list-style: none;
-      border-radius: 4px 0 0 4px;
       overflow: hidden;
       margin-bottom: 20px;
 
@@ -112,13 +111,13 @@ $content-width: 840px;
       }
 
       a {
+        font-size: 14px;
         display: block;
         padding: 15px;
         color: $darker-text-color;
         text-decoration: none;
         transition: all 200ms linear;
         transition-property: color, background-color;
-        border-radius: 4px 0 0 4px;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
@@ -129,19 +128,13 @@ $content-width: 840px;
 
         &:hover {
           color: $primary-text-color;
-          background-color: darken($ui-base-color, 5%);
           transition: all 100ms linear;
           transition-property: color, background-color;
-        }
-
-        &.selected {
-          border-radius: 4px 0 0;
         }
       }
 
       ul {
         background: var(--background-color);
-        border-radius: 0 0 0 4px;
         margin: 0;
 
         a {
@@ -156,15 +149,9 @@ $content-width: 840px;
       }
 
       .simple-navigation-active-leaf a {
-        color: $primary-text-color;
-        background-color: $ui-highlight-color;
+        color: $highlight-text-color;
         border-bottom: 0;
-        border-radius: 0;
       }
-    }
-
-    & > ul > .simple-navigation-active-leaf a {
-      border-radius: 4px 0 0 4px;
     }
   }
 
@@ -410,14 +397,15 @@ $content-width: 840px;
           inset-inline-start: 0;
           bottom: 0;
           overflow-y: auto;
-          background: $ui-base-color;
+          background: var(--background-color);
         }
       }
 
       ul a,
       ul ul a {
+        font-size: 16px;
         border-radius: 0;
-        border-bottom: 1px solid lighten($ui-base-color, 4%);
+        // border-bottom: 1px solid lighten($ui-base-color, 4%);
         transition: none;
 
         &:hover {

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -671,8 +671,9 @@ body,
   line-height: 20px;
   padding: 15px;
   padding-inline-start: 15px * 2 + 40px;
-  background: $ui-base-color;
-  border-bottom: 1px solid darken($ui-base-color, 8%);
+  background: var(--background-color);
+  border: 1px solid lighten($ui-base-color, 8%);
+  border-bottom: none;
   position: relative;
   text-decoration: none;
   color: $darker-text-color;
@@ -686,13 +687,7 @@ body,
   &:last-child {
     border-bottom-left-radius: 4px;
     border-bottom-right-radius: 4px;
-    border-bottom: 0;
-  }
-
-  &:hover,
-  &:focus,
-  &:active {
-    background: lighten($ui-base-color, 4%);
+    border-bottom: 1px solid lighten($ui-base-color, 8%);
   }
 
   &__avatar {
@@ -738,6 +733,9 @@ a.inline-name-tag,
 .inline-name-tag {
   text-decoration: none;
   color: $secondary-text-color;
+  &:hover {
+    color: $highlight-text-color;
+  }
 
   .username {
     font-weight: 500;
@@ -893,7 +891,7 @@ a.name-tag,
         max-width: calc(100% - 300px);
 
         &__icon {
-          color: $dark-text-color;
+          // color: $dark-text-color;
           margin-inline-end: 4px;
           font-weight: 500;
         }
@@ -906,6 +904,9 @@ a.name-tag,
         padding: 15px;
         text-decoration: none;
         color: $darker-text-color;
+        &:hover {
+          color: $highlight-text-color;
+        }
       }
     }
   }

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -1736,9 +1736,6 @@ a.sparkline {
 
 .strike-card {
   padding: 15px;
-  // border: 1px solid lighten($ui-base-color, 8%);
-  // border-radius: 4px;
-  // background: $ui-base-color;
   font-size: 15px;
   line-height: 20px;
   word-wrap: break-word;
@@ -1746,6 +1743,7 @@ a.sparkline {
   color: $primary-text-color;
   box-sizing: border-box;
   min-height: 100%;
+  padding-left: 0;
 
   a {
     color: $highlight-text-color;

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -1146,8 +1146,9 @@ a.name-tag,
 .sparkline {
   display: block;
   text-decoration: none;
-  background: lighten($ui-base-color, 4%);
+  background: var(--background-color);
   border-radius: 4px;
+  border: 1px solid lighten($ui-base-color, 8%);
   padding: 0;
   position: relative;
   padding-bottom: 55px + 20px;
@@ -1219,12 +1220,12 @@ a.sparkline {
   &:hover,
   &:focus,
   &:active {
-    background: lighten($ui-base-color, 6%);
+    background: $ui-base-color;
   }
 }
 
 .skeleton {
-  background-color: lighten($ui-base-color, 8%);
+  background-color: var(--background-color);
   background-image: linear-gradient(
     90deg,
     lighten($ui-base-color, 8%),

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -671,8 +671,9 @@ body,
   padding: 15px;
   padding-inline-start: 15px * 2 + 40px;
   background: var(--background-color);
-  border: 1px solid lighten($ui-base-color, 8%);
-  border-bottom: none;
+  border-right: 1px solid lighten($ui-base-color, 8%);
+  border-left: 1px solid lighten($ui-base-color, 8%);
+  border-bottom: 1px solid lighten($ui-base-color, 8%);
   position: relative;
   text-decoration: none;
   color: $darker-text-color;
@@ -681,6 +682,7 @@ body,
   &:first-child {
     border-top-left-radius: 4px;
     border-top-right-radius: 4px;
+    border-top: 1px solid lighten($ui-base-color, 8%);
   }
 
   &:last-child {
@@ -992,7 +994,6 @@ a.name-tag,
 
   &__item {
     padding: 15px 0;
-    background: var(--background-color);
     border-bottom: 1px solid lighten($ui-base-color, 8%);
 
     &__title {

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -940,14 +940,15 @@ a.name-tag,
 
   .account__header__fields,
   .account__header__content {
-    background: lighten($ui-base-color, 8%);
+    background: var(--background-color);
+    border: 1px solid lighten($ui-base-color, 8%);
     border-radius: 4px;
     height: 100%;
   }
 
   .account__header__fields {
     margin: 0;
-    border: 0;
+    border: 1px solid lighten($ui-base-color, 8%);
 
     a {
       color: $highlight-text-color;

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -819,6 +819,7 @@ a.name-tag,
 
 .report-card {
   background: var(--background-color);
+  border: 1px solid lighten($ui-base-color, 8%);
   border-radius: 4px;
   margin-bottom: 20px;
 
@@ -830,7 +831,7 @@ a.name-tag,
 
     .account {
       padding: 0;
-      border: 0;
+
 
       &__avatar-wrapper {
         margin-inline-start: 0;
@@ -867,9 +868,9 @@ a.name-tag,
       justify-content: flex-start;
       border-top: 1px solid darken($ui-base-color, 8%);
 
-      &:hover {
-        background: lighten($ui-base-color, 2%);
-      }
+      // &:hover {
+      //   background: lighten($ui-base-color, 2%);
+      // }
 
       &__reported-by,
       &__assigned {
@@ -1306,16 +1307,12 @@ a.sparkline {
 
 .report-reason-selector {
   border-radius: 4px;
-  background: $ui-base-color;
+  background: var(--background-color);
   margin-bottom: 20px;
 
   &__category {
     cursor: pointer;
     border-bottom: 1px solid darken($ui-base-color, 8%);
-
-    &:last-child {
-      border-bottom: 0;
-    }
 
     &__label {
       padding: 15px;

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -865,7 +865,7 @@ a.name-tag,
     &__item {
       display: flex;
       justify-content: flex-start;
-      border-top: 1px solid darken($ui-base-color, 4%);
+      border-top: 1px solid darken($ui-base-color, 8%);
 
       &:hover {
         background: lighten($ui-base-color, 2%);
@@ -977,7 +977,7 @@ a.name-tag,
 .filters-list__item {
   padding: 15px 0;
   background: var(--background-color);
-  border: 1px solid lighten($ui-base-color, 4%);
+  border: 1px solid lighten($ui-base-color, 8%);
   border-radius: 4px;
   margin-top: 15px;
 }
@@ -988,13 +988,13 @@ a.name-tag,
 
 .announcements-list,
 .filters-list {
-  border: 1px solid lighten($ui-base-color, 4%);
+  border: 1px solid lighten($ui-base-color, 8%);
   border-radius: 4px;
 
   &__item {
     padding: 15px 0;
     background: var(--background-color);
-    border-bottom: 1px solid lighten($ui-base-color, 4%);
+    border-bottom: 1px solid lighten($ui-base-color, 8%);
 
     &__title {
       padding: 0 15px;

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -1533,7 +1533,7 @@ a.sparkline {
   margin-bottom: 20px;
 
   &__item {
-    background: $ui-base-color;
+    background: var(--background-color);
     position: relative;
     padding: 15px;
     padding-inline-start: 15px * 2 + 40px;
@@ -1548,10 +1548,6 @@ a.sparkline {
       border-bottom-left-radius: 4px;
       border-bottom-right-radius: 4px;
       border-bottom: 0;
-    }
-
-    &:hover {
-      background-color: lighten($ui-base-color, 4%);
     }
 
     &__avatar {
@@ -1698,6 +1694,7 @@ a.sparkline {
 
 .strike-card {
   padding: 15px;
+  border: 1px solid $gold-star;
   border-radius: 4px;
   background: $ui-base-color;
   font-size: 15px;
@@ -1754,7 +1751,6 @@ a.sparkline {
 
     &__item {
       padding: 16px;
-      background: lighten($ui-base-color, 2%);
       border-bottom: 1px solid darken($ui-base-color, 8%);
 
       &:last-child {

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -1,7 +1,7 @@
 @use 'sass:math';
 
 $no-columns-breakpoint: 600px;
-$sidebar-width: 240px;
+$sidebar-width: 300px;
 $content-width: 840px;
 
 .admin-wrapper {
@@ -976,7 +976,7 @@ a.name-tag,
 .applications-list__item,
 .filters-list__item {
   padding: 15px 0;
-  background: $ui-base-color;
+  background: var(--background-color);
   border: 1px solid lighten($ui-base-color, 4%);
   border-radius: 4px;
   margin-top: 15px;
@@ -993,7 +993,7 @@ a.name-tag,
 
   &__item {
     padding: 15px 0;
-    background: $ui-base-color;
+    background: var(--background-color);
     border-bottom: 1px solid lighten($ui-base-color, 4%);
 
     &__title {

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -405,7 +405,6 @@ $content-width: 840px;
       ul ul a {
         font-size: 16px;
         border-radius: 0;
-        // border-bottom: 1px solid lighten($ui-base-color, 4%);
         transition: none;
 
         &:hover {
@@ -733,6 +732,7 @@ a.inline-name-tag,
 .inline-name-tag {
   text-decoration: none;
   color: $secondary-text-color;
+
   &:hover {
     color: $highlight-text-color;
   }
@@ -830,7 +830,6 @@ a.name-tag,
     .account {
       padding: 0;
 
-
       &__avatar-wrapper {
         margin-inline-start: 0;
       }
@@ -866,10 +865,6 @@ a.name-tag,
       justify-content: flex-start;
       border-top: 1px solid darken($ui-base-color, 8%);
 
-      // &:hover {
-      //   background: lighten($ui-base-color, 2%);
-      // }
-
       &__reported-by,
       &__assigned {
         padding: 15px;
@@ -891,7 +886,6 @@ a.name-tag,
         max-width: calc(100% - 300px);
 
         &__icon {
-          // color: $dark-text-color;
           margin-inline-end: 4px;
           font-weight: 500;
         }
@@ -904,6 +898,7 @@ a.name-tag,
         padding: 15px;
         text-decoration: none;
         color: $darker-text-color;
+
         &:hover {
           color: $highlight-text-color;
         }
@@ -1008,6 +1003,7 @@ a.name-tag,
       color: $secondary-text-color;
       text-decoration: none;
       margin-bottom: 10px;
+
       &:hover {
         color: $highlight-text-color;
       }

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -1050,10 +1050,6 @@ a.name-tag,
     &__permissions {
       margin-top: 10px;
     }
-
-    &:last-child {
-      border-bottom: 0;
-    }
   }
 }
 

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -1461,7 +1461,6 @@ a.sparkline {
       position: absolute;
       bottom: 0;
       inset-inline-end: 15px;
-      background: linear-gradient(to left, $ui-base-color, transparent);
       pointer-events: none;
     }
 

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -728,6 +728,47 @@ body,
   }
 }
 
+.strike-entry {
+  display: block;
+  line-height: 20px;
+  padding: 15px;
+  padding-inline-start: 15px * 2 + 40px;
+  background: var(--background-color);
+  border: 1px solid lighten($ui-base-color, 8%);
+  border-radius: 4px;
+  position: relative;
+  text-decoration: none;
+  color: $darker-text-color;
+  font-size: 14px;
+  margin-bottom: 15px;
+
+  &__avatar {
+    position: absolute;
+    inset-inline-start: 15px;
+    top: 15px;
+
+    .avatar {
+      border-radius: 4px;
+      width: 40px;
+      height: 40px;
+    }
+  }
+
+  &__title {
+    word-wrap: break-word;
+  }
+
+  &__timestamp {
+    color: $dark-text-color;
+  }
+
+  &:hover,
+  &:focus,
+  &:active {
+    background: $ui-base-color;
+  }
+}
+
 a.name-tag,
 .name-tag,
 a.inline-name-tag,
@@ -1695,9 +1736,9 @@ a.sparkline {
 
 .strike-card {
   padding: 15px;
-  border: 1px solid lighten($ui-base-color, 8%);
-  border-radius: 4px;
-  background: $ui-base-color;
+  // border: 1px solid lighten($ui-base-color, 8%);
+  // border-radius: 4px;
+  // background: $ui-base-color;
   font-size: 15px;
   line-height: 20px;
   word-wrap: break-word;

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -1579,7 +1579,7 @@ a.sparkline {
     position: relative;
     padding: 15px;
     padding-inline-start: 15px * 2 + 40px;
-    border-bottom: 1px solid darken($ui-base-color, 8%);
+    border: 1px solid lighten($ui-base-color, 8%);
 
     &:first-child {
       border-top-left-radius: 4px;
@@ -1589,7 +1589,6 @@ a.sparkline {
     &:last-child {
       border-bottom-left-radius: 4px;
       border-bottom-right-radius: 4px;
-      border-bottom: 0;
     }
 
     &__avatar {

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -988,6 +988,7 @@ a.name-tag,
 .filters-list {
   border: 1px solid lighten($ui-base-color, 8%);
   border-radius: 4px;
+  border-bottom: none;
 
   &__item {
     padding: 15px 0;

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -1743,6 +1743,7 @@ a.sparkline {
   box-sizing: border-box;
   min-height: 100%;
   border: 1px solid var(--background-border-color);
+  border-radius: 4px;
 
   a {
     color: $highlight-text-color;

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -818,7 +818,7 @@ a.name-tag,
 }
 
 .report-card {
-  background: $ui-base-color;
+  background: var(--background-color);
   border-radius: 4px;
   margin-bottom: 20px;
 
@@ -1097,7 +1097,7 @@ a.name-tag,
 
   &__table {
     &__number {
-      color: $secondary-text-color;
+      color: var(--background-color);
       padding: 10px;
     }
 
@@ -1124,7 +1124,7 @@ a.name-tag,
 
     &__box {
       box-sizing: border-box;
-      background: $ui-highlight-color;
+      background: var(--background-color);
       padding: 10px;
       font-weight: 500;
       color: $primary-text-color;

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -1666,7 +1666,6 @@ a.sparkline {
 }
 
 .report-actions {
-
   &__item {
     display: flex;
     align-items: center;

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -850,7 +850,7 @@ a.name-tag,
         &:focus,
         &:hover,
         &:active {
-          color: lighten($darker-text-color, 8%);
+          color: $highlight-text-color;
         }
       }
 

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -1008,6 +1008,9 @@ a.name-tag,
       color: $secondary-text-color;
       text-decoration: none;
       margin-bottom: 10px;
+      &:hover {
+        color: $highlight-text-color;
+      }
 
       .account-role {
         vertical-align: middle;

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -359,7 +359,7 @@ $content-width: 840px;
       width: 100%;
       height: 0;
       border: 0;
-      border-bottom: 1px solid rgba($ui-base-lighter-color, 0.6);
+      border-bottom: 1px solid var(--background-border-color);
       margin: 20px 0;
 
       &.spacer {
@@ -1666,13 +1666,11 @@ a.sparkline {
 }
 
 .report-actions {
-  border: 1px solid darken($ui-base-color, 8%);
 
   &__item {
     display: flex;
     align-items: center;
     line-height: 18px;
-    border-bottom: 1px solid darken($ui-base-color, 8%);
 
     &:last-child {
       border-bottom: 0;

--- a/app/javascript/styles/mastodon/basics.scss
+++ b/app/javascript/styles/mastodon/basics.scss
@@ -122,7 +122,7 @@ body {
   }
 
   &.admin {
-    background: darken($ui-base-color, 4%);
+    background: var(--background-color);
     padding: 0;
   }
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1794,7 +1794,6 @@ body > [data-popper-placement] {
 
 .account {
   padding: 16px;
-  border-bottom: 1px solid var(--background-border-color);
 
   .account__display-name {
     flex: 1 1 auto;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -521,7 +521,7 @@ body > [data-popper-placement] {
     gap: 16px;
     flex: 0 1 auto;
     border-radius: 4px;
-    border: 1px solid lighten($ui-base-color, 8%);
+    border: 1px solid var(--background-border-color);
     transition: border-color 300ms linear;
     min-height: 0;
     position: relative;
@@ -587,7 +587,7 @@ body > [data-popper-placement] {
 
     .autosuggest-input {
       flex: 1 1 auto;
-      border-bottom: 1px solid lighten($ui-base-color, 8%);
+      border-bottom: 1px solid var(--background-border-color);
     }
   }
 
@@ -1452,7 +1452,7 @@ body > [data-popper-placement] {
   }
 
   &--first-in-thread {
-    border-top: 1px solid lighten($ui-base-color, 8%);
+    border-top: 1px solid var(--background-border-color);
   }
 
   &__line {
@@ -3324,7 +3324,7 @@ $ui-header-logo-wordmark-width: 99px;
 .copy-paste-text {
   background: lighten($ui-base-color, 4%);
   border-radius: 8px;
-  border: 1px solid lighten($ui-base-color, 8%);
+  border: 1px solid var(--background-border-color);
   padding: 16px;
   color: $primary-text-color;
   font-size: 15px;
@@ -4727,7 +4727,7 @@ a.status-card {
 
   section {
     padding: 16px;
-    border-bottom: 1px solid lighten($ui-base-color, 8%);
+    border-bottom: 1px solid var(--background-border-color);
 
     &:last-child {
       border-bottom: 0;
@@ -5315,7 +5315,7 @@ a.status-card {
       input {
         padding: 8px 12px;
         background: $ui-base-color;
-        border: 1px solid lighten($ui-base-color, 8%);
+        border: 1px solid var(--background-border-color);
         color: $darker-text-color;
 
         @media screen and (width <= 600px) {
@@ -5401,7 +5401,7 @@ a.status-card {
     margin-top: -2px;
     width: 100%;
     background: $ui-base-color;
-    border: 1px solid lighten($ui-base-color, 8%);
+    border: 1px solid var(--background-border-color);
     border-radius: 0 0 4px 4px;
     box-shadow: var(--dropdown-shadow);
     z-index: 99;
@@ -8788,13 +8788,13 @@ noscript {
   }
 
   .search__input {
-    border: 1px solid lighten($ui-base-color, 8%);
+    border: 1px solid var(--background-border-color);
     padding: 10px;
     padding-inline-end: 30px;
   }
 
   .search__popout {
-    border: 1px solid lighten($ui-base-color, 8%);
+    border: 1px solid var(--background-border-color);
   }
 
   .search .icon {
@@ -9113,7 +9113,7 @@ noscript {
     &__input {
       @include search-input;
 
-      border: 1px solid lighten($ui-base-color, 8%);
+      border: 1px solid var(--background-border-color);
       padding: 4px 6px;
       color: $primary-text-color;
       font-size: 16px;
@@ -9148,7 +9148,7 @@ noscript {
       margin-top: -1px;
       padding-top: 5px;
       padding-bottom: 5px;
-      border: 1px solid lighten($ui-base-color, 8%);
+      border: 1px solid var(--background-border-color);
     }
 
     &.focused &__input {

--- a/app/javascript/styles/mastodon/containers.scss
+++ b/app/javascript/styles/mastodon/containers.scss
@@ -63,7 +63,7 @@
   padding: 20px 0;
   margin-top: 40px;
   margin-bottom: 10px;
-  border-bottom: 1px solid lighten($ui-base-color, 8%);
+  border-bottom: 1px solid var(--background-border-color);
 
   @media screen and (width <= 440px) {
     width: 100%;

--- a/app/javascript/styles/mastodon/dashboard.scss
+++ b/app/javascript/styles/mastodon/dashboard.scss
@@ -13,8 +13,9 @@
     & > div,
     & > a {
       padding: 20px;
-      background: lighten($ui-base-color, 4%);
+      background: var(--background-color);
       border-radius: 4px;
+      border: 1px solid lighten($ui-base-color, 8%);
       box-sizing: border-box;
       height: 100%;
     }
@@ -24,11 +25,11 @@
       color: inherit;
       display: block;
 
-      &:hover,
-      &:focus,
-      &:active {
-        background: lighten($ui-base-color, 8%);
-      }
+      // &:hover,
+      // &:focus,
+      // &:active {
+      //   background: lighten($ui-base-color, 8%);
+      // }
     }
   }
 

--- a/app/javascript/styles/mastodon/dashboard.scss
+++ b/app/javascript/styles/mastodon/dashboard.scss
@@ -15,7 +15,7 @@
       padding: 20px;
       background: var(--background-color);
       border-radius: 4px;
-      border: 1px solid lighten($ui-base-color, 8%);
+      border: 1px solid var(--background-border-color);
       box-sizing: border-box;
       height: 100%;
     }

--- a/app/javascript/styles/mastodon/dashboard.scss
+++ b/app/javascript/styles/mastodon/dashboard.scss
@@ -25,11 +25,11 @@
       color: inherit;
       display: block;
 
-      // &:hover,
-      // &:focus,
-      // &:active {
-      //   background: lighten($ui-base-color, 8%);
-      // }
+      &:hover,
+      &:focus,
+      &:active {
+        background: $ui-base-color;
+      }
     }
   }
 

--- a/app/javascript/styles/mastodon/emoji_picker.scss
+++ b/app/javascript/styles/mastodon/emoji_picker.scss
@@ -105,7 +105,7 @@
     width: 100%;
     background: $ui-base-color;
     color: $darker-text-color;
-    border: 1px solid lighten($ui-base-color, 8%);
+    border: 1px solid var(--background-border-color);
     border-radius: 4px;
 
     &::-moz-focus-inner {

--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -438,7 +438,7 @@ code {
     resize: vertical;
     background: $ui-base-color;
     border: 1px solid lighten($ui-base-color, 8%);
-    border-radius: 8px;
+    border-radius: 4px;
     padding: 10px 16px;
 
     &::placeholder {

--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -436,8 +436,8 @@ code {
     outline: 0;
     font-family: inherit;
     resize: vertical;
-    background: darken($ui-base-color, 10%);
-    border: 1px solid darken($ui-base-color, 10%);
+    background: $ui-base-color;
+    border: 1px solid lighten($ui-base-color, 8%);
     border-radius: 8px;
     padding: 10px 16px;
 
@@ -583,10 +583,10 @@ code {
     outline: 0;
     font-family: inherit;
     resize: vertical;
-    background: darken($ui-base-color, 10%)
+    background: $ui-base-color
       url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14.933 18.467' height='19.698' width='15.929'><path d='M3.467 14.967l-3.393-3.5H14.86l-3.392 3.5c-1.866 1.925-3.666 3.5-4 3.5-.335 0-2.135-1.575-4-3.5zm.266-11.234L7.467 0 11.2 3.733l3.733 3.734H0l3.733-3.734z' fill='#{hex-color(lighten($ui-base-color, 12%))}'/></svg>")
       no-repeat right 8px center / auto 16px;
-    border: 1px solid darken($ui-base-color, 14%);
+    border: 1px solid lighten($ui-base-color, 8%);
     border-radius: 4px;
     padding-inline-start: 10px;
     padding-inline-end: 30px;

--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -442,7 +442,8 @@ code {
     padding: 10px 16px;
 
     &::placeholder {
-      color: lighten($darker-text-color, 4%);
+      color: $dark-text-color;
+      opacity: 1;
     }
 
     &:invalid {
@@ -453,10 +454,10 @@ code {
       border-color: $valid-value-color;
     }
 
-    &:active,
-    &:focus {
-      border-color: $highlight-text-color;
-    }
+    // &:active,
+    // &:focus {
+    //   border-color: $highlight-text-color;
+    // }
 
     @media screen and (width <= 600px) {
       font-size: 16px;

--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -437,7 +437,7 @@ code {
     font-family: inherit;
     resize: vertical;
     background: $ui-base-color;
-    border: 1px solid lighten($ui-base-color, 8%);
+    border: 1px solid var(--background-border-color);
     border-radius: 4px;
     padding: 10px 16px;
 
@@ -582,7 +582,7 @@ code {
     background: $ui-base-color
       url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14.933 18.467' height='19.698' width='15.929'><path d='M3.467 14.967l-3.393-3.5H14.86l-3.392 3.5c-1.866 1.925-3.666 3.5-4 3.5-.335 0-2.135-1.575-4-3.5zm.266-11.234L7.467 0 11.2 3.733l3.733 3.734H0l3.733-3.734z' fill='#{hex-color(lighten($ui-base-color, 12%))}'/></svg>")
       no-repeat right 8px center / auto 14px;
-    border: 1px solid lighten($ui-base-color, 8%);
+    border: 1px solid var(--background-border-color);
     border-radius: 4px;
     padding-inline-start: 10px;
     padding-inline-end: 30px;
@@ -1336,7 +1336,7 @@ code {
 
     &__toggle > div {
       display: flex;
-      border-inline-start: 1px solid lighten($ui-base-color, 8%);
+      border-inline-start: 1px solid var(--background-border-color);
       padding-inline-start: 16px;
     }
   }

--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -644,8 +644,9 @@ code {
 }
 
 .flash-message {
-  background: lighten($ui-base-color, 8%);
-  color: $darker-text-color;
+  background: var(--background-color);
+  color: $highlight-text-color;
+  border: 1px solid $ui-highlight-color;
   border-radius: 4px;
   padding: 15px 10px;
   margin-bottom: 30px;

--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -414,7 +414,7 @@ code {
   }
 
   .input.static .label_input__wrapper {
-    font-size: 16px;
+    font-size: 14px;
     padding: 10px;
     border: 1px solid $dark-text-color;
     border-radius: 4px;
@@ -453,11 +453,6 @@ code {
     &:required:valid {
       border-color: $valid-value-color;
     }
-
-    // &:active,
-    // &:focus {
-    //   border-color: $highlight-text-color;
-    // }
 
     @media screen and (width <= 600px) {
       font-size: 16px;
@@ -577,7 +572,7 @@ code {
   select {
     appearance: none;
     box-sizing: border-box;
-    font-size: 16px;
+    font-size: 14px;
     color: $primary-text-color;
     display: block;
     width: 100%;
@@ -586,12 +581,16 @@ code {
     resize: vertical;
     background: $ui-base-color
       url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14.933 18.467' height='19.698' width='15.929'><path d='M3.467 14.967l-3.393-3.5H14.86l-3.392 3.5c-1.866 1.925-3.666 3.5-4 3.5-.335 0-2.135-1.575-4-3.5zm.266-11.234L7.467 0 11.2 3.733l3.733 3.734H0l3.733-3.734z' fill='#{hex-color(lighten($ui-base-color, 12%))}'/></svg>")
-      no-repeat right 8px center / auto 16px;
+      no-repeat right 8px center / auto 14px;
     border: 1px solid lighten($ui-base-color, 8%);
     border-radius: 4px;
     padding-inline-start: 10px;
     padding-inline-end: 30px;
     height: 41px;
+
+    @media screen and (width <= 600px) {
+      font-size: 16px;
+    }
   }
 
   h4 {

--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -646,7 +646,7 @@ code {
 .flash-message {
   background: var(--background-color);
   color: $highlight-text-color;
-  border: 1px solid $ui-highlight-color;
+  border: 1px solid $highlight-text-color;
   border-radius: 4px;
   padding: 15px 10px;
   margin-bottom: 30px;

--- a/app/javascript/styles/mastodon/rtl.scss
+++ b/app/javascript/styles/mastodon/rtl.scss
@@ -46,7 +46,7 @@ body.rtl {
   }
 
   .simple_form select {
-    background: darken($ui-base-color, 10%)
+    background: $ui-base-color
       url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14.933 18.467' height='19.698' width='15.929'><path d='M3.467 14.967l-3.393-3.5H14.86l-3.392 3.5c-1.866 1.925-3.666 3.5-4 3.5-.335 0-2.135-1.575-4-3.5zm.266-11.234L7.467 0 11.2 3.733l3.733 3.734H0l3.733-3.734z' fill='#{hex-color(lighten($ui-base-color, 12%))}'/></svg>")
       no-repeat left 8px center / auto 16px;
   }

--- a/app/javascript/styles/mastodon/tables.scss
+++ b/app/javascript/styles/mastodon/tables.scss
@@ -9,7 +9,7 @@
     padding: 8px;
     line-height: 18px;
     vertical-align: top;
-    border-bottom: 1px solid $ui-base-color;
+    border-bottom: 1px solid var(--background-border-color);
     text-align: start;
     background: var(--background-color);
 

--- a/app/javascript/styles/mastodon/tables.scss
+++ b/app/javascript/styles/mastodon/tables.scss
@@ -136,7 +136,7 @@ a.table-action-link {
   font-weight: 500;
 
   &:hover {
-    color: $primary-text-color;
+    color: $highlight-text-color;
   }
 
   i.fa {

--- a/app/javascript/styles/mastodon/tables.scss
+++ b/app/javascript/styles/mastodon/tables.scss
@@ -3,13 +3,15 @@
   max-width: 100%;
   border-spacing: 0;
   border-collapse: collapse;
+  // border: 1px solid $ui-base-color;
+  // border-radius: 4px;
 
   th,
   td {
     padding: 8px;
     line-height: 18px;
     vertical-align: top;
-    border-top: 1px solid $ui-base-color;
+    border-bottom: 1px solid $ui-base-color;
     text-align: start;
     background: var(--background-color);
 
@@ -21,8 +23,8 @@
 
   & > thead > tr > th {
     vertical-align: bottom;
-    border-bottom: 2px solid $ui-base-color;
-    border-top: 0;
+    // border-bottom: 2px solid $ui-base-color;
+    // border-top: 0;
     font-weight: 500;
   }
 
@@ -34,13 +36,17 @@
   & > tbody > tr:nth-child(odd) > th {
     background: var(--background-color);
   }
+  & > tbody > tr:last-child > td,
+  & > tbody > tr:last-child > th {
+    border-bottom: 0;
+  }
 
   a {
-    color: $highlight-text-color;
-    text-decoration: underline;
+    color: $darker-text-color;
+    text-decoration: none;
 
     &:hover {
-      text-decoration: none;
+      color: $highlight-text-color;
     }
   }
 

--- a/app/javascript/styles/mastodon/tables.scss
+++ b/app/javascript/styles/mastodon/tables.scss
@@ -188,7 +188,7 @@ a.table-action-link {
     z-index: 1;
     border: 1px solid lighten($ui-base-color, 8%);
     background: var(--background-color);
-    border-radius: 4px 0 0;
+    border-radius: 4px 4px 0 0;
     height: 47px;
     align-items: center;
 

--- a/app/javascript/styles/mastodon/tables.scss
+++ b/app/javascript/styles/mastodon/tables.scss
@@ -3,8 +3,6 @@
   max-width: 100%;
   border-spacing: 0;
   border-collapse: collapse;
-  // border: 1px solid $ui-base-color;
-  // border-radius: 4px;
 
   th,
   td {
@@ -23,8 +21,6 @@
 
   & > thead > tr > th {
     vertical-align: bottom;
-    // border-bottom: 2px solid $ui-base-color;
-    // border-top: 0;
     font-weight: 500;
   }
 
@@ -36,6 +32,7 @@
   & > tbody > tr:nth-child(odd) > th {
     background: var(--background-color);
   }
+
   & > tbody > tr:last-child > td,
   & > tbody > tr:last-child > th {
     border-bottom: 0;
@@ -276,16 +273,8 @@ a.table-action-link {
       }
     }
 
-    // &:hover {
-    //   background: $ui-highlight-color;
-    // }
-
     &:nth-child(even) {
       background: var(--background-color);
-
-      // &:hover {
-      //   background: $ui-highlight-color;
-      // }
     }
 
     &__content {

--- a/app/javascript/styles/mastodon/tables.scss
+++ b/app/javascript/styles/mastodon/tables.scss
@@ -11,7 +11,7 @@
     vertical-align: top;
     border-top: 1px solid $ui-base-color;
     text-align: start;
-    background: darken($ui-base-color, 4%);
+    background: var(--background-color);
 
     &.critical {
       font-weight: 700;
@@ -90,18 +90,18 @@
 
   &.batch-table {
     & > thead > tr > th {
-      background: $ui-base-color;
-      border-top: 1px solid darken($ui-base-color, 8%);
-      border-bottom: 1px solid darken($ui-base-color, 8%);
+      background: var(--background-color);
+      border-top: 1px solid lighten($ui-base-color, 8%);
+      border-bottom: 1px solid lighten($ui-base-color, 8%);
 
       &:first-child {
         border-radius: 4px 0 0;
-        border-inline-start: 1px solid darken($ui-base-color, 8%);
+        border-inline-start: 1px solid lighten($ui-base-color, 8%);
       }
 
       &:last-child {
         border-radius: 0 4px 0 0;
-        border-inline-end: 1px solid darken($ui-base-color, 8%);
+        border-inline-end: 1px solid lighten($ui-base-color, 8%);
       }
     }
   }
@@ -186,8 +186,8 @@ a.table-action-link {
     position: sticky;
     top: 0;
     z-index: 1;
-    border: 1px solid darken($ui-base-color, 8%);
-    background: $ui-base-color;
+    border: 1px solid lighten($ui-base-color, 8%);
+    background: var(--background-color);
     border-radius: 4px 0 0;
     height: 47px;
     align-items: center;
@@ -199,11 +199,11 @@ a.table-action-link {
   }
 
   &__select-all {
-    background: $ui-base-color;
+    background: var(--background-color);
     height: 47px;
     align-items: center;
     justify-content: center;
-    border: 1px solid darken($ui-base-color, 8%);
+    border: 1px solid lighten($ui-base-color, 8%);
     border-top: 0;
     color: $secondary-text-color;
     display: none;
@@ -249,9 +249,9 @@ a.table-action-link {
 
   &__form {
     padding: 16px;
-    border: 1px solid darken($ui-base-color, 8%);
+    border: 1px solid lighten($ui-base-color, 8%);
     border-top: 0;
-    background: $ui-base-color;
+    background: var(--background-color);
 
     .fields-row {
       padding-top: 0;
@@ -260,13 +260,13 @@ a.table-action-link {
   }
 
   &__row {
-    border: 1px solid darken($ui-base-color, 8%);
+    border: 1px solid lighten($ui-base-color, 8%);
     border-top: 0;
-    background: darken($ui-base-color, 4%);
+    background: var(--background-color);
 
     @media screen and (max-width: $no-gap-breakpoint) {
       .optional &:first-child {
-        border-top: 1px solid darken($ui-base-color, 8%);
+        border-top: 1px solid lighten($ui-base-color, 8%);
       }
     }
 
@@ -275,7 +275,7 @@ a.table-action-link {
     }
 
     &:nth-child(even) {
-      background: $ui-base-color;
+      background: var(--background-color);
 
       &:hover {
         background: lighten($ui-base-color, 2%);
@@ -357,12 +357,13 @@ a.table-action-link {
   }
 
   .nothing-here {
-    border: 1px solid darken($ui-base-color, 8%);
+    border: 1px solid lighten($ui-base-color, 8%);
     border-top: 0;
     box-shadow: none;
+    background: var(--background-color);
 
     @media screen and (max-width: $no-gap-breakpoint) {
-      border-top: 1px solid darken($ui-base-color, 8%);
+      border-top: 1px solid lighten($ui-base-color, 8%);
     }
   }
 

--- a/app/javascript/styles/mastodon/tables.scss
+++ b/app/javascript/styles/mastodon/tables.scss
@@ -81,7 +81,7 @@
     & > tbody > tr > td {
       padding: 11px 10px;
       background: transparent;
-      border: 1px solid lighten($ui-base-color, 8%);
+      border: 1px solid var(--background-border-color);
       color: $secondary-text-color;
     }
 
@@ -94,17 +94,17 @@
   &.batch-table {
     & > thead > tr > th {
       background: var(--background-color);
-      border-top: 1px solid lighten($ui-base-color, 8%);
-      border-bottom: 1px solid lighten($ui-base-color, 8%);
+      border-top: 1px solid var(--background-border-color);
+      border-bottom: 1px solid var(--background-border-color);
 
       &:first-child {
         border-radius: 4px 0 0;
-        border-inline-start: 1px solid lighten($ui-base-color, 8%);
+        border-inline-start: 1px solid var(--background-border-color);
       }
 
       &:last-child {
         border-radius: 0 4px 0 0;
-        border-inline-end: 1px solid lighten($ui-base-color, 8%);
+        border-inline-end: 1px solid var(--background-border-color);
       }
     }
   }
@@ -189,7 +189,7 @@ a.table-action-link {
     position: sticky;
     top: 0;
     z-index: 1;
-    border: 1px solid lighten($ui-base-color, 8%);
+    border: 1px solid var(--background-border-color);
     background: var(--background-color);
     border-radius: 4px 4px 0 0;
     height: 47px;
@@ -206,7 +206,7 @@ a.table-action-link {
     height: 47px;
     align-items: center;
     justify-content: center;
-    border: 1px solid lighten($ui-base-color, 8%);
+    border: 1px solid var(--background-border-color);
     border-top: 0;
     color: $secondary-text-color;
     display: none;
@@ -252,7 +252,7 @@ a.table-action-link {
 
   &__form {
     padding: 16px;
-    border: 1px solid lighten($ui-base-color, 8%);
+    border: 1px solid var(--background-border-color);
     border-top: 0;
     background: var(--background-color);
 
@@ -263,13 +263,13 @@ a.table-action-link {
   }
 
   &__row {
-    border: 1px solid lighten($ui-base-color, 8%);
+    border: 1px solid var(--background-border-color);
     border-top: 0;
     background: var(--background-color);
 
     @media screen and (max-width: $no-gap-breakpoint) {
       .optional &:first-child {
-        border-top: 1px solid lighten($ui-base-color, 8%);
+        border-top: 1px solid var(--background-border-color);
       }
     }
 
@@ -352,13 +352,13 @@ a.table-action-link {
   }
 
   .nothing-here {
-    border: 1px solid lighten($ui-base-color, 8%);
+    border: 1px solid var(--background-border-color);
     border-top: 0;
     box-shadow: none;
     background: var(--background-color);
 
     @media screen and (max-width: $no-gap-breakpoint) {
-      border-top: 1px solid lighten($ui-base-color, 8%);
+      border-top: 1px solid var(--background-border-color);
     }
   }
 

--- a/app/javascript/styles/mastodon/tables.scss
+++ b/app/javascript/styles/mastodon/tables.scss
@@ -270,16 +270,16 @@ a.table-action-link {
       }
     }
 
-    &:hover {
-      background: darken($ui-base-color, 2%);
-    }
+    // &:hover {
+    //   background: $ui-highlight-color;
+    // }
 
     &:nth-child(even) {
       background: var(--background-color);
 
-      &:hover {
-        background: lighten($ui-base-color, 2%);
-      }
+      // &:hover {
+      //   background: $ui-highlight-color;
+      // }
     }
 
     &__content {

--- a/app/javascript/styles/mastodon/tables.scss
+++ b/app/javascript/styles/mastodon/tables.scss
@@ -32,7 +32,7 @@
 
   & > tbody > tr:nth-child(odd) > td,
   & > tbody > tr:nth-child(odd) > th {
-    background: $ui-base-color;
+    background: var(--background-color);
   }
 
   a {

--- a/app/javascript/styles/mastodon/widgets.scss
+++ b/app/javascript/styles/mastodon/widgets.scss
@@ -351,7 +351,7 @@
       &:focus,
       &:hover,
       &:active {
-        text-decoration: underline;
+        color: $highlight-text-color;
       }
     }
   }

--- a/app/javascript/styles/mastodon/widgets.scss
+++ b/app/javascript/styles/mastodon/widgets.scss
@@ -204,7 +204,7 @@
 }
 
 .directory {
-  background: $ui-base-color;
+  background: var(--background-color);
   border-radius: 4px;
   box-shadow: 0 0 15px rgba($base-shadow-color, 0.2);
 
@@ -217,7 +217,7 @@
       display: flex;
       align-items: center;
       justify-content: space-between;
-      background: $ui-base-color;
+      border: 1px solid lighten($ui-base-color, 8%);
       border-radius: 4px;
       padding: 15px;
       text-decoration: none;
@@ -229,7 +229,7 @@
       &:hover,
       &:active,
       &:focus {
-        background: lighten($ui-base-color, 8%);
+        background: $ui-base-color;
       }
     }
 

--- a/app/views/admin/roles/index.html.haml
+++ b/app/views/admin/roles/index.html.haml
@@ -8,10 +8,10 @@
 
 %hr.spacer/
 
-.applications-list
+.announcements-list
   = render partial: 'role', collection: @roles.select(&:everyone?)
 
 %hr.spacer/
 
-.applications-list
+.announcements-list
   = render partial: 'role', collection: @roles.reject(&:everyone?)

--- a/app/views/auth/registrations/_account_warning.html.haml
+++ b/app/views/auth/registrations/_account_warning.html.haml
@@ -1,14 +1,14 @@
-= link_to disputes_strike_path(account_warning), class: 'log-entry' do
-  .log-entry__header
-    .log-entry__avatar
+= link_to disputes_strike_path(account_warning), class: 'strike-entry' do
+  .strike-entry__header
+    .strike-entry__avatar
       .indicator-icon{ class: account_warning.overruled? ? 'success' : 'failure' }
         = fa_icon 'warning'
-    .log-entry__content
-      .log-entry__title
+    .strike-entry__content
+      .strike-entry__title
         = t 'disputes.strikes.title',
             action: t(account_warning.action, scope: 'disputes.strikes.title_actions'),
             date: l(account_warning.created_at.to_date)
-      .log-entry__timestamp
+      .strike-entry__timestamp
         %time.formatted{ datetime: account_warning.created_at.iso8601 }= l(account_warning.created_at)
 
         - if account_warning.overruled?


### PR DESCRIPTION
The current Preferences and Admin UI design seems to be a holdover from pre-4.0 interface styling, resulting in an experience that feels like it's part of a separate app, particularly in Mastodon 4.3 where so many of the background colors in both dark and light mode have changes.

This is an attempt to incorporate the color and themes from the main interface into the Preferences.

<img width="1624" alt="Screenshot 2024-07-15 at 2 16 12 PM" src="https://github.com/user-attachments/assets/08655a8d-53cd-4211-92b6-de4e53772182">
<img width="1624" alt="Screenshot 2024-07-15 at 2 29 46 PM" src="https://github.com/user-attachments/assets/5a122503-541c-434c-8e1e-48139772d0b6">
<img width="1624" alt="Screenshot 2024-07-15 at 2 17 29 PM" src="https://github.com/user-attachments/assets/116aa468-9462-4d86-ad15-32ac13ec4e37">
<img width="1624" alt="Screenshot 2024-07-15 at 2 29 58 PM" src="https://github.com/user-attachments/assets/77ae6a39-c1bf-42c1-adff-a882afa8be74">
<img width="1624" alt="Screenshot 2024-07-15 at 2 17 41 PM" src="https://github.com/user-attachments/assets/87973616-113d-4365-b523-6a4aa31eb1ef">
<img width="1624" alt="Screenshot 2024-07-15 at 2 30 05 PM" src="https://github.com/user-attachments/assets/c8b4af9d-89d7-4094-afc1-515ea31d3c96">
<img width="1624" alt="Screenshot 2024-07-15 at 2 17 46 PM" src="https://github.com/user-attachments/assets/09b6e0c6-8130-49b8-af1d-915c6ada440a">
<img width="1624" alt="Screenshot 2024-07-15 at 2 30 10 PM" src="https://github.com/user-attachments/assets/5d01b796-7ed0-4a57-be25-2599e5ff759a">
<img width="1624" alt="Screenshot 2024-07-15 at 2 18 02 PM" src="https://github.com/user-attachments/assets/7fa6ff13-7bb8-45c7-979a-9800467a1246">
<img width="1624" alt="Screenshot 2024-07-15 at 2 30 18 PM" src="https://github.com/user-attachments/assets/53cf9600-d4a8-40dc-979b-d613803c29ea">
<img width="1624" alt="Screenshot 2024-07-15 at 2 18 08 PM" src="https://github.com/user-attachments/assets/7fea90a0-e450-414a-9044-fdf76b0056b6">
<img width="1624" alt="Screenshot 2024-07-15 at 2 30 27 PM" src="https://github.com/user-attachments/assets/abc3de4f-de0b-46d7-b4ad-8d026a764448">
<img width="1624" alt="Screenshot 2024-07-15 at 2 19 22 PM" src="https://github.com/user-attachments/assets/07eacf84-f9db-4f1c-8d18-4806a4005956">
<img width="1624" alt="Screenshot 2024-07-15 at 2 30 36 PM" src="https://github.com/user-attachments/assets/15683c9d-e4d6-452c-ad5d-407d4ae8b7f5">
