### PR TITLE
Add coverage for `REST::AnnualReportEventSerializer` and two `ActivityPub::*` serializers

### DIFF
--- a/spec/serializers/activitypub/accept_follow_serializer_spec.rb
+++ b/spec/serializers/activitypub/accept_follow_serializer_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ActivityPub::AcceptFollowSerializer do
     it 'returns expected attributes' do
       expect(subject.deep_symbolize_keys)
         .to include(
-          actor: match(record.target_account.username),
+          actor: eq(ActivityPub::TagManager.instance.uri_for(record.target_account)),
           id: match("#accepts/follows/#{record.id}"),
           object: include(type: 'Follow'),
           type: 'Accept'

--- a/spec/serializers/activitypub/accept_follow_serializer_spec.rb
+++ b/spec/serializers/activitypub/accept_follow_serializer_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ActivityPub::AcceptFollowSerializer do
+  subject { serialized_record_json(record, described_class, adapter: ActivityPub::Adapter) }
+
+  describe 'serializing an object' do
+    let(:record) { Fabricate :follow_request }
+
+    it 'returns expected attributes' do
+      expect(subject.deep_symbolize_keys)
+        .to include(
+          actor: match(record.target_account.username),
+          id: match("#accepts/follows/#{record.id}"),
+          object: include(type: 'Follow'),
+          type: 'Accept'
+        )
+    end
+  end
+end

--- a/spec/serializers/activitypub/reject_follow_serializer_spec.rb
+++ b/spec/serializers/activitypub/reject_follow_serializer_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ActivityPub::RejectFollowSerializer do
+  subject { serialized_record_json(record, described_class, adapter: ActivityPub::Adapter) }
+
+  describe 'serializing an object' do
+    let(:record) { Fabricate :follow_request }
+
+    it 'returns expected attributes' do
+      expect(subject.deep_symbolize_keys)
+        .to include(
+          actor: match(record.target_account.username),
+          id: match("#rejects/follows/#{record.id}"),
+          object: include(type: 'Follow'),
+          type: 'Reject'
+        )
+    end
+  end
+end

--- a/spec/serializers/activitypub/reject_follow_serializer_spec.rb
+++ b/spec/serializers/activitypub/reject_follow_serializer_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ActivityPub::RejectFollowSerializer do
     it 'returns expected attributes' do
       expect(subject.deep_symbolize_keys)
         .to include(
-          actor: match(record.target_account.username),
+          actor: eq(ActivityPub::TagManager.instance.uri_for(record.target_account)),
           id: match("#rejects/follows/#{record.id}"),
           object: include(type: 'Follow'),
           type: 'Reject'

--- a/spec/serializers/rest/annual_report_event_serializer_spec.rb
+++ b/spec/serializers/rest/annual_report_event_serializer_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe REST::AnnualReportEventSerializer do
+  subject { serialized_record_json(record, described_class) }
+
+  describe 'serializing an object' do
+    let(:record) { Fabricate.build :generated_annual_report, year: 2024 }
+
+    it 'returns expected attributes' do
+      expect(subject.deep_symbolize_keys)
+        .to include(
+          year: '2024'
+        )
+    end
+  end
+end


### PR DESCRIPTION
This is in some part a followup on the recent datetime serializer PRs, and in some part the beginning of a larger serializer specs once over. Purposefully chose some relatively small/simple ones here just to go through the motions of a style/approach check before adding what may wind up being a lot of these.

The annual report one was not being exercised at all, the other two were being used by other specs, but not directly asserted about anywhere.

I'm going to try to strike a balance here between not being so overspecified that they become kind of brittle and coupled to other spec assumptions ... but being thorough enough that any serious regression would be caught.