### PR TITLE
Change media attachments to use `summary` instead of `name` for attachment description

### DIFF
--- a/app/serializers/activitypub/note_serializer.rb
+++ b/app/serializers/activitypub/note_serializer.rb
@@ -199,7 +199,7 @@ class ActivityPub::NoteSerializer < ActivityPub::Serializer
 
     include RoutingHelper
 
-    attributes :type, :media_type, :url, :name, :blurhash
+    attributes :type, :media_type, :url, :summary, :blurhash
     attribute :focal_point, if: :focal_point?
     attribute :width, if: :width?
     attribute :height, if: :height?
@@ -210,7 +210,7 @@ class ActivityPub::NoteSerializer < ActivityPub::Serializer
       'Document'
     end
 
-    def name
+    def summary
       object.description
     end
 


### PR DESCRIPTION
Mastodon supports `summary` and prefers it over `name` in inbound activities since #13763, which is included since v3.2.0, so this is a safe change as far as Mastodon is concerned.

I am unsure what other implementations support, though.