### PR TITLE
Adjust spacing on setting sub-nav items when below mobile size

### DIFF
--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -226,6 +226,10 @@ $content-width: 840px;
           gap: 5px;
           white-space: nowrap;
 
+          @media screen and (max-width: $mobile-breakpoint) {
+            flex: 1 0 50%;
+          }
+
           &:hover,
           &:focus,
           &:active {


### PR DESCRIPTION
Currently on narrow width:

<img width="493" alt="Screenshot 2024-09-27 at 16 50 33" src="https://github.com/user-attachments/assets/eeefe79f-b2bd-4567-a3c7-34ebc3b39891">

Change adjusts these elements to flex out below mobile breakpoint:

<img width="452" alt="Screenshot 2024-09-27 at 16 50 54" src="https://github.com/user-attachments/assets/b95aff6e-542c-491d-9f31-8fa3575f9a9b">

When above mobile, things stay same (left aligned, no extra spacing). I looked at a variety of sizes here, and I think this is a net improvement, though you can still find sort of wonky layouts (esp given diff number of elements on account profile vs admin site settings, for example). If anyone ever does a more exhaustive responsive overhaul, and/or adds more breakpoints, and/or adjusts current breakpoints, etc ... this would be good to review again.