### PR TITLE
Fix performance of dashboard metrics by periodically warming cache

### DIFF
--- a/app/javascript/mastodon/components/admin/Counter.jsx
+++ b/app/javascript/mastodon/components/admin/Counter.jsx
@@ -95,7 +95,7 @@ export default class Counter extends PureComponent {
 
         <div className='sparkline__graph'>
           {!loading && (
-            <Sparklines width={259} height={55} data={data[0].data.map(x => x.value * 1)}>
+            <Sparklines width={259} height={55} data={data[0].data.map(x => x.value * 1)} margin={0}>
               <SparklinesCurve />
             </Sparklines>
           )}

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -1315,12 +1315,18 @@ a.sparkline {
     &__key {
       font-weight: 500;
       padding: 11px 10px;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      overflow: hidden;
     }
 
     &__value {
       text-align: end;
       color: $darker-text-color;
       padding: 11px 10px;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      overflow: hidden;
     }
 
     &__indicator {

--- a/app/lib/admin/metrics/dimension/base_dimension.rb
+++ b/app/lib/admin/metrics/dimension/base_dimension.rb
@@ -39,6 +39,10 @@ class Admin::Metrics::Dimension::BaseDimension
     send(key) if respond_to?(key)
   end
 
+  def perform_for_cache!
+    Rails.cache.write(cache_key, perform_query, expires_in: CACHE_TTL)
+  end
+
   protected
 
   def load

--- a/app/lib/admin/metrics/measure/base_measure.rb
+++ b/app/lib/admin/metrics/measure/base_measure.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Admin::Metrics::Measure::BaseMeasure
-  CACHE_TTL = 5.minutes.freeze
+  CACHE_TTL = 3.hours.freeze
 
   def self.with_params?
     false
@@ -52,6 +52,10 @@ class Admin::Metrics::Measure::BaseMeasure
 
   def read_attribute_for_serialization(key)
     send(key) if respond_to?(key)
+  end
+
+  def perform_for_cache!
+    Rails.cache.write(cache_key, perform_queries, expires_in: CACHE_TTL)
   end
 
   protected

--- a/app/lib/admin/metrics/retention.rb
+++ b/app/lib/admin/metrics/retention.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Admin::Metrics::Retention
-  CACHE_TTL = 5.minutes.freeze
+  CACHE_TTL = 1.day.freeze
 
   class Cohort < ActiveModelSerializers::Model
     attributes :period, :frequency, :data
@@ -28,6 +28,10 @@ class Admin::Metrics::Retention
 
   def cohorts
     load
+  end
+
+  def perform_for_cache!
+    Rails.cache.write(cache_key, perform_query, expires_in: CACHE_TTL)
   end
 
   protected

--- a/app/views/admin/dashboard/index.html.haml
+++ b/app/views/admin/dashboard/index.html.haml
@@ -107,7 +107,7 @@
                             dimension: 'software_versions',
                             end_at: @time_period.last,
                             label: t('admin.dashboard.software'),
-                            limit: 4,
+                            limit: 8,
                             start_at: @time_period.first
 
   .dashboard__item
@@ -115,5 +115,5 @@
                             dimension: 'space_usage',
                             end_at: @time_period.last,
                             label: t('admin.dashboard.space'),
-                            limit: 3,
+                            limit: 8,
                             start_at: @time_period.first

--- a/app/workers/scheduler/admin/dashboard_cache_warmer_scheduler.rb
+++ b/app/workers/scheduler/admin/dashboard_cache_warmer_scheduler.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+class Scheduler::Admin::DashboardCacheWarmerScheduler
+  include Sidekiq::Worker
+
+  # The values in this file have to align with the values in app/views/admin/dashboard/index.html.haml
+  # so that the generated cache keys are the same, otherwise cache warming will have no benefit
+
+  MEASURES = %w(
+    new_users
+    active_users
+    interactions
+    opened_reports
+    resolved_reports
+  ).freeze
+
+  DIMENSIONS = %w(
+    sources
+    languages
+    servers
+    software_versions
+    space_usage
+  ).freeze
+
+  DIMENSION_LIMIT = 8
+
+  TIME_PERIOD_DAYS = 29
+
+  RETENTION_TIME_PERIOD_MONTHS = 6
+
+  def perform
+    @start_at = TIME_PERIOD_DAYS.days.ago.to_date
+    @end_at = Time.now.utc.to_date
+    @retention_start_at = @end_at - RETENTION_TIME_PERIOD_MONTHS.months
+    @retention_end_at = @end_at
+
+    warm_measures_cache!
+    warm_dimensions_cache!
+    warm_retention_cache!
+  end
+
+  private
+
+  def warm_measures_cache!
+    Admin::Metrics::Measure.retrieve(MEASURES, @start_at, @end_at, {}).each(&:perform_for_cache!)
+  end
+
+  def warm_dimensions_cache!
+    Admin::Metrics::Dimension.retrieve(DIMENSIONS, @start_at, @end_at, DIMENSION_LIMIT, {}).each(&:perform_for_cache!)
+  end
+
+  def warm_retention_cache!
+    Admin::Metrics::Retention.new(@retention_start_at, @retention_end_at, 'month').perform_for_cache!
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -67,3 +67,7 @@
       interval: 1 hour
       class: Scheduler::AutoCloseRegistrationsScheduler
       queue: scheduler
+    dashboard_cache_warmer_scheduler:
+      interval: 2 hours
+      class: Scheduler::Admin::DashboardCacheWarmerScheduler
+      queue: scheduler


### PR DESCRIPTION
Increase cache for metrics and dimensions from 5 minutes to 3 hours, and from 5 minutes to 1 day for retention, and run a job every 2 hours re-calculating the metrics and dimensions that the admin dashboard loads so that the cache is always available.