### PR TITLE
Reduce extra factories in `FanOutOnWriteService` spec

### DIFF
--- a/spec/services/fan_out_on_write_service_spec.rb
+++ b/spec/services/fan_out_on_write_service_spec.rb
@@ -34,21 +34,14 @@ RSpec.describe FanOutOnWriteService do
   context 'when status is public' do
     let(:visibility) { 'public' }
 
-    it 'is added to the home feed of its author' do
-      expect(home_feed_of(alice)).to include status.id
-    end
+    it 'adds status to home feed of author and followers and broadcasts', :inline_jobs do
+      expect(status.id)
+        .to be_in(home_feed_of(alice))
+        .and be_in(home_feed_of(bob))
+        .and be_in(home_feed_of(tom))
 
-    it 'is added to the home feed of a follower', :inline_jobs do
-      expect(home_feed_of(bob)).to include status.id
-      expect(home_feed_of(tom)).to include status.id
-    end
-
-    it 'is broadcast to the hashtag stream' do
       expect(redis).to have_received(:publish).with('timeline:hashtag:hoge', anything)
       expect(redis).to have_received(:publish).with('timeline:hashtag:hoge:local', anything)
-    end
-
-    it 'is broadcast to the public stream' do
       expect(redis).to have_received(:publish).with('timeline:public', anything)
       expect(redis).to have_received(:publish).with('timeline:public:local', anything)
       expect(redis).to have_received(:publish).with('timeline:public:media', anything)
@@ -58,60 +51,41 @@ RSpec.describe FanOutOnWriteService do
   context 'when status is limited' do
     let(:visibility) { 'limited' }
 
-    it 'is added to the home feed of its author' do
-      expect(home_feed_of(alice)).to include status.id
-    end
+    it 'adds status to home feed of author and mentioned followers and does not broadcast', :inline_jobs do
+      expect(status.id)
+        .to be_in(home_feed_of(alice))
+        .and be_in(home_feed_of(bob))
+      expect(status.id)
+        .to_not be_in(home_feed_of(tom))
 
-    it 'is added to the home feed of the mentioned follower', :inline_jobs do
-      expect(home_feed_of(bob)).to include status.id
-    end
-
-    it 'is not added to the home feed of the other follower' do
-      expect(home_feed_of(tom)).to_not include status.id
-    end
-
-    it 'is not broadcast publicly' do
-      expect(redis).to_not have_received(:publish).with('timeline:hashtag:hoge', anything)
-      expect(redis).to_not have_received(:publish).with('timeline:public', anything)
+      expect_no_broadcasting
     end
   end
 
   context 'when status is private' do
     let(:visibility) { 'private' }
 
-    it 'is added to the home feed of its author' do
-      expect(home_feed_of(alice)).to include status.id
-    end
+    it 'adds status to home feed of author and followers and does not broadcast', :inline_jobs do
+      expect(status.id)
+        .to be_in(home_feed_of(alice))
+        .and be_in(home_feed_of(bob))
+        .and be_in(home_feed_of(tom))
 
-    it 'is added to the home feed of a follower', :inline_jobs do
-      expect(home_feed_of(bob)).to include status.id
-      expect(home_feed_of(tom)).to include status.id
-    end
-
-    it 'is not broadcast publicly' do
-      expect(redis).to_not have_received(:publish).with('timeline:hashtag:hoge', anything)
-      expect(redis).to_not have_received(:publish).with('timeline:public', anything)
+      expect_no_broadcasting
     end
   end
 
   context 'when status is direct' do
     let(:visibility) { 'direct' }
 
-    it 'is added to the home feed of its author' do
-      expect(home_feed_of(alice)).to include status.id
-    end
+    it 'is added to the home feed of its author and mentioned followers and does not broadcast', :inline_jobs do
+      expect(status.id)
+        .to be_in(home_feed_of(alice))
+        .and be_in(home_feed_of(bob))
+      expect(status.id)
+        .to_not be_in(home_feed_of(tom))
 
-    it 'is added to the home feed of the mentioned follower', :inline_jobs do
-      expect(home_feed_of(bob)).to include status.id
-    end
-
-    it 'is not added to the home feed of the other follower' do
-      expect(home_feed_of(tom)).to_not include status.id
-    end
-
-    it 'is not broadcast publicly' do
-      expect(redis).to_not have_received(:publish).with('timeline:hashtag:hoge', anything)
-      expect(redis).to_not have_received(:publish).with('timeline:public', anything)
+      expect_no_broadcasting
     end
 
     context 'when handling status updates' do
@@ -130,5 +104,14 @@ RSpec.describe FanOutOnWriteService do
         expect(PushUpdateWorker).to have_enqueued_sidekiq_job(anything, status.id, "timeline:#{eve.id}:notifications", { 'update' => true })
       end
     end
+  end
+
+  def expect_no_broadcasting
+    expect(redis)
+      .to_not have_received(:publish)
+      .with('timeline:hashtag:hoge', anything)
+    expect(redis)
+      .to_not have_received(:publish)
+      .with('timeline:public', anything)
   end
 end


### PR DESCRIPTION
Reduces factories from 96 to 30, ~50% speed up.