### PR TITLE
Add upper limit to ruby version range in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
-ruby '>= 3.2.0'
+ruby '>= 3.2.0', '< 3.4'
 
 gem 'propshaft'
 gem 'puma', '~> 6.3'


### PR DESCRIPTION
A few recent renovate PRs are failing because the renovate side is (I assume?) using the latest allowed ruby version to run the changes, and then failing on the bundle step (but opening the PR anyway?).

This is a temporary work-around to hopefully allow renovate to function correctly until https://github.com/mastodon/mastodon/pull/33304 is ready. Will update that one to remove this limit whenever I convert it from draft to ready.