### PR TITLE
Wrap admin announcements list scheduled at in `time` element

### DIFF
--- a/app/views/admin/announcements/_announcement.html.haml
+++ b/app/views/admin/announcements/_announcement.html.haml
@@ -5,7 +5,9 @@
   .announcements-list__item__action-bar
     .announcements-list__item__meta
       - if announcement.scheduled_at.present?
-        = t('admin.announcements.scheduled_for', time: l(announcement.scheduled_at))
+        %time.formatted{ datetime: announcement.scheduled_at.iso8601 }
+          = t('admin.announcements.scheduled_for', time: l(announcement.scheduled_at))
+
       - else
         = l(announcement.created_at)
 


### PR DESCRIPTION
Followup on https://github.com/mastodon/mastodon/pull/32177 and I think resolves the original issue there.

More or less mirrors what we do with statuses edited_at in the filters view.