### PR TITLE
Do not enable "forward report" toggle by default

### DIFF
--- a/app/javascript/mastodon/features/report/comment.jsx
+++ b/app/javascript/mastodon/features/report/comment.jsx
@@ -59,12 +59,7 @@ const Comment = ({ comment, domain, statusIds, isRemote, isSubmitting, selectedD
 
     loadedRef.current = true;
 
-    // First, pre-select known domains
-    availableDomains.forEach((domain) => {
-      onToggleDomain(domain, true);
-    });
-
-    // Then, fetch missing replied-to accounts
+    // Fetch missing replied-to accounts
     const unknownAccounts = OrderedSet(accountIds.filter(accountId => accountId && !accountsMap.has(accountId)));
     unknownAccounts.forEach((accountId) => {
       dispatch(fetchAccount(accountId));


### PR DESCRIPTION
It is valuable to be able to report (anonymized) bad behavior to remote instance admins.  Unfortunately, in some / many cases, these anonymous reports wind up being screenshotted and used to run public retaliation campaigns against the reporting instance - and this places administrators in a bind, in which their duty to their users is met with an outside demand to "do something about this person".

No user should be punished for reporting something, and certainly admins will treat their own users with courtesy, but the software has baked in the assumption that every remote server is amenable to receiving such reports.  [This post proposes an extreme solution](https://mastodon.social/@fedilore/113041381236193141): the ability to instance-wide block the ability to forward reports.  My patch is simpler: reports are simply not forwarded by default.  This prevents accidental forwarding when the user didn't intend it, and it also causes users to make a calculated decision on whether the remote will handle it appropriately.