### PR TITLE
Hide multiple selection bar for notification requests when no notificion requests are loaded

### DIFF
--- a/app/javascript/mastodon/features/notifications/requests.jsx
+++ b/app/javascript/mastodon/features/notifications/requests.jsx
@@ -217,7 +217,9 @@ export const NotificationRequests = ({ multiColumn }) => {
         multiColumn={multiColumn}
         showBackButton
         appendContent={
-          <SelectRow selectionMode={selectionMode} setSelectionMode={setSelectionMode} selectAllChecked={selectAllChecked} toggleSelectAll={toggleSelectAll} selectedItems={checkedRequestIds} />}
+          notificationRequests.size > 0 && (
+            <SelectRow selectionMode={selectionMode} setSelectionMode={setSelectionMode} selectAllChecked={selectAllChecked} toggleSelectAll={toggleSelectAll} selectedItems={checkedRequestIds} />
+          )}
       >
         <ColumnSettings />
       </ColumnHeader>


### PR DESCRIPTION
The multiple selection bar is confusing when there is nothing at all to select…

Fixes #31534