### PR TITLE
Use rails configuration storage for paperclip path

### DIFF
--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -160,9 +160,10 @@ elsif ENV['AZURE_ENABLED'] == 'true'
     )
   end
 else
+  Rails.configuration.x.file_storage_root_path = ENV.fetch('PAPERCLIP_ROOT_PATH', File.join(':rails_root', 'public', 'system'))
   Paperclip::Attachment.default_options.merge!(
     storage: :filesystem,
-    path: File.join(ENV.fetch('PAPERCLIP_ROOT_PATH', File.join(':rails_root', 'public', 'system')), ':prefix_path:class', ':attachment', ':id_partition', ':style', ':filename'),
+    path: File.join(Rails.configuration.x.file_storage_root_path, ':prefix_path:class', ':attachment', ':id_partition', ':style', ':filename'),
     url: ENV.fetch('PAPERCLIP_ROOT_URL', '/system') + "/#{PATH}"
   )
 end

--- a/lib/mastodon/cli/media.rb
+++ b/lib/mastodon/cli/media.rb
@@ -157,7 +157,7 @@ module Mastodon::CLI
       when :filesystem
         require 'find'
 
-        root_path = ENV.fetch('PAPERCLIP_ROOT_PATH', File.join(':rails_root', 'public', 'system')).gsub(':rails_root', Rails.root.to_s)
+        root_path = Rails.configuration.x.file_storage_root_path.gsub(':rails_root', Rails.root.to_s)
 
         Find.find(File.join(*[root_path, prefix].compact)) do |path|
           next if File.directory?(path)


### PR DESCRIPTION
Extracted in part from https://github.com/mastodon/mastodon/pull/31515

The linked PR still needs contemplation/refactoring for handling some of the expectations around what the file path looks like, but this is just pulling out some repeated setup into a config setting.

Both of these paths are only used when in `:filesystem` storage mode, and the before/after for the setting from paperclip's perspective looks the same.

On a side note, the paperclip initializer file is pretty large, contains logic for some slightly different things, creates global vars/constants, etc ... could stand a clean-up of it's own.