### PR TITLE
Remove single-use `ProfileStories` method

### DIFF
--- a/spec/support/stories/profile_stories.rb
+++ b/spec/support/stories/profile_stories.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ProfileStories
-  attr_reader :bob, :alice, :alice_bio
+  attr_reader :bob
 
   def fill_in_auth_details(email, password)
     fill_in 'user_email', with: email

--- a/spec/support/stories/profile_stories.rb
+++ b/spec/support/stories/profile_stories.rb
@@ -31,18 +31,6 @@ module ProfileStories
     bob.update!(role: UserRole.find_by!(name: 'Admin'))
   end
 
-  def with_alice_as_local_user
-    @alice_bio = '@alice and @bob are fictional characters commonly used as' \
-                 'placeholder names in #cryptology, as well as #science and' \
-                 'engineering 📖 literature. Not affiliated with @pepe.'
-
-    @alice = Fabricate(
-      :user,
-      email: 'alice@example.com', password: password, confirmed_at: confirmed_at,
-      account: Fabricate(:account, username: 'alice', note: @alice_bio)
-    )
-  end
-
   def confirmed_at
     @confirmed_at ||= Time.zone.now
   end

--- a/spec/system/profile_spec.rb
+++ b/spec/system/profile_spec.rb
@@ -11,10 +11,10 @@ RSpec.describe 'Profile' do
 
   before do
     as_a_logged_in_user
-    with_alice_as_local_user
+    Fabricate(:user, account: Fabricate(:account, username: 'alice'))
   end
 
-  it 'I can view Annes public account' do
+  it 'I can view public account page for Alice' do
     visit account_path('alice')
 
     expect(subject).to have_title("alice (@alice@#{local_domain})")


### PR DESCRIPTION
This method is only used in this one spot, the values can all just be made by the fabricator, and only one of them (the username) really matters to the spec in question).
