### PR TITLE
Reduce factory creation (14 -> 8) in `ActivityPub::Activity::Block` spec

### DIFF
--- a/spec/lib/activitypub/activity/block_spec.rb
+++ b/spec/lib/activitypub/activity/block_spec.rb
@@ -42,11 +42,8 @@ RSpec.describe ActivityPub::Activity::Block do
         subject.perform
       end
 
-      it 'creates a block from sender to recipient' do
+      it 'creates a block from sender to recipient and sets uri to last received block activity' do
         expect(sender.blocking?(recipient)).to be true
-      end
-
-      it 'sets the uri to that of last received block activity' do
         expect(sender.block_relationships.find_by(target_account: recipient).uri).to eq 'foo'
       end
     end
@@ -64,11 +61,8 @@ RSpec.describe ActivityPub::Activity::Block do
         subject.perform
       end
 
-      it 'creates a block from sender to recipient' do
+      it 'creates a block from sender to recipient and ensures recipient not following sender' do
         expect(sender.blocking?(recipient)).to be true
-      end
-
-      it 'ensures recipient is not following sender' do
         expect(recipient.following?(sender)).to be false
       end
     end
@@ -97,11 +91,8 @@ RSpec.describe ActivityPub::Activity::Block do
         subject.perform
       end
 
-      it 'does not create a block from sender to recipient' do
+      it 'does not create a block from sender to recipient and ensures recipient not following sender' do
         expect(sender.blocking?(recipient)).to be false
-      end
-
-      it 'ensures recipient is not following sender' do
         expect(recipient.following?(sender)).to be false
       end
     end

--- a/spec/lib/activitypub/activity/block_spec.rb
+++ b/spec/lib/activitypub/activity/block_spec.rb
@@ -28,21 +28,18 @@ RSpec.describe ActivityPub::Activity::Block do
     end
 
     context 'when the recipient is already blocked' do
-      before do
-        sender.block!(recipient, uri: 'old')
-      end
+      before { sender.block!(recipient, uri: 'old') }
 
       it 'creates a block from sender to recipient and sets uri to last received block activity' do
         subject.perform
+
         expect(sender.blocking?(recipient)).to be true
         expect(sender.block_relationships.find_by(target_account: recipient).uri).to eq 'foo'
       end
     end
 
     context 'when the recipient follows the sender' do
-      before do
-        recipient.follow!(sender)
-      end
+      before { recipient.follow!(sender) }
 
       it 'creates a block from sender to recipient and ensures recipient not following sender' do
         subject.perform

--- a/spec/lib/activitypub/activity/block_spec.rb
+++ b/spec/lib/activitypub/activity/block_spec.rb
@@ -20,11 +20,9 @@ RSpec.describe ActivityPub::Activity::Block do
 
   context 'when the recipient does not follow the sender' do
     describe '#perform' do
-      before do
-        subject.perform
-      end
-
       it 'creates a block from sender to recipient' do
+        subject.perform
+
         expect(sender.blocking?(recipient)).to be true
       end
     end
@@ -36,11 +34,8 @@ RSpec.describe ActivityPub::Activity::Block do
     end
 
     describe '#perform' do
-      before do
-        subject.perform
-      end
-
       it 'creates a block from sender to recipient and sets uri to last received block activity' do
+        subject.perform
         expect(sender.blocking?(recipient)).to be true
         expect(sender.block_relationships.find_by(target_account: recipient).uri).to eq 'foo'
       end
@@ -53,11 +48,9 @@ RSpec.describe ActivityPub::Activity::Block do
     end
 
     describe '#perform' do
-      before do
-        subject.perform
-      end
-
       it 'creates a block from sender to recipient and ensures recipient not following sender' do
+        subject.perform
+
         expect(sender.blocking?(recipient)).to be true
         expect(recipient.following?(sender)).to be false
       end
@@ -81,11 +74,9 @@ RSpec.describe ActivityPub::Activity::Block do
     end
 
     describe '#perform' do
-      before do
-        subject.perform
-      end
-
       it 'does not create a block from sender to recipient and ensures recipient not following sender' do
+        subject.perform
+
         expect(sender.blocking?(recipient)).to be false
         expect(recipient.following?(sender)).to be false
       end

--- a/spec/lib/activitypub/activity/block_spec.rb
+++ b/spec/lib/activitypub/activity/block_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe ActivityPub::Activity::Block do
       it 'creates a block from sender to recipient' do
         subject.perform
 
-        expect(sender.blocking?(recipient)).to be true
+        expect(sender)
+          .to be_blocking(recipient)
       end
     end
 
@@ -33,8 +34,14 @@ RSpec.describe ActivityPub::Activity::Block do
       it 'creates a block from sender to recipient and sets uri to last received block activity' do
         subject.perform
 
-        expect(sender.blocking?(recipient)).to be true
-        expect(sender.block_relationships.find_by(target_account: recipient).uri).to eq 'foo'
+        expect(sender)
+          .to be_blocking(recipient)
+        expect(sender_blocking_recipient.uri)
+          .to eq 'foo'
+      end
+
+      def sender_blocking_recipient
+        sender.block_relationships.find_by(target_account: recipient)
       end
     end
 
@@ -44,8 +51,10 @@ RSpec.describe ActivityPub::Activity::Block do
       it 'creates a block from sender to recipient and ensures recipient not following sender' do
         subject.perform
 
-        expect(sender.blocking?(recipient)).to be true
-        expect(recipient.following?(sender)).to be false
+        expect(sender)
+          .to be_blocking(recipient)
+        expect(recipient)
+          .to_not be_following(sender)
       end
     end
 
@@ -68,8 +77,10 @@ RSpec.describe ActivityPub::Activity::Block do
       it 'does not create a block from sender to recipient and ensures recipient not following sender' do
         subject.perform
 
-        expect(sender.blocking?(recipient)).to be false
-        expect(recipient.following?(sender)).to be false
+        expect(sender)
+          .to_not be_blocking(recipient)
+        expect(recipient)
+          .to_not be_following(sender)
       end
     end
   end

--- a/spec/lib/activitypub/activity/block_spec.rb
+++ b/spec/lib/activitypub/activity/block_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe ActivityPub::Activity::Block do
+  subject { described_class.new(json, sender) }
+
   let(:sender)    { Fabricate(:account) }
   let(:recipient) { Fabricate(:account) }
 
@@ -18,8 +20,6 @@ RSpec.describe ActivityPub::Activity::Block do
 
   context 'when the recipient does not follow the sender' do
     describe '#perform' do
-      subject { described_class.new(json, sender) }
-
       before do
         subject.perform
       end
@@ -36,8 +36,6 @@ RSpec.describe ActivityPub::Activity::Block do
     end
 
     describe '#perform' do
-      subject { described_class.new(json, sender) }
-
       before do
         subject.perform
       end
@@ -55,8 +53,6 @@ RSpec.describe ActivityPub::Activity::Block do
     end
 
     describe '#perform' do
-      subject { described_class.new(json, sender) }
-
       before do
         subject.perform
       end
@@ -85,8 +81,6 @@ RSpec.describe ActivityPub::Activity::Block do
     end
 
     describe '#perform' do
-      subject { described_class.new(json, sender) }
-
       before do
         subject.perform
       end

--- a/spec/lib/activitypub/activity/block_spec.rb
+++ b/spec/lib/activitypub/activity/block_spec.rb
@@ -36,12 +36,8 @@ RSpec.describe ActivityPub::Activity::Block do
 
         expect(sender)
           .to be_blocking(recipient)
-        expect(sender_blocking_recipient.uri)
+        expect(sender.block_relationships.find_by(target_account: recipient).uri)
           .to eq 'foo'
-      end
-
-      def sender_blocking_recipient
-        sender.block_relationships.find_by(target_account: recipient)
       end
     end
 


### PR DESCRIPTION
Main thing is factory reduction, but while in there I noticed that every single context group had a `describe '#perform'...` block inside of it ... so flipped that nesting (ie, one describe perform outside the whole thing, with the contexts inside that).