### PR TITLE
Ensure push notification IDs are strings

### DIFF
--- a/app/serializers/web/notification_serializer.rb
+++ b/app/serializers/web/notification_serializer.rb
@@ -17,7 +17,7 @@ class Web::NotificationSerializer < ActiveModel::Serializer
   end
 
   def notification_id
-    object.id
+    object.id.to_s
   end
 
   def notification_type


### PR DESCRIPTION
From discord:
> It's been a long time since I looked at the code on my end, but I noticed that the notification_id field in the push notification payload is coming is as an int not a string in the JSON. This doesn't seem consistent with how the REST API works?

It looks like in the API notification serializers, we do `.to_s` on the notification ID, but in the web push notification serializer this was missed.

This is almost certainly a BREAKING CHANGE