### PR TITLE
Increase no-gap-breakpoint by 32px to fix overflow

### DIFF
--- a/app/javascript/mastodon/features/ui/components/columns_area.jsx
+++ b/app/javascript/mastodon/features/ui/components/columns_area.jsx
@@ -63,8 +63,8 @@ export default class ColumnsArea extends ImmutablePureComponent {
     children: PropTypes.node,
   };
 
-  // Corresponds to (max-width: $no-gap-breakpoint + 285px - 1px) in SCSS
-  mediaQuery = 'matchMedia' in window && window.matchMedia('(max-width: 1174px)');
+  // Corresponds to (max-width: $no-gap-breakpoint - 1px) in SCSS
+  mediaQuery = 'matchMedia' in window && window.matchMedia('(max-width: 1206px)');
 
   state = {
     renderComposePanel: !(this.mediaQuery && this.mediaQuery.matches),

--- a/app/javascript/styles/mastodon/variables.scss
+++ b/app/javascript/styles/mastodon/variables.scss
@@ -87,7 +87,7 @@ $media-modal-media-max-width: 100%;
 // put margins on top and bottom of image to avoid the screen covered by image.
 $media-modal-media-max-height: 80%;
 
-$no-gap-breakpoint: 1175px;
+$no-gap-breakpoint: 1207px;
 $mobile-breakpoint: 630px;
 
 $font-sans-serif: 'mastodon-font-sans-serif' !default;


### PR DESCRIPTION
Fixes #31679

In #28119, the middle-column's padding has been replaced by the use of the flex `gap` property, which changed the middle column to be 600px *inclusive* of padding to 600px *excluding the padding*.

This PR keeps the increased size of the middle column and changes the layout breakpoint instead. An alternative approach is #31888