### PR TITLE
Always remove setting keys in legacy user settings migrations

### DIFF
--- a/db/migrate/20241205135901_remove_legacy_user_settings_data.rb
+++ b/db/migrate/20241205135901_remove_legacy_user_settings_data.rb
@@ -8,6 +8,22 @@ class RemoveLegacyUserSettingsData < ActiveRecord::Migration[7.2]
         thing_type IS NOT NULL
         AND thing_id IS NOT NULL
     SQL
+
+    # When running these migrations on mastodon.social, we saw 'notification_emails'
+    # and 'interactions' records that were not associated to a user and caused a
+    # migration issue.
+    # While I have not been able to pinpoint the exact cause of the issue, it is likely
+    # related to the settings system changes made in b11fdc3ae3f90731c01149a5a36dc64e065d4ea2.
+    # So, delete a few user settings that should already have been deleted.
+    connection.execute(<<~SQL.squish)
+      DELETE FROM settings
+      WHERE var IN (
+        'notification_emails', 'interactions', 'boost_modal', 'auto_play_gif',
+        'delete_modal', 'system_font_ui', 'default_sensitive', 'unfollow_modal',
+        'reduce_motion', 'display_sensitive_media', 'hide_network', 'expand_spoilers',
+        'display_media', 'aggregate_reblogs', 'show_application', 'advanced_layout',
+        'use_blurhash', 'use_pending_items')
+    SQL
   end
 
   def down

--- a/db/post_migrate/20241205135925_remove_legacy_user_settings_columns.rb
+++ b/db/post_migrate/20241205135925_remove_legacy_user_settings_columns.rb
@@ -15,6 +15,22 @@ class RemoveLegacyUserSettingsColumns < ActiveRecord::Migration[7.2]
         AND thing_id IS NOT NULL
     SQL
 
+    # When running these migrations on mastodon.social, we saw 'notification_emails'
+    # and 'interactions' records that were not associated to a user and caused a
+    # migration issue.
+    # While I have not been able to pinpoint the exact cause of the issue, it is likely
+    # related to the settings system changes made in b11fdc3ae3f90731c01149a5a36dc64e065d4ea2.
+    # So, delete a few user settings that should already have been deleted.
+    connection.execute(<<~SQL.squish)
+      DELETE FROM settings
+      WHERE var IN (
+        'notification_emails', 'interactions', 'boost_modal', 'auto_play_gif',
+        'delete_modal', 'system_font_ui', 'default_sensitive', 'unfollow_modal',
+        'reduce_motion', 'display_sensitive_media', 'hide_network', 'expand_spoilers',
+        'display_media', 'aggregate_reblogs', 'show_application', 'advanced_layout',
+        'use_blurhash', 'use_pending_items')
+    SQL
+
     add_index :settings, :var, unique: true, algorithm: :concurrently
     remove_index :settings, [:thing_type, :thing_id, :var], name: :index_settings_on_thing_type_and_thing_id_and_var, unique: true
 


### PR DESCRIPTION
Context for this is that when we ran the migrations from #31971 on mastodon.social, we ran into duplicated records.

Indeed, there were a few records with `interactions` or `notification_emails` as `var` but no `thing_id` or `thing_type` values.

While I have not been able to figure out the exact cause for this, all these records were from 2017-01-12, which coincides with changes made to how settings were stored (b11fdc3ae3f90731c01149a5a36dc64e065d4ea2). This could have been a migration/deployment issue at the time or another bug, but it is most likely to be related to this migration.

At the time of those migrations, the only user settings were `interactions` and `notification_emails`.

Therefore, in order to avoid the issue being reproduced on other old servers who could have had a similar upgrade path, I added explicit deletion of those records. I also added a few other user-settings-only settings to be deleted, as this was easy and safe to do, just to err on the side of caution.

The first setting that could be either a site setting or a user setting is `noindex`, it was added 6 months later in #4199, and is not touched by this PR.