### PR TITLE
Enable "zero monkey patching" mode in RSpec

### DIFF
--- a/spec/chewy/accounts_index_spec.rb
+++ b/spec/chewy/accounts_index_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe AccountsIndex do
+RSpec.describe AccountsIndex do
   describe 'Searching the index' do
     before do
       mock_elasticsearch_response(described_class, raw_response)

--- a/spec/chewy/public_statuses_index_spec.rb
+++ b/spec/chewy/public_statuses_index_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe PublicStatusesIndex do
+RSpec.describe PublicStatusesIndex do
   describe 'Searching the index' do
     before do
       mock_elasticsearch_response(described_class, raw_response)

--- a/spec/chewy/statuses_index_spec.rb
+++ b/spec/chewy/statuses_index_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe StatusesIndex do
+RSpec.describe StatusesIndex do
   describe 'Searching the index' do
     before do
       mock_elasticsearch_response(described_class, raw_response)

--- a/spec/chewy/tags_index_spec.rb
+++ b/spec/chewy/tags_index_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe TagsIndex do
+RSpec.describe TagsIndex do
   describe 'Searching the index' do
     before do
       mock_elasticsearch_response(described_class, raw_response)

--- a/spec/config/initializers/rack/attack_spec.rb
+++ b/spec/config/initializers/rack/attack_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Rack::Attack, type: :request do
+RSpec.describe Rack::Attack, type: :request do
   def app
     Rails.application
   end

--- a/spec/controllers/activitypub/claims_controller_spec.rb
+++ b/spec/controllers/activitypub/claims_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe ActivityPub::ClaimsController do
+RSpec.describe ActivityPub::ClaimsController do
   let(:account) { Fabricate(:account) }
 
   describe 'POST #create' do

--- a/spec/controllers/admin/account_actions_controller_spec.rb
+++ b/spec/controllers/admin/account_actions_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::AccountActionsController do
+RSpec.describe Admin::AccountActionsController do
   render_views
 
   let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }

--- a/spec/controllers/admin/action_logs_controller_spec.rb
+++ b/spec/controllers/admin/action_logs_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::ActionLogsController do
+RSpec.describe Admin::ActionLogsController do
   render_views
 
   # Action logs typically cause issues when their targets are not in the database

--- a/spec/controllers/admin/base_controller_spec.rb
+++ b/spec/controllers/admin/base_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::BaseController do
+RSpec.describe Admin::BaseController do
   controller do
     def success
       authorize :dashboard, :index?

--- a/spec/controllers/admin/custom_emojis_controller_spec.rb
+++ b/spec/controllers/admin/custom_emojis_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::CustomEmojisController do
+RSpec.describe Admin::CustomEmojisController do
   render_views
 
   let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }

--- a/spec/controllers/admin/dashboard_controller_spec.rb
+++ b/spec/controllers/admin/dashboard_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::DashboardController do
+RSpec.describe Admin::DashboardController do
   render_views
 
   describe 'GET #index' do

--- a/spec/controllers/admin/follow_recommendations_controller_spec.rb
+++ b/spec/controllers/admin/follow_recommendations_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::FollowRecommendationsController do
+RSpec.describe Admin::FollowRecommendationsController do
   render_views
 
   let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }

--- a/spec/controllers/admin/invites_controller_spec.rb
+++ b/spec/controllers/admin/invites_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::InvitesController do
+RSpec.describe Admin::InvitesController do
   render_views
 
   let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }

--- a/spec/controllers/admin/ip_blocks_controller_spec.rb
+++ b/spec/controllers/admin/ip_blocks_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::IpBlocksController do
+RSpec.describe Admin::IpBlocksController do
   render_views
 
   let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }

--- a/spec/controllers/admin/relationships_controller_spec.rb
+++ b/spec/controllers/admin/relationships_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::RelationshipsController do
+RSpec.describe Admin::RelationshipsController do
   render_views
 
   let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }

--- a/spec/controllers/admin/relays_controller_spec.rb
+++ b/spec/controllers/admin/relays_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::RelaysController do
+RSpec.describe Admin::RelaysController do
   render_views
 
   let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }

--- a/spec/controllers/admin/report_notes_controller_spec.rb
+++ b/spec/controllers/admin/report_notes_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::ReportNotesController do
+RSpec.describe Admin::ReportNotesController do
   render_views
 
   let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }

--- a/spec/controllers/admin/reports/actions_controller_spec.rb
+++ b/spec/controllers/admin/reports/actions_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::Reports::ActionsController do
+RSpec.describe Admin::Reports::ActionsController do
   render_views
 
   let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }

--- a/spec/controllers/admin/reports_controller_spec.rb
+++ b/spec/controllers/admin/reports_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::ReportsController do
+RSpec.describe Admin::ReportsController do
   render_views
 
   let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }

--- a/spec/controllers/admin/roles_controller_spec.rb
+++ b/spec/controllers/admin/roles_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::RolesController do
+RSpec.describe Admin::RolesController do
   render_views
 
   let(:permissions)  { UserRole::Flags::NONE }

--- a/spec/controllers/admin/rules_controller_spec.rb
+++ b/spec/controllers/admin/rules_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::RulesController do
+RSpec.describe Admin::RulesController do
   render_views
 
   let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }

--- a/spec/controllers/admin/site_uploads_controller_spec.rb
+++ b/spec/controllers/admin/site_uploads_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::SiteUploadsController do
+RSpec.describe Admin::SiteUploadsController do
   render_views
 
   let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }

--- a/spec/controllers/admin/statuses_controller_spec.rb
+++ b/spec/controllers/admin/statuses_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::StatusesController do
+RSpec.describe Admin::StatusesController do
   render_views
 
   let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }

--- a/spec/controllers/admin/trends/links/preview_card_providers_controller_spec.rb
+++ b/spec/controllers/admin/trends/links/preview_card_providers_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::Trends::Links::PreviewCardProvidersController do
+RSpec.describe Admin::Trends::Links::PreviewCardProvidersController do
   render_views
 
   let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }

--- a/spec/controllers/admin/trends/links_controller_spec.rb
+++ b/spec/controllers/admin/trends/links_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::Trends::LinksController do
+RSpec.describe Admin::Trends::LinksController do
   render_views
 
   let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }

--- a/spec/controllers/admin/trends/statuses_controller_spec.rb
+++ b/spec/controllers/admin/trends/statuses_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::Trends::StatusesController do
+RSpec.describe Admin::Trends::StatusesController do
   render_views
 
   let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }

--- a/spec/controllers/admin/trends/tags_controller_spec.rb
+++ b/spec/controllers/admin/trends/tags_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::Trends::TagsController do
+RSpec.describe Admin::Trends::TagsController do
   render_views
 
   let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }

--- a/spec/controllers/admin/users/roles_controller_spec.rb
+++ b/spec/controllers/admin/users/roles_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::Users::RolesController do
+RSpec.describe Admin::Users::RolesController do
   render_views
 
   let(:current_role) { UserRole.create(name: 'Foo', permissions: UserRole::FLAGS[:manage_roles], position: 10) }

--- a/spec/controllers/admin/users/two_factor_authentications_controller_spec.rb
+++ b/spec/controllers/admin/users/two_factor_authentications_controller_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'webauthn/fake_client'
 
-describe Admin::Users::TwoFactorAuthenticationsController do
+RSpec.describe Admin::Users::TwoFactorAuthenticationsController do
   render_views
 
   let(:user) { Fabricate(:user) }

--- a/spec/controllers/admin/warning_presets_controller_spec.rb
+++ b/spec/controllers/admin/warning_presets_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::WarningPresetsController do
+RSpec.describe Admin::WarningPresetsController do
   render_views
 
   let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }

--- a/spec/controllers/admin/webhooks/secrets_controller_spec.rb
+++ b/spec/controllers/admin/webhooks/secrets_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::Webhooks::SecretsController do
+RSpec.describe Admin::Webhooks::SecretsController do
   render_views
 
   let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }

--- a/spec/controllers/admin/webhooks_controller_spec.rb
+++ b/spec/controllers/admin/webhooks_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::WebhooksController do
+RSpec.describe Admin::WebhooksController do
   render_views
 
   let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }

--- a/spec/controllers/api/base_controller_spec.rb
+++ b/spec/controllers/api/base_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Api::BaseController do
+RSpec.describe Api::BaseController do
   controller do
     def success
       head 200

--- a/spec/controllers/api/web/push_subscriptions_controller_spec.rb
+++ b/spec/controllers/api/web/push_subscriptions_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Api::Web::PushSubscriptionsController do
+RSpec.describe Api::Web::PushSubscriptionsController do
   render_views
 
   let(:user) { Fabricate(:user) }

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe ApplicationController do
+RSpec.describe ApplicationController do
   controller do
     def success
       head 200

--- a/spec/controllers/auth/challenges_controller_spec.rb
+++ b/spec/controllers/auth/challenges_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Auth::ChallengesController do
+RSpec.describe Auth::ChallengesController do
   render_views
 
   let(:password) { 'foobar12345' }

--- a/spec/controllers/auth/confirmations_controller_spec.rb
+++ b/spec/controllers/auth/confirmations_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Auth::ConfirmationsController do
+RSpec.describe Auth::ConfirmationsController do
   render_views
 
   describe 'GET #new' do

--- a/spec/controllers/auth/passwords_controller_spec.rb
+++ b/spec/controllers/auth/passwords_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Auth::PasswordsController do
+RSpec.describe Auth::PasswordsController do
   include Devise::Test::ControllerHelpers
 
   describe 'GET #new' do

--- a/spec/controllers/auth/setup_controller_spec.rb
+++ b/spec/controllers/auth/setup_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Auth::SetupController do
+RSpec.describe Auth::SetupController do
   render_views
 
   describe 'GET #show' do

--- a/spec/controllers/authorize_interactions_controller_spec.rb
+++ b/spec/controllers/authorize_interactions_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe AuthorizeInteractionsController do
+RSpec.describe AuthorizeInteractionsController do
   render_views
 
   describe 'GET #show' do

--- a/spec/controllers/concerns/account_controller_concern_spec.rb
+++ b/spec/controllers/concerns/account_controller_concern_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe AccountControllerConcern do
+RSpec.describe AccountControllerConcern do
   controller(ApplicationController) do
     include AccountControllerConcern
 

--- a/spec/controllers/concerns/api/error_handling_spec.rb
+++ b/spec/controllers/concerns/api/error_handling_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Api::ErrorHandling do
+RSpec.describe Api::ErrorHandling do
   before do
     stub_const('FakeService', Class.new)
   end

--- a/spec/controllers/concerns/api/rate_limit_headers_spec.rb
+++ b/spec/controllers/concerns/api/rate_limit_headers_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Api::RateLimitHeaders do
+RSpec.describe Api::RateLimitHeaders do
   controller(ApplicationController) do
     include Api::RateLimitHeaders
 

--- a/spec/controllers/concerns/localized_spec.rb
+++ b/spec/controllers/concerns/localized_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Localized do
+RSpec.describe Localized do
   controller(ApplicationController) do
     include Localized
 

--- a/spec/controllers/concerns/settings/export_controller_concern_spec.rb
+++ b/spec/controllers/concerns/settings/export_controller_concern_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Settings::ExportControllerConcern do
+RSpec.describe Settings::ExportControllerConcern do
   controller(ApplicationController) do
     include Settings::ExportControllerConcern
 

--- a/spec/controllers/concerns/user_tracking_concern_spec.rb
+++ b/spec/controllers/concerns/user_tracking_concern_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe UserTrackingConcern do
+RSpec.describe UserTrackingConcern do
   controller(ApplicationController) do
     include UserTrackingConcern
 

--- a/spec/controllers/filters/statuses_controller_spec.rb
+++ b/spec/controllers/filters/statuses_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Filters::StatusesController do
+RSpec.describe Filters::StatusesController do
   render_views
 
   describe 'GET #index' do

--- a/spec/controllers/filters_controller_spec.rb
+++ b/spec/controllers/filters_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe FiltersController do
+RSpec.describe FiltersController do
   render_views
 
   describe 'GET #index' do

--- a/spec/controllers/follower_accounts_controller_spec.rb
+++ b/spec/controllers/follower_accounts_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe FollowerAccountsController do
+RSpec.describe FollowerAccountsController do
   render_views
 
   let(:alice) { Fabricate(:account, username: 'alice') }

--- a/spec/controllers/following_accounts_controller_spec.rb
+++ b/spec/controllers/following_accounts_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe FollowingAccountsController do
+RSpec.describe FollowingAccountsController do
   render_views
 
   let(:alice) { Fabricate(:account, username: 'alice') }

--- a/spec/controllers/invites_controller_spec.rb
+++ b/spec/controllers/invites_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe InvitesController do
+RSpec.describe InvitesController do
   render_views
 
   let(:user) { Fabricate(:user) }

--- a/spec/controllers/oauth/authorized_applications_controller_spec.rb
+++ b/spec/controllers/oauth/authorized_applications_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Oauth::AuthorizedApplicationsController do
+RSpec.describe Oauth::AuthorizedApplicationsController do
   render_views
 
   describe 'GET #index' do

--- a/spec/controllers/relationships_controller_spec.rb
+++ b/spec/controllers/relationships_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe RelationshipsController do
+RSpec.describe RelationshipsController do
   render_views
 
   let(:user) { Fabricate(:user) }

--- a/spec/controllers/settings/aliases_controller_spec.rb
+++ b/spec/controllers/settings/aliases_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Settings::AliasesController do
+RSpec.describe Settings::AliasesController do
   render_views
 
   let!(:user) { Fabricate(:user) }

--- a/spec/controllers/settings/applications_controller_spec.rb
+++ b/spec/controllers/settings/applications_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Settings::ApplicationsController do
+RSpec.describe Settings::ApplicationsController do
   render_views
 
   let!(:user) { Fabricate(:user) }

--- a/spec/controllers/settings/deletes_controller_spec.rb
+++ b/spec/controllers/settings/deletes_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Settings::DeletesController do
+RSpec.describe Settings::DeletesController do
   render_views
 
   describe 'GET #show' do

--- a/spec/controllers/settings/exports_controller_spec.rb
+++ b/spec/controllers/settings/exports_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Settings::ExportsController do
+RSpec.describe Settings::ExportsController do
   render_views
 
   describe 'GET #show' do

--- a/spec/controllers/settings/featured_tags_controller_spec.rb
+++ b/spec/controllers/settings/featured_tags_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Settings::FeaturedTagsController do
+RSpec.describe Settings::FeaturedTagsController do
   render_views
 
   shared_examples 'authenticate user' do

--- a/spec/controllers/settings/login_activities_controller_spec.rb
+++ b/spec/controllers/settings/login_activities_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Settings::LoginActivitiesController do
+RSpec.describe Settings::LoginActivitiesController do
   render_views
 
   let!(:user) { Fabricate(:user) }

--- a/spec/controllers/settings/migration/redirects_controller_spec.rb
+++ b/spec/controllers/settings/migration/redirects_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Settings::Migration::RedirectsController do
+RSpec.describe Settings::Migration::RedirectsController do
   render_views
 
   let!(:user) { Fabricate(:user, password: 'testtest') }

--- a/spec/controllers/settings/migrations_controller_spec.rb
+++ b/spec/controllers/settings/migrations_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Settings::MigrationsController do
+RSpec.describe Settings::MigrationsController do
   render_views
 
   shared_examples 'authenticate user' do

--- a/spec/controllers/settings/pictures_controller_spec.rb
+++ b/spec/controllers/settings/pictures_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Settings::PicturesController do
+RSpec.describe Settings::PicturesController do
   render_views
 
   let!(:user) { Fabricate(:user) }

--- a/spec/controllers/settings/preferences/appearance_controller_spec.rb
+++ b/spec/controllers/settings/preferences/appearance_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Settings::Preferences::AppearanceController do
+RSpec.describe Settings::Preferences::AppearanceController do
   render_views
 
   let!(:user) { Fabricate(:user) }

--- a/spec/controllers/settings/preferences/base_controller_spec.rb
+++ b/spec/controllers/settings/preferences/base_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Settings::Preferences::BaseController do
+RSpec.describe Settings::Preferences::BaseController do
   describe 'after_update_redirect_path' do
     it 'raises error when called' do
       expect { described_class.new.send(:after_update_redirect_path) }.to raise_error(/Override/)

--- a/spec/controllers/settings/preferences/notifications_controller_spec.rb
+++ b/spec/controllers/settings/preferences/notifications_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Settings::Preferences::NotificationsController do
+RSpec.describe Settings::Preferences::NotificationsController do
   render_views
 
   let(:user) { Fabricate(:user) }

--- a/spec/controllers/settings/preferences/other_controller_spec.rb
+++ b/spec/controllers/settings/preferences/other_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Settings::Preferences::OtherController do
+RSpec.describe Settings::Preferences::OtherController do
   render_views
 
   let(:user) { Fabricate(:user, chosen_languages: []) }

--- a/spec/controllers/settings/sessions_controller_spec.rb
+++ b/spec/controllers/settings/sessions_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Settings::SessionsController do
+RSpec.describe Settings::SessionsController do
   render_views
 
   let(:user) { Fabricate(:user) }

--- a/spec/controllers/settings/two_factor_authentication/confirmations_controller_spec.rb
+++ b/spec/controllers/settings/two_factor_authentication/confirmations_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Settings::TwoFactorAuthentication::ConfirmationsController do
+RSpec.describe Settings::TwoFactorAuthentication::ConfirmationsController do
   render_views
 
   shared_examples 'renders :new' do

--- a/spec/controllers/settings/two_factor_authentication/otp_authentication_controller_spec.rb
+++ b/spec/controllers/settings/two_factor_authentication/otp_authentication_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Settings::TwoFactorAuthentication::OtpAuthenticationController do
+RSpec.describe Settings::TwoFactorAuthentication::OtpAuthenticationController do
   render_views
 
   let(:user) { Fabricate(:user) }

--- a/spec/controllers/settings/two_factor_authentication/recovery_codes_controller_spec.rb
+++ b/spec/controllers/settings/two_factor_authentication/recovery_codes_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Settings::TwoFactorAuthentication::RecoveryCodesController do
+RSpec.describe Settings::TwoFactorAuthentication::RecoveryCodesController do
   render_views
 
   describe 'POST #create' do

--- a/spec/controllers/settings/two_factor_authentication/webauthn_credentials_controller_spec.rb
+++ b/spec/controllers/settings/two_factor_authentication/webauthn_credentials_controller_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'webauthn/fake_client'
 
-describe Settings::TwoFactorAuthentication::WebauthnCredentialsController do
+RSpec.describe Settings::TwoFactorAuthentication::WebauthnCredentialsController do
   render_views
 
   let(:user) { Fabricate(:user) }

--- a/spec/controllers/settings/two_factor_authentication_methods_controller_spec.rb
+++ b/spec/controllers/settings/two_factor_authentication_methods_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Settings::TwoFactorAuthenticationMethodsController do
+RSpec.describe Settings::TwoFactorAuthenticationMethodsController do
   render_views
 
   context 'when not signed in' do

--- a/spec/controllers/statuses_controller_spec.rb
+++ b/spec/controllers/statuses_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe StatusesController do
+RSpec.describe StatusesController do
   render_views
 
   describe 'GET #show' do

--- a/spec/fabrication/fabricators_spec.rb
+++ b/spec/fabrication/fabricators_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 Fabrication.manager.load_definitions if Fabrication.manager.empty?
 
 Fabrication.manager.schematics.map(&:first).each do |factory_name|
-  describe "The #{factory_name} factory" do
+  RSpec.describe "The #{factory_name} factory" do
     it 'is able to create valid records' do
       records = Fabricate.times(2, factory_name) # Create multiple of each to uncover uniqueness issues
       expect(records).to all(be_valid)

--- a/spec/generators/post_deployment_migration_generator_spec.rb
+++ b/spec/generators/post_deployment_migration_generator_spec.rb
@@ -6,7 +6,7 @@ require 'rails/generators/testing/assertions'
 
 require 'generators/post_deployment_migration/post_deployment_migration_generator'
 
-describe PostDeploymentMigrationGenerator, type: :generator do
+RSpec.describe PostDeploymentMigrationGenerator, type: :generator do
   include Rails::Generators::Testing::Behavior
   include Rails::Generators::Testing::Assertions
   include FileUtils

--- a/spec/helpers/admin/dashboard_helper_spec.rb
+++ b/spec/helpers/admin/dashboard_helper_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::DashboardHelper do
+RSpec.describe Admin::DashboardHelper do
   describe 'relevant_account_timestamp' do
     context 'with an account with older sign in' do
       let(:account) { Fabricate(:account) }

--- a/spec/helpers/admin/disputes_helper_spec.rb
+++ b/spec/helpers/admin/disputes_helper_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::DisputesHelper do
+RSpec.describe Admin::DisputesHelper do
   describe 'strike_action_label' do
     it 'returns html describing the appeal' do
       adam = Account.new(username: 'Adam')

--- a/spec/helpers/admin/filter_helper_spec.rb
+++ b/spec/helpers/admin/filter_helper_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::FilterHelper do
+RSpec.describe Admin::FilterHelper do
   it 'Uses filter_link_to to create filter links' do
     params = ActionController::Parameters.new(
       { test: 'test' }

--- a/spec/helpers/admin/trends/statuses_helper_spec.rb
+++ b/spec/helpers/admin/trends/statuses_helper_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::Trends::StatusesHelper do
+RSpec.describe Admin::Trends::StatusesHelper do
   describe '.one_line_preview' do
     before do
       allow(helper).to receive(:current_user).and_return(Fabricate.build(:user))

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe ApplicationHelper do
+RSpec.describe ApplicationHelper do
   describe 'body_classes' do
     context 'with a body class string from a controller' do
       before { helper.extend controller_helpers }

--- a/spec/helpers/flashes_helper_spec.rb
+++ b/spec/helpers/flashes_helper_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe FlashesHelper do
+RSpec.describe FlashesHelper do
   describe 'user_facing_flashes' do
     before do
       # rubocop:disable Rails/I18nLocaleTexts

--- a/spec/helpers/formatting_helper_spec.rb
+++ b/spec/helpers/formatting_helper_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe FormattingHelper do
+RSpec.describe FormattingHelper do
   include Devise::Test::ControllerHelpers
 
   describe '#rss_status_content_format' do

--- a/spec/helpers/instance_helper_spec.rb
+++ b/spec/helpers/instance_helper_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe InstanceHelper do
+RSpec.describe InstanceHelper do
   describe 'site_title' do
     it 'Uses the Setting.site_title value when it exists' do
       Setting.site_title = 'New site title'

--- a/spec/helpers/json_ld_helper_spec.rb
+++ b/spec/helpers/json_ld_helper_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe JsonLdHelper do
+RSpec.describe JsonLdHelper do
   describe '#equals_or_includes?' do
     it 'returns true when value equals' do
       expect(helper.equals_or_includes?('foo', 'foo')).to be true

--- a/spec/helpers/languages_helper_spec.rb
+++ b/spec/helpers/languages_helper_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe LanguagesHelper do
+RSpec.describe LanguagesHelper do
   describe 'the SUPPORTED_LOCALES constant' do
     it 'includes all i18n locales' do
       expect(Set.new(described_class::SUPPORTED_LOCALES.keys + described_class::REGIONAL_LOCALE_NAMES.keys)).to include(*I18n.available_locales)

--- a/spec/helpers/media_component_helper_spec.rb
+++ b/spec/helpers/media_component_helper_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe MediaComponentHelper do
+RSpec.describe MediaComponentHelper do
   before { helper.extend controller_helpers }
 
   describe 'render_video_component' do

--- a/spec/helpers/react_component_helper_spec.rb
+++ b/spec/helpers/react_component_helper_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe ReactComponentHelper do
+RSpec.describe ReactComponentHelper do
   describe 'react_component' do
     context 'with no block passed in' do
       let(:result) { helper.react_component('name', { one: :two }) }

--- a/spec/helpers/settings_helper_spec.rb
+++ b/spec/helpers/settings_helper_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe SettingsHelper do
+RSpec.describe SettingsHelper do
   describe 'session_device_icon' do
     context 'with a mobile device' do
       let(:session) { SessionActivation.new(user_agent: 'Mozilla/5.0 (iPhone)') }

--- a/spec/helpers/statuses_helper_spec.rb
+++ b/spec/helpers/statuses_helper_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe StatusesHelper do
+RSpec.describe StatusesHelper do
   describe 'status_text_summary' do
     context 'with blank text' do
       let(:status) { Status.new(spoiler_text: '') }

--- a/spec/helpers/theme_helper_spec.rb
+++ b/spec/helpers/theme_helper_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe ThemeHelper do
+RSpec.describe ThemeHelper do
   describe 'theme_style_tags' do
     let(:result) { helper.theme_style_tags(theme) }
 

--- a/spec/lib/admin/metrics/dimension/instance_accounts_dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension/instance_accounts_dimension_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::Metrics::Dimension::InstanceAccountsDimension do
+RSpec.describe Admin::Metrics::Dimension::InstanceAccountsDimension do
   subject { described_class.new(start_at, end_at, limit, params) }
 
   let(:start_at) { 2.days.ago }

--- a/spec/lib/admin/metrics/dimension/instance_languages_dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension/instance_languages_dimension_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::Metrics::Dimension::InstanceLanguagesDimension do
+RSpec.describe Admin::Metrics::Dimension::InstanceLanguagesDimension do
   subject { described_class.new(start_at, end_at, limit, params) }
 
   let(:start_at) { 2.days.ago }

--- a/spec/lib/admin/metrics/dimension/languages_dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension/languages_dimension_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::Metrics::Dimension::LanguagesDimension do
+RSpec.describe Admin::Metrics::Dimension::LanguagesDimension do
   subject { described_class.new(start_at, end_at, limit, params) }
 
   let(:start_at) { 2.days.ago }

--- a/spec/lib/admin/metrics/dimension/servers_dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension/servers_dimension_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::Metrics::Dimension::ServersDimension do
+RSpec.describe Admin::Metrics::Dimension::ServersDimension do
   subject { described_class.new(start_at, end_at, limit, params) }
 
   let(:start_at) { 2.days.ago }

--- a/spec/lib/admin/metrics/dimension/software_versions_dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension/software_versions_dimension_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::Metrics::Dimension::SoftwareVersionsDimension do
+RSpec.describe Admin::Metrics::Dimension::SoftwareVersionsDimension do
   subject { described_class.new(start_at, end_at, limit, params) }
 
   let(:start_at) { 2.days.ago }

--- a/spec/lib/admin/metrics/dimension/sources_dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension/sources_dimension_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::Metrics::Dimension::SourcesDimension do
+RSpec.describe Admin::Metrics::Dimension::SourcesDimension do
   subject { described_class.new(start_at, end_at, limit, params) }
 
   let(:start_at) { 2.days.ago }

--- a/spec/lib/admin/metrics/dimension/space_usage_dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension/space_usage_dimension_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::Metrics::Dimension::SpaceUsageDimension do
+RSpec.describe Admin::Metrics::Dimension::SpaceUsageDimension do
   subject { described_class.new(start_at, end_at, limit, params) }
 
   let(:start_at) { 2.days.ago }

--- a/spec/lib/admin/metrics/dimension/tag_languages_dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension/tag_languages_dimension_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::Metrics::Dimension::TagLanguagesDimension do
+RSpec.describe Admin::Metrics::Dimension::TagLanguagesDimension do
   subject { described_class.new(start_at, end_at, limit, params) }
 
   let(:start_at) { 2.days.ago }

--- a/spec/lib/admin/metrics/dimension/tag_servers_dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension/tag_servers_dimension_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::Metrics::Dimension::TagServersDimension do
+RSpec.describe Admin::Metrics::Dimension::TagServersDimension do
   subject { described_class.new(start_at, end_at, limit, params) }
 
   let(:start_at) { 2.days.ago }

--- a/spec/lib/admin/metrics/dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::Metrics::Dimension do
+RSpec.describe Admin::Metrics::Dimension do
   describe '.retrieve' do
     subject { described_class.retrieve(reports, start_at, end_at, 5, params) }
 

--- a/spec/lib/admin/metrics/measure/active_users_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/active_users_measure_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::Metrics::Measure::ActiveUsersMeasure do
+RSpec.describe Admin::Metrics::Measure::ActiveUsersMeasure do
   subject { described_class.new(start_at, end_at, params) }
 
   let(:start_at) { 2.days.ago }

--- a/spec/lib/admin/metrics/measure/instance_accounts_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/instance_accounts_measure_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::Metrics::Measure::InstanceAccountsMeasure do
+RSpec.describe Admin::Metrics::Measure::InstanceAccountsMeasure do
   subject { described_class.new(start_at, end_at, params) }
 
   let(:domain) { 'example.com' }

--- a/spec/lib/admin/metrics/measure/instance_followers_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/instance_followers_measure_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::Metrics::Measure::InstanceFollowersMeasure do
+RSpec.describe Admin::Metrics::Measure::InstanceFollowersMeasure do
   subject { described_class.new(start_at, end_at, params) }
 
   let(:domain) { 'example.com' }

--- a/spec/lib/admin/metrics/measure/instance_follows_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/instance_follows_measure_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::Metrics::Measure::InstanceFollowsMeasure do
+RSpec.describe Admin::Metrics::Measure::InstanceFollowsMeasure do
   subject { described_class.new(start_at, end_at, params) }
 
   let(:domain) { 'example.com' }

--- a/spec/lib/admin/metrics/measure/instance_media_attachments_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/instance_media_attachments_measure_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::Metrics::Measure::InstanceMediaAttachmentsMeasure do
+RSpec.describe Admin::Metrics::Measure::InstanceMediaAttachmentsMeasure do
   subject { described_class.new(start_at, end_at, params) }
 
   let(:domain) { 'example.com' }

--- a/spec/lib/admin/metrics/measure/instance_reports_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/instance_reports_measure_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::Metrics::Measure::InstanceReportsMeasure do
+RSpec.describe Admin::Metrics::Measure::InstanceReportsMeasure do
   subject { described_class.new(start_at, end_at, params) }
 
   let(:domain) { 'example.com' }

--- a/spec/lib/admin/metrics/measure/instance_statuses_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/instance_statuses_measure_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::Metrics::Measure::InstanceStatusesMeasure do
+RSpec.describe Admin::Metrics::Measure::InstanceStatusesMeasure do
   subject { described_class.new(start_at, end_at, params) }
 
   let(:domain) { 'example.com' }

--- a/spec/lib/admin/metrics/measure/interactions_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/interactions_measure_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::Metrics::Measure::InteractionsMeasure do
+RSpec.describe Admin::Metrics::Measure::InteractionsMeasure do
   subject { described_class.new(start_at, end_at, params) }
 
   let(:start_at) { 2.days.ago }

--- a/spec/lib/admin/metrics/measure/new_users_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/new_users_measure_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::Metrics::Measure::NewUsersMeasure do
+RSpec.describe Admin::Metrics::Measure::NewUsersMeasure do
   subject { described_class.new(start_at, end_at, params) }
 
   let(:start_at) { 2.days.ago }

--- a/spec/lib/admin/metrics/measure/opened_reports_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/opened_reports_measure_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::Metrics::Measure::OpenedReportsMeasure do
+RSpec.describe Admin::Metrics::Measure::OpenedReportsMeasure do
   subject { described_class.new(start_at, end_at, params) }
 
   let(:start_at) { 2.days.ago }

--- a/spec/lib/admin/metrics/measure/resolved_reports_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/resolved_reports_measure_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::Metrics::Measure::ResolvedReportsMeasure do
+RSpec.describe Admin::Metrics::Measure::ResolvedReportsMeasure do
   subject { described_class.new(start_at, end_at, params) }
 
   let(:start_at) { 2.days.ago }

--- a/spec/lib/admin/metrics/measure/tag_accounts_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/tag_accounts_measure_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::Metrics::Measure::TagAccountsMeasure do
+RSpec.describe Admin::Metrics::Measure::TagAccountsMeasure do
   subject { described_class.new(start_at, end_at, params) }
 
   let!(:tag) { Fabricate(:tag) }

--- a/spec/lib/admin/metrics/measure/tag_servers_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/tag_servers_measure_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::Metrics::Measure::TagServersMeasure do
+RSpec.describe Admin::Metrics::Measure::TagServersMeasure do
   subject { described_class.new(start_at, end_at, params) }
 
   let!(:tag) { Fabricate(:tag) }

--- a/spec/lib/admin/metrics/measure/tag_uses_measure_spec.rb
+++ b/spec/lib/admin/metrics/measure/tag_uses_measure_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::Metrics::Measure::TagUsesMeasure do
+RSpec.describe Admin::Metrics::Measure::TagUsesMeasure do
   subject { described_class.new(start_at, end_at, params) }
 
   let!(:tag) { Fabricate(:tag) }

--- a/spec/lib/admin/metrics/measure_spec.rb
+++ b/spec/lib/admin/metrics/measure_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::Metrics::Measure do
+RSpec.describe Admin::Metrics::Measure do
   describe '.retrieve' do
     subject { described_class.retrieve(reports, start_at, end_at, params) }
 

--- a/spec/lib/admin/system_check/base_check_spec.rb
+++ b/spec/lib/admin/system_check/base_check_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::SystemCheck::BaseCheck do
+RSpec.describe Admin::SystemCheck::BaseCheck do
   subject(:check) { described_class.new(user) }
 
   let(:user) { Fabricate(:user) }

--- a/spec/lib/admin/system_check/database_schema_check_spec.rb
+++ b/spec/lib/admin/system_check/database_schema_check_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::SystemCheck::DatabaseSchemaCheck do
+RSpec.describe Admin::SystemCheck::DatabaseSchemaCheck do
   subject(:check) { described_class.new(user) }
 
   let(:user) { Fabricate(:user) }

--- a/spec/lib/admin/system_check/elasticsearch_check_spec.rb
+++ b/spec/lib/admin/system_check/elasticsearch_check_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::SystemCheck::ElasticsearchCheck do
+RSpec.describe Admin::SystemCheck::ElasticsearchCheck do
   subject(:check) { described_class.new(user) }
 
   let(:user) { Fabricate(:user) }

--- a/spec/lib/admin/system_check/media_privacy_check_spec.rb
+++ b/spec/lib/admin/system_check/media_privacy_check_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::SystemCheck::MediaPrivacyCheck do
+RSpec.describe Admin::SystemCheck::MediaPrivacyCheck do
   subject(:check) { described_class.new(user) }
 
   let(:user) { Fabricate(:user) }

--- a/spec/lib/admin/system_check/message_spec.rb
+++ b/spec/lib/admin/system_check/message_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::SystemCheck::Message do
+RSpec.describe Admin::SystemCheck::Message do
   subject(:check) { described_class.new(:key_value, :value_value, :action_value, :critical_value) }
 
   it 'providers readers when initialized' do

--- a/spec/lib/admin/system_check/rules_check_spec.rb
+++ b/spec/lib/admin/system_check/rules_check_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::SystemCheck::RulesCheck do
+RSpec.describe Admin::SystemCheck::RulesCheck do
   subject(:check) { described_class.new(user) }
 
   let(:user) { Fabricate(:user) }

--- a/spec/lib/admin/system_check/sidekiq_process_check_spec.rb
+++ b/spec/lib/admin/system_check/sidekiq_process_check_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::SystemCheck::SidekiqProcessCheck do
+RSpec.describe Admin::SystemCheck::SidekiqProcessCheck do
   subject(:check) { described_class.new(user) }
 
   let(:user) { Fabricate(:user) }

--- a/spec/lib/admin/system_check/software_version_check_spec.rb
+++ b/spec/lib/admin/system_check/software_version_check_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::SystemCheck::SoftwareVersionCheck do
+RSpec.describe Admin::SystemCheck::SoftwareVersionCheck do
   include RoutingHelper
 
   subject(:check) { described_class.new(user) }

--- a/spec/lib/admin/system_check_spec.rb
+++ b/spec/lib/admin/system_check_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::SystemCheck do
+RSpec.describe Admin::SystemCheck do
   let(:user) { Fabricate(:user) }
 
   describe 'perform' do

--- a/spec/lib/annual_report_spec.rb
+++ b/spec/lib/annual_report_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe AnnualReport do
+RSpec.describe AnnualReport do
   describe '#generate' do
     subject { described_class.new(account, Time.zone.now.year) }
 

--- a/spec/lib/cache_buster_spec.rb
+++ b/spec/lib/cache_buster_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe CacheBuster do
+RSpec.describe CacheBuster do
   subject { described_class.new(secret_header: secret_header, secret: secret, http_method: http_method) }
 
   let(:secret_header) { nil }

--- a/spec/lib/connection_pool/shared_connection_pool_spec.rb
+++ b/spec/lib/connection_pool/shared_connection_pool_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe ConnectionPool::SharedConnectionPool do
+RSpec.describe ConnectionPool::SharedConnectionPool do
   subject { described_class.new(size: 5, timeout: 5) { |site| mini_connection_class.new(site) } }
 
   let(:mini_connection_class) do

--- a/spec/lib/connection_pool/shared_timed_stack_spec.rb
+++ b/spec/lib/connection_pool/shared_timed_stack_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe ConnectionPool::SharedTimedStack do
+RSpec.describe ConnectionPool::SharedTimedStack do
   subject { described_class.new(5) { |site| mini_connection_class.new(site) } }
 
   let(:mini_connection_class) do

--- a/spec/lib/content_security_policy_spec.rb
+++ b/spec/lib/content_security_policy_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe ContentSecurityPolicy do
+RSpec.describe ContentSecurityPolicy do
   subject { described_class.new }
 
   around do |example|

--- a/spec/lib/delivery_failure_tracker_spec.rb
+++ b/spec/lib/delivery_failure_tracker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe DeliveryFailureTracker do
+RSpec.describe DeliveryFailureTracker do
   subject { described_class.new('http://example.com/inbox') }
 
   describe '#track_success!' do

--- a/spec/lib/extractor_spec.rb
+++ b/spec/lib/extractor_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Extractor do
+RSpec.describe Extractor do
   describe 'extract_mentions_or_lists_with_indices' do
     it 'returns an empty array if the given string does not have at signs' do
       text = 'a string without at signs'

--- a/spec/lib/fast_ip_map_spec.rb
+++ b/spec/lib/fast_ip_map_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe FastIpMap do
+RSpec.describe FastIpMap do
   describe '#include?' do
     subject { described_class.new([IPAddr.new('20.4.0.0/16'), IPAddr.new('145.22.30.0/24'), IPAddr.new('189.45.86.3')]) }
 

--- a/spec/lib/hashtag_normalizer_spec.rb
+++ b/spec/lib/hashtag_normalizer_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe HashtagNormalizer do
+RSpec.describe HashtagNormalizer do
   subject { described_class.new }
 
   describe '#normalize' do

--- a/spec/lib/importer/accounts_index_importer_spec.rb
+++ b/spec/lib/importer/accounts_index_importer_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Importer::AccountsIndexImporter do
+RSpec.describe Importer::AccountsIndexImporter do
   describe 'import!' do
     let(:pool) { Concurrent::FixedThreadPool.new(5) }
     let(:importer) { described_class.new(batch_size: 123, executor: pool) }

--- a/spec/lib/importer/base_importer_spec.rb
+++ b/spec/lib/importer/base_importer_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Importer::BaseImporter do
+RSpec.describe Importer::BaseImporter do
   describe 'import!' do
     let(:pool) { Concurrent::FixedThreadPool.new(5) }
     let(:importer) { described_class.new(batch_size: 123, executor: pool) }

--- a/spec/lib/importer/public_statuses_index_importer_spec.rb
+++ b/spec/lib/importer/public_statuses_index_importer_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Importer::PublicStatusesIndexImporter do
+RSpec.describe Importer::PublicStatusesIndexImporter do
   describe 'import!' do
     let(:pool) { Concurrent::FixedThreadPool.new(5) }
     let(:importer) { described_class.new(batch_size: 123, executor: pool) }

--- a/spec/lib/importer/statuses_index_importer_spec.rb
+++ b/spec/lib/importer/statuses_index_importer_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Importer::StatusesIndexImporter do
+RSpec.describe Importer::StatusesIndexImporter do
   describe 'import!' do
     let(:pool) { Concurrent::FixedThreadPool.new(5) }
     let(:importer) { described_class.new(batch_size: 123, executor: pool) }

--- a/spec/lib/importer/tags_index_importer_spec.rb
+++ b/spec/lib/importer/tags_index_importer_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Importer::TagsIndexImporter do
+RSpec.describe Importer::TagsIndexImporter do
   describe 'import!' do
     let(:pool) { Concurrent::FixedThreadPool.new(5) }
     let(:importer) { described_class.new(batch_size: 123, executor: pool) }

--- a/spec/lib/mastodon/cli/accounts_spec.rb
+++ b/spec/lib/mastodon/cli/accounts_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'mastodon/cli/accounts'
 
-describe Mastodon::CLI::Accounts do
+RSpec.describe Mastodon::CLI::Accounts do
   subject { cli.invoke(action, arguments, options) }
 
   let(:cli) { described_class.new }

--- a/spec/lib/mastodon/cli/cache_spec.rb
+++ b/spec/lib/mastodon/cli/cache_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'mastodon/cli/cache'
 
-describe Mastodon::CLI::Cache do
+RSpec.describe Mastodon::CLI::Cache do
   subject { cli.invoke(action, arguments, options) }
 
   let(:cli) { described_class.new }

--- a/spec/lib/mastodon/cli/canonical_email_blocks_spec.rb
+++ b/spec/lib/mastodon/cli/canonical_email_blocks_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'mastodon/cli/canonical_email_blocks'
 
-describe Mastodon::CLI::CanonicalEmailBlocks do
+RSpec.describe Mastodon::CLI::CanonicalEmailBlocks do
   subject { cli.invoke(action, arguments, options) }
 
   let(:cli) { described_class.new }

--- a/spec/lib/mastodon/cli/domains_spec.rb
+++ b/spec/lib/mastodon/cli/domains_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'mastodon/cli/domains'
 
-describe Mastodon::CLI::Domains do
+RSpec.describe Mastodon::CLI::Domains do
   subject { cli.invoke(action, arguments, options) }
 
   let(:cli) { described_class.new }

--- a/spec/lib/mastodon/cli/email_domain_blocks_spec.rb
+++ b/spec/lib/mastodon/cli/email_domain_blocks_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'mastodon/cli/email_domain_blocks'
 
-describe Mastodon::CLI::EmailDomainBlocks do
+RSpec.describe Mastodon::CLI::EmailDomainBlocks do
   subject { cli.invoke(action, arguments, options) }
 
   let(:cli) { described_class.new }

--- a/spec/lib/mastodon/cli/emoji_spec.rb
+++ b/spec/lib/mastodon/cli/emoji_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'mastodon/cli/emoji'
 
-describe Mastodon::CLI::Emoji do
+RSpec.describe Mastodon::CLI::Emoji do
   subject { cli.invoke(action, arguments, options) }
 
   let(:cli) { described_class.new }

--- a/spec/lib/mastodon/cli/feeds_spec.rb
+++ b/spec/lib/mastodon/cli/feeds_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'mastodon/cli/feeds'
 
-describe Mastodon::CLI::Feeds do
+RSpec.describe Mastodon::CLI::Feeds do
   subject { cli.invoke(action, arguments, options) }
 
   let(:cli) { described_class.new }

--- a/spec/lib/mastodon/cli/ip_blocks_spec.rb
+++ b/spec/lib/mastodon/cli/ip_blocks_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'mastodon/cli/ip_blocks'
 
-describe Mastodon::CLI::IpBlocks do
+RSpec.describe Mastodon::CLI::IpBlocks do
   subject { cli.invoke(action, arguments, options) }
 
   let(:cli) { described_class.new }

--- a/spec/lib/mastodon/cli/main_spec.rb
+++ b/spec/lib/mastodon/cli/main_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'mastodon/cli/main'
 
-describe Mastodon::CLI::Main do
+RSpec.describe Mastodon::CLI::Main do
   subject { cli.invoke(action, arguments, options) }
 
   let(:cli) { described_class.new }

--- a/spec/lib/mastodon/cli/maintenance_spec.rb
+++ b/spec/lib/mastodon/cli/maintenance_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'mastodon/cli/maintenance'
 
-describe Mastodon::CLI::Maintenance do
+RSpec.describe Mastodon::CLI::Maintenance do
   subject { cli.invoke(action, arguments, options) }
 
   let(:cli) { described_class.new }

--- a/spec/lib/mastodon/cli/media_spec.rb
+++ b/spec/lib/mastodon/cli/media_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'mastodon/cli/media'
 
-describe Mastodon::CLI::Media do
+RSpec.describe Mastodon::CLI::Media do
   subject { cli.invoke(action, arguments, options) }
 
   let(:cli) { described_class.new }

--- a/spec/lib/mastodon/cli/preview_cards_spec.rb
+++ b/spec/lib/mastodon/cli/preview_cards_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'mastodon/cli/preview_cards'
 
-describe Mastodon::CLI::PreviewCards do
+RSpec.describe Mastodon::CLI::PreviewCards do
   subject { cli.invoke(action, arguments, options) }
 
   let(:cli) { described_class.new }

--- a/spec/lib/mastodon/cli/search_spec.rb
+++ b/spec/lib/mastodon/cli/search_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'mastodon/cli/search'
 
-describe Mastodon::CLI::Search do
+RSpec.describe Mastodon::CLI::Search do
   subject { cli.invoke(action, arguments, options) }
 
   let(:cli) { described_class.new }

--- a/spec/lib/mastodon/cli/settings_spec.rb
+++ b/spec/lib/mastodon/cli/settings_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'mastodon/cli/settings'
 
-describe Mastodon::CLI::Settings do
+RSpec.describe Mastodon::CLI::Settings do
   it_behaves_like 'CLI Command'
 
   describe 'subcommand "registrations"' do

--- a/spec/lib/mastodon/cli/statuses_spec.rb
+++ b/spec/lib/mastodon/cli/statuses_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'mastodon/cli/statuses'
 
-describe Mastodon::CLI::Statuses do
+RSpec.describe Mastodon::CLI::Statuses do
   subject { cli.invoke(action, arguments, options) }
 
   let(:cli) { described_class.new }

--- a/spec/lib/mastodon/cli/upgrade_spec.rb
+++ b/spec/lib/mastodon/cli/upgrade_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'mastodon/cli/upgrade'
 
-describe Mastodon::CLI::Upgrade do
+RSpec.describe Mastodon::CLI::Upgrade do
   subject { cli.invoke(action, arguments, options) }
 
   let(:cli) { described_class.new }

--- a/spec/lib/mastodon/migration_warning_spec.rb
+++ b/spec/lib/mastodon/migration_warning_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'mastodon/migration_warning'
 
-describe Mastodon::MigrationWarning do
+RSpec.describe Mastodon::MigrationWarning do
   describe 'migration_duration_warning' do
     before do
       allow(migration).to receive(:valid_environment?).and_return(true)

--- a/spec/lib/ostatus/tag_manager_spec.rb
+++ b/spec/lib/ostatus/tag_manager_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe OStatus::TagManager do
+RSpec.describe OStatus::TagManager do
   describe '#unique_tag' do
     it 'returns a unique tag' do
       expect(described_class.instance.unique_tag(Time.utc(2000), 12, 'Status')).to eq 'tag:cb6e6126.ngrok.io,2000-01-01:objectId=12:objectType=Status'

--- a/spec/lib/paperclip/response_with_limit_adapter_spec.rb
+++ b/spec/lib/paperclip/response_with_limit_adapter_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Paperclip::ResponseWithLimitAdapter do
+RSpec.describe Paperclip::ResponseWithLimitAdapter do
   subject { described_class.new(response_with_limit) }
 
   before { stub_request(:get, url).to_return(headers: headers, body: body) }

--- a/spec/lib/permalink_redirector_spec.rb
+++ b/spec/lib/permalink_redirector_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe PermalinkRedirector do
+RSpec.describe PermalinkRedirector do
   let(:remote_account) { Fabricate(:account, username: 'alice', domain: 'example.com', url: 'https://example.com/@alice', id: 2) }
 
   describe '#redirect_url' do

--- a/spec/lib/request_pool_spec.rb
+++ b/spec/lib/request_pool_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe RequestPool do
+RSpec.describe RequestPool do
   subject { described_class.new }
 
   describe '#with' do

--- a/spec/lib/request_spec.rb
+++ b/spec/lib/request_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'securerandom'
 
-describe Request do
+RSpec.describe Request do
   subject { described_class.new(:get, 'http://example.com') }
 
   describe '#headers' do

--- a/spec/lib/sanitize/config_spec.rb
+++ b/spec/lib/sanitize/config_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Sanitize::Config do
+RSpec.describe Sanitize::Config do
   describe '::MASTODON_STRICT' do
     subject { described_class::MASTODON_STRICT }
 

--- a/spec/lib/scope_transformer_spec.rb
+++ b/spec/lib/scope_transformer_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe ScopeTransformer do
+RSpec.describe ScopeTransformer do
   describe '#apply' do
     subject { described_class.new.apply(ScopeParser.new.parse(input)) }
 

--- a/spec/lib/search_query_parser_spec.rb
+++ b/spec/lib/search_query_parser_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'parslet/rig/rspec'
 
-describe SearchQueryParser do
+RSpec.describe SearchQueryParser do
   let(:parser) { described_class.new }
 
   context 'with term' do

--- a/spec/lib/search_query_transformer_spec.rb
+++ b/spec/lib/search_query_transformer_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe SearchQueryTransformer do
+RSpec.describe SearchQueryTransformer do
   subject { described_class.new.apply(parser, current_account: account) }
 
   let(:account) { Fabricate(:account) }

--- a/spec/lib/status_cache_hydrator_spec.rb
+++ b/spec/lib/status_cache_hydrator_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe StatusCacheHydrator do
+RSpec.describe StatusCacheHydrator do
   let(:status)  { Fabricate(:status) }
   let(:account) { Fabricate(:account) }
 

--- a/spec/lib/status_filter_spec.rb
+++ b/spec/lib/status_filter_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe StatusFilter do
+RSpec.describe StatusFilter do
   describe '#filtered?' do
     let(:status) { Fabricate(:status) }
 

--- a/spec/lib/status_finder_spec.rb
+++ b/spec/lib/status_finder_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe StatusFinder do
+RSpec.describe StatusFinder do
   include RoutingHelper
 
   describe '#status' do

--- a/spec/lib/status_reach_finder_spec.rb
+++ b/spec/lib/status_reach_finder_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe StatusReachFinder do
+RSpec.describe StatusReachFinder do
   describe '#inboxes' do
     context 'with a local status' do
       subject { described_class.new(status) }

--- a/spec/lib/webfinger_resource_spec.rb
+++ b/spec/lib/webfinger_resource_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe WebfingerResource do
+RSpec.describe WebfingerResource do
   around do |example|
     before_local = Rails.configuration.x.local_domain
     before_web = Rails.configuration.x.web_domain

--- a/spec/lib/webhooks/payload_renderer_spec.rb
+++ b/spec/lib/webhooks/payload_renderer_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Webhooks::PayloadRenderer do
+RSpec.describe Webhooks::PayloadRenderer do
   subject(:renderer) { described_class.new(json) }
 
   let(:event)   { Webhooks::EventPresenter.new(type, object) }

--- a/spec/locales/i18n_spec.rb
+++ b/spec/locales/i18n_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'I18n' do
+RSpec.describe 'I18n' do
   describe 'Pluralizing locale translations' do
     subject { I18n.t('generic.validation_errors', count: 1) }
 

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe UserMailer do
+RSpec.describe UserMailer do
   let(:receiver) { Fabricate(:user) }
 
   describe '#confirmation_instructions' do

--- a/spec/models/account_filter_spec.rb
+++ b/spec/models/account_filter_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe AccountFilter do
+RSpec.describe AccountFilter do
   describe 'with empty params' do
     it 'excludes instance actor by default' do
       filter = described_class.new({})

--- a/spec/models/account_warning_preset_spec.rb
+++ b/spec/models/account_warning_preset_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe AccountWarningPreset do
+RSpec.describe AccountWarningPreset do
   describe 'alphabetical' do
     let(:first) { Fabricate(:account_warning_preset, title: 'aaa', text: 'aaa') }
     let(:second) { Fabricate(:account_warning_preset, title: 'bbb', text: 'aaa') }

--- a/spec/models/admin/appeal_filter_spec.rb
+++ b/spec/models/admin/appeal_filter_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::AppealFilter do
+RSpec.describe Admin::AppealFilter do
   describe '#results' do
     let(:approved_appeal) { Fabricate(:appeal, approved_at: 10.days.ago) }
     let(:not_approved_appeal) { Fabricate(:appeal, approved_at: nil) }

--- a/spec/models/admin/tag_filter_spec.rb
+++ b/spec/models/admin/tag_filter_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::TagFilter do
+RSpec.describe Admin::TagFilter do
   describe 'with invalid params' do
     it 'raises with key error' do
       filter = described_class.new(wrong: true)

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Announcement do
+RSpec.describe Announcement do
   describe 'Scopes' do
     context 'with published and unpublished records' do
       let!(:published) { Fabricate(:announcement, published: true) }

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Appeal do
+RSpec.describe Appeal do
   describe 'Validations' do
     it 'validates text length is under limit' do
       appeal = Fabricate.build(

--- a/spec/models/concerns/account/counters_spec.rb
+++ b/spec/models/concerns/account/counters_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Account::Counters do
+RSpec.describe Account::Counters do
   let!(:account) { Fabricate(:account) }
 
   describe '#increment_count!' do

--- a/spec/models/concerns/account/finder_concern_spec.rb
+++ b/spec/models/concerns/account/finder_concern_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Account::FinderConcern do
+RSpec.describe Account::FinderConcern do
   describe 'local finders' do
     let!(:account) { Fabricate(:account, username: 'Alice') }
 

--- a/spec/models/concerns/account/interactions_spec.rb
+++ b/spec/models/concerns/account/interactions_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Account::Interactions do
+RSpec.describe Account::Interactions do
   let(:account)            { Fabricate(:account, username: 'account') }
   let(:account_id)         { account.id }
   let(:account_ids)        { [account_id] }

--- a/spec/models/concerns/account/statuses_search_spec.rb
+++ b/spec/models/concerns/account/statuses_search_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Account::StatusesSearch do
+RSpec.describe Account::StatusesSearch do
   let(:account) { Fabricate(:account, indexable: indexable) }
 
   before do

--- a/spec/models/concerns/status/threading_concern_spec.rb
+++ b/spec/models/concerns/status/threading_concern_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Status::ThreadingConcern do
+RSpec.describe Status::ThreadingConcern do
   describe '#ancestors' do
     let!(:alice)  { Fabricate(:account, username: 'alice') }
     let!(:bob)    { Fabricate(:account, username: 'bob', domain: 'example.com') }

--- a/spec/models/custom_emoji_category_spec.rb
+++ b/spec/models/custom_emoji_category_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe CustomEmojiCategory do
+RSpec.describe CustomEmojiCategory do
   describe 'validations' do
     it 'validates name presence' do
       record = described_class.new(name: nil)

--- a/spec/models/domain_allow_spec.rb
+++ b/spec/models/domain_allow_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe DomainAllow do
+RSpec.describe DomainAllow do
   describe 'Validations' do
     it 'is invalid without a domain' do
       domain_allow = Fabricate.build(:domain_allow, domain: nil)

--- a/spec/models/export_spec.rb
+++ b/spec/models/export_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Export do
+RSpec.describe Export do
   let(:account) { Fabricate(:account) }
   let(:target_accounts) do
     [{}, { username: 'one', domain: 'local.host' }].map(&method(:Fabricate).curry(2).call(:account))

--- a/spec/models/extended_description_spec.rb
+++ b/spec/models/extended_description_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe ExtendedDescription do
+RSpec.describe ExtendedDescription do
   describe '.current' do
     context 'with the default values' do
       it 'makes a new instance' do

--- a/spec/models/form/admin_settings_spec.rb
+++ b/spec/models/form/admin_settings_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Form::AdminSettings do
+RSpec.describe Form::AdminSettings do
   describe 'validations' do
     describe 'site_contact_username' do
       context 'with no accounts' do

--- a/spec/models/form/custom_emoji_batch_spec.rb
+++ b/spec/models/form/custom_emoji_batch_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Form::CustomEmojiBatch do
+RSpec.describe Form::CustomEmojiBatch do
   describe '#save' do
     subject { described_class.new({ current_account: account }.merge(options)) }
 

--- a/spec/models/form/status_filter_batch_action_spec.rb
+++ b/spec/models/form/status_filter_batch_action_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Form::StatusFilterBatchAction do
+RSpec.describe Form::StatusFilterBatchAction do
   describe '#save!' do
     it 'does nothing if status_filter_ids is empty' do
       batch_action = described_class.new(status_filter_ids: [])

--- a/spec/models/ip_block_spec.rb
+++ b/spec/models/ip_block_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe IpBlock do
+RSpec.describe IpBlock do
   describe 'validations' do
     it 'validates ip presence', :aggregate_failures do
       ip_block = described_class.new(ip: nil, severity: :no_access)

--- a/spec/models/marker_spec.rb
+++ b/spec/models/marker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Marker do
+RSpec.describe Marker do
   describe 'validations' do
     describe 'timeline' do
       it 'must be included in valid list' do

--- a/spec/models/one_time_key_spec.rb
+++ b/spec/models/one_time_key_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe OneTimeKey do
+RSpec.describe OneTimeKey do
   describe 'validations' do
     context 'with an invalid signature' do
       let(:one_time_key) { Fabricate.build(:one_time_key, signature: 'wrong!') }

--- a/spec/models/poll_spec.rb
+++ b/spec/models/poll_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Poll do
+RSpec.describe Poll do
   describe 'scopes' do
     let(:status) { Fabricate(:status) }
     let(:attached_poll) { Fabricate(:poll, status: status) }

--- a/spec/models/preview_card_provider_spec.rb
+++ b/spec/models/preview_card_provider_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe PreviewCardProvider do
+RSpec.describe PreviewCardProvider do
   include_examples 'Reviewable'
 
   describe 'scopes' do

--- a/spec/models/preview_card_spec.rb
+++ b/spec/models/preview_card_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe PreviewCard do
+RSpec.describe PreviewCard do
   describe 'validations' do
     describe 'urls' do
       it 'allows http schemes' do

--- a/spec/models/privacy_policy_spec.rb
+++ b/spec/models/privacy_policy_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe PrivacyPolicy do
+RSpec.describe PrivacyPolicy do
   describe '.current' do
     context 'with the default values' do
       it 'has the privacy text' do

--- a/spec/models/relationship_filter_spec.rb
+++ b/spec/models/relationship_filter_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe RelationshipFilter do
+RSpec.describe RelationshipFilter do
   let(:account) { Fabricate(:account) }
 
   describe '#results' do

--- a/spec/models/report_filter_spec.rb
+++ b/spec/models/report_filter_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe ReportFilter do
+RSpec.describe ReportFilter do
   describe 'with empty params' do
     it 'defaults to unresolved reports list' do
       filter = described_class.new({})

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Report do
+RSpec.describe Report do
   describe 'statuses' do
     it 'returns the statuses for the report' do
       status = Fabricate(:status)

--- a/spec/models/rule_spec.rb
+++ b/spec/models/rule_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Rule do
+RSpec.describe Rule do
   describe 'scopes' do
     describe 'ordered' do
       let(:deleted_rule) { Fabricate(:rule, deleted_at: 10.days.ago) }

--- a/spec/models/status_edit_spec.rb
+++ b/spec/models/status_edit_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe StatusEdit do
+RSpec.describe StatusEdit do
   describe '#reblog?' do
     it 'returns false' do
       record = described_class.new

--- a/spec/models/tag_feed_spec.rb
+++ b/spec/models/tag_feed_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe TagFeed do
+RSpec.describe TagFeed do
   describe '#get' do
     let(:account) { Fabricate(:account) }
     let(:tag_cats) { Fabricate(:tag, name: 'cats') }

--- a/spec/policies/account_warning_preset_policy_spec.rb
+++ b/spec/policies/account_warning_preset_policy_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'pundit/rspec'
 
-describe AccountWarningPresetPolicy do
+RSpec.describe AccountWarningPresetPolicy do
   let(:policy) { described_class }
   let(:admin)   { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
   let(:john)    { Fabricate(:account) }

--- a/spec/policies/admin/status_policy_spec.rb
+++ b/spec/policies/admin/status_policy_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'pundit/rspec'
 
-describe Admin::StatusPolicy do
+RSpec.describe Admin::StatusPolicy do
   let(:policy) { described_class }
   let(:admin)   { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
   let(:john)    { Fabricate(:account) }

--- a/spec/policies/announcement_policy_spec.rb
+++ b/spec/policies/announcement_policy_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'pundit/rspec'
 
-describe AnnouncementPolicy do
+RSpec.describe AnnouncementPolicy do
   let(:policy) { described_class }
   let(:admin)   { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
   let(:john)    { Fabricate(:account) }

--- a/spec/policies/appeal_policy_spec.rb
+++ b/spec/policies/appeal_policy_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'pundit/rspec'
 
-describe AppealPolicy do
+RSpec.describe AppealPolicy do
   let(:policy) { described_class }
   let(:admin)   { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
   let(:john)    { Fabricate(:account) }

--- a/spec/policies/canonical_email_block_policy_spec.rb
+++ b/spec/policies/canonical_email_block_policy_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'pundit/rspec'
 
-describe CanonicalEmailBlockPolicy do
+RSpec.describe CanonicalEmailBlockPolicy do
   let(:policy) { described_class }
   let(:admin)   { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
   let(:john)    { Fabricate(:account) }

--- a/spec/policies/delivery_policy_spec.rb
+++ b/spec/policies/delivery_policy_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'pundit/rspec'
 
-describe DeliveryPolicy do
+RSpec.describe DeliveryPolicy do
   let(:policy) { described_class }
   let(:admin)   { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
   let(:john)    { Fabricate(:account) }

--- a/spec/policies/follow_recommendation_policy_spec.rb
+++ b/spec/policies/follow_recommendation_policy_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'pundit/rspec'
 
-describe FollowRecommendationPolicy do
+RSpec.describe FollowRecommendationPolicy do
   let(:policy) { described_class }
   let(:admin)   { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
   let(:john)    { Fabricate(:account) }

--- a/spec/policies/ip_block_policy_spec.rb
+++ b/spec/policies/ip_block_policy_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'pundit/rspec'
 
-describe IpBlockPolicy do
+RSpec.describe IpBlockPolicy do
   let(:policy) { described_class }
   let(:admin)   { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
   let(:john)    { Fabricate(:account) }

--- a/spec/policies/preview_card_policy_spec.rb
+++ b/spec/policies/preview_card_policy_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'pundit/rspec'
 
-describe PreviewCardPolicy do
+RSpec.describe PreviewCardPolicy do
   let(:policy) { described_class }
   let(:admin)   { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
   let(:john)    { Fabricate(:account) }

--- a/spec/policies/preview_card_provider_policy_spec.rb
+++ b/spec/policies/preview_card_provider_policy_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'pundit/rspec'
 
-describe PreviewCardProviderPolicy do
+RSpec.describe PreviewCardProviderPolicy do
   let(:policy) { described_class }
   let(:admin)   { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
   let(:john)    { Fabricate(:account) }

--- a/spec/policies/rule_policy_spec.rb
+++ b/spec/policies/rule_policy_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'pundit/rspec'
 
-describe RulePolicy do
+RSpec.describe RulePolicy do
   let(:policy) { described_class }
   let(:admin)   { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
   let(:john)    { Fabricate(:account) }

--- a/spec/policies/webhook_policy_spec.rb
+++ b/spec/policies/webhook_policy_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'pundit/rspec'
 
-describe WebhookPolicy do
+RSpec.describe WebhookPolicy do
   let(:policy) { described_class }
   let(:admin)   { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
   let(:john)    { Fabricate(:account) }

--- a/spec/presenters/instance_presenter_spec.rb
+++ b/spec/presenters/instance_presenter_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe InstancePresenter do
+RSpec.describe InstancePresenter do
   let(:instance_presenter) { described_class.new }
 
   describe '#description' do

--- a/spec/requests/account_show_page_spec.rb
+++ b/spec/requests/account_show_page_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'The account show page' do
+RSpec.describe 'The account show page' do
   it 'has valid opengraph tags' do
     alice = Fabricate(:account, username: 'alice', display_name: 'Alice')
     _status = Fabricate(:status, account: alice, text: 'Hello World')

--- a/spec/requests/accounts_spec.rb
+++ b/spec/requests/accounts_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Accounts show response' do
+RSpec.describe 'Accounts show response' do
   let(:account) { Fabricate(:account) }
 
   context 'with an unapproved account' do

--- a/spec/requests/anonymous_cookies_spec.rb
+++ b/spec/requests/anonymous_cookies_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Anonymous visits' do
+RSpec.describe 'Anonymous visits' do
   around do |example|
     old = ActionController::Base.allow_forgery_protection
     ActionController::Base.allow_forgery_protection = true

--- a/spec/requests/api/v1/accounts/familiar_followers_spec.rb
+++ b/spec/requests/api/v1/accounts/familiar_followers_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Accounts Familiar Followers API' do
+RSpec.describe 'Accounts Familiar Followers API' do
   let(:user)     { Fabricate(:user) }
   let(:token)    { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:scopes)   { 'read:follows' }

--- a/spec/requests/api/v1/accounts/follower_accounts_spec.rb
+++ b/spec/requests/api/v1/accounts/follower_accounts_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'API V1 Accounts FollowerAccounts' do
+RSpec.describe 'API V1 Accounts FollowerAccounts' do
   let(:user)    { Fabricate(:user) }
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:scopes)   { 'read:accounts' }

--- a/spec/requests/api/v1/accounts/following_accounts_spec.rb
+++ b/spec/requests/api/v1/accounts/following_accounts_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'API V1 Accounts FollowingAccounts' do
+RSpec.describe 'API V1 Accounts FollowingAccounts' do
   let(:user)    { Fabricate(:user) }
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:scopes)   { 'read:accounts' }

--- a/spec/requests/api/v1/accounts/identity_proofs_spec.rb
+++ b/spec/requests/api/v1/accounts/identity_proofs_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Accounts Identity Proofs API' do
+RSpec.describe 'Accounts Identity Proofs API' do
   let(:user)     { Fabricate(:user) }
   let(:token)    { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:scopes)   { 'read:accounts' }

--- a/spec/requests/api/v1/accounts/lists_spec.rb
+++ b/spec/requests/api/v1/accounts/lists_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Accounts Lists API' do
+RSpec.describe 'Accounts Lists API' do
   let(:user)     { Fabricate(:user) }
   let(:token)    { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:scopes)   { 'read:lists' }

--- a/spec/requests/api/v1/accounts/lookup_spec.rb
+++ b/spec/requests/api/v1/accounts/lookup_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Accounts Lookup API' do
+RSpec.describe 'Accounts Lookup API' do
   let(:user)     { Fabricate(:user) }
   let(:token)    { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:scopes)   { 'read:accounts' }

--- a/spec/requests/api/v1/accounts/notes_spec.rb
+++ b/spec/requests/api/v1/accounts/notes_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Accounts Notes API' do
+RSpec.describe 'Accounts Notes API' do
   let(:user)     { Fabricate(:user) }
   let(:token)    { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:scopes)   { 'write:accounts' }

--- a/spec/requests/api/v1/accounts/pins_spec.rb
+++ b/spec/requests/api/v1/accounts/pins_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Accounts Pins API' do
+RSpec.describe 'Accounts Pins API' do
   let(:user)     { Fabricate(:user) }
   let(:token)    { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:scopes)   { 'write:accounts' }

--- a/spec/requests/api/v1/accounts/relationships_spec.rb
+++ b/spec/requests/api/v1/accounts/relationships_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'GET /api/v1/accounts/relationships' do
+RSpec.describe 'GET /api/v1/accounts/relationships' do
   subject do
     get '/api/v1/accounts/relationships', headers: headers, params: params
   end

--- a/spec/requests/api/v1/accounts/search_spec.rb
+++ b/spec/requests/api/v1/accounts/search_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Accounts Search API' do
+RSpec.describe 'Accounts Search API' do
   let(:user)     { Fabricate(:user) }
   let(:token)    { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:scopes)   { 'read:accounts' }

--- a/spec/requests/api/v1/accounts/statuses_spec.rb
+++ b/spec/requests/api/v1/accounts/statuses_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'API V1 Accounts Statuses' do
+RSpec.describe 'API V1 Accounts Statuses' do
   let(:user) { Fabricate(:user) }
   let(:scopes) { 'read:statuses' }
   let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }

--- a/spec/requests/api/v1/accounts_spec.rb
+++ b/spec/requests/api/v1/accounts_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe '/api/v1/accounts' do
+RSpec.describe '/api/v1/accounts' do
   let(:user)    { Fabricate(:user) }
   let(:scopes)  { '' }
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }

--- a/spec/requests/api/v1/admin/dimensions_spec.rb
+++ b/spec/requests/api/v1/admin/dimensions_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Admin Dimensions' do
+RSpec.describe 'Admin Dimensions' do
   let(:user)    { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }

--- a/spec/requests/api/v1/admin/measures_spec.rb
+++ b/spec/requests/api/v1/admin/measures_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Admin Measures' do
+RSpec.describe 'Admin Measures' do
   let(:user)    { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }

--- a/spec/requests/api/v1/admin/retention_spec.rb
+++ b/spec/requests/api/v1/admin/retention_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Admin Retention' do
+RSpec.describe 'Admin Retention' do
   let(:user)    { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }

--- a/spec/requests/api/v1/admin/trends/links/links_spec.rb
+++ b/spec/requests/api/v1/admin/trends/links/links_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Links' do
+RSpec.describe 'Links' do
   let(:role)    { UserRole.find_by(name: 'Admin') }
   let(:user)    { Fabricate(:user, role: role) }
   let(:scopes)  { 'admin:read admin:write' }

--- a/spec/requests/api/v1/admin/trends/links/preview_card_providers_spec.rb
+++ b/spec/requests/api/v1/admin/trends/links/preview_card_providers_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'API V1 Admin Trends Links Preview Card Providers' do
+RSpec.describe 'API V1 Admin Trends Links Preview Card Providers' do
   let(:role)   { UserRole.find_by(name: 'Admin') }
   let(:user)   { Fabricate(:user, role: role) }
   let(:scopes) { 'admin:read admin:write' }

--- a/spec/requests/api/v1/admin/trends/statuses_spec.rb
+++ b/spec/requests/api/v1/admin/trends/statuses_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'API V1 Admin Trends Statuses' do
+RSpec.describe 'API V1 Admin Trends Statuses' do
   let(:role)   { UserRole.find_by(name: 'Admin') }
   let(:user)   { Fabricate(:user, role: role) }
   let(:scopes) { 'admin:read admin:write' }

--- a/spec/requests/api/v1/admin/trends/tags_spec.rb
+++ b/spec/requests/api/v1/admin/trends/tags_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'API V1 Admin Trends Tags' do
+RSpec.describe 'API V1 Admin Trends Tags' do
   let(:role)   { UserRole.find_by(name: 'Admin') }
   let(:user)   { Fabricate(:user, role: role) }
   let(:scopes) { 'admin:read admin:write' }

--- a/spec/requests/api/v1/annual_reports_spec.rb
+++ b/spec/requests/api/v1/annual_reports_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'API V1 Annual Reports' do
+RSpec.describe 'API V1 Annual Reports' do
   let(:user)    { Fabricate(:user) }
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }

--- a/spec/requests/api/v1/apps/credentials_spec.rb
+++ b/spec/requests/api/v1/apps/credentials_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Credentials' do
+RSpec.describe 'Credentials' do
   describe 'GET /api/v1/apps/verify_credentials' do
     subject do
       get '/api/v1/apps/verify_credentials', headers: headers

--- a/spec/requests/api/v1/csp_spec.rb
+++ b/spec/requests/api/v1/csp_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'API namespace minimal Content-Security-Policy' do
+RSpec.describe 'API namespace minimal Content-Security-Policy' do
   before { stub_tests_controller }
 
   after { Rails.application.reload_routes! }

--- a/spec/requests/api/v1/custom_emojis_spec.rb
+++ b/spec/requests/api/v1/custom_emojis_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Custom Emojis' do
+RSpec.describe 'Custom Emojis' do
   let(:user)    { Fabricate(:user) }
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id) }
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }

--- a/spec/requests/api/v1/directories_spec.rb
+++ b/spec/requests/api/v1/directories_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Directories API' do
+RSpec.describe 'Directories API' do
   let(:user)    { Fabricate(:user, confirmed_at: nil) }
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:scopes)  { 'read:follows' }

--- a/spec/requests/api/v1/endorsements_spec.rb
+++ b/spec/requests/api/v1/endorsements_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Endorsements' do
+RSpec.describe 'Endorsements' do
   let(:user)    { Fabricate(:user) }
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }

--- a/spec/requests/api/v1/featured_tags/suggestions_spec.rb
+++ b/spec/requests/api/v1/featured_tags/suggestions_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Featured Tags Suggestions API' do
+RSpec.describe 'Featured Tags Suggestions API' do
   let(:user)    { Fabricate(:user) }
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:scopes)  { 'read:accounts' }

--- a/spec/requests/api/v1/instance_spec.rb
+++ b/spec/requests/api/v1/instance_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Instances' do
+RSpec.describe 'Instances' do
   let(:user)    { Fabricate(:user) }
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id) }
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }

--- a/spec/requests/api/v1/instances/translation_languages_spec.rb
+++ b/spec/requests/api/v1/instances/translation_languages_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Translation Languages' do
+RSpec.describe 'Translation Languages' do
   describe 'GET /api/v1/instances/translation_languages' do
     context 'when no translation service is configured' do
       it 'returns empty language matrix', :aggregate_failures do

--- a/spec/requests/api/v1/peers/search_spec.rb
+++ b/spec/requests/api/v1/peers/search_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'API Peers Search' do
+RSpec.describe 'API Peers Search' do
   describe 'GET /api/v1/peers/search' do
     context 'when peers api is disabled' do
       before do

--- a/spec/requests/api/v1/preferences_spec.rb
+++ b/spec/requests/api/v1/preferences_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Preferences' do
+RSpec.describe 'Preferences' do
   let(:user)    { Fabricate(:user) }
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }

--- a/spec/requests/api/v1/push/subscriptions_spec.rb
+++ b/spec/requests/api/v1/push/subscriptions_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'API V1 Push Subscriptions' do
+RSpec.describe 'API V1 Push Subscriptions' do
   let(:user) { Fabricate(:user) }
   let(:endpoint) { 'https://fcm.googleapis.com/fcm/send/fiuH06a27qE:APA91bHnSiGcLwdaxdyqVXNDR9w1NlztsHb6lyt5WDKOC_Z_Q8BlFxQoR8tWFSXUIDdkyw0EdvxTu63iqamSaqVSevW5LfoFwojws8XYDXv_NRRLH6vo2CdgiN4jgHv5VLt2A8ah6lUX' }
   let(:keys) do

--- a/spec/requests/api/v1/scheduled_status_spec.rb
+++ b/spec/requests/api/v1/scheduled_status_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Scheduled Statuses' do
+RSpec.describe 'Scheduled Statuses' do
   let(:user)    { Fabricate(:user) }
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }

--- a/spec/requests/api/v1/statuses/histories_spec.rb
+++ b/spec/requests/api/v1/statuses/histories_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'API V1 Statuses Histories' do
+RSpec.describe 'API V1 Statuses Histories' do
   let(:user)  { Fabricate(:user) }
   let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:scopes)  { 'read:statuses' }

--- a/spec/requests/api/v1/statuses/mutes_spec.rb
+++ b/spec/requests/api/v1/statuses/mutes_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'API V1 Statuses Mutes' do
+RSpec.describe 'API V1 Statuses Mutes' do
   let(:user)  { Fabricate(:user) }
   let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:scopes)  { 'write:mutes' }

--- a/spec/requests/api/v1/statuses/pins_spec.rb
+++ b/spec/requests/api/v1/statuses/pins_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Pins' do
+RSpec.describe 'Pins' do
   let(:user)    { Fabricate(:user) }
   let(:scopes)  { 'write:accounts' }
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }

--- a/spec/requests/api/v1/statuses/reblogs_spec.rb
+++ b/spec/requests/api/v1/statuses/reblogs_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'API V1 Statuses Reblogs' do
+RSpec.describe 'API V1 Statuses Reblogs' do
   let(:user)  { Fabricate(:user) }
   let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:scopes)  { 'write:statuses' }

--- a/spec/requests/api/v1/statuses/translations_spec.rb
+++ b/spec/requests/api/v1/statuses/translations_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'API V1 Statuses Translations' do
+RSpec.describe 'API V1 Statuses Translations' do
   let(:user)  { Fabricate(:user) }
   let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:scopes)  { 'read:statuses' }

--- a/spec/requests/api/v1/statuses_spec.rb
+++ b/spec/requests/api/v1/statuses_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe '/api/v1/statuses' do
+RSpec.describe '/api/v1/statuses' do
   context 'with an oauth token' do
     let(:user)  { Fabricate(:user) }
     let(:client_app) { Fabricate(:application, name: 'Test app', website: 'http://testapp.com') }

--- a/spec/requests/api/v1/streaming_spec.rb
+++ b/spec/requests/api/v1/streaming_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'API V1 Streaming' do
+RSpec.describe 'API V1 Streaming' do
   around do |example|
     before = Rails.configuration.x.streaming_api_base_url
     Rails.configuration.x.streaming_api_base_url = "wss://#{Rails.configuration.x.web_domain}"

--- a/spec/requests/api/v1/timelines/home_spec.rb
+++ b/spec/requests/api/v1/timelines/home_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Home', :inline_jobs do
+RSpec.describe 'Home', :inline_jobs do
   let(:user)    { Fabricate(:user) }
   let(:scopes)  { 'read:statuses' }
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }

--- a/spec/requests/api/v1/timelines/link_spec.rb
+++ b/spec/requests/api/v1/timelines/link_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Link' do
+RSpec.describe 'Link' do
   let(:user)    { Fabricate(:user) }
   let(:scopes)  { 'read:statuses' }
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }

--- a/spec/requests/api/v1/timelines/list_spec.rb
+++ b/spec/requests/api/v1/timelines/list_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'API V1 Timelines List' do
+RSpec.describe 'API V1 Timelines List' do
   let(:user) { Fabricate(:user) }
   let(:scopes)  { 'read:statuses' }
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }

--- a/spec/requests/api/v1/timelines/public_spec.rb
+++ b/spec/requests/api/v1/timelines/public_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Public' do
+RSpec.describe 'Public' do
   let(:user)    { Fabricate(:user) }
   let(:scopes)  { 'read:statuses' }
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }

--- a/spec/requests/api/v2/instance_spec.rb
+++ b/spec/requests/api/v2/instance_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Instances' do
+RSpec.describe 'Instances' do
   let(:user)    { Fabricate(:user) }
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id) }
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }

--- a/spec/requests/api/v2/search_spec.rb
+++ b/spec/requests/api/v2/search_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Search API' do
+RSpec.describe 'Search API' do
   context 'with token' do
     let(:user)    { Fabricate(:user) }
     let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }

--- a/spec/requests/api/v2/suggestions_spec.rb
+++ b/spec/requests/api/v2/suggestions_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Suggestions API' do
+RSpec.describe 'Suggestions API' do
   let(:user)    { Fabricate(:user) }
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:scopes)  { 'read' }

--- a/spec/requests/backups_spec.rb
+++ b/spec/requests/backups_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Backups' do
+RSpec.describe 'Backups' do
   include RoutingHelper
 
   describe 'GET backups#download' do

--- a/spec/requests/cache_spec.rb
+++ b/spec/requests/cache_spec.rb
@@ -118,7 +118,7 @@ module TestEndpoints
   end
 end
 
-describe 'Caching behavior' do
+RSpec.describe 'Caching behavior' do
   shared_examples 'cachable response' do |http_success: false|
     it 'does not set cookies or set public cache control', :aggregate_failures do
       expect(response.cookies).to be_empty

--- a/spec/requests/catch_all_route_request_spec.rb
+++ b/spec/requests/catch_all_route_request_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'The catch all route' do
+RSpec.describe 'The catch all route' do
   describe 'with a simple value' do
     it 'returns a 404 page as html' do
       get '/test'

--- a/spec/requests/content_security_policy_spec.rb
+++ b/spec/requests/content_security_policy_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Content-Security-Policy' do
+RSpec.describe 'Content-Security-Policy' do
   before { allow(SecureRandom).to receive(:base64).with(16).and_return('ZbA+JmE7+bK8F5qvADZHuQ==') }
 
   it 'sets the expected CSP headers' do

--- a/spec/requests/custom_css_spec.rb
+++ b/spec/requests/custom_css_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Custom CSS' do
+RSpec.describe 'Custom CSS' do
   include RoutingHelper
 
   describe 'GET /custom.css' do

--- a/spec/requests/custom_stylesheets_spec.rb
+++ b/spec/requests/custom_stylesheets_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Custom stylesheets' do
+RSpec.describe 'Custom stylesheets' do
   describe 'GET /custom.css' do
     before { get '/custom.css' }
 

--- a/spec/requests/disabled_oauth_endpoints_spec.rb
+++ b/spec/requests/disabled_oauth_endpoints_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Disabled OAuth routes' do
+RSpec.describe 'Disabled OAuth routes' do
   # These routes are disabled via the doorkeeper configuration for
   # `admin_authenticator`, as these routes should only be accessible by server
   # administrators. For now, these routes are not properly designed and

--- a/spec/requests/emojis_spec.rb
+++ b/spec/requests/emojis_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Emojis' do
+RSpec.describe 'Emojis' do
   describe 'GET /emojis/:id' do
     let(:emoji) { Fabricate(:custom_emoji, shortcode: 'coolcat') }
 

--- a/spec/requests/health_spec.rb
+++ b/spec/requests/health_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Health check endpoint' do
+RSpec.describe 'Health check endpoint' do
   describe 'GET /health' do
     it 'returns http success when server is functioning' do
       get '/health'

--- a/spec/requests/invite_spec.rb
+++ b/spec/requests/invite_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'invites' do
+RSpec.describe 'invites' do
   let(:invite) { Fabricate(:invite) }
 
   context 'when requesting a JSON document' do

--- a/spec/requests/link_headers_spec.rb
+++ b/spec/requests/link_headers_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Link headers' do
+RSpec.describe 'Link headers' do
   describe 'on the account show page' do
     let(:account) { Fabricate(:account, username: 'test') }
 

--- a/spec/requests/localization_spec.rb
+++ b/spec/requests/localization_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Localization' do
+RSpec.describe 'Localization' do
   around do |example|
     I18n.with_locale(I18n.locale) do
       example.run

--- a/spec/requests/log_out_spec.rb
+++ b/spec/requests/log_out_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Log Out' do
+RSpec.describe 'Log Out' do
   include RoutingHelper
 
   describe 'DELETE /auth/sign_out' do

--- a/spec/requests/manifest_spec.rb
+++ b/spec/requests/manifest_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Manifest' do
+RSpec.describe 'Manifest' do
   describe 'GET /manifest' do
     before { get '/manifest' }
 

--- a/spec/requests/media_proxy_spec.rb
+++ b/spec/requests/media_proxy_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Media Proxy' do
+RSpec.describe 'Media Proxy' do
   describe 'GET /media_proxy/:id' do
     before { stub_attachment_request }
 

--- a/spec/requests/omniauth_callbacks_spec.rb
+++ b/spec/requests/omniauth_callbacks_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'OmniAuth callbacks' do
+RSpec.describe 'OmniAuth callbacks' do
   shared_examples 'omniauth provider callbacks' do |provider|
     subject { post send :"user_#{provider}_omniauth_callback_path" }
 

--- a/spec/requests/remote_interaction_helper_spec.rb
+++ b/spec/requests/remote_interaction_helper_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Remote Interaction Helper' do
+RSpec.describe 'Remote Interaction Helper' do
   describe 'GET /remote_interaction_helper' do
     it 'returns http success' do
       get remote_interaction_helper_path

--- a/spec/requests/self_destruct_spec.rb
+++ b/spec/requests/self_destruct_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Self-destruct mode' do
+RSpec.describe 'Self-destruct mode' do
   before do
     allow(SelfDestructHelper).to receive(:self_destruct?).and_return(true)
   end

--- a/spec/requests/settings/exports/blocked_accounts_spec.rb
+++ b/spec/requests/settings/exports/blocked_accounts_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Settings / Exports / Blocked Accounts' do
+RSpec.describe 'Settings / Exports / Blocked Accounts' do
   describe 'GET /settings/exports/blocks' do
     context 'with a signed in user who has blocked accounts' do
       let(:user) { Fabricate :user }

--- a/spec/requests/settings/exports/blocked_domains_spec.rb
+++ b/spec/requests/settings/exports/blocked_domains_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Settings / Exports / Blocked Domains' do
+RSpec.describe 'Settings / Exports / Blocked Domains' do
   describe 'GET /settings/exports/domain_blocks' do
     context 'with a signed in user who has blocked domains' do
       let(:account) { Fabricate :account, domain: 'example.com' }

--- a/spec/requests/settings/exports/bookmarks_spec.rb
+++ b/spec/requests/settings/exports/bookmarks_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Settings / Exports / Bookmarks' do
+RSpec.describe 'Settings / Exports / Bookmarks' do
   describe 'GET /settings/exports/bookmarks' do
     context 'with a signed in user who has bookmarks' do
       let(:account) { Fabricate(:account, domain: 'foo.bar') }

--- a/spec/requests/settings/exports/following_accounts_spec.rb
+++ b/spec/requests/settings/exports/following_accounts_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Settings / Exports / Following Accounts' do
+RSpec.describe 'Settings / Exports / Following Accounts' do
   describe 'GET /settings/exports/follows' do
     context 'with a signed in user who is following accounts' do
       let(:user) { Fabricate :user }

--- a/spec/requests/settings/exports/lists_spec.rb
+++ b/spec/requests/settings/exports/lists_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Settings / Exports / Lists' do
+RSpec.describe 'Settings / Exports / Lists' do
   describe 'GET /settings/exports/lists' do
     context 'with a signed in user who has lists' do
       let(:account) { Fabricate(:account, username: 'test', domain: 'example.com') }

--- a/spec/requests/settings/exports/muted_accounts_spec.rb
+++ b/spec/requests/settings/exports/muted_accounts_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Settings / Exports / Muted Accounts' do
+RSpec.describe 'Settings / Exports / Muted Accounts' do
   describe 'GET /settings/exports/mutes' do
     context 'with a signed in user who has muted accounts' do
       let(:user) { Fabricate :user }

--- a/spec/requests/signature_verification_spec.rb
+++ b/spec/requests/signature_verification_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'signature verification concern' do
+RSpec.describe 'signature verification concern' do
   before do
     stub_tests_controller
 

--- a/spec/requests/well_known/change_password_spec.rb
+++ b/spec/requests/well_known/change_password_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'The /.well-known/change-password request' do
+RSpec.describe 'The /.well-known/change-password request' do
   it 'redirects to the change password page' do
     get '/.well-known/change-password'
 

--- a/spec/requests/well_known/host_meta_spec.rb
+++ b/spec/requests/well_known/host_meta_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'The /.well-known/host-meta request' do
+RSpec.describe 'The /.well-known/host-meta request' do
   it 'returns http success with valid XML response' do
     get '/.well-known/host-meta'
 

--- a/spec/requests/well_known/node_info_spec.rb
+++ b/spec/requests/well_known/node_info_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'The well-known node-info endpoints' do
+RSpec.describe 'The well-known node-info endpoints' do
   describe 'The /.well-known/node-info endpoint' do
     it 'returns JSON document pointing to node info' do
       get '/.well-known/nodeinfo'

--- a/spec/requests/well_known/oauth_metadata_spec.rb
+++ b/spec/requests/well_known/oauth_metadata_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'The /.well-known/oauth-authorization-server request' do
+RSpec.describe 'The /.well-known/oauth-authorization-server request' do
   let(:protocol) { ENV.fetch('LOCAL_HTTPS', true) ? :https : :http }
 
   before do

--- a/spec/requests/well_known/webfinger_spec.rb
+++ b/spec/requests/well_known/webfinger_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'The /.well-known/webfinger endpoint' do
+RSpec.describe 'The /.well-known/webfinger endpoint' do
   subject(:perform_request!) { get webfinger_url(resource: resource) }
 
   let(:alternate_domains) { [] }

--- a/spec/routing/accounts_routing_spec.rb
+++ b/spec/routing/accounts_routing_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Routes under accounts/' do
+RSpec.describe 'Routes under accounts/' do
   context 'with local username' do
     let(:username) { 'alice' }
 

--- a/spec/routing/api_routing_spec.rb
+++ b/spec/routing/api_routing_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'API routes' do
+RSpec.describe 'API routes' do
   describe 'Credentials routes' do
     it 'routes to verify credentials' do
       expect(get('/api/v1/accounts/verify_credentials'))

--- a/spec/routing/well_known_routes_spec.rb
+++ b/spec/routing/well_known_routes_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Well Known routes' do
+RSpec.describe 'Well Known routes' do
   describe 'the host-meta route' do
     it 'routes to correct place with xml format' do
       expect(get('/.well-known/host-meta'))

--- a/spec/search/models/concerns/account/search_spec.rb
+++ b/spec/search/models/concerns/account/search_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Account::Search do
+RSpec.describe Account::Search do
   describe 'a non-discoverable account becoming discoverable' do
     let(:account) { Account.find_by(username: 'search_test_account_1') }
 

--- a/spec/search/models/concerns/account/statuses_search_spec.rb
+++ b/spec/search/models/concerns/account/statuses_search_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Account::StatusesSearch, :inline_jobs do
+RSpec.describe Account::StatusesSearch, :inline_jobs do
   describe 'a non-indexable account becoming indexable' do
     let(:account) { Account.find_by(username: 'search_test_account_1') }
 

--- a/spec/serializers/activitypub/device_serializer_spec.rb
+++ b/spec/serializers/activitypub/device_serializer_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe ActivityPub::DeviceSerializer do
+RSpec.describe ActivityPub::DeviceSerializer do
   let(:serialization) { serialized_record_json(record, described_class) }
   let(:record) { Fabricate(:device) }
 

--- a/spec/serializers/activitypub/note_serializer_spec.rb
+++ b/spec/serializers/activitypub/note_serializer_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe ActivityPub::NoteSerializer do
+RSpec.describe ActivityPub::NoteSerializer do
   subject { serialized_record_json(parent, described_class, adapter: ActivityPub::Adapter) }
 
   let!(:account) { Fabricate(:account) }

--- a/spec/serializers/activitypub/one_time_key_serializer_spec.rb
+++ b/spec/serializers/activitypub/one_time_key_serializer_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe ActivityPub::OneTimeKeySerializer do
+RSpec.describe ActivityPub::OneTimeKeySerializer do
   let(:serialization) { serialized_record_json(record, described_class) }
   let(:record) { Fabricate(:one_time_key) }
 

--- a/spec/serializers/activitypub/undo_like_serializer_spec.rb
+++ b/spec/serializers/activitypub/undo_like_serializer_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe ActivityPub::UndoLikeSerializer do
+RSpec.describe ActivityPub::UndoLikeSerializer do
   let(:serialization) { serialized_record_json(record, described_class) }
   let(:record) { Fabricate(:favourite) }
 

--- a/spec/serializers/activitypub/update_poll_serializer_spec.rb
+++ b/spec/serializers/activitypub/update_poll_serializer_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe ActivityPub::UpdatePollSerializer do
+RSpec.describe ActivityPub::UpdatePollSerializer do
   subject { serialized_record_json(status, described_class, adapter: ActivityPub::Adapter) }
 
   let(:account) { Fabricate(:account) }

--- a/spec/serializers/activitypub/vote_serializer_spec.rb
+++ b/spec/serializers/activitypub/vote_serializer_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe ActivityPub::VoteSerializer do
+RSpec.describe ActivityPub::VoteSerializer do
   let(:serialization) { serialized_record_json(record, described_class) }
   let(:record) { Fabricate(:poll_vote) }
 

--- a/spec/serializers/rest/account_serializer_spec.rb
+++ b/spec/serializers/rest/account_serializer_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe REST::AccountSerializer do
+RSpec.describe REST::AccountSerializer do
   subject { serialized_record_json(account, described_class) }
 
   let(:role)    { Fabricate(:user_role, name: 'Role', highlighted: true) }

--- a/spec/serializers/rest/encrypted_message_serializer_spec.rb
+++ b/spec/serializers/rest/encrypted_message_serializer_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe REST::EncryptedMessageSerializer do
+RSpec.describe REST::EncryptedMessageSerializer do
   let(:serialization) { serialized_record_json(record, described_class) }
   let(:record) { Fabricate(:encrypted_message) }
 

--- a/spec/serializers/rest/instance_serializer_spec.rb
+++ b/spec/serializers/rest/instance_serializer_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe REST::InstanceSerializer do
+RSpec.describe REST::InstanceSerializer do
   let(:serialization) { serialized_record_json(record, described_class) }
   let(:record) { InstancePresenter.new }
 

--- a/spec/serializers/rest/keys/claim_result_serializer_spec.rb
+++ b/spec/serializers/rest/keys/claim_result_serializer_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe REST::Keys::ClaimResultSerializer do
+RSpec.describe REST::Keys::ClaimResultSerializer do
   let(:serialization) { serialized_record_json(record, described_class) }
   let(:record) { Keys::ClaimService::Result.new(Account.new(id: 123), 456) }
 

--- a/spec/serializers/rest/keys/device_serializer_spec.rb
+++ b/spec/serializers/rest/keys/device_serializer_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe REST::Keys::DeviceSerializer do
+RSpec.describe REST::Keys::DeviceSerializer do
   let(:serialization) { serialized_record_json(record, described_class) }
   let(:record) { Device.new(name: 'Device name') }
 

--- a/spec/serializers/rest/keys/query_result_serializer_spec.rb
+++ b/spec/serializers/rest/keys/query_result_serializer_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe REST::Keys::QueryResultSerializer do
+RSpec.describe REST::Keys::QueryResultSerializer do
   let(:serialization) { serialized_record_json(record, described_class) }
   let(:record) { Keys::QueryService::Result.new(Account.new(id: 123), []) }
 

--- a/spec/serializers/rest/suggestion_serializer_spec.rb
+++ b/spec/serializers/rest/suggestion_serializer_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe REST::SuggestionSerializer do
+RSpec.describe REST::SuggestionSerializer do
   let(:serialization) { serialized_record_json(record, described_class) }
   let(:record) do
     AccountSuggestions::Suggestion.new(

--- a/spec/services/account_search_service_spec.rb
+++ b/spec/services/account_search_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe AccountSearchService do
+RSpec.describe AccountSearchService do
   describe '#call' do
     context 'with a query to ignore' do
       it 'returns empty array for missing query' do

--- a/spec/services/account_statuses_cleanup_service_spec.rb
+++ b/spec/services/account_statuses_cleanup_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe AccountStatusesCleanupService do
+RSpec.describe AccountStatusesCleanupService do
   let(:account)           { Fabricate(:account, username: 'alice', domain: nil) }
   let(:account_policy)    { Fabricate(:account_statuses_cleanup_policy, account: account) }
   let!(:unrelated_status) { Fabricate(:status, created_at: 3.years.ago) }

--- a/spec/services/fetch_oembed_service_spec.rb
+++ b/spec/services/fetch_oembed_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe FetchOEmbedService do
+RSpec.describe FetchOEmbedService do
   subject { described_class.new }
 
   before do

--- a/spec/services/resolve_url_service_spec.rb
+++ b/spec/services/resolve_url_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe ResolveURLService do
+RSpec.describe ResolveURLService do
   subject { described_class.new }
 
   describe '#call' do

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe SearchService do
+RSpec.describe SearchService do
   subject { described_class.new }
 
   describe '#call' do

--- a/spec/services/unblock_domain_service_spec.rb
+++ b/spec/services/unblock_domain_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe UnblockDomainService do
+RSpec.describe UnblockDomainService do
   subject { described_class.new }
 
   describe 'call' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,8 @@ RSpec.configure do |config|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end
 
+  config.disable_monkey_patching!
+
   config.mock_with :rspec do |mocks|
     mocks.verify_partial_doubles = true
   end

--- a/spec/support/examples/api.rb
+++ b/spec/support/examples/api.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-shared_examples 'forbidden for wrong scope' do |wrong_scope|
+RSpec.shared_examples 'forbidden for wrong scope' do |wrong_scope|
   let(:scopes) { wrong_scope }
 
   it 'returns http forbidden' do
@@ -11,7 +11,7 @@ shared_examples 'forbidden for wrong scope' do |wrong_scope|
   end
 end
 
-shared_examples 'forbidden for wrong role' do |wrong_role|
+RSpec.shared_examples 'forbidden for wrong role' do |wrong_role|
   let(:role) { UserRole.find_by(name: wrong_role) }
 
   it 'returns http forbidden' do

--- a/spec/support/examples/cli.rb
+++ b/spec/support/examples/cli.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-shared_examples 'CLI Command' do
+RSpec.shared_examples 'CLI Command' do
   it 'configures Thor to exit on failure' do
     expect(described_class.exit_on_failure?).to be true
   end

--- a/spec/support/examples/lib/admin/checks.rb
+++ b/spec/support/examples/lib/admin/checks.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-shared_examples 'a check available to devops users' do
+RSpec.shared_examples 'a check available to devops users' do
   describe 'skip?' do
     context 'when user can view devops' do
       before { allow(user).to receive(:can?).with(:view_devops).and_return(true) }

--- a/spec/support/examples/mailers.rb
+++ b/spec/support/examples/mailers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-shared_examples 'localized subject' do |*args, **kwrest|
+RSpec.shared_examples 'localized subject' do |*args, **kwrest|
   it 'renders subject localized for the locale of the receiver' do
     locale = :de
     receiver.update!(locale: locale)

--- a/spec/support/examples/models/concerns/account_avatar.rb
+++ b/spec/support/examples/models/concerns/account_avatar.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-shared_examples 'AccountAvatar' do |fabricator|
+RSpec.shared_examples 'AccountAvatar' do |fabricator|
   describe 'static avatars', :attachment_processing do
     describe 'when GIF' do
       it 'creates a png static style' do

--- a/spec/support/examples/models/concerns/account_header.rb
+++ b/spec/support/examples/models/concerns/account_header.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-shared_examples 'AccountHeader' do |fabricator|
+RSpec.shared_examples 'AccountHeader' do |fabricator|
   describe 'base64-encoded files', :attachment_processing do
     let(:base64_attachment) { "data:image/jpeg;base64,#{Base64.encode64(attachment_fixture('attachment.jpg').read)}" }
     let(:account) { Fabricate(fabricator, header: base64_attachment) }

--- a/spec/support/examples/models/concerns/reviewable.rb
+++ b/spec/support/examples/models/concerns/reviewable.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-shared_examples 'Reviewable' do
+RSpec.shared_examples 'Reviewable' do
   subject { described_class.new(reviewed_at: reviewed_at, requested_review_at: requested_review_at) }
 
   let(:reviewed_at) { nil }

--- a/spec/system/about_spec.rb
+++ b/spec/system/about_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'About page' do
+RSpec.describe 'About page' do
   it 'visits the about page and renders the web app' do
     visit about_path
 

--- a/spec/system/admin/accounts_spec.rb
+++ b/spec/system/admin/accounts_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Admin::Accounts' do
+RSpec.describe 'Admin::Accounts' do
   let(:current_user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
 
   before do

--- a/spec/system/admin/announcements_spec.rb
+++ b/spec/system/admin/announcements_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Admin::Announcements' do
+RSpec.describe 'Admin::Announcements' do
   include ActionView::RecordIdentifier
 
   describe 'Viewing announcements' do

--- a/spec/system/admin/custom_emojis_spec.rb
+++ b/spec/system/admin/custom_emojis_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Admin::CustomEmojis' do
+RSpec.describe 'Admin::CustomEmojis' do
   let(:current_user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
 
   before do

--- a/spec/system/admin/domain_blocks_spec.rb
+++ b/spec/system/admin/domain_blocks_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'blocking domains through the moderation interface' do
+RSpec.describe 'blocking domains through the moderation interface' do
   before do
     allow(DomainBlockWorker).to receive(:perform_async).and_return(true)
     sign_in Fabricate(:user, role: UserRole.find_by(name: 'Admin')), scope: :user

--- a/spec/system/admin/email_domain_blocks_spec.rb
+++ b/spec/system/admin/email_domain_blocks_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Admin::EmailDomainBlocks' do
+RSpec.describe 'Admin::EmailDomainBlocks' do
   let(:current_user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
 
   before do

--- a/spec/system/admin/ip_blocks_spec.rb
+++ b/spec/system/admin/ip_blocks_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Admin::IpBlocks' do
+RSpec.describe 'Admin::IpBlocks' do
   let(:current_user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
 
   before do

--- a/spec/system/admin/reset_spec.rb
+++ b/spec/system/admin/reset_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Admin::Reset' do
+RSpec.describe 'Admin::Reset' do
   it 'Resets password for account user' do
     account = Fabricate :account
     sign_in admin_user

--- a/spec/system/admin/settings/about_spec.rb
+++ b/spec/system/admin/settings/about_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Admin::Settings::About' do
+RSpec.describe 'Admin::Settings::About' do
   it 'Saves changes to about settings' do
     sign_in admin_user
     visit admin_settings_about_path

--- a/spec/system/admin/settings/appearance_spec.rb
+++ b/spec/system/admin/settings/appearance_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Admin::Settings::Appearance' do
+RSpec.describe 'Admin::Settings::Appearance' do
   it 'Saves changes to appearance settings' do
     sign_in admin_user
     visit admin_settings_appearance_path

--- a/spec/system/admin/settings/branding_spec.rb
+++ b/spec/system/admin/settings/branding_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Admin::Settings::Branding' do
+RSpec.describe 'Admin::Settings::Branding' do
   it 'Saves changes to branding settings' do
     sign_in admin_user
     visit admin_settings_branding_path

--- a/spec/system/admin/settings/content_retention_spec.rb
+++ b/spec/system/admin/settings/content_retention_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Admin::Settings::ContentRetention' do
+RSpec.describe 'Admin::Settings::ContentRetention' do
   it 'Saves changes to content retention settings' do
     sign_in admin_user
     visit admin_settings_content_retention_path

--- a/spec/system/admin/settings/discovery_spec.rb
+++ b/spec/system/admin/settings/discovery_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Admin::Settings::Discovery' do
+RSpec.describe 'Admin::Settings::Discovery' do
   it 'Saves changes to discovery settings' do
     sign_in admin_user
     visit admin_settings_discovery_path

--- a/spec/system/admin/settings/registrations_spec.rb
+++ b/spec/system/admin/settings/registrations_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Admin::Settings::Registrations' do
+RSpec.describe 'Admin::Settings::Registrations' do
   it 'Saves changes to registrations settings' do
     sign_in admin_user
     visit admin_settings_registrations_path

--- a/spec/system/admin/software_updates_spec.rb
+++ b/spec/system/admin/software_updates_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'finding software updates through the admin interface' do
+RSpec.describe 'finding software updates through the admin interface' do
   before do
     Fabricate(:software_update, version: '99.99.99', type: 'major', urgent: true, release_notes: 'https://github.com/mastodon/mastodon/releases/v99')
 

--- a/spec/system/admin/statuses_spec.rb
+++ b/spec/system/admin/statuses_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Admin::Statuses' do
+RSpec.describe 'Admin::Statuses' do
   let(:current_user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
 
   before do

--- a/spec/system/admin/trends/links/preview_card_providers_spec.rb
+++ b/spec/system/admin/trends/links/preview_card_providers_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Admin::Trends::Links::PreviewCardProviders' do
+RSpec.describe 'Admin::Trends::Links::PreviewCardProviders' do
   let(:current_user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
 
   before do

--- a/spec/system/admin/trends/links_spec.rb
+++ b/spec/system/admin/trends/links_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Admin::Trends::Links' do
+RSpec.describe 'Admin::Trends::Links' do
   let(:current_user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
 
   before do

--- a/spec/system/admin/trends/statuses_spec.rb
+++ b/spec/system/admin/trends/statuses_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Admin::Trends::Statuses' do
+RSpec.describe 'Admin::Trends::Statuses' do
   let(:current_user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
 
   before do

--- a/spec/system/admin/trends/tags_spec.rb
+++ b/spec/system/admin/trends/tags_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Admin::Trends::Tags' do
+RSpec.describe 'Admin::Trends::Tags' do
   let(:current_user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
 
   before do

--- a/spec/system/captcha_spec.rb
+++ b/spec/system/captcha_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'email confirmation flow when captcha is enabled' do
+RSpec.describe 'email confirmation flow when captcha is enabled' do
   let(:user)        { Fabricate(:user, confirmed_at: nil, confirmation_token: 'foobar', created_by_application: client_app) }
   let(:client_app)  { nil }
 

--- a/spec/system/filters_spec.rb
+++ b/spec/system/filters_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Filters' do
+RSpec.describe 'Filters' do
   let(:user) { Fabricate(:user) }
   let(:filter_title) { 'Filter of fun and games' }
 

--- a/spec/system/home_spec.rb
+++ b/spec/system/home_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Home page' do
+RSpec.describe 'Home page' do
   context 'when signed in' do
     before { sign_in Fabricate(:user) }
 

--- a/spec/system/log_in_spec.rb
+++ b/spec/system/log_in_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Log in' do
+RSpec.describe 'Log in' do
   include ProfileStories
 
   subject { page }

--- a/spec/system/log_out_spec.rb
+++ b/spec/system/log_out_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Log out' do
+RSpec.describe 'Log out' do
   include ProfileStories
 
   before do

--- a/spec/system/new_statuses_spec.rb
+++ b/spec/system/new_statuses_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'NewStatuses', :inline_jobs, :js, :streaming do
+RSpec.describe 'NewStatuses', :inline_jobs, :js, :streaming do
   include ProfileStories
 
   subject { page }

--- a/spec/system/oauth_spec.rb
+++ b/spec/system/oauth_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Using OAuth from an external app' do
+RSpec.describe 'Using OAuth from an external app' do
   include ProfileStories
 
   subject { visit "/oauth/authorize?#{params.to_query}" }

--- a/spec/system/ocr_spec.rb
+++ b/spec/system/ocr_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'OCR', :attachment_processing, :inline_jobs, :js, :streaming do
+RSpec.describe 'OCR', :attachment_processing, :inline_jobs, :js, :streaming do
   include ProfileStories
 
   let(:email)               { 'test@example.com' }

--- a/spec/system/privacy_spec.rb
+++ b/spec/system/privacy_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Privacy policy page' do
+RSpec.describe 'Privacy policy page' do
   it 'visits the privacy policy page and renders the web app' do
     visit privacy_policy_path
 

--- a/spec/system/profile_spec.rb
+++ b/spec/system/profile_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Profile' do
+RSpec.describe 'Profile' do
   include ProfileStories
 
   subject { page }

--- a/spec/system/redirections_spec.rb
+++ b/spec/system/redirections_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'redirection confirmations' do
+RSpec.describe 'redirection confirmations' do
   let(:account) { Fabricate(:account, domain: 'example.com', uri: 'https://example.com/users/foo', url: 'https://example.com/@foo') }
   let(:status)  { Fabricate(:status, account: account, uri: 'https://example.com/users/foo/statuses/1', url: 'https://example.com/@foo/1') }
 

--- a/spec/system/report_interface_spec.rb
+++ b/spec/system/report_interface_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'report interface', :attachment_processing, :js, :streaming do
+RSpec.describe 'report interface', :attachment_processing, :js, :streaming do
   include ProfileStories
 
   let(:email)               { 'admin@example.com' }

--- a/spec/system/severed_relationships_spec.rb
+++ b/spec/system/severed_relationships_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Severed relationships page' do
+RSpec.describe 'Severed relationships page' do
   include ProfileStories
 
   describe 'GET severed_relationships#index' do

--- a/spec/system/share_entrypoint_spec.rb
+++ b/spec/system/share_entrypoint_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Share page', :js, :streaming do
+RSpec.describe 'Share page', :js, :streaming do
   include ProfileStories
 
   let(:email)               { 'test@example.com' }

--- a/spec/system/unlogged_spec.rb
+++ b/spec/system/unlogged_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'UnloggedBrowsing', :js, :streaming do
+RSpec.describe 'UnloggedBrowsing', :js, :streaming do
   subject { page }
 
   before do

--- a/spec/validators/email_mx_validator_spec.rb
+++ b/spec/validators/email_mx_validator_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe EmailMxValidator do
+RSpec.describe EmailMxValidator do
   describe '#validate' do
     let(:user) { instance_double(User, email: 'foo@example.com', sign_up_ip: '1.2.3.4', errors: instance_double(ActiveModel::Errors, add: nil)) }
     let(:resolv_dns_double) { instance_double(Resolv::DNS) }

--- a/spec/validators/existing_username_validator_spec.rb
+++ b/spec/validators/existing_username_validator_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe ExistingUsernameValidator do
+RSpec.describe ExistingUsernameValidator do
   let(:record_class) do
     Class.new do
       include ActiveModel::Validations

--- a/spec/validators/language_validator_spec.rb
+++ b/spec/validators/language_validator_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe LanguageValidator do
+RSpec.describe LanguageValidator do
   let(:record_class) do
     Class.new do
       include ActiveModel::Validations

--- a/spec/validators/note_length_validator_spec.rb
+++ b/spec/validators/note_length_validator_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe NoteLengthValidator do
+RSpec.describe NoteLengthValidator do
   subject { described_class.new(attributes: { note: true }, maximum: 500) }
 
   describe '#validate' do

--- a/spec/validators/reaction_validator_spec.rb
+++ b/spec/validators/reaction_validator_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe ReactionValidator do
+RSpec.describe ReactionValidator do
   let(:announcement) { Fabricate(:announcement) }
 
   describe '#validate' do

--- a/spec/validators/status_length_validator_spec.rb
+++ b/spec/validators/status_length_validator_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe StatusLengthValidator do
+RSpec.describe StatusLengthValidator do
   describe '#validate' do
     before { stub_const("#{described_class}::MAX_CHARS", 500) } # Example values below are relative to this baseline
 

--- a/spec/validators/unique_username_validator_spec.rb
+++ b/spec/validators/unique_username_validator_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe UniqueUsernameValidator do
+RSpec.describe UniqueUsernameValidator do
   describe '#validate' do
     context 'when local account' do
       it 'does not add errors if username is nil' do

--- a/spec/validators/unreserved_username_validator_spec.rb
+++ b/spec/validators/unreserved_username_validator_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe UnreservedUsernameValidator do
+RSpec.describe UnreservedUsernameValidator do
   let(:record_class) do
     Class.new do
       include ActiveModel::Validations

--- a/spec/validators/url_validator_spec.rb
+++ b/spec/validators/url_validator_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe URLValidator do
+RSpec.describe URLValidator do
   let(:record_class) do
     Class.new do
       include ActiveModel::Validations

--- a/spec/views/admin/trends/links/_preview_card.html.haml_spec.rb
+++ b/spec/views/admin/trends/links/_preview_card.html.haml_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'admin/trends/links/_preview_card.html.haml' do
+RSpec.describe 'admin/trends/links/_preview_card.html.haml' do
   it 'correctly escapes user supplied url values' do
     form = instance_double(ActionView::Helpers::FormHelper, check_box: nil)
     trend = PreviewCardTrend.new(allowed: false)

--- a/spec/views/statuses/show.html.haml_spec.rb
+++ b/spec/views/statuses/show.html.haml_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'statuses/show.html.haml' do
+RSpec.describe 'statuses/show.html.haml' do
   let(:alice) { Fabricate(:account, username: 'alice', display_name: 'Alice') }
   let(:status) { Fabricate(:status, account: alice, text: 'Hello World') }
 

--- a/spec/workers/account_refresh_worker_spec.rb
+++ b/spec/workers/account_refresh_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe AccountRefreshWorker do
+RSpec.describe AccountRefreshWorker do
   let(:worker) { described_class.new }
   let(:service) { instance_double(ResolveAccountService, call: true) }
 

--- a/spec/workers/activitypub/delivery_worker_spec.rb
+++ b/spec/workers/activitypub/delivery_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe ActivityPub::DeliveryWorker do
+RSpec.describe ActivityPub::DeliveryWorker do
   include RoutingHelper
 
   subject { described_class.new }

--- a/spec/workers/activitypub/distribute_poll_update_worker_spec.rb
+++ b/spec/workers/activitypub/distribute_poll_update_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe ActivityPub::DistributePollUpdateWorker do
+RSpec.describe ActivityPub::DistributePollUpdateWorker do
   subject { described_class.new }
 
   let(:account)  { Fabricate(:account) }

--- a/spec/workers/activitypub/distribution_worker_spec.rb
+++ b/spec/workers/activitypub/distribution_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe ActivityPub::DistributionWorker do
+RSpec.describe ActivityPub::DistributionWorker do
   subject { described_class.new }
 
   let(:status)   { Fabricate(:status) }

--- a/spec/workers/activitypub/fetch_replies_worker_spec.rb
+++ b/spec/workers/activitypub/fetch_replies_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe ActivityPub::FetchRepliesWorker do
+RSpec.describe ActivityPub::FetchRepliesWorker do
   subject { described_class.new }
 
   let(:account) { Fabricate(:account, domain: 'example.com') }

--- a/spec/workers/activitypub/move_distribution_worker_spec.rb
+++ b/spec/workers/activitypub/move_distribution_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe ActivityPub::MoveDistributionWorker do
+RSpec.describe ActivityPub::MoveDistributionWorker do
   subject { described_class.new }
 
   let(:migration) { Fabricate(:account_migration) }

--- a/spec/workers/activitypub/post_upgrade_worker_spec.rb
+++ b/spec/workers/activitypub/post_upgrade_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe ActivityPub::PostUpgradeWorker do
+RSpec.describe ActivityPub::PostUpgradeWorker do
   let(:worker) { described_class.new }
 
   describe '#perform' do

--- a/spec/workers/activitypub/processing_worker_spec.rb
+++ b/spec/workers/activitypub/processing_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe ActivityPub::ProcessingWorker do
+RSpec.describe ActivityPub::ProcessingWorker do
   subject { described_class.new }
 
   let(:account) { Fabricate(:account) }

--- a/spec/workers/activitypub/status_update_distribution_worker_spec.rb
+++ b/spec/workers/activitypub/status_update_distribution_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe ActivityPub::StatusUpdateDistributionWorker do
+RSpec.describe ActivityPub::StatusUpdateDistributionWorker do
   subject { described_class.new }
 
   let(:status)   { Fabricate(:status, text: 'foo') }

--- a/spec/workers/activitypub/synchronize_featured_tags_collection_worker_spec.rb
+++ b/spec/workers/activitypub/synchronize_featured_tags_collection_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe ActivityPub::SynchronizeFeaturedTagsCollectionWorker do
+RSpec.describe ActivityPub::SynchronizeFeaturedTagsCollectionWorker do
   let(:worker) { described_class.new }
   let(:service) { instance_double(ActivityPub::FetchFeaturedTagsCollectionService, call: true) }
 

--- a/spec/workers/activitypub/update_distribution_worker_spec.rb
+++ b/spec/workers/activitypub/update_distribution_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe ActivityPub::UpdateDistributionWorker do
+RSpec.describe ActivityPub::UpdateDistributionWorker do
   subject { described_class.new }
 
   let(:account)  { Fabricate(:account) }

--- a/spec/workers/add_to_public_statuses_index_worker_spec.rb
+++ b/spec/workers/add_to_public_statuses_index_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe AddToPublicStatusesIndexWorker do
+RSpec.describe AddToPublicStatusesIndexWorker do
   describe '#perform' do
     let(:account) { Fabricate(:account, indexable: indexable) }
     let(:account_id) { account.id }

--- a/spec/workers/admin/account_deletion_worker_spec.rb
+++ b/spec/workers/admin/account_deletion_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::AccountDeletionWorker do
+RSpec.describe Admin::AccountDeletionWorker do
   let(:worker) { described_class.new }
 
   describe 'perform' do

--- a/spec/workers/admin/domain_purge_worker_spec.rb
+++ b/spec/workers/admin/domain_purge_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::DomainPurgeWorker do
+RSpec.describe Admin::DomainPurgeWorker do
   subject { described_class.new }
 
   describe 'perform' do

--- a/spec/workers/admin/suspension_worker_spec.rb
+++ b/spec/workers/admin/suspension_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Admin::SuspensionWorker do
+RSpec.describe Admin::SuspensionWorker do
   let(:worker) { described_class.new }
   let(:service) { instance_double(SuspendAccountService, call: true) }
 

--- a/spec/workers/after_account_domain_block_worker_spec.rb
+++ b/spec/workers/after_account_domain_block_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe AfterAccountDomainBlockWorker do
+RSpec.describe AfterAccountDomainBlockWorker do
   let(:worker) { described_class.new }
   let(:service) { instance_double(AfterBlockDomainFromAccountService, call: true) }
 

--- a/spec/workers/backup_worker_spec.rb
+++ b/spec/workers/backup_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe BackupWorker do
+RSpec.describe BackupWorker do
   let(:worker) { described_class.new }
   let(:service) { instance_double(BackupService, call: true) }
 

--- a/spec/workers/bulk_import_worker_spec.rb
+++ b/spec/workers/bulk_import_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe BulkImportWorker do
+RSpec.describe BulkImportWorker do
   subject { described_class.new }
 
   let(:import) { Fabricate(:bulk_import, state: :scheduled) }

--- a/spec/workers/cache_buster_worker_spec.rb
+++ b/spec/workers/cache_buster_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe CacheBusterWorker do
+RSpec.describe CacheBusterWorker do
   let(:worker) { described_class.new }
 
   describe 'perform' do

--- a/spec/workers/delete_mute_worker_spec.rb
+++ b/spec/workers/delete_mute_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe DeleteMuteWorker do
+RSpec.describe DeleteMuteWorker do
   let(:worker) { described_class.new }
   let(:service) { instance_double(UnmuteService, call: true) }
 

--- a/spec/workers/domain_block_worker_spec.rb
+++ b/spec/workers/domain_block_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe DomainBlockWorker do
+RSpec.describe DomainBlockWorker do
   subject { described_class.new }
 
   describe 'perform' do

--- a/spec/workers/domain_clear_media_worker_spec.rb
+++ b/spec/workers/domain_clear_media_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe DomainClearMediaWorker do
+RSpec.describe DomainClearMediaWorker do
   subject { described_class.new }
 
   describe 'perform' do

--- a/spec/workers/feed_insert_worker_spec.rb
+++ b/spec/workers/feed_insert_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe FeedInsertWorker do
+RSpec.describe FeedInsertWorker do
   subject { described_class.new }
 
   describe 'perform' do

--- a/spec/workers/filtered_notification_cleanup_worker_spec.rb
+++ b/spec/workers/filtered_notification_cleanup_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe FilteredNotificationCleanupWorker do
+RSpec.describe FilteredNotificationCleanupWorker do
   describe '#perform' do
     let(:sender) { Fabricate(:account) }
     let(:recipient) { Fabricate(:account) }

--- a/spec/workers/import/row_worker_spec.rb
+++ b/spec/workers/import/row_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Import::RowWorker do
+RSpec.describe Import::RowWorker do
   subject { described_class.new }
 
   let(:row) { Fabricate(:bulk_import_row, bulk_import: import) }

--- a/spec/workers/import_worker_spec.rb
+++ b/spec/workers/import_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe ImportWorker do
+RSpec.describe ImportWorker do
   let(:worker) { described_class.new }
   let(:service) { instance_double(ImportService, call: true) }
 

--- a/spec/workers/move_worker_spec.rb
+++ b/spec/workers/move_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe MoveWorker do
+RSpec.describe MoveWorker do
   subject { described_class.new }
 
   let(:local_follower)   { Fabricate(:account, domain: nil) }

--- a/spec/workers/poll_expiration_notify_worker_spec.rb
+++ b/spec/workers/poll_expiration_notify_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe PollExpirationNotifyWorker do
+RSpec.describe PollExpirationNotifyWorker do
   let(:worker) { described_class.new }
   let(:account) { Fabricate(:account, domain: remote? ? 'example.com' : nil) }
   let(:status) { Fabricate(:status, account: account) }

--- a/spec/workers/post_process_media_worker_spec.rb
+++ b/spec/workers/post_process_media_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe PostProcessMediaWorker, :attachment_processing do
+RSpec.describe PostProcessMediaWorker, :attachment_processing do
   let(:worker) { described_class.new }
 
   describe '#perform' do

--- a/spec/workers/publish_announcement_reaction_worker_spec.rb
+++ b/spec/workers/publish_announcement_reaction_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe PublishAnnouncementReactionWorker do
+RSpec.describe PublishAnnouncementReactionWorker do
   let(:worker) { described_class.new }
 
   describe '#perform' do

--- a/spec/workers/publish_scheduled_announcement_worker_spec.rb
+++ b/spec/workers/publish_scheduled_announcement_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe PublishScheduledAnnouncementWorker do
+RSpec.describe PublishScheduledAnnouncementWorker do
   subject { described_class.new }
 
   let!(:remote_account) { Fabricate(:account, domain: 'domain.com', username: 'foo', uri: 'https://domain.com/users/foo') }

--- a/spec/workers/publish_scheduled_status_worker_spec.rb
+++ b/spec/workers/publish_scheduled_status_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe PublishScheduledStatusWorker do
+RSpec.describe PublishScheduledStatusWorker do
   subject { described_class.new }
 
   let(:scheduled_status) { Fabricate(:scheduled_status, params: { text: 'Hello world, future!' }) }

--- a/spec/workers/push_conversation_worker_spec.rb
+++ b/spec/workers/push_conversation_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe PushConversationWorker do
+RSpec.describe PushConversationWorker do
   let(:worker) { described_class.new }
 
   describe 'perform' do

--- a/spec/workers/push_encrypted_message_worker_spec.rb
+++ b/spec/workers/push_encrypted_message_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe PushEncryptedMessageWorker do
+RSpec.describe PushEncryptedMessageWorker do
   let(:worker) { described_class.new }
 
   describe 'perform' do

--- a/spec/workers/push_update_worker_spec.rb
+++ b/spec/workers/push_update_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe PushUpdateWorker do
+RSpec.describe PushUpdateWorker do
   let(:worker) { described_class.new }
 
   describe 'perform' do

--- a/spec/workers/redownload_avatar_worker_spec.rb
+++ b/spec/workers/redownload_avatar_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe RedownloadAvatarWorker do
+RSpec.describe RedownloadAvatarWorker do
   let(:worker) { described_class.new }
 
   describe '#perform' do

--- a/spec/workers/redownload_header_worker_spec.rb
+++ b/spec/workers/redownload_header_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe RedownloadHeaderWorker do
+RSpec.describe RedownloadHeaderWorker do
   let(:worker) { described_class.new }
 
   describe '#perform' do

--- a/spec/workers/redownload_media_worker_spec.rb
+++ b/spec/workers/redownload_media_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe RedownloadMediaWorker do
+RSpec.describe RedownloadMediaWorker do
   let(:worker) { described_class.new }
 
   describe '#perform' do

--- a/spec/workers/refollow_worker_spec.rb
+++ b/spec/workers/refollow_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe RefollowWorker do
+RSpec.describe RefollowWorker do
   subject { described_class.new }
 
   let(:account) { Fabricate(:account, domain: 'example.org', protocol: :activitypub) }

--- a/spec/workers/regeneration_worker_spec.rb
+++ b/spec/workers/regeneration_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe RegenerationWorker do
+RSpec.describe RegenerationWorker do
   subject { described_class.new }
 
   describe 'perform' do

--- a/spec/workers/removal_worker_spec.rb
+++ b/spec/workers/removal_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe RemovalWorker do
+RSpec.describe RemovalWorker do
   let(:worker) { described_class.new }
   let(:service) { instance_double(RemoveStatusService, call: true) }
 

--- a/spec/workers/remove_featured_tag_worker_spec.rb
+++ b/spec/workers/remove_featured_tag_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe RemoveFeaturedTagWorker do
+RSpec.describe RemoveFeaturedTagWorker do
   let(:worker) { described_class.new }
 
   describe 'perform' do

--- a/spec/workers/remove_from_public_statuses_index_worker_spec.rb
+++ b/spec/workers/remove_from_public_statuses_index_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe RemoveFromPublicStatusesIndexWorker do
+RSpec.describe RemoveFromPublicStatusesIndexWorker do
   describe '#perform' do
     let(:account) { Fabricate(:account, indexable: indexable) }
     let(:account_id) { account.id }

--- a/spec/workers/resolve_account_worker_spec.rb
+++ b/spec/workers/resolve_account_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe ResolveAccountWorker do
+RSpec.describe ResolveAccountWorker do
   let(:worker) { described_class.new }
 
   describe 'perform' do

--- a/spec/workers/scheduler/accounts_statuses_cleanup_scheduler_spec.rb
+++ b/spec/workers/scheduler/accounts_statuses_cleanup_scheduler_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Scheduler::AccountsStatusesCleanupScheduler do
+RSpec.describe Scheduler::AccountsStatusesCleanupScheduler do
   subject { described_class.new }
 
   let!(:account_alice) { Fabricate(:account, domain: nil, username: 'alice') }

--- a/spec/workers/scheduler/auto_close_registrations_scheduler_spec.rb
+++ b/spec/workers/scheduler/auto_close_registrations_scheduler_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Scheduler::AutoCloseRegistrationsScheduler do
+RSpec.describe Scheduler::AutoCloseRegistrationsScheduler do
   subject { described_class.new }
 
   describe '#perform' do

--- a/spec/workers/scheduler/follow_recommendations_scheduler_spec.rb
+++ b/spec/workers/scheduler/follow_recommendations_scheduler_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Scheduler::FollowRecommendationsScheduler do
+RSpec.describe Scheduler::FollowRecommendationsScheduler do
   let!(:target_accounts) do
     Fabricate.times(3, :account) do
       statuses(count: 6)

--- a/spec/workers/scheduler/indexing_scheduler_spec.rb
+++ b/spec/workers/scheduler/indexing_scheduler_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Scheduler::IndexingScheduler do
+RSpec.describe Scheduler::IndexingScheduler do
   let(:worker) { described_class.new }
 
   describe 'perform' do

--- a/spec/workers/scheduler/instance_refresh_scheduler_spec.rb
+++ b/spec/workers/scheduler/instance_refresh_scheduler_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Scheduler::InstanceRefreshScheduler do
+RSpec.describe Scheduler::InstanceRefreshScheduler do
   let(:worker) { described_class.new }
 
   describe 'perform' do

--- a/spec/workers/scheduler/ip_cleanup_scheduler_spec.rb
+++ b/spec/workers/scheduler/ip_cleanup_scheduler_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Scheduler::IpCleanupScheduler do
+RSpec.describe Scheduler::IpCleanupScheduler do
   let(:worker) { described_class.new }
 
   describe 'perform' do

--- a/spec/workers/scheduler/pghero_scheduler_spec.rb
+++ b/spec/workers/scheduler/pghero_scheduler_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Scheduler::PgheroScheduler do
+RSpec.describe Scheduler::PgheroScheduler do
   let(:worker) { described_class.new }
 
   describe 'perform' do

--- a/spec/workers/scheduler/scheduled_statuses_scheduler_spec.rb
+++ b/spec/workers/scheduler/scheduled_statuses_scheduler_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Scheduler::ScheduledStatusesScheduler do
+RSpec.describe Scheduler::ScheduledStatusesScheduler do
   let(:worker) { described_class.new }
 
   describe 'perform' do

--- a/spec/workers/scheduler/self_destruct_scheduler_spec.rb
+++ b/spec/workers/scheduler/self_destruct_scheduler_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Scheduler::SelfDestructScheduler do
+RSpec.describe Scheduler::SelfDestructScheduler do
   let(:worker) { described_class.new }
 
   describe '#perform' do

--- a/spec/workers/scheduler/software_update_check_scheduler_spec.rb
+++ b/spec/workers/scheduler/software_update_check_scheduler_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Scheduler::SoftwareUpdateCheckScheduler do
+RSpec.describe Scheduler::SoftwareUpdateCheckScheduler do
   subject { described_class.new }
 
   describe 'perform' do

--- a/spec/workers/scheduler/suspended_user_cleanup_scheduler_spec.rb
+++ b/spec/workers/scheduler/suspended_user_cleanup_scheduler_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Scheduler::SuspendedUserCleanupScheduler do
+RSpec.describe Scheduler::SuspendedUserCleanupScheduler do
   let(:worker) { described_class.new }
 
   describe 'perform' do

--- a/spec/workers/scheduler/trends/refresh_scheduler_spec.rb
+++ b/spec/workers/scheduler/trends/refresh_scheduler_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Scheduler::Trends::RefreshScheduler do
+RSpec.describe Scheduler::Trends::RefreshScheduler do
   let(:worker) { described_class.new }
 
   describe 'perform' do

--- a/spec/workers/scheduler/trends/review_notifications_scheduler_spec.rb
+++ b/spec/workers/scheduler/trends/review_notifications_scheduler_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Scheduler::Trends::ReviewNotificationsScheduler do
+RSpec.describe Scheduler::Trends::ReviewNotificationsScheduler do
   let(:worker) { described_class.new }
 
   describe 'perform' do

--- a/spec/workers/scheduler/user_cleanup_scheduler_spec.rb
+++ b/spec/workers/scheduler/user_cleanup_scheduler_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Scheduler::UserCleanupScheduler do
+RSpec.describe Scheduler::UserCleanupScheduler do
   subject { described_class.new }
 
   let!(:new_unconfirmed_user) { Fabricate(:user) }

--- a/spec/workers/scheduler/vacuum_scheduler_spec.rb
+++ b/spec/workers/scheduler/vacuum_scheduler_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Scheduler::VacuumScheduler do
+RSpec.describe Scheduler::VacuumScheduler do
   let(:worker) { described_class.new }
 
   describe 'perform' do

--- a/spec/workers/tag_unmerge_worker_spec.rb
+++ b/spec/workers/tag_unmerge_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe TagUnmergeWorker do
+RSpec.describe TagUnmergeWorker do
   subject { described_class.new }
 
   describe 'perform' do

--- a/spec/workers/unfilter_notifications_worker_spec.rb
+++ b/spec/workers/unfilter_notifications_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe UnfilterNotificationsWorker do
+RSpec.describe UnfilterNotificationsWorker do
   let(:recipient) { Fabricate(:account) }
   let(:sender) { Fabricate(:account) }
 

--- a/spec/workers/unfollow_follow_worker_spec.rb
+++ b/spec/workers/unfollow_follow_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe UnfollowFollowWorker do
+RSpec.describe UnfollowFollowWorker do
   subject { described_class.new }
 
   let(:local_follower)   { Fabricate(:account) }

--- a/spec/workers/unpublish_announcement_worker_spec.rb
+++ b/spec/workers/unpublish_announcement_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe UnpublishAnnouncementWorker do
+RSpec.describe UnpublishAnnouncementWorker do
   let(:worker) { described_class.new }
 
   describe 'perform' do

--- a/spec/workers/verify_account_links_worker_spec.rb
+++ b/spec/workers/verify_account_links_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe VerifyAccountLinksWorker do
+RSpec.describe VerifyAccountLinksWorker do
   let(:worker) { described_class.new }
 
   describe 'perform' do

--- a/spec/workers/web/push_notification_worker_spec.rb
+++ b/spec/workers/web/push_notification_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Web::PushNotificationWorker do
+RSpec.describe Web::PushNotificationWorker do
   subject { described_class.new }
 
   let(:p256dh) { 'BN4GvZtEZiZuqFxSKVZfSfluwKBD7UxHNBmWkfiZfCtgDE8Bwh-_MtLXbBxTBAWH9r7IPKL0lhdcaqtL1dfxU5E=' }

--- a/spec/workers/webhooks/delivery_worker_spec.rb
+++ b/spec/workers/webhooks/delivery_worker_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Webhooks::DeliveryWorker do
+RSpec.describe Webhooks::DeliveryWorker do
   let(:worker) { described_class.new }
 
   describe '#perform' do


### PR DESCRIPTION
Background/motivation similar to https://gitlab.com/gitlab-org/gitlab/-/issues/220018

What it does: <https://rubydoc.info/github/rspec/rspec-core/RSpec%2FCore%2FConfiguration:disable_monkey_patching!>

This is a mostly-style change which touches a lot of files, however - it does it in a way that should be pretty surgical/rebase-able for any open PRs touching same areas. Prior to the change, we have about ~300 uses of `RSpec.describe...` and about ~400 uses of just plain top-level `describe` (noticed inconsistency while working on other spec changes). This migrates the latter group to be consistent with the former, and enables a setting which will keep it consistent in future.

The `rubocop-rspec` project (purposefully) does NOT have a cop for this - https://docs.rubocop.org/rubocop-rspec/index.html#enforcing-an-explicit-rspec-receiver-for-top-level-methods-disabling-monkey-patching - the rationale being that you should just enable this setting instead (which will make the other style not work).

Key benefit here is to just get a consistent/standardized style, but a nice side benefit is to reduce globally available methods, and prepare for a (still somewhat hypothetical and years in the planning) rspec 4 release which would remove the monkey patched methods.

Followup on https://github.com/mastodon/mastodon/pull/31607
