### PR TITLE
Fix cancel follow request button sometimes saying “Follow back”

### DIFF
--- a/app/javascript/mastodon/components/follow_button.tsx
+++ b/app/javascript/mastodon/components/follow_button.tsx
@@ -75,10 +75,10 @@ export const FollowButton: React.FC<{
     label = <LoadingIndicator />;
   } else if (relationship.following && relationship.followed_by) {
     label = intl.formatMessage(messages.mutual);
-  } else if (!relationship.following && relationship.followed_by) {
-    label = intl.formatMessage(messages.followBack);
   } else if (relationship.following || relationship.requested) {
     label = intl.formatMessage(messages.unfollow);
+  } else if (relationship.followed_by) {
+    label = intl.formatMessage(messages.followBack);
   } else {
     label = intl.formatMessage(messages.follow);
   }

--- a/app/javascript/mastodon/features/account/components/header.jsx
+++ b/app/javascript/mastodon/features/account/components/header.jsx
@@ -92,10 +92,10 @@ const messageForFollowButton = relationship => {
 
   if (relationship.get('following') && relationship.get('followed_by')) {
     return messages.mutual;
-  } else if (!relationship.get('following') && relationship.get('followed_by')) {
-    return messages.followBack;
   } else if (relationship.get('following') || relationship.get('requested')) {
     return messages.unfollow;
+  } else if (relationship.get('followed_by')) {
+    return messages.followBack;
   } else {
     return messages.follow;
   }


### PR DESCRIPTION
In #28452, the follow/unfollow button label was changed to reflect the state of the relationship instead of or in addition to the action it performs.

However, when someone is following you and you have already issued a follow request but that follow request is still pending, the interface will still show “Follow back” even though clicking the button will cause the follow request to be canceled.

This PR changes it so that the button shows “Unfollow”. The information that the person is following you is still lost, though, so maybe it should show “Mutual” instead, even if that is not accurate.

However, I think #28452 as a whole should be reconsidered, as it makes the button label encompass two pieces of state and potentially the performed action in a non-obvious way.