### PR TITLE
Add a border above the timeline hint for statuses with replies

### DIFF
--- a/app/javascript/mastodon/components/timeline_hint.tsx
+++ b/app/javascript/mastodon/components/timeline_hint.tsx
@@ -1,12 +1,15 @@
 import { FormattedMessage } from 'react-intl';
 
+import classNames from 'classnames';
+
 interface Props {
   resource: JSX.Element;
   url: string;
+  className?: string;
 }
 
-export const TimelineHint: React.FC<Props> = ({ resource, url }) => (
-  <div className='timeline-hint'>
+export const TimelineHint: React.FC<Props> = ({ className, resource, url }) => (
+  <div className={classNames('timeline-hint', className)}>
     <strong>
       <FormattedMessage
         id='timeline_hint.remote_resource_not_displayed'

--- a/app/javascript/mastodon/features/status/index.jsx
+++ b/app/javascript/mastodon/features/status/index.jsx
@@ -629,7 +629,7 @@ class Status extends ImmutablePureComponent {
     const isIndexable = !status.getIn(['account', 'noindex']);
 
     if (!isLocal) {
-      remoteHint = <TimelineHint url={status.get('url')} resource={<FormattedMessage id='timeline_hint.resources.replies' defaultMessage='Some replies' />} />;
+      remoteHint = <TimelineHint className={classNames(!!descendants && 'timeline-hint--with-descendants')} url={status.get('url')} resource={<FormattedMessage id='timeline_hint.resources.replies' defaultMessage='Some replies' />} />;
     }
 
     const handlers = {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -4248,6 +4248,10 @@ a.status-card {
   }
 }
 
+.timeline-hint--with-descendants {
+  border-top: 1px solid var(--background-border-color);
+}
+
 .regeneration-indicator {
   text-align: center;
   font-size: 16px;


### PR DESCRIPTION
I tried to do it in pure CSS, but this does not work as the sibling divs do not have a class (they are `<HotKeys>` wrappers).

The border is only added when needed. I checked the other places the hint is displayed, and there is already a border here (due to the previous component having it).

When there are descendants, a top border is added:
<img width="346" alt="image" src="https://github.com/user-attachments/assets/622cf042-7fa2-4380-908b-145145164959">

But not when there are no descendants, as the top border is already there due to the buttons bar

<img width="334" alt="image" src="https://github.com/user-attachments/assets/f88d1a90-a6b3-4f6e-a2ea-c6b8708f1875">

Fixes #31385