### PR TITLE
Set "admin" body class from `admin` nested layout

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -7,16 +7,11 @@ module Admin
 
     layout 'admin'
 
-    before_action :set_body_classes
     before_action :set_cache_headers
 
     after_action :verify_authorized
 
     private
-
-    def set_body_classes
-      @body_classes = 'admin'
-    end
 
     def set_cache_headers
       response.cache_control.replace(private: true, no_store: true)

--- a/app/controllers/auth/registrations_controller.rb
+++ b/app/controllers/auth/registrations_controller.rb
@@ -11,7 +11,6 @@ class Auth::RegistrationsController < Devise::RegistrationsController
   before_action :configure_sign_up_params, only: [:create]
   before_action :set_sessions, only: [:edit, :update]
   before_action :set_strikes, only: [:edit, :update]
-  before_action :set_body_classes, only: [:new, :create, :edit, :update]
   before_action :require_not_suspended!, only: [:update]
   before_action :set_cache_headers, only: [:edit, :update]
   before_action :set_rules, only: :new
@@ -103,10 +102,6 @@ class Auth::RegistrationsController < Devise::RegistrationsController
   end
 
   private
-
-  def set_body_classes
-    @body_classes = 'admin' if %w(edit update).include?(action_name)
-  end
 
   def set_invite
     @invite = begin

--- a/app/controllers/disputes/base_controller.rb
+++ b/app/controllers/disputes/base_controller.rb
@@ -7,15 +7,10 @@ class Disputes::BaseController < ApplicationController
 
   skip_before_action :require_functional!
 
-  before_action :set_body_classes
   before_action :authenticate_user!
   before_action :set_cache_headers
 
   private
-
-  def set_body_classes
-    @body_classes = 'admin'
-  end
 
   def set_cache_headers
     response.cache_control.replace(private: true, no_store: true)

--- a/app/controllers/filters/statuses_controller.rb
+++ b/app/controllers/filters/statuses_controller.rb
@@ -6,7 +6,6 @@ class Filters::StatusesController < ApplicationController
   before_action :authenticate_user!
   before_action :set_filter
   before_action :set_status_filters
-  before_action :set_body_classes
   before_action :set_cache_headers
 
   PER_PAGE = 20
@@ -40,10 +39,6 @@ class Filters::StatusesController < ApplicationController
 
   def action_from_button
     'remove' if params[:remove]
-  end
-
-  def set_body_classes
-    @body_classes = 'admin'
   end
 
   def set_cache_headers

--- a/app/controllers/filters_controller.rb
+++ b/app/controllers/filters_controller.rb
@@ -5,7 +5,6 @@ class FiltersController < ApplicationController
 
   before_action :authenticate_user!
   before_action :set_filter, only: [:edit, :update, :destroy]
-  before_action :set_body_classes
   before_action :set_cache_headers
 
   def index
@@ -50,10 +49,6 @@ class FiltersController < ApplicationController
 
   def resource_params
     params.require(:custom_filter).permit(:title, :expires_in, :filter_action, context: [], keywords_attributes: [:id, :keyword, :whole_word, :_destroy])
-  end
-
-  def set_body_classes
-    @body_classes = 'admin'
   end
 
   def set_cache_headers

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -6,7 +6,6 @@ class InvitesController < ApplicationController
   layout 'admin'
 
   before_action :authenticate_user!
-  before_action :set_body_classes
   before_action :set_cache_headers
 
   def index
@@ -45,10 +44,6 @@ class InvitesController < ApplicationController
 
   def resource_params
     params.require(:invite).permit(:max_uses, :expires_in, :autofollow, :comment)
-  end
-
-  def set_body_classes
-    @body_classes = 'admin'
   end
 
   def set_cache_headers

--- a/app/controllers/oauth/authorized_applications_controller.rb
+++ b/app/controllers/oauth/authorized_applications_controller.rb
@@ -6,7 +6,6 @@ class Oauth::AuthorizedApplicationsController < Doorkeeper::AuthorizedApplicatio
   before_action :store_current_location
   before_action :authenticate_resource_owner!
   before_action :require_not_suspended!, only: :destroy
-  before_action :set_body_classes
   before_action :set_cache_headers
 
   before_action :set_last_used_at_by_app, only: :index, unless: -> { request.format == :json }
@@ -22,10 +21,6 @@ class Oauth::AuthorizedApplicationsController < Doorkeeper::AuthorizedApplicatio
   end
 
   private
-
-  def set_body_classes
-    @body_classes = 'admin'
-  end
 
   def store_current_location
     store_location_for(:user, request.url)

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -6,7 +6,6 @@ class RelationshipsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_accounts, only: :show
   before_action :set_relationships, only: :show
-  before_action :set_body_classes
   before_action :set_cache_headers
 
   helper_method :following_relationship?, :followed_by_relationship?, :mutual_relationship?
@@ -66,10 +65,6 @@ class RelationshipsController < ApplicationController
     elsif params[:block_domains] || params[:remove_domains_from_followers]
       'remove_domains_from_followers'
     end
-  end
-
-  def set_body_classes
-    @body_classes = 'admin'
   end
 
   def set_cache_headers

--- a/app/controllers/settings/base_controller.rb
+++ b/app/controllers/settings/base_controller.rb
@@ -4,14 +4,9 @@ class Settings::BaseController < ApplicationController
   layout 'admin'
 
   before_action :authenticate_user!
-  before_action :set_body_classes
   before_action :set_cache_headers
 
   private
-
-  def set_body_classes
-    @body_classes = 'admin'
-  end
 
   def set_cache_headers
     response.cache_control.replace(private: true, no_store: true)

--- a/app/controllers/severed_relationships_controller.rb
+++ b/app/controllers/severed_relationships_controller.rb
@@ -4,7 +4,6 @@ class SeveredRelationshipsController < ApplicationController
   layout 'admin'
 
   before_action :authenticate_user!
-  before_action :set_body_classes
   before_action :set_cache_headers
 
   before_action :set_event, only: [:following, :followers]
@@ -49,10 +48,6 @@ class SeveredRelationshipsController < ApplicationController
 
   def acct(account)
     account.local? ? account.local_username_and_domain : account.acct
-  end
-
-  def set_body_classes
-    @body_classes = 'admin'
   end
 
   def set_cache_headers

--- a/app/controllers/statuses_cleanup_controller.rb
+++ b/app/controllers/statuses_cleanup_controller.rb
@@ -5,7 +5,6 @@ class StatusesCleanupController < ApplicationController
 
   before_action :authenticate_user!
   before_action :set_policy
-  before_action :set_body_classes
   before_action :set_cache_headers
 
   def show; end
@@ -32,10 +31,6 @@ class StatusesCleanupController < ApplicationController
 
   def resource_params
     params.require(:account_statuses_cleanup_policy).permit(:enabled, :min_status_age, :keep_direct, :keep_pinned, :keep_polls, :keep_media, :keep_self_fav, :keep_self_bookmark, :min_favs, :min_reblogs)
-  end
-
-  def set_body_classes
-    @body_classes = 'admin'
   end
 
   def set_cache_headers

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -159,6 +159,7 @@ module ApplicationHelper
 
   def body_classes
     output = body_class_string.split
+    output << content_for(:body_classes)
     output << "theme-#{current_theme.parameterize}"
     output << 'system-font' if current_account&.user&.setting_system_font_ui
     output << (current_account&.user&.setting_reduce_motion ? 'reduce-motion' : 'no-reduce-motion')

--- a/app/views/layouts/admin.html.haml
+++ b/app/views/layouts/admin.html.haml
@@ -3,6 +3,8 @@
   = javascript_pack_tag 'public', crossorigin: 'anonymous'
   = javascript_pack_tag 'admin', async: true, crossorigin: 'anonymous'
 
+- content_for :body_classes, 'admin'
+
 - content_for :content do
   .admin-wrapper
     .sidebar-wrapper

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -8,7 +8,16 @@ RSpec.describe ApplicationHelper do
       before { helper.extend controller_helpers }
 
       it 'uses the controller body classes in the result' do
-        expect(helper.body_classes).to match(/modal-layout compose-standalone/)
+        expect(helper.body_classes)
+          .to match(/modal-layout compose-standalone/)
+          .and match(/theme-default/)
+      end
+
+      it 'includes values set via content_for' do
+        helper.content_for(:body_classes) { 'admin' }
+
+        expect(helper.body_classes)
+          .to match(/admin/)
       end
 
       private


### PR DESCRIPTION
Follow up on https://github.com/mastodon/mastodon/pull/31266 (which removed a bunch of explicit body class setting) -- the vast majority (all but one, noted below) of the controllers which set `@body_classes = 'admin'` are also using the `admin` layout. The change here is to allow the admin layout itself to contribute the body class value back up to the application that it's nested within, via a `content_for` value.

Some notes and more to contemplate:

- Every place with a removed method here does in fact use the admin layout
- The settings and admin base controllers are included here and both use admin layout, so all inheriting controllers previously getting both admin layout and body class will continue to do so
- The auth/registrations spot with the conditional has a corresponding conditional elsewhere in controller which sets layout to admin for those same actions
- I added specs to assert around this new behavior (allowing content_for to contribute to the value) and noticed while doing that many of the other contributors to the `body_classes` helper are not well spec'd - might make sense to add to this at some point.
- There is only one spot - `oauth/authorized_applications` which is setting the `@body_classes = 'admin'` but is NOT using the admin layout. I've left this alone and it will continue to work, but might be worth reviewing here if this one *should be* using the admin layout?
- After these changes and the previous which removed all the `lighter` ones, there are only ~5 remaining spots setting the value this way. Some of them repeat each other and could maybe be extracted to base classes, and/or some could be moved to views and contributed via content_for instead, and we could completely remove the i-var-passing approach and the `body_class_string` method entirely.