### PR TITLE
Simplify model validation specs for `WebauthnCredential`

### DIFF
--- a/spec/models/webauthn_credential_spec.rb
+++ b/spec/models/webauthn_credential_spec.rb
@@ -3,53 +3,17 @@
 require 'rails_helper'
 
 RSpec.describe WebauthnCredential do
-  describe 'validations' do
+  describe 'Validations' do
+    subject { Fabricate.build :webauthn_credential }
+
     it { is_expected.to validate_presence_of(:external_id) }
     it { is_expected.to validate_presence_of(:public_key) }
     it { is_expected.to validate_presence_of(:nickname) }
     it { is_expected.to validate_presence_of(:sign_count) }
 
-    it 'is invalid if already exist a webauthn credential with the same external id' do
-      Fabricate(:webauthn_credential, external_id: '_Typ0ygudDnk9YUVWLQayw')
-      new_webauthn_credential = Fabricate.build(:webauthn_credential, external_id: '_Typ0ygudDnk9YUVWLQayw')
+    it { is_expected.to validate_uniqueness_of(:external_id) }
+    it { is_expected.to validate_uniqueness_of(:nickname).scoped_to(:user_id) }
 
-      new_webauthn_credential.valid?
-
-      expect(new_webauthn_credential).to model_have_error_on_field(:external_id)
-    end
-
-    it 'is invalid if user already registered a webauthn credential with the same nickname' do
-      user = Fabricate(:user)
-      Fabricate(:webauthn_credential, user_id: user.id, nickname: 'USB Key')
-      new_webauthn_credential = Fabricate.build(:webauthn_credential, user_id: user.id, nickname: 'USB Key')
-
-      new_webauthn_credential.valid?
-
-      expect(new_webauthn_credential).to model_have_error_on_field(:nickname)
-    end
-
-    it 'is invalid if sign_count is not a number' do
-      webauthn_credential = Fabricate.build(:webauthn_credential, sign_count: 'invalid sign_count')
-
-      webauthn_credential.valid?
-
-      expect(webauthn_credential).to model_have_error_on_field(:sign_count)
-    end
-
-    it 'is invalid if sign_count is negative number' do
-      webauthn_credential = Fabricate.build(:webauthn_credential, sign_count: -1)
-
-      webauthn_credential.valid?
-
-      expect(webauthn_credential).to model_have_error_on_field(:sign_count)
-    end
-
-    it 'is invalid if sign_count is greater than the limit' do
-      webauthn_credential = Fabricate.build(:webauthn_credential, sign_count: (described_class::SIGN_COUNT_LIMIT * 2))
-
-      webauthn_credential.valid?
-
-      expect(webauthn_credential).to model_have_error_on_field(:sign_count)
-    end
+    it { is_expected.to validate_numericality_of(:sign_count).only_integer.is_greater_than_or_equal_to(0).is_less_than_or_equal_to(described_class::SIGN_COUNT_LIMIT - 1) }
   end
 end


### PR DESCRIPTION
Extracted from https://github.com/mastodon/mastodon/pull/31775

Preserve coverage with simpler validation checks

Future thing here ... it's sort of odd to use "LTE the constant minus 1" instead of "LT the constant" in the model, maybe change.