### PR TITLE
Fix duplicate `orderedItems` in user archive's `outbox.json`

### DIFF
--- a/app/lib/activitypub/adapter.rb
+++ b/app/lib/activitypub/adapter.rb
@@ -20,6 +20,6 @@ class ActivityPub::Adapter < ActiveModelSerializers::Adapter::Base
     serialized_hash = serialized_hash.select { |k, _| options[:fields].include?(k) } if options[:fields]
     serialized_hash = self.class.transform_key_casing!(serialized_hash, instance_options)
 
-    { '@context' => serialized_context(named_contexts, context_extensions) }.merge(serialized_hash)
+    { '@context': serialized_context(named_contexts, context_extensions) }.merge(serialized_hash)
   end
 end

--- a/app/services/backup_service.rb
+++ b/app/services/backup_service.rb
@@ -19,8 +19,8 @@ class BackupService < BaseService
 
   def build_outbox_json!(file)
     skeleton = serialize(collection_presenter, ActivityPub::CollectionSerializer)
-    skeleton['@context'] = full_context
-    skeleton['orderedItems'] = ['!PLACEHOLDER!']
+    skeleton[:@context] = full_context
+    skeleton[:orderedItems] = ['!PLACEHOLDER!']
     skeleton = Oj.dump(skeleton)
     prepend, append = skeleton.split('"!PLACEHOLDER!"')
     add_comma = false
@@ -33,7 +33,7 @@ class BackupService < BaseService
 
       file.write(statuses.map do |status|
         item = serialize_payload(ActivityPub::ActivityPresenter.from_status(status), ActivityPub::ActivitySerializer)
-        item.delete('@context')
+        item.delete(:@context)
 
         unless item[:type] == 'Announce' || item[:object][:attachment].blank?
           item[:object][:attachment].each do |attachment|

--- a/spec/lib/activitypub/adapter_spec.rb
+++ b/spec/lib/activitypub/adapter_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe ActivityPub::Adapter do
       let(:serializer_class) { TestWithBasicContextSerializer }
 
       it 'renders a basic @context' do
-        expect(subject).to include({ '@context' => 'https://www.w3.org/ns/activitystreams' })
+        expect(subject).to include({ '@context': 'https://www.w3.org/ns/activitystreams' })
       end
     end
 
@@ -67,7 +67,7 @@ RSpec.describe ActivityPub::Adapter do
       let(:serializer_class) { TestWithNamedContextSerializer }
 
       it 'renders a @context with both items' do
-        expect(subject).to include({ '@context' => ['https://www.w3.org/ns/activitystreams', 'https://w3id.org/security/v1'] })
+        expect(subject).to include({ '@context': ['https://www.w3.org/ns/activitystreams', 'https://w3id.org/security/v1'] })
       end
     end
 
@@ -75,7 +75,7 @@ RSpec.describe ActivityPub::Adapter do
       let(:serializer_class) { TestWithNestedNamedContextSerializer }
 
       it 'renders a @context with both items' do
-        expect(subject).to include({ '@context' => ['https://www.w3.org/ns/activitystreams', 'https://w3id.org/security/v1'] })
+        expect(subject).to include({ '@context': ['https://www.w3.org/ns/activitystreams', 'https://w3id.org/security/v1'] })
       end
     end
 
@@ -83,7 +83,7 @@ RSpec.describe ActivityPub::Adapter do
       let(:serializer_class) { TestWithContextExtensionSerializer }
 
       it 'renders a @context with the extension' do
-        expect(subject).to include({ '@context' => ['https://www.w3.org/ns/activitystreams', { 'sensitive' => 'as:sensitive' }] })
+        expect(subject).to include({ '@context': ['https://www.w3.org/ns/activitystreams', { 'sensitive' => 'as:sensitive' }] })
       end
     end
 
@@ -91,7 +91,7 @@ RSpec.describe ActivityPub::Adapter do
       let(:serializer_class) { TestWithNestedContextExtensionSerializer }
 
       it 'renders a @context with both extensions' do
-        expect(subject).to include({ '@context' => ['https://www.w3.org/ns/activitystreams', { 'manuallyApprovesFollowers' => 'as:manuallyApprovesFollowers', 'sensitive' => 'as:sensitive' }] })
+        expect(subject).to include({ '@context': ['https://www.w3.org/ns/activitystreams', { 'manuallyApprovesFollowers' => 'as:manuallyApprovesFollowers', 'sensitive' => 'as:sensitive' }] })
       end
     end
   end

--- a/spec/services/backup_service_spec.rb
+++ b/spec/services/backup_service_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe BackupService do
 
     aggregate_failures do
       expect(body.scan('@context').count).to eq 1
+      expect(body.scan('orderedItems').count).to eq 1
       expect(json['@context']).to_not be_nil
       expect(json['type']).to eq 'OrderedCollection'
       expect(json['totalItems']).to eq 2


### PR DESCRIPTION
Fixes #31091

This was introduced #30653. The underlying issue was the inconsistent use of string VS symbol keys in that hash. This PR changes it to only use symbols, and adds tests for the issue.