### PR TITLE
Disable codecov github annotations

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,3 +1,4 @@
+annotations: false
 comment: false # Do not leave PR comments
 coverage:
   status:


### PR DESCRIPTION
For some reasons, CodeCov annotations are incorrect, and thus only make PRs harder to read in github without bringing anything useful.

It would be best to fix it so CodeCov annotations are accurate instead, but at that point I don't know why they are inaccurate.