### PR TITLE
Oauth system spec cleanup / helper method extraction

### DIFF
--- a/spec/system/oauth_spec.rb
+++ b/spec/system/oauth_spec.rb
@@ -24,10 +24,10 @@ RSpec.describe 'Using OAuth from an external app' do
       subject
 
       # It presents the user with an authorization page
-      expect(page).to have_content(I18n.t('doorkeeper.authorizations.buttons.authorize'))
+      expect(page).to have_content(oauth_authorize_text)
 
       # Upon authorizing, it redirects to the apps' callback URL
-      click_on I18n.t('doorkeeper.authorizations.buttons.authorize')
+      click_on oauth_authorize_text
       expect(page).to have_current_path(/\A#{client_app.redirect_uri}/, url: true)
 
       # It grants the app access to the account
@@ -38,10 +38,10 @@ RSpec.describe 'Using OAuth from an external app' do
       subject
 
       # It presents the user with an authorization page
-      expect(page).to have_content(I18n.t('doorkeeper.authorizations.buttons.deny'))
+      expect(page).to have_content(oauth_deny_text)
 
       # Upon denying, it redirects to the apps' callback URL
-      click_on I18n.t('doorkeeper.authorizations.buttons.deny')
+      click_on oauth_deny_text
       expect(page).to have_current_path(/\A#{client_app.redirect_uri}/, url: true)
 
       # It does not grant the app access to the account
@@ -145,10 +145,10 @@ RSpec.describe 'Using OAuth from an external app' do
 
       # Logging in redirects to an authorization page
       fill_in_auth_details(email, password)
-      expect(page).to have_content(I18n.t('doorkeeper.authorizations.buttons.authorize'))
+      expect(page).to have_content(oauth_authorize_text)
 
       # Upon authorizing, it redirects to the apps' callback URL
-      click_on I18n.t('doorkeeper.authorizations.buttons.authorize')
+      click_on oauth_authorize_text
       expect(page).to have_current_path(/\A#{client_app.redirect_uri}/, url: true)
 
       # It grants the app access to the account
@@ -168,10 +168,10 @@ RSpec.describe 'Using OAuth from an external app' do
 
       # Logging in redirects to an authorization page
       fill_in_auth_details(email, password)
-      expect(page).to have_content(I18n.t('doorkeeper.authorizations.buttons.authorize'))
+      expect(page).to have_content(oauth_authorize_text)
 
       # Upon denying, it redirects to the apps' callback URL
-      click_on I18n.t('doorkeeper.authorizations.buttons.deny')
+      click_on oauth_deny_text
       expect(page).to have_current_path(/\A#{client_app.redirect_uri}/, url: true)
 
       # It does not grant the app access to the account
@@ -202,10 +202,10 @@ RSpec.describe 'Using OAuth from an external app' do
 
         # Filling in the correct TOTP code redirects to an app authorization page
         fill_in_otp_details(user.current_otp)
-        expect(page).to have_content(I18n.t('doorkeeper.authorizations.buttons.authorize'))
+        expect(page).to have_content(oauth_authorize_text)
 
         # Upon authorizing, it redirects to the apps' callback URL
-        click_on I18n.t('doorkeeper.authorizations.buttons.authorize')
+        click_on oauth_authorize_text
         expect(page).to have_current_path(/\A#{client_app.redirect_uri}/, url: true)
 
         # It grants the app access to the account
@@ -233,10 +233,10 @@ RSpec.describe 'Using OAuth from an external app' do
 
         # Filling in the correct TOTP code redirects to an app authorization page
         fill_in_otp_details(user.current_otp)
-        expect(page).to have_content(I18n.t('doorkeeper.authorizations.buttons.authorize'))
+        expect(page).to have_content(oauth_authorize_text)
 
         # Upon denying, it redirects to the apps' callback URL
-        click_on I18n.t('doorkeeper.authorizations.buttons.deny')
+        click_on oauth_deny_text
         expect(page).to have_current_path(/\A#{client_app.redirect_uri}/, url: true)
 
         # It does not grant the app access to the account
@@ -251,5 +251,13 @@ RSpec.describe 'Using OAuth from an external app' do
   def fill_in_otp_details(value)
     fill_in 'user_otp_attempt', with: value
     click_on I18n.t('auth.login')
+  end
+
+  def oauth_authorize_text
+    I18n.t('doorkeeper.authorizations.buttons.authorize')
+  end
+
+  def oauth_deny_text
+    I18n.t('doorkeeper.authorizations.buttons.deny')
   end
 end

--- a/spec/system/oauth_spec.rb
+++ b/spec/system/oauth_spec.rb
@@ -26,12 +26,12 @@ RSpec.describe 'Using OAuth from an external app' do
       # It presents the user with an authorization page
       expect(page).to have_content(oauth_authorize_text)
 
-      # Upon authorizing, it redirects to the apps' callback URL
-      click_on oauth_authorize_text
-      expect(page).to have_current_path(/\A#{client_app.redirect_uri}/, url: true)
-
       # It grants the app access to the account
-      expect(Doorkeeper::AccessGrant.exists?(application: client_app, resource_owner_id: user.id)).to be true
+      expect { click_on oauth_authorize_text }
+        .to change { Doorkeeper::AccessGrant.exists?(application: client_app, resource_owner_id: user.id) }.to(true)
+
+      # Upon authorizing, it redirects to the apps' callback URL
+      expect(page).to have_current_path(/\A#{client_app.redirect_uri}/, url: true)
     end
 
     it 'when rejecting the authorization request' do
@@ -40,12 +40,12 @@ RSpec.describe 'Using OAuth from an external app' do
       # It presents the user with an authorization page
       expect(page).to have_content(oauth_deny_text)
 
-      # Upon denying, it redirects to the apps' callback URL
-      click_on oauth_deny_text
-      expect(page).to have_current_path(/\A#{client_app.redirect_uri}/, url: true)
-
       # It does not grant the app access to the account
-      expect(Doorkeeper::AccessGrant.exists?(application: client_app, resource_owner_id: user.id)).to be false
+      expect { click_on oauth_deny_text }
+        .to_not change { Doorkeeper::AccessGrant.exists?(application: client_app, resource_owner_id: user.id) }.from(false)
+
+      # Upon denying, it redirects to the apps' callback URL
+      expect(page).to have_current_path(/\A#{client_app.redirect_uri}/, url: true)
     end
 
     # The tests in this context ensures that requests without PKCE parameters
@@ -147,12 +147,12 @@ RSpec.describe 'Using OAuth from an external app' do
       fill_in_auth_details(email, password)
       expect(page).to have_content(oauth_authorize_text)
 
-      # Upon authorizing, it redirects to the apps' callback URL
-      click_on oauth_authorize_text
-      expect(page).to have_current_path(/\A#{client_app.redirect_uri}/, url: true)
-
       # It grants the app access to the account
-      expect(Doorkeeper::AccessGrant.exists?(application: client_app, resource_owner_id: user.id)).to be true
+      expect { click_on oauth_authorize_text }
+        .to change { Doorkeeper::AccessGrant.exists?(application: client_app, resource_owner_id: user.id) }.to(true)
+
+      # Upon authorizing, it redirects to the apps' callback URL
+      expect(page).to have_current_path(/\A#{client_app.redirect_uri}/, url: true)
     end
 
     it 'when rejecting the authorization request' do
@@ -170,12 +170,12 @@ RSpec.describe 'Using OAuth from an external app' do
       fill_in_auth_details(email, password)
       expect(page).to have_content(oauth_authorize_text)
 
-      # Upon denying, it redirects to the apps' callback URL
-      click_on oauth_deny_text
-      expect(page).to have_current_path(/\A#{client_app.redirect_uri}/, url: true)
-
       # It does not grant the app access to the account
-      expect(Doorkeeper::AccessGrant.exists?(application: client_app, resource_owner_id: user.id)).to be false
+      expect { click_on oauth_deny_text }
+        .to_not change { Doorkeeper::AccessGrant.exists?(application: client_app, resource_owner_id: user.id) }.from(false)
+
+      # Upon denying, it redirects to the apps' callback URL
+      expect(page).to have_current_path(/\A#{client_app.redirect_uri}/, url: true)
     end
 
     context 'when the user has set up TOTP' do
@@ -204,12 +204,12 @@ RSpec.describe 'Using OAuth from an external app' do
         fill_in_otp_details(user.current_otp)
         expect(page).to have_content(oauth_authorize_text)
 
-        # Upon authorizing, it redirects to the apps' callback URL
-        click_on oauth_authorize_text
-        expect(page).to have_current_path(/\A#{client_app.redirect_uri}/, url: true)
-
         # It grants the app access to the account
-        expect(Doorkeeper::AccessGrant.exists?(application: client_app, resource_owner_id: user.id)).to be true
+        expect { click_on oauth_authorize_text }
+          .to change { Doorkeeper::AccessGrant.exists?(application: client_app, resource_owner_id: user.id) }.to(true)
+
+        # Upon authorizing, it redirects to the apps' callback URL
+        expect(page).to have_current_path(/\A#{client_app.redirect_uri}/, url: true)
       end
 
       it 'when rejecting the authorization request' do
@@ -235,12 +235,12 @@ RSpec.describe 'Using OAuth from an external app' do
         fill_in_otp_details(user.current_otp)
         expect(page).to have_content(oauth_authorize_text)
 
-        # Upon denying, it redirects to the apps' callback URL
-        click_on oauth_deny_text
-        expect(page).to have_current_path(/\A#{client_app.redirect_uri}/, url: true)
-
         # It does not grant the app access to the account
-        expect(Doorkeeper::AccessGrant.exists?(application: client_app, resource_owner_id: user.id)).to be false
+        expect { click_on oauth_deny_text }
+          .to_not change { Doorkeeper::AccessGrant.exists?(application: client_app, resource_owner_id: user.id) }.from(false)
+
+        # Upon denying, it redirects to the apps' callback URL
+        expect(page).to have_current_path(/\A#{client_app.redirect_uri}/, url: true)
       end
     end
     # TODO: external auth

--- a/spec/system/oauth_spec.rb
+++ b/spec/system/oauth_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'Using OAuth from an external app' do
         .to change { Doorkeeper::AccessGrant.exists?(application: client_app, resource_owner_id: user.id) }.to(true)
 
       # Upon authorizing, it redirects to the apps' callback URL
-      expect(page).to have_current_path(/\A#{client_app.redirect_uri}/, url: true)
+      expect(page).to redirect_to_callback_url
     end
 
     it 'when rejecting the authorization request' do
@@ -45,7 +45,7 @@ RSpec.describe 'Using OAuth from an external app' do
         .to_not change { Doorkeeper::AccessGrant.exists?(application: client_app, resource_owner_id: user.id) }.from(false)
 
       # Upon denying, it redirects to the apps' callback URL
-      expect(page).to have_current_path(/\A#{client_app.redirect_uri}/, url: true)
+      expect(page).to redirect_to_callback_url
     end
 
     # The tests in this context ensures that requests without PKCE parameters
@@ -152,7 +152,7 @@ RSpec.describe 'Using OAuth from an external app' do
         .to change { Doorkeeper::AccessGrant.exists?(application: client_app, resource_owner_id: user.id) }.to(true)
 
       # Upon authorizing, it redirects to the apps' callback URL
-      expect(page).to have_current_path(/\A#{client_app.redirect_uri}/, url: true)
+      expect(page).to redirect_to_callback_url
     end
 
     it 'when rejecting the authorization request' do
@@ -175,7 +175,7 @@ RSpec.describe 'Using OAuth from an external app' do
         .to_not change { Doorkeeper::AccessGrant.exists?(application: client_app, resource_owner_id: user.id) }.from(false)
 
       # Upon denying, it redirects to the apps' callback URL
-      expect(page).to have_current_path(/\A#{client_app.redirect_uri}/, url: true)
+      expect(page).to redirect_to_callback_url
     end
 
     context 'when the user has set up TOTP' do
@@ -209,7 +209,7 @@ RSpec.describe 'Using OAuth from an external app' do
           .to change { Doorkeeper::AccessGrant.exists?(application: client_app, resource_owner_id: user.id) }.to(true)
 
         # Upon authorizing, it redirects to the apps' callback URL
-        expect(page).to have_current_path(/\A#{client_app.redirect_uri}/, url: true)
+        expect(page).to redirect_to_callback_url
       end
 
       it 'when rejecting the authorization request' do
@@ -240,7 +240,7 @@ RSpec.describe 'Using OAuth from an external app' do
           .to_not change { Doorkeeper::AccessGrant.exists?(application: client_app, resource_owner_id: user.id) }.from(false)
 
         # Upon denying, it redirects to the apps' callback URL
-        expect(page).to have_current_path(/\A#{client_app.redirect_uri}/, url: true)
+        expect(page).to redirect_to_callback_url
       end
     end
     # TODO: external auth
@@ -259,5 +259,9 @@ RSpec.describe 'Using OAuth from an external app' do
 
   def oauth_deny_text
     I18n.t('doorkeeper.authorizations.buttons.deny')
+  end
+
+  def redirect_to_callback_url
+    have_current_path(/\A#{client_app.redirect_uri}/, url: true)
   end
 end

--- a/spec/system/oauth_spec.rb
+++ b/spec/system/oauth_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Using OAuth from an external app' do
 
       # It grants the app access to the account
       expect { click_on oauth_authorize_text }
-        .to change { Doorkeeper::AccessGrant.exists?(application: client_app, resource_owner_id: user.id) }.to(true)
+        .to change { user_has_grant_with_client_app? }.to(true)
 
       # Upon authorizing, it redirects to the apps' callback URL
       expect(page).to redirect_to_callback_url
@@ -42,7 +42,7 @@ RSpec.describe 'Using OAuth from an external app' do
 
       # It does not grant the app access to the account
       expect { click_on oauth_deny_text }
-        .to_not change { Doorkeeper::AccessGrant.exists?(application: client_app, resource_owner_id: user.id) }.from(false)
+        .to_not change { user_has_grant_with_client_app? }.from(false)
 
       # Upon denying, it redirects to the apps' callback URL
       expect(page).to redirect_to_callback_url
@@ -149,7 +149,7 @@ RSpec.describe 'Using OAuth from an external app' do
 
       # It grants the app access to the account
       expect { click_on oauth_authorize_text }
-        .to change { Doorkeeper::AccessGrant.exists?(application: client_app, resource_owner_id: user.id) }.to(true)
+        .to change { user_has_grant_with_client_app? }.to(true)
 
       # Upon authorizing, it redirects to the apps' callback URL
       expect(page).to redirect_to_callback_url
@@ -172,7 +172,7 @@ RSpec.describe 'Using OAuth from an external app' do
 
       # It does not grant the app access to the account
       expect { click_on oauth_deny_text }
-        .to_not change { Doorkeeper::AccessGrant.exists?(application: client_app, resource_owner_id: user.id) }.from(false)
+        .to_not change { user_has_grant_with_client_app? }.from(false)
 
       # Upon denying, it redirects to the apps' callback URL
       expect(page).to redirect_to_callback_url
@@ -206,7 +206,7 @@ RSpec.describe 'Using OAuth from an external app' do
 
         # It grants the app access to the account
         expect { click_on oauth_authorize_text }
-          .to change { Doorkeeper::AccessGrant.exists?(application: client_app, resource_owner_id: user.id) }.to(true)
+          .to change { user_has_grant_with_client_app? }.to(true)
 
         # Upon authorizing, it redirects to the apps' callback URL
         expect(page).to redirect_to_callback_url
@@ -237,7 +237,7 @@ RSpec.describe 'Using OAuth from an external app' do
 
         # It does not grant the app access to the account
         expect { click_on oauth_deny_text }
-          .to_not change { Doorkeeper::AccessGrant.exists?(application: client_app, resource_owner_id: user.id) }.from(false)
+          .to_not change { user_has_grant_with_client_app? }.from(false)
 
         # Upon denying, it redirects to the apps' callback URL
         expect(page).to redirect_to_callback_url
@@ -263,5 +263,13 @@ RSpec.describe 'Using OAuth from an external app' do
 
   def redirect_to_callback_url
     have_current_path(/\A#{client_app.redirect_uri}/, url: true)
+  end
+
+  def user_has_grant_with_client_app?
+    Doorkeeper::AccessGrant
+      .exists?(
+        application: client_app,
+        resource_owner_id: user.id
+      )
   end
 end

--- a/spec/system/oauth_spec.rb
+++ b/spec/system/oauth_spec.rb
@@ -133,7 +133,6 @@ RSpec.describe 'Using OAuth from an external app' do
     end
 
     it 'when accepting the authorization request' do
-      params = { client_id: client_app.uid, response_type: 'code', redirect_uri: client_app.redirect_uri, scope: 'read' }
       visit "/oauth/authorize?#{params.to_query}"
 
       # It presents the user with a log-in page
@@ -156,7 +155,6 @@ RSpec.describe 'Using OAuth from an external app' do
     end
 
     it 'when rejecting the authorization request' do
-      params = { client_id: client_app.uid, response_type: 'code', redirect_uri: client_app.redirect_uri, scope: 'read' }
       visit "/oauth/authorize?#{params.to_query}"
 
       # It presents the user with a log-in page
@@ -182,7 +180,6 @@ RSpec.describe 'Using OAuth from an external app' do
       let(:user) { Fabricate(:user, email: email, password: password, otp_required_for_login: true, otp_secret: User.generate_otp_secret) }
 
       it 'when accepting the authorization request' do
-        params = { client_id: client_app.uid, response_type: 'code', redirect_uri: client_app.redirect_uri, scope: 'read' }
         visit "/oauth/authorize?#{params.to_query}"
 
         # It presents the user with a log-in page
@@ -213,7 +210,6 @@ RSpec.describe 'Using OAuth from an external app' do
       end
 
       it 'when rejecting the authorization request' do
-        params = { client_id: client_app.uid, response_type: 'code', redirect_uri: client_app.redirect_uri, scope: 'read' }
         visit "/oauth/authorize?#{params.to_query}"
 
         # It presents the user with a log-in page


### PR DESCRIPTION
There's a TODO in here about adding coverage for external auth, which I was going to attempt, but noticed some cleanup tasks first...

- Pull out DRY/wrapper methods for the accept/reject oauth i18n text
- Same for the callback redirect check
- Same for the user/client grant exists query
- For all the "did this action lead to grant creation" checks, put them into expect/change blocks so that we are more confident in checking for the result of the action rather than pre-existing scenario
- Remove some local var `params` setup which was repeating the exact values from outer level `let` setup

Hopefully straightforward, but they are in one focused commit at a time if that's easier to review.

Will take pass at the TODO as followup.

Other followup - I left it in for now, but I suspect all/most of the comments spread across this file could be removed as-is, or via slight method/naming changes to make them less needed.