### PR TITLE
Avoid `id` duplication conflict with main navigation from settings profile link

### DIFF
--- a/app/views/settings/shared/_profile_navigation.html.haml
+++ b/app/views/settings/shared/_profile_navigation.html.haml
@@ -1,7 +1,7 @@
 .content__heading__tabs
   = render_navigation renderer: :links do |primary|
     :ruby
-      primary.item :profile, safe_join([material_symbol('person'), t('settings.edit_profile')]), settings_profile_path
-      primary.item :privacy, safe_join([material_symbol('lock'), t('privacy.title')]), settings_privacy_path
+      primary.item :edit_profile, safe_join([material_symbol('person'), t('settings.edit_profile')]), settings_profile_path
+      primary.item :privacy_reach, safe_join([material_symbol('lock'), t('privacy.title')]), settings_privacy_path
       primary.item :verification, safe_join([material_symbol('check'), t('verification.verification')]), settings_verification_path
       primary.item :featured_tags, safe_join([material_symbol('tag'), t('settings.featured_tags')]), settings_featured_tags_path

--- a/config/navigation.rb
+++ b/config/navigation.rb
@@ -35,7 +35,7 @@ SimpleNavigation::Configuration.run do |navigation|
       s.item :export, safe_join([material_symbol('cloud_download'), t('settings.export')]), settings_export_path
     end
 
-    n.item :invites, safe_join([material_symbol('person_add'), t('invites.title')]), invites_path, if: -> { current_user.can?(:invite_users) && current_user.functional? && !self_destruct }
+    n.item :user_invites, safe_join([material_symbol('person_add'), t('invites.title')]), invites_path, if: -> { current_user.can?(:invite_users) && current_user.functional? && !self_destruct }
     n.item :development, safe_join([material_symbol('code'), t('settings.development')]), settings_applications_path, highlights_on: %r{/settings/applications}, if: -> { current_user.functional? && !self_destruct }
 
     n.item :trends, safe_join([material_symbol('trending_up'), t('admin.trends.title')]), admin_trends_statuses_path, if: -> { current_user.can?(:manage_taxonomies) && !self_destruct } do |s|


### PR DESCRIPTION
There is a link with `#profile` id in the main side nav, and then it's used again in the top area nav on the settings pages. According to the wisdom of the ancients, this is bad. Update to use alt IDs ... I think these are never referenced for style or js hook purposes, so seems safe.