### PR TITLE
Fix titles being escaped twice

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -79,7 +79,7 @@ module ApplicationHelper
 
   def html_title
     safe_join(
-      [content_for(:page_title).to_s.chomp, title]
+      [content_for(:page_title), title]
       .compact_blank,
       ' - '
     )

--- a/app/views/about/show.html.haml
+++ b/app/views/about/show.html.haml
@@ -1,5 +1,4 @@
-- content_for :page_title do
-  = t('about.title')
+- content_for :page_title, t('about.title')
 
 - content_for :header_tags do
   = render partial: 'shared/og'

--- a/app/views/accounts/show.html.haml
+++ b/app/views/accounts/show.html.haml
@@ -1,5 +1,4 @@
-- content_for :page_title do
-  #{display_name(@account)} (#{acct(@account)})
+- content_for :page_title, "#{display_name(@account)} (#{acct(@account)})"
 
 - content_for :header_tags do
   - if @account.user_prefers_noindex?

--- a/app/views/privacy/show.html.haml
+++ b/app/views/privacy/show.html.haml
@@ -1,5 +1,4 @@
-- content_for :page_title do
-  = t('privacy_policy.title')
+- content_for :page_title, t('privacy_policy.title')
 
 - content_for :header_tags do
   = render partial: 'shared/og'

--- a/app/views/statuses/show.html.haml
+++ b/app/views/statuses/show.html.haml
@@ -1,5 +1,4 @@
-- content_for :page_title do
-  = t('statuses.title', name: display_name(@account), quote: truncate(@status.spoiler_text.presence || @status.text, length: 50, omission: '…', escape: false))
+- content_for :page_title, t('statuses.title', name: display_name(@account), quote: truncate(@status.spoiler_text.presence || @status.text, length: 50, omission: '…', escape: false))
 
 - content_for :header_tags do
   - if @account.user_prefers_noindex?

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -257,11 +257,11 @@ RSpec.describe ApplicationHelper do
         expect(helper.html_title).to be_html_safe
       end
 
-      it 'removes extra new lines' do
+      it 'does not escape twice' do
         Setting.site_title = 'Site Title'
-        helper.content_for(:page_title, "Test Value\n")
+        helper.content_for(:page_title, '&quot;Test Value&quot;'.html_safe)
 
-        expect(helper.html_title).to eq 'Test Value - Site Title'
+        expect(helper.html_title).to eq '&quot;Test Value&quot; - Site Title'
         expect(helper.html_title).to be_html_safe
       end
     end

--- a/spec/views/statuses/show.html.haml_spec.rb
+++ b/spec/views/statuses/show.html.haml_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'statuses/show.html.haml' do
     assign(:descendant_threads, [])
   end
 
-  it 'has valid opengraph tags' do
+  it 'has valid opengraph tags and twitter player tags' do
     render
 
     expect(header_tags)
@@ -26,10 +26,6 @@ RSpec.describe 'statuses/show.html.haml' do
       .and match(/<meta content="article" property="og:type">/)
       .and match(/<meta content=".+" property="og:image">/)
       .and match(%r{<meta content="http://.+" property="og:url">})
-  end
-
-  it 'has twitter player tag' do
-    render
 
     expect(header_tags)
       .to match(%r{<meta content="http://.+/media/.+/player" property="twitter:player">})


### PR DESCRIPTION
Fixes #32877

Note that this causes the titles to include a newline