### PR TITLE
Move default embed size knowledge into `OEmbedSerializer`

### DIFF
--- a/app/controllers/api/oembed_controller.rb
+++ b/app/controllers/api/oembed_controller.rb
@@ -7,7 +7,7 @@ class Api::OEmbedController < Api::BaseController
   before_action :require_public_status!
 
   def show
-    render json: @status, serializer: OEmbedSerializer, width: maxwidth_or_default, height: maxheight_or_default
+    render json: @status, serializer: OEmbedSerializer, width: params[:maxwidth], height: params[:maxheight]
   end
 
   private
@@ -22,13 +22,5 @@ class Api::OEmbedController < Api::BaseController
 
   def status_finder
     StatusFinder.new(params[:url])
-  end
-
-  def maxwidth_or_default
-    (params[:maxwidth].presence || 400).to_i
-  end
-
-  def maxheight_or_default
-    params[:maxheight].present? ? params[:maxheight].to_i : nil
   end
 end

--- a/app/controllers/api/web/embeds_controller.rb
+++ b/app/controllers/api/web/embeds_controller.rb
@@ -9,7 +9,7 @@ class Api::Web::EmbedsController < Api::Web::BaseController
     return not_found if @status.hidden?
 
     if @status.local?
-      render json: @status, serializer: OEmbedSerializer, width: 400
+      render json: @status, serializer: OEmbedSerializer
     else
       return not_found unless user_signed_in?
 

--- a/app/serializers/oembed_serializer.rb
+++ b/app/serializers/oembed_serializer.rb
@@ -63,6 +63,6 @@ class OEmbedSerializer < ActiveModel::Serializer
   end
 
   def height
-    Array.new(instance_options[:height].to_i).detect(&:positive?)
+    instance_options[:height].presence&.to_i
   end
 end

--- a/app/serializers/oembed_serializer.rb
+++ b/app/serializers/oembed_serializer.rb
@@ -8,6 +8,8 @@ class OEmbedSerializer < ActiveModel::Serializer
     div1: 'font-weight: 500;',
   }.freeze
 
+  DEFAULT_WIDTH = 400
+
   include RoutingHelper
   include ActionView::Helpers::TagHelper
 
@@ -57,10 +59,10 @@ class OEmbedSerializer < ActiveModel::Serializer
   end
 
   def width
-    instance_options[:width]
+    (instance_options[:width] || DEFAULT_WIDTH).to_i
   end
 
   def height
-    instance_options[:height]
+    Array.new(instance_options[:height].to_i).detect(&:positive?)
   end
 end


### PR DESCRIPTION
Both of `api/oembed` and `api/web/oembed` call this serializer and pass in the same value for a default width. Seems like "what is the default width" is more owned by the serializer itself than the controllers which call it? Thus, changes:

- Move the 400 value into a constant in the serializer
- Both controllers still attempt to pass in their values to override where relevant
- The "use param or 400 and convert to_i" logic on width is preserved
- The "use param or leave as nil/unspecified" logic on height is preserved