### PR TITLE
Reuse REST::RoleSerializer in REST::AccountSerializer

### DIFF
--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -10,7 +10,7 @@ class InitialStateSerializer < ActiveModel::Serializer
   attribute :critical_updates_pending, if: -> { object&.role&.can?(:view_devops) && SoftwareUpdate.check_enabled? }
 
   has_one :push_subscription, serializer: REST::WebPushSubscriptionSerializer
-  has_one :role, serializer: REST::RoleSerializer
+  has_one :role, serializer: REST::CredentialRoleSerializer
 
   def meta
     store = default_meta_store

--- a/app/serializers/rest/account_serializer.rb
+++ b/app/serializers/rest/account_serializer.rb
@@ -30,15 +30,7 @@ class REST::AccountSerializer < ActiveModel::Serializer
     end
   end
 
-  class RoleSerializer < ActiveModel::Serializer
-    attributes :id, :name, :color
-
-    def id
-      object.id.to_s
-    end
-  end
-
-  has_many :roles, serializer: RoleSerializer, if: :local?
+  has_many :roles, serializer: REST::RoleSerializer, if: :local?
 
   class FieldSerializer < ActiveModel::Serializer
     include FormattingHelper

--- a/app/serializers/rest/admin/account_serializer.rb
+++ b/app/serializers/rest/admin/account_serializer.rb
@@ -11,7 +11,7 @@ class REST::Admin::AccountSerializer < ActiveModel::Serializer
 
   has_many :ips, serializer: REST::Admin::IpSerializer
   has_one :account, serializer: REST::AccountSerializer
-  has_one :role, serializer: REST::RoleSerializer
+  has_one :role, serializer: REST::CredentialRoleSerializer
 
   def id
     object.id.to_s

--- a/app/serializers/rest/credential_role_serializer.rb
+++ b/app/serializers/rest/credential_role_serializer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class REST::CredentialRoleSerializer < REST::RoleSerializer
+  attributes :permissions
+
+  def permissions
+    object.computed_permissions.to_s
+  end
+end

--- a/app/serializers/rest/role_serializer.rb
+++ b/app/serializers/rest/role_serializer.rb
@@ -6,8 +6,4 @@ class REST::RoleSerializer < ActiveModel::Serializer
   def id
     object.id.to_s
   end
-
-  def permissions
-    object.computed_permissions.to_s
-  end
 end

--- a/spec/serializers/rest/account_serializer_spec.rb
+++ b/spec/serializers/rest/account_serializer_spec.rb
@@ -25,6 +25,10 @@ describe REST::AccountSerializer do
     it 'returns the expected role' do
       expect(subject['roles'].first).to include({ 'name' => 'Role' })
     end
+
+    it 'does not expose the roles permissions' do
+      expect(subject['roles'].first).to_not include({ 'permissions' => role.computed_permissions.to_s })
+    end
   end
 
   context 'when the account has a non-highlighted role' do

--- a/spec/serializers/rest/account_serializer_spec.rb
+++ b/spec/serializers/rest/account_serializer_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe REST::AccountSerializer do
   subject { serialized_record_json(account, described_class) }
 
-  let(:role)    { Fabricate(:user_role, name: 'Role', highlighted: true) }
+  let(:role)    { Fabricate(:user_role, name: 'Fancy User', highlighted: true) }
   let(:user)    { Fabricate(:user, role: role) }
   let(:account) { user.account }
 
@@ -20,10 +20,10 @@ describe REST::AccountSerializer do
   end
 
   context 'when the account has a highlighted role' do
-    let(:role) { Fabricate(:user_role, name: 'Role', highlighted: true) }
+    let(:role) { Fabricate(:user_role, name: 'Fancy User', highlighted: true) }
 
     it 'returns the expected role' do
-      expect(subject['roles'].first).to include({ 'name' => 'Role' })
+      expect(subject['roles'].first).to include({ 'name' => 'Fancy User' })
     end
 
     it 'does not expose the roles permissions' do
@@ -32,7 +32,7 @@ describe REST::AccountSerializer do
   end
 
   context 'when the account has a non-highlighted role' do
-    let(:role) { Fabricate(:user_role, name: 'Role', highlighted: false) }
+    let(:role) { Fabricate(:user_role, name: 'Fancy User', highlighted: false) }
 
     it 'returns empty roles' do
       expect(subject['roles']).to eq []

--- a/spec/serializers/rest/credential_account_serializer_spec.rb
+++ b/spec/serializers/rest/credential_account_serializer_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe REST::CredentialAccountSerializer do
+  subject { serialized_record_json(account, described_class) }
+
+  let(:role)    { Fabricate(:user_role, name: 'Fancy User') }
+  let(:user)    { Fabricate(:user, role: role) }
+  let(:account) { user.account }
+
+  context 'when the account has a role' do
+    it 'returns the expected role' do
+      expect(subject['roles'].first).to include({ 'name' => 'Fancy User' })
+    end
+
+    it 'exposes the role permissions' do
+      expect(subject['roles'].first).to include({ 'permissions' => role.computed_permissions.to_s })
+    end
+  end
+end


### PR DESCRIPTION
I started this, but then realised we've a weird inconsistency:

The user -> user_role relationship is a "belongs to" relationship, but in AccountSerializer we have a has_many :roles? 
- https://github.com/mastodon/mastodon/blob/main/app/serializers/rest/account_serializer.rb#L33-L41
- https://github.com/mastodon/mastodon/blob/main/app/serializers/rest/account_serializer.rb#L143-L149 

In the admin UI you cannot set multiple roles, you can only have a single role. The documentation for the API also doesn't mention a "roles" property, only a "role" property on CredentialAccount: https://docs.joinmastodon.org/entities/Account/