### PR TITLE
Increase length of OTP secret (4.1)

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -64,7 +64,8 @@ class User < ApplicationRecord
   ACTIVE_DURATION = ENV.fetch('USER_ACTIVE_DAYS', 7).to_i.days.freeze
 
   devise :two_factor_authenticatable,
-         otp_secret_encryption_key: Rails.configuration.x.otp_secret
+         otp_secret_encryption_key: Rails.configuration.x.otp_secret,
+         otp_secret_length: 26
 
   devise :two_factor_backupable,
          otp_number_of_backup_codes: 10


### PR DESCRIPTION
Workaround for https://github.com/devise-two-factor/devise-two-factor/security/advisories/GHSA-qjxf-mc72-wjr2