### PR TITLE
Update browser to version 6.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'ruby-vips', '~> 2.2', require: false
 gem 'active_model_serializers', '~> 0.10'
 gem 'addressable', '~> 2.8'
 gem 'bootsnap', '~> 1.18.0', require: false
-gem 'browser', '< 6' # https://github.com/fnando/browser/issues/543
+gem 'browser'
 gem 'charlock_holmes', '~> 0.7.7'
 gem 'chewy', '~> 7.3'
 gem 'devise', '~> 4.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,7 +133,7 @@ GEM
       msgpack (~> 1.2)
     brakeman (6.2.2)
       racc
-    browser (5.3.1)
+    browser (6.0.0)
     brpoplpush-redis_script (0.1.3)
       concurrent-ruby (~> 1.0, >= 1.0.5)
       redis (>= 1.0, < 6)
@@ -908,7 +908,7 @@ DEPENDENCIES
   blurhash (~> 0.1)
   bootsnap (~> 1.18.0)
   brakeman (~> 6.0)
-  browser (< 6)
+  browser
   bundler-audit (~> 0.9)
   capybara (~> 3.39)
   charlock_holmes (~> 0.7.7)


### PR DESCRIPTION
Another one enabled by https://github.com/mastodon/mastodon/pull/32363

The 6.0 release on browser gem side was some performance improvements, and bumping min ruby to 3.2, so I think this is good now.