### PR TITLE
Add Accept-Language header when fetching preview card

### DIFF
--- a/app/services/fetch_link_card_service.rb
+++ b/app/services/fetch_link_card_service.rb
@@ -45,7 +45,13 @@ class FetchLinkCardService < BaseService
   def html
     return @html if defined?(@html)
 
-    @html = Request.new(:get, @url).add_headers('Accept' => 'text/html', 'User-Agent' => "#{Mastodon::Version.user_agent} Bot").perform do |res|
+    headers = {
+      'Accept' => 'text/html',
+      'Accept-Language' => "#{I18n.default_locale}, *;q=0.5",
+      'User-Agent' => "#{Mastodon::Version.user_agent} Bot",
+    }
+
+    @html = Request.new(:get, @url).add_headers(headers).perform do |res|
       next unless res.code == 200 && res.mime_type == 'text/html'
 
       # We follow redirects, and ideally we want to save the preview card for


### PR DESCRIPTION
Some websites use the client IP address for language selection in addition to the `Accept-Language` header. E.g. if you add a post with a link to https://www.youtube.com/shorts/ on mastodon.social, the preview card will have German texts, because the mastodon.social server is hosted in Germany (I assume).

This feels a bit random. If we send a `Accept-Language` header we are in better control of which language is used. Preview cards are shared between posts, so we cannot use the language of the post. I suggest we just use the instance's default locale. This language is probably likely to be understood by the majority of users on the instance.