### PR TITLE
Fix broken border on applications list

### DIFF
--- a/app/views/settings/applications/index.html.haml
+++ b/app/views/settings/applications/index.html.haml
@@ -20,7 +20,7 @@
             %td= link_to application.name, settings_application_path(application)
             %th
               - application.scopes.to_s.split.each do |scope|
-                = tag.samp(scope, class: 'information-badge')
+                = tag.samp(scope, class: 'information-badge', title: t("doorkeeper.scopes.#{scope}"))
             %td
               = table_link_to 'close', t('doorkeeper.applications.index.delete'), settings_application_path(application), method: :delete, data: { confirm: t('doorkeeper.applications.confirmations.destroy') }
 

--- a/app/views/settings/applications/index.html.haml
+++ b/app/views/settings/applications/index.html.haml
@@ -18,7 +18,9 @@
         - @applications.each do |application|
           %tr
             %td= link_to application.name, settings_application_path(application)
-            %th= application.scopes
+            %th
+              - application.scopes.to_s.split.each do |scope|
+                = tag.samp(scope, class: 'information-badge')
             %td
               = table_link_to 'close', t('doorkeeper.applications.index.delete'), settings_application_path(application), method: :delete, data: { confirm: t('doorkeeper.applications.confirmations.destroy') }
 

--- a/app/views/settings/applications/show.html.haml
+++ b/app/views/settings/applications/show.html.haml
@@ -15,10 +15,11 @@
         %td
           %code= @application.secret
       %tr
-        %th{ rowspan: 2 }= t('applications.your_token')
+        %th= t('applications.your_token')
         %td
           %code= current_user.token_for_app(@application).token
       %tr
+        %th
         %td= table_link_to 'refresh', t('applications.regenerate_token'), regenerate_settings_application_path(@application), method: :post
 
 %hr/


### PR DESCRIPTION
As side effect of this PR - https://github.com/mastodon/mastodon/pull/31034 - we remove bottom border from the last row in tables. This is usually fine, but in this applications listing spot we have a `th` with `rowspan=2` and it makes the border uneven across table bottom:

<img width="860" alt="Screenshot 2024-09-28 at 14 51 13" src="https://github.com/user-attachments/assets/d0aa2e66-1a67-4b28-bab9-ee9fde011dc3">

Fix here is to just remove that rowspan approach in favor of an empty th instead:

<img width="792" alt="Screenshot 2024-09-28 at 14 56 16" src="https://github.com/user-attachments/assets/b71edc35-7ead-4584-9b35-e43af5e91b5f">

Not sure if this is ideal markup, but it makes the border look less broken. Might be worth looking for other rowspan pages and see if same issue exists.

Separately, on the listing page, style change to wrap the granted scopes with `samp` and put them in info badge - also added the hint text for each one as a `title` attribute for hover/hint:

<img width="917" alt="Screenshot 2024-09-28 at 15 00 08" src="https://github.com/user-attachments/assets/2f2f790e-316e-45b2-8889-d22f488d1d77">

<img width="893" alt="Screenshot 2024-09-28 at 14 47 56" src="https://github.com/user-attachments/assets/ddd047d9-b637-457c-bcfd-852ad2f9d1d3">

