### PR TITLE
Improve legibility of account/hashtag autosuggest

### DIFF
--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -559,3 +559,9 @@ a.sparkline {
 .report-dialog-modal__textarea {
   background: darken($ui-base-color, 10%);
 }
+
+.autosuggest-account {
+  .display-name__account {
+    color: $dark-text-color;
+  }
+}

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -472,7 +472,7 @@ body > [data-popper-placement] {
     display: block;
     line-height: 16px;
     font-size: 12px;
-    color: $dark-text-color;
+    color: $ui-primary-color;
   }
 }
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -426,10 +426,17 @@ body > [data-popper-placement] {
 
       &:hover,
       &:focus,
-      &:active,
+      &:active {
+        background: var(--dropdown-border-color);
+
+        .autosuggest-account .display-name__account {
+          color: inherit;
+        }
+      }
+
       &.selected {
         background: $ui-highlight-color;
-        color: $primary-text-color;
+        color: $ui-button-color;
 
         .autosuggest-account .display-name__account {
           color: inherit;


### PR DESCRIPTION
Adopts color schemes used in new privacy drop-down for hashtag and account autocomplete in the post composer.

**Before**
<img width="295" alt="image" src="https://github.com/user-attachments/assets/bd04a4d8-5799-4df4-aae8-8196ae4c0c79">
<img width="297" alt="image" src="https://github.com/user-attachments/assets/5094619f-4428-4eea-a60e-9d8bc4887f7a">
<img width="303" alt="image" src="https://github.com/user-attachments/assets/4612f343-1c41-4dd9-8f76-2371896629c9">

**After**
![CleanShot 2024-08-09 at 13 44 11](https://github.com/user-attachments/assets/1bfee8ee-3583-4b0a-a9ab-0a2f692a07a6)
![CleanShot 2024-08-09 at 13 47 46@2x](https://github.com/user-attachments/assets/c4bde95d-5f5d-4f38-9c5a-cc78b7bd75b4)
<img width="309" alt="Screenshot 2024-08-09 at 2 03 15 PM" src="https://github.com/user-attachments/assets/32493e2c-9069-491c-a517-6d68989f410c">
