### PR TITLE
Use `ubuntu-latest` for all GH actions runners

### DIFF
--- a/.github/workflows/check-i18n.yml
+++ b/.github/workflows/check-i18n.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   check-i18n:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -174,7 +174,7 @@ jobs:
 
   test-libvips:
     name: Libvips tests
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     needs:
       - build


### PR DESCRIPTION
From a few recent actions runs it looks like we have been migrated to ubuntu 24 as the new "latest" (it's been a staggered rollout). With that change in place, these configs are not needed any more.

Background: https://github.com/actions/runner-images/issues/10636