### PR TITLE
Add `reviewed` and `unreviewed` scopes to `Reviewable` model concern

### DIFF
--- a/app/models/concerns/reviewable.rb
+++ b/app/models/concerns/reviewable.rb
@@ -5,6 +5,7 @@ module Reviewable
 
   included do
     scope :reviewed, -> { where.not(reviewed_at: nil) }
+    scope :unreviewed, -> { where(reviewed_at: nil) }
   end
 
   def requires_review?

--- a/app/models/concerns/reviewable.rb
+++ b/app/models/concerns/reviewable.rb
@@ -3,6 +3,10 @@
 module Reviewable
   extend ActiveSupport::Concern
 
+  included do
+    scope :reviewed, -> { where.not(reviewed_at: nil) }
+  end
+
   def requires_review?
     reviewed_at.nil?
   end

--- a/app/models/preview_card_provider.rb
+++ b/app/models/preview_card_provider.rb
@@ -34,7 +34,6 @@ class PreviewCardProvider < ApplicationRecord
 
   scope :trendable, -> { where(trendable: true) }
   scope :not_trendable, -> { where(trendable: false) }
-  scope :reviewed, -> { where.not(reviewed_at: nil) }
   scope :pending_review, -> { where(reviewed_at: nil) }
 
   def self.matching_domain(domain)

--- a/app/models/preview_card_provider.rb
+++ b/app/models/preview_card_provider.rb
@@ -34,7 +34,6 @@ class PreviewCardProvider < ApplicationRecord
 
   scope :trendable, -> { where(trendable: true) }
   scope :not_trendable, -> { where(trendable: false) }
-  scope :pending_review, -> { where(reviewed_at: nil) }
 
   def self.matching_domain(domain)
     segments = domain.split('.')

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -50,7 +50,6 @@ class Tag < ApplicationRecord
   validate :validate_name_change, if: -> { !new_record? && name_changed? }
   validate :validate_display_name_change, if: -> { !new_record? && display_name_changed? }
 
-  scope :reviewed, -> { where.not(reviewed_at: nil) }
   scope :unreviewed, -> { where(reviewed_at: nil) }
   scope :pending_review, -> { unreviewed.where.not(requested_review_at: nil) }
   scope :usable, -> { where(usable: [true, nil]) }

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -125,7 +125,7 @@ class Tag < ApplicationRecord
 
       query = Tag.matches_name(stripped_term)
       query = query.merge(Tag.listable) if options[:exclude_unlistable]
-      query = query.merge(matching_name(stripped_term).or(where.not(reviewed_at: nil))) if options[:exclude_unreviewed]
+      query = query.merge(matching_name(stripped_term).or(reviewed)) if options[:exclude_unreviewed]
 
       query.order(Arel.sql('length(name) ASC, name ASC'))
            .limit(limit)

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -50,7 +50,6 @@ class Tag < ApplicationRecord
   validate :validate_name_change, if: -> { !new_record? && name_changed? }
   validate :validate_display_name_change, if: -> { !new_record? && display_name_changed? }
 
-  scope :unreviewed, -> { where(reviewed_at: nil) }
   scope :pending_review, -> { unreviewed.where.not(requested_review_at: nil) }
   scope :usable, -> { where(usable: [true, nil]) }
   scope :not_usable, -> { where(usable: false) }

--- a/app/models/trends/preview_card_provider_filter.rb
+++ b/app/models/trends/preview_card_provider_filter.rb
@@ -41,7 +41,7 @@ class Trends::PreviewCardProviderFilter
     when 'rejected'
       PreviewCardProvider.not_trendable
     when 'pending_review'
-      PreviewCardProvider.pending_review
+      PreviewCardProvider.unreviewed
     else
       raise Mastodon::InvalidParameterError, "Unknown status: #{value}"
     end

--- a/app/views/admin/trends/links/preview_card_providers/index.html.haml
+++ b/app/views/admin/trends/links/preview_card_providers/index.html.haml
@@ -12,7 +12,7 @@
       %li= filter_link_to t('generic.all'), status: nil
       %li= filter_link_to t('admin.trends.approved'), status: 'approved'
       %li= filter_link_to t('admin.trends.rejected'), status: 'rejected'
-      %li= filter_link_to safe_join([t('admin.accounts.moderation.pending'), "(#{PreviewCardProvider.pending_review.count})"], ' '), status: 'pending_review'
+      %li= filter_link_to safe_join([t('admin.accounts.moderation.pending'), "(#{PreviewCardProvider.unreviewed.count})"], ' '), status: 'pending_review'
   .back-link
     = link_to admin_trends_links_path do
       = material_symbol 'chevron_left'

--- a/spec/models/preview_card_provider_spec.rb
+++ b/spec/models/preview_card_provider_spec.rb
@@ -24,21 +24,5 @@ RSpec.describe PreviewCardProvider do
         expect(results).to eq([not_trendable_and_not_reviewed])
       end
     end
-
-    describe 'reviewed' do
-      it 'returns the relevant records' do
-        results = described_class.reviewed
-
-        expect(results).to eq([trendable_and_reviewed])
-      end
-    end
-
-    describe 'pending_review' do
-      it 'returns the relevant records' do
-        results = described_class.pending_review
-
-        expect(results).to eq([not_trendable_and_not_reviewed])
-      end
-    end
   end
 end

--- a/spec/support/examples/models/concerns/reviewable.rb
+++ b/spec/support/examples/models/concerns/reviewable.rb
@@ -6,18 +6,28 @@ RSpec.shared_examples 'Reviewable' do
   let(:reviewed_at) { nil }
   let(:requested_review_at) { nil }
 
-  describe '.reviewed' do
-    it 'returns reviewed records' do
-      reviewed_record = Fabricate factory_name, reviewed_at: 10.days.ago
-      un_reviewed_record = Fabricate factory_name, reviewed_at: nil
+  describe 'Scopes' do
+    let!(:reviewed_record) { Fabricate factory_name, reviewed_at: 10.days.ago }
+    let!(:un_reviewed_record) { Fabricate factory_name, reviewed_at: nil }
 
-      expect(described_class.reviewed)
-        .to include(reviewed_record)
-        .and not_include(un_reviewed_record)
+    describe '.reviewed' do
+      it 'returns reviewed records' do
+        expect(described_class.reviewed)
+          .to include(reviewed_record)
+          .and not_include(un_reviewed_record)
+      end
+    end
+
+    describe '.unreviewed' do
+      it 'returns non reviewed records' do
+        expect(described_class.unreviewed)
+          .to include(un_reviewed_record)
+          .and not_include(reviewed_record)
+      end
     end
 
     def factory_name
-      described_class.name.downcase.to_sym
+      described_class.name.underscore.to_sym
     end
   end
 

--- a/spec/support/examples/models/concerns/reviewable.rb
+++ b/spec/support/examples/models/concerns/reviewable.rb
@@ -6,6 +6,21 @@ RSpec.shared_examples 'Reviewable' do
   let(:reviewed_at) { nil }
   let(:requested_review_at) { nil }
 
+  describe '.reviewed' do
+    it 'returns reviewed records' do
+      reviewed_record = Fabricate factory_name, reviewed_at: 10.days.ago
+      un_reviewed_record = Fabricate factory_name, reviewed_at: nil
+
+      expect(described_class.reviewed)
+        .to include(reviewed_record)
+        .and not_include(un_reviewed_record)
+    end
+
+    def factory_name
+      described_class.name.downcase.to_sym
+    end
+  end
+
   describe '#requires_review?' do
     it { is_expected.to be_requires_review }
 


### PR DESCRIPTION
On the last episode of "oh look I found a model concern" (https://github.com/mastodon/mastodon/pull/31152) we were able to extract `Reviewable` and pull out some shared methods for models with `reviewed_at` columns and similar logic.

Now, as the prophecy foretold, let's pull out some scopes too.