### PR TITLE
Prevent new embed script from loading arbitrary URLs

### DIFF
--- a/app/serializers/oembed_serializer.rb
+++ b/app/serializers/oembed_serializer.rb
@@ -45,7 +45,7 @@ class OEmbedSerializer < ActiveModel::Serializer
           <div style="font-weight: 500;">View on Mastodon</div>
         </a>
       </blockquote>
-      <script src="#{full_asset_url('embed.js', skip_pipeline: true)}" async="true"></script>
+      <script data-allowed-prefixes="#{root_url}" src="#{full_asset_url('embed.js', skip_pipeline: true)}" async="true"></script>
     HTML
   end
 

--- a/public/embed.js
+++ b/public/embed.js
@@ -1,5 +1,7 @@
 // @ts-check
 
+const allowedPrefixes = (document.currentScript && document.currentScript.tagName.toUpperCase() === 'SCRIPT' && document.currentScript.dataset.allowedPrefixes) ? document.currentScript.dataset.allowedPrefixes.split(' ') : [];
+
 (function () {
   'use strict';
 
@@ -104,6 +106,7 @@
       var embedUrl = new URL(container.getAttribute('data-embed-url'));
 
       if (embedUrl.protocol !== 'https:' && embedUrl.protocol !== 'http:') return;
+      if (allowedPrefixes.every((allowedPrefix) => !embedUrl.toString().startsWith(allowedPrefix))) return;
 
       iframe.src = embedUrl.toString();
       iframe.width = container.clientWidth;


### PR DESCRIPTION
This is just hardening to avoid the embed script possibly being used in an XSS by an attacker able to create blockquote HTML elements with a specific class name and `data` attribute.

After this change, to perform an XSS, the attacker would have to also control the `data-allowed-prefixes` attribute of the `script` element, which basically means having an XSS already.

This change is compatible with the script being eventually hosted on a different domain, as well as manually including the script once for multiple posts or multiple domains (by manually adjusting `data-allowed-prefixes`).