### PR TITLE
Clean up `AnnualReport::*` classes

### DIFF
--- a/app/lib/annual_report/commonly_interacted_with_accounts.rb
+++ b/app/lib/annual_report/commonly_interacted_with_accounts.rb
@@ -2,21 +2,32 @@
 
 class AnnualReport::CommonlyInteractedWithAccounts < AnnualReport::Source
   SET_SIZE = 40
+  MINIMUM_INTERACTIONS = 1
 
   def generate
     {
-      commonly_interacted_with_accounts: commonly_interacted_with_accounts.map do |(account_id, count)|
-                                           {
-                                             account_id: account_id.to_s,
-                                             count: count,
-                                           }
-                                         end,
+      commonly_interacted_with_accounts: account_map,
     }
   end
 
   private
 
+  def account_map
+    commonly_interacted_with_accounts.map do |account_id, count|
+      {
+        account_id: account_id.to_s,
+        count: count,
+      }
+    end
+  end
+
   def commonly_interacted_with_accounts
-    report_statuses.where.not(in_reply_to_account_id: @account.id).group(:in_reply_to_account_id).having('count(*) > 1').order(total: :desc).limit(SET_SIZE).pluck(Arel.sql('in_reply_to_account_id, count(*) AS total'))
+    report_statuses
+      .without_replies_to(@account)
+      .group(:in_reply_to_account_id)
+      .having(Arel.star.count.gt(MINIMUM_INTERACTIONS))
+      .limit(SET_SIZE)
+      .order(total: :desc)
+      .pluck(:in_reply_to_account_id, Arel.star.count.as('total'))
   end
 end

--- a/app/lib/annual_report/most_used_apps.rb
+++ b/app/lib/annual_report/most_used_apps.rb
@@ -5,18 +5,27 @@ class AnnualReport::MostUsedApps < AnnualReport::Source
 
   def generate
     {
-      most_used_apps: most_used_apps.map do |(name, count)|
-                        {
-                          name: name,
-                          count: count,
-                        }
-                      end,
+      most_used_apps: app_map,
     }
   end
 
   private
 
+  def app_map
+    most_used_apps.map do |name, count|
+      {
+        name: name,
+        count: count,
+      }
+    end
+  end
+
   def most_used_apps
-    report_statuses.joins(:application).group('oauth_applications.name').order(total: :desc).limit(SET_SIZE).pluck(Arel.sql('oauth_applications.name, count(*) as total'))
+    report_statuses
+      .group(Doorkeeper::Application.arel_table[:name])
+      .joins(:application)
+      .limit(SET_SIZE)
+      .order(total: :desc)
+      .pluck(Doorkeeper::Application.arel_table[:name], Arel.star.count.as('total'))
   end
 end

--- a/app/lib/annual_report/time_series.rb
+++ b/app/lib/annual_report/time_series.rb
@@ -1,30 +1,78 @@
 # frozen_string_literal: true
 
 class AnnualReport::TimeSeries < AnnualReport::Source
+  MONTH_INDEXES = (1..12)
+
   def generate
     {
-      time_series: (1..12).map do |month|
-                     {
-                       month: month,
-                       statuses: statuses_per_month[month] || 0,
-                       following: following_per_month[month] || 0,
-                       followers: followers_per_month[month] || 0,
-                     }
-                   end,
+      time_series: time_series_map,
     }
   end
 
   private
 
+  def time_series_map
+    MONTH_INDEXES.map do |month|
+      {
+        month: month,
+        statuses: statuses_per_month[month] || 0,
+        following: following_per_month[month] || 0,
+        followers: followers_per_month[month] || 0,
+      }
+    end
+  end
+
   def statuses_per_month
-    @statuses_per_month ||= report_statuses.group(:period).pluck(Arel.sql("date_part('month', created_at)::int AS period, count(*)")).to_h
+    @statuses_per_month ||= monthly_statuses.to_h
   end
 
   def following_per_month
-    @following_per_month ||= @account.active_relationships.where("date_part('year', created_at) = ?", @year).group(:period).pluck(Arel.sql("date_part('month', created_at)::int AS period, count(*)")).to_h
+    @following_per_month ||= monthly_following.to_h
   end
 
   def followers_per_month
-    @followers_per_month ||= @account.passive_relationships.where("date_part('year', created_at) = ?", @year).group(:period).pluck(Arel.sql("date_part('month', created_at)::int AS period, count(*)")).to_h
+    @followers_per_month ||= monthly_followers.to_h
+  end
+
+  def monthly_statuses
+    report_statuses
+      .group(:period)
+      .pluck(created_month.as('period'), Arel.star.count)
+  end
+
+  def monthly_following
+    following_from_year
+      .group(:period)
+      .pluck(created_month.as('period'), Arel.star.count)
+  end
+
+  def monthly_followers
+    followers_from_year
+      .group(:period)
+      .pluck(created_month.as('period'), Arel.star.count)
+  end
+
+  def following_from_year
+    @account
+      .active_relationships
+      .where(created_year.eq(@year))
+  end
+
+  def followers_from_year
+    @account
+      .passive_relationships
+      .where(created_year.eq(@year))
+  end
+
+  def created_year
+    Arel.sql(<<~SQL.squish)
+      DATE_PART('year', created_at)::int
+    SQL
+  end
+
+  def created_month
+    Arel.sql(<<~SQL.squish)
+      DATE_PART('month', created_at)::int
+    SQL
   end
 end

--- a/app/lib/annual_report/top_hashtags.rb
+++ b/app/lib/annual_report/top_hashtags.rb
@@ -2,21 +2,43 @@
 
 class AnnualReport::TopHashtags < AnnualReport::Source
   SET_SIZE = 40
+  MINIMUM_COUNT = 1
 
   def generate
     {
-      top_hashtags: top_hashtags.map do |(name, count)|
-                      {
-                        name: name,
-                        count: count,
-                      }
-                    end,
+      top_hashtags: hashtag_map,
     }
   end
 
   private
 
+  def hashtag_map
+    top_hashtags.map do |name, count|
+      {
+        name: name,
+        count: count,
+      }
+    end
+  end
+
   def top_hashtags
-    Tag.joins(:statuses).where(statuses: { id: report_statuses.select(:id) }).group(:id).having('count(*) > 1').order(total: :desc).limit(SET_SIZE).pluck(Arel.sql('COALESCE(tags.display_name, tags.name), count(*) AS total'))
+    Tag
+      .joins(:statuses)
+      .where(statuses: { id: report_status_ids })
+      .group(:id)
+      .having(Arel.star.count.gt(MINIMUM_COUNT))
+      .limit(SET_SIZE)
+      .order(total: :desc)
+      .pluck(coalesced_name, Arel.star.count.as('total'))
+  end
+
+  def report_status_ids
+    report_statuses.select(:id)
+  end
+
+  def coalesced_name
+    Arel.sql(<<~SQL.squish)
+      COALESCE(tags.display_name, tags.name)
+    SQL
   end
 end

--- a/app/lib/annual_report/top_statuses.rb
+++ b/app/lib/annual_report/top_statuses.rb
@@ -2,20 +2,42 @@
 
 class AnnualReport::TopStatuses < AnnualReport::Source
   def generate
-    top_reblogs = base_scope.order(reblogs_count: :desc).first&.id
-    top_favourites = base_scope.where.not(id: top_reblogs).order(favourites_count: :desc).first&.id
-    top_replies = base_scope.where.not(id: [top_reblogs, top_favourites]).order(replies_count: :desc).first&.id
-
     {
       top_statuses: {
-        by_reblogs: top_reblogs&.to_s,
-        by_favourites: top_favourites&.to_s,
-        by_replies: top_replies&.to_s,
+        by_reblogs: top_reblog_status_id.to_s,
+        by_favourites: top_favourite_status_id.to_s,
+        by_replies: top_reply_status_id.to_s,
       },
     }
   end
 
-  def base_scope
+  private
+
+  def top_reblog_status_id
+    @top_reblog_status_id ||= statuses_by_reblog_count.pick(:id)
+  end
+
+  def top_favourite_status_id
+    @top_favourite_status_id ||= statuses_by_favourite_count.where.not(id: top_reblog_status_id).pick(:id)
+  end
+
+  def top_reply_status_id
+    @top_reply_status_id ||= statuses_by_replies_count.where.not(id: [top_reblog_status_id, top_favourite_status_id]).pick(:id)
+  end
+
+  def statuses_by_reblog_count
+    public_statuses.order(reblogs_count: :desc)
+  end
+
+  def statuses_by_favourite_count
+    public_statuses.order(favourites_count: :desc)
+  end
+
+  def statuses_by_replies_count
+    public_statuses.order(replies_count: :desc)
+  end
+
+  def public_statuses
     report_statuses.public_visibility.joins(:status_stat)
   end
 end

--- a/app/lib/annual_report/type_distribution.rb
+++ b/app/lib/annual_report/type_distribution.rb
@@ -5,10 +5,24 @@ class AnnualReport::TypeDistribution < AnnualReport::Source
     {
       type_distribution: {
         total: report_statuses.count,
-        reblogs: report_statuses.where.not(reblog_of_id: nil).count,
-        replies: report_statuses.where.not(in_reply_to_id: nil).where.not(in_reply_to_account_id: @account.id).count,
-        standalone: report_statuses.without_replies.without_reblogs.count,
+        reblogs: reblog_statuses.count,
+        replies: replied_statuses.count,
+        standalone: standalone_statuses.count,
       },
     }
+  end
+
+  private
+
+  def reblog_statuses
+    report_statuses.with_reblogs
+  end
+
+  def replied_statuses
+    report_statuses.with_replies.without_replies_to(@account)
+  end
+
+  def standalone_statuses
+    report_statuses.without_replies.without_reblogs
   end
 end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -112,6 +112,10 @@ class Status < ApplicationRecord
   scope :not_reply, -> { where(reply: false) }
   scope :reply_to_account, -> { where(arel_table[:in_reply_to_account_id].eq arel_table[:account_id]) }
   scope :without_reblogs, -> { where(statuses: { reblog_of_id: nil }) }
+  scope :with_reblogs, -> { where.not(reblog_of_id: nil) }
+  scope :with_replies, -> { where.not(in_reply_to_id: nil) }
+  scope :with_polls, -> { where.not(poll_id: nil) }
+  scope :without_replies_to, ->(account) { where.not(in_reply_to_account_id: account.id) }
   scope :tagged_with, ->(tag_ids) { joins(:statuses_tags).where(statuses_tags: { tag_id: tag_ids }) }
   scope :not_excluded_by_account, ->(account) { where.not(account_id: account.excluded_from_timeline_account_ids) }
   scope :not_domain_blocked_by_account, ->(account) { account.excluded_from_timeline_domains.blank? ? left_outer_joins(:account) : left_outer_joins(:account).merge(Account.not_domain_blocked_by_account(account)) }

--- a/spec/lib/annual_report/top_statuses_spec.rb
+++ b/spec/lib/annual_report/top_statuses_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe AnnualReport::TopStatuses do
         expect(subject.generate)
           .to include(
             top_statuses: include(
-              by_reblogs: be_nil,
-              by_favourites: be_nil,
-              by_replies: be_nil
+              by_reblogs: be_blank,
+              by_favourites: be_blank,
+              by_replies: be_blank
             )
           )
       end


### PR DESCRIPTION
With this coverage - https://github.com/mastodon/mastodon/pull/31849 - merged, this is a pass at some tidying up in the annual report classes.

Repeating more or less the same things across these classes:

- Pull out some of the inline magic numbers to (hopefully) well-named constants to reveal some intent
- Use existing AR scopes where they exist, make a few new ones where needed (side note - some of these new ones will be usable in other non-annual-report parts of app, but I kept this PR to just the annual report stuff, can do that as follow up)
- Nudge some inline logic down into well named private methods, including memoizing where needed
- Once over on the core scope/query in many of the classes, generally trying to prefer Arel/AR/scope type composable query assembly over raw sql string approach
- There's one change which has a slight readability benefit (moving to private mapping methods), but is also sort of a style-only thing ... which is that the inline `do...end` block sitting indented in the hash creation looks odd to me, and is going to make for very noisy diffs when changed, so moved those into simpler alignment

There are a few more changes I wanted to do ... percentiles class specifically I think can be further simplified, and it's possible some of these methods can be pulled out to the source base class ... but this was about as far as I wanted to go with the coverage pass I did. Would want to add a little more thorough coverage to percentiles in advance of that. May do as followup on that as well.