### PR TITLE
Remove unneeded `reorder(nil)` conditions

### DIFF
--- a/app/lib/vacuum/imports_vacuum.rb
+++ b/app/lib/vacuum/imports_vacuum.rb
@@ -9,10 +9,10 @@ class Vacuum::ImportsVacuum
   private
 
   def clean_unconfirmed_imports!
-    BulkImport.state_unconfirmed.where(created_at: ..10.minutes.ago).reorder(nil).in_batches.delete_all
+    BulkImport.state_unconfirmed.where(created_at: ..10.minutes.ago).in_batches.delete_all
   end
 
   def clean_old_imports!
-    BulkImport.where(created_at: ..1.week.ago).reorder(nil).in_batches.delete_all
+    BulkImport.where(created_at: ..1.week.ago).in_batches.delete_all
   end
 end

--- a/app/models/account_filter.rb
+++ b/app/models/account_filter.rb
@@ -21,7 +21,7 @@ class AccountFilter
   end
 
   def results
-    scope = Account.includes(:account_stat, user: [:ips, :invite_request]).without_instance_actor.reorder(nil)
+    scope = Account.includes(:account_stat, user: [:ips, :invite_request]).without_instance_actor
 
     relevant_params.each do |key, value|
       next if key.to_s == 'page'

--- a/app/models/admin/tag_filter.rb
+++ b/app/models/admin/tag_filter.rb
@@ -14,7 +14,7 @@ class Admin::TagFilter
   end
 
   def results
-    scope = Tag.reorder(nil)
+    scope = Tag.all
 
     params.each do |key, value|
       next if key == :page

--- a/app/services/purge_domain_service.rb
+++ b/app/services/purge_domain_service.rb
@@ -16,12 +16,12 @@ class PurgeDomainService < BaseService
   end
 
   def purge_accounts!
-    Account.remote.where(domain: @domain).reorder(nil).find_each do |account|
+    Account.remote.where(domain: @domain).find_each do |account|
       DeleteAccountService.new.call(account, reserve_username: false, skip_side_effects: true)
     end
   end
 
   def purge_emojis!
-    CustomEmoji.remote.where(domain: @domain).reorder(nil).find_each(&:destroy)
+    CustomEmoji.remote.where(domain: @domain).find_each(&:destroy)
   end
 end

--- a/app/workers/filtered_notification_cleanup_worker.rb
+++ b/app/workers/filtered_notification_cleanup_worker.rb
@@ -4,6 +4,6 @@ class FilteredNotificationCleanupWorker
   include Sidekiq::Worker
 
   def perform(account_id, from_account_id)
-    Notification.where(account_id: account_id, from_account_id: from_account_id, filtered: true).reorder(nil).in_batches(order: :desc).delete_all
+    Notification.where(account_id: account_id, from_account_id: from_account_id, filtered: true).in_batches(order: :desc).delete_all
   end
 end

--- a/app/workers/scheduler/user_cleanup_scheduler.rb
+++ b/app/workers/scheduler/user_cleanup_scheduler.rb
@@ -16,7 +16,7 @@ class Scheduler::UserCleanupScheduler
   private
 
   def clean_unconfirmed_accounts!
-    User.unconfirmed.where(confirmation_sent_at: ..UNCONFIRMED_ACCOUNTS_MAX_AGE_DAYS.days.ago).reorder(nil).find_in_batches do |batch|
+    User.unconfirmed.where(confirmation_sent_at: ..UNCONFIRMED_ACCOUNTS_MAX_AGE_DAYS.days.ago).find_in_batches do |batch|
       # We have to do it separately because of missing database constraints
       AccountModerationNote.where(target_account_id: batch.map(&:account_id)).delete_all
       Account.where(id: batch.map(&:account_id)).delete_all


### PR DESCRIPTION
I believe some of this used to have default orders but now dont.

At this point I think the only default orders left on classes are for `Status`, which has both `kept` (necessary) as well as an order. We should consider removing the order there.

The other thing that interacts and requires some of these (though none in this PR, I dont think) is that some of the account associations (block/follow/mute, maybe more) have default order on the association as well, so for anything which has been joined/merged/whatever on those its an issue. We should consider removing those as well, in favour of explicitly requesting whatever we want in various contexts.