### PR TITLE
Add rel alternate rss/json links to tags show html page

### DIFF
--- a/app/views/tags/show.html.haml
+++ b/app/views/tags/show.html.haml
@@ -1,4 +1,6 @@
 - content_for :header_tags do
+  %link{ rel: :alternate, type: 'application/rss+xml', href: tag_url(@tag) }/
+  %link{ rel: :alternate, type: 'application/activity+json', href: tag_url(@tag) }/
   %meta{ name: 'robots', content: 'noindex' }/
   = render partial: 'shared/og'
 

--- a/spec/requests/tags_spec.rb
+++ b/spec/requests/tags_spec.rb
@@ -7,6 +7,29 @@ RSpec.describe 'Tags' do
     context 'when tag exists' do
       let(:tag) { Fabricate :tag }
 
+      context 'with HTML format' do
+        before { get tag_path(tag) }
+
+        it 'returns page with links to alternate resources' do
+          expect(rss_links.first[:href])
+            .to eq(tag_url(tag))
+          expect(activity_json_links.first[:href])
+            .to eq(tag_url(tag))
+        end
+
+        def rss_links
+          alternate_links.css('[type="application/rss+xml"]')
+        end
+
+        def activity_json_links
+          alternate_links.css('[type="application/activity+json"]')
+        end
+
+        def alternate_links
+          response.parsed_body.css('link[rel=alternate]')
+        end
+      end
+
       context 'with JSON format' do
         before { get tag_path(tag, format: :json) }
 


### PR DESCRIPTION
Resolves https://github.com/mastodon/mastodon/issues/22340 (or at least, the html page portion)

Will do `Link` header as followup (if desired).