### PR TITLE
Extract method for self-referencing records in `AccountStatusCleanupPolicy`

### DIFF
--- a/app/models/account_statuses_cleanup_policy.rb
+++ b/app/models/account_statuses_cleanup_policy.rb
@@ -145,15 +145,15 @@ class AccountStatusesCleanupPolicy < ApplicationRecord
   end
 
   def without_self_fav_scope
-    Status.where('NOT EXISTS (SELECT 1 FROM favourites fav WHERE fav.account_id = statuses.account_id AND fav.status_id = statuses.id)')
+    Status.where.not(self_status_reference_exists(Favourite))
   end
 
   def without_self_bookmark_scope
-    Status.where('NOT EXISTS (SELECT 1 FROM bookmarks bookmark WHERE bookmark.account_id = statuses.account_id AND bookmark.status_id = statuses.id)')
+    Status.where.not(self_status_reference_exists(Bookmark))
   end
 
   def without_pinned_scope
-    Status.where('NOT EXISTS (SELECT 1 FROM status_pins pin WHERE pin.account_id = statuses.account_id AND pin.status_id = statuses.id)')
+    Status.where.not(self_status_reference_exists(StatusPin))
   end
 
   def without_media_scope
@@ -173,5 +173,14 @@ class AccountStatusesCleanupPolicy < ApplicationRecord
 
   def account_statuses
     Status.where(account_id: account_id)
+  end
+
+  def self_status_reference_exists(model)
+    model
+      .where(model.arel_table[:account_id].eq Status.arel_table[:account_id])
+      .where(model.arel_table[:status_id].eq Status.arel_table[:id])
+      .select(1)
+      .arel
+      .exists
   end
 end


### PR DESCRIPTION
Part of my ongoing campaign to eliminate sql strings where possible.

I think this is an improvement as-is, but one thing that would be nice (and I'm just not sure on) would be to pull the conditions out by reflecting on the association and getting the "where" part but not getting the join as well. Maybe this exists and I don't know about it.

I could also see the first portion of this done instead as a class method or scope on `Status` directly.