### PR TITLE
Add `used` scope to access token and `access_tokens` association for User

### DIFF
--- a/app/lib/access_token_extension.rb
+++ b/app/lib/access_token_extension.rb
@@ -13,6 +13,7 @@ module AccessTokenExtension
     scope :expired, -> { where.not(expires_in: nil).where('created_at + MAKE_INTERVAL(secs => expires_in) < NOW()') }
     scope :not_revoked, -> { where(revoked_at: nil) }
     scope :revoked, -> { where.not(revoked_at: nil).where(revoked_at: ...Time.now.utc) }
+    scope :used, -> { where.not(last_used_at: nil) }
   end
 
   def revoke(clock = Time)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -283,7 +283,7 @@ class User < ApplicationRecord
   def applications_last_used
     Doorkeeper::AccessToken
       .where(resource_owner_id: id)
-      .where.not(last_used_at: nil)
+      .used
       .group(:application_id)
       .maximum(:last_used_at)
       .to_h

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -89,6 +89,7 @@ class User < ApplicationRecord
   accepts_nested_attributes_for :account
 
   has_many :applications, class_name: 'Doorkeeper::Application', as: :owner, dependent: nil
+  has_many :access_tokens, class_name: 'Doorkeeper::AccessToken', foreign_key: :resource_owner_id, dependent: nil, inverse_of: false
   has_many :backups, inverse_of: :user, dependent: nil
   has_many :invites, inverse_of: :user, dependent: nil
   has_many :markers, inverse_of: :user, dependent: :destroy
@@ -281,8 +282,7 @@ class User < ApplicationRecord
   end
 
   def applications_last_used
-    Doorkeeper::AccessToken
-      .where(resource_owner_id: id)
+    access_tokens
       .used
       .group(:application_id)
       .maximum(:last_used_at)


### PR DESCRIPTION
Follow-up on https://github.com/mastodon/mastodon/pull/32912 with future changes hypothesized in there.

It occurs to me that we could the extensions->models conversion speculated about in https://github.com/mastodon/mastodon/pull/31042#issuecomment-2474320847 one small piece at a time if we wanted (it may be overwhelming to safely convert all instances at once).