### PR TITLE
Cache rspec persistence file between CI runs

### DIFF
--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -151,6 +151,7 @@ jobs:
           bin/flatware fan bin/rails db:test:prepare
 
       - name: Cache RSpec persistence file
+        if: matrix.ruby-version == '.ruby-version'
         uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -150,6 +150,18 @@ jobs:
           bin/rails db:setup
           bin/flatware fan bin/rails db:test:prepare
 
+      - name: Cache RSpec persistence file
+        uses: actions/cache@v4
+        with:
+          path: |
+            tmp/rspec/examples.txt
+          key: rspec-persistence-${{ github.head_ref || github.ref_name }}-${{ github.sha }}
+          restore-keys: |
+            rspec-persistence-${{ github.head_ref || github.ref_name }}-${{ github.sha }}
+            rspec-persistence-${{ github.head_ref || github.ref_name }}
+            rspec-persistence-main
+            rspec-persistence
+
       - run: bin/flatware rspec -r ./spec/flatware_helper.rb
 
       - name: Upload coverage reports to Codecov

--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -151,13 +151,13 @@ jobs:
           bin/flatware fan bin/rails db:test:prepare
 
       - name: Cache RSpec persistence file
-        if: matrix.ruby-version == '.ruby-version'
         uses: actions/cache@v4
         with:
           path: |
             tmp/rspec/examples.txt
           key: rspec-persistence-${{ github.head_ref || github.ref_name }}-${{ github.sha }}
           restore-keys: |
+            rspec-persistence-${{ github.head_ref || github.ref_name }}-${{ github.sha }}-${{ matrix.ruby-version }}
             rspec-persistence-${{ github.head_ref || github.ref_name }}-${{ github.sha }}
             rspec-persistence-${{ github.head_ref || github.ref_name }}
             rspec-persistence-main


### PR DESCRIPTION
Similar to https://github.com/mastodon/mastodon/pull/30868

I believe that flatware will read this file to allocate spec files to each parallel run (though I think this is at the spec file level, not example level). The goal is to get each run as evenly allocated in terms of expected time as possible, so you don't have one of them just happen to get more of the slow ones than the others and delay completion of overall run.

Since the CI runs are sort of variable I'm not sure how to confidently verify this is having the intended effect ... but it also seems mostly harmless. I guess we can watch a bunch of runs and see if they appear more even over time.