### PR TITLE
Reject status creation with invalid `media_ids` parameter

### DIFF
--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -134,6 +134,9 @@ class PostStatusService < BaseService
 
     @media = @account.media_attachments.where(status_id: nil).where(id: @options[:media_ids].take(Status::MEDIA_ATTACHMENTS_LIMIT).map(&:to_i))
 
+    not_found_ids = @options[:media_ids] - @media.map(&:id)
+    raise Mastodon::ValidationError, I18n.t('media_attachments.validations.not_found', ids: not_found_ids.join(', ')) if not_found_ids.any?
+
     raise Mastodon::ValidationError, I18n.t('media_attachments.validations.images_and_video') if @media.size > 1 && @media.find(&:audio_or_video?)
     raise Mastodon::ValidationError, I18n.t('media_attachments.validations.not_ready') if @media.any?(&:not_processed?)
   end

--- a/app/services/update_status_service.rb
+++ b/app/services/update_status_service.rb
@@ -73,6 +73,9 @@ class UpdateStatusService < BaseService
 
     media_attachments = @status.account.media_attachments.where(status_id: [nil, @status.id]).where(scheduled_status_id: nil).where(id: @options[:media_ids].take(Status::MEDIA_ATTACHMENTS_LIMIT).map(&:to_i)).to_a
 
+    not_found_ids = @options[:media_ids] - media_attachments.map(&:id)
+    raise Mastodon::ValidationError, I18n.t('media_attachments.validations.not_found', ids: not_found_ids.join(', ')) if not_found_ids.any?
+
     raise Mastodon::ValidationError, I18n.t('media_attachments.validations.images_and_video') if media_attachments.size > 1 && media_attachments.find(&:audio_or_video?)
     raise Mastodon::ValidationError, I18n.t('media_attachments.validations.not_ready') if media_attachments.any?(&:not_processed?)
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1454,6 +1454,7 @@ en:
   media_attachments:
     validations:
       images_and_video: Cannot attach a video to a post that already contains images
+      not_found: Media %{ids} not found or already attached to another post
       not_ready: Cannot attach files that have not finished processing. Try again in a moment!
       too_many: Cannot attach more than 4 files
   migrations:

--- a/spec/services/post_status_service_spec.rb
+++ b/spec/services/post_status_service_spec.rb
@@ -229,13 +229,16 @@ RSpec.describe PostStatusService do
     account = Fabricate(:account)
     media = Fabricate(:media_attachment, account: Fabricate(:account))
 
-    subject.call(
-      account,
-      text: 'test status update',
-      media_ids: [media.id]
+    expect do
+      subject.call(
+        account,
+        text: 'test status update',
+        media_ids: [media.id]
+      )
+    end.to raise_error(
+      Mastodon::ValidationError,
+      I18n.t('media_attachments.validations.not_found', ids: media.id)
     )
-
-    expect(media.reload.status).to be_nil
   end
 
   it 'does not allow attaching more files than configured limit' do


### PR DESCRIPTION
Using the API, if you try to create a status with too many attachments, the request is rejected with 422 Unprocessable Content. However, if you pass an invalid ID, this is just silently ignored. I think this is inconsistent and surprising. If you explicitly pass an ID which – for whatever reason – is not/no longer valid, you likely don't want the post to be created anyway.

Changing this behaviour is strictly speaking an API change, though it doesn't require any changes to the documentation, so I don't think it warrants an API version bump (i.e. v1 → v2).
