### PR TITLE
Fix processing of incoming notifications for unfilterable types

### DIFF
--- a/app/javascript/mastodon/actions/notification_groups.ts
+++ b/app/javascript/mastodon/actions/notification_groups.ts
@@ -155,7 +155,7 @@ export const processNewNotificationForGroups = createAppAsyncThunk(
 
     const showInColumn =
       activeFilter === 'all'
-        ? notificationShows[notification.type]
+        ? notificationShows[notification.type] !== false
         : activeFilter === notification.type;
 
     if (!showInColumn) return;


### PR DESCRIPTION
This fixes new notifications of types `moderation_warning`, `severed_relationships` or `annual_report` not being inserted from streaming in the client-side code.

This is because notifications that can't be turned off don't have a settings entry, so the check returns `undefined` which is falsy.