### PR TITLE
Add coverage for fixing the thing with the dates in the search area

### DIFF
--- a/spec/lib/search_query_transformer_spec.rb
+++ b/spec/lib/search_query_transformer_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe SearchQueryTransformer do
       ['"2022-01-01"', '2022-01-01'],
       ['12345678', '12345678'],
       ['"12345678"', '12345678'],
+      ['"2024-10-31T23:47:20Z"', '2024-10-31T23:47:20Z'],
     ].each do |value, parsed|
       context "with #{operator}:#{value}" do
         let(:query) { "#{operator}:#{value}" }


### PR DESCRIPTION
Would have failed before https://github.com/mastodon/mastodon/pull/32857

Value pulled from the `max_id` provided in original issue.