### PR TITLE
Remove un-needed edge case sort condition in languages helper

### DIFF
--- a/app/helpers/languages_helper.rb
+++ b/app/helpers/languages_helper.rb
@@ -238,9 +238,7 @@ module LanguagesHelper
 
   # Helper for self.sorted_locale_keys
   private_class_method def self.locale_name_for_sorting(locale)
-    if locale.blank? || locale == 'und'
-      '000'
-    elsif (supported_locale = SUPPORTED_LOCALES[locale.to_sym])
+    if (supported_locale = SUPPORTED_LOCALES[locale.to_sym])
       ASCIIFolding.new.fold(supported_locale[1]).downcase
     elsif (regional_locale = REGIONAL_LOCALE_NAMES[locale.to_sym])
       ASCIIFolding.new.fold(regional_locale).downcase


### PR DESCRIPTION
As noted in https://github.com/mastodon/mastodon/pull/31701#issuecomment-2326305630

This is only ever called from `sorted_locale_keys`, which itself is only ever called with values from our language lists. There's also a rake task which runs on CI designed to detect missing values for that.

The original PR does not have an explanation or test for why these are here ... I'm guessing it's excessive defensiveness that can be safely removed.