### PR TITLE
Fix missing border around tab/filter bar

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -7354,7 +7354,7 @@ a.status-card {
   display: flex;
   flex-shrink: 0;
 
-  @media screen and (max-width: $no-gap-breakpoint) {
+  @media screen and (max-width: $no-gap-breakpoint - 1px) {
     border-right: 0;
     border-left: 0;
   }


### PR DESCRIPTION
When the viewport width is exactly 1175px, the left and right borders of the tab bar and notification filter bar are missing, even though the wide-viewport design is otherwise being used. This PR fixes that issue by changing the related CSS breakpoint to 1174px.

**Before:**

<p><img src="https://github.com/user-attachments/assets/848cdf81-a45d-4311-83f6-e9f2e31d83c6" width="778" height="207" alt=""></p>

**After:**

<p><img src="https://github.com/user-attachments/assets/ec22c7b0-5321-47b6-8132-16b1ac578883" width="778" height="207" alt=""></p>