### PR TITLE
Reinforce coverage for `DomainBlock` model

### DIFF
--- a/app/models/domain_block.rb
+++ b/app/models/domain_block.rb
@@ -40,7 +40,9 @@ class DomainBlock < ApplicationRecord
     if suspend?
       [:suspend]
     else
-      [severity.to_sym, reject_media? ? :reject_media : nil, reject_reports? ? :reject_reports : nil].reject { |policy| policy == :noop || policy.nil? }
+      [severity.to_sym, reject_media? ? :reject_media : nil, reject_reports? ? :reject_reports : nil]
+        .reject { |policy| policy == :noop }
+        .compact
     end
   end
 

--- a/spec/models/domain_block_spec.rb
+++ b/spec/models/domain_block_spec.rb
@@ -3,14 +3,13 @@
 require 'rails_helper'
 
 RSpec.describe DomainBlock do
-  describe 'validations' do
+  describe 'Validations' do
     it { is_expected.to validate_presence_of(:domain) }
 
-    it 'is invalid if the same normalized domain already exists' do
-      _domain_block = Fabricate(:domain_block, domain: 'にゃん')
-      domain_block_with_normalized_value = Fabricate.build(:domain_block, domain: 'xn--r9j5b5b')
-      domain_block_with_normalized_value.valid?
-      expect(domain_block_with_normalized_value).to model_have_error_on_field(:domain)
+    context 'when a normalized domain exists' do
+      before { Fabricate(:domain_block, domain: 'にゃん') }
+
+      it { is_expected.to_not allow_value('xn--r9j5b5b').for(:domain) }
     end
   end
 

--- a/spec/models/domain_block_spec.rb
+++ b/spec/models/domain_block_spec.rb
@@ -104,4 +104,26 @@ RSpec.describe DomainBlock do
       end
     end
   end
+
+  describe '#policies' do
+    subject { domain_block.policies }
+
+    context 'when severity is suspend' do
+      let(:domain_block) { Fabricate.build :domain_block, severity: :suspend }
+
+      it { is_expected.to eq(%i(suspend)) }
+    end
+
+    context 'when severity is noop' do
+      let(:domain_block) { Fabricate.build :domain_block, severity: :noop, reject_media: true }
+
+      it { is_expected.to eq(%i(reject_media)) }
+    end
+
+    context 'when severity is silence' do
+      let(:domain_block) { Fabricate.build :domain_block, severity: :silence, reject_reports: true }
+
+      it { is_expected.to eq(%i(silence reject_reports)) }
+    end
+  end
 end


### PR DESCRIPTION
Extracted from https://github.com/mastodon/mastodon/pull/31775

Clean up validation specs, add `policies` coverage, use array `compact` instead of inline `nil?` check.

Future idea: look for something similar to action view `token_list` to use instead of these ternary checks.