### PR TITLE
Remove `body_class_string` helper

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,7 +22,6 @@ class ApplicationController < ActionController::Base
   helper_method :use_seamless_external_login?
   helper_method :sso_account_settings
   helper_method :limited_federation_mode?
-  helper_method :body_class_string
   helper_method :skip_csrf_meta_tags?
 
   rescue_from ActionController::ParameterMissing, Paperclip::AdapterRegistry::NoHandlerError, with: :bad_request
@@ -156,10 +155,6 @@ class ApplicationController < ActionController::Base
     return Setting.theme unless Themes.instance.names.include? current_user&.setting_theme
 
     current_user.setting_theme
-  end
-
-  def body_class_string
-    @body_classes || ''
   end
 
   def respond_with_error(code)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -143,7 +143,7 @@ module ApplicationHelper
   end
 
   def body_classes
-    output = body_class_string.split
+    output = []
     output << content_for(:body_classes)
     output << "theme-#{current_theme.parameterize}"
     output << 'system-font' if current_account&.user&.setting_system_font_ui

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -5,12 +5,20 @@ require 'rails_helper'
 RSpec.describe ApplicationHelper do
   describe 'body_classes' do
     context 'with a body class string from a controller' do
-      before { helper.extend controller_helpers }
+      before do
+        user = Fabricate :user
+        user.settings['web.use_system_font'] = true
+        user.settings['web.reduce_motion'] = true
+        user.save
 
-      it 'uses the controller body classes in the result' do
+        helper.extend controller_helpers
+      end
+
+      it 'uses the current theme and user settings classes in the result' do
         expect(helper.body_classes)
-          .to match(/modal-layout compose-standalone/)
-          .and match(/theme-default/)
+          .to match(/theme-default/)
+          .and match(/system-font/)
+          .and match(/reduce-motion/)
       end
 
       it 'includes values set via content_for' do
@@ -24,10 +32,8 @@ RSpec.describe ApplicationHelper do
 
       def controller_helpers
         Module.new do
-          def body_class_string = 'modal-layout compose-standalone'
-
           def current_account
-            @current_account ||= Fabricate(:account)
+            @current_account ||= Fabricate(:account, user: User.last)
           end
 
           def current_theme = 'default'


### PR DESCRIPTION
Reformulation of https://github.com/mastodon/mastodon/pull/31842 with just the bare minimum changes to remove the now-unused method, along with the specs added there, but without the lightweight refactor of the method added there.

I think the `class_names` approach is nice - but can do that as followup, it's not narrowly needed for the removal.