### PR TITLE
Fix clicking on a profile mention while logged out potentially leading to incorrect account

### DIFF
--- a/app/javascript/mastodon/actions/search.ts
+++ b/app/javascript/mastodon/actions/search.ts
@@ -79,15 +79,12 @@ export const expandSearch = createDataLoadingThunk(
 
 export const openURL = createDataLoadingThunk(
   'search/openURL',
-  ({ url }: { url: string }, { getState }) => {
-    const signedIn = !!getState().meta.get('me');
-
-    return apiGetSearch({
+  ({ url }: { url: string }) =>
+    apiGetSearch({
       q: url,
-      resolve: signedIn,
+      resolve: true,
       limit: 1,
-    });
-  },
+    }),
   (data, { dispatch }) => {
     if (data.accounts.length > 0) {
       dispatch(importFetchedAccounts(data.accounts));


### PR DESCRIPTION
For the purposes of OpenURL we explicitly want to resolve the URL or fail, not search for something that contains the URL.