### PR TITLE
Fix `latest` tag for 4.3 docker image builds

### DIFF
--- a/.github/workflows/build-releases.yml
+++ b/.github/workflows/build-releases.yml
@@ -23,7 +23,7 @@ jobs:
       # Only tag with latest when ran against the latest stable branch
       # This needs to be updated after each minor version release
       flavor: |
-        latest=${{ startsWith(github.ref, 'refs/tags/v4.2.') }}
+        latest=${{ startsWith(github.ref, 'refs/tags/v4.3.') }}
       tags: |
         type=pep440,pattern={{raw}}
         type=pep440,pattern=v{{major}}.{{minor}}


### PR DESCRIPTION
I'm not too sure comparing the branch name here really is useful though.