### PR TITLE
Fix unnecessary “next” link when API returns fewer notification requests than requested

### DIFF
--- a/app/controllers/api/v1/notifications/requests_controller.rb
+++ b/app/controllers/api/v1/notifications/requests_controller.rb
@@ -75,11 +75,15 @@ class Api::V1::Notifications::RequestsController < Api::BaseController
   end
 
   def next_path
-    api_v1_notifications_requests_url pagination_params(max_id: pagination_max_id) unless @requests.empty?
+    api_v1_notifications_requests_url pagination_params(max_id: pagination_max_id) if records_continue?
   end
 
   def prev_path
     api_v1_notifications_requests_url pagination_params(min_id: pagination_since_id) unless @requests.empty?
+  end
+
+  def records_continue?
+    @requests.size == limit_param(DEFAULT_ACCOUNTS_LIMIT)
   end
 
   def pagination_max_id


### PR DESCRIPTION
Using the same pattern as in various paginated controllers.