### PR TITLE
Remove regexp timeout feature

### DIFF
--- a/config/initializers/regexp.rb
+++ b/config/initializers/regexp.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-# 2s is a fairly high default, but that should account for slow servers under load
-Regexp.timeout = ENV.fetch('REGEXP_TIMEOUT', 2).to_f if Regexp.respond_to?(:timeout=)


### PR DESCRIPTION
Back in beta.2, we added a regexp timeout to catch slow regexps. However, it seems to trigger for unrelated reasons (busy CPU, possibly threading and global interpreter lock-related reasons) on trivial regexps throughout the codebase, introducing new failure modes (see https://github.com/mastodon/mastodon/issues/32051)

This PR removes the regexp timeout feature altogether.