### PR TITLE
Fix filters not being correctly applied to boosted posts

### DIFF
--- a/app/javascript/mastodon/components/status.jsx
+++ b/app/javascript/mastodon/components/status.jsx
@@ -397,6 +397,7 @@ class Status extends ImmutablePureComponent {
     const connectUp = previousId && previousId === status.get('in_reply_to_id');
     const connectToRoot = rootId && rootId === status.get('in_reply_to_id');
     const connectReply = nextInReplyToId && nextInReplyToId === status.get('id');
+    const matchedFilters = status.get('matched_filters');
 
     if (featured) {
       prepend = (
@@ -432,7 +433,6 @@ class Status extends ImmutablePureComponent {
       );
     }
 
-    const matchedFilters = status.get('matched_filters');
     const expanded = (!matchedFilters || this.state.showDespiteFilter) && (!status.get('hidden') || status.get('spoiler_text').length === 0);
 
     if (hidden) {


### PR DESCRIPTION
Fix regression from #32887.

Filters are applied on the top-level `status` by the selector, and we were trying to access the boosted status' but that's not where the information is stored.