### PR TITLE
Disable rule selector in ReportReasonSelector if instance has no rules

### DIFF
--- a/app/javascript/mastodon/components/admin/ReportReasonSelector.jsx
+++ b/app/javascript/mastodon/components/admin/ReportReasonSelector.jsx
@@ -153,7 +153,7 @@ class ReportReasonSelector extends PureComponent {
         <Category id='other' text={intl.formatMessage(messages.other)} selected={category === 'other'} onSelect={this.handleSelect} disabled={disabled} />
         <Category id='legal' text={intl.formatMessage(messages.legal)} selected={category === 'legal'} onSelect={this.handleSelect} disabled={disabled} />
         <Category id='spam' text={intl.formatMessage(messages.spam)} selected={category === 'spam'} onSelect={this.handleSelect} disabled={disabled} />
-        <Category id='violation' text={intl.formatMessage(messages.violation)} selected={category === 'violation'} onSelect={this.handleSelect} disabled={disabled}>
+        <Category id='violation' text={intl.formatMessage(messages.violation)} selected={category === 'violation'} onSelect={this.handleSelect} disabled={disabled || rules.length === 0}>
           {rules.map(rule => <Rule key={rule.id} id={rule.id} text={rule.text} selected={rule_ids.includes(rule.id)} onToggle={this.handleToggle} disabled={disabled} />)}
         </Category>
       </div>


### PR DESCRIPTION
Previously you could end up with bad data in the database if the server had no rules, because you'd be able to mark the report as for a Rule Violation, but not have a rule selected.

This change was made following receiving an error in my console of:

```
Warning: Failed prop type: Invalid prop `id` of type `number` supplied to `ReportReasonSelector`, expected `string`.
ReportReasonSelector@webpack-internal:///./app/javascript/mastodon/components/admin/ReportReasonSelector.jsx:181:5
injectIntl(ReportReasonSelector)
IntlProvider@webpack-internal:///./node_modules/react-intl/lib/src/components/provider.js:39:47
IntlProvider@webpack-internal:///./app/javascript/mastodon/locales/intl_provider.tsx:42:9
AdminComponent@webpack-internal:///./app/javascript/mastodon/containers/admin_component.jsx:18:1
```

When my server had no rules, but had generated reports with the rule violation category select.