### PR TITLE
Fix distracting and confusing always-showing scrollbar track in boost confirmation modal

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -6247,7 +6247,7 @@ a.status-card {
 }
 
 .boost-modal__container {
-  overflow-x: scroll;
+  overflow-y: auto;
   padding: 10px;
 
   .status {


### PR DESCRIPTION
This has been here from 2017, introduced by https://github.com/mastodon/mastodon/pull/1710, but never as noticeable as it is now with the color changes.

My understanding from the original issue is that it should have been an `overflow-y`, not `overflow-x`. Furthermore, it does not need to be unconditionally shown.

## Before

![image](https://github.com/user-attachments/assets/df71431f-5df2-4957-ac0d-fe4a2cfe98a5)

## After

![image](https://github.com/user-attachments/assets/b349bb65-06a8-4e19-9e91-dd531c417314)

