### PR TITLE
Use `response.parsed_body` for html response checks

### DIFF
--- a/spec/controllers/admin/accounts_controller_spec.rb
+++ b/spec/controllers/admin/accounts_controller_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Admin::AccountsController do
     end
 
     def accounts_table_rows
-      Nokogiri::Slop(response.body).css('table.accounts-table tr')
+      response.parsed_body.css('table.accounts-table tr')
     end
   end
 

--- a/spec/controllers/admin/export_domain_blocks_controller_spec.rb
+++ b/spec/controllers/admin/export_domain_blocks_controller_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Admin::ExportDomainBlocksController do
     end
 
     def batch_table_rows
-      Nokogiri::Slop(response.body).css('body div.batch-table__row')
+      response.parsed_body.css('body div.batch-table__row')
     end
   end
 

--- a/spec/controllers/admin/instances_controller_spec.rb
+++ b/spec/controllers/admin/instances_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Admin::InstancesController do
     end
 
     def instance_directory_links
-      Nokogiri::Slop(response.body).css('div.directory__tag a')
+      response.parsed_body.css('div.directory__tag a')
     end
   end
 

--- a/spec/controllers/auth/registrations_controller_spec.rb
+++ b/spec/controllers/auth/registrations_controller_spec.rb
@@ -342,7 +342,7 @@ RSpec.describe Auth::RegistrationsController do
       end
 
       def username_error_text
-        Nokogiri::Slop(response.body).css('.user_account_username .error').text
+        response.parsed_body.css('.user_account_username .error').text
       end
     end
 

--- a/spec/requests/account_show_page_spec.rb
+++ b/spec/requests/account_show_page_spec.rb
@@ -18,14 +18,16 @@ RSpec.describe 'The account show page' do
   end
 
   def head_link_icons
-    head_section.css('link[rel=icon]')
+    response
+      .parsed_body
+      .search('html head link[rel=icon]')
   end
 
   def head_meta_content(property)
-    head_section.meta("[@property='#{property}']")[:content]
-  end
-
-  def head_section
-    Nokogiri::Slop(response.body).html.head
+    response
+      .parsed_body
+      .search("html head meta[property='#{property}']")
+      .attr('content')
+      .text
   end
 end


### PR DESCRIPTION
Follow-up on https://github.com/mastodon/mastodon/pull/31749

Most of these are straight swap out, but our `Slop` usage in one of them was different enough than the built-in parser (`Nokogiri::HTML5` based on our settings) that the example needed a little update as well.

Some of these are called multiple times, so we probably get a small speed-up from the memoization here ... but it's such a small part of overall suite I didn't bother a measurement on it.