### PR TITLE
Use `distinct` and `count` to generate query in `ReactionValidator` limit check

### DIFF
--- a/app/validators/reaction_validator.rb
+++ b/app/validators/reaction_validator.rb
@@ -23,6 +23,6 @@ class ReactionValidator < ActiveModel::Validator
   end
 
   def limit_reached?(reaction)
-    reaction.announcement.announcement_reactions.where.not(name: reaction.name).count('distinct name') >= LIMIT
+    reaction.announcement.announcement_reactions.where.not(name: reaction.name).distinct.count(:name) >= LIMIT
   end
 end


### PR DESCRIPTION
This one is utterly silly, and yet here we are. I'll take a hard look in the mirror tomorrow and figure out how it's come to this.

Part of my ongoing campaign to eliminate hard-coded string fragments in favour of framework generation.