### PR TITLE
Fix average user retention calculation

### DIFF
--- a/app/javascript/mastodon/components/admin/Retention.jsx
+++ b/app/javascript/mastodon/components/admin/Retention.jsx
@@ -92,7 +92,9 @@ export default class Retention extends PureComponent {
               </td>
 
               {data[0].data.slice(1).map((retention, i) => {
-                const average = data.reduce((sum, cohort, k) => cohort.data[i + 1] ? sum + (cohort.data[i + 1].rate - sum)/(k + 1) : sum, 0);
+                const sum_of_active = data.reduce((sum, cohort) => cohort.data[i + 1] ? sum + (cohort.data[i + 1].value * 1) : sum, 0);
+                const sum_of_new = data.reduce((sum, cohort) => cohort.data[0].value ? sum + (cohort.data[0].value * 1) : sum, 0);
+                const average = sum_of_active / sum_of_new;
 
                 return (
                   <td key={retention.date}>


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/c7705e2f-5c27-4ceb-9538-248198ddaae9)
After:
![image](https://github.com/user-attachments/assets/aeb07275-996a-4314-94be-0912541c8f19)

For example: If 99 users signed up 2 mo before, and their retention was 100%, And 1 user signed up 1 mo before and their retention was 0%, Average 1 mo retention would be 99%. Not 50%

Average retention was calculated using `avg(retentions)` which is not correct
This PR fix that using `sum_of_active_users / sum_of_new_users` per periods