### PR TITLE
WIP: Notifications for Report Notes

### DIFF
--- a/app/javascript/mastodon/api_types/notifications.ts
+++ b/app/javascript/mastodon/api_types/notifications.ts
@@ -3,7 +3,7 @@
 import type { AccountWarningAction } from 'mastodon/models/notification_group';
 
 import type { ApiAccountJSON } from './accounts';
-import type { ApiReportJSON } from './reports';
+import type { ApiReportJSON, ApiReportNoteJSON } from './reports';
 import type { ApiStatusJSON } from './statuses';
 
 // See app/model/notification.rb
@@ -18,6 +18,7 @@ export const allNotificationTypes = [
   'update',
   'admin.sign_up',
   'admin.report',
+  'admin.report_note',
   'moderation_warning',
   'severed_relationships',
   'annual_report',
@@ -39,6 +40,7 @@ export type NotificationType =
   | 'severed_relationships'
   | 'admin.sign_up'
   | 'admin.report'
+  | 'admin.report_note'
   | 'annual_report';
 
 export interface BaseNotificationJSON {
@@ -78,6 +80,16 @@ interface ReportNotificationGroupJSON extends BaseNotificationGroupJSON {
 interface ReportNotificationJSON extends BaseNotificationJSON {
   type: 'admin.report';
   report: ApiReportJSON;
+}
+
+interface ReportNoteNotificationGroupJSON extends BaseNotificationGroupJSON {
+  type: 'admin.report_note';
+  report_note: ApiReportNoteJSON;
+}
+
+interface ReportNoteNotificationJSON extends BaseNotificationJSON {
+  type: 'admin.report_note';
+  report_note: ApiReportNoteJSON;
 }
 
 type SimpleNotificationTypes = 'follow' | 'follow_request' | 'admin.sign_up';
@@ -144,6 +156,7 @@ interface AnnualReportNotificationGroupJSON extends BaseNotificationGroupJSON {
 export type ApiNotificationJSON =
   | SimpleNotificationJSON
   | ReportNotificationJSON
+  | ReportNoteNotificationJSON
   | AccountRelationshipSeveranceNotificationJSON
   | NotificationWithStatusJSON
   | ModerationWarningNotificationJSON;
@@ -151,6 +164,7 @@ export type ApiNotificationJSON =
 export type ApiNotificationGroupJSON =
   | SimpleNotificationGroupJSON
   | ReportNotificationGroupJSON
+  | ReportNoteNotificationGroupJSON
   | AccountRelationshipSeveranceNotificationGroupJSON
   | NotificationGroupWithStatusJSON
   | ModerationWarningNotificationGroupJSON

--- a/app/javascript/mastodon/api_types/reports.ts
+++ b/app/javascript/mastodon/api_types/reports.ts
@@ -14,3 +14,10 @@ export interface ApiReportJSON {
   rule_ids: string[];
   target_account: ApiAccountJSON;
 }
+
+export interface ApiReportNoteJSON {
+  id: string;
+  content: string;
+  created_at: string;
+  report: ApiReportJSON;
+}

--- a/app/javascript/mastodon/features/notifications_v2/components/notification_admin_report_note.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/components/notification_admin_report_note.tsx
@@ -1,0 +1,66 @@
+import { FormattedMessage } from 'react-intl';
+
+import classNames from 'classnames';
+
+import FlagIcon from '@/material-icons/400-24px/flag-fill.svg?react';
+import { Icon } from 'mastodon/components/icon';
+import { RelativeTimestamp } from 'mastodon/components/relative_timestamp';
+import type { NotificationGroupAdminReportNote } from 'mastodon/models/notification_group';
+import { useAppSelector } from 'mastodon/store';
+
+export const NotificationAdminReportNote: React.FC<{
+  notification: NotificationGroupAdminReportNote;
+  unread?: boolean;
+}> = ({ notification, notification: { reportNote }, unread }) => {
+  const account = useAppSelector((state) =>
+    state.accounts.get(notification.sampleAccountIds[0] ?? '0'),
+  );
+
+  if (!account) return null;
+
+  const domain = account.acct.split('@')[1];
+
+  const values = {
+    name: <bdi>{domain ?? `@${account.acct}`}</bdi>,
+    reportId: reportNote.report.id,
+  };
+
+  const message = (
+    <FormattedMessage
+      id='notification.admin.report_note'
+      defaultMessage='{name} added a report note to Report #{reportId}'
+      values={values}
+    />
+  );
+
+  return (
+    <a
+      href={`/admin/reports/${reportNote.report.id}#report_note_${reportNote.id}`}
+      target='_blank'
+      rel='noopener noreferrer'
+      className={classNames(
+        'notification-group notification-group--link notification-group--admin-report focusable',
+        { 'notification-group--unread': unread },
+      )}
+    >
+      <div className='notification-group__icon'>
+        <Icon id='flag' icon={FlagIcon} />
+      </div>
+
+      <div className='notification-group__main'>
+        <div className='notification-group__main__header'>
+          <div className='notification-group__main__header__label'>
+            {message}
+            <RelativeTimestamp timestamp={reportNote.created_at} />
+          </div>
+        </div>
+
+        {reportNote.content.length > 0 && (
+          <div className='notification-group__embedded-status__content'>
+            “{reportNote.content}”
+          </div>
+        )}
+      </div>
+    </a>
+  );
+};

--- a/app/javascript/mastodon/features/notifications_v2/components/notification_group.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/components/notification_group.tsx
@@ -8,6 +8,7 @@ import type { NotificationGroup as NotificationGroupModel } from 'mastodon/model
 import { useAppSelector, useAppDispatch } from 'mastodon/store';
 
 import { NotificationAdminReport } from './notification_admin_report';
+import { NotificationAdminReportNote } from './notification_admin_report_note';
 import { NotificationAdminSignUp } from './notification_admin_sign_up';
 import { NotificationAnnualReport } from './notification_annual_report';
 import { NotificationFavourite } from './notification_favourite';
@@ -131,6 +132,14 @@ export const NotificationGroup: React.FC<{
     case 'admin.report':
       content = (
         <NotificationAdminReport
+          unread={unread}
+          notification={notificationGroup}
+        />
+      );
+      break;
+    case 'admin.report_note':
+      content = (
+        <NotificationAdminReportNote
           unread={unread}
           notification={notificationGroup}
         />

--- a/app/javascript/mastodon/reducers/notifications.js
+++ b/app/javascript/mastodon/reducers/notifications.js
@@ -56,6 +56,7 @@ export const notificationToMap = notification => ImmutableMap({
   created_at: notification.created_at,
   status: notification.status ? notification.status.id : null,
   report: notification.report ? fromJS(notification.report) : null,
+  report_note: notification.report_note ? fromJS(notification.report_note) : null,
   event: notification.event ? fromJS(notification.event) : null,
   moderation_warning: notification.moderation_warning ? fromJS(notification.moderation_warning) : null,
 });

--- a/app/javascript/mastodon/reducers/settings.js
+++ b/app/javascript/mastodon/reducers/settings.js
@@ -41,6 +41,7 @@ const initialState = ImmutableMap({
       update: false,
       'admin.sign_up': false,
       'admin.report': false,
+      'admin.report_note': false,
     }),
 
     quickFilter: ImmutableMap({
@@ -64,6 +65,7 @@ const initialState = ImmutableMap({
       update: true,
       'admin.sign_up': true,
       'admin.report': true,
+      'admin.report_note': true,
     }),
 
     sounds: ImmutableMap({
@@ -77,6 +79,7 @@ const initialState = ImmutableMap({
       update: true,
       'admin.sign_up': true,
       'admin.report': true,
+      'admin.report_note': true,
     }),
 
     group: ImmutableMap({

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -21,6 +21,14 @@ class AdminMailer < ApplicationMailer
     end
   end
 
+  def new_report_note(report_note)
+    @report_note = report_note
+
+    locale_for_account(@me) do
+      mail subject: default_i18n_subject(instance: @instance, id: @report_note.report.id)
+    end
+  end
+
   def new_appeal(appeal)
     @appeal = appeal
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -73,6 +73,9 @@ class Notification < ApplicationRecord
     'admin.report': {
       filterable: false,
     }.freeze,
+    'admin.report_note': {
+      filterable: false,
+    }.freeze,
   }.freeze
 
   TYPES = PROPERTIES.keys.freeze
@@ -85,6 +88,7 @@ class Notification < ApplicationRecord
     poll: [poll: :status],
     update: :status,
     'admin.report': [report: :target_account],
+    'admin.report_note': [report_note: :report],
   }.freeze
 
   belongs_to :account, optional: true
@@ -99,6 +103,7 @@ class Notification < ApplicationRecord
     belongs_to :favourite, inverse_of: :notification
     belongs_to :poll, inverse_of: false
     belongs_to :report, inverse_of: false
+    belongs_to :report_note, inverse_of: false
     belongs_to :account_relationship_severance_event, inverse_of: false
     belongs_to :account_warning, inverse_of: false
     belongs_to :generated_annual_report, inverse_of: false
@@ -192,7 +197,7 @@ class Notification < ApplicationRecord
     return unless new_record?
 
     case activity_type
-    when 'Status', 'Follow', 'Favourite', 'FollowRequest', 'Poll', 'Report'
+    when 'Status', 'Follow', 'Favourite', 'FollowRequest', 'Poll', 'Report', 'ReportNote'
       self.from_account_id = activity&.account_id
     when 'Mention'
       self.from_account_id = activity&.status&.account_id

--- a/app/models/notification_group.rb
+++ b/app/models/notification_group.rb
@@ -49,6 +49,7 @@ class NotificationGroup < ActiveModelSerializers::Model
   delegate :type,
            :target_status,
            :report,
+           :report_note,
            :account_relationship_severance_event,
            :account_warning,
            :generated_annual_report,

--- a/app/serializers/rest/notification_group_serializer.rb
+++ b/app/serializers/rest/notification_group_serializer.rb
@@ -11,6 +11,7 @@ class REST::NotificationGroupSerializer < ActiveModel::Serializer
   attribute :sample_account_ids
   attribute :status_id, if: :status_type?
   belongs_to :report, if: :report_type?, serializer: REST::ReportSerializer
+  belongs_to :report_note, if: :report_note_type?, serializer: REST::ReportNoteSerializer
   belongs_to :account_relationship_severance_event, key: :event, if: :relationship_severance_event?, serializer: REST::AccountRelationshipSeveranceEventSerializer
   belongs_to :account_warning, key: :moderation_warning, if: :moderation_warning_event?, serializer: REST::AccountWarningSerializer
   belongs_to :generated_annual_report, key: :annual_report, if: :annual_report_event?, serializer: REST::AnnualReportEventSerializer
@@ -29,6 +30,10 @@ class REST::NotificationGroupSerializer < ActiveModel::Serializer
 
   def report_type?
     object.type == :'admin.report'
+  end
+
+  def report_note_type?
+    object.type == :'admin.report_note'
   end
 
   def relationship_severance_event?

--- a/app/serializers/rest/notification_serializer.rb
+++ b/app/serializers/rest/notification_serializer.rb
@@ -9,6 +9,7 @@ class REST::NotificationSerializer < ActiveModel::Serializer
   belongs_to :from_account, key: :account, serializer: REST::AccountSerializer
   belongs_to :target_status, key: :status, if: :status_type?, serializer: REST::StatusSerializer
   belongs_to :report, if: :report_type?, serializer: REST::ReportSerializer
+  belongs_to :report_note, if: :report_note_type?, serializer: REST::ReportNoteSerializer
   belongs_to :account_relationship_severance_event, key: :event, if: :relationship_severance_event?, serializer: REST::AccountRelationshipSeveranceEventSerializer
   belongs_to :account_warning, key: :moderation_warning, if: :moderation_warning_event?, serializer: REST::AccountWarningSerializer
 
@@ -26,6 +27,10 @@ class REST::NotificationSerializer < ActiveModel::Serializer
 
   def report_type?
     object.type == :'admin.report'
+  end
+
+  def report_note_type?
+    object.type == :'admin.report_note'
   end
 
   def relationship_severance_event?

--- a/app/serializers/rest/report_note_serializer.rb
+++ b/app/serializers/rest/report_note_serializer.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class REST::ReportNoteSerializer < ActiveModel::Serializer
+  attributes :id, :content, :created_at
+
+  has_one :report, serializer: REST::ReportSerializer
+
+  def id
+    object.id.to_s
+  end
+end

--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -6,6 +6,7 @@ class NotifyService < BaseService
   # TODO: the severed_relationships and annual_report types probably warrants email notifications
   NON_EMAIL_TYPES = %i(
     admin.report
+    admin.report_note
     admin.sign_up
     update
     poll
@@ -23,6 +24,7 @@ class NotifyService < BaseService
     NON_FILTERABLE_TYPES = %i(
       admin.sign_up
       admin.report
+      admin.report_note
       poll
       update
       account_warning

--- a/app/views/admin_mailer/new_report_note.text.erb
+++ b/app/views/admin_mailer/new_report_note.text.erb
@@ -1,0 +1,5 @@
+<%= raw t('admin_mailer.new_report_note.body', report_id: @report_note.report.id, account: @report_note.account.pretty_acct) %>
+
+> <%= raw word_wrap(@report_note.content, break_sequence: "\n> ") %>
+
+<%= raw t('application_mailer.view')%> <%= admin_report_url(@report_note.report, anchor: dom_id(@report_note)) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1052,6 +1052,9 @@ en:
       body: "%{reporter} has reported %{target}"
       body_remote: Someone from %{domain} has reported %{target}
       subject: New report for %{instance} (#%{id})
+    new_report_note:
+      body: "%{account} has added a report note to Report #%{report_id}:"
+      subject: "New report note for %{instance} (Report #%{id})"
     new_software_updates:
       body: New Mastodon versions have been released, you may want to update!
       subject: New Mastodon versions are available for %{instance}!


### PR DESCRIPTION
This would partially solve: #8517 (it implements just for Report Notes for now, not resolution of reports or other note types)

I have absolutely no idea if I've done any of this correctly, but it seems to roughly work?

I based part of the work on https://github.com/mastodon/mastodon/pull/30065 but implemented only notifications_v2 for now, since I assume that's the correct thing to edit? There's not a way to show the ungrouped notifications post 4.3.0, right?

<img width="976" alt="Screenshot 2024-11-21 at 00 09 37" src="https://github.com/user-attachments/assets/b4f2464f-19fb-4376-817c-998ad3199f68">

<img width="589" alt="Screenshot 2024-11-21 at 00 11 56" src="https://github.com/user-attachments/assets/3df53d10-fd7e-41e4-8b8a-c67307996470">
