### PR TITLE
Remove explicit `put` action in prefs forms

### DIFF
--- a/app/views/settings/preferences/appearance/show.html.haml
+++ b/app/views/settings/preferences/appearance/show.html.haml
@@ -4,7 +4,7 @@
 - content_for :heading_actions do
   = button_tag t('generic.save_changes'), class: 'button', form: 'edit_user'
 
-= simple_form_for current_user, url: settings_preferences_appearance_path, html: { method: :put, id: 'edit_user' } do |f|
+= simple_form_for current_user, url: settings_preferences_appearance_path, html: { id: :edit_user } do |f|
   .fields-row
     .fields-group.fields-row__column.fields-row__column-6
       = f.input :locale,

--- a/app/views/settings/preferences/notifications/show.html.haml
+++ b/app/views/settings/preferences/notifications/show.html.haml
@@ -4,7 +4,7 @@
 - content_for :heading_actions do
   = button_tag t('generic.save_changes'), class: 'button', form: 'edit_notification'
 
-= simple_form_for current_user, url: settings_preferences_notifications_path, html: { method: :put, id: 'edit_notification' } do |f|
+= simple_form_for current_user, url: settings_preferences_notifications_path, html: { id: :edit_notification } do |f|
   = render 'shared/error_messages', object: current_user
 
   %h4= t 'notifications.email_events'

--- a/app/views/settings/preferences/other/show.html.haml
+++ b/app/views/settings/preferences/other/show.html.haml
@@ -4,7 +4,7 @@
 - content_for :heading_actions do
   = button_tag t('generic.save_changes'), class: 'button', form: 'edit_preferences'
 
-= simple_form_for current_user, url: settings_preferences_other_path, html: { method: :put, id: 'edit_preferences' } do |f|
+= simple_form_for current_user, url: settings_preferences_other_path, html: { id: :edit_preferences } do |f|
   = render 'shared/error_messages', object: current_user
 
   = f.simple_fields_for :settings, current_user.settings do |ff|


### PR DESCRIPTION
These all infer the correct method from the saved object passed in.