### PR TITLE
Change private mention icon for consistency in grouped notifications

### DIFF
--- a/app/javascript/mastodon/features/notifications_v2/components/notification_mention.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/components/notification_mention.tsx
@@ -1,5 +1,6 @@
 import { FormattedMessage } from 'react-intl';
 
+import AlternateEmailIcon from '@/material-icons/400-24px/alternate_email.svg?react';
 import ReplyIcon from '@/material-icons/400-24px/reply-fill.svg?react';
 import type { StatusVisibility } from 'mastodon/api_types/statuses';
 import type { NotificationGroupMention } from 'mastodon/models/notification_group';
@@ -39,7 +40,7 @@ export const NotificationMention: React.FC<{
   return (
     <NotificationWithStatus
       type='mention'
-      icon={ReplyIcon}
+      icon={statusVisibility === 'direct' ? AlternateEmailIcon : ReplyIcon}
       iconId='reply'
       accountIds={notification.sampleAccountIds}
       count={notification.notifications_count}


### PR DESCRIPTION
Fixes #31175

## Before

![image](https://github.com/user-attachments/assets/4672b14b-0305-474c-93fc-1506e3d774b4)

## After

![image](https://github.com/user-attachments/assets/ef13d949-710b-42e0-8386-8145bdf48708)