### PR TITLE
Remove unused `api/v1/polls#create` route

### DIFF
--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -225,7 +225,7 @@ namespace :api, format: false do
 
     resources :featured_tags, only: [:index, :create, :destroy]
 
-    resources :polls, only: [:create, :show] do
+    resources :polls, only: [:show] do
       resources :votes, only: :create, module: :polls
     end
 


### PR DESCRIPTION
Looks like the route was added with initial PR - https://github.com/mastodon/mastodon/pull/10111/files#diff-959bc9abc46a55332bb64d5155a79323afa75a50ec1a2137ddd22d926f62c6c5R365 - but a `create` controller action has never actually existed?