### PR TITLE
Change percentile label in year in review in web UI

### DIFF
--- a/app/javascript/mastodon/features/annual_report/percentile.tsx
+++ b/app/javascript/mastodon/features/annual_report/percentile.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/jsx-no-useless-fragment */
 import { FormattedMessage, FormattedNumber } from 'react-intl';
 
+import { domain } from 'mastodon/initial_state';
 import type { Percentiles } from 'mastodon/models/annual_report';
 
 export const Percentile: React.FC<{
@@ -12,7 +13,7 @@ export const Percentile: React.FC<{
     <div className='annual-report__bento__box annual-report__summary__percentile'>
       <FormattedMessage
         id='annual_report.summary.percentile.text'
-        defaultMessage='<topLabel>That puts you in the top</topLabel><percentage></percentage><bottomLabel>of Mastodon users.</bottomLabel>'
+        defaultMessage='<topLabel>That puts you in the top</topLabel><percentage></percentage><bottomLabel>of {domain} users.</bottomLabel>'
         values={{
           topLabel: (str) => (
             <div className='annual-report__summary__percentile__label'>
@@ -44,6 +45,8 @@ export const Percentile: React.FC<{
               )}
             </div>
           ),
+
+          domain,
         }}
       >
         {(message) => <>{message}</>}

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -103,7 +103,7 @@
   "annual_report.summary.most_used_hashtag.most_used_hashtag": "most used hashtag",
   "annual_report.summary.most_used_hashtag.none": "None",
   "annual_report.summary.new_posts.new_posts": "new posts",
-  "annual_report.summary.percentile.text": "<topLabel>That puts you in the top</topLabel><percentage></percentage><bottomLabel>of Mastodon users.</bottomLabel>",
+  "annual_report.summary.percentile.text": "<topLabel>That puts you in the top</topLabel><percentage></percentage><bottomLabel>of {domain} users.</bottomLabel>",
   "annual_report.summary.percentile.we_wont_tell_bernie": "We won't tell Bernie.",
   "annual_report.summary.thanks": "Thanks for being part of Mastodon!",
   "attachments_list.unprocessed": "(unprocessed)",


### PR DESCRIPTION
The string "of Mastodon users" implies all of Mastodon (or all of the fediverse), but we don't have that data to make the comparison, what is actually used is data for your server's users. Use "of {domain} users" instead.