### PR TITLE
Fix spec descriptions around configurable limit values

### DIFF
--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -592,7 +592,7 @@ RSpec.describe Account do
       expect(results).to eq [match]
     end
 
-    it 'limits by 10 by default' do
+    it 'limits result count by default value' do
       stub_const('Account::Search::DEFAULT_LIMIT', 1)
       2.times { Fabricate(:account, display_name: 'Display Name') }
       results = described_class.advanced_search_for('display', account)

--- a/spec/validators/reaction_validator_spec.rb
+++ b/spec/validators/reaction_validator_spec.rb
@@ -19,8 +19,9 @@ describe ReactionValidator do
       expect(reaction.errors).to be_empty
     end
 
-    it 'adds error when 8 reactions already exist' do
-      %w(🐘 ❤️ 🙉 😍 😋 😂 😞 👍).each do |name|
+    it 'adds error when reaction limit count has already been reached' do
+      stub_const 'ReactionValidator::LIMIT', 2
+      %w(🐘 ❤️).each do |name|
         announcement.announcement_reactions.create!(name: name, account: Fabricate(:account))
       end
 

--- a/spec/validators/status_length_validator_spec.rb
+++ b/spec/validators/status_length_validator_spec.rb
@@ -42,23 +42,23 @@ describe StatusLengthValidator do
       expect(status.errors).to have_received(:add)
     end
 
-    it 'counts URLs as 23 characters flat' do
-      text   = ('a' * 476) + " http://#{'b' * 30}.com/example"
+    it 'reduces calculated length of auto-linkable space-separated URLs' do
+      text = [starting_string, example_link].join(' ')
       status = status_double(text: text)
 
       subject.validate(status)
       expect(status.errors).to_not have_received(:add)
     end
 
-    it 'does not count non-autolinkable URLs as 23 characters flat' do
-      text   = ('a' * 476) + "http://#{'b' * 30}.com/example"
+    it 'does not reduce calculated length of non-autolinkable URLs' do
+      text = [starting_string, example_link].join
       status = status_double(text: text)
 
       subject.validate(status)
       expect(status.errors).to have_received(:add)
     end
 
-    it 'does not count overly long URLs as 23 characters flat' do
+    it 'does not reduce calculated length of count overly long URLs' do
       text = "http://example.com/valid?#{'#foo?' * 1000}"
       status = status_double(text: text)
       subject.validate(status)
@@ -83,6 +83,14 @@ describe StatusLengthValidator do
   end
 
   private
+
+  def starting_string
+    'a' * 476
+  end
+
+  def example_link
+    "http://#{'b' * 30}.com/example"
+  end
 
   def status_double(spoiler_text: '', text: '')
     instance_double(


### PR DESCRIPTION
Various recent PRs have moved some previously inline defined "magic numbers" to be constants in their classes, but not all fo the spec example names were updated as well. This is a few changes:

- Account spec - we are using stub_const here, just reflect that in description
- Note and Status length validator specs - both clarify what's happening in spec descs, and also tidy up spec code to make a little more obvious the different cases
- Reaction validator spec - clean up desc, and also reduce number of needed records within the spec