### PR TITLE
Change output format of `repo:changelog` task

### DIFF
--- a/lib/tasks/repo.rake
+++ b/lib/tasks/repo.rake
@@ -49,24 +49,32 @@ namespace :repo do
       File.open(path, 'r') do |file|
         file.each_line do |line|
           if line.start_with?('-')
-            new_line = line.gsub(/[(]#([[:digit:]]+)[)]\Z/) do |pull_request_reference|
-              pull_request_number = pull_request_reference[2..-2]
+            new_line = line.gsub(/\(#([[:digit:]]+)(, #([[:digit:]]+))*\)\Z/) do |pull_requests_string|
+              pull_requests = pull_requests_string[1...-1].split(',').map { |pr_id| pr_id.strip[1...] }
               response = nil
 
-              loop do
-                response = HTTP.headers('Authorization' => "token #{ENV['GITHUB_API_TOKEN']}").get("https://api.github.com/repos/#{REPOSITORY_NAME}/pulls/#{pull_request_number}")
+              authors = pull_requests.map do |pull_request_number|
+                response = nil
 
-                if response.code == 403
-                  sleep_for = (response.headers['X-RateLimit-Reset'].to_i - Time.now.to_i).abs
-                  puts "Sleeping for #{sleep_for} seconds to get over rate limit"
-                  sleep sleep_for
-                else
-                  break
+                loop do
+                  response = HTTP.headers('Authorization' => "token #{ENV['GITHUB_API_TOKEN']}").get("https://api.github.com/repos/#{REPOSITORY_NAME}/pulls/#{pull_request_number}")
+
+                  if response.code == 403
+                    sleep_for = (response.headers['X-RateLimit-Reset'].to_i - Time.now.to_i).abs
+                    puts "Sleeping for #{sleep_for} seconds to get over rate limit"
+                    sleep sleep_for
+                  else
+                    break
+                  end
                 end
+
+                pull_request = Oj.load(response.to_s)
+                pull_request['user']['login']
               end
 
-              pull_request = Oj.load(response.to_s)
-              "([#{pull_request['user']['login']}](#{pull_request['html_url']}))"
+              authors.sort!.uniq!
+
+              "(#{pull_requests.map { |pr| "##{pr}" }.join(', ')} by #{authors.map { |author| "@#{author}" }.join(', ')})"
             end
 
             tmp.puts new_line

--- a/lib/tasks/repo.rake
+++ b/lib/tasks/repo.rake
@@ -74,7 +74,7 @@ namespace :repo do
 
               authors.sort!.uniq!
 
-              "(#{pull_requests.map { |pr| "##{pr}" }.join(', ')} by #{authors.map { |author| "@#{author}" }.join(', ')})"
+              "(#{pull_requests.map { |pr| "##{pr}" }.to_sentence} by #{authors.map { |author| "@#{author}" }.to_sentence})"
             end
 
             tmp.puts new_line


### PR DESCRIPTION
This changes the format from:
```md
-  Changelog entry title ([@author](https://github.com/mastodon/mastodon/pull/1234))
```

To:
```md
- Changelog entry title (#1234 by @author)
```

So that authors are mentioned in the release.

Furthermore, this changes the script to handle multiple PR identifiers in a single line and deduplicate authors so that:
```md
- Feature change (#1234, #1235, #1236)
```

gets processed as:
```md
- Feature change (#1234, #1235 and #1236 by @authorA and @authorB)
```