### PR TITLE
Fix follow notifications being filtered

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -47,7 +47,7 @@ class Notification < ApplicationRecord
       filterable: true,
     }.freeze,
     follow: {
-      filterable: true,
+      filterable: false,
     }.freeze,
     follow_request: {
       filterable: true,

--- a/spec/services/notify_service_spec.rb
+++ b/spec/services/notify_service_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe NotifyService do
   let(:user) { Fabricate(:user) }
   let(:recipient) { user.account }
   let(:sender) { Fabricate(:account, domain: 'example.com') }
-  let(:activity) { Fabricate(:follow, account: sender, target_account: recipient) }
-  let(:type) { :follow }
+  let(:activity) { Fabricate(:mention, account: recipient, status: Fabricate(:status, account: sender)) }
+  let(:type) { :mention }
 
   it { expect { subject }.to change(Notification, :count).by(1) }
 
@@ -98,7 +98,7 @@ RSpec.describe NotifyService do
 
   describe 'email' do
     before do
-      user.settings.update('notification_emails.follow': enabled)
+      user.settings.update('notification_emails.mention': enabled)
       user.save
     end
 
@@ -113,7 +113,7 @@ RSpec.describe NotifyService do
         expect(emails.first)
           .to have_attributes(
             to: contain_exactly(user.email),
-            subject: eq(I18n.t('notification_mailer.follow.subject', name: sender.acct))
+            subject: eq(I18n.t('notification_mailer.mention.subject', name: sender.acct))
           )
       end
     end


### PR DESCRIPTION
Fixes #32441

I am not 100% sure about this one, but I think it makes more sense to see all follows than filtering them. There are multiple things a user can do to avoid noise from follow spam:
- group follow notifications (#32520)
- require follow requests instead of auto-accepting follows
- hide notifications for follows

In addition, limited accounts still generate follow requests instead of follows, regardless of the user's settings, so this does not change the behavior about this.