### PR TITLE
Fix missing or incorrect cache-control headers for Streaming server

### DIFF
--- a/streaming/index.js
+++ b/streaming/index.js
@@ -235,7 +235,7 @@ const startServer = async () => {
   app.get('/favicon.ico', (_req, res) => res.status(404).end());
 
   app.get('/api/v1/streaming/health', (_req, res) => {
-    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.writeHead(200, { 'Content-Type': 'text/plain', 'Cache-Control': 'private, no-store' });
     res.end('OK');
   });
 
@@ -858,7 +858,7 @@ const startServer = async () => {
     }
 
     res.setHeader('Content-Type', 'text/event-stream');
-    res.setHeader('Cache-Control', 'no-store');
+    res.setHeader('Cache-Control', 'private, no-store');
     res.setHeader('Transfer-Encoding', 'chunked');
 
     res.write(':)\n');

--- a/streaming/metrics.js
+++ b/streaming/metrics.js
@@ -98,9 +98,11 @@ export function setupMetrics(channels, pgPool) {
   const requestHandler = (req, res) => {
     metrics.register.metrics().then((output) => {
       res.set('Content-Type', metrics.register.contentType);
+      res.set('Cache-Control', 'private, no-store');
       res.end(output);
     }).catch((err) => {
       req.log.error(err, "Error collecting metrics");
+      res.set('Cache-Control', 'private, no-store');
       res.status(500).end();
     });
   };


### PR DESCRIPTION
Fixes #32540. This was likely causing Cloudflare to cache the healthcheck endpoint.

This could explain what @ChadOhman was seeing with mstdn.ca when using cloudflare tunnel, if cloudflare does caching automatically with Cloudflare Tunnel.