### PR TITLE
Add ability to forward a report in admin UI

### DIFF
--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -47,6 +47,13 @@ module Admin
       redirect_to admin_reports_path, notice: I18n.t('admin.reports.resolved_msg')
     end
 
+    def forward
+      authorize @report, :update?
+      ForwardReportService.new.call(@report)
+      log_action :forward, @report
+      redirect_to admin_report_path(@report), notice: I18n.t('admin.reports.forwarded_msg')
+    end
+
     private
 
     def filtered_reports

--- a/app/models/admin/action_log_filter.rb
+++ b/app/models/admin/action_log_filter.rb
@@ -51,6 +51,7 @@ class Admin::ActionLogFilter
     disable_user: { target_type: 'User', action: 'disable' }.freeze,
     enable_custom_emoji: { target_type: 'CustomEmoji', action: 'enable' }.freeze,
     enable_user: { target_type: 'User', action: 'enable' }.freeze,
+    forward_report: { target_type: 'Report', action: 'forward' }.freeze,
     memorialize_account: { target_type: 'Account', action: 'memorialize' }.freeze,
     promote_user: { target_type: 'User', action: 'promote' }.freeze,
     remove_avatar_user: { target_type: 'User', action: 'remove_avatar' }.freeze,

--- a/app/services/forward_report_service.rb
+++ b/app/services/forward_report_service.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class ForwardReportService < BaseService
+  include Payloadable
+
+  def call(report)
+    @report = report
+
+    forward_to_origin!
+    update_report!
+  end
+
+  private
+
+  def forward_to_origin!
+    ActivityPub::DeliveryWorker.perform_async(payload, some_local_account.id, @report.target_account.inbox_url)
+  end
+
+  def update_report!
+    @report.update(forwarded: true)
+  end
+
+  def payload
+    Oj.dump(serialize_payload(@report, ActivityPub::FlagSerializer, account: some_local_account))
+  end
+
+  def some_local_account
+    @some_local_account ||= Account.representative
+  end
+end

--- a/app/views/admin/reports/_header_details.html.haml
+++ b/app/views/admin/reports/_header_details.html.haml
@@ -11,15 +11,12 @@
       - if report.account.instance_actor?
         = site_hostname
       - elsif report.account.local?
-        = admin_account_link_to report.account
+        - if report.application.present?
+          = t('admin.reports.reported_via_html', name: admin_account_link_to(report.account), app: report.application.name)
+        - else
+          = admin_account_link_to report.account
       - else
         = report.account.domain
-  - if report.application.present?
-    .report-header__details__item
-      .report-header__details__item__header
-        %strong= t('admin.reports.reported_with_application')
-      .report-header__details__item__content
-        = report.application.name
   .report-header__details__item
     .report-header__details__item__header
       %strong= t('admin.reports.status')
@@ -37,6 +34,8 @@
           = t('simple_form.yes')
         - else
           = t('simple_form.no')
+          —
+          = table_link_to 'cloud_sync', t('admin.reports.forward', domain: report.target_account.domain), forward_admin_report_path(report), method: :post, data: { confirm: t('admin.reports.are_you_sure') }
   - if report.action_taken_by_account.present?
     .report-header__details__item
       .report-header__details__item__header

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -208,6 +208,7 @@ en:
         enable_custom_emoji: Enable Custom Emoji
         enable_sign_in_token_auth_user: Enable Email Token Authentication for User
         enable_user: Enable User
+        forward_report: Forward Report
         memorialize_account: Memorialize Account
         promote_user: Promote User
         reject_appeal: Reject Appeal
@@ -268,6 +269,7 @@ en:
         enable_custom_emoji_html: "%{name} enabled emoji %{target}"
         enable_sign_in_token_auth_user_html: "%{name} enabled email token authentication for %{target}"
         enable_user_html: "%{name} enabled login for user %{target}"
+        forward_report_html: "%{name} forwarded report %{target}"
         memorialize_account_html: "%{name} turned %{target}'s account into a memoriam page"
         promote_user_html: "%{name} promoted user %{target}"
         reject_appeal_html: "%{name} rejected moderation decision appeal from %{target}"
@@ -624,7 +626,9 @@ en:
       confirm_action: Confirm moderation action against @%{acct}
       created_at: Reported
       delete_and_resolve: Delete posts
+      forward: Forward to %{domain}
       forwarded: Forwarded
+      forwarded_msg: Report successfully forwarded!
       forwarded_replies_explanation: This report is from a remote user and about remote content. It has been forwarded to you because the reported content is in reply to one of your users.
       forwarded_to: Forwarded to %{domain}
       mark_as_resolved: Mark as resolved
@@ -646,6 +650,7 @@ en:
       report: 'Report #%{id}'
       reported_account: Reported account
       reported_by: Reported by
+      reported_via_html: "%{name} via %{app}"
       reported_with_application: Reported with application
       resolved: Resolved
       resolved_msg: Report successfully resolved!

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -102,6 +102,7 @@ namespace :admin do
       post :unassign
       post :reopen
       post :resolve
+      post :forward
     end
   end
 


### PR DESCRIPTION
- Add button to forward to origin if not already forwarded by reporter
- Combine "reported by" and "reported with application" to prevent empty space under header

![grafik](https://github.com/user-attachments/assets/78b7e1c0-3b2c-426c-86f7-6adf281b4aa9)

___

Fix #24681, fix #32138