### PR TITLE
Add button to Admin Account details page to view the instance if non-local account

### DIFF
--- a/app/views/admin/accounts/show.html.haml
+++ b/app/views/admin/accounts/show.html.haml
@@ -3,7 +3,7 @@
 
 - content_for :heading_actions do
   - unless @account.local?
-    = link_to t('admin.accounts.view_instance'), admin_instance_path(@account.domain), method: :post, class: 'button'
+    = link_to t('admin.accounts.view_instance'), admin_instance_path(@account.domain), class: 'button'
 
 - if @account.instance_actor?
   .flash-message.notice

--- a/app/views/admin/accounts/show.html.haml
+++ b/app/views/admin/accounts/show.html.haml
@@ -1,6 +1,10 @@
 - content_for :page_title do
   = @account.pretty_acct
 
+- content_for :heading_actions do
+  - unless @account.local?
+    = link_to t('admin.accounts.view_instance'), admin_instance_path(@account.domain), method: :post, class: 'button'
+
 - if @account.instance_actor?
   .flash-message.notice
     %strong= t('accounts.instance_actor_flash')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -165,6 +165,7 @@ en:
       unsuspended_msg: Successfully unsuspended %{username}'s account
       username: Username
       view_domain: View summary for domain
+      view_instance: View instance
       warn: Warn
       web: Web
       whitelisted: Allowed for federation


### PR DESCRIPTION
This could improve navigation based on feedback from https://github.com/mastodon/mastodon/issues/29024, as the "View summary of domain" link just isn't really clear enough.

<img width="1300" alt="Screenshot 2024-08-17 at 21 43 18" src="https://github.com/user-attachments/assets/b551ec3a-2191-4bb6-9bc0-b1335e40bc11">
