### PR TITLE
Add new eventListener to force rendering of embedded toots

### DIFF
--- a/public/embed.js
+++ b/public/embed.js
@@ -72,7 +72,7 @@
     });
 
     // Legacy embeds
-    document.querySelectorAll('iframe.mastodon-embed').forEach(iframe => {
+    var renderLegacyEmbed = function (iframe) {
       var id = generateId(embeds);
 
       embeds.set(id, iframe);
@@ -91,10 +91,11 @@
       };
 
       iframe.onload(); // In case the script is executing after the iframe has already loaded
-    });
+    };
+    document.querySelectorAll('iframe.mastodon-embed').forEach(renderLegacyEmbed);
 
     // New generation of embeds
-    document.querySelectorAll('blockquote.mastodon-embed').forEach(container => {
+    var renderEmbed = function (container) {
       var id = generateId(embeds);
 
       embeds.set(id, container);
@@ -122,6 +123,14 @@
       };
 
       container.appendChild(iframe);
+    };
+    document.querySelectorAll('blockquote.mastodon-embed').forEach(renderEmbed);
+
+    // Listen to "mastodon.render" to force rendering of embedded posts
+    document.addEventListener('mastodon.render', function (e) {
+      if (e.target.matches('blockquote.mastodon-embed')) {
+        renderEmbed(e.target);
+      }
     });
   });
 })((document.currentScript && document.currentScript.tagName.toUpperCase() === 'SCRIPT' && document.currentScript.dataset.allowedPrefixes) ? document.currentScript.dataset.allowedPrefixes.split(' ') : []);


### PR DESCRIPTION
:information_source: **Disclaimer**: I am **not** a front-end developer, there might be cleaner/nicer/better ways to fix the issue. Also, some of the words or concepts used in my PR might not be proper JS terminology, but I hope it is still understandable :wink: 

# Issue

The rendering of embedded toots happen only once, when the parent document is ready. It prevents toots later added to the DOM from being rendered.

Codepen: https://codepen.io/yannweyer-tu/pen/KwPwMYx

See https://github.com/mastodon/mastodon/issues/33049#issuecomment-2508052744 for more context.

# Changes

This MR extracts the anonymous rendering functions into named functions, and adds an eventListener that will trigger the rendering of one specific toot.

The events needs to be triggered on the specific toot to be rendered, and must bubble all the way up to the `document` level or else it will be ignored.
When toots from multiple instances are embedded, the Event will trigger the EventListener of each instance, but only the instance(s) with corresponding `allowedPrefixes` will perform the rendering. 

## How to trigger the rendering of a toot

```javascript
// Add the toot (data is the result of a call to /api/oembed)
let element = document.createElement('div');
element.innerHTML = data.html;
let node = document.querySelector('#container').appendChild(element);

// Trigger the rendering of the toot. The Event MUST be dispatched from the blockquote element.
// ⚠️ { bubbles: true } is required since the eventListener is at the document level.
node.querySelector('blockquote.mastodon-embed').dispatchEvent(new Event('mastodon.render', { bubbles: true }));

// Trigger rendering of ALL toots on the page
let event = new Event('mastodon.render', { bubbles: true });
document.querySelectorAll('blockquote.mastodon-embed').forEach(function(elem){
  elem.dispatchEvent(event);
});
```

# Questions and open points

* I don't know if the EventListener is the best strategy? Other social networks provide objects to do similar things, but since we might be working with several instances that have differing versions, I couldn't think of any better way to let instances provide their own logic (but once again, I am not specialized in front-end dev, so don't take my word for it).
* I am not sure about naming conventions for both the event and the variables & functions. Do you have any preferences?
* The event won't trigger the rendering of legacy toots, I am not sure we would need it as well?
   * If so, would we need some kind of filtering mechanism?
* Should I also provide documentation for the Event? If so, where and how?
* Unrelated: Would it make sense to remove the `readystatechange` listener once `document.readyState` is `complete?