### PR TITLE
Fix `/health` endpoint when OTEL is configured

### DIFF
--- a/config/initializers/opentelemetry.rb
+++ b/config/initializers/opentelemetry.rb
@@ -86,10 +86,7 @@ if ENV.keys.any? { |name| name.match?(/OTEL_.*_ENDPOINT/) }
     def call(env)
       span = OpenTelemetry::Trace.current_span
 
-      unless span.recording?
-        @app.call(env)
-        return
-      end
+      return @app.call(env) unless span.recording?
 
       span_id = span.context.hex_span_id
       trace_id = span.context.hex_trace_id


### PR DESCRIPTION
Introduced by me in #33339

This caused a `<NoMethodError: undefined method `[]=' for nil>` error for requests to `/health`