### PR TITLE
 Fix only the first paragraph being displayed in some notifications

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -10814,12 +10814,16 @@ noscript {
       color: $darker-text-color;
       -webkit-line-clamp: 4;
       -webkit-box-orient: vertical;
-      max-height: 4 * 22px;
+      max-height: none;
       overflow: hidden;
 
       p,
       a {
         color: inherit;
+      }
+
+      p {
+        margin-bottom: 8px;
       }
     }
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -10817,14 +10817,6 @@ noscript {
       max-height: 4 * 22px;
       overflow: hidden;
 
-      p {
-        display: none;
-
-        &:first-child {
-          display: initial;
-        }
-      }
-
       p,
       a {
         color: inherit;


### PR DESCRIPTION
Fixes #32196

Alternative to #32347 which does not rewrite the HTML. Unlike #32347, it is future proof, but it is a little less consistent, can result in slightly higher notifications, and breaks ellipsizing on Safari when multiple paragraphs are involved.

## Before

![image](https://github.com/user-attachments/assets/69968797-f8f0-4d0e-8ca0-bbcdee82a44b)

## After

![image](https://github.com/user-attachments/assets/e1a11b65-4762-4e5a-904b-7a0ad47a7e88)