### PR TITLE
Increase preview card image size limit from 2MB to 8MB when using libvips

### DIFF
--- a/app/models/preview_card.rb
+++ b/app/models/preview_card.rb
@@ -39,7 +39,7 @@ class PreviewCard < ApplicationRecord
   include Attachmentable
 
   IMAGE_MIME_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'].freeze
-  LIMIT = 2.megabytes
+  LIMIT = Rails.configuration.x.use_vips ? 8.megabytes : 2.megabytes
 
   BLURHASH_OPTIONS = {
     x_comp: 4,

--- a/spec/models/preview_card_spec.rb
+++ b/spec/models/preview_card_spec.rb
@@ -3,6 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe PreviewCard do
+  describe 'file size limit', :attachment_processing do
+    it 'is set differently whether vips is enabled or not' do
+      expect(described_class::LIMIT).to eq(Rails.configuration.x.use_vips ? 8.megabytes : 2.megabytes)
+    end
+  end
+
   describe 'validations' do
     describe 'urls' do
       it 'allows http schemes' do


### PR DESCRIPTION
oEmbed/OpenGraph previews sometimes exceed our current 2MB limit.

There are a few reasons for our 2MB limit:
- storage size: this is only partially relevant, as in most cases the image will be resized to fit a roughly 640x360px size
- bandwidth and download time: this is relevant, but downloading 8MB files is not a lot more costly than downloading 2MB files
- CPU and RAM usage: ImageMagick is a bottleneck, and on my server, processing a real-world 4.2MB JPEG preview image takes over 60 seconds with ImageMagick, and less than 3 seconds using libvips

---

Fixes MAS-309