### PR TITLE
Add `response.content_type` checks for JSON to `api/v1` request specs

### DIFF
--- a/spec/requests/api/oembed_spec.rb
+++ b/spec/requests/api/oembed_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe 'API OEmbed' do
 
         expect(response)
           .to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.headers['Cache-Control'])
           .to include('private, no-store')
       end
@@ -27,6 +29,8 @@ RSpec.describe 'API OEmbed' do
 
         expect(response)
           .to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end

--- a/spec/requests/api/v1/accounts/credentials_spec.rb
+++ b/spec/requests/api/v1/accounts/credentials_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe 'credentials API' do
 
       expect(response)
         .to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body).to include({
         source: hash_including({
           discoverable: false,
@@ -36,6 +38,8 @@ RSpec.describe 'credentials API' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
 
         expect(response.parsed_body).to include({
           locked: true,
@@ -75,6 +79,8 @@ RSpec.describe 'credentials API' do
       it 'returns http success' do
         subject
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -84,6 +90,8 @@ RSpec.describe 'credentials API' do
       it 'returns http unprocessable entity' do
         subject
         expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -92,6 +100,8 @@ RSpec.describe 'credentials API' do
 
       expect(response)
         .to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
 
       expect(response.parsed_body).to include({
         source: hash_including({

--- a/spec/requests/api/v1/accounts/familiar_followers_spec.rb
+++ b/spec/requests/api/v1/accounts/familiar_followers_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe 'Accounts Familiar Followers API' do
       get '/api/v1/accounts/familiar_followers', params: { account_id: account.id, limit: 2 }, headers: headers
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
     end
 
     context 'when there are duplicate account IDs in the params' do

--- a/spec/requests/api/v1/accounts/featured_tags_spec.rb
+++ b/spec/requests/api/v1/accounts/featured_tags_spec.rb
@@ -23,6 +23,8 @@ RSpec.describe 'account featured tags API' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body).to contain_exactly(a_hash_including({
         name: 'bar',
         url: "https://cb6e6126.ngrok.io/@#{account.username}/tagged/bar",
@@ -37,6 +39,8 @@ RSpec.describe 'account featured tags API' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body).to contain_exactly(a_hash_including({
           name: 'bar',
           url: "https://cb6e6126.ngrok.io/@#{account.pretty_acct}/tagged/bar",

--- a/spec/requests/api/v1/accounts/follower_accounts_spec.rb
+++ b/spec/requests/api/v1/accounts/follower_accounts_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe 'API V1 Accounts FollowerAccounts' do
       get "/api/v1/accounts/#{account.id}/followers", params: { limit: 2 }, headers: headers
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body.size).to eq 2
       expect([response.parsed_body[0][:id], response.parsed_body[1][:id]]).to contain_exactly(alice.id.to_s, bob.id.to_s)
     end
@@ -30,6 +32,8 @@ RSpec.describe 'API V1 Accounts FollowerAccounts' do
       get "/api/v1/accounts/#{account.id}/followers", params: { limit: 2 }, headers: headers
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body.size).to eq 1
       expect(response.parsed_body[0][:id]).to eq alice.id.to_s
     end

--- a/spec/requests/api/v1/accounts/following_accounts_spec.rb
+++ b/spec/requests/api/v1/accounts/following_accounts_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe 'API V1 Accounts FollowingAccounts' do
       get "/api/v1/accounts/#{account.id}/following", params: { limit: 2 }, headers: headers
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body.size).to eq 2
       expect([response.parsed_body[0][:id], response.parsed_body[1][:id]]).to contain_exactly(alice.id.to_s, bob.id.to_s)
     end
@@ -30,6 +32,8 @@ RSpec.describe 'API V1 Accounts FollowingAccounts' do
       get "/api/v1/accounts/#{account.id}/following", params: { limit: 2 }, headers: headers
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body.size).to eq 1
       expect(response.parsed_body[0][:id]).to eq alice.id.to_s
     end

--- a/spec/requests/api/v1/accounts/identity_proofs_spec.rb
+++ b/spec/requests/api/v1/accounts/identity_proofs_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe 'Accounts Identity Proofs API' do
       get "/api/v1/accounts/#{account.id}/identity_proofs", params: { limit: 2 }, headers: headers
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
     end
   end
 end

--- a/spec/requests/api/v1/accounts/lists_spec.rb
+++ b/spec/requests/api/v1/accounts/lists_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe 'Accounts Lists API' do
       get "/api/v1/accounts/#{account.id}/lists", headers: headers
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
     end
   end
 end

--- a/spec/requests/api/v1/accounts/lookup_spec.rb
+++ b/spec/requests/api/v1/accounts/lookup_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe 'Accounts Lookup API' do
       get '/api/v1/accounts/lookup', params: { account_id: account.id, acct: account.acct }, headers: headers
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
     end
   end
 end

--- a/spec/requests/api/v1/accounts/notes_spec.rb
+++ b/spec/requests/api/v1/accounts/notes_spec.rb
@@ -22,6 +22,8 @@ RSpec.describe 'Accounts Notes API' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(AccountNote.find_by(account_id: user.account.id, target_account_id: account.id).comment).to eq comment
       end
     end
@@ -33,6 +35,8 @@ RSpec.describe 'Accounts Notes API' do
         subject
 
         expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(AccountNote.where(account_id: user.account.id, target_account_id: account.id)).to_not exist
       end
     end

--- a/spec/requests/api/v1/accounts/pins_spec.rb
+++ b/spec/requests/api/v1/accounts/pins_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe 'Accounts Pins API' do
         subject
       end.to change { AccountPin.where(account: user.account, target_account: kevin.account).count }.by(1)
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
     end
   end
 
@@ -36,6 +38,8 @@ RSpec.describe 'Accounts Pins API' do
         subject
       end.to change { AccountPin.where(account: user.account, target_account: kevin.account).count }.by(-1)
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
     end
   end
 end

--- a/spec/requests/api/v1/accounts/relationships_spec.rb
+++ b/spec/requests/api/v1/accounts/relationships_spec.rb
@@ -29,6 +29,8 @@ RSpec.describe 'GET /api/v1/accounts/relationships' do
 
       expect(response)
         .to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body)
         .to be_an(Enumerable)
         .and contain_exactly(
@@ -50,6 +52,8 @@ RSpec.describe 'GET /api/v1/accounts/relationships' do
 
           expect(response)
             .to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
           expect(response.parsed_body)
             .to be_an(Enumerable)
             .and have_attributes(
@@ -70,6 +74,8 @@ RSpec.describe 'GET /api/v1/accounts/relationships' do
 
           expect(response)
             .to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
           expect(response.parsed_body)
             .to be_an(Enumerable)
             .and have_attributes(
@@ -149,6 +155,8 @@ RSpec.describe 'GET /api/v1/accounts/relationships' do
 
       expect(response)
         .to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
 
       expect(response.parsed_body)
         .to be_an(Enumerable)
@@ -171,6 +179,8 @@ RSpec.describe 'GET /api/v1/accounts/relationships' do
 
       expect(response)
         .to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
 
       expect(response.parsed_body)
         .to be_an(Enumerable)

--- a/spec/requests/api/v1/accounts/search_spec.rb
+++ b/spec/requests/api/v1/accounts/search_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe 'Accounts Search API' do
       get '/api/v1/accounts/search', params: { q: 'query' }, headers: headers
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
     end
   end
 end

--- a/spec/requests/api/v1/accounts/statuses_spec.rb
+++ b/spec/requests/api/v1/accounts/statuses_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe 'API V1 Accounts Statuses' do
           prev: api_v1_account_statuses_url(limit: 1, min_id: status.id),
           next: api_v1_account_statuses_url(limit: 1, max_id: status.id)
         )
+      expect(response.content_type)
+        .to start_with('application/json')
     end
 
     context 'with only media' do
@@ -26,6 +28,8 @@ RSpec.describe 'API V1 Accounts Statuses' do
         get "/api/v1/accounts/#{user.account.id}/statuses", params: { only_media: true }, headers: headers
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -41,6 +45,8 @@ RSpec.describe 'API V1 Accounts Statuses' do
       it 'returns posts along with self replies', :aggregate_failures do
         expect(response)
           .to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body)
           .to have_attributes(size: 2)
           .and contain_exactly(
@@ -61,6 +67,8 @@ RSpec.describe 'API V1 Accounts Statuses' do
         expect(response)
           .to have_http_status(200)
           .and include_pagination_headers(prev: api_v1_account_statuses_url(pinned: true, min_id: Status.first.id))
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -79,6 +87,8 @@ RSpec.describe 'API V1 Accounts Statuses' do
             prev: api_v1_account_statuses_url(pinned: true, min_id: Status.first.id),
             next: api_v1_account_statuses_url(pinned: true, max_id: Status.first.id)
           )
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -96,6 +106,8 @@ RSpec.describe 'API V1 Accounts Statuses' do
         get "/api/v1/accounts/#{account.id}/statuses", params: { pinned: true }, headers: headers
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
 
       context 'when user does not follow account' do
@@ -122,6 +134,8 @@ RSpec.describe 'API V1 Accounts Statuses' do
               a_hash_including(id: status.id.to_s),
               a_hash_including(id: private_status.id.to_s)
             )
+          expect(response.content_type)
+            .to start_with('application/json')
         end
       end
     end

--- a/spec/requests/api/v1/accounts_spec.rb
+++ b/spec/requests/api/v1/accounts_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe '/api/v1/accounts' do
       get '/api/v1/accounts', headers: headers, params: { id: [account.id, other_account.id, 123_123] }
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body).to contain_exactly(
         hash_including(id: account.id.to_s),
         hash_including(id: other_account.id.to_s)
@@ -32,6 +34,8 @@ RSpec.describe '/api/v1/accounts' do
         get "/api/v1/accounts/#{account.id}"
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body[:id]).to eq(account.id.to_s)
       end
     end
@@ -41,6 +45,8 @@ RSpec.describe '/api/v1/accounts' do
         get '/api/v1/accounts/1'
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body[:error]).to eq('Record not found')
       end
     end
@@ -57,6 +63,8 @@ RSpec.describe '/api/v1/accounts' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body[:id]).to eq(account.id.to_s)
       end
 
@@ -80,6 +88,8 @@ RSpec.describe '/api/v1/accounts' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body[:access_token]).to_not be_blank
 
         user = User.find_by(email: 'hello@world.tld')
@@ -93,6 +103,8 @@ RSpec.describe '/api/v1/accounts' do
         subject
 
         expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -113,6 +125,8 @@ RSpec.describe '/api/v1/accounts' do
           subject
 
           expect(response).to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
 
           expect(response.parsed_body)
             .to include(
@@ -133,6 +147,8 @@ RSpec.describe '/api/v1/accounts' do
           subject
 
           expect(response).to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
 
           expect(response.parsed_body)
             .to include(
@@ -203,6 +219,8 @@ RSpec.describe '/api/v1/accounts' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(user.account.following?(other_account)).to be false
     end
 
@@ -225,6 +243,8 @@ RSpec.describe '/api/v1/accounts' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(user.account.followed_by?(other_account)).to be false
     end
 
@@ -247,6 +267,8 @@ RSpec.describe '/api/v1/accounts' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(user.account.following?(other_account)).to be false
       expect(user.account.blocking?(other_account)).to be true
     end
@@ -270,6 +292,8 @@ RSpec.describe '/api/v1/accounts' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(user.account.blocking?(other_account)).to be false
     end
 
@@ -292,6 +316,8 @@ RSpec.describe '/api/v1/accounts' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(user.account.following?(other_account)).to be true
       expect(user.account.muting?(other_account)).to be true
       expect(user.account.muting_notifications?(other_account)).to be true
@@ -316,6 +342,8 @@ RSpec.describe '/api/v1/accounts' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(user.account.following?(other_account)).to be true
       expect(user.account.muting?(other_account)).to be true
       expect(user.account.muting_notifications?(other_account)).to be false
@@ -340,6 +368,8 @@ RSpec.describe '/api/v1/accounts' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(user.account.following?(other_account)).to be true
       expect(user.account.muting?(other_account)).to be true
       expect(user.account.muting_notifications?(other_account)).to be true
@@ -364,6 +394,8 @@ RSpec.describe '/api/v1/accounts' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(user.account.muting?(other_account)).to be false
     end
 

--- a/spec/requests/api/v1/admin/account_actions_spec.rb
+++ b/spec/requests/api/v1/admin/account_actions_spec.rb
@@ -61,6 +61,8 @@ RSpec.describe 'Account actions' do
       it 'disables the target account' do
         expect { subject }.to change { target_account.reload.user_disabled? }.from(false).to(true)
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -75,6 +77,8 @@ RSpec.describe 'Account actions' do
       it 'marks the target account as sensitive' do
         expect { subject }.to change { target_account.reload.sensitized? }.from(false).to(true)
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -89,6 +93,8 @@ RSpec.describe 'Account actions' do
       it 'marks the target account as silenced' do
         expect { subject }.to change { target_account.reload.silenced? }.from(false).to(true)
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -103,6 +109,8 @@ RSpec.describe 'Account actions' do
       it 'marks the target account as suspended' do
         expect { subject }.to change { target_account.reload.suspended? }.from(false).to(true)
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -115,6 +123,8 @@ RSpec.describe 'Account actions' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -125,6 +135,8 @@ RSpec.describe 'Account actions' do
         subject
 
         expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -135,6 +147,8 @@ RSpec.describe 'Account actions' do
         subject
 
         expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end

--- a/spec/requests/api/v1/admin/accounts_spec.rb
+++ b/spec/requests/api/v1/admin/accounts_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe 'Accounts' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body.pluck(:id)).to match_array(expected_results.map { |a| a.id.to_s })
       end
     end
@@ -93,6 +95,8 @@ RSpec.describe 'Accounts' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body.size).to eq(params[:limit])
       end
     end
@@ -112,6 +116,8 @@ RSpec.describe 'Accounts' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body).to match(
         a_hash_including(id: account.id.to_s, username: account.username, email: account.user.email)
       )
@@ -122,6 +128,8 @@ RSpec.describe 'Accounts' do
         get '/api/v1/admin/accounts/-1', headers: headers
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -145,6 +153,8 @@ RSpec.describe 'Accounts' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(account.reload.user_approved?).to be(true)
       end
 
@@ -166,6 +176,8 @@ RSpec.describe 'Accounts' do
         subject
 
         expect(response).to have_http_status(403)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -174,6 +186,8 @@ RSpec.describe 'Accounts' do
         post '/api/v1/admin/accounts/-1/approve', headers: headers
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -197,6 +211,8 @@ RSpec.describe 'Accounts' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(User.where(id: account.user.id)).to_not exist
 
         expect(latest_admin_action_log)
@@ -214,6 +230,8 @@ RSpec.describe 'Accounts' do
         subject
 
         expect(response).to have_http_status(403)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -222,6 +240,8 @@ RSpec.describe 'Accounts' do
         post '/api/v1/admin/accounts/-1/reject', headers: headers
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -244,6 +264,8 @@ RSpec.describe 'Accounts' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(account.reload.user_disabled?).to be false
     end
 
@@ -252,6 +274,8 @@ RSpec.describe 'Accounts' do
         post '/api/v1/admin/accounts/-1/enable', headers: headers
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -275,6 +299,8 @@ RSpec.describe 'Accounts' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(account.reload.suspended?).to be false
       end
     end
@@ -284,6 +310,8 @@ RSpec.describe 'Accounts' do
         subject
 
         expect(response).to have_http_status(403)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -292,6 +320,8 @@ RSpec.describe 'Accounts' do
         post '/api/v1/admin/accounts/-1/unsuspend', headers: headers
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -314,6 +344,8 @@ RSpec.describe 'Accounts' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(account.reload.sensitized?).to be false
     end
 
@@ -322,6 +354,8 @@ RSpec.describe 'Accounts' do
         post '/api/v1/admin/accounts/-1/unsensitive', headers: headers
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -344,6 +378,8 @@ RSpec.describe 'Accounts' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(account.reload.silenced?).to be false
     end
 
@@ -352,6 +388,8 @@ RSpec.describe 'Accounts' do
         post '/api/v1/admin/accounts/-1/unsilence', headers: headers
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -376,6 +414,8 @@ RSpec.describe 'Accounts' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(Admin::AccountDeletionWorker).to have_received(:perform_async).with(account.id).once
       end
     end
@@ -393,6 +433,8 @@ RSpec.describe 'Accounts' do
         delete '/api/v1/admin/accounts/-1', headers: headers
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end

--- a/spec/requests/api/v1/admin/canonical_email_blocks_spec.rb
+++ b/spec/requests/api/v1/admin/canonical_email_blocks_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe 'Canonical Email Blocks' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
     end
 
     context 'when there is no canonical email block' do
@@ -96,6 +98,8 @@ RSpec.describe 'Canonical Email Blocks' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body)
           .to include(
             id: eq(canonical_email_block.id.to_s),
@@ -109,6 +113,8 @@ RSpec.describe 'Canonical Email Blocks' do
         get '/api/v1/admin/canonical_email_blocks/-1', headers: headers
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -131,6 +137,8 @@ RSpec.describe 'Canonical Email Blocks' do
         subject
 
         expect(response).to have_http_status(400)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -142,6 +150,8 @@ RSpec.describe 'Canonical Email Blocks' do
           subject
 
           expect(response).to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
           expect(response.parsed_body.first[:canonical_email_hash]).to eq(canonical_email_block.canonical_email_hash)
         end
       end
@@ -151,6 +161,8 @@ RSpec.describe 'Canonical Email Blocks' do
           subject
 
           expect(response).to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
           expect(response.parsed_body).to be_empty
         end
       end
@@ -173,6 +185,8 @@ RSpec.describe 'Canonical Email Blocks' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body[:canonical_email_hash]).to eq(canonical_email_block.canonical_email_hash)
     end
 
@@ -183,6 +197,8 @@ RSpec.describe 'Canonical Email Blocks' do
         subject
 
         expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -193,6 +209,8 @@ RSpec.describe 'Canonical Email Blocks' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body[:canonical_email_hash]).to eq(params[:canonical_email_hash])
       end
     end
@@ -204,6 +222,8 @@ RSpec.describe 'Canonical Email Blocks' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body[:canonical_email_hash]).to eq(canonical_email_block.canonical_email_hash)
       end
     end
@@ -217,6 +237,8 @@ RSpec.describe 'Canonical Email Blocks' do
         subject
 
         expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -237,6 +259,8 @@ RSpec.describe 'Canonical Email Blocks' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(CanonicalEmailBlock.find_by(id: canonical_email_block.id)).to be_nil
     end
 
@@ -245,6 +269,8 @@ RSpec.describe 'Canonical Email Blocks' do
         delete '/api/v1/admin/canonical_email_blocks/0', headers: headers
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end

--- a/spec/requests/api/v1/admin/dimensions_spec.rb
+++ b/spec/requests/api/v1/admin/dimensions_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe 'Admin Dimensions' do
 
         expect(response)
           .to have_http_status(403)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -26,6 +28,9 @@ RSpec.describe 'Admin Dimensions' do
 
         expect(response)
           .to have_http_status(200)
+
+        expect(response.content_type)
+          .to start_with('application/json')
 
         expect(response.parsed_body)
           .to be_an(Array)

--- a/spec/requests/api/v1/admin/domain_allows_spec.rb
+++ b/spec/requests/api/v1/admin/domain_allows_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe 'Domain Allows' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
     end
 
     context 'when there is no allowed domains' do
@@ -79,6 +81,8 @@ RSpec.describe 'Domain Allows' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body[:domain]).to eq domain_allow.domain
     end
 
@@ -87,6 +91,8 @@ RSpec.describe 'Domain Allows' do
         get '/api/v1/admin/domain_allows/-1', headers: headers
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -107,6 +113,8 @@ RSpec.describe 'Domain Allows' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body[:domain]).to eq 'foo.bar.com'
         expect(DomainAllow.find_by(domain: 'foo.bar.com')).to be_present
       end
@@ -119,6 +127,8 @@ RSpec.describe 'Domain Allows' do
         subject
 
         expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -129,6 +139,8 @@ RSpec.describe 'Domain Allows' do
         subject
 
         expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -160,6 +172,8 @@ RSpec.describe 'Domain Allows' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(DomainAllow.find_by(id: domain_allow.id)).to be_nil
     end
 
@@ -168,6 +182,8 @@ RSpec.describe 'Domain Allows' do
         delete '/api/v1/admin/domain_allows/-1', headers: headers
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end

--- a/spec/requests/api/v1/admin/domain_blocks_spec.rb
+++ b/spec/requests/api/v1/admin/domain_blocks_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe 'Domain Blocks' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
     end
 
     context 'when there are no domain blocks' do
@@ -94,6 +96,8 @@ RSpec.describe 'Domain Blocks' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body).to match(
         id: domain_block.id.to_s,
         domain: domain_block.domain,
@@ -113,6 +117,8 @@ RSpec.describe 'Domain Blocks' do
         get '/api/v1/admin/domain_blocks/-1', headers: headers
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -132,6 +138,8 @@ RSpec.describe 'Domain Blocks' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body).to match a_hash_including(
         {
           domain: 'foo.bar.com',
@@ -153,6 +161,8 @@ RSpec.describe 'Domain Blocks' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body).to match a_hash_including(
           {
             domain: 'foo.bar.com',
@@ -173,6 +183,8 @@ RSpec.describe 'Domain Blocks' do
         subject
 
         expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body[:existing_domain_block][:domain]).to eq('foo.bar.com')
       end
     end
@@ -186,6 +198,8 @@ RSpec.describe 'Domain Blocks' do
         subject
 
         expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body[:existing_domain_block][:domain]).to eq('bar.com')
       end
     end
@@ -197,6 +211,8 @@ RSpec.describe 'Domain Blocks' do
         subject
 
         expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -217,6 +233,8 @@ RSpec.describe 'Domain Blocks' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body).to match a_hash_including(
         {
           id: domain_block.id.to_s,
@@ -236,6 +254,8 @@ RSpec.describe 'Domain Blocks' do
         put '/api/v1/admin/domain_blocks/-1', headers: headers
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -255,6 +275,8 @@ RSpec.describe 'Domain Blocks' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(DomainBlock.find_by(id: domain_block.id)).to be_nil
     end
 
@@ -263,6 +285,8 @@ RSpec.describe 'Domain Blocks' do
         delete '/api/v1/admin/domain_blocks/-1', headers: headers
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end

--- a/spec/requests/api/v1/admin/email_domain_blocks_spec.rb
+++ b/spec/requests/api/v1/admin/email_domain_blocks_spec.rb
@@ -25,6 +25,8 @@ RSpec.describe 'Email Domain Blocks' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
     end
 
     context 'when there is no email domain block' do
@@ -97,6 +99,8 @@ RSpec.describe 'Email Domain Blocks' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body[:domain]).to eq(email_domain_block.domain)
       end
     end
@@ -106,6 +110,8 @@ RSpec.describe 'Email Domain Blocks' do
         get '/api/v1/admin/email_domain_blocks/-1', headers: headers
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -125,6 +131,8 @@ RSpec.describe 'Email Domain Blocks' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body[:domain]).to eq(params[:domain])
     end
 
@@ -135,6 +143,8 @@ RSpec.describe 'Email Domain Blocks' do
         subject
 
         expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -145,6 +155,8 @@ RSpec.describe 'Email Domain Blocks' do
         subject
 
         expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -157,6 +169,8 @@ RSpec.describe 'Email Domain Blocks' do
         subject
 
         expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -176,6 +190,8 @@ RSpec.describe 'Email Domain Blocks' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body).to be_empty
       expect(EmailDomainBlock.find_by(id: email_domain_block.id)).to be_nil
     end
@@ -185,6 +201,8 @@ RSpec.describe 'Email Domain Blocks' do
         delete '/api/v1/admin/email_domain_blocks/-1', headers: headers
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end

--- a/spec/requests/api/v1/admin/ip_blocks_spec.rb
+++ b/spec/requests/api/v1/admin/ip_blocks_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe 'IP Blocks' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
     end
 
     context 'when there is no ip block' do
@@ -88,6 +90,8 @@ RSpec.describe 'IP Blocks' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
 
       expect(response.parsed_body)
         .to include(
@@ -101,6 +105,8 @@ RSpec.describe 'IP Blocks' do
         get '/api/v1/admin/ip_blocks/-1', headers: headers
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -120,6 +126,8 @@ RSpec.describe 'IP Blocks' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body)
         .to include(
           ip: eq("#{params[:ip]}/32"),
@@ -135,6 +143,8 @@ RSpec.describe 'IP Blocks' do
         subject
 
         expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -145,6 +155,8 @@ RSpec.describe 'IP Blocks' do
         subject
 
         expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -157,6 +169,8 @@ RSpec.describe 'IP Blocks' do
         subject
 
         expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -167,6 +181,8 @@ RSpec.describe 'IP Blocks' do
         subject
 
         expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -185,6 +201,8 @@ RSpec.describe 'IP Blocks' do
         .and change_comment_value
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body).to match(hash_including({
         ip: "#{ip_block.ip}/#{ip_block.ip.prefix}",
         severity: 'sign_up_requires_approval',
@@ -205,6 +223,8 @@ RSpec.describe 'IP Blocks' do
         put '/api/v1/admin/ip_blocks/-1', headers: headers, params: params
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -220,6 +240,8 @@ RSpec.describe 'IP Blocks' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body).to be_empty
       expect(IpBlock.find_by(id: ip_block.id)).to be_nil
     end
@@ -229,6 +251,8 @@ RSpec.describe 'IP Blocks' do
         delete '/api/v1/admin/ip_blocks/-1', headers: headers
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end

--- a/spec/requests/api/v1/admin/measures_spec.rb
+++ b/spec/requests/api/v1/admin/measures_spec.rb
@@ -32,6 +32,8 @@ RSpec.describe 'Admin Measures' do
 
         expect(response)
           .to have_http_status(403)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -43,6 +45,8 @@ RSpec.describe 'Admin Measures' do
 
         expect(response)
           .to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
 
         expect(response.parsed_body)
           .to be_an(Array)

--- a/spec/requests/api/v1/admin/reports_spec.rb
+++ b/spec/requests/api/v1/admin/reports_spec.rb
@@ -23,6 +23,8 @@ RSpec.describe 'Reports' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
     end
 
     context 'when there are no reports' do
@@ -126,6 +128,8 @@ RSpec.describe 'Reports' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body).to include(
         {
           id: report.id.to_s,
@@ -156,6 +160,8 @@ RSpec.describe 'Reports' do
         .and create_an_action_log
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
 
       report.reload
 
@@ -190,6 +196,8 @@ RSpec.describe 'Reports' do
         .to change { report.reload.unresolved? }.from(true).to(false)
         .and create_an_action_log
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
     end
   end
 
@@ -208,6 +216,8 @@ RSpec.describe 'Reports' do
         .to change { report.reload.unresolved? }.from(false).to(true)
         .and create_an_action_log
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
     end
   end
 
@@ -226,6 +236,8 @@ RSpec.describe 'Reports' do
         .to change { report.reload.assigned_account_id }.from(nil).to(user.account.id)
         .and create_an_action_log
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
     end
   end
 
@@ -244,6 +256,8 @@ RSpec.describe 'Reports' do
         .to change { report.reload.assigned_account_id }.from(user.account.id).to(nil)
         .and create_an_action_log
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
     end
   end
 

--- a/spec/requests/api/v1/admin/retention_spec.rb
+++ b/spec/requests/api/v1/admin/retention_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe 'Admin Retention' do
 
         expect(response)
           .to have_http_status(403)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -26,6 +28,8 @@ RSpec.describe 'Admin Retention' do
 
         expect(response)
           .to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
 
         expect(response.parsed_body)
           .to be_an(Array)

--- a/spec/requests/api/v1/admin/tags_spec.rb
+++ b/spec/requests/api/v1/admin/tags_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe 'Tags' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
     end
 
     context 'when there are no tags' do
@@ -77,6 +79,8 @@ RSpec.describe 'Tags' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
 
       expect(response.parsed_body[:id].to_i).to eq(tag.id)
       expect(response.parsed_body[:name]).to eq(tag.name)
@@ -87,6 +91,8 @@ RSpec.describe 'Tags' do
         get '/api/v1/admin/tags/-1', headers: headers
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -107,6 +113,8 @@ RSpec.describe 'Tags' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
 
       expect(response.parsed_body[:id].to_i).to eq(tag.id)
       expect(response.parsed_body[:name]).to eq(tag.name.upcase)
@@ -119,6 +127,8 @@ RSpec.describe 'Tags' do
         subject
 
         expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -127,6 +137,8 @@ RSpec.describe 'Tags' do
         get '/api/v1/admin/tags/-1', headers: headers
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end

--- a/spec/requests/api/v1/admin/trends/links/links_spec.rb
+++ b/spec/requests/api/v1/admin/trends/links/links_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe 'Links' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
     end
   end
 
@@ -36,6 +38,8 @@ RSpec.describe 'Links' do
         .to change_link_trendable_to_true
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expects_correct_link_data
     end
 
@@ -60,6 +64,8 @@ RSpec.describe 'Links' do
         post '/api/v1/admin/trends/links/-1/approve', headers: headers
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -70,6 +76,8 @@ RSpec.describe 'Links' do
         subject
 
         expect(response).to have_http_status(403)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -89,6 +97,8 @@ RSpec.describe 'Links' do
         .to_not change_link_trendable
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
     end
 
     def change_link_trendable
@@ -114,6 +124,8 @@ RSpec.describe 'Links' do
         post '/api/v1/admin/trends/links/-1/reject', headers: headers
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -124,6 +136,8 @@ RSpec.describe 'Links' do
         subject
 
         expect(response).to have_http_status(403)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end

--- a/spec/requests/api/v1/admin/trends/links/preview_card_providers_spec.rb
+++ b/spec/requests/api/v1/admin/trends/links/preview_card_providers_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe 'API V1 Admin Trends Links Preview Card Providers' do
       get '/api/v1/admin/trends/links/publishers', params: { account_id: account.id, limit: 2 }, headers: headers
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
     end
   end
 
@@ -29,6 +31,8 @@ RSpec.describe 'API V1 Admin Trends Links Preview Card Providers' do
 
     it 'returns http success' do
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
     end
   end
 
@@ -42,6 +46,8 @@ RSpec.describe 'API V1 Admin Trends Links Preview Card Providers' do
 
     it 'returns http success' do
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
     end
   end
 end

--- a/spec/requests/api/v1/admin/trends/statuses_spec.rb
+++ b/spec/requests/api/v1/admin/trends/statuses_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe 'API V1 Admin Trends Statuses' do
       get '/api/v1/admin/trends/statuses', params: { account_id: account.id, limit: 2 }, headers: headers
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
     end
   end
 
@@ -29,6 +31,8 @@ RSpec.describe 'API V1 Admin Trends Statuses' do
 
     it 'returns http success' do
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
     end
   end
 
@@ -42,6 +46,8 @@ RSpec.describe 'API V1 Admin Trends Statuses' do
 
     it 'returns http success' do
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
     end
   end
 end

--- a/spec/requests/api/v1/admin/trends/tags_spec.rb
+++ b/spec/requests/api/v1/admin/trends/tags_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe 'API V1 Admin Trends Tags' do
       get '/api/v1/admin/trends/tags', params: { account_id: account.id, limit: 2 }, headers: headers
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
     end
   end
 
@@ -29,6 +31,8 @@ RSpec.describe 'API V1 Admin Trends Tags' do
 
     it 'returns http success' do
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
     end
   end
 
@@ -42,6 +46,8 @@ RSpec.describe 'API V1 Admin Trends Tags' do
 
     it 'returns http success' do
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
     end
   end
 end

--- a/spec/requests/api/v1/announcements/reactions_spec.rb
+++ b/spec/requests/api/v1/announcements/reactions_spec.rb
@@ -15,7 +15,9 @@ RSpec.describe 'API V1 Announcements Reactions' do
       it 'returns http unauthorized' do
         put "/api/v1/announcements/#{announcement.id}/reactions/#{escaped_emoji}"
 
-        expect(response).to have_http_status 401
+        expect(response).to have_http_status(401)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -26,6 +28,8 @@ RSpec.describe 'API V1 Announcements Reactions' do
 
       it 'creates reaction', :aggregate_failures do
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(announcement.announcement_reactions.find_by(name: '😂', account: user.account)).to_not be_nil
       end
     end
@@ -39,7 +43,9 @@ RSpec.describe 'API V1 Announcements Reactions' do
     context 'without token' do
       it 'returns http unauthorized' do
         delete "/api/v1/announcements/#{announcement.id}/reactions/#{escaped_emoji}"
-        expect(response).to have_http_status 401
+        expect(response).to have_http_status(401)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -50,6 +56,8 @@ RSpec.describe 'API V1 Announcements Reactions' do
 
       it 'creates reaction', :aggregate_failures do
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(announcement.announcement_reactions.find_by(name: '😂', account: user.account)).to be_nil
       end
     end

--- a/spec/requests/api/v1/announcements_spec.rb
+++ b/spec/requests/api/v1/announcements_spec.rb
@@ -15,7 +15,9 @@ RSpec.describe 'API V1 Announcements' do
       it 'returns http unprocessable entity' do
         get '/api/v1/announcements'
 
-        expect(response).to have_http_status 422
+        expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -26,6 +28,8 @@ RSpec.describe 'API V1 Announcements' do
 
       it 'returns http success' do
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -35,7 +39,9 @@ RSpec.describe 'API V1 Announcements' do
       it 'returns http unauthorized' do
         post "/api/v1/announcements/#{announcement.id}/dismiss"
 
-        expect(response).to have_http_status 401
+        expect(response).to have_http_status(401)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -48,6 +54,8 @@ RSpec.describe 'API V1 Announcements' do
 
       it 'dismisses announcement', :aggregate_failures do
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(announcement.announcement_mutes.find_by(account: user.account)).to_not be_nil
       end
     end

--- a/spec/requests/api/v1/annual_reports_spec.rb
+++ b/spec/requests/api/v1/annual_reports_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe 'API V1 Annual Reports' do
 
         expect(response)
           .to have_http_status(401)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -33,6 +35,8 @@ RSpec.describe 'API V1 Annual Reports' do
 
         expect(response)
           .to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
 
         expect(response.parsed_body)
           .to be_present
@@ -51,6 +55,8 @@ RSpec.describe 'API V1 Annual Reports' do
           .to change { annual_report.reload.viewed? }.to(true)
         expect(response)
           .to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end

--- a/spec/requests/api/v1/apps/credentials_spec.rb
+++ b/spec/requests/api/v1/apps/credentials_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe 'Credentials' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
 
         expect(response.parsed_body).to match(
           a_hash_including(
@@ -36,6 +38,8 @@ RSpec.describe 'Credentials' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
 
         expect(response.parsed_body[:client_id]).to_not be_present
         expect(response.parsed_body[:client_secret]).to_not be_present
@@ -51,6 +55,8 @@ RSpec.describe 'Credentials' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
 
         expect(response.parsed_body).to match(
           a_hash_including(
@@ -74,6 +80,8 @@ RSpec.describe 'Credentials' do
         subject
 
         expect(response).to have_http_status(401)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -86,6 +94,8 @@ RSpec.describe 'Credentials' do
         subject
 
         expect(response).to have_http_status(401)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
 
       it 'returns the error in the json response' do
@@ -108,6 +118,8 @@ RSpec.describe 'Credentials' do
         subject
 
         expect(response).to have_http_status(401)
+        expect(response.content_type)
+          .to start_with('application/json')
 
         expect(response.parsed_body).to match(
           a_hash_including(

--- a/spec/requests/api/v1/apps_spec.rb
+++ b/spec/requests/api/v1/apps_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe 'Apps' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
 
         app = Doorkeeper::Application.find_by(name: client_name)
 
@@ -59,6 +61,8 @@ RSpec.describe 'Apps' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(Doorkeeper::Application.find_by(name: client_name)).to be_present
 
         expect(response.parsed_body)
@@ -76,6 +80,8 @@ RSpec.describe 'Apps' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
 
         app = Doorkeeper::Application.find_by(name: client_name)
 
@@ -96,6 +102,8 @@ RSpec.describe 'Apps' do
         subject
 
         expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -106,6 +114,8 @@ RSpec.describe 'Apps' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(Doorkeeper::Application.find_by(name: client_name).scopes.to_s).to eq 'read'
       end
     end
@@ -117,6 +127,8 @@ RSpec.describe 'Apps' do
         subject
 
         expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -127,6 +139,8 @@ RSpec.describe 'Apps' do
         subject
 
         expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -137,6 +151,8 @@ RSpec.describe 'Apps' do
         subject
 
         expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -148,6 +164,8 @@ RSpec.describe 'Apps' do
         subject
 
         expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -158,6 +176,8 @@ RSpec.describe 'Apps' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
 
         app = Doorkeeper::Application.find_by(name: client_name)
 
@@ -180,6 +200,8 @@ RSpec.describe 'Apps' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
 
         app = Doorkeeper::Application.find_by(name: client_name)
 
@@ -202,6 +224,8 @@ RSpec.describe 'Apps' do
         subject
 
         expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -212,6 +236,8 @@ RSpec.describe 'Apps' do
         subject
 
         expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -222,6 +248,8 @@ RSpec.describe 'Apps' do
         subject
 
         expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -232,6 +260,8 @@ RSpec.describe 'Apps' do
         subject
 
         expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -242,6 +272,8 @@ RSpec.describe 'Apps' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
 
         app = Doorkeeper::Application.find_by(name: client_name)
 

--- a/spec/requests/api/v1/blocks_spec.rb
+++ b/spec/requests/api/v1/blocks_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe 'Blocks' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body).to match_array(expected_response)
     end
 
@@ -36,6 +38,8 @@ RSpec.describe 'Blocks' do
         subject
 
         expect(response.parsed_body.size).to eq(params[:limit])
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response)
           .to include_pagination_headers(
             prev: api_v1_blocks_url(limit: params[:limit], since_id: blocks.last.id),

--- a/spec/requests/api/v1/bookmarks_spec.rb
+++ b/spec/requests/api/v1/bookmarks_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe 'Bookmarks' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body).to match_array(expected_response)
     end
 
@@ -40,6 +42,8 @@ RSpec.describe 'Bookmarks' do
         expect(response.parsed_body.size)
           .to eq(params[:limit])
 
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response)
           .to include_pagination_headers(
             prev: api_v1_bookmarks_url(limit: params[:limit], min_id: bookmarks.last.id),
@@ -55,6 +59,8 @@ RSpec.describe 'Bookmarks' do
         subject
 
         expect(response).to have_http_status(401)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end

--- a/spec/requests/api/v1/conversations_spec.rb
+++ b/spec/requests/api/v1/conversations_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe 'API V1 Conversations' do
           prev: api_v1_conversations_url(limit: 1, min_id: Status.first.id),
           next: api_v1_conversations_url(limit: 1, max_id: Status.first.id)
         )
+      expect(response.content_type)
+        .to start_with('application/json')
     end
 
     it 'returns conversations', :aggregate_failures do

--- a/spec/requests/api/v1/custom_emojis_spec.rb
+++ b/spec/requests/api/v1/custom_emojis_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe 'Custom Emojis' do
 
         expect(response)
           .to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
 
         expect(response.parsed_body)
           .to be_present
@@ -33,6 +35,8 @@ RSpec.describe 'Custom Emojis' do
 
         expect(response)
           .to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
 
         expect(response.parsed_body)
           .to be_present

--- a/spec/requests/api/v1/directories_spec.rb
+++ b/spec/requests/api/v1/directories_spec.rb
@@ -82,6 +82,8 @@ RSpec.describe 'Directories API' do
         get '/api/v1/directory', headers: headers
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body.size).to eq(2)
         expect(response.parsed_body.pluck(:id)).to contain_exactly(eligible_remote_account.id.to_s, local_discoverable_account.id.to_s)
       end
@@ -101,6 +103,8 @@ RSpec.describe 'Directories API' do
         get '/api/v1/directory', headers: headers, params: { local: '1' }
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body.size).to eq(1)
         expect(response.parsed_body.first[:id]).to include(local_account.id.to_s)
         expect(response.body).to_not include(remote_account.id.to_s)
@@ -115,6 +119,8 @@ RSpec.describe 'Directories API' do
         get '/api/v1/directory', headers: headers, params: { order: 'active' }
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body.size).to eq(2)
         expect(response.parsed_body.first[:id]).to include(new_stat.account_id.to_s)
         expect(response.parsed_body.second[:id]).to include(old_stat.account_id.to_s)
@@ -130,6 +136,8 @@ RSpec.describe 'Directories API' do
         get '/api/v1/directory', headers: headers, params: { order: 'new' }
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body.size).to eq(2)
         expect(response.parsed_body.first[:id]).to include(account_new.id.to_s)
         expect(response.parsed_body.second[:id]).to include(account_old.id.to_s)

--- a/spec/requests/api/v1/domain_blocks_spec.rb
+++ b/spec/requests/api/v1/domain_blocks_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe 'Domain blocks' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body).to match_array(blocked_domains)
     end
 
@@ -53,6 +55,8 @@ RSpec.describe 'Domain blocks' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(user.account.domain_blocking?(params[:domain])).to be(true)
     end
 
@@ -63,6 +67,8 @@ RSpec.describe 'Domain blocks' do
         subject
 
         expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -73,6 +79,8 @@ RSpec.describe 'Domain blocks' do
         subject
 
         expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -94,6 +102,8 @@ RSpec.describe 'Domain blocks' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(user.account.domain_blocking?('example.com')).to be(false)
     end
 
@@ -104,6 +114,8 @@ RSpec.describe 'Domain blocks' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end

--- a/spec/requests/api/v1/emails/confirmations_spec.rb
+++ b/spec/requests/api/v1/emails/confirmations_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe 'Confirmations' do
           subject
 
           expect(response).to have_http_status(403)
+          expect(response.content_type)
+            .to start_with('application/json')
         end
       end
 
@@ -41,6 +43,8 @@ RSpec.describe 'Confirmations' do
             subject
 
             expect(response).to have_http_status(403)
+            expect(response.content_type)
+              .to start_with('application/json')
           end
 
           context 'when user changed e-mail and has not confirmed it' do
@@ -52,6 +56,8 @@ RSpec.describe 'Confirmations' do
               subject
 
               expect(response).to have_http_status(200)
+              expect(response.content_type)
+                .to start_with('application/json')
             end
           end
         end
@@ -61,6 +67,8 @@ RSpec.describe 'Confirmations' do
             subject
 
             expect(response).to have_http_status(200)
+            expect(response.content_type)
+              .to start_with('application/json')
           end
         end
 
@@ -71,6 +79,8 @@ RSpec.describe 'Confirmations' do
             subject
 
             expect(response).to have_http_status(200)
+            expect(response.content_type)
+              .to start_with('application/json')
             expect(user.reload.unconfirmed_email).to eq('foo@bar.com')
           end
         end
@@ -82,6 +92,8 @@ RSpec.describe 'Confirmations' do
             subject
 
             expect(response).to have_http_status(422)
+            expect(response.content_type)
+              .to start_with('application/json')
           end
         end
       end
@@ -94,6 +106,8 @@ RSpec.describe 'Confirmations' do
         subject
 
         expect(response).to have_http_status(401)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -111,6 +125,8 @@ RSpec.describe 'Confirmations' do
           subject
 
           expect(response).to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
           expect(response.parsed_body).to be false
         end
       end
@@ -122,6 +138,8 @@ RSpec.describe 'Confirmations' do
           subject
 
           expect(response).to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
           expect(response.parsed_body).to be true
         end
       end
@@ -139,6 +157,8 @@ RSpec.describe 'Confirmations' do
           subject
 
           expect(response).to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
           expect(response.parsed_body).to be false
         end
       end
@@ -150,6 +170,8 @@ RSpec.describe 'Confirmations' do
           subject
 
           expect(response).to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
           expect(response.parsed_body).to be true
         end
       end
@@ -162,6 +184,8 @@ RSpec.describe 'Confirmations' do
         subject
 
         expect(response).to have_http_status(401)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end

--- a/spec/requests/api/v1/endorsements_spec.rb
+++ b/spec/requests/api/v1/endorsements_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe 'Endorsements' do
 
         expect(response)
           .to have_http_status(401)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -36,6 +38,8 @@ RSpec.describe 'Endorsements' do
 
           expect(response)
             .to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
 
           expect(response.parsed_body)
             .to be_present
@@ -51,6 +55,8 @@ RSpec.describe 'Endorsements' do
 
           expect(response)
             .to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
 
           expect(response.parsed_body)
             .to_not be_present

--- a/spec/requests/api/v1/favourites_spec.rb
+++ b/spec/requests/api/v1/favourites_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe 'Favourites' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body).to match_array(expected_response)
     end
 
@@ -43,6 +45,8 @@ RSpec.describe 'Favourites' do
             prev: api_v1_favourites_url(limit: params[:limit], min_id: favourites.last.id),
             next: api_v1_favourites_url(limit: params[:limit], max_id: favourites.second.id)
           )
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -53,6 +57,8 @@ RSpec.describe 'Favourites' do
         subject
 
         expect(response).to have_http_status(401)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end

--- a/spec/requests/api/v1/featured_tags/suggestions_spec.rb
+++ b/spec/requests/api/v1/featured_tags/suggestions_spec.rb
@@ -32,6 +32,8 @@ RSpec.describe 'Featured Tags Suggestions API' do
 
       expect(response)
         .to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body)
         .to contain_exactly(
           include(name: used_tag.name)

--- a/spec/requests/api/v1/featured_tags_spec.rb
+++ b/spec/requests/api/v1/featured_tags_spec.rb
@@ -22,6 +22,8 @@ RSpec.describe 'FeaturedTags' do
         get '/api/v1/featured_tags'
 
         expect(response).to have_http_status(401)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -29,6 +31,8 @@ RSpec.describe 'FeaturedTags' do
       get '/api/v1/featured_tags', headers: headers
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
     end
 
     context 'when the requesting user has no featured tag' do
@@ -62,6 +66,8 @@ RSpec.describe 'FeaturedTags' do
       post '/api/v1/featured_tags', headers: headers, params: params
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body)
         .to include(
           name: params[:name]
@@ -89,6 +95,8 @@ RSpec.describe 'FeaturedTags' do
         post '/api/v1/featured_tags', params: params
 
         expect(response).to have_http_status(401)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -97,6 +105,8 @@ RSpec.describe 'FeaturedTags' do
         post '/api/v1/featured_tags', headers: headers
 
         expect(response).to have_http_status(400)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -107,6 +117,8 @@ RSpec.describe 'FeaturedTags' do
         post '/api/v1/featured_tags', headers: headers, params: params
 
         expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -119,6 +131,8 @@ RSpec.describe 'FeaturedTags' do
         post '/api/v1/featured_tags', headers: headers, params: params
 
         expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -131,6 +145,8 @@ RSpec.describe 'FeaturedTags' do
       delete "/api/v1/featured_tags/#{id}", headers: headers
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body).to be_empty
 
       featured_tag = FeaturedTag.find_by(id: id)
@@ -150,6 +166,8 @@ RSpec.describe 'FeaturedTags' do
         delete "/api/v1/featured_tags/#{id}"
 
         expect(response).to have_http_status(401)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -158,6 +176,8 @@ RSpec.describe 'FeaturedTags' do
         delete '/api/v1/featured_tags/0', headers: headers
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -169,6 +189,8 @@ RSpec.describe 'FeaturedTags' do
         delete "/api/v1/featured_tags/#{id}", headers: headers
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end

--- a/spec/requests/api/v1/filters_spec.rb
+++ b/spec/requests/api/v1/filters_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe 'API V1 Filters' do
     it 'returns http success' do
       get '/api/v1/filters', headers: headers
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body)
         .to contain_exactly(
           include(id: custom_filter_keyword.id.to_s)
@@ -35,6 +37,8 @@ RSpec.describe 'API V1 Filters' do
       filter = user.account.custom_filters.first
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(filter).to_not be_nil
       expect(filter.keywords.pluck(:keyword, :whole_word)).to eq [['magic', whole_word]]
       expect(filter.context).to eq %w(home)
@@ -50,6 +54,8 @@ RSpec.describe 'API V1 Filters' do
         filter = user.account.custom_filters.first
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(filter).to_not be_nil
         expect(filter.keywords.pluck(:keyword, :whole_word)).to eq [['magic', whole_word]]
         expect(filter.context).to eq %w(home)
@@ -68,6 +74,8 @@ RSpec.describe 'API V1 Filters' do
       get "/api/v1/filters/#{keyword.id}", headers: headers
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
     end
   end
 
@@ -82,6 +90,8 @@ RSpec.describe 'API V1 Filters' do
 
     it 'updates the filter', :aggregate_failures do
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(keyword.reload.phrase).to eq 'updated'
     end
   end
@@ -97,6 +107,8 @@ RSpec.describe 'API V1 Filters' do
 
     it 'removes the filter', :aggregate_failures do
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect { keyword.reload }.to raise_error ActiveRecord::RecordNotFound
     end
   end

--- a/spec/requests/api/v1/follow_requests_spec.rb
+++ b/spec/requests/api/v1/follow_requests_spec.rb
@@ -36,6 +36,8 @@ RSpec.describe 'Follow requests' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body).to match_array(expected_response)
     end
 
@@ -66,6 +68,8 @@ RSpec.describe 'Follow requests' do
     it 'allows the requesting follower to follow', :aggregate_failures do
       expect { subject }.to change { follower.following?(user.account) }.from(false).to(true)
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body[:followed_by]).to be true
     end
   end
@@ -87,6 +91,8 @@ RSpec.describe 'Follow requests' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(FollowRequest.where(target_account: user.account, account: follower)).to_not exist
       expect(response.parsed_body[:followed_by]).to be false
     end

--- a/spec/requests/api/v1/followed_tags_spec.rb
+++ b/spec/requests/api/v1/followed_tags_spec.rb
@@ -32,20 +32,20 @@ RSpec.describe 'Followed tags' do
       subject
 
       expect(response).to have_http_status(:success)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body).to match_array(expected_response)
     end
 
     context 'with limit param' do
       let(:params) { { limit: 1 } }
 
-      it 'returns only the requested number of follow tags' do
+      it 'returns only the requested number of follow tags and sets pagination headers' do
         subject
 
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body.size).to eq(params[:limit])
-      end
-
-      it 'sets the correct pagination headers' do
-        subject
 
         expect(response)
           .to include_pagination_headers(

--- a/spec/requests/api/v1/instance_spec.rb
+++ b/spec/requests/api/v1/instance_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe 'Instances' do
 
         expect(response)
           .to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
 
         expect(response.parsed_body)
           .to be_present
@@ -27,6 +29,8 @@ RSpec.describe 'Instances' do
 
         expect(response)
           .to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
 
         expect(response.parsed_body)
           .to be_present

--- a/spec/requests/api/v1/instances/activity_spec.rb
+++ b/spec/requests/api/v1/instances/activity_spec.rb
@@ -13,6 +13,9 @@ RSpec.describe 'Activity' do
         expect(response)
           .to have_http_status(200)
 
+        expect(response.content_type)
+          .to start_with('application/json')
+
         expect(response.parsed_body)
           .to be_present
           .and(be_an(Array))

--- a/spec/requests/api/v1/instances/domain_blocks_spec.rb
+++ b/spec/requests/api/v1/instances/domain_blocks_spec.rb
@@ -17,6 +17,9 @@ RSpec.describe 'Domain Blocks' do
         expect(response)
           .to have_http_status(200)
 
+        expect(response.content_type)
+          .to start_with('application/json')
+
         expect(response.parsed_body)
           .to be_present
           .and(be_an(Array))

--- a/spec/requests/api/v1/instances/extended_descriptions_spec.rb
+++ b/spec/requests/api/v1/instances/extended_descriptions_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe 'Extended Descriptions' do
 
       expect(response)
         .to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
 
       expect(response.parsed_body)
         .to be_present

--- a/spec/requests/api/v1/instances/languages_spec.rb
+++ b/spec/requests/api/v1/instances/languages_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe 'Languages' do
 
     it 'returns http success and includes supported languages' do
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body.pluck(:code)).to match_array LanguagesHelper::SUPPORTED_LOCALES.keys.map(&:to_s)
     end
   end

--- a/spec/requests/api/v1/instances/peers_spec.rb
+++ b/spec/requests/api/v1/instances/peers_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe 'Peers' do
 
         expect(response)
           .to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
 
         expect(response.parsed_body)
           .to be_an(Array)

--- a/spec/requests/api/v1/instances/privacy_policies_spec.rb
+++ b/spec/requests/api/v1/instances/privacy_policies_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe 'Privacy Policy' do
 
       expect(response)
         .to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
 
       expect(response.parsed_body)
         .to be_present

--- a/spec/requests/api/v1/instances/rules_spec.rb
+++ b/spec/requests/api/v1/instances/rules_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe 'Rules' do
 
       expect(response)
         .to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
 
       expect(response.parsed_body)
         .to be_an(Array)

--- a/spec/requests/api/v1/instances/translation_languages_spec.rb
+++ b/spec/requests/api/v1/instances/translation_languages_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe 'Translation Languages' do
 
         expect(response)
           .to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
 
         expect(response.parsed_body)
           .to eq({})
@@ -24,6 +26,8 @@ RSpec.describe 'Translation Languages' do
 
         expect(response)
           .to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
 
         expect(response.parsed_body)
           .to match({ und: %w(en de), en: ['de'] })

--- a/spec/requests/api/v1/lists/accounts_spec.rb
+++ b/spec/requests/api/v1/lists/accounts_spec.rb
@@ -34,6 +34,8 @@ RSpec.describe 'Accounts' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body).to match_array(expected_response)
     end
 
@@ -68,6 +70,8 @@ RSpec.describe 'Accounts' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(list.accounts).to include(bob)
       end
     end
@@ -81,6 +85,8 @@ RSpec.describe 'Accounts' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(list.accounts).to include(bob)
       end
     end
@@ -90,6 +96,8 @@ RSpec.describe 'Accounts' do
         subject
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(list.accounts).to_not include(bob)
       end
     end
@@ -105,6 +113,8 @@ RSpec.describe 'Accounts' do
         subject
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -118,6 +128,8 @@ RSpec.describe 'Accounts' do
         subject
 
         expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -143,6 +155,8 @@ RSpec.describe 'Accounts' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(list.accounts).to_not include(bob)
         expect(list.accounts).to include(peter)
       end
@@ -154,6 +168,8 @@ RSpec.describe 'Accounts' do
           subject
 
           expect(response).to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
           expect(list.accounts).to contain_exactly(bob, peter)
         end
       end
@@ -167,6 +183,8 @@ RSpec.describe 'Accounts' do
         subject
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end

--- a/spec/requests/api/v1/lists_spec.rb
+++ b/spec/requests/api/v1/lists_spec.rb
@@ -43,6 +43,8 @@ RSpec.describe 'Lists' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body).to match_array(expected_response)
     end
   end
@@ -60,6 +62,8 @@ RSpec.describe 'Lists' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body).to match({
         id: list.id.to_s,
         title: list.title,
@@ -75,6 +79,8 @@ RSpec.describe 'Lists' do
         subject
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -83,6 +89,8 @@ RSpec.describe 'Lists' do
         get '/api/v1/lists/-1', headers: headers
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -100,6 +108,8 @@ RSpec.describe 'Lists' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body).to match(a_hash_including(title: 'my list', replies_policy: 'none', exclusive: true))
       expect(List.where(account: user.account).count).to eq(1)
     end
@@ -111,6 +121,8 @@ RSpec.describe 'Lists' do
         subject
 
         expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -121,6 +133,8 @@ RSpec.describe 'Lists' do
         subject
 
         expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -142,6 +156,8 @@ RSpec.describe 'Lists' do
         .and change_list_exclusive
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       list.reload
 
       expect(response.parsed_body).to match({
@@ -169,6 +185,8 @@ RSpec.describe 'Lists' do
         put '/api/v1/lists/-1', headers: headers, params: params
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -179,6 +197,8 @@ RSpec.describe 'Lists' do
         subject
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -196,6 +216,8 @@ RSpec.describe 'Lists' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(List.where(id: list.id)).to_not exist
     end
 
@@ -214,6 +236,8 @@ RSpec.describe 'Lists' do
         subject
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end

--- a/spec/requests/api/v1/markers_spec.rb
+++ b/spec/requests/api/v1/markers_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe 'API Markers' do
 
     it 'returns markers', :aggregate_failures do
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body)
         .to include(
           home: include(last_read_id: '123'),
@@ -34,6 +36,8 @@ RSpec.describe 'API Markers' do
 
       it 'creates a marker', :aggregate_failures do
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(user.markers.first.timeline).to eq 'home'
         expect(user.markers.first.last_read_id).to eq 69_420
       end
@@ -47,6 +51,8 @@ RSpec.describe 'API Markers' do
 
       it 'updates a marker', :aggregate_failures do
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(user.markers.first.timeline).to eq 'home'
         expect(user.markers.first.last_read_id).to eq 70_120
       end
@@ -61,6 +67,8 @@ RSpec.describe 'API Markers' do
       it 'returns error json' do
         expect(response)
           .to have_http_status(409)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body)
           .to include(error: /Conflict during update/)
       end

--- a/spec/requests/api/v1/media_spec.rb
+++ b/spec/requests/api/v1/media_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe 'Media' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body).to match(
         a_hash_including(
           id: media.id.to_s,
@@ -39,6 +41,8 @@ RSpec.describe 'Media' do
         subject
 
         expect(response).to have_http_status(206)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -49,6 +53,8 @@ RSpec.describe 'Media' do
         subject
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -59,6 +65,8 @@ RSpec.describe 'Media' do
         subject
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -75,6 +83,8 @@ RSpec.describe 'Media' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(MediaAttachment.first).to be_present
         expect(MediaAttachment.first).to have_attached_file(:file)
 
@@ -102,6 +112,8 @@ RSpec.describe 'Media' do
           subject
 
           expect(response).to have_http_status(422)
+          expect(response.content_type)
+            .to start_with('application/json')
         end
       end
 
@@ -112,6 +124,8 @@ RSpec.describe 'Media' do
           subject
 
           expect(response).to have_http_status(500)
+          expect(response.content_type)
+            .to start_with('application/json')
         end
       end
     end
@@ -153,6 +167,8 @@ RSpec.describe 'Media' do
         subject
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -171,6 +187,8 @@ RSpec.describe 'Media' do
           subject
 
           expect(response).to have_http_status(404)
+          expect(response.content_type)
+            .to start_with('application/json')
         end
       end
     end

--- a/spec/requests/api/v1/mutes_spec.rb
+++ b/spec/requests/api/v1/mutes_spec.rb
@@ -22,6 +22,8 @@ RSpec.describe 'Mutes' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
 
       muted_accounts = mutes.map(&:target_account)
       expect(response.parsed_body.pluck(:id)).to match_array(muted_accounts.map { |account| account.id.to_s })
@@ -34,6 +36,8 @@ RSpec.describe 'Mutes' do
         subject
 
         expect(response.parsed_body.size).to eq(params[:limit])
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response)
           .to include_pagination_headers(
             prev: api_v1_mutes_url(limit: params[:limit], since_id: mutes.last.id),
@@ -71,6 +75,8 @@ RSpec.describe 'Mutes' do
         subject
 
         expect(response).to have_http_status(401)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end

--- a/spec/requests/api/v1/notifications/policies_spec.rb
+++ b/spec/requests/api/v1/notifications/policies_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe 'Policies' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body).to include(
           filter_not_following: false,
           filter_not_followers: false,
@@ -54,6 +56,8 @@ RSpec.describe 'Policies' do
         .to change { NotificationPolicy.find_or_initialize_by(account: user.account).for_not_following.to_sym }.from(:accept).to(:filter)
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body).to include(
         filter_not_following: true,
         filter_not_followers: false,

--- a/spec/requests/api/v1/notifications/requests_spec.rb
+++ b/spec/requests/api/v1/notifications/requests_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe 'Requests' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -43,6 +45,8 @@ RSpec.describe 'Requests' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(NotificationPermission.find_by(account: notification_request.account, from_account: notification_request.from_account)).to_not be_nil
     end
 
@@ -53,6 +57,8 @@ RSpec.describe 'Requests' do
         subject
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -70,6 +76,8 @@ RSpec.describe 'Requests' do
       expect { subject }.to change(NotificationRequest, :count).by(-1)
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
     end
 
     context 'when notification request belongs to someone else' do
@@ -79,6 +87,8 @@ RSpec.describe 'Requests' do
         subject
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -97,6 +107,8 @@ RSpec.describe 'Requests' do
 
       expect(NotificationPermission.find_by(account: notification_request.account, from_account: notification_request.from_account)).to_not be_nil
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
     end
   end
 
@@ -113,6 +125,8 @@ RSpec.describe 'Requests' do
       expect { subject }.to change(NotificationRequest, :count).by(-1)
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
     end
   end
 
@@ -128,6 +142,8 @@ RSpec.describe 'Requests' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body).to match({ merged: true })
       end
     end
@@ -141,6 +157,8 @@ RSpec.describe 'Requests' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body).to match({ merged: false })
       end
     end

--- a/spec/requests/api/v1/notifications_spec.rb
+++ b/spec/requests/api/v1/notifications_spec.rb
@@ -31,6 +31,8 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body[:count]).to eq 5
       end
     end
@@ -45,6 +47,8 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body[:count]).to eq 2
       end
     end
@@ -56,6 +60,8 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body[:count]).to eq 4
       end
     end
@@ -67,6 +73,8 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body[:count]).to eq 2
       end
     end
@@ -80,6 +88,8 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body[:count]).to eq Api::V1::NotificationsController::DEFAULT_NOTIFICATIONS_COUNT_LIMIT
       end
     end
@@ -111,6 +121,8 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body.size).to eq 5
         expect(body_json_types).to include('reblog', 'mention', 'favourite', 'follow')
         expect(response.parsed_body.any? { |x| x[:filtered] }).to be false
@@ -124,6 +136,8 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body.size).to eq 6
         expect(body_json_types).to include('reblog', 'mention', 'favourite', 'follow')
         expect(response.parsed_body.any? { |x| x[:filtered] }).to be true
@@ -137,6 +151,8 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(body_json_account_ids.uniq).to eq [tom.account.id.to_s]
       end
 
@@ -152,6 +168,8 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body.size).to eq 0
       end
     end
@@ -163,6 +181,8 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body.size).to_not eq 0
         expect(body_json_types.uniq).to_not include 'mention'
       end
@@ -175,6 +195,8 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(body_json_types.uniq).to eq ['mention']
       end
     end
@@ -216,6 +238,8 @@ RSpec.describe 'Notifications' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
     end
 
     context 'when notification belongs to someone else' do
@@ -225,6 +249,8 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -242,6 +268,8 @@ RSpec.describe 'Notifications' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect { notification.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
@@ -252,6 +280,8 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -272,6 +302,8 @@ RSpec.describe 'Notifications' do
 
       expect(user.account.reload.notifications).to be_empty
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
     end
   end
 end

--- a/spec/requests/api/v1/peers/search_spec.rb
+++ b/spec/requests/api/v1/peers/search_spec.rb
@@ -23,6 +23,8 @@ RSpec.describe 'API Peers Search' do
 
         expect(response)
           .to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body)
           .to be_blank
       end
@@ -34,6 +36,8 @@ RSpec.describe 'API Peers Search' do
 
         expect(response)
           .to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body)
           .to be_blank
       end
@@ -49,6 +53,8 @@ RSpec.describe 'API Peers Search' do
 
         expect(response)
           .to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body.size)
           .to eq(1)
         expect(response.parsed_body.first)

--- a/spec/requests/api/v1/polls/votes_spec.rb
+++ b/spec/requests/api/v1/polls/votes_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe 'API V1 Polls Votes' do
 
     it 'creates a vote', :aggregate_failures do
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
 
       expect(vote).to_not be_nil
       expect(vote.choice).to eq 1
@@ -30,6 +32,8 @@ RSpec.describe 'API V1 Polls Votes' do
 
       it 'returns http bad request' do
         expect(response).to have_http_status(400)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 

--- a/spec/requests/api/v1/polls_spec.rb
+++ b/spec/requests/api/v1/polls_spec.rb
@@ -23,6 +23,8 @@ RSpec.describe 'Polls' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body).to match(
           a_hash_including(
             id: poll.id.to_s,
@@ -41,6 +43,8 @@ RSpec.describe 'Polls' do
         subject
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end

--- a/spec/requests/api/v1/preferences_spec.rb
+++ b/spec/requests/api/v1/preferences_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe 'Preferences' do
 
         expect(response)
           .to have_http_status(401)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -33,6 +35,9 @@ RSpec.describe 'Preferences' do
 
         expect(response)
           .to have_http_status(200)
+
+        expect(response.content_type)
+          .to start_with('application/json')
 
         expect(response.parsed_body)
           .to be_present

--- a/spec/requests/api/v1/profiles_spec.rb
+++ b/spec/requests/api/v1/profiles_spec.rb
@@ -32,6 +32,8 @@ RSpec.describe 'Deleting profile images' do
         delete '/api/v1/profile/avatar', headers: headers
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
 
         account.reload
         expect(account.avatar).to_not exist
@@ -53,6 +55,8 @@ RSpec.describe 'Deleting profile images' do
         delete '/api/v1/profile/header', headers: headers
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
 
         account.reload
         expect(account.avatar).to exist

--- a/spec/requests/api/v1/push/subscriptions_spec.rb
+++ b/spec/requests/api/v1/push/subscriptions_spec.rb
@@ -45,6 +45,8 @@ RSpec.describe 'API V1 Push Subscriptions' do
       subject
 
       expect(response).to have_http_status(422)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(endpoint_push_subscriptions.count).to eq(0)
       expect(endpoint_push_subscription).to be_nil
     end

--- a/spec/requests/api/v1/reports_spec.rb
+++ b/spec/requests/api/v1/reports_spec.rb
@@ -37,6 +37,8 @@ RSpec.describe 'Reports' do
       emails = capture_emails { subject }
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body).to match(
         a_hash_including(
           status_ids: [status.id.to_s],
@@ -65,6 +67,8 @@ RSpec.describe 'Reports' do
         subject
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 

--- a/spec/requests/api/v1/scheduled_status_spec.rb
+++ b/spec/requests/api/v1/scheduled_status_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe 'Scheduled Statuses' do
 
         expect(response)
           .to have_http_status(401)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -33,6 +35,8 @@ RSpec.describe 'Scheduled Statuses' do
 
         expect(response)
           .to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -45,6 +49,8 @@ RSpec.describe 'Scheduled Statuses' do
 
           expect(response)
             .to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
 
           expect(response.parsed_body)
             .to_not be_present
@@ -59,6 +65,8 @@ RSpec.describe 'Scheduled Statuses' do
 
           expect(response)
             .to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
 
           expect(response.parsed_body)
             .to be_present

--- a/spec/requests/api/v1/statuses/bookmarks_spec.rb
+++ b/spec/requests/api/v1/statuses/bookmarks_spec.rb
@@ -22,6 +22,8 @@ RSpec.describe 'Bookmarks' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(user.account.bookmarked?(status)).to be true
 
         expect(response.parsed_body).to match(
@@ -37,6 +39,8 @@ RSpec.describe 'Bookmarks' do
         subject
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -51,6 +55,8 @@ RSpec.describe 'Bookmarks' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(user.account.bookmarked?(status)).to be true
       end
     end
@@ -60,6 +66,8 @@ RSpec.describe 'Bookmarks' do
         post '/api/v1/statuses/-1/bookmark', headers: headers
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -70,6 +78,8 @@ RSpec.describe 'Bookmarks' do
         subject
 
         expect(response).to have_http_status(401)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -93,6 +103,8 @@ RSpec.describe 'Bookmarks' do
           subject
 
           expect(response).to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
           expect(user.account.bookmarked?(status)).to be false
 
           expect(response.parsed_body).to match(
@@ -113,6 +125,8 @@ RSpec.describe 'Bookmarks' do
           subject
 
           expect(response).to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
           expect(user.account.bookmarked?(status)).to be false
 
           expect(response.parsed_body).to match(
@@ -126,6 +140,8 @@ RSpec.describe 'Bookmarks' do
           subject
 
           expect(response).to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
         end
       end
     end
@@ -137,6 +153,8 @@ RSpec.describe 'Bookmarks' do
         subject
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end

--- a/spec/requests/api/v1/statuses/favourited_by_accounts_spec.rb
+++ b/spec/requests/api/v1/statuses/favourited_by_accounts_spec.rb
@@ -33,6 +33,8 @@ RSpec.describe 'API V1 Statuses Favourited by Accounts' do
             prev: api_v1_status_favourited_by_index_url(limit: 2, since_id: Favourite.last.id),
             next: api_v1_status_favourited_by_index_url(limit: 2, max_id: Favourite.first.id)
           )
+        expect(response.content_type)
+          .to start_with('application/json')
 
         expect(response.parsed_body.size)
           .to eq(2)
@@ -72,6 +74,8 @@ RSpec.describe 'API V1 Statuses Favourited by Accounts' do
           subject
 
           expect(response).to have_http_status(404)
+          expect(response.content_type)
+            .to start_with('application/json')
         end
       end
     end
@@ -88,6 +92,8 @@ RSpec.describe 'API V1 Statuses Favourited by Accounts' do
           subject
 
           expect(response).to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
         end
       end
     end

--- a/spec/requests/api/v1/statuses/favourites_spec.rb
+++ b/spec/requests/api/v1/statuses/favourites_spec.rb
@@ -22,6 +22,8 @@ RSpec.describe 'Favourites', :inline_jobs do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(user.account.favourited?(status)).to be true
 
         expect(response.parsed_body).to match(
@@ -37,6 +39,8 @@ RSpec.describe 'Favourites', :inline_jobs do
         subject
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -51,6 +55,8 @@ RSpec.describe 'Favourites', :inline_jobs do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(user.account.favourited?(status)).to be true
       end
     end
@@ -62,6 +68,8 @@ RSpec.describe 'Favourites', :inline_jobs do
         subject
 
         expect(response).to have_http_status(401)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -84,6 +92,8 @@ RSpec.describe 'Favourites', :inline_jobs do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
 
         expect(user.account.favourited?(status)).to be false
 
@@ -103,6 +113,8 @@ RSpec.describe 'Favourites', :inline_jobs do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
 
         expect(user.account.favourited?(status)).to be false
 
@@ -117,6 +129,8 @@ RSpec.describe 'Favourites', :inline_jobs do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -127,6 +141,8 @@ RSpec.describe 'Favourites', :inline_jobs do
         subject
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end

--- a/spec/requests/api/v1/statuses/histories_spec.rb
+++ b/spec/requests/api/v1/statuses/histories_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe 'API V1 Statuses Histories' do
 
       it 'returns http success' do
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body.size).to_not be 0
       end
     end

--- a/spec/requests/api/v1/statuses/mutes_spec.rb
+++ b/spec/requests/api/v1/statuses/mutes_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe 'API V1 Statuses Mutes' do
 
       it 'creates a conversation mute', :aggregate_failures do
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(ConversationMute.find_by(account: user.account, conversation_id: status.conversation_id)).to_not be_nil
       end
     end
@@ -32,6 +34,8 @@ RSpec.describe 'API V1 Statuses Mutes' do
 
       it 'destroys the conversation mute', :aggregate_failures do
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(ConversationMute.find_by(account: user.account, conversation_id: status.conversation_id)).to be_nil
       end
     end

--- a/spec/requests/api/v1/statuses/pins_spec.rb
+++ b/spec/requests/api/v1/statuses/pins_spec.rb
@@ -22,6 +22,8 @@ RSpec.describe 'Pins' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(user.account.pinned?(status)).to be true
 
         expect(response.parsed_body).to match(
@@ -37,6 +39,8 @@ RSpec.describe 'Pins' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(user.account.pinned?(status)).to be true
       end
     end
@@ -48,6 +52,8 @@ RSpec.describe 'Pins' do
         subject
 
         expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -56,6 +62,8 @@ RSpec.describe 'Pins' do
         post '/api/v1/statuses/-1/pin', headers: headers
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -66,6 +74,8 @@ RSpec.describe 'Pins' do
         subject
 
         expect(response).to have_http_status(401)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -86,6 +96,8 @@ RSpec.describe 'Pins' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(user.account.pinned?(status)).to be false
 
         expect(response.parsed_body).to match(
@@ -99,6 +111,8 @@ RSpec.describe 'Pins' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -107,6 +121,8 @@ RSpec.describe 'Pins' do
         post '/api/v1/statuses/-1/unpin', headers: headers
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -117,6 +133,8 @@ RSpec.describe 'Pins' do
         subject
 
         expect(response).to have_http_status(401)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end

--- a/spec/requests/api/v1/statuses/reblogged_by_accounts_spec.rb
+++ b/spec/requests/api/v1/statuses/reblogged_by_accounts_spec.rb
@@ -32,6 +32,8 @@ RSpec.describe 'API V1 Statuses Reblogged by Accounts' do
             prev: api_v1_status_reblogged_by_index_url(limit: 2, since_id: bob.statuses.first.id),
             next: api_v1_status_reblogged_by_index_url(limit: 2, max_id: alice.statuses.first.id)
           )
+        expect(response.content_type)
+          .to start_with('application/json')
 
         expect(response.parsed_body.size)
           .to eq(2)
@@ -71,6 +73,8 @@ RSpec.describe 'API V1 Statuses Reblogged by Accounts' do
           subject
 
           expect(response).to have_http_status(404)
+          expect(response.content_type)
+            .to start_with('application/json')
         end
       end
     end
@@ -87,6 +91,8 @@ RSpec.describe 'API V1 Statuses Reblogged by Accounts' do
           subject
 
           expect(response).to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
         end
       end
     end

--- a/spec/requests/api/v1/statuses/reblogs_spec.rb
+++ b/spec/requests/api/v1/statuses/reblogs_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe 'API V1 Statuses Reblogs' do
       context 'with public status' do
         it 'reblogs the status', :aggregate_failures do
           expect(response).to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
 
           expect(status.reblogs.count).to eq 1
 
@@ -40,6 +42,8 @@ RSpec.describe 'API V1 Statuses Reblogs' do
 
         it 'returns http not found' do
           expect(response).to have_http_status(404)
+          expect(response.content_type)
+            .to start_with('application/json')
         end
       end
     end
@@ -55,6 +59,8 @@ RSpec.describe 'API V1 Statuses Reblogs' do
 
         it 'destroys the reblog', :aggregate_failures do
           expect(response).to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
 
           expect(status.reblogs.count).to eq 0
 
@@ -80,6 +86,8 @@ RSpec.describe 'API V1 Statuses Reblogs' do
 
         it 'destroys the reblog', :aggregate_failures do
           expect(response).to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
 
           expect(status.reblogs.count).to eq 0
 
@@ -103,6 +111,8 @@ RSpec.describe 'API V1 Statuses Reblogs' do
 
         it 'returns http not found' do
           expect(response).to have_http_status(404)
+          expect(response.content_type)
+            .to start_with('application/json')
         end
       end
     end

--- a/spec/requests/api/v1/statuses/sources_spec.rb
+++ b/spec/requests/api/v1/statuses/sources_spec.rb
@@ -22,6 +22,8 @@ RSpec.describe 'Sources' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body).to match({
           id: status.id.to_s,
           text: status.text,
@@ -37,6 +39,8 @@ RSpec.describe 'Sources' do
         subject
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -51,6 +55,8 @@ RSpec.describe 'Sources' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body).to match({
           id: status.id.to_s,
           text: status.text,
@@ -66,6 +72,8 @@ RSpec.describe 'Sources' do
         subject
 
         expect(response).to have_http_status(401)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end

--- a/spec/requests/api/v1/statuses/translations_spec.rb
+++ b/spec/requests/api/v1/statuses/translations_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe 'API V1 Statuses Translations' do
 
       it 'returns http unprocessable entity' do
         expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -38,6 +40,8 @@ RSpec.describe 'API V1 Statuses Translations' do
 
       it 'returns http success' do
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end

--- a/spec/requests/api/v1/statuses_spec.rb
+++ b/spec/requests/api/v1/statuses_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe '/api/v1/statuses' do
         get '/api/v1/statuses', headers: headers, params: { id: [status.id, other_status.id, 123_123] }
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body).to contain_exactly(
           hash_including(id: status.id.to_s),
           hash_including(id: other_status.id.to_s)
@@ -39,6 +41,8 @@ RSpec.describe '/api/v1/statuses' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
 
       context 'when post includes filtered terms' do
@@ -52,6 +56,8 @@ RSpec.describe '/api/v1/statuses' do
           subject
 
           expect(response).to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
           expect(response.parsed_body[:filtered][0]).to include({
             filter: a_hash_including({
               id: user.account.custom_filters.first.id.to_s,
@@ -75,6 +81,8 @@ RSpec.describe '/api/v1/statuses' do
           subject
 
           expect(response).to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
           expect(response.parsed_body[:filtered][0]).to include({
             filter: a_hash_including({
               id: user.account.custom_filters.first.id.to_s,
@@ -97,6 +105,8 @@ RSpec.describe '/api/v1/statuses' do
           subject
 
           expect(response).to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
           expect(response.parsed_body[:reblog][:filtered][0]).to include({
             filter: a_hash_including({
               id: user.account.custom_filters.first.id.to_s,
@@ -121,6 +131,8 @@ RSpec.describe '/api/v1/statuses' do
         get "/api/v1/statuses/#{status.id}/context", headers: headers
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -139,6 +151,8 @@ RSpec.describe '/api/v1/statuses' do
           subject
 
           expect(response).to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
           expect(response.headers['X-RateLimit-Limit']).to eq RateLimiter::FAMILIES[:statuses][:limit].to_s
           expect(response.headers['X-RateLimit-Remaining']).to eq (RateLimiter::FAMILIES[:statuses][:limit] - 1).to_s
         end
@@ -154,6 +168,8 @@ RSpec.describe '/api/v1/statuses' do
           subject
 
           expect(response).to have_http_status(422)
+          expect(response.content_type)
+            .to start_with('application/json')
           expect(response.parsed_body[:unexpected_accounts].map { |a| a.slice(:id, :acct) }).to match [{ id: bob.id.to_s, acct: bob.acct }]
         end
       end
@@ -165,6 +181,8 @@ RSpec.describe '/api/v1/statuses' do
           subject
 
           expect(response).to have_http_status(422)
+          expect(response.content_type)
+            .to start_with('application/json')
           expect(response.headers['X-RateLimit-Limit']).to eq RateLimiter::FAMILIES[:statuses][:limit].to_s
         end
       end
@@ -179,6 +197,8 @@ RSpec.describe '/api/v1/statuses' do
           subject
 
           expect(response).to have_http_status(429)
+          expect(response.content_type)
+            .to start_with('application/json')
           expect(response.headers['X-RateLimit-Limit']).to eq RateLimiter::FAMILIES[:statuses][:limit].to_s
           expect(response.headers['X-RateLimit-Remaining']).to eq '0'
         end
@@ -191,6 +211,8 @@ RSpec.describe '/api/v1/statuses' do
           subject
 
           expect(response).to have_http_status(404)
+          expect(response.content_type)
+            .to start_with('application/json')
         end
       end
 
@@ -202,6 +224,8 @@ RSpec.describe '/api/v1/statuses' do
           subject
 
           expect(response).to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
         end
 
         it 'creates a scheduled status' do
@@ -215,6 +239,8 @@ RSpec.describe '/api/v1/statuses' do
             subject
 
             expect(response).to have_http_status(422)
+            expect(response.content_type)
+              .to start_with('application/json')
             expect(account.scheduled_statuses).to be_empty
           end
         end
@@ -235,6 +261,8 @@ RSpec.describe '/api/v1/statuses' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(Status.find_by(id: status.id)).to be_nil
       end
     end
@@ -253,6 +281,8 @@ RSpec.describe '/api/v1/statuses' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(status.reload.text).to eq 'I am updated'
       end
     end
@@ -267,6 +297,8 @@ RSpec.describe '/api/v1/statuses' do
           get "/api/v1/statuses/#{status.id}"
 
           expect(response).to have_http_status(404)
+          expect(response.content_type)
+            .to start_with('application/json')
         end
       end
 
@@ -279,6 +311,8 @@ RSpec.describe '/api/v1/statuses' do
           get "/api/v1/statuses/#{status.id}/context"
 
           expect(response).to have_http_status(404)
+          expect(response.content_type)
+            .to start_with('application/json')
         end
       end
     end
@@ -291,6 +325,8 @@ RSpec.describe '/api/v1/statuses' do
           get "/api/v1/statuses/#{status.id}"
 
           expect(response).to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
         end
       end
 
@@ -303,6 +339,8 @@ RSpec.describe '/api/v1/statuses' do
           get "/api/v1/statuses/#{status.id}/context"
 
           expect(response).to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
         end
       end
     end

--- a/spec/requests/api/v1/streaming_spec.rb
+++ b/spec/requests/api/v1/streaming_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe 'API V1 Streaming' do
         get '/api/v1/streaming'
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end

--- a/spec/requests/api/v1/suggestions_spec.rb
+++ b/spec/requests/api/v1/suggestions_spec.rb
@@ -27,6 +27,8 @@ RSpec.describe 'Suggestions' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body)
         .to contain_exactly(include(id: bob.id.to_s), include(id: jeff.id.to_s))
     end
@@ -48,6 +50,8 @@ RSpec.describe 'Suggestions' do
         subject
 
         expect(response).to have_http_status(401)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -71,6 +75,8 @@ RSpec.describe 'Suggestions' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(FollowRecommendationMute.exists?(account: user.account, target_account: jeff)).to be true
     end
 

--- a/spec/requests/api/v1/tags_spec.rb
+++ b/spec/requests/api/v1/tags_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe 'Tags' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body[:name]).to eq(name)
       end
     end
@@ -32,6 +34,8 @@ RSpec.describe 'Tags' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -42,6 +46,8 @@ RSpec.describe 'Tags' do
         subject
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -61,6 +67,8 @@ RSpec.describe 'Tags' do
         subject
 
         expect(response).to have_http_status(:success)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(TagFollow.where(tag: tag, account: user.account)).to exist
       end
     end
@@ -72,6 +80,8 @@ RSpec.describe 'Tags' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(Tag.where(name: name)).to exist
         expect(TagFollow.where(tag: Tag.find_by(name: name), account: user.account)).to exist
       end
@@ -84,6 +94,8 @@ RSpec.describe 'Tags' do
         subject
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -95,6 +107,8 @@ RSpec.describe 'Tags' do
         subject
 
         expect(response).to have_http_status(401)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -117,6 +131,8 @@ RSpec.describe 'Tags' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(TagFollow.where(tag: tag, account: user.account)).to_not exist
     end
 
@@ -127,6 +143,8 @@ RSpec.describe 'Tags' do
         subject
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -138,6 +156,8 @@ RSpec.describe 'Tags' do
         subject
 
         expect(response).to have_http_status(401)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end

--- a/spec/requests/api/v1/timelines/home_spec.rb
+++ b/spec/requests/api/v1/timelines/home_spec.rb
@@ -35,6 +35,8 @@ RSpec.describe 'Home', :inline_jobs do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
 
         expect(response.parsed_body.pluck(:id)).to match_array(home_statuses.map { |status| status.id.to_s })
       end
@@ -52,6 +54,8 @@ RSpec.describe 'Home', :inline_jobs do
               prev: api_v1_timelines_home_url(limit: params[:limit], min_id: ana.statuses.first.id),
               next: api_v1_timelines_home_url(limit: params[:limit], max_id: ana.statuses.first.id)
             )
+          expect(response.content_type)
+            .to start_with('application/json')
         end
       end
     end
@@ -67,6 +71,8 @@ RSpec.describe 'Home', :inline_jobs do
         subject
 
         expect(response).to have_http_status(206)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -77,6 +83,8 @@ RSpec.describe 'Home', :inline_jobs do
         subject
 
         expect(response).to have_http_status(401)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -89,6 +97,8 @@ RSpec.describe 'Home', :inline_jobs do
         expect(response)
           .to have_http_status(422)
           .and not_have_http_link_header
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end

--- a/spec/requests/api/v1/timelines/link_spec.rb
+++ b/spec/requests/api/v1/timelines/link_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe 'Link' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body.pluck(:id)).to match_array(expected_statuses.map { |status| status.id.to_s })
     end
   end
@@ -50,6 +52,8 @@ RSpec.describe 'Link' do
         subject
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -62,6 +66,8 @@ RSpec.describe 'Link' do
         subject
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -74,6 +80,8 @@ RSpec.describe 'Link' do
         subject
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -91,6 +99,8 @@ RSpec.describe 'Link' do
           subject
 
           expect(response).to have_http_status(422)
+          expect(response.content_type)
+            .to start_with('application/json')
         end
       end
 
@@ -101,6 +111,8 @@ RSpec.describe 'Link' do
           subject
 
           expect(response).to have_http_status(422)
+          expect(response.content_type)
+            .to start_with('application/json')
         end
       end
 
@@ -127,6 +139,8 @@ RSpec.describe 'Link' do
           subject
 
           expect(response).to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
           expect(response.parsed_body.size).to eq(params[:limit])
 
           expect(response)

--- a/spec/requests/api/v1/timelines/list_spec.rb
+++ b/spec/requests/api/v1/timelines/list_spec.rb
@@ -23,6 +23,8 @@ RSpec.describe 'API V1 Timelines List' do
         get "/api/v1/timelines/list/#{list.id}", headers: headers
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -36,6 +38,8 @@ RSpec.describe 'API V1 Timelines List' do
         get "/api/v1/timelines/list/#{list.id}", headers: headers
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end

--- a/spec/requests/api/v1/timelines/public_spec.rb
+++ b/spec/requests/api/v1/timelines/public_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe 'Public' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body.pluck(:id)).to match_array(expected_statuses.map { |status| status.id.to_s })
     end
   end
@@ -77,15 +79,13 @@ RSpec.describe 'Public' do
       context 'with limit param' do
         let(:params) { { limit: 1 } }
 
-        it 'returns only the requested number of statuses', :aggregate_failures do
+        it 'returns only the requested number of statuses and sets pagination headers', :aggregate_failures do
           subject
 
           expect(response).to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
           expect(response.parsed_body.size).to eq(params[:limit])
-        end
-
-        it 'sets the correct pagination headers', :aggregate_failures do
-          subject
 
           expect(response)
             .to include_pagination_headers(
@@ -110,6 +110,8 @@ RSpec.describe 'Public' do
           subject
 
           expect(response).to have_http_status(422)
+          expect(response.content_type)
+            .to start_with('application/json')
         end
       end
 
@@ -120,6 +122,8 @@ RSpec.describe 'Public' do
           subject
 
           expect(response).to have_http_status(422)
+          expect(response.content_type)
+            .to start_with('application/json')
         end
       end
 

--- a/spec/requests/api/v1/timelines/tag_spec.rb
+++ b/spec/requests/api/v1/timelines/tag_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe 'Tag' do
 
         expect(response)
           .to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body.pluck(:id))
           .to match_array(expected_statuses.map { |status| status.id.to_s })
           .and not_include(private_status.id)
@@ -81,6 +83,8 @@ RSpec.describe 'Tag' do
             prev: api_v1_timelines_tag_url(limit: params[:limit], min_id: love_status.id),
             next: api_v1_timelines_tag_url(limit: params[:limit], max_id: love_status.id)
           )
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -107,6 +111,8 @@ RSpec.describe 'Tag' do
           subject
 
           expect(response).to have_http_status(422)
+          expect(response.content_type)
+            .to start_with('application/json')
         end
       end
 

--- a/spec/requests/api/v1/trends/links_spec.rb
+++ b/spec/requests/api/v1/trends/links_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe 'API V1 Trends Links' do
         expect(response)
           .to have_http_status(200)
           .and not_have_http_link_header
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -27,6 +29,8 @@ RSpec.describe 'API V1 Trends Links' do
         expect(response)
           .to have_http_status(200)
           .and have_http_link_header(api_v1_trends_links_url(offset: 2)).for(rel: 'next')
+        expect(response.content_type)
+          .to start_with('application/json')
       end
 
       def prepare_trends

--- a/spec/requests/api/v1/trends/statuses_spec.rb
+++ b/spec/requests/api/v1/trends/statuses_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe 'API V1 Trends Statuses' do
         expect(response)
           .to have_http_status(200)
           .and not_have_http_link_header
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -27,6 +29,8 @@ RSpec.describe 'API V1 Trends Statuses' do
         expect(response)
           .to have_http_status(200)
           .and have_http_link_header(api_v1_trends_statuses_url(offset: 2)).for(rel: 'next')
+        expect(response.content_type)
+          .to start_with('application/json')
       end
 
       def prepare_trends

--- a/spec/requests/api/v1/trends/tags_spec.rb
+++ b/spec/requests/api/v1/trends/tags_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe 'API V1 Trends Tags' do
         expect(response)
           .to have_http_status(200)
           .and not_have_http_link_header
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -27,6 +29,8 @@ RSpec.describe 'API V1 Trends Tags' do
         expect(response)
           .to have_http_status(200)
           .and have_http_link_header(api_v1_trends_tags_url(offset: 2)).for(rel: 'next')
+        expect(response.content_type)
+          .to start_with('application/json')
       end
 
       def prepare_trends

--- a/spec/requests/api/web/settings_spec.rb
+++ b/spec/requests/api/web/settings_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe '/api/web/settings' do
 
         expect(response)
           .to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -29,6 +31,8 @@ RSpec.describe '/api/web/settings' do
 
         expect(response)
           .to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 


### PR DESCRIPTION
Follow-up on https://github.com/mastodon/mastodon/pull/31970 to handle concern in linked comment from there.

For a first pass here, I stuck to the `api/v1` controllers and a few others. Will do follow-up for v2 and some of the other namespace. Tried to stick to just adding these assertions and not any other formatting/cleanup for now. Only exception to that is 2-3 examples I missed in the previous combining one, and a few have_http_status parens/no-parens spots.

I've also limited this to changes in specs which did not need corresponding app side changes (ie, where json was response). THe only things I turned up which might warrant more review is:

- The csp spec has an html response, but this is from a spec-inline-defined controller which does a `head` response, and probably doesnt matter
- In some of the peers/instances/etc specs where we return 404 when something is disabled (ie, when peers_api_disabled in peers/search spec) we also just do a `head` response and it comes back as text/html as well. I suspect in this cases we care much more about the http status code (which is correctly 404) than we do the content type ... but if that matters or we'd prefer it be json, I could do that as followup as well.
