### PR TITLE
Fix inability to locally suspend remotely-suspended accounts in moderation interface

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -259,6 +259,10 @@ class Account < ApplicationRecord
     suspended_at.present? && !instance_actor?
   end
 
+  def suspended_locally?
+    suspended? && suspension_origin_local?
+  end
+
   def suspended_permanently?
     suspended? && deletion_request.nil?
   end

--- a/app/models/admin/account_action.rb
+++ b/app/models/admin/account_action.rb
@@ -74,7 +74,7 @@ class Admin::AccountAction
     end
 
     def disabled_types_for_account(account)
-      if account.suspended?
+      if account.suspended_locally?
         %w(silence suspend)
       elsif account.silenced?
         %w(silence)

--- a/app/views/admin/account_actions/new.html.haml
+++ b/app/views/admin/account_actions/new.html.haml
@@ -1,7 +1,7 @@
 - content_for :page_title do
   = t('admin.account_actions.title', acct: @account.pretty_acct)
 
-- if @account.suspended?
+- if @account.suspended_locally?
   .flash-message.alert
     = t('admin.account_actions.already_suspended')
 - elsif @account.silenced?

--- a/app/views/admin/reports/_actions.html.haml
+++ b/app/views/admin/reports/_actions.html.haml
@@ -27,7 +27,7 @@
         = form.button t('admin.accounts.silence'),
                       name: :silence,
                       class: 'button button--destructive',
-                      disabled: report.target_account.silenced? || report.target_account.suspended?,
+                      disabled: report.target_account.silenced? || report.target_account.suspended_locally?,
                       title: report.target_account.silenced? ? t('admin.account_actions.already_silenced') : ''
       .report-actions__item__description
         = t('admin.reports.actions.silence_description_html')
@@ -36,8 +36,8 @@
         = form.button t('admin.accounts.suspend'),
                       name: :suspend,
                       class: 'button button--destructive',
-                      disabled: report.target_account.suspended?,
-                      title: report.target_account.suspended? ? t('admin.account_actions.already_suspended') : ''
+                      disabled: report.target_account.suspended_locally?,
+                      title: report.target_account.suspended_locally? ? t('admin.account_actions.already_suspended') : ''
       .report-actions__item__description
         = t('admin.reports.actions.suspend_description_html')
     .report-actions__item


### PR DESCRIPTION
In #31773, some moderation actions were disabled depending on context to streamline the moderation workflow and reduce confusion.

However, when an account is suspended on the remote server, this prevents local moderators from making a moderation decision and ensuring the suspension sticks even if the remote server changes their mind.

cc @ThisIsMissEm