### PR TITLE
Use material symbol for filters/statuses views

### DIFF
--- a/app/views/disputes/strikes/_card.html.haml
+++ b/app/views/disputes/strikes/_card.html.haml
@@ -24,7 +24,7 @@
               .emojify= one_line_preview(status)
               - status.ordered_media_attachments.each do |media_attachment|
                 %abbr{ title: media_attachment.description }
-                  = fa_icon 'link'
+                  = material_symbol 'link'
                   = media_attachment.file_file_name
             .strike-card__statuses-list__item__meta
               = link_to ActivityPub::TagManager.instance.url_for(status), target: '_blank', rel: 'noopener noreferrer' do

--- a/app/views/filters/statuses/_status_filter.html.haml
+++ b/app/views/filters/statuses/_status_filter.html.haml
@@ -15,7 +15,7 @@
 
     - status.ordered_media_attachments.each do |media_attachment|
       %abbr{ title: media_attachment.description }
-        = fa_icon 'link'
+        = material_symbol 'link'
         = media_attachment.file_file_name
 
     .detailed-status__meta
@@ -33,5 +33,5 @@
       = t("statuses.visibilities.#{status.visibility}")
       - if status.sensitive?
         ·
-        = fa_icon('eye-slash fw')
+        = material_symbol 'visibility_off'
         = t('stream_entries.sensitive_content')

--- a/app/views/filters/statuses/index.html.haml
+++ b/app/views/filters/statuses/index.html.haml
@@ -6,7 +6,7 @@
 .filters
   .back-link
     = link_to edit_filter_path(@filter) do
-      = fa_icon 'chevron-left fw'
+      = material_symbol 'chevron_left'
       = t('filters.statuses.back_to_filter')
 
 %p.hint= t('filters.statuses.index.hint')
@@ -25,7 +25,7 @@
         = check_box_tag :batch_checkbox_all, nil, false
       .batch-table__toolbar__actions
         - unless @status_filters.empty?
-          = f.button safe_join([fa_icon('times'), t('filters.statuses.batch.remove')]), name: :remove, class: 'table-action-link', type: :submit
+          = f.button safe_join([material_symbol('close'), t('filters.statuses.batch.remove')]), name: :remove, class: 'table-action-link', type: :submit
     .batch-table__body
       - if @status_filters.empty?
         = nothing_here 'nothing-here--under-tabs'

--- a/app/views/statuses/_attachment_list.html.haml
+++ b/app/views/statuses/_attachment_list.html.haml
@@ -1,6 +1,6 @@
 .attachment-list
   .attachment-list__icon
-    = fa_icon 'link'
+    = material_symbol 'link'
   %ul.attachment-list__list
     - attachments.each do |media|
       %li


### PR DESCRIPTION
I believe that after https://github.com/mastodon/mastodon/pull/31359 and https://github.com/mastodon/mastodon/pull/31360 these are the last remaining usages of the helper.

After these are all merged there will be a cleanup PR to remove the helper method, its specs, the js package, and whatever fa-specific styles we still may have.