### PR TITLE
Include `TEST_ENV_NUMBER` as part of file storage path in test environment

### DIFF
--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -160,13 +160,8 @@ elsif ENV['AZURE_ENABLED'] == 'true'
     )
   end
 else
-  if ENV['TEST_ENV_NUMBER']
-    path_suffix = "test-env-#{ENV['TEST_ENV_NUMBER']}"
-    default_root_url = "/system/#{path_suffix}"
-  else
-    path_suffix = nil
-    default_root_url = '/system'
-  end
+  path_suffix = ENV['TEST_ENV_NUMBER'].present? ? "test-env-#{ENV['TEST_ENV_NUMBER']}" : nil
+  default_root_url = ['/system', path_suffix].compact.join('/')
 
   Rails.configuration.x.file_storage_root_path = ENV.fetch(
     'PAPERCLIP_ROOT_PATH',

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -160,11 +160,23 @@ elsif ENV['AZURE_ENABLED'] == 'true'
     )
   end
 else
-  Rails.configuration.x.file_storage_root_path = ENV.fetch('PAPERCLIP_ROOT_PATH', File.join(':rails_root', 'public', 'system'))
+  if ENV['TEST_ENV_NUMBER']
+    path_suffix = "test-env-#{ENV['TEST_ENV_NUMBER']}"
+    default_root_url = "/system/#{path_suffix}"
+  else
+    path_suffix = nil
+    default_root_url = '/system'
+  end
+
+  Rails.configuration.x.file_storage_root_path = ENV.fetch(
+    'PAPERCLIP_ROOT_PATH',
+    File.join(%w(:rails_root public system).push(path_suffix).compact)
+  )
+
   Paperclip::Attachment.default_options.merge!(
     storage: :filesystem,
     path: File.join(Rails.configuration.x.file_storage_root_path, ':prefix_path:class', ':attachment', ':id_partition', ':style', ':filename'),
-    url: ENV.fetch('PAPERCLIP_ROOT_URL', '/system') + "/#{PATH}"
+    url: ENV.fetch('PAPERCLIP_ROOT_URL', default_root_url) + "/#{PATH}"
   )
 end
 

--- a/spec/lib/mastodon/cli/media_spec.rb
+++ b/spec/lib/mastodon/cli/media_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe Mastodon::CLI::Media do
     let(:action) { :remove_orphans }
 
     before do
-      FileUtils.mkdir_p Rails.public_path.join('system')
+      FileUtils.mkdir_p Rails.configuration.x.file_storage_root_path
     end
 
     context 'without any options' do


### PR DESCRIPTION
A few related changes:

- The paperclip initializer and CLI/media class have repeated logic about finding the file storage root path ... pull this out to a `configuration.x...` setting which they can then both use (would be happy to do this as stand-alone PR first if we want to eparate out the "consolidate config" aspect from the next item)
- When running in test env, include the `Process.id` value in the file storage root path -- I suspect this will fix some of the intermittent failures around things like media processing, directory cleanup, etc if my guess (that one process is cleaning up something while another is using it) is right there.

I believe that this preserves the non-test-env filesystem-based settings as before, which probably makes this relatively low risk (ie, if there are code paths which are in some way hard coding this path expectation and not relying on the config, they'd only break in test env?)

If this does not merge before the various open `config_for` PRs, we may want to rework this to move the setting into one of those themed around file storage vars.