### PR TITLE
Remove `app/views` rubocop rule exception for haml-lint

### DIFF
--- a/.rubocop/style.yml
+++ b/.rubocop/style.yml
@@ -22,6 +22,10 @@ Style/HashSyntax:
   EnforcedShorthandSyntax: either
   EnforcedStyle: ruby19_no_mixed_keys
 
+Style/IfUnlessModifier:
+  Exclude:
+    - '**/*.haml'
+
 Style/KeywordArgumentsMerging:
   Enabled: false
 

--- a/app/views/.rubocop.yml
+++ b/app/views/.rubocop.yml
@@ -1,5 +1,0 @@
-inherit_from: ../../.rubocop.yml
-
-# Disable for the `Rubocop` lints in haml-lint
-Style/IfUnlessModifier:
-  Enabled: false


### PR DESCRIPTION
Dependency of https://github.com/mastodon/mastodon/pull/33256

Convert what was previously a views-only disable rule to just disable everywhere.