### PR TITLE
WIP: Redesign reports list in moderation UI to improve clarity

### DIFF
--- a/app/helpers/admin/account_moderation_notes_helper.rb
+++ b/app/helpers/admin/account_moderation_notes_helper.rb
@@ -23,8 +23,6 @@ module Admin::AccountModerationNotesHelper
     )
   end
 
-  private
-
   def labeled_account_avatar(account)
     safe_join(
       [
@@ -34,6 +32,8 @@ module Admin::AccountModerationNotesHelper
       ' '
     )
   end
+
+  private
 
   def account_inline_text(account)
     content_tag(:span, account.acct, class: 'username')

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -906,6 +906,15 @@ a.name-tag,
       justify-content: flex-start;
       border-top: 1px solid var(--background-border-color);
 
+      &__report-id {
+        text-decoration: none;
+        color: $darker-text-color;
+
+        &:hover {
+          color: $highlight-text-color;
+        }
+      }
+
       &__reported-by,
       &__assigned {
         padding: 15px;

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -288,6 +288,10 @@ $content-width: 840px;
       padding-bottom: 8px;
       margin-bottom: 8px;
       border-bottom: 1px solid var(--background-border-color);
+
+      &.no-border {
+        border-bottom: none;
+      }
     }
 
     h6 {
@@ -938,6 +942,11 @@ a.name-tag,
         &__icon {
           margin-inline-end: 4px;
           font-weight: 500;
+
+          .name-tag {
+            color: inherit;
+            margin-inline-start: 4px;
+          }
         }
       }
 

--- a/app/views/admin/reports/index.html.haml
+++ b/app/views/admin/reports/index.html.haml
@@ -30,6 +30,8 @@
       %button.button= t('admin.accounts.search')
       = link_to t('admin.accounts.reset'), admin_reports_path, class: 'button negative'
 
+%h4 Reports by reported account
+
 - @reports.group_by(&:target_account_id).each_value do |reports|
   - target_account = reports.first.target_account
   .report-card
@@ -50,12 +52,9 @@
       - reports.each do |report|
         .report-card__summary__item
           .report-card__summary__item__reported-by
-            - if report.account.instance_actor?
-              = site_hostname
-            - elsif report.account.local?
-              = admin_account_link_to report.account
-            - else
-              = report.account.domain
+            = link_to t('admin.reports.report', id: report.id), admin_report_path(report), class: 'report-card__summary__item__report-id'
+            %br
+
           .report-card__summary__item__content
             = link_to admin_report_path(report) do
               .one-line= report.comment.presence || t('admin.reports.comment.none')
@@ -68,11 +67,25 @@
                 = material_symbol('photo_camera')
                 = report.media_attachments_count
 
+              %span.report-card__summary__item__content__icon{ title: }
+                - if report.account.instance_actor?
+                  = material_symbol('cloud')
+                  = site_hostname
+                - elsif report.account.local?
+                  = material_symbol('person')
+                  = report.account.acct
+                - else
+                  = material_symbol('cloud')
+                  = report.account.domain
+
               - if report.forwarded?
                 ·
                 = t('admin.reports.forwarded_to', domain: target_account.domain)
 
           .report-card__summary__item__assigned
+            %span.report-card__summary__item__content__icon{ title: t('admin.reports.notes.title') }
+              = material_symbol('comment')
+              = report.notes.count
             - if report.assigned_account.present?
               = admin_account_link_to report.assigned_account
             - else

--- a/app/views/admin/reports/index.html.haml
+++ b/app/views/admin/reports/index.html.haml
@@ -30,7 +30,7 @@
       %button.button= t('admin.accounts.search')
       = link_to t('admin.accounts.reset'), admin_reports_path, class: 'button negative'
 
-%h4 Reports by reported account
+%h4.no-border Reports grouped by reported account
 
 - @reports.group_by(&:target_account_id).each_value do |reports|
   - target_account = reports.first.target_account
@@ -54,6 +54,20 @@
           .report-card__summary__item__reported-by
             = link_to admin_report_path(report), class: 'report-card__summary__item__report-id' do
               .one-line= t('admin.reports.report', id: report.id)
+              - case report.category
+              - when 'legal'
+                Illegal
+              - when 'spam'
+                Spam
+              - when 'violation'
+                Rule Violation
+              - else
+                Other
+
+          .report-card__summary__item__content
+            = link_to admin_report_path(report) do
+              .one-line
+                = report.comment.presence || t('admin.reports.comment.none')
 
               %span.report-card__summary__item__content__icon{ title: t('admin.accounts.statuses') }
                 = material_symbol('comment')
@@ -62,26 +76,20 @@
               %span.report-card__summary__item__content__icon{ title: t('admin.accounts.media_attachments') }
                 = material_symbol('photo_camera')
                 = report.media_attachments_count
-
-          .report-card__summary__item__content
-            = link_to admin_report_path(report) do
-              .one-line= report.comment.presence || t('admin.reports.comment.none')
-
-
-              %span.report-card__summary__item__content__icon{ title: }
+              %span.report-card__summary__item__content__icon
                 - if report.account.instance_actor?
                   = material_symbol('cloud')
                   = site_hostname
                 - elsif report.account.local?
-                  = material_symbol('person')
-                  = report.account.acct
+                  .name-tag= labeled_account_avatar report.account
+                  -# = material_symbol('person')
+                    = report.account.acct
+                  - if report.forwarded?
+                    &bullet;
+                    = t('admin.reports.forwarded')
                 - else
                   = material_symbol('cloud')
                   = report.account.domain
-
-              - if report.forwarded?
-                ·
-                = t('admin.reports.forwarded_to', domain: target_account.domain)
 
           .report-card__summary__item__assigned
             %span.report-card__summary__item__content__icon{ title: t('admin.reports.notes.title') }
@@ -92,5 +100,5 @@
             - if report.assigned_account.present?
               = admin_account_link_to report.assigned_account
             - else
-              unassigned
+              = t 'admin.reports.unassigned'
 = paginate @reports

--- a/app/views/admin/reports/index.html.haml
+++ b/app/views/admin/reports/index.html.haml
@@ -52,12 +52,8 @@
       - reports.each do |report|
         .report-card__summary__item
           .report-card__summary__item__reported-by
-            = link_to t('admin.reports.report', id: report.id), admin_report_path(report), class: 'report-card__summary__item__report-id'
-            %br
-
-          .report-card__summary__item__content
-            = link_to admin_report_path(report) do
-              .one-line= report.comment.presence || t('admin.reports.comment.none')
+            = link_to admin_report_path(report), class: 'report-card__summary__item__report-id' do
+              .one-line= t('admin.reports.report', id: report.id)
 
               %span.report-card__summary__item__content__icon{ title: t('admin.accounts.statuses') }
                 = material_symbol('comment')
@@ -66,6 +62,11 @@
               %span.report-card__summary__item__content__icon{ title: t('admin.accounts.media_attachments') }
                 = material_symbol('photo_camera')
                 = report.media_attachments_count
+
+          .report-card__summary__item__content
+            = link_to admin_report_path(report) do
+              .one-line= report.comment.presence || t('admin.reports.comment.none')
+
 
               %span.report-card__summary__item__content__icon{ title: }
                 - if report.account.instance_actor?
@@ -86,8 +87,10 @@
             %span.report-card__summary__item__content__icon{ title: t('admin.reports.notes.title') }
               = material_symbol('comment')
               = report.notes.count
+              = t('admin.reports.notes.title')
+            %br
             - if report.assigned_account.present?
               = admin_account_link_to report.assigned_account
             - else
-              \-
+              unassigned
 = paginate @reports

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -614,7 +614,7 @@ en:
       category: Category
       category_description_html: The reason this account and/or content was reported will be cited in communication with the reported account
       comment:
-        none: None
+        none: No Comment
       comment_description_html: 'To provide more information, %{name} wrote:'
       confirm: Confirm
       confirm_action: Confirm moderation action against @%{acct}


### PR DESCRIPTION
This is a super rough work-in-progress, but I had a crack at trying to improve the report list items in the moderation UI. These design changes have been workshopped with the help of the Hachyderm Moderation team.

Do keep in mind that the top of the page for search & filter would change per #31449 

#### Current Design:

<img width="888" alt="Screenshot 2024-08-22 at 22 45 02" src="https://github.com/user-attachments/assets/9d3c2f05-0689-4f7d-844f-0ce50837780b">

#### Proposed Design

<img width="900" alt="Screenshot 2024-08-22 at 22 43 01" src="https://github.com/user-attachments/assets/6a830321-5af8-4755-8d45-bf0de0d6d6ba">

### Notable Changes

- Added back in Report ID, solving https://github.com/mastodon/mastodon/issues/9338
- Added count of Report Notes to show which reports have had interaction (whilst not being resolved yet)
- Changed text of the blank assignee to "unassigned" from "-", which previously looked like a bug.
- Changed text for missing comment to "No Comment" from "None"
- Added report category (with the caveat of #24968)
- Added heading to explain how the reports are grouped (since this isn't immediately obvious)
- **Removed** direct link to the reporting account from the list view — all too often you'd click that and end up on the accounts page, instead of on the report, where you most likely want to go.

### To Do

- [ ] Change "0 Notes" on reported account line to say "0 Account Notes"
- [ ] Clean up code changes
- [ ] Consider right aligning the Notes / Unassigned column
- [ ] Use localization for Report Category (currently these localizations only exist in the Web UI / javascript locales)

