### PR TITLE
Fix display name being displayed instead of domain in remote reports

### DIFF
--- a/app/javascript/mastodon/features/notifications_v2/components/notification_admin_report.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/components/notification_admin_report.tsx
@@ -42,8 +42,12 @@ export const NotificationAdminReport: React.FC<{
 
   if (!account || !targetAccount) return null;
 
+  const domain = account.acct.split('@')[1];
+
   const values = {
-    name: (
+    name: domain ? (
+      <bdi>{domain}</bdi>
+    ) : (
       <bdi
         dangerouslySetInnerHTML={{ __html: account.get('display_name_html') }}
       />

--- a/app/javascript/mastodon/features/notifications_v2/components/notification_admin_report.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/components/notification_admin_report.tsx
@@ -45,20 +45,8 @@ export const NotificationAdminReport: React.FC<{
   const domain = account.acct.split('@')[1];
 
   const values = {
-    name: domain ? (
-      <bdi>{domain}</bdi>
-    ) : (
-      <bdi
-        dangerouslySetInnerHTML={{ __html: account.get('display_name_html') }}
-      />
-    ),
-    target: (
-      <bdi
-        dangerouslySetInnerHTML={{
-          __html: targetAccount.get('display_name_html'),
-        }}
-      />
-    ),
+    name: <bdi>{domain ?? `@${account.acct}`}</bdi>,
+    target: <bdi>@{targetAccount.acct}</bdi>,
     category: intl.formatMessage(messages[report.category]),
     count: report.status_ids.length,
   };


### PR DESCRIPTION
Mastodon anonymizes local reports when forwarding them, but that is not always the case of other software.

The moderation interface already hides the particular account attached to remote reporters, so it makes sense to hide it in the report notifications as well (even though the full account is returned by the API).

Furthermore, since the display names do not have hover cards or individual links, this PR changes the notifications to use the usernames rather the display names, as those can be changed and could be misleading.