### PR TITLE
Use `describe` instead of `context` in top-level spec declaration

### DIFF
--- a/spec/requests/anonymous_cookies_spec.rb
+++ b/spec/requests/anonymous_cookies_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-context 'when visited anonymously' do
+describe 'Anonymous visits' do
   around do |example|
     old = ActionController::Base.allow_forgery_protection
     ActionController::Base.allow_forgery_protection = true


### PR DESCRIPTION
I have a separate branch going to potentially enable the rspec `disable_monkey_patching` setting - noticed this while doing that. Basically a style update.