### PR TITLE
Use textarea for potentially medium/long note fields

### DIFF
--- a/app/views/admin/domain_blocks/_form.html.haml
+++ b/app/views/admin/domain_blocks/_form.html.haml
@@ -34,13 +34,11 @@
                wrapper: :with_label
 .field-group
   = form.input :private_comment,
-               as: :string,
                hint: t('admin.domain_blocks.private_comment_hint'),
                label: I18n.t('admin.domain_blocks.private_comment'),
                wrapper: :with_label
 .field-group
   = form.input :public_comment,
-               as: :string,
                hint: t('admin.domain_blocks.public_comment_hint'),
                label: I18n.t('admin.domain_blocks.public_comment'),
                wrapper: :with_label

--- a/app/views/admin/ip_blocks/new.html.haml
+++ b/app/views/admin/ip_blocks/new.html.haml
@@ -27,7 +27,6 @@
 
   .fields-group
     = f.input :comment,
-              as: :string,
               wrapper: :with_block_label
 
   .actions

--- a/app/views/admin/relays/new.html.haml
+++ b/app/views/admin/relays/new.html.haml
@@ -5,7 +5,10 @@
   = render 'shared/error_messages', object: @relay
 
   .field-group
-    = f.input :inbox_url, as: :string, wrapper: :with_block_label
+    = f.input :inbox_url,
+              required: true,
+              type: :url,
+              wrapper: :with_block_label
 
   .actions
     = f.button :button, t('admin.relays.save_and_enable'), type: :submit


### PR DESCRIPTION
The domain and ip block comment fields are `text` at db level, and presumably sometimes accept lengthier input?

The relay inbox url is a string at db level, so doesn't need that specified, but is required and now showing as required (I suspect from conditional validation ... may review as followup).