### PR TITLE
Add thumbnails to grouped notifications in web UI

### DIFF
--- a/app/javascript/mastodon/features/notifications_v2/components/embedded_status.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/components/embedded_status.tsx
@@ -17,6 +17,7 @@ import type { Status } from 'mastodon/models/status';
 import { useAppSelector, useAppDispatch } from 'mastodon/store';
 
 import { EmbeddedStatusContent } from './embedded_status_content';
+import { EmbeddedStatusThumbnail } from './embedded_status_thumbnail';
 
 export type Mention = RecordOf<{ url: string; acct: string }>;
 
@@ -142,12 +143,19 @@ export const EmbeddedStatus: React.FC<{ statusId: string }> = ({
       )}
 
       {(!contentWarning || expanded) && (
-        <EmbeddedStatusContent
-          className='notification-group__embedded-status__content reply-indicator__content translate'
-          content={contentHtml}
-          language={language}
-          mentions={mentions}
-        />
+        <div className='notification-group__embedded-status__row'>
+          <EmbeddedStatusThumbnail
+            className='notification-group__embedded-status__thumbnail'
+            statusId={statusId}
+          />
+
+          <EmbeddedStatusContent
+            className='notification-group__embedded-status__content reply-indicator__content translate'
+            content={contentHtml}
+            language={language}
+            mentions={mentions}
+          />
+        </div>
       )}
 
       {expanded && (poll || mediaAttachmentsSize > 0) && (

--- a/app/javascript/mastodon/features/notifications_v2/components/embedded_status_thumbnail.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/components/embedded_status_thumbnail.tsx
@@ -1,0 +1,53 @@
+import { useState, useCallback } from 'react';
+
+import { is } from 'immutable';
+
+import { Blurhash } from 'mastodon/components/blurhash';
+import { useBlurhash } from 'mastodon/initial_state';
+import type { MediaAttachment } from 'mastodon/models/status';
+import { useAppSelector } from 'mastodon/store';
+
+export const EmbeddedStatusThumbnail: React.FC<{
+  statusId: string;
+  className?: string;
+}> = ({ statusId, className }) => {
+  const attachment = useAppSelector(
+    (state) =>
+      state.statuses.getIn([statusId, 'media_attachments', 0]) as
+        | MediaAttachment
+        | undefined,
+    (oldValue, newValue) => is(oldValue, newValue),
+  );
+  const [loaded, setLoaded] = useState(false);
+
+  const handleLoad = useCallback(() => {
+    setLoaded(true);
+  }, [setLoaded]);
+
+  if (!attachment) {
+    return null;
+  }
+
+  const previewUrl = attachment.get('preview_url') as string;
+  const blurhash = attachment.get('blurhash') as string;
+  const description = (attachment.getIn(['translation', 'description']) ||
+    attachment.get('description')) as string;
+  const focusX = (attachment.getIn(['meta', 'focus', 'x']) || 0) as number;
+  const focusY = (attachment.getIn(['meta', 'focus', 'y']) || 0) as number;
+  const x = (focusX / 2 + 0.5) * 100;
+  const y = (focusY / -2 + 0.5) * 100;
+
+  return (
+    <div className={className}>
+      {!loaded && <Blurhash hash={blurhash} dummy={!useBlurhash} />}
+
+      <img
+        src={previewUrl}
+        alt={description}
+        title={description}
+        onLoad={handleLoad}
+        style={{ objectPosition: `${x}% ${y}%` }}
+      />
+    </div>
+  );
+};

--- a/app/javascript/mastodon/models/status.ts
+++ b/app/javascript/mastodon/models/status.ts
@@ -10,3 +10,6 @@ export type Status = Immutable.Map<string, unknown>;
 type CardShape = Required<ApiPreviewCardJSON>;
 
 export type Card = RecordOf<CardShape>;
+
+// Temporary until we type it correctly
+export type MediaAttachment = Immutable.Map<string, unknown>;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -10626,6 +10626,36 @@ noscript {
       }
     }
 
+    &__row {
+      display: flex;
+      gap: 8px;
+      align-items: flex-start;
+    }
+
+    &__thumbnail {
+      flex: 0 0 auto;
+      width: 90px;
+      height: 90px;
+      border-radius: 8px;
+      overflow: hidden;
+      position: relative;
+
+      canvas {
+        position: absolute;
+        top: 0;
+        inset-inline-start: 0;
+        width: 100%;
+        height: 100%;
+      }
+
+      img {
+        display: block;
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+      }
+    }
+
     &__content {
       display: -webkit-box;
       font-size: 15px;


### PR DESCRIPTION
To make it a bit easier to visually distinguish notifications for different posts, display a singular thumbnail.

![grafik](https://github.com/user-attachments/assets/55b42eb9-39fe-476f-924c-ed772fa035e1)
