### PR TITLE
Support translation branches in Crowdin

### DIFF
--- a/.github/workflows/crowdin-download-stable.yml
+++ b/.github/workflows/crowdin-download-stable.yml
@@ -1,7 +1,5 @@
-name: Crowdin / Download translations
+name: Crowdin / Download translations (stable branches)
 on:
-  schedule:
-    - cron: '17 4 * * *' # Every day
   workflow_dispatch:
 
 permissions:
@@ -9,7 +7,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  download-translations:
+  download-translations-stable:
     runs-on: ubuntu-latest
     if: github.repository == 'mastodon/mastodon'
 
@@ -31,7 +29,7 @@ jobs:
           upload_sources: false
           upload_translations: false
           download_translations: true
-          crowdin_branch_name: main
+          crowdin_branch_name: ${{ github.base_ref || github.ref_name }}
           push_translations: false
           create_pull_request: false
         env:
@@ -55,7 +53,7 @@ jobs:
         uses: peter-evans/create-pull-request@v7.0.1
         with:
           commit-message: 'New Crowdin translations'
-          title: 'New Crowdin Translations (automated)'
+          title: 'New Crowdin Translations for ${{ github.base_ref || github.ref_name }} (automated)'
           author: 'GitHub Actions <noreply@github.com>'
           body: |
             New Crowdin translations, automated with GitHub Actions
@@ -66,6 +64,6 @@ jobs:
 
             Due to a limitation in GitHub Actions, checks are not running on this PR without manual action.
             If you want to run the checks, then close and re-open it.
-          branch: i18n/crowdin/translations
-          base: main
+          branch: i18n/crowdin/translations-${{ github.base_ref || github.ref_name }}
+          base: ${{ github.base_ref || github.ref_name }}
           labels: i18n

--- a/.github/workflows/crowdin-download.yml
+++ b/.github/workflows/crowdin-download.yml
@@ -69,3 +69,64 @@ jobs:
           branch: i18n/crowdin/translations
           base: main
           labels: i18n
+
+  download-translations-4.2:
+    runs-on: ubuntu-latest
+    if: github.repository == 'mastodon/mastodon'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Increase Git http.postBuffer
+        # This is needed due to a bug in Ubuntu's cURL version?
+        # See https://github.com/orgs/community/discussions/55820
+        run: |
+          git config --global http.version HTTP/1.1
+          git config --global http.postBuffer 157286400
+
+      # Download the translation files from Crowdin
+      - name: crowdin action
+        uses: crowdin/github-action@v2
+        with:
+          upload_sources: false
+          upload_translations: false
+          download_translations: true
+          crowdin_branch_name: stable-4.2
+          push_translations: false
+          create_pull_request: false
+        env:
+          CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+
+      # As the files are extracted from a Docker container, they belong to root:root
+      # We need to fix this before the next steps
+      - name: Fix file permissions
+        run: sudo chown -R runner:docker .
+
+      # This is needed to run the normalize step
+      - name: Set up Ruby environment
+        uses: ./.github/actions/setup-ruby
+
+      - name: Run i18n normalize task
+        run: bundle exec i18n-tasks normalize
+
+      # Create or update the pull request
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7.0.1
+        with:
+          commit-message: 'New Crowdin translations'
+          title: 'New Crowdin Translations (automated)'
+          author: 'GitHub Actions <noreply@github.com>'
+          body: |
+            New Crowdin translations, automated with GitHub Actions
+
+            See `.github/workflows/crowdin-download.yml`
+
+            This PR will be updated every day with new translations.
+
+            Due to a limitation in GitHub Actions, checks are not running on this PR without manual action.
+            If you want to run the checks, then close and re-open it.
+          branch: i18n/crowdin/translations-4.2
+          base: stable-4.2
+          labels: i18n

--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'stable-*'
     paths:
       - crowdin.yml
       - app/javascript/mastodon/locales/en.json
@@ -30,7 +31,7 @@ jobs:
           upload_sources: true
           upload_translations: false
           download_translations: false
-          crowdin_branch_name: main
+          crowdin_branch_name: ${{ github.base_ref || github.ref_name }}
 
         env:
           CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}

--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - 'main'
-      - 'stable-*'
     paths:
       - crowdin.yml
       - app/javascript/mastodon/locales/en.json


### PR DESCRIPTION
I believe this is how downloading translation strings from multiple branches should work with Crowdin.

I have created the branch in Crowdin, but we still need to populate it, and that should probably be done in a variant of our `crowdin-upload` workflow.

The crowdin-download workflow could use a refactor.