### PR TITLE
Bring icon vertical middle to applications list style

### DIFF
--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -1029,6 +1029,12 @@ a.name-tag,
   color: var(--user-role-accent);
 }
 
+.applications-list {
+  .icon {
+    vertical-align: middle;
+  }
+}
+
 .announcements-list,
 .filters-list {
   border: 1px solid var(--background-border-color);


### PR DESCRIPTION
On this - https://github.com/mastodon/mastodon/pull/32153 - the change was scoped within `.announcements-list` and `.filters-list`, but the webhooks listing view uses `.applications-list` wrapper.

This brings just that change over there as well.

Before

<img width="327" alt="Screenshot 2024-10-07 at 14 51 15" src="https://github.com/user-attachments/assets/3bfca6d4-1051-44cf-b219-15062d48e2ae">

After

<img width="244" alt="Screenshot 2024-10-07 at 14 51 04" src="https://github.com/user-attachments/assets/047340b0-9050-4bf5-afcf-a00429a5f519">

Might be worth an audit at some point to see how much overlap there is between some of these, and consolidate the admin area to (ideally one each!) fewer "table style" and "list style" approaches.