### PR TITLE
Enable hostname config for all system specs

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -161,6 +161,11 @@ RSpec.configure do |config|
     host! Rails.configuration.x.local_domain
   end
 
+  config.before :each, type: :system do
+    # Align with capybara config so that rails helpers called from rspec use matching host
+    host! 'localhost:3000'
+  end
+
   config.after do
     Rails.cache.clear
     redis.del(redis.keys)

--- a/spec/system/invites_spec.rb
+++ b/spec/system/invites_spec.rb
@@ -7,10 +7,7 @@ RSpec.describe 'Invites' do
 
   let(:user) { Fabricate :user }
 
-  before do
-    host! 'localhost:3000' # TODO: Move into before for all system specs?
-    sign_in user
-  end
+  before { sign_in user }
 
   describe 'Viewing invites' do
     it 'Lists existing user invites' do


### PR DESCRIPTION
Handles TODO from the diff

This is useful so that url helpers and other rails things, when called from the specs directly, can match what capybara is doing w/out needing extra host options.