### PR TITLE
Mailer layout fixes

### DIFF
--- a/app/javascript/styles/mailer.scss
+++ b/app/javascript/styles/mailer.scss
@@ -524,6 +524,7 @@ table + p {
   height: 40px;
   text-align: center;
   mso-padding-alt: 0 35px;
+  word-break: normal;
 }
 
 .email-btn-a {

--- a/app/javascript/styles/mailer.scss
+++ b/app/javascript/styles/mailer.scss
@@ -366,6 +366,7 @@ table + p {
 
 .email-header-card-banner-td {
   border-radius: 12px 12px 0 0;
+  width: 236px;
   height: 80px;
   background-color: #f3f2f5 !important;
   background-position: center !important;

--- a/app/views/user_mailer/welcome.html.haml
+++ b/app/views/user_mailer/welcome.html.haml
@@ -9,7 +9,7 @@
             %td
               %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
                 %tr
-                  %td.email-header-card-banner-td{ height: 140, background: full_asset_url(instance_presenter.thumbnail&.file&.url(:'@1x') || frontend_asset_path('images/preview.png')) }
+                  %td.email-header-card-banner-td{ background: full_asset_url(instance_presenter.thumbnail&.file&.url(:'@1x') || frontend_asset_path('images/preview.png')) }
               %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
                 %tr
                   %td.email-header-card-body-td


### PR DESCRIPTION
- Specify explicit width to banner in welcome mail to prevent collapsing (fixes a regression introduced by #32073).
- Allow buttons to expand to prevent mid-word wrapping (see screenshots in https://github.com/mastodon/mastodon/pull/32073#issuecomment-2379734322).
- Remove redundant `height=140`. The cell height is overridden in CSS to 80px.
