### PR TITLE
Add explainer for filtered notifications from limited accounts

### DIFF
--- a/app/javascript/mastodon/features/notifications/request.jsx
+++ b/app/javascript/mastodon/features/notifications/request.jsx
@@ -93,10 +93,15 @@ export const NotificationRequest = ({ multiColumn, params: { id } }) => {
   let explainer = null;
 
   if (account?.limited) {
+    const isLocal = account.acct.indexOf('@') === -1;
     explainer = (
       <div className='dismissable-banner'>
         <div className='dismissable-banner__message'>
-          <FormattedMessage id='notification_requests.explainer_for_limited_account' defaultMessage='Notifications from this account have been filtered because the account has been limited by a moderator.' />
+          {isLocal ? (
+            <FormattedMessage id='notification_requests.explainer_for_limited_account' defaultMessage='Notifications from this account have been filtered because the account has been limited by a moderator.' />
+          ) : (
+            <FormattedMessage id='notification_requests.explainer_for_limited_remote_account' defaultMessage='Notifications from this account have been filtered because the account or its server has been limited by a moderator.' />
+          )}
         </div>
       </div>
     );

--- a/app/javascript/mastodon/features/notifications/request.jsx
+++ b/app/javascript/mastodon/features/notifications/request.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import { useRef, useCallback, useEffect } from 'react';
 
-import { defineMessages, useIntl } from 'react-intl';
+import { defineMessages, useIntl, FormattedMessage } from 'react-intl';
 
 import { Helmet } from 'react-helmet';
 
@@ -90,6 +90,18 @@ export const NotificationRequest = ({ multiColumn, params: { id } }) => {
 
   const columnTitle = intl.formatMessage(messages.title, { name: account?.get('display_name') || account?.get('username') });
 
+  let explainer = null;
+
+  if (account?.limited) {
+    explainer = (
+      <div className='dismissable-banner'>
+        <div className='dismissable-banner__message'>
+          <FormattedMessage id='notification_requests.explainer_for_limited_account' defaultMessage='Notifications from this account have been filtered because the account has been limited by a moderator.' />
+        </div>
+      </div>
+    );
+  }
+
   return (
     <Column bindToDocument={!multiColumn} ref={columnRef} label={columnTitle}>
       <ColumnHeader
@@ -109,6 +121,7 @@ export const NotificationRequest = ({ multiColumn, params: { id } }) => {
 
       <SensitiveMediaContextProvider hideMediaByDefault>
         <ScrollableList
+          prepend={explainer}
           scrollKey={`notification_requests/${id}`}
           trackScroll={!multiColumn}
           bindToDocument={!multiColumn}

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -506,6 +506,7 @@
   "notification_requests.accept": "Accept",
   "notification_requests.dismiss": "Dismiss",
   "notification_requests.explainer_for_limited_account": "Notifications from this account have been filtered because the account has been limited by a moderator.",
+  "notification_requests.explainer_for_limited_remote_account": "Notifications from this account have been filtered because the account or its server has been limited by a moderator.",
   "notification_requests.maximize": "Maximize",
   "notification_requests.minimize_banner": "Minimize filtered notifications banner",
   "notification_requests.notifications_from": "Notifications from {name}",

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -505,6 +505,7 @@
   "notification.update": "{name} edited a post",
   "notification_requests.accept": "Accept",
   "notification_requests.dismiss": "Dismiss",
+  "notification_requests.explainer_for_limited_account": "Notifications from this account have been filtered because the account has been limited by a moderator.",
   "notification_requests.maximize": "Maximize",
   "notification_requests.minimize_banner": "Minimize filtered notifications banner",
   "notification_requests.notifications_from": "Notifications from {name}",


### PR DESCRIPTION
This is a first easy step until we change more deeply how to surface the reason why a notification request has been created.

![image](https://github.com/user-attachments/assets/2ea28687-e9de-4871-9df1-e8a7618aa0b5)