### PR TITLE
Add coverage for `UserRole` validations and use `with_options` in declaration

### DIFF
--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -88,7 +88,7 @@ class UserRole < ApplicationRecord
   attr_writer :current_account
 
   validates :name, presence: true, unless: :everyone?
-  validates :color, format: { with: /\A#?(?:[A-F0-9]{3}){1,2}\z/i }, unless: -> { color.blank? }
+  validates :color, format: { with: /\A#?(?:[A-F0-9]{3}){1,2}\z/i }, if: :color?
 
   validate :validate_permissions_elevation
   validate :validate_position_elevation

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -40,6 +40,7 @@ class UserRole < ApplicationRecord
 
   EVERYONE_ROLE_ID = -99
   NOBODY_POSITION = -1
+  VALID_COLOR = /\A#?(?:[A-F0-9]{3}){1,2}\z/i # CSS-style hex colors
 
   module Flags
     NONE = 0
@@ -88,7 +89,7 @@ class UserRole < ApplicationRecord
   attr_writer :current_account
 
   validates :name, presence: true, unless: :everyone?
-  validates :color, format: { with: /\A#?(?:[A-F0-9]{3}){1,2}\z/i }, if: :color?
+  validates :color, format: { with: VALID_COLOR }, if: :color?
 
   validate :validate_permissions_elevation
   validate :validate_position_elevation

--- a/spec/models/user_role_spec.rb
+++ b/spec/models/user_role_spec.rb
@@ -3,6 +3,22 @@
 require 'rails_helper'
 
 RSpec.describe UserRole do
+  describe 'Validations' do
+    describe 'name' do
+      context 'when everyone' do
+        subject { described_class.everyone }
+
+        it { is_expected.to_not validate_presence_of(:name) }
+      end
+
+      context 'when not everyone' do
+        subject { Fabricate.build :user_role }
+
+        it { is_expected.to validate_presence_of(:name) }
+      end
+    end
+  end
+
   describe '#can?' do
     subject { Fabricate :user_role }
 

--- a/spec/models/user_role_spec.rb
+++ b/spec/models/user_role_spec.rb
@@ -17,6 +17,11 @@ RSpec.describe UserRole do
         it { is_expected.to validate_presence_of(:name) }
       end
     end
+
+    describe 'color' do
+      it { is_expected.to allow_values('#112233', '#aabbcc', '').for(:color) }
+      it { is_expected.to_not allow_values('x', '112233445566', '#xxyyzz').for(:color) }
+    end
   end
 
   describe '#can?' do

--- a/spec/models/user_role_spec.rb
+++ b/spec/models/user_role_spec.rb
@@ -3,9 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe UserRole do
-  subject { described_class.create(name: 'Foo', position: 1) }
-
   describe '#can?' do
+    subject { Fabricate :user_role }
+
     context 'with a single flag' do
       it 'returns true if any of them are present' do
         subject.permissions = described_class::FLAGS[:manage_reports]
@@ -92,6 +92,8 @@ RSpec.describe UserRole do
   end
 
   describe '#computed_permissions' do
+    subject { Fabricate :user_role }
+
     context 'when the role is nobody' do
       subject { described_class.nobody }
 

--- a/spec/models/user_role_spec.rb
+++ b/spec/models/user_role_spec.rb
@@ -24,6 +24,26 @@ RSpec.describe UserRole do
     end
   end
 
+  describe 'Callback for position' do
+    context 'when everyone' do
+      subject { Fabricate.build :user_role, id: described_class::EVERYONE_ROLE_ID }
+
+      it 'sets the position to nobody position' do
+        expect { subject.valid? }
+          .to change(subject, :position).to(described_class::NOBODY_POSITION)
+      end
+    end
+
+    context 'when not everyone' do
+      subject { Fabricate.build :user_role }
+
+      it 'does not change the position' do
+        expect { subject.valid? }
+          .to_not change(subject, :position)
+      end
+    end
+  end
+
   describe '#can?' do
     subject { Fabricate :user_role }
 

--- a/spec/models/user_role_spec.rb
+++ b/spec/models/user_role_spec.rb
@@ -22,6 +22,25 @@ RSpec.describe UserRole do
       it { is_expected.to allow_values('#112233', '#aabbcc', '').for(:color) }
       it { is_expected.to_not allow_values('x', '112233445566', '#xxyyzz').for(:color) }
     end
+
+    context 'when current_account is set' do
+      subject { Fabricate :user_role }
+
+      let(:account) { Fabricate :account }
+
+      before { subject.current_account = account }
+
+      it { is_expected.to_not allow_value(999_999).for(:position).with_message(:elevated) }
+
+      it { is_expected.to_not allow_value(999_999).for(:permissions).against(:permissions_as_keys).with_message(:elevated) }
+
+      context 'when current_account is changing their own role' do
+        let(:account) { Fabricate :account, user: Fabricate(:user, role: subject) }
+
+        it { is_expected.to_not allow_value(100).for(:permissions).against(:permissions_as_keys).with_message(:own_role) }
+        it { is_expected.to_not allow_value(100).for(:position).with_message(:own_role) }
+      end
+    end
   end
 
   describe 'Callback for position' do


### PR DESCRIPTION
Changes to model:

- Pull out regex for css-style hex code to constant (this regex could be shortended by using `\h` which I think is available in all rubies we support?)
- Use `if: :color?` instead of `unless: -> { color.blank? }` for validation condition
- Pull out a `with_options` block to do the "do we have a current account" check, removing it from the validation methods
- Pull out `everyone?` check from the dangerous permissions check to the declaration as well -- same logic as last one, generally trying to move the "should we run this?" checks in the declaration area, while leaving the actual "is this valid?" logic down in the methods

Changes to spec:

- Add coverage for name, and position validations, and for the custom methods which were changed here
- Remove the top-level subject which created records because most examples dont need a saved record (Added back in where needed). Dropped the spec from creating ~120 records to creating ~80 (my additions then added more, but that was initial reduction)
