### PR TITLE
Add coverage for title/limit validations in `List` model

### DIFF
--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -20,20 +20,22 @@ class List < ApplicationRecord
 
   enum :replies_policy, { list: 0, followed: 1, none: 2 }, prefix: :show
 
-  belongs_to :account, optional: true
+  belongs_to :account
 
   has_many :list_accounts, inverse_of: :list, dependent: :destroy
   has_many :accounts, through: :list_accounts
 
   validates :title, presence: true
 
-  validates_each :account_id, on: :create do |record, _attr, value|
-    record.errors.add(:base, I18n.t('lists.errors.limit')) if List.where(account_id: value).count >= PER_ACCOUNT_LIMIT
-  end
+  validate :validate_account_lists_limit, on: :create
 
   before_destroy :clean_feed_manager
 
   private
+
+  def validate_account_lists_limit
+    errors.add(:base, I18n.t('lists.errors.limit')) if account.lists.count >= PER_ACCOUNT_LIMIT
+  end
 
   def clean_feed_manager
     FeedManager.instance.clean_feeds!(:list, [id])

--- a/spec/models/list_spec.rb
+++ b/spec/models/list_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe List do
+  describe 'Validations' do
+    subject { Fabricate.build :list }
+
+    it { is_expected.to validate_presence_of(:title) }
+
+    context 'when account has hit max list limit' do
+      let(:account) { Fabricate :account }
+
+      before { stub_const 'List::PER_ACCOUNT_LIMIT', 0 }
+
+      context 'when creating a new list' do
+        it { is_expected.to_not allow_value(account).for(:account).against(:base).with_message(I18n.t('lists.errors.limit')) }
+      end
+
+      context 'when updating an existing list' do
+        before { subject.save(validate: false) }
+
+        it { is_expected.to allow_value(account).for(:account).against(:base) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Changes:

- Restore the account being required here (the field is not null). This option was added in - https://github.com/mastodon/mastodon/pull/5888 - to work around a rails config issue  (long since resolved). It's not clear to me from that PR why this specific one was changed to optional ... seems incorrect?
- Change the validation style away from `validates_each` since we're only doing this on one field
- Add List spec (previously none) for title presence and limit enforcement