### PR TITLE
Fix double border on column filter on narrow screens

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -7380,6 +7380,11 @@ a.status-card {
   display: flex;
   flex-shrink: 0;
 
+  @media screen and (max-width: $no-gap-breakpoint) {
+    border-right: 0;
+    border-left: 0;
+  }
+
   button {
     background: transparent;
     border: 0;


### PR DESCRIPTION
The column filter on the notifications screen and the live feeds view had an extra border on narrow width screens and mobile.

Before
![image](https://github.com/user-attachments/assets/443bb146-8046-40f4-bb7e-918f367a1aca)

After
![image](https://github.com/user-attachments/assets/323436e9-9793-4702-9d4f-7eaeca4829fc)
