### PR TITLE
Fix all streamed notification types being stored without filtering

### DIFF
--- a/app/javascript/mastodon/actions/streaming.js
+++ b/app/javascript/mastodon/actions/streaming.js
@@ -104,7 +104,7 @@ export const connectTimelineStream = (timelineId, channelName, params = {}, opti
           const notificationJSON = JSON.parse(data.payload);
           dispatch(updateNotifications(notificationJSON, messages, locale));
           // TODO: remove this once the groups feature replaces the previous one
-          if(getState().notificationGroups.groups.length > 0) {
+          if(getState().settings.getIn(['notifications', 'groupingBeta'], false)) {
             dispatch(processNewNotificationForGroups(notificationJSON));
           }
           break;

--- a/app/javascript/mastodon/api_types/statuses.ts
+++ b/app/javascript/mastodon/api_types/statuses.ts
@@ -58,6 +58,29 @@ export interface ApiPreviewCardJSON {
   authors: ApiPreviewCardAuthorJSON[];
 }
 
+export type FilterContext =
+  | 'home'
+  | 'notifications'
+  | 'public'
+  | 'thread'
+  | 'account';
+
+export interface ApiFilterJSON {
+  id: string;
+  title: string;
+  context: FilterContext;
+  expires_at: string;
+  filter_action: 'warn' | 'hide';
+  keywords?: unknown[]; // TODO: FilterKeywordSerializer
+  statuses?: unknown[]; // TODO: FilterStatusSerializer
+}
+
+export interface ApiFilterResultJSON {
+  filter: ApiFilterJSON;
+  keyword_matches: string[];
+  status_matches: string[];
+}
+
 export interface ApiStatusJSON {
   id: string;
   created_at: string;
@@ -80,8 +103,7 @@ export interface ApiStatusJSON {
   bookmarked?: boolean;
   pinned?: boolean;
 
-  // filtered: FilterResult[]
-  filtered: unknown; // TODO
+  filtered?: ApiFilterResultJSON[];
   content?: string;
   text?: string;
 

--- a/app/javascript/mastodon/reducers/notification_groups.ts
+++ b/app/javascript/mastodon/reducers/notification_groups.ts
@@ -387,12 +387,14 @@ export const notificationGroupsReducer = createReducer<NotificationGroupsState>(
       })
       .addCase(processNewNotificationForGroups.fulfilled, (state, action) => {
         const notification = action.payload;
-        processNewNotification(
-          usePendingItems ? state.pendingGroups : state.groups,
-          notification,
-        );
-        updateLastReadId(state);
-        trimNotifications(state);
+        if (notification) {
+          processNewNotification(
+            usePendingItems ? state.pendingGroups : state.groups,
+            notification,
+          );
+          updateLastReadId(state);
+          trimNotifications(state);
+        }
       })
       .addCase(disconnectTimeline, (state, action) => {
         if (action.payload.timeline === 'home') {


### PR DESCRIPTION
This fixes notifications being stored in redux regardless of their filtering status, which can cause unneeded work and cause notification pruning to filter all visible notifications.

Also fixes incorrect test in streaming event handler that could have resulted in new accounts not receiving grouped notifications.