### PR TITLE
Fix column-settings spacing in local timeline in advanced view

### DIFF
--- a/app/javascript/mastodon/features/community_timeline/components/column_settings.jsx
+++ b/app/javascript/mastodon/features/community_timeline/components/column_settings.jsx
@@ -21,9 +21,11 @@ class ColumnSettings extends PureComponent {
 
     return (
       <div className='column-settings'>
-        <div className='column-settings__row'>
-          <SettingToggle settings={settings} settingPath={['other', 'onlyMedia']} onChange={onChange} label={<FormattedMessage id='community.column_settings.media_only' defaultMessage='Media only' />} />
-        </div>
+        <section>
+          <div className='column-settings__row'>
+            <SettingToggle settings={settings} settingPath={['other', 'onlyMedia']} onChange={onChange} label={<FormattedMessage id='community.column_settings.media_only' defaultMessage='Media only' />} />
+          </div>
+        </section>
       </div>
     );
   }


### PR DESCRIPTION
### Actual behaviour before this PR

<img width="300" alt="Screenshot_20241018_050125_vivaldi" src="https://github.com/user-attachments/assets/e33e3c82-e550-4283-8c1d-c95ce45e0ba3">
