### PR TITLE
Add `NOT NULL` requirement to columns on `account_conversations`

### DIFF
--- a/app/models/account_conversation.rb
+++ b/app/models/account_conversation.rb
@@ -5,13 +5,13 @@
 # Table name: account_conversations
 #
 #  id                      :bigint(8)        not null, primary key
-#  account_id              :bigint(8)
-#  conversation_id         :bigint(8)
+#  lock_version            :integer          default(0), not null
 #  participant_account_ids :bigint(8)        default([]), not null, is an Array
 #  status_ids              :bigint(8)        default([]), not null, is an Array
-#  last_status_id          :bigint(8)
-#  lock_version            :integer          default(0), not null
 #  unread                  :boolean          default(FALSE), not null
+#  account_id              :bigint(8)        not null
+#  conversation_id         :bigint(8)        not null
+#  last_status_id          :bigint(8)
 #
 
 class AccountConversation < ApplicationRecord

--- a/db/migrate/20241213170027_add_not_null_to_account_conversation_account_column.rb
+++ b/db/migrate/20241213170027_add_not_null_to_account_conversation_account_column.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddNotNullToAccountConversationAccountColumn < ActiveRecord::Migration[7.2]
+  def change
+    add_check_constraint :account_conversations, 'account_id IS NOT NULL', name: 'account_conversations_account_id_null', validate: false
+  end
+end

--- a/db/migrate/20241213170036_validate_not_null_to_account_conversation_account_column.rb
+++ b/db/migrate/20241213170036_validate_not_null_to_account_conversation_account_column.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class ValidateNotNullToAccountConversationAccountColumn < ActiveRecord::Migration[7.2]
+  def up
+    connection.execute(<<~SQL.squish)
+      DELETE FROM account_conversations
+      WHERE account_id IS NULL
+    SQL
+
+    validate_check_constraint :account_conversations, name: 'account_conversations_account_id_null'
+    change_column_null :account_conversations, :account_id, false
+    remove_check_constraint :account_conversations, name: 'account_conversations_account_id_null'
+  end
+
+  def down
+    add_check_constraint :account_conversations, 'account_id IS NOT NULL', name: 'account_conversations_account_id_null', validate: false
+    change_column_null :account_conversations, :account_id, true
+  end
+end

--- a/db/migrate/20241213170043_add_not_null_to_account_conversation_conversation_column.rb
+++ b/db/migrate/20241213170043_add_not_null_to_account_conversation_conversation_column.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddNotNullToAccountConversationConversationColumn < ActiveRecord::Migration[7.2]
+  def change
+    add_check_constraint :account_conversations, 'conversation_id IS NOT NULL', name: 'account_conversations_conversation_id_null', validate: false
+  end
+end

--- a/db/migrate/20241213170053_validate_not_null_to_account_conversation_conversation_column.rb
+++ b/db/migrate/20241213170053_validate_not_null_to_account_conversation_conversation_column.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class ValidateNotNullToAccountConversationConversationColumn < ActiveRecord::Migration[7.2]
+  def up
+    connection.execute(<<~SQL.squish)
+      DELETE FROM account_conversations
+      WHERE conversation_id IS NULL
+    SQL
+
+    validate_check_constraint :account_conversations, name: 'account_conversations_conversation_id_null'
+    change_column_null :account_conversations, :conversation_id, false
+    remove_check_constraint :account_conversations, name: 'account_conversations_conversation_id_null'
+  end
+
+  def down
+    add_check_constraint :account_conversations, 'conversation_id IS NOT NULL', name: 'account_conversations_conversation_id_null', validate: false
+    change_column_null :account_conversations, :conversation_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_12_154346) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_13_170053) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -24,8 +24,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_12_154346) do
   end
 
   create_table "account_conversations", force: :cascade do |t|
-    t.bigint "account_id"
-    t.bigint "conversation_id"
+    t.bigint "account_id", null: false
+    t.bigint "conversation_id", null: false
     t.bigint "participant_account_ids", default: [], null: false, array: true
     t.bigint "status_ids", default: [], null: false, array: true
     t.bigint "last_status_id"


### PR DESCRIPTION
In https://github.com/mastodon/mastodon/pull/33284 we did all of the smaller tables with valid indexes and good data.

This is the first of the larger tables with good data and good indexes.

Opening this with just one table to start with, to just double-check the approach. Once we're good on that I can add the next ~4 (large tables w/ good data) either onto this PR or in subsequent ... wanted to avoid doing too much before we're good on style.

For both of account_id and conversation_id on account_conversations ...

- Initial migration which adds the check constraint but does not validate it
- Second migration which deletes any bad data (we believe there should be none, but out of caution), validates the constraint, changes the column null, drops the constraint

Basically boilerplate from the strong migrations suggestion on how to stage the changing column null.

In addition to any logic/style changes, let me know if you'd prefer ~10 more migrations added to this PR, or to do one-PR-per-table for the "large table" ones.