### PR TITLE
Add coverage for name/display_name changes in `Tag` model

### DIFF
--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -5,7 +5,39 @@ require 'rails_helper'
 RSpec.describe Tag do
   include_examples 'Reviewable'
 
-  describe 'validations' do
+  describe 'Validations' do
+    describe 'name' do
+      context 'with a new record' do
+        subject { Fabricate.build :tag, name: 'original' }
+
+        it { is_expected.to allow_value('changed').for(:name) }
+      end
+
+      context 'with an existing record' do
+        subject { Fabricate :tag, name: 'original' }
+
+        it { is_expected.to_not allow_value('changed').for(:name).with_message(previous_name_error_message) }
+      end
+    end
+
+    describe 'display_name' do
+      context 'with a new record' do
+        subject { Fabricate.build :tag, name: 'original', display_name: 'OriginalDisplayName' }
+
+        it { is_expected.to allow_value('ChangedDisplayName').for(:display_name) }
+      end
+
+      context 'with an existing record' do
+        subject { Fabricate :tag, name: 'original', display_name: 'OriginalDisplayName' }
+
+        it { is_expected.to_not allow_value('ChangedDisplayName').for(:display_name).with_message(previous_name_error_message) }
+      end
+    end
+
+    def previous_name_error_message
+      I18n.t('tags.does_not_match_previous_name')
+    end
+
     it 'invalid with #' do
       expect(described_class.new(name: '#hello_world')).to_not be_valid
     end


### PR DESCRIPTION
Spec changes: add coverage for the `name` and `display_name` changing value validations.

Model changes:

- Pull out shared `on: :update` to `with_options` for both of these, since (I think?) that has same meaning as previous "not new record" check
- Pull out repeated I18n string lookup to method
- Pull out repeated mb_chars/casecmp check to method

Future side quest for someone: look into the history of our app-wide usage of multi-byte character comparison, and see if ruby/rails have since evolved more benificent methods for same results.