### PR TITLE
Modify profile directory page image borders

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -7373,7 +7373,7 @@ a.status-card {
 .scrollable .account-card__title__avatar {
   img,
   .account__avatar {
-    border-color: lighten($ui-base-color, 8%);
+    border: none;
   }
 }
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -7374,7 +7374,7 @@ a.status-card {
   img {
     border: 2px solid var(--background-color);
   }
-  
+
   .account__avatar {
     border: none;
   }

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -7374,6 +7374,7 @@ a.status-card {
   img {
     border: 2px solid var(--background-color);
   }
+  
   .account__avatar {
     border: none;
   }

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -7371,9 +7371,17 @@ a.status-card {
 }
 
 .scrollable .account-card__title__avatar {
-  img,
+  img {
+    border: 2px solid var(--background-color);
+  }
   .account__avatar {
     border: none;
+  }
+}
+
+.scrollable .account-card__header {
+  img {
+    border-radius: 4px;
   }
 }
 


### PR DESCRIPTION
Removes the border from the profile avatar on the profile directory page that was being rendered extra thick and misaligned. There is no border around the header which is padded from the cell of the profile here so an overlay seems more appropriate vs the full user profile page where both have a border at their edges.

**Before**
<img width="588" alt="Screenshot 2024-08-12 at 2 46 22 PM" src="https://github.com/user-attachments/assets/f210cd17-a015-4701-9aa0-f3cd56f6cdf5">

**After**
<img width="588" alt="image" src="https://github.com/user-attachments/assets/45e31721-3341-4745-afd1-d0d745f306c6">
