### PR TITLE
Match dependency-generator output for `require_relative` usage

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,6 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require File.expand_path('config/application', __dir__)
+require_relative 'config/application'
 
 Rails.application.load_tasks

--- a/config.ru
+++ b/config.ru
@@ -2,5 +2,6 @@
 
 # This file is used by Rack-based servers to start the application.
 
-require File.expand_path('config/environment', __dir__)
+require_relative 'config/environment'
+
 run Rails.application

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -32,7 +32,7 @@ end
 STREAMING_PORT = ENV.fetch('TEST_STREAMING_PORT', '4020')
 ENV['STREAMING_API_BASE_URL'] = "http://localhost:#{STREAMING_PORT}"
 
-require File.expand_path('../config/environment', __dir__)
+require_relative '../config/environment'
 
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 


### PR DESCRIPTION
Noticed while doing https://github.com/mastodon/mastodon/pull/32335 and the rails upgrade `app:update` tasks. This is basically aligning a few files to what a fresh "generator" run would output.

There are some other rspec-related things that are sort of in the "prep for v4" family, which I want to review more first, and will do those separately.

_(We are well past whatever ruby version added this ... 1.9 maybe?)_

🏟️ 