### PR TITLE
Wrap webhook event label with `samp` tag

### DIFF
--- a/app/views/admin/webhooks/_form.html.haml
+++ b/app/views/admin/webhooks/_form.html.haml
@@ -13,7 +13,8 @@
                as: :check_boxes,
                collection_wrapper_tag: 'ul',
                item_wrapper_tag: 'li',
-               disabled: Webhook::EVENTS.filter { |event| !current_user.role.can?(Webhook.permission_for_event(event)) }
+               disabled: Webhook::EVENTS.filter { |event| !current_user.role.can?(Webhook.permission_for_event(event)) },
+               label_method: ->(event) { tag.samp(event) }
 
 .fields-group
   = form.input :template,


### PR DESCRIPTION
Puts the webhook event names into `samp` tags, which matches font style from the oauth applicaiton page where the potential "scopes" values are in `samp` as well.

I did a version which also grouped them by type, similar to that other page, but  because there are so few of them it's not as useful. Also thought about adding "hint" values here ... but the names are really self explanatory and I'm not sure how much value basically repeating the event names in a full sentence would be.