### PR TITLE
Prep work for coverage addition to `ActivityPub::DeliveryWorker` spec

### DIFF
--- a/spec/workers/activitypub/delivery_worker_spec.rb
+++ b/spec/workers/activitypub/delivery_worker_spec.rb
@@ -29,7 +29,9 @@ RSpec.describe ActivityPub::DeliveryWorker do
         a_request(:post, url)
           .with(
             headers: {
-              'Collection-Synchronization' => "collectionId=\"#{account_followers_url(sender)}\", digest=\"somehash\", url=\"#{account_followers_synchronization_url(sender)}\"",
+              'Collection-Synchronization' => <<~VALUES.squish,
+                collectionId="#{account_followers_url(sender)}", digest="somehash", url="#{account_followers_synchronization_url(sender)}"
+              VALUES
             }
           )
       end

--- a/spec/workers/activitypub/delivery_worker_spec.rb
+++ b/spec/workers/activitypub/delivery_worker_spec.rb
@@ -5,24 +5,25 @@ require 'rails_helper'
 RSpec.describe ActivityPub::DeliveryWorker do
   include RoutingHelper
 
-  let(:sender)  { Fabricate(:account) }
+  let(:sender) { Fabricate(:account) }
   let(:payload) { 'test' }
+  let(:url) { 'https://example.com/api' }
 
   before do
-    allow(sender).to receive(:remote_followers_hash).with('https://example.com/api').and_return('somehash')
+    allow(sender).to receive(:remote_followers_hash).with(url).and_return('somehash')
     allow(Account).to receive(:find).with(sender.id).and_return(sender)
   end
 
   describe 'perform' do
     it 'performs a request' do
-      stub_request(:post, 'https://example.com/api').to_return(status: 200)
-      subject.perform(payload, sender.id, 'https://example.com/api', { synchronize_followers: true })
-      expect(a_request(:post, 'https://example.com/api').with(headers: { 'Collection-Synchronization' => "collectionId=\"#{account_followers_url(sender)}\", digest=\"somehash\", url=\"#{account_followers_synchronization_url(sender)}\"" })).to have_been_made.once
+      stub_request(:post, url).to_return(status: 200)
+      subject.perform(payload, sender.id, url, { synchronize_followers: true })
+      expect(a_request(:post, url).with(headers: { 'Collection-Synchronization' => "collectionId=\"#{account_followers_url(sender)}\", digest=\"somehash\", url=\"#{account_followers_synchronization_url(sender)}\"" })).to have_been_made.once
     end
 
     it 'raises when request fails' do
-      stub_request(:post, 'https://example.com/api').to_return(status: 500)
-      expect { subject.perform(payload, sender.id, 'https://example.com/api') }.to raise_error Mastodon::UnexpectedResponseError
+      stub_request(:post, url).to_return(status: 500)
+      expect { subject.perform(payload, sender.id, url) }.to raise_error Mastodon::UnexpectedResponseError
     end
   end
 end

--- a/spec/workers/activitypub/delivery_worker_spec.rb
+++ b/spec/workers/activitypub/delivery_worker_spec.rb
@@ -5,8 +5,6 @@ require 'rails_helper'
 RSpec.describe ActivityPub::DeliveryWorker do
   include RoutingHelper
 
-  subject { described_class.new }
-
   let(:sender)  { Fabricate(:account) }
   let(:payload) { 'test' }
 


### PR DESCRIPTION
I want to improve the coverage in this spec, but this is in advance of that as just cleanup.

- Pull out repeat url value to `let`
- Add `context` for the main scenarios
- Extract method for the `a_request` setup