### PR TITLE
Reduce factory generation in `AccountStatusesFilter` spec

### DIFF
--- a/spec/lib/account_statuses_filter_spec.rb
+++ b/spec/lib/account_statuses_filter_spec.rb
@@ -52,36 +52,24 @@ RSpec.describe AccountStatusesFilter do
     end
 
     shared_examples 'filter params' do
-      context 'with only_media param' do
-        let(:params) { { only_media: true } }
+      it 'respects param options in results' do
+        expect(results_for(only_media: true))
+          .to all(satisfy(&:with_media?))
 
-        it 'returns only statuses with media' do
-          expect(subject.all?(&:with_media?)).to be true
-        end
+        expect(results_for(tagged: tag.name))
+          .to all(satisfy { |status| status.tags.include?(tag) })
+
+        expect(results_for(exclude_replies: true))
+          .to all(satisfy { |status| !status.reply? })
+
+        expect(results_for(exclude_reblogs: true))
+          .to all(satisfy { |status| !status.reblog? })
       end
 
-      context 'with tagged param' do
-        let(:params) { { tagged: tag.name } }
-
-        it 'returns only statuses with tag' do
-          expect(subject.all? { |s| s.tags.include?(tag) }).to be true
-        end
-      end
-
-      context 'with exclude_replies param' do
-        let(:params) { { exclude_replies: true } }
-
-        it 'returns only statuses that are not replies' do
-          expect(subject.none?(&:reply?)).to be true
-        end
-      end
-
-      context 'with exclude_reblogs param' do
-        let(:params) { { exclude_reblogs: true } }
-
-        it 'returns only statuses that are not reblogs' do
-          expect(subject.none?(&:reblog?)).to be true
-        end
+      def results_for(params)
+        described_class
+          .new(account, current_account, params)
+          .results
       end
     end
 


### PR DESCRIPTION
Reduces from 454 to 268.

This is similar to others in that there's this outer shared example which all the other examples that exercise different scenarios then call.

All the variations in the shared example are starting with the same data setup, they just vary on what params they pass in.

Possible future thing to look at for this one (and other filters) ... it would almost make more sense here to pass the params to `#results`, not to the initializer. Could be worth reviewing the batch of them and the call sites and see how that would look.