### PR TITLE
Fix account header avatar border

### DIFF
--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -52,10 +52,6 @@ html {
   color: darken($action-button-color, 25%);
 }
 
-.account__header__bar .avatar .account__avatar {
-  border-color: $white;
-}
-
 .getting-started__footer a {
   color: $ui-secondary-color;
   text-decoration: underline;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -7970,7 +7970,8 @@ noscript {
 
       .account__avatar {
         background: var(--background-color);
-        border: 2px solid var(--background-border-color);
+        border: 1px solid var(--background-border-color);
+        border-radius: 4px;
       }
     }
   }


### PR DESCRIPTION
The current account profile view has a 2px square border instead of 1px rounded border to match the rounded image. Also on white mode the border is fully white instead of the color of the other borders.

**Before**
![CleanShot 2024-08-10 at 11 56 11@2x](https://github.com/user-attachments/assets/8b3989c4-90d3-4184-9d93-f7b03fb81a8b)
<img width="162" alt="Screenshot 2024-08-10 at 11 56 34 AM" src="https://github.com/user-attachments/assets/2cf2c7b0-338e-4e0c-afb2-844b7b49d959">

**After**
![CleanShot 2024-08-10 at 12 06 05@2x](https://github.com/user-attachments/assets/f511659d-7d72-4283-9a82-884ea78e3cb4)
<img width="325" alt="Screenshot 2024-08-10 at 12 06 30 PM" src="https://github.com/user-attachments/assets/dd28cf4d-e97c-4b3a-8bec-33c3994ef8e0">
