### PR TITLE
Remove postgres version support check for `REINDEX` in migration

### DIFF
--- a/db/post_migrate/20230803082451_add_unique_index_on_preview_cards_statuses.rb
+++ b/db/post_migrate/20230803082451_add_unique_index_on_preview_cards_statuses.rb
@@ -15,21 +15,10 @@ class AddUniqueIndexOnPreviewCardsStatuses < ActiveRecord::Migration[6.1]
 
   private
 
-  def supports_concurrent_reindex?
-    @supports_concurrent_reindex ||= begin
-      ActiveRecord::Base.connection.database_version >= 120_000
-    end
-  end
-
   def deduplicate_and_reindex!
     deduplicate_preview_cards!
 
-    if supports_concurrent_reindex?
-      safety_assured { execute 'REINDEX INDEX CONCURRENTLY preview_cards_statuses_pkey' }
-    else
-      remove_index :preview_cards_statuses, name: :preview_cards_statuses_pkey
-      add_index :preview_cards_statuses, [:status_id, :preview_card_id], name: :preview_cards_statuses_pkey, algorithm: :concurrently, unique: true
-    end
+    safety_assured { execute 'REINDEX INDEX CONCURRENTLY preview_cards_statuses_pkey' }
   rescue ActiveRecord::RecordNotUnique
     retry
   end


### PR DESCRIPTION
We have version 12+ as a requirement so presumably can remove this check?

Any DB that hasn't run this migration yet but is running current main code will run into the `pre_migration_check` code and bail out before this is even attempted.