### PR TITLE
Explore more resplendent model validation specs for `Form::AdminSettings`

### DIFF
--- a/spec/models/form/admin_settings_spec.rb
+++ b/spec/models/form/admin_settings_spec.rb
@@ -3,33 +3,17 @@
 require 'rails_helper'
 
 RSpec.describe Form::AdminSettings do
-  describe 'validations' do
+  describe 'Validations' do
     describe 'site_contact_username' do
       context 'with no accounts' do
-        it 'is not valid' do
-          setting = described_class.new(site_contact_username: 'Test')
-          setting.valid?
-
-          expect(setting).to model_have_error_on_field(:site_contact_username)
-        end
+        it { is_expected.to_not allow_value('Test').for(:site_contact_username) }
       end
 
       context 'with an account' do
         before { Fabricate(:account, username: 'Glorp') }
 
-        it 'is not valid when account doesnt match' do
-          setting = described_class.new(site_contact_username: 'Test')
-          setting.valid?
-
-          expect(setting).to model_have_error_on_field(:site_contact_username)
-        end
-
-        it 'is valid when account matches' do
-          setting = described_class.new(site_contact_username: 'Glorp')
-          setting.valid?
-
-          expect(setting).to_not model_have_error_on_field(:site_contact_username)
-        end
+        it { is_expected.to_not allow_value('Test').for(:site_contact_username) }
+        it { is_expected.to allow_value('Glorp').for(:site_contact_username) }
       end
     end
   end


### PR DESCRIPTION
Extracted from https://github.com/mastodon/mastodon/pull/31775
