### PR TITLE
Use `in_order_of` with `filter: false` in `AccountSummary.localized`

### DIFF
--- a/app/models/account_summary.rb
+++ b/app/models/account_summary.rb
@@ -17,6 +17,6 @@ class AccountSummary < ApplicationRecord
   has_many :follow_recommendation_suppressions, primary_key: :account_id, foreign_key: :account_id, inverse_of: false, dependent: nil
 
   scope :safe, -> { where(sensitive: false) }
-  scope :localized, ->(locale) { order(Arel::Nodes::Case.new.when(arel_table[:language].eq(locale)).then(1).else(0).desc) }
+  scope :localized, ->(locale) { in_order_of(:language, [locale], filter: false) }
   scope :filtered, -> { where.missing(:follow_recommendation_suppressions) }
 end

--- a/spec/models/account_summary_spec.rb
+++ b/spec/models/account_summary_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AccountSummary do
+  describe 'Scopes' do
+    describe '.localized' do
+      let(:first) { Fabricate :account }
+      let(:last) { Fabricate :account }
+
+      before do
+        Fabricate :status, account: first, language: 'en'
+        Fabricate :status, account: last, language: 'es'
+        described_class.refresh
+      end
+
+      it 'returns records in order of language' do
+        expect(described_class.localized('en'))
+          .to contain_exactly(
+            have_attributes(account_id: first.id, language: 'en'),
+            have_attributes(account_id: last.id, language: 'es')
+          )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Prior to rails 8, the `in_order_of` method would always add a where clause to the generated sql query so that not only did you order by whatever was passed in, but you would only get records matching any of those options.

The `filter: false` option, added in rails 8, does not add the "where", so all records are returned. The generated sql is effectively the same (uses ASC instead of DESC, but logically same).

I think there may be more places to apply this pattern, but starting with just this one and will link back here on others as I find them. This particular one is used by the "global source" and "follow recommendation filter", which both called `FollowRecommendation.localized`, which in turn calls this method.