### PR TITLE
Target firefox all the way back to Firefox 78

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,6 +1,7 @@
 [production]
 defaults
 > 0.2%
+firefox >= 78
 ios >= 15.6
 not dead
 not OperaMini all


### PR DESCRIPTION
Fixes #31712, #31713

This increases JS size by approximatively 6k (+0.24%) and does not significantly increase CSS size (+50 bytes).

According to https://browsersl.ist/, the increase in browser coverage is really modest (90.4% to 90.7%), but the actual increase may be higher as I imagine features that end up getting polyfilled also matter for other old browsers.

I am not sure we should be actively supporting such old browsers though.