### PR TITLE
Add missing autofocus on boost modal

### DIFF
--- a/app/javascript/mastodon/features/ui/components/boost_modal.tsx
+++ b/app/javascript/mastodon/features/ui/components/boost_modal.tsx
@@ -128,6 +128,8 @@ export const BoostModal: React.FC<{
                 ? messages.cancel_reblog
                 : messages.reblog,
             )}
+            /* eslint-disable-next-line jsx-a11y/no-autofocus -- We are in the modal */
+            autoFocus
           />
         </div>
       </div>


### PR DESCRIPTION
Add `autoFocus` attribute on boost modal. It was missed on #31883 

Related: #31880