### PR TITLE
Fix N+1s in grouped notifications

### DIFF
--- a/app/controllers/api/v2_alpha/notifications_controller.rb
+++ b/app/controllers/api/v2_alpha/notifications_controller.rb
@@ -48,7 +48,7 @@ class Api::V2Alpha::NotificationsController < Api::BaseController
 
   def show
     @notification = current_account.notifications.without_suspended.find_by!(group_key: params[:id])
-    presenter = GroupedNotificationsPresenter.new([NotificationGroup.from_notification(@notification)])
+    presenter = GroupedNotificationsPresenter.new(NotificationGroup.from_notifications([@notification]))
     render json: presenter, serializer: REST::DedupNotificationGroupSerializer
   end
 
@@ -92,7 +92,7 @@ class Api::V2Alpha::NotificationsController < Api::BaseController
 
   def load_grouped_notifications
     MastodonOTELTracer.in_span('Api::V2Alpha::NotificationsController#load_grouped_notifications') do
-      @notifications.map { |notification| NotificationGroup.from_notification(notification, max_id: @group_metadata.dig(notification.group_key, :max_id), grouped_types: params[:grouped_types]) }
+      NotificationGroup.from_notifications(@notifications, max_id: @notifications.first.id, grouped_types: params[:grouped_types])
     end
   end
 

--- a/app/models/notification_group.rb
+++ b/app/models/notification_group.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 class NotificationGroup < ActiveModelSerializers::Model
-  attributes :group_key, :sample_accounts, :notifications_count, :notification, :most_recent_notification_id
+  attributes :group_key, :sample_accounts, :notifications_count, :notification, :most_recent_notification_id, :pagination_data
 
   # Try to keep this consistent with `app/javascript/mastodon/models/notification_group.ts`
   SAMPLE_ACCOUNTS_SIZE = 8
 
-  def self.from_notifications(notifications, max_id: nil, grouped_types: nil)
+  def self.from_notifications(notifications, pagination_range: nil, grouped_types: nil)
     return [] if notifications.empty?
 
     grouped_types = grouped_types.presence&.map(&:to_sym) || Notification::GROUPABLE_NOTIFICATION_TYPES
@@ -14,26 +14,33 @@ class NotificationGroup < ActiveModelSerializers::Model
     grouped_notifications = notifications.filter { |notification| notification.group_key.present? && grouped_types.include?(notification.type) }
     group_keys = grouped_notifications.pluck(:group_key)
 
-    groups_data = load_groups_data(notifications.first.account_id, group_keys, max_id: max_id)
+    groups_data = load_groups_data(notifications.first.account_id, group_keys, pagination_range: pagination_range)
     accounts_map = Account.where(id: groups_data.values.pluck(1).flatten).index_by(&:id)
 
     notifications.map do |notification|
       if notification.group_key.present? && grouped_types.include?(notification.type)
-        most_recent_notification_id, sample_account_ids, count = groups_data[notification.group_key]
+        most_recent_notification_id, sample_account_ids, count, *raw_pagination_data = groups_data[notification.group_key]
+
+        pagination_data = raw_pagination_data.empty? ? nil : { min_id: raw_pagination_data[0], latest_notification_at: raw_pagination_data[1] }
+
         NotificationGroup.new(
           notification: notification,
           group_key: notification.group_key,
           sample_accounts: sample_account_ids.map { |id| accounts_map[id] },
           notifications_count: count,
-          most_recent_notification_id: most_recent_notification_id
+          most_recent_notification_id: most_recent_notification_id,
+          pagination_data: pagination_data
         )
       else
+        pagination_data = pagination_range.blank? ? nil : { min_id: notification.id, latest_notification_at: notification.created_at }
+
         NotificationGroup.new(
           notification: notification,
           group_key: "ungrouped-#{notification.id}",
           sample_accounts: [notification.from_account],
           notifications_count: 1,
-          most_recent_notification_id: notification.id
+          most_recent_notification_id: notification.id,
+          pagination_data: pagination_data
         )
       end
     end
@@ -49,25 +56,28 @@ class NotificationGroup < ActiveModelSerializers::Model
   class << self
     private
 
-    def load_groups_data(account_id, group_keys, max_id: nil)
+    def load_groups_data(account_id, group_keys, pagination_range: nil)
       return {} if group_keys.empty?
 
-      if max_id.present?
+      if pagination_range.present?
         binds = [
           account_id,
-          max_id,
           SAMPLE_ACCOUNTS_SIZE,
+          pagination_range.begin,
+          pagination_range.end,
         ]
         binds.concat(group_keys)
 
         ActiveRecord::Base.connection.select_all(<<~SQL.squish, 'grouped_notifications', binds).cast_values.to_h { |k, *values| [k, values] }
           SELECT
             groups.group_key,
-            (SELECT id FROM notifications WHERE notifications.account_id = $1 AND notifications.group_key = groups.group_key AND id <= $2 ORDER BY id DESC LIMIT 1),
-            array(SELECT from_account_id FROM notifications WHERE notifications.account_id = $1 AND notifications.group_key = groups.group_key AND id <= $2 ORDER BY id DESC LIMIT $3),
-            (SELECT count(*) FROM notifications WHERE notifications.account_id = $1 AND notifications.group_key = groups.group_key AND id <= $2) AS notifications_count
+            (SELECT id FROM notifications WHERE notifications.account_id = $1 AND notifications.group_key = groups.group_key AND id <= $4 ORDER BY id DESC LIMIT 1),
+            array(SELECT from_account_id FROM notifications WHERE notifications.account_id = $1 AND notifications.group_key = groups.group_key AND id <= $4 ORDER BY id DESC LIMIT $2),
+            (SELECT count(*) FROM notifications WHERE notifications.account_id = $1 AND notifications.group_key = groups.group_key AND id <= $4) AS notifications_count,
+            (SELECT id FROM notifications WHERE notifications.account_id = $1 AND notifications.group_key = groups.group_key AND id >= $3 ORDER BY id ASC LIMIT 1) AS min_id,
+            (SELECT created_at FROM notifications WHERE notifications.account_id = $1 AND notifications.group_key = groups.group_key AND id <= $4 ORDER BY id DESC LIMIT 1)
           FROM
-            (VALUES #{Array.new(group_keys.size) { |i| "($#{i + 4})" }.join(', ')}) AS groups(group_key);
+            (VALUES #{Array.new(group_keys.size) { |i| "($#{i + 5})" }.join(', ')}) AS groups(group_key);
         SQL
       else
         binds = [

--- a/app/models/notification_group.rb
+++ b/app/models/notification_group.rb
@@ -6,33 +6,37 @@ class NotificationGroup < ActiveModelSerializers::Model
   # Try to keep this consistent with `app/javascript/mastodon/models/notification_group.ts`
   SAMPLE_ACCOUNTS_SIZE = 8
 
-  def self.from_notification(notification, max_id: nil, grouped_types: nil)
+  def self.from_notifications(notifications, max_id: nil, grouped_types: nil)
+    return [] if notifications.empty?
+
     grouped_types = grouped_types.presence&.map(&:to_sym) || Notification::GROUPABLE_NOTIFICATION_TYPES
-    groupable = notification.group_key.present? && grouped_types.include?(notification.type)
 
-    if groupable
-      # TODO: caching, and, if caching, preloading
-      scope = notification.account.notifications.where(group_key: notification.group_key)
-      scope = scope.where(id: ..max_id) if max_id.present?
+    grouped_notifications = notifications.filter { |notification| notification.group_key.present? && grouped_types.include?(notification.type) }
+    group_keys = grouped_notifications.pluck(:group_key)
 
-      # Ideally, we would not load accounts for each notification group
-      most_recent_notifications = scope.order(id: :desc).includes(:from_account).take(SAMPLE_ACCOUNTS_SIZE)
-      most_recent_id = most_recent_notifications.first.id
-      sample_accounts = most_recent_notifications.map(&:from_account)
-      notifications_count = scope.count
-    else
-      most_recent_id = notification.id
-      sample_accounts = [notification.from_account]
-      notifications_count = 1
+    groups_data = load_groups_data(notifications.first.account_id, group_keys, max_id: max_id)
+    accounts_map = Account.where(id: groups_data.values.pluck(1).flatten).index_by(&:id)
+
+    notifications.map do |notification|
+      if notification.group_key.present? && grouped_types.include?(notification.type)
+        most_recent_notification_id, sample_account_ids, count = groups_data[notification.group_key]
+        NotificationGroup.new(
+          notification: notification,
+          group_key: notification.group_key,
+          sample_accounts: sample_account_ids.map { |id| accounts_map[id] },
+          notifications_count: count,
+          most_recent_notification_id: most_recent_notification_id
+        )
+      else
+        NotificationGroup.new(
+          notification: notification,
+          group_key: "ungrouped-#{notification.id}",
+          sample_accounts: [notification.from_account],
+          notifications_count: 1,
+          most_recent_notification_id: notification.id
+        )
+      end
     end
-
-    NotificationGroup.new(
-      notification: notification,
-      group_key: groupable ? notification.group_key : "ungrouped-#{notification.id}",
-      sample_accounts: sample_accounts,
-      notifications_count: notifications_count,
-      most_recent_notification_id: most_recent_id
-    )
   end
 
   delegate :type,
@@ -41,4 +45,47 @@ class NotificationGroup < ActiveModelSerializers::Model
            :account_relationship_severance_event,
            :account_warning,
            to: :notification, prefix: false
+
+  class << self
+    private
+
+    def load_groups_data(account_id, group_keys, max_id: nil)
+      return {} if group_keys.empty?
+
+      if max_id.present?
+        binds = [
+          account_id,
+          max_id,
+          SAMPLE_ACCOUNTS_SIZE,
+        ]
+        binds.concat(group_keys)
+
+        ActiveRecord::Base.connection.select_all(<<~SQL.squish, 'grouped_notifications', binds).cast_values.to_h { |k, *values| [k, values] }
+          SELECT
+            groups.group_key,
+            (SELECT id FROM notifications WHERE notifications.account_id = $1 AND notifications.group_key = groups.group_key AND id <= $2 ORDER BY id DESC LIMIT 1),
+            array(SELECT from_account_id FROM notifications WHERE notifications.account_id = $1 AND notifications.group_key = groups.group_key AND id <= $2 ORDER BY id DESC LIMIT $3),
+            (SELECT count(*) FROM notifications WHERE notifications.account_id = $1 AND notifications.group_key = groups.group_key AND id <= $2) AS notifications_count
+          FROM
+            (VALUES #{Array.new(group_keys.size) { |i| "($#{i + 4})" }.join(', ')}) AS groups(group_key);
+        SQL
+      else
+        binds = [
+          account_id,
+          SAMPLE_ACCOUNTS_SIZE,
+        ]
+        binds.concat(group_keys)
+
+        ActiveRecord::Base.connection.select_all(<<~SQL.squish, 'grouped_notifications', binds).cast_values.to_h { |k, *values| [k, values] }
+          SELECT
+            groups.group_key,
+            (SELECT id FROM notifications WHERE notifications.account_id = $1 AND notifications.group_key = groups.group_key ORDER BY id DESC LIMIT 1),
+            array(SELECT from_account_id FROM notifications WHERE notifications.account_id = $1 AND notifications.group_key = groups.group_key ORDER BY id DESC LIMIT $2),
+            (SELECT count(*) FROM notifications WHERE notifications.account_id = $1 AND notifications.group_key = groups.group_key) AS notifications_count
+          FROM
+            (VALUES #{Array.new(group_keys.size) { |i| "($#{i + 3})" }.join(', ')}) AS groups(group_key);
+        SQL
+      end
+    end
+  end
 end

--- a/app/serializers/rest/notification_group_serializer.rb
+++ b/app/serializers/rest/notification_group_serializer.rb
@@ -39,21 +39,18 @@ class REST::NotificationGroupSerializer < ActiveModel::Serializer
   end
 
   def page_min_id
-    range = instance_options[:group_metadata][object.group_key]
-    range.present? ? range[:min_id].to_s : object.notification.id.to_s
+    object.pagination_data[:min_id].to_s
   end
 
   def page_max_id
-    range = instance_options[:group_metadata][object.group_key]
-    range.present? ? range[:max_id].to_s : object.notification.id.to_s
+    object.most_recent_notification_id.to_s
   end
 
   def latest_page_notification_at
-    range = instance_options[:group_metadata][object.group_key]
-    range.present? ? range[:latest_notification_at] : object.notification.created_at
+    object.pagination_data[:latest_notification_at]
   end
 
   def paginated?
-    !instance_options[:group_metadata].nil?
+    object.pagination_data.present?
   end
 end


### PR DESCRIPTION
This is far too low-level to my taste, but it does avoid N+1s and account overlap when loading accounts.

In a best-case scenario (the grouped notification page is entirely made of the same 10 people reblogging the same posts), this cuts the total response time from 0.126s to 0.085s (average on 100 calls) on my development computer.

In a worst-case scenario (every notification is from a different person), the response time is dominated by serialization and this cuts the total response time goes from 0.38s to 0.31s (average on 100 calls) on my development computer.