### PR TITLE
Disable Chrome's search engine selection screen when running system specs

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -6,14 +6,20 @@ Capybara.app_host = "http://#{Capybara.server_host}:#{Capybara.server_port}"
 
 require 'selenium/webdriver'
 
+def common_chrome_options
+  options = Selenium::WebDriver::Chrome::Options.new
+  options.add_argument '--window-size=1680,1050'
+  options.add_argument '--disable-search-engine-choice-screen'
+  options
+end
+
 Capybara.register_driver :chrome do |app|
-  Capybara::Selenium::Driver.new(app, browser: :chrome)
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: common_chrome_options)
 end
 
 Capybara.register_driver :headless_chrome do |app|
-  options = Selenium::WebDriver::Chrome::Options.new
+  options = common_chrome_options
   options.add_argument '--headless=new'
-  options.add_argument '--window-size=1680,1050'
 
   Capybara::Selenium::Driver.new(
     app,


### PR DESCRIPTION
I refactored the options to be able to set some base one for both drivers. I think it makes sense to set the window size all the time, as our specs might rely on it.

In a Selenium issue (https://github.com/SeleniumHQ/selenium/issues/14343) they said that they do not want to change the default browser behaviour and each app should do it, so here we go.

This only applies when Chrome detects that you are in Europe I think, thats why it did not happen in CI.