### PR TITLE
Prefer structure checks over multi-line size/parts checks in `parsed_body`

### DIFF
--- a/spec/requests/api/v1/accounts/follower_accounts_spec.rb
+++ b/spec/requests/api/v1/accounts/follower_accounts_spec.rb
@@ -23,8 +23,11 @@ RSpec.describe 'API V1 Accounts FollowerAccounts' do
       expect(response).to have_http_status(200)
       expect(response.content_type)
         .to start_with('application/json')
-      expect(response.parsed_body.size).to eq 2
-      expect([response.parsed_body[0][:id], response.parsed_body[1][:id]]).to contain_exactly(alice.id.to_s, bob.id.to_s)
+      expect(response.parsed_body)
+        .to contain_exactly(
+          hash_including(id: alice.id.to_s),
+          hash_including(id: bob.id.to_s)
+        )
     end
 
     it 'does not return blocked users', :aggregate_failures do
@@ -34,8 +37,10 @@ RSpec.describe 'API V1 Accounts FollowerAccounts' do
       expect(response).to have_http_status(200)
       expect(response.content_type)
         .to start_with('application/json')
-      expect(response.parsed_body.size).to eq 1
-      expect(response.parsed_body[0][:id]).to eq alice.id.to_s
+      expect(response.parsed_body)
+        .to contain_exactly(
+          hash_including(id: alice.id.to_s)
+        )
     end
 
     context 'when requesting user is blocked' do
@@ -56,8 +61,11 @@ RSpec.describe 'API V1 Accounts FollowerAccounts' do
         account.mute!(bob)
         get "/api/v1/accounts/#{account.id}/followers", params: { limit: 2 }, headers: headers
 
-        expect(response.parsed_body.size).to eq 2
-        expect([response.parsed_body[0][:id], response.parsed_body[1][:id]]).to contain_exactly(alice.id.to_s, bob.id.to_s)
+        expect(response.parsed_body)
+          .to contain_exactly(
+            hash_including(id: alice.id.to_s),
+            hash_including(id: bob.id.to_s)
+          )
       end
     end
   end

--- a/spec/requests/api/v1/accounts/following_accounts_spec.rb
+++ b/spec/requests/api/v1/accounts/following_accounts_spec.rb
@@ -23,8 +23,11 @@ RSpec.describe 'API V1 Accounts FollowingAccounts' do
       expect(response).to have_http_status(200)
       expect(response.content_type)
         .to start_with('application/json')
-      expect(response.parsed_body.size).to eq 2
-      expect([response.parsed_body[0][:id], response.parsed_body[1][:id]]).to contain_exactly(alice.id.to_s, bob.id.to_s)
+      expect(response.parsed_body)
+        .to contain_exactly(
+          hash_including(id: alice.id.to_s),
+          hash_including(id: bob.id.to_s)
+        )
     end
 
     it 'does not return blocked users', :aggregate_failures do
@@ -34,8 +37,10 @@ RSpec.describe 'API V1 Accounts FollowingAccounts' do
       expect(response).to have_http_status(200)
       expect(response.content_type)
         .to start_with('application/json')
-      expect(response.parsed_body.size).to eq 1
-      expect(response.parsed_body[0][:id]).to eq alice.id.to_s
+      expect(response.parsed_body)
+        .to contain_exactly(
+          hash_including(id: alice.id.to_s)
+        )
     end
 
     context 'when requesting user is blocked' do
@@ -56,8 +61,11 @@ RSpec.describe 'API V1 Accounts FollowingAccounts' do
         account.mute!(bob)
         get "/api/v1/accounts/#{account.id}/following", params: { limit: 2 }, headers: headers
 
-        expect(response.parsed_body.size).to eq 2
-        expect([response.parsed_body[0][:id], response.parsed_body[1][:id]]).to contain_exactly(alice.id.to_s, bob.id.to_s)
+        expect(response.parsed_body)
+          .to contain_exactly(
+            hash_including(id: alice.id.to_s),
+            hash_including(id: bob.id.to_s)
+          )
       end
     end
   end

--- a/spec/requests/api/v1/directories_spec.rb
+++ b/spec/requests/api/v1/directories_spec.rb
@@ -84,8 +84,11 @@ RSpec.describe 'Directories API' do
         expect(response).to have_http_status(200)
         expect(response.content_type)
           .to start_with('application/json')
-        expect(response.parsed_body.size).to eq(2)
-        expect(response.parsed_body.pluck(:id)).to contain_exactly(eligible_remote_account.id.to_s, local_discoverable_account.id.to_s)
+        expect(response.parsed_body)
+          .to contain_exactly(
+            hash_including(id: eligible_remote_account.id.to_s),
+            hash_including(id: local_discoverable_account.id.to_s)
+          )
       end
     end
 
@@ -105,9 +108,11 @@ RSpec.describe 'Directories API' do
         expect(response).to have_http_status(200)
         expect(response.content_type)
           .to start_with('application/json')
-        expect(response.parsed_body.size).to eq(1)
-        expect(response.parsed_body.first[:id]).to include(local_account.id.to_s)
-        expect(response.body).to_not include(remote_account.id.to_s)
+        expect(response.parsed_body)
+          .to contain_exactly(
+            hash_including(id: local_account.id.to_s)
+          )
+          .and not_include(remote_account.id.to_s)
       end
     end
 
@@ -121,9 +126,11 @@ RSpec.describe 'Directories API' do
         expect(response).to have_http_status(200)
         expect(response.content_type)
           .to start_with('application/json')
-        expect(response.parsed_body.size).to eq(2)
-        expect(response.parsed_body.first[:id]).to include(new_stat.account_id.to_s)
-        expect(response.parsed_body.second[:id]).to include(old_stat.account_id.to_s)
+        expect(response.parsed_body)
+          .to contain_exactly(
+            hash_including(id: new_stat.account_id.to_s),
+            hash_including(id: old_stat.account_id.to_s)
+          )
       end
     end
 
@@ -138,9 +145,11 @@ RSpec.describe 'Directories API' do
         expect(response).to have_http_status(200)
         expect(response.content_type)
           .to start_with('application/json')
-        expect(response.parsed_body.size).to eq(2)
-        expect(response.parsed_body.first[:id]).to include(account_new.id.to_s)
-        expect(response.parsed_body.second[:id]).to include(account_old.id.to_s)
+        expect(response.parsed_body)
+          .to contain_exactly(
+            hash_including(id: account_new.id.to_s),
+            hash_including(id: account_old.id.to_s)
+          )
       end
     end
   end

--- a/spec/requests/api/v1/peers/search_spec.rb
+++ b/spec/requests/api/v1/peers/search_spec.rb
@@ -55,10 +55,10 @@ RSpec.describe 'API Peers Search' do
           .to have_http_status(200)
         expect(response.content_type)
           .to start_with('application/json')
-        expect(response.parsed_body.size)
-          .to eq(1)
-        expect(response.parsed_body.first)
-          .to eq(account.domain)
+        expect(response.parsed_body)
+          .to contain_exactly(
+            eq(account.domain)
+          )
       end
     end
   end

--- a/spec/requests/api/v1/statuses/favourited_by_accounts_spec.rb
+++ b/spec/requests/api/v1/statuses/favourited_by_accounts_spec.rb
@@ -36,8 +36,6 @@ RSpec.describe 'API V1 Statuses Favourited by Accounts' do
         expect(response.content_type)
           .to start_with('application/json')
 
-        expect(response.parsed_body.size)
-          .to eq(2)
         expect(response.parsed_body)
           .to contain_exactly(
             include(id: alice.id.to_s),
@@ -50,9 +48,10 @@ RSpec.describe 'API V1 Statuses Favourited by Accounts' do
 
         subject
 
-        expect(response.parsed_body.size)
-          .to eq 1
-        expect(response.parsed_body.first[:id]).to eq(alice.id.to_s)
+        expect(response.parsed_body)
+          .to contain_exactly(
+            hash_including(id: alice.id.to_s)
+          )
       end
     end
   end

--- a/spec/requests/api/v1/statuses/reblogged_by_accounts_spec.rb
+++ b/spec/requests/api/v1/statuses/reblogged_by_accounts_spec.rb
@@ -35,8 +35,6 @@ RSpec.describe 'API V1 Statuses Reblogged by Accounts' do
         expect(response.content_type)
           .to start_with('application/json')
 
-        expect(response.parsed_body.size)
-          .to eq(2)
         expect(response.parsed_body)
           .to contain_exactly(
             include(id: alice.id.to_s),
@@ -49,9 +47,10 @@ RSpec.describe 'API V1 Statuses Reblogged by Accounts' do
 
         subject
 
-        expect(response.parsed_body.size)
-          .to eq 1
-        expect(response.parsed_body.first[:id]).to eq(alice.id.to_s)
+        expect(response.parsed_body)
+          .to contain_exactly(
+            hash_including(id: alice.id.to_s)
+          )
       end
     end
   end


### PR DESCRIPTION
Continuing cleanup, nudging the checks away from navigating by array indexes, `first`, `last`, etc - and towards built-in matchers, as side effect, we can drop the `size` check in some spots as its implicit with others.