### PR TITLE
Use `Follow.joins....` for `Instance.domain_account_follows` query creation

### DIFF
--- a/app/models/instance.rb
+++ b/app/models/instance.rb
@@ -30,16 +30,12 @@ class Instance < ApplicationRecord
   scope :with_domain_follows, ->(domains) { where(domain: domains).where(domain_account_follows) }
 
   def self.domain_account_follows
-    Arel.sql(
-      <<~SQL.squish
-        EXISTS (
-          SELECT 1
-          FROM follows
-          JOIN accounts ON follows.account_id = accounts.id OR follows.target_account_id = accounts.id
-          WHERE accounts.domain = instances.domain
-        )
+    Follow
+      .joins(<<~SQL.squish)
+        JOIN accounts ON follows.account_id = accounts.id OR follows.target_account_id = accounts.id
       SQL
-    )
+      .where(Account.arel_table[:domain].eq arel_table[:domain])
+      .select(1).arel.exists
   end
 
   def delivery_failure_tracker


### PR DESCRIPTION
I think this class method is only used in the scope (above) in this same class.

Basically just a pass over to convert to arel/exists style ...

I started to also update the joins sql but because of the "or" in there, the arel version was quite verbose and in my opinion not necessarily easier to grasp. Good future improvement would be to improve that join while preserving the OR there ... or convert it to use the associations, and make sure we only need one and not both of them present.