### PR TITLE
Fix Style/MultipleComparison

### DIFF
--- a/.rubocop/style.yml
+++ b/.rubocop/style.yml
@@ -29,9 +29,6 @@ Style/IfUnlessModifier:
 Style/KeywordArgumentsMerging:
   Enabled: false
 
-Style/MultipleComparison:
-  Enabled: false
-
 Style/NumericLiterals:
   AllowedPatterns:
     - \d{4}_\d{2}_\d{2}_\d{6}

--- a/app/lib/activitypub/tag_manager.rb
+++ b/app/lib/activitypub/tag_manager.rb
@@ -13,7 +13,7 @@ class ActivityPub::TagManager
   }.freeze
 
   def public_collection?(uri)
-    uri == COLLECTIONS[:public] || uri == 'as:Public' || uri == 'Public'
+    uri == COLLECTIONS[:public] || ['as:Public', 'Public'].include?(uri)
   end
 
   def url_for(target)

--- a/app/lib/activitypub/tag_manager.rb
+++ b/app/lib/activitypub/tag_manager.rb
@@ -13,7 +13,7 @@ class ActivityPub::TagManager
   }.freeze
 
   def public_collection?(uri)
-    uri == COLLECTIONS[:public] || ['as:Public', 'Public'].include?(uri)
+    uri == COLLECTIONS[:public] || %w(as:Public Public).include?(uri)
   end
 
   def url_for(target)


### PR DESCRIPTION
Rule was disabled in the Rubocop update for a bad autocorrect. That bug that @mjankowski reported upstream got fixed in 1.69.2 in https://github.com/mastodon/mastodon/pull/33283