### PR TITLE
Remove domain attribution bypass for trendable providers

### DIFF
--- a/app/services/fetch_link_card_service.rb
+++ b/app/services/fetch_link_card_service.rb
@@ -154,17 +154,15 @@ class FetchLinkCardService < BaseService
 
     link_details_extractor = LinkDetailsExtractor.new(@url, @html, @html_charset)
     domain = Addressable::URI.parse(link_details_extractor.canonical_url).normalized_host
-    provider = PreviewCardProvider.matching_domain(domain)
     linked_account = ResolveAccountService.new.call(link_details_extractor.author_account, suppress_errors: true) if link_details_extractor.author_account.present?
 
     @card = PreviewCard.find_or_initialize_by(url: link_details_extractor.canonical_url) if link_details_extractor.canonical_url != @card.url
     @card.assign_attributes(link_details_extractor.to_preview_card_attributes)
 
-    if linked_account.present?
-      # There is an overlap in the two conditions when `provider` is trendable. This is on purpose to give users
-      # a heads-up before we remove the `provider&.trendable?` condition.
-      @card.author_account = linked_account if linked_account.can_be_attributed_from?(domain) || provider&.trendable?
-      @card.unverified_author_account = linked_account if linked_account.local? && !linked_account.can_be_attributed_from?(domain)
+    if linked_account&.can_be_attributed_from?(domain)
+      @card.author_account = linked_account
+    elsif linked_account&.local?
+      @card.unverified_author_account = linked_account
     end
 
     @card.save_with_optional_image! unless @card.title.blank? && @card.html.blank?


### PR DESCRIPTION
Back when we first implemented `fediverse:provider`, we did not have the `attributionDomains` flow.

Since then, we have decided that a website's ability to trend was not a correct way to allow attribution.

We nevertheless kept for transition, but it is poorly documented, and potentially dangerous, as it can allow misattribution.