### PR TITLE
Fix missing value limits for `UserRole` position

### DIFF
--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -41,6 +41,8 @@ class UserRole < ApplicationRecord
   EVERYONE_ROLE_ID = -99
   NOBODY_POSITION = -1
 
+  POSITION_LIMIT = 2**31
+
   module Flags
     NONE = 0
     ALL  = FLAGS.values.reduce(&:|)
@@ -89,6 +91,7 @@ class UserRole < ApplicationRecord
 
   validates :name, presence: true, unless: :everyone?
   validates :color, format: { with: /\A#?(?:[A-F0-9]{3}){1,2}\z/i }, unless: -> { color.blank? }
+  validates :position, numericality: { greater_than_or_equal_to: -POSITION_LIMIT, less_than_or_equal_to: POSITION_LIMIT }
 
   validate :validate_permissions_elevation
   validate :validate_position_elevation

--- a/spec/models/user_role_spec.rb
+++ b/spec/models/user_role_spec.rb
@@ -18,6 +18,16 @@ RSpec.describe UserRole do
       end
     end
 
+    describe 'position' do
+      subject { Fabricate.build :user_role }
+
+      let(:excess) { 2**32 }
+      let(:limit) { 2**31 }
+
+      it { is_expected.to_not allow_values(-excess, excess).for(:position) }
+      it { is_expected.to allow_values(-limit, limit).for(:position) }
+    end
+
     describe 'color' do
       it { is_expected.to allow_values('#112233', '#aabbcc', '').for(:color) }
       it { is_expected.to_not allow_values('x', '112233445566', '#xxyyzz').for(:color) }


### PR DESCRIPTION
Resolves https://github.com/mastodon/mastodon/issues/26256

Similar to existing https://github.com/mastodon/mastodon/blob/v4.3.2/app/models/webauthn_credential.rb#L18

What is currently an app error becomes an utterly absurd validation error instead:

<img width="353" alt="Screenshot 2024-12-03 at 21 28 40" src="https://github.com/user-attachments/assets/4971bbe6-fa94-46b4-a0a7-d71eb755ffec">

Possible followup...

- I bet there are more of these where user-supplied values could exceed a column limit, could do audit on that
- I could have sworn there was either a more framework-native way to do this, or a way to introspect into PG/Rails to get these values, but I can't find it