### PR TITLE
Change dismissing a notification to clear existing filtered notifications for that account

### DIFF
--- a/app/controllers/api/v1/notifications/requests_controller.rb
+++ b/app/controllers/api/v1/notifications/requests_controller.rb
@@ -29,7 +29,7 @@ class Api::V1::Notifications::RequestsController < Api::BaseController
   end
 
   def dismiss
-    @request.destroy!
+    DismissNotificationRequestService.new.call(@request)
     render_empty
   end
 

--- a/app/services/dismiss_notification_request_service.rb
+++ b/app/services/dismiss_notification_request_service.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class DismissNotificationRequestService < BaseService
+  def call(request)
+    FilteredNotificationCleanupWorker.perform_async(request.account_id, request.from_account_id)
+    request.destroy!
+  end
+end

--- a/app/workers/filtered_notification_cleanup_worker.rb
+++ b/app/workers/filtered_notification_cleanup_worker.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class FilteredNotificationCleanupWorker
+  include Sidekiq::Worker
+
+  def perform(account_id, from_account_id)
+    Notification.where(account_id: account_id, from_account_id: from_account_id, filtered: true).reorder(nil).in_batches(order: :desc).delete_all
+  end
+end

--- a/spec/services/dismiss_notification_request_service_spec.rb
+++ b/spec/services/dismiss_notification_request_service_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DismissNotificationRequestService do
+  describe '#call' do
+    let(:sender) { Fabricate(:account) }
+    let(:receiver) { Fabricate(:account) }
+    let(:request) { Fabricate(:notification_request, account: receiver, from_account: sender) }
+
+    it 'destroys the request and queues a worker', :aggregate_failures do
+      expect { described_class.new.call(request) }
+        .to change(request, :destroyed?).to(true)
+
+      expect(FilteredNotificationCleanupWorker)
+        .to have_enqueued_sidekiq_job(receiver.id, sender.id)
+    end
+  end
+end

--- a/spec/workers/filtered_notification_cleanup_worker_spec.rb
+++ b/spec/workers/filtered_notification_cleanup_worker_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe FilteredNotificationCleanupWorker do
+  describe '#perform' do
+    let(:sender) { Fabricate(:account) }
+    let(:recipient) { Fabricate(:account) }
+    let(:bystander) { Fabricate(:account) }
+
+    before do
+      Fabricate(:notification, account: recipient, activity: Fabricate(:favourite, account: sender), filtered: true)
+      Fabricate(:notification, account: recipient, activity: Fabricate(:favourite, account: bystander), filtered: true)
+      Fabricate(:notification, account: recipient, activity: Fabricate(:follow, account: sender), filtered: true)
+      Fabricate(:notification, account: recipient, activity: Fabricate(:favourite, account: bystander), filtered: true)
+    end
+
+    it 'deletes all filtered notifications to the account' do
+      expect { described_class.new.perform(recipient.id, sender.id) }
+        .to change { recipient.notifications.where(from_account: sender).count }.from(2).to(0)
+        .and(not_change { recipient.notifications.where(from_account: bystander).count })
+    end
+  end
+end


### PR DESCRIPTION
Up until now, dismissing a notification request would just dismiss the request itself.

This means that all the filtered notifications would come back and accumulate on the next notification request from the same account, meaning this would either look like:
- dismissing did nothing, or
- the account has interacted more than it actually did

This PR changes it so that dismissing a request deletes the notifications. The downside is that it is easier accidentally lose them forever.