### PR TITLE
Add `Tag#discoverable_public_status_accounts` association for use in welcome mailer

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -32,6 +32,8 @@ class Tag < ApplicationRecord
   has_many :featured_tags, dependent: :destroy, inverse_of: :tag
   has_many :followers, through: :passive_relationships, source: :account
 
+  has_many :discoverable_public_status_accounts, -> { merge(Status.public_visibility).merge(Account.discoverable) }, through: :statuses, source: :account
+
   HASHTAG_SEPARATORS = "_\u00B7\u30FB\u200c"
   HASHTAG_FIRST_SEQUENCE_CHUNK_ONE = "[[:word:]_][[:word:]#{HASHTAG_SEPARATORS}]*[[:alpha:]#{HASHTAG_SEPARATORS}]"
   HASHTAG_FIRST_SEQUENCE_CHUNK_TWO = "[[:word:]#{HASHTAG_SEPARATORS}]*[[:word:]_]"

--- a/app/views/application/mailer/_hashtag.html.haml
+++ b/app/views/application/mailer/_hashtag.html.haml
@@ -1,5 +1,3 @@
-- accounts = hashtag.statuses.public_visibility.joins(:account).merge(Account.without_suspended.without_silenced).includes(:account).limit(3).map(&:account)
-
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-mini-wrapper-td
@@ -13,7 +11,7 @@
                   %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
                     %tr
                       %td.email-mini-hashtag-img-td
-                        - accounts.each do |account|
+                        - hashtag.discoverable_public_status_accounts.limit(3).each do |account|
                           %span.email-mini-hashtag-img-span
                             = image_tag full_asset_url(account.avatar.url), alt: '', width: 16, height: 16
                       %td

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -227,6 +227,27 @@ RSpec.describe Tag do
     end
   end
 
+  describe '#discoverable_public_status_accounts' do
+    let(:non_discoverable_account) { Fabricate :account, discoverable: false }
+    let(:private_status) { Fabricate :status, visibility: :private }
+    let(:public_status) { Fabricate :status, visibility: :public }
+    let(:public_status_from_non_discoverable_account) { Fabricate :status, visibility: :public, account: non_discoverable_account }
+    let(:tag) { Fabricate :tag }
+
+    before do
+      public_status.tags << tag
+      private_status.tags << tag
+      public_status_from_non_discoverable_account.tags << tag
+    end
+
+    it 'returns discoverable authors of public statuses tagged with the tag' do
+      expect(tag.discoverable_public_status_accounts)
+        .to include(public_status.account)
+        .and not_include(non_discoverable_account)
+        .and not_include(private_status.account)
+    end
+  end
+
   describe '.search_for' do
     it 'finds tag records with matching names' do
       tag = Fabricate(:tag, name: 'match')


### PR DESCRIPTION
This is technically a change in which accounts are included, because "discoverable" covers more than the previous logic ... but I suspect it's a desired change, and is consistent with how we query elsewhere.

Main benefit is just cleaning up the partial and getting directly to the account records we want, rather than ruby-iterating to collect them.

Future improvement here could nudge this even further up into the mailer setup to preload the accounts for any hashtags.

I added some basic coverage for the association since the conditions are non-trivial, but I don't think the mailer coverage is actually exposing any tags/accounts. Would be another good future improvement to add that in before any further change.