### PR TITLE
Move self destruct check to `config_for` and add constant for verifier string

### DIFF
--- a/app/helpers/self_destruct_helper.rb
+++ b/app/helpers/self_destruct_helper.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 module SelfDestructHelper
+  VERIFY_PURPOSE = 'self-destruct'
+
   def self.self_destruct?
     value = ENV.fetch('SELF_DESTRUCT', nil)
-    value.present? && Rails.application.message_verifier('self-destruct').verify(value) == ENV['LOCAL_DOMAIN']
+    value.present? && Rails.application.message_verifier(VERIFY_PURPOSE).verify(value) == ENV['LOCAL_DOMAIN']
   rescue ActiveSupport::MessageVerifier::InvalidSignature
     false
   end

--- a/app/helpers/self_destruct_helper.rb
+++ b/app/helpers/self_destruct_helper.rb
@@ -4,7 +4,7 @@ module SelfDestructHelper
   VERIFY_PURPOSE = 'self-destruct'
 
   def self.self_destruct?
-    value = ENV.fetch('SELF_DESTRUCT', nil)
+    value = Rails.configuration.x.mastodon.self_destruct_value
     value.present? && Rails.application.message_verifier(VERIFY_PURPOSE).verify(value) == ENV['LOCAL_DOMAIN']
   rescue ActiveSupport::MessageVerifier::InvalidSignature
     false

--- a/config/mastodon.yml
+++ b/config/mastodon.yml
@@ -1,3 +1,4 @@
 ---
 shared:
+  self_destruct_value: <%= ENV.fetch('SELF_DESTRUCT', nil) %>
   software_update_url: <%= ENV.fetch('UPDATE_CHECK_URL', 'https://api.joinmastodon.org/update-check') %>

--- a/lib/mastodon/cli/federation.rb
+++ b/lib/mastodon/cli/federation.rb
@@ -76,7 +76,7 @@ module Mastodon::CLI
       def self_destruct_value
         Rails
           .application
-          .message_verifier('self-destruct')
+          .message_verifier(SelfDestructHelper::VERIFY_PURPOSE)
           .generate(Rails.configuration.x.local_domain)
       end
     end

--- a/spec/helpers/self_destruct_helper_spec.rb
+++ b/spec/helpers/self_destruct_helper_spec.rb
@@ -5,17 +5,17 @@ require 'rails_helper'
 RSpec.describe SelfDestructHelper do
   describe 'self_destruct?' do
     context 'when SELF_DESTRUCT is unset' do
+      before { Rails.configuration.x.mastodon.self_destruct_value = nil }
+      after { Rails.configuration.x.mastodon.self_destruct_value = nil }
+
       it 'returns false' do
         expect(helper.self_destruct?).to be false
       end
     end
 
     context 'when SELF_DESTRUCT is set to an invalid value' do
-      around do |example|
-        ClimateControl.modify SELF_DESTRUCT: 'true' do
-          example.run
-        end
-      end
+      before { Rails.configuration.x.mastodon.self_destruct_value = 'true' }
+      after { Rails.configuration.x.mastodon.self_destruct_value = nil }
 
       it 'returns false' do
         expect(helper.self_destruct?).to be false
@@ -23,9 +23,11 @@ RSpec.describe SelfDestructHelper do
     end
 
     context 'when SELF_DESTRUCT is set to value signed for the wrong purpose' do
+      before { Rails.configuration.x.mastodon.self_destruct_value = Rails.application.message_verifier('foo').generate('example.com') }
+      after { Rails.configuration.x.mastodon.self_destruct_value = nil }
+
       around do |example|
         ClimateControl.modify(
-          SELF_DESTRUCT: Rails.application.message_verifier('foo').generate('example.com'),
           LOCAL_DOMAIN: 'example.com'
         ) do
           example.run
@@ -38,9 +40,11 @@ RSpec.describe SelfDestructHelper do
     end
 
     context 'when SELF_DESTRUCT is set to value signed for the wrong domain' do
+      before { Rails.configuration.x.mastodon.self_destruct_value = Rails.application.message_verifier(described_class::VERIFY_PURPOSE).generate('foo.com') }
+      after { Rails.configuration.x.mastodon.self_destruct_value = nil }
+
       around do |example|
         ClimateControl.modify(
-          SELF_DESTRUCT: Rails.application.message_verifier(described_class::VERIFY_PURPOSE).generate('foo.com'),
           LOCAL_DOMAIN: 'example.com'
         ) do
           example.run
@@ -53,9 +57,11 @@ RSpec.describe SelfDestructHelper do
     end
 
     context 'when SELF_DESTRUCT is set to a correctly-signed value' do
+      before { Rails.configuration.x.mastodon.self_destruct_value = Rails.application.message_verifier(described_class::VERIFY_PURPOSE).generate('example.com') }
+      after { Rails.configuration.x.mastodon.self_destruct_value = nil }
+
       around do |example|
         ClimateControl.modify(
-          SELF_DESTRUCT: Rails.application.message_verifier(described_class::VERIFY_PURPOSE).generate('example.com'),
           LOCAL_DOMAIN: 'example.com'
         ) do
           example.run

--- a/spec/helpers/self_destruct_helper_spec.rb
+++ b/spec/helpers/self_destruct_helper_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe SelfDestructHelper do
     context 'when SELF_DESTRUCT is set to value signed for the wrong domain' do
       around do |example|
         ClimateControl.modify(
-          SELF_DESTRUCT: Rails.application.message_verifier('self-destruct').generate('foo.com'),
+          SELF_DESTRUCT: Rails.application.message_verifier(described_class::VERIFY_PURPOSE).generate('foo.com'),
           LOCAL_DOMAIN: 'example.com'
         ) do
           example.run
@@ -55,7 +55,7 @@ RSpec.describe SelfDestructHelper do
     context 'when SELF_DESTRUCT is set to a correctly-signed value' do
       around do |example|
         ClimateControl.modify(
-          SELF_DESTRUCT: Rails.application.message_verifier('self-destruct').generate('example.com'),
+          SELF_DESTRUCT: Rails.application.message_verifier(described_class::VERIFY_PURPOSE).generate('example.com'),
           LOCAL_DOMAIN: 'example.com'
         ) do
           example.run

--- a/spec/helpers/self_destruct_helper_spec.rb
+++ b/spec/helpers/self_destruct_helper_spec.rb
@@ -3,10 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe SelfDestructHelper do
-  describe 'self_destruct?' do
+  describe '#self_destruct?' do
+    before { Rails.configuration.x.mastodon.self_destruct_value = destruct_value }
+    after { Rails.configuration.x.mastodon.self_destruct_value = nil }
+
     context 'when SELF_DESTRUCT is unset' do
-      before { Rails.configuration.x.mastodon.self_destruct_value = nil }
-      after { Rails.configuration.x.mastodon.self_destruct_value = nil }
+      let(:destruct_value) { nil }
 
       it 'returns false' do
         expect(helper.self_destruct?).to be false
@@ -14,8 +16,7 @@ RSpec.describe SelfDestructHelper do
     end
 
     context 'when SELF_DESTRUCT is set to an invalid value' do
-      before { Rails.configuration.x.mastodon.self_destruct_value = 'true' }
-      after { Rails.configuration.x.mastodon.self_destruct_value = nil }
+      let(:destruct_value) { 'true' }
 
       it 'returns false' do
         expect(helper.self_destruct?).to be false
@@ -23,8 +24,7 @@ RSpec.describe SelfDestructHelper do
     end
 
     context 'when SELF_DESTRUCT is set to value signed for the wrong purpose' do
-      before { Rails.configuration.x.mastodon.self_destruct_value = Rails.application.message_verifier('foo').generate('example.com') }
-      after { Rails.configuration.x.mastodon.self_destruct_value = nil }
+      let(:destruct_value) { Rails.configuration.x.mastodon.self_destruct_value = Rails.application.message_verifier('foo').generate('example.com') }
 
       around do |example|
         ClimateControl.modify(
@@ -40,8 +40,7 @@ RSpec.describe SelfDestructHelper do
     end
 
     context 'when SELF_DESTRUCT is set to value signed for the wrong domain' do
-      before { Rails.configuration.x.mastodon.self_destruct_value = Rails.application.message_verifier(described_class::VERIFY_PURPOSE).generate('foo.com') }
-      after { Rails.configuration.x.mastodon.self_destruct_value = nil }
+      let(:destruct_value) { Rails.configuration.x.mastodon.self_destruct_value = Rails.application.message_verifier(described_class::VERIFY_PURPOSE).generate('foo.com') }
 
       around do |example|
         ClimateControl.modify(
@@ -57,8 +56,7 @@ RSpec.describe SelfDestructHelper do
     end
 
     context 'when SELF_DESTRUCT is set to a correctly-signed value' do
-      before { Rails.configuration.x.mastodon.self_destruct_value = Rails.application.message_verifier(described_class::VERIFY_PURPOSE).generate('example.com') }
-      after { Rails.configuration.x.mastodon.self_destruct_value = nil }
+      let(:destruct_value) { Rails.configuration.x.mastodon.self_destruct_value = Rails.application.message_verifier(described_class::VERIFY_PURPOSE).generate('example.com') }
 
       around do |example|
         ClimateControl.modify(


### PR DESCRIPTION
Another in a series of various `config_for` extractions.

If/when we also pull out the `LOCAL_DOMAIN` setup at some point, may be worth doing once-over on this spec file to improve the around/before/after setup.

Another future change here would be to move the calculation of "are we in self destruct mode?" to be in an initializer and have it happen once (rather than the verifier here running on every call). There are relatively few places even calling it (and the navigation calls at least only call it once and assign to local var), so not huge perf thing, but may make sense.