### PR TITLE
Move redirect/base body class to view

### DIFF
--- a/app/controllers/redirect/base_controller.rb
+++ b/app/controllers/redirect/base_controller.rb
@@ -4,7 +4,6 @@ class Redirect::BaseController < ApplicationController
   vary_by 'Accept-Language'
 
   before_action :set_resource
-  before_action :set_app_body_class
 
   def show
     @redirect_path = ActivityPub::TagManager.instance.url_for(@resource)
@@ -13,10 +12,6 @@ class Redirect::BaseController < ApplicationController
   end
 
   private
-
-  def set_app_body_class
-    @body_classes = 'app-body'
-  end
 
   def set_resource
     raise NotImplementedError

--- a/app/views/redirects/show.html.haml
+++ b/app/views/redirects/show.html.haml
@@ -2,6 +2,8 @@
   %meta{ name: 'robots', content: 'noindex, noarchive' }/
   %link{ rel: 'canonical', href: @redirect_path }
 
+- content_for :body_classes, 'app-body'
+
 .redirect
   .redirect__logo
     = link_to render_logo, root_path

--- a/spec/system/redirections_spec.rb
+++ b/spec/system/redirections_spec.rb
@@ -6,27 +6,31 @@ RSpec.describe 'redirection confirmations' do
   let(:account) { Fabricate(:account, domain: 'example.com', uri: 'https://example.com/users/foo', url: 'https://example.com/@foo') }
   let(:status)  { Fabricate(:status, account: account, uri: 'https://example.com/users/foo/statuses/1', url: 'https://example.com/@foo/1') }
 
-  context 'when a logged out user visits a local page for a remote account' do
-    it 'shows a confirmation page' do
-      visit "/@#{account.pretty_acct}"
+  context 'when logged out' do
+    describe 'a local page for a remote account' do
+      it 'shows a confirmation page with relevant content' do
+        visit "/@#{account.pretty_acct}"
 
-      # It explains about the redirect
-      expect(page).to have_content(I18n.t('redirects.title', instance: 'cb6e6126.ngrok.io'))
+        expect(page)
+          .to have_content(redirect_title) # Redirect explanation
+          .and have_link(account.url, href: account.url) # Appropriate account link
+          .and have_css('body', class: 'app-body')
+      end
+    end
 
-      # It features an appropriate link
-      expect(page).to have_link(account.url, href: account.url)
+    describe 'a local page for a remote status' do
+      it 'shows a confirmation page with relevant content' do
+        visit "/@#{account.pretty_acct}/#{status.id}"
+
+        expect(page)
+          .to have_content(redirect_title) # Redirect explanation
+          .and have_link(status.url, href: status.url) # Appropriate status link
+          .and have_css('body', class: 'app-body')
+      end
     end
   end
 
-  context 'when a logged out user visits a local page for a remote status' do
-    it 'shows a confirmation page' do
-      visit "/@#{account.pretty_acct}/#{status.id}"
-
-      # It explains about the redirect
-      expect(page).to have_content(I18n.t('redirects.title', instance: 'cb6e6126.ngrok.io'))
-
-      # It features an appropriate link
-      expect(page).to have_link(status.url, href: status.url)
-    end
+  def redirect_title
+    I18n.t('redirects.title', instance: 'cb6e6126.ngrok.io')
   end
 end


### PR DESCRIPTION
Similar to others, pull out i-var to view content_for instead, and update existing system spec to check for presence of expected body class value (bumped out one level of context in spec as well).