### PR TITLE
Fix incorrect `'navigator'` check

### DIFF
--- a/app/javascript/mastodon/actions/markers.ts
+++ b/app/javascript/mastodon/actions/markers.ts
@@ -37,8 +37,7 @@ export const synchronouslySubmitMarkers = createAppAsyncThunk(
       });
 
       return;
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    } else if ('navigator' && 'sendBeacon' in navigator) {
+    } else if ('sendBeacon' in navigator) {
       // Failing that, we can use sendBeacon, but we have to encode the data as
       // FormData for DoorKeeper to recognize the token.
       const formData = new FormData();


### PR DESCRIPTION
The TypeScript conversion incorrectly changed `navigator` to `'navigator'`. That being said, `window.navigator` is part of the basic DOM spec and is universally supported, so we do not need to check it (and TypeScript considers it is always defined).

Related: #32165