### PR TITLE
Avoid "double icon" near each other in nav sidebar

### DIFF
--- a/config/navigation.rb
+++ b/config/navigation.rb
@@ -65,7 +65,7 @@ SimpleNavigation::Configuration.run do |navigation|
 
     n.item :admin, safe_join([material_symbol('manufacturing'), t('admin.title')]), nil, if: -> { current_user.can?(:view_dashboard, :manage_settings, :manage_rules, :manage_announcements, :manage_custom_emojis, :manage_webhooks, :manage_federation) && !self_destruct } do |s|
       s.item :dashboard, safe_join([material_symbol('speed'), t('admin.dashboard.title')]), admin_dashboard_path, if: -> { current_user.can?(:view_dashboard) }
-      s.item :settings, safe_join([material_symbol('manufacturing'), t('admin.settings.title')]), admin_settings_path, if: -> { current_user.can?(:manage_settings) }, highlights_on: %r{/admin/settings}
+      s.item :settings, safe_join([material_symbol('tune'), t('admin.settings.title')]), admin_settings_path, if: -> { current_user.can?(:manage_settings) }, highlights_on: %r{/admin/settings}
       s.item :terms_of_service, safe_join([material_symbol('description'), t('admin.terms_of_service.title')]), admin_terms_of_service_index_path, highlights_on: %r{/admin/terms_of_service}, if: -> { current_user.can?(:manage_rules) }
       s.item :rules, safe_join([material_symbol('gavel'), t('admin.rules.title')]), admin_rules_path, highlights_on: %r{/admin/rules}, if: -> { current_user.can?(:manage_rules) }
       s.item :warning_presets, safe_join([material_symbol('warning'), t('admin.warning_presets.title')]), admin_warning_presets_path, highlights_on: %r{/admin/warning_presets}, if: -> { current_user.can?(:manage_settings) }

--- a/config/navigation.rb
+++ b/config/navigation.rb
@@ -17,7 +17,7 @@ SimpleNavigation::Configuration.run do |navigation|
     n.item :preferences, safe_join([material_symbol('settings'), t('settings.preferences')]), settings_preferences_path, if: -> { current_user.functional? && !self_destruct } do |s|
       s.item :appearance, safe_join([material_symbol('computer'), t('settings.appearance')]), settings_preferences_appearance_path
       s.item :notifications, safe_join([material_symbol('mail'), t('settings.notifications')]), settings_preferences_notifications_path
-      s.item :other, safe_join([material_symbol('settings'), t('preferences.other')]), settings_preferences_other_path
+      s.item :other, safe_join([material_symbol('tune'), t('preferences.other')]), settings_preferences_other_path
     end
 
     n.item :relationships, safe_join([material_symbol('groups'), t('settings.relationships')]), relationships_path, if: -> { current_user.functional? && !self_destruct } do |s|


### PR DESCRIPTION
Both the "admin -> settings" path and the "Preferences -> Other" path re-use the same icon, which looks sort of weird right next to each other.

Update here leaves the top-level ones as-is, and updates the sub items to use "tune" (chosen entirely because we happen to have it already, and it's not used near by - open to other ideas, but strikes me as better merely by being different and vaguely topical).

Before:

<img width="231" alt="Screenshot 2025-01-03 at 18 27 39" src="https://github.com/user-attachments/assets/8fdc0da9-0ab5-4bda-ba99-93325934c87f" />
<img width="241" alt="Screenshot 2025-01-03 at 18 27 46" src="https://github.com/user-attachments/assets/2636bc19-872b-41fd-bd02-a5f8b0e88aef" />

After:

<img width="230" alt="Screenshot 2025-01-03 at 18 28 20" src="https://github.com/user-attachments/assets/13e3d931-884f-403a-8b21-a3c3e9a5ac47" />
<img width="239" alt="Screenshot 2025-01-03 at 18 28 30" src="https://github.com/user-attachments/assets/04f5fe60-6002-4561-9b67-0466e55f8ce4" />

Similar to https://github.com/mastodon/mastodon/pull/32201 which solved same problem elsewhere in the nav.