### PR TITLE
Use nil for timestamp column in admin/confirmations spec

### DIFF
--- a/spec/controllers/admin/confirmations_controller_spec.rb
+++ b/spec/controllers/admin/confirmations_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Admin::ConfirmationsController do
 
   describe 'POST #create' do
     it 'confirms the user' do
-      user = Fabricate(:user, confirmed_at: false)
+      user = Fabricate(:user, confirmed_at: nil)
       post :create, params: { account_id: user.account.id }
 
       expect(response).to redirect_to(admin_accounts_path)


### PR DESCRIPTION
Extracted from Rails 8 PR branch (where it raises a type error) ... assuming checking got more strict at some point.