### PR TITLE
Change design of request notifications

### DIFF
--- a/app/javascript/mastodon/features/notifications/components/notification_request.jsx
+++ b/app/javascript/mastodon/features/notifications/components/notification_request.jsx
@@ -1,31 +1,26 @@
 import PropTypes from 'prop-types';
 import { useCallback } from 'react';
 
-import { defineMessages, useIntl } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
 import { Link } from 'react-router-dom';
 
 import { useSelector, useDispatch } from 'react-redux';
 
+import ChevronRightIcon from '@/material-icons/400-24px/chevron_right.svg?react';
 import DeleteIcon from '@/material-icons/400-24px/delete.svg?react';
 import DoneIcon from '@/material-icons/400-24px/done.svg?react';
 import { acceptNotificationRequest, dismissNotificationRequest } from 'mastodon/actions/notifications';
 import { Avatar } from 'mastodon/components/avatar';
-import { IconButton } from 'mastodon/components/icon_button';
+import { Icon } from 'mastodon/components/icon';
 import { makeGetAccount } from 'mastodon/selectors';
 import { toCappedNumber } from 'mastodon/utils/numbers';
 
 const getAccount = makeGetAccount();
 
-const messages = defineMessages({
-  accept: { id: 'notification_requests.accept', defaultMessage: 'Accept' },
-  dismiss: { id: 'notification_requests.dismiss', defaultMessage: 'Dismiss' },
-});
-
 export const NotificationRequest = ({ id, accountId, notificationsCount }) => {
   const dispatch = useDispatch();
   const account = useSelector(state => getAccount(state, accountId));
-  const intl = useIntl();
 
   const handleDismiss = useCallback(() => {
     dispatch(dismissNotificationRequest(id));
@@ -48,11 +43,19 @@ export const NotificationRequest = ({ id, accountId, notificationsCount }) => {
 
           <span>@{account?.get('acct')}</span>
         </div>
+
+        <Icon id='chevron-right' icon={ChevronRightIcon} className='notification-request__disclosure-indicator' />
       </Link>
 
       <div className='notification-request__actions'>
-        <IconButton iconComponent={DeleteIcon} onClick={handleDismiss} title={intl.formatMessage(messages.dismiss)} />
-        <IconButton iconComponent={DoneIcon} onClick={handleAccept} title={intl.formatMessage(messages.accept)} />
+        <button type='button' className='button button-tertiary button--destructive' onClick={handleDismiss}>
+          <Icon id='times' icon={DeleteIcon} />
+          <FormattedMessage id='notification_requests.dismiss' defaultMessage='Dismiss' />
+        </button>
+        <button type='button' className='button button-tertiary' onClick={handleAccept}>
+          <Icon id='check' icon={DoneIcon} />
+          <FormattedMessage id='notification_requests.accept' defaultMessage='Accept' />
+        </button>
       </div>
     </div>
   );

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -10195,6 +10195,7 @@ noscript {
 
 .notification-request {
   display: flex;
+  flex-direction: column;
   align-items: center;
   gap: 16px;
   padding: 15px;
@@ -10208,6 +10209,7 @@ noscript {
     text-decoration: none;
     color: inherit;
     overflow: hidden;
+    width: 100%;
 
     .account__avatar {
       flex-shrink: 0;
@@ -10234,21 +10236,24 @@ noscript {
 
     .filtered-notifications-banner__badge {
       background: $ui-button-background-color;
-      border-radius: 4px;
+      border-radius: 8px;
       padding: 1px 6px;
       color: $white;
     }
+  }
+
+  &__disclosure-indicator {
+    color: $darker-text-color;
   }
 
   &__actions {
     display: flex;
     align-items: center;
     gap: 8px;
+    width: 100%;
 
-    .icon-button {
-      border-radius: 4px;
-      border: 1px solid var(--background-border-color);
-      padding: 5px;
+    .button {
+      flex-grow: 1;
     }
   }
 }


### PR DESCRIPTION
Redesign the list of notification requests to better accommodate narrow column sizes, make the buttons more obvious, and make it more obvious that the notifications can be clicked.

Work in progress as it still needs hover styles, as well as a review from our designer.

## Before

![image](https://github.com/user-attachments/assets/d61b52a2-f95a-4e12-921e-1f2a7e84c9ff)
![image](https://github.com/user-attachments/assets/cf720e41-67ef-49ac-9124-88756250f8f4)

## After

![image](https://github.com/user-attachments/assets/c7d83240-ebff-4c6e-bffa-880b76060d05)
![image](https://github.com/user-attachments/assets/a09a8bcd-652b-4094-8012-16a5d6e9e39a)