### PR TITLE
Fix inconsistencies between code and notification source translation strings

### DIFF
--- a/app/javascript/mastodon/features/notifications/components/notification.jsx
+++ b/app/javascript/mastodon/features/notifications/components/notification.jsx
@@ -31,11 +31,11 @@ import { RelationshipsSeveranceEvent } from './relationships_severance_event';
 import Report from './report';
 
 const messages = defineMessages({
-  favourite: { id: 'notification.favourite', defaultMessage: '{name} favorited your status' },
+  favourite: { id: 'notification.favourite', defaultMessage: '{name} favorited your post' },
   follow: { id: 'notification.follow', defaultMessage: '{name} followed you' },
   ownPoll: { id: 'notification.own_poll', defaultMessage: 'Your poll has ended' },
   poll: { id: 'notification.poll', defaultMessage: 'A poll you voted in has ended' },
-  reblog: { id: 'notification.reblog', defaultMessage: '{name} boosted your status' },
+  reblog: { id: 'notification.reblog', defaultMessage: '{name} boosted your post' },
   status: { id: 'notification.status', defaultMessage: '{name} just posted' },
   update: { id: 'notification.update', defaultMessage: '{name} edited a post' },
   adminSignUp: { id: 'notification.admin.sign_up', defaultMessage: '{name} signed up' },
@@ -201,7 +201,7 @@ class Notification extends ImmutablePureComponent {
             <Icon id='star' icon={StarIcon} className='star-icon' />
 
             <span title={notification.get('created_at')}>
-              <FormattedMessage id='notification.favourite' defaultMessage='{name} favorited your status' values={{ name: link }} />
+              <FormattedMessage id='notification.favourite' defaultMessage='{name} favorited your post' values={{ name: link }} />
             </span>
           </div>
 
@@ -231,7 +231,7 @@ class Notification extends ImmutablePureComponent {
             <Icon id='retweet' icon={RepeatIcon} />
 
             <span title={notification.get('created_at')}>
-              <FormattedMessage id='notification.reblog' defaultMessage='{name} boosted your status' values={{ name: link }} />
+              <FormattedMessage id='notification.reblog' defaultMessage='{name} boosted your post' values={{ name: link }} />
             </span>
           </div>
 

--- a/app/javascript/mastodon/features/notifications_v2/components/notification_favourite.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/components/notification_favourite.tsx
@@ -14,7 +14,7 @@ const labelRenderer: LabelRenderer = (displayedName, total, seeMoreHref) => {
     return (
       <FormattedMessage
         id='notification.favourite'
-        defaultMessage='{name} favorited your status'
+        defaultMessage='{name} favorited your post'
         values={{ name: displayedName }}
       />
     );

--- a/app/javascript/mastodon/features/notifications_v2/components/notification_reblog.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/components/notification_reblog.tsx
@@ -14,7 +14,7 @@ const labelRenderer: LabelRenderer = (displayedName, total, seeMoreHref) => {
     return (
       <FormattedMessage
         id='notification.reblog'
-        defaultMessage='{name} boosted your status'
+        defaultMessage='{name} boosted your post'
         values={{ name: displayedName }}
       />
     );


### PR DESCRIPTION
The strings in `app/javascript/mastodon/locales/en.json` had been changed, but not those in the code itself.