### PR TITLE
Mute XHR abort errors

### DIFF
--- a/app/javascript/mastodon/actions/alerts.js
+++ b/app/javascript/mastodon/actions/alerts.js
@@ -1,5 +1,7 @@
 import { defineMessages } from 'react-intl';
 
+import { AxiosError } from 'axios';
+
 const messages = defineMessages({
   unexpectedTitle: { id: 'alert.unexpected.title', defaultMessage: 'Oops!' },
   unexpectedMessage: { id: 'alert.unexpected.message', defaultMessage: 'An unexpected error occurred.' },
@@ -48,6 +50,11 @@ export const showAlertForError = (error, skipNotFound = false) => {
       title: `${status}`,
       message: data.error || statusText,
     });
+  }
+
+  // An aborted request, e.g. due to reloading the browser window, it not really error
+  if (error.code === AxiosError.ECONNABORTED) {
+    return { type: ALERT_NOOP };
   }
 
   console.error(error);

--- a/app/javascript/mastodon/api.ts
+++ b/app/javascript/mastodon/api.ts
@@ -42,6 +42,9 @@ const authorizationTokenFromInitialState = (): RawAxiosRequestHeaders => {
 // eslint-disable-next-line import/no-default-export
 export default function api(withAuthorization = true) {
   return axios.create({
+    transitional: {
+      clarifyTimeoutError: true,
+    },
     headers: {
       ...csrfHeader,
       ...(withAuthorization ? authorizationTokenFromInitialState() : {}),


### PR DESCRIPTION
When you reload the browser window, you often see an alert with _"Oops! An unexpected error occurred”_, especially on development (localhost).

This is because Axios maps the XHR `abort` event to `AxiosError` (see https://github.com/axios/axios/blob/1472163d373dda71f74e86365ee2f298d922f5db/lib/adapters/xhr.js#L95-L104). I suggest we mute those errors.