### PR TITLE
Add `LoginActivity` model spec and `BrowserDetection` concern shared example

### DIFF
--- a/spec/models/login_activity_spec.rb
+++ b/spec/models/login_activity_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LoginActivity do
+  describe 'Associations' do
+    it { is_expected.to belong_to(:user).required }
+  end
+
+  describe 'Validations' do
+    subject { Fabricate.build :login_activity }
+
+    it { is_expected.to define_enum_for(:authentication_method).backed_by_column_of_type(:string) }
+  end
+end

--- a/spec/models/login_activity_spec.rb
+++ b/spec/models/login_activity_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe LoginActivity do
+  include_examples 'BrowserDetection'
+
   describe 'Associations' do
     it { is_expected.to belong_to(:user).required }
   end

--- a/spec/models/session_activation_spec.rb
+++ b/spec/models/session_activation_spec.rb
@@ -3,39 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe SessionActivation do
-  describe '#detection' do
-    let(:session_activation) { Fabricate(:session_activation, user_agent: 'Chrome/62.0.3202.89') }
-
-    it 'sets a Browser instance as detection' do
-      expect(session_activation.detection).to be_a Browser::Chrome
-    end
-  end
-
-  describe '#browser' do
-    before do
-      allow(session_activation).to receive(:detection).and_return(detection)
-    end
-
-    let(:detection)          { instance_double(Browser::Chrome, id: 1) }
-    let(:session_activation) { Fabricate(:session_activation) }
-
-    it 'returns detection.id' do
-      expect(session_activation.browser).to be 1
-    end
-  end
-
-  describe '#platform' do
-    before do
-      allow(session_activation).to receive(:detection).and_return(detection)
-    end
-
-    let(:session_activation) { Fabricate(:session_activation) }
-    let(:detection)          { instance_double(Browser::Chrome, platform: instance_double(Browser::Platform, id: 1)) }
-
-    it 'returns detection.platform.id' do
-      expect(session_activation.platform).to be 1
-    end
-  end
+  include_examples 'BrowserDetection'
 
   describe '.active?' do
     subject { described_class.active?(id) }

--- a/spec/support/examples/models/concerns/browser_detection.rb
+++ b/spec/support/examples/models/concerns/browser_detection.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'BrowserDetection' do
+  subject { described_class.new(user_agent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.1 Safari/605.1.15') }
+
+  describe '#detection' do
+    it 'sets a Browser instance as detection' do
+      expect(subject.detection)
+        .to be_a(Browser::Safari)
+    end
+  end
+
+  describe '#browser' do
+    it 'returns browser name from id' do
+      expect(subject.browser)
+        .to eq(:safari)
+    end
+  end
+
+  describe '#platform' do
+    it 'returns detected platform' do
+      expect(subject.platform)
+        .to eq(:mac)
+    end
+  end
+
+  describe 'Callbacks' do
+    describe 'populating the user_agent value' do
+      subject { Fabricate.build described_class.name.underscore.to_sym, user_agent: nil }
+
+      it 'changes nil to empty string' do
+        expect { subject.save }
+          .to change(subject, :user_agent).from(nil).to('')
+      end
+    end
+  end
+end


### PR DESCRIPTION
First commit is super-basic coverage for `LoginActivity`, which had none.

Second commit pulls out what was the browser-detection-centric portion of `SessionActivation` model spec into a shared example, which both the specs for `LoginActivity` and `SessionActivation` both include.

On the spec side, I removed some of the stubbing in favoür of direct usage of the browser gem features.

I have a related followup which uses an aliases feature the browser gem added at some point, but wanted to improve this baseline first.