### PR TITLE
Change ability to navigate of unconfirmed users

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -70,7 +70,13 @@ class ApplicationController < ActionController::Base
   end
 
   def require_functional!
-    redirect_to edit_user_registration_path unless current_user.functional?
+    return if current_user.functional?
+
+    if current_user.confirmed?
+      redirect_to edit_user_registration_path
+    else
+      redirect_to auth_setup_path
+    end
   end
 
   def skip_csrf_meta_tags?

--- a/app/views/auth/registrations/new.html.haml
+++ b/app/views/auth/registrations/new.html.haml
@@ -78,5 +78,3 @@
 
   .actions
     = f.button :button, @invite.present? ? t('auth.register') : sign_up_message, type: :submit
-
-.form-footer= render 'auth/shared/links'

--- a/app/views/auth/registrations/rules.html.haml
+++ b/app/views/auth/registrations/rules.html.haml
@@ -27,5 +27,3 @@
     - accept_path = @invite_code.present? ? public_invite_url(invite_code: @invite_code, accept: @accept_token) : new_user_registration_path(accept: @accept_token)
     = link_to t('auth.rules.accept'), accept_path, class: 'button'
     = link_to t('auth.rules.back'), root_path, class: 'button button-tertiary'
-
-.form-footer= render 'auth/shared/links'

--- a/app/views/auth/setup/show.html.haml
+++ b/app/views/auth/setup/show.html.haml
@@ -11,17 +11,17 @@
 
   = render 'shared/error_messages', object: @user
 
-  %p.lead
-    %strong= t('auth.setup.link_not_received')
-  %p.lead= t('auth.setup.email_below_hint_html')
+  %details
+    %summary.lead
+      %strong= t('auth.setup.link_not_received')
 
-  .fields-group
-    = f.input :email,
-              hint: false,
-              input_html: { 'aria-label': t('simple_form.labels.defaults.email'), autocomplete: 'off' },
-              required: true
+    %p.lead= t('auth.setup.email_below_hint_html')
 
-  .actions
-    = f.button :button, t('auth.resend_confirmation'), type: :submit, class: 'button timer-button', disabled: true
+    .fields-group
+      = f.input :email,
+                hint: false,
+                input_html: { 'aria-label': t('simple_form.labels.defaults.email'), autocomplete: 'off', placeholder: t('simple_form.labels.defaults.email') },
+                required: true
 
-.form-footer= render 'auth/shared/links'
+    .actions
+      = f.button :button, t('auth.resend_confirmation'), type: :submit, class: 'button timer-button', disabled: true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1157,7 +1157,7 @@ en:
     set_new_password: Set new password
     setup:
       email_below_hint_html: Check your spam folder, or request another one. You can correct your email address if it's wrong.
-      email_settings_hint_html: Click the link we sent you to verify %{email}. We'll wait right here.
+      email_settings_hint_html: Click the link we sent to %{email} to begin using Mastodon. We'll wait right here.
       link_not_received: Didn't get a link?
       new_confirmation_instructions_sent: You will receive a new email with the confirmation link in a few minutes!
       title: Check your inbox
@@ -1166,7 +1166,7 @@ en:
       title: Login to %{domain}
     sign_up:
       manual_review: Sign-ups on %{domain} go through manual review by our moderators. To help us process your registration, write a bit about yourself and why you want an account on %{domain}.
-      preamble: With an account on this Mastodon server, you'll be able to follow any other person on the network, regardless of where their account is hosted.
+      preamble: With an account on this Mastodon server, you'll be able to follow any other person on the fediverse, regardless of where their account is hosted.
       title: Let's get you set up on %{domain}.
     status:
       account_status: Account status

--- a/spec/system/log_in_spec.rb
+++ b/spec/system/log_in_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'Log in' do
     it 'A unconfirmed user is able to log in' do
       fill_in_auth_details(email, password)
 
-      expect(subject).to have_css('div.admin-wrapper')
+      expect(subject).to have_css('.title', text: I18n.t('auth.setup.title'))
     end
   end
 


### PR DESCRIPTION
Previously, if a user with an unconfirmed e-mail tries to navigate to e.g. the domain of the website, they will be redirected to the settings area, which is quite complex. Instead, always redirect unconfirmed users to the "Check your inbox" screen until they confirm their e-mail. Furthermore, remove the "Account settings", "Didn't receive the confirmation link?" and "Logout" links from that screen, and hide the form for re-sending confirmation in a collapsible area that is not open by default.