### PR TITLE
Update location of unused `MIN_SCHEDULE_OFFSET` constant

### DIFF
--- a/app/models/scheduled_status.rb
+++ b/app/models/scheduled_status.rb
@@ -15,6 +15,7 @@ class ScheduledStatus < ApplicationRecord
 
   TOTAL_LIMIT = 300
   DAILY_LIMIT = 25
+  MINIMUM_OFFSET = 5.minutes.freeze
 
   belongs_to :account, inverse_of: :scheduled_statuses
   has_many :media_attachments, inverse_of: :scheduled_status, dependent: :nullify
@@ -26,7 +27,7 @@ class ScheduledStatus < ApplicationRecord
   private
 
   def validate_future_date
-    errors.add(:scheduled_at, I18n.t('scheduled_statuses.too_soon')) if scheduled_at.present? && scheduled_at <= Time.now.utc + PostStatusService::MIN_SCHEDULE_OFFSET
+    errors.add(:scheduled_at, I18n.t('scheduled_statuses.too_soon')) if scheduled_at.present? && scheduled_at <= Time.now.utc + MINIMUM_OFFSET
   end
 
   def validate_total_limit

--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -4,8 +4,6 @@ class PostStatusService < BaseService
   include Redisable
   include LanguagesHelper
 
-  MIN_SCHEDULE_OFFSET = 5.minutes.freeze
-
   class UnexpectedMentionsError < StandardError
     attr_reader :accounts
 

--- a/app/workers/scheduler/scheduled_statuses_scheduler.rb
+++ b/app/workers/scheduler/scheduled_statuses_scheduler.rb
@@ -20,7 +20,7 @@ class Scheduler::ScheduledStatusesScheduler
   end
 
   def due_statuses
-    ScheduledStatus.where(scheduled_at: ..Time.now.utc + PostStatusService::MIN_SCHEDULE_OFFSET)
+    ScheduledStatus.where(scheduled_at: ..time_due_at)
   end
 
   def publish_scheduled_announcements!
@@ -30,7 +30,7 @@ class Scheduler::ScheduledStatusesScheduler
   end
 
   def due_announcements
-    Announcement.unpublished.where('scheduled_at IS NOT NULL AND scheduled_at <= ?', Time.now.utc + PostStatusService::MIN_SCHEDULE_OFFSET)
+    Announcement.unpublished.where('scheduled_at IS NOT NULL AND scheduled_at <= ?', time_due_at)
   end
 
   def unpublish_expired_announcements!
@@ -39,5 +39,9 @@ class Scheduler::ScheduledStatusesScheduler
 
   def expired_announcements
     Announcement.published.where('ends_at IS NOT NULL AND ends_at <= ?', Time.now.utc)
+  end
+
+  def time_due_at
+    Time.now.utc + ScheduledStatus::MINIMUM_OFFSET
   end
 end


### PR DESCRIPTION
After the changes in https://github.com/mastodon/mastodon/pull/30584 - this constant is no longer used in the class within which it is defined. Changes here are just to move it to somewhere it is still referenced from, and cleanup previous references to hit new location.

