### PR TITLE
Reload notifications when accepted notifications are merged (streaming only)

### DIFF
--- a/app/javascript/mastodon/actions/streaming.js
+++ b/app/javascript/mastodon/actions/streaming.js
@@ -10,7 +10,7 @@ import {
   deleteAnnouncement,
 } from './announcements';
 import { updateConversations } from './conversations';
-import { processNewNotificationForGroups } from './notification_groups';
+import { processNewNotificationForGroups, fetchNotifications as fetchNotificationGroups } from './notification_groups';
 import { updateNotifications, expandNotifications } from './notifications';
 import { updateStatus } from './statuses';
 import {
@@ -109,6 +109,15 @@ export const connectTimelineStream = (timelineId, channelName, params = {}, opti
           }
           break;
         }
+        case 'notifications_merged':
+          const state = getState();
+          // TODO: what to do when in the middle of browsing notifications?
+          if (state.notifications.top || !state.notifications.mounted)
+            dispatch(expandNotifications({ forceLoad: true, maxId: undefined }));
+          if(state.settings.getIn(['notifications', 'groupingBeta'], false) && (state.notificationGroups.scrolledToTop || !state.notificationGroups.mounted)) {
+            dispatch(fetchNotificationGroups());
+          }
+          break;
         case 'conversation':
           // @ts-expect-error
           dispatch(updateConversations(JSON.parse(data.payload)));

--- a/app/javascript/mastodon/actions/streaming.js
+++ b/app/javascript/mastodon/actions/streaming.js
@@ -10,7 +10,7 @@ import {
   deleteAnnouncement,
 } from './announcements';
 import { updateConversations } from './conversations';
-import { processNewNotificationForGroups, fetchNotifications as fetchNotificationGroups } from './notification_groups';
+import { processNewNotificationForGroups, refreshStaleNotificationGroups } from './notification_groups';
 import { updateNotifications, expandNotifications } from './notifications';
 import { updateStatus } from './statuses';
 import {
@@ -114,8 +114,8 @@ export const connectTimelineStream = (timelineId, channelName, params = {}, opti
           // TODO: what to do when in the middle of browsing notifications?
           if (state.notifications.top || !state.notifications.mounted)
             dispatch(expandNotifications({ forceLoad: true, maxId: undefined }));
-          if(state.settings.getIn(['notifications', 'groupingBeta'], false) && (state.notificationGroups.scrolledToTop || !state.notificationGroups.mounted)) {
-            dispatch(fetchNotificationGroups());
+          if(state.settings.getIn(['notifications', 'groupingBeta'], false)) {
+            dispatch(refreshStaleNotificationGroups());
           }
           break;
         case 'conversation':

--- a/app/javascript/mastodon/actions/streaming.js
+++ b/app/javascript/mastodon/actions/streaming.js
@@ -111,7 +111,6 @@ export const connectTimelineStream = (timelineId, channelName, params = {}, opti
         }
         case 'notifications_merged':
           const state = getState();
-          // TODO: what to do when in the middle of browsing notifications?
           if (state.notifications.top || !state.notifications.mounted)
             dispatch(expandNotifications({ forceLoad: true, maxId: undefined }));
           if(state.settings.getIn(['notifications', 'groupingBeta'], false)) {

--- a/app/javascript/mastodon/features/notifications_v2/index.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/index.tsx
@@ -118,11 +118,11 @@ export const Notifications: React.FC<{
 
   // Keep track of mounted components for unread notification handling
   useEffect(() => {
-    dispatch(mountNotifications());
+    void dispatch(mountNotifications());
 
     return () => {
       dispatch(unmountNotifications());
-      dispatch(updateScrollPosition({ top: false }));
+      void dispatch(updateScrollPosition({ top: false }));
     };
   }, [dispatch]);
 
@@ -147,11 +147,11 @@ export const Notifications: React.FC<{
   }, [dispatch]);
 
   const handleScrollToTop = useDebouncedCallback(() => {
-    dispatch(updateScrollPosition({ top: true }));
+    void dispatch(updateScrollPosition({ top: true }));
   }, 100);
 
   const handleScroll = useDebouncedCallback(() => {
-    dispatch(updateScrollPosition({ top: false }));
+    void dispatch(updateScrollPosition({ top: false }));
   }, 100);
 
   useEffect(() => {

--- a/app/javascript/mastodon/features/notifications_v2/index.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/index.tsx
@@ -81,7 +81,11 @@ export const Notifications: React.FC<{
 
   const anyPendingNotification = useAppSelector(selectAnyPendingNotification);
 
-  const isUnread = unreadNotificationsCount > 0;
+  const needsReload = useAppSelector(
+    (state) => state.notificationGroups.mergedNotifications === 'needs-reload',
+  );
+
+  const isUnread = unreadNotificationsCount > 0 || needsReload;
 
   const canMarkAsRead =
     useAppSelector(selectSettingsNotificationsShowUnread) &&

--- a/app/javascript/mastodon/reducers/notification_groups.ts
+++ b/app/javascript/mastodon/reducers/notification_groups.ts
@@ -60,12 +60,13 @@ const initialState: NotificationGroupsState = {
   pendingGroups: [], // holds pending groups in slow mode
   scrolledToTop: false,
   isLoading: false,
+  // this is used to track whether we need to refresh notifications after accepting requests
+  mergedNotifications: 'ok',
   // The following properties are used to track unread notifications
   lastReadId: '0', // used internally for unread notifications
   readMarkerId: '0', // user-facing and updated when focus changes
   mounted: 0, // number of mounted notification list components, usually 0 or 1
   isTabVisible: true,
-  mergedNotifications: 'ok',
 };
 
 function filterNotificationsForAccounts(

--- a/app/services/accept_notification_request_service.rb
+++ b/app/services/accept_notification_request_service.rb
@@ -1,9 +1,21 @@
 # frozen_string_literal: true
 
 class AcceptNotificationRequestService < BaseService
+  include Redisable
+
   def call(request)
     NotificationPermission.create!(account: request.account, from_account: request.from_account)
+    increment_worker_count!(request)
     UnfilterNotificationsWorker.perform_async(request.account_id, request.from_account_id)
     request.destroy!
+  end
+
+  private
+
+  def increment_worker_count!(request)
+    with_redis do |redis|
+      redis.incr("notification_unfilter_jobs:#{request.account_id}")
+      redis.expire("notification_unfilter_jobs:#{request.account_id}", 30.minutes.to_i)
+    end
   end
 end

--- a/app/workers/unfilter_notifications_worker.rb
+++ b/app/workers/unfilter_notifications_worker.rb
@@ -54,7 +54,7 @@ class UnfilterNotificationsWorker
   end
 
   def push_streaming_event!
-    redis.publish("timeline:#{@recipient.id}:notifications", Oj.dump(event: :notifications_merged))
+    redis.publish("timeline:#{@recipient.id}:notifications", Oj.dump(event: :notifications_merged, payload: '1'))
   end
 
   def subscribed_to_streaming_api?

--- a/app/workers/unfilter_notifications_worker.rb
+++ b/app/workers/unfilter_notifications_worker.rb
@@ -2,6 +2,7 @@
 
 class UnfilterNotificationsWorker
   include Sidekiq::Worker
+  include Redisable
 
   # Earlier versions of the feature passed a `notification_request` ID
   # If `to_account_id` is passed, the first argument is an account ID
@@ -9,19 +10,20 @@ class UnfilterNotificationsWorker
   def perform(notification_request_or_account_id, from_account_id = nil)
     if from_account_id.present?
       @notification_request = nil
-      @from_account = Account.find(from_account_id)
-      @recipient    = Account.find(notification_request_or_account_id)
+      @from_account = Account.find_by(id: from_account_id)
+      @recipient    = Account.find_by(id: notification_request_or_account_id)
     else
-      @notification_request = NotificationRequest.find(notification_request_or_account_id)
-      @from_account = @notification_request.from_account
-      @recipient    = @notification_request.account
+      @notification_request = NotificationRequest.find_by(id: notification_request_or_account_id)
+      @from_account = @notification_request&.from_account
+      @recipient    = @notification_request&.account
     end
+
+    return if @from_account.nil? || @recipient.nil?
 
     push_to_conversations!
     unfilter_notifications!
     remove_request!
-  rescue ActiveRecord::RecordNotFound
-    true
+    decrement_worker_count!
   end
 
   private
@@ -44,5 +46,18 @@ class UnfilterNotificationsWorker
 
   def notifications_with_private_mentions
     filtered_notifications.joins(mention: :status).merge(Status.where(visibility: :direct)).includes(mention: :status)
+  end
+
+  def decrement_worker_count!
+    value = redis.decr("notification_unfilter_jobs:#{@recipient.id}")
+    push_streaming_event! if value <= 0 && subscribed_to_streaming_api?
+  end
+
+  def push_streaming_event!
+    redis.publish("timeline:#{@recipient.id}:notifications", Oj.dump(event: :notifications_merged))
+  end
+
+  def subscribed_to_streaming_api?
+    redis.exists?("subscribed:timeline:#{@recipient.id}") || redis.exists?("subscribed:timeline:#{@recipient.id}:notifications")
   end
 end

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -158,6 +158,7 @@ namespace :api, format: false do
         collection do
           post :accept, to: 'requests#accept_bulk'
           post :dismiss, to: 'requests#dismiss_bulk'
+          get :merged, to: 'requests#merged?'
         end
 
         member do

--- a/spec/requests/api/v1/notifications/requests_spec.rb
+++ b/spec/requests/api/v1/notifications/requests_spec.rb
@@ -120,4 +120,38 @@ RSpec.describe 'Requests' do
       expect(response).to have_http_status(200)
     end
   end
+
+  describe 'GET /api/v1/notifications/requests/merged' do
+    subject do
+      get '/api/v1/notifications/requests/merged', headers: headers
+    end
+
+    it_behaves_like 'forbidden for wrong scope', 'write write:notifications'
+
+    context 'when the user has no accepted request pending merge' do
+      it 'returns http success and returns merged: true' do
+        subject
+
+        expect(response).to have_http_status(200)
+        expect(body_as_json).to include(
+          merged: true
+        )
+      end
+    end
+
+    context 'when the user has an accepted request pending merge' do
+      before do
+        redis.set("notification_unfilter_jobs:#{user.account_id}", 1)
+      end
+
+      it 'returns http success and returns merged: false' do
+        subject
+
+        expect(response).to have_http_status(200)
+        expect(body_as_json).to include(
+          merged: false
+        )
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/notifications/requests_spec.rb
+++ b/spec/requests/api/v1/notifications/requests_spec.rb
@@ -133,9 +133,7 @@ RSpec.describe 'Requests' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json).to include(
-          merged: true
-        )
+        expect(body_as_json).to eq({ merged: true })
       end
     end
 
@@ -148,9 +146,7 @@ RSpec.describe 'Requests' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json).to include(
-          merged: false
-        )
+        expect(body_as_json).to eq({ merged: false })
       end
     end
   end

--- a/spec/services/accept_notification_request_service_spec.rb
+++ b/spec/services/accept_notification_request_service_spec.rb
@@ -8,10 +8,11 @@ RSpec.describe AcceptNotificationRequestService do
   let(:notification_request) { Fabricate(:notification_request) }
 
   describe '#call' do
-    it 'destroys the notification request, creates a permission, and queues a worker' do
+    it 'destroys the notification request, creates a permission, increases the jobs count and queues a worker' do
       expect { subject.call(notification_request) }
         .to change { NotificationRequest.exists?(notification_request.id) }.to(false)
         .and change { NotificationPermission.exists?(account_id: notification_request.account_id, from_account_id: notification_request.from_account_id) }.to(true)
+        .and change { redis.get("notification_unfilter_jobs:#{notification_request.account_id}").to_i }.by(1)
 
       expect(UnfilterNotificationsWorker).to have_enqueued_sidekiq_job(notification_request.account_id, notification_request.from_account_id)
     end

--- a/spec/workers/unfilter_notifications_worker_spec.rb
+++ b/spec/workers/unfilter_notifications_worker_spec.rb
@@ -30,7 +30,7 @@ describe UnfilterNotificationsWorker do
           .and change { recipient.conversations.exists?(last_status_id: sender.statuses.first.id) }.to(true)
           .and change { redis.get("notification_unfilter_jobs:#{recipient.id}").to_i }.by(-1)
 
-        expect(redis).to have_received(:publish).with("timeline:#{recipient.id}:notifications", '{"event":"notifications_merged"}')
+        expect(redis).to have_received(:publish).with("timeline:#{recipient.id}:notifications", '{"event":"notifications_merged","payload":"1"}')
       end
     end
 
@@ -46,7 +46,7 @@ describe UnfilterNotificationsWorker do
           .and change { recipient.conversations.exists?(last_status_id: sender.statuses.first.id) }.to(true)
           .and change { redis.get("notification_unfilter_jobs:#{recipient.id}").to_i }.by(-1)
 
-        expect(redis).to_not have_received(:publish).with("timeline:#{recipient.id}:notifications", '{"event":"notifications_merged"}')
+        expect(redis).to_not have_received(:publish).with("timeline:#{recipient.id}:notifications", '{"event":"notifications_merged","payload":"1"}')
       end
     end
 
@@ -61,7 +61,7 @@ describe UnfilterNotificationsWorker do
           .and change { recipient.conversations.exists?(last_status_id: sender.statuses.first.id) }.to(true)
           .and change { redis.get("notification_unfilter_jobs:#{recipient.id}").to_i }.by(-1)
 
-        expect(redis).to_not have_received(:publish).with("timeline:#{recipient.id}:notifications", '{"event":"notifications_merged"}')
+        expect(redis).to_not have_received(:publish).with("timeline:#{recipient.id}:notifications", '{"event":"notifications_merged","payload":"1"}')
       end
     end
   end

--- a/spec/workers/unfilter_notifications_worker_spec.rb
+++ b/spec/workers/unfilter_notifications_worker_spec.rb
@@ -13,13 +13,56 @@ describe UnfilterNotificationsWorker do
     Fabricate(:notification, filtered: true, from_account: sender, account: recipient, type: :mention, activity: mention)
     follow_request = sender.request_follow!(recipient)
     Fabricate(:notification, filtered: true, from_account: sender, account: recipient, type: :follow_request, activity: follow_request)
+    allow(redis).to receive(:publish)
+    allow(redis).to receive(:exists?).and_return(false)
   end
 
   shared_examples 'shared behavior' do
-    it 'unfilters notifications and adds private messages to conversations' do
-      expect { subject }
-        .to change { recipient.notifications.where(from_account_id: sender.id).pluck(:filtered) }.from([true, true]).to([false, false])
-        .and change { recipient.conversations.exists?(last_status_id: sender.statuses.first.id) }.to(true)
+    context 'when this is the last pending merge job and the user is subscribed to streaming' do
+      before do
+        redis.set("notification_unfilter_jobs:#{recipient.id}", 1)
+        allow(redis).to receive(:exists?).with("subscribed:timeline:#{recipient.id}").and_return(true)
+      end
+
+      it 'unfilters notifications, adds private messages to conversations, and pushes to redis' do
+        expect { subject }
+          .to change { recipient.notifications.where(from_account_id: sender.id).pluck(:filtered) }.from([true, true]).to([false, false])
+          .and change { recipient.conversations.exists?(last_status_id: sender.statuses.first.id) }.to(true)
+          .and change { redis.get("notification_unfilter_jobs:#{recipient.id}").to_i }.by(-1)
+
+        expect(redis).to have_received(:publish).with("timeline:#{recipient.id}:notifications", '{"event":"notifications_merged"}')
+      end
+    end
+
+    context 'when this is not last pending merge job and the user is subscribed to streaming' do
+      before do
+        redis.set("notification_unfilter_jobs:#{recipient.id}", 2)
+        allow(redis).to receive(:exists?).with("subscribed:timeline:#{recipient.id}").and_return(true)
+      end
+
+      it 'unfilters notifications, adds private messages to conversations, and does not push to redis' do
+        expect { subject }
+          .to change { recipient.notifications.where(from_account_id: sender.id).pluck(:filtered) }.from([true, true]).to([false, false])
+          .and change { recipient.conversations.exists?(last_status_id: sender.statuses.first.id) }.to(true)
+          .and change { redis.get("notification_unfilter_jobs:#{recipient.id}").to_i }.by(-1)
+
+        expect(redis).to_not have_received(:publish).with("timeline:#{recipient.id}:notifications", '{"event":"notifications_merged"}')
+      end
+    end
+
+    context 'when this is the last pending merge job and the user is not subscribed to streaming' do
+      before do
+        redis.set("notification_unfilter_jobs:#{recipient.id}", 1)
+      end
+
+      it 'unfilters notifications, adds private messages to conversations, and does not push to redis' do
+        expect { subject }
+          .to change { recipient.notifications.where(from_account_id: sender.id).pluck(:filtered) }.from([true, true]).to([false, false])
+          .and change { recipient.conversations.exists?(last_status_id: sender.statuses.first.id) }.to(true)
+          .and change { redis.get("notification_unfilter_jobs:#{recipient.id}").to_i }.by(-1)
+
+        expect(redis).to_not have_received(:publish).with("timeline:#{recipient.id}:notifications", '{"event":"notifications_merged"}')
+      end
     end
   end
 


### PR DESCRIPTION
This adds a `notifications_merged` streaming event that is fired when all accepted notifications have been merged (in case of bulk accepts, it will get fired once when all of them have been merged).

This also adds `GET /api/v1/notifications/requests/merged` so that the same information can be polled, for apps that do not use streaming.

Finally, it adds a streaming event handler to the Web UI to refresh the notifications when those are scrolled on top or hidden.

If the notifications column is shown and not scrolled to top, a “unread item” glow will be shown, and the notifications will refresh next time the user scrolls to top. (**Note:** this part is only implemented for the grouped notifications)

**Note:** polling is not currently handled by the Web UI, as it requires a little more work