### PR TITLE
Consolidate shared `a scope` example parts into one attributes check

### DIFF
--- a/spec/lib/scope_transformer_spec.rb
+++ b/spec/lib/scope_transformer_spec.rb
@@ -7,16 +7,13 @@ RSpec.describe ScopeTransformer do
     subject { described_class.new.apply(ScopeParser.new.parse(input)) }
 
     shared_examples 'a scope' do |namespace, term, access|
-      it 'parses the term' do
-        expect(subject.term).to eq term
-      end
-
-      it 'parses the namespace' do
-        expect(subject.namespace).to eq namespace
-      end
-
-      it 'parses the access' do
-        expect(subject.access).to eq access
+      it 'parses the attributes' do
+        expect(subject)
+          .to have_attributes(
+            term: term,
+            namespace: namespace,
+            access: access
+          )
       end
     end
 


### PR DESCRIPTION
There are no factories here, but this does reduce the number of effective examples by 3x, while keeping coverage.