### PR TITLE
Fix broken i18n in text welcome mailer tags area

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -244,6 +244,11 @@ module ApplicationHelper
     tag.input(type: :text, maxlength: 999, spellcheck: false, readonly: true, **options)
   end
 
+  def recent_tag_usage(tag)
+    people = tag.history.aggregate(2.days.ago.to_date..Time.zone.today).accounts
+    I18n.t 'user_mailer.welcome.hashtags_recent_count', people: number_with_delimiter(people), count: people
+  end
+
   private
 
   def storage_host_var

--- a/app/views/application/mailer/_hashtag.html.haml
+++ b/app/views/application/mailer/_hashtag.html.haml
@@ -17,5 +17,4 @@
                           %span.email-mini-hashtag-img-span
                             = image_tag full_asset_url(account.avatar.url), alt: '', width: 16, height: 16
                       %td
-                        - people = hashtag.history.aggregate(2.days.ago.to_date..Time.zone.today).accounts
-                        %p= t('user_mailer.welcome.hashtags_recent_count', people: number_with_delimiter(people), count: people)
+                        %p= recent_tag_usage(hashtag)

--- a/app/views/user_mailer/welcome.text.erb
+++ b/app/views/user_mailer/welcome.text.erb
@@ -53,7 +53,7 @@
 <%= t('user_mailer.welcome.hashtags_subtitle') %>
 
 <%- @tags.each do |tag| %>
-* #<%= tag.display_name %> · <%= t('user_mailer.welcome.hashtags_recent_count', people: number_with_delimiter(tag.history.aggregate(2.days.ago.to_date..Time.zone.today).accounts)) %>
+* #<%= tag.display_name %> · <%= recent_tag_usage(tag) %>
   <%= tag_url(tag) %>
 <%- end %>
 


### PR DESCRIPTION
Typically an i18n entry like this would just accept a single `count` and use it both as an interpolation value if needed, and to determine the [pluralization](https://guides.rubyonrails.org/i18n.html#pluralization) as well.

In the html mailer we are sending both `count` (determines pluralization) and `people` (used in string); but in the text version of the welcome mailer we are only sending `people` which leads to view being not able to pluralize.

Thus, a text version of mailer shows as:


```text
Trending hashtags
===
Explore what’s trending since past 2 days

* #expedita0 · {:one=>"%{people} person in the past 2 days", :other=>"%{people} people in the past 2 days"}
  http://mastodon.test/tags/expedita0
* #test · {:one=>"%{people} person in the past 2 days", :other=>"%{people} people in the past 2 days"}
  http://mastodon.test/tags/test

http://mastodon.test/web/explore/tags
```

Change here is to pull out a helper which wraps the full i18n call along with both needed params. As added side benefit, pulls local var out of html view, and by keeping the history-chain logic in one spot should be less likely to diverge.

After:


```
Trending hashtags
===
Explore what’s trending since past 2 days

* #expedita0 · 0 people in the past 2 days
  http://mastodon.test/tags/expedita0
* #test · 0 people in the past 2 days
  http://mastodon.test/tags/test

http://mastodon.test/web/explore/tags
```

Looks like pluralization added in https://github.com/mastodon/mastodon/pull/29607 and then this issued actually noticed/fixed already in https://github.com/mastodon/mastodon/pull/29879 but only html fixed, not text as well.

Questions/Future:

- I assume that the usage of `number_with_delimiter` here is the rationale behind not just having the `count` directly. Is that necessary, or could we switch to just `count`?
- I put this in application helper as simplest/quick fix, not sure where best home is
- This history method could go on Tag directly, or a presenter?
- Arguably the welcome mailer template should have a presenter just for it and nothing else? The checklist and features would go nicely in there, and the large collection of mailer i-vars could move into that class as well. This tags setup as well.

