### PR TITLE
Misc cleanup/extraction in spec/services examples

### DIFF
--- a/spec/services/account_statuses_cleanup_service_spec.rb
+++ b/spec/services/account_statuses_cleanup_service_spec.rb
@@ -102,7 +102,14 @@ RSpec.describe AccountStatusesCleanupService do
           subject.call(account_policy, 10)
           subject.call(account_policy, 10)
           subject.call(account_policy, 10)
-          expect(account_policy.last_inspected).to be < Mastodon::Snowflake.id_at(account_policy.min_status_age.seconds.ago, with_random: false)
+          expect(account_policy.last_inspected).to be < oldest_deletable_record_id
+        end
+
+        def oldest_deletable_record_id
+          Mastodon::Snowflake.id_at(
+            account_policy.min_status_age.seconds.ago,
+            with_random: false
+          )
         end
       end
     end

--- a/spec/services/activitypub/process_status_update_service_spec.rb
+++ b/spec/services/activitypub/process_status_update_service_spec.rb
@@ -2,10 +2,6 @@
 
 require 'rails_helper'
 
-def poll_option_json(name, votes)
-  { type: 'Note', name: name, replies: { type: 'Collection', totalItems: votes } }
-end
-
 RSpec.describe ActivityPub::ProcessStatusUpdateService do
   subject { described_class.new }
 
@@ -418,5 +414,9 @@ RSpec.describe ActivityPub::ProcessStatusUpdateService do
       expect(status.reload.edited_at.to_s)
         .to eq '2021-09-08 22:39:25 UTC'
     end
+  end
+
+  def poll_option_json(name, votes)
+    { type: 'Note', name: name, replies: { type: 'Collection', totalItems: votes } }
   end
 end

--- a/spec/services/bulk_import_service_spec.rb
+++ b/spec/services/bulk_import_service_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe BulkImportService do
 
       it 'enqueues workers for the expected rows' do
         subject.call(import)
-        expect(Import::RowWorker.jobs.pluck('args').flatten).to match_array(rows.map(&:id))
+        expect(row_worker_job_args).to match_array(rows.map(&:id))
       end
 
       it 'requests to follow all the listed users once the workers have run' do
@@ -79,7 +79,7 @@ RSpec.describe BulkImportService do
 
       it 'enqueues workers for the expected rows' do
         subject.call(import)
-        expect(Import::RowWorker.jobs.pluck('args').flatten).to match_array(rows[1..].map(&:id))
+        expect(row_worker_job_args).to match_array(rows[1..].map(&:id))
       end
 
       it 'requests to follow all the expected users once the workers have run' do
@@ -114,7 +114,7 @@ RSpec.describe BulkImportService do
 
       it 'enqueues workers for the expected rows' do
         subject.call(import)
-        expect(Import::RowWorker.jobs.pluck('args').flatten).to match_array(rows.map(&:id))
+        expect(row_worker_job_args).to match_array(rows.map(&:id))
       end
 
       it 'blocks all the listed users once the workers have run' do
@@ -155,7 +155,7 @@ RSpec.describe BulkImportService do
 
       it 'enqueues workers for the expected rows' do
         subject.call(import)
-        expect(Import::RowWorker.jobs.pluck('args').flatten).to match_array(rows[1..].map(&:id))
+        expect(row_worker_job_args).to match_array(rows[1..].map(&:id))
       end
 
       it 'requests to follow all the expected users once the workers have run' do
@@ -190,7 +190,7 @@ RSpec.describe BulkImportService do
 
       it 'enqueues workers for the expected rows' do
         subject.call(import)
-        expect(Import::RowWorker.jobs.pluck('args').flatten).to match_array(rows.map(&:id))
+        expect(row_worker_job_args).to match_array(rows.map(&:id))
       end
 
       it 'mutes all the listed users once the workers have run' do
@@ -235,7 +235,7 @@ RSpec.describe BulkImportService do
 
       it 'enqueues workers for the expected rows' do
         subject.call(import)
-        expect(Import::RowWorker.jobs.pluck('args').flatten).to match_array(rows[1..].map(&:id))
+        expect(row_worker_job_args).to match_array(rows[1..].map(&:id))
       end
 
       it 'requests to follow all the expected users once the workers have run' do
@@ -331,7 +331,7 @@ RSpec.describe BulkImportService do
 
       it 'enqueues workers for the expected rows' do
         subject.call(import)
-        expect(Import::RowWorker.jobs.pluck('args').flatten).to match_array(rows.map(&:id))
+        expect(row_worker_job_args).to match_array(rows.map(&:id))
       end
 
       it 'updates the bookmarks as expected once the workers have run' do
@@ -371,7 +371,7 @@ RSpec.describe BulkImportService do
 
       it 'enqueues workers for the expected rows' do
         subject.call(import)
-        expect(Import::RowWorker.jobs.pluck('args').flatten).to match_array(rows.map(&:id))
+        expect(row_worker_job_args).to match_array(rows.map(&:id))
       end
 
       it 'updates the bookmarks as expected once the workers have run' do
@@ -383,6 +383,13 @@ RSpec.describe BulkImportService do
 
         expect(account.bookmarks.map { |bookmark| bookmark.status.uri }).to contain_exactly(status.uri, bookmarked.uri, 'https://domain.unknown/foo')
       end
+    end
+
+    def row_worker_job_args
+      Import::RowWorker
+        .jobs
+        .pluck('args')
+        .flatten
     end
 
     def stub_resolve_account_service

--- a/spec/services/bulk_import_service_spec.rb
+++ b/spec/services/bulk_import_service_spec.rb
@@ -40,10 +40,7 @@ RSpec.describe BulkImportService do
       it 'requests to follow all the listed users once the workers have run' do
         subject.call(import)
 
-        resolve_account_service_double = instance_double(ResolveAccountService)
-        allow(ResolveAccountService).to receive(:new).and_return(resolve_account_service_double)
-        allow(resolve_account_service_double).to receive(:call).with('user@foo.bar', any_args) { Fabricate(:account, username: 'user', domain: 'foo.bar', protocol: :activitypub) }
-        allow(resolve_account_service_double).to receive(:call).with('unknown@unknown.bar', any_args) { Fabricate(:account, username: 'unknown', domain: 'unknown.bar', protocol: :activitypub) }
+        stub_resolve_account_service
 
         Import::RowWorker.drain
 
@@ -88,10 +85,7 @@ RSpec.describe BulkImportService do
       it 'requests to follow all the expected users once the workers have run' do
         subject.call(import)
 
-        resolve_account_service_double = instance_double(ResolveAccountService)
-        allow(ResolveAccountService).to receive(:new).and_return(resolve_account_service_double)
-        allow(resolve_account_service_double).to receive(:call).with('user@foo.bar', any_args) { Fabricate(:account, username: 'user', domain: 'foo.bar', protocol: :activitypub) }
-        allow(resolve_account_service_double).to receive(:call).with('unknown@unknown.bar', any_args) { Fabricate(:account, username: 'unknown', domain: 'unknown.bar', protocol: :activitypub) }
+        stub_resolve_account_service
 
         Import::RowWorker.drain
 
@@ -126,10 +120,7 @@ RSpec.describe BulkImportService do
       it 'blocks all the listed users once the workers have run' do
         subject.call(import)
 
-        resolve_account_service_double = instance_double(ResolveAccountService)
-        allow(ResolveAccountService).to receive(:new).and_return(resolve_account_service_double)
-        allow(resolve_account_service_double).to receive(:call).with('user@foo.bar', any_args) { Fabricate(:account, username: 'user', domain: 'foo.bar', protocol: :activitypub) }
-        allow(resolve_account_service_double).to receive(:call).with('unknown@unknown.bar', any_args) { Fabricate(:account, username: 'unknown', domain: 'unknown.bar', protocol: :activitypub) }
+        stub_resolve_account_service
 
         Import::RowWorker.drain
 
@@ -170,10 +161,7 @@ RSpec.describe BulkImportService do
       it 'requests to follow all the expected users once the workers have run' do
         subject.call(import)
 
-        resolve_account_service_double = instance_double(ResolveAccountService)
-        allow(ResolveAccountService).to receive(:new).and_return(resolve_account_service_double)
-        allow(resolve_account_service_double).to receive(:call).with('user@foo.bar', any_args) { Fabricate(:account, username: 'user', domain: 'foo.bar', protocol: :activitypub) }
-        allow(resolve_account_service_double).to receive(:call).with('unknown@unknown.bar', any_args) { Fabricate(:account, username: 'unknown', domain: 'unknown.bar', protocol: :activitypub) }
+        stub_resolve_account_service
 
         Import::RowWorker.drain
 
@@ -208,10 +196,7 @@ RSpec.describe BulkImportService do
       it 'mutes all the listed users once the workers have run' do
         subject.call(import)
 
-        resolve_account_service_double = instance_double(ResolveAccountService)
-        allow(ResolveAccountService).to receive(:new).and_return(resolve_account_service_double)
-        allow(resolve_account_service_double).to receive(:call).with('user@foo.bar', any_args) { Fabricate(:account, username: 'user', domain: 'foo.bar', protocol: :activitypub) }
-        allow(resolve_account_service_double).to receive(:call).with('unknown@unknown.bar', any_args) { Fabricate(:account, username: 'unknown', domain: 'unknown.bar', protocol: :activitypub) }
+        stub_resolve_account_service
 
         Import::RowWorker.drain
 
@@ -256,10 +241,7 @@ RSpec.describe BulkImportService do
       it 'requests to follow all the expected users once the workers have run' do
         subject.call(import)
 
-        resolve_account_service_double = instance_double(ResolveAccountService)
-        allow(ResolveAccountService).to receive(:new).and_return(resolve_account_service_double)
-        allow(resolve_account_service_double).to receive(:call).with('user@foo.bar', any_args) { Fabricate(:account, username: 'user', domain: 'foo.bar', protocol: :activitypub) }
-        allow(resolve_account_service_double).to receive(:call).with('unknown@unknown.bar', any_args) { Fabricate(:account, username: 'unknown', domain: 'unknown.bar', protocol: :activitypub) }
+        stub_resolve_account_service
 
         Import::RowWorker.drain
 
@@ -355,10 +337,7 @@ RSpec.describe BulkImportService do
       it 'updates the bookmarks as expected once the workers have run' do
         subject.call(import)
 
-        service_double = instance_double(ActivityPub::FetchRemoteStatusService)
-        allow(ActivityPub::FetchRemoteStatusService).to receive(:new).and_return(service_double)
-        allow(service_double).to receive(:call).with('https://domain.unknown/foo') { Fabricate(:status, uri: 'https://domain.unknown/foo') }
-        allow(service_double).to receive(:call).with('https://domain.unknown/private') { Fabricate(:status, uri: 'https://domain.unknown/private', visibility: :direct) }
+        stub_fetch_remote_status_service
 
         Import::RowWorker.drain
 
@@ -398,15 +377,40 @@ RSpec.describe BulkImportService do
       it 'updates the bookmarks as expected once the workers have run' do
         subject.call(import)
 
-        service_double = instance_double(ActivityPub::FetchRemoteStatusService)
-        allow(ActivityPub::FetchRemoteStatusService).to receive(:new).and_return(service_double)
-        allow(service_double).to receive(:call).with('https://domain.unknown/foo') { Fabricate(:status, uri: 'https://domain.unknown/foo') }
-        allow(service_double).to receive(:call).with('https://domain.unknown/private') { Fabricate(:status, uri: 'https://domain.unknown/private', visibility: :direct) }
+        stub_fetch_remote_status_service
 
         Import::RowWorker.drain
 
         expect(account.bookmarks.map { |bookmark| bookmark.status.uri }).to contain_exactly(status.uri, bookmarked.uri, 'https://domain.unknown/foo')
       end
+    end
+
+    def stub_resolve_account_service
+      resolve_account_service_double = instance_double(ResolveAccountService)
+
+      allow(ResolveAccountService)
+        .to receive(:new)
+        .and_return(resolve_account_service_double)
+      allow(resolve_account_service_double)
+        .to receive(:call)
+        .with('user@foo.bar', any_args) { Fabricate(:account, username: 'user', domain: 'foo.bar', protocol: :activitypub) }
+      allow(resolve_account_service_double)
+        .to receive(:call)
+        .with('unknown@unknown.bar', any_args) { Fabricate(:account, username: 'unknown', domain: 'unknown.bar', protocol: :activitypub) }
+    end
+
+    def stub_fetch_remote_status_service
+      service_double = instance_double(ActivityPub::FetchRemoteStatusService)
+
+      allow(ActivityPub::FetchRemoteStatusService)
+        .to receive(:new)
+        .and_return(service_double)
+      allow(service_double)
+        .to receive(:call)
+        .with('https://domain.unknown/foo') { Fabricate(:status, uri: 'https://domain.unknown/foo') }
+      allow(service_double)
+        .to receive(:call)
+        .with('https://domain.unknown/private') { Fabricate(:status, uri: 'https://domain.unknown/private', visibility: :direct) }
     end
   end
 end

--- a/spec/services/resolve_account_service_spec.rb
+++ b/spec/services/resolve_account_service_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe ResolveAccountService do
 
         it 'does not make a webfinger query' do
           subject.call('foo@ap.example.com', skip_webfinger: true)
-          expect(a_request(:get, 'https://ap.example.com/.well-known/webfinger?resource=acct:foo@ap.example.com')).to_not have_been_made
+          expect(webfinger_discovery_request).to_not have_been_made
         end
       end
 
@@ -39,7 +39,7 @@ RSpec.describe ResolveAccountService do
 
         it 'does not make a webfinger query' do
           subject.call('foo@ap.example.com', skip_webfinger: true)
-          expect(a_request(:get, 'https://ap.example.com/.well-known/webfinger?resource=acct:foo@ap.example.com')).to_not have_been_made
+          expect(webfinger_discovery_request).to_not have_been_made
         end
       end
     end
@@ -51,8 +51,15 @@ RSpec.describe ResolveAccountService do
 
       it 'does not make a webfinger query' do
         subject.call('foo@ap.example.com', skip_webfinger: true)
-        expect(a_request(:get, 'https://ap.example.com/.well-known/webfinger?resource=acct:foo@ap.example.com')).to_not have_been_made
+        expect(webfinger_discovery_request).to_not have_been_made
       end
+    end
+
+    def webfinger_discovery_request
+      a_request(
+        :get,
+        'https://ap.example.com/.well-known/webfinger?resource=acct:foo@ap.example.com'
+      )
     end
   end
 


### PR DESCRIPTION
I have a WIP branch going which is doing similar cleanup within spec/services to what I previously did in some of the API request specs and elsewhere -- looking for places where we have the same exact setup/execution steps, but are repeating them in advance of doing different assertions, leading to excess factory creation.

The diff has gotten pretty large, but is fortunately very boring.

This PR is in advance of that, and is attempting to pull out the majority of things which are NOT just simple de-duplication changes to remove repeated execution. Hopefully getting this in first will make that easier to review.

In this one:

- Helper method to find snowflake ID
- Move a method out of global scope and into describe block
- Pull out methods for multi-line repeated stubbing
- Pull out method to wrap repeated webfinger request stub

Will rebase WIP branch and open another PR including total factory reduction after this.