### PR TITLE
Refresh Heroku related thingy for heroku-24 stack

### DIFF
--- a/.profile
+++ b/.profile
@@ -1,1 +1,0 @@
-LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/app/.apt/lib/x86_64-linux-gnu:/app/.apt/usr/lib/x86_64-linux-gnu/mesa:/app/.apt/usr/lib/x86_64-linux-gnu/pulseaudio:/app/.apt/usr/lib/x86_64-linux-gnu/openblas-pthread

--- a/Aptfile
+++ b/Aptfile
@@ -1,5 +1,5 @@
-ffmpeg
-libopenblas0-pthread
-libpq-dev
-libxdamage1
-libxfixes3
+libidn12
+# for idn-ruby on heroku-24 stack
+
+# use https://github.com/heroku/heroku-buildpack-activestorage-preview
+# in place for ffmpeg and its dependent packages to reduce slag size

--- a/Procfile
+++ b/Procfile
@@ -11,4 +11,4 @@ worker: bundle exec sidekiq
 #
 # and let the main app use the separate app:
 #
-# heroku config:set STREAMING_API_BASE_URL=wss://<streaming-app>.herokuapp.com -a <main-app>
+# heroku config:set STREAMING_API_BASE_URL=wss://<streaming-app-random>.herokuapp.com -a <main-app>

--- a/app.json
+++ b/app.json
@@ -91,7 +91,13 @@
   },
   "buildpacks": [
     {
+      "url": "https://github.com/heroku/heroku-buildpack-activestorage-preview"
+    },
+    {
       "url": "https://github.com/heroku/heroku-buildpack-apt"
+    },
+    {
+      "url": "heroku/nodejs"
     },
     {
       "url": "heroku/ruby"
@@ -100,5 +106,6 @@
   "scripts": {
     "postdeploy": "bundle exec rails db:migrate && bundle exec rails db:seed"
   },
-  "addons": ["heroku-postgresql", "heroku-redis"]
+  "addons": ["heroku-postgresql", "heroku-redis"],
+  "stack": "heroku-24"
 }


### PR DESCRIPTION
This should make it possible to run Puma on Heroku with steps like:

```
$ export HEROKU_APP=<app-name>
$ heroku create --addons heroku-postgresql,heroku-redis -s heroku-24
$ heroku buildpacks:add https://github.com/heroku/heroku-buildpack-activestorage-preview
$ heroku buildpacks:add https://github.com/heroku/heroku-buildpack-apt
$ heroku buildpacks:add heroku/nodejs
$ heroku buildpacks:add heroku/ruby
$ heroku config:set \
OTP_SECRET=`ruby -r securerandom -e 'puts SecureRandom.hex(64)'` \
RAILS_SERVE_STATIC_FILES=true \
LOCAL_DOMAIN=`heroku domains --json | jq -r '.[] | select(.kind=="heroku").hostname'` \
`RAILS_ENV=production bin/rails db:encryption:init | grep ^ACTIVE_RECORD_ENCRYPTION_`
$ git push heroku main
$ heroku run rake db:migrate
```