### PR TITLE
Use `async_count` in more view locations

### DIFF
--- a/app/controllers/admin/announcements_controller.rb
+++ b/app/controllers/admin/announcements_controller.rb
@@ -6,6 +6,7 @@ class Admin::AnnouncementsController < Admin::BaseController
 
   def index
     authorize :announcement, :index?
+    @published_announcements_count = Announcement.published.async_count
   end
 
   def new

--- a/app/controllers/admin/disputes/appeals_controller.rb
+++ b/app/controllers/admin/disputes/appeals_controller.rb
@@ -6,6 +6,7 @@ class Admin::Disputes::AppealsController < Admin::BaseController
   def index
     authorize :appeal, :index?
 
+    @pending_appeals_count = Appeal.pending.async_count
     @appeals = filtered_appeals.page(params[:page])
   end
 

--- a/app/controllers/admin/trends/links/preview_card_providers_controller.rb
+++ b/app/controllers/admin/trends/links/preview_card_providers_controller.rb
@@ -4,6 +4,7 @@ class Admin::Trends::Links::PreviewCardProvidersController < Admin::BaseControll
   def index
     authorize :preview_card_provider, :review?
 
+    @pending_preview_card_providers_count = PreviewCardProvider.unreviewed.async_count
     @preview_card_providers = filtered_preview_card_providers.page(params[:page])
     @form = Trends::PreviewCardProviderBatch.new
   end

--- a/app/controllers/admin/trends/tags_controller.rb
+++ b/app/controllers/admin/trends/tags_controller.rb
@@ -4,6 +4,7 @@ class Admin::Trends::TagsController < Admin::BaseController
   def index
     authorize :tag, :review?
 
+    @pending_tags_count = Tag.pending_review.async_count
     @tags = filtered_tags.page(params[:page])
     @form = Trends::TagBatch.new
   end

--- a/app/views/admin/announcements/index.html.haml
+++ b/app/views/admin/announcements/index.html.haml
@@ -9,7 +9,7 @@
     %strong= t('admin.relays.status')
     %ul
       %li= filter_link_to t('generic.all'), published: nil, unpublished: nil
-      %li= filter_link_to safe_join([t('admin.announcements.live'), "(#{number_with_delimiter(Announcement.published.count)})"], ' '), published: '1', unpublished: nil
+      %li= filter_link_to safe_join([t('admin.announcements.live'), "(#{number_with_delimiter(@published_announcements_count.value)})"], ' '), published: '1', unpublished: nil
 
 - if @announcements.empty?
   .muted-hint.center-text

--- a/app/views/admin/disputes/appeals/index.html.haml
+++ b/app/views/admin/disputes/appeals/index.html.haml
@@ -5,7 +5,7 @@
   .filter-subset
     %strong= t('admin.tags.review')
     %ul
-      %li= filter_link_to safe_join([t('admin.accounts.moderation.pending'), "(#{Appeal.pending.count})"], ' '), status: 'pending'
+      %li= filter_link_to safe_join([t('admin.accounts.moderation.pending'), "(#{@pending_appeals_count.value})"], ' '), status: 'pending'
       %li= filter_link_to t('admin.trends.approved'), status: 'approved'
       %li= filter_link_to t('admin.trends.rejected'), status: 'rejected'
 

--- a/app/views/admin/trends/links/preview_card_providers/index.html.haml
+++ b/app/views/admin/trends/links/preview_card_providers/index.html.haml
@@ -12,7 +12,7 @@
       %li= filter_link_to t('generic.all'), status: nil
       %li= filter_link_to t('admin.trends.approved'), status: 'approved'
       %li= filter_link_to t('admin.trends.rejected'), status: 'rejected'
-      %li= filter_link_to safe_join([t('admin.accounts.moderation.pending'), "(#{PreviewCardProvider.unreviewed.count})"], ' '), status: 'pending_review'
+      %li= filter_link_to safe_join([t('admin.accounts.moderation.pending'), "(#{@pending_preview_card_providers_count.value})"], ' '), status: 'pending_review'
   .back-link
     = link_to admin_trends_links_path do
       = material_symbol 'chevron_left'

--- a/app/views/admin/trends/tags/index.html.haml
+++ b/app/views/admin/trends/tags/index.html.haml
@@ -12,7 +12,7 @@
       %li= filter_link_to t('generic.all'), status: nil
       %li= filter_link_to t('admin.trends.approved'), status: 'approved'
       %li= filter_link_to t('admin.trends.rejected'), status: 'rejected'
-      %li= filter_link_to safe_join([t('admin.accounts.moderation.pending'), "(#{Tag.pending_review.count})"], ' '), status: 'pending_review'
+      %li= filter_link_to safe_join([t('admin.accounts.moderation.pending'), "(#{@pending_tags_count.value})"], ' '), status: 'pending_review'
 
 = form_with model: @form, url: batch_admin_trends_tags_path do |f|
   = hidden_field_tag :page, params[:page] || 1


### PR DESCRIPTION
More of the same approach as https://github.com/mastodon/mastodon/pull/30606

Same caveat as there - I haven't benchmarked this, but it should be at worst the same performance, and likely some small improvement since the count can be async gathered while other execution happens.

Nice side effect of here of getting some direct constant references out of views as well.