### PR TITLE
media_ids is an array of strings

### DIFF
--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -134,7 +134,7 @@ class PostStatusService < BaseService
 
     @media = @account.media_attachments.where(status_id: nil).where(id: @options[:media_ids].take(Status::MEDIA_ATTACHMENTS_LIMIT).map(&:to_i))
 
-    not_found_ids = @options[:media_ids] - @media.map(&:id)
+    not_found_ids = @options[:media_ids].map(&:to_i) - @media.map(&:id)
     raise Mastodon::ValidationError, I18n.t('media_attachments.validations.not_found', ids: not_found_ids.join(', ')) if not_found_ids.any?
 
     raise Mastodon::ValidationError, I18n.t('media_attachments.validations.images_and_video') if @media.size > 1 && @media.find(&:audio_or_video?)

--- a/app/services/update_status_service.rb
+++ b/app/services/update_status_service.rb
@@ -73,7 +73,7 @@ class UpdateStatusService < BaseService
 
     media_attachments = @status.account.media_attachments.where(status_id: [nil, @status.id]).where(scheduled_status_id: nil).where(id: @options[:media_ids].take(Status::MEDIA_ATTACHMENTS_LIMIT).map(&:to_i)).to_a
 
-    not_found_ids = @options[:media_ids] - media_attachments.map(&:id)
+    not_found_ids = @options[:media_ids].map(&:to_i) - media_attachments.map(&:id)
     raise Mastodon::ValidationError, I18n.t('media_attachments.validations.not_found', ids: not_found_ids.join(', ')) if not_found_ids.any?
 
     raise Mastodon::ValidationError, I18n.t('media_attachments.validations.images_and_video') if media_attachments.size > 1 && media_attachments.find(&:audio_or_video?)

--- a/spec/services/post_status_service_spec.rb
+++ b/spec/services/post_status_service_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe PostStatusService do
 
     it 'schedules a status for future creation and does not create one immediately' do
       media = Fabricate(:media_attachment, account: account)
-      status = subject.call(account, text: 'Hi future!', media_ids: [media.id], scheduled_at: future)
+      status = subject.call(account, text: 'Hi future!', media_ids: [media.id.to_s], scheduled_at: future)
 
       expect(status)
         .to be_a(ScheduledStatus)
@@ -42,7 +42,7 @@ RSpec.describe PostStatusService do
           scheduled_at: eq(future),
           params: include(
             'text' => eq('Hi future!'),
-            'media_ids' => contain_exactly(media.id)
+            'media_ids' => contain_exactly(media.id.to_s)
           )
         )
       expect(media.reload.status).to be_nil
@@ -219,7 +219,7 @@ RSpec.describe PostStatusService do
     status = subject.call(
       account,
       text: 'test status update',
-      media_ids: [media.id]
+      media_ids: [media.id.to_s]
     )
 
     expect(media.reload.status).to eq status
@@ -233,7 +233,7 @@ RSpec.describe PostStatusService do
       subject.call(
         account,
         text: 'test status update',
-        media_ids: [media.id]
+        media_ids: [media.id.to_s]
       )
     end.to raise_error(
       Mastodon::ValidationError,
@@ -249,7 +249,7 @@ RSpec.describe PostStatusService do
       subject.call(
         account,
         text: 'test status update',
-        media_ids: Array.new(2) { Fabricate(:media_attachment, account: account) }.map(&:id)
+        media_ids: Array.new(2) { Fabricate(:media_attachment, account: account) }.map { |m| m.id.to_s }
       )
     end.to raise_error(
       Mastodon::ValidationError,
@@ -271,7 +271,7 @@ RSpec.describe PostStatusService do
         media_ids: [
           video,
           image,
-        ].map(&:id)
+        ].map { |m| m.id.to_s }
       )
     end.to raise_error(
       Mastodon::ValidationError,

--- a/spec/services/update_status_service_spec.rb
+++ b/spec/services/update_status_service_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe UpdateStatusService do
 
     before do
       status.media_attachments << detached_media_attachment
-      subject.call(status, status.account_id, text: 'Foo', media_ids: [attached_media_attachment.id])
+      subject.call(status, status.account_id, text: 'Foo', media_ids: [attached_media_attachment.id.to_s])
     end
 
     it 'updates media attachments' do
@@ -95,7 +95,7 @@ RSpec.describe UpdateStatusService do
 
     before do
       status.media_attachments << media_attachment
-      subject.call(status, status.account_id, text: 'Foo', media_ids: [media_attachment.id], media_attributes: [{ id: media_attachment.id, description: 'New description' }])
+      subject.call(status, status.account_id, text: 'Foo', media_ids: [media_attachment.id.to_s], media_attributes: [{ id: media_attachment.id, description: 'New description' }])
     end
 
     it 'does not detach media attachment' do


### PR DESCRIPTION
Fixes #31707 caused by #31681. My bad, sorry :-(

According to [the documentation](https://docs.joinmastodon.org/methods/statuses/#create), the `media_ids` parameter is an array of strings.
