### PR TITLE
Extract method for account-referencing in CLI prune task

### DIFF
--- a/lib/mastodon/cli/accounts.rb
+++ b/lib/mastodon/cli/accounts.rb
@@ -502,17 +502,7 @@ module Mastodon::CLI
       - not muted/blocked by us
     LONG_DESC
     def prune
-      query = Account.remote.non_automated
-      query = query.where('NOT EXISTS (SELECT 1 FROM mentions WHERE account_id = accounts.id)')
-      query = query.where('NOT EXISTS (SELECT 1 FROM favourites WHERE account_id = accounts.id)')
-      query = query.where('NOT EXISTS (SELECT 1 FROM statuses WHERE account_id = accounts.id)')
-      query = query.where('NOT EXISTS (SELECT 1 FROM follows WHERE account_id = accounts.id OR target_account_id = accounts.id)')
-      query = query.where('NOT EXISTS (SELECT 1 FROM blocks WHERE account_id = accounts.id OR target_account_id = accounts.id)')
-      query = query.where('NOT EXISTS (SELECT 1 FROM mutes WHERE target_account_id = accounts.id)')
-      query = query.where('NOT EXISTS (SELECT 1 FROM reports WHERE target_account_id = accounts.id)')
-      query = query.where('NOT EXISTS (SELECT 1 FROM follow_requests WHERE account_id = accounts.id OR target_account_id = accounts.id)')
-
-      _, deleted = parallelize_with_progress(query) do |account|
+      _, deleted = parallelize_with_progress(prunable_accounts) do |account|
         next if account.bot? || account.group?
         next if account.suspended?
         next if account.silenced?
@@ -576,6 +566,31 @@ module Mastodon::CLI
     end
 
     private
+
+    def prunable_accounts
+      Account
+        .remote
+        .non_automated
+        .where.not(referencing_account(Mention, :account_id))
+        .where.not(referencing_account(Favourite, :account_id))
+        .where.not(referencing_account(Status, :account_id))
+        .where.not(referencing_account(Follow, :account_id))
+        .where.not(referencing_account(Follow, :target_account_id))
+        .where.not(referencing_account(Block, :account_id))
+        .where.not(referencing_account(Block, :target_account_id))
+        .where.not(referencing_account(Mute, :target_account_id))
+        .where.not(referencing_account(Report, :target_account_id))
+        .where.not(referencing_account(FollowRequest, :account_id))
+        .where.not(referencing_account(FollowRequest, :target_account_id))
+    end
+
+    def referencing_account(model, attribute)
+      model
+        .where(model.arel_table[attribute].eq Account.arel_table[:id])
+        .select(1)
+        .arel
+        .exists
+    end
 
     def report_errors(errors)
       message = errors.map do |error|


### PR DESCRIPTION
Follow-up on https://github.com/mastodon/mastodon/pull/31772/files#diff-6e4501125194d4a5e46e53a382c4bed1c8f05d901aaab09b4e7b8b3d5560edf8R505 and repeating basically the same approach as in https://github.com/mastodon/mastodon/pull/31244

The before/after query here is similar, differing basically just in framework-generated quoting/naming of things, and in that some of the previously OR'd exists queries are separated (but the logic is the same, I believe).

<details><summary>Before</summary>
<pre>
SELECT
    "accounts"."id",
    "accounts"."username",
    "accounts"."domain",
    "accounts"."private_key",
    "accounts"."public_key",
    "accounts"."created_at",
    "accounts"."updated_at",
    "accounts"."note",
    "accounts"."display_name",
    "accounts"."uri",
    "accounts"."url",
    "accounts"."avatar_file_name",
    "accounts"."avatar_content_type",
    "accounts"."avatar_file_size",
    "accounts"."avatar_updated_at",
    "accounts"."header_file_name",
    "accounts"."header_content_type",
    "accounts"."header_file_size",
    "accounts"."header_updated_at",
    "accounts"."avatar_remote_url",
    "accounts"."locked",
    "accounts"."header_remote_url",
    "accounts"."last_webfingered_at",
    "accounts"."inbox_url",
    "accounts"."outbox_url",
    "accounts"."shared_inbox_url",
    "accounts"."followers_url",
    "accounts"."protocol",
    "accounts"."memorial",
    "accounts"."moved_to_account_id",
    "accounts"."featured_collection_url",
    "accounts"."fields",
    "accounts"."actor_type",
    "accounts"."discoverable",
    "accounts"."also_known_as",
    "accounts"."silenced_at",
    "accounts"."suspended_at",
    "accounts"."hide_collections",
    "accounts"."avatar_storage_schema_version",
    "accounts"."header_storage_schema_version",
    "accounts"."devices_url",
    "accounts"."sensitized_at",
    "accounts"."suspension_origin",
    "accounts"."trendable",
    "accounts"."reviewed_at",
    "accounts"."requested_review_at",
    "accounts"."indexable"
FROM
    "accounts"
WHERE
    "accounts"."domain" IS NOT NULL
    AND "accounts"."actor_type" NOT IN ($1, $2)
    AND (
        NOT EXISTS (
            SELECT
                1
            FROM
                mentions
            WHERE
                account_id = accounts.id
        )
    )
    AND (
        NOT EXISTS (
            SELECT
                1
            FROM
                favourites
            WHERE
                account_id = accounts.id
        )
    )
    AND (
        NOT EXISTS (
            SELECT
                1
            FROM
                statuses
            WHERE
                account_id = accounts.id
        )
    )
    AND (
        NOT EXISTS (
            SELECT
                1
            FROM
                follows
            WHERE
                account_id = accounts.id
                OR target_account_id = accounts.id
        )
    )
    AND (
        NOT EXISTS (
            SELECT
                1
            FROM
                blocks
            WHERE
                account_id = accounts.id
                OR target_account_id = accounts.id
        )
    )
    AND (
        NOT EXISTS (
            SELECT
                1
            FROM
                mutes
            WHERE
                target_account_id = accounts.id
        )
    )
    AND (
        NOT EXISTS (
            SELECT
                1
            FROM
                reports
            WHERE
                target_account_id = accounts.id
        )
    )
    AND (
        NOT EXISTS (
            SELECT
                1
            FROM
                follow_requests
            WHERE
                account_id = accounts.id
                OR target_account_id = accounts.id
        )
    )
ORDER BY
    "accounts"."id" ASC
LIMIT
    $3
</pre>
</details>

<details><summary>After</summary>
<pre>
SELECT
    "accounts"."id",
    "accounts"."username",
    "accounts"."domain",
    "accounts"."private_key",
    "accounts"."public_key",
    "accounts"."created_at",
    "accounts"."updated_at",
    "accounts"."note",
    "accounts"."display_name",
    "accounts"."uri",
    "accounts"."url",
    "accounts"."avatar_file_name",
    "accounts"."avatar_content_type",
    "accounts"."avatar_file_size",
    "accounts"."avatar_updated_at",
    "accounts"."header_file_name",
    "accounts"."header_content_type",
    "accounts"."header_file_size",
    "accounts"."header_updated_at",
    "accounts"."avatar_remote_url",
    "accounts"."locked",
    "accounts"."header_remote_url",
    "accounts"."last_webfingered_at",
    "accounts"."inbox_url",
    "accounts"."outbox_url",
    "accounts"."shared_inbox_url",
    "accounts"."followers_url",
    "accounts"."protocol",
    "accounts"."memorial",
    "accounts"."moved_to_account_id",
    "accounts"."featured_collection_url",
    "accounts"."fields",
    "accounts"."actor_type",
    "accounts"."discoverable",
    "accounts"."also_known_as",
    "accounts"."silenced_at",
    "accounts"."suspended_at",
    "accounts"."hide_collections",
    "accounts"."avatar_storage_schema_version",
    "accounts"."header_storage_schema_version",
    "accounts"."devices_url",
    "accounts"."sensitized_at",
    "accounts"."suspension_origin",
    "accounts"."trendable",
    "accounts"."reviewed_at",
    "accounts"."requested_review_at",
    "accounts"."indexable"
FROM
    "accounts"
WHERE
    "accounts"."domain" IS NOT NULL
    AND "accounts"."actor_type" NOT IN ($1, $2)
    AND NOT (
        EXISTS (
            SELECT
                1
            FROM
                "mentions"
            WHERE
                "mentions"."account_id" = "accounts"."id"
        )
    )
    AND NOT (
        EXISTS (
            SELECT
                1
            FROM
                "favourites"
            WHERE
                "favourites"."account_id" = "accounts"."id"
        )
    )
    AND NOT (
        EXISTS (
            SELECT
                1
            FROM
                "statuses"
            WHERE
                "statuses"."deleted_at" IS NULL
                AND "statuses"."account_id" = "accounts"."id"
            ORDER BY
                "statuses"."id" DESC
        )
    )
    AND NOT (
        EXISTS (
            SELECT
                1
            FROM
                "follows"
            WHERE
                "follows"."account_id" = "accounts"."id"
        )
    )
    AND NOT (
        EXISTS (
            SELECT
                1
            FROM
                "follows"
            WHERE
                "follows"."target_account_id" = "accounts"."id"
        )
    )
    AND NOT (
        EXISTS (
            SELECT
                1
            FROM
                "blocks"
            WHERE
                "blocks"."account_id" = "accounts"."id"
        )
    )
    AND NOT (
        EXISTS (
            SELECT
                1
            FROM
                "blocks"
            WHERE
                "blocks"."target_account_id" = "accounts"."id"
        )
    )
    AND NOT (
        EXISTS (
            SELECT
                1
            FROM
                "mutes"
            WHERE
                "mutes"."target_account_id" = "accounts"."id"
        )
    )
    AND NOT (
        EXISTS (
            SELECT
                1
            FROM
                "reports"
            WHERE
                "reports"."target_account_id" = "accounts"."id"
        )
    )
    AND NOT (
        EXISTS (
            SELECT
                1
            FROM
                "follow_requests"
            WHERE
                "follow_requests"."account_id" = "accounts"."id"
        )
    )
    AND NOT (
        EXISTS (
            SELECT
                1
            FROM
                "follow_requests"
            WHERE
                "follow_requests"."target_account_id" = "accounts"."id"
        )
    )
ORDER BY
    "accounts"."id" ASC
LIMIT
    $3
</pre>
</details>


I was looking to use Rails `missing` and/or `associated` methods for this situation, but those use a left outer join with a null check to identify rows with missing associations (as opposed to NOT EXISTS approach here). There have been efforts/PRs over the years to add something like that, but nothing successful so far. If we use this pattern another couple times I'll look for somewhere to extract it to. Ideally this would be done in a more generic way like those missing/associated methods, where you reflect on the association name and pull out the relevant tables/columns/etc from that. Seems doable but want to confirm the pattern first.

Asides:

- I noticed that in this outer query we're selecting non_automated (which should exclude Application/Service actors) but then within the loop we have another check for `bot?` ... is this extraneous?
- The group/silenced/suspended checks are not extraneous ... but could also be pulled to outer query?
- This is at least a test data question and maybe a real data question ... on Account, actor_type is not enforced to be present, and the fabricator doesn't set it. We set it via the `bot=` in the spec here, but (I think) if we had a query similar to the `where actor_type not in ...` sort of thing, and we did have null values, they wouldn't get included. Maybe a test-only edge case, but I guess the question is ... SHOULD there be a presence enforcement and/or a valid values enforcement on `accounts.actor_type`?

