### PR TITLE
Fix Renovate by temporarily constraining it to Ruby 3.3

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,6 +14,11 @@
   // If we do not want a package to be grouped with others, we need to set its groupName
   // to `null` after any other rule set it to something.
   dependencyDashboardHeader: 'This issue lists Renovate updates and detected dependencies. Read the [Dependency Dashboard](https://docs.renovatebot.com/key-concepts/dashboard/) docs to learn more. Before approving any upgrade: read the description and comments in the [`renovate.json5` file](https://github.com/mastodon/mastodon/blob/main/.github/renovate.json5).',
+  constraints: {
+    // Mastodon should work on Ruby 3.4, but its test dependencies are currently uninstallable on Ruby 3.4.
+    // TODO: remove this once https://github.com/briandunn/flatware/issues/103 is fixed
+    ruby: '3.3',
+  },
   postUpdateOptions: ['yarnDedupeHighest'],
   packageRules: [
     {

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
-ruby '>= 3.2.0'
+ruby '>= 3.2.0', '< 3.5'
 
 gem 'propshaft'
 gem 'puma', '~> 6.3'


### PR DESCRIPTION
See https://github.com/mastodon/mastodon/pull/33432