### PR TITLE
Add `no-toolbar` state for "nothing here" batch table views

### DIFF
--- a/app/javascript/styles/mastodon/tables.scss
+++ b/app/javascript/styles/mastodon/tables.scss
@@ -359,6 +359,10 @@ a.table-action-link {
     @media screen and (max-width: $no-gap-breakpoint) {
       border-top: 1px solid var(--background-border-color);
     }
+
+    &--no-toolbar {
+      border-top: 1px solid var(--background-border-color);
+    }
   }
 
   @media screen and (width <= 870px) {

--- a/app/views/admin/tags/index.html.haml
+++ b/app/views/admin/tags/index.html.haml
@@ -32,7 +32,7 @@
 .batch-table
   .batch-table__body
     - if @tags.empty?
-      = nothing_here 'nothing-here--under-tabs'
+      = nothing_here 'nothing-here--under-tabs nothing-here--no-toolbar'
     - else
       = render partial: 'tag', collection: @tags
 


### PR DESCRIPTION
There is a pattern across many of the admin listing views where there's a wrapper `.batch-table` element which has a child `.batch-table__toolbar` to hold the toolbar actions, and a child `.batch-table__body` below that to list the rows of whatever you are viewing.

The admin/tags view does have a "body" section, but no "toolbar" section. As a result, the blank slate state is missing a top border:

<img width="925" alt="Screenshot 2024-09-27 at 10 28 06" src="https://github.com/user-attachments/assets/f808bb01-07af-4412-90c7-59d80519f5c2">

This change adds a class which can handle the no toolbar state by restoring the top border:

<img width="935" alt="Screenshot 2024-09-27 at 10 43 06" src="https://github.com/user-attachments/assets/2062e83f-7c3e-464b-ade0-01d02e671fa0">


I chose this approach because it kept the html structure most similar to other views, and did not involve adding an i18n key.

Another approach would be to change the tags view to do something like the appeals index view does -- remove the `nothing_here` approach, and wrap some `.muted-hint.center-text` with appropriate missing tags text.