### PR TITLE
Add missing `on_delete: :cascade` on `notification_permissions`

### DIFF
--- a/db/migrate/20241007071624_fix_notification_permission_foreign_keys.rb
+++ b/db/migrate/20241007071624_fix_notification_permission_foreign_keys.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class FixNotificationPermissionForeignKeys < ActiveRecord::Migration[7.1]
+  def up
+    safety_assured do
+      execute <<~SQL.squish
+        ALTER TABLE notification_permissions
+          DROP CONSTRAINT fk_rails_7c0bed08df,
+          ADD CONSTRAINT fk_rails_7c0bed08df
+            FOREIGN KEY (account_id)
+            REFERENCES accounts(id)
+            ON DELETE CASCADE,
+
+          DROP CONSTRAINT fk_rails_e3e0aaad70,
+          ADD CONSTRAINT fk_rails_e3e0aaad70
+            FOREIGN KEY (from_account_id)
+            REFERENCES accounts(id)
+            ON DELETE CASCADE
+      SQL
+    end
+  end
+
+  def down
+    safety_assured do
+      execute <<~SQL.squish
+        ALTER TABLE notification_permissions
+          DROP CONSTRAINT fk_rails_7c0bed08df,
+          ADD CONSTRAINT fk_rails_7c0bed08df
+            FOREIGN KEY (account_id)
+            REFERENCES accounts(id),
+
+          DROP CONSTRAINT fk_rails_e3e0aaad70,
+          ADD CONSTRAINT fk_rails_e3e0aaad70
+            FOREIGN KEY (from_account_id)
+            REFERENCES accounts(id)
+      SQL
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_16_190140) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_07_071624) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -1291,8 +1291,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_16_190140) do
   add_foreign_key "mentions", "statuses", on_delete: :cascade
   add_foreign_key "mutes", "accounts", column: "target_account_id", name: "fk_eecff219ea", on_delete: :cascade
   add_foreign_key "mutes", "accounts", name: "fk_b8d8daf315", on_delete: :cascade
-  add_foreign_key "notification_permissions", "accounts"
-  add_foreign_key "notification_permissions", "accounts", column: "from_account_id"
+  add_foreign_key "notification_permissions", "accounts", column: "from_account_id", on_delete: :cascade
+  add_foreign_key "notification_permissions", "accounts", on_delete: :cascade
   add_foreign_key "notification_policies", "accounts", on_delete: :cascade
   add_foreign_key "notification_requests", "accounts", column: "from_account_id", on_delete: :cascade
   add_foreign_key "notification_requests", "accounts", on_delete: :cascade


### PR DESCRIPTION
Similar to #30251

Fixes error like the following when completely deleting accounts:
```
Error processing 112883558119053320: PG::ForeignKeyViolation: ERROR:  update or delete on table "accounts" violates foreign key constraint "fk_rails_e3e0aaad70" on table "notification_permissions"

DETAIL:  Key (id)=(112883558119053320) is still referenced from table "notification_permissions".
```