### PR TITLE
Add coverage for `AccountPin` model

### DIFF
--- a/app/models/account_pin.rb
+++ b/app/models/account_pin.rb
@@ -18,7 +18,7 @@ class AccountPin < ApplicationRecord
   belongs_to :account
   belongs_to :target_account, class_name: 'Account'
 
-  validate :validate_follow_relationship
+  validate :validate_follow_relationship, if: -> { account.present? }
 
   private
 

--- a/app/models/account_pin.rb
+++ b/app/models/account_pin.rb
@@ -18,11 +18,11 @@ class AccountPin < ApplicationRecord
   belongs_to :account
   belongs_to :target_account, class_name: 'Account'
 
-  validate :validate_follow_relationship, if: -> { account.present? }
+  validate :validate_follow_relationship
 
   private
 
   def validate_follow_relationship
-    errors.add(:base, I18n.t('accounts.pin_errors.following')) unless account.following?(target_account)
+    errors.add(:base, I18n.t('accounts.pin_errors.following')) unless account&.following?(target_account)
   end
 end

--- a/spec/models/account_pin_spec.rb
+++ b/spec/models/account_pin_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AccountPin do
+  describe 'Associations' do
+    it { is_expected.to belong_to(:account).required }
+    it { is_expected.to belong_to(:target_account).required }
+  end
+
+  describe 'Validations' do
+    describe 'the follow relationship' do
+      subject { Fabricate.build :account_pin, account: account }
+
+      let(:account) { Fabricate :account }
+      let(:target_account) { Fabricate :account }
+
+      context 'when account is following target account' do
+        before { account.follow!(target_account) }
+
+        it { is_expected.to allow_value(target_account).for(:target_account).against(:base) }
+      end
+
+      context 'when account is not following target account' do
+        it { is_expected.to_not allow_value(target_account).for(:target_account).against(:base).with_message(not_following_message) }
+
+        def not_following_message
+          I18n.t('accounts.pin_errors.following')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Extracted from a previous now-closed PR which was also doing more things. Simpler version here I hope.

The spec changes are adding coverage for the one validation method in the class re: the follow status of the connected accounts.

The change in the model is needed to make spec pass, and I think is probably a bugfix (the line in the validation method will error when an account is not present -- so it needs either a change like this, or safe navigation added, to run correctly). When the account is missed the record will be invalid (from the association declaration).