### PR TITLE
Restore stdout logging setting in development environment

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,6 +37,11 @@ Rails.application.configure do
 
   config.action_controller.forgery_protection_origin_check = ENV['DISABLE_FORGERY_REQUEST_PROTECTION'].nil?
 
+  ActiveSupport::Logger.new($stdout).tap do |logger|
+    logger.formatter = config.log_formatter
+    config.logger = ActiveSupport::TaggedLogging.new(logger)
+  end
+
   # Generate random VAPID keys
   Webpush.generate_key.tap do |vapid_key|
     config.x.vapid_private_key = vapid_key.private_key


### PR DESCRIPTION
In the Rails 7.2 upgrade PR this setting was removed (by me!) - https://github.com/mastodon/mastodon/pull/30391/files#diff-d3c4b3f41072daa416f1920511e9b2e26caea8c5cec0a14cb9508589a4dafa47L40-L42 - on some research that the equivalent setting had become the default.

It looks like when run in single process server mode (`bin/rails server`) the removal of this setting logs to both stdout and also the development.log -- but when supervised by overmind/foreman via the bin/dev script, the stdout logging for the "web" process does not show up.

This restores the previous setting (I'm not going to dig deeply into what I was looking at it ... confirmed this reverts by just launching locally in various combinations and watching logs).