### PR TITLE
Fix `Lint/UselessAssignment` cop

### DIFF
--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -261,7 +261,7 @@ class Request
         outer_e = nil
         port    = args.first
 
-        addresses = []
+        addresses = [] # # TODO: https://github.com/rubocop/rubocop/issues/13395
         begin
           addresses = [IPAddr.new(host)]
         rescue IPAddr::InvalidAddressError

--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -261,7 +261,7 @@ class Request
         outer_e = nil
         port    = args.first
 
-        addresses = [] # # TODO: https://github.com/rubocop/rubocop/issues/13395
+        addresses = [] # rubocop:disable Lint/UselessAssignment # TODO: https://github.com/rubocop/rubocop/issues/13395
         begin
           addresses = [IPAddr.new(host)]
         rescue IPAddr::InvalidAddressError


### PR DESCRIPTION
Also from https://github.com/mastodon/mastodon/pull/32967

The autocorrect on this one removed the variable and turned that first line into just `[]` ...  which seems odd/pointless.

I assume the cop here is triggered because it sees the var will be assigned in one of the code paths, so the initial assignment isnt needed. I think that's correct, but thats a weird autocorrect.