### PR TITLE
Expand coverage for `Export` utility class

### DIFF
--- a/spec/fabricators/account_domain_block_fabricator.rb
+++ b/spec/fabricators/account_domain_block_fabricator.rb
@@ -2,5 +2,5 @@
 
 Fabricator(:account_domain_block) do
   account { Fabricate.build(:account) }
-  domain 'example.com'
+  domain { sequence { |n| "host-#{n}.example" } }
 end

--- a/spec/models/export_spec.rb
+++ b/spec/models/export_spec.rb
@@ -3,66 +3,175 @@
 require 'rails_helper'
 
 RSpec.describe Export do
+  subject { described_class.new(account) }
+
   let(:account) { Fabricate(:account) }
   let(:target_accounts) do
-    [{}, { username: 'one', domain: 'local.host' }].map(&method(:Fabricate).curry(2).call(:account))
+    [
+      Fabricate(:account),
+      Fabricate(:account, username: 'one', domain: 'local.host'),
+    ]
   end
 
-  describe 'to_csv' do
-    it 'returns a csv of the blocked accounts' do
-      target_accounts.each { |target_account| account.block!(target_account) }
+  describe '#to_bookmarks_csv' do
+    before { Fabricate.times(2, :bookmark, account: account) }
 
-      export = described_class.new(account).to_blocked_accounts_csv
-      results = export.strip.split
+    let(:export) { CSV.parse(subject.to_bookmarks_csv) }
 
-      expect(results.size).to eq 2
-      expect(results.first).to eq 'one@local.host'
+    it 'returns a csv of bookmarks' do
+      expect(export)
+        .to contain_exactly(
+          include(/statuses/),
+          include(/statuses/)
+        )
     end
+  end
+
+  describe '#to_blocked_accounts_csv' do
+    before { target_accounts.each { |target_account| account.block!(target_account) } }
+
+    let(:export) { CSV.parse(subject.to_blocked_accounts_csv) }
+
+    it 'returns a csv of the blocked accounts' do
+      expect(export)
+        .to contain_exactly(
+          include('one@local.host'),
+          include(be_present)
+        )
+    end
+  end
+
+  describe '#to_muted_accounts_csv' do
+    before { target_accounts.each { |target_account| account.mute!(target_account) } }
+
+    let(:export) { CSV.parse(subject.to_muted_accounts_csv) }
 
     it 'returns a csv of the muted accounts' do
-      target_accounts.each { |target_account| account.mute!(target_account) }
-
-      export = described_class.new(account).to_muted_accounts_csv
-      results = export.strip.split("\n")
-
-      expect(results.size).to eq 3
-      expect(results.first).to eq 'Account address,Hide notifications'
-      expect(results.second).to eq 'one@local.host,true'
+      expect(export)
+        .to contain_exactly(
+          contain_exactly('Account address', 'Hide notifications'),
+          include('one@local.host', 'true'),
+          include(be_present)
+        )
     end
+  end
+
+  describe '#to_following_accounts_csv' do
+    before { target_accounts.each { |target_account| account.follow!(target_account) } }
+
+    let(:export) { CSV.parse(subject.to_following_accounts_csv) }
 
     it 'returns a csv of the following accounts' do
-      target_accounts.each { |target_account| account.follow!(target_account) }
-
-      export = described_class.new(account).to_following_accounts_csv
-      results = export.strip.split("\n")
-
-      expect(results.size).to eq 3
-      expect(results.first).to eq 'Account address,Show boosts,Notify on new posts,Languages'
-      expect(results.second).to eq 'one@local.host,true,false,'
+      expect(export)
+        .to contain_exactly(
+          contain_exactly('Account address', 'Show boosts', 'Notify on new posts', 'Languages'),
+          include('one@local.host', 'true', 'false', be_blank),
+          include(be_present)
+        )
     end
   end
 
-  describe 'total_storage' do
+  describe '#to_lists_csv' do
+    before do
+      target_accounts.each do |target_account|
+        account.follow!(target_account)
+        Fabricate(:list, account: account).accounts << target_account
+      end
+    end
+
+    let(:export) { CSV.parse(subject.to_lists_csv) }
+
+    it 'returns a csv of the lists' do
+      expect(export)
+        .to contain_exactly(
+          include('one@local.host'),
+          include(be_present)
+        )
+    end
+  end
+
+  describe '#to_blocked_domains_csv' do
+    before { Fabricate.times(2, :account_domain_block, account: account) }
+
+    let(:export) { CSV.parse(subject.to_blocked_domains_csv) }
+
+    it 'returns a csv of the blocked domains' do
+      expect(export)
+        .to contain_exactly(
+          include(/example/),
+          include(/example/)
+        )
+    end
+  end
+
+  describe '#total_storage' do
     it 'returns the total size of the media attachments' do
       media_attachment = Fabricate(:media_attachment, account: account)
-      expect(described_class.new(account).total_storage).to eq media_attachment.file_file_size || 0
+      expect(subject.total_storage).to eq media_attachment.file_file_size || 0
     end
   end
 
-  describe 'total_follows' do
-    it 'returns the total number of the followed accounts' do
-      target_accounts.each { |target_account| account.follow!(target_account) }
-      expect(described_class.new(account.reload).total_follows).to eq 2
+  describe '#total_statuses' do
+    before { Fabricate.times(2, :status, account: account) }
+
+    it 'returns the total number of statuses' do
+      expect(subject.total_statuses).to eq(2)
     end
+  end
+
+  describe '#total_bookmarks' do
+    before { Fabricate.times(2, :bookmark, account: account) }
+
+    it 'returns the total number of bookmarks' do
+      expect(subject.total_bookmarks).to eq(2)
+    end
+  end
+
+  describe '#total_follows' do
+    before { target_accounts.each { |target_account| account.follow!(target_account) } }
+
+    it 'returns the total number of the followed accounts' do
+      expect(subject.total_follows).to eq(2)
+    end
+  end
+
+  describe '#total_lists' do
+    before { Fabricate.times(2, :list, account: account) }
+
+    it 'returns the total number of lists' do
+      expect(subject.total_lists).to eq(2)
+    end
+  end
+
+  describe '#total_followers' do
+    before { target_accounts.each { |target_account| target_account.follow!(account) } }
+
+    it 'returns the total number of the follower accounts' do
+      expect(subject.total_followers).to eq(2)
+    end
+  end
+
+  describe '#total_blocks' do
+    before { target_accounts.each { |target_account| account.block!(target_account) } }
 
     it 'returns the total number of the blocked accounts' do
-      target_accounts.each { |target_account| account.block!(target_account) }
-      expect(described_class.new(account.reload).total_blocks).to eq 2
+      expect(subject.total_blocks).to eq(2)
     end
+  end
+
+  describe '#total_mutes' do
+    before { target_accounts.each { |target_account| account.mute!(target_account) } }
 
     it 'returns the total number of the muted accounts' do
-      target_accounts.each { |target_account| account.mute!(target_account) }
-      expect(described_class.new(account.reload).total_mutes).to eq 2
+      expect(subject.total_mutes).to eq(2)
+    end
+  end
+
+  describe '#total_domain_blocks' do
+    before { Fabricate.times(2, :account_domain_block, account: account) }
+
+    it 'returns the total number of account domain blocks' do
+      expect(subject.total_domain_blocks).to eq(2)
     end
   end
 end


### PR DESCRIPTION
This is some prep work for larger change, but also probably useful if that doesn't happen.

Changes here:

- The fabricator was valid because it used diff account each time, but in this spec I needed 2 records for same account, so the uniqueness failed. Solved with a sequence on the fabricator.
- Expand the export spec to add coverage for both the "to csv" and "count" methods where they were totally missing
- For both the missing ones and existing ones, on the csv specs, actually use `CSV.parse` to interpret the results -- this strikes me as useful in catching anything we change which makes these totally unparseable for whatever reason

Some of the new coverage here is pretty barebones and just exercising code paths and asserting *something* but there's room for more precision there in future.

The refactor I have in mind is some combination of:

- Separate the "what are the various summary count values for an account" and "generate csv exports for an account" aspects of this
- Within the counting one, explore whether we can shove the counting early enough in the controller that we can utilize `async`, similar to other PRs
- For the export portion, explore doing a per-type class which would just have `to_csv` and inherit from base class (like `BookmarkExport` or something ... sort of TBD)
- Add headers for exports where they are missing