### PR TITLE
Update Prettier to 3.3.3

### DIFF
--- a/app/javascript/entrypoints/public.tsx
+++ b/app/javascript/entrypoints/public.tsx
@@ -316,8 +316,8 @@ function loaded() {
 
       const message =
         statusEl.dataset.spoiler === 'expanded'
-          ? localeData['status.show_less'] ?? 'Show less'
-          : localeData['status.show_more'] ?? 'Show more';
+          ? (localeData['status.show_less'] ?? 'Show less')
+          : (localeData['status.show_more'] ?? 'Show more');
       spoilerLink.textContent = new IntlMessageFormat(
         message,
         locale,

--- a/package.json
+++ b/package.json
@@ -187,7 +187,7 @@
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
     "lint-staged": "^15.0.0",
-    "prettier": "^3.0.0",
+    "prettier": "^3.3.3",
     "react-test-renderer": "^18.2.0",
     "stylelint": "^16.0.2",
     "stylelint-config-standard-scss": "^13.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2871,7 +2871,7 @@ __metadata:
     postcss: "npm:^8.4.24"
     postcss-loader: "npm:^4.3.0"
     postcss-preset-env: "npm:^9.5.2"
-    prettier: "npm:^3.0.0"
+    prettier: "npm:^3.3.3"
     prop-types: "npm:^15.8.1"
     punycode: "npm:^2.3.0"
     react: "npm:^18.2.0"
@@ -14129,12 +14129,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^3.0.0":
-  version: 3.3.2
-  resolution: "prettier@npm:3.3.2"
+"prettier@npm:^3.3.3":
+  version: 3.3.3
+  resolution: "prettier@npm:3.3.3"
   bin:
     prettier: bin/prettier.cjs
-  checksum: 10c0/39ed27d17f0238da6dd6571d63026566bd790d3d0edac57c285fbab525982060c8f1e01955fe38134ab10f0951a6076da37f015db8173c02f14bc7f0803a384c
+  checksum: 10c0/b85828b08e7505716324e4245549b9205c0cacb25342a030ba8885aba2039a115dbcf75a0b7ca3b37bc9d101ee61fab8113fc69ca3359f2a226f1ecc07ad2e26
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
https://github.com/mastodon/mastodon/pull/31096 is failing because there is a formatting change for the patch update