### PR TITLE
Add support for Active Record query log tags

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -108,6 +108,11 @@ module Mastodon
     config.x.mastodon = config_for(:mastodon)
     config.x.translation = config_for(:translation)
 
+    if ENV.fetch('QUERY_LOG_TAGS_ENABLED', 'false') == 'true'
+      config.active_record.query_log_tags_enabled = ENV.fetch('QUERY_LOG_TAGS_ENABLED', 'false') == 'true'
+      config.active_record.query_log_tags = [:namespaced_controller, :action, :sidekiq_job_class]
+    end
+
     config.to_prepare do
       Doorkeeper::AuthorizationsController.layout 'modal'
       Doorkeeper::AuthorizedApplicationsController.layout 'admin'

--- a/lib/mastodon/sidekiq_middleware.rb
+++ b/lib/mastodon/sidekiq_middleware.rb
@@ -3,8 +3,10 @@
 class Mastodon::SidekiqMiddleware
   BACKTRACE_LIMIT = 3
 
-  def call(*, &block)
-    Chewy.strategy(:mastodon, &block)
+  def call(_worker_class, job, _queue, &block)
+    setup_query_log_tags(job) do
+      Chewy.strategy(:mastodon, &block)
+    end
   rescue Mastodon::HostValidationError
     # Do not retry
   rescue => e
@@ -60,5 +62,15 @@ class Mastodon::SidekiqMiddleware
   def clean_up_statsd_socket!
     Thread.current[:statsd_socket]&.close
     Thread.current[:statsd_socket] = nil
+  end
+
+  def setup_query_log_tags(job, &block)
+    if Rails.configuration.active_record.query_log_tags_enabled
+      # If `wrapped` is set, this is an `ActiveJob` which is already in the execution context
+      sidekiq_job_class = job['wrapped'].present? ? nil : job['class'].to_s
+      ActiveSupport::ExecutionContext.set(sidekiq_job_class: sidekiq_job_class, &block)
+    else
+      yield
+    end
   end
 end


### PR DESCRIPTION
Configuring `QUERY_LOG_TAGS_ENABLED=true` will have ActiveRecord insert a comment at the end of SQL statements that will contain the controller name and action (for web requests) or the Sidekiq job class.

For example:
- web request
  ``` SessionActivation Load (0.8ms)  SELECT "session_activations".* FROM "session_activations" WHERE "session_activations"."session_id" = 'e41a1ef7831b69b7271bb82cd0a13664' LIMIT 1 /*action='index',namespaced_controller='api%2Fv1%2Faccounts%2Frelationships'*/ ```
- request from a Sidekiq job
  ``` AccountDeletionRequest Load (0.9ms)  SELECT "account_deletion_requests".* FROM "account_deletion_requests" ORDER BY "account_deletion_requests"."id" ASC LIMIT 10 /*sidekiq_job_class='Scheduler%3A%3ASuspendedUserCleanupScheduler'*/ ```

Important note: this will disable prepared statements, if they are enabled.