### PR TITLE
Fix `min_id` and `max_id` causing error in search API

### DIFF
--- a/app/lib/search_query_transformer.rb
+++ b/app/lib/search_query_transformer.rb
@@ -144,6 +144,8 @@ class SearchQueryTransformer < Parslet::Transform
   end
 
   class PrefixClause
+    EPOCH_RE = /\A\d+\z/
+
     attr_reader :operator, :prefix, :term
 
     def initialize(prefix, operator, term, options = {})
@@ -168,15 +170,15 @@ class SearchQueryTransformer < Parslet::Transform
       when 'before'
         @filter = :created_at
         @type = :range
-        @term = { lt: TermValidator.validate_date!(term), time_zone: @options[:current_account]&.user_time_zone.presence || 'UTC' }
+        @term = { lt: date_from_term(term), time_zone: @options[:current_account]&.user_time_zone.presence || 'UTC' }
       when 'after'
         @filter = :created_at
         @type = :range
-        @term = { gt: TermValidator.validate_date!(term), time_zone: @options[:current_account]&.user_time_zone.presence || 'UTC' }
+        @term = { gt: date_from_term(term), time_zone: @options[:current_account]&.user_time_zone.presence || 'UTC' }
       when 'during'
         @filter = :created_at
         @type = :range
-        @term = { gte: TermValidator.validate_date!(term), lte: TermValidator.validate_date!(term), time_zone: @options[:current_account]&.user_time_zone.presence || 'UTC' }
+        @term = { gte: date_from_term(term), lte: date_from_term(term), time_zone: @options[:current_account]&.user_time_zone.presence || 'UTC' }
       when 'in'
         @operator = :flag
         @term = term
@@ -222,16 +224,10 @@ class SearchQueryTransformer < Parslet::Transform
 
       term
     end
-  end
 
-  class TermValidator
-    STRICT_DATE_REGEX = /\A\d{4}-\d{2}-\d{2}\z/ # yyyy-MM-dd
-    EPOCH_MILLIS_REGEX = /\A\d{1,19}\z/
-
-    def self.validate_date!(value)
-      return value if value.match?(STRICT_DATE_REGEX) || value.match?(EPOCH_MILLIS_REGEX)
-
-      raise Mastodon::FilterValidationError, "Invalid date #{value}"
+    def date_from_term(term)
+      DateTime.iso8601(term) unless term.match?(EPOCH_RE) # This will raise Date::Error if the date is invalid
+      term
     end
   end
 

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -8,7 +8,6 @@ module Mastodon
   class LengthValidationError < ValidationError; end
   class DimensionsValidationError < ValidationError; end
   class StreamValidationError < ValidationError; end
-  class FilterValidationError < ValidationError; end
   class RaceConditionError < Error; end
   class RateLimitExceededError < Error; end
   class SyntaxError < Error; end

--- a/spec/lib/search_query_transformer_spec.rb
+++ b/spec/lib/search_query_transformer_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe SearchQueryTransformer do
       let(:query) { "#{operator}:\"abc\"" }
 
       it 'raises an exception' do
-        expect { subject }.to raise_error(Mastodon::FilterValidationError, 'Invalid date abc')
+        expect { subject }.to raise_error(Date::Error)
       end
     end
   end


### PR DESCRIPTION
Fix #32731