### PR TITLE
Use browser gem `aliases` module, move `detection` to private

### DIFF
--- a/app/controllers/api/web/push_subscriptions_controller.rb
+++ b/app/controllers/api/web/push_subscriptions_controller.rb
@@ -54,7 +54,7 @@ class Api::Web::PushSubscriptionsController < Api::Web::BaseController
 
   def alerts_enabled
     # Mobile devices do not support regular notifications, so we enable push notifications by default
-    active_session.detection.device.mobile? || active_session.detection.device.tablet?
+    active_session.browser_mobile? || active_session.browser_tablet?
   end
 
   def update_session_with_subscription

--- a/app/helpers/admin/settings_helper.rb
+++ b/app/helpers/admin/settings_helper.rb
@@ -56,8 +56,8 @@ module Admin::SettingsHelper
   def login_activity_browser_description(activity)
     t(
       'sessions.description',
-      browser: t(activity.browser, scope: 'sessions.browsers', default: activity.browser.to_s),
-      platform: t(activity.platform, scope: 'sessions.platforms', default: activity.platform.to_s)
+      browser: t(activity.browser, scope: 'sessions.browsers', default: activity.browser_name),
+      platform: t(activity.platform, scope: 'sessions.platforms', default: activity.platform_name)
     )
   end
 end

--- a/app/helpers/admin/settings_helper.rb
+++ b/app/helpers/admin/settings_helper.rb
@@ -21,24 +21,21 @@ module Admin::SettingsHelper
   end
 
   def login_activity_method(activity)
-    content_tag(
-      :span,
+    tag.span(
       login_activity_method_string(activity),
       class: 'target'
     )
   end
 
   def login_activity_ip(activity)
-    content_tag(
-      :span,
+    tag.span(
       activity.ip,
       class: 'target'
     )
   end
 
   def login_activity_browser(activity)
-    content_tag(
-      :span,
+    tag.span(
       login_activity_browser_description(activity),
       class: 'target',
       title: activity.user_agent

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -24,11 +24,9 @@ module SettingsHelper
   end
 
   def session_device_icon(session)
-    browser = session.detection
-
-    if browser.mobile?
+    if session.browser_mobile?
       'smartphone'
-    elsif browser.tablet?
+    elsif session.browser_tablet?
       'tablet'
     else
       'desktop_mac'

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -24,11 +24,11 @@ module SettingsHelper
   end
 
   def session_device_icon(session)
-    device = session.detection.device
+    browser = session.detection
 
-    if device.mobile?
+    if browser.mobile?
       'smartphone'
-    elsif device.tablet?
+    elsif browser.tablet?
       'tablet'
     else
       'desktop_mac'

--- a/app/models/concerns/browser_detection.rb
+++ b/app/models/concerns/browser_detection.rb
@@ -7,10 +7,12 @@ module BrowserDetection
     before_save :assign_user_agent
   end
 
-  delegate :mobile?,
-           :tablet?,
-           to: :detection,
-           prefix: :browser
+  delegate(
+    :mobile?,
+    :tablet?,
+    to: :detection,
+    prefix: :browser
+  )
 
   def browser
     detection.id

--- a/app/models/concerns/browser_detection.rb
+++ b/app/models/concerns/browser_detection.rb
@@ -18,8 +18,16 @@ module BrowserDetection
     detection.id
   end
 
+  def browser_name
+    browser.to_s.capitalize
+  end
+
   def platform
     detection.platform.id
+  end
+
+  def platform_name
+    platform.to_s.capitalize
   end
 
   private

--- a/app/models/concerns/browser_detection.rb
+++ b/app/models/concerns/browser_detection.rb
@@ -7,10 +7,6 @@ module BrowserDetection
     before_save :assign_user_agent
   end
 
-  def detection
-    @detection ||= Browser.new(user_agent)
-  end
-
   delegate :mobile?,
            :tablet?,
            to: :detection,
@@ -25,6 +21,10 @@ module BrowserDetection
   end
 
   private
+
+  def detection
+    @detection ||= Browser.new(user_agent)
+  end
 
   def assign_user_agent
     self.user_agent ||= ''

--- a/app/models/concerns/browser_detection.rb
+++ b/app/models/concerns/browser_detection.rb
@@ -11,6 +11,11 @@ module BrowserDetection
     @detection ||= Browser.new(user_agent)
   end
 
+  delegate :mobile?,
+           :tablet?,
+           to: :detection,
+           prefix: :browser
+
   def browser
     detection.id
   end

--- a/config/initializers/browser.rb
+++ b/config/initializers/browser.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require 'browser/aliases'
+Browser::Base.include(Browser::Aliases)

--- a/spec/support/examples/models/concerns/browser_detection.rb
+++ b/spec/support/examples/models/concerns/browser_detection.rb
@@ -17,6 +17,18 @@ RSpec.shared_examples 'BrowserDetection' do
     end
   end
 
+  describe '#browser_mobile?' do
+    subject { described_class.new(user_agent: 'Mozilla/5.0 (iPhone)') }
+
+    it { is_expected.to be_browser_mobile }
+  end
+
+  describe '#browser_tablet?' do
+    subject { described_class.new(user_agent: 'Mozilla/5.0 (iPad)') }
+
+    it { is_expected.to be_browser_tablet }
+  end
+
   describe 'Callbacks' do
     describe 'populating the user_agent value' do
       subject { Fabricate.build described_class.name.underscore.to_sym, user_agent: nil }

--- a/spec/support/examples/models/concerns/browser_detection.rb
+++ b/spec/support/examples/models/concerns/browser_detection.rb
@@ -10,10 +10,24 @@ RSpec.shared_examples 'BrowserDetection' do
     end
   end
 
+  describe '#browser_name' do
+    it 'returns browser name from id' do
+      expect(subject.browser_name)
+        .to eq('Safari')
+    end
+  end
+
   describe '#platform' do
     it 'returns detected platform' do
       expect(subject.platform)
         .to eq(:mac)
+    end
+  end
+
+  describe '#platform_name' do
+    it 'returns detected platform' do
+      expect(subject.platform_name)
+        .to eq('Mac')
     end
   end
 

--- a/spec/support/examples/models/concerns/browser_detection.rb
+++ b/spec/support/examples/models/concerns/browser_detection.rb
@@ -3,13 +3,6 @@
 RSpec.shared_examples 'BrowserDetection' do
   subject { described_class.new(user_agent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.1 Safari/605.1.15') }
 
-  describe '#detection' do
-    it 'sets a Browser instance as detection' do
-      expect(subject.detection)
-        .to be_a(Browser::Safari)
-    end
-  end
-
   describe '#browser' do
     it 'returns browser name from id' do
       expect(subject.browser)


### PR DESCRIPTION
A few related changes -- main motivation here is to slightly tighten up the external calls into the browser detection (LoginActivity, SessionActivation) classes...

- Include the browser/aliases module, which gives us method delegation for `mobile?` and `tablet?` (previously had to get to `device`, now just on the base browser/detection object)
- With that in place, also add our own delegate call so that the settings helper and web/pushsubs can call query methods right on the passed in session
- With those changes, there is no longer any direct access to the `detection` method, so move that to internal private method
- Convert some content_tag to tag.span while in the helper file
- Add `_name` methods for platform/browser to wrap the `to_s`