### PR TITLE
Convert `account_link_to` helper method to view partial

### DIFF
--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -7,36 +7,8 @@ module HomeHelper
     }
   end
 
-  def account_link_to(account, button = '', path: nil)
-    content_tag(:div, class: 'account account--minimal') do
-      content_tag(:div, class: 'account__wrapper') do
-        section = if account.nil?
-                    content_tag(:div, class: 'account__display-name') do
-                      content_tag(:div, class: 'account__avatar-wrapper') do
-                        image_tag(full_asset_url('avatars/original/missing.png', skip_pipeline: true), class: 'account__avatar')
-                      end +
-                        content_tag(:span, class: 'display-name') do
-                          content_tag(:strong, t('about.contact_missing')) +
-                            content_tag(:span, t('about.contact_unavailable'), class: 'display-name__account')
-                        end
-                    end
-                  else
-                    link_to(path || ActivityPub::TagManager.instance.url_for(account), class: 'account__display-name') do
-                      content_tag(:div, class: 'account__avatar-wrapper') do
-                        image_tag(full_asset_url(current_account&.user&.setting_auto_play_gif ? account.avatar_original_url : account.avatar_static_url), class: 'account__avatar', width: 46, height: 46)
-                      end +
-                        content_tag(:span, class: 'display-name') do
-                          content_tag(:bdi) do
-                            content_tag(:strong, display_name(account, custom_emojify: true), class: 'display-name__html emojify')
-                          end +
-                            content_tag(:span, "@#{account.acct}", class: 'display-name__account')
-                        end
-                    end
-                  end
-
-        section + button
-      end
-    end
+  def preferred_avatar(account)
+    current_account&.user&.setting_auto_play_gif ? account.avatar_original_url : account.avatar_static_url
   end
 
   def obscured_counter(count)

--- a/app/views/admin/accounts/_account.html.haml
+++ b/app/views/admin/accounts/_account.html.haml
@@ -6,7 +6,7 @@
       %tbody
         %tr
           %td
-            = account_link_to account, path: admin_account_path(account.id)
+            = render 'shared/account', account: account, path: admin_account_path(account.id)
           %td.accounts-table__count.optional
             - if account.unavailable? || account.user_pending?
               \-

--- a/app/views/admin/follow_recommendations/_account.html.haml
+++ b/app/views/admin/follow_recommendations/_account.html.haml
@@ -5,7 +5,7 @@
     %table.accounts-table
       %tbody
         %tr
-          %td= account_link_to account
+          %td= render 'shared/account', account: account
           %td.accounts-table__count.optional
             = friendly_number_to_human account.statuses_count
             %small= t('accounts.posts', count: account.statuses_count).downcase

--- a/app/views/admin/reports/index.html.haml
+++ b/app/views/admin/reports/index.html.haml
@@ -34,7 +34,7 @@
   - target_account = reports.first.target_account
   .report-card
     .report-card__profile
-      = account_link_to target_account, '', path: admin_account_path(target_account.id)
+      = render 'shared/account', account: target_account, path: admin_account_path(target_account.id)
       .report-card__profile__stats
         = link_to t('admin.reports.account.notes', count: target_account.targeted_moderation_notes.count), admin_account_path(target_account.id)
         %br/

--- a/app/views/relationships/_account.html.haml
+++ b/app/views/relationships/_account.html.haml
@@ -7,7 +7,7 @@
         %tr
           %td.accounts-table__interrelationships
             = interrelationships_icon(relationships, account.id)
-          %td= account_link_to account
+          %td= render 'shared/account', account: account
           %td.accounts-table__count.optional
             = friendly_number_to_human account.statuses_count
             %small= t('accounts.posts', count: account.statuses_count).downcase

--- a/app/views/shared/_account.html.haml
+++ b/app/views/shared/_account.html.haml
@@ -1,0 +1,23 @@
+-# locals: (account: nil, path: nil)
+
+.account.account--minimal
+  .account__wrapper
+  - if account.nil?
+    .account__display_name
+      .account__avatar-wrapper
+        = image_tag(full_asset_url('avatars/original/missing.png', skip_pipeline: true), class: 'account__avatar', size: 46)
+      %span.display-name
+        %strong
+          = t('about.contact_missing')
+        %span.display-name__account
+          = t('about.contact_unavailable')
+  - else
+    = link_to(path || ActivityPub::TagManager.instance.url_for(account), class: 'account__display-name') do
+      .account__avatar-wrapper
+        = image_tag(full_asset_url(preferred_avatar(account)), class: 'account__avatar', size: 46)
+      %span.display-name
+        %bdi
+          %strong.display-name__html.emojify
+            = display_name(account, custom_emojify: true)
+        %span.display-name__account
+          @#{account.acct}

--- a/spec/helpers/home_helper_spec.rb
+++ b/spec/helpers/home_helper_spec.rb
@@ -9,38 +9,6 @@ RSpec.describe HomeHelper do
     end
   end
 
-  describe 'account_link_to' do
-    context 'with a missing account' do
-      let(:account) { nil }
-
-      it 'returns a button' do
-        result = helper.account_link_to(account)
-
-        expect(result).to match t('about.contact_missing')
-      end
-    end
-
-    context 'with a valid account' do
-      let(:account) { Fabricate(:account) }
-
-      before { helper.extend controller_helpers }
-
-      it 'returns a link to the account' do
-        result = helper.account_link_to(account)
-
-        expect(result).to match "@#{account.acct}"
-      end
-
-      private
-
-      def controller_helpers
-        Module.new do
-          def current_account = Account.last
-        end
-      end
-    end
-  end
-
   describe 'obscured_counter' do
     context 'with a value of less than zero' do
       let(:count) { -10 }


### PR DESCRIPTION
This is another in the "wow that's a dense hard to parse code block" genre.

I started on a separate effort to just extract some methods into the helper module - https://github.com/mastodon/mastodon/compare/main...mjankowski:mastodon:home-helper-method - and that was an impreovement in terms of the nesting, but still felt like a bit of a sprawl.

Then I realized that this helper is actually used very few times, and none of the calling sites actually pass in any value for the `button`. I also realized that the vast majority of this (not as true when first added, but pretty true now) is just building html markup, not doing interesting ruby logic.

Thus, changes here:

- Delete the helper method and convert it's generated markup and logic to a partial
- Update call sites to render directly and pass in their args
- Remove the button param since not used anywhere
- Add helper to wrap the autoplay setting
- I forced a nil value in for account and realized that without a size setting the missing image looks huge, so added a size there to match the existing

To me, the smaller haml file is much easier to grasp what's happening and see the correct nested structure, etc.

Future ideas:

- I think it's possible that none of the calling sites actually have any plausible scenario where the account is missing ... might be possible to remove that whole path, but I'd want to review more first

Alternate scenarios:

If for whatever reason this is not desirable, I think we should AT LEAST, do both of a) remove the unused button option, b) convert style to `tag.element(...)` away from `content_tag`, just for a little reduction in this huge method.