### PR TITLE
Fix spacing between icons and labels in settings/admin interface

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -106,11 +106,16 @@ module ApplicationHelper
   end
 
   def material_symbol(icon, attributes = {})
-    inline_svg_tag(
-      "400-24px/#{icon}.svg",
-      class: ['icon', "material-#{icon}"].concat(attributes[:class].to_s.split),
-      role: :img,
-      data: attributes[:data]
+    safe_join(
+      [
+        inline_svg_tag(
+          "400-24px/#{icon}.svg",
+          class: ['icon', "material-#{icon}"].concat(attributes[:class].to_s.split),
+          role: :img,
+          data: attributes[:data]
+        ),
+        ' ',
+      ]
     )
   end
 


### PR DESCRIPTION
Up until we updated `inline_svg`, material icons included in the admin/settings interface were followed by a newline. The `inline_svg` update changed that, so reintroduce some spacing explicitly.