### PR TITLE
Move "is this an active resource?" check to mailer callbacks

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -12,13 +12,13 @@ class UserMailer < Devise::Mailer
 
   before_action :set_instance
 
+  before_deliver :verify_active_resource
+
   default to: -> { @resource.email }
 
   def confirmation_instructions(user, token, *, **)
     @resource = user
     @token    = token
-
-    return unless @resource.active_for_authentication?
 
     I18n.with_locale(locale) do
       mail to: @resource.unconfirmed_email.presence || @resource.email,
@@ -31,8 +31,6 @@ class UserMailer < Devise::Mailer
     @resource = user
     @token    = token
 
-    return unless @resource.active_for_authentication?
-
     I18n.with_locale(locale(use_current_locale: true)) do
       mail subject: default_devise_subject
     end
@@ -40,8 +38,6 @@ class UserMailer < Devise::Mailer
 
   def password_change(user, *, **)
     @resource = user
-
-    return unless @resource.active_for_authentication?
 
     I18n.with_locale(locale(use_current_locale: true)) do
       mail subject: default_devise_subject
@@ -51,8 +47,6 @@ class UserMailer < Devise::Mailer
   def email_changed(user, *, **)
     @resource = user
 
-    return unless @resource.active_for_authentication?
-
     I18n.with_locale(locale(use_current_locale: true)) do
       mail subject: default_devise_subject
     end
@@ -60,8 +54,6 @@ class UserMailer < Devise::Mailer
 
   def two_factor_enabled(user, *, **)
     @resource = user
-
-    return unless @resource.active_for_authentication?
 
     I18n.with_locale(locale(use_current_locale: true)) do
       mail subject: default_devise_subject
@@ -71,8 +63,6 @@ class UserMailer < Devise::Mailer
   def two_factor_disabled(user, *, **)
     @resource = user
 
-    return unless @resource.active_for_authentication?
-
     I18n.with_locale(locale(use_current_locale: true)) do
       mail subject: default_devise_subject
     end
@@ -80,8 +70,6 @@ class UserMailer < Devise::Mailer
 
   def two_factor_recovery_codes_changed(user, *, **)
     @resource = user
-
-    return unless @resource.active_for_authentication?
 
     I18n.with_locale(locale(use_current_locale: true)) do
       mail subject: default_devise_subject
@@ -91,8 +79,6 @@ class UserMailer < Devise::Mailer
   def webauthn_enabled(user, *, **)
     @resource = user
 
-    return unless @resource.active_for_authentication?
-
     I18n.with_locale(locale(use_current_locale: true)) do
       mail subject: default_devise_subject
     end
@@ -100,8 +86,6 @@ class UserMailer < Devise::Mailer
 
   def webauthn_disabled(user, *, **)
     @resource = user
-
-    return unless @resource.active_for_authentication?
 
     I18n.with_locale(locale(use_current_locale: true)) do
       mail subject: default_devise_subject
@@ -112,8 +96,6 @@ class UserMailer < Devise::Mailer
     @resource = user
     @webauthn_credential = webauthn_credential
 
-    return unless @resource.active_for_authentication?
-
     I18n.with_locale(locale(use_current_locale: true)) do
       mail subject: I18n.t('devise.mailer.webauthn_credential.added.subject')
     end
@@ -123,8 +105,6 @@ class UserMailer < Devise::Mailer
     @resource = user
     @webauthn_credential = webauthn_credential
 
-    return unless @resource.active_for_authentication?
-
     I18n.with_locale(locale(use_current_locale: true)) do
       mail subject: I18n.t('devise.mailer.webauthn_credential.deleted.subject')
     end
@@ -132,8 +112,6 @@ class UserMailer < Devise::Mailer
 
   def welcome(user)
     @resource = user
-
-    return unless @resource.active_for_authentication?
 
     @suggestions = AccountSuggestions.new(@resource.account).get(5)
     @tags = Trends.tags.query.allowed.limit(5)
@@ -149,8 +127,6 @@ class UserMailer < Devise::Mailer
   def backup_ready(user, backup)
     @resource = user
     @backup   = backup
-
-    return unless @resource.active_for_authentication?
 
     I18n.with_locale(locale) do
       mail subject: default_i18n_subject
@@ -210,6 +186,10 @@ class UserMailer < Devise::Mailer
   end
 
   private
+
+  def verify_active_resource
+    throw(:abort) unless @resource.active_for_authentication?
+  end
 
   def default_devise_subject
     I18n.t(:subject, scope: ['devise.mailer', action_name])

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -3,6 +3,17 @@
 require 'rails_helper'
 
 RSpec.describe UserMailer do
+  shared_examples 'delivery to memorialized user' do
+    context 'when user is not active for authentication' do
+      before { receiver.account.update(memorial: true) }
+
+      it 'does not deliver mail' do
+        emails = capture_emails { mail.deliver_now }
+        expect(emails).to be_empty
+      end
+    end
+  end
+
   let(:receiver) { Fabricate(:user) }
 
   describe '#confirmation_instructions' do
@@ -21,6 +32,7 @@ RSpec.describe UserMailer do
     include_examples 'localized subject',
                      'devise.mailer.confirmation_instructions.subject',
                      instance: Rails.configuration.x.local_domain
+    include_examples 'delivery to memorialized user'
   end
 
   describe '#reconfirmation_instructions' do
@@ -55,6 +67,7 @@ RSpec.describe UserMailer do
 
     include_examples 'localized subject',
                      'devise.mailer.reset_password_instructions.subject'
+    include_examples 'delivery to memorialized user'
   end
 
   describe '#password_change' do
@@ -70,6 +83,7 @@ RSpec.describe UserMailer do
 
     include_examples 'localized subject',
                      'devise.mailer.password_change.subject'
+    include_examples 'delivery to memorialized user'
   end
 
   describe '#email_changed' do
@@ -85,6 +99,7 @@ RSpec.describe UserMailer do
 
     include_examples 'localized subject',
                      'devise.mailer.email_changed.subject'
+    include_examples 'delivery to memorialized user'
   end
 
   describe '#warning' do
@@ -115,6 +130,7 @@ RSpec.describe UserMailer do
 
     include_examples 'localized subject',
                      'devise.mailer.webauthn_credential.deleted.subject'
+    include_examples 'delivery to memorialized user'
   end
 
   describe '#suspicious_sign_in' do
@@ -186,6 +202,8 @@ RSpec.describe UserMailer do
         .and(have_subject(I18n.t('devise.mailer.two_factor_enabled.subject')))
         .and(have_body_text(I18n.t('devise.mailer.two_factor_enabled.explanation')))
     end
+
+    include_examples 'delivery to memorialized user'
   end
 
   describe '#two_factor_disabled' do
@@ -197,6 +215,8 @@ RSpec.describe UserMailer do
         .and(have_subject(I18n.t('devise.mailer.two_factor_disabled.subject')))
         .and(have_body_text(I18n.t('devise.mailer.two_factor_disabled.explanation')))
     end
+
+    include_examples 'delivery to memorialized user'
   end
 
   describe '#webauthn_enabled' do
@@ -208,6 +228,8 @@ RSpec.describe UserMailer do
         .and(have_subject(I18n.t('devise.mailer.webauthn_enabled.subject')))
         .and(have_body_text(I18n.t('devise.mailer.webauthn_enabled.explanation')))
     end
+
+    include_examples 'delivery to memorialized user'
   end
 
   describe '#webauthn_disabled' do
@@ -219,6 +241,8 @@ RSpec.describe UserMailer do
         .and(have_subject(I18n.t('devise.mailer.webauthn_disabled.subject')))
         .and(have_body_text(I18n.t('devise.mailer.webauthn_disabled.explanation')))
     end
+
+    include_examples 'delivery to memorialized user'
   end
 
   describe '#two_factor_recovery_codes_changed' do
@@ -230,6 +254,8 @@ RSpec.describe UserMailer do
         .and(have_subject(I18n.t('devise.mailer.two_factor_recovery_codes_changed.subject')))
         .and(have_body_text(I18n.t('devise.mailer.two_factor_recovery_codes_changed.explanation')))
     end
+
+    include_examples 'delivery to memorialized user'
   end
 
   describe '#webauthn_credential_added' do
@@ -242,6 +268,8 @@ RSpec.describe UserMailer do
         .and(have_subject(I18n.t('devise.mailer.webauthn_credential.added.subject')))
         .and(have_body_text(I18n.t('devise.mailer.webauthn_credential.added.explanation')))
     end
+
+    include_examples 'delivery to memorialized user'
   end
 
   describe '#welcome' do
@@ -259,6 +287,8 @@ RSpec.describe UserMailer do
         .and(have_subject(I18n.t('user_mailer.welcome.subject')))
         .and(have_body_text(I18n.t('user_mailer.welcome.explanation')))
     end
+
+    include_examples 'delivery to memorialized user'
   end
 
   describe '#backup_ready' do
@@ -271,5 +301,7 @@ RSpec.describe UserMailer do
         .and(have_subject(I18n.t('user_mailer.backup_ready.subject')))
         .and(have_body_text(I18n.t('user_mailer.backup_ready.explanation')))
     end
+
+    include_examples 'delivery to memorialized user'
   end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe UserMailer do
     include_examples 'localized subject',
                      'devise.mailer.confirmation_instructions.subject',
                      instance: Rails.configuration.x.local_domain
+    include_examples 'delivery to memorialized user'
   end
 
   describe '#reset_password_instructions' do
@@ -114,6 +115,8 @@ RSpec.describe UserMailer do
         .and(have_body_text(I18n.t('user_mailer.warning.title.suspend', acct: receiver.account.acct)))
         .and(have_body_text(strike.text))
     end
+
+    include_examples 'delivery to memorialized user'
   end
 
   describe '#webauthn_credential_deleted' do
@@ -149,6 +152,7 @@ RSpec.describe UserMailer do
 
     include_examples 'localized subject',
                      'user_mailer.suspicious_sign_in.subject'
+    include_examples 'delivery to memorialized user'
   end
 
   describe '#failed_2fa' do
@@ -167,6 +171,7 @@ RSpec.describe UserMailer do
 
     include_examples 'localized subject',
                      'user_mailer.failed_2fa.subject'
+    include_examples 'delivery to memorialized user'
   end
 
   describe '#appeal_approved' do
@@ -191,6 +196,8 @@ RSpec.describe UserMailer do
         .and(have_subject(I18n.t('user_mailer.appeal_rejected.subject', date: I18n.l(appeal.created_at))))
         .and(have_body_text(I18n.t('user_mailer.appeal_rejected.title')))
     end
+
+    include_examples 'delivery to memorialized user'
   end
 
   describe '#two_factor_enabled' do


### PR DESCRIPTION
Similar approach to notifiers -- use the `before_deliver` callback to stop delivery in cases (memorialized here) where we don't want to actually send.