### PR TITLE
Add `AccountWarning` case to `Report#history` spec

### DIFF
--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -108,15 +108,22 @@ RSpec.describe Report do
     let(:report) { Fabricate(:report, target_account_id: target_account.id, status_ids: [status.id], created_at: 3.days.ago, updated_at: 1.day.ago) }
     let(:target_account) { Fabricate(:account) }
     let(:status) { Fabricate(:status) }
+    let(:account_warning) { Fabricate(:account_warning, report_id: report.id) }
 
     before do
       Fabricate(:action_log, target_type: 'Report', account_id: target_account.id, target_id: report.id, created_at: 2.days.ago)
       Fabricate(:action_log, target_type: 'Account', account_id: target_account.id, target_id: report.target_account_id, created_at: 2.days.ago)
       Fabricate(:action_log, target_type: 'Status', account_id: target_account.id, target_id: status.id, created_at: 2.days.ago)
+      Fabricate(:action_log, target_type: 'AccountWarning', account_id: target_account.id, target_id: account_warning.id, created_at: 2.days.ago)
     end
 
-    it 'returns right logs' do
-      expect(action_logs.count).to eq 3
+    it 'returns expected logs' do
+      expect(action_logs)
+        .to have_attributes(count: 4)
+        .and include(have_attributes(target_type: 'Account'))
+        .and include(have_attributes(target_type: 'AccountWarning'))
+        .and include(have_attributes(target_type: 'Report'))
+        .and include(have_attributes(target_type: 'Status'))
     end
   end
 


### PR DESCRIPTION
The method covers four types of action log -- we have 3 of them already in spec, just adding the last one here.

Separately - this is out of a WIP branch looking at converting the arel/union approach to this query into a CTE/WITH style query. Need do a little benchmark first to make sure ok, but wanted to get spec addition in first.

Added some assertions to make sure the returned rows are what we expect, in addition to count being accurate.