### PR TITLE
Move `ALLOWED_PRIVATE_ADDRESSES` parsing to an initializer

### DIFF
--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -334,13 +334,9 @@ class Request
       def check_private_address(address, host)
         addr = IPAddr.new(address.to_s)
 
-        return if Rails.env.development? || private_address_exceptions.any? { |range| range.include?(addr) }
+        return if Rails.env.development? || Rails.configuration.x.private_address_exceptions.any? { |range| range.include?(addr) }
 
         raise Mastodon::PrivateNetworkAddressError, host if PrivateAddressCheck.private_address?(addr)
-      end
-
-      def private_address_exceptions
-        @private_address_exceptions = (ENV['ALLOWED_PRIVATE_ADDRESSES'] || '').split(/(?:\s*,\s*|\s+)/).map { |addr| IPAddr.new(addr) }
       end
     end
   end

--- a/config/initializers/allowed_private_addresses.rb
+++ b/config/initializers/allowed_private_addresses.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Rails.application.configure do
+  config.x.private_address_exceptions = (ENV['ALLOWED_PRIVATE_ADDRESSES'] || '').split(/(?:\s*,\s*|\s+)/).map { |addr| IPAddr.new(addr) }
+end


### PR DESCRIPTION
This needs not be re-parsed every single request. Furthermore, moving this earlier makes errors easier to spot, instead of being swallowed in the `Request` class error handling (see <https://github.com/mastodon/mastodon/issues/32792>)