### PR TITLE
Add system spec for TOS page

### DIFF
--- a/spec/system/terms_of_service_spec.rb
+++ b/spec/system/terms_of_service_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Terms of Service page' do
+  it 'visits the about page and renders the web app' do
+    visit terms_of_service_path
+
+    expect(page)
+      .to have_css('noscript', text: /Mastodon/)
+      .and have_css('body', class: 'app-body')
+  end
+end


### PR DESCRIPTION
Clean up after https://github.com/mastodon/mastodon/pull/33055 just getting some C0/happy-path on this public page.