### PR TITLE
Update `strong_migrations` to version 2.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,7 +88,7 @@ gem 'sidekiq-unique-jobs', '~> 7.1'
 gem 'simple_form', '~> 5.2'
 gem 'simple-navigation', '~> 4.4'
 gem 'stoplight', '~> 4.1'
-gem 'strong_migrations', '1.8.0'
+gem 'strong_migrations'
 gem 'tty-prompt', '~> 0.23', require: false
 gem 'twitter-text', '~> 3.1.0'
 gem 'tzinfo-data', '~> 1.2023'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -821,8 +821,8 @@ GEM
     stoplight (4.1.0)
       redlock (~> 1.0)
     stringio (3.1.1)
-    strong_migrations (1.8.0)
-      activerecord (>= 5.2)
+    strong_migrations (2.0.0)
+      activerecord (>= 6.1)
     strscan (3.1.0)
     swd (1.3.0)
       activesupport (>= 3)
@@ -1046,7 +1046,7 @@ DEPENDENCIES
   simplecov-lcov (~> 0.8)
   stackprof
   stoplight (~> 4.1)
-  strong_migrations (= 1.8.0)
+  strong_migrations
   test-prof
   thor (~> 1.2)
   tty-prompt (~> 0.23)


### PR DESCRIPTION
The major version bump on gem side was to drop support for old ruby, activerecord, postgres versions -- all either EOL and/or older than we support, so I think this is safe.