### PR TITLE
Add system spec for `Admin::TermsOfService` index view

### DIFF
--- a/spec/system/admin/terms_of_service_spec.rb
+++ b/spec/system/admin/terms_of_service_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin Terms of services' do
+  describe 'Viewing terms of services index page' do
+    let!(:terms) { Fabricate :terms_of_service, text: 'Test terms' }
+
+    before { sign_in Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+
+    it 'allows tags listing and editing' do
+      visit admin_terms_of_service_index_path
+
+      expect(page)
+        .to have_title(I18n.t('admin.terms_of_service.title'))
+
+      expect(page)
+        .to have_content(terms.text)
+    end
+  end
+end


### PR DESCRIPTION
Clean up on https://github.com/mastodon/mastodon/pull/33055 which did not exercise this controller path.

There's more interesting things to capture here. Doing this as first pass to have *something* in place. Will improve this during ongoing controller->system spec updates.