### PR TITLE
Only target modern browsers in development

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -7,4 +7,7 @@ not dead
 not OperaMini all
 
 [development]
-supports es6-module
+last 1 chrome version
+last 1 edge version
+last 1 firefox version
+last 1 safari version

--- a/babel.config.js
+++ b/babel.config.js
@@ -13,6 +13,7 @@ module.exports = (api) => {
     include: [
       'transform-numeric-separator',
       'transform-optional-chaining',
+      'transform-logical-assignment-operators',
       'transform-nullish-coalescing-operator',
       'transform-class-properties',
     ],

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "private": true,
   "dependencies": {
     "@babel/core": "^7.22.1",
+    "@babel/plugin-transform-logical-assignment-operators": "^7.25.7",
     "@babel/plugin-transform-nullish-coalescing-operator": "^7.22.3",
     "@babel/plugin-transform-react-inline-elements": "^7.21.0",
     "@babel/plugin-transform-runtime": "^7.22.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2789,6 +2789,7 @@ __metadata:
   resolution: "@mastodon/mastodon@workspace:."
   dependencies:
     "@babel/core": "npm:^7.22.1"
+    "@babel/plugin-transform-logical-assignment-operators": "npm:^7.25.7"
     "@babel/plugin-transform-nullish-coalescing-operator": "npm:^7.22.3"
     "@babel/plugin-transform-react-inline-elements": "npm:^7.21.0"
     "@babel/plugin-transform-runtime": "npm:^7.22.4"


### PR DESCRIPTION
I noticed that Firefox was complaining about an unknown property, `-moz-columns`. The unprefixed version has been supported in Firefox [since version 52](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/52), so I was curious why Autoprefixer is still prefixing it.

I realized that we currently target [a very wide range of browsers](https://browsersl.ist/#q=supports+es6-module) in development. This was changed in #18519 from just the latest version of the major browsers to _all_ browsers supporting ES6. I assume this was not the intention.

I suggest we revert to the previous strategy of targeting just the latest version of the major browsers.

All modern browsers support the [nullish coalescing assignment (`??=`)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_assignment), but Webpack apparently does not, so we need the [`transform-logical-assignment-operators` plugin](https://babeljs.io/docs/babel-plugin-transform-logical-assignment-operators) (similar to how we had to add `transform-nullish-coalescing-operator` in #24374).

BTW, I noticed that on several production sites, including https://mastodon.social, the CSS includes `-moz-columns`, but if I run `yarn build:production` on my local machine, it does _not_ include `-moz-columns`. So it seems that the prodution CSS is notsometimes built with a different target than the `production` target in .browserslistrc. Seems weird?
