### PR TITLE
Codify accepted url schemes in validator

### DIFF
--- a/app/controllers/authorize_interactions_controller.rb
+++ b/app/controllers/authorize_interactions_controller.rb
@@ -38,7 +38,7 @@ class AuthorizeInteractionsController < ApplicationController
   end
 
   def uri_param_is_url?
-    parsed_uri.path && %w(http https).include?(parsed_uri.scheme)
+    parsed_uri.path && URLValidator::VALID_SCHEMES.include?(parsed_uri.scheme)
   end
 
   def parsed_uri

--- a/app/lib/link_details_extractor.rb
+++ b/app/lib/link_details_extractor.rb
@@ -229,7 +229,7 @@ class LinkDetailsExtractor
 
     url = @original_url + Addressable::URI.parse(str)
 
-    return if url.host.blank? || !%w(http https).include?(url.scheme) || (same_origin_only && url.host != @original_url.host)
+    return if url.host.blank? || !URLValidator::VALID_SCHEMES.include?(url.scheme) || (same_origin_only && url.host != @original_url.host)
 
     url.to_s
   rescue Addressable::URI::InvalidURIError

--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -136,7 +136,7 @@ class Request
         return false
       end
 
-      %w(http https).include?(parsed_url.scheme) && parsed_url.host.present?
+      URLValidator::VALID_SCHEMES.include?(parsed_url.scheme) && parsed_url.host.present?
     end
 
     def http_client

--- a/app/models/concerns/remotable.rb
+++ b/app/models/concerns/remotable.rb
@@ -18,7 +18,7 @@ module Remotable
           return
         end
 
-        return if !%w(http https).include?(parsed_url.scheme) || parsed_url.host.blank?
+        return if !URLValidator::VALID_SCHEMES.include?(parsed_url.scheme) || parsed_url.host.blank?
 
         begin
           Request.new(:get, url).perform do |response|

--- a/app/models/concerns/user/omniauthable.rb
+++ b/app/models/concerns/user/omniauthable.rb
@@ -73,7 +73,7 @@ module User::Omniauthable
       user = User.new(user_params_from_auth(email, auth))
 
       begin
-        user.account.avatar_remote_url = auth.info.image if /\A#{URI::DEFAULT_PARSER.make_regexp(%w(http https))}\z/.match?(auth.info.image)
+        user.account.avatar_remote_url = auth.info.image if /\A#{URI::DEFAULT_PARSER.make_regexp(URLValidator::VALID_SCHEMES)}\z/.match?(auth.info.image)
       rescue Mastodon::UnexpectedResponseError
         user.account.avatar_remote_url = nil
       end

--- a/app/services/fetch_link_card_service.rb
+++ b/app/services/fetch_link_card_service.rb
@@ -91,7 +91,7 @@ class FetchLinkCardService < BaseService
 
   def bad_url?(uri)
     # Avoid local instance URLs and invalid URLs
-    uri.host.blank? || TagManager.instance.local_url?(uri.to_s) || !%w(http https).include?(uri.scheme)
+    uri.host.blank? || TagManager.instance.local_url?(uri.to_s) || !URLValidator::VALID_SCHEMES.include?(uri.scheme)
   end
 
   def mention_link?(anchor)

--- a/config/initializers/http_client_proxy.rb
+++ b/config/initializers/http_client_proxy.rb
@@ -6,7 +6,7 @@ Rails.application.configure do
   if ENV['http_proxy'].present?
     proxy = URI.parse(ENV['http_proxy'])
 
-    raise "Unsupported proxy type: #{proxy.scheme}" unless %w(http https).include? proxy.scheme
+    raise "Unsupported proxy type: #{proxy.scheme}" unless URLValidator::VALID_SCHEMES.include? proxy.scheme
     raise 'No proxy host' unless proxy.host
 
     host = proxy.host
@@ -23,7 +23,7 @@ Rails.application.configure do
   if ENV['http_hidden_proxy'].present?
     proxy = URI.parse(ENV['http_hidden_proxy'])
 
-    raise "Unsupported proxy type: #{proxy.scheme}" unless %w(http https).include? proxy.scheme
+    raise "Unsupported proxy type: #{proxy.scheme}" unless URLValidator::VALID_SCHEMES.include? proxy.scheme
     raise 'No proxy host' unless proxy.host
 
     host = proxy.host


### PR DESCRIPTION
I don't think this exact pair is held in a constant in ruby internals (URI or something) or Addressable - so use this one we already have defined in the validator.