### PR TITLE
Add “A Mastodon update is available.” message on admin dashboard for non-bugfix updates

### DIFF
--- a/app/lib/admin/system_check/software_version_check.rb
+++ b/app/lib/admin/system_check/software_version_check.rb
@@ -14,14 +14,16 @@ class Admin::SystemCheck::SoftwareVersionCheck < Admin::SystemCheck::BaseCheck
   def message
     if software_updates.any?(&:urgent?)
       Admin::SystemCheck::Message.new(:software_version_critical_check, nil, admin_software_updates_path, true)
-    else
+    elsif software_updates.any?(&:patch_type?)
       Admin::SystemCheck::Message.new(:software_version_patch_check, nil, admin_software_updates_path)
+    else
+      Admin::SystemCheck::Message.new(:software_version_check, nil, admin_software_updates_path)
     end
   end
 
   private
 
   def software_updates
-    @software_updates ||= SoftwareUpdate.pending_to_a.filter { |update| update.urgent? || update.patch_type? }
+    @software_updates ||= SoftwareUpdate.pending_to_a
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -875,6 +875,9 @@ en:
         message_html: You haven't defined any server rules.
       sidekiq_process_check:
         message_html: No Sidekiq process running for the %{value} queue(s). Please review your Sidekiq configuration
+      software_version_check:
+        action: See available updates
+        message_html: A Mastodon update is available.
       software_version_critical_check:
         action: See available updates
         message_html: A critical Mastodon update is available, please update as quickly as possible.

--- a/spec/lib/admin/system_check/software_version_check_spec.rb
+++ b/spec/lib/admin/system_check/software_version_check_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe Admin::SystemCheck::SoftwareVersionCheck do
         Fabricate(:software_update, version: '99.99.99', type: 'major', urgent: false)
       end
 
-      it 'returns true' do
-        expect(check.pass?).to be true
+      it 'returns false' do
+        expect(check.pass?).to be false
       end
     end
 


### PR DESCRIPTION
We may possibly want to backport this.