### PR TITLE
Remove duplicate `omniauth_only?` helper method

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,7 +20,6 @@ class ApplicationController < ActionController::Base
   helper_method :current_theme
   helper_method :single_user_mode?
   helper_method :use_seamless_external_login?
-  helper_method :omniauth_only?
   helper_method :sso_account_settings
   helper_method :limited_federation_mode?
   helper_method :body_class_string
@@ -135,10 +134,6 @@ class ApplicationController < ActionController::Base
 
   def use_seamless_external_login?
     Devise.pam_authentication || Devise.ldap_authentication
-  end
-
-  def omniauth_only?
-    ENV['OMNIAUTH_ONLY'] == 'true'
   end
 
   def sso_account_settings

--- a/app/helpers/registration_helper.rb
+++ b/app/helpers/registration_helper.rb
@@ -11,6 +11,10 @@ module RegistrationHelper
     Setting.registrations_mode != 'none'
   end
 
+  def omniauth_only?
+    ENV['OMNIAUTH_ONLY'] == 'true'
+  end
+
   def ip_blocked?(remote_ip)
     IpBlock.where(severity: :sign_up_block).exists?(['ip >>= ?', remote_ip.to_s])
   end

--- a/app/helpers/registration_helper.rb
+++ b/app/helpers/registration_helper.rb
@@ -11,10 +11,6 @@ module RegistrationHelper
     Setting.registrations_mode != 'none'
   end
 
-  def omniauth_only?
-    ENV['OMNIAUTH_ONLY'] == 'true'
-  end
-
   def ip_blocked?(remote_ip)
     IpBlock.where(severity: :sign_up_block).exists?(['ip >>= ?', remote_ip.to_s])
   end


### PR DESCRIPTION
There is a method with same name/definition in `ApplicationHelper`, and at this point there is only usage of this method from views and none from controllers, so I think this is safe.

There is a third definition of this in `RegistrationsHelper` as well (same name and def) but I think that since the registrations controller inherits from devise controller that's actually still needed. Future idea maybe to further handle that one.