### PR TITLE
Fix: update token usage tracking from streaming

### DIFF
--- a/streaming/index.js
+++ b/streaming/index.js
@@ -9,6 +9,7 @@ import cors from 'cors';
 import dotenv from 'dotenv';
 import express from 'express';
 import { JSDOM } from 'jsdom';
+import proxyaddr from 'proxy-addr';
 import { WebSocketServer } from 'ws';
 
 import * as Database from './database.js';
@@ -145,8 +146,13 @@ const startServer = async () => {
   });
 
   const app = express();
+  const trustProxy = proxyaddr.compile(
+    process.env.TRUSTED_PROXY_IP ?
+      process.env.TRUSTED_PROXY_IP.split(/(?:\s*,\s*|\s+)/) :
+      ['loopback', 'uniquelocal']
+  );
 
-  app.set('trust proxy', process.env.TRUSTED_PROXY_IP ? process.env.TRUSTED_PROXY_IP.split(/(?:\s*,\s*|\s+)/) : 'loopback,uniquelocal');
+  app.set('trust proxy', trustProxy);
 
   app.use(httpLogger);
   app.use(cors());

--- a/streaming/package.json
+++ b/streaming/package.json
@@ -38,7 +38,8 @@
     "@types/ws": "^8.5.9",
     "eslint-define-config": "^2.0.0",
     "pino-pretty": "^11.0.0",
-    "typescript": "^5.0.4"
+    "typescript": "^5.0.4",
+    "wscat": "^6.0.1"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.7",

--- a/streaming/package.json
+++ b/streaming/package.json
@@ -27,6 +27,7 @@
     "pino": "^9.0.0",
     "pino-http": "^10.0.0",
     "prom-client": "^15.0.0",
+    "proxy-addr": "~2.0.7",
     "uuid": "^11.0.0",
     "ws": "^8.12.1"
   },
@@ -34,6 +35,7 @@
     "@types/cors": "^2.8.16",
     "@types/express": "^4.17.17",
     "@types/pg": "^8.6.6",
+    "@types/proxy-addr": "^2.0.3",
     "@types/uuid": "^10.0.0",
     "@types/ws": "^8.5.9",
     "eslint-define-config": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3029,6 +3029,7 @@ __metadata:
     utf-8-validate: "npm:^6.0.3"
     uuid: "npm:^11.0.0"
     ws: "npm:^8.12.1"
+    wscat: "npm:^6.0.1"
   dependenciesMeta:
     bufferutil:
       optional: true
@@ -6215,6 +6216,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"commander@npm:^12.1.0, commander@npm:~12.1.0":
+  version: 12.1.0
+  resolution: "commander@npm:12.1.0"
+  checksum: 10c0/6e1996680c083b3b897bfc1cfe1c58dfbcd9842fd43e1aaf8a795fbc237f65efcc860a3ef457b318e73f29a4f4a28f6403c3d653d021d960e4632dd45bde54a9
+  languageName: node
+  linkType: hard
+
 "commander@npm:^2.20.0":
   version: 2.20.3
   resolution: "commander@npm:2.20.3"
@@ -6226,13 +6234,6 @@ __metadata:
   version: 7.2.0
   resolution: "commander@npm:7.2.0"
   checksum: 10c0/8d690ff13b0356df7e0ebbe6c59b4712f754f4b724d4f473d3cc5b3fdcf978e3a5dc3078717858a2ceb50b0f84d0660a7f22a96cdc50fb877d0c9bb31593d23a
-  languageName: node
-  linkType: hard
-
-"commander@npm:~12.1.0":
-  version: 12.1.0
-  resolution: "commander@npm:12.1.0"
-  checksum: 10c0/6e1996680c083b3b897bfc1cfe1c58dfbcd9842fd43e1aaf8a795fbc237f65efcc860a3ef457b318e73f29a4f4a28f6403c3d653d021d960e4632dd45bde54a9
   languageName: node
   linkType: hard
 
@@ -12175,6 +12176,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mute-stream@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "mute-stream@npm:2.0.0"
+  checksum: 10c0/2cf48a2087175c60c8dcdbc619908b49c07f7adcfc37d29236b0c5c612d6204f789104c98cc44d38acab7b3c96f4a3ec2cfdc4934d0738d876dbefa2a12c69f4
+  languageName: node
+  linkType: hard
+
 "nan@npm:^2.12.1":
   version: 2.17.0
   resolution: "nan@npm:2.17.0"
@@ -14833,6 +14841,15 @@ __metadata:
   dependencies:
     loose-envify: "npm:^1.1.0"
   checksum: 10c0/283e8c5efcf37802c9d1ce767f302dd569dd97a70d9bb8c7be79a789b9902451e0d16334b05d73299b20f048cbc3c7d288bbbde10b701fa194e2089c237dbea3
+  languageName: node
+  linkType: hard
+
+"read@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "read@npm:4.0.0"
+  dependencies:
+    mute-stream: "npm:^2.0.0"
+  checksum: 10c0/448dd2cb8163fa7004dbe9e7fc9b0814cedd55028e2d45fbebd774f6b05e3ac046b092f3910a4eff942471187afa0b56b5db6caf2cd230d264d8d8fe22f9af6f
   languageName: node
   linkType: hard
 
@@ -18546,7 +18563,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^8.11.0, ws@npm:^8.12.1, ws@npm:^8.18.0":
+"ws@npm:^8.0.0, ws@npm:^8.11.0, ws@npm:^8.12.1, ws@npm:^8.18.0":
   version: 8.18.0
   resolution: "ws@npm:8.18.0"
   peerDependencies:
@@ -18558,6 +18575,20 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: 10c0/25eb33aff17edcb90721ed6b0eb250976328533ad3cd1a28a274bd263682e7296a6591ff1436d6cbc50fa67463158b062f9d1122013b361cec99a05f84680e06
+  languageName: node
+  linkType: hard
+
+"wscat@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "wscat@npm:6.0.1"
+  dependencies:
+    commander: "npm:^12.1.0"
+    https-proxy-agent: "npm:^7.0.5"
+    read: "npm:^4.0.0"
+    ws: "npm:^8.0.0"
+  bin:
+    wscat: bin/wscat
+  checksum: 10c0/8245b6cdebb6bde8bc6bf647991d289107bdbda24f51cf820683f40a06b72226e606fbc8d263e4812018928315200377e615035918399bdcaca8b0b0182ecbd1
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3010,6 +3010,7 @@ __metadata:
     "@types/cors": "npm:^2.8.16"
     "@types/express": "npm:^4.17.17"
     "@types/pg": "npm:^8.6.6"
+    "@types/proxy-addr": "npm:^2.0.3"
     "@types/uuid": "npm:^10.0.0"
     "@types/ws": "npm:^8.5.9"
     bufferutil: "npm:^4.0.7"
@@ -3025,6 +3026,7 @@ __metadata:
     pino-http: "npm:^10.0.0"
     pino-pretty: "npm:^11.0.0"
     prom-client: "npm:^15.0.0"
+    proxy-addr: "npm:~2.0.7"
     typescript: "npm:^5.0.4"
     utf-8-validate: "npm:^6.0.3"
     uuid: "npm:^11.0.0"
@@ -3884,6 +3886,15 @@ __metadata:
   version: 15.7.13
   resolution: "@types/prop-types@npm:15.7.13"
   checksum: 10c0/1b20fc67281902c6743379960247bc161f3f0406ffc0df8e7058745a85ea1538612109db0406290512947f9632fe9e10e7337bf0ce6338a91d6c948df16a7c61
+  languageName: node
+  linkType: hard
+
+"@types/proxy-addr@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "@types/proxy-addr@npm:2.0.3"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/680f5eeaf434461daf856d694fd6b228c9850f736f377b8fc1d373ba282feca25bc642eeed93f3a9511d9406a9b93014b94c4d7cb8488646482ca0610d931e30
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Prior to this change, and access token that was only used to access the streaming API would appear unused, despite it very much so being used.

whilst working on this, I also needed better insight into what streaming was doing with database access and needed wscat for testing