### PR TITLE
Remove ability to get embed code for remote posts

### DIFF
--- a/app/javascript/mastodon/components/status_action_bar.jsx
+++ b/app/javascript/mastodon/components/status_action_bar.jsx
@@ -264,7 +264,7 @@ class StatusActionBar extends ImmutablePureComponent {
       menu.push({ text: intl.formatMessage(messages.share), action: this.handleShareClick });
     }
 
-    if (publicStatus && (signedIn || !isRemote)) {
+    if (publicStatus && !isRemote) {
       menu.push({ text: intl.formatMessage(messages.embed), action: this.handleEmbed });
     }
 


### PR DESCRIPTION
Currently, trying to get the remote code for a remote posts can fail in different ways depending on the fediverse software used on the other side:
- Mastodon 4.3: everything useful is stripped away and the only thing remaining is a non-functional text placeholder (see https://github.com/mastodon/mastodon/issues/32408#issuecomment-2419018087)
- Mastodon 4.2 and earlier: this returns a functional, but badly-sized `iframe` with the embed
- pretty much any other fediverse software: this errors out with a 404

This PR is not a real fix, but it hides the menu entry for remote posts since in most cases the result is confusing and useless.