### PR TITLE
Streaming: Fix BIND IPv6 handling

### DIFF
--- a/streaming/index.js
+++ b/streaming/index.js
@@ -1351,8 +1351,8 @@ const startServer = async () => {
  * @param {function(string): void} [onSuccess]
  */
 const attachServerWithConfig = (server, onSuccess) => {
-  if (process.env.SOCKET || process.env.PORT && isNaN(+process.env.PORT)) {
-    server.listen(process.env.SOCKET || process.env.PORT, () => {
+  if (process.env.SOCKET) {
+    server.listen(process.env.SOCKET, () => {
       if (onSuccess) {
         fs.chmodSync(server.address(), 0o666);
         onSuccess(server.address());

--- a/streaming/index.js
+++ b/streaming/index.js
@@ -1359,7 +1359,15 @@ const attachServerWithConfig = (server, onSuccess) => {
       }
     });
   } else {
-    server.listen(+(process.env.PORT || 4000), process.env.BIND || '127.0.0.1', () => {
+    const port = +(process.env.PORT || 4000);
+    let bind = process.env.BIND ?? '127.0.0.1';
+    // Web uses the URI syntax for BIND, which means IPv6 addresses may
+    // be wrapped in square brackets:
+    if (bind.startsWith('[') && bind.endsWith(']')) {
+      bind = bind.slice(1, -1);
+    }
+
+    server.listen(port, bind, () => {
       if (onSuccess) {
         onSuccess(`${server.address().address}:${server.address().port}`);
       }


### PR DESCRIPTION
Fixes #31395

Mastodon Web [uses the URI syntax](https://github.com/mastodon/mastodon/blob/1d557305d2fbd53a8a0e66af4e46ccc84d597ce8/config/puma.rb#L12) for `BIND` (versus rails' `BINDING` environment variable which uses the correct syntax). As Streaming needs to accept the `BIND` value but convert it to something Node.js understands, we need to strip the square brackets if present.

Newer versions of Node.js will actually through if BIND is malformed: https://github.com/nodejs/node/pull/54470