### PR TITLE
Prefer "strict locals" over `defined?` checks in welcome mailer partials

### DIFF
--- a/app/views/application/mailer/_button.html.haml
+++ b/app/views/application/mailer/_button.html.haml
@@ -1,7 +1,8 @@
+-# locals: (text:, url:, has_arrow: true)
 %table.email-btn-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-btn-td
-      - if defined?(has_arrow) && !has_arrow
-        = link_to text, url, class: 'email-btn-a email-btn-hover'
-      - else
+      - if has_arrow
         = link_to "#{text} ➜", url, class: 'email-btn-a email-btn-hover'
+      - else
+        = link_to text, url, class: 'email-btn-a email-btn-hover'

--- a/app/views/application/mailer/_checklist.html.haml
+++ b/app/views/application/mailer/_checklist.html.haml
@@ -1,7 +1,8 @@
+-# locals: (checked:, key:, button_text: nil, button_url: nil, show_apps_buttons: nil)
 %table.email-w-full.email-checklist-wrapper-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-checklist-wrapper-td
-      %table.email-w-full.email-checklist-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation', class: ('email-checklist-checked' if defined?(checked) && checked) }
+      %table.email-w-full.email-checklist-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation', class: ('email-checklist-checked' if checked) }
         %tr
           %td.email-checklist-td
             %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
@@ -10,13 +11,12 @@
                   %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
                     %tr
                       %td.email-checklist-icons-checkbox-td
-                        - if defined?(checked) && checked
+                        - if checked
                           = image_tag frontend_asset_url('images/mailer-new/welcome/checkbox-on.png'), alt: '', width: 20, height: 20
                         - else
                           = image_tag frontend_asset_url('images/mailer-new/welcome/checkbox-off.png'), alt: '', width: 20, height: 20
                       %td.email-checklist-icons-step-td
-                        - if defined?(key)
-                          = image_tag frontend_asset_url("images/mailer-new/welcome-icons/#{key}_step-#{checked ? 'on' : 'off'}.png"), alt: '', width: 40, height: 40
+                        = image_tag frontend_asset_url("images/mailer-new/welcome-icons/#{key}_step-#{checked ? 'on' : 'off'}.png"), alt: '', width: 40, height: 40
                 %td.email-checklist-text-td
                   .email-desktop-flex
                     /[if mso]
@@ -27,11 +27,11 @@
                     /[if mso]
                       </td><td style="vertical-align:top;">
                     %div
-                      - if defined?(show_apps_buttons) && show_apps_buttons
+                      - if show_apps_buttons
                         .email-welcome-apps-btns
                           = link_to image_tag(frontend_asset_url('images/mailer-new/store-icons/btn-app-store.png'), alt: t('user_mailer.welcome.apps_ios_action'), width: 120, height: 40), 'https://apps.apple.com/app/mastodon-for-iphone-and-ipad/id1571998974'
                           = link_to image_tag(frontend_asset_url('images/mailer-new/store-icons/btn-google-play.png'), alt: t('user_mailer.welcome.apps_android_action'), width: 120, height: 40), 'https://play.google.com/store/apps/details?id=org.joinmastodon.android'
-                      - elsif defined?(button_text) && defined?(button_url) && defined?(checked) && !checked
+                      - elsif button_text && button_url && !checked
                         = render 'application/mailer/button', text: button_text, url: button_url, has_arrow: false
                     /[if mso]
                       </td></tr></table>

--- a/app/views/application/mailer/_feature.html.haml
+++ b/app/views/application/mailer/_feature.html.haml
@@ -1,3 +1,4 @@
+-# locals: (feature:, feature_iteration:, feature_btn_url: nil)
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-feature-wrapper-td
@@ -13,7 +14,7 @@
                     %td.email-column-td
                       %h2.email-h2= t("user_mailer.welcome.feature_#{feature}_title")
                       %p.email-p= t("user_mailer.welcome.feature_#{feature}")
-                      - if defined?(feature_btn_url)
+                      - if feature_btn_url
                         = link_to '', href: feature_btn_url, class: 'email-link-with-arrow' do
                           #{t('user_mailer.welcome.feature_action')} 
                           %span= '❯'
@@ -23,8 +24,7 @@
                 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
                   %tr
                     %td.email-column-td
-                      - if defined?(feature)
-                        %p{ class: ('email-desktop-text-right' if feature_iteration.index.even?) }
-                          = image_tag frontend_asset_url("images/mailer-new/welcome/feature_#{feature}.png"), alt: '', width: 240, height: 230
+                      %p{ class: ('email-desktop-text-right' if feature_iteration.index.even?) }
+                        = image_tag frontend_asset_url("images/mailer-new/welcome/feature_#{feature}.png"), alt: '', width: 240, height: 230
               /[if mso]
                 </td></tr></table>


### PR DESCRIPTION
Related - looks like `feature_btn_url` is checked for in the feature partial, but never passed in anywhere and thus never used. Added here - https://github.com/mastodon/mastodon/commit/934cab75083a4ab79003a583881775b6d4a2b58a#diff-22ef91bed098efa69bdc2d68784ee3993ad21737f683633d3e07f04ea04bff6bR19 - but never used anywhere.

Is this something where we plan on adding URLs for "learn more" links to point to, or should be removed?