### PR TITLE
Fix contrast between background and form elements on some pages

### DIFF
--- a/app/controllers/auth/confirmations_controller.rb
+++ b/app/controllers/auth/confirmations_controller.rb
@@ -5,7 +5,6 @@ class Auth::ConfirmationsController < Devise::ConfirmationsController
 
   layout 'auth'
 
-  before_action :set_body_classes
   before_action :set_confirmation_user!, only: [:show, :confirm_captcha]
   before_action :redirect_confirmed_user, if: :signed_in_confirmed_user?
 
@@ -71,10 +70,6 @@ class Auth::ConfirmationsController < Devise::ConfirmationsController
 
   def signed_in_confirmed_user?
     user_signed_in? && current_user.confirmed? && current_user.unconfirmed_email.blank?
-  end
-
-  def set_body_classes
-    @body_classes = 'lighter'
   end
 
   def after_resending_confirmation_instructions_path_for(_resource_name)

--- a/app/controllers/auth/passwords_controller.rb
+++ b/app/controllers/auth/passwords_controller.rb
@@ -3,7 +3,6 @@
 class Auth::PasswordsController < Devise::PasswordsController
   skip_before_action :check_self_destruct!
   before_action :redirect_invalid_reset_token, only: :edit, unless: :reset_password_token_is_valid?
-  before_action :set_body_classes
 
   layout 'auth'
 
@@ -22,10 +21,6 @@ class Auth::PasswordsController < Devise::PasswordsController
   def redirect_invalid_reset_token
     flash[:error] = I18n.t('auth.invalid_reset_password_token')
     redirect_to new_password_path(resource_name)
-  end
-
-  def set_body_classes
-    @body_classes = 'lighter'
   end
 
   def reset_password_token_is_valid?

--- a/app/controllers/auth/registrations_controller.rb
+++ b/app/controllers/auth/registrations_controller.rb
@@ -105,7 +105,7 @@ class Auth::RegistrationsController < Devise::RegistrationsController
   private
 
   def set_body_classes
-    @body_classes = %w(edit update).include?(action_name) ? 'admin' : 'lighter'
+    @body_classes = 'admin' if %w(edit update).include?(action_name)
   end
 
   def set_invite

--- a/app/controllers/auth/sessions_controller.rb
+++ b/app/controllers/auth/sessions_controller.rb
@@ -16,8 +16,6 @@ class Auth::SessionsController < Devise::SessionsController
 
   include Auth::TwoFactorAuthenticationConcern
 
-  before_action :set_body_classes
-
   content_security_policy only: :new do |p|
     p.form_action(false)
   end
@@ -102,10 +100,6 @@ class Auth::SessionsController < Devise::SessionsController
   end
 
   private
-
-  def set_body_classes
-    @body_classes = 'lighter'
-  end
 
   def home_paths(resource)
     paths = [about_path, '/explore']

--- a/app/controllers/auth/setup_controller.rb
+++ b/app/controllers/auth/setup_controller.rb
@@ -5,7 +5,6 @@ class Auth::SetupController < ApplicationController
 
   before_action :authenticate_user!
   before_action :require_unconfirmed_or_pending!
-  before_action :set_body_classes
   before_action :set_user
 
   skip_before_action :require_functional!
@@ -33,10 +32,6 @@ class Auth::SetupController < ApplicationController
 
   def set_user
     @user = current_user
-  end
-
-  def set_body_classes
-    @body_classes = 'lighter'
   end
 
   def user_params

--- a/app/controllers/concerns/auth/two_factor_authentication_concern.rb
+++ b/app/controllers/concerns/auth/two_factor_authentication_concern.rb
@@ -83,7 +83,6 @@ module Auth::TwoFactorAuthenticationConcern
   def prompt_for_two_factor(user)
     register_attempt_in_session(user)
 
-    @body_classes     = 'lighter'
     @webauthn_enabled = user.webauthn_enabled?
     @scheme_type      = if user.webauthn_enabled? && user_params[:otp_attempt].blank?
                           'webauthn'

--- a/app/controllers/concerns/challengable_concern.rb
+++ b/app/controllers/concerns/challengable_concern.rb
@@ -42,7 +42,6 @@ module ChallengableConcern
   end
 
   def render_challenge
-    @body_classes = 'lighter'
     render 'auth/challenges/new', layout: 'auth'
   end
 

--- a/app/controllers/mail_subscriptions_controller.rb
+++ b/app/controllers/mail_subscriptions_controller.rb
@@ -5,7 +5,6 @@ class MailSubscriptionsController < ApplicationController
 
   skip_before_action :require_functional!
 
-  before_action :set_body_classes
   before_action :set_user
   before_action :set_type
 
@@ -23,10 +22,6 @@ class MailSubscriptionsController < ApplicationController
   def set_user
     @user = GlobalID::Locator.locate_signed(params[:token], for: 'unsubscribe')
     not_found unless @user
-  end
-
-  def set_body_classes
-    @body_classes = 'lighter'
   end
 
   def set_type

--- a/app/javascript/styles/mastodon/basics.scss
+++ b/app/javascript/styles/mastodon/basics.scss
@@ -66,10 +66,6 @@ body {
     }
   }
 
-  &.lighter {
-    background: $ui-base-color;
-  }
-
   &.with-modals {
     overflow-x: hidden;
     overflow-y: scroll;
@@ -109,7 +105,6 @@ body {
   }
 
   &.embed {
-    background: lighten($ui-base-color, 4%);
     margin: 0;
     padding-bottom: 0;
 
@@ -122,15 +117,12 @@ body {
   }
 
   &.admin {
-    background: var(--background-color);
     padding: 0;
   }
 
   &.error {
     position: absolute;
     text-align: center;
-    color: $darker-text-color;
-    background: $ui-base-color;
     width: 100%;
     height: 100%;
     padding: 0;


### PR DESCRIPTION
The background color of most pages and form elements were changed in #31034, but some pages were still using a lighter background color, which happened to be the same as the form elements, reducing legibility.

## Before

![image](https://github.com/user-attachments/assets/0533f1f2-e2f9-42a6-8c2e-156d39a82e02)
![image](https://github.com/user-attachments/assets/4d9c4bbb-d7f1-4d5e-9e1f-0d2739deeabb)
![image](https://github.com/user-attachments/assets/84993283-c038-4936-85b2-c91a18b737f3)
![image](https://github.com/user-attachments/assets/954f972e-806c-40ee-8676-a3487e3e0bc3)

## After

![image](https://github.com/user-attachments/assets/924ea0cf-52f1-4dc8-8881-b3b4594c1bf2)
![image](https://github.com/user-attachments/assets/543f8b40-e505-4bf7-bac7-21ca916ff4d1)
![image](https://github.com/user-attachments/assets/38a7b7dc-d5b8-4136-b6fc-e6d57e6a07ef)
![image](https://github.com/user-attachments/assets/608d4942-e411-4795-9819-8592f05fecc3)
