### PR TITLE
Fix media gallery items having incorrect borders when hidden

### DIFF
--- a/app/javascript/mastodon/components/media_gallery.jsx
+++ b/app/javascript/mastodon/components/media_gallery.jsx
@@ -336,13 +336,13 @@ class MediaGallery extends PureComponent {
 
     return (
       <div className={`media-gallery media-gallery--layout-${size}`} style={style} ref={this.handleRef}>
+        {children}
+
         {(!visible || uncached) && (
           <div className={classNames('spoiler-button', { 'spoiler-button--click-thru': uncached })}>
             {spoilerButton}
           </div>
         )}
-
-        {children}
 
         {(visible && !uncached) && (
           <div className='media-gallery__actions'>


### PR DESCRIPTION
## Before

![image](https://github.com/user-attachments/assets/9bb46848-4fbc-4645-9e39-8af062931cf8)

## After

![image](https://github.com/user-attachments/assets/f5da8e91-e4b8-432b-900f-01146c8d9b28)