### PR TITLE
Add coverage for `UserMailer#terms_of_service_changed` mailer

### DIFF
--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -272,4 +272,16 @@ RSpec.describe UserMailer do
         .and(have_body_text(I18n.t('user_mailer.backup_ready.explanation')))
     end
   end
+
+  describe '#terms_of_service_changed' do
+    let(:terms) { Fabricate :terms_of_service }
+    let(:mail) { described_class.terms_of_service_changed(receiver, terms) }
+
+    it 'renders terms_of_service_changed mail' do
+      expect(mail)
+        .to be_present
+        .and(have_subject(I18n.t('user_mailer.terms_of_service_changed.subject')))
+        .and(have_body_text(I18n.t('user_mailer.terms_of_service_changed.changelog')))
+    end
+  end
 end


### PR DESCRIPTION
Clean up after https://github.com/mastodon/mastodon/pull/33055 which does not execute the mailer.