### PR TITLE
Add `UserRole#bypass_block?` method for notification check

### DIFF
--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -142,7 +142,7 @@ class UserRole < ApplicationRecord
     other_role.nil? || position > other_role.position
   end
 
-  def enables_delivery?(role)
+  def bypass_block?(role)
     overrides?(role) && highlighted? && can?(*Flags::CATEGORIES[:moderation])
   end
 

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -142,6 +142,10 @@ class UserRole < ApplicationRecord
     other_role.nil? || position > other_role.position
   end
 
+  def enables_delivery?(role)
+    overrides?(role) && highlighted? && can?(*Flags::CATEGORIES[:moderation])
+  end
+
   def computed_permissions
     # If called on the everyone role, no further computation needed
     return permissions if everyone?

--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -134,7 +134,7 @@ class NotifyService < BaseService
     end
 
     def from_staff?
-      @sender.local? && @sender.user.present? && @sender.user_role&.overrides?(@recipient.user_role) && @sender.user_role&.highlighted? && @sender.user_role&.can?(*UserRole::Flags::CATEGORIES[:moderation])
+      @sender.local? && @sender.user.present? && @sender.user_role&.enables_delivery?(@recipient.user_role)
     end
 
     def from_self?

--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -134,7 +134,7 @@ class NotifyService < BaseService
     end
 
     def from_staff?
-      @sender.local? && @sender.user.present? && @sender.user_role&.enables_delivery?(@recipient.user_role)
+      @sender.local? && @sender.user.present? && @sender.user_role&.bypass_block?(@recipient.user_role)
     end
 
     def from_self?


### PR DESCRIPTION
Alternative to cop fix in https://github.com/mastodon/mastodon/pull/32971

Open to naming suggestions. The "from staff" concept has different meaning in different app contexts already.