### PR TITLE
Add NOT NULL requirement to account columns on `AccountPin`

### DIFF
--- a/app/models/account_pin.rb
+++ b/app/models/account_pin.rb
@@ -5,10 +5,10 @@
 # Table name: account_pins
 #
 #  id                :bigint(8)        not null, primary key
-#  account_id        :bigint(8)
-#  target_account_id :bigint(8)
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
+#  account_id        :bigint(8)        not null
+#  target_account_id :bigint(8)        not null
 #
 
 class AccountPin < ApplicationRecord

--- a/db/migrate/20241210140838_add_not_null_to_account_pin_account_columns.rb
+++ b/db/migrate/20241210140838_add_not_null_to_account_pin_account_columns.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class AddNotNullToAccountPinAccountColumns < ActiveRecord::Migration[7.2]
+  def up
+    connection.execute(<<~SQL.squish)
+      DELETE FROM account_pins
+      WHERE account_id IS NULL
+      OR target_account_id IS NULL
+    SQL
+
+    safety_assured do
+      change_column_null :account_pins, :account_id, false
+      change_column_null :account_pins, :target_account_id, false
+    end
+  end
+
+  def down
+    safety_assured do
+      change_column_null :account_pins, :account_id, true
+      change_column_null :account_pins, :target_account_id, true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_05_163118) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_10_140838) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -82,8 +82,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_05_163118) do
   end
 
   create_table "account_pins", force: :cascade do |t|
-    t.bigint "account_id"
-    t.bigint "target_account_id"
+    t.bigint "account_id", null: false
+    t.bigint "target_account_id", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.index ["account_id", "target_account_id"], name: "index_account_pins_on_account_id_and_target_account_id", unique: true


### PR DESCRIPTION
Background in https://github.com/mastodon/mastodon/pull/33231

When adding this, strong migrations suggested doing two migrations -- adding a constraint in first migration; then change nulls and remove constraint in second migration. However, based on assumption that we will not actually have any invalid rows here (likely none at all to begin with, and they'll be cleaned up by first query here if so), I just kept it all in one with `safety_assured` wrapper. Let me know if we'd prefer the constraint/change/drop approach across multiple migrations.

Separately -- we just happened to notice this missing not null on the other PR ... scanning through schema there are actually a bunch of these where we have required association columns but don't have not null at DB level and probably should. Shall I do a more thorough pass on those? If so ... keep it to one migration per table, or lump them all together?