### PR TITLE
Fix deletion of unconfirmed users with Webauthn set

### DIFF
--- a/app/workers/scheduler/user_cleanup_scheduler.rb
+++ b/app/workers/scheduler/user_cleanup_scheduler.rb
@@ -19,6 +19,7 @@ class Scheduler::UserCleanupScheduler
     User.unconfirmed.where(confirmation_sent_at: ..UNCONFIRMED_ACCOUNTS_MAX_AGE_DAYS.days.ago).find_in_batches do |batch|
       # We have to do it separately because of missing database constraints
       AccountModerationNote.where(target_account_id: batch.map(&:account_id)).delete_all
+      WebauthnCredential.where(user_id: batch.map(&:id)).delete_all
       Account.where(id: batch.map(&:account_id)).delete_all
       User.where(id: batch.map(&:id)).delete_all
     end

--- a/spec/workers/scheduler/user_cleanup_scheduler_spec.rb
+++ b/spec/workers/scheduler/user_cleanup_scheduler_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Scheduler::UserCleanupScheduler do
   let!(:old_unconfirmed_user) { Fabricate(:user) }
   let!(:confirmed_user)       { Fabricate(:user) }
   let!(:moderation_note)      { Fabricate(:account_moderation_note, account: Fabricate(:account), target_account: old_unconfirmed_user.account) }
+  let!(:webauthn_credential)  { Fabricate(:webauthn_credential, user_id: old_unconfirmed_user.id) }
 
   describe '#perform' do
     before do
@@ -25,6 +26,8 @@ RSpec.describe Scheduler::UserCleanupScheduler do
         .and change { Account.exists?(old_unconfirmed_user.account_id) }
         .from(true).to(false)
       expect { moderation_note.reload }
+        .to raise_error(ActiveRecord::RecordNotFound)
+      expect { webauthn_credential.reload }
         .to raise_error(ActiveRecord::RecordNotFound)
       expect_preservation_of(new_unconfirmed_user)
       expect_preservation_of(confirmed_user)


### PR DESCRIPTION
This foreign key could use a `on_delete: :cascade`, but this fix doesn't rely on this, to avoid complicating backports with database migrations.