### PR TITLE
Support JSON-LD named graph

### DIFF
--- a/app/lib/link_details_extractor.rb
+++ b/app/lib/link_details_extractor.rb
@@ -101,12 +101,9 @@ class LinkDetailsExtractor
     end
 
     def json
-      @json ||= begin
-        json = Oj.load(@data)
-        first = first_of_value(json)
-        json = first['@graph'] if first && first['@graph'] && (first.keys - ['@context', '@graph']).none?
-        root_array(json).compact.find { |obj| SUPPORTED_TYPES.include?(obj['@type']) } || {}
-      end
+      @json ||= root_array(Oj.load(@data))
+                .map { |node| JSON::LD::API.compact(node, 'https://schema.org') }
+                .find { |node| SUPPORTED_TYPES.include?(node['type']) } || {}
     end
   end
 

--- a/app/lib/link_details_extractor.rb
+++ b/app/lib/link_details_extractor.rb
@@ -101,7 +101,12 @@ class LinkDetailsExtractor
     end
 
     def json
-      @json ||= root_array(Oj.load(@data)).compact.find { |obj| SUPPORTED_TYPES.include?(obj['@type']) } || {}
+      @json ||= begin
+        json = Oj.load(@data)
+        first = first_of_value(json)
+        json = first['@graph'] if first && first['@graph'] && (first.keys - ['@context', '@graph']).none?
+        root_array(json).compact.find { |obj| SUPPORTED_TYPES.include?(obj['@type']) } || {}
+      end
     end
   end
 

--- a/spec/lib/link_details_extractor_spec.rb
+++ b/spec/lib/link_details_extractor_spec.rb
@@ -79,6 +79,16 @@ RSpec.describe LinkDetailsExtractor do
         },
       }.to_json
     end
+    let(:html) { <<~HTML }
+      <!doctype html>
+      <html>
+      <body>
+        <script type="application/ld+json">
+          #{ld_json}
+        </script>
+      </body>
+      </html>
+    HTML
 
     shared_examples 'structured data' do
       it 'extracts the expected values from structured data' do
@@ -224,19 +234,25 @@ RSpec.describe LinkDetailsExtractor do
           },
         }.to_json
       end
-      let(:html) { <<~HTML }
-        <!doctype html>
-        <html>
-        <body>
-          <script type="application/ld+json">
-            #{ld_json}
-          </script>
-        </body>
-        </html>
-      HTML
 
       it 'joins author names' do
         expect(subject.author_name).to eq 'Author 1, Author 2'
+      end
+    end
+
+    context 'with named graph' do
+      let(:ld_json) do
+        {
+          '@context' => 'https://schema.org',
+          '@graph' => [
+            '@type' => 'NewsArticle',
+            'headline' => "What's in a name",
+          ],
+        }.to_json
+      end
+
+      it 'descends into @graph node' do
+        expect(subject.title).to eq "What's in a name"
       end
     end
   end


### PR DESCRIPTION
On https://mastodon.social/explore/links I noticed that ProPublica articles are not displayed with a publication time above the headline, even though the JSON-LD block contains a `datePublished` key.

Example: https://www.propublica.org/atpropublica/propublica-and-partners-nominated-for-six-emmy-awards

Apparently the JSON-LD used by ProPublica is a [“named graphs”](https://www.w3.org/TR/json-ld11/#named-graphs). I was not aware of this concept, but AFAIU the `@graph` property can just be flatted (compare examples [116](https://www.w3.org/TR/json-ld11/#example-116-using-graph-to-explicitly-express-the-default-graph) and [117](https://www.w3.org/TR/json-ld11/#example-117-context-needs-to-be-duplicated-if-graph-is-not-used) in the spec).