### PR TITLE
Fix multiple bugs in notification requests and notification policies

### DIFF
--- a/app/javascript/mastodon/actions/notification_policies.ts
+++ b/app/javascript/mastodon/actions/notification_policies.ts
@@ -17,6 +17,6 @@ export const updateNotificationsPolicy = createDataLoadingThunk(
   (policy: Partial<NotificationPolicy>) => apiUpdateNotificationsPolicy(policy),
 );
 
-export const decreasePendingNotificationsCount = createAction<number>(
-  'notificationPolicy/decreasePendingNotificationCount',
+export const decreasePendingRequestsCount = createAction<number>(
+  'notificationPolicy/decreasePendingRequestsCount',
 );

--- a/app/javascript/mastodon/api/notifications.ts
+++ b/app/javascript/mastodon/api/notifications.ts
@@ -91,5 +91,5 @@ export const apiAcceptNotificationRequests = async (id: string[]) => {
 };
 
 export const apiDismissNotificationRequests = async (id: string[]) => {
-  return apiRequestPost('v1/notifications/dismiss/dismiss', { id });
+  return apiRequestPost('v1/notifications/requests/dismiss', { id });
 };

--- a/app/javascript/mastodon/features/notifications/components/filtered_notifications_banner.tsx
+++ b/app/javascript/mastodon/features/notifications/components/filtered_notifications_banner.tsx
@@ -31,7 +31,7 @@ export const FilteredNotificationsIconButton: React.FC<{
     history.push('/notifications/requests');
   }, [history]);
 
-  if (policy === null || policy.summary.pending_notifications_count === 0) {
+  if (policy === null || policy.summary.pending_requests_count <= 0) {
     return null;
   }
 
@@ -70,7 +70,7 @@ export const FilteredNotificationsBanner: React.FC = () => {
     };
   }, [dispatch]);
 
-  if (policy === null || policy.summary.pending_notifications_count === 0) {
+  if (policy === null || policy.summary.pending_requests_count <= 0) {
     return null;
   }
 

--- a/app/javascript/mastodon/reducers/notification_policy.ts
+++ b/app/javascript/mastodon/reducers/notification_policy.ts
@@ -2,7 +2,7 @@ import { createReducer, isAnyOf } from '@reduxjs/toolkit';
 
 import {
   fetchNotificationPolicy,
-  decreasePendingNotificationsCount,
+  decreasePendingRequestsCount,
   updateNotificationsPolicy,
 } from 'mastodon/actions/notification_policies';
 import type { NotificationPolicy } from 'mastodon/models/notification_policy';
@@ -10,10 +10,9 @@ import type { NotificationPolicy } from 'mastodon/models/notification_policy';
 export const notificationPolicyReducer =
   createReducer<NotificationPolicy | null>(null, (builder) => {
     builder
-      .addCase(decreasePendingNotificationsCount, (state, action) => {
+      .addCase(decreasePendingRequestsCount, (state, action) => {
         if (state) {
-          state.summary.pending_notifications_count -= action.payload;
-          state.summary.pending_requests_count -= 1;
+          state.summary.pending_requests_count -= action.payload;
         }
       })
       .addMatcher(


### PR DESCRIPTION
This:
- fixes an issue with the number of pending notification requests not being properly decremented when accepting/rejecting more than 1 request in bulk
- only shows the “Filtered notifications From X people you may know” banner if there is more than 0 counted notification requests, since the *notifications* count is not shown and can more easily go out of sync
- fix wrong endpoint path for bulk rejection of requests