### PR TITLE
Add coverage for admin/terms/drafts#update and admin/terms/generates#create actions

### DIFF
--- a/spec/controllers/admin/terms_of_service/drafts_controller_spec.rb
+++ b/spec/controllers/admin/terms_of_service/drafts_controller_spec.rb
@@ -18,4 +18,49 @@ RSpec.describe Admin::TermsOfService::DraftsController do
       expect(response).to have_http_status(:success)
     end
   end
+
+  describe 'PUT #update' do
+    subject { put :update, params: params }
+
+    let!(:terms) { Fabricate :terms_of_service, published_at: nil }
+
+    context 'with publishing params' do
+      let(:params) { { terms_of_service: { text: 'new' }, action_type: 'publish' } }
+
+      it 'publishes the record' do
+        expect { subject }
+          .to change(Admin::ActionLog, :count).by(1)
+
+        expect(response)
+          .to redirect_to(admin_terms_of_service_index_path)
+        expect(terms.reload.published_at)
+          .to_not be_nil
+      end
+    end
+
+    context 'with non publishing params' do
+      let(:params) { { terms_of_service: { text: 'new' }, action_type: 'save_draft' } }
+
+      it 'updates but does not publish the record' do
+        expect { subject }
+          .to_not change(Admin::ActionLog, :count)
+
+        expect(response)
+          .to redirect_to(admin_terms_of_service_draft_path)
+        expect(terms.reload.published_at)
+          .to be_nil
+      end
+    end
+
+    context 'with invalid params' do
+      let(:params) { { terms_of_service: { text: '' }, action_type: 'save_draft' } }
+
+      it 'does not update the record' do
+        subject
+
+        expect(response)
+          .to have_http_status(:success)
+      end
+    end
+  end
 end

--- a/spec/controllers/admin/terms_of_service/generates_controller_spec.rb
+++ b/spec/controllers/admin/terms_of_service/generates_controller_spec.rb
@@ -18,4 +18,48 @@ RSpec.describe Admin::TermsOfService::GeneratesController do
       expect(response).to have_http_status(:success)
     end
   end
+
+  describe 'POST #create' do
+    subject { post :create, params: params }
+
+    context 'with valid params' do
+      let(:params) do
+        {
+          terms_of_service_generator: {
+            admin_email: 'test@host.example',
+            arbitration_address: '123 Main Street',
+            arbitration_website: 'https://host.example',
+            dmca_address: '123 DMCA Ave',
+            dmca_email: 'dmca@host.example',
+            domain: 'host.example',
+            jurisdiction: 'Europe',
+          },
+        }
+      end
+
+      it 'saves new record' do
+        expect { subject }
+          .to change(TermsOfService, :count).by(1)
+        expect(response)
+          .to redirect_to(admin_terms_of_service_draft_path)
+      end
+    end
+
+    context 'with invalid params' do
+      let(:params) do
+        {
+          terms_of_service_generator: {
+            admin_email: 'what the',
+          },
+        }
+      end
+
+      it 'does not save new record' do
+        expect { subject }
+          .to_not change(TermsOfService, :count)
+        expect(response)
+          .to have_http_status(200)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Clean up on https://github.com/mastodon/mastodon/pull/33055 which did not exercise these controller paths.

Doing these as controller specs since the existing is in there -- will do future cleanup at some point during ongoing odyssey of controller->system conversion.