### PR TITLE
Remove unused argument from `AccountMigration.within_cooldown`

### DIFF
--- a/app/models/account_migration.rb
+++ b/app/models/account_migration.rb
@@ -31,9 +31,13 @@ class AccountMigration < ApplicationRecord
   validate :validate_migration_cooldown
   validate :validate_target_account
 
-  scope :within_cooldown, ->(now = Time.now.utc) { where(arel_table[:created_at].gteq(now - COOLDOWN_PERIOD)) }
+  scope :within_cooldown, -> { where(created_at: cooldown_duration_ago..) }
 
   attr_accessor :current_password, :current_username
+
+  def self.cooldown_duration_ago
+    Time.current - COOLDOWN_PERIOD
+  end
 
   def save_with_challenge(current_user)
     if current_user.encrypted_password.present?


### PR DESCRIPTION
This method is only used in two spots, and neither one passes in an argument. From brief history scan I think the arg was never used.