### PR TITLE
Add coverage for `UserMailer` not delivering to memorialized users

### DIFF
--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe UserMailer do
   shared_examples 'delivery to memorialized user' do
-    context 'when user is not active for authentication' do
+    context 'when the account is memorialized' do
       before { receiver.account.update(memorial: true) }
 
       it 'does not deliver mail' do

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -3,6 +3,17 @@
 require 'rails_helper'
 
 RSpec.describe UserMailer do
+  shared_examples 'delivery to memorialized user' do
+    context 'when user is not active for authentication' do
+      before { receiver.account.update(memorial: true) }
+
+      it 'does not deliver mail' do
+        emails = capture_emails { mail.deliver_now }
+        expect(emails).to be_empty
+      end
+    end
+  end
+
   let(:receiver) { Fabricate(:user) }
 
   describe '#confirmation_instructions' do
@@ -21,6 +32,7 @@ RSpec.describe UserMailer do
     include_examples 'localized subject',
                      'devise.mailer.confirmation_instructions.subject',
                      instance: Rails.configuration.x.local_domain
+    include_examples 'delivery to memorialized user'
   end
 
   describe '#reconfirmation_instructions' do
@@ -39,6 +51,7 @@ RSpec.describe UserMailer do
     include_examples 'localized subject',
                      'devise.mailer.confirmation_instructions.subject',
                      instance: Rails.configuration.x.local_domain
+    include_examples 'delivery to memorialized user'
   end
 
   describe '#reset_password_instructions' do
@@ -55,6 +68,7 @@ RSpec.describe UserMailer do
 
     include_examples 'localized subject',
                      'devise.mailer.reset_password_instructions.subject'
+    include_examples 'delivery to memorialized user'
   end
 
   describe '#password_change' do
@@ -70,6 +84,7 @@ RSpec.describe UserMailer do
 
     include_examples 'localized subject',
                      'devise.mailer.password_change.subject'
+    include_examples 'delivery to memorialized user'
   end
 
   describe '#email_changed' do
@@ -85,6 +100,7 @@ RSpec.describe UserMailer do
 
     include_examples 'localized subject',
                      'devise.mailer.email_changed.subject'
+    include_examples 'delivery to memorialized user'
   end
 
   describe '#warning' do
@@ -115,6 +131,7 @@ RSpec.describe UserMailer do
 
     include_examples 'localized subject',
                      'devise.mailer.webauthn_credential.deleted.subject'
+    include_examples 'delivery to memorialized user'
   end
 
   describe '#suspicious_sign_in' do
@@ -186,6 +203,8 @@ RSpec.describe UserMailer do
         .and(have_subject(I18n.t('devise.mailer.two_factor_enabled.subject')))
         .and(have_body_text(I18n.t('devise.mailer.two_factor_enabled.explanation')))
     end
+
+    include_examples 'delivery to memorialized user'
   end
 
   describe '#two_factor_disabled' do
@@ -197,6 +216,8 @@ RSpec.describe UserMailer do
         .and(have_subject(I18n.t('devise.mailer.two_factor_disabled.subject')))
         .and(have_body_text(I18n.t('devise.mailer.two_factor_disabled.explanation')))
     end
+
+    include_examples 'delivery to memorialized user'
   end
 
   describe '#webauthn_enabled' do
@@ -208,6 +229,8 @@ RSpec.describe UserMailer do
         .and(have_subject(I18n.t('devise.mailer.webauthn_enabled.subject')))
         .and(have_body_text(I18n.t('devise.mailer.webauthn_enabled.explanation')))
     end
+
+    include_examples 'delivery to memorialized user'
   end
 
   describe '#webauthn_disabled' do
@@ -219,6 +242,8 @@ RSpec.describe UserMailer do
         .and(have_subject(I18n.t('devise.mailer.webauthn_disabled.subject')))
         .and(have_body_text(I18n.t('devise.mailer.webauthn_disabled.explanation')))
     end
+
+    include_examples 'delivery to memorialized user'
   end
 
   describe '#two_factor_recovery_codes_changed' do
@@ -230,6 +255,8 @@ RSpec.describe UserMailer do
         .and(have_subject(I18n.t('devise.mailer.two_factor_recovery_codes_changed.subject')))
         .and(have_body_text(I18n.t('devise.mailer.two_factor_recovery_codes_changed.explanation')))
     end
+
+    include_examples 'delivery to memorialized user'
   end
 
   describe '#webauthn_credential_added' do
@@ -242,6 +269,8 @@ RSpec.describe UserMailer do
         .and(have_subject(I18n.t('devise.mailer.webauthn_credential.added.subject')))
         .and(have_body_text(I18n.t('devise.mailer.webauthn_credential.added.explanation')))
     end
+
+    include_examples 'delivery to memorialized user'
   end
 
   describe '#welcome' do
@@ -259,6 +288,8 @@ RSpec.describe UserMailer do
         .and(have_subject(I18n.t('user_mailer.welcome.subject')))
         .and(have_body_text(I18n.t('user_mailer.welcome.explanation')))
     end
+
+    include_examples 'delivery to memorialized user'
   end
 
   describe '#backup_ready' do
@@ -271,6 +302,8 @@ RSpec.describe UserMailer do
         .and(have_subject(I18n.t('user_mailer.backup_ready.subject')))
         .and(have_body_text(I18n.t('user_mailer.backup_ready.explanation')))
     end
+
+    include_examples 'delivery to memorialized user'
   end
 
   describe '#terms_of_service_changed' do


### PR DESCRIPTION
A previous closed PR - https://github.com/mastodon/mastodon/pull/32210 - added these specs and a small refactor to how we stop the relevant mailers.

This PR is just the spec addition capturing the existing behavior, and only for the mailers which already have it. Future things that were never resolved on that original PR:

- Even though some mailers don't have the check, SHOULD all the mailers in there have the check?
- If so (or even if not), desirability of the `throw` refactor in there?

Figure we should at least capture the current behavior with this, and can do either of these as followup if/when answers are available.