### PR TITLE
Move admin action log type list generation to helper

### DIFF
--- a/app/helpers/admin/action_logs_helper.rb
+++ b/app/helpers/admin/action_logs_helper.rb
@@ -40,5 +40,6 @@ module Admin::ActionLogsHelper
     Admin::ActionLogFilter::ACTION_TYPE_MAP
       .keys
       .map { |key| [I18n.t("admin.action_logs.action_types.#{key}"), key] }
+      .sort_by(&:first)
   end
 end

--- a/app/helpers/admin/action_logs_helper.rb
+++ b/app/helpers/admin/action_logs_helper.rb
@@ -35,4 +35,10 @@ module Admin::ActionLogsHelper
       end
     end
   end
+
+  def sorted_action_log_types
+    Admin::ActionLogFilter::ACTION_TYPE_MAP
+      .keys
+      .map { |key| [I18n.t("admin.action_logs.action_types.#{key}"), key] }
+  end
 end

--- a/app/views/admin/action_logs/index.html.haml
+++ b/app/views/admin/action_logs/index.html.haml
@@ -16,7 +16,7 @@
       %strong= t('admin.action_logs.filter_by_action')
       .input.select.optional
         = form.select :action_type,
-                      options_for_select(Admin::ActionLogFilter::ACTION_TYPE_MAP.keys.map { |key| [I18n.t("admin.action_logs.action_types.#{key}"), key] }, params[:action_type]),
+                      options_for_select(sorted_action_log_types, params[:action_type]),
                       prompt: I18n.t('admin.accounts.moderation.all')
 
 - if @action_logs.empty?


### PR DESCRIPTION
This PR is just the method extraction, but thoughts on some/any of:

- Sort this list alphabetically by target_type first, then by action?
- Sort that way, but then also do a group by (model type) and used a grouped select in the view?

The long/large list here is somewhat hard to parse in the dropdown.