### PR TITLE
Fix logic in "last used at per application" oauth token list

### DIFF
--- a/app/controllers/oauth/authorized_applications_controller.rb
+++ b/app/controllers/oauth/authorized_applications_controller.rb
@@ -35,12 +35,6 @@ class Oauth::AuthorizedApplicationsController < Doorkeeper::AuthorizedApplicatio
   end
 
   def set_last_used_at_by_app
-    @last_used_at_by_app = Doorkeeper::AccessToken
-                           .select('DISTINCT ON (application_id) application_id, last_used_at')
-                           .where(resource_owner_id: current_resource_owner.id)
-                           .where.not(last_used_at: nil)
-                           .order(application_id: :desc, last_used_at: :desc)
-                           .pluck(:application_id, :last_used_at)
-                           .to_h
+    @last_used_at_by_app = current_resource_owner.applications_last_used
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -280,6 +280,16 @@ class User < ApplicationRecord
     save!
   end
 
+  def applications_last_used
+    Doorkeeper::AccessToken
+      .select('DISTINCT ON (application_id) application_id, last_used_at')
+      .where(resource_owner_id: id)
+      .where.not(last_used_at: nil)
+      .order(application_id: :desc, last_used_at: :desc)
+      .pluck(:application_id, :last_used_at)
+      .to_h
+  end
+
   def token_for_app(app)
     return nil if app.nil? || app.owner != self
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -282,11 +282,10 @@ class User < ApplicationRecord
 
   def applications_last_used
     Doorkeeper::AccessToken
-      .select('DISTINCT ON (application_id) application_id, last_used_at')
       .where(resource_owner_id: id)
       .where.not(last_used_at: nil)
-      .order(application_id: :desc, last_used_at: :desc)
-      .pluck(:application_id, :last_used_at)
+      .group(:application_id)
+      .maximum(:last_used_at)
       .to_h
   end
 


### PR DESCRIPTION
Background: https://github.com/mastodon/mastodon/pull/25060#pullrequestreview-2436891784

The resulting query winds up looking like...

```
Doorkeeper::AccessToken Maximum (1.5ms)  SELECT MAX("oauth_access_tokens"."last_used_at") AS "maximum_last_used_at", "oauth_access_tokens"."application_id" AS "oauth_access_tokens_application_id" FROM "oauth_access_tokens" WHERE "oauth_access_tokens"."resource_owner_id" = $1 AND "oauth_access_tokens"."last_used_at" IS NOT NULL GROUP BY "oauth_access_tokens"."application_id"  [["resource_owner_id", 1259]]
```

...which gives us the id-indexed hash pointing to latest date for each application.

Future improvements here:

- At minium, we could declare an association for user<>token which could be used here and in a few other spots where we are fully building these types of queries
- In addition to that, we could contemplate something like https://github.com/mastodon/mastodon/pull/31042#issuecomment-2433259456 in which case those new models could also have scopes for the "last used not nil" portion of this

I think this spec covers at least the most basic scenarios, but let me know if I missed an edge case or some portion of what this is doing.