### PR TITLE
Use more accurate beginning/ending times in annual report source

### DIFF
--- a/app/lib/annual_report/source.rb
+++ b/app/lib/annual_report/source.rb
@@ -11,6 +11,16 @@ class AnnualReport::Source
   protected
 
   def year_as_snowflake_range
-    (Mastodon::Snowflake.id_at(DateTime.new(year, 1, 1))..Mastodon::Snowflake.id_at(DateTime.new(year, 12, 31)))
+    (beginning_snowflake_id..ending_snowflake_id)
+  end
+
+  private
+
+  def beginning_snowflake_id
+    Mastodon::Snowflake.id_at DateTime.new(year).beginning_of_year
+  end
+
+  def ending_snowflake_id
+    Mastodon::Snowflake.id_at DateTime.new(year).end_of_year
   end
 end


### PR DESCRIPTION
This doesn't change the calculated snowflake id for the beginning of the year, but it does change it a bit for the end of year by nudging the hours/mins all the way up to the very last second of the day. Before this any statuses made on the very last day of the year would not be in the query.


Example:

```
irb(main):002> test = DateTime.new(2024, 12, 31)
=> Tue, 31 Dec 2024 00:00:00 +0000
irb(main):003> tester = DateTime.new(2024).end_of_year
=> Tue, 31 Dec 2024 23:59:59 +0000
irb(main):004> Mastodon::Snowflake.id_at(test, with_random: false)
=> 113744491315200000
irb(main):005> Mastodon::Snowflake.id_at(tester, with_random: false)
=> 113750153560064000
irb(main):006> test = DateTime.new(2024, 1, 1)
=> Mon, 01 Jan 2024 00:00:00 +0000
irb(main):007> tester = DateTime.new(2024).beginning_of_year
=> Mon, 01 Jan 2024 00:00:00 +0000
```