### PR TITLE
Fix keyboard shortcut for open status

### DIFF
--- a/app/javascript/mastodon/components/status.jsx
+++ b/app/javascript/mastodon/components/status.jsx
@@ -290,10 +290,10 @@ class Status extends ImmutablePureComponent {
 
     const path = `/@${status.getIn(['account', 'acct'])}/${status.get('id')}`;
 
-    if (e?.button === 0 && !(e?.ctrlKey || e?.metaKey)) {
-      history.push(path);
-    } else if (e?.button === 1 || (e?.button === 0 && (e?.ctrlKey || e?.metaKey))) {
+    if (e?.button === 1 || (e?.button === 0 && (e?.ctrlKey || e?.metaKey))) {
       window.open(path, '_blank', 'noopener');
+    } else {
+      history.push(path);
     }
   };
 


### PR DESCRIPTION
#32988 Only considered mouse clicks, So keyboard shortcut <kbd>o</kbd>, <kbd>enter</kbd> was broken.