### PR TITLE
Fix streaming image with Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,8 @@ services:
   #     - '127.0.0.1:9200:9200'
 
   web:
-    build: .
+    # You can uncomment the following line if you want to not use the prebuilt image, for example if you have local code changes
+    # build: .
     image: ghcr.io/mastodon/mastodon:v4.3.0-beta.1
     restart: always
     env_file: .env.production
@@ -78,7 +79,10 @@ services:
       - ./public/system:/mastodon/public/system
 
   streaming:
-    build: .
+    # You can uncomment the following lines if you want to not use the prebuilt image, for example if you have local code changes
+    # build:
+    #   dockerfile: ./streaming/Dockerfile
+    #   context: .
     image: ghcr.io/mastodon/mastodon-streaming:v4.3.0-beta.1
     restart: always
     env_file: .env.production


### PR DESCRIPTION
It was not using the correct Dockerfile.

I also commented out the `build` attribute, so by default your Compose stack uses the prebuild images, rather than rebuilding everything locally. People with local code changes can uncomment this to build things locally.