### PR TITLE
Use `print_table` to wrap storage output CLI

### DIFF
--- a/lib/mastodon/cli/media.rb
+++ b/lib/mastodon/cli/media.rb
@@ -278,14 +278,10 @@ module Mastodon::CLI
 
     desc 'usage', 'Calculate disk space consumed by Mastodon'
     def usage
-      say("Attachments:\t#{number_to_human_size(media_attachment_storage_size)} (#{number_to_human_size(local_media_attachment_storage_size)} local)")
-      say("Custom emoji:\t#{number_to_human_size(CustomEmoji.sum(:image_file_size))} (#{number_to_human_size(CustomEmoji.local.sum(:image_file_size))} local)")
-      say("Preview cards:\t#{number_to_human_size(PreviewCard.sum(:image_file_size))}")
-      say("Avatars:\t#{number_to_human_size(Account.sum(:avatar_file_size))} (#{number_to_human_size(Account.local.sum(:avatar_file_size))} local)")
-      say("Headers:\t#{number_to_human_size(Account.sum(:header_file_size))} (#{number_to_human_size(Account.local.sum(:header_file_size))} local)")
-      say("Backups:\t#{number_to_human_size(Backup.sum(:dump_file_size))}")
-      say("Imports:\t#{number_to_human_size(Import.sum(:data_file_size))}")
-      say("Settings:\t#{number_to_human_size(SiteUpload.sum(:file_file_size))}")
+      print_table [
+        ['Object', 'Total Storage', 'Local Storage'],
+        *object_storage_summary,
+      ]
     end
 
     desc 'lookup URL', 'Lookup where media is displayed by passing a media URL'
@@ -318,20 +314,23 @@ module Mastodon::CLI
 
     private
 
-    def media_attachment_storage_size
-      MediaAttachment.sum(file_and_thumbnail_size_sql)
+    def object_storage_summary
+      [
+        [:attachments, MediaAttachment.sum(combined_media_sum), MediaAttachment.where(account: Account.local).sum(combined_media_sum)],
+        [:custom_emoji, CustomEmoji.sum(:image_file_size), CustomEmoji.local.sum(:image_file_size)],
+        [:avatars, Account.sum(:avatar_file_size), Account.local.sum(:avatar_file_size)],
+        [:headers, Account.sum(:header_file_size), Account.local.sum(:header_file_size)],
+        [:preview_cards, PreviewCard.sum(:image_file_size), nil],
+        [:backups, Backup.sum(:dump_file_size), nil],
+        [:imports, Import.sum(:data_file_size), nil],
+        [:settings, SiteUpload.sum(:file_file_size), nil],
+      ].map { |label, total, local| [label.to_s.titleize, number_to_human_size(total), local.present? ? number_to_human_size(local) : nil] }
     end
 
-    def local_media_attachment_storage_size
-      MediaAttachment.where(account: Account.local).sum(file_and_thumbnail_size_sql)
-    end
-
-    def file_and_thumbnail_size_sql
-      Arel.sql(
-        <<~SQL.squish
-          COALESCE(file_file_size, 0) + COALESCE(thumbnail_file_size, 0)
-        SQL
-      )
+    def combined_media_sum
+      Arel.sql(<<~SQL.squish)
+        COALESCE(file_file_size, 0) + COALESCE(thumbnail_file_size, 0)
+      SQL
     end
 
     PRELOAD_MODEL_WHITELIST = %w(

--- a/lib/mastodon/cli/media.rb
+++ b/lib/mastodon/cli/media.rb
@@ -279,7 +279,7 @@ module Mastodon::CLI
     desc 'usage', 'Calculate disk space consumed by Mastodon'
     def usage
       print_table [
-        ['Object', 'Total Storage', 'Local Storage'],
+        %w(Object Total Local),
         *object_storage_summary,
       ]
     end


### PR DESCRIPTION
Previous version here was rejected on grounds of not being delightful enough - https://github.com/mastodon/mastodon/pull/29593/files

This is similar to that one in that it's trying to unpack the quite entangled output-assembling, data-gathering, string-formatting, etc responsibilities from that method, but with a hopefully more obvious separation/improvement.

Changes output slightly:

Before:

```
Attachments:	160 Bytes (160 Bytes local)
Custom emoji:	172 KB (172 KB local)
Preview cards:	0 Bytes
Avatars:	37.6 KB (37.6 KB local)
Headers:	537 KB (537 KB local)
Backups:	131 KB
Imports:	0 Bytes
Settings:	4.56 MB
```

After:

```
Object         Total Storage  Local Storage
Attachments    160 Bytes      160 Bytes
Custom Emoji   172 KB         172 KB
Avatars        37.6 KB        37.6 KB
Headers        537 KB         537 KB
Preview Cards  0 Bytes        
Backups        131 KB         
Imports        0 Bytes        
Settings       4.56 MB        
```

I had a more complicated version of this which also moved the count gathering to a separate class and did some `async_` counting as well ... but this seems like a good first step.