### PR TITLE
Remove unused deprecator configuration

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -96,10 +96,6 @@ module Mastodon
     config.middleware.use Rack::Attack
     config.middleware.use Mastodon::RackMiddleware
 
-    initializer :deprecator do |app|
-      app.deprecators[:mastodon] = ActiveSupport::Deprecation.new('4.3', 'mastodon/mastodon')
-    end
-
     config.before_configuration do
       require 'mastodon/redis_configuration'
       ::REDIS_CONFIGURATION = Mastodon::RedisConfiguration.new


### PR DESCRIPTION
This was added here - https://github.com/mastodon/mastodon/pull/25963/files#diff-6a53425981fa47537d8fba6ddc15777d23faba10334ca1e4f7b555a42cf5016fR5 (example usage) - as part of a rails upgrade. Since then, the usage has been removed.

I've opted to just remove outright here ... but another option would be to more dilligently track down deprecation areas, keep the version bumped, use this feature more as intended, etc (though, in my opinion, the feature makes more sense for libs/gems/etc that have more external dependencies that need to integrate with a deprecation/removal cycle).
