### PR TITLE
Use `prefer` as the default value for `DB_SSLMODE` in the streaming API database configuration

### DIFF
--- a/streaming/database.js
+++ b/streaming/database.js
@@ -82,19 +82,17 @@ export function configFromEnv(env, environment) {
   } else if (Object.hasOwn(pgConfigs, environment)) {
     baseConfig = pgConfigs[environment];
 
-    if (env.DB_SSLMODE) {
-      switch(env.DB_SSLMODE) {
-      case 'disable':
-      case '':
-        baseConfig.ssl = false;
-        break;
-      case 'no-verify':
-        baseConfig.ssl = { rejectUnauthorized: false };
-        break;
-      default:
-        baseConfig.ssl = {};
-        break;
-      }
+    switch(env.DB_SSLMODE) {
+    case 'disable':
+      baseConfig.ssl = false;
+      break;
+    case 'no-verify':
+      baseConfig.ssl = { rejectUnauthorized: false };
+      break;
+    case 'prefer':
+    default:
+      baseConfig.ssl = {};
+      break;
     }
   } else {
     throw new Error('Unable to resolve postgresql database configuration.');


### PR DESCRIPTION
As explained in #31774, there appears to be a discrepancy between the documentation about `DB_SSLMODE` and its actual behaviour. The documentation stated that `prefer` is the default value when the environment variable is unset. However, the database configuration for the streaming API doesn't reflect this behaviour. This pull request addresses the issue.