### PR TITLE
Fix alt text modal styling

### DIFF
--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -159,13 +159,18 @@
 .error-modal,
 .onboarding-modal,
 .compare-history-modal,
-.report-modal__comment .setting-text__wrapper,
-.report-modal__comment .setting-text,
+.report-modal__comment,
+.report-modal__comment,
 .announcements,
 .picture-in-picture__header,
 .picture-in-picture__footer,
 .reactions-bar__item {
   background: $white;
+  border: 1px solid var(--background-border-color);
+}
+
+.setting-text__wrapper,
+.setting-text {
   border: 1px solid var(--background-border-color);
 }
 
@@ -196,14 +201,6 @@
 .icon-with-badge__badge {
   border-color: $white;
   color: $white;
-}
-
-.report-modal__comment {
-  border-right-color: lighten($ui-base-color, 8%);
-}
-
-.report-modal__container {
-  border-top-color: lighten($ui-base-color, 8%);
 }
 
 .column-settings__hashtags .column-select__option {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -3911,7 +3911,7 @@ $ui-header-logo-wordmark-width: 99px;
 
   &__wrapper {
     background: $white;
-    border: 1px solid $ui-secondary-color;
+    border: 1px solid var(--background-border-color);
     margin-bottom: 10px;
     border-radius: 4px;
 
@@ -6298,9 +6298,10 @@ a.status-card {
 .report-modal,
 .actions-modal,
 .compare-history-modal {
-  background: lighten($ui-secondary-color, 8%);
-  color: $inverted-text-color;
-  border-radius: 8px;
+  background: var(--background-color);
+  color: $primary-text-color;
+  border-radius: 4px;
+  border: 1px solid var(--background-border-color);
   overflow: hidden;
   max-width: 90vw;
   width: 480px;
@@ -6344,6 +6345,7 @@ a.status-card {
 .report-modal {
   width: 90vw;
   max-width: 700px;
+  border: 1px solid var(--background-border-color);
 }
 
 .report-dialog-modal {
@@ -6567,7 +6569,7 @@ a.status-card {
 
 .report-modal__container {
   display: flex;
-  border-top: 1px solid $ui-secondary-color;
+  border-top: 1px solid var(--background-border-color);
 
   @media screen and (width <= 480px) {
     flex-wrap: wrap;
@@ -6625,7 +6627,7 @@ a.status-card {
 
 .report-modal__comment {
   padding: 20px;
-  border-inline-end: 1px solid $ui-secondary-color;
+  border-inline-end: 1px solid var(--background-border-color);
   max-width: 320px;
 
   p {
@@ -6636,7 +6638,7 @@ a.status-card {
 
   .setting-text-label {
     display: block;
-    color: $inverted-text-color;
+    color: $secondary-text-color;
     font-size: 14px;
     font-weight: 500;
     margin-bottom: 10px;


### PR DESCRIPTION
Fixes #31690

Applies similar styling as done for filter and report modals in #31349

Before
<img width="973" alt="Screenshot 2024-09-10 at 9 59 45 AM" src="https://github.com/user-attachments/assets/61cbeedc-c263-483d-b202-628133dfa766">
<img width="976" alt="Screenshot 2024-09-10 at 9 59 16 AM" src="https://github.com/user-attachments/assets/530b8795-5d9c-421d-acfa-c6bfcf967cbd">

After
<img width="977" alt="Screenshot 2024-09-10 at 9 58 09 AM" src="https://github.com/user-attachments/assets/78c23339-a0d8-478b-86b1-074e0c3bdf5f">
<img width="976" alt="Screenshot 2024-09-10 at 10 24 26 AM" src="https://github.com/user-attachments/assets/65b7c063-d043-4fca-9a9d-8e9bb8620cd5">
