### PR TITLE
Dont run crowdin upload workflow on forks

### DIFF
--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -19,6 +19,7 @@ on:
 jobs:
   upload-translations:
     runs-on: ubuntu-latest
+    if: github.repository == 'mastodon/mastodon'
 
     steps:
       - name: Checkout


### PR DESCRIPTION
We have a similar disable in place on the download workflow ... I think we probably want same here? (currently the job will run but fail on forks which have actions enabled but dont have the env vars set)