### PR TITLE
Change User-Agent to use Mastodon as the product, and http.rb as platform details

### DIFF
--- a/lib/mastodon/version.rb
+++ b/lib/mastodon/version.rb
@@ -65,7 +65,7 @@ module Mastodon
     end
 
     def user_agent
-      @user_agent ||= "#{HTTP::Request::USER_AGENT} (Mastodon/#{Version}; +http#{Rails.configuration.x.use_https ? 's' : ''}://#{Rails.configuration.x.web_domain}/)"
+      @user_agent ||= "Mastodon/#{Version} (#{HTTP::Request::USER_AGENT}; +http#{Rails.configuration.x.use_https ? 's' : ''}://#{Rails.configuration.x.web_domain}/)"
     end
   end
 end


### PR DESCRIPTION
Before:
`http.rb/5.2.0 (Mastodon/4.3.0-alpha.5; +https://cb6e6126.ngrok.io/)`

After:
`Mastodon/4.3.0-alpha.5 (http.rb/5.2.0; +https://cb6e6126.ngrok.io/)`

### Rationale

https://desu.social/@pixel/112870098202561811
https://desu.social/@pixel/112870106346895505

Browsers are a bit of a mess, but the general format of `User-Agent` is the following:
`User-Agent: <product> / <product-version> <comment>`

In Mastodon's case, the product is not `http.rb` but Mastodon, so it makes sense to mark it as such.