### PR TITLE
Adjust ffmpeg version detection in admin panel

### DIFF
--- a/app/lib/admin/metrics/dimension/software_versions_dimension.rb
+++ b/app/lib/admin/metrics/dimension/software_versions_dimension.rb
@@ -98,7 +98,10 @@ class Admin::Metrics::Dimension::SoftwareVersionsDimension < Admin::Metrics::Dim
   end
 
   def ffmpeg_version
-    version = `ffmpeg -version`.match(/ffmpeg version ([^\s]+)/)[1]
+    version_output = `ffmpeg -version`
+    version_match = version_output.match(/ffmpeg version ([\d\.]+|[^\s]+)/)
+
+    version = version_match ? version_match[1] : '0.0.0'
 
     {
       key: 'ffmpeg',

--- a/app/lib/admin/metrics/dimension/software_versions_dimension.rb
+++ b/app/lib/admin/metrics/dimension/software_versions_dimension.rb
@@ -98,7 +98,7 @@ class Admin::Metrics::Dimension::SoftwareVersionsDimension < Admin::Metrics::Dim
   end
 
   def ffmpeg_version
-    version = `ffmpeg -version`.match(/ffmpeg version ([\d\.]+)/)[1]
+    version = `ffmpeg -version`.match(/ffmpeg version ([^\s]+)/)[1]
 
     {
       key: 'ffmpeg',

--- a/app/lib/admin/metrics/dimension/software_versions_dimension.rb
+++ b/app/lib/admin/metrics/dimension/software_versions_dimension.rb
@@ -107,11 +107,7 @@ class Admin::Metrics::Dimension::SoftwareVersionsDimension < Admin::Metrics::Dim
       value: version,
       human_value: version,
     }
-  rescue Terrapin::CommandNotFoundError
-    nil
-  rescue Terrapin::ExitStatusError
-    nil
-  rescue Oj::ParseError
+  rescue Terrapin::CommandNotFoundError, Terrapin::ExitStatusError, Oj::ParseError
     nil
   end
 

--- a/app/lib/admin/metrics/dimension/software_versions_dimension.rb
+++ b/app/lib/admin/metrics/dimension/software_versions_dimension.rb
@@ -98,7 +98,7 @@ class Admin::Metrics::Dimension::SoftwareVersionsDimension < Admin::Metrics::Dim
   end
 
   def ffmpeg_version
-    version_output = `ffmpeg -version`
+    version_output = Terrapin::CommandLine.new(Rails.configuration.x.ffmpeg_binary, "-version").run
     version_match = version_output.match(/ffmpeg version ([\d\.]+|[^\s]+)/)
 
     version = version_match ? version_match[1] : '0.0.0'

--- a/app/lib/admin/metrics/dimension/software_versions_dimension.rb
+++ b/app/lib/admin/metrics/dimension/software_versions_dimension.rb
@@ -98,7 +98,7 @@ class Admin::Metrics::Dimension::SoftwareVersionsDimension < Admin::Metrics::Dim
   end
 
   def ffmpeg_version
-    version_output = Terrapin::CommandLine.new(Rails.configuration.x.ffmpeg_binary, "-version").run
+    version_output = Terrapin::CommandLine.new(Rails.configuration.x.ffmpeg_binary, '-version').run
     version_match = version_output.match(/ffmpeg version ([\d\.]+|[^\s]+)/)
 
     version = version_match ? version_match[1] : '0.0.0'

--- a/app/lib/admin/metrics/dimension/software_versions_dimension.rb
+++ b/app/lib/admin/metrics/dimension/software_versions_dimension.rb
@@ -107,7 +107,11 @@ class Admin::Metrics::Dimension::SoftwareVersionsDimension < Admin::Metrics::Dim
       value: version,
       human_value: version,
     }
-  rescue Errno::ENOENT
+  rescue Terrapin::CommandNotFoundError
+    nil
+  rescue Terrapin::ExitStatusError
+    nil
+  rescue Oj::ParseError
     nil
   end
 

--- a/app/lib/admin/metrics/dimension/software_versions_dimension.rb
+++ b/app/lib/admin/metrics/dimension/software_versions_dimension.rb
@@ -98,10 +98,8 @@ class Admin::Metrics::Dimension::SoftwareVersionsDimension < Admin::Metrics::Dim
   end
 
   def ffmpeg_version
-    version_output = Terrapin::CommandLine.new(Rails.configuration.x.ffmpeg_binary, '-version').run
-    version_match = version_output.match(/ffmpeg version ([\d\.]+|[^\s]+)/)
-
-    version = version_match ? version_match[1] : '0.0.0'
+    version_output = Terrapin::CommandLine.new(Rails.configuration.x.ffprobe_binary, '-show_program_version -v 0 -of json').run
+    version = Oj.load(version_output, mode: :strict, symbol_keys: true).dig(:program_version, :version)
 
     {
       key: 'ffmpeg',


### PR DESCRIPTION
The static builds linked off of ffmpeg.org use a non-X.Y.Z format that the previous regex was failing on. This looks for number format or the next block of text instead of matching the number format. If neither function it'll return 0.0.0.

<img width="412" alt="image" src="https://github.com/user-attachments/assets/a1a2c8c3-1f5e-47d9-82ae-3c8b810f8b7e">
