### PR TITLE
Harmonize persistent scrollbar styles

### DIFF
--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -557,3 +557,12 @@ a.sparkline {
     color: $dark-text-color;
   }
 }
+
+html {
+  scrollbar-color: rgba($action-button-color, 0.25)
+    var(--background-border-color);
+}
+
+::-webkit-scrollbar-thumb {
+  opacity: 0.25;
+}

--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -558,9 +558,11 @@ a.sparkline {
   }
 }
 
-html {
-  scrollbar-color: rgba($action-button-color, 0.25)
-    var(--background-border-color);
+@supports not selector(::-webkit-scrollbar) {
+  html {
+    scrollbar-color: rgba($action-button-color, 0.25)
+      var(--background-border-color);
+  }
 }
 
 ::-webkit-scrollbar-thumb {

--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -1,10 +1,6 @@
 // Notes!
 // Sass color functions, "darken" and "lighten" are automatically replaced.
 
-html {
-  scrollbar-color: $ui-base-color rgba($ui-base-color, 0.25);
-}
-
 .simple_form .button.button-tertiary {
   color: $highlight-text-color;
 }

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -7560,10 +7560,6 @@ a.status-card {
   }
 }
 
-::-webkit-scrollbar-thumb {
-  border-radius: 0;
-}
-
 noscript {
   text-align: center;
 

--- a/app/javascript/styles/mastodon/reset.scss
+++ b/app/javascript/styles/mastodon/reset.scss
@@ -59,17 +59,17 @@ html {
 }
 
 ::-webkit-scrollbar {
-  width: 12px;
-  height: 12px;
+  width: 8px;
+  height: 8px;
 }
 
 ::-webkit-scrollbar-thumb {
   background-color: $ui-highlight-color;
-  border: 6px var(--background-border-color);
+  border: 2px var(--background-border-color);
   border-radius: 12px;
   opacity: .25;
   width: 6px;
-  box-shadow: inset 0 0 0 3px var(--background-border-color);
+  box-shadow: inset 0 0 0 2px var(--background-border-color);
 }
 
 ::-webkit-scrollbar-track {

--- a/app/javascript/styles/mastodon/reset.scss
+++ b/app/javascript/styles/mastodon/reset.scss
@@ -54,21 +54,27 @@ table {
 }
 
 html {
-  scrollbar-color: var(--background-border-color);
+  scrollbar-color: rgba($ui-highlight-color, .25) var(--background-border-color);
+  scrollbar-width: thin;
 }
 
 ::-webkit-scrollbar {
-  width: 4px;
-  height: 4px;
+  width: 12px;
+  height: 12px;
 }
 
 ::-webkit-scrollbar-thumb {
   background-color: $ui-highlight-color;
+  border: 6px var(--background-border-color);
+  border-radius: 12px;
   opacity: .25;
+  width: 6px;
+  box-shadow: inset 0 0 0 3px var(--background-border-color);
 }
 
 ::-webkit-scrollbar-track {
   background-color: var(--background-border-color);
+  border-radius: 0px;
 }
 
 ::-webkit-scrollbar-corner {

--- a/app/javascript/styles/mastodon/reset.scss
+++ b/app/javascript/styles/mastodon/reset.scss
@@ -54,7 +54,7 @@ table {
 }
 
 html {
-  scrollbar-color: rgba($ui-highlight-color, .25) var(--background-border-color);
+  scrollbar-color: $action-button-color var(--background-border-color);
   scrollbar-width: thin;
 }
 
@@ -64,10 +64,10 @@ html {
 }
 
 ::-webkit-scrollbar-thumb {
-  background-color: $ui-highlight-color;
+  background-color: $action-button-color;
   border: 2px var(--background-border-color);
   border-radius: 12px;
-  opacity: .25;
+  // opacity: .25;
   width: 6px;
   box-shadow: inset 0 0 0 2px var(--background-border-color);
 }

--- a/app/javascript/styles/mastodon/reset.scss
+++ b/app/javascript/styles/mastodon/reset.scss
@@ -53,9 +53,11 @@ table {
   border-spacing: 0;
 }
 
-html {
-  scrollbar-color: $action-button-color var(--background-border-color);
-  scrollbar-width: thin;
+@supports not selector(::-webkit-scrollbar) {
+  html {
+    scrollbar-color: $action-button-color var(--background-border-color);
+    scrollbar-width: thin;
+  }
 }
 
 ::-webkit-scrollbar {

--- a/app/javascript/styles/mastodon/reset.scss
+++ b/app/javascript/styles/mastodon/reset.scss
@@ -67,7 +67,6 @@ html {
   background-color: $action-button-color;
   border: 2px var(--background-border-color);
   border-radius: 12px;
-  // opacity: .25;
   width: 6px;
   box-shadow: inset 0 0 0 2px var(--background-border-color);
 }


### PR DESCRIPTION
This seeks to bring some harmony to the various browser scrollbars after a couple of previous changes to adapt to the new border styles. 

- Tweaks the Safari desktop style to include a more macOS style rounded thumb/throbber in the tray which is slightly wider to accommodate being able to grab it with the mouse pointer
- Uses the same coloring for the native scrollbars in Firefox and Chrome/Edge on all platforms.

Safari on macOS insists on making the scrollbars visible if any styles are applied. Not styling it will cause them to appear (in a discolored tray) in advanced mode and other places after the session has been sitting for some time. I'm open to ideas to get around this. Everything I looked at included additional JavaScript to detect the state of the mouse/scrollbar which I wasn't keen in introducing.

Firefox and Chrome/Edge will respect the OS behavior to only throw the scroll thumb if you're hovering over the section with the mouse. When "always show scrollbar" is applied to the OS/browser then they will all appear to be similarly correct per platform.

**macOS Safari**
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/7d5c7fb0-85e3-4ef5-8a72-69826762b1f5">
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/f2e7872a-0639-4e89-880a-5a0919fba1c2">
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/6d03e953-3d5b-4802-abf8-39ab016921aa">

**macOS Firefox**
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/d3dd333f-992a-4865-98e8-d52b76531d81">
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/72ecc162-c4aa-4e2b-990f-53f69b1c06ec">
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/6d1c9ce8-49f7-439d-9391-8e6bf11c29b9">

**macOS Chrome/Edge**
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/d8973563-a04d-406c-a31f-54fa7838aa0a">
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/13f9ccc6-ce83-4a57-8644-2c4e1beb48d9">
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/8fff203d-b641-41df-8566-6efb89e90840">

**Windows Firefox**
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/1986f2c7-adb0-49f0-8f60-388c409cd422">
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/da05fc84-8ecf-402f-bd08-6c4fe7428c00">
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/88f9e47b-747d-40aa-ab42-174d22016e54">

**Windows Chrome/Edge**
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/a5660a20-b7a4-4954-9f3b-f44f1dcf57ef">
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/c6234620-37bb-454f-89a7-c1d5171b9774">
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/e1d33f9f-1729-4286-9985-ac12127cc495">

**Linux Firefox**
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/578da9b9-ba70-4d3c-a3d6-b0ada5dd82bb">
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/8ef0620c-6787-4261-bc0f-ba24097cdda5">
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/2d6bc1a0-73de-49e9-a41d-c79dc860bdec">

