### PR TITLE
Combine shared-setup examples across `spec/controllers/auth/*` specs

### DIFF
--- a/spec/controllers/auth/challenges_controller_spec.rb
+++ b/spec/controllers/auth/challenges_controller_spec.rb
@@ -8,9 +8,7 @@ RSpec.describe Auth::ChallengesController do
   let(:password) { 'foobar12345' }
   let(:user) { Fabricate(:user, password: password) }
 
-  before do
-    sign_in user
-  end
+  before { sign_in user }
 
   describe 'POST #create' do
     let(:return_to) { edit_user_registration_path }
@@ -18,28 +16,24 @@ RSpec.describe Auth::ChallengesController do
     context 'with correct password' do
       before { post :create, params: { form_challenge: { return_to: return_to, current_password: password } } }
 
-      it 'redirects back' do
-        expect(response).to redirect_to(return_to)
-      end
-
-      it 'sets session' do
-        expect(session[:challenge_passed_at]).to_not be_nil
+      it 'redirects back and sets challenge passed at in session' do
+        expect(response)
+          .to redirect_to(return_to)
+        expect(session[:challenge_passed_at])
+          .to_not be_nil
       end
     end
 
     context 'with incorrect password' do
       before { post :create, params: { form_challenge: { return_to: return_to, current_password: 'hhfggjjd562' } } }
 
-      it 'renders challenge' do
-        expect(response).to render_template('auth/challenges/new')
-      end
-
-      it 'displays error' do
-        expect(response.body).to include 'Invalid password'
-      end
-
-      it 'does not set session' do
-        expect(session[:challenge_passed_at]).to be_nil
+      it 'renders challenge, displays error, does not set session' do
+        expect(response)
+          .to render_template('auth/challenges/new')
+        expect(response.body)
+          .to include 'Invalid password'
+        expect(session[:challenge_passed_at])
+          .to be_nil
       end
     end
   end

--- a/spec/controllers/auth/confirmations_controller_spec.rb
+++ b/spec/controllers/auth/confirmations_controller_spec.rb
@@ -23,12 +23,11 @@ RSpec.describe Auth::ConfirmationsController do
         get :show, params: { confirmation_token: 'foobar' }
       end
 
-      it 'redirects to login' do
-        expect(response).to redirect_to(new_user_session_path)
-      end
-
-      it 'queues up bootstrapping of home timeline' do
-        expect(BootstrapTimelineWorker).to have_received(:perform_async).with(user.account_id)
+      it 'redirects to login and queues worker' do
+        expect(response)
+          .to redirect_to(new_user_session_path)
+        expect(BootstrapTimelineWorker)
+          .to have_received(:perform_async).with(user.account_id)
       end
     end
 
@@ -88,13 +87,13 @@ RSpec.describe Auth::ConfirmationsController do
         get :show, params: { confirmation_token: 'foobar' }
       end
 
-      it 'redirects to login and confirms email' do
-        expect(response).to redirect_to(new_user_session_path)
-        expect(user.reload.unconfirmed_email).to be_nil
-      end
-
-      it 'does not queue up bootstrapping of home timeline' do
-        expect(BootstrapTimelineWorker).to_not have_received(:perform_async)
+      it 'redirects to login, confirms email, does not queue worker' do
+        expect(response)
+          .to redirect_to(new_user_session_path)
+        expect(user.reload.unconfirmed_email)
+          .to be_nil
+        expect(BootstrapTimelineWorker)
+          .to_not have_received(:perform_async)
       end
     end
   end

--- a/spec/controllers/auth/registrations_controller_spec.rb
+++ b/spec/controllers/auth/registrations_controller_spec.rb
@@ -6,25 +6,33 @@ RSpec.describe Auth::RegistrationsController do
   render_views
 
   shared_examples 'checks for enabled registrations' do |path|
-    it 'redirects if it is in single user mode while it is open for registration' do
-      Fabricate(:account)
-      Setting.registrations_mode = 'open'
-      allow(Rails.configuration.x).to receive(:single_user_mode).and_return(true)
+    context 'when in single user mode and open for registration' do
+      before do
+        Setting.registrations_mode = 'open'
+        allow(Rails.configuration.x).to receive(:single_user_mode).and_return(true)
+      end
 
-      get path
+      it 'redirects to root' do
+        Fabricate(:account)
+        get path
 
-      expect(response).to redirect_to '/'
-      expect(Rails.configuration.x).to have_received(:single_user_mode)
+        expect(response).to redirect_to '/'
+        expect(Rails.configuration.x).to have_received(:single_user_mode)
+      end
     end
 
-    it 'redirects if it is not open for registration while it is not in single user mode' do
-      Setting.registrations_mode = 'none'
-      allow(Rails.configuration.x).to receive(:single_user_mode).and_return(false)
+    context 'when registrations closed and not in single user mode' do
+      before do
+        Setting.registrations_mode = 'none'
+        allow(Rails.configuration.x).to receive(:single_user_mode).and_return(false)
+      end
 
-      get path
+      it 'redirects to root' do
+        get path
 
-      expect(response).to redirect_to '/'
-      expect(Rails.configuration.x).to have_received(:single_user_mode)
+        expect(response).to redirect_to '/'
+        expect(Rails.configuration.x).to have_received(:single_user_mode)
+      end
     end
   end
 
@@ -35,12 +43,12 @@ RSpec.describe Auth::RegistrationsController do
       get :edit
     end
 
-    it 'returns http success' do
-      expect(response).to have_http_status(200)
-    end
+    it 'returns http success and cache headers' do
+      expect(response)
+        .to have_http_status(200)
 
-    it 'returns private cache control header' do
-      expect(response.headers['Cache-Control']).to include('private, no-store')
+      expect(response.headers['Cache-Control'])
+        .to include('private, no-store')
     end
   end
 
@@ -53,14 +61,13 @@ RSpec.describe Auth::RegistrationsController do
       sign_in(user, scope: :user)
     end
 
-    it 'returns http success' do
+    it 'returns http success and cache headers' do
       put :update
-      expect(response).to have_http_status(200)
-    end
 
-    it 'returns private cache control headers' do
-      put :update
-      expect(response.headers['Cache-Control']).to include('private, no-store')
+      expect(response)
+        .to have_http_status(200)
+      expect(response.headers['Cache-Control'])
+        .to include('private, no-store')
     end
 
     it 'can update the user email' do
@@ -174,16 +181,14 @@ RSpec.describe Auth::RegistrationsController do
         post :create, params: { user: { account_attributes: { username: 'test' }, email: 'test@example.com', password: '12345678', password_confirmation: '12345678', agreement: 'true' } }
       end
 
-      it 'redirects to setup' do
+      it 'redirects to setup and creates user' do
         subject
-        expect(response).to redirect_to auth_setup_path
-      end
 
-      it 'creates user' do
-        subject
-        user = User.find_by(email: 'test@example.com')
-        expect(user).to_not be_nil
-        expect(user.locale).to eq(accept_language)
+        expect(response)
+          .to redirect_to auth_setup_path
+        expect(User.find_by(email: 'test@example.com'))
+          .to be_present
+          .and have_attributes(locale: eq(accept_language))
       end
     end
 
@@ -254,17 +259,18 @@ RSpec.describe Auth::RegistrationsController do
         post :create, params: { user: { account_attributes: { username: 'test' }, email: 'test@example.com', password: '12345678', password_confirmation: '12345678', agreement: 'true' } }
       end
 
-      it 'redirects to setup' do
+      it 'redirects to setup and creates user' do
         subject
-        expect(response).to redirect_to auth_setup_path
-      end
 
-      it 'creates user' do
-        subject
-        user = User.find_by(email: 'test@example.com')
-        expect(user).to_not be_nil
-        expect(user.locale).to eq(accept_language)
-        expect(user.approved).to be(false)
+        expect(response)
+          .to redirect_to auth_setup_path
+
+        expect(User.find_by(email: 'test@example.com'))
+          .to be_present
+          .and have_attributes(
+            locale: eq(accept_language),
+            approved: be(false)
+          )
       end
     end
 
@@ -276,17 +282,17 @@ RSpec.describe Auth::RegistrationsController do
         post :create, params: { user: { account_attributes: { username: 'test' }, email: 'test@example.com', password: '12345678', password_confirmation: '12345678', invite_code: invite.code, agreement: 'true' } }
       end
 
-      it 'redirects to setup' do
+      it 'redirects to setup and creates user' do
         subject
-        expect(response).to redirect_to auth_setup_path
-      end
 
-      it 'creates user' do
-        subject
-        user = User.find_by(email: 'test@example.com')
-        expect(user).to_not be_nil
-        expect(user.locale).to eq(accept_language)
-        expect(user.approved).to be(false)
+        expect(response).to redirect_to auth_setup_path
+
+        expect(User.find_by(email: 'test@example.com'))
+          .to be_present
+          .and have_attributes(
+            locale: eq(accept_language),
+            approved: be(false)
+          )
       end
     end
 
@@ -300,17 +306,17 @@ RSpec.describe Auth::RegistrationsController do
         post :create, params: { user: { account_attributes: { username: 'test' }, email: 'test@example.com', password: '12345678', password_confirmation: '12345678', invite_code: invite.code, agreement: 'true' } }
       end
 
-      it 'redirects to setup' do
+      it 'redirects to setup and creates user' do
         subject
-        expect(response).to redirect_to auth_setup_path
-      end
 
-      it 'creates user' do
-        subject
-        user = User.find_by(email: 'test@example.com')
-        expect(user).to_not be_nil
-        expect(user.locale).to eq(accept_language)
-        expect(user.approved).to be(true)
+        expect(response).to redirect_to auth_setup_path
+
+        expect(User.find_by(email: 'test@example.com'))
+          .to be_present
+          .and have_attributes(
+            locale: eq(accept_language),
+            approved: be(true)
+          )
       end
     end
 
@@ -348,12 +354,11 @@ RSpec.describe Auth::RegistrationsController do
       delete :destroy
     end
 
-    it 'returns http not found' do
-      expect(response).to have_http_status(404)
-    end
-
-    it 'does not delete user' do
-      expect(User.find(user.id)).to_not be_nil
+    it 'returns http not found and keeps user' do
+      expect(response)
+        .to have_http_status(404)
+      expect(User.find(user.id))
+        .to_not be_nil
     end
   end
 end


### PR DESCRIPTION
Done in prep for converting these into system specs.

Drops factory creation across the group from ~80 to ~50.