### PR TITLE
Avoid double request in `admin/export_domain_allows` controller spec

### DIFF
--- a/spec/controllers/admin/export_domain_allows_controller_spec.rb
+++ b/spec/controllers/admin/export_domain_allows_controller_spec.rb
@@ -32,15 +32,16 @@ RSpec.describe Admin::ExportDomainAllowsController do
     it 'allows imported domains' do
       post :import, params: { admin_import: { data: fixture_file_upload('domain_allows.csv') } }
 
-      expect(response).to redirect_to(admin_instances_path)
+      expect(response)
+        .to redirect_to(admin_instances_path)
 
-      # Header should not be imported
-      expect(DomainAllow.where(domain: '#domain').present?).to be(false)
-
-      # Domains should now be added
-      get :export, params: { format: :csv }
-      expect(response).to have_http_status(200)
-      expect(response.body).to eq(domain_allows_csv_file)
+      # Header row should not be imported, but domains should
+      expect(DomainAllow)
+        .to_not exist(domain: '#domain')
+      expect(DomainAllow)
+        .to exist(domain: 'good.domain')
+      expect(DomainAllow)
+        .to exist(domain: 'better.domain')
     end
 
     it 'displays error on no file selected' do


### PR DESCRIPTION
Extracted from the Rails 8 PR - https://github.com/mastodon/mastodon/pull/32357 - which was getting some `EOFError` on this spec specifically, which I tracked down to what seems like a lack of reset between the two requests in this spec.

I'd like to eventually convert this spec into some combination of system/request specs -- but for now, for upgrade-dependency-path purposes, remove the double request, but keep the assertions (we have existing coverage of the `export` action in the example right above this one in the same spec, doing basically the same thing).