### PR TITLE
Fix WebUI erroneously stopping to offer expanding search results after second page

### DIFF
--- a/app/javascript/mastodon/actions/search.ts
+++ b/app/javascript/mastodon/actions/search.ts
@@ -56,7 +56,7 @@ export const expandSearch = createDataLoadingThunk(
     return apiGetSearch({
       q,
       type,
-      limit: 11,
+      limit: 10,
       offset,
     });
   },


### PR DESCRIPTION
Partially addresses #33427

The logic is still brittle, but this PR will at least fix search results erroneously offering only two pages of results in most cases