### PR TITLE
Change notification requests to only count mentions

### DIFF
--- a/app/models/notification_request.rb
+++ b/app/models/notification_request.rb
@@ -47,6 +47,6 @@ class NotificationRequest < ApplicationRecord
   private
 
   def prepare_notifications_count
-    self.notifications_count = Notification.where(account: account, from_account: from_account, filtered: true).limit(MAX_MEANINGFUL_COUNT).count
+    self.notifications_count = Notification.where(account: account, from_account: from_account, type: :mention, filtered: true).limit(MAX_MEANINGFUL_COUNT).count
   end
 end

--- a/spec/models/notification_policy_spec.rb
+++ b/spec/models/notification_policy_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe NotificationPolicy do
     let(:sender) { Fabricate(:account) }
 
     before do
-      Fabricate.times(2, :notification, account: subject.account, activity: Fabricate(:status, account: sender), filtered: true)
+      Fabricate.times(2, :notification, account: subject.account, activity: Fabricate(:status, account: sender), filtered: true, type: :mention)
       Fabricate(:notification_request, account: subject.account, from_account: sender)
       subject.summarize!
     end

--- a/spec/models/notification_request_spec.rb
+++ b/spec/models/notification_request_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe NotificationRequest do
 
     context 'when there are remaining notifications' do
       before do
-        Fabricate(:notification, account: subject.account, activity: Fabricate(:status, account: subject.from_account), filtered: true)
+        Fabricate(:notification, account: subject.account, activity: Fabricate(:status, account: subject.from_account), filtered: true, type: :mention)
         subject.reconsider_existence!
       end
 


### PR DESCRIPTION
While other types of notifications are actually filtered too, they only appear if there is at least one filtered mention, and the whole UI is centered around mentions.

Therefore, it may make sense to only count mentions.