### PR TITLE
Use rails built-in default attributes instead of `boolean_with_default`

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -181,6 +181,8 @@ class Account < ApplicationRecord
 
   update_index('accounts', :self)
 
+  attribute :trendable, default: -> { Setting.trendable_by_default }
+
   def local?
     domain.nil?
   end
@@ -245,10 +247,6 @@ class Account < ApplicationRecord
 
   def memorialize!
     update!(memorial: true)
-  end
-
-  def trendable?
-    boolean_with_default('trendable', Setting.trendable_by_default)
   end
 
   def sign?

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -13,16 +13,6 @@ class ApplicationRecord < ActiveRecord::Base
     end
   end
 
-  def boolean_with_default(key, default_value)
-    value = attributes[key]
-
-    if value.nil?
-      default_value
-    else
-      value
-    end
-  end
-
   # Prevent implicit serialization in ActiveModel::Serializer or other code paths.
   # This is a hardening step to avoid accidental leaking of attributes.
   def as_json

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -67,6 +67,8 @@ class Tag < ApplicationRecord
 
   update_index('tags', :self)
 
+  attribute :usable, default: true
+
   def to_param
     name
   end
@@ -78,12 +80,6 @@ class Tag < ApplicationRecord
   def formatted_name
     "##{display_name}"
   end
-
-  def usable
-    boolean_with_default('usable', true)
-  end
-
-  alias usable? usable
 
   def listable
     boolean_with_default('listable', true)

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -68,6 +68,7 @@ class Tag < ApplicationRecord
   update_index('tags', :self)
 
   attribute :usable, default: true
+  attribute :listable, default: true
 
   def to_param
     name
@@ -80,12 +81,6 @@ class Tag < ApplicationRecord
   def formatted_name
     "##{display_name}"
   end
-
-  def listable
-    boolean_with_default('listable', true)
-  end
-
-  alias listable? listable
 
   def trendable
     boolean_with_default('trendable', Setting.trendable_by_default)

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -69,6 +69,7 @@ class Tag < ApplicationRecord
 
   attribute :usable, default: true
   attribute :listable, default: true
+  attribute :trendable, default: -> { Setting.trendable_by_default }
 
   def to_param
     name
@@ -81,12 +82,6 @@ class Tag < ApplicationRecord
   def formatted_name
     "##{display_name}"
   end
-
-  def trendable
-    boolean_with_default('trendable', Setting.trendable_by_default)
-  end
-
-  alias trendable? trendable
 
   def decaying?
     max_score_at && max_score_at >= Trends.tags.options[:max_score_cooldown].ago && max_score_at < 1.day.ago

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -5,6 +5,38 @@ require 'rails_helper'
 RSpec.describe Account do
   include_examples 'Reviewable'
 
+  describe 'Defaults' do
+    describe 'trendable' do
+      context 'when default is true' do
+        before { Setting.trendable_by_default = true }
+
+        context 'without any value provided' do
+          it { is_expected.to be_trendable }
+        end
+
+        context 'when default value is overridden' do
+          subject { described_class.new trendable: false }
+
+          it { is_expected.to_not be_trendable }
+        end
+      end
+
+      context 'when default is false' do
+        before { Setting.trendable_by_default = false }
+
+        context 'without any value provided' do
+          it { is_expected.to_not be_trendable }
+        end
+
+        context 'when default value is overridden' do
+          subject { described_class.new trendable: true }
+
+          it { is_expected.to be_trendable }
+        end
+      end
+    end
+  end
+
   context 'with an account record' do
     subject { Fabricate(:account) }
 

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -29,6 +29,36 @@ RSpec.describe Tag do
         it { is_expected.to_not be_listable }
       end
     end
+
+    describe 'trendable' do
+      context 'when default is true' do
+        before { Setting.trendable_by_default = true }
+
+        context 'without any value provided' do
+          it { is_expected.to be_trendable }
+        end
+
+        context 'when default value is overridden' do
+          subject { described_class.new trendable: false }
+
+          it { is_expected.to_not be_trendable }
+        end
+      end
+
+      context 'when default is false' do
+        before { Setting.trendable_by_default = false }
+
+        context 'without any value provided' do
+          it { is_expected.to_not be_trendable }
+        end
+
+        context 'when default value is overridden' do
+          subject { described_class.new trendable: true }
+
+          it { is_expected.to be_trendable }
+        end
+      end
+    end
   end
 
   describe 'validations' do

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -17,6 +17,18 @@ RSpec.describe Tag do
         it { is_expected.to_not be_usable }
       end
     end
+
+    describe 'listable' do
+      context 'without any values' do
+        it { is_expected.to be_listable }
+      end
+
+      context 'with an overriden value' do
+        subject { described_class.new listable: false }
+
+        it { is_expected.to_not be_listable }
+      end
+    end
   end
 
   describe 'validations' do

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -5,6 +5,20 @@ require 'rails_helper'
 RSpec.describe Tag do
   include_examples 'Reviewable'
 
+  describe 'Defaults' do
+    describe 'usable' do
+      context 'without any values' do
+        it { is_expected.to be_usable }
+      end
+
+      context 'with an overriden value' do
+        subject { described_class.new usable: false }
+
+        it { is_expected.to_not be_usable }
+      end
+    end
+  end
+
   describe 'validations' do
     it 'invalid with #' do
       expect(described_class.new(name: '#hello_world')).to_not be_valid


### PR DESCRIPTION
This is an initial step to get rid of some "three state boolean" type scenarios for some attributes. Will need follow-up to put defaults in DB where possible, and then clean up scope/checks which currently handle nil to just handle true/false.

I suspect that this custom wrapper method pre-dates the existence of this default feature in rails attribute api (maybe rails ~5 or so? not sure) and that's why this method was used, but I think we can safely use the actual api instead at this point.

The coverage here is ... weirdly boring? ... but I wanted something to capture the previous behaviour before making changes. The actual model changes are a nice LOC reduction, and preserve the behavior of the previous accessors and query methods.