### PR TITLE
Fix missing top border on Admin Hashtags UI

### DIFF
--- a/app/javascript/styles/mastodon/tables.scss
+++ b/app/javascript/styles/mastodon/tables.scss
@@ -153,6 +153,14 @@ a.table-action-link {
 }
 
 .batch-table {
+  &--no-toolbar {
+    .batch-table__toolbar {
+      position: static;
+      height: 4px;
+      border-bottom: none;
+    }
+  }
+
   &__toolbar,
   &__row {
     display: flex;

--- a/app/views/admin/tags/index.html.haml
+++ b/app/views/admin/tags/index.html.haml
@@ -29,7 +29,8 @@
 
 %hr.spacer/
 
-.batch-table
+.batch-table.batch-table--no-toolbar
+  .batch-table__toolbar
   .batch-table__body
     - if @tags.empty?
       = nothing_here 'nothing-here--under-tabs'


### PR DESCRIPTION
Fixes #31212

This possibly isn't the most ideal fix, but then again, we're using divs for tables, so styling is going to be weird anyway.

<img width="1208" alt="Screenshot 2024-08-15 at 19 45 46" src="https://github.com/user-attachments/assets/6f8b1103-44c8-49b8-9225-faf3ab96f690">
