### PR TITLE
Add `AnnualReport::Source#report_statuses` method for subclasses to use

### DIFF
--- a/app/lib/annual_report/archetype.rb
+++ b/app/lib/annual_report/archetype.rb
@@ -28,22 +28,18 @@ class AnnualReport::Archetype < AnnualReport::Source
   end
 
   def polls_count
-    @polls_count ||= base_scope.where.not(poll_id: nil).count
+    @polls_count ||= report_statuses.where.not(poll_id: nil).count
   end
 
   def reblogs_count
-    @reblogs_count ||= base_scope.where.not(reblog_of_id: nil).count
+    @reblogs_count ||= report_statuses.where.not(reblog_of_id: nil).count
   end
 
   def replies_count
-    @replies_count ||= base_scope.where.not(in_reply_to_id: nil).where.not(in_reply_to_account_id: @account.id).count
+    @replies_count ||= report_statuses.where.not(in_reply_to_id: nil).where.not(in_reply_to_account_id: @account.id).count
   end
 
   def standalone_count
-    @standalone_count ||= base_scope.without_replies.without_reblogs.count
-  end
-
-  def base_scope
-    @account.statuses.where(id: year_as_snowflake_range)
+    @standalone_count ||= report_statuses.without_replies.without_reblogs.count
   end
 end

--- a/app/lib/annual_report/commonly_interacted_with_accounts.rb
+++ b/app/lib/annual_report/commonly_interacted_with_accounts.rb
@@ -17,6 +17,6 @@ class AnnualReport::CommonlyInteractedWithAccounts < AnnualReport::Source
   private
 
   def commonly_interacted_with_accounts
-    @account.statuses.reorder(nil).where(id: year_as_snowflake_range).where.not(in_reply_to_account_id: @account.id).group(:in_reply_to_account_id).having('count(*) > 1').order(total: :desc).limit(SET_SIZE).pluck(Arel.sql('in_reply_to_account_id, count(*) AS total'))
+    report_statuses.where.not(in_reply_to_account_id: @account.id).group(:in_reply_to_account_id).having('count(*) > 1').order(total: :desc).limit(SET_SIZE).pluck(Arel.sql('in_reply_to_account_id, count(*) AS total'))
   end
 end

--- a/app/lib/annual_report/most_reblogged_accounts.rb
+++ b/app/lib/annual_report/most_reblogged_accounts.rb
@@ -17,6 +17,6 @@ class AnnualReport::MostRebloggedAccounts < AnnualReport::Source
   private
 
   def most_reblogged_accounts
-    @account.statuses.reorder(nil).where(id: year_as_snowflake_range).where.not(reblog_of_id: nil).joins(reblog: :account).group('accounts.id').having('count(*) > 1').order(total: :desc).limit(SET_SIZE).pluck(Arel.sql('accounts.id, count(*) as total'))
+    report_statuses.where.not(reblog_of_id: nil).joins(reblog: :account).group('accounts.id').having('count(*) > 1').order(total: :desc).limit(SET_SIZE).pluck(Arel.sql('accounts.id, count(*) as total'))
   end
 end

--- a/app/lib/annual_report/most_used_apps.rb
+++ b/app/lib/annual_report/most_used_apps.rb
@@ -17,6 +17,6 @@ class AnnualReport::MostUsedApps < AnnualReport::Source
   private
 
   def most_used_apps
-    @account.statuses.reorder(nil).where(id: year_as_snowflake_range).joins(:application).group('oauth_applications.name').order(total: :desc).limit(SET_SIZE).pluck(Arel.sql('oauth_applications.name, count(*) as total'))
+    report_statuses.joins(:application).group('oauth_applications.name').order(total: :desc).limit(SET_SIZE).pluck(Arel.sql('oauth_applications.name, count(*) as total'))
   end
 end

--- a/app/lib/annual_report/percentiles.rb
+++ b/app/lib/annual_report/percentiles.rb
@@ -17,7 +17,7 @@ class AnnualReport::Percentiles < AnnualReport::Source
   end
 
   def statuses_created
-    @statuses_created ||= @account.statuses.where(id: year_as_snowflake_range).count
+    @statuses_created ||= report_statuses.count
   end
 
   def total_with_fewer_followers

--- a/app/lib/annual_report/source.rb
+++ b/app/lib/annual_report/source.rb
@@ -10,6 +10,13 @@ class AnnualReport::Source
 
   protected
 
+  def report_statuses
+    @account
+      .statuses
+      .where(id: year_as_snowflake_range)
+      .reorder(nil)
+  end
+
   def year_as_snowflake_range
     (beginning_snowflake_id..ending_snowflake_id)
   end

--- a/app/lib/annual_report/time_series.rb
+++ b/app/lib/annual_report/time_series.rb
@@ -17,7 +17,7 @@ class AnnualReport::TimeSeries < AnnualReport::Source
   private
 
   def statuses_per_month
-    @statuses_per_month ||= @account.statuses.reorder(nil).where(id: year_as_snowflake_range).group(:period).pluck(Arel.sql("date_part('month', created_at)::int AS period, count(*)")).to_h
+    @statuses_per_month ||= report_statuses.group(:period).pluck(Arel.sql("date_part('month', created_at)::int AS period, count(*)")).to_h
   end
 
   def following_per_month

--- a/app/lib/annual_report/top_hashtags.rb
+++ b/app/lib/annual_report/top_hashtags.rb
@@ -17,6 +17,6 @@ class AnnualReport::TopHashtags < AnnualReport::Source
   private
 
   def top_hashtags
-    Tag.joins(:statuses).where(statuses: { id: @account.statuses.where(id: year_as_snowflake_range).reorder(nil).select(:id) }).group(:id).having('count(*) > 1').order(total: :desc).limit(SET_SIZE).pluck(Arel.sql('COALESCE(tags.display_name, tags.name), count(*) AS total'))
+    Tag.joins(:statuses).where(statuses: { id: report_statuses.select(:id) }).group(:id).having('count(*) > 1').order(total: :desc).limit(SET_SIZE).pluck(Arel.sql('COALESCE(tags.display_name, tags.name), count(*) AS total'))
   end
 end

--- a/app/lib/annual_report/top_statuses.rb
+++ b/app/lib/annual_report/top_statuses.rb
@@ -16,6 +16,6 @@ class AnnualReport::TopStatuses < AnnualReport::Source
   end
 
   def base_scope
-    @account.statuses.public_visibility.joins(:status_stat).where(id: year_as_snowflake_range).reorder(nil)
+    report_statuses.public_visibility.joins(:status_stat)
   end
 end

--- a/app/lib/annual_report/type_distribution.rb
+++ b/app/lib/annual_report/type_distribution.rb
@@ -4,17 +4,11 @@ class AnnualReport::TypeDistribution < AnnualReport::Source
   def generate
     {
       type_distribution: {
-        total: base_scope.count,
-        reblogs: base_scope.where.not(reblog_of_id: nil).count,
-        replies: base_scope.where.not(in_reply_to_id: nil).where.not(in_reply_to_account_id: @account.id).count,
-        standalone: base_scope.without_replies.without_reblogs.count,
+        total: report_statuses.count,
+        reblogs: report_statuses.where.not(reblog_of_id: nil).count,
+        replies: report_statuses.where.not(in_reply_to_id: nil).where.not(in_reply_to_account_id: @account.id).count,
+        standalone: report_statuses.without_replies.without_reblogs.count,
       },
     }
-  end
-
-  private
-
-  def base_scope
-    @account.statuses.where(id: year_as_snowflake_range)
   end
 end


### PR DESCRIPTION
The query of `@account.statuses.reorder(nil).where(id: year_as_snowflake_range)` is used in all the subclasses of `AnnualReport::Source`. Some of them have `base_scope` methods which capture this ... but they also all inherit from that `Source` class and do the same exact query, so it could live there instead.

There are more refactors available in this annual report section (re-using some existing scopes, DRY up the raw sql a bit, etc) ... but will probably just do this one for now, and hold off on anything more until a little more detailed coverage in place. Did https://github.com/mastodon/mastodon/pull/31704 as first pass, but will do more per-class spec with actual data detail and not just error free execution check.