### PR TITLE
Add verbose mode to CLI `version` command

### DIFF
--- a/lib/mastodon/cli/main.rb
+++ b/lib/mastodon/cli/main.rb
@@ -18,6 +18,7 @@ require_relative 'search'
 require_relative 'settings'
 require_relative 'statuses'
 require_relative 'upgrade'
+require_relative 'version'
 
 module Mastodon::CLI
   class Main < Base
@@ -67,12 +68,6 @@ module Mastodon::CLI
     subcommand 'maintenance', Maintenance
 
     include Federation
-
-    map %w(--version -v) => :version
-
-    desc 'version', 'Show version'
-    def version
-      say(Mastodon::Version.to_s)
-    end
+    include Version
   end
 end

--- a/lib/mastodon/cli/version.rb
+++ b/lib/mastodon/cli/version.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Mastodon::CLI
+  module Version
+    extend ActiveSupport::Concern
+
+    included do
+      map %w(--version -v) => :version
+
+      option :verbose, type: :boolean, aliases: [:v]
+      desc 'version', 'Show version'
+      def version
+        if options[:verbose]
+          print_table [
+            %w(Software Version),
+            *software_versions,
+          ]
+        else
+          say(Mastodon::Version.to_s)
+        end
+      end
+
+      private
+
+      def software_versions
+        Admin::Metrics::Dimension::SoftwareVersionsDimension
+          .new(Date.current, Date.current, 0, {})
+          .data
+          .map { |data| [data[:human_key], data[:value]] }
+      end
+    end
+  end
+end

--- a/spec/lib/mastodon/cli/main_spec.rb
+++ b/spec/lib/mastodon/cli/main_spec.rb
@@ -19,6 +19,15 @@ RSpec.describe Mastodon::CLI::Main do
       expect { subject }
         .to output_results(Mastodon::Version.to_s)
     end
+
+    context 'when in verbose mode' do
+      let(:options) { { verbose: true } }
+
+      it 'returns mastodon and more information' do
+        expect { subject }
+          .to output_results(Mastodon::Version.to_s, RUBY_VERSION)
+      end
+    end
   end
 
   describe '#self_destruct' do


### PR DESCRIPTION
Preserves prior behavior, but adds more version output with verbose (borrowing from existing admin report). Idea here would be to help with issue filing (prompt people for output of this). Could add more information in future, just went with what we already had for first pass.

Example:

```shell
❯ bin/tootctl version          
4.4.0-alpha.1

~/repos/mastodon cli-version-verbose
❯ bin/tootctl version --verbose
Software     Version
Mastodon     4.4.0-alpha.1
Ruby         ruby 3.3.5 (2024-09-03 revision ef084cc8f4) +YJIT [arm64-darwin23]
PostgreSQL   17.0
Redis        7.2.6
ImageMagick  7.1.1-39
FFmpeg       7.1
```