### PR TITLE
Change Account::Field parsing to use HTML5::DocumentFragment

### DIFF
--- a/app/models/account/field.rb
+++ b/app/models/account/field.rb
@@ -73,10 +73,10 @@ class Account::Field < ActiveModelSerializers::Model
   end
 
   def extract_url_from_html
-    doc = Nokogiri::HTML(value).at_xpath('//body')
+    doc = Nokogiri::HTML5.fragment(value)
 
     return if doc.nil?
-    return if doc.children.size > 1
+    return if doc.children.size != 1
 
     element = doc.children.first
 


### PR DESCRIPTION
__Context__

This PR is one in a series that aims to update Mastodon to parse all HTML content as HTML5. See https://github.com/mastodon/mastodon/pull/31812 for a longer explanation.

__Changes__

Change `Nokogiri::HTML` to `Nokogiri::HTML5.fragment` because we're parsing a fragment and not an HTML document. Also change the guard clause to check for children size != 1 because the nodeset may be empty.