### PR TITLE
Add API datetime/format matcher for serialization specs, reduce factories

### DIFF
--- a/spec/serializers/rest/account_relationship_severance_event_serializer_spec.rb
+++ b/spec/serializers/rest/account_relationship_severance_event_serializer_spec.rb
@@ -11,14 +11,9 @@ RSpec.describe REST::AccountRelationshipSeveranceEventSerializer do
     it 'returns expected values' do
       expect(subject)
         .to include(
-          'id' => be_a(String).and(eq('123'))
+          'id' => be_a(String).and(eq('123')),
+          'created_at' => match_api_datetime_format
         )
-    end
-  end
-
-  context 'when created_at is populated' do
-    it 'parses as RFC 3339 datetime' do
-      expect { DateTime.rfc3339(subject['created_at']) }.to_not raise_error
     end
   end
 end

--- a/spec/serializers/rest/account_serializer/field_serializer_spec.rb
+++ b/spec/serializers/rest/account_serializer/field_serializer_spec.rb
@@ -6,8 +6,7 @@ RSpec.describe REST::AccountSerializer::FieldSerializer do
   subject { serialized_record_json(field, described_class) }
 
   let(:default_datetime) { DateTime.new(2024, 11, 28, 16, 20, 0) }
-  let(:user)    { Fabricate(:user) }
-  let(:account) { user.account }
+  let(:account) { Fabricate.build :account }
 
   context 'when verified_at is populated' do
     let(:field) { Account::Field.new(account, 'name' => 'Foo', 'value' => 'Bar', 'verified_at' => default_datetime) }

--- a/spec/serializers/rest/account_serializer/field_serializer_spec.rb
+++ b/spec/serializers/rest/account_serializer/field_serializer_spec.rb
@@ -13,7 +13,10 @@ RSpec.describe REST::AccountSerializer::FieldSerializer do
     let(:field) { Account::Field.new(account, 'name' => 'Foo', 'value' => 'Bar', 'verified_at' => default_datetime) }
 
     it 'parses as RFC 3339 datetime' do
-      expect { DateTime.rfc3339(subject['verified_at']) }.to_not raise_error
+      expect(subject)
+        .to include(
+          'verified_at' => match_api_datetime_format
+        )
     end
   end
 end

--- a/spec/serializers/rest/account_serializer_spec.rb
+++ b/spec/serializers/rest/account_serializer_spec.rb
@@ -52,7 +52,10 @@ RSpec.describe REST::AccountSerializer do
     end
 
     it 'parses as RFC 3339 datetime' do
-      expect { DateTime.rfc3339(subject['created_at']) }.to_not raise_error
+      expect(subject)
+        .to include(
+          'created_at' => match_api_datetime_format
+        )
     end
   end
 

--- a/spec/serializers/rest/account_warning_serializer_spec.rb
+++ b/spec/serializers/rest/account_warning_serializer_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe REST::AccountWarningSerializer do
       expect(subject)
         .to include(
           'id' => be_a(String).and(eq('123')),
-          'status_ids' => be_a(Array).and(eq(['456', '789']))
+          'status_ids' => be_a(Array).and(eq(['456', '789'])),
+          'created_at' => match_api_datetime_format
         )
-      expect { DateTime.rfc3339(subject['created_at']) }.to_not raise_error
     end
   end
 end

--- a/spec/serializers/rest/admin/account_serializer_spec.rb
+++ b/spec/serializers/rest/admin/account_serializer_spec.rb
@@ -9,7 +9,10 @@ RSpec.describe REST::Admin::AccountSerializer do
     let(:record) { Fabricate :account, user: Fabricate(:user) }
 
     it 'parses as RFC 3339 datetime' do
-      expect { DateTime.rfc3339(subject['created_at']) }.to_not raise_error
+      expect(subject)
+        .to include(
+          'created_at' => match_api_datetime_format
+        )
     end
   end
 

--- a/spec/serializers/rest/admin/cohort_serializer_spec.rb
+++ b/spec/serializers/rest/admin/cohort_serializer_spec.rb
@@ -11,11 +11,11 @@ RSpec.describe REST::Admin::CohortSerializer do
     it 'returns expected values' do
       expect(subject)
         .to include(
-          'data' => be_a(Array),
-          'period' => /2024-01-01/
+          'data' => be_a(Array).and(
+            all(include('date' => match_api_datetime_format))
+          ),
+          'period' => match(/2024-01-01/).and(match_api_datetime_format)
         )
-      expect { DateTime.rfc3339(subject['period']) }.to_not raise_error
-      subject['data'].each { |datum| expect { DateTime.rfc3339(datum['date']) }.to_not raise_error }
     end
   end
 end

--- a/spec/serializers/rest/admin/domain_allow_serializer_spec.rb
+++ b/spec/serializers/rest/admin/domain_allow_serializer_spec.rb
@@ -9,7 +9,10 @@ RSpec.describe REST::Admin::DomainAllowSerializer do
 
   context 'when created_at is populated' do
     it 'parses as RFC 3339 datetime' do
-      expect { DateTime.rfc3339(subject['created_at']) }.to_not raise_error
+      expect(subject)
+        .to include(
+          'created_at' => match_api_datetime_format
+        )
     end
   end
 end

--- a/spec/serializers/rest/admin/domain_block_serializer_spec.rb
+++ b/spec/serializers/rest/admin/domain_block_serializer_spec.rb
@@ -9,7 +9,10 @@ RSpec.describe REST::Admin::DomainBlockSerializer do
 
   context 'when created_at is populated' do
     it 'parses as RFC 3339 datetime' do
-      expect { DateTime.rfc3339(subject['created_at']) }.to_not raise_error
+      expect(subject)
+        .to include(
+          'created_at' => match_api_datetime_format
+        )
     end
   end
 end

--- a/spec/serializers/rest/admin/email_domain_block_serializer_spec.rb
+++ b/spec/serializers/rest/admin/email_domain_block_serializer_spec.rb
@@ -9,7 +9,10 @@ RSpec.describe REST::Admin::EmailDomainBlockSerializer do
 
   context 'when created_at is populated' do
     it 'parses as RFC 3339 datetime' do
-      expect { DateTime.rfc3339(subject['created_at']) }.to_not raise_error
+      expect(subject)
+        .to include(
+          'created_at' => match_api_datetime_format
+        )
     end
   end
 end

--- a/spec/serializers/rest/admin/ip_block_serializer_spec.rb
+++ b/spec/serializers/rest/admin/ip_block_serializer_spec.rb
@@ -5,23 +5,13 @@ require 'rails_helper'
 RSpec.describe REST::Admin::IpBlockSerializer do
   subject { serialized_record_json(record, described_class) }
 
-  let(:record) { Fabricate(:ip_block) }
-
-  context 'when created_at is populated' do
-    it 'parses as RFC 3339 datetime' do
-      expect(subject)
-        .to include(
-          'created_at' => match_api_datetime_format
-        )
-    end
-  end
-
-  context 'when expires_at is populated' do
+  context 'when timestamps are populated' do
     let(:record) { Fabricate(:ip_block, expires_at: DateTime.new(2024, 11, 28, 16, 20, 0)) }
 
     it 'parses as RFC 3339 datetime' do
       expect(subject)
         .to include(
+          'created_at' => match_api_datetime_format,
           'expires_at' => match_api_datetime_format
         )
     end

--- a/spec/serializers/rest/admin/ip_block_serializer_spec.rb
+++ b/spec/serializers/rest/admin/ip_block_serializer_spec.rb
@@ -9,7 +9,10 @@ RSpec.describe REST::Admin::IpBlockSerializer do
 
   context 'when created_at is populated' do
     it 'parses as RFC 3339 datetime' do
-      expect { DateTime.rfc3339(subject['created_at']) }.to_not raise_error
+      expect(subject)
+        .to include(
+          'created_at' => match_api_datetime_format
+        )
     end
   end
 
@@ -17,7 +20,10 @@ RSpec.describe REST::Admin::IpBlockSerializer do
     let(:record) { Fabricate(:ip_block, expires_at: DateTime.new(2024, 11, 28, 16, 20, 0)) }
 
     it 'parses as RFC 3339 datetime' do
-      expect { DateTime.rfc3339(subject['expires_at']) }.to_not raise_error
+      expect(subject)
+        .to include(
+          'expires_at' => match_api_datetime_format
+        )
     end
   end
 end

--- a/spec/serializers/rest/admin/ip_serializer_spec.rb
+++ b/spec/serializers/rest/admin/ip_serializer_spec.rb
@@ -9,7 +9,10 @@ RSpec.describe REST::Admin::IpSerializer do
 
   context 'when used_at is populated' do
     it 'parses as RFC 3339 datetime' do
-      expect { DateTime.rfc3339(subject['used_at']) }.to_not raise_error
+      expect(subject)
+        .to include(
+          'used_at' => match_api_datetime_format
+        )
     end
   end
 end

--- a/spec/serializers/rest/admin/measure_serializer_spec.rb
+++ b/spec/serializers/rest/admin/measure_serializer_spec.rb
@@ -12,7 +12,12 @@ RSpec.describe REST::Admin::MeasureSerializer do
 
   context 'when start_at is populated' do
     it 'parses as RFC 3339 datetime' do
-      subject['data'].each { |datum| expect { DateTime.rfc3339(datum['date']) }.to_not raise_error }
+      expect(subject)
+        .to include(
+          'data' => all(
+            include('date' => match_api_datetime_format)
+          )
+        )
     end
   end
 end

--- a/spec/serializers/rest/admin/report_serializer_spec.rb
+++ b/spec/serializers/rest/admin/report_serializer_spec.rb
@@ -5,28 +5,14 @@ require 'rails_helper'
 RSpec.describe REST::Admin::ReportSerializer do
   subject { serialized_record_json(report, described_class) }
 
-  let(:report) { Fabricate(:report) }
+  context 'with timestamps' do
+    let(:report) { Fabricate(:report, action_taken_at: 3.days.ago) }
 
-  context 'with created_at' do
     it 'is serialized as RFC 3339 datetime' do
       expect(subject)
         .to include(
+          'action_taken_at' => match_api_datetime_format,
           'created_at' => match_api_datetime_format
-        )
-    end
-  end
-
-  context 'with action_taken_at' do
-    let(:acting_account) { Fabricate(:account) }
-
-    before do
-      report.resolve!(acting_account)
-    end
-
-    it 'is serialized as RFC 3339 datetime' do
-      expect(subject)
-        .to include(
-          'action_taken_at' => match_api_datetime_format
         )
     end
   end

--- a/spec/serializers/rest/admin/report_serializer_spec.rb
+++ b/spec/serializers/rest/admin/report_serializer_spec.rb
@@ -9,7 +9,10 @@ RSpec.describe REST::Admin::ReportSerializer do
 
   context 'with created_at' do
     it 'is serialized as RFC 3339 datetime' do
-      expect { DateTime.rfc3339(subject['created_at']) }.to_not raise_error
+      expect(subject)
+        .to include(
+          'created_at' => match_api_datetime_format
+        )
     end
   end
 
@@ -21,7 +24,10 @@ RSpec.describe REST::Admin::ReportSerializer do
     end
 
     it 'is serialized as RFC 3339 datetime' do
-      expect { DateTime.rfc3339(subject['action_taken_at']) }.to_not raise_error
+      expect(subject)
+        .to include(
+          'action_taken_at' => match_api_datetime_format
+        )
     end
   end
 end

--- a/spec/serializers/rest/announcement_serializer_spec.rb
+++ b/spec/serializers/rest/announcement_serializer_spec.rb
@@ -19,10 +19,13 @@ RSpec.describe REST::AnnouncementSerializer do
 
   context 'when date fields are populated' do
     it 'parses as RFC 3339 datetime' do
-      expect { DateTime.rfc3339(subject['starts_at']) }.to_not raise_error
-      expect { DateTime.rfc3339(subject['ends_at']) }.to_not raise_error
-      expect { DateTime.rfc3339(subject['published_at']) }.to_not raise_error
-      expect { DateTime.rfc3339(subject['updated_at']) }.to_not raise_error
+      expect(subject)
+        .to include(
+          'starts_at' => match_api_datetime_format,
+          'ends_at' => match_api_datetime_format,
+          'published_at' => match_api_datetime_format,
+          'updated_at' => match_api_datetime_format
+        )
     end
   end
 end

--- a/spec/serializers/rest/filter_serializer_spec.rb
+++ b/spec/serializers/rest/filter_serializer_spec.rb
@@ -14,7 +14,10 @@ RSpec.describe REST::FilterSerializer do
 
   context 'when expires_at is populated' do
     it 'parses as RFC 3339 datetime' do
-      expect { DateTime.rfc3339(subject['expires_at']) }.to_not raise_error
+      expect(subject)
+        .to include(
+          'expires_at' => match_api_datetime_format
+        )
     end
   end
 end

--- a/spec/serializers/rest/filter_serializer_spec.rb
+++ b/spec/serializers/rest/filter_serializer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe REST::FilterSerializer do
     )
   end
 
-  let(:filter) { Fabricate :custom_filter, expires_at: DateTime.new(2024, 11, 28, 16, 20, 0) }
+  let(:filter) { Fabricate.build :custom_filter, expires_at: DateTime.new(2024, 11, 28, 16, 20, 0) }
 
   context 'when expires_at is populated' do
     it 'parses as RFC 3339 datetime' do

--- a/spec/serializers/rest/marker_serializer_spec.rb
+++ b/spec/serializers/rest/marker_serializer_spec.rb
@@ -14,7 +14,10 @@ RSpec.describe REST::MarkerSerializer do
 
   context 'when updated_at is populated' do
     it 'parses as RFC 3339 datetime' do
-      expect { DateTime.rfc3339(subject['updated_at']) }.to_not raise_error
+      expect(subject)
+        .to include(
+          'updated_at' => match_api_datetime_format
+        )
     end
   end
 end

--- a/spec/serializers/rest/muted_account_serializer_spec.rb
+++ b/spec/serializers/rest/muted_account_serializer_spec.rb
@@ -25,7 +25,10 @@ RSpec.describe REST::MutedAccountSerializer do
     end
 
     it 'parses as RFC 3339 datetime' do
-      expect { DateTime.rfc3339(subject['mute_expires_at']) }.to_not raise_error
+      expect(subject)
+        .to include(
+          'mute_expires_at' => match_api_datetime_format
+        )
     end
   end
 

--- a/spec/serializers/rest/notification_group_serializer_spec.rb
+++ b/spec/serializers/rest/notification_group_serializer_spec.rb
@@ -14,7 +14,10 @@ RSpec.describe REST::NotificationGroupSerializer do
 
   context 'when latest_page_notification_at is populated' do
     it 'parses as RFC 3339 datetime' do
-      expect { DateTime.rfc3339(subject['latest_page_notification_at']) }.to_not raise_error
+      expect(subject)
+        .to include(
+          'latest_page_notification_at' => match_api_datetime_format
+        )
     end
   end
 end

--- a/spec/serializers/rest/notification_request_serializer_spec.rb
+++ b/spec/serializers/rest/notification_request_serializer_spec.rb
@@ -17,15 +17,13 @@ RSpec.describe REST::NotificationRequestSerializer do
   let(:current_user) { Fabricate(:user) }
   let(:notification_request) { Fabricate :notification_request }
 
-  context 'when created_at is populated' do
+  context 'when timestampts are populated' do
     it 'parses as RFC 3339 datetime' do
-      expect { DateTime.rfc3339(subject['created_at']) }.to_not raise_error
-    end
-  end
-
-  context 'when updated_at is populated' do
-    it 'parses as RFC 3339 datetime' do
-      expect { DateTime.rfc3339(subject['updated_at']) }.to_not raise_error
+      expect(subject)
+        .to include(
+          'created_at' => match_api_datetime_format,
+          'updated_at' => match_api_datetime_format
+        )
     end
   end
 end

--- a/spec/serializers/rest/notification_serializer_spec.rb
+++ b/spec/serializers/rest/notification_serializer_spec.rb
@@ -14,7 +14,10 @@ RSpec.describe REST::NotificationSerializer do
 
   context 'when created_at is populated' do
     it 'parses as RFC 3339 datetime' do
-      expect { DateTime.rfc3339(subject['created_at']) }.to_not raise_error
+      expect(subject)
+        .to include(
+          'created_at' => match_api_datetime_format
+        )
     end
   end
 end

--- a/spec/serializers/rest/poll_serializer_spec.rb
+++ b/spec/serializers/rest/poll_serializer_spec.rb
@@ -19,7 +19,10 @@ RSpec.describe REST::PollSerializer do
 
   context 'when expires_at is populated' do
     it 'parses as RFC 3339 datetime' do
-      expect { DateTime.rfc3339(subject['expires_at']) }.to_not raise_error
+      expect(subject)
+        .to include(
+          'expires_at' => match_api_datetime_format
+        )
     end
   end
 end

--- a/spec/serializers/rest/poll_serializer_spec.rb
+++ b/spec/serializers/rest/poll_serializer_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe REST::PollSerializer do
   end
 
   let(:current_user) { Fabricate(:user) }
-  let(:poll) { Fabricate :poll }
+  let(:poll) { Fabricate.build :poll, expires_at: 5.days.from_now }
 
   context 'when expires_at is populated' do
     it 'parses as RFC 3339 datetime' do

--- a/spec/serializers/rest/report_serializer_spec.rb
+++ b/spec/serializers/rest/report_serializer_spec.rb
@@ -15,7 +15,10 @@ RSpec.describe REST::ReportSerializer do
 
   context 'with created_at' do
     it 'is serialized as RFC 3339 datetime' do
-      expect { DateTime.rfc3339(subject['created_at']) }.to_not raise_error
+      expect(subject)
+        .to include(
+          'created_at' => match_api_datetime_format
+        )
     end
   end
 
@@ -27,7 +30,10 @@ RSpec.describe REST::ReportSerializer do
     end
 
     it 'is serialized as RFC 3339 datetime' do
-      expect { DateTime.rfc3339(subject['action_taken_at']) }.to_not raise_error
+      expect(subject)
+        .to include(
+          'action_taken_at' => match_api_datetime_format
+        )
     end
   end
 end

--- a/spec/serializers/rest/report_serializer_spec.rb
+++ b/spec/serializers/rest/report_serializer_spec.rb
@@ -10,28 +10,13 @@ RSpec.describe REST::ReportSerializer do
     )
   end
 
-  let(:status) { Fabricate(:status) }
-  let(:report) { Fabricate(:report, status_ids: [status.id]) }
-
-  context 'with created_at' do
-    it 'is serialized as RFC 3339 datetime' do
-      expect(subject)
-        .to include(
-          'created_at' => match_api_datetime_format
-        )
-    end
-  end
-
-  context 'with action_taken_at' do
-    let(:acting_account) { Fabricate(:account) }
-
-    before do
-      report.resolve!(acting_account)
-    end
+  context 'with timestamps' do
+    let(:report) { Fabricate(:report, action_taken_at: 3.days.ago) }
 
     it 'is serialized as RFC 3339 datetime' do
       expect(subject)
         .to include(
+          'created_at' => match_api_datetime_format,
           'action_taken_at' => match_api_datetime_format
         )
     end

--- a/spec/serializers/rest/scheduled_status_serializer_spec.rb
+++ b/spec/serializers/rest/scheduled_status_serializer_spec.rb
@@ -14,15 +14,12 @@ RSpec.describe REST::ScheduledStatusSerializer do
   let(:scheduled_status) { Fabricate.build(:scheduled_status, scheduled_at: 4.minutes.from_now, account: account, params: { application_id: 123 }) }
 
   describe 'serialization' do
-    it 'is serialized as RFC 3339 datetime' do
-      expect { DateTime.rfc3339(subject['scheduled_at']) }
-        .to_not raise_error
-    end
-
     it 'returns expected values and removes application_id from params' do
       expect(subject.deep_symbolize_keys)
-        .to include(scheduled_at: be_a(String))
-        .and include(params: not_include(:application_id))
+        .to include(
+          scheduled_at: be_a(String).and(match_api_datetime_format),
+          params: not_include(:application_id)
+        )
     end
   end
 end

--- a/spec/serializers/rest/scheduled_status_serializer_spec.rb
+++ b/spec/serializers/rest/scheduled_status_serializer_spec.rb
@@ -10,8 +10,7 @@ RSpec.describe REST::ScheduledStatusSerializer do
     )
   end
 
-  let(:account) { Fabricate(:account) }
-  let(:scheduled_status) { Fabricate.build(:scheduled_status, scheduled_at: 4.minutes.from_now, account: account, params: { application_id: 123 }) }
+  let(:scheduled_status) { Fabricate.build(:scheduled_status, scheduled_at: 4.minutes.from_now, params: { application_id: 123 }) }
 
   describe 'serialization' do
     it 'returns expected values and removes application_id from params' do

--- a/spec/serializers/rest/status_edit_serializer_spec.rb
+++ b/spec/serializers/rest/status_edit_serializer_spec.rb
@@ -14,7 +14,10 @@ RSpec.describe REST::StatusEditSerializer do
 
   context 'when created_at is populated' do
     it 'parses as RFC 3339 datetime' do
-      expect { DateTime.rfc3339(subject['created_at']) }.to_not raise_error
+      expect(subject)
+        .to include(
+          'created_at' => match_api_datetime_format
+        )
     end
   end
 end

--- a/spec/serializers/rest/status_serializer_spec.rb
+++ b/spec/serializers/rest/status_serializer_spec.rb
@@ -54,7 +54,10 @@ RSpec.describe REST::StatusSerializer do
 
     context 'with created_at' do
       it 'is serialized as RFC 3339 datetime' do
-        expect { DateTime.rfc3339(subject['created_at']) }.to_not raise_error
+        expect(subject)
+          .to include(
+            'created_at' => match_api_datetime_format
+          )
       end
     end
 
@@ -62,7 +65,10 @@ RSpec.describe REST::StatusSerializer do
       let(:status) { Fabricate.build :status, edited_at: 3.days.ago }
 
       it 'is serialized as RFC 3339 datetime' do
-        expect { DateTime.rfc3339(subject['edited_at']) }.to_not raise_error
+        expect(subject)
+          .to include(
+            'edited_at' => match_api_datetime_format
+          )
       end
     end
   end

--- a/spec/support/matchers/api_datetime_format.rb
+++ b/spec/support/matchers/api_datetime_format.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+RSpec::Matchers.define :match_api_datetime_format do
+  match(notify_expectation_failures: true) do |value|
+    expect { DateTime.rfc3339(value) }
+      .to_not raise_error
+  end
+end


### PR DESCRIPTION
Changes:

- Consolidate the somewhat repetitive RFC3339 format check into matcher
- In a few specs, where it made sense, combine examples that had (or could easily have) same setup
- In a few specs, turn a full factory creation into a `build` instead where we dont need persistence

Reduces factory creation from 81 to 65 in this pass ... I suspect there are more we could find here, but I just sort of did a high level pass on the most easy/obvious ones that (hopefully) kept the diff manageable.

I think this makes sense by itself, but this is also somewhat prep for:

- The remove OJ use JSON thing
- Future coverage improvement across all serializers (I think the `expect(subject)...` style here will reduce future diff when adding stuff)