### PR TITLE
Retry oEmbed cache after redirect

### DIFF
--- a/app/services/fetch_link_card_service.rb
+++ b/app/services/fetch_link_card_service.rb
@@ -106,12 +106,11 @@ class FetchLinkCardService < BaseService
   end
 
   def attempt_oembed
-    service         = FetchOEmbedService.new
-    url_domain      = Addressable::URI.parse(@url).normalized_host
-    cached_endpoint = Rails.cache.read("oembed_endpoint:#{url_domain}")
+    service = FetchOEmbedService.new
 
-    embed   = service.call(@url, cached_endpoint: cached_endpoint) unless cached_endpoint.nil?
+    embed   = service.call(@url, use_cached_endpoint: true)
     embed ||= service.call(@url, html: html) unless html.nil?
+    embed ||= service.call(@url, use_cached_endpoint: true) if @url != @original_url.to_s
 
     return false if embed.nil?
 

--- a/spec/services/fetch_link_card_service_spec.rb
+++ b/spec/services/fetch_link_card_service_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe FetchLinkCardService do
     stub_request(:get, 'http://example.com/not-found').to_return(status: 404, headers: { 'Content-Type' => 'text/html' }, body: html)
     stub_request(:get, 'http://example.com/text').to_return(status: 404, headers: { 'Content-Type' => 'text/plain' }, body: 'Hello')
     stub_request(:get, 'http://example.com/redirect').to_return(status: 302, headers: { 'Location' => 'http://example.com/html' })
+    stub_request(:get, 'http://example.net/redirect-to-other-domain').to_return(status: 302, headers: { 'Location' => 'http://example.com/html' })
     stub_request(:get, 'http://example.com/redirect-to-404').to_return(status: 302, headers: { 'Location' => 'http://example.com/not-found' })
     stub_request(:get, 'http://example.com/oembed?url=http://example.com/html').to_return(headers: { 'Content-Type' => 'application/json' }, body: '{ "version": "1.0", "type": "link", "title": "oEmbed title" }')
     stub_request(:get, 'http://example.com/oembed?format=json&url=http://example.com/html').to_return(headers: { 'Content-Type' => 'application/json' }, body: '{ "version": "1.0", "type": "link", "title": "oEmbed title" }')
@@ -254,6 +255,39 @@ RSpec.describe FetchLinkCardService do
 
         it 'uses the cached oEmbed response' do
           expect(a_request(:get, 'http://example.com/oembed?url=http://example.com/html')).to_not have_been_made
+          expect(a_request(:get, 'http://example.com/oembed?format=json&url=http://example.com/html')).to have_been_made
+        end
+
+        it 'creates preview card' do
+          expect(status.preview_card).to_not be_nil
+          expect(status.preview_card.url).to eq 'http://example.com/html'
+          expect(status.preview_card.title).to eq 'oEmbed title'
+        end
+      end
+
+      context 'when oEmbed endpoint cache populated with redirect target' do
+        let(:status) { Fabricate(:status, text: 'http://example.net/redirect-to-other-domain') }
+        let(:oembed_cache) { { endpoint: 'http://example.com/oembed?format=json&url={url}', format: :json } }
+
+        it 'uses the cached oEmbed response' do
+          expect(a_request(:get, 'http://example.net/redirect-to-other-domain')).to have_been_made
+          expect(a_request(:get, 'http://example.com/oembed?url=http://example.com/html')).to have_been_made
+        end
+
+        it 'creates preview card' do
+          expect(status.preview_card).to_not be_nil
+          expect(status.preview_card.url).to eq 'http://example.com/html'
+          expect(status.preview_card.title).to eq 'oEmbed title'
+        end
+      end
+
+      context 'when oEmbed endpoint cache populated with redirect target but page contains no oEmbed tags' do
+        let(:status) { Fabricate(:status, text: 'http://example.net/redirect-to-other-domain') }
+        let(:html) { 'Please fill out CAPTCHA' }
+        let(:oembed_cache) { { endpoint: 'http://example.com/oembed?format=json&url={url}', format: :json } }
+
+        it 'uses the cached oEmbed response' do
+          expect(a_request(:get, 'http://example.net/redirect-to-other-domain')).to have_been_made
           expect(a_request(:get, 'http://example.com/oembed?format=json&url=http://example.com/html')).to have_been_made
         end
 

--- a/spec/services/fetch_oembed_service_spec.rb
+++ b/spec/services/fetch_oembed_service_spec.rb
@@ -160,10 +160,12 @@ RSpec.describe FetchOEmbedService do
           headers: { 'Content-Type': 'text/html' },
           body: request_fixture('oembed_json_empty.html')
         )
+
+        Rails.cache.write('oembed_endpoint:www.youtube.com', { endpoint: 'http://www.youtube.com/oembed?format=json&url={url}', format: :json })
       end
 
       it 'returns new provider without fetching original URL first' do
-        subject.call('https://www.youtube.com/watch?v=dqwpQarrDwk', cached_endpoint: { endpoint: 'http://www.youtube.com/oembed?format=json&url={url}', format: :json })
+        subject.call('https://www.youtube.com/watch?v=dqwpQarrDwk', use_cached_endpoint: true)
         expect(a_request(:get, 'https://www.youtube.com/watch?v=dqwpQarrDwk')).to_not have_been_made
         expect(subject.endpoint_url).to eq 'http://www.youtube.com/oembed?format=json&url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DdqwpQarrDwk'
         expect(subject.format).to eq :json


### PR DESCRIPTION
When a status contains a URL that redirects to a different URL, we currently only use the oEmbed cache to fetch the oEmbed data for the original URL. If the original URL has no cache entry, or the oEmbed endpoint returns no data for the original URL, and the HTML of the destination URL for some reason contains no oEmbed HTML tags (e.g. due to a CAPTCHA), it might be worth checking the oEmbed cache for destination URL. 

Why would the HTML sometimes not contain any oEmbed tags? This seems weird, but according to the findings by @alexandru in https://github.com/mastodon/mastodon/issues/31308#issuecomment-2333920424 it happens when YouTube's bot detection is triggered.

I think this might fix #31308 (and duplicates #31376 and #31462), though I cannot reproduce the issue myself.