### PR TITLE
Migrate from the deprecated `azure-storage-blob` to `azure-blob`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'blurhash', '~> 0.1'
 gem 'fog-core', '<= 2.6.0'
 gem 'fog-openstack', '~> 1.0', require: false
 gem 'kt-paperclip', '~> 7.2'
-gem 'md-paperclip-azure', '~> 2.2', require: false
+gem 'jd-paperclip-azure', '~> 3.0', require: false
 gem 'ruby-vips', '~> 2.2', require: false
 
 gem 'active_model_serializers', '~> 0.10'

--- a/Gemfile
+++ b/Gemfile
@@ -18,8 +18,8 @@ gem 'aws-sdk-s3', '~> 1.123', require: false
 gem 'blurhash', '~> 0.1'
 gem 'fog-core', '<= 2.6.0'
 gem 'fog-openstack', '~> 1.0', require: false
-gem 'kt-paperclip', '~> 7.2'
 gem 'jd-paperclip-azure', '~> 3.0', require: false
+gem 'kt-paperclip', '~> 7.2'
 gem 'ruby-vips', '~> 2.2', require: false
 
 gem 'active_model_serializers', '~> 0.10'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,14 +115,8 @@ GEM
       aws-sigv4 (~> 1.5)
     aws-sigv4 (1.10.1)
       aws-eventstream (~> 1, >= 1.0.2)
-    azure-storage-blob (2.0.3)
-      azure-storage-common (~> 2.0)
-      nokogiri (~> 1, >= 1.10.8)
-    azure-storage-common (2.0.4)
-      faraday (~> 1.0)
-      faraday_middleware (~> 1.0, >= 1.0.0.rc1)
-      net-http-persistent (~> 4.0)
-      nokogiri (~> 1, >= 1.10.8)
+    azure-blob (0.5.2)
+      rexml
     base64 (0.2.0)
     bcp47_spec (0.2.1)
     bcrypt (3.1.20)
@@ -258,8 +252,6 @@ GEM
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
     faraday-retry (1.0.3)
-    faraday_middleware (1.2.0)
-      faraday (~> 1.0)
     fast_blank (1.0.1)
     fastimage (2.3.1)
     ffi (1.17.0)
@@ -350,6 +342,10 @@ GEM
     irb (1.14.1)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
+    jd-paperclip-azure (3.0.0)
+      addressable (~> 2.5)
+      azure-blob (~> 0.5.2)
+      hashie (~> 5.0)
     jmespath (1.6.2)
     json (2.7.4)
     json-canonicalization (1.0.0)
@@ -424,10 +420,6 @@ GEM
     mario-redis-lock (1.2.1)
       redis (>= 3.0.5)
     matrix (0.4.2)
-    md-paperclip-azure (2.2.0)
-      addressable (~> 2.5)
-      azure-storage-blob (~> 2.0.1)
-      hashie (~> 5.0)
     memory_profiler (1.1.0)
     mime-types (3.6.0)
       logger
@@ -442,8 +434,6 @@ GEM
     mutex_m (0.2.0)
     net-http (0.4.1)
       uri
-    net-http-persistent (4.0.2)
-      connection_pool (~> 2.2)
     net-imap (0.5.0)
       date
       net-protocol
@@ -958,6 +948,7 @@ DEPENDENCIES
   idn-ruby
   inline_svg
   irb (~> 1.8)
+  jd-paperclip-azure (~> 3.0)
   json-ld
   json-ld-preloaded (~> 3.2)
   json-schema (~> 5.0)
@@ -969,7 +960,6 @@ DEPENDENCIES
   lograge (~> 0.12)
   mail (~> 2.8)
   mario-redis-lock (~> 1.2)
-  md-paperclip-azure (~> 2.2)
   memory_profiler
   mime-types (~> 3.6.0)
   net-http (~> 0.4.0)


### PR DESCRIPTION
Fixes #30352 and #31617

`azure-storage-blob` is deprecated and prevent updating gems such as Faraday.

This PR migrates to `azure-blob`, a new azure blob adapter with minimal dependencies.