### PR TITLE
Add coverage for `DatabaseHelper` primary/replica methods

### DIFF
--- a/spec/helpers/database_helper_spec.rb
+++ b/spec/helpers/database_helper_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DatabaseHelper do
+  context 'when a replica is enabled' do
+    around do |example|
+      ClimateControl.modify REPLICA_DB_NAME: 'prod-relay-quantum-tunnel-mirror' do
+        example.run
+      end
+    end
+
+    before { allow(ApplicationRecord).to receive(:connected_to) }
+
+    describe '#with_read_replica' do
+      it 'uses the replica for connections' do
+        helper.with_read_replica { _x = 1 }
+
+        expect(ApplicationRecord)
+          .to have_received(:connected_to).with(role: :reading, prevent_writes: true)
+      end
+    end
+
+    describe '#with_primary' do
+      it 'uses the primary for connections' do
+        helper.with_primary { _x = 1 }
+
+        expect(ApplicationRecord)
+          .to have_received(:connected_to).with(role: :writing)
+      end
+    end
+  end
+
+  context 'when a replica is not enabled' do
+    around do |example|
+      ClimateControl.modify REPLICA_DB_NAME: nil do
+        example.run
+      end
+    end
+
+    before { allow(ApplicationRecord).to receive(:connected_to) }
+
+    describe '#with_read_replica' do
+      it 'does not use the replica for connections' do
+        helper.with_read_replica { _x = 1 }
+
+        expect(ApplicationRecord)
+          .to_not have_received(:connected_to).with(role: :reading, prevent_writes: true)
+      end
+    end
+
+    describe '#with_primary' do
+      it 'does not use the primary for connections' do
+        helper.with_primary { _x = 1 }
+
+        expect(ApplicationRecord)
+          .to_not have_received(:connected_to).with(role: :writing)
+      end
+    end
+  end
+end


### PR DESCRIPTION
It would be awkward to actually set up a primary/replica scenario in specs, so just doing some allow/expect here to see that the env variable does trigger the expected code path for the used connection.

If we ever move this check to a `config_for` style early initialization, we can drop the climate control setup and intead stub out the configuration instead.