### PR TITLE
Wrap app store platforms/urls in `config_for` setup

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -237,14 +237,14 @@ module ApplicationHelper
     I18n.t 'user_mailer.welcome.hashtags_recent_count', people: number_with_delimiter(people), count: people
   end
 
-  def app_store_url(platform)
-    app_store(platform)[:url]
+  def app_store_location(platform)
+    app_store(platform)[:url].to_s
   end
 
   private
 
   def app_store(platform)
-    Rails.configuration.x.mastodon.apps[platform]
+    Rails.configuration.x.mastodon.apps[platform] || {}
   end
 
   def storage_host_var

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -237,7 +237,15 @@ module ApplicationHelper
     I18n.t 'user_mailer.welcome.hashtags_recent_count', people: number_with_delimiter(people), count: people
   end
 
+  def app_store_url(platform)
+    app_store(platform)[:url]
+  end
+
   private
+
+  def app_store(platform)
+    Rails.configuration.x.mastodon.apps.detect { |store| store[:platform] == platform.to_s }
+  end
 
   def storage_host_var
     ENV.fetch('S3_ALIAS_HOST', nil) || ENV.fetch('S3_CLOUDFRONT_HOST', nil) || ENV.fetch('AZURE_ALIAS_HOST', nil)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -244,7 +244,7 @@ module ApplicationHelper
   private
 
   def app_store(platform)
-    Rails.configuration.x.mastodon.apps.detect { |store| store[:platform] == platform.to_s }
+    Rails.configuration.x.mastodon.apps[platform]
   end
 
   def storage_host_var

--- a/app/serializers/manifest_serializer.rb
+++ b/app/serializers/manifest_serializer.rb
@@ -96,22 +96,6 @@ class ManifestSerializer < ActiveModel::Serializer
   end
 
   def related_applications
-    [
-      {
-        platform: 'play',
-        url: 'https://play.google.com/store/apps/details?id=org.joinmastodon.android',
-        id: 'org.joinmastodon.android',
-      },
-      {
-        platform: 'itunes',
-        url: 'https://apps.apple.com/us/app/mastodon-for-iphone/id1571998974',
-        id: 'id1571998974',
-      },
-      {
-        platform: 'f-droid',
-        url: 'https://f-droid.org/en/packages/org.joinmastodon.android/',
-        id: 'org.joinmastodon.android',
-      },
-    ]
+    Rails.configuration.x.mastodon.apps
   end
 end

--- a/app/serializers/manifest_serializer.rb
+++ b/app/serializers/manifest_serializer.rb
@@ -96,6 +96,8 @@ class ManifestSerializer < ActiveModel::Serializer
   end
 
   def related_applications
-    Rails.configuration.x.mastodon.apps
+    Rails.configuration.x.mastodon.apps.map do |key, values|
+      { platform: key, url: values[:url], id: values[:id] }
+    end
   end
 end

--- a/app/views/application/mailer/_checklist.html.haml
+++ b/app/views/application/mailer/_checklist.html.haml
@@ -29,8 +29,8 @@
                     %div
                       - if defined?(show_apps_buttons) && show_apps_buttons
                         .email-welcome-apps-btns
-                          = link_to image_tag(frontend_asset_url('images/mailer-new/store-icons/btn-app-store.png'), alt: t('user_mailer.welcome.apps_ios_action'), width: 120, height: 40), app_store_url(:itunes)
-                          = link_to image_tag(frontend_asset_url('images/mailer-new/store-icons/btn-google-play.png'), alt: t('user_mailer.welcome.apps_android_action'), width: 120, height: 40), app_store_url(:play)
+                          = link_to image_tag(frontend_asset_url('images/mailer-new/store-icons/btn-app-store.png'), alt: t('user_mailer.welcome.apps_ios_action'), width: 120, height: 40), app_store_location(:itunes)
+                          = link_to image_tag(frontend_asset_url('images/mailer-new/store-icons/btn-google-play.png'), alt: t('user_mailer.welcome.apps_android_action'), width: 120, height: 40), app_store_location(:play)
                       - elsif defined?(button_text) && defined?(button_url) && defined?(checked) && !checked
                         = render 'application/mailer/button', text: button_text, url: button_url, has_arrow: false
                     /[if mso]

--- a/app/views/application/mailer/_checklist.html.haml
+++ b/app/views/application/mailer/_checklist.html.haml
@@ -29,8 +29,8 @@
                     %div
                       - if defined?(show_apps_buttons) && show_apps_buttons
                         .email-welcome-apps-btns
-                          = link_to image_tag(frontend_asset_url('images/mailer-new/store-icons/btn-app-store.png'), alt: t('user_mailer.welcome.apps_ios_action'), width: 120, height: 40), 'https://apps.apple.com/app/mastodon-for-iphone-and-ipad/id1571998974'
-                          = link_to image_tag(frontend_asset_url('images/mailer-new/store-icons/btn-google-play.png'), alt: t('user_mailer.welcome.apps_android_action'), width: 120, height: 40), 'https://play.google.com/store/apps/details?id=org.joinmastodon.android'
+                          = link_to image_tag(frontend_asset_url('images/mailer-new/store-icons/btn-app-store.png'), alt: t('user_mailer.welcome.apps_ios_action'), width: 120, height: 40), app_store_url(:itunes)
+                          = link_to image_tag(frontend_asset_url('images/mailer-new/store-icons/btn-google-play.png'), alt: t('user_mailer.welcome.apps_android_action'), width: 120, height: 40), app_store_url(:play)
                       - elsif defined?(button_text) && defined?(button_url) && defined?(checked) && !checked
                         = render 'application/mailer/button', text: button_text, url: button_url, has_arrow: false
                     /[if mso]

--- a/app/views/user_mailer/welcome.text.erb
+++ b/app/views/user_mailer/welcome.text.erb
@@ -30,8 +30,8 @@
 
 5. <%= t('user_mailer.welcome.apps_title') %>
    <%= t('user_mailer.welcome.apps_step') %>
-   * iOS: https://apps.apple.com/app/mastodon-for-iphone-and-ipad/id1571998974
-   * Android: https://play.google.com/store/apps/details?id=org.joinmastodon.android
+   * iOS: <%= app_store_url(:itunes) %>
+   * Android: <%= app_store_url(:play) %>
 
 ---
 

--- a/app/views/user_mailer/welcome.text.erb
+++ b/app/views/user_mailer/welcome.text.erb
@@ -30,8 +30,8 @@
 
 5. <%= t('user_mailer.welcome.apps_title') %>
    <%= t('user_mailer.welcome.apps_step') %>
-   * iOS: <%= app_store_url(:itunes) %>
-   * Android: <%= app_store_url(:play) %>
+   * iOS: <%= app_store_location(:itunes) %>
+   * Android: <%= app_store_location(:play) %>
 
 ---
 

--- a/config/mastodon.yml
+++ b/config/mastodon.yml
@@ -1,4 +1,14 @@
 ---
 shared:
+  apps:
+    - id: org.joinmastodon.android
+      platform: f-droid
+      url: https://f-droid.org/en/packages/org.joinmastodon.android/
+    - id: id1571998974
+      platform: itunes
+      url: https://apps.apple.com/us/app/mastodon/id1571998974
+    - id: org.joinmastodon.android
+      platform: play
+      url: https://play.google.com/store/apps/details?id=org.joinmastodon.android
   self_destruct_value: <%= ENV.fetch('SELF_DESTRUCT', nil) %>
   software_update_url: <%= ENV.fetch('UPDATE_CHECK_URL', 'https://api.joinmastodon.org/update-check') %>

--- a/config/mastodon.yml
+++ b/config/mastodon.yml
@@ -1,14 +1,14 @@
 ---
 shared:
   apps:
-    - id: org.joinmastodon.android
-      platform: f-droid
+    f-droid:
+      id: org.joinmastodon.android
       url: https://f-droid.org/en/packages/org.joinmastodon.android/
-    - id: id1571998974
-      platform: itunes
+    itunes:
+      id: id1571998974
       url: https://apps.apple.com/us/app/mastodon/id1571998974
-    - id: org.joinmastodon.android
-      platform: play
+    play:
+      id: org.joinmastodon.android
       url: https://play.google.com/store/apps/details?id=org.joinmastodon.android
   self_destruct_value: <%= ENV.fetch('SELF_DESTRUCT', nil) %>
   software_update_url: <%= ENV.fetch('UPDATE_CHECK_URL', 'https://api.joinmastodon.org/update-check') %>

--- a/spec/requests/manifest_spec.rb
+++ b/spec/requests/manifest_spec.rb
@@ -16,7 +16,12 @@ RSpec.describe 'Manifest' do
       expect(response.parsed_body)
         .to include(
           id: '/home',
-          name: 'Mastodon'
+          name: 'Mastodon',
+          related_applications: include(
+            include(platform: 'play', url: /play.google/),
+            include(platform: 'itunes', url: /apps.apple/),
+            include(platform: 'f-droid', url: /f-droid.org/)
+          )
         )
     end
   end


### PR DESCRIPTION
Changes here:

- Add some basic checks to existing manifest spec to make sure we have store urls
- Push the array of hashes formerly in the serliazer into a config yml file
- Use that config access in both the serializer and the welcome mailers, which as far as I can tell are the only places linking to the apps

I noticed the apple store links in the serializer vs mailers were different from each other ... but they both redirect to the same (new) url. Used that location here.

Related to https://github.com/mastodon/mastodon/pull/30534 and https://github.com/mastodon/mastodon/pull/30669 which both add the same config namespace/file. Will have to reconcile if we ever move forward on tryign to nudge the env var access into `config_for` style.