### PR TITLE
Add `response_avatar_link` helper to webfinger request spec

### DIFF
--- a/spec/requests/well_known/webfinger_spec.rb
+++ b/spec/requests/well_known/webfinger_spec.rb
@@ -168,10 +168,12 @@ RSpec.describe 'The /.well-known/webfinger endpoint' do
     it 'returns avatar in response' do
       perform_request!
 
-      avatar_link = get_avatar_link(response.parsed_body)
-      expect(avatar_link).to_not be_nil
-      expect(avatar_link[:type]).to eq alice.avatar.content_type
-      expect(avatar_link[:href]).to eq Addressable::URI.new(host: Rails.configuration.x.local_domain, path: alice.avatar.to_s, scheme: 'https').to_s
+      expect(response_avatar_link)
+        .to be_present
+        .and include(
+          type: eq(alice.avatar.content_type),
+          href: eq(Addressable::URI.new(host: Rails.configuration.x.local_domain, path: alice.avatar.to_s, scheme: 'https').to_s)
+        )
     end
 
     context 'with limited federation mode' do
@@ -182,8 +184,8 @@ RSpec.describe 'The /.well-known/webfinger endpoint' do
       it 'does not return avatar in response' do
         perform_request!
 
-        avatar_link = get_avatar_link(response.parsed_body)
-        expect(avatar_link).to be_nil
+        expect(response_avatar_link)
+          .to be_nil
       end
     end
 
@@ -197,8 +199,8 @@ RSpec.describe 'The /.well-known/webfinger endpoint' do
       it 'does not return avatar in response' do
         perform_request!
 
-        avatar_link = get_avatar_link(response.parsed_body)
-        expect(avatar_link).to be_nil
+        expect(response_avatar_link)
+          .to be_nil
       end
     end
   end
@@ -212,8 +214,8 @@ RSpec.describe 'The /.well-known/webfinger endpoint' do
     end
 
     it 'does not return avatar in response' do
-      avatar_link = get_avatar_link(response.parsed_body)
-      expect(avatar_link).to be_nil
+      expect(response_avatar_link)
+        .to be_nil
     end
   end
 
@@ -247,7 +249,9 @@ RSpec.describe 'The /.well-known/webfinger endpoint' do
 
   private
 
-  def get_avatar_link(json)
-    json[:links].find { |link| link[:rel] == 'http://webfinger.net/rel/avatar' }
+  def response_avatar_link
+    response
+      .parsed_body[:links]
+      .find { |link| link[:rel] == 'http://webfinger.net/rel/avatar' }
   end
 end


### PR DESCRIPTION
Follow-up on misc json/spec/etc type PRs, doing a cleanup pass (there will be fewer than I thought!)

In this case - we only ever call this method with the same thing, so lets just get it from the method.