### PR TITLE
Add support for numeric-based URIs for local accounts

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -71,6 +71,10 @@ class AccountsController < ApplicationController
     params[:username]
   end
 
+  def account_id_param
+    params[:id]
+  end
+
   def skip_temporary_suspension_response?
     request.format == :json
   end

--- a/app/controllers/activitypub/likes_controller.rb
+++ b/app/controllers/activitypub/likes_controller.rb
@@ -28,7 +28,7 @@ class ActivityPub::LikesController < ActivityPub::BaseController
 
   def likes_collection_presenter
     ActivityPub::CollectionPresenter.new(
-      id: account_status_likes_url(@account, @status),
+      id: ActivityPub::TagManager.instance.likes_uri_for(@status),
       type: :unordered,
       size: @status.favourites_count
     )

--- a/app/controllers/activitypub/outboxes_controller.rb
+++ b/app/controllers/activitypub/outboxes_controller.rb
@@ -73,6 +73,8 @@ class ActivityPub::OutboxesController < ActivityPub::BaseController
   end
 
   def set_account
-    @account = params[:account_username].present? ? Account.find_local!(username_param) : Account.representative
+    return super if params[:account_username].present? || params[:account_id].present?
+
+    @account = Account.representative
   end
 end

--- a/app/controllers/activitypub/replies_controller.rb
+++ b/app/controllers/activitypub/replies_controller.rb
@@ -37,7 +37,7 @@ class ActivityPub::RepliesController < ActivityPub::BaseController
 
   def replies_collection_presenter
     page = ActivityPub::CollectionPresenter.new(
-      id: account_status_replies_url(@account, @status, page_params),
+      id: ActivityPub::TagManager.instance.replies_uri_for(@status, page_params),
       type: :unordered,
       part_of: account_status_replies_url(@account, @status),
       next: next_page,
@@ -47,7 +47,7 @@ class ActivityPub::RepliesController < ActivityPub::BaseController
     return page if page_requested?
 
     ActivityPub::CollectionPresenter.new(
-      id: account_status_replies_url(@account, @status),
+      id: ActivityPub::TagManager.instance.replies_uri_for(@status),
       type: :unordered,
       first: page
     )
@@ -66,8 +66,7 @@ class ActivityPub::RepliesController < ActivityPub::BaseController
       # Only consider remote accounts
       return nil if @replies.size < DESCENDANTS_LIMIT
 
-      account_status_replies_url(
-        @account,
+      ActivityPub::TagManager.instance.replies_uri_for(
         @status,
         page: true,
         min_id: @replies&.last&.id,
@@ -77,8 +76,7 @@ class ActivityPub::RepliesController < ActivityPub::BaseController
       # For now, we're serving only self-replies, but next page might be other accounts
       next_only_other_accounts = @replies&.last&.account_id != @account.id || @replies.size < DESCENDANTS_LIMIT
 
-      account_status_replies_url(
-        @account,
+      ActivityPub::TagManager.instance.replies_uri_for(
         @status,
         page: true,
         min_id: next_only_other_accounts ? nil : @replies&.last&.id,

--- a/app/controllers/activitypub/shares_controller.rb
+++ b/app/controllers/activitypub/shares_controller.rb
@@ -28,7 +28,7 @@ class ActivityPub::SharesController < ActivityPub::BaseController
 
   def shares_collection_presenter
     ActivityPub::CollectionPresenter.new(
-      id: account_status_shares_url(@account, @status),
+      id: ActivityPub::TagManager.instance.shares_uri_for(@status),
       type: :unordered,
       size: @status.reblogs_count
     )

--- a/app/controllers/concerns/account_owned_concern.rb
+++ b/app/controllers/concerns/account_owned_concern.rb
@@ -18,7 +18,11 @@ module AccountOwnedConcern
   end
 
   def set_account
-    @account = Account.find_local!(username_param)
+    @account = username_param.present? ? Account.find_local!(username_param) : Account.local.find(account_id_param)
+  end
+
+  def account_id_param
+    params[:account_id]
   end
 
   def username_param

--- a/app/controllers/follower_accounts_controller.rb
+++ b/app/controllers/follower_accounts_controller.rb
@@ -60,17 +60,17 @@ class FollowerAccountsController < ApplicationController
   def collection_presenter
     if page_requested?
       ActivityPub::CollectionPresenter.new(
-        id: account_followers_url(@account, page: params.fetch(:page, 1)),
+        id: page_url(params.fetch(:page, 1)),
         type: :ordered,
         size: @account.followers_count,
         items: follows.map { |follow| ActivityPub::TagManager.instance.uri_for(follow.account) },
-        part_of: account_followers_url(@account),
+        part_of: ActivityPub::TagManager.instance.followers_uri_for(@account),
         next: next_page_url,
         prev: prev_page_url
       )
     else
       ActivityPub::CollectionPresenter.new(
-        id: account_followers_url(@account),
+        id: ActivityPub::TagManager.instance.followers_uri_for(@account),
         type: :ordered,
         size: @account.followers_count,
         first: page_url(1)

--- a/app/controllers/following_accounts_controller.rb
+++ b/app/controllers/following_accounts_controller.rb
@@ -49,7 +49,7 @@ class FollowingAccountsController < ApplicationController
   end
 
   def page_url(page)
-    account_following_index_url(@account, page: page) unless page.nil?
+    ActivityPub::TagManager.instance.following_uri_for(@account, page: page) unless page.nil?
   end
 
   def next_page_url
@@ -63,17 +63,17 @@ class FollowingAccountsController < ApplicationController
   def collection_presenter
     if page_requested?
       ActivityPub::CollectionPresenter.new(
-        id: account_following_index_url(@account, page: params.fetch(:page, 1)),
+        id: page_url(params.fetch(:page, 1)),
         type: :ordered,
         size: @account.following_count,
         items: follows.map { |follow| ActivityPub::TagManager.instance.uri_for(follow.target_account) },
-        part_of: account_following_index_url(@account),
+        part_of: ActivityPub::TagManager.instance.following_uri_for(@account),
         next: next_page_url,
         prev: prev_page_url
       )
     else
       ActivityPub::CollectionPresenter.new(
-        id: account_following_index_url(@account),
+        id: ActivityPub::TagManager.instance.following_uri_for(@account),
         type: :ordered,
         size: @account.following_count,
         first: page_url(1)

--- a/app/lib/activitypub/tag_manager.rb
+++ b/app/lib/activitypub/tag_manager.rb
@@ -290,10 +290,9 @@ class ActivityPub::TagManager
 
     path_params = Rails.application.routes.recognize_path(uri)
 
-    # TODO: handle numeric IDs
     case path_params[:controller]
     when 'accounts'
-      [:username, path_params[:username]]
+      path_params.key?(:username) ? [:username, path_params[:username]] : [:id, path_params[:id]]
     when 'instance_actors'
       [:id, -99]
     end

--- a/app/lib/activitypub/tag_manager.rb
+++ b/app/lib/activitypub/tag_manager.rb
@@ -39,13 +39,25 @@ class ActivityPub::TagManager
 
     case target.object_type
     when :person
-      target.instance_actor? ? instance_actor_url : account_url(target)
+      if target.instance_actor?
+        instance_actor_url
+      elsif target.numeric_ap_id?
+        ap_account_url(target.id)
+      else
+        account_url(target)
+      end
     when :conversation
       context_url(target) unless target.parent_account_id.nil? || target.parent_status_id.nil?
     when :note, :comment, :activity
-      return activity_account_status_url(target.account, target) if target.reblog?
+      if target.account.numeric_ap_id?
+        return activity_ap_account_status_url(target.account, target) if target.reblog?
 
-      account_status_url(target.account, target)
+        ap_account_status_url(target.account.id, target)
+      else
+        return activity_account_status_url(target.account, target) if target.reblog?
+
+        account_status_url(target.account, target)
+      end
     when :emoji
       emoji_url(target)
     when :flag
@@ -57,7 +69,7 @@ class ActivityPub::TagManager
     return quote.approval_uri unless quote.quoted_account&.local?
     return if check_approval && !quote.accepted?
 
-    account_quote_authorization_url(quote.quoted_account, quote)
+    quote.quoted_account.numeric_ap_id? ? ap_account_quote_authorization_url(quote.quoted_account_id, quote) : account_quote_authorization_url(quote.quoted_account, quote)
   end
 
   def key_uri_for(target)
@@ -68,6 +80,10 @@ class ActivityPub::TagManager
     account_url(username: username)
   end
 
+  def uri_for_account_id(id)
+    ap_account_url(id: id)
+  end
+
   def generate_uri_for(_target)
     URI.join(root_url, 'payloads', SecureRandom.uuid)
   end
@@ -75,7 +91,7 @@ class ActivityPub::TagManager
   def activity_uri_for(target)
     raise ArgumentError, 'target must be a local activity' unless %i(note comment activity).include?(target.object_type) && target.local?
 
-    activity_account_status_url(target.account, target)
+    target.account.numeric_ap_id? ? activity_ap_account_status_url(target.account.id, target) : activity_account_status_url(target.account, target)
   end
 
   def context_uri_for(target, page_params = nil)
@@ -87,49 +103,61 @@ class ActivityPub::TagManager
   def replies_uri_for(target, page_params = nil)
     raise ArgumentError, 'target must be a local activity' unless %i(note comment activity).include?(target.object_type) && target.local?
 
-    account_status_replies_url(target.account, target, page_params)
+    target.account.numeric_ap_id? ? ap_account_status_replies_url(target.account.id, target, page_params) : account_status_replies_url(target.account, target, page_params)
   end
 
   def likes_uri_for(target)
     raise ArgumentError, 'target must be a local activity' unless %i(note comment activity).include?(target.object_type) && target.local?
 
-    account_status_likes_url(target.account, target)
+    target.account.numeric_ap_id? ? ap_account_status_likes_url(target.account.id, target) : account_status_likes_url(target.account, target)
   end
 
   def shares_uri_for(target)
     raise ArgumentError, 'target must be a local activity' unless %i(note comment activity).include?(target.object_type) && target.local?
 
-    account_status_shares_url(target.account, target)
+    target.account.numeric_ap_id? ? ap_account_status_shares_url(target.account.id, target) : account_status_shares_url(target.account, target)
   end
 
   def following_uri_for(target, ...)
     raise ArgumentError, 'target must be a local account' unless target.local?
 
-    account_following_index_url(target, ...)
+    target.numeric_ap_id? ? ap_account_following_index_url(target.id, ...) : account_following_index_url(target, ...)
   end
 
   def followers_uri_for(target, ...)
     return target.followers_url.presence unless target.local?
 
-    account_followers_url(target, ...)
+    target.numeric_ap_id? ? ap_account_followers_url(target.id, ...) : account_followers_url(target, ...)
   end
 
   def collection_uri_for(target, ...)
-    raise NotImplementedError unless target.local?
+    raise ArgumentError, 'target must be a local account' unless target.local?
 
-    account_collection_url(target, ...)
+    target.numeric_ap_id? ? ap_account_collection_url(target.id, ...) : account_collection_url(target, ...)
   end
 
   def inbox_uri_for(target)
-    raise NotImplementedError unless target.local?
+    raise ArgumentError, 'target must be a local account' unless target.local?
 
-    target.instance_actor? ? instance_actor_inbox_url : account_inbox_url(target)
+    if target.instance_actor?
+      instance_actor_inbox_url
+    elsif target.numeric_ap_id?
+      ap_account_inbox_url(target.id)
+    else
+      account_inbox_url(target)
+    end
   end
 
   def outbox_uri_for(target, ...)
-    raise NotImplementedError unless target.local?
+    raise ArgumentError, 'target must be a local account' unless target.local?
 
-    target.instance_actor? ? instance_actor_outbox_url(...) : account_outbox_url(target, ...)
+    if target.instance_actor?
+      instance_actor_outbox_url(...)
+    elsif target.numeric_ap_id?
+      ap_account_outbox_url(target.id, ...)
+    else
+      account_outbox_url(target, ...)
+    end
   end
 
   # Primary audience of a status

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -52,6 +52,7 @@
 #  requested_review_at           :datetime
 #  indexable                     :boolean          default(FALSE), not null
 #  attribution_domains           :string           default([]), is an Array
+#  id_scheme                     :integer          default("username_ap_id")
 #
 
 class Account < ApplicationRecord
@@ -105,6 +106,7 @@ class Account < ApplicationRecord
 
   enum :protocol, { ostatus: 0, activitypub: 1 }
   enum :suspension_origin, { local: 0, remote: 1 }, prefix: true
+  enum :id_scheme, { username_ap_id: 0, numeric_ap_id: 1 }
 
   validates :username, presence: true
   validates_with UniqueUsernameValidator, if: -> { will_save_change_to_username? }
@@ -185,11 +187,6 @@ class Account < ApplicationRecord
   delegate :chosen_languages, to: :user, prefix: false, allow_nil: true
 
   update_index('accounts', :self)
-
-  def numeric_ap_id?
-    # TODO: this is a placeholder for now
-    false
-  end
 
   def local?
     domain.nil?

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -186,6 +186,11 @@ class Account < ApplicationRecord
 
   update_index('accounts', :self)
 
+  def numeric_ap_id?
+    # TODO: this is a placeholder for now
+    false
+  end
+
   def local?
     domain.nil?
   end

--- a/app/models/concerns/account/interactions.rb
+++ b/app/models/concerns/account/interactions.rb
@@ -215,8 +215,10 @@ module Account::Interactions
   def local_followers_hash
     Rails.cache.fetch("followers_hash:#{id}:local") do
       digest = "\x00" * 32
-      followers.where(domain: nil).pluck_each(:username) do |username|
-        Xorcist.xor!(digest, Digest::SHA256.digest(ActivityPub::TagManager.instance.uri_for_username(username)))
+      # TODO
+      followers.where(domain: nil).pluck_each('false as numeric_ap_id', :id, :username) do |numeric_ap_id, id, username|
+        uri = numeric_ap_id ? ActivityPub::TagManager.instance.uri_for_account_id(id) : ActivityPub::TagManager.instance.uri_for_username(username)
+        Xorcist.xor!(digest, Digest::SHA256.digest(uri))
       end
       digest.unpack1('H*')
     end

--- a/app/models/concerns/account/interactions.rb
+++ b/app/models/concerns/account/interactions.rb
@@ -215,9 +215,8 @@ module Account::Interactions
   def local_followers_hash
     Rails.cache.fetch("followers_hash:#{id}:local") do
       digest = "\x00" * 32
-      # TODO
-      followers.where(domain: nil).pluck_each('false as numeric_ap_id', :id, :username) do |numeric_ap_id, id, username|
-        uri = numeric_ap_id ? ActivityPub::TagManager.instance.uri_for_account_id(id) : ActivityPub::TagManager.instance.uri_for_username(username)
+      followers.where(domain: nil).pluck_each(:id_scheme, :id, :username) do |id_scheme, id, username|
+        uri = id_scheme == 'numeric_ap_id' ? ActivityPub::TagManager.instance.uri_for_account_id(id) : ActivityPub::TagManager.instance.uri_for_username(username)
         Xorcist.xor!(digest, Digest::SHA256.digest(uri))
       end
       digest.unpack1('H*')

--- a/app/workers/activitypub/delivery_worker.rb
+++ b/app/workers/activitypub/delivery_worker.rb
@@ -55,7 +55,7 @@ class ActivityPub::DeliveryWorker
   end
 
   def synchronization_header
-    "collectionId=\"#{account_followers_url(@source_account)}\", digest=\"#{@source_account.remote_followers_hash(@inbox_url)}\", url=\"#{account_followers_synchronization_url(@source_account)}\""
+    "collectionId=\"#{ActivityPub::TagManager.instance.followers_uri_for(@source_account)}\", digest=\"#{@source_account.remote_followers_hash(@inbox_url)}\", url=\"#{account_followers_synchronization_url(@source_account)}\""
   end
 
   def perform_request

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,7 +95,20 @@ Rails.application.routes.draw do
 
   get '/authorize_follow', to: redirect { |_, request| "/authorize_interaction?#{request.params.to_query}" }
 
-  resources :accounts, path: 'users', only: [:show], param: :username do
+  concern :account_resources do
+    resources :followers, only: [:index], controller: :follower_accounts
+    resources :following, only: [:index], controller: :following_accounts
+
+    scope module: :activitypub do
+      resource :outbox, only: [:show]
+      resource :inbox, only: [:create]
+      resources :collections, only: [:show]
+      resource :followers_synchronization, only: [:show]
+      resources :quote_authorizations, only: [:show]
+    end
+  end
+
+  resources :accounts, path: 'users', only: [:show], param: :username, concerns: :account_resources do
     resources :statuses, only: [:show] do
       member do
         get :activity
@@ -106,16 +119,19 @@ Rails.application.routes.draw do
       resources :likes, only: [:index], module: :activitypub
       resources :shares, only: [:index], module: :activitypub
     end
+  end
 
-    resources :followers, only: [:index], controller: :follower_accounts
-    resources :following, only: [:index], controller: :following_accounts
+  scope path: 'ap', as: 'ap' do
+    resources :accounts, path: 'users', only: [:show], param: :id, concerns: :account_resources do
+      resources :statuses, module: :activitypub, only: [:show] do
+        member do
+          get :activity
+        end
 
-    scope module: :activitypub do
-      resource :outbox, only: [:show]
-      resource :inbox, only: [:create]
-      resources :collections, only: [:show]
-      resource :followers_synchronization, only: [:show]
-      resources :quote_authorizations, only: [:show]
+        resources :replies, only: [:index]
+        resources :likes, only: [:index]
+        resources :shares, only: [:index]
+      end
     end
   end
 

--- a/db/migrate/20250924170259_add_id_scheme_to_accounts.rb
+++ b/db/migrate/20250924170259_add_id_scheme_to_accounts.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIdSchemeToAccounts < ActiveRecord::Migration[8.0]
+  def change
+    add_column :accounts, :id_scheme, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_12_082651) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_24_170259) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -199,6 +199,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_12_082651) do
     t.boolean "indexable", default: false, null: false
     t.string "attribution_domains", default: [], array: true
     t.string "following_url", default: "", null: false
+    t.integer "id_scheme", default: 0
     t.index "(((setweight(to_tsvector('simple'::regconfig, (display_name)::text), 'A'::\"char\") || setweight(to_tsvector('simple'::regconfig, (username)::text), 'B'::\"char\")) || setweight(to_tsvector('simple'::regconfig, (COALESCE(domain, ''::character varying))::text), 'C'::\"char\")))", name: "search_index", using: :gin
     t.index "lower((username)::text), COALESCE(lower((domain)::text), ''::text)", name: "index_accounts_on_username_and_domain_lower", unique: true
     t.index ["domain", "id"], name: "index_accounts_on_domain_and_id"

--- a/spec/lib/activitypub/tag_manager_spec.rb
+++ b/spec/lib/activitypub/tag_manager_spec.rb
@@ -29,6 +29,15 @@ RSpec.describe ActivityPub::TagManager do
         expect(subject.url_for(account))
           .to eq("#{host_prefix}/@#{account.username}")
       end
+
+      context 'when using a numeric ID based scheme' do
+        let(:account) { Fabricate(:account, id_scheme: :numeric_ap_id) }
+
+        it 'returns a string starting with web domain and with the expected path' do
+          expect(subject.url_for(account))
+            .to eq("#{host_prefix}/@#{account.username}")
+        end
+      end
     end
 
     context 'with a remote account' do
@@ -45,6 +54,16 @@ RSpec.describe ActivityPub::TagManager do
       it 'returns a string starting with web domain and with the expected path' do
         expect(subject.url_for(status))
           .to eq("#{host_prefix}/@#{status.account.username}/#{status.id}")
+      end
+
+      context 'when using a numeric ID based scheme' do
+        let(:account) { Fabricate(:account, id_scheme: :numeric_ap_id) }
+        let(:status) { Fabricate(:status, account: account) }
+
+        it 'returns a string starting with web domain and with the expected path' do
+          expect(subject.url_for(status))
+            .to eq("#{host_prefix}/@#{status.account.username}/#{status.id}")
+        end
       end
     end
 
@@ -73,6 +92,15 @@ RSpec.describe ActivityPub::TagManager do
         expect(subject.uri_for(account))
           .to eq("#{host_prefix}/users/#{account.username}")
       end
+
+      context 'when using a numeric ID based scheme' do
+        let(:account) { Fabricate(:account, id_scheme: :numeric_ap_id) }
+
+        it 'returns a string starting with web domain and with the expected path' do
+          expect(subject.uri_for(account))
+            .to eq("#{host_prefix}/ap/users/#{account.id}")
+        end
+      end
     end
 
     context 'with a remote account' do
@@ -89,6 +117,16 @@ RSpec.describe ActivityPub::TagManager do
       it 'returns a string starting with web domain and with the expected path' do
         expect(subject.uri_for(status))
           .to eq("#{host_prefix}/users/#{status.account.username}/statuses/#{status.id}")
+      end
+
+      context 'when using a numeric ID based scheme' do
+        let(:account) { Fabricate(:account, id_scheme: :numeric_ap_id) }
+        let(:status) { Fabricate(:status, account: account) }
+
+        it 'returns a string starting with web domain and with the expected path' do
+          expect(subject.uri_for(status))
+            .to eq("#{host_prefix}/ap/users/#{status.account.id}/statuses/#{status.id}")
+        end
       end
     end
 
@@ -107,6 +145,16 @@ RSpec.describe ActivityPub::TagManager do
       it 'returns a string starting with web domain and with the expected path' do
         expect(subject.uri_for(status.conversation))
           .to eq("#{host_prefix}/contexts/#{status.account.id}-#{status.id}")
+      end
+
+      context 'when using a numeric ID based scheme' do
+        let(:account) { Fabricate(:account, id_scheme: :numeric_ap_id) }
+        let(:status) { Fabricate(:status, account: account) }
+
+        it 'returns a string starting with web domain and with the expected path' do
+          expect(subject.uri_for(status.conversation))
+            .to eq("#{host_prefix}/contexts/#{status.account.id}-#{status.id}")
+        end
       end
     end
 
@@ -139,6 +187,15 @@ RSpec.describe ActivityPub::TagManager do
         expect(subject.key_uri_for(account))
           .to eq("#{host_prefix}/users/#{account.username}#main-key")
       end
+
+      context 'when using a numeric ID based scheme' do
+        let(:account) { Fabricate(:account, id_scheme: :numeric_ap_id) }
+
+        it 'returns a string starting with web domain and with the expected path' do
+          expect(subject.key_uri_for(account))
+            .to eq("#{host_prefix}/ap/users/#{account.id}#main-key")
+        end
+      end
     end
   end
 
@@ -167,6 +224,17 @@ RSpec.describe ActivityPub::TagManager do
         expect(subject.approval_uri_for(quote))
           .to eq("#{host_prefix}/users/#{quote.quoted_account.username}/quote_authorizations/#{quote.id}")
       end
+
+      context 'when using a numeric ID based scheme' do
+        let(:quoted_account) { Fabricate(:account, id_scheme: :numeric_ap_id) }
+        let(:quoted_status) { Fabricate(:status, account: quoted_account) }
+        let(:quote) { Fabricate(:quote, state: :accepted, quoted_status: quoted_status) }
+
+        it 'returns a string with the web domain and expected path' do
+          expect(subject.approval_uri_for(quote))
+            .to eq("#{host_prefix}/ap/users/#{quote.quoted_account_id}/quote_authorizations/#{quote.id}")
+        end
+      end
     end
 
     context 'with an unapproved local quote' do
@@ -175,6 +243,17 @@ RSpec.describe ActivityPub::TagManager do
       it 'returns nil' do
         expect(subject.approval_uri_for(quote))
           .to be_nil
+      end
+
+      context 'when using a numeric ID based scheme' do
+        let(:quoted_account) { Fabricate(:account, id_scheme: :numeric_ap_id) }
+        let(:quoted_status) { Fabricate(:status, account: quoted_account) }
+        let(:quote) { Fabricate(:quote, state: :rejected, quoted_status: quoted_status) }
+
+        it 'returns nil' do
+          expect(subject.approval_uri_for(quote))
+            .to be_nil
+        end
       end
     end
 
@@ -195,6 +274,17 @@ RSpec.describe ActivityPub::TagManager do
         expect(subject.approval_uri_for(quote, check_approval: false))
           .to eq("#{host_prefix}/users/#{quote.quoted_account.username}/quote_authorizations/#{quote.id}")
       end
+
+      context 'when using a numeric ID based scheme' do
+        let(:quoted_account) { Fabricate(:account, id_scheme: :numeric_ap_id) }
+        let(:quoted_status) { Fabricate(:status, account: quoted_account) }
+        let(:quote) { Fabricate(:quote, state: :rejected, quoted_status: quoted_status) }
+
+        it 'returns a string with the web domain and expected path' do
+          expect(subject.approval_uri_for(quote, check_approval: false))
+            .to eq("#{host_prefix}/ap/users/#{quote.quoted_account_id}/quote_authorizations/#{quote.id}")
+        end
+      end
     end
   end
 
@@ -205,6 +295,16 @@ RSpec.describe ActivityPub::TagManager do
       it 'returns a string starting with web domain and with the expected path' do
         expect(subject.replies_uri_for(status))
           .to eq("#{host_prefix}/users/#{status.account.username}/statuses/#{status.id}/replies")
+      end
+
+      context 'when using a numeric ID based scheme' do
+        let(:account) { Fabricate(:account, id_scheme: :numeric_ap_id) }
+        let(:status) { Fabricate(:status, account: account) }
+
+        it 'returns a string starting with web domain and with the expected path' do
+          expect(subject.replies_uri_for(status))
+            .to eq("#{host_prefix}/ap/users/#{status.account.id}/statuses/#{status.id}/replies")
+        end
       end
     end
   end
@@ -217,6 +317,16 @@ RSpec.describe ActivityPub::TagManager do
         expect(subject.likes_uri_for(status))
           .to eq("#{host_prefix}/users/#{status.account.username}/statuses/#{status.id}/likes")
       end
+
+      context 'when using a numeric ID based scheme' do
+        let(:account) { Fabricate(:account, id_scheme: :numeric_ap_id) }
+        let(:status) { Fabricate(:status, account: account) }
+
+        it 'returns a string starting with web domain and with the expected path' do
+          expect(subject.likes_uri_for(status))
+            .to eq("#{host_prefix}/ap/users/#{status.account.id}/statuses/#{status.id}/likes")
+        end
+      end
     end
   end
 
@@ -227,6 +337,16 @@ RSpec.describe ActivityPub::TagManager do
       it 'returns a string starting with web domain and with the expected path' do
         expect(subject.shares_uri_for(status))
           .to eq("#{host_prefix}/users/#{status.account.username}/statuses/#{status.id}/shares")
+      end
+
+      context 'when using a numeric ID based scheme' do
+        let(:account) { Fabricate(:account, id_scheme: :numeric_ap_id) }
+        let(:status) { Fabricate(:status, account: account) }
+
+        it 'returns a string starting with web domain and with the expected path' do
+          expect(subject.shares_uri_for(status))
+            .to eq("#{host_prefix}/ap/users/#{status.account.id}/statuses/#{status.id}/shares")
+        end
       end
     end
   end
@@ -239,6 +359,15 @@ RSpec.describe ActivityPub::TagManager do
         expect(subject.following_uri_for(account))
           .to eq("#{host_prefix}/users/#{account.username}/following")
       end
+
+      context 'when using a numeric ID based scheme' do
+        let(:account) { Fabricate(:account, id_scheme: :numeric_ap_id) }
+
+        it 'returns a string starting with web domain and with the expected path' do
+          expect(subject.following_uri_for(account))
+            .to eq("#{host_prefix}/ap/users/#{account.id}/following")
+        end
+      end
     end
   end
 
@@ -249,6 +378,15 @@ RSpec.describe ActivityPub::TagManager do
       it 'returns a string starting with web domain and with the expected path' do
         expect(subject.followers_uri_for(account))
           .to eq("#{host_prefix}/users/#{account.username}/followers")
+      end
+
+      context 'when using a numeric ID based scheme' do
+        let(:account) { Fabricate(:account, id_scheme: :numeric_ap_id) }
+
+        it 'returns a string starting with web domain and with the expected path' do
+          expect(subject.followers_uri_for(account))
+            .to eq("#{host_prefix}/ap/users/#{account.id}/followers")
+        end
       end
     end
   end
@@ -268,6 +406,15 @@ RSpec.describe ActivityPub::TagManager do
         expect(subject.inbox_uri_for(account))
           .to eq("#{host_prefix}/users/#{account.username}/inbox")
       end
+
+      context 'when using a numeric ID based scheme' do
+        let(:account) { Fabricate(:account, id_scheme: :numeric_ap_id) }
+
+        it 'returns a string starting with web domain and with the expected path' do
+          expect(subject.inbox_uri_for(account))
+            .to eq("#{host_prefix}/ap/users/#{account.id}/inbox")
+        end
+      end
     end
   end
 
@@ -286,6 +433,15 @@ RSpec.describe ActivityPub::TagManager do
         expect(subject.outbox_uri_for(account))
           .to eq("#{host_prefix}/users/#{account.username}/outbox")
       end
+
+      context 'when using a numeric ID based scheme' do
+        let(:account) { Fabricate(:account, id_scheme: :numeric_ap_id) }
+
+        it 'returns a string starting with web domain and with the expected path' do
+          expect(subject.outbox_uri_for(account))
+            .to eq("#{host_prefix}/ap/users/#{account.id}/outbox")
+        end
+      end
     end
   end
 
@@ -300,16 +456,28 @@ RSpec.describe ActivityPub::TagManager do
       expect(subject.to(status)).to eq [account_followers_url(status.account)]
     end
 
+    it 'returns followers collection for unlisted status when using a numeric ID based scheme' do
+      status = Fabricate(:status, visibility: :unlisted, account: Fabricate(:account, id_scheme: :numeric_ap_id))
+      expect(subject.to(status)).to eq [ap_account_followers_url(status.account_id)]
+    end
+
     it 'returns followers collection for private status' do
       status = Fabricate(:status, visibility: :private)
       expect(subject.to(status)).to eq [account_followers_url(status.account)]
     end
 
+    it 'returns followers collection for private status when using a numeric ID based scheme' do
+      status = Fabricate(:status, visibility: :private, account: Fabricate(:account, id_scheme: :numeric_ap_id))
+      expect(subject.to(status)).to eq [ap_account_followers_url(status.account_id)]
+    end
+
     it 'returns URIs of mentions for direct status' do
       status    = Fabricate(:status, visibility: :direct)
       mentioned = Fabricate(:account)
+      mentioned_numeric = Fabricate(:account, id_scheme: :numeric_ap_id)
       status.mentions.create(account: mentioned)
-      expect(subject.to(status)).to eq [subject.uri_for(mentioned)]
+      status.mentions.create(account: mentioned_numeric)
+      expect(subject.to(status)).to eq [subject.uri_for(mentioned), subject.uri_for(mentioned_numeric)]
     end
 
     it "returns URIs of mentioned group's followers for direct statuses to groups" do
@@ -350,6 +518,11 @@ RSpec.describe ActivityPub::TagManager do
       expect(subject.cc(status)).to eq [account_followers_url(status.account)]
     end
 
+    it 'returns followers collection for public status when using a numeric ID based scheme' do
+      status = Fabricate(:status, visibility: :public, account: Fabricate(:account, id_scheme: :numeric_ap_id))
+      expect(subject.cc(status)).to eq [ap_account_followers_url(status.account_id)]
+    end
+
     it 'returns public collection for unlisted status' do
       status = Fabricate(:status, visibility: :unlisted)
       expect(subject.cc(status)).to eq ['https://www.w3.org/ns/activitystreams#Public']
@@ -368,8 +541,10 @@ RSpec.describe ActivityPub::TagManager do
     it 'returns URIs of mentions for non-direct status' do
       status    = Fabricate(:status, visibility: :public)
       mentioned = Fabricate(:account)
+      mentioned_numeric = Fabricate(:account, id_scheme: :numeric_ap_id)
       status.mentions.create(account: mentioned)
-      expect(subject.cc(status)).to include(subject.uri_for(mentioned))
+      status.mentions.create(account: mentioned_numeric)
+      expect(subject.cc(status)).to include(subject.uri_for(mentioned), subject.uri_for(mentioned_numeric))
     end
 
     context 'with followers and requested followers' do

--- a/spec/models/concerns/account/interactions_spec.rb
+++ b/spec/models/concerns/account/interactions_spec.rb
@@ -563,6 +563,22 @@ RSpec.describe Account::Interactions do
       me.follow!(remote_alice)
       expect(remote_alice.local_followers_hash).to eq Digest::SHA256.hexdigest(ActivityPub::TagManager.instance.uri_for(me))
     end
+
+    context 'when using numeric ID based scheme' do
+      let(:me) { Fabricate(:account, username: 'Me', id_scheme: :numeric_ap_id) }
+
+      it 'returns correct hash for local users' do
+        expect(remote_alice.local_followers_hash).to eq Digest::SHA256.hexdigest(ActivityPub::TagManager.instance.uri_for(me))
+      end
+
+      it 'invalidates cache as needed when removing or adding followers' do
+        expect(remote_alice.local_followers_hash).to eq Digest::SHA256.hexdigest(ActivityPub::TagManager.instance.uri_for(me))
+        me.unfollow!(remote_alice)
+        expect(remote_alice.local_followers_hash).to eq '0000000000000000000000000000000000000000000000000000000000000000'
+        me.follow!(remote_alice)
+        expect(remote_alice.local_followers_hash).to eq Digest::SHA256.hexdigest(ActivityPub::TagManager.instance.uri_for(me))
+      end
+    end
   end
 
   describe 'muting an account' do

--- a/spec/requests/accounts_spec.rb
+++ b/spec/requests/accounts_spec.rb
@@ -5,6 +5,14 @@ require 'rails_helper'
 RSpec.describe 'Accounts show response' do
   let(:account) { Fabricate(:account) }
 
+  context 'with numeric-based identifiers' do
+    it 'returns http success' do
+      get "/ap/users/#{account.id}"
+
+      expect(response).to have_http_status(200)
+    end
+  end
+
   context 'with an unapproved account' do
     before { account.user.update(approved: false) }
 

--- a/spec/services/activitypub/synchronize_followers_service_spec.rb
+++ b/spec/services/activitypub/synchronize_followers_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ActivityPub::SynchronizeFollowersService do
   subject { described_class.new }
 
   let(:actor)          { Fabricate(:account, domain: 'example.com', uri: 'http://example.com/account', inbox_url: 'http://example.com/inbox') }
-  let(:alice)          { Fabricate(:account, username: 'alice') }
+  let(:alice)          { Fabricate(:account, username: 'alice', id_scheme: :numeric_ap_id) }
   let(:bob)            { Fabricate(:account, username: 'bob') }
   let(:eve)            { Fabricate(:account, username: 'eve') }
   let(:mallory)        { Fabricate(:account, username: 'mallory') }


### PR DESCRIPTION
This is work-in-progress.

The idea is to eventually switch new accounts to using snowflake-ID-based ActivityPub identifiers instead of embedding their username, so that username changes can be considered.

This PR is only one part of the required changes, with the other parts being:
- better handling remote username changes
- adapt the `ResolveURLService#process_url_from_db` workaround

---

Fixes MAS-331