### PR TITLE
Strip protocol from attribution domains

### DIFF
--- a/app/models/concerns/account/attribution_domains.rb
+++ b/app/models/concerns/account/attribution_domains.rb
@@ -13,7 +13,11 @@ module Account::AttributionDomains
 
   def attribution_domains_as_text=(str)
     self[:attribution_domains] = str.split.filter_map do |line|
-      line.strip.delete_prefix('*.')
+      line
+        .strip
+        .delete_prefix('http://')
+        .delete_prefix('https://')
+        .delete_prefix('*.')
     end
   end
 

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -792,6 +792,34 @@ RSpec.describe Account do
     end
   end
 
+  describe '#attribution_domains_as_text=' do
+    subject { Fabricate(:account) }
+
+    it 'sets attribution_domains accordingly' do
+      subject.attribution_domains_as_text = "hoge.com\nexample.com"
+
+      expect(subject.attribution_domains).to contain_exactly('hoge.com', 'example.com')
+    end
+
+    it 'strips leading "*."' do
+      subject.attribution_domains_as_text = "hoge.com\n*.example.com"
+
+      expect(subject.attribution_domains).to contain_exactly('hoge.com', 'example.com')
+    end
+
+    it 'strips the protocol if present' do
+      subject.attribution_domains_as_text = "http://hoge.com\nhttps://example.com"
+
+      expect(subject.attribution_domains).to contain_exactly('hoge.com', 'example.com')
+    end
+
+    it 'strips a combination of leading "*." and protocol' do
+      subject.attribution_domains_as_text = "http://*.hoge.com\nhttps://*.example.com"
+
+      expect(subject.attribution_domains).to contain_exactly('hoge.com', 'example.com')
+    end
+  end
+
   describe 'Normalizations' do
     describe 'username' do
       it { is_expected.to normalize(:username).from(" \u3000bob \t \u00a0 \n ").to('bob') }


### PR DESCRIPTION
Removes `http://` and `https://` from attribution domains. Some users already tried to enter domains *with* a protocol. This is not necessary and did not work.

This change will simply discard the protocol before the domains are being saved.