### PR TITLE
Update user role position range limit

### DIFF
--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -41,7 +41,7 @@ class UserRole < ApplicationRecord
   EVERYONE_ROLE_ID = -99
   NOBODY_POSITION = -1
 
-  POSITION_LIMIT = 2**31
+  POSITION_LIMIT = (2**31) - 1
 
   module Flags
     NONE = 0
@@ -91,7 +91,7 @@ class UserRole < ApplicationRecord
 
   validates :name, presence: true, unless: :everyone?
   validates :color, format: { with: /\A#?(?:[A-F0-9]{3}){1,2}\z/i }, unless: -> { color.blank? }
-  validates :position, numericality: { greater_than_or_equal_to: -POSITION_LIMIT, less_than_or_equal_to: POSITION_LIMIT }
+  validates :position, numericality: { in: (-POSITION_LIMIT..POSITION_LIMIT) }
 
   validate :validate_permissions_elevation
   validate :validate_position_elevation

--- a/spec/models/user_role_spec.rb
+++ b/spec/models/user_role_spec.rb
@@ -21,11 +21,9 @@ RSpec.describe UserRole do
     describe 'position' do
       subject { Fabricate.build :user_role }
 
-      let(:excess) { 2**32 }
-      let(:limit) { 2**31 }
+      let(:limit) { described_class::POSITION_LIMIT }
 
-      it { is_expected.to_not allow_values(-excess, excess).for(:position) }
-      it { is_expected.to allow_values(-limit, limit).for(:position) }
+      it { is_expected.to validate_numericality_of(:position).is_in(-limit..limit) }
     end
 
     describe 'color' do


### PR DESCRIPTION
Background: https://github.com/mastodon/mastodon/pull/33172#issuecomment-2550727650

The initial logic here was like "treat the column limit as the highest (or lowest) allowable value", but that should actually be the first NON-allowed value.

Updated to match that, and style update to use `in:` as requested on other PR.