### PR TITLE
Ignore `undefined` as canonical url

### DIFF
--- a/app/lib/link_details_extractor.rb
+++ b/app/lib/link_details_extractor.rb
@@ -225,7 +225,7 @@ class LinkDetailsExtractor
   end
 
   def valid_url_or_nil(str, same_origin_only: false)
-    return if str.blank? || str == 'null'
+    return if str.blank? || str == 'null' || str == 'undefined'
 
     url = @original_url + Addressable::URI.parse(str)
 

--- a/spec/lib/link_details_extractor_spec.rb
+++ b/spec/lib/link_details_extractor_spec.rb
@@ -33,6 +33,14 @@ RSpec.describe LinkDetailsExtractor do
         expect(subject.canonical_url).to eq original_url
       end
     end
+
+    context 'when canonical URL is set to "undefined"' do
+      let(:url) { 'undefined' }
+
+      it 'ignores the canonical URLs' do
+        expect(subject.canonical_url).to eq original_url
+      end
+    end
   end
 
   context 'when only basic metadata is present' do


### PR DESCRIPTION
This is what youtube currently includes in their bot detection page that is presented to some instances hosted in germany.

Fixes #31376

Special thanks to @alexandru whose comment, https://github.com/mastodon/mastodon/issues/31308#issuecomment-2333920424, was a big help!