### PR TITLE
Add fallback to domain block confirmation modal

### DIFF
--- a/app/javascript/mastodon/features/ui/components/domain_block_modal.tsx
+++ b/app/javascript/mastodon/features/ui/components/domain_block_modal.tsx
@@ -30,9 +30,9 @@ export const DomainBlockModal: React.FC<{
 }> = ({ domain, accountId, acct }) => {
   const dispatch = useAppDispatch();
   const [loading, setLoading] = useState(true);
-  const [preview, setPreview] = useState<DomainBlockPreviewResponse | null>(
-    null,
-  );
+  const [preview, setPreview] = useState<
+    DomainBlockPreviewResponse | 'error' | null
+  >(null);
 
   const handleClick = useCallback(() => {
     if (loading) {
@@ -65,6 +65,7 @@ export const DomainBlockModal: React.FC<{
         return '';
       })
       .catch(() => {
+        setPreview('error');
         setLoading(false);
       });
   }, [setPreview, setLoading, domain]);
@@ -89,7 +90,35 @@ export const DomainBlockModal: React.FC<{
         </div>
 
         <div className='safety-action-modal__bullet-points'>
-          {preview && preview.followers_count + preview.following_count > 0 && (
+          {preview &&
+            preview !== 'error' &&
+            preview.followers_count + preview.following_count > 0 && (
+              <div>
+                <div className='safety-action-modal__bullet-points__icon'>
+                  <Icon id='' icon={PersonRemoveIcon} />
+                </div>
+                <div>
+                  <strong>
+                    <FormattedMessage
+                      id='domain_block_modal.you_will_lose_num_followers'
+                      defaultMessage='You will lose {followersCount, plural, one {{followersCountDisplay} follower} other {{followersCountDisplay} followers}} and {followingCount, plural, one {{followingCountDisplay} person you follow} other {{followingCountDisplay} people you follow}}.'
+                      values={{
+                        followersCount: preview.followers_count,
+                        followersCountDisplay: (
+                          <ShortNumber value={preview.followers_count} />
+                        ),
+                        followingCount: preview.following_count,
+                        followingCountDisplay: (
+                          <ShortNumber value={preview.following_count} />
+                        ),
+                      }}
+                    />
+                  </strong>
+                </div>
+              </div>
+            )}
+
+          {preview === 'error' && (
             <div>
               <div className='safety-action-modal__bullet-points__icon'>
                 <Icon id='' icon={PersonRemoveIcon} />
@@ -97,18 +126,8 @@ export const DomainBlockModal: React.FC<{
               <div>
                 <strong>
                   <FormattedMessage
-                    id='domain_block_modal.you_will_lose_num_followers'
-                    defaultMessage='You will lose {followersCount, plural, one {{followersCountDisplay} follower} other {{followersCountDisplay} followers}} and {followingCount, plural, one {{followingCountDisplay} person you follow} other {{followingCountDisplay} people you follow}}.'
-                    values={{
-                      followersCount: preview.followers_count,
-                      followersCountDisplay: (
-                        <ShortNumber value={preview.followers_count} />
-                      ),
-                      followingCount: preview.following_count,
-                      followingCountDisplay: (
-                        <ShortNumber value={preview.following_count} />
-                      ),
-                    }}
+                    id='domain_block_modal.you_will_lose_relationships'
+                    defaultMessage='You will lose all followers and people you follow from this server.'
                   />
                 </strong>
               </div>

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -222,6 +222,7 @@
   "domain_block_modal.they_wont_know": "They won't know they've been blocked.",
   "domain_block_modal.title": "Block domain?",
   "domain_block_modal.you_will_lose_num_followers": "You will lose {followersCount, plural, one {{followersCountDisplay} follower} other {{followersCountDisplay} followers}} and {followingCount, plural, one {{followingCountDisplay} person you follow} other {{followingCountDisplay} people you follow}}.",
+  "domain_block_modal.you_will_lose_relationships": "You will lose all followers and people you follow from this server.",
   "domain_block_modal.you_wont_see_posts": "You won't see posts or notifications from users on this server.",
   "domain_pill.activitypub_lets_connect": "It lets you connect and interact with people not just on Mastodon, but across different social apps too.",
   "domain_pill.activitypub_like_language": "ActivityPub is like the language Mastodon speaks with other social networks.",


### PR DESCRIPTION
#32032 added a count of followers/follows that would be lost when blocking a server, in order to highlight the destructive nature of the action.

In addition, it removed the line about losing follows/followers when no relationship would be removed, but that change also applies to the API request erroring out or timing out (which is actually slightly more likely to occur if there are lots of relationships with the server), which means that the information may be missing.

This PR adds a generic “You will lose any follower and any person you follow that you may have from this server.” message in place of the counts if the API request times out or errors out.

![image](https://github.com/user-attachments/assets/df89133f-3c4f-4b51-94a8-68e263d24d50)