### PR TITLE
Avoid latest featured tag use on post removal unless necessary

### DIFF
--- a/app/models/featured_tag.rb
+++ b/app/models/featured_tag.rb
@@ -44,8 +44,16 @@ class FeaturedTag < ApplicationRecord
     update(statuses_count: statuses_count + 1, last_status_at: timestamp)
   end
 
-  def decrement(deleted_status_id)
-    update(statuses_count: [0, statuses_count - 1].max, last_status_at: visible_tagged_account_statuses.where.not(id: deleted_status_id).pick(:created_at))
+  def decrement(deleted_status)
+    if statuses_count <= 1
+      update(statuses_count: 0, last_status_at: nil)
+    elsif last_status_at > deleted_status.created_at
+      update(statuses_count: statuses_count - 1)
+    else
+      # Fetching the latest status creation time can be expensive, so only perform it
+      # if we know we are deleting the latest status using this tag
+      update(statuses_count: statuses_count - 1, last_status_at: visible_tagged_account_statuses.where(id: ...deleted_status.id).pick(:created_at))
+    end
   end
 
   private

--- a/app/services/process_hashtags_service.rb
+++ b/app/services/process_hashtags_service.rb
@@ -33,7 +33,7 @@ class ProcessHashtagsService < BaseService
 
     unless removed_tags.empty?
       @account.featured_tags.where(tag_id: removed_tags.map(&:id)).find_each do |featured_tag|
-        featured_tag.decrement(@status.id)
+        featured_tag.decrement(@status)
       end
     end
   end

--- a/app/services/remove_status_service.rb
+++ b/app/services/remove_status_service.rb
@@ -115,7 +115,7 @@ class RemoveStatusService < BaseService
 
   def remove_from_hashtags
     @account.featured_tags.where(tag_id: @status.tags.map(&:id)).find_each do |featured_tag|
-      featured_tag.decrement(@status.id)
+      featured_tag.decrement(@status)
     end
 
     return unless @status.public_visibility?


### PR DESCRIPTION
Fetching tagged posts for an account can be really slow, so avoid doing it if we can.

Currently, the most recent use of a featured tag is fetched on each post deletion featuring that tag.

This PR avoids it so it is only performed when the deletion is the latest known use of the featured tag. It also rewrites the remaining case in a way that should be a little more efficient.