### PR TITLE
Add endpoints for unread notifications count

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -30,10 +30,10 @@ class Api::BaseController < ApplicationController
 
   protected
 
-  def limit_param(default_limit)
+  def limit_param(default_limit, max_limit = nil)
     return default_limit unless params[:limit]
 
-    [params[:limit].to_i.abs, default_limit * 2].min
+    [params[:limit].to_i.abs, max_limit || (default_limit * 2)].min
   end
 
   def params_slice(*keys)

--- a/app/controllers/api/v1/notifications_controller.rb
+++ b/app/controllers/api/v1/notifications_controller.rb
@@ -7,7 +7,8 @@ class Api::V1::NotificationsController < Api::BaseController
   after_action :insert_pagination_headers, only: :index
 
   DEFAULT_NOTIFICATIONS_LIMIT = 40
-  NOTIFICATIONS_COUNT_LIMIT = 100
+  DEFAULT_NOTIFICATIONS_COUNT_LIMIT = 100
+  MAX_NOTIFICATIONS_COUNT_LIMIT = 1_000
 
   def index
     with_read_replica do
@@ -19,8 +20,10 @@ class Api::V1::NotificationsController < Api::BaseController
   end
 
   def count
+    limit = limit_param(DEFAULT_NOTIFICATIONS_COUNT_LIMIT, MAX_NOTIFICATIONS_COUNT_LIMIT)
+
     with_read_replica do
-      render json: { count: browserable_account_notifications.paginate_by_min_id(NOTIFICATIONS_COUNT_LIMIT, notification_marker&.last_read_id).count }
+      render json: { count: browserable_account_notifications.paginate_by_min_id(limit, notification_marker&.last_read_id).count }
     end
   end
 

--- a/app/controllers/api/v1/notifications_controller.rb
+++ b/app/controllers/api/v1/notifications_controller.rb
@@ -19,7 +19,7 @@ class Api::V1::NotificationsController < Api::BaseController
     render json: @notifications, each_serializer: REST::NotificationSerializer, relationships: @relationships
   end
 
-  def count
+  def unread_count
     limit = limit_param(DEFAULT_NOTIFICATIONS_COUNT_LIMIT, MAX_NOTIFICATIONS_COUNT_LIMIT)
 
     with_read_replica do

--- a/app/controllers/api/v1/notifications_controller.rb
+++ b/app/controllers/api/v1/notifications_controller.rb
@@ -7,6 +7,7 @@ class Api::V1::NotificationsController < Api::BaseController
   after_action :insert_pagination_headers, only: :index
 
   DEFAULT_NOTIFICATIONS_LIMIT = 40
+  NOTIFICATIONS_COUNT_LIMIT = 100
 
   def index
     with_read_replica do
@@ -15,6 +16,12 @@ class Api::V1::NotificationsController < Api::BaseController
     end
 
     render json: @notifications, each_serializer: REST::NotificationSerializer, relationships: @relationships
+  end
+
+  def count
+    with_read_replica do
+      render json: { count: browserable_account_notifications.paginate_by_min_id(NOTIFICATIONS_COUNT_LIMIT, notification_marker&.last_read_id).count }
+    end
   end
 
   def show
@@ -52,6 +59,10 @@ class Api::V1::NotificationsController < Api::BaseController
       from_account_id: browserable_params[:account_id],
       include_filtered: truthy_param?(:include_filtered)
     )
+  end
+
+  def notification_marker
+    current_user.markers.find_by(timeline: 'notifications')
   end
 
   def target_statuses_from_notifications

--- a/app/controllers/api/v2_alpha/notifications_controller.rb
+++ b/app/controllers/api/v2_alpha/notifications_controller.rb
@@ -37,7 +37,7 @@ class Api::V2Alpha::NotificationsController < Api::BaseController
     end
   end
 
-  def count
+  def unread_count
     limit = limit_param(DEFAULT_NOTIFICATIONS_COUNT_LIMIT, MAX_NOTIFICATIONS_COUNT_LIMIT)
 
     with_read_replica do

--- a/app/controllers/api/v2_alpha/notifications_controller.rb
+++ b/app/controllers/api/v2_alpha/notifications_controller.rb
@@ -7,7 +7,8 @@ class Api::V2Alpha::NotificationsController < Api::BaseController
   after_action :insert_pagination_headers, only: :index
 
   DEFAULT_NOTIFICATIONS_LIMIT = 40
-  NOTIFICATIONS_COUNT_LIMIT = 100
+  DEFAULT_NOTIFICATIONS_COUNT_LIMIT = 100
+  MAX_NOTIFICATIONS_COUNT_LIMIT = 1_000
 
   def index
     with_read_replica do
@@ -37,8 +38,10 @@ class Api::V2Alpha::NotificationsController < Api::BaseController
   end
 
   def count
+    limit = limit_param(DEFAULT_NOTIFICATIONS_COUNT_LIMIT, MAX_NOTIFICATIONS_COUNT_LIMIT)
+
     with_read_replica do
-      render json: { count: browserable_account_notifications.without_suspended.paginate_groups_by_min_id(NOTIFICATIONS_COUNT_LIMIT, min_id: notification_marker&.last_read_id).count }
+      render json: { count: browserable_account_notifications.paginate_groups_by_min_id(limit, min_id: notification_marker&.last_read_id).count }
     end
   end
 

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -336,6 +336,7 @@ namespace :api, format: false do
     resources :notifications, only: [:index, :show] do
       collection do
         post :clear
+        get :count
       end
 
       member do

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -167,6 +167,7 @@ namespace :api, format: false do
     resources :notifications, only: [:index, :show] do
       collection do
         post :clear
+        get :count
       end
 
       member do

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -167,7 +167,7 @@ namespace :api, format: false do
     resources :notifications, only: [:index, :show] do
       collection do
         post :clear
-        get :count
+        get :unread_count
       end
 
       member do
@@ -337,7 +337,7 @@ namespace :api, format: false do
     resources :notifications, only: [:index, :show] do
       collection do
         post :clear
-        get :count
+        get :unread_count
       end
 
       member do

--- a/spec/requests/api/v1/notifications_spec.rb
+++ b/spec/requests/api/v1/notifications_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe 'Notifications' do
   let(:scopes)  { 'read:notifications write:notifications' }
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
 
-  describe 'GET /api/v1/notifications/count', :inline_jobs do
+  describe 'GET /api/v1/notifications/unread_count', :inline_jobs do
     subject do
-      get '/api/v1/notifications/count', headers: headers, params: params
+      get '/api/v1/notifications/unread_count', headers: headers, params: params
     end
 
     let(:params) { {} }

--- a/spec/requests/api/v1/notifications_spec.rb
+++ b/spec/requests/api/v1/notifications_spec.rb
@@ -8,6 +8,72 @@ RSpec.describe 'Notifications' do
   let(:scopes)  { 'read:notifications write:notifications' }
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
 
+  describe 'GET /api/v1/notifications/count', :inline_jobs do
+    subject do
+      get '/api/v1/notifications/count', headers: headers, params: params
+    end
+
+    let(:params) { {} }
+
+    before do
+      first_status = PostStatusService.new.call(user.account, text: 'Test')
+      ReblogService.new.call(Fabricate(:account), first_status)
+      PostStatusService.new.call(Fabricate(:account), text: 'Hello @alice')
+      FavouriteService.new.call(Fabricate(:account), first_status)
+      FavouriteService.new.call(Fabricate(:account), first_status)
+      FollowService.new.call(Fabricate(:account), user.account)
+    end
+
+    it_behaves_like 'forbidden for wrong scope', 'write write:notifications'
+
+    context 'with no options' do
+      it 'returns expected notifications count' do
+        subject
+
+        expect(response).to have_http_status(200)
+        expect(body_as_json[:count]).to eq 5
+      end
+    end
+
+    context 'with a read marker' do
+      before do
+        id = user.account.notifications.browserable.order(id: :desc).offset(2).first.id
+        user.markers.create!(timeline: 'notifications', last_read_id: id)
+      end
+
+      it 'returns expected notifications count' do
+        subject
+
+        expect(response).to have_http_status(200)
+        expect(body_as_json[:count]).to eq 2
+      end
+    end
+
+    context 'with exclude_types param' do
+      let(:params) { { exclude_types: %w(mention) } }
+
+      it 'returns expected notifications count' do
+        subject
+
+        expect(response).to have_http_status(200)
+        expect(body_as_json[:count]).to eq 4
+      end
+    end
+
+    context 'when there are more notifications than the limit' do
+      before do
+        stub_const('Api::V1::NotificationsController::NOTIFICATIONS_COUNT_LIMIT', 2)
+      end
+
+      it 'returns a capped value' do
+        subject
+
+        expect(response).to have_http_status(200)
+        expect(body_as_json[:count]).to eq Api::V1::NotificationsController::NOTIFICATIONS_COUNT_LIMIT
+      end
+    end
+  end
+
   describe 'GET /api/v1/notifications', :inline_jobs do
     subject do
       get '/api/v1/notifications', headers: headers, params: params

--- a/spec/requests/api/v1/notifications_spec.rb
+++ b/spec/requests/api/v1/notifications_spec.rb
@@ -60,6 +60,17 @@ RSpec.describe 'Notifications' do
       end
     end
 
+    context 'with a user-provided limit' do
+      let(:params) { { limit: 2 } }
+
+      it 'returns a capped value' do
+        subject
+
+        expect(response).to have_http_status(200)
+        expect(body_as_json[:count]).to eq 2
+      end
+    end
+
     context 'when there are more notifications than the limit' do
       before do
         stub_const('Api::V1::NotificationsController::DEFAULT_NOTIFICATIONS_COUNT_LIMIT', 2)

--- a/spec/requests/api/v1/notifications_spec.rb
+++ b/spec/requests/api/v1/notifications_spec.rb
@@ -62,14 +62,14 @@ RSpec.describe 'Notifications' do
 
     context 'when there are more notifications than the limit' do
       before do
-        stub_const('Api::V1::NotificationsController::NOTIFICATIONS_COUNT_LIMIT', 2)
+        stub_const('Api::V1::NotificationsController::DEFAULT_NOTIFICATIONS_COUNT_LIMIT', 2)
       end
 
       it 'returns a capped value' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json[:count]).to eq Api::V1::NotificationsController::NOTIFICATIONS_COUNT_LIMIT
+        expect(body_as_json[:count]).to eq Api::V1::NotificationsController::DEFAULT_NOTIFICATIONS_COUNT_LIMIT
       end
     end
   end

--- a/spec/requests/api/v2_alpha/notifications_spec.rb
+++ b/spec/requests/api/v2_alpha/notifications_spec.rb
@@ -60,6 +60,17 @@ RSpec.describe 'Notifications' do
       end
     end
 
+    context 'with a user-provided limit' do
+      let(:params) { { limit: 2 } }
+
+      it 'returns a capped value' do
+        subject
+
+        expect(response).to have_http_status(200)
+        expect(body_as_json[:count]).to eq 2
+      end
+    end
+
     context 'when there are more notifications than the limit' do
       before do
         stub_const('Api::V2Alpha::NotificationsController::DEFAULT_NOTIFICATIONS_COUNT_LIMIT', 2)

--- a/spec/requests/api/v2_alpha/notifications_spec.rb
+++ b/spec/requests/api/v2_alpha/notifications_spec.rb
@@ -8,6 +8,72 @@ RSpec.describe 'Notifications' do
   let(:scopes)  { 'read:notifications write:notifications' }
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
 
+  describe 'GET /api/v2_alpha/notifications/count', :inline_jobs do
+    subject do
+      get '/api/v2_alpha/notifications/count', headers: headers, params: params
+    end
+
+    let(:params) { {} }
+
+    before do
+      first_status = PostStatusService.new.call(user.account, text: 'Test')
+      ReblogService.new.call(Fabricate(:account), first_status)
+      PostStatusService.new.call(Fabricate(:account), text: 'Hello @alice')
+      FavouriteService.new.call(Fabricate(:account), first_status)
+      FavouriteService.new.call(Fabricate(:account), first_status)
+      FollowService.new.call(Fabricate(:account), user.account)
+    end
+
+    it_behaves_like 'forbidden for wrong scope', 'write write:notifications'
+
+    context 'with no options' do
+      it 'returns expected notifications count' do
+        subject
+
+        expect(response).to have_http_status(200)
+        expect(body_as_json[:count]).to eq 4
+      end
+    end
+
+    context 'with a read marker' do
+      before do
+        id = user.account.notifications.browserable.order(id: :desc).offset(2).first.id
+        user.markers.create!(timeline: 'notifications', last_read_id: id)
+      end
+
+      it 'returns expected notifications count' do
+        subject
+
+        expect(response).to have_http_status(200)
+        expect(body_as_json[:count]).to eq 2
+      end
+    end
+
+    context 'with exclude_types param' do
+      let(:params) { { exclude_types: %w(mention) } }
+
+      it 'returns expected notifications count' do
+        subject
+
+        expect(response).to have_http_status(200)
+        expect(body_as_json[:count]).to eq 3
+      end
+    end
+
+    context 'when there are more notifications than the limit' do
+      before do
+        stub_const('Api::V2Alpha::NotificationsController::NOTIFICATIONS_COUNT_LIMIT', 2)
+      end
+
+      it 'returns a capped value' do
+        subject
+
+        expect(response).to have_http_status(200)
+        expect(body_as_json[:count]).to eq Api::V2Alpha::NotificationsController::NOTIFICATIONS_COUNT_LIMIT
+      end
+    end
+  end
+
   describe 'GET /api/v2_alpha/notifications', :inline_jobs do
     subject do
       get '/api/v2_alpha/notifications', headers: headers, params: params

--- a/spec/requests/api/v2_alpha/notifications_spec.rb
+++ b/spec/requests/api/v2_alpha/notifications_spec.rb
@@ -62,14 +62,14 @@ RSpec.describe 'Notifications' do
 
     context 'when there are more notifications than the limit' do
       before do
-        stub_const('Api::V2Alpha::NotificationsController::NOTIFICATIONS_COUNT_LIMIT', 2)
+        stub_const('Api::V2Alpha::NotificationsController::DEFAULT_NOTIFICATIONS_COUNT_LIMIT', 2)
       end
 
       it 'returns a capped value' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json[:count]).to eq Api::V2Alpha::NotificationsController::NOTIFICATIONS_COUNT_LIMIT
+        expect(body_as_json[:count]).to eq Api::V2Alpha::NotificationsController::DEFAULT_NOTIFICATIONS_COUNT_LIMIT
       end
     end
   end

--- a/spec/requests/api/v2_alpha/notifications_spec.rb
+++ b/spec/requests/api/v2_alpha/notifications_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe 'Notifications' do
   let(:scopes)  { 'read:notifications write:notifications' }
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
 
-  describe 'GET /api/v2_alpha/notifications/count', :inline_jobs do
+  describe 'GET /api/v2_alpha/notifications/unread_count', :inline_jobs do
     subject do
-      get '/api/v2_alpha/notifications/count', headers: headers, params: params
+      get '/api/v2_alpha/notifications/unread_count', headers: headers, params: params
     end
 
     let(:params) { {} }


### PR DESCRIPTION
This adds `GET /api/v1/notifications/unread_count` (for ungrouped notifications) and `GET /api/v2_alpha/notifications/unread_count` (for grouped notifications count) to get the number of notifications since the last read marker, without having to fetch the notifications themselves, capped to a specified `limit`.

These take the same arguments as `GET /api/v1/notifications` and `GET /api/v2_alpha/notifications` respectively, with the difference that the default value for `limit` is `100` and the maximum value is `1000`.