### PR TITLE
Remove vendor prefix from `mobile-web-app-capable` meta tag

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -21,7 +21,7 @@
       %link{ rel: 'mask-icon', href: frontend_asset_path('images/logo-symbol-icon.svg'), color: '#6364FF' }/
     %link{ rel: 'manifest', href: manifest_path(format: :json) }/
     = theme_color_tags current_theme
-    %meta{ name: 'apple-mobile-web-app-capable', content: 'yes' }/
+    %meta{ name: 'mobile-web-app-capable', content: 'yes' }/
 
     %title= html_title
 


### PR DESCRIPTION
Silences browser deprecation warning from chrome.

I struggled to find definitive version/capability reference on this - I believe this tag predates standardization of manifest handling, and can be safely changed like this. Would love to point to something more authoritative if we can find something.