### PR TITLE
Disable `Naming/VariableNumber` cop in old migrations

### DIFF
--- a/db/migrate/.rubocop.yml
+++ b/db/migrate/.rubocop.yml
@@ -1,8 +1,5 @@
 inherit_from: ../../.rubocop.yml
 
-Naming/VariableNumber:
-  CheckSymbols: false
-
 # Below are all enabled as workaround for https://docs.rubocop.org/rubocop/configuration.html#path-relativity
 # TODO: Delete this file and move above config to base naming config
 

--- a/db/migrate/20180106000232_add_index_on_statuses_for_api_v1_accounts_account_id_statuses.rb
+++ b/db/migrate/20180106000232_add_index_on_statuses_for_api_v1_accounts_account_id_statuses.rb
@@ -5,7 +5,7 @@ class AddIndexOnStatusesForApiV1AccountsAccountIdStatuses < ActiveRecord::Migrat
 
   def change
     safety_assured do
-      add_index :statuses, [:account_id, :id, :visibility, :updated_at], order: { id: :desc }, algorithm: :concurrently, name: :index_statuses_20180106
+      add_index :statuses, [:account_id, :id, :visibility, :updated_at], order: { id: :desc }, algorithm: :concurrently, name: :index_statuses_20180106 # rubocop:disable Naming/VariableNumber
     end
     remove_index :statuses, [:account_id, :id], name: :index_statuses_on_account_id_id
   end

--- a/db/migrate/20180514140000_revert_index_change_on_statuses_for_api_v1_accounts_account_id_statuses.rb
+++ b/db/migrate/20180514140000_revert_index_change_on_statuses_for_api_v1_accounts_account_id_statuses.rb
@@ -5,7 +5,7 @@ class RevertIndexChangeOnStatusesForApiV1AccountsAccountIdStatuses < ActiveRecor
 
   def change
     safety_assured do
-      add_index :statuses, [:account_id, :id, :visibility, :updated_at], order: { id: :desc }, algorithm: :concurrently, name: :index_statuses_20180106 unless index_name_exists?(:statuses, 'index_statuses_20180106')
+      add_index :statuses, [:account_id, :id, :visibility, :updated_at], order: { id: :desc }, algorithm: :concurrently, name: :index_statuses_20180106 unless index_name_exists?(:statuses, 'index_statuses_20180106') # rubocop:disable Naming/VariableNumber
     end
 
     # These index may not exists (see migration 20180514130000)

--- a/db/migrate/20190820003045_update_statuses_index.rb
+++ b/db/migrate/20190820003045_update_statuses_index.rb
@@ -4,12 +4,12 @@ class UpdateStatusesIndex < ActiveRecord::Migration[5.2]
   disable_ddl_transaction!
 
   def up
-    safety_assured { add_index :statuses, [:account_id, :id, :visibility, :updated_at], where: 'deleted_at IS NULL', order: { id: :desc }, algorithm: :concurrently, name: :index_statuses_20190820 }
-    remove_index :statuses, name: :index_statuses_20180106
+    safety_assured { add_index :statuses, [:account_id, :id, :visibility, :updated_at], where: 'deleted_at IS NULL', order: { id: :desc }, algorithm: :concurrently, name: :index_statuses_20190820 } # rubocop:disable Naming/VariableNumber
+    remove_index :statuses, name: :index_statuses_20180106 # rubocop:disable Naming/VariableNumber
   end
 
   def down
-    safety_assured { add_index :statuses, [:account_id, :id, :visibility, :updated_at], order: { id: :desc }, algorithm: :concurrently, name: :index_statuses_20180106 }
-    remove_index :statuses, name: :index_statuses_20190820
+    safety_assured { add_index :statuses, [:account_id, :id, :visibility, :updated_at], order: { id: :desc }, algorithm: :concurrently, name: :index_statuses_20180106 } # rubocop:disable Naming/VariableNumber
+    remove_index :statuses, name: :index_statuses_20190820 # rubocop:disable Naming/VariableNumber
   end
 end

--- a/db/migrate/20190823221802_add_local_index_to_statuses.rb
+++ b/db/migrate/20190823221802_add_local_index_to_statuses.rb
@@ -4,10 +4,10 @@ class AddLocalIndexToStatuses < ActiveRecord::Migration[5.2]
   disable_ddl_transaction!
 
   def up
-    add_index :statuses, [:id, :account_id], name: :index_statuses_local_20190824, algorithm: :concurrently, order: { id: :desc }, where: '(local OR (uri IS NULL)) AND deleted_at IS NULL AND visibility = 0 AND reblog_of_id IS NULL AND ((NOT reply) OR (in_reply_to_account_id = account_id))'
+    add_index :statuses, [:id, :account_id], name: :index_statuses_local_20190824, algorithm: :concurrently, order: { id: :desc }, where: '(local OR (uri IS NULL)) AND deleted_at IS NULL AND visibility = 0 AND reblog_of_id IS NULL AND ((NOT reply) OR (in_reply_to_account_id = account_id))' # rubocop:disable Naming/VariableNumber
   end
 
   def down
-    remove_index :statuses, name: :index_statuses_local_20190824
+    remove_index :statuses, name: :index_statuses_local_20190824 # rubocop:disable Naming/VariableNumber
   end
 end

--- a/db/migrate/20200119112504_add_public_index_to_statuses.rb
+++ b/db/migrate/20200119112504_add_public_index_to_statuses.rb
@@ -4,10 +4,10 @@ class AddPublicIndexToStatuses < ActiveRecord::Migration[5.2]
   disable_ddl_transaction!
 
   def up
-    add_index :statuses, [:id, :account_id], name: :index_statuses_public_20200119, algorithm: :concurrently, order: { id: :desc }, where: 'deleted_at IS NULL AND visibility = 0 AND reblog_of_id IS NULL AND ((NOT reply) OR (in_reply_to_account_id = account_id))'
+    add_index :statuses, [:id, :account_id], name: :index_statuses_public_20200119, algorithm: :concurrently, order: { id: :desc }, where: 'deleted_at IS NULL AND visibility = 0 AND reblog_of_id IS NULL AND ((NOT reply) OR (in_reply_to_account_id = account_id))' # rubocop:disable Naming/VariableNumber
   end
 
   def down
-    remove_index :statuses, name: :index_statuses_public_20200119
+    remove_index :statuses, name: :index_statuses_public_20200119 # rubocop:disable Naming/VariableNumber
   end
 end


### PR DESCRIPTION
Final prep for https://github.com/mastodon/mastodon/pull/33256

