### PR TITLE
Improve look of verified header fields in profile

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -8076,16 +8076,17 @@ noscript {
       .verified {
         border: 1px solid rgba($valid-value-color, 0.5);
         margin-top: -1px;
+        margin-inline: -1px;
 
         &:first-child {
           border-top-left-radius: 4px;
           border-top-right-radius: 4px;
-          margin-top: 0;
         }
 
         &:last-child {
           border-bottom-left-radius: 4px;
           border-bottom-right-radius: 4px;
+          margin-bottom: -1px;
         }
 
         dt,


### PR DESCRIPTION
Avoids the thin borders next to each other. I think this looks better.

Light theme, before and after:

<img src="https://github.com/user-attachments/assets/1b982239-6a90-447e-b65f-546c1500186f" width="300" height="254" alt=""><img src="https://github.com/user-attachments/assets/ea072334-5221-47df-b3e7-51e2f458de5b" width="300" height="254" alt="">

Dark theme, before and after:

<img src="https://github.com/user-attachments/assets/2a9e79a3-cc26-4422-b302-eb151d8d7978" width="300" height="254" alt=""><img src="https://github.com/user-attachments/assets/b46837a9-24ad-406e-bfd6-9dccba324e23" width="300" height="254" alt="">
