### PR TITLE
Fix typo in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -399,7 +399,7 @@ The following changelog entries focus on changes visible to users, administrator
 - Fix empty environment variables not using default nil value (#27400 by @renchap)
 - Fix language sorting in settings (#27158 by @gunchleoc)
 
-## |4.2.11] - 2024-08-16
+## [4.2.11] - 2024-08-16
 
 ### Added
 


### PR DESCRIPTION
I believe `|4.2.11]` should be `[4.2.11]` referring to other headings.