### PR TITLE
Extricate `Invite` constants for code generation

### DIFF
--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -20,6 +20,9 @@ class Invite < ApplicationRecord
   include Expireable
 
   COMMENT_SIZE_LIMIT = 420
+  ELIGIBLE_CODE_CHARACTERS = [*('a'..'z'), *('A'..'Z'), *('0'..'9')].freeze
+  HOMOGLYPHS = %w(0 1 I l O).freeze
+  VALID_CODE_CHARACTERS = ELIGIBLE_CODE_CHARACTERS - HOMOGLYPHS
 
   belongs_to :user, inverse_of: :invites
   has_many :users, inverse_of: :invite, dependent: nil
@@ -38,7 +41,7 @@ class Invite < ApplicationRecord
 
   def set_code
     loop do
-      self.code = ([*('a'..'z'), *('A'..'Z'), *('0'..'9')] - %w(0 1 I l O)).sample(8).join
+      self.code = VALID_CODE_CHARACTERS.sample(8).join
       break if Invite.find_by(code: code).nil?
     end
   end


### PR DESCRIPTION
Pulled out of previous larger refactor PR - this is just some constant extraction. Primary benefit is just a little readability improvement, but there's also technically a small perf benefit by generating what is going to be the same exact character array once on load rather than every method call.

Separately, I think I asked this elsewhere previously -- it's currently the case that any update at all to a previously saved `Invite` record will re-generate the code. Is this intentional?