### PR TITLE
Add `DomainResource` class to wrap MX lookup/normalize

### DIFF
--- a/app/controllers/admin/email_domain_blocks_controller.rb
+++ b/app/controllers/admin/email_domain_blocks_controller.rb
@@ -58,12 +58,7 @@ module Admin
     private
 
     def set_resolved_records
-      @resolved_records = domain_resource.mx
-    end
-
-    def domain_resource
-      DomainResource
-        .new(@email_domain_block.domain)
+      @resolved_records = DomainResource.new(@email_domain_block.domain).mx
     end
 
     def resource_params

--- a/app/controllers/admin/email_domain_blocks_controller.rb
+++ b/app/controllers/admin/email_domain_blocks_controller.rb
@@ -58,7 +58,7 @@ module Admin
     private
 
     def set_resolved_records
-      @resolved_records = domain_resource.mx_resources
+      @resolved_records = domain_resource.mx
     end
 
     def domain_resource

--- a/app/controllers/admin/email_domain_blocks_controller.rb
+++ b/app/controllers/admin/email_domain_blocks_controller.rb
@@ -58,10 +58,12 @@ module Admin
     private
 
     def set_resolved_records
-      Resolv::DNS.open do |dns|
-        dns.timeouts = 5
-        @resolved_records = dns.getresources(@email_domain_block.domain, Resolv::DNS::Resource::IN::MX).to_a
-      end
+      @resolved_records = domain_resource.mx_resources
+    end
+
+    def domain_resource
+      DomainResource
+        .new(@email_domain_block.domain)
     end
 
     def resource_params

--- a/app/lib/domain_resource.rb
+++ b/app/lib/domain_resource.rb
@@ -9,7 +9,7 @@ class DomainResource
     @domain = domain
   end
 
-  def mx_resources
+  def mx
     Resolv::DNS.open do |dns|
       dns.timeouts = TIMEOUT_LIMIT
       dns.getresources(domain, Resolv::DNS::Resource::IN::MX).to_a

--- a/app/lib/domain_resource.rb
+++ b/app/lib/domain_resource.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class DomainResource
+  attr_reader :domain
+
+  TIMEOUT_LIMIT = 5
+
+  def initialize(domain)
+    @domain = domain
+  end
+
+  def mx_resources
+    Resolv::DNS.open do |dns|
+      dns.timeouts = TIMEOUT_LIMIT
+      dns.getresources(domain, Resolv::DNS::Resource::IN::MX).to_a
+    end
+  end
+end

--- a/app/lib/domain_resource.rb
+++ b/app/lib/domain_resource.rb
@@ -12,7 +12,11 @@ class DomainResource
   def mx
     Resolv::DNS.open do |dns|
       dns.timeouts = TIMEOUT_LIMIT
-      dns.getresources(domain, Resolv::DNS::Resource::IN::MX).to_a
+      dns
+        .getresources(domain, Resolv::DNS::Resource::IN::MX)
+        .to_a
+        .map { |mx| mx.exchange.to_s }
+        .compact_blank
     end
   end
 end

--- a/app/lib/domain_resource.rb
+++ b/app/lib/domain_resource.rb
@@ -3,7 +3,7 @@
 class DomainResource
   attr_reader :domain
 
-  TIMEOUT_LIMIT = 5
+  RESOLVE_TIMEOUT = 5
 
   def initialize(domain)
     @domain = domain
@@ -11,7 +11,7 @@ class DomainResource
 
   def mx
     Resolv::DNS.open do |dns|
-      dns.timeouts = TIMEOUT_LIMIT
+      dns.timeouts = RESOLVE_TIMEOUT
       dns
         .getresources(domain, Resolv::DNS::Resource::IN::MX)
         .to_a

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -457,13 +457,7 @@ class User < ApplicationRecord
 
     # Doing this conditionally is not very satisfying, but this is consistent
     # with the MX records validations we do and keeps the specs tractable.
-    unless self.class.skip_mx_check?
-      Resolv::DNS.open do |dns|
-        dns.timeouts = 5
-
-        records = dns.getresources(domain, Resolv::DNS::Resource::IN::MX).to_a.map { |e| e.exchange.to_s }.compact_blank
-      end
-    end
+    records = DomainResource.new(domain).mx unless self.class.skip_mx_check?
 
     EmailDomainBlock.requires_approval?(records + [domain], attempt_ip: sign_up_ip)
   end

--- a/app/views/admin/email_domain_blocks/new.html.haml
+++ b/app/views/admin/email_domain_blocks/new.html.haml
@@ -30,12 +30,12 @@
             %label.batch-table__row__select.batch-table__row__select--aligned.batch-checkbox
               = f.input_field :other_domains,
                               as: :boolean,
-                              checked_value: record.exchange.to_s,
+                              checked_value: record,
                               include_hidden: false,
                               multiple: true
             .batch-table__row__content.pending-account
               .pending-account__header
-                %samp= record.exchange.to_s
+                %samp= record
                 %br
                 = t('admin.email_domain_blocks.dns.types.mx')
 

--- a/lib/mastodon/cli/email_domain_blocks.rb
+++ b/lib/mastodon/cli/email_domain_blocks.rb
@@ -45,7 +45,7 @@ module Mastodon::CLI
         end
 
         other_domains = []
-        other_domains = DomainResource.new(domain).mx_resources if options[:with_dns_records]
+        other_domains = DomainResource.new(domain).mx if options[:with_dns_records]
 
         email_domain_block = EmailDomainBlock.new(domain: domain, other_domains: other_domains)
         email_domain_block.save!

--- a/lib/mastodon/cli/email_domain_blocks.rb
+++ b/lib/mastodon/cli/email_domain_blocks.rb
@@ -45,12 +45,7 @@ module Mastodon::CLI
         end
 
         other_domains = []
-        if options[:with_dns_records]
-          Resolv::DNS.open do |dns|
-            dns.timeouts = 5
-            other_domains = dns.getresources(domain, Resolv::DNS::Resource::IN::MX).to_a.map { |e| e.exchange.to_s }.compact_blank
-          end
-        end
+        other_domains = DomainResource.new(domain).mx_resources if options[:with_dns_records]
 
         email_domain_block = EmailDomainBlock.new(domain: domain, other_domains: other_domains)
         email_domain_block.save!

--- a/spec/lib/domain_resource_spec.rb
+++ b/spec/lib/domain_resource_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DomainResource do
+  describe '#mx' do
+    subject { described_class.new(domain) }
+
+    let(:domain) { 'example.host' }
+    let(:exchange) { 'mx.host' }
+
+    before { configure_mx(domain: domain, exchange: exchange) }
+
+    it 'returns array of hostnames' do
+      expect(subject.mx)
+        .to eq([exchange])
+    end
+  end
+end


### PR DESCRIPTION
I was actually doing this when I found https://github.com/mastodon/mastodon/pull/32863 -- that one should probably merge first, so will keep this draft for now.

Changes:

- Add `DomainResource` class which takes a string and does an MX lookup, returning array of hostname strings
- Update admin/email_domain_blocks controller, user class, email domain blocks CLI - to all use this wrapper class
- Update view which now has an array of strings and doesnt need to run through the `exchange.to_s` step

Good next steps:

- The `configure_mx` helper was added recently, but could be expanded to allow for more edge case stubbing, for both this class spec and elsewhere. There's also still some more conversion to do with things that probably could use it but are not
- We could move the "skip mx check" from `User` over to this class