### PR TITLE
Fix security context sometimes not being added in LD-Signed activities

### DIFF
--- a/spec/lib/activitypub/linked_data_signature_spec.rb
+++ b/spec/lib/activitypub/linked_data_signature_spec.rb
@@ -95,16 +95,11 @@ RSpec.describe ActivityPub::LinkedDataSignature do
   describe '#sign!' do
     subject { described_class.new(raw_json).sign!(sender) }
 
-    it 'returns a hash' do
+    it 'returns a hash with a signature, the expected context, and the signature can be verified', :aggregate_failures do
       expect(subject).to be_a Hash
-    end
-
-    it 'contains signature' do
       expect(subject['signature']).to be_a Hash
       expect(subject['signature']['signatureValue']).to be_present
-    end
-
-    it 'can be verified again' do
+      expect(Array(subject['@context'])).to include('https://w3id.org/security/v1')
       expect(described_class.new(subject).verify_actor!).to eq sender
     end
   end


### PR DESCRIPTION
Contexts included in activities are so far decided at serialization-time, but Linked-Data signature occurs after serialization time.

In some cases, signed activities were missing the `https://w3id.org/security/v1` context.

This PR makes it so that the signing code always adds that context to signed activities.

PR marked as draft because I have yet to add tests.