### PR TITLE
Add `Account#remote?` query method

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -107,7 +107,7 @@ class Account < ApplicationRecord
   validates_with UniqueUsernameValidator, if: -> { will_save_change_to_username? }
 
   # Remote user validations, also applies to internal actors
-  validates :username, format: { with: USERNAME_ONLY_RE }, if: -> { (!local? || actor_type == 'Application') && will_save_change_to_username? }
+  validates :username, format: { with: USERNAME_ONLY_RE }, if: -> { (remote? || actor_type == 'Application') && will_save_change_to_username? }
 
   # Remote user validations
   validates :uri, presence: true, unless: :local?, on: :create
@@ -183,6 +183,10 @@ class Account < ApplicationRecord
 
   def local?
     domain.nil?
+  end
+
+  def remote?
+    domain.present?
   end
 
   def moved?

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -64,11 +64,7 @@ class Poll < ApplicationRecord
     votes.where(account: account).pluck(:choice)
   end
 
-  delegate :local?, to: :account
-
-  def remote?
-    !local?
-  end
+  delegate :local?, :remote?, to: :account
 
   def emojis
     @emojis ||= CustomEmoji.from_text(options.join(' '), account.domain)

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -48,14 +48,26 @@ RSpec.describe Account do
   end
 
   describe '#local?' do
-    it 'returns true when the account is local' do
+    it 'returns true when domain is null' do
       account = Fabricate(:account, domain: nil)
-      expect(account.local?).to be true
+      expect(account).to be_local
     end
 
-    it 'returns false when the account is on a different domain' do
+    it 'returns false when domain is present' do
       account = Fabricate(:account, domain: 'foreign.tld')
-      expect(account.local?).to be false
+      expect(account).to_not be_local
+    end
+  end
+
+  describe '#remote?' do
+    it 'returns false when the domain is null' do
+      account = Fabricate(:account, domain: nil)
+      expect(account).to_not be_remote
+    end
+
+    it 'returns true when domain is present' do
+      account = Fabricate(:account, domain: 'foreign.tld')
+      expect(account).to be_remote
     end
   end
 


### PR DESCRIPTION
The opposite of the already existing `local?` method, adding here in advance of further cleanup of the local-vs-remote validations on Account, which are currently sort of verbose/repetitive, but need (I suspect) this method to clean up.