### PR TITLE
Add `api_versions` to `/api/v2/instance`

### DIFF
--- a/app/serializers/rest/instance_serializer.rb
+++ b/app/serializers/rest/instance_serializer.rb
@@ -11,7 +11,7 @@ class REST::InstanceSerializer < ActiveModel::Serializer
 
   attributes :domain, :title, :version, :source_url, :description,
              :usage, :thumbnail, :languages, :configuration,
-             :registrations
+             :registrations, :api_versions
 
   has_one :contact, serializer: ContactSerializer
   has_many :rules, serializer: REST::RuleSerializer
@@ -91,6 +91,12 @@ class REST::InstanceSerializer < ActiveModel::Serializer
       approval_required: Setting.registrations_mode == 'approved',
       message: registrations_enabled? ? nil : registrations_message,
       url: ENV.fetch('SSO_ACCOUNT_SIGN_UP', nil),
+    }
+  end
+
+  def api_versions
+    {
+      mastodon: 1,
     }
   end
 

--- a/spec/requests/api/v2/instance_spec.rb
+++ b/spec/requests/api/v2/instance_spec.rb
@@ -18,6 +18,7 @@ describe 'Instances' do
         expect(body_as_json)
           .to be_present
           .and include(title: 'Mastodon')
+          .and include_api_versions
           .and include_configuration_limits
       end
     end
@@ -32,6 +33,7 @@ describe 'Instances' do
         expect(body_as_json)
           .to be_present
           .and include(title: 'Mastodon')
+          .and include_api_versions
           .and include_configuration_limits
       end
     end
@@ -50,6 +52,14 @@ describe 'Instances' do
           polls: include(
             max_options: PollValidator::MAX_OPTIONS
           )
+        )
+      )
+    end
+
+    def include_api_versions
+      include(
+        api_versions: include(
+          mastodon: anything
         )
       )
     end


### PR DESCRIPTION
This introduces a version number that clients can query to know which APIs are supported.

This is a Mastodon-centric alternative to [FEP-9fde](https://socialhub.activitypub.rocks/t/fep-9fde-mechanism-for-servers-to-expose-supported-operations/3999) which is much more lightweight in payload size and implementation, and still supports third-party extensions to the Mastodon API, at the cost of granularity and availability to accurately represent a subset of the Mastodon API.

```json
{
  …,
  "api_versions": {
    "mastodon": 1,
  },
}
```

Once this is added, we will bump the version every time we introduce a new API that cannot be easily discovered (e.g. a new API endpoint, or a new `POST` parameter to an existing one) and document it in the API documentations, so that applications can check that single value to know if they can make use of a feature.

Forks can indicate their own API version in addition to our own:
```json
{
  …,
  "api_versions": {
    "mastodon": 1,
    "org.mymastodonfork": 2,
  },
}
```