### PR TITLE
Pull out https/hostname setup for request specs to shared config

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -142,6 +142,12 @@ RSpec.configure do |config|
     end
   end
 
+  config.before :each, type: :request do
+    # Use https and configured hostname in request spec requests
+    integration_session.https!
+    host! Rails.configuration.x.local_domain
+  end
+
   config.after do
     Rails.cache.clear
     redis.del(redis.keys)

--- a/spec/requests/account_show_page_spec.rb
+++ b/spec/requests/account_show_page_spec.rb
@@ -14,7 +14,7 @@ describe 'The account show page' do
     expect(head_meta_content('og:title')).to match alice.display_name
     expect(head_meta_content('og:type')).to eq 'profile'
     expect(head_meta_content('og:image')).to match '.+'
-    expect(head_meta_content('og:url')).to match 'http://.+'
+    expect(head_meta_content('og:url')).to eq short_account_url(username: alice.username)
   end
 
   def head_link_icons

--- a/spec/requests/api/v1/streaming_spec.rb
+++ b/spec/requests/api/v1/streaming_spec.rb
@@ -10,12 +10,11 @@ describe 'API V1 Streaming' do
     Rails.configuration.x.streaming_api_base_url = before
   end
 
-  let(:headers) { { 'Host' => Rails.configuration.x.web_domain } }
-
   context 'with streaming api on same host' do
     describe 'GET /api/v1/streaming' do
       it 'raises ActiveRecord::RecordNotFound' do
-        get '/api/v1/streaming', headers: headers
+        integration_session.https!(false)
+        get '/api/v1/streaming'
 
         expect(response).to have_http_status(404)
       end

--- a/spec/requests/link_headers_spec.rb
+++ b/spec/requests/link_headers_spec.rb
@@ -13,7 +13,7 @@ describe 'Link headers' do
     it 'contains webfinger url in link header' do
       link_header = link_header_with_type('application/jrd+json')
 
-      expect(link_header.href).to eq 'http://www.example.com/.well-known/webfinger?resource=acct%3Atest%40cb6e6126.ngrok.io'
+      expect(link_header.href).to eq 'https://cb6e6126.ngrok.io/.well-known/webfinger?resource=acct%3Atest%40cb6e6126.ngrok.io'
       expect(link_header.attr_pairs.first).to eq %w(rel lrdd)
     end
 

--- a/spec/requests/media_proxy_spec.rb
+++ b/spec/requests/media_proxy_spec.rb
@@ -4,12 +4,7 @@ require 'rails_helper'
 
 describe 'Media Proxy' do
   describe 'GET /media_proxy/:id' do
-    before do
-      integration_session.https! # TODO: Move to global rails_helper for all request specs?
-      host! Rails.configuration.x.local_domain # TODO: Move to global rails_helper for all request specs?
-
-      stub_request(:get, 'http://example.com/attachment.png').to_return(request_fixture('avatar.txt'))
-    end
+    before { stub_attachment_request }
 
     context 'when attached to a status' do
       let(:status) { Fabricate(:status) }
@@ -62,6 +57,16 @@ describe 'Media Proxy' do
         expect(response)
           .to have_http_status(404)
       end
+    end
+
+    def stub_attachment_request
+      stub_request(
+        :get,
+        'http://example.com/attachment.png'
+      )
+        .to_return(
+          request_fixture('avatar.txt')
+        )
     end
   end
 end


### PR DESCRIPTION
Handles a `TODO` added in a previous PR.

Currently the spec/request side of request specs is using http requests and `www.example.com` as the hostname; but the server/response side is using https and `cb6e6126.ngrok.io` as the hostname. This *usually doesnt matter* because relatively few specs interact in a way where it matters, but we do have a few of them.

The change here is to (by default) align these values for request specs, allowing specs to override if for whatever reason they do NOT want this to be the same.

Other than pulling out the config, a few things failed which I fixed:

- OG tag spec was hard-coded to `http`, updated to compare full expected URL for account username
- a link header spec needed hostname changed
- streaming api spec was essentially doing its own version of this workaround with a `Host` header, but thats no longer needed. Removed that override and updated to send that request over http so that the server side controller (hard-coded to port 80) would go down the right path. Possible future improvement here would be make that area more flexible, but I think out of scope for this change.

