### PR TITLE
Avoid `validate: false` save in expired poll create activity spec

### DIFF
--- a/spec/lib/activitypub/activity/create_spec.rb
+++ b/spec/lib/activitypub/activity/create_spec.rb
@@ -909,9 +909,9 @@ RSpec.describe ActivityPub::Activity::Create do
 
       context 'when a vote to an expired local poll' do
         let(:poll) do
-          poll = Fabricate.build(:poll, options: %w(Yellow Blue), expires_at: 1.day.ago)
-          poll.save(validate: false)
-          poll
+          travel_to 2.days.ago do
+            Fabricate(:poll, options: %w(Yellow Blue), expires_at: 1.day.from_now)
+          end
         end
         let!(:local_status) { Fabricate(:status, poll: poll) }
 


### PR DESCRIPTION
This is in prep for another `NOT NULL` db migration for polls.

The approach prior to this change was blowing up on that branch, because the `validate: false` here tries to persist the record before the `local_status` is properly connected, and so the new "not null status_id" constraint at db level causes issue.

Instead, travel back to when we would have created an at-the-time valid record with a future expires at, but then during actual spec run its in the past and so the expired condition still gets hit and spec still passes.

There might be other ways to rearrange this in terms of how the spec vars interact with the fabricator and the setup/before here .. but this seemed ok, and works for purposes of that other branch (I think this is last blocker, will double check on fresh DB once merged).