### PR TITLE
Remove unused `ApplicationHelper#visibility_icon` helper method

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -120,18 +120,6 @@ module ApplicationHelper
     inline_svg_tag 'check.svg'
   end
 
-  def visibility_icon(status)
-    if status.public_visibility?
-      material_symbol('globe', title: I18n.t('statuses.visibilities.public'))
-    elsif status.unlisted_visibility?
-      material_symbol('lock_open', title: I18n.t('statuses.visibilities.unlisted'))
-    elsif status.private_visibility? || status.limited_visibility?
-      material_symbol('lock', title: I18n.t('statuses.visibilities.private'))
-    elsif status.direct_visibility?
-      material_symbol('alternate_email', title: I18n.t('statuses.visibilities.direct'))
-    end
-  end
-
   def interrelationships_icon(relationships, account_id)
     if relationships.following[account_id] && relationships.followed_by[account_id]
       material_symbol('sync_alt', title: I18n.t('relationships.mutual'), class: 'active passive')

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -227,28 +227,6 @@ RSpec.describe ApplicationHelper do
     end
   end
 
-  describe 'visibility_icon' do
-    it 'returns a globe icon for a public visible status' do
-      result = helper.visibility_icon Status.new(visibility: 'public')
-      expect(result).to match(/globe/)
-    end
-
-    it 'returns an unlock icon for a unlisted visible status' do
-      result = helper.visibility_icon Status.new(visibility: 'unlisted')
-      expect(result).to match(/lock_open/)
-    end
-
-    it 'returns a lock icon for a private visible status' do
-      result = helper.visibility_icon Status.new(visibility: 'private')
-      expect(result).to match(/lock/)
-    end
-
-    it 'returns an at icon for a direct visible status' do
-      result = helper.visibility_icon Status.new(visibility: 'direct')
-      expect(result).to match(/alternate_email/)
-    end
-  end
-
   describe 'title' do
     it 'returns site title on production environment' do
       Setting.site_title = 'site title'


### PR DESCRIPTION
I noticed in code coverage that this method is not used, which was sort of confusing because the few spots in the UI which show these icons do indeed show icons conditional on status visibility (I looked during FA migration time).

Did a little tracing and I think what happened is that during the font-awesome cleanup/removal we renamed a method that previously had an `fa_` prefix to not have one - https://github.com/mastodon/mastodon/pull/31846 - as a side effect of that we unintentionally wound up with two method definitions for the same thing (one which just returns an icon name, and this one which also calls `material_symbol`).

This is a risk of the flat helper namespace, but fortunately all view usage had already been updated to expect the former style (only two spots, and both call `material_symbol` on their own and expect just a string from this method), and that's the one that was getting used (in statuses helper ... presumably load order last one wins).

As a side effect of all that, this method winds being a) basically the same as the other one (both impl and specs); and b) not used anywhere.

Maybe useful additional history - https://github.com/mastodon/mastodon/pull/14123 / https://github.com/mastodon/mastodon/pull/30962