### PR TITLE
Add unchangeable filtered notification setting for limited accounts

### DIFF
--- a/app/javascript/mastodon/features/notifications/components/policy_controls.tsx
+++ b/app/javascript/mastodon/features/notifications/components/policy_controls.tsx
@@ -7,6 +7,9 @@ import { useAppSelector, useAppDispatch } from 'mastodon/store';
 
 import { CheckboxWithLabel } from './checkbox_with_label';
 
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
+
 export const PolicyControls: React.FC = () => {
   const dispatch = useAppDispatch();
 
@@ -132,6 +135,21 @@ export const PolicyControls: React.FC = () => {
             <FormattedMessage
               id='notifications.policy.filter_private_mentions_hint'
               defaultMessage="Filtered unless it's in reply to your own mention or if you follow the sender"
+            />
+          </span>
+        </CheckboxWithLabel>
+
+        <CheckboxWithLabel checked disabled onChange={noop}>
+          <strong>
+            <FormattedMessage
+              id='notifications.policy.filter_limited_accounts_title'
+              defaultMessage='Moderated accounts'
+            />
+          </strong>
+          <span className='hint'>
+            <FormattedMessage
+              id='notifications.policy.filter_limited_accounts_hint'
+              defaultMessage='Limited by server moderators'
             />
           </span>
         </CheckboxWithLabel>

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -545,6 +545,8 @@
   "notifications.permission_denied": "Desktop notifications are unavailable due to previously denied browser permissions request",
   "notifications.permission_denied_alert": "Desktop notifications can't be enabled, as browser permission has been denied before",
   "notifications.permission_required": "Desktop notifications are unavailable because the required permission has not been granted.",
+  "notifications.policy.filter_limited_accounts_hint": "Limited by server moderators",
+  "notifications.policy.filter_limited_accounts_title": "Moderated accounts",
   "notifications.policy.filter_new_accounts.hint": "Created within the past {days, plural, one {one day} other {# days}}",
   "notifications.policy.filter_new_accounts_title": "New accounts",
   "notifications.policy.filter_not_followers_hint": "Including people who have been following you fewer than {days, plural, one {one day} other {# days}}",


### PR DESCRIPTION
In #30559, we changed notifications from limited accounts to end up in filtered notifications, but this was not made clear in the UI.

This PR introduces an unchangeable filtered notifications “setting” to mention this case.

![image](https://github.com/user-attachments/assets/9b7ba3f0-830b-4a45-be8b-4518eee7ec8f)

It would also make sense to change this to an actual setting in the future, especially if we end up adding an option to drop notifications outright for a category.