### PR TITLE
Streaming: add development logging of database queries

### DIFF
--- a/streaming/index.js
+++ b/streaming/index.js
@@ -101,7 +101,8 @@ const CHANNEL_NAMES = [
 ];
 
 const startServer = async () => {
-  const pgPool = Database.getPool(Database.configFromEnv(process.env, environment));
+  const pgConfig = Database.configFromEnv(process.env, environment);
+  const pgPool = Database.getPool(pgConfig, environment, logger);
 
   const metrics = setupMetrics(CHANNEL_NAMES, pgPool);
 


### PR DESCRIPTION
This is purely intended for development, so there isn't really a strong cost to us doing this, and it's the only way that's possible, as far as I can tell from the `pg` docs, based on this: https://node-postgres.com/guides/project-structure

We could of course create our own wrapper around `pg` but I don't think we want to spend time doing that.

split from #32851 