### PR TITLE
Add `ObfuscateDomainPresenter` implementation for `DomainBlock#public_domain` consumption

### DIFF
--- a/app/models/domain_block.rb
+++ b/app/models/domain_block.rb
@@ -87,18 +87,11 @@ class DomainBlock < ApplicationRecord
   end
 
   def public_domain
-    return domain unless obfuscate?
-
-    length        = domain.size
-    visible_ratio = length / 4
-
-    domain.chars.map.with_index do |chr, i|
-      if i > visible_ratio && i < length - visible_ratio && chr != '.'
-        '*'
-      else
-        chr
-      end
-    end.join
+    if obfuscate?
+      ObfuscatedDomainPresenter.new(domain).to_s
+    else
+      domain
+    end
   end
 
   def domain_digest

--- a/app/presenters/obfuscated_domain_presenter.rb
+++ b/app/presenters/obfuscated_domain_presenter.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class ObfuscatedDomainPresenter
+  attr_reader :domain, :placeholder
+
+  PRESERVED_CHARACTERS = %w(.).freeze
+  VISIBLE_WINDOW_EDGE = 4
+
+  def initialize(domain, placeholder: '*')
+    @domain = domain
+    @placeholder = placeholder
+  end
+
+  def to_s
+    domain_characters
+      .with_index { |character, index| solution(character, index) }
+      .join
+  end
+
+  private
+
+  def solution(character, index)
+    if midstream?(index) && PRESERVED_CHARACTERS.exclude?(character)
+      placeholder
+    else
+      character
+    end
+  end
+
+  def midstream?(index)
+    index > visible_ratio && index < ending_boundary
+  end
+
+  def domain_characters
+    domain.chars.map
+  end
+
+  def length
+    @length ||= domain.size
+  end
+
+  def visible_ratio
+    @visible_ratio ||= length / VISIBLE_WINDOW_EDGE
+  end
+
+  def ending_boundary
+    @ending_boundary ||= length - visible_ratio
+  end
+end

--- a/spec/presenters/obfuscated_domain_presenter_spec.rb
+++ b/spec/presenters/obfuscated_domain_presenter_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ObfuscatedDomainPresenter do
+  describe '#to_s' do
+    subject { described_class.new(domain).to_s }
+
+    context 'with a short domain' do
+      let(:domain) { 'abc.com' }
+
+      it { is_expected.to eq('ab*.**m') }
+    end
+
+    context 'with a long domain' do
+      let(:domain) { 'alphabet.soup.is.good.for.breakfast.and.lunch.and.dinner.org' }
+
+      it { is_expected.to eq('alphabet.soup.is.****.***.*********.***.*****.and.dinner.org') }
+    end
+
+    context 'with a domain from the federalized multiverse' do
+      let(:domain) { 'mastodon.social' }
+
+      it { is_expected.to eq('mast****.***ial') }
+    end
+
+    context 'with a series of dots' do
+      let(:domain) { '.....' }
+
+      it { is_expected.to eq('.....') }
+    end
+  end
+end


### PR DESCRIPTION
Pulls this non-core logic out of model into presenter.

The method already has some coverage in the model spec, added some stand-alone as well.