### PR TITLE
Extract job args and stubs in bulk import service spec

### DIFF
--- a/spec/services/bulk_import_service_spec.rb
+++ b/spec/services/bulk_import_service_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe BulkImportService do
 
       it 'enqueues workers for the expected rows' do
         subject.call(import)
-        expect(Import::RowWorker.jobs.pluck('args').flatten).to match_array(rows.map(&:id))
+        expect(row_worker_job_args).to match_array(rows.map(&:id))
       end
 
       it 'requests to follow all the listed users once the workers have run' do
@@ -79,7 +79,7 @@ RSpec.describe BulkImportService do
 
       it 'enqueues workers for the expected rows' do
         subject.call(import)
-        expect(Import::RowWorker.jobs.pluck('args').flatten).to match_array(rows[1..].map(&:id))
+        expect(row_worker_job_args).to match_array(rows[1..].map(&:id))
       end
 
       it 'requests to follow all the expected users once the workers have run' do
@@ -114,7 +114,7 @@ RSpec.describe BulkImportService do
 
       it 'enqueues workers for the expected rows' do
         subject.call(import)
-        expect(Import::RowWorker.jobs.pluck('args').flatten).to match_array(rows.map(&:id))
+        expect(row_worker_job_args).to match_array(rows.map(&:id))
       end
 
       it 'blocks all the listed users once the workers have run' do
@@ -155,7 +155,7 @@ RSpec.describe BulkImportService do
 
       it 'enqueues workers for the expected rows' do
         subject.call(import)
-        expect(Import::RowWorker.jobs.pluck('args').flatten).to match_array(rows[1..].map(&:id))
+        expect(row_worker_job_args).to match_array(rows[1..].map(&:id))
       end
 
       it 'requests to follow all the expected users once the workers have run' do
@@ -190,7 +190,7 @@ RSpec.describe BulkImportService do
 
       it 'enqueues workers for the expected rows' do
         subject.call(import)
-        expect(Import::RowWorker.jobs.pluck('args').flatten).to match_array(rows.map(&:id))
+        expect(row_worker_job_args).to match_array(rows.map(&:id))
       end
 
       it 'mutes all the listed users once the workers have run' do
@@ -235,7 +235,7 @@ RSpec.describe BulkImportService do
 
       it 'enqueues workers for the expected rows' do
         subject.call(import)
-        expect(Import::RowWorker.jobs.pluck('args').flatten).to match_array(rows[1..].map(&:id))
+        expect(row_worker_job_args).to match_array(rows[1..].map(&:id))
       end
 
       it 'requests to follow all the expected users once the workers have run' do
@@ -331,7 +331,7 @@ RSpec.describe BulkImportService do
 
       it 'enqueues workers for the expected rows' do
         subject.call(import)
-        expect(Import::RowWorker.jobs.pluck('args').flatten).to match_array(rows.map(&:id))
+        expect(row_worker_job_args).to match_array(rows.map(&:id))
       end
 
       it 'updates the bookmarks as expected once the workers have run' do
@@ -371,7 +371,7 @@ RSpec.describe BulkImportService do
 
       it 'enqueues workers for the expected rows' do
         subject.call(import)
-        expect(Import::RowWorker.jobs.pluck('args').flatten).to match_array(rows.map(&:id))
+        expect(row_worker_job_args).to match_array(rows.map(&:id))
       end
 
       it 'updates the bookmarks as expected once the workers have run' do
@@ -383,6 +383,13 @@ RSpec.describe BulkImportService do
 
         expect(account.bookmarks.map { |bookmark| bookmark.status.uri }).to contain_exactly(status.uri, bookmarked.uri, 'https://domain.unknown/foo')
       end
+    end
+
+    def row_worker_job_args
+      Import::RowWorker
+        .jobs
+        .pluck('args')
+        .flatten
     end
 
     def stub_resolve_account_service

--- a/spec/services/bulk_import_service_spec.rb
+++ b/spec/services/bulk_import_service_spec.rb
@@ -40,10 +40,7 @@ RSpec.describe BulkImportService do
       it 'requests to follow all the listed users once the workers have run' do
         subject.call(import)
 
-        resolve_account_service_double = instance_double(ResolveAccountService)
-        allow(ResolveAccountService).to receive(:new).and_return(resolve_account_service_double)
-        allow(resolve_account_service_double).to receive(:call).with('user@foo.bar', any_args) { Fabricate(:account, username: 'user', domain: 'foo.bar', protocol: :activitypub) }
-        allow(resolve_account_service_double).to receive(:call).with('unknown@unknown.bar', any_args) { Fabricate(:account, username: 'unknown', domain: 'unknown.bar', protocol: :activitypub) }
+        stub_resolve_account_service
 
         Import::RowWorker.drain
 
@@ -88,10 +85,7 @@ RSpec.describe BulkImportService do
       it 'requests to follow all the expected users once the workers have run' do
         subject.call(import)
 
-        resolve_account_service_double = instance_double(ResolveAccountService)
-        allow(ResolveAccountService).to receive(:new).and_return(resolve_account_service_double)
-        allow(resolve_account_service_double).to receive(:call).with('user@foo.bar', any_args) { Fabricate(:account, username: 'user', domain: 'foo.bar', protocol: :activitypub) }
-        allow(resolve_account_service_double).to receive(:call).with('unknown@unknown.bar', any_args) { Fabricate(:account, username: 'unknown', domain: 'unknown.bar', protocol: :activitypub) }
+        stub_resolve_account_service
 
         Import::RowWorker.drain
 
@@ -126,10 +120,7 @@ RSpec.describe BulkImportService do
       it 'blocks all the listed users once the workers have run' do
         subject.call(import)
 
-        resolve_account_service_double = instance_double(ResolveAccountService)
-        allow(ResolveAccountService).to receive(:new).and_return(resolve_account_service_double)
-        allow(resolve_account_service_double).to receive(:call).with('user@foo.bar', any_args) { Fabricate(:account, username: 'user', domain: 'foo.bar', protocol: :activitypub) }
-        allow(resolve_account_service_double).to receive(:call).with('unknown@unknown.bar', any_args) { Fabricate(:account, username: 'unknown', domain: 'unknown.bar', protocol: :activitypub) }
+        stub_resolve_account_service
 
         Import::RowWorker.drain
 
@@ -170,10 +161,7 @@ RSpec.describe BulkImportService do
       it 'requests to follow all the expected users once the workers have run' do
         subject.call(import)
 
-        resolve_account_service_double = instance_double(ResolveAccountService)
-        allow(ResolveAccountService).to receive(:new).and_return(resolve_account_service_double)
-        allow(resolve_account_service_double).to receive(:call).with('user@foo.bar', any_args) { Fabricate(:account, username: 'user', domain: 'foo.bar', protocol: :activitypub) }
-        allow(resolve_account_service_double).to receive(:call).with('unknown@unknown.bar', any_args) { Fabricate(:account, username: 'unknown', domain: 'unknown.bar', protocol: :activitypub) }
+        stub_resolve_account_service
 
         Import::RowWorker.drain
 
@@ -208,10 +196,7 @@ RSpec.describe BulkImportService do
       it 'mutes all the listed users once the workers have run' do
         subject.call(import)
 
-        resolve_account_service_double = instance_double(ResolveAccountService)
-        allow(ResolveAccountService).to receive(:new).and_return(resolve_account_service_double)
-        allow(resolve_account_service_double).to receive(:call).with('user@foo.bar', any_args) { Fabricate(:account, username: 'user', domain: 'foo.bar', protocol: :activitypub) }
-        allow(resolve_account_service_double).to receive(:call).with('unknown@unknown.bar', any_args) { Fabricate(:account, username: 'unknown', domain: 'unknown.bar', protocol: :activitypub) }
+        stub_resolve_account_service
 
         Import::RowWorker.drain
 
@@ -256,10 +241,7 @@ RSpec.describe BulkImportService do
       it 'requests to follow all the expected users once the workers have run' do
         subject.call(import)
 
-        resolve_account_service_double = instance_double(ResolveAccountService)
-        allow(ResolveAccountService).to receive(:new).and_return(resolve_account_service_double)
-        allow(resolve_account_service_double).to receive(:call).with('user@foo.bar', any_args) { Fabricate(:account, username: 'user', domain: 'foo.bar', protocol: :activitypub) }
-        allow(resolve_account_service_double).to receive(:call).with('unknown@unknown.bar', any_args) { Fabricate(:account, username: 'unknown', domain: 'unknown.bar', protocol: :activitypub) }
+        stub_resolve_account_service
 
         Import::RowWorker.drain
 
@@ -355,10 +337,7 @@ RSpec.describe BulkImportService do
       it 'updates the bookmarks as expected once the workers have run' do
         subject.call(import)
 
-        service_double = instance_double(ActivityPub::FetchRemoteStatusService)
-        allow(ActivityPub::FetchRemoteStatusService).to receive(:new).and_return(service_double)
-        allow(service_double).to receive(:call).with('https://domain.unknown/foo') { Fabricate(:status, uri: 'https://domain.unknown/foo') }
-        allow(service_double).to receive(:call).with('https://domain.unknown/private') { Fabricate(:status, uri: 'https://domain.unknown/private', visibility: :direct) }
+        stub_fetch_remote_status_service
 
         Import::RowWorker.drain
 
@@ -398,15 +377,40 @@ RSpec.describe BulkImportService do
       it 'updates the bookmarks as expected once the workers have run' do
         subject.call(import)
 
-        service_double = instance_double(ActivityPub::FetchRemoteStatusService)
-        allow(ActivityPub::FetchRemoteStatusService).to receive(:new).and_return(service_double)
-        allow(service_double).to receive(:call).with('https://domain.unknown/foo') { Fabricate(:status, uri: 'https://domain.unknown/foo') }
-        allow(service_double).to receive(:call).with('https://domain.unknown/private') { Fabricate(:status, uri: 'https://domain.unknown/private', visibility: :direct) }
+        stub_fetch_remote_status_service
 
         Import::RowWorker.drain
 
         expect(account.bookmarks.map { |bookmark| bookmark.status.uri }).to contain_exactly(status.uri, bookmarked.uri, 'https://domain.unknown/foo')
       end
+    end
+
+    def stub_resolve_account_service
+      resolve_account_service_double = instance_double(ResolveAccountService)
+
+      allow(ResolveAccountService)
+        .to receive(:new)
+        .and_return(resolve_account_service_double)
+      allow(resolve_account_service_double)
+        .to receive(:call)
+        .with('user@foo.bar', any_args) { Fabricate(:account, username: 'user', domain: 'foo.bar', protocol: :activitypub) }
+      allow(resolve_account_service_double)
+        .to receive(:call)
+        .with('unknown@unknown.bar', any_args) { Fabricate(:account, username: 'unknown', domain: 'unknown.bar', protocol: :activitypub) }
+    end
+
+    def stub_fetch_remote_status_service
+      service_double = instance_double(ActivityPub::FetchRemoteStatusService)
+
+      allow(ActivityPub::FetchRemoteStatusService)
+        .to receive(:new)
+        .and_return(service_double)
+      allow(service_double)
+        .to receive(:call)
+        .with('https://domain.unknown/foo') { Fabricate(:status, uri: 'https://domain.unknown/foo') }
+      allow(service_double)
+        .to receive(:call)
+        .with('https://domain.unknown/private') { Fabricate(:status, uri: 'https://domain.unknown/private', visibility: :direct) }
     end
   end
 end


### PR DESCRIPTION
Pulled out from https://github.com/mastodon/mastodon/pull/32035 and in prep for larger PR to speed up services specs.

This one has two changes, but in same file...

- Add `row_worker_job_args` helper
- Add two stubs for common pattern

Both just DRYing up the spec.