### PR TITLE
Move body class to shared partial for web app controller concern views

### DIFF
--- a/app/controllers/concerns/web_app_controller_concern.rb
+++ b/app/controllers/concerns/web_app_controller_concern.rb
@@ -7,7 +7,6 @@ module WebAppControllerConcern
     vary_by 'Accept, Accept-Language, Cookie'
 
     before_action :redirect_unauthenticated_to_permalinks!
-    before_action :set_app_body_class
 
     content_security_policy do |p|
       policy = ContentSecurityPolicy.new
@@ -22,10 +21,6 @@ module WebAppControllerConcern
 
   def skip_csrf_meta_tags?
     !(ENV['ONE_CLICK_SSO_LOGIN'] == 'true' && ENV['OMNIAUTH_ONLY'] == 'true' && Devise.omniauth_providers.length == 1) && current_user.nil?
-  end
-
-  def set_app_body_class
-    @body_classes = 'app-body'
   end
 
   def redirect_unauthenticated_to_permalinks!

--- a/app/views/shared/_web_app.html.haml
+++ b/app/views/shared/_web_app.html.haml
@@ -1,3 +1,4 @@
+- content_for :body_classes, 'app-body'
 - content_for :header_tags do
   - if user_signed_in?
     = preload_pack_asset 'features/compose.js'

--- a/spec/system/about_spec.rb
+++ b/spec/system/about_spec.rb
@@ -8,5 +8,6 @@ RSpec.describe 'About page' do
 
     expect(page)
       .to have_css('noscript', text: /Mastodon/)
+      .and have_css('body', class: 'app-body')
   end
 end

--- a/spec/system/home_spec.rb
+++ b/spec/system/home_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'Home page' do
 
       expect(page)
         .to have_css('noscript', text: /Mastodon/)
+        .and have_css('body', class: 'app-body')
     end
   end
 
@@ -20,6 +21,7 @@ RSpec.describe 'Home page' do
 
       expect(page)
         .to have_css('noscript', text: /Mastodon/)
+        .and have_css('body', class: 'app-body')
     end
   end
 end

--- a/spec/system/privacy_spec.rb
+++ b/spec/system/privacy_spec.rb
@@ -8,5 +8,6 @@ RSpec.describe 'Privacy policy page' do
 
     expect(page)
       .to have_css('noscript', text: /Mastodon/)
+      .and have_css('body', class: 'app-body')
   end
 end

--- a/spec/system/tags_spec.rb
+++ b/spec/system/tags_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe 'Tags' do
 
       expect(page)
         .to have_css('noscript', text: /Mastodon/)
+        .and have_css('body', class: 'app-body')
         .and have_private_cache_control
     end
   end


### PR DESCRIPTION
I *think* this rounds out this collection, along with a few other open PRs. Will do a clean-up follow-up to the helper method itself once they are all merged.

For this one, all the relevant actions here have very lighteweight views which just set some head meta tags and render the `shared/web_app` partial - so it was easy to preserve all the output but only need to add in one spot.
