### PR TITLE
Remove constant definition from global scope in embed.js

### DIFF
--- a/public/embed.js
+++ b/public/embed.js
@@ -1,8 +1,5 @@
 // @ts-check
-
-const allowedPrefixes = (document.currentScript && document.currentScript.tagName.toUpperCase() === 'SCRIPT' && document.currentScript.dataset.allowedPrefixes) ? document.currentScript.dataset.allowedPrefixes.split(' ') : [];
-
-(function () {
+(function (allowedPrefixes) {
   'use strict';
 
   /**
@@ -127,4 +124,4 @@ const allowedPrefixes = (document.currentScript && document.currentScript.tagNam
       container.appendChild(iframe);
     });
   });
-})();
+})((document.currentScript && document.currentScript.tagName.toUpperCase() === 'SCRIPT' && document.currentScript.dataset.allowedPrefixes) ? document.currentScript.dataset.allowedPrefixes.split(' ') : []);


### PR DESCRIPTION
:information_source: **Disclaimer**: I am **not** a front-end developer, there might be cleaner/nicer/better ways to fix the issue. Also, some of the words or concepts used in my PR might not be proper JS terminology, but I hope it is still understandable :wink: 

# Issue

The `embed.js` script defines a constant in the global scope. When two Toots from different instances are embedded on the same page, the second script loaded triggers an error because it tries to redefine the constant.

```
Uncaught SyntaxError: Identifier 'allowedPrefixes' has already been declared (at embed.js:1:1)
```

Codepen: https://codepen.io/yannweyer-tu/pen/qEWEpyr

See https://github.com/mastodon/mastodon/issues/33049#issuecomment-2507552757 for more context and discussion.

# Suggested fix

Instead of declaring the constant, the value is transmitted as a parameter of the anonymous function when it is invoked.