### PR TITLE
Continue `form` partial extraction in admin area views

### DIFF
--- a/app/controllers/admin/account_actions_controller.rb
+++ b/app/controllers/admin/account_actions_controller.rb
@@ -7,8 +7,7 @@ module Admin
     def new
       authorize @account, :show?
 
-      @account_action  = Admin::AccountAction.new(type: params[:type], report_id: params[:report_id], send_email_notification: true, include_statuses: true)
-      @warning_presets = AccountWarningPreset.all
+      @account_action = Admin::AccountAction.new(type: params[:type], report_id: params[:report_id], send_email_notification: true, include_statuses: true, target_account: @account)
     end
 
     def create

--- a/app/controllers/admin/email_domain_blocks_controller.rb
+++ b/app/controllers/admin/email_domain_blocks_controller.rb
@@ -57,6 +57,15 @@ module Admin
 
     private
 
+    def resolved_records
+      if defined?(@resolved_records)
+        @resolved_records
+      else
+        []
+      end
+    end
+    helper_method :resolved_records
+
     def set_resolved_records
       @resolved_records = DomainResource.new(@email_domain_block.domain).mx
     end

--- a/app/helpers/admin/account_actions_helper.rb
+++ b/app/helpers/admin/account_actions_helper.rb
@@ -9,4 +9,8 @@ module Admin::AccountActionsHelper
       ]
     )
   end
+
+  def warning_presets
+    AccountWarningPreset.alphabetic
+  end
 end

--- a/app/models/admin/account_action.rb
+++ b/app/models/admin/account_action.rb
@@ -25,6 +25,8 @@ class Admin::AccountAction
   alias send_email_notification? send_email_notification
   alias include_statuses? include_statuses
 
+  delegate :local?, :pretty_acct, to: :target_account, prefix: true
+
   validates :type, :target_account, :current_account, presence: true
   validates :type, inclusion: { in: TYPES }
 

--- a/app/views/admin/account_actions/_form.html.haml
+++ b/app/views/admin/account_actions/_form.html.haml
@@ -1,0 +1,34 @@
+= form.input :report_id,
+             as: :hidden
+.fields-group
+  = form.input :type,
+               as: :radio_buttons,
+               collection: Admin::AccountAction.types_for_account(form.object.target_account),
+               disabled: Admin::AccountAction.disabled_types_for_account(form.object.target_account),
+               hint: t('simple_form.hints.admin_account_action.type_html', acct: form.object.target_account_pretty_acct),
+               include_blank: false,
+               label_method: ->(type) { account_action_type_label(type) },
+               wrapper: :with_block_label
+- if form.object.target_account_local?
+  %hr.spacer/
+  .fields-group
+    = form.input :send_email_notification,
+                 as: :boolean,
+                 wrapper: :with_label
+  - if params[:report_id].present?
+    .fields-group
+      = form.input :include_statuses,
+                   as: :boolean,
+                   wrapper: :with_label
+  %hr.spacer/
+  - unless warning_presets.empty?
+    .fields-group
+      = form.input :warning_preset_id,
+                   collection: warning_presets,
+                   label_method: ->(warning_preset) { [warning_preset.title.presence, truncate(warning_preset.text)].compact.join(' - ') },
+                   wrapper: :with_block_label
+  .fields-group
+    = form.input :text,
+                 as: :text,
+                 hint: t('simple_form.hints.admin_account_action.text_html', path: admin_warning_presets_path),
+                 wrapper: :with_block_label

--- a/app/views/admin/account_actions/new.html.haml
+++ b/app/views/admin/account_actions/new.html.haml
@@ -8,50 +8,10 @@
   .flash-message.warn
     = t('admin.account_actions.already_silenced')
 
-= simple_form_for @account_action, url: admin_account_action_path(@account.id) do |f|
-  = f.input :report_id,
-            as: :hidden
-
-  .fields-group
-    = f.input :type,
-              as: :radio_buttons,
-              collection: Admin::AccountAction.types_for_account(@account),
-              disabled: Admin::AccountAction.disabled_types_for_account(@account),
-              hint: t('simple_form.hints.admin_account_action.type_html', acct: @account.pretty_acct),
-              include_blank: false,
-              label_method: ->(type) { account_action_type_label(type) },
-              wrapper: :with_block_label
-
-  - if @account.local?
-    %hr.spacer/
-
-    .fields-group
-      = f.input :send_email_notification,
-                as: :boolean,
-                wrapper: :with_label
-
-    - if params[:report_id].present?
-      .fields-group
-        = f.input :include_statuses,
-                  as: :boolean,
-                  wrapper: :with_label
-
-    %hr.spacer/
-
-    - unless @warning_presets.empty?
-      .fields-group
-        = f.input :warning_preset_id,
-                  collection: @warning_presets,
-                  label_method: ->(warning_preset) { [warning_preset.title.presence, truncate(warning_preset.text)].compact.join(' - ') },
-                  wrapper: :with_block_label
-
-    .fields-group
-      = f.input :text,
-                as: :text,
-                hint: t('simple_form.hints.admin_account_action.text_html', path: admin_warning_presets_path),
-                wrapper: :with_block_label
+= simple_form_for @account_action, url: admin_account_action_path(@account.id) do |form|
+  = render form
 
   .actions
-    = f.button :button,
-               t('admin.account_actions.action'),
-               type: :submit
+    = form.button :button,
+                  t('admin.account_actions.action'),
+                  type: :submit

--- a/app/views/admin/custom_emojis/_form.html.haml
+++ b/app/views/admin/custom_emojis/_form.html.haml
@@ -1,0 +1,10 @@
+.fields-group
+  = form.input :shortcode,
+               hint: t('admin.custom_emojis.shortcode_hint'),
+               label: t('admin.custom_emojis.shortcode'),
+               wrapper: :with_label
+.fields-group
+  = form.input :image,
+               hint: t('admin.custom_emojis.image_hint', size: number_to_human_size(CustomEmoji::LIMIT)),
+               input_html: { accept: CustomEmoji::IMAGE_MIME_TYPES.join(',') },
+               wrapper: :with_label

--- a/app/views/admin/custom_emojis/new.html.haml
+++ b/app/views/admin/custom_emojis/new.html.haml
@@ -1,21 +1,12 @@
 - content_for :page_title do
   = t('.title')
 
-= simple_form_for @custom_emoji, url: admin_custom_emojis_path do |f|
+= simple_form_for @custom_emoji, url: admin_custom_emojis_path do |form|
   = render 'shared/error_messages', object: @custom_emoji
 
-  .fields-group
-    = f.input :shortcode,
-              wrapper: :with_label,
-              label: t('admin.custom_emojis.shortcode'),
-              hint: t('admin.custom_emojis.shortcode_hint')
-  .fields-group
-    = f.input :image,
-              wrapper: :with_label,
-              input_html: { accept: CustomEmoji::IMAGE_MIME_TYPES.join(',') },
-              hint: t('admin.custom_emojis.image_hint', size: number_to_human_size(CustomEmoji::LIMIT))
+  = render form
 
   .actions
-    = f.button :button,
-               t('admin.custom_emojis.upload'),
-               type: :submit
+    = form.button :button,
+                  t('admin.custom_emojis.upload'),
+                  type: :submit

--- a/app/views/admin/domain_allows/_form.html.haml
+++ b/app/views/admin/domain_allows/_form.html.haml
@@ -1,0 +1,5 @@
+.fields-group
+  = form.input :domain,
+               label: t('admin.domain_blocks.domain'),
+               required: true,
+               wrapper: :with_label

--- a/app/views/admin/domain_allows/new.html.haml
+++ b/app/views/admin/domain_allows/new.html.haml
@@ -1,11 +1,10 @@
 - content_for :page_title do
   = t('admin.domain_allows.add_new')
 
-= simple_form_for @domain_allow, url: admin_domain_allows_path do |f|
+= simple_form_for @domain_allow, url: admin_domain_allows_path do |form|
   = render 'shared/error_messages', object: @domain_allow
 
-  .fields-group
-    = f.input :domain, wrapper: :with_label, label: t('admin.domain_blocks.domain'), required: true
+  = render form
 
   .actions
-    = f.button :button, t('admin.domain_allows.add_new'), type: :submit
+    = form.button :button, t('admin.domain_allows.add_new'), type: :submit

--- a/app/views/admin/email_domain_blocks/_form.html.haml
+++ b/app/views/admin/email_domain_blocks/_form.html.haml
@@ -1,0 +1,32 @@
+.fields-group
+  = form.input :domain,
+               input_html: { readonly: resolved_records.any? },
+               label: t('admin.email_domain_blocks.domain'),
+               wrapper: :with_block_label
+.fields-group
+  = form.input :allow_with_approval,
+               hint: false,
+               label: I18n.t('admin.email_domain_blocks.allow_registrations_with_approval'),
+               wrapper: :with_label
+- if resolved_records.any?
+  %p.hint= t('admin.email_domain_blocks.resolved_dns_records_hint_html')
+  .batch-table
+    .batch-table__toolbar
+      %label.batch-table__toolbar__select.batch-checkbox-all
+        = check_box_tag :batch_checkbox_all, nil, false
+      .batch-table__toolbar__actions
+    .batch-table__body
+      - resolved_records.each do |record|
+        .batch-table__row
+          %label.batch-table__row__select.batch-table__row__select--aligned.batch-checkbox
+            = form.input_field :other_domains,
+                               as: :boolean,
+                               checked_value: record,
+                               include_hidden: false,
+                               multiple: true
+          .batch-table__row__content.pending-account
+            .pending-account__header
+              %samp= record
+              %br
+              = t('admin.email_domain_blocks.dns.types.mx')
+  %hr.spacer/

--- a/app/views/admin/email_domain_blocks/new.html.haml
+++ b/app/views/admin/email_domain_blocks/new.html.haml
@@ -1,48 +1,13 @@
 - content_for :page_title do
   = t('.title')
 
-= simple_form_for @email_domain_block, url: admin_email_domain_blocks_path do |f|
+= simple_form_for @email_domain_block, url: admin_email_domain_blocks_path do |form|
   = render 'shared/error_messages', object: @email_domain_block
 
-  .fields-group
-    = f.input :domain,
-              input_html: { readonly: defined?(@resolved_records) },
-              label: t('admin.email_domain_blocks.domain'),
-              wrapper: :with_block_label
-
-  .fields-group
-    = f.input :allow_with_approval,
-              hint: false,
-              label: I18n.t('admin.email_domain_blocks.allow_registrations_with_approval'),
-              wrapper: :with_label
-
-  - if defined?(@resolved_records) && @resolved_records.any?
-    %p.hint= t('admin.email_domain_blocks.resolved_dns_records_hint_html')
-
-    .batch-table
-      .batch-table__toolbar
-        %label.batch-table__toolbar__select.batch-checkbox-all
-          = check_box_tag :batch_checkbox_all, nil, false
-        .batch-table__toolbar__actions
-      .batch-table__body
-        - @resolved_records.each do |record|
-          .batch-table__row
-            %label.batch-table__row__select.batch-table__row__select--aligned.batch-checkbox
-              = f.input_field :other_domains,
-                              as: :boolean,
-                              checked_value: record,
-                              include_hidden: false,
-                              multiple: true
-            .batch-table__row__content.pending-account
-              .pending-account__header
-                %samp= record
-                %br
-                = t('admin.email_domain_blocks.dns.types.mx')
-
-    %hr.spacer/
+  = render form
 
   .actions
     - if defined?(@resolved_records)
-      = f.button :button, t('.create'), type: :submit, name: :save
+      = form.button :button, t('.create'), type: :submit, name: :save
     - else
-      = f.button :button, t('.resolve'), type: :submit, name: :resolve
+      = form.button :button, t('.resolve'), type: :submit, name: :resolve

--- a/app/views/admin/export_domain_allows/_form.html.haml
+++ b/app/views/admin/export_domain_allows/_form.html.haml
@@ -1,0 +1,6 @@
+.fields-row
+  .fields-group.fields-row__column.fields-row__column-6
+    = form.input :data,
+                 as: :file,
+                 hint: t('simple_form.hints.imports.data'),
+                 wrapper: :with_block_label

--- a/app/views/admin/export_domain_allows/new.html.haml
+++ b/app/views/admin/export_domain_allows/new.html.haml
@@ -1,13 +1,8 @@
 - content_for :page_title do
   = t('.title')
 
-= simple_form_for @import, url: import_admin_export_domain_allows_path, html: { multipart: true } do |f|
-  .fields-row
-    .fields-group.fields-row__column.fields-row__column-6
-      = f.input :data,
-                as: :file,
-                hint: t('simple_form.hints.imports.data'),
-                wrapper: :with_block_label
+= simple_form_for @import, url: import_admin_export_domain_allows_path, html: { multipart: true } do |form|
+  = render form
 
   .actions
-    = f.button :button, t('imports.upload'), type: :submit
+    = form.button :button, t('imports.upload'), type: :submit

--- a/app/views/admin/export_domain_blocks/_form.html.haml
+++ b/app/views/admin/export_domain_blocks/_form.html.haml
@@ -1,0 +1,6 @@
+.fields-row
+  .fields-group.fields-row__column.fields-row__column-6
+    = form.input :data,
+                 as: :file,
+                 hint: t('simple_form.hints.imports.data'),
+                 wrapper: :with_block_label

--- a/app/views/admin/export_domain_blocks/new.html.haml
+++ b/app/views/admin/export_domain_blocks/new.html.haml
@@ -1,13 +1,8 @@
 - content_for :page_title do
   = t('.title')
 
-= simple_form_for @import, url: import_admin_export_domain_blocks_path, html: { multipart: true } do |f|
-  .fields-row
-    .fields-group.fields-row__column.fields-row__column-6
-      = f.input :data,
-                as: :file,
-                hint: t('simple_form.hints.imports.data'),
-                wrapper: :with_block_label
+= simple_form_for @import, url: import_admin_export_domain_blocks_path, html: { multipart: true } do |form|
+  = render form
 
   .actions
-    = f.button :button, t('imports.upload'), type: :submit
+    = form.button :button, t('imports.upload'), type: :submit

--- a/app/views/admin/ip_blocks/_form.html.haml
+++ b/app/views/admin/ip_blocks/_form.html.haml
@@ -1,0 +1,22 @@
+.fields-group
+  = form.input :ip,
+               as: :string,
+               input_html: { placeholder: '192.0.2.0/24' },
+               wrapper: :with_block_label
+.fields-group
+  = form.input :expires_in,
+               collection: [1.day, 2.weeks, 1.month, 6.months, 1.year, 3.years].map(&:to_i),
+               label_method: ->(i) { I18n.t("admin.ip_blocks.expires_in.#{i}") },
+               prompt: I18n.t('invites.expires_in_prompt'),
+               wrapper: :with_block_label
+.fields-group
+  = form.input :severity,
+               as: :radio_buttons,
+               collection: IpBlock.severities.keys,
+               include_blank: false,
+               label_method: ->(severity) { ip_blocks_severity_label(severity) },
+               wrapper: :with_block_label
+.fields-group
+  = form.input :comment,
+               as: :string,
+               wrapper: :with_block_label

--- a/app/views/admin/ip_blocks/new.html.haml
+++ b/app/views/admin/ip_blocks/new.html.haml
@@ -1,34 +1,10 @@
 - content_for :page_title do
   = t('.title')
 
-= simple_form_for @ip_block, url: admin_ip_blocks_path do |f|
+= simple_form_for @ip_block, url: admin_ip_blocks_path do |form|
   = render 'shared/error_messages', object: @ip_block
 
-  .fields-group
-    = f.input :ip,
-              as: :string,
-              input_html: { placeholder: '192.0.2.0/24' },
-              wrapper: :with_block_label
-
-  .fields-group
-    = f.input :expires_in,
-              collection: [1.day, 2.weeks, 1.month, 6.months, 1.year, 3.years].map(&:to_i),
-              label_method: ->(i) { I18n.t("admin.ip_blocks.expires_in.#{i}") },
-              prompt: I18n.t('invites.expires_in_prompt'),
-              wrapper: :with_block_label
-
-  .fields-group
-    = f.input :severity,
-              as: :radio_buttons,
-              collection: IpBlock.severities.keys,
-              include_blank: false,
-              label_method: ->(severity) { ip_blocks_severity_label(severity) },
-              wrapper: :with_block_label
-
-  .fields-group
-    = f.input :comment,
-              as: :string,
-              wrapper: :with_block_label
+  = render form
 
   .actions
-    = f.button :button, t('admin.ip_blocks.add_new'), type: :submit
+    = form.button :button, t('admin.ip_blocks.add_new'), type: :submit

--- a/app/views/admin/relays/_form.html.haml
+++ b/app/views/admin/relays/_form.html.haml
@@ -1,0 +1,4 @@
+.field-group
+  = form.input :inbox_url,
+               as: :string,
+               wrapper: :with_block_label

--- a/app/views/admin/relays/new.html.haml
+++ b/app/views/admin/relays/new.html.haml
@@ -1,13 +1,12 @@
 - content_for :page_title do
   = t('admin.relays.add_new')
 
-= simple_form_for @relay, url: admin_relays_path do |f|
+= simple_form_for @relay, url: admin_relays_path do |form|
   = render 'shared/error_messages', object: @relay
 
-  .field-group
-    = f.input :inbox_url, as: :string, wrapper: :with_block_label
+  = render form
 
   .actions
-    = f.button :button, t('admin.relays.save_and_enable'), type: :submit
+    = form.button :button, t('admin.relays.save_and_enable'), type: :submit
 
   %p.hint.subtle-hint= t('admin.relays.enable_hint')


### PR DESCRIPTION
In previous unrelated PRs working through haml lint things, we wound up pulling out `form` view partials for many, but not all, of the admin area new/edit views. This PR continues that and handles most of the rest (but not all - this does not do admin/settings area (will do separately), or any of the  searching/filtering sort of forms), notes:

-  For account actions, moved a previous i-var reference to a helper method (`warning_presets`, which as a side note, now uses an ordering scope to match how its presented in all other spots), and moved another i-var ref (account) into the `AccountAction`, and uses a `delegate` to keep the access from within the form simpler.
- For email_domain_blocks, similar helper extraction for `resolved_records` i-var
- The rest are just straight copy/extraction to the partial

If desired, I could pull out some of those preparation-type changes to precursor PRs and then rebase this one to have it be just exactractions ... but it didnt seem TOO excessive, so trying this first.