### PR TITLE
Reduce factory creation (36 -> 12) in `spec/controllers/oauth/*` area

### DIFF
--- a/spec/controllers/oauth/authorizations_controller_spec.rb
+++ b/spec/controllers/oauth/authorizations_controller_spec.rb
@@ -10,13 +10,6 @@ RSpec.describe Oauth::AuthorizationsController do
       get :new, params: { client_id: app.uid, response_type: 'code', redirect_uri: 'http://localhost/', scope: 'read' }
     end
 
-    shared_examples 'stores location for user' do
-      it 'stores location for user' do
-        subject
-        expect(controller.stored_location_for(:user)).to eq "/oauth/authorize?client_id=#{app.uid}&redirect_uri=http%3A%2F%2Flocalhost%2F&response_type=code&scope=read"
-      end
-    end
-
     context 'when signed in' do
       let!(:user) { Fabricate(:user) }
 
@@ -24,17 +17,16 @@ RSpec.describe Oauth::AuthorizationsController do
         sign_in user, scope: :user
       end
 
-      it 'returns http success' do
+      it 'returns http success and private cache control headers' do
         subject
-        expect(response).to have_http_status(200)
-      end
 
-      it 'returns private cache control headers' do
-        subject
-        expect(response.headers['Cache-Control']).to include('private, no-store')
+        expect(response)
+          .to have_http_status(200)
+        expect(response.headers['Cache-Control'])
+          .to include('private, no-store')
+        expect(controller.stored_location_for(:user))
+          .to eq authorize_path_for(app)
       end
-
-      include_examples 'stores location for user'
 
       context 'when app is already authorized' do
         before do
@@ -52,10 +44,12 @@ RSpec.describe Oauth::AuthorizationsController do
           expect(response).to redirect_to(/\A#{app.redirect_uri}/)
         end
 
-        it 'does not redirect to callback with force_login=true' do
-          get :new, params: { client_id: app.uid, response_type: 'code', redirect_uri: 'http://localhost/', scope: 'read', force_login: 'true' }
+        context 'with `force_login` param true' do
+          subject do
+            get :new, params: { client_id: app.uid, response_type: 'code', redirect_uri: 'http://localhost/', scope: 'read', force_login: 'true' }
+          end
 
-          expect(response).to have_http_status(:success)
+          it { is_expected.to have_http_status(:success) }
         end
       end
     end
@@ -63,10 +57,16 @@ RSpec.describe Oauth::AuthorizationsController do
     context 'when not signed in' do
       it 'redirects' do
         subject
-        expect(response).to redirect_to '/auth/sign_in'
-      end
 
-      include_examples 'stores location for user'
+        expect(response)
+          .to redirect_to '/auth/sign_in'
+        expect(controller.stored_location_for(:user))
+          .to eq authorize_path_for(app)
+      end
+    end
+
+    def authorize_path_for(app)
+      "/oauth/authorize?client_id=#{app.uid}&redirect_uri=http%3A%2F%2Flocalhost%2F&response_type=code&scope=read"
     end
   end
 end

--- a/spec/controllers/oauth/tokens_controller_spec.rb
+++ b/spec/controllers/oauth/tokens_controller_spec.rb
@@ -9,20 +9,15 @@ RSpec.describe Oauth::TokensController do
     let!(:access_token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, application: application) }
     let!(:web_push_subscription) { Fabricate(:web_push_subscription, user: user, access_token: access_token) }
 
-    before do
+    it 'revokes the token and removes subscriptions' do
       post :revoke, params: { client_id: application.uid, token: access_token.token }
-    end
 
-    it 'revokes the token' do
-      expect(access_token.reload.revoked_at).to_not be_nil
-    end
-
-    it 'removes web push subscription for token' do
-      expect(Web::PushSubscription.where(access_token: access_token).count).to eq 0
-    end
-
-    it 'removes the web_push_subscription' do
-      expect { web_push_subscription.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect(access_token.reload.revoked_at)
+        .to_not be_nil
+      expect(Web::PushSubscription.where(access_token: access_token).count)
+        .to eq(0)
+      expect { web_push_subscription.reload }
+        .to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 end


### PR DESCRIPTION
Mix of combining examples with same execution, and folding some single-/double-use shared examples back into an existing example to share the setup.