### PR TITLE
#31505 Add highlighted (boolean) column to tags

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -17,6 +17,7 @@
 #  max_score           :float
 #  max_score_at        :datetime
 #  display_name        :string
+#  highlighted         :boolean          default(FALSE), not null
 #
 
 class Tag < ApplicationRecord
@@ -48,6 +49,7 @@ class Tag < ApplicationRecord
   validate :validate_name_change, if: -> { !new_record? && name_changed? }
   validate :validate_display_name_change, if: -> { !new_record? && display_name_changed? }
 
+  scope :highlighted, -> { where(highlighted: true) }
   scope :reviewed, -> { where.not(reviewed_at: nil) }
   scope :unreviewed, -> { where(reviewed_at: nil) }
   scope :pending_review, -> { unreviewed.where.not(requested_review_at: nil) }

--- a/db/migrate/20240822171341_add_highlighted_to_tags.rb
+++ b/db/migrate/20240822171341_add_highlighted_to_tags.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddHighlightedToTags < ActiveRecord::Migration[7.1]
+  def change
+    add_column :tags, :highlighted, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_08_125420) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_22_171341) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -1131,6 +1131,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_08_125420) do
     t.float "max_score"
     t.datetime "max_score_at", precision: nil
     t.string "display_name"
+    t.boolean "highlighted", default: false, null: false
     t.index "lower((name)::text) text_pattern_ops", name: "index_tags_on_name_lower_btree", unique: true
   end
 


### PR DESCRIPTION
Proposal to consider adding the ability for instance admins to select tags for instance-level recommendation. #31505 

Unlike trending tags (which are algorithmic and represent the actual behavior of the users), highlighted tags are expected to a fixed set and meant for guiding the focus of the instance towards pre-selected topics. For example, once exposed via an API, these tags can be presented in a sidebar of topics (much like Slack or Discord).

Caveats:
- This is a boolean column, so it does not enable explicit ordering of topics.
- No work has been done towards the API design to expose these to the clients.
- No effort has been made to provide an admin UI for toggling these.


