### PR TITLE
Fix links for reblogs in moderation interface

### DIFF
--- a/app/views/admin/reports/_status.html.haml
+++ b/app/views/admin/reports/_status.html.haml
@@ -18,7 +18,7 @@
       - if status.application
         = status.application.name
         ·
-      = link_to ActivityPub::TagManager.instance.url_for(status), class: 'detailed-status__datetime', target: stream_link_target, rel: 'noopener noreferrer' do
+      = link_to ActivityPub::TagManager.instance.url_for(status.proper), class: 'detailed-status__datetime', target: stream_link_target, rel: 'noopener noreferrer' do
         %time.formatted{ datetime: status.created_at.iso8601, title: l(status.created_at) }= l(status.created_at)
       - if status.edited?
         ·


### PR DESCRIPTION
Reblogs are listed in `/admin/statuses` but the link is to the reblog activity itself, which is only served as an ActivityStreams object. This PR changes the user-facing link to be that of the boosted post.