### PR TITLE
Fix handling of long display names in notification requests

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -10215,6 +10215,12 @@ noscript {
       letter-spacing: 0.5px;
       line-height: 24px;
       color: $secondary-text-color;
+
+      bdi {
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+      }
     }
 
     .filtered-notifications-banner__badge {


### PR DESCRIPTION
## Before

![image](https://github.com/user-attachments/assets/85b053a3-5470-4f3d-9010-644eeb8eab9a)

## After

![image](https://github.com/user-attachments/assets/4b83b503-976e-49a3-a893-f38be03a060b)
