### PR TITLE
Add missing routes check to CI ruby lint step

### DIFF
--- a/.github/workflows/lint-ruby.yml
+++ b/.github/workflows/lint-ruby.yml
@@ -52,4 +52,4 @@ jobs:
 
       - name: Check for unused routes
         if: always()
-        run: bin/rails routes --unused
+        run: RAILS_ENV=test bin/rails routes --unused

--- a/.github/workflows/lint-ruby.yml
+++ b/.github/workflows/lint-ruby.yml
@@ -50,5 +50,5 @@ jobs:
       - name: Check for unused routes
         if: always()
         env:
-          RAILS_ENV: development
+          RAILS_ENV: test
         run: bin/rails routes --unused

--- a/.github/workflows/lint-ruby.yml
+++ b/.github/workflows/lint-ruby.yml
@@ -53,5 +53,5 @@ jobs:
       - name: Check for unused routes
         if: always()
         env:
-          RAILS_ENV: test
+          RAILS_ENV: development
         run: bin/rails routes --unused

--- a/.github/workflows/lint-ruby.yml
+++ b/.github/workflows/lint-ruby.yml
@@ -52,4 +52,6 @@ jobs:
 
       - name: Check for unused routes
         if: always()
-        run: RAILS_ENV=test bin/rails routes --unused
+        env:
+          RAILS_ENV: test
+        run: bin/rails routes --unused

--- a/.github/workflows/lint-ruby.yml
+++ b/.github/workflows/lint-ruby.yml
@@ -49,3 +49,7 @@ jobs:
       - name: Run brakeman
         if: always() # Run both checks, even if the first failed
         run: bin/brakeman
+
+      - name: Check for unused routes
+        if: always()
+        run: bin/rails routes --unused

--- a/.github/workflows/lint-ruby.yml
+++ b/.github/workflows/lint-ruby.yml
@@ -28,9 +28,6 @@ jobs:
   lint:
     runs-on: ubuntu-latest
 
-    env:
-      BUNDLE_ONLY: development
-
     steps:
       - name: Clone repository
         uses: actions/checkout@v4


### PR DESCRIPTION
With https://github.com/mastodon/mastodon/pull/32860 merged there are not currently any unused routes (in the sense meant by this tool ... just matching defined routes to defined controller actions, not verying actual usage in the app).