### PR TITLE
Extricate `Invite::VALID_CODE_CHARACTERS` constant to generate codes

### DIFF
--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -20,6 +20,10 @@ class Invite < ApplicationRecord
   include Expireable
 
   COMMENT_SIZE_LIMIT = 420
+  VALID_CODE_CHARACTERS = (
+    # Lowercase chars & Uppercase chars & numbers with homoglyphs removed
+    [*('a'..'z'), *('A'..'Z'), *('0'..'9')] - %w(0 1 I l O)
+  ).freeze
 
   belongs_to :user, inverse_of: :invites
   has_many :users, inverse_of: :invite, dependent: nil
@@ -38,8 +42,8 @@ class Invite < ApplicationRecord
 
   def set_code
     loop do
-      self.code = ([*('a'..'z'), *('A'..'Z'), *('0'..'9')] - %w(0 1 I l O)).sample(8).join
-      break if Invite.find_by(code: code).nil?
+      self.code = VALID_CODE_CHARACTERS.sample(8).join
+      break unless self.class.exists?(code: code)
     end
   end
 end


### PR DESCRIPTION
Two _very very marginal_ performance benefits here:

- The array of chars we choose from never changes - so move to a constant instead of building on every execution
- I think the `exists` check is slightly better than the record load/check?

Added inline comment to slightly clarify the array of chars being built.

Side note here...

- There is db-level unique index on `code`, but no rails-level uniqueness validation ... should there be?
- The `before_validation` here runs on every save and has the effect of updating the `code` on every save call, which (I think?) also invalidates the previous code. In practice this may not matter because I don't think the user or admin facing UI can actually update it ... but the console can. Should this just be `on: :create` ... or do we want it to invalidate on any save?