### PR TITLE
Enable `aggregate_failures` meta globally

### DIFF
--- a/spec/controllers/settings/aliases_controller_spec.rb
+++ b/spec/controllers/settings/aliases_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Settings::AliasesController do
       get :index
     end
 
-    it 'returns http success with private cache control headers', :aggregate_failures do
+    it 'returns http success with private cache control headers' do
       expect(response).to have_http_status(200)
       expect(response.headers['Cache-Control']).to include('private, no-store')
     end

--- a/spec/controllers/settings/deletes_controller_spec.rb
+++ b/spec/controllers/settings/deletes_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Settings::DeletesController do
         get :show
       end
 
-      it 'renders confirmation page with private cache control headers', :aggregate_failures do
+      it 'renders confirmation page with private cache control headers' do
         expect(response).to have_http_status(200)
         expect(response.headers['Cache-Control']).to include('private, no-store')
       end
@@ -22,7 +22,7 @@ RSpec.describe Settings::DeletesController do
       context 'when suspended' do
         let(:user) { Fabricate(:user, account_attributes: { suspended_at: Time.now.utc }) }
 
-        it 'returns http forbidden with private cache control headers', :aggregate_failures do
+        it 'returns http forbidden with private cache control headers' do
           expect(response).to have_http_status(403)
           expect(response.headers['Cache-Control']).to include('private, no-store')
         end
@@ -50,7 +50,7 @@ RSpec.describe Settings::DeletesController do
           delete :destroy, params: { form_delete_confirmation: { password: 'petsmoldoggos' } }
         end
 
-        it 'removes user record and redirects', :aggregate_failures, :inline_jobs do
+        it 'removes user record and redirects', :inline_jobs do
           expect(response).to redirect_to '/auth/sign_in'
           expect(User.find_by(id: user.id)).to be_nil
           expect(user.account.reload).to be_suspended

--- a/spec/controllers/settings/imports_controller_spec.rb
+++ b/spec/controllers/settings/imports_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Settings::ImportsController do
       get :index
     end
 
-    it 'assigns the expected imports', :aggregate_failures do
+    it 'assigns the expected imports' do
       expect(response).to have_http_status(200)
       expect(response.headers['Cache-Control']).to include('private, no-store')
       expect(response.body)
@@ -68,7 +68,7 @@ RSpec.describe Settings::ImportsController do
     context 'with someone else\'s import' do
       let(:bulk_import) { Fabricate(:bulk_import, state: :unconfirmed) }
 
-      it 'does not change the import\'s state and returns missing', :aggregate_failures do
+      it 'does not change the import\'s state and returns missing' do
         expect { subject }.to_not(change { bulk_import.reload.state })
 
         expect(BulkImportWorker).to_not have_received(:perform_async)
@@ -79,7 +79,7 @@ RSpec.describe Settings::ImportsController do
     context 'with an already-confirmed import' do
       let(:bulk_import) { Fabricate(:bulk_import, account: user.account, state: :in_progress) }
 
-      it 'does not change the import\'s state and returns missing', :aggregate_failures do
+      it 'does not change the import\'s state and returns missing' do
         expect { subject }.to_not(change { bulk_import.reload.state })
 
         expect(BulkImportWorker).to_not have_received(:perform_async)
@@ -90,7 +90,7 @@ RSpec.describe Settings::ImportsController do
     context 'with an unconfirmed import' do
       let(:bulk_import) { Fabricate(:bulk_import, account: user.account, state: :unconfirmed) }
 
-      it 'changes the import\'s state to scheduled and redirects', :aggregate_failures do
+      it 'changes the import\'s state to scheduled and redirects' do
         expect { subject }.to change { bulk_import.reload.state.to_sym }.from(:unconfirmed).to(:scheduled)
 
         expect(BulkImportWorker).to have_received(:perform_async).with(bulk_import.id)
@@ -105,7 +105,7 @@ RSpec.describe Settings::ImportsController do
     context 'with someone else\'s import' do
       let(:bulk_import) { Fabricate(:bulk_import, state: :unconfirmed) }
 
-      it 'does not delete the import and returns missing', :aggregate_failures do
+      it 'does not delete the import and returns missing' do
         expect { subject }.to_not(change { BulkImport.exists?(bulk_import.id) })
 
         expect(response).to have_http_status(404)
@@ -115,7 +115,7 @@ RSpec.describe Settings::ImportsController do
     context 'with an already-confirmed import' do
       let(:bulk_import) { Fabricate(:bulk_import, account: user.account, state: :in_progress) }
 
-      it 'does not delete the import and returns missing', :aggregate_failures do
+      it 'does not delete the import and returns missing' do
         expect { subject }.to_not(change { BulkImport.exists?(bulk_import.id) })
 
         expect(response).to have_http_status(404)
@@ -125,7 +125,7 @@ RSpec.describe Settings::ImportsController do
     context 'with an unconfirmed import' do
       let(:bulk_import) { Fabricate(:bulk_import, account: user.account, state: :unconfirmed) }
 
-      it 'deletes the import and redirects', :aggregate_failures do
+      it 'deletes the import and redirects' do
         expect { subject }.to change { BulkImport.exists?(bulk_import.id) }.from(true).to(false)
 
         expect(response).to redirect_to(settings_imports_path)
@@ -144,7 +144,7 @@ RSpec.describe Settings::ImportsController do
         bulk_import.update(total_items: bulk_import.rows.count, processed_items: bulk_import.rows.count, imported_items: 0)
       end
 
-      it 'returns expected contents', :aggregate_failures do
+      it 'returns expected contents' do
         subject
 
         expect(response).to have_http_status(200)
@@ -247,7 +247,7 @@ RSpec.describe Settings::ImportsController do
       let(:import_file) { file }
       let(:import_mode) { mode }
 
-      it 'creates an unconfirmed bulk_import with expected type and redirects', :aggregate_failures do
+      it 'creates an unconfirmed bulk_import with expected type and redirects' do
         expect { subject }.to change { user.account.bulk_imports.pluck(:state, :type) }.from([]).to([['unconfirmed', import_type]])
 
         expect(response).to redirect_to(settings_import_path(user.account.bulk_imports.first))
@@ -259,7 +259,7 @@ RSpec.describe Settings::ImportsController do
       let(:import_file) { file }
       let(:import_mode) { mode }
 
-      it 'does not creates an unconfirmed bulk_import', :aggregate_failures do
+      it 'does not creates an unconfirmed bulk_import' do
         expect { subject }.to_not(change { user.account.bulk_imports.count })
 
         expect(response.body)

--- a/spec/controllers/settings/login_activities_controller_spec.rb
+++ b/spec/controllers/settings/login_activities_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Settings::LoginActivitiesController do
       get :index
     end
 
-    it 'returns http success with private cache control headers', :aggregate_failures do
+    it 'returns http success with private cache control headers' do
       expect(response).to have_http_status(200)
       expect(response.headers['Cache-Control']).to include('private, no-store')
       expect(response.body)

--- a/spec/controllers/settings/migration/redirects_controller_spec.rb
+++ b/spec/controllers/settings/migration/redirects_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Settings::Migration::RedirectsController do
       get :new
     end
 
-    it 'returns http success with private cache control headers', :aggregate_failures do
+    it 'returns http success with private cache control headers' do
       expect(response).to have_http_status(200)
       expect(response.headers['Cache-Control']).to include('private, no-store')
     end

--- a/spec/controllers/settings/migrations_controller_spec.rb
+++ b/spec/controllers/settings/migrations_controller_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Settings::MigrationsController do
       context 'when acct is the current account' do
         let(:acct) { user.account }
 
-        it 'does not update the moved account', :aggregate_failures do
+        it 'does not update the moved account' do
           subject
 
           expect(user.account.reload.moved_to_account_id).to be_nil
@@ -76,7 +76,7 @@ RSpec.describe Settings::MigrationsController do
       context 'when target account does not reference the account being moved from' do
         let(:acct) { Fabricate(:account, also_known_as: []) }
 
-        it 'does not update the moved account', :aggregate_failures do
+        it 'does not update the moved account' do
           subject
 
           expect(user.account.reload.moved_to_account_id).to be_nil
@@ -92,7 +92,7 @@ RSpec.describe Settings::MigrationsController do
           user.account.migrations.create!(acct: moved_to.acct)
         end
 
-        it 'does not update the moved account', :aggregate_failures do
+        it 'does not update the moved account' do
           subject
 
           expect(user.account.reload.moved_to_account_id).to be_nil

--- a/spec/controllers/settings/preferences/appearance_controller_spec.rb
+++ b/spec/controllers/settings/preferences/appearance_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Settings::Preferences::AppearanceController do
       get :show
     end
 
-    it 'returns http success with private cache control headers', :aggregate_failures do
+    it 'returns http success with private cache control headers' do
       expect(response).to have_http_status(200)
       expect(response.headers['Cache-Control']).to include('private, no-store')
     end

--- a/spec/controllers/settings/preferences/notifications_controller_spec.rb
+++ b/spec/controllers/settings/preferences/notifications_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Settings::Preferences::NotificationsController do
       get :show
     end
 
-    it 'returns http success with private cache control headers', :aggregate_failures do
+    it 'returns http success with private cache control headers' do
       expect(response).to have_http_status(200)
       expect(response.headers['Cache-Control']).to include('private, no-store')
     end

--- a/spec/controllers/settings/preferences/other_controller_spec.rb
+++ b/spec/controllers/settings/preferences/other_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Settings::Preferences::OtherController do
       get :show
     end
 
-    it 'returns http success with private cache control headers', :aggregate_failures do
+    it 'returns http success with private cache control headers' do
       expect(response).to have_http_status(200)
       expect(response.headers['Cache-Control']).to include('private, no-store')
     end

--- a/spec/controllers/settings/privacy_controller_spec.rb
+++ b/spec/controllers/settings/privacy_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Settings::PrivacyController do
       get :show
     end
 
-    it 'returns http success with private cache control headers', :aggregate_failures do
+    it 'returns http success with private cache control headers' do
       expect(response)
         .to have_http_status(200)
         .and have_attributes(

--- a/spec/controllers/settings/profiles_controller_spec.rb
+++ b/spec/controllers/settings/profiles_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Settings::ProfilesController do
       get :show
     end
 
-    it 'returns http success with private cache control headers', :aggregate_failures do
+    it 'returns http success with private cache control headers' do
       expect(response).to have_http_status(200)
       expect(response.headers['Cache-Control']).to include('private, no-store')
     end

--- a/spec/controllers/settings/two_factor_authentication/webauthn_credentials_controller_spec.rb
+++ b/spec/controllers/settings/two_factor_authentication/webauthn_credentials_controller_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe Settings::TwoFactorAuthentication::WebauthnCredentialsController 
             add_webauthn_credential(user)
           end
 
-          it 'includes existing credentials in list of excluded credentials', :aggregate_failures do
+          it 'includes existing credentials in list of excluded credentials' do
             expect { get :options }.to_not change(user, :webauthn_id)
 
             expect(response).to have_http_status(200)
@@ -134,7 +134,7 @@ RSpec.describe Settings::TwoFactorAuthentication::WebauthnCredentialsController 
         end
 
         context 'when user does not have webauthn enabled' do
-          it 'stores the challenge on the session and sets user webauthn_id', :aggregate_failures do
+          it 'stores the challenge on the session and sets user webauthn_id' do
             get :options
 
             expect(response).to have_http_status(200)
@@ -194,7 +194,7 @@ RSpec.describe Settings::TwoFactorAuthentication::WebauthnCredentialsController 
             add_webauthn_credential(user)
           end
 
-          it 'adds a new credential to user credentials and does not change webauthn_id when creation succeeds', :aggregate_failures do
+          it 'adds a new credential to user credentials and does not change webauthn_id when creation succeeds' do
             controller.session[:webauthn_challenge] = challenge
 
             expect do
@@ -281,7 +281,7 @@ RSpec.describe Settings::TwoFactorAuthentication::WebauthnCredentialsController 
             add_webauthn_credential(user)
           end
 
-          it 'redirects to 2FA methods list and shows flash success and deletes the credential when deletion succeeds', :aggregate_failures do
+          it 'redirects to 2FA methods list and shows flash success and deletes the credential when deletion succeeds' do
             expect do
               delete :destroy, params: { id: user.webauthn_credentials.take.id }
             end.to change { user.webauthn_credentials.count }.by(-1)

--- a/spec/controllers/settings/two_factor_authentication_methods_controller_spec.rb
+++ b/spec/controllers/settings/two_factor_authentication_methods_controller_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Settings::TwoFactorAuthenticationMethodsController do
           get :index
         end
 
-        it 'returns http success with private cache control headers', :aggregate_failures do
+        it 'returns http success with private cache control headers' do
           expect(response).to have_http_status(200)
           expect(response.headers['Cache-Control']).to include('private, no-store')
         end

--- a/spec/controllers/settings/verifications_controller_spec.rb
+++ b/spec/controllers/settings/verifications_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Settings::VerificationsController do
       get :show
     end
 
-    it 'returns http success with private cache control headers', :aggregate_failures do
+    it 'returns http success with private cache control headers' do
       expect(response)
         .to have_http_status(200)
         .and have_attributes(

--- a/spec/controllers/statuses_controller_spec.rb
+++ b/spec/controllers/statuses_controller_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe StatusesController do
       context 'with HTML' do
         let(:format) { 'html' }
 
-        it 'renders status successfully', :aggregate_failures do
+        it 'renders status successfully' do
           expect(response)
             .to have_http_status(200)
             .and render_template(:show)
@@ -72,7 +72,7 @@ RSpec.describe StatusesController do
       context 'with JSON' do
         let(:format) { 'json' }
 
-        it 'renders ActivityPub Note object successfully', :aggregate_failures do
+        it 'renders ActivityPub Note object successfully' do
           expect(response)
             .to have_http_status(200)
             .and have_cacheable_headers.with_vary('Accept, Accept-Language, Cookie')
@@ -161,7 +161,7 @@ RSpec.describe StatusesController do
         context 'with HTML' do
           let(:format) { 'html' }
 
-          it 'renders status successfully', :aggregate_failures do
+          it 'renders status successfully' do
             expect(response)
               .to have_http_status(200)
               .and render_template(:show)
@@ -177,7 +177,7 @@ RSpec.describe StatusesController do
         context 'with JSON' do
           let(:format) { 'json' }
 
-          it 'renders ActivityPub Note object successfully', :aggregate_failures do
+          it 'renders ActivityPub Note object successfully' do
             expect(response)
               .to have_http_status(200)
             expect(response.headers).to include(
@@ -204,7 +204,7 @@ RSpec.describe StatusesController do
           context 'with HTML' do
             let(:format) { 'html' }
 
-            it 'renders status successfully', :aggregate_failures do
+            it 'renders status successfully' do
               expect(response)
                 .to have_http_status(200)
                 .and render_template(:show)
@@ -221,7 +221,7 @@ RSpec.describe StatusesController do
           context 'with JSON' do
             let(:format) { 'json' }
 
-            it 'renders ActivityPub Note object successfully', :aggregate_failures do
+            it 'renders ActivityPub Note object successfully' do
               expect(response)
                 .to have_http_status(200)
               expect(response.headers).to include(
@@ -271,7 +271,7 @@ RSpec.describe StatusesController do
           context 'with HTML' do
             let(:format) { 'html' }
 
-            it 'renders status successfully', :aggregate_failures do
+            it 'renders status successfully' do
               expect(response)
                 .to have_http_status(200)
                 .and render_template(:show)
@@ -363,7 +363,7 @@ RSpec.describe StatusesController do
         context 'with HTML' do
           let(:format) { 'html' }
 
-          it 'renders status successfully', :aggregate_failures do
+          it 'renders status successfully' do
             expect(response)
               .to have_http_status(200)
               .and render_template(:show)
@@ -379,7 +379,7 @@ RSpec.describe StatusesController do
         context 'with JSON' do
           let(:format) { 'json' }
 
-          it 'renders ActivityPub Note object successfully', :aggregate_failures do
+          it 'renders ActivityPub Note object successfully' do
             expect(response)
               .to have_http_status(200)
               .and have_cacheable_headers.with_vary('Accept, Accept-Language, Cookie')
@@ -405,7 +405,7 @@ RSpec.describe StatusesController do
           context 'with HTML' do
             let(:format) { 'html' }
 
-            it 'renders status successfully', :aggregate_failures do
+            it 'renders status successfully' do
               expect(response)
                 .to have_http_status(200)
                 .and render_template(:show)
@@ -472,7 +472,7 @@ RSpec.describe StatusesController do
           context 'with HTML' do
             let(:format) { 'html' }
 
-            it 'renders status successfully', :aggregate_failures do
+            it 'renders status successfully' do
               expect(response)
                 .to have_http_status(200)
                 .and render_template(:show)
@@ -488,7 +488,7 @@ RSpec.describe StatusesController do
           context 'with JSON' do
             let(:format) { 'json' }
 
-            it 'renders ActivityPub Note object', :aggregate_failures do
+            it 'renders ActivityPub Note object' do
               expect(response)
                 .to have_http_status(200)
               expect(response.headers).to include(

--- a/spec/lib/activitypub/activity/create_spec.rb
+++ b/spec/lib/activitypub/activity/create_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe ActivityPub::Activity::Create do
       expect(Notification.count).to eq 2
     end
 
-    it 'ignores unprocessable mention', :aggregate_failures do
+    it 'ignores unprocessable mention' do
       stub_request(:get, invalid_mention_json[:tag][:href]).to_raise(HTTP::ConnectionError)
       # When receiving the post that contains an invalid mention…
       described_class.new(activity_for_object(invalid_mention_json), sender, delivery: true).perform

--- a/spec/lib/activitypub/activity/create_spec.rb
+++ b/spec/lib/activitypub/activity/create_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe ActivityPub::Activity::Create do
       follower.follow!(sender)
     end
 
-    it 'correctly processes posts and inserts them in timelines', :aggregate_failures do
+    it 'correctly processes posts and inserts them in timelines' do
       # Simulate a temporary failure preventing from fetching the parent post
       stub_request(:get, object_json[:id]).to_return(status: 500)
 
@@ -174,7 +174,7 @@ RSpec.describe ActivityPub::Activity::Create do
           }
         end
 
-        it 'creates status with a valid creation date', :aggregate_failures do
+        it 'creates status with a valid creation date' do
           status = sender.statuses.first
 
           expect(status).to_not be_nil
@@ -194,7 +194,7 @@ RSpec.describe ActivityPub::Activity::Create do
           }
         end
 
-        it 'creates status with a valid creation date', :aggregate_failures do
+        it 'creates status with a valid creation date' do
           status = sender.statuses.first
 
           expect(status).to_not be_nil
@@ -215,7 +215,7 @@ RSpec.describe ActivityPub::Activity::Create do
           }
         end
 
-        it 'creates status with appropriate creation and edition dates', :aggregate_failures do
+        it 'creates status with appropriate creation and edition dates' do
           status = sender.statuses.first
 
           expect(status).to_not be_nil

--- a/spec/lib/activitypub/linked_data_signature_spec.rb
+++ b/spec/lib/activitypub/linked_data_signature_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe ActivityPub::LinkedDataSignature do
   describe '#sign!' do
     subject { described_class.new(raw_json).sign!(sender) }
 
-    it 'returns a hash with a signature, the expected context, and the signature can be verified', :aggregate_failures do
+    it 'returns a hash with a signature, the expected context, and the signature can be verified' do
       expect(subject).to be_a Hash
       expect(subject['signature']).to be_a Hash
       expect(subject['signature']['signatureValue']).to be_present

--- a/spec/models/account_suggestions/friends_of_friends_source_spec.rb
+++ b/spec/models/account_suggestions/friends_of_friends_source_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe AccountSuggestions::FriendsOfFriendsSource do
         [eve, mallory, jerk, larry, neil, morty].each { |account| eugen.follow!(account) }
       end
 
-      it 'returns eligible accounts', :aggregate_failures do
+      it 'returns eligible accounts' do
         results = subject.get(bob)
 
         # eve is returned through eugen

--- a/spec/models/admin/account_action_spec.rb
+++ b/spec/models/admin/account_action_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Admin::AccountAction do
       )
     end
 
-    it 'sends notification, log the action, and closes other reports', :aggregate_failures do
+    it 'sends notification, log the action, and closes other reports' do
       other_report = Fabricate(:report, target_account: target_account)
 
       expect { subject }

--- a/spec/models/scheduled_status_spec.rb
+++ b/spec/models/scheduled_status_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ScheduledStatus do
     context 'when scheduled_at is less than minimum offset' do
       subject { Fabricate.build(:scheduled_status, scheduled_at: 4.minutes.from_now, account: account) }
 
-      it 'is not valid', :aggregate_failures do
+      it 'is not valid' do
         expect(subject).to_not be_valid
         expect(subject.errors[:scheduled_at]).to include(I18n.t('scheduled_statuses.too_soon'))
       end
@@ -22,7 +22,7 @@ RSpec.describe ScheduledStatus do
         allow(account.scheduled_statuses).to receive(:count).and_return(described_class::TOTAL_LIMIT)
       end
 
-      it 'is not valid', :aggregate_failures do
+      it 'is not valid' do
         expect(subject).to_not be_valid
         expect(subject.errors[:base]).to include(I18n.t('scheduled_statuses.over_total_limit', limit: ScheduledStatus::TOTAL_LIMIT))
       end
@@ -41,7 +41,7 @@ RSpec.describe ScheduledStatus do
         end
       end
 
-      it 'is not valid', :aggregate_failures do
+      it 'is not valid' do
         expect(subject).to_not be_valid
         expect(subject.errors[:base]).to include(I18n.t('scheduled_statuses.over_daily_limit', limit: ScheduledStatus::DAILY_LIMIT))
       end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -93,6 +93,10 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
 
+  config.define_derived_metadata do |meta|
+    meta[:aggregate_failures] = true
+  end
+
   # Set type to `cli` for all CLI specs
   config.define_derived_metadata(file_path: Regexp.new('spec/lib/mastodon/cli')) do |metadata|
     metadata[:type] = :cli

--- a/spec/requests/accounts_spec.rb
+++ b/spec/requests/accounts_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'Accounts show response' do
         let(:format) { 'html' }
 
         shared_examples 'common HTML response' do
-          it 'returns a standard HTML response', :aggregate_failures do
+          it 'returns a standard HTML response' do
             expect(response)
               .to have_http_status(200)
               .and render_template(:show)
@@ -111,7 +111,7 @@ RSpec.describe 'Accounts show response' do
             get short_account_path(username: account.username), headers: headers
           end
 
-          it 'returns a JSON version of the account', :aggregate_failures do
+          it 'returns a JSON version of the account' do
             expect(response)
               .to have_http_status(200)
               .and have_cacheable_headers.with_vary('Accept, Accept-Language, Cookie')
@@ -139,7 +139,7 @@ RSpec.describe 'Accounts show response' do
             get short_account_path(username: account.username), headers: headers.merge({ 'Cookie' => '123' })
           end
 
-          it 'returns a private JSON version of the account', :aggregate_failures do
+          it 'returns a private JSON version of the account' do
             expect(response)
               .to have_http_status(200)
               .and have_attributes(
@@ -159,7 +159,7 @@ RSpec.describe 'Accounts show response' do
             get short_account_path(username: account.username), headers: headers, sign_with: remote_account
           end
 
-          it 'returns a JSON version of the account', :aggregate_failures do
+          it 'returns a JSON version of the account' do
             expect(response)
               .to have_http_status(200)
               .and have_cacheable_headers.with_vary('Accept, Accept-Language, Cookie')
@@ -173,7 +173,7 @@ RSpec.describe 'Accounts show response' do
           context 'with authorized fetch mode' do
             let(:authorized_fetch_mode) { true }
 
-            it 'returns a private signature JSON version of the account', :aggregate_failures do
+            it 'returns a private signature JSON version of the account' do
               expect(response)
                 .to have_http_status(200)
                 .and have_attributes(
@@ -212,7 +212,7 @@ RSpec.describe 'Accounts show response' do
             get short_account_path(username: account.username, format: format)
           end
 
-          it 'responds with correct statuses', :aggregate_failures do
+          it 'responds with correct statuses' do
             expect(response)
               .to have_http_status(200)
               .and have_cacheable_headers.with_vary('Accept, Accept-Language, Cookie')
@@ -231,7 +231,7 @@ RSpec.describe 'Accounts show response' do
             get short_account_with_replies_path(username: account.username, format: format)
           end
 
-          it 'responds with correct statuses with replies', :aggregate_failures do
+          it 'responds with correct statuses with replies' do
             expect(response)
               .to have_http_status(200)
               .and have_cacheable_headers.with_vary('Accept, Accept-Language, Cookie')
@@ -251,7 +251,7 @@ RSpec.describe 'Accounts show response' do
             get short_account_media_path(username: account.username, format: format)
           end
 
-          it 'responds with correct statuses with media', :aggregate_failures do
+          it 'responds with correct statuses with media' do
             expect(response)
               .to have_http_status(200)
               .and have_cacheable_headers.with_vary('Accept, Accept-Language, Cookie')
@@ -275,7 +275,7 @@ RSpec.describe 'Accounts show response' do
             get short_account_tag_path(username: account.username, tag: tag, format: format)
           end
 
-          it 'responds with correct statuses with a tag', :aggregate_failures do
+          it 'responds with correct statuses with a tag' do
             expect(response)
               .to have_http_status(200)
               .and have_cacheable_headers.with_vary('Accept, Accept-Language, Cookie')

--- a/spec/requests/api/v1/accounts/featured_tags_spec.rb
+++ b/spec/requests/api/v1/accounts/featured_tags_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'account featured tags API' do
       account.featured_tags.create!(name: 'bar')
     end
 
-    it 'returns the expected tags', :aggregate_failures do
+    it 'returns the expected tags' do
       subject
 
       expect(response).to have_http_status(200)
@@ -35,7 +35,7 @@ RSpec.describe 'account featured tags API' do
     end
 
     context 'when the account is remote' do
-      it 'returns the expected tags', :aggregate_failures do
+      it 'returns the expected tags' do
         subject
 
         expect(response).to have_http_status(200)

--- a/spec/requests/api/v1/accounts/follower_accounts_spec.rb
+++ b/spec/requests/api/v1/accounts/follower_accounts_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'API V1 Accounts FollowerAccounts' do
   end
 
   describe 'GET /api/v1/accounts/:acount_id/followers' do
-    it 'returns accounts following the given account', :aggregate_failures do
+    it 'returns accounts following the given account' do
       get "/api/v1/accounts/#{account.id}/followers", params: { limit: 2 }, headers: headers
 
       expect(response).to have_http_status(200)
@@ -30,7 +30,7 @@ RSpec.describe 'API V1 Accounts FollowerAccounts' do
         )
     end
 
-    it 'does not return blocked users', :aggregate_failures do
+    it 'does not return blocked users' do
       user.account.block!(bob)
       get "/api/v1/accounts/#{account.id}/followers", params: { limit: 2 }, headers: headers
 

--- a/spec/requests/api/v1/accounts/following_accounts_spec.rb
+++ b/spec/requests/api/v1/accounts/following_accounts_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'API V1 Accounts FollowingAccounts' do
   end
 
   describe 'GET /api/v1/accounts/:account_id/following' do
-    it 'returns accounts followed by the given account', :aggregate_failures do
+    it 'returns accounts followed by the given account' do
       get "/api/v1/accounts/#{account.id}/following", params: { limit: 2 }, headers: headers
 
       expect(response).to have_http_status(200)
@@ -30,7 +30,7 @@ RSpec.describe 'API V1 Accounts FollowingAccounts' do
         )
     end
 
-    it 'does not return blocked users', :aggregate_failures do
+    it 'does not return blocked users' do
       user.account.block!(bob)
       get "/api/v1/accounts/#{account.id}/following", params: { limit: 2 }, headers: headers
 

--- a/spec/requests/api/v1/accounts/notes_spec.rb
+++ b/spec/requests/api/v1/accounts/notes_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Accounts Notes API' do
       post "/api/v1/accounts/#{account.id}/note", params: { comment: comment }, headers: headers
     end
 
-    context 'when account note has reasonable length', :aggregate_failures do
+    context 'when account note has reasonable length' do
       let(:comment) { 'foo' }
 
       it 'updates account note' do
@@ -28,7 +28,7 @@ RSpec.describe 'Accounts Notes API' do
       end
     end
 
-    context 'when account note exceeds allowed length', :aggregate_failures do
+    context 'when account note exceeds allowed length' do
       let(:comment) { 'a' * 2_001 }
 
       it 'does not create account note' do

--- a/spec/requests/api/v1/accounts/pins_spec.rb
+++ b/spec/requests/api/v1/accounts/pins_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Accounts Pins API' do
   describe 'POST /api/v1/accounts/:account_id/pin' do
     subject { post "/api/v1/accounts/#{kevin.account.id}/pin", headers: headers }
 
-    it 'creates account_pin', :aggregate_failures do
+    it 'creates account_pin' do
       expect do
         subject
       end.to change { AccountPin.where(account: user.account, target_account: kevin.account).count }.by(1)
@@ -33,7 +33,7 @@ RSpec.describe 'Accounts Pins API' do
       Fabricate(:account_pin, account: user.account, target_account: kevin.account)
     end
 
-    it 'destroys account_pin', :aggregate_failures do
+    it 'destroys account_pin' do
       expect do
         subject
       end.to change { AccountPin.where(account: user.account, target_account: kevin.account).count }.by(-1)

--- a/spec/requests/api/v1/accounts/relationships_spec.rb
+++ b/spec/requests/api/v1/accounts/relationships_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'GET /api/v1/accounts/relationships' do
   context 'when provided only one ID' do
     let(:params) { { id: simon.id } }
 
-    it 'returns JSON with correct data', :aggregate_failures do
+    it 'returns JSON with correct data' do
       subject
 
       expect(response)
@@ -47,7 +47,7 @@ RSpec.describe 'GET /api/v1/accounts/relationships' do
 
     context 'when there is returned JSON data' do
       context 'with default parameters' do
-        it 'returns an enumerable json with correct elements, excluding suspended accounts', :aggregate_failures do
+        it 'returns an enumerable json with correct elements, excluding suspended accounts' do
           subject
 
           expect(response)
@@ -69,7 +69,7 @@ RSpec.describe 'GET /api/v1/accounts/relationships' do
       context 'with `with_suspended` parameter' do
         let(:params) { { id: [simon.id, lewis.id, bob.id], with_suspended: true } }
 
-        it 'returns an enumerable json with correct elements, including suspended accounts', :aggregate_failures do
+        it 'returns an enumerable json with correct elements, including suspended accounts' do
           subject
 
           expect(response)

--- a/spec/requests/api/v1/accounts/statuses_spec.rb
+++ b/spec/requests/api/v1/accounts/statuses_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'API V1 Accounts Statuses' do
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
 
   describe 'GET /api/v1/accounts/:account_id/statuses' do
-    it 'returns expected headers', :aggregate_failures do
+    it 'returns expected headers' do
       status = Fabricate(:status, account: user.account)
       get "/api/v1/accounts/#{user.account.id}/statuses", params: { limit: 1 }, headers: headers
 
@@ -42,7 +42,7 @@ RSpec.describe 'API V1 Accounts Statuses' do
         get "/api/v1/accounts/#{user.account.id}/statuses", params: { exclude_replies: true }, headers: headers
       end
 
-      it 'returns posts along with self replies', :aggregate_failures do
+      it 'returns posts along with self replies' do
         expect(response)
           .to have_http_status(200)
         expect(response.content_type)

--- a/spec/requests/api/v1/accounts_spec.rb
+++ b/spec/requests/api/v1/accounts_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe '/api/v1/accounts' do
     context 'when logged out' do
       let(:account) { Fabricate(:account) }
 
-      it 'returns account entity as 200 OK', :aggregate_failures do
+      it 'returns account entity as 200 OK' do
         get "/api/v1/accounts/#{account.id}"
 
         expect(response).to have_http_status(200)
@@ -59,7 +59,7 @@ RSpec.describe '/api/v1/accounts' do
       let(:account) { Fabricate(:account) }
       let(:scopes) { 'read:accounts' }
 
-      it 'returns account entity as 200 OK', :aggregate_failures do
+      it 'returns account entity as 200 OK' do
         subject
 
         expect(response).to have_http_status(200)
@@ -84,7 +84,7 @@ RSpec.describe '/api/v1/accounts' do
     context 'when given truthy agreement' do
       let(:agreement) { 'true' }
 
-      it 'creates a user', :aggregate_failures do
+      it 'creates a user' do
         subject
 
         expect(response).to have_http_status(200)
@@ -121,7 +121,7 @@ RSpec.describe '/api/v1/accounts' do
       context 'with unlocked account' do
         let(:locked) { false }
 
-        it 'creates a following relation between user and target user', :aggregate_failures do
+        it 'creates a following relation between user and target user' do
           subject
 
           expect(response).to have_http_status(200)
@@ -143,7 +143,7 @@ RSpec.describe '/api/v1/accounts' do
       context 'with locked account' do
         let(:locked) { true }
 
-        it 'creates a follow request relation between user and target user', :aggregate_failures do
+        it 'creates a follow request relation between user and target user' do
           subject
 
           expect(response).to have_http_status(200)
@@ -235,7 +235,7 @@ RSpec.describe '/api/v1/accounts' do
       user.account.follow!(other_account)
     end
 
-    it 'removes the following relation between user and target user', :aggregate_failures do
+    it 'removes the following relation between user and target user' do
       subject
 
       expect(response).to have_http_status(200)
@@ -259,7 +259,7 @@ RSpec.describe '/api/v1/accounts' do
       other_account.follow!(user.account)
     end
 
-    it 'removes the followed relation between user and target user', :aggregate_failures do
+    it 'removes the followed relation between user and target user' do
       subject
 
       expect(response).to have_http_status(200)
@@ -283,7 +283,7 @@ RSpec.describe '/api/v1/accounts' do
       user.account.follow!(other_account)
     end
 
-    it 'creates a blocking relation', :aggregate_failures do
+    it 'creates a blocking relation' do
       subject
 
       expect(response).to have_http_status(200)
@@ -308,7 +308,7 @@ RSpec.describe '/api/v1/accounts' do
       user.account.block!(other_account)
     end
 
-    it 'removes the blocking relation between user and target user', :aggregate_failures do
+    it 'removes the blocking relation between user and target user' do
       subject
 
       expect(response).to have_http_status(200)
@@ -332,7 +332,7 @@ RSpec.describe '/api/v1/accounts' do
       user.account.follow!(other_account)
     end
 
-    it 'mutes notifications', :aggregate_failures do
+    it 'mutes notifications' do
       subject
 
       expect(response).to have_http_status(200)
@@ -358,7 +358,7 @@ RSpec.describe '/api/v1/accounts' do
       user.account.follow!(other_account)
     end
 
-    it 'does not mute notifications', :aggregate_failures do
+    it 'does not mute notifications' do
       subject
 
       expect(response).to have_http_status(200)
@@ -384,7 +384,7 @@ RSpec.describe '/api/v1/accounts' do
       user.account.follow!(other_account)
     end
 
-    it 'mutes notifications', :aggregate_failures do
+    it 'mutes notifications' do
       subject
 
       expect(response).to have_http_status(200)
@@ -410,7 +410,7 @@ RSpec.describe '/api/v1/accounts' do
       user.account.mute!(other_account)
     end
 
-    it 'removes the muting relation between user and target user', :aggregate_failures do
+    it 'removes the muting relation between user and target user' do
       subject
 
       expect(response).to have_http_status(200)

--- a/spec/requests/api/v1/admin/accounts_spec.rb
+++ b/spec/requests/api/v1/admin/accounts_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Accounts' do
     end
 
     shared_examples 'a successful request' do
-      it 'returns the correct accounts', :aggregate_failures do
+      it 'returns the correct accounts' do
         subject
 
         expect(response).to have_http_status(200)
@@ -91,7 +91,7 @@ RSpec.describe 'Accounts' do
     context 'with limit param' do
       let(:params) { { limit: 2 } }
 
-      it 'returns only the requested number of accounts', :aggregate_failures do
+      it 'returns only the requested number of accounts' do
         subject
 
         expect(response).to have_http_status(200)
@@ -112,7 +112,7 @@ RSpec.describe 'Accounts' do
     it_behaves_like 'forbidden for wrong scope', 'read read:accounts admin:write admin:write:accounts'
     it_behaves_like 'forbidden for wrong role', ''
 
-    it 'returns the requested account successfully', :aggregate_failures do
+    it 'returns the requested account successfully' do
       subject
 
       expect(response).to have_http_status(200)
@@ -149,7 +149,7 @@ RSpec.describe 'Accounts' do
       it_behaves_like 'forbidden for wrong scope', 'write write:accounts read admin:read'
       it_behaves_like 'forbidden for wrong role', ''
 
-      it 'approves the user successfully', :aggregate_failures do
+      it 'approves the user successfully' do
         subject
 
         expect(response).to have_http_status(200)
@@ -158,7 +158,7 @@ RSpec.describe 'Accounts' do
         expect(account.reload.user_approved?).to be(true)
       end
 
-      it 'logs action', :aggregate_failures do
+      it 'logs action' do
         subject
 
         expect(latest_admin_action_log)
@@ -207,7 +207,7 @@ RSpec.describe 'Accounts' do
       it_behaves_like 'forbidden for wrong scope', 'write write:accounts read admin:read'
       it_behaves_like 'forbidden for wrong role', ''
 
-      it 'removes the user successfully and logs action', :aggregate_failures do
+      it 'removes the user successfully and logs action' do
         subject
 
         expect(response).to have_http_status(200)
@@ -260,7 +260,7 @@ RSpec.describe 'Accounts' do
     it_behaves_like 'forbidden for wrong scope', 'write write:accounts read admin:read'
     it_behaves_like 'forbidden for wrong role', ''
 
-    it 'enables the user successfully', :aggregate_failures do
+    it 'enables the user successfully' do
       subject
 
       expect(response).to have_http_status(200)
@@ -295,7 +295,7 @@ RSpec.describe 'Accounts' do
       it_behaves_like 'forbidden for wrong scope', 'write write:accounts read admin:read'
       it_behaves_like 'forbidden for wrong role', ''
 
-      it 'unsuspends the account successfully', :aggregate_failures do
+      it 'unsuspends the account successfully' do
         subject
 
         expect(response).to have_http_status(200)
@@ -340,7 +340,7 @@ RSpec.describe 'Accounts' do
     it_behaves_like 'forbidden for wrong scope', 'write write:accounts read admin:read'
     it_behaves_like 'forbidden for wrong role', ''
 
-    it 'unsensitizes the account successfully', :aggregate_failures do
+    it 'unsensitizes the account successfully' do
       subject
 
       expect(response).to have_http_status(200)
@@ -374,7 +374,7 @@ RSpec.describe 'Accounts' do
     it_behaves_like 'forbidden for wrong scope', 'write write:accounts read admin:read'
     it_behaves_like 'forbidden for wrong role', ''
 
-    it 'unsilences the account successfully', :aggregate_failures do
+    it 'unsilences the account successfully' do
       subject
 
       expect(response).to have_http_status(200)
@@ -409,7 +409,7 @@ RSpec.describe 'Accounts' do
       it_behaves_like 'forbidden for wrong scope', 'write write:accounts read admin:read'
       it_behaves_like 'forbidden for wrong role', ''
 
-      it 'deletes the account successfully', :aggregate_failures do
+      it 'deletes the account successfully' do
         allow(Admin::AccountDeletionWorker).to receive(:perform_async)
         subject
 

--- a/spec/requests/api/v1/admin/canonical_email_blocks_spec.rb
+++ b/spec/requests/api/v1/admin/canonical_email_blocks_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe 'Canonical Email Blocks' do
     it_behaves_like 'forbidden for wrong role', 'Moderator'
 
     context 'when the requested canonical email block exists' do
-      it 'returns the requested canonical email block data correctly', :aggregate_failures do
+      it 'returns the requested canonical email block data correctly' do
         subject
 
         expect(response).to have_http_status(200)
@@ -148,7 +148,7 @@ RSpec.describe 'Canonical Email Blocks' do
       context 'when there is a matching canonical email block' do
         let!(:canonical_email_block) { CanonicalEmailBlock.create(params) }
 
-        it 'returns the expected canonical email hash', :aggregate_failures do
+        it 'returns the expected canonical email hash' do
           subject
 
           expect(response).to have_http_status(200)
@@ -159,7 +159,7 @@ RSpec.describe 'Canonical Email Blocks' do
       end
 
       context 'when there is no matching canonical email block' do
-        it 'returns an empty list', :aggregate_failures do
+        it 'returns an empty list' do
           subject
 
           expect(response).to have_http_status(200)
@@ -183,7 +183,7 @@ RSpec.describe 'Canonical Email Blocks' do
     it_behaves_like 'forbidden for wrong role', ''
     it_behaves_like 'forbidden for wrong role', 'Moderator'
 
-    it 'returns the canonical_email_hash correctly', :aggregate_failures do
+    it 'returns the canonical_email_hash correctly' do
       subject
 
       expect(response).to have_http_status(200)
@@ -207,7 +207,7 @@ RSpec.describe 'Canonical Email Blocks' do
     context 'when the canonical_email_hash param is provided instead of email' do
       let(:params) { { canonical_email_hash: 'dd501ce4e6b08698f19df96f2f15737e48a75660b1fa79b6ff58ea25ee4851a4' } }
 
-      it 'returns the correct canonical_email_hash', :aggregate_failures do
+      it 'returns the correct canonical_email_hash' do
         subject
 
         expect(response).to have_http_status(200)
@@ -220,7 +220,7 @@ RSpec.describe 'Canonical Email Blocks' do
     context 'when both email and canonical_email_hash params are provided' do
       let(:params) { { email: 'example@email.com', canonical_email_hash: 'dd501ce4e6b08698f19df96f2f15737e48a75660b1fa79b6ff58ea25ee4851a4' } }
 
-      it 'ignores the canonical_email_hash param', :aggregate_failures do
+      it 'ignores the canonical_email_hash param' do
         subject
 
         expect(response).to have_http_status(200)
@@ -257,7 +257,7 @@ RSpec.describe 'Canonical Email Blocks' do
     it_behaves_like 'forbidden for wrong role', ''
     it_behaves_like 'forbidden for wrong role', 'Moderator'
 
-    it 'deletes the canonical email block', :aggregate_failures do
+    it 'deletes the canonical email block' do
       subject
 
       expect(response).to have_http_status(200)

--- a/spec/requests/api/v1/admin/domain_allows_spec.rb
+++ b/spec/requests/api/v1/admin/domain_allows_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe 'Domain Allows' do
     it_behaves_like 'forbidden for wrong role', ''
     it_behaves_like 'forbidden for wrong role', 'Moderator'
 
-    it 'returns the expected allowed domain name', :aggregate_failures do
+    it 'returns the expected allowed domain name' do
       subject
 
       expect(response).to have_http_status(200)
@@ -110,7 +110,7 @@ RSpec.describe 'Domain Allows' do
     it_behaves_like 'forbidden for wrong role', 'Moderator'
 
     context 'with a valid domain name' do
-      it 'returns the expected domain name', :aggregate_failures do
+      it 'returns the expected domain name' do
         subject
 
         expect(response).to have_http_status(200)
@@ -169,7 +169,7 @@ RSpec.describe 'Domain Allows' do
     it_behaves_like 'forbidden for wrong role', ''
     it_behaves_like 'forbidden for wrong role', 'Moderator'
 
-    it 'deletes the allowed domain', :aggregate_failures do
+    it 'deletes the allowed domain' do
       subject
 
       expect(response).to have_http_status(200)

--- a/spec/requests/api/v1/admin/domain_blocks_spec.rb
+++ b/spec/requests/api/v1/admin/domain_blocks_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe 'Domain Blocks' do
     it_behaves_like 'forbidden for wrong role', ''
     it_behaves_like 'forbidden for wrong role', 'Moderator'
 
-    it 'returns the expected domain block content', :aggregate_failures do
+    it 'returns the expected domain block content' do
       subject
 
       expect(response).to have_http_status(200)
@@ -136,7 +136,7 @@ RSpec.describe 'Domain Blocks' do
     it_behaves_like 'forbidden for wrong role', ''
     it_behaves_like 'forbidden for wrong role', 'Moderator'
 
-    it 'creates a domain block with the expected domain name and severity', :aggregate_failures do
+    it 'creates a domain block with the expected domain name and severity' do
       subject
 
       expect(response).to have_http_status(200)
@@ -159,7 +159,7 @@ RSpec.describe 'Domain Blocks' do
         Fabricate(:domain_block, domain: 'bar.com', severity: :silence)
       end
 
-      it 'creates a domain block with the expected domain name and severity', :aggregate_failures do
+      it 'creates a domain block with the expected domain name and severity' do
         subject
 
         expect(response).to have_http_status(200)
@@ -181,7 +181,7 @@ RSpec.describe 'Domain Blocks' do
         Fabricate(:domain_block, domain: 'foo.bar.com', severity: :silence)
       end
 
-      it 'returns existing domain block in error', :aggregate_failures do
+      it 'returns existing domain block in error' do
         subject
 
         expect(response).to have_http_status(422)
@@ -196,7 +196,7 @@ RSpec.describe 'Domain Blocks' do
         Fabricate(:domain_block, domain: 'bar.com', severity: :suspend)
       end
 
-      it 'returns existing domain block in error', :aggregate_failures do
+      it 'returns existing domain block in error' do
         subject
 
         expect(response).to have_http_status(422)
@@ -231,7 +231,7 @@ RSpec.describe 'Domain Blocks' do
     it_behaves_like 'forbidden for wrong role', ''
     it_behaves_like 'forbidden for wrong role', 'Moderator'
 
-    it 'returns the updated domain block', :aggregate_failures do
+    it 'returns the updated domain block' do
       subject
 
       expect(response).to have_http_status(200)
@@ -273,7 +273,7 @@ RSpec.describe 'Domain Blocks' do
     it_behaves_like 'forbidden for wrong role', ''
     it_behaves_like 'forbidden for wrong role', 'Moderator'
 
-    it 'deletes the domain block', :aggregate_failures do
+    it 'deletes the domain block' do
       subject
 
       expect(response).to have_http_status(200)

--- a/spec/requests/api/v1/admin/email_domain_blocks_spec.rb
+++ b/spec/requests/api/v1/admin/email_domain_blocks_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe 'Email Domain Blocks' do
     it_behaves_like 'forbidden for wrong role', 'Moderator'
 
     context 'when email domain block exists' do
-      it 'returns the correct blocked domain', :aggregate_failures do
+      it 'returns the correct blocked domain' do
         subject
 
         expect(response).to have_http_status(200)
@@ -129,7 +129,7 @@ RSpec.describe 'Email Domain Blocks' do
     it_behaves_like 'forbidden for wrong role', ''
     it_behaves_like 'forbidden for wrong role', 'Moderator'
 
-    it 'returns the correct blocked email domain', :aggregate_failures do
+    it 'returns the correct blocked email domain' do
       subject
 
       expect(response).to have_http_status(200)
@@ -188,7 +188,7 @@ RSpec.describe 'Email Domain Blocks' do
     it_behaves_like 'forbidden for wrong role', ''
     it_behaves_like 'forbidden for wrong role', 'Moderator'
 
-    it 'deletes email domain block', :aggregate_failures do
+    it 'deletes email domain block' do
       subject
 
       expect(response).to have_http_status(200)

--- a/spec/requests/api/v1/admin/ip_blocks_spec.rb
+++ b/spec/requests/api/v1/admin/ip_blocks_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe 'IP Blocks' do
     it_behaves_like 'forbidden for wrong role', ''
     it_behaves_like 'forbidden for wrong role', 'Moderator'
 
-    it 'returns the correct ip block', :aggregate_failures do
+    it 'returns the correct ip block' do
       subject
 
       expect(response).to have_http_status(200)
@@ -124,7 +124,7 @@ RSpec.describe 'IP Blocks' do
     it_behaves_like 'forbidden for wrong role', ''
     it_behaves_like 'forbidden for wrong role', 'Moderator'
 
-    it 'returns the correct ip block', :aggregate_failures do
+    it 'returns the correct ip block' do
       subject
 
       expect(response).to have_http_status(200)
@@ -197,7 +197,7 @@ RSpec.describe 'IP Blocks' do
     let!(:ip_block) { IpBlock.create(ip: '185.200.13.3', severity: 'no_access', comment: 'Spam', expires_in: 48.hours) }
     let(:params)    { { severity: 'sign_up_requires_approval', comment: 'Decreasing severity' } }
 
-    it 'returns the correct ip block', :aggregate_failures do
+    it 'returns the correct ip block' do
       expect { subject }
         .to change_severity_level
         .and change_comment_value
@@ -238,7 +238,7 @@ RSpec.describe 'IP Blocks' do
 
     let!(:ip_block) { IpBlock.create(ip: '185.200.13.3', severity: 'no_access') }
 
-    it 'deletes the ip block', :aggregate_failures do
+    it 'deletes the ip block' do
       subject
 
       expect(response).to have_http_status(200)

--- a/spec/requests/api/v1/admin/reports_spec.rb
+++ b/spec/requests/api/v1/admin/reports_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe 'Reports' do
     it_behaves_like 'forbidden for wrong scope', 'write:statuses'
     it_behaves_like 'forbidden for wrong role', ''
 
-    it 'returns the requested report content', :aggregate_failures do
+    it 'returns the requested report content' do
       subject
 
       expect(response).to have_http_status(200)
@@ -156,7 +156,7 @@ RSpec.describe 'Reports' do
     let!(:report) { Fabricate(:report, category: :other) }
     let(:params)  { { category: 'spam' } }
 
-    it 'updates the report category', :aggregate_failures do
+    it 'updates the report category' do
       expect { subject }
         .to change { report.reload.category }.from('other').to('spam')
         .and create_an_action_log
@@ -193,7 +193,7 @@ RSpec.describe 'Reports' do
     it_behaves_like 'forbidden for wrong scope', 'write:statuses'
     it_behaves_like 'forbidden for wrong role', ''
 
-    it 'marks report as resolved', :aggregate_failures do
+    it 'marks report as resolved' do
       expect { subject }
         .to change { report.reload.unresolved? }.from(true).to(false)
         .and create_an_action_log
@@ -213,7 +213,7 @@ RSpec.describe 'Reports' do
     it_behaves_like 'forbidden for wrong scope', 'write:statuses'
     it_behaves_like 'forbidden for wrong role', ''
 
-    it 'marks report as unresolved', :aggregate_failures do
+    it 'marks report as unresolved' do
       expect { subject }
         .to change { report.reload.unresolved? }.from(false).to(true)
         .and create_an_action_log
@@ -233,7 +233,7 @@ RSpec.describe 'Reports' do
     it_behaves_like 'forbidden for wrong scope', 'write:statuses'
     it_behaves_like 'forbidden for wrong role', ''
 
-    it 'assigns report to the requesting user', :aggregate_failures do
+    it 'assigns report to the requesting user' do
       expect { subject }
         .to change { report.reload.assigned_account_id }.from(nil).to(user.account.id)
         .and create_an_action_log
@@ -253,7 +253,7 @@ RSpec.describe 'Reports' do
     it_behaves_like 'forbidden for wrong scope', 'write:statuses'
     it_behaves_like 'forbidden for wrong role', ''
 
-    it 'unassigns report from assignee', :aggregate_failures do
+    it 'unassigns report from assignee' do
       expect { subject }
         .to change { report.reload.assigned_account_id }.from(user.account.id).to(nil)
         .and create_an_action_log

--- a/spec/requests/api/v1/announcements/reactions_spec.rb
+++ b/spec/requests/api/v1/announcements/reactions_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'API V1 Announcements Reactions' do
         put "/api/v1/announcements/#{announcement.id}/reactions/#{escaped_emoji}", headers: headers
       end
 
-      it 'creates reaction', :aggregate_failures do
+      it 'creates reaction' do
         expect(response).to have_http_status(200)
         expect(response.content_type)
           .to start_with('application/json')
@@ -54,7 +54,7 @@ RSpec.describe 'API V1 Announcements Reactions' do
         delete "/api/v1/announcements/#{announcement.id}/reactions/#{escaped_emoji}", headers: headers
       end
 
-      it 'creates reaction', :aggregate_failures do
+      it 'creates reaction' do
         expect(response).to have_http_status(200)
         expect(response.content_type)
           .to start_with('application/json')

--- a/spec/requests/api/v1/announcements_spec.rb
+++ b/spec/requests/api/v1/announcements_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe 'API V1 Announcements' do
         post "/api/v1/announcements/#{announcement.id}/dismiss", headers: headers
       end
 
-      it 'dismisses announcement', :aggregate_failures do
+      it 'dismisses announcement' do
         expect(response).to have_http_status(200)
         expect(response.content_type)
           .to start_with('application/json')

--- a/spec/requests/api/v1/apps/credentials_spec.rb
+++ b/spec/requests/api/v1/apps/credentials_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Credentials' do
       let(:token)   { Fabricate(:accessible_access_token, application: application) }
       let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
 
-      it 'returns the app information correctly', :aggregate_failures do
+      it 'returns the app information correctly' do
         subject
 
         expect(response).to have_http_status(200)

--- a/spec/requests/api/v1/apps_spec.rb
+++ b/spec/requests/api/v1/apps_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'Apps' do
     end
 
     context 'with valid params' do
-      it 'creates an OAuth app', :aggregate_failures do
+      it 'creates an OAuth app' do
         subject
 
         expect(response).to have_http_status(200)
@@ -110,7 +110,7 @@ RSpec.describe 'Apps' do
     context 'with many duplicate scopes' do
       let(:scopes) { (%w(read) * 40).join(' ') }
 
-      it 'only saves the scope once', :aggregate_failures do
+      it 'only saves the scope once' do
         subject
 
         expect(response).to have_http_status(200)

--- a/spec/requests/api/v1/blocks_spec.rb
+++ b/spec/requests/api/v1/blocks_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Blocks' do
 
     it_behaves_like 'forbidden for wrong scope', 'write write:blocks'
 
-    it 'returns the blocked accounts', :aggregate_failures do
+    it 'returns the blocked accounts' do
       subject
 
       expect(response).to have_http_status(200)
@@ -51,7 +51,7 @@ RSpec.describe 'Blocks' do
     context 'with max_id param' do
       let(:params) { { max_id: blocks[1].id } }
 
-      it 'queries the blocks in range according to max_id', :aggregate_failures do
+      it 'queries the blocks in range according to max_id' do
         subject
 
         expect(response.parsed_body)
@@ -62,7 +62,7 @@ RSpec.describe 'Blocks' do
     context 'with since_id param' do
       let(:params) { { since_id: blocks[1].id } }
 
-      it 'queries the blocks in range according to since_id', :aggregate_failures do
+      it 'queries the blocks in range according to since_id' do
         subject
 
         expect(response.parsed_body)

--- a/spec/requests/api/v1/bookmarks_spec.rb
+++ b/spec/requests/api/v1/bookmarks_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'Bookmarks' do
     context 'with limit param' do
       let(:params) { { limit: 1 } }
 
-      it 'paginates correctly', :aggregate_failures do
+      it 'paginates correctly' do
         subject
 
         expect(response.parsed_body.size)

--- a/spec/requests/api/v1/conversations_spec.rb
+++ b/spec/requests/api/v1/conversations_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'API V1 Conversations' do
       PostStatusService.new.call(user.account, text: 'Hey, nobody here', visibility: 'direct')
     end
 
-    it 'returns pagination headers', :aggregate_failures do
+    it 'returns pagination headers' do
       get '/api/v1/conversations', params: { limit: 1 }, headers: headers
 
       expect(response)
@@ -30,7 +30,7 @@ RSpec.describe 'API V1 Conversations' do
         .to start_with('application/json')
     end
 
-    it 'returns conversations', :aggregate_failures do
+    it 'returns conversations' do
       get '/api/v1/conversations', headers: headers
 
       expect(response.parsed_body.size).to eq 2

--- a/spec/requests/api/v1/domain_blocks_spec.rb
+++ b/spec/requests/api/v1/domain_blocks_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Domain blocks' do
 
     it_behaves_like 'forbidden for wrong scope', 'write:blocks'
 
-    it 'returns the domains blocked by the requesting user', :aggregate_failures do
+    it 'returns the domains blocked by the requesting user' do
       subject
 
       expect(response).to have_http_status(200)
@@ -51,7 +51,7 @@ RSpec.describe 'Domain blocks' do
 
     it_behaves_like 'forbidden for wrong scope', 'read read:blocks'
 
-    it 'creates a domain block', :aggregate_failures do
+    it 'creates a domain block' do
       subject
 
       expect(response).to have_http_status(200)
@@ -98,7 +98,7 @@ RSpec.describe 'Domain blocks' do
 
     it_behaves_like 'forbidden for wrong scope', 'read read:blocks'
 
-    it 'deletes the specified domain block', :aggregate_failures do
+    it 'deletes the specified domain block' do
       subject
 
       expect(response).to have_http_status(200)

--- a/spec/requests/api/v1/emails/confirmations_spec.rb
+++ b/spec/requests/api/v1/emails/confirmations_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe 'Confirmations' do
         context 'with email param' do
           let(:params) { { email: 'foo@bar.com' } }
 
-          it "updates the user's e-mail address", :aggregate_failures do
+          it "updates the user's e-mail address" do
             subject
 
             expect(response).to have_http_status(200)
@@ -121,7 +121,7 @@ RSpec.describe 'Confirmations' do
 
     context 'with an oauth token' do
       context 'when the account is not confirmed' do
-        it 'returns the confirmation status successfully', :aggregate_failures do
+        it 'returns the confirmation status successfully' do
           subject
 
           expect(response).to have_http_status(200)
@@ -134,7 +134,7 @@ RSpec.describe 'Confirmations' do
       context 'when the account is confirmed' do
         let(:confirmed_at) { Time.now.utc }
 
-        it 'returns the confirmation status successfully', :aggregate_failures do
+        it 'returns the confirmation status successfully' do
           subject
 
           expect(response).to have_http_status(200)
@@ -153,7 +153,7 @@ RSpec.describe 'Confirmations' do
       end
 
       context 'when the account is not confirmed' do
-        it 'returns the confirmation status successfully', :aggregate_failures do
+        it 'returns the confirmation status successfully' do
           subject
 
           expect(response).to have_http_status(200)
@@ -166,7 +166,7 @@ RSpec.describe 'Confirmations' do
       context 'when the account is confirmed' do
         let(:confirmed_at) { Time.now.utc }
 
-        it 'returns the confirmation status successfully', :aggregate_failures do
+        it 'returns the confirmation status successfully' do
           subject
 
           expect(response).to have_http_status(200)

--- a/spec/requests/api/v1/filters_spec.rb
+++ b/spec/requests/api/v1/filters_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'API V1 Filters' do
       post '/api/v1/filters', params: { phrase: 'magic', context: %w(home), irreversible: irreversible, whole_word: whole_word }, headers: headers
     end
 
-    it 'creates a filter', :aggregate_failures do
+    it 'creates a filter' do
       filter = user.account.custom_filters.first
 
       expect(response).to have_http_status(200)
@@ -50,7 +50,7 @@ RSpec.describe 'API V1 Filters' do
       let(:irreversible) { false }
       let(:whole_word)   { true }
 
-      it 'creates a filter', :aggregate_failures do
+      it 'creates a filter' do
         filter = user.account.custom_filters.first
 
         expect(response).to have_http_status(200)
@@ -88,7 +88,7 @@ RSpec.describe 'API V1 Filters' do
       put "/api/v1/filters/#{keyword.id}", headers: headers, params: { phrase: 'updated' }
     end
 
-    it 'updates the filter', :aggregate_failures do
+    it 'updates the filter' do
       expect(response).to have_http_status(200)
       expect(response.content_type)
         .to start_with('application/json')
@@ -105,7 +105,7 @@ RSpec.describe 'API V1 Filters' do
       delete "/api/v1/filters/#{keyword.id}", headers: headers
     end
 
-    it 'removes the filter', :aggregate_failures do
+    it 'removes the filter' do
       expect(response).to have_http_status(200)
       expect(response.content_type)
         .to start_with('application/json')

--- a/spec/requests/api/v1/follow_requests_spec.rb
+++ b/spec/requests/api/v1/follow_requests_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'Follow requests' do
 
     it_behaves_like 'forbidden for wrong scope', 'write write:follows'
 
-    it 'returns the expected content from accounts requesting to follow', :aggregate_failures do
+    it 'returns the expected content from accounts requesting to follow' do
       subject
 
       expect(response).to have_http_status(200)
@@ -65,7 +65,7 @@ RSpec.describe 'Follow requests' do
 
     it_behaves_like 'forbidden for wrong scope', 'read read:follows'
 
-    it 'allows the requesting follower to follow', :aggregate_failures do
+    it 'allows the requesting follower to follow' do
       expect { subject }.to change { follower.following?(user.account) }.from(false).to(true)
       expect(response).to have_http_status(200)
       expect(response.content_type)
@@ -87,7 +87,7 @@ RSpec.describe 'Follow requests' do
 
     it_behaves_like 'forbidden for wrong scope', 'read read:follows'
 
-    it 'removes the follow request', :aggregate_failures do
+    it 'removes the follow request' do
       subject
 
       expect(response).to have_http_status(200)

--- a/spec/requests/api/v1/instances/translation_languages_spec.rb
+++ b/spec/requests/api/v1/instances/translation_languages_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Translation Languages' do
   describe 'GET /api/v1/instances/translation_languages' do
     context 'when no translation service is configured' do
-      it 'returns empty language matrix', :aggregate_failures do
+      it 'returns empty language matrix' do
         get api_v1_instance_translation_languages_path
 
         expect(response)
@@ -21,7 +21,7 @@ RSpec.describe 'Translation Languages' do
     context 'when a translation service is configured' do
       before { configure_translation_service }
 
-      it 'returns language matrix', :aggregate_failures do
+      it 'returns language matrix' do
         get api_v1_instance_translation_languages_path
 
         expect(response)

--- a/spec/requests/api/v1/lists/accounts_spec.rb
+++ b/spec/requests/api/v1/lists/accounts_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Accounts' do
 
     it_behaves_like 'forbidden for wrong scope', 'write write:lists'
 
-    it 'returns the accounts in the requested list', :aggregate_failures do
+    it 'returns the accounts in the requested list' do
       subject
 
       expect(response).to have_http_status(200)
@@ -66,7 +66,7 @@ RSpec.describe 'Accounts' do
         user.account.follow!(bob)
       end
 
-      it 'adds account to the list', :aggregate_failures do
+      it 'adds account to the list' do
         subject
 
         expect(response).to have_http_status(200)
@@ -81,7 +81,7 @@ RSpec.describe 'Accounts' do
         user.account.follow_requests.create!(target_account: bob)
       end
 
-      it 'adds account to the list', :aggregate_failures do
+      it 'adds account to the list' do
         subject
 
         expect(response).to have_http_status(200)
@@ -92,7 +92,7 @@ RSpec.describe 'Accounts' do
     end
 
     context 'when the added account is not followed' do
-      it 'does not add the account to the list', :aggregate_failures do
+      it 'does not add the account to the list' do
         subject
 
         expect(response).to have_http_status(404)
@@ -151,7 +151,7 @@ RSpec.describe 'Accounts' do
         list.accounts << [bob, peter]
       end
 
-      it 'removes the specified account from the list but keeps other accounts in the list', :aggregate_failures do
+      it 'removes the specified account from the list but keeps other accounts in the list' do
         subject
 
         expect(response).to have_http_status(200)
@@ -164,7 +164,7 @@ RSpec.describe 'Accounts' do
       context 'when the specified account is not in the list' do
         let(:params) { { account_ids: [0] } }
 
-        it 'does not remove any account from the list', :aggregate_failures do
+        it 'does not remove any account from the list' do
           subject
 
           expect(response).to have_http_status(200)

--- a/spec/requests/api/v1/lists_spec.rb
+++ b/spec/requests/api/v1/lists_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'Lists' do
 
     it_behaves_like 'forbidden for wrong scope', 'write write:lists'
 
-    it 'returns the expected lists', :aggregate_failures do
+    it 'returns the expected lists' do
       subject
 
       expect(response).to have_http_status(200)
@@ -58,7 +58,7 @@ RSpec.describe 'Lists' do
 
     it_behaves_like 'forbidden for wrong scope', 'write write:lists'
 
-    it 'returns the requested list correctly', :aggregate_failures do
+    it 'returns the requested list correctly' do
       subject
 
       expect(response).to have_http_status(200)
@@ -104,7 +104,7 @@ RSpec.describe 'Lists' do
 
     it_behaves_like 'forbidden for wrong scope', 'read read:lists'
 
-    it 'returns the new list', :aggregate_failures do
+    it 'returns the new list' do
       subject
 
       expect(response).to have_http_status(200)
@@ -149,7 +149,7 @@ RSpec.describe 'Lists' do
 
     it_behaves_like 'forbidden for wrong scope', 'read read:lists'
 
-    it 'returns the updated list and updates values', :aggregate_failures do
+    it 'returns the updated list and updates values' do
       expect { subject }
         .to change_list_title
         .and change_list_replies_policy
@@ -212,7 +212,7 @@ RSpec.describe 'Lists' do
 
     it_behaves_like 'forbidden for wrong scope', 'read read:lists'
 
-    it 'deletes the list', :aggregate_failures do
+    it 'deletes the list' do
       subject
 
       expect(response).to have_http_status(200)

--- a/spec/requests/api/v1/markers_spec.rb
+++ b/spec/requests/api/v1/markers_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'API Markers' do
       get '/api/v1/markers', headers: headers, params: { timeline: %w(home notifications) }
     end
 
-    it 'returns markers', :aggregate_failures do
+    it 'returns markers' do
       expect(response).to have_http_status(200)
       expect(response.content_type)
         .to start_with('application/json')
@@ -34,7 +34,7 @@ RSpec.describe 'API Markers' do
         post '/api/v1/markers', headers: headers, params: { home: { last_read_id: '69420' } }
       end
 
-      it 'creates a marker', :aggregate_failures do
+      it 'creates a marker' do
         expect(response).to have_http_status(200)
         expect(response.content_type)
           .to start_with('application/json')
@@ -49,7 +49,7 @@ RSpec.describe 'API Markers' do
         post '/api/v1/markers', headers: headers, params: { home: { last_read_id: '70120' } }
       end
 
-      it 'updates a marker', :aggregate_failures do
+      it 'updates a marker' do
         expect(response).to have_http_status(200)
         expect(response.content_type)
           .to start_with('application/json')

--- a/spec/requests/api/v1/media_spec.rb
+++ b/spec/requests/api/v1/media_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe 'Media' do
     let(:params) { {} }
 
     shared_examples 'a successful media upload' do |media_type|
-      it 'uploads the file successfully and returns correct media content', :aggregate_failures do
+      it 'uploads the file successfully and returns correct media content' do
         subject
 
         expect(response).to have_http_status(200)

--- a/spec/requests/api/v1/mutes_spec.rb
+++ b/spec/requests/api/v1/mutes_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe 'Mutes' do
     context 'with max_id param' do
       let(:params) { { max_id: mutes[1].id } }
 
-      it 'queries mutes in range according to max_id', :aggregate_failures do
+      it 'queries mutes in range according to max_id' do
         subject
 
         expect(response.parsed_body)
@@ -60,7 +60,7 @@ RSpec.describe 'Mutes' do
     context 'with since_id param' do
       let(:params) { { since_id: mutes[0].id } }
 
-      it 'queries mutes in range according to since_id', :aggregate_failures do
+      it 'queries mutes in range according to since_id' do
         subject
 
         expect(response.parsed_body)

--- a/spec/requests/api/v1/notifications/policies_spec.rb
+++ b/spec/requests/api/v1/notifications/policies_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Policies' do
     it_behaves_like 'forbidden for wrong scope', 'write write:notifications'
 
     context 'with no options' do
-      it 'returns json with expected attributes', :aggregate_failures do
+      it 'returns json with expected attributes' do
         subject
 
         expect(response).to have_http_status(200)
@@ -51,7 +51,7 @@ RSpec.describe 'Policies' do
 
     it_behaves_like 'forbidden for wrong scope', 'read read:notifications'
 
-    it 'changes notification policy and returns an updated json object', :aggregate_failures do
+    it 'changes notification policy and returns an updated json object' do
       expect { subject }
         .to change { NotificationPolicy.find_or_initialize_by(account: user.account).for_not_following.to_sym }.from(:accept).to(:filter)
 

--- a/spec/requests/api/v1/notifications/requests_spec.rb
+++ b/spec/requests/api/v1/notifications/requests_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Requests' do
     it_behaves_like 'forbidden for wrong scope', 'write write:notifications'
 
     context 'with no options' do
-      it 'returns http success', :aggregate_failures do
+      it 'returns http success' do
         subject
 
         expect(response).to have_http_status(200)
@@ -72,7 +72,7 @@ RSpec.describe 'Requests' do
 
     it_behaves_like 'forbidden for wrong scope', 'read read:notifications'
 
-    it 'returns http success and destroys the notification request', :aggregate_failures do
+    it 'returns http success and destroys the notification request' do
       expect { subject }.to change(NotificationRequest, :count).by(-1)
 
       expect(response).to have_http_status(200)
@@ -102,7 +102,7 @@ RSpec.describe 'Requests' do
 
     it_behaves_like 'forbidden for wrong scope', 'read read:notifications'
 
-    it 'returns http success and creates notification permission', :aggregate_failures do
+    it 'returns http success and creates notification permission' do
       subject
 
       expect(NotificationPermission.find_by(account: notification_request.account, from_account: notification_request.from_account)).to_not be_nil
@@ -121,7 +121,7 @@ RSpec.describe 'Requests' do
 
     it_behaves_like 'forbidden for wrong scope', 'read read:notifications'
 
-    it 'returns http success and destroys the notification request', :aggregate_failures do
+    it 'returns http success and destroys the notification request' do
       expect { subject }.to change(NotificationRequest, :count).by(-1)
 
       expect(response).to have_http_status(200)

--- a/spec/requests/api/v1/notifications_spec.rb
+++ b/spec/requests/api/v1/notifications_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe 'Notifications' do
     it_behaves_like 'forbidden for wrong scope', 'write write:notifications'
 
     context 'with no options' do
-      it 'returns expected notification types', :aggregate_failures do
+      it 'returns expected notification types' do
         subject
 
         expect(response).to have_http_status(200)
@@ -147,7 +147,7 @@ RSpec.describe 'Notifications' do
     context 'with account_id param' do
       let(:params) { { account_id: tom.account.id } }
 
-      it 'returns only notifications from specified user', :aggregate_failures do
+      it 'returns only notifications from specified user' do
         subject
 
         expect(response).to have_http_status(200)
@@ -164,7 +164,7 @@ RSpec.describe 'Notifications' do
     context 'with invalid account_id param' do
       let(:params) { { account_id: 'foo' } }
 
-      it 'returns nothing', :aggregate_failures do
+      it 'returns nothing' do
         subject
 
         expect(response).to have_http_status(200)
@@ -177,7 +177,7 @@ RSpec.describe 'Notifications' do
     context 'with exclude_types param' do
       let(:params) { { exclude_types: %w(mention) } }
 
-      it 'returns everything but excluded type', :aggregate_failures do
+      it 'returns everything but excluded type' do
         subject
 
         expect(response).to have_http_status(200)
@@ -191,7 +191,7 @@ RSpec.describe 'Notifications' do
     context 'with types param' do
       let(:params) { { types: %w(mention) } }
 
-      it 'returns only requested type', :aggregate_failures do
+      it 'returns only requested type' do
         subject
 
         expect(response).to have_http_status(200)
@@ -204,7 +204,7 @@ RSpec.describe 'Notifications' do
     context 'with limit param' do
       let(:params) { { limit: 3 } }
 
-      it 'returns the requested number of notifications paginated', :aggregate_failures do
+      it 'returns the requested number of notifications paginated' do
         subject
 
         notifications = user.account.notifications.browserable.order(id: :asc)

--- a/spec/requests/api/v1/polls/votes_spec.rb
+++ b/spec/requests/api/v1/polls/votes_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'API V1 Polls Votes' do
       post "/api/v1/polls/#{poll.id}/votes", params: params, headers: headers
     end
 
-    it 'creates a vote', :aggregate_failures do
+    it 'creates a vote' do
       expect(response).to have_http_status(200)
       expect(response.content_type)
         .to start_with('application/json')

--- a/spec/requests/api/v1/polls_spec.rb
+++ b/spec/requests/api/v1/polls_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Polls' do
     it_behaves_like 'forbidden for wrong scope', 'write write:statuses'
 
     context 'when parent status is public' do
-      it 'returns the poll data successfully', :aggregate_failures do
+      it 'returns the poll data successfully' do
         subject
 
         expect(response).to have_http_status(200)

--- a/spec/requests/api/v1/reports_spec.rb
+++ b/spec/requests/api/v1/reports_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'Reports' do
 
     it_behaves_like 'forbidden for wrong scope', 'read read:reports'
 
-    it 'creates a report', :aggregate_failures, :inline_jobs do
+    it 'creates a report', :inline_jobs do
       emails = capture_emails { subject }
 
       expect(response).to have_http_status(200)

--- a/spec/requests/api/v1/statuses/bookmarks_spec.rb
+++ b/spec/requests/api/v1/statuses/bookmarks_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Bookmarks' do
     it_behaves_like 'forbidden for wrong scope', 'read'
 
     context 'with public status' do
-      it 'bookmarks the status successfully and includes updated json', :aggregate_failures do
+      it 'bookmarks the status successfully and includes updated json' do
         subject
 
         expect(response).to have_http_status(200)
@@ -51,7 +51,7 @@ RSpec.describe 'Bookmarks' do
         user.account.follow!(status.account)
       end
 
-      it 'bookmarks the status successfully', :aggregate_failures do
+      it 'bookmarks the status successfully' do
         subject
 
         expect(response).to have_http_status(200)
@@ -99,7 +99,7 @@ RSpec.describe 'Bookmarks' do
           Bookmark.find_or_create_by!(account: user.account, status: status)
         end
 
-        it 'unbookmarks the status successfully and includes updated json', :aggregate_failures do
+        it 'unbookmarks the status successfully and includes updated json' do
           subject
 
           expect(response).to have_http_status(200)
@@ -121,7 +121,7 @@ RSpec.describe 'Bookmarks' do
           status.account.block!(user.account)
         end
 
-        it 'unbookmarks the status successfully and includes updated json', :aggregate_failures do
+        it 'unbookmarks the status successfully and includes updated json' do
           subject
 
           expect(response).to have_http_status(200)

--- a/spec/requests/api/v1/statuses/favourites_spec.rb
+++ b/spec/requests/api/v1/statuses/favourites_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Favourites', :inline_jobs do
     it_behaves_like 'forbidden for wrong scope', 'read read:favourites'
 
     context 'with public status' do
-      it 'favourites the status successfully and includes updated json', :aggregate_failures do
+      it 'favourites the status successfully and includes updated json' do
         subject
 
         expect(response).to have_http_status(200)
@@ -51,7 +51,7 @@ RSpec.describe 'Favourites', :inline_jobs do
         user.account.follow!(status.account)
       end
 
-      it 'favourites the status successfully', :aggregate_failures do
+      it 'favourites the status successfully' do
         subject
 
         expect(response).to have_http_status(200)
@@ -88,7 +88,7 @@ RSpec.describe 'Favourites', :inline_jobs do
         FavouriteService.new.call(user.account, status)
       end
 
-      it 'unfavourites the status successfully and includes updated json', :aggregate_failures do
+      it 'unfavourites the status successfully and includes updated json' do
         subject
 
         expect(response).to have_http_status(200)
@@ -109,7 +109,7 @@ RSpec.describe 'Favourites', :inline_jobs do
         status.account.block!(user.account)
       end
 
-      it 'unfavourites the status successfully and includes updated json', :aggregate_failures do
+      it 'unfavourites the status successfully and includes updated json' do
         subject
 
         expect(response).to have_http_status(200)

--- a/spec/requests/api/v1/statuses/mutes_spec.rb
+++ b/spec/requests/api/v1/statuses/mutes_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'API V1 Statuses Mutes' do
         post "/api/v1/statuses/#{status.id}/mute", headers: headers
       end
 
-      it 'creates a conversation mute', :aggregate_failures do
+      it 'creates a conversation mute' do
         expect(response).to have_http_status(200)
         expect(response.content_type)
           .to start_with('application/json')
@@ -32,7 +32,7 @@ RSpec.describe 'API V1 Statuses Mutes' do
         post "/api/v1/statuses/#{status.id}/unmute", headers: headers
       end
 
-      it 'destroys the conversation mute', :aggregate_failures do
+      it 'destroys the conversation mute' do
         expect(response).to have_http_status(200)
         expect(response.content_type)
           .to start_with('application/json')

--- a/spec/requests/api/v1/statuses/pins_spec.rb
+++ b/spec/requests/api/v1/statuses/pins_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Pins' do
     it_behaves_like 'forbidden for wrong scope', 'read read:accounts'
 
     context 'when the status is public' do
-      it 'pins the status successfully and returns updated json', :aggregate_failures do
+      it 'pins the status successfully and returns updated json' do
         subject
 
         expect(response).to have_http_status(200)
@@ -35,7 +35,7 @@ RSpec.describe 'Pins' do
     context 'when the status is private' do
       let(:status) { Fabricate(:status, account: user.account, visibility: :private) }
 
-      it 'pins the status successfully', :aggregate_failures do
+      it 'pins the status successfully' do
         subject
 
         expect(response).to have_http_status(200)
@@ -92,7 +92,7 @@ RSpec.describe 'Pins' do
         Fabricate(:status_pin, status: status, account: user.account)
       end
 
-      it 'unpins the status successfully and includes updated json', :aggregate_failures do
+      it 'unpins the status successfully and includes updated json' do
         subject
 
         expect(response).to have_http_status(200)

--- a/spec/requests/api/v1/statuses/reblogged_by_accounts_spec.rb
+++ b/spec/requests/api/v1/statuses/reblogged_by_accounts_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'API V1 Statuses Reblogged by Accounts' do
         Fabricate(:status, account: bob, reblog_of_id: status.id)
       end
 
-      it 'returns accounts who reblogged the status', :aggregate_failures do
+      it 'returns accounts who reblogged the status' do
         subject
 
         expect(response)

--- a/spec/requests/api/v1/statuses/reblogs_spec.rb
+++ b/spec/requests/api/v1/statuses/reblogs_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'API V1 Statuses Reblogs' do
       end
 
       context 'with public status' do
-        it 'reblogs the status', :aggregate_failures do
+        it 'reblogs the status' do
           expect(response).to have_http_status(200)
           expect(response.content_type)
             .to start_with('application/json')
@@ -57,7 +57,7 @@ RSpec.describe 'API V1 Statuses Reblogs' do
           post "/api/v1/statuses/#{status.id}/unreblog", headers: headers
         end
 
-        it 'destroys the reblog', :aggregate_failures do
+        it 'destroys the reblog' do
           expect(response).to have_http_status(200)
           expect(response.content_type)
             .to start_with('application/json')
@@ -84,7 +84,7 @@ RSpec.describe 'API V1 Statuses Reblogs' do
           post "/api/v1/statuses/#{status.id}/unreblog", headers: headers
         end
 
-        it 'destroys the reblog', :aggregate_failures do
+        it 'destroys the reblog' do
           expect(response).to have_http_status(200)
           expect(response.content_type)
             .to start_with('application/json')

--- a/spec/requests/api/v1/statuses/sources_spec.rb
+++ b/spec/requests/api/v1/statuses/sources_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Sources' do
     it_behaves_like 'forbidden for wrong scope', 'write write:statuses'
 
     context 'with public status' do
-      it 'returns the source properties of the status', :aggregate_failures do
+      it 'returns the source properties of the status' do
         subject
 
         expect(response).to have_http_status(200)
@@ -51,7 +51,7 @@ RSpec.describe 'Sources' do
         user.account.follow!(status.account)
       end
 
-      it 'returns the source properties of the status', :aggregate_failures do
+      it 'returns the source properties of the status' do
         subject
 
         expect(response).to have_http_status(200)

--- a/spec/requests/api/v1/statuses_spec.rb
+++ b/spec/requests/api/v1/statuses_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe '/api/v1/statuses' do
           user.account.custom_filters.create!(phrase: 'filter1', context: %w(home), action: :hide, keywords_attributes: [{ keyword: 'banned' }, { keyword: 'irrelevant' }])
         end
 
-        it 'returns filter information', :aggregate_failures do
+        it 'returns filter information' do
           subject
 
           expect(response).to have_http_status(200)
@@ -77,7 +77,7 @@ RSpec.describe '/api/v1/statuses' do
           filter.statuses.create!(status_id: status.id)
         end
 
-        it 'returns filter information', :aggregate_failures do
+        it 'returns filter information' do
           subject
 
           expect(response).to have_http_status(200)
@@ -101,7 +101,7 @@ RSpec.describe '/api/v1/statuses' do
           user.account.custom_filters.create!(phrase: 'filter1', context: %w(home), action: :hide, keywords_attributes: [{ keyword: 'banned' }, { keyword: 'irrelevant' }])
         end
 
-        it 'returns filter information', :aggregate_failures do
+        it 'returns filter information' do
           subject
 
           expect(response).to have_http_status(200)
@@ -147,7 +147,7 @@ RSpec.describe '/api/v1/statuses' do
       it_behaves_like 'forbidden for wrong scope', 'read read:statuses'
 
       context 'with a basic status body' do
-        it 'returns rate limit headers', :aggregate_failures do
+        it 'returns rate limit headers' do
           subject
 
           expect(response).to have_http_status(200)
@@ -164,7 +164,7 @@ RSpec.describe '/api/v1/statuses' do
 
         let(:params) { { status: '@alice hm, @bob is really annoying lately', allowed_mentions: [alice.id] } }
 
-        it 'returns serialized extra accounts in body', :aggregate_failures do
+        it 'returns serialized extra accounts in body' do
           subject
 
           expect(response).to have_http_status(422)
@@ -177,7 +177,7 @@ RSpec.describe '/api/v1/statuses' do
       context 'with missing parameters' do
         let(:params) { {} }
 
-        it 'returns rate limit headers', :aggregate_failures do
+        it 'returns rate limit headers' do
           subject
 
           expect(response).to have_http_status(422)
@@ -193,7 +193,7 @@ RSpec.describe '/api/v1/statuses' do
           RateLimiter::FAMILIES[:statuses][:limit].times { rate_limiter.record! }
         end
 
-        it 'returns rate limit headers', :aggregate_failures do
+        it 'returns rate limit headers' do
           subject
 
           expect(response).to have_http_status(429)
@@ -235,7 +235,7 @@ RSpec.describe '/api/v1/statuses' do
         context 'when the scheduling time is less than 5 minutes' do
           let(:params) { { status: 'Hello world', scheduled_at: 4.minutes.from_now } }
 
-          it 'does not create a scheduled status', :aggregate_failures do
+          it 'does not create a scheduled status' do
             subject
 
             expect(response).to have_http_status(422)
@@ -257,7 +257,7 @@ RSpec.describe '/api/v1/statuses' do
 
       it_behaves_like 'forbidden for wrong scope', 'read read:statuses'
 
-      it 'removes the status', :aggregate_failures do
+      it 'removes the status' do
         subject
 
         expect(response).to have_http_status(200)
@@ -277,7 +277,7 @@ RSpec.describe '/api/v1/statuses' do
 
       it_behaves_like 'forbidden for wrong scope', 'read read:statuses'
 
-      it 'updates the status', :aggregate_failures do
+      it 'updates the status' do
         subject
 
         expect(response).to have_http_status(200)

--- a/spec/requests/api/v1/tags_spec.rb
+++ b/spec/requests/api/v1/tags_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Tags' do
       let!(:tag) { Fabricate(:tag) }
       let(:name) { tag.name }
 
-      it 'returns the tag', :aggregate_failures do
+      it 'returns the tag' do
         subject
 
         expect(response).to have_http_status(200)
@@ -63,7 +63,7 @@ RSpec.describe 'Tags' do
     it_behaves_like 'forbidden for wrong scope', 'read read:follows'
 
     context 'when the tag exists' do
-      it 'creates follow', :aggregate_failures do
+      it 'creates follow' do
         subject
 
         expect(response).to have_http_status(:success)
@@ -76,7 +76,7 @@ RSpec.describe 'Tags' do
     context 'when the tag does not exist' do
       let(:name) { 'hoge' }
 
-      it 'creates a new tag with the specified name', :aggregate_failures do
+      it 'creates a new tag with the specified name' do
         subject
 
         expect(response).to have_http_status(200)
@@ -127,7 +127,7 @@ RSpec.describe 'Tags' do
 
     it_behaves_like 'forbidden for wrong scope', 'read read:follows'
 
-    it 'removes the follow', :aggregate_failures do
+    it 'removes the follow' do
       subject
 
       expect(response).to have_http_status(200)

--- a/spec/requests/api/v1/timelines/home_spec.rb
+++ b/spec/requests/api/v1/timelines/home_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'Home', :inline_jobs do
       context 'with limit param' do
         let(:params) { { limit: 1 } }
 
-        it 'returns only the requested number of statuses with pagination headers', :aggregate_failures do
+        it 'returns only the requested number of statuses with pagination headers' do
           subject
 
           expect(response.parsed_body.size).to eq(params[:limit])
@@ -91,7 +91,7 @@ RSpec.describe 'Home', :inline_jobs do
     context 'without a user context' do
       let(:token) { Fabricate(:accessible_access_token, resource_owner_id: nil, scopes: scopes) }
 
-      it 'returns http unprocessable entity', :aggregate_failures do
+      it 'returns http unprocessable entity' do
         subject
 
         expect(response)

--- a/spec/requests/api/v1/timelines/link_spec.rb
+++ b/spec/requests/api/v1/timelines/link_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Link' do
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
 
   shared_examples 'a successful request to the link timeline' do
-    it 'returns the expected statuses successfully', :aggregate_failures do
+    it 'returns the expected statuses successfully' do
       subject
 
       expect(response).to have_http_status(200)
@@ -135,7 +135,7 @@ RSpec.describe 'Link' do
       context 'with limit param' do
         let(:params) { { limit: 1, url: url } }
 
-        it 'returns only the requested number of statuses with pagination headers', :aggregate_failures do
+        it 'returns only the requested number of statuses with pagination headers' do
           subject
 
           expect(response).to have_http_status(200)

--- a/spec/requests/api/v1/timelines/public_spec.rb
+++ b/spec/requests/api/v1/timelines/public_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Public' do
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
 
   shared_examples 'a successful request to the public timeline' do
-    it 'returns the expected statuses successfully', :aggregate_failures do
+    it 'returns the expected statuses successfully' do
       subject
 
       expect(response).to have_http_status(200)
@@ -79,7 +79,7 @@ RSpec.describe 'Public' do
       context 'with limit param' do
         let(:params) { { limit: 1 } }
 
-        it 'returns only the requested number of statuses and sets pagination headers', :aggregate_failures do
+        it 'returns only the requested number of statuses and sets pagination headers' do
           subject
 
           expect(response).to have_http_status(200)

--- a/spec/requests/api/v1/timelines/tag_spec.rb
+++ b/spec/requests/api/v1/timelines/tag_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Tag' do
     end
 
     shared_examples 'a successful request to the tag timeline' do
-      it 'returns the expected statuses', :aggregate_failures do
+      it 'returns the expected statuses' do
         subject
 
         expect(response)
@@ -75,7 +75,7 @@ RSpec.describe 'Tag' do
         expect(response.parsed_body.size).to eq(params[:limit])
       end
 
-      it 'sets the correct pagination headers', :aggregate_failures do
+      it 'sets the correct pagination headers' do
         subject
 
         expect(response)

--- a/spec/requests/api/v2/filters/keywords_spec.rb
+++ b/spec/requests/api/v2/filters/keywords_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'API V2 Filters Keywords' do
       post "/api/v2/filters/#{filter_id}/keywords", headers: headers, params: { keyword: 'magic', whole_word: false }
     end
 
-    it 'creates a filter', :aggregate_failures do
+    it 'creates a filter' do
       expect(response).to have_http_status(200)
       expect(response.content_type)
         .to start_with('application/json')
@@ -78,7 +78,7 @@ RSpec.describe 'API V2 Filters Keywords' do
       get "/api/v2/filters/keywords/#{keyword.id}", headers: headers
     end
 
-    it 'responds with the keyword', :aggregate_failures do
+    it 'responds with the keyword' do
       expect(response).to have_http_status(200)
       expect(response.content_type)
         .to start_with('application/json')
@@ -109,7 +109,7 @@ RSpec.describe 'API V2 Filters Keywords' do
       put "/api/v2/filters/keywords/#{keyword.id}", headers: headers, params: { keyword: 'updated' }
     end
 
-    it 'updates the keyword', :aggregate_failures do
+    it 'updates the keyword' do
       expect(response).to have_http_status(200)
       expect(response.content_type)
         .to start_with('application/json')
@@ -136,7 +136,7 @@ RSpec.describe 'API V2 Filters Keywords' do
       delete "/api/v2/filters/keywords/#{keyword.id}", headers: headers
     end
 
-    it 'destroys the keyword', :aggregate_failures do
+    it 'destroys the keyword' do
       expect(response).to have_http_status(200)
       expect(response.content_type)
         .to start_with('application/json')

--- a/spec/requests/api/v2/filters/statuses_spec.rb
+++ b/spec/requests/api/v2/filters/statuses_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'API V2 Filters Statuses' do
       post "/api/v2/filters/#{filter_id}/statuses", headers: headers, params: { status_id: status.id }
     end
 
-    it 'creates a filter', :aggregate_failures do
+    it 'creates a filter' do
       expect(response).to have_http_status(200)
       expect(response.content_type)
         .to start_with('application/json')
@@ -78,7 +78,7 @@ RSpec.describe 'API V2 Filters Statuses' do
       get "/api/v2/filters/statuses/#{status_filter.id}", headers: headers
     end
 
-    it 'responds with the filter', :aggregate_failures do
+    it 'responds with the filter' do
       expect(response).to have_http_status(200)
       expect(response.content_type)
         .to start_with('application/json')
@@ -106,7 +106,7 @@ RSpec.describe 'API V2 Filters Statuses' do
       delete "/api/v2/filters/statuses/#{status_filter.id}", headers: headers
     end
 
-    it 'destroys the filter', :aggregate_failures do
+    it 'destroys the filter' do
       expect(response).to have_http_status(200)
       expect(response.content_type)
         .to start_with('application/json')

--- a/spec/requests/api/v2/filters_spec.rb
+++ b/spec/requests/api/v2/filters_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Filters' do
     it_behaves_like 'forbidden for wrong scope', 'write write:filters'
     it_behaves_like 'unauthorized for invalid token'
 
-    it 'returns the existing filters successfully', :aggregate_failures do
+    it 'returns the existing filters successfully' do
       subject
 
       expect(response).to have_http_status(200)
@@ -53,7 +53,7 @@ RSpec.describe 'Filters' do
     context 'with valid params' do
       let(:params) { { title: 'magic', context: %w(home), filter_action: 'hide', keywords_attributes: [keyword: 'magic'] } }
 
-      it 'returns http success with a filter with keywords in json and creates a filter', :aggregate_failures do
+      it 'returns http success with a filter with keywords in json and creates a filter' do
         subject
 
         expect(response).to have_http_status(200)
@@ -127,7 +127,7 @@ RSpec.describe 'Filters' do
     it_behaves_like 'forbidden for wrong scope', 'write write:filters'
     it_behaves_like 'unauthorized for invalid token'
 
-    it 'returns the filter successfully', :aggregate_failures do
+    it 'returns the filter successfully' do
       subject
 
       expect(response).to have_http_status(200)
@@ -168,7 +168,7 @@ RSpec.describe 'Filters' do
       context 'with valid params' do
         let(:params) { { title: 'updated', context: %w(home public) } }
 
-        it 'updates the filter successfully', :aggregate_failures do
+        it 'updates the filter successfully' do
           subject
 
           filter.reload

--- a/spec/requests/api/v2/notifications/policies_spec.rb
+++ b/spec/requests/api/v2/notifications/policies_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Policies' do
     it_behaves_like 'forbidden for wrong scope', 'write write:notifications'
 
     context 'with no options' do
-      it 'returns json with expected attributes', :aggregate_failures do
+      it 'returns json with expected attributes' do
         subject
 
         expect(response).to have_http_status(200)
@@ -52,7 +52,7 @@ RSpec.describe 'Policies' do
 
     it_behaves_like 'forbidden for wrong scope', 'read read:notifications'
 
-    it 'changes notification policy and returns an updated json object', :aggregate_failures do
+    it 'changes notification policy and returns an updated json object' do
       expect { subject }
         .to change { NotificationPolicy.find_or_initialize_by(account: user.account).for_not_following.to_sym }.from(:accept).to(:filter)
         .and change { NotificationPolicy.find_or_initialize_by(account: user.account).for_limited_accounts.to_sym }.from(:filter).to(:drop)

--- a/spec/requests/api/v2/notifications_spec.rb
+++ b/spec/requests/api/v2/notifications_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe 'Notifications' do
     end
 
     context 'with no options' do
-      it 'returns expected notification types', :aggregate_failures do
+      it 'returns expected notification types' do
         subject
 
         expect(response).to have_http_status(200)
@@ -191,7 +191,7 @@ RSpec.describe 'Notifications' do
     context 'with exclude_types param' do
       let(:params) { { exclude_types: %w(mention) } }
 
-      it 'returns everything but excluded type', :aggregate_failures do
+      it 'returns everything but excluded type' do
         subject
 
         expect(response).to have_http_status(200)
@@ -205,7 +205,7 @@ RSpec.describe 'Notifications' do
     context 'with types param' do
       let(:params) { { types: %w(mention) } }
 
-      it 'returns only requested type', :aggregate_failures do
+      it 'returns only requested type' do
         subject
 
         expect(response).to have_http_status(200)
@@ -220,7 +220,7 @@ RSpec.describe 'Notifications' do
       let(:params) { { limit: 3 } }
       let(:notifications) { user.account.notifications.reorder(id: :desc) }
 
-      it 'returns the requested number of notifications paginated', :aggregate_failures do
+      it 'returns the requested number of notifications paginated' do
         subject
 
         expect(response.parsed_body[:notification_groups].size)
@@ -242,7 +242,7 @@ RSpec.describe 'Notifications' do
       let(:params) { { since_id: notifications[2].id } }
       let(:notifications) { user.account.notifications.reorder(id: :desc) }
 
-      it 'returns the requested number of notifications paginated', :aggregate_failures do
+      it 'returns the requested number of notifications paginated' do
         subject
 
         expect(response.parsed_body[:notification_groups].size)
@@ -269,7 +269,7 @@ RSpec.describe 'Notifications' do
         FavouriteService.new.call(recent_account, user.account.statuses.first)
       end
 
-      it 'returns an account in "partial_accounts", with the expected keys', :aggregate_failures do
+      it 'returns an account in "partial_accounts", with the expected keys' do
         subject
 
         expect(response).to have_http_status(200)

--- a/spec/requests/cache_spec.rb
+++ b/spec/requests/cache_spec.rb
@@ -120,7 +120,7 @@ end
 
 RSpec.describe 'Caching behavior' do
   shared_examples 'cachable response' do |http_success: false|
-    it 'does not set cookies or set public cache control', :aggregate_failures do
+    it 'does not set cookies or set public cache control' do
       expect(response.cookies).to be_empty
 
       # expect(response.cache_control[:max_age]&.to_i).to be_positive
@@ -143,7 +143,7 @@ RSpec.describe 'Caching behavior' do
   end
 
   shared_examples 'non-cacheable error' do
-    it 'does not return HTTP success and does not have cache headers', :aggregate_failures do
+    it 'does not return HTTP success and does not have cache headers' do
       expect(response).to_not have_http_status(200)
       expect(response.cache_control[:public]).to be_falsy
     end
@@ -184,7 +184,7 @@ RSpec.describe 'Caching behavior' do
 
   context 'when anonymously accessed' do
     describe '/users/alice' do
-      it 'redirects with proper cache header', :aggregate_failures do
+      it 'redirects with proper cache header' do
         get '/users/alice'
 
         expect(response).to redirect_to('/@alice')

--- a/spec/requests/signature_verification_spec.rb
+++ b/spec/requests/signature_verification_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe 'signature verification concern' do
         'keyId="https://remote.domain/users/bob#main-key",algorithm="rsa-sha256",headers="date host (request-target)",signature="Z8ilar3J7bOwqZkMp7sL8sRs4B1FT+UorbmvWoE+A5UeoOJ3KBcUmbsh+k3wQwbP5gMNUrra9rEWabpasZGphLsbDxfbsWL3Cf0PllAc7c1c7AFEwnewtExI83/qqgEkfWc2z7UDutXc2NfgAx89Ox8DXU/fA2GG0jILjB6UpFyNugkY9rg6oI31UnvfVi3R7sr3/x8Ea3I9thPvqI2byF6cojknSpDAwYzeKdngX3TAQEGzFHz3SDWwyp3jeMWfwvVVbM38FxhvAnSumw7YwWW4L7M7h4M68isLimoT3yfCn2ucBVL5Dz8koBpYf/40w7QidClAwCafZQFC29yDOg=="' # rubocop:disable Layout/LineLength
       end
 
-      it 'successfuly verifies signature', :aggregate_failures do
+      it 'successfuly verifies signature' do
         expect(signature_header).to eq build_signature_string(actor_keypair, 'https://remote.domain/users/bob#main-key', 'get /activitypub/success', { 'Date' => 'Wed, 20 Dec 2023 10:00:00 GMT', 'Host' => 'www.example.com' })
 
         get '/activitypub/success', headers: {
@@ -99,7 +99,7 @@ RSpec.describe 'signature verification concern' do
         'keyId="https://remote.domain/users/bob#main-key",algorithm="rsa-sha256",headers="date host (request-target)",signature="SDMa4r/DQYMXYxVgYO2yEqGWWUXugKjVuz0I8dniQAk+aunzBaF2aPu+4grBfawAshlx1Xytl8lhb0H2MllEz16/tKY7rUrb70MK0w8ohXgpb0qs3YvQgdj4X24L1x2MnkFfKHR/J+7TBlnivq0HZqXm8EIkPWLv+eQxu8fbowLwHIVvRd/3t6FzvcfsE0UZKkoMEX02542MhwSif6cu7Ec/clsY9qgKahb9JVGOGS1op9Lvg/9y1mc8KCgD83U5IxVygYeYXaVQ6gixA9NgZiTCwEWzHM5ELm7w5hpdLFYxYOHg/3G3fiqJzpzNQAcCD4S4JxfE7hMI0IzVlNLT6A=="' # rubocop:disable Layout/LineLength
       end
 
-      it 'successfuly verifies signature', :aggregate_failures do
+      it 'successfuly verifies signature' do
         expect(signature_header).to eq build_signature_string(actor_keypair, 'https://remote.domain/users/bob#main-key', 'get /activitypub/success?foo=42', { 'Date' => 'Wed, 20 Dec 2023 10:00:00 GMT', 'Host' => 'www.example.com' })
 
         get '/activitypub/success?foo=42', headers: {
@@ -121,7 +121,7 @@ RSpec.describe 'signature verification concern' do
         'keyId="https://remote.domain/users/bob#main-key",algorithm="rsa-sha256",headers="date host (request-target)",signature="Z8ilar3J7bOwqZkMp7sL8sRs4B1FT+UorbmvWoE+A5UeoOJ3KBcUmbsh+k3wQwbP5gMNUrra9rEWabpasZGphLsbDxfbsWL3Cf0PllAc7c1c7AFEwnewtExI83/qqgEkfWc2z7UDutXc2NfgAx89Ox8DXU/fA2GG0jILjB6UpFyNugkY9rg6oI31UnvfVi3R7sr3/x8Ea3I9thPvqI2byF6cojknSpDAwYzeKdngX3TAQEGzFHz3SDWwyp3jeMWfwvVVbM38FxhvAnSumw7YwWW4L7M7h4M68isLimoT3yfCn2ucBVL5Dz8koBpYf/40w7QidClAwCafZQFC29yDOg=="' # rubocop:disable Layout/LineLength
       end
 
-      it 'successfuly verifies signature', :aggregate_failures do
+      it 'successfuly verifies signature' do
         expect(signature_header).to eq build_signature_string(actor_keypair, 'https://remote.domain/users/bob#main-key', 'get /activitypub/success', { 'Date' => 'Wed, 20 Dec 2023 10:00:00 GMT', 'Host' => 'www.example.com' })
 
         get '/activitypub/success?foo=42', headers: {
@@ -143,7 +143,7 @@ RSpec.describe 'signature verification concern' do
         'keyId="https://remote.domain/users/bob#main-key",algorithm="rsa-sha256",headers="date host (request-target)",signature="SDMa4r/DQYMXYxVgYO2yEqGWWUXugKjVuz0I8dniQAk+aunzBaF2aPu+4grBfawAshlx1Xytl8lhb0H2MllEz16/tKY7rUrb70MK0w8ohXgpb0qs3YvQgdj4X24L1x2MnkFfKHR/J+7TBlnivq0HZqXm8EIkPWLv+eQxu8fbowLwHIVvRd/3t6FzvcfsE0UZKkoMEX02542MhwSif6cu7Ec/clsY9qgKahb9JVGOGS1op9Lvg/9y1mc8KCgD83U5IxVygYeYXaVQ6gixA9NgZiTCwEWzHM5ELm7w5hpdLFYxYOHg/3G3fiqJzpzNQAcCD4S4JxfE7hMI0IzVlNLT6A=="' # rubocop:disable Layout/LineLength
       end
 
-      it 'fails to verify signature', :aggregate_failures do
+      it 'fails to verify signature' do
         expect(signature_header).to eq build_signature_string(actor_keypair, 'https://remote.domain/users/bob#main-key', 'get /activitypub/success?foo=42', { 'Date' => 'Wed, 20 Dec 2023 10:00:00 GMT', 'Host' => 'www.example.com' })
 
         get '/activitypub/success?foo=43', headers: {
@@ -161,7 +161,7 @@ RSpec.describe 'signature verification concern' do
     end
 
     context 'with a mismatching path' do
-      it 'fails to verify signature', :aggregate_failures do
+      it 'fails to verify signature' do
         get '/activitypub/alternative-path', headers: {
           'Host' => 'www.example.com',
           'Date' => 'Wed, 20 Dec 2023 10:00:00 GMT',
@@ -177,7 +177,7 @@ RSpec.describe 'signature verification concern' do
     end
 
     context 'with a mismatching method' do
-      it 'fails to verify signature', :aggregate_failures do
+      it 'fails to verify signature' do
         post '/activitypub/success', headers: {
           'Host' => 'www.example.com',
           'Date' => 'Wed, 20 Dec 2023 10:00:00 GMT',
@@ -197,7 +197,7 @@ RSpec.describe 'signature verification concern' do
         'keyId="https://remote.domain/users/bob#main-key",algorithm="rsa-sha256",headers="date host (request-target)",signature="d4B7nfx8RJcfdJDu1J//5WzPzK/hgtPkdzZx49lu5QhnE7qdV3lgyVimmhCFrO16bwvzIp9iRMyRLkNFxLiEeVaa1gqeKbldGSnU0B0OMjx7rFBa65vLuzWQOATDitVGiBEYqoK4v0DMuFCz2DtFaA/DIUZ3sty8bZ/Ea3U1nByLOO6MacARA3zhMSI0GNxGqsSmZmG0hPLavB3jIXoE3IDoQabMnC39jrlcO/a8h1iaxBm2WD8TejrImJullgqlJIFpKhIHI3ipQkvTGPlm9dx0y+beM06qBvWaWQcmT09eRIUefVsOAzIhUtS/7FVb/URhZvircIJDa7vtiFcmZQ=="' # rubocop:disable Layout/LineLength
       end
 
-      it 'fails to verify signature', :aggregate_failures do
+      it 'fails to verify signature' do
         expect(signature_header).to eq build_signature_string(actor_keypair, 'https://remote.domain/users/bob#main-key', 'get /activitypub/success', { 'Date' => 'wrong date', 'Host' => 'www.example.com' })
 
         get '/activitypub/success', headers: {
@@ -219,7 +219,7 @@ RSpec.describe 'signature verification concern' do
         'keyId="https://remote.domain/users/bob#main-key",algorithm="rsa-sha256",headers="date host (request-target)",signature="G1NuJv4zgoZ3B/ZIjzDWZHK4RC+5pYee74q8/LJEMCWXhcnAomcb9YHaqk1QYfQvcBUIXw3UZ3Q9xO8F9y0i8G5mzJHfQ+OgHqCoJk8EmGwsUXJMh5s1S5YFCRt8TT12TmJZz0VMqLq85ubueSYBM7QtUE/FzFIVLvz4RysgXxaXQKzdnM6+gbUEEKdCURpXdQt2NXQhp4MAmZH3+0lQoR6VxdsK0hx0Ji2PNp1nuqFTlYqNWZazVdLBN+9rETLRmvGXknvg9jOxTTppBVWnkAIl26HtLS3wwFVvz4pJzi9OQDOvLziehVyLNbU61hky+oJ215e2HuKSe2hxHNl1MA=="' # rubocop:disable Layout/LineLength
       end
 
-      it 'fails to verify signature', :aggregate_failures do
+      it 'fails to verify signature' do
         expect(signature_header).to eq build_signature_string(actor_keypair, 'https://remote.domain/users/bob#main-key', 'get /activitypub/success', { 'Date' => 'Wed, 18 Dec 2023 10:00:00 GMT', 'Host' => 'www.example.com' })
 
         get '/activitypub/success', headers: {
@@ -242,7 +242,7 @@ RSpec.describe 'signature verification concern' do
         'keyId="https://remote.domain/users/bob#main-key",algorithm="rsa-sha256",headers="host date digest (request-target)",signature="gmhMjgMROGElJU3fpehV2acD5kMHeELi8EFP2UPHOdQ54H0r55AxIpji+J3lPe+N2qSb/4H1KXIh6f0lRu8TGSsu12OQmg5hiO8VA9flcA/mh9Lpk+qwlQZIPRqKP9xUEfqD+Z7ti5wPzDKrWAUK/7FIqWgcT/mlqB1R1MGkpMFc/q4CIs2OSNiWgA4K+Kp21oQxzC2kUuYob04gAZ7cyE/FTia5t08uv6lVYFdRsn4XNPn1MsHgFBwBMRG79ng3SyhoG4PrqBEi5q2IdLq3zfre/M6He3wlCpyO2VJNdGVoTIzeZ0Zz8jUscPV3XtWUchpGclLGSaKaq/JyNZeiYQ=="' # rubocop:disable Layout/LineLength
       end
 
-      it 'successfuly verifies signature', :aggregate_failures do
+      it 'successfuly verifies signature' do
         expect(digest_header).to eq digest_value('Hello world')
         expect(signature_header).to eq build_signature_string(actor_keypair, 'https://remote.domain/users/bob#main-key', 'post /activitypub/success', { 'Host' => 'www.example.com', 'Date' => 'Wed, 20 Dec 2023 10:00:00 GMT', 'Digest' => digest_header })
 
@@ -267,7 +267,7 @@ RSpec.describe 'signature verification concern' do
         'keyId="https://remote.domain/users/bob#main-key",algorithm="rsa-sha256",headers="host date (request-target)",signature="CPD704CG8aCm8X8qIP8kkkiGp1qwFLk/wMVQHOGP0Txxan8c2DZtg/KK7eN8RG8tHx8br/yS2hJs51x4kXImYukGzNJd7ihE3T8lp+9RI1tCcdobTzr/VcVJHDFySdQkg266GCMijRQRZfNvqlJLiisr817PI+gNVBI5qV+vnVd1XhWCEZ+YSmMe8UqYARXAYNqMykTheojqGpTeTFGPUpTQA2Fmt2BipwIjcFDm2Hpihl2kB0MUS0x3zPmHDuadvzoBbN6m3usPDLgYrpALlh+wDs1dYMntcwdwawRKY1oE1XNtgOSum12wntDq3uYL4gya2iPdcw3c929b4koUzw=="' # rubocop:disable Layout/LineLength
       end
 
-      it 'fails to verify signature', :aggregate_failures do
+      it 'fails to verify signature' do
         expect(digest_header).to eq digest_value('Hello world')
         expect(signature_header).to eq build_signature_string(actor_keypair, 'https://remote.domain/users/bob#main-key', 'post /activitypub/success', { 'Host' => 'www.example.com', 'Date' => 'Wed, 20 Dec 2023 10:00:00 GMT' })
 
@@ -292,7 +292,7 @@ RSpec.describe 'signature verification concern' do
         'keyId="https://remote.domain/users/bob#main-key",algorithm="rsa-sha256",headers="host date digest (request-target)",signature="gmhMjgMROGElJU3fpehV2acD5kMHeELi8EFP2UPHOdQ54H0r55AxIpji+J3lPe+N2qSb/4H1KXIh6f0lRu8TGSsu12OQmg5hiO8VA9flcA/mh9Lpk+qwlQZIPRqKP9xUEfqD+Z7ti5wPzDKrWAUK/7FIqWgcT/mlqB1R1MGkpMFc/q4CIs2OSNiWgA4K+Kp21oQxzC2kUuYob04gAZ7cyE/FTia5t08uv6lVYFdRsn4XNPn1MsHgFBwBMRG79ng3SyhoG4PrqBEi5q2IdLq3zfre/M6He3wlCpyO2VJNdGVoTIzeZ0Zz8jUscPV3XtWUchpGclLGSaKaq/JyNZeiYQ=="' # rubocop:disable Layout/LineLength
       end
 
-      it 'fails to verify signature', :aggregate_failures do
+      it 'fails to verify signature' do
         expect(digest_header).to_not eq digest_value('Hello world!')
         expect(signature_header).to eq build_signature_string(actor_keypair, 'https://remote.domain/users/bob#main-key', 'post /activitypub/success', { 'Host' => 'www.example.com', 'Date' => 'Wed, 20 Dec 2023 10:00:00 GMT', 'Digest' => digest_header })
 
@@ -312,7 +312,7 @@ RSpec.describe 'signature verification concern' do
     end
 
     context 'with a tampered path in a POST request' do
-      it 'fails to verify signature', :aggregate_failures do
+      it 'fails to verify signature' do
         post '/activitypub/alternative-path', params: 'Hello world', headers: {
           'Host' => 'www.example.com',
           'Date' => 'Wed, 20 Dec 2023 10:00:00 GMT',
@@ -335,7 +335,7 @@ RSpec.describe 'signature verification concern' do
       stub_request(:get, 'https://remote.domain/users/alice#main-key').to_return(status: 404)
     end
 
-    it 'fails to verify signature', :aggregate_failures do
+    it 'fails to verify signature' do
       get '/activitypub/success', headers: {
         'Host' => 'www.example.com',
         'Date' => 'Wed, 20 Dec 2023 10:00:00 GMT',

--- a/spec/requests/statuses/embed_spec.rb
+++ b/spec/requests/statuses/embed_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'Status embed' do
     end
 
     context 'when status is public' do
-      it 'renders status successfully', :aggregate_failures do
+      it 'renders status successfully' do
         subject
 
         expect(response)

--- a/spec/services/after_block_domain_from_account_service_spec.rb
+++ b/spec/services/after_block_domain_from_account_service_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe AfterBlockDomainFromAccountService do
     alice.follow!(dog)
   end
 
-  it 'purge followers from blocked domain, remove notification permissions, sends `Reject->Follow`, and records severed relationships', :aggregate_failures do
+  it 'purge followers from blocked domain, remove notification permissions, sends `Reject->Follow`, and records severed relationships' do
     expect { subject.call(alice, 'evil.org') }
       .to change { wolf.following?(alice) }.from(true).to(false)
       .and change { NotificationPermission.exists?(account: alice, from_account: wolf) }.from(true).to(false)

--- a/spec/services/app_sign_up_service_spec.rb
+++ b/spec/services/app_sign_up_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe AppSignUpService do
     let(:params) { good_params }
 
     shared_examples 'successful registration' do
-      it 'creates an unconfirmed user with access token and the app\'s scope', :aggregate_failures do
+      it 'creates an unconfirmed user with access token and the app\'s scope' do
         access_token = subject.call(app, remote_ip, params)
         expect(access_token).to_not be_nil
         expect(access_token.scopes.to_s).to eq 'read write'
@@ -33,7 +33,7 @@ RSpec.describe AppSignUpService do
         Fabricate(:email_domain_block, allow_with_approval: true, domain: 'email.com')
       end
 
-      it 'creates an unapproved user', :aggregate_failures do
+      it 'creates an unapproved user' do
         access_token = subject.call(app, remote_ip, params)
         expect(access_token).to_not be_nil
         expect(access_token.scopes.to_s).to eq 'read write'
@@ -56,7 +56,7 @@ RSpec.describe AppSignUpService do
         configure_mx(domain: 'email.com', exchange: 'smtp.email.com')
       end
 
-      it 'creates an unapproved user', :aggregate_failures do
+      it 'creates an unapproved user' do
         access_token = subject.call(app, remote_ip, params)
         expect(access_token).to_not be_nil
         expect(access_token.scopes.to_s).to eq 'read write'
@@ -76,7 +76,7 @@ RSpec.describe AppSignUpService do
         Setting.registrations_mode = 'none'
       end
 
-      it 'raises an error', :aggregate_failures do
+      it 'raises an error' do
         expect { subject.call(app, remote_ip, good_params) }.to raise_error Mastodon::NotPermittedError
       end
 
@@ -95,7 +95,7 @@ RSpec.describe AppSignUpService do
         let(:params) { good_params.merge({ invite_code: invite.code }) }
         let(:invite) { Fabricate(:invite, uses: 1, max_uses: 1) }
 
-        it 'raises an error', :aggregate_failures do
+        it 'raises an error' do
           expect { subject.call(app, remote_ip, params) }.to raise_error Mastodon::NotPermittedError
         end
       end

--- a/spec/services/backup_service_spec.rb
+++ b/spec/services/backup_service_spec.rb
@@ -58,34 +58,28 @@ RSpec.describe BackupService do
     body = export_json_raw(:outbox)
     json = Oj.load(body)
 
-    aggregate_failures do
-      expect(body.scan('@context').count).to eq 1
-      expect(body.scan('orderedItems').count).to eq 1
-      expect(json['@context']).to_not be_nil
-      expect(json['type']).to eq 'OrderedCollection'
-      expect(json['totalItems']).to eq 2
-      expect(json['orderedItems'][0]['@context']).to be_nil
-      expect(json['orderedItems'][0]).to include_create_item(status)
-      expect(json['orderedItems'][1]).to include_create_item(private_status)
-    end
+    expect(body.scan('@context').count).to eq 1
+    expect(body.scan('orderedItems').count).to eq 1
+    expect(json['@context']).to_not be_nil
+    expect(json['type']).to eq 'OrderedCollection'
+    expect(json['totalItems']).to eq 2
+    expect(json['orderedItems'][0]['@context']).to be_nil
+    expect(json['orderedItems'][0]).to include_create_item(status)
+    expect(json['orderedItems'][1]).to include_create_item(private_status)
   end
 
   def expect_likes_export
     json = export_json(:likes)
 
-    aggregate_failures do
-      expect(json['type']).to eq 'OrderedCollection'
-      expect(json['orderedItems']).to eq [ActivityPub::TagManager.instance.uri_for(favourite.status)]
-    end
+    expect(json['type']).to eq 'OrderedCollection'
+    expect(json['orderedItems']).to eq [ActivityPub::TagManager.instance.uri_for(favourite.status)]
   end
 
   def expect_bookmarks_export
     json = export_json(:bookmarks)
 
-    aggregate_failures do
-      expect(json['type']).to eq 'OrderedCollection'
-      expect(json['orderedItems']).to eq [ActivityPub::TagManager.instance.uri_for(bookmark.status)]
-    end
+    expect(json['type']).to eq 'OrderedCollection'
+    expect(json['orderedItems']).to eq [ActivityPub::TagManager.instance.uri_for(bookmark.status)]
   end
 
   def export_json_raw(type)

--- a/spec/services/dismiss_notification_request_service_spec.rb
+++ b/spec/services/dismiss_notification_request_service_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe DismissNotificationRequestService do
     let(:receiver) { Fabricate(:account) }
     let(:request) { Fabricate(:notification_request, account: receiver, from_account: sender) }
 
-    it 'destroys the request and queues a worker', :aggregate_failures do
+    it 'destroys the request and queues a worker' do
       expect { described_class.new.call(request) }
         .to change(request, :destroyed?).to(true)
 

--- a/spec/services/software_update_check_service_spec.rb
+++ b/spec/services/software_update_check_service_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe SoftwareUpdateCheckService do
       end
 
       context 'when no update is urgent' do
-        it 'sends e-mail notifications according to settings', :aggregate_failures do
+        it 'sends e-mail notifications according to settings' do
           expect { subject.call }.to have_enqueued_mail(AdminMailer, :new_software_updates)
             .with(hash_including(params: { recipient: owner_user.account })).once
             .and(have_enqueued_mail(AdminMailer, :new_software_updates).with(hash_including(params: { recipient: patch_user.account })).once)
@@ -111,7 +111,7 @@ RSpec.describe SoftwareUpdateCheckService do
           }
         end
 
-        it 'sends e-mail notifications according to settings', :aggregate_failures do
+        it 'sends e-mail notifications according to settings' do
           expect { subject.call }.to have_enqueued_mail(AdminMailer, :new_critical_software_updates)
             .with(hash_including(params: { recipient: owner_user.account })).once
             .and(have_enqueued_mail(AdminMailer, :new_critical_software_updates).with(hash_including(params: { recipient: patch_user.account })).once)

--- a/spec/services/suspend_account_service_spec.rb
+++ b/spec/services/suspend_account_service_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe SuspendAccountService, :inline_jobs do
         account.follow!(local_followee)
       end
 
-      it 'sends a Reject Follow activity', :aggregate_failures do
+      it 'sends a Reject Follow activity' do
         subject
 
         expect(a_request(:post, account.inbox_url).with { |req| match_reject_follow_request(req, account, local_followee) }).to have_been_made.once

--- a/spec/support/browser_errors.rb
+++ b/spec/support/browser_errors.rb
@@ -25,14 +25,12 @@ RSpec.configure do |config|
     end
 
     if errors.present?
-      aggregate_failures 'browser errrors' do
-        errors.each do |error|
-          expect(error.level).to_not eq('SEVERE'), error.message
-          next unless error.level == 'WARNING'
+      errors.each do |error|
+        expect(error.level).to_not eq('SEVERE'), error.message
+        next unless error.level == 'WARNING'
 
-          warn 'WARN: browser warning'
-          warn error.message
-        end
+        warn 'WARN: browser warning'
+        warn error.message
       end
     end
   end

--- a/spec/system/settings/exports_spec.rb
+++ b/spec/system/settings/exports_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Export page' do
 
   describe 'Viewing the export page' do
     context 'when signed in' do
-      it 'shows the export page', :aggregate_failures do
+      it 'shows the export page' do
         visit settings_export_path
 
         expect(page)

--- a/spec/workers/mention_resolve_worker_spec.rb
+++ b/spec/workers/mention_resolve_worker_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe MentionResolveWorker do
         allow(service_double).to receive(:call).with(uri, anything) { Fabricate(:account, domain: 'example.com', uri: uri) }
       end
 
-      it 'resolves the account and adds a new mention', :aggregate_failures do
+      it 'resolves the account and adds a new mention' do
         expect { subject }
           .to change { status.reload.mentions }.from([]).to(a_collection_including(having_attributes(account: having_attributes(uri: uri), silent: false)))
 


### PR DESCRIPTION
As we continue to migrate things towards multiple assertions about same execution, I think it makes sense to just turn this on globally ... I also can't think of scenarios where I would not want to see all failures.

Changes here:

- In config  file, enable aggregate_failures by default everywhere
- In spec files, remove the explicit enables
- Quick clean up of block_domain_service spec (noticed while scanning diff here)