### PR TITLE
Capture actual behavior in v2/notifications "someone else" dismiss scenario

### DIFF
--- a/spec/requests/api/v2/notifications_spec.rb
+++ b/spec/requests/api/v2/notifications_spec.rb
@@ -312,12 +312,15 @@ RSpec.describe 'Notifications' do
     end
 
     context 'when notification belongs to someone else' do
-      let(:notification) { Fabricate(:notification) }
+      let(:notification) { Fabricate(:notification, group_key: 'foobar') }
 
-      it 'returns http not found' do
-        subject
+      it 'leaves the notification alone' do
+        expect { subject }
+          .to_not change(Notification, :count)
 
-        expect(response).to have_http_status(404)
+        expect(response).to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
       end
     end
   end


### PR DESCRIPTION
Mentioned/noticed in https://github.com/mastodon/mastodon/pull/31983#issue-2536688849

The action here - https://github.com/mastodon/mastodon/blob/v4.3.0-beta.2/app/controllers/api/v2/notifications_controller.rb#L59-L62 - is going to attempt to delete any matching notifications for the user, but as currently written does not check to make sure there actually are any first, and will succeed (either deleting some or not) either way, and return 200.

If I understand what's happening here, I think the spec here was passing because the `group_key` was missing so we were getting a 404 from the routing layer, not from hitting the action.

If we do want to enforce the "return 404 when user does not have any notifications with the group key", we'd need to either add a callback or change the action logic.