### PR TITLE
Remove unused `Mention#active?` method

### DIFF
--- a/app/models/mention.rb
+++ b/app/models/mention.rb
@@ -29,8 +29,4 @@ class Mention < ApplicationRecord
     to: :account,
     prefix: true
   )
-
-  def active?
-    !silent?
-  end
 end


### PR DESCRIPTION
Added but never (as far as I can tell?) used: https://github.com/mastodon/mastodon/pull/8950/files#diff-22a2f87e0b7bd088bfe469d8db38ca57f2382dcc6750eeb5ce1e4cd0007cc0b8R32-R34