### PR TITLE
Add `action_log_description` helper and move action log desc string formation out of view

### DIFF
--- a/app/helpers/admin/action_logs_helper.rb
+++ b/app/helpers/admin/action_logs_helper.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 module Admin::ActionLogsHelper
+  def action_log_description(action_log)
+    t "admin.action_logs.actions.#{action_log.action}_#{action_log.target_type.underscore}_html",
+      name: tag.span(action_log.account.username, class: :username),
+      target: tag.span(log_target(action_log), class: :target)
+  end
+
   def log_target(log)
     case log.target_type
     when 'Account'

--- a/app/views/admin/action_logs/_action_log.html.haml
+++ b/app/views/admin/action_logs/_action_log.html.haml
@@ -4,8 +4,6 @@
       = image_tag action_log.account.avatar.url(:original), alt: '', width: 40, height: 40, class: 'avatar'
     .log-entry__content
       .log-entry__title
-        = t "admin.action_logs.actions.#{action_log.action}_#{action_log.target_type.underscore}_html",
-            name: tag.span(action_log.account.username, class: 'username'),
-            target: tag.span(log_target(action_log), class: 'target')
+        = action_log_description(action_log)
       .log-entry__timestamp
         %time.formatted{ datetime: action_log.created_at.iso8601 }

--- a/app/views/admin/action_logs/_action_log.html.haml
+++ b/app/views/admin/action_logs/_action_log.html.haml
@@ -5,7 +5,7 @@
     .log-entry__content
       .log-entry__title
         = t "admin.action_logs.actions.#{action_log.action}_#{action_log.target_type.underscore}_html",
-            name: content_tag(:span, action_log.account.username, class: 'username'),
-            target: content_tag(:span, log_target(action_log), class: 'target')
+            name: tag.span(action_log.account.username, class: 'username'),
+            target: tag.span(log_target(action_log), class: 'target')
       .log-entry__timestamp
         %time.formatted{ datetime: action_log.created_at.iso8601 }


### PR DESCRIPTION
Noticed while looking at other audit log things.

In advance of (hopeful!) cleanup to what is currently sort of a sprawl of conditions in the big nested case statement method (tbd, needs more lab time).