### PR TITLE
Fix typo causing incorrect error being raised in blurhash processing failure

### DIFF
--- a/lib/paperclip/blurhash_transcoder.rb
+++ b/lib/paperclip/blurhash_transcoder.rb
@@ -7,7 +7,7 @@ module Paperclip
 
       width, height, data = blurhash_params
       # Guard against segfaults if data has unexpected size
-      raise RangeError("Invalid image data size (expected #{width * height * 3}, got #{data.size})") if data.size != width * height * 3 # TODO: should probably be another exception type
+      raise RangeError, "Invalid image data size (expected #{width * height * 3}, got #{data.size})" if data.size != width * height * 3 # TODO: should probably be another exception type
 
       attachment.instance.blurhash = Blurhash.encode(width, height, data, **(options[:blurhash] || {}))
 


### PR DESCRIPTION
Related to #32096, though it does not fix the underlying issue.