### PR TITLE
Fix web UI crash when a encoutering an orphaned notification group

### DIFF
--- a/app/javascript/mastodon/features/notifications_v2/components/notification_group.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/components/notification_group.tsx
@@ -20,6 +20,21 @@ import { NotificationSeveredRelationships } from './notification_severed_relatio
 import { NotificationStatus } from './notification_status';
 import { NotificationUpdate } from './notification_update';
 
+function missingActivity(notificationGroup: NotificationGroupModel) {
+  switch (notificationGroup.type) {
+    case 'reblog':
+    case 'favourite':
+    case 'mention':
+    case 'update':
+    case 'status':
+    case 'poll':
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- our type is actually not correct as the server can occasionally have orphaned notifications
+      return notificationGroup.statusId === null;
+    default:
+      return false;
+  }
+}
+
 export const NotificationGroup: React.FC<{
   notificationGroupId: NotificationGroupModel['group_key'];
   unread: boolean;
@@ -60,7 +75,12 @@ export const NotificationGroup: React.FC<{
     [dispatch, notificationGroupId, accountId, onMoveUp, onMoveDown],
   );
 
-  if (!notificationGroup || notificationGroup.type === 'gap') return null;
+  if (
+    !notificationGroup ||
+    notificationGroup.type === 'gap' ||
+    missingActivity(notificationGroup)
+  )
+    return null;
 
   let content;
 


### PR DESCRIPTION
Fixes #31392

Note that this is a quick and pretty dirty fix. The underlying issue is that notifications can sometimes be orphaned, that is, their underlying activity has been deleted, which results in them having a `null` activity or activity ID.

A correct client-side fix would be to update the API and model types accordingly. A correct server-side fix would be to ensure that can never happen in the first place.