### PR TITLE
Convert notification mailer spec shared examples to matchers

### DIFF
--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -8,38 +8,12 @@ RSpec.describe NotificationMailer do
   let(:foreign_status) { Fabricate(:status, account: sender, text: 'The body of the foreign status') }
   let(:own_status)     { Fabricate(:status, account: receiver.account, text: 'The body of the own status') }
 
-  shared_examples 'standard headers' do |type|
-    it 'renders the email' do
-      expect(mail)
-        .to be_present
-        .and(have_header('To', "#{receiver.account.username} <#{receiver.email}>"))
-        .and(have_header('List-ID', "<#{type}.alice.cb6e6126.ngrok.io>"))
-        .and(have_header('List-Unsubscribe', %r{<https://cb6e6126.ngrok.io/unsubscribe\?token=.+>}))
-        .and(have_header('List-Unsubscribe', /&type=#{type}/))
-        .and(have_header('List-Unsubscribe-Post', 'List-Unsubscribe=One-Click'))
-        .and(deliver_to("#{receiver.account.username} <#{receiver.email}>"))
-        .and(deliver_from('notifications@localhost'))
-    end
-  end
-
-  shared_examples 'thread headers' do
-    it 'renders the email with conversation thread headers' do
-      conversation_header_regex = /<conversation-\d+.\d\d\d\d-\d\d-\d\d@cb6e6126.ngrok.io>/
-      expect(mail)
-        .to be_present
-        .and(have_header('In-Reply-To', conversation_header_regex))
-        .and(have_header('References', conversation_header_regex))
-    end
-  end
-
   describe 'mention' do
     let(:mention) { Mention.create!(account: receiver.account, status: foreign_status) }
     let(:notification) { Notification.create!(account: receiver.account, activity: mention) }
     let(:mail) { prepared_mailer_for(receiver.account).mention }
 
     include_examples 'localized subject', 'notification_mailer.mention.subject', name: 'bob'
-    include_examples 'standard headers', 'mention'
-    include_examples 'thread headers'
 
     it 'renders the email' do
       expect(mail)
@@ -47,6 +21,8 @@ RSpec.describe NotificationMailer do
         .and(have_subject('You were mentioned by bob'))
         .and(have_body_text('You were mentioned by bob'))
         .and(have_body_text('The body of the foreign status'))
+        .and have_thread_headers
+        .and have_standard_headers('mention').for(receiver)
     end
   end
 
@@ -56,13 +32,13 @@ RSpec.describe NotificationMailer do
     let(:mail) { prepared_mailer_for(receiver.account).follow }
 
     include_examples 'localized subject', 'notification_mailer.follow.subject', name: 'bob'
-    include_examples 'standard headers', 'follow'
 
     it 'renders the email' do
       expect(mail)
         .to be_present
         .and(have_subject('bob is now following you'))
         .and(have_body_text('bob is now following you'))
+        .and have_standard_headers('follow').for(receiver)
     end
   end
 
@@ -72,8 +48,6 @@ RSpec.describe NotificationMailer do
     let(:mail) { prepared_mailer_for(own_status.account).favourite }
 
     include_examples 'localized subject', 'notification_mailer.favourite.subject', name: 'bob'
-    include_examples 'standard headers', 'favourite'
-    include_examples 'thread headers'
 
     it 'renders the email' do
       expect(mail)
@@ -81,6 +55,8 @@ RSpec.describe NotificationMailer do
         .and(have_subject('bob favorited your post'))
         .and(have_body_text('Your post was favorited by bob'))
         .and(have_body_text('The body of the own status'))
+        .and have_thread_headers
+        .and have_standard_headers('favourite').for(receiver)
     end
   end
 
@@ -90,8 +66,6 @@ RSpec.describe NotificationMailer do
     let(:mail) { prepared_mailer_for(own_status.account).reblog }
 
     include_examples 'localized subject', 'notification_mailer.reblog.subject', name: 'bob'
-    include_examples 'standard headers', 'reblog'
-    include_examples 'thread headers'
 
     it 'renders the email' do
       expect(mail)
@@ -99,6 +73,8 @@ RSpec.describe NotificationMailer do
         .and(have_subject('bob boosted your post'))
         .and(have_body_text('Your post was boosted by bob'))
         .and(have_body_text('The body of the own status'))
+        .and have_thread_headers
+        .and have_standard_headers('reblog').for(receiver)
     end
   end
 
@@ -108,13 +84,13 @@ RSpec.describe NotificationMailer do
     let(:mail) { prepared_mailer_for(receiver.account).follow_request }
 
     include_examples 'localized subject', 'notification_mailer.follow_request.subject', name: 'bob'
-    include_examples 'standard headers', 'follow_request'
 
     it 'renders the email' do
       expect(mail)
         .to be_present
         .and(have_subject('Pending follower: bob'))
         .and(have_body_text('bob has requested to follow you'))
+        .and have_standard_headers('follow_request').for(receiver)
     end
   end
 

--- a/spec/support/examples/mailers.rb
+++ b/spec/support/examples/mailers.rb
@@ -12,3 +12,32 @@ RSpec.shared_examples 'localized subject' do |*args, **kwrest|
     expect(mail.subject).to eq I18n.t(*args, **kwrest.merge(locale: I18n.default_locale))
   end
 end
+
+RSpec::Matchers.define :have_thread_headers do
+  match(notify_expectation_failures: true) do |mail|
+    expect(mail)
+      .to be_present
+      .and(have_header('In-Reply-To', conversation_header_regex))
+      .and(have_header('References', conversation_header_regex))
+  end
+
+  def conversation_header_regex = /<conversation-\d+.\d\d\d\d-\d\d-\d\d@cb6e6126.ngrok.io>/
+end
+
+RSpec::Matchers.define :have_standard_headers do |type|
+  chain :for do |user|
+    @user = user
+  end
+
+  match(notify_expectation_failures: true) do |mail|
+    expect(mail)
+      .to be_present
+      .and(have_header('To', "#{@user.account.username} <#{@user.email}>"))
+      .and(have_header('List-ID', "<#{type}.#{@user.account.username}.#{Rails.configuration.x.local_domain}>"))
+      .and(have_header('List-Unsubscribe', %r{<https://#{Rails.configuration.x.local_domain}/unsubscribe\?token=.+>}))
+      .and(have_header('List-Unsubscribe', /&type=#{type}/))
+      .and(have_header('List-Unsubscribe-Post', 'List-Unsubscribe=One-Click'))
+      .and(deliver_to("#{@user.account.username} <#{@user.email}>"))
+      .and(deliver_from(Rails.configuration.action_mailer.default_options[:from]))
+  end
+end


### PR DESCRIPTION
Reduces factory usage from 65 to 42 - and also (my opinion) reads better.

I made the "standard headers" one a little less hard-coded in process.