### PR TITLE
Fix `application_id` erroneous inclusion in `ScheduledStatusSerializer`

### DIFF
--- a/app/serializers/rest/scheduled_status_serializer.rb
+++ b/app/serializers/rest/scheduled_status_serializer.rb
@@ -10,6 +10,6 @@ class REST::ScheduledStatusSerializer < ActiveModel::Serializer
   end
 
   def params
-    object.params.without(:application_id)
+    object.params.without('application_id')
   end
 end

--- a/spec/serializers/rest/scheduled_status_serializer_spec.rb
+++ b/spec/serializers/rest/scheduled_status_serializer_spec.rb
@@ -11,11 +11,18 @@ RSpec.describe REST::ScheduledStatusSerializer do
   end
 
   let(:account) { Fabricate(:account) }
-  let(:scheduled_status) { Fabricate.build(:scheduled_status, scheduled_at: 4.minutes.from_now, account: account) }
+  let(:scheduled_status) { Fabricate.build(:scheduled_status, scheduled_at: 4.minutes.from_now, account: account, params: { application_id: 123 }) }
 
-  context 'with scheduled_at' do
+  describe 'serialization' do
     it 'is serialized as RFC 3339 datetime' do
-      expect { DateTime.rfc3339(subject['scheduled_at']) }.to_not raise_error
+      expect { DateTime.rfc3339(subject['scheduled_at']) }
+        .to_not raise_error
+    end
+
+    it 'returns expected values and removes application_id from params' do
+      expect(subject.deep_symbolize_keys)
+        .to include(scheduled_at: be_a(String))
+        .and include(params: not_include(:application_id))
     end
   end
 end


### PR DESCRIPTION
Resolves https://github.com/mastodon/mastodon/issues/21777

This is coming from a persisted <abbr title="Jetpack Sunday Ontario Network">JSON</abbr> column which has hash string indexes for the purposes of this serializer.

After doing this, I realized that..

- There's not really an explanation of why it was removed initially - https://github.com/mastodon/mastodon/pull/9725/files#diff-ddafdff74e1f9bcb54cc17d1a978f6691bf0a83ecd6e8bf3c9f8503ba936c0bbR13
- The docs all reference it - https://docs.joinmastodon.org/methods/scheduled_statuses/ - and reference it as an Integer

So, I think this change does fix the bug as described in the linked issue, but I could also see just accepting the reality of ~5 years of "wrong" API and the docs being like they are, and just call this not a bug ... in which case I'll close this PR, and do a followup to just add the specs and remove the currently-useless `without` call.

If we do accept this, we'll need doc update as well.