### PR TITLE
Fix mute duration not being shown in list of muted accounts in web UI

### DIFF
--- a/app/javascript/mastodon/api_types/accounts.ts
+++ b/app/javascript/mastodon/api_types/accounts.ts
@@ -13,7 +13,7 @@ export interface ApiAccountRoleJSON {
 }
 
 // See app/serializers/rest/account_serializer.rb
-export interface ApiAccountJSON {
+export interface BaseApiAccountJSON {
   acct: string;
   avatar: string;
   avatar_static: string;
@@ -45,3 +45,12 @@ export interface ApiAccountJSON {
   memorial?: boolean;
   hide_collections: boolean;
 }
+
+// See app/serializers/rest/muted_account_serializer.rb
+export interface ApiMutedAccountJSON extends BaseApiAccountJSON {
+  mute_expires_at?: string | null;
+}
+
+// For now, we have the same type representing both `Account` and `MutedAccount`
+// objects, but we should refactor this in the future.
+export type ApiAccountJSON = ApiMutedAccountJSON;

--- a/app/javascript/mastodon/models/account.ts
+++ b/app/javascript/mastodon/models/account.ts
@@ -95,6 +95,9 @@ export const accountDefaultValues: AccountShape = {
   limited: false,
   moved: null,
   hide_collections: false,
+  // This comes from `ApiMutedAccountJSON`, but we should eventually
+  // store that in a different object.
+  mute_expires_at: null,
 };
 
 const AccountFactory = ImmutableRecord<AccountShape>(accountDefaultValues);


### PR DESCRIPTION
Fixes #32371

Basically, `/api/v1/mutes` returns `MutedAccount` objects that are `Account` with an additional `mute_expires_at`, but we ignored that attribute in the common handling of `Account` objects.

This PR changes it back so that the redux-stored accounts contain `mute_expires_at`. That being said, this does not seem to be a very clean solution, and a better solution is probably to store that information in another piece of redux state to not pollute the `Account` record definition.