### PR TITLE
Fix long account username leaving container

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1960,6 +1960,8 @@ body > [data-popper-placement] {
         }
 
         &__handle {
+          overflow: hidden;
+          text-overflow: ellipsis;
           user-select: all;
         }
       }
@@ -7923,6 +7925,8 @@ noscript {
           text-overflow: ellipsis;
 
           span {
+            overflow: hidden;
+            text-overflow: ellipsis;
             user-select: all;
           }
 


### PR DESCRIPTION
Reformulation of https://github.com/mastodon/mastodon/pull/32779 which appears abandoned. Incorporates the suggested changes. Fixes both the popup box wrap, and the lack of ability to even see the domain in initial view.

Before:

<img width="622" alt="Screenshot 2024-12-12 at 13 00 01" src="https://github.com/user-attachments/assets/60042fb3-2fc5-491f-a670-d9dd0b678085" />

After:

<img width="628" alt="Screenshot 2024-12-12 at 12 55 35" src="https://github.com/user-attachments/assets/b704ea5a-cca8-4838-a65b-eca7d05a56da" />

Before:

<img width="769" alt="Screenshot 2024-12-12 at 13 00 32" src="https://github.com/user-attachments/assets/d2acbee2-fee7-4c48-af1c-d0b8a0a2b2f4" />

After:

<img width="383" alt="Screenshot 2024-12-12 at 12 55 43" src="https://github.com/user-attachments/assets/72a45e3f-78dd-422f-a83c-b8f3bb969f65" />


Good followup here might be to put the username and domain portions in the popup into separate spans so that we could truncate (or other responsive approach) that so you always see the domain? For now just doing broken-ness fix.