### PR TITLE
Fix `/share` not using server-set characters limit

### DIFF
--- a/app/javascript/mastodon/containers/compose_container.jsx
+++ b/app/javascript/mastodon/containers/compose_container.jsx
@@ -1,6 +1,7 @@
 import { Provider } from 'react-redux';
 
 import { fetchCustomEmojis } from 'mastodon/actions/custom_emojis';
+import { fetchServer } from 'mastodon/actions/server';
 import { hydrateStore } from 'mastodon/actions/store';
 import { Router } from 'mastodon/components/router';
 import Compose from 'mastodon/features/standalone/compose';
@@ -13,6 +14,7 @@ if (initialState) {
 }
 
 store.dispatch(fetchCustomEmojis());
+store.dispatch(fetchServer());
 
 const ComposeContainer = () => (
   <IntlProvider>


### PR DESCRIPTION
See also:

Issue (also affects vanilla Mastodon, actually): https://github.com/glitch-soc/mastodon/issues/2687