### PR TITLE
Fix username and display name being hidden on narrow screens in moderation interface

### DIFF
--- a/app/javascript/styles/mastodon/widgets.scss
+++ b/app/javascript/styles/mastodon/widgets.scss
@@ -84,6 +84,7 @@
   width: 100%;
 
   .account {
+    max-width: calc(56px + 30ch);
     padding: 0;
     border: 0;
   }

--- a/app/javascript/styles/mastodon/widgets.scss
+++ b/app/javascript/styles/mastodon/widgets.scss
@@ -82,7 +82,6 @@
 
 .accounts-table {
   width: 100%;
-  table-layout: fixed;
 
   .account {
     padding: 0;


### PR DESCRIPTION
This screen could use a redesign, but in the meantime, fix moderation on mobile being near impossible following #29316

## Before

![image](https://github.com/user-attachments/assets/1e7522ff-ec38-47be-a350-bd51330af004)

## After

![image](https://github.com/user-attachments/assets/d0b9978b-bef1-47d4-9a48-c83e7081ce23)