### PR TITLE
Add `User::Activity` concern to hold activity window features

### DIFF
--- a/app/models/concerns/user/activity.rb
+++ b/app/models/concerns/user/activity.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module User::Activity
+  extend ActiveSupport::Concern
+
+  # The home and list feeds will be stored for this amount of time, and status
+  # fan-out to followers will include only people active within this time frame.
+  #
+  # Lowering the duration may improve performance if many people sign up, but
+  # most will not check their feed every day. Raising the duration reduces the
+  # amount of background processing that happens when people become active.
+  ACTIVE_DURATION = ENV.fetch('USER_ACTIVE_DAYS', 7).to_i.days.freeze
+
+  included do
+    scope :signed_in_recently, -> { where(current_sign_in_at: ACTIVE_DURATION.ago..) }
+    scope :not_signed_in_recently, -> { where(current_sign_in_at: ...ACTIVE_DURATION.ago) }
+  end
+
+  private
+
+  def inactive_since_duration?
+    last_sign_in_at < ACTIVE_DURATION.ago
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -56,19 +56,11 @@ class User < ApplicationRecord
 
   include LanguagesHelper
   include Redisable
+  include User::Activity
   include User::HasSettings
   include User::LdapAuthenticable
   include User::Omniauthable
   include User::PamAuthenticable
-
-  # The home and list feeds will be stored in Redis for this amount
-  # of time, and status fan-out to followers will include only people
-  # within this time frame. Lowering the duration may improve performance
-  # if lots of people sign up, but not a lot of them check their feed
-  # every day. Raising the duration reduces the amount of expensive
-  # RegenerationWorker jobs that need to be run when those people come
-  # to check their feed
-  ACTIVE_DURATION = ENV.fetch('USER_ACTIVE_DAYS', 7).to_i.days.freeze
 
   devise :two_factor_authenticatable,
          otp_secret_encryption_key: Rails.configuration.x.otp_secret,
@@ -122,8 +114,6 @@ class User < ApplicationRecord
   scope :enabled, -> { where(disabled: false) }
   scope :disabled, -> { where(disabled: true) }
   scope :active, -> { confirmed.signed_in_recently.account_not_suspended }
-  scope :signed_in_recently, -> { where(current_sign_in_at: ACTIVE_DURATION.ago..) }
-  scope :not_signed_in_recently, -> { where(current_sign_in_at: ...ACTIVE_DURATION.ago) }
   scope :matches_email, ->(value) { where(arel_table[:email].matches("#{value}%")) }
   scope :matches_ip, ->(value) { left_joins(:ips).where('user_ips.ip <<= ?', value).group('users.id') }
 
@@ -496,7 +486,7 @@ class User < ApplicationRecord
     return unless confirmed?
 
     ActivityTracker.record('activity:logins', id)
-    regenerate_feed! if needs_feed_update?
+    regenerate_feed! if inactive_since_duration?
   end
 
   def notify_staff_about_pending_account!
@@ -509,10 +499,6 @@ class User < ApplicationRecord
 
   def regenerate_feed!
     RegenerationWorker.perform_async(account_id) if redis.set("account:#{account_id}:regeneration", true, nx: true, ex: 1.day.seconds)
-  end
-
-  def needs_feed_update?
-    last_sign_in_at < ACTIVE_DURATION.ago
   end
 
   def validate_email_dns?

--- a/spec/models/concerns/user/activity_spec.rb
+++ b/spec/models/concerns/user/activity_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe User::Activity do
+  describe 'Scopes' do
+    describe '.signed_in_recently' do
+      let!(:recent_sign_in_user) { Fabricate(:user, current_sign_in_at: within_duration_window_days.ago) }
+
+      before { Fabricate(:user, current_sign_in_at: exceed_duration_window_days.ago) }
+
+      it 'returns a relation of users who have signed in during the recent period' do
+        expect(User.signed_in_recently)
+          .to contain_exactly(recent_sign_in_user)
+      end
+    end
+
+    describe '.not_signed_in_recently' do
+      let!(:no_recent_sign_in_user) { Fabricate(:user, current_sign_in_at: exceed_duration_window_days.ago) }
+
+      before { Fabricate(:user, current_sign_in_at: within_duration_window_days.ago) }
+
+      it 'returns a relation of users who have not signed in during the recent period' do
+        expect(User.not_signed_in_recently)
+          .to contain_exactly(no_recent_sign_in_user)
+      end
+    end
+
+    private
+
+    def exceed_duration_window_days
+      described_class::ACTIVE_DURATION + 2.days
+    end
+
+    def within_duration_window_days
+      described_class::ACTIVE_DURATION - 2.days
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -89,26 +89,6 @@ RSpec.describe User do
       end
     end
 
-    describe 'signed_in_recently' do
-      it 'returns a relation of users who have signed in during the recent period' do
-        recent_sign_in_user = Fabricate(:user, current_sign_in_at: within_duration_window_days.ago)
-        Fabricate(:user, current_sign_in_at: exceed_duration_window_days.ago)
-
-        expect(described_class.signed_in_recently)
-          .to contain_exactly(recent_sign_in_user)
-      end
-    end
-
-    describe 'not_signed_in_recently' do
-      it 'returns a relation of users who have not signed in during the recent period' do
-        no_recent_sign_in_user = Fabricate(:user, current_sign_in_at: exceed_duration_window_days.ago)
-        Fabricate(:user, current_sign_in_at: within_duration_window_days.ago)
-
-        expect(described_class.not_signed_in_recently)
-          .to contain_exactly(no_recent_sign_in_user)
-      end
-    end
-
     describe 'account_not_suspended' do
       it 'returns with linked accounts that are not suspended' do
         suspended_account = Fabricate(:account, suspended_at: 10.days.ago)
@@ -142,14 +122,6 @@ RSpec.describe User do
 
         expect(described_class.matches_ip('2160:2160::/32')).to contain_exactly(user1)
       end
-    end
-
-    def exceed_duration_window_days
-      described_class::ACTIVE_DURATION + 2.days
-    end
-
-    def within_duration_window_days
-      described_class::ACTIVE_DURATION - 2.days
     end
   end
 


### PR DESCRIPTION
In the spirit of https://github.com/mastodon/mastodon/pull/28351 / https://github.com/mastodon/mastodon/pull/28865 / https://github.com/mastodon/mastodon/pull/28866 - same sort of thing for a user model feature, trying to chip away at overall LOC in the various god classes.

Other possible candidates in User (not confident, just guess at glance)...?

- "invite related" stuff
- The world of pending/approved/confirmed/enabled/etc type onboarding/state stuff
- Maybe otp/webauthn/2fa stuff
- Session management and/or devise-override stuff
- "Feed management"