### PR TITLE
Fix Content-Security-Policy when using sso-redirect

### DIFF
--- a/app/controllers/concerns/web_app_controller_concern.rb
+++ b/app/controllers/concerns/web_app_controller_concern.rb
@@ -13,7 +13,7 @@ module WebAppControllerConcern
       policy = ContentSecurityPolicy.new
 
       if policy.sso_host.present?
-        p.form_action policy.sso_host
+        p.form_action policy.sso_host, -> { "https://#{request.host}/auth/auth/" }
       else
         p.form_action :none
       end


### PR DESCRIPTION
Fixes #32186

Note that this builds the CSP with a user-provided value (which, unless Mastodon is modified, is checked against `LOCAL_DOMAIN`, `WEB_DOMAIN` and `ALTERNATE_DOMAINS` by Rails' `HostAuthorization` middleware) in order to support setups where `ALTERNATE_DOMAINS` is set to allow users to more easily log in with multiple accounts on the same domain.

This, however, might be a security concern. An alternative is to hardcode the use of `Rails.configuration.x.web_domain`, which would have the side-effect of not allowing the use-case described above, but maybe this is fine.