### PR TITLE
Move status creation to "with rss" context in accounts request spec

### DIFF
--- a/spec/requests/accounts_spec.rb
+++ b/spec/requests/accounts_spec.rb
@@ -46,21 +46,6 @@ RSpec.describe 'Accounts show response' do
 
   describe 'GET to short username paths' do
     context 'with existing statuses' do
-      let!(:status) { Fabricate(:status, account: account) }
-      let!(:status_reply) { Fabricate(:status, account: account, thread: Fabricate(:status)) }
-      let!(:status_self_reply) { Fabricate(:status, account: account, thread: status) }
-      let!(:status_media) { Fabricate(:status, account: account) }
-      let!(:status_pinned) { Fabricate(:status, account: account) }
-      let!(:status_private) { Fabricate(:status, account: account, visibility: :private) }
-      let!(:status_direct) { Fabricate(:status, account: account, visibility: :direct) }
-      let!(:status_reblog) { Fabricate(:status, account: account, reblog: Fabricate(:status)) }
-
-      before do
-        status_media.media_attachments << Fabricate(:media_attachment, account: account, type: :image)
-        account.pinned_statuses << status_pinned
-        account.pinned_statuses << status_private
-      end
-
       context 'with HTML' do
         let(:format) { 'html' }
 
@@ -206,6 +191,21 @@ RSpec.describe 'Accounts show response' do
 
       context 'with RSS' do
         let(:format) { 'rss' }
+
+        let!(:status) { Fabricate(:status, account: account) }
+        let!(:status_reply) { Fabricate(:status, account: account, thread: Fabricate(:status)) }
+        let!(:status_self_reply) { Fabricate(:status, account: account, thread: status) }
+        let!(:status_media) { Fabricate(:status, account: account) }
+        let!(:status_pinned) { Fabricate(:status, account: account) }
+        let!(:status_private) { Fabricate(:status, account: account, visibility: :private) }
+        let!(:status_direct) { Fabricate(:status, account: account, visibility: :direct) }
+        let!(:status_reblog) { Fabricate(:status, account: account, reblog: Fabricate(:status)) }
+
+        before do
+          status_media.media_attachments << Fabricate(:media_attachment, account: account, type: :image)
+          account.pinned_statuses << status_pinned
+          account.pinned_statuses << status_private
+        end
 
         context 'with a normal account in an RSS request' do
           before do


### PR DESCRIPTION
These records are only relevant to and asserted about in the RSS section here, but they are being created for the other contexts as well. Reduces factory creation from ~170 to ~70 in this spec.

Side note - a good refactor would be to move this rss context out to it's own request spec to isolate it a bit, and then also refactor the controller actions so that we preserve the routes/endpoints, but move the implementation to like `accounts/statuses#index` (for rss format) or something to better reflect the "return a bunch of rss-serialized statuses" aspect here.
