### PR TITLE
Reduce overridden values in `haml-lint` configuration

### DIFF
--- a/.haml-lint.yml
+++ b/.haml-lint.yml
@@ -10,6 +10,6 @@ linters:
   MiddleDot:
     enabled: true
   LineLength:
-    max: 300
+    max: 256 # Override default of 80
   ViewLength:
-    max: 200 # Override default value of 100 inherited from rubocop
+    max: 128 # Override default of 100

--- a/app/views/admin/terms_of_service/previews/show.html.haml
+++ b/app/views/admin/terms_of_service/previews/show.html.haml
@@ -16,5 +16,12 @@
 %hr.spacer/
 
 .content__heading__actions
-  = link_to t('admin.terms_of_service.preview.send_preview', email: current_user.email), admin_terms_of_service_test_path(@terms_of_service), method: :post, class: 'button button-secondary'
-  = link_to t('admin.terms_of_service.preview.send_to_all', count: @user_count, display_count: number_with_delimiter(@user_count)), admin_terms_of_service_distribution_path(@terms_of_service), method: :post, class: 'button', data: { confirm: t('admin.reports.are_you_sure') }
+  = link_to t('admin.terms_of_service.preview.send_preview', email: current_user.email),
+            admin_terms_of_service_test_path(@terms_of_service),
+            class: 'button button-secondary',
+            method: :post
+  = link_to t('admin.terms_of_service.preview.send_to_all', count: @user_count, display_count: number_with_delimiter(@user_count)),
+            admin_terms_of_service_distribution_path(@terms_of_service),
+            class: 'button',
+            data: { confirm: t('admin.reports.are_you_sure') },
+            method: :post


### PR DESCRIPTION
For both `LineLength` and `ViewLength` we are overriding the default values `haml-lint` uses. Change here bumps them down to 2^7 and 2^8, respectively.

For line length - there was one remaining violation which was new since last rebase of this branch, which is corrected here (can pull out earlier if desired). I think this line length value should go even further, but did not want to put any views in a state where some lines are JUST UNDER the limit and normal/unrelated changes trigger this. There are only 3 views with lines over 235, so hopefully there's some buffer and we avoid that. Will do more future passes on this to further reduce ... something like ~160 (2x the default) seems like a reasonable long term target for this.

For view length - there are only 2 views over 100, both of which (in my opinion) could/should reduce further - so we can probably get to the default on this one eventually.