### PR TITLE
Fix `mastodon:stats` decoration of stats rake task

### DIFF
--- a/lib/tasks/statistics.rake
+++ b/lib/tasks/statistics.rake
@@ -9,11 +9,13 @@ namespace :mastodon do
     [
       ['App Libraries', 'app/lib'],
       %w(Presenters app/presenters),
+      %w(Policies app/policies),
+      %w(Serializers app/serializers),
       %w(Services app/services),
       %w(Validators app/validators),
       %w(Workers app/workers),
     ].each do |name, dir|
-      STATS_DIRECTORIES << [name, Rails.root.join(dir)]
+      STATS_DIRECTORIES << [name, dir]
     end
   end
 end


### PR DESCRIPTION
I think that sometime after this was first created the underlying code in Rails that consumes the constant changed to need just the local relative path and not the full path - so this removes the full path creation.

While in there I noticed a few dirs missing from the group and added those.