### PR TITLE
Resolve `TODO` in `api/v1/admin/domain_*` controllers

### DIFF
--- a/app/controllers/api/v1/admin/domain_allows_controller.rb
+++ b/app/controllers/api/v1/admin/domain_allows_controller.rb
@@ -47,16 +47,11 @@ class Api::V1::Admin::DomainAllowsController < Api::BaseController
   private
 
   def set_domain_allows
-    @domain_allows = filtered_domain_allows.order(id: :desc).to_a_paginated_by_id(limit_param(LIMIT), params_slice(:max_id, :since_id, :min_id))
+    @domain_allows = DomainAllow.order(id: :desc).to_a_paginated_by_id(limit_param(LIMIT), params_slice(:max_id, :since_id, :min_id))
   end
 
   def set_domain_allow
     @domain_allow = DomainAllow.find(params[:id])
-  end
-
-  def filtered_domain_allows
-    # TODO: no filtering yet
-    DomainAllow.all
   end
 
   def next_path

--- a/app/controllers/api/v1/admin/domain_blocks_controller.rb
+++ b/app/controllers/api/v1/admin/domain_blocks_controller.rb
@@ -59,16 +59,11 @@ class Api::V1::Admin::DomainBlocksController < Api::BaseController
   end
 
   def set_domain_blocks
-    @domain_blocks = filtered_domain_blocks.order(id: :desc).to_a_paginated_by_id(limit_param(LIMIT), params_slice(:max_id, :since_id, :min_id))
+    @domain_blocks = DomainBlock.order(id: :desc).to_a_paginated_by_id(limit_param(LIMIT), params_slice(:max_id, :since_id, :min_id))
   end
 
   def set_domain_block
     @domain_block = DomainBlock.find(params[:id])
-  end
-
-  def filtered_domain_blocks
-    # TODO: no filtering yet
-    DomainBlock.all
   end
 
   def domain_block_params


### PR DESCRIPTION
Assuming this is not imminent or planned, seems reasonable to remove a ~2-year old note. Style matches the other `set_*` methods in the other `admin/*` controllers.