### PR TITLE
Add coverage for ActivityPub likes/shares endpoints

### DIFF
--- a/spec/requests/activitypub/likes_spec.rb
+++ b/spec/requests/activitypub/likes_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'ActivityPub Likes' do
+  let(:account) { Fabricate(:account) }
+  let(:status) { Fabricate :status, account: account }
+
+  before { Fabricate :favourite, status: status }
+
+  describe 'GET /accounts/:account_username/statuses/:status_id/likes' do
+    it 'returns http success and activity json types and correct items count' do
+      get account_status_likes_path(account, status)
+
+      expect(response)
+        .to have_http_status(200)
+      expect(response.media_type)
+        .to eq 'application/activity+json'
+
+      expect(response.parsed_body)
+        .to include(type: 'Collection')
+        .and include(totalItems: 1)
+    end
+  end
+end

--- a/spec/requests/activitypub/shares_spec.rb
+++ b/spec/requests/activitypub/shares_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'ActivityPub Shares' do
+  let(:account) { Fabricate(:account) }
+  let(:status) { Fabricate :status, account: account }
+
+  before { Fabricate :status, reblog: status }
+
+  describe 'GET /accounts/:account_username/statuses/:status_id/shares' do
+    it 'returns http success and activity json types and correct items count' do
+      get account_status_shares_path(account, status)
+
+      expect(response)
+        .to have_http_status(200)
+      expect(response.media_type)
+        .to eq 'application/activity+json'
+
+      expect(response.parsed_body)
+        .to include(type: 'Collection')
+        .and include(totalItems: 1)
+    end
+  end
+end


### PR DESCRIPTION
Presumably lost in a rebase during https://github.com/mastodon/mastodon/pull/32007

This is the first of the `AP::...` controllers to have request specs, and as such I've done sort of a high level happy path version here. I'll do a round of cleanup/prep on the other ones still in spec/controllers/ before starting to move those (specifically, I think the way we stub signed requests won't move over to request specs, so want to take a pass at that).