### PR TITLE
Use `body_as_json` directly instead of via local var assignment

### DIFF
--- a/spec/requests/api/v1/accounts_spec.rb
+++ b/spec/requests/api/v1/accounts_spec.rb
@@ -114,10 +114,11 @@ describe '/api/v1/accounts' do
 
           expect(response).to have_http_status(200)
 
-          json = body_as_json
-
-          expect(json[:following]).to be true
-          expect(json[:requested]).to be false
+          expect(body_as_json)
+            .to include(
+              following: true,
+              requested: false
+            )
 
           expect(user.account.following?(other_account)).to be true
         end
@@ -133,10 +134,11 @@ describe '/api/v1/accounts' do
 
           expect(response).to have_http_status(200)
 
-          json = body_as_json
-
-          expect(json[:following]).to be false
-          expect(json[:requested]).to be true
+          expect(body_as_json)
+            .to include(
+              following: false,
+              requested: true
+            )
 
           expect(user.account.requested?(other_account)).to be true
         end

--- a/spec/requests/api/v1/admin/canonical_email_blocks_spec.rb
+++ b/spec/requests/api/v1/admin/canonical_email_blocks_spec.rb
@@ -96,10 +96,11 @@ RSpec.describe 'Canonical Email Blocks' do
         subject
 
         expect(response).to have_http_status(200)
-        json = body_as_json
-
-        expect(json[:id]).to eq(canonical_email_block.id.to_s)
-        expect(json[:canonical_email_hash]).to eq(canonical_email_block.canonical_email_hash)
+        expect(body_as_json)
+          .to include(
+            id: eq(canonical_email_block.id.to_s),
+            canonical_email_hash: eq(canonical_email_block.canonical_email_hash)
+          )
       end
     end
 

--- a/spec/requests/api/v1/admin/domain_blocks_spec.rb
+++ b/spec/requests/api/v1/admin/domain_blocks_spec.rb
@@ -133,10 +133,8 @@ RSpec.describe 'Domain Blocks' do
     it 'creates a domain block with the expected domain name and severity', :aggregate_failures do
       subject
 
-      body = body_as_json
-
       expect(response).to have_http_status(200)
-      expect(body).to match a_hash_including(
+      expect(body_as_json).to match a_hash_including(
         {
           domain: 'foo.bar.com',
           severity: 'silence',
@@ -156,10 +154,8 @@ RSpec.describe 'Domain Blocks' do
       it 'creates a domain block with the expected domain name and severity', :aggregate_failures do
         subject
 
-        body = body_as_json
-
         expect(response).to have_http_status(200)
-        expect(body).to match a_hash_including(
+        expect(body_as_json).to match a_hash_including(
           {
             domain: 'foo.bar.com',
             severity: 'suspend',

--- a/spec/requests/api/v1/admin/ip_blocks_spec.rb
+++ b/spec/requests/api/v1/admin/ip_blocks_spec.rb
@@ -88,10 +88,12 @@ RSpec.describe 'IP Blocks' do
       subject
 
       expect(response).to have_http_status(200)
-      json = body_as_json
 
-      expect(json[:ip]).to eq("#{ip_block.ip}/#{ip_block.ip.prefix}")
-      expect(json[:severity]).to eq(ip_block.severity.to_s)
+      expect(body_as_json)
+        .to include(
+          ip: eq("#{ip_block.ip}/#{ip_block.ip.prefix}"),
+          severity: eq(ip_block.severity.to_s)
+        )
     end
 
     context 'when ip block does not exist' do
@@ -118,11 +120,12 @@ RSpec.describe 'IP Blocks' do
       subject
 
       expect(response).to have_http_status(200)
-      json = body_as_json
-
-      expect(json[:ip]).to eq("#{params[:ip]}/32")
-      expect(json[:severity]).to eq(params[:severity])
-      expect(json[:comment]).to eq(params[:comment])
+      expect(body_as_json)
+        .to include(
+          ip: eq("#{params[:ip]}/32"),
+          severity: eq(params[:severity]),
+          comment: eq(params[:comment])
+        )
     end
 
     context 'when the required ip param is not provided' do

--- a/spec/requests/api/v1/apps_spec.rb
+++ b/spec/requests/api/v1/apps_spec.rb
@@ -61,9 +61,10 @@ RSpec.describe 'Apps' do
         expect(response).to have_http_status(200)
         expect(Doorkeeper::Application.find_by(name: client_name)).to be_present
 
-        body = body_as_json
-
-        expect(body[:scopes]).to eq Doorkeeper.config.default_scopes.to_a
+        expect(body_as_json)
+          .to include(
+            scopes: Doorkeeper.config.default_scopes.to_a
+          )
       end
     end
 
@@ -81,9 +82,10 @@ RSpec.describe 'Apps' do
         expect(app).to be_present
         expect(app.scopes.to_s).to eq 'read'
 
-        body = body_as_json
-
-        expect(body[:scopes]).to eq ['read']
+        expect(body_as_json)
+          .to include(
+            scopes: %w(read)
+          )
       end
     end
 
@@ -163,10 +165,11 @@ RSpec.describe 'Apps' do
         expect(app.redirect_uri).to eq redirect_uris
         expect(app.redirect_uris).to eq redirect_uris.split
 
-        body = body_as_json
-
-        expect(body[:redirect_uri]).to eq redirect_uris
-        expect(body[:redirect_uris]).to eq redirect_uris.split
+        expect(body_as_json)
+          .to include(
+            redirect_uri: redirect_uris,
+            redirect_uris: redirect_uris.split
+          )
       end
     end
 
@@ -184,10 +187,11 @@ RSpec.describe 'Apps' do
         expect(app.redirect_uri).to eq redirect_uris.join "\n"
         expect(app.redirect_uris).to eq redirect_uris
 
-        body = body_as_json
-
-        expect(body[:redirect_uri]).to eq redirect_uris.join "\n"
-        expect(body[:redirect_uris]).to eq redirect_uris
+        expect(body_as_json)
+          .to include(
+            redirect_uri: redirect_uris.join("\n"),
+            redirect_uris: redirect_uris
+          )
       end
     end
 

--- a/spec/requests/api/v1/blocks_spec.rb
+++ b/spec/requests/api/v1/blocks_spec.rb
@@ -55,10 +55,8 @@ RSpec.describe 'Blocks' do
       it 'queries the blocks in range according to max_id', :aggregate_failures do
         subject
 
-        response_body = body_as_json
-
-        expect(response_body.size).to be 1
-        expect(response_body[0][:id]).to eq(blocks[0].target_account.id.to_s)
+        expect(body_as_json)
+          .to contain_exactly(include(id: blocks.first.target_account.id.to_s))
       end
     end
 
@@ -68,10 +66,8 @@ RSpec.describe 'Blocks' do
       it 'queries the blocks in range according to since_id', :aggregate_failures do
         subject
 
-        response_body = body_as_json
-
-        expect(response_body.size).to be 1
-        expect(response_body[0][:id]).to eq(blocks[2].target_account.id.to_s)
+        expect(body_as_json)
+          .to contain_exactly(include(id: blocks[2].target_account.id.to_s))
       end
     end
   end

--- a/spec/requests/api/v1/featured_tags_spec.rb
+++ b/spec/requests/api/v1/featured_tags_spec.rb
@@ -37,9 +37,7 @@ RSpec.describe 'FeaturedTags' do
       it 'returns an empty body' do
         get '/api/v1/featured_tags', headers: headers
 
-        body = body_as_json
-
-        expect(body).to be_empty
+        expect(body_as_json).to be_empty
       end
     end
 
@@ -49,10 +47,10 @@ RSpec.describe 'FeaturedTags' do
       it 'returns only the featured tags belonging to the requesting user' do
         get '/api/v1/featured_tags', headers: headers
 
-        body = body_as_json
-        expected_ids = user_featured_tags.pluck(:id).map(&:to_s)
-
-        expect(body.pluck(:id)).to match_array(expected_ids)
+        expect(body_as_json.pluck(:id))
+          .to match_array(
+            user_featured_tags.pluck(:id).map(&:to_s)
+          )
       end
     end
   end
@@ -69,9 +67,10 @@ RSpec.describe 'FeaturedTags' do
     it 'returns the correct tag name' do
       post '/api/v1/featured_tags', headers: headers, params: params
 
-      body = body_as_json
-
-      expect(body[:name]).to eq(params[:name])
+      expect(body_as_json)
+        .to include(
+          name: params[:name]
+        )
     end
 
     it 'creates a new featured tag for the requesting user' do
@@ -142,9 +141,7 @@ RSpec.describe 'FeaturedTags' do
     it 'returns an empty body' do
       delete "/api/v1/featured_tags/#{id}", headers: headers
 
-      body = body_as_json
-
-      expect(body).to be_empty
+      expect(body_as_json).to be_empty
     end
 
     it 'deletes the featured tag', :inline_jobs do

--- a/spec/requests/api/v1/markers_spec.rb
+++ b/spec/requests/api/v1/markers_spec.rb
@@ -17,13 +17,12 @@ RSpec.describe 'API Markers' do
     end
 
     it 'returns markers', :aggregate_failures do
-      json = body_as_json
-
       expect(response).to have_http_status(200)
-      expect(json.key?(:home)).to be true
-      expect(json[:home][:last_read_id]).to eq '123'
-      expect(json.key?(:notifications)).to be true
-      expect(json[:notifications][:last_read_id]).to eq '456'
+      expect(body_as_json)
+        .to include(
+          home: include(last_read_id: '123'),
+          notifications: include(last_read_id: '456')
+        )
     end
   end
 

--- a/spec/requests/api/v1/mutes_spec.rb
+++ b/spec/requests/api/v1/mutes_spec.rb
@@ -58,10 +58,8 @@ RSpec.describe 'Mutes' do
       it 'queries mutes in range according to max_id', :aggregate_failures do
         subject
 
-        body = body_as_json
-
-        expect(body.size).to eq 1
-        expect(body[0][:id]).to eq mutes[0].target_account_id.to_s
+        expect(body_as_json)
+          .to contain_exactly(include(id: mutes.first.target_account_id.to_s))
       end
     end
 
@@ -71,10 +69,8 @@ RSpec.describe 'Mutes' do
       it 'queries mutes in range according to since_id', :aggregate_failures do
         subject
 
-        body = body_as_json
-
-        expect(body.size).to eq 1
-        expect(body[0][:id]).to eq mutes[1].target_account_id.to_s
+        expect(body_as_json)
+          .to contain_exactly(include(id: mutes[1].target_account_id.to_s))
       end
     end
 

--- a/spec/requests/api/v1/statuses/reblogs_spec.rb
+++ b/spec/requests/api/v1/statuses/reblogs_spec.rb
@@ -24,11 +24,14 @@ describe 'API V1 Statuses Reblogs' do
 
           expect(user.account.reblogged?(status)).to be true
 
-          hash_body = body_as_json
-
-          expect(hash_body[:reblog][:id]).to eq status.id.to_s
-          expect(hash_body[:reblog][:reblogs_count]).to eq 1
-          expect(hash_body[:reblog][:reblogged]).to be true
+          expect(body_as_json)
+            .to include(
+              reblog: include(
+                id: status.id.to_s,
+                reblogs_count: 1,
+                reblogged: true
+              )
+            )
         end
       end
 
@@ -57,11 +60,12 @@ describe 'API V1 Statuses Reblogs' do
 
           expect(user.account.reblogged?(status)).to be false
 
-          hash_body = body_as_json
-
-          expect(hash_body[:id]).to eq status.id.to_s
-          expect(hash_body[:reblogs_count]).to eq 0
-          expect(hash_body[:reblogged]).to be false
+          expect(body_as_json)
+            .to include(
+              id: status.id.to_s,
+              reblogs_count: 0,
+              reblogged: false
+            )
         end
       end
 
@@ -81,11 +85,12 @@ describe 'API V1 Statuses Reblogs' do
 
           expect(user.account.reblogged?(status)).to be false
 
-          hash_body = body_as_json
-
-          expect(hash_body[:id]).to eq status.id.to_s
-          expect(hash_body[:reblogs_count]).to eq 0
-          expect(hash_body[:reblogged]).to be false
+          expect(body_as_json)
+            .to include(
+              id: status.id.to_s,
+              reblogs_count: 0,
+              reblogged: false
+            )
         end
       end
 

--- a/spec/requests/api/v1/suggestions_spec.rb
+++ b/spec/requests/api/v1/suggestions_spec.rb
@@ -32,10 +32,8 @@ RSpec.describe 'Suggestions' do
     it 'returns accounts' do
       subject
 
-      body = body_as_json
-
-      expect(body.size).to eq 2
-      expect(body.pluck(:id)).to match_array([bob, jeff].map { |i| i.id.to_s })
+      expect(body_as_json)
+        .to contain_exactly(include(id: bob.id.to_s), include(id: jeff.id.to_s))
     end
 
     context 'with limit param' do

--- a/spec/requests/api/v2/filters/keywords_spec.rb
+++ b/spec/requests/api/v2/filters/keywords_spec.rb
@@ -42,9 +42,11 @@ RSpec.describe 'API V2 Filters Keywords' do
     it 'creates a filter', :aggregate_failures do
       expect(response).to have_http_status(200)
 
-      json = body_as_json
-      expect(json[:keyword]).to eq 'magic'
-      expect(json[:whole_word]).to be false
+      expect(body_as_json)
+        .to include(
+          keyword: 'magic',
+          whole_word: false
+        )
 
       filter = user.account.custom_filters.first
       expect(filter).to_not be_nil
@@ -71,9 +73,11 @@ RSpec.describe 'API V2 Filters Keywords' do
     it 'responds with the keyword', :aggregate_failures do
       expect(response).to have_http_status(200)
 
-      json = body_as_json
-      expect(json[:keyword]).to eq 'foo'
-      expect(json[:whole_word]).to be false
+      expect(body_as_json)
+        .to include(
+          keyword: 'foo',
+          whole_word: false
+        )
     end
 
     context "when trying to access another user's filter keyword" do

--- a/spec/requests/api/v2/filters/statuses_spec.rb
+++ b/spec/requests/api/v2/filters/statuses_spec.rb
@@ -43,8 +43,10 @@ RSpec.describe 'API V2 Filters Statuses' do
     it 'creates a filter', :aggregate_failures do
       expect(response).to have_http_status(200)
 
-      json = body_as_json
-      expect(json[:status_id]).to eq status.id.to_s
+      expect(body_as_json)
+        .to include(
+          status_id: status.id.to_s
+        )
 
       filter = user.account.custom_filters.first
       expect(filter).to_not be_nil
@@ -71,8 +73,10 @@ RSpec.describe 'API V2 Filters Statuses' do
     it 'responds with the filter', :aggregate_failures do
       expect(response).to have_http_status(200)
 
-      json = body_as_json
-      expect(json[:status_id]).to eq status_filter.status_id.to_s
+      expect(body_as_json)
+        .to include(
+          status_id: status_filter.status.id.to_s
+        )
     end
 
     context "when trying to access another user's filter keyword" do

--- a/spec/requests/api/v2/filters_spec.rb
+++ b/spec/requests/api/v2/filters_spec.rb
@@ -58,12 +58,15 @@ RSpec.describe 'Filters' do
       it 'returns a filter with keywords', :aggregate_failures do
         subject
 
-        json = body_as_json
-
-        expect(json[:title]).to eq 'magic'
-        expect(json[:filter_action]).to eq 'hide'
-        expect(json[:context]).to eq ['home']
-        expect(json[:keywords].map { |keyword| keyword.slice(:keyword, :whole_word) }).to match [{ keyword: 'magic', whole_word: true }]
+        expect(body_as_json)
+          .to include(
+            title: 'magic',
+            filter_action: 'hide',
+            context: %w(home),
+            keywords: contain_exactly(
+              include(keyword: 'magic', whole_word: true)
+            )
+          )
       end
 
       it 'creates a filter', :aggregate_failures do

--- a/spec/requests/well_known/webfinger_spec.rb
+++ b/spec/requests/well_known/webfinger_spec.rb
@@ -129,9 +129,11 @@ describe 'The /.well-known/webfinger endpoint' do
     end
 
     it 'returns links for the internal account' do
-      json = body_as_json
-      expect(json[:subject]).to eq 'acct:mastodon.internal@cb6e6126.ngrok.io'
-      expect(json[:aliases]).to eq ['https://cb6e6126.ngrok.io/actor']
+      expect(body_as_json)
+        .to include(
+          subject: 'acct:mastodon.internal@cb6e6126.ngrok.io',
+          aliases: ['https://cb6e6126.ngrok.io/actor']
+        )
     end
   end
 


### PR DESCRIPTION
Follow-up on https://github.com/mastodon/mastodon/pull/31674 and for same reasons.

In this pass, just a once-over on the places where we assign a local var instead of using the helper directly. Will have more prep PRs ahead of one which does a final swap to remove the helper and use `response.parsed_body` everywhere.