### PR TITLE
Move non-form button outside `form` on `admin` `reports` page

### DIFF
--- a/app/views/admin/reports/_actions.html.haml
+++ b/app/views/admin/reports/_actions.html.haml
@@ -1,10 +1,10 @@
-= form_with url: preview_admin_report_actions_path(report) do |form|
-  .report-actions
-    .report-actions__item
-      .report-actions__item__button
-        = link_to t('admin.reports.mark_as_resolved'), resolve_admin_report_path(report), method: :post, class: 'button'
-      .report-actions__item__description
-        = t('admin.reports.actions.resolve_description_html')
+.report-actions
+  .report-actions__item
+    .report-actions__item__button
+      = link_to t('admin.reports.mark_as_resolved'), resolve_admin_report_path(report), method: :post, class: 'button'
+    .report-actions__item__description
+      = t('admin.reports.actions.resolve_description_html')
+  = form_with url: preview_admin_report_actions_path(report) do |form|
     - if statuses.any? { |status| (status.with_media? || status.with_preview_card?) && !status.discarded? }
       .report-actions__item
         .report-actions__item__button


### PR DESCRIPTION
Related to https://github.com/mastodon/mastodon/pull/32255

The previous structure here was -- top level `form` element, then a wrapper div with `.report-actions`, and then each button in a `.report-actions__item` wrapper.

The very first button does a POST to immediately resolve the report. The rest of the buttons use their `name` attribute to hit a preview page and control which option will be selected.

The change here is to pull the first button option (resolve report) out of the form entirely, but keep the general `report-actions` and `report-actions__item` markup structure, and keep the remaining buttons inside the form.

This looks visually the same to me, and would open up the first button to be changed to `button_to` in linked PR, without breaking the form again.

Another option would be to totally drop the outer `form`, and convert the internal buttons to `button_to` as well, continuing to use the `name` value to populate the preview page options.