### PR TITLE
Fix `Lint/SafeNavigationConsistency` cop

### DIFF
--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -134,7 +134,7 @@ class NotifyService < BaseService
     end
 
     def from_staff?
-      @sender.local? && @sender.user.present? && @sender.user_role&.overrides?(@recipient.user_role) && @sender.user_role&.highlighted? && @sender.user_role&.can?(*UserRole::Flags::CATEGORIES[:moderation])
+      @sender.local? && @sender.user.present? && @sender.user_role&.overrides?(@recipient.user_role) && @sender.user_role.highlighted? && @sender.user_role.can?(*UserRole::Flags::CATEGORIES[:moderation])
     end
 
     def from_self?


### PR DESCRIPTION
This is the auto-correct from https://github.com/mastodon/mastodon/pull/32967

I believe the motivation/change here is that once we've advanced past the first check with safe nav, all the subsequent ones will be present and dont need the safe nav as well.

This is probably safe, but hypothetically for this example - if the "override" portion here was no longer required, I'm not sure it would occur to anyone making that change to re-add safe nav to the next call.

I could see:

- Move all of "role overrides role?", "role highlighted?", "role can moderation?" checks into one combined method on `UserRole`, call that from here (passing in recipient role)
- Use delegate (allowing nils) to get implicit safe nav in each call, and leave it as separate calls

Feel free to merge as-is if not worried, or indicate one of those (or some other) changes.