### PR TITLE
Update `zeitwerk` to version 2.7.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -893,7 +893,7 @@ GEM
     xorcist (1.1.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.18)
+    zeitwerk (2.7.1)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
After https://github.com/mastodon/mastodon/pull/32363 we can bump this as well. Keeps getting picked up as side effect of others.