### PR TITLE
Remove unused `merge_context` helper

### DIFF
--- a/app/helpers/jsonld_helper.rb
+++ b/app/helpers/jsonld_helper.rb
@@ -200,14 +200,6 @@ module JsonLdHelper
     nil
   end
 
-  def merge_context(context, new_context)
-    if context.is_a?(Array)
-      context << new_context
-    else
-      [context, new_context]
-    end
-  end
-
   def response_successful?(response)
     (200...300).cover?(response.code)
   end


### PR DESCRIPTION
Last usage removed in https://github.com/mastodon/mastodon/commit/9a5ae096206df2240ba042efed62854193898a65#diff-921be6083d49efbacd91b23f7c0055defb4f407dc6da1313d514111bf7113533L48