### PR TITLE
don't start OTel traces with Redis spans

### DIFF
--- a/config/initializers/opentelemetry.rb
+++ b/config/initializers/opentelemetry.rb
@@ -54,6 +54,9 @@ if ENV.keys.any? { |name| name.match?(/OTEL_.*_ENDPOINT/) }
       'OpenTelemetry::Instrumentation::Sidekiq' => {
         span_naming: :job_class, # Use the job class as the span name, otherwise this is the queue name and not very helpful
       },
+      'OpenTelemetry::Instrumentation::Redis' => {
+        trace_root_spans: false, # don't start traces with Redis spans
+      },
     })
 
     prefix    = ENV.fetch('OTEL_SERVICE_NAME_PREFIX', 'mastodon')


### PR DESCRIPTION
The Redis instrumentation picks up a lot of activity that does not have a parent context. (e.g. Sidekiq polling for jobs. App library methods that are not seen by auto-instrumentation using Redis as a cache.)

This change flips an option on the instrumentation to never generate a Redis span unless there is already another current span started by something else. This will reduce the large volume of essentially-anonymous low-value Redis calls.