### PR TITLE
add description to avatar and header attributes for alt tags

### DIFF
--- a/app/controllers/settings/profiles_controller.rb
+++ b/app/controllers/settings/profiles_controller.rb
@@ -20,7 +20,7 @@ class Settings::ProfilesController < Settings::BaseController
   private
 
   def account_params
-    params.require(:account).permit(:display_name, :note, :avatar, :header, :bot, fields_attributes: [:name, :value])
+    params.require(:account).permit(:display_name, :note, :avatar, :header, :bot, :avatar_description, :header_description, fields_attributes: [:name, :value])
   end
 
   def set_account

--- a/app/javascript/mastodon/api_types/accounts.ts
+++ b/app/javascript/mastodon/api_types/accounts.ts
@@ -44,8 +44,8 @@ export interface BaseApiAccountJSON {
   limited?: boolean;
   memorial?: boolean;
   hide_collections: boolean;
-  avatar_description: string;
-  header_description: string;
+  avatar_description: string | null;
+  header_description: string | null;
 }
 
 // See app/serializers/rest/muted_account_serializer.rb

--- a/app/javascript/mastodon/api_types/accounts.ts
+++ b/app/javascript/mastodon/api_types/accounts.ts
@@ -44,6 +44,8 @@ export interface BaseApiAccountJSON {
   limited?: boolean;
   memorial?: boolean;
   hide_collections: boolean;
+  avatar_description: string;
+  header_description: string;
 }
 
 // See app/serializers/rest/muted_account_serializer.rb

--- a/app/javascript/mastodon/components/avatar.tsx
+++ b/app/javascript/mastodon/components/avatar.tsx
@@ -59,7 +59,7 @@ export const Avatar: React.FC<Props> = ({
       style={style}
     >
       {src && !error && (
-        <img src={src} alt='' onLoad={handleLoad} onError={handleError} />
+        <img src={src} alt={account?.get('avatar_description') ?? ''} onLoad={handleLoad} onError={handleError} />
       )}
 
       {counter && (

--- a/app/javascript/mastodon/components/avatar.tsx
+++ b/app/javascript/mastodon/components/avatar.tsx
@@ -14,7 +14,6 @@ interface Props {
   animate?: boolean;
   counter?: number | string;
   counterBorderColor?: string;
-  showAltTag?: boolean;
 }
 
 export const Avatar: React.FC<Props> = ({
@@ -25,7 +24,6 @@ export const Avatar: React.FC<Props> = ({
   style: styleFromParent,
   counter,
   counterBorderColor,
-  showAltTag
 }) => {
   const { hovering, handleMouseEnter, handleMouseLeave } = useHovering(animate);
   const [loading, setLoading] = useState(true);
@@ -61,7 +59,7 @@ export const Avatar: React.FC<Props> = ({
       style={style}
     >
       {src && !error && (
-        <img src={src} alt={(showAltTag && account?.get('avatar_description')) || ''} onLoad={handleLoad} onError={handleError} />
+        <img src={src} alt={''} onLoad={handleLoad} onError={handleError} />
       )}
 
       {counter && (

--- a/app/javascript/mastodon/components/avatar.tsx
+++ b/app/javascript/mastodon/components/avatar.tsx
@@ -14,6 +14,7 @@ interface Props {
   animate?: boolean;
   counter?: number | string;
   counterBorderColor?: string;
+  showAltTag?: boolean;
 }
 
 export const Avatar: React.FC<Props> = ({
@@ -24,6 +25,7 @@ export const Avatar: React.FC<Props> = ({
   style: styleFromParent,
   counter,
   counterBorderColor,
+  showAltTag
 }) => {
   const { hovering, handleMouseEnter, handleMouseLeave } = useHovering(animate);
   const [loading, setLoading] = useState(true);
@@ -59,7 +61,7 @@ export const Avatar: React.FC<Props> = ({
       style={style}
     >
       {src && !error && (
-        <img src={src} alt={account?.get('avatar_description') ?? ''} onLoad={handleLoad} onError={handleError} />
+        <img src={src} alt={(showAltTag && account?.get('avatar_description')) || ''} onLoad={handleLoad} onError={handleError} />
       )}
 
       {counter && (

--- a/app/javascript/mastodon/features/account/components/header.jsx
+++ b/app/javascript/mastodon/features/account/components/header.jsx
@@ -422,7 +422,7 @@ class Header extends ImmutablePureComponent {
         <div className='account__header__bar'>
           <div className='account__header__tabs'>
             <a className='avatar' href={account.get('avatar')} rel='noopener noreferrer' target='_blank' onClick={this.handleAvatarClick}>
-              <Avatar account={suspended || hidden ? undefined : account} size={90} />
+              <Avatar account={suspended || hidden ? undefined : account} size={90} showAltTag />
             </a>
 
             <div className='account__header__tabs__buttons'>

--- a/app/javascript/mastodon/features/account/components/header.jsx
+++ b/app/javascript/mastodon/features/account/components/header.jsx
@@ -416,7 +416,7 @@ class Header extends ImmutablePureComponent {
             {info}
           </div>
 
-          {!(suspended || hidden) && <img src={autoPlayGif ? account.get('header') : account.get('header_static')} alt='' className='parallax' />}
+          {!(suspended || hidden) && <img src={autoPlayGif ? account.get('header') : account.get('header_static')} alt={account.get('header_description') ?? ''} className='parallax' />}
         </div>
 
         <div className='account__header__bar'>

--- a/app/javascript/mastodon/features/account/components/header.jsx
+++ b/app/javascript/mastodon/features/account/components/header.jsx
@@ -422,7 +422,7 @@ class Header extends ImmutablePureComponent {
         <div className='account__header__bar'>
           <div className='account__header__tabs'>
             <a className='avatar' href={account.get('avatar')} rel='noopener noreferrer' target='_blank' onClick={this.handleAvatarClick}>
-              <Avatar account={suspended || hidden ? undefined : account} size={90} showAltTag />
+              <Avatar account={suspended || hidden ? undefined : account} size={90} />
             </a>
 
             <div className='account__header__tabs__buttons'>

--- a/app/javascript/mastodon/features/account_timeline/containers/header_container.jsx
+++ b/app/javascript/mastodon/features/account_timeline/containers/header_container.jsx
@@ -139,7 +139,7 @@ const mapDispatchToProps = (dispatch) => ({
       modalType: 'IMAGE',
       modalProps: {
         src: account.get('avatar'),
-        alt: '',
+        alt: account.get('avatar_description'),
       },
     }));
   },

--- a/app/javascript/mastodon/models/account.ts
+++ b/app/javascript/mastodon/models/account.ts
@@ -56,6 +56,8 @@ export interface AccountShape
   note_plain: string | null;
   hidden: boolean;
   moved: string | null;
+  avatar_description: string | null;
+  header_description: string | null;
 }
 
 export type Account = RecordOf<AccountShape>;
@@ -98,6 +100,8 @@ export const accountDefaultValues: AccountShape = {
   // This comes from `ApiMutedAccountJSON`, but we should eventually
   // store that in a different object.
   mute_expires_at: null,
+  avatar_description: null,
+  header_description: null
 };
 
 const AccountFactory = ImmutableRecord<AccountShape>(accountDefaultValues);

--- a/app/javascript/mastodon/models/account.ts
+++ b/app/javascript/mastodon/models/account.ts
@@ -56,8 +56,8 @@ export interface AccountShape
   note_plain: string | null;
   hidden: boolean;
   moved: string | null;
-  avatar_description: string | null;
-  header_description: string | null;
+  avatar_description: string;
+  header_description: string;
 }
 
 export type Account = RecordOf<AccountShape>;
@@ -100,8 +100,8 @@ export const accountDefaultValues: AccountShape = {
   // This comes from `ApiMutedAccountJSON`, but we should eventually
   // store that in a different object.
   mute_expires_at: null,
-  avatar_description: null,
-  header_description: null
+  avatar_description: '',
+  header_description: ''
 };
 
 const AccountFactory = ImmutableRecord<AccountShape>(accountDefaultValues);

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -44,13 +44,15 @@
 #  hide_collections              :boolean
 #  avatar_storage_schema_version :integer
 #  header_storage_schema_version :integer
-#  suspension_origin             :integer
 #  sensitized_at                 :datetime
+#  suspension_origin             :integer
 #  trendable                     :boolean
 #  reviewed_at                   :datetime
 #  requested_review_at           :datetime
 #  indexable                     :boolean          default(FALSE), not null
 #  attribution_domains           :string           default([]), is an Array
+#  avatar_description            :string
+#  header_description            :string
 #
 
 class Account < ApplicationRecord

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -51,8 +51,8 @@
 #  requested_review_at           :datetime
 #  indexable                     :boolean          default(FALSE), not null
 #  attribution_domains           :string           default([]), is an Array
-#  avatar_description            :string
-#  header_description            :string
+#  avatar_description            :string           default("")
+#  header_description            :string           default("")
 #
 
 class Account < ApplicationRecord

--- a/app/models/concerns/account/avatar.rb
+++ b/app/models/concerns/account/avatar.rb
@@ -8,7 +8,7 @@ module Account::Avatar
 
   AVATAR_DIMENSIONS = [400, 400].freeze
   AVATAR_GEOMETRY = [AVATAR_DIMENSIONS.first, AVATAR_DIMENSIONS.last].join('x')
-  AVATAR_MAX_DESCRIPTION_LENGTH = 1_500
+  MAX_DESCRIPTION_LENGTH = 1_500
 
   class_methods do
     def avatar_styles(file)
@@ -27,7 +27,7 @@ module Account::Avatar
     validates_attachment_size :avatar, less_than: LIMIT
     remotable_attachment :avatar, LIMIT, suppress_errors: false
 
-    validates :avatar_description, length: { maximum: AVATAR_MAX_DESCRIPTION_LENGTH }
+    validates :avatar_description, length: { maximum: MAX_DESCRIPTION_LENGTH }
   end
 
   def avatar_original_url

--- a/app/models/concerns/account/avatar.rb
+++ b/app/models/concerns/account/avatar.rb
@@ -8,6 +8,7 @@ module Account::Avatar
 
   AVATAR_DIMENSIONS = [400, 400].freeze
   AVATAR_GEOMETRY = [AVATAR_DIMENSIONS.first, AVATAR_DIMENSIONS.last].join('x')
+  AVATAR_MAX_DESCRIPTION_LENGTH = 1_500
 
   class_methods do
     def avatar_styles(file)
@@ -25,6 +26,8 @@ module Account::Avatar
     validates_attachment_content_type :avatar, content_type: IMAGE_MIME_TYPES
     validates_attachment_size :avatar, less_than: LIMIT
     remotable_attachment :avatar, LIMIT, suppress_errors: false
+
+    validates :avatar_description, length: { maximum: AVATAR_MAX_DESCRIPTION_LENGTH }
   end
 
   def avatar_original_url

--- a/app/models/concerns/account/header.rb
+++ b/app/models/concerns/account/header.rb
@@ -10,7 +10,7 @@ module Account::Header
   HEADER_GEOMETRY = [HEADER_DIMENSIONS.first, HEADER_DIMENSIONS.last].join('x')
   MAX_PIXELS = HEADER_DIMENSIONS.first * HEADER_DIMENSIONS.last
 
-  HEADER_MAX_DESCRIPTION_LENGTH = 1_500
+  MAX_DESCRIPTION_LENGTH = 1_500
 
   class_methods do
     def header_styles(file)
@@ -29,7 +29,7 @@ module Account::Header
     validates_attachment_size :header, less_than: LIMIT
     remotable_attachment :header, LIMIT, suppress_errors: false
 
-    validates :header_description, length: { maximum: HEADER_MAX_DESCRIPTION_LENGTH }
+    validates :header_description, length: { maximum: MAX_DESCRIPTION_LENGTH }
   end
 
   def header_original_url

--- a/app/models/concerns/account/header.rb
+++ b/app/models/concerns/account/header.rb
@@ -10,6 +10,8 @@ module Account::Header
   HEADER_GEOMETRY = [HEADER_DIMENSIONS.first, HEADER_DIMENSIONS.last].join('x')
   MAX_PIXELS = HEADER_DIMENSIONS.first * HEADER_DIMENSIONS.last
 
+  HEADER_MAX_DESCRIPTION_LENGTH = 1_500
+
   class_methods do
     def header_styles(file)
       styles = { original: { pixels: MAX_PIXELS, file_geometry_parser: FastGeometryParser } }
@@ -26,6 +28,8 @@ module Account::Header
     validates_attachment_content_type :header, content_type: IMAGE_MIME_TYPES
     validates_attachment_size :header, less_than: LIMIT
     remotable_attachment :header, LIMIT, suppress_errors: false
+
+    validates :header_description, length: { maximum: HEADER_MAX_DESCRIPTION_LENGTH }
   end
 
   def header_original_url

--- a/app/serializers/activitypub/image_serializer.rb
+++ b/app/serializers/activitypub/image_serializer.rb
@@ -5,7 +5,7 @@ class ActivityPub::ImageSerializer < ActivityPub::Serializer
 
   context_extensions :focal_point
 
-  attributes :type, :media_type, :url
+  attributes :type, :media_type, :url, :name
   attribute :focal_point, if: :focal_point?
 
   def type
@@ -19,6 +19,8 @@ class ActivityPub::ImageSerializer < ActivityPub::Serializer
   def media_type
     object.content_type
   end
+
+  delegate :name, to: :object
 
   def focal_point?
     object.respond_to?(:meta) && object.meta.is_a?(Hash) && object.meta['focus'].is_a?(Hash)

--- a/app/serializers/rest/account_serializer.rb
+++ b/app/serializers/rest/account_serializer.rb
@@ -8,7 +8,8 @@ class REST::AccountSerializer < ActiveModel::Serializer
 
   attributes :id, :username, :acct, :display_name, :locked, :bot, :discoverable, :indexable, :group, :created_at,
              :note, :url, :uri, :avatar, :avatar_static, :header, :header_static,
-             :followers_count, :following_count, :statuses_count, :last_status_at, :hide_collections
+             :followers_count, :following_count, :statuses_count, :last_status_at, :hide_collections,
+             :avatar_description, :header_description
 
   has_one :moved_to_account, key: :moved, serializer: REST::AccountSerializer, if: :moved_and_not_nested?
 

--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -199,7 +199,7 @@ class ActivityPub::ProcessAccountService < BaseService
     end
   end
 
-  def image_description(key)
+  def image(key)
     value = first_of_value(@json[key])
 
     return if value.nil?
@@ -208,21 +208,22 @@ class ActivityPub::ProcessAccountService < BaseService
       value = fetch_resource_without_id_validation(value)
       return if value.nil?
     end
+  end
 
-    value = first_of_value(value['name']) if value.is_a?(Hash) && value['type'] == 'Image'
-    value = value['summary'] if value.is_a?(Hash)
-    value if value.is_a?(String)
+  def image_description(key)
+    value = image(key)
+
+    return unless value.is_a(Hash)
+
+    max_length = (key == 'icon' ? Account::Avatar::MAX_DESCRIPTION_LENGTH : Account::Header::MAX_DESCRIPTION_LENGTH)
+
+    description = value['summary'].presence || value['name'].presence
+    description = description.strip[0...max_length] if description.present?
+    description
   end
 
   def image_url(key)
-    value = first_of_value(@json[key])
-
-    return if value.nil?
-
-    if value.is_a?(String)
-      value = fetch_resource_without_id_validation(value)
-      return if value.nil?
-    end
+    value = image(key)
 
     value = first_of_value(value['url']) if value.is_a?(Hash) && value['type'] == 'Image'
     value = value['href'] if value.is_a?(Hash)

--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -206,7 +206,7 @@ class ActivityPub::ProcessAccountService < BaseService
 
     if value.is_a?(String)
       value = fetch_resource_without_id_validation(value)
-      return if value.nil?
+      nil if value.nil?
     end
   end
 

--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -117,6 +117,8 @@ class ActivityPub::ProcessAccountService < BaseService
     @account.indexable               = @json['indexable'] || false
     @account.memorial                = @json['memorial'] || false
     @account.attribution_domains     = as_array(@json['attributionDomains'] || []).map { |item| value_or_id(item) }
+    @account.avatar_description      = @json['avatarDescription'] || ''
+    @account.header_description      = @json['headerDescription'] || ''
   end
 
   def set_fetchable_key!
@@ -127,12 +129,14 @@ class ActivityPub::ProcessAccountService < BaseService
     begin
       @account.avatar_remote_url = image_url('icon') || '' unless skip_download?
       @account.avatar = nil if @account.avatar_remote_url.blank?
+      @account.avatar_description = @json['avatarDescription'] || '' unless @account.avatar_remote_url.blank?
     rescue Mastodon::UnexpectedResponseError, *Mastodon::HTTP_CONNECTION_ERRORS
       RedownloadAvatarWorker.perform_in(rand(30..600).seconds, @account.id)
     end
     begin
       @account.header_remote_url = image_url('image') || '' unless skip_download?
       @account.header = nil if @account.header_remote_url.blank?
+      @account.header_description = @json['headerDescription'] || '' unless @account.header_remote_url.blank?
     rescue Mastodon::UnexpectedResponseError, *Mastodon::HTTP_CONNECTION_ERRORS
       RedownloadHeaderWorker.perform_in(rand(30..600).seconds, @account.id)
     end

--- a/app/views/settings/profiles/show.html.haml
+++ b/app/views/settings/profiles/show.html.haml
@@ -46,6 +46,7 @@
             = material_symbol 'delete'
             = t('generic.delete')
 
+  .fields-row
     .fields-row__column.fields-row__column-6
       .fields-group
         = f.input :avatar_description,
@@ -68,7 +69,8 @@
           = link_to settings_profile_picture_path('header'), data: { method: :delete }, class: 'link-button link-button--destructive' do
             = material_symbol 'delete'
             = t('generic.delete')
-
+  
+  .fields-row
     .fields-row__column.fields-row__column-6
       .fields-group
         = f.input :header_description,

--- a/app/views/settings/profiles/show.html.haml
+++ b/app/views/settings/profiles/show.html.haml
@@ -46,8 +46,7 @@
             = material_symbol 'delete'
             = t('generic.delete')
 
-  .fields-row
-    .fields-row__column.fields-row__column-12
+    .fields-row__column.fields-row__column-6
       .fields-group
         = f.input :avatar_description,
                   as: :text,
@@ -70,8 +69,7 @@
             = material_symbol 'delete'
             = t('generic.delete')
 
-  .fields-row
-    .fields-row__column.fields-row__column-12
+    .fields-row__column.fields-row__column-6
       .fields-group
         = f.input :header_description,
                   as: :text,

--- a/app/views/settings/profiles/show.html.haml
+++ b/app/views/settings/profiles/show.html.haml
@@ -47,6 +47,14 @@
             = t('generic.delete')
 
   .fields-row
+    .fields-row__column.fields-row__column-12
+      .fields-group
+        = f.input :avatar_description,
+                  as: :text,
+                  hint: t('simple_form.hints.defaults.profile_picture_description'),
+                  wrapper: :with_block_label
+
+  .fields-row
     .fields-row__column.fields-row__column-6
       .fields-group
         = f.input :header,
@@ -61,6 +69,14 @@
           = link_to settings_profile_picture_path('header'), data: { method: :delete }, class: 'link-button link-button--destructive' do
             = material_symbol 'delete'
             = t('generic.delete')
+
+  .fields-row
+    .fields-row__column.fields-row__column-12
+      .fields-group
+        = f.input :header_description,
+                  as: :text,
+                  hint: t('simple_form.hints.defaults.header_description'),
+                  wrapper: :with_block_label
 
   %h4= t('edit_profile.other')
 

--- a/db/migrate/20241017192240_add_description_to_avatar_and_header.rb
+++ b/db/migrate/20241017192240_add_description_to_avatar_and_header.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 class AddDescriptionToAvatarAndHeader < ActiveRecord::Migration[7.1]
   def change
-    add_column :accounts, :avatar_description, :string, default: ""
-    add_column :accounts, :header_description, :string, default: ""
+    add_column :accounts, :avatar_description, :string, default: ''
+    add_column :accounts, :header_description, :string, default: ''
   end
 end

--- a/db/migrate/20241017192240_add_description_to_avatar_and_header.rb
+++ b/db/migrate/20241017192240_add_description_to_avatar_and_header.rb
@@ -1,6 +1,6 @@
 class AddDescriptionToAvatarAndHeader < ActiveRecord::Migration[7.1]
   def change
-    add_column :accounts, :avatar_description, :string
-    add_column :accounts, :header_description, :string
+    add_column :accounts, :avatar_description, :string, default: ""
+    add_column :accounts, :header_description, :string, default: ""
   end
 end

--- a/db/migrate/20241017192240_add_description_to_avatar_and_header.rb
+++ b/db/migrate/20241017192240_add_description_to_avatar_and_header.rb
@@ -1,0 +1,6 @@
+class AddDescriptionToAvatarAndHeader < ActiveRecord::Migration[7.1]
+  def change
+    add_column :accounts, :avatar_description, :string
+    add_column :accounts, :header_description, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -200,8 +200,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_17_192240) do
     t.datetime "requested_review_at", precision: nil
     t.boolean "indexable", default: false, null: false
     t.string "attribution_domains", default: [], array: true
-    t.string "avatar_description"
-    t.string "header_description"
+    t.string "avatar_description", default: ""
+    t.string "header_description", default: ""
     t.index "(((setweight(to_tsvector('simple'::regconfig, (display_name)::text), 'A'::\"char\") || setweight(to_tsvector('simple'::regconfig, (username)::text), 'B'::\"char\")) || setweight(to_tsvector('simple'::regconfig, (COALESCE(domain, ''::character varying))::text), 'C'::\"char\")))", name: "search_index", using: :gin
     t.index "lower((username)::text), COALESCE(lower((domain)::text), ''::text)", name: "index_accounts_on_username_and_domain_lower", unique: true
     t.index ["domain", "id"], name: "index_accounts_on_domain_and_id"
@@ -1377,9 +1377,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_17_192240) do
   add_index "instances", ["domain"], name: "index_instances_on_domain", unique: true
 
   create_view "user_ips", sql_definition: <<-SQL
-      SELECT t0.user_id,
-      t0.ip,
-      max(t0.used_at) AS used_at
+      SELECT user_id,
+      ip,
+      max(used_at) AS used_at
      FROM ( SELECT users.id AS user_id,
               users.sign_up_ip AS ip,
               users.created_at AS used_at

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1396,7 +1396,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_17_192240) do
               login_activities.created_at
              FROM login_activities
             WHERE (login_activities.success = true)) t0
-    GROUP BY t0.user_id, t0.ip;
+    GROUP BY user_id, ip;
   SQL
   create_view "account_summaries", materialized: true, sql_definition: <<-SQL
       SELECT accounts.id AS account_id,
@@ -1417,9 +1417,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_17_192240) do
   add_index "account_summaries", ["account_id"], name: "index_account_summaries_on_account_id", unique: true
 
   create_view "global_follow_recommendations", materialized: true, sql_definition: <<-SQL
-      SELECT t0.account_id,
-      sum(t0.rank) AS rank,
-      array_agg(t0.reason) AS reason
+      SELECT account_id,
+      sum(rank) AS rank,
+      array_agg(reason) AS reason
      FROM ( SELECT account_summaries.account_id,
               ((count(follows.id))::numeric / (1.0 + (count(follows.id))::numeric)) AS rank,
               'most_followed'::text AS reason
@@ -1443,8 +1443,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_17_192240) do
                     WHERE (follow_recommendation_suppressions.account_id = statuses.account_id)))))
             GROUP BY account_summaries.account_id
            HAVING (sum((status_stats.reblogs_count + status_stats.favourites_count)) >= (5)::numeric)) t0
-    GROUP BY t0.account_id
-    ORDER BY (sum(t0.rank)) DESC;
+    GROUP BY account_id
+    ORDER BY (sum(rank)) DESC;
   SQL
   add_index "global_follow_recommendations", ["account_id"], name: "index_global_follow_recommendations_on_account_id", unique: true
 


### PR DESCRIPTION
As described in the [issue 10313](https://github.com/mastodon/mastodon/issues/10313)  it would be beneficial to have alt tags for avatar and header in the profile.
In this PR I have introduced `avatar_description` and `header_description` that can be used for the alt tags.

- [x] and avatar and header descriptions to account migration, update account model and controller
- [x] use descriptions for alt tags in the profile frontend
- [x] add form fields for editing 
- [ ] update ActivityPub
- [ ] tests
- [ ] translations 

Screenshots:

Form
![Screenshot_2024-10-19-20-33-58_1920x1080](https://github.com/user-attachments/assets/f95dbd0a-74f6-422b-9597-6aab6da6e57f)


Profile
![Screenshot_2024-11-07-20-55-58_1920x1080](https://github.com/user-attachments/assets/19f8ac25-72a2-4a94-a5d0-57396b5193e8)




