### PR TITLE
Fix: Reword 'pick one' to 'single choice' for polls

### DIFF
--- a/app/javascript/mastodon/features/compose/components/poll_form.jsx
+++ b/app/javascript/mastodon/features/compose/components/poll_form.jsx
@@ -25,7 +25,7 @@ const messages = defineMessages({
   minutes: { id: 'intervals.full.minutes', defaultMessage: '{number, plural, one {# minute} other {# minutes}}' },
   hours: { id: 'intervals.full.hours', defaultMessage: '{number, plural, one {# hour} other {# hours}}' },
   days: { id: 'intervals.full.days', defaultMessage: '{number, plural, one {# day} other {# days}}' },
-  singleChoice: { id: 'compose_form.poll.single', defaultMessage: 'Pick one' },
+  singleChoice: { id: 'compose_form.poll.single', defaultMessage: 'Single choice' },
   multipleChoice: { id: 'compose_form.poll.multiple', defaultMessage: 'Multiple choice' },
 });
 

--- a/app/javascript/mastodon/locales/en-GB.json
+++ b/app/javascript/mastodon/locales/en-GB.json
@@ -158,7 +158,7 @@
   "compose_form.poll.duration": "Poll duration",
   "compose_form.poll.multiple": "Multiple choice",
   "compose_form.poll.option_placeholder": "Option {number}",
-  "compose_form.poll.single": "Pick one",
+  "compose_form.poll.single": "Single choice",
   "compose_form.poll.switch_to_multiple": "Change poll to allow multiple choices",
   "compose_form.poll.switch_to_single": "Change poll to allow for a single choice",
   "compose_form.poll.type": "Style",

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -158,7 +158,7 @@
   "compose_form.poll.duration": "Poll duration",
   "compose_form.poll.multiple": "Multiple choice",
   "compose_form.poll.option_placeholder": "Option {number}",
-  "compose_form.poll.single": "Pick one",
+  "compose_form.poll.single": "Single choice",
   "compose_form.poll.switch_to_multiple": "Change poll to allow multiple choices",
   "compose_form.poll.switch_to_single": "Change poll to allow for a single choice",
   "compose_form.poll.type": "Style",


### PR DESCRIPTION
The language of "pick one" sounds like you should select something different from the list when creating a poll, changing the locale to "single choice" is clearer, given the one option is "multiple choice"

![image](https://github.com/user-attachments/assets/ca50c041-3d8f-405f-ada9-f6b9642b3c93)
