### PR TITLE
Add coverage for `media#player`, move body class to view

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -19,9 +19,7 @@ class MediaController < ApplicationController
     redirect_to @media_attachment.file.url(:original)
   end
 
-  def player
-    @body_classes = 'player'
-  end
+  def player; end
 
   private
 

--- a/app/views/media/player.html.haml
+++ b/app/views/media/player.html.haml
@@ -2,6 +2,8 @@
   = render_initial_state
   = javascript_pack_tag 'public', crossorigin: 'anonymous'
 
+- content_for :body_classes, 'player'
+
 :ruby
   meta = @media_attachment.file.meta || {}
 

--- a/spec/system/media_spec.rb
+++ b/spec/system/media_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Media' do
+  describe 'Player page' do
+    context 'when signed in' do
+      before { sign_in Fabricate(:user) }
+
+      it 'visits the media player page and renders the media' do
+        status = Fabricate :status
+        media = Fabricate :media_attachment, type: :video
+        status.media_attachments << media
+
+        visit medium_player_path(media)
+
+        expect(page)
+          .to have_css('body', class: 'player')
+          .and have_css('div[data-component="Video"]')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Noticed there was no coverage for this one (maybe accessed only via the twitter/ogp meta tags?) so added basic coverage, and also moved the body class setter to `content_for` approach.