### PR TITLE
Fix search params being dropped when redirected to non-deck path

### DIFF
--- a/app/controllers/concerns/web_app_controller_concern.rb
+++ b/app/controllers/concerns/web_app_controller_concern.rb
@@ -31,7 +31,7 @@ module WebAppControllerConcern
   def redirect_unauthenticated_to_permalinks!
     return if user_signed_in? && current_account.moved_to_account_id.nil?
 
-    permalink_redirector = PermalinkRedirector.new(request.path)
+    permalink_redirector = PermalinkRedirector.new(request.original_fullpath)
     return if permalink_redirector.redirect_path.blank?
 
     expires_in(15.seconds, public: true, stale_while_revalidate: 30.seconds, stale_if_error: 1.day) unless user_signed_in?

--- a/app/javascript/mastodon/features/ui/index.jsx
+++ b/app/javascript/mastodon/features/ui/index.jsx
@@ -186,7 +186,7 @@ class SwitchingColumnsArea extends PureComponent {
             {redirect}
 
             {singleColumn ? <Redirect from='/deck' to='/home' exact /> : null}
-            {singleColumn && pathName.startsWith('/deck/') ? <Redirect from={pathName} to={pathName.slice(5)} /> : null}
+            {singleColumn && pathName.startsWith('/deck/') ? <Redirect from={pathName} to={{...this.props.location, pathname: pathName.slice(5)}} /> : null}
             {/* Redirect old bookmarks (without /deck) with home-like routes to the advanced interface */}
             {!singleColumn && pathName === '/getting-started' ? <Redirect from='/getting-started' to='/deck/getting-started' exact /> : null}
             {!singleColumn && pathName === '/home' ? <Redirect from='/home' to='/deck/getting-started' exact /> : null}

--- a/app/lib/permalink_redirector.rb
+++ b/app/lib/permalink_redirector.rb
@@ -83,6 +83,6 @@ class PermalinkRedirector
   end
 
   def path_segments
-    @path_segments ||= @path.delete_prefix('/deck').delete_prefix('/').split('/')
+    @path_segments ||= @path.split('?')[0].delete_prefix('/deck').delete_prefix('/').split('/')
   end
 end

--- a/spec/lib/permalink_redirector_spec.rb
+++ b/spec/lib/permalink_redirector_spec.rb
@@ -29,5 +29,20 @@ RSpec.describe PermalinkRedirector do
       redirector = described_class.new('@alice/123')
       expect(redirector.redirect_path).to eq 'https://example.com/status-123'
     end
+
+    it 'returns path for legacy status links with a query param' do
+      redirector = described_class.new('statuses/123?foo=bar')
+      expect(redirector.redirect_path).to eq 'https://example.com/status-123'
+    end
+
+    it 'returns path for pretty status links with a query param' do
+      redirector = described_class.new('@alice/123?foo=bar')
+      expect(redirector.redirect_path).to eq 'https://example.com/status-123'
+    end
+
+    it 'returns path for deck URLs with query params' do
+      redirector = described_class.new('/deck/directory?local=true')
+      expect(redirector.redirect_path).to eq '/directory?local=true'
+    end
   end
 end


### PR DESCRIPTION
For example `http://localhost:3000/deck/directory?order=active&local=false` to `http://localhost:3000/directory?order=active&local=false`

This works when you are logged-in but do not have the advanced interface enabled.

When you are logged out the redirect is done by Rails (in `PermalinkRedirector`) and the query string is not kept, I am not sure how to fix it.