### PR TITLE
Improve failure message on pagination matcher

### DIFF
--- a/spec/support/matchers/api_pagination.rb
+++ b/spec/support/matchers/api_pagination.rb
@@ -7,7 +7,7 @@ RSpec::Matchers.define :include_pagination_headers do |links|
     end.all?
   end
 
-  failure_message do |header|
-    "expected that #{header} would have the same values as #{links}."
+  failure_message do |response|
+    "expected that #{response.headers['Link']} would have the same values as #{links}."
   end
 end


### PR DESCRIPTION
Related to intermittent failures like - https://github.com/mastodon/mastodon/actions/runs/10090024708/job/27898697766?pr=31139

The current failure message is like:

```
expected that #<ActionDispatch::TestResponse:0x000000030a5fdf40> would have the same values as {:prev=>"http://www.example.com/api/v1/timelines/tag/love?age=123&limit=1&min_id=112847500723286951", :next=>"http://www.example.com/api/v1/timelines/tag/love?limit=1&max_id=112847500723286951"}.
```

Change here is something like:

```
expected that <http://www.example.com/api/v1/timelines/tag/love?limit=1&max_id=112847502660442460>; rel="next", <http://www.example.com/api/v1/timelines/tag/love?limit=1&min_id=112847502660442460>; rel="prev" would have the same values as {:prev=>"http://www.example.com/api/v1/timelines/tag/love?age=123&limit=1&min_id=112847502660442460", :next=>"http://www.example.com/api/v1/timelines/tag/love?limit=1&max_id=112847502660442460"}.
```