### PR TITLE
Re-attempt at `admin` area link/button conversion

### DIFF
--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -19,6 +19,10 @@ code {
   margin-bottom: 24px;
 }
 
+form.button_to {
+  display: inline-block;
+}
+
 .fade-out-top {
   position: relative;
   overflow: hidden;

--- a/app/views/admin/accounts/_buttons.html.haml
+++ b/app/views/admin/accounts/_buttons.html.haml
@@ -4,8 +4,8 @@
     %p.muted-hint= deletion_request.present? ? t('admin.accounts.remote_suspension_reversible_hint_html', date: content_tag(:strong, l(deletion_request.due_at.to_date))) : t('admin.accounts.remote_suspension_irreversible')
   - else
     %p.muted-hint= deletion_request.present? ? t('admin.accounts.suspension_reversible_hint_html', date: content_tag(:strong, l(deletion_request.due_at.to_date))) : t('admin.accounts.suspension_irreversible')
-  = link_to t('admin.accounts.undo_suspension'), unsuspend_admin_account_path(account.id), method: :post, class: 'button' if can?(:unsuspend, account)
-  = link_to t('admin.accounts.redownload'), redownload_admin_account_path(account.id), method: :post, class: 'button' if can?(:redownload, account) && account.suspension_origin_remote?
+  = button_to t('admin.accounts.undo_suspension'), unsuspend_admin_account_path(account.id), class: :button if can?(:unsuspend, account)
+  = button_to t('admin.accounts.redownload'), redownload_admin_account_path(account.id), class: :button if can?(:redownload, account) && account.suspension_origin_remote?
   - if deletion_request.present? && can?(:destroy, account)
     = link_to t('admin.accounts.delete'), admin_account_path(account.id), method: :delete, class: 'button button--destructive', data: { confirm: t('admin.accounts.are_you_sure') }
 - else
@@ -14,28 +14,28 @@
       - if account.local? && account.user_approved?
         = link_to t('admin.accounts.warn'), new_admin_account_action_path(account.id, type: 'none'), class: 'button' if can?(:warn, account)
         - if account.user_disabled?
-          = link_to t('admin.accounts.enable'), enable_admin_account_path(account.id), method: :post, class: 'button' if can?(:enable, account.user)
+          = button_to t('admin.accounts.enable'), enable_admin_account_path(account.id), class: :button if can?(:enable, account.user)
         - elsif can?(:disable, account.user)
           = link_to t('admin.accounts.disable'), new_admin_account_action_path(account.id, type: 'disable'), class: 'button'
       - if account.sensitized?
-        = link_to t('admin.accounts.undo_sensitized'), unsensitive_admin_account_path(account.id), method: :post, class: 'button' if can?(:unsensitive, account)
+        = button_to t('admin.accounts.undo_sensitized'), unsensitive_admin_account_path(account.id), class: :button if can?(:unsensitive, account)
       - elsif !account.local? || account.user_approved?
         = link_to t('admin.accounts.sensitive'), new_admin_account_action_path(account.id, type: 'sensitive'), class: 'button' if can?(:sensitive, account)
       - if account.silenced?
-        = link_to t('admin.accounts.undo_silenced'), unsilence_admin_account_path(account.id), method: :post, class: 'button' if can?(:unsilence, account)
+        = button_to t('admin.accounts.undo_silenced'), unsilence_admin_account_path(account.id), class: :button if can?(:unsilence, account)
       - elsif !account.local? || account.user_approved?
         = link_to t('admin.accounts.silence'), new_admin_account_action_path(account.id, type: 'silence'), class: 'button' if can?(:silence, account)
       - if account.local?
         - if account.user_pending?
-          = link_to t('admin.accounts.approve'), approve_admin_account_path(account.id), method: :post, data: { confirm: t('admin.accounts.are_you_sure') }, class: 'button' if can?(:approve, account.user)
-          = link_to t('admin.accounts.reject'), reject_admin_account_path(account.id), method: :post, data: { confirm: t('admin.accounts.are_you_sure') }, class: 'button button--destructive' if can?(:reject, account.user)
+          = button_to t('admin.accounts.approve'), approve_admin_account_path(account.id), data: { confirm: t('admin.accounts.are_you_sure') }, class: :button if can?(:approve, account.user)
+          = button_to t('admin.accounts.reject'), reject_admin_account_path(account.id), data: { confirm: t('admin.accounts.are_you_sure') }, class: 'button button--destructive' if can?(:reject, account.user)
         - if !account.user_confirmed? && can?(:confirm, account.user)
-          = link_to t('admin.accounts.confirm'), admin_account_confirmation_path(account.id), method: :post, class: 'button'
+          = button_to t('admin.accounts.confirm'), admin_account_confirmation_path(account.id), class: :button
       - if (!account.local? || account.user_approved?) && can?(:suspend, account)
         = link_to t('admin.accounts.perform_full_suspension'), new_admin_account_action_path(account.id, type: 'suspend'), class: 'button'
     %div
       - if account.local?
         - if !account.memorial? && account.user_approved? && can?(:memorialize, account)
-          = link_to t('admin.accounts.memorialize'), memorialize_admin_account_path(account.id), method: :post, data: { confirm: t('admin.accounts.are_you_sure') }, class: 'button button--destructive'
+          = button_to t('admin.accounts.memorialize'), memorialize_admin_account_path(account.id), data: { confirm: t('admin.accounts.are_you_sure') }, class: 'button button--destructive'
       - elsif can?(:redownload, account)
-        = link_to t('admin.accounts.redownload'), redownload_admin_account_path(account.id), method: :post, class: 'button'
+        = button_to t('admin.accounts.redownload'), redownload_admin_account_path(account.id), class: :button

--- a/app/views/admin/accounts/show.html.haml
+++ b/app/views/admin/accounts/show.html.haml
@@ -30,7 +30,7 @@
 = render 'admin/accounts/counters', account: @account
 
 - if @account.local? && @account.user.nil?
-  = link_to t('admin.accounts.unblock_email'), unblock_email_admin_account_path(@account.id), method: :post, class: 'button' if can?(:unblock_email, @account) && CanonicalEmailBlock.exists?(reference_account_id: @account.id)
+  = button_to t('admin.accounts.unblock_email'), unblock_email_admin_account_path(@account.id), class: :button if can?(:unblock_email, @account) && CanonicalEmailBlock.exists?(reference_account_id: @account.id)
 - else
   .table-wrapper
     %table.table.inline-table

--- a/app/views/admin/instances/show.html.haml
+++ b/app/views/admin/instances/show.html.haml
@@ -21,7 +21,7 @@
   - if @instance.domain_allow
     = link_to t('admin.domain_allows.undo'), admin_domain_allow_path(@instance.domain_allow), class: 'button button--destructive', data: { confirm: t('admin.accounts.are_you_sure'), method: :delete }
   - else
-    = link_to t('admin.domain_allows.add_new'), admin_domain_allows_path(domain_allow: { domain: @instance.domain }), class: 'button', method: :post
+    = button_to t('admin.domain_allows.add_new'), admin_domain_allows_path(domain_allow: { domain: @instance.domain }), class: :button
 - else
   %p= t('admin.instances.content_policies.description_html')
 
@@ -40,7 +40,7 @@
             %td= @instance.domain_block.policies.map { |policy| t(policy, scope: 'admin.instances.content_policies.policies') }.join(' · ')
 
     = link_to t('admin.domain_blocks.edit'), edit_admin_domain_block_path(@instance.domain_block), class: 'button'
-    = link_to t('admin.domain_blocks.undo'), admin_domain_block_path(@instance.domain_block), class: 'button', data: { confirm: t('admin.accounts.are_you_sure'), method: :delete }
+    = button_to t('admin.domain_blocks.undo'), admin_domain_block_path(@instance.domain_block), class: :button, data: { confirm: t('admin.accounts.are_you_sure'), method: :delete }
   - else
     = link_to t('admin.domain_blocks.add_new'), new_admin_domain_block_path(_domain: @instance.domain), class: 'button'
 
@@ -70,16 +70,16 @@
       - if @instance.unavailable?
         %span.negative-hint
           = t('admin.instances.availability.failure_threshold_reached', date: l(@instance.unavailable_domain.created_at.to_date))
-          = link_to t('admin.instances.delivery.restart'), restart_delivery_admin_instance_path(@instance), data: { confirm: t('admin.accounts.are_you_sure'), method: :post }
+          = button_to t('admin.instances.delivery.restart'), restart_delivery_admin_instance_path(@instance), data: { confirm: t('admin.accounts.are_you_sure') }
       - elsif @instance.exhausted_deliveries_days.empty?
         %span.positive-hint
           = t('admin.instances.availability.no_failures_recorded')
-          = link_to t('admin.instances.delivery.stop'), stop_delivery_admin_instance_path(@instance), data: { confirm: t('admin.accounts.are_you_sure'), method: :post }
+          = button_to t('admin.instances.delivery.stop'), stop_delivery_admin_instance_path(@instance), data: { confirm: t('admin.accounts.are_you_sure') }
       - else
         %span.negative-hint
           = t('admin.instances.availability.failures_recorded', count: @instance.delivery_failure_tracker.days)
-          %span= link_to t('admin.instances.delivery.clear'), clear_delivery_errors_admin_instance_path(@instance), data: { confirm: t('admin.accounts.are_you_sure'), method: :post } unless @instance.exhausted_deliveries_days.empty?
-          %span= link_to t('admin.instances.delivery.stop'), stop_delivery_admin_instance_path(@instance), data: { confirm: t('admin.accounts.are_you_sure'), method: :post }
+          %span= button_to t('admin.instances.delivery.clear'), clear_delivery_errors_admin_instance_path(@instance), data: { confirm: t('admin.accounts.are_you_sure') } unless @instance.exhausted_deliveries_days.empty?
+          %span= button_to t('admin.instances.delivery.stop'), stop_delivery_admin_instance_path(@instance), data: { confirm: t('admin.accounts.are_you_sure') }
 
   - if @instance.purgeable?
     %p= t('admin.instances.purge_description_html')

--- a/app/views/admin/invites/index.html.haml
+++ b/app/views/admin/invites/index.html.haml
@@ -34,4 +34,4 @@
 = paginate @invites
 
 - if policy(:invite).deactivate_all?
-  = link_to t('admin.invites.deactivate_all'), deactivate_all_admin_invites_path, method: :post, data: { confirm: t('admin.accounts.are_you_sure') }, class: 'button'
+  = button_to t('admin.invites.deactivate_all'), deactivate_all_admin_invites_path, data: { confirm: t('admin.accounts.are_you_sure') }, class: :button

--- a/app/views/admin/reports/_actions.html.haml
+++ b/app/views/admin/reports/_actions.html.haml
@@ -2,7 +2,7 @@
   .report-actions
     .report-actions__item
       .report-actions__item__button
-        = button_to t('admin.reports.mark_as_resolved'), resolve_admin_report_path(report), class: :button
+        = link_to t('admin.reports.mark_as_resolved'), resolve_admin_report_path(report), method: :post, class: 'button'
       .report-actions__item__description
         = t('admin.reports.actions.resolve_description_html')
     - if statuses.any? { |status| (status.with_media? || status.with_preview_card?) && !status.discarded? }

--- a/app/views/admin/reports/_actions.html.haml
+++ b/app/views/admin/reports/_actions.html.haml
@@ -2,7 +2,7 @@
   .report-actions
     .report-actions__item
       .report-actions__item__button
-        = link_to t('admin.reports.mark_as_resolved'), resolve_admin_report_path(report), method: :post, class: 'button'
+        = button_to t('admin.reports.mark_as_resolved'), resolve_admin_report_path(report), class: :button
       .report-actions__item__description
         = t('admin.reports.actions.resolve_description_html')
     - if statuses.any? { |status| (status.with_media? || status.with_preview_card?) && !status.discarded? }

--- a/app/views/admin/reports/show.html.haml
+++ b/app/views/admin/reports/show.html.haml
@@ -3,9 +3,9 @@
 
 - content_for :heading_actions do
   - if @report.unresolved?
-    = link_to t('admin.reports.mark_as_resolved'), resolve_admin_report_path(@report), method: :post, class: 'button'
+    = button_to t('admin.reports.mark_as_resolved'), resolve_admin_report_path(@report), class: :button
   - else
-    = link_to t('admin.reports.mark_as_unresolved'), reopen_admin_report_path(@report), method: :post, class: 'button'
+    = button_to t('admin.reports.mark_as_unresolved'), reopen_admin_report_path(@report), class: :button
 
 - unless @report.account.local? || @report.target_account.local?
   .flash-message= t('admin.reports.forwarded_replies_explanation')

--- a/app/views/disputes/strikes/show.html.haml
+++ b/app/views/disputes/strikes/show.html.haml
@@ -3,8 +3,8 @@
 
 - content_for :heading_actions do
   - if @appeal.persisted?
-    = link_to t('disputes.strikes.approve_appeal'), approve_admin_disputes_appeal_path(@appeal), method: :post, class: 'button' if can?(:approve, @appeal)
-    = link_to t('disputes.strikes.reject_appeal'), reject_admin_disputes_appeal_path(@appeal), method: :post, class: 'button button--destructive' if can?(:reject, @appeal)
+    = button_to t('disputes.strikes.approve_appeal'), approve_admin_disputes_appeal_path(@appeal), class: :button if can?(:approve, @appeal)
+    = button_to t('disputes.strikes.reject_appeal'), reject_admin_disputes_appeal_path(@appeal), class: 'button button--destructive' if can?(:reject, @appeal)
 
 - if @strike.overruled?
   %p.hint

--- a/app/views/settings/exports/show.html.haml
+++ b/app/views/settings/exports/show.html.haml
@@ -46,7 +46,7 @@
 %p.muted-hint= t('exports.archive_takeout.hint_html')
 
 - if policy(:backup).create?
-  %p= link_to t('exports.archive_takeout.request'), settings_export_path, class: 'button', method: :post
+  %p= button_to t('exports.archive_takeout.request'), settings_export_path, class: :button
 
 - unless @backups.empty?
   %hr.spacer/

--- a/app/views/settings/two_factor_authentication/otp_authentication/show.html.haml
+++ b/app/views/settings/two_factor_authentication/otp_authentication/show.html.haml
@@ -6,4 +6,4 @@
 
   %hr.spacer/
 
-  = link_to t('otp_authentication.setup'), settings_otp_authentication_path, data: { method: :post }, class: 'block-button'
+  = button_to t('otp_authentication.setup'), settings_otp_authentication_path, class: 'block-button'

--- a/app/views/settings/two_factor_authentication_methods/index.html.haml
+++ b/app/views/settings/two_factor_authentication_methods/index.html.haml
@@ -2,7 +2,7 @@
   = t('settings.two_factor_authentication')
 
 - content_for :heading_actions do
-  = link_to t('two_factor_authentication.disable'), disable_settings_two_factor_authentication_methods_path, class: 'button button--destructive', method: :post
+  = button_to t('two_factor_authentication.disable'), disable_settings_two_factor_authentication_methods_path, class: 'button button--destructive'
 
 %p.hint
   %span.positive-hint
@@ -38,4 +38,4 @@
 %hr.spacer/
 
 .simple_form
-  = link_to t('two_factor_authentication.generate_recovery_codes'), settings_two_factor_authentication_recovery_codes_path, data: { method: :post }, class: 'block-button'
+  = button_to t('two_factor_authentication.generate_recovery_codes'), settings_two_factor_authentication_recovery_codes_path, class: 'block-button'


### PR DESCRIPTION
Follow up on https://github.com/mastodon/mastodon/pull/32240

Restores those changes except not the one which was in the middle of a separate form, which as of https://github.com/mastodon/mastodon/pull/32248 has some protection which should catch that issue on further changes. Might attempt to pull that button out of the form in separate PR.

Apologies again on missing this inititally -- I'm assuming here that that one button was the only one with issues, but if that's not the case, let me know which others are concerns and I'll try to expand coverage on those first as well.

This is all in support of slow migration away from deprecated rails-ujs lib.