### PR TITLE
Remove unused E2EE-related methods

### DIFF
--- a/app/javascript/mastodon/stream.js
+++ b/app/javascript/mastodon/stream.js
@@ -209,7 +209,6 @@ const KNOWN_EVENT_TYPES = [
   'notification',
   'conversation',
   'filters_changed',
-  'encrypted_message',
   'announcement',
   'announcement.delete',
   'announcement.reaction',

--- a/app/presenters/activitypub/activity_presenter.rb
+++ b/app/presenters/activitypub/activity_presenter.rb
@@ -26,16 +26,5 @@ class ActivityPub::ActivityPresenter < ActiveModelSerializers::Model
         end
       end
     end
-
-    def from_encrypted_message(encrypted_message)
-      new.tap do |presenter|
-        presenter.id = ActivityPub::TagManager.instance.generate_uri_for(nil)
-        presenter.type = 'Create'
-        presenter.actor = ActivityPub::TagManager.instance.uri_for(encrypted_message.source_account)
-        presenter.published = Time.now.utc
-        presenter.to = ActivityPub::TagManager.instance.uri_for(encrypted_message.target_account)
-        presenter.virtual_object = encrypted_message
-      end
-    end
   end
 end


### PR DESCRIPTION
Followup/cleanup from https://github.com/mastodon/mastodon/pull/31193

That PR started with a git revert, so probably missed some things which are E2EE-related but were not in original PR. In this PR:

- I assume the stream JS code no longer needs to recognize this type of event (which presumably was also never sent)
- In presenter, remove handling of encrypted message (this I think was in original PR, may have been lost in revert rebase or something)