### PR TITLE
Remove unused `Poll.unattached` scope

### DIFF
--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -40,7 +40,6 @@ class Poll < ApplicationRecord
   validates_with PollValidator, on: :create, if: :local?
 
   scope :attached, -> { where.not(status_id: nil) }
-  scope :unattached, -> { where(status_id: nil) }
 
   before_validation :prepare_options, if: :local?
   before_validation :prepare_votes_count

--- a/spec/models/poll_spec.rb
+++ b/spec/models/poll_spec.rb
@@ -20,14 +20,6 @@ RSpec.describe Poll do
         expect(results).to eq([attached_poll])
       end
     end
-
-    describe '.unattached' do
-      it 'finds the correct records' do
-        results = described_class.unattached
-
-        expect(results).to eq([not_attached_poll])
-      end
-    end
   end
 
   describe '#reset_votes!' do


### PR DESCRIPTION
Background: https://github.com/mastodon/mastodon/issues/33249#issuecomment-2548569564

As far as I can tell this method was not used when added https://github.com/mastodon/mastodon/pull/10111/files#diff-6490cbd2800c2c0c4edd81cc11049d665ceeed808f7fbde902f12306e6bf1b38R33
 and has not been used since, and seemingly captures an invalid data scenario?