### PR TITLE
Fix direct inbox delivery pushing posts into inactive followers' timelines

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -165,6 +165,10 @@ class User < ApplicationRecord
     end
   end
 
+  def signed_in_recently?
+    current_sign_in_at.present? && current_sign_in_at >= ACTIVE_DURATION.ago
+  end
+
   def confirmed?
     confirmed_at.present?
   end


### PR DESCRIPTION
The code path at `ActivityPub::Activity::Create#postprocess_audience_and_deliver`, triggered on user-inbox delivery, enqueues `FeedInsertWorker` after checking for a follow relationship, but not whether the recipient is considered active.

I thought about adding that check here (and maybe it would still be a good idea to do so), but I figured having the check in the timeline insert code could make sense as well, since this is the most relevant code path, and we already query the recipient's `user` record there.