### PR TITLE
Handle invalid visibility

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -52,7 +52,7 @@ class Status < ApplicationRecord
   update_index('statuses', :proper)
   update_index('public_statuses', :proper)
 
-  enum :visibility, { public: 0, unlisted: 1, private: 2, direct: 3, limited: 4 }, suffix: :visibility
+  enum :visibility, { public: 0, unlisted: 1, private: 2, direct: 3, limited: 4 }, suffix: :visibility, validate: true
 
   belongs_to :application, class_name: 'Doorkeeper::Application', optional: true
 

--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -73,7 +73,12 @@ class PostStatusService < BaseService
   end
 
   def process_status!
-    @status = @account.statuses.new(status_attributes)
+    begin
+      @status = @account.statuses.new(status_attributes)
+    rescue ArgumentError
+      raise ActiveRecord::RecordInvalid
+    end
+
     process_mentions_service.call(@status, save_records: false)
     safeguard_mentions!(@status)
 

--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -73,12 +73,7 @@ class PostStatusService < BaseService
   end
 
   def process_status!
-    begin
-      @status = @account.statuses.new(status_attributes)
-    rescue ArgumentError
-      raise ActiveRecord::RecordInvalid
-    end
-
+    @status = @account.statuses.new(status_attributes)
     process_mentions_service.call(@status, save_records: false)
     safeguard_mentions!(@status)
 

--- a/spec/services/post_status_service_spec.rb
+++ b/spec/services/post_status_service_spec.rb
@@ -68,7 +68,10 @@ RSpec.describe PostStatusService do
       it 'raises invalid record error' do
         expect do
           subject.call(account, text: 'Hi future!', scheduled_at: invalid_scheduled_time)
-        end.to raise_error(ActiveRecord::RecordInvalid)
+        end.to raise_error(
+          ActiveRecord::RecordInvalid,
+          'Validation failed: Scheduled at The scheduled date must be in the future'
+        )
       end
     end
   end
@@ -126,7 +129,10 @@ RSpec.describe PostStatusService do
   it 'raises on an invalid visibility' do
     expect do
       create_status_with_options(visibility: :xxx)
-    end.to raise_error(ActiveRecord::RecordInvalid)
+    end.to raise_error(
+      ActiveRecord::RecordInvalid,
+      'Validation failed: Visibility is not included in the list'
+    )
   end
 
   it 'creates a status with limited visibility for silenced users' do

--- a/spec/services/post_status_service_spec.rb
+++ b/spec/services/post_status_service_spec.rb
@@ -123,6 +123,12 @@ RSpec.describe PostStatusService do
     expect(status.visibility).to eq 'private'
   end
 
+  it 'raises on an invalid visibility' do
+    expect do
+      create_status_with_options(visibility: :xxx)
+    end.to raise_error(ActiveRecord::RecordInvalid)
+  end
+
   it 'creates a status with limited visibility for silenced users' do
     status = subject.call(Fabricate(:account, silenced: true), text: 'test', visibility: :public)
 


### PR DESCRIPTION
When passing an invalid value for `visibility` to `/api/v1/statuses`, the API returns 500 Internal Server Error. It should return 422 Unprocessable Content.