### PR TITLE
Add coverage for `CustomFilter#expires_in` method

### DIFF
--- a/spec/models/custom_filter_spec.rb
+++ b/spec/models/custom_filter_spec.rb
@@ -27,4 +27,28 @@ RSpec.describe CustomFilter do
       it { is_expected.to normalize(:context).from(['home', 'notifications', 'public    ', '']).to(%w(home notifications public)) }
     end
   end
+
+  describe '#expires_in' do
+    subject { custom_filter.expires_in }
+
+    let(:custom_filter) { Fabricate.build(:custom_filter, expires_at: expires_at) }
+
+    context 'when expires_at is nil' do
+      let(:expires_at) { nil }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when expires is beyond the end of the range' do
+      let(:expires_at) { described_class::EXPIRATION_DURATIONS.last.from_now + 2.days }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when expires is before the start of the range' do
+      let(:expires_at) { described_class::EXPIRATION_DURATIONS.first.from_now - 10.minutes }
+
+      it { is_expected.to eq(described_class::EXPIRATION_DURATIONS.first) }
+    end
+  end
 end


### PR DESCRIPTION
Pulled out of https://github.com/mastodon/mastodon/pull/32479 which was closed for non trivial diff. This adds coverage for unrelated method I noticed while in there. I suspect that having this merged might also make the other diff easier for future re-open on that one.