### PR TITLE
Link directly to account notes section from reports index

### DIFF
--- a/app/views/admin/accounts/show.html.haml
+++ b/app/views/admin/accounts/show.html.haml
@@ -55,7 +55,7 @@
 
     %hr.spacer/
 
-  %h3= t 'admin.reports.notes.title'
+  %h3#notes= t 'admin.reports.notes.title'
 
   %p= t 'admin.reports.notes_description_html'
 

--- a/app/views/admin/reports/index.html.haml
+++ b/app/views/admin/reports/index.html.haml
@@ -36,7 +36,7 @@
     .report-card__profile
       = account_link_to target_account, '', path: admin_account_path(target_account.id)
       .report-card__profile__stats
-        = link_to t('admin.reports.account.notes', count: target_account.targeted_moderation_notes.count), admin_account_path(target_account.id)
+        = link_to t('admin.reports.account.notes', count: target_account.targeted_moderation_notes.count), admin_account_path(target_account.id, anchor: :notes)
         %br/
         - if target_account.suspended?
           %span.red= t('admin.accounts.suspended')


### PR DESCRIPTION
There's an existing link here on the username which goes to the account page. This adds an anchor the "notes" link to go to that specific section of the account page.