### PR TITLE
`Form::Import` spec reduce factories

### DIFF
--- a/spec/models/form/import_spec.rb
+++ b/spec/models/form/import_spec.rb
@@ -248,40 +248,19 @@ RSpec.describe Form::Import do
       context 'with a BulkImport' do
         let(:bulk_import) { account.bulk_imports.first }
 
-        it 'creates a non-nil bulk import' do
-          expect(bulk_import).to_not be_nil
-        end
-
-        it 'matches the subjects type' do
-          expect(bulk_import.type.to_sym).to eq subject.type.to_sym
-        end
-
-        it 'matches the subjects original filename' do
-          expect(bulk_import.original_filename).to eq subject.data.original_filename
-        end
-
-        it 'matches the subjects likely_mismatched? value' do
-          expect(bulk_import.likely_mismatched?).to eq subject.likely_mismatched?
-        end
-
-        it 'matches the subject overwrite value' do
-          expect(bulk_import.overwrite?).to eq !!subject.overwrite # rubocop:disable Style/DoubleNegation
-        end
-
-        it 'has zero processed items' do
-          expect(bulk_import.processed_items).to eq 0
-        end
-
-        it 'has zero imported items' do
-          expect(bulk_import.imported_items).to eq 0
-        end
-
-        it 'has a correct total_items value' do
-          expect(bulk_import.total_items).to eq bulk_import.rows.count
-        end
-
-        it 'defaults to unconfirmed true' do
-          expect(bulk_import.state_unconfirmed?).to be true
+        it 'creates a bulk import with correct values' do
+          expect(bulk_import)
+            .to be_present
+            .and have_attributes(
+              type: eq(subject.type),
+              original_filename: eq(subject.data.original_filename),
+              likely_mismatched?: eq(subject.likely_mismatched?),
+              overwrite?: eq(!!subject.overwrite), # rubocop:disable Style/DoubleNegation
+              processed_items: eq(0),
+              imported_items: eq(0),
+              total_items: eq(bulk_import.rows.count),
+              state_unconfirmed?: be(true)
+            )
         end
       end
     end

--- a/spec/models/form/import_spec.rb
+++ b/spec/models/form/import_spec.rb
@@ -237,13 +237,7 @@ RSpec.describe Form::Import do
       let(:import_file) { file }
       let(:import_mode) { mode }
 
-      before do
-        subject.save
-      end
-
-      it 'creates the expected rows' do
-        expect(account.bulk_imports.first.rows.pluck(:data)).to match_array(expected_rows)
-      end
+      before { subject.save }
 
       context 'with a BulkImport' do
         let(:bulk_import) { account.bulk_imports.first }
@@ -261,6 +255,8 @@ RSpec.describe Form::Import do
               total_items: eq(bulk_import.rows.count),
               state_unconfirmed?: be(true)
             )
+          expect(bulk_import.rows.pluck(:data))
+            .to match_array(expected_rows)
         end
       end
     end


### PR DESCRIPTION
Combines examples with shared setup. Drops factories from 190 to 90.

