### PR TITLE
Fix sort order of moderation notes on Reports and Accounts

### DIFF
--- a/app/controllers/admin/account_moderation_notes_controller.rb
+++ b/app/controllers/admin/account_moderation_notes_controller.rb
@@ -13,7 +13,7 @@ module Admin
         redirect_to admin_account_path(@account_moderation_note.target_account_id), notice: I18n.t('admin.account_moderation_notes.created_msg')
       else
         @account          = @account_moderation_note.target_account
-        @moderation_notes = @account.targeted_moderation_notes.latest
+        @moderation_notes = @account.targeted_moderation_notes.includes(:account)
         @warnings         = @account.strikes.custom.latest
 
         render 'admin/accounts/show'

--- a/app/controllers/admin/account_moderation_notes_controller.rb
+++ b/app/controllers/admin/account_moderation_notes_controller.rb
@@ -13,7 +13,7 @@ module Admin
         redirect_to admin_account_path(@account_moderation_note.target_account_id), notice: I18n.t('admin.account_moderation_notes.created_msg')
       else
         @account          = @account_moderation_note.target_account
-        @moderation_notes = @account.targeted_moderation_notes.includes(:account)
+        @moderation_notes = @account.targeted_moderation_notes.chronological.includes(:account)
         @warnings         = @account.strikes.custom.latest
 
         render 'admin/accounts/show'

--- a/app/controllers/admin/accounts_controller.rb
+++ b/app/controllers/admin/accounts_controller.rb
@@ -33,7 +33,7 @@ module Admin
 
       @deletion_request        = @account.deletion_request
       @account_moderation_note = current_account.account_moderation_notes.new(target_account: @account)
-      @moderation_notes        = @account.targeted_moderation_notes.includes(:account)
+      @moderation_notes        = @account.targeted_moderation_notes.chronological.includes(:account)
       @warnings                = @account.strikes.includes(:target_account, :account, :appeal).latest
       @domain_block            = DomainBlock.rule_for(@account.domain)
     end

--- a/app/controllers/admin/accounts_controller.rb
+++ b/app/controllers/admin/accounts_controller.rb
@@ -33,7 +33,7 @@ module Admin
 
       @deletion_request        = @account.deletion_request
       @account_moderation_note = current_account.account_moderation_notes.new(target_account: @account)
-      @moderation_notes        = @account.targeted_moderation_notes.latest
+      @moderation_notes        = @account.targeted_moderation_notes.includes(:account)
       @warnings                = @account.strikes.includes(:target_account, :account, :appeal).latest
       @domain_block            = DomainBlock.rule_for(@account.domain)
     end

--- a/app/controllers/admin/report_notes_controller.rb
+++ b/app/controllers/admin/report_notes_controller.rb
@@ -21,7 +21,7 @@ module Admin
 
         redirect_to after_create_redirect_path, notice: I18n.t('admin.report_notes.created_msg')
       else
-        @report_notes = @report.notes.includes(:account).latest
+        @report_notes = @report.notes.includes(:account)
         @action_logs  = @report.history.includes(:target)
         @form         = Admin::StatusBatchAction.new
         @statuses     = @report.statuses.with_includes

--- a/app/controllers/admin/report_notes_controller.rb
+++ b/app/controllers/admin/report_notes_controller.rb
@@ -21,7 +21,7 @@ module Admin
 
         redirect_to after_create_redirect_path, notice: I18n.t('admin.report_notes.created_msg')
       else
-        @report_notes = @report.notes.includes(:account).order(id: :desc)
+        @report_notes = @report.notes.includes(:account).latest
         @action_logs  = @report.history.includes(:target)
         @form         = Admin::StatusBatchAction.new
         @statuses     = @report.statuses.with_includes

--- a/app/controllers/admin/report_notes_controller.rb
+++ b/app/controllers/admin/report_notes_controller.rb
@@ -21,7 +21,7 @@ module Admin
 
         redirect_to after_create_redirect_path, notice: I18n.t('admin.report_notes.created_msg')
       else
-        @report_notes = @report.notes.includes(:account)
+        @report_notes = @report.notes.chronological.includes(:account)
         @action_logs  = @report.history.includes(:target)
         @form         = Admin::StatusBatchAction.new
         @statuses     = @report.statuses.with_includes

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -13,7 +13,7 @@ module Admin
       authorize @report, :show?
 
       @report_note  = @report.notes.new
-      @report_notes = @report.notes.includes(:account).latest
+      @report_notes = @report.notes.includes(:account)
       @action_logs  = @report.history.includes(:target)
       @form         = Admin::StatusBatchAction.new
       @statuses     = @report.statuses.with_includes

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -13,7 +13,7 @@ module Admin
       authorize @report, :show?
 
       @report_note  = @report.notes.new
-      @report_notes = @report.notes.includes(:account).order(id: :desc)
+      @report_notes = @report.notes.includes(:account).latest
       @action_logs  = @report.history.includes(:target)
       @form         = Admin::StatusBatchAction.new
       @statuses     = @report.statuses.with_includes

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -13,7 +13,7 @@ module Admin
       authorize @report, :show?
 
       @report_note  = @report.notes.new
-      @report_notes = @report.notes.includes(:account)
+      @report_notes = @report.notes.chronological.includes(:account)
       @action_logs  = @report.history.includes(:target)
       @form         = Admin::StatusBatchAction.new
       @statuses     = @report.statuses.with_includes

--- a/app/models/account_moderation_note.rb
+++ b/app/models/account_moderation_note.rb
@@ -18,7 +18,7 @@ class AccountModerationNote < ApplicationRecord
   belongs_to :account
   belongs_to :target_account, class_name: 'Account'
 
-  default_scope { reorder(id: :asc) }
+  scope :chronological, -> { reorder(id: :asc) }
 
   validates :content, presence: true, length: { maximum: CONTENT_SIZE_LIMIT }
 end

--- a/app/models/account_moderation_note.rb
+++ b/app/models/account_moderation_note.rb
@@ -18,7 +18,7 @@ class AccountModerationNote < ApplicationRecord
   belongs_to :account
   belongs_to :target_account, class_name: 'Account'
 
-  scope :latest, -> { reorder('created_at DESC') }
+  scope :latest, -> { reorder(id: :asc) }
 
   validates :content, presence: true, length: { maximum: CONTENT_SIZE_LIMIT }
 end

--- a/app/models/account_moderation_note.rb
+++ b/app/models/account_moderation_note.rb
@@ -18,7 +18,7 @@ class AccountModerationNote < ApplicationRecord
   belongs_to :account
   belongs_to :target_account, class_name: 'Account'
 
-  scope :latest, -> { reorder(id: :asc) }
+  default_scope { reorder(id: :asc) }
 
   validates :content, presence: true, length: { maximum: CONTENT_SIZE_LIMIT }
 end

--- a/app/models/report_note.rb
+++ b/app/models/report_note.rb
@@ -18,7 +18,7 @@ class ReportNote < ApplicationRecord
   belongs_to :account
   belongs_to :report, inverse_of: :notes, touch: true
 
-  scope :latest, -> { reorder(created_at: :desc) }
+  scope :latest, -> { reorder(id: :asc) }
 
   validates :content, presence: true, length: { maximum: CONTENT_SIZE_LIMIT }
 end

--- a/app/models/report_note.rb
+++ b/app/models/report_note.rb
@@ -18,7 +18,7 @@ class ReportNote < ApplicationRecord
   belongs_to :account
   belongs_to :report, inverse_of: :notes, touch: true
 
-  scope :latest, -> { reorder(id: :asc) }
+  default_scope { reorder(id: :asc) }
 
   validates :content, presence: true, length: { maximum: CONTENT_SIZE_LIMIT }
 end

--- a/app/models/report_note.rb
+++ b/app/models/report_note.rb
@@ -18,7 +18,7 @@ class ReportNote < ApplicationRecord
   belongs_to :account
   belongs_to :report, inverse_of: :notes, touch: true
 
-  default_scope { reorder(id: :asc) }
+  scope :chronological, -> { reorder(id: :asc) }
 
   validates :content, presence: true, length: { maximum: CONTENT_SIZE_LIMIT }
 end

--- a/spec/controllers/admin/account_moderation_notes_controller_spec.rb
+++ b/spec/controllers/admin/account_moderation_notes_controller_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe Admin::AccountModerationNotesController do
 
       it 'fails to create a note' do
         expect { subject }.to_not change(AccountModerationNote, :count)
+        expect(assigns(:moderation_notes).to_a).to eq []
         expect(response).to render_template 'admin/accounts/show'
       end
     end
@@ -38,6 +39,7 @@ RSpec.describe Admin::AccountModerationNotesController do
 
       it 'fails to create a note' do
         expect { subject }.to_not change(AccountModerationNote, :count)
+        expect(assigns(:moderation_notes).to_a).to eq []
         expect(response).to render_template 'admin/accounts/show'
       end
     end

--- a/spec/controllers/admin/account_moderation_notes_controller_spec.rb
+++ b/spec/controllers/admin/account_moderation_notes_controller_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe Admin::AccountModerationNotesController do
 
       it 'fails to create a note' do
         expect { subject }.to_not change(AccountModerationNote, :count)
-        expect(assigns(:moderation_notes).to_a).to eq []
         expect(response).to render_template 'admin/accounts/show'
       end
     end
@@ -39,7 +38,6 @@ RSpec.describe Admin::AccountModerationNotesController do
 
       it 'fails to create a note' do
         expect { subject }.to_not change(AccountModerationNote, :count)
-        expect(assigns(:moderation_notes).to_a).to eq []
         expect(response).to render_template 'admin/accounts/show'
       end
     end

--- a/spec/controllers/admin/accounts_controller_spec.rb
+++ b/spec/controllers/admin/accounts_controller_spec.rb
@@ -55,6 +55,23 @@ RSpec.describe Admin::AccountsController do
   describe 'GET #show' do
     let(:current_user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
 
+    describe 'account moderation notes' do
+      let(:account) { Fabricate(:account) }
+
+      it 'includes moderation notes' do
+        note1 = Fabricate(:account_moderation_note, target_account: account)
+        note2 = Fabricate(:account_moderation_note, target_account: account)
+
+        get :show, params: { id: account.id }
+        expect(response).to have_http_status(200)
+
+        moderation_notes = assigns(:moderation_notes).to_a
+
+        expect(moderation_notes.size).to be 2
+        expect(moderation_notes).to eq [note1, note2]
+      end
+    end
+
     context 'with a remote account' do
       let(:account) { Fabricate(:account, domain: 'example.com') }
 

--- a/spec/controllers/admin/reports_controller_spec.rb
+++ b/spec/controllers/admin/reports_controller_spec.rb
@@ -47,6 +47,24 @@ RSpec.describe Admin::ReportsController do
       expect(response.body)
         .to include(report.comment)
     end
+
+    describe 'account moderation notes' do
+      let(:report) { Fabricate(:report) }
+
+      it 'includes moderation notes' do
+        note1 = Fabricate(:report_note, report: report)
+        note2 = Fabricate(:report_note, report: report)
+
+        get :show, params: { id: report }
+
+        expect(response).to have_http_status(200)
+
+        report_notes = assigns(:report_notes).to_a
+
+        expect(report_notes.size).to be 2
+        expect(report_notes).to eq [note1, note2]
+      end
+    end
   end
 
   describe 'POST #resolve' do

--- a/spec/fabricators/account_moderation_note_fabricator.rb
+++ b/spec/fabricators/account_moderation_note_fabricator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Fabricator(:account_moderation_note) do
-  content 'MyText'
+  content { Faker::Lorem.sentences }
   account { Fabricate.build(:account) }
   target_account { Fabricate.build(:account) }
 end

--- a/spec/fabricators/report_note_fabricator.rb
+++ b/spec/fabricators/report_note_fabricator.rb
@@ -3,5 +3,5 @@
 Fabricator(:report_note) do
   report { Fabricate.build(:report) }
   account { Fabricate.build(:account) }
-  content 'Test Content'
+  content { Faker::Lorem.sentences }
 end

--- a/spec/models/account_moderation_note_spec.rb
+++ b/spec/models/account_moderation_note_spec.rb
@@ -3,13 +3,13 @@
 require 'rails_helper'
 
 RSpec.describe AccountModerationNote do
-  describe 'default scope' do
+  describe 'chronological scope' do
     it 'returns account moderation notes oldest to newest' do
       account = Fabricate(:account)
       note1 = Fabricate(:account_moderation_note, target_account: account)
       note2 = Fabricate(:account_moderation_note, target_account: account)
 
-      expect(account.targeted_moderation_notes).to eq [note1, note2]
+      expect(account.targeted_moderation_notes.chronological).to eq [note1, note2]
     end
   end
 

--- a/spec/models/account_moderation_note_spec.rb
+++ b/spec/models/account_moderation_note_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AccountModerationNote do
+  describe 'latest scope' do
+    it 'returns account moderation notes oldest to newest' do
+      account = Fabricate(:account)
+      note1 = Fabricate(:account_moderation_note, target_account: account)
+      note2 = Fabricate(:account_moderation_note, target_account: account)
+
+      expect(account.targeted_moderation_notes.latest).to eq [note1, note2]
+    end
+  end
+
+  describe 'validations' do
+    it 'is invalid if the content is empty' do
+      report = Fabricate.build(:account_moderation_note, content: '')
+      expect(report.valid?).to be false
+    end
+
+    it 'is invalid if content is longer than character limit' do
+      report = Fabricate.build(:account_moderation_note, content: comment_over_limit)
+      expect(report.valid?).to be false
+    end
+
+    def comment_over_limit
+      Faker::Lorem.paragraph_by_chars(number: described_class::CONTENT_SIZE_LIMIT * 2)
+    end
+  end
+end

--- a/spec/models/account_moderation_note_spec.rb
+++ b/spec/models/account_moderation_note_spec.rb
@@ -3,13 +3,13 @@
 require 'rails_helper'
 
 RSpec.describe AccountModerationNote do
-  describe 'latest scope' do
+  describe 'default scope' do
     it 'returns account moderation notes oldest to newest' do
       account = Fabricate(:account)
       note1 = Fabricate(:account_moderation_note, target_account: account)
       note2 = Fabricate(:account_moderation_note, target_account: account)
 
-      expect(account.targeted_moderation_notes.latest).to eq [note1, note2]
+      expect(account.targeted_moderation_notes).to eq [note1, note2]
     end
   end
 

--- a/spec/models/report_note_spec.rb
+++ b/spec/models/report_note_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ReportNote do
+  describe 'latest scope' do
+    it 'returns report notes oldest to newest' do
+      report = Fabricate(:report)
+      note1 = Fabricate(:report_note, report: report)
+      note2 = Fabricate(:report_note, report: report)
+
+      expect(report.notes.latest).to eq [note1, note2]
+    end
+  end
+
+  describe 'validations' do
+    it 'is invalid if the content is empty' do
+      report = Fabricate.build(:report_note, content: '')
+      expect(report.valid?).to be false
+    end
+
+    it 'is invalid if content is longer than character limit' do
+      report = Fabricate.build(:report_note, content: comment_over_limit)
+      expect(report.valid?).to be false
+    end
+
+    def comment_over_limit
+      Faker::Lorem.paragraph_by_chars(number: described_class::CONTENT_SIZE_LIMIT * 2)
+    end
+  end
+end

--- a/spec/models/report_note_spec.rb
+++ b/spec/models/report_note_spec.rb
@@ -3,13 +3,13 @@
 require 'rails_helper'
 
 RSpec.describe ReportNote do
-  describe 'default scope' do
+  describe 'chronological scope' do
     it 'returns report notes oldest to newest' do
       report = Fabricate(:report)
       note1 = Fabricate(:report_note, report: report)
       note2 = Fabricate(:report_note, report: report)
 
-      expect(report.notes).to eq [note1, note2]
+      expect(report.notes.chronological).to eq [note1, note2]
     end
   end
 

--- a/spec/models/report_note_spec.rb
+++ b/spec/models/report_note_spec.rb
@@ -3,13 +3,13 @@
 require 'rails_helper'
 
 RSpec.describe ReportNote do
-  describe 'latest scope' do
+  describe 'default scope' do
     it 'returns report notes oldest to newest' do
       report = Fabricate(:report)
       note1 = Fabricate(:report_note, report: report)
       note2 = Fabricate(:report_note, report: report)
 
-      expect(report.notes.latest).to eq [note1, note2]
+      expect(report.notes).to eq [note1, note2]
     end
   end
 


### PR DESCRIPTION
In #9630 the sort order was accidentally reversed for report notes. When account moderation notes where added in #5240, the sort order was different to the sort order used on report notes.

This meant that the note directly above the textarea to add a note was actually the oldest note, not the latest note. Typically when a form is at the end of a list of items, you'd expect submitting it to append to the list, not prepend.

This was likely the source of some confusion in the report and account moderation UI, where things just didn't appear in the right order.

As there was no test coverage, I've add some.

Previous behavior:

<img width="856" alt="Screenshot 2024-08-21 at 22 03 50" src="https://github.com/user-attachments/assets/92ddd16e-d144-43e3-bce3-14f093829704">

Expected behavior:

<img width="855" alt="Screenshot 2024-08-21 at 22 03 16" src="https://github.com/user-attachments/assets/3403a464-c1f4-48e5-ac93-fc6b88ecaf7f">
