### PR TITLE
Move `Account#domain_blocks` declaration from interactions->associations

### DIFF
--- a/app/models/account_domain_block.rb
+++ b/app/models/account_domain_block.rb
@@ -15,7 +15,8 @@ class AccountDomainBlock < ApplicationRecord
   include Paginable
   include DomainNormalizable
 
-  belongs_to :account
+  belongs_to :account, inverse_of: :domain_blocks
+
   validates :domain, presence: true, uniqueness: { scope: :account_id }, domain: true
 
   after_commit :invalidate_domain_blocking_cache

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -15,6 +15,7 @@ module Account::Associations
         has_many :bookmarks
         has_many :conversations, class_name: 'AccountConversation'
         has_many :custom_filters
+        has_many :domain_blocks, class_name: 'AccountDomainBlock'
         has_many :favourites
         has_many :featured_tags, -> { includes(:tag) }
         has_many :list_accounts

--- a/app/models/concerns/account/interactions.rb
+++ b/app/models/concerns/account/interactions.rb
@@ -107,7 +107,6 @@ module Account::Interactions
     has_many :muting, -> { order(mutes: { id: :desc }) }, through: :mute_relationships, source: :target_account
     has_many :muted_by, -> { order(mutes: { id: :desc }) }, through: :muted_by_relationships, source: :account
     has_many :conversation_mutes, dependent: :destroy
-    has_many :domain_blocks, class_name: 'AccountDomainBlock', dependent: :destroy
     has_many :announcement_mutes, dependent: :destroy
   end
 


### PR DESCRIPTION
Same idea as https://github.com/mastodon/mastodon/pull/32975 but for `domain_blocks` assoc. This one is not used anywhere in a way where it's possible to go through the assoc but is not already, I don't think.