### PR TITLE
Convert "string-based" scope order generation to arel/composable style

### DIFF
--- a/app/models/admin/status_filter.rb
+++ b/app/models/admin/status_filter.rb
@@ -32,7 +32,7 @@ class Admin::StatusFilter
   def scope_for(key, _value)
     case key.to_s
     when 'media'
-      Status.joins(:media_attachments).merge(@account.media_attachments).group(:id).reorder('statuses.id desc')
+      Status.joins(:media_attachments).merge(@account.media_attachments).group(:id).recent
     else
       raise Mastodon::InvalidParameterError, "Unknown filter: #{key}"
     end

--- a/app/models/block.rb
+++ b/app/models/block.rb
@@ -21,6 +21,8 @@ class Block < ApplicationRecord
 
   validates :account_id, uniqueness: { scope: :target_account_id }
 
+  scope :recent, -> { reorder(id: :desc) }
+
   def local?
     false # Force uri_for to use uri attribute
   end

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -23,7 +23,7 @@ module Account::Associations
 
     # Pinned statuses
     has_many :status_pins, inverse_of: :account, dependent: :destroy
-    has_many :pinned_statuses, -> { reorder('status_pins.created_at DESC') }, through: :status_pins, class_name: 'Status', source: :status
+    has_many :pinned_statuses, -> { StatusPin.latest }, through: :status_pins, class_name: 'Status', source: :status
 
     # Endorsements
     has_many :account_pins, inverse_of: :account, dependent: :destroy

--- a/app/models/concerns/account/interactions.rb
+++ b/app/models/concerns/account/interactions.rb
@@ -80,8 +80,8 @@ module Account::Interactions
       has_many :passive_relationships, foreign_key: 'target_account_id', inverse_of: :target_account
     end
 
-    has_many :following, -> { order('follows.id desc') }, through: :active_relationships,  source: :target_account
-    has_many :followers, -> { order('follows.id desc') }, through: :passive_relationships, source: :account
+    has_many :following, -> { Follow.recent }, through: :active_relationships,  source: :target_account
+    has_many :followers, -> { Follow.recent }, through: :passive_relationships, source: :account
 
     with_options class_name: 'SeveredRelationship', dependent: :destroy do
       has_many :severed_relationships, foreign_key: 'local_account_id', inverse_of: :local_account
@@ -96,16 +96,16 @@ module Account::Interactions
       has_many :block_relationships, foreign_key: 'account_id', inverse_of: :account
       has_many :blocked_by_relationships, foreign_key: :target_account_id, inverse_of: :target_account
     end
-    has_many :blocking, -> { order('blocks.id desc') }, through: :block_relationships, source: :target_account
-    has_many :blocked_by, -> { order('blocks.id desc') }, through: :blocked_by_relationships, source: :account
+    has_many :blocking, -> { Block.recent }, through: :block_relationships, source: :target_account
+    has_many :blocked_by, -> { Block.recent }, through: :blocked_by_relationships, source: :account
 
     # Mute relationships
     with_options class_name: 'Mute', dependent: :destroy do
       has_many :mute_relationships, foreign_key: 'account_id', inverse_of: :account
       has_many :muted_by_relationships, foreign_key: :target_account_id, inverse_of: :target_account
     end
-    has_many :muting, -> { order('mutes.id desc') }, through: :mute_relationships, source: :target_account
-    has_many :muted_by, -> { order('mutes.id desc') }, through: :muted_by_relationships, source: :account
+    has_many :muting, -> { Mute.recent }, through: :mute_relationships, source: :target_account
+    has_many :muted_by, -> { Mute.recent }, through: :muted_by_relationships, source: :account
     has_many :conversation_mutes, dependent: :destroy
     has_many :domain_blocks, class_name: 'AccountDomainBlock', dependent: :destroy
     has_many :announcement_mutes, dependent: :destroy

--- a/app/models/mute.rb
+++ b/app/models/mute.rb
@@ -23,6 +23,8 @@ class Mute < ApplicationRecord
 
   validates :account_id, uniqueness: { scope: :target_account_id }
 
+  scope :recent, -> { reorder(id: :desc) }
+
   after_commit :invalidate_blocking_cache
   after_commit :invalidate_follow_recommendations_cache
 

--- a/app/models/session_activation.rb
+++ b/app/models/session_activation.rb
@@ -30,6 +30,8 @@ class SessionActivation < ApplicationRecord
 
   DEFAULT_SCOPES = %w(read write follow).freeze
 
+  scope :latest, -> { order(created_at: :desc) }
+
   class << self
     def active?(id)
       id && exists?(session_id: id)
@@ -48,7 +50,7 @@ class SessionActivation < ApplicationRecord
     end
 
     def purge_old
-      order('created_at desc').offset(Rails.configuration.x.max_session_activations).destroy_all
+      latest.offset(Rails.configuration.x.max_session_activations).destroy_all
     end
 
     def exclusive(id)

--- a/app/models/status_pin.rb
+++ b/app/models/status_pin.rb
@@ -17,6 +17,8 @@ class StatusPin < ApplicationRecord
 
   validates_with StatusPinValidator
 
+  scope :latest, -> { reorder(created_at: :desc) }
+
   after_destroy :invalidate_cleanup_info, if: %i(account_matches_status_account? account_local?)
 
   delegate :local?, to: :account, prefix: true


### PR DESCRIPTION
Update a mix of `order` calls doing string-style query building in favor of arel-style building.

Makes things a little more composable (ie, can flip the order, easier support for including in joins, etc).

Some of these were just using an already-existing order scope, others needed one added first.

Tried to keep one change per commit so if we want this as separate PRs or not to do any of it, should be easy to accomodate.