### PR TITLE
Add coverage for `ListAccount` follow/follow_request set up

### DIFF
--- a/app/models/list_account.rb
+++ b/app/models/list_account.rb
@@ -20,13 +20,11 @@ class ListAccount < ApplicationRecord
   validates :account_id, uniqueness: { scope: :list_id }
   validate :validate_relationship
 
-  before_validation :set_follow
+  before_validation :set_follow, unless: :list_owner_account_is_account?
 
   private
 
   def set_follow
-    return if list.account_id == account.id
-
     self.follow = Follow.find_by!(account_id: list.account_id, target_account_id: account.id)
   rescue ActiveRecord::RecordNotFound
     self.follow_request = FollowRequest.find_by!(account_id: list.account_id, target_account_id: account.id)
@@ -38,5 +36,9 @@ class ListAccount < ApplicationRecord
     errors.add(:account_id, 'follow relationship missing') if follow_id.nil? && follow_request_id.nil?
     errors.add(:follow, 'mismatched accounts') if follow_id.present? && follow.target_account_id != account_id
     errors.add(:follow_request, 'mismatched accounts') if follow_request_id.present? && follow_request.target_account_id != account_id
+  end
+
+  def list_owner_account_is_account?
+    list.account_id == account_id
   end
 end

--- a/spec/models/list_account_spec.rb
+++ b/spec/models/list_account_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ListAccount do
+  describe 'Callbacks to set follows' do
+    context 'when list owner follows account' do
+      let!(:follow) { Fabricate :follow }
+      let(:list) { Fabricate :list, account: follow.account }
+
+      it 'finds and sets the follow with the list account' do
+        list_account = described_class.create list: list, account: follow.target_account
+        expect(list_account)
+          .to have_attributes(
+            follow: eq(follow),
+            follow_request: be_nil
+          )
+      end
+    end
+
+    context 'when list owner has a follow request for account' do
+      let!(:follow_request) { Fabricate :follow_request }
+      let(:list) { Fabricate :list, account: follow_request.account }
+
+      it 'finds and sets the follow request with the list account' do
+        list_account = described_class.create list: list, account: follow_request.target_account
+        expect(list_account)
+          .to have_attributes(
+            follow: be_nil,
+            follow_request: eq(follow_request)
+          )
+      end
+    end
+
+    context 'when list owner is the account' do
+      let(:list) { Fabricate :list  }
+
+      it 'does not set follow or follow request' do
+        list_account = described_class.create list: list, account: list.account
+        expect(list_account)
+          .to have_attributes(
+            follow: be_nil,
+            follow_request: be_nil
+          )
+      end
+    end
+  end
+end


### PR DESCRIPTION
For first pass here just doing the "set follow" portion and not the other validation callbacks. Interacting with the fabricator here is a little odd (it creates a follow every time so that it can be valid) ... and creating some of the conditions here while keeping the callback from raising or the fabricator intact was a little delicate.