### PR TITLE
Avoid double icon stack in prefs sidebar

### DIFF
--- a/config/navigation.rb
+++ b/config/navigation.rb
@@ -13,7 +13,7 @@ SimpleNavigation::Configuration.run do |navigation|
     n.item :preferences, safe_join([material_symbol('settings'), t('settings.preferences')]), settings_preferences_path, if: -> { current_user.functional? && !self_destruct } do |s|
       s.item :appearance, safe_join([material_symbol('computer'), t('settings.appearance')]), settings_preferences_appearance_path
       s.item :notifications, safe_join([material_symbol('mail'), t('settings.notifications')]), settings_preferences_notifications_path
-      s.item :other, safe_join([material_symbol('settings'), t('preferences.other')]), settings_preferences_other_path
+      s.item :other, safe_join([material_symbol('tune'), t('preferences.other')]), settings_preferences_other_path
     end
 
     n.item :relationships, safe_join([material_symbol('groups'), t('settings.relationships')]), relationships_path, if: -> { current_user.functional? && !self_destruct } do |s|

--- a/config/navigation.rb
+++ b/config/navigation.rb
@@ -61,7 +61,7 @@ SimpleNavigation::Configuration.run do |navigation|
 
     n.item :admin, safe_join([material_symbol('manufacturing'), t('admin.title')]), nil, if: -> { current_user.can?(:view_dashboard, :manage_settings, :manage_rules, :manage_announcements, :manage_custom_emojis, :manage_webhooks, :manage_federation) && !self_destruct } do |s|
       s.item :dashboard, safe_join([material_symbol('speed'), t('admin.dashboard.title')]), admin_dashboard_path, if: -> { current_user.can?(:view_dashboard) }
-      s.item :settings, safe_join([material_symbol('manufacturing'), t('admin.settings.title')]), admin_settings_path, if: -> { current_user.can?(:manage_settings) }, highlights_on: %r{/admin/settings}
+      s.item :settings, safe_join([material_symbol('tune'), t('admin.settings.title')]), admin_settings_path, if: -> { current_user.can?(:manage_settings) }, highlights_on: %r{/admin/settings}
       s.item :rules, safe_join([material_symbol('gavel'), t('admin.rules.title')]), admin_rules_path, highlights_on: %r{/admin/rules}, if: -> { current_user.can?(:manage_rules) }
       s.item :warning_presets, safe_join([material_symbol('warning'), t('admin.warning_presets.title')]), admin_warning_presets_path, highlights_on: %r{/admin/warning_presets}, if: -> { current_user.can?(:manage_settings) }
       s.item :roles, safe_join([material_symbol('contact_mail'), t('admin.roles.title')]), admin_roles_path, highlights_on: %r{/admin/roles}, if: -> { current_user.can?(:manage_roles) }


### PR DESCRIPTION
Same idea as https://github.com/mastodon/mastodon/pull/32201

For this one, before:

<img width="245" alt="Screenshot 2024-10-09 at 09 51 52" src="https://github.com/user-attachments/assets/2c0ebea4-f183-493c-b7ff-a958c5fa5934">

After:

<img width="268" alt="Screenshot 2024-10-09 at 09 53 15" src="https://github.com/user-attachments/assets/46de1074-571d-4f6d-83c5-93886e0b4017">

I chose "tune" here entirely for "its not the same as the other one" and "we already had it" reasons. Open to other ideas.

Related -- thoughts on renaming "Other" here to "Posting" or "Visibility" or something?

I could also see some mix of:

- Move the "group boosts" (at top of Other now) to the "appearance" group
- Rename "Email notifications" to just "Notifications" and move the group boosts thing there
- Add a "Languages" group here and put the "Posting language" and "filter languages" things in it, leaving "posting privacy" and "mark media" behind in other (which could be renamed)

Also related -- the options in the "posting privacy" are kind of large with their hints in there ... could see converting this to a radio with bolded main options and inline hints, similar to other views.