### PR TITLE
Use hash arguments to `group` when possible

### DIFF
--- a/app/lib/annual_report/most_reblogged_accounts.rb
+++ b/app/lib/annual_report/most_reblogged_accounts.rb
@@ -17,6 +17,6 @@ class AnnualReport::MostRebloggedAccounts < AnnualReport::Source
   private
 
   def most_reblogged_accounts
-    report_statuses.where.not(reblog_of_id: nil).joins(reblog: :account).group('accounts.id').having('count(*) > 1').order(count_all: :desc).limit(SET_SIZE).count
+    report_statuses.where.not(reblog_of_id: nil).joins(reblog: :account).group(accounts: [:id]).having('count(*) > 1').order(count_all: :desc).limit(SET_SIZE).count
   end
 end

--- a/app/lib/annual_report/most_used_apps.rb
+++ b/app/lib/annual_report/most_used_apps.rb
@@ -17,6 +17,6 @@ class AnnualReport::MostUsedApps < AnnualReport::Source
   private
 
   def most_used_apps
-    report_statuses.joins(:application).group('oauth_applications.name').order(count_all: :desc).limit(SET_SIZE).count
+    report_statuses.joins(:application).group(oauth_applications: [:name]).order(count_all: :desc).limit(SET_SIZE).count
   end
 end

--- a/app/models/account_filter.rb
+++ b/app/models/account_filter.rb
@@ -61,7 +61,7 @@ class AccountFilter
     when 'email'
       accounts_with_users.merge(User.matches_email(value.to_s.strip))
     when 'ip'
-      valid_ip?(value) ? accounts_with_users.merge(User.matches_ip(value).group('users.id, accounts.id')) : Account.none
+      valid_ip?(value) ? accounts_with_users.merge(User.matches_ip(value).group(users: [:id], accounts: [:id])) : Account.none
     when 'invited_by'
       invited_by_scope(value)
     when 'order'

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -29,8 +29,8 @@ class Poll < ApplicationRecord
   has_many :votes, class_name: 'PollVote', inverse_of: :poll, dependent: :delete_all
 
   with_options class_name: 'Account', source: :account, through: :votes do
-    has_many :voters, -> { group('accounts.id') }
-    has_many :local_voters, -> { group('accounts.id').merge(Account.local) }
+    has_many :voters, -> { group(accounts: [:id]) }
+    has_many :local_voters, -> { group(accounts: [:id]).merge(Account.local) }
   end
 
   has_many :notifications, as: :activity, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -125,7 +125,7 @@ class User < ApplicationRecord
   scope :signed_in_recently, -> { where(current_sign_in_at: ACTIVE_DURATION.ago..) }
   scope :not_signed_in_recently, -> { where(current_sign_in_at: ...ACTIVE_DURATION.ago) }
   scope :matches_email, ->(value) { where(arel_table[:email].matches("#{value}%")) }
-  scope :matches_ip, ->(value) { left_joins(:ips).merge(IpBlock.contained_by(value)).group('users.id') }
+  scope :matches_ip, ->(value) { left_joins(:ips).merge(IpBlock.contained_by(value)).group(users: [:id]) }
 
   before_validation :sanitize_role
   before_create :set_approved


### PR DESCRIPTION
Same background as https://github.com/mastodon/mastodon/pull/32915 and same guidance (ie, maybe some framework-generation style diffs, but should be same logic). Nudging things towards greater consistency/composability across the app.