### PR TITLE
Add shared example for `RankedTrend` concern

### DIFF
--- a/spec/models/preview_card_trend_spec.rb
+++ b/spec/models/preview_card_trend_spec.rb
@@ -3,20 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe PreviewCardTrend do
+  include_examples 'RankedTrend'
+
   describe 'Associations' do
     it { is_expected.to belong_to(:preview_card).required }
-  end
-
-  describe '.locales' do
-    before do
-      Fabricate :preview_card_trend, language: 'en'
-      Fabricate :preview_card_trend, language: 'en'
-      Fabricate :preview_card_trend, language: 'es'
-    end
-
-    it 'returns unique set of languages' do
-      expect(described_class.locales)
-        .to eq(['en', 'es'])
-    end
   end
 end

--- a/spec/models/status_trend_spec.rb
+++ b/spec/models/status_trend_spec.rb
@@ -3,21 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe StatusTrend do
+  include_examples 'RankedTrend'
+
   describe 'Associations' do
     it { is_expected.to belong_to(:account).required }
     it { is_expected.to belong_to(:status).required }
-  end
-
-  describe '.locales' do
-    before do
-      Fabricate :status_trend, language: 'en'
-      Fabricate :status_trend, language: 'en'
-      Fabricate :status_trend, language: 'es'
-    end
-
-    it 'returns unique set of languages' do
-      expect(described_class.locales)
-        .to eq(['en', 'es'])
-    end
   end
 end

--- a/spec/support/examples/models/concerns/ranked_trend.rb
+++ b/spec/support/examples/models/concerns/ranked_trend.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'RankedTrend' do
+  describe 'Scopes' do
+    describe '.by_rank' do
+      let!(:lower_rank) { Fabricate factory_name, rank: 5 }
+      let!(:higher_rank) { Fabricate factory_name, rank: 50 }
+
+      it 'returns records ordered by rank' do
+        expect(described_class.by_rank)
+          .to eq([higher_rank, lower_rank])
+      end
+    end
+
+    describe '.ranked_below' do
+      let!(:low_rank) { Fabricate factory_name, rank: 5 }
+      let!(:med_rank) { Fabricate factory_name, rank: 50 }
+      let!(:high_rank) { Fabricate factory_name, rank: 500 }
+
+      it 'returns records ordered by rank' do
+        expect(described_class.ranked_below(100))
+          .to include(low_rank)
+          .and include(med_rank)
+          .and not_include(high_rank)
+      end
+    end
+  end
+
+  describe '.locales' do
+    before do
+      Fabricate.times 2, factory_name, language: 'en'
+      Fabricate factory_name, language: 'es'
+    end
+
+    it 'returns unique set of languages' do
+      expect(described_class.locales)
+        .to eq(['en', 'es'])
+    end
+  end
+
+  describe '.recalculate_ordered_rank' do
+    let!(:low_score) { Fabricate factory_name, score: 5, rank: 123 }
+    let!(:high_score) { Fabricate factory_name, score: 10, rank: 456 }
+
+    it 'ranks records based on their score' do
+      expect { described_class.recalculate_ordered_rank }
+        .to change { low_score.reload.rank }.to(2)
+        .and change { high_score.reload.rank }.to(1)
+    end
+  end
+
+  def factory_name
+    described_class.name.underscore.to_sym
+  end
+end


### PR DESCRIPTION
Background: https://github.com/mastodon/mastodon/pull/32837/files#r1864936211

Pulls out what was repeated coverage of `.locales`, and adds coverage for the rest of the concern.

Future change - if/when that linked PR progresses, could pull in the shared examples there as well.