### PR TITLE
Add role-specific user fabricators

### DIFF
--- a/spec/controllers/admin/account_actions_controller_spec.rb
+++ b/spec/controllers/admin/account_actions_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Admin::AccountActionsController do
   render_views
 
-  let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:user) { Fabricate(:admin_user) }
 
   before do
     sign_in user, scope: :user

--- a/spec/controllers/admin/accounts_controller_spec.rb
+++ b/spec/controllers/admin/accounts_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Admin::AccountsController do
   before { sign_in current_user, scope: :user }
 
   describe 'GET #index' do
-    let(:current_user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+    let(:current_user) { Fabricate(:admin_user) }
     let(:params) do
       {
         origin: 'local',
@@ -53,7 +53,7 @@ RSpec.describe Admin::AccountsController do
   end
 
   describe 'GET #show' do
-    let(:current_user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+    let(:current_user) { Fabricate(:admin_user) }
 
     describe 'account moderation notes' do
       let(:account) { Fabricate(:account) }

--- a/spec/controllers/admin/action_logs_controller_spec.rb
+++ b/spec/controllers/admin/action_logs_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Admin::ActionLogsController do
 
   describe 'GET #index' do
     it 'returns 200' do
-      sign_in Fabricate(:user, role: UserRole.find_by(name: 'Admin'))
+      sign_in Fabricate(:admin_user)
       get :index, params: { page: 1 }
 
       expect(response).to have_http_status(200)

--- a/spec/controllers/admin/base_controller_spec.rb
+++ b/spec/controllers/admin/base_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Admin::BaseController do
 
   it 'returns private cache control headers' do
     routes.draw { get 'success' => 'admin/base#success' }
-    sign_in(Fabricate(:user, role: UserRole.find_by(name: 'Moderator')))
+    sign_in(Fabricate(:moderator_user))
     get :success
 
     expect(response.headers['Cache-Control']).to include('private, no-store')
@@ -28,14 +28,14 @@ RSpec.describe Admin::BaseController do
 
   it 'renders admin layout as a moderator' do
     routes.draw { get 'success' => 'admin/base#success' }
-    sign_in(Fabricate(:user, role: UserRole.find_by(name: 'Moderator')))
+    sign_in(Fabricate(:moderator_user))
     get :success
     expect(response).to render_template layout: 'admin'
   end
 
   it 'renders admin layout as an admin' do
     routes.draw { get 'success' => 'admin/base#success' }
-    sign_in(Fabricate(:user, role: UserRole.find_by(name: 'Admin')))
+    sign_in(Fabricate(:admin_user))
     get :success
     expect(response).to render_template layout: 'admin'
   end

--- a/spec/controllers/admin/change_emails_controller_spec.rb
+++ b/spec/controllers/admin/change_emails_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Admin::ChangeEmailsController do
   render_views
 
-  let(:admin) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:admin) { Fabricate(:admin_user) }
 
   before do
     sign_in admin

--- a/spec/controllers/admin/confirmations_controller_spec.rb
+++ b/spec/controllers/admin/confirmations_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Admin::ConfirmationsController do
   render_views
 
   before do
-    sign_in Fabricate(:user, role: UserRole.find_by(name: 'Admin')), scope: :user
+    sign_in Fabricate(:admin_user), scope: :user
   end
 
   describe 'POST #create' do

--- a/spec/controllers/admin/dashboard_controller_spec.rb
+++ b/spec/controllers/admin/dashboard_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Admin::DashboardController do
   render_views
 
   describe 'GET #index' do
-    let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Owner')) }
+    let(:user) { Fabricate(:owner_user) }
 
     before do
       stub_system_checks

--- a/spec/controllers/admin/disputes/appeals_controller_spec.rb
+++ b/spec/controllers/admin/disputes/appeals_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Admin::Disputes::AppealsController do
   let(:appeal) { Fabricate(:appeal, strike: strike, account: target_account) }
 
   describe 'GET #index' do
-    let(:current_user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+    let(:current_user) { Fabricate(:admin_user) }
 
     before { appeal }
 
@@ -32,7 +32,7 @@ RSpec.describe Admin::Disputes::AppealsController do
   describe 'POST #approve' do
     subject { post :approve, params: { id: appeal.id } }
 
-    let(:current_user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+    let(:current_user) { Fabricate(:admin_user) }
 
     it 'redirects back to the strike page and notifies target account about approved appeal', :inline_jobs do
       emails = capture_emails { subject }
@@ -56,7 +56,7 @@ RSpec.describe Admin::Disputes::AppealsController do
   describe 'POST #reject' do
     subject { post :reject, params: { id: appeal.id } }
 
-    let(:current_user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+    let(:current_user) { Fabricate(:admin_user) }
 
     it 'redirects back to the strike page and notifies target account about rejected appeal', :inline_jobs do
       emails = capture_emails { subject }

--- a/spec/controllers/admin/domain_blocks_controller_spec.rb
+++ b/spec/controllers/admin/domain_blocks_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Admin::DomainBlocksController do
   render_views
 
   before do
-    sign_in Fabricate(:user, role: UserRole.find_by(name: 'Admin')), scope: :user
+    sign_in Fabricate(:admin_user), scope: :user
   end
 
   describe 'GET #new' do

--- a/spec/controllers/admin/email_domain_blocks_controller_spec.rb
+++ b/spec/controllers/admin/email_domain_blocks_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Admin::EmailDomainBlocksController do
   render_views
 
   before do
-    sign_in Fabricate(:user, role: UserRole.find_by(name: 'Admin')), scope: :user
+    sign_in Fabricate(:admin_user), scope: :user
   end
 
   describe 'GET #index' do

--- a/spec/controllers/admin/export_domain_allows_controller_spec.rb
+++ b/spec/controllers/admin/export_domain_allows_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Admin::ExportDomainAllowsController do
   render_views
 
   before do
-    sign_in Fabricate(:user, role: UserRole.find_by(name: 'Admin')), scope: :user
+    sign_in Fabricate(:admin_user), scope: :user
   end
 
   describe 'GET #new' do

--- a/spec/controllers/admin/export_domain_blocks_controller_spec.rb
+++ b/spec/controllers/admin/export_domain_blocks_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Admin::ExportDomainBlocksController do
   render_views
 
   before do
-    sign_in Fabricate(:user, role: UserRole.find_by(name: 'Admin')), scope: :user
+    sign_in Fabricate(:admin_user), scope: :user
   end
 
   describe 'GET #new' do

--- a/spec/controllers/admin/follow_recommendations_controller_spec.rb
+++ b/spec/controllers/admin/follow_recommendations_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Admin::FollowRecommendationsController do
   render_views
 
-  let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:user) { Fabricate(:admin_user) }
 
   before do
     sign_in user, scope: :user

--- a/spec/controllers/admin/instances_controller_spec.rb
+++ b/spec/controllers/admin/instances_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Admin::InstancesController do
   render_views
 
-  let(:current_user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:current_user) { Fabricate(:admin_user) }
 
   let!(:account_popular_main) { Fabricate(:account, domain: 'popular') }
 

--- a/spec/controllers/admin/relationships_controller_spec.rb
+++ b/spec/controllers/admin/relationships_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Admin::RelationshipsController do
   render_views
 
-  let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:user) { Fabricate(:admin_user) }
 
   before do
     sign_in user, scope: :user

--- a/spec/controllers/admin/reports/actions_controller_spec.rb
+++ b/spec/controllers/admin/reports/actions_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Admin::Reports::ActionsController do
   render_views
 
-  let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:user) { Fabricate(:admin_user) }
 
   before do
     sign_in user, scope: :user

--- a/spec/controllers/admin/reports_controller_spec.rb
+++ b/spec/controllers/admin/reports_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Admin::ReportsController do
   render_views
 
-  let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:user) { Fabricate(:admin_user) }
 
   before do
     sign_in user, scope: :user

--- a/spec/controllers/admin/settings/branding_controller_spec.rb
+++ b/spec/controllers/admin/settings/branding_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Admin::Settings::BrandingController do
 
   describe 'When signed in as an admin' do
     before do
-      sign_in Fabricate(:user, role: UserRole.find_by(name: 'Admin')), scope: :user
+      sign_in Fabricate(:admin_user), scope: :user
     end
 
     describe 'PUT #update' do

--- a/spec/controllers/admin/site_uploads_controller_spec.rb
+++ b/spec/controllers/admin/site_uploads_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Admin::SiteUploadsController do
   render_views
 
-  let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:user) { Fabricate(:admin_user) }
 
   before do
     sign_in user, scope: :user

--- a/spec/controllers/admin/statuses_controller_spec.rb
+++ b/spec/controllers/admin/statuses_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Admin::StatusesController do
   render_views
 
-  let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:user) { Fabricate(:admin_user) }
   let(:account) { Fabricate(:account) }
   let!(:status) { Fabricate(:status, account: account) }
   let(:media_attached_status) { Fabricate(:status, account: account, sensitive: !sensitive) }

--- a/spec/controllers/admin/terms_of_service/distributions_controller_spec.rb
+++ b/spec/controllers/admin/terms_of_service/distributions_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Admin::TermsOfService::DistributionsController do
   render_views
 
-  let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:user) { Fabricate(:admin_user) }
   let(:terms_of_service) { Fabricate(:terms_of_service, notification_sent_at: nil) }
 
   before do

--- a/spec/controllers/admin/terms_of_service/drafts_controller_spec.rb
+++ b/spec/controllers/admin/terms_of_service/drafts_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Admin::TermsOfService::DraftsController do
   render_views
 
-  let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:user) { Fabricate(:admin_user) }
 
   before do
     sign_in user, scope: :user

--- a/spec/controllers/admin/terms_of_service/generates_controller_spec.rb
+++ b/spec/controllers/admin/terms_of_service/generates_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Admin::TermsOfService::GeneratesController do
   render_views
 
-  let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:user) { Fabricate(:admin_user) }
 
   before do
     sign_in user, scope: :user

--- a/spec/controllers/admin/terms_of_service/histories_controller_spec.rb
+++ b/spec/controllers/admin/terms_of_service/histories_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Admin::TermsOfService::HistoriesController do
   render_views
 
-  let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:user) { Fabricate(:admin_user) }
 
   before do
     sign_in user, scope: :user

--- a/spec/controllers/admin/terms_of_service/previews_controller_spec.rb
+++ b/spec/controllers/admin/terms_of_service/previews_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Admin::TermsOfService::PreviewsController do
   render_views
 
-  let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:user) { Fabricate(:admin_user) }
   let(:terms_of_service) { Fabricate(:terms_of_service, notification_sent_at: nil) }
 
   before do

--- a/spec/controllers/admin/terms_of_service/tests_controller_spec.rb
+++ b/spec/controllers/admin/terms_of_service/tests_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Admin::TermsOfService::TestsController do
   render_views
 
-  let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:user) { Fabricate(:admin_user) }
   let(:terms_of_service) { Fabricate(:terms_of_service, notification_sent_at: nil) }
 
   before do

--- a/spec/controllers/admin/terms_of_service_controller_spec.rb
+++ b/spec/controllers/admin/terms_of_service_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Admin::TermsOfServiceController do
   render_views
 
-  let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:user) { Fabricate(:admin_user) }
 
   before do
     sign_in user, scope: :user

--- a/spec/controllers/admin/trends/links/preview_card_providers_controller_spec.rb
+++ b/spec/controllers/admin/trends/links/preview_card_providers_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Admin::Trends::Links::PreviewCardProvidersController do
   render_views
 
-  let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:user) { Fabricate(:admin_user) }
 
   before do
     sign_in user, scope: :user

--- a/spec/controllers/admin/trends/links_controller_spec.rb
+++ b/spec/controllers/admin/trends/links_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Admin::Trends::LinksController do
   render_views
 
-  let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:user) { Fabricate(:admin_user) }
 
   before do
     sign_in user, scope: :user

--- a/spec/controllers/admin/trends/statuses_controller_spec.rb
+++ b/spec/controllers/admin/trends/statuses_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Admin::Trends::StatusesController do
   render_views
 
-  let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:user) { Fabricate(:admin_user) }
 
   before do
     sign_in user, scope: :user

--- a/spec/controllers/admin/trends/tags_controller_spec.rb
+++ b/spec/controllers/admin/trends/tags_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Admin::Trends::TagsController do
   render_views
 
-  let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:user) { Fabricate(:admin_user) }
 
   before do
     sign_in user, scope: :user

--- a/spec/controllers/admin/users/two_factor_authentications_controller_spec.rb
+++ b/spec/controllers/admin/users/two_factor_authentications_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Admin::Users::TwoFactorAuthenticationsController do
   let(:user) { Fabricate(:user) }
 
   before do
-    sign_in Fabricate(:user, role: UserRole.find_by(name: 'Admin')), scope: :user
+    sign_in Fabricate(:admin_user), scope: :user
   end
 
   describe 'DELETE #destroy' do

--- a/spec/controllers/admin/warning_presets_controller_spec.rb
+++ b/spec/controllers/admin/warning_presets_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Admin::WarningPresetsController do
   render_views
 
-  let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:user) { Fabricate(:admin_user) }
 
   before do
     sign_in user, scope: :user

--- a/spec/controllers/admin/webhooks/secrets_controller_spec.rb
+++ b/spec/controllers/admin/webhooks/secrets_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Admin::Webhooks::SecretsController do
   render_views
 
-  let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:user) { Fabricate(:admin_user) }
 
   before do
     sign_in user, scope: :user

--- a/spec/fabricators/user_fabricator.rb
+++ b/spec/fabricators/user_fabricator.rb
@@ -21,3 +21,7 @@ end
 Fabricator(:moderator_user, from: :user) do
   role UserRole.find_by(name: 'Moderator')
 end
+
+Fabricator(:owner_user, from: :user) do
+  role UserRole.find_by(name: 'Owner')
+end

--- a/spec/fabricators/user_fabricator.rb
+++ b/spec/fabricators/user_fabricator.rb
@@ -13,3 +13,11 @@ Fabricator(:user) do
   current_sign_in_at { Time.zone.now }
   agreement true
 end
+
+Fabricator(:admin_user, from: :user) do
+  role UserRole.find_by(name: 'Admin')
+end
+
+Fabricator(:moderator_user, from: :user) do
+  role UserRole.find_by(name: 'Moderator')
+end

--- a/spec/models/admin/account_action_spec.rb
+++ b/spec/models/admin/account_action_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Admin::AccountAction do
   describe '#save!' do
     subject              { account_action.save! }
 
-    let(:account)        { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
+    let(:account)        { Fabricate(:admin_user).account }
     let(:target_account) { Fabricate(:account) }
     let(:type)           { 'disable' }
 

--- a/spec/models/form/account_batch_spec.rb
+++ b/spec/models/form/account_batch_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Form::AccountBatch do
   describe '#save' do
     subject           { account_batch.save }
 
-    let(:account)     { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
+    let(:account)     { Fabricate(:admin_user).account }
     let(:account_ids) { [] }
     let(:query)       { Account.none }
 

--- a/spec/models/form/custom_emoji_batch_spec.rb
+++ b/spec/models/form/custom_emoji_batch_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Form::CustomEmojiBatch do
     subject { described_class.new({ current_account: account }.merge(options)) }
 
     let(:options) { {} }
-    let(:account) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
+    let(:account) { Fabricate(:admin_user).account }
 
     context 'with empty custom_emoji_ids' do
       let(:options) { { custom_emoji_ids: [] } }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -601,7 +601,7 @@ RSpec.describe User do
   end
 
   describe '.those_who_can' do
-    before { Fabricate(:user, role: UserRole.find_by(name: 'Moderator')) }
+    before { Fabricate(:moderator_user) }
 
     context 'when there are not any user roles' do
       before { UserRole.destroy_all }
@@ -618,7 +618,7 @@ RSpec.describe User do
     end
 
     context 'when there are users with roles' do
-      let!(:admin_user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+      let!(:admin_user) { Fabricate(:admin_user) }
 
       it 'returns the users with the role' do
         expect(described_class.those_who_can(:manage_blocks)).to eq([admin_user])

--- a/spec/models/webhook_spec.rb
+++ b/spec/models/webhook_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Webhook do
       subject { Fabricate.build :webhook, current_account: account }
 
       context 'with account that has permissions' do
-        let(:account) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
+        let(:account) { Fabricate(:admin_user).account }
 
         it { is_expected.to allow_values(%w(account.created)).for(:events) }
       end

--- a/spec/policies/account_moderation_note_policy_spec.rb
+++ b/spec/policies/account_moderation_note_policy_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe AccountModerationNotePolicy do
   subject { described_class }
 
-  let(:admin)   { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
+  let(:admin)   { Fabricate(:admin_user).account }
   let(:john)    { Fabricate(:account) }
 
   permissions :create? do

--- a/spec/policies/account_policy_spec.rb
+++ b/spec/policies/account_policy_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe AccountPolicy do
   subject { described_class }
 
-  let(:admin)   { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
+  let(:admin)   { Fabricate(:admin_user).account }
   let(:john)    { Fabricate(:account) }
   let(:alice)   { Fabricate(:account) }
 
@@ -70,7 +70,7 @@ RSpec.describe AccountPolicy do
   end
 
   permissions :suspend?, :silence? do
-    let(:staff) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
+    let(:staff) { Fabricate(:admin_user).account }
 
     context 'when staff' do
       context 'when record is staff' do
@@ -94,7 +94,7 @@ RSpec.describe AccountPolicy do
   end
 
   permissions :memorialize? do
-    let(:other_admin) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
+    let(:other_admin) { Fabricate(:admin_user).account }
 
     context 'when admin' do
       context 'when record is admin' do

--- a/spec/policies/account_warning_policy_spec.rb
+++ b/spec/policies/account_warning_policy_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe AccountWarningPolicy do
   subject { described_class }
 
-  let(:admin) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
+  let(:admin) { Fabricate(:admin_user).account }
   let(:account) { Fabricate(:account) }
 
   permissions :show? do

--- a/spec/policies/account_warning_preset_policy_spec.rb
+++ b/spec/policies/account_warning_preset_policy_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe AccountWarningPresetPolicy do
   let(:policy) { described_class }
-  let(:admin)   { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
+  let(:admin)   { Fabricate(:admin_user).account }
   let(:john)    { Fabricate(:account) }
 
   permissions :index?, :create?, :update?, :destroy? do

--- a/spec/policies/admin/status_policy_spec.rb
+++ b/spec/policies/admin/status_policy_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Admin::StatusPolicy do
   let(:policy) { described_class }
-  let(:admin)   { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
+  let(:admin)   { Fabricate(:admin_user).account }
   let(:john)    { Fabricate(:account) }
   let(:status) { Fabricate(:status, visibility: status_visibility) }
   let(:status_visibility) { :public }

--- a/spec/policies/announcement_policy_spec.rb
+++ b/spec/policies/announcement_policy_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe AnnouncementPolicy do
   let(:policy) { described_class }
-  let(:admin)   { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
+  let(:admin)   { Fabricate(:admin_user).account }
   let(:john)    { Fabricate(:account) }
 
   permissions :index?, :create?, :update?, :destroy? do

--- a/spec/policies/appeal_policy_spec.rb
+++ b/spec/policies/appeal_policy_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe AppealPolicy do
   let(:policy) { described_class }
-  let(:admin)   { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
+  let(:admin)   { Fabricate(:admin_user).account }
   let(:john)    { Fabricate(:account) }
   let(:appeal) { Fabricate(:appeal) }
 

--- a/spec/policies/audit_log_policy_spec.rb
+++ b/spec/policies/audit_log_policy_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe AuditLogPolicy do
   subject { described_class }
 
-  let(:admin) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
+  let(:admin) { Fabricate(:admin_user).account }
   let(:account) { Fabricate(:account) }
 
   permissions :index? do

--- a/spec/policies/canonical_email_block_policy_spec.rb
+++ b/spec/policies/canonical_email_block_policy_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe CanonicalEmailBlockPolicy do
   let(:policy) { described_class }
-  let(:admin)   { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
+  let(:admin)   { Fabricate(:admin_user).account }
   let(:john)    { Fabricate(:account) }
 
   permissions :index?, :show?, :test?, :create?, :destroy? do

--- a/spec/policies/custom_emoji_policy_spec.rb
+++ b/spec/policies/custom_emoji_policy_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe CustomEmojiPolicy do
   subject { described_class }
 
-  let(:admin)   { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
+  let(:admin)   { Fabricate(:admin_user).account }
   let(:john)    { Fabricate(:account) }
 
   permissions :index?, :enable?, :disable? do

--- a/spec/policies/dashboard_policy_spec.rb
+++ b/spec/policies/dashboard_policy_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe DashboardPolicy do
   subject { described_class }
 
-  let(:admin) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
+  let(:admin) { Fabricate(:admin_user).account }
   let(:account) { Fabricate(:account) }
 
   permissions :index? do

--- a/spec/policies/delivery_policy_spec.rb
+++ b/spec/policies/delivery_policy_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe DeliveryPolicy do
   let(:policy) { described_class }
-  let(:admin)   { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
+  let(:admin)   { Fabricate(:admin_user).account }
   let(:john)    { Fabricate(:account) }
 
   permissions :clear_delivery_errors?, :restart_delivery?, :stop_delivery? do

--- a/spec/policies/domain_allow_policy_spec.rb
+++ b/spec/policies/domain_allow_policy_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe DomainAllowPolicy do
   subject { described_class }
 
-  let(:admin)   { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
+  let(:admin)   { Fabricate(:admin_user).account }
   let(:john)    { Fabricate(:account) }
 
   permissions :index?, :show?, :create?, :destroy? do

--- a/spec/policies/domain_block_policy_spec.rb
+++ b/spec/policies/domain_block_policy_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe DomainBlockPolicy do
   subject { described_class }
 
-  let(:admin)   { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
+  let(:admin)   { Fabricate(:admin_user).account }
   let(:john)    { Fabricate(:account) }
 
   permissions :index?, :show?, :create?, :destroy?, :update? do

--- a/spec/policies/email_domain_block_policy_spec.rb
+++ b/spec/policies/email_domain_block_policy_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe EmailDomainBlockPolicy do
   subject { described_class }
 
-  let(:admin)   { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
+  let(:admin)   { Fabricate(:admin_user).account }
   let(:john)    { Fabricate(:account) }
 
   permissions :index?, :show?, :create?, :destroy? do

--- a/spec/policies/follow_recommendation_policy_spec.rb
+++ b/spec/policies/follow_recommendation_policy_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe FollowRecommendationPolicy do
   let(:policy) { described_class }
-  let(:admin)   { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
+  let(:admin)   { Fabricate(:admin_user).account }
   let(:john)    { Fabricate(:account) }
 
   permissions :show?, :suppress?, :unsuppress? do

--- a/spec/policies/instance_policy_spec.rb
+++ b/spec/policies/instance_policy_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe InstancePolicy do
   subject { described_class }
 
-  let(:admin)   { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
+  let(:admin)   { Fabricate(:admin_user).account }
   let(:john)    { Fabricate(:account) }
 
   permissions :index?, :show?, :destroy? do

--- a/spec/policies/invite_policy_spec.rb
+++ b/spec/policies/invite_policy_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe InvitePolicy do
   subject { described_class }
 
-  let(:admin)   { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
+  let(:admin)   { Fabricate(:admin_user).account }
   let(:john)    { Fabricate(:user).account }
 
   permissions :index? do

--- a/spec/policies/ip_block_policy_spec.rb
+++ b/spec/policies/ip_block_policy_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe IpBlockPolicy do
   let(:policy) { described_class }
-  let(:admin)   { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
+  let(:admin)   { Fabricate(:admin_user).account }
   let(:john)    { Fabricate(:account) }
 
   permissions :index?, :show?, :create?, :update?, :destroy? do

--- a/spec/policies/preview_card_policy_spec.rb
+++ b/spec/policies/preview_card_policy_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe PreviewCardPolicy do
   let(:policy) { described_class }
-  let(:admin)   { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
+  let(:admin)   { Fabricate(:admin_user).account }
   let(:john)    { Fabricate(:account) }
 
   permissions :index?, :review? do

--- a/spec/policies/preview_card_provider_policy_spec.rb
+++ b/spec/policies/preview_card_provider_policy_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe PreviewCardProviderPolicy do
   let(:policy) { described_class }
-  let(:admin)   { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
+  let(:admin)   { Fabricate(:admin_user).account }
   let(:john)    { Fabricate(:account) }
 
   permissions :index?, :review? do

--- a/spec/policies/relay_policy_spec.rb
+++ b/spec/policies/relay_policy_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe RelayPolicy do
   subject { described_class }
 
-  let(:admin)   { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
+  let(:admin)   { Fabricate(:admin_user).account }
   let(:john)    { Fabricate(:account) }
 
   permissions :update? do

--- a/spec/policies/report_note_policy_spec.rb
+++ b/spec/policies/report_note_policy_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe ReportNotePolicy do
   subject { described_class }
 
-  let(:admin)   { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
+  let(:admin)   { Fabricate(:admin_user).account }
   let(:john)    { Fabricate(:account) }
 
   permissions :create? do

--- a/spec/policies/report_policy_spec.rb
+++ b/spec/policies/report_policy_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe ReportPolicy do
   subject { described_class }
 
-  let(:admin)   { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
+  let(:admin)   { Fabricate(:admin_user).account }
   let(:john)    { Fabricate(:account) }
 
   permissions :update?, :index?, :show? do

--- a/spec/policies/rule_policy_spec.rb
+++ b/spec/policies/rule_policy_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe RulePolicy do
   let(:policy) { described_class }
-  let(:admin)   { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
+  let(:admin)   { Fabricate(:admin_user).account }
   let(:john)    { Fabricate(:account) }
 
   permissions :index?, :create?, :update?, :destroy? do

--- a/spec/policies/settings_policy_spec.rb
+++ b/spec/policies/settings_policy_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe SettingsPolicy do
   subject { described_class }
 
-  let(:admin)   { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
+  let(:admin)   { Fabricate(:admin_user).account }
   let(:john)    { Fabricate(:account) }
 
   permissions :update?, :show?, :destroy? do

--- a/spec/policies/software_update_policy_spec.rb
+++ b/spec/policies/software_update_policy_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe SoftwareUpdatePolicy do
   subject { described_class }
 
-  let(:admin)   { Fabricate(:user, role: UserRole.find_by(name: 'Owner')).account }
+  let(:admin)   { Fabricate(:owner_user).account }
   let(:john)    { Fabricate(:account) }
 
   permissions :index? do

--- a/spec/policies/status_policy_spec.rb
+++ b/spec/policies/status_policy_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe StatusPolicy, type: :model do
   subject { described_class }
 
-  let(:admin) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:admin) { Fabricate(:admin_user) }
   let(:alice) { Fabricate(:account, username: 'alice') }
   let(:bob) { Fabricate(:account, username: 'bob') }
   let(:status) { Fabricate(:status, account: alice) }

--- a/spec/policies/tag_policy_spec.rb
+++ b/spec/policies/tag_policy_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe TagPolicy do
   subject { described_class }
 
-  let(:admin)   { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
+  let(:admin)   { Fabricate(:admin_user).account }
   let(:john)    { Fabricate(:account) }
 
   permissions :index?, :show?, :update?, :review? do

--- a/spec/policies/terms_of_service_policy_spec.rb
+++ b/spec/policies/terms_of_service_policy_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe TermsOfServicePolicy do
   subject { described_class }
 
-  let(:admin) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
+  let(:admin) { Fabricate(:admin_user).account }
   let(:john) { Fabricate(:account) }
 
   permissions :index?, :create? do

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe UserPolicy do
   subject { described_class }
 
-  let(:admin)   { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
+  let(:admin)   { Fabricate(:admin_user).account }
   let(:john)    { Fabricate(:account) }
 
   permissions :reset_password?, :change_email? do

--- a/spec/policies/user_role_policy_spec.rb
+++ b/spec/policies/user_role_policy_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe UserRolePolicy do
   subject { described_class }
 
-  let(:admin) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
+  let(:admin) { Fabricate(:admin_user).account }
   let(:account) { Fabricate(:account) }
 
   permissions :index?, :create? do

--- a/spec/policies/webhook_policy_spec.rb
+++ b/spec/policies/webhook_policy_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe WebhookPolicy do
   let(:policy) { described_class }
-  let(:admin)   { Fabricate(:user, role: UserRole.find_by(name: 'Admin')).account }
+  let(:admin)   { Fabricate(:admin_user).account }
   let(:john)    { Fabricate(:account) }
 
   permissions :index?, :create? do

--- a/spec/requests/api/v1/admin/dimensions_spec.rb
+++ b/spec/requests/api/v1/admin/dimensions_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Admin Dimensions' do
-  let(:user)    { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:user)    { Fabricate(:admin_user) }
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
   let(:account) { Fabricate(:account) }

--- a/spec/requests/api/v1/admin/measures_spec.rb
+++ b/spec/requests/api/v1/admin/measures_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Admin Measures' do
-  let(:user)    { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:user)    { Fabricate(:admin_user) }
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
   let(:account) { Fabricate(:account) }

--- a/spec/requests/api/v1/admin/retention_spec.rb
+++ b/spec/requests/api/v1/admin/retention_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Admin Retention' do
-  let(:user)    { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:user)    { Fabricate(:admin_user) }
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
   let(:account) { Fabricate(:account) }

--- a/spec/requests/api/v1/reports_spec.rb
+++ b/spec/requests/api/v1/reports_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Reports' do
       post '/api/v1/reports', headers: headers, params: params
     end
 
-    let!(:admin)         { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+    let!(:admin)         { Fabricate(:admin_user) }
     let(:status)         { Fabricate(:status) }
     let(:target_account) { status.account }
     let(:category)       { 'other' }

--- a/spec/requests/cache_spec.rb
+++ b/spec/requests/cache_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe 'Caching behavior' do
 
   before_all do
     alice = Fabricate(:account, username: 'alice')
-    user = Fabricate(:user, email: 'user@host.example', role: UserRole.find_by(name: 'Moderator'))
+    user = Fabricate(:moderator_user, email: 'user@host.example')
     status = Fabricate(:status, account: alice, id: 110_224_538_612_341_312)
     Fabricate(:status, account: alice, id: 110_224_538_643_211_312, visibility: :private)
     Fabricate(:invite, code: 'abcdef')

--- a/spec/services/appeal_service_spec.rb
+++ b/spec/services/appeal_service_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe AppealService, :inline_jobs do
   describe '#call' do
-    let!(:admin) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+    let!(:admin) { Fabricate(:admin_user) }
 
     context 'with an existing strike' do
       let(:strike) { Fabricate(:account_warning) }

--- a/spec/services/software_update_check_service_spec.rb
+++ b/spec/services/software_update_check_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe SoftwareUpdateCheckService do
     let(:full_update_check_url) { "#{update_check_url}?version=#{Mastodon::Version.to_s.split('+')[0]}" }
 
     let(:devops_role)     { Fabricate(:user_role, name: 'DevOps', permissions: UserRole::FLAGS[:view_devops]) }
-    let(:owner_user)      { Fabricate(:user, role: UserRole.find_by(name: 'Owner')) }
+    let(:owner_user)      { Fabricate(:owner_user) }
     let(:old_devops_user) { Fabricate(:user) }
     let(:none_user)       { Fabricate(:user, role: devops_role) }
     let(:patch_user)      { Fabricate(:user, role: devops_role) }

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -2,7 +2,7 @@
 
 module SystemHelpers
   def admin_user
-    Fabricate(:user, role: UserRole.find_by(name: 'Admin'))
+    Fabricate(:admin_user)
   end
 
   def submit_button

--- a/spec/system/admin/account_moderation_notes_spec.rb
+++ b/spec/system/admin/account_moderation_notes_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Admin::AccountModerationNotes' do
-  let(:current_user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:current_user) { Fabricate(:admin_user) }
   let(:target_account) { Fabricate(:account) }
 
   before { sign_in current_user }

--- a/spec/system/admin/accounts_spec.rb
+++ b/spec/system/admin/accounts_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Admin::Accounts' do
-  let(:current_user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:current_user) { Fabricate(:admin_user) }
 
   before do
     sign_in current_user

--- a/spec/system/admin/announcements_spec.rb
+++ b/spec/system/admin/announcements_spec.rb
@@ -121,6 +121,6 @@ RSpec.describe 'Admin::Announcements' do
   end
 
   def admin_user
-    Fabricate(:user, role: UserRole.find_by(name: 'Admin'))
+    Fabricate(:admin_user)
   end
 end

--- a/spec/system/admin/custom_emojis_spec.rb
+++ b/spec/system/admin/custom_emojis_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Admin::CustomEmojis' do
-  let(:current_user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:current_user) { Fabricate(:admin_user) }
 
   before { sign_in current_user }
 

--- a/spec/system/admin/domain_allows_spec.rb
+++ b/spec/system/admin/domain_allows_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Admin::DomainAllows' do
-  let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:user) { Fabricate(:admin_user) }
   let(:domain) { 'host.example' }
 
   before do

--- a/spec/system/admin/domain_blocks_spec.rb
+++ b/spec/system/admin/domain_blocks_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'blocking domains through the moderation interface' do
   before do
     allow(DomainBlockWorker).to receive(:perform_async).and_return(true)
-    sign_in Fabricate(:user, role: UserRole.find_by(name: 'Admin')), scope: :user
+    sign_in Fabricate(:admin_user), scope: :user
   end
 
   context 'when silencing a new domain' do

--- a/spec/system/admin/email_domain_blocks_spec.rb
+++ b/spec/system/admin/email_domain_blocks_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Admin::EmailDomainBlocks' do
-  let(:current_user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:current_user) { Fabricate(:admin_user) }
 
   before do
     sign_in current_user

--- a/spec/system/admin/invites_spec.rb
+++ b/spec/system/admin/invites_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Admin Invites' do
   describe 'Invite interaction' do
     let!(:invite) { Fabricate(:invite, expires_at: nil) }
 
-    let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+    let(:user) { Fabricate(:admin_user) }
 
     before { sign_in user }
 

--- a/spec/system/admin/ip_blocks_spec.rb
+++ b/spec/system/admin/ip_blocks_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Admin::IpBlocks' do
-  let(:current_user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:current_user) { Fabricate(:admin_user) }
 
   before { sign_in current_user }
 

--- a/spec/system/admin/relays_spec.rb
+++ b/spec/system/admin/relays_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Admin Relays' do
   describe 'Managing relays' do
-    before { sign_in Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+    before { sign_in Fabricate(:admin_user) }
 
     describe 'Viewing relays' do
       let!(:relay) { Fabricate :relay }

--- a/spec/system/admin/report_notes_spec.rb
+++ b/spec/system/admin/report_notes_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Admin Report Notes' do
-  let(:user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:user) { Fabricate(:admin_user) }
 
   before { sign_in user }
 

--- a/spec/system/admin/reset_spec.rb
+++ b/spec/system/admin/reset_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Admin::Reset' do
   end
 
   def admin_user
-    Fabricate(:user, role: UserRole.find_by(name: 'Admin'))
+    Fabricate(:admin_user)
   end
 
   def submit_reset

--- a/spec/system/admin/rules_spec.rb
+++ b/spec/system/admin/rules_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Admin Rules' do
   describe 'Managing rules' do
-    before { sign_in Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+    before { sign_in Fabricate(:admin_user) }
 
     describe 'Viewing rules' do
       let!(:rule) { Fabricate :rule, text: 'This is a rule' }

--- a/spec/system/admin/software_updates_spec.rb
+++ b/spec/system/admin/software_updates_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'finding software updates through the admin interface' do
   before do
     Fabricate(:software_update, version: '99.99.99', type: 'major', urgent: true, release_notes: 'https://github.com/mastodon/mastodon/releases/v99')
 
-    sign_in Fabricate(:user, role: UserRole.find_by(name: 'Owner')), scope: :user
+    sign_in Fabricate(:owner_user), scope: :user
   end
 
   it 'shows a link to the software updates page, which links to release notes' do

--- a/spec/system/admin/statuses_spec.rb
+++ b/spec/system/admin/statuses_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Admin::Statuses' do
-  let(:current_user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:current_user) { Fabricate(:admin_user) }
 
   before do
     sign_in current_user

--- a/spec/system/admin/tags_spec.rb
+++ b/spec/system/admin/tags_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Admin Tags' do
   describe 'Tag interaction' do
     let!(:tag) { Fabricate(:tag, name: 'test') }
 
-    before { sign_in Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+    before { sign_in Fabricate(:admin_user) }
 
     it 'allows tags listing and editing' do
       visit admin_tags_path

--- a/spec/system/admin/terms_of_service_spec.rb
+++ b/spec/system/admin/terms_of_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Admin Terms of services' do
   describe 'Viewing terms of services index page' do
     let!(:terms) { Fabricate :terms_of_service, text: 'Test terms' }
 
-    before { sign_in Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+    before { sign_in Fabricate(:admin_user) }
 
     it 'allows tags listing and editing' do
       visit admin_terms_of_service_index_path

--- a/spec/system/admin/trends/links/preview_card_providers_spec.rb
+++ b/spec/system/admin/trends/links/preview_card_providers_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Admin::Trends::Links::PreviewCardProviders' do
-  let(:current_user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:current_user) { Fabricate(:admin_user) }
 
   before do
     sign_in current_user

--- a/spec/system/admin/trends/links_spec.rb
+++ b/spec/system/admin/trends/links_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Admin::Trends::Links' do
-  let(:current_user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:current_user) { Fabricate(:admin_user) }
 
   before do
     sign_in current_user

--- a/spec/system/admin/trends/statuses_spec.rb
+++ b/spec/system/admin/trends/statuses_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Admin::Trends::Statuses' do
-  let(:current_user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:current_user) { Fabricate(:admin_user) }
 
   before do
     sign_in current_user

--- a/spec/system/admin/trends/tags_spec.rb
+++ b/spec/system/admin/trends/tags_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Admin::Trends::Tags' do
-  let(:current_user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:current_user) { Fabricate(:admin_user) }
 
   before do
     sign_in current_user

--- a/spec/system/admin/webhooks_spec.rb
+++ b/spec/system/admin/webhooks_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Admin Webhooks' do
   describe 'Managing webhooks' do
-    before { sign_in Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+    before { sign_in Fabricate(:admin_user) }
 
     describe 'Viewing webhooks' do
       let!(:webhook) { Fabricate :webhook }

--- a/spec/system/disputes/appeals_spec.rb
+++ b/spec/system/disputes/appeals_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Dispute Appeals' do
   let(:user) { Fabricate(:user) }
-  let!(:admin) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let!(:admin) { Fabricate(:admin_user) }
 
   before { sign_in user }
 

--- a/spec/workers/scheduler/auto_close_registrations_scheduler_spec.rb
+++ b/spec/workers/scheduler/auto_close_registrations_scheduler_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Scheduler::AutoCloseRegistrationsScheduler do
 
     before do
       Fabricate(:user, role: UserRole.find_by(name: 'Owner'), current_sign_in_at: 10.years.ago)
-      Fabricate(:user, role: UserRole.find_by(name: 'Moderator'), current_sign_in_at: moderator_activity_date)
+      Fabricate(:moderator_user, current_sign_in_at: moderator_activity_date)
     end
 
     context 'when registrations are open' do

--- a/spec/workers/scheduler/auto_close_registrations_scheduler_spec.rb
+++ b/spec/workers/scheduler/auto_close_registrations_scheduler_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Scheduler::AutoCloseRegistrationsScheduler do
     let(:moderator_activity_date) { Time.now.utc }
 
     before do
-      Fabricate(:user, role: UserRole.find_by(name: 'Owner'), current_sign_in_at: 10.years.ago)
+      Fabricate(:owner_user, current_sign_in_at: 10.years.ago)
       Fabricate(:moderator_user, current_sign_in_at: moderator_activity_date)
     end
 


### PR DESCRIPTION
Followup on previously closed PR. Adds a role-specific user fabricator for each of admin/moderator/owner; for slight ease improvement in setting these up.