### PR TITLE
Use hash arguments to `order` when possible (Rails 7.2)

### DIFF
--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -48,7 +48,7 @@ module Account::Associations
     end
 
     # Status records pinned by the account
-    has_many :pinned_statuses, -> { reorder('status_pins.created_at DESC') }, through: :status_pins, class_name: 'Status', source: :status
+    has_many :pinned_statuses, -> { reorder(status_pins: { created_at: :desc }) }, through: :status_pins, class_name: 'Status', source: :status
 
     # Account records endorsed (pinned) by the account
     has_many :endorsed_accounts, through: :account_pins, class_name: 'Account', source: :target_account

--- a/app/models/concerns/account/interactions.rb
+++ b/app/models/concerns/account/interactions.rb
@@ -80,8 +80,8 @@ module Account::Interactions
       has_many :passive_relationships, foreign_key: 'target_account_id', inverse_of: :target_account
     end
 
-    has_many :following, -> { order('follows.id desc') }, through: :active_relationships,  source: :target_account
-    has_many :followers, -> { order('follows.id desc') }, through: :passive_relationships, source: :account
+    has_many :following, -> { order(follows: { id: :desc }) }, through: :active_relationships,  source: :target_account
+    has_many :followers, -> { order(follows: { id: :desc }) }, through: :passive_relationships, source: :account
 
     with_options class_name: 'SeveredRelationship', dependent: :destroy do
       has_many :severed_relationships, foreign_key: 'local_account_id', inverse_of: :local_account
@@ -96,16 +96,16 @@ module Account::Interactions
       has_many :block_relationships, foreign_key: 'account_id', inverse_of: :account
       has_many :blocked_by_relationships, foreign_key: :target_account_id, inverse_of: :target_account
     end
-    has_many :blocking, -> { order('blocks.id desc') }, through: :block_relationships, source: :target_account
-    has_many :blocked_by, -> { order('blocks.id desc') }, through: :blocked_by_relationships, source: :account
+    has_many :blocking, -> { order(blocks: { id: :desc }) }, through: :block_relationships, source: :target_account
+    has_many :blocked_by, -> { order(blocks: { id: :desc }) }, through: :blocked_by_relationships, source: :account
 
     # Mute relationships
     with_options class_name: 'Mute', dependent: :destroy do
       has_many :mute_relationships, foreign_key: 'account_id', inverse_of: :account
       has_many :muted_by_relationships, foreign_key: :target_account_id, inverse_of: :target_account
     end
-    has_many :muting, -> { order('mutes.id desc') }, through: :mute_relationships, source: :target_account
-    has_many :muted_by, -> { order('mutes.id desc') }, through: :muted_by_relationships, source: :account
+    has_many :muting, -> { order(mutes: { id: :desc }) }, through: :mute_relationships, source: :target_account
+    has_many :muted_by, -> { order(mutes: { id: :desc }) }, through: :muted_by_relationships, source: :account
     has_many :conversation_mutes, dependent: :destroy
     has_many :domain_blocks, class_name: 'AccountDomainBlock', dependent: :destroy
     has_many :announcement_mutes, dependent: :destroy

--- a/app/models/instance_filter.rb
+++ b/app/models/instance_filter.rb
@@ -28,9 +28,9 @@ class InstanceFilter
   def scope_for(key, value)
     case key.to_s
     when 'limited'
-      Instance.joins(:domain_block).reorder(Arel.sql('domain_blocks.id desc'))
+      Instance.joins(:domain_block).reorder(domain_blocks: { id: :desc })
     when 'allowed'
-      Instance.joins(:domain_allow).reorder(Arel.sql('domain_allows.id desc'))
+      Instance.joins(:domain_allow).reorder(domain_allows: { id: :desc })
     when 'by_domain'
       Instance.matches_domain(value)
     when 'availability'

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -61,7 +61,7 @@ class Tag < ApplicationRecord
   scope :recently_used, lambda { |account|
                           joins(:statuses)
                             .where(statuses: { id: account.statuses.select(:id).limit(RECENT_STATUS_LIMIT) })
-                            .group(:id).order(Arel.sql('count(*) desc'))
+                            .group(:id).order(Arel.star.count.desc)
                         }
   scope :matches_name, ->(term) { where(arel_table[:name].lower.matches(arel_table.lower("#{sanitize_sql_like(Tag.normalize(term))}%"), nil, true)) } # Search with case-sensitive to use B-tree index
 
@@ -127,7 +127,7 @@ class Tag < ApplicationRecord
       query = query.merge(Tag.listable) if options[:exclude_unlistable]
       query = query.merge(matching_name(stripped_term).or(reviewed)) if options[:exclude_unreviewed]
 
-      query.order(Arel.sql('length(name) ASC, name ASC'))
+      query.order(Arel.sql('LENGTH(name)').asc, name: :asc)
            .limit(limit)
            .offset(offset)
     end


### PR DESCRIPTION
Another Rails 7.2 update like https://github.com/mastodon/mastodon/pull/32799 or https://github.com/mastodon/mastodon/pull/32909

In 7.2 some of the methods (select, pluck, pick, order, reorder, etc) that did not already have support for hash arguments now do have that support. This PR does the order/reorder changes only, will do others per-method if I find them.

With the exception of framework-generated sql quoting style, queries should be the same.

While in there, found two order in `Tag` which I made "more generated" (though not fully), even though its not the exact same. This is in separate commit if objectionable.

Related to https://github.com/mastodon/mastodon/pull/32435 - I think *removing the order* would be preferable on the associations, but if we are not ready for that this is fine.