### PR TITLE
Fix preview cards with long titles erroneously causing layout changes

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2759,6 +2759,7 @@ a.account__display-name {
       flex: 0 1 auto;
       display: flex;
       flex-direction: column;
+      contain: inline-size layout paint style;
 
       @media screen and (min-width: $no-gap-breakpoint) {
         max-width: 600px;
@@ -4032,6 +4033,7 @@ $ui-header-logo-wordmark-width: 99px;
   overflow: hidden;
   border: 1px solid var(--background-border-color);
   border-radius: 8px;
+  contain: inline-size layout paint style;
 
   &.bottomless {
     border-radius: 8px 8px 0 0;


### PR DESCRIPTION
Fixes #32652

For some reason, the overflowing (but hidden) text in preview cards push the container's size and prevent the flex shrinking for occurring.

I have found no way to handle that except for `contain: inline-size`, which should be safe because both containers are expected to take the available horizontal space with no regards to their contents.