### PR TITLE
Use heredoc/squish for inline css styles in oembed serializer

### DIFF
--- a/app/serializers/oembed_serializer.rb
+++ b/app/serializers/oembed_serializer.rb
@@ -2,10 +2,36 @@
 
 class OEmbedSerializer < ActiveModel::Serializer
   INLINE_STYLES = {
-    blockquote: 'max-width: 540px; min-width: 270px; background:#FCF8FF; border: 1px solid #C9C4DA; border-radius: 8px; overflow: hidden; margin: 0; padding: 0;',
-    a: "color: #1C1A25; text-decoration: none; display: flex; align-items: center; justify-content: center; flex-direction: column; padding: 24px; font-size: 14px; line-height: 20px; letter-spacing: 0.25px; font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Oxygen, Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans', 'Helvetica Neue', Roboto, sans-serif;", # rubocop:disable Layout/LineLength
-    div0: 'margin-top: 16px; color: #787588;',
-    div1: 'font-weight: 500;',
+    blockquote: <<~STYLES.squish,
+      background: #FCF8FF;
+      border-radius: 8px;
+      border: 1px solid #C9C4DA;
+      margin: 0;
+      max-width: 540px;
+      min-width: 270px;
+      overflow: hidden;
+      padding: 0;
+    STYLES
+    status_link: <<~STYLES.squish,
+      align-items: center;
+      color: #1C1A25;
+      display: flex;
+      flex-direction: column;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Oxygen, Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans', 'Helvetica Neue', Roboto, sans-serif;
+      font-size: 14px;
+      justify-content: center;
+      letter-spacing: 0.25px;
+      line-height: 20px;
+      padding: 24px;
+      text-decoration: none;
+    STYLES
+    div_account: <<~STYLES.squish,
+      color: #787588;
+      margin-top: 16px;
+    STYLES
+    div_view: <<~STYLES.squish,
+      font-weight: 500;
+    STYLES
   }.freeze
 
   include RoutingHelper
@@ -46,10 +72,10 @@ class OEmbedSerializer < ActiveModel::Serializer
   def html
     <<~HTML.squish
       <blockquote class="mastodon-embed" data-embed-url="#{embed_short_account_status_url(object.account, object)}" style="#{INLINE_STYLES[:blockquote]}">
-        <a href="#{short_account_status_url(object.account, object)}" target="_blank" style="#{INLINE_STYLES[:a]}">
+        <a href="#{short_account_status_url(object.account, object)}" target="_blank" style="#{INLINE_STYLES[:status_link]}">
           <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="32" height="32" viewBox="0 0 79 75"><path d="M74.7135 16.6043C73.6199 8.54587 66.5351 2.19527 58.1366 0.964691C56.7196 0.756754 51.351 0 38.9148 0H38.822C26.3824 0 23.7135 0.756754 22.2966 0.964691C14.1319 2.16118 6.67571 7.86752 4.86669 16.0214C3.99657 20.0369 3.90371 24.4888 4.06535 28.5726C4.29578 34.4289 4.34049 40.275 4.877 46.1075C5.24791 49.9817 5.89495 53.8251 6.81328 57.6088C8.53288 64.5968 15.4938 70.4122 22.3138 72.7848C29.6155 75.259 37.468 75.6697 44.9919 73.971C45.8196 73.7801 46.6381 73.5586 47.4475 73.3063C49.2737 72.7302 51.4164 72.086 52.9915 70.9542C53.0131 70.9384 53.0308 70.9178 53.0433 70.8942C53.0558 70.8706 53.0628 70.8445 53.0637 70.8179V65.1661C53.0634 65.1412 53.0574 65.1167 53.0462 65.0944C53.035 65.0721 53.0189 65.0525 52.9992 65.0371C52.9794 65.0218 52.9564 65.011 52.9318 65.0056C52.9073 65.0002 52.8819 65.0003 52.8574 65.0059C48.0369 66.1472 43.0971 66.7193 38.141 66.7103C29.6118 66.7103 27.3178 62.6981 26.6609 61.0278C26.1329 59.5842 25.7976 58.0784 25.6636 56.5486C25.6622 56.5229 25.667 56.4973 25.6775 56.4738C25.688 56.4502 25.7039 56.4295 25.724 56.4132C25.7441 56.397 25.7678 56.3856 25.7931 56.3801C25.8185 56.3746 25.8448 56.3751 25.8699 56.3816C30.6101 57.5151 35.4693 58.0873 40.3455 58.086C41.5183 58.086 42.6876 58.086 43.8604 58.0553C48.7647 57.919 53.9339 57.6701 58.7591 56.7361C58.8794 56.7123 58.9998 56.6918 59.103 56.6611C66.7139 55.2124 73.9569 50.665 74.6929 39.1501C74.7204 38.6967 74.7892 34.4016 74.7892 33.9312C74.7926 32.3325 75.3085 22.5901 74.7135 16.6043ZM62.9996 45.3371H54.9966V25.9069C54.9966 21.8163 53.277 19.7302 49.7793 19.7302C45.9343 19.7302 44.0083 22.1981 44.0083 27.0727V37.7082H36.0534V27.0727C36.0534 22.1981 34.124 19.7302 30.279 19.7302C26.8019 19.7302 25.0651 21.8163 25.0617 25.9069V45.3371H17.0656V25.3172C17.0656 21.2266 18.1191 17.9769 20.2262 15.568C22.3998 13.1648 25.2509 11.9308 28.7898 11.9308C32.8859 11.9308 35.9812 13.492 38.0447 16.6111L40.036 19.9245L42.0308 16.6111C44.0943 13.492 47.1896 11.9308 51.2788 11.9308C54.8143 11.9308 57.6654 13.1648 59.8459 15.568C61.9529 17.9746 63.0065 21.2243 63.0065 25.3172L62.9996 45.3371Z" fill="currentColor"/></svg>
-          <div style="#{INLINE_STYLES[:div0]}">Post by @#{object.account.pretty_acct}@#{provider_name}</div>
-          <div style="#{INLINE_STYLES[:div1]}">View on Mastodon</div>
+          <div style="#{INLINE_STYLES[:div_account]}">Post by @#{object.account.pretty_acct}@#{provider_name}</div>
+          <div style="#{INLINE_STYLES[:div_view]}">View on Mastodon</div>
         </a>
       </blockquote>
       <script data-allowed-prefixes="#{root_url}" async src="#{full_asset_url('embed.js', skip_pipeline: true)}"></script>

--- a/app/serializers/oembed_serializer.rb
+++ b/app/serializers/oembed_serializer.rb
@@ -2,7 +2,7 @@
 
 class OEmbedSerializer < ActiveModel::Serializer
   INLINE_STYLES = {
-    blockquote: <<~STYLES.squish,
+    blockquote: <<~CSS.squish,
       background: #FCF8FF;
       border-radius: 8px;
       border: 1px solid #C9C4DA;
@@ -11,8 +11,8 @@ class OEmbedSerializer < ActiveModel::Serializer
       min-width: 270px;
       overflow: hidden;
       padding: 0;
-    STYLES
-    status_link: <<~STYLES.squish,
+    CSS
+    status_link: <<~CSS.squish,
       align-items: center;
       color: #1C1A25;
       display: flex;
@@ -24,14 +24,14 @@ class OEmbedSerializer < ActiveModel::Serializer
       line-height: 20px;
       padding: 24px;
       text-decoration: none;
-    STYLES
-    div_account: <<~STYLES.squish,
+    CSS
+    div_account: <<~CSS.squish,
       color: #787588;
       margin-top: 16px;
-    STYLES
-    div_view: <<~STYLES.squish,
+    CSS
+    div_view: <<~CSS.squish,
       font-weight: 500;
-    STYLES
+    CSS
   }.freeze
 
   include RoutingHelper


### PR DESCRIPTION
Noticed this while looking at https://github.com/mastodon/mastodon/pull/31990

The main change here is to pull these out to a heredoc'd/squish'd arrangement to make for slightly easier "css editing" if/when these need to be changed. Tried to improve the hash keys a bit while in there.

As a fun side project, I discovered some what I think is broken CSS/heredoc/hash syntax highlighting bugs in my editor, which I'll report to the relevant local authorities.