### PR TITLE
Add first pass coverage for `AnnualReport` class

### DIFF
--- a/spec/lib/annual_report_spec.rb
+++ b/spec/lib/annual_report_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe AnnualReport do
+  describe '#generate' do
+    subject { described_class.new(account, Time.zone.now.year) }
+
+    let(:account) { Fabricate :account }
+
+    it 'builds a report for an account' do
+      expect { subject.generate }
+        .to change(GeneratedAnnualReport, :count).by(1)
+    end
+  end
+end


### PR DESCRIPTION
This feature is the next-largest block of uncovered code, after the unused E2EE messaging collection.

This is just a very high level first pass here to get some C0 coverage of the top level report generator class and (by extension) some C0 on the various "source" classes called in the process.

Will do follow-ups here with more thorough per-class spec, and lightweight refactor where needed.