### PR TITLE
Fix scrollbar width

### DIFF
--- a/app/javascript/styles/mastodon/reset.scss
+++ b/app/javascript/styles/mastodon/reset.scss
@@ -56,7 +56,6 @@ table {
 @supports not selector(::-webkit-scrollbar) {
   html {
     scrollbar-color: $action-button-color var(--background-border-color);
-    scrollbar-width: thin;
   }
 }
 


### PR DESCRIPTION
Fixes #31917

Note that I am not entirely sure this is sufficient. Indeed, we have different code responsible for scrollbar styling on Chromium.

Furthermore, I have not been able to see any difference with and without `scrollbar-width: thin` on Firefox on Linux.