### PR TITLE
Use built-in `response.parsed_body` for JSON response specs

### DIFF
--- a/spec/requests/api/v1/admin/domain_blocks_spec.rb
+++ b/spec/requests/api/v1/admin/domain_blocks_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe 'Domain Blocks' do
       subject
 
       expect(response).to have_http_status(200)
-      expect(body_as_json).to eq(
+      expect(body_as_json).to include(
         {
           id: domain_block.id.to_s,
           domain: domain_block.domain,

--- a/spec/requests/api/v1/admin/domain_blocks_spec.rb
+++ b/spec/requests/api/v1/admin/domain_blocks_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe 'Domain Blocks' do
       subject
 
       expect(response).to have_http_status(200)
-      expect(body_as_json).to include(
+      expect(body_as_json).to match(
         {
           id: domain_block.id.to_s,
           domain: domain_block.domain,

--- a/spec/requests/api/v1/instances/translation_languages_spec.rb
+++ b/spec/requests/api/v1/instances/translation_languages_spec.rb
@@ -26,7 +26,7 @@ describe 'Translation Languages' do
           .to have_http_status(200)
 
         expect(body_as_json)
-          .to include({ und: %w(en de), en: ['de'] })
+          .to match({ und: %w(en de), en: ['de'] })
       end
 
       private

--- a/spec/requests/api/v1/instances/translation_languages_spec.rb
+++ b/spec/requests/api/v1/instances/translation_languages_spec.rb
@@ -26,7 +26,7 @@ describe 'Translation Languages' do
           .to have_http_status(200)
 
         expect(body_as_json)
-          .to eq({ und: %w(en de), en: ['de'] })
+          .to include({ und: %w(en de), en: ['de'] })
       end
 
       private

--- a/spec/requests/api/v1/lists_spec.rb
+++ b/spec/requests/api/v1/lists_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe 'Lists' do
       subject
 
       expect(response).to have_http_status(200)
-      expect(body_as_json).to eq({
+      expect(body_as_json).to include({
         id: list.id.to_s,
         title: list.title,
         replies_policy: list.replies_policy,
@@ -144,7 +144,7 @@ RSpec.describe 'Lists' do
       expect(response).to have_http_status(200)
       list.reload
 
-      expect(body_as_json).to eq({
+      expect(body_as_json).to include({
         id: list.id.to_s,
         title: list.title,
         replies_policy: list.replies_policy,

--- a/spec/requests/api/v1/lists_spec.rb
+++ b/spec/requests/api/v1/lists_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe 'Lists' do
       subject
 
       expect(response).to have_http_status(200)
-      expect(body_as_json).to include({
+      expect(body_as_json).to match({
         id: list.id.to_s,
         title: list.title,
         replies_policy: list.replies_policy,
@@ -144,7 +144,7 @@ RSpec.describe 'Lists' do
       expect(response).to have_http_status(200)
       list.reload
 
-      expect(body_as_json).to include({
+      expect(body_as_json).to match({
         id: list.id.to_s,
         title: list.title,
         replies_policy: list.replies_policy,

--- a/spec/requests/api/v1/notifications/requests_spec.rb
+++ b/spec/requests/api/v1/notifications/requests_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe 'Requests' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json).to eq({ merged: true })
+        expect(body_as_json).to include({ merged: true })
       end
     end
 
@@ -146,7 +146,7 @@ RSpec.describe 'Requests' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json).to eq({ merged: false })
+        expect(body_as_json).to include({ merged: false })
       end
     end
   end

--- a/spec/requests/api/v1/notifications/requests_spec.rb
+++ b/spec/requests/api/v1/notifications/requests_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe 'Requests' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json).to include({ merged: true })
+        expect(body_as_json).to match({ merged: true })
       end
     end
 
@@ -146,7 +146,7 @@ RSpec.describe 'Requests' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json).to include({ merged: false })
+        expect(body_as_json).to match({ merged: false })
       end
     end
   end

--- a/spec/requests/api/v1/statuses/sources_spec.rb
+++ b/spec/requests/api/v1/statuses/sources_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Sources' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json).to eq({
+        expect(body_as_json).to include({
           id: status.id.to_s,
           text: status.text,
           spoiler_text: status.spoiler_text,
@@ -51,7 +51,7 @@ RSpec.describe 'Sources' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json).to eq({
+        expect(body_as_json).to include({
           id: status.id.to_s,
           text: status.text,
           spoiler_text: status.spoiler_text,

--- a/spec/requests/api/v1/statuses/sources_spec.rb
+++ b/spec/requests/api/v1/statuses/sources_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Sources' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json).to include({
+        expect(body_as_json).to match({
           id: status.id.to_s,
           text: status.text,
           spoiler_text: status.spoiler_text,
@@ -51,7 +51,7 @@ RSpec.describe 'Sources' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json).to include({
+        expect(body_as_json).to match({
           id: status.id.to_s,
           text: status.text,
           spoiler_text: status.spoiler_text,

--- a/spec/requests/api/v1/statuses_spec.rb
+++ b/spec/requests/api/v1/statuses_spec.rb
@@ -154,12 +154,7 @@ describe '/api/v1/statuses' do
           subject
 
           expect(response).to have_http_status(422)
-          expect(body_as_json)
-            .to include(
-              unexpected_accounts: have_attributes(
-                first: include(id: bob.id.to_s, acct: bob.acct)
-              )
-            )
+          expect(body_as_json[:unexpected_accounts].map { |a| a.slice(:id, :acct) }).to match [{ id: bob.id.to_s, acct: bob.acct }]
         end
       end
 

--- a/spec/requests/api/v1/statuses_spec.rb
+++ b/spec/requests/api/v1/statuses_spec.rb
@@ -154,7 +154,12 @@ describe '/api/v1/statuses' do
           subject
 
           expect(response).to have_http_status(422)
-          expect(body_as_json[:unexpected_accounts].map { |a| a.slice(:id, :acct) }).to eq [{ id: bob.id.to_s, acct: bob.acct }]
+          expect(body_as_json)
+            .to include(
+              unexpected_accounts: have_attributes(
+                first: include(id: bob.id.to_s, acct: bob.acct)
+              )
+            )
         end
       end
 

--- a/spec/requests/api/v2/filters_spec.rb
+++ b/spec/requests/api/v2/filters_spec.rb
@@ -58,15 +58,12 @@ RSpec.describe 'Filters' do
       it 'returns a filter with keywords', :aggregate_failures do
         subject
 
-        expect(body_as_json)
-          .to include(
-            title: 'magic',
-            filter_action: 'hide',
-            context: %w(home),
-            keywords: have_attributes(
-              first: include(keyword: 'magic', whole_word: true)
-            )
-          )
+        json = body_as_json
+
+        expect(json[:title]).to eq 'magic'
+        expect(json[:filter_action]).to eq 'hide'
+        expect(json[:context]).to eq ['home']
+        expect(json[:keywords].map { |keyword| keyword.slice(:keyword, :whole_word) }).to match [{ keyword: 'magic', whole_word: true }]
       end
 
       it 'creates a filter', :aggregate_failures do

--- a/spec/requests/api/v2/filters_spec.rb
+++ b/spec/requests/api/v2/filters_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe 'Filters' do
           .to include(
             title: 'magic',
             filter_action: 'hide',
-            context: ['home'],
+            context: %w(home),
             keywords: have_attributes(
               first: include(keyword: 'magic', whole_word: true)
             )

--- a/spec/requests/api/v2/filters_spec.rb
+++ b/spec/requests/api/v2/filters_spec.rb
@@ -58,12 +58,15 @@ RSpec.describe 'Filters' do
       it 'returns a filter with keywords', :aggregate_failures do
         subject
 
-        json = body_as_json
-
-        expect(json[:title]).to eq 'magic'
-        expect(json[:filter_action]).to eq 'hide'
-        expect(json[:context]).to eq ['home']
-        expect(json[:keywords].map { |keyword| keyword.slice(:keyword, :whole_word) }).to eq [{ keyword: 'magic', whole_word: true }]
+        expect(body_as_json)
+          .to include(
+            title: 'magic',
+            filter_action: 'hide',
+            context: ['home'],
+            keywords: have_attributes(
+              first: include(keyword: 'magic', whole_word: true)
+            )
+          )
       end
 
       it 'creates a filter', :aggregate_failures do

--- a/spec/requests/api/v2_alpha/notifications_spec.rb
+++ b/spec/requests/api/v2_alpha/notifications_spec.rb
@@ -234,16 +234,10 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json)
-          .to include(
-            partial_accounts: have_attributes(
-              size: be > 0,
-              first: have_attributes(keys: contain_exactly('acct', 'avatar', 'avatar_static', 'bot', 'id', 'locked', 'url'))
-            ).and(not_include(id: recent_account.id.to_s)),
-            accounts: have_attributes(
-              first: include(id: recent_account.id.to_s)
-            )
-          )
+        expect(body_as_json[:partial_accounts].size).to be > 0
+        expect(body_as_json[:partial_accounts][0].keys.map(&:to_sym)).to contain_exactly(:acct, :avatar, :avatar_static, :bot, :id, :locked, :url)
+        expect(body_as_json[:partial_accounts].pluck(:id)).to_not include(recent_account.id.to_s)
+        expect(body_as_json[:accounts].pluck(:id)).to include(recent_account.id.to_s)
       end
     end
 

--- a/spec/requests/api/v2_alpha/notifications_spec.rb
+++ b/spec/requests/api/v2_alpha/notifications_spec.rb
@@ -234,10 +234,16 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json[:partial_accounts].size).to be > 0
-        expect(body_as_json[:partial_accounts][0].keys).to contain_exactly(:acct, :avatar, :avatar_static, :bot, :id, :locked, :url)
-        expect(body_as_json[:partial_accounts].pluck(:id)).to_not include(recent_account.id.to_s)
-        expect(body_as_json[:accounts].pluck(:id)).to include(recent_account.id.to_s)
+        expect(body_as_json)
+          .to include(
+            partial_accounts: have_attributes(
+              size: be > 0,
+              first: have_attributes(keys: contain_exactly('acct', 'avatar', 'avatar_static', 'bot', 'id', 'locked', 'url'))
+            ).and(not_include(id: recent_account.id.to_s)),
+            accounts: have_attributes(
+              first: include(id: recent_account.id.to_s)
+            )
+          )
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,11 +39,7 @@ RSpec.configure do |config|
 end
 
 def body_as_json
-  json_str_to_hash(response.body)
-end
-
-def json_str_to_hash(str)
-  JSON.parse(str, symbolize_names: true)
+  response.parsed_body
 end
 
 def serialized_record_json(record, serializer, adapter: nil)

--- a/spec/support/matchers/json/match_json_schema.rb
+++ b/spec/support/matchers/json/match_json_schema.rb
@@ -9,7 +9,9 @@ end
 
 RSpec::Matchers.define :match_json_values do |values|
   match do |string|
-    expect(json_str_to_hash(string))
+    parsed_json = JSON.parse(string, symbolize_names: true)
+
+    expect(parsed_json)
       .to include(values)
   end
 


### PR DESCRIPTION
There's a built-in framework testing method `parsed_body` on `TestReponse` objects - https://api.rubyonrails.org/classes/ActionDispatch/TestResponse.html#method-i-parsed_body - which provides a memoized helper which attempts to parse response bodies with the appropriate type (html, json, xml, etc).

We have a custom spec helper method - `body_as_json` which pre-dates the existence of this helper in Rails, but a) is not memoized, b) is doing almost exactly what the framework method is.

Right now we have sort of a mix of approaches to asserting about json responses in controller/request specs...

- Some of them do access `response.parsed_body` directly
- Some use `body_as_json` directly
- Some assign a local var to `body_as_json` then assert on that (or use `let` in similar approach)
- Some don't use any helpers, and have JSON parse directly in the spec

I'd like to unify all this for performance/consistency reasons ... I have a branch doing the whole thing but it's pretty large. This first pass is doing:

- Replace the implementation of our `body_as_json` method to just be a wrapper around the framework method
- Move the `json_str_to_hash` impl to the only other place which is using it
- Update all the places in the specs which had any failures from just this change (ie, places that need more than just a rename). Main diffs here are due to symbolized keys, more or less.

Will do follow-up PRs for both a) unifying the various other styles, b) a probably-large but hopefully-boring PR doing a full swap-out on using `body_as_json` vs just using `response.parsed_body` directly in specs.
