### PR TITLE
Fix preview card sizing in “Author attribution” in profile settings

### DIFF
--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -659,6 +659,10 @@ code {
       }
     }
   }
+
+  .status-card {
+    contain: unset;
+  }
 }
 
 .block-icon {


### PR DESCRIPTION
An alternative, I guess, would be to change the `contain` to only be applied to `.status .status-card` and `.detailed-status .status-card`