### PR TITLE
Add Support for Local Themes: Enable User-Uploaded CSS Customization Issues #32770

### DIFF
--- a/app/javascript/mastodon/features/local_themes/index.jsx
+++ b/app/javascript/mastodon/features/local_themes/index.jsx
@@ -1,0 +1,105 @@
+import React from 'react';
+
+import { FormattedMessage } from 'react-intl';
+
+import { Button } from 'mastodon/components/button';
+
+class LocalThemeSettings extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      currentTheme: null,
+      isEnabled: false,
+    };
+    this.handleFileUploadChange = this.handleFileUploadChange.bind(this);
+    this.handleToggleTheme = this.handleToggleTheme.bind(this);
+  }
+
+  componentDidMount() {
+    const savedTheme = localStorage.getItem('localTheme');
+    if (savedTheme) {
+      this.setState({ 
+        currentTheme: savedTheme,
+        isEnabled: true 
+      });
+      this.applyTheme(savedTheme);
+    }
+  }
+
+  handleFileUploadChange(event) {
+    const file = event.target.files[0];
+    if (file) {
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        const css = e.target.result;
+        this.setState({ currentTheme: css });
+        localStorage.setItem('localTheme', css);
+        this.applyTheme(css);
+        this.setState({ isEnabled: true });
+      };
+      reader.readAsText(file);
+    }
+  }
+
+  applyTheme(css) {
+    let styleElement = document.getElementById('local-theme');
+    if (!styleElement) {
+      styleElement = document.createElement('style');
+      styleElement.id = 'local-theme';
+      document.head.appendChild(styleElement);
+    }
+    styleElement.textContent = css;
+  }
+
+  toggleTheme() {
+    this.setState(prevState => ({
+      isEnabled: !prevState.isEnabled
+    }), () => {
+      if (this.state.isEnabled && this.state.currentTheme) {
+        this.applyTheme(this.state.currentTheme);
+      } else {
+        const styleElement = document.getElementById('local-theme');
+        if (styleElement) {
+          styleElement.textContent = '';
+        }
+      }
+    });
+  }
+
+  handleToggleTheme() {
+    this.toggleTheme();
+  }
+
+  render() {
+    const { currentTheme } = this.state; 
+
+    return (
+      <div className='setting-local-theme'>
+        <div className='setting-local-theme__input'>
+          <input
+            type='file'
+            accept='.css'
+            onChange={this.handleFileUploadChange} 
+            id='local-theme-input'
+          />
+          <label htmlFor='local-theme-input'>
+            <FormattedMessage
+              id='local_theme.select_file'
+              defaultMessage='Seleccionar archivo de tema local'
+            />
+          </label>
+        </div>
+        {currentTheme && (
+          <Button onClick={this.handleToggleTheme}> 
+            <FormattedMessage
+              id='local_theme.toggle'
+              defaultMessage='Activar/Desactivar tema'
+            />
+          </Button>
+        )}
+      </div>
+    );
+  }
+}
+
+export default LocalThemeSettings;

--- a/app/javascript/mastodon/features/preferences/index.jsx
+++ b/app/javascript/mastodon/features/preferences/index.jsx
@@ -1,46 +1,36 @@
 import React from 'react';
 
-import { FormattedMessage } from 'react-intl';
+import { injectIntl, FormattedMessage } from 'react-intl';
 
+import ImmutablePureComponent from 'react-immutable-pure-component';
+
+import Column from '../../components/column';
+import ColumnBackButton from '../../components/column_back_button';
 import LocalThemeSettings from '../local_themes';
-import Column from '../ui/components/column.jsx';
-import ColumnBackButton from '../../components/column_back_button.jsx'; // Importación corregida
 
-const Preferences = () => {
-  return (
-    <Column>
-      <ColumnBackButton />
-      <div className='scrollable'>
-        <div className='column-header'>
-          <h1>
-            <FormattedMessage
-              id='column.preferences'
-              defaultMessage='Preferencias'
-            />
-          </h1>
+class Preferences extends ImmutablePureComponent {
+  render() {
+    return (
+      <Column>
+        <ColumnBackButton />
+        <div className='scrollable'>
+          <div className='column-header'>
+            <h1><FormattedMessage id='column.preferences' defaultMessage='Preferencias' /></h1>
+          </div>
+
+          <div className='column-section'>
+            <h2>
+              <FormattedMessage
+                id='preferences.local_themes'
+                defaultMessage='Temas Locales'
+              />
+            </h2>
+            <LocalThemeSettings />
+          </div>
         </div>
+      </Column>
+    );
+  }
+}
 
-        {/* Otras secciones de preferencias */}
-
-        <div className='column-section'>
-          <h2>
-            <FormattedMessage
-              id='preferences.local_themes'
-              defaultMessage='Temas Locales'
-            />
-          </h2>
-          <p className='column-section__description'>
-            <FormattedMessage
-              id='preferences.local_themes_description'
-              defaultMessage='Personaliza la apariencia de Mastodon con tus propios estilos CSS'
-            />
-          </p>
-
-          <LocalThemeSettings />
-        </div>
-      </div>
-    </Column>
-  );
-};
-
-export default Preferences;
+export default injectIntl(Preferences);

--- a/app/javascript/mastodon/features/preferences/index.jsx
+++ b/app/javascript/mastodon/features/preferences/index.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+import { FormattedMessage } from 'react-intl';
+
+import LocalThemeSettings from '../local_themes';
+import Column from '../ui/components/column.jsx';
+import ColumnBackButton from '../../components/column_back_button.jsx'; // Importación corregida
+
+const Preferences = () => {
+  return (
+    <Column>
+      <ColumnBackButton />
+      <div className='scrollable'>
+        <div className='column-header'>
+          <h1>
+            <FormattedMessage
+              id='column.preferences'
+              defaultMessage='Preferencias'
+            />
+          </h1>
+        </div>
+
+        {/* Otras secciones de preferencias */}
+
+        <div className='column-section'>
+          <h2>
+            <FormattedMessage
+              id='preferences.local_themes'
+              defaultMessage='Temas Locales'
+            />
+          </h2>
+          <p className='column-section__description'>
+            <FormattedMessage
+              id='preferences.local_themes_description'
+              defaultMessage='Personaliza la apariencia de Mastodon con tus propios estilos CSS'
+            />
+          </p>
+
+          <LocalThemeSettings />
+        </div>
+      </div>
+    </Column>
+  );
+};
+
+export default Preferences;

--- a/app/javascript/mastodon/features/ui/index.jsx
+++ b/app/javascript/mastodon/features/ui/index.jsx
@@ -71,6 +71,7 @@ import {
   Explore,
   About,
   PrivacyPolicy,
+  Preferences,
 } from './util/async-components';
 import { ColumnsContextProvider } from './util/columns_context';
 import { WrappedSwitch, WrappedRoute } from './util/react_router_helpers';
@@ -198,6 +199,7 @@ class SwitchingColumnsArea extends PureComponent {
             <WrappedRoute path='/keyboard-shortcuts' component={KeyboardShortcuts} content={children} />
             <WrappedRoute path='/about' component={About} content={children} />
             <WrappedRoute path='/privacy-policy' component={PrivacyPolicy} content={children} />
+            <WrappedRoute path='/preferences/themes' component={Preferences} content={children} />
 
             <WrappedRoute path={['/home', '/timelines/home']} component={HomeTimeline} content={children} />
             <Redirect from='/timelines/public' to='/public' exact />

--- a/app/javascript/mastodon/features/ui/util/async-components.js
+++ b/app/javascript/mastodon/features/ui/util/async-components.js
@@ -221,3 +221,9 @@ export function ListEdit () {
 export function ListMembers () {
   return import(/* webpackChunkName: "features/lists" */'../../lists/members');
 }
+
+export function Preferences () {
+  return import(/* webpackChunkName: "features/preferences" */'../../preferences');
+}
+
+

--- a/app/javascript/mastodon/locales/es.json
+++ b/app/javascript/mastodon/locales/es.json
@@ -900,5 +900,9 @@
   "video.mute": "Silenciar sonido",
   "video.pause": "Pausar",
   "video.play": "Reproducir",
-  "video.unmute": "Desilenciar sonido"
+  "video.unmute": "Desilenciar sonido",
+  "preferences.local_themes": "Temas Locales",
+  "preferences.local_themes_description": "Personaliza la apariencia de Mastodon con tus propios estilos CSS",
+  "local_theme.select_file": "Seleccionar archivo CSS",
+  "local_theme.toggle": "Activar/Desactivar tema"
 }

--- a/app/javascript/mastodon/locales/es.json
+++ b/app/javascript/mastodon/locales/es.json
@@ -901,8 +901,6 @@
   "video.pause": "Pausar",
   "video.play": "Reproducir",
   "video.unmute": "Desilenciar sonido",
-  "preferences.local_themes": "Temas Locales",
-  "preferences.local_themes_description": "Personaliza la apariencia de Mastodon con tus propios estilos CSS",
-  "local_theme.select_file": "Seleccionar archivo CSS",
-  "local_theme.toggle": "Activar/Desactivar tema"
+  "local_themes": "Temas Locales",
+  "local_themes_description": "Personaliza la apariencia de Mastodon con tus propios estilos CSS"
 }

--- a/app/views/settings/preferences/themes/show.html.haml
+++ b/app/views/settings/preferences/themes/show.html.haml
@@ -1,0 +1,8 @@
+= render partial: 'shared/settings_header'
+
+.simple_form
+  .fields-group
+    .input-group
+      %h2= t('preferences.local_themes')
+      %p.hint= t('preferences.local_themes_description')
+      = react_component :local_theme_settings


### PR DESCRIPTION
This Pull Request introduces a solution to implement local theme functionality in Mastodon, enabling users to upload and apply CSS files directly from their browser. While the logic for managing and applying themes was successfully developed, the full integration with the frontend remains incomplete, preventing a seamless user interface experience.

Key Changes:
LocalThemeSettings Component:

- Allows users to upload CSS files via a file input.
- Applies the uploaded styles to the DOM through a dynamic <style> element.
- Saves themes in localStorage, ensuring they persist across sessions.
- Includes a button to toggle the activation or deactivation of the loaded theme.

Preferences Component Update:

- Adds a new "Local Themes" section to the preferences menu.
- Provides clear options for selecting a theme file and toggling its application.

Benefits:
- Customization: Empowers users to modify Mastodon’s appearance without relying on instance administrators.
- Accessibility: Enables users with specific style needs (e.g., fonts and colors) to personalize the interface.
- Autonomy: Encourages experimentation and the creation of themes by the community.

Current Limitations:
- Incomplete Frontend Integration: While the underlying logic is functional, the UI flow is not yet fully connected to Mastodon’s frontend structure, limiting user accessibility to the feature.
- Design Adjustments Needed: The user experience and visual integration need refinement to align with Mastodon’s standards.

This PR is a significant step toward enhancing Mastodon’s customization and accessibility. Although the feature is not fully integrated, the changes provide a solid foundation that can be finalized with additional adjustments to activate the functionality within the user interface.