### PR TITLE
Fix intermittent failure on ap/activity/create spec timestamp check

### DIFF
--- a/spec/lib/activitypub/activity/create_spec.rb
+++ b/spec/lib/activitypub/activity/create_spec.rb
@@ -768,7 +768,7 @@ RSpec.describe ActivityPub::Activity::Create do
           expect { subject.perform }
             .to change(sender.statuses, :count).by(1)
             .and change { sender.featured_tags.first.reload.statuses_count }.by(1)
-            .and change { sender.featured_tags.first.reload.last_status_at }.from(nil).to(be_within(0.1).of(Time.now.utc))
+            .and change { sender.featured_tags.first.reload.last_status_at }.from(nil).to(be_present)
 
           status = sender.statuses.first
 


### PR DESCRIPTION
Has been source of some (intermittent, but apparently sort of frequent?) timing failures - https://github.com/mastodon/mastodon/actions/runs/12507993576/job/34895506277 / https://github.com/mastodon/mastodon/actions/runs/12485259487/job/34843828447 / https://github.com/mastodon/mastodon/actions/runs/12474029891/job/34815520294

Change here is to just care about the value changing, but drop precision about what it changed to. Seems fine given larger context ... but if we want to preserve some value check, I'd do one/both of a) assign a local variable to current time right before the `perform` runs, instead of at time of comparison, b) relax the window to larger value than `0.1`.

I suspect this is much more likely to fail on CI than local envs ... I had to make the within value very very low to get a local failure.