### PR TITLE
Update `rails-html-sanitizer` to version 1.6.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -632,9 +632,9 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.6.0)
+    rails-html-sanitizer (1.6.1)
       loofah (~> 2.21)
-      nokogiri (~> 1.14)
+      nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     rails-i18n (7.0.10)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 8)


### PR DESCRIPTION
Saw bundler audit issue on https://github.com/mastodon/mastodon/actions/runs/12166474565/job/33932809494?pr=33176

Resolves CVE