### PR TITLE
Fix back arrow pointing to the incorrect direction in RTL languages

### DIFF
--- a/app/javascript/styles/mastodon/rtl.scss
+++ b/app/javascript/styles/mastodon/rtl.scss
@@ -35,6 +35,10 @@ body.rtl {
     direction: rtl;
   }
 
+  .column-back-button__icon {
+    transform: scale(-1, 1);
+  }
+
   .simple_form select {
     background: $ui-base-color
       url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14.933 18.467' height='19.698' width='15.929'><path d='M3.467 14.967l-3.393-3.5H14.86l-3.392 3.5c-1.866 1.925-3.666 3.5-4 3.5-.335 0-2.135-1.575-4-3.5zm.266-11.234L7.467 0 11.2 3.733l3.733 3.734H0l3.733-3.734z' fill='#{hex-color(lighten($ui-base-color, 12%))}'/></svg>")


### PR DESCRIPTION
I preferred to do a vertical symetry using CSS rather than using another icon, it seems cleaner and our arrows are symetric.

Fixes #32459