### PR TITLE
Introduce account search query object, reduce search surface area in `Account` model

### DIFF
--- a/app/models/concerns/account/search.rb
+++ b/app/models/concerns/account/search.rb
@@ -15,14 +15,12 @@ module Account::Search
     end
   end
 
-  DEFAULT_LIMIT = 10
-
   class_methods do
-    def search_for(terms, limit: DEFAULT_LIMIT, offset: 0)
+    def search_for(terms, limit: AccountSearchQuery::DEFAULT_LIMIT, offset: 0)
       AccountSearchQuery.search_for(terms, limit: limit, offset: offset)
     end
 
-    def advanced_search_for(terms, account, limit: DEFAULT_LIMIT, following: false, offset: 0)
+    def advanced_search_for(terms, account, limit: AccountSearchQuery::DEFAULT_LIMIT, following: false, offset: 0)
       AccountSearchQuery.advanced_search_for(terms, account, limit: limit, following: following, offset: offset)
     end
   end

--- a/app/models/concerns/account/search.rb
+++ b/app/models/concerns/account/search.rb
@@ -17,11 +17,11 @@ module Account::Search
 
   class_methods do
     def search_for(terms, limit: AccountSearchQuery::DEFAULT_LIMIT, offset: 0)
-      AccountSearchQuery.new(terms:).search_for(limit: limit, offset: offset)
+      AccountSearchQuery.new(terms:, limit:, offset:).search
     end
 
     def advanced_search_for(terms, account, limit: AccountSearchQuery::DEFAULT_LIMIT, following: false, offset: 0)
-      AccountSearchQuery.new(terms:).advanced_search_for(account, limit: limit, following: following, offset: offset)
+      AccountSearchQuery.new(terms:, limit:, offset:).advanced_search(account, following: following)
     end
   end
 end

--- a/app/models/concerns/account/search.rb
+++ b/app/models/concerns/account/search.rb
@@ -3,111 +3,6 @@
 module Account::Search
   extend ActiveSupport::Concern
 
-  DISALLOWED_TSQUERY_CHARACTERS = /['?\\:‘’]/
-
-  TEXT_SEARCH_RANKS = <<~SQL.squish
-    (
-        setweight(to_tsvector('simple', accounts.display_name), 'A') ||
-        setweight(to_tsvector('simple', accounts.username), 'B') ||
-        setweight(to_tsvector('simple', coalesce(accounts.domain, '')), 'C')
-    )
-  SQL
-
-  REPUTATION_SCORE_FUNCTION = <<~SQL.squish
-    (
-        greatest(0, coalesce(s.followers_count, 0)) / (
-            greatest(0, coalesce(s.following_count, 0)) + 1.0
-        )
-    )
-  SQL
-
-  FOLLOWERS_SCORE_FUNCTION = <<~SQL.squish
-    log(
-        greatest(0, coalesce(s.followers_count, 0)) + 2
-    )
-  SQL
-
-  TIME_DISTANCE_FUNCTION = <<~SQL.squish
-    (
-        case
-            when s.last_status_at is null then 0
-            else exp(
-                -1.0 * (
-                    (
-                        greatest(0, abs(extract(DAY FROM age(s.last_status_at))) - 30.0)^2) /#{' '}
-                        (2.0 * ((-1.0 * 30^2) / (2.0 * ln(0.3)))
-                    )
-                )
-            )
-        end
-    )
-  SQL
-
-  BOOST = <<~SQL.squish
-    (
-        (#{REPUTATION_SCORE_FUNCTION} + #{FOLLOWERS_SCORE_FUNCTION} + #{TIME_DISTANCE_FUNCTION}) / 3.0
-    )
-  SQL
-
-  BASIC_SEARCH_SQL = <<~SQL.squish
-    SELECT
-      accounts.*,
-      #{BOOST} * ts_rank_cd(#{TEXT_SEARCH_RANKS}, to_tsquery('simple', :tsquery), 32) AS rank
-    FROM accounts
-    LEFT JOIN users ON accounts.id = users.account_id
-    LEFT JOIN account_stats AS s ON accounts.id = s.account_id
-    WHERE to_tsquery('simple', :tsquery) @@ #{TEXT_SEARCH_RANKS}
-      AND accounts.suspended_at IS NULL
-      AND accounts.moved_to_account_id IS NULL
-      AND (accounts.domain IS NOT NULL OR (users.approved = TRUE AND users.confirmed_at IS NOT NULL))
-    ORDER BY rank DESC
-    LIMIT :limit OFFSET :offset
-  SQL
-
-  ADVANCED_SEARCH_WITH_FOLLOWING = <<~SQL.squish
-    WITH first_degree AS (
-      SELECT target_account_id
-      FROM follows
-      WHERE account_id = :id
-      UNION ALL
-      SELECT :id
-    )
-    SELECT
-      accounts.*,
-      (count(f.id) + 1) * #{BOOST} * ts_rank_cd(#{TEXT_SEARCH_RANKS}, to_tsquery('simple', :tsquery), 32) AS rank
-    FROM accounts
-    LEFT OUTER JOIN follows AS f ON (accounts.id = f.account_id AND f.target_account_id = :id)
-    LEFT JOIN account_stats AS s ON accounts.id = s.account_id
-    WHERE accounts.id IN (SELECT * FROM first_degree)
-      AND to_tsquery('simple', :tsquery) @@ #{TEXT_SEARCH_RANKS}
-      AND accounts.suspended_at IS NULL
-      AND accounts.moved_to_account_id IS NULL
-    GROUP BY accounts.id, s.id
-    ORDER BY rank DESC
-    LIMIT :limit OFFSET :offset
-  SQL
-
-  ADVANCED_SEARCH_WITHOUT_FOLLOWING = <<~SQL.squish
-    SELECT
-      accounts.*,
-      #{BOOST} * ts_rank_cd(#{TEXT_SEARCH_RANKS}, to_tsquery('simple', :tsquery), 32) AS rank,
-      count(f.id) AS followed
-    FROM accounts
-    LEFT OUTER JOIN follows AS f ON
-      (accounts.id = f.account_id AND f.target_account_id = :id) OR (accounts.id = f.target_account_id AND f.account_id = :id)
-    LEFT JOIN users ON accounts.id = users.account_id
-    LEFT JOIN account_stats AS s ON accounts.id = s.account_id
-    WHERE to_tsquery('simple', :tsquery) @@ #{TEXT_SEARCH_RANKS}
-      AND accounts.suspended_at IS NULL
-      AND accounts.moved_to_account_id IS NULL
-      AND (accounts.domain IS NOT NULL OR (users.approved = TRUE AND users.confirmed_at IS NOT NULL))
-    GROUP BY accounts.id, s.id
-    ORDER BY followed DESC, rank DESC
-    LIMIT :limit OFFSET :offset
-  SQL
-
-  DEFAULT_LIMIT = 10
-
   def searchable_text
     PlainTextFormatter.new(note, local?).to_s if discoverable?
   end
@@ -120,35 +15,15 @@ module Account::Search
     end
   end
 
+  DEFAULT_LIMIT = 10
+
   class_methods do
     def search_for(terms, limit: DEFAULT_LIMIT, offset: 0)
-      tsquery = generate_query_for_search(terms)
-
-      find_by_sql([BASIC_SEARCH_SQL, { limit: limit, offset: offset, tsquery: tsquery }]).tap do |records|
-        ActiveRecord::Associations::Preloader.new(records: records, associations: [:account_stat, { user: :role }]).call
-      end
+      AccountSearchQuery.search_for(terms, limit: limit, offset: offset)
     end
 
     def advanced_search_for(terms, account, limit: DEFAULT_LIMIT, following: false, offset: 0)
-      tsquery = generate_query_for_search(terms)
-      sql_template = following ? ADVANCED_SEARCH_WITH_FOLLOWING : ADVANCED_SEARCH_WITHOUT_FOLLOWING
-
-      find_by_sql([sql_template, { id: account.id, limit: limit, offset: offset, tsquery: tsquery }]).tap do |records|
-        ActiveRecord::Associations::Preloader.new(records: records, associations: [:account_stat, { user: :role }]).call
-      end
-    end
-
-    private
-
-    def generate_query_for_search(unsanitized_terms)
-      terms = unsanitized_terms.gsub(DISALLOWED_TSQUERY_CHARACTERS, ' ')
-
-      # The final ":*" is for prefix search.
-      # The trailing space does not seem to fit any purpose, but `to_tsquery`
-      # behaves differently with and without a leading space if the terms start
-      # with `./`, `../`, or `.. `. I don't understand why, so, in doubt, keep
-      # the same query.
-      "' #{terms} ':*"
+      AccountSearchQuery.advanced_search_for(terms, account, limit: limit, following: following, offset: offset)
     end
   end
 end

--- a/app/models/concerns/account/search.rb
+++ b/app/models/concerns/account/search.rb
@@ -17,11 +17,11 @@ module Account::Search
 
   class_methods do
     def search_for(terms, limit: AccountSearchQuery::DEFAULT_LIMIT, offset: 0)
-      AccountSearchQuery.search_for(terms, limit: limit, offset: offset)
+      AccountSearchQuery.new(terms:).search_for(limit: limit, offset: offset)
     end
 
     def advanced_search_for(terms, account, limit: AccountSearchQuery::DEFAULT_LIMIT, following: false, offset: 0)
-      AccountSearchQuery.advanced_search_for(terms, account, limit: limit, following: following, offset: offset)
+      AccountSearchQuery.new(terms:).advanced_search_for(account, limit: limit, following: following, offset: offset)
     end
   end
 end

--- a/app/queries/account_search_query.rb
+++ b/app/queries/account_search_query.rb
@@ -121,9 +121,7 @@ class AccountSearchQuery
   end
 
   def advanced_search(account, following: false)
-    sql_template = following ? ADVANCED_SEARCH_WITH_FOLLOWING : ADVANCED_SEARCH_WITHOUT_FOLLOWING
-
-    Account.find_by_sql([sql_template, { id: account.id, limit: @limit, offset: @offset, tsquery: generate_query_for_search }]).tap do |records|
+    Account.find_by_sql([advanced_sql_template(following), { id: account.id, limit: @limit, offset: @offset, tsquery: generate_query_for_search }]).tap do |records|
       ActiveRecord::Associations::Preloader.new(records: records, associations: [:account_stat, { user: :role }]).call
     end
   end
@@ -142,5 +140,9 @@ class AccountSearchQuery
   def sanitized_search_terms
     @terms
       .gsub(DISALLOWED_TSQUERY_CHARACTERS, ' ')
+  end
+
+  def advanced_sql_template(following)
+    following ? ADVANCED_SEARCH_WITH_FOLLOWING : ADVANCED_SEARCH_WITHOUT_FOLLOWING
   end
 end

--- a/app/queries/account_search_query.rb
+++ b/app/queries/account_search_query.rb
@@ -116,17 +116,24 @@ class AccountSearchQuery
 
   def search
     Account.find_by_sql([BASIC_SEARCH_SQL, { limit: @limit, offset: @offset, tsquery: generate_query_for_search }]).tap do |records|
-      ActiveRecord::Associations::Preloader.new(records: records, associations: [:account_stat, { user: :role }]).call
+      preload(records)
     end
   end
 
   def advanced_search(account, following: false)
     Account.find_by_sql([advanced_sql_template(following), { id: account.id, limit: @limit, offset: @offset, tsquery: generate_query_for_search }]).tap do |records|
-      ActiveRecord::Associations::Preloader.new(records: records, associations: [:account_stat, { user: :role }]).call
+      preload(records)
     end
   end
 
   private
+
+  def preload(records)
+    ActiveRecord::Associations::Preloader.new(
+      records: records,
+      associations: [:account_stat, { user: :role }]
+    ).call
+  end
 
   def generate_query_for_search
     # The final ":*" is for prefix search.

--- a/app/queries/account_search_query.rb
+++ b/app/queries/account_search_query.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+class AccountSearchQuery
+  DISALLOWED_TSQUERY_CHARACTERS = /['?\\:‘’]/
+
+  TEXT_SEARCH_RANKS = <<~SQL.squish
+    (
+        setweight(to_tsvector('simple', accounts.display_name), 'A') ||
+        setweight(to_tsvector('simple', accounts.username), 'B') ||
+        setweight(to_tsvector('simple', coalesce(accounts.domain, '')), 'C')
+    )
+  SQL
+
+  REPUTATION_SCORE_FUNCTION = <<~SQL.squish
+    (
+        greatest(0, coalesce(s.followers_count, 0)) / (
+            greatest(0, coalesce(s.following_count, 0)) + 1.0
+        )
+    )
+  SQL
+
+  FOLLOWERS_SCORE_FUNCTION = <<~SQL.squish
+    log(
+        greatest(0, coalesce(s.followers_count, 0)) + 2
+    )
+  SQL
+
+  TIME_DISTANCE_FUNCTION = <<~SQL.squish
+    (
+        case
+            when s.last_status_at is null then 0
+            else exp(
+                -1.0 * (
+                    (
+                        greatest(0, abs(extract(DAY FROM age(s.last_status_at))) - 30.0)^2) /#{' '}
+                        (2.0 * ((-1.0 * 30^2) / (2.0 * ln(0.3)))
+                    )
+                )
+            )
+        end
+    )
+  SQL
+
+  BOOST = <<~SQL.squish
+    (
+        (#{REPUTATION_SCORE_FUNCTION} + #{FOLLOWERS_SCORE_FUNCTION} + #{TIME_DISTANCE_FUNCTION}) / 3.0
+    )
+  SQL
+
+  BASIC_SEARCH_SQL = <<~SQL.squish
+    SELECT
+      accounts.*,
+      #{BOOST} * ts_rank_cd(#{TEXT_SEARCH_RANKS}, to_tsquery('simple', :tsquery), 32) AS rank
+    FROM accounts
+    LEFT JOIN users ON accounts.id = users.account_id
+    LEFT JOIN account_stats AS s ON accounts.id = s.account_id
+    WHERE to_tsquery('simple', :tsquery) @@ #{TEXT_SEARCH_RANKS}
+      AND accounts.suspended_at IS NULL
+      AND accounts.moved_to_account_id IS NULL
+      AND (accounts.domain IS NOT NULL OR (users.approved = TRUE AND users.confirmed_at IS NOT NULL))
+    ORDER BY rank DESC
+    LIMIT :limit OFFSET :offset
+  SQL
+
+  ADVANCED_SEARCH_WITH_FOLLOWING = <<~SQL.squish
+    WITH first_degree AS (
+      SELECT target_account_id
+      FROM follows
+      WHERE account_id = :id
+      UNION ALL
+      SELECT :id
+    )
+    SELECT
+      accounts.*,
+      (count(f.id) + 1) * #{BOOST} * ts_rank_cd(#{TEXT_SEARCH_RANKS}, to_tsquery('simple', :tsquery), 32) AS rank
+    FROM accounts
+    LEFT OUTER JOIN follows AS f ON (accounts.id = f.account_id AND f.target_account_id = :id)
+    LEFT JOIN account_stats AS s ON accounts.id = s.account_id
+    WHERE accounts.id IN (SELECT * FROM first_degree)
+      AND to_tsquery('simple', :tsquery) @@ #{TEXT_SEARCH_RANKS}
+      AND accounts.suspended_at IS NULL
+      AND accounts.moved_to_account_id IS NULL
+    GROUP BY accounts.id, s.id
+    ORDER BY rank DESC
+    LIMIT :limit OFFSET :offset
+  SQL
+
+  ADVANCED_SEARCH_WITHOUT_FOLLOWING = <<~SQL.squish
+    SELECT
+      accounts.*,
+      #{BOOST} * ts_rank_cd(#{TEXT_SEARCH_RANKS}, to_tsquery('simple', :tsquery), 32) AS rank,
+      count(f.id) AS followed
+    FROM accounts
+    LEFT OUTER JOIN follows AS f ON
+      (accounts.id = f.account_id AND f.target_account_id = :id) OR (accounts.id = f.target_account_id AND f.account_id = :id)
+    LEFT JOIN users ON accounts.id = users.account_id
+    LEFT JOIN account_stats AS s ON accounts.id = s.account_id
+    WHERE to_tsquery('simple', :tsquery) @@ #{TEXT_SEARCH_RANKS}
+      AND accounts.suspended_at IS NULL
+      AND accounts.moved_to_account_id IS NULL
+      AND (accounts.domain IS NOT NULL OR (users.approved = TRUE AND users.confirmed_at IS NOT NULL))
+    GROUP BY accounts.id, s.id
+    ORDER BY followed DESC, rank DESC
+    LIMIT :limit OFFSET :offset
+  SQL
+
+  DEFAULT_LIMIT = 10
+
+  class << self
+    def search_for(terms, limit: DEFAULT_LIMIT, offset: 0)
+      tsquery = generate_query_for_search(terms)
+
+      Account.find_by_sql([BASIC_SEARCH_SQL, { limit: limit, offset: offset, tsquery: tsquery }]).tap do |records|
+        ActiveRecord::Associations::Preloader.new(records: records, associations: [:account_stat, { user: :role }]).call
+      end
+    end
+
+    def advanced_search_for(terms, account, limit: DEFAULT_LIMIT, following: false, offset: 0)
+      tsquery = generate_query_for_search(terms)
+      sql_template = following ? ADVANCED_SEARCH_WITH_FOLLOWING : ADVANCED_SEARCH_WITHOUT_FOLLOWING
+
+      Account.find_by_sql([sql_template, { id: account.id, limit: limit, offset: offset, tsquery: tsquery }]).tap do |records|
+        ActiveRecord::Associations::Preloader.new(records: records, associations: [:account_stat, { user: :role }]).call
+      end
+    end
+
+    private
+
+    def generate_query_for_search(unsanitized_terms)
+      terms = unsanitized_terms.gsub(DISALLOWED_TSQUERY_CHARACTERS, ' ')
+
+      # The final ":*" is for prefix search.
+      # The trailing space does not seem to fit any purpose, but `to_tsquery`
+      # behaves differently with and without a leading space if the terms start
+      # with `./`, `../`, or `.. `. I don't understand why, so, in doubt, keep
+      # the same query.
+      "' #{terms} ':*"
+    end
+  end
+end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -422,7 +422,7 @@ RSpec.describe Account do
     end
 
     it 'limits via constant by default' do
-      stub_const('Account::Search::DEFAULT_LIMIT', 1)
+      stub_const('AccountSearchQuery::DEFAULT_LIMIT', 1)
       2.times.each { Fabricate(:account, display_name: 'Display Name') }
       results = described_class.search_for('display')
       expect(results.size).to eq 1
@@ -566,7 +566,7 @@ RSpec.describe Account do
     end
 
     it 'limits result count by default value' do
-      stub_const('Account::Search::DEFAULT_LIMIT', 1)
+      stub_const('AccountSearchQuery::DEFAULT_LIMIT', 1)
       2.times { Fabricate(:account, display_name: 'Display Name') }
       results = described_class.advanced_search_for('display', account)
       expect(results.size).to eq 1


### PR DESCRIPTION
This model concern is used for both a) exposing some required methods for the ES based search, b) providing class methods for when ES not available to do sql queries.

I have a WIP branch going which attempts to pull out some of the sql-string-creation going on here into a mix of arel-built queries, re-using existing scopes, etc. It's currently passing for the basic conversion of the queries (basic and both advanced) and is right at point where I'd either PR it, or continue to convert/simplify some of the larger sql-string constants ... but it occurred to me while in there that since it's a model concern, we're effectively including all the constants/methods directly into the `Account` model class as well. Maybe not awful (it's large, but not massive?) but also not ideal.

This is a first-pass at extracting an account search query object which essentially takes the implementation out of the previous concern and puts it into this class instead.

It may be easier to review this commit by commit instead of the full diff at once. The very first commit just does a dumb copy/paste (to extent possible) into the new class, and the subsequent commits should be obvious and are all small-ish.

I did this in a way where the previous external interface is still held in the concern module, and remains the same to any callers. There's decent coverage of all this in the account spec, and all passes, and the extracted query class has 100% coverage.

Obvious next steps:

- At least do another pass here to further simplify/cleanup given the i-var access that the query class has (instead of passing as many args/strings around) ... I wanted to keep this PR to basically the simplest extraction, and not totally reshape the sql building at the same time.
- If relevant (I'd rebase other branch and continue work), keep going on the scope-reuse/arel path to see how that shakes out

