### PR TITLE
Reduce middle column size by 32px to fix overflow around layout breakpoint

### DIFF
--- a/app/javascript/mastodon/features/ui/components/columns_area.jsx
+++ b/app/javascript/mastodon/features/ui/components/columns_area.jsx
@@ -63,7 +63,7 @@ export default class ColumnsArea extends ImmutablePureComponent {
     children: PropTypes.node,
   };
 
-  // Corresponds to (max-width: $no-gap-breakpoint + 285px - 1px) in SCSS
+  // Corresponds to (max-width: $no-gap-breakpoint - 1px) in SCSS
   mediaQuery = 'matchMedia' in window && window.matchMedia('(max-width: 1174px)');
 
   state = {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2712,7 +2712,7 @@ a.account__display-name {
       flex-direction: column;
 
       @media screen and (min-width: $no-gap-breakpoint) {
-        max-width: 600px;
+        max-width: 568px;
       }
     }
   }


### PR DESCRIPTION
Fixes #31679

In #28119, the middle-column's padding has been replaced by the use of the flex `gap` property, which changed the middle column to be 600px *inclusive* of padding to 600px *excluding the padding*.

This PR reduces the middle column's size so that, including padding, it has the same width as before. An alternative approach is #31889