### PR TITLE
Fix mastodon-streaming@.service's PORT escaping

### DIFF
--- a/dist/mastodon-streaming@.service
+++ b/dist/mastodon-streaming@.service
@@ -10,7 +10,7 @@ Type=simple
 User=mastodon
 WorkingDirectory=/home/mastodon/live
 Environment="NODE_ENV=production"
-Environment="PORT=%i"
+Environment="PORT=%I"
 ExecStart=/usr/bin/node ./streaming
 TimeoutSec=15
 Restart=always


### PR DESCRIPTION
Noticed this whilst doing a system upgrade. See: https://unix.stackexchange.com/questions/396978/specifier-resolution-i-and-i-difference