### PR TITLE
Extract constants for header and avatar geometry

### DIFF
--- a/app/models/concerns/account/avatar.rb
+++ b/app/models/concerns/account/avatar.rb
@@ -6,10 +6,13 @@ module Account::Avatar
   IMAGE_MIME_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'].freeze
   LIMIT = 2.megabytes
 
+  AVATAR_DIMENSIONS = [400, 400].freeze
+  AVATAR_GEOMETRY = [AVATAR_DIMENSIONS.first, AVATAR_DIMENSIONS.last].join('x')
+
   class_methods do
     def avatar_styles(file)
-      styles = { original: { geometry: '400x400#', file_geometry_parser: FastGeometryParser } }
-      styles[:static] = { geometry: '400x400#', format: 'png', convert_options: '-coalesce', file_geometry_parser: FastGeometryParser } if file.content_type == 'image/gif'
+      styles = { original: { geometry: "#{AVATAR_GEOMETRY}#", file_geometry_parser: FastGeometryParser } }
+      styles[:static] = { geometry: "#{AVATAR_GEOMETRY}#", format: 'png', convert_options: '-coalesce', file_geometry_parser: FastGeometryParser } if file.content_type == 'image/gif'
       styles
     end
 

--- a/app/models/concerns/account/header.rb
+++ b/app/models/concerns/account/header.rb
@@ -5,7 +5,10 @@ module Account::Header
 
   IMAGE_MIME_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'].freeze
   LIMIT = 2.megabytes
-  MAX_PIXELS = 750_000 # 1500x500px
+
+  HEADER_DIMENSIONS = [1500, 500].freeze
+  HEADER_GEOMETRY = [HEADER_DIMENSIONS.first, HEADER_DIMENSIONS.last].join('x')
+  MAX_PIXELS = HEADER_DIMENSIONS.first * HEADER_DIMENSIONS.last
 
   class_methods do
     def header_styles(file)

--- a/app/views/settings/profiles/show.html.haml
+++ b/app/views/settings/profiles/show.html.haml
@@ -34,7 +34,7 @@
     .fields-row__column.fields-row__column-6
       .fields-group
         = f.input :avatar,
-                  hint: t('simple_form.hints.defaults.avatar', dimensions: '400x400', size: number_to_human_size(Account::Avatar::LIMIT)),
+                  hint: t('simple_form.hints.defaults.avatar', dimensions: Account::Avatar::AVATAR_GEOMETRY, size: number_to_human_size(Account::Avatar::LIMIT)),
                   input_html: { accept: Account::Avatar::IMAGE_MIME_TYPES.join(',') },
                   wrapper: :with_block_label
 
@@ -50,7 +50,7 @@
     .fields-row__column.fields-row__column-6
       .fields-group
         = f.input :header,
-                  hint: t('simple_form.hints.defaults.header', dimensions: '1500x500', size: number_to_human_size(Account::Header::LIMIT)),
+                  hint: t('simple_form.hints.defaults.header', dimensions: Account::Header::HEADER_GEOMETRY, size: number_to_human_size(Account::Header::LIMIT)),
                   input_html: { accept: Account::Header::IMAGE_MIME_TYPES.join(',') },
                   wrapper: :with_block_label
 


### PR DESCRIPTION
Connects the hard-coded values on the view form back to something in the model.

Believe this preserves the conversion options.

Side note here - both of these concerns are included into `Account`, and they have existing same-named constants - might be worth reviewing if that's acting like we want it to.