### PR TITLE
Remove extraneous `greatest` from search score functions

### DIFF
--- a/app/models/concerns/account/search.rb
+++ b/app/models/concerns/account/search.rb
@@ -15,15 +15,15 @@ module Account::Search
 
   REPUTATION_SCORE_FUNCTION = <<~SQL.squish
     (
-        greatest(0, coalesce(s.followers_count, 0)) / (
-            greatest(0, coalesce(s.following_count, 0)) + 1.0
+        coalesce(s.followers_count, 0) / (
+            coalesce(s.following_count, 0) + 1.0
         )
     )
   SQL
 
   FOLLOWERS_SCORE_FUNCTION = <<~SQL.squish
     log(
-        greatest(0, coalesce(s.followers_count, 0)) + 2
+        coalesce(s.followers_count, 0) + 2
     )
   SQL
 


### PR DESCRIPTION
These are assured to be non-negative where they are set, so I think the greatest value here is always going to be either the count if present, or the coalesced `0` value (tie) if not.