### PR TITLE
Remove reference to removed `Capfile` in lint-staged config

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,6 +1,6 @@
 const config = {
   '*': 'prettier --ignore-unknown --write',
-  'Capfile|Gemfile|*.{rb,ruby,ru,rake}': 'bin/rubocop --force-exclusion -a',
+  'Gemfile|*.{rb,ruby,ru,rake}': 'bin/rubocop --force-exclusion -a',
   '*.{js,jsx,ts,tsx}': 'eslint --fix',
   '*.{css,scss}': 'stylelint --fix',
   '*.haml': 'bin/haml-lint -a',


### PR DESCRIPTION
Removed in https://github.com/mastodon/mastodon/pull/27295