### PR TITLE
Use enum-generated `IpBlock.severity...` scopes

### DIFF
--- a/app/helpers/registration_helper.rb
+++ b/app/helpers/registration_helper.rb
@@ -16,6 +16,6 @@ module RegistrationHelper
   end
 
   def ip_blocked?(remote_ip)
-    IpBlock.where(severity: :sign_up_block).containing(remote_ip.to_s).exists?
+    IpBlock.severity_sign_up_block.containing(remote_ip.to_s).exists?
   end
 end


### PR DESCRIPTION
We have the `enum` in the model generating these, and they are used in most places, but not all ... I think these are the few remaining spots they aren't used.