### PR TITLE
Update dependency rexml

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -695,7 +695,7 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    rexml (3.3.4)
+    rexml (3.3.6)
       strscan
     rotp (6.3.0)
     rouge (4.2.1)


### PR DESCRIPTION
See https://github.com/ruby/rexml/security/advisories/GHSA-vmwr-mc7x-5vc3

All our uses of ReXML are indirect and most, if not all of them, are in tests or otherwise controlled input. I am not sure this is the case of absolutely all of them, though.