### PR TITLE
Fix broken notifications for mentions from local moderators in 4.2.11

### DIFF
--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -87,7 +87,7 @@ class NotifyService < BaseService
 
   def from_staff?
     sender = @notification.from_account
-    sender.local? && sender.user.present? && sender.user_role&.overrides?(@recipient.user_role) && @sender.user_role&.highlighted? && sender.user_role&.can?(*UserRole::Flags::CATEGORIES[:moderation])
+    sender.local? && sender.user.present? && sender.user_role&.overrides?(@recipient.user_role) && sender.user_role&.highlighted? && sender.user_role&.can?(*UserRole::Flags::CATEGORIES[:moderation].map(&:to_sym))
   end
 
   def optional_non_following_and_direct?

--- a/spec/services/notify_service_spec.rb
+++ b/spec/services/notify_service_spec.rb
@@ -18,6 +18,17 @@ RSpec.describe NotifyService, type: :service do
     expect { subject }.to_not change(Notification, :count)
   end
 
+  context 'when the sender is a local moderator' do
+    let(:sender) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
+    let(:type) { :mention }
+    let(:activity) { Fabricate(:mention, account: recipient, status: Fabricate(:status, account: sender)) }
+
+    it 'does notify when the sender is blocked' do
+      recipient.block!(sender)
+      expect { subject }.to change(Notification, :count).by(1)
+    end
+  end
+
   it 'does not notify when sender is muted with hide_notifications' do
     recipient.mute!(sender, notifications: true)
     expect { subject }.to_not change(Notification, :count)


### PR DESCRIPTION
This was caused by an incorrect backport of #31271 to v4.2.11.