### PR TITLE
Add migration to populate everyone role and change database default `role_id`

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,7 +36,7 @@
 #  sign_in_token_sent_at     :datetime
 #  webauthn_id               :string
 #  sign_up_ip                :inet
-#  role_id                   :bigint(8)
+#  role_id                   :bigint(8)        default(-99)
 #  settings                  :text
 #  time_zone                 :string
 #  otp_secret                :string
@@ -129,6 +129,7 @@ class User < ApplicationRecord
   before_validation :sanitize_role
   before_create :set_approved
   after_commit :send_pending_devise_notifications
+  after_find :set_role_id
   after_create_commit :trigger_webhooks
 
   normalizes :locale, with: ->(locale) { I18n.available_locales.exclude?(locale.to_sym) ? nil : locale }
@@ -154,6 +155,10 @@ class User < ApplicationRecord
 
   def self.skip_mx_check?
     Rails.env.local?
+  end
+
+  def set_role_id
+    self.role_id ||= -99
   end
 
   def role

--- a/db/migrate/20240801094244_populate_everyone_role.rb
+++ b/db/migrate/20240801094244_populate_everyone_role.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class PopulateEveryoneRole < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  class UserRole < ApplicationRecord
+    EVERYONE_ROLE_ID = -99
+
+    FLAGS = {
+      invite_users: (1 << 16),
+    }.freeze
+  end
+
+  def up
+    UserRole.create!(id: UserRole::EVERYONE_ROLE_ID, permissions: UserRole::FLAGS[:invite_users])
+  rescue ActiveRecord::RecordNotUnique
+    nil
+  end
+
+  def down; end
+end

--- a/db/migrate/20240801100823_change_users_default_role_id.rb
+++ b/db/migrate/20240801100823_change_users_default_role_id.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ChangeUsersDefaultRoleId < ActiveRecord::Migration[7.1]
+  def change
+    change_column_default :users, :role_id, from: nil, to: -99
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_24_181224) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_01_100823) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -1201,7 +1201,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_24_181224) do
     t.string "webauthn_id"
     t.inet "sign_up_ip"
     t.boolean "skip_sign_in_token"
-    t.bigint "role_id"
+    t.bigint "role_id", default: -99
     t.text "settings"
     t.string "time_zone"
     t.string "otp_secret"


### PR DESCRIPTION
Fixes #31240

Note that I am not sure whether this is a good approach, as this would increase the index size for `index_users_on_role_id` for little benefit. Ideally, a user with the default role would still not have `role_id` set, but preloading would work anyway.