### PR TITLE
Remove `before` block in spec with TODOs which have been TO-DONE already

### DIFF
--- a/spec/requests/instance_actor_spec.rb
+++ b/spec/requests/instance_actor_spec.rb
@@ -4,11 +4,6 @@ require 'rails_helper'
 
 RSpec.describe 'Instance actor endpoint' do
   describe 'GET /actor' do
-    before do
-      integration_session.https! # TODO: Move to global rails_helper for all request specs?
-      host! Rails.configuration.x.local_domain # TODO: Move to global rails_helper for all request specs?
-    end
-
     let!(:original_federation_mode) { Rails.configuration.x.limited_federation_mode }
 
     shared_examples 'instance actor endpoint' do


### PR DESCRIPTION
These were pulled out to `rails_helper` elsewhere already.