### PR TITLE
Extract `WebPushRequest` from push notification worker and subscription

### DIFF
--- a/app/lib/web_push_request.rb
+++ b/app/lib/web_push_request.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+class WebPushRequest
+  SIGNATURE_ALGORITHM = 'p256ecdsa'
+  AUTH_HEADER = 'WebPush'
+  PAYLOAD_EXPIRATION = 24.hours
+  JWT_ALGORITHM = 'ES256'
+  JWT_TYPE = 'JWT'
+
+  attr_reader :web_push_subscription
+
+  delegate(
+    :endpoint,
+    :key_auth,
+    :key_p256dh,
+    to: :web_push_subscription
+  )
+
+  def initialize(web_push_subscription)
+    @web_push_subscription = web_push_subscription
+  end
+
+  def audience
+    @audience ||= Addressable::URI.parse(endpoint).normalized_site
+  end
+
+  def authorization_header
+    [AUTH_HEADER, encoded_json_web_token].join(' ')
+  end
+
+  def crypto_key_header
+    [SIGNATURE_ALGORITHM, vapid_key.public_key_for_push_header].join('=')
+  end
+
+  def encrypt(payload)
+    Webpush::Encryption.encrypt(payload, key_p256dh, key_auth)
+  end
+
+  private
+
+  def encoded_json_web_token
+    JWT.encode(
+      web_token_payload,
+      vapid_key.curve,
+      JWT_ALGORITHM,
+      typ: JWT_TYPE
+    )
+  end
+
+  def web_token_payload
+    {
+      aud: audience,
+      exp: PAYLOAD_EXPIRATION.from_now.to_i,
+      sub: payload_subject,
+    }
+  end
+
+  def payload_subject
+    [:mailto, contact_email].join(':')
+  end
+
+  def vapid_key
+    @vapid_key ||= Webpush::VapidKey.from_keys(
+      Rails.configuration.x.vapid_public_key,
+      Rails.configuration.x.vapid_private_key
+    )
+  end
+
+  def contact_email
+    @contact_email ||= ::Setting.site_contact_email
+  end
+end

--- a/app/models/web/push_subscription.rb
+++ b/app/models/web/push_subscription.rb
@@ -29,26 +29,6 @@ class Web::PushSubscription < ApplicationRecord
 
   delegate :locale, to: :associated_user
 
-  def encrypt(payload)
-    Webpush::Encryption.encrypt(payload, key_p256dh, key_auth)
-  end
-
-  def audience
-    @audience ||= Addressable::URI.parse(endpoint).normalized_site
-  end
-
-  def crypto_key_header
-    p256ecdsa = vapid_key.public_key_for_push_header
-
-    "p256ecdsa=#{p256ecdsa}"
-  end
-
-  def authorization_header
-    jwt = JWT.encode({ aud: audience, exp: 24.hours.from_now.to_i, sub: "mailto:#{contact_email}" }, vapid_key.curve, 'ES256', typ: 'JWT')
-
-    "WebPush #{jwt}"
-  end
-
   def pushable?(notification)
     policy_allows_notification?(notification) && alert_enabled_for_notification_type?(notification)
   end
@@ -90,14 +70,6 @@ class Web::PushSubscription < ApplicationRecord
       expires_in: Doorkeeper.configuration.access_token_expires_in,
       use_refresh_token: Doorkeeper.configuration.refresh_token_enabled?
     )
-  end
-
-  def vapid_key
-    @vapid_key ||= Webpush::VapidKey.from_keys(Rails.configuration.x.vapid_public_key, Rails.configuration.x.vapid_private_key)
-  end
-
-  def contact_email
-    @contact_email ||= ::Setting.site_contact_email
   end
 
   def alert_enabled_for_notification_type?(notification)

--- a/spec/workers/web/push_notification_worker_spec.rb
+++ b/spec/workers/web/push_notification_worker_spec.rb
@@ -23,26 +23,39 @@ RSpec.describe Web::PushNotificationWorker do
 
   describe 'perform' do
     before do
-      allow(subscription).to receive_messages(contact_email: contact_email, vapid_key: vapid_key)
-      allow(Web::PushSubscription).to receive(:find).with(subscription.id).and_return(subscription)
+      Rails.configuration.x.vapid_private_key = vapid_private_key
+      Rails.configuration.x.vapid_public_key = vapid_public_key
+      Setting.site_contact_email = contact_email
+
       allow(Webpush::Encryption).to receive(:encrypt).and_return(payload)
       allow(JWT).to receive(:encode).and_return('jwt.encoded.payload')
 
       stub_request(:post, endpoint).to_return(status: 201, body: '')
-
-      subject.perform(subscription.id, notification.id)
     end
 
     it 'calls the relevant service with the correct headers' do
-      expect(a_request(:post, endpoint).with(headers: {
-        'Content-Encoding' => 'aesgcm',
-        'Content-Type' => 'application/octet-stream',
-        'Crypto-Key' => "dh=BAgtUks5d90kFmxGevk9tH7GEmvz9DB0qcEMUsOBgKwMf-TMjsKIIG6LQvGcFAf6jcmAod15VVwmYwGIIxE4VWE;p256ecdsa=#{vapid_public_key.delete('=')}",
-        'Encryption' => 'salt=WJeVM-RY-F9351SVxTFx_g',
-        'Ttl' => '172800',
-        'Urgency' => 'normal',
-        'Authorization' => 'WebPush jwt.encoded.payload',
-      }, body: "+\xB8\xDBT}\u0013\xB6\xDD.\xF9\xB0\xA7\xC8Ҁ\xFD\x99#\xF7\xAC\x83\xA4\xDB,\u001F\xB5\xB9w\x85>\xF7\xADr")).to have_been_made
+      subject.perform(subscription.id, notification.id)
+
+      expect(web_push_endpoint_request)
+        .to have_been_made
+    end
+
+    def web_push_endpoint_request
+      a_request(
+        :post,
+        endpoint
+      ).with(
+        headers: {
+          'Content-Encoding' => 'aesgcm',
+          'Content-Type' => 'application/octet-stream',
+          'Crypto-Key' => "dh=BAgtUks5d90kFmxGevk9tH7GEmvz9DB0qcEMUsOBgKwMf-TMjsKIIG6LQvGcFAf6jcmAod15VVwmYwGIIxE4VWE;p256ecdsa=#{vapid_public_key.delete('=')}",
+          'Encryption' => 'salt=WJeVM-RY-F9351SVxTFx_g',
+          'Ttl' => '172800',
+          'Urgency' => 'normal',
+          'Authorization' => 'WebPush jwt.encoded.payload',
+        },
+        body: "+\xB8\xDBT}\u0013\xB6\xDD.\xF9\xB0\xA7\xC8Ҁ\xFD\x99#\xF7\xAC\x83\xA4\xDB,\u001F\xB5\xB9w\x85>\xF7\xADr"
+      )
     end
   end
 end

--- a/spec/workers/web/push_notification_worker_spec.rb
+++ b/spec/workers/web/push_notification_worker_spec.rb
@@ -22,9 +22,17 @@ RSpec.describe Web::PushNotificationWorker do
   let(:payload) { { ciphertext: ciphertext, salt: salt, server_public_key: server_public_key, shared_secret: shared_secret } }
 
   describe 'perform' do
-    before do
+    around do |example|
+      original_private = Rails.configuration.x.vapid_private_key
+      original_public = Rails.configuration.x.vapid_public_key
       Rails.configuration.x.vapid_private_key = vapid_private_key
       Rails.configuration.x.vapid_public_key = vapid_public_key
+      example.run
+      Rails.configuration.x.vapid_private_key = original_private
+      Rails.configuration.x.vapid_public_key = original_public
+    end
+
+    before do
       Setting.site_contact_email = contact_email
 
       allow(Webpush::Encryption).to receive(:encrypt).and_return(payload)


### PR DESCRIPTION
The motivation here is sort of two-fold:

- Within the `Web::PushSubscription` AR model, pull out the methods which are not narrowly about basic attributes/permissions/etc but are actually about assembling a request and/or its headers, and put them into a class that can handle those things
- Similarly, in the push notification worker, make the worker have less knowledge of the http request its building and instead just take subs/notifications and cram them into something responsible for doing the actual delivery/request
- To the extent we have any "some day" roadmap (I don't have full context on this, but recall vague ideas in this direction) items around replacing/upgrading the webpush gem situation, start to consolidate that into more obvious single place to do updates.

Thus, actual changes are to add a `WebPushRequest` class that the worker can use for request stuff, and which can be a new home for the removed things from the AR model.

Follow-up here:

- Both the worker and model have some spec coverage, but not exhaustive coverage. This was about as far as I was willing to go w/out shoring that up more
- Next obvious thing here to do would be pull out even more of the request stuff from the worker, and have it handled by either this new class, or some other new class which can build headers/payloads with this class and wrap the request.