### PR TITLE
Add coverage for malformed version cleanup in `SoftwareUpdateCheckService`, add helper query methods

### DIFF
--- a/app/models/software_update.rb
+++ b/app/models/software_update.rb
@@ -26,6 +26,10 @@ class SoftwareUpdate < ApplicationRecord
     Mastodon::Version.gem_version >= gem_version
   end
 
+  def pending?
+    gem_version > Mastodon::Version.gem_version
+  end
+
   class << self
     def check_enabled?
       Rails.configuration.x.mastodon.software_update_url.present?
@@ -34,7 +38,7 @@ class SoftwareUpdate < ApplicationRecord
     def pending_to_a
       return [] unless check_enabled?
 
-      all.to_a.filter { |update| update.gem_version > Mastodon::Version.gem_version }
+      all.to_a.filter(&:pending?)
     end
 
     def urgent_pending?

--- a/app/models/software_update.rb
+++ b/app/models/software_update.rb
@@ -22,6 +22,10 @@ class SoftwareUpdate < ApplicationRecord
     Gem::Version.new(version)
   end
 
+  def outdated?
+    Mastodon::Version.gem_version >= gem_version
+  end
+
   class << self
     def check_enabled?
       Rails.configuration.x.mastodon.software_update_url.present?

--- a/app/models/software_update.rb
+++ b/app/models/software_update.rb
@@ -23,11 +23,11 @@ class SoftwareUpdate < ApplicationRecord
   end
 
   def outdated?
-    Mastodon::Version.gem_version >= gem_version
+    runtime_version >= gem_version
   end
 
   def pending?
-    gem_version > Mastodon::Version.gem_version
+    gem_version > runtime_version
   end
 
   class << self
@@ -44,5 +44,11 @@ class SoftwareUpdate < ApplicationRecord
     def urgent_pending?
       pending_to_a.any?(&:urgent?)
     end
+  end
+
+  private
+
+  def runtime_version
+    Mastodon::Version.gem_version
   end
 end

--- a/app/services/software_update_check_service.rb
+++ b/app/services/software_update_check_service.rb
@@ -12,7 +12,7 @@ class SoftwareUpdateCheckService < BaseService
 
   def clean_outdated_updates!
     SoftwareUpdate.find_each do |software_update|
-      software_update.delete if Mastodon::Version.gem_version >= software_update.gem_version
+      software_update.delete if software_update.outdated?
     rescue ArgumentError
       software_update.delete
     end

--- a/spec/models/software_update_spec.rb
+++ b/spec/models/software_update_spec.rb
@@ -3,6 +3,60 @@
 require 'rails_helper'
 
 RSpec.describe SoftwareUpdate do
+  describe '#pending?' do
+    subject { described_class.new(version: update_version) }
+
+    before { allow(Mastodon::Version).to receive(:gem_version).and_return(Gem::Version.new(mastodon_version)) }
+
+    context 'when the runtime version is older than the update' do
+      let(:mastodon_version) { '4.0.0' }
+      let(:update_version) { '5.0.0' }
+
+      it { is_expected.to be_pending }
+    end
+
+    context 'when the runtime version is newer than the update' do
+      let(:mastodon_version) { '6.0.0' }
+      let(:update_version) { '5.0.0' }
+
+      it { is_expected.to_not be_pending }
+    end
+
+    context 'when the runtime version is same as the update' do
+      let(:mastodon_version) { '4.0.0' }
+      let(:update_version) { '4.0.0' }
+
+      it { is_expected.to_not be_pending }
+    end
+  end
+
+  describe '#outdated?' do
+    subject { described_class.new(version: update_version) }
+
+    before { allow(Mastodon::Version).to receive(:gem_version).and_return(Gem::Version.new(mastodon_version)) }
+
+    context 'when the runtime version is older than the update' do
+      let(:mastodon_version) { '4.0.0' }
+      let(:update_version) { '5.0.0' }
+
+      it { is_expected.to_not be_outdated }
+    end
+
+    context 'when the runtime version is newer than the update' do
+      let(:mastodon_version) { '6.0.0' }
+      let(:update_version) { '5.0.0' }
+
+      it { is_expected.to be_outdated }
+    end
+
+    context 'when the runtime version is same as the update' do
+      let(:mastodon_version) { '4.0.0' }
+      let(:update_version) { '4.0.0' }
+
+      it { is_expected.to be_outdated }
+    end
+  end
+
   describe '.pending_to_a' do
     before do
       allow(Mastodon::Version).to receive(:gem_version).and_return(Gem::Version.new(mastodon_version))

--- a/spec/services/software_update_check_service_spec.rb
+++ b/spec/services/software_update_check_service_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe SoftwareUpdateCheckService do
     before do
       Fabricate(:software_update, version: '3.5.0', type: 'major', urgent: false)
       Fabricate(:software_update, version: '42.13.12', type: 'major', urgent: false)
+      Fabricate(:software_update, version: 'Malformed', type: 'major', urgent: false)
 
       owner_user.settings.update('notification_emails.software_updates': 'all')
       owner_user.save!
@@ -50,7 +51,7 @@ RSpec.describe SoftwareUpdateCheckService do
       end
 
       it 'deletes outdated update records but keeps valid update records' do
-        expect { subject.call }.to change { SoftwareUpdate.pluck(:version).sort }.from(['3.5.0', '42.13.12']).to(['42.13.12'])
+        expect { subject.call }.to change { SoftwareUpdate.pluck(:version).sort }.from(['3.5.0', '42.13.12', 'Malformed']).to(['42.13.12'])
       end
     end
 
@@ -85,7 +86,7 @@ RSpec.describe SoftwareUpdateCheckService do
       end
 
       it 'updates the list of known updates' do
-        expect { subject.call }.to change { SoftwareUpdate.pluck(:version).sort }.from(['3.5.0', '42.13.12']).to(['4.2.1', '4.3.0', '5.0.0'])
+        expect { subject.call }.to change { SoftwareUpdate.pluck(:version).sort }.from(['3.5.0', '42.13.12', 'Malformed']).to(['4.2.1', '4.3.0', '5.0.0'])
       end
 
       context 'when no update is urgent' do


### PR DESCRIPTION
There's a line in the service which rescues an `ArgumentError` and deletes updates that raised it - https://github.com/mastodon/mastodon/blob/v4.3.1/app/services/software_update_check_service.rb#L16-L18 - I assume this is to handle the scenario where garbage data gets in there by accident and we want to clean it up. This line was not hit by spec - so added coverage in the service spec.

Separately - we had two different spots doing version comparised about whether updates were outdated or pending - wrapped those into query methods.

Possible future improvements:

- There are a few external spots which sort records based on gem version. We cant literally add a scope here because of the string/semver aspect of the version value, but we could add a class method that acts like one.
- Same deal but on "urgent" checks externally
- Maybe rename the `pending_to_a` class method to just `pending`?