### PR TITLE
Drop support for ruby 3.1

### DIFF
--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -124,7 +124,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '3.1'
           - '3.2'
           - '.ruby-version'
     steps:
@@ -226,7 +225,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '3.1'
           - '3.2'
           - '.ruby-version'
     steps:
@@ -305,7 +303,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '3.1'
           - '3.2'
           - '.ruby-version'
 
@@ -422,7 +419,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '3.1'
           - '3.2'
           - '.ruby-version'
         search-image:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ AllCops:
     - lib/mastodon/migration_helpers.rb
   ExtraDetails: true
   NewCops: enable
-  TargetRubyVersion: 3.1 # Oldest supported ruby version
+  TargetRubyVersion: 3.2 # Oldest supported ruby version
 
 inherit_from:
   - .rubocop/layout.yml

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
-ruby '>= 3.1.0'
+ruby '>= 3.2.0'
 
 gem 'propshaft'
 gem 'puma', '~> 6.3'

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Mastodon acts as an OAuth2 provider, so 3rd party apps can use the REST and Stre
 
 - **PostgreSQL** 12+
 - **Redis** 4+
-- **Ruby** 3.1+
+- **Ruby** 3.2+
 - **Node.js** 18+
 
 The repository includes deployment configurations for **Docker and docker-compose** as well as specific platforms like **Heroku**, and **Scalingo**. For Helm charts, reference the [mastodon/chart repository](https://github.com/mastodon/chart). The [**standalone** installation guide](https://docs.joinmastodon.org/admin/install/) is available in the documentation.

--- a/app/controllers/activitypub/outboxes_controller.rb
+++ b/app/controllers/activitypub/outboxes_controller.rb
@@ -41,11 +41,11 @@ class ActivityPub::OutboxesController < ActivityPub::BaseController
     end
   end
 
-  def outbox_url(**kwargs)
+  def outbox_url(**)
     if params[:account_username].present?
-      account_outbox_url(@account, **kwargs)
+      account_outbox_url(@account, **)
     else
-      instance_actor_outbox_url(**kwargs)
+      instance_actor_outbox_url(**)
     end
   end
 

--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -106,8 +106,8 @@ class Api::V1::AccountsController < Api::BaseController
     render json: { error: I18n.t('accounts.self_follow_error') }, status: 403 if current_user.account.id == @account.id
   end
 
-  def relationships(**options)
-    AccountRelationshipsPresenter.new([@account], current_user.account_id, **options)
+  def relationships(**)
+    AccountRelationshipsPresenter.new([@account], current_user.account_id, **)
   end
 
   def account_ids

--- a/app/controllers/api/v1/follow_requests_controller.rb
+++ b/app/controllers/api/v1/follow_requests_controller.rb
@@ -28,8 +28,8 @@ class Api::V1::FollowRequestsController < Api::BaseController
     @account ||= Account.find(params[:id])
   end
 
-  def relationships(**options)
-    AccountRelationshipsPresenter.new([account], current_user.account_id, **options)
+  def relationships(**)
+    AccountRelationshipsPresenter.new([account], current_user.account_id, **)
   end
 
   def load_accounts

--- a/app/helpers/media_component_helper.rb
+++ b/app/helpers/media_component_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module MediaComponentHelper
-  def render_video_component(status, **options)
+  def render_video_component(status, **)
     video = status.ordered_media_attachments.first
 
     meta = video.file.meta || {}
@@ -18,14 +18,14 @@ module MediaComponentHelper
       media: [
         serialize_media_attachment(video),
       ].as_json,
-    }.merge(**options)
+    }.merge(**)
 
     react_component :video, component_params do
       render partial: 'statuses/attachment_list', locals: { attachments: status.ordered_media_attachments }
     end
   end
 
-  def render_audio_component(status, **options)
+  def render_audio_component(status, **)
     audio = status.ordered_media_attachments.first
 
     meta = audio.file.meta || {}
@@ -38,19 +38,19 @@ module MediaComponentHelper
       foregroundColor: meta.dig('colors', 'foreground'),
       accentColor: meta.dig('colors', 'accent'),
       duration: meta.dig('original', 'duration'),
-    }.merge(**options)
+    }.merge(**)
 
     react_component :audio, component_params do
       render partial: 'statuses/attachment_list', locals: { attachments: status.ordered_media_attachments }
     end
   end
 
-  def render_media_gallery_component(status, **options)
+  def render_media_gallery_component(status, **)
     component_params = {
       sensitive: sensitive_viewer?(status, current_account),
       autoplay: prefers_autoplay?,
       media: status.ordered_media_attachments.map { |a| serialize_media_attachment(a).as_json },
-    }.merge(**options)
+    }.merge(**)
 
     react_component :media_gallery, component_params do
       render partial: 'statuses/attachment_list', locals: { attachments: status.ordered_media_attachments }

--- a/app/helpers/routing_helper.rb
+++ b/app/helpers/routing_helper.rb
@@ -14,8 +14,8 @@ module RoutingHelper
     end
   end
 
-  def full_asset_url(source, **options)
-    source = ActionController::Base.helpers.asset_url(source, **options) unless use_storage?
+  def full_asset_url(source, **)
+    source = ActionController::Base.helpers.asset_url(source, **) unless use_storage?
 
     URI.join(asset_host, source).to_s
   end
@@ -24,12 +24,12 @@ module RoutingHelper
     Rails.configuration.action_controller.asset_host || root_url
   end
 
-  def frontend_asset_path(source, **options)
-    asset_pack_path("media/#{source}", **options)
+  def frontend_asset_path(source, **)
+    asset_pack_path("media/#{source}", **)
   end
 
-  def frontend_asset_url(source, **options)
-    full_asset_url(frontend_asset_path(source, **options))
+  def frontend_asset_url(source, **)
+    full_asset_url(frontend_asset_path(source, **))
   end
 
   def use_storage?

--- a/app/lib/activitypub/activity.rb
+++ b/app/lib/activitypub/activity.rb
@@ -20,9 +20,9 @@ class ActivityPub::Activity
   end
 
   class << self
-    def factory(json, account, **options)
+    def factory(json, account, **)
       @json = json
-      klass&.new(json, account, **options)
+      klass&.new(json, account, **)
     end
 
     private

--- a/app/lib/rss/element.rb
+++ b/app/lib/rss/element.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class RSS::Element
-  def self.with(*args, &block)
-    new(*args).tap(&block).to_element
+  def self.with(*, &block)
+    new(*).tap(&block).to_element
   end
 
   def create_element(name, content = nil)

--- a/app/lib/translation_service/deepl.rb
+++ b/app/lib/translation_service/deepl.rb
@@ -42,8 +42,8 @@ class TranslationService::DeepL < TranslationService
     subtags.join('-')
   end
 
-  def request(verb, path, **options)
-    req = Request.new(verb, "#{base_url}#{path}", **options)
+  def request(verb, path, **)
+    req = Request.new(verb, "#{base_url}#{path}", **)
     req.add_headers(Authorization: "DeepL-Auth-Key #{@api_key}")
     req.perform do |res|
       case res.code

--- a/app/lib/translation_service/libre_translate.rb
+++ b/app/lib/translation_service/libre_translate.rb
@@ -27,8 +27,8 @@ class TranslationService::LibreTranslate < TranslationService
 
   private
 
-  def request(verb, path, **options)
-    req = Request.new(verb, "#{@base_url}#{path}", allow_local: true, **options)
+  def request(verb, path, **)
+    req = Request.new(verb, "#{@base_url}#{path}", allow_local: true, **)
     req.add_headers('Content-Type': 'application/json')
     req.perform do |res|
       case res.code

--- a/app/models/concerns/status/snapshot_concern.rb
+++ b/app/models/concerns/status/snapshot_concern.rb
@@ -29,7 +29,7 @@ module Status::SnapshotConcern
     )
   end
 
-  def snapshot!(**options)
-    build_snapshot(**options).save!
+  def snapshot!(**)
+    build_snapshot(**).save!
   end
 end

--- a/app/models/session_activation.rb
+++ b/app/models/session_activation.rb
@@ -35,8 +35,8 @@ class SessionActivation < ApplicationRecord
       id && exists?(session_id: id)
     end
 
-    def activate(**options)
-      activation = create!(**options)
+    def activate(**)
+      activation = create!(**)
       purge_old
       activation
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -405,8 +405,8 @@ class User < ApplicationRecord
     @pending_devise_notifications ||= []
   end
 
-  def render_and_send_devise_message(notification, *args, **kwargs)
-    devise_mailer.send(notification, self, *args, **kwargs).deliver_later
+  def render_and_send_devise_message(notification, *, **)
+    devise_mailer.send(notification, self, *, **).deliver_later
   end
 
   def set_approved

--- a/lib/mastodon/cli/accounts.rb
+++ b/lib/mastodon/cli/accounts.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'set'
 require_relative 'base'
 
 module Mastodon::CLI

--- a/spec/support/command_line_helpers.rb
+++ b/spec/support/command_line_helpers.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module CommandLineHelpers
-  def output_results(*args)
+  def output_results(*)
     output(
-      include(*args)
+      include(*)
     ).to_stdout
   end
 end


### PR DESCRIPTION
Still not EOL for a bit, but opening now to work out any concerns.

Related to https://github.com/mastodon/mastodon/pull/32357 in that Rails 8.0 will require 3.2+

Related to https://github.com/mastodon/mastodon/pull/32332 in that they are both ruby versions, which is nice.

On a side note here - do we have any idea what portion of instance operators are stuck in a "my linux distribution has an outdated ruby version and I can't change it" sort of scenario? My understanding is that this persona is the main reason we support any old versions at all?

It seems like if the "I'm running from the Docker image" or "I'm copy and pasting `rbenv` commands" personas were ever all/most of the deployments, we could safely require one modern/current/latest version with each release? (which seems desirable from many perspectives - support, maintenance, performance, developer, CI, etc)