### PR TITLE
Add title attributes to invite expiration statuses missing them

### DIFF
--- a/app/helpers/invites_helper.rb
+++ b/app/helpers/invites_helper.rb
@@ -8,4 +8,8 @@ module InvitesHelper
   def invites_expires_options
     [30.minutes, 1.hour, 6.hours, 12.hours, 1.day, 1.week]
   end
+
+  def invite_never_expires
+    '∞'
+  end
 end

--- a/app/views/admin/invites/_invite.html.haml
+++ b/app/views/admin/invites/_invite.html.haml
@@ -17,13 +17,15 @@
       = " / #{invite.max_uses}" unless invite.max_uses.nil?
     %td
       - if invite.expires_at.nil?
-        ∞
+        %span{ title: t('invites.expires_in_prompt') }
+          = invite_never_expires
       - else
         %time.formatted{ datetime: invite.expires_at.iso8601, title: l(invite.expires_at) }
           = l invite.expires_at
   - else
     %td{ colspan: 2 }
-      = t('invites.expired')
+      %span{ title: l(invite.expires_at) }
+        = t('invites.expired')
 
   %td
     - if invite.valid_for_use? && policy(invite).destroy?

--- a/app/views/invites/_invite.html.haml
+++ b/app/views/invites/_invite.html.haml
@@ -12,13 +12,15 @@
       = " / #{invite.max_uses}" unless invite.max_uses.nil?
     %td
       - if invite.expires_at.nil?
-        ∞
+        %span{ title: t('invites.expires_in_prompt') }
+          = invite_never_expires
       - else
         %time.formatted{ datetime: invite.expires_at.iso8601, title: l(invite.expires_at) }
           = l invite.expires_at
   - else
     %td{ colspan: 2 }
-      = t('invites.expired')
+      %span{ title: l(invite.expires_at) }
+        = t('invites.expired')
 
   %td
     - if invite.valid_for_use? && policy(invite).destroy?


### PR DESCRIPTION
The non-expired entries have dates in their title attributes, but the expired and never expiring are missing them.

For expired ones, add their expiry date (will be in the past); for never-expiring, grab the i18n label value.

Extracted the infinity symbol to a helper so the views dont get out of sync if it ever changes to a silly emoji or something.