### PR TITLE
Remove `body_class_string` helper, use `class_names` in `body_classes` helper

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,7 +22,6 @@ class ApplicationController < ActionController::Base
   helper_method :use_seamless_external_login?
   helper_method :sso_account_settings
   helper_method :limited_federation_mode?
-  helper_method :body_class_string
   helper_method :skip_csrf_meta_tags?
 
   rescue_from ActionController::ParameterMissing, Paperclip::AdapterRegistry::NoHandlerError, with: :bad_request
@@ -156,10 +155,6 @@ class ApplicationController < ActionController::Base
     return Setting.theme unless Themes.instance.names.include? current_user&.setting_theme
 
     current_user.setting_theme
-  end
-
-  def body_class_string
-    @body_classes || ''
   end
 
   def respond_with_error(code)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -143,13 +143,13 @@ module ApplicationHelper
   end
 
   def body_classes
-    output = body_class_string.split
-    output << content_for(:body_classes)
-    output << "theme-#{current_theme.parameterize}"
-    output << 'system-font' if current_account&.user&.setting_system_font_ui
-    output << (current_account&.user&.setting_reduce_motion ? 'reduce-motion' : 'no-reduce-motion')
-    output << 'rtl' if locale_direction == 'rtl'
-    output.compact_blank.join(' ')
+    class_names(
+      content_for(:body_classes),
+      "theme-#{current_theme.parameterize}",
+      (current_account&.user&.setting_reduce_motion ? 'reduce-motion' : 'no-reduce-motion'),
+      locale_direction,
+      'system-font': current_account&.user&.setting_system_font_ui
+    )
   end
 
   def cdn_host

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -5,12 +5,20 @@ require 'rails_helper'
 RSpec.describe ApplicationHelper do
   describe 'body_classes' do
     context 'with a body class string from a controller' do
-      before { helper.extend controller_helpers }
+      before do
+        user = Fabricate :user
+        user.settings['web.use_system_font'] = true
+        user.settings['web.reduce_motion'] = true
+        user.save
 
-      it 'uses the controller body classes in the result' do
+        helper.extend controller_helpers
+      end
+
+      it 'uses the current theme and user settings classes in the result' do
         expect(helper.body_classes)
-          .to match(/modal-layout compose-standalone/)
-          .and match(/theme-default/)
+          .to match(/theme-default/)
+          .and match(/system-font/)
+          .and match(/reduce-motion/)
       end
 
       it 'includes values set via content_for' do
@@ -24,10 +32,8 @@ RSpec.describe ApplicationHelper do
 
       def controller_helpers
         Module.new do
-          def body_class_string = 'modal-layout compose-standalone'
-
           def current_account
-            @current_account ||= Fabricate(:account)
+            @current_account ||= Fabricate(:account, user: User.last)
           end
 
           def current_theme = 'default'


### PR DESCRIPTION
This contains the entire contents of https://github.com/mastodon/mastodon/pull/31797 / https://github.com/mastodon/mastodon/pull/31796 / https://github.com/mastodon/mastodon/pull/31787 - and also the final removal/cleanup of the body class helpers.

I'll keep this rebased as those merge, until this is just the final removal. The only notable change here other than the removal of what will be the unused `body_class_string` method, is to also update `body_classes` to just use built-in `class_names` for the compact/join step.