### PR TITLE
Remove unused `statuses#embed` body class assignment

### DIFF
--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -11,7 +11,6 @@ class StatusesController < ApplicationController
   before_action :require_account_signature!, only: [:show, :activity], if: -> { request.format == :json && authorized_fetch_mode? }
   before_action :set_status
   before_action :redirect_to_original, only: :show
-  before_action :set_body_classes, only: :embed
 
   after_action :set_link_headers
 
@@ -50,10 +49,6 @@ class StatusesController < ApplicationController
   end
 
   private
-
-  def set_body_classes
-    @body_classes = 'with-modals'
-  end
 
   def set_link_headers
     response.headers['Link'] = LinkHeader.new(


### PR DESCRIPTION
I was going to move this one to the layout in a `content_for` like the just-merged admin one ... but looking at the layout, it does not actually call the body classes helper method, and never has ... so as far as I can tell this is assigned but not actually used.

When first added - https://github.com/mastodon/mastodon/commit/63c7fe8e4892b22e80c015bf0ecb04496318623b - it was relevant to the `show` view (not embed), but that has subsequently changed and it's no longer needed at all.