### PR TITLE
Match ruby version in lockfile to version in `.ruby-version`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1057,7 +1057,7 @@ DEPENDENCIES
   xorcist (~> 1.1)
 
 RUBY VERSION
-   ruby 3.3.4p94
+   ruby 3.3.5p100
 
 BUNDLED WITH
    2.5.18

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1060,4 +1060,4 @@ RUBY VERSION
    ruby 3.3.5p100
 
 BUNDLED WITH
-   2.5.18
+   2.5.19

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1060,4 +1060,4 @@ RUBY VERSION
    ruby 3.3.5p100
 
 BUNDLED WITH
-   2.5.21
+   2.5.22

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1060,4 +1060,4 @@ RUBY VERSION
    ruby 3.3.5p100
 
 BUNDLED WITH
-   2.5.19
+   2.5.21


### PR DESCRIPTION
I don't know if we can configure renovate to do this update as well when it bumps the `.ruby-version` ?