### PR TITLE
Add non-matching cases to `Report#history` spec

### DIFF
--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -110,20 +110,27 @@ RSpec.describe Report do
     let(:status) { Fabricate(:status) }
     let(:account_warning) { Fabricate(:account_warning, report_id: report.id) }
 
-    before do
-      Fabricate(:action_log, target_type: 'Report', target_id: report.id)
-      Fabricate(:action_log, target_type: 'Account', target_id: report.target_account_id)
-      Fabricate(:action_log, target_type: 'Status', target_id: status.id)
-      Fabricate(:action_log, target_type: 'AccountWarning', target_id: account_warning.id)
-    end
+    let!(:matched_type_account_warning) { Fabricate(:action_log, target_type: 'AccountWarning', target_id: account_warning.id) }
+    let!(:matched_type_account) { Fabricate(:action_log, target_type: 'Account', target_id: report.target_account_id) }
+    let!(:matched_type_report) { Fabricate(:action_log, target_type: 'Report', target_id: report.id) }
+    let!(:matched_type_status) { Fabricate(:action_log, target_type: 'Status', target_id: status.id) }
+
+    let!(:unmatched_type_account_warning) { Fabricate(:action_log, target_type: 'AccountWarning') }
+    let!(:unmatched_type_account) { Fabricate(:action_log, target_type: 'Account') }
+    let!(:unmatched_type_report) { Fabricate(:action_log, target_type: 'Report') }
+    let!(:unmatched_type_status) { Fabricate(:action_log, target_type: 'Status') }
 
     it 'returns expected logs' do
       expect(action_logs)
         .to have_attributes(count: 4)
-        .and include(have_attributes(target_type: 'Account'))
-        .and include(have_attributes(target_type: 'AccountWarning'))
-        .and include(have_attributes(target_type: 'Report'))
-        .and include(have_attributes(target_type: 'Status'))
+        .and include(matched_type_account_warning)
+        .and include(matched_type_account)
+        .and include(matched_type_report)
+        .and include(matched_type_status)
+        .and not_include(unmatched_type_account_warning)
+        .and not_include(unmatched_type_account)
+        .and not_include(unmatched_type_report)
+        .and not_include(unmatched_type_status)
     end
   end
 

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -105,16 +105,16 @@ RSpec.describe Report do
   describe 'history' do
     subject(:action_logs) { report.history }
 
-    let(:report) { Fabricate(:report, target_account_id: target_account.id, status_ids: [status.id], created_at: 3.days.ago, updated_at: 1.day.ago) }
+    let(:report) { Fabricate(:report, target_account_id: target_account.id, status_ids: [status.id]) }
     let(:target_account) { Fabricate(:account) }
     let(:status) { Fabricate(:status) }
     let(:account_warning) { Fabricate(:account_warning, report_id: report.id) }
 
     before do
-      Fabricate(:action_log, target_type: 'Report', account_id: target_account.id, target_id: report.id, created_at: 2.days.ago)
-      Fabricate(:action_log, target_type: 'Account', account_id: target_account.id, target_id: report.target_account_id, created_at: 2.days.ago)
-      Fabricate(:action_log, target_type: 'Status', account_id: target_account.id, target_id: status.id, created_at: 2.days.ago)
-      Fabricate(:action_log, target_type: 'AccountWarning', account_id: target_account.id, target_id: account_warning.id, created_at: 2.days.ago)
+      Fabricate(:action_log, target_type: 'Report', account_id: target_account.id, target_id: report.id)
+      Fabricate(:action_log, target_type: 'Account', account_id: target_account.id, target_id: report.target_account_id)
+      Fabricate(:action_log, target_type: 'Status', account_id: target_account.id, target_id: status.id)
+      Fabricate(:action_log, target_type: 'AccountWarning', account_id: target_account.id, target_id: account_warning.id)
     end
 
     it 'returns expected logs' do

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -111,10 +111,10 @@ RSpec.describe Report do
     let(:account_warning) { Fabricate(:account_warning, report_id: report.id) }
 
     before do
-      Fabricate(:action_log, target_type: 'Report', account_id: target_account.id, target_id: report.id)
-      Fabricate(:action_log, target_type: 'Account', account_id: target_account.id, target_id: report.target_account_id)
-      Fabricate(:action_log, target_type: 'Status', account_id: target_account.id, target_id: status.id)
-      Fabricate(:action_log, target_type: 'AccountWarning', account_id: target_account.id, target_id: account_warning.id)
+      Fabricate(:action_log, target_type: 'Report', target_id: report.id)
+      Fabricate(:action_log, target_type: 'Account', target_id: report.target_account_id)
+      Fabricate(:action_log, target_type: 'Status', target_id: status.id)
+      Fabricate(:action_log, target_type: 'AccountWarning', target_id: account_warning.id)
     end
 
     it 'returns expected logs' do


### PR DESCRIPTION
Follow-up on https://github.com/mastodon/mastodon/pull/32984

I was about to start the CTE-approach experiment mentioned in that PR, and realized the spec here does not create any records which will not be in the result ... and the method could have been `.all`, basically, and still passed.

Changes:

- Remove some not-spec-relevant created/updated times from the factories
- Remove some not-relevant association details from some of the existing fabricators, leaving just what is relevant to the query we care about
- Add some non-matching records (one for each type)
- Update assertion to be specific about which records should/shouldnt be there

Post-changes here feels like more suitable baseline for any CTE/with changes, and/or future updates here.