### PR TITLE
Extract `User::Approval` concern

### DIFF
--- a/app/models/concerns/user/approval.rb
+++ b/app/models/concerns/user/approval.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module User::Approval
+  extend ActiveSupport::Concern
+
+  included do
+    scope :approved, -> { where(approved: true) }
+    scope :pending, -> { where(approved: false) }
+  end
+end

--- a/app/models/concerns/user/approval.rb
+++ b/app/models/concerns/user/approval.rb
@@ -11,4 +11,14 @@ module User::Approval
   def pending?
     !approved?
   end
+
+  def approve!
+    return if approved?
+
+    update!(approved: true)
+
+    # Handle scenario when approving and confirming a user at the same time
+    reload unless confirmed?
+    prepare_new_user! if confirmed?
+  end
 end

--- a/app/models/concerns/user/approval.rb
+++ b/app/models/concerns/user/approval.rb
@@ -6,6 +6,8 @@ module User::Approval
   included do
     scope :approved, -> { where(approved: true) }
     scope :pending, -> { where(approved: false) }
+
+    before_create :set_approved
   end
 
   def pending?
@@ -20,5 +22,41 @@ module User::Approval
     # Handle scenario when approving and confirming a user at the same time
     reload unless confirmed?
     prepare_new_user! if confirmed?
+  end
+
+  private
+
+  def set_approved
+    self.approved = begin
+      if sign_up_from_ip_requires_approval? || sign_up_email_requires_approval?
+        false
+      else
+        open_registrations? || valid_invitation? || external?
+      end
+    end
+  end
+
+  def grant_approval_on_confirmation?
+    # Re-check approval on confirmation if the server has switched to open registrations
+    open_registrations? && !sign_up_from_ip_requires_approval? && !sign_up_email_requires_approval?
+  end
+
+  def sign_up_from_ip_requires_approval?
+    sign_up_ip.present? && IpBlock.severity_sign_up_requires_approval.containing(sign_up_ip.to_s).exists?
+  end
+
+  def sign_up_email_requires_approval?
+    return false if email.blank?
+
+    _, domain = email.split('@', 2)
+    return false if domain.blank?
+
+    records = []
+
+    # Doing this conditionally is not very satisfying, but this is consistent
+    # with the MX records validations we do and keeps the specs tractable.
+    records = DomainResource.new(domain).mx unless self.class.skip_mx_check?
+
+    EmailDomainBlock.requires_approval?(records + [domain], attempt_ip: sign_up_ip)
   end
 end

--- a/app/models/concerns/user/approval.rb
+++ b/app/models/concerns/user/approval.rb
@@ -7,4 +7,8 @@ module User::Approval
     scope :approved, -> { where(approved: true) }
     scope :pending, -> { where(approved: false) }
   end
+
+  def pending?
+    !approved?
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -56,6 +56,7 @@ class User < ApplicationRecord
 
   include LanguagesHelper
   include Redisable
+  include User::Approval
   include User::HasSettings
   include User::LdapAuthenticable
   include User::Omniauthable
@@ -115,8 +116,6 @@ class User < ApplicationRecord
 
   scope :account_not_suspended, -> { joins(:account).merge(Account.without_suspended) }
   scope :recent, -> { order(id: :desc) }
-  scope :pending, -> { where(approved: false) }
-  scope :approved, -> { where(approved: true) }
   scope :confirmed, -> { where.not(confirmed_at: nil) }
   scope :unconfirmed, -> { where(confirmed_at: nil) }
   scope :enabled, -> { where(disabled: false) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -222,10 +222,6 @@ class User < ApplicationRecord
     prepare_returning_user!
   end
 
-  def pending?
-    !approved?
-  end
-
   def active_for_authentication?
     !account.memorial?
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -242,17 +242,6 @@ class User < ApplicationRecord
     unconfirmed? || pending?
   end
 
-  def approve!
-    return if approved?
-
-    update!(approved: true)
-
-    # Avoid extremely unlikely race condition when approving and confirming
-    # the user at the same time
-    reload unless confirmed?
-    prepare_new_user! if confirmed?
-  end
-
   def otp_enabled?
     otp_required_for_login
   end


### PR DESCRIPTION
Similar to https://github.com/mastodon/mastodon/pull/31270 and some of the recently merged `Account::*` concerns.

I wanted to keep this as move/reorg only and not refactor anything, but definite future things here:

- The "confirmed" aspect of user could almost definitely be pulled out in similar way to this and the activity one
- The "sign up ip or sign up email" logic here could be pulled into single method
- The resolvs/dns/mx lookup is repeated a few times across app, could pull that out better
- Same thing for the simple email/domain parse check