### PR TITLE
WIP: Expose if an OAuth Application is a user-owned application

### DIFF
--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -35,6 +35,17 @@ code {
     display: none;
   }
 
+  a {
+    color: $highlight-text-color;
+    text-decoration: underline;
+
+    &:hover,
+    &:active,
+    &:focus {
+      text-decoration: none;
+    }
+  }
+
   .input {
     margin-bottom: 16px;
     overflow: hidden;

--- a/app/views/oauth/authorizations/new.html.haml
+++ b/app/views/oauth/authorizations/new.html.haml
@@ -6,6 +6,8 @@
     %h3= t('doorkeeper.authorizations.new.title')
 
     %p= t('doorkeeper.authorizations.new.prompt_html', client_name: content_tag(:strong, @pre_auth.client.name))
+    - if @pre_auth.client.application.owner
+      %p= t('doorkeeper.authorizations.new.prompt_author_html', author_profile: link_to(@pre_auth.client.application.owner.account.local_username_and_domain, account_path(@pre_auth.client.application.owner.account)))
 
     %h3= t('doorkeeper.authorizations.new.review_permissions')
 

--- a/config/locales/doorkeeper.en.yml
+++ b/config/locales/doorkeeper.en.yml
@@ -61,6 +61,7 @@ en:
         title: An error has occurred
       new:
         prompt_html: "%{client_name} would like permission to access your account. It is a third-party application. <strong>If you do not trust it, then you should not authorize it.</strong>"
+        prompt_author_html: 'This application was created by <span class="username">@%{author_profile}</span>'
         review_permissions: Review permissions
         title: Authorization required
       show:


### PR DESCRIPTION
Currently since we have multiple ways of creating OAuth Applications (`/api/v1/apps`, Developer Settings), there's potential for a malicious user on a server to register an OAuth Application that impersonates an well known application that users `/api/v1/apps`

This attempts to address that potential application mix-up by exposing more details about the registered application to users during the OAuth Application flow.

This is just one mitigation attempt for [OAuth 2.0 Mix-Up Attacks](https://www.ietf.org/archive/id/draft-ietf-oauth-security-topics-27.html#name-mix-up-attacks), we should also follow other Security Best Current Practices, for which I've created a number of issues for recently.

![image](https://github.com/user-attachments/assets/d4e4e7ad-b1f4-4541-bedf-f182e86d26c9)
