### PR TITLE
Refer to constant values from `api/v1/apps` request spec

### DIFF
--- a/app/lib/application_extension.rb
+++ b/app/lib/application_extension.rb
@@ -3,14 +3,18 @@
 module ApplicationExtension
   extend ActiveSupport::Concern
 
+  APP_NAME_LIMIT = 60
+  APP_REDIRECT_URI_LIMIT = 2_000
+  APP_WEBSITE_LIMIT = 2_000
+
   included do
     include Redisable
 
     has_many :created_users, class_name: 'User', foreign_key: 'created_by_application_id', inverse_of: :created_by_application
 
-    validates :name, length: { maximum: 60 }
-    validates :website, url: true, length: { maximum: 2_000 }, if: :website?
-    validates :redirect_uri, length: { maximum: 2_000 }
+    validates :name, length: { maximum: APP_NAME_LIMIT }
+    validates :redirect_uri, length: { maximum: APP_REDIRECT_URI_LIMIT }
+    validates :website, url: true, length: { maximum: APP_WEBSITE_LIMIT }, if: :website?
 
     # The relationship used between Applications and AccessTokens is using
     # dependent: delete_all, which means the ActiveRecord callback in

--- a/spec/models/doorkeeper/application_spec.rb
+++ b/spec/models/doorkeeper/application_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Doorkeeper::Application do
+  describe 'Associations' do
+    it { is_expected.to have_many(:created_users).class_name('User').inverse_of(:created_by_application).with_foreign_key(:created_by_application_id) }
+  end
+
+  describe 'Validations' do
+    it { is_expected.to validate_length_of(:name).is_at_most(described_class::APP_NAME_LIMIT) }
+    it { is_expected.to validate_length_of(:redirect_uri).is_at_most(described_class::APP_REDIRECT_URI_LIMIT) }
+    it { is_expected.to validate_length_of(:website).is_at_most(described_class::APP_WEBSITE_LIMIT) }
+  end
+end

--- a/spec/requests/api/v1/apps_spec.rb
+++ b/spec/requests/api/v1/apps_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe 'Apps' do
     end
 
     context 'with a too-long name' do
-      let(:client_name) { 'hoge' * 20 }
+      let(:client_name) { 'a' * Doorkeeper::Application::APP_NAME_LIMIT * 2 }
 
       it 'returns http unprocessable entity' do
         subject
@@ -134,7 +134,7 @@ RSpec.describe 'Apps' do
     end
 
     context 'with a too-long website' do
-      let(:website) { "https://foo.bar/#{'hoge' * 2_000}" }
+      let(:website) { "https://foo.bar/#{'a' * Doorkeeper::Application::APP_WEBSITE_LIMIT * 2}" }
 
       it 'returns http unprocessable entity' do
         subject
@@ -146,7 +146,7 @@ RSpec.describe 'Apps' do
     end
 
     context 'with a too-long redirect_uri' do
-      let(:redirect_uris) { "https://app.example/#{'hoge' * 2_000}" }
+      let(:redirect_uris) { "https://app.example/#{'a' * Doorkeeper::Application::APP_REDIRECT_URI_LIMIT * 2}" }
 
       it 'returns http unprocessable entity' do
         subject


### PR DESCRIPTION
First of some followup from https://github.com/mastodon/mastodon/pull/33479 where I noticed a few spec locations which could be relative to constants but were lacking constants!

- Add model spec for `Doorkeeper::Application` -- could be useful starting point if we ever migrate to our own models, but also is valuable on its own to capture whatever our "extensions" are doing.
- Update apps request spec to refer to the added values