### PR TITLE
Fix Codespaces startup fails due to Corepack download prompt

### DIFF
--- a/.devcontainer/codespaces/devcontainer.json
+++ b/.devcontainer/codespaces/devcontainer.json
@@ -39,7 +39,7 @@
   },
 
   "onCreateCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}",
-  "postCreateCommand": "bin/setup",
+  "postCreateCommand": "COREPACK_ENABLE_DOWNLOAD_PROMPT=0 bin/setup",
   "waitFor": "postCreateCommand",
 
   "customizations": {


### PR DESCRIPTION
While GitHub Codespaces is preparing the environment, users cannot interact to terminal.
Currently, DevContainer configuration for GitHub Codespaces prompts user before installing yarn while running `bin/setup` and we cannot respond it.
This PR fixes it and make it possible to use GitHub Codespaces.

See https://github.com/nodejs/corepack/pull/360 for the `COREPACK_ENABLE_DOWNLOAD_PROMPT` environment variable.

# Current behavior

Codespaces setup hangs with logs below:

```
Running the postCreateCommand from devcontainer.json...

bin/setup

... (snip) ...

== Installing JS dependencies ==
! Corepack is about to download https://repo.yarnpkg.com/4.3.1/packages/yarnpkg-cli/bin/yarn.js
? Do you want to continue? [Y/n] 
```