### PR TITLE
Use `Tag#formatted_name` where relevant

### DIFF
--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -51,7 +51,7 @@ module SettingsHelper
 
   def post_link_to_featured_tag(tag)
     link_to(
-      "##{tag.display_name}",
+      tag.formatted_name,
       settings_featured_tags_path(featured_tag: { name: tag.name }),
       method: :post
     )

--- a/app/models/featured_tag.rb
+++ b/app/models/featured_tag.rb
@@ -30,6 +30,8 @@ class FeaturedTag < ApplicationRecord
 
   scope :by_name, ->(name) { joins(:tag).where(tag: { name: HashtagNormalizer.new.normalize(name) }) }
 
+  delegate :formatted_name, to: :tag
+
   LIMIT = 10
 
   def sign?

--- a/app/serializers/activitypub/actor_serializer.rb
+++ b/app/serializers/activitypub/actor_serializer.rb
@@ -182,7 +182,7 @@ class ActivityPub::ActorSerializer < ActivityPub::Serializer
     end
 
     def name
-      "##{object.name}"
+      object.formatted_name
     end
   end
 

--- a/app/serializers/activitypub/hashtag_serializer.rb
+++ b/app/serializers/activitypub/hashtag_serializer.rb
@@ -12,7 +12,7 @@ class ActivityPub::HashtagSerializer < ActivityPub::Serializer
   end
 
   def name
-    "##{object.display_name}"
+    object.formatted_name
   end
 
   def href

--- a/app/serializers/activitypub/note_serializer.rb
+++ b/app/serializers/activitypub/note_serializer.rb
@@ -287,7 +287,7 @@ class ActivityPub::NoteSerializer < ActivityPub::Serializer
     end
 
     def name
-      "##{object.name}"
+      object.formatted_name
     end
   end
 

--- a/app/views/tags/show.rss.ruby
+++ b/app/views/tags/show.rss.ruby
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSS::Builder.build do |doc|
-  doc.title("##{@tag.display_name}")
+  doc.title(@tag.formatted_name)
   doc.description(I18n.t('rss.descriptions.tag', hashtag: @tag.display_name))
   doc.link(tag_url(@tag))
   doc.last_build_date(@statuses.first.created_at) if @statuses.any?

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -115,14 +115,22 @@ RSpec.describe Tag do
   end
 
   describe '#formatted_name' do
-    it 'returns name with a proceeding hash symbol' do
-      tag = Fabricate(:tag, name: 'foo')
-      expect(tag.formatted_name).to eq '#foo'
+    context 'when display name is not present' do
+      let(:tag) { Fabricate.build :tag, name: 'foo' }
+
+      it 'returns name with a preceding hash symbol' do
+        expect(tag.formatted_name)
+          .to eq '#foo'
+      end
     end
 
-    it 'returns display_name with a proceeding hash symbol, if display name present' do
-      tag = Fabricate(:tag, name: 'foobar', display_name: 'FooBar')
-      expect(tag.formatted_name).to eq '#FooBar'
+    context 'when display name is present' do
+      let(:tag) { Fabricate.build :tag, name: 'foobar', display_name: 'FooBar' }
+
+      it 'returns display_name with a preceding hash symbol' do
+        expect(tag.formatted_name)
+          .to eq '#FooBar'
+      end
     end
   end
 


### PR DESCRIPTION
Added in https://github.com/mastodon/mastodon/pull/30880/files#diff-175888239adc2b81ed2e4e82f0ee0663be0677f376e1aa1d9151baa69596e546R78-R80 but not broadly applied at the time.

In spec - add context, fix typo, use unsaved records (method does not need DB hit).

Across app - switch to this method instead of interpolate/join approach.