### PR TITLE
Remove unused `Account#local_followers_count` method

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -220,10 +220,6 @@ class Account < ApplicationRecord
     "#{username}@#{Rails.configuration.x.local_domain}"
   end
 
-  def local_followers_count
-    Follow.where(target_account_id: id).count
-  end
-
   def to_webfinger_s
     "acct:#{local_username_and_domain}"
   end

--- a/app/views/admin/accounts/_counters.html.haml
+++ b/app/views/admin/accounts/_counters.html.haml
@@ -9,7 +9,7 @@
       .dashboard__counters__label= t 'admin.accounts.media_attachments'
   %div
     = link_to admin_account_relationships_path(account.id, location: account.local? ? nil : 'local', relationship: 'followed_by') do
-      .dashboard__counters__num= number_with_delimiter account.local_followers_count
+      .dashboard__counters__num= number_with_delimiter account.followers_count
       .dashboard__counters__label= t 'admin.accounts.followers'
   %div
     = link_to admin_reports_path(account_id: account.id) do


### PR DESCRIPTION
Originally added here - https://github.com/mastodon/mastodon/pull/9610/files#diff-865163666d571e5c003445950978182c91a1197f994b10fa84b5ca28b66d0e62R94 - along with an i18n key.

The i18n key was then removed and the view changed in a subsequent update - https://github.com/mastodon/mastodon/commit/6e49907ecfc7036b6bf2dd91b9ebf4ba62d16080#diff-865163666d571e5c003445950978182c91a1197f994b10fa84b5ca28b66d0e62R16 - which I think probably should have also switched this over to use the value in the "stat" object (like what statuses does a little higher in this view).

Removes one `Follow` query from the view, since the `AccountStat` is already loaded we can just pull that value.