### PR TITLE
Fix use of deprecated `Iterable.isIndexed` from immutable

### DIFF
--- a/app/javascript/mastodon/actions/store.js
+++ b/app/javascript/mastodon/actions/store.js
@@ -1,4 +1,4 @@
-import { Iterable, fromJS } from 'immutable';
+import { fromJS, isIndexed } from 'immutable';
 
 import { hydrateCompose } from './compose';
 import { importFetchedAccounts } from './importer';
@@ -9,8 +9,7 @@ export const STORE_HYDRATE_LAZY = 'STORE_HYDRATE_LAZY';
 
 const convertState = rawState =>
   fromJS(rawState, (k, v) =>
-    Iterable.isIndexed(v) ? v.toList() : v.toMap());
-
+    isIndexed(v) ? v.toList() : v.toMap());
 
 export function hydrateStore(rawState) {
   return dispatch => {


### PR DESCRIPTION
In preparation of #32762