### PR TITLE
Mailer header partial access cleanup

### DIFF
--- a/app/views/application/mailer/_heading.html.haml
+++ b/app/views/application/mailer/_heading.html.haml
@@ -1,13 +1,13 @@
--# locals: (heading_title:, heading_image_url: nil, heading_subtitle: nil)
+-# locals: (title:, image_url: nil, subtitle: nil)
 %table.email-w-full.email-header-heading-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-header-heading-td
       %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
         %tr
-          - if heading_image_url
+          - if image_url
             %td.email-header-heading-img-td
-              = image_tag heading_image_url, alt: '', width: 56, height: 56
+              = image_tag image_url, alt: '', width: 56, height: 56
           %td.email-header-heading-txt-td
-            %h1= heading_title
-            - if heading_subtitle
-              %p= heading_subtitle
+            %h1= title
+            - if subtitle
+              %p= subtitle

--- a/app/views/application/mailer/_heading.html.haml
+++ b/app/views/application/mailer/_heading.html.haml
@@ -1,13 +1,13 @@
+-# locals: (heading_title:, heading_image_url: nil, heading_subtitle: nil)
 %table.email-w-full.email-header-heading-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-header-heading-td
       %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
         %tr
-          - if defined?(heading_image_url)
+          - if heading_image_url
             %td.email-header-heading-img-td
               = image_tag heading_image_url, alt: '', width: 56, height: 56
           %td.email-header-heading-txt-td
-            - if defined?(heading_title)
-              %h1= heading_title
-            - if defined?(heading_subtitle)
+            %h1= heading_title
+            - if heading_subtitle
               %p= heading_subtitle

--- a/app/views/notification_mailer/favourite.html.haml
+++ b/app/views/notification_mailer/favourite.html.haml
@@ -1,5 +1,8 @@
 = content_for :heading do
-  = render 'application/mailer/heading', heading_title: t('notification_mailer.favourite.title'), heading_subtitle: t('notification_mailer.favourite.body', name: @account.pretty_acct), heading_image_url: frontend_asset_url('images/mailer-new/heading/favorite.png')
+  = render 'application/mailer/heading',
+           heading_image_url: frontend_asset_url('images/mailer-new/heading/favorite.png'),
+           heading_subtitle: t('notification_mailer.favourite.body', name: @account.pretty_acct),
+           heading_title: t('notification_mailer.favourite.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/notification_mailer/favourite.html.haml
+++ b/app/views/notification_mailer/favourite.html.haml
@@ -1,8 +1,8 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           heading_image_url: frontend_asset_url('images/mailer-new/heading/favorite.png'),
-           heading_subtitle: t('notification_mailer.favourite.body', name: @account.pretty_acct),
-           heading_title: t('notification_mailer.favourite.title')
+           image_url: frontend_asset_url('images/mailer-new/heading/favorite.png'),
+           subtitle: t('notification_mailer.favourite.body', name: @account.pretty_acct),
+           title: t('notification_mailer.favourite.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/notification_mailer/follow.html.haml
+++ b/app/views/notification_mailer/follow.html.haml
@@ -1,8 +1,8 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           heading_image_url: frontend_asset_url('images/mailer-new/heading/user.png'),
-           heading_subtitle: t('notification_mailer.follow.body', name: @account.pretty_acct),
-           heading_title: t('notification_mailer.follow.title')
+           image_url: frontend_asset_url('images/mailer-new/heading/user.png'),
+           subtitle: t('notification_mailer.follow.body', name: @account.pretty_acct),
+           title: t('notification_mailer.follow.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/notification_mailer/follow.html.haml
+++ b/app/views/notification_mailer/follow.html.haml
@@ -1,5 +1,8 @@
 = content_for :heading do
-  = render 'application/mailer/heading', heading_title: t('notification_mailer.follow.title'), heading_subtitle: t('notification_mailer.follow.body', name: @account.pretty_acct), heading_image_url: frontend_asset_url('images/mailer-new/heading/user.png')
+  = render 'application/mailer/heading',
+           heading_image_url: frontend_asset_url('images/mailer-new/heading/user.png'),
+           heading_subtitle: t('notification_mailer.follow.body', name: @account.pretty_acct),
+           heading_title: t('notification_mailer.follow.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/notification_mailer/follow_request.html.haml
+++ b/app/views/notification_mailer/follow_request.html.haml
@@ -1,8 +1,8 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           heading_image_url: frontend_asset_url('images/mailer-new/heading/follow.png'),
-           heading_subtitle: t('notification_mailer.follow_request.body', name: @account.pretty_acct),
-           heading_title: t('notification_mailer.follow_request.title')
+           image_url: frontend_asset_url('images/mailer-new/heading/follow.png'),
+           subtitle: t('notification_mailer.follow_request.body', name: @account.pretty_acct),
+           title: t('notification_mailer.follow_request.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/notification_mailer/follow_request.html.haml
+++ b/app/views/notification_mailer/follow_request.html.haml
@@ -1,5 +1,8 @@
 = content_for :heading do
-  = render 'application/mailer/heading', heading_title: t('notification_mailer.follow_request.title'), heading_subtitle: t('notification_mailer.follow_request.body', name: @account.pretty_acct), heading_image_url: frontend_asset_url('images/mailer-new/heading/follow.png')
+  = render 'application/mailer/heading',
+           heading_image_url: frontend_asset_url('images/mailer-new/heading/follow.png'),
+           heading_subtitle: t('notification_mailer.follow_request.body', name: @account.pretty_acct),
+           heading_title: t('notification_mailer.follow_request.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/notification_mailer/mention.html.haml
+++ b/app/views/notification_mailer/mention.html.haml
@@ -1,5 +1,8 @@
 = content_for :heading do
-  = render 'application/mailer/heading', heading_title: t('notification_mailer.mention.title'), heading_subtitle: t('notification_mailer.mention.body', name: @status.account.pretty_acct), heading_image_url: frontend_asset_url('images/mailer-new/heading/mention.png')
+  = render 'application/mailer/heading',
+           heading_image_url: frontend_asset_url('images/mailer-new/heading/mention.png'),
+           heading_subtitle: t('notification_mailer.mention.body', name: @status.account.pretty_acct),
+           heading_title: t('notification_mailer.mention.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/notification_mailer/mention.html.haml
+++ b/app/views/notification_mailer/mention.html.haml
@@ -1,8 +1,8 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           heading_image_url: frontend_asset_url('images/mailer-new/heading/mention.png'),
-           heading_subtitle: t('notification_mailer.mention.body', name: @status.account.pretty_acct),
-           heading_title: t('notification_mailer.mention.title')
+           image_url: frontend_asset_url('images/mailer-new/heading/mention.png'),
+           subtitle: t('notification_mailer.mention.body', name: @status.account.pretty_acct),
+           title: t('notification_mailer.mention.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/notification_mailer/reblog.html.haml
+++ b/app/views/notification_mailer/reblog.html.haml
@@ -1,8 +1,8 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           heading_image_url: frontend_asset_url('images/mailer-new/heading/boost.png'),
-           heading_subtitle: t('notification_mailer.reblog.body', name: @account.pretty_acct),
-           heading_title: t('notification_mailer.reblog.title')
+           image_url: frontend_asset_url('images/mailer-new/heading/boost.png'),
+           subtitle: t('notification_mailer.reblog.body', name: @account.pretty_acct),
+           title: t('notification_mailer.reblog.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/notification_mailer/reblog.html.haml
+++ b/app/views/notification_mailer/reblog.html.haml
@@ -1,5 +1,8 @@
 = content_for :heading do
-  = render 'application/mailer/heading', heading_title: t('notification_mailer.reblog.title'), heading_subtitle: t('notification_mailer.reblog.body', name: @account.pretty_acct), heading_image_url: frontend_asset_url('images/mailer-new/heading/boost.png')
+  = render 'application/mailer/heading',
+           heading_image_url: frontend_asset_url('images/mailer-new/heading/boost.png'),
+           heading_subtitle: t('notification_mailer.reblog.body', name: @account.pretty_acct),
+           heading_title: t('notification_mailer.reblog.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/user_mailer/appeal_approved.html.haml
+++ b/app/views/user_mailer/appeal_approved.html.haml
@@ -1,5 +1,8 @@
 = content_for :heading do
-  = render 'application/mailer/heading', heading_title: t('user_mailer.appeal_approved.title'), heading_subtitle: t('user_mailer.appeal_approved.subtitle'), heading_image_url: frontend_asset_url('images/mailer-new/heading/appeal-approved.png')
+  = render 'application/mailer/heading',
+           heading_image_url: frontend_asset_url('images/mailer-new/heading/appeal-approved.png'),
+           heading_subtitle: t('user_mailer.appeal_approved.subtitle'),
+           heading_title: t('user_mailer.appeal_approved.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/user_mailer/appeal_approved.html.haml
+++ b/app/views/user_mailer/appeal_approved.html.haml
@@ -1,8 +1,8 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           heading_image_url: frontend_asset_url('images/mailer-new/heading/appeal-approved.png'),
-           heading_subtitle: t('user_mailer.appeal_approved.subtitle'),
-           heading_title: t('user_mailer.appeal_approved.title')
+           image_url: frontend_asset_url('images/mailer-new/heading/appeal-approved.png'),
+           subtitle: t('user_mailer.appeal_approved.subtitle'),
+           title: t('user_mailer.appeal_approved.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/user_mailer/appeal_rejected.html.haml
+++ b/app/views/user_mailer/appeal_rejected.html.haml
@@ -1,8 +1,8 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           heading_image_url: frontend_asset_url('images/mailer-new/heading/appeal-rejected.png'),
-           heading_subtitle: t('user_mailer.appeal_rejected.subtitle'),
-           heading_title: t('user_mailer.appeal_rejected.title')
+           image_url: frontend_asset_url('images/mailer-new/heading/appeal-rejected.png'),
+           subtitle: t('user_mailer.appeal_rejected.subtitle'),
+           title: t('user_mailer.appeal_rejected.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/user_mailer/appeal_rejected.html.haml
+++ b/app/views/user_mailer/appeal_rejected.html.haml
@@ -1,5 +1,8 @@
 = content_for :heading do
-  = render 'application/mailer/heading', heading_title: t('user_mailer.appeal_rejected.title'), heading_subtitle: t('user_mailer.appeal_rejected.subtitle'), heading_image_url: frontend_asset_url('images/mailer-new/heading/appeal-rejected.png')
+  = render 'application/mailer/heading',
+           heading_image_url: frontend_asset_url('images/mailer-new/heading/appeal-rejected.png'),
+           heading_subtitle: t('user_mailer.appeal_rejected.subtitle'),
+           heading_title: t('user_mailer.appeal_rejected.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/user_mailer/backup_ready.html.haml
+++ b/app/views/user_mailer/backup_ready.html.haml
@@ -1,5 +1,8 @@
 = content_for :heading do
-  = render 'application/mailer/heading', heading_title: t('user_mailer.backup_ready.title'), heading_subtitle: t('user_mailer.backup_ready.explanation'), heading_image_url: frontend_asset_url('images/mailer-new/heading/archive.png')
+  = render 'application/mailer/heading',
+           heading_image_url: frontend_asset_url('images/mailer-new/heading/archive.png'),
+           heading_subtitle: t('user_mailer.backup_ready.explanation'),
+           heading_title: t('user_mailer.backup_ready.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/user_mailer/backup_ready.html.haml
+++ b/app/views/user_mailer/backup_ready.html.haml
@@ -1,8 +1,8 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           heading_image_url: frontend_asset_url('images/mailer-new/heading/archive.png'),
-           heading_subtitle: t('user_mailer.backup_ready.explanation'),
-           heading_title: t('user_mailer.backup_ready.title')
+           image_url: frontend_asset_url('images/mailer-new/heading/archive.png'),
+           subtitle: t('user_mailer.backup_ready.explanation'),
+           title: t('user_mailer.backup_ready.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/user_mailer/confirmation_instructions.html.haml
+++ b/app/views/user_mailer/confirmation_instructions.html.haml
@@ -1,7 +1,7 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           heading_image_url: frontend_asset_url('images/mailer-new/heading/email.png'),
-           heading_title: t('devise.mailer.confirmation_instructions.title')
+           image_url: frontend_asset_url('images/mailer-new/heading/email.png'),
+           title: t('devise.mailer.confirmation_instructions.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/user_mailer/confirmation_instructions.html.haml
+++ b/app/views/user_mailer/confirmation_instructions.html.haml
@@ -1,5 +1,7 @@
 = content_for :heading do
-  = render 'application/mailer/heading', heading_title: t('devise.mailer.confirmation_instructions.title'), heading_image_url: frontend_asset_url('images/mailer-new/heading/email.png')
+  = render 'application/mailer/heading',
+           heading_image_url: frontend_asset_url('images/mailer-new/heading/email.png'),
+           heading_title: t('devise.mailer.confirmation_instructions.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/user_mailer/email_changed.html.haml
+++ b/app/views/user_mailer/email_changed.html.haml
@@ -1,8 +1,8 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           heading_image_url: frontend_asset_url('images/mailer-new/heading/email.png'),
-           heading_subtitle: t('devise.mailer.email_changed.explanation'),
-           heading_title: t('devise.mailer.email_changed.title')
+           image_url: frontend_asset_url('images/mailer-new/heading/email.png'),
+           subtitle: t('devise.mailer.email_changed.explanation'),
+           title: t('devise.mailer.email_changed.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/user_mailer/email_changed.html.haml
+++ b/app/views/user_mailer/email_changed.html.haml
@@ -1,5 +1,8 @@
 = content_for :heading do
-  = render 'application/mailer/heading', heading_title: t('devise.mailer.email_changed.title'), heading_subtitle: t('devise.mailer.email_changed.explanation'), heading_image_url: frontend_asset_url('images/mailer-new/heading/email.png')
+  = render 'application/mailer/heading',
+           heading_image_url: frontend_asset_url('images/mailer-new/heading/email.png'),
+           heading_subtitle: t('devise.mailer.email_changed.explanation'),
+           heading_title: t('devise.mailer.email_changed.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/user_mailer/failed_2fa.html.haml
+++ b/app/views/user_mailer/failed_2fa.html.haml
@@ -1,8 +1,8 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           heading_image_url: frontend_asset_url('images/mailer-new/heading/login.png'),
-           heading_subtitle: t('user_mailer.failed_2fa.explanation'),
-           heading_title: t('user_mailer.failed_2fa.title')
+           image_url: frontend_asset_url('images/mailer-new/heading/login.png'),
+           subtitle: t('user_mailer.failed_2fa.explanation'),
+           title: t('user_mailer.failed_2fa.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/user_mailer/failed_2fa.html.haml
+++ b/app/views/user_mailer/failed_2fa.html.haml
@@ -1,5 +1,8 @@
 = content_for :heading do
-  = render 'application/mailer/heading', heading_title: t('user_mailer.failed_2fa.title'), heading_subtitle: t('user_mailer.failed_2fa.explanation'), heading_image_url: frontend_asset_url('images/mailer-new/heading/login.png')
+  = render 'application/mailer/heading',
+           heading_image_url: frontend_asset_url('images/mailer-new/heading/login.png'),
+           heading_subtitle: t('user_mailer.failed_2fa.explanation'),
+           heading_title: t('user_mailer.failed_2fa.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/user_mailer/password_change.html.haml
+++ b/app/views/user_mailer/password_change.html.haml
@@ -1,5 +1,8 @@
 = content_for :heading do
-  = render 'application/mailer/heading', heading_title: t('devise.mailer.password_change.title'), heading_subtitle: t('devise.mailer.password_change.explanation'), heading_image_url: frontend_asset_url('images/mailer-new/heading/password.png')
+  = render 'application/mailer/heading',
+           heading_image_url: frontend_asset_url('images/mailer-new/heading/password.png'),
+           heading_subtitle: t('devise.mailer.password_change.explanation'),
+           heading_title: t('devise.mailer.password_change.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/user_mailer/password_change.html.haml
+++ b/app/views/user_mailer/password_change.html.haml
@@ -1,8 +1,8 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           heading_image_url: frontend_asset_url('images/mailer-new/heading/password.png'),
-           heading_subtitle: t('devise.mailer.password_change.explanation'),
-           heading_title: t('devise.mailer.password_change.title')
+           image_url: frontend_asset_url('images/mailer-new/heading/password.png'),
+           subtitle: t('devise.mailer.password_change.explanation'),
+           title: t('devise.mailer.password_change.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/user_mailer/reconfirmation_instructions.html.haml
+++ b/app/views/user_mailer/reconfirmation_instructions.html.haml
@@ -1,5 +1,7 @@
 = content_for :heading do
-  = render 'application/mailer/heading', heading_title: t('devise.mailer.reconfirmation_instructions.title'), heading_image_url: frontend_asset_url('images/mailer-new/heading/email.png')
+  = render 'application/mailer/heading',
+           heading_image_url: frontend_asset_url('images/mailer-new/heading/email.png'),
+           heading_title: t('devise.mailer.reconfirmation_instructions.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/user_mailer/reconfirmation_instructions.html.haml
+++ b/app/views/user_mailer/reconfirmation_instructions.html.haml
@@ -1,7 +1,7 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           heading_image_url: frontend_asset_url('images/mailer-new/heading/email.png'),
-           heading_title: t('devise.mailer.reconfirmation_instructions.title')
+           image_url: frontend_asset_url('images/mailer-new/heading/email.png'),
+           title: t('devise.mailer.reconfirmation_instructions.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/user_mailer/reset_password_instructions.html.haml
+++ b/app/views/user_mailer/reset_password_instructions.html.haml
@@ -1,5 +1,8 @@
 = content_for :heading do
-  = render 'application/mailer/heading', heading_title: t('devise.mailer.reset_password_instructions.title'), heading_subtitle: t('devise.mailer.reset_password_instructions.explanation'), heading_image_url: frontend_asset_url('images/mailer-new/heading/password.png')
+  = render 'application/mailer/heading',
+           heading_image_url: frontend_asset_url('images/mailer-new/heading/password.png'),
+           heading_subtitle: t('devise.mailer.reset_password_instructions.explanation'),
+           heading_title: t('devise.mailer.reset_password_instructions.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/user_mailer/reset_password_instructions.html.haml
+++ b/app/views/user_mailer/reset_password_instructions.html.haml
@@ -1,8 +1,8 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           heading_image_url: frontend_asset_url('images/mailer-new/heading/password.png'),
-           heading_subtitle: t('devise.mailer.reset_password_instructions.explanation'),
-           heading_title: t('devise.mailer.reset_password_instructions.title')
+           image_url: frontend_asset_url('images/mailer-new/heading/password.png'),
+           subtitle: t('devise.mailer.reset_password_instructions.explanation'),
+           title: t('devise.mailer.reset_password_instructions.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/user_mailer/suspicious_sign_in.html.haml
+++ b/app/views/user_mailer/suspicious_sign_in.html.haml
@@ -1,5 +1,8 @@
 = content_for :heading do
-  = render 'application/mailer/heading', heading_title: t('user_mailer.suspicious_sign_in.title'), heading_subtitle: t('user_mailer.suspicious_sign_in.explanation'), heading_image_url: frontend_asset_url('images/mailer-new/heading/login.png')
+  = render 'application/mailer/heading',
+           heading_image_url: frontend_asset_url('images/mailer-new/heading/login.png'),
+           heading_subtitle: t('user_mailer.suspicious_sign_in.explanation'),
+           heading_title: t('user_mailer.suspicious_sign_in.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/user_mailer/suspicious_sign_in.html.haml
+++ b/app/views/user_mailer/suspicious_sign_in.html.haml
@@ -1,8 +1,8 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           heading_image_url: frontend_asset_url('images/mailer-new/heading/login.png'),
-           heading_subtitle: t('user_mailer.suspicious_sign_in.explanation'),
-           heading_title: t('user_mailer.suspicious_sign_in.title')
+           image_url: frontend_asset_url('images/mailer-new/heading/login.png'),
+           subtitle: t('user_mailer.suspicious_sign_in.explanation'),
+           title: t('user_mailer.suspicious_sign_in.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/user_mailer/two_factor_disabled.html.haml
+++ b/app/views/user_mailer/two_factor_disabled.html.haml
@@ -1,8 +1,8 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           heading_image_url: frontend_asset_url('images/mailer-new/heading/2fa-disabled.png'),
-           heading_subtitle: t('devise.mailer.two_factor_disabled.subtitle'),
-           heading_title: t('devise.mailer.two_factor_disabled.title')
+           image_url: frontend_asset_url('images/mailer-new/heading/2fa-disabled.png'),
+           subtitle: t('devise.mailer.two_factor_disabled.subtitle'),
+           title: t('devise.mailer.two_factor_disabled.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/user_mailer/two_factor_disabled.html.haml
+++ b/app/views/user_mailer/two_factor_disabled.html.haml
@@ -1,5 +1,8 @@
 = content_for :heading do
-  = render 'application/mailer/heading', heading_title: t('devise.mailer.two_factor_disabled.title'), heading_subtitle: t('devise.mailer.two_factor_disabled.subtitle'), heading_image_url: frontend_asset_url('images/mailer-new/heading/2fa-disabled.png')
+  = render 'application/mailer/heading',
+           heading_image_url: frontend_asset_url('images/mailer-new/heading/2fa-disabled.png'),
+           heading_subtitle: t('devise.mailer.two_factor_disabled.subtitle'),
+           heading_title: t('devise.mailer.two_factor_disabled.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/user_mailer/two_factor_enabled.html.haml
+++ b/app/views/user_mailer/two_factor_enabled.html.haml
@@ -1,8 +1,8 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           heading_image_url: frontend_asset_url('images/mailer-new/heading/2fa-enabled.png'),
-           heading_subtitle: t('devise.mailer.two_factor_enabled.subtitle'),
-           heading_title: t('devise.mailer.two_factor_enabled.title')
+           image_url: frontend_asset_url('images/mailer-new/heading/2fa-enabled.png'),
+           subtitle: t('devise.mailer.two_factor_enabled.subtitle'),
+           title: t('devise.mailer.two_factor_enabled.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/user_mailer/two_factor_enabled.html.haml
+++ b/app/views/user_mailer/two_factor_enabled.html.haml
@@ -1,5 +1,8 @@
 = content_for :heading do
-  = render 'application/mailer/heading', heading_title: t('devise.mailer.two_factor_enabled.title'), heading_subtitle: t('devise.mailer.two_factor_enabled.subtitle'), heading_image_url: frontend_asset_url('images/mailer-new/heading/2fa-enabled.png')
+  = render 'application/mailer/heading',
+           heading_image_url: frontend_asset_url('images/mailer-new/heading/2fa-enabled.png'),
+           heading_subtitle: t('devise.mailer.two_factor_enabled.subtitle'),
+           heading_title: t('devise.mailer.two_factor_enabled.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/user_mailer/two_factor_recovery_codes_changed.html.haml
+++ b/app/views/user_mailer/two_factor_recovery_codes_changed.html.haml
@@ -1,5 +1,8 @@
 = content_for :heading do
-  = render 'application/mailer/heading', heading_title: t('devise.mailer.two_factor_recovery_codes_changed.title'), heading_subtitle: t('devise.mailer.two_factor_recovery_codes_changed.subtitle'), heading_image_url: frontend_asset_url('images/mailer-new/heading/2fa-recovery.png')
+  = render 'application/mailer/heading',
+           heading_image_url: frontend_asset_url('images/mailer-new/heading/2fa-recovery.png'),
+           heading_subtitle: t('devise.mailer.two_factor_recovery_codes_changed.subtitle'),
+           heading_title: t('devise.mailer.two_factor_recovery_codes_changed.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/user_mailer/two_factor_recovery_codes_changed.html.haml
+++ b/app/views/user_mailer/two_factor_recovery_codes_changed.html.haml
@@ -1,8 +1,8 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           heading_image_url: frontend_asset_url('images/mailer-new/heading/2fa-recovery.png'),
-           heading_subtitle: t('devise.mailer.two_factor_recovery_codes_changed.subtitle'),
-           heading_title: t('devise.mailer.two_factor_recovery_codes_changed.title')
+           image_url: frontend_asset_url('images/mailer-new/heading/2fa-recovery.png'),
+           subtitle: t('devise.mailer.two_factor_recovery_codes_changed.subtitle'),
+           title: t('devise.mailer.two_factor_recovery_codes_changed.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/user_mailer/warning.html.haml
+++ b/app/views/user_mailer/warning.html.haml
@@ -1,5 +1,7 @@
 = content_for :heading do
-  = render 'application/mailer/heading', heading_title: t("user_mailer.warning.title.#{@warning.action}"), heading_image_url: frontend_asset_url('images/mailer-new/heading/warning.png')
+  = render 'application/mailer/heading',
+           heading_image_url: frontend_asset_url('images/mailer-new/heading/warning.png'),
+           heading_title: t("user_mailer.warning.title.#{@warning.action}")
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/user_mailer/warning.html.haml
+++ b/app/views/user_mailer/warning.html.haml
@@ -1,7 +1,7 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           heading_image_url: frontend_asset_url('images/mailer-new/heading/warning.png'),
-           heading_title: t("user_mailer.warning.title.#{@warning.action}")
+           image_url: frontend_asset_url('images/mailer-new/heading/warning.png'),
+           title: t("user_mailer.warning.title.#{@warning.action}")
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/user_mailer/webauthn_credential_added.html.haml
+++ b/app/views/user_mailer/webauthn_credential_added.html.haml
@@ -1,5 +1,8 @@
 = content_for :heading do
-  = render 'application/mailer/heading', heading_title: t('devise.mailer.webauthn_credential.added.title'), heading_subtitle: t('devise.mailer.webauthn_credential.added.explanation'), heading_image_url: frontend_asset_url('images/mailer-new/heading/key-added.png')
+  = render 'application/mailer/heading',
+           heading_image_url: frontend_asset_url('images/mailer-new/heading/key-added.png'),
+           heading_subtitle: t('devise.mailer.webauthn_credential.added.explanation'),
+           heading_title: t('devise.mailer.webauthn_credential.added.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/user_mailer/webauthn_credential_added.html.haml
+++ b/app/views/user_mailer/webauthn_credential_added.html.haml
@@ -1,8 +1,8 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           heading_image_url: frontend_asset_url('images/mailer-new/heading/key-added.png'),
-           heading_subtitle: t('devise.mailer.webauthn_credential.added.explanation'),
-           heading_title: t('devise.mailer.webauthn_credential.added.title')
+           image_url: frontend_asset_url('images/mailer-new/heading/key-added.png'),
+           subtitle: t('devise.mailer.webauthn_credential.added.explanation'),
+           title: t('devise.mailer.webauthn_credential.added.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/user_mailer/webauthn_credential_deleted.html.haml
+++ b/app/views/user_mailer/webauthn_credential_deleted.html.haml
@@ -1,5 +1,8 @@
 = content_for :heading do
-  = render 'application/mailer/heading', heading_title: t('devise.mailer.webauthn_credential.deleted.title'), heading_subtitle: t('devise.mailer.webauthn_credential.deleted.explanation'), heading_image_url: frontend_asset_url('images/mailer-new/heading/key-deleted.png')
+  = render 'application/mailer/heading',
+           heading_image_url: frontend_asset_url('images/mailer-new/heading/key-deleted.png'),
+           heading_subtitle: t('devise.mailer.webauthn_credential.deleted.explanation'),
+           heading_title: t('devise.mailer.webauthn_credential.deleted.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/user_mailer/webauthn_credential_deleted.html.haml
+++ b/app/views/user_mailer/webauthn_credential_deleted.html.haml
@@ -1,8 +1,8 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           heading_image_url: frontend_asset_url('images/mailer-new/heading/key-deleted.png'),
-           heading_subtitle: t('devise.mailer.webauthn_credential.deleted.explanation'),
-           heading_title: t('devise.mailer.webauthn_credential.deleted.title')
+           image_url: frontend_asset_url('images/mailer-new/heading/key-deleted.png'),
+           subtitle: t('devise.mailer.webauthn_credential.deleted.explanation'),
+           title: t('devise.mailer.webauthn_credential.deleted.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/user_mailer/webauthn_disabled.html.haml
+++ b/app/views/user_mailer/webauthn_disabled.html.haml
@@ -1,8 +1,8 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           heading_image_url: frontend_asset_url('images/mailer-new/heading/key-disabled.png'),
-           heading_subtitle: t('devise.mailer.webauthn_disabled.explanation'),
-           heading_title: t('devise.mailer.webauthn_disabled.title')
+           image_url: frontend_asset_url('images/mailer-new/heading/key-disabled.png'),
+           subtitle: t('devise.mailer.webauthn_disabled.explanation'),
+           title: t('devise.mailer.webauthn_disabled.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/user_mailer/webauthn_disabled.html.haml
+++ b/app/views/user_mailer/webauthn_disabled.html.haml
@@ -1,5 +1,8 @@
 = content_for :heading do
-  = render 'application/mailer/heading', heading_title: t('devise.mailer.webauthn_disabled.title'), heading_subtitle: t('devise.mailer.webauthn_disabled.explanation'), heading_image_url: frontend_asset_url('images/mailer-new/heading/key-disabled.png')
+  = render 'application/mailer/heading',
+           heading_image_url: frontend_asset_url('images/mailer-new/heading/key-disabled.png'),
+           heading_subtitle: t('devise.mailer.webauthn_disabled.explanation'),
+           heading_title: t('devise.mailer.webauthn_disabled.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/user_mailer/webauthn_enabled.html.haml
+++ b/app/views/user_mailer/webauthn_enabled.html.haml
@@ -1,8 +1,8 @@
 = content_for :heading do
   = render 'application/mailer/heading',
-           heading_image_url: frontend_asset_url('images/mailer-new/heading/key-enabled.png'),
-           heading_subtitle: t('devise.mailer.webauthn_enabled.explanation'),
-           heading_title: t('devise.mailer.webauthn_enabled.title')
+           image_url: frontend_asset_url('images/mailer-new/heading/key-enabled.png'),
+           subtitle: t('devise.mailer.webauthn_enabled.explanation'),
+           title: t('devise.mailer.webauthn_enabled.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/user_mailer/webauthn_enabled.html.haml
+++ b/app/views/user_mailer/webauthn_enabled.html.haml
@@ -1,5 +1,8 @@
 = content_for :heading do
-  = render 'application/mailer/heading', heading_title: t('devise.mailer.webauthn_enabled.title'), heading_subtitle: t('devise.mailer.webauthn_enabled.explanation'), heading_image_url: frontend_asset_url('images/mailer-new/heading/key-enabled.png')
+  = render 'application/mailer/heading',
+           heading_image_url: frontend_asset_url('images/mailer-new/heading/key-enabled.png'),
+           heading_subtitle: t('devise.mailer.webauthn_enabled.explanation'),
+           heading_title: t('devise.mailer.webauthn_enabled.title')
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-body-padding-td

--- a/app/views/user_mailer/welcome.html.haml
+++ b/app/views/user_mailer/welcome.html.haml
@@ -1,7 +1,9 @@
 = content_for :heading do
   .email-desktop-flex
     .email-header-left
-      = render 'application/mailer/heading', heading_title: t('user_mailer.welcome.title', name: @resource.account.username), heading_subtitle: t('user_mailer.welcome.explanation')
+      = render 'application/mailer/heading',
+               heading_subtitle: t('user_mailer.welcome.explanation'),
+               heading_title: t('user_mailer.welcome.title', name: @resource.account.username)
     .email-header-right
       .email-header-card
         %table.email-header-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }

--- a/app/views/user_mailer/welcome.html.haml
+++ b/app/views/user_mailer/welcome.html.haml
@@ -2,8 +2,8 @@
   .email-desktop-flex
     .email-header-left
       = render 'application/mailer/heading',
-               heading_subtitle: t('user_mailer.welcome.explanation'),
-               heading_title: t('user_mailer.welcome.title', name: @resource.account.username)
+               subtitle: t('user_mailer.welcome.explanation'),
+               title: t('user_mailer.welcome.title', name: @resource.account.username)
     .email-header-right
       .email-header-card
         %table.email-header-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }


### PR DESCRIPTION
Related changes:

- Turn on strict locals in the _heading partial, and drop `defined?` - repeats a portion of https://github.com/mastodon/mastodon/pull/32387/files - will rebase that one if needed. The `title` is always required (and present at all callers), which the other do get nil default and conditionals remain.
- Drop the `heading_` prefix from all var names for brevity, since they are only ever accessed from within this partial
- Within all calling locations, due what is a purely formatting-only style-only lint-related change, which is to convert to a multi-line call. This is in part for its own  future diffability improvement sake, but separately - I realized that we are pretty close to being to drop some of the haml-lint line length overrides, and this collection includes some of the remaining violations which are solved here.

