### PR TITLE
Update `rails-i18n` to version 7.0.10

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -654,7 +654,7 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
-    rails-i18n (7.0.9)
+    rails-i18n (7.0.10)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 8)
     railties (7.1.4.2)


### PR DESCRIPTION
https://github.com/mastodon/mastodon/pull/32686 but w/out the rackup bump.