### PR TITLE
Fix incorrect activity matching in notification unfiltering worker

### DIFF
--- a/app/workers/unfilter_notifications_worker.rb
+++ b/app/workers/unfilter_notifications_worker.rb
@@ -43,6 +43,6 @@ class UnfilterNotificationsWorker
   end
 
   def notifications_with_private_mentions
-    filtered_notifications.joins(mention: :status).merge(Status.where(visibility: :direct)).includes(mention: :status)
+    filtered_notifications.where(type: :mention).joins(mention: :status).merge(Status.where(visibility: :direct)).includes(mention: :status)
   end
 end


### PR DESCRIPTION
This scope was occasionally matching notifications that were not for mentions, but whose `activity_id` happened to match a mention with the same `id` (`activity` is a polymorphic association, but the type was not checked in this SQL bit).

See https://github.com/mastodon/mastodon/pull/31455#issuecomment-2293757367 for more information.