### PR TITLE
Don't push to cache buster if attachment path is nil

### DIFF
--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -422,7 +422,7 @@ class MediaAttachment < ApplicationRecord
       attachment = public_send(attachment_name)
       styles = DEFAULT_STYLES | attachment.styles.keys
       styles.map { |style| attachment.path(style) }
-    end
+    end.compact
   rescue => e
     # We really don't want any error here preventing media deletion
     Rails.logger.warn "Error #{e.class} busting cache: #{e.message}"

--- a/spec/models/media_attachment_spec.rb
+++ b/spec/models/media_attachment_spec.rb
@@ -303,11 +303,14 @@ RSpec.describe MediaAttachment, :attachment_processing do
       original_path = media.file.path(:original)
       small_path = media.file.path(:small)
       thumbnail_path = media.thumbnail.path(:original)
+      paths = [original_path, small_path, thumbnail_path]
 
-      expect { media.destroy }
-        .to enqueue_sidekiq_job(CacheBusterWorker).with(original_path)
-        .and enqueue_sidekiq_job(CacheBusterWorker).with(small_path)
-        .and enqueue_sidekiq_job(CacheBusterWorker).with(thumbnail_path)
+      media.destroy
+
+      paths.each do |path|
+        expect(CacheBusterWorker).to have_enqueued_sidekiq_job(path) if path
+        expect(CacheBusterWorker).to_not have_enqueued_sidekiq_job(path) if path.nil?
+      end
     end
   end
 

--- a/spec/models/media_attachment_spec.rb
+++ b/spec/models/media_attachment_spec.rb
@@ -302,15 +302,10 @@ RSpec.describe MediaAttachment, :attachment_processing do
     it 'queues CacheBusterWorker jobs' do
       original_path = media.file.path(:original)
       small_path = media.file.path(:small)
-      thumbnail_path = media.thumbnail.path(:original)
-      paths = [original_path, small_path, thumbnail_path]
 
-      media.destroy
-
-      paths.each do |path|
-        expect(CacheBusterWorker).to have_enqueued_sidekiq_job(path) if path
-        expect(CacheBusterWorker).to_not have_enqueued_sidekiq_job(path) if path.nil?
-      end
+      expect { media.destroy }
+        .to enqueue_sidekiq_job(CacheBusterWorker).with(original_path)
+        .and enqueue_sidekiq_job(CacheBusterWorker).with(small_path)
     end
   end
 


### PR DESCRIPTION
Old remote media which already deleted by scheduler was causing an error by passing `nil` value into `CacheBuster`

Related: #31353