### PR TITLE
Add credentials to redis sentinel configuration

### DIFF
--- a/lib/mastodon/redis_configuration.rb
+++ b/lib/mastodon/redis_configuration.rb
@@ -57,15 +57,17 @@ class Mastodon::RedisConfiguration
   def setup_config(prefix: nil, defaults: {})
     prefix = "#{prefix}REDIS_"
 
-    url           = ENV.fetch("#{prefix}URL", nil)
-    user          = ENV.fetch("#{prefix}USER", nil)
-    password      = ENV.fetch("#{prefix}PASSWORD", nil)
-    host          = ENV.fetch("#{prefix}HOST", defaults[:host])
-    port          = ENV.fetch("#{prefix}PORT", defaults[:port])
-    db            = ENV.fetch("#{prefix}DB", defaults[:db])
-    name          = ENV.fetch("#{prefix}SENTINEL_MASTER", nil)
-    sentinel_port = ENV.fetch("#{prefix}SENTINEL_PORT", 26_379)
-    sentinel_list = ENV.fetch("#{prefix}SENTINELS", nil)
+    url               = ENV.fetch("#{prefix}URL", nil)
+    user              = ENV.fetch("#{prefix}USER", nil)
+    password          = ENV.fetch("#{prefix}PASSWORD", nil)
+    host              = ENV.fetch("#{prefix}HOST", defaults[:host])
+    port              = ENV.fetch("#{prefix}PORT", defaults[:port])
+    db                = ENV.fetch("#{prefix}DB", defaults[:db])
+    name              = ENV.fetch("#{prefix}SENTINEL_MASTER", nil)
+    sentinel_port     = ENV.fetch("#{prefix}SENTINEL_PORT", 26_379)
+    sentinel_list     = ENV.fetch("#{prefix}SENTINELS", nil)
+    sentinel_username = ENV.fetch("#{prefix}SENTINEL_USER", user)
+    sentinel_password = ENV.fetch("#{prefix}SENTINEL_PASSWORD", password)
 
     return { url:, driver: } if url
 
@@ -77,12 +79,14 @@ class Mastodon::RedisConfiguration
       db ||= 0
     else
       sentinels = nil
+      sentinel_username = nil
+      sentinel_password = nil
     end
 
     url = construct_uri(host, port, db, user, password)
 
     if url.present?
-      { url:, driver:, name:, sentinels: }
+      { url:, driver:, name:, sentinels:, sentinel_username:, sentinel_password: }
     else
       # Fall back to base config. This has defaults for the URL
       # so this cannot lead to an endless loop.

--- a/lib/mastodon/redis_configuration.rb
+++ b/lib/mastodon/redis_configuration.rb
@@ -57,40 +57,47 @@ class Mastodon::RedisConfiguration
   def setup_config(prefix: nil, defaults: {})
     prefix = "#{prefix}REDIS_"
 
-    url               = ENV.fetch("#{prefix}URL", nil)
-    user              = ENV.fetch("#{prefix}USER", nil)
-    password          = ENV.fetch("#{prefix}PASSWORD", nil)
-    host              = ENV.fetch("#{prefix}HOST", defaults[:host])
-    port              = ENV.fetch("#{prefix}PORT", defaults[:port])
-    db                = ENV.fetch("#{prefix}DB", defaults[:db])
-    name              = ENV.fetch("#{prefix}SENTINEL_MASTER", nil)
-    sentinel_port     = ENV.fetch("#{prefix}SENTINEL_PORT", 26_379)
-    sentinel_list     = ENV.fetch("#{prefix}SENTINELS", nil)
-    sentinel_username = ENV.fetch("#{prefix}SENTINEL_USER", user)
-    sentinel_password = ENV.fetch("#{prefix}SENTINEL_PASSWORD", password)
+    url      = ENV.fetch("#{prefix}URL", nil)
+    user     = ENV.fetch("#{prefix}USER", nil)
+    password = ENV.fetch("#{prefix}PASSWORD", nil)
+    host     = ENV.fetch("#{prefix}HOST", defaults[:host])
+    port     = ENV.fetch("#{prefix}PORT", defaults[:port])
+    db       = ENV.fetch("#{prefix}DB", defaults[:db])
 
     return { url:, driver: } if url
 
-    sentinels = parse_sentinels(sentinel_list, default_port: sentinel_port)
+    sentinel_options = setup_sentinels(prefix, default_user: user, default_password: password)
 
-    if name.present? && sentinels.present?
-      host = name
+    if sentinel_options.present?
+      host = sentinel_options[:name]
       port = nil
       db ||= 0
-    else
-      sentinels = nil
-      sentinel_username = nil
-      sentinel_password = nil
     end
 
     url = construct_uri(host, port, db, user, password)
 
     if url.present?
-      { url:, driver:, name:, sentinels:, sentinel_username:, sentinel_password: }
+      { url:, driver: }.merge(sentinel_options)
     else
-      # Fall back to base config. This has defaults for the URL
-      # so this cannot lead to an endless loop.
+      # Fall back to base config, which has defaults for the URL
+      # so this cannot lead to endless recursion.
       base
+    end
+  end
+
+  def setup_sentinels(prefix, default_user: nil, default_password: nil)
+    name              = ENV.fetch("#{prefix}SENTINEL_MASTER", nil)
+    sentinel_port     = ENV.fetch("#{prefix}SENTINEL_PORT", 26_379)
+    sentinel_list     = ENV.fetch("#{prefix}SENTINELS", nil)
+    sentinel_username = ENV.fetch("#{prefix}SENTINEL_USER", default_user)
+    sentinel_password = ENV.fetch("#{prefix}SENTINEL_PASSWORD", default_password)
+
+    sentinels = parse_sentinels(sentinel_list, default_port: sentinel_port)
+
+    if name.present? && sentinels.present?
+      { name:, sentinels:, sentinel_username:, sentinel_password: }
+    else
+      {}
     end
   end
 

--- a/lib/mastodon/redis_configuration.rb
+++ b/lib/mastodon/redis_configuration.rb
@@ -89,7 +89,7 @@ class Mastodon::RedisConfiguration
     name              = ENV.fetch("#{prefix}SENTINEL_MASTER", nil)
     sentinel_port     = ENV.fetch("#{prefix}SENTINEL_PORT", 26_379)
     sentinel_list     = ENV.fetch("#{prefix}SENTINELS", nil)
-    sentinel_username = ENV.fetch("#{prefix}SENTINEL_USER", default_user)
+    sentinel_username = ENV.fetch("#{prefix}SENTINEL_USERNAME", default_user)
     sentinel_password = ENV.fetch("#{prefix}SENTINEL_PASSWORD", default_password)
 
     sentinels = parse_sentinels(sentinel_list, default_port: sentinel_port)

--- a/spec/lib/mastodon/redis_configuration_spec.rb
+++ b/spec/lib/mastodon/redis_configuration_spec.rb
@@ -171,10 +171,6 @@ RSpec.describe Mastodon::RedisConfiguration do
           url: 'redis://localhost:6379/0',
           driver: :hiredis,
           namespace: nil,
-          name: nil,
-          sentinels: nil,
-          sentinel_username: nil,
-          sentinel_password: nil,
         })
       end
     end
@@ -207,10 +203,6 @@ RSpec.describe Mastodon::RedisConfiguration do
           url: 'redis://:testpass@redis.example.com:3333/3',
           driver: :hiredis,
           namespace: nil,
-          name: nil,
-          sentinels: nil,
-          sentinel_username: nil,
-          sentinel_password: nil,
         })
       end
     end
@@ -239,10 +231,6 @@ RSpec.describe Mastodon::RedisConfiguration do
         namespace: 'cache',
         expires_in: 10.minutes,
         connect_timeout: 5,
-        name: nil,
-        sentinels: nil,
-        sentinel_username: nil,
-        sentinel_password: nil,
         pool: {
           size: 5,
           timeout: 5,

--- a/spec/lib/mastodon/redis_configuration_spec.rb
+++ b/spec/lib/mastodon/redis_configuration_spec.rb
@@ -100,9 +100,26 @@ RSpec.describe Mastodon::RedisConfiguration do
         expect(subject[:url]).to eq 'redis://:testpass1@mainsentinel/0'
       end
 
+      it 'uses the redis password to authenticate with sentinels' do
+        expect(subject[:sentinel_password]).to eq 'testpass1'
+      end
+
       it 'includes the sentinel master name and list of sentinels' do
         expect(subject[:name]).to eq 'mainsentinel'
         expect(subject[:sentinels]).to contain_exactly({ host: '192.168.0.1', port: 3000 }, { host: '192.168.0.2', port: 4000 })
+      end
+
+      context "when giving dedicated credentials in `#{prefix}REDIS_SENTINEL_USER` and `#{prefix}REDIS_SENTINEL_PASSWORD`" do
+        around do |example|
+          ClimateControl.modify "#{prefix}REDIS_SENTINEL_USER": 'sentinel_user', "#{prefix}REDIS_SENTINEL_PASSWORD": 'sentinel_pass1' do
+            example.run
+          end
+        end
+
+        it 'uses the credential to authenticate with sentinels' do
+          expect(subject[:sentinel_username]).to eq 'sentinel_user'
+          expect(subject[:sentinel_password]).to eq 'sentinel_pass1'
+        end
       end
     end
 
@@ -156,6 +173,8 @@ RSpec.describe Mastodon::RedisConfiguration do
           namespace: nil,
           name: nil,
           sentinels: nil,
+          sentinel_username: nil,
+          sentinel_password: nil,
         })
       end
     end
@@ -190,6 +209,8 @@ RSpec.describe Mastodon::RedisConfiguration do
           namespace: nil,
           name: nil,
           sentinels: nil,
+          sentinel_username: nil,
+          sentinel_password: nil,
         })
       end
     end
@@ -220,6 +241,8 @@ RSpec.describe Mastodon::RedisConfiguration do
         connect_timeout: 5,
         name: nil,
         sentinels: nil,
+        sentinel_username: nil,
+        sentinel_password: nil,
         pool: {
           size: 5,
           timeout: 5,

--- a/spec/lib/mastodon/redis_configuration_spec.rb
+++ b/spec/lib/mastodon/redis_configuration_spec.rb
@@ -109,9 +109,9 @@ RSpec.describe Mastodon::RedisConfiguration do
         expect(subject[:sentinels]).to contain_exactly({ host: '192.168.0.1', port: 3000 }, { host: '192.168.0.2', port: 4000 })
       end
 
-      context "when giving dedicated credentials in `#{prefix}REDIS_SENTINEL_USER` and `#{prefix}REDIS_SENTINEL_PASSWORD`" do
+      context "when giving dedicated credentials in `#{prefix}REDIS_SENTINEL_USERNAME` and `#{prefix}REDIS_SENTINEL_PASSWORD`" do
         around do |example|
-          ClimateControl.modify "#{prefix}REDIS_SENTINEL_USER": 'sentinel_user', "#{prefix}REDIS_SENTINEL_PASSWORD": 'sentinel_pass1' do
+          ClimateControl.modify "#{prefix}REDIS_SENTINEL_USERNAME": 'sentinel_user', "#{prefix}REDIS_SENTINEL_PASSWORD": 'sentinel_pass1' do
             example.run
           end
         end


### PR DESCRIPTION
This should be the last missing piece for feature parity with the JS configuration of the streaming server.

(Sorry for delivering this in small pieces.)

This allows setting a username and/or password that is used to connect to the sentinels.

To be compatible with the JS implementation this will also use the redis username and password as fallback if no dedicated sentinel credentials are specified. This probably means we do not support mixed setups where redis itself requires authentication but the sentinels do not. I guess that is OK, though.

I also refactored this a little bit as the `#setup_config` method was already too big to begin with. I split this up with only a little success, but a nice side-effect is that configurations not using sentinel become more compact.