### PR TITLE
Extract `Account::AUTOMATED_ACTOR_TYPES` for "bot" actor_type values

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -75,6 +75,8 @@ class Account < ApplicationRecord
   DISPLAY_NAME_LENGTH_LIMIT = 30
   NOTE_LENGTH_LIMIT = 500
 
+  AUTOMATED_ACTOR_TYPES = %w(Application Service).freeze
+
   include Attachmentable # Load prior to Avatar & Header concerns
 
   include Account::Associations
@@ -127,7 +129,7 @@ class Account < ApplicationRecord
   scope :without_silenced, -> { where(silenced_at: nil) }
   scope :without_instance_actor, -> { where.not(id: INSTANCE_ACTOR_ID) }
   scope :recent, -> { reorder(id: :desc) }
-  scope :bots, -> { where(actor_type: %w(Application Service)) }
+  scope :bots, -> { where(actor_type: AUTOMATED_ACTOR_TYPES) }
   scope :groups, -> { where(actor_type: 'Group') }
   scope :alphabetic, -> { order(domain: :asc, username: :asc) }
   scope :matches_uri_prefix, ->(value) { where(arel_table[:uri].matches("#{sanitize_sql_like(value)}/%", false, true)).or(where(uri: value)) }
@@ -183,7 +185,7 @@ class Account < ApplicationRecord
   end
 
   def bot?
-    %w(Application Service).include? actor_type
+    AUTOMATED_ACTOR_TYPES.include?(actor_type)
   end
 
   def instance_actor?

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -130,6 +130,7 @@ class Account < ApplicationRecord
   scope :without_instance_actor, -> { where.not(id: INSTANCE_ACTOR_ID) }
   scope :recent, -> { reorder(id: :desc) }
   scope :bots, -> { where(actor_type: AUTOMATED_ACTOR_TYPES) }
+  scope :non_automated, -> { where.not(actor_type: AUTOMATED_ACTOR_TYPES) }
   scope :groups, -> { where(actor_type: 'Group') }
   scope :alphabetic, -> { order(domain: :asc, username: :asc) }
   scope :matches_uri_prefix, ->(value) { where(arel_table[:uri].matches("#{sanitize_sql_like(value)}/%", false, true)).or(where(uri: value)) }

--- a/lib/mastodon/cli/accounts.rb
+++ b/lib/mastodon/cli/accounts.rb
@@ -502,7 +502,7 @@ module Mastodon::CLI
       - not muted/blocked by us
     LONG_DESC
     def prune
-      query = Account.remote.where.not(actor_type: %i(Application Service))
+      query = Account.remote.non_automated
       query = query.where('NOT EXISTS (SELECT 1 FROM mentions WHERE account_id = accounts.id)')
       query = query.where('NOT EXISTS (SELECT 1 FROM favourites WHERE account_id = accounts.id)')
       query = query.where('NOT EXISTS (SELECT 1 FROM statuses WHERE account_id = accounts.id)')


### PR DESCRIPTION
Two things:

- Cleans up list of types repeated between bots scope and query method
- Adds `non_automated` scope using same constant, referenced in CLI

Side notes here...

- I wonder about making `actor_type` an `enum` on `Account` model? Could do this with string values as the values so we don't need a migration, and get some scopes and generated query methods with prefixes as side effect ... which I suspect would let us delete/simplify various checks on type in a few spots. Should there also be any validations for this column? (presumably the AP set of actor types is expected?)
- Looks like the `bots` scope was added here - https://github.com/mastodon/mastodon/pull/9340/files#diff-b3ff5e3df6b875e9ecfde657ae21de84f4f43c942d3232761ed550cf0eecbce0R126 - and has never been used. Could delete this?