### PR TITLE
Extract some readability/organization private methods across policies

### DIFF
--- a/app/policies/account_warning_policy.rb
+++ b/app/policies/account_warning_policy.rb
@@ -6,10 +6,14 @@ class AccountWarningPolicy < ApplicationPolicy
   end
 
   def appeal?
-    target? && record.created_at >= Appeal::MAX_STRIKE_AGE.ago
+    target? && eligible_for_appeal?
   end
 
   private
+
+  def eligible_for_appeal?
+    record.created_at >= Appeal::MAX_STRIKE_AGE.ago
+  end
 
   def target?
     record.target_account_id == current_account&.id

--- a/app/policies/admin/status_policy.rb
+++ b/app/policies/admin/status_policy.rb
@@ -12,7 +12,7 @@ class Admin::StatusPolicy < ApplicationPolicy
   end
 
   def show?
-    role.can?(:manage_reports, :manage_users) && (record.public_visibility? || record.unlisted_visibility? || record.reported? || viewable_through_normal_policy?)
+    role.can?(:manage_reports, :manage_users) && (record.distributable? || record.reported? || viewable_through_normal_policy?)
   end
 
   def destroy?

--- a/app/policies/admin/status_policy.rb
+++ b/app/policies/admin/status_policy.rb
@@ -12,7 +12,7 @@ class Admin::StatusPolicy < ApplicationPolicy
   end
 
   def show?
-    role.can?(:manage_reports, :manage_users) && (record.distributable? || record.reported? || viewable_through_normal_policy?)
+    role.can?(:manage_reports, :manage_users) && eligible_to_show?
   end
 
   def destroy?
@@ -28,6 +28,10 @@ class Admin::StatusPolicy < ApplicationPolicy
   end
 
   private
+
+  def eligible_to_show?
+    record.distributable? || record.reported? || viewable_through_normal_policy?
+  end
 
   def viewable_through_normal_policy?
     StatusPolicy.new(current_account, record, @preloaded_relations).show?

--- a/app/policies/backup_policy.rb
+++ b/app/policies/backup_policy.rb
@@ -4,6 +4,16 @@ class BackupPolicy < ApplicationPolicy
   MIN_AGE = 6.days
 
   def create?
-    user_signed_in? && current_user.backups.where(created_at: MIN_AGE.ago..).count.zero?
+    user_signed_in? && eligible_for_backup?
+  end
+
+  private
+
+  def eligible_for_backup?
+    current_user
+      .backups
+      .where(created_at: MIN_AGE.ago..)
+      .count
+      .zero?
   end
 end

--- a/app/policies/poll_policy.rb
+++ b/app/policies/poll_policy.rb
@@ -2,6 +2,16 @@
 
 class PollPolicy < ApplicationPolicy
   def vote?
-    StatusPolicy.new(current_account, record.status).show? && !current_account.blocking?(record.account) && !record.account.blocking?(current_account)
+    viewable_through_normal_policy? && accounts_not_blocking?
+  end
+
+  private
+
+  def viewable_through_normal_policy?
+    StatusPolicy.new(current_account, record.status).show?
+  end
+
+  def accounts_not_blocking?
+    !current_account.blocking?(record.account) && !record.account.blocking?(current_account)
   end
 end

--- a/app/policies/user_role_policy.rb
+++ b/app/policies/user_role_policy.rb
@@ -10,10 +10,16 @@ class UserRolePolicy < ApplicationPolicy
   end
 
   def update?
-    role.can?(:manage_roles) && (role.overrides?(record) || role.id == record.id)
+    role.can?(:manage_roles) && (role.overrides?(record) || self_editing?)
   end
 
   def destroy?
-    !record.everyone? && role.can?(:manage_roles) && role.overrides?(record) && role.id != record.id
+    !record.everyone? && role.can?(:manage_roles) && role.overrides?(record) && !self_editing?
+  end
+
+  private
+
+  def self_editing?
+    role.id == record.id
   end
 end


### PR DESCRIPTION
Follow-up on https://github.com/mastodon/mastodon/pull/32426

Linked PR was kept to coverage improvement only, but I noticed some of these while in there.

The change in the status policy is wrapping two conditions that already have a method (distributable?). Every other change is just pulling some inline logic out to well named private method for easier scanning.

Possible followups...

- Many of these are just wrapping the same check over and over for every method ... could pull out to private methods they all call, and/or use `alias_method` to just point at question in check.
- Could do some `delegate` in various places to make things less chained.
- There are a few repeated logics that could move to base class
- account warning policy - Appeal "not eligible?" logic is also used in validation, could move to public method on appeal
- There's a check in webhook policy re: permissions which could easily be moved to a method on webhook
- There's a check on status re: direct/limited that could move to query method on model
- The status policy here is the only that has any sort of real complexity at all, the rest are very straightforward. I could see some similar method bundling/extraction being useful there as well, but I would want to double check the coverage there and make sure it's really exhaustive first