### PR TITLE
Simplify "exact match" check on admin dashboard relevant time helper

### DIFF
--- a/app/helpers/admin/dashboard_helper.rb
+++ b/app/helpers/admin/dashboard_helper.rb
@@ -24,22 +24,18 @@ module Admin::DashboardHelper
   end
 
   def relevant_account_timestamp(account)
-    timestamp, exact = if account.user_current_sign_in_at && account.user_current_sign_in_at < 24.hours.ago
-                         [account.user_current_sign_in_at, true]
-                       elsif account.user_current_sign_in_at
-                         [account.user_current_sign_in_at, false]
-                       elsif account.user_pending?
-                         [account.user_created_at, true]
-                       elsif account.suspended_at.present? && account.local? && account.user.nil?
-                         [account.suspended_at, true]
-                       elsif account.last_status_at.present?
-                         [account.last_status_at, true]
-                       else
-                         [nil, false]
-                       end
+    timestamp = if account.user_current_sign_in_at
+                  account.user_current_sign_in_at
+                elsif account.user_pending?
+                  account.user_created_at
+                elsif account.suspended_at.present? && account.local? && account.user.nil?
+                  account.suspended_at
+                elsif account.last_status_at.present?
+                  account.last_status_at
+                end
 
     return '-' if timestamp.nil?
-    return t('generic.today') unless exact
+    return t('generic.today') if account.user_current_sign_in_at && account.user_current_sign_in_at >= 24.hours.ago
 
     content_tag(:time, l(timestamp), class: 'time-ago', datetime: timestamp.iso8601, title: l(timestamp))
   end

--- a/app/helpers/admin/dashboard_helper.rb
+++ b/app/helpers/admin/dashboard_helper.rb
@@ -27,7 +27,7 @@ module Admin::DashboardHelper
     timestamp = account.relevant_time
 
     return '-' if timestamp.nil?
-    return t('generic.today') if account.user_current_sign_in_at && account.user_current_sign_in_at >= 24.hours.ago
+    return t('generic.today') if account.user_signed_in_today?
 
     content_tag(:time, l(timestamp), class: 'time-ago', datetime: timestamp.iso8601, title: l(timestamp))
   end

--- a/app/helpers/admin/dashboard_helper.rb
+++ b/app/helpers/admin/dashboard_helper.rb
@@ -28,9 +28,12 @@ module Admin::DashboardHelper
   def relevant_account_timestamp(account)
     timestamp = account.relevant_time
 
-    return DASHBOARD_MISSING_CONTENT if timestamp.nil?
-    return t('generic.today') if account.user_signed_in_today?
-
-    content_tag(:time, l(timestamp), class: 'time-ago', datetime: timestamp.iso8601, title: l(timestamp))
+    if timestamp.nil?
+      DASHBOARD_MISSING_CONTENT
+    elsif account.user_signed_in_today?
+      t('generic.today')
+    else
+      tag.time(l(timestamp), class: 'time-ago', datetime: timestamp.iso8601, title: l(timestamp))
+    end
   end
 end

--- a/app/helpers/admin/dashboard_helper.rb
+++ b/app/helpers/admin/dashboard_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module Admin::DashboardHelper
+  DASHBOARD_MISSING_CONTENT = '-'
+
   def relevant_account_ip(account, ip_query)
     ips = account.user.present? ? account.user.ips.to_a : []
 
@@ -14,7 +16,7 @@ module Admin::DashboardHelper
     if matched_ip
       link_to matched_ip.ip, admin_accounts_path(ip: matched_ip.ip)
     else
-      '-'
+      DASHBOARD_MISSING_CONTENT
     end
   end
 
@@ -26,7 +28,7 @@ module Admin::DashboardHelper
   def relevant_account_timestamp(account)
     timestamp = account.relevant_time
 
-    return '-' if timestamp.nil?
+    return DASHBOARD_MISSING_CONTENT if timestamp.nil?
     return t('generic.today') if account.user_signed_in_today?
 
     content_tag(:time, l(timestamp), class: 'time-ago', datetime: timestamp.iso8601, title: l(timestamp))

--- a/app/helpers/admin/dashboard_helper.rb
+++ b/app/helpers/admin/dashboard_helper.rb
@@ -24,15 +24,7 @@ module Admin::DashboardHelper
   end
 
   def relevant_account_timestamp(account)
-    timestamp = if account.user_current_sign_in_at
-                  account.user_current_sign_in_at
-                elsif account.user_pending?
-                  account.user_created_at
-                elsif account.suspended_at.present? && account.local? && account.user.nil?
-                  account.suspended_at
-                elsif account.last_status_at.present?
-                  account.last_status_at
-                end
+    timestamp = account.relevant_time
 
     return '-' if timestamp.nil?
     return t('generic.today') if account.user_current_sign_in_at && account.user_current_sign_in_at >= 24.hours.ago

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -225,6 +225,18 @@ class Account < ApplicationRecord
     Follow.where(target_account_id: id).count
   end
 
+  def relevant_time
+    if user_current_sign_in_at
+      user_current_sign_in_at
+    elsif user_pending?
+      user_created_at
+    elsif suspended_at.present? && local? && user.nil?
+      suspended_at
+    elsif last_status_at.present?
+      last_status_at
+    end
+  end
+
   def to_webfinger_s
     "acct:#{local_username_and_domain}"
   end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -173,6 +173,7 @@ class Account < ApplicationRecord
            :shows_application?,
            :prefers_noindex?,
            :time_zone,
+           :signed_in_today?,
            to: :user,
            prefix: true,
            allow_nil: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -69,6 +69,7 @@ class User < ApplicationRecord
   # RegenerationWorker jobs that need to be run when those people come
   # to check their feed
   ACTIVE_DURATION = ENV.fetch('USER_ACTIVE_DAYS', 7).to_i.days.freeze
+  DAILY_WINDOW = 24.hours
 
   devise :two_factor_authenticatable,
          otp_secret_encryption_key: Rails.configuration.x.otp_secret,
@@ -367,6 +368,10 @@ class User < ApplicationRecord
 
     # Finally, send a reset password prompt to the user
     send_reset_password_instructions
+  end
+
+  def signed_in_today?
+    current_sign_in_at && current_sign_in_at >= DAILY_WINDOW.ago
   end
 
   protected

--- a/spec/helpers/admin/dashboard_helper_spec.rb
+++ b/spec/helpers/admin/dashboard_helper_spec.rb
@@ -4,16 +4,17 @@ require 'rails_helper'
 
 RSpec.describe Admin::DashboardHelper do
   describe 'relevant_account_timestamp' do
+    subject { helper.relevant_account_timestamp(account) }
+
     context 'with an account with older sign in' do
       let(:account) { Fabricate(:account) }
       let(:stamp) { 10.days.ago }
 
       it 'returns a time element' do
         account.user.update(current_sign_in_at: stamp)
-        result = helper.relevant_account_timestamp(account)
-
-        expect(result).to match('time-ago')
-        expect(result).to match(I18n.l(stamp))
+        expect(subject)
+          .to match('time-ago')
+          .and match(I18n.l(stamp))
       end
     end
 
@@ -22,9 +23,9 @@ RSpec.describe Admin::DashboardHelper do
 
       it 'returns a time element' do
         account.user.update(current_sign_in_at: 10.hours.ago)
-        result = helper.relevant_account_timestamp(account)
 
-        expect(result).to eq(I18n.t('generic.today'))
+        expect(subject)
+          .to eq(I18n.t('generic.today'))
       end
     end
 
@@ -34,10 +35,10 @@ RSpec.describe Admin::DashboardHelper do
       it 'returns a time element' do
         account.user.update(current_sign_in_at: nil)
         account.user.update(approved: false)
-        result = helper.relevant_account_timestamp(account)
 
-        expect(result).to match('time-ago')
-        expect(result).to match(I18n.l(account.user.created_at))
+        expect(subject)
+          .to match('time-ago')
+          .and match(I18n.l(account.user.created_at))
       end
     end
 
@@ -45,10 +46,9 @@ RSpec.describe Admin::DashboardHelper do
       let(:account) { Fabricate(:account, suspended_at: 5.days.ago, user: nil) }
 
       it 'returns a time element' do
-        result = helper.relevant_account_timestamp(account)
-
-        expect(result).to match('time-ago')
-        expect(result).to match(I18n.l(account.suspended_at))
+        expect(subject)
+          .to match('time-ago')
+          .and match(I18n.l(account.suspended_at))
       end
     end
 
@@ -59,10 +59,10 @@ RSpec.describe Admin::DashboardHelper do
       it 'returns a time element' do
         account.user.update(current_sign_in_at: nil)
         account.account_stat.update(last_status_at: stamp)
-        result = helper.relevant_account_timestamp(account)
 
-        expect(result).to match('time-ago')
-        expect(result).to match(I18n.l(stamp))
+        expect(subject)
+          .to match('time-ago')
+          .and match(I18n.l(stamp))
       end
     end
 
@@ -71,9 +71,9 @@ RSpec.describe Admin::DashboardHelper do
 
       it 'returns a time element' do
         account.user.update(current_sign_in_at: nil)
-        result = helper.relevant_account_timestamp(account)
 
-        expect(result).to eq('-')
+        expect(subject)
+          .to eq('-')
       end
     end
   end

--- a/spec/helpers/admin/dashboard_helper_spec.rb
+++ b/spec/helpers/admin/dashboard_helper_spec.rb
@@ -41,6 +41,17 @@ RSpec.describe Admin::DashboardHelper do
       end
     end
 
+    context 'with a local account without a user that is suspended' do
+      let(:account) { Fabricate(:account, suspended_at: 5.days.ago, user: nil) }
+
+      it 'returns a time element' do
+        result = helper.relevant_account_timestamp(account)
+
+        expect(result).to match('time-ago')
+        expect(result).to match(I18n.l(account.suspended_at))
+      end
+    end
+
     context 'with an account with a last status value' do
       let(:account) { Fabricate(:account) }
       let(:stamp) { 5.minutes.ago }

--- a/spec/helpers/admin/dashboard_helper_spec.rb
+++ b/spec/helpers/admin/dashboard_helper_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Admin::DashboardHelper do
 
         expect(subject)
           .to eq(I18n.t('generic.today'))
+          .and not_include('time-ago')
       end
     end
 
@@ -74,6 +75,7 @@ RSpec.describe Admin::DashboardHelper do
 
         expect(subject)
           .to eq('-')
+          .and not_include('time-ago')
       end
     end
   end


### PR DESCRIPTION
Issues here:

- The double assignment feels weird, and there's only one code path where "exact" matters
- Basically everything in this method is reaching into the `Account` instance

Changes:

- We added code path here - https://github.com/mastodon/mastodon/pull/25640 - but did not add coverage, so add it first.
- Tidy up the helper spec (use subject, etc...)
- Move the full if/else block into a new `Account#relevant_time` method which holds that logic, leaving the hepler to just handle the string returns for each case
- Move the logic about which condition is not exact onto a method on User that checks the sign in

Followups here:

- This has good coverage from the helper method ... possible refactor would be to move the strict time checks over to account spec, and stub values for the helper specs
- The method on user would make a truly succulent addition to https://github.com/mastodon/mastodon/pull/31270 - should rebase this after that merges, or vice versa