### PR TITLE
Fix down clause for notification policy v2 migrations

### DIFF
--- a/db/migrate/20240808124338_migrate_notifications_policy_v2.rb
+++ b/db/migrate/20240808124338_migrate_notifications_policy_v2.rb
@@ -18,7 +18,7 @@ class MigrateNotificationsPolicyV2 < ActiveRecord::Migration[7.1]
   def down
     NotificationPolicy.in_batches.update_all(<<~SQL.squish)
       filter_not_following = CASE for_not_following WHEN 0 THEN false ELSE true END,
-      filter_not_following = CASE for_not_followers WHEN 0 THEN false ELSE true END,
+      filter_not_followers = CASE for_not_followers WHEN 0 THEN false ELSE true END,
       filter_new_accounts = CASE for_new_accounts WHEN 0 THEN false ELSE true END,
       filter_private_mentions = CASE for_private_mentions WHEN 0 THEN false ELSE true END
     SQL

--- a/db/post_migrate/20240808124339_post_deployment_migrate_notifications_policy_v2.rb
+++ b/db/post_migrate/20240808124339_post_deployment_migrate_notifications_policy_v2.rb
@@ -18,7 +18,7 @@ class PostDeploymentMigrateNotificationsPolicyV2 < ActiveRecord::Migration[7.1]
   def down
     NotificationPolicy.in_batches.update_all(<<~SQL.squish)
       filter_not_following = CASE for_not_following WHEN 0 THEN false ELSE true END,
-      filter_not_following = CASE for_not_followers WHEN 0 THEN false ELSE true END,
+      filter_not_followers = CASE for_not_followers WHEN 0 THEN false ELSE true END,
       filter_new_accounts = CASE for_new_accounts WHEN 0 THEN false ELSE true END,
       filter_private_mentions = CASE for_private_mentions WHEN 0 THEN false ELSE true END
     SQL


### PR DESCRIPTION
I was testing rolling back an upgrade from 4.2.x to 4.3.x and ran into the following error when rolling back the migrations:

```
PostDeploymentMigrateNotificationsPolicyV2::NotificationPolicy Update All (2.4ms)  UPDATE "notification_policies" SET filter_not_following = CASE for_not_following WHEN 0 THEN false ELSE true END, filter_not_following = CASE for_not_followers WHEN 0 THEN false ELSE true END, filter_new_accounts = CASE for_new_accounts WHEN 0 THEN false ELSE true END, filter_private_mentions = CASE for_private_mentions WHEN 0 THEN false ELSE true END WHERE "notification_policies"."id" <= $1  [["id", 5]]
   (0.2ms)  SELECT pg_advisory_unlock(5881450594042647960)
bin/rails aborted!
StandardError: An error has occurred, all later migrations canceled: (StandardError)

PG::SyntaxError: ERROR:  multiple assignments to same column "filter_not_following"
~/mastodon/db/post_migrate/20240808124339_post_deployment_migrate_notifications_policy_v2.rb:19:in `down'

Caused by:
ActiveRecord::StatementInvalid: PG::SyntaxError: ERROR:  multiple assignments to same column "filter_not_following" (ActiveRecord::StatementInvalid)
~/mastodon/db/post_migrate/20240808124339_post_deployment_migrate_notifications_policy_v2.rb:19:in `down'

Caused by:
PG::SyntaxError: ERROR:  multiple assignments to same column "filter_not_following" (PG::SyntaxError)
~/mastodon/db/post_migrate/20240808124339_post_deployment_migrate_notifications_policy_v2.rb:19:in `down'
Tasks: TOP => db:migrate:down
(See full trace by running task with --trace)

```

The same issue also happened for `MigrateNotificationsPolicyV2`.

------


This fixes the typos to match the columns touched in the `up` clause.