### PR TITLE
Drop support for `Postgres` version 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Mastodon acts as an OAuth2 provider, so 3rd party apps can use the REST and Stre
 
 ### Requirements
 
-- **PostgreSQL** 12+
+- **PostgreSQL** 13+
 - **Redis** 4+
 - **Ruby** 3.2+
 - **Node.js** 18+

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -44,7 +44,7 @@ namespace :db do
 
   task pre_migration_check: :environment do
     version = ActiveRecord::Base.connection.database_version
-    abort 'This version of Mastodon requires PostgreSQL 12.0 or newer. Please update PostgreSQL before updating Mastodon.' if version < 120_000
+    abort 'This version of Mastodon requires PostgreSQL 13.0 or newer. Please update PostgreSQL before updating Mastodon.' if version < 130_000
   end
 
   Rake::Task['db:migrate'].enhance(['db:pre_migration_check'])


### PR DESCRIPTION
Version 12 is EOL in about ~2 weeks.

We currently require 12+, but are using 14 in the Dockerfile ... presumably anyone running from recent releases is running 14 or higher already and this would be low impact?

Mostly opening because we should contemplate a more automated version to version migration strategy.

I believe the last version bump was a somewhat manual "run these steps to do a sql dump, update, restart, import, etc" sort of thing. Would be nice to have something at least as well documented in release notes whenever we need to, and/or do some automation. I believe at this point in time anyone coming from at least 12+ to any of the newer versions could utilize the upgrade script distributed with PG and which (I think?) is expected to work for any supported version to any newer version. 

Might be tricky to automate in a way that is resilient to various deploy envs - not sure.

We have ~2 years until 14 is EOL, so this is ... not urgent.
