### PR TITLE
Fix and improve batch attachment deletion handling when using OpenStack Swift

### DIFF
--- a/app/lib/attachment_batch.rb
+++ b/app/lib/attachment_batch.rb
@@ -77,8 +77,8 @@ class AttachmentBatch
           when :fog
             logger.debug { "Deleting #{attachment.path(style)}" }
 
+            retries = 0
             begin
-              retries ||= 0
               attachment.send(:directory).files.new(key: attachment.path(style)).destroy
             rescue => e
               if e.is_a?(Fog::OpenStack::Storage::NotFound)

--- a/app/lib/attachment_batch.rb
+++ b/app/lib/attachment_batch.rb
@@ -80,15 +80,13 @@ class AttachmentBatch
             retries = 0
             begin
               attachment.send(:directory).files.new(key: attachment.path(style)).destroy
+            rescue Fog::OpenStack::Storage::NotFound
+              logger.debug "Will ignore because file is not found #{attachment.path(style)}"
             rescue => e
-              if e.is_a?(Fog::OpenStack::Storage::NotFound)
-                logger.debug "Will ignore because file is not found #{attachment.path(style)}"
-              else
                 sleep(5)
                 retry if (retries += 1) < MAX_RETRY
                 logger.error "Batch deletion from fog failed after #{e.message}"
                 raise e
-              end
             end
           when :azure
             logger.debug { "Deleting #{attachment.path(style)}" }

--- a/app/lib/attachment_batch.rb
+++ b/app/lib/attachment_batch.rb
@@ -84,7 +84,6 @@ class AttachmentBatch
               if e.is_a?(Fog::OpenStack::Storage::NotFound)
                 logger.debug { "Will ignore because file is not found #{attachment.path(style)}" }
               else
-                # Retry mechanism for other errors
                 sleep(5)
                 retry if (retries += 1) < 3
                 logger.error "Batch deletion from fog failed after #{e.message}"

--- a/app/lib/attachment_batch.rb
+++ b/app/lib/attachment_batch.rb
@@ -83,10 +83,16 @@ class AttachmentBatch
             rescue Fog::OpenStack::Storage::NotFound
               logger.debug "Will ignore because file is not found #{attachment.path(style)}"
             rescue => e
-                sleep(5)
-                retry if (retries += 1) < MAX_RETRY
+              retries += 1
+
+              if retries < MAX_RETRY
+                logger.debug "Retry #{retries}/#{MAX_RETRY} after #{e.message}"
+                sleep 2**retries
+                retry
+              else
                 logger.error "Batch deletion from fog failed after #{e.message}"
                 raise e
+              end
             end
           when :azure
             logger.debug { "Deleting #{attachment.path(style)}" }

--- a/app/lib/attachment_batch.rb
+++ b/app/lib/attachment_batch.rb
@@ -85,7 +85,7 @@ class AttachmentBatch
                 logger.debug "Will ignore because file is not found #{attachment.path(style)}"
               else
                 sleep(5)
-                retry if (retries += 1) < 3
+                retry if (retries += 1) < MAX_RETRY
                 logger.error "Batch deletion from fog failed after #{e.message}"
                 raise e
               end

--- a/app/lib/attachment_batch.rb
+++ b/app/lib/attachment_batch.rb
@@ -82,7 +82,7 @@ class AttachmentBatch
               attachment.send(:directory).files.new(key: attachment.path(style)).destroy
             rescue => e
               if e.is_a?(Fog::OpenStack::Storage::NotFound)
-                logger.debug { "Will ignore because file is not found #{attachment.path(style)}" }
+                logger.debug "Will ignore because file is not found #{attachment.path(style)}"
               else
                 sleep(5)
                 retry if (retries += 1) < 3


### PR DESCRIPTION
Since v4.3.0 `rescue Fog::Storage::OpenStack::NotFound` in batch attachment for OpenStack Swift has caused the batch deletion to never finish in the case of attempting to delete a file that is missing.

In debug mode it logs "uninitialized constant Fog::Storage::OpenStack (NameError)".

Changing the class from `Fog::Storage::OpenStack::NotFound` to the new `Fog::OpenStack::Storage::NotFound` fixes it.

Also, in this PR I suggest introducing some improvements to how attachment batch deletion is handle for OpenStack Swift:
- retry 3 times (5 second interval) for temporary object storage failures
- error logging
- raise in case of failure after retries