### PR TITLE
Update CONTRIBUTING doc with various clarifications

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,27 +34,23 @@ reviewed and merged into the codebase.
 
 ### Size and Scope
 
-The smaller and more focused a set of changes in a Pull Request is, the easier
-it is to review. Splitting tasks into multiple smaller PRs is often preferable.
-Team time is limited and pull requests making large sprawling changes are harder
-to review and less likely to get any feedback at all. If your change only makes
-sense in some larger context of future changes, note that in the description,
-but still aim to keep each distinct PR to a "smallest viable change" size.
+The smaller and more focused changes in a Pull Request are, the easier they are
+to review. Team time is limited and PRs making large sprawling changes are
+unlikely to get any feedback at all. If your change only makes sense in some
+larger context of future ongoing work, note that in the description, but still
+aim to keep each distinct PR to a "smallest viable change" size.
 
 ### Description of Changes
 
 Unless the Pull Request is about refactoring code, updating dependencies or
-other internal tasks, assume that the person reading the PR is not a programmer
-or Mastodon developer, but a Mastodon user or server admin, and try to describe
-things from their perspective.
+other internal tasks, assume that the audience are not developers, but a
+Mastodon user or server admin, and try to describe from their perspective.
 
-We use commit squashing, so the final commit in the main branch will carry the
-title and description from the Pull Request. Commits from the main branch are
-then fed into the changelog and ultimately into release notes. We try to follow
-the [keepachangelog] spec, and while that does not prescribe how the entries
-ought to be named, for easier sorting, starting your pull request titles using
-one of the verbs "Add", "Change", "Deprecate", "Remove", or "Fix" (present
-tense) is helpful when it makes sense.
+The final commit in the main branch will carry the title from the PR. The main
+branch is then fed into the changelog and ultimately into release notes. We try
+to follow the [keepachangelog] spec, and while that does not prescribe how the
+entries ought to be named, starting titles using one of the verbs "Add",
+"Change", "Deprecate", "Remove", or "Fix" (present tense) is helpful.
 
 Example:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,9 @@ request on our [documentation repository].
 
 ## Bug reports
 
-Bug reports and feature suggestions must use descriptive and concise titles and be submitted to [GitHub Issues](https://github.com/mastodon/mastodon/issues). Please use the search function to make sure that you are not submitting duplicates, and that a similar report or request has not already been resolved or rejected.
+Bug reports and feature suggestions must use descriptive and concise titles and
+be submitted to [GitHub Issues]. Please use the search function to make sure
+that you are not submitting duplicate bug reports or feature requests.
 
 ## Translations
 
@@ -54,3 +56,4 @@ The [Mastodon documentation](https://docs.joinmastodon.org) is a statically gene
 [contribution guidelines]: https://github.com/mastodon/.github/blob/main/CONTRIBUTING.md
 [DEVELOPMENT]: docs/DEVELOPMENT.md
 [documentation repository]: https://github.com/mastodon/documentation
+[GitHub Issues]: https://github.com/mastodon/mastodon/issues

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ criteria guidance and the [DEVELOPMENT] guide for environment-specific details.
 Any changes or additions made to the API should have an accompanying pull
 request on our [documentation repository].
 
-## Bug reports
+## Bug Reports
 
 Bug reports and feature suggestions must use descriptive and concise titles and
 be submitted to [GitHub Issues]. Please use the search function to make sure
@@ -30,9 +30,9 @@ reviewed and merged into the codebase.
 
 [![Crowdin](https://d322cqt584bo4o.cloudfront.net/mastodon/localized.svg)](https://crowdin.com/project/mastodon)
 
-## Pull requests
+## Pull Requests
 
-### Size and scope
+### Size and Scope
 
 The smaller and more focused a set of changes in a Pull Request is, the easier
 it is to review. Splitting tasks into multiple smaller PRs is often preferable.
@@ -41,7 +41,7 @@ to review and less likely to get any feedback at all. If your change only makes
 sense in some larger context of future changes, note that in the description,
 but still aim to keep each distinct PR to a "smallest viable change" size.
 
-### Description of changes
+### Description of Changes
 
 Unless the Pull Request is about refactoring code, updating dependencies or
 other internal tasks, assume that the person reading the PR is not a programmer
@@ -62,7 +62,7 @@ Example:
 | ------------------------------------ | ------------------------------------------------------------- |
 | Fixed NoMethodError in RemovalWorker | Fix nil error when removing statuses caused by race condition |
 
-### Technical requirements
+### Technical Requirements
 
 Pull requests that do not pass automated checks on CI may not be reviewed. In
 particular, please keep in mind:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,23 +34,25 @@ reviewed and merged into the codebase.
 
 ### Size and Scope
 
-The smaller and more focused changes in a Pull Request are, the easier they are
-to review. Team time is limited and PRs making large sprawling changes are
-unlikely to get any feedback at all. If your change only makes sense in some
-larger context of future ongoing work, note that in the description, but still
-aim to keep each distinct PR to a "smallest viable change" size.
+Our team time is limited and PRs making large sprawling unsolicited changes are
+unlikely to get any response at all.
+
+The smaller and more narrowly focused the changes in a Pull Request are, the
+easier they are to review and hopefully merge. If your change only makes sense
+in some larger context of future ongoing work, note that in the description, but
+still aim to keep each distinct PR to a "smallest viable change" chunk of work.
 
 ### Description of Changes
 
 Unless the Pull Request is about refactoring code, updating dependencies or
 other internal tasks, assume that the audience are not developers, but a
-Mastodon user or server admin, and try to describe from their perspective.
+Mastodon user or server admin, and try to describe it from their perspective.
 
 The final commit in the main branch will carry the title from the PR. The main
 branch is then fed into the changelog and ultimately into release notes. We try
-to follow the [keepachangelog] spec, and while that does not prescribe how the
-entries ought to be named, starting titles using one of the verbs "Add",
-"Change", "Deprecate", "Remove", or "Fix" (present tense) is helpful.
+to follow the [keepachangelog] spec, and while that does not prescribe how
+exactly the entries ought to be named, starting titles using one of the verbs
+"Add", "Change", "Deprecate", "Remove", or "Fix" (present tense) is helpful.
 
 Example:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,8 +12,6 @@ You can contribute in the following ways:
 Please review the org-level [contribution guidelines] for high-level acceptance
 criteria guidance and the [DEVELOPMENT] guide for environment-specific details.
 
-[contribution guidelines]: https://github.com/mastodon/.github/blob/main/CONTRIBUTING.md
-
 ## API Changes and Additions
 
 Please note that any changes or additions made to the API should have an accompanying pull request on [our documentation repository](https://github.com/mastodon/documentation).
@@ -52,4 +50,5 @@ It is not always possible to phrase every change in such a manner, but it is des
 
 The [Mastodon documentation](https://docs.joinmastodon.org) is a statically generated site. You can [submit merge requests to mastodon/documentation](https://github.com/mastodon/documentation).
 
+[contribution guidelines]: https://github.com/mastodon/.github/blob/main/CONTRIBUTING.md
 [DEVELOPMENT]: docs/DEVELOPMENT.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,29 @@ reviewed and merged into the codebase.
 
 ## Pull requests
 
-**Please use clean, concise titles for your pull requests.** Unless the pull request is about refactoring code, updating dependencies or other internal tasks, assume that the person reading the pull request title is not a programmer or Mastodon developer, but instead a Mastodon user or server administrator, and **try to describe your change or fix from their perspective**. We use commit squashing, so the final commit in the main branch will carry the title of the pull request, and commits from the main branch are fed into the changelog. The changelog is separated into [keepachangelog.com categories](https://keepachangelog.com/en/1.0.0/), and while that spec does not prescribe how the entries ought to be named, for easier sorting, start your pull request titles using one of the verbs "Add", "Change", "Deprecate", "Remove", or "Fix" (present tense).
+### Size and scope
+
+The smaller and more focused a set of changes in a Pull Request is, the easier
+it is to review. Splitting tasks into multiple smaller PRs is often preferable.
+Team time is limited and pull requests making large sprawling changes are harder
+to review and less likely to get any feedback at all. If your change only makes
+sense in some larger context of future changes, note that in the description,
+but still aim to keep each distinct PR to a "smallest viable change" size.
+
+### Description of changes
+
+Unless the Pull Request is about refactoring code, updating dependencies or
+other internal tasks, assume that the person reading the PR is not a programmer
+or Mastodon developer, but a Mastodon user or server admin, and try to describe
+things from their perspective.
+
+We use commit squashing, so the final commit in the main branch will carry the
+title and description from the Pull Request. Commits from the main branch are
+then fed into the changelog and ultimately into release notes. We try to follow
+the [keepachangelog] spec, and while that does not prescribe how the entries
+ought to be named, for easier sorting, starting your pull request titles using
+one of the verbs "Add", "Change", "Deprecate", "Remove", or "Fix" (present
+tense) is helpful when it makes sense.
 
 Example:
 
@@ -40,15 +62,15 @@ Example:
 | ------------------------------------ | ------------------------------------------------------------- |
 | Fixed NoMethodError in RemovalWorker | Fix nil error when removing statuses caused by race condition |
 
-It is not always possible to phrase every change in such a manner, but it is desired.
+### Technical requirements
 
-**The smaller the set of changes in the pull request is, the quicker it can be reviewed and merged.** Splitting tasks into multiple smaller pull requests is often preferable.
-
-**Pull requests that do not pass automated checks may not be reviewed**. In particular, you need to keep in mind:
+Pull requests that do not pass automated checks on CI may not be reviewed. In
+particular, please keep in mind:
 
 - Unit and integration tests (rspec, jest)
 - Code style rules (rubocop, eslint)
 - Normalization of locale files (i18n-tasks)
+- Relevant accessibility or performance concerns
 
 ## Documentation
 
@@ -59,3 +81,4 @@ The [Mastodon documentation](https://docs.joinmastodon.org) is a statically gene
 [DEVELOPMENT]: docs/DEVELOPMENT.md
 [documentation repository]: https://github.com/mastodon/documentation
 [GitHub Issues]: https://github.com/mastodon/mastodon/issues
+[keepachangelog]: https://keepachangelog.com/en/1.0.0/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,8 @@ criteria guidance and the [DEVELOPMENT] guide for environment-specific details.
 
 ## API Changes and Additions
 
-Please note that any changes or additions made to the API should have an accompanying pull request on [our documentation repository](https://github.com/mastodon/documentation).
+Any changes or additions made to the API should have an accompanying pull
+request on our [documentation repository].
 
 ## Bug reports
 
@@ -52,3 +53,4 @@ The [Mastodon documentation](https://docs.joinmastodon.org) is a statically gene
 
 [contribution guidelines]: https://github.com/mastodon/.github/blob/main/CONTRIBUTING.md
 [DEVELOPMENT]: docs/DEVELOPMENT.md
+[documentation repository]: https://github.com/mastodon/documentation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,11 +74,13 @@ particular, please keep in mind:
 
 ## Documentation
 
-The [Mastodon documentation](https://docs.joinmastodon.org) is a statically generated site. You can [submit merge requests to mastodon/documentation](https://github.com/mastodon/documentation).
+The [Mastodon documentation] is a statically generated site that contains guides
+and API docs. You can submit pull requests to the [documentation repository].
 
-[Crowdin]: https://crowdin.com/project/mastodon
 [contribution guidelines]: https://github.com/mastodon/.github/blob/main/CONTRIBUTING.md
+[Crowdin]: https://crowdin.com/project/mastodon
 [DEVELOPMENT]: docs/DEVELOPMENT.md
 [documentation repository]: https://github.com/mastodon/documentation
 [GitHub Issues]: https://github.com/mastodon/mastodon/issues
 [keepachangelog]: https://keepachangelog.com/en/1.0.0/
+[Mastodon documentation]: https://docs.joinmastodon.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ request on our [documentation repository].
 
 Bug reports and feature suggestions must use descriptive and concise titles and
 be submitted to [GitHub Issues]. Please use the search function to make sure
-that you are not submitting duplicate bug reports or feature requests.
+there are not duplicate bug reports or feature requests.
 
 ## Translations
 
@@ -34,13 +34,14 @@ reviewed and merged into the codebase.
 
 ### Size and Scope
 
-Our team time is limited and PRs making large sprawling unsolicited changes are
-unlikely to get any response at all.
+Our time is limited and PRs making large, unsolicited changes are unlikely to
+get a response. Changes which link to an existing confirmed issue, or which come
+from a "help wanted" issue or other request are more likely to be reviewed.
 
-The smaller and more narrowly focused the changes in a Pull Request are, the
-easier they are to review and hopefully merge. If your change only makes sense
-in some larger context of future ongoing work, note that in the description, but
-still aim to keep each distinct PR to a "smallest viable change" chunk of work.
+The smaller and more narrowly focused the changes in a PR are, the easier they
+are to review and potentially merge. If the change only makes sense in some
+larger context of future ongoing work, note that in the description, but still
+aim to keep each distinct PR to a "smallest viable change" chunk of work.
 
 ### Description of Changes
 
@@ -73,7 +74,7 @@ particular, please keep in mind:
 ## Documentation
 
 The [Mastodon documentation] is a statically generated site that contains guides
-and API docs. You can submit pull requests to the [documentation repository].
+and API docs. Improvements are made via PRs to the [documentation repository].
 
 [contribution guidelines]: https://github.com/mastodon/.github/blob/main/CONTRIBUTING.md
 [Crowdin]: https://crowdin.com/project/mastodon

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,6 @@ You can contribute in the following ways:
 - Contributing code to Mastodon by fixing bugs or implementing features
 - Improving the documentation
 
-If your contributions are accepted into Mastodon, you can request to be paid through [our OpenCollective](https://opencollective.com/mastodon).
-
 Please review the org-level [contribution guidelines] for high-level acceptance
 criteria guidance and the [DEVELOPMENT] guide for environment-specific details.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,8 @@ that you are not submitting duplicate bug reports or feature requests.
 
 ## Translations
 
-You can submit translations via [Crowdin](https://crowdin.com/project/mastodon). They are periodically merged into the codebase.
+Translations are community contributed via [Crowdin]. They are periodically
+reviewed and merged into the codebase.
 
 [![Crowdin](https://d322cqt584bo4o.cloudfront.net/mastodon/localized.svg)](https://crowdin.com/project/mastodon)
 
@@ -53,6 +54,7 @@ It is not always possible to phrase every change in such a manner, but it is des
 
 The [Mastodon documentation](https://docs.joinmastodon.org) is a statically generated site. You can [submit merge requests to mastodon/documentation](https://github.com/mastodon/documentation).
 
+[Crowdin]: https://crowdin.com/project/mastodon
 [contribution guidelines]: https://github.com/mastodon/.github/blob/main/CONTRIBUTING.md
 [DEVELOPMENT]: docs/DEVELOPMENT.md
 [documentation repository]: https://github.com/mastodon/documentation


### PR DESCRIPTION
Background: various discussions around trying to properly set expectations internally and externally on how to process contributions, and some recent other docs PRs. Changes:

- Remove open collective ref (from this doc only, still in other spots)
- Chop up PR section into subsections
- Within PR section, clarify team time aspect a bit, and reference the help-wanted issues
- Add accessibility/performance to tech requirements section
- Misc tiny wording changes and markdown formatting/style/org changes throughout

On assumption the end diff might be awkward, tried to keep small commits here - looking at those (or the end preview) may be easier than full raw diff. Ironically, this PR may violate the very rules it's describing.

@andypiper @renchap 
