### PR TITLE
Add coverage for `AnnualReport::*` source child classes

### DIFF
--- a/spec/lib/annual_report/commonly_interacted_with_accounts_spec.rb
+++ b/spec/lib/annual_report/commonly_interacted_with_accounts_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AnnualReport::CommonlyInteractedWithAccounts do
+  describe '#generate' do
+    subject { described_class.new(account, Time.zone.now.year) }
+
+    context 'with an inactive account' do
+      let(:account) { Fabricate :account }
+
+      it 'builds a report for an account' do
+        expect(subject.generate)
+          .to include(
+            commonly_interacted_with_accounts: be_an(Array).and(be_empty)
+          )
+      end
+    end
+
+    context 'with an active account' do
+      let(:account) { Fabricate :account }
+
+      let(:other_account) { Fabricate :account }
+
+      before do
+        _other = Fabricate :status
+        Fabricate :status, account: account, reply: true, in_reply_to_id: Fabricate(:status, account: other_account).id
+        Fabricate :status, account: account, reply: true, in_reply_to_id: Fabricate(:status, account: other_account).id
+      end
+
+      it 'builds a report for an account' do
+        expect(subject.generate)
+          .to include(
+            commonly_interacted_with_accounts: contain_exactly(
+              include(account_id: other_account.id, count: 2)
+            )
+          )
+      end
+    end
+  end
+end

--- a/spec/lib/annual_report/most_reblogged_accounts_spec.rb
+++ b/spec/lib/annual_report/most_reblogged_accounts_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AnnualReport::MostRebloggedAccounts do
+  describe '#generate' do
+    subject { described_class.new(account, Time.zone.now.year) }
+
+    context 'with an inactive account' do
+      let(:account) { Fabricate :account }
+
+      it 'builds a report for an account' do
+        expect(subject.generate)
+          .to include(
+            most_reblogged_accounts: be_an(Array).and(be_empty)
+          )
+      end
+    end
+
+    context 'with an active account' do
+      let(:account) { Fabricate :account }
+
+      let(:other_account) { Fabricate :account }
+
+      before do
+        _other = Fabricate :status
+        Fabricate :status, account: account, reblog: Fabricate(:status, account: other_account)
+        Fabricate :status, account: account, reblog: Fabricate(:status, account: other_account)
+      end
+
+      it 'builds a report for an account' do
+        expect(subject.generate)
+          .to include(
+            most_reblogged_accounts: contain_exactly(
+              include(account_id: other_account.id, count: 2)
+            )
+          )
+      end
+    end
+  end
+end

--- a/spec/lib/annual_report/most_used_apps_spec.rb
+++ b/spec/lib/annual_report/most_used_apps_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AnnualReport::MostUsedApps do
+  describe '#generate' do
+    subject { described_class.new(account, Time.zone.now.year) }
+
+    context 'with an inactive account' do
+      let(:account) { Fabricate :account }
+
+      it 'builds a report for an account' do
+        expect(subject.generate)
+          .to include(
+            most_used_apps: be_an(Array).and(be_empty)
+          )
+      end
+    end
+
+    context 'with an active account' do
+      let(:account) { Fabricate :account }
+
+      let(:application) { Fabricate :application }
+
+      before do
+        _other = Fabricate :status
+        Fabricate.times 2, :status, account: account, application: application
+      end
+
+      it 'builds a report for an account' do
+        expect(subject.generate)
+          .to include(
+            most_used_apps: contain_exactly(
+              include(name: application.name, count: 2)
+            )
+          )
+      end
+    end
+  end
+end

--- a/spec/lib/annual_report/percentiles_spec.rb
+++ b/spec/lib/annual_report/percentiles_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AnnualReport::Percentiles do
+  describe '#generate' do
+    subject { described_class.new(account, Time.zone.now.year) }
+
+    context 'with an inactive account' do
+      let(:account) { Fabricate :account }
+
+      it 'builds a report for an account' do
+        expect(subject.generate)
+          .to include(
+            percentiles: include(
+              followers: 0,
+              statuses: 0
+            )
+          )
+      end
+    end
+
+    context 'with an active account' do
+      let(:account) { Fabricate :account }
+
+      before do
+        Fabricate.times 2, :status # Others as `account`
+        Fabricate.times 2, :follow # Others as `target_account`
+        Fabricate.times 2, :status, account: account
+        Fabricate.times 2, :follow, target_account: account
+      end
+
+      it 'builds a report for an account' do
+        expect(subject.generate)
+          .to include(
+            percentiles: include(
+              followers: 50,
+              statuses: 50
+            )
+          )
+      end
+    end
+  end
+end

--- a/spec/lib/annual_report/time_series_spec.rb
+++ b/spec/lib/annual_report/time_series_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AnnualReport::TimeSeries do
+  describe '#generate' do
+    subject { described_class.new(account, Time.zone.now.year) }
+
+    context 'with an inactive account' do
+      let(:account) { Fabricate :account }
+
+      it 'builds a report for an account' do
+        expect(subject.generate)
+          .to include(
+            time_series: match(
+              include(followers: 0, following: 0, month: 1, statuses: 0)
+            )
+          )
+      end
+    end
+
+    context 'with an active account' do
+      let(:account) { Fabricate :account }
+
+      let(:month_one_date) { DateTime.new(Time.zone.now.year, 1, 1, 12, 12, 12) }
+
+      let(:tag) { Fabricate :tag }
+
+      before do
+        _other = Fabricate :status
+        Fabricate :status, account: account, created_at: month_one_date
+        Fabricate :follow, account: account, created_at: month_one_date
+        Fabricate :follow, target_account: account, created_at: month_one_date
+      end
+
+      it 'builds a report for an account' do
+        expect(subject.generate)
+          .to include(
+            time_series: match(
+              include(followers: 1, following: 1, month: 1, statuses: 1)
+            )
+          )
+      end
+    end
+  end
+end

--- a/spec/lib/annual_report/top_hashtags_spec.rb
+++ b/spec/lib/annual_report/top_hashtags_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AnnualReport::TopHashtags do
+  describe '#generate' do
+    subject { described_class.new(account, Time.zone.now.year) }
+
+    context 'with an inactive account' do
+      let(:account) { Fabricate :account }
+
+      it 'builds a report for an account' do
+        expect(subject.generate)
+          .to include(
+            top_hashtags: be_an(Array).and(be_empty)
+          )
+      end
+    end
+
+    context 'with an active account' do
+      let(:account) { Fabricate :account }
+
+      let(:tag) { Fabricate :tag }
+
+      before do
+        _other = Fabricate :status
+        first = Fabricate :status, account: account
+        first.tags << tag
+        last = Fabricate :status, account: account
+        last.tags << tag
+      end
+
+      it 'builds a report for an account' do
+        expect(subject.generate)
+          .to include(
+            top_hashtags: contain_exactly(
+              include(name: tag.name, count: 2)
+            )
+          )
+      end
+    end
+  end
+end

--- a/spec/lib/annual_report/top_statuses_spec.rb
+++ b/spec/lib/annual_report/top_statuses_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AnnualReport::TopStatuses do
+  describe '#generate' do
+    subject { described_class.new(account, Time.zone.now.year) }
+
+    context 'with an inactive account' do
+      let(:account) { Fabricate :account }
+
+      it 'builds a report for an account' do
+        expect(subject.generate)
+          .to include(
+            top_statuses: include(
+              by_reblogs: be_nil,
+              by_favourites: be_nil,
+              by_replies: be_nil
+            )
+          )
+      end
+    end
+
+    context 'with an active account' do
+      let(:account) { Fabricate :account }
+
+      let(:reblogged_status) { Fabricate :status, account: account }
+      let(:favourited_status) { Fabricate :status, account: account }
+      let(:replied_status) { Fabricate :status, account: account }
+
+      before do
+        _other = Fabricate :status
+        reblogged_status.status_stat.update(reblogs_count: 123)
+        favourited_status.status_stat.update(favourites_count: 123)
+        replied_status.status_stat.update(replies_count: 123)
+      end
+
+      it 'builds a report for an account' do
+        expect(subject.generate)
+          .to include(
+            top_statuses: include(
+              by_reblogs: reblogged_status.id,
+              by_favourites: favourited_status.id,
+              by_replies: replied_status.id
+            )
+          )
+      end
+    end
+  end
+end

--- a/spec/lib/annual_report/type_distribution_spec.rb
+++ b/spec/lib/annual_report/type_distribution_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AnnualReport::TypeDistribution do
+  describe '#generate' do
+    subject { described_class.new(account, Time.zone.now.year) }
+
+    context 'with an inactive account' do
+      let(:account) { Fabricate :account }
+
+      it 'builds a report for an account' do
+        expect(subject.generate)
+          .to include(
+            type_distribution: include(
+              total: 0,
+              reblogs: 0,
+              replies: 0,
+              standalone: 0
+            )
+          )
+      end
+    end
+
+    context 'with an active account' do
+      let(:account) { Fabricate :account }
+
+      before do
+        _other = Fabricate :status
+        Fabricate :status, reblog: Fabricate(:status), account: account
+        Fabricate :status, in_reply_to_id: Fabricate(:status).id, account: account, reply: true
+        Fabricate :status, account: account
+      end
+
+      it 'builds a report for an account' do
+        expect(subject.generate)
+          .to include(
+            type_distribution: include(
+              total: 3,
+              reblogs: 1,
+              replies: 1,
+              standalone: 1
+            )
+          )
+      end
+    end
+  end
+end


### PR DESCRIPTION
For basically all of these, each spec has two examples -- one that asserts nil/empty/zero/whatever for the case where the account exists but with no activity, and another which does some basic data setup just so the responses are not empty. I'm sure there are uncovered edge cases and conditions here, but wanted to have at least something in place before any more changes to that area. Will continue to add coverage if I do any risky changes there.