### PR TITLE
Show default time zone

### DIFF
--- a/app/views/settings/preferences/appearance/show.html.haml
+++ b/app/views/settings/preferences/appearance/show.html.haml
@@ -18,6 +18,7 @@
       = f.input :time_zone,
                 collection: ActiveSupport::TimeZone.all.map { |tz| ["(GMT#{tz.formatted_offset}) #{tz.name}", tz.tzinfo.name] },
                 hint: false,
+                selected: current_user.time_zone || Time.zone.tzinfo.name,
                 wrapper: :with_label
 
   .fields-group


### PR DESCRIPTION
If the user hasn't selected a time zone, the time zone dropdown is just blank.

<img width="474" alt="image" src="https://github.com/user-attachments/assets/df2ecf57-1644-4ad3-98ac-c8eab0679298">

If no time is selected, the system default time zone (UTC) is used, but the user isn't told which zone this is. Let's make the default zone pre-selected.