### PR TITLE
Use `ubuntu-latest` for all GH actions runners

### DIFF
--- a/.github/workflows/check-i18n.yml
+++ b/.github/workflows/check-i18n.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   check-i18n:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -175,7 +175,7 @@ jobs:
 
   test-libvips:
     name: Libvips tests
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     needs:
       - build


### PR DESCRIPTION
I believe the ubuntu 24.04 image is in process of becoming default (staggered roll out maybe?).

Opening this to see what breaks, and can periodically trigger until we're good.