### PR TITLE
Remove debug output in migration controller spec

### DIFF
--- a/spec/controllers/settings/migrations_controller_spec.rb
+++ b/spec/controllers/settings/migrations_controller_spec.rb
@@ -95,7 +95,6 @@ RSpec.describe Settings::MigrationsController do
 
         before do
           moved_to = Fabricate(:account, also_known_as: [ActivityPub::TagManager.instance.uri_for(user.account)])
-          p moved_to.acct
           user.account.migrations.create!(acct: moved_to.acct)
         end
 


### PR DESCRIPTION
Presumably left by accident in https://github.com/mastodon/mastodon/pull/31819/files#diff-5cfecad18efbb7f9069455482201f8ead4136d311761cc8fc5bc0a4327aff166R98