### PR TITLE
Buttress coverage for `Report` model

### DIFF
--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -177,6 +177,12 @@ RSpec.describe Report do
       it { is_expected.to_not allow_value(rule.id).for(:rule_ids) }
     end
 
+    context 'with extra rule ids on a violation' do
+      subject { Fabricate.build :report, category: :violation }
+
+      it { is_expected.to_not allow_value([nil, Fabricate(:rule).id]).for(:rule_ids) }
+    end
+
     def comment_over_limit
       'a' * described_class::COMMENT_SIZE_LIMIT * 2
     end

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -127,6 +127,28 @@ RSpec.describe Report do
     end
   end
 
+  describe '#unresolved_siblings?' do
+    subject { Fabricate :report }
+
+    context 'when the target account has other unresolved reports' do
+      before { Fabricate :report, action_taken_at: nil, target_account: subject.target_account }
+
+      it { is_expected.to be_unresolved_siblings }
+    end
+
+    context 'when the target account has a resolved report' do
+      before { Fabricate :report, action_taken_at: 3.days.ago, target_account: subject.target_account }
+
+      it { is_expected.to_not be_unresolved_siblings }
+    end
+
+    context 'when the target account has no other reports' do
+      before { described_class.where(target_account: subject.target_account).destroy_all }
+
+      it { is_expected.to_not be_unresolved_siblings }
+    end
+  end
+
   describe 'validations' do
     subject { Fabricate.build :report }
 


### PR DESCRIPTION
Extracted from https://github.com/mastodon/mastodon/pull/31775

Clean up validation specs, add coverage for unresolved_siblings method and for `rules.size != rule_ids.size` scenario.