### PR TITLE
Add coverage for `AccountPin` validations

### DIFF
--- a/app/models/account_pin.rb
+++ b/app/models/account_pin.rb
@@ -18,7 +18,7 @@ class AccountPin < ApplicationRecord
   belongs_to :account
   belongs_to :target_account, class_name: 'Account'
 
-  validate :validate_follow_relationship
+  validate :validate_follow_relationship, if: -> { account.present? }
 
   private
 

--- a/spec/models/account_pin_spec.rb
+++ b/spec/models/account_pin_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe AccountPin do
 
   describe 'Validations' do
     describe 'the follow relationship' do
-      subject { described_class.new account: account }
+      subject { Fabricate.build :account_pin, account: account }
 
       let(:account) { Fabricate :account }
       let(:target_account) { Fabricate :account }

--- a/spec/models/account_pin_spec.rb
+++ b/spec/models/account_pin_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AccountPin do
+  describe 'Associations' do
+    it { is_expected.to belong_to(:account).required }
+    it { is_expected.to belong_to(:target_account).required }
+  end
+
+  describe 'Validations' do
+    describe 'the follow relationship' do
+      subject { described_class.new account: account }
+
+      let(:account) { Fabricate :account }
+      let(:target_account) { Fabricate :account }
+
+      context 'when account is following target account' do
+        before { account.follow!(target_account) }
+
+        it { is_expected.to allow_value(target_account).for(:target_account).against(:base) }
+      end
+
+      context 'when account is not following target account' do
+        it { is_expected.to_not allow_value(target_account).for(:target_account).against(:base).with_message(not_following_message) }
+
+        def not_following_message
+          I18n.t('accounts.pin_errors.following')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Coverage is straightforward ... only note is on the fabricator I wanted to do something like this - https://github.com/mastodon/mastodon/pull/31902 - but while in that case it was possible to have a valid record w/out the extra `before_..` creation, here it's not. Instead, just use `new` on class instead of fabricator for that specific validation check where we need to not have a `Follow` to exercise the validation failure.