### PR TITLE
Use `conflicted` configuration for renovate rebase strategy

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,6 +7,7 @@
     ':prConcurrentLimitNone', // Remove limit for open PRs at any time.
     ':prHourlyLimit2', // Rate limit PR creation to a maximum of two per hour.
   ],
+  rebaseWhen: 'conflicted',
   minimumReleaseAge: '3', // Wait 3 days after the package has been published before upgrading it
   // packageRules order is important, they are applied from top to bottom and are merged,
   // meaning the most important ones must be at the bottom, for example grouping rules


### PR DESCRIPTION
The renovate PRs are currently rebasing themselves every time main is updated, even when they have no conflicts. This is gobbling up many CI minutes ... but also, with the merge queue enabled, the scenario this is protecting against seems like it's already protected against?

https://docs.renovatebot.com/configuration-options/#rebasewhen
