### PR TITLE
Second attempt at disabling Codecov annotations

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,4 +1,3 @@
-annotations: false
 comment: false # Do not leave PR comments
 coverage:
   status:
@@ -10,3 +9,5 @@ coverage:
       default:
         # GitHub status check is not blocking
         informational: true
+github_checks:
+  annotations: false


### PR DESCRIPTION
The documentation (<https://docs.codecov.com/docs/codecovyml-reference#codecov-cloud-report-archiving>) was confusing, but I think this was not supposed to be a root key.