### PR TITLE
Move welcome mailer account condition checks to `OnboardingPresenter`

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -135,11 +135,9 @@ class UserMailer < Devise::Mailer
 
     return unless @resource.active_for_authentication?
 
+    @onboarding = OnboardingPresenter.new(@resource.account)
     @suggestions = AccountSuggestions.new(@resource.account).get(5)
     @tags = Trends.tags.query.allowed.limit(5)
-    @has_account_fields = @resource.account.display_name.present? || @resource.account.note.present? || @resource.account.avatar.present?
-    @has_active_relationships = @resource.account.active_relationships.exists?
-    @has_statuses = @resource.account.statuses.exists?
 
     I18n.with_locale(locale) do
       mail subject: default_i18n_subject

--- a/app/presenters/onboarding_presenter.rb
+++ b/app/presenters/onboarding_presenter.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class OnboardingPresenter
+  attr_reader :account
+
+  SUGGESTIONS = 5
+
+  def initialize(account)
+    @account = account
+  end
+
+  def account_fields_present?
+    account.display_name.present? || account.note.present? || account.avatar.present?
+  end
+
+  def active_relationships?
+    account.active_relationships.exists?
+  end
+
+  def statuses_exist?
+    account.statuses.exists?
+  end
+end

--- a/app/views/user_mailer/welcome.html.haml
+++ b/app/views/user_mailer/welcome.html.haml
@@ -25,9 +25,9 @@
     %td.email-body-huge-padding-td
       %h2.email-h2= t('user_mailer.welcome.checklist_title')
       %p.email-h-sub= t('user_mailer.welcome.checklist_subtitle')
-      = render 'application/mailer/checklist', key: 'edit_profile', checked: @has_account_fields, button_text: t('user_mailer.welcome.edit_profile_action'), button_url: web_url('start/profile')
-      = render 'application/mailer/checklist', key: 'follow', checked: @has_active_relationships, button_text: t('user_mailer.welcome.follow_action'), button_url: web_url('start/follows')
-      = render 'application/mailer/checklist', key: 'post', checked: @has_statuses, button_text: t('user_mailer.welcome.post_action'), button_url: web_url
+      = render 'application/mailer/checklist', key: 'edit_profile', checked: @onboarding.account_fields_present?, button_text: t('user_mailer.welcome.edit_profile_action'), button_url: web_url('start/profile')
+      = render 'application/mailer/checklist', key: 'follow', checked: @onboarding.active_relationships?, button_text: t('user_mailer.welcome.follow_action'), button_url: web_url('start/follows')
+      = render 'application/mailer/checklist', key: 'post', checked: @onboarding.statuses_exist?, button_text: t('user_mailer.welcome.post_action'), button_url: web_url
       = render 'application/mailer/checklist', key: 'share', checked: false, button_text: t('user_mailer.welcome.share_action'), button_url: web_url('start/share')
       = render 'application/mailer/checklist', key: 'apps', checked: false, show_apps_buttons: true
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }


### PR DESCRIPTION
Possible followups here:

- Also move in the tags/suggestions (those are less narrowly about onboarding an account ... but maybe close enough)?
- Extract classes for the "checklist" and "feature" concepts in this mailer - either within this presenter or working with it - which let us do a collection render for those sections?