### PR TITLE
Fix: Enforce SSL for http-based OAuth redirects

### DIFF
--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -136,7 +136,7 @@ Doorkeeper.configure do
   # by default in non-development environments). OAuth2 delegates security in
   # communication to the HTTPS protocol so it is wise to keep this enabled.
   #
-  force_ssl_in_redirect_uri false
+  force_ssl_in_redirect_uri Rails.env.production?
 
   # Specify what redirect URI's you want to block during Application creation.
   # Any redirect URI is allowed by default.


### PR DESCRIPTION
This was [originally set to false in 2016](https://github.com/mastodon/mastodon/commit/492224b93fc11f1c0bc127ede8376bf243925caa) to support andstatus.org, however, fast forward to near the end of 2024 and andstatus.org still does not have TLS/SSL.

Given that OAuth 2 relies on HTTPS for the security of authorization codes, when used without PKCE, we should make HTTPS mandatory for HTTP based redirects.

See OAuth 2 Authorization Framework, [RFC 6749](https://www.rfc-editor.org/rfc/rfc6749.html#section-3.1.2.1):
> The redirection endpoint SHOULD require the use of TLS as described in [Section 1.6](https://www.rfc-editor.org/rfc/rfc6749.html#section-1.6) when the requested response type is "code" or "token", or when the redirection request will result in the transmission of sensitive credentials over an open network.  This specification does not mandate the use of TLS because at the time of this writing, requiring clients to deploy TLS is a significant hurdle for many client developers.  If TLS is not available, the authorization server SHOULD warn the resource owner about the insecure endpoint prior to redirection (e.g., display a message during the authorization request).
>
> Lack of transport-layer security can have a severe impact on the security of the client and the protected resources it is authorized to access.  The use of transport-layer security is particularly critical when the authorization process is used as a form of delegated end-user authentication by the client (e.g., third-party sign-in service). 
