### PR TITLE
Add link to `/admin/roles` in moderation interface when changing someone's role

### DIFF
--- a/app/views/admin/users/roles/show.html.haml
+++ b/app/views/admin/users/roles/show.html.haml
@@ -7,7 +7,8 @@
                     collection: UserRole.assignable,
                     include_blank: I18n.t('admin.accounts.change_role.no_role'),
                     label_method: :name,
-                    wrapper: :with_block_label
+                    wrapper: :with_block_label,
+                    hint: safe_join([I18n.t('simple_form.hints.user.role'), ' ', link_to(I18n.t('admin.accounts.change_role.edit_roles'), admin_roles_path)])
 
   .actions
     = f.button :button,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,6 +46,7 @@ en:
         title: Change email for %{username}
       change_role:
         changed_msg: Role successfully changed!
+        edit_roles: Manage user roles
         label: Change role
         no_role: No role
         title: Change role for %{username}

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -130,7 +130,7 @@ en:
         name: You can only change the casing of the letters, for example, to make it more readable
       user:
         chosen_languages: When checked, only posts in selected languages will be displayed in public timelines
-        role: The role controls which permissions the user has
+        role: The role controls which permissions the user has.
       user_role:
         color: Color to be used for the role throughout the UI, as RGB in hex format
         highlighted: This makes the role publicly visible


### PR DESCRIPTION
Just to make the setting more discoverable

![image](https://github.com/user-attachments/assets/7a2f4e02-0e7a-4a0a-a4c0-865ea4146931)
