### PR TITLE
Use `likes` and `shares` totalItems on status creations and updates

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -173,8 +173,8 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
     return if likes.nil? && shares.nil?
 
     status.status_stat.tap do |status_stat|
-      status_stat.reblogs_count = shares.nil? ? 0 : shares
-      status_stat.favourites_count = likes.nil? ? 0 : likes
+      status_stat.untrusted_reblogs_count = shares unless shares.nil?
+      status_stat.untrusted_favourites_count = likes unless likes.nil?
       status_stat.save if status_stat.changed?
     end
   end

--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -168,15 +168,15 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
   end
 
   def attach_counts(status)
-    likes = @json.dig(:likes, :totalItems)
-    shares = @json.dig(:shares, :totalItems)
+    likes = @status_parser.favourites_count
+    shares = @status_parser.reblogs_count
     return if likes.nil? && shares.nil?
 
-    status.status_stat.build(
-      reblogs_count: shares.nil? ? 0 : shares,
-      favourites_count: likes.nil? ? 0 : likes
-    )
-    status.save
+    status.status_stat.tap do |status_stat|
+      status_stat.reblogs_count = shares.nil? ? 0 : shares
+      status_stat.favourites_count = likes.nil? ? 0 : likes
+      status_stat.save if status_stat.changed?
+    end
   end
 
   def process_tags

--- a/app/lib/activitypub/parser/status_parser.rb
+++ b/app/lib/activitypub/parser/status_parser.rb
@@ -93,6 +93,14 @@ class ActivityPub::Parser::StatusParser
     lang.presence && NORMALIZED_LOCALE_NAMES.fetch(lang.downcase.to_sym, lang)
   end
 
+  def favourites_count
+    @object.dig(:likes, :totalItems)
+  end
+
+  def reblogs_count
+    @object.dig(:shares, :totalItems)
+  end
+
   private
 
   def raw_language_code

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -415,9 +415,6 @@ class Status < ApplicationRecord
   def update_status_stat!(attrs)
     return if marked_for_destruction? || destroyed?
 
-    attrs[:untrusted_favourites_count] = attrs[:favourites_count] if attrs.key?(:favourites_count) && !untrusted_favourites_count.nil?
-    attrs[:untrusted_reblogs_count] = value if key == :favourites_count && !untrusted_favourites_count.nil?
-
     status_stat.update(attrs)
   end
 

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -303,6 +303,16 @@ class Status < ApplicationRecord
     status_stat&.favourites_count || 0
   end
 
+  # Reblogs count received from an external instance
+  def untrusted_reblogs_count
+    status_stat&.untrusted_reblogs_count unless local?
+  end
+
+  # Favourites count received from an external instance
+  def untrusted_favourites_count
+    status_stat&.untrusted_favourites_count unless local?
+  end
+
   def increment_count!(key)
     update_status_stat!(key => public_send(key) + 1)
   end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -314,19 +314,23 @@ class Status < ApplicationRecord
   end
 
   def increment_count!(key)
-    update = {}
-    update[key] = public_send(key) + 1
-    update[:untrusted_favourites_count] = untrusted_favourites_count + 1 if key == :favourites_count && !untrusted_favourites_count.nil?
-    update[:untrusted_reblogs_count] = untrusted_reblogs_count + 1 if key == :reblogs_count && !untrusted_reblogs_count.nil?
-    update_status_stat!(update)
+    if key == :favourites_count && !untrusted_favourites_count.nil?
+      update_status_stat!(favourites_count: favourites_count + 1, untrusted_favourites_count: untrusted_favourites_count + 1)
+    elsif key == :reblogs_count && !untrusted_reblogs_count.nil?
+      update_status_stat!(reblogs_count: reblogs_count + 1, untrusted_reblogs_count: untrusted_reblogs_count + 1)
+    else
+      update_status_stat!(key => public_send(key) + 1)
+    end
   end
 
   def decrement_count!(key)
-    update = {}
-    update[key] = [public_send(key) - 1, 0].max
-    update[:untrusted_favourites_count] = [untrusted_favourites_count - 1, 0].max if key == :favourites_count && !untrusted_favourites_count.nil?
-    update[:untrusted_reblogs_count] = [untrusted_reblogs_count - 1, 0].max if key == :reblogs_count && !untrusted_reblogs_count.nil?
-    update_status_stat!(update)
+    if key == :favourites_count && !untrusted_favourites_count.nil?
+      update_status_stat!(favourites_count: [favourites_count - 1, 0].max, untrusted_favourites_count: [untrusted_favourites_count - 1, 0].max)
+    elsif key == :reblogs_count && !untrusted_reblogs_count.nil?
+      update_status_stat!(reblogs_count: [reblogs_count - 1, 0].max, untrusted_reblogs_count: [untrusted_reblogs_count - 1, 0].max)
+    else
+      update_status_stat!(key => [public_send(key) - 1, 0].max)
+    end
   end
 
   def trendable?

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -315,10 +315,14 @@ class Status < ApplicationRecord
 
   def increment_count!(key)
     update_status_stat!(key => public_send(key) + 1)
+    increment_count!(:untrusted_favourites_count) if key == :favourites_count && !untrusted_favourites_count.nil?
+    increment_count!(:untrusted_reblogs_count) if key == :reblogs_count && !untrusted_reblogs_count.nil?
   end
 
   def decrement_count!(key)
     update_status_stat!(key => [public_send(key) - 1, 0].max)
+    decrement_count!(:untrusted_favourites_count) if key == :favourites_count && !untrusted_favourites_count.nil?
+    decrement_count!(:untrusted_reblogs_count) if key == :reblogs_count && !untrusted_reblogs_count.nil?
   end
 
   def trendable?

--- a/app/models/status_stat.rb
+++ b/app/models/status_stat.rb
@@ -18,6 +18,8 @@
 class StatusStat < ApplicationRecord
   belongs_to :status, inverse_of: :status_stat
 
+  before_validation :clamp_untrusted_counts
+
   def replies_count
     [attributes['replies_count'], 0].max
   end
@@ -28,5 +30,12 @@ class StatusStat < ApplicationRecord
 
   def favourites_count
     [attributes['favourites_count'], 0].max
+  end
+
+  private
+
+  def clamp_untrusted_counts
+    self.untrusted_favourites_count = untrusted_favourites_count.to_i.clamp(0, 1_000_000) if untrusted_favourites_count.present?
+    self.untrusted_reblogs_count = untrusted_reblogs_count.to_i.clamp(0, 1_000_000) if untrusted_reblogs_count.present?
   end
 end

--- a/app/models/status_stat.rb
+++ b/app/models/status_stat.rb
@@ -11,8 +11,8 @@
 #  favourites_count           :bigint(8)        default(0), not null
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null
-#  untrusted_favourites_count :integer
-#  untrusted_reblogs_count    :integer
+#  untrusted_favourites_count :bigint(8)
+#  untrusted_reblogs_count    :bigint(8)
 #
 
 class StatusStat < ApplicationRecord
@@ -20,7 +20,7 @@ class StatusStat < ApplicationRecord
 
   before_validation :clamp_untrusted_counts
 
-  MAX_UNTRUSTED_COUNT = 1_000_000
+  MAX_UNTRUSTED_COUNT = 100_000_000
 
   def replies_count
     [attributes['replies_count'], 0].max

--- a/app/models/status_stat.rb
+++ b/app/models/status_stat.rb
@@ -20,6 +20,8 @@ class StatusStat < ApplicationRecord
 
   before_validation :clamp_untrusted_counts
 
+  MAX_UNTRUSTED_COUNT = 1_000_000
+
   def replies_count
     [attributes['replies_count'], 0].max
   end
@@ -35,7 +37,7 @@ class StatusStat < ApplicationRecord
   private
 
   def clamp_untrusted_counts
-    self.untrusted_favourites_count = untrusted_favourites_count.to_i.clamp(0, 1_000_000) if untrusted_favourites_count.present?
-    self.untrusted_reblogs_count = untrusted_reblogs_count.to_i.clamp(0, 1_000_000) if untrusted_reblogs_count.present?
+    self.untrusted_favourites_count = untrusted_favourites_count.to_i.clamp(0, MAX_UNTRUSTED_COUNT) if untrusted_favourites_count.present?
+    self.untrusted_reblogs_count = untrusted_reblogs_count.to_i.clamp(0, MAX_UNTRUSTED_COUNT) if untrusted_reblogs_count.present?
   end
 end

--- a/app/models/status_stat.rb
+++ b/app/models/status_stat.rb
@@ -4,13 +4,15 @@
 #
 # Table name: status_stats
 #
-#  id               :bigint(8)        not null, primary key
-#  status_id        :bigint(8)        not null
-#  replies_count    :bigint(8)        default(0), not null
-#  reblogs_count    :bigint(8)        default(0), not null
-#  favourites_count :bigint(8)        default(0), not null
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
+#  id                         :bigint(8)        not null, primary key
+#  status_id                  :bigint(8)        not null
+#  replies_count              :bigint(8)        default(0), not null
+#  reblogs_count              :bigint(8)        default(0), not null
+#  favourites_count           :bigint(8)        default(0), not null
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
+#  untrusted_favourites_count :integer
+#  untrusted_reblogs_count    :integer
 #
 
 class StatusStat < ApplicationRecord

--- a/app/serializers/rest/status_serializer.rb
+++ b/app/serializers/rest/status_serializer.rb
@@ -45,7 +45,7 @@ class REST::StatusSerializer < ActiveModel::Serializer
   end
 
   def current_user?
-    defined?(current_user) && !current_user.nil?
+    !current_user.nil?
   end
 
   def show_application?

--- a/app/serializers/rest/status_serializer.rb
+++ b/app/serializers/rest/status_serializer.rb
@@ -45,7 +45,7 @@ class REST::StatusSerializer < ActiveModel::Serializer
   end
 
   def current_user?
-    !current_user.nil?
+    defined?(current_user) && !current_user.nil?
   end
 
   def show_application?
@@ -84,11 +84,11 @@ class REST::StatusSerializer < ActiveModel::Serializer
   end
 
   def reblogs_count
-    relationships&.attributes_map&.dig(object.id, :reblogs_count) || object.reblogs_count
+    object.untrusted_reblogs_count || relationships&.attributes_map&.dig(object.id, :reblogs_count) || object.reblogs_count
   end
 
   def favourites_count
-    relationships&.attributes_map&.dig(object.id, :favourites_count) || object.favourites_count
+    object.untrusted_favourites_count || relationships&.attributes_map&.dig(object.id, :favourites_count) || object.favourites_count
   end
 
   def favourited

--- a/app/services/activitypub/process_status_update_service.rb
+++ b/app/services/activitypub/process_status_update_service.rb
@@ -242,8 +242,10 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
   end
 
   def update_counts!
-    likes = @json.dig(:likes, :totalItems)
-    shares = @json.dig(:shares, :totalItems)
+    likes = @status_parser.favourites_count
+    shares =  @status_parser.reblogs_count
+    return if likes.nil? && shares.nil?
+
     @status.status_stat.tap do |status_stat|
       status_stat.reblogs_count = shares unless shares.nil?
       status_stat.favourites_count = likes unless likes.nil?

--- a/app/services/activitypub/process_status_update_service.rb
+++ b/app/services/activitypub/process_status_update_service.rb
@@ -247,8 +247,8 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
     return if likes.nil? && shares.nil?
 
     @status.status_stat.tap do |status_stat|
-      status_stat.reblogs_count = shares unless shares.nil?
-      status_stat.favourites_count = likes unless likes.nil?
+      status_stat.untrusted_reblogs_count = shares unless shares.nil?
+      status_stat.untrusted_favourites_count = likes unless likes.nil?
 
       status_stat.save if status_stat.changed?
     end

--- a/db/migrate/20241022214312_add_untrusted_favourites_count_and_untrusted_reblogs_count_to_status_stat.rb
+++ b/db/migrate/20241022214312_add_untrusted_favourites_count_and_untrusted_reblogs_count_to_status_stat.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddUntrustedFavouritesCountAndUntrustedReblogsCountToStatusStat < ActiveRecord::Migration[7.1]
+  def change
+    add_column :status_stats, :untrusted_favourites_count, :integer, null: true
+    add_column :status_stats, :untrusted_reblogs_count, :integer, null: true
+  end
+end

--- a/db/migrate/20241022214312_add_untrusted_favourites_count_and_untrusted_reblogs_count_to_status_stat.rb
+++ b/db/migrate/20241022214312_add_untrusted_favourites_count_and_untrusted_reblogs_count_to_status_stat.rb
@@ -2,7 +2,7 @@
 
 class AddUntrustedFavouritesCountAndUntrustedReblogsCountToStatusStat < ActiveRecord::Migration[7.1]
   def change
-    add_column :status_stats, :untrusted_favourites_count, :integer, null: true
-    add_column :status_stats, :untrusted_reblogs_count, :integer, null: true
+    add_column :status_stats, :untrusted_favourites_count, :bigint, null: true
+    add_column :status_stats, :untrusted_reblogs_count, :bigint, null: true
   end
 end

--- a/db/migrate/20241022214312_add_untrusted_replies_count_and_untrusted_reblogs_count_to_status_stat.rb
+++ b/db/migrate/20241022214312_add_untrusted_replies_count_and_untrusted_reblogs_count_to_status_stat.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddUntrustedRepliesCountAndUntrustedReblogsCountToStatusStat < ActiveRecord::Migration[7.1]
+  def change
+    add_column :status_stats, :untrusted_replies_count, :integer, null: true
+    add_column :status_stats, :untrusted_reblogs_count, :integer, null: true
+  end
+end

--- a/db/migrate/20241022214312_add_untrusted_replies_count_and_untrusted_reblogs_count_to_status_stat.rb
+++ b/db/migrate/20241022214312_add_untrusted_replies_count_and_untrusted_reblogs_count_to_status_stat.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-class AddUntrustedRepliesCountAndUntrustedReblogsCountToStatusStat < ActiveRecord::Migration[7.1]
-  def change
-    add_column :status_stats, :untrusted_replies_count, :integer, null: true
-    add_column :status_stats, :untrusted_reblogs_count, :integer, null: true
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1008,8 +1008,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_22_214312) do
     t.bigint "favourites_count", default: 0, null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
-    t.integer "untrusted_favourites_count"
-    t.integer "untrusted_reblogs_count"
+    t.bigint "untrusted_favourites_count"
+    t.bigint "untrusted_reblogs_count"
     t.index ["status_id"], name: "index_status_stats_on_status_id", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1008,7 +1008,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_22_214312) do
     t.bigint "favourites_count", default: 0, null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
-    t.integer "untrusted_replies_count"
+    t.integer "untrusted_favourites_count"
     t.integer "untrusted_reblogs_count"
     t.index ["status_id"], name: "index_status_stats_on_status_id", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_14_010506) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_22_214312) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -1008,6 +1008,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_14_010506) do
     t.bigint "favourites_count", default: 0, null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.integer "untrusted_replies_count"
+    t.integer "untrusted_reblogs_count"
     t.index ["status_id"], name: "index_status_stats_on_status_id", unique: true
   end
 

--- a/spec/lib/activitypub/activity/create_spec.rb
+++ b/spec/lib/activitypub/activity/create_spec.rb
@@ -950,8 +950,8 @@ RSpec.describe ActivityPub::Activity::Create do
 
         it 'uses the counts from the created object' do
           status = sender.statuses.first
-          expect(status.favourites_count).to eq 50
-          expect(status.reblogs_count).to eq 100
+          expect(status.untrusted_favourites_count).to eq 50
+          expect(status.untrusted_reblogs_count).to eq 100
         end
       end
     end

--- a/spec/lib/activitypub/activity/create_spec.rb
+++ b/spec/lib/activitypub/activity/create_spec.rb
@@ -928,6 +928,32 @@ RSpec.describe ActivityPub::Activity::Create do
           expect(poll.votes.first).to be_nil
         end
       end
+
+      context 'with counts' do
+        let(:object_json) do
+          {
+            id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
+            type: 'Note',
+            content: 'Lorem ipsum',
+            likes: {
+              id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar', '/likes'].join,
+              type: 'Collection',
+              totalItems: 50,
+            },
+            shares: {
+              id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar', '/shares'].join,
+              type: 'Collection',
+              totalItems: 100,
+            },
+          }
+        end
+
+        it 'uses the counts from the created object' do
+          status = sender.statuses.first
+          expect(status.favourites_count).to eq 50
+          expect(status.reblogs_count).to eq 100
+        end
+      end
     end
 
     context 'when object URI uses bearcaps' do

--- a/spec/lib/activitypub/activity/update_spec.rb
+++ b/spec/lib/activitypub/activity/update_spec.rb
@@ -115,5 +115,69 @@ RSpec.describe ActivityPub::Activity::Update do
         expect(status.edited_at).to be_nil
       end
     end
+
+    context 'with a Note object' do
+      let(:updated) { nil }
+      let(:favourites) { 50 }
+      let(:reblogs) { 100 }
+
+      let!(:status) { Fabricate(:status, uri: 'https://example.com/statuses/poll', account: sender) }
+      let(:json) do
+        {
+          '@context': 'https://www.w3.org/ns/activitystreams',
+          id: 'foo',
+          type: 'Update',
+          actor: sender.uri,
+          object: {
+            type: 'Note',
+            id: status.uri,
+            content: 'Foo',
+            updated: updated,
+            likes: {
+              id: "#{status.uri}/likes",
+              type: 'Collection',
+              totalItems: favourites,
+            },
+            shares: {
+              id: "#{status.uri}/shares",
+              type: 'Collection',
+              totalItems: reblogs,
+            },
+          },
+        }.with_indifferent_access
+      end
+
+      shared_examples 'updates counts' do
+        it 'updates the reblog count' do
+          expect(status.reblogs_count).to eq reblogs
+        end
+
+        it 'updates the favourites count' do
+          expect(status.favourites_count).to eq favourites
+        end
+      end
+
+      context 'with an implicit update' do
+        before do
+          status.update!(uri: ActivityPub::TagManager.instance.uri_for(status))
+          subject.perform
+        end
+
+        it_behaves_like 'updates counts'
+      end
+
+      context 'with an explicit update' do
+        let(:favourites) { 150 }
+        let(:reblogs) { 200 }
+        let(:updated) { Time.now.utc.iso8601 }
+
+        before do
+          status.update!(uri: ActivityPub::TagManager.instance.uri_for(status))
+          subject.perform
+        end
+
+        it_behaves_like 'updates counts'
+      end
+    end
   end
 end

--- a/spec/lib/activitypub/activity/update_spec.rb
+++ b/spec/lib/activitypub/activity/update_spec.rb
@@ -149,11 +149,11 @@ RSpec.describe ActivityPub::Activity::Update do
 
       shared_examples 'updates counts' do
         it 'updates the reblog count' do
-          expect(status.reblogs_count).to eq reblogs
+          expect(status.untrusted_reblogs_count).to eq reblogs
         end
 
         it 'updates the favourites count' do
-          expect(status.favourites_count).to eq favourites
+          expect(status.untrusted_favourites_count).to eq favourites
         end
       end
 

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -164,6 +164,31 @@ RSpec.describe Status do
     end
   end
 
+  describe '#untrusted_reblogs_count' do
+    before do
+      alice.update(domain: 'example.com')
+      subject.status_stat.tap do |status_stat|
+        status_stat.untrusted_reblogs_count = 0
+        status_stat.save
+      end
+      subject.save
+    end
+
+    it 'is incremented by the number of reblogs' do
+      Fabricate(:status, account: bob, reblog: subject)
+      Fabricate(:status, account: alice, reblog: subject)
+
+      expect(subject.untrusted_reblogs_count).to eq 2
+    end
+
+    it 'is decremented when reblog is removed' do
+      reblog = Fabricate(:status, account: bob, reblog: subject)
+      expect(subject.untrusted_reblogs_count).to eq 1
+      reblog.destroy
+      expect(subject.untrusted_reblogs_count).to eq 0
+    end
+  end
+
   describe '#replies_count' do
     it 'is the number of replies' do
       Fabricate(:status, account: bob, thread: subject)
@@ -191,6 +216,31 @@ RSpec.describe Status do
       expect(subject.favourites_count).to eq 1
       favourite.destroy
       expect(subject.favourites_count).to eq 0
+    end
+  end
+
+  describe '#untrusted_favourites_count' do
+    before do
+      alice.update(domain: 'example.com')
+      subject.status_stat.tap do |status_stat|
+        status_stat.untrusted_favourites_count = 0
+        status_stat.save
+      end
+      subject.save
+    end
+
+    it 'is incremented by favorites' do
+      Fabricate(:favourite, account: bob, status: subject)
+      Fabricate(:favourite, account: alice, status: subject)
+
+      expect(subject.untrusted_favourites_count).to eq 2
+    end
+
+    it 'is decremented when favourite is removed' do
+      favourite = Fabricate(:favourite, account: bob, status: subject)
+      expect(subject.untrusted_favourites_count).to eq 1
+      favourite.destroy
+      expect(subject.untrusted_favourites_count).to eq 0
     end
   end
 

--- a/spec/requests/api/v1/trends/statuses_spec.rb
+++ b/spec/requests/api/v1/trends/statuses_spec.rb
@@ -39,6 +39,42 @@ RSpec.describe 'API V1 Trends Statuses' do
         end
         Trends::Statuses.new(threshold: 1, decay_threshold: -1).refresh
       end
+
+      context 'with a comically inflated external interactions count' do
+        def prepare_fake_trends
+          fake_remote_account = Fabricate(:account, domain: 'other.com')
+          fake_status = Fabricate(:status, account: fake_remote_account, text: 'I am a big faker', trendable: true, language: 'en')
+          fake_status.status_stat.tap do |status_stat|
+            status_stat.reblogs_count = 0
+            status_stat.favourites_count = 0
+            status_stat.untrusted_reblogs_count = 1_000_000_000
+            status_stat.untrusted_favourites_count = 1_000_000_000
+            status_stat.save
+          end
+          real_remote_account = Fabricate(:account, domain: 'other.com')
+          real_status = Fabricate(:status, account: real_remote_account, text: 'I make real friends online', trendable: true, language: 'en')
+          real_status.status_stat.tap do |status_stat|
+            status_stat.reblogs_count = 10
+            status_stat.favourites_count = 10
+            status_stat.untrusted_reblogs_count = 10
+            status_stat.untrusted_favourites_count = 10
+            status_stat.save
+          end
+          Trends.statuses.add(fake_status, 100)
+          Trends.statuses.add(real_status, 101)
+          Trends::Statuses.new(threshold: 1, decay_threshold: 1).refresh
+        end
+
+        it 'ignores the feeble attempts at deception' do
+          prepare_fake_trends
+          stub_const('Api::BaseController::DEFAULT_STATUSES_LIMIT', 10)
+          get '/api/v1/trends/statuses'
+
+          expect(response).to have_http_status(200)
+          expect(response.parsed_body.length).to eq(1)
+          expect(response.parsed_body[0]['content']).to eq('I make real friends online')
+        end
+      end
     end
   end
 end

--- a/spec/serializers/rest/status_serializer_spec.rb
+++ b/spec/serializers/rest/status_serializer_spec.rb
@@ -3,8 +3,18 @@
 require 'rails_helper'
 
 RSpec.describe REST::StatusSerializer do
-  subject { serialized_record_json(status, described_class) }
+  subject do
+    serialized_record_json(
+      status,
+      described_class,
+      options: {
+        scope: current_user,
+        scope_name: :current_user,
+      }
+    )
+  end
 
+  let(:current_user) { Fabricate(:user) }
   let(:alice) { Fabricate(:account, username: 'alice') }
   let(:bob)   { Fabricate(:account, username: 'bob', domain: 'other.com') }
   let(:status) { Fabricate(:status, account: alice) }

--- a/spec/serializers/rest/status_serializer_spec.rb
+++ b/spec/serializers/rest/status_serializer_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe REST::StatusSerializer do
+  subject { serialized_record_json(status, described_class) }
+
+  let(:alice) { Fabricate(:account, username: 'alice') }
+  let(:bob)   { Fabricate(:account, username: 'bob', domain: 'other.com') }
+  let(:status) { Fabricate(:status, account: alice) }
+
+  context 'with a remote status' do
+    let(:status) { Fabricate(:status, account: bob) }
+
+    before do
+      status.status_stat.tap do |status_stat|
+        status_stat.reblogs_count = 10
+        status_stat.favourites_count = 20
+        status_stat.save
+      end
+    end
+
+    context 'with only trusted counts' do
+      it 'shows the trusted counts' do
+        expect(subject['reblogs_count']).to eq(10)
+        expect(subject['favourites_count']).to eq(20)
+      end
+    end
+
+    context 'with untrusted counts' do
+      before do
+        status.status_stat.tap do |status_stat|
+          status_stat.untrusted_reblogs_count = 30
+          status_stat.untrusted_favourites_count = 40
+          status_stat.save
+        end
+      end
+
+      it 'shows the untrusted counts' do
+        expect(subject['reblogs_count']).to eq(30)
+        expect(subject['favourites_count']).to eq(40)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,8 +34,8 @@ RSpec.configure do |config|
   end
 end
 
-def serialized_record_json(record, serializer, adapter: nil)
-  options = { serializer: serializer }
+def serialized_record_json(record, serializer, adapter: nil, options: {})
+  options[:serializer] = serializer
   options[:adapter] = adapter if adapter.present?
   JSON.parse(
     ActiveModelSerializers::SerializableResource.new(


### PR DESCRIPTION
"the likes and the boosts are wrong" is a super common complaint. 

Reading previous discussion, it seems like choosing to not enumerate all favourites and boosts was an active decision, and that seems fine. 

I don't see a similar reason why not to use the like/share counts when they are provided by the server tho.

When I fetch a status like this: 

```shell
curl -H 'Accept: application/ld+json' https://neuromatch.social/@jonny/113347217701900056
```

I get a JSON-LD object like this:

```json
{
    "id": "https://neuromatch.social/users/jonny/statuses/113347217701900056",
    "type": "Note",
    "...": "...",
    "likes":
    {
        "id": "https://neuromatch.social/users/jonny/statuses/113347217701900056/likes",
        "type": "Collection",
        "totalItems": 50
    },
    "shares":
    {
        "id": "https://neuromatch.social/users/jonny/statuses/113347217701900056/shares",
        "type": "Collection",
        "totalItems": 39
    }
}
```

Here the originating server is telling me the correct number of boosts and favorites, which should supercede any local count we have. Currently this information is just discarded.

This PR, quite simply, uses that information when it is present.

When combined with https://github.com/mastodon/mastodon/pull/32615 , this means that expanding a status to its detailed view will update the boost and favorite count for a status and all its replies. 

There is some possibility for mismatches, and these counts will also get overridden if someone runs the `tootctl` command to update counts, but in either case I think it's still desirable to use "ground truth" information when we get it.

I think the abuse potential here is super low. I can't think of an abuse scenario when knowing an accurate boosts/faves count (which could be gotten by any logged out user by visiting the post's page) would cause harm - recall that fetch all replies would be the main trigger for this for already-existing statuses, and it doesn't fetch any followers-only or dm statuses.

If this looks acceptable, i will update https://github.com/mastodon/mastodon/pull/32615 to also fetch the root post in order to update its stats 

