### PR TITLE
Fix background of text detection progress

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -3921,7 +3921,7 @@ $ui-header-logo-wordmark-width: 99px;
   }
 
   &__wrapper {
-    background: $white;
+    background: $ui-base-color;
     border: 1px solid var(--background-border-color);
     margin-bottom: 10px;
     border-radius: 4px;


### PR DESCRIPTION
Fixes this to match the text area above it:

<img width="469" alt="Screenshot 2024-09-16 at 12 54 44 PM" src="https://github.com/user-attachments/assets/5effe017-876d-42ac-b7a4-15b06e65f119">