### PR TITLE
Change PostCSS config to allow logical properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "@svgr/webpack": "^5.5.0",
     "arrow-key-navigation": "^1.2.0",
     "async-mutex": "^0.5.0",
-    "autoprefixer": "^10.4.14",
     "axios": "^1.4.0",
     "babel-loader": "^8.3.0",
     "babel-plugin-formatjs": "^10.5.1",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,8 +1,13 @@
+const postcssPresetEnv = require('postcss-preset-env');
+
 /** @type {import('postcss-load-config').Config} */
 const config = ({ env }) => ({
   plugins: [
-    require('postcss-preset-env'),
-    require('autoprefixer'),
+    postcssPresetEnv({
+      features: {
+        'logical-properties-and-values': false
+      }
+    }),
     env === 'production' ? require('cssnano') : '',
   ],
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2814,7 +2814,6 @@ __metadata:
     "@typescript-eslint/parser": "npm:^7.0.0"
     arrow-key-navigation: "npm:^1.2.0"
     async-mutex: "npm:^0.5.0"
-    autoprefixer: "npm:^10.4.14"
     axios: "npm:^1.4.0"
     babel-jest: "npm:^29.5.0"
     babel-loader: "npm:^8.3.0"
@@ -5107,7 +5106,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"autoprefixer@npm:^10.4.14, autoprefixer@npm:^10.4.19":
+"autoprefixer@npm:^10.4.19":
   version: 10.4.19
   resolution: "autoprefixer@npm:10.4.19"
   dependencies:


### PR DESCRIPTION
We use the `insert-*` properties in the codebase, but `postcss-preset-env` replaces them with their LTR equivalent for compatibility. This is well supported in recent browsers, so let's disable the plugin so they are used in the final CSS.

Autoprefixer is now automatically called by `postcss-preset-env`, so we can remove it from our config.