### PR TITLE
Fix what was intended as a comment being interpreted as strings

### DIFF
--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -5,6 +5,7 @@ class NotifyService < BaseService
 
   MAXIMUM_GROUP_SPAN_HOURS = 12
 
+  # TODO: the severed_relationships type probably warrants email notifications
   NON_EMAIL_TYPES = %i(
     admin.report
     admin.sign_up
@@ -12,7 +13,6 @@ class NotifyService < BaseService
     poll
     status
     moderation_warning
-    # TODO: this probably warrants an email notification
     severed_relationships
   ).freeze
 


### PR DESCRIPTION
This had no ill effect as none of the words were a notification type, but still.