### PR TITLE
Extract `User::Confirmation` model concern

### DIFF
--- a/app/models/concerns/user/confirmation.rb
+++ b/app/models/concerns/user/confirmation.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module User::Confirmation
+  extend ActiveSupport::Concern
+
+  included do
+    scope :confirmed, -> { where.not(confirmed_at: nil) }
+    scope :unconfirmed, -> { where(confirmed_at: nil) }
+  end
+
+  def confirmed?
+    confirmed_at.present?
+  end
+
+  def unconfirmed?
+    !confirmed?
+  end
+
+  def confirm
+    wrap_email_confirmation do
+      super
+    end
+  end
+
+  # Mark current email as confirmed, bypassing Devise
+  def mark_email_as_confirmed!
+    wrap_email_confirmation do
+      skip_confirmation!
+      save!
+    end
+  end
+
+  private
+
+  def wrap_email_confirmation
+    new_user = !confirmed?
+    self.approved = true if grant_approval_on_confirmation?
+
+    yield
+
+    if new_user
+      # Handle race condition when approving and confirming user at the same time
+      reload unless approved?
+
+      if approved?
+        prepare_new_user!
+      else
+        notify_staff_about_pending_account!
+      end
+    end
+  end
+end

--- a/app/models/concerns/user/confirmation.rb
+++ b/app/models/concerns/user/confirmation.rb
@@ -15,38 +15,4 @@ module User::Confirmation
   def unconfirmed?
     !confirmed?
   end
-
-  def confirm
-    wrap_email_confirmation do
-      super
-    end
-  end
-
-  # Mark current email as confirmed, bypassing Devise
-  def mark_email_as_confirmed!
-    wrap_email_confirmation do
-      skip_confirmation!
-      save!
-    end
-  end
-
-  private
-
-  def wrap_email_confirmation
-    new_user = !confirmed?
-    self.approved = true if grant_approval_on_confirmation?
-
-    yield
-
-    if new_user
-      # Handle race condition when approving and confirming user at the same time
-      reload unless approved?
-
-      if approved?
-        prepare_new_user!
-      else
-        notify_staff_about_pending_account!
-      end
-    end
-  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -188,6 +188,20 @@ class User < ApplicationRecord
     account_id
   end
 
+  def confirm
+    wrap_email_confirmation do
+      super
+    end
+  end
+
+  # Mark current email as confirmed, bypassing Devise
+  def mark_email_as_confirmed!
+    wrap_email_confirmation do
+      skip_confirmation!
+      save!
+    end
+  end
+
   def update_sign_in!(new_sign_in: false)
     old_current = current_sign_in_at
     new_current = Time.now.utc
@@ -399,6 +413,25 @@ class User < ApplicationRecord
   def grant_approval_on_confirmation?
     # Re-check approval on confirmation if the server has switched to open registrations
     open_registrations? && !sign_up_from_ip_requires_approval? && !sign_up_email_requires_approval?
+  end
+
+  def wrap_email_confirmation
+    new_user      = !confirmed?
+    self.approved = true if grant_approval_on_confirmation?
+
+    yield
+
+    if new_user
+      # Avoid extremely unlikely race condition when approving and confirming
+      # the user at the same time
+      reload unless approved?
+
+      if approved?
+        prepare_new_user!
+      else
+        notify_staff_about_pending_account!
+      end
+    end
   end
 
   def sign_up_from_ip_requires_approval?


### PR DESCRIPTION
Similar to and mentioned in https://github.com/mastodon/mastodon/pull/32855

There are a few more related methods here, but they have load-order issues with devise. Figured I'd do the simple ones first and then add the next few after confirming how that works.

Separately, I think devise defines a `confirmed?` with similar meaning as our version ... could drop maybe.