### PR TITLE
Add `tootctl feeds vacuum`

### DIFF
--- a/lib/mastodon/cli/feeds.rb
+++ b/lib/mastodon/cli/feeds.rb
@@ -5,6 +5,7 @@ require_relative 'base'
 module Mastodon::CLI
   class Feeds < Base
     include Redisable
+    include DatabaseHelper
 
     option :all, type: :boolean, default: false
     option :concurrency, type: :numeric, default: 5, aliases: [:c]
@@ -53,14 +54,26 @@ module Mastodon::CLI
       may have been missed because of bugs or database mishaps.
     LONG_DESC
     def vacuum
-      say('Deleting home feeds for deleted local users…')
-      Account.local.where.missing(:user).select(:id).in_batches do |accounts|
-        FeedManager.instance.clean_feeds!(:home, accounts.ids)
-      end
+      with_read_replica do
+        say('Deleting orphaned home feeds…')
+        redis.scan_each(match: 'feed:home:*').each_slice(1000) do |keys|
+          ids = keys.map { |key| key.split(':')[2] }.compact_blank
 
-      say('Deleting home feeds for remote users…')
-      Account.remote.select(:id).in_batches do |accounts|
-        FeedManager.instance.clean_feeds!(:home, accounts.ids)
+          known_ids = User.confirmed.signed_in_recently.where(account_id: ids).pluck(:account_id)
+
+          keys_to_delete = keys.filter { |key| known_ids.exclude?(key.split(':')[2]&.to_i) }
+          redis.del(keys_to_delete)
+        end
+
+        say('Deleting orphaned list feeds…')
+        redis.scan_each(match: 'feed:list:*').each_slice(1000) do |keys|
+          ids = keys.map { |key| key.split(':')[2] }.compact_blank
+
+          known_ids = List.where(account_id: User.confirmed.signed_in_recently.select(:account_id)).where(id: ids).pluck(:id)
+
+          keys_to_delete = keys.filter { |key| known_ids.exclude?(key.split(':')[2]&.to_i) }
+          redis.del(keys_to_delete)
+        end
       end
     end
 


### PR DESCRIPTION
Background: we have been investigating high Redis memory usage on mastodon.social, and most of it is due to feeds storage.

One thing we have noticed is that some feeds that should have been removed hadn't been. One reason for this has been fixed in #33018, but this does not retroactively clean up feeds from deleted accounts, hence this task.