### PR TITLE
Fix compose file for independent streaming image

### DIFF
--- a/.github/workflows/build-releases.yml
+++ b/.github/workflows/build-releases.yml
@@ -30,7 +30,7 @@ jobs:
     secrets: inherit
 
   build-image-streaming:
-    if: startsWith(github.ref, 'refs/tags/v4.3.')
+    if: startsWith(github.ref, 'refs/tags/v4.2.')
     uses: ./.github/workflows/build-container-image.yml
     with:
       file_to_build: streaming/Dockerfile
@@ -44,7 +44,7 @@ jobs:
       # Only tag with latest when ran against the latest stable branch
       # This needs to be updated after each minor version release
       flavor: |
-        latest=${{ startsWith(github.ref, 'refs/tags/v4.3.') }}
+        latest=${{ startsWith(github.ref, 'refs/tags/v4.2.') }}
       tags: |
         type=pep440,pattern={{raw}}
         type=pep440,pattern=v{{major}}.{{minor}}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,11 +78,12 @@ services:
       - ./public/system:/mastodon/public/system
 
   streaming:
-    build: .
-    image: ghcr.io/mastodon/mastodon:v4.2.11
+    build:
+      context: .
+      dockerfile: streaming/Dockerfile
+    image: ghcr.io/mastodon/mastodon-streaming:v4.2.11
     restart: always
     env_file: .env.production
-    command: node ./streaming
     networks:
       - external_network
       - internal_network


### PR DESCRIPTION
This is a follow up to a80530d1df39f549b3fa2e4f84669c4851bea443

I was unable to bring my instance up after that without this change.
I'm not sure if the "v4.3" in the build-workflow was intended, but given that the normal image does not seem to work for the streaming-service anymore, it seems v4.2.x images are needed?