### PR TITLE
Use `button_to` for `method: :post` links on account show page

### DIFF
--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -19,6 +19,10 @@ code {
   margin-bottom: 24px;
 }
 
+form.button_to {
+  display: inline-block;
+}
+
 .fade-out-top {
   position: relative;
   overflow: hidden;

--- a/app/views/admin/accounts/_buttons.html.haml
+++ b/app/views/admin/accounts/_buttons.html.haml
@@ -4,8 +4,8 @@
     %p.muted-hint= deletion_request.present? ? t('admin.accounts.remote_suspension_reversible_hint_html', date: content_tag(:strong, l(deletion_request.due_at.to_date))) : t('admin.accounts.remote_suspension_irreversible')
   - else
     %p.muted-hint= deletion_request.present? ? t('admin.accounts.suspension_reversible_hint_html', date: content_tag(:strong, l(deletion_request.due_at.to_date))) : t('admin.accounts.suspension_irreversible')
-  = link_to t('admin.accounts.undo_suspension'), unsuspend_admin_account_path(account.id), method: :post, class: 'button' if can?(:unsuspend, account)
-  = link_to t('admin.accounts.redownload'), redownload_admin_account_path(account.id), method: :post, class: 'button' if can?(:redownload, account) && account.suspension_origin_remote?
+  = button_to t('admin.accounts.undo_suspension'), unsuspend_admin_account_path(account.id), class: :button if can?(:unsuspend, account)
+  = button_to t('admin.accounts.redownload'), redownload_admin_account_path(account.id), class: :button if can?(:redownload, account) && account.suspension_origin_remote?
   - if deletion_request.present? && can?(:destroy, account)
     = link_to t('admin.accounts.delete'), admin_account_path(account.id), method: :delete, class: 'button button--destructive', data: { confirm: t('admin.accounts.are_you_sure') }
 - else
@@ -14,28 +14,28 @@
       - if account.local? && account.user_approved?
         = link_to t('admin.accounts.warn'), new_admin_account_action_path(account.id, type: 'none'), class: 'button' if can?(:warn, account)
         - if account.user_disabled?
-          = link_to t('admin.accounts.enable'), enable_admin_account_path(account.id), method: :post, class: 'button' if can?(:enable, account.user)
+          = button_to t('admin.accounts.enable'), enable_admin_account_path(account.id), class: :button if can?(:enable, account.user)
         - elsif can?(:disable, account.user)
           = link_to t('admin.accounts.disable'), new_admin_account_action_path(account.id, type: 'disable'), class: 'button'
       - if account.sensitized?
-        = link_to t('admin.accounts.undo_sensitized'), unsensitive_admin_account_path(account.id), method: :post, class: 'button' if can?(:unsensitive, account)
+        = button_to t('admin.accounts.undo_sensitized'), unsensitive_admin_account_path(account.id), class: :button if can?(:unsensitive, account)
       - elsif !account.local? || account.user_approved?
         = link_to t('admin.accounts.sensitive'), new_admin_account_action_path(account.id, type: 'sensitive'), class: 'button' if can?(:sensitive, account)
       - if account.silenced?
-        = link_to t('admin.accounts.undo_silenced'), unsilence_admin_account_path(account.id), method: :post, class: 'button' if can?(:unsilence, account)
+        = button_to t('admin.accounts.undo_silenced'), unsilence_admin_account_path(account.id), class: :button if can?(:unsilence, account)
       - elsif !account.local? || account.user_approved?
         = link_to t('admin.accounts.silence'), new_admin_account_action_path(account.id, type: 'silence'), class: 'button' if can?(:silence, account)
       - if account.local?
         - if account.user_pending?
-          = link_to t('admin.accounts.approve'), approve_admin_account_path(account.id), method: :post, data: { confirm: t('admin.accounts.are_you_sure') }, class: 'button' if can?(:approve, account.user)
-          = link_to t('admin.accounts.reject'), reject_admin_account_path(account.id), method: :post, data: { confirm: t('admin.accounts.are_you_sure') }, class: 'button button--destructive' if can?(:reject, account.user)
+          = button_to t('admin.accounts.approve'), approve_admin_account_path(account.id), data: { confirm: t('admin.accounts.are_you_sure') }, class: :button if can?(:approve, account.user)
+          = button_to t('admin.accounts.reject'), reject_admin_account_path(account.id), data: { confirm: t('admin.accounts.are_you_sure') }, class: 'button button--destructive' if can?(:reject, account.user)
         - if !account.user_confirmed? && can?(:confirm, account.user)
-          = link_to t('admin.accounts.confirm'), admin_account_confirmation_path(account.id), method: :post, class: 'button'
+          = button_to t('admin.accounts.confirm'), admin_account_confirmation_path(account.id), class: :button
       - if (!account.local? || account.user_approved?) && can?(:suspend, account)
         = link_to t('admin.accounts.perform_full_suspension'), new_admin_account_action_path(account.id, type: 'suspend'), class: 'button'
     %div
       - if account.local?
         - if !account.memorial? && account.user_approved? && can?(:memorialize, account)
-          = link_to t('admin.accounts.memorialize'), memorialize_admin_account_path(account.id), method: :post, data: { confirm: t('admin.accounts.are_you_sure') }, class: 'button button--destructive'
+          = button_to t('admin.accounts.memorialize'), memorialize_admin_account_path(account.id), data: { confirm: t('admin.accounts.are_you_sure') }, class: 'button button--destructive'
       - elsif can?(:redownload, account)
-        = link_to t('admin.accounts.redownload'), redownload_admin_account_path(account.id), method: :post, class: 'button'
+        = button_to t('admin.accounts.redownload'), redownload_admin_account_path(account.id), class: :button


### PR DESCRIPTION
This is both a slight shortening up of code (the button_to automatically gets us the `method: :post`), and also a step on the "lets try to remove rails ujs" path.

The buttons already have `button` class to keep them styled the same, and making the wrapping form inline-block seemed to be all that was needed layout wise.

Example, this "After" looks visually same to me as the before:

<img width="864" alt="Screenshot 2024-09-28 at 18 29 50" src="https://github.com/user-attachments/assets/5ad3831c-b72e-44d9-a838-5d3a4307fc0f">

There are more of these in admin area, but just starting with this one to get thumbs up on the idea. Can add more here or followup if approved.

Separately, this partial in particular is super super dense and hard to reason through all the scenarios -- could benefit from either/both of a) getting rid of all the trailing conditional guard clause `can`, b) in some spots, even more partials for the high level logic.