### PR TITLE
Add the ability to ignore specific browser errors for a spec

### DIFF
--- a/spec/support/browser_errors.rb
+++ b/spec/support/browser_errors.rb
@@ -1,23 +1,36 @@
 # frozen_string_literal: true
 
+module BrowserErrorsHelpers
+  def ignore_js_error(error)
+    @ignored_js_errors_for_spec << error
+  end
+end
+
 RSpec.configure do |config|
+  config.include BrowserErrorsHelpers, :js, type: :system
+
+  config.before(:each, :js, type: :system) do
+    @ignored_js_errors_for_spec = []
+  end
+
   config.after(:each, :js, type: :system) do
     # Classes of intermittent ignorable errors
     ignored_errors = [
       /Error while trying to use the following icon from the Manifest/, # https://github.com/mastodon/mastodon/pull/30793
       /Manifest: Line: 1, column: 1, Syntax error/, # Similar parsing/interruption issue as above
-    ]
+    ].concat(@ignored_js_errors_for_spec)
+
     errors = page.driver.browser.logs.get(:browser).reject do |error|
       ignored_errors.any? { |pattern| pattern.match(error.message) }
     end
 
     if errors.present?
-      aggregate_failures 'javascript errrors' do
+      aggregate_failures 'browser errrors' do
         errors.each do |error|
           expect(error.level).to_not eq('SEVERE'), error.message
           next unless error.level == 'WARNING'
 
-          warn 'WARN: javascript warning'
+          warn 'WARN: browser warning'
           warn error.message
         end
       end

--- a/spec/system/log_out_spec.rb
+++ b/spec/system/log_out_spec.rb
@@ -24,6 +24,9 @@ describe 'Log out' do
 
   describe 'Logging out from the JS app', :js, :streaming do
     it 'logs the user out' do
+      # The frontend tries to load announcements after a short delay, but the session might be expired by then, and the browser will output an error.
+      ignore_js_error(/Failed to load resource: the server responded with a status of 422/)
+
       visit root_path
 
       within '.navigation-bar' do


### PR DESCRIPTION
This fixes the newly introduced test flakiness caused by the new log out system spec.

Also renamed the file to better indicate that those are browser logs & errors, and not specifically Javascript.