### PR TITLE
Add support for PKCE Extension in OmniAuth OIDC

### DIFF
--- a/config/initializers/3_omniauth.rb
+++ b/config/initializers/3_omniauth.rb
@@ -84,6 +84,7 @@ Devise.setup do |config|
     oidc_options[:response_mode] = ENV['OIDC_RESPONSE_MODE'] if ENV['OIDC_RESPONSE_MODE'] # OPTIONAL (default: query)
     oidc_options[:display] = ENV['OIDC_DISPLAY'] if ENV['OIDC_DISPLAY'] # OPTIONAL (default: page)
     oidc_options[:prompt] = ENV['OIDC_PROMPT'] if ENV['OIDC_PROMPT'] # OPTIONAL
+    oidc_options[:pkce] = ENV['OIDC_USE_PKCE'] == 'true' if ENV['OIDC_USE_PKCE'] # OPTIONAL (default: false)
     oidc_options[:send_nonce] = ENV['OIDC_SEND_NONCE'] == 'true' if ENV['OIDC_SEND_NONCE'] # OPTIONAL (default: true)
     oidc_options[:send_scope_to_token_endpoint] = ENV['OIDC_SEND_SCOPE_TO_TOKEN_ENDPOINT'] == 'true' if ENV['OIDC_SEND_SCOPE_TO_TOKEN_ENDPOINT'] # OPTIONAL (default: true)
     oidc_options[:post_logout_redirect_uri] = ENV['OIDC_IDP_LOGOUT_REDIRECT_URI'] if ENV['OIDC_IDP_LOGOUT_REDIRECT_URI'] # OPTIONAL


### PR DESCRIPTION
This pull request introduces a new optional environment variable of `OIDC_USE_PKCE` whose value must be `"true"` for PKCE to be enabled.

Since there's only [two code_challenge_methods](https://www.iana.org/assignments/oauth-parameters/oauth-parameters.xhtml#pkce-code-challenge-method), and [plain should not be used](https://www.ietf.org/archive/id/draft-ietf-oauth-security-topics-27.html#section-2.1.1-5), and OmniAuth uses S256 by default, we only support enabling or disabling PKCE. It is disabled by default.

This was requested by @erlend-sh by accident on #30329 where he thought that [pull request affected SSO](https://github.com/commune-os/weird/issues/28), when it actually only affected our OAuth setup for API access. (at least, I think that's what happened, correct me if I'm wrong).

