### PR TITLE
Drop support for `ruby` version 3.2

### DIFF
--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -124,7 +124,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '3.2'
           - '.ruby-version'
     steps:
       - uses: actions/checkout@v4
@@ -225,7 +224,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '3.2'
           - '.ruby-version'
     steps:
       - uses: actions/checkout@v4
@@ -303,7 +301,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '3.2'
           - '.ruby-version'
 
     steps:
@@ -419,7 +416,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '3.2'
           - '.ruby-version'
         search-image:
           - docker.elastic.co/elasticsearch/elasticsearch:7.17.13

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ AllCops:
     - lib/mastodon/migration_helpers.rb
   ExtraDetails: true
   NewCops: enable
-  TargetRubyVersion: 3.2 # Oldest supported ruby version
+  TargetRubyVersion: 3.3 # Oldest supported ruby version
 
 inherit_from:
   - .rubocop/layout.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,6 @@ AllCops:
     - lib/mastodon/migration_helpers.rb
   ExtraDetails: true
   NewCops: enable
-  TargetRubyVersion: 3.3 # Oldest supported ruby version
 
 inherit_from:
   - .rubocop/layout.yml

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
-ruby '>= 3.2.0'
+ruby file: '.ruby-version'
 
 gem 'propshaft'
 gem 'puma', '~> 6.3'

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Mastodon acts as an OAuth2 provider, so 3rd party apps can use the REST and Stre
 
 - **PostgreSQL** 12+
 - **Redis** 4+
-- **Ruby** 3.2+
+- **Ruby** 3.3+
 - **Node.js** 18+
 
 The repository includes deployment configurations for **Docker and docker-compose** as well as specific platforms like **Heroku**, and **Scalingo**. For Helm charts, reference the [mastodon/chart repository](https://github.com/mastodon/chart). The [**standalone** installation guide](https://docs.joinmastodon.org/admin/install/) is available in the documentation.


### PR DESCRIPTION
Opening as draft after https://github.com/mastodon/mastodon/pull/32363#pullrequestreview-2408256601

Zero expectation for this to even get contemplated until either post-4.4-release and/or post-ruby-3.4 release. I'll watch CI, keep it rebased, etc.

Basically same deal as last few drops, would get us down to one supported version (3.3) which as of now is latest stable. Expectation would be everyone either runs via Docker (using 3.3.5 as of today), or follows instructions for rbenv (or similar tool) and manually updates to match `.ruby-version` (also 3.3.5 as of today).

For now I've left the CI matrix configuration in place, but if we did ever want to go down to just one supported version there are a few conditional things in there which either do or dont do something based on being ruby-version, and we could remove those along with the matrix.

Great potential for reducing greenhouse gas emissions here.

🌳 