### PR TITLE
Strengthen coverage for `CustomFilter` model

### DIFF
--- a/spec/models/custom_filter_spec.rb
+++ b/spec/models/custom_filter_spec.rb
@@ -8,11 +8,36 @@ RSpec.describe CustomFilter do
     it { is_expected.to validate_presence_of(:context) }
 
     it { is_expected.to_not allow_values([], %w(invalid)).for(:context) }
+    it { is_expected.to allow_values(%w(home)).for(:context) }
   end
 
   describe 'Normalizations' do
     describe 'context' do
       it { is_expected.to normalize(:context).from(['home', 'notifications', 'public    ', '']).to(%w(home notifications public)) }
+    end
+  end
+
+  describe '#expires_in' do
+    subject { custom_filter.expires_in }
+
+    let(:custom_filter) { Fabricate.build(:custom_filter, expires_at: expires_at) }
+
+    context 'when expires_at is nil' do
+      let(:expires_at) { nil }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when expires is beyond the end of the range' do
+      let(:expires_at) { described_class::EXPIRATION_DURATIONS.last.from_now + 2.days }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when expires is before the start of the range' do
+      let(:expires_at) { described_class::EXPIRATION_DURATIONS.first.from_now - 10.minutes }
+
+      it { is_expected.to eq(described_class::EXPIRATION_DURATIONS.first) }
     end
   end
 end

--- a/spec/models/custom_filter_spec.rb
+++ b/spec/models/custom_filter_spec.rb
@@ -7,19 +7,7 @@ RSpec.describe CustomFilter do
     it { is_expected.to validate_presence_of(:title) }
     it { is_expected.to validate_presence_of(:context) }
 
-    it 'requires non-empty of context' do
-      record = described_class.new(context: [])
-      record.valid?
-
-      expect(record).to model_have_error_on_field(:context)
-    end
-
-    it 'requires valid context value' do
-      record = described_class.new(context: ['invalid'])
-      record.valid?
-
-      expect(record).to model_have_error_on_field(:context)
-    end
+    it { is_expected.to_not allow_values([], %w(invalid)).for(:context) }
   end
 
   describe 'Normalizations' do


### PR DESCRIPTION
Extracted from https://github.com/mastodon/mastodon/pull/31775

Improve validation specs, add `expires_in` coverage.

Future thing - this model includes the expireable module and also has its own `expires_in` (which takes precedence). This is fine, and I think desired, may want to double-check/rename and/or see if the logic here would be relevant/desirable to other spots which include the module.