### PR TITLE
Prevent Web::Push notification delivery if notification is outside of TTL window

### DIFF
--- a/app/workers/web/push_notification_worker.rb
+++ b/app/workers/web/push_notification_worker.rb
@@ -13,6 +13,8 @@ class Web::PushNotificationWorker
     @subscription = Web::PushSubscription.find(subscription_id)
     @notification = Notification.find(notification_id)
 
+    return if @notification.updated_at < TTL.ago
+
     # Polymorphically associated activity could have been deleted
     # in the meantime, so we have to double-check before proceeding
     return unless @notification.activity.present? && @subscription.pushable?(@notification)


### PR DESCRIPTION
I just noticed that if Web::PushSubscriptions are failing, and the push queue backs up, then it's possible for us to attempt notification delivery even though the TTL has expired. I think this should prevent that.