### PR TITLE
Use `have_http_link_header` matcher in `api/v1/trends/*` specs

### DIFF
--- a/spec/requests/api/v1/trends/links_spec.rb
+++ b/spec/requests/api/v1/trends/links_spec.rb
@@ -10,7 +10,9 @@ RSpec.describe 'API V1 Trends Links' do
       it 'returns http success' do
         get '/api/v1/trends/links'
 
-        expect(response).to have_http_status(200)
+        expect(response)
+          .to have_http_status(200)
+          .and not_have_http_link_header
       end
     end
 
@@ -22,8 +24,9 @@ RSpec.describe 'API V1 Trends Links' do
         stub_const('Api::V1::Trends::LinksController::DEFAULT_LINKS_LIMIT', 2)
         get '/api/v1/trends/links'
 
-        expect(response).to have_http_status(200)
-        expect(response.headers).to include('Link')
+        expect(response)
+          .to have_http_status(200)
+          .and have_http_link_header(api_v1_trends_links_url(offset: 2)).for(rel: 'next')
       end
 
       def prepare_trends

--- a/spec/requests/api/v1/trends/statuses_spec.rb
+++ b/spec/requests/api/v1/trends/statuses_spec.rb
@@ -10,7 +10,9 @@ RSpec.describe 'API V1 Trends Statuses' do
       it 'returns http success' do
         get '/api/v1/trends/statuses'
 
-        expect(response).to have_http_status(200)
+        expect(response)
+          .to have_http_status(200)
+          .and not_have_http_link_header
       end
     end
 
@@ -22,8 +24,9 @@ RSpec.describe 'API V1 Trends Statuses' do
         stub_const('Api::BaseController::DEFAULT_STATUSES_LIMIT', 2)
         get '/api/v1/trends/statuses'
 
-        expect(response).to have_http_status(200)
-        expect(response.headers).to include('Link')
+        expect(response)
+          .to have_http_status(200)
+          .and have_http_link_header(api_v1_trends_statuses_url(offset: 2)).for(rel: 'next')
       end
 
       def prepare_trends

--- a/spec/requests/api/v1/trends/tags_spec.rb
+++ b/spec/requests/api/v1/trends/tags_spec.rb
@@ -10,8 +10,9 @@ RSpec.describe 'API V1 Trends Tags' do
       it 'returns http success' do
         get '/api/v1/trends/tags'
 
-        expect(response).to have_http_status(200)
-        expect(response.headers).to_not include('Link')
+        expect(response)
+          .to have_http_status(200)
+          .and not_have_http_link_header
       end
     end
 
@@ -23,8 +24,9 @@ RSpec.describe 'API V1 Trends Tags' do
         stub_const('Api::V1::Trends::TagsController::DEFAULT_TAGS_LIMIT', 2)
         get '/api/v1/trends/tags'
 
-        expect(response).to have_http_status(200)
-        expect(response.headers).to include('Link')
+        expect(response)
+          .to have_http_status(200)
+          .and have_http_link_header(api_v1_trends_tags_url(offset: 2)).for(rel: 'next')
       end
 
       def prepare_trends


### PR DESCRIPTION
Adding a few spots missed in the inital addition of the matcher.