### PR TITLE
Add missing `on_delete: :cascade` foreign keys option

### DIFF
--- a/db/migrate/20241205162640_add_missing_delete_cascade_webauthn_credentials.rb
+++ b/db/migrate/20241205162640_add_missing_delete_cascade_webauthn_credentials.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class AddMissingDeleteCascadeWebauthnCredentials < ActiveRecord::Migration[7.2]
+  def up
+    safety_assured do
+      execute <<~SQL.squish
+        ALTER TABLE webauthn_credentials
+          DROP CONSTRAINT fk_rails_a4355aef77,
+          ADD CONSTRAINT fk_rails_a4355aef77
+            FOREIGN KEY (user_id)
+            REFERENCES users(id)
+            ON DELETE CASCADE
+      SQL
+    end
+  end
+
+  def down
+    safety_assured do
+      execute <<~SQL.squish
+        ALTER TABLE webauthn_credentials
+          DROP CONSTRAINT fk_rails_a4355aef77,
+          ADD CONSTRAINT fk_rails_a4355aef77
+            FOREIGN KEY (user_id)
+            REFERENCES users(id)
+      SQL
+    end
+  end
+end

--- a/db/migrate/20241205163118_add_missing_delete_cascade_account_moderation_notes.rb
+++ b/db/migrate/20241205163118_add_missing_delete_cascade_account_moderation_notes.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class AddMissingDeleteCascadeAccountModerationNotes < ActiveRecord::Migration[7.2]
+  def up
+    safety_assured do
+      execute <<~SQL.squish
+        ALTER TABLE account_moderation_notes
+          DROP CONSTRAINT fk_rails_3f8b75089b,
+          ADD CONSTRAINT fk_rails_3f8b75089b
+            FOREIGN KEY (account_id)
+            REFERENCES accounts(id)
+            ON DELETE CASCADE
+      SQL
+
+      execute <<~SQL.squish
+        ALTER TABLE account_moderation_notes
+          DROP CONSTRAINT fk_rails_dd62ed5ac3,
+          ADD CONSTRAINT fk_rails_dd62ed5ac3
+            FOREIGN KEY (target_account_id)
+            REFERENCES accounts(id)
+            ON DELETE CASCADE
+      SQL
+    end
+  end
+
+  def down
+    safety_assured do
+      execute <<~SQL.squish
+        ALTER TABLE account_moderation_notes
+          DROP CONSTRAINT fk_rails_3f8b75089b,
+          ADD CONSTRAINT fk_rails_3f8b75089b
+            FOREIGN KEY (account_id)
+            REFERENCES accounts(id)
+      SQL
+
+      execute <<~SQL.squish
+        ALTER TABLE account_moderation_notes
+          DROP CONSTRAINT fk_rails_dd62ed5ac3,
+          ADD CONSTRAINT fk_rails_dd62ed5ac3
+            FOREIGN KEY (target_account_id)
+            REFERENCES accounts(id)
+      SQL
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_05_135925) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_05_163118) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -1235,8 +1235,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_05_135925) do
   add_foreign_key "account_domain_blocks", "accounts", name: "fk_206c6029bd", on_delete: :cascade
   add_foreign_key "account_migrations", "accounts", column: "target_account_id", on_delete: :nullify
   add_foreign_key "account_migrations", "accounts", on_delete: :cascade
-  add_foreign_key "account_moderation_notes", "accounts"
-  add_foreign_key "account_moderation_notes", "accounts", column: "target_account_id"
+  add_foreign_key "account_moderation_notes", "accounts", column: "target_account_id", on_delete: :cascade
+  add_foreign_key "account_moderation_notes", "accounts", on_delete: :cascade
   add_foreign_key "account_notes", "accounts", column: "target_account_id", on_delete: :cascade
   add_foreign_key "account_notes", "accounts", on_delete: :cascade
   add_foreign_key "account_pins", "accounts", column: "target_account_id", on_delete: :cascade
@@ -1360,7 +1360,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_05_135925) do
   add_foreign_key "web_push_subscriptions", "oauth_access_tokens", column: "access_token_id", on_delete: :cascade
   add_foreign_key "web_push_subscriptions", "users", on_delete: :cascade
   add_foreign_key "web_settings", "users", name: "fk_11910667b2", on_delete: :cascade
-  add_foreign_key "webauthn_credentials", "users"
+  add_foreign_key "webauthn_credentials", "users", on_delete: :cascade
 
   create_view "instances", materialized: true, sql_definition: <<-SQL
       WITH domain_counts(domain, accounts_count) AS (


### PR DESCRIPTION
Background: https://github.com/mastodon/mastodon/issues/19628#issuecomment-2517890598

Was initially going to do one migration per table, but got a warning from strong migrations.

The approach of adding in one migration and validating in a followup was suggested, and seems similar to what was done in https://github.com/mastodon/mastodon/pull/30539/files#diff-b0186af727b01e91260bddb0b3f844b6da359e5c23dfb8b97a4e23a9baa7002d

I think the net result would basically be the same, but let me know if you'd prefer to do all the remove/add steps for both tables in one migration, and all the validations in one followup migration.

Finally - I don't think we have to worry about valid data here ... the FKs are already in place and we are only changing the ON DELETE behavior ... but just want to double check that...
