### PR TITLE
Add hover card to filtered notifications

### DIFF
--- a/app/javascript/mastodon/features/notifications/components/notification_request.jsx
+++ b/app/javascript/mastodon/features/notifications/components/notification_request.jsx
@@ -37,7 +37,7 @@ export const NotificationRequest = ({ id, accountId, notificationsCount }) => {
 
   return (
     <div className='notification-request'>
-      <Link to={`/notifications/requests/${id}`} className='notification-request__link'>
+      <Link to={`/notifications/requests/${id}`} className='notification-request__link' data-hover-card-account={account?.get('id')}>
         <Avatar account={account} size={40} counter={toCappedNumber(notificationsCount)} />
 
         <div className='notification-request__name'>


### PR DESCRIPTION
On the one hand, this allows quick inspection of the account without having to see the notifications themselves.

On the other hand, the account's bio can itself be pretty offensive.

Another worry is that having a hover card may make it even more difficult for people to discover clicking the name will bring up the filtered notifications for inspection.