### PR TITLE
Use `rtl` direction on copyable invite links

### DIFF
--- a/app/views/admin/invites/_invite.html.haml
+++ b/app/views/admin/invites/_invite.html.haml
@@ -2,7 +2,7 @@
   %td
     .input-copy
       .input-copy__wrapper
-        = copyable_input value: public_invite_url(invite_code: invite.code)
+        = copyable_input value: public_invite_url(invite_code: invite.code), dir: :rtl
       %button{ type: :button }= t('generic.copy')
 
   %td

--- a/app/views/invites/_invite.html.haml
+++ b/app/views/invites/_invite.html.haml
@@ -2,7 +2,7 @@
   %td
     .input-copy
       .input-copy__wrapper
-        = copyable_input value: public_invite_url(invite_code: invite.code)
+        = copyable_input value: public_invite_url(invite_code: invite.code), dir: :rtl
       %button{ type: :button }= t('generic.copy')
 
   - if invite.valid_for_use?


### PR DESCRIPTION
These input fields are not editable, and are meant to show a preview of the invite URL before being copied to clipboard. The more "interesting" portion of the URL is the code at the very end, and at narrower sizes that gets collapsed/hidden away.

Switch to `rtl` direction keeps that part visible more at narrow width.

Before

<img width="598" alt="Screenshot 2024-09-29 at 13 27 35" src="https://github.com/user-attachments/assets/99b4201d-8de8-4ea4-bd72-d1a2a1d61841">

After

<img width="596" alt="Screenshot 2024-09-29 at 13 28 15" src="https://github.com/user-attachments/assets/c27eb08a-4405-46d4-b1ba-3a8a0b104f50">

Side note - might be worth exposing "does this make invitees follow you" option exposed on the list view?

If https://github.com/mastodon/mastodon/pull/32119 merges they'll need to be reconciled w/ each other.