### PR TITLE
Fix only the first paragraph being displayed in some notifications

### DIFF
--- a/app/javascript/mastodon/features/notifications_v2/components/embedded_status_content.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/components/embedded_status_content.tsx
@@ -87,7 +87,7 @@ export const EmbeddedStatusContent: React.FC<{
       className={className}
       ref={handleContentRef}
       lang={language}
-      dangerouslySetInnerHTML={{ __html: content }}
+      dangerouslySetInnerHTML={{ __html: content.replace(/<\/p><p>/g, '\n\n') }}
     />
   );
 };

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -10817,14 +10817,6 @@ noscript {
       max-height: 4 * 22px;
       overflow: hidden;
 
-      p {
-        display: none;
-
-        &:first-child {
-          display: initial;
-        }
-      }
-
       p,
       a {
         color: inherit;


### PR DESCRIPTION
Fixes #32196

This rewrites the contents to merge paragraphs into one. Indeed, without this, the existing `max-height` kicks in earlier than `-webkit-line-clamp` because of the one-line margin between paragraphs not actually being a line of text, preventing proper ellipsizing.

The downsides of this approach are that:
- it's not future proof, if we end up having other non-textual spacing (e.g. lists)
- it requires rewriting HTML, which can be a bit icky

An alternative without these downsides is #32348

## Before

![image](https://github.com/user-attachments/assets/2058e920-a11c-4ba8-84c9-1c426b47ff99)

## After

![image](https://github.com/user-attachments/assets/c4cea343-3687-42ba-9991-32086003afb3)