### PR TITLE
Character conversion on TOS template

### DIFF
--- a/config/templates/terms-of-service.md
+++ b/config/templates/terms-of-service.md
@@ -1,7 +1,7 @@
 ## Introduction
 
-These terms of service (the "Terms") cover your access and use of Server
-Operator’s ("Administrator", "we", or "us") instance, located at %{domain} (the
+These terms of service (the "Terms") cover your access and use of Server
+Operator's ("Administrator", "we", or "us") instance, located at %{domain} (the
 "Instance"). These Terms apply solely to your use of the Instance as operated
 by the Administrator. Please note that we have no affiliation with Mastodon
 gGmbH (“Mastodon”) and these Terms do not contain any representations or
@@ -23,8 +23,8 @@ are old enough to access the Instance in your country, but are not old enough to
 have the legal authority to consent to our Terms, please ask your parent or
 legal guardian to read these Terms with you, as they must agree to the Terms on
 your behalf. If you are a parent or legal guardian who has accepted these terms
-on your child’s behalf, these terms apply to you and you are responsible for
-your child’s activities on the Instance.
+on your child's behalf, these terms apply to you and you are responsible for
+your child's activities on the Instance.
 
 ## Prohibited Uses
 
@@ -36,14 +36,14 @@ and local laws and regulations in connection with your use of the Instance. You
 also agree not to use the Instance to engage in any prohibited conduct, or to
 assist any other person or entity in engaging in any prohibited conduct.
 
-We reserve the right (but do not have the obligation) in our sole discretion to:
+We reserve the right (but do not have the obligation) in our sole discretion to:
 (1) monitor the Instance for violations of these Terms; (2) take appropriate
-legal action against anyone who uses or accesses the Instance in a manner that
-we believe violates the law or these Terms, including without limitation,
-reporting such user to law enforcement authorities; (3) deny access to the
+legal action against anyone who uses or accesses the Instance in a manner that
+we believe violates the law or these Terms, including without limitation,
+reporting such user to law enforcement authorities; (3) deny access to the
 Instance or any features of the Instance to anyone who violates these Terms or
-who we believe interferes with the ability of others to enjoy our Instance or
-infringes the rights of others; and (4) otherwise manage the Instance in a
+who we believe interferes with the ability of others to enjoy our Instance or
+infringes the rights of others; and (4) otherwise manage the Instance in a
 manner designed to protect our rights and property and to facilitate the proper
 functioning of the Instance.
 
@@ -53,16 +53,16 @@ attempt to):
 
 - Violate these Terms or other policies and terms posted on, or otherwise
 - applicable to, the Instance; Upload any material, program, or software that
-- contains any virus, worm, spyware, Trojan horse or other program or code
+- contains any virus, worm, spyware, Trojan horse or other program or code
 - designed to interrupt, destroy or limit the functionality of the Instance,
-- launch a denial of service attack, or in any other way attempt to interfere
+- launch a denial of service attack, or in any other way attempt to interfere
 - with the functioning and availability of the Instance; Except as may be the
 - result of standard search engine or Internet browser usage, use, launch,
 - develop, or distribute any automated system, including without limitation, any
 - spider, robot, cheat utility, scraper, offline reader, or any data mining or
-- similar data gathering extraction tools to access the Instance, or use or
+- similar data gathering extraction tools to access the Instance, or use or
 - launch any unauthorized script or other software; Interfere with, disable,
-- vandalize or disrupt the Instance or servers or networks connected to the
+- vandalize or disrupt the Instance or servers or networks connected to the
 - Instance; Hack into, penetrate, disable, or otherwise circumvent the security
 - measures of the Instance or servers or networks connected to the Instance; or
 - otherwise use the Instance in any way that violates any applicable national,
@@ -90,11 +90,11 @@ the Content on the Instance.
 ## DMCA Copyright Infringement Notice
 
 We have implemented the procedures described in the Digital Millennium Copyright
-Act of 1998 ("DMCA"), 17 U.S.C. § 512 , regarding the reporting of alleged
+Act of 1998 ("DMCA"), 17 U.S.C. § 512 , regarding the reporting of alleged
 copyright infringement and the removal of or disabling access to infringing
-material. If you have a good faith belief that copyrighted material on the
-Instance is being used in a way that infringes a copyright over which you are
-authorized to act, you may make a Notice of Infringing Material. If you have a
+material. If you have a good faith belief that copyrighted material on the
+Instance is being used in a way that infringes a copyright over which you are
+authorized to act, you may make a Notice of Infringing Material. If you have a
 good faith belief that copyrighted material that was removed or access to which
 was disabled was a result of a mistake or misidentification, then you may make a
 Notice of Counter-Notification.
@@ -103,57 +103,57 @@ Before serving a Notice of Infringing Material or Counter-Notification, you may
 wish to contact a lawyer to better understand your rights and obligations under
 the DMCA and other applicable laws. For example, if your Notice or
 Counter-Notifications fails to comply with all requirements of sections
-512(c)(3) or 512(g)(3), respectively, your Notice or Counter-Notification may
+512(c)(3) or 512(g)(3), respectively, your Notice or Counter-Notification may
 not be effective.
 
 ### Termination of Repeat Infringers
 
-We will terminate or disable your use of the Instance in appropriate
+We will terminate or disable your use of the Instance in appropriate
 circumstances if you are deemed by us to be a repeat copyright infringer.
 
 ### Notices and Counter-Notifications must be sent to:
 
 DMCA Agent: Copyright Manager
 
-Address: %{dmca_address}
+Address: %{dmca_address}
 
 Email: %{dmca_email}
 
 ## Disclaimer
 
-Administrator reserves the right in our sole discretion to modify or
-discontinue, temporarily or permanently, the Instance (or any part thereof) with
+Administrator reserves the right in our sole discretion to modify or
+discontinue, temporarily or permanently, the Instance (or any part thereof) with
 or without notice to you. You agree that Administrator will not be liable to
 you or to any third party for any modification or discontinuance of the
 Instance, except as set forth in the "Limitation of Liability" section below.
 
 You understand that we are not responsible for any activities or legal
 consequences of your use of the Instance. Users are responsible for using the
-Instance in compliance with all applicable laws and regulations of the
+Instance in compliance with all applicable laws and regulations of the
 jurisdictions in which such users are domiciled, reside, or are located at the
-time of such access or use, as well as these Terms. Any violation of these
+time of such access or use, as well as these Terms. Any violation of these
 Terms may result in the suspension or termination by us, in our sole discretion,
 of your access to and use of the Instance.
 
 ## Limitation of Liability
 
-In no event will Administrator’s total liability to you for all damages, losses,
+In no event will Administrator's total liability to you for all damages, losses,
 or causes of action exceed one hundred dollars ($100). If you are dissatisfied
 with the Instance or with these Terms, your sole remedy is to discontinue your
 use of the Instance.
 
 ## Links to and From Other Websites
 
-You may gain access to other websites and Instances via links on the Instance. 
+You may gain access to other websites and Instances via links on the Instance.
 These Terms apply to the Instance only and do not apply to Mastodon, other
 Instances, or other parties' websites. Similarly, you may have come to the
 Instance via a link from another website or Instance. The terms of use of other
-websites and Instances do not apply to the Instance. Administrator assumes no
+websites and Instances do not apply to the Instance. Administrator assumes no
 responsibility for any terms of use or material outside of the Instance accessed
 via any link. You are free to establish a hypertext link to the Instance so
 long as the link does not state or imply any sponsorship of your website,
-instance or service by Administrator or the Instance. Unless expressly agreed
-to by us in writing, reference to any of our products, services, processes or
+instance or service by Administrator or the Instance. Unless expressly agreed
+to by us in writing, reference to any of our products, services, processes or
 other information, by trade name, trademark, logo, or otherwise by you or any
 third party does not constitute or imply endorsement, sponsorship or
 recommendation thereof by us. You may not, without our prior written
@@ -175,7 +175,7 @@ us, will be resolved exclusively through final and binding arbitration before a
 neutral arbitrator, rather than in a court by a judge or jury, in accordance
 with the terms of this Arbitration Agreement, except that, where available, you
 or we may (but are not required to) assert individual Claims in small claims
-court if such Claims are within the scope of such court’s jurisdiction. Further,
+court if such Claims are within the scope of such court's jurisdiction. Further,
 this Arbitration Agreement does not preclude you from bringing issues to the
 attention of federal, state/provincial, or local agencies, and such agencies
 can, if the law allows, seek relief against us on your behalf. You agree that,
@@ -203,7 +203,7 @@ Instance has your contact information, the Instance will send its Notice to you
 using the last email address we have on file for you if you have provided us
 with an email address (each, a “Notice Address”). The Notice must (i) describe
 the nature and basis of the Claim in sufficient detail to evaluate the merits of
-the claiming party’s Claim and (ii) set forth the specific relief sought,
+the claiming party's Claim and (ii) set forth the specific relief sought,
 including the amount of money (if any) that is demanded and the means by which
 the demanding party calculated the claimed amount. Both parties agree that they
 will attempt to resolve a Claim through informal negotiation within sixty (60)
@@ -242,33 +242,33 @@ pursue a Claim in a local small claims court rather than through arbitration so
 long as the matter remains in a small claims court and proceeds only on an
 individual basis.
 
-## Choice of Law 
+## Choice of Law
 
-Any and all claims related to or arising out of your use of, or access to the
-Instance shall be governed by internal substantive laws of New York in all
+Any and all claims related to or arising out of your use of, or access to the
+Instance shall be governed by internal substantive laws of New York in all
 respects, without regard for the jurisdiction or forum in which you are
 domiciled, reside, or located at the time of such access or use.
 
-## Waiver and Severability 
+## Waiver and Severability
 
-If you do not comply with a portion of these Terms and we do not take action
-right away, this does not mean we are giving up any of our rights under these
+If you do not comply with a portion of these Terms and we do not take action
+right away, this does not mean we are giving up any of our rights under these
 Terms. If any part of these Terms is determined to be invalid or unenforceable
-by a court of competent jurisdiction or arbitrator, the remainder of the Terms
-shall be enforced to the maximum extent permitted by law.
+by a court of competent jurisdiction or arbitrator, the remainder of the Terms
+shall be enforced to the maximum extent permitted by law.
 
 ## Notices
 
 All notices to Administrator under these Terms, unless otherwise specified shall
-be sent to %{admin_email}. Service of any notice will be deemed given on the
+be sent to %{admin_email}. Service of any notice will be deemed given on the
 date of receipt delivered by email.
 
 ## Changes to these Terms
 
-We may change or modify these Terms by posting a revised version on the
+We may change or modify these Terms by posting a revised version on the
 Instance, or by otherwise providing notice to you, and will state at the top of
-the revised Terms the date they were last revised. Changes will not apply
-retroactively and will become effective no earlier than fourteen (14) calendar
+the revised Terms the date they were last revised. Changes will not apply
+retroactively and will become effective no earlier than fourteen (14) calendar
 days after they are posted, except for changes addressing changes made for legal
 reasons, which will be effective immediately. Your continued use of the
-Instance after any change means you agree to the new Terms.
+Instance after any change means you agree to the new Terms.


### PR DESCRIPTION
I suspect the diff here will look like absolutely nothing happened, but this converts what I'm guessing were some copied-from-a-word-doc or other legal process characters into their equivalents.

Will almost definitely need rebase with https://github.com/mastodon/mastodon/pull/33230 - let me know if combining them instead makes more sense.