### PR TITLE
Move Follow Recommendations to Trends menu, rename to Recommendations & Trends

### DIFF
--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -290,6 +290,10 @@ code {
     flex: 0;
   }
 
+  .input.select.select--languages {
+    min-width: 32ch;
+  }
+
   .required abbr {
     text-decoration: none;
     color: lighten($error-value-color, 12%);

--- a/app/views/admin/follow_recommendations/show.html.haml
+++ b/app/views/admin/follow_recommendations/show.html.haml
@@ -12,7 +12,7 @@
   .filters
     .filter-subset.filter-subset--with-select
       %strong= t('admin.follow_recommendations.language')
-      .input.select.optional
+      .input.select.select--languages.optional
         = form.select :language,
                       options_for_select(Trends.available_locales.map { |key| [standard_locale_name(key), key] }, @language)
     .filter-subset

--- a/app/views/admin/trends/statuses/index.html.haml
+++ b/app/views/admin/trends/statuses/index.html.haml
@@ -12,10 +12,11 @@
   .filters
     .filter-subset.filter-subset--with-select
       %strong= t('admin.follow_recommendations.language')
-      .input.select.optional
+      .input.select.select--languages.optional
         = form.select :locale,
                       options_for_select(@locales.map { |key| [standard_locale_name(key), key] }, params[:locale]),
-                      include_blank: true
+                      { include_blank: true },
+                      { disabled: @locales.empty? }
     .filter-subset
       %strong= t('admin.trends.trending')
       %ul

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -976,7 +976,7 @@ en:
         used_by_over_week:
           one: Used by one person over the last week
           other: Used by %{count} people over the last week
-      title: Trends
+      title: Recommendations & Trends
       trending: Trending
     warning_presets:
       add_new: Add new

--- a/config/navigation.rb
+++ b/config/navigation.rb
@@ -42,6 +42,7 @@ SimpleNavigation::Configuration.run do |navigation|
       s.item :statuses, safe_join([material_symbol('chat_bubble'), t('admin.trends.statuses.title')]), admin_trends_statuses_path, highlights_on: %r{/admin/trends/statuses}
       s.item :tags, safe_join([material_symbol('tag'), t('admin.trends.tags.title')]), admin_trends_tags_path, highlights_on: %r{/admin/trends/tags}
       s.item :links, safe_join([material_symbol('breaking_news'), t('admin.trends.links.title')]), admin_trends_links_path, highlights_on: %r{/admin/trends/links}
+      s.item :follow_recommendations, safe_join([material_symbol('person_add'), t('admin.follow_recommendations.title')]), admin_follow_recommendations_path, highlights_on: %r{/admin/follow_recommendations}
     end
 
     n.item :moderation, safe_join([material_symbol('gavel'), t('moderation.title')]), nil, if: -> { current_user.can?(:manage_reports, :view_audit_log, :manage_users, :manage_invites, :manage_taxonomies, :manage_federation, :manage_blocks) && !self_destruct } do |s|
@@ -49,7 +50,6 @@ SimpleNavigation::Configuration.run do |navigation|
       s.item :accounts, safe_join([material_symbol('groups'), t('admin.accounts.title')]), admin_accounts_path(origin: 'local'), highlights_on: %r{/admin/accounts|admin/account_moderation_notes|/admin/pending_accounts|/admin/disputes|/admin/users}, if: -> { current_user.can?(:manage_users) }
       s.item :tags, safe_join([material_symbol('tag'), t('admin.tags.title')]), admin_tags_path, highlights_on: %r{/admin/tags}, if: -> { current_user.can?(:manage_taxonomies) }
       s.item :invites, safe_join([material_symbol('person_add'), t('admin.invites.title')]), admin_invites_path, if: -> { current_user.can?(:manage_invites) }
-      s.item :follow_recommendations, safe_join([material_symbol('person_add'), t('admin.follow_recommendations.title')]), admin_follow_recommendations_path, highlights_on: %r{/admin/follow_recommendations}, if: -> { current_user.can?(:manage_taxonomies) }
       s.item :instances, safe_join([material_symbol('cloud'), t('admin.instances.title')]), admin_instances_path(limited: limited_federation_mode? ? nil : '1'), highlights_on: %r{/admin/instances|/admin/domain_blocks|/admin/domain_allows}, if: -> { current_user.can?(:manage_federation) }
       s.item :email_domain_blocks, safe_join([material_symbol('mail'), t('admin.email_domain_blocks.title')]), admin_email_domain_blocks_path, highlights_on: %r{/admin/email_domain_blocks}, if: -> { current_user.can?(:manage_blocks) }
       s.item :ip_blocks, safe_join([material_symbol('hide_source'), t('admin.ip_blocks.title')]), admin_ip_blocks_path, highlights_on: %r{/admin/ip_blocks}, if: -> { current_user.can?(:manage_blocks) }


### PR DESCRIPTION
The "Follow Recommendations" seemed really out of place amongst the rest of the moderation related features in the navigation, and is more closely related to trends (i.e., algorithmic stuff)

This change moves "Follow Recommendations" under "Trends", and renames "Trends" to "Recommendations & Trends".

<img width="520" alt="Screenshot 2024-08-04 at 23 25 36" src="https://github.com/user-attachments/assets/bf97c71e-3005-42c5-bfb1-475c4599dc65">
