### PR TITLE
Fix logic of block/mute bypass for mentions from moderators

### DIFF
--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -48,7 +48,7 @@ class NotifyService < BaseService
     end
 
     def from_staff?
-      @sender.local? && @sender.user.present? && @sender.user_role&.overrides?(@recipient.user_role)
+      @sender.local? && @sender.user.present? && @sender.user_role&.overrides?(@recipient.user_role) && @sender.user_role&.highlighted? && @sender.user_role&.can?(*UserRole::Flags::CATEGORIES[:moderation])
     end
 
     def from_self?


### PR DESCRIPTION
Early on, it has been decided that mentions from local moderators would be exempt from block/mute checks.

However, that is not extremely well communicated, and it is possible that moderators don't know about this and may accidentally expose their moderator status by messaging someone who has muted or blocked them.

This PR changes it so this exemption only applies if the sender's role is public (`highlighted`) and they have actual moderation permissions.