### PR TITLE
Fix performance issue by using LATERAL in group notification CTE

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -138,12 +138,10 @@ class Notification < ApplicationRecord
       end
     end
 
-    # This returns notifications from the request page, but with at most one notification per group.
-    # Notifications that have no `group_key` each count as a separate group.
-    def paginate_groups_by_max_id(limit, max_id: nil, since_id: nil)
-      query = reorder(id: :desc)
-      query = query.where(id: ...max_id) if max_id.present?
-      query = query.where(id: (since_id + 1)...) if since_id.present?
+    def paginate_groups(limit, pagination_order)
+      raise ArgumentError unless %i(asc desc).include?(pagination_order)
+
+      query = reorder(id: pagination_order)
 
       unscoped
         .with_recursive(
@@ -164,7 +162,7 @@ class Notification < ApplicationRecord
                     .arel.as('wt'),
                   # Recursive query, using `LATERAL` so we can refer to `wt`
                   query
-                    .where('notifications.id < wt.id')
+                    .where(pagination_order == :desc ? 'notifications.id < wt.id' : 'notifications.id > wt.id')
                     .where.not("COALESCE(notifications.group_key, 'ungrouped-' || notifications.id) = ANY(wt.groups)")
                     .limit(1)
                     .arel.lateral('notifications'),
@@ -174,8 +172,17 @@ class Notification < ApplicationRecord
           ]
         )
         .from('grouped_notifications AS notifications')
-        .order(id: :desc)
+        .order(id: pagination_order)
         .limit(limit)
+    end
+
+    # This returns notifications from the request page, but with at most one notification per group.
+    # Notifications that have no `group_key` each count as a separate group.
+    def paginate_groups_by_max_id(limit, max_id: nil, since_id: nil)
+      query = reorder(id: :desc)
+      query = query.where(id: ...max_id) if max_id.present?
+      query = query.where(id: (since_id + 1)...) if since_id.present?
+      query.paginate_groups(limit, :desc)
     end
 
     # Differs from :paginate_groups_by_max_id in that it gives the results immediately following min_id,
@@ -185,38 +192,7 @@ class Notification < ApplicationRecord
       query = reorder(id: :asc)
       query = query.where(id: (min_id + 1)...) if min_id.present?
       query = query.where(id: ...max_id) if max_id.present?
-
-      unscoped
-        .with_recursive(
-          grouped_notifications: [
-            # Base case: fetching one notification and annotating it with visited groups
-            query
-              .select('notifications.*', "ARRAY[COALESCE(notifications.group_key, 'ungrouped-' || notifications.id)] AS groups")
-              .limit(1),
-            # Recursive case, always yielding at most one annotated notification
-            unscoped
-              .from(
-                [
-                  # Expose the working table as `wt`, but quit early if we've reached the limit
-                  unscoped
-                    .select('id', 'groups')
-                    .from('grouped_notifications')
-                    .where('array_length(grouped_notifications.groups, 1) < :limit', limit: limit)
-                    .arel.as('wt'),
-                  # Recursive query, using `LATERAL` so we can refer to `wt`
-                  query
-                    .where('notifications.id > wt.id')
-                    .where.not("COALESCE(notifications.group_key, 'ungrouped-' || notifications.id) = ANY(wt.groups)")
-                    .limit(1)
-                    .arel.lateral('notifications'),
-                ]
-              )
-              .select('notifications.*', "array_append(wt.groups, COALESCE(notifications.group_key, 'ungrouped-' || notifications.id))"),
-          ]
-        )
-        .from('grouped_notifications AS notifications')
-        .order(id: :asc)
-        .limit(limit)
+      query.paginate_groups(limit, :asc)
     end
 
     def to_a_grouped_paginated_by_id(limit, options = {})


### PR DESCRIPTION
The CTE used `CROSS JOIN` instead of a `JOIN LATERAL`, meaning that the `notifications` query could not use the (single-item) working table for quick filtering, and had to filter and limit *a posteriori*, causing a lot of extra work.

Unfortunately, it does not seem ActiveRecord exposes `LATERAL`, so we have to work around with `arel`. Using the `FROM foo, LATERAL (SELECT …)` allows keeping `arel` usage to a minimal.