### PR TITLE
fix: set s3_acl_enabled to false when s3_permission is no-acl

### DIFF
--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -72,7 +72,8 @@ if ENV['S3_ENABLED'] == 'true'
     }
   )
 
-  Paperclip::Attachment.default_options[:s3_permissions] = ->(*) {} if ENV['S3_PERMISSION'] == ''
+  Paperclip::Attachment.default_options[:s3_permissions] = ->(*) { nil } if ENV['S3_PERMISSION'] == ''
+  Paperclip::Attachment.default_options[:s3_acl_enabled] = ->(*) { false } if ENV['S3_PERMISSION'] == 'no-acl'
 
   if ENV.has_key?('S3_ENDPOINT')
     Paperclip::Attachment.default_options[:s3_options].merge!(

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -72,7 +72,7 @@ if ENV['S3_ENABLED'] == 'true'
     }
   )
 
-  Paperclip::Attachment.default_options[:s3_permissions] = ->(*) { nil } if ENV['S3_PERMISSION'] == ''
+  Paperclip::Attachment.default_options[:s3_permissions] = ->(*) {} if ENV['S3_PERMISSION'] == ''
   Paperclip::Attachment.default_options[:s3_acl_enabled] = ->(*) { false } if ENV['S3_PERMISSION'] == 'no-acl'
 
   if ENV.has_key?('S3_ENDPOINT')


### PR DESCRIPTION
successor of https://github.com/mastodon/mastodon/pull/17979

- fix: https://github.com/mastodon/mastodon/issues/17978