### PR TITLE
Fix `requestAnimationFrame` not always being called when handling embeds

### DIFF
--- a/app/javascript/entrypoints/embed.tsx
+++ b/app/javascript/entrypoints/embed.tsx
@@ -62,13 +62,15 @@ window.addEventListener('message', (e) => {
 
   // We use a timeout to allow for the React page to render before calculating the height
   afterInitialRender(() => {
-    window.parent.postMessage(
-      {
-        type: 'setHeight',
-        id: data.id,
-        height: document.getElementsByTagName('html')[0]?.scrollHeight,
-      },
-      '*',
-    );
+    window.requestAnimationFrame(() => {
+      window.parent.postMessage(
+        {
+          type: 'setHeight',
+          id: data.id,
+          height: document.getElementsByTagName('html')[0]?.scrollHeight,
+        },
+        '*',
+      );
+    });
   });
 });

--- a/app/javascript/hooks/useRenderSignal.ts
+++ b/app/javascript/hooks/useRenderSignal.ts
@@ -24,9 +24,7 @@ export const useRenderSignal = () => {
     renderSignalReceived = true;
 
     if (typeof onInitialRender !== 'undefined') {
-      window.requestAnimationFrame(() => {
-        onInitialRender();
-      });
+      onInitialRender();
     }
   };
 };


### PR DESCRIPTION
The intent is to fix #33167 but I have actually no idea if this would solve the issue, as I have not managed to reproduce it yet.