### PR TITLE
Use array compact style for classes in `nothing_here` helper

### DIFF
--- a/app/helpers/statuses_helper.rb
+++ b/app/helpers/statuses_helper.rb
@@ -12,7 +12,7 @@ module StatusesHelper
   }.freeze
 
   def nothing_here(extra_classes = '')
-    content_tag(:div, class: "nothing-here #{extra_classes}") do
+    tag.div(class: ['nothing-here', extra_classes]) do
       t('accounts.nothing_here')
     end
   end


### PR DESCRIPTION
The helper will flatten/compact/join/etc args to `class: ...` behind the scenes, and we can skip the interpolation.