### PR TITLE
Provide `use_path` to qr generator for svg data size reduction

### DIFF
--- a/app/views/settings/two_factor_authentication/confirmations/new.html.haml
+++ b/app/views/settings/two_factor_authentication/confirmations/new.html.haml
@@ -5,7 +5,7 @@
   %p.hint= t('otp_authentication.instructions_html')
 
   .qr-wrapper
-    .qr-code!= @qrcode.as_svg(padding: 0, module_size: 4)
+    .qr-code!= @qrcode.as_svg(padding: 0, module_size: 4, use_path: true)
 
     .qr-alternative
       %p.hint= t('otp_authentication.manual_instructions')

--- a/spec/controllers/settings/two_factor_authentication/confirmations_controller_spec.rb
+++ b/spec/controllers/settings/two_factor_authentication/confirmations_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Settings::TwoFactorAuthentication::ConfirmationsController do
     def qr_code_markup
       RQRCode::QRCode.new(
         'otpauth://totp/cb6e6126.ngrok.io:local-part%40domain?secret=thisisasecretforthespecofnewview&issuer=cb6e6126.ngrok.io'
-      ).as_svg(padding: 0, module_size: 4)
+      ).as_svg(padding: 0, module_size: 4, use_path: true)
     end
   end
 


### PR DESCRIPTION
This will be a default in a future rqrcode release -- reduces size of generated inline svg by using one `path` element instead of many many `rect`, should preserve data in the Quick Response code image itself.