### PR TITLE
Add counter cache on `Account#targeted_moderation_notes`

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -4,53 +4,54 @@
 #
 # Table name: accounts
 #
-#  id                            :bigint(8)        not null, primary key
-#  username                      :string           default(""), not null
-#  domain                        :string
-#  private_key                   :text
-#  public_key                    :text             default(""), not null
-#  created_at                    :datetime         not null
-#  updated_at                    :datetime         not null
-#  note                          :text             default(""), not null
-#  display_name                  :string           default(""), not null
-#  uri                           :string           default(""), not null
-#  url                           :string
-#  avatar_file_name              :string
-#  avatar_content_type           :string
-#  avatar_file_size              :integer
-#  avatar_updated_at             :datetime
-#  header_file_name              :string
-#  header_content_type           :string
-#  header_file_size              :integer
-#  header_updated_at             :datetime
-#  avatar_remote_url             :string
-#  locked                        :boolean          default(FALSE), not null
-#  header_remote_url             :string           default(""), not null
-#  last_webfingered_at           :datetime
-#  inbox_url                     :string           default(""), not null
-#  outbox_url                    :string           default(""), not null
-#  shared_inbox_url              :string           default(""), not null
-#  followers_url                 :string           default(""), not null
-#  protocol                      :integer          default("ostatus"), not null
-#  memorial                      :boolean          default(FALSE), not null
-#  moved_to_account_id           :bigint(8)
-#  featured_collection_url       :string
-#  fields                        :jsonb
-#  actor_type                    :string
-#  discoverable                  :boolean
-#  also_known_as                 :string           is an Array
-#  silenced_at                   :datetime
-#  suspended_at                  :datetime
-#  hide_collections              :boolean
-#  avatar_storage_schema_version :integer
-#  header_storage_schema_version :integer
-#  suspension_origin             :integer
-#  sensitized_at                 :datetime
-#  trendable                     :boolean
-#  reviewed_at                   :datetime
-#  requested_review_at           :datetime
-#  indexable                     :boolean          default(FALSE), not null
-#  attribution_domains           :string           default([]), is an Array
+#  id                              :bigint(8)        not null, primary key
+#  username                        :string           default(""), not null
+#  domain                          :string
+#  private_key                     :text
+#  public_key                      :text             default(""), not null
+#  created_at                      :datetime         not null
+#  updated_at                      :datetime         not null
+#  note                            :text             default(""), not null
+#  display_name                    :string           default(""), not null
+#  uri                             :string           default(""), not null
+#  url                             :string
+#  avatar_file_name                :string
+#  avatar_content_type             :string
+#  avatar_file_size                :integer
+#  avatar_updated_at               :datetime
+#  header_file_name                :string
+#  header_content_type             :string
+#  header_file_size                :integer
+#  header_updated_at               :datetime
+#  avatar_remote_url               :string
+#  locked                          :boolean          default(FALSE), not null
+#  header_remote_url               :string           default(""), not null
+#  last_webfingered_at             :datetime
+#  inbox_url                       :string           default(""), not null
+#  outbox_url                      :string           default(""), not null
+#  shared_inbox_url                :string           default(""), not null
+#  followers_url                   :string           default(""), not null
+#  protocol                        :integer          default("ostatus"), not null
+#  memorial                        :boolean          default(FALSE), not null
+#  moved_to_account_id             :bigint(8)
+#  featured_collection_url         :string
+#  fields                          :jsonb
+#  actor_type                      :string
+#  discoverable                    :boolean
+#  also_known_as                   :string           is an Array
+#  silenced_at                     :datetime
+#  suspended_at                    :datetime
+#  hide_collections                :boolean
+#  avatar_storage_schema_version   :integer
+#  header_storage_schema_version   :integer
+#  sensitized_at                   :datetime
+#  suspension_origin               :integer
+#  trendable                       :boolean
+#  reviewed_at                     :datetime
+#  requested_review_at             :datetime
+#  indexable                       :boolean          default(FALSE), not null
+#  attribution_domains             :string           default([]), is an Array
+#  targeted_moderation_notes_count :integer          default(0), not null
 #
 
 class Account < ApplicationRecord

--- a/app/models/account_moderation_note.rb
+++ b/app/models/account_moderation_note.rb
@@ -16,7 +16,7 @@ class AccountModerationNote < ApplicationRecord
   CONTENT_SIZE_LIMIT = 2_000
 
   belongs_to :account
-  belongs_to :target_account, class_name: 'Account', counter_cache: true
+  belongs_to :target_account, class_name: 'Account', counter_cache: :targeted_moderation_notes_count
 
   scope :chronological, -> { reorder(id: :asc) }
 

--- a/app/models/account_moderation_note.rb
+++ b/app/models/account_moderation_note.rb
@@ -16,7 +16,7 @@ class AccountModerationNote < ApplicationRecord
   CONTENT_SIZE_LIMIT = 2_000
 
   belongs_to :account
-  belongs_to :target_account, class_name: 'Account'
+  belongs_to :target_account, class_name: 'Account', counter_cache: true
 
   scope :chronological, -> { reorder(id: :asc) }
 

--- a/app/views/admin/reports/index.html.haml
+++ b/app/views/admin/reports/index.html.haml
@@ -36,7 +36,7 @@
     .report-card__profile
       = account_link_to target_account, '', path: admin_account_path(target_account.id)
       .report-card__profile__stats
-        = link_to t('admin.reports.account.notes', count: target_account.targeted_moderation_notes.count), admin_account_path(target_account.id)
+        = link_to t('admin.reports.account.notes', count: target_account.targeted_moderation_notes_count), admin_account_path(target_account.id)
         %br/
         - if target_account.suspended?
           %span.red= t('admin.accounts.suspended')

--- a/db/migrate/20240924211543_add_counter_cache_to_account_moderation_note_on_target_account.rb
+++ b/db/migrate/20240924211543_add_counter_cache_to_account_moderation_note_on_target_account.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class AddCounterCacheToAccountModerationNoteOnTargetAccount < ActiveRecord::Migration[7.1]
+  def up
+    add_column :accounts, :targeted_moderation_notes_count, :integer, null: false, default: 0
+
+    connection.execute(<<~SQL.squish)
+      UPDATE accounts
+      SET targeted_moderation_notes_count = (
+        SELECT COUNT(*)
+        FROM account_moderation_notes
+        WHERE account_moderation_notes.target_account_id = accounts.id
+      )
+    SQL
+  end
+
+  def down
+    remove_column :accounts, :targeted_moderation_notes_count
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -200,6 +200,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_07_071624) do
     t.datetime "requested_review_at", precision: nil
     t.boolean "indexable", default: false, null: false
     t.string "attribution_domains", default: [], array: true
+    t.integer "targeted_moderation_notes_count", default: 0, null: false
     t.index "(((setweight(to_tsvector('simple'::regconfig, (display_name)::text), 'A'::\"char\") || setweight(to_tsvector('simple'::regconfig, (username)::text), 'B'::\"char\")) || setweight(to_tsvector('simple'::regconfig, (COALESCE(domain, ''::character varying))::text), 'C'::\"char\")))", name: "search_index", using: :gin
     t.index "lower((username)::text), COALESCE(lower((domain)::text), ''::text)", name: "index_accounts_on_username_and_domain_lower", unique: true
     t.index ["domain", "id"], name: "index_accounts_on_domain_and_id"


### PR DESCRIPTION
Opening as draft for feedback on the idea. Helps with an N+1-ish query on the page (we are looping through reports grouped by target account, and then need a query for each ones account moderation note count) ... though there's a limit one reports per page, and thus a limit on extra count as well.

Things to handle before merge:

- I did this as normal migration for PoC, should probably be post deploy migration instead?
- There's a feature (Starting in rails 7.2 I think) which lets you pass an `active: false` to counter caches so that they don't get used, and then once migrations are complete you remove that and they do get used. Might want to wait on this for 7.2 bump, then review
- Not sure on perf implications of the one big update query ... might want this batched or something instead (and/or, batched and also per record, at which point we can use the `reset` method instead of custom sql?)
- There are probably more places with this type of pattern, just noticed this one while looking at something else
- Wow that's really a jarringly-large diff from `annotate` in the account model isnt it? Sure is.