### PR TITLE
Use `before_action` to handle missing status scenario in `NotificationMailer`

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -9,8 +9,6 @@ class ApplicationMailer < ActionMailer::Base
 
   after_action :set_autoreply_headers!
 
-  rescue_from UncaughtThrowError, with: -> {}
-
   protected
 
   def locale_for_account(account, &block)

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -9,6 +9,8 @@ class ApplicationMailer < ActionMailer::Base
 
   after_action :set_autoreply_headers!
 
+  rescue_from UncaughtThrowError, with: -> {}
+
   protected
 
   def locale_for_account(account, &block)

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -11,6 +11,7 @@ class NotificationMailer < ApplicationMailer
     after_action :thread_by_conversation!
   end
   before_action :set_account, only: [:follow, :favourite, :reblog, :follow_request]
+  before_action :verify_status_presence, only: %i(favourite mention reblog)
   after_action :set_list_headers!
 
   before_deliver :verify_functional_user
@@ -20,8 +21,6 @@ class NotificationMailer < ApplicationMailer
   layout 'mailer'
 
   def mention
-    return if @status.blank?
-
     locale_for_account(@me) do
       mail subject: default_i18n_subject(name: @status.account.acct)
     end
@@ -34,16 +33,12 @@ class NotificationMailer < ApplicationMailer
   end
 
   def favourite
-    return if @status.blank?
-
     locale_for_account(@me) do
       mail subject: default_i18n_subject(name: @account.acct)
     end
   end
 
   def reblog
-    return if @status.blank?
-
     locale_for_account(@me) do
       mail subject: default_i18n_subject(name: @account.acct)
     end
@@ -75,6 +70,10 @@ class NotificationMailer < ApplicationMailer
 
   def verify_functional_user
     throw(:abort) unless @user.functional?
+  end
+
+  def verify_status_presence
+    throw(:abort) if @status.blank?
   end
 
   def set_list_headers!

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -6,12 +6,12 @@ class NotificationMailer < ApplicationMailer
          :routing
 
   before_action :process_params
-  with_options only: %i(mention favourite reblog) do
-    before_action :set_status
+  with_options only: %i(favourite mention reblog) do
     after_action :thread_by_conversation!
+    before_action :set_status
+    before_action :verify_status_presence
   end
   before_action :set_account, only: [:follow, :favourite, :reblog, :follow_request]
-  before_action :verify_status_presence, only: %i(favourite mention reblog)
   after_action :set_list_headers!
 
   before_deliver :verify_functional_user
@@ -73,7 +73,10 @@ class NotificationMailer < ApplicationMailer
   end
 
   def verify_status_presence
-    throw(:abort) if @status.blank?
+    if @status.blank?
+      self.perform_deliveries = false
+      self.response_body = :do_not_deliver
+    end
   end
 
   def set_list_headers!


### PR DESCRIPTION
Follow-up on https://github.com/mastodon/mastodon/pull/32055 and adding same sort of coverage for the "when notification is missing a target_status" edge case.

Because this is an invalid data scenario, opted to just stub out a nil in the spec.

The `rescue` here is a little odd, but needed because a) as far as I can tell there's not an equivalent way (that does not reaching into private api) in mailers to do what you do with with a render/redirect/return in a controller to get the action to halt in a before_action, b) the empty proc here leads to a null message being used internally, and so no mails are sent.