### PR TITLE
Add explicit migration breakpoints

### DIFF
--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -12,6 +12,7 @@ on:
       - '**/*.rb'
       - '.github/workflows/test-migrations.yml'
       - 'lib/tasks/tests.rake'
+      - 'lib/tasks/db.rake'
 
   pull_request:
     paths:

--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -91,6 +91,11 @@ jobs:
           bin/rails db:drop
           bin/rails db:create
           SKIP_POST_DEPLOYMENT_MIGRATIONS=true bin/rails tests:migrations:prepare_database
+
+          # Migrate up to v4.2.0 breakpoint
+          bin/rails db:migrate VERSION=20230907150100
+
+          # Migrate the rest
           SKIP_POST_DEPLOYMENT_MIGRATIONS=true bin/rails db:migrate
           bin/rails db:migrate
           bin/rails tests:migrations:check_database


### PR DESCRIPTION
See https://github.com/mastodon/mastodon/pull/31971#issuecomment-2506034200 as well as the “Cookies and rolling updates” section of https://github.com/mastodon/mastodon/releases/tag/v4.3.0

Basically, this PR means we don't support zero-downtime migrations past 4.2.0 (migrations with downtime are still allowed), enforces it by `abort`ing when trying to run migrations using `SKIP_POST_DEPLOYMENT_MIGRATIONS` from earlier versions than 4.2.0 with the following message:
> Zero-downtime migrations from Mastodon versions earlier than 4.2.0 are not supported.
> Please update to Mastodon 4.2.x first or upgrade by stopping all services and running migrations without `SKIP_POST_DEPLOYMENT_MIGRATIONS`.