### PR TITLE
Always validate `inbox_url` presence on Relay

### DIFF
--- a/app/models/relay.rb
+++ b/app/models/relay.rb
@@ -13,8 +13,7 @@
 #
 
 class Relay < ApplicationRecord
-  validates :inbox_url, presence: true
-  validates :inbox_url, uniqueness: true, url: true, if: :will_save_change_to_inbox_url?
+  validates :inbox_url, presence: true, uniqueness: true, url: true # rubocop:disable Rails/UniqueValidationWithoutIndex
 
   enum :state, { idle: 0, pending: 1, accepted: 2, rejected: 3 }
 

--- a/app/models/relay.rb
+++ b/app/models/relay.rb
@@ -13,7 +13,8 @@
 #
 
 class Relay < ApplicationRecord
-  validates :inbox_url, presence: true, uniqueness: true, url: true, if: :will_save_change_to_inbox_url?
+  validates :inbox_url, presence: true
+  validates :inbox_url, uniqueness: true, url: true, if: :will_save_change_to_inbox_url?
 
   enum :state, { idle: 0, pending: 1, accepted: 2, rejected: 3 }
 


### PR DESCRIPTION
Background: https://github.com/mastodon/mastodon/pull/32118#issuecomment-2380105381

Before -- form does not reflect that presence is required, and you can save relay with empty value:

<img width="523" alt="Screenshot 2024-10-09 at 13 05 18" src="https://github.com/user-attachments/assets/3d4c9cbf-3b2b-413c-af64-5019672377a1">
<img width="710" alt="Screenshot 2024-10-09 at 13 05 22" src="https://github.com/user-attachments/assets/bfb0e548-ddf4-4fc7-93dd-9143518266c7">

After -- form reflects on presence (note red asterisk) and errors when trying to save w/out value:

<img width="529" alt="Screenshot 2024-10-09 at 13 04 28" src="https://github.com/user-attachments/assets/5dd91ccb-d993-4941-b506-1142ae80b175">
<img width="603" alt="Screenshot 2024-10-09 at 13 04 32" src="https://github.com/user-attachments/assets/e5653759-89b3-44f3-8cf9-26fc473eb899">

As noted in linked comment, I don't fully understand the motivation on the conditional here.
