### PR TITLE
Add `Account#remote?` query method

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -107,7 +107,7 @@ class Account < ApplicationRecord
   validates_with UniqueUsernameValidator, if: -> { will_save_change_to_username? }
 
   # Remote user validations, also applies to internal actors
-  validates :username, format: { with: USERNAME_ONLY_RE }, if: -> { (!local? || actor_type == 'Application') && will_save_change_to_username? }
+  validates :username, format: { with: USERNAME_ONLY_RE }, if: -> { (remote? || actor_type == 'Application') && will_save_change_to_username? }
 
   # Remote user validations
   validates :uri, presence: true, unless: :local?, on: :create
@@ -184,6 +184,10 @@ class Account < ApplicationRecord
 
   def local?
     domain.nil?
+  end
+
+  def remote?
+    domain.present?
   end
 
   def moved?

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -61,11 +61,7 @@ class Poll < ApplicationRecord
     votes.where(account: account).pluck(:choice)
   end
 
-  delegate :local?, to: :account
-
-  def remote?
-    !local?
-  end
+  delegate :local?, :remote?, to: :account
 
   def emojis
     @emojis ||= CustomEmoji.from_text(options.join(' '), account.domain)

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -48,14 +48,34 @@ RSpec.describe Account do
   end
 
   describe '#local?' do
-    it 'returns true when the account is local' do
+    it 'returns true when domain is null' do
       account = Fabricate(:account, domain: nil)
-      expect(account.local?).to be true
+      expect(account).to be_local
     end
 
-    it 'returns false when the account is on a different domain' do
+    it 'returns false when domain is present' do
       account = Fabricate(:account, domain: 'foreign.tld')
-      expect(account.local?).to be false
+      expect(account).to_not be_local
+    end
+  end
+
+  describe '#remote?' do
+    context 'when the domain is null' do
+      subject { Fabricate.build :account, domain: nil }
+
+      it { is_expected.to_not be_remote }
+    end
+
+    context 'when the domain is blank' do
+      subject { Fabricate.build :account, domain: '' }
+
+      it { is_expected.to_not be_remote }
+    end
+
+    context 'when the domain is present' do
+      subject { Fabricate.build :account, domain: 'host.example' }
+
+      it { is_expected.to be_remote }
     end
   end
 


### PR DESCRIPTION
This is a pre-cursor to a future PR where I will attempt to clean up all the validation declarations in the top of `Account` (probably two large `with_options` blocks), which are a mix of "do this for remote" and "do this for local". Having both a `local?` and `remote?` to work with will make this much more readable.

In this PR, only using the method in a few places -- but future work will use it more in both a) validation declaration here, b) various other spots around app where there's either "unless" or other negation used and this method would be more clear.