### PR TITLE
Add helpers for ios/android app store links in welcome mailer

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -238,6 +238,14 @@ module ApplicationHelper
     I18n.t 'user_mailer.welcome.hashtags_recent_count', people: number_with_delimiter(people), count: people
   end
 
+  def app_store_url_ios
+    'https://apps.apple.com/app/mastodon-for-iphone-and-ipad/id1571998974'
+  end
+
+  def app_store_url_android
+    'https://play.google.com/store/apps/details?id=org.joinmastodon.android'
+  end
+
   private
 
   def storage_host_var

--- a/app/views/application/mailer/_checklist.html.haml
+++ b/app/views/application/mailer/_checklist.html.haml
@@ -29,8 +29,8 @@
                     %div
                       - if defined?(show_apps_buttons) && show_apps_buttons
                         .email-welcome-apps-btns
-                          = link_to image_tag(frontend_asset_url('images/mailer-new/store-icons/btn-app-store.png'), alt: t('user_mailer.welcome.apps_ios_action'), width: 120, height: 40), 'https://apps.apple.com/app/mastodon-for-iphone-and-ipad/id1571998974'
-                          = link_to image_tag(frontend_asset_url('images/mailer-new/store-icons/btn-google-play.png'), alt: t('user_mailer.welcome.apps_android_action'), width: 120, height: 40), 'https://play.google.com/store/apps/details?id=org.joinmastodon.android'
+                          = link_to image_tag(frontend_asset_url('images/mailer-new/store-icons/btn-app-store.png'), alt: t('user_mailer.welcome.apps_ios_action'), width: 120, height: 40), app_store_url_ios
+                          = link_to image_tag(frontend_asset_url('images/mailer-new/store-icons/btn-google-play.png'), alt: t('user_mailer.welcome.apps_android_action'), width: 120, height: 40), app_store_url_android
                       - elsif defined?(button_text) && defined?(button_url) && defined?(checked) && !checked
                         = render 'application/mailer/button', text: button_text, url: button_url, has_arrow: false
                     /[if mso]

--- a/app/views/user_mailer/welcome.text.erb
+++ b/app/views/user_mailer/welcome.text.erb
@@ -30,8 +30,8 @@
 
 5. <%= t('user_mailer.welcome.apps_title') %>
    <%= t('user_mailer.welcome.apps_step') %>
-   * iOS: https://apps.apple.com/app/mastodon-for-iphone-and-ipad/id1571998974
-   * Android: https://play.google.com/store/apps/details?id=org.joinmastodon.android
+   * iOS: <%= app_store_url_ios %>
+   * Android: <%= app_store_url_android %>
 
 ---
 


### PR DESCRIPTION
A previous (not reviewed, now closed) PR moved these into a `config_for` yml setting ... but also did other things (changed a serializer around, maybe more).

I still think this should eventually migrate to a `config_for` as part of that larger effort, but short of that - just move to helper for now to both consolidate the value to fewer places and tidy up the view (we are very close to being able to reduce the haml lint overrides to be less substantial, this chips away at that as well).