### PR TITLE
Align sign-up rate limits between API and Web UI

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -86,7 +86,7 @@ class Rack::Attack
     req.throttleable_remote_ip if req.path.start_with?('/media_proxy')
   end
 
-  throttle('throttle_api_sign_up', limit: 5, period: 30.minutes) do |req|
+  throttle('throttle_api_sign_up', limit: 15, period: 15.minutes) do |req|
     req.throttleable_remote_ip if req.post? && req.path == '/api/v1/accounts'
   end
 
@@ -109,7 +109,7 @@ class Rack::Attack
     req.throttleable_remote_ip if req.post? && req.path == '/api/v1/apps'
   end
 
-  throttle('throttle_sign_up_attempts/ip', limit: 25, period: 5.minutes) do |req|
+  throttle('throttle_sign_up_attempts/ip', limit: 15, period: 15.minutes) do |req|
     req.throttleable_remote_ip if req.post? && req.path_matches?('/auth')
   end
 

--- a/spec/config/initializers/rack/attack_spec.rb
+++ b/spec/config/initializers/rack/attack_spec.rb
@@ -74,8 +74,8 @@ describe Rack::Attack, type: :request do
   describe 'throttle excessive sign-up requests by IP address' do
     context 'when accessed through the website' do
       let(:throttle) { 'throttle_sign_up_attempts/ip' }
-      let(:limit)  { 25 }
-      let(:period) { 5.minutes }
+      let(:limit)  { 15 }
+      let(:period) { 15.minutes }
       let(:request) { -> { post path, headers: { 'REMOTE_ADDR' => remote_ip } } }
 
       context 'with exact path' do
@@ -93,8 +93,8 @@ describe Rack::Attack, type: :request do
 
     context 'when accessed through the API' do
       let(:throttle) { 'throttle_api_sign_up' }
-      let(:limit)  { 5 }
-      let(:period) { 30.minutes }
+      let(:limit)  { 15 }
+      let(:period) { 15.minutes }
       let(:request) { -> { post path, headers: { 'REMOTE_ADDR' => remote_ip } } }
 
       context 'with exact path' do


### PR DESCRIPTION
I noticed in https://github.com/mastodon/mastodon/issues/16043#issuecomment-2237827570 that we currently have different rate limits in place for signups depending on if they're through the API or through the Web UI.

This aligns these two to use the same values.

Why 15 requests in 15 minutes? Because during signup, users may encounter errors (e.g., username taken, invalid email, etc). Arguably we could lower these further, but that could pose issues for signups on shared networks (like schools or universities)