### PR TITLE
Use Dockerfile ADD to obtain ffmpeg and libvips source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -196,11 +196,14 @@ ARG VIPS_VERSION=8.15.3
 ARG VIPS_URL=https://github.com/libvips/libvips/releases/download
 
 WORKDIR /usr/local/libvips/src
+# Download and extract libvips source code
+ADD ${VIPS_URL}/v${VIPS_VERSION}/vips-${VIPS_VERSION}.tar.xz /usr/local/libvips/src/
+RUN tar xf vips-${VIPS_VERSION}.tar.xz;
 
+WORKDIR /usr/local/libvips/src/vips-${VIPS_VERSION}
+
+# Configure and compile libvips
 RUN \
-  curl -sSL -o vips-${VIPS_VERSION}.tar.xz ${VIPS_URL}/v${VIPS_VERSION}/vips-${VIPS_VERSION}.tar.xz; \
-  tar xf vips-${VIPS_VERSION}.tar.xz; \
-  cd vips-${VIPS_VERSION}; \
   meson setup build --prefix /usr/local/libvips --libdir=lib -Ddeprecated=false -Dintrospection=disabled -Dmodules=disabled -Dexamples=false; \
   cd build; \
   ninja; \
@@ -216,11 +219,14 @@ ARG FFMPEG_VERSION=7.0.2
 ARG FFMPEG_URL=https://ffmpeg.org/releases
 
 WORKDIR /usr/local/ffmpeg/src
+# Download and extract ffmpeg source code
+ADD ${FFMPEG_URL}/ffmpeg-${FFMPEG_VERSION}.tar.xz /usr/local/ffmpeg/src/
+RUN tar xf ffmpeg-${FFMPEG_VERSION}.tar.xz;
 
+WORKDIR /usr/local/ffmpeg/src/ffmpeg-${FFMPEG_VERSION}
+
+# Configure and compile ffmpeg
 RUN \
-  curl -sSL -o ffmpeg-${FFMPEG_VERSION}.tar.xz ${FFMPEG_URL}/ffmpeg-${FFMPEG_VERSION}.tar.xz; \
-  tar xf ffmpeg-${FFMPEG_VERSION}.tar.xz; \
-  cd ffmpeg-${FFMPEG_VERSION}; \
   ./configure \
     --prefix=/usr/local/ffmpeg \
     --toolchain=hardened \


### PR DESCRIPTION
Changes the method of obtaining the ffmpeg and libvips source tarballs from executing curl inside of the container, to the Docker Build ADD command which should help with caching the source files and reduce the need to redownload on every execution -- and in my experience the ffmpeg site can be very slow at times. Separates the tar extraction from the build commands to help with caching that process.