### PR TITLE
Delete pending notification requests on block and notification mutes

### DIFF
--- a/app/services/after_block_service.rb
+++ b/app/services/after_block_service.rb
@@ -7,6 +7,7 @@ class AfterBlockService < BaseService
 
     clear_home_feed!
     clear_list_feeds!
+    clear_notification_requests!
     clear_notifications!
     clear_conversations!
   end
@@ -27,5 +28,9 @@ class AfterBlockService < BaseService
 
   def clear_notifications!
     Notification.where(account: @account).where(from_account: @target_account).in_batches.delete_all
+  end
+
+  def clear_notification_requests!
+    NotificationRequest.where(account: @account, from_account: @target_account).destroy_all
   end
 end


### PR DESCRIPTION
Notifications themselves were being deleted (skipping callbacks for performance reasons) but not notification requests.