### PR TITLE
Extend custom CSS cache time with digest paths

### DIFF
--- a/app/controllers/custom_css_controller.rb
+++ b/app/controllers/custom_css_controller.rb
@@ -2,7 +2,7 @@
 
 class CustomCssController < ActionController::Base # rubocop:disable Rails/ApplicationController
   def show
-    expires_in 3.minutes, public: true
+    expires_in 1.month, public: true
     render content_type: 'text/css'
   end
 

--- a/app/helpers/theme_helper.rb
+++ b/app/helpers/theme_helper.rb
@@ -24,7 +24,7 @@ module ThemeHelper
   end
 
   def custom_stylesheet
-    if active_sheet_digest.present?
+    if active_custom_stylesheet.present?
       stylesheet_link_tag(
         custom_css_path(active_custom_stylesheet),
         host: root_url,
@@ -37,13 +37,15 @@ module ThemeHelper
   private
 
   def active_custom_stylesheet
-    ['custom', active_sheet_digest]
-      .compact_blank
-      .join('-')
+    if cached_custom_css_digest.present?
+      [:custom, cached_custom_css_digest.to_s.first(8)]
+        .compact_blank
+        .join('-')
+    end
   end
 
-  def active_sheet_digest
-    Rails.cache.read(:setting_digest_custom_css).to_s.first(8)
+  def cached_custom_css_digest
+    Rails.cache.read(:setting_digest_custom_css)
   end
 
   def theme_color_for(theme)

--- a/app/helpers/theme_helper.rb
+++ b/app/helpers/theme_helper.rb
@@ -23,7 +23,15 @@ module ThemeHelper
     end
   end
 
+  def active_custom_stylesheet
+    [:custom, active_sheet_digest].join('-')
+  end
+
   private
+
+  def active_sheet_digest
+    (Rails.cache.read(:custom_style_digest) || :styles).to_s.first(8)
+  end
 
   def theme_color_for(theme)
     theme == 'mastodon-light' ? Themes::THEME_COLORS[:light] : Themes::THEME_COLORS[:dark]

--- a/app/helpers/theme_helper.rb
+++ b/app/helpers/theme_helper.rb
@@ -43,7 +43,7 @@ module ThemeHelper
   end
 
   def active_sheet_digest
-    Rails.cache.read(:custom_style_digest).to_s.first(8)
+    Rails.cache.read(:setting_digest_custom_css).to_s.first(8)
   end
 
   def theme_color_for(theme)

--- a/app/helpers/theme_helper.rb
+++ b/app/helpers/theme_helper.rb
@@ -23,14 +23,27 @@ module ThemeHelper
     end
   end
 
-  def active_custom_stylesheet
-    [:custom, active_sheet_digest].join('-')
+  def custom_stylesheet
+    if active_sheet_digest.present?
+      stylesheet_link_tag(
+        custom_css_path(active_custom_stylesheet),
+        host: root_url,
+        media: :all,
+        skip_pipeline: true
+      )
+    end
   end
 
   private
 
+  def active_custom_stylesheet
+    ['custom', active_sheet_digest]
+      .compact_blank
+      .join('-')
+  end
+
   def active_sheet_digest
-    (Rails.cache.read(:custom_style_digest) || :styles).to_s.first(8)
+    Rails.cache.read(:custom_style_digest).to_s.first(8)
   end
 
   def theme_color_for(theme)

--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -140,12 +140,12 @@ class Form::AdminSettings
   private
 
   def cache_digest_value(key)
-    Rails.cache.delete(:custom_style_digest)
+    Rails.cache.delete(:"setting_digest_#{key}")
 
     key_value = instance_variable_get(:"@#{key}")
     if key_value.present?
       Rails.cache.write(
-        :custom_style_digest,
+        :"setting_digest_#{key}",
         Digest::SHA256.hexdigest(key_value)
       )
     end

--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -69,6 +69,10 @@ class Form::AdminSettings
     favicon
   ).freeze
 
+  DIGEST_KEYS = %i(
+    custom_css
+  ).freeze
+
   OVERRIDEN_SETTINGS = {
     authorized_fetch: :authorized_fetch_mode?,
   }.freeze
@@ -121,6 +125,11 @@ class Form::AdminSettings
 
     KEYS.each do |key|
       next unless instance_variable_defined?(:"@#{key}")
+
+      if DIGEST_KEYS.include?(key)
+        digest = Digest::SHA256.hexdigest instance_variable_get(:"@#{key}")
+        Rails.cache.write(:custom_style_digest, digest)
+      end
 
       if UPLOAD_KEYS.include?(key)
         public_send(key).save

--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -126,10 +126,7 @@ class Form::AdminSettings
     KEYS.each do |key|
       next unless instance_variable_defined?(:"@#{key}")
 
-      if DIGEST_KEYS.include?(key)
-        digest = Digest::SHA256.hexdigest instance_variable_get(:"@#{key}")
-        Rails.cache.write(:custom_style_digest, digest)
-      end
+      cache_digest_value(key) if DIGEST_KEYS.include?(key)
 
       if UPLOAD_KEYS.include?(key)
         public_send(key).save
@@ -141,6 +138,18 @@ class Form::AdminSettings
   end
 
   private
+
+  def cache_digest_value(key)
+    Rails.cache.delete(:custom_style_digest)
+
+    key_value = instance_variable_get(:"@#{key}")
+    if key_value.present?
+      Rails.cache.write(
+        :custom_style_digest,
+        Digest::SHA256.hexdigest(key_value)
+      )
+    end
+  end
 
   def typecast_value(key, value)
     if BOOLEAN_KEYS.include?(key)

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -34,7 +34,7 @@
     = csrf_meta_tags unless skip_csrf_meta_tags?
     %meta{ name: 'style-nonce', content: request.content_security_policy_nonce }
 
-    = stylesheet_link_tag custom_css_path, skip_pipeline: true, host: root_url, media: 'all'
+    = stylesheet_link_tag custom_css_path(active_custom_stylesheet), skip_pipeline: true, host: root_url, media: 'all'
 
     = yield :header_tags
 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -34,7 +34,7 @@
     = csrf_meta_tags unless skip_csrf_meta_tags?
     %meta{ name: 'style-nonce', content: request.content_security_policy_nonce }
 
-    = stylesheet_link_tag custom_css_path(active_custom_stylesheet), skip_pipeline: true, host: root_url, media: 'all'
+    = custom_stylesheet
 
     = yield :header_tags
 

--- a/config/initializers/settings_digests.rb
+++ b/config/initializers/settings_digests.rb
@@ -1,11 +1,18 @@
 # frozen_string_literal: true
 
 Rails.application.config.to_prepare do
-  digest = begin
-    Digest::SHA256.hexdigest(Setting.custom_css.to_s)
+  custom_css = begin
+    Setting.custom_css
   rescue ActiveRecord::AdapterError # Running without a database, not migrated, no connection, etc
-    :styles
+    nil
   end
 
-  Rails.cache.write(:custom_style_digest, digest)
+  if custom_css.present?
+    Rails
+      .cache
+      .write(
+        :custom_style_digest,
+        Digest::SHA256.hexdigest(custom_css)
+      )
+  end
 end

--- a/config/initializers/settings_digests.rb
+++ b/config/initializers/settings_digests.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+Rails.application.config.to_prepare do
+  digest = begin
+    Digest::SHA256.hexdigest(Setting.custom_css.to_s)
+  rescue ActiveRecord::AdapterError # Running without a database, not migrated, no connection, etc
+    :styles
+  end
+
+  Rails.cache.write(:custom_style_digest, digest)
+end

--- a/config/initializers/settings_digests.rb
+++ b/config/initializers/settings_digests.rb
@@ -11,7 +11,7 @@ Rails.application.config.to_prepare do
     Rails
       .cache
       .write(
-        :custom_style_digest,
+        :setting_digest_custom_css,
         Digest::SHA256.hexdigest(custom_css)
       )
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,7 +55,8 @@ Rails.application.routes.draw do
 
   get 'manifest', to: 'manifests#show', defaults: { format: 'json' }
   get 'intent', to: 'intents#show'
-  get 'custom.css', to: 'custom_css#show', as: :custom_css
+  get 'custom.css', to: 'custom_css#show'
+  resources :custom_css, only: :show, path: :css
 
   get 'remote_interaction_helper', to: 'remote_interaction_helper#index'
 

--- a/spec/helpers/theme_helper_spec.rb
+++ b/spec/helpers/theme_helper_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe ThemeHelper do
 
   describe '#custom_stylesheet' do
     context 'when custom css setting value digest is present' do
-      before { Rails.cache.write(:custom_style_digest, '1a2s3d4f1a2s3d4f') }
+      before { Rails.cache.write(:setting_digest_custom_css, '1a2s3d4f1a2s3d4f') }
 
       it 'returns value from settings' do
         expect(custom_stylesheet)
@@ -90,7 +90,7 @@ RSpec.describe ThemeHelper do
     end
 
     context 'when custom css setting value digest is not present' do
-      before { Rails.cache.delete(:custom_style_digest) }
+      before { Rails.cache.delete(:setting_digest_custom_css) }
 
       it 'returns default value' do
         expect(custom_stylesheet)

--- a/spec/helpers/theme_helper_spec.rb
+++ b/spec/helpers/theme_helper_spec.rb
@@ -79,6 +79,26 @@ RSpec.describe ThemeHelper do
     end
   end
 
+  describe '#active_custom_stylesheet' do
+    context 'when settings value is present' do
+      before { Rails.cache.write(:custom_style_digest, '1a2s3d4f1a2s3d4f') }
+
+      it 'returns value from settings' do
+        expect(active_custom_stylesheet)
+          .to eq('custom-1a2s3d4f')
+      end
+    end
+
+    context 'when settings value not present' do
+      before { Rails.cache.delete(:custom_style_digest) }
+
+      it 'returns default value' do
+        expect(active_custom_stylesheet)
+          .to eq('custom-styles')
+      end
+    end
+  end
+
   private
 
   def html_links

--- a/spec/helpers/theme_helper_spec.rb
+++ b/spec/helpers/theme_helper_spec.rb
@@ -79,22 +79,22 @@ RSpec.describe ThemeHelper do
     end
   end
 
-  describe '#active_custom_stylesheet' do
-    context 'when settings value is present' do
+  describe '#custom_stylesheet' do
+    context 'when custom css setting value digest is present' do
       before { Rails.cache.write(:custom_style_digest, '1a2s3d4f1a2s3d4f') }
 
       it 'returns value from settings' do
-        expect(active_custom_stylesheet)
-          .to eq('custom-1a2s3d4f')
+        expect(custom_stylesheet)
+          .to match('/css/custom-1a2s3d4f.css')
       end
     end
 
-    context 'when settings value not present' do
+    context 'when custom css setting value digest is not present' do
       before { Rails.cache.delete(:custom_style_digest) }
 
       it 'returns default value' do
-        expect(active_custom_stylesheet)
-          .to eq('custom-styles')
+        expect(custom_stylesheet)
+          .to be_blank
       end
     end
   end

--- a/spec/models/form/admin_settings_spec.rb
+++ b/spec/models/form/admin_settings_spec.rb
@@ -28,18 +28,18 @@ RSpec.describe Form::AdminSettings do
 
         it 'changes relevant digest value' do
           expect { subject.save }
-            .to(change { Rails.cache.read(:custom_style_digest) }.to(digested))
+            .to(change { Rails.cache.read(:setting_digest_custom_css) }.to(digested))
         end
       end
 
       context 'when updating custom css to empty value' do
         subject { described_class.new(custom_css: '') }
 
-        before { Rails.cache.write(:custom_style_digest, 'previous-value') }
+        before { Rails.cache.write(:setting_digest_custom_css, 'previous-value') }
 
         it 'changes relevant digest value' do
           expect { subject.save }
-            .to(change { Rails.cache.read(:custom_style_digest) }.to(be_blank))
+            .to(change { Rails.cache.read(:setting_digest_custom_css) }.to(be_blank))
         end
       end
 
@@ -48,7 +48,7 @@ RSpec.describe Form::AdminSettings do
 
         it 'does not update digests' do
           expect { subject.save }
-            .to(not_change { Rails.cache.read(:custom_style_digest) })
+            .to(not_change { Rails.cache.read(:setting_digest_custom_css) })
         end
       end
     end

--- a/spec/models/form/admin_settings_spec.rb
+++ b/spec/models/form/admin_settings_spec.rb
@@ -17,4 +17,26 @@ RSpec.describe Form::AdminSettings do
       end
     end
   end
+
+  describe '#save' do
+    describe 'updating digest values' do
+      context 'when updating custom css' do
+        subject { described_class.new(custom_css: 'body { color: red; }') }
+
+        it 'changes relevant digest value' do
+          expect { subject.save }
+            .to(change { Rails.cache.read(:custom_style_digest) })
+        end
+      end
+
+      context 'when updating other fields' do
+        subject { described_class.new(site_contact_email: 'test@example.host') }
+
+        it 'does not update digests' do
+          expect { subject.save }
+            .to(not_change { Rails.cache.read(:custom_style_digest) })
+        end
+      end
+    end
+  end
 end

--- a/spec/models/form/admin_settings_spec.rb
+++ b/spec/models/form/admin_settings_spec.rb
@@ -20,12 +20,26 @@ RSpec.describe Form::AdminSettings do
 
   describe '#save' do
     describe 'updating digest values' do
-      context 'when updating custom css' do
-        subject { described_class.new(custom_css: 'body { color: red; }') }
+      context 'when updating custom css to real value' do
+        subject { described_class.new(custom_css: css) }
+
+        let(:css) { 'body { color: red; }' }
+        let(:digested) { Digest::SHA256.hexdigest(css) }
 
         it 'changes relevant digest value' do
           expect { subject.save }
-            .to(change { Rails.cache.read(:custom_style_digest) })
+            .to(change { Rails.cache.read(:custom_style_digest) }.to(digested))
+        end
+      end
+
+      context 'when updating custom css to empty value' do
+        subject { described_class.new(custom_css: '') }
+
+        before { Rails.cache.write(:custom_style_digest, 'previous-value') }
+
+        it 'changes relevant digest value' do
+          expect { subject.save }
+            .to(change { Rails.cache.read(:custom_style_digest) }.to(be_blank))
         end
       end
 

--- a/spec/requests/cache_spec.rb
+++ b/spec/requests/cache_spec.rb
@@ -10,6 +10,7 @@ module TestEndpoints
     /.well-known/nodeinfo
     /nodeinfo/2.0
     /manifest
+    /css/custom-1a2s3d4f.css
     /custom.css
     /actor
     /api/v1/instance/extended_description

--- a/spec/requests/custom_css_spec.rb
+++ b/spec/requests/custom_css_spec.rb
@@ -5,10 +5,10 @@ require 'rails_helper'
 RSpec.describe 'Custom CSS' do
   include RoutingHelper
 
-  describe 'GET /custom.css' do
+  describe 'GET /css/:id.css' do
     context 'without any CSS or User Roles' do
       it 'returns empty stylesheet' do
-        get '/custom.css'
+        get '/css/custom-123.css'
 
         expect(response)
           .to have_http_status(200)
@@ -27,7 +27,7 @@ RSpec.describe 'Custom CSS' do
       end
 
       it 'returns stylesheet from settings' do
-        get '/custom.css'
+        get '/css/custom-456.css'
 
         expect(response)
           .to have_http_status(200)

--- a/spec/routing/custom_css_routing_spec.rb
+++ b/spec/routing/custom_css_routing_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Custom CSS routes' do
+  describe 'the legacy route' do
+    it 'routes to correct place' do
+      expect(get('/custom.css'))
+        .to route_to('custom_css#show')
+    end
+  end
+
+  describe 'the custom digest route' do
+    it 'routes to correct place' do
+      expect(get('/css/custom-1a2s3d4f.css'))
+        .to route_to('custom_css#show', id: 'custom-1a2s3d4f', format: 'css')
+    end
+  end
+end


### PR DESCRIPTION
Resolves https://github.com/mastodon/mastodon/issues/33192

Somewhat of a re-attempt at https://github.com/mastodon/mastodon/pull/15928

This wound up being slightly larger than I thought it would be, mostly due to the "avoid extra query" goal.

Changes:

- Extend the cache time in custom css controller from 3 mins to 1 month (given other changes, could probably be much longer, dont feel strongly about correct number here)
- Use the rails cache to store the digest of the contents of the custom css. Initialized once (from settintgs table) on app load, and updated whenever a "digestable" attribute is updated in `Form::AdminSettings` (for now this is just the `custom_css` value)
- Update custom css routes, app layout, helpers, etc - so what was previously always `/custom.css` for this asset is now something like `/css/custom-3f9r8dc7.css` where that value is the first 8 chars of the digest.
- When custom css is not sent (or set to blank), don't include the stylesheet link in the page html at all.

Notes:

- I initially removed the previous `/custom.css` route, but then restored it to minimize any rolling deploy issues. Could remove in future.
- Even when the value changes, all prior routes will still work (the action does not use/need the params `id` value -- its there purely as a cache buster)
- I dont feel strongly about basically any of the naming/paths/whatever here, just wanted to find a way to make this more cachable.
- I put this in `Form::AdminSettings` because we already had some custom logic for "types" of vars there, but this whole thing could also sit directly on `Setting` instead.
- Other than the spec coverage, I did a little local "change value, see it update styles, watch digests change or not, etc" type of smoke testing ... open to ideas here on either more local validation or more spec coverage to add.

Alternate approaches, followup...

- One idea I had was to refactor the "current theme" code instead into a more generic "pluck a few settings values we will need on every page load" sort of thing. Since we're already doing that theme query we could pull the css value digest (via sql, not ruby) there as well ...  though I'd have to think about this a little and confirm edge cases. This might let us avoid all the config/initialize/settings ceremony needed here to avoid the query if we could re-use an existing query that we're ok having every time.
- On top of that - we pull a few vars down every (or almost) page view ... authorized_fetch, site_short_description, site_title, site_contact_username, activity_api_enabled, etc -- many of these are cached already, but this could be updated to pull them all down at once (still caching relevant ones) and lump the css digest grab in there as well. Seems like a bigger refactor than appropriate here, and I'd need to research more first.

If either of those sound interesting, could explore those first, and/or pursue as followup here.