### PR TITLE
Use `distributable?` method in admin/status_policy method

### DIFF
--- a/app/policies/admin/status_policy.rb
+++ b/app/policies/admin/status_policy.rb
@@ -12,7 +12,7 @@ class Admin::StatusPolicy < ApplicationPolicy
   end
 
   def show?
-    role.can?(:manage_reports, :manage_users) && (record.public_visibility? || record.unlisted_visibility? || record.reported? || viewable_through_normal_policy?)
+    role.can?(:manage_reports, :manage_users) && eligible_to_show?
   end
 
   def destroy?
@@ -28,6 +28,10 @@ class Admin::StatusPolicy < ApplicationPolicy
   end
 
   private
+
+  def eligible_to_show?
+    record.distributable? || record.reported? || viewable_through_normal_policy?
+  end
 
   def viewable_through_normal_policy?
     StatusPolicy.new(current_account, record, @preloaded_relations).show?


### PR DESCRIPTION
After adding a bunch of spec coverage for the policies, I had opened up a refactor PR that changed too many policies all at once (now closed).

Going through that and attempting to extract a few small changes which are small improvement in clarity or otherwise tidy-up refactor to some policies.
