### PR TITLE
Right align text in last child `td` elements

### DIFF
--- a/app/javascript/styles/mastodon/tables.scss
+++ b/app/javascript/styles/mastodon/tables.scss
@@ -17,6 +17,10 @@
       font-weight: 700;
       color: $gold-star;
     }
+
+    &:last-child {
+      text-align: end;
+    }
   }
 
   & > thead > tr > th {


### PR DESCRIPTION
A few befores...

<img width="895" alt="Screenshot 2024-09-28 at 15 07 29" src="https://github.com/user-attachments/assets/e2af9f55-4b61-4fc7-9e9e-1879dd280791">
<img width="923" alt="Screenshot 2024-09-28 at 15 07 34" src="https://github.com/user-attachments/assets/61f073ed-c8f7-4b09-b07e-a9e5cc74a5c2">
<img width="927" alt="Screenshot 2024-09-28 at 15 07 39" src="https://github.com/user-attachments/assets/e298b2f6-6645-425a-a686-491ff977f240">

After:

<img width="892" alt="Screenshot 2024-09-28 at 15 09 15" src="https://github.com/user-attachments/assets/cc988fdd-c87a-4bb7-af83-ad943955aef6">
<img width="847" alt="Screenshot 2024-09-28 at 15 09 20" src="https://github.com/user-attachments/assets/47379a84-08ad-4890-8679-13d00a49abad">
<img width="854" alt="Screenshot 2024-09-28 at 15 09 24" src="https://github.com/user-attachments/assets/3926636d-c74b-4494-ae9f-39c5764b991b">
