### PR TITLE
Move User pending count to async query on admin accounts dropdown

### DIFF
--- a/app/controllers/admin/accounts_controller.rb
+++ b/app/controllers/admin/accounts_controller.rb
@@ -9,6 +9,7 @@ module Admin
     def index
       authorize :account, :index?
 
+      @state_counts = load_state_counts
       @accounts = filtered_accounts.page(params[:page])
       @form     = Form::AccountBatch.new
     end
@@ -159,6 +160,10 @@ module Admin
 
     def form_account_batch_params
       params.require(:form_account_batch).permit(:action, account_ids: [])
+    end
+
+    def load_state_counts
+      { pending: User.pending.async_count }
     end
 
     def action_from_button

--- a/app/helpers/admin/accounts_helper.rb
+++ b/app/helpers/admin/accounts_helper.rb
@@ -1,19 +1,13 @@
 # frozen_string_literal: true
 
 module Admin::AccountsHelper
-  def admin_accounts_moderation_options
+  def admin_accounts_moderation_options(counts)
     [
       [t('admin.accounts.moderation.active'), 'active'],
       [t('admin.accounts.moderation.silenced'), 'silenced'],
       [t('admin.accounts.moderation.disabled'), 'disabled'],
       [t('admin.accounts.moderation.suspended'), 'suspended'],
-      [safe_join([t('admin.accounts.moderation.pending'), "(#{pending_user_count_label})"], ' '), 'pending'],
+      [safe_join([t('admin.accounts.moderation.pending'), "(#{number_with_delimiter(counts[:pending].value)})"], ' '), 'pending'],
     ]
-  end
-
-  private
-
-  def pending_user_count_label
-    number_with_delimiter User.pending.count
   end
 end

--- a/app/views/admin/accounts/index.html.haml
+++ b/app/views/admin/accounts/index.html.haml
@@ -13,7 +13,7 @@
       %strong= t('admin.accounts.moderation.title')
       .input.select.optional
         = form.select :status,
-                      options_for_select(admin_accounts_moderation_options, params[:status]),
+                      options_for_select(admin_accounts_moderation_options(@state_counts), params[:status]),
                       prompt: I18n.t('generic.all')
     .filter-subset.filter-subset--with-select
       %strong= t('admin.accounts.role')


### PR DESCRIPTION
Moves the count query up out of view generation and into controller, and uses async so in theory we can grab a count while other stuff happens.

Went back and forth on naming this more narrowly for current usage (`@pending_user_count` or something) vs keeping it a little abstract for potential use by other things on the page which could be async counted. Would be fine swapping approach there.