### PR TITLE
Enable `Rails/ReversibleMigration` cop

### DIFF
--- a/db/migrate/.rubocop.yml
+++ b/db/migrate/.rubocop.yml
@@ -3,12 +3,17 @@ inherit_from: ../../.rubocop.yml
 Naming/VariableNumber:
   CheckSymbols: false
 
-# Enabled here as workaround for https://docs.rubocop.org/rubocop/configuration.html#path-relativity
+# Below are all enabled as workaround for https://docs.rubocop.org/rubocop/configuration.html#path-relativity
+# TODO: Delete this file and move above config to base naming config
+
 Rails/CreateTableWithTimestamps:
   Include:
     - '*.rb'
 
-# Enabled here as workaround for https://docs.rubocop.org/rubocop/configuration.html#path-relativity
 Rails/ThreeStateBooleanColumn:
+  Include:
+    - '*.rb'
+
+Rails/ReversibleMigration:
   Include:
     - '*.rb'

--- a/db/migrate/20170205175257_remove_devices.rb
+++ b/db/migrate/20170205175257_remove_devices.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 class RemoveDevices < ActiveRecord::Migration[5.0]
-  def change
+  def up
     drop_table :devices if table_exists?(:devices)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
   end
 end

--- a/db/migrate/20170711225116_fix_null_booleans.rb
+++ b/db/migrate/20170711225116_fix_null_booleans.rb
@@ -3,10 +3,10 @@
 class FixNullBooleans < ActiveRecord::Migration[5.1]
   def change
     safety_assured do
-      change_column_default :domain_blocks, :reject_media, false
+      change_column_default :domain_blocks, :reject_media, false # rubocop:disable Rails/ReversibleMigration
       change_column_null :domain_blocks, :reject_media, false, false
 
-      change_column_default :imports, :approved, false
+      change_column_default :imports, :approved, false # rubocop:disable Rails/ReversibleMigration
       change_column_null :imports, :approved, false, false
 
       change_column_null :statuses, :sensitive, false, false
@@ -14,7 +14,7 @@ class FixNullBooleans < ActiveRecord::Migration[5.1]
 
       change_column_null :users, :admin, false, false
 
-      change_column_default :users, :otp_required_for_login, false
+      change_column_default :users, :otp_required_for_login, false # rubocop:disable Rails/ReversibleMigration
       change_column_null :users, :otp_required_for_login, false, false
     end
   end

--- a/db/migrate/20220827195229_change_canonical_email_blocks_nullable.rb
+++ b/db/migrate/20220827195229_change_canonical_email_blocks_nullable.rb
@@ -2,6 +2,6 @@
 
 class ChangeCanonicalEmailBlocksNullable < ActiveRecord::Migration[6.1]
   def change
-    safety_assured { change_column :canonical_email_blocks, :reference_account_id, :bigint, null: true, default: nil }
+    safety_assured { change_column :canonical_email_blocks, :reference_account_id, :bigint, null: true, default: nil } # rubocop:disable Rails/ReversibleMigration
   end
 end


### PR DESCRIPTION
Dependency of https://github.com/mastodon/mastodon/pull/33256

I suspect we may ultimately delete `db/migrate/.rubocop.yml` in this series of PRs, but as interim step do an explicit opt-in here to turn rule on (fixes relative path thing currently unintentionally disabling rule), and then add disable in older migrations.

These are old migrations which will almost definitely never be run beyond CI/dev, but we do want the rule on for new migrations.