### PR TITLE
Fix Trending Tags pending review having an unstable sort order

### DIFF
--- a/app/models/trends/tag_filter.rb
+++ b/app/models/trends/tag_filter.rb
@@ -14,7 +14,7 @@ class Trends::TagFilter
 
   def results
     scope = if params[:status] == 'pending_review'
-              Tag.unscoped.order(created_at: :desc)
+              Tag.unscoped.order(id: :desc)
             else
               trending_scope
             end

--- a/app/models/trends/tag_filter.rb
+++ b/app/models/trends/tag_filter.rb
@@ -14,7 +14,7 @@ class Trends::TagFilter
 
   def results
     scope = if params[:status] == 'pending_review'
-              Tag.unscoped
+              Tag.unscoped.order(created_at: :desc)
             else
               trending_scope
             end


### PR DESCRIPTION
Fixes: #30135

I think this would be an appropriate fix. The controller specs for this page currently do not concern themselves with the sort order at all. Arguably there isn't even any controller specs, because all it's testing is that the page loads successfully when logged in, and nothing else.