### PR TITLE
Chore: Add ruby-lsp for better developer experience

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -189,6 +189,10 @@ group :development do
 
   # Validate missing i18n keys
   gem 'i18n-tasks', '~> 1.0', require: false
+
+  # Ruby Language Server
+  gem 'ruby-lsp', '~> 0.20.1'
+  gem 'ruby-lsp-rails', '~> 0.3.19'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -601,6 +601,7 @@ GEM
       actionmailer (>= 3)
       net-smtp
       premailer (~> 1.7, >= 1.7.9)
+    prism (1.2.0)
     propshaft (1.1.0)
       actionpack (>= 7.0.0)
       activesupport (>= 7.0.0)
@@ -676,6 +677,8 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.2.1)
+    rbs (3.6.1)
+      logger
     rdf (3.3.2)
       bcp47_spec (~> 0.2)
       bigdecimal (~> 3.1, >= 3.1.5)
@@ -761,6 +764,13 @@ GEM
     rubocop-rspec_rails (2.30.0)
       rubocop (~> 1.61)
       rubocop-rspec (~> 3, >= 3.0.1)
+    ruby-lsp (0.20.1)
+      language_server-protocol (~> 3.17.0)
+      prism (>= 1.2, < 2.0)
+      rbs (>= 3, < 4)
+      sorbet-runtime (>= 0.5.10782)
+    ruby-lsp-rails (0.3.19)
+      ruby-lsp (>= 0.20.0, < 0.21.0)
     ruby-prof (1.7.0)
     ruby-progressbar (1.13.0)
     ruby-saml (1.17.0)
@@ -818,6 +828,7 @@ GEM
     simplecov-html (0.13.1)
     simplecov-lcov (0.8.0)
     simplecov_json_formatter (0.1.4)
+    sorbet-runtime (0.5.11604)
     stackprof (0.2.26)
     stoplight (4.1.0)
       redlock (~> 1.0)
@@ -1026,6 +1037,8 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec
   rubocop-rspec_rails
+  ruby-lsp (~> 0.20.1)
+  ruby-lsp-rails (~> 0.3.19)
   ruby-prof
   ruby-progressbar (~> 1.13)
   ruby-vips (~> 2.2)


### PR DESCRIPTION
I've been using ruby-lsp for a little while, and it's pretty useful for development, especially on a codebase as large as the Mastodon codebase. Whilst it is still quite new, Shopify is behind both the gems used here.

- https://rubygems.org/gems/ruby-lsp
- https://rubygems.org/gems/ruby-lsp-rails

Arguably we could add this to the `:development, :test` group, but `:development` felt most right?

I think this goes hand in hand with us adopting the debug gem for debugging last year #27960 

#### Sidenote

I had been using rbenv gemsets to automatically install ruby-lsp with each ruby version, but recently started getting issues where different gems such as yard, rake, etc would suddenly become corrupted (I suspect this was due to the VSCode ruby-lsp plugin messing with something)