### PR TITLE
Skip paperclip spoof detector unless opted into attachment processing specs

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -138,7 +138,10 @@ RSpec.configure do |config|
 
   config.before do |example|
     unless example.metadata[:attachment_processing]
-      allow_any_instance_of(Paperclip::Attachment).to receive(:post_process).and_return(true) # rubocop:disable RSpec/AnyInstance
+      # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(Paperclip::Attachment).to receive(:post_process).and_return(true)
+      allow_any_instance_of(Paperclip::MediaTypeSpoofDetector).to receive(:spoofed?).and_return(false)
+      # rubocop:enable RSpec/AnyInstance
     end
   end
 


### PR DESCRIPTION
This validator shells out (does at least a `file` check, maybe more) -- so we can skip this check during spec runs in all the places we're already skipping the other media attachment processing stuff.

Cuts off ~40s from full (non parallel) suite run for me locally.