### PR TITLE
improve search-field's handling of drag-and-drop & raw URLs

### DIFF
--- a/app/javascript/mastodon/features/compose/components/search.tsx
+++ b/app/javascript/mastodon/features/compose/components/search.tsx
@@ -451,6 +451,33 @@ export const Search: React.FC<{
     setSelectedOption(-1);
   }, [setExpanded, setSelectedOption]);
 
+  const handleDragOver = useCallback(
+    (event: React.DragEvent<HTMLInputElement>) => {
+      event.preventDefault();
+    },
+    [],
+  );
+  const handleDrop = useCallback(
+    (event: React.DragEvent<HTMLInputElement>) => {
+      event.preventDefault();
+
+      handleClear();
+
+      const query =
+        event.dataTransfer.getData('URL') ||
+        event.dataTransfer.getData('text/plain');
+
+      Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        'value',
+      )?.set?.call(event.target, query);
+
+      event.currentTarget.focus();
+      event.target.dispatchEvent(new Event('change', { bubbles: true }));
+    },
+    [handleClear],
+  );
+
   return (
     <form className={classNames('search', { active: expanded })}>
       <input
@@ -468,6 +495,8 @@ export const Search: React.FC<{
         onKeyDown={handleKeyDown}
         onFocus={handleFocus}
         onBlur={handleBlur}
+        onDragOver={handleDragOver}
+        onDrop={handleDrop}
       />
 
       <button type='button' className='search__icon' onClick={handleClear}>


### PR DESCRIPTION
This is an updated version of https://github.com/mastodon/mastodon/pull/27827
to account for the changeover from jsx to tsx plus additional features of search functionality.

This PR accomplishes two things: 1. it allows repeated drag & drop interactions with the search box to replace entirely its previous entry with the newly dropped text (rather than interleaving them); and 2. it extracts things like possible tag or account references from raw URLs, the way it already did for search strings with `#` or `@` characters in them