### PR TITLE
Use account display name for pretend blog example in attribution area

### DIFF
--- a/app/views/settings/verifications/show.html.haml
+++ b/app/views/settings/verifications/show.html.haml
@@ -50,13 +50,13 @@
               = image_tag frontend_asset_url('images/preview.png'), alt: '', class: 'status-card__image-image'
             .status-card__content
               %span.status-card__host
-                %span= t('author_attribution.s_blog', name: @account.username)
+                %span= t('author_attribution.s_blog', name: display_name(@account))
                 ·
                 %time.time-ago{ datetime: 1.year.ago.to_date.iso8601 }
               %strong.status-card__title= t('author_attribution.example_title')
           .more-from-author
             = logo_as_symbol(:icon)
-            = t('author_attribution.more_from_html', name: link_to(root_url, class: 'story__details__shared__author-link') { image_tag(@account.avatar.url, class: 'account__avatar', width: 16, height: 16, alt: '') + content_tag(:bdi, display_name(@account)) })
+            = t('author_attribution.more_from_html', name: link_to(root_url, class: 'story__details__shared__author-link') { image_tag(@account.avatar.url, class: 'account__avatar', width: 16, height: 16, alt: '') + tag.bdi(display_name(@account)) })
 
   .actions
     = f.button :button, t('generic.save_changes'), type: :submit


### PR DESCRIPTION
Matches bottom line where we use the display_name wrapper value, instead of username directly.