### PR TITLE
Update deprecated `enum` style in older migrations

### DIFF
--- a/db/migrate/20170304202101_add_type_to_media_attachments.rb
+++ b/db/migrate/20170304202101_add_type_to_media_attachments.rb
@@ -3,7 +3,7 @@
 class AddTypeToMediaAttachments < ActiveRecord::Migration[5.0]
   class MigrationMediaAttachment < ApplicationRecord
     self.table_name = :media_attachments
-    enum type: [:image, :gifv, :video]
+    enum :type, [:image, :gifv, :video]
     IMAGE_MIME_TYPES = ['image/jpeg', 'image/png', 'image/gif'].freeze
     VIDEO_MIME_TYPES = ['video/webm', 'video/mp4'].freeze
   end

--- a/db/migrate/20181024224956_migrate_account_conversations.rb
+++ b/db/migrate/20181024224956_migrate_account_conversations.rb
@@ -21,7 +21,7 @@ class MigrateAccountConversations < ActiveRecord::Migration[5.2]
     belongs_to :account, class_name: 'MigrationAccount'
     has_many :mentions, dependent: :destroy, inverse_of: :status, class_name: 'MigrationMention', foreign_key: :status_id
     scope :local, -> { where(local: true).or(where(uri: nil)) }
-    enum visibility: { public: 0, unlisted: 1, private: 2, direct: 3, limited: 4 }, _suffix: :visibility
+    enum :visibility, { public: 0, unlisted: 1, private: 2, direct: 3, limited: 4 }, suffix: :visibility
     has_many :active_mentions, -> { active }, class_name: 'MigrationMention', inverse_of: :status, foreign_key: :status_id
   end
 

--- a/db/migrate/20190511134027_add_silenced_at_suspended_at_to_accounts.rb
+++ b/db/migrate/20190511134027_add_silenced_at_suspended_at_to_accounts.rb
@@ -7,7 +7,7 @@ class AddSilencedAtSuspendedAtToAccounts < ActiveRecord::Migration[5.2]
 
   class DomainBlock < ApplicationRecord
     # Dummy class, to make migration possible across version changes
-    enum severity: [:silence, :suspend, :noop]
+    enum :severity, [:silence, :suspend, :noop]
 
     has_many :accounts, foreign_key: :domain, primary_key: :domain
   end

--- a/db/post_migrate/20190511152737_remove_suspended_silenced_account_fields.rb
+++ b/db/post_migrate/20190511152737_remove_suspended_silenced_account_fields.rb
@@ -7,7 +7,7 @@ class RemoveSuspendedSilencedAccountFields < ActiveRecord::Migration[5.2]
 
   class DomainBlock < ApplicationRecord
     # Dummy class, to make migration possible across version changes
-    enum severity: [:silence, :suspend, :noop]
+    enum :severity, [:silence, :suspend, :noop]
 
     has_many :accounts, foreign_key: :domain, primary_key: :domain
   end

--- a/db/post_migrate/20201017234926_fill_account_suspension_origin.rb
+++ b/db/post_migrate/20201017234926_fill_account_suspension_origin.rb
@@ -6,7 +6,7 @@ class FillAccountSuspensionOrigin < ActiveRecord::Migration[5.2]
   class MigrationAccount < ApplicationRecord
     self.table_name = :accounts
     scope :suspended, -> { where.not(suspended_at: nil) }
-    enum suspension_origin: { local: 0, remote: 1 }, _prefix: true
+    enum :suspension_origin, { local: 0, remote: 1 }, prefix: true
   end
 
   def up


### PR DESCRIPTION
These run fine despite being deprecated now, but will error in Rails 8.

Extracted from https://github.com/mastodon/mastodon/pull/32357