### PR TITLE
Add `mail_header_image` helper to wrap email header icons

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -120,6 +120,10 @@ module ApplicationHelper
     inline_svg_tag 'check.svg'
   end
 
+  def mail_header_image(icon = 'email.png')
+    frontend_asset_url("images/mailer-new/heading/#{icon}")
+  end
+
   def interrelationships_icon(relationships, account_id)
     if relationships.following[account_id] && relationships.followed_by[account_id]
       material_symbol('sync_alt', title: I18n.t('relationships.mutual'), class: 'active passive')

--- a/app/views/notification_mailer/favourite.html.haml
+++ b/app/views/notification_mailer/favourite.html.haml
@@ -1,6 +1,6 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           image_url: frontend_asset_url('images/mailer-new/heading/favorite.png'),
+           image_url: mail_header_image('favorite.png'),
            subtitle: t('notification_mailer.favourite.body', name: @account.pretty_acct),
            title: t('notification_mailer.favourite.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }

--- a/app/views/notification_mailer/follow.html.haml
+++ b/app/views/notification_mailer/follow.html.haml
@@ -1,6 +1,6 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           image_url: frontend_asset_url('images/mailer-new/heading/user.png'),
+           image_url: mail_header_image('user.png'),
            subtitle: t('notification_mailer.follow.body', name: @account.pretty_acct),
            title: t('notification_mailer.follow.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }

--- a/app/views/notification_mailer/follow_request.html.haml
+++ b/app/views/notification_mailer/follow_request.html.haml
@@ -1,6 +1,6 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           image_url: frontend_asset_url('images/mailer-new/heading/follow.png'),
+           image_url: mail_header_image('follow.png'),
            subtitle: t('notification_mailer.follow_request.body', name: @account.pretty_acct),
            title: t('notification_mailer.follow_request.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }

--- a/app/views/notification_mailer/mention.html.haml
+++ b/app/views/notification_mailer/mention.html.haml
@@ -1,6 +1,6 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           image_url: frontend_asset_url('images/mailer-new/heading/mention.png'),
+           image_url: mail_header_image('mention.png'),
            subtitle: t('notification_mailer.mention.body', name: @status.account.pretty_acct),
            title: t('notification_mailer.mention.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }

--- a/app/views/notification_mailer/reblog.html.haml
+++ b/app/views/notification_mailer/reblog.html.haml
@@ -1,6 +1,6 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           image_url: frontend_asset_url('images/mailer-new/heading/boost.png'),
+           image_url: mail_header_image('boost.png'),
            subtitle: t('notification_mailer.reblog.body', name: @account.pretty_acct),
            title: t('notification_mailer.reblog.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }

--- a/app/views/user_mailer/appeal_approved.html.haml
+++ b/app/views/user_mailer/appeal_approved.html.haml
@@ -1,6 +1,6 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           image_url: frontend_asset_url('images/mailer-new/heading/appeal-approved.png'),
+           image_url: mail_header_image('appeal-approved.png'),
            subtitle: t('user_mailer.appeal_approved.subtitle'),
            title: t('user_mailer.appeal_approved.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }

--- a/app/views/user_mailer/appeal_rejected.html.haml
+++ b/app/views/user_mailer/appeal_rejected.html.haml
@@ -1,6 +1,6 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           image_url: frontend_asset_url('images/mailer-new/heading/appeal-rejected.png'),
+           image_url: mail_header_image('appeal-rejected.png'),
            subtitle: t('user_mailer.appeal_rejected.subtitle'),
            title: t('user_mailer.appeal_rejected.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }

--- a/app/views/user_mailer/backup_ready.html.haml
+++ b/app/views/user_mailer/backup_ready.html.haml
@@ -1,6 +1,6 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           image_url: frontend_asset_url('images/mailer-new/heading/archive.png'),
+           image_url: mail_header_image('archive.png'),
            subtitle: t('user_mailer.backup_ready.explanation'),
            title: t('user_mailer.backup_ready.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }

--- a/app/views/user_mailer/confirmation_instructions.html.haml
+++ b/app/views/user_mailer/confirmation_instructions.html.haml
@@ -1,6 +1,6 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           image_url: frontend_asset_url('images/mailer-new/heading/email.png'),
+           image_url: mail_header_image('email.png'),
            title: t('devise.mailer.confirmation_instructions.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr

--- a/app/views/user_mailer/email_changed.html.haml
+++ b/app/views/user_mailer/email_changed.html.haml
@@ -1,6 +1,6 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           image_url: frontend_asset_url('images/mailer-new/heading/email.png'),
+           image_url: mail_header_image('email.png'),
            subtitle: t('devise.mailer.email_changed.explanation'),
            title: t('devise.mailer.email_changed.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }

--- a/app/views/user_mailer/failed_2fa.html.haml
+++ b/app/views/user_mailer/failed_2fa.html.haml
@@ -1,6 +1,6 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           image_url: frontend_asset_url('images/mailer-new/heading/login.png'),
+           image_url: mail_header_image('login.png'),
            subtitle: t('user_mailer.failed_2fa.explanation'),
            title: t('user_mailer.failed_2fa.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }

--- a/app/views/user_mailer/password_change.html.haml
+++ b/app/views/user_mailer/password_change.html.haml
@@ -1,6 +1,6 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           image_url: frontend_asset_url('images/mailer-new/heading/password.png'),
+           image_url: mail_header_image('password.png'),
            subtitle: t('devise.mailer.password_change.explanation'),
            title: t('devise.mailer.password_change.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }

--- a/app/views/user_mailer/reconfirmation_instructions.html.haml
+++ b/app/views/user_mailer/reconfirmation_instructions.html.haml
@@ -1,6 +1,6 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           image_url: frontend_asset_url('images/mailer-new/heading/email.png'),
+           image_url: mail_header_image('email.png'),
            title: t('devise.mailer.reconfirmation_instructions.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr

--- a/app/views/user_mailer/reset_password_instructions.html.haml
+++ b/app/views/user_mailer/reset_password_instructions.html.haml
@@ -1,6 +1,6 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           image_url: frontend_asset_url('images/mailer-new/heading/password.png'),
+           image_url: mail_header_image('password.png'),
            subtitle: t('devise.mailer.reset_password_instructions.explanation'),
            title: t('devise.mailer.reset_password_instructions.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }

--- a/app/views/user_mailer/suspicious_sign_in.html.haml
+++ b/app/views/user_mailer/suspicious_sign_in.html.haml
@@ -1,6 +1,6 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           image_url: frontend_asset_url('images/mailer-new/heading/login.png'),
+           image_url: mail_header_image('login.png'),
            subtitle: t('user_mailer.suspicious_sign_in.explanation'),
            title: t('user_mailer.suspicious_sign_in.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }

--- a/app/views/user_mailer/two_factor_disabled.html.haml
+++ b/app/views/user_mailer/two_factor_disabled.html.haml
@@ -1,6 +1,6 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           image_url: frontend_asset_url('images/mailer-new/heading/2fa-disabled.png'),
+           image_url: mail_header_image('2fa-disabled.png'),
            subtitle: t('devise.mailer.two_factor_disabled.subtitle'),
            title: t('devise.mailer.two_factor_disabled.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }

--- a/app/views/user_mailer/two_factor_enabled.html.haml
+++ b/app/views/user_mailer/two_factor_enabled.html.haml
@@ -1,6 +1,6 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           image_url: frontend_asset_url('images/mailer-new/heading/2fa-enabled.png'),
+           image_url: mail_header_image('2fa-enabled.png'),
            subtitle: t('devise.mailer.two_factor_enabled.subtitle'),
            title: t('devise.mailer.two_factor_enabled.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }

--- a/app/views/user_mailer/two_factor_recovery_codes_changed.html.haml
+++ b/app/views/user_mailer/two_factor_recovery_codes_changed.html.haml
@@ -1,6 +1,6 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           image_url: frontend_asset_url('images/mailer-new/heading/2fa-recovery.png'),
+           image_url: mail_header_image('2fa-recovery.png'),
            subtitle: t('devise.mailer.two_factor_recovery_codes_changed.subtitle'),
            title: t('devise.mailer.two_factor_recovery_codes_changed.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }

--- a/app/views/user_mailer/warning.html.haml
+++ b/app/views/user_mailer/warning.html.haml
@@ -1,6 +1,6 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           image_url: frontend_asset_url('images/mailer-new/heading/warning.png'),
+           image_url: mail_header_image('warning.png'),
            title: t("user_mailer.warning.title.#{@warning.action}")
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr

--- a/app/views/user_mailer/webauthn_credential_added.html.haml
+++ b/app/views/user_mailer/webauthn_credential_added.html.haml
@@ -1,6 +1,6 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           image_url: frontend_asset_url('images/mailer-new/heading/key-added.png'),
+           image_url: mail_header_image('key-added.png'),
            subtitle: t('devise.mailer.webauthn_credential.added.explanation'),
            title: t('devise.mailer.webauthn_credential.added.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }

--- a/app/views/user_mailer/webauthn_credential_deleted.html.haml
+++ b/app/views/user_mailer/webauthn_credential_deleted.html.haml
@@ -1,6 +1,6 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           image_url: frontend_asset_url('images/mailer-new/heading/key-deleted.png'),
+           image_url: mail_header_image('key-deleted.png'),
            subtitle: t('devise.mailer.webauthn_credential.deleted.explanation'),
            title: t('devise.mailer.webauthn_credential.deleted.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }

--- a/app/views/user_mailer/webauthn_disabled.html.haml
+++ b/app/views/user_mailer/webauthn_disabled.html.haml
@@ -1,6 +1,6 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           image_url: frontend_asset_url('images/mailer-new/heading/key-disabled.png'),
+           image_url: mail_header_image('key-disabled.png'),
            subtitle: t('devise.mailer.webauthn_disabled.explanation'),
            title: t('devise.mailer.webauthn_disabled.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }

--- a/app/views/user_mailer/webauthn_enabled.html.haml
+++ b/app/views/user_mailer/webauthn_enabled.html.haml
@@ -1,6 +1,6 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           image_url: frontend_asset_url('images/mailer-new/heading/key-enabled.png'),
+           image_url: mail_header_image('key-enabled.png'),
            subtitle: t('devise.mailer.webauthn_enabled.explanation'),
            title: t('devise.mailer.webauthn_enabled.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }


### PR DESCRIPTION
Fun fact: `email.png` is the most common image name here. Sort of ironic with these being emails themselves.