### PR TITLE
Avoid repeated icon stack in settings sidebar

### DIFF
--- a/config/navigation.rb
+++ b/config/navigation.rb
@@ -24,7 +24,7 @@ SimpleNavigation::Configuration.run do |navigation|
     n.item :filters, safe_join([material_symbol('filter_alt'), t('filters.index.title')]), filters_path, highlights_on: %r{/filters}, if: -> { current_user.functional? && !self_destruct }
     n.item :statuses_cleanup, safe_join([material_symbol('history'), t('settings.statuses_cleanup')]), statuses_cleanup_path, if: -> { current_user.functional_or_moved? && !self_destruct }
 
-    n.item :security, safe_join([material_symbol('lock'), t('settings.account')]), edit_user_registration_path do |s|
+    n.item :security, safe_join([material_symbol('account_circle'), t('settings.account')]), edit_user_registration_path do |s|
       s.item :password, safe_join([material_symbol('lock'), t('settings.account_settings')]), edit_user_registration_path, highlights_on: %r{^/auth|/settings/delete|/settings/migration|/settings/aliases|/settings/login_activities|^/disputes}
       s.item :two_factor_authentication, safe_join([material_symbol('safety_check'), t('settings.two_factor_authentication')]), settings_two_factor_authentication_methods_path, highlights_on: %r{/settings/two_factor_authentication|/settings/otp_authentication|/settings/security_keys}
       s.item :authorized_apps, safe_join([material_symbol('list_alt'), t('settings.authorized_apps')]), oauth_authorized_applications_path, if: -> { !self_destruct }


### PR DESCRIPTION
We currently have sort of a DOUBLE LOCK SITUATION:

<img width="244" alt="Screenshot 2024-10-01 at 09 38 39" src="https://github.com/user-attachments/assets/31ba6fad-d255-4c3e-95d5-c9df9560e835">

Update to use a different thing (we are using account circle currently somewhere in onboarding, so just re-use here as well?)...

<img width="258" alt="Screenshot 2024-10-01 at 09 38 58" src="https://github.com/user-attachments/assets/235f3d31-0ad8-42ae-a1d1-6e881441b868">
