### PR TITLE
Add NotificationMailer layout

### DIFF
--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -17,7 +17,7 @@ class NotificationMailer < ApplicationMailer
 
   default to: -> { email_address_with_name(@user.email, @me.username) }
 
-  layout 'mailer'
+  layout 'notification_mailer'
 
   def mention
     return if @status.blank?

--- a/app/views/layouts/mailer.html.haml
+++ b/app/views/layouts/mailer.html.haml
@@ -61,7 +61,7 @@
                       %tr
                         %td.email-body-td
                           -# Content
-                          = yield
+                          = content_for?(:content) ? yield(:content) : yield
 
               /[if mso]
                 </td></tr></table>

--- a/app/views/layouts/mailer.text.erb
+++ b/app/views/layouts/mailer.text.erb
@@ -1,4 +1,4 @@
-<%= yield %>
+<%= content_for?(:content) ? yield(:content) : yield %>
 ---
 
 <%= t 'about.hosted_on', domain: site_hostname %>

--- a/app/views/layouts/notification_mailer.html.haml
+++ b/app/views/layouts/notification_mailer.html.haml
@@ -1,6 +1,9 @@
 - content_for :content do
   %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: :presentation }
     %tr
-      = yield
+      %td.email-body-padding-td
+        %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: :presentation }
+          %tr
+            = yield
 
 = render template: 'layouts/mailer'

--- a/app/views/layouts/notification_mailer.html.haml
+++ b/app/views/layouts/notification_mailer.html.haml
@@ -1,4 +1,6 @@
 - content_for :content do
-  = yield
+  %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: :presentation }
+    %tr
+      = yield
 
 = render template: 'layouts/mailer'

--- a/app/views/layouts/notification_mailer.html.haml
+++ b/app/views/layouts/notification_mailer.html.haml
@@ -1,0 +1,4 @@
+- content_for :content do
+  = yield
+
+= render template: 'layouts/mailer'

--- a/app/views/layouts/notification_mailer.text.erb
+++ b/app/views/layouts/notification_mailer.text.erb
@@ -1,0 +1,7 @@
+<%- content_for :content do -%>
+<%= raw t('application_mailer.salutation', name: display_name(@me)) %>
+
+<%= yield %>
+<% end -%>
+
+<%= render template: 'layouts/mailer' %>

--- a/app/views/layouts/notification_mailer.text.haml
+++ b/app/views/layouts/notification_mailer.text.haml
@@ -1,6 +1,0 @@
-- content_for :content do
-  = raw t('application_mailer.salutation', name: display_name(@me))
-  \
-  = yield
-
-= render template: 'layouts/mailer'

--- a/app/views/layouts/notification_mailer.text.haml
+++ b/app/views/layouts/notification_mailer.text.haml
@@ -1,0 +1,6 @@
+- content_for :content do
+  = raw t('application_mailer.salutation', name: display_name(@me))
+  \
+  = yield
+
+= render template: 'layouts/mailer'

--- a/app/views/notification_mailer/favourite.html.haml
+++ b/app/views/notification_mailer/favourite.html.haml
@@ -3,12 +3,9 @@
            image_url: frontend_asset_url('images/mailer-new/heading/favorite.png'),
            subtitle: t('notification_mailer.favourite.body', name: @account.pretty_acct),
            title: t('notification_mailer.favourite.title')
-%td.email-body-padding-td
-  %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+%td.email-inner-card-td
+  = render 'status', status: @status, time_zone: @me.user_time_zone
+  %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: :presentation }
     %tr
-      %td.email-inner-card-td
-        = render 'status', status: @status, time_zone: @me.user_time_zone
-        %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-          %tr
-            %td.email-padding-top-24
-              = render 'application/mailer/button', text: t('application_mailer.view_status'), url: web_url("@#{@status.account.pretty_acct}/#{@status.id}")
+      %td.email-padding-top-24
+        = render 'application/mailer/button', text: t('application_mailer.view_status'), url: web_url("@#{@status.account.pretty_acct}/#{@status.id}")

--- a/app/views/notification_mailer/favourite.html.haml
+++ b/app/views/notification_mailer/favourite.html.haml
@@ -3,14 +3,12 @@
            image_url: frontend_asset_url('images/mailer-new/heading/favorite.png'),
            subtitle: t('notification_mailer.favourite.body', name: @account.pretty_acct),
            title: t('notification_mailer.favourite.title')
-%table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-  %tr
-    %td.email-body-padding-td
-      %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-        %tr
-          %td.email-inner-card-td
-            = render 'status', status: @status, time_zone: @me.user_time_zone
-            %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-              %tr
-                %td.email-padding-top-24
-                  = render 'application/mailer/button', text: t('application_mailer.view_status'), url: web_url("@#{@status.account.pretty_acct}/#{@status.id}")
+%td.email-body-padding-td
+  %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+    %tr
+      %td.email-inner-card-td
+        = render 'status', status: @status, time_zone: @me.user_time_zone
+        %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+          %tr
+            %td.email-padding-top-24
+              = render 'application/mailer/button', text: t('application_mailer.view_status'), url: web_url("@#{@status.account.pretty_acct}/#{@status.id}")

--- a/app/views/notification_mailer/favourite.text.erb
+++ b/app/views/notification_mailer/favourite.text.erb
@@ -1,5 +1,3 @@
-<%= raw t('application_mailer.salutation', name: display_name(@me)) %>
-
 <%= raw t('notification_mailer.favourite.body', name: @account.pretty_acct) %>
 
 <%= render 'status', status: @status %>

--- a/app/views/notification_mailer/follow.html.haml
+++ b/app/views/notification_mailer/follow.html.haml
@@ -3,12 +3,9 @@
            image_url: frontend_asset_url('images/mailer-new/heading/user.png'),
            subtitle: t('notification_mailer.follow.body', name: @account.pretty_acct),
            title: t('notification_mailer.follow.title')
-%td.email-body-padding-td
-  %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+%td.email-inner-card-td-without-padding
+  = render 'application/mailer/account', account: @account
+  %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: :presentation }
     %tr
-      %td.email-inner-card-td-without-padding
-        = render 'application/mailer/account', account: @account
-        %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-          %tr
-            %td.email-padding-24.email-padding-top-0
-              = render 'application/mailer/button', text: t('application_mailer.view_profile'), url: web_url("@#{@account.pretty_acct}")
+      %td.email-padding-24.email-padding-top-0
+        = render 'application/mailer/button', text: t('application_mailer.view_profile'), url: web_url("@#{@account.pretty_acct}")

--- a/app/views/notification_mailer/follow.html.haml
+++ b/app/views/notification_mailer/follow.html.haml
@@ -3,14 +3,12 @@
            image_url: frontend_asset_url('images/mailer-new/heading/user.png'),
            subtitle: t('notification_mailer.follow.body', name: @account.pretty_acct),
            title: t('notification_mailer.follow.title')
-%table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-  %tr
-    %td.email-body-padding-td
-      %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-        %tr
-          %td.email-inner-card-td-without-padding
-            = render 'application/mailer/account', account: @account
-            %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-              %tr
-                %td.email-padding-24.email-padding-top-0
-                  = render 'application/mailer/button', text: t('application_mailer.view_profile'), url: web_url("@#{@account.pretty_acct}")
+%td.email-body-padding-td
+  %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+    %tr
+      %td.email-inner-card-td-without-padding
+        = render 'application/mailer/account', account: @account
+        %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+          %tr
+            %td.email-padding-24.email-padding-top-0
+              = render 'application/mailer/button', text: t('application_mailer.view_profile'), url: web_url("@#{@account.pretty_acct}")

--- a/app/views/notification_mailer/follow.text.erb
+++ b/app/views/notification_mailer/follow.text.erb
@@ -1,5 +1,3 @@
-<%= raw t('application_mailer.salutation', name: display_name(@me)) %>
-
 <%= raw t('notification_mailer.follow.body', name: @account.pretty_acct) %>
 
 <%= raw t('application_mailer.view')%> <%= web_url("@#{@account.pretty_acct}") %>

--- a/app/views/notification_mailer/follow_request.html.haml
+++ b/app/views/notification_mailer/follow_request.html.haml
@@ -3,12 +3,9 @@
            image_url: frontend_asset_url('images/mailer-new/heading/follow.png'),
            subtitle: t('notification_mailer.follow_request.body', name: @account.pretty_acct),
            title: t('notification_mailer.follow_request.title')
-%td.email-body-padding-td
-  %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+%td.email-inner-card-td-without-padding
+  = render 'application/mailer/account', account: @account
+  %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: :presentation }
     %tr
-      %td.email-inner-card-td-without-padding
-        = render 'application/mailer/account', account: @account
-        %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-          %tr
-            %td.email-padding-24.email-padding-top-0
-              = render 'application/mailer/button', text: t('notification_mailer.follow_request.action'), url: web_url('follow_requests')
+      %td.email-padding-24.email-padding-top-0
+        = render 'application/mailer/button', text: t('notification_mailer.follow_request.action'), url: web_url('follow_requests')

--- a/app/views/notification_mailer/follow_request.html.haml
+++ b/app/views/notification_mailer/follow_request.html.haml
@@ -3,14 +3,12 @@
            image_url: frontend_asset_url('images/mailer-new/heading/follow.png'),
            subtitle: t('notification_mailer.follow_request.body', name: @account.pretty_acct),
            title: t('notification_mailer.follow_request.title')
-%table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-  %tr
-    %td.email-body-padding-td
-      %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-        %tr
-          %td.email-inner-card-td-without-padding
-            = render 'application/mailer/account', account: @account
-            %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-              %tr
-                %td.email-padding-24.email-padding-top-0
-                  = render 'application/mailer/button', text: t('notification_mailer.follow_request.action'), url: web_url('follow_requests')
+%td.email-body-padding-td
+  %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+    %tr
+      %td.email-inner-card-td-without-padding
+        = render 'application/mailer/account', account: @account
+        %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+          %tr
+            %td.email-padding-24.email-padding-top-0
+              = render 'application/mailer/button', text: t('notification_mailer.follow_request.action'), url: web_url('follow_requests')

--- a/app/views/notification_mailer/follow_request.text.erb
+++ b/app/views/notification_mailer/follow_request.text.erb
@@ -1,5 +1,3 @@
-<%= raw t('application_mailer.salutation', name: display_name(@me)) %>
-
 <%= raw t('notification_mailer.follow_request.body', name: @account.pretty_acct) %>
 
 <%= raw t('application_mailer.view')%> <%= web_url("follow_requests") %>

--- a/app/views/notification_mailer/mention.html.haml
+++ b/app/views/notification_mailer/mention.html.haml
@@ -3,12 +3,9 @@
            image_url: frontend_asset_url('images/mailer-new/heading/mention.png'),
            subtitle: t('notification_mailer.mention.body', name: @status.account.pretty_acct),
            title: t('notification_mailer.mention.title')
-%td.email-body-padding-td
-  %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+%td.email-inner-card-td
+  = render 'status', status: @status, time_zone: @me.user_time_zone
+  %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: :presentation }
     %tr
-      %td.email-inner-card-td
-        = render 'status', status: @status, time_zone: @me.user_time_zone
-        %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-          %tr
-            %td.email-padding-top-24
-              = render 'application/mailer/button', text: t('notification_mailer.mention.action'), url: web_url("@#{@status.account.pretty_acct}/#{@status.id}")
+      %td.email-padding-top-24
+        = render 'application/mailer/button', text: t('notification_mailer.mention.action'), url: web_url("@#{@status.account.pretty_acct}/#{@status.id}")

--- a/app/views/notification_mailer/mention.html.haml
+++ b/app/views/notification_mailer/mention.html.haml
@@ -3,14 +3,12 @@
            image_url: frontend_asset_url('images/mailer-new/heading/mention.png'),
            subtitle: t('notification_mailer.mention.body', name: @status.account.pretty_acct),
            title: t('notification_mailer.mention.title')
-%table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-  %tr
-    %td.email-body-padding-td
-      %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-        %tr
-          %td.email-inner-card-td
-            = render 'status', status: @status, time_zone: @me.user_time_zone
-            %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-              %tr
-                %td.email-padding-top-24
-                  = render 'application/mailer/button', text: t('notification_mailer.mention.action'), url: web_url("@#{@status.account.pretty_acct}/#{@status.id}")
+%td.email-body-padding-td
+  %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+    %tr
+      %td.email-inner-card-td
+        = render 'status', status: @status, time_zone: @me.user_time_zone
+        %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+          %tr
+            %td.email-padding-top-24
+              = render 'application/mailer/button', text: t('notification_mailer.mention.action'), url: web_url("@#{@status.account.pretty_acct}/#{@status.id}")

--- a/app/views/notification_mailer/mention.text.erb
+++ b/app/views/notification_mailer/mention.text.erb
@@ -1,5 +1,3 @@
-<%= raw t('application_mailer.salutation', name: display_name(@me)) %>
-
 <%= raw t('notification_mailer.mention.body', name: @status.account.pretty_acct) %>
 
 <%= render 'status', status: @status %>

--- a/app/views/notification_mailer/reblog.html.haml
+++ b/app/views/notification_mailer/reblog.html.haml
@@ -3,12 +3,9 @@
            image_url: frontend_asset_url('images/mailer-new/heading/boost.png'),
            subtitle: t('notification_mailer.reblog.body', name: @account.pretty_acct),
            title: t('notification_mailer.reblog.title')
-%td.email-body-padding-td
-  %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+%td.email-inner-card-td
+  = render 'status', status: @status, time_zone: @me.user_time_zone
+  %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: :presentation }
     %tr
-      %td.email-inner-card-td
-        = render 'status', status: @status, time_zone: @me.user_time_zone
-        %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-          %tr
-            %td.email-padding-top-24
-              = render 'application/mailer/button', text: t('application_mailer.view_status'), url: web_url("@#{@status.account.pretty_acct}/#{@status.id}")
+      %td.email-padding-top-24
+        = render 'application/mailer/button', text: t('application_mailer.view_status'), url: web_url("@#{@status.account.pretty_acct}/#{@status.id}")

--- a/app/views/notification_mailer/reblog.html.haml
+++ b/app/views/notification_mailer/reblog.html.haml
@@ -3,14 +3,12 @@
            image_url: frontend_asset_url('images/mailer-new/heading/boost.png'),
            subtitle: t('notification_mailer.reblog.body', name: @account.pretty_acct),
            title: t('notification_mailer.reblog.title')
-%table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-  %tr
-    %td.email-body-padding-td
-      %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-        %tr
-          %td.email-inner-card-td
-            = render 'status', status: @status, time_zone: @me.user_time_zone
-            %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
-              %tr
-                %td.email-padding-top-24
-                  = render 'application/mailer/button', text: t('application_mailer.view_status'), url: web_url("@#{@status.account.pretty_acct}/#{@status.id}")
+%td.email-body-padding-td
+  %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+    %tr
+      %td.email-inner-card-td
+        = render 'status', status: @status, time_zone: @me.user_time_zone
+        %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+          %tr
+            %td.email-padding-top-24
+              = render 'application/mailer/button', text: t('application_mailer.view_status'), url: web_url("@#{@status.account.pretty_acct}/#{@status.id}")

--- a/app/views/notification_mailer/reblog.text.erb
+++ b/app/views/notification_mailer/reblog.text.erb
@@ -1,5 +1,3 @@
-<%= raw t('application_mailer.salutation', name: display_name(@me)) %>
-
 <%= raw t('notification_mailer.reblog.body', name: @account.pretty_acct) %>
 
 <%= render 'status', status: @status %>


### PR DESCRIPTION
Sort of a followup on https://github.com/mastodon/mastodon/pull/28746

In that initial PR we hit a point where we almost merged something similar, but realized the `welcome` email specifically did not fit the same format.

In this round, I'm making similar changes, but only within the notification mailer, which do all share the same outer wrapping.

Changes:

- Add html and text nested layouts for notification mailer, and modify parent layouts to understand the nesting (similar to non-mailer layouts in main app)
- Extract the repeated/shared top ~5 layers of markup from all notification mailers and move to layout. Diff may be messy from haml indentation changes, but it's just pulling out the common code.
- The text layout is similar for notifications to what the admin one (added in https://github.com/mastodon/mastodon/pull/28085/files ) is already doing for the admin mailers (pulled out salutation portion)

Future ideas:

- As followup, we potentially could have all the non-welcome user emails (I think, would verify) also use this layout, though it may make sense to rename it in that case. I'm not sure if there are more scheduled non-conforming mailers in the mailer pipeline, or if there even is a mailer pipeline. Sounds like something I invented honestly.
- If we ever did want to add/maintain HTML versions of the admin mailers (previously rejected), there is a lot of commonality between the admin mailers and notification mailers, and they could almost definitely both fold into the same text and html layouts if desired.

Misc observations on things I saw while doing this:

- Most (all?) of the text versions of the mailers have `erb` (ie, not `haml`) layouts/templates. I assume this is intentional for some historical haml/plaintext formatting reason. For all I know it was my decision. Nonetheless, it surprised me.