### PR TITLE
Replace deprecated iFrame frameborder with border: 0

### DIFF
--- a/app/javascript/mastodon/features/ui/components/embed_modal.tsx
+++ b/app/javascript/mastodon/features/ui/components/embed_modal.tsx
@@ -101,9 +101,9 @@ const EmbedModal: React.FC<{
           />
 
           <iframe
-            frameBorder='0'
             ref={iframeRef}
             sandbox='allow-scripts allow-same-origin'
+            style={{ border: 0 }}
             title='Preview'
           />
         </div>

--- a/app/lib/link_details_extractor.rb
+++ b/app/lib/link_details_extractor.rb
@@ -145,7 +145,7 @@ class LinkDetailsExtractor
   end
 
   def html
-    player_url.present? ? content_tag(:iframe, nil, src: player_url, width: width, height: height, allowfullscreen: 'true', allowtransparency: 'true', scrolling: 'no', frameborder: '0') : nil
+    player_url.present? ? content_tag(:iframe, nil, src: player_url, width: width, height: height, allowfullscreen: 'true', allowtransparency: 'true', scrolling: 'no', style: 'border: 0') : nil
   end
 
   def width

--- a/lib/sanitize_ext/sanitize_config.rb
+++ b/lib/sanitize_ext/sanitize_config.rb
@@ -135,7 +135,7 @@ class Sanitize
 
       attributes: {
         'audio' => %w(controls),
-        'iframe' => %w(allowfullscreen frameborder height scrolling src width),
+        'iframe' => %w(allowfullscreen frameborder height scrolling src style width),
         'source' => %w(src type),
         'video' => %w(controls height loop width),
       },


### PR DESCRIPTION
Not completely sure about the Ruby changes, but looked for the refrences from the failing ESLint PR.
Used the inline style to turn off the border https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#frameborder