### PR TITLE
Change URL truncation to account for ellipses

### DIFF
--- a/app/lib/text_formatter.rb
+++ b/app/lib/text_formatter.rb
@@ -68,6 +68,12 @@ class TextFormatter
       suffix      = url[prefix.length + 30..]
       cutoff      = url[prefix.length..].length > 30
 
+      if suffix && suffix.length == 1 # revert truncation to account for ellipsis
+        display_url += suffix
+        suffix = nil
+        cutoff = false
+      end
+
       tag.a href: url, target: '_blank', rel: rel.join(' '), translate: 'no' do
         tag.span(prefix, class: 'invisible') +
           tag.span(display_url, class: (cutoff ? 'ellipsis' : '')) +

--- a/spec/lib/text_formatter_spec.rb
+++ b/spec/lib/text_formatter_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe TextFormatter do
       end
     end
 
-    context 'when given a stand-alone google URL' do
+    context 'when given a stand-alone Google URL' do
       let(:text) { 'http://google.com' }
 
       it 'matches the full URL' do
@@ -277,6 +277,26 @@ RSpec.describe TextFormatter do
 
       it 'outputs the raw URL' do
         expect(subject).to eq '<p>http://www\.google\.com</p>'
+      end
+    end
+
+    context 'when given a lengthy URL' do
+      let(:text) { 'lorem https://prepitaph.org/wip/web-dovespair/ ipsum' }
+
+      it 'truncates the URL' do
+        expect(subject).to include '<span class="invisible">https://</span>'
+        expect(subject).to include '<span class="ellipsis">prepitaph.org/wip/web-dovespai</span>'
+        expect(subject).to include '<span class="invisible">r/</span>'
+      end
+    end
+
+    context 'when given a sufficiently short URL' do
+      let(:text) { 'lorem https://prepitaph.org/wip/web-devspair/ ipsum' }
+
+      it 'does not truncate the URL' do
+        expect(subject).to include '<span class="invisible">https://</span>'
+        expect(subject).to include '<span class="">prepitaph.org/wip/web-devspair/</span>'
+        expect(subject).to include '<span class="invisible"></span>'
       end
     end
 


### PR DESCRIPTION
![example of spurious truncation](https://github.com/user-attachments/assets/2ebc8b1c-5c6c-4629-bae4-415938b60fe6)

> previously URLs were truncated if they exceeded 30 characters in length, which could lead to slightly absurd or even misleading results because truncated URLs are displayed with a trailing ellipsis - so as far as end users are concerned, for URLs of exactly 31 characters, their final character was merely replaced with an ellipsis
>
> noticed in https://hachyderm.io/@FND/113618242403691814, where
> https://prepitaph.org/wip/web-devspair/ was transformed to
> https://prepitaph.org/wip/web-devspair… for display purposes
>
> this particular implementation is not the most efficient, but the idea here was to be minimally invasive while confirming desired behavior

Note that this last part implies I'm not entirely sure whether these changes are desirable in the first place or whether there are other concerns I haven't considered.