### PR TITLE
Remove unused `fa_icon` helper method

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -105,14 +105,6 @@ module ApplicationHelper
     policy(record).public_send(:"#{action}?")
   end
 
-  def fa_icon(icon, attributes = {})
-    class_names = attributes[:class]&.split || []
-    class_names << 'fa'
-    class_names += icon.split.map { |cl| "fa-#{cl}" }
-
-    content_tag(:i, nil, attributes.merge(class: class_names.join(' ')))
-  end
-
   def material_symbol(icon, attributes = {})
     inline_svg_tag(
       "400-24px/#{icon}.svg",

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -53,12 +53,6 @@ describe ApplicationHelper do
     end
   end
 
-  describe 'fa_icon' do
-    it 'returns a tag of fixed-width cog' do
-      expect(helper.fa_icon('cog fw')).to eq '<i class="fa fa-cog fa-fw"></i>'
-    end
-  end
-
   describe '#material_symbol' do
     it 'returns an svg with the icon and options' do
       expect(helper.material_symbol('lock', class: :test, data: { hidden: true }))


### PR DESCRIPTION
The latest merged batch of PRs removed all remaining usage of this helper.

Still to do:

- Go through css and remove all `.fa ...` or `.fa-` styles (check each one to be sure we don't need to re-create whatever they were doing for the material symbols)
- Remove font-awesome js package and any imports/usage left on JS side