### PR TITLE
Fix IDs not being serialized as strings in annual reports API

### DIFF
--- a/app/lib/annual_report/commonly_interacted_with_accounts.rb
+++ b/app/lib/annual_report/commonly_interacted_with_accounts.rb
@@ -7,7 +7,7 @@ class AnnualReport::CommonlyInteractedWithAccounts < AnnualReport::Source
     {
       commonly_interacted_with_accounts: commonly_interacted_with_accounts.map do |(account_id, count)|
                                            {
-                                             account_id: account_id,
+                                             account_id: account_id.to_s,
                                              count: count,
                                            }
                                          end,

--- a/app/lib/annual_report/most_reblogged_accounts.rb
+++ b/app/lib/annual_report/most_reblogged_accounts.rb
@@ -7,7 +7,7 @@ class AnnualReport::MostRebloggedAccounts < AnnualReport::Source
     {
       most_reblogged_accounts: most_reblogged_accounts.map do |(account_id, count)|
                                  {
-                                   account_id: account_id,
+                                   account_id: account_id.to_s,
                                    count: count,
                                  }
                                end,

--- a/app/lib/annual_report/top_statuses.rb
+++ b/app/lib/annual_report/top_statuses.rb
@@ -8,9 +8,9 @@ class AnnualReport::TopStatuses < AnnualReport::Source
 
     {
       top_statuses: {
-        by_reblogs: top_reblogs,
-        by_favourites: top_favourites,
-        by_replies: top_replies,
+        by_reblogs: top_reblogs&.to_s,
+        by_favourites: top_favourites&.to_s,
+        by_replies: top_replies&.to_s,
       },
     }
   end

--- a/spec/lib/annual_report/commonly_interacted_with_accounts_spec.rb
+++ b/spec/lib/annual_report/commonly_interacted_with_accounts_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe AnnualReport::CommonlyInteractedWithAccounts do
         expect(subject.generate)
           .to include(
             commonly_interacted_with_accounts: contain_exactly(
-              include(account_id: other_account.id, count: 2)
+              include(account_id: other_account.id.to_s, count: 2)
             )
           )
       end

--- a/spec/lib/annual_report/most_reblogged_accounts_spec.rb
+++ b/spec/lib/annual_report/most_reblogged_accounts_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe AnnualReport::MostRebloggedAccounts do
         expect(subject.generate)
           .to include(
             most_reblogged_accounts: contain_exactly(
-              include(account_id: other_account.id, count: 2)
+              include(account_id: other_account.id.to_s, count: 2)
             )
           )
       end

--- a/spec/lib/annual_report/top_statuses_spec.rb
+++ b/spec/lib/annual_report/top_statuses_spec.rb
@@ -39,9 +39,9 @@ RSpec.describe AnnualReport::TopStatuses do
         expect(subject.generate)
           .to include(
             top_statuses: include(
-              by_reblogs: reblogged_status.id,
-              by_favourites: favourited_status.id,
-              by_replies: replied_status.id
+              by_reblogs: reblogged_status.id.to_s,
+              by_favourites: favourited_status.id.to_s,
+              by_replies: replied_status.id.to_s
             )
           )
       end


### PR DESCRIPTION
Follow-up to #28693. IDs not being serialized as strings leads to integer overflow in JavaScript.