### PR TITLE
Remove references to deprecated `Import` model

### DIFF
--- a/app/views/settings/imports/index.html.haml
+++ b/app/views/settings/imports/index.html.haml
@@ -23,7 +23,7 @@
       = f.input :mode,
                 as: :radio_buttons,
                 collection_wrapper_tag: 'ul',
-                collection: Import::MODES,
+                collection: Form::Import::MODES,
                 item_wrapper_tag: 'li',
                 label_method: ->(mode) { safe_join([I18n.t("imports.modes.#{mode}"), content_tag(:span, I18n.t("imports.modes.#{mode}_long"), class: 'hint')]) }
 


### PR DESCRIPTION
Background: https://github.com/mastodon/mastodon/pull/30345#issuecomment-2328715051

The view change is in a form which already has a `Form::Import` as its object, so this one seems safe/sensible (the constant with same values exists in both classes).

The second one to paperclip config originates in https://github.com/mastodon/mastodon/pull/13835 ... the change is safe given its the same values, but its possible that when we do complete that deprecation/removal from linked PR that we can also delete this config entirely? (I'd need to look into more details of whether this mapping was needed for any upload at all and thus we still need it, or for the specific usage of the deprecated import class)