### PR TITLE
Target same browsers in development and production

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,10 +1,6 @@
-[production]
 defaults
 > 0.2%
 firefox >= 78
 ios >= 15.6
 not dead
 not OperaMini all
-
-[development]
-supports es6-module


### PR DESCRIPTION
Currently we target [a very wide range of browsers](https://browsersl.ist/#q=supports+es6-module) in development (see #32267).

To catch compatibility issues as early as possible, use the same settings for development as is used in production.