### PR TITLE
Fix in memoriam accounts appearing in follow recommendations

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -144,6 +144,7 @@ class Account < ApplicationRecord
   scope :dormant, -> { joins(:account_stat).merge(AccountStat.without_recent_activity) }
   scope :with_username, ->(value) { where arel_table[:username].lower.eq(value.to_s.downcase) }
   scope :with_domain, ->(value) { where arel_table[:domain].lower.eq(value&.to_s&.downcase) }
+  scope :without_memorial, -> { where(memorial: false) }
 
   after_update_commit :trigger_update_webhooks
 

--- a/app/models/account_suggestions/friends_of_friends_source.rb
+++ b/app/models/account_suggestions/friends_of_friends_source.rb
@@ -31,6 +31,7 @@ class AccountSuggestions::FriendsOfFriendsSource < AccountSuggestions::Source
         AND accounts.suspended_at IS NULL
         AND accounts.silenced_at IS NULL
         AND accounts.moved_to_account_id IS NULL
+        AND accounts.memorial = FALSE
         AND follow_recommendation_mutes.target_account_id IS NULL
       GROUP BY accounts.id, account_stats.id
       ORDER BY frequency DESC, account_stats.followers_count ASC

--- a/app/models/account_suggestions/source.rb
+++ b/app/models/account_suggestions/source.rb
@@ -14,6 +14,7 @@ class AccountSuggestions::Source
       .searchable
       .where(discoverable: true)
       .without_silenced
+      .without_memorial
       .where.not(follows_sql, id: account.id)
       .where.not(follow_requests_sql, id: account.id)
       .not_excluded_by_account(account)

--- a/spec/models/account_suggestions/friends_of_friends_source_spec.rb
+++ b/spec/models/account_suggestions/friends_of_friends_source_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe AccountSuggestions::FriendsOfFriendsSource do
     let!(:john) { Fabricate(:account, discoverable: true, hide_collections: false) }
     let!(:jerk) { Fabricate(:account, discoverable: true, hide_collections: false) }
     let!(:larry) { Fabricate(:account, discoverable: true, hide_collections: false) }
+    let!(:morty) { Fabricate(:account, discoverable: true, hide_collections: false, memorial: true) }
 
     context 'with follows and blocks' do
       before do
@@ -27,8 +28,8 @@ RSpec.describe AccountSuggestions::FriendsOfFriendsSource do
         # alice follows eve and mallory
         [john, mallory].each { |account| alice.follow!(account) }
 
-        # eugen follows eve, john, jerk, larry and neil
-        [eve, mallory, jerk, larry, neil].each { |account| eugen.follow!(account) }
+        # eugen follows eve, john, jerk, larry, neil and morty
+        [eve, mallory, jerk, larry, neil, morty].each { |account| eugen.follow!(account) }
       end
 
       it 'returns eligible accounts', :aggregate_failures do
@@ -51,6 +52,9 @@ RSpec.describe AccountSuggestions::FriendsOfFriendsSource do
 
         # the suggestion for neil has already been rejected
         expect(results).to_not include([neil.id, :friends_of_friends])
+
+        # morty is not included because his account is in memoriam
+        expect(results).to_not include([morty.id, :friends_of_friends])
       end
     end
 

--- a/spec/models/account_suggestions/source_spec.rb
+++ b/spec/models/account_suggestions/source_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe AccountSuggestions::Source do
       let!(:moved_account) { Fabricate(:account, moved_to_account: Fabricate(:account), discoverable: true) }
       let!(:silenced_account) { Fabricate(:account, silenced: true, discoverable: true) }
       let!(:undiscoverable_account) { Fabricate(:account, discoverable: false) }
+      let!(:memorial_account) { Fabricate(:account, memorial: true, discoverable: true) }
 
       before do
         Fabricate :account_domain_block, account: account, domain: account_domain_blocked_account.domain
@@ -44,6 +45,7 @@ RSpec.describe AccountSuggestions::Source do
           .and not_include(moved_account)
           .and not_include(silenced_account)
           .and not_include(undiscoverable_account)
+          .and not_include(memorial_account)
       end
     end
   end


### PR DESCRIPTION
Further to #30466, this fix prevents _in memoriam_ accounts from appearing in accounts' follow recommendations.

This is achieved by adding an extra restriction (`memorial: false`) in both of the following sources of these recommendations:

- `app/models/account_suggestions/source.rb`
- `app/models/account_suggestions/friends_of_friends_source.rb`

Note - this does _not_ invalidate any caches upon an admin "memorialising" a user. Since this action could hypothetically affect the recommendation cache for any account, and due to memorialisation being a one-off and _irreversible_ operation, I did not see this as necessary.