### PR TITLE
Worker specs coverage increase

### DIFF
--- a/spec/fabricators/account_conversation_fabricator.rb
+++ b/spec/fabricators/account_conversation_fabricator.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Fabricator(:account_conversation) do
+  account
+  conversation
+  status_ids { [Fabricate(:status).id] }
+end

--- a/spec/workers/account_refresh_worker_spec.rb
+++ b/spec/workers/account_refresh_worker_spec.rb
@@ -7,9 +7,7 @@ RSpec.describe AccountRefreshWorker do
   let(:service) { instance_double(ResolveAccountService, call: true) }
 
   describe '#perform' do
-    before do
-      allow(ResolveAccountService).to receive(:new).and_return(service)
-    end
+    before { stub_service }
 
     context 'when account does not exist' do
       it 'returns immediately without processing' do
@@ -47,6 +45,12 @@ RSpec.describe AccountRefreshWorker do
       def outdated_webfinger_at
         (Account::BACKGROUND_REFRESH_INTERVAL + 3.days).ago
       end
+    end
+
+    def stub_service
+      allow(ResolveAccountService)
+        .to receive(:new)
+        .and_return(service)
     end
   end
 end

--- a/spec/workers/activitypub/followers_synchronization_worker_spec.rb
+++ b/spec/workers/activitypub/followers_synchronization_worker_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ActivityPub::FollowersSynchronizationWorker do
+  let(:worker) { described_class.new }
+  let(:service) { instance_double(ActivityPub::SynchronizeFollowersService, call: true) }
+
+  describe '#perform' do
+    before { stub_service }
+
+    let(:account) { Fabricate(:account, domain: 'host.example') }
+    let(:url) { 'https://sync.url' }
+
+    it 'sends the status to the service' do
+      worker.perform(account.id, url)
+
+      expect(service).to have_received(:call).with(account, url)
+    end
+
+    it 'returns nil for non-existent record' do
+      result = worker.perform(123_123_123, url)
+
+      expect(result).to be(true)
+    end
+  end
+
+  def stub_service
+    allow(ActivityPub::SynchronizeFollowersService)
+      .to receive(:new)
+      .and_return(service)
+  end
+end

--- a/spec/workers/push_conversation_worker_spec.rb
+++ b/spec/workers/push_conversation_worker_spec.rb
@@ -6,8 +6,30 @@ RSpec.describe PushConversationWorker do
   let(:worker) { described_class.new }
 
   describe 'perform' do
-    it 'runs without error for missing record' do
-      expect { worker.perform(nil) }.to_not raise_error
+    context 'with missing values' do
+      it 'runs without error' do
+        expect { worker.perform(nil) }
+          .to_not raise_error
+      end
+    end
+
+    context 'with valid records' do
+      let(:account_conversation) { Fabricate :account_conversation }
+
+      before { allow(redis).to receive(:publish) }
+
+      it 'pushes message to timeline' do
+        expect { worker.perform(account_conversation.id) }
+          .to_not raise_error
+
+        expect(redis)
+          .to have_received(:publish)
+          .with(redis_key, anything)
+      end
+
+      def redis_key
+        "timeline:direct:#{account_conversation.account_id}"
+      end
     end
   end
 end

--- a/spec/workers/push_update_worker_spec.rb
+++ b/spec/workers/push_update_worker_spec.rb
@@ -6,11 +6,31 @@ RSpec.describe PushUpdateWorker do
   let(:worker) { described_class.new }
 
   describe 'perform' do
-    it 'runs without error for missing record' do
-      account_id = nil
-      status_id = nil
+    context 'with missing values' do
+      it 'runs without error' do
+        expect { worker.perform(nil, nil) }
+          .to_not raise_error
+      end
+    end
 
-      expect { worker.perform(account_id, status_id) }.to_not raise_error
+    context 'with valid records' do
+      let(:account) { Fabricate :account }
+      let(:status) { Fabricate :status }
+
+      before { allow(redis).to receive(:publish) }
+
+      it 'pushes message to timeline' do
+        expect { worker.perform(account.id, status.id) }
+          .to_not raise_error
+
+        expect(redis)
+          .to have_received(:publish)
+          .with(redis_key, anything)
+      end
+
+      def redis_key
+        "timeline:#{account.id}"
+      end
     end
   end
 end

--- a/spec/workers/remote_account_refresh_worker_spec.rb
+++ b/spec/workers/remote_account_refresh_worker_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RemoteAccountRefreshWorker do
+  let(:worker) { described_class.new }
+  let(:service) { instance_double(ActivityPub::FetchRemoteAccountService, call: true) }
+
+  describe '#perform' do
+    before { stub_service }
+
+    let(:account) { Fabricate(:account, domain: 'host.example') }
+
+    it 'sends the status to the service' do
+      worker.perform(account.id)
+
+      expect(service).to have_received(:call).with(account.uri)
+    end
+
+    it 'returns nil for non-existent record' do
+      result = worker.perform(123_123_123)
+
+      expect(result).to be_nil
+    end
+
+    it 'returns nil for a local record' do
+      account = Fabricate :account, domain: nil
+      result = worker.perform(account)
+      expect(result).to be_nil
+    end
+
+    def stub_service
+      allow(ActivityPub::FetchRemoteAccountService)
+        .to receive(:new)
+        .and_return(service)
+    end
+  end
+end

--- a/spec/workers/remove_featured_tag_worker_spec.rb
+++ b/spec/workers/remove_featured_tag_worker_spec.rb
@@ -4,12 +4,35 @@ require 'rails_helper'
 
 RSpec.describe RemoveFeaturedTagWorker do
   let(:worker) { described_class.new }
+  let(:service) { instance_double(RemoveFeaturedTagService, call: true) }
 
   describe 'perform' do
-    it 'runs without error for missing record' do
-      account_id = nil
-      featured_tag_id = nil
-      expect { worker.perform(account_id, featured_tag_id) }.to_not raise_error
+    context 'with missing values' do
+      it 'runs without error' do
+        expect { worker.perform(nil, nil) }
+          .to_not raise_error
+      end
+    end
+
+    context 'with real records' do
+      before { stub_service }
+
+      let(:account) { Fabricate :account }
+      let(:featured_tag) { Fabricate :featured_tag }
+
+      it 'calls the service for processing' do
+        worker.perform(account.id, featured_tag.id)
+
+        expect(service)
+          .to have_received(:call)
+          .with(be_an(Account), be_an(FeaturedTag))
+      end
+
+      def stub_service
+        allow(RemoveFeaturedTagService)
+          .to receive(:new)
+          .and_return(service)
+      end
     end
   end
 end

--- a/spec/workers/resolve_account_worker_spec.rb
+++ b/spec/workers/resolve_account_worker_spec.rb
@@ -4,10 +4,34 @@ require 'rails_helper'
 
 RSpec.describe ResolveAccountWorker do
   let(:worker) { described_class.new }
+  let(:service) { instance_double(ResolveAccountService, call: true) }
 
   describe 'perform' do
-    it 'runs without error for missing record' do
-      expect { worker.perform(nil) }.to_not raise_error
+    context 'with missing values' do
+      it 'runs without error' do
+        expect { worker.perform(nil) }
+          .to_not raise_error
+      end
+    end
+
+    context 'with a URI' do
+      before { stub_service }
+
+      let(:uri) { 'https://host/path/value' }
+
+      it 'initiates account resolution' do
+        worker.perform(uri)
+
+        expect(service)
+          .to have_received(:call)
+          .with(uri)
+      end
+
+      def stub_service
+        allow(ResolveAccountService)
+          .to receive(:new)
+          .and_return(service)
+      end
     end
   end
 end


### PR DESCRIPTION
Many of these just have "does this run w/out error" coverage, which was added previously to just get the codebase-wide C0 coverage up a bit.

Starting to expand that a bit and have at least that basic check plus some happy path checks for many of them.

Will do these in little batches. This one adds a few new specs, and expands a few that just had the basic coverage to have at least a little more.