### PR TITLE
Use `with_options` blocks in `Associations` concern

### DIFF
--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -16,6 +16,7 @@ module Account::Associations
       has_many :notification_requests, inverse_of: :account
       has_many :notifications, inverse_of: :account
       has_many :polls
+      has_many :reports, inverse_of: :account
       has_many :scheduled_statuses, inverse_of: :account
       has_many :status_pins, inverse_of: :account
       has_many :statuses, inverse_of: :account
@@ -30,7 +31,6 @@ module Account::Associations
     has_many :endorsed_accounts, through: :account_pins, class_name: 'Account', source: :target_account
 
     # Report relationships
-    has_many :reports, dependent: :destroy, inverse_of: :account
     has_many :targeted_reports, class_name: 'Report', foreign_key: :target_account_id, dependent: :destroy, inverse_of: :target_account
 
     has_many :report_notes, dependent: :destroy

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -6,6 +6,7 @@ module Account::Associations
   included do
     # Core associations
     with_options dependent: :destroy do
+      has_many :account_moderation_notes, inverse_of: :account
       has_many :account_pins, inverse_of: :account
       has_many :bookmarks, inverse_of: :account
       has_many :conversations, class_name: 'AccountConversation', inverse_of: :account
@@ -34,7 +35,6 @@ module Account::Associations
     has_many :endorsed_accounts, through: :account_pins, class_name: 'Account', source: :target_account
 
     # Moderation notes
-    has_many :account_moderation_notes, dependent: :destroy, inverse_of: :account
     has_many :targeted_moderation_notes, class_name: 'AccountModerationNote', foreign_key: :target_account_id, dependent: :destroy, inverse_of: :target_account
     has_many :account_warnings, dependent: :destroy, inverse_of: :account
     has_many :strikes, class_name: 'AccountWarning', foreign_key: :target_account_id, dependent: :destroy, inverse_of: :target_account

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -7,6 +7,7 @@ module Account::Associations
     # Core associations
     with_options dependent: :destroy do
       has_many :bookmarks, inverse_of: :account
+      has_many :conversations, class_name: 'AccountConversation', inverse_of: :account
       has_many :favourites, inverse_of: :account
       has_many :mentions, inverse_of: :account
       has_many :statuses, inverse_of: :account
@@ -14,7 +15,6 @@ module Account::Associations
     end
 
     # Timelines
-    has_many :conversations, class_name: 'AccountConversation', dependent: :destroy, inverse_of: :account
     has_many :scheduled_statuses, inverse_of: :account, dependent: :destroy
 
     # Notifications

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -47,25 +47,25 @@ module Account::Associations
       end
     end
 
-    # Pinned statuses
+    # Status records pinned by the account
     has_many :pinned_statuses, -> { reorder('status_pins.created_at DESC') }, through: :status_pins, class_name: 'Status', source: :status
 
-    # Endorsements
+    # Account records endorsed (pinned) by the account
     has_many :endorsed_accounts, through: :account_pins, class_name: 'Account', source: :target_account
 
-    # Lists (that the account is on, not owned by the account)
+    # List records the account has been added to (not owned by the account)
     has_many :lists, through: :list_accounts
 
-    # Account migrations
+    # Account record where account has been migrated
     belongs_to :moved_to_account, class_name: 'Account', optional: true
 
-    # Hashtags
+    # Tag records applied to account
     has_and_belongs_to_many :tags # rubocop:disable Rails/HasAndBelongsToMany
 
-    # Follow recommendations
+    # FollowRecommendation for account (surfaced via view)
     has_one :follow_recommendation, inverse_of: :account, dependent: nil
 
-    # Imports
+    # BulkImport records owned by account
     has_many :bulk_imports, inverse_of: :account, dependent: :delete_all
   end
 end

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -15,6 +15,7 @@ module Account::Associations
       has_many :notification_permissions, inverse_of: :account
       has_many :notification_requests, inverse_of: :account
       has_many :notifications, inverse_of: :account
+      has_many :polls
       has_many :scheduled_statuses, inverse_of: :account
       has_many :status_pins, inverse_of: :account
       has_many :statuses, inverse_of: :account
@@ -27,9 +28,6 @@ module Account::Associations
 
     # Endorsements
     has_many :endorsed_accounts, through: :account_pins, class_name: 'Account', source: :target_account
-
-    # Media
-    has_many :polls, dependent: :destroy
 
     # Report relationships
     has_many :reports, dependent: :destroy, inverse_of: :account

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -13,6 +13,7 @@ module Account::Associations
       has_many :conversations, class_name: 'AccountConversation', inverse_of: :account
       has_many :custom_filters, inverse_of: :account
       has_many :favourites, inverse_of: :account
+      has_many :list_accounts, inverse_of: :account
       has_many :media_attachments
       has_many :mentions, inverse_of: :account
       has_many :notification_permissions, inverse_of: :account
@@ -38,7 +39,6 @@ module Account::Associations
     has_many :endorsed_accounts, through: :account_pins, class_name: 'Account', source: :target_account
 
     # Lists (that the account is on, not owned by the account)
-    has_many :list_accounts, inverse_of: :account, dependent: :destroy
     has_many :lists, through: :list_accounts
 
     # Lists (owned by the account)

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -23,6 +23,7 @@ module Account::Associations
       has_many :scheduled_statuses, inverse_of: :account
       has_many :status_pins, inverse_of: :account
       has_many :statuses, inverse_of: :account
+      has_many :targeted_moderation_notes, class_name: 'AccountModerationNote', foreign_key: :target_account_id, inverse_of: :target_account
       has_many :targeted_reports, class_name: 'Report', foreign_key: :target_account_id, inverse_of: :target_account
       has_one :notification_policy, inverse_of: :account
       has_one :user, inverse_of: :account
@@ -35,7 +36,6 @@ module Account::Associations
     has_many :endorsed_accounts, through: :account_pins, class_name: 'Account', source: :target_account
 
     # Moderation notes
-    has_many :targeted_moderation_notes, class_name: 'AccountModerationNote', foreign_key: :target_account_id, dependent: :destroy, inverse_of: :target_account
     has_many :account_warnings, dependent: :destroy, inverse_of: :account
     has_many :strikes, class_name: 'AccountWarning', foreign_key: :target_account_id, dependent: :destroy, inverse_of: :target_account
 

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -31,6 +31,7 @@ module Account::Associations
         has_many :scheduled_statuses
         has_many :status_pins
         has_many :statuses
+
         has_one :deletion_request, class_name: 'AccountDeletionRequest'
         has_one :follow_recommendation_suppression
         has_one :notification_policy

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -16,6 +16,7 @@ module Account::Associations
       has_many :list_accounts, inverse_of: :account
       has_many :media_attachments
       has_many :mentions, inverse_of: :account
+      has_many :migrations, class_name: 'AccountMigration', inverse_of: :account
       has_many :notification_permissions, inverse_of: :account
       has_many :notification_requests, inverse_of: :account
       has_many :notifications, inverse_of: :account
@@ -46,7 +47,6 @@ module Account::Associations
 
     # Account migrations
     belongs_to :moved_to_account, class_name: 'Account', optional: true
-    has_many :migrations, class_name: 'AccountMigration', dependent: :destroy, inverse_of: :account
     has_many :aliases, class_name: 'AccountAlias', dependent: :destroy, inverse_of: :account
 
     # Hashtags

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -16,6 +16,7 @@ module Account::Associations
       has_many :notification_requests, inverse_of: :account
       has_many :notifications, inverse_of: :account
       has_many :polls
+      has_many :report_notes
       has_many :reports, inverse_of: :account
       has_many :scheduled_statuses, inverse_of: :account
       has_many :status_pins, inverse_of: :account
@@ -31,7 +32,6 @@ module Account::Associations
     # Endorsements
     has_many :endorsed_accounts, through: :account_pins, class_name: 'Account', source: :target_account
 
-    has_many :report_notes, dependent: :destroy
     has_many :custom_filters, inverse_of: :account, dependent: :destroy
 
     # Moderation notes

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -8,12 +8,12 @@ module Account::Associations
     with_options dependent: :destroy do
       has_many :bookmarks, inverse_of: :account
       has_many :favourites, inverse_of: :account
+      has_many :mentions, inverse_of: :account
       has_many :statuses, inverse_of: :account
       has_one :user, inverse_of: :account
     end
 
     # Timelines
-    has_many :mentions, inverse_of: :account, dependent: :destroy
     has_many :conversations, class_name: 'AccountConversation', dependent: :destroy, inverse_of: :account
     has_many :scheduled_statuses, inverse_of: :account, dependent: :destroy
 

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -9,6 +9,7 @@ module Account::Associations
       has_many :account_pins, inverse_of: :account
       has_many :bookmarks, inverse_of: :account
       has_many :conversations, class_name: 'AccountConversation', inverse_of: :account
+      has_many :custom_filters, inverse_of: :account
       has_many :favourites, inverse_of: :account
       has_many :media_attachments
       has_many :mentions, inverse_of: :account
@@ -31,8 +32,6 @@ module Account::Associations
 
     # Endorsements
     has_many :endorsed_accounts, through: :account_pins, class_name: 'Account', source: :target_account
-
-    has_many :custom_filters, inverse_of: :account, dependent: :destroy
 
     # Moderation notes
     has_many :account_moderation_notes, dependent: :destroy, inverse_of: :account

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -4,6 +4,11 @@ module Account::Associations
   extend ActiveSupport::Concern
 
   included do
+    # Core associations
+    with_options dependent: :destroy do
+      # TODO
+    end
+
     # Local users
     has_one :user, inverse_of: :account, dependent: :destroy
 

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -32,6 +32,7 @@ module Account::Associations
       has_many :strikes, class_name: 'AccountWarning', foreign_key: :target_account_id, inverse_of: :target_account
       has_many :targeted_moderation_notes, class_name: 'AccountModerationNote', foreign_key: :target_account_id, inverse_of: :target_account
       has_many :targeted_reports, class_name: 'Report', foreign_key: :target_account_id, inverse_of: :target_account
+      has_one :deletion_request, class_name: 'AccountDeletionRequest', inverse_of: :account
       has_one :notification_policy, inverse_of: :account
       has_one :user, inverse_of: :account
     end
@@ -50,9 +51,6 @@ module Account::Associations
 
     # Hashtags
     has_and_belongs_to_many :tags # rubocop:disable Rails/HasAndBelongsToMany
-
-    # Account deletion requests
-    has_one :deletion_request, class_name: 'AccountDeletionRequest', inverse_of: :account, dependent: :destroy
 
     # Follow recommendations
     has_one :follow_recommendation, inverse_of: :account, dependent: nil

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -24,6 +24,7 @@ module Account::Associations
       has_many :scheduled_statuses, inverse_of: :account
       has_many :status_pins, inverse_of: :account
       has_many :statuses, inverse_of: :account
+      has_many :strikes, class_name: 'AccountWarning', foreign_key: :target_account_id, inverse_of: :target_account
       has_many :targeted_moderation_notes, class_name: 'AccountModerationNote', foreign_key: :target_account_id, inverse_of: :target_account
       has_many :targeted_reports, class_name: 'Report', foreign_key: :target_account_id, inverse_of: :target_account
       has_one :notification_policy, inverse_of: :account
@@ -35,9 +36,6 @@ module Account::Associations
 
     # Endorsements
     has_many :endorsed_accounts, through: :account_pins, class_name: 'Account', source: :target_account
-
-    # Moderation notes
-    has_many :strikes, class_name: 'AccountWarning', foreign_key: :target_account_id, dependent: :destroy, inverse_of: :target_account
 
     # Lists (that the account is on, not owned by the account)
     has_many :list_accounts, inverse_of: :account, dependent: :destroy

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -35,6 +35,7 @@ module Account::Associations
       has_one :deletion_request, class_name: 'AccountDeletionRequest', inverse_of: :account
       has_one :follow_recommendation_suppression, inverse_of: :account
       has_one :notification_policy, inverse_of: :account
+      has_one :statuses_cleanup_policy, class_name: 'AccountStatusesCleanupPolicy', inverse_of: :account
       has_one :user, inverse_of: :account
     end
 
@@ -55,9 +56,6 @@ module Account::Associations
 
     # Follow recommendations
     has_one :follow_recommendation, inverse_of: :account, dependent: nil
-
-    # Account statuses cleanup policy
-    has_one :statuses_cleanup_policy, class_name: 'AccountStatusesCleanupPolicy', inverse_of: :account, dependent: :destroy
 
     # Imports
     has_many :bulk_imports, inverse_of: :account, dependent: :delete_all

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -11,6 +11,7 @@ module Account::Associations
       has_many :favourites, inverse_of: :account
       has_many :mentions, inverse_of: :account
       has_many :notification_permissions, inverse_of: :account
+      has_many :notification_requests, inverse_of: :account
       has_many :notifications, inverse_of: :account
       has_many :scheduled_statuses, inverse_of: :account
       has_many :statuses, inverse_of: :account
@@ -19,7 +20,6 @@ module Account::Associations
     end
 
     # Notifications
-    has_many :notification_requests, inverse_of: :account, dependent: :destroy
 
     # Pinned statuses
     has_many :status_pins, inverse_of: :account, dependent: :destroy

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -19,6 +19,7 @@ module Account::Associations
       has_many :notification_permissions, inverse_of: :account
       has_many :notification_requests, inverse_of: :account
       has_many :notifications, inverse_of: :account
+      has_many :owned_lists, class_name: 'List', inverse_of: :account
       has_many :polls
       has_many :report_notes
       has_many :reports, inverse_of: :account
@@ -42,7 +43,6 @@ module Account::Associations
     has_many :lists, through: :list_accounts
 
     # Lists (owned by the account)
-    has_many :owned_lists, class_name: 'List', dependent: :destroy, inverse_of: :account
 
     # Account migrations
     belongs_to :moved_to_account, class_name: 'Account', optional: true

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -10,13 +10,13 @@ module Account::Associations
       has_many :conversations, class_name: 'AccountConversation', inverse_of: :account
       has_many :favourites, inverse_of: :account
       has_many :mentions, inverse_of: :account
+      has_many :notifications, inverse_of: :account
       has_many :scheduled_statuses, inverse_of: :account
       has_many :statuses, inverse_of: :account
       has_one :user, inverse_of: :account
     end
 
     # Notifications
-    has_many :notifications, inverse_of: :account, dependent: :destroy
     has_one :notification_policy, inverse_of: :account, dependent: :destroy
     has_many :notification_permissions, inverse_of: :account, dependent: :destroy
     has_many :notification_requests, inverse_of: :account, dependent: :destroy

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -9,6 +9,7 @@ module Account::Associations
       has_many :account_moderation_notes, inverse_of: :account
       has_many :account_pins, inverse_of: :account
       has_many :account_warnings, inverse_of: :account
+      has_many :aliases, class_name: 'AccountAlias', inverse_of: :account
       has_many :bookmarks, inverse_of: :account
       has_many :conversations, class_name: 'AccountConversation', inverse_of: :account
       has_many :custom_filters, inverse_of: :account
@@ -45,7 +46,6 @@ module Account::Associations
 
     # Account migrations
     belongs_to :moved_to_account, class_name: 'Account', optional: true
-    has_many :aliases, class_name: 'AccountAlias', dependent: :destroy, inverse_of: :account
 
     # Hashtags
     has_and_belongs_to_many :tags # rubocop:disable Rails/HasAndBelongsToMany

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -43,8 +43,6 @@ module Account::Associations
     # Lists (that the account is on, not owned by the account)
     has_many :lists, through: :list_accounts
 
-    # Lists (owned by the account)
-
     # Account migrations
     belongs_to :moved_to_account, class_name: 'Account', optional: true
     has_many :aliases, class_name: 'AccountAlias', dependent: :destroy, inverse_of: :account

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -6,12 +6,12 @@ module Account::Associations
   included do
     # Core associations
     with_options dependent: :destroy do
+      has_many :favourites, inverse_of: :account
       has_many :statuses, inverse_of: :account
       has_one :user, inverse_of: :account
     end
 
     # Timelines
-    has_many :favourites, inverse_of: :account, dependent: :destroy
     has_many :bookmarks, inverse_of: :account, dependent: :destroy
     has_many :mentions, inverse_of: :account, dependent: :destroy
     has_many :conversations, class_name: 'AccountConversation', dependent: :destroy, inverse_of: :account

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -14,13 +14,13 @@ module Account::Associations
       has_many :notification_requests, inverse_of: :account
       has_many :notifications, inverse_of: :account
       has_many :scheduled_statuses, inverse_of: :account
+      has_many :status_pins, inverse_of: :account
       has_many :statuses, inverse_of: :account
       has_one :notification_policy, inverse_of: :account
       has_one :user, inverse_of: :account
     end
 
     # Pinned statuses
-    has_many :status_pins, inverse_of: :account, dependent: :destroy
     has_many :pinned_statuses, -> { reorder('status_pins.created_at DESC') }, through: :status_pins, class_name: 'Status', source: :status
 
     # Endorsements

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -6,11 +6,11 @@ module Account::Associations
   included do
     # Core associations
     with_options dependent: :destroy do
+      has_many :statuses, inverse_of: :account
       has_one :user, inverse_of: :account
     end
 
     # Timelines
-    has_many :statuses, inverse_of: :account, dependent: :destroy
     has_many :favourites, inverse_of: :account, dependent: :destroy
     has_many :bookmarks, inverse_of: :account, dependent: :destroy
     has_many :mentions, inverse_of: :account, dependent: :destroy

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -33,6 +33,7 @@ module Account::Associations
       has_many :targeted_moderation_notes, class_name: 'AccountModerationNote', foreign_key: :target_account_id, inverse_of: :target_account
       has_many :targeted_reports, class_name: 'Report', foreign_key: :target_account_id, inverse_of: :target_account
       has_one :deletion_request, class_name: 'AccountDeletionRequest', inverse_of: :account
+      has_one :follow_recommendation_suppression, inverse_of: :account
       has_one :notification_policy, inverse_of: :account
       has_one :user, inverse_of: :account
     end
@@ -54,7 +55,6 @@ module Account::Associations
 
     # Follow recommendations
     has_one :follow_recommendation, inverse_of: :account, dependent: nil
-    has_one :follow_recommendation_suppression, inverse_of: :account, dependent: :destroy
 
     # Account statuses cleanup policy
     has_one :statuses_cleanup_policy, class_name: 'AccountStatusesCleanupPolicy', inverse_of: :account, dependent: :destroy

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -14,6 +14,7 @@ module Account::Associations
       has_many :conversations, class_name: 'AccountConversation', inverse_of: :account
       has_many :custom_filters, inverse_of: :account
       has_many :favourites, inverse_of: :account
+      has_many :featured_tags, -> { includes(:tag) }, inverse_of: :account
       has_many :list_accounts, inverse_of: :account
       has_many :media_attachments
       has_many :mentions, inverse_of: :account
@@ -49,7 +50,6 @@ module Account::Associations
 
     # Hashtags
     has_and_belongs_to_many :tags # rubocop:disable Rails/HasAndBelongsToMany
-    has_many :featured_tags, -> { includes(:tag) }, dependent: :destroy, inverse_of: :account
 
     # Account deletion requests
     has_one :deletion_request, class_name: 'AccountDeletionRequest', inverse_of: :account, dependent: :destroy

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -20,6 +20,7 @@ module Account::Associations
       has_many :scheduled_statuses, inverse_of: :account
       has_many :status_pins, inverse_of: :account
       has_many :statuses, inverse_of: :account
+      has_many :targeted_reports, class_name: 'Report', foreign_key: :target_account_id, inverse_of: :target_account
       has_one :notification_policy, inverse_of: :account
       has_one :user, inverse_of: :account
     end
@@ -29,9 +30,6 @@ module Account::Associations
 
     # Endorsements
     has_many :endorsed_accounts, through: :account_pins, class_name: 'Account', source: :target_account
-
-    # Report relationships
-    has_many :targeted_reports, class_name: 'Report', foreign_key: :target_account_id, dependent: :destroy, inverse_of: :target_account
 
     has_many :report_notes, dependent: :destroy
     has_many :custom_filters, inverse_of: :account, dependent: :destroy

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -10,6 +10,7 @@ module Account::Associations
       has_many :conversations, class_name: 'AccountConversation', inverse_of: :account
       has_many :favourites, inverse_of: :account
       has_many :mentions, inverse_of: :account
+      has_many :notification_permissions, inverse_of: :account
       has_many :notifications, inverse_of: :account
       has_many :scheduled_statuses, inverse_of: :account
       has_many :statuses, inverse_of: :account
@@ -18,7 +19,6 @@ module Account::Associations
     end
 
     # Notifications
-    has_many :notification_permissions, inverse_of: :account, dependent: :destroy
     has_many :notification_requests, inverse_of: :account, dependent: :destroy
 
     # Pinned statuses

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -10,6 +10,7 @@ module Account::Associations
       has_many :bookmarks, inverse_of: :account
       has_many :conversations, class_name: 'AccountConversation', inverse_of: :account
       has_many :favourites, inverse_of: :account
+      has_many :media_attachments
       has_many :mentions, inverse_of: :account
       has_many :notification_permissions, inverse_of: :account
       has_many :notification_requests, inverse_of: :account
@@ -28,7 +29,6 @@ module Account::Associations
     has_many :endorsed_accounts, through: :account_pins, class_name: 'Account', source: :target_account
 
     # Media
-    has_many :media_attachments, dependent: :destroy
     has_many :polls, dependent: :destroy
 
     # Report relationships

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -6,11 +6,8 @@ module Account::Associations
   included do
     # Core associations
     with_options dependent: :destroy do
-      # TODO
+      has_one :user, inverse_of: :account
     end
-
-    # Local users
-    has_one :user, inverse_of: :account, dependent: :destroy
 
     # Timelines
     has_many :statuses, inverse_of: :account, dependent: :destroy

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -10,12 +10,10 @@ module Account::Associations
       has_many :conversations, class_name: 'AccountConversation', inverse_of: :account
       has_many :favourites, inverse_of: :account
       has_many :mentions, inverse_of: :account
+      has_many :scheduled_statuses, inverse_of: :account
       has_many :statuses, inverse_of: :account
       has_one :user, inverse_of: :account
     end
-
-    # Timelines
-    has_many :scheduled_statuses, inverse_of: :account, dependent: :destroy
 
     # Notifications
     has_many :notifications, inverse_of: :account, dependent: :destroy

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -6,13 +6,13 @@ module Account::Associations
   included do
     # Core associations
     with_options dependent: :destroy do
+      has_many :bookmarks, inverse_of: :account
       has_many :favourites, inverse_of: :account
       has_many :statuses, inverse_of: :account
       has_one :user, inverse_of: :account
     end
 
     # Timelines
-    has_many :bookmarks, inverse_of: :account, dependent: :destroy
     has_many :mentions, inverse_of: :account, dependent: :destroy
     has_many :conversations, class_name: 'AccountConversation', dependent: :destroy, inverse_of: :account
     has_many :scheduled_statuses, inverse_of: :account, dependent: :destroy

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -6,36 +6,39 @@ module Account::Associations
   included do
     # Core associations
     with_options dependent: :destroy do
-      has_many :account_moderation_notes, inverse_of: :account
-      has_many :account_pins, inverse_of: :account
-      has_many :account_warnings, inverse_of: :account
-      has_many :aliases, class_name: 'AccountAlias', inverse_of: :account
-      has_many :bookmarks, inverse_of: :account
-      has_many :conversations, class_name: 'AccountConversation', inverse_of: :account
-      has_many :custom_filters, inverse_of: :account
-      has_many :favourites, inverse_of: :account
-      has_many :featured_tags, -> { includes(:tag) }, inverse_of: :account
-      has_many :list_accounts, inverse_of: :account
-      has_many :media_attachments, inverse_of: :account
-      has_many :mentions, inverse_of: :account
-      has_many :migrations, class_name: 'AccountMigration', inverse_of: :account
-      has_many :notification_permissions, inverse_of: :account
-      has_many :notification_requests, inverse_of: :account
-      has_many :notifications, inverse_of: :account
-      has_many :owned_lists, class_name: 'List', inverse_of: :account
-      has_many :polls, inverse_of: :account
-      has_many :report_notes, inverse_of: :account
-      has_many :reports, inverse_of: :account
-      has_many :scheduled_statuses, inverse_of: :account
-      has_many :status_pins, inverse_of: :account
-      has_many :statuses, inverse_of: :account
-      has_one :deletion_request, class_name: 'AccountDeletionRequest', inverse_of: :account
-      has_one :follow_recommendation_suppression, inverse_of: :account
-      has_one :notification_policy, inverse_of: :account
-      has_one :statuses_cleanup_policy, class_name: 'AccountStatusesCleanupPolicy', inverse_of: :account
-      has_one :user, inverse_of: :account
+      # Association where account owns record
+      with_options inverse_of: :account do
+        has_many :account_moderation_notes
+        has_many :account_pins
+        has_many :account_warnings
+        has_many :aliases, class_name: 'AccountAlias'
+        has_many :bookmarks
+        has_many :conversations, class_name: 'AccountConversation'
+        has_many :custom_filters
+        has_many :favourites
+        has_many :featured_tags, -> { includes(:tag) }
+        has_many :list_accounts
+        has_many :media_attachments
+        has_many :mentions
+        has_many :migrations, class_name: 'AccountMigration'
+        has_many :notification_permissions
+        has_many :notification_requests
+        has_many :notifications
+        has_many :owned_lists, class_name: 'List'
+        has_many :polls
+        has_many :report_notes
+        has_many :reports
+        has_many :scheduled_statuses
+        has_many :status_pins
+        has_many :statuses
+        has_one :deletion_request, class_name: 'AccountDeletionRequest'
+        has_one :follow_recommendation_suppression
+        has_one :notification_policy
+        has_one :statuses_cleanup_policy, class_name: 'AccountStatusesCleanupPolicy'
+        has_one :user
+      end
 
-      # Association where account is targeted
+      # Association where account is targeted by record
       with_options foreign_key: :target_account_id, inverse_of: :target_account do
         has_many :strikes, class_name: 'AccountWarning'
         has_many :targeted_moderation_notes, class_name: 'AccountModerationNote'

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -6,6 +6,7 @@ module Account::Associations
   included do
     # Core associations
     with_options dependent: :destroy do
+      has_many :account_pins, inverse_of: :account
       has_many :bookmarks, inverse_of: :account
       has_many :conversations, class_name: 'AccountConversation', inverse_of: :account
       has_many :favourites, inverse_of: :account
@@ -24,7 +25,6 @@ module Account::Associations
     has_many :pinned_statuses, -> { reorder('status_pins.created_at DESC') }, through: :status_pins, class_name: 'Status', source: :status
 
     # Endorsements
-    has_many :account_pins, inverse_of: :account, dependent: :destroy
     has_many :endorsed_accounts, through: :account_pins, class_name: 'Account', source: :target_account
 
     # Media

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -29,14 +29,18 @@ module Account::Associations
       has_many :scheduled_statuses, inverse_of: :account
       has_many :status_pins, inverse_of: :account
       has_many :statuses, inverse_of: :account
-      has_many :strikes, class_name: 'AccountWarning', foreign_key: :target_account_id, inverse_of: :target_account
-      has_many :targeted_moderation_notes, class_name: 'AccountModerationNote', foreign_key: :target_account_id, inverse_of: :target_account
-      has_many :targeted_reports, class_name: 'Report', foreign_key: :target_account_id, inverse_of: :target_account
       has_one :deletion_request, class_name: 'AccountDeletionRequest', inverse_of: :account
       has_one :follow_recommendation_suppression, inverse_of: :account
       has_one :notification_policy, inverse_of: :account
       has_one :statuses_cleanup_policy, class_name: 'AccountStatusesCleanupPolicy', inverse_of: :account
       has_one :user, inverse_of: :account
+
+      # Association where account is targeted
+      with_options foreign_key: :target_account_id, inverse_of: :target_account do
+        has_many :strikes, class_name: 'AccountWarning'
+        has_many :targeted_moderation_notes, class_name: 'AccountModerationNote'
+        has_many :targeted_reports, class_name: 'Report'
+      end
     end
 
     # Pinned statuses

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -19,8 +19,6 @@ module Account::Associations
       has_one :user, inverse_of: :account
     end
 
-    # Notifications
-
     # Pinned statuses
     has_many :status_pins, inverse_of: :account, dependent: :destroy
     has_many :pinned_statuses, -> { reorder('status_pins.created_at DESC') }, through: :status_pins, class_name: 'Status', source: :status

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -13,11 +13,11 @@ module Account::Associations
       has_many :notifications, inverse_of: :account
       has_many :scheduled_statuses, inverse_of: :account
       has_many :statuses, inverse_of: :account
+      has_one :notification_policy, inverse_of: :account
       has_one :user, inverse_of: :account
     end
 
     # Notifications
-    has_one :notification_policy, inverse_of: :account, dependent: :destroy
     has_many :notification_permissions, inverse_of: :account, dependent: :destroy
     has_many :notification_requests, inverse_of: :account, dependent: :destroy
 

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -16,15 +16,15 @@ module Account::Associations
       has_many :favourites, inverse_of: :account
       has_many :featured_tags, -> { includes(:tag) }, inverse_of: :account
       has_many :list_accounts, inverse_of: :account
-      has_many :media_attachments
+      has_many :media_attachments, inverse_of: :account
       has_many :mentions, inverse_of: :account
       has_many :migrations, class_name: 'AccountMigration', inverse_of: :account
       has_many :notification_permissions, inverse_of: :account
       has_many :notification_requests, inverse_of: :account
       has_many :notifications, inverse_of: :account
       has_many :owned_lists, class_name: 'List', inverse_of: :account
-      has_many :polls
-      has_many :report_notes
+      has_many :polls, inverse_of: :account
+      has_many :report_notes, inverse_of: :account
       has_many :reports, inverse_of: :account
       has_many :scheduled_statuses, inverse_of: :account
       has_many :status_pins, inverse_of: :account

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -8,6 +8,7 @@ module Account::Associations
     with_options dependent: :destroy do
       has_many :account_moderation_notes, inverse_of: :account
       has_many :account_pins, inverse_of: :account
+      has_many :account_warnings, inverse_of: :account
       has_many :bookmarks, inverse_of: :account
       has_many :conversations, class_name: 'AccountConversation', inverse_of: :account
       has_many :custom_filters, inverse_of: :account
@@ -36,7 +37,6 @@ module Account::Associations
     has_many :endorsed_accounts, through: :account_pins, class_name: 'Account', source: :target_account
 
     # Moderation notes
-    has_many :account_warnings, dependent: :destroy, inverse_of: :account
     has_many :strikes, class_name: 'AccountWarning', foreign_key: :target_account_id, dependent: :destroy, inverse_of: :target_account
 
     # Lists (that the account is on, not owned by the account)


### PR DESCRIPTION
Sort of a mix of DRY/readability/organization here...

This module has a big collection of various associations for Account. Almost all of them are `dependent: :destroy`, and within that group, there's a mix of some that are also `inverse_of: :account` (most of them) and some `inverse_of: :target_account` (smaller group). There are then a handful which don't fit that "dependent destroy, account or target" pattern.

Changes here:

- Pull out an outer `with_options` to hold all the dependent destroy declarations -- these are more or less the core "owned" records for account (with some exception, note below...)
- Within that, pull out two more `with_options` blocks for each of the `inverse_of` groups
- The only declaration change here is to add a missing `inverse_of` to media_attachments, polls, report_notes - all else is re-org only

Possible future changes here, and some speculation...

- The breakdown between what's declared in this file vs what's in the similar "interactions" module is sort of (but not totally) consistent. It kinda makes sense for the core follow/mute/block as "interactions" in the other file, but then is maybe a little less clear for some of the other ones in there, at least by my reading.
- I could see doing one/both of:
  - Similar pass as this through interactions, looking for groupable blocks, maybe moving some things back and forth between the two files if that makes sense conceptually.
  - Pull out some of the interactions ones into more feature-named concerns, and include the "action methods" in them as well (ie, put all the blocking-related associations, the block/unblock methods, the blocking "map" methods, etc - into a `Blocking` concern ... and do same for others- Muting, Following, etc)
- For now I've just left the few associations which did not go into these groups down at the bottom by themselves ... but if there's further cleanup here, and/or other module extraction, those should be contemplated along those lines as well - some would have obvious places to go, others would prob stay at bottom here or bump over to interactions.
- Should any of assocs left here which do not have `dependent: :destroy` have it?

Probably easier to either go commit by commit or just look at end state than to view diff alone.

We do NOT have exhaustive specs on association declaration throughout the app, and I haven't added that here ... but I could definitely do a pass on that in advance of reviewing this if desired. Could also pull out the few `inverse_of` additions first so this is re-org only.