### PR TITLE
Add `native_name` attribute to `instances/language` API response

### DIFF
--- a/app/serializers/rest/language_serializer.rb
+++ b/app/serializers/rest/language_serializer.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class REST::LanguageSerializer < ActiveModel::Serializer
-  attributes :code, :name
+  attributes :code, :name, :native_name
 end

--- a/spec/requests/api/v1/instances/languages_spec.rb
+++ b/spec/requests/api/v1/instances/languages_spec.rb
@@ -14,7 +14,17 @@ RSpec.describe 'Languages' do
       expect(response.content_type)
         .to start_with('application/json')
       expect(response.parsed_body)
-        .to match_array(LanguagesHelper::SUPPORTED_LOCALES.map { |key, values| include(code: key.to_s, name: values.first, native_name: values.last) })
+        .to match_array(supported_locale_expectations)
+    end
+
+    def supported_locale_expectations
+      LanguagesHelper::SUPPORTED_LOCALES.map do |key, values|
+        include(
+          code: key.to_s,
+          name: values.first,
+          native_name: values.last
+        )
+      end
     end
   end
 end

--- a/spec/requests/api/v1/instances/languages_spec.rb
+++ b/spec/requests/api/v1/instances/languages_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Languages' do
       expect(response.content_type)
         .to start_with('application/json')
       expect(response.parsed_body)
-        .to match_array(LanguagesHelper::SUPPORTED_LOCALES.map { |key, values| include(code: key.to_s, name: values.first) })
+        .to match_array(LanguagesHelper::SUPPORTED_LOCALES.map { |key, values| include(code: key.to_s, name: values.first, native_name: values.last) })
     end
   end
 end

--- a/spec/requests/api/v1/instances/languages_spec.rb
+++ b/spec/requests/api/v1/instances/languages_spec.rb
@@ -9,10 +9,12 @@ RSpec.describe 'Languages' do
     end
 
     it 'returns http success and includes supported languages' do
-      expect(response).to have_http_status(200)
+      expect(response)
+        .to have_http_status(200)
       expect(response.content_type)
         .to start_with('application/json')
-      expect(response.parsed_body.pluck(:code)).to match_array LanguagesHelper::SUPPORTED_LOCALES.keys.map(&:to_s)
+      expect(response.parsed_body)
+        .to match_array(LanguagesHelper::SUPPORTED_LOCALES.map { |key, values| include(code: key.to_s, name: values.first) })
     end
   end
 end


### PR DESCRIPTION
Context: https://github.com/mastodon/mastodon/pull/24443#issuecomment-2341283865

In linked PR, this attribute was added to the presenter, but not the serializer. This assumes it was intended to be in the response. If that's not the case (question did not receive a reply), I can update this to be a removal from the presenter instead (this is the only place it would be used, pretty sure).

Added coverage for already-present `name` value as well.

Not sure if this is technically a bug fix or an addition.