### PR TITLE
Use a system setting for the Referer policy

### DIFF
--- a/app/controllers/concerns/web_app_controller_concern.rb
+++ b/app/controllers/concerns/web_app_controller_concern.rb
@@ -7,6 +7,7 @@ module WebAppControllerConcern
     vary_by 'Accept, Accept-Language, Cookie'
 
     before_action :redirect_unauthenticated_to_permalinks!
+    before_action :set_referer_header
 
     content_security_policy do |p|
       policy = ContentSecurityPolicy.new
@@ -40,5 +41,11 @@ module WebAppControllerConcern
         redirect_to(permalink_redirector.redirect_uri, allow_other_host: true)
       end
     end
+  end
+
+  protected
+
+  def set_referer_header
+    response.set_header('Referrer-Policy', Setting.allow_referrer_origin ? 'origin' : 'same-origin')
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -153,7 +153,7 @@ Rails.application.configure do
     'X-Frame-Options' => 'DENY',
     'X-Content-Type-Options' => 'nosniff',
     'X-XSS-Protection' => '0',
-    'Referrer-Policy' => ENV['ALLOW_REFERRER_ORIGIN'] == 'true' ? 'origin' : 'same-origin',
+    'Referrer-Policy' => 'same-origin',
   }
 
   # TODO: Remove once devise-two-factor data migration complete

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -51,6 +51,7 @@ defaults: &defaults
   require_invite_text: false
   backups_retention_period: 7
   captcha_enabled: false
+  allow_referer_origin: false
 
 development:
   <<: *defaults


### PR DESCRIPTION
Follow up on #33214

Having this as a setting will allow exposing it as an admin setting.

There is a slight drawback here as reading the setting for every request makes a Redis call, but I am not sure if we have a way to cache it in memory for the Rails process for a few seconds. Not sure if this additional Redis query will have any impact at all.