### PR TITLE
Standardize uniqueness validation declaration on `Mention`

### DIFF
--- a/app/models/mention.rb
+++ b/app/models/mention.rb
@@ -18,7 +18,7 @@ class Mention < ApplicationRecord
 
   has_one :notification, as: :activity, dependent: :destroy
 
-  validates :account, uniqueness: { scope: :status }
+  validates :account_id, uniqueness: { scope: :status_id }
 
   scope :active, -> { where(silent: false) }
   scope :silent, -> { where(silent: true) }

--- a/spec/models/mention_spec.rb
+++ b/spec/models/mention_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Mention do
-  describe 'validations' do
+  describe 'Associations' do
     it { is_expected.to belong_to(:account).required }
     it { is_expected.to belong_to(:status).required }
   end

--- a/spec/models/mention_spec.rb
+++ b/spec/models/mention_spec.rb
@@ -7,4 +7,10 @@ RSpec.describe Mention do
     it { is_expected.to belong_to(:account).required }
     it { is_expected.to belong_to(:status).required }
   end
+
+  describe 'Validations' do
+    subject { Fabricate.build :mention }
+
+    it { is_expected.to validate_uniqueness_of(:account_id).scoped_to(:status_id) }
+  end
 end


### PR DESCRIPTION
Extracted from previous larger now closed PR, pulling out simpler portions.

There is a DB level uniqueness index here on these columns, so I dont think there's a data issue, but this updates the validation to be on the columns instead of the association names.

In spec, fix a previous typo, add a barebones validation check.