### PR TITLE
Remove un-needed `Poll.attached` scope

### DIFF
--- a/app/controllers/api/v1/polls/votes_controller.rb
+++ b/app/controllers/api/v1/polls/votes_controller.rb
@@ -15,7 +15,7 @@ class Api::V1::Polls::VotesController < Api::BaseController
   private
 
   def set_poll
-    @poll = Poll.attached.find(params[:poll_id])
+    @poll = Poll.find(params[:poll_id])
     authorize @poll.status, :show?
   rescue Mastodon::NotPermittedError
     not_found

--- a/app/controllers/api/v1/polls_controller.rb
+++ b/app/controllers/api/v1/polls_controller.rb
@@ -15,7 +15,7 @@ class Api::V1::PollsController < Api::BaseController
   private
 
   def set_poll
-    @poll = Poll.attached.find(params[:id])
+    @poll = Poll.find(params[:id])
     authorize @poll.status, :show?
   rescue Mastodon::NotPermittedError
     not_found

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -39,8 +39,6 @@ class Poll < ApplicationRecord
   validates :expires_at, presence: true, if: :local?
   validates_with PollValidator, on: :create, if: :local?
 
-  scope :attached, -> { where.not(status_id: nil) }
-
   before_validation :prepare_options, if: :local?
   before_validation :prepare_votes_count
   before_validation :prepare_cached_tallies

--- a/spec/models/poll_spec.rb
+++ b/spec/models/poll_spec.rb
@@ -5,25 +5,6 @@ require 'rails_helper'
 RSpec.describe Poll do
   include_examples 'Expireable'
 
-  describe 'Scopes' do
-    let(:status) { Fabricate(:status) }
-    let(:attached_poll) { Fabricate(:poll, status: status) }
-    let(:not_attached_poll) do
-      Fabricate(:poll).tap do |poll|
-        poll.status = nil
-        poll.save(validate: false)
-      end
-    end
-
-    describe '.attached' do
-      it 'finds the correct records' do
-        results = described_class.attached
-
-        expect(results).to eq([attached_poll])
-      end
-    end
-  end
-
   describe '#reset_votes!' do
     let(:poll) { Fabricate :poll, cached_tallies: [2, 3], votes_count: 5, voters_count: 5 }
     let!(:vote) { Fabricate :poll_vote, poll: }


### PR DESCRIPTION
Sort of follow-up on https://github.com/mastodon/mastodon/pull/33350 and also sort of prep for NOT NULL migration here, at which point this scope seems sort of pointless?
