### PR TITLE
Remove completed TODO note in tags request spec

### DIFF
--- a/spec/requests/tags_spec.rb
+++ b/spec/requests/tags_spec.rb
@@ -7,18 +7,6 @@ RSpec.describe 'Tags' do
     context 'when tag exists' do
       let(:tag) { Fabricate :tag }
 
-      context 'with HTML format' do
-        # TODO: Update the have_cacheable_headers matcher to operate on capybara sessions
-        # Remove this example, rely on system spec (which should use matcher)
-        before { get tag_path(tag) }
-
-        it 'returns http success' do
-          expect(response)
-            .to have_http_status(200)
-            .and have_cacheable_headers.with_vary('Accept, Accept-Language, Cookie')
-        end
-      end
-
       context 'with JSON format' do
         before { get tag_path(tag, format: :json) }
 


### PR DESCRIPTION
This was here as interim holdover until we could add a private headers check on the capybara system specs side. That has since been done, and this action in html format is covered there, so this can go.