### PR TITLE
Proof-of-concept: Open status links in-app if possible

### DIFF
--- a/app/controllers/api/v2/resolved_urls_controller.rb
+++ b/app/controllers/api/v2/resolved_urls_controller.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class Api::V2::ResolvedUrlsController < Api::BaseController
+  include Authorization
+
+  before_action :set_url
+  before_action :set_resource
+
+  def show
+    expires_in(1.day, public: true, stale_while_revalidate: 30.seconds, stale_if_error: 1.day) unless user_signed_in?
+
+    case @resource
+    when Account
+      render json: { 'resolvedPath' => "/@#{@resource.pretty_acct}" }
+    when Status
+      render json: { 'resolvedPath' => "/@#{@resource.account.pretty_acct}/#{@resource.id}" }
+    else
+      render json: {}
+    end
+  end
+
+  private
+
+  def set_url
+    @url = params.require(:url)
+  end
+
+  def set_resource
+    @resource = ResolveURLService.new.call(@url, on_behalf_of: current_user, allow_caching: true) if user_signed_in?
+  end
+end

--- a/app/javascript/mastodon/api.ts
+++ b/app/javascript/mastodon/api.ts
@@ -67,6 +67,7 @@ export async function apiRequest<ApiResponse = unknown>(
   args: {
     params?: RequestParamsOrData;
     data?: RequestParamsOrData;
+    timeout?: number;
   } = {},
 ) {
   const { data } = await api().request<ApiResponse>({
@@ -81,8 +82,9 @@ export async function apiRequest<ApiResponse = unknown>(
 export async function apiRequestGet<ApiResponse = unknown>(
   url: string,
   params?: RequestParamsOrData,
+  timeout?: number
 ) {
-  return apiRequest<ApiResponse>('GET', url, { params });
+  return apiRequest<ApiResponse>('GET', url, {params: params, timeout: timeout });
 }
 
 export async function apiRequestPost<ApiResponse = unknown>(

--- a/app/javascript/mastodon/components/status_content.jsx
+++ b/app/javascript/mastodon/components/status_content.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 
-import { FormattedMessage, injectIntl } from 'react-intl';
+import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
 
 import classnames from 'classnames';
 import { Link, withRouter } from 'react-router-dom';
@@ -10,6 +10,8 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
 
 import ChevronRightIcon from '@/material-icons/400-24px/chevron_right.svg?react';
+import { openModal } from 'mastodon/actions/modal';
+import { apiRequestGet } from 'mastodon/api';
 import { Icon }  from 'mastodon/components/icon';
 import PollContainer from 'mastodon/containers/poll_container';
 import { identityContextPropShape, withIdentity } from 'mastodon/identity_context';
@@ -18,6 +20,10 @@ import { autoPlayGif, languages as preloadedLanguages } from 'mastodon/initial_s
 
 const MAX_HEIGHT = 706; // 22px * 32 (+ 2px padding at the top)
 
+const messages = defineMessages({
+  openExternalLink: { id: 'status_content.external_link.open', defaultMessage: 'You are now leaving mastodon'},
+  openExternalLinkConfirm: { id: 'status_content.external_link.confirm', defaultMessage: 'Open link'},
+});
 /**
  *
  * @param {any} status
@@ -64,6 +70,20 @@ class TranslateButton extends PureComponent {
 
 }
 
+const mapDispatchToProps = (dispatch, { intl }) => ({
+  openExternalLink(url) {
+    dispatch(openModal({
+      modalType: 'CONFIRM',
+      modalProps: {
+        message: intl.formatMessage(messages.openExternalLink),
+        confirm: intl.formatMessage(messages.openExternalLinkConfirm),
+        closeWhenConfirm: true,
+        onConfirm: () => window.open(url, null, 'norefferer'),
+      },
+    }));
+  },
+});
+
 const mapStateToProps = state => ({
   languages: state.getIn(['server', 'translationLanguages', 'items']),
 });
@@ -84,7 +104,8 @@ class StatusContent extends PureComponent {
     // from react-router
     match: PropTypes.object.isRequired,
     location: PropTypes.object.isRequired,
-    history: PropTypes.object.isRequired
+    history: PropTypes.object.isRequired,
+    openExternalLink: PropTypes.func.isRequired
   };
 
   state = {
@@ -122,9 +143,12 @@ class StatusContent extends PureComponent {
       } else if (link.textContent[0] === '#' || (link.previousSibling && link.previousSibling.textContent && link.previousSibling.textContent[link.previousSibling.textContent.length - 1] === '#')) {
         link.addEventListener('click', this.onHashtagClick.bind(this, link.text), false);
         link.setAttribute('href', `/tags/${link.text.replace(/^#/, '')}`);
-      } else {
+      } else if (status.get('uri') === link.href) {
         link.setAttribute('title', link.href);
         link.classList.add('unhandled-link');
+      } else {
+        link.setAttribute('title', link.href);
+        link.addEventListener('click', this.onLinkClick.bind(this, link), false);
       }
     }
 
@@ -189,6 +213,41 @@ class StatusContent extends PureComponent {
       e.preventDefault();
       this.props.history.push(`/tags/${hashtag}`);
     }
+  };
+
+  onLinkClick = (anchor, e) => {
+    if (anchor.getAttribute('search-not-found')) {
+      return;
+    }
+    const url = anchor?.href;
+    if (!url || !(this.props && e.button === 0 && !(e.ctrlKey || e.metaKey))) {
+      return;
+    }
+    e.preventDefault();
+    if (url.startsWith("/")) {
+      this.props.history.push(url);
+      return;
+    }
+    if (url.startsWith(window.location.origin)) {
+      this.props.history.push(url.slice(window.location.origin.length));
+      return;
+    }
+    const query = new URLSearchParams();
+    query.set("url", url);
+    apiRequestGet(`/v2/resolved_url?${query}`, null, 1000)
+      .then((result) => {
+        let resolvedPath = result.resolvedPath;
+
+        if (resolvedPath) {
+          this.props.history.push(resolvedPath);
+        } else {
+          anchor.setAttribute('search-not-found', 'true');
+          window.open(url, null, 'noreferrer');
+        }
+      })
+      .catch(() => {
+        this.props.openExternalLink(url);
+      });
   };
 
   handleMouseDown = (e) => {
@@ -327,4 +386,4 @@ class StatusContent extends PureComponent {
 
 }
 
-export default withRouter(withIdentity(connect(mapStateToProps)(injectIntl(StatusContent))));
+export default withRouter(withIdentity(injectIntl(connect(mapStateToProps, mapDispatchToProps)(StatusContent))));

--- a/app/javascript/mastodon/components/status_content.jsx
+++ b/app/javascript/mastodon/components/status_content.jsx
@@ -78,7 +78,7 @@ const mapDispatchToProps = (dispatch, { intl }) => ({
         message: intl.formatMessage(messages.openExternalLink),
         confirm: intl.formatMessage(messages.openExternalLinkConfirm),
         closeWhenConfirm: true,
-        onConfirm: () => window.open(url, null, 'norefferer'),
+        onConfirm: () => window.open(url, null, 'noreferrer'),
       },
     }));
   },

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -310,6 +310,7 @@ namespace :api, format: false do
   end
 
   namespace :v2 do
+    get '/resolved_url', to: 'resolved_urls#show', as: :resolved_url
     get '/search', to: 'search#index', as: :search
 
     resources :media, only: [:create]


### PR DESCRIPTION
This is a sketch for an alternative approach to #26917 

The goal is to mimick the behavior of native apps in our web UI and not open links in a new tab/window if we can display them "in-app". This is the case for accounts and statuses. The native apps use the search API to "resolve" the linked URL and then decide how to open it. If we try the same on the web, the search API request might take too long and we trigger the browser's built-in pop-up blocking.

#26917 works around these issues by linking to a local "redirect" controller that resolves the URL and redirects properly. This works well but has two important downsides: "Internal" links will still open in a new/tab window and a new "open redirect" is introduced that could easily be exploited.

We pondered a few possible alternatives, including annotating the HTML server-side. But that would add considerable processing time to an already critical code path.

This is a proof of concept of a different approach: If timing is the problem, then maybe we should try to stay within the bounds *most* of the time. This will not work all of the time, but might be "good enough". Besides fixing the issues mentioned above this could also benefit other clients.

The idea is twofold: To get faster results, I added a new API endpoint to resolve URLs. This works similar to the search API but will return faster if a status / account is already known in the local database. A couple of additional optimizations are possible (see below).

On the client-side I added a timeout to the API call to guarantee we stay within the browser's limits. If the timeout triggers, I open a modal warning the user that they are now leaving the site. If they confirm, the link opens in a new tab/window.

This is still only a rough sketch: Here is an incomplete list of what is still missing:

* This is only for statuses. The same should be implemented for account bios.
* When resolving URLs only make an HTTP call to the external server if its domain is within the list of known instances. This should cut down response times for external links a lot.
* A loading indicator when the link is clicked. Even with a small timeout, users might be worried if a click has no immediate effect.
* Proper naming. I am especially unhappy with the name of the new API endpoint. "Resolved URL" is consisent with the existing naming, but does not express what is really going on very well.
* I currently use the existing confirmation modal. This should maybe be replaced to be consistent with the new "interstitial" introduced in #27792. I could not easily re-use that because it currently lives outside of the react app and cannot handle arbitrary external URLs yet.
* Tests

Open questions:
* Should we increase the timeout? I tested with one second, which is still okay(ish) in terms of UI snappiness, but at least double that should be possible.
* Should we cache the resolved URL in the rails cache? This would make the new API endpoint even faster at the cost of redis memory.
* Does the HTTP caching directive make sense here? (I copy&pasted it from #26917)
* And most importantly: Do we  want to go down this route?

(JS code heavily inspired by #28762. Thanks @Joshix-1!)