### PR TITLE
Fix error in CLI EmailDomainBlocks when supplying `--with-dns-records`

### DIFF
--- a/lib/mastodon/cli/email_domain_blocks.rb
+++ b/lib/mastodon/cli/email_domain_blocks.rb
@@ -48,7 +48,7 @@ module Mastodon::CLI
         if options[:with_dns_records]
           Resolv::DNS.open do |dns|
             dns.timeouts = 5
-            other_domains = dns.getresources(@email_domain_block.domain, Resolv::DNS::Resource::IN::MX).to_a
+            other_domains = dns.getresources(domain, Resolv::DNS::Resource::IN::MX).to_a
           end
         end
 

--- a/lib/mastodon/cli/email_domain_blocks.rb
+++ b/lib/mastodon/cli/email_domain_blocks.rb
@@ -48,7 +48,7 @@ module Mastodon::CLI
         if options[:with_dns_records]
           Resolv::DNS.open do |dns|
             dns.timeouts = 5
-            other_domains = dns.getresources(domain, Resolv::DNS::Resource::IN::MX).to_a
+            other_domains = dns.getresources(domain, Resolv::DNS::Resource::IN::MX).to_a.map { |e| e.exchange.to_s }.compact_blank
           end
         end
 

--- a/spec/lib/mastodon/cli/email_domain_blocks_spec.rb
+++ b/spec/lib/mastodon/cli/email_domain_blocks_spec.rb
@@ -70,11 +70,7 @@ RSpec.describe Mastodon::CLI::EmailDomainBlocks do
       let(:options) { { with_dns_records: true } }
 
       before do
-        resolver = instance_double(Resolv::DNS)
-
-        allow(resolver).to receive(:getresources).with(domain, Resolv::DNS::Resource::IN::MX).and_return(%w(other.host))
-        allow(resolver).to receive(:timeouts=).and_return(nil)
-        allow(Resolv::DNS).to receive(:open).and_yield(resolver)
+        configure_mx(domain: domain, exchange: 'other.host')
       end
 
       it 'adds a new block for parent and children' do


### PR DESCRIPTION
The CLI line changed was added in https://github.com/mastodon/mastodon/pull/17842/files#diff-3fcd83db8f04ad94ce30166173fd117ffa4e480b9f9f2c8792ec234694a62ec2R60 ... I'm assuming that was a copy/paste from elsewhere, or accidental conversion of local->instance when moved from above in that PR.

Related - the `other_domains` logic in this CLI class and in the controller where processed are pretty similar ... could pull those into model and/or otherwise de-dupe.