### PR TITLE
Remove unused failure action in api/base controller spec

### DIFF
--- a/spec/controllers/api/base_controller_spec.rb
+++ b/spec/controllers/api/base_controller_spec.rb
@@ -7,10 +7,6 @@ RSpec.describe Api::BaseController do
     def success
       head 200
     end
-
-    def failure
-      FakeService.new
-    end
   end
 
   it 'returns private cache control headers by default' do


### PR DESCRIPTION
A previous PR moved this coverage to an errors-specific spec, but left this line behind - https://github.com/mastodon/mastodon/pull/29574/files#diff-b336f096f1d3ed96f60d77d325914c284901eb649dfa4597ce10f09d29ec745cL6-L8