### PR TITLE
Fix Chromium showing scrollbar on embedded posts

### DIFF
--- a/app/javascript/entrypoints/embed.tsx
+++ b/app/javascript/entrypoints/embed.tsx
@@ -60,6 +60,10 @@ window.addEventListener('message', (e) => {
 
   const data = e.data;
 
+  // Only set overflow to `hidden` once we got the expected `message` so the post can still be scrolled if
+  // embedded without parent Javascript support
+  document.body.style.overflow = 'hidden';
+
   // We use a timeout to allow for the React page to render before calculating the height
   afterInitialRender(() => {
     window.parent.postMessage(

--- a/app/javascript/styles/mastodon/basics.scss
+++ b/app/javascript/styles/mastodon/basics.scss
@@ -107,13 +107,7 @@ body {
   &.embed {
     margin: 0;
     padding-bottom: 0;
-
-    .container {
-      position: absolute;
-      width: 100%;
-      height: 100%;
-      overflow: hidden;
-    }
+    overflow: hidden;
   }
 
   &.admin {


### PR DESCRIPTION
Fixes #33167

For some reason, Chromium shows a scrollbar in the `iframe` despite it being sized appropriately and the scrollbar being useless. This scrollbar disappears when adding a few more pixels of leeway, but I have not been able to figure out the cause.

As an alternative, keep the existing sizing logic, but simply disable scrollbars once we know the `iframe` will be appropriately sized.