### PR TITLE
Ignore manifest JS parse/interrupt error on CI

### DIFF
--- a/spec/support/javascript_errors.rb
+++ b/spec/support/javascript_errors.rb
@@ -5,6 +5,7 @@ RSpec.configure do |config|
     # Classes of intermittent ignorable errors
     ignored_errors = [
       /Error while trying to use the following icon from the Manifest/, # https://github.com/mastodon/mastodon/pull/30793
+      /Manifest: Line: 1, column: 1, Syntax error/, # Similar parsing/interruption issue as above
     ]
     errors = page.driver.browser.logs.get(:browser).reject do |error|
       ignored_errors.any? { |pattern| pattern.match(error.message) }


### PR DESCRIPTION
This seems to be the currently most frequent intermittent JS issue in the system specs. Basically a variation on the other existing one we already ignore.

Recent occurrence: https://github.com/mastodon/mastodon/actions/runs/10011030158/job/27673658740?pr=31079