### PR TITLE
Misc gem version bumps

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,7 +112,7 @@ GEM
       aws-sigv4 (~> 1.5)
     aws-sigv4 (1.10.1)
       aws-eventstream (~> 1, >= 1.0.2)
-    azure-blob (0.5.2)
+    azure-blob (0.5.3)
       rexml
     base64 (0.2.0)
     bcp47_spec (0.2.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -579,7 +579,7 @@ GEM
       activesupport (>= 7.0.0)
       rack
       railties (>= 7.0.0)
-    psych (5.1.2)
+    psych (5.2.0)
       stringio
     public_suffix (6.0.1)
     puma (6.4.3)
@@ -794,7 +794,7 @@ GEM
     stackprof (0.2.26)
     stoplight (4.1.0)
       redlock (~> 1.0)
-    stringio (3.1.1)
+    stringio (3.1.2)
     strong_migrations (2.1.0)
       activerecord (>= 6.1)
     swd (1.3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -554,7 +554,7 @@ GEM
     opentelemetry-semantic_conventions (1.10.1)
       opentelemetry-api (~> 1.0)
     orm_adapter (0.5.0)
-    ostruct (0.6.0)
+    ostruct (0.6.1)
     ox (2.14.18)
     parallel (1.26.3)
     parser (3.3.5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -673,7 +673,7 @@ GEM
       railties (>= 5.2)
     rexml (3.3.9)
     rotp (6.3.0)
-    rouge (4.4.0)
+    rouge (4.5.1)
     rpam2 (4.0.2)
     rqrcode (2.2.0)
       chunky_png (~> 1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -693,7 +693,7 @@ GEM
     rspec-mocks (3.13.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-rails (7.0.1)
+    rspec-rails (7.1.0)
       actionpack (>= 7.0)
       activesupport (>= 7.0)
       railties (>= 7.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -867,7 +867,7 @@ GEM
       rack-proxy (>= 0.6.1)
       railties (>= 5.2)
       semantic_range (>= 2.3.0)
-    webrick (1.8.2)
+    webrick (1.9.0)
     websocket (1.2.11)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -411,7 +411,7 @@ GEM
     mini_mime (1.1.5)
     mini_portile2 (2.8.7)
     minitest (5.25.1)
-    msgpack (1.7.3)
+    msgpack (1.7.5)
     multi_json (1.15.0)
     mutex_m (0.2.0)
     net-http (0.5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -330,7 +330,7 @@ GEM
       azure-blob (~> 0.5.2)
       hashie (~> 5.0)
     jmespath (1.6.2)
-    json (2.7.4)
+    json (2.8.1)
     json-canonicalization (1.0.0)
     json-jwt (1.15.3.1)
       activesupport (>= 4.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -557,7 +557,7 @@ GEM
     ostruct (0.6.1)
     ox (2.14.18)
     parallel (1.26.3)
-    parser (3.3.5.0)
+    parser (3.3.6.0)
       ast (~> 2.4.1)
       racc
     parslet (2.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -407,7 +407,7 @@ GEM
     mime-types (3.6.0)
       logger
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2024.1001)
+    mime-types-data (3.2024.1105)
     mini_mime (1.1.5)
     mini_portile2 (2.8.7)
     minitest (5.25.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,7 +178,7 @@ GEM
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
-    date (3.3.4)
+    date (3.4.0)
     debug (1.9.2)
       irb (~> 1.10)
       reline (>= 0.3.8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -416,7 +416,7 @@ GEM
     mutex_m (0.2.0)
     net-http (0.5.0)
       uri
-    net-imap (0.5.0)
+    net-imap (0.5.1)
       date
       net-protocol
     net-ldap (0.19.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,10 +189,10 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
-    devise-two-factor (6.0.0)
-      activesupport (~> 7.0)
+    devise-two-factor (6.1.0)
+      activesupport (>= 7.0, < 8.1)
       devise (~> 4.0)
-      railties (~> 7.0)
+      railties (>= 7.0, < 8.1)
       rotp (~> 6.0)
     devise_pam_authenticatable2 (9.2.0)
       devise (>= 4.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -664,7 +664,7 @@ GEM
     redlock (1.3.2)
       redis (>= 3.0.0, < 6.0)
     regexp_parser (2.9.2)
-    reline (0.5.10)
+    reline (0.5.11)
       io-console (~> 0.5)
     request_store (1.6.0)
       rack (>= 1.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,7 @@ GEM
     attr_required (1.0.2)
     awrence (1.2.1)
     aws-eventstream (1.3.0)
-    aws-partitions (1.1001.0)
+    aws-partitions (1.1004.0)
     aws-sdk-core (3.212.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)


### PR DESCRIPTION
A few renovate PRs are failing CI because they bumped rackup which currently has a broken interaction with puma.

This mainly bumps rspec-rails and devise-two-factor - https://github.com/mastodon/mastodon/pull/32844 / https://github.com/mastodon/mastodon/pull/32814

While in there did a bunch of patch version bumps to stdlib gems and misc other stuff.

Parser gem bump matches ruby version, json bump related to https://github.com/mastodon/mastodon/pull/32704