### PR TITLE
Add missing coverage for `Webhook` model

### DIFF
--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -38,7 +38,7 @@ class Webhook < ApplicationRecord
   validate :validate_template
 
   normalizes :events, with: ->(events) { events.filter_map { |event| event.strip.presence } }
-  before_validation :generate_secret
+  before_validation :generate_secret, unless: :secret?
 
   def rotate_secret!
     update!(secret: SecureRandom.hex(20))
@@ -99,6 +99,6 @@ class Webhook < ApplicationRecord
   end
 
   def generate_secret
-    self.secret = SecureRandom.hex(20) if secret.blank?
+    self.secret = SecureRandom.hex(20)
   end
 end

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -58,11 +58,11 @@ class Webhook < ApplicationRecord
 
   def self.permission_for_event(event)
     case event
-    when 'account.approved', 'account.created', 'account.updated'
+    when /account/
       :manage_users
-    when 'report.created', 'report.updated'
+    when /report/
       :manage_reports
-    when 'status.created', 'status.updated'
+    when /status/
       :view_devops
     end
   end

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -53,7 +53,9 @@ class Webhook < ApplicationRecord
   end
 
   def required_permissions
-    events.map { |event| Webhook.permission_for_event(event) }
+    events
+      .map { |event| Webhook.permission_for_event(event) }
+      .uniq
   end
 
   def self.permission_for_event(event)

--- a/spec/models/webhook_spec.rb
+++ b/spec/models/webhook_spec.rb
@@ -71,6 +71,22 @@ RSpec.describe Webhook do
     end
   end
 
+  describe '#required_permissions' do
+    subject { described_class.new(events:).required_permissions }
+
+    context 'with empty events' do
+      let(:events) { [] }
+
+      it { is_expected.to eq([]) }
+    end
+
+    context 'with multiple event types' do
+      let(:events) { %w(account.created account.updated status.created) }
+
+      it { is_expected.to eq %i(manage_users view_devops) }
+    end
+  end
+
   describe '#rotate_secret!' do
     it 'changes the secret' do
       expect { webhook.rotate_secret! }

--- a/spec/models/webhook_spec.rb
+++ b/spec/models/webhook_spec.rb
@@ -35,6 +35,28 @@ RSpec.describe Webhook do
     end
   end
 
+  describe 'Callbacks' do
+    describe 'Generating a secret' do
+      context 'when secret exists already' do
+        subject { described_class.new(secret: 'secret') }
+
+        it 'does not override' do
+          expect { subject.valid? }
+            .to_not change(subject, :secret)
+        end
+      end
+
+      context 'when secret does not exist' do
+        subject { described_class.new(secret: nil) }
+
+        it 'does not override' do
+          expect { subject.valid? }
+            .to change(subject, :secret)
+        end
+      end
+    end
+  end
+
   describe '.permission_for_event' do
     subject { described_class.permission_for_event(event) }
 

--- a/spec/models/webhook_spec.rb
+++ b/spec/models/webhook_spec.rb
@@ -6,21 +6,11 @@ RSpec.describe Webhook do
   let(:webhook) { Fabricate(:webhook) }
 
   describe 'Validations' do
+    subject { Fabricate.build :webhook }
+
     it { is_expected.to validate_presence_of(:events) }
 
-    it 'requires non-empty events value' do
-      record = described_class.new(events: [])
-      record.valid?
-
-      expect(record).to model_have_error_on_field(:events)
-    end
-
-    it 'requires valid events value from EVENTS' do
-      record = described_class.new(events: ['account.invalid'])
-      record.valid?
-
-      expect(record).to model_have_error_on_field(:events)
-    end
+    it { is_expected.to_not allow_values([], %w(account.invalid)).for(:events) }
   end
 
   describe 'Normalizations' do

--- a/spec/models/webhook_spec.rb
+++ b/spec/models/webhook_spec.rb
@@ -19,6 +19,58 @@ RSpec.describe Webhook do
     end
   end
 
+  describe '.permission_for_event' do
+    subject { described_class.permission_for_event(event) }
+
+    context 'with a nil value' do
+      let(:event) { nil }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'with an account approved event' do
+      let(:event) { 'account.approved' }
+
+      it { is_expected.to eq(:manage_users) }
+    end
+
+    context 'with an account created event' do
+      let(:event) { 'account.created' }
+
+      it { is_expected.to eq(:manage_users) }
+    end
+
+    context 'with an account updated event' do
+      let(:event) { 'account.updated' }
+
+      it { is_expected.to eq(:manage_users) }
+    end
+
+    context 'with an report created event' do
+      let(:event) { 'report.created' }
+
+      it { is_expected.to eq(:manage_reports) }
+    end
+
+    context 'with an report updated event' do
+      let(:event) { 'report.updated' }
+
+      it { is_expected.to eq(:manage_reports) }
+    end
+
+    context 'with an status created event' do
+      let(:event) { 'status.created' }
+
+      it { is_expected.to eq(:view_devops) }
+    end
+
+    context 'with an status updated event' do
+      let(:event) { 'status.updated' }
+
+      it { is_expected.to eq(:view_devops) }
+    end
+  end
+
   describe '#rotate_secret!' do
     it 'changes the secret' do
       expect { webhook.rotate_secret! }

--- a/spec/models/webhook_spec.rb
+++ b/spec/models/webhook_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe Webhook do
 
     it { is_expected.to_not allow_values([], %w(account.invalid)).for(:events) }
 
+    it { is_expected.to_not allow_values('{{account }').for(:template) }
+
     context 'when current_account is assigned' do
       subject { Fabricate.build :webhook, current_account: account }
 

--- a/spec/models/webhook_spec.rb
+++ b/spec/models/webhook_spec.rb
@@ -11,6 +11,22 @@ RSpec.describe Webhook do
     it { is_expected.to validate_presence_of(:events) }
 
     it { is_expected.to_not allow_values([], %w(account.invalid)).for(:events) }
+
+    context 'when current_account is assigned' do
+      subject { Fabricate.build :webhook, current_account: account }
+
+      context 'with account that has permissions' do
+        let(:account) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
+
+        it { is_expected.to allow_values(%w(account.created)).for(:events) }
+      end
+
+      context 'with account lacking permissions' do
+        let(:account) { Fabricate :account }
+
+        it { is_expected.to_not allow_values(%w(account.created)).for(:events) }
+      end
+    end
   end
 
   describe 'Normalizations' do


### PR DESCRIPTION
Extracted from https://github.com/mastodon/mastodon/pull/31775

Adds coverage for some permissions methods, the secret callback, and simplifies existing validation specs.

Fixes bug where you could get duplicate values for `required_permissions`

Moves the "conditions where this should run" checks to calling location.

Un-embiggens permission_for_event w/ regex

