### PR TITLE
Clean up labels on development application form

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
-  DANGEROUS_SCOPES = %w(
-    read
-    write
-    follow
-  ).freeze
-
   RTL_LOCALES = %i(
     ar
     ckb
@@ -95,8 +89,11 @@ module ApplicationHelper
     Rails.env.production? ? site_title : "#{site_title} (Dev)"
   end
 
-  def class_for_scope(scope)
-    'scope-danger' if DANGEROUS_SCOPES.include?(scope.to_s)
+  def label_for_scope(scope)
+    safe_join [
+      tag.samp(scope, class: { 'scope-danger' => SessionActivation::DEFAULT_SCOPES.include?(scope.to_s) }),
+      tag.span(t("doorkeeper.scopes.#{scope}"), class: :hint),
+    ]
   end
 
   def can?(action, record)

--- a/app/models/session_activation.rb
+++ b/app/models/session_activation.rb
@@ -28,6 +28,8 @@ class SessionActivation < ApplicationRecord
 
   before_create :assign_access_token
 
+  DEFAULT_SCOPES = %w(read write follow).freeze
+
   class << self
     def active?(id)
       id && exists?(session_id: id)
@@ -64,7 +66,7 @@ class SessionActivation < ApplicationRecord
     {
       application_id: Doorkeeper::Application.find_by(superapp: true)&.id,
       resource_owner_id: user_id,
-      scopes: 'read write follow',
+      scopes: DEFAULT_SCOPES.join(' '),
       expires_in: Doorkeeper.configuration.access_token_expires_in,
       use_refresh_token: Doorkeeper.configuration.refresh_token_enabled?,
     }

--- a/app/views/settings/applications/_form.html.haml
+++ b/app/views/settings/applications/_form.html.haml
@@ -18,7 +18,7 @@
 
 .field-group
   .input.with_block_label
-    %label= t('activerecord.attributes.doorkeeper/application.scopes')
+    = form.label t('activerecord.attributes.doorkeeper/application.scopes'), required: true
     %span.hint= t('simple_form.hints.defaults.scopes')
 
   - Doorkeeper.configuration.scopes.group_by { |s| s.split(':').first }.each_value do |value|
@@ -29,7 +29,7 @@
                  hint: false,
                  include_blank: false,
                  item_wrapper_tag: 'li',
-                 label_method: ->(scope) { safe_join([content_tag(:samp, scope, class: class_for_scope(scope)), content_tag(:span, t("doorkeeper.scopes.#{scope}"), class: 'hint')]) },
+                 label_method: ->(scope) { label_for_scope(scope) },
                  label: false,
                  required: false,
                  selected: form.object.scopes.all,


### PR DESCRIPTION
Some related changes:

- The `DANGEROUS_SCOPES` constant from this helper file matches exactly the scopes we create by default on a `SessionActivation` ... and I think in a way that's not an accident and should stay like that in a stable way? Given that, pull out the string to a constant in the model, and refer to it from the helper method.
- Move the entire "what is the label for this scope" logic to the helper, not just the classes
- Add a `required` to the form label (creates tiny red asterisk on visual form)