### PR TITLE
Adjust alignment of "recommended" form badges

### DIFF
--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -112,6 +112,12 @@ code {
         color: $primary-text-color;
         display: block;
         width: auto;
+
+        &.boolean {
+          width: 100%;
+          display: flex;
+          justify-content: space-between;
+        }
       }
 
       .label_input,
@@ -143,7 +149,6 @@ code {
       .overridden,
       .recommended,
       .not_recommended {
-        position: absolute;
         margin: 0 4px;
         margin-top: -2px;
       }

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -15,7 +15,7 @@ module RecommendedComponent
     return unless options[:recommended]
 
     key = options[:recommended].is_a?(Symbol) ? options[:recommended] : :recommended
-    options[:label_text] = ->(raw_label_text, _required_label_text, _label_present) { safe_join([raw_label_text, ' ', content_tag(:span, I18n.t(key, scope: 'simple_form'), class: key)]) }
+    options[:label_text] = ->(raw_label_text, _required_label_text, _label_present) { safe_join([tag.span(raw_label_text), tag.span(I18n.t(key, scope: 'simple_form'), class: key)]) }
 
     nil
   end


### PR DESCRIPTION
Removes an absolute positioning, updates the builder to wrap the label text and additional value in separate span, and then lets the elements flex.

Good follow-up here would be some responsive tweaking at very narrow widths to have it collapse better, or just disappear.

Before

<img width="607" alt="Screenshot 2024-09-28 at 16 29 59" src="https://github.com/user-attachments/assets/d3e249ca-11b5-4732-8c8f-d8ecd950b4ed">

After

<img width="600" alt="Screenshot 2024-09-28 at 16 28 47" src="https://github.com/user-attachments/assets/9bfecd31-c90d-4788-80c0-76f465ef587c">
