### PR TITLE
Feature more otel customization

### DIFF
--- a/config/initializers/opentelemetry.rb
+++ b/config/initializers/opentelemetry.rb
@@ -56,7 +56,7 @@ if ENV.keys.any? { |name| name.match?(/OTEL_.*_ENDPOINT/) }
       },
     })
 
-    prefix = ENV.fetch('OTEL_SERVICE_NAME_PREFIX', 'mastodon')
+    prefix    = ENV.fetch('OTEL_SERVICE_NAME_PREFIX', 'mastodon')
     separator = ENV.fetch('OTEL_SERVICE_NAME_SEPARATOR', '/')
 
     c.service_name =  case $PROGRAM_NAME

--- a/config/initializers/opentelemetry.rb
+++ b/config/initializers/opentelemetry.rb
@@ -57,11 +57,12 @@ if ENV.keys.any? { |name| name.match?(/OTEL_.*_ENDPOINT/) }
     })
 
     prefix = ENV.fetch('OTEL_SERVICE_NAME_PREFIX', 'mastodon')
+    separator = ENV.fetch('OTEL_SERVICE_NAME_SEPARATOR', '/')
 
     c.service_name =  case $PROGRAM_NAME
-                      when /puma/ then "#{prefix}/web"
+                      when /puma/ then "#{prefix}#{separator}web"
                       else
-                        "#{prefix}/#{$PROGRAM_NAME.split('/').last}"
+                        "#{prefix}#{separator}#{$PROGRAM_NAME.split('/').last}"
                       end
     c.service_version = Mastodon::Version.to_s
   end


### PR DESCRIPTION
When dealing with service names, especially in kubernetes, the forward slash (`/`) isn't friendly when creating labels and annotations, which is why all other services use dashes (`-`) as their separator (`joinmastodon-api`, `webpush-fcm-relay`, etc) in our internal service catalog.

This basically just allows setting the service name separator for web and sidekiq services to something other than a dash via the `OTEL_SERVICE_NAME_SEPARATOR` environment variable.

Related documentation PR: https://github.com/mastodon/documentation/pull/1534