### PR TITLE
Only include asset blocks when present on branding page

### DIFF
--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -388,6 +388,10 @@ code {
 
       &-6 {
         max-width: 50%;
+
+        &:only-child {
+          max-width: 100%;
+        }
       }
 
       .actions {

--- a/app/views/admin/settings/branding/show.html.haml
+++ b/app/views/admin/settings/branding/show.html.haml
@@ -33,8 +33,8 @@
       = f.input :thumbnail,
                 as: :file,
                 wrapper: :with_block_label
-    .fields-row__column.fields-row__column-6.fields-group
-      - if @admin_settings.thumbnail.persisted?
+    - if @admin_settings.thumbnail.persisted?
+      .fields-row__column.fields-row__column-6.fields-group
         = image_tag @admin_settings.thumbnail.file.url(:'@1x'), class: 'fields-group__thumbnail'
         = link_to admin_site_upload_path(@admin_settings.thumbnail), data: { method: :delete }, class: 'link-button link-button--destructive' do
           = material_symbol 'delete'
@@ -47,8 +47,8 @@
                 input_html: { accept: ['image/jpeg', 'image/png', 'image/gif', 'image/webp'].join(',') },
                 wrapper: :with_block_label
 
-    .fields-row__column.fields-row__column-6.fields-group
-      - if @admin_settings.favicon.persisted?
+    - if @admin_settings.favicon.persisted?
+      .fields-row__column.fields-row__column-6.fields-group
         = image_tag @admin_settings.favicon.file.url('48'), class: 'fields-group__thumbnail'
         = link_to admin_site_upload_path(@admin_settings.favicon), data: { method: :delete }, class: 'link-button link-button--destructive' do
           = material_symbol 'delete'
@@ -61,8 +61,8 @@
                 input_html: { accept: ['image/jpeg', 'image/png', 'image/gif', 'image/webp'].join(',') },
                 wrapper: :with_block_label
 
-    .fields-row__column.fields-row__column-6.fields-group
-      - if @admin_settings.app_icon.persisted?
+    - if @admin_settings.app_icon.persisted?
+      .fields-row__column.fields-row__column-6.fields-group
         = image_tag @admin_settings.app_icon.file.url('48'), class: 'fields-group__thumbnail'
         = link_to admin_site_upload_path(@admin_settings.app_icon), data: { method: :delete }, class: 'link-button link-button--destructive' do
           = material_symbol 'delete'


### PR DESCRIPTION
Currently we have a grid display with these elements where each take 50%, but when the value has not been set that just means we are putting out an empty element on the right half. This changes the view to only output that section if there is a relevant  asset to display, and updates the style to allow the element to grow when its the only child.

This would be relevant to the user profile page (avatar/header) as well, but the logic in the view there is a little different w/ the preview values. Will do that separately.

Before:
<img width="942" alt="Screenshot 2024-09-28 at 15 13 06" src="https://github.com/user-attachments/assets/c006d373-5544-4d10-a7f9-cc23c41c6094">

After:
<img width="890" alt="Screenshot 2024-09-28 at 15 13 21" src="https://github.com/user-attachments/assets/3c1e8417-263a-4aee-905b-f71004402757">
