### PR TITLE
Register an XML encoder for response tests

### DIFF
--- a/spec/requests/well_known/host_meta_spec.rb
+++ b/spec/requests/well_known/host_meta_spec.rb
@@ -3,45 +3,62 @@
 require 'rails_helper'
 
 RSpec.describe 'The /.well-known/host-meta request' do
-  it 'returns http success with valid XML response' do
-    get '/.well-known/host-meta'
+  context 'without extension format or accept header' do
+    it 'returns http success with expected XML' do
+      get '/.well-known/host-meta'
 
-    expect(response)
-      .to have_http_status(200)
-      .and have_attributes(
-        media_type: 'application/xrd+xml'
-      )
+      expect(response)
+        .to have_http_status(200)
+        .and have_attributes(
+          media_type: 'application/xrd+xml'
+        )
 
-    doc = Nokogiri::XML(response.parsed_body)
-    expect(doc.at_xpath('/xrd:XRD/xrd:Link[@rel="lrdd"]/@template', 'xrd' => 'http://docs.oasis-open.org/ns/xri/xrd-1.0').value)
-      .to eq 'https://cb6e6126.ngrok.io/.well-known/webfinger?resource={uri}'
+      expect(xrd_link_template_value)
+        .to eq 'https://cb6e6126.ngrok.io/.well-known/webfinger?resource={uri}'
+    end
+
+    def xrd_link_template_value
+      response
+        .parsed_body
+        .at_xpath('/xrd:XRD/xrd:Link[@rel="lrdd"]/@template', 'xrd' => 'http://docs.oasis-open.org/ns/xri/xrd-1.0')
+        .value
+    end
   end
 
-  it 'returns http success with valid JSON response with .json extension' do
-    get '/.well-known/host-meta.json'
+  context 'with a .json format extension' do
+    it 'returns http success with expected JSON' do
+      get '/.well-known/host-meta.json'
 
-    expect(response)
-      .to have_http_status(200)
-      .and have_attributes(
-        media_type: 'application/json'
-      )
-
-    expect(response.parsed_body)
-      .to include(
-        links: [
-          'rel' => 'lrdd',
-          'template' => 'https://cb6e6126.ngrok.io/.well-known/webfinger?resource={uri}',
-        ]
-      )
+      expect(response)
+        .to have_http_status(200)
+        .and have_attributes(
+          media_type: 'application/json'
+        )
+      expect(response.parsed_body)
+        .to include(expected_json_template)
+    end
   end
 
-  it 'returns http success with valid JSON response with Accept header' do
-    get '/.well-known/host-meta', headers: { 'Accept' => 'application/json' }
+  context 'with a JSON `Accept` header' do
+    it 'returns http success with expected JSON' do
+      get '/.well-known/host-meta', headers: { 'Accept' => 'application/json' }
 
-    expect(response)
-      .to have_http_status(200)
-      .and have_attributes(
-        media_type: 'application/json'
-      )
+      expect(response)
+        .to have_http_status(200)
+        .and have_attributes(
+          media_type: 'application/json'
+        )
+      expect(response.parsed_body)
+        .to include(expected_json_template)
+    end
+  end
+
+  def expected_json_template
+    {
+      links: [
+        'rel' => 'lrdd',
+        'template' => 'https://cb6e6126.ngrok.io/.well-known/webfinger?resource={uri}',
+      ],
+    }
   end
 end

--- a/spec/support/response_encoders.rb
+++ b/spec/support/response_encoders.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+ActionDispatch::IntegrationTest
+  .register_encoder :xml, response_parser: ->(body) { Nokogiri::XML(body) }


### PR DESCRIPTION
This is essentially more feedback I had on https://github.com/mastodon/mastodon/pull/32206 but it was merged before I could add some. Basically two changes:

- Add an encoder for xml so we can just use parsed_body directly (there are some other specs that may benefit from this, will do that as followup)
- Within the existing spec, add some rspec contexts, and add the expected response assertion to the json example that was missing it