### PR TITLE
Extrude `fill_in_auth_details` method to `ProfileStories` spec support module

### DIFF
--- a/spec/support/stories/profile_stories.rb
+++ b/spec/support/stories/profile_stories.rb
@@ -3,6 +3,12 @@
 module ProfileStories
   attr_reader :bob, :alice, :alice_bio
 
+  def fill_in_auth_details(email, password)
+    fill_in 'user_email', with: email
+    fill_in 'user_password', with: password
+    click_on I18n.t('auth.login')
+  end
+
   def as_a_registered_user
     @bob = Fabricate(
       :user,
@@ -16,9 +22,7 @@ module ProfileStories
   def as_a_logged_in_user
     as_a_registered_user
     visit new_user_session_path
-    fill_in 'user_email', with: email
-    fill_in 'user_password', with: password
-    click_on I18n.t('auth.login')
+    fill_in_auth_details(email, password)
   end
 
   def as_a_logged_in_admin

--- a/spec/system/log_in_spec.rb
+++ b/spec/system/log_in_spec.rb
@@ -17,17 +17,13 @@ describe 'Log in' do
   end
 
   it 'A valid email and password user is able to log in' do
-    fill_in 'user_email', with: email
-    fill_in 'user_password', with: password
-    click_on I18n.t('auth.login')
+    fill_in_auth_details(email, password)
 
     expect(subject).to have_css('div.app-holder')
   end
 
   it 'A invalid email and password user is not able to log in' do
-    fill_in 'user_email', with: 'invalid_email'
-    fill_in 'user_password', with: 'invalid_password'
-    click_on I18n.t('auth.login')
+    fill_in_auth_details('invalid_email', 'invalid_password')
 
     expect(subject).to have_css('.flash-message', text: failure_message('invalid'))
   end
@@ -36,9 +32,7 @@ describe 'Log in' do
     let(:confirmed_at) { nil }
 
     it 'A unconfirmed user is able to log in' do
-      fill_in 'user_email', with: email
-      fill_in 'user_password', with: password
-      click_on I18n.t('auth.login')
+      fill_in_auth_details(email, password)
 
       expect(subject).to have_css('div.admin-wrapper')
     end

--- a/spec/system/oauth_spec.rb
+++ b/spec/system/oauth_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 describe 'Using OAuth from an external app' do
+  include ProfileStories
+
   subject { visit "/oauth/authorize?#{params.to_query}" }
 
   let(:client_app) { Doorkeeper::Application.create!(name: 'test', redirect_uri: about_url(host: Rails.application.config.x.local_domain), scopes: 'read') }
@@ -245,12 +247,6 @@ describe 'Using OAuth from an external app' do
   end
 
   private
-
-  def fill_in_auth_details(email, password)
-    fill_in 'user_email', with: email
-    fill_in 'user_password', with: password
-    click_on I18n.t('auth.login')
-  end
 
   def fill_in_otp_details(value)
     fill_in 'user_otp_attempt', with: value


### PR DESCRIPTION
This method was already defined in one of the specs, but we are doing the same sequence of steps in a few other spots. Pull out to the shared support module, and use the method in the other places.

Part of general spec helper cleanup in advance of moving some controller specs to system specs.