### PR TITLE
Direct link to each authorized_application entry with html anchor

### DIFF
--- a/app/views/oauth/authorized_applications/index.html.haml
+++ b/app/views/oauth/authorized_applications/index.html.haml
@@ -7,7 +7,7 @@
 
 .applications-list
   - @applications.each do |application|
-    .applications-list__item{id: application.id}
+    .applications-list__item{ id: dom_id(application) }
       - if application.website.present?
         = link_to application.name, application.website, target: '_blank', rel: 'noopener noreferrer', class: 'announcements-list__item__title'
       - else

--- a/app/views/oauth/authorized_applications/index.html.haml
+++ b/app/views/oauth/authorized_applications/index.html.haml
@@ -7,7 +7,7 @@
 
 .applications-list
   - @applications.each do |application|
-    .applications-list__item
+    .applications-list__item{id: application.id}
       - if application.website.present?
         = link_to application.name, application.website, target: '_blank', rel: 'noopener noreferrer', class: 'announcements-list__item__title'
       - else


### PR DESCRIPTION
eg. allowing `/oauth/authorized_applications#436138` to scroll to the right place.

Future work might be:
* to highlight the linked to app
* a page for each app, as `authorized_applications/:id` currently 404s (try middling clicking "revoke")