### PR TITLE
Fix radio buttons styling in web UI

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -7580,7 +7580,7 @@ a.status-card {
   }
 }
 
-.radio-button.checked::before {
+.radio-button__input.checked::before {
   position: absolute;
   left: 2px;
   top: 2px;


### PR DESCRIPTION
Fixes #31661

I also wanted to replace the markup to use the radio button itself (using `appearance: none`) rather than a span, but decided not to do it yet because of the shared styling with checkboxes, which are more complicated to implement with the current style and the SVG icon.