### PR TITLE
Fix missing content warning text in rss formatter

### DIFF
--- a/spec/helpers/formatting_helper_spec.rb
+++ b/spec/helpers/formatting_helper_spec.rb
@@ -6,19 +6,15 @@ RSpec.describe FormattingHelper do
   include Devise::Test::ControllerHelpers
 
   describe '#rss_status_content_format' do
+    subject { helper.rss_status_content_format(status) }
+
     let(:status) { Fabricate(:status, text: 'Hello world<>', spoiler_text: 'This is a spoiler<>', poll: Fabricate(:poll, options: %w(Yes<> No))) }
-    let(:html) { helper.rss_status_content_format(status) }
 
-    it 'renders the spoiler text' do
-      expect(html).to include('<p>This is a spoiler&lt;&gt;</p><hr>')
-    end
-
-    it 'renders the status text' do
-      expect(html).to include('<p>Hello world&lt;&gt;</p>')
-    end
-
-    it 'renders the poll' do
-      expect(html).to include('<radio disabled="disabled">Yes&lt;&gt;</radio><br>')
+    it 'renders the formatted elements' do
+      expect(subject)
+        .to include('<p>This is a spoiler&lt;&gt;</p><hr>')
+        .and include('<p>Hello world&lt;&gt;</p>')
+        .and include('<radio disabled="disabled">Yes&lt;&gt;</radio><br>')
     end
   end
 end

--- a/spec/helpers/formatting_helper_spec.rb
+++ b/spec/helpers/formatting_helper_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe FormattingHelper do
       let(:status) { Fabricate.build :status, text: 'Hello world' }
 
       it 'renders the formatted elements' do
-        expect(subject)
-          .to eq('<p>Hello world</p>')
+        expect(parsed_result.css('p').first.text)
+          .to eq('Hello world')
       end
     end
 
@@ -23,12 +23,40 @@ RSpec.describe FormattingHelper do
       before { Fabricate :custom_emoji, shortcode: 'world' }
 
       it 'renders the formatted elements' do
-        expect(subject)
-          .to include('<p><strong>Content warning:</strong>This is a spoiler&lt;&gt;</p><hr>')
-          .and include('<p>Hello <img rel="emoji" draggable="false"')
-          .and include('emojo.png"> &lt;&gt;</p>')
-          .and include('<radio disabled="disabled">Yes&lt;&gt;</radio><br>')
+        expect(spoiler_node.css('strong').text)
+          .to eq('Content warning:')
+        expect(spoiler_node.text)
+          .to include('This is a spoiler<>')
+        expect(content_node.text)
+          .to eq('Hello  <>')
+        expect(content_node.css('img').first.to_h.symbolize_keys)
+          .to include(
+            rel: 'emoji',
+            title: ':world:'
+          )
+        expect(poll_node.css('radio').first.text)
+          .to eq('Yes<>')
+        expect(poll_node.css('radio').first.to_h.symbolize_keys)
+          .to include(
+            disabled: 'disabled'
+          )
       end
+
+      def spoiler_node
+        parsed_result.css('p').first
+      end
+
+      def content_node
+        parsed_result.css('p')[1]
+      end
+
+      def poll_node
+        parsed_result.css('p').last
+      end
+    end
+
+    def parsed_result
+      Nokogiri::HTML.fragment(subject)
     end
   end
 end

--- a/spec/helpers/formatting_helper_spec.rb
+++ b/spec/helpers/formatting_helper_spec.rb
@@ -8,13 +8,27 @@ RSpec.describe FormattingHelper do
   describe '#rss_status_content_format' do
     subject { helper.rss_status_content_format(status) }
 
-    let(:status) { Fabricate(:status, text: 'Hello world<>', spoiler_text: 'This is a spoiler<>', poll: Fabricate(:poll, options: %w(Yes<> No))) }
+    context 'with a simple status' do
+      let(:status) { Fabricate.build :status, text: 'Hello world' }
 
-    it 'renders the formatted elements' do
-      expect(subject)
-        .to include('<p>This is a spoiler&lt;&gt;</p><hr>')
-        .and include('<p>Hello world&lt;&gt;</p>')
-        .and include('<radio disabled="disabled">Yes&lt;&gt;</radio><br>')
+      it 'renders the formatted elements' do
+        expect(subject)
+          .to eq('<p>Hello world</p>')
+      end
+    end
+
+    context 'with a spoiler and an emoji and a poll' do
+      let(:status) { Fabricate(:status, text: 'Hello :world: <>', spoiler_text: 'This is a spoiler<>', poll: Fabricate(:poll, options: %w(Yes<> No))) }
+
+      before { Fabricate :custom_emoji, shortcode: 'world' }
+
+      it 'renders the formatted elements' do
+        expect(subject)
+          .to include('<p><strong>Content warning:</strong>This is a spoiler&lt;&gt;</p><hr>')
+          .and include('<p>Hello <img rel="emoji" draggable="false"')
+          .and include('emojo.png"> &lt;&gt;</p>')
+          .and include('<radio disabled="disabled">Yes&lt;&gt;</radio><br>')
+      end
     end
   end
 end


### PR DESCRIPTION
Changes here:

- In spec file, combine previous same-setup examples
- In spec, split into contexts for "basic" (just simple status) and more advanced -- spoiler, polls, emoji, etc
- Extract css to constant (and add missing trailing semicolon, probably inconsequential)
- Fix issue where the `<strong>Content warning:</strong>` warning wrapper portion was not included in the feed. Note how it's in the nested hierarchy here, but not string concat'd, so it gets silently dropped. I'm assuming it should be included?
- Split up the before/main/after portions of the built item into separate methods

Future:

- Might make sense to more narrowly handle each type of thing in the spec, just did enough here to expose the issue.
- There should probably be an entire class to wrap this generation, instead of passing around the status in here