### PR TITLE
Fix invalid date searches returning 503

### DIFF
--- a/app/lib/search_query_transformer.rb
+++ b/app/lib/search_query_transformer.rb
@@ -168,15 +168,15 @@ class SearchQueryTransformer < Parslet::Transform
       when 'before'
         @filter = :created_at
         @type = :range
-        @term = { lt: TermValidator::validate_date!(term), time_zone: @options[:current_account]&.user_time_zone.presence || 'UTC' }
+        @term = { lt: TermValidator.validate_date!(term), time_zone: @options[:current_account]&.user_time_zone.presence || 'UTC' }
       when 'after'
         @filter = :created_at
         @type = :range
-        @term = { gt: TermValidator::validate_date!(term), time_zone: @options[:current_account]&.user_time_zone.presence || 'UTC' }
+        @term = { gt: TermValidator.validate_date!(term), time_zone: @options[:current_account]&.user_time_zone.presence || 'UTC' }
       when 'during'
         @filter = :created_at
         @type = :range
-        @term = { gte: TermValidator::validate_date!(term), lte: TermValidator::validate_date!(term), time_zone: @options[:current_account]&.user_time_zone.presence || 'UTC' }
+        @term = { gte: TermValidator.validate_date!(term), lte: TermValidator.validate_date!(term), time_zone: @options[:current_account]&.user_time_zone.presence || 'UTC' }
       when 'in'
         @operator = :flag
         @term = term
@@ -229,7 +229,7 @@ class SearchQueryTransformer < Parslet::Transform
     EPOCH_MILLIS_REGEX = /\A\d{1,19}\z/
 
     def self.validate_date!(value)
-      return value if (value.match?(STRICT_DATE_REGEX) || value.match?(EPOCH_MILLIS_REGEX))
+      return value if value.match?(STRICT_DATE_REGEX) || value.match?(EPOCH_MILLIS_REGEX)
 
       raise Mastodon::FilterValidationError, "Invalid date #{value}"
     end

--- a/app/lib/search_query_transformer.rb
+++ b/app/lib/search_query_transformer.rb
@@ -168,15 +168,15 @@ class SearchQueryTransformer < Parslet::Transform
       when 'before'
         @filter = :created_at
         @type = :range
-        @term = { lt: term, time_zone: @options[:current_account]&.user_time_zone.presence || 'UTC' }
+        @term = { lt: TermValidator::validate_date!(term), time_zone: @options[:current_account]&.user_time_zone.presence || 'UTC' }
       when 'after'
         @filter = :created_at
         @type = :range
-        @term = { gt: term, time_zone: @options[:current_account]&.user_time_zone.presence || 'UTC' }
+        @term = { gt: TermValidator::validate_date!(term), time_zone: @options[:current_account]&.user_time_zone.presence || 'UTC' }
       when 'during'
         @filter = :created_at
         @type = :range
-        @term = { gte: term, lte: term, time_zone: @options[:current_account]&.user_time_zone.presence || 'UTC' }
+        @term = { gte: TermValidator::validate_date!(term), lte: TermValidator::validate_date!(term), time_zone: @options[:current_account]&.user_time_zone.presence || 'UTC' }
       when 'in'
         @operator = :flag
         @term = term
@@ -221,6 +221,14 @@ class SearchQueryTransformer < Parslet::Transform
       return language_code if LanguagesHelper::SUPPORTED_LOCALES.key?(language_code.to_sym)
 
       term
+    end
+  end
+
+  class TermValidator
+    def self.validate_date!(value)
+      return value if (value.match?(/\A\d{4}-\d{2}-\d{2}(\s\d{2}:\d{2})?\z/) || value.match?(/\A\d{1,11}\z/))
+
+      raise Mastodon::FilterValidationError, "Invalid date #{value}"
     end
   end
 

--- a/app/lib/search_query_transformer.rb
+++ b/app/lib/search_query_transformer.rb
@@ -226,7 +226,7 @@ class SearchQueryTransformer < Parslet::Transform
 
   class TermValidator
     STRICT_DATE_REGEX = /\A\d{4}-\d{2}-\d{2}\z/ # yyyy-MM-dd
-    EPOCH_MILLIS_REGEX = /\A\d{1,11}\z/
+    EPOCH_MILLIS_REGEX = /\A\d{1,19}\z/
 
     def self.validate_date!(value)
       return value if (value.match?(STRICT_DATE_REGEX) || value.match?(EPOCH_MILLIS_REGEX))

--- a/app/lib/search_query_transformer.rb
+++ b/app/lib/search_query_transformer.rb
@@ -225,8 +225,11 @@ class SearchQueryTransformer < Parslet::Transform
   end
 
   class TermValidator
+    STRICT_DATE_REGEX = /\A\d{4}-\d{2}-\d{2}\z/ # yyyy-MM-dd
+    EPOCH_MILLIS_REGEX = /\A\d{1,11}\z/
+
     def self.validate_date!(value)
-      return value if (value.match?(/\A\d{4}-\d{2}-\d{2}(\s\d{2}:\d{2})?\z/) || value.match?(/\A\d{1,11}\z/))
+      return value if (value.match?(STRICT_DATE_REGEX) || value.match?(EPOCH_MILLIS_REGEX))
 
       raise Mastodon::FilterValidationError, "Invalid date #{value}"
     end

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -8,6 +8,7 @@ module Mastodon
   class LengthValidationError < ValidationError; end
   class DimensionsValidationError < ValidationError; end
   class StreamValidationError < ValidationError; end
+  class FilterValidationError < ValidationError; end
   class RaceConditionError < Error; end
   class RateLimitExceededError < Error; end
   class SyntaxError < Error; end

--- a/spec/lib/search_query_transformer_spec.rb
+++ b/spec/lib/search_query_transformer_spec.rb
@@ -77,4 +77,12 @@ describe SearchQueryTransformer do
       expect(subject.send(:filter_clauses).map(&:term)).to contain_exactly(lt: '2022-01-01 23:00', time_zone: 'UTC')
     end
   end
+
+  context 'with \'before:"abc"\'' do
+    let(:query) { 'before:"abc"' }
+
+    it 'raises an exception' do
+      expect { subject }.to raise_error(Mastodon::FilterValidationError, 'Invalid date abc')
+    end
+  end
 end

--- a/spec/lib/search_query_transformer_spec.rb
+++ b/spec/lib/search_query_transformer_spec.rb
@@ -12,22 +12,21 @@ describe SearchQueryTransformer do
     let(:statement_operations) { [] }
 
     [
-      ["2022-01-01", "2022-01-01"],
-      ["\"2022-01-01\"", "2022-01-01"],
-      ["12345678", "12345678"],
-      ["\"12345678\"", "12345678"]
+      ['2022-01-01', '2022-01-01'],
+      ['"2022-01-01"', '2022-01-01'],
+      ['12345678', '12345678'],
+      ['"12345678"', '12345678'],
     ].each do |value, parsed|
       context "with #{operator}:#{value}" do
         let(:query) { "#{operator}:#{value}" }
 
-        it "transforms clauses" do
-          ops = statement_operations.map { |op| [op, parsed] }.to_h
+        it 'transforms clauses' do
+          ops = statement_operations.index_with { |_op| parsed }
 
           expect(subject.send(:must_clauses)).to be_empty
           expect(subject.send(:must_not_clauses)).to be_empty
           expect(subject.send(:filter_clauses).map(&:term)).to contain_exactly(**ops, time_zone: 'UTC')
         end
-
       end
     end
 
@@ -111,19 +110,19 @@ describe SearchQueryTransformer do
   end
 
   context 'with date operators' do
-    context "before" do
+    context 'with "before"' do
       it_behaves_like 'date operator', 'before' do
         let(:statement_operations) { [:lt] }
       end
     end
 
-    context "after" do
+    context 'with "after"' do
       it_behaves_like 'date operator', 'after' do
         let(:statement_operations) { [:gt] }
       end
     end
 
-    context "during" do
+    context 'with "during"' do
       it_behaves_like 'date operator', 'during' do
         let(:statement_operations) { [:gte, :lte] }
       end

--- a/spec/lib/search_query_transformer_spec.rb
+++ b/spec/lib/search_query_transformer_spec.rb
@@ -68,13 +68,23 @@ describe SearchQueryTransformer do
     end
   end
 
-  context 'with \'before:"2022-01-01 23:00"\'' do
-    let(:query) { 'before:"2022-01-01 23:00"' }
+  context 'with \'is:"foo bar"\'' do
+    let(:query) { 'is:"foo bar"' }
 
     it 'transforms clauses' do
       expect(subject.send(:must_clauses)).to be_empty
       expect(subject.send(:must_not_clauses)).to be_empty
-      expect(subject.send(:filter_clauses).map(&:term)).to contain_exactly(lt: '2022-01-01 23:00', time_zone: 'UTC')
+      expect(subject.send(:filter_clauses).map(&:term)).to contain_exactly('foo bar')
+    end
+  end
+
+  context 'with \'before:"2022-01-01"\'' do
+    let(:query) { 'before:"2022-01-01"' }
+
+    it 'transforms clauses' do
+      expect(subject.send(:must_clauses)).to be_empty
+      expect(subject.send(:must_not_clauses)).to be_empty
+      expect(subject.send(:filter_clauses).map(&:term)).to contain_exactly(lt: '2022-01-01', time_zone: 'UTC')
     end
   end
 


### PR DESCRIPTION
Hitting the search controller with date queries returns 503 right now. For example, performing a search with `after:2020-01-011` will return a 503.

Per elasticsearch [date docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/date.html) only `"strict_date_optional_time||epoch_millis"` is supported (see [strict-date-time](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-date-format.html#strict-date-time)).

<img width="700" alt="image" src="https://github.com/user-attachments/assets/50116ae5-eca6-4e8f-aa28-0d48695685a9">

This change adds a validator that checks for these regexes, returning a 422 if invalid.

Another option would be to rescue, but it sounds like catching earlier [may be preferred earlier](https://github.com/mastodon/mastodon/pull/28256#issuecomment-1845036239) in the search context.
