### PR TITLE
Remove `follow` creation from `ListAccount` fabricator

### DIFF
--- a/spec/fabricators/list_account_fabricator.rb
+++ b/spec/fabricators/list_account_fabricator.rb
@@ -2,6 +2,8 @@
 
 Fabricator(:list_account) do
   list
-  account
-  before_create { |list_account, _| list_account.list.account.follow!(account) }
+
+  initialize_with do
+    resolved_class.new(list: list, account: list.account)
+  end
 end

--- a/spec/models/list_account_spec.rb
+++ b/spec/models/list_account_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ListAccount do
       let(:list) { Fabricate :list, account: follow.account }
 
       it 'finds and sets the follow with the list account' do
-        list_account = described_class.create list: list, account: follow.target_account
+        list_account = Fabricate :list_account, list: list, account: follow.target_account
         expect(list_account)
           .to have_attributes(
             follow: eq(follow),
@@ -23,7 +23,7 @@ RSpec.describe ListAccount do
       let(:list) { Fabricate :list, account: follow_request.account }
 
       it 'finds and sets the follow request with the list account' do
-        list_account = described_class.create list: list, account: follow_request.target_account
+        list_account = Fabricate :list_account, list: list, account: follow_request.target_account
         expect(list_account)
           .to have_attributes(
             follow: be_nil,
@@ -33,10 +33,8 @@ RSpec.describe ListAccount do
     end
 
     context 'when list owner is the account' do
-      let(:list) { Fabricate :list  }
-
       it 'does not set follow or follow request' do
-        list_account = described_class.create list: list, account: list.account
+        list_account = Fabricate :list_account
         expect(list_account)
           .to have_attributes(
             follow: be_nil,


### PR DESCRIPTION
Follow-up on https://github.com/mastodon/mastodon/pull/31896

The change here is to have the default fabrication for `ListAccount` be the "list owner is the account" scenario, and not create the follow in the fabricator callback.

I expected there to be a more straightforward way to refer to another attribute from within the fabrication definition, but there doesn't seem to be?

Side effect here will be slightly fewer records created across uses of this fabricator - but main goal is as described in the linked PR, to make it simpler to add more coverage around the custom validations in the class.