### PR TITLE
Decrease count of filtered notifications  when notification requests are accepted or dismissed

### DIFF
--- a/app/javascript/mastodon/actions/notification_policies.ts
+++ b/app/javascript/mastodon/actions/notification_policies.ts
@@ -18,5 +18,5 @@ export const updateNotificationsPolicy = createDataLoadingThunk(
 );
 
 export const decreasePendingNotificationsCount = createAction<number>(
-  'notification_policy/decrease_pending_notification_count',
+  'notificationPolicy/decreasePendingNotificationCount',
 );

--- a/app/javascript/mastodon/actions/notification_policies.ts
+++ b/app/javascript/mastodon/actions/notification_policies.ts
@@ -1,3 +1,5 @@
+import { createAction } from '@reduxjs/toolkit';
+
 import {
   apiGetNotificationPolicy,
   apiUpdateNotificationsPolicy,
@@ -13,4 +15,8 @@ export const fetchNotificationPolicy = createDataLoadingThunk(
 export const updateNotificationsPolicy = createDataLoadingThunk(
   'notificationPolicy/update',
   (policy: Partial<NotificationPolicy>) => apiUpdateNotificationsPolicy(policy),
+);
+
+export const decreasePendingNotificationsCount = createAction<number>(
+  'notification_policy/decrease_pending_notification_count',
 );

--- a/app/javascript/mastodon/actions/notifications.js
+++ b/app/javascript/mastodon/actions/notifications.js
@@ -85,6 +85,12 @@ const fetchRelatedRelationships = (dispatch, notifications) => {
   }
 };
 
+const selectNotificationCountForRequest = (state, id) => {
+  const requests = state.getIn(['notificationRequests', 'items']);
+  const thisRequest = requests.find(request => request.get('id') === id);
+  return thisRequest ? thisRequest.get('notifications_count') : 0;
+};
+
 export const loadPending = () => ({
   type: NOTIFICATIONS_LOAD_PENDING,
 });
@@ -434,7 +440,8 @@ export const fetchNotificationRequestFail = (id, error) => ({
   error,
 });
 
-export const acceptNotificationRequest = (id, count) => (dispatch) => {
+export const acceptNotificationRequest = (id) => (dispatch, getState) => {
+  const count = selectNotificationCountForRequest(getState(), id);
   dispatch(acceptNotificationRequestRequest(id));
 
   api().post(`/api/v1/notifications/requests/${id}/accept`).then(() => {
@@ -461,7 +468,8 @@ export const acceptNotificationRequestFail = (id, error) => ({
   error,
 });
 
-export const dismissNotificationRequest = (id, count) => (dispatch) => {
+export const dismissNotificationRequest = (id) => (dispatch, getState) => {
+  const count = selectNotificationCountForRequest(getState(), id);
   dispatch(dismissNotificationRequestRequest(id));
 
   api().post(`/api/v1/notifications/requests/${id}/dismiss`).then(() =>{

--- a/app/javascript/mastodon/actions/notifications.js
+++ b/app/javascript/mastodon/actions/notifications.js
@@ -18,6 +18,7 @@ import {
   importFetchedStatuses,
 } from './importer';
 import { submitMarkers } from './markers';
+import { decreasePendingNotificationsCount } from './notification_policies';
 import { notificationsUpdate } from "./notifications_typed";
 import { register as registerPushNotifications } from './push_notifications';
 import { saveSettings } from './settings';
@@ -433,11 +434,12 @@ export const fetchNotificationRequestFail = (id, error) => ({
   error,
 });
 
-export const acceptNotificationRequest = id => (dispatch) => {
+export const acceptNotificationRequest = (id, count) => (dispatch) => {
   dispatch(acceptNotificationRequestRequest(id));
 
   api().post(`/api/v1/notifications/requests/${id}/accept`).then(() => {
     dispatch(acceptNotificationRequestSuccess(id));
+    dispatch(decreasePendingNotificationsCount(count));
   }).catch(err => {
     dispatch(acceptNotificationRequestFail(id, err));
   });
@@ -459,11 +461,12 @@ export const acceptNotificationRequestFail = (id, error) => ({
   error,
 });
 
-export const dismissNotificationRequest = id => (dispatch) => {
+export const dismissNotificationRequest = (id, count) => (dispatch) => {
   dispatch(dismissNotificationRequestRequest(id));
 
   api().post(`/api/v1/notifications/requests/${id}/dismiss`).then(() =>{
     dispatch(dismissNotificationRequestSuccess(id));
+    dispatch(decreasePendingNotificationsCount(count));
   }).catch(err => {
     dispatch(dismissNotificationRequestFail(id, err));
   });

--- a/app/javascript/mastodon/features/notifications/components/notification_request.jsx
+++ b/app/javascript/mastodon/features/notifications/components/notification_request.jsx
@@ -28,12 +28,12 @@ export const NotificationRequest = ({ id, accountId, notificationsCount }) => {
   const intl = useIntl();
 
   const handleDismiss = useCallback(() => {
-    dispatch(dismissNotificationRequest(id, notificationsCount));
-  }, [dispatch, id, notificationsCount]);
+    dispatch(dismissNotificationRequest(id));
+  }, [dispatch, id]);
 
   const handleAccept = useCallback(() => {
-    dispatch(acceptNotificationRequest(id, notificationsCount));
-  }, [dispatch, id, notificationsCount]);
+    dispatch(acceptNotificationRequest(id));
+  }, [dispatch, id]);
 
   return (
     <div className='notification-request'>

--- a/app/javascript/mastodon/features/notifications/components/notification_request.jsx
+++ b/app/javascript/mastodon/features/notifications/components/notification_request.jsx
@@ -28,12 +28,12 @@ export const NotificationRequest = ({ id, accountId, notificationsCount }) => {
   const intl = useIntl();
 
   const handleDismiss = useCallback(() => {
-    dispatch(dismissNotificationRequest(id));
-  }, [dispatch, id]);
+    dispatch(dismissNotificationRequest(id, notificationsCount));
+  }, [dispatch, id, notificationsCount]);
 
   const handleAccept = useCallback(() => {
-    dispatch(acceptNotificationRequest(id));
-  }, [dispatch, id]);
+    dispatch(acceptNotificationRequest(id, notificationsCount));
+  }, [dispatch, id, notificationsCount]);
 
   return (
     <div className='notification-request'>

--- a/app/javascript/mastodon/reducers/notification_policy.ts
+++ b/app/javascript/mastodon/reducers/notification_policy.ts
@@ -2,17 +2,23 @@ import { createReducer, isAnyOf } from '@reduxjs/toolkit';
 
 import {
   fetchNotificationPolicy,
+  decreasePendingNotificationsCount,
   updateNotificationsPolicy,
 } from 'mastodon/actions/notification_policies';
 import type { NotificationPolicy } from 'mastodon/models/notification_policy';
 
 export const notificationPolicyReducer =
   createReducer<NotificationPolicy | null>(null, (builder) => {
-    builder.addMatcher(
-      isAnyOf(
-        fetchNotificationPolicy.fulfilled,
-        updateNotificationsPolicy.fulfilled,
-      ),
-      (_state, action) => action.payload,
-    );
+    builder
+      .addCase(decreasePendingNotificationsCount, (state, action) => {
+        state.summary.pending_notifications_count -= action.payload;
+        state.summary.pending_requests_count -= 1;
+      })
+      .addMatcher(
+        isAnyOf(
+          fetchNotificationPolicy.fulfilled,
+          updateNotificationsPolicy.fulfilled,
+        ),
+        (_state, action) => action.payload,
+      );
   });

--- a/app/javascript/mastodon/reducers/notification_policy.ts
+++ b/app/javascript/mastodon/reducers/notification_policy.ts
@@ -11,8 +11,10 @@ export const notificationPolicyReducer =
   createReducer<NotificationPolicy | null>(null, (builder) => {
     builder
       .addCase(decreasePendingNotificationsCount, (state, action) => {
-        state.summary.pending_notifications_count -= action.payload;
-        state.summary.pending_requests_count -= 1;
+        if (state) {
+          state.summary.pending_notifications_count -= action.payload;
+          state.summary.pending_requests_count -= 1;
+        }
       })
       .addMatcher(
         isAnyOf(


### PR DESCRIPTION
Partially addresses MAS-285

Currently when a notification request is either accepted or dismissed the filtered notifications banner on top of the notifications column does not change immediately. One has to reload the page or wait until the banner re-fetches its data from the server.

This is not very ... reactive :grimacing: 

This commit tries to fix that by making the reaction immediate without re-fetching data from the server.

This is my first time doing anything with redux, so please ge gentle :slightly_smiling_face: 