### PR TITLE
Fix list creation textbox styling

### DIFF
--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -551,3 +551,7 @@ a.sparkline {
     background: darken($ui-base-color, 10%);
   }
 }
+
+.setting-text {
+  background: darken($ui-base-color, 10%);
+}

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -3881,18 +3881,17 @@ $ui-header-logo-wordmark-width: 99px;
   display: block;
   box-sizing: border-box;
   margin: 0;
-  color: $inverted-text-color;
-  background: $white;
+  color: $primary-text-color;
+  background: $ui-base-color;
   padding: 7px 10px;
   font-family: inherit;
   font-size: 14px;
   line-height: 22px;
   border-radius: 4px;
-  border: 1px solid $white;
+  border: 1px solid var(--background-border-color);
 
   &:focus {
     outline: 0;
-    border-color: lighten($ui-highlight-color, 12%);
   }
 
   &__wrapper {


### PR DESCRIPTION
Matches textbox styling of Lists creation to other text entry areas.

**Before**
<img width="611" alt="Screenshot 2024-08-08 at 1 31 57 PM" src="https://github.com/user-attachments/assets/2defc967-42d1-4016-b19f-987a7d1e6cbf">
<img width="611" alt="Screenshot 2024-08-08 at 1 32 14 PM" src="https://github.com/user-attachments/assets/e1ffac30-2f05-4914-b85b-c5f8bd326692">

**After**
<img width="615" alt="Screenshot 2024-08-08 at 1 24 02 PM" src="https://github.com/user-attachments/assets/204546e3-71ca-4bfa-b0b1-5f65661414f8">
<img width="620" alt="Screenshot 2024-08-08 at 1 23 44 PM" src="https://github.com/user-attachments/assets/bbe9086f-0c93-43f5-a399-14316b5edf92">