### PR TITLE
Fix `fediverse:creator` metadata not showing up in REST API

### DIFF
--- a/app/models/preview_card.rb
+++ b/app/models/preview_card.rb
@@ -170,7 +170,7 @@ class PreviewCard < ApplicationRecord
   private
 
   def serialized_authors
-    if author_name? || author_url?
+    if author_name? || author_url? || author_account_id?
       PreviewCard::Author
         .new(self)
     end

--- a/spec/serializers/rest/preview_card_serializer_spec.rb
+++ b/spec/serializers/rest/preview_card_serializer_spec.rb
@@ -21,7 +21,24 @@ RSpec.describe REST::PreviewCardSerializer do
     end
   end
 
-  context 'when preview card has author data' do
+  context 'when preview card has fediverse author data' do
+    let(:preview_card) { Fabricate.build :preview_card, author_account: Fabricate(:account) }
+
+    it 'includes populated authors array' do
+      expect(subject.deep_symbolize_keys)
+        .to include(
+          authors: be_an(Array).and(
+            contain_exactly(
+              include(
+                account: be_present
+              )
+            )
+          )
+        )
+    end
+  end
+
+  context 'when preview card has non-fediverse author data' do
     let(:preview_card) { Fabricate.build :preview_card, author_name: 'Name', author_url: 'https://host.example/123' }
 
     it 'includes populated authors array' do


### PR DESCRIPTION
Fix regression from #33151