### PR TITLE
Add endpoints to accept and dismiss multiple notification requests at once

### DIFF
--- a/app/controllers/api/v1/notifications/requests_controller.rb
+++ b/app/controllers/api/v1/notifications/requests_controller.rb
@@ -5,7 +5,8 @@ class Api::V1::Notifications::RequestsController < Api::BaseController
   before_action -> { doorkeeper_authorize! :write, :'write:notifications' }, except: :index
 
   before_action :require_user!
-  before_action :set_request, except: :index
+  before_action :set_request, only: [:show, :accept, :dismiss]
+  before_action :set_requests, only: [:accept_bulk, :dismiss_bulk]
 
   after_action :insert_pagination_headers, only: :index
 
@@ -32,6 +33,16 @@ class Api::V1::Notifications::RequestsController < Api::BaseController
     render_empty
   end
 
+  def accept_bulk
+    @requests.each { |request| AcceptNotificationRequestService.new.call(request) }
+    render_empty
+  end
+
+  def dismiss_bulk
+    @requests.each(&:destroy!)
+    render_empty
+  end
+
   private
 
   def load_requests
@@ -51,6 +62,10 @@ class Api::V1::Notifications::RequestsController < Api::BaseController
 
   def set_request
     @request = NotificationRequest.where(account: current_account).find(params[:id])
+  end
+
+  def set_requests
+    @requests = NotificationRequest.where(account: current_account, id: Array(params[:id]).uniq.map(&:to_i))
   end
 
   def next_path

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -155,6 +155,11 @@ namespace :api, format: false do
 
     namespace :notifications do
       resources :requests, only: [:index, :show] do
+        collection do
+          post :accept, to: 'requests#accept_bulk'
+          post :dismiss, to: 'requests#dismiss_bulk'
+        end
+
         member do
           post :accept
           post :dismiss

--- a/spec/requests/api/v1/notifications/requests_spec.rb
+++ b/spec/requests/api/v1/notifications/requests_spec.rb
@@ -87,4 +87,37 @@ RSpec.describe 'Requests' do
       end
     end
   end
+
+  describe 'POST /api/v1/notifications/requests/accept' do
+    subject do
+      post '/api/v1/notifications/requests/accept', params: { id: [notification_request.id] }, headers: headers
+    end
+
+    let!(:notification_request) { Fabricate(:notification_request, account: user.account) }
+
+    it_behaves_like 'forbidden for wrong scope', 'read read:notifications'
+
+    it 'returns http success and creates notification permission', :aggregate_failures do
+      subject
+
+      expect(NotificationPermission.find_by(account: notification_request.account, from_account: notification_request.from_account)).to_not be_nil
+      expect(response).to have_http_status(200)
+    end
+  end
+
+  describe 'POST /api/v1/notifications/requests/dismiss' do
+    subject do
+      post '/api/v1/notifications/requests/dismiss', params: { id: [notification_request.id] }, headers: headers
+    end
+
+    let!(:notification_request) { Fabricate(:notification_request, account: user.account) }
+
+    it_behaves_like 'forbidden for wrong scope', 'read read:notifications'
+
+    it 'returns http success and destroys the notification request', :aggregate_failures do
+      expect { subject }.to change(NotificationRequest, :count).by(-1)
+
+      expect(response).to have_http_status(200)
+    end
+  end
 end


### PR DESCRIPTION
This adds `POST /api/v1/notifications/requests/accept` and `POST /api/v1/notifications/requests/dismiss` both taking an `id` parameter with an array of request IDs to accept or reject at once.

Rationale: make #31226 possible without risking triggering rate limits