### PR TITLE
Add media attachment description limit to instance API response

### DIFF
--- a/app/serializers/rest/instance_serializer.rb
+++ b/app/serializers/rest/instance_serializer.rb
@@ -77,12 +77,13 @@ class REST::InstanceSerializer < ActiveModel::Serializer
       },
 
       media_attachments: {
-        supported_mime_types: MediaAttachment.supported_mime_types,
-        image_size_limit: MediaAttachment::IMAGE_LIMIT,
+        description_limit: MediaAttachment::MAX_DESCRIPTION_LENGTH,
         image_matrix_limit: Attachmentable::MAX_MATRIX_LIMIT,
-        video_size_limit: MediaAttachment::VIDEO_LIMIT,
+        image_size_limit: MediaAttachment::IMAGE_LIMIT,
+        supported_mime_types: MediaAttachment.supported_mime_types,
         video_frame_rate_limit: MediaAttachment::MAX_VIDEO_FRAME_RATE,
         video_matrix_limit: MediaAttachment::MAX_VIDEO_MATRIX_LIMIT,
+        video_size_limit: MediaAttachment::VIDEO_LIMIT,
       },
 
       polls: {

--- a/spec/requests/api/v2/instance_spec.rb
+++ b/spec/requests/api/v2/instance_spec.rb
@@ -55,6 +55,9 @@ RSpec.describe 'Instances' do
             max_characters: StatusLengthValidator::MAX_CHARS,
             max_media_attachments: Status::MEDIA_ATTACHMENTS_LIMIT
           ),
+          media_attachments: include(
+            description_limit: MediaAttachment::MAX_DESCRIPTION_LENGTH
+          ),
           polls: include(
             max_options: PollValidator::MAX_OPTIONS
           )


### PR DESCRIPTION
Resolves https://github.com/mastodon/mastodon/issues/28338

Can do docs PR if merged, or in parallel.