### PR TITLE
Extend spec coverage for `Poll` model

### DIFF
--- a/spec/models/poll_spec.rb
+++ b/spec/models/poll_spec.rb
@@ -30,11 +30,9 @@ RSpec.describe Poll do
     end
   end
 
-  describe 'validations' do
-    context 'when not valid' do
-      subject { Fabricate.build(:poll) }
+  describe 'Validations' do
+    subject { Fabricate.build(:poll) }
 
-      it { is_expected.to validate_presence_of(:expires_at) }
-    end
+    it { is_expected.to validate_presence_of(:expires_at) }
   end
 end

--- a/spec/models/poll_spec.rb
+++ b/spec/models/poll_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Poll do
-  describe 'scopes' do
+  describe 'Scopes' do
     let(:status) { Fabricate(:status) }
     let(:attached_poll) { Fabricate(:poll, status: status) }
     let(:not_attached_poll) do
@@ -13,7 +13,7 @@ RSpec.describe Poll do
       end
     end
 
-    describe 'attached' do
+    describe '.attached' do
       it 'finds the correct records' do
         results = described_class.attached
 
@@ -21,12 +21,26 @@ RSpec.describe Poll do
       end
     end
 
-    describe 'unattached' do
+    describe '.unattached' do
       it 'finds the correct records' do
         results = described_class.unattached
 
         expect(results).to eq([not_attached_poll])
       end
+    end
+  end
+
+  describe '#reset_votes!' do
+    let(:poll) { Fabricate :poll, cached_tallies: [2, 3], votes_count: 5, voters_count: 5 }
+    let!(:vote) { Fabricate :poll_vote, poll: }
+
+    it 'resets vote data and deletes votes' do
+      expect { poll.reset_votes! }
+        .to change(poll, :cached_tallies).to([0, 0])
+        .and change(poll, :votes_count).to(0)
+        .and(change(poll, :voters_count).to(0))
+      expect { vote.reload }
+        .to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 


### PR DESCRIPTION
Extracted from https://github.com/mastodon/mastodon/pull/31775

Adds coverage for `#reset_votes!` method, minor style fixes elsewhere.