### PR TITLE
Disable actions on reports that have already been taken

### DIFF
--- a/app/models/admin/account_action.rb
+++ b/app/models/admin/account_action.rb
@@ -73,6 +73,14 @@ class Admin::AccountAction
       end
     end
 
+    def disabled_types_for_account(account)
+      if account.suspended?
+        %w(silence suspend)
+      elsif account.silenced?
+        %w(silence)
+      end
+    end
+
     def i18n_scope
       :activerecord
     end

--- a/app/views/admin/account_actions/new.html.haml
+++ b/app/views/admin/account_actions/new.html.haml
@@ -1,6 +1,13 @@
 - content_for :page_title do
   = t('admin.account_actions.title', acct: @account.pretty_acct)
 
+- if @account.suspended?
+  .flash-message.alert
+    = t('admin.account_actions.already_suspended')
+- elsif @account.silenced?
+  .flash-message.warn
+    = t('admin.account_actions.already_silenced')
+
 = simple_form_for @account_action, url: admin_account_action_path(@account.id) do |f|
   = f.input :report_id,
             as: :hidden
@@ -9,6 +16,7 @@
     = f.input :type,
               as: :radio_buttons,
               collection: Admin::AccountAction.types_for_account(@account),
+              disabled: Admin::AccountAction.disabled_types_for_account(@account),
               hint: t('simple_form.hints.admin_account_action.type_html', acct: @account.pretty_acct),
               include_blank: false,
               label_method: ->(type) { account_action_type_label(type) },

--- a/app/views/admin/reports/_actions.html.haml
+++ b/app/views/admin/reports/_actions.html.haml
@@ -17,21 +17,27 @@
       .report-actions__item__button
         = form.button t('admin.reports.delete_and_resolve'),
                       name: :delete,
-                      class: 'button button--destructive'
+                      class: 'button button--destructive',
+                      disabled: statuses.empty?,
+                      title: statuses.empty? ? t('admin.reports.actions_no_posts') : ''
       .report-actions__item__description
         = t('admin.reports.actions.delete_description_html')
     .report-actions__item
       .report-actions__item__button
         = form.button t('admin.accounts.silence'),
                       name: :silence,
-                      class: 'button button--destructive'
+                      class: 'button button--destructive',
+                      disabled: report.target_account.silenced? || report.target_account.suspended?,
+                      title: report.target_account.silenced? ? t('admin.account_actions.already_silenced') : ''
       .report-actions__item__description
         = t('admin.reports.actions.silence_description_html')
     .report-actions__item
       .report-actions__item__button
         = form.button t('admin.accounts.suspend'),
                       name: :suspend,
-                      class: 'button button--destructive'
+                      class: 'button button--destructive',
+                      disabled: report.target_account.suspended?,
+                      title: report.target_account.suspended? ? t('admin.account_actions.already_suspended') : ''
       .report-actions__item__description
         = t('admin.reports.actions.suspend_description_html')
     .report-actions__item

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,6 +25,8 @@ en:
   admin:
     account_actions:
       action: Perform action
+      already_silenced: This account has already been silenced.
+      already_suspended: This account has already been suspended.
       title: Perform moderation action on %{acct}
     account_moderation_notes:
       create: Leave note
@@ -602,6 +604,7 @@ en:
         suspend_description_html: The account and all its contents will be inaccessible and eventually deleted, and interacting with it will be impossible. Reversible within 30 days. Closes all reports against this account.
       actions_description_html: Decide which action to take to resolve this report. If you take a punitive action against the reported account, an email notification will be sent to them, except when the <strong>Spam</strong> category is selected.
       actions_description_remote_html: Decide which action to take to resolve this report. This will only affect how <strong>your</strong> server communicates with this remote account and handle its content.
+      actions_no_posts: This report doesn't have any associated posts to delete
       add_to_report: Add more to report
       already_suspended_badges:
         local: Already suspended on this server


### PR DESCRIPTION
This fixes #18718

### Screenshots

Report actions when report has no posts and the account is already limited:
<img width="864" alt="Screenshot 2024-09-05 at 19 00 15" src="https://github.com/user-attachments/assets/0b49c3da-9f40-4485-82bd-a5e50c92b9e2">

Report actions when report has no posts and the account is already suspended:
<img width="871" alt="Screenshot 2024-09-05 at 18 59 51" src="https://github.com/user-attachments/assets/028e78c6-7d4d-4265-a317-331702667b6e">

Custom Actions for Account when Account is already suspended:
<img width="919" alt="Screenshot 2024-09-05 at 18 59 43" src="https://github.com/user-attachments/assets/c099df5a-db4b-49f7-89df-15b7d4b4ecec">

Custom Actions for Account when Account is already limited.
<img width="890" alt="Screenshot 2024-09-05 at 18 59 20" src="https://github.com/user-attachments/assets/39874ae7-02b0-4e3b-9875-fd4121122d7f">
