### PR TITLE
Fix CSS warnings

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -10482,6 +10482,7 @@ noscript {
 
   &__text {
     flex: 1 1 auto;
+    font-size: 14px;
     line-height: 20px;
 
     strong {
@@ -10539,6 +10540,7 @@ noscript {
   &__name {
     flex: 1 1 auto;
     color: $darker-text-color;
+    font-size: 14px;
     line-height: 20px;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -8811,6 +8811,7 @@ noscript {
   &__item {
     flex-shrink: 0;
     background: lighten($ui-base-color, 12%);
+    color: $darker-text-color;
     border: 0;
     border-radius: 3px;
     margin: 2px;
@@ -8847,7 +8848,6 @@ noscript {
       font-weight: 500;
       text-align: center;
       margin-inline-start: 6px;
-      color: $darker-text-color;
     }
 
     &:hover,
@@ -8856,10 +8856,7 @@ noscript {
       background: lighten($ui-base-color, 16%);
       transition: all 200ms ease-out;
       transition-property: background-color, color;
-
-      &__count {
-        color: lighten($darker-text-color, 4%);
-      }
+      color: lighten($darker-text-color, 4%);
     }
 
     &.active {
@@ -8870,10 +8867,7 @@ noscript {
         $ui-highlight-color,
         80%
       );
-
-      .reactions-bar__item__count {
-        color: lighten($highlight-text-color, 8%);
-      }
+      color: lighten($highlight-text-color, 8%);
     }
   }
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -6133,12 +6133,6 @@ a.status-card {
   }
 }
 
-.onboard-sliders {
-  display: inline-block;
-  max-width: 30px;
-  margin-inline-start: 10px;
-}
-
 .safety-action-modal {
   width: 600px;
   flex-direction: column;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -6136,7 +6136,6 @@ a.status-card {
 .onboard-sliders {
   display: inline-block;
   max-width: 30px;
-  max-height: auto;
   margin-inline-start: 10px;
 }
 
@@ -10489,7 +10488,6 @@ noscript {
 
   &__text {
     flex: 1 1 auto;
-    font-style: 14px;
     line-height: 20px;
 
     strong {
@@ -10547,7 +10545,6 @@ noscript {
   &__name {
     flex: 1 1 auto;
     color: $darker-text-color;
-    font-style: 14px;
     line-height: 20px;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/app/javascript/styles/mastodon/polls.scss
+++ b/app/javascript/styles/mastodon/polls.scss
@@ -38,11 +38,6 @@
       background: darken($ui-primary-color, 5%);
     }
 
-    &::-ms-fill {
-      border-radius: 4px;
-      background: darken($ui-primary-color, 5%);
-    }
-
     &::-webkit-progress-value {
       border-radius: 4px;
       background: darken($ui-primary-color, 5%);


### PR DESCRIPTION
Remove some broken/outdated CSS that triggers warnings in Firefox's developer console:

- Remove `-ms-fill` which is only relevant for Internet Explorer and pre-Chromium Edge (added in #13438).
- Remove declarations with invalid property values: `max-height: auto` (#6303) and `font-style: 14px` (#13438).
- Use of `&__foo` inside `:hover` results in CSS with invalid pseudo-class: `:hover__foo` (#12662).