### PR TITLE
WIP: Implement Moderation Notes APIs

### DIFF
--- a/app/controllers/api/v1/admin/accounts/notes_controller.rb
+++ b/app/controllers/api/v1/admin/accounts/notes_controller.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+class Api::V1::Admin::Accounts::NotesController < Api::BaseController
+  include Authorization
+  include AccountableConcern
+
+  PERMITTED_PARAMS = %i(
+    content
+  ).freeze
+
+  before_action -> { authorize_if_got_token! :'admin:read', :'admin:read:accounts' }, only: [:index, :show]
+  before_action -> { authorize_if_got_token! :'admin:write', :'admin:write:accounts' }, except: [:index, :show]
+  before_action :set_account
+  before_action :set_account_note, except: [:index, :create]
+
+  rescue_from ArgumentError do |e|
+    render json: { error: e.to_s }, status: 422
+  end
+
+  def index
+    authorize @account, :show?
+    render json: @account.targeted_moderation_notes.chronological.includes(:account), each_serializer: REST::Admin::ModerationNoteSerializer
+  end
+
+  def show
+    authorize @account_moderation_note, :show?
+    render json: @account_moderation_note, serializer: REST::Admin::ModerationNoteSerializer
+  end
+
+  def create
+    authorize AccountModerationNote, :create?
+
+    @account_moderation_note = current_account.account_moderation_notes.new(account_note_params.merge(target_account_id: @account.id))
+    @account_moderation_note.save!
+
+    render json: @account_moderation_note, serializer: REST::Admin::ModerationNoteSerializer
+  end
+
+  def destroy
+    authorize @account_moderation_note, :destroy?
+    @account_moderation_note.destroy!
+    render_empty
+  end
+
+  private
+
+  def set_account
+    @account = Account.find(params[:account_id])
+  end
+
+  def set_account_note
+    @account_moderation_note = AccountModerationNote.where(target_account_id: params[:account_id]).find(params[:id])
+  end
+
+  def account_note_params
+    params
+      .slice(*PERMITTED_PARAMS)
+      .permit(*PERMITTED_PARAMS)
+  end
+end

--- a/app/controllers/api/v1/admin/accounts/notes_controller.rb
+++ b/app/controllers/api/v1/admin/accounts/notes_controller.rb
@@ -11,7 +11,7 @@ class Api::V1::Admin::Accounts::NotesController < Api::BaseController
   before_action -> { authorize_if_got_token! :'admin:read', :'admin:read:accounts' }, only: [:index, :show]
   before_action -> { authorize_if_got_token! :'admin:write', :'admin:write:accounts' }, except: [:index, :show]
   before_action :set_account
-  before_action :set_account_note, except: [:index, :create]
+  before_action :set_account_moderation_note, except: [:index, :create]
 
   rescue_from ArgumentError do |e|
     render json: { error: e.to_s }, status: 422
@@ -48,7 +48,7 @@ class Api::V1::Admin::Accounts::NotesController < Api::BaseController
     @account = Account.find(params[:account_id])
   end
 
-  def set_account_note
+  def set_account_moderation_note
     @account_moderation_note = AccountModerationNote.where(target_account_id: params[:account_id]).find(params[:id])
   end
 

--- a/app/controllers/api/v1/admin/reports/notes_controller.rb
+++ b/app/controllers/api/v1/admin/reports/notes_controller.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+class Api::V1::Admin::Reports::NotesController < Api::BaseController
+  include Authorization
+  include AccountableConcern
+
+  PERMITTED_PARAMS = %i(
+    content
+  ).freeze
+
+  before_action -> { authorize_if_got_token! :'admin:read', :'admin:read:reports' }, only: [:index, :show]
+  before_action -> { authorize_if_got_token! :'admin:write', :'admin:write:reports' }, except: [:index, :show]
+  before_action :set_report
+  before_action :set_report_note, except: [:index, :create]
+
+  rescue_from ArgumentError do |e|
+    render json: { error: e.to_s }, status: 422
+  end
+
+  def index
+    authorize @report, :show?
+    render json: @report.notes.chronological.includes(:account), each_serializer: REST::Admin::ModerationNoteSerializer
+  end
+
+  def show
+    authorize @report_note, :show?
+    render json: @report_note, serializer: REST::Admin::ModerationNoteSerializer
+  end
+
+  def create
+    authorize :report_note, :create?
+    authorize @report, :update? if truthy_param?(:resolve_report) || truthy_param?(:unresolve_report)
+
+    @report_note = current_account.report_notes.new(report_note_params.merge(report_id: @report.id))
+
+    if @report_note.save!
+      if truthy_param?(:resolve_report)
+        @report.resolve!(current_account)
+        log_action :resolve, @report
+      elsif truthy_param?(:unresolve_report)
+        @report.unresolve!
+        log_action :reopen, @report
+      end
+
+      render json: @report_note, serializer: REST::Admin::ModerationNoteSerializer
+    end
+  end
+
+  def destroy
+    authorize @report_note, :destroy?
+    @report_note.destroy!
+    render_empty
+  end
+
+  private
+
+  def set_report
+    @report = Report.find(params[:report_id])
+  end
+
+  def set_report_note
+    @report_note = ReportNote.where(report_id: params[:report_id]).find(params[:id])
+  end
+
+  def report_note_params
+    params
+      .slice(*PERMITTED_PARAMS)
+      .permit(*PERMITTED_PARAMS)
+  end
+end

--- a/app/controllers/api/v1/admin/reports/notes_controller.rb
+++ b/app/controllers/api/v1/admin/reports/notes_controller.rb
@@ -28,7 +28,7 @@ class Api::V1::Admin::Reports::NotesController < Api::BaseController
   end
 
   def create
-    authorize :report_note, :create?
+    authorize ReportNote, :create?
     authorize @report, :update? if truthy_param?(:resolve_report) || truthy_param?(:unresolve_report)
 
     @report_note = current_account.report_notes.new(report_note_params.merge(report_id: @report.id))

--- a/app/policies/report_note_policy.rb
+++ b/app/policies/report_note_policy.rb
@@ -5,6 +5,10 @@ class ReportNotePolicy < ApplicationPolicy
     role.can?(:manage_reports)
   end
 
+  def show?
+    role.can?(:manage_reports)
+  end
+
   def destroy?
     owner? || (role.can?(:manage_reports) && role.overrides?(record.account.user_role))
   end

--- a/app/serializers/rest/admin/account_minimal_serializer.rb
+++ b/app/serializers/rest/admin/account_minimal_serializer.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class REST::Admin::AccountMinimalSerializer < ActiveModel::Serializer
+  include RoutingHelper
+
+  attributes :id, :username, :acct, :display_name, :uri, :url, :avatar, :avatar_static
+
+  def id
+    object.id.to_s
+  end
+
+  def acct
+    object.pretty_acct
+  end
+
+  def url
+    ActivityPub::TagManager.instance.url_for(object)
+  end
+
+  def uri
+    ActivityPub::TagManager.instance.uri_for(object)
+  end
+
+  def avatar
+    full_asset_url(object.unavailable? ? object.avatar.default_url : object.avatar_original_url)
+  end
+
+  def avatar_static
+    full_asset_url(object.unavailable? ? object.avatar.default_url : object.avatar_static_url)
+  end
+end

--- a/app/serializers/rest/admin/moderation_note_serializer.rb
+++ b/app/serializers/rest/admin/moderation_note_serializer.rb
@@ -17,9 +17,9 @@ class REST::Admin::ModerationNoteSerializer < ActiveModel::Serializer
   def target
     case object
     when ReportNote
-      { type: 'Report', id: object.report_id.to_s, url: api_v1_admin_report_url(object.report) }
+      { type: 'Report', id: object.report_id.to_s, url: api_v1_admin_report_url(object.report.id) }
     when AccountModerationNote
-      { type: 'Account', id: object.target_account_id.to_s, url: api_v1_admin_account_url(object.target_account) }
+      { type: 'Account', id: object.target_account_id.to_s, url: api_v1_admin_account_url(object.target_account.id) }
     end
   end
 end

--- a/app/serializers/rest/admin/moderation_note_serializer.rb
+++ b/app/serializers/rest/admin/moderation_note_serializer.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class REST::Admin::ModerationNoteSerializer < ActiveModel::Serializer
+  include RoutingHelper
+
+  attributes :id, :content, :created_at, :updated_at, :target
+  belongs_to :account, serializer: REST::Admin::AccountMinimalSerializer
+
+  def id
+    object.id.to_s
+  end
+
+  def content
+    object.content.strip
+  end
+
+  def target
+    case object
+    when ReportNote
+      { type: 'Report', id: object.report_id.to_s, url: api_v1_admin_report_url(object.report) }
+    when AccountModerationNote
+      { type: 'Account', id: object.target_account_id.to_s, url: api_v1_admin_account_url(object.target_account) }
+    end
+  end
+end

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -245,6 +245,7 @@ namespace :api, format: false do
         end
 
         resource :action, only: [:create], controller: 'account_actions'
+        resources :notes, controller: 'accounts/notes', only: [:index, :show, :create, :destroy]
       end
 
       resources :reports, only: [:index, :update, :show] do
@@ -255,7 +256,7 @@ namespace :api, format: false do
           post :resolve
         end
 
-        resources :notes, controller: 'reports/notes', except: [:new, :edit, :update]
+        resources :notes, controller: 'reports/notes', only: [:index, :show, :create, :destroy]
       end
 
       resources :domain_allows, only: [:index, :show, :create, :destroy]

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -254,6 +254,8 @@ namespace :api, format: false do
           post :reopen
           post :resolve
         end
+
+        resources :notes, controller: 'reports/notes', except: [:new, :edit, :update]
       end
 
       resources :domain_allows, only: [:index, :show, :create, :destroy]


### PR DESCRIPTION
Resolves: #11399

- [ ] Report Notes
  - [x] basic implementation
  - [ ] specs
- [ ] Account Moderation Notes
  - [x] basic implementation
  - [ ] specs

### Rationale

Rather than every moderation note entity embedding the full report/target_account/etc, I think it's better to just reference by type, id, and API URL, because otherwise the responses would get incredibly large with data you almost certainly already have (it's unlikely to show a list of report notes without also showing the report itself).

The Account representation for the author of the moderation note is also fairly minimal, limited to just what you'd need to query back the account or display something meaningful in a list view. I've included `acct` for now, as in the future we could federate moderation notes.

I'm not entirely happy with the amount of duplication between these two controllers, but I'm not sure there's a good way to avoid it?

### API Routes
```
api_v1_admin_report_notes   GET    /api/v1/admin/reports/:report_id/notes         api/v1/admin/reports/notes#index
                            POST   /api/v1/admin/reports/:report_id/notes         api/v1/admin/reports/notes#create
api_v1_admin_report_note    GET    /api/v1/admin/reports/:report_id/notes/:id     api/v1/admin/reports/notes#show
                            DELETE /api/v1/admin/reports/:report_id/notes/:id     api/v1/admin/reports/notes#destroy

api_v1_admin_account_notes  GET    /api/v1/admin/accounts/:account_id/notes       api/v1/admin/accounts/notes#index
                            POST   /api/v1/admin/accounts/:account_id/notes       api/v1/admin/accounts/notes#create
api_v1_admin_account_note   GET    /api/v1/admin/accounts/:account_id/notes/:id   api/v1/admin/accounts/notes#show
                            DELETE /api/v1/admin/accounts/:account_id/notes/:id   api/v1/admin/accounts/notes#destroy
```

#### `POST   /api/v1/admin/reports/:report_id/notes`

Requires a `content` parameter and optionally a `resolve_report` or `unresolve_report` truthy value. For `resolve_report` and `unresolve_report`, permissions need to allow for the report to be modified.

#### `POST   /api/v1/admin/accounts/:account_id/notes`

Requires a `content` parameter.

### Example Response

For an Account Moderation Note
```json
  {
    "id": "1",
    "content": "Test 1",
    "created_at": "2024-09-04T17:19:11.139Z",
    "updated_at": "2024-09-04T17:19:11.139Z",
    "target": {
      "type": "Account",
      "id": "113002490559008678",
      "url": "http://localhost:3000/api/v1/admin/accounts/113002490559008678"
    },
    "account": {
      "id": "112570037924789254",
      "username": "thisismissem",
      "acct": "thisismissem",
      "display_name": "Emelia 👸🏻",
      "uri": "http://localhost:3000/users/thisismissem",
      "url": "http://localhost:3000/@thisismissem",
      "avatar": "http://localhost:9000/mastodon-development/accounts/avatars/112/570/037/924/789/254/original/6ea746a330746ef8.jpg",
      "avatar_static": "http://localhost:9000/mastodon-development/accounts/avatars/112/570/037/924/789/254/original/6ea746a330746ef8.jpg"
    }
  }
```

For a Report Note:
```json
  {
    "id": "1",
    "content": "Test 1",
    "created_at": "2024-09-04T17:19:11.139Z",
    "updated_at": "2024-09-04T17:19:11.139Z",
    "target": {
      "type": "Report",
      "id": "15",
      "url": "http://localhost:3000/api/v1/admin/reports/15"
    },
    "account": {
      "id": "112570037924789254",
      "username": "thisismissem",
      "acct": "thisismissem",
      "display_name": "Emelia 👸🏻",
      "uri": "http://localhost:3000/users/thisismissem",
      "url": "http://localhost:3000/@thisismissem",
      "avatar": "http://localhost:9000/mastodon-development/accounts/avatars/112/570/037/924/789/254/original/6ea746a330746ef8.jpg",
      "avatar_static": "http://localhost:9000/mastodon-development/accounts/avatars/112/570/037/924/789/254/original/6ea746a330746ef8.jpg"
    }
  }
```