### PR TITLE
Use `not-allowed` for cursor on disabled buttons

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -93,7 +93,7 @@
   &:disabled,
   &.disabled {
     background-color: $ui-primary-color;
-    cursor: default;
+    cursor: not-allowed;
   }
 
   &.copyable {


### PR DESCRIPTION
Original value added w/out much context - https://github.com/mastodon/mastodon/commit/be86d4e0a3c40e95648971bc9b0fe58c58cbc5da#diff-52ba73553797b2f50c1767d4a0676b5a0d7ac507c0044930a4e70afe013529deR27

<img width="203" alt="Screenshot 2024-09-24 at 16 47 06" src="https://github.com/user-attachments/assets/2edf4b01-63af-463f-b8a5-8b568a26167e">
