### PR TITLE
Remove `render_template` from accounts request spec

### DIFF
--- a/spec/requests/accounts_spec.rb
+++ b/spec/requests/accounts_spec.rb
@@ -53,8 +53,9 @@ RSpec.describe 'Accounts show response' do
           it 'returns a standard HTML response', :aggregate_failures do
             expect(response)
               .to have_http_status(200)
-              .and render_template(:show)
               .and have_http_link_header(ActivityPub::TagManager.instance.uri_for(account)).for(rel: 'alternate')
+            expect(response.parsed_body.at('title').content)
+              .to include(account.username)
           end
         end
 


### PR DESCRIPTION
Same idea as https://github.com/mastodon/mastodon/pull/33515 ... there are a small handful of these where we won't migrate to system spec, but want to drop a `render_template`.