### PR TITLE
Change width of columns in advanced web UI

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2789,7 +2789,7 @@ $ui-header-logo-wordmark-width: 99px;
 }
 
 .column {
-  width: 350px;
+  width: 400px;
   position: relative;
   box-sizing: border-box;
   display: flex;
@@ -2822,7 +2822,7 @@ $ui-header-logo-wordmark-width: 99px;
 }
 
 .drawer {
-  width: 300px;
+  width: 350px;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Increases column width from 350px to 400px. Since our primary design target is the default web UI, it is getting trickier to design interfaces that work well in both layouts because of how much narrower content is in the advanced web UI. This is one approach to improve that by giving us a bit more space to work with.

![grafik](https://github.com/user-attachments/assets/b2d9d949-7ba8-4001-a8bd-c2bcf0eac01f)
