### PR TITLE
Add support for incoming <s> tag

### DIFF
--- a/lib/sanitize_ext/sanitize_config.rb
+++ b/lib/sanitize_ext/sanitize_config.rb
@@ -65,7 +65,7 @@ class Sanitize
     end
 
     MASTODON_STRICT = freeze_config(
-      elements: %w(p br span a del pre blockquote code b strong u i em ul ol li ruby rt rp),
+      elements: %w(p br span a del s pre blockquote code b strong u i em ul ol li ruby rt rp),
 
       attributes: {
         'a' => %w(href rel class translate),


### PR DESCRIPTION
Add native support for the incoming tag: `s`

From [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s):
> The `<s>` element renders text with a strikethrough, or a line through it. Use the `<s>` element to represent things that are no longer relevant or no longer accurate. However, `<s>` is not appropriate when indicating document edits; for that, use the `<del>` and `<ins>` elements, as appropriate.

Solves: https://github.com/mastodon/mastodon/issues/31374
