### PR TITLE
Fix tl language native name

### DIFF
--- a/app/helpers/languages_helper.rb
+++ b/app/helpers/languages_helper.rb
@@ -162,7 +162,7 @@ module LanguagesHelper
     th: ['Thai', 'ไทย'].freeze,
     ti: ['Tigrinya', 'ትግርኛ'].freeze,
     tk: ['Turkmen', 'Türkmen'].freeze,
-    tl: ['Tagalog', 'Wikang Tagalog'].freeze,
+    tl: ['Tagalog', 'Tagalog'].freeze,
     tn: ['Tswana', 'Setswana'].freeze,
     to: ['Tonga', 'faka Tonga'].freeze,
     tr: ['Turkish', 'Türkçe'].freeze,


### PR DESCRIPTION
The most common name of the tl language is just "Tagalog" instead of "Wikang Tagalog", which literally means "Tagalog Language". Unlike "Bahasa Indonesia", you can refer to the language as just "Tagalog" in English or in Tagalog.