### PR TITLE
Change label of grouped favourite notification on private mentions

### DIFF
--- a/app/javascript/mastodon/features/notifications_v2/components/notification_favourite.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/components/notification_favourite.tsx
@@ -33,6 +33,34 @@ const labelRenderer: LabelRenderer = (displayedName, total, seeMoreHref) => {
   );
 };
 
+const privateLabelRenderer: LabelRenderer = (
+  displayedName,
+  total,
+  seeMoreHref,
+) => {
+  if (total === 1)
+    return (
+      <FormattedMessage
+        id='notification.favourite_pm'
+        defaultMessage='{name} favorited your private mention'
+        values={{ name: displayedName }}
+      />
+    );
+
+  return (
+    <FormattedMessage
+      id='notification.favourite_pm.name_and_others_with_link'
+      defaultMessage='{name} and <a>{count, plural, one {# other} other {# others}}</a> favorited your private mention'
+      values={{
+        name: displayedName,
+        count: total - 1,
+        a: (chunks) =>
+          seeMoreHref ? <Link to={seeMoreHref}>{chunks}</Link> : chunks,
+      }}
+    />
+  );
+};
+
 export const NotificationFavourite: React.FC<{
   notification: NotificationGroupFavourite;
   unread: boolean;
@@ -44,6 +72,10 @@ export const NotificationFavourite: React.FC<{
         ?.acct,
   );
 
+  const isPrivateMention = useAppSelector(
+    (state) => state.statuses.getIn([statusId, 'visibility']) === 'direct',
+  );
+
   return (
     <NotificationGroupWithStatus
       type='favourite'
@@ -53,7 +85,7 @@ export const NotificationFavourite: React.FC<{
       statusId={notification.statusId}
       timestamp={notification.latest_page_notification_at}
       count={notification.notifications_count}
-      labelRenderer={labelRenderer}
+      labelRenderer={isPrivateMention ? privateLabelRenderer : labelRenderer}
       labelSeeMoreHref={
         statusAccount ? `/@${statusAccount}/${statusId}/favourites` : undefined
       }

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -505,6 +505,8 @@
   "notification.admin.sign_up.name_and_others": "{name} and {count, plural, one {# other} other {# others}} signed up",
   "notification.favourite": "{name} favorited your post",
   "notification.favourite.name_and_others_with_link": "{name} and <a>{count, plural, one {# other} other {# others}}</a> favorited your post",
+  "notification.favourite_pm": "{name} favorited your private mention",
+  "notification.favourite_pm.name_and_others_with_link": "{name} and <a>{count, plural, one {# other} other {# others}}</a> favorited your private mention",
   "notification.follow": "{name} followed you",
   "notification.follow.name_and_others": "{name} and {count, plural, one {# other} other {# others}} followed you",
   "notification.follow_request": "{name} has requested to follow you",


### PR DESCRIPTION
Follow-up to #31657

As pointed out in that PR, we used to render the privacy indicator in those notifications, but that is not the case anymore. In addition to the background tint used in that PR, this commit changes the text so it reads “`@foo` favorited your private mention” instead of “`@foo` favourited your post” to distinguish between normal posts and private mentions.