### PR TITLE
Fix 'unknown' media attachment type rendering

### DIFF
--- a/app/javascript/mastodon/components/status.jsx
+++ b/app/javascript/mastodon/components/status.jsx
@@ -449,7 +449,7 @@ class Status extends ImmutablePureComponent {
     } else if (status.get('media_attachments').size > 0) {
       const language = status.getIn(['translation', 'language']) || status.get('language');
 
-      if (['image', 'gifv'].includes(status.getIn(['media_attachments', 0, 'type'])) || status.get('media_attachments').size > 1) {
+      if (['image', 'gifv', 'unknown'].includes(status.getIn(['media_attachments', 0, 'type'])) || status.get('media_attachments').size > 1) {
         media = (
           <Bundle fetchComponent={MediaGallery} loading={this.renderLoadingMediaGallery}>
             {Component => (


### PR DESCRIPTION
Fixes #32595. Essentially this code was reworked at some point and the previous else branch that caught the 'unknown' media type was removed.

@renchap @ClearlyClaire this is an active regression between v4.3.0-beta.2 and v4.3.0 / v4.3.1, where media from server's marked as "reject_media" wouldn't be displayed at all in any way.