### PR TITLE
Improve alignment of icons on admin roles list

### DIFF
--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -1054,6 +1054,10 @@ a.name-tag,
       }
     }
 
+    .icon {
+      padding-top: 5px;
+    }
+
     a.announcements-list__item__title {
       &:hover,
       &:focus,

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -1055,7 +1055,7 @@ a.name-tag,
     }
 
     .icon {
-      padding-top: 5px;
+      vertical-align: middle;
     }
 
     a.announcements-list__item__title {

--- a/app/javascript/styles/mastodon/tables.scss
+++ b/app/javascript/styles/mastodon/tables.scss
@@ -137,6 +137,7 @@ a.table-action-link {
   padding: 0 10px;
   color: $darker-text-color;
   font-weight: 500;
+  white-space: nowrap;
 
   &:hover {
     color: $highlight-text-color;


### PR DESCRIPTION
Before

<img width="330" alt="Screenshot 2024-09-28 at 17 19 24" src="https://github.com/user-attachments/assets/e10a6268-31c7-4352-a36c-3bd3137c18df">

After

<img width="319" alt="Screenshot 2024-09-28 at 17 19 33" src="https://github.com/user-attachments/assets/eca4db0a-4d87-4867-8a77-5c1c5a2dfcca">

The other change keeps the icons with their text, eg...

Before

<img width="592" alt="Screenshot 2024-09-28 at 17 29 23" src="https://github.com/user-attachments/assets/ab17488b-495c-4c64-8dd8-5d5c335e5e89">

After

<img width="591" alt="Screenshot 2024-09-28 at 17 29 34" src="https://github.com/user-attachments/assets/ad59ebf0-1273-4bea-9ecf-49b218510b3d">

Good followup here would be to better align those as well.