### PR TITLE
Add coverage for `Report#unresolved_siblings?`

### DIFF
--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -127,6 +127,28 @@ RSpec.describe Report do
     end
   end
 
+  describe '#unresolved_siblings?' do
+    subject { Fabricate :report }
+
+    context 'when the target account has other unresolved reports' do
+      before { Fabricate :report, action_taken_at: nil, target_account: subject.target_account }
+
+      it { is_expected.to be_unresolved_siblings }
+    end
+
+    context 'when the target account has a resolved report' do
+      before { Fabricate :report, action_taken_at: 3.days.ago, target_account: subject.target_account }
+
+      it { is_expected.to_not be_unresolved_siblings }
+    end
+
+    context 'when the target account has no other reports' do
+      before { described_class.where(target_account: subject.target_account).destroy_all }
+
+      it { is_expected.to_not be_unresolved_siblings }
+    end
+  end
+
   describe 'validations' do
     let(:remote_account) { Fabricate(:account, domain: 'example.com', protocol: :activitypub, inbox_url: 'http://example.com/inbox') }
 


### PR DESCRIPTION
Pulled out of https://github.com/mastodon/mastodon/pull/32478 which was closed for complexity in the rest of the changes, this just adds some coverage for an unrelated method I noticed while in there.