### PR TITLE
Add `Reviewable` model concern

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -89,6 +89,7 @@ class Account < ApplicationRecord
   include DomainMaterializable
   include DomainNormalizable
   include Paginable
+  include Reviewable
 
   enum :protocol, { ostatus: 0, activitypub: 1 }
   enum :suspension_origin, { local: 0, remote: 1 }, prefix: true
@@ -423,22 +424,6 @@ class Account < ApplicationRecord
     return 'local' if local?
 
     @synchronization_uri_prefix ||= "#{uri[URL_PREFIX_RE]}/"
-  end
-
-  def requires_review?
-    reviewed_at.nil?
-  end
-
-  def reviewed?
-    reviewed_at.present?
-  end
-
-  def requested_review?
-    requested_review_at.present?
-  end
-
-  def requires_review_notification?
-    requires_review? && !requested_review?
   end
 
   class << self

--- a/app/models/concerns/reviewable.rb
+++ b/app/models/concerns/reviewable.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Reviewable
+  extend ActiveSupport::Concern
+
+  def requires_review?
+    reviewed_at.nil?
+  end
+
+  def reviewed?
+    reviewed_at.present?
+  end
+
+  def requested_review?
+    requested_review_at.present?
+  end
+
+  def requires_review_notification?
+    requires_review? && !requested_review?
+  end
+end

--- a/app/models/preview_card_provider.rb
+++ b/app/models/preview_card_provider.rb
@@ -21,6 +21,7 @@ class PreviewCardProvider < ApplicationRecord
   include Paginable
   include DomainNormalizable
   include Attachmentable
+  include Reviewable
 
   ICON_MIME_TYPES = %w(image/x-icon image/vnd.microsoft.icon image/png).freeze
   LIMIT = 1.megabyte
@@ -35,22 +36,6 @@ class PreviewCardProvider < ApplicationRecord
   scope :not_trendable, -> { where(trendable: false) }
   scope :reviewed, -> { where.not(reviewed_at: nil) }
   scope :pending_review, -> { where(reviewed_at: nil) }
-
-  def requires_review?
-    reviewed_at.nil?
-  end
-
-  def reviewed?
-    reviewed_at.present?
-  end
-
-  def requested_review?
-    requested_review_at.present?
-  end
-
-  def requires_review_notification?
-    requires_review? && !requested_review?
-  end
 
   def self.matching_domain(domain)
     segments = domain.split('.')

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -21,6 +21,8 @@
 
 class Tag < ApplicationRecord
   include Paginable
+  include Reviewable
+
   # rubocop:disable Rails/HasAndBelongsToMany
   has_and_belongs_to_many :statuses
   has_and_belongs_to_many :accounts
@@ -96,22 +98,6 @@ class Tag < ApplicationRecord
   end
 
   alias trendable? trendable
-
-  def requires_review?
-    reviewed_at.nil?
-  end
-
-  def reviewed?
-    reviewed_at.present?
-  end
-
-  def requested_review?
-    requested_review_at.present?
-  end
-
-  def requires_review_notification?
-    requires_review? && !requested_review?
-  end
 
   def decaying?
     max_score_at && max_score_at >= Trends.tags.options[:max_score_cooldown].ago && max_score_at < 1.day.ago

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Account do
+  include_examples 'Reviewable'
+
   context 'with an account record' do
     subject { Fabricate(:account) }
 

--- a/spec/models/preview_card_provider_spec.rb
+++ b/spec/models/preview_card_provider_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 describe PreviewCardProvider do
+  include_examples 'Reviewable'
+
   describe 'scopes' do
     let(:trendable_and_reviewed) { Fabricate(:preview_card_provider, trendable: true, reviewed_at: 5.days.ago) }
     let(:not_trendable_and_not_reviewed) { Fabricate(:preview_card_provider, trendable: false, reviewed_at: nil) }

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Tag do
+  include_examples 'Reviewable'
+
   describe 'validations' do
     it 'invalid with #' do
       expect(described_class.new(name: '#hello_world')).to_not be_valid

--- a/spec/support/examples/models/concerns/reviewable.rb
+++ b/spec/support/examples/models/concerns/reviewable.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+shared_examples 'Reviewable' do
+  subject { described_class.new(reviewed_at: reviewed_at, requested_review_at: requested_review_at) }
+
+  let(:reviewed_at) { nil }
+  let(:requested_review_at) { nil }
+
+  describe '#requires_review?' do
+    it { is_expected.to be_requires_review }
+
+    context 'when reviewed_at is not null' do
+      let(:reviewed_at) { 5.days.ago }
+
+      it { is_expected.to_not be_requires_review }
+    end
+  end
+
+  describe '#reviewed?' do
+    it { is_expected.to_not be_reviewed }
+
+    context 'when reviewed_at is not null' do
+      let(:reviewed_at) { 5.days.ago }
+
+      it { is_expected.to be_reviewed }
+    end
+  end
+
+  describe '#requested_review?' do
+    it { is_expected.to_not be_requested_review }
+
+    context 'when requested_reviewed_at is not null' do
+      let(:requested_review_at) { 5.days.ago }
+
+      it { is_expected.to be_requested_review }
+    end
+  end
+
+  describe '#requires_review_notification?' do
+    it { is_expected.to be_requires_review_notification }
+
+    context 'when reviewed_at is not null' do
+      let(:reviewed_at) { 5.days.ago }
+
+      it { is_expected.to_not be_requires_review_notification }
+    end
+
+    context 'when requested_reviewed_at is not null' do
+      let(:requested_review_at) { 5.days.ago }
+
+      it { is_expected.to_not be_requires_review_notification }
+    end
+  end
+end


### PR DESCRIPTION
The `Account`, `Tag` and `PreviewCardProvider` models all have these same two columns which are used in these same four query methods. Extract the query methods to a shared concern.

I also noticed zero coverage for these methods in any of the models, so added a shared example which they all include for that (just basic truth table sort of thing).

Possible future work here -- there are some similarly-named (but not exactly the same) scopes using these columns across the models. It would make sense to unify their usage/naming and pull those out into this concern as well.