### PR TITLE
Add `relevant_params` to ReportFilter (matches account filter)

### DIFF
--- a/app/models/report_filter.rb
+++ b/app/models/report_filter.rb
@@ -18,11 +18,23 @@ class ReportFilter
   def results
     scope = Report.unresolved
 
-    params.each do |key, value|
+    relevant_params.each do |key, value|
       scope = scope.merge scope_for(key, value)
     end
 
     scope
+  end
+
+  private
+
+  def relevant_params
+    params.tap do |args|
+      args.delete(:target_origin) if origin_is_remote_and_domain_present?
+    end
+  end
+
+  def origin_is_remote_and_domain_present?
+    params[:target_origin] == 'remote' && params[:by_target_domain].present?
   end
 
   def scope_for(key, value)

--- a/spec/models/report_filter_spec.rb
+++ b/spec/models/report_filter_spec.rb
@@ -30,4 +30,17 @@ RSpec.describe ReportFilter do
       expect(Report).to have_received(:resolved)
     end
   end
+
+  context 'when given remote target_origin and also by_target_domain' do
+    let!(:matching_report) { Fabricate :report, target_account: Fabricate(:account, domain: 'match.example') }
+    let!(:non_matching_report) { Fabricate :report, target_account: Fabricate(:account, domain: 'other.example') }
+
+    it 'preserves the domain value' do
+      filter = described_class.new(by_target_domain: 'match.example', target_origin: 'remote')
+
+      expect(filter.results)
+        .to include(matching_report)
+        .and not_include(non_matching_report)
+    end
+  end
 end


### PR DESCRIPTION
When we use `merge` on the scopes the arel intersection math winds up dropping one of the conditions.

Example to illustrate this - on reports list view in admin area, choose "remote" accounts, and also enter a domain search term. You will see results that show reports from all remote accounts, without applying the domain portion. In the filter builder, I think the "is this remote" gets applied last, and the last condition wins (so it deletes the previous domain condition).

This change is similar to an already existing solution in the account filter.