### PR TITLE
Reference value constants from specs

### DIFF
--- a/spec/lib/activitypub/activity/create_spec.rb
+++ b/spec/lib/activitypub/activity/create_spec.rb
@@ -624,7 +624,7 @@ RSpec.describe ActivityPub::Activity::Create do
                 type: 'Document',
                 mediaType: 'image/png',
                 url: 'http://example.com/attachment.png',
-                name: '*' * 1500,
+                name: '*' * MediaAttachment::MAX_DESCRIPTION_LENGTH,
               },
             ],
           }
@@ -636,7 +636,7 @@ RSpec.describe ActivityPub::Activity::Create do
           status = sender.statuses.first
 
           expect(status).to_not be_nil
-          expect(status.media_attachments.map(&:description)).to include('*' * 1500)
+          expect(status.media_attachments.map(&:description)).to include('*' * MediaAttachment::MAX_DESCRIPTION_LENGTH)
         end
       end
 
@@ -651,7 +651,7 @@ RSpec.describe ActivityPub::Activity::Create do
                 type: 'Document',
                 mediaType: 'image/png',
                 url: 'http://example.com/attachment.png',
-                summary: '*' * 1500,
+                summary: '*' * MediaAttachment::MAX_DESCRIPTION_LENGTH,
               },
             ],
           }
@@ -663,7 +663,7 @@ RSpec.describe ActivityPub::Activity::Create do
           status = sender.statuses.first
 
           expect(status).to_not be_nil
-          expect(status.media_attachments.map(&:description)).to include('*' * 1500)
+          expect(status.media_attachments.map(&:description)).to include('*' * MediaAttachment::MAX_DESCRIPTION_LENGTH)
         end
       end
 

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -824,8 +824,7 @@ RSpec.describe Account do
       it { is_expected.to_not allow_values(account_note_over_limit).for(:note) }
 
       it { is_expected.to allow_value(fields_empty_name_value).for(:fields) }
-      it { is_expected.to_not allow_value(fields_over_limit).for(:fields) }
-      it { is_expected.to_not allow_value(fields_empty_name).for(:fields) }
+      it { is_expected.to_not allow_values(fields_over_limit, fields_empty_name).for(:fields) }
     end
 
     context 'when account is remote' do

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Appeal do
     it { is_expected.to validate_length_of(:text).is_at_most(described_class::TEXT_LENGTH_LIMIT) }
 
     context 'with a strike created too long ago' do
-      let(:strike) { Fabricate.build :account_warning, created_at: 100.days.ago }
+      let(:strike) { Fabricate.build :account_warning, created_at: (described_class::MAX_STRIKE_AGE * 2).ago }
 
       it { is_expected.to_not allow_values(strike).for(:strike).against(:base).on(:create) }
     end

--- a/spec/policies/backup_policy_spec.rb
+++ b/spec/policies/backup_policy_spec.rb
@@ -23,21 +23,29 @@ RSpec.describe BackupPolicy do
 
       context 'when backups are too old' do
         it 'permits' do
-          travel(-8.days) do
+          travel(-before_time) do
             Fabricate(:backup, user: john.user)
           end
 
           expect(subject).to permit(john, Backup)
         end
+
+        def before_time
+          described_class::MIN_AGE + 2.days
+        end
       end
 
       context 'when backups are newer' do
         it 'denies' do
-          travel(-3.days) do
+          travel(-within_time) do
             Fabricate(:backup, user: john.user)
           end
 
           expect(subject).to_not permit(john, Backup)
+        end
+
+        def within_time
+          described_class::MIN_AGE - 2.days
         end
       end
     end

--- a/spec/requests/api/v1/accounts/credentials_spec.rb
+++ b/spec/requests/api/v1/accounts/credentials_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe 'credentials API' do
     end
 
     describe 'with invalid data' do
-      let(:params) { { note: 'This is too long. ' * 30 } }
+      let(:params) { { note: 'a' * 2 * Account::NOTE_LENGTH_LIMIT } }
 
       it 'returns http unprocessable entity' do
         subject

--- a/spec/requests/api/v1/accounts/notes_spec.rb
+++ b/spec/requests/api/v1/accounts/notes_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Accounts Notes API' do
     end
 
     context 'when account note exceeds allowed length', :aggregate_failures do
-      let(:comment) { 'a' * 2_001 }
+      let(:comment) { 'a' * AccountNote::COMMENT_SIZE_LIMIT * 2 }
 
       it 'does not create account note' do
         subject

--- a/spec/requests/api/v2/media_spec.rb
+++ b/spec/requests/api/v2/media_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'Media API', :attachment_processing do
       let(:params) do
         {
           file: fixture_file_upload('attachment-jpg.123456_abcd', 'image/jpeg'),
-          description: 'aa' * MediaAttachment::MAX_DESCRIPTION_LENGTH,
+          description: 'a' * MediaAttachment::MAX_DESCRIPTION_LENGTH * 2,
         }
       end
 


### PR DESCRIPTION
Follow-up on https://github.com/mastodon/mastodon/pull/33463

Updates a few spots where size constants could be overridden in forks or otherwise, and makes the spec relative to that value rather than hard-coded to a historical value.

While doing this I found a few more things which probably should be but are not yet constants. Will do follow-up on those.