### PR TITLE
Prevent delivery of posts to (even more) suspended followers

### DIFF
--- a/app/lib/status_reach_finder.rb
+++ b/app/lib/status_reach_finder.rb
@@ -17,8 +17,7 @@ class StatusReachFinder
 
   def reached_account_inboxes
     scope = Account.where(id: reached_account_ids)
-    scope.merge!(Account.without_suspended) unless unsafe?
-    scope.inboxes
+    inboxes_without_suspended_for(scope)
   end
 
   def reached_account_ids
@@ -71,13 +70,8 @@ class StatusReachFinder
   end
 
   def followers_inboxes
-    if @status.in_reply_to_local_account? && distributable?
-      @status.account.followers.or(@status.thread.account.followers.not_domain_blocked_by_account(@status.account)).inboxes
-    elsif @status.direct_visibility? || @status.limited_visibility?
-      []
-    else
-      @status.account.followers.inboxes
-    end
+    scope = followers_scope
+    inboxes_without_suspended_for(scope)
   end
 
   def relay_inboxes
@@ -94,5 +88,20 @@ class StatusReachFinder
 
   def unsafe?
     @options[:unsafe]
+  end
+
+  def followers_scope
+    if @status.in_reply_to_local_account? && distributable?
+      @status.account.followers.or(@status.thread.account.followers.not_domain_blocked_by_account(@status.account))
+    elsif @status.direct_visibility? || @status.limited_visibility?
+      Account.none
+    else
+      @status.account.followers
+    end
+  end
+
+  def inboxes_without_suspended_for(scope)
+    scope.merge!(Account.without_suspended) unless unsafe?
+    scope.inboxes
   end
 end


### PR DESCRIPTION
Follow-up to #27509, applying the same logic to `#follower_inboxes`.