### PR TITLE
Add `self_editing?` method to user role policy

### DIFF
--- a/app/policies/user_role_policy.rb
+++ b/app/policies/user_role_policy.rb
@@ -10,10 +10,16 @@ class UserRolePolicy < ApplicationPolicy
   end
 
   def update?
-    role.can?(:manage_roles) && (role.overrides?(record) || role.id == record.id)
+    role.can?(:manage_roles) && (role.overrides?(record) || self_editing?)
   end
 
   def destroy?
-    !record.everyone? && role.can?(:manage_roles) && role.overrides?(record) && role.id != record.id
+    !record.everyone? && role.can?(:manage_roles) && role.overrides?(record) && !self_editing?
+  end
+
+  private
+
+  def self_editing?
+    role.id == record.id
   end
 end


### PR DESCRIPTION
After adding a bunch of spec coverage for the policies, I had opened up a refactor PR that changed too many policies all at once (now closed).

Going through that and attempting to extract a few small changes which are small improvement in clarity or otherwise tidy-up refactor to some policies.
