### PR TITLE
Localize language names

### DIFF
--- a/app/javascript/mastodon/components/status_content.jsx
+++ b/app/javascript/mastodon/components/status_content.jsx
@@ -38,7 +38,7 @@ class TranslateButton extends PureComponent {
 
     if (translation) {
       const language     = preloadedLanguages.find(lang => lang[0] === translation.get('detected_source_language'));
-      const languageName = language ? language[2] : translation.get('detected_source_language');
+      const languageName = language ? language[1] : translation.get('detected_source_language');
       const provider     = translation.get('provider');
 
       return (

--- a/app/javascript/mastodon/initial_state.js
+++ b/app/javascript/mastodon/initial_state.js
@@ -120,7 +120,7 @@ export const statusPageUrl = getMeta('status_page_url');
 export const sso_redirect = getMeta('sso_redirect');
 export const termsOfServiceEnabled = getMeta('terms_of_service_enabled');
 
-const displayNames = new Intl.DisplayNames(getMeta('locale'), {
+const displayNames = Intl.DisplayNames && new Intl.DisplayNames(getMeta('locale'), {
   type: 'language',
   fallback: 'none',
   languageDisplay: 'standard',
@@ -128,7 +128,7 @@ const displayNames = new Intl.DisplayNames(getMeta('locale'), {
 
 export const languages = initialState?.languages?.map(lang => {
   // zh-YUE is not a valid CLDR unicode_language_id
-  return [lang[0], displayNames.of(lang[0].replace('zh-YUE', 'yue')) || lang[1], lang[2]];
+  return [lang[0], displayNames?.of(lang[0].replace('zh-YUE', 'yue')) || lang[1], lang[2]];
 });
 
 /**

--- a/app/javascript/mastodon/initial_state.js
+++ b/app/javascript/mastodon/initial_state.js
@@ -115,11 +115,22 @@ export const trendsAsLanding = getMeta('trends_as_landing_page');
 export const useBlurhash = getMeta('use_blurhash');
 export const usePendingItems = getMeta('use_pending_items');
 export const version = getMeta('version');
-export const languages = initialState?.languages;
 export const criticalUpdatesPending = initialState?.critical_updates_pending;
 export const statusPageUrl = getMeta('status_page_url');
 export const sso_redirect = getMeta('sso_redirect');
 export const termsOfServiceEnabled = getMeta('terms_of_service_enabled');
+
+const displayNames = new Intl.DisplayNames(getMeta('locale'), {
+  type: 'language',
+  fallback: 'none',
+  languageDisplay: 'standard',
+});
+
+export const languages = initialState?.languages?.map(lang => {
+  // zh-YUE is not a valid CLDR unicode_language_id
+  return [lang[0], displayNames.of(lang[0].replace('zh-YUE', 'yue')) || lang[1], lang[2]];
+});
+
 /**
  * @returns {string | undefined}
  */


### PR DESCRIPTION
Instead of showing all language names in English regardless of the current locale, localize language names using [Intl.DisplayNames](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames).

Screenshot of language selector with German locale:
<img width="331" alt="Mastodon language selector dropdown with each language name displayed in its native language followed by the German name of the language" src="https://github.com/user-attachments/assets/0c9ee6fe-c92c-4dcd-bd75-3c77c1f22f57" />

Screenshot of translated status displaying the German name of the source language:
<img width="613" alt="Screenshot of status translated to German with the text &quot;Aus Englisch mittels LibreTranslate übersetzt&quot;" src="https://github.com/user-attachments/assets/02cfbb41-3475-4f92-8943-4d0f5ffd7840" />
