### PR TITLE
Follow up tweaking of admin UI changes

### DIFF
--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -298,12 +298,6 @@ html {
 .directory__tag > div {
   background: $white;
   border: 1px solid var(--background-border-color);
-
-  @media screen and (max-width: $no-gap-breakpoint) {
-    border-left: 0;
-    border-right: 0;
-    border-top: 0;
-  }
 }
 
 .picture-in-picture-placeholder {
@@ -317,10 +311,6 @@ html {
   &:active,
   &:focus {
     background: $ui-base-color;
-  }
-
-  @media screen and (max-width: $no-gap-breakpoint) {
-    border: 0;
   }
 }
 

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -1,6 +1,6 @@
 @use 'sass:math';
 
-$no-columns-breakpoint: 600px;
+$no-columns-breakpoint: 890px;
 $sidebar-width: 300px;
 $content-width: 840px;
 


### PR DESCRIPTION
Follow up to #31034

- Fix missing borders on admin/federation in single-column/mobile light theme
- Adjusts breakpoint to trigger single-column/mobile view sooner, matching main UI