### PR TITLE
Fix extra slash on notification policy request

### DIFF
--- a/app/javascript/mastodon/api/notification_policies.ts
+++ b/app/javascript/mastodon/api/notification_policies.ts
@@ -2,8 +2,8 @@ import { apiRequestGet, apiRequestPut } from 'mastodon/api';
 import type { NotificationPolicyJSON } from 'mastodon/api_types/notification_policies';
 
 export const apiGetNotificationPolicy = () =>
-  apiRequestGet<NotificationPolicyJSON>('/v2/notifications/policy');
+  apiRequestGet<NotificationPolicyJSON>('v2/notifications/policy');
 
 export const apiUpdateNotificationsPolicy = (
   policy: Partial<NotificationPolicyJSON>,
-) => apiRequestPut<NotificationPolicyJSON>('/v2/notifications/policy', policy);
+) => apiRequestPut<NotificationPolicyJSON>('v2/notifications/policy', policy);


### PR DESCRIPTION
Unlike the other calls to the `apiRequest*` functions, the calls for the notification policy endpoints have a leading slash in the path, resulting in a URL like `https://instance/api//v2/notifications/policy`. This fixes the issue.