### PR TITLE
Only register stats dirs when command available

### DIFF
--- a/config/initializers/statistics.rb
+++ b/config/initializers/statistics.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+return unless defined?(Rails::Command::StatsCommand)
+
 [
   %w(AppLibs app/lib),
   %w(Policies app/policies),


### PR DESCRIPTION
See comment here re: issues with this in nightlies - https://github.com/mastodon/mastodon/pull/33445#issuecomment-2571327647

I suspect this was working fine in dev/test because of autoload, but fails in production with eager load. Was able to confirm locally things working fine in dev/test, but failing in production. With this change, dev/test still work fine, and production (which will not have loaded the stats command at this point) proceeds w/out.

We could also probably just do an explicit require here if production would ever need to run this?

Might do followup to see how CI could have caught this ... I thought there was an eager load setting to essentially give it parity with production in that regard, but maybe not.