### PR TITLE
Move `Account#account_notes` declaration from interactions->associations

### DIFF
--- a/app/controllers/api/v1/accounts/notes_controller.rb
+++ b/app/controllers/api/v1/accounts/notes_controller.rb
@@ -9,9 +9,9 @@ class Api::V1::Accounts::NotesController < Api::BaseController
 
   def create
     if params[:comment].blank?
-      AccountNote.find_by(account: current_account, target_account: @account)&.destroy
+      current_account.account_notes.find_by(target_account: @account)&.destroy
     else
-      @note = AccountNote.find_or_initialize_by(account: current_account, target_account: @account)
+      @note = current_account.account_notes.find_or_initialize_by(target_account: @account)
       @note.comment = params[:comment]
       @note.save! if @note.changed?
     end

--- a/app/models/account_note.rb
+++ b/app/models/account_note.rb
@@ -16,8 +16,8 @@ class AccountNote < ApplicationRecord
 
   COMMENT_SIZE_LIMIT = 2_000
 
-  belongs_to :account
-  belongs_to :target_account, class_name: 'Account'
+  belongs_to :account, inverse_of: :account_notes
+  belongs_to :target_account, class_name: 'Account', inverse_of: :targeted_account_notes
 
   validates :account_id, uniqueness: { scope: :target_account_id }
   validates :comment, length: { maximum: COMMENT_SIZE_LIMIT }

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -9,6 +9,7 @@ module Account::Associations
       # Association where account owns record
       with_options inverse_of: :account do
         has_many :account_moderation_notes
+        has_many :account_notes
         has_many :account_pins
         has_many :account_warnings
         has_many :aliases, class_name: 'AccountAlias'
@@ -42,6 +43,7 @@ module Account::Associations
       # Association where account is targeted by record
       with_options foreign_key: :target_account_id, inverse_of: :target_account do
         has_many :strikes, class_name: 'AccountWarning'
+        has_many :targeted_account_notes, class_name: 'AccountNote'
         has_many :targeted_moderation_notes, class_name: 'AccountModerationNote'
         has_many :targeted_reports, class_name: 'Report'
       end

--- a/app/models/concerns/account/interactions.rb
+++ b/app/models/concerns/account/interactions.rb
@@ -88,9 +88,6 @@ module Account::Interactions
       has_many :remote_severed_relationships, foreign_key: 'remote_account_id', inverse_of: :remote_account
     end
 
-    # Account notes
-    has_many :account_notes, dependent: :destroy
-
     # Block relationships
     with_options class_name: 'Block', dependent: :destroy do
       has_many :block_relationships, foreign_key: 'account_id', inverse_of: :account


### PR DESCRIPTION
Follow-up on my [treatise on the associations and interactions concerns](https://github.com/mastodon/mastodon/pull/32840#issue-2649786824) from a previous PR.

As mentioned there, the differene between the two concerns sort of makes sense to me for the specific collection of follows/blocks/mutes "interactions", but is less clear for some of the rest.

This change moves the `account_notes` declaration from interactions to associations, where it sits comfortably inside a `with_options` block, inheriting all the niceties and privileges of such a location (dependent destroy, inverse_of account). 

While in there...

- Also add a `targeted_account_notes` which is what is sounds like
- Use both of those associations in various places that they seem to be fun to use

I'll attempt to work through these 1-2 at a time and see what end state is re: any further changes to the two concerns.