### PR TITLE
Use same styling for statuses in email as on web

### DIFF
--- a/app/javascript/styles/mailer.scss
+++ b/app/javascript/styles/mailer.scss
@@ -168,6 +168,7 @@ table + p {
 
 // Utility classes
 .email-w-full {
+  table-layout: fixed;
   width: 100%;
 }
 
@@ -587,7 +588,10 @@ table + p {
   p {
     font-size: 14px;
     line-height: 20px;
+    margin-bottom: 20px;
     color: #17063b;
+    white-space: pre-wrap;
+    unicode-bidi: plaintext;
   }
 
   a {
@@ -596,6 +600,21 @@ table + p {
 
     &:hover {
       color: #563acc !important;
+    }
+  }
+
+  .invisible {
+    font-size: 0;
+    line-height: 0;
+    display: inline-block;
+    width: 0;
+    height: 0;
+    position: absolute;
+  }
+
+  .ellipsis {
+    &::after {
+      content: '…';
     }
   }
 }


### PR DESCRIPTION
The notification emails containing statuses are rendered with a different styling than on the web.

- White-space are collapsed, so ASCII art or spaces used for indentation will not work.
- There is no margin between paragraphs, so two consecutive newlines look like a single newline.
- Links are not displayed in their compact format (leading `https://www` is stripped and long path is truncated with ellipsis).
- A very long word will make the container grow horizontally (in Mail.app on macOS).

This PR does address the difference in font family and size. I assume that is intentional.