### PR TITLE
Reduce long lines in `relationships/show` view

### DIFF
--- a/app/views/relationships/show.html.haml
+++ b/app/views/relationships/show.html.haml
@@ -42,13 +42,33 @@
       %label.batch-table__toolbar__select.batch-checkbox-all
         = check_box_tag :batch_checkbox_all, nil, false
       .batch-table__toolbar__actions
-        = f.button safe_join([material_symbol('person_add'), t('relationships.follow_selected_followers')]), name: :follow, class: 'table-action-link', type: :submit, data: { confirm: t('relationships.confirm_follow_selected_followers') } if followed_by_relationship? && !mutual_relationship?
+        - if followed_by_relationship? && !mutual_relationship?
+          = f.button safe_join([material_symbol('person_add'), t('relationships.follow_selected_followers')]),
+                     class: 'table-action-link',
+                     data: { confirm: t('relationships.confirm_follow_selected_followers') },
+                     name: :follow,
+                     type: :submit
 
-        = f.button safe_join([material_symbol('person_remove'), t('relationships.remove_selected_follows')]), name: :unfollow, class: 'table-action-link', type: :submit, data: { confirm: t('relationships.confirm_remove_selected_follows') } unless followed_by_relationship?
+        - unless followed_by_relationship?
+          = f.button safe_join([material_symbol('person_remove'), t('relationships.remove_selected_follows')]),
+                     class: 'table-action-link',
+                     data: { confirm: t('relationships.confirm_remove_selected_follows') },
+                     name: :unfollow,
+                     type: :submit
 
-        = f.button safe_join([material_symbol('delete'), t('relationships.remove_selected_followers')]), name: :remove_from_followers, class: 'table-action-link', type: :submit, data: { confirm: t('relationships.confirm_remove_selected_followers') } unless following_relationship?
+        - unless following_relationship?
+          = f.button safe_join([material_symbol('delete'), t('relationships.remove_selected_followers')]),
+                     class: 'table-action-link',
+                     data: { confirm: t('relationships.confirm_remove_selected_followers') },
+                     name: :remove_from_followers,
+                     type: :submit
 
-        = f.button safe_join([material_symbol('delete'), t('relationships.remove_selected_domains')]), name: :remove_domains_from_followers, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') } if followed_by_relationship?
+        - if followed_by_relationship?
+          = f.button safe_join([material_symbol('delete'), t('relationships.remove_selected_domains')]),
+                     class: 'table-action-link',
+                     data: { confirm: t('admin.reports.are_you_sure') },
+                     name: :remove_domains_from_followers,
+                     type: :submit
     .batch-table__body
       - if @accounts.empty?
         = nothing_here 'nothing-here--under-tabs'


### PR DESCRIPTION
This is a style-only lint-only change.

Between this change and a portion of what's in https://github.com/mastodon/mastodon/pull/32584 - I believe we'll be able to reduce the configured haml-lint line and view length limit cops down closer to the default values from rubocop (we currently override both b/c we were nowhere close at first configuration).

Will rebase WIP branch to do that reduction after this and the linked one merge.