### PR TITLE
Move admin pending counts into `Admin::DashboardPresenter` class

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -7,12 +7,9 @@ module Admin
     def index
       authorize :dashboard, :index?
 
-      @pending_appeals_count = Appeal.pending.async_count
-      @pending_reports_count = Report.unresolved.async_count
-      @pending_tags_count    = Tag.pending_review.async_count
-      @pending_users_count   = User.pending.async_count
-      @system_checks         = Admin::SystemCheck.perform(current_user)
-      @time_period           = (29.days.ago.to_date...Time.now.utc.to_date)
+      @dashboard = Admin::DashboardPresenter.new
+      @system_checks = Admin::SystemCheck.perform(current_user)
+      @time_period = (29.days.ago.to_date...Time.now.utc.to_date)
     end
   end
 end

--- a/app/presenters/admin/dashboard_presenter.rb
+++ b/app/presenters/admin/dashboard_presenter.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class Admin::DashboardPresenter
+  attr_reader :counts
+
+  def initialize
+    @counts = populate_counts
+  end
+
+  def pending_appeals_count
+    counts[:appeals].value
+  end
+
+  def pending_reports_count
+    counts[:reports].value
+  end
+
+  def pending_tags_count
+    counts[:tags].value
+  end
+
+  def pending_users_count
+    counts[:users].value
+  end
+
+  private
+
+  def populate_counts
+    {
+      appeals: Appeal.pending.async_count,
+      reports: Report.unresolved.async_count,
+      tags: Tag.pending_review.async_count,
+      users: User.pending.async_count,
+    }
+  end
+end

--- a/app/views/admin/dashboard/index.html.haml
+++ b/app/views/admin/dashboard/index.html.haml
@@ -54,19 +54,19 @@
 
   .dashboard__item
     = link_to admin_reports_path, class: 'dashboard__quick-access' do
-      %span= t('admin.dashboard.pending_reports_html', count: @pending_reports_count.value)
+      %span= t('admin.dashboard.pending_reports_html', count: @dashboard.pending_reports_count)
       = material_symbol 'chevron_right'
 
     = link_to admin_accounts_path(status: 'pending'), class: 'dashboard__quick-access' do
-      %span= t('admin.dashboard.pending_users_html', count: @pending_users_count.value)
+      %span= t('admin.dashboard.pending_users_html', count: @dashboard.pending_users_count)
       = material_symbol 'chevron_right'
 
     = link_to admin_trends_tags_path(status: 'pending_review'), class: 'dashboard__quick-access' do
-      %span= t('admin.dashboard.pending_tags_html', count: @pending_tags_count.value)
+      %span= t('admin.dashboard.pending_tags_html', count: @dashboard.pending_tags_count)
       = material_symbol 'chevron_right'
 
     = link_to admin_disputes_appeals_path(status: 'pending'), class: 'dashboard__quick-access' do
-      %span= t('admin.dashboard.pending_appeals_html', count: @pending_appeals_count.value)
+      %span= t('admin.dashboard.pending_appeals_html', count: @dashboard.pending_appeals_count)
       = material_symbol 'chevron_right'
   .dashboard__item
     = react_admin_component :dimension,


### PR DESCRIPTION
Reduce ivar setup in controller action, preserves the async aspect of the counting.

Similar to https://github.com/mastodon/mastodon/pull/32227 which did something similar on the export summary view.

Similar to https://github.com/mastodon/mastodon/pull/32859 in that one side goal there is to prepare for wrapping the checklist/feature portions of view in collection render, and one side goal here is to be able to pull out all the dashboard components on this page into a collection render or better abstraction as well.