### PR TITLE
Fix click event handling when clicking outside of an open dropdown menu

### DIFF
--- a/app/javascript/mastodon/components/dropdown_menu.jsx
+++ b/app/javascript/mastodon/components/dropdown_menu.jsx
@@ -39,6 +39,7 @@ class DropdownMenu extends PureComponent {
     if (this.node && !this.node.contains(e.target)) {
       this.props.onClose();
       e.stopPropagation();
+      e.preventDefault();
     }
   };
 


### PR DESCRIPTION
While experimenting with designs involving dropdown menus, I encountered a weird bug: clicking on a link while a dropdown is open will prevent the associated javascript event handler (because of `stopPropagation()` I assume) but open the link in a new tab, which can be extremely confusing.

This PR fixes that by calling `preventDefault()`.