### PR TITLE
Fix email language when recipient has no selected locale

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -12,7 +12,7 @@ class ApplicationMailer < ActionMailer::Base
   protected
 
   def locale_for_account(account, &block)
-    I18n.with_locale(account.user_locale || I18n.locale || I18n.default_locale, &block)
+    I18n.with_locale(account.user_locale || I18n.default_locale, &block)
   end
 
   def set_autoreply_headers!

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -33,7 +33,7 @@ class UserMailer < Devise::Mailer
 
     return unless @resource.active_for_authentication?
 
-    I18n.with_locale(locale) do
+    I18n.with_locale(locale(use_current_locale: true)) do
       mail subject: default_devise_subject
     end
   end
@@ -43,7 +43,7 @@ class UserMailer < Devise::Mailer
 
     return unless @resource.active_for_authentication?
 
-    I18n.with_locale(locale) do
+    I18n.with_locale(locale(use_current_locale: true)) do
       mail subject: default_devise_subject
     end
   end
@@ -53,7 +53,7 @@ class UserMailer < Devise::Mailer
 
     return unless @resource.active_for_authentication?
 
-    I18n.with_locale(locale) do
+    I18n.with_locale(locale(use_current_locale: true)) do
       mail subject: default_devise_subject
     end
   end
@@ -63,7 +63,7 @@ class UserMailer < Devise::Mailer
 
     return unless @resource.active_for_authentication?
 
-    I18n.with_locale(locale) do
+    I18n.with_locale(locale(use_current_locale: true)) do
       mail subject: default_devise_subject
     end
   end
@@ -73,7 +73,7 @@ class UserMailer < Devise::Mailer
 
     return unless @resource.active_for_authentication?
 
-    I18n.with_locale(locale) do
+    I18n.with_locale(locale(use_current_locale: true)) do
       mail subject: default_devise_subject
     end
   end
@@ -83,7 +83,7 @@ class UserMailer < Devise::Mailer
 
     return unless @resource.active_for_authentication?
 
-    I18n.with_locale(locale) do
+    I18n.with_locale(locale(use_current_locale: true)) do
       mail subject: default_devise_subject
     end
   end
@@ -93,7 +93,7 @@ class UserMailer < Devise::Mailer
 
     return unless @resource.active_for_authentication?
 
-    I18n.with_locale(locale) do
+    I18n.with_locale(locale(use_current_locale: true)) do
       mail subject: default_devise_subject
     end
   end
@@ -103,7 +103,7 @@ class UserMailer < Devise::Mailer
 
     return unless @resource.active_for_authentication?
 
-    I18n.with_locale(locale) do
+    I18n.with_locale(locale(use_current_locale: true)) do
       mail subject: default_devise_subject
     end
   end
@@ -114,7 +114,7 @@ class UserMailer < Devise::Mailer
 
     return unless @resource.active_for_authentication?
 
-    I18n.with_locale(locale) do
+    I18n.with_locale(locale(use_current_locale: true)) do
       mail subject: I18n.t('devise.mailer.webauthn_credential.added.subject')
     end
   end
@@ -125,7 +125,7 @@ class UserMailer < Devise::Mailer
 
     return unless @resource.active_for_authentication?
 
-    I18n.with_locale(locale) do
+    I18n.with_locale(locale(use_current_locale: true)) do
       mail subject: I18n.t('devise.mailer.webauthn_credential.deleted.subject')
     end
   end
@@ -219,7 +219,7 @@ class UserMailer < Devise::Mailer
     @instance = Rails.configuration.x.local_domain
   end
 
-  def locale
-    @resource.locale.presence || I18n.locale || I18n.default_locale
+  def locale(use_current_locale: false)
+    @resource.locale.presence || (use_current_locale && I18n.locale) || I18n.default_locale
   end
 end


### PR DESCRIPTION
Fixes #31715

The current logic for selecting languages for emails is to use the first defined value between:
1. the recipient's selected locale
2. the current locale
3. the server's default locale

In some cases, such as for the registration confirmation email, the email is sent to the person who initiated the action, and using the current locale makes sense.

In other cases, such as when a moderator gets a notification mail for a pending registration, the current locale is not related to that of the recipient, so it does not really make sense to use it as a fallback.

Therefore, this PR changes it so that only a few select email types use that logic, and the remaining ones skip the current locale.