### PR TITLE
Update dependency google-protobuf

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -289,7 +289,7 @@ GEM
       raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    google-protobuf (3.25.4)
+    google-protobuf (3.25.5)
     googleapis-common-protos-types (1.15.0)
       google-protobuf (>= 3.18, < 5.a)
     haml (6.3.0)


### PR DESCRIPTION
To the best of my knowledge, we are not affected, as this only affects JRuby, which we don't recommend (and maybe does not work at all with Mastodon?).

Nevertheless, updating it to be safe, and to be spared from bundler-audit's warnings.