### PR TITLE
Change `DropdownMenu` component's `items` prop type

### DIFF
--- a/app/javascript/mastodon/components/dropdown_menu.jsx
+++ b/app/javascript/mastodon/components/dropdown_menu.jsx
@@ -20,7 +20,7 @@ let id = 0;
 class DropdownMenu extends PureComponent {
 
   static propTypes = {
-    items: PropTypes.oneOfType([PropTypes.array, ImmutablePropTypes.list]).isRequired,
+    items: PropTypes.array.isRequired,
     loading: PropTypes.bool,
     scrollable: PropTypes.bool,
     onClose: PropTypes.func.isRequired,
@@ -165,7 +165,7 @@ class Dropdown extends PureComponent {
     children: PropTypes.node,
     icon: PropTypes.string,
     iconComponent: PropTypes.func,
-    items: PropTypes.oneOfType([PropTypes.array, ImmutablePropTypes.list]),
+    items: PropTypes.array.isRequired,
     loading: PropTypes.bool,
     size: PropTypes.number,
     title: PropTypes.string,


### PR DESCRIPTION
While trying to use this component in Typescript, I stumbled on its pretty complex type.

I don't think there has been any case of us passing down an Immutable.js list to this component in a long time, if ever.

On a side note, `DropdownMenuContainer` has an optional `scrollKey` prop that looks pretty suspect and does not appear in the declared `propTypes`. I have not fully looked into how it were used and whether it still serves a purpose.