### PR TITLE
Extract development section from top-level readme into standalone doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ You can contribute in the following ways:
 If your contributions are accepted into Mastodon, you can request to be paid through [our OpenCollective](https://opencollective.com/mastodon).
 
 Please review the org-level [contribution guidelines] for high-level acceptance
-criteria guidance.
+criteria guidance and the [DEVELOPMENT] guide for environment-specific details.
 
 [contribution guidelines]: https://github.com/mastodon/.github/blob/main/CONTRIBUTING.md
 
@@ -53,3 +53,5 @@ It is not always possible to phrase every change in such a manner, but it is des
 ## Documentation
 
 The [Mastodon documentation](https://docs.joinmastodon.org) is a statically generated site. You can [submit merge requests to mastodon/documentation](https://github.com/mastodon/documentation).
+
+[DEVELOPMENT]: docs/DEVELOPMENT.md

--- a/README.md
+++ b/README.md
@@ -74,69 +74,14 @@ Mastodon acts as an OAuth2 provider, so 3rd party apps can use the REST and Stre
 
 The repository includes deployment configurations for **Docker and docker-compose** as well as specific platforms like **Heroku**, and **Scalingo**. For Helm charts, reference the [mastodon/chart repository](https://github.com/mastodon/chart). The [**standalone** installation guide](https://docs.joinmastodon.org/admin/install/) is available in the documentation.
 
-## Development
-
-### Vagrant
-
-A **Vagrant** configuration is included for development purposes. To use it, complete the following steps:
-
-- Install Vagrant and Virtualbox
-- Install the `vagrant-hostsupdater` plugin: `vagrant plugin install vagrant-hostsupdater`
-- Run `vagrant up`
-- Run `vagrant ssh -c "cd /vagrant && bin/dev"`
-- Open `http://mastodon.local` in your browser
-
-### macOS
-
-To set up **macOS** for native development, complete the following steps:
-
-- Install [Homebrew] and run `brew install postgresql@14 redis imagemagick
-libidn nvm` to install the required project dependencies
-- Use a Ruby version manager to activate the ruby in `.ruby-version` and run
-  `nvm use` to activate the node version from `.nvmrc`
-- Run the `bin/setup` script, which will install the required ruby gems and node
-  packages and prepare the database for local development
-- Finally, run the `bin/dev` script which will launch services via `overmind`
-  (if installed) or `foreman`
-
-### Docker
-
-For production hosting and deployment with **Docker**, use the `Dockerfile` and
-`docker-compose.yml` in the project root directory.
-
-For local development, install and launch [Docker], and run:
-
-```shell
-docker compose -f .devcontainer/compose.yaml up -d
-docker compose -f .devcontainer/compose.yaml exec app bin/setup
-docker compose -f .devcontainer/compose.yaml exec app bin/dev
-```
-
-### Dev Containers
-
-Within IDEs that support the [Development Containers] specification, start the
-"Mastodon on local machine" container from the editor. The necessary `docker
-compose` commands to build and setup the container should run automatically. For
-**Visual Studio Code** this requires installing the [Dev Container extension].
-
-### GitHub Codespaces
-
-[GitHub Codespaces] provides a web-based version of VS Code and a cloud hosted
-development environment configured with the software needed for this project.
-
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)][codespace]
-
-- Click the button to create a new codespace, and confirm the options
-- Wait for the environment to build (takes a few minutes)
-- When the editor is ready, run `bin/dev` in the terminal
-- Wait for an _Open in Browser_ prompt. This will open Mastodon
-- On the _Ports_ tab "stream" setting change _Port visibility_ → _Public_
-
 ## Contributing
 
 Mastodon is **free, open-source software** licensed under **AGPLv3**.
 
-You can open issues for bugs you've found or features you think are missing. You can also submit pull requests to this repository or submit translations using Crowdin. To get started, take a look at [CONTRIBUTING.md](CONTRIBUTING.md). If your contributions are accepted into Mastodon, you can request to be paid through [our OpenCollective](https://opencollective.com/mastodon).
+You can open issues for bugs you've found or features you think are missing. You
+can also submit pull requests to this repository or translations via Crowdin. To
+get started, look at the [CONTRIBUTING] and [DEVELOPMENT] guides. For changes
+accepted into Mastodon, you can request to be paid through our [OpenCollective].
 
 **IRC channel**: #mastodon on irc.libera.chat
 
@@ -150,9 +95,6 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 
 You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-[codespace]: https://codespaces.new/mastodon/mastodon?quickstart=1&devcontainer_path=.devcontainer%2Fcodespaces%2Fdevcontainer.json
-[Dev Container extension]: https://containers.dev/supporting#dev-containers
-[Development Containers]: https://containers.dev/supporting
-[Docker]: https://docs.docker.com
-[GitHub Codespaces]: https://docs.github.com/en/codespaces
-[Homebrew]: https://brew.sh
+[CONTRIBUTING]: CONTRIBUTING.md
+[DEVELOPMENT]: docs/DEVELOPMENT.md
+[OpenCollective]: https://opencollective.com/mastodon

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,75 @@
+# Development
+
+## Overview
+
+Before starting local development, read the [CONTRIBUTING] guide to understand
+what changes are desirable and what general processes to use.
+
+## Environments
+
+### Vagrant
+
+A **Vagrant** configuration is included for development purposes. To use it,
+complete the following steps:
+
+- Install Vagrant and Virtualbox
+- Install the `vagrant-hostsupdater` plugin:
+  `vagrant plugin install vagrant-hostsupdater`
+- Run `vagrant up`
+- Run `vagrant ssh -c "cd /vagrant && bin/dev"`
+- Open `http://mastodon.local` in your browser
+
+### macOS
+
+To set up **macOS** for native development, complete the following steps:
+
+- Install [Homebrew] and run:
+  `brew install postgresql@14 redis imagemagick libidn nvm`
+  to install the required project dependencies
+- Use a Ruby version manager to activate the ruby in `.ruby-version` and run
+  `nvm use` to activate the node version from `.nvmrc`
+- Run the `bin/setup` script, which will install the required ruby gems and node
+  packages and prepare the database for local development
+- Finally, run the `bin/dev` script which will launch services via `overmind`
+  (if installed) or `foreman`
+
+### Docker
+
+For production hosting and deployment with **Docker**, use the `Dockerfile` and
+`docker-compose.yml` in the project root directory.
+
+For local development, install and launch [Docker], and run:
+
+```shell
+docker compose -f .devcontainer/compose.yaml up -d
+docker compose -f .devcontainer/compose.yaml exec app bin/setup
+docker compose -f .devcontainer/compose.yaml exec app bin/dev
+```
+
+### Dev Containers
+
+Within IDEs that support the [Development Containers] specification, start the
+"Mastodon on local machine" container from the editor. The necessary `docker
+compose` commands to build and setup the container should run automatically. For
+**Visual Studio Code** this requires installing the [Dev Container extension].
+
+### GitHub Codespaces
+
+[GitHub Codespaces] provides a web-based version of VS Code and a cloud hosted
+development environment configured with the software needed for this project.
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)][codespace]
+
+- Click the button to create a new codespace, and confirm the options
+- Wait for the environment to build (takes a few minutes)
+- When the editor is ready, run `bin/dev` in the terminal
+- Wait for an _Open in Browser_ prompt. This will open Mastodon
+- On the _Ports_ tab "stream" setting change _Port visibility_ → _Public_
+
+[codespace]: https://codespaces.new/mastodon/mastodon?quickstart=1&devcontainer_path=.devcontainer%2Fcodespaces%2Fdevcontainer.json
+[CONTRIBUTING]: CONTRIBUTING.md
+[Dev Container extension]: https://containers.dev/supporting#dev-containers
+[Development Containers]: https://containers.dev/supporting
+[Docker]: https://docs.docker.com
+[GitHub Codespaces]: https://docs.github.com/en/codespaces
+[Homebrew]: https://brew.sh


### PR DESCRIPTION
Motivation here:

- The dev section is an oddly large portion of the top level README
- I'd like to **expand it** but this seems awkward given that dynamic
- I'd like to be able to add gotchas and best practices in there when people in issues/PRs/whatever hit setup/env type issues, which feels more appropriate in dedicated doc

Actual changes:

- Copy out verbatim the previous "Development" Section from README into a new `docs/DEVELOPMENT.md` file
- Make sure the README and DEVELOPMENT and CONTRIBUTING docs are linking to each other

