### PR TITLE
Add coverage for missing status scenario in NotificationMailer

### DIFF
--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -86,7 +86,7 @@ class NotificationMailer < ApplicationMailer
   end
 
   def thread_by_conversation!
-    return if @status.conversation.nil?
+    return if @status&.conversation.nil?
 
     conversation_message_id = "<conversation-#{@status.conversation.id}.#{@status.conversation.created_at.to_date}@#{Rails.configuration.x.local_domain}>"
 

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -14,6 +14,17 @@ RSpec.describe NotificationMailer do
     end
   end
 
+  shared_examples 'delivery without status' do
+    context 'when notification target_status is missing' do
+      before { allow(notification).to receive(:target_status).and_return(nil) }
+
+      it 'does not deliver mail' do
+        emails = capture_emails { mail.deliver_now }
+        expect(emails).to be_empty
+      end
+    end
+  end
+
   let(:receiver)       { Fabricate(:user, account_attributes: { username: 'alice' }) }
   let(:sender)         { Fabricate(:account, username: 'bob') }
   let(:foreign_status) { Fabricate(:status, account: sender, text: 'The body of the foreign status') }
@@ -37,6 +48,7 @@ RSpec.describe NotificationMailer do
     end
 
     include_examples 'delivery to non functional user'
+    include_examples 'delivery without status'
   end
 
   describe 'follow' do
@@ -75,6 +87,7 @@ RSpec.describe NotificationMailer do
     end
 
     include_examples 'delivery to non functional user'
+    include_examples 'delivery without status'
   end
 
   describe 'reblog' do
@@ -95,6 +108,7 @@ RSpec.describe NotificationMailer do
     end
 
     include_examples 'delivery to non functional user'
+    include_examples 'delivery without status'
   end
 
   describe 'follow_request' do


### PR DESCRIPTION
Coverage only portion from https://github.com/mastodon/mastodon/pull/32090 plus one safe navigation change needed to actually execute when status missing.