### PR TITLE
Fix boost dialog visibility selection not being taken into account

### DIFF
--- a/app/javascript/mastodon/actions/interactions.js
+++ b/app/javascript/mastodon/actions/interactions.js
@@ -437,12 +437,12 @@ export function unpinFail(status, error) {
   };
 }
 
-function toggleReblogWithoutConfirmation(status, privacy) {
+function toggleReblogWithoutConfirmation(status, visibility) {
   return (dispatch) => {
     if (status.get('reblogged')) {
       dispatch(unreblog({ statusId: status.get('id') }));
     } else {
-      dispatch(reblog({ statusId: status.get('id'), privacy }));
+      dispatch(reblog({ statusId: status.get('id'), visibility }));
     }
   };
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/5033b978-b8cf-4c9b-8d23-f3eb6f37b5d4)

The visibility choices in the boost dialog are not working. Currently, the default visibility is always used even if visibility is changed. This is a problem with the web client.