### PR TITLE
Fix 'unknown' media attachment rendering in detailed view

### DIFF
--- a/app/javascript/mastodon/features/status/components/detailed_status.tsx
+++ b/app/javascript/mastodon/features/status/components/detailed_status.tsx
@@ -152,7 +152,7 @@ export const DetailedStatus: React.FC<{
     media = <PictureInPicturePlaceholder aspectRatio={attachmentAspectRatio} />;
   } else if (status.get('media_attachments').size > 0) {
     if (
-      ['image', 'gifv'].includes(
+      ['image', 'gifv', 'unknown'].includes(
         status.getIn(['media_attachments', 0, 'type']) as string,
       ) ||
       status.get('media_attachments').size > 1


### PR DESCRIPTION
I followed the fix by @ThisIsMissEm in #32613, this relates to #32595 and fixes the same issue in the detailed view.

I noticed that if I displayed a toot I would still not see the media, this fixes it.
