### PR TITLE
Remove `fa_` prefix from status visibility icon method

### DIFF
--- a/app/helpers/statuses_helper.rb
+++ b/app/helpers/statuses_helper.rb
@@ -4,6 +4,13 @@ module StatusesHelper
   EMBEDDED_CONTROLLER = 'statuses'
   EMBEDDED_ACTION = 'embed'
 
+  VISIBLITY_ICONS = {
+    public: 'globe',
+    unlisted: 'lock_open',
+    private: 'lock',
+    direct: 'alternate_email',
+  }.freeze
+
   def nothing_here(extra_classes = '')
     content_tag(:div, class: "nothing-here #{extra_classes}") do
       t('accounts.nothing_here')
@@ -57,17 +64,8 @@ module StatusesHelper
     embedded_view? ? '_blank' : nil
   end
 
-  def fa_visibility_icon(status)
-    case status.visibility
-    when 'public'
-      material_symbol 'globe'
-    when 'unlisted'
-      material_symbol 'lock_open'
-    when 'private'
-      material_symbol 'lock'
-    when 'direct'
-      material_symbol 'alternate_email'
-    end
+  def visibility_icon(status)
+    VISIBLITY_ICONS[status.visibility.to_sym]
   end
 
   def embedded_view?

--- a/app/views/admin/reports/_status.html.haml
+++ b/app/views/admin/reports/_status.html.haml
@@ -33,7 +33,7 @@
         = material_symbol('repeat_active')
         = t('statuses.boosted_from_html', acct_link: admin_account_inline_link_to(status.proper.account))
       - else
-        = fa_visibility_icon(status)
+        = material_symbol visibility_icon(status)
         = t("statuses.visibilities.#{status.visibility}")
       - if status.proper.sensitive?
         ·

--- a/app/views/filters/statuses/_status_filter.html.haml
+++ b/app/views/filters/statuses/_status_filter.html.haml
@@ -29,7 +29,7 @@
         ·
         = t('statuses.edited_at_html', date: content_tag(:time, l(status.edited_at), datetime: status.edited_at.iso8601, title: l(status.edited_at), class: 'formatted'))
       ·
-      = fa_visibility_icon(status)
+      = material_symbol visibility_icon(status)
       = t("statuses.visibilities.#{status.visibility}")
       - if status.sensitive?
         ·

--- a/spec/helpers/statuses_helper_spec.rb
+++ b/spec/helpers/statuses_helper_spec.rb
@@ -36,14 +36,14 @@ RSpec.describe StatusesHelper do
     end
   end
 
-  describe 'fa_visibility_icon' do
+  describe 'visibility_icon' do
     context 'with a status that is public' do
       let(:status) { Status.new(visibility: 'public') }
 
       it 'returns the correct fa icon' do
-        result = helper.fa_visibility_icon(status)
+        result = helper.visibility_icon(status)
 
-        expect(result).to match('material-globe')
+        expect(result).to match('globe')
       end
     end
 
@@ -51,9 +51,9 @@ RSpec.describe StatusesHelper do
       let(:status) { Status.new(visibility: 'unlisted') }
 
       it 'returns the correct fa icon' do
-        result = helper.fa_visibility_icon(status)
+        result = helper.visibility_icon(status)
 
-        expect(result).to match('material-lock_open')
+        expect(result).to match('lock_open')
       end
     end
 
@@ -61,9 +61,9 @@ RSpec.describe StatusesHelper do
       let(:status) { Status.new(visibility: 'private') }
 
       it 'returns the correct fa icon' do
-        result = helper.fa_visibility_icon(status)
+        result = helper.visibility_icon(status)
 
-        expect(result).to match('material-lock')
+        expect(result).to match('lock')
       end
     end
 
@@ -71,9 +71,9 @@ RSpec.describe StatusesHelper do
       let(:status) { Status.new(visibility: 'direct') }
 
       it 'returns the correct fa icon' do
-        result = helper.fa_visibility_icon(status)
+        result = helper.visibility_icon(status)
 
-        expect(result).to match('material-alternate_email')
+        expect(result).to match('alternate_email')
       end
     end
   end


### PR DESCRIPTION
This is just some naming cleanup after font-awesome removal.