### PR TITLE
Store `combined_file_size` virtual column on media attachments

### DIFF
--- a/app/lib/admin/metrics/dimension/space_usage_dimension.rb
+++ b/app/lib/admin/metrics/dimension/space_usage_dimension.rb
@@ -40,7 +40,7 @@ class Admin::Metrics::Dimension::SpaceUsageDimension < Admin::Metrics::Dimension
 
   def media_size
     value = [
-      MediaAttachment.sum(Arel.sql('COALESCE(file_file_size, 0) + COALESCE(thumbnail_file_size, 0)')),
+      MediaAttachment.sum(:combined_file_size),
       CustomEmoji.sum(:image_file_size),
       PreviewCard.sum(:image_file_size),
       Account.sum(Arel.sql('COALESCE(avatar_file_size, 0) + COALESCE(header_file_size, 0)')),

--- a/app/lib/admin/metrics/measure/instance_media_attachments_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_media_attachments_measure.rb
@@ -29,7 +29,7 @@ class Admin::Metrics::Measure::InstanceMediaAttachmentsMeasure < Admin::Metrics:
   def perform_total_query
     domain = params[:domain]
     domain = Instance.by_domain_and_subdomains(params[:domain]).select(:domain) if params[:include_subdomains]
-    MediaAttachment.joins(:account).merge(Account.where(domain: domain)).sum('COALESCE(file_file_size, 0) + COALESCE(thumbnail_file_size, 0)')
+    MediaAttachment.joins(:account).merge(Account.where(domain: domain)).sum(:combined_file_size)
   end
 
   def perform_previous_total_query

--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -27,6 +27,7 @@
 #  thumbnail_file_size         :integer
 #  thumbnail_updated_at        :datetime
 #  thumbnail_remote_url        :string
+#  combined_file_size          :integer
 #
 
 class MediaAttachment < ApplicationRecord

--- a/db/migrate/20241008154604_add_virtual_column_for_media_storage_sum.rb
+++ b/db/migrate/20241008154604_add_virtual_column_for_media_storage_sum.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class AddVirtualColumnForMediaStorageSum < ActiveRecord::Migration[7.1]
+  def change
+    safety_assured do
+      change_table :media_attachments do |t|
+        t.virtual :combined_file_size, type: :integer, as: combined_file_size, stored: true
+      end
+    end
+  end
+
+  private
+
+  def combined_file_size
+    <<~SQL.squish
+      COALESCE(file_file_size, 0) + COALESCE(thumbnail_file_size, 0)
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -624,6 +624,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_14_010506) do
     t.integer "thumbnail_file_size"
     t.datetime "thumbnail_updated_at", precision: nil
     t.string "thumbnail_remote_url"
+    t.virtual "combined_file_size", type: :integer, as: "(COALESCE(file_file_size, 0) + COALESCE(thumbnail_file_size, 0))", stored: true
     t.index ["account_id", "status_id"], name: "index_media_attachments_on_account_id_and_status_id", order: { status_id: :desc }
     t.index ["scheduled_status_id"], name: "index_media_attachments_on_scheduled_status_id", where: "(scheduled_status_id IS NOT NULL)"
     t.index ["shortcode"], name: "index_media_attachments_on_shortcode", unique: true, opclass: :text_pattern_ops, where: "(shortcode IS NOT NULL)"

--- a/lib/mastodon/cli/media.rb
+++ b/lib/mastodon/cli/media.rb
@@ -316,7 +316,7 @@ module Mastodon::CLI
 
     def object_storage_summary
       [
-        [:attachments, MediaAttachment.sum(combined_media_sum), MediaAttachment.where(account: Account.local).sum(combined_media_sum)],
+        [:attachments, MediaAttachment.sum(:combined_file_size), MediaAttachment.where(account: Account.local).sum(:combined_file_size)],
         [:custom_emoji, CustomEmoji.sum(:image_file_size), CustomEmoji.local.sum(:image_file_size)],
         [:avatars, Account.sum(:avatar_file_size), Account.local.sum(:avatar_file_size)],
         [:headers, Account.sum(:header_file_size), Account.local.sum(:header_file_size)],
@@ -325,12 +325,6 @@ module Mastodon::CLI
         [:imports, Import.sum(:data_file_size), nil],
         [:settings, SiteUpload.sum(:file_file_size), nil],
       ].map { |label, total, local| [label.to_s.titleize, number_to_human_size(total), local.present? ? number_to_human_size(local) : nil] }
-    end
-
-    def combined_media_sum
-      Arel.sql(<<~SQL.squish)
-        COALESCE(file_file_size, 0) + COALESCE(thumbnail_file_size, 0)
-      SQL
     end
 
     PRELOADED_MODELS = %w(


### PR DESCRIPTION
Opening as draft for feedback.

I believe this feature is supported in PG since v12, so we're good on that front.

I picked a very trivial example here -- there are other places (combined avatar/header size, domain name length in a few spots, lowercasing things in a few spots, announcements data coalesce thing, etc) -- where it might be nice to have an always ready queryable read only attribute in place, created by what would act like a db-level `after_` callback from model perspective.