### PR TITLE
Include time portion in formatted datetimes when provided

### DIFF
--- a/app/javascript/entrypoints/public.tsx
+++ b/app/javascript/entrypoints/public.tsx
@@ -119,7 +119,11 @@ function loaded() {
         formattedContent = dateFormat.format(datetime);
       }
 
-      content.title = formattedContent;
+      const timeGiven = content.dateTime.includes('T');
+      content.title = timeGiven
+        ? dateTimeFormat.format(datetime)
+        : dateFormat.format(datetime);
+
       content.textContent = formattedContent;
     });
 

--- a/app/views/admin/report_notes/_report_note.html.haml
+++ b/app/views/admin/report_notes/_report_note.html.haml
@@ -4,7 +4,7 @@
   .report-notes__item__header
     %span.username
       = link_to report_note.account.username, admin_account_path(report_note.account_id)
-    %time.relative-formatted{ datetime: report_note.created_at.iso8601 }
+    %time.relative-formatted{ datetime: report_note.created_at.iso8601, title: report_note.created_at }
       = l report_note.created_at.to_date
 
   .report-notes__item__content

--- a/app/views/admin/reports/_comment.html.haml
+++ b/app/views/admin/reports/_comment.html.haml
@@ -18,7 +18,7 @@
           = link_to report.account.username, admin_account_path(report.account_id)
         - else
           = link_to report.account.domain, admin_instance_path(report.account.domain)
-      %time.relative-formatted{ datetime: report.created_at.iso8601 }
+      %time.relative-formatted{ datetime: report.created_at.iso8601, title: report.created_at }
         = l report.created_at.to_date
     .report-notes__item__content
       = simple_format(h(report.comment))

--- a/app/views/disputes/strikes/show.html.haml
+++ b/app/views/disputes/strikes/show.html.haml
@@ -66,7 +66,7 @@
       .report-notes__item__header
         %span.username
           = link_to @appeal.account.username, can?(:show, @appeal.account) ? admin_account_path(@appeal.account_id) : short_account_url(@appeal.account)
-        %time.relative-formatted{ datetime: @appeal.created_at.iso8601 }
+        %time.relative-formatted{ datetime: @appeal.created_at.iso8601, title: @appeal.created_at }
           = l @appeal.created_at.to_date
 
       .report-notes__item__content


### PR DESCRIPTION
Previously when viewing report notes and a few other formatted times, administrators were not able to see the actual time portion of the formatted date/time. This does change the public javascript which applies to all uses of `time.relative-formatted`, however, it is in line with how `time.time-ago` does this.

<img width="673" alt="Screenshot 2024-12-05 at 18 53 42" src="https://github.com/user-attachments/assets/f286c795-0177-4a7d-89d7-6ab542e15941">

I've added the title attribute as a fallback if the javascript doesn't run.