### PR TITLE
Re-introduce `application_id` in `ScheduledStatusSerializer`

### DIFF
--- a/app/serializers/rest/scheduled_status_serializer.rb
+++ b/app/serializers/rest/scheduled_status_serializer.rb
@@ -8,8 +8,4 @@ class REST::ScheduledStatusSerializer < ActiveModel::Serializer
   def id
     object.id.to_s
   end
-
-  def params
-    object.params.without('application_id')
-  end
 end

--- a/spec/serializers/rest/scheduled_status_serializer_spec.rb
+++ b/spec/serializers/rest/scheduled_status_serializer_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe REST::ScheduledStatusSerializer do
     it 'returns expected values and removes application_id from params' do
       expect(subject.deep_symbolize_keys)
         .to include(
-          scheduled_at: be_a(String).and(match_api_datetime_format)
+          scheduled_at: be_a(String).and(match_api_datetime_format),
+          params: include(:application_id)
         )
     end
   end

--- a/spec/serializers/rest/scheduled_status_serializer_spec.rb
+++ b/spec/serializers/rest/scheduled_status_serializer_spec.rb
@@ -16,8 +16,7 @@ RSpec.describe REST::ScheduledStatusSerializer do
     it 'returns expected values and removes application_id from params' do
       expect(subject.deep_symbolize_keys)
         .to include(
-          scheduled_at: be_a(String).and(match_api_datetime_format),
-          params: not_include(:application_id)
+          scheduled_at: be_a(String).and(match_api_datetime_format)
         )
     end
   end


### PR DESCRIPTION
`application_id` is an internal property that is no use to API clients, and it was meant to be omitted.

However, because of a discrepancy between key types (symbols vs strings), it was not actually omitted, and has been present in the values returned from the API for years, and documented as such in the official documentation.

#33159 went and fixed the issue, effectively removing the attribute from the API response.

While no API consumer would have any reason whatsoever to use this value, it is possible some of them expect the value anyway and perform strict checking when ingesting the data. I am aware of no such application, but it is entirely possible they exist. Should such applications exist, the change introduced in #33159 would break them.

The most conservative approach is thus to re-introduce the attribute, and document it as not to be used.