### PR TITLE
Fix dashboard quick access button text spilling over if too long to fit

### DIFF
--- a/app/javascript/styles/mastodon/dashboard.scss
+++ b/app/javascript/styles/mastodon/dashboard.scss
@@ -91,6 +91,7 @@
     height: 36px;
     text-decoration: none;
     margin-bottom: 4px;
+    white-space: nowrap;
 
     &:active,
     &:focus,
@@ -111,6 +112,8 @@
 
     span {
       flex: 1 1 auto;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
 
     strong {


### PR DESCRIPTION
Fixes https://github.com/mastodon/mastodon/issues/31976