### PR TITLE
Simplify model spec validator coverage

### DIFF
--- a/spec/fabricators/ip_block_fabricator.rb
+++ b/spec/fabricators/ip_block_fabricator.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+Fabricator(:ip_block) do
+  severity { :sign_up_requires_approval }
+  ip { sequence(:ip) { |n| "10.0.0.#{n}" } }
+end

--- a/spec/models/account_migration_spec.rb
+++ b/spec/models/account_migration_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe AccountMigration do
     end
   end
 
-  describe 'validations' do
-    subject { described_class.new(account: source_account, acct: target_acct) }
+  describe 'Validations' do
+    subject { described_class.new(account: source_account) }
 
     let(:source_account) { Fabricate(:account) }
     let(:target_acct)    { target_account.acct }
@@ -26,9 +26,7 @@ RSpec.describe AccountMigration do
         allow(service_double).to receive(:call).with(target_acct, anything).and_return(target_account)
       end
 
-      it 'passes validations' do
-        expect(subject).to be_valid
-      end
+      it { is_expected.to allow_value(target_account.acct).for(:acct) }
     end
 
     context 'with unresolvable account' do
@@ -40,17 +38,13 @@ RSpec.describe AccountMigration do
         allow(service_double).to receive(:call).with(target_acct, anything).and_return(nil)
       end
 
-      it 'has errors on acct field' do
-        expect(subject).to model_have_error_on_field(:acct)
-      end
+      it { is_expected.to_not allow_value(target_acct).for(:acct) }
     end
 
     context 'with a space in the domain part' do
       let(:target_acct) { 'target@remote. org' }
 
-      it 'has errors on acct field' do
-        expect(subject).to model_have_error_on_field(:acct)
-      end
+      it { is_expected.to_not allow_value(target_acct).for(:acct) }
     end
   end
 end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -826,22 +826,19 @@ RSpec.describe Account do
     end
   end
 
-  describe 'validations' do
+  describe 'Validations' do
     it { is_expected.to validate_presence_of(:username) }
 
-    context 'when is local' do
-      it 'is invalid if the username is not unique in case-insensitive comparison among local accounts' do
-        _account = Fabricate(:account, username: 'the_doctor')
-        non_unique_account = Fabricate.build(:account, username: 'the_Doctor')
-        non_unique_account.valid?
-        expect(non_unique_account).to model_have_error_on_field(:username)
+    context 'when account is local' do
+      subject { Fabricate.build :account, domain: nil }
+
+      context 'with an existing differently-cased username account' do
+        before { Fabricate :account, username: 'the_doctor' }
+
+        it { is_expected.to_not allow_value('the_Doctor').for(:username) }
       end
 
-      it 'is invalid if the username is reserved' do
-        account = Fabricate.build(:account, username: 'support')
-        account.valid?
-        expect(account).to model_have_error_on_field(:username)
-      end
+      it { is_expected.to_not allow_value('support').for(:username) }
 
       it 'is valid when username is reserved but record has already been created' do
         account = Fabricate.build(:account, username: 'support')
@@ -849,9 +846,10 @@ RSpec.describe Account do
         expect(account.valid?).to be true
       end
 
-      it 'is valid if we are creating an instance actor account with a period' do
-        account = Fabricate.build(:account, id: described_class::INSTANCE_ACTOR_ID, actor_type: 'Application', locked: true, username: 'example.com')
-        expect(account.valid?).to be true
+      context 'with the instance actor' do
+        subject { Fabricate.build :account, id: described_class::INSTANCE_ACTOR_ID, actor_type: 'Application', locked: true }
+
+        it { is_expected.to allow_value('example.com').for(:username) }
       end
 
       it 'is valid if we are creating a possibly-conflicting instance actor account' do
@@ -860,81 +858,31 @@ RSpec.describe Account do
         expect(instance_account.valid?).to be true
       end
 
-      it 'is invalid if the username doesn\'t only contains letters, numbers and underscores' do
-        account = Fabricate.build(:account, username: 'the-doctor')
-        account.valid?
-        expect(account).to model_have_error_on_field(:username)
-      end
+      it { is_expected.to_not allow_values('the-doctor', 'the.doctor').for(:username) }
 
-      it 'is invalid if the username contains a period' do
-        account = Fabricate.build(:account, username: 'the.doctor')
-        account.valid?
-        expect(account).to model_have_error_on_field(:username)
-      end
+      it { is_expected.to validate_length_of(:username).is_at_most(described_class::USERNAME_LENGTH_LIMIT) }
+      it { is_expected.to validate_length_of(:display_name).is_at_most(described_class::DISPLAY_NAME_LENGTH_LIMIT) }
 
-      it 'is invalid if the username is longer than the character limit' do
-        account = Fabricate.build(:account, username: username_over_limit)
-        account.valid?
-        expect(account).to model_have_error_on_field(:username)
-      end
-
-      it 'is invalid if the display name is longer than the character limit' do
-        account = Fabricate.build(:account, display_name: display_name_over_limit)
-        account.valid?
-        expect(account).to model_have_error_on_field(:display_name)
-      end
-
-      it 'is invalid if the note is longer than the character limit' do
-        account = Fabricate.build(:account, note: account_note_over_limit)
-        account.valid?
-        expect(account).to model_have_error_on_field(:note)
-      end
+      it { is_expected.to_not allow_values(account_note_over_limit).for(:note) }
     end
 
-    context 'when is remote' do
-      it 'is invalid if the username is same among accounts in the same normalized domain' do
-        Fabricate(:account, domain: 'にゃん', username: 'username')
-        account = Fabricate.build(:account, domain: 'xn--r9j5b5b', username: 'username')
-        account.valid?
-        expect(account).to model_have_error_on_field(:username)
+    context 'when account is remote' do
+      subject { Fabricate.build :account, domain: 'host.example' }
+
+      context 'when a normalized domain account exists' do
+        subject { Fabricate.build :account, domain: 'xn--r9j5b5b' }
+
+        before { Fabricate(:account, domain: 'にゃん', username: 'username') }
+
+        it { is_expected.to_not allow_values('username', 'Username').for(:username) }
       end
 
-      it 'is invalid if the username is not unique in case-insensitive comparison among accounts in the same normalized domain' do
-        Fabricate(:account, domain: 'にゃん', username: 'username')
-        account = Fabricate.build(:account, domain: 'xn--r9j5b5b', username: 'Username')
-        account.valid?
-        expect(account).to model_have_error_on_field(:username)
-      end
+      it { is_expected.to allow_values('the-doctor', username_over_limit).for(:username) }
+      it { is_expected.to_not allow_values('the doctor').for(:username) }
 
-      it 'is valid even if the username contains hyphens' do
-        account = Fabricate.build(:account, domain: 'domain', username: 'the-doctor')
-        account.valid?
-        expect(account).to_not model_have_error_on_field(:username)
-      end
+      it { is_expected.to allow_values(display_name_over_limit).for(:display_name) }
 
-      it 'is invalid if the username doesn\'t only contains letters, numbers, underscores and hyphens' do
-        account = Fabricate.build(:account, domain: 'domain', username: 'the doctor')
-        account.valid?
-        expect(account).to model_have_error_on_field(:username)
-      end
-
-      it 'is valid even if the username is longer than the character limit' do
-        account = Fabricate.build(:account, domain: 'domain', username: username_over_limit)
-        account.valid?
-        expect(account).to_not model_have_error_on_field(:username)
-      end
-
-      it 'is valid even if the display name is longer than the character limit' do
-        account = Fabricate.build(:account, domain: 'domain', display_name: display_name_over_limit)
-        account.valid?
-        expect(account).to_not model_have_error_on_field(:display_name)
-      end
-
-      it 'is valid even if the note is longer than the character limit' do
-        account = Fabricate.build(:account, domain: 'domain', note: account_note_over_limit)
-        account.valid?
-        expect(account).to_not model_have_error_on_field(:note)
-      end
+      it { is_expected.to allow_values(account_note_over_limit).for(:note) }
     end
 
     def username_over_limit

--- a/spec/models/account_statuses_cleanup_policy_spec.rb
+++ b/spec/models/account_statuses_cleanup_policy_spec.rb
@@ -5,13 +5,12 @@ require 'rails_helper'
 RSpec.describe AccountStatusesCleanupPolicy do
   let(:account) { Fabricate(:account, username: 'alice', domain: nil) }
 
-  describe 'validation' do
-    it 'disallow remote accounts' do
-      account.update(domain: 'example.com')
-      account_statuses_cleanup_policy = Fabricate.build(:account_statuses_cleanup_policy, account: account)
-      account_statuses_cleanup_policy.valid?
-      expect(account_statuses_cleanup_policy).to model_have_error_on_field(:account)
-    end
+  describe 'Validations' do
+    subject { Fabricate.build :account_statuses_cleanup_policy }
+
+    let(:remote_account) { Fabricate(:account, domain: 'example.com') }
+
+    it { is_expected.to_not allow_value(remote_account).for(:account) }
   end
 
   describe 'save hooks' do

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -67,18 +67,30 @@ RSpec.describe Announcement do
     it { is_expected.to validate_presence_of(:text) }
 
     describe 'ends_at' do
-      it 'validates presence when starts_at is present' do
-        record = Fabricate.build(:announcement, starts_at: 1.day.ago)
+      context 'when starts_at is present' do
+        subject { Fabricate.build :announcement, starts_at: 1.day.ago }
 
-        expect(record).to_not be_valid
-        expect(record.errors[:ends_at]).to be_present
+        it { is_expected.to validate_presence_of(:ends_at) }
       end
 
-      it 'does not validate presence when starts_at is missing' do
-        record = Fabricate.build(:announcement, starts_at: nil)
+      context 'when starts_at is missing' do
+        subject { Fabricate.build :announcement, starts_at: nil }
 
-        expect(record).to be_valid
-        expect(record.errors[:ends_at]).to_not be_present
+        it { is_expected.to_not validate_presence_of(:ends_at) }
+      end
+    end
+
+    describe 'starts_at' do
+      context 'when ends_at is present' do
+        subject { Fabricate.build :announcement, ends_at: 1.day.ago }
+
+        it { is_expected.to validate_presence_of(:starts_at) }
+      end
+
+      context 'when ends_at is missing' do
+        subject { Fabricate.build :announcement, ends_at: nil }
+
+        it { is_expected.to_not validate_presence_of(:starts_at) }
       end
     end
   end

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -4,16 +4,9 @@ require 'rails_helper'
 
 RSpec.describe Appeal do
   describe 'Validations' do
-    it 'validates text length is under limit' do
-      appeal = Fabricate.build(
-        :appeal,
-        strike: Fabricate(:account_warning),
-        text: 'a' * described_class::TEXT_LENGTH_LIMIT * 2
-      )
+    subject { Fabricate.build :appeal, strike: Fabricate(:account_warning) }
 
-      expect(appeal).to_not be_valid
-      expect(appeal).to model_have_error_on_field(:text)
-    end
+    it { is_expected.to validate_length_of(:text).is_at_most(described_class::TEXT_LENGTH_LIMIT) }
   end
 
   describe 'scopes' do

--- a/spec/models/block_spec.rb
+++ b/spec/models/block_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Block do
-  describe 'validations' do
+  describe 'Associations' do
     it { is_expected.to belong_to(:account).required }
     it { is_expected.to belong_to(:target_account).required }
   end

--- a/spec/models/custom_filter_spec.rb
+++ b/spec/models/custom_filter_spec.rb
@@ -7,19 +7,7 @@ RSpec.describe CustomFilter do
     it { is_expected.to validate_presence_of(:title) }
     it { is_expected.to validate_presence_of(:context) }
 
-    it 'requires non-empty of context' do
-      record = described_class.new(context: [])
-      record.valid?
-
-      expect(record).to model_have_error_on_field(:context)
-    end
-
-    it 'requires valid context value' do
-      record = described_class.new(context: ['invalid'])
-      record.valid?
-
-      expect(record).to model_have_error_on_field(:context)
-    end
+    it { is_expected.to_not allow_values([], %w(invalid)).for(:context) }
   end
 
   describe 'Normalizations' do

--- a/spec/models/domain_allow_spec.rb
+++ b/spec/models/domain_allow_spec.rb
@@ -6,11 +6,10 @@ RSpec.describe DomainAllow do
   describe 'Validations' do
     it { is_expected.to validate_presence_of(:domain) }
 
-    it 'is invalid if the same normalized domain already exists' do
-      _domain_allow = Fabricate(:domain_allow, domain: 'にゃん')
-      domain_allow_with_normalized_value = Fabricate.build(:domain_allow, domain: 'xn--r9j5b5b')
-      domain_allow_with_normalized_value.valid?
-      expect(domain_allow_with_normalized_value).to model_have_error_on_field(:domain)
+    context 'when a normalized domain exists' do
+      before { Fabricate(:domain_allow, domain: 'にゃん') }
+
+      it { is_expected.to_not allow_value('xn--r9j5b5b').for(:domain) }
     end
   end
 end

--- a/spec/models/domain_block_spec.rb
+++ b/spec/models/domain_block_spec.rb
@@ -3,14 +3,13 @@
 require 'rails_helper'
 
 RSpec.describe DomainBlock do
-  describe 'validations' do
+  describe 'Validations' do
     it { is_expected.to validate_presence_of(:domain) }
 
-    it 'is invalid if the same normalized domain already exists' do
-      _domain_block = Fabricate(:domain_block, domain: 'にゃん')
-      domain_block_with_normalized_value = Fabricate.build(:domain_block, domain: 'xn--r9j5b5b')
-      domain_block_with_normalized_value.valid?
-      expect(domain_block_with_normalized_value).to model_have_error_on_field(:domain)
+    context 'when a normalized domain exists' do
+      before { Fabricate(:domain_block, domain: 'にゃん') }
+
+      it { is_expected.to_not allow_value('xn--r9j5b5b').for(:domain) }
     end
   end
 

--- a/spec/models/form/admin_settings_spec.rb
+++ b/spec/models/form/admin_settings_spec.rb
@@ -3,33 +3,17 @@
 require 'rails_helper'
 
 RSpec.describe Form::AdminSettings do
-  describe 'validations' do
+  describe 'Validations' do
     describe 'site_contact_username' do
       context 'with no accounts' do
-        it 'is not valid' do
-          setting = described_class.new(site_contact_username: 'Test')
-          setting.valid?
-
-          expect(setting).to model_have_error_on_field(:site_contact_username)
-        end
+        it { is_expected.to_not allow_value('Test').for(:site_contact_username) }
       end
 
       context 'with an account' do
         before { Fabricate(:account, username: 'Glorp') }
 
-        it 'is not valid when account doesnt match' do
-          setting = described_class.new(site_contact_username: 'Test')
-          setting.valid?
-
-          expect(setting).to model_have_error_on_field(:site_contact_username)
-        end
-
-        it 'is valid when account matches' do
-          setting = described_class.new(site_contact_username: 'Glorp')
-          setting.valid?
-
-          expect(setting).to_not model_have_error_on_field(:site_contact_username)
-        end
+        it { is_expected.to_not allow_value('Test').for(:site_contact_username) }
+        it { is_expected.to allow_value('Glorp').for(:site_contact_username) }
       end
     end
   end

--- a/spec/models/ip_block_spec.rb
+++ b/spec/models/ip_block_spec.rb
@@ -3,18 +3,13 @@
 require 'rails_helper'
 
 RSpec.describe IpBlock do
-  describe 'validations' do
+  describe 'Validations' do
+    subject { Fabricate.build :ip_block }
+
     it { is_expected.to validate_presence_of(:ip) }
     it { is_expected.to validate_presence_of(:severity) }
 
-    it 'validates ip uniqueness', :aggregate_failures do
-      described_class.create!(ip: '127.0.0.1', severity: :no_access)
-
-      ip_block = described_class.new(ip: '127.0.0.1', severity: :no_access)
-
-      expect(ip_block).to_not be_valid
-      expect(ip_block).to model_have_error_on_field(:ip)
-    end
+    it { is_expected.to validate_uniqueness_of(:ip) }
   end
 
   describe '#to_log_human_identifier' do

--- a/spec/models/mention_spec.rb
+++ b/spec/models/mention_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Mention do
-  describe 'validations' do
+  describe 'Associations' do
     it { is_expected.to belong_to(:account).required }
     it { is_expected.to belong_to(:status).required }
   end

--- a/spec/models/poll_spec.rb
+++ b/spec/models/poll_spec.rb
@@ -30,11 +30,9 @@ RSpec.describe Poll do
     end
   end
 
-  describe 'validations' do
-    context 'when not valid' do
-      subject { Fabricate.build(:poll) }
+  describe 'Validations' do
+    subject { Fabricate.build(:poll) }
 
-      it { is_expected.to validate_presence_of(:expires_at) }
-    end
+    it { is_expected.to validate_presence_of(:expires_at) }
   end
 end

--- a/spec/models/preview_card_spec.rb
+++ b/spec/models/preview_card_spec.rb
@@ -9,26 +9,10 @@ RSpec.describe PreviewCard do
     end
   end
 
-  describe 'validations' do
-    describe 'urls' do
-      it 'allows http schemes' do
-        record = described_class.new(url: 'http://example.host/path')
-
-        expect(record).to be_valid
-      end
-
-      it 'allows https schemes' do
-        record = described_class.new(url: 'https://example.host/path')
-
-        expect(record).to be_valid
-      end
-
-      it 'does not allow javascript: schemes' do
-        record = described_class.new(url: 'javascript:alert()')
-
-        expect(record).to_not be_valid
-        expect(record).to model_have_error_on_field(:url)
-      end
+  describe 'Validations' do
+    describe 'url' do
+      it { is_expected.to allow_values('http://example.host/path', 'https://example.host/path').for(:url) }
+      it { is_expected.to_not allow_value('javascript:alert()').for(:url) }
     end
   end
 end

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -121,30 +121,31 @@ RSpec.describe Report do
   end
 
   describe 'validations' do
+    subject { Fabricate.build :report }
+
     let(:remote_account) { Fabricate(:account, domain: 'example.com', protocol: :activitypub, inbox_url: 'http://example.com/inbox') }
+    let(:local_account) { Fabricate(:account, domain: nil) }
 
-    it 'is invalid if comment is longer than character limit and reporter is local' do
-      report = Fabricate.build(:report, comment: comment_over_limit)
-      expect(report.valid?).to be false
-      expect(report).to model_have_error_on_field(:comment)
+    context 'with a local reporter' do
+      subject { Fabricate.build :report, account: local_account }
+
+      it { is_expected.to_not allow_value(comment_over_limit).for(:comment) }
     end
 
-    it 'is valid if comment is longer than character limit and reporter is not local' do
-      report = Fabricate.build(:report, account: remote_account, comment: comment_over_limit)
-      expect(report.valid?).to be true
+    context 'with a remote reporter' do
+      subject { Fabricate.build :report, account: remote_account }
+
+      it { is_expected.to allow_value(comment_over_limit).for(:comment) }
     end
 
-    it 'is invalid if it references invalid rules' do
-      report = Fabricate.build(:report, category: :violation, rule_ids: [-1])
-      expect(report.valid?).to be false
-      expect(report).to model_have_error_on_field(:rule_ids)
-    end
+    it { is_expected.to_not allow_value([-1]).for(:rule_ids) }
 
-    it 'is invalid if it references rules but category is not "violation"' do
-      rule = Fabricate(:rule)
-      report = Fabricate.build(:report, category: :spam, rule_ids: rule.id)
-      expect(report.valid?).to be false
-      expect(report).to model_have_error_on_field(:rule_ids)
+    context 'with a category that is not "violation"' do
+      subject { Fabricate.build :report, category: :spam }
+
+      let(:rule) { Fabricate :rule }
+
+      it { is_expected.to_not allow_value(rule.id).for(:rule_ids) }
     end
 
     def comment_over_limit

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -472,11 +472,13 @@ RSpec.describe Status do
     end
   end
 
-  describe 'validation' do
-    it 'disallow empty uri for remote status' do
-      alice.update(domain: 'example.com')
-      status = Fabricate.build(:status, uri: '', account: alice)
-      expect(status).to model_have_error_on_field(:uri)
+  describe 'Validations' do
+    context 'with a remote account' do
+      subject { Fabricate.build :status, account: remote_account }
+
+      let(:remote_account) { Fabricate :account, domain: 'example.com' }
+
+      it { is_expected.to_not allow_value('').for(:uri) }
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -33,14 +33,12 @@ RSpec.describe User do
     end
   end
 
-  describe 'validations' do
+  describe 'Associations' do
     it { is_expected.to belong_to(:account).required }
+  end
 
-    it 'is invalid without a valid email' do
-      user = Fabricate.build(:user, email: 'john@')
-      user.valid?
-      expect(user).to model_have_error_on_field(:email)
-    end
+  describe 'Validations' do
+    it { is_expected.to_not allow_value('john@').for(:email) }
 
     it 'is valid with an invalid e-mail that has already been saved' do
       user = Fabricate.build(:user, email: 'invalid-email')
@@ -48,11 +46,7 @@ RSpec.describe User do
       expect(user.valid?).to be true
     end
 
-    it 'is valid with a localhost e-mail address' do
-      user = Fabricate.build(:user, email: 'admin@localhost')
-      user.valid?
-      expect(user.valid?).to be true
-    end
+    it { is_expected.to allow_value('admin@localhost').for(:email) }
   end
 
   describe 'Normalizations' do

--- a/spec/models/webauthn_credential_spec.rb
+++ b/spec/models/webauthn_credential_spec.rb
@@ -3,53 +3,17 @@
 require 'rails_helper'
 
 RSpec.describe WebauthnCredential do
-  describe 'validations' do
+  describe 'Validations' do
+    subject { Fabricate.build :webauthn_credential }
+
     it { is_expected.to validate_presence_of(:external_id) }
     it { is_expected.to validate_presence_of(:public_key) }
     it { is_expected.to validate_presence_of(:nickname) }
     it { is_expected.to validate_presence_of(:sign_count) }
 
-    it 'is invalid if already exist a webauthn credential with the same external id' do
-      Fabricate(:webauthn_credential, external_id: '_Typ0ygudDnk9YUVWLQayw')
-      new_webauthn_credential = Fabricate.build(:webauthn_credential, external_id: '_Typ0ygudDnk9YUVWLQayw')
+    it { is_expected.to validate_uniqueness_of(:external_id) }
+    it { is_expected.to validate_uniqueness_of(:nickname).scoped_to(:user_id) }
 
-      new_webauthn_credential.valid?
-
-      expect(new_webauthn_credential).to model_have_error_on_field(:external_id)
-    end
-
-    it 'is invalid if user already registered a webauthn credential with the same nickname' do
-      user = Fabricate(:user)
-      Fabricate(:webauthn_credential, user_id: user.id, nickname: 'USB Key')
-      new_webauthn_credential = Fabricate.build(:webauthn_credential, user_id: user.id, nickname: 'USB Key')
-
-      new_webauthn_credential.valid?
-
-      expect(new_webauthn_credential).to model_have_error_on_field(:nickname)
-    end
-
-    it 'is invalid if sign_count is not a number' do
-      webauthn_credential = Fabricate.build(:webauthn_credential, sign_count: 'invalid sign_count')
-
-      webauthn_credential.valid?
-
-      expect(webauthn_credential).to model_have_error_on_field(:sign_count)
-    end
-
-    it 'is invalid if sign_count is negative number' do
-      webauthn_credential = Fabricate.build(:webauthn_credential, sign_count: -1)
-
-      webauthn_credential.valid?
-
-      expect(webauthn_credential).to model_have_error_on_field(:sign_count)
-    end
-
-    it 'is invalid if sign_count is greater than the limit' do
-      webauthn_credential = Fabricate.build(:webauthn_credential, sign_count: (described_class::SIGN_COUNT_LIMIT * 2))
-
-      webauthn_credential.valid?
-
-      expect(webauthn_credential).to model_have_error_on_field(:sign_count)
-    end
+    it { is_expected.to validate_numericality_of(:sign_count).only_integer.is_greater_than_or_equal_to(0).is_less_than_or_equal_to(described_class::SIGN_COUNT_LIMIT - 1) }
   end
 end

--- a/spec/models/webhook_spec.rb
+++ b/spec/models/webhook_spec.rb
@@ -6,21 +6,11 @@ RSpec.describe Webhook do
   let(:webhook) { Fabricate(:webhook) }
 
   describe 'Validations' do
+    subject { Fabricate.build :webhook }
+
     it { is_expected.to validate_presence_of(:events) }
 
-    it 'requires non-empty events value' do
-      record = described_class.new(events: [])
-      record.valid?
-
-      expect(record).to model_have_error_on_field(:events)
-    end
-
-    it 'requires valid events value from EVENTS' do
-      record = described_class.new(events: ['account.invalid'])
-      record.valid?
-
-      expect(record).to model_have_error_on_field(:events)
-    end
+    it { is_expected.to_not allow_values([], %w(account.invalid)).for(:events) }
   end
 
   describe 'Normalizations' do


### PR DESCRIPTION
Follow-up on https://github.com/mastodon/mastodon/pull/29664

I think there are more of these to find, but tried to stick to the areas where there was basically a 1:1 replacement for keeping the same coverage but doing the assertions in fewer LOC by leveraging the recently added matchers. The diff is sort of large, but I tried to keep each section near it's replacement so hopefully that's acceptable (can pull out some one-offs for the larger changes maybe if desired?)

Notes:

- IP Block did not have a fabricator, added that
- A few of these were mislabeled after the initial PR (associations/validations) so did some word-only changes in here
- Where possible, updated to use `build` on the fabricators, which reduces factory creation across the run
- A few spots (announcement starts/ends for example) had an obvious tiny bit of coverage to add that was missing while I was simplifying, so went ahead and did those ... but generally speaking this is preserving coverage while reducing test LOC, and not adding too much.
