### PR TITLE
Reduce factory creation across `spec/workers` examples

### DIFF
--- a/spec/workers/bulk_import_worker_spec.rb
+++ b/spec/workers/bulk_import_worker_spec.rb
@@ -14,13 +14,11 @@ RSpec.describe BulkImportWorker do
       allow(BulkImportService).to receive(:new).and_return(service_double)
     end
 
-    it 'changes the import\'s state as appropriate' do
-      expect { subject.perform(import.id) }.to change { import.reload.state.to_sym }.from(:scheduled).to(:in_progress)
-    end
-
-    it 'calls BulkImportService' do
-      subject.perform(import.id)
-      expect(service_double).to have_received(:call).with(import)
+    it 'changes the state of the bulk import and calls BulkImportService' do
+      expect { subject.perform(import.id) }
+        .to change { import.reload.state.to_sym }.from(:scheduled).to(:in_progress)
+      expect(service_double)
+        .to have_received(:call).with(import)
     end
   end
 end

--- a/spec/workers/publish_announcement_reaction_worker_spec.rb
+++ b/spec/workers/publish_announcement_reaction_worker_spec.rb
@@ -11,22 +11,28 @@ RSpec.describe PublishAnnouncementReactionWorker do
     let(:announcement) { Fabricate(:announcement) }
     let(:name) { 'name value' }
 
-    it 'sends the announcement and name to the service when subscribed' do
-      allow(redis).to receive(:exists?).and_return(true)
-      allow(redis).to receive(:publish)
+    context 'when subscribed' do
+      before { allow(redis).to receive(:exists?).and_return(true) }
 
-      worker.perform(announcement.id, name)
+      it 'sends the announcement and name to the service' do
+        allow(redis).to receive(:publish)
 
-      expect(redis).to have_received(:publish)
+        worker.perform(announcement.id, name)
+
+        expect(redis).to have_received(:publish)
+      end
     end
 
-    it 'does not send the announcement and name to the service when not subscribed' do
-      allow(redis).to receive(:exists?).and_return(false)
-      allow(redis).to receive(:publish)
+    context 'when not subscribed' do
+      before { allow(redis).to receive(:exists?).and_return(false) }
 
-      worker.perform(announcement.id, name)
+      it 'does not send the announcement and name to the service' do
+        allow(redis).to receive(:publish)
 
-      expect(redis).to_not have_received(:publish)
+        worker.perform(announcement.id, name)
+
+        expect(redis).to_not have_received(:publish)
+      end
     end
 
     it 'returns true for non-existent record' do

--- a/spec/workers/publish_scheduled_status_worker_spec.rb
+++ b/spec/workers/publish_scheduled_status_worker_spec.rb
@@ -5,32 +5,30 @@ require 'rails_helper'
 RSpec.describe PublishScheduledStatusWorker do
   subject { described_class.new }
 
-  let(:scheduled_status) { Fabricate(:scheduled_status, params: { text: 'Hello world, future!' }) }
+  let(:scheduled_status) { Fabricate(:scheduled_status, params: { text: text }) }
+  let(:text) { 'Hello world, future!' }
 
   describe 'perform' do
-    before do
-      subject.perform(scheduled_status.id)
-    end
+    before { subject.perform(scheduled_status.id) }
 
     context 'when the account is not disabled' do
-      it 'creates a status' do
-        expect(scheduled_status.account.statuses.first.text).to eq 'Hello world, future!'
-      end
+      it 'creates a new status and removes the scheduled' do
+        expect(scheduled_status.account.statuses.first.text)
+          .to eq 'Hello world, future!'
 
-      it 'removes the scheduled status' do
-        expect(ScheduledStatus.find_by(id: scheduled_status.id)).to be_nil
+        expect { scheduled_status.reload }
+          .to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 
     context 'when the account is disabled' do
       let(:scheduled_status) { Fabricate(:scheduled_status, account: Fabricate(:account, user: Fabricate(:user, disabled: true))) }
 
-      it 'does not create a status' do
-        expect(Status.count).to eq 0
-      end
-
-      it 'removes the scheduled status' do
-        expect(ScheduledStatus.find_by(id: scheduled_status.id)).to be_nil
+      it 'does not create a new status and removes the scheduled status' do
+        expect(Status.count)
+          .to eq 0
+        expect { scheduled_status.reload }
+          .to raise_error(ActiveRecord::RecordNotFound)
       end
     end
   end

--- a/spec/workers/unfollow_follow_worker_spec.rb
+++ b/spec/workers/unfollow_follow_worker_spec.rb
@@ -18,15 +18,13 @@ RSpec.describe UnfollowFollowWorker do
     let(:show_reblogs) { true }
 
     describe 'perform' do
-      it 'unfollows source account and follows target account' do
+      it 'unfollows source account and follows target account and preserves show_reblogs' do
         subject.perform(local_follower.id, source_account.id, target_account.id)
+
         expect(local_follower.following?(source_account)).to be false
         expect(local_follower.following?(target_account)).to be true
-      end
 
-      it 'preserves show_reblogs' do
-        subject.perform(local_follower.id, source_account.id, target_account.id)
-        expect(Follow.find_by(account: local_follower, target_account: target_account).show_reblogs?).to be show_reblogs
+        expect(follow_record.show_reblogs?).to be show_reblogs
       end
     end
   end
@@ -35,16 +33,18 @@ RSpec.describe UnfollowFollowWorker do
     let(:show_reblogs) { false }
 
     describe 'perform' do
-      it 'unfollows source account and follows target account' do
+      it 'unfollows source account and follows target account and preserves show_reblogs' do
         subject.perform(local_follower.id, source_account.id, target_account.id)
+
         expect(local_follower.following?(source_account)).to be false
         expect(local_follower.following?(target_account)).to be true
-      end
 
-      it 'preserves show_reblogs' do
-        subject.perform(local_follower.id, source_account.id, target_account.id)
-        expect(Follow.find_by(account: local_follower, target_account: target_account).show_reblogs?).to be show_reblogs
+        expect(follow_record.show_reblogs?).to be show_reblogs
       end
     end
+  end
+
+  def follow_record
+    Follow.find_by(account: local_follower, target_account: target_account)
   end
 end


### PR DESCRIPTION
Does not contain any of https://github.com/mastodon/mastodon/pull/32311 but handles some other reductions across spec/workers.

Net change is ~1115 factories before to ~1050 after.

Similar to the spec/services one, there's some small element of adding some contexts or other naming/tidying, but for the most part its just combining assertions of same-setup/execution to use fewer factories.
