### PR TITLE
Change some instances of Nokogiri HTML4 parsing to HTML5

### DIFF
--- a/app/helpers/admin/trends/statuses_helper.rb
+++ b/app/helpers/admin/trends/statuses_helper.rb
@@ -5,7 +5,7 @@ module Admin::Trends::StatusesHelper
     text = if status.local?
              status.text.split("\n").first
            else
-             Nokogiri::HTML(status.text).css('html > body > *').first&.text
+             Nokogiri::HTML5(status.text).css('html > body > *').first&.text
            end
 
     return '' if text.blank?

--- a/app/lib/emoji_formatter.rb
+++ b/app/lib/emoji_formatter.rb
@@ -43,8 +43,8 @@ class EmojiFormatter
 
           next unless (char_after.nil? || !DISALLOWED_BOUNDING_REGEX.match?(char_after)) && (emoji = emoji_map[shortcode])
 
-          result << Nokogiri::XML::Text.new(text[last_index..shortname_start_index - 1], tree.document) if shortname_start_index.positive?
-          result << Nokogiri::HTML.fragment(tag_for_emoji(shortcode, emoji))
+          result << tree.document.create_text_node(text[last_index..shortname_start_index - 1]) if shortname_start_index.positive?
+          result << tree.document.fragment(tag_for_emoji(shortcode, emoji))
 
           last_index = i + 1
         elsif text[i] == ':' && (i.zero? || !DISALLOWED_BOUNDING_REGEX.match?(text[i - 1]))
@@ -53,7 +53,7 @@ class EmojiFormatter
         end
       end
 
-      result << Nokogiri::XML::Text.new(text[last_index..], tree.document)
+      result << tree.document.create_text_node(text[last_index..])
       node.replace(result)
     end
 

--- a/app/lib/emoji_formatter.rb
+++ b/app/lib/emoji_formatter.rb
@@ -24,7 +24,7 @@ class EmojiFormatter
   def to_s
     return html if custom_emojis.empty? || html.blank?
 
-    tree = Nokogiri::HTML.fragment(html)
+    tree = Nokogiri::HTML5.fragment(html)
     tree.xpath('./text()|.//text()[not(ancestor[@class="invisible"])]').to_a.each do |node|
       i                     = -1
       inside_shortname      = false

--- a/app/lib/plain_text_formatter.rb
+++ b/app/lib/plain_text_formatter.rb
@@ -16,7 +16,7 @@ class PlainTextFormatter
     if local?
       text
     else
-      node = Nokogiri::HTML.fragment(insert_newlines)
+      node = Nokogiri::HTML5.fragment(insert_newlines)
       # Elements that are entirely removed with our Sanitize config
       node.xpath('.//iframe|.//math|.//noembed|.//noframes|.//noscript|.//plaintext|.//script|.//style|.//svg|.//xmp').remove
       node.text.chomp

--- a/app/services/fetch_oembed_service.rb
+++ b/app/services/fetch_oembed_service.rb
@@ -25,7 +25,7 @@ class FetchOEmbedService
     return if html.nil?
 
     @format = @options[:format]
-    page    = Nokogiri::HTML(html)
+    page    = Nokogiri::HTML5(html)
 
     if @format.nil? || @format == :json
       @endpoint_url ||= page.at_xpath('//link[@type="application/json+oembed"]|//link[@type="text/json+oembed"]')&.attribute('href')&.value

--- a/app/services/fetch_resource_service.rb
+++ b/app/services/fetch_resource_service.rb
@@ -73,7 +73,7 @@ class FetchResourceService < BaseService
   end
 
   def process_html(response)
-    page      = Nokogiri::HTML(response.body_with_limit)
+    page      = Nokogiri::HTML5(response.body_with_limit)
     json_link = page.xpath('//link[@rel="alternate"]').find { |link| ACTIVITY_STREAM_LINK_TYPES.include?(link['type']) }
 
     process(json_link['href'], terminal: true) unless json_link.nil?

--- a/app/services/translate_status_service.rb
+++ b/app/services/translate_status_service.rb
@@ -100,7 +100,7 @@ class TranslateStatusService < BaseService
   end
 
   def unwrap_emoji_shortcodes(html)
-    fragment = Nokogiri::HTML.fragment(html)
+    fragment = Nokogiri::HTML5.fragment(html)
     fragment.css('span[translate="no"]').each do |element|
       element.remove_attribute('translate')
       element.replace(element.children) if element.attributes.empty?

--- a/lib/sanitize_ext/sanitize_config.rb
+++ b/lib/sanitize_ext/sanitize_config.rb
@@ -52,7 +52,7 @@ class Sanitize
                  :relative
                end
 
-      current_node.replace(Nokogiri::XML::Text.new(current_node.text, current_node.document)) unless LINK_PROTOCOLS.include?(scheme)
+      current_node.replace(current_node.document.create_text_node(current_node.text)) unless LINK_PROTOCOLS.include?(scheme)
     end
 
     UNSUPPORTED_ELEMENTS_TRANSFORMER = lambda do |env|

--- a/lib/tasks/emojis.rake
+++ b/lib/tasks/emojis.rake
@@ -13,7 +13,7 @@ def gen_border(codepoint, color)
     view_box[3] += 4
     svg['viewBox'] = view_box.join(' ')
   end
-  g = Nokogiri::XML::Node.new 'g', doc
+  g = doc.create_element('g')
   doc.css('svg > *').each do |elem|
     border_elem = elem.dup
 


### PR DESCRIPTION
__Context__

This PR is one in a series that aims to update Mastodon to parse all HTML content as HTML5. Because modern browsers are all HTML5-compliant, and there exist attack vectors where content is parsed and/or sanitized by the server as HTML4 but served as HTML5, it's good practice to parse everything as HTML5 everywhere.

For input under a few kilobytes, HTML5 document parsing is comparable in performance to the HTML4 parsing (though it slows down relatively as document size increases); and HTML5 fragment parsing is faster than HTML4 fragment parsing. For the same 1kb input:

```
ruby 3.3.4 (2024-07-09 revision be1089c8ec) +YJIT [x86_64-linux]
Warming up --------------------------------------
           html4 doc     2.454k i/100ms
           html5 doc     2.641k i/100ms
          html4 frag     1.363k i/100ms
          html5 frag     2.372k i/100ms
Calculating -------------------------------------
           html4 doc     24.029k (± 2.0%) i/s -    120.246k in   5.006138s
           html5 doc     25.158k (± 3.0%) i/s -    126.768k in   5.043532s
          html4 frag     12.910k (± 3.8%) i/s -     65.424k in   5.075214s
          html5 frag     22.373k (± 5.6%) i/s -    113.856k in   5.104700s

Comparison:
           html5 doc:    25157.7 i/s
           html4 doc:    24029.3 i/s - same-ish: difference falls within error
          html5 frag:    22372.8 i/s - 1.12x  slower
          html4 frag:    12910.1 i/s - 1.95x  slower
```


__Changes__

This PR updates a few instances of `Nokogiri::HTML` to `Nokogiri::HTML5` which uses libgumbo instead of libxml2 to parse the HTML.

It also uses Document helper methods instead of specific node constructors, which is both more readable but in the case of creating fragments also avoids the unnecessary overhead of creating an anonymous Document object.



