### PR TITLE
Add content type checks to api/v2 request specs

### DIFF
--- a/spec/requests/api/v2/admin/accounts_spec.rb
+++ b/spec/requests/api/v2/admin/accounts_spec.rb
@@ -34,6 +34,8 @@ RSpec.describe 'API V2 Admin Accounts' do
 
       it 'returns the correct accounts' do
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(body_json_ids).to eq([admin_account.id])
       end
     end
@@ -43,6 +45,8 @@ RSpec.describe 'API V2 Admin Accounts' do
 
       it 'returns the correct accounts' do
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(body_json_ids).to include(remote_account.id)
         expect(body_json_ids).to_not include(other_remote_account.id)
       end
@@ -53,6 +57,8 @@ RSpec.describe 'API V2 Admin Accounts' do
 
       it 'returns the correct accounts' do
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(body_json_ids).to include(suspended_remote.id, suspended_account.id)
       end
     end
@@ -62,6 +68,8 @@ RSpec.describe 'API V2 Admin Accounts' do
 
       it 'returns the correct accounts' do
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(body_json_ids).to include(disabled_account.id)
       end
     end
@@ -71,6 +79,8 @@ RSpec.describe 'API V2 Admin Accounts' do
 
       it 'returns the correct accounts' do
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(body_json_ids).to include(pending_account.id)
       end
     end
@@ -85,6 +95,8 @@ RSpec.describe 'API V2 Admin Accounts' do
       it 'sets the correct pagination headers' do
         expect(response)
           .to include_pagination_headers(next: api_v2_admin_accounts_url(limit: 1, max_id: admin_account.id))
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end

--- a/spec/requests/api/v2/filters/keywords_spec.rb
+++ b/spec/requests/api/v2/filters/keywords_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe 'API V2 Filters Keywords' do
     it 'returns http success' do
       get "/api/v2/filters/#{filter.id}/keywords", headers: headers
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body)
         .to contain_exactly(
           include(id: keyword.id.to_s)
@@ -27,6 +29,8 @@ RSpec.describe 'API V2 Filters Keywords' do
       it 'returns http not found' do
         get "/api/v2/filters/#{other_filter.id}/keywords", headers: headers
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -41,6 +45,8 @@ RSpec.describe 'API V2 Filters Keywords' do
 
     it 'creates a filter', :aggregate_failures do
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
 
       expect(response.parsed_body)
         .to include(
@@ -58,6 +64,8 @@ RSpec.describe 'API V2 Filters Keywords' do
 
       it 'returns http not found' do
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -72,6 +80,8 @@ RSpec.describe 'API V2 Filters Keywords' do
 
     it 'responds with the keyword', :aggregate_failures do
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
 
       expect(response.parsed_body)
         .to include(
@@ -85,6 +95,8 @@ RSpec.describe 'API V2 Filters Keywords' do
 
       it 'returns http not found' do
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -99,6 +111,8 @@ RSpec.describe 'API V2 Filters Keywords' do
 
     it 'updates the keyword', :aggregate_failures do
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
 
       expect(keyword.reload.keyword).to eq 'updated'
     end
@@ -108,6 +122,8 @@ RSpec.describe 'API V2 Filters Keywords' do
 
       it 'returns http not found' do
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -122,6 +138,8 @@ RSpec.describe 'API V2 Filters Keywords' do
 
     it 'destroys the keyword', :aggregate_failures do
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
 
       expect { keyword.reload }.to raise_error ActiveRecord::RecordNotFound
     end
@@ -131,6 +149,8 @@ RSpec.describe 'API V2 Filters Keywords' do
 
       it 'returns http not found' do
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end

--- a/spec/requests/api/v2/filters/statuses_spec.rb
+++ b/spec/requests/api/v2/filters/statuses_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe 'API V2 Filters Statuses' do
     it 'returns http success' do
       get "/api/v2/filters/#{filter.id}/statuses", headers: headers
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body)
         .to contain_exactly(
           include(id: status_filter.id.to_s)
@@ -27,6 +29,8 @@ RSpec.describe 'API V2 Filters Statuses' do
       it 'returns http not found' do
         get "/api/v2/filters/#{other_filter.id}/statuses", headers: headers
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -42,6 +46,8 @@ RSpec.describe 'API V2 Filters Statuses' do
 
     it 'creates a filter', :aggregate_failures do
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
 
       expect(response.parsed_body)
         .to include(
@@ -58,6 +64,8 @@ RSpec.describe 'API V2 Filters Statuses' do
 
       it 'returns http not found' do
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -72,6 +80,8 @@ RSpec.describe 'API V2 Filters Statuses' do
 
     it 'responds with the filter', :aggregate_failures do
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
 
       expect(response.parsed_body)
         .to include(
@@ -98,6 +108,8 @@ RSpec.describe 'API V2 Filters Statuses' do
 
     it 'destroys the filter', :aggregate_failures do
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
 
       expect { status_filter.reload }.to raise_error ActiveRecord::RecordNotFound
     end
@@ -107,6 +119,8 @@ RSpec.describe 'API V2 Filters Statuses' do
 
       it 'returns http not found' do
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end

--- a/spec/requests/api/v2/filters_spec.rb
+++ b/spec/requests/api/v2/filters_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe 'Filters' do
       subject
 
       expect(response).to have_http_status(401)
+      expect(response.content_type)
+        .to start_with('application/json')
     end
   end
 
@@ -32,6 +34,8 @@ RSpec.describe 'Filters' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body.pluck(:id)).to match_array(filters.map { |filter| filter.id.to_s })
     end
   end
@@ -53,6 +57,8 @@ RSpec.describe 'Filters' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
 
         expect(response.parsed_body)
           .to include(
@@ -81,6 +87,8 @@ RSpec.describe 'Filters' do
         subject
 
         expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -91,6 +99,8 @@ RSpec.describe 'Filters' do
         subject
 
         expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -101,6 +111,8 @@ RSpec.describe 'Filters' do
         subject
 
         expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -119,6 +131,8 @@ RSpec.describe 'Filters' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body)
         .to include(
           id: filter.id.to_s
@@ -132,6 +146,8 @@ RSpec.describe 'Filters' do
         subject
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -158,6 +174,8 @@ RSpec.describe 'Filters' do
           filter.reload
 
           expect(response).to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
           expect(filter.title).to eq 'updated'
           expect(filter.reload.context).to eq %w(home public)
         end
@@ -170,6 +188,8 @@ RSpec.describe 'Filters' do
           subject
 
           expect(response).to have_http_status(422)
+          expect(response.content_type)
+            .to start_with('application/json')
         end
       end
     end
@@ -185,6 +205,8 @@ RSpec.describe 'Filters' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
 
         expect(keyword.reload.keyword).to eq 'updated'
 
@@ -199,6 +221,8 @@ RSpec.describe 'Filters' do
         subject
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -217,6 +241,8 @@ RSpec.describe 'Filters' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
 
       expect { filter.reload }.to raise_error ActiveRecord::RecordNotFound
     end
@@ -228,6 +254,8 @@ RSpec.describe 'Filters' do
         subject
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end

--- a/spec/requests/api/v2/instance_spec.rb
+++ b/spec/requests/api/v2/instance_spec.rb
@@ -15,6 +15,9 @@ RSpec.describe 'Instances' do
         expect(response)
           .to have_http_status(200)
 
+        expect(response.content_type)
+          .to start_with('application/json')
+
         expect(response.parsed_body)
           .to be_present
           .and include(title: 'Mastodon')
@@ -29,6 +32,9 @@ RSpec.describe 'Instances' do
 
         expect(response)
           .to have_http_status(200)
+
+        expect(response.content_type)
+          .to start_with('application/json')
 
         expect(response.parsed_body)
           .to be_present

--- a/spec/requests/api/v2/media_spec.rb
+++ b/spec/requests/api/v2/media_spec.rb
@@ -21,6 +21,9 @@ RSpec.describe 'Media API', :attachment_processing do
         expect(response)
           .to have_http_status(200)
 
+        expect(response.content_type)
+          .to start_with('application/json')
+
         expect(response.parsed_body)
           .to be_a(Hash)
       end
@@ -37,6 +40,9 @@ RSpec.describe 'Media API', :attachment_processing do
 
         expect(response)
           .to have_http_status(202)
+
+        expect(response.content_type)
+          .to start_with('application/json')
 
         expect(response.parsed_body)
           .to be_a(Hash)
@@ -63,6 +69,9 @@ RSpec.describe 'Media API', :attachment_processing do
           expect(response)
             .to have_http_status(422)
 
+          expect(response.content_type)
+            .to start_with('application/json')
+
           expect(response.parsed_body)
             .to be_a(Hash)
             .and include(error: /File type/)
@@ -79,6 +88,9 @@ RSpec.describe 'Media API', :attachment_processing do
 
           expect(response)
             .to have_http_status(500)
+
+          expect(response.content_type)
+            .to start_with('application/json')
 
           expect(response.parsed_body)
             .to be_a(Hash)

--- a/spec/requests/api/v2/notifications/accounts_spec.rb
+++ b/spec/requests/api/v2/notifications/accounts_spec.rb
@@ -30,6 +30,8 @@ RSpec.describe 'Accounts in grouped notifications' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
 
       # The group we are interested in is only favorites
       notifications = user.account.notifications.where(type: 'favourite').reorder(id: :desc)
@@ -55,6 +57,8 @@ RSpec.describe 'Accounts in grouped notifications' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
 
         # The group we are interested in is only favorites
         notifications = user.account.notifications.where(type: 'favourite').reorder(id: :desc)

--- a/spec/requests/api/v2/notifications/policies_spec.rb
+++ b/spec/requests/api/v2/notifications/policies_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe 'Policies' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body).to include(
           for_not_following: 'accept',
           for_not_followers: 'accept',
@@ -56,6 +58,8 @@ RSpec.describe 'Policies' do
         .and change { NotificationPolicy.find_or_initialize_by(account: user.account).for_limited_accounts.to_sym }.from(:filter).to(:drop)
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect(response.parsed_body).to include(
         for_not_following: 'filter',
         for_not_followers: 'accept',

--- a/spec/requests/api/v2/notifications_spec.rb
+++ b/spec/requests/api/v2/notifications_spec.rb
@@ -31,6 +31,8 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body[:count]).to eq 4
       end
     end
@@ -42,6 +44,8 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body[:count]).to eq 5
       end
     end
@@ -56,6 +60,8 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body[:count]).to eq 2
       end
     end
@@ -67,6 +73,8 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body[:count]).to eq 3
       end
     end
@@ -78,6 +86,8 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body[:count]).to eq 2
       end
     end
@@ -91,6 +101,8 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body[:count]).to eq Api::V2::NotificationsController::DEFAULT_NOTIFICATIONS_COUNT_LIMIT
       end
     end
@@ -125,6 +137,8 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body[:notification_groups]).to eq []
       end
     end
@@ -134,6 +148,8 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(body_json_types).to include('reblog', 'mention', 'favourite', 'follow')
       end
     end
@@ -145,6 +161,8 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body[:notification_groups]).to contain_exactly(
           a_hash_including(
             type: 'reblog',
@@ -177,6 +195,8 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body.size).to_not eq 0
         expect(body_json_types.uniq).to_not include 'mention'
       end
@@ -189,6 +209,8 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(body_json_types.uniq).to eq ['mention']
         expect(response.parsed_body.dig(:notification_groups, 0, :page_min_id)).to_not be_nil
       end
@@ -211,6 +233,8 @@ RSpec.describe 'Notifications' do
             # not the last that has been skipped, so pagination is very likely to give overlap
             next: api_v2_notifications_url(limit: params[:limit], max_id: notifications[3].id)
           )
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -224,6 +248,8 @@ RSpec.describe 'Notifications' do
         expect(response.parsed_body[:notification_groups].size)
           .to eq(2)
 
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response)
           .to include_pagination_headers(
             prev: api_v2_notifications_url(limit: params[:limit], min_id: notifications.first.id),
@@ -247,6 +273,8 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
         expect(response.parsed_body[:partial_accounts].size).to be > 0
         expect(response.parsed_body[:partial_accounts][0].keys.map(&:to_sym)).to contain_exactly(:acct, :avatar, :avatar_static, :bot, :id, :locked, :url)
         expect(response.parsed_body[:partial_accounts].pluck(:id)).to_not include(recent_account.id.to_s)
@@ -261,6 +289,8 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(400)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -282,6 +312,8 @@ RSpec.describe 'Notifications' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
     end
 
     context 'when notification belongs to someone else' do
@@ -291,6 +323,8 @@ RSpec.describe 'Notifications' do
         subject
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -308,6 +342,8 @@ RSpec.describe 'Notifications' do
       subject
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
       expect { notification.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
@@ -338,6 +374,8 @@ RSpec.describe 'Notifications' do
 
       expect(user.account.reload.notifications).to be_empty
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
     end
   end
 end

--- a/spec/requests/api/v2/search_spec.rb
+++ b/spec/requests/api/v2/search_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe 'Search API' do
         get '/api/v2/search', headers: headers, params: params
 
         expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
 
       context 'when searching accounts' do
@@ -37,6 +39,8 @@ RSpec.describe 'Search API' do
             get '/api/v2/search', headers: headers, params: params
 
             expect(response).to have_http_status(200)
+            expect(response.content_type)
+              .to start_with('application/json')
           end
         end
 
@@ -47,6 +51,8 @@ RSpec.describe 'Search API' do
             get '/api/v2/search', headers: headers, params: params
 
             expect(response).to have_http_status(200)
+            expect(response.content_type)
+              .to start_with('application/json')
           end
         end
 
@@ -57,6 +63,8 @@ RSpec.describe 'Search API' do
             get '/api/v2/search', headers: headers, params: params
 
             expect(response).to have_http_status(400)
+            expect(response.content_type)
+              .to start_with('application/json')
           end
         end
 
@@ -67,6 +75,8 @@ RSpec.describe 'Search API' do
             get '/api/v2/search', headers: headers, params: params
 
             expect(response).to have_http_status(400)
+            expect(response.content_type)
+              .to start_with('application/json')
           end
         end
 
@@ -92,6 +102,8 @@ RSpec.describe 'Search API' do
           get '/api/v2/search', headers: headers, params: params
 
           expect(response).to have_http_status(422)
+          expect(response.content_type)
+            .to start_with('application/json')
         end
       end
 
@@ -102,6 +114,8 @@ RSpec.describe 'Search API' do
           get '/api/v2/search', headers: headers, params: params
 
           expect(response).to have_http_status(404)
+          expect(response.content_type)
+            .to start_with('application/json')
         end
       end
     end
@@ -118,6 +132,8 @@ RSpec.describe 'Search API' do
       context 'without a `q` param' do
         it 'returns http bad_request' do
           expect(response).to have_http_status(400)
+          expect(response.content_type)
+            .to start_with('application/json')
         end
       end
 
@@ -126,6 +142,8 @@ RSpec.describe 'Search API' do
 
         it 'returns http success' do
           expect(response).to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
         end
       end
 
@@ -134,6 +152,8 @@ RSpec.describe 'Search API' do
 
         it 'returns http success' do
           expect(response).to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
         end
 
         context 'with truthy `resolve`' do
@@ -141,6 +161,8 @@ RSpec.describe 'Search API' do
 
           it 'returns http unauthorized' do
             expect(response).to have_http_status(401)
+            expect(response.content_type)
+              .to start_with('application/json')
             expect(response.body).to match('resolve remote resources')
           end
         end
@@ -150,6 +172,8 @@ RSpec.describe 'Search API' do
 
           it 'returns http unauthorized' do
             expect(response).to have_http_status(401)
+            expect(response.content_type)
+              .to start_with('application/json')
             expect(response.body).to match('pagination is not supported')
           end
         end

--- a/spec/requests/api/v2/suggestions_spec.rb
+++ b/spec/requests/api/v2/suggestions_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe 'Suggestions API' do
       get '/api/v2/suggestions', headers: headers
 
       expect(response).to have_http_status(200)
+      expect(response.content_type)
+        .to start_with('application/json')
 
       expect(response.parsed_body).to match_array(
         [bob, jeff].map do |account|

--- a/spec/requests/api/web/embeds_spec.rb
+++ b/spec/requests/api/web/embeds_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe '/api/web/embed' do
           subject
 
           expect(response).to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
           expect(response.parsed_body[:html]).to be_present
         end
       end
@@ -29,6 +31,8 @@ RSpec.describe '/api/web/embed' do
           subject
 
           expect(response).to have_http_status(404)
+          expect(response.content_type)
+            .to start_with('application/json')
         end
       end
     end
@@ -42,6 +46,8 @@ RSpec.describe '/api/web/embed' do
         subject
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -52,6 +58,8 @@ RSpec.describe '/api/web/embed' do
         subject
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end
@@ -71,6 +79,8 @@ RSpec.describe '/api/web/embed' do
           subject
 
           expect(response).to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
           expect(response.parsed_body[:html]).to be_present
         end
 
@@ -83,6 +93,8 @@ RSpec.describe '/api/web/embed' do
             subject
 
             expect(response).to have_http_status(404)
+            expect(response.content_type)
+              .to start_with('application/json')
           end
         end
       end
@@ -98,6 +110,8 @@ RSpec.describe '/api/web/embed' do
           subject
 
           expect(response).to have_http_status(404)
+          expect(response.content_type)
+            .to start_with('application/json')
         end
       end
     end
@@ -123,6 +137,8 @@ RSpec.describe '/api/web/embed' do
           subject
 
           expect(response).to have_http_status(404)
+          expect(response.content_type)
+            .to start_with('application/json')
         end
       end
 
@@ -133,6 +149,8 @@ RSpec.describe '/api/web/embed' do
           subject
 
           expect(response).to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
           expect(response.parsed_body[:html]).to be_present
         end
       end
@@ -146,6 +164,8 @@ RSpec.describe '/api/web/embed' do
           subject
 
           expect(response).to have_http_status(404)
+          expect(response.content_type)
+            .to start_with('application/json')
         end
       end
 
@@ -156,6 +176,8 @@ RSpec.describe '/api/web/embed' do
           subject
 
           expect(response).to have_http_status(404)
+          expect(response.content_type)
+            .to start_with('application/json')
         end
       end
     end
@@ -167,6 +189,8 @@ RSpec.describe '/api/web/embed' do
         subject
 
         expect(response).to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end

--- a/spec/requests/api/web/settings_spec.rb
+++ b/spec/requests/api/web/settings_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe '/api/web/settings' do
 
         expect(response)
           .to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 
@@ -29,6 +31,8 @@ RSpec.describe '/api/web/settings' do
 
         expect(response)
           .to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
 


### PR DESCRIPTION
Same as https://github.com/mastodon/mastodon/pull/31981 but for other area.

Only issue seen in this one was -- in the notifications spec when checking `dismiss` for a notification that belongs to someone else, we get a text/html 404 back. I may look at this further b/c I don't totally understand why it's different from other spots where we catch errors and render json.

