### PR TITLE
Reduce haml-lint `ViewLength` and `LineLength` limits closer to rubocop defaults

### DIFF
--- a/.haml-lint.yml
+++ b/.haml-lint.yml
@@ -10,6 +10,6 @@ linters:
   MiddleDot:
     enabled: true
   LineLength:
-    max: 300
+    max: 256 # Override default value of 80 inherited from rubocop
   ViewLength:
-    max: 200 # Override default value of 100 inherited from rubocop
+    max: 128 # Override default value of 100 inherited from rubocop

--- a/app/views/application/mailer/_checklist.html.haml
+++ b/app/views/application/mailer/_checklist.html.haml
@@ -29,8 +29,16 @@
                     %div
                       - if defined?(show_apps_buttons) && show_apps_buttons
                         .email-welcome-apps-btns
-                          = link_to image_tag(frontend_asset_url('images/mailer-new/store-icons/btn-app-store.png'), alt: t('user_mailer.welcome.apps_ios_action'), width: 120, height: 40), 'https://apps.apple.com/app/mastodon-for-iphone-and-ipad/id1571998974'
-                          = link_to image_tag(frontend_asset_url('images/mailer-new/store-icons/btn-google-play.png'), alt: t('user_mailer.welcome.apps_android_action'), width: 120, height: 40), 'https://play.google.com/store/apps/details?id=org.joinmastodon.android'
+                          = link_to 'https://apps.apple.com/app/mastodon-for-iphone-and-ipad/id1571998974' do
+                            = image_tag frontend_asset_url('images/mailer-new/store-icons/btn-app-store.png'),
+                                        alt: t('user_mailer.welcome.apps_ios_action'),
+                                        height: 40,
+                                        width: 120
+                          = link_to 'https://play.google.com/store/apps/details?id=org.joinmastodon.android' do
+                            = image_tag frontend_asset_url('images/mailer-new/store-icons/btn-google-play.png'),
+                                        alt: t('user_mailer.welcome.apps_android_action'),
+                                        height: 40,
+                                        width: 120
                       - elsif defined?(button_text) && defined?(button_url) && defined?(checked) && !checked
                         = render 'application/mailer/button', text: button_text, url: button_url, has_arrow: false
                     /[if mso]


### PR DESCRIPTION
I'd been planning on have https://github.com/mastodon/mastodon/pull/32584 merge first and then open this after, but instead I'd like to push this in first and then I'll rebase that one to just the config changes but not also the lint/line changes.

Following various other changes here, we are able to bump both of these values down a bit ... still increase over the base rubocop setting, but nudging down.