### PR TITLE
Added require for gems causing missing name errors in rspec tests

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -37,11 +37,14 @@ abort('The Rails environment is running in production mode!') if Rails.env.produ
 
 require 'spec_helper'
 require 'rspec/rails'
+require 'rspec-sidekiq'
 require 'webmock/rspec'
 require 'paperclip/matchers'
 require 'capybara/rspec'
 require 'chewy/rspec'
+require 'email_spec'
 require 'email_spec/rspec'
+require 'database_cleaner/active_record'
 require 'test_prof/recipes/rspec/before_all'
 
 Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }


### PR DESCRIPTION
Fixes #31197

When running `rspec` the test runner failed due to missing constants from these three Gems (`rspec-sidekiq`, `email_spec`, `database_cleaner/active_record`) and all tests are skipped. This PR adds them into `rails_helper.rb` allows the tests to run as expected. Note that these Gems were already included in the bundle, just not `required` in the rspec helper.