### PR TITLE
Increase regexp timeout and allow override

### DIFF
--- a/config/initializers/regexp.rb
+++ b/config/initializers/regexp.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-# 0.5s is a fairly high timeout, but that should account for slow servers under load
-Regexp.timeout = 0.5 if Regexp.respond_to?(:timeout=)
+# 2s is a fairly high default, but that should account for slow servers under load
+Regexp.timeout = ENV.fetch('REGEXP_TIMEOUT', 2).to_f if Regexp.respond_to?(:timeout=)


### PR DESCRIPTION
Fixes #32051 

Ruby's `Regexp.timeout` method was originally proposed by discourse. I had a look at their config and they use 2 seconds as a default but also allow to override this.

This is my attempt to do the same here.