### PR TITLE
Remove unneeded `to_s` on `Link` header comparison in statuses controller spec

### DIFF
--- a/spec/controllers/statuses_controller_spec.rb
+++ b/spec/controllers/statuses_controller_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe StatusesController do
           expect(response.headers).to include(
             'Vary' => 'Accept, Accept-Language, Cookie',
             'Cache-Control' => include('public'),
-            'Link' => satisfy { |header| header.to_s.include?('activity+json') }
+            'Link' => include('activity+json')
           )
           expect(response.body).to include status.text
         end
@@ -79,7 +79,7 @@ RSpec.describe StatusesController do
 
           expect(response.headers).to include(
             'Content-Type' => include('application/activity+json'),
-            'Link' => satisfy { |header| header.to_s.include?('activity+json') }
+            'Link' => include('activity+json')
           )
           expect(response.parsed_body)
             .to include(content: include(status.text))
@@ -168,7 +168,7 @@ RSpec.describe StatusesController do
             expect(response.headers).to include(
               'Vary' => 'Accept, Accept-Language, Cookie',
               'Cache-Control' => include('private'),
-              'Link' => satisfy { |header| header.to_s.include?('activity+json') }
+              'Link' => include('activity+json')
             )
             expect(response.body).to include status.text
           end
@@ -184,7 +184,7 @@ RSpec.describe StatusesController do
               'Vary' => 'Accept, Accept-Language, Cookie',
               'Cache-Control' => include('private'),
               'Content-Type' => include('application/activity+json'),
-              'Link' => satisfy { |header| header.to_s.include?('activity+json') }
+              'Link' => include('activity+json')
             )
             expect(response.parsed_body)
               .to include(content: include(status.text))
@@ -212,7 +212,7 @@ RSpec.describe StatusesController do
               expect(response.headers).to include(
                 'Vary' => 'Accept, Accept-Language, Cookie',
                 'Cache-Control' => include('private'),
-                'Link' => satisfy { |header| header.to_s.include?('activity+json') }
+                'Link' => include('activity+json')
               )
               expect(response.body).to include status.text
             end
@@ -228,7 +228,7 @@ RSpec.describe StatusesController do
                 'Vary' => 'Accept, Accept-Language, Cookie',
                 'Cache-Control' => include('private'),
                 'Content-Type' => include('application/activity+json'),
-                'Link' => satisfy { |header| header.to_s.include?('activity+json') }
+                'Link' => include('activity+json')
               )
               expect(response.parsed_body)
                 .to include(content: include(status.text))
@@ -278,7 +278,7 @@ RSpec.describe StatusesController do
               expect(response.headers).to include(
                 'Vary' => 'Accept, Accept-Language, Cookie',
                 'Cache-Control' => include('private'),
-                'Link' => satisfy { |header| header.to_s.include?('activity+json') }
+                'Link' => include('activity+json')
               )
               expect(response.body).to include status.text
             end
@@ -294,7 +294,7 @@ RSpec.describe StatusesController do
                 'Vary' => 'Accept, Accept-Language, Cookie',
                 'Cache-Control' => include('private'),
                 'Content-Type' => include('application/activity+json'),
-                'Link' => satisfy { |header| header.to_s.include?('activity+json') }
+                'Link' => include('activity+json')
               )
               expect(response.parsed_body)
                 .to include(content: include(status.text))
@@ -370,7 +370,7 @@ RSpec.describe StatusesController do
             expect(response.headers).to include(
               'Vary' => 'Accept, Accept-Language, Cookie',
               'Cache-Control' => include('private'),
-              'Link' => satisfy { |header| header.to_s.include?('activity+json') }
+              'Link' => include('activity+json')
             )
             expect(response.body).to include status.text
           end
@@ -385,7 +385,7 @@ RSpec.describe StatusesController do
               .and have_cacheable_headers.with_vary('Accept, Accept-Language, Cookie')
             expect(response.headers).to include(
               'Content-Type' => include('application/activity+json'),
-              'Link' => satisfy { |header| header.to_s.include?('activity+json') }
+              'Link' => include('activity+json')
             )
             expect(response.parsed_body)
               .to include(content: include(status.text))
@@ -412,7 +412,7 @@ RSpec.describe StatusesController do
               expect(response.headers).to include(
                 'Vary' => 'Accept, Accept-Language, Cookie',
                 'Cache-Control' => include('private'),
-                'Link' => satisfy { |header| header.to_s.include?('activity+json') }
+                'Link' => include('activity+json')
               )
               expect(response.body).to include status.text
             end
@@ -428,7 +428,7 @@ RSpec.describe StatusesController do
                 'Vary' => 'Accept, Accept-Language, Cookie',
                 'Cache-Control' => include('private'),
                 'Content-Type' => include('application/activity+json'),
-                'Link' => satisfy { |header| header.to_s.include?('activity+json') }
+                'Link' => include('activity+json')
               )
 
               expect(response.parsed_body)
@@ -479,7 +479,7 @@ RSpec.describe StatusesController do
               expect(response.headers).to include(
                 'Vary' => 'Accept, Accept-Language, Cookie',
                 'Cache-Control' => include('private'),
-                'Link' => satisfy { |header| header.to_s.include?('activity+json') }
+                'Link' => include('activity+json')
               )
               expect(response.body).to include status.text
             end
@@ -495,7 +495,7 @@ RSpec.describe StatusesController do
                 'Vary' => 'Accept, Accept-Language, Cookie',
                 'Cache-Control' => include('private'),
                 'Content-Type' => include('application/activity+json'),
-                'Link' => satisfy { |header| header.to_s.include?('activity+json') }
+                'Link' => include('activity+json')
               )
               expect(response.parsed_body)
                 .to include(content: include(status.text))
@@ -779,7 +779,7 @@ RSpec.describe StatusesController do
         expect(response.headers).to include(
           'Vary' => 'Accept, Accept-Language, Cookie',
           'Cache-Control' => include('public'),
-          'Link' => satisfy { |header| header.to_s.include?('activity+json') }
+          'Link' => include('activity+json')
         )
       end
     end


### PR DESCRIPTION
Previously we were putting a `Link` object (not a string) in the headers, to we needed to do this `to_s` here before the assertion. After a recent fix we are assigning strings directly in the header, so we can just compare directly w/out going through the `to_s` step.

Some of these (and/or their surrounding assertions) might be relevant to either of the recently added link or caching headers matchers ... but for now, just a once over to match style and remove no longer needed step.