### PR TITLE
Add `InetContainer` with scopes of `containing` and `contained`

### DIFF
--- a/app/helpers/registration_helper.rb
+++ b/app/helpers/registration_helper.rb
@@ -16,6 +16,6 @@ module RegistrationHelper
   end
 
   def ip_blocked?(remote_ip)
-    IpBlock.where(severity: :sign_up_block).exists?(['ip >>= ?', remote_ip.to_s])
+    IpBlock.where(severity: :sign_up_block).containing(remote_ip.to_s).exists?
   end
 end

--- a/app/lib/suspicious_sign_in_detector.rb
+++ b/app/lib/suspicious_sign_in_detector.rb
@@ -19,7 +19,7 @@ class SuspiciousSignInDetector
   end
 
   def previously_seen_ip?(request)
-    @user.ips.exists?(['ip <<= ?', masked_ip(request)])
+    @user.ips.contained_by(masked_ip(request)).exists?
   end
 
   def freshly_signed_up?

--- a/app/models/concerns/inet_container.rb
+++ b/app/models/concerns/inet_container.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module InetContainer
+  extend ActiveSupport::Concern
+
+  included do
+    scope :containing, ->(value) { where('ip >>= ?', value) }
+    scope :contained_by, ->(value) { where('ip <<= ?', value) }
+  end
+end

--- a/app/models/ip_block.rb
+++ b/app/models/ip_block.rb
@@ -17,6 +17,7 @@ class IpBlock < ApplicationRecord
   CACHE_KEY = 'blocked_ips'
 
   include Expireable
+  include InetContainer
   include Paginable
 
   enum :severity, {
@@ -29,9 +30,6 @@ class IpBlock < ApplicationRecord
   validates :ip, uniqueness: true
 
   after_commit :reset_cache
-
-  scope :containing, ->(value) { where('ip >>= ?', value) }
-  scope :contained_by, ->(value) { where('ip <<= ?', value) }
 
   def to_log_human_identifier
     "#{ip}/#{ip.prefix}"

--- a/app/models/ip_block.rb
+++ b/app/models/ip_block.rb
@@ -30,6 +30,9 @@ class IpBlock < ApplicationRecord
 
   after_commit :reset_cache
 
+  scope :containing, ->(value) { where('ip >>= ?', value) }
+  scope :contained_by, ->(value) { where('ip <<= ?', value) }
+
   def to_log_human_identifier
     "#{ip}/#{ip.prefix}"
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -125,7 +125,7 @@ class User < ApplicationRecord
   scope :signed_in_recently, -> { where(current_sign_in_at: ACTIVE_DURATION.ago..) }
   scope :not_signed_in_recently, -> { where(current_sign_in_at: ...ACTIVE_DURATION.ago) }
   scope :matches_email, ->(value) { where(arel_table[:email].matches("#{value}%")) }
-  scope :matches_ip, ->(value) { left_joins(:ips).where('user_ips.ip <<= ?', value).group('users.id') }
+  scope :matches_ip, ->(value) { left_joins(:ips).merge(IpBlock.contained_by(value)).group('users.id') }
 
   before_validation :sanitize_role
   before_create :set_approved
@@ -444,7 +444,7 @@ class User < ApplicationRecord
   end
 
   def sign_up_from_ip_requires_approval?
-    sign_up_ip.present? && IpBlock.severity_sign_up_requires_approval.exists?(['ip >>= ?', sign_up_ip.to_s])
+    sign_up_ip.present? && IpBlock.severity_sign_up_requires_approval.containing(sign_up_ip.to_s).exists?
   end
 
   def sign_up_email_requires_approval?

--- a/app/models/user_ip.rb
+++ b/app/models/user_ip.rb
@@ -11,13 +11,11 @@
 
 class UserIp < ApplicationRecord
   include DatabaseViewRecord
+  include InetContainer
 
   self.primary_key = :user_id
 
   belongs_to :user
 
   scope :by_latest_used, -> { order(used_at: :desc) }
-
-  scope :containing, ->(value) { where('ip >>= ?', value) }
-  scope :contained_by, ->(value) { where('ip <<= ?', value) }
 end

--- a/app/models/user_ip.rb
+++ b/app/models/user_ip.rb
@@ -17,4 +17,7 @@ class UserIp < ApplicationRecord
   belongs_to :user
 
   scope :by_latest_used, -> { order(used_at: :desc) }
+
+  scope :containing, ->(value) { where('ip >>= ?', value) }
+  scope :contained_by, ->(value) { where('ip <<= ?', value) }
 end

--- a/lib/mastodon/cli/ip_blocks.rb
+++ b/lib/mastodon/cli/ip_blocks.rb
@@ -80,9 +80,9 @@ module Mastodon::CLI
         end
 
         ip_blocks = if options[:force]
-                      IpBlock.where('ip >>= ?', address)
+                      IpBlock.containing(address)
                     else
-                      IpBlock.where('ip <<= ?', address)
+                      IpBlock.contained_by(address)
                     end
 
         if ip_blocks.empty?


### PR DESCRIPTION
As far as I can tell there is not a straightforward (ie, without jumping through some verbose arel construction) way to have framework generate the comparison for the PG inet operators.