### PR TITLE
Remove unused `User#inactive_message` method

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -246,10 +246,6 @@ class User < ApplicationRecord
     unconfirmed? || pending?
   end
 
-  def inactive_message
-    approved? ? super : :pending
-  end
-
   def approve!
     return if approved?
 


### PR DESCRIPTION
Introduced here but never used: https://github.com/mastodon/mastodon/pull/10250/files#diff-9802ca3c9c4cf89904fd44bc114e35ebdf2c5dd3d5b645491e2b253e1afef29bR155-R157