### PR TITLE
Streaming: Improve Redis connection options handling

### DIFF
--- a/streaming/redis.js
+++ b/streaming/redis.js
@@ -4,9 +4,8 @@ import { parseIntFromEnvValue } from './utils.js';
 
 /**
  * @typedef RedisConfiguration
- * @property {import('ioredis').RedisOptions} redisParams
- * @property {string} redisPrefix
  * @property {string|undefined} redisUrl
+ * @property {import('ioredis').RedisOptions} redisOptions
  */
 
 /**
@@ -14,34 +13,42 @@ import { parseIntFromEnvValue } from './utils.js';
  * @returns {RedisConfiguration} configuration for the Redis connection
  */
 export function configFromEnv(env) {
-  // ioredis *can* transparently add prefixes for us, but it doesn't *in some cases*,
-  // which means we can't use it. But this is something that should be looked into.
-  const redisPrefix = env.REDIS_NAMESPACE ? `${env.REDIS_NAMESPACE}:` : '';
+  const redisNamespace = env.REDIS_NAMESPACE ? `${env.REDIS_NAMESPACE}:` : undefined;
+
+  // These options apply for both REDIS_URL based connections and connections
+  // using the other REDIS_* environment variables:
+  const commonOptions = {
+    // Force support for both IPv6 and IPv4, by default ioredis sets this to 4,
+    // only allowing IPv4 connections:
+    // https://github.com/redis/ioredis/issues/1576
+    family: 0,
+    // Support auto-prefixing keys:
+    keyPrefix: redisNamespace
+  };
+
+  // If we receive REDIS_URL, don't continue parsing any other REDIS_*
+  // environment variables:
+  if (typeof env.REDIS_URL === 'string' && env.REDIS_URL.length > 0) {
+    return {
+      redisUrl: env.REDIS_URL,
+      redisOptions: commonOptions
+    };
+  }
 
   let redisPort = parseIntFromEnvValue(env.REDIS_PORT, 6379, 'REDIS_PORT');
   let redisDatabase = parseIntFromEnvValue(env.REDIS_DB, 0, 'REDIS_DB');
 
   /** @type {import('ioredis').RedisOptions} */
-  const redisParams = {
-    host: env.REDIS_HOST || '127.0.0.1',
+  const redisOptions = {
+    host: env.REDIS_HOST ?? '127.0.0.1',
     port: redisPort,
-    // Force support for both IPv6 and IPv4, by default ioredis sets this to 4,
-    // only allowing IPv4 connections:
-    // https://github.com/redis/ioredis/issues/1576
-    family: 0,
     db: redisDatabase,
     password: env.REDIS_PASSWORD || undefined,
+    ...commonOptions
   };
 
-  // redisParams.path takes precedence over host and port.
-  if (env.REDIS_URL && env.REDIS_URL.startsWith('unix://')) {
-    redisParams.path = env.REDIS_URL.slice(7);
-  }
-
   return {
-    redisParams,
-    redisPrefix,
-    redisUrl: typeof env.REDIS_URL === 'string' ? env.REDIS_URL : undefined,
+    redisOptions
   };
 }
 
@@ -50,13 +57,13 @@ export function configFromEnv(env) {
  * @param {import('pino').Logger} logger
  * @returns {Redis}
  */
-export function createClient({ redisParams, redisUrl }, logger) {
+export function createClient({ redisUrl, redisOptions }, logger) {
   let client;
 
   if (typeof redisUrl === 'string') {
-    client = new Redis(redisUrl, redisParams);
+    client = new Redis(redisUrl, redisOptions);
   } else {
-    client = new Redis(redisParams);
+    client = new Redis(redisOptions);
   }
 
   client.on('error', (err) => logger.error({ err }, 'Redis Client Error!'));

--- a/streaming/redis.js
+++ b/streaming/redis.js
@@ -35,6 +35,7 @@ export function configFromEnv(env) {
     };
   }
 
+  // Finally, handle all the other REDIS_* environment variables:
   let redisPort = parseIntFromEnvValue(env.REDIS_PORT, 6379, 'REDIS_PORT');
   let redisDatabase = parseIntFromEnvValue(env.REDIS_DB, 0, 'REDIS_DB');
 
@@ -43,8 +44,9 @@ export function configFromEnv(env) {
     host: env.REDIS_HOST ?? '127.0.0.1',
     port: redisPort,
     db: redisDatabase,
-    password: env.REDIS_PASSWORD || undefined,
-    ...commonOptions
+    username: env.REDIS_USERNAME,
+    password: env.REDIS_PASSWORD,
+    ...commonOptions,
   };
 
   return {

--- a/streaming/redis.js
+++ b/streaming/redis.js
@@ -4,6 +4,7 @@ import { parseIntFromEnvValue } from './utils.js';
 
 /**
  * @typedef RedisConfiguration
+ * @property {string|undefined} redisNamespace
  * @property {string|undefined} redisUrl
  * @property {import('ioredis').RedisOptions} redisOptions
  */
@@ -63,7 +64,7 @@ function getSentinelConfiguration(env, commonOptions) {
  * @returns {RedisConfiguration} configuration for the Redis connection
  */
 export function configFromEnv(env) {
-  const redisNamespace = env.REDIS_NAMESPACE ? `${env.REDIS_NAMESPACE}:` : undefined;
+  const redisNamespace = env.REDIS_NAMESPACE ? `${env.REDIS_NAMESPACE}:` : '';
 
   // These options apply for both REDIS_URL based connections and connections
   // using the other REDIS_* environment variables:
@@ -81,7 +82,8 @@ export function configFromEnv(env) {
   if (typeof env.REDIS_URL === 'string' && env.REDIS_URL.length > 0) {
     return {
       redisUrl: env.REDIS_URL,
-      redisOptions: commonOptions
+      redisOptions: commonOptions,
+      redisNamespace
     };
   }
 
@@ -89,6 +91,7 @@ export function configFromEnv(env) {
   if (hasSentinelConfiguration(env)) {
     return {
       redisOptions: getSentinelConfiguration(env, commonOptions),
+      redisNamespace
     };
   }
 
@@ -107,7 +110,8 @@ export function configFromEnv(env) {
   };
 
   return {
-    redisOptions
+    redisOptions,
+    redisNamespace
   };
 }
 


### PR DESCRIPTION
This does the following:

- [x] Migrates streaming to using `keyPrefix` which appears to work correctly in ioredis, since we don't use KEYS or SCAN commands. Note: we still need to manually prefix `subscribe` and `unsubscribe` commands.
- [x] Prefers `REDIS_URL` over all other `REDIS_*` options. This does mean that we don't merge those options with `REDIS_URL`, which is the expected behavior from the Ruby side. Fixes #29770 
- [x] Adds support for Redis in Sentinel mode, per #26571, but uses the following environment variables:
  - `REDIS_SENTINELS`
  - `REDIS_SENTINEL_MASTER`
  - `REDIS_SENTINEL_PORT`
  - `REDIS_SENTINEL_USERNAME` (defaults to `REDIS_USERNAME`)
  - `REDIS_SENTINEL_PASSWORD` (defaults to `REDIS_PASSWORD`)

We may also want to consider a method here for setting TLS options.