### PR TITLE
Combine API request spec assertions

### DIFF
--- a/spec/requests/api/v1/admin/accounts_spec.rb
+++ b/spec/requests/api/v1/admin/accounts_spec.rb
@@ -193,15 +193,11 @@ RSpec.describe 'Accounts' do
       it_behaves_like 'forbidden for wrong scope', 'write write:accounts read admin:read'
       it_behaves_like 'forbidden for wrong role', ''
 
-      it 'removes the user successfully', :aggregate_failures do
+      it 'removes the user successfully and logs action', :aggregate_failures do
         subject
 
         expect(response).to have_http_status(200)
         expect(User.where(id: account.user.id)).to_not exist
-      end
-
-      it 'logs action', :aggregate_failures do
-        subject
 
         expect(latest_admin_action_log)
           .to be_present

--- a/spec/requests/api/v1/admin/tags_spec.rb
+++ b/spec/requests/api/v1/admin/tags_spec.rb
@@ -73,14 +73,10 @@ RSpec.describe 'Tags' do
     it_behaves_like 'forbidden for wrong scope', 'write:statuses'
     it_behaves_like 'forbidden for wrong role', ''
 
-    it 'returns http success' do
+    it 'returns http success and expected tag content' do
       subject
 
       expect(response).to have_http_status(200)
-    end
-
-    it 'returns expected tag content' do
-      subject
 
       expect(response.parsed_body[:id].to_i).to eq(tag.id)
       expect(response.parsed_body[:name]).to eq(tag.name)
@@ -107,14 +103,10 @@ RSpec.describe 'Tags' do
     it_behaves_like 'forbidden for wrong scope', 'admin:read'
     it_behaves_like 'forbidden for wrong role', ''
 
-    it 'returns http success' do
+    it 'returns http success and updates tag' do
       subject
 
       expect(response).to have_http_status(200)
-    end
-
-    it 'returns updated tag' do
-      subject
 
       expect(response.parsed_body[:id].to_i).to eq(tag.id)
       expect(response.parsed_body[:name]).to eq(tag.name.upcase)

--- a/spec/requests/api/v1/apps/credentials_spec.rb
+++ b/spec/requests/api/v1/apps/credentials_spec.rb
@@ -47,14 +47,10 @@ RSpec.describe 'Credentials' do
       let(:token)   { Fabricate(:accessible_access_token, application: application) }
       let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
 
-      it 'returns http success' do
+      it 'returns http success and returns app information' do
         subject
 
         expect(response).to have_http_status(200)
-      end
-
-      it 'returns the app information correctly' do
-        subject
 
         expect(response.parsed_body).to match(
           a_hash_including(
@@ -108,14 +104,10 @@ RSpec.describe 'Credentials' do
       let(:token)   { Fabricate(:accessible_access_token, application: application) }
       let(:headers) { { 'Authorization' => "Bearer #{token.token}-invalid" } }
 
-      it 'returns http authorization error' do
+      it 'returns http authorization error with json error' do
         subject
 
         expect(response).to have_http_status(401)
-      end
-
-      it 'returns the error in the json response' do
-        subject
 
         expect(response.parsed_body).to match(
           a_hash_including(

--- a/spec/requests/api/v1/blocks_spec.rb
+++ b/spec/requests/api/v1/blocks_spec.rb
@@ -32,15 +32,10 @@ RSpec.describe 'Blocks' do
     context 'with limit param' do
       let(:params) { { limit: 2 } }
 
-      it 'returns only the requested number of blocked accounts' do
+      it 'returns only the requested number of blocked accounts and sets link header pagination' do
         subject
 
         expect(response.parsed_body.size).to eq(params[:limit])
-      end
-
-      it 'sets correct link header pagination' do
-        subject
-
         expect(response)
           .to include_pagination_headers(
             prev: api_v1_blocks_url(limit: params[:limit], since_id: blocks.last.id),

--- a/spec/requests/api/v1/bookmarks_spec.rb
+++ b/spec/requests/api/v1/bookmarks_spec.rb
@@ -24,15 +24,10 @@ RSpec.describe 'Bookmarks' do
 
     it_behaves_like 'forbidden for wrong scope', 'write'
 
-    it 'returns http success' do
+    it 'returns http success and the bookmarked statuses' do
       subject
 
       expect(response).to have_http_status(200)
-    end
-
-    it 'returns the bookmarked statuses' do
-      subject
-
       expect(response.parsed_body).to match_array(expected_response)
     end
 

--- a/spec/requests/api/v1/favourites_spec.rb
+++ b/spec/requests/api/v1/favourites_spec.rb
@@ -24,30 +24,20 @@ RSpec.describe 'Favourites' do
 
     it_behaves_like 'forbidden for wrong scope', 'write'
 
-    it 'returns http success' do
+    it 'returns http success and includes the favourites' do
       subject
 
       expect(response).to have_http_status(200)
-    end
-
-    it 'returns the favourites' do
-      subject
-
       expect(response.parsed_body).to match_array(expected_response)
     end
 
     context 'with limit param' do
       let(:params) { { limit: 1 } }
 
-      it 'returns only the requested number of favourites' do
+      it 'returns only the requested number of favourites and sets pagination headers' do
         subject
 
         expect(response.parsed_body.size).to eq(params[:limit])
-      end
-
-      it 'sets the correct pagination headers' do
-        subject
-
         expect(response)
           .to include_pagination_headers(
             prev: api_v1_favourites_url(limit: params[:limit], min_id: favourites.last.id),

--- a/spec/requests/api/v1/featured_tags_spec.rb
+++ b/spec/requests/api/v1/featured_tags_spec.rb
@@ -58,15 +58,10 @@ RSpec.describe 'FeaturedTags' do
   describe 'POST /api/v1/featured_tags' do
     let(:params) { { name: 'tag' } }
 
-    it 'returns http success' do
+    it 'returns http success and includes correct tag name' do
       post '/api/v1/featured_tags', headers: headers, params: params
 
       expect(response).to have_http_status(200)
-    end
-
-    it 'returns the correct tag name' do
-      post '/api/v1/featured_tags', headers: headers, params: params
-
       expect(response.parsed_body)
         .to include(
           name: params[:name]
@@ -132,23 +127,13 @@ RSpec.describe 'FeaturedTags' do
     let!(:featured_tag) { FeaturedTag.create(name: 'tag', account: user.account) }
     let(:id) { featured_tag.id }
 
-    it 'returns http success' do
+    it 'returns http success with an empty body and deletes the featured tag', :inline_jobs do
       delete "/api/v1/featured_tags/#{id}", headers: headers
 
       expect(response).to have_http_status(200)
-    end
-
-    it 'returns an empty body' do
-      delete "/api/v1/featured_tags/#{id}", headers: headers
-
       expect(response.parsed_body).to be_empty
-    end
-
-    it 'deletes the featured tag', :inline_jobs do
-      delete "/api/v1/featured_tags/#{id}", headers: headers
 
       featured_tag = FeaturedTag.find_by(id: id)
-
       expect(featured_tag).to be_nil
     end
 

--- a/spec/requests/api/v1/followed_tags_spec.rb
+++ b/spec/requests/api/v1/followed_tags_spec.rb
@@ -28,15 +28,10 @@ RSpec.describe 'Followed tags' do
 
     it_behaves_like 'forbidden for wrong scope', 'write write:follows'
 
-    it 'returns http success' do
+    it 'returns http success and includes followed tags' do
       subject
 
       expect(response).to have_http_status(:success)
-    end
-
-    it 'returns the followed tags correctly' do
-      subject
-
       expect(response.parsed_body).to match_array(expected_response)
     end
 

--- a/spec/requests/api/v1/instances/languages_spec.rb
+++ b/spec/requests/api/v1/instances/languages_spec.rb
@@ -8,11 +8,8 @@ RSpec.describe 'Languages' do
       get '/api/v1/instance/languages'
     end
 
-    it 'returns http success' do
+    it 'returns http success and includes supported languages' do
       expect(response).to have_http_status(200)
-    end
-
-    it 'returns the supported languages' do
       expect(response.parsed_body.pluck(:code)).to match_array LanguagesHelper::SUPPORTED_LOCALES.keys.map(&:to_s)
     end
   end

--- a/spec/requests/api/v1/lists/accounts_spec.rb
+++ b/spec/requests/api/v1/lists/accounts_spec.rb
@@ -139,16 +139,11 @@ RSpec.describe 'Accounts' do
         list.accounts << [bob, peter]
       end
 
-      it 'removes the specified account from the list', :aggregate_failures do
+      it 'removes the specified account from the list but keeps other accounts in the list', :aggregate_failures do
         subject
 
         expect(response).to have_http_status(200)
         expect(list.accounts).to_not include(bob)
-      end
-
-      it 'does not remove any other account from the list' do
-        subject
-
         expect(list.accounts).to include(peter)
       end
 

--- a/spec/requests/api/v1/media_spec.rb
+++ b/spec/requests/api/v1/media_spec.rb
@@ -17,15 +17,10 @@ RSpec.describe 'Media' do
 
     it_behaves_like 'forbidden for wrong scope', 'read'
 
-    it 'returns http success' do
+    it 'returns http success with media information' do
       subject
 
       expect(response).to have_http_status(200)
-    end
-
-    it 'returns the media information' do
-      subject
-
       expect(response.parsed_body).to match(
         a_hash_including(
           id: media.id.to_s,

--- a/spec/requests/api/v1/mutes_spec.rb
+++ b/spec/requests/api/v1/mutes_spec.rb
@@ -18,32 +18,22 @@ RSpec.describe 'Mutes' do
 
     it_behaves_like 'forbidden for wrong scope', 'write write:mutes'
 
-    it 'returns http success' do
+    it 'returns http success with muted accounts' do
       subject
 
       expect(response).to have_http_status(200)
-    end
-
-    it 'returns the muted accounts' do
-      subject
 
       muted_accounts = mutes.map(&:target_account)
-
       expect(response.parsed_body.pluck(:id)).to match_array(muted_accounts.map { |account| account.id.to_s })
     end
 
     context 'with limit param' do
       let(:params) { { limit: 1 } }
 
-      it 'returns only the requested number of muted accounts' do
+      it 'returns only the requested number of muted accounts with pagination headers' do
         subject
 
         expect(response.parsed_body.size).to eq(params[:limit])
-      end
-
-      it 'sets the correct pagination headers', :aggregate_failures do
-        subject
-
         expect(response)
           .to include_pagination_headers(
             prev: api_v1_mutes_url(limit: params[:limit], since_id: mutes.last.id),

--- a/spec/requests/api/v1/notifications/requests_spec.rb
+++ b/spec/requests/api/v1/notifications/requests_spec.rb
@@ -39,15 +39,10 @@ RSpec.describe 'Requests' do
 
     it_behaves_like 'forbidden for wrong scope', 'read read:notifications'
 
-    it 'returns http success' do
+    it 'returns http success and creates notification permission' do
       subject
 
       expect(response).to have_http_status(200)
-    end
-
-    it 'creates notification permission' do
-      subject
-
       expect(NotificationPermission.find_by(account: notification_request.account, from_account: notification_request.from_account)).to_not be_nil
     end
 

--- a/spec/requests/api/v1/profiles_spec.rb
+++ b/spec/requests/api/v1/profiles_spec.rb
@@ -28,31 +28,14 @@ RSpec.describe 'Deleting profile images' do
         it_behaves_like 'forbidden for wrong scope', 'read'
       end
 
-      it 'returns http success' do
+      it 'returns http success and deletes the avatar, preserves the header, queues up distribution' do
         delete '/api/v1/profile/avatar', headers: headers
 
         expect(response).to have_http_status(200)
-      end
-
-      it 'deletes the avatar' do
-        delete '/api/v1/profile/avatar', headers: headers
 
         account.reload
-
         expect(account.avatar).to_not exist
-      end
-
-      it 'does not delete the header' do
-        delete '/api/v1/profile/avatar', headers: headers
-
-        account.reload
-
         expect(account.header).to exist
-      end
-
-      it 'queues up an account update distribution' do
-        delete '/api/v1/profile/avatar', headers: headers
-
         expect(ActivityPub::UpdateDistributionWorker).to have_received(:perform_async).with(account.id)
       end
     end
@@ -66,31 +49,14 @@ RSpec.describe 'Deleting profile images' do
         it_behaves_like 'forbidden for wrong scope', 'read'
       end
 
-      it 'returns http success' do
+      it 'returns http success, preserves the avatar, deletes the header, queues up distribution' do
         delete '/api/v1/profile/header', headers: headers
 
         expect(response).to have_http_status(200)
-      end
-
-      it 'does not delete the avatar' do
-        delete '/api/v1/profile/header', headers: headers
 
         account.reload
-
         expect(account.avatar).to exist
-      end
-
-      it 'deletes the header' do
-        delete '/api/v1/profile/header', headers: headers
-
-        account.reload
-
         expect(account.header).to_not exist
-      end
-
-      it 'queues up an account update distribution' do
-        delete '/api/v1/profile/header', headers: headers
-
         expect(ActivityPub::UpdateDistributionWorker).to have_received(:perform_async).with(account.id)
       end
     end

--- a/spec/requests/api/v1/statuses/bookmarks_spec.rb
+++ b/spec/requests/api/v1/statuses/bookmarks_spec.rb
@@ -18,15 +18,11 @@ RSpec.describe 'Bookmarks' do
     it_behaves_like 'forbidden for wrong scope', 'read'
 
     context 'with public status' do
-      it 'bookmarks the status successfully', :aggregate_failures do
+      it 'bookmarks the status successfully and includes updated json', :aggregate_failures do
         subject
 
         expect(response).to have_http_status(200)
         expect(user.account.bookmarked?(status)).to be true
-      end
-
-      it 'returns json with updated attributes' do
-        subject
 
         expect(response.parsed_body).to match(
           a_hash_including(id: status.id.to_s, bookmarked: true)
@@ -93,15 +89,11 @@ RSpec.describe 'Bookmarks' do
           Bookmark.find_or_create_by!(account: user.account, status: status)
         end
 
-        it 'unbookmarks the status successfully', :aggregate_failures do
+        it 'unbookmarks the status successfully and includes updated json', :aggregate_failures do
           subject
 
           expect(response).to have_http_status(200)
           expect(user.account.bookmarked?(status)).to be false
-        end
-
-        it 'returns json with updated attributes' do
-          subject
 
           expect(response.parsed_body).to match(
             a_hash_including(id: status.id.to_s, bookmarked: false)
@@ -117,15 +109,11 @@ RSpec.describe 'Bookmarks' do
           status.account.block!(user.account)
         end
 
-        it 'unbookmarks the status successfully', :aggregate_failures do
+        it 'unbookmarks the status successfully and includes updated json', :aggregate_failures do
           subject
 
           expect(response).to have_http_status(200)
           expect(user.account.bookmarked?(status)).to be false
-        end
-
-        it 'returns json with updated attributes' do
-          subject
 
           expect(response.parsed_body).to match(
             a_hash_including(id: status.id.to_s, bookmarked: false)

--- a/spec/requests/api/v1/statuses/favourites_spec.rb
+++ b/spec/requests/api/v1/statuses/favourites_spec.rb
@@ -18,15 +18,11 @@ RSpec.describe 'Favourites', :inline_jobs do
     it_behaves_like 'forbidden for wrong scope', 'read read:favourites'
 
     context 'with public status' do
-      it 'favourites the status successfully', :aggregate_failures do
+      it 'favourites the status successfully and includes updated json', :aggregate_failures do
         subject
 
         expect(response).to have_http_status(200)
         expect(user.account.favourited?(status)).to be true
-      end
-
-      it 'returns json with updated attributes' do
-        subject
 
         expect(response.parsed_body).to match(
           a_hash_including(id: status.id.to_s, favourites_count: 1, favourited: true)
@@ -84,16 +80,12 @@ RSpec.describe 'Favourites', :inline_jobs do
         FavouriteService.new.call(user.account, status)
       end
 
-      it 'unfavourites the status successfully', :aggregate_failures do
+      it 'unfavourites the status successfully and includes updated json', :aggregate_failures do
         subject
 
         expect(response).to have_http_status(200)
 
         expect(user.account.favourited?(status)).to be false
-      end
-
-      it 'returns json with updated attributes' do
-        subject
 
         expect(response.parsed_body).to match(
           a_hash_including(id: status.id.to_s, favourites_count: 0, favourited: false)
@@ -107,16 +99,12 @@ RSpec.describe 'Favourites', :inline_jobs do
         status.account.block!(user.account)
       end
 
-      it 'unfavourites the status successfully', :aggregate_failures do
+      it 'unfavourites the status successfully and includes updated json', :aggregate_failures do
         subject
 
         expect(response).to have_http_status(200)
 
         expect(user.account.favourited?(status)).to be false
-      end
-
-      it 'returns json with updated attributes' do
-        subject
 
         expect(response.parsed_body).to match(
           a_hash_including(id: status.id.to_s, favourites_count: 0, favourited: false)

--- a/spec/requests/api/v1/statuses/pins_spec.rb
+++ b/spec/requests/api/v1/statuses/pins_spec.rb
@@ -18,15 +18,11 @@ RSpec.describe 'Pins' do
     it_behaves_like 'forbidden for wrong scope', 'read read:accounts'
 
     context 'when the status is public' do
-      it 'pins the status successfully', :aggregate_failures do
+      it 'pins the status successfully and returns updated json', :aggregate_failures do
         subject
 
         expect(response).to have_http_status(200)
         expect(user.account.pinned?(status)).to be true
-      end
-
-      it 'return json with updated attributes' do
-        subject
 
         expect(response.parsed_body).to match(
           a_hash_including(id: status.id.to_s, pinned: true)
@@ -86,15 +82,11 @@ RSpec.describe 'Pins' do
         Fabricate(:status_pin, status: status, account: user.account)
       end
 
-      it 'unpins the status successfully', :aggregate_failures do
+      it 'unpins the status successfully and includes updated json', :aggregate_failures do
         subject
 
         expect(response).to have_http_status(200)
         expect(user.account.pinned?(status)).to be false
-      end
-
-      it 'return json with updated attributes' do
-        subject
 
         expect(response.parsed_body).to match(
           a_hash_including(id: status.id.to_s, pinned: false)

--- a/spec/requests/api/v1/suggestions_spec.rb
+++ b/spec/requests/api/v1/suggestions_spec.rb
@@ -23,15 +23,10 @@ RSpec.describe 'Suggestions' do
 
     it_behaves_like 'forbidden for wrong scope', 'write'
 
-    it 'returns http success' do
+    it 'returns http success with accounts' do
       subject
 
       expect(response).to have_http_status(200)
-    end
-
-    it 'returns accounts' do
-      subject
-
       expect(response.parsed_body)
         .to contain_exactly(include(id: bob.id.to_s), include(id: jeff.id.to_s))
     end
@@ -72,15 +67,10 @@ RSpec.describe 'Suggestions' do
 
     it_behaves_like 'forbidden for wrong scope', 'read'
 
-    it 'returns http success' do
+    it 'returns http success and removes suggestion' do
       subject
 
       expect(response).to have_http_status(200)
-    end
-
-    it 'removes the specified suggestion' do
-      subject
-
       expect(FollowRecommendationMute.exists?(account: user.account, target_account: jeff)).to be true
     end
 

--- a/spec/requests/api/v1/timelines/home_spec.rb
+++ b/spec/requests/api/v1/timelines/home_spec.rb
@@ -31,14 +31,10 @@ RSpec.describe 'Home', :inline_jobs do
         PostStatusService.new.call(ana, text: 'New toot from ana.')
       end
 
-      it 'returns http success' do
+      it 'returns http success and statuses of followed users' do
         subject
 
         expect(response).to have_http_status(200)
-      end
-
-      it 'returns the statuses of followed users' do
-        subject
 
         expect(response.parsed_body.pluck(:id)).to match_array(home_statuses.map { |status| status.id.to_s })
       end
@@ -46,14 +42,10 @@ RSpec.describe 'Home', :inline_jobs do
       context 'with limit param' do
         let(:params) { { limit: 1 } }
 
-        it 'returns only the requested number of statuses' do
+        it 'returns only the requested number of statuses with pagination headers', :aggregate_failures do
           subject
 
           expect(response.parsed_body.size).to eq(params[:limit])
-        end
-
-        it 'sets the correct pagination headers', :aggregate_failures do
-          subject
 
           expect(response)
             .to include_pagination_headers(

--- a/spec/requests/api/v1/timelines/link_spec.rb
+++ b/spec/requests/api/v1/timelines/link_spec.rb
@@ -123,15 +123,11 @@ RSpec.describe 'Link' do
       context 'with limit param' do
         let(:params) { { limit: 1, url: url } }
 
-        it 'returns only the requested number of statuses', :aggregate_failures do
+        it 'returns only the requested number of statuses with pagination headers', :aggregate_failures do
           subject
 
           expect(response).to have_http_status(200)
           expect(response.parsed_body.size).to eq(params[:limit])
-        end
-
-        it 'sets the correct pagination headers', :aggregate_failures do
-          subject
 
           expect(response)
             .to include_pagination_headers(


### PR DESCRIPTION
In prep for adding a truly comical amount of "is this a json response" checks (see https://github.com/mastodon/mastodon/pull/31749#issuecomment-2331821603), this is a once over on the api request specs looking for places to consolidate multiple request/response cycles.

Reduces factory creation from ~3050 to ~2900, specs run slightly faster (just over a minute to just under a minute pretty reliably for api req specs only locally).

I tried to minimize any style/formatting stuff and keep it to just combining things. Will probably do the json response additions, and then do another pass to address any truly weird readability/formatting things in the aftermath of the various changes.