### PR TITLE
Add missing `NOT NULL` on more columns from "large but valid" tables

### DIFF
--- a/app/models/account_note.rb
+++ b/app/models/account_note.rb
@@ -5,11 +5,11 @@
 # Table name: account_notes
 #
 #  id                :bigint(8)        not null, primary key
-#  account_id        :bigint(8)
-#  target_account_id :bigint(8)
 #  comment           :text             not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
+#  account_id        :bigint(8)        not null
+#  target_account_id :bigint(8)        not null
 #
 class AccountNote < ApplicationRecord
   include RelationshipCacheable

--- a/app/models/marker.rb
+++ b/app/models/marker.rb
@@ -5,12 +5,12 @@
 # Table name: markers
 #
 #  id           :bigint(8)        not null, primary key
-#  user_id      :bigint(8)
-#  timeline     :string           default(""), not null
-#  last_read_id :bigint(8)        default(0), not null
 #  lock_version :integer          default(0), not null
+#  timeline     :string           default(""), not null
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
+#  last_read_id :bigint(8)        default(0), not null
+#  user_id      :bigint(8)        not null
 #
 
 class Marker < ApplicationRecord

--- a/app/models/poll_vote.rb
+++ b/app/models/poll_vote.rb
@@ -5,12 +5,12 @@
 # Table name: poll_votes
 #
 #  id         :bigint(8)        not null, primary key
-#  account_id :bigint(8)
-#  poll_id    :bigint(8)
 #  choice     :integer          default(0), not null
+#  uri        :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  uri        :string
+#  account_id :bigint(8)        not null
+#  poll_id    :bigint(8)        not null
 #
 
 class PollVote < ApplicationRecord

--- a/app/models/tombstone.rb
+++ b/app/models/tombstone.rb
@@ -5,11 +5,11 @@
 # Table name: tombstones
 #
 #  id           :bigint(8)        not null, primary key
-#  account_id   :bigint(8)
+#  by_moderator :boolean
 #  uri          :string           not null
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
-#  by_moderator :boolean
+#  account_id   :bigint(8)        not null
 #
 
 class Tombstone < ApplicationRecord

--- a/db/migrate/20241216223425_add_not_null_to_account_note_account_column.rb
+++ b/db/migrate/20241216223425_add_not_null_to_account_note_account_column.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddNotNullToAccountNoteAccountColumn < ActiveRecord::Migration[7.2]
+  def change
+    add_check_constraint :account_notes, 'account_id IS NOT NULL', name: 'account_notes_account_id_null', validate: false
+  end
+end

--- a/db/migrate/20241216223433_validate_not_null_to_account_note_account_column.rb
+++ b/db/migrate/20241216223433_validate_not_null_to_account_note_account_column.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class ValidateNotNullToAccountNoteAccountColumn < ActiveRecord::Migration[7.2]
+  def up
+    connection.execute(<<~SQL.squish)
+      DELETE FROM account_notes
+      WHERE account_id IS NULL
+    SQL
+
+    validate_check_constraint :account_notes, name: 'account_notes_account_id_null'
+    change_column_null :account_notes, :account_id, false
+    remove_check_constraint :account_notes, name: 'account_notes_account_id_null'
+  end
+
+  def down
+    add_check_constraint :account_notes, 'account_id IS NOT NULL', name: 'account_notes_account_id_null', validate: false
+    change_column_null :account_notes, :account_id, true
+  end
+end

--- a/db/migrate/20241216223446_add_not_null_to_account_note_target_account_column.rb
+++ b/db/migrate/20241216223446_add_not_null_to_account_note_target_account_column.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddNotNullToAccountNoteTargetAccountColumn < ActiveRecord::Migration[7.2]
+  def change
+    add_check_constraint :account_notes, 'target_account_id IS NOT NULL', name: 'account_notes_target_account_id_null', validate: false
+  end
+end

--- a/db/migrate/20241216223452_validate_not_null_to_account_note_target_account_column.rb
+++ b/db/migrate/20241216223452_validate_not_null_to_account_note_target_account_column.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class ValidateNotNullToAccountNoteTargetAccountColumn < ActiveRecord::Migration[7.2]
+  def up
+    connection.execute(<<~SQL.squish)
+      DELETE FROM account_notes
+      WHERE target_account_id IS NULL
+    SQL
+
+    validate_check_constraint :account_notes, name: 'account_notes_target_account_id_null'
+    change_column_null :account_notes, :target_account_id, false
+    remove_check_constraint :account_notes, name: 'account_notes_target_account_id_null'
+  end
+
+  def down
+    add_check_constraint :account_notes, 'target_account_id IS NOT NULL', name: 'account_notes_target_account_id_null', validate: false
+    change_column_null :account_notes, :target_account_id, true
+  end
+end

--- a/db/migrate/20241216223852_add_not_null_to_marker_user_column.rb
+++ b/db/migrate/20241216223852_add_not_null_to_marker_user_column.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddNotNullToMarkerUserColumn < ActiveRecord::Migration[7.2]
+  def change
+    add_check_constraint :markers, 'user_id IS NOT NULL', name: 'markers_user_id_null', validate: false
+  end
+end

--- a/db/migrate/20241216223859_validate_not_null_to_marker_user_column.rb
+++ b/db/migrate/20241216223859_validate_not_null_to_marker_user_column.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class ValidateNotNullToMarkerUserColumn < ActiveRecord::Migration[7.2]
+  def up
+    connection.execute(<<~SQL.squish)
+      DELETE FROM markers
+      WHERE user_id IS NULL
+    SQL
+
+    validate_check_constraint :markers, name: 'markers_user_id_null'
+    change_column_null :markers, :user_id, false
+    remove_check_constraint :markers, name: 'markers_user_id_null'
+  end
+
+  def down
+    add_check_constraint :markers, 'user_id IS NOT NULL', name: 'markers_user_id_null', validate: false
+    change_column_null :markers, :user_id, true
+  end
+end

--- a/db/migrate/20241216224211_add_not_null_to_poll_vote_account_column.rb
+++ b/db/migrate/20241216224211_add_not_null_to_poll_vote_account_column.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddNotNullToPollVoteAccountColumn < ActiveRecord::Migration[7.2]
+  def change
+    add_check_constraint :poll_votes, 'account_id IS NOT NULL', name: 'poll_votes_account_id_null', validate: false
+  end
+end

--- a/db/migrate/20241216224218_validate_not_null_to_poll_vote_account_column.rb
+++ b/db/migrate/20241216224218_validate_not_null_to_poll_vote_account_column.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class ValidateNotNullToPollVoteAccountColumn < ActiveRecord::Migration[7.2]
+  def up
+    connection.execute(<<~SQL.squish)
+      DELETE FROM poll_votes
+      WHERE account_id IS NULL
+    SQL
+
+    validate_check_constraint :poll_votes, name: 'poll_votes_account_id_null'
+    change_column_null :poll_votes, :account_id, false
+    remove_check_constraint :poll_votes, name: 'poll_votes_account_id_null'
+  end
+
+  def down
+    add_check_constraint :poll_votes, 'account_id IS NOT NULL', name: 'poll_votes_account_id_null', validate: false
+    change_column_null :poll_votes, :account_id, true
+  end
+end

--- a/db/migrate/20241216224229_add_not_null_to_poll_vote_poll_column.rb
+++ b/db/migrate/20241216224229_add_not_null_to_poll_vote_poll_column.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddNotNullToPollVotePollColumn < ActiveRecord::Migration[7.2]
+  def change
+    add_check_constraint :poll_votes, 'poll_id IS NOT NULL', name: 'poll_votes_poll_id_null', validate: false
+  end
+end

--- a/db/migrate/20241216224237_validate_not_null_to_poll_vote_poll_column.rb
+++ b/db/migrate/20241216224237_validate_not_null_to_poll_vote_poll_column.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class ValidateNotNullToPollVotePollColumn < ActiveRecord::Migration[7.2]
+  def up
+    connection.execute(<<~SQL.squish)
+      DELETE FROM poll_votes
+      WHERE poll_id IS NULL
+    SQL
+
+    validate_check_constraint :poll_votes, name: 'poll_votes_poll_id_null'
+    change_column_null :poll_votes, :poll_id, false
+    remove_check_constraint :poll_votes, name: 'poll_votes_poll_id_null'
+  end
+
+  def down
+    add_check_constraint :poll_votes, 'poll_id IS NOT NULL', name: 'poll_votes_poll_id_null', validate: false
+    change_column_null :poll_votes, :poll_id, true
+  end
+end

--- a/db/migrate/20241216224813_add_not_null_to_tombstone_account_column.rb
+++ b/db/migrate/20241216224813_add_not_null_to_tombstone_account_column.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddNotNullToTombstoneAccountColumn < ActiveRecord::Migration[7.2]
+  def change
+    add_check_constraint :tombstones, 'account_id IS NOT NULL', name: 'tombstones_account_id_null', validate: false
+  end
+end

--- a/db/migrate/20241216224825_validate_not_null_to_tombstone_account_column.rb
+++ b/db/migrate/20241216224825_validate_not_null_to_tombstone_account_column.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class ValidateNotNullToTombstoneAccountColumn < ActiveRecord::Migration[7.2]
+  def up
+    connection.execute(<<~SQL.squish)
+      DELETE FROM tombstones
+      WHERE account_id IS NULL
+    SQL
+
+    validate_check_constraint :tombstones, name: 'tombstones_account_id_null'
+    change_column_null :tombstones, :account_id, false
+    remove_check_constraint :tombstones, name: 'tombstones_account_id_null'
+  end
+
+  def down
+    add_check_constraint :tombstones, 'account_id IS NOT NULL', name: 'tombstones_account_id_null', validate: false
+    change_column_null :tombstones, :account_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_16_223859) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_16_224237) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -767,8 +767,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_16_223859) do
   end
 
   create_table "poll_votes", force: :cascade do |t|
-    t.bigint "account_id"
-    t.bigint "poll_id"
+    t.bigint "account_id", null: false
+    t.bigint "poll_id", null: false
     t.integer "choice", default: 0, null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_16_224237) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_16_224825) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -1113,7 +1113,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_16_224237) do
   end
 
   create_table "tombstones", force: :cascade do |t|
-    t.bigint "account_id"
+    t.bigint "account_id", null: false
     t.string "uri", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_13_170053) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_16_223452) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -72,8 +72,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_13_170053) do
   end
 
   create_table "account_notes", force: :cascade do |t|
-    t.bigint "account_id"
-    t.bigint "target_account_id"
+    t.bigint "account_id", null: false
+    t.bigint "target_account_id", null: false
     t.text "comment", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_16_223452) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_16_223859) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -599,7 +599,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_16_223452) do
   end
 
   create_table "markers", force: :cascade do |t|
-    t.bigint "user_id"
+    t.bigint "user_id", null: false
     t.string "timeline", default: "", null: false
     t.bigint "last_read_id", default: 0, null: false
     t.integer "lock_version", default: 0, null: false


### PR DESCRIPTION
Repeating pattern from https://github.com/mastodon/mastodon/pull/33308 for the other five "large but valid" tables from https://github.com/mastodon/mastodon/issues/33249

Kind of sizable, but just same pattern over and over. Each table has it's own commit, so if one-PR-per-table desired for any reason, easy enough to do.