### PR TITLE
Use 1 column layout for form `ul` on narrow widths

### DIFF
--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -312,6 +312,10 @@ code {
 
     ul {
       columns: 2;
+
+      @media screen and (max-width: $mobile-breakpoint) {
+        columns: 1;
+      }
     }
   }
 


### PR DESCRIPTION
Currently on narrow widths some of the elements with longer descriptions overlap a bit. This bumps things down to one column when we are below the mobile breakpoint. Look at both the "choose languages" and "allow scopes" forms,  and both seemed improved in my opinion.

Before:

<img width="554" alt="Screenshot 2024-09-26 at 13 28 23" src="https://github.com/user-attachments/assets/857f7802-2f23-4804-8ab6-60a5de6cb858">

After:

<img width="557" alt="Screenshot 2024-09-26 at 13 28 38" src="https://github.com/user-attachments/assets/19f726bb-ea83-4470-b135-35e1cf306186">

I was going to also bump UP to three columns at larger sizes, but that had similar overlap issues on the scopes form. Might need some combination of overflow handling and column changes, so for now - just this change.