### PR TITLE
Add a follow button & follower count on follow notifications

### DIFF
--- a/app/javascript/mastodon/features/notifications_v2/components/notification_follow.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/components/notification_follow.tsx
@@ -1,7 +1,11 @@
 import { FormattedMessage } from 'react-intl';
 
 import PersonAddIcon from '@/material-icons/400-24px/person_add-fill.svg?react';
+import { FollowersCounter } from 'mastodon/components/counters';
+import { FollowButton } from 'mastodon/components/follow_button';
+import { ShortNumber } from 'mastodon/components/short_number';
 import type { NotificationGroupFollow } from 'mastodon/models/notification_group';
+import { useAppSelector } from 'mastodon/store';
 
 import type { LabelRenderer } from './notification_group_with_status';
 import { NotificationGroupWithStatus } from './notification_group_with_status';
@@ -14,18 +18,45 @@ const labelRenderer: LabelRenderer = (values) => (
   />
 );
 
+const FollowerCount: React.FC<{ accountId: string }> = ({ accountId }) => {
+  const account = useAppSelector((s) => s.accounts.get(accountId));
+
+  if (!account) return null;
+
+  return (
+    <ShortNumber value={account.followers_count} renderer={FollowersCounter} />
+  );
+};
+
 export const NotificationFollow: React.FC<{
   notification: NotificationGroupFollow;
   unread: boolean;
-}> = ({ notification, unread }) => (
-  <NotificationGroupWithStatus
-    type='follow'
-    icon={PersonAddIcon}
-    iconId='person-add'
-    accountIds={notification.sampleAccountIds}
-    timestamp={notification.latest_page_notification_at}
-    count={notification.notifications_count}
-    labelRenderer={labelRenderer}
-    unread={unread}
-  />
-);
+}> = ({ notification, unread }) => {
+  let actions: JSX.Element | undefined;
+  let additionalContent: JSX.Element | undefined;
+
+  if (notification.sampleAccountIds.length === 1) {
+    // only display those if the group contains 1 account, otherwise it does not makes sense
+    const account = notification.sampleAccountIds[0];
+
+    if (account) {
+      actions = <FollowButton accountId={notification.sampleAccountIds[0]} />;
+      additionalContent = <FollowerCount accountId={account} />;
+    }
+  }
+
+  return (
+    <NotificationGroupWithStatus
+      type='follow'
+      icon={PersonAddIcon}
+      iconId='person-add'
+      accountIds={notification.sampleAccountIds}
+      timestamp={notification.latest_page_notification_at}
+      count={notification.notifications_count}
+      labelRenderer={labelRenderer}
+      unread={unread}
+      actions={actions}
+      additionalContent={additionalContent}
+    />
+  );
+};

--- a/app/javascript/mastodon/features/notifications_v2/components/notification_follow_request.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/components/notification_follow_request.tsx
@@ -46,7 +46,7 @@ export const NotificationFollowRequest: React.FC<{
   }, [dispatch, notification.sampleAccountIds]);
 
   const actions = (
-    <div className='notification-group__actions'>
+    <>
       <IconButton
         title={intl.formatMessage(messages.reject)}
         icon='times'
@@ -59,7 +59,7 @@ export const NotificationFollowRequest: React.FC<{
         iconComponent={CheckIcon}
         onClick={onAuthorize}
       />
-    </div>
+    </>
   );
 
   return (

--- a/app/javascript/mastodon/features/notifications_v2/components/notification_group_with_status.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/components/notification_group_with_status.tsx
@@ -31,6 +31,7 @@ export const NotificationGroupWithStatus: React.FC<{
   labelSeeMoreHref?: string;
   type: string;
   unread: boolean;
+  additionalContent?: JSX.Element;
 }> = ({
   icon,
   iconId,
@@ -43,6 +44,7 @@ export const NotificationGroupWithStatus: React.FC<{
   labelSeeMoreHref,
   type,
   unread,
+  additionalContent,
 }) => {
   const dispatch = useAppDispatch();
 
@@ -92,7 +94,9 @@ export const NotificationGroupWithStatus: React.FC<{
             <div className='notification-group__main__header__wrapper'>
               <AvatarGroup accountIds={accountIds} />
 
-              {actions}
+              {actions && (
+                <div className='notification-group__actions'>{actions}</div>
+              )}
             </div>
 
             <div className='notification-group__main__header__label'>
@@ -104,6 +108,12 @@ export const NotificationGroupWithStatus: React.FC<{
           {statusId && (
             <div className='notification-group__main__status'>
               <EmbeddedStatus statusId={statusId} />
+            </div>
+          )}
+
+          {additionalContent && (
+            <div className='notification-group__main__additional-content'>
+              {additionalContent}
             </div>
           )}
         </div>

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -10525,6 +10525,11 @@ noscript {
       border-radius: 8px;
       padding: 8px;
     }
+
+    &__additional-content {
+      color: $darker-text-color;
+      margin-top: -8px; // to offset the parent's `gap` property
+    }
   }
 
   &__avatar-group {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -10486,6 +10486,13 @@ noscript {
     gap: 8px;
     flex: 1 1 auto;
     overflow: hidden;
+    container-type: inline-size;
+
+    @container (width < 350px) {
+      &__header time {
+        display: none;
+      }
+    }
 
     &__header {
       display: flex;


### PR DESCRIPTION
This brings back some of the previous features, for groups with only 1 account (all of them for now).

I also refactored the `actions` prop a bit to always wrap it into a container.

Here is how it looks:
![image](https://github.com/user-attachments/assets/ea0f30fc-32c5-46c1-829b-5e3d5a3055fb)


But not ideal on the advanced interface:
![image](https://github.com/user-attachments/assets/144edc4d-128b-4182-adc8-373eed8d81eb)

Fixes MAS-298