### PR TITLE
Use shared system spec helper methods

### DIFF
--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -16,4 +16,8 @@ module SystemHelpers
   def form_label(key)
     I18n.t key, scope: 'simple_form.labels'
   end
+
+  def css_id(record)
+    "##{dom_id(record)}"
+  end
 end

--- a/spec/system/admin/announcements_spec.rb
+++ b/spec/system/admin/announcements_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'Admin::Announcements' do
 
       fill_in text_label,
               with: 'Announcement text'
-      save_changes
+      click_on submit_button
 
       expect(page)
         .to have_content(I18n.t('admin.announcements.updated_msg'))
@@ -94,10 +94,6 @@ RSpec.describe 'Admin::Announcements' do
 
   private
 
-  def css_id(record)
-    "##{dom_id(record)}" # TODO: Extract to system spec helper?
-  end
-
   def publish_announcement(announcement)
     within css_id(announcement) do
       click_on I18n.t('admin.announcements.publish')
@@ -114,10 +110,6 @@ RSpec.describe 'Admin::Announcements' do
     within css_id(announcement) do
       click_on I18n.t('generic.delete')
     end
-  end
-
-  def save_changes
-    click_on I18n.t('generic.save_changes')
   end
 
   def submit_form

--- a/spec/system/admin/domain_blocks_spec.rb
+++ b/spec/system/admin/domain_blocks_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe 'blocking domains through the moderation interface' do
       visit edit_admin_domain_block_path(domain_block)
 
       select I18n.t('admin.domain_blocks.new.severity.suspend'), from: 'domain_block_severity'
-      click_on I18n.t('generic.save_changes')
+      click_on submit_button
 
       # It doesn't immediately block but presents a confirmation screen
       expect(page).to have_title(I18n.t('admin.domain_blocks.confirm_suspension.title', domain: 'example.com'))

--- a/spec/system/filters_spec.rb
+++ b/spec/system/filters_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Filters' do
       click_on filter_title
 
       fill_in filter_title_field, with: new_title
-      click_on I18n.t('generic.save_changes')
+      click_on submit_button
 
       expect(page).to have_content(new_title)
     end

--- a/spec/system/invites_spec.rb
+++ b/spec/system/invites_spec.rb
@@ -56,10 +56,6 @@ RSpec.describe 'Invites' do
 
   private
 
-  def css_id(record)
-    "##{dom_id(record)}" # TODO: Extract to system spec helper?
-  end
-
   def copyable_field
     within '.input-copy' do
       find(:field, type: :text, readonly: true)


### PR DESCRIPTION
The `css_id` extraction covers a known TODO, the other two use a helper method which already existed but was not used there.