### PR TITLE
Rename "Data export" menu item

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1693,7 +1693,7 @@ en:
     delete: Account deletion
     development: Development
     edit_profile: Edit profile
-    export: Data export
+    export: Export
     featured_tags: Featured hashtags
     import: Import
     import_and_export: Import and export


### PR DESCRIPTION
The settings menu item _Import and export_ has two submenu items, _Import_ and _Data export_.

Menu item labels should be brief. “Data” is redundant in this context, and using it  on only one of the two items is inconsistent.

This is a spin-off from #26346 which was probably trying to do too many things in one PR. I hope this simple, uncontroversial PR has a greater chance of being merged.