### PR TITLE
Add github action workflow to build nightly images for releases

### DIFF
--- a/.github/workflows/build-container-image.yml
+++ b/.github/workflows/build-container-image.yml
@@ -1,6 +1,9 @@
 on:
   workflow_call:
     inputs:
+      branch:
+        required: false
+        type: string
       platforms:
         required: true
         type: string
@@ -30,6 +33,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        ref: ${{ inputs.branch || '' }}
 
       - uses: docker/setup-qemu-action@v3
         if: contains(inputs.platforms, 'linux/arm64') && !inputs.use_native_arm64_builder

--- a/.github/workflows/build-stable-nightly.yml
+++ b/.github/workflows/build-stable-nightly.yml
@@ -1,0 +1,66 @@
+name: Build nightly container image (stable branches)
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 2 * * *' # run at 2 AM UTC
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  compute-suffix:
+    runs-on: ubuntu-latest
+    if: github.repository == 'mastodon/mastodon'
+    steps:
+      - id: version_vars
+        env:
+          TZ: Etc/UTC
+        run: |
+          echo mastodon_version_prerelease=4.3-nightly.$(date +'%Y-%m-%d')>> $GITHUB_OUTPUT
+    outputs:
+      prerelease: ${{ steps.version_vars.outputs.mastodon_version_prerelease }}
+
+  build-image:
+    needs: compute-suffix
+    uses: ./.github/workflows/build-container-image.yml
+    with:
+      branch: stable-4.3
+      file_to_build: Dockerfile
+      platforms: linux/amd64,linux/arm64
+      use_native_arm64_builder: true
+      cache: false
+      push_to_images: |
+        tootsuite/mastodon
+        ghcr.io/mastodon/mastodon
+      version_prerelease: ${{ needs.compute-suffix.outputs.prerelease }}
+      labels: |
+        org.opencontainers.image.description=Nightly build image used for testing purposes
+      flavor: |
+        latest=false
+      tags: |
+        type=raw,value=4.3-nightly
+        type=schedule,pattern=${{ needs.compute-suffix.outputs.prerelease }}
+    secrets: inherit
+
+  build-image-streaming:
+    needs: compute-suffix
+    uses: ./.github/workflows/build-container-image.yml
+    with:
+      branch: stable-4.3
+      file_to_build: streaming/Dockerfile
+      platforms: linux/amd64,linux/arm64
+      use_native_arm64_builder: true
+      cache: false
+      push_to_images: |
+        tootsuite/mastodon-streaming
+        ghcr.io/mastodon/mastodon-streaming
+      version_prerelease: ${{ needs.compute-suffix.outputs.prerelease }}
+      labels: |
+        org.opencontainers.image.description=Nightly build image used for testing purposes
+      flavor: |
+        latest=false
+      tags: |
+        type=raw,value=4.3-nightly
+        type=schedule,pattern=${{ needs.compute-suffix.outputs.prerelease }}
+    secrets: inherit


### PR DESCRIPTION
Add nightly builds for 4.3 as well.

I'm not sure how to test it, and I suppose there is potential for breaking other builds :/

Also, we probably want to only build new nightlies if there have been actual changes since the previous nightly, but I'm not completely sure how to do that.