### PR TITLE
Add `maxlength` to registration reason input

### DIFF
--- a/app/views/auth/registrations/new.html.haml
+++ b/app/views/auth/registrations/new.html.haml
@@ -62,6 +62,7 @@
                                       as: :text,
                                       hint: false,
                                       label: false,
+                                      input_html: { maxlength: UserInviteRequest::TEXT_SIZE_LIMIT },
                                       required: Setting.require_invite_text,
                                       wrapper: :with_block_label
 


### PR DESCRIPTION
Resolves https://github.com/mastodon/mastodon/issues/33160, Fixes https://github.com/mastodon/mastodon/issues/33093

Similar to what https://github.com/mastodon/mastodon/pull/30288/files#diff-865163666d571e5c003445950978182c91a1197f994b10fa84b5ca28b66d0e62R71 did for the admin area note length, and both of them could use similar further improvements (hints or other copy near the text, live JS counters, etc).

I did not do it in first pass here, but this could also benefit from a higher `rows` value, I think.