### PR TITLE
Change Mastodon to issue correctly-signed queries by default

### DIFF
--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -77,7 +77,7 @@ class Request
     @url         = Addressable::URI.parse(url).normalize
     @http_client = options.delete(:http_client)
     @allow_local = options.delete(:allow_local)
-    @full_path   = options.delete(:with_query_string)
+    @full_path   = !options.delete(:omit_query_string)
     @options     = options.merge(socket_class: use_proxy? || @allow_local ? ProxySocket : Socket)
     @options     = @options.merge(timeout_class: PerOperationWithDeadline, timeout_options: TIMEOUT)
     @options     = @options.merge(proxy_url) if use_proxy?

--- a/app/services/activitypub/fetch_replies_service.rb
+++ b/app/services/activitypub/fetch_replies_service.rb
@@ -49,7 +49,7 @@ class ActivityPub::FetchRepliesService < BaseService
     rescue Mastodon::UnexpectedResponseError => e
       raise unless e.response && e.response.code == 401 && Addressable::URI.parse(collection_or_uri).query.present?
 
-      fetch_resource_without_id_validation(collection_or_uri, nil, true, request_options: { with_query_string: true })
+      fetch_resource_without_id_validation(collection_or_uri, nil, true, request_options: { omit_query_string: false })
     end
   end
 


### PR DESCRIPTION
Mastodon had a quirk in HTTP signing and verification and had incorrect behavior when querystrings were involved.

Support for correctly-signed requests was added in v4.1.11 and v4.2.10, which were released a little over 6 months ago.

I think the next step in phasing out the incorrect signatures is, as in this PR, changing the default behavior to use the correct signatures, and having the incorrect signatures as a fallback.

An ulterior step would be to completely disable incorrect signatures, but this would have important compatibility implications, so I'd defer that to a later release.