### PR TITLE
Extract top-level suspended/buttons `admin/account` partial

### DIFF
--- a/app/helpers/admin/accounts_helper.rb
+++ b/app/helpers/admin/accounts_helper.rb
@@ -11,7 +11,27 @@ module Admin::AccountsHelper
     ]
   end
 
+  def remote_suspension_hint(deletion_request)
+    if deletion_request.present?
+      t('admin.accounts.remote_suspension_reversible_hint_html', date: due_date_for_hint(deletion_request))
+    else
+      t('admin.accounts.remote_suspension_irreversible')
+    end
+  end
+
+  def suspension_hint(deletion_request)
+    if deletion_request.present?
+      t('admin.accounts.suspension_reversible_hint_html', date: due_date_for_hint(deletion_request))
+    else
+      t('admin.accounts.suspension_irreversible')
+    end
+  end
+
   private
+
+  def due_date_for_hint(deletion_request)
+    tag.strong(l(deletion_request.due_at.to_date))
+  end
 
   def pending_user_count_label
     number_with_delimiter User.pending.count

--- a/app/views/admin/accounts/_buttons.html.haml
+++ b/app/views/admin/accounts/_buttons.html.haml
@@ -1,41 +1,31 @@
-- if account.suspended?
-  %hr.spacer/
-  - if account.suspension_origin_remote?
-    %p.muted-hint= deletion_request.present? ? t('admin.accounts.remote_suspension_reversible_hint_html', date: content_tag(:strong, l(deletion_request.due_at.to_date))) : t('admin.accounts.remote_suspension_irreversible')
-  - else
-    %p.muted-hint= deletion_request.present? ? t('admin.accounts.suspension_reversible_hint_html', date: content_tag(:strong, l(deletion_request.due_at.to_date))) : t('admin.accounts.suspension_irreversible')
-  = button_to t('admin.accounts.undo_suspension'), unsuspend_admin_account_path(account.id), class: :button if can?(:unsuspend, account)
-  = button_to t('admin.accounts.redownload'), redownload_admin_account_path(account.id), class: :button if can?(:redownload, account) && account.suspension_origin_remote?
-  - if deletion_request.present? && can?(:destroy, account)
-    = link_to t('admin.accounts.delete'), admin_account_path(account.id), method: :delete, class: 'button button--destructive', data: { confirm: t('admin.accounts.are_you_sure') }
-- else
-  .action-buttons
-    %div
-      - if account.local? && account.user_approved?
-        = link_to t('admin.accounts.warn'), new_admin_account_action_path(account.id, type: 'none'), class: 'button' if can?(:warn, account)
-        - if account.user_disabled?
-          = button_to t('admin.accounts.enable'), enable_admin_account_path(account.id), class: :button if can?(:enable, account.user)
-        - elsif can?(:disable, account.user)
-          = link_to t('admin.accounts.disable'), new_admin_account_action_path(account.id, type: 'disable'), class: 'button'
-      - if account.sensitized?
-        = button_to t('admin.accounts.undo_sensitized'), unsensitive_admin_account_path(account.id), class: :button if can?(:unsensitive, account)
-      - elsif !account.local? || account.user_approved?
-        = link_to t('admin.accounts.sensitive'), new_admin_account_action_path(account.id, type: 'sensitive'), class: 'button' if can?(:sensitive, account)
-      - if account.silenced?
-        = button_to t('admin.accounts.undo_silenced'), unsilence_admin_account_path(account.id), class: :button if can?(:unsilence, account)
-      - elsif !account.local? || account.user_approved?
-        = link_to t('admin.accounts.silence'), new_admin_account_action_path(account.id, type: 'silence'), class: 'button' if can?(:silence, account)
-      - if account.local?
-        - if account.user_pending?
-          = button_to t('admin.accounts.approve'), approve_admin_account_path(account.id), data: { confirm: t('admin.accounts.are_you_sure') }, class: :button if can?(:approve, account.user)
-          = button_to t('admin.accounts.reject'), reject_admin_account_path(account.id), data: { confirm: t('admin.accounts.are_you_sure') }, class: 'button button--destructive' if can?(:reject, account.user)
-        - if !account.user_confirmed? && can?(:confirm, account.user)
-          = button_to t('admin.accounts.confirm'), admin_account_confirmation_path(account.id), class: :button
-      - if (!account.local? || account.user_approved?) && can?(:suspend, account)
-        = link_to t('admin.accounts.perform_full_suspension'), new_admin_account_action_path(account.id, type: 'suspend'), class: 'button'
-    %div
-      - if account.local?
-        - if !account.memorial? && account.user_approved? && can?(:memorialize, account)
-          = button_to t('admin.accounts.memorialize'), memorialize_admin_account_path(account.id), data: { confirm: t('admin.accounts.are_you_sure') }, class: 'button button--destructive'
-      - elsif can?(:redownload, account)
-        = button_to t('admin.accounts.redownload'), redownload_admin_account_path(account.id), class: :button
+-# locals: (account:)
+.action-buttons
+  %div
+    - if account.local? && account.user_approved?
+      = link_to t('admin.accounts.warn'), new_admin_account_action_path(account.id, type: :none), class: :button if can?(:warn, account)
+      - if account.user_disabled?
+        = button_to t('admin.accounts.enable'), enable_admin_account_path(account.id), class: :button if can?(:enable, account.user)
+      - elsif can?(:disable, account.user)
+        = link_to t('admin.accounts.disable'), new_admin_account_action_path(account.id, type: :disable), class: :button
+    - if account.sensitized?
+      = button_to t('admin.accounts.undo_sensitized'), unsensitive_admin_account_path(account.id), class: :button if can?(:unsensitive, account)
+    - elsif !account.local? || account.user_approved?
+      = link_to t('admin.accounts.sensitive'), new_admin_account_action_path(account.id, type: :sensitive), class: :button if can?(:sensitive, account)
+    - if account.silenced?
+      = button_to t('admin.accounts.undo_silenced'), unsilence_admin_account_path(account.id), class: :button if can?(:unsilence, account)
+    - elsif !account.local? || account.user_approved?
+      = link_to t('admin.accounts.silence'), new_admin_account_action_path(account.id, type: :silence), class: :button if can?(:silence, account)
+    - if account.local?
+      - if account.user_pending?
+        = button_to t('admin.accounts.approve'), approve_admin_account_path(account.id), data: { confirm: t('admin.accounts.are_you_sure') }, class: :button if can?(:approve, account.user)
+        = button_to t('admin.accounts.reject'), reject_admin_account_path(account.id), data: { confirm: t('admin.accounts.are_you_sure') }, class: [:button, 'button--destructive'] if can?(:reject, account.user)
+      - if !account.user_confirmed? && can?(:confirm, account.user)
+        = button_to t('admin.accounts.confirm'), admin_account_confirmation_path(account.id), class: :button
+    - if (!account.local? || account.user_approved?) && can?(:suspend, account)
+      = link_to t('admin.accounts.perform_full_suspension'), new_admin_account_action_path(account.id, type: :suspend), class: :button
+  %div
+    - if account.local?
+      - if !account.memorial? && account.user_approved? && can?(:memorialize, account)
+        = button_to t('admin.accounts.memorialize'), memorialize_admin_account_path(account.id), data: { confirm: t('admin.accounts.are_you_sure') }, class: [:button, 'button--destructive']
+    - elsif can?(:redownload, account)
+      = button_to t('admin.accounts.redownload'), redownload_admin_account_path(account.id), class: :button

--- a/app/views/admin/accounts/_suspended_buttons.html.haml
+++ b/app/views/admin/accounts/_suspended_buttons.html.haml
@@ -1,0 +1,25 @@
+-# locals: (account:, deletion_request:)
+%hr.spacer/
+
+%p.muted-hint
+  - if account.suspension_origin_remote?
+    = deletion_request.present? ? t('admin.accounts.remote_suspension_reversible_hint_html', date: content_tag(:strong, l(deletion_request.due_at.to_date))) : t('admin.accounts.remote_suspension_irreversible')
+  - else
+    = deletion_request.present? ? t('admin.accounts.suspension_reversible_hint_html', date: content_tag(:strong, l(deletion_request.due_at.to_date))) : t('admin.accounts.suspension_irreversible')
+
+- if can?(:unsuspend, account)
+  = button_to t('admin.accounts.undo_suspension'),
+              unsuspend_admin_account_path(account.id),
+              class: :button
+
+- if can?(:redownload, account) && account.suspension_origin_remote?
+  = button_to t('admin.accounts.redownload'),
+              redownload_admin_account_path(account.id),
+              class: :button
+
+- if deletion_request.present? && can?(:destroy, account)
+  = link_to t('admin.accounts.delete'),
+            admin_account_path(account.id),
+            class: 'button button--destructive',
+            data: { confirm: t('admin.accounts.are_you_sure') },
+            method: :delete

--- a/app/views/admin/accounts/_suspended_buttons.html.haml
+++ b/app/views/admin/accounts/_suspended_buttons.html.haml
@@ -3,9 +3,9 @@
 
 %p.muted-hint
   - if account.suspension_origin_remote?
-    = deletion_request.present? ? t('admin.accounts.remote_suspension_reversible_hint_html', date: content_tag(:strong, l(deletion_request.due_at.to_date))) : t('admin.accounts.remote_suspension_irreversible')
+    = remote_suspension_hint(deletion_request)
   - else
-    = deletion_request.present? ? t('admin.accounts.suspension_reversible_hint_html', date: content_tag(:strong, l(deletion_request.due_at.to_date))) : t('admin.accounts.suspension_irreversible')
+    = suspension_hint(deletion_request)
 
 - if can?(:unsuspend, account)
   = button_to t('admin.accounts.undo_suspension'),
@@ -20,6 +20,6 @@
 - if deletion_request.present? && can?(:destroy, account)
   = link_to t('admin.accounts.delete'),
             admin_account_path(account.id),
-            class: 'button button--destructive',
+            class: [:button, 'button--destructive'],
             data: { confirm: t('admin.accounts.are_you_sure') },
             method: :delete

--- a/app/views/admin/accounts/show.html.haml
+++ b/app/views/admin/accounts/show.html.haml
@@ -40,7 +40,13 @@
         - else
           = render 'admin/accounts/remote_account', account: @account, domain_block: @domain_block
 
-  = render 'admin/accounts/buttons', account: @account, deletion_request: @deletion_request
+  - if @account.suspended?
+    = render 'admin/accounts/suspended_buttons',
+             account: @account,
+             deletion_request: @deletion_request
+  - else
+    = render 'admin/accounts/buttons',
+             account: @account
 
   %hr.spacer/
 


### PR DESCRIPTION
This is just the very top-level extraction/separation of the suspended vs not suspended logic, referenced from here - https://github.com/mastodon/mastodon/pull/32204#issuecomment-2388441043

As followup, I'll at least rebase the linked PR and see what's still useful there. I may also attempt a separate "lets try well named query methods" sort of approach.

The only change here from original PR is I did one more clean up step in the suspended partial, pulling out helper methods to replace the lengthy ternary around the suspension hint. Otherwise should be same sort of thing as initial.