### PR TITLE
Set unicode-bidi of account header content to plaintext in styles

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -7897,6 +7897,7 @@ noscript {
 
   p {
     margin-bottom: 20px;
+    unicode-bidi: plaintext;
 
     &:last-child {
       margin-bottom: 0;


### PR DESCRIPTION
To fix: #33087 

This adds `unicode-bidi: plaintext;` to the `.account__header__content p` in the css styles.
This is exactly like what is already set for posts (`.status__content p`).
