### PR TITLE
Only run PR rebase needed check on non-fork repos

### DIFF
--- a/.github/workflows/rebase-needed.yml
+++ b/.github/workflows/rebase-needed.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   label-rebase-needed:
     runs-on: ubuntu-latest
+    if: github.repository == 'mastodon/mastodon'
 
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Similar to https://github.com/mastodon/mastodon/pull/31195 and some others -- skip this workflow on fork repos.