### PR TITLE
Fix language of push notifications

### DIFF
--- a/app/workers/web/push_notification_worker.rb
+++ b/app/workers/web/push_notification_worker.rb
@@ -55,12 +55,8 @@ class Web::PushNotificationWorker
   end
 
   def push_notification_json
-    Oj.dump(serialized_notification_in_subscription_locale.as_json)
-  end
-
-  def serialized_notification_in_subscription_locale
     I18n.with_locale(@subscription.locale.presence || I18n.default_locale) do
-      serialized_notification
+      Oj.dump(serialized_notification.as_json)
     end
   end
 


### PR DESCRIPTION
Fixes #32294

The `#as_json` call is the one responsible for serializing, and thus calling the translation strings. In #32208, it had been erroneously moved outside the `I18n.with_locale` block.