### PR TITLE
Fix source strings being uploaded to crowdin in merge groups

### DIFF
--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -1,7 +1,6 @@
 name: Crowdin / Upload translations
 
 on:
-  merge_group:
   push:
     branches:
       - 'main'


### PR DESCRIPTION
This was running twice on merging to `main` or `stable-*`, once for `push`, and once for `merge-group`, the latter pushing a different branch name and polluting Crowdin.