### PR TITLE
Fix syntax error in grouped notifications CTE on some PostgreSQL versions

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -148,7 +148,7 @@ class Notification < ApplicationRecord
         .with_recursive(
           grouped_notifications: [
             query
-              .select('notifications.*', "ARRAY[COALESCE(notifications.group_key, 'ungrouped-' || notifications.id)] groups")
+              .select('notifications.*', "ARRAY[COALESCE(notifications.group_key, 'ungrouped-' || notifications.id)] AS groups")
               .limit(1),
             query
               .joins('CROSS JOIN grouped_notifications')
@@ -176,7 +176,7 @@ class Notification < ApplicationRecord
         .with_recursive(
           grouped_notifications: [
             query
-              .select('notifications.*', "ARRAY[COALESCE(notifications.group_key, 'ungrouped-' || notifications.id)] groups")
+              .select('notifications.*', "ARRAY[COALESCE(notifications.group_key, 'ungrouped-' || notifications.id)] AS groups")
               .limit(1),
             query
               .joins('CROSS JOIN grouped_notifications')


### PR DESCRIPTION
This apparently fails on PostgreSQL 12. In any case, explicitly using the `AS` keyword is good practice.