### PR TITLE
Fix editing description of media uploads with custom thumbnails

### DIFF
--- a/app/javascript/mastodon/reducers/compose.js
+++ b/app/javascript/mastodon/reducers/compose.js
@@ -402,7 +402,7 @@ export default function compose(state = initialState, action) {
       .set('isUploadingThumbnail', false)
       .update('media_attachments', list => list.map(item => {
         if (item.get('id') === action.media.id) {
-          return fromJS(action.media);
+          return fromJS(action.media).set('unattached', item.get('unattached'));
         }
 
         return item;


### PR DESCRIPTION
Fixes #31680

The issue is that we basically have two paths for updating media attachments:
- changes to already-attached media when editing a post
- changes to a media prior to attaching it to a post

The web UI tracks the information of whether a media is attached to an existing post to make that decision. However, uploading a thumbnail for video/audio incorrectly cleared that flag.