### PR TITLE
Increase maximum page size for Admin Domain Management APIs

### DIFF
--- a/app/controllers/api/v1/admin/domain_allows_controller.rb
+++ b/app/controllers/api/v1/admin/domain_allows_controller.rb
@@ -5,6 +5,7 @@ class Api::V1::Admin::DomainAllowsController < Api::BaseController
   include AccountableConcern
 
   LIMIT = 100
+  MAX_LIMIT = 500
 
   before_action -> { authorize_if_got_token! :'admin:read', :'admin:read:domain_allows' }, only: [:index, :show]
   before_action -> { authorize_if_got_token! :'admin:write', :'admin:write:domain_allows' }, except: [:index, :show]
@@ -47,7 +48,7 @@ class Api::V1::Admin::DomainAllowsController < Api::BaseController
   private
 
   def set_domain_allows
-    @domain_allows = DomainAllow.order(id: :desc).to_a_paginated_by_id(limit_param(LIMIT), params_slice(:max_id, :since_id, :min_id))
+    @domain_allows = DomainAllow.order(id: :desc).to_a_paginated_by_id(limit_param(LIMIT, MAX_LIMIT), params_slice(:max_id, :since_id, :min_id))
   end
 
   def set_domain_allow
@@ -67,7 +68,7 @@ class Api::V1::Admin::DomainAllowsController < Api::BaseController
   end
 
   def records_continue?
-    @domain_allows.size == limit_param(LIMIT)
+    @domain_allows.size == limit_param(LIMIT, MAX_LIMIT)
   end
 
   def resource_params

--- a/app/controllers/api/v1/admin/domain_blocks_controller.rb
+++ b/app/controllers/api/v1/admin/domain_blocks_controller.rb
@@ -5,6 +5,7 @@ class Api::V1::Admin::DomainBlocksController < Api::BaseController
   include AccountableConcern
 
   LIMIT = 100
+  MAX_LIMIT = 500
 
   before_action -> { authorize_if_got_token! :'admin:read', :'admin:read:domain_blocks' }, only: [:index, :show]
   before_action -> { authorize_if_got_token! :'admin:write', :'admin:write:domain_blocks' }, except: [:index, :show]
@@ -59,7 +60,7 @@ class Api::V1::Admin::DomainBlocksController < Api::BaseController
   end
 
   def set_domain_blocks
-    @domain_blocks = DomainBlock.order(id: :desc).to_a_paginated_by_id(limit_param(LIMIT), params_slice(:max_id, :since_id, :min_id))
+    @domain_blocks = DomainBlock.order(id: :desc).to_a_paginated_by_id(limit_param(LIMIT, MAX_LIMIT), params_slice(:max_id, :since_id, :min_id))
   end
 
   def set_domain_block
@@ -83,7 +84,7 @@ class Api::V1::Admin::DomainBlocksController < Api::BaseController
   end
 
   def records_continue?
-    @domain_blocks.size == limit_param(LIMIT)
+    @domain_blocks.size == limit_param(LIMIT, MAX_LIMIT)
   end
 
   def resource_params


### PR DESCRIPTION
In my experience working on FediCheck, I noticed that we were frequently needing to make at least 4-10 API requests to retrieve back the full set of domain blocks for an instance through the admin APIs, when we can just request back the full set via the public domain blocks API.

This change allows for requesting up to 500 records at a time, as opposed to 200 at a time. 

From a sampling of 38 Fediverse servers that I have data for, both big and small, the median number of domain blocks is 363, with some outliers both at the low end <100 and some at the high end >1000. Given this data, 500 generally allows requesting back the full set of domain blocks in a single request, with some servers needing a few more requests.

This change will make it easier to synchronise domain block data with external tools.