### PR TITLE
Convert HABTM statuses/accounts tag associations to polymorphic HMT via `Taggable` concern

### DIFF
--- a/app/lib/admin/metrics/dimension/tag_languages_dimension.rb
+++ b/app/lib/admin/metrics/dimension/tag_languages_dimension.rb
@@ -26,8 +26,8 @@ class Admin::Metrics::Dimension::TagLanguagesDimension < Admin::Metrics::Dimensi
     <<~SQL.squish
       SELECT COALESCE(statuses.language, 'und') AS language, count(*) AS value
       FROM statuses
-      INNER JOIN statuses_tags ON statuses_tags.status_id = statuses.id
-      WHERE statuses_tags.tag_id = :tag_id
+      INNER JOIN taggings ON taggings.taggable_id = statuses.id AND taggings.taggable_type = 'Status'
+      WHERE taggings.tag_id = :tag_id
         AND statuses.id BETWEEN :earliest_status_id AND :latest_status_id
       GROUP BY COALESCE(statuses.language, 'und')
       ORDER BY count(*) DESC

--- a/app/lib/admin/metrics/dimension/tag_servers_dimension.rb
+++ b/app/lib/admin/metrics/dimension/tag_servers_dimension.rb
@@ -26,8 +26,8 @@ class Admin::Metrics::Dimension::TagServersDimension < Admin::Metrics::Dimension
       SELECT accounts.domain, count(*) AS value
       FROM statuses
       INNER JOIN accounts ON accounts.id = statuses.account_id
-      INNER JOIN statuses_tags ON statuses_tags.status_id = statuses.id
-      WHERE statuses_tags.tag_id = :tag_id
+      INNER JOIN taggings ON taggings.taggable_id = statuses.id AND taggings.taggable_type = 'Status'
+      WHERE taggings.tag_id = :tag_id
         AND statuses.id BETWEEN :earliest_status_id AND :latest_status_id
       GROUP BY accounts.domain
       ORDER BY count(*) DESC

--- a/app/lib/admin/metrics/measure/tag_servers_measure.rb
+++ b/app/lib/admin/metrics/measure/tag_servers_measure.rb
@@ -31,9 +31,9 @@ class Admin::Metrics::Measure::TagServersMeasure < Admin::Metrics::Measure::Base
         WITH tag_servers AS (
           SELECT DISTINCT accounts.domain
           FROM statuses
-          INNER JOIN statuses_tags ON statuses.id = statuses_tags.status_id
+          INNER JOIN taggings ON statuses.id = taggings.taggable_id AND taggings.taggable_type = 'Status'
           INNER JOIN accounts ON statuses.account_id = accounts.id
-          WHERE statuses_tags.tag_id = :tag_id
+          WHERE taggings.tag_id = :tag_id
             AND statuses.id BETWEEN :earliest_status_id AND :latest_status_id
             AND date_trunc('day', statuses.created_at)::date = axis.period
         )

--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -196,7 +196,7 @@ class FeedManager
                     .where.not(account: into_account.following)
                     .tagged_with_none(TagFollow.where(account: into_account).pluck(:tag_id))
 
-      scope.select(:id, :reblog_of_id).reorder(nil).find_each do |status|
+    scope.select(:id, :reblog_of_id).reorder(nil).find_each do |status|
       remove_from_feed(:home, into_account.id, status, aggregate_reblogs: into_account.user&.aggregates_reblogs?)
     end
   end

--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -196,7 +196,7 @@ class FeedManager
                     .where.not(account: into_account.following)
                     .tagged_with_none(TagFollow.where(account: into_account).pluck(:tag_id))
 
-    scope.select(:id, :reblog_of_id).reorder(nil).find_each do |status|
+      scope.select(:id, :reblog_of_id).reorder(nil).find_each do |status|
       remove_from_feed(:home, into_account.id, status, aggregate_reblogs: into_account.user&.aggregates_reblogs?)
     end
   end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -99,6 +99,7 @@ class Account < ApplicationRecord
   include DomainNormalizable
   include Paginable
   include Reviewable
+  include Taggable
 
   enum :protocol, { ostatus: 0, activitypub: 1 }
   enum :suspension_origin, { local: 0, remote: 1 }, prefix: true

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -45,6 +45,9 @@ module Account::Associations
         has_many :targeted_moderation_notes, class_name: 'AccountModerationNote'
         has_many :targeted_reports, class_name: 'Report'
       end
+
+      # Tagging applied to account
+      has_many :taggings, as: :taggable
     end
 
     # Status records pinned by the account
@@ -60,7 +63,7 @@ module Account::Associations
     belongs_to :moved_to_account, class_name: 'Account', optional: true
 
     # Tag records applied to account
-    has_and_belongs_to_many :tags # rubocop:disable Rails/HasAndBelongsToMany
+    has_many :tags, through: :taggings
 
     # FollowRecommendation for account (surfaced via view)
     has_one :follow_recommendation, inverse_of: :account, dependent: nil

--- a/app/models/concerns/taggable.rb
+++ b/app/models/concerns/taggable.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Taggable
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :taggings, as: :taggable, dependent: :destroy
+    has_many :tags, through: :taggings
+  end
+end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -84,7 +84,8 @@ class Status < ApplicationRecord
   has_many :local_reblogged, -> { merge(Account.local) }, through: :reblogs, source: :account
   has_many :local_bookmarked, -> { merge(Account.local) }, through: :bookmarks, source: :account
 
-  has_and_belongs_to_many :tags # rubocop:disable Rails/HasAndBelongsToMany
+  has_many :taggings, as: :taggable, dependent: :destroy
+  has_many :tags, through: :taggings
 
   has_one :preview_cards_status, inverse_of: :status, dependent: :delete
 

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -124,7 +124,7 @@ class Status < ApplicationRecord
     end
   }
   scope :tagged_with_none, lambda { |tag_ids|
-    where('NOT EXISTS (SELECT * FROM taggings forbidden WHERE forbidden.taggable_id = statuses.id AND forbidden.taggable_type = \'Status\' AND forbidden.tag_id IN (?))', tag_ids)
+    where('NOT EXISTS (SELECT * FROM taggings WHERE taggings.taggable_id = statuses.id AND taggings.taggable_type = \'Status\' AND taggings.tag_id IN (?))', tag_ids)
   }
   scope :distributable_visibility, -> { where(visibility: %i(public unlisted)) }
   scope :list_eligible_visibility, -> { where(visibility: %i(public unlisted private)) }

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -38,6 +38,7 @@ class Status < ApplicationRecord
   include Status::SearchConcern
   include Status::SnapshotConcern
   include Status::ThreadingConcern
+  include Taggable
 
   MEDIA_ATTACHMENTS_LIMIT = 4
 
@@ -83,9 +84,6 @@ class Status < ApplicationRecord
   has_many :local_favorited, -> { merge(Account.local) }, through: :favourites, source: :account
   has_many :local_reblogged, -> { merge(Account.local) }, through: :reblogs, source: :account
   has_many :local_bookmarked, -> { merge(Account.local) }, through: :bookmarks, source: :account
-
-  has_many :taggings, as: :taggable, dependent: :destroy
-  has_many :tags, through: :taggings
 
   has_one :preview_cards_status, inverse_of: :status, dependent: :delete
 

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -113,18 +113,18 @@ class Status < ApplicationRecord
   scope :not_reply, -> { where(reply: false) }
   scope :reply_to_account, -> { where(arel_table[:in_reply_to_account_id].eq arel_table[:account_id]) }
   scope :without_reblogs, -> { where(statuses: { reblog_of_id: nil }) }
-  scope :tagged_with, ->(tag_ids) { joins(:statuses_tags).where(statuses_tags: { tag_id: tag_ids }) }
+  scope :tagged_with, ->(tag_ids) { joins(:tags).where(tags: { id: tag_ids }) }
   scope :not_excluded_by_account, ->(account) { where.not(account_id: account.excluded_from_timeline_account_ids) }
   scope :not_domain_blocked_by_account, ->(account) { account.excluded_from_timeline_domains.blank? ? left_outer_joins(:account) : left_outer_joins(:account).merge(Account.not_domain_blocked_by_account(account)) }
   scope :tagged_with_all, lambda { |tag_ids|
     Array(tag_ids).map(&:to_i).reduce(self) do |result, id|
       result.where(<<~SQL.squish, tag_id: id)
-        EXISTS(SELECT 1 FROM statuses_tags WHERE statuses_tags.status_id = statuses.id AND statuses_tags.tag_id = :tag_id)
+        EXISTS(SELECT 1 FROM taggings WHERE taggings.taggable_id = statuses.id AND taggings.taggable_type = 'Status' AND taggings.tag_id = :tag_id)
       SQL
     end
   }
   scope :tagged_with_none, lambda { |tag_ids|
-    where('NOT EXISTS (SELECT * FROM statuses_tags forbidden WHERE forbidden.status_id = statuses.id AND forbidden.tag_id IN (?))', tag_ids)
+    where('NOT EXISTS (SELECT * FROM taggings forbidden WHERE forbidden.taggable_id = statuses.id AND forbidden.taggable_type = \'Status\' AND forbidden.tag_id IN (?))', tag_ids)
   }
   scope :distributable_visibility, -> { where(visibility: %i(public unlisted)) }
   scope :list_eligible_visibility, -> { where(visibility: %i(public unlisted private)) }

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -23,10 +23,11 @@ class Tag < ApplicationRecord
   include Paginable
   include Reviewable
 
-  # rubocop:disable Rails/HasAndBelongsToMany
-  has_and_belongs_to_many :statuses
-  has_and_belongs_to_many :accounts
-  # rubocop:enable Rails/HasAndBelongsToMany
+  has_many :taggings, dependent: :destroy
+  with_options through: :taggings, source: :taggable do
+    has_many :statuses, source_type: 'Status'
+    has_many :accounts, source_type: 'Account'
+  end
 
   has_many :passive_relationships, class_name: 'TagFollow', inverse_of: :tag, dependent: :destroy
   has_many :featured_tags, dependent: :destroy, inverse_of: :tag

--- a/app/models/tagging.rb
+++ b/app/models/tagging.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: taggings
+#
+#  id            :bigint(8)        not null, primary key
+#  tag_id        :bigint(8)        not null
+#  taggable_type :string           not null
+#  taggable_id   :bigint(8)        not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
+class Tagging < ApplicationRecord
+  belongs_to :tag
+  belongs_to :taggable, polymorphic: true
+end

--- a/db/migrate/20240731194619_create_taggings.rb
+++ b/db/migrate/20240731194619_create_taggings.rb
@@ -34,13 +34,13 @@ class CreateTaggings < ActiveRecord::Migration[7.1]
   end
 
   def restore_join_tables
-    create_table :statuses_tags, primary_key: [:tag_id, :status_id], force: :cascade do |t|
+    create_table :statuses_tags, primary_key: [:tag_id, :status_id], force: :cascade do |t| # rubocop:disable Rails/CreateTableWithTimestamps
       t.bigint :status_id, null: false
       t.bigint :tag_id, null: false
       t.index :status_id
     end
 
-    create_table :accounts_tags, primary_key: [:tag_id, :account_id], force: :cascade do |t|
+    create_table :accounts_tags, primary_key: [:tag_id, :account_id], force: :cascade do |t| # rubocop:disable Rails/CreateTableWithTimestamps
       t.bigint :account_id, null: false
       t.bigint :tag_id, null: false
       t.index [:account_id, :tag_id]

--- a/db/migrate/20240731194619_create_taggings.rb
+++ b/db/migrate/20240731194619_create_taggings.rb
@@ -1,12 +1,85 @@
 # frozen_string_literal: true
 
 class CreateTaggings < ActiveRecord::Migration[7.1]
-  def change
+  def up
+    create_taggings
+
+    safety_assured do
+      convert_status_taggings
+      convert_account_taggings
+    end
+
+    drop_table :accounts_tags
+    drop_table :statuses_tags
+  end
+
+  def down
+    restore_join_tables
+
+    safety_assured do
+      restore_account_taggings
+      restore_status_taggings
+    end
+
+    drop_table :taggings
+  end
+
+  def create_taggings
     create_table :taggings do |t|
       t.references :tag, null: false, foreign_key: true
       t.references :taggable, polymorphic: true, null: false
 
       t.timestamps
     end
+  end
+
+  def restore_join_tables
+    create_table :statuses_tags, primary_key: [:tag_id, :status_id], force: :cascade do |t|
+      t.bigint :status_id, null: false
+      t.bigint :tag_id, null: false
+      t.index :status_id
+    end
+
+    create_table :accounts_tags, primary_key: [:tag_id, :account_id], force: :cascade do |t|
+      t.bigint :account_id, null: false
+      t.bigint :tag_id, null: false
+      t.index [:account_id, :tag_id]
+    end
+  end
+
+  def convert_status_taggings
+    execute <<~SQL.squish
+      INSERT INTO taggings(tag_id, taggable_type, taggable_id, created_at, updated_at)
+      SELECT statuses_tags.tag_id, 'Status', statuses_tags.status_id, statuses.updated_at, statuses.updated_at
+      FROM statuses_tags
+      JOIN statuses ON statuses.id = statuses_tags.status_id
+    SQL
+  end
+
+  def convert_account_taggings
+    execute <<~SQL.squish
+      INSERT INTO taggings(tag_id, taggable_type, taggable_id, created_at, updated_at)
+      SELECT accounts_tags.tag_id, 'Account', accounts_tags.account_id, accounts.updated_at, accounts.updated_at
+      FROM accounts_tags
+      JOIN accounts ON accounts.id = accounts_tags.account_id
+    SQL
+  end
+
+  def restore_account_taggings
+    execute <<~SQL.squish
+      INSERT INTO accounts_tags(account_id, tag_id)
+      SELECT taggable_id, tag_id
+      FROM taggings
+      WHERE taggable_type = 'Account'
+    SQL
+  end
+
+  def restore_status_taggings
+    execute <<~SQL.squish
+      INSERT INTO statuses_tags(status_id, tag_id)
+      SELECT taggable_id, tag_id
+      FROM taggings
+      WHERE taggable_type = 'Status'
+    SQL
   end
 end

--- a/db/migrate/20240731194619_create_taggings.rb
+++ b/db/migrate/20240731194619_create_taggings.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateTaggings < ActiveRecord::Migration[7.1]
+  def change
+    create_table :taggings do |t|
+      t.references :tag, null: false, foreign_key: true
+      t.references :taggable, polymorphic: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1080,6 +1080,16 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_04_082851) do
     t.index ["tag_id"], name: "index_tag_follows_on_tag_id"
   end
 
+  create_table "taggings", force: :cascade do |t|
+    t.bigint "tag_id", null: false
+    t.string "taggable_type", null: false
+    t.bigint "taggable_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["tag_id"], name: "index_taggings_on_tag_id"
+    t.index ["taggable_type", "taggable_id"], name: "index_taggings_on_taggable"
+  end
+
   create_table "tags", force: :cascade do |t|
     t.string "name", default: "", null: false
     t.datetime "created_at", precision: nil, null: false
@@ -1343,6 +1353,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_04_082851) do
   add_foreign_key "statuses_tags", "tags", name: "fk_3081861e21", on_delete: :cascade
   add_foreign_key "tag_follows", "accounts", on_delete: :cascade
   add_foreign_key "tag_follows", "tags", on_delete: :cascade
+  add_foreign_key "taggings", "tags"
   add_foreign_key "tombstones", "accounts", on_delete: :cascade
   add_foreign_key "user_invite_requests", "users", on_delete: :cascade
   add_foreign_key "users", "accounts", name: "fk_50500f500d", on_delete: :cascade

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -206,12 +206,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_04_082851) do
     t.index ["url"], name: "index_accounts_on_url", opclass: :text_pattern_ops, where: "(url IS NOT NULL)"
   end
 
-  create_table "accounts_tags", primary_key: ["tag_id", "account_id"], force: :cascade do |t|
-    t.bigint "account_id", null: false
-    t.bigint "tag_id", null: false
-    t.index ["account_id", "tag_id"], name: "index_accounts_tags_on_account_id_and_tag_id"
-  end
-
   create_table "admin_action_logs", force: :cascade do |t|
     t.bigint "account_id"
     t.string "action", default: "", null: false
@@ -1065,12 +1059,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_04_082851) do
     t.index ["uri"], name: "index_statuses_on_uri", unique: true, opclass: :text_pattern_ops, where: "(uri IS NOT NULL)"
   end
 
-  create_table "statuses_tags", primary_key: ["tag_id", "status_id"], force: :cascade do |t|
-    t.bigint "status_id", null: false
-    t.bigint "tag_id", null: false
-    t.index ["status_id"], name: "index_statuses_tags_on_status_id"
-  end
-
   create_table "tag_follows", force: :cascade do |t|
     t.bigint "tag_id", null: false
     t.bigint "account_id", null: false
@@ -1349,8 +1337,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_04_082851) do
   add_foreign_key "statuses", "accounts", name: "fk_9bda1543f7", on_delete: :cascade
   add_foreign_key "statuses", "statuses", column: "in_reply_to_id", on_delete: :nullify
   add_foreign_key "statuses", "statuses", column: "reblog_of_id", on_delete: :cascade
-  add_foreign_key "statuses_tags", "statuses", on_delete: :cascade
-  add_foreign_key "statuses_tags", "tags", name: "fk_3081861e21", on_delete: :cascade
   add_foreign_key "tag_follows", "accounts", on_delete: :cascade
   add_foreign_key "tag_follows", "tags", on_delete: :cascade
   add_foreign_key "taggings", "tags"

--- a/spec/fabricators/tagging_fabricator.rb
+++ b/spec/fabricators/tagging_fabricator.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+Fabricator(:tagging) do
+  tag
+  taggable { Fabricate :status }
+end

--- a/spec/models/tagging_spec.rb
+++ b/spec/models/tagging_spec.rb
@@ -7,10 +7,4 @@ RSpec.describe Tagging do
     it { is_expected.to belong_to(:tag).required }
     it { is_expected.to belong_to(:taggable).required }
   end
-
-  describe 'Validations' do
-    it 'validates presence of something' do
-      expect(subject).to_not be_valid
-    end
-  end
 end

--- a/spec/models/tagging_spec.rb
+++ b/spec/models/tagging_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Tagging do
+  describe 'Validations' do
+    it 'validates presence of something' do
+      expect(subject).to_not be_valid
+    end
+  end
+end

--- a/spec/models/tagging_spec.rb
+++ b/spec/models/tagging_spec.rb
@@ -3,6 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe Tagging do
+  describe 'Associations' do
+    it { is_expected.to belong_to(:tag).required }
+    it { is_expected.to belong_to(:taggable).required }
+  end
+
   describe 'Validations' do
     it 'validates presence of something' do
       expect(subject).to_not be_valid


### PR DESCRIPTION
Opening as draft for feedback, and because...

- If we can get this - https://github.com/mastodon/mastodon/pull/30654 - or something similar in first, some of these changes will be simpler/consolidated or done for us by the associations
- There are some other outstanding PRs which would clean up the queries within `Status`, and also simplify this PR in that respect.
- I believe the migration here is logically/datawise correct, but I've done zero contemplation about performance/duration/etc and it might need consideration on that front
