### PR TITLE
Fix: prevent linking to pages which require extra permissions

### DIFF
--- a/app/views/admin/dashboard/index.html.haml
+++ b/app/views/admin/dashboard/index.html.haml
@@ -16,7 +16,7 @@
   .dashboard__item
     = react_admin_component :counter,
                             end_at: @time_period.last,
-                            href: admin_accounts_path(origin: 'local'),
+                            href: current_user.can?(:manage_users) ? admin_accounts_path(origin: 'local') : nil,
                             label: t('admin.dashboard.new_users'),
                             measure: 'new_users',
                             start_at: @time_period.first
@@ -24,7 +24,7 @@
   .dashboard__item
     = react_admin_component :counter,
                             end_at: @time_period.last,
-                            href: admin_accounts_path(origin: 'local'),
+                            href: current_user.can?(:manage_users) ? admin_accounts_path(origin: 'local') : nil,
                             label: t('admin.dashboard.active_users'),
                             measure: 'active_users',
                             start_at: @time_period.first
@@ -39,7 +39,7 @@
   .dashboard__item
     = react_admin_component :counter,
                             end_at: @time_period.last,
-                            href: admin_reports_path,
+                            href: current_user.can?(:manage_reports) ? admin_reports_path : nil,
                             label: t('admin.dashboard.opened_reports'),
                             measure: 'opened_reports',
                             start_at: @time_period.first
@@ -47,7 +47,7 @@
   .dashboard__item
     = react_admin_component :counter,
                             end_at: @time_period.last,
-                            href: admin_reports_path(resolved: '1'),
+                            href: current_user.can?(:manage_reports) ? admin_reports_path(resolved: '1') : nil,
                             label: t('admin.dashboard.resolved_reports'),
                             measure: 'resolved_reports',
                             start_at: @time_period.first

--- a/app/views/admin/instances/_dashboard.html.haml
+++ b/app/views/admin/instances/_dashboard.html.haml
@@ -7,7 +7,7 @@
   .dashboard__item
     = react_admin_component :counter,
                             end_at: period_end_at,
-                            href: admin_accounts_path(origin: 'remote', by_domain: instance_domain),
+                            href: current_user.can?(:manage_users) ? admin_accounts_path(origin: 'remote', by_domain: instance_domain) : nil,
                             label: t('admin.instances.dashboard.instance_accounts_measure'),
                             measure: 'instance_accounts',
                             params: { domain: instance_domain },
@@ -43,7 +43,7 @@
   .dashboard__item
     = react_admin_component :counter,
                             end_at: period_end_at,
-                            href: admin_reports_path(by_target_domain: instance_domain),
+                            href: current_user.can?(:manage_reports) ? admin_reports_path(by_target_domain: instance_domain) : nil,
                             label: t('admin.instances.dashboard.instance_reports_measure'),
                             measure: 'instance_reports',
                             params: { domain: instance_domain },


### PR DESCRIPTION
I noticed this because I kept accidentally clicking stuff that required permissions my user didn't have.

Whilst I've done the dashboards, I've not yet done these links, because I'm not sure how we could do them immediately? I think we'd want something that conditionally renders a link based on user role?

<img width="319" alt="Screenshot 2024-11-11 at 20 18 06" src="https://github.com/user-attachments/assets/2bd53fab-0d50-47b0-8647-995ef72fec4b">
