### PR TITLE
Add Doorkeeper::Application.webapp helper

### DIFF
--- a/app/lib/application_extension.rb
+++ b/app/lib/application_extension.rb
@@ -19,6 +19,14 @@ module ApplicationExtension
     before_destroy :close_streaming_sessions, prepend: true
   end
 
+  class_methods do
+    def webapp
+      Doorkeeper::Application.find_by!(name: 'Web', superapp: true)
+    rescue ActiveRecord::RecordNotFound
+      Doorkeeper::Application.create!(name: 'Web', redirect_uri: Doorkeeper.configuration.native_redirect_uri, scopes: 'read write follow push', superapp: true)
+    end
+  end
+
   def confirmation_redirect_uri
     redirect_uri.lines.first.strip
   end

--- a/app/models/session_activation.rb
+++ b/app/models/session_activation.rb
@@ -28,7 +28,7 @@ class SessionActivation < ApplicationRecord
 
   before_create :assign_access_token
 
-  DEFAULT_SCOPES = %w(read write follow).freeze
+  DEFAULT_SCOPES = Doorkeeper::Application.webapp.scopes.without('push').freeze
 
   scope :latest, -> { order(id: :desc) }
 
@@ -66,9 +66,9 @@ class SessionActivation < ApplicationRecord
 
   def access_token_attributes
     {
-      application_id: Doorkeeper::Application.find_by(superapp: true)&.id,
+      application_id: Doorkeeper::Application.webapp.id,
       resource_owner_id: user_id,
-      scopes: DEFAULT_SCOPES.join(' '),
+      scopes: DEFAULT_SCOPES,
       expires_in: Doorkeeper.configuration.access_token_expires_in,
       use_refresh_token: Doorkeeper.configuration.refresh_token_enabled?,
     }

--- a/app/models/web/push_subscription.rb
+++ b/app/models/web/push_subscription.rb
@@ -66,9 +66,9 @@ class Web::PushSubscription < ApplicationRecord
 
   def find_or_create_access_token
     Doorkeeper::AccessToken.find_or_create_for(
-      application: Doorkeeper::Application.find_by(superapp: true),
+      application: Doorkeeper::Application.webapp,
       resource_owner: user_id || session_activation.user_id,
-      scopes: Doorkeeper::OAuth::Scopes.from_string('read write follow push'),
+      scopes: Doorkeeper::Application.webapp.scopes,
       expires_in: Doorkeeper.configuration.access_token_expires_in,
       use_refresh_token: Doorkeeper.configuration.refresh_token_enabled?
     )

--- a/db/seeds/01_web_app.rb
+++ b/db/seeds/01_web_app.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-Doorkeeper::Application.create_with(name: 'Web', redirect_uri: Doorkeeper.configuration.native_redirect_uri, scopes: 'read write follow push').find_or_create_by(superapp: true)
+Doorkeeper::Application.webapp


### PR DESCRIPTION
This is from [this comment](https://github.com/mastodon/mastodon/pull/30539#issuecomment-2146195807) on a recent PR, idea being to have a single method for the webapp OAuth Application, rather than having it in multiple places.

We could do an application ID of a fixed value, but then we'd want a migration to remove the old webapp, which would log everyone out, unless we modified access tokens.

Currently we have no tests for the Doorkeeper extensions in `app/lib/`, and I'm not sure where best to add them besides `spec/lib` given these are auto-loaded from [config/application.rb](https://github.com/mastodon/mastodon/blob/2cda1dd542b20a47245cb8d28a4f6f8750c2284c/config/application.rb#L115-L123)