### PR TITLE
Improve `app/policies` coverage

### DIFF
--- a/spec/policies/account_moderation_note_policy_spec.rb
+++ b/spec/policies/account_moderation_note_policy_spec.rb
@@ -11,13 +11,13 @@ RSpec.describe AccountModerationNotePolicy do
   permissions :create? do
     context 'when staff' do
       it 'grants to create' do
-        expect(subject).to permit(admin, described_class)
+        expect(subject).to permit(admin, AccountModerationNote)
       end
     end
 
     context 'when not staff' do
       it 'denies to create' do
-        expect(subject).to_not permit(john, described_class)
+        expect(subject).to_not permit(john, AccountModerationNote)
       end
     end
   end

--- a/spec/policies/account_moderation_note_policy_spec.rb
+++ b/spec/policies/account_moderation_note_policy_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'pundit/rspec'
 
 RSpec.describe AccountModerationNotePolicy do
   subject { described_class }

--- a/spec/policies/account_policy_spec.rb
+++ b/spec/policies/account_policy_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe AccountPolicy do
     end
   end
 
-  permissions :show?, :unsilence?, :unsensitive?, :remove_avatar?, :remove_header? do
+  permissions :show?, :unsilence?, :unsensitive?, :remove_avatar?, :remove_header?, :sensitive?, :warn? do
     context 'when staff' do
       it 'permits' do
         expect(subject).to permit(admin, alice)

--- a/spec/policies/account_policy_spec.rb
+++ b/spec/policies/account_policy_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'pundit/rspec'
 
 RSpec.describe AccountPolicy do
   subject { described_class }

--- a/spec/policies/account_warning_policy_spec.rb
+++ b/spec/policies/account_warning_policy_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'pundit/rspec'
+
+RSpec.describe AccountWarningPolicy do
+  subject { described_class }
+
+  let(:admin) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
+  let(:account) { Fabricate(:account) }
+
+  permissions :show? do
+    context 'with an admin' do
+      it { is_expected.to permit(admin, AccountWarning.new) }
+    end
+
+    context 'with a non-admin' do
+      context 'when account is not target' do
+        it { is_expected.to_not permit(account, AccountWarning.new) }
+      end
+
+      context 'when account is target' do
+        it { is_expected.to permit(account, AccountWarning.new(target_account_id: account.id)) }
+      end
+    end
+  end
+
+  permissions :appeal? do
+    context 'when account is not target' do
+      it { is_expected.to_not permit(account, AccountWarning.new) }
+    end
+
+    context 'when account is target' do
+      context 'when record is appealable' do
+        it { is_expected.to permit(account, AccountWarning.new(target_account_id: account.id, created_at: Appeal::MAX_STRIKE_AGE.ago + 1.hour)) }
+      end
+
+      context 'when record is not appealable' do
+        it { is_expected.to_not permit(account, AccountWarning.new(target_account_id: account.id, created_at: Appeal::MAX_STRIKE_AGE.ago - 1.hour)) }
+      end
+    end
+  end
+end

--- a/spec/policies/account_warning_policy_spec.rb
+++ b/spec/policies/account_warning_policy_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'pundit/rspec'
 
 RSpec.describe AccountWarningPolicy do
   subject { described_class }

--- a/spec/policies/account_warning_preset_policy_spec.rb
+++ b/spec/policies/account_warning_preset_policy_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe AccountWarningPresetPolicy do
   permissions :index?, :create?, :update?, :destroy? do
     context 'with an admin' do
       it 'permits' do
-        expect(policy).to permit(admin, Tag)
+        expect(policy).to permit(admin, AccountWarningPreset)
       end
     end
 
     context 'with a non-admin' do
       it 'denies' do
-        expect(policy).to_not permit(john, Tag)
+        expect(policy).to_not permit(john, AccountWarningPreset)
       end
     end
   end

--- a/spec/policies/account_warning_preset_policy_spec.rb
+++ b/spec/policies/account_warning_preset_policy_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'pundit/rspec'
 
 RSpec.describe AccountWarningPresetPolicy do
   let(:policy) { described_class }

--- a/spec/policies/admin/status_policy_spec.rb
+++ b/spec/policies/admin/status_policy_spec.rb
@@ -12,13 +12,13 @@ RSpec.describe Admin::StatusPolicy do
   permissions :index?, :update?, :review?, :destroy? do
     context 'with an admin' do
       it 'permits' do
-        expect(policy).to permit(admin, Tag)
+        expect(policy).to permit(admin, Status)
       end
     end
 
     context 'with a non-admin' do
       it 'denies' do
-        expect(policy).to_not permit(john, Tag)
+        expect(policy).to_not permit(john, Status)
       end
     end
   end

--- a/spec/policies/admin/status_policy_spec.rb
+++ b/spec/policies/admin/status_policy_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'pundit/rspec'
 
 RSpec.describe Admin::StatusPolicy do
   let(:policy) { described_class }

--- a/spec/policies/announcement_policy_spec.rb
+++ b/spec/policies/announcement_policy_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe AnnouncementPolicy do
   permissions :index?, :create?, :update?, :destroy? do
     context 'with an admin' do
       it 'permits' do
-        expect(policy).to permit(admin, Tag)
+        expect(policy).to permit(admin, Announcement)
       end
     end
 
     context 'with a non-admin' do
       it 'denies' do
-        expect(policy).to_not permit(john, Tag)
+        expect(policy).to_not permit(john, Announcement)
       end
     end
   end

--- a/spec/policies/announcement_policy_spec.rb
+++ b/spec/policies/announcement_policy_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'pundit/rspec'
 
 RSpec.describe AnnouncementPolicy do
   let(:policy) { described_class }

--- a/spec/policies/appeal_policy_spec.rb
+++ b/spec/policies/appeal_policy_spec.rb
@@ -11,13 +11,13 @@ RSpec.describe AppealPolicy do
   permissions :index? do
     context 'with an admin' do
       it 'permits' do
-        expect(policy).to permit(admin, Tag)
+        expect(policy).to permit(admin, Appeal)
       end
     end
 
     context 'with a non-admin' do
       it 'denies' do
-        expect(policy).to_not permit(john, Tag)
+        expect(policy).to_not permit(john, Appeal)
       end
     end
   end

--- a/spec/policies/appeal_policy_spec.rb
+++ b/spec/policies/appeal_policy_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe AppealPolicy do
     end
   end
 
-  permissions :reject? do
+  permissions :reject?, :approve? do
     context 'with an admin' do
       context 'with a pending appeal' do
         before { allow(appeal).to receive(:pending?).and_return(true) }

--- a/spec/policies/appeal_policy_spec.rb
+++ b/spec/policies/appeal_policy_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'pundit/rspec'
 
 RSpec.describe AppealPolicy do
   let(:policy) { described_class }

--- a/spec/policies/audit_log_policy_spec.rb
+++ b/spec/policies/audit_log_policy_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'pundit/rspec'
 
 RSpec.describe AuditLogPolicy do
   subject { described_class }

--- a/spec/policies/audit_log_policy_spec.rb
+++ b/spec/policies/audit_log_policy_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'pundit/rspec'
+
+RSpec.describe AuditLogPolicy do
+  subject { described_class }
+
+  let(:admin) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
+  let(:account) { Fabricate(:account) }
+
+  permissions :index? do
+    context 'with an admin' do
+      it { is_expected.to permit(admin, AccountWarning.new) }
+    end
+
+    context 'with a non-admin' do
+      it { is_expected.to_not permit(account, AccountWarning.new) }
+    end
+  end
+end

--- a/spec/policies/audit_log_policy_spec.rb
+++ b/spec/policies/audit_log_policy_spec.rb
@@ -10,11 +10,11 @@ RSpec.describe AuditLogPolicy do
 
   permissions :index? do
     context 'with an admin' do
-      it { is_expected.to permit(admin, AccountWarning.new) }
+      it { is_expected.to permit(admin, nil) }
     end
 
     context 'with a non-admin' do
-      it { is_expected.to_not permit(account, AccountWarning.new) }
+      it { is_expected.to_not permit(account, nil) }
     end
   end
 end

--- a/spec/policies/backup_policy_spec.rb
+++ b/spec/policies/backup_policy_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'pundit/rspec'
 
 RSpec.describe BackupPolicy do
   subject { described_class }

--- a/spec/policies/canonical_email_block_policy_spec.rb
+++ b/spec/policies/canonical_email_block_policy_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'pundit/rspec'
 
 RSpec.describe CanonicalEmailBlockPolicy do
   let(:policy) { described_class }

--- a/spec/policies/canonical_email_block_policy_spec.rb
+++ b/spec/policies/canonical_email_block_policy_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe CanonicalEmailBlockPolicy do
   permissions :index?, :show?, :test?, :create?, :destroy? do
     context 'with an admin' do
       it 'permits' do
-        expect(policy).to permit(admin, Tag)
+        expect(policy).to permit(admin, CanonicalEmailBlock)
       end
     end
 
     context 'with a non-admin' do
       it 'denies' do
-        expect(policy).to_not permit(john, Tag)
+        expect(policy).to_not permit(john, CanonicalEmailBlock)
       end
     end
   end

--- a/spec/policies/custom_emoji_policy_spec.rb
+++ b/spec/policies/custom_emoji_policy_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'pundit/rspec'
 
 RSpec.describe CustomEmojiPolicy do
   subject { described_class }

--- a/spec/policies/dashboard_policy_spec.rb
+++ b/spec/policies/dashboard_policy_spec.rb
@@ -10,11 +10,11 @@ RSpec.describe DashboardPolicy do
 
   permissions :index? do
     context 'with an admin' do
-      it { is_expected.to permit(admin, AccountWarning.new) }
+      it { is_expected.to permit(admin, nil) }
     end
 
     context 'with a non-admin' do
-      it { is_expected.to_not permit(account, AccountWarning.new) }
+      it { is_expected.to_not permit(account, nil) }
     end
   end
 end

--- a/spec/policies/dashboard_policy_spec.rb
+++ b/spec/policies/dashboard_policy_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'pundit/rspec'
+
+RSpec.describe DashboardPolicy do
+  subject { described_class }
+
+  let(:admin) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
+  let(:account) { Fabricate(:account) }
+
+  permissions :index? do
+    context 'with an admin' do
+      it { is_expected.to permit(admin, AccountWarning.new) }
+    end
+
+    context 'with a non-admin' do
+      it { is_expected.to_not permit(account, AccountWarning.new) }
+    end
+  end
+end

--- a/spec/policies/dashboard_policy_spec.rb
+++ b/spec/policies/dashboard_policy_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'pundit/rspec'
 
 RSpec.describe DashboardPolicy do
   subject { described_class }

--- a/spec/policies/delivery_policy_spec.rb
+++ b/spec/policies/delivery_policy_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe DeliveryPolicy do
   permissions :clear_delivery_errors?, :restart_delivery?, :stop_delivery? do
     context 'with an admin' do
       it 'permits' do
-        expect(policy).to permit(admin, Tag)
+        expect(policy).to permit(admin, nil)
       end
     end
 
     context 'with a non-admin' do
       it 'denies' do
-        expect(policy).to_not permit(john, Tag)
+        expect(policy).to_not permit(john, nil)
       end
     end
   end

--- a/spec/policies/delivery_policy_spec.rb
+++ b/spec/policies/delivery_policy_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'pundit/rspec'
 
 RSpec.describe DeliveryPolicy do
   let(:policy) { described_class }

--- a/spec/policies/domain_allow_policy_spec.rb
+++ b/spec/policies/domain_allow_policy_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'pundit/rspec'
 
 RSpec.describe DomainAllowPolicy do
   subject { described_class }

--- a/spec/policies/domain_allow_policy_spec.rb
+++ b/spec/policies/domain_allow_policy_spec.rb
@@ -3,22 +3,22 @@
 require 'rails_helper'
 require 'pundit/rspec'
 
-RSpec.describe DomainBlockPolicy do
+RSpec.describe DomainAllowPolicy do
   subject { described_class }
 
   let(:admin)   { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
   let(:john)    { Fabricate(:account) }
 
-  permissions :index?, :show?, :create?, :destroy?, :update? do
+  permissions :index?, :show?, :create?, :destroy? do
     context 'when admin' do
       it 'permits' do
-        expect(subject).to permit(admin, DomainBlock)
+        expect(subject).to permit(admin, DomainAllow)
       end
     end
 
     context 'when not admin' do
       it 'denies' do
-        expect(subject).to_not permit(john, DomainBlock)
+        expect(subject).to_not permit(john, DomainAllow)
       end
     end
   end

--- a/spec/policies/domain_block_policy_spec.rb
+++ b/spec/policies/domain_block_policy_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'pundit/rspec'
 
 RSpec.describe DomainBlockPolicy do
   subject { described_class }

--- a/spec/policies/email_domain_block_policy_spec.rb
+++ b/spec/policies/email_domain_block_policy_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'pundit/rspec'
 
 RSpec.describe EmailDomainBlockPolicy do
   subject { described_class }

--- a/spec/policies/follow_recommendation_policy_spec.rb
+++ b/spec/policies/follow_recommendation_policy_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'pundit/rspec'
 
 RSpec.describe FollowRecommendationPolicy do
   let(:policy) { described_class }

--- a/spec/policies/follow_recommendation_policy_spec.rb
+++ b/spec/policies/follow_recommendation_policy_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe FollowRecommendationPolicy do
   permissions :show?, :suppress?, :unsuppress? do
     context 'with an admin' do
       it 'permits' do
-        expect(policy).to permit(admin, Tag)
+        expect(policy).to permit(admin, FollowRecommendation)
       end
     end
 
     context 'with a non-admin' do
       it 'denies' do
-        expect(policy).to_not permit(john, Tag)
+        expect(policy).to_not permit(john, FollowRecommendation)
       end
     end
   end

--- a/spec/policies/instance_policy_spec.rb
+++ b/spec/policies/instance_policy_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'pundit/rspec'
 
 RSpec.describe InstancePolicy do
   subject { described_class }

--- a/spec/policies/invite_policy_spec.rb
+++ b/spec/policies/invite_policy_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'pundit/rspec'
 
 RSpec.describe InvitePolicy do
   subject { described_class }

--- a/spec/policies/ip_block_policy_spec.rb
+++ b/spec/policies/ip_block_policy_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe IpBlockPolicy do
   permissions :index?, :show?, :create?, :update?, :destroy? do
     context 'with an admin' do
       it 'permits' do
-        expect(policy).to permit(admin, Tag)
+        expect(policy).to permit(admin, IpBlock)
       end
     end
 
     context 'with a non-admin' do
       it 'denies' do
-        expect(policy).to_not permit(john, Tag)
+        expect(policy).to_not permit(john, IpBlock)
       end
     end
   end

--- a/spec/policies/ip_block_policy_spec.rb
+++ b/spec/policies/ip_block_policy_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'pundit/rspec'
 
 RSpec.describe IpBlockPolicy do
   let(:policy) { described_class }

--- a/spec/policies/poll_policy_spec.rb
+++ b/spec/policies/poll_policy_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'pundit/rspec'
 
 RSpec.describe PollPolicy do
   subject { described_class }

--- a/spec/policies/poll_policy_spec.rb
+++ b/spec/policies/poll_policy_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'pundit/rspec'
+
+RSpec.describe PollPolicy do
+  subject { described_class }
+
+  let(:account) { Fabricate(:account) }
+  let(:poll) { Fabricate :poll }
+
+  permissions :vote? do
+    context 'when account cannot view status' do
+      before { poll.status.update(visibility: :private) }
+
+      it { is_expected.to_not permit(account, poll) }
+    end
+
+    context 'when account can view status' do
+      context 'when accounts do not block each other' do
+        it { is_expected.to permit(account, poll) }
+      end
+
+      context 'when view blocks poll creator' do
+        before { Fabricate :block, account: account, target_account: poll.account }
+
+        it { is_expected.to_not permit(account, poll) }
+      end
+
+      context 'when poll creator blocks viewer' do
+        before { Fabricate :block, account: poll.account, target_account: account }
+
+        it { is_expected.to_not permit(account, poll) }
+      end
+    end
+  end
+end

--- a/spec/policies/preview_card_policy_spec.rb
+++ b/spec/policies/preview_card_policy_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe PreviewCardPolicy do
   permissions :index?, :review? do
     context 'with an admin' do
       it 'permits' do
-        expect(policy).to permit(admin, Tag)
+        expect(policy).to permit(admin, PreviewCard)
       end
     end
 
     context 'with a non-admin' do
       it 'denies' do
-        expect(policy).to_not permit(john, Tag)
+        expect(policy).to_not permit(john, PreviewCard)
       end
     end
   end

--- a/spec/policies/preview_card_policy_spec.rb
+++ b/spec/policies/preview_card_policy_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'pundit/rspec'
 
 RSpec.describe PreviewCardPolicy do
   let(:policy) { described_class }

--- a/spec/policies/preview_card_provider_policy_spec.rb
+++ b/spec/policies/preview_card_provider_policy_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe PreviewCardProviderPolicy do
   permissions :index?, :review? do
     context 'with an admin' do
       it 'permits' do
-        expect(policy).to permit(admin, Tag)
+        expect(policy).to permit(admin, PreviewCardProvider)
       end
     end
 
     context 'with a non-admin' do
       it 'denies' do
-        expect(policy).to_not permit(john, Tag)
+        expect(policy).to_not permit(john, PreviewCardProvider)
       end
     end
   end

--- a/spec/policies/preview_card_provider_policy_spec.rb
+++ b/spec/policies/preview_card_provider_policy_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'pundit/rspec'
 
 RSpec.describe PreviewCardProviderPolicy do
   let(:policy) { described_class }

--- a/spec/policies/relay_policy_spec.rb
+++ b/spec/policies/relay_policy_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'pundit/rspec'
 
 RSpec.describe RelayPolicy do
   subject { described_class }

--- a/spec/policies/report_note_policy_spec.rb
+++ b/spec/policies/report_note_policy_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'pundit/rspec'
 
 RSpec.describe ReportNotePolicy do
   subject { described_class }

--- a/spec/policies/report_policy_spec.rb
+++ b/spec/policies/report_policy_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'pundit/rspec'
 
 RSpec.describe ReportPolicy do
   subject { described_class }

--- a/spec/policies/rule_policy_spec.rb
+++ b/spec/policies/rule_policy_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe RulePolicy do
   permissions :index?, :create?, :update?, :destroy? do
     context 'with an admin' do
       it 'permits' do
-        expect(policy).to permit(admin, Tag)
+        expect(policy).to permit(admin, Rule)
       end
     end
 
     context 'with a non-admin' do
       it 'denies' do
-        expect(policy).to_not permit(john, Tag)
+        expect(policy).to_not permit(john, Rule)
       end
     end
   end

--- a/spec/policies/rule_policy_spec.rb
+++ b/spec/policies/rule_policy_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'pundit/rspec'
 
 RSpec.describe RulePolicy do
   let(:policy) { described_class }

--- a/spec/policies/settings_policy_spec.rb
+++ b/spec/policies/settings_policy_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'pundit/rspec'
 
 RSpec.describe SettingsPolicy do
   subject { described_class }

--- a/spec/policies/software_update_policy_spec.rb
+++ b/spec/policies/software_update_policy_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'pundit/rspec'
 
 RSpec.describe SoftwareUpdatePolicy do
   subject { described_class }

--- a/spec/policies/status_policy_spec.rb
+++ b/spec/policies/status_policy_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'pundit/rspec'
 
 RSpec.describe StatusPolicy, type: :model do
   subject { described_class }

--- a/spec/policies/tag_policy_spec.rb
+++ b/spec/policies/tag_policy_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'pundit/rspec'
 
 RSpec.describe TagPolicy do
   subject { described_class }

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'pundit/rspec'
 
 RSpec.describe UserPolicy do
   subject { described_class }

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -112,4 +112,42 @@ RSpec.describe UserPolicy do
       end
     end
   end
+
+  permissions :approve?, :reject? do
+    context 'when admin' do
+      context 'when user is approved' do
+        it { is_expected.to_not permit(admin, User.new(approved: true)) }
+      end
+
+      context 'when user is not approved' do
+        it { is_expected.to permit(admin, User.new(approved: false)) }
+      end
+    end
+
+    context 'when not admin' do
+      it { is_expected.to_not permit(john, User.new) }
+    end
+  end
+
+  permissions :change_role? do
+    context 'when not admin' do
+      it { is_expected.to_not permit(john, User.new) }
+    end
+
+    context 'when admin' do
+      let(:user) { User.new(role: role) }
+
+      context 'when role of admin overrides user role' do
+        let(:role) { UserRole.new(position: admin.user.role.position - 10, id: 123) }
+
+        it { is_expected.to permit(admin, user) }
+      end
+
+      context 'when role of admin does not override user role' do
+        let(:role) { UserRole.new(position: admin.user.role.position + 10, id: 123) }
+
+        it { is_expected.to_not permit(admin, user) }
+      end
+    end
+  end
 end

--- a/spec/policies/user_role_policy_spec.rb
+++ b/spec/policies/user_role_policy_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'pundit/rspec'
+
+RSpec.describe UserRolePolicy do
+  subject { described_class }
+
+  let(:admin) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
+  let(:account) { Fabricate(:account) }
+
+  permissions :index?, :create? do
+    context 'when admin' do
+      it { is_expected.to permit(admin, UserRole.new) }
+    end
+
+    context 'when not admin' do
+      it { is_expected.to_not permit(account, UserRole.new) }
+    end
+  end
+
+  permissions :update? do
+    context 'when admin' do
+      context 'when role of admin overrides relevant role' do
+        it { is_expected.to permit(admin, UserRole.new(position: admin.user.role.position - 10, id: 123)) }
+      end
+
+      context 'when role of admin does not override relevant role' do
+        it { is_expected.to_not permit(admin, UserRole.new(position: admin.user.role.position + 10, id: 123)) }
+      end
+    end
+
+    context 'when not admin' do
+      it { is_expected.to_not permit(account, UserRole.new) }
+    end
+  end
+
+  permissions :destroy? do
+    context 'when admin' do
+      context 'when role of admin overrides relevant role' do
+        it { is_expected.to permit(admin, UserRole.new(position: admin.user.role.position - 10)) }
+      end
+
+      context 'when role of admin does not override relevant role' do
+        it { is_expected.to_not permit(admin, UserRole.new(position: admin.user.role.position + 10)) }
+      end
+
+      context 'when everyone role' do
+        it { is_expected.to_not permit(admin, UserRole.everyone) }
+      end
+    end
+
+    context 'when not admin' do
+      it { is_expected.to_not permit(account, UserRole.new) }
+    end
+  end
+end

--- a/spec/policies/user_role_policy_spec.rb
+++ b/spec/policies/user_role_policy_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'pundit/rspec'
 
 RSpec.describe UserRolePolicy do
   subject { described_class }

--- a/spec/policies/webhook_policy_spec.rb
+++ b/spec/policies/webhook_policy_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'pundit/rspec'
 
 RSpec.describe WebhookPolicy do
   let(:policy) { described_class }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -43,6 +43,7 @@ require 'paperclip/matchers'
 require 'capybara/rspec'
 require 'chewy/rspec'
 require 'email_spec/rspec'
+require 'pundit/rspec'
 require 'test_prof/recipes/rspec/before_all'
 
 Rails.root.glob('spec/support/**/*.rb').each { |f| require f }


### PR DESCRIPTION
Across all policies:

- Some classes/methods did not have specs, add them
- Move the `require pundit/rspec` to rails_helper instead of every spec
- For many of these checks, the second argument passed in really doesnt matter because the only thing being checked is ther permissions on the first (user) arg; thus many specs were just passing in `Tag`, probably a copy/paste side effect on initial coverage. Update many of these to use at least  the relevant class if not an actual instance.

This gets app/policies close to 100%, with only shortage being a few StatusPolicy edge cases, will attempt that and some policy class refactor as followup after coverage is in.