### PR TITLE
Use `nil` instead of `false` for datetime value in spec

### DIFF
--- a/spec/models/concerns/account/sensitizes_spec.rb
+++ b/spec/models/concerns/account/sensitizes_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Account::Sensitizes do
     describe '.sensitized' do
       let(:sensitized_account) { Fabricate :account, sensitized_at: 2.days.ago }
 
-      before { Fabricate :account, sensitized_at: false }
+      before { Fabricate :account, sensitized_at: nil }
 
       it 'returns an array of accounts who are sensitized' do
         expect(Account.sensitized)


### PR DESCRIPTION
Basically same thing as https://github.com/mastodon/mastodon/pull/32682 - but this one was hidden in a much older branch as added coverage, separate from Rails 8 PR.

Will error in Rails 8. Extracted from https://github.com/mastodon/mastodon/pull/32357

