### PR TITLE
Disable `httplog` gem in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,7 @@ gem 'hiredis', '~> 0.6'
 gem 'htmlentities', '~> 4.3'
 gem 'http', '~> 5.2.0'
 gem 'http_accept_language', '~> 2.1'
-gem 'httplog', '~> 1.7.0'
+gem 'httplog', '~> 1.7.0', require: false
 gem 'i18n'
 gem 'idn-ruby', require: 'idn'
 gem 'inline_svg'

--- a/config/initializers/httplog.rb
+++ b/config/initializers/httplog.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
-HttpLog.configure do |config|
-  config.logger = Rails.logger
-  config.color = { color: :yellow }
-  config.compact_log = true
+# Disable httplog in production unless log_level is `debug`
+if !Rails.env.production? || Rails.configuration.log_level == :debug
+  require 'httplog'
+
+  HttpLog.configure do |config|
+    config.logger = Rails.logger
+    config.color = { color: :yellow }
+    config.compact_log = true
+  end
 end


### PR DESCRIPTION
Unless `log_level` is `debug`.

`httplog` is responsible for the regular expression timeout errors that some people experienced when we tried to set a timeout (see #32051). We removed the timeout but revisited the issue because rails 8 will set a timeout by default.

We found out that `httplog` will match a regular expression against the full request body, even on large file uploads.

Also, the original author advises against using it in production altogether.

This is a compromise that would disable `httplog` for most production setups, but allows re-enabling it for debugging purposes, i.e. when setting rails' log level to `debug`.