### PR TITLE
Reduce factory creation in `User#reset_password!` spec

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -434,7 +434,9 @@ RSpec.describe User do
   end
 
   describe '#reset_password!' do
-    subject(:user) { Fabricate(:user, password: 'foobar12345') }
+    subject(:user) { Fabricate(:user, password: original_password) }
+
+    let(:original_password) { 'foobar12345' }
 
     let!(:session_activation) { Fabricate(:session_activation, user: user) }
     let!(:access_token) { Fabricate(:access_token, resource_owner_id: user.id) }
@@ -442,31 +444,40 @@ RSpec.describe User do
 
     let(:redis_pipeline_stub) { instance_double(Redis::Namespace, publish: nil) }
 
-    before do
-      allow(redis).to receive(:pipelined).and_yield(redis_pipeline_stub)
-      user.reset_password!
+    before { stub_redis }
+
+    it 'changes the password immediately and revokes related access' do
+      expect { user.reset_password! }
+        .to remove_activated_sessions
+        .and remove_active_user_tokens
+        .and remove_user_web_subscriptions
+
+      expect(user)
+        .to_not be_external_or_valid_password(original_password)
+      expect { session_activation.reload }
+        .to raise_error(ActiveRecord::RecordNotFound)
+      expect { web_push_subscription.reload }
+        .to raise_error(ActiveRecord::RecordNotFound)
+      expect(redis_pipeline_stub)
+        .to have_received(:publish).with("timeline:access_token:#{access_token.id}", Oj.dump(event: :kill)).once
     end
 
-    it 'changes the password immediately' do
-      expect(user.external_or_valid_password?('foobar12345')).to be false
+    def remove_activated_sessions
+      change(user.session_activations, :count).to(0)
     end
 
-    it 'deactivates all sessions' do
-      expect(user.session_activations.count).to eq 0
-      expect { session_activation.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    def remove_active_user_tokens
+      change { Doorkeeper::AccessToken.active_for(user).count }.to(0)
     end
 
-    it 'revokes all access tokens' do
-      expect(Doorkeeper::AccessToken.active_for(user).count).to eq 0
+    def remove_user_web_subscriptions
+      change { Web::PushSubscription.where(user: user).or(Web::PushSubscription.where(access_token: access_token)).count }.to(0)
     end
 
-    it 'revokes streaming access for all access tokens' do
-      expect(redis_pipeline_stub).to have_received(:publish).with("timeline:access_token:#{access_token.id}", Oj.dump(event: :kill)).once
-    end
-
-    it 'removes push subscriptions' do
-      expect(Web::PushSubscription.where(user: user).or(Web::PushSubscription.where(access_token: access_token)).count).to eq 0
-      expect { web_push_subscription.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    def stub_redis
+      allow(redis)
+        .to receive(:pipelined)
+        .and_yield(redis_pipeline_stub)
     end
   end
 


### PR DESCRIPTION
Removes ~20 factory creations by consolidating assertions about the same execution.

Attempted to preserve the previous descriptions via `change`-wrapping method names.