### PR TITLE
Add coverage for `StatusTrend` and `PreviewCardTrend` models, add `locales` class method to `RankedTrend`

### DIFF
--- a/app/controllers/admin/trends/links_controller.rb
+++ b/app/controllers/admin/trends/links_controller.rb
@@ -4,7 +4,7 @@ class Admin::Trends::LinksController < Admin::BaseController
   def index
     authorize :preview_card, :review?
 
-    @locales       = PreviewCardTrend.pluck('distinct language')
+    @locales       = PreviewCardTrend.locales
     @preview_cards = filtered_preview_cards.page(params[:page])
     @form          = Trends::PreviewCardBatch.new
   end

--- a/app/controllers/admin/trends/statuses_controller.rb
+++ b/app/controllers/admin/trends/statuses_controller.rb
@@ -4,7 +4,7 @@ class Admin::Trends::StatusesController < Admin::BaseController
   def index
     authorize [:admin, :status], :review?
 
-    @locales  = StatusTrend.pluck('distinct language')
+    @locales  = StatusTrend.locales
     @statuses = filtered_statuses.page(params[:page])
     @form     = Trends::StatusBatch.new
   end

--- a/app/models/concerns/ranked_trend.rb
+++ b/app/models/concerns/ranked_trend.rb
@@ -9,6 +9,10 @@ module RankedTrend
   end
 
   class_methods do
+    def locales
+      distinct.pluck(:language)
+    end
+
     def recalculate_ordered_rank
       connection
         .exec_update(<<~SQL.squish)

--- a/app/models/trends/links.rb
+++ b/app/models/trends/links.rb
@@ -85,7 +85,7 @@ class Trends::Links < Trends::Base
   end
 
   def request_review
-    PreviewCardTrend.pluck('distinct language').flat_map do |language|
+    PreviewCardTrend.locales.flat_map do |language|
       score_at_threshold  = PreviewCardTrend.where(language: language).allowed.by_rank.ranked_below(options[:review_threshold]).first&.score || 0
       preview_card_trends = PreviewCardTrend.where(language: language).not_allowed.joins(:preview_card)
 

--- a/app/models/trends/statuses.rb
+++ b/app/models/trends/statuses.rb
@@ -78,7 +78,7 @@ class Trends::Statuses < Trends::Base
   end
 
   def request_review
-    StatusTrend.pluck('distinct language').flat_map do |language|
+    StatusTrend.locales.flat_map do |language|
       score_at_threshold = StatusTrend.where(language: language, allowed: true).by_rank.ranked_below(options[:review_threshold]).first&.score || 0
       status_trends      = StatusTrend.where(language: language, allowed: false).joins(:status).includes(status: :account)
 

--- a/spec/fabricators/preview_card_trend_fabricator.rb
+++ b/spec/fabricators/preview_card_trend_fabricator.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Fabricator(:preview_card_trend) do
+  preview_card
+end

--- a/spec/fabricators/status_trend_fabricator.rb
+++ b/spec/fabricators/status_trend_fabricator.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+Fabricator(:status_trend) do
+  status
+  account
+end

--- a/spec/models/preview_card_trend_spec.rb
+++ b/spec/models/preview_card_trend_spec.rb
@@ -6,4 +6,17 @@ RSpec.describe PreviewCardTrend do
   describe 'Associations' do
     it { is_expected.to belong_to(:preview_card).required }
   end
+
+  describe '.locales' do
+    before do
+      Fabricate :preview_card_trend, language: 'en'
+      Fabricate :preview_card_trend, language: 'en'
+      Fabricate :preview_card_trend, language: 'es'
+    end
+
+    it 'returns unique set of languages' do
+      expect(described_class.locales)
+        .to eq(['en', 'es'])
+    end
+  end
 end

--- a/spec/models/preview_card_trend_spec.rb
+++ b/spec/models/preview_card_trend_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PreviewCardTrend do
+  describe 'Associations' do
+    it { is_expected.to belong_to(:preview_card).required }
+  end
+end

--- a/spec/models/status_trend_spec.rb
+++ b/spec/models/status_trend_spec.rb
@@ -7,4 +7,17 @@ RSpec.describe StatusTrend do
     it { is_expected.to belong_to(:account).required }
     it { is_expected.to belong_to(:status).required }
   end
+
+  describe '.locales' do
+    before do
+      Fabricate :status_trend, language: 'en'
+      Fabricate :status_trend, language: 'en'
+      Fabricate :status_trend, language: 'es'
+    end
+
+    it 'returns unique set of languages' do
+      expect(described_class.locales)
+        .to eq(['en', 'es'])
+    end
+  end
 end

--- a/spec/models/status_trend_spec.rb
+++ b/spec/models/status_trend_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe StatusTrend do
+  describe 'Associations' do
+    it { is_expected.to belong_to(:account).required }
+    it { is_expected.to belong_to(:status).required }
+  end
+end


### PR DESCRIPTION
Collection of changes:

- Add barebones spec coverage for both models
- Add missing fabricators to enable those specs
- Both of these models have this repeated "pluck distinct language" usage, and also both of them include `RankedTrend`, so pull that out into a class method via that concern, use it where relevant, add specs for that method, etc.

Related -- getting feedback/review on https://github.com/mastodon/mastodon/pull/29600 would potentially enable pulling the allowed/not_allowed scopes on both of these models out into the concern as well.