### PR TITLE
Make use of existing `Account.with_domain` scope for `ReportService#reported_status_ids`

### DIFF
--- a/app/services/report_service.rb
+++ b/app/services/report_service.rb
@@ -86,7 +86,7 @@ class ReportService < BaseService
     has_followers = @target_account.followers.with_domain(domain).exists?
     visibility = has_followers ? %i(public unlisted private) : %i(public unlisted)
     scope = @target_account.statuses.with_discarded
-    scope.merge!(scope.where(visibility: visibility).or(scope.where('EXISTS (SELECT 1 FROM mentions m JOIN accounts a ON m.account_id = a.id WHERE lower(a.domain) = ?)', domain)))
+    scope.merge!(scope.where(visibility: visibility).or(scope.where(mentioned_domain_accounts(domain))))
     # Allow missing posts to not drop reports that include e.g. a deleted post
     scope.where(id: Array(@status_ids)).pluck(:id)
   end
@@ -97,5 +97,14 @@ class ReportService < BaseService
 
   def some_local_account
     @some_local_account ||= Account.representative
+  end
+
+  def mentioned_domain_accounts(domain)
+    Mention
+      .joins(:account)
+      .merge(Account.with_domain(domain))
+      .select(1)
+      .arel
+      .exists
   end
 end


### PR DESCRIPTION
This method is quite dense and hard to quickly grasp - I think there are a few quick improvements here:

- This PR pulls out the manually constructed string conditions to re-use an existing method on Account (preserves the `lower` usage) and pulls that out to private method. The generated sql varies in framework quoting/naming style, but is otherwise the same
- Will do as followup - we have scopes for both of the status visibility collections, will pull out method for that
- In general I think basically all the local vars in this section could be private methods and that would make the whole thing more readable, and (maybe, tbd) make the scope construction more straightforward

Will do latter two things as follow-up assuming this is merged as starting point.