### PR TITLE
Simplify model validation specs for `CustomFilter`

### DIFF
--- a/spec/models/custom_filter_spec.rb
+++ b/spec/models/custom_filter_spec.rb
@@ -7,19 +7,8 @@ RSpec.describe CustomFilter do
     it { is_expected.to validate_presence_of(:title) }
     it { is_expected.to validate_presence_of(:context) }
 
-    it 'requires non-empty of context' do
-      record = described_class.new(context: [])
-      record.valid?
-
-      expect(record).to model_have_error_on_field(:context)
-    end
-
-    it 'requires valid context value' do
-      record = described_class.new(context: ['invalid'])
-      record.valid?
-
-      expect(record).to model_have_error_on_field(:context)
-    end
+    it { is_expected.to_not allow_values([], %w(invalid)).for(:context) }
+    it { is_expected.to allow_values(%w(home)).for(:context) }
   end
 
   describe 'Normalizations' do


### PR DESCRIPTION
This is also a re-do of an older closed PR which previously had more spec additions and some model refactor.

Exercises the previously covered invalid cases, and adds a valid one as well.

I think we are down to just a few more models specs still using `model_have_error_on_field`, will attempt to work through those in a few small spec-only PRs and then remove it.