### PR TITLE
Use bundler version 2.6.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,7 @@ GEM
     ast (2.4.2)
     attr_required (1.0.2)
     aws-eventstream (1.3.0)
-    aws-partitions (1.1017.0)
+    aws-partitions (1.1023.0)
     aws-sdk-core (3.214.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -754,7 +754,7 @@ GEM
     scenic (1.8.0)
       activerecord (>= 4.0.0)
       railties (>= 4.0.0)
-    securerandom (0.3.2)
+    securerandom (0.4.1)
     selenium-webdriver (4.27.0)
       base64 (~> 0.2)
       logger (~> 1.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -406,7 +406,7 @@ GEM
     mime-types (3.6.0)
       logger
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2024.1105)
+    mime-types-data (3.2024.1203)
     mini_mime (1.1.5)
     mini_portile2 (2.8.8)
     minitest (5.25.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -279,7 +279,7 @@ GEM
       rainbow
       rubocop (>= 1.0)
       sysexits (~> 1.1)
-    hashdiff (1.1.1)
+    hashdiff (1.1.2)
     hashie (5.0.0)
     hcaptcha (7.1.0)
       json

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -318,7 +318,7 @@ GEM
     inline_svg (1.10.0)
       activesupport (>= 3.0)
       nokogiri (>= 1.6)
-    io-console (0.7.2)
+    io-console (0.8.0)
     irb (1.14.2)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -294,7 +294,7 @@ GEM
       http-cookie (~> 1.0)
       http-form_data (~> 2.2)
       llhttp-ffi (~> 0.5.0)
-    http-cookie (1.0.5)
+    http-cookie (1.0.8)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
     http_accept_language (2.1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1036,4 +1036,4 @@ RUBY VERSION
    ruby 3.3.6p108
 
 BUNDLED WITH
-   2.5.23
+   2.6.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,7 +168,7 @@ GEM
       bigdecimal
       rexml
     crass (1.0.6)
-    css_parser (1.19.1)
+    css_parser (1.21.0)
       addressable
     csv (3.3.1)
     database_cleaner-active_record (2.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -707,7 +707,7 @@ GEM
       rspec-expectations (~> 3.0)
       rspec-mocks (~> 3.0)
       sidekiq (>= 5, < 8)
-    rspec-support (3.13.1)
+    rspec-support (3.13.2)
     rubocop (1.69.2)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -665,7 +665,7 @@ GEM
     redlock (1.3.2)
       redis (>= 3.0.0, < 6.0)
     regexp_parser (2.9.3)
-    reline (0.5.12)
+    reline (0.6.0)
       io-console (~> 0.5)
     request_store (1.6.0)
       rack (>= 1.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -718,7 +718,7 @@ GEM
       rubocop-ast (>= 1.36.2, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.36.2)
+    rubocop-ast (1.37.0)
       parser (>= 3.3.1.0)
     rubocop-capybara (2.21.0)
       rubocop (~> 1.41)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -224,14 +224,14 @@ GEM
     fabrication (2.31.0)
     faker (3.5.1)
       i18n (>= 1.8.11, < 2)
-    faraday (2.12.0)
-      faraday-net_http (>= 2.0, < 3.4)
+    faraday (2.12.2)
+      faraday-net_http (>= 2.0, < 3.5)
       json
       logger
     faraday-httpclient (2.0.1)
       httpclient (>= 2.2)
-    faraday-net_http (3.3.0)
-      net-http
+    faraday-net_http (3.4.0)
+      net-http (>= 0.5.0)
     fast_blank (1.0.1)
     fastimage (2.3.1)
     ffi (1.17.0)
@@ -384,7 +384,7 @@ GEM
     llhttp-ffi (0.5.0)
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
-    logger (1.6.2)
+    logger (1.6.3)
     lograge (0.14.0)
       actionpack (>= 4)
       activesupport (>= 4)
@@ -837,7 +837,7 @@ GEM
       unf_ext
     unf_ext (0.0.9.1)
     unicode-display_width (2.6.0)
-    uri (0.13.1)
+    uri (1.0.2)
     useragent (0.16.11)
     validate_email (0.1.6)
       activemodel (>= 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -667,7 +667,7 @@ GEM
     regexp_parser (2.9.3)
     reline (0.6.0)
       io-console (~> 0.5)
-    request_store (1.6.0)
+    request_store (1.7.0)
       rack (>= 1.4)
     responders (3.1.1)
       actionpack (>= 5.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -761,7 +761,7 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
-    semantic_range (3.0.0)
+    semantic_range (3.1.0)
     shoulda-matchers (6.4.0)
       activesupport (>= 5.2.0)
     sidekiq (6.5.12)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -415,7 +415,7 @@ GEM
     mutex_m (0.3.0)
     net-http (0.5.0)
       uri
-    net-imap (0.5.1)
+    net-imap (0.5.2)
       date
       net-protocol
     net-ldap (0.19.0)
@@ -811,7 +811,7 @@ GEM
     test-prof (1.4.2)
     thor (1.3.2)
     tilt (2.4.0)
-    timeout (0.4.2)
+    timeout (0.4.3)
     tpm-key_attestation (0.12.1)
       bindata (~> 2.4)
       openssl (> 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -656,7 +656,7 @@ GEM
       link_header (~> 0.0, >= 0.0.8)
     rdf-normalize (0.7.0)
       rdf (~> 3.3)
-    rdoc (6.7.0)
+    rdoc (6.9.1)
       psych (>= 4.0.0)
     redcarpet (3.6.0)
     redis (4.8.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,7 +109,7 @@ GEM
       aws-sigv4 (~> 1.5)
     aws-sigv4 (1.10.1)
       aws-eventstream (~> 1, >= 1.0.2)
-    azure-blob (0.5.3)
+    azure-blob (0.5.4)
       rexml
     base64 (0.2.0)
     bcp47_spec (0.2.1)
@@ -672,7 +672,7 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    rexml (3.3.9)
+    rexml (3.4.0)
     rotp (6.3.0)
     rouge (4.5.1)
     rpam2 (4.0.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -634,7 +634,7 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.6.1)
+    rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     rails-i18n (7.0.10)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -744,8 +744,8 @@ GEM
       ffi (~> 1.12)
       logger
     rubyzip (2.3.2)
-    rufus-scheduler (3.9.1)
-      fugit (~> 1.1, >= 1.1.6)
+    rufus-scheduler (3.9.2)
+      fugit (~> 1.1, >= 1.11.1)
     safety_net_attestation (0.4.0)
       jwt (~> 2.0)
     sanitize (6.1.3)


### PR DESCRIPTION
In part prep for https://github.com/mastodon/mastodon/pull/33304 (this release is in advance of ruby 3.4.0 later this month) ... but I think the other changes (support dropped for older rubies, etc) are harmless to pull in earlier.

While in there, do a round of patch/minor version bumps on misc stuff that renovate never updates. Leaves things with known blocked update paths (rails, sidekiq, rack, elastic, etc) as the outdated things.