### PR TITLE
Add size constraint for header preview (matches avatar)

### DIFF
--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -367,6 +367,12 @@ code {
         height: 90px;
         object-fit: cover;
       }
+
+      &#account_header-preview {
+        width: 300px;
+        height: 100px;
+        object-fit: cover;
+      }
     }
   }
 


### PR DESCRIPTION
From profile page uploading avatar/header images, the avatar image has an existing style constraint which keeps the size smaller, matches ratio of processed image output, and adds object-fit, but the header image does not. This adds those for header.

Before:

<img width="939" alt="Screenshot 2024-10-09 at 13 35 08" src="https://github.com/user-attachments/assets/7dd4e2ad-c0be-4b42-bd9b-17cdad36b3f0">

After:

<img width="924" alt="Screenshot 2024-10-09 at 13 53 40" src="https://github.com/user-attachments/assets/db67fad7-49e0-4423-9f01-4ec8d8d054f8">

The `cover` with the sizes actually does a reasonable job of matching what the output winds up being, in some limited testing.