### PR TITLE
Add warning in reports if the local reporting user has disabled hiding of sensitive media

### DIFF
--- a/app/views/admin/reports/show.html.haml
+++ b/app/views/admin/reports/show.html.haml
@@ -29,7 +29,7 @@
 - if @report.comment.present?
   = render 'admin/reports/comment', report: @report
 
-- if @report.account.local? && (@report.account.user.settings['web.expand_content_warnings'] || @report.account.user.settings['web.display_media'] == 'show_all')
+- if @report.account.local? && !@statuses.empty? && (@report.account.user.settings['web.expand_content_warnings'] || @report.account.user.settings['web.display_media'] == 'show_all')
   .flash-message.warning= t('admin.reports.sensitive_media_explanation')
 
 %hr.spacer/

--- a/app/views/admin/reports/show.html.haml
+++ b/app/views/admin/reports/show.html.haml
@@ -29,6 +29,9 @@
 - if @report.comment.present?
   = render 'admin/reports/comment', report: @report
 
+- if @report.account.local? && (@report.account.user.settings['web.expand_content_warnings'] || @report.account.user.settings['web.display_media'] == 'show_all')
+  .flash-message.warning= t('admin.reports.sensitive_media_explanation')
+
 %hr.spacer/
 
 %h3

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -645,6 +645,7 @@ en:
       reported_with_application: Reported with application
       resolved: Resolved
       resolved_msg: Report successfully resolved!
+      sensitive_media_explanation: The reporting user has content warnings disabled or has chosen to always shows media, even if it contains sensitive content.
       skip_to_actions: Skip to actions
       status: Status
       statuses: Reported content


### PR DESCRIPTION
Fixes #29291

<img width="862" alt="Screenshot 2024-08-17 at 21 05 12" src="https://github.com/user-attachments/assets/b97f4f96-b804-4eec-81cc-1a5369cbde3d">
