### PR TITLE
Add IP retention question to setup rake task

### DIFF
--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -362,7 +362,7 @@ namespace :mastodon do
         q.convert :int
       end
 
-      env['IP_RETENTION_PERIOD'] = (ip_retention_period_days * 86_400)
+      env['IP_RETENTION_PERIOD'] = ip_retention_period_days.days.to_i
 
       prompt.say "\n"
 

--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -358,7 +358,7 @@ namespace :mastodon do
 
       ip_retention_period_days = prompt.ask('How long should we store IP addresses in the database, for moderation purposes? (in days)') do |q|
         q.required true
-        q.default 31
+        q.default 365
         q.convert :int
       end
 

--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -356,6 +356,16 @@ namespace :mastodon do
 
       prompt.say "\n"
 
+      ip_retention_period_days = prompt.ask('How long should we store IP addresses in the database, for moderation purposes? (in days)') do |q|
+        q.required true
+        q.default 31
+        q.convert :int
+      end
+
+      env['IP_RETENTION_PERIOD'] = (ip_retention_period_days * 86400)
+
+      prompt.say "\n"
+
       loop do
         if prompt.yes?('Do you want to send e-mails from localhost?', default: false)
           env['SMTP_SERVER'] = 'localhost'

--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -362,7 +362,7 @@ namespace :mastodon do
         q.convert :int
       end
 
-      env['IP_RETENTION_PERIOD'] = (ip_retention_period_days * 86400)
+      env['IP_RETENTION_PERIOD'] = (ip_retention_period_days * 86_400)
 
       prompt.say "\n"
 


### PR DESCRIPTION
(Follow up on #23071)

As discussed in the previous pull request, people were interested in the setup rake modification to ask the operator for how long they may wish to store IP addresses in the database.

In the original PR, this was changed to 31 days in response to an issue asking for stricter IP retention values. 
In this PR however no changes to the current default value of 1 year, other than changing the current default (when undefined) of 31556952 seconds (~365.25 days) to 31536000 seconds (365 days) when set through the rake job. This is because of the [Input (in days)] * 86400 formula used in the rake task

**This change does the following:**

- Add a question to the setup rake task about IP retention

**Things to keep in mind:**

The default when IP_RETENTION_PERIOD is undefined is 31556952 (365.25 days), however the default from the setup rake task will be 31536000. This results to a slight discrepancy between the IP_RENTENTION_PERIOD used by people who have not defined this variable (installations prior to the inclusion of this PR), and users who do use the default IP_RETENTION_PERIOD generated by this task.

If this is unwanted, we should add logic to the rake task to convert cases of "365 days" to the right 31556952 seconds. Please let me know if this preferred 