### PR TITLE
Add coverage for model normalizations

### DIFF
--- a/spec/models/account_alias_spec.rb
+++ b/spec/models/account_alias_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AccountAlias do
+  describe 'Normalizations' do
+    describe 'acct' do
+      it { is_expected.to normalize(:acct).from('  @username@domain  ').to('username@domain') }
+    end
+  end
+end

--- a/spec/models/account_migration_spec.rb
+++ b/spec/models/account_migration_spec.rb
@@ -3,6 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe AccountMigration do
+  describe 'Normalizations' do
+    describe 'acct' do
+      it { is_expected.to normalize(:acct).from('  @username@domain  ').to('username@domain') }
+    end
+  end
+
   describe 'validations' do
     subject { described_class.new(account: source_account, acct: target_acct) }
 

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -723,13 +723,14 @@ RSpec.describe Account do
     end
   end
 
+  describe 'Normalizations' do
+    describe 'username' do
+      it { is_expected.to normalize(:username).from(" \u3000bob \t \u00a0 \n ").to('bob') }
+    end
+  end
+
   describe 'validations' do
     it { is_expected.to validate_presence_of(:username) }
-
-    it 'squishes the username before validation' do
-      account = Fabricate(:account, domain: nil, username: " \u3000bob \t \u00a0 \n ")
-      expect(account.username).to eq 'bob'
-    end
 
     context 'when is local' do
       it 'is invalid if the username is not unique in case-insensitive comparison among local accounts' do

--- a/spec/models/account_warning_spec.rb
+++ b/spec/models/account_warning_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AccountWarning do
+  describe 'Normalizations' do
+    describe 'text' do
+      it { is_expected.to normalize(:text).from(nil).to('') }
+    end
+  end
+end

--- a/spec/models/custom_emoji_spec.rb
+++ b/spec/models/custom_emoji_spec.rb
@@ -79,22 +79,9 @@ RSpec.describe CustomEmoji, :attachment_processing do
   end
 
   describe 'Normalizations' do
-    describe 'downcase domain value' do
-      context 'with a mixed case domain value' do
-        it 'normalizes the value to downcased' do
-          custom_emoji = Fabricate.build(:custom_emoji, domain: 'wWw.MaStOdOn.CoM')
-
-          expect(custom_emoji.domain).to eq('www.mastodon.com')
-        end
-      end
-
-      context 'with a nil domain value' do
-        it 'leaves the value as nil' do
-          custom_emoji = Fabricate.build(:custom_emoji, domain: nil)
-
-          expect(custom_emoji.domain).to be_nil
-        end
-      end
+    describe 'domain' do
+      it { is_expected.to normalize(:domain).from('wWw.MaStOdOn.CoM').to('www.mastodon.com') }
+      it { is_expected.to normalize(:domain).from(nil).to(nil) }
     end
   end
 end

--- a/spec/models/custom_filter_spec.rb
+++ b/spec/models/custom_filter_spec.rb
@@ -34,10 +34,8 @@ RSpec.describe CustomFilter do
   end
 
   describe 'Normalizations' do
-    it 'cleans up context values' do
-      record = described_class.new(context: ['home', 'notifications', 'public    ', ''])
-
-      expect(record.context).to eq(%w(home notifications public))
+    describe 'context' do
+      it { is_expected.to normalize(:context).from(['home', 'notifications', 'public    ', '']).to(%w(home notifications public)) }
     end
   end
 end

--- a/spec/models/featured_tag_spec.rb
+++ b/spec/models/featured_tag_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FeaturedTag do
+  describe 'Normalizations' do
+    describe 'name' do
+      it { is_expected.to normalize(:name).from('  #hashtag  ').to('hashtag') }
+    end
+  end
+end

--- a/spec/models/relay_spec.rb
+++ b/spec/models/relay_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Relay do
+  describe 'Normalizations' do
+    describe 'inbox_url' do
+      it { is_expected.to normalize(:inbox_url).from('  http://host.example  ').to('http://host.example') }
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -59,45 +59,18 @@ RSpec.describe User do
 
   describe 'Normalizations' do
     describe 'locale' do
-      it 'preserves valid locale' do
-        user = Fabricate.build(:user, locale: 'en')
-
-        expect(user.locale).to eq('en')
-      end
-
-      it 'cleans out invalid locale' do
-        user = Fabricate.build(:user, locale: 'toto')
-
-        expect(user.locale).to be_nil
-      end
+      it { is_expected.to_not normalize(:locale).from('en') }
+      it { is_expected.to normalize(:locale).from('toto').to(nil) }
     end
 
     describe 'time_zone' do
-      it 'preserves valid timezone' do
-        user = Fabricate.build(:user, time_zone: 'UTC')
-
-        expect(user.time_zone).to eq('UTC')
-      end
-
-      it 'cleans out invalid timezone' do
-        user = Fabricate.build(:user, time_zone: 'toto')
-
-        expect(user.time_zone).to be_nil
-      end
+      it { is_expected.to_not normalize(:time_zone).from('UTC') }
+      it { is_expected.to normalize(:time_zone).from('toto').to(nil) }
     end
 
-    describe 'languages' do
-      it 'preserves valid options for languages' do
-        user = Fabricate.build(:user, chosen_languages: ['en', 'fr', ''])
-
-        expect(user.chosen_languages).to eq(['en', 'fr'])
-      end
-
-      it 'cleans out empty string from languages' do
-        user = Fabricate.build(:user, chosen_languages: [''])
-
-        expect(user.chosen_languages).to be_nil
-      end
+    describe 'chosen_languages' do
+      it { is_expected.to normalize(:chosen_languages).from(['en', 'fr', '']).to(%w(en fr)) }
+      it { is_expected.to normalize(:chosen_languages).from(['']).to(nil) }
     end
   end
 

--- a/spec/models/webhook_spec.rb
+++ b/spec/models/webhook_spec.rb
@@ -29,10 +29,8 @@ RSpec.describe Webhook do
   end
 
   describe 'Normalizations' do
-    it 'cleans up events values' do
-      record = described_class.new(events: ['account.approved', 'account.created     ', ''])
-
-      expect(record.events).to eq(%w(account.approved account.created))
+    describe 'events' do
+      it { is_expected.to normalize(:events).from(['account.approved', 'account.created     ', '']).to(%w(account.approved account.created)) }
     end
   end
 


### PR DESCRIPTION
With https://github.com/mastodon/mastodon/pull/31013 merged, using some newly available helpers.

I'm not sure I got 100% of the normalizers, but probably close. This is a mix of adding missing coverage for some, and simplifying coverage for others that already had some.