### PR TITLE
Use full width on keyboard shortcut page

### DIFF
--- a/app/javascript/mastodon/features/keyboard_shortcuts/index.jsx
+++ b/app/javascript/mastodon/features/keyboard_shortcuts/index.jsx
@@ -37,134 +37,134 @@ class KeyboardShortcuts extends ImmutablePureComponent {
           <table>
             <thead>
               <tr>
-                <th><FormattedMessage id='keyboard_shortcuts.hotkey' defaultMessage='Hotkey' /></th>
                 <th><FormattedMessage id='keyboard_shortcuts.description' defaultMessage='Description' /></th>
+                <th><FormattedMessage id='keyboard_shortcuts.hotkey' defaultMessage='Hotkey' /></th>
               </tr>
             </thead>
             <tbody>
               <tr>
-                <td><kbd>r</kbd></td>
                 <td><FormattedMessage id='keyboard_shortcuts.reply' defaultMessage='to reply' /></td>
+                <td><kbd>r</kbd></td>
               </tr>
               <tr>
-                <td><kbd>m</kbd></td>
                 <td><FormattedMessage id='keyboard_shortcuts.mention' defaultMessage='to mention author' /></td>
+                <td><kbd>m</kbd></td>
               </tr>
               <tr>
-                <td><kbd>p</kbd></td>
                 <td><FormattedMessage id='keyboard_shortcuts.profile' defaultMessage="to open author's profile" /></td>
+                <td><kbd>p</kbd></td>
               </tr>
               <tr>
-                <td><kbd>f</kbd></td>
                 <td><FormattedMessage id='keyboard_shortcuts.favourite' defaultMessage='to favorite' /></td>
+                <td><kbd>f</kbd></td>
               </tr>
               <tr>
-                <td><kbd>b</kbd></td>
                 <td><FormattedMessage id='keyboard_shortcuts.boost' defaultMessage='to boost' /></td>
+                <td><kbd>b</kbd></td>
               </tr>
               <tr>
-                <td><kbd>enter</kbd>, <kbd>o</kbd></td>
                 <td><FormattedMessage id='keyboard_shortcuts.enter' defaultMessage='to open status' /></td>
+                <td><kbd>enter</kbd>, <kbd>o</kbd></td>
               </tr>
               <tr>
-                <td><kbd>e</kbd></td>
                 <td><FormattedMessage id='keyboard_shortcuts.open_media' defaultMessage='to open media' /></td>
+                <td><kbd>e</kbd></td>
               </tr>
               <tr>
-                <td><kbd>x</kbd></td>
                 <td><FormattedMessage id='keyboard_shortcuts.toggle_hidden' defaultMessage='to show/hide text behind CW' /></td>
+                <td><kbd>x</kbd></td>
               </tr>
               <tr>
-                <td><kbd>h</kbd></td>
                 <td><FormattedMessage id='keyboard_shortcuts.toggle_sensitivity' defaultMessage='to show/hide media' /></td>
+                <td><kbd>h</kbd></td>
               </tr>
               <tr>
-                <td><kbd>up</kbd>, <kbd>k</kbd></td>
                 <td><FormattedMessage id='keyboard_shortcuts.up' defaultMessage='to move up in the list' /></td>
+                <td><kbd>up</kbd>, <kbd>k</kbd></td>
               </tr>
               <tr>
-                <td><kbd>down</kbd>, <kbd>j</kbd></td>
                 <td><FormattedMessage id='keyboard_shortcuts.down' defaultMessage='to move down in the list' /></td>
+                <td><kbd>down</kbd>, <kbd>j</kbd></td>
               </tr>
               <tr>
-                <td><kbd>1</kbd>-<kbd>9</kbd></td>
                 <td><FormattedMessage id='keyboard_shortcuts.column' defaultMessage='to focus a status in one of the columns' /></td>
+                <td><kbd>1</kbd>-<kbd>9</kbd></td>
               </tr>
               <tr>
-                <td><kbd>n</kbd></td>
                 <td><FormattedMessage id='keyboard_shortcuts.compose' defaultMessage='to focus the compose textarea' /></td>
+                <td><kbd>n</kbd></td>
               </tr>
               <tr>
-                <td><kbd>alt</kbd>+<kbd>n</kbd></td>
                 <td><FormattedMessage id='keyboard_shortcuts.toot' defaultMessage='to start a brand new post' /></td>
+                <td><kbd>alt</kbd>+<kbd>n</kbd></td>
               </tr>
               <tr>
-                <td><kbd>alt</kbd>+<kbd>x</kbd></td>
                 <td><FormattedMessage id='keyboard_shortcuts.spoilers' defaultMessage='to show/hide CW field' /></td>
+                <td><kbd>alt</kbd>+<kbd>x</kbd></td>
               </tr>
               <tr>
-                <td><kbd>backspace</kbd></td>
                 <td><FormattedMessage id='keyboard_shortcuts.back' defaultMessage='to navigate back' /></td>
+                <td><kbd>backspace</kbd></td>
               </tr>
               <tr>
-                <td><kbd>s</kbd>, <kbd>/</kbd></td>
                 <td><FormattedMessage id='keyboard_shortcuts.search' defaultMessage='to focus search' /></td>
+                <td><kbd>s</kbd>, <kbd>/</kbd></td>
               </tr>
               <tr>
-                <td><kbd>esc</kbd></td>
                 <td><FormattedMessage id='keyboard_shortcuts.unfocus' defaultMessage='to un-focus compose textarea/search' /></td>
+                <td><kbd>esc</kbd></td>
               </tr>
               <tr>
-                <td><kbd>g</kbd>+<kbd>h</kbd></td>
                 <td><FormattedMessage id='keyboard_shortcuts.home' defaultMessage='to open home timeline' /></td>
+                <td><kbd>g</kbd>+<kbd>h</kbd></td>
               </tr>
               <tr>
-                <td><kbd>g</kbd>+<kbd>n</kbd></td>
                 <td><FormattedMessage id='keyboard_shortcuts.notifications' defaultMessage='to open notifications column' /></td>
+                <td><kbd>g</kbd>+<kbd>n</kbd></td>
               </tr>
               <tr>
-                <td><kbd>g</kbd>+<kbd>l</kbd></td>
                 <td><FormattedMessage id='keyboard_shortcuts.local' defaultMessage='to open local timeline' /></td>
+                <td><kbd>g</kbd>+<kbd>l</kbd></td>
               </tr>
               <tr>
-                <td><kbd>g</kbd>+<kbd>t</kbd></td>
                 <td><FormattedMessage id='keyboard_shortcuts.federated' defaultMessage='to open federated timeline' /></td>
+                <td><kbd>g</kbd>+<kbd>t</kbd></td>
               </tr>
               <tr>
-                <td><kbd>g</kbd>+<kbd>d</kbd></td>
                 <td><FormattedMessage id='keyboard_shortcuts.direct' defaultMessage='to open direct messages column' /></td>
+                <td><kbd>g</kbd>+<kbd>d</kbd></td>
               </tr>
               <tr>
-                <td><kbd>g</kbd>+<kbd>s</kbd></td>
                 <td><FormattedMessage id='keyboard_shortcuts.start' defaultMessage='to open "get started" column' /></td>
+                <td><kbd>g</kbd>+<kbd>s</kbd></td>
               </tr>
               <tr>
-                <td><kbd>g</kbd>+<kbd>f</kbd></td>
                 <td><FormattedMessage id='keyboard_shortcuts.favourites' defaultMessage='to open favorites list' /></td>
+                <td><kbd>g</kbd>+<kbd>f</kbd></td>
               </tr>
               <tr>
-                <td><kbd>g</kbd>+<kbd>p</kbd></td>
                 <td><FormattedMessage id='keyboard_shortcuts.pinned' defaultMessage='to open pinned posts list' /></td>
+                <td><kbd>g</kbd>+<kbd>p</kbd></td>
               </tr>
               <tr>
-                <td><kbd>g</kbd>+<kbd>u</kbd></td>
                 <td><FormattedMessage id='keyboard_shortcuts.my_profile' defaultMessage='to open your profile' /></td>
+                <td><kbd>g</kbd>+<kbd>u</kbd></td>
               </tr>
               <tr>
-                <td><kbd>g</kbd>+<kbd>b</kbd></td>
                 <td><FormattedMessage id='keyboard_shortcuts.blocked' defaultMessage='to open blocked users list' /></td>
+                <td><kbd>g</kbd>+<kbd>b</kbd></td>
               </tr>
               <tr>
-                <td><kbd>g</kbd>+<kbd>m</kbd></td>
                 <td><FormattedMessage id='keyboard_shortcuts.muted' defaultMessage='to open muted users list' /></td>
+                <td><kbd>g</kbd>+<kbd>m</kbd></td>
               </tr>
               <tr>
-                <td><kbd>g</kbd>+<kbd>r</kbd></td>
                 <td><FormattedMessage id='keyboard_shortcuts.requests' defaultMessage='to open follow requests list' /></td>
+                <td><kbd>g</kbd>+<kbd>r</kbd></td>
               </tr>
               <tr>
-                <td><kbd>?</kbd></td>
                 <td><FormattedMessage id='keyboard_shortcuts.legend' defaultMessage='to display this legend' /></td>
+                <td><kbd>?</kbd></td>
               </tr>
             </tbody>
           </table>

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -3954,9 +3954,19 @@ $ui-header-logo-wordmark-width: 99px;
   padding: 8px 0 0;
   overflow: hidden;
 
+  table {
+    width: 100%;
+  }
+
   thead {
     position: absolute;
     inset-inline-start: -9999px;
+  }
+
+  tbody {
+    td:last-child {
+      text-align: right;
+    }
   }
 
   td {
@@ -3964,10 +3974,16 @@ $ui-header-logo-wordmark-width: 99px;
   }
 
   kbd {
-    display: inline-block;
-    padding: 3px 5px;
-    background-color: lighten($ui-base-color, 8%);
+    background-color: darken($ui-base-color, 10%);
+    border-radius: 6px;
     border: 1px solid darken($ui-base-color, 4%);
+    box-shadow: inset 0 -1px 0;
+    color: $light-text-color;
+    display: inline-block;
+    font: 11px monospace;
+    margin: 0 2px;
+    padding: 4px 6px;
+    vertical-align: middle;
   }
 }
 


### PR DESCRIPTION
Before:
<img width="622" alt="Screenshot 2024-09-26 at 12 54 16" src="https://github.com/user-attachments/assets/85a8c650-7a08-4be4-bc30-b92d001a856c">

After:
<img width="610" alt="Screenshot 2024-09-26 at 12 54 27" src="https://github.com/user-attachments/assets/c989d67e-67f4-4882-a27e-5f1e59baf64b">

Swap order of elements (label on left, key value on right), make table take up full space, style once over on `kbd`, etc.