### PR TITLE
Remove `body_as_json` in favor of built-in `response.parsed_body` for JSON response specs

### DIFF
--- a/spec/controllers/activitypub/collections_controller_spec.rb
+++ b/spec/controllers/activitypub/collections_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe ActivityPub::CollectionsController do
             .and have_cacheable_headers
           expect(response.media_type).to eq 'application/activity+json'
 
-          expect(body_as_json[:orderedItems])
+          expect(response.parsed_body[:orderedItems])
             .to be_an(Array)
             .and have_attributes(size: 3)
             .and include(ActivityPub::TagManager.instance.uri_for(private_pinned))
@@ -71,7 +71,7 @@ RSpec.describe ActivityPub::CollectionsController do
 
             expect(response.media_type).to eq 'application/activity+json'
 
-            expect(body_as_json[:orderedItems])
+            expect(response.parsed_body[:orderedItems])
               .to be_an(Array)
               .and have_attributes(size: 3)
               .and include(ActivityPub::TagManager.instance.uri_for(private_pinned))
@@ -94,7 +94,7 @@ RSpec.describe ActivityPub::CollectionsController do
               expect(response.media_type).to eq 'application/activity+json'
               expect(response.headers['Cache-Control']).to include 'private'
 
-              expect(body_as_json[:orderedItems])
+              expect(response.parsed_body[:orderedItems])
                 .to be_an(Array)
                 .and be_empty
             end
@@ -110,7 +110,7 @@ RSpec.describe ActivityPub::CollectionsController do
               expect(response.media_type).to eq 'application/activity+json'
               expect(response.headers['Cache-Control']).to include 'private'
 
-              expect(body_as_json[:orderedItems])
+              expect(response.parsed_body[:orderedItems])
                 .to be_an(Array)
                 .and be_empty
             end

--- a/spec/controllers/activitypub/followers_synchronizations_controller_spec.rb
+++ b/spec/controllers/activitypub/followers_synchronizations_controller_spec.rb
@@ -34,7 +34,6 @@ RSpec.describe ActivityPub::FollowersSynchronizationsController do
     context 'with signature from example.com' do
       subject(:response) { get :show, params: { account_username: account.username } }
 
-      let(:body) { body_as_json }
       let(:remote_account) { Fabricate(:account, domain: 'example.com', uri: 'https://example.com/instance') }
 
       it 'returns http success and cache control and activity json types and correct items' do
@@ -42,7 +41,7 @@ RSpec.describe ActivityPub::FollowersSynchronizationsController do
         expect(response.headers['Cache-Control']).to eq 'max-age=0, private'
         expect(response.media_type).to eq 'application/activity+json'
 
-        expect(body[:orderedItems])
+        expect(response.parsed_body[:orderedItems])
           .to be_an(Array)
           .and contain_exactly(
             follower_example_com_instance_actor.uri,

--- a/spec/controllers/activitypub/outboxes_controller_spec.rb
+++ b/spec/controllers/activitypub/outboxes_controller_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe ActivityPub::OutboxesController do
     context 'without signature' do
       subject(:response) { get :show, params: { account_username: account.username, page: page } }
 
-      let(:body) { body_as_json }
       let(:remote_account) { nil }
 
       context 'with page not requested' do
@@ -32,7 +31,7 @@ RSpec.describe ActivityPub::OutboxesController do
 
           expect(response.media_type).to eq 'application/activity+json'
           expect(response.headers['Vary']).to be_nil
-          expect(body[:totalItems]).to eq 4
+          expect(response.parsed_body[:totalItems]).to eq 4
         end
 
         context 'when account is permanently suspended' do
@@ -68,9 +67,11 @@ RSpec.describe ActivityPub::OutboxesController do
           expect(response.media_type).to eq 'application/activity+json'
           expect(response.headers['Vary']).to include 'Signature'
 
-          expect(body[:orderedItems]).to be_an Array
-          expect(body[:orderedItems].size).to eq 2
-          expect(body[:orderedItems].all? { |item| targets_public_collection?(item) }).to be true
+          expect(response.parsed_body)
+            .to include(
+              orderedItems: be_an(Array).and(have_attributes(size: 2))
+            )
+          expect(response.parsed_body[:orderedItems].all? { |item| targets_public_collection?(item) }).to be true
         end
 
         context 'when account is permanently suspended' do
@@ -110,9 +111,11 @@ RSpec.describe ActivityPub::OutboxesController do
           expect(response.media_type).to eq 'application/activity+json'
           expect(response.headers['Cache-Control']).to eq 'max-age=60, private'
 
-          expect(body_as_json[:orderedItems]).to be_an Array
-          expect(body_as_json[:orderedItems].size).to eq 2
-          expect(body_as_json[:orderedItems].all? { |item| targets_public_collection?(item) }).to be true
+          expect(response.parsed_body)
+            .to include(
+              orderedItems: be_an(Array).and(have_attributes(size: 2))
+            )
+          expect(response.parsed_body[:orderedItems].all? { |item| targets_public_collection?(item) }).to be true
         end
       end
 
@@ -127,9 +130,11 @@ RSpec.describe ActivityPub::OutboxesController do
           expect(response.media_type).to eq 'application/activity+json'
           expect(response.headers['Cache-Control']).to eq 'max-age=60, private'
 
-          expect(body_as_json[:orderedItems]).to be_an Array
-          expect(body_as_json[:orderedItems].size).to eq 3
-          expect(body_as_json[:orderedItems].all? { |item| targets_public_collection?(item) || targets_followers_collection?(item, account) }).to be true
+          expect(response.parsed_body)
+            .to include(
+              orderedItems: be_an(Array).and(have_attributes(size: 3))
+            )
+          expect(response.parsed_body[:orderedItems].all? { |item| targets_public_collection?(item) || targets_followers_collection?(item, account) }).to be true
         end
       end
 
@@ -144,9 +149,10 @@ RSpec.describe ActivityPub::OutboxesController do
           expect(response.media_type).to eq 'application/activity+json'
           expect(response.headers['Cache-Control']).to eq 'max-age=60, private'
 
-          expect(body_as_json[:orderedItems])
-            .to be_an(Array)
-            .and be_empty
+          expect(response.parsed_body)
+            .to include(
+              orderedItems: be_an(Array).and(be_empty)
+            )
         end
       end
 
@@ -161,9 +167,10 @@ RSpec.describe ActivityPub::OutboxesController do
           expect(response.media_type).to eq 'application/activity+json'
           expect(response.headers['Cache-Control']).to eq 'max-age=60, private'
 
-          expect(body_as_json[:orderedItems])
-            .to be_an(Array)
-            .and be_empty
+          expect(response.parsed_body)
+            .to include(
+              orderedItems: be_an(Array).and(be_empty)
+            )
         end
       end
     end

--- a/spec/controllers/activitypub/replies_controller_spec.rb
+++ b/spec/controllers/activitypub/replies_controller_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe ActivityPub::RepliesController do
 
     context 'when status is public' do
       let(:parent_visibility) { :public }
-      let(:page_json) { body_as_json[:first] }
+      let(:page_json) { response.parsed_body[:first] }
 
       it 'returns http success and correct media type' do
         expect(response)

--- a/spec/controllers/auth/sessions_controller_spec.rb
+++ b/spec/controllers/auth/sessions_controller_spec.rb
@@ -402,7 +402,7 @@ RSpec.describe Auth::SessionsController do
           end
 
           it 'instructs the browser to redirect to home, logs the user in, and updates the sign count' do
-            expect(body_as_json[:redirect_path]).to eq(root_path)
+            expect(response.parsed_body[:redirect_path]).to eq(root_path)
 
             expect(controller.current_user).to eq user
 

--- a/spec/controllers/follower_accounts_controller_spec.rb
+++ b/spec/controllers/follower_accounts_controller_spec.rb
@@ -39,8 +39,6 @@ RSpec.describe FollowerAccountsController do
     end
 
     context 'when format is json' do
-      subject(:body) { response.parsed_body }
-
       let(:response) { get :index, params: { account_username: alice.username, page: page, format: :json } }
 
       context 'with page' do
@@ -48,15 +46,15 @@ RSpec.describe FollowerAccountsController do
 
         it 'returns followers' do
           expect(response).to have_http_status(200)
-          expect(body_as_json)
+          expect(response.parsed_body)
             .to include(
               orderedItems: contain_exactly(
                 include(follow_from_bob.account.username),
                 include(follow_from_chris.account.username)
-              )
+              ),
+              totalItems: eq(2),
+              partOf: be_present
             )
-          expect(body['totalItems']).to eq 2
-          expect(body['partOf']).to be_present
         end
 
         context 'when account is permanently suspended' do
@@ -86,8 +84,11 @@ RSpec.describe FollowerAccountsController do
 
         it 'returns followers' do
           expect(response).to have_http_status(200)
-          expect(body['totalItems']).to eq 2
-          expect(body['partOf']).to be_blank
+          expect(response.parsed_body)
+            .to include(
+              totalItems: eq(2)
+            )
+            .and not_include(:partOf)
         end
 
         context 'when account hides their network' do
@@ -95,15 +96,17 @@ RSpec.describe FollowerAccountsController do
             alice.update(hide_collections: true)
           end
 
-          it 'returns followers count' do
-            expect(body['totalItems']).to eq 2
-          end
-
-          it 'does not return items' do
-            expect(body['items']).to be_blank
-            expect(body['orderedItems']).to be_blank
-            expect(body['first']).to be_blank
-            expect(body['last']).to be_blank
+          it 'returns followers count but not any items' do
+            expect(response.parsed_body)
+              .to include(
+                totalItems: eq(2)
+              )
+              .and not_include(
+                :items,
+                :orderedItems,
+                :first,
+                :last
+              )
           end
         end
 

--- a/spec/controllers/following_accounts_controller_spec.rb
+++ b/spec/controllers/following_accounts_controller_spec.rb
@@ -39,8 +39,6 @@ RSpec.describe FollowingAccountsController do
     end
 
     context 'when format is json' do
-      subject(:body) { response.parsed_body }
-
       let(:response) { get :index, params: { account_username: alice.username, page: page, format: :json } }
 
       context 'with page' do
@@ -48,15 +46,15 @@ RSpec.describe FollowingAccountsController do
 
         it 'returns followers' do
           expect(response).to have_http_status(200)
-          expect(body_as_json)
+          expect(response.parsed_body)
             .to include(
               orderedItems: contain_exactly(
                 include(follow_of_bob.target_account.username),
                 include(follow_of_chris.target_account.username)
-              )
+              ),
+              totalItems: eq(2),
+              partOf: be_present
             )
-          expect(body['totalItems']).to eq 2
-          expect(body['partOf']).to be_present
         end
 
         context 'when account is permanently suspended' do
@@ -86,8 +84,11 @@ RSpec.describe FollowingAccountsController do
 
         it 'returns followers' do
           expect(response).to have_http_status(200)
-          expect(body['totalItems']).to eq 2
-          expect(body['partOf']).to be_blank
+          expect(response.parsed_body)
+            .to include(
+              totalItems: eq(2)
+            )
+            .and not_include(:partOf)
         end
 
         context 'when account hides their network' do
@@ -95,15 +96,17 @@ RSpec.describe FollowingAccountsController do
             alice.update(hide_collections: true)
           end
 
-          it 'returns followers count' do
-            expect(body['totalItems']).to eq 2
-          end
-
-          it 'does not return items' do
-            expect(body['items']).to be_blank
-            expect(body['orderedItems']).to be_blank
-            expect(body['first']).to be_blank
-            expect(body['last']).to be_blank
+          it 'returns followers count but not any items' do
+            expect(response.parsed_body)
+              .to include(
+                totalItems: eq(2)
+              )
+              .and not_include(
+                :items,
+                :orderedItems,
+                :first,
+                :last
+              )
           end
         end
 

--- a/spec/controllers/statuses_controller_spec.rb
+++ b/spec/controllers/statuses_controller_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe StatusesController do
             'Content-Type' => include('application/activity+json'),
             'Link' => satisfy { |header| header.to_s.include?('activity+json') }
           )
-          expect(body_as_json)
+          expect(response.parsed_body)
             .to include(content: include(status.text))
         end
       end
@@ -186,7 +186,7 @@ RSpec.describe StatusesController do
               'Content-Type' => include('application/activity+json'),
               'Link' => satisfy { |header| header.to_s.include?('activity+json') }
             )
-            expect(body_as_json)
+            expect(response.parsed_body)
               .to include(content: include(status.text))
           end
         end
@@ -230,7 +230,7 @@ RSpec.describe StatusesController do
                 'Content-Type' => include('application/activity+json'),
                 'Link' => satisfy { |header| header.to_s.include?('activity+json') }
               )
-              expect(body_as_json)
+              expect(response.parsed_body)
                 .to include(content: include(status.text))
             end
           end
@@ -296,7 +296,7 @@ RSpec.describe StatusesController do
                 'Content-Type' => include('application/activity+json'),
                 'Link' => satisfy { |header| header.to_s.include?('activity+json') }
               )
-              expect(body_as_json)
+              expect(response.parsed_body)
                 .to include(content: include(status.text))
             end
           end
@@ -387,7 +387,7 @@ RSpec.describe StatusesController do
               'Content-Type' => include('application/activity+json'),
               'Link' => satisfy { |header| header.to_s.include?('activity+json') }
             )
-            expect(body_as_json)
+            expect(response.parsed_body)
               .to include(content: include(status.text))
           end
         end
@@ -431,7 +431,7 @@ RSpec.describe StatusesController do
                 'Link' => satisfy { |header| header.to_s.include?('activity+json') }
               )
 
-              expect(body_as_json)
+              expect(response.parsed_body)
                 .to include(content: include(status.text))
             end
           end
@@ -497,7 +497,7 @@ RSpec.describe StatusesController do
                 'Content-Type' => include('application/activity+json'),
                 'Link' => satisfy { |header| header.to_s.include?('activity+json') }
               )
-              expect(body_as_json)
+              expect(response.parsed_body)
                 .to include(content: include(status.text))
             end
           end

--- a/spec/requests/accounts_spec.rb
+++ b/spec/requests/accounts_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe 'Accounts show response' do
                 media_type: eq('application/activity+json')
               )
 
-            expect(body_as_json).to include(:id, :type, :preferredUsername, :inbox, :publicKey, :name, :summary)
+            expect(response.parsed_body).to include(:id, :type, :preferredUsername, :inbox, :publicKey, :name, :summary)
           end
 
           context 'with authorized fetch mode' do
@@ -164,7 +164,7 @@ RSpec.describe 'Accounts show response' do
 
             expect(response.headers['Cache-Control']).to include 'private'
 
-            expect(body_as_json).to include(:id, :type, :preferredUsername, :inbox, :publicKey, :name, :summary)
+            expect(response.parsed_body).to include(:id, :type, :preferredUsername, :inbox, :publicKey, :name, :summary)
           end
         end
 
@@ -183,7 +183,7 @@ RSpec.describe 'Accounts show response' do
                 media_type: eq('application/activity+json')
               )
 
-            expect(body_as_json).to include(:id, :type, :preferredUsername, :inbox, :publicKey, :name, :summary)
+            expect(response.parsed_body).to include(:id, :type, :preferredUsername, :inbox, :publicKey, :name, :summary)
           end
 
           context 'with authorized fetch mode' do
@@ -199,7 +199,7 @@ RSpec.describe 'Accounts show response' do
               expect(response.headers['Cache-Control']).to include 'private'
               expect(response.headers['Vary']).to include 'Signature'
 
-              expect(body_as_json).to include(:id, :type, :preferredUsername, :inbox, :publicKey, :name, :summary)
+              expect(response.parsed_body).to include(:id, :type, :preferredUsername, :inbox, :publicKey, :name, :summary)
             end
           end
         end

--- a/spec/requests/api/v1/accounts/credentials_spec.rb
+++ b/spec/requests/api/v1/accounts/credentials_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'credentials API' do
 
       expect(response)
         .to have_http_status(200)
-      expect(body_as_json).to include({
+      expect(response.parsed_body).to include({
         source: hash_including({
           discoverable: false,
           indexable: false,
@@ -37,7 +37,7 @@ RSpec.describe 'credentials API' do
 
         expect(response).to have_http_status(200)
 
-        expect(body_as_json).to include({
+        expect(response.parsed_body).to include({
           locked: true,
         })
       end
@@ -93,7 +93,7 @@ RSpec.describe 'credentials API' do
       expect(response)
         .to have_http_status(200)
 
-      expect(body_as_json).to include({
+      expect(response.parsed_body).to include({
         source: hash_including({
           discoverable: true,
           indexable: true,

--- a/spec/requests/api/v1/accounts/familiar_followers_spec.rb
+++ b/spec/requests/api/v1/accounts/familiar_followers_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'Accounts Familiar Followers API' do
         account_ids = [account_a, account_b, account_b, account_a, account_a].map { |a| a.id.to_s }
         get '/api/v1/accounts/familiar_followers', params: { id: account_ids }, headers: headers
 
-        expect(body_as_json.pluck(:id)).to contain_exactly(account_a.id.to_s, account_b.id.to_s)
+        expect(response.parsed_body.pluck(:id)).to contain_exactly(account_a.id.to_s, account_b.id.to_s)
       end
     end
   end

--- a/spec/requests/api/v1/accounts/featured_tags_spec.rb
+++ b/spec/requests/api/v1/accounts/featured_tags_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'account featured tags API' do
       subject
 
       expect(response).to have_http_status(200)
-      expect(body_as_json).to contain_exactly(a_hash_including({
+      expect(response.parsed_body).to contain_exactly(a_hash_including({
         name: 'bar',
         url: "https://cb6e6126.ngrok.io/@#{account.username}/tagged/bar",
       }), a_hash_including({
@@ -37,7 +37,7 @@ RSpec.describe 'account featured tags API' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json).to contain_exactly(a_hash_including({
+        expect(response.parsed_body).to contain_exactly(a_hash_including({
           name: 'bar',
           url: "https://cb6e6126.ngrok.io/@#{account.pretty_acct}/tagged/bar",
         }), a_hash_including({

--- a/spec/requests/api/v1/accounts/follower_accounts_spec.rb
+++ b/spec/requests/api/v1/accounts/follower_accounts_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe 'API V1 Accounts FollowerAccounts' do
       get "/api/v1/accounts/#{account.id}/followers", params: { limit: 2 }, headers: headers
 
       expect(response).to have_http_status(200)
-      expect(body_as_json.size).to eq 2
-      expect([body_as_json[0][:id], body_as_json[1][:id]]).to contain_exactly(alice.id.to_s, bob.id.to_s)
+      expect(response.parsed_body.size).to eq 2
+      expect([response.parsed_body[0][:id], response.parsed_body[1][:id]]).to contain_exactly(alice.id.to_s, bob.id.to_s)
     end
 
     it 'does not return blocked users', :aggregate_failures do
@@ -30,8 +30,8 @@ RSpec.describe 'API V1 Accounts FollowerAccounts' do
       get "/api/v1/accounts/#{account.id}/followers", params: { limit: 2 }, headers: headers
 
       expect(response).to have_http_status(200)
-      expect(body_as_json.size).to eq 1
-      expect(body_as_json[0][:id]).to eq alice.id.to_s
+      expect(response.parsed_body.size).to eq 1
+      expect(response.parsed_body[0][:id]).to eq alice.id.to_s
     end
 
     context 'when requesting user is blocked' do
@@ -41,7 +41,7 @@ RSpec.describe 'API V1 Accounts FollowerAccounts' do
 
       it 'hides results' do
         get "/api/v1/accounts/#{account.id}/followers", params: { limit: 2 }, headers: headers
-        expect(body_as_json.size).to eq 0
+        expect(response.parsed_body.size).to eq 0
       end
     end
 
@@ -52,8 +52,8 @@ RSpec.describe 'API V1 Accounts FollowerAccounts' do
         account.mute!(bob)
         get "/api/v1/accounts/#{account.id}/followers", params: { limit: 2 }, headers: headers
 
-        expect(body_as_json.size).to eq 2
-        expect([body_as_json[0][:id], body_as_json[1][:id]]).to contain_exactly(alice.id.to_s, bob.id.to_s)
+        expect(response.parsed_body.size).to eq 2
+        expect([response.parsed_body[0][:id], response.parsed_body[1][:id]]).to contain_exactly(alice.id.to_s, bob.id.to_s)
       end
     end
   end

--- a/spec/requests/api/v1/accounts/following_accounts_spec.rb
+++ b/spec/requests/api/v1/accounts/following_accounts_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe 'API V1 Accounts FollowingAccounts' do
       get "/api/v1/accounts/#{account.id}/following", params: { limit: 2 }, headers: headers
 
       expect(response).to have_http_status(200)
-      expect(body_as_json.size).to eq 2
-      expect([body_as_json[0][:id], body_as_json[1][:id]]).to contain_exactly(alice.id.to_s, bob.id.to_s)
+      expect(response.parsed_body.size).to eq 2
+      expect([response.parsed_body[0][:id], response.parsed_body[1][:id]]).to contain_exactly(alice.id.to_s, bob.id.to_s)
     end
 
     it 'does not return blocked users', :aggregate_failures do
@@ -30,8 +30,8 @@ RSpec.describe 'API V1 Accounts FollowingAccounts' do
       get "/api/v1/accounts/#{account.id}/following", params: { limit: 2 }, headers: headers
 
       expect(response).to have_http_status(200)
-      expect(body_as_json.size).to eq 1
-      expect(body_as_json[0][:id]).to eq alice.id.to_s
+      expect(response.parsed_body.size).to eq 1
+      expect(response.parsed_body[0][:id]).to eq alice.id.to_s
     end
 
     context 'when requesting user is blocked' do
@@ -41,7 +41,7 @@ RSpec.describe 'API V1 Accounts FollowingAccounts' do
 
       it 'hides results' do
         get "/api/v1/accounts/#{account.id}/following", params: { limit: 2 }, headers: headers
-        expect(body_as_json.size).to eq 0
+        expect(response.parsed_body.size).to eq 0
       end
     end
 
@@ -52,8 +52,8 @@ RSpec.describe 'API V1 Accounts FollowingAccounts' do
         account.mute!(bob)
         get "/api/v1/accounts/#{account.id}/following", params: { limit: 2 }, headers: headers
 
-        expect(body_as_json.size).to eq 2
-        expect([body_as_json[0][:id], body_as_json[1][:id]]).to contain_exactly(alice.id.to_s, bob.id.to_s)
+        expect(response.parsed_body.size).to eq 2
+        expect([response.parsed_body[0][:id], response.parsed_body[1][:id]]).to contain_exactly(alice.id.to_s, bob.id.to_s)
       end
     end
   end

--- a/spec/requests/api/v1/accounts/relationships_spec.rb
+++ b/spec/requests/api/v1/accounts/relationships_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'GET /api/v1/accounts/relationships' do
 
       expect(response)
         .to have_http_status(200)
-      expect(body_as_json)
+      expect(response.parsed_body)
         .to be_an(Enumerable)
         .and contain_exactly(
           include(
@@ -50,7 +50,7 @@ RSpec.describe 'GET /api/v1/accounts/relationships' do
 
           expect(response)
             .to have_http_status(200)
-          expect(body_as_json)
+          expect(response.parsed_body)
             .to be_an(Enumerable)
             .and have_attributes(
               size: 2
@@ -70,7 +70,7 @@ RSpec.describe 'GET /api/v1/accounts/relationships' do
 
           expect(response)
             .to have_http_status(200)
-          expect(body_as_json)
+          expect(response.parsed_body)
             .to be_an(Enumerable)
             .and have_attributes(
               size: 3
@@ -89,7 +89,7 @@ RSpec.describe 'GET /api/v1/accounts/relationships' do
         it 'removes duplicate account IDs from params' do
           subject
 
-          expect(body_as_json)
+          expect(response.parsed_body)
             .to be_an(Enumerable)
             .and have_attributes(
               size: 2
@@ -141,7 +141,7 @@ RSpec.describe 'GET /api/v1/accounts/relationships' do
     it 'returns JSON with correct data on previously cached requests' do
       # Initial request including multiple accounts in params
       get '/api/v1/accounts/relationships', headers: headers, params: { id: [simon.id, lewis.id] }
-      expect(body_as_json)
+      expect(response.parsed_body)
         .to have_attributes(size: 2)
 
       # Subsequent request with different id, should override cache from first request
@@ -150,7 +150,7 @@ RSpec.describe 'GET /api/v1/accounts/relationships' do
       expect(response)
         .to have_http_status(200)
 
-      expect(body_as_json)
+      expect(response.parsed_body)
         .to be_an(Enumerable)
         .and have_attributes(
           size: 1
@@ -172,7 +172,7 @@ RSpec.describe 'GET /api/v1/accounts/relationships' do
       expect(response)
         .to have_http_status(200)
 
-      expect(body_as_json)
+      expect(response.parsed_body)
         .to be_an(Enumerable)
         .and contain_exactly(
           include(

--- a/spec/requests/api/v1/accounts/statuses_spec.rb
+++ b/spec/requests/api/v1/accounts/statuses_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'API V1 Accounts Statuses' do
       it 'returns posts along with self replies', :aggregate_failures do
         expect(response)
           .to have_http_status(200)
-        expect(body_as_json)
+        expect(response.parsed_body)
           .to have_attributes(size: 2)
           .and contain_exactly(
             include(id: status.id.to_s),
@@ -102,7 +102,7 @@ RSpec.describe 'API V1 Accounts Statuses' do
         it 'lists the public status only' do
           get "/api/v1/accounts/#{account.id}/statuses", params: { pinned: true }, headers: headers
 
-          expect(body_as_json)
+          expect(response.parsed_body)
             .to contain_exactly(
               a_hash_including(id: status.id.to_s)
             )
@@ -117,7 +117,7 @@ RSpec.describe 'API V1 Accounts Statuses' do
         it 'lists both the public and the private statuses' do
           get "/api/v1/accounts/#{account.id}/statuses", params: { pinned: true }, headers: headers
 
-          expect(body_as_json)
+          expect(response.parsed_body)
             .to contain_exactly(
               a_hash_including(id: status.id.to_s),
               a_hash_including(id: private_status.id.to_s)

--- a/spec/requests/api/v1/accounts_spec.rb
+++ b/spec/requests/api/v1/accounts_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe '/api/v1/accounts' do
       get '/api/v1/accounts', headers: headers, params: { id: [account.id, other_account.id, 123_123] }
 
       expect(response).to have_http_status(200)
-      expect(body_as_json).to contain_exactly(
+      expect(response.parsed_body).to contain_exactly(
         hash_including(id: account.id.to_s),
         hash_including(id: other_account.id.to_s)
       )
@@ -32,7 +32,7 @@ RSpec.describe '/api/v1/accounts' do
         get "/api/v1/accounts/#{account.id}"
 
         expect(response).to have_http_status(200)
-        expect(body_as_json[:id]).to eq(account.id.to_s)
+        expect(response.parsed_body[:id]).to eq(account.id.to_s)
       end
     end
 
@@ -41,7 +41,7 @@ RSpec.describe '/api/v1/accounts' do
         get '/api/v1/accounts/1'
 
         expect(response).to have_http_status(404)
-        expect(body_as_json[:error]).to eq('Record not found')
+        expect(response.parsed_body[:error]).to eq('Record not found')
       end
     end
 
@@ -57,7 +57,7 @@ RSpec.describe '/api/v1/accounts' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json[:id]).to eq(account.id.to_s)
+        expect(response.parsed_body[:id]).to eq(account.id.to_s)
       end
 
       it_behaves_like 'forbidden for wrong scope', 'write:statuses'
@@ -80,7 +80,7 @@ RSpec.describe '/api/v1/accounts' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json[:access_token]).to_not be_blank
+        expect(response.parsed_body[:access_token]).to_not be_blank
 
         user = User.find_by(email: 'hello@world.tld')
         expect(user).to_not be_nil
@@ -114,7 +114,7 @@ RSpec.describe '/api/v1/accounts' do
 
           expect(response).to have_http_status(200)
 
-          expect(body_as_json)
+          expect(response.parsed_body)
             .to include(
               following: true,
               requested: false
@@ -134,7 +134,7 @@ RSpec.describe '/api/v1/accounts' do
 
           expect(response).to have_http_status(200)
 
-          expect(body_as_json)
+          expect(response.parsed_body)
             .to include(
               following: false,
               requested: true
@@ -157,7 +157,7 @@ RSpec.describe '/api/v1/accounts' do
       it 'changes reblogs option' do
         post "/api/v1/accounts/#{other_account.id}/follow", headers: headers, params: { reblogs: true }
 
-        expect(body_as_json).to include({
+        expect(response.parsed_body).to include({
           following: true,
           showing_reblogs: true,
           notifying: false,
@@ -167,7 +167,7 @@ RSpec.describe '/api/v1/accounts' do
       it 'changes notify option' do
         post "/api/v1/accounts/#{other_account.id}/follow", headers: headers, params: { notify: true }
 
-        expect(body_as_json).to include({
+        expect(response.parsed_body).to include({
           following: true,
           showing_reblogs: false,
           notifying: true,
@@ -177,7 +177,7 @@ RSpec.describe '/api/v1/accounts' do
       it 'changes languages option' do
         post "/api/v1/accounts/#{other_account.id}/follow", headers: headers, params: { languages: %w(en es) }
 
-        expect(body_as_json).to include({
+        expect(response.parsed_body).to include({
           following: true,
           showing_reblogs: false,
           notifying: false,

--- a/spec/requests/api/v1/admin/accounts_spec.rb
+++ b/spec/requests/api/v1/admin/accounts_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Accounts' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json.pluck(:id)).to match_array(expected_results.map { |a| a.id.to_s })
+        expect(response.parsed_body.pluck(:id)).to match_array(expected_results.map { |a| a.id.to_s })
       end
     end
 
@@ -93,7 +93,7 @@ RSpec.describe 'Accounts' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json.size).to eq(params[:limit])
+        expect(response.parsed_body.size).to eq(params[:limit])
       end
     end
   end
@@ -112,7 +112,7 @@ RSpec.describe 'Accounts' do
       subject
 
       expect(response).to have_http_status(200)
-      expect(body_as_json).to match(
+      expect(response.parsed_body).to match(
         a_hash_including(id: account.id.to_s, username: account.username, email: account.user.email)
       )
     end

--- a/spec/requests/api/v1/admin/canonical_email_blocks_spec.rb
+++ b/spec/requests/api/v1/admin/canonical_email_blocks_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Canonical Email Blocks' do
       it 'returns an empty list' do
         subject
 
-        expect(body_as_json).to be_empty
+        expect(response.parsed_body).to be_empty
       end
     end
 
@@ -41,7 +41,7 @@ RSpec.describe 'Canonical Email Blocks' do
       it 'returns the correct canonical email hashes' do
         subject
 
-        expect(body_as_json.pluck(:canonical_email_hash)).to match_array(expected_email_hashes)
+        expect(response.parsed_body.pluck(:canonical_email_hash)).to match_array(expected_email_hashes)
       end
 
       context 'with limit param' do
@@ -50,7 +50,7 @@ RSpec.describe 'Canonical Email Blocks' do
         it 'returns only the requested number of canonical email blocks' do
           subject
 
-          expect(body_as_json.size).to eq(params[:limit])
+          expect(response.parsed_body.size).to eq(params[:limit])
         end
       end
 
@@ -62,7 +62,7 @@ RSpec.describe 'Canonical Email Blocks' do
 
           canonical_email_blocks_ids = canonical_email_blocks.pluck(:id).map(&:to_s)
 
-          expect(body_as_json.pluck(:id)).to match_array(canonical_email_blocks_ids[2..])
+          expect(response.parsed_body.pluck(:id)).to match_array(canonical_email_blocks_ids[2..])
         end
       end
 
@@ -74,7 +74,7 @@ RSpec.describe 'Canonical Email Blocks' do
 
           canonical_email_blocks_ids = canonical_email_blocks.pluck(:id).map(&:to_s)
 
-          expect(body_as_json.pluck(:id)).to match_array(canonical_email_blocks_ids[..2])
+          expect(response.parsed_body.pluck(:id)).to match_array(canonical_email_blocks_ids[..2])
         end
       end
     end
@@ -96,7 +96,7 @@ RSpec.describe 'Canonical Email Blocks' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json)
+        expect(response.parsed_body)
           .to include(
             id: eq(canonical_email_block.id.to_s),
             canonical_email_hash: eq(canonical_email_block.canonical_email_hash)
@@ -142,7 +142,7 @@ RSpec.describe 'Canonical Email Blocks' do
           subject
 
           expect(response).to have_http_status(200)
-          expect(body_as_json[0][:canonical_email_hash]).to eq(canonical_email_block.canonical_email_hash)
+          expect(response.parsed_body.first[:canonical_email_hash]).to eq(canonical_email_block.canonical_email_hash)
         end
       end
 
@@ -151,7 +151,7 @@ RSpec.describe 'Canonical Email Blocks' do
           subject
 
           expect(response).to have_http_status(200)
-          expect(body_as_json).to be_empty
+          expect(response.parsed_body).to be_empty
         end
       end
     end
@@ -173,7 +173,7 @@ RSpec.describe 'Canonical Email Blocks' do
       subject
 
       expect(response).to have_http_status(200)
-      expect(body_as_json[:canonical_email_hash]).to eq(canonical_email_block.canonical_email_hash)
+      expect(response.parsed_body[:canonical_email_hash]).to eq(canonical_email_block.canonical_email_hash)
     end
 
     context 'when the required email param is not provided' do
@@ -193,7 +193,7 @@ RSpec.describe 'Canonical Email Blocks' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json[:canonical_email_hash]).to eq(params[:canonical_email_hash])
+        expect(response.parsed_body[:canonical_email_hash]).to eq(params[:canonical_email_hash])
       end
     end
 
@@ -204,7 +204,7 @@ RSpec.describe 'Canonical Email Blocks' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json[:canonical_email_hash]).to eq(canonical_email_block.canonical_email_hash)
+        expect(response.parsed_body[:canonical_email_hash]).to eq(canonical_email_block.canonical_email_hash)
       end
     end
 

--- a/spec/requests/api/v1/admin/dimensions_spec.rb
+++ b/spec/requests/api/v1/admin/dimensions_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Admin Dimensions' do
         expect(response)
           .to have_http_status(200)
 
-        expect(body_as_json)
+        expect(response.parsed_body)
           .to be_an(Array)
       end
     end

--- a/spec/requests/api/v1/admin/domain_allows_spec.rb
+++ b/spec/requests/api/v1/admin/domain_allows_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Domain Allows' do
       it 'returns an empty body' do
         subject
 
-        expect(body_as_json).to be_empty
+        expect(response.parsed_body).to be_empty
       end
     end
 
@@ -49,7 +49,7 @@ RSpec.describe 'Domain Allows' do
       it 'returns the correct allowed domains' do
         subject
 
-        expect(body_as_json).to match_array(expected_response)
+        expect(response.parsed_body).to match_array(expected_response)
       end
 
       context 'with limit param' do
@@ -58,7 +58,7 @@ RSpec.describe 'Domain Allows' do
         it 'returns only the requested number of allowed domains' do
           subject
 
-          expect(body_as_json.size).to eq(params[:limit])
+          expect(response.parsed_body.size).to eq(params[:limit])
         end
       end
     end
@@ -79,7 +79,7 @@ RSpec.describe 'Domain Allows' do
       subject
 
       expect(response).to have_http_status(200)
-      expect(body_as_json[:domain]).to eq domain_allow.domain
+      expect(response.parsed_body[:domain]).to eq domain_allow.domain
     end
 
     context 'when the requested allowed domain does not exist' do
@@ -107,7 +107,7 @@ RSpec.describe 'Domain Allows' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json[:domain]).to eq 'foo.bar.com'
+        expect(response.parsed_body[:domain]).to eq 'foo.bar.com'
         expect(DomainAllow.find_by(domain: 'foo.bar.com')).to be_present
       end
     end
@@ -140,7 +140,7 @@ RSpec.describe 'Domain Allows' do
       it 'returns the existing allowed domain name' do
         subject
 
-        expect(body_as_json[:domain]).to eq(params[:domain])
+        expect(response.parsed_body[:domain]).to eq(params[:domain])
       end
     end
   end

--- a/spec/requests/api/v1/admin/domain_blocks_spec.rb
+++ b/spec/requests/api/v1/admin/domain_blocks_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Domain Blocks' do
       it 'returns an empty list' do
         subject
 
-        expect(body_as_json).to be_empty
+        expect(response.parsed_body).to be_empty
       end
     end
 
@@ -64,7 +64,7 @@ RSpec.describe 'Domain Blocks' do
       it 'returns the expected domain blocks' do
         subject
 
-        expect(body_as_json).to match_array(expected_responde)
+        expect(response.parsed_body).to match_array(expected_responde)
       end
 
       context 'with limit param' do
@@ -73,7 +73,7 @@ RSpec.describe 'Domain Blocks' do
         it 'returns only the requested number of domain blocks' do
           subject
 
-          expect(body_as_json.size).to eq(params[:limit])
+          expect(response.parsed_body.size).to eq(params[:limit])
         end
       end
     end
@@ -94,19 +94,17 @@ RSpec.describe 'Domain Blocks' do
       subject
 
       expect(response).to have_http_status(200)
-      expect(body_as_json).to match(
-        {
-          id: domain_block.id.to_s,
-          domain: domain_block.domain,
-          digest: domain_block.domain_digest,
-          created_at: domain_block.created_at.strftime('%Y-%m-%dT%H:%M:%S.%LZ'),
-          severity: domain_block.severity.to_s,
-          reject_media: domain_block.reject_media,
-          reject_reports: domain_block.reject_reports,
-          private_comment: domain_block.private_comment,
-          public_comment: domain_block.public_comment,
-          obfuscate: domain_block.obfuscate,
-        }
+      expect(response.parsed_body).to match(
+        id: domain_block.id.to_s,
+        domain: domain_block.domain,
+        digest: domain_block.domain_digest,
+        created_at: domain_block.created_at.strftime('%Y-%m-%dT%H:%M:%S.%LZ'),
+        severity: domain_block.severity.to_s,
+        reject_media: domain_block.reject_media,
+        reject_reports: domain_block.reject_reports,
+        private_comment: domain_block.private_comment,
+        public_comment: domain_block.public_comment,
+        obfuscate: domain_block.obfuscate
       )
     end
 
@@ -134,7 +132,7 @@ RSpec.describe 'Domain Blocks' do
       subject
 
       expect(response).to have_http_status(200)
-      expect(body_as_json).to match a_hash_including(
+      expect(response.parsed_body).to match a_hash_including(
         {
           domain: 'foo.bar.com',
           severity: 'silence',
@@ -155,7 +153,7 @@ RSpec.describe 'Domain Blocks' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json).to match a_hash_including(
+        expect(response.parsed_body).to match a_hash_including(
           {
             domain: 'foo.bar.com',
             severity: 'suspend',
@@ -175,7 +173,7 @@ RSpec.describe 'Domain Blocks' do
         subject
 
         expect(response).to have_http_status(422)
-        expect(body_as_json[:existing_domain_block][:domain]).to eq('foo.bar.com')
+        expect(response.parsed_body[:existing_domain_block][:domain]).to eq('foo.bar.com')
       end
     end
 
@@ -188,7 +186,7 @@ RSpec.describe 'Domain Blocks' do
         subject
 
         expect(response).to have_http_status(422)
-        expect(body_as_json[:existing_domain_block][:domain]).to eq('bar.com')
+        expect(response.parsed_body[:existing_domain_block][:domain]).to eq('bar.com')
       end
     end
 
@@ -219,7 +217,7 @@ RSpec.describe 'Domain Blocks' do
       subject
 
       expect(response).to have_http_status(200)
-      expect(body_as_json).to match a_hash_including(
+      expect(response.parsed_body).to match a_hash_including(
         {
           id: domain_block.id.to_s,
           domain: domain_block.domain,

--- a/spec/requests/api/v1/admin/email_domain_blocks_spec.rb
+++ b/spec/requests/api/v1/admin/email_domain_blocks_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'Email Domain Blocks' do
       it 'returns an empty list' do
         subject
 
-        expect(body_as_json).to be_empty
+        expect(response.parsed_body).to be_empty
       end
     end
 
@@ -42,7 +42,7 @@ RSpec.describe 'Email Domain Blocks' do
       it 'return the correct blocked email domains' do
         subject
 
-        expect(body_as_json.pluck(:domain)).to match_array(blocked_email_domains)
+        expect(response.parsed_body.pluck(:domain)).to match_array(blocked_email_domains)
       end
 
       context 'with limit param' do
@@ -51,7 +51,7 @@ RSpec.describe 'Email Domain Blocks' do
         it 'returns only the requested number of email domain blocks' do
           subject
 
-          expect(body_as_json.size).to eq(params[:limit])
+          expect(response.parsed_body.size).to eq(params[:limit])
         end
       end
 
@@ -63,7 +63,7 @@ RSpec.describe 'Email Domain Blocks' do
 
           email_domain_blocks_ids = email_domain_blocks.pluck(:id).map(&:to_s)
 
-          expect(body_as_json.pluck(:id)).to match_array(email_domain_blocks_ids[2..])
+          expect(response.parsed_body.pluck(:id)).to match_array(email_domain_blocks_ids[2..])
         end
       end
 
@@ -75,7 +75,7 @@ RSpec.describe 'Email Domain Blocks' do
 
           email_domain_blocks_ids = email_domain_blocks.pluck(:id).map(&:to_s)
 
-          expect(body_as_json.pluck(:id)).to match_array(email_domain_blocks_ids[..2])
+          expect(response.parsed_body.pluck(:id)).to match_array(email_domain_blocks_ids[..2])
         end
       end
     end
@@ -97,7 +97,7 @@ RSpec.describe 'Email Domain Blocks' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json[:domain]).to eq(email_domain_block.domain)
+        expect(response.parsed_body[:domain]).to eq(email_domain_block.domain)
       end
     end
 
@@ -125,7 +125,7 @@ RSpec.describe 'Email Domain Blocks' do
       subject
 
       expect(response).to have_http_status(200)
-      expect(body_as_json[:domain]).to eq(params[:domain])
+      expect(response.parsed_body[:domain]).to eq(params[:domain])
     end
 
     context 'when domain param is not provided' do
@@ -176,7 +176,7 @@ RSpec.describe 'Email Domain Blocks' do
       subject
 
       expect(response).to have_http_status(200)
-      expect(body_as_json).to be_empty
+      expect(response.parsed_body).to be_empty
       expect(EmailDomainBlock.find_by(id: email_domain_block.id)).to be_nil
     end
 

--- a/spec/requests/api/v1/admin/ip_blocks_spec.rb
+++ b/spec/requests/api/v1/admin/ip_blocks_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'IP Blocks' do
       it 'returns an empty body' do
         subject
 
-        expect(body_as_json).to be_empty
+        expect(response.parsed_body).to be_empty
       end
     end
 
@@ -58,7 +58,7 @@ RSpec.describe 'IP Blocks' do
       it 'returns the correct blocked ips' do
         subject
 
-        expect(body_as_json).to match_array(expected_response)
+        expect(response.parsed_body).to match_array(expected_response)
       end
 
       context 'with limit param' do
@@ -67,7 +67,7 @@ RSpec.describe 'IP Blocks' do
         it 'returns only the requested number of ip blocks' do
           subject
 
-          expect(body_as_json.size).to eq(params[:limit])
+          expect(response.parsed_body.size).to eq(params[:limit])
         end
       end
     end
@@ -89,7 +89,7 @@ RSpec.describe 'IP Blocks' do
 
       expect(response).to have_http_status(200)
 
-      expect(body_as_json)
+      expect(response.parsed_body)
         .to include(
           ip: eq("#{ip_block.ip}/#{ip_block.ip.prefix}"),
           severity: eq(ip_block.severity.to_s)
@@ -120,7 +120,7 @@ RSpec.describe 'IP Blocks' do
       subject
 
       expect(response).to have_http_status(200)
-      expect(body_as_json)
+      expect(response.parsed_body)
         .to include(
           ip: eq("#{params[:ip]}/32"),
           severity: eq(params[:severity]),
@@ -185,7 +185,7 @@ RSpec.describe 'IP Blocks' do
         .and change_comment_value
 
       expect(response).to have_http_status(200)
-      expect(body_as_json).to match(hash_including({
+      expect(response.parsed_body).to match(hash_including({
         ip: "#{ip_block.ip}/#{ip_block.ip.prefix}",
         severity: 'sign_up_requires_approval',
         comment: 'Decreasing severity',
@@ -220,7 +220,7 @@ RSpec.describe 'IP Blocks' do
       subject
 
       expect(response).to have_http_status(200)
-      expect(body_as_json).to be_empty
+      expect(response.parsed_body).to be_empty
       expect(IpBlock.find_by(id: ip_block.id)).to be_nil
     end
 

--- a/spec/requests/api/v1/admin/measures_spec.rb
+++ b/spec/requests/api/v1/admin/measures_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'Admin Measures' do
         expect(response)
           .to have_http_status(200)
 
-        expect(body_as_json)
+        expect(response.parsed_body)
           .to be_an(Array)
       end
     end

--- a/spec/requests/api/v1/admin/reports_spec.rb
+++ b/spec/requests/api/v1/admin/reports_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Reports' do
       it 'returns an empty list' do
         subject
 
-        expect(body_as_json).to be_empty
+        expect(response.parsed_body).to be_empty
       end
     end
 
@@ -64,7 +64,7 @@ RSpec.describe 'Reports' do
       it 'returns all unresolved reports' do
         subject
 
-        expect(body_as_json).to match_array(expected_response)
+        expect(response.parsed_body).to match_array(expected_response)
       end
 
       context 'with resolved param' do
@@ -74,7 +74,7 @@ RSpec.describe 'Reports' do
         it 'returns only the resolved reports' do
           subject
 
-          expect(body_as_json).to match_array(expected_response)
+          expect(response.parsed_body).to match_array(expected_response)
         end
       end
 
@@ -85,7 +85,7 @@ RSpec.describe 'Reports' do
         it 'returns all unresolved reports filed by the specified account' do
           subject
 
-          expect(body_as_json).to match_array(expected_response)
+          expect(response.parsed_body).to match_array(expected_response)
         end
       end
 
@@ -96,7 +96,7 @@ RSpec.describe 'Reports' do
         it 'returns all unresolved reports targeting the specified account' do
           subject
 
-          expect(body_as_json).to match_array(expected_response)
+          expect(response.parsed_body).to match_array(expected_response)
         end
       end
 
@@ -106,7 +106,7 @@ RSpec.describe 'Reports' do
         it 'returns only the requested number of reports' do
           subject
 
-          expect(body_as_json.size).to eq(1)
+          expect(response.parsed_body.size).to eq(1)
         end
       end
     end
@@ -126,7 +126,7 @@ RSpec.describe 'Reports' do
       subject
 
       expect(response).to have_http_status(200)
-      expect(body_as_json).to include(
+      expect(response.parsed_body).to include(
         {
           id: report.id.to_s,
           action_taken: report.action_taken?,
@@ -159,7 +159,7 @@ RSpec.describe 'Reports' do
 
       report.reload
 
-      expect(body_as_json).to include(
+      expect(response.parsed_body).to include(
         {
           id: report.id.to_s,
           action_taken: report.action_taken?,

--- a/spec/requests/api/v1/admin/retention_spec.rb
+++ b/spec/requests/api/v1/admin/retention_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Admin Retention' do
         expect(response)
           .to have_http_status(200)
 
-        expect(body_as_json)
+        expect(response.parsed_body)
           .to be_an(Array)
       end
     end

--- a/spec/requests/api/v1/admin/tags_spec.rb
+++ b/spec/requests/api/v1/admin/tags_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Tags' do
       it 'returns an empty list' do
         subject
 
-        expect(body_as_json).to be_empty
+        expect(response.parsed_body).to be_empty
       end
     end
 
@@ -47,7 +47,7 @@ RSpec.describe 'Tags' do
       it 'returns the expected tags' do
         subject
         tags.each do |tag|
-          expect(body_as_json.find { |item| item[:id] == tag.id.to_s && item[:name] == tag.name }).to_not be_nil
+          expect(response.parsed_body.find { |item| item[:id] == tag.id.to_s && item[:name] == tag.name }).to_not be_nil
         end
       end
 
@@ -57,7 +57,7 @@ RSpec.describe 'Tags' do
         it 'returns only the requested number of tags' do
           subject
 
-          expect(body_as_json.size).to eq(params[:limit])
+          expect(response.parsed_body.size).to eq(params[:limit])
         end
       end
     end
@@ -82,8 +82,8 @@ RSpec.describe 'Tags' do
     it 'returns expected tag content' do
       subject
 
-      expect(body_as_json[:id].to_i).to eq(tag.id)
-      expect(body_as_json[:name]).to eq(tag.name)
+      expect(response.parsed_body[:id].to_i).to eq(tag.id)
+      expect(response.parsed_body[:name]).to eq(tag.name)
     end
 
     context 'when the requested tag does not exist' do
@@ -116,8 +116,8 @@ RSpec.describe 'Tags' do
     it 'returns updated tag' do
       subject
 
-      expect(body_as_json[:id].to_i).to eq(tag.id)
-      expect(body_as_json[:name]).to eq(tag.name.upcase)
+      expect(response.parsed_body[:id].to_i).to eq(tag.id)
+      expect(response.parsed_body[:name]).to eq(tag.name.upcase)
     end
 
     context 'when the updated display name is invalid' do

--- a/spec/requests/api/v1/admin/trends/links/links_spec.rb
+++ b/spec/requests/api/v1/admin/trends/links/links_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'Links' do
     end
 
     def expects_correct_link_data
-      expect(body_as_json).to match(
+      expect(response.parsed_body).to match(
         a_hash_including(
           url: preview_card.url,
           title: preview_card.title,
@@ -98,7 +98,7 @@ RSpec.describe 'Links' do
     it 'returns the link data' do
       subject
 
-      expect(body_as_json).to match(
+      expect(response.parsed_body).to match(
         a_hash_including(
           url: preview_card.url,
           title: preview_card.title,

--- a/spec/requests/api/v1/annual_reports_spec.rb
+++ b/spec/requests/api/v1/annual_reports_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'API V1 Annual Reports' do
         expect(response)
           .to have_http_status(200)
 
-        expect(body_as_json)
+        expect(response.parsed_body)
           .to be_present
       end
     end

--- a/spec/requests/api/v1/apps/credentials_spec.rb
+++ b/spec/requests/api/v1/apps/credentials_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Credentials' do
 
         expect(response).to have_http_status(200)
 
-        expect(body_as_json).to match(
+        expect(response.parsed_body).to match(
           a_hash_including(
             id: token.application.id.to_s,
             name: token.application.name,
@@ -37,8 +37,8 @@ RSpec.describe 'Credentials' do
 
         expect(response).to have_http_status(200)
 
-        expect(body_as_json[:client_id]).to_not be_present
-        expect(body_as_json[:client_secret]).to_not be_present
+        expect(response.parsed_body[:client_id]).to_not be_present
+        expect(response.parsed_body[:client_secret]).to_not be_present
       end
     end
 
@@ -56,7 +56,7 @@ RSpec.describe 'Credentials' do
       it 'returns the app information correctly' do
         subject
 
-        expect(body_as_json).to match(
+        expect(response.parsed_body).to match(
           a_hash_including(
             id: token.application.id.to_s,
             name: token.application.name,
@@ -95,7 +95,7 @@ RSpec.describe 'Credentials' do
       it 'returns the error in the json response' do
         subject
 
-        expect(body_as_json).to match(
+        expect(response.parsed_body).to match(
           a_hash_including(
             error: 'The access token was revoked'
           )
@@ -117,7 +117,7 @@ RSpec.describe 'Credentials' do
       it 'returns the error in the json response' do
         subject
 
-        expect(body_as_json).to match(
+        expect(response.parsed_body).to match(
           a_hash_including(
             error: 'The access token is invalid'
           )

--- a/spec/requests/api/v1/apps_spec.rb
+++ b/spec/requests/api/v1/apps_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Apps' do
         expect(app.scopes.to_s).to eq scopes
         expect(app.redirect_uris).to eq redirect_uris
 
-        expect(body_as_json).to match(
+        expect(response.parsed_body).to match(
           a_hash_including(
             id: app.id.to_s,
             client_id: app.uid,
@@ -61,7 +61,7 @@ RSpec.describe 'Apps' do
         expect(response).to have_http_status(200)
         expect(Doorkeeper::Application.find_by(name: client_name)).to be_present
 
-        expect(body_as_json)
+        expect(response.parsed_body)
           .to include(
             scopes: Doorkeeper.config.default_scopes.to_a
           )
@@ -82,7 +82,7 @@ RSpec.describe 'Apps' do
         expect(app).to be_present
         expect(app.scopes.to_s).to eq 'read'
 
-        expect(body_as_json)
+        expect(response.parsed_body)
           .to include(
             scopes: %w(read)
           )
@@ -165,7 +165,7 @@ RSpec.describe 'Apps' do
         expect(app.redirect_uri).to eq redirect_uris
         expect(app.redirect_uris).to eq redirect_uris.split
 
-        expect(body_as_json)
+        expect(response.parsed_body)
           .to include(
             redirect_uri: redirect_uris,
             redirect_uris: redirect_uris.split
@@ -187,7 +187,7 @@ RSpec.describe 'Apps' do
         expect(app.redirect_uri).to eq redirect_uris.join "\n"
         expect(app.redirect_uris).to eq redirect_uris
 
-        expect(body_as_json)
+        expect(response.parsed_body)
           .to include(
             redirect_uri: redirect_uris.join("\n"),
             redirect_uris: redirect_uris

--- a/spec/requests/api/v1/blocks_spec.rb
+++ b/spec/requests/api/v1/blocks_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Blocks' do
       subject
 
       expect(response).to have_http_status(200)
-      expect(body_as_json).to match_array(expected_response)
+      expect(response.parsed_body).to match_array(expected_response)
     end
 
     context 'with limit param' do
@@ -35,7 +35,7 @@ RSpec.describe 'Blocks' do
       it 'returns only the requested number of blocked accounts' do
         subject
 
-        expect(body_as_json.size).to eq(params[:limit])
+        expect(response.parsed_body.size).to eq(params[:limit])
       end
 
       it 'sets correct link header pagination' do
@@ -55,7 +55,7 @@ RSpec.describe 'Blocks' do
       it 'queries the blocks in range according to max_id', :aggregate_failures do
         subject
 
-        expect(body_as_json)
+        expect(response.parsed_body)
           .to contain_exactly(include(id: blocks.first.target_account.id.to_s))
       end
     end
@@ -66,7 +66,7 @@ RSpec.describe 'Blocks' do
       it 'queries the blocks in range according to since_id', :aggregate_failures do
         subject
 
-        expect(body_as_json)
+        expect(response.parsed_body)
           .to contain_exactly(include(id: blocks[2].target_account.id.to_s))
       end
     end

--- a/spec/requests/api/v1/bookmarks_spec.rb
+++ b/spec/requests/api/v1/bookmarks_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'Bookmarks' do
     it 'returns the bookmarked statuses' do
       subject
 
-      expect(body_as_json).to match_array(expected_response)
+      expect(response.parsed_body).to match_array(expected_response)
     end
 
     context 'with limit param' do
@@ -42,7 +42,7 @@ RSpec.describe 'Bookmarks' do
       it 'paginates correctly', :aggregate_failures do
         subject
 
-        expect(body_as_json.size)
+        expect(response.parsed_body.size)
           .to eq(params[:limit])
 
         expect(response)

--- a/spec/requests/api/v1/conversations_spec.rb
+++ b/spec/requests/api/v1/conversations_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe 'API V1 Conversations' do
     it 'returns conversations', :aggregate_failures do
       get '/api/v1/conversations', headers: headers
 
-      expect(body_as_json.size).to eq 2
-      expect(body_as_json[0][:accounts].size).to eq 1
+      expect(response.parsed_body.size).to eq 2
+      expect(response.parsed_body.first[:accounts].size).to eq 1
     end
 
     context 'with since_id' do
@@ -40,7 +40,7 @@ RSpec.describe 'API V1 Conversations' do
         it 'returns conversations' do
           get '/api/v1/conversations', params: { since_id: Mastodon::Snowflake.id_at(1.hour.ago, with_random: false) }, headers: headers
 
-          expect(body_as_json.size).to eq 2
+          expect(response.parsed_body.size).to eq 2
         end
       end
 
@@ -48,7 +48,7 @@ RSpec.describe 'API V1 Conversations' do
         it 'returns no conversation' do
           get '/api/v1/conversations', params: { since_id: Mastodon::Snowflake.id_at(1.hour.from_now, with_random: false) }, headers: headers
 
-          expect(body_as_json.size).to eq 0
+          expect(response.parsed_body.size).to eq 0
         end
       end
     end

--- a/spec/requests/api/v1/custom_emojis_spec.rb
+++ b/spec/requests/api/v1/custom_emojis_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Custom Emojis' do
         expect(response)
           .to have_http_status(200)
 
-        expect(body_as_json)
+        expect(response.parsed_body)
           .to be_present
           .and have_attributes(
             first: include(shortcode: 'coolcat')
@@ -34,7 +34,7 @@ RSpec.describe 'Custom Emojis' do
         expect(response)
           .to have_http_status(200)
 
-        expect(body_as_json)
+        expect(response.parsed_body)
           .to be_present
           .and have_attributes(
             first: include(shortcode: 'coolcat')

--- a/spec/requests/api/v1/directories_spec.rb
+++ b/spec/requests/api/v1/directories_spec.rb
@@ -82,8 +82,8 @@ RSpec.describe 'Directories API' do
         get '/api/v1/directory', headers: headers
 
         expect(response).to have_http_status(200)
-        expect(body_as_json.size).to eq(2)
-        expect(body_as_json.pluck(:id)).to contain_exactly(eligible_remote_account.id.to_s, local_discoverable_account.id.to_s)
+        expect(response.parsed_body.size).to eq(2)
+        expect(response.parsed_body.pluck(:id)).to contain_exactly(eligible_remote_account.id.to_s, local_discoverable_account.id.to_s)
       end
     end
 
@@ -101,8 +101,8 @@ RSpec.describe 'Directories API' do
         get '/api/v1/directory', headers: headers, params: { local: '1' }
 
         expect(response).to have_http_status(200)
-        expect(body_as_json.size).to eq(1)
-        expect(body_as_json.first[:id]).to include(local_account.id.to_s)
+        expect(response.parsed_body.size).to eq(1)
+        expect(response.parsed_body.first[:id]).to include(local_account.id.to_s)
         expect(response.body).to_not include(remote_account.id.to_s)
       end
     end
@@ -115,9 +115,9 @@ RSpec.describe 'Directories API' do
         get '/api/v1/directory', headers: headers, params: { order: 'active' }
 
         expect(response).to have_http_status(200)
-        expect(body_as_json.size).to eq(2)
-        expect(body_as_json.first[:id]).to include(new_stat.account_id.to_s)
-        expect(body_as_json.second[:id]).to include(old_stat.account_id.to_s)
+        expect(response.parsed_body.size).to eq(2)
+        expect(response.parsed_body.first[:id]).to include(new_stat.account_id.to_s)
+        expect(response.parsed_body.second[:id]).to include(old_stat.account_id.to_s)
       end
     end
 
@@ -130,9 +130,9 @@ RSpec.describe 'Directories API' do
         get '/api/v1/directory', headers: headers, params: { order: 'new' }
 
         expect(response).to have_http_status(200)
-        expect(body_as_json.size).to eq(2)
-        expect(body_as_json.first[:id]).to include(account_new.id.to_s)
-        expect(body_as_json.second[:id]).to include(account_old.id.to_s)
+        expect(response.parsed_body.size).to eq(2)
+        expect(response.parsed_body.first[:id]).to include(account_new.id.to_s)
+        expect(response.parsed_body.second[:id]).to include(account_old.id.to_s)
       end
     end
   end

--- a/spec/requests/api/v1/domain_blocks_spec.rb
+++ b/spec/requests/api/v1/domain_blocks_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Domain blocks' do
       subject
 
       expect(response).to have_http_status(200)
-      expect(body_as_json).to match_array(blocked_domains)
+      expect(response.parsed_body).to match_array(blocked_domains)
     end
 
     context 'with limit param' do
@@ -35,7 +35,7 @@ RSpec.describe 'Domain blocks' do
       it 'returns only the requested number of blocked domains' do
         subject
 
-        expect(body_as_json.size).to eq(params[:limit])
+        expect(response.parsed_body.size).to eq(params[:limit])
       end
     end
   end

--- a/spec/requests/api/v1/emails/confirmations_spec.rb
+++ b/spec/requests/api/v1/emails/confirmations_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe 'Confirmations' do
           subject
 
           expect(response).to have_http_status(200)
-          expect(body_as_json).to be false
+          expect(response.parsed_body).to be false
         end
       end
 
@@ -122,7 +122,7 @@ RSpec.describe 'Confirmations' do
           subject
 
           expect(response).to have_http_status(200)
-          expect(body_as_json).to be true
+          expect(response.parsed_body).to be true
         end
       end
     end
@@ -139,7 +139,7 @@ RSpec.describe 'Confirmations' do
           subject
 
           expect(response).to have_http_status(200)
-          expect(body_as_json).to be false
+          expect(response.parsed_body).to be false
         end
       end
 
@@ -150,7 +150,7 @@ RSpec.describe 'Confirmations' do
           subject
 
           expect(response).to have_http_status(200)
-          expect(body_as_json).to be true
+          expect(response.parsed_body).to be true
         end
       end
     end

--- a/spec/requests/api/v1/endorsements_spec.rb
+++ b/spec/requests/api/v1/endorsements_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Endorsements' do
           expect(response)
             .to have_http_status(200)
 
-          expect(body_as_json)
+          expect(response.parsed_body)
             .to be_present
             .and have_attributes(
               first: include(acct: account_pin.target_account.acct)
@@ -52,7 +52,7 @@ RSpec.describe 'Endorsements' do
           expect(response)
             .to have_http_status(200)
 
-          expect(body_as_json)
+          expect(response.parsed_body)
             .to_not be_present
         end
       end

--- a/spec/requests/api/v1/favourites_spec.rb
+++ b/spec/requests/api/v1/favourites_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'Favourites' do
     it 'returns the favourites' do
       subject
 
-      expect(body_as_json).to match_array(expected_response)
+      expect(response.parsed_body).to match_array(expected_response)
     end
 
     context 'with limit param' do
@@ -42,7 +42,7 @@ RSpec.describe 'Favourites' do
       it 'returns only the requested number of favourites' do
         subject
 
-        expect(body_as_json.size).to eq(params[:limit])
+        expect(response.parsed_body.size).to eq(params[:limit])
       end
 
       it 'sets the correct pagination headers' do

--- a/spec/requests/api/v1/featured_tags/suggestions_spec.rb
+++ b/spec/requests/api/v1/featured_tags/suggestions_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'Featured Tags Suggestions API' do
 
       expect(response)
         .to have_http_status(200)
-      expect(body_as_json)
+      expect(response.parsed_body)
         .to contain_exactly(
           include(name: used_tag.name)
         )

--- a/spec/requests/api/v1/featured_tags_spec.rb
+++ b/spec/requests/api/v1/featured_tags_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'FeaturedTags' do
       it 'returns an empty body' do
         get '/api/v1/featured_tags', headers: headers
 
-        expect(body_as_json).to be_empty
+        expect(response.parsed_body).to be_empty
       end
     end
 
@@ -47,7 +47,7 @@ RSpec.describe 'FeaturedTags' do
       it 'returns only the featured tags belonging to the requesting user' do
         get '/api/v1/featured_tags', headers: headers
 
-        expect(body_as_json.pluck(:id))
+        expect(response.parsed_body.pluck(:id))
           .to match_array(
             user_featured_tags.pluck(:id).map(&:to_s)
           )
@@ -67,7 +67,7 @@ RSpec.describe 'FeaturedTags' do
     it 'returns the correct tag name' do
       post '/api/v1/featured_tags', headers: headers, params: params
 
-      expect(body_as_json)
+      expect(response.parsed_body)
         .to include(
           name: params[:name]
         )
@@ -141,7 +141,7 @@ RSpec.describe 'FeaturedTags' do
     it 'returns an empty body' do
       delete "/api/v1/featured_tags/#{id}", headers: headers
 
-      expect(body_as_json).to be_empty
+      expect(response.parsed_body).to be_empty
     end
 
     it 'deletes the featured tag', :inline_jobs do

--- a/spec/requests/api/v1/filters_spec.rb
+++ b/spec/requests/api/v1/filters_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'API V1 Filters' do
     it 'returns http success' do
       get '/api/v1/filters', headers: headers
       expect(response).to have_http_status(200)
-      expect(body_as_json)
+      expect(response.parsed_body)
         .to contain_exactly(
           include(id: custom_filter_keyword.id.to_s)
         )

--- a/spec/requests/api/v1/follow_requests_spec.rb
+++ b/spec/requests/api/v1/follow_requests_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'Follow requests' do
       subject
 
       expect(response).to have_http_status(200)
-      expect(body_as_json).to match_array(expected_response)
+      expect(response.parsed_body).to match_array(expected_response)
     end
 
     context 'with limit param' do
@@ -45,7 +45,7 @@ RSpec.describe 'Follow requests' do
       it 'returns only the requested number of follow requests' do
         subject
 
-        expect(body_as_json.size).to eq(params[:limit])
+        expect(response.parsed_body.size).to eq(params[:limit])
       end
     end
   end
@@ -66,7 +66,7 @@ RSpec.describe 'Follow requests' do
     it 'allows the requesting follower to follow', :aggregate_failures do
       expect { subject }.to change { follower.following?(user.account) }.from(false).to(true)
       expect(response).to have_http_status(200)
-      expect(body_as_json[:followed_by]).to be true
+      expect(response.parsed_body[:followed_by]).to be true
     end
   end
 
@@ -88,7 +88,7 @@ RSpec.describe 'Follow requests' do
 
       expect(response).to have_http_status(200)
       expect(FollowRequest.where(target_account: user.account, account: follower)).to_not exist
-      expect(body_as_json[:followed_by]).to be false
+      expect(response.parsed_body[:followed_by]).to be false
     end
   end
 end

--- a/spec/requests/api/v1/followed_tags_spec.rb
+++ b/spec/requests/api/v1/followed_tags_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Followed tags' do
     it 'returns the followed tags correctly' do
       subject
 
-      expect(body_as_json).to match_array(expected_response)
+      expect(response.parsed_body).to match_array(expected_response)
     end
 
     context 'with limit param' do
@@ -46,7 +46,7 @@ RSpec.describe 'Followed tags' do
       it 'returns only the requested number of follow tags' do
         subject
 
-        expect(body_as_json.size).to eq(params[:limit])
+        expect(response.parsed_body.size).to eq(params[:limit])
       end
 
       it 'sets the correct pagination headers' do

--- a/spec/requests/api/v1/instance_spec.rb
+++ b/spec/requests/api/v1/instance_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Instances' do
         expect(response)
           .to have_http_status(200)
 
-        expect(body_as_json)
+        expect(response.parsed_body)
           .to be_present
           .and include(title: 'Mastodon')
       end
@@ -28,7 +28,7 @@ RSpec.describe 'Instances' do
         expect(response)
           .to have_http_status(200)
 
-        expect(body_as_json)
+        expect(response.parsed_body)
           .to be_present
           .and include(title: 'Mastodon')
       end

--- a/spec/requests/api/v1/instances/activity_spec.rb
+++ b/spec/requests/api/v1/instances/activity_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Activity' do
         expect(response)
           .to have_http_status(200)
 
-        expect(body_as_json)
+        expect(response.parsed_body)
           .to be_present
           .and(be_an(Array))
           .and(have_attributes(size: Api::V1::Instances::ActivityController::WEEKS_OF_ACTIVITY))

--- a/spec/requests/api/v1/instances/domain_blocks_spec.rb
+++ b/spec/requests/api/v1/instances/domain_blocks_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Domain Blocks' do
         expect(response)
           .to have_http_status(200)
 
-        expect(body_as_json)
+        expect(response.parsed_body)
           .to be_present
           .and(be_an(Array))
           .and(have_attributes(size: 1))

--- a/spec/requests/api/v1/instances/extended_descriptions_spec.rb
+++ b/spec/requests/api/v1/instances/extended_descriptions_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Extended Descriptions' do
       expect(response)
         .to have_http_status(200)
 
-      expect(body_as_json)
+      expect(response.parsed_body)
         .to be_present
         .and include(:content)
     end

--- a/spec/requests/api/v1/instances/languages_spec.rb
+++ b/spec/requests/api/v1/instances/languages_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Languages' do
     end
 
     it 'returns the supported languages' do
-      expect(body_as_json.pluck(:code)).to match_array LanguagesHelper::SUPPORTED_LOCALES.keys.map(&:to_s)
+      expect(response.parsed_body.pluck(:code)).to match_array LanguagesHelper::SUPPORTED_LOCALES.keys.map(&:to_s)
     end
   end
 end

--- a/spec/requests/api/v1/instances/peers_spec.rb
+++ b/spec/requests/api/v1/instances/peers_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Peers' do
         expect(response)
           .to have_http_status(200)
 
-        expect(body_as_json)
+        expect(response.parsed_body)
           .to be_an(Array)
       end
     end

--- a/spec/requests/api/v1/instances/privacy_policies_spec.rb
+++ b/spec/requests/api/v1/instances/privacy_policies_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Privacy Policy' do
       expect(response)
         .to have_http_status(200)
 
-      expect(body_as_json)
+      expect(response.parsed_body)
         .to be_present
         .and include(:content)
     end

--- a/spec/requests/api/v1/instances/rules_spec.rb
+++ b/spec/requests/api/v1/instances/rules_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Rules' do
       expect(response)
         .to have_http_status(200)
 
-      expect(body_as_json)
+      expect(response.parsed_body)
         .to be_an(Array)
     end
   end

--- a/spec/requests/api/v1/instances/translation_languages_spec.rb
+++ b/spec/requests/api/v1/instances/translation_languages_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Translation Languages' do
         expect(response)
           .to have_http_status(200)
 
-        expect(body_as_json)
+        expect(response.parsed_body)
           .to eq({})
       end
     end
@@ -25,7 +25,7 @@ RSpec.describe 'Translation Languages' do
         expect(response)
           .to have_http_status(200)
 
-        expect(body_as_json)
+        expect(response.parsed_body)
           .to match({ und: %w(en de), en: ['de'] })
       end
 

--- a/spec/requests/api/v1/lists/accounts_spec.rb
+++ b/spec/requests/api/v1/lists/accounts_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'Accounts' do
       subject
 
       expect(response).to have_http_status(200)
-      expect(body_as_json).to match_array(expected_response)
+      expect(response.parsed_body).to match_array(expected_response)
     end
 
     context 'with limit param' do
@@ -43,7 +43,7 @@ RSpec.describe 'Accounts' do
       it 'returns only the requested number of accounts' do
         subject
 
-        expect(body_as_json.size).to eq(params[:limit])
+        expect(response.parsed_body.size).to eq(params[:limit])
       end
     end
   end

--- a/spec/requests/api/v1/lists_spec.rb
+++ b/spec/requests/api/v1/lists_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'Lists' do
       subject
 
       expect(response).to have_http_status(200)
-      expect(body_as_json).to match_array(expected_response)
+      expect(response.parsed_body).to match_array(expected_response)
     end
   end
 
@@ -60,7 +60,7 @@ RSpec.describe 'Lists' do
       subject
 
       expect(response).to have_http_status(200)
-      expect(body_as_json).to match({
+      expect(response.parsed_body).to match({
         id: list.id.to_s,
         title: list.title,
         replies_policy: list.replies_policy,
@@ -100,7 +100,7 @@ RSpec.describe 'Lists' do
       subject
 
       expect(response).to have_http_status(200)
-      expect(body_as_json).to match(a_hash_including(title: 'my list', replies_policy: 'none', exclusive: true))
+      expect(response.parsed_body).to match(a_hash_including(title: 'my list', replies_policy: 'none', exclusive: true))
       expect(List.where(account: user.account).count).to eq(1)
     end
 
@@ -144,7 +144,7 @@ RSpec.describe 'Lists' do
       expect(response).to have_http_status(200)
       list.reload
 
-      expect(body_as_json).to match({
+      expect(response.parsed_body).to match({
         id: list.id.to_s,
         title: list.title,
         replies_policy: list.replies_policy,

--- a/spec/requests/api/v1/markers_spec.rb
+++ b/spec/requests/api/v1/markers_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'API Markers' do
 
     it 'returns markers', :aggregate_failures do
       expect(response).to have_http_status(200)
-      expect(body_as_json)
+      expect(response.parsed_body)
         .to include(
           home: include(last_read_id: '123'),
           notifications: include(last_read_id: '456')
@@ -61,7 +61,7 @@ RSpec.describe 'API Markers' do
       it 'returns error json' do
         expect(response)
           .to have_http_status(409)
-        expect(body_as_json)
+        expect(response.parsed_body)
           .to include(error: /Conflict during update/)
       end
     end

--- a/spec/requests/api/v1/media_spec.rb
+++ b/spec/requests/api/v1/media_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Media' do
     it 'returns the media information' do
       subject
 
-      expect(body_as_json).to match(
+      expect(response.parsed_body).to match(
         a_hash_including(
           id: media.id.to_s,
           description: media.description,
@@ -83,7 +83,7 @@ RSpec.describe 'Media' do
         expect(MediaAttachment.first).to be_present
         expect(MediaAttachment.first).to have_attached_file(:file)
 
-        expect(body_as_json).to match(
+        expect(response.parsed_body).to match(
           a_hash_including(id: MediaAttachment.first.id.to_s, description: params[:description], type: media_type)
         )
       end

--- a/spec/requests/api/v1/mutes_spec.rb
+++ b/spec/requests/api/v1/mutes_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Mutes' do
 
       muted_accounts = mutes.map(&:target_account)
 
-      expect(body_as_json.pluck(:id)).to match_array(muted_accounts.map { |account| account.id.to_s })
+      expect(response.parsed_body.pluck(:id)).to match_array(muted_accounts.map { |account| account.id.to_s })
     end
 
     context 'with limit param' do
@@ -38,7 +38,7 @@ RSpec.describe 'Mutes' do
       it 'returns only the requested number of muted accounts' do
         subject
 
-        expect(body_as_json.size).to eq(params[:limit])
+        expect(response.parsed_body.size).to eq(params[:limit])
       end
 
       it 'sets the correct pagination headers', :aggregate_failures do
@@ -58,7 +58,7 @@ RSpec.describe 'Mutes' do
       it 'queries mutes in range according to max_id', :aggregate_failures do
         subject
 
-        expect(body_as_json)
+        expect(response.parsed_body)
           .to contain_exactly(include(id: mutes.first.target_account_id.to_s))
       end
     end
@@ -69,7 +69,7 @@ RSpec.describe 'Mutes' do
       it 'queries mutes in range according to since_id', :aggregate_failures do
         subject
 
-        expect(body_as_json)
+        expect(response.parsed_body)
           .to contain_exactly(include(id: mutes[1].target_account_id.to_s))
       end
     end

--- a/spec/requests/api/v1/notifications/policies_spec.rb
+++ b/spec/requests/api/v1/notifications/policies_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Policies' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json).to include(
+        expect(response.parsed_body).to include(
           filter_not_following: false,
           filter_not_followers: false,
           filter_new_accounts: false,
@@ -54,7 +54,7 @@ RSpec.describe 'Policies' do
         .to change { NotificationPolicy.find_or_initialize_by(account: user.account).for_not_following.to_sym }.from(:accept).to(:filter)
 
       expect(response).to have_http_status(200)
-      expect(body_as_json).to include(
+      expect(response.parsed_body).to include(
         filter_not_following: true,
         filter_not_followers: false,
         filter_new_accounts: false,

--- a/spec/requests/api/v1/notifications/requests_spec.rb
+++ b/spec/requests/api/v1/notifications/requests_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe 'Requests' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json).to match({ merged: true })
+        expect(response.parsed_body).to match({ merged: true })
       end
     end
 
@@ -146,7 +146,7 @@ RSpec.describe 'Requests' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json).to match({ merged: false })
+        expect(response.parsed_body).to match({ merged: false })
       end
     end
   end

--- a/spec/requests/api/v1/notifications_spec.rb
+++ b/spec/requests/api/v1/notifications_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json[:count]).to eq 5
+        expect(response.parsed_body[:count]).to eq 5
       end
     end
 
@@ -45,7 +45,7 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json[:count]).to eq 2
+        expect(response.parsed_body[:count]).to eq 2
       end
     end
 
@@ -56,7 +56,7 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json[:count]).to eq 4
+        expect(response.parsed_body[:count]).to eq 4
       end
     end
 
@@ -67,7 +67,7 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json[:count]).to eq 2
+        expect(response.parsed_body[:count]).to eq 2
       end
     end
 
@@ -80,7 +80,7 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json[:count]).to eq Api::V1::NotificationsController::DEFAULT_NOTIFICATIONS_COUNT_LIMIT
+        expect(response.parsed_body[:count]).to eq Api::V1::NotificationsController::DEFAULT_NOTIFICATIONS_COUNT_LIMIT
       end
     end
   end
@@ -111,9 +111,9 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json.size).to eq 5
+        expect(response.parsed_body.size).to eq 5
         expect(body_json_types).to include('reblog', 'mention', 'favourite', 'follow')
-        expect(body_as_json.any? { |x| x[:filtered] }).to be false
+        expect(response.parsed_body.any? { |x| x[:filtered] }).to be false
       end
     end
 
@@ -124,9 +124,9 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json.size).to eq 6
+        expect(response.parsed_body.size).to eq 6
         expect(body_json_types).to include('reblog', 'mention', 'favourite', 'follow')
-        expect(body_as_json.any? { |x| x[:filtered] }).to be true
+        expect(response.parsed_body.any? { |x| x[:filtered] }).to be true
       end
     end
 
@@ -141,7 +141,7 @@ RSpec.describe 'Notifications' do
       end
 
       def body_json_account_ids
-        body_as_json.map { |x| x[:account][:id] }
+        response.parsed_body.map { |x| x[:account][:id] }
       end
     end
 
@@ -152,7 +152,7 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json.size).to eq 0
+        expect(response.parsed_body.size).to eq 0
       end
     end
 
@@ -163,7 +163,7 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json.size).to_not eq 0
+        expect(response.parsed_body.size).to_not eq 0
         expect(body_json_types.uniq).to_not include 'mention'
       end
     end
@@ -187,7 +187,7 @@ RSpec.describe 'Notifications' do
 
         notifications = user.account.notifications.browserable.order(id: :asc)
 
-        expect(body_as_json.size)
+        expect(response.parsed_body.size)
           .to eq(params[:limit])
 
         expect(response)
@@ -199,7 +199,7 @@ RSpec.describe 'Notifications' do
     end
 
     def body_json_types
-      body_as_json.pluck(:type)
+      response.parsed_body.pluck(:type)
     end
   end
 

--- a/spec/requests/api/v1/peers/search_spec.rb
+++ b/spec/requests/api/v1/peers/search_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'API Peers Search' do
 
         expect(response)
           .to have_http_status(200)
-        expect(body_as_json)
+        expect(response.parsed_body)
           .to be_blank
       end
     end
@@ -34,7 +34,7 @@ RSpec.describe 'API Peers Search' do
 
         expect(response)
           .to have_http_status(200)
-        expect(body_as_json)
+        expect(response.parsed_body)
           .to be_blank
       end
     end
@@ -49,9 +49,9 @@ RSpec.describe 'API Peers Search' do
 
         expect(response)
           .to have_http_status(200)
-        expect(body_as_json.size)
+        expect(response.parsed_body.size)
           .to eq(1)
-        expect(body_as_json.first)
+        expect(response.parsed_body.first)
           .to eq(account.domain)
       end
     end

--- a/spec/requests/api/v1/polls_spec.rb
+++ b/spec/requests/api/v1/polls_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Polls' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json).to match(
+        expect(response.parsed_body).to match(
           a_hash_including(
             id: poll.id.to_s,
             voted: false,

--- a/spec/requests/api/v1/preferences_spec.rb
+++ b/spec/requests/api/v1/preferences_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'Preferences' do
         expect(response)
           .to have_http_status(200)
 
-        expect(body_as_json)
+        expect(response.parsed_body)
           .to be_present
       end
     end

--- a/spec/requests/api/v1/push/subscriptions_spec.rb
+++ b/spec/requests/api/v1/push/subscriptions_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe 'API V1 Push Subscriptions' do
           access_token_id: eq(token.id)
         )
 
-      expect(body_as_json.with_indifferent_access)
+      expect(response.parsed_body.with_indifferent_access)
         .to include(
           { endpoint: create_payload[:subscription][:endpoint], alerts: {}, policy: 'all' }
         )
@@ -124,7 +124,7 @@ RSpec.describe 'API V1 Push Subscriptions' do
         )
       end
 
-      expect(body_as_json.with_indifferent_access)
+      expect(response.parsed_body.with_indifferent_access)
         .to include(
           endpoint: create_payload[:subscription][:endpoint],
           alerts: alerts_payload[:data][:alerts],

--- a/spec/requests/api/v1/reports_spec.rb
+++ b/spec/requests/api/v1/reports_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Reports' do
       emails = capture_emails { subject }
 
       expect(response).to have_http_status(200)
-      expect(body_as_json).to match(
+      expect(response.parsed_body).to match(
         a_hash_including(
           status_ids: [status.id.to_s],
           category: category,

--- a/spec/requests/api/v1/scheduled_status_spec.rb
+++ b/spec/requests/api/v1/scheduled_status_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe 'Scheduled Statuses' do
           expect(response)
             .to have_http_status(200)
 
-          expect(body_as_json)
+          expect(response.parsed_body)
             .to_not be_present
         end
       end
@@ -60,7 +60,7 @@ RSpec.describe 'Scheduled Statuses' do
           expect(response)
             .to have_http_status(200)
 
-          expect(body_as_json)
+          expect(response.parsed_body)
             .to be_present
             .and have_attributes(
               first: include(id: scheduled_status.id.to_s)

--- a/spec/requests/api/v1/statuses/bookmarks_spec.rb
+++ b/spec/requests/api/v1/statuses/bookmarks_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Bookmarks' do
       it 'returns json with updated attributes' do
         subject
 
-        expect(body_as_json).to match(
+        expect(response.parsed_body).to match(
           a_hash_including(id: status.id.to_s, bookmarked: true)
         )
       end
@@ -103,7 +103,7 @@ RSpec.describe 'Bookmarks' do
         it 'returns json with updated attributes' do
           subject
 
-          expect(body_as_json).to match(
+          expect(response.parsed_body).to match(
             a_hash_including(id: status.id.to_s, bookmarked: false)
           )
         end
@@ -127,7 +127,7 @@ RSpec.describe 'Bookmarks' do
         it 'returns json with updated attributes' do
           subject
 
-          expect(body_as_json).to match(
+          expect(response.parsed_body).to match(
             a_hash_including(id: status.id.to_s, bookmarked: false)
           )
         end

--- a/spec/requests/api/v1/statuses/favourited_by_accounts_spec.rb
+++ b/spec/requests/api/v1/statuses/favourited_by_accounts_spec.rb
@@ -34,9 +34,9 @@ RSpec.describe 'API V1 Statuses Favourited by Accounts' do
             next: api_v1_status_favourited_by_index_url(limit: 2, max_id: Favourite.first.id)
           )
 
-        expect(body_as_json.size)
+        expect(response.parsed_body.size)
           .to eq(2)
-        expect(body_as_json)
+        expect(response.parsed_body)
           .to contain_exactly(
             include(id: alice.id.to_s),
             include(id: bob.id.to_s)
@@ -48,9 +48,9 @@ RSpec.describe 'API V1 Statuses Favourited by Accounts' do
 
         subject
 
-        expect(body_as_json.size)
+        expect(response.parsed_body.size)
           .to eq 1
-        expect(body_as_json.first[:id]).to eq(alice.id.to_s)
+        expect(response.parsed_body.first[:id]).to eq(alice.id.to_s)
       end
     end
   end

--- a/spec/requests/api/v1/statuses/favourites_spec.rb
+++ b/spec/requests/api/v1/statuses/favourites_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Favourites', :inline_jobs do
       it 'returns json with updated attributes' do
         subject
 
-        expect(body_as_json).to match(
+        expect(response.parsed_body).to match(
           a_hash_including(id: status.id.to_s, favourites_count: 1, favourited: true)
         )
       end
@@ -95,7 +95,7 @@ RSpec.describe 'Favourites', :inline_jobs do
       it 'returns json with updated attributes' do
         subject
 
-        expect(body_as_json).to match(
+        expect(response.parsed_body).to match(
           a_hash_including(id: status.id.to_s, favourites_count: 0, favourited: false)
         )
       end
@@ -118,7 +118,7 @@ RSpec.describe 'Favourites', :inline_jobs do
       it 'returns json with updated attributes' do
         subject
 
-        expect(body_as_json).to match(
+        expect(response.parsed_body).to match(
           a_hash_including(id: status.id.to_s, favourites_count: 0, favourited: false)
         )
       end

--- a/spec/requests/api/v1/statuses/histories_spec.rb
+++ b/spec/requests/api/v1/statuses/histories_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'API V1 Statuses Histories' do
 
       it 'returns http success' do
         expect(response).to have_http_status(200)
-        expect(body_as_json.size).to_not be 0
+        expect(response.parsed_body.size).to_not be 0
       end
     end
   end

--- a/spec/requests/api/v1/statuses/pins_spec.rb
+++ b/spec/requests/api/v1/statuses/pins_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Pins' do
       it 'return json with updated attributes' do
         subject
 
-        expect(body_as_json).to match(
+        expect(response.parsed_body).to match(
           a_hash_including(id: status.id.to_s, pinned: true)
         )
       end
@@ -96,7 +96,7 @@ RSpec.describe 'Pins' do
       it 'return json with updated attributes' do
         subject
 
-        expect(body_as_json).to match(
+        expect(response.parsed_body).to match(
           a_hash_including(id: status.id.to_s, pinned: false)
         )
       end

--- a/spec/requests/api/v1/statuses/reblogged_by_accounts_spec.rb
+++ b/spec/requests/api/v1/statuses/reblogged_by_accounts_spec.rb
@@ -33,9 +33,9 @@ RSpec.describe 'API V1 Statuses Reblogged by Accounts' do
             next: api_v1_status_reblogged_by_index_url(limit: 2, max_id: alice.statuses.first.id)
           )
 
-        expect(body_as_json.size)
+        expect(response.parsed_body.size)
           .to eq(2)
-        expect(body_as_json)
+        expect(response.parsed_body)
           .to contain_exactly(
             include(id: alice.id.to_s),
             include(id: bob.id.to_s)
@@ -47,9 +47,9 @@ RSpec.describe 'API V1 Statuses Reblogged by Accounts' do
 
         subject
 
-        expect(body_as_json.size)
+        expect(response.parsed_body.size)
           .to eq 1
-        expect(body_as_json.first[:id]).to eq(alice.id.to_s)
+        expect(response.parsed_body.first[:id]).to eq(alice.id.to_s)
       end
     end
   end

--- a/spec/requests/api/v1/statuses/reblogs_spec.rb
+++ b/spec/requests/api/v1/statuses/reblogs_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'API V1 Statuses Reblogs' do
 
           expect(user.account.reblogged?(status)).to be true
 
-          expect(body_as_json)
+          expect(response.parsed_body)
             .to include(
               reblog: include(
                 id: status.id.to_s,
@@ -60,7 +60,7 @@ RSpec.describe 'API V1 Statuses Reblogs' do
 
           expect(user.account.reblogged?(status)).to be false
 
-          expect(body_as_json)
+          expect(response.parsed_body)
             .to include(
               id: status.id.to_s,
               reblogs_count: 0,
@@ -85,7 +85,7 @@ RSpec.describe 'API V1 Statuses Reblogs' do
 
           expect(user.account.reblogged?(status)).to be false
 
-          expect(body_as_json)
+          expect(response.parsed_body)
             .to include(
               id: status.id.to_s,
               reblogs_count: 0,

--- a/spec/requests/api/v1/statuses/sources_spec.rb
+++ b/spec/requests/api/v1/statuses/sources_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Sources' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json).to match({
+        expect(response.parsed_body).to match({
           id: status.id.to_s,
           text: status.text,
           spoiler_text: status.spoiler_text,
@@ -51,7 +51,7 @@ RSpec.describe 'Sources' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json).to match({
+        expect(response.parsed_body).to match({
           id: status.id.to_s,
           text: status.text,
           spoiler_text: status.spoiler_text,

--- a/spec/requests/api/v1/statuses_spec.rb
+++ b/spec/requests/api/v1/statuses_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe '/api/v1/statuses' do
         get '/api/v1/statuses', headers: headers, params: { id: [status.id, other_status.id, 123_123] }
 
         expect(response).to have_http_status(200)
-        expect(body_as_json).to contain_exactly(
+        expect(response.parsed_body).to contain_exactly(
           hash_including(id: status.id.to_s),
           hash_including(id: other_status.id.to_s)
         )
@@ -52,7 +52,7 @@ RSpec.describe '/api/v1/statuses' do
           subject
 
           expect(response).to have_http_status(200)
-          expect(body_as_json[:filtered][0]).to include({
+          expect(response.parsed_body[:filtered][0]).to include({
             filter: a_hash_including({
               id: user.account.custom_filters.first.id.to_s,
               title: 'filter1',
@@ -75,7 +75,7 @@ RSpec.describe '/api/v1/statuses' do
           subject
 
           expect(response).to have_http_status(200)
-          expect(body_as_json[:filtered][0]).to include({
+          expect(response.parsed_body[:filtered][0]).to include({
             filter: a_hash_including({
               id: user.account.custom_filters.first.id.to_s,
               title: 'filter1',
@@ -97,7 +97,7 @@ RSpec.describe '/api/v1/statuses' do
           subject
 
           expect(response).to have_http_status(200)
-          expect(body_as_json[:reblog][:filtered][0]).to include({
+          expect(response.parsed_body[:reblog][:filtered][0]).to include({
             filter: a_hash_including({
               id: user.account.custom_filters.first.id.to_s,
               title: 'filter1',
@@ -154,7 +154,7 @@ RSpec.describe '/api/v1/statuses' do
           subject
 
           expect(response).to have_http_status(422)
-          expect(body_as_json[:unexpected_accounts].map { |a| a.slice(:id, :acct) }).to match [{ id: bob.id.to_s, acct: bob.acct }]
+          expect(response.parsed_body[:unexpected_accounts].map { |a| a.slice(:id, :acct) }).to match [{ id: bob.id.to_s, acct: bob.acct }]
         end
       end
 

--- a/spec/requests/api/v1/suggestions_spec.rb
+++ b/spec/requests/api/v1/suggestions_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'Suggestions' do
     it 'returns accounts' do
       subject
 
-      expect(body_as_json)
+      expect(response.parsed_body)
         .to contain_exactly(include(id: bob.id.to_s), include(id: jeff.id.to_s))
     end
 
@@ -42,7 +42,7 @@ RSpec.describe 'Suggestions' do
       it 'returns only the requested number of accounts' do
         subject
 
-        expect(body_as_json.size).to eq 1
+        expect(response.parsed_body.size).to eq 1
       end
     end
 

--- a/spec/requests/api/v1/tags_spec.rb
+++ b/spec/requests/api/v1/tags_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Tags' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json[:name]).to eq(name)
+        expect(response.parsed_body[:name]).to eq(name)
       end
     end
 

--- a/spec/requests/api/v1/timelines/home_spec.rb
+++ b/spec/requests/api/v1/timelines/home_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'Home', :inline_jobs do
       it 'returns the statuses of followed users' do
         subject
 
-        expect(body_as_json.pluck(:id)).to match_array(home_statuses.map { |status| status.id.to_s })
+        expect(response.parsed_body.pluck(:id)).to match_array(home_statuses.map { |status| status.id.to_s })
       end
 
       context 'with limit param' do
@@ -49,7 +49,7 @@ RSpec.describe 'Home', :inline_jobs do
         it 'returns only the requested number of statuses' do
           subject
 
-          expect(body_as_json.size).to eq(params[:limit])
+          expect(response.parsed_body.size).to eq(params[:limit])
         end
 
         it 'sets the correct pagination headers', :aggregate_failures do

--- a/spec/requests/api/v1/timelines/link_spec.rb
+++ b/spec/requests/api/v1/timelines/link_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Link' do
       subject
 
       expect(response).to have_http_status(200)
-      expect(body_as_json.pluck(:id)).to match_array(expected_statuses.map { |status| status.id.to_s })
+      expect(response.parsed_body.pluck(:id)).to match_array(expected_statuses.map { |status| status.id.to_s })
     end
   end
 
@@ -127,7 +127,7 @@ RSpec.describe 'Link' do
           subject
 
           expect(response).to have_http_status(200)
-          expect(body_as_json.size).to eq(params[:limit])
+          expect(response.parsed_body.size).to eq(params[:limit])
         end
 
         it 'sets the correct pagination headers', :aggregate_failures do

--- a/spec/requests/api/v1/timelines/public_spec.rb
+++ b/spec/requests/api/v1/timelines/public_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Public' do
       subject
 
       expect(response).to have_http_status(200)
-      expect(body_as_json.pluck(:id)).to match_array(expected_statuses.map { |status| status.id.to_s })
+      expect(response.parsed_body.pluck(:id)).to match_array(expected_statuses.map { |status| status.id.to_s })
     end
   end
 
@@ -81,7 +81,7 @@ RSpec.describe 'Public' do
           subject
 
           expect(response).to have_http_status(200)
-          expect(body_as_json.size).to eq(params[:limit])
+          expect(response.parsed_body.size).to eq(params[:limit])
         end
 
         it 'sets the correct pagination headers', :aggregate_failures do

--- a/spec/requests/api/v1/timelines/tag_spec.rb
+++ b/spec/requests/api/v1/timelines/tag_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Tag' do
 
         expect(response)
           .to have_http_status(200)
-        expect(body_as_json.pluck(:id))
+        expect(response.parsed_body.pluck(:id))
           .to match_array(expected_statuses.map { |status| status.id.to_s })
           .and not_include(private_status.id)
       end
@@ -70,7 +70,7 @@ RSpec.describe 'Tag' do
       it 'returns only the requested number of statuses' do
         subject
 
-        expect(body_as_json.size).to eq(params[:limit])
+        expect(response.parsed_body.size).to eq(params[:limit])
       end
 
       it 'sets the correct pagination headers', :aggregate_failures do

--- a/spec/requests/api/v2/admin/accounts_spec.rb
+++ b/spec/requests/api/v2/admin/accounts_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe 'API V2 Admin Accounts' do
     end
 
     def body_json_ids
-      body_as_json.map { |a| a[:id].to_i }
+      response.parsed_body.map { |a| a[:id].to_i }
     end
 
     context 'with limit param' do

--- a/spec/requests/api/v2/filters/keywords_spec.rb
+++ b/spec/requests/api/v2/filters/keywords_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'API V2 Filters Keywords' do
     it 'returns http success' do
       get "/api/v2/filters/#{filter.id}/keywords", headers: headers
       expect(response).to have_http_status(200)
-      expect(body_as_json)
+      expect(response.parsed_body)
         .to contain_exactly(
           include(id: keyword.id.to_s)
         )
@@ -42,7 +42,7 @@ RSpec.describe 'API V2 Filters Keywords' do
     it 'creates a filter', :aggregate_failures do
       expect(response).to have_http_status(200)
 
-      expect(body_as_json)
+      expect(response.parsed_body)
         .to include(
           keyword: 'magic',
           whole_word: false
@@ -73,7 +73,7 @@ RSpec.describe 'API V2 Filters Keywords' do
     it 'responds with the keyword', :aggregate_failures do
       expect(response).to have_http_status(200)
 
-      expect(body_as_json)
+      expect(response.parsed_body)
         .to include(
           keyword: 'foo',
           whole_word: false

--- a/spec/requests/api/v2/filters/statuses_spec.rb
+++ b/spec/requests/api/v2/filters/statuses_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'API V2 Filters Statuses' do
     it 'returns http success' do
       get "/api/v2/filters/#{filter.id}/statuses", headers: headers
       expect(response).to have_http_status(200)
-      expect(body_as_json)
+      expect(response.parsed_body)
         .to contain_exactly(
           include(id: status_filter.id.to_s)
         )
@@ -43,7 +43,7 @@ RSpec.describe 'API V2 Filters Statuses' do
     it 'creates a filter', :aggregate_failures do
       expect(response).to have_http_status(200)
 
-      expect(body_as_json)
+      expect(response.parsed_body)
         .to include(
           status_id: status.id.to_s
         )
@@ -73,7 +73,7 @@ RSpec.describe 'API V2 Filters Statuses' do
     it 'responds with the filter', :aggregate_failures do
       expect(response).to have_http_status(200)
 
-      expect(body_as_json)
+      expect(response.parsed_body)
         .to include(
           status_id: status_filter.status.id.to_s
         )

--- a/spec/requests/api/v2/filters_spec.rb
+++ b/spec/requests/api/v2/filters_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'Filters' do
       subject
 
       expect(response).to have_http_status(200)
-      expect(body_as_json.pluck(:id)).to match_array(filters.map { |filter| filter.id.to_s })
+      expect(response.parsed_body.pluck(:id)).to match_array(filters.map { |filter| filter.id.to_s })
     end
   end
 
@@ -58,7 +58,7 @@ RSpec.describe 'Filters' do
       it 'returns a filter with keywords', :aggregate_failures do
         subject
 
-        expect(body_as_json)
+        expect(response.parsed_body)
           .to include(
             title: 'magic',
             filter_action: 'hide',
@@ -127,7 +127,10 @@ RSpec.describe 'Filters' do
       subject
 
       expect(response).to have_http_status(200)
-      expect(body_as_json[:id]).to eq(filter.id.to_s)
+      expect(response.parsed_body)
+        .to include(
+          id: filter.id.to_s
+        )
     end
 
     context 'when the filter belongs to someone else' do

--- a/spec/requests/api/v2/instance_spec.rb
+++ b/spec/requests/api/v2/instance_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Instances' do
         expect(response)
           .to have_http_status(200)
 
-        expect(body_as_json)
+        expect(response.parsed_body)
           .to be_present
           .and include(title: 'Mastodon')
           .and include_api_versions
@@ -30,7 +30,7 @@ RSpec.describe 'Instances' do
         expect(response)
           .to have_http_status(200)
 
-        expect(body_as_json)
+        expect(response.parsed_body)
           .to be_present
           .and include(title: 'Mastodon')
           .and include_api_versions

--- a/spec/requests/api/v2/media_spec.rb
+++ b/spec/requests/api/v2/media_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Media API', :attachment_processing do
         expect(response)
           .to have_http_status(200)
 
-        expect(body_as_json)
+        expect(response.parsed_body)
           .to be_a(Hash)
       end
     end
@@ -38,7 +38,7 @@ RSpec.describe 'Media API', :attachment_processing do
         expect(response)
           .to have_http_status(202)
 
-        expect(body_as_json)
+        expect(response.parsed_body)
           .to be_a(Hash)
       end
     end
@@ -63,7 +63,7 @@ RSpec.describe 'Media API', :attachment_processing do
           expect(response)
             .to have_http_status(422)
 
-          expect(body_as_json)
+          expect(response.parsed_body)
             .to be_a(Hash)
             .and include(error: /File type/)
         end
@@ -80,7 +80,7 @@ RSpec.describe 'Media API', :attachment_processing do
           expect(response)
             .to have_http_status(500)
 
-          expect(body_as_json)
+          expect(response.parsed_body)
             .to be_a(Hash)
             .and include(error: /processing/)
         end

--- a/spec/requests/api/v2/notifications/policies_spec.rb
+++ b/spec/requests/api/v2/notifications/policies_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Policies' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json).to include(
+        expect(response.parsed_body).to include(
           for_not_following: 'accept',
           for_not_followers: 'accept',
           for_new_accounts: 'accept',
@@ -56,7 +56,7 @@ RSpec.describe 'Policies' do
         .and change { NotificationPolicy.find_or_initialize_by(account: user.account).for_limited_accounts.to_sym }.from(:filter).to(:drop)
 
       expect(response).to have_http_status(200)
-      expect(body_as_json).to include(
+      expect(response.parsed_body).to include(
         for_not_following: 'filter',
         for_not_followers: 'accept',
         for_new_accounts: 'accept',

--- a/spec/requests/api/v2/search_spec.rb
+++ b/spec/requests/api/v2/search_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Search API' do
         it 'returns all matching accounts' do
           get '/api/v2/search', headers: headers, params: params
 
-          expect(body_as_json[:accounts].pluck(:id)).to contain_exactly(bob.id.to_s, ana.id.to_s, tom.id.to_s)
+          expect(response.parsed_body[:accounts].pluck(:id)).to contain_exactly(bob.id.to_s, ana.id.to_s, tom.id.to_s)
         end
 
         context 'with truthy `resolve`' do
@@ -80,7 +80,7 @@ RSpec.describe 'Search API' do
           it 'returns only the followed accounts' do
             get '/api/v2/search', headers: headers, params: params
 
-            expect(body_as_json[:accounts].pluck(:id)).to contain_exactly(ana.id.to_s)
+            expect(response.parsed_body[:accounts].pluck(:id)).to contain_exactly(ana.id.to_s)
           end
         end
       end

--- a/spec/requests/api/v2/suggestions_spec.rb
+++ b/spec/requests/api/v2/suggestions_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Suggestions API' do
 
       expect(response).to have_http_status(200)
 
-      expect(body_as_json).to match_array(
+      expect(response.parsed_body).to match_array(
         [bob, jeff].map do |account|
           hash_including({
             source: 'staff',

--- a/spec/requests/api/v2_alpha/notifications/accounts_spec.rb
+++ b/spec/requests/api/v2_alpha/notifications/accounts_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'Accounts in grouped notifications' do
 
       # The group we are interested in is only favorites
       notifications = user.account.notifications.where(type: 'favourite').reorder(id: :desc)
-      expect(body_as_json).to match(
+      expect(response.parsed_body).to match(
         [
           a_hash_including(
             id: notifications.first.from_account_id.to_s
@@ -58,7 +58,7 @@ RSpec.describe 'Accounts in grouped notifications' do
 
         # The group we are interested in is only favorites
         notifications = user.account.notifications.where(type: 'favourite').reorder(id: :desc)
-        expect(body_as_json).to match(
+        expect(response.parsed_body).to match(
           [
             a_hash_including(
               id: notifications.first.from_account_id.to_s

--- a/spec/requests/api/v2_alpha/notifications_spec.rb
+++ b/spec/requests/api/v2_alpha/notifications_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json[:count]).to eq 4
+        expect(response.parsed_body[:count]).to eq 4
       end
     end
 
@@ -42,7 +42,7 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json[:count]).to eq 5
+        expect(response.parsed_body[:count]).to eq 5
       end
     end
 
@@ -56,7 +56,7 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json[:count]).to eq 2
+        expect(response.parsed_body[:count]).to eq 2
       end
     end
 
@@ -67,7 +67,7 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json[:count]).to eq 3
+        expect(response.parsed_body[:count]).to eq 3
       end
     end
 
@@ -78,7 +78,7 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json[:count]).to eq 2
+        expect(response.parsed_body[:count]).to eq 2
       end
     end
 
@@ -91,7 +91,7 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json[:count]).to eq Api::V2Alpha::NotificationsController::DEFAULT_NOTIFICATIONS_COUNT_LIMIT
+        expect(response.parsed_body[:count]).to eq Api::V2Alpha::NotificationsController::DEFAULT_NOTIFICATIONS_COUNT_LIMIT
       end
     end
   end
@@ -125,7 +125,7 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json[:notification_groups]).to eq []
+        expect(response.parsed_body[:notification_groups]).to eq []
       end
     end
 
@@ -145,7 +145,7 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json[:notification_groups]).to contain_exactly(
+        expect(response.parsed_body[:notification_groups]).to contain_exactly(
           a_hash_including(
             type: 'reblog',
             sample_account_ids: [bob.account_id.to_s]
@@ -177,7 +177,7 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json.size).to_not eq 0
+        expect(response.parsed_body.size).to_not eq 0
         expect(body_json_types.uniq).to_not include 'mention'
       end
     end
@@ -190,7 +190,7 @@ RSpec.describe 'Notifications' do
 
         expect(response).to have_http_status(200)
         expect(body_json_types.uniq).to eq ['mention']
-        expect(body_as_json.dig(:notification_groups, 0, :page_min_id)).to_not be_nil
+        expect(response.parsed_body.dig(:notification_groups, 0, :page_min_id)).to_not be_nil
       end
     end
 
@@ -201,7 +201,7 @@ RSpec.describe 'Notifications' do
       it 'returns the requested number of notifications paginated', :aggregate_failures do
         subject
 
-        expect(body_as_json[:notification_groups].size)
+        expect(response.parsed_body[:notification_groups].size)
           .to eq(params[:limit])
 
         expect(response)
@@ -221,7 +221,7 @@ RSpec.describe 'Notifications' do
       it 'returns the requested number of notifications paginated', :aggregate_failures do
         subject
 
-        expect(body_as_json[:notification_groups].size)
+        expect(response.parsed_body[:notification_groups].size)
           .to eq(2)
 
         expect(response)
@@ -247,10 +247,10 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(body_as_json[:partial_accounts].size).to be > 0
-        expect(body_as_json[:partial_accounts][0].keys.map(&:to_sym)).to contain_exactly(:acct, :avatar, :avatar_static, :bot, :id, :locked, :url)
-        expect(body_as_json[:partial_accounts].pluck(:id)).to_not include(recent_account.id.to_s)
-        expect(body_as_json[:accounts].pluck(:id)).to include(recent_account.id.to_s)
+        expect(response.parsed_body[:partial_accounts].size).to be > 0
+        expect(response.parsed_body[:partial_accounts][0].keys.map(&:to_sym)).to contain_exactly(:acct, :avatar, :avatar_static, :bot, :id, :locked, :url)
+        expect(response.parsed_body[:partial_accounts].pluck(:id)).to_not include(recent_account.id.to_s)
+        expect(response.parsed_body[:accounts].pluck(:id)).to include(recent_account.id.to_s)
       end
     end
 
@@ -265,7 +265,7 @@ RSpec.describe 'Notifications' do
     end
 
     def body_json_types
-      body_as_json[:notification_groups].pluck(:type)
+      response.parsed_body[:notification_groups].pluck(:type)
     end
   end
 

--- a/spec/requests/api/web/embeds_spec.rb
+++ b/spec/requests/api/web/embeds_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe '/api/web/embed' do
           subject
 
           expect(response).to have_http_status(200)
-          expect(body_as_json[:html]).to be_present
+          expect(response.parsed_body[:html]).to be_present
         end
       end
 
@@ -71,7 +71,7 @@ RSpec.describe '/api/web/embed' do
           subject
 
           expect(response).to have_http_status(200)
-          expect(body_as_json[:html]).to be_present
+          expect(response.parsed_body[:html]).to be_present
         end
 
         context 'when the requesting user is blocked' do
@@ -133,7 +133,7 @@ RSpec.describe '/api/web/embed' do
           subject
 
           expect(response).to have_http_status(200)
-          expect(body_as_json[:html]).to be_present
+          expect(response.parsed_body[:html]).to be_present
         end
       end
 

--- a/spec/requests/emojis_spec.rb
+++ b/spec/requests/emojis_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Emojis' do
 
       expect(response)
         .to have_http_status(200)
-      expect(body_as_json)
+      expect(response.parsed_body)
         .to include(
           name: ':coolcat:',
           type: 'Emoji'

--- a/spec/requests/instance_actor_spec.rb
+++ b/spec/requests/instance_actor_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Instance actor endpoint' do
           .and have_cacheable_headers
         expect(response.content_type)
           .to start_with('application/activity+json')
-        expect(body_as_json)
+        expect(response.parsed_body)
           .to include(
             id: instance_actor_url,
             type: 'Application',

--- a/spec/requests/invite_spec.rb
+++ b/spec/requests/invite_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'invites' do
       expect(response).to have_http_status(200)
       expect(response.media_type).to eq 'application/json'
 
-      expect(body_as_json[:invite_code]).to eq invite.code
+      expect(response.parsed_body[:invite_code]).to eq invite.code
     end
   end
 

--- a/spec/requests/log_out_spec.rb
+++ b/spec/requests/log_out_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'Log Out' do
       expect(response).to have_http_status(200)
       expect(response.media_type).to eq 'application/json'
 
-      expect(body_as_json[:redirect_to]).to eq '/auth/sign_in'
+      expect(response.parsed_body[:redirect_to]).to eq '/auth/sign_in'
     end
   end
 end

--- a/spec/requests/manifest_spec.rb
+++ b/spec/requests/manifest_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Manifest' do
         .and have_attributes(
           content_type: match('application/json')
         )
-      expect(body_as_json)
+      expect(response.parsed_body)
         .to include(
           id: '/home',
           name: 'Mastodon'

--- a/spec/requests/oauth/token_spec.rb
+++ b/spec/requests/oauth/token_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'Obtaining OAuth Tokens' do
           subject
 
           expect(response).to have_http_status(200)
-          expect(body_as_json[:scope]).to eq 'read write'
+          expect(response.parsed_body[:scope]).to eq 'read write'
         end
       end
 
@@ -76,7 +76,7 @@ RSpec.describe 'Obtaining OAuth Tokens' do
           subject
 
           expect(response).to have_http_status(200)
-          expect(body_as_json[:scope]).to eq('read')
+          expect(response.parsed_body[:scope]).to eq('read')
         end
       end
 
@@ -88,7 +88,7 @@ RSpec.describe 'Obtaining OAuth Tokens' do
             subject
 
             expect(response).to have_http_status(200)
-            expect(body_as_json[:scope]).to eq 'read write'
+            expect(response.parsed_body[:scope]).to eq 'read write'
           end
         end
 

--- a/spec/requests/signature_verification_spec.rb
+++ b/spec/requests/signature_verification_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'signature verification concern' do
       get '/activitypub/success'
 
       expect(response).to have_http_status(200)
-      expect(body_as_json).to match(
+      expect(response.parsed_body).to match(
         signed_request: false,
         signature_actor_id: nil,
         error: 'Request not signed'
@@ -62,7 +62,7 @@ RSpec.describe 'signature verification concern' do
         get '/activitypub/signature_required'
 
         expect(response).to have_http_status(401)
-        expect(body_as_json).to match(
+        expect(response.parsed_body).to match(
           error: 'Request not signed'
         )
       end
@@ -87,7 +87,7 @@ RSpec.describe 'signature verification concern' do
         }
 
         expect(response).to have_http_status(200)
-        expect(body_as_json).to match(
+        expect(response.parsed_body).to match(
           signed_request: true,
           signature_actor_id: actor.id.to_s
         )
@@ -109,7 +109,7 @@ RSpec.describe 'signature verification concern' do
         }
 
         expect(response).to have_http_status(200)
-        expect(body_as_json).to match(
+        expect(response.parsed_body).to match(
           signed_request: true,
           signature_actor_id: actor.id.to_s
         )
@@ -131,7 +131,7 @@ RSpec.describe 'signature verification concern' do
         }
 
         expect(response).to have_http_status(200)
-        expect(body_as_json).to match(
+        expect(response.parsed_body).to match(
           signed_request: true,
           signature_actor_id: actor.id.to_s
         )
@@ -152,7 +152,7 @@ RSpec.describe 'signature verification concern' do
           'Signature' => signature_header,
         }
 
-        expect(body_as_json).to match(
+        expect(response.parsed_body).to match(
           signed_request: true,
           signature_actor_id: nil,
           error: anything
@@ -168,7 +168,7 @@ RSpec.describe 'signature verification concern' do
           'Signature' => 'keyId="https://remote.domain/users/bob#main-key",algorithm="rsa-sha256",headers="date host (request-target)",signature="Z8ilar3J7bOwqZkMp7sL8sRs4B1FT+UorbmvWoE+A5UeoOJ3KBcUmbsh+k3wQwbP5gMNUrra9rEWabpasZGphLsbDxfbsWL3Cf0PllAc7c1c7AFEwnewtExI83/qqgEkfWc2z7UDutXc2NfgAx89Ox8DXU/fA2GG0jILjB6UpFyNugkY9rg6oI31UnvfVi3R7sr3/x8Ea3I9thPvqI2byF6cojknSpDAwYzeKdngX3TAQEGzFHz3SDWwyp3jeMWfwvVVbM38FxhvAnSumw7YwWW4L7M7h4M68isLimoT3yfCn2ucBVL5Dz8koBpYf/40w7QidClAwCafZQFC29yDOg=="', # rubocop:disable Layout/LineLength
         }
 
-        expect(body_as_json).to match(
+        expect(response.parsed_body).to match(
           signed_request: true,
           signature_actor_id: nil,
           error: anything
@@ -184,7 +184,7 @@ RSpec.describe 'signature verification concern' do
           'Signature' => 'keyId="https://remote.domain/users/bob#main-key",algorithm="rsa-sha256",headers="date host (request-target)",signature="Z8ilar3J7bOwqZkMp7sL8sRs4B1FT+UorbmvWoE+A5UeoOJ3KBcUmbsh+k3wQwbP5gMNUrra9rEWabpasZGphLsbDxfbsWL3Cf0PllAc7c1c7AFEwnewtExI83/qqgEkfWc2z7UDutXc2NfgAx89Ox8DXU/fA2GG0jILjB6UpFyNugkY9rg6oI31UnvfVi3R7sr3/x8Ea3I9thPvqI2byF6cojknSpDAwYzeKdngX3TAQEGzFHz3SDWwyp3jeMWfwvVVbM38FxhvAnSumw7YwWW4L7M7h4M68isLimoT3yfCn2ucBVL5Dz8koBpYf/40w7QidClAwCafZQFC29yDOg=="', # rubocop:disable Layout/LineLength
         }
 
-        expect(body_as_json).to match(
+        expect(response.parsed_body).to match(
           signed_request: true,
           signature_actor_id: nil,
           error: anything
@@ -206,7 +206,7 @@ RSpec.describe 'signature verification concern' do
           'Signature' => signature_header,
         }
 
-        expect(body_as_json).to match(
+        expect(response.parsed_body).to match(
           signed_request: true,
           signature_actor_id: nil,
           error: 'Invalid Date header: not RFC 2616 compliant date: "wrong date"'
@@ -228,7 +228,7 @@ RSpec.describe 'signature verification concern' do
           'Signature' => signature_header,
         }
 
-        expect(body_as_json).to match(
+        expect(response.parsed_body).to match(
           signed_request: true,
           signature_actor_id: nil,
           error: 'Signed request date outside acceptable time window'
@@ -254,7 +254,7 @@ RSpec.describe 'signature verification concern' do
         }
 
         expect(response).to have_http_status(200)
-        expect(body_as_json).to match(
+        expect(response.parsed_body).to match(
           signed_request: true,
           signature_actor_id: actor.id.to_s
         )
@@ -278,7 +278,7 @@ RSpec.describe 'signature verification concern' do
           'Signature' => signature_header,
         }
 
-        expect(body_as_json).to match(
+        expect(response.parsed_body).to match(
           signed_request: true,
           signature_actor_id: nil,
           error: 'Mastodon requires the Digest header to be signed when doing a POST request'
@@ -303,7 +303,7 @@ RSpec.describe 'signature verification concern' do
           'Signature' => signature_header,
         }
 
-        expect(body_as_json).to match(
+        expect(response.parsed_body).to match(
           signed_request: true,
           signature_actor_id: nil,
           error: 'Invalid Digest value. Computed SHA-256 digest: wFNeS+K3n/2TKRMFQ2v4iTFOSj+uwF7P/Lt98xrZ5Ro=; given: ZOyIygCyaOW6GjVnihtTFtIS9PNmskdyMlNKiuyjfzw='
@@ -321,7 +321,7 @@ RSpec.describe 'signature verification concern' do
         }
 
         expect(response).to have_http_status(200)
-        expect(body_as_json).to match(
+        expect(response.parsed_body).to match(
           signed_request: true,
           signature_actor_id: nil,
           error: anything
@@ -342,7 +342,7 @@ RSpec.describe 'signature verification concern' do
         'Signature' => 'keyId="https://remote.domain/users/alice#main-key",algorithm="rsa-sha256",headers="date host (request-target)",signature="Z8ilar3J7bOwqZkMp7sL8sRs4B1FT+UorbmvWoE+A5UeoOJ3KBcUmbsh+k3wQwbP5gMNUrra9rEWabpasZGphLsbDxfbsWL3Cf0PllAc7c1c7AFEwnewtExI83/qqgEkfWc2z7UDutXc2NfgAx89Ox8DXU/fA2GG0jILjB6UpFyNugkY9rg6oI31UnvfVi3R7sr3/x8Ea3I9thPvqI2byF6cojknSpDAwYzeKdngX3TAQEGzFHz3SDWwyp3jeMWfwvVVbM38FxhvAnSumw7YwWW4L7M7h4M68isLimoT3yfCn2ucBVL5Dz8koBpYf/40w7QidClAwCafZQFC29yDOg=="', # rubocop:disable Layout/LineLength
       }
 
-      expect(body_as_json).to match(
+      expect(response.parsed_body).to match(
         signed_request: true,
         signature_actor_id: nil,
         error: 'Unable to fetch key JSON at https://remote.domain/users/alice#main-key'

--- a/spec/requests/well_known/node_info_spec.rb
+++ b/spec/requests/well_known/node_info_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'The well-known node-info endpoints' do
           media_type: 'application/json'
         )
 
-      expect(body_as_json).to include(
+      expect(response.parsed_body).to include(
         links: be_an(Array).and(
           contain_exactly(
             include(
@@ -39,7 +39,7 @@ RSpec.describe 'The well-known node-info endpoints' do
       expect(non_matching_hash)
         .to_not match_json_schema('nodeinfo_2.0')
 
-      expect(body_as_json)
+      expect(response.parsed_body)
         .to match_json_schema('nodeinfo_2.0')
         .and include(
           version: '2.0',

--- a/spec/requests/well_known/oauth_metadata_spec.rb
+++ b/spec/requests/well_known/oauth_metadata_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'The /.well-known/oauth-authorization-server request' do
     grant_types_supported = Doorkeeper.configuration.grant_flows.dup
     grant_types_supported << 'refresh_token' if Doorkeeper.configuration.refresh_token_enabled?
 
-    expect(body_as_json).to include(
+    expect(response.parsed_body).to include(
       issuer: root_url(protocol: protocol),
       service_documentation: 'https://docs.joinmastodon.org/',
       authorization_endpoint: oauth_authorization_url(protocol: protocol),

--- a/spec/requests/well_known/webfinger_spec.rb
+++ b/spec/requests/well_known/webfinger_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'The /.well-known/webfinger endpoint' do
 
       expect(response.media_type).to eq 'application/jrd+json'
 
-      expect(body_as_json)
+      expect(response.parsed_body)
         .to include(
           subject: eq('acct:alice@cb6e6126.ngrok.io'),
           aliases: include('https://cb6e6126.ngrok.io/@alice', 'https://cb6e6126.ngrok.io/users/alice')
@@ -129,7 +129,7 @@ RSpec.describe 'The /.well-known/webfinger endpoint' do
     end
 
     it 'returns links for the internal account' do
-      expect(body_as_json)
+      expect(response.parsed_body)
         .to include(
           subject: 'acct:mastodon.internal@cb6e6126.ngrok.io',
           aliases: ['https://cb6e6126.ngrok.io/actor']
@@ -168,7 +168,7 @@ RSpec.describe 'The /.well-known/webfinger endpoint' do
     it 'returns avatar in response' do
       perform_request!
 
-      avatar_link = get_avatar_link(body_as_json)
+      avatar_link = get_avatar_link(response.parsed_body)
       expect(avatar_link).to_not be_nil
       expect(avatar_link[:type]).to eq alice.avatar.content_type
       expect(avatar_link[:href]).to eq Addressable::URI.new(host: Rails.configuration.x.local_domain, path: alice.avatar.to_s, scheme: 'https').to_s
@@ -182,7 +182,7 @@ RSpec.describe 'The /.well-known/webfinger endpoint' do
       it 'does not return avatar in response' do
         perform_request!
 
-        avatar_link = get_avatar_link(body_as_json)
+        avatar_link = get_avatar_link(response.parsed_body)
         expect(avatar_link).to be_nil
       end
     end
@@ -197,7 +197,7 @@ RSpec.describe 'The /.well-known/webfinger endpoint' do
       it 'does not return avatar in response' do
         perform_request!
 
-        avatar_link = get_avatar_link(body_as_json)
+        avatar_link = get_avatar_link(response.parsed_body)
         expect(avatar_link).to be_nil
       end
     end
@@ -212,7 +212,7 @@ RSpec.describe 'The /.well-known/webfinger endpoint' do
     end
 
     it 'does not return avatar in response' do
-      avatar_link = get_avatar_link(body_as_json)
+      avatar_link = get_avatar_link(response.parsed_body)
       expect(avatar_link).to be_nil
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,10 +34,6 @@ RSpec.configure do |config|
   end
 end
 
-def body_as_json
-  response.parsed_body
-end
-
 def serialized_record_json(record, serializer, adapter: nil)
   options = { serializer: serializer }
   options[:adapter] = adapter if adapter.present?


### PR DESCRIPTION
Follow up on https://github.com/mastodon/mastodon/pull/31696 and https://github.com/mastodon/mastodon/pull/31674

This is wrapping up the changes from the previous preparation PRs, actually removing the helper method, and updating specs to rely on the built-in framework response body parser.

This is large diff line count, but they are almost all utterly boring and doing the same thing.

For some of the multi-line repetitive blocks, I started to do some clean-up on these, but stopped in favor of just keeping the diff simplest. I may do a subsequent round of example cleanup where we do still have some repetitive multi line assertions (in favor of chaining). I may also review whether any of the xml/html responses would benefit from this memoized approach instead of custom parsing ... but there are many fewer of those type I think.