### PR TITLE
Fix collapsable column borders in Safari and improve Safari scrollbars

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -4503,6 +4503,9 @@ a.status-card {
   opacity: 1;
   z-index: 1;
   position: relative;
+  border-left: 1px solid var(--background-border-color);
+  border-right: 1px solid var(--background-border-color);
+  border-bottom: 0;
 
   &.collapsed {
     max-height: 0;
@@ -4523,7 +4526,7 @@ a.status-card {
 }
 
 .column-header__collapsible-inner {
-  border: 1px solid var(--background-border-color);
+  border-bottom: 1px solid var(--background-border-color);
   border-top: 0;
 
   @media screen and (max-width: $no-gap-breakpoint) {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -4507,6 +4507,11 @@ a.status-card {
   border-right: 1px solid var(--background-border-color);
   border-bottom: 1px solid var(--background-border-color);
 
+  @media screen and (max-width: $no-gap-breakpoint) {
+    border-left: 0;
+    border-right: 0;
+  }
+
   &.collapsed {
     max-height: 0;
     opacity: 0.5;
@@ -4528,11 +4533,6 @@ a.status-card {
 
 .column-header__collapsible-inner {
   border-top: 0;
-
-  @media screen and (max-width: $no-gap-breakpoint) {
-    border-left: 0;
-    border-right: 0;
-  }
 }
 
 .column-header__setting-btn {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -4505,11 +4505,12 @@ a.status-card {
   position: relative;
   border-left: 1px solid var(--background-border-color);
   border-right: 1px solid var(--background-border-color);
-  border-bottom: 0;
+  border-bottom: 1px solid var(--background-border-color);
 
   &.collapsed {
     max-height: 0;
     opacity: 0.5;
+    border-bottom: 0;
   }
 
   &.animating {
@@ -4526,7 +4527,6 @@ a.status-card {
 }
 
 .column-header__collapsible-inner {
-  border-bottom: 1px solid var(--background-border-color);
   border-top: 0;
 
   @media screen and (max-width: $no-gap-breakpoint) {

--- a/app/javascript/styles/mastodon/reset.scss
+++ b/app/javascript/styles/mastodon/reset.scss
@@ -54,40 +54,21 @@ table {
 }
 
 html {
-  scrollbar-color: lighten($ui-base-color, 4%) rgba($base-overlay-background, 0.1);
+  scrollbar-color: var(--background-border-color);
 }
 
 ::-webkit-scrollbar {
-  width: 12px;
-  height: 12px;
+  width: 4px;
+  height: 4px;
 }
 
 ::-webkit-scrollbar-thumb {
-  background: lighten($ui-base-color, 4%);
-  border: 0px none $base-border-color;
-  border-radius: 50px;
-}
-
-::-webkit-scrollbar-thumb:hover {
-  background: lighten($ui-base-color, 6%);
-}
-
-::-webkit-scrollbar-thumb:active {
-  background: lighten($ui-base-color, 4%);
+  background-color: $ui-highlight-color;
+  opacity: .25;
 }
 
 ::-webkit-scrollbar-track {
-  border: 0px none $base-border-color;
-  border-radius: 0;
-  background: rgba($base-overlay-background, 0.1);
-}
-
-::-webkit-scrollbar-track:hover {
-  background: $ui-base-color;
-}
-
-::-webkit-scrollbar-track:active {
-  background: $ui-base-color;
+  background-color: var(--background-border-color);
 }
 
 ::-webkit-scrollbar-corner {


### PR DESCRIPTION
The column borders when expandable sections like Notifications settings don't line up currently in Safari desktop. Additionally in all browsers the bottom of the expanded column lacks a border. This also leads to border lines that don't go across the column in the advanced view.

This PR changes where the borders are generated, to properly show them on the other side of the scrollbar in Safari. It does not visually change their appearance in Firefox or Chrome expect where the bottom border is now drawn when expanded.

Because of nuances in how Safari desktop generates scrollbars, the dedicated style is modified to use the existing border color is used as the scrollbar track and made narrower to visually lock the lines together with the side of the column. The active location of the  slider has been changed to a subtle purple in this proposal but could easily stay a darker gray.

**Before**
<img width="702" alt="Screenshot 2024-08-12 at 11 43 14 AM" src="https://github.com/user-attachments/assets/b414be91-1d7e-4d05-b2b0-fc6b20b3eb2f">
<img width="699" alt="Screenshot 2024-08-12 at 11 43 52 AM" src="https://github.com/user-attachments/assets/8dbad1c3-b740-42cd-ba44-ac9c56f53322">

**After**
<img width="701" alt="Screenshot 2024-08-12 at 12 15 41 PM" src="https://github.com/user-attachments/assets/d5710778-a3b0-4615-9b81-95d6e5681ecb">
<img width="701" alt="Screenshot 2024-08-12 at 12 16 23 PM" src="https://github.com/user-attachments/assets/cebb0784-86ee-4a0f-a87e-fc863a4f1b3f">
