### PR TITLE
Remove unused `usage` method from `REST::V1::InstanceSerializer`

### DIFF
--- a/app/serializers/rest/v1/instance_serializer.rb
+++ b/app/serializers/rest/v1/instance_serializer.rb
@@ -48,14 +48,6 @@ class REST::V1::InstanceSerializer < ActiveModel::Serializer
     { streaming_api: Rails.configuration.x.streaming_api_base_url }
   end
 
-  def usage
-    {
-      users: {
-        active_month: instance_presenter.active_user_count(4),
-      },
-    }
-  end
-
   def configuration
     {
       accounts: {


### PR DESCRIPTION
In the `AP::UpdatePollSerializer` -- it looks like this was added in original PR, but has never been used, and is not exposed via `attributes` call in the class. If it SHOULD be exposed, let me know and I'll do that separately.

In the instance serializer, this attribute was added in the v2 API update (handled by what is currently `serializers/rest/instance_serializer`) but does not exist in the V1 API, and is not included via the attributes call in the class. I assume it was added here via copy/paste or something when V2 version was added.