### PR TITLE
Remove `WebfingerHelper` module & move usage inline

### DIFF
--- a/app/helpers/webfinger_helper.rb
+++ b/app/helpers/webfinger_helper.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-module WebfingerHelper
-  def webfinger!(uri)
-    Webfinger.new(uri).perform
-  end
-end

--- a/app/models/remote_follow.rb
+++ b/app/models/remote_follow.rb
@@ -3,7 +3,6 @@
 class RemoteFollow
   include ActiveModel::Validations
   include RoutingHelper
-  include WebfingerHelper
 
   attr_accessor :acct, :addressable_template
 
@@ -66,7 +65,7 @@ class RemoteFollow
   end
 
   def acct_resource
-    @acct_resource ||= webfinger!("acct:#{acct}")
+    @acct_resource ||= Webfinger.new("acct:#{acct}").perform
   rescue Webfinger::Error, HTTP::ConnectionError
     nil
   end

--- a/app/services/activitypub/fetch_remote_actor_service.rb
+++ b/app/services/activitypub/fetch_remote_actor_service.rb
@@ -3,7 +3,6 @@
 class ActivityPub::FetchRemoteActorService < BaseService
   include JsonLdHelper
   include DomainControlHelper
-  include WebfingerHelper
 
   class Error < StandardError; end
 
@@ -45,7 +44,7 @@ class ActivityPub::FetchRemoteActorService < BaseService
   private
 
   def check_webfinger!
-    webfinger                            = webfinger!("acct:#{@username}@#{@domain}")
+    webfinger = Webfinger.new("acct:#{@username}@#{@domain}").perform
     confirmed_username, confirmed_domain = split_acct(webfinger.subject)
 
     if @username.casecmp(confirmed_username).zero? && @domain.casecmp(confirmed_domain).zero?
@@ -54,7 +53,7 @@ class ActivityPub::FetchRemoteActorService < BaseService
       return
     end
 
-    webfinger                            = webfinger!("acct:#{confirmed_username}@#{confirmed_domain}")
+    webfinger = Webfinger.new("acct:#{confirmed_username}@#{confirmed_domain}").perform
     @username, @domain                   = split_acct(webfinger.subject)
 
     raise Webfinger::RedirectError, "Too many webfinger redirects for URI #{@uri} (stopped at #{@username}@#{@domain})" unless confirmed_username.casecmp(@username).zero? && confirmed_domain.casecmp(@domain).zero?


### PR DESCRIPTION
Similar to - https://github.com/mastodon/mastodon/pull/31202 - in terms of their being module-style code in `app/helpers` that's not used in controllers/views (this one has more usage than the other one -- a mix of models/services).

For this one I've chosen to just remove the module and inline the code, instead of moving to lib or something. I think that's fine ... but if we were getting some value ("hi, I make a network request!" or something) out of the bang-method naming, I can move it to lib instead.

Separately - I noticed while doing this that the two primary users of this method (`ResolveAccountService` and `FetchRemoteActorService`) have considerable overlap on the webfinger/acct parsing, fetching, error handling, etc. It's not exactly 1:1, but I suspect we could extract a class there which would do a little de-duping, make both those classes smaller, and consolidate the logic into a better-named webfinger-specific place? Might be good future follow-up to this.