### PR TITLE
Restore default devise `secret_key` behavior

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -105,11 +105,9 @@ Devise.setup do |config|
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing
   # confirmation, reset password and unlock tokens in the database.
-  #
-  # Set explicitly to Rails default to avoid deprecation warnings.
-  # https://github.com/heartcombo/devise/pull/5645#issuecomment-1871849856
-  # Remove when Devise changes `SecretKeyFinder` to not emit deprecations.
-  config.secret_key = Rails.application.secret_key_base
+  # Devise will use the `secret_key_base` as its `secret_key`
+  # by default. You can change it below and use your own secret key.
+  # config.secret_key = '<%= SecureRandom.hex(64) %>'
 
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,


### PR DESCRIPTION
We previously had overridden this to avoid a rails deprecation warning in regard to how the secret key value is made available:

https://github.com/mastodon/mastodon/pull/28760

Devise recently merged a PR which totally removes the `SecretKeyFinder`:

https://github.com/heartcombo/devise/pull/5645

With merge of this PR we will no longer see the deprecation noise, and can go back to just using the devise default (which is the same value we were configuring).

Opening as draft because this is contingent on a devise release being cut and our updating to it first. Will toggle to ready when that occurs.