### PR TITLE
Remove redundant temporary index creation in `tootctl status remove`

### DIFF
--- a/lib/mastodon/cli/statuses.rb
+++ b/lib/mastodon/cli/statuses.rb
@@ -40,12 +40,13 @@ module Mastodon::CLI
     def remove_statuses
       return if options[:skip_status_remove]
 
+      start_at = Time.now.to_f
+
       say('Creating temporary database indices...')
 
       ActiveRecord::Base.connection.add_index(:media_attachments, :remote_url, name: :index_media_attachments_remote_url, where: 'remote_url is not null', algorithm: :concurrently, if_not_exists: true)
 
       max_id   = Mastodon::Snowflake.id_at(options[:days].days.ago, with_random: false)
-      start_at = Time.now.to_f
 
       unless options[:continue] && ActiveRecord::Base.connection.table_exists?('statuses_to_be_deleted')
         ActiveRecord::Base.connection.add_index(:accounts, :id, name: :index_accounts_local, where: 'domain is null', algorithm: :concurrently, if_not_exists: true)

--- a/lib/mastodon/cli/statuses.rb
+++ b/lib/mastodon/cli/statuses.rb
@@ -44,8 +44,6 @@ module Mastodon::CLI
 
       say('Creating temporary database indices...')
 
-      ActiveRecord::Base.connection.add_index(:media_attachments, :remote_url, name: :index_media_attachments_remote_url, where: 'remote_url is not null', algorithm: :concurrently, if_not_exists: true)
-
       max_id   = Mastodon::Snowflake.id_at(options[:days].days.ago, with_random: false)
 
       unless options[:continue] && ActiveRecord::Base.connection.table_exists?('statuses_to_be_deleted')
@@ -105,7 +103,6 @@ module Mastodon::CLI
       say('Removing temporary database indices to restore write performance...')
 
       ActiveRecord::Base.connection.remove_index(:accounts, name: :index_accounts_local, if_exists: true)
-      ActiveRecord::Base.connection.remove_index(:media_attachments, name: :index_media_attachments_remote_url, if_exists: true)
     end
 
     def remove_orphans_media_attachments

--- a/lib/mastodon/cli/statuses.rb
+++ b/lib/mastodon/cli/statuses.rb
@@ -42,13 +42,9 @@ module Mastodon::CLI
 
       start_at = Time.now.to_f
 
-      say('Creating temporary database indices...')
-
       max_id   = Mastodon::Snowflake.id_at(options[:days].days.ago, with_random: false)
 
       unless options[:continue] && ActiveRecord::Base.connection.table_exists?('statuses_to_be_deleted')
-        ActiveRecord::Base.connection.add_index(:accounts, :id, name: :index_accounts_local, where: 'domain is null', algorithm: :concurrently, if_not_exists: true)
-
         say('Extract the deletion target from statuses... This might take a while...')
 
         ActiveRecord::Base.connection.create_table('statuses_to_be_deleted', force: true)
@@ -70,8 +66,6 @@ module Mastodon::CLI
         SQL
 
         say('Removing temporary database indices to restore write performance...')
-
-        ActiveRecord::Base.connection.remove_index(:accounts, name: :index_accounts_local, if_exists: true)
       end
 
       say('Beginning statuses removal... This might take a while...')
@@ -99,10 +93,6 @@ module Mastodon::CLI
       ActiveRecord::Base.connection.drop_table('statuses_to_be_deleted')
 
       say("Done after #{Time.now.to_f - start_at}s, removed #{removed} out of #{processed} statuses.", :green)
-    ensure
-      say('Removing temporary database indices to restore write performance...')
-
-      ActiveRecord::Base.connection.remove_index(:accounts, name: :index_accounts_local, if_exists: true)
     end
 
     def remove_orphans_media_attachments

--- a/lib/mastodon/cli/statuses.rb
+++ b/lib/mastodon/cli/statuses.rb
@@ -49,7 +49,6 @@ module Mastodon::CLI
 
       unless options[:continue] && ActiveRecord::Base.connection.table_exists?('statuses_to_be_deleted')
         ActiveRecord::Base.connection.add_index(:accounts, :id, name: :index_accounts_local, where: 'domain is null', algorithm: :concurrently, if_not_exists: true)
-        ActiveRecord::Base.connection.add_index(:status_pins, :status_id, name: :index_status_pins_status_id, algorithm: :concurrently, if_not_exists: true)
 
         say('Extract the deletion target from statuses... This might take a while...')
 
@@ -74,7 +73,6 @@ module Mastodon::CLI
         say('Removing temporary database indices to restore write performance...')
 
         ActiveRecord::Base.connection.remove_index(:accounts, name: :index_accounts_local, if_exists: true)
-        ActiveRecord::Base.connection.remove_index(:status_pins, name: :index_status_pins_status_id, if_exists: true)
       end
 
       say('Beginning statuses removal... This might take a while...')
@@ -106,7 +104,6 @@ module Mastodon::CLI
       say('Removing temporary database indices to restore write performance...')
 
       ActiveRecord::Base.connection.remove_index(:accounts, name: :index_accounts_local, if_exists: true)
-      ActiveRecord::Base.connection.remove_index(:status_pins, name: :index_status_pins_status_id, if_exists: true)
       ActiveRecord::Base.connection.remove_index(:media_attachments, name: :index_media_attachments_remote_url, if_exists: true)
     end
 


### PR DESCRIPTION
While investigating performance concerns yesterday, I stumbled upon `tootctl status remove` and its use of temporary indexes. Most of those indexes are now redundant with existing indexes, or are exact duplicates.

Removed those indexes.

Another way we could optimize this is to use `temporary` tables (which will be automatically cleaned up, and are unlogged, which greatly reduces write costs) for the temporary tables created here. But there is some logic to interrupt the task and resume it, so I will have to review that logic first.