### PR TITLE
Add `ip_blocks_expires_options` helper method for collection options

### DIFF
--- a/app/helpers/admin/ip_blocks_helper.rb
+++ b/app/helpers/admin/ip_blocks_helper.rb
@@ -9,4 +9,8 @@ module Admin::IpBlocksHelper
       ]
     )
   end
+
+  def ip_blocks_expires_options
+    [1.day, 2.weeks, 1.month, 6.months, 1.year, 3.years]
+  end
 end

--- a/app/views/admin/ip_blocks/new.html.haml
+++ b/app/views/admin/ip_blocks/new.html.haml
@@ -12,7 +12,7 @@
 
   .fields-group
     = f.input :expires_in,
-              collection: [1.day, 2.weeks, 1.month, 6.months, 1.year, 3.years].map(&:to_i),
+              collection: ip_blocks_expires_options.map(&:to_i),
               label_method: ->(i) { I18n.t("admin.ip_blocks.expires_in.#{i}") },
               prompt: I18n.t('invites.expires_in_prompt'),
               wrapper: :with_block_label


### PR DESCRIPTION
Matches similar helper for invites that we already have.

There's a similar thing for `CustomFilter` as well, but in that case there's also some logic on the model side so it lives there.

If any of these ever evolve to have validations/normalizations/whatever using these values, could nudge over to model as well for ip block and invite.

If the three of them have *the same* code (minus the actual options) doing those things, maybe extract concern module.