### PR TITLE
Remove default order from associations

### DIFF
--- a/app/models/concerns/account/interactions.rb
+++ b/app/models/concerns/account/interactions.rb
@@ -80,8 +80,8 @@ module Account::Interactions
       has_many :passive_relationships, foreign_key: 'target_account_id', inverse_of: :target_account
     end
 
-    has_many :following, -> { order(follows: { id: :desc }) }, through: :active_relationships,  source: :target_account
-    has_many :followers, -> { order(follows: { id: :desc }) }, through: :passive_relationships, source: :account
+    has_many :following, through: :active_relationships,  source: :target_account
+    has_many :followers, through: :passive_relationships, source: :account
 
     with_options class_name: 'SeveredRelationship', dependent: :destroy do
       has_many :severed_relationships, foreign_key: 'local_account_id', inverse_of: :local_account
@@ -96,16 +96,16 @@ module Account::Interactions
       has_many :block_relationships, foreign_key: 'account_id', inverse_of: :account
       has_many :blocked_by_relationships, foreign_key: :target_account_id, inverse_of: :target_account
     end
-    has_many :blocking, -> { order(blocks: { id: :desc }) }, through: :block_relationships, source: :target_account
-    has_many :blocked_by, -> { order(blocks: { id: :desc }) }, through: :blocked_by_relationships, source: :account
+    has_many :blocking, through: :block_relationships, source: :target_account
+    has_many :blocked_by, through: :blocked_by_relationships, source: :account
 
     # Mute relationships
     with_options class_name: 'Mute', dependent: :destroy do
       has_many :mute_relationships, foreign_key: 'account_id', inverse_of: :account
       has_many :muted_by_relationships, foreign_key: :target_account_id, inverse_of: :target_account
     end
-    has_many :muting, -> { order(mutes: { id: :desc }) }, through: :mute_relationships, source: :target_account
-    has_many :muted_by, -> { order(mutes: { id: :desc }) }, through: :muted_by_relationships, source: :account
+    has_many :muting, through: :mute_relationships, source: :target_account
+    has_many :muted_by, through: :muted_by_relationships, source: :account
     has_many :conversation_mutes, dependent: :destroy
     has_many :domain_blocks, class_name: 'AccountDomainBlock', dependent: :destroy
     has_many :announcement_mutes, dependent: :destroy


### PR DESCRIPTION
We'll confirm on CI, but I think this is going to pass the suite...

That is reassuring in that maybe nothing is relying on these, but this is also worrying in that it seems like something is ALMOST DEFINITELY relying on this, but it's not captured in specs.

Would be nice to remove these if possible and prefer explicit ordering where we need it ... curious what the threshold would be here for what coverage do we need to add to what places to be confident in this? My guess is at a minimum the various API endpoints which might have been relying on the default order. Feedback appreciated.