### PR TITLE
Only show email domain blocks MX table when some found

### DIFF
--- a/app/views/admin/email_domain_blocks/new.html.haml
+++ b/app/views/admin/email_domain_blocks/new.html.haml
@@ -16,7 +16,7 @@
               label: I18n.t('admin.email_domain_blocks.allow_registrations_with_approval'),
               wrapper: :with_label
 
-  - if defined?(@resolved_records)
+  - if defined?(@resolved_records) && @resolved_records.any?
     %p.hint= t('admin.email_domain_blocks.resolved_dns_records_hint_html')
 
     .batch-table


### PR DESCRIPTION
This form submits once with the domain and does lookups, and then renders new again the second time.

The view uses this ivar to determine what step we're on, but there's a case where the ivar is SET (we just did a lookup), but the contents of it are an empty array.

Normal domain:

<img width="943" alt="Screenshot 2024-09-28 at 18 39 21" src="https://github.com/user-attachments/assets/7f8fe059-9ae2-4ee8-b09f-d131e5804568">

Empty results:

<img width="937" alt="Screenshot 2024-09-28 at 18 39 34" src="https://github.com/user-attachments/assets/287af13a-3174-406e-ae68-86524ea76ee5">

After change:

<img width="813" alt="Screenshot 2024-09-28 at 18 46 33" src="https://github.com/user-attachments/assets/53e8ca84-046f-45ae-be09-15eaecdaefa4">

Possible followup - add a blank slate i18n value and show that instead.