### PR TITLE
Use `size: ...` shorthand for width/height of square images

### DIFF
--- a/app/helpers/admin/account_moderation_notes_helper.rb
+++ b/app/helpers/admin/account_moderation_notes_helper.rb
@@ -28,7 +28,7 @@ module Admin::AccountModerationNotesHelper
   def labeled_account_avatar(account)
     safe_join(
       [
-        image_tag(account.avatar.url, width: 15, height: 15, alt: '', class: 'avatar'),
+        image_tag(account.avatar.url, size: 15, alt: '', class: 'avatar'),
         account_inline_text(account),
       ],
       ' '

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -13,7 +13,7 @@ module HomeHelper
         section = if account.nil?
                     content_tag(:div, class: 'account__display-name') do
                       content_tag(:div, class: 'account__avatar-wrapper') do
-                        image_tag(full_asset_url('avatars/original/missing.png', skip_pipeline: true), class: 'account__avatar')
+                        image_tag(full_asset_url('avatars/original/missing.png', skip_pipeline: true), class: 'account__avatar', size: 46)
                       end +
                         content_tag(:span, class: 'display-name') do
                           content_tag(:strong, t('about.contact_missing')) +
@@ -23,7 +23,7 @@ module HomeHelper
                   else
                     link_to(path || ActivityPub::TagManager.instance.url_for(account), class: 'account__display-name') do
                       content_tag(:div, class: 'account__avatar-wrapper') do
-                        image_tag(full_asset_url(current_account&.user&.setting_auto_play_gif ? account.avatar_original_url : account.avatar_static_url), class: 'account__avatar', width: 46, height: 46)
+                        image_tag(full_asset_url(current_account&.user&.setting_auto_play_gif ? account.avatar_original_url : account.avatar_static_url), class: 'account__avatar', size: 46)
                       end +
                         content_tag(:span, class: 'display-name') do
                           content_tag(:bdi) do

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -39,7 +39,7 @@ module SettingsHelper
     return if account.nil?
 
     link_to ActivityPub::TagManager.instance.url_for(account), class: 'name-tag', title: account.acct do
-      safe_join([image_tag(account.avatar.url, width: 15, height: 15, alt: '', class: 'avatar'), content_tag(:span, account.acct, class: 'username')], ' ')
+      safe_join([image_tag(account.avatar.url, size: 15, alt: '', class: 'avatar'), content_tag(:span, account.acct, class: 'username')], ' ')
     end
   end
 

--- a/app/views/admin/action_logs/_action_log.html.haml
+++ b/app/views/admin/action_logs/_action_log.html.haml
@@ -1,7 +1,7 @@
 .log-entry
   .log-entry__header
     .log-entry__avatar
-      = image_tag action_log.account.avatar.url(:original), alt: '', width: 40, height: 40, class: 'avatar'
+      = image_tag action_log.account.avatar.url(:original), alt: '', size: 40, class: 'avatar'
     .log-entry__content
       .log-entry__title
         = t "admin.action_logs.actions.#{action_log.action}_#{action_log.target_type.underscore}_html",

--- a/app/views/admin/disputes/appeals/_appeal.html.haml
+++ b/app/views/admin/disputes/appeals/_appeal.html.haml
@@ -1,7 +1,7 @@
 = link_to disputes_strike_path(appeal.strike), class: ['log-entry', appeal.approved? && 'log-entry--inactive'] do
   .log-entry__header
     .log-entry__avatar
-      = image_tag appeal.account.avatar.url(:original), alt: '', width: 40, height: 40, class: 'avatar'
+      = image_tag appeal.account.avatar.url(:original), alt: '', size: 40, class: 'avatar'
     .log-entry__content
       .log-entry__title
         = strike_action_label(appeal)

--- a/app/views/admin/invites/_invite.html.haml
+++ b/app/views/admin/invites/_invite.html.haml
@@ -7,7 +7,7 @@
 
   %td
     .name-tag
-      = image_tag invite.user.account.avatar.url(:original), alt: '', width: 16, height: 16, class: 'avatar'
+      = image_tag invite.user.account.avatar.url(:original), alt: '', size: 16, class: 'avatar'
       %span.username= invite.user.account.username
 
   - if invite.valid_for_use?

--- a/app/views/application/_card.html.haml
+++ b/app/views/application/_card.html.haml
@@ -8,7 +8,7 @@
         = image_tag account.header.url, alt: ''
     .card__bar
       .avatar
-        = image_tag account.avatar.url, alt: '', width: 48, height: 48, class: 'u-photo'
+        = image_tag account.avatar.url, alt: '', size: 48, class: 'u-photo'
 
       .display-name
         %bdi

--- a/app/views/application/mailer/_account.html.haml
+++ b/app/views/application/mailer/_account.html.haml
@@ -8,7 +8,7 @@
               %table.email-account-banner-icon-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
                 %tr
                   %td
-                    %img{ src: full_asset_url(account.avatar.url), width: 80, height: 80, alt: '' }
+                    %img{ src: full_asset_url(account.avatar.url), size: 80, alt: '' }
 %table.email-w-full.email-account-body-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-account-body-td

--- a/app/views/application/mailer/_checklist.html.haml
+++ b/app/views/application/mailer/_checklist.html.haml
@@ -11,12 +11,12 @@
                     %tr
                       %td.email-checklist-icons-checkbox-td
                         - if defined?(checked) && checked
-                          = image_tag frontend_asset_url('images/mailer-new/welcome/checkbox-on.png'), alt: '', width: 20, height: 20
+                          = image_tag frontend_asset_url('images/mailer-new/welcome/checkbox-on.png'), alt: '', size: 20
                         - else
-                          = image_tag frontend_asset_url('images/mailer-new/welcome/checkbox-off.png'), alt: '', width: 20, height: 20
+                          = image_tag frontend_asset_url('images/mailer-new/welcome/checkbox-off.png'), alt: '', size: 20
                       %td.email-checklist-icons-step-td
                         - if defined?(key)
-                          = image_tag frontend_asset_url("images/mailer-new/welcome-icons/#{key}_step-#{checked ? 'on' : 'off'}.png"), alt: '', width: 40, height: 40
+                          = image_tag frontend_asset_url("images/mailer-new/welcome-icons/#{key}_step-#{checked ? 'on' : 'off'}.png"), alt: '', size: 40
                 %td.email-checklist-text-td
                   .email-desktop-flex
                     /[if mso]

--- a/app/views/application/mailer/_follow.html.haml
+++ b/app/views/application/mailer/_follow.html.haml
@@ -7,7 +7,7 @@
             %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
               %tr
                 %td.email-mini-follow-img-td
-                  = image_tag full_asset_url(follow.account.avatar.url), alt: '', width: 40, height: 40
+                  = image_tag full_asset_url(follow.account.avatar.url), alt: '', size: 40
                 %td.email-mini-follow-text-td
                   %h3= follow.account.display_name.presence || follow.account.username
                   %p @#{follow.account.pretty_acct}

--- a/app/views/application/mailer/_hashtag.html.haml
+++ b/app/views/application/mailer/_hashtag.html.haml
@@ -15,6 +15,6 @@
                       %td.email-mini-hashtag-img-td
                         - accounts.each do |account|
                           %span.email-mini-hashtag-img-span
-                            = image_tag full_asset_url(account.avatar.url), alt: '', width: 16, height: 16
+                            = image_tag full_asset_url(account.avatar.url), alt: '', size: 16
                       %td
                         %p= recent_tag_usage(hashtag)

--- a/app/views/application/mailer/_heading.html.haml
+++ b/app/views/application/mailer/_heading.html.haml
@@ -6,7 +6,7 @@
         %tr
           - if image_url
             %td.email-header-heading-img-td
-              = image_tag image_url, alt: '', width: 56, height: 56
+              = image_tag image_url, alt: '', size: 56
           %td.email-header-heading-txt-td
             %h1= title
             - if subtitle

--- a/app/views/filters/statuses/_status_filter.html.haml
+++ b/app/views/filters/statuses/_status_filter.html.haml
@@ -20,7 +20,7 @@
 
     .detailed-status__meta
       = link_to ActivityPub::TagManager.instance.url_for(status.account), class: 'name-tag', target: '_blank', rel: 'noopener noreferrer' do
-        = image_tag(status.account.avatar.url, width: 15, height: 15, alt: '', class: 'avatar')
+        = image_tag(status.account.avatar.url, size: 15, alt: '', class: 'avatar')
         .username= status.account.acct
       ·
       = link_to ActivityPub::TagManager.instance.url_for(status), class: 'detailed-status__datetime', target: stream_link_target, rel: 'noopener noreferrer' do

--- a/app/views/layouts/mailer.html.haml
+++ b/app/views/layouts/mailer.html.haml
@@ -75,7 +75,7 @@
                   %td.email-footer-td
                     %p.email-footer-p
                       = link_to root_url, class: 'email-footer-logo-a' do
-                        = image_tag frontend_asset_url('images/mailer-new/common/logo-footer.png'), alt: 'Mastodon', width: 44, height: 44
+                        = image_tag frontend_asset_url('images/mailer-new/common/logo-footer.png'), alt: 'Mastodon', size: 44
                     %p.email-footer-p
                       = t 'about.hosted_on', domain: site_hostname
                     %p.email-footer-p

--- a/app/views/notification_mailer/_status.html.haml
+++ b/app/views/notification_mailer/_status.html.haml
@@ -1,7 +1,7 @@
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-status-header-img
-      = image_tag full_asset_url(status.account.avatar.url), alt: '', width: 48, height: 48
+      = image_tag full_asset_url(status.account.avatar.url), alt: '', size: 48
     %td.email-status-header-text
       %h2.email-status-header-name
         = display_name(status.account)

--- a/app/views/settings/verifications/show.html.haml
+++ b/app/views/settings/verifications/show.html.haml
@@ -51,7 +51,7 @@
           %strong.status-card__title= t('author_attribution.example_title')
       .more-from-author
         = logo_as_symbol(:icon)
-        = t('author_attribution.more_from_html', name: link_to(root_url, class: 'story__details__shared__author-link') { image_tag(@account.avatar.url, class: 'account__avatar', width: 16, height: 16, alt: '') + tag.bdi(display_name(@account)) })
+        = t('author_attribution.more_from_html', name: link_to(root_url, class: 'story__details__shared__author-link') { image_tag(@account.avatar.url, class: 'account__avatar', size: 16, alt: '') + tag.bdi(display_name(@account)) })
 
   %h4= t('verification.here_is_how')
 


### PR DESCRIPTION
When the dimensions are the same, this will generate both `height` and `width` attributes in the markup, same as though they were passed separately.