### PR TITLE
Extract constants for `AnnualReport::*` minimum thresholds

### DIFF
--- a/app/lib/annual_report/commonly_interacted_with_accounts.rb
+++ b/app/lib/annual_report/commonly_interacted_with_accounts.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class AnnualReport::CommonlyInteractedWithAccounts < AnnualReport::Source
+  MINIMUM_INTERACTIONS = 1
   SET_SIZE = 40
 
   def generate
@@ -17,6 +18,10 @@ class AnnualReport::CommonlyInteractedWithAccounts < AnnualReport::Source
   private
 
   def commonly_interacted_with_accounts
-    report_statuses.where.not(in_reply_to_account_id: @account.id).group(:in_reply_to_account_id).having('count(*) > 1').order(count_all: :desc).limit(SET_SIZE).count
+    report_statuses.where.not(in_reply_to_account_id: @account.id).group(:in_reply_to_account_id).having(minimum_interaction_count).order(count_all: :desc).limit(SET_SIZE).count
+  end
+
+  def minimum_interaction_count
+    Arel.star.count.gt(MINIMUM_INTERACTIONS)
   end
 end

--- a/app/lib/annual_report/most_reblogged_accounts.rb
+++ b/app/lib/annual_report/most_reblogged_accounts.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class AnnualReport::MostRebloggedAccounts < AnnualReport::Source
+  MINIMUM_REBLOGS = 1
   SET_SIZE = 10
 
   def generate
@@ -17,6 +18,10 @@ class AnnualReport::MostRebloggedAccounts < AnnualReport::Source
   private
 
   def most_reblogged_accounts
-    report_statuses.where.not(reblog_of_id: nil).joins(reblog: :account).group(accounts: [:id]).having('count(*) > 1').order(count_all: :desc).limit(SET_SIZE).count
+    report_statuses.where.not(reblog_of_id: nil).joins(reblog: :account).group(accounts: [:id]).having(minimum_reblog_count).order(count_all: :desc).limit(SET_SIZE).count
+  end
+
+  def minimum_reblog_count
+    Arel.star.count.gt(MINIMUM_REBLOGS)
   end
 end

--- a/app/lib/annual_report/top_hashtags.rb
+++ b/app/lib/annual_report/top_hashtags.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class AnnualReport::TopHashtags < AnnualReport::Source
+  MINIMUM_TAGGINGS = 1
   SET_SIZE = 40
 
   def generate
@@ -17,7 +18,11 @@ class AnnualReport::TopHashtags < AnnualReport::Source
   private
 
   def top_hashtags
-    Tag.joins(:statuses).where(statuses: { id: report_statuses.select(:id) }).group(coalesced_tag_names).having('count(*) > 1').order(count_all: :desc).limit(SET_SIZE).count
+    Tag.joins(:statuses).where(statuses: { id: report_statuses.select(:id) }).group(coalesced_tag_names).having(minimum_taggings_count).order(count_all: :desc).limit(SET_SIZE).count
+  end
+
+  def minimum_taggings_count
+    Arel.star.count.gt(MINIMUM_TAGGINGS)
   end
 
   def coalesced_tag_names


### PR DESCRIPTION
For each of "commonly interacted accounts", "most reblogged accounts", "top hashtags" - pull out private method to generate count SQL, and constant to capture the threshold for the measurement.

Pulled out of a previous (originally larger refactor) PR.