### PR TITLE
Add `DomainHelpers` spec support module for DNS/MX stub

### DIFF
--- a/spec/controllers/auth/registrations_controller_spec.rb
+++ b/spec/controllers/auth/registrations_controller_spec.rb
@@ -233,17 +233,7 @@ RSpec.describe Auth::RegistrationsController do
         Setting.registrations_mode = 'open'
         Fabricate(:email_domain_block, allow_with_approval: true, domain: 'mail.example.com')
         allow(User).to receive(:skip_mx_check?).and_return(false)
-
-        resolver = instance_double(Resolv::DNS, :timeouts= => nil)
-
-        allow(resolver).to receive(:getresources)
-          .with('example.com', Resolv::DNS::Resource::IN::MX)
-          .and_return([instance_double(Resolv::DNS::Resource::MX, exchange: 'mail.example.com')])
-        allow(resolver).to receive(:getresources).with('example.com', Resolv::DNS::Resource::IN::A).and_return([])
-        allow(resolver).to receive(:getresources).with('example.com', Resolv::DNS::Resource::IN::AAAA).and_return([])
-        allow(resolver).to receive(:getresources).with('mail.example.com', Resolv::DNS::Resource::IN::A).and_return([instance_double(Resolv::DNS::Resource::IN::A, address: '2.3.4.5')])
-        allow(resolver).to receive(:getresources).with('mail.example.com', Resolv::DNS::Resource::IN::AAAA).and_return([instance_double(Resolv::DNS::Resource::IN::AAAA, address: 'fd00::2')])
-        allow(Resolv::DNS).to receive(:open).and_yield(resolver)
+        configure_mx(domain: 'example.com', exchange: 'mail.example.com')
       end
 
       it 'creates unapproved user and redirects to setup' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -113,6 +113,7 @@ RSpec.configure do |config|
   config.include ActiveSupport::Testing::TimeHelpers
   config.include Chewy::Rspec::Helpers
   config.include Redisable
+  config.include DomainHelpers
   config.include ThreadingHelpers
   config.include SignedRequestHelpers, type: :request
   config.include CommandLineHelpers, type: :cli

--- a/spec/services/app_sign_up_service_spec.rb
+++ b/spec/services/app_sign_up_service_spec.rb
@@ -53,17 +53,7 @@ RSpec.describe AppSignUpService do
         Setting.registrations_mode = 'open'
         Fabricate(:email_domain_block, allow_with_approval: true, domain: 'smtp.email.com')
         allow(User).to receive(:skip_mx_check?).and_return(false)
-
-        resolver = instance_double(Resolv::DNS, :timeouts= => nil)
-
-        allow(resolver).to receive(:getresources)
-          .with('email.com', Resolv::DNS::Resource::IN::MX)
-          .and_return([instance_double(Resolv::DNS::Resource::MX, exchange: 'smtp.email.com')])
-        allow(resolver).to receive(:getresources).with('email.com', Resolv::DNS::Resource::IN::A).and_return([])
-        allow(resolver).to receive(:getresources).with('email.com', Resolv::DNS::Resource::IN::AAAA).and_return([])
-        allow(resolver).to receive(:getresources).with('smtp.email.com', Resolv::DNS::Resource::IN::A).and_return([instance_double(Resolv::DNS::Resource::IN::A, address: '2.3.4.5')])
-        allow(resolver).to receive(:getresources).with('smtp.email.com', Resolv::DNS::Resource::IN::AAAA).and_return([instance_double(Resolv::DNS::Resource::IN::AAAA, address: 'fd00::2')])
-        allow(Resolv::DNS).to receive(:open).and_yield(resolver)
+        configure_mx(domain: 'email.com', exchange: 'smtp.email.com')
       end
 
       it 'creates an unapproved user', :aggregate_failures do

--- a/spec/support/domain_helpers.rb
+++ b/spec/support/domain_helpers.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module DomainHelpers
+  def configure_mx(domain:, exchange:, ip_v4_addr: '2.3.4.5', ip_v6_addr: 'fd00::2')
+    resolver = instance_double(Resolv::DNS, :timeouts= => nil)
+
+    allow(resolver).to receive(:getresources)
+      .with(domain, Resolv::DNS::Resource::IN::MX)
+      .and_return([double_mx(exchange)])
+    allow(resolver)
+      .to receive(:getresources)
+      .with(domain, Resolv::DNS::Resource::IN::A)
+      .and_return([])
+    allow(resolver)
+      .to receive(:getresources)
+      .with(domain, Resolv::DNS::Resource::IN::AAAA)
+      .and_return([])
+    allow(resolver)
+      .to receive(:getresources)
+      .with(exchange, Resolv::DNS::Resource::IN::A)
+      .and_return([double_resource_v4(ip_v4_addr)])
+    allow(resolver)
+      .to receive(:getresources)
+      .with(exchange, Resolv::DNS::Resource::IN::AAAA)
+      .and_return([double_resource_v6(ip_v6_addr)])
+    allow(Resolv::DNS)
+      .to receive(:open)
+      .and_yield(resolver)
+  end
+
+  private
+
+  def double_mx(exchange)
+    instance_double(Resolv::DNS::Resource::MX, exchange: exchange)
+  end
+
+  def double_resource_v4(addr)
+    instance_double(Resolv::DNS::Resource::IN::A, address: addr)
+  end
+
+  def double_resource_v6(addr)
+    instance_double(Resolv::DNS::Resource::IN::AAAA, address: addr)
+  end
+end


### PR DESCRIPTION
These two examples have the same (pretty verbose!) stub setup process, with the exception of the domain/exchange they are working with. Extract that to shared helper.

Usefully - neither of them assert anything on the double, they just need the DNS responses stubbed.

Future work here -- the email mx validator spec has a similar-but-not-exact sort of thing going on. Could probably fold that one in here as well, but I wanted to start with two which were exactly the same. I also think some of the validator specs (including that one) should be updated to stop stubbing the SUT (ie, assert on errors/object/results directly, not that `add` was called, etc) - and maybe do that in advance of any other changes there.