### PR TITLE
Extract constants for `AnnualReport::*` calculations

### DIFF
--- a/app/lib/annual_report/archetype.rb
+++ b/app/lib/annual_report/archetype.rb
@@ -5,6 +5,9 @@ class AnnualReport::Archetype < AnnualReport::Source
   # each active user in a single year (2023)
   AVERAGE_PER_YEAR = 113
 
+  SCORE_MULTIPLIER = 2
+  SCORE_REDUCER = 0.1
+
   def generate
     {
       archetype: archetype,
@@ -16,11 +19,11 @@ class AnnualReport::Archetype < AnnualReport::Source
   def archetype
     if (standalone_count + replies_count + reblogs_count) < AVERAGE_PER_YEAR
       :lurker
-    elsif reblogs_count > (standalone_count * 2)
+    elsif reblogs_count > (standalone_count * SCORE_MULTIPLIER)
       :booster
-    elsif polls_count > (standalone_count * 0.1) # standalone_count includes posts with polls
+    elsif polls_count > (standalone_count * SCORE_REDUCER) # standalone_count includes posts with polls
       :pollster
-    elsif replies_count > (standalone_count * 2)
+    elsif replies_count > (standalone_count * SCORE_MULTIPLIER)
       :replier
     else
       :oracle

--- a/app/lib/annual_report/commonly_interacted_with_accounts.rb
+++ b/app/lib/annual_report/commonly_interacted_with_accounts.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class AnnualReport::CommonlyInteractedWithAccounts < AnnualReport::Source
+  MINIMUM_INTERACTIONS = 1
   SET_SIZE = 40
 
   def generate
@@ -17,6 +18,6 @@ class AnnualReport::CommonlyInteractedWithAccounts < AnnualReport::Source
   private
 
   def commonly_interacted_with_accounts
-    report_statuses.where.not(in_reply_to_account_id: @account.id).group(:in_reply_to_account_id).having('count(*) > 1').order(count_all: :desc).limit(SET_SIZE).count
+    report_statuses.where.not(in_reply_to_account_id: @account.id).group(:in_reply_to_account_id).having(Arel.star.count.gt(MINIMUM_INTERACTIONS)).order(count_all: :desc).limit(SET_SIZE).count
   end
 end

--- a/app/lib/annual_report/most_reblogged_accounts.rb
+++ b/app/lib/annual_report/most_reblogged_accounts.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class AnnualReport::MostRebloggedAccounts < AnnualReport::Source
+  MINIMUM_COUNT = 1
   SET_SIZE = 10
 
   def generate
@@ -17,6 +18,6 @@ class AnnualReport::MostRebloggedAccounts < AnnualReport::Source
   private
 
   def most_reblogged_accounts
-    report_statuses.where.not(reblog_of_id: nil).joins(reblog: :account).group(accounts: [:id]).having('count(*) > 1').order(count_all: :desc).limit(SET_SIZE).count
+    report_statuses.where.not(reblog_of_id: nil).joins(reblog: :account).group(accounts: [:id]).having(Arel.star.count.gt(MINIMUM_COUNT)).order(count_all: :desc).limit(SET_SIZE).count
   end
 end

--- a/app/lib/annual_report/top_hashtags.rb
+++ b/app/lib/annual_report/top_hashtags.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class AnnualReport::TopHashtags < AnnualReport::Source
+  MINIMUM_COUNT = 1
   SET_SIZE = 40
 
   def generate
@@ -17,7 +18,7 @@ class AnnualReport::TopHashtags < AnnualReport::Source
   private
 
   def top_hashtags
-    Tag.joins(:statuses).where(statuses: { id: report_statuses.select(:id) }).group(coalesced_tag_names).having('count(*) > 1').order(count_all: :desc).limit(SET_SIZE).count
+    Tag.joins(:statuses).where(statuses: { id: report_statuses.select(:id) }).group(coalesced_tag_names).having(Arel.star.count.gt(MINIMUM_COUNT)).order(count_all: :desc).limit(SET_SIZE).count
   end
 
   def coalesced_tag_names


### PR DESCRIPTION
Follow up on https://github.com/mastodon/mastodon/pull/32914

Pulling a few more things out of https://github.com/mastodon/mastodon/pull/31862

As an aside here, in terms of the `AVERAGE_PER_YEAR = 113` ... I assume this comes from mastodon.social for last year? Do we need to update this approach prior to releasing this? Presumably you want this relative to the instance it's running on? Or maybe I misunderstand.