### PR TITLE
Add option to request partial accounts in grouped notifications API

### DIFF
--- a/app/controllers/api/v2_alpha/notifications_controller.rb
+++ b/app/controllers/api/v2_alpha/notifications_controller.rb
@@ -33,8 +33,8 @@ class Api::V2Alpha::NotificationsController < Api::BaseController
         'app.notification_grouping.status.unique_count' => statuses.uniq.size
       )
 
-      presenter = GroupedNotificationsPresenter.new(@grouped_notifications)
-      render json: presenter, serializer: REST::DedupNotificationGroupSerializer, relationships: @relationships, group_metadata: @group_metadata
+      presenter = GroupedNotificationsPresenter.new(@grouped_notifications, partial_accounts: params[:stripped])
+      render json: presenter, serializer: REST::DedupNotificationGroupSerializer, relationships: @relationships, group_metadata: @group_metadata, stripped: params[:stripped]
     end
   end
 

--- a/app/controllers/api/v2_alpha/notifications_controller.rb
+++ b/app/controllers/api/v2_alpha/notifications_controller.rb
@@ -33,8 +33,8 @@ class Api::V2Alpha::NotificationsController < Api::BaseController
         'app.notification_grouping.status.unique_count' => statuses.uniq.size
       )
 
-      presenter = GroupedNotificationsPresenter.new(@grouped_notifications, partial_accounts: params[:stripped])
-      render json: presenter, serializer: REST::DedupNotificationGroupSerializer, relationships: @relationships, group_metadata: @group_metadata, stripped: params[:stripped]
+      presenter = GroupedNotificationsPresenter.new(@grouped_notifications, expand_accounts: expand_accounts_param)
+      render json: presenter, serializer: REST::DedupNotificationGroupSerializer, relationships: @relationships, group_metadata: @group_metadata, expand_accounts: expand_accounts_param
     end
   end
 
@@ -130,5 +130,16 @@ class Api::V2Alpha::NotificationsController < Api::BaseController
 
   def pagination_params(core_params)
     params.slice(:limit, :types, :exclude_types, :include_filtered).permit(:limit, :include_filtered, types: [], exclude_types: []).merge(core_params)
+  end
+
+  def expand_accounts_param
+    case params[:expand_accounts]
+    when nil, 'full'
+      'full'
+    when 'partial_avatars'
+      'partial_avatars'
+    else
+      raise Mastodon::InvalidParameterError, "Invalid value for 'expand_accounts': '#{params[:expand_accounts]}', allowed values are 'full' and 'partial_avatars'"
+    end
   end
 end

--- a/app/controllers/api/v2_alpha/notifications_controller.rb
+++ b/app/controllers/api/v2_alpha/notifications_controller.rb
@@ -16,10 +16,10 @@ class Api::V2Alpha::NotificationsController < Api::BaseController
       @group_metadata = load_group_metadata
       @grouped_notifications = load_grouped_notifications
       @relationships = StatusRelationshipsPresenter.new(target_statuses_from_notifications, current_user&.account_id)
-      @sample_accounts = @grouped_notifications.flat_map(&:sample_accounts)
+      @presenter = GroupedNotificationsPresenter.new(@grouped_notifications, expand_accounts: expand_accounts_param)
 
       # Preload associations to avoid N+1s
-      ActiveRecord::Associations::Preloader.new(records: @sample_accounts, associations: [:account_stat, { user: :role }]).call
+      ActiveRecord::Associations::Preloader.new(records: @presenter.accounts, associations: [:account_stat, { user: :role }]).call
     end
 
     MastodonOTELTracer.in_span('Api::V2Alpha::NotificationsController#index rendering') do |span|
@@ -27,14 +27,14 @@ class Api::V2Alpha::NotificationsController < Api::BaseController
 
       span.add_attributes(
         'app.notification_grouping.count' => @grouped_notifications.size,
-        'app.notification_grouping.sample_account.count' => @sample_accounts.size,
-        'app.notification_grouping.sample_account.unique_count' => @sample_accounts.pluck(:id).uniq.size,
+        'app.notification_grouping.account.count' => @presenter.accounts.size,
+        'app.notification_grouping.partial_account.count' => @presenter.partial_accounts.size,
         'app.notification_grouping.status.count' => statuses.size,
-        'app.notification_grouping.status.unique_count' => statuses.uniq.size
+        'app.notification_grouping.status.unique_count' => statuses.uniq.size,
+        'app.notification_grouping.expand_accounts_param' => expand_accounts_param
       )
 
-      presenter = GroupedNotificationsPresenter.new(@grouped_notifications, expand_accounts: expand_accounts_param)
-      render json: presenter, serializer: REST::DedupNotificationGroupSerializer, relationships: @relationships, group_metadata: @group_metadata, expand_accounts: expand_accounts_param
+      render json: @presenter, serializer: REST::DedupNotificationGroupSerializer, relationships: @relationships, group_metadata: @group_metadata, expand_accounts: expand_accounts_param
     end
   end
 

--- a/app/presenters/grouped_notifications_presenter.rb
+++ b/app/presenters/grouped_notifications_presenter.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 class GroupedNotificationsPresenter < ActiveModelSerializers::Model
-  def initialize(grouped_notifications)
+  def initialize(grouped_notifications, options = {})
     super()
 
     @grouped_notifications = grouped_notifications
+    @options = options
   end
 
   def notification_groups
@@ -16,6 +17,16 @@ class GroupedNotificationsPresenter < ActiveModelSerializers::Model
   end
 
   def accounts
-    @grouped_notifications.flat_map(&:sample_accounts).uniq(&:id)
+    @accounts ||= begin
+      if @options[:partial_accounts]
+        @grouped_notifications.map { |group| group.sample_accounts.first }.uniq(&:id)
+      else
+        @grouped_notifications.flat_map(&:sample_accounts).uniq(&:id)
+      end
+    end
+  end
+
+  def partial_accounts
+    @grouped_notifications.flat_map { |group| group.sample_accounts[1...] }.uniq(&:id).filter { |account| accounts.exclude?(account) }
   end
 end

--- a/app/presenters/grouped_notifications_presenter.rb
+++ b/app/presenters/grouped_notifications_presenter.rb
@@ -18,7 +18,7 @@ class GroupedNotificationsPresenter < ActiveModelSerializers::Model
 
   def accounts
     @accounts ||= begin
-      if @options[:partial_accounts]
+      if partial_avatars?
         @grouped_notifications.map { |group| group.sample_accounts.first }.uniq(&:id)
       else
         @grouped_notifications.flat_map(&:sample_accounts).uniq(&:id)
@@ -28,5 +28,11 @@ class GroupedNotificationsPresenter < ActiveModelSerializers::Model
 
   def partial_accounts
     @grouped_notifications.flat_map { |group| group.sample_accounts[1...] }.uniq(&:id).filter { |account| accounts.exclude?(account) }
+  end
+
+  private
+
+  def partial_avatars?
+    @options[:expand_accounts] == 'partial_avatars'
   end
 end

--- a/app/presenters/grouped_notifications_presenter.rb
+++ b/app/presenters/grouped_notifications_presenter.rb
@@ -27,7 +27,13 @@ class GroupedNotificationsPresenter < ActiveModelSerializers::Model
   end
 
   def partial_accounts
-    @grouped_notifications.flat_map { |group| group.sample_accounts[1...] }.uniq(&:id).filter { |account| accounts.exclude?(account) }
+    @partial_accounts ||= begin
+      if partial_avatars?
+        @grouped_notifications.flat_map { |group| group.sample_accounts[1...] }.uniq(&:id).filter { |account| accounts.exclude?(account) }
+      else
+        []
+      end
+    end
   end
 
   private

--- a/app/serializers/rest/dedup_notification_group_serializer.rb
+++ b/app/serializers/rest/dedup_notification_group_serializer.rb
@@ -1,7 +1,42 @@
 # frozen_string_literal: true
 
 class REST::DedupNotificationGroupSerializer < ActiveModel::Serializer
+  class PartialAccountSerializer < ActiveModel::Serializer
+    include RoutingHelper
+
+    attributes :id, :acct, :locked, :bot, :url, :avatar, :avatar_static
+
+    def id
+      object.id.to_s
+    end
+
+    def acct
+      object.pretty_acct
+    end
+
+    def note
+      object.unavailable? ? '' : account_bio_format(object)
+    end
+
+    def url
+      ActivityPub::TagManager.instance.url_for(object)
+    end
+
+    def avatar
+      full_asset_url(object.unavailable? ? object.avatar.default_url : object.avatar_original_url)
+    end
+
+    def avatar_static
+      full_asset_url(object.unavailable? ? object.avatar.default_url : object.avatar_static_url)
+    end
+  end
+
   has_many :accounts, serializer: REST::AccountSerializer
+  has_many :partial_accounts, serializer: PartialAccountSerializer, if: :stripped?
   has_many :statuses, serializer: REST::StatusSerializer
   has_many :notification_groups, serializer: REST::NotificationGroupSerializer
+
+  def stripped?
+    instance_options[:stripped]
+  end
 end

--- a/app/serializers/rest/dedup_notification_group_serializer.rb
+++ b/app/serializers/rest/dedup_notification_group_serializer.rb
@@ -32,11 +32,11 @@ class REST::DedupNotificationGroupSerializer < ActiveModel::Serializer
   end
 
   has_many :accounts, serializer: REST::AccountSerializer
-  has_many :partial_accounts, serializer: PartialAccountSerializer, if: :stripped?
+  has_many :partial_accounts, serializer: PartialAccountSerializer, if: :return_partial_accounts?
   has_many :statuses, serializer: REST::StatusSerializer
   has_many :notification_groups, serializer: REST::NotificationGroupSerializer
 
-  def stripped?
-    instance_options[:stripped]
+  def return_partial_accounts?
+    instance_options[:expand_accounts] == 'partial_avatars'
   end
 end

--- a/app/serializers/rest/dedup_notification_group_serializer.rb
+++ b/app/serializers/rest/dedup_notification_group_serializer.rb
@@ -1,34 +1,14 @@
 # frozen_string_literal: true
 
 class REST::DedupNotificationGroupSerializer < ActiveModel::Serializer
-  class PartialAccountSerializer < ActiveModel::Serializer
-    include RoutingHelper
+  class PartialAccountSerializer < REST::AccountSerializer
+    # This is a hack to reset ActiveModel::Serializer internals and only expose the attributes
+    # we care about.
+    self._attributes_data = {}
+    self._reflections = []
+    self._links = []
 
     attributes :id, :acct, :locked, :bot, :url, :avatar, :avatar_static
-
-    def id
-      object.id.to_s
-    end
-
-    def acct
-      object.pretty_acct
-    end
-
-    def note
-      object.unavailable? ? '' : account_bio_format(object)
-    end
-
-    def url
-      ActivityPub::TagManager.instance.url_for(object)
-    end
-
-    def avatar
-      full_asset_url(object.unavailable? ? object.avatar.default_url : object.avatar_original_url)
-    end
-
-    def avatar_static
-      full_asset_url(object.unavailable? ? object.avatar.default_url : object.avatar_static_url)
-    end
   end
 
   has_many :accounts, serializer: REST::AccountSerializer

--- a/spec/requests/api/v2_alpha/notifications_spec.rb
+++ b/spec/requests/api/v2_alpha/notifications_spec.rb
@@ -169,11 +169,12 @@ RSpec.describe 'Notifications' do
         FavouriteService.new.call(recent_account, user.account.statuses.first)
       end
 
-      it 'returns an account in "partial_accounts"', :aggregate_failures do
+      it 'returns an account in "partial_accounts", with the expected keys', :aggregate_failures do
         subject
 
         expect(response).to have_http_status(200)
         expect(body_as_json[:partial_accounts].size).to be > 0
+        expect(body_as_json[:partial_accounts][0].keys).to contain_exactly(:acct, :avatar, :avatar_static, :bot, :id, :locked, :url)
         expect(body_as_json[:partial_accounts].pluck(:id)).to_not include(recent_account.id.to_s)
         expect(body_as_json[:accounts].pluck(:id)).to include(recent_account.id.to_s)
       end

--- a/spec/requests/api/v2_alpha/notifications_spec.rb
+++ b/spec/requests/api/v2_alpha/notifications_spec.rb
@@ -160,6 +160,25 @@ RSpec.describe 'Notifications' do
       end
     end
 
+    context 'when requesting stripped-down accounts' do
+      let(:params) { { stripped: true } }
+
+      let(:recent_account) { Fabricate(:account) }
+
+      before do
+        FavouriteService.new.call(recent_account, user.account.statuses.first)
+      end
+
+      it 'returns an account in "partial_accounts"', :aggregate_failures do
+        subject
+
+        expect(response).to have_http_status(200)
+        expect(body_as_json[:partial_accounts].size).to be > 0
+        expect(body_as_json[:partial_accounts].pluck(:id)).to_not include(recent_account.id.to_s)
+        expect(body_as_json[:accounts].pluck(:id)).to include(recent_account.id.to_s)
+      end
+    end
+
     def body_json_types
       body_as_json[:notification_groups].pluck(:type)
     end

--- a/spec/requests/api/v2_alpha/notifications_spec.rb
+++ b/spec/requests/api/v2_alpha/notifications_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe 'Notifications' do
     end
 
     context 'when requesting stripped-down accounts' do
-      let(:params) { { stripped: true } }
+      let(:params) { { expand_accounts: 'partial_avatars' } }
 
       let(:recent_account) { Fabricate(:account) }
 
@@ -176,6 +176,16 @@ RSpec.describe 'Notifications' do
         expect(body_as_json[:partial_accounts].size).to be > 0
         expect(body_as_json[:partial_accounts].pluck(:id)).to_not include(recent_account.id.to_s)
         expect(body_as_json[:accounts].pluck(:id)).to include(recent_account.id.to_s)
+      end
+    end
+
+    context 'when passing an invalid value for "expand_accounts"' do
+      let(:params) { { expand_accounts: 'unknown_foobar' } }
+
+      it 'returns http bad request' do
+        subject
+
+        expect(response).to have_http_status(400)
       end
     end
 


### PR DESCRIPTION
This allows clients to request trimmed-down versions of accounts in the grouped notifications API to cut down on payload side and server CPU time.

To do this, it introduces a new `expand_accounts` parameters that currently has two possible values: `full` (default, output full accounts in all cases) and `partial_avatars` which moves some of the accounts to `partial_accounts` with a trimmed-down version.

The fields for trimmed-down accounts are:
- the fields required for immediate display in our current web user interface: `id`, `acct`, `avatar` and `avatar_static`
- a few other cheap fields for future-proofing the API and potentially be useful to other clients: `locked`, `bot`, `url`

### Example

```http
GET /api/v2_alpha/notifications?expand_accounts=partial_avatars
```

<details>
<summary>Response</summary>

```json
{
  "accounts": [
    {
      "id": "112909520826355962",
      "username": "renna_lockman409",
      "acct": "renna_lockman409",
      "display_name": "",
      "locked": false,
      "bot": false,
      "discoverable": true,
      "indexable": false,
      "group": false,
      "created_at": "2024-08-05T00:00:00.000Z",
      "note": "<p>hi i boost things!</p>",
      "url": "https://cb6e6126.ngrok.io/@renna_lockman409",
      "uri": "https://cb6e6126.ngrok.io/users/renna_lockman409",
      "avatar": "https://cb6e6126.ngrok.io/avatars/original/missing.png",
      "avatar_static": "https://cb6e6126.ngrok.io/avatars/original/missing.png",
      "header": "https://cb6e6126.ngrok.io/headers/original/missing.png",
      "header_static": "https://cb6e6126.ngrok.io/headers/original/missing.png",
      "followers_count": 0,
      "following_count": 0,
      "statuses_count": 1,
      "last_status_at": "2024-08-05",
      "hide_collections": null,
      "noindex": false,
      "emojis": [],
      "roles": [],
      "fields": []
    },
    {
      "id": "112909520799194838",
      "username": "sandy399",
      "acct": "sandy399",
      "display_name": "",
      "locked": false,
      "bot": false,
      "discoverable": true,
      "indexable": false,
      "group": false,
      "created_at": "2024-08-05T00:00:00.000Z",
      "note": "<p>hi i boost things!</p>",
      "url": "https://cb6e6126.ngrok.io/@sandy399",
      "uri": "https://cb6e6126.ngrok.io/users/sandy399",
      "avatar": "https://cb6e6126.ngrok.io/avatars/original/missing.png",
      "avatar_static": "https://cb6e6126.ngrok.io/avatars/original/missing.png",
      "header": "https://cb6e6126.ngrok.io/headers/original/missing.png",
      "header_static": "https://cb6e6126.ngrok.io/headers/original/missing.png",
      "followers_count": 0,
      "following_count": 0,
      "statuses_count": 1,
      "last_status_at": "2024-08-05",
      "hide_collections": null,
      "noindex": false,
      "emojis": [],
      "roles": [],
      "fields": []
    },
    {
      "id": "112909520772114535",
      "username": "mickey389",
      "acct": "mickey389",
      "display_name": "",
      "locked": false,
      "bot": false,
      "discoverable": true,
      "indexable": false,
      "group": false,
      "created_at": "2024-08-05T00:00:00.000Z",
      "note": "<p>hi i boost things!</p>",
      "url": "https://cb6e6126.ngrok.io/@mickey389",
      "uri": "https://cb6e6126.ngrok.io/users/mickey389",
      "avatar": "https://cb6e6126.ngrok.io/avatars/original/missing.png",
      "avatar_static": "https://cb6e6126.ngrok.io/avatars/original/missing.png",
      "header": "https://cb6e6126.ngrok.io/headers/original/missing.png",
      "header_static": "https://cb6e6126.ngrok.io/headers/original/missing.png",
      "followers_count": 0,
      "following_count": 0,
      "statuses_count": 1,
      "last_status_at": "2024-08-05",
      "hide_collections": null,
      "noindex": false,
      "emojis": [],
      "roles": [],
      "fields": []
    }
  ],
  "partial_accounts": [
    {
      "id": 112909520825810295,
      "acct": "tonisha408",
      "locked": false,
      "bot": false,
      "url": "https://cb6e6126.ngrok.io/@tonisha408",
      "avatar": "https://cb6e6126.ngrok.io/avatars/original/missing.png",
      "avatar_static": "https://cb6e6126.ngrok.io/avatars/original/missing.png"
    },
    {
      "id": 112909520825346274,
      "acct": "frank407",
      "locked": false,
      "bot": false,
      "url": "https://cb6e6126.ngrok.io/@frank407",
      "avatar": "https://cb6e6126.ngrok.io/avatars/original/missing.png",
      "avatar_static": "https://cb6e6126.ngrok.io/avatars/original/missing.png"
    },
    …
  ],
  "statuses": [
    {
      "id": "112909520820351365",
      "created_at": "2024-08-05T12:56:01.345Z",
      "in_reply_to_id": null,
      "in_reply_to_account_id": null,
      "sensitive": false,
      "spoiler_text": "",
      "visibility": "public",
      "language": "en",
      "uri": "https://cb6e6126.ngrok.io/users/alice/statuses/112909520820351365",
      "url": "https://cb6e6126.ngrok.io/@alice/112909520820351365",
      "replies_count": 0,
      "reblogs_count": 10,
      "favourites_count": 0,
      "edited_at": null,
      "favourited": false,
      "reblogged": false,
      "muted": false,
      "bookmarked": false,
      "pinned": false,
      "content": "<p>Hello world!</p>",
      "filtered": [],
      "reblog": null,
      "application": null,
      "account": {
        "id": "112909519581744667",
        "username": "alice",
        "acct": "alice",
        "display_name": "",
        "locked": false,
        "bot": false,
        "discoverable": true,
        "indexable": false,
        "group": false,
        "created_at": "2024-08-05T00:00:00.000Z",
        "note": "<p>hello i&#39;m a test user with <a href=\"https://cb6e6126.ngrok.io/tags/hashtags\" class=\"mention hashtag\" rel=\"tag\">#<span>hashtags</span></a></p>",
        "url": "https://cb6e6126.ngrok.io/@alice",
        "uri": "https://cb6e6126.ngrok.io/users/alice",
        "avatar": "https://cb6e6126.ngrok.io/avatars/original/missing.png",
        "avatar_static": "https://cb6e6126.ngrok.io/avatars/original/missing.png",
        "header": "https://cb6e6126.ngrok.io/headers/original/missing.png",
        "header_static": "https://cb6e6126.ngrok.io/headers/original/missing.png",
        "followers_count": 0,
        "following_count": 0,
        "statuses_count": 41,
        "last_status_at": "2024-08-05",
        "hide_collections": null,
        "noindex": false,
        "emojis": [],
        "roles": [],
        "fields": []
      },
      "media_attachments": [],
      "mentions": [],
      "tags": [],
      "emojis": [],
      "card": null,
      "poll": null
    },
    …
  ],
  "notification_groups": [
    {
      "group_key": "reblog-112909520820351365-478572",
      "notifications_count": 10,
      "type": "reblog",
      "most_recent_notification_id": 401,
      "page_min_id": "392",
      "page_max_id": "401",
      "latest_page_notification_at": "2024-08-05T12:56:01.758Z",
      "sample_account_ids": [
        "112909520826355962",
        "112909520825810295",
        "112909520825346274",
        "112909520824837350",
        "112909520824425144",
        "112909520823924966",
        "112909520823464479",
        "112909520822940951"
      ],
      "status_id": "112909520820351365"
    },
    {
      "group_key": "reblog-112909520793485892-478572",
      "notifications_count": 10,
      "type": "reblog",
      "most_recent_notification_id": 391,
      "page_min_id": "382",
      "page_max_id": "391",
      "latest_page_notification_at": "2024-08-05T12:56:01.342Z",
      "sample_account_ids": [
        "112909520799194838",
        "112909520798717928",
        "112909520798230763",
        "112909520797793509",
        "112909520797362864",
        "112909520796860342",
        "112909520796411691",
        "112909520795973102"
      ],
      "status_id": "112909520793485892"
    },
    {
      "group_key": "reblog-112909520766941880-478572",
      "notifications_count": 10,
      "type": "reblog",
      "most_recent_notification_id": 381,
      "page_min_id": "381",
      "page_max_id": "381",
      "latest_page_notification_at": "2024-08-05T12:56:00.932Z",
      "sample_account_ids": [
        "112909520772114535",
        "112909520771628751",
        "112909520771222009",
        "112909520770788459",
        "112909520770387469",
        "112909520769908851",
        "112909520769545628",
        "112909520769116350"
      ],
      "status_id": "112909520766941880"
    }
  ]
}
```
</details>

## Benchmark

I did a small benchmark of a manufactured scenario of 20×(1 reblog + 1 like) notification from the same set of 10 (fairly simple, with no account fields and a short bio) accounts.

`expand_accounts=full` takes around 385ms and returns a 334kb payload (before compression)

`expand_accounts=partial_avatars` takes around 203ms and returns a 186kb payload (before compression)