### PR TITLE
Separate settings for public timelines for remote and local content

### DIFF
--- a/app/controllers/api/v1/timelines/base_controller.rb
+++ b/app/controllers/api/v1/timelines/base_controller.rb
@@ -8,7 +8,7 @@ class Api::V1::Timelines::BaseController < Api::BaseController
   private
 
   def require_auth?
-    !Setting.timeline_preview
+    !(Setting.timeline_preview_local && Setting.timeline_preview_remote)
   end
 
   def pagination_collection

--- a/app/controllers/api/v1/timelines/link_controller.rb
+++ b/app/controllers/api/v1/timelines/link_controller.rb
@@ -2,6 +2,7 @@
 
 class Api::V1::Timelines::LinkController < Api::V1::Timelines::BaseController
   before_action -> { authorize_if_got_token! :read, :'read:statuses' }
+  before_action :require_user!, if: :require_auth?
   before_action :set_preview_card
   before_action :set_statuses
 
@@ -16,6 +17,12 @@ class Api::V1::Timelines::LinkController < Api::V1::Timelines::BaseController
   end
 
   private
+
+  # A viewer can only see the link timeline if both timeline_preview_local and
+  # timeline_preview_remote are true, since it includes remote content
+  def require_auth?
+    !(Setting.timeline_preview_local && Setting.timeline_preview_remote)
+  end
 
   def set_preview_card
     @preview_card = PreviewCard.joins(:trend).merge(PreviewCardTrend.allowed).find_by!(url: params[:url])

--- a/app/controllers/api/v1/timelines/tag_controller.rb
+++ b/app/controllers/api/v1/timelines/tag_controller.rb
@@ -14,10 +14,6 @@ class Api::V1::Timelines::TagController < Api::V1::Timelines::BaseController
 
   private
 
-  def require_auth?
-    !Setting.timeline_preview
-  end
-
   def load_tag
     @tag = Tag.find_normalized(params[:id])
   end

--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -14,7 +14,8 @@ class Form::AdminSettings
     site_terms
     registrations_mode
     closed_registrations_message
-    timeline_preview
+    timeline_preview_local
+    timeline_preview_remote
     bootstrap_timeline_accounts
     theme
     activity_api_enabled
@@ -48,7 +49,8 @@ class Form::AdminSettings
   ).freeze
 
   BOOLEAN_KEYS = %i(
-    timeline_preview
+    timeline_preview_local
+    timeline_preview_remote
     activity_api_enabled
     peers_api_enabled
     preview_sensitive_media

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -12,7 +12,8 @@ defaults: &defaults
   registrations_mode: 'none'
   profile_directory: true
   closed_registrations_message: ''
-  timeline_preview: true
+  timeline_preview_local: true
+  timeline_preview_remote: false
   show_staff_badge: true
   preview_sensitive_media: false
   noindex: false

--- a/db/migrate/20240817155611_split_public_timelines_setting.rb
+++ b/db/migrate/20240817155611_split_public_timelines_setting.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class SplitPublicTimelinesSetting < ActiveRecord::Migration[7.1]
+  def up
+    previous_setting = Setting.find_by(var: 'timeline_preview')
+
+    unless previous_setting.nil?
+      Setting['timeline_preview_local'] = previous_setting.value
+      Setting['timeline_preview_remote'] = previous_setting.value
+      previous_setting.delete
+    end
+  end
+
+  def down
+    preview_local = Setting['timeline_preview_local']
+    preview_remote = Setting['timeline_preview_remote']
+
+    unless preview_local.nil? && preview_remote.nil?
+      preview_timelines = (!preview_local.nil? && preview_local) && (!preview_remote.nil? && preview_remote)
+      Setting['timeline_preview'] = preview_timelines
+    end
+
+    Setting.where(var: ['timeline_preview_local', 'timeline_preview_remote']).delete_all
+  end
+end

--- a/spec/requests/api/v1/timelines/link_spec.rb
+++ b/spec/requests/api/v1/timelines/link_spec.rb
@@ -17,6 +17,14 @@ describe 'Link' do
     end
   end
 
+  # The default settings are that timeline_preview_local is true but
+  # timeline_preview_remote is false, which caused this spec to fail because it
+  # assumes the default visibility is true.
+  before do
+    Form::AdminSettings.new(timeline_preview_local: true).save
+    Form::AdminSettings.new(timeline_preview_remote: true).save
+  end
+
   describe 'GET /api/v1/timelines/link' do
     subject do
       get '/api/v1/timelines/link', headers: headers, params: params
@@ -79,7 +87,8 @@ describe 'Link' do
 
     context 'when the instance does not allow public preview' do
       before do
-        Form::AdminSettings.new(timeline_preview: false).save
+        Form::AdminSettings.new(timeline_preview_local: false).save
+        Form::AdminSettings.new(timeline_preview_remote: false).save
       end
 
       it_behaves_like 'forbidden for wrong scope', 'profile'
@@ -110,6 +119,11 @@ describe 'Link' do
     end
 
     context 'when the instance allows public preview' do
+      before do
+        Form::AdminSettings.new(timeline_preview_local: true).save
+        Form::AdminSettings.new(timeline_preview_remote: true).save
+      end
+
       context 'with an authorized user' do
         it_behaves_like 'a successful request to the link timeline'
       end


### PR DESCRIPTION
Work in progress for https://github.com/mastodon/mastodon/issues/20831

The permissions around accessing timelines is a bit of a mess, because you're always potentially getting local and remote content, but you really only want `Setting.timeline_preview_remote` to only come into force if the user explicitly requested remote content, or didn't filter at all.

I'm not sure if I'm making complete sense of the permissions model here.

- [x] Migration to split timeline_preview setting
- [x] Changes to `Form::AdminSettings` for the new settings
- [ ] Changes to Timeline APIs for the new settings
- [ ] Changes to the Admin UI to have separate local and remote timeline preview settings
- [ ] Changes to the Web UI's initial state for local and remote timeline preview settings
- [ ] Changes to the Instance info API for whether timeline previews are enabled, and which are local and/or remote.
- [ ] Changes to the Firehose timeline in Web UI
- [ ] Changes to the Navigation Panel in Web UI

There's almost certainly spec changes required here.