### PR TITLE
Add userinfo oauth endpoint

### DIFF
--- a/app/controllers/oauth/userinfo_controller.rb
+++ b/app/controllers/oauth/userinfo_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Oauth::UserinfoController < Api::BaseController
+  before_action -> { doorkeeper_authorize! :profile }, only: [:show]
+  before_action :require_user!
+
+  def show
+    @account = current_account
+    render json: @account, serializer: OauthUserinfoSerializer
+  end
+end

--- a/app/presenters/oauth_metadata_presenter.rb
+++ b/app/presenters/oauth_metadata_presenter.rb
@@ -26,6 +26,10 @@ class OauthMetadataPresenter < ActiveModelSerializers::Model
     oauth_token_url
   end
 
+  def userinfo_endpoint
+    oauth_userinfo_url
+  end
+
   # As the api_v1_apps route doesn't technically conform to the specification
   # for OAuth 2.0 Dynamic Client Registration defined in RFC 7591 we use a
   # non-standard property for now to indicate the mastodon specific registration

--- a/app/serializers/oauth_metadata_serializer.rb
+++ b/app/serializers/oauth_metadata_serializer.rb
@@ -2,7 +2,7 @@
 
 class OauthMetadataSerializer < ActiveModel::Serializer
   attributes :issuer, :authorization_endpoint, :token_endpoint,
-             :revocation_endpoint, :scopes_supported,
+             :revocation_endpoint, :userinfo_endpoint, :scopes_supported,
              :response_types_supported, :response_modes_supported,
              :grant_types_supported, :token_endpoint_auth_methods_supported,
              :code_challenge_methods_supported,

--- a/app/serializers/oauth_userinfo_serializer.rb
+++ b/app/serializers/oauth_userinfo_serializer.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class OauthUserinfoSerializer < ActiveModel::Serializer
+  include RoutingHelper
+
+  attributes :iss, :sub, :name, :preferred_username, :profile, :picture
+
+  def iss
+    root_url
+  end
+
+  def sub
+    ActivityPub::TagManager.instance.uri_for(object)
+  end
+
+  def name
+    object.unavailable? ? '' : object.display_name
+  end
+
+  def preferred_username
+    object.username
+  end
+
+  def profile
+    ActivityPub::TagManager.instance.url_for(object)
+  end
+
+  def picture
+    full_asset_url(object.unavailable? ? object.avatar.default_url : object.avatar_original_url)
+  end
+end

--- a/app/serializers/oauth_userinfo_serializer.rb
+++ b/app/serializers/oauth_userinfo_serializer.rb
@@ -14,7 +14,7 @@ class OauthUserinfoSerializer < ActiveModel::Serializer
   end
 
   def name
-    object.unavailable? ? '' : object.display_name
+    object.display_name
   end
 
   def preferred_username
@@ -26,6 +26,6 @@ class OauthUserinfoSerializer < ActiveModel::Serializer
   end
 
   def picture
-    full_asset_url(object.unavailable? ? object.avatar.default_url : object.avatar_original_url)
+    full_asset_url(object.avatar_original_url)
   end
 end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -23,7 +23,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
                methods: %i(post put delete get patch options)
       resource '/oauth/token', methods: [:post]
       resource '/oauth/revoke', methods: [:post]
-      resource '/oauth/userinfo', methods: [:get]
+      resource '/oauth/userinfo', methods: [:get, :post]
     end
   end
 end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -23,6 +23,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
                methods: %i(post put delete get patch options)
       resource '/oauth/token', methods: [:post]
       resource '/oauth/revoke', methods: [:post]
+      resource '/oauth/userinfo', methods: [:get]
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,11 +65,10 @@ Rails.application.routes.draw do
   end
 
   namespace :oauth do
-    get 'userinfo', to: 'userinfo#show', defaults: { format: 'json' }
     # As this is borrowed from OpenID, the specification says we must also support
     # POST for the userinfo endpoint:
     # https://openid.net/specs/openid-connect-core-1_0.html#UserInfo
-    post 'userinfo', to: 'userinfo#show', defaults: { format: 'json' }
+    match 'userinfo', via: [:get, :post], to: 'userinfo#show', defaults: { format: 'json' }
   end
 
   scope path: '.well-known' do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,10 @@ Rails.application.routes.draw do
                 tokens: 'oauth/tokens'
   end
 
+  namespace :oauth do
+    get 'userinfo', to: 'userinfo#show', defaults: { format: 'json' }
+  end
+
   scope path: '.well-known' do
     scope module: :well_known do
       get 'oauth-authorization-server', to: 'oauth_metadata#show', as: :oauth_metadata, defaults: { format: 'json' }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,6 +66,10 @@ Rails.application.routes.draw do
 
   namespace :oauth do
     get 'userinfo', to: 'userinfo#show', defaults: { format: 'json' }
+    # As this is borrowed from OpenID, the specification says we must also support
+    # POST for the userinfo endpoint:
+    # https://openid.net/specs/openid-connect-core-1_0.html#UserInfo
+    post 'userinfo', to: 'userinfo#show', defaults: { format: 'json' }
   end
 
   scope path: '.well-known' do

--- a/spec/requests/oauth/userinfo_spec.rb
+++ b/spec/requests/oauth/userinfo_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Oauth Userinfo Endpoint' do
         name: account.display_name,
         preferred_username: account.username,
         profile: short_account_url(account),
-        picture: full_asset_url(account.unavailable? ? account.avatar.default_url : account.avatar_original_url),
+        picture: full_asset_url(account.avatar_original_url),
       })
     end
   end

--- a/spec/requests/oauth/userinfo_spec.rb
+++ b/spec/requests/oauth/userinfo_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Oauth Userinfo Endpoint' do
+  include RoutingHelper
+
+  describe 'GET /oauth/userinfo' do
+    subject do
+      get '/oauth/userinfo', headers: headers
+    end
+
+    let(:user)     { Fabricate(:user) }
+    let(:account)  { user.account }
+    let(:token)    { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
+    let(:scopes)   { 'profile' }
+    let(:headers)  { { 'Authorization' => "Bearer #{token.token}" } }
+
+    it_behaves_like 'forbidden for wrong scope', 'read:accounts'
+
+    it 'returns http success' do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(response.content_type).to start_with('application/json')
+      expect(response.parsed_body).to include({
+        iss: root_url,
+        sub: account_url(account),
+        name: account.display_name,
+        preferred_username: account.username,
+        profile: short_account_url(account),
+        picture: full_asset_url(account.unavailable? ? account.avatar.default_url : account.avatar_original_url),
+      })
+    end
+  end
+end

--- a/spec/requests/well_known/oauth_metadata_spec.rb
+++ b/spec/requests/well_known/oauth_metadata_spec.rb
@@ -3,12 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe 'The /.well-known/oauth-authorization-server request' do
-  let(:protocol) { ENV.fetch('LOCAL_HTTPS', true) ? :https : :http }
-
-  before do
-    host! Rails.configuration.x.local_domain
-  end
-
   it 'returns http success with valid JSON response' do
     get '/.well-known/oauth-authorization-server'
 
@@ -22,11 +16,12 @@ RSpec.describe 'The /.well-known/oauth-authorization-server request' do
     grant_types_supported << 'refresh_token' if Doorkeeper.configuration.refresh_token_enabled?
 
     expect(response.parsed_body).to include(
-      issuer: root_url(protocol: protocol),
+      issuer: root_url,
       service_documentation: 'https://docs.joinmastodon.org/',
-      authorization_endpoint: oauth_authorization_url(protocol: protocol),
-      token_endpoint: oauth_token_url(protocol: protocol),
-      revocation_endpoint: oauth_revoke_url(protocol: protocol),
+      authorization_endpoint: oauth_authorization_url,
+      token_endpoint: oauth_token_url,
+      userinfo_endpoint: oauth_userinfo_url,
+      revocation_endpoint: oauth_revoke_url,
       scopes_supported: Doorkeeper.configuration.scopes.map(&:to_s),
       response_types_supported: Doorkeeper.configuration.authorization_response_types,
       response_modes_supported: Doorkeeper.configuration.authorization_response_flows.flat_map(&:response_mode_matches).uniq,
@@ -34,7 +29,7 @@ RSpec.describe 'The /.well-known/oauth-authorization-server request' do
       grant_types_supported: grant_types_supported,
       code_challenge_methods_supported: ['S256'],
       # non-standard extension:
-      app_registration_endpoint: api_v1_apps_url(protocol: protocol)
+      app_registration_endpoint: api_v1_apps_url
     )
   end
 end


### PR DESCRIPTION
This implements #31257, and gives a response using [standard claims](https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims) from OpenID Connect.

### Example Response

```json
{
  "sub": "http://localhost:3000/users/thisismissem",
  "name": "Emelia 👸🏻",
  "preferred_username": "thisismissem",
  "profile": "http://localhost:3000/@thisismissem",
  "picture": "http://localhost:9000/mastodon-development/accounts/avatars/112/570/037/924/789/254/original/6ea746a330746ef8.jpg"
}
```

This further significantly reduces the amount of data about the user that is given to third-party apps which don't necessarily need it. This follows on from implementing the `profile` scope in v4.3.0.

### On `sub` claim

This can be a String or URI, we _could_ make it the account ID, but this value is not globally unique, for example, on MastoHost, many accounts have the ID of `1` across different servers. So this felt better to use the ActivityPub Actor URI instead.

There isn't a reasonable claim that we can use to indicate the activitypub server, e.g., `user@mastodon.social`, though we could also validly use the `Account#local_username_and_domain` here which would give that.

I'm not sure which is best, to be honest. Arguably app developers may prefer `user@mastodon.social` over the activitypub actor URI.

### Additional Claims

We could optionally also add an `email` scope which allows returning `email` and `email_verified` claims, however, we do not currently ever expose the users' email address via the API, apart from in Admin API responses. I'm not sure how we'd check scopes for `email` and then optionally return `email` and `email_verified` claims. Perhaps that's something we can add in the future, tbd?

### On discovery

Services/applications can discover via the [OAuth Authorization Server Metadata](https://docs.joinmastodon.org/spec/oauth/#authorization-server-metadata) endpoint (`/.well-known/oauth-authorization-server`) as to whether a Mastodon server supports this endpoint via the `userinfo_endpoint` property's presence. If it's missing, you'd need to fallback to doing a request to `GET /api/v1/accounts/verify_credentials` (this is the case for Mastodon v4.3.0)

### Why GET and POST requests?

The OpenID Specification that defines the userinfo endpoint mandates it:

> The Client sends the UserInfo Request using either HTTP GET or HTTP POST. The Access Token obtained from an OpenID Connect Authentication Request MUST be sent as a Bearer Token, per Section 2 of [OAuth 2.0 Bearer Token Usage](https://openid.net/specs/openid-connect-core-1_0.html#RFC6750) [RFC6750].
> 
> It is RECOMMENDED that the request use the HTTP GET method and the Access Token be sent using the Authorization header field.

I think it's a bit silly to need both GET and POST, but then recommend GET, but it is what it is.