### PR TITLE
Fix last paginated notification group only including data on a single notification

### DIFF
--- a/app/models/notification_group.rb
+++ b/app/models/notification_group.rb
@@ -64,21 +64,31 @@ class NotificationGroup < ActiveModelSerializers::Model
         binds = [
           account_id,
           SAMPLE_ACCOUNTS_SIZE,
-          pagination_range.begin,
-          pagination_range.end,
           ActiveRecord::Relation::QueryAttribute.new('group_keys', group_keys, ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Array.new(ActiveModel::Type::String.new)),
+          pagination_range.begin || 0,
         ]
+        binds << pagination_range.end unless pagination_range.end.nil?
+
+        upper_bound_cond = begin
+          if pagination_range.end.nil?
+            ''
+          elsif pagination_range.exclude_end?
+            'AND id < $5'
+          else
+            'AND id <= $5'
+          end
+        end
 
         ActiveRecord::Base.connection.select_all(<<~SQL.squish, 'grouped_notifications', binds).cast_values.to_h { |k, *values| [k, values] }
           SELECT
             groups.group_key,
-            (SELECT id FROM notifications WHERE notifications.account_id = $1 AND notifications.group_key = groups.group_key AND id <= $4 ORDER BY id DESC LIMIT 1),
-            array(SELECT from_account_id FROM notifications WHERE notifications.account_id = $1 AND notifications.group_key = groups.group_key AND id <= $4 ORDER BY id DESC LIMIT $2),
-            (SELECT count(*) FROM notifications WHERE notifications.account_id = $1 AND notifications.group_key = groups.group_key AND id <= $4) AS notifications_count,
-            (SELECT id FROM notifications WHERE notifications.account_id = $1 AND notifications.group_key = groups.group_key AND id >= $3 ORDER BY id ASC LIMIT 1) AS min_id,
-            (SELECT created_at FROM notifications WHERE notifications.account_id = $1 AND notifications.group_key = groups.group_key AND id <= $4 ORDER BY id DESC LIMIT 1)
+            (SELECT id FROM notifications WHERE notifications.account_id = $1 AND notifications.group_key = groups.group_key #{upper_bound_cond} ORDER BY id DESC LIMIT 1),
+            array(SELECT from_account_id FROM notifications WHERE notifications.account_id = $1 AND notifications.group_key = groups.group_key #{upper_bound_cond} ORDER BY id DESC LIMIT $2),
+            (SELECT count(*) FROM notifications WHERE notifications.account_id = $1 AND notifications.group_key = groups.group_key #{upper_bound_cond}) AS notifications_count,
+            (SELECT id FROM notifications WHERE notifications.account_id = $1 AND notifications.group_key = groups.group_key AND id >= $4 ORDER BY id ASC LIMIT 1) AS min_id,
+            (SELECT created_at FROM notifications WHERE notifications.account_id = $1 AND notifications.group_key = groups.group_key #{upper_bound_cond} ORDER BY id DESC LIMIT 1)
           FROM
-            unnest($5::text[]) AS groups(group_key);
+            unnest($3::text[]) AS groups(group_key);
         SQL
       else
         binds = [


### PR DESCRIPTION
Notification group details get filled with the range of fetched notifications, inclusive of first and last notifications of a group within a page.

However, when reaching the last page, this means a single notification is taken into account, even if the group contains more notification.

This PR changes it so that upon reaching the last page (fewer groups than expected are returned), the corresponding bound is ignored, and all notifications of the group in the paging direction are taken into account when backfilling the group information.

The code for this is a lot more awkward than I would like, in part due to not being able to use ActiveRecord scopes here.