### PR TITLE
Fix incorrect notification settings migration for non-followers

### DIFF
--- a/db/migrate/20240808124338_migrate_notifications_policy_v2.rb
+++ b/db/migrate/20240808124338_migrate_notifications_policy_v2.rb
@@ -9,7 +9,7 @@ class MigrateNotificationsPolicyV2 < ActiveRecord::Migration[7.1]
   def up
     NotificationPolicy.in_batches.update_all(<<~SQL.squish)
       for_not_following = CASE filter_not_following WHEN true THEN 1 ELSE 0 END,
-      for_not_followers = CASE filter_not_following WHEN true THEN 1 ELSE 0 END,
+      for_not_followers = CASE filter_not_followers WHEN true THEN 1 ELSE 0 END,
       for_new_accounts = CASE filter_new_accounts WHEN true THEN 1 ELSE 0 END,
       for_private_mentions = CASE filter_private_mentions WHEN true THEN 1 ELSE 0 END
     SQL

--- a/db/post_migrate/20240808124339_post_deployment_migrate_notifications_policy_v2.rb
+++ b/db/post_migrate/20240808124339_post_deployment_migrate_notifications_policy_v2.rb
@@ -9,7 +9,7 @@ class PostDeploymentMigrateNotificationsPolicyV2 < ActiveRecord::Migration[7.1]
   def up
     NotificationPolicy.in_batches.update_all(<<~SQL.squish)
       for_not_following = CASE filter_not_following WHEN true THEN 1 ELSE 0 END,
-      for_not_followers = CASE filter_not_following WHEN true THEN 1 ELSE 0 END,
+      for_not_followers = CASE filter_not_followers WHEN true THEN 1 ELSE 0 END,
       for_new_accounts = CASE filter_new_accounts WHEN true THEN 1 ELSE 0 END,
       for_private_mentions = CASE filter_private_mentions WHEN true THEN 1 ELSE 0 END
     SQL


### PR DESCRIPTION
See https://github.com/mastodon/mastodon/pull/33340#issuecomment-2549791241

This fixes incorrect migrations, but unfortunately, not retroactively.