### PR TITLE
Use change-requiring records in admin/reports controller spec

### DIFF
--- a/spec/controllers/admin/reports_controller_spec.rb
+++ b/spec/controllers/admin/reports_controller_spec.rb
@@ -64,7 +64,7 @@ describe Admin::ReportsController do
 
   describe 'POST #reopen' do
     it 'reopens the report' do
-      report = Fabricate(:report)
+      report = Fabricate(:report, action_taken_at: 3.days.ago)
 
       put :reopen, params: { id: report }
       expect(response).to redirect_to(admin_report_path(report))
@@ -89,7 +89,7 @@ describe Admin::ReportsController do
 
   describe 'POST #unassign' do
     it 'reopens the report' do
-      report = Fabricate(:report)
+      report = Fabricate(:report, assigned_account_id: Account.last.id)
 
       put :unassign, params: { id: report }
       expect(response).to redirect_to(admin_report_path(report))


### PR DESCRIPTION
Some spec changes from https://github.com/mastodon/mastodon/pull/30423 unrelated to the core audit log changes there.

Previously the relevant report records here were not actually being changed. With these changes, they will be.

Useful future improvement here would be to do a once over on this whole spec file and add some `change` blocks to assert that the various actions actually update anything.