### PR TITLE
Stagger backup ID sequence in parallel runs

### DIFF
--- a/spec/support/parallel_sequences.rb
+++ b/spec/support/parallel_sequences.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+if ENV['TEST_ENV_NUMBER'].present?
+  starter = [ENV['TEST_ENV_NUMBER'].to_i * 1_000_000, 1].max
+  ActiveRecord::Base.connection.execute <<~SQL.squish
+    ALTER SEQUENCE backups_id_seq RESTART WITH #{starter}
+  SQL
+end


### PR DESCRIPTION
Intermittent failures like - https://github.com/mastodon/mastodon/actions/runs/11162830529/job/31028523540

My guess about what is happening on these is that since the parallel test DBs are all separate from each other, it's easy to wind up with the same integer ID values as they increment up from 1. If they happen to be running related examples at same time, and one of them cleans up or otherwise processes/changes things on the filesystem (which is NOT separated) it could lead to issues like this.

That said, I can't replicate this locally, and this is sort of a guess about the issue.

Just doing this for backups to start, but we may want to do all the tables which potentially create ID-numbered FS paths.