### PR TITLE
Add button to view the Hashtag on the instance from Hashtags in Moderation UI

### DIFF
--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -248,6 +248,11 @@ $content-width: 840px;
         display: inline-flex;
         flex-flow: wrap;
         gap: 5px;
+        align-items: center;
+
+        .time-period {
+          padding: 0 10px;
+        }
       }
 
       h2 small {

--- a/app/views/admin/tags/show.html.haml
+++ b/app/views/admin/tags/show.html.haml
@@ -3,9 +3,12 @@
 
 - content_for :heading_actions do
   - if current_user.can?(:view_dashboard)
-    = l(@time_period.first)
-    = ' - '
-    = l(@time_period.last)
+    .time-period
+      = l(@time_period.first)
+      = ' - '
+      = l(@time_period.last)
+
+  = link_to t('admin.tags.open'), tag_url(@tag), class: 'button', target: '_blank', rel: 'noopener noreferrer'
 
 - if current_user.can?(:view_dashboard)
   .dashboard

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -898,6 +898,7 @@ en:
       name: Name
       newest: Newest
       oldest: Oldest
+      open: View Publicly
       reset: Reset
       review: Review status
       search: Search


### PR DESCRIPTION
This was proposed in #17059, and makes sense given the ability to search for hashtags that landed in #30880.

<img width="923" alt="Screenshot 2024-08-22 at 00 20 21" src="https://github.com/user-attachments/assets/028bde95-5f15-411b-b86c-4fab59d2b32c">
