### PR TITLE
Extract constant for backup frequency limit in policy

### DIFF
--- a/app/policies/backup_policy.rb
+++ b/app/policies/backup_policy.rb
@@ -1,9 +1,17 @@
 # frozen_string_literal: true
 
 class BackupPolicy < ApplicationPolicy
-  MIN_AGE = 6.days
+  REQUEST_LIMIT = 7.days
 
   def create?
-    user_signed_in? && current_user.backups.where(created_at: MIN_AGE.ago..).count.zero?
+    user_signed_in? && user_backups_after_limit.count.zero?
+  end
+
+  private
+
+  def user_backups_after_limit
+    current_user
+      .backups
+      .where(created_at: REQUEST_LIMIT.ago..)
   end
 end


### PR DESCRIPTION
Reference the policy value from the view.

SIde note here ... I guess "every 7 days" is up for interpretation a bit as to what exact previous datetime window we should look at, but there's a small disconnect between the policy class and the hard-coded view number (again, depending how you interpret it). I've chosen to preserve the previous query logic, which was 6 days, while changing  the constant to keep the view output the same. If the query should change to use 7, I can remove the "minus one" portion there.

For the locale file handling here ... for most of the languages there was an obvious thing to replace. For a few, there was no sensible place to put it and I have no personal ability to understand the existing text, so I just randomly put an attribute in there with the count ... which is both not useful, but also made the i18n interpolation check pass. Better ideas welcome.