### PR TITLE
Add `role_priveleges` helper method

### DIFF
--- a/app/helpers/admin/roles_helper.rb
+++ b/app/helpers/admin/roles_helper.rb
@@ -11,6 +11,13 @@ module Admin
       )
     end
 
+    def role_priveleges(role)
+      role
+        .permissions_as_keys
+        .map { |privilege| t("admin.roles.privileges.#{privilege}") }
+        .join(', ')
+    end
+
     def disable_permissions?(permissions)
       permissions.filter { |privilege| role_flag_value(privilege).zero? }
     end

--- a/app/views/admin/roles/_role.html.haml
+++ b/app/views/admin/roles/_role.html.haml
@@ -25,6 +25,6 @@
       - else
         = link_to t('admin.roles.assigned_users', count: role.users.count), admin_accounts_path(role_ids: role.id)
         ·
-        %abbr{ title: role.permissions_as_keys.map { |privilege| I18n.t("admin.roles.privileges.#{privilege}") }.join(', ') }= t('admin.roles.permissions_count', count: role.permissions_as_keys.size)
+        %abbr{ title: role_priveleges(role) }= t('admin.roles.permissions_count', count: role.permissions_as_keys.size)
     %div
       = table_link_to 'edit', t('admin.accounts.edit'), edit_admin_role_path(role) if can?(:update, role)


### PR DESCRIPTION
Just a little buddy for the `admin/roles/role` partial to collaborate with on the display of lists of priveleges for roles. Similar to existing method above it in same helper.