### PR TITLE
Fix `Admin::AccountAction` call to log action after updating records

### DIFF
--- a/app/models/admin/account_action.rb
+++ b/app/models/admin/account_action.rb
@@ -132,26 +132,26 @@ class Admin::AccountAction
 
   def handle_disable!
     authorize(target_account.user, :disable?)
-    log_action(:disable, target_account.user)
     target_account.user&.disable!
+    log_action(:disable, target_account.user)
   end
 
   def handle_sensitive!
     authorize(target_account, :sensitive?)
-    log_action(:sensitive, target_account)
     target_account.sensitize!
+    log_action(:sensitive, target_account)
   end
 
   def handle_silence!
     authorize(target_account, :silence?)
-    log_action(:silence, target_account)
     target_account.silence!
+    log_action(:silence, target_account)
   end
 
   def handle_suspend!
     authorize(target_account, :suspend?)
-    log_action(:suspend, target_account)
     target_account.suspend!(origin: :local)
+    log_action(:suspend, target_account)
   end
 
   def text_for_warning


### PR DESCRIPTION
Another extracted from https://github.com/mastodon/mastodon/pull/30423

This does not change the behavior of the log_action method itself, but does change the usage of it with in `Admin::AccountAction` to be consistent with (AFAICT) the entire rest of the app, where the logging call comes after the updating method.