### PR TITLE
Extract `form` partial from admin/settings views

### DIFF
--- a/app/views/admin/settings/about/_form.html.haml
+++ b/app/views/admin/settings/about/_form.html.haml
@@ -1,0 +1,34 @@
+.fields-group
+  = form.input :site_extended_description,
+               as: :text,
+               input_html: { rows: 8 },
+               wrapper: :with_block_label
+  %p.hint
+    = t 'admin.settings.about.rules_hint'
+    = link_to t('admin.settings.about.manage_rules'), admin_rules_path
+.fields-row
+  .fields-row__column.fields-row__column-6.fields-group
+    = form.input :show_domain_blocks,
+                 collection_wrapper_tag: 'ul',
+                 collection: %i(disabled users all),
+                 include_blank: false,
+                 item_wrapper_tag: 'li',
+                 label_method: ->(value) { t("admin.settings.domain_blocks.#{value}") },
+                 wrapper: :with_label
+  .fields-row__column.fields-row__column-6.fields-group
+    = form.input :show_domain_blocks_rationale,
+                 collection_wrapper_tag: 'ul',
+                 collection: %i(disabled users all),
+                 include_blank: false,
+                 item_wrapper_tag: 'li',
+                 label_method: ->(value) { t("admin.settings.domain_blocks.#{value}") },
+                 wrapper: :with_label
+.fields-group
+  = form.input :status_page_url,
+               input_html: { placeholder: "https://status.#{Rails.configuration.x.local_domain}" },
+               wrapper: :with_block_label
+.fields-group
+  = form.input :site_terms,
+               as: :text,
+               input_html: { rows: 8 },
+               wrapper: :with_block_label

--- a/app/views/admin/settings/about/show.html.haml
+++ b/app/views/admin/settings/about/show.html.haml
@@ -5,49 +5,12 @@
   %h2= t('admin.settings.title')
   = render partial: 'admin/settings/shared/links'
 
-= simple_form_for @admin_settings, url: admin_settings_about_path, html: { method: :patch } do |f|
+= simple_form_for @admin_settings, url: admin_settings_about_path, html: { method: :patch } do |form|
   = render 'shared/error_messages', object: @admin_settings
 
   %p.lead= t('admin.settings.about.preamble')
 
-  .fields-group
-    = f.input :site_extended_description,
-              as: :text,
-              input_html: { rows: 8 },
-              wrapper: :with_block_label
-
-    %p.hint
-      = t 'admin.settings.about.rules_hint'
-      = link_to t('admin.settings.about.manage_rules'), admin_rules_path
-
-  .fields-row
-    .fields-row__column.fields-row__column-6.fields-group
-      = f.input :show_domain_blocks,
-                collection_wrapper_tag: 'ul',
-                collection: %i(disabled users all),
-                include_blank: false,
-                item_wrapper_tag: 'li',
-                label_method: ->(value) { t("admin.settings.domain_blocks.#{value}") },
-                wrapper: :with_label
-    .fields-row__column.fields-row__column-6.fields-group
-      = f.input :show_domain_blocks_rationale,
-                collection_wrapper_tag: 'ul',
-                collection: %i(disabled users all),
-                include_blank: false,
-                item_wrapper_tag: 'li',
-                label_method: ->(value) { t("admin.settings.domain_blocks.#{value}") },
-                wrapper: :with_label
-
-  .fields-group
-    = f.input :status_page_url,
-              input_html: { placeholder: "https://status.#{Rails.configuration.x.local_domain}" },
-              wrapper: :with_block_label
-
-  .fields-group
-    = f.input :site_terms,
-              as: :text,
-              input_html: { rows: 8 },
-              wrapper: :with_block_label
+  = render form
 
   .actions
-    = f.button :button, t('generic.save_changes'), type: :submit
+    = form.button :button, t('generic.save_changes'), type: :submit

--- a/app/views/admin/settings/appearance/_form.html.haml
+++ b/app/views/admin/settings/appearance/_form.html.haml
@@ -1,0 +1,22 @@
+.fields-group
+  = form.input :theme,
+               collection: Themes.instance.names,
+               include_blank: false,
+               label_method: ->(theme) { I18n.t("themes.#{theme}", default: theme) },
+               wrapper: :with_label
+.fields-group
+  = form.input :custom_css,
+               as: :text,
+               input_html: { rows: 8 },
+               wrapper: :with_block_label
+.fields-row
+  .fields-row__column.fields-row__column-6.fields-group
+    = form.input :mascot,
+                 as: :file,
+                 wrapper: :with_block_label
+  .fields-row__column.fields-row__column-6.fields-group
+    - if form.object.mascot.persisted?
+      = image_tag form.object.mascot.file.url, class: 'fields-group__thumbnail'
+      = link_to admin_site_upload_path(form.object.mascot), data: { method: :delete }, class: 'link-button link-button--destructive' do
+        = material_symbol 'delete'
+        = t('admin.site_uploads.delete')

--- a/app/views/admin/settings/appearance/show.html.haml
+++ b/app/views/admin/settings/appearance/show.html.haml
@@ -5,36 +5,12 @@
   %h2= t('admin.settings.title')
   = render partial: 'admin/settings/shared/links'
 
-= simple_form_for @admin_settings, url: admin_settings_appearance_path, html: { method: :patch } do |f|
+= simple_form_for @admin_settings, url: admin_settings_appearance_path, html: { method: :patch } do |form|
   = render 'shared/error_messages', object: @admin_settings
 
   %p.lead= t('admin.settings.appearance.preamble')
 
-  .fields-group
-    = f.input :theme,
-              collection: Themes.instance.names,
-              include_blank: false,
-              label_method: ->(theme) { I18n.t("themes.#{theme}", default: theme) },
-              wrapper: :with_label
-
-  .fields-group
-    = f.input :custom_css,
-              as: :text,
-              input_html: { rows: 8 },
-              wrapper: :with_block_label
-
-  .fields-row
-    .fields-row__column.fields-row__column-6.fields-group
-      = f.input :mascot,
-                as: :file,
-                wrapper: :with_block_label
-
-    .fields-row__column.fields-row__column-6.fields-group
-      - if @admin_settings.mascot.persisted?
-        = image_tag @admin_settings.mascot.file.url, class: 'fields-group__thumbnail'
-        = link_to admin_site_upload_path(@admin_settings.mascot), data: { method: :delete }, class: 'link-button link-button--destructive' do
-          = material_symbol 'delete'
-          = t('admin.site_uploads.delete')
+  = render form
 
   .actions
-    = f.button :button, t('generic.save_changes'), type: :submit
+    = form.button :button, t('generic.save_changes'), type: :submit

--- a/app/views/admin/settings/branding/_form.html.haml
+++ b/app/views/admin/settings/branding/_form.html.haml
@@ -1,0 +1,50 @@
+.fields-group
+  = form.input :site_title,
+               wrapper: :with_label
+.fields-row
+  .fields-row__column.fields-row__column-6.fields-group
+    = form.input :site_contact_username,
+                 wrapper: :with_label
+  .fields-row__column.fields-row__column-6.fields-group
+    = form.input :site_contact_email,
+                 wrapper: :with_label
+.fields-group
+  = form.input :site_short_description,
+               as: :text,
+               input_html: { rows: 2, maxlength: Form::AdminSettings::DESCRIPTION_LIMIT },
+               wrapper: :with_block_label
+.fields-row
+  .fields-row__column.fields-row__column-6.fields-group
+    = form.input :thumbnail,
+                 as: :file,
+                 wrapper: :with_block_label
+  .fields-row__column.fields-row__column-6.fields-group
+    - if form.object.thumbnail.persisted?
+      = image_tag form.object.thumbnail.file.url(:'@1x'), class: 'fields-group__thumbnail'
+      = link_to admin_site_upload_path(form.object.thumbnail), data: { method: :delete }, class: 'link-button link-button--destructive' do
+        = material_symbol 'delete'
+        = t('admin.site_uploads.delete')
+.fields-row
+  .fields-row__column.fields-row__column-6.fields-group
+    = form.input :favicon,
+                 as: :file,
+                 input_html: { accept: ['image/jpeg', 'image/png', 'image/gif', 'image/webp'].join(',') },
+                 wrapper: :with_block_label
+  .fields-row__column.fields-row__column-6.fields-group
+    - if form.object.favicon.persisted?
+      = image_tag form.object.favicon.file.url('48'), class: 'fields-group__thumbnail'
+      = link_to admin_site_upload_path(form.object.favicon), data: { method: :delete }, class: 'link-button link-button--destructive' do
+        = material_symbol 'delete'
+        = t('admin.site_uploads.delete')
+.fields-row
+  .fields-row__column.fields-row__column-6.fields-group
+    = form.input :app_icon,
+                 as: :file,
+                 input_html: { accept: ['image/jpeg', 'image/png', 'image/gif', 'image/webp'].join(',') },
+                 wrapper: :with_block_label
+  .fields-row__column.fields-row__column-6.fields-group
+    - if form.object.app_icon.persisted?
+      = image_tag form.object.app_icon.file.url('48'), class: 'fields-group__thumbnail'
+      = link_to admin_site_upload_path(form.object.app_icon), data: { method: :delete }, class: 'link-button link-button--destructive' do
+        = material_symbol 'delete'
+        = t('admin.site_uploads.delete')

--- a/app/views/admin/settings/branding/show.html.haml
+++ b/app/views/admin/settings/branding/show.html.haml
@@ -5,68 +5,12 @@
   %h2= t('admin.settings.title')
   = render partial: 'admin/settings/shared/links'
 
-= simple_form_for @admin_settings, url: admin_settings_branding_path, html: { method: :patch } do |f|
+= simple_form_for @admin_settings, url: admin_settings_branding_path, html: { method: :patch } do |form|
   = render 'shared/error_messages', object: @admin_settings
 
   %p.lead= t('admin.settings.branding.preamble')
 
-  .fields-group
-    = f.input :site_title,
-              wrapper: :with_label
-
-  .fields-row
-    .fields-row__column.fields-row__column-6.fields-group
-      = f.input :site_contact_username,
-                wrapper: :with_label
-    .fields-row__column.fields-row__column-6.fields-group
-      = f.input :site_contact_email,
-                wrapper: :with_label
-
-  .fields-group
-    = f.input :site_short_description,
-              as: :text,
-              input_html: { rows: 2, maxlength: Form::AdminSettings::DESCRIPTION_LIMIT },
-              wrapper: :with_block_label
-
-  .fields-row
-    .fields-row__column.fields-row__column-6.fields-group
-      = f.input :thumbnail,
-                as: :file,
-                wrapper: :with_block_label
-    .fields-row__column.fields-row__column-6.fields-group
-      - if @admin_settings.thumbnail.persisted?
-        = image_tag @admin_settings.thumbnail.file.url(:'@1x'), class: 'fields-group__thumbnail'
-        = link_to admin_site_upload_path(@admin_settings.thumbnail), data: { method: :delete }, class: 'link-button link-button--destructive' do
-          = material_symbol 'delete'
-          = t('admin.site_uploads.delete')
-
-  .fields-row
-    .fields-row__column.fields-row__column-6.fields-group
-      = f.input :favicon,
-                as: :file,
-                input_html: { accept: ['image/jpeg', 'image/png', 'image/gif', 'image/webp'].join(',') },
-                wrapper: :with_block_label
-
-    .fields-row__column.fields-row__column-6.fields-group
-      - if @admin_settings.favicon.persisted?
-        = image_tag @admin_settings.favicon.file.url('48'), class: 'fields-group__thumbnail'
-        = link_to admin_site_upload_path(@admin_settings.favicon), data: { method: :delete }, class: 'link-button link-button--destructive' do
-          = material_symbol 'delete'
-          = t('admin.site_uploads.delete')
-
-  .fields-row
-    .fields-row__column.fields-row__column-6.fields-group
-      = f.input :app_icon,
-                as: :file,
-                input_html: { accept: ['image/jpeg', 'image/png', 'image/gif', 'image/webp'].join(',') },
-                wrapper: :with_block_label
-
-    .fields-row__column.fields-row__column-6.fields-group
-      - if @admin_settings.app_icon.persisted?
-        = image_tag @admin_settings.app_icon.file.url('48'), class: 'fields-group__thumbnail'
-        = link_to admin_site_upload_path(@admin_settings.app_icon), data: { method: :delete }, class: 'link-button link-button--destructive' do
-          = material_symbol 'delete'
-          = t('admin.site_uploads.delete')
+  = render form
 
   .actions
-    = f.button :button, t('generic.save_changes'), type: :submit
+    = form.button :button, t('generic.save_changes'), type: :submit

--- a/app/views/admin/settings/content_retention/_form.html.haml
+++ b/app/views/admin/settings/content_retention/_form.html.haml
@@ -1,0 +1,14 @@
+.fields-group
+  = form.input :media_cache_retention_period,
+               input_html: { pattern: '[0-9]+' },
+               wrapper: :with_block_label
+  = form.input :backups_retention_period,
+               input_html: { pattern: '[0-9]+' },
+               wrapper: :with_block_label
+%h4= t('admin.settings.content_retention.danger_zone')
+.fields-group
+  = form.input :content_cache_retention_period,
+               hint: false,
+               input_html: { pattern: '[0-9]+' },
+               warning_hint: t('simple_form.hints.form_admin_settings.content_cache_retention_period'),
+               wrapper: :with_block_label

--- a/app/views/admin/settings/content_retention/show.html.haml
+++ b/app/views/admin/settings/content_retention/show.html.haml
@@ -5,27 +5,12 @@
   %h2= t('admin.settings.title')
   = render partial: 'admin/settings/shared/links'
 
-= simple_form_for @admin_settings, url: admin_settings_content_retention_path, html: { method: :patch } do |f|
+= simple_form_for @admin_settings, url: admin_settings_content_retention_path, html: { method: :patch } do |form|
   = render 'shared/error_messages', object: @admin_settings
 
   %p.lead= t('admin.settings.content_retention.preamble')
 
-  .fields-group
-    = f.input :media_cache_retention_period,
-              input_html: { pattern: '[0-9]+' },
-              wrapper: :with_block_label
-    = f.input :backups_retention_period,
-              input_html: { pattern: '[0-9]+' },
-              wrapper: :with_block_label
-
-  %h4= t('admin.settings.content_retention.danger_zone')
-
-  .fields-group
-    = f.input :content_cache_retention_period,
-              hint: false,
-              input_html: { pattern: '[0-9]+' },
-              warning_hint: t('simple_form.hints.form_admin_settings.content_cache_retention_period'),
-              wrapper: :with_block_label
+  = render form
 
   .actions
-    = f.button :button, t('generic.save_changes'), type: :submit
+    = form.button :button, t('generic.save_changes'), type: :submit

--- a/app/views/admin/settings/discovery/_form.html.haml
+++ b/app/views/admin/settings/discovery/_form.html.haml
@@ -1,0 +1,56 @@
+%h4= t('admin.settings.discovery.trends')
+.fields-group
+  = form.input :trends,
+               as: :boolean,
+               wrapper: :with_label
+.fields-group
+  = form.input :trends_as_landing_page,
+               as: :boolean,
+               wrapper: :with_label
+.fields-group
+  = form.input :trendable_by_default,
+               as: :boolean,
+               recommended: :not_recommended,
+               wrapper: :with_label
+%h4= t('admin.settings.discovery.public_timelines')
+.fields-group
+  = form.input :timeline_preview,
+               as: :boolean,
+               wrapper: :with_label
+.fields-group
+  = form.input :noindex,
+               as: :boolean,
+               hint: t('admin.settings.default_noindex.desc_html'),
+               label: t('admin.settings.default_noindex.title'),
+               wrapper: :with_label
+%h4= t('admin.settings.discovery.publish_statistics')
+.fields-group
+  = form.input :activity_api_enabled,
+               as: :boolean,
+               recommended: :recommended,
+               wrapper: :with_label
+%h4= t('admin.settings.discovery.publish_discovered_servers')
+.fields-group
+  = form.input :peers_api_enabled,
+               as: :boolean,
+               recommended: :recommended,
+               wrapper: :with_label
+%h4= t('admin.settings.security.federation_authentication')
+.fields-group
+  = form.input :authorized_fetch,
+               as: :boolean,
+               disabled: authorized_fetch_overridden?,
+               hint: discovery_hint_text,
+               label: t('admin.settings.security.authorized_fetch'),
+               recommended: discovery_recommended_value,
+               warning_hint: discovery_warning_hint_text,
+               wrapper: :with_label
+%h4= t('admin.settings.discovery.follow_recommendations')
+.fields-group
+  = form.input :bootstrap_timeline_accounts,
+               wrapper: :with_block_label
+%h4= t('admin.settings.discovery.profile_directory')
+.fields-group
+  = form.input :profile_directory,
+               as: :boolean,
+               wrapper: :with_label

--- a/app/views/admin/settings/discovery/show.html.haml
+++ b/app/views/admin/settings/discovery/show.html.haml
@@ -5,83 +5,12 @@
   %h2= t('admin.settings.title')
   = render partial: 'admin/settings/shared/links'
 
-= simple_form_for @admin_settings, url: admin_settings_discovery_path, html: { method: :patch } do |f|
+= simple_form_for @admin_settings, url: admin_settings_discovery_path, html: { method: :patch } do |form|
   = render 'shared/error_messages', object: @admin_settings
 
   %p.lead= t('admin.settings.discovery.preamble')
 
-  %h4= t('admin.settings.discovery.trends')
-
-  .fields-group
-    = f.input :trends,
-              as: :boolean,
-              wrapper: :with_label
-
-  .fields-group
-    = f.input :trends_as_landing_page,
-              as: :boolean,
-              wrapper: :with_label
-
-  .fields-group
-    = f.input :trendable_by_default,
-              as: :boolean,
-              wrapper: :with_label,
-              recommended: :not_recommended
-
-  %h4= t('admin.settings.discovery.public_timelines')
-
-  .fields-group
-    = f.input :timeline_preview,
-              as: :boolean,
-              wrapper: :with_label
-
-  .fields-group
-    = f.input :noindex,
-              as: :boolean,
-              hint: t('admin.settings.default_noindex.desc_html'),
-              label: t('admin.settings.default_noindex.title'),
-              wrapper: :with_label
-
-  %h4= t('admin.settings.discovery.publish_statistics')
-
-  .fields-group
-    = f.input :activity_api_enabled,
-              as: :boolean,
-              wrapper: :with_label,
-              recommended: :recommended
-
-  %h4= t('admin.settings.discovery.publish_discovered_servers')
-
-  .fields-group
-    = f.input :peers_api_enabled,
-              as: :boolean,
-              wrapper: :with_label,
-              recommended: :recommended
-
-  %h4= t('admin.settings.security.federation_authentication')
-
-  .fields-group
-    = f.input :authorized_fetch,
-              as: :boolean,
-              disabled: authorized_fetch_overridden?,
-              hint: discovery_hint_text,
-              label: t('admin.settings.security.authorized_fetch'),
-              recommended: discovery_recommended_value,
-              warning_hint: discovery_warning_hint_text,
-              wrapper: :with_label
-
-  %h4= t('admin.settings.discovery.follow_recommendations')
-
-  .fields-group
-    = f.input :bootstrap_timeline_accounts,
-              wrapper: :with_block_label
-
-  %h4= t('admin.settings.discovery.profile_directory')
-
-  .fields-group
-    = f.input :profile_directory,
-              as: :boolean,
-              wrapper: :with_label
+  = render form
 
   .actions
-    = f.button :button, t('generic.save_changes'), type: :submit
+    = form.button :button, t('generic.save_changes'), type: :submit

--- a/app/views/admin/settings/registrations/_form.html.haml
+++ b/app/views/admin/settings/registrations/_form.html.haml
@@ -1,0 +1,27 @@
+.flash-message= t('admin.settings.registrations.moderation_recommandation')
+
+.fields-row
+  .fields-row__column.fields-row__column-6.fields-group
+    = form.input :registrations_mode,
+                 collection: %w(open approved none),
+                 include_blank: false,
+                 label_method: ->(mode) { I18n.t("admin.settings.registrations_mode.modes.#{mode}") },
+                 warning_hint: I18n.t('admin.settings.registrations_mode.warning_hint'),
+                 wrapper: :with_label
+  .fields-row__column.fields-row__column-6.fields-group
+    = form.input :require_invite_text,
+                 as: :boolean,
+                 disabled: !approved_registrations?,
+                 wrapper: :with_label
+- if captcha_available?
+  .fields-group
+    = form.input :captcha_enabled,
+                 as: :boolean,
+                 hint: t('admin.settings.captcha_enabled.desc_html'),
+                 label: t('admin.settings.captcha_enabled.title'),
+                 wrapper: :with_label
+.fields-group
+  = form.input :closed_registrations_message,
+               as: :text,
+               input_html: { rows: 2 },
+               wrapper: :with_block_label

--- a/app/views/admin/settings/registrations/show.html.haml
+++ b/app/views/admin/settings/registrations/show.html.haml
@@ -5,41 +5,12 @@
   %h2= t('admin.settings.title')
   = render partial: 'admin/settings/shared/links'
 
-= simple_form_for @admin_settings, url: admin_settings_registrations_path, html: { method: :patch } do |f|
+= simple_form_for @admin_settings, url: admin_settings_registrations_path, html: { method: :patch } do |form|
   = render 'shared/error_messages', object: @admin_settings
 
   %p.lead= t('admin.settings.registrations.preamble')
 
-  .flash-message= t('admin.settings.registrations.moderation_recommandation')
-
-  .fields-row
-    .fields-row__column.fields-row__column-6.fields-group
-      = f.input :registrations_mode,
-                collection: %w(open approved none),
-                include_blank: false,
-                label_method: ->(mode) { I18n.t("admin.settings.registrations_mode.modes.#{mode}") },
-                warning_hint: I18n.t('admin.settings.registrations_mode.warning_hint'),
-                wrapper: :with_label
-
-    .fields-row__column.fields-row__column-6.fields-group
-      = f.input :require_invite_text,
-                as: :boolean,
-                disabled: !approved_registrations?,
-                wrapper: :with_label
-
-  - if captcha_available?
-    .fields-group
-      = f.input :captcha_enabled,
-                as: :boolean,
-                hint: t('admin.settings.captcha_enabled.desc_html'),
-                label: t('admin.settings.captcha_enabled.title'),
-                wrapper: :with_label
-
-  .fields-group
-    = f.input :closed_registrations_message,
-              as: :text,
-              input_html: { rows: 2 },
-              wrapper: :with_block_label
+  = render form
 
   .actions
-    = f.button :button, t('generic.save_changes'), type: :submit
+    = form.button :button, t('generic.save_changes'), type: :submit


### PR DESCRIPTION
Same idea as https://github.com/mastodon/mastodon/pull/32095 but just the group of admin/settings views.

In the two cases here using i-vars in the forms, the vars were the same as `form.object`, so easier here to just use that instead of needing helpers as in linked PR.

Did a local visual before/after check to verify same, and specs should be ok.