### PR TITLE
Add `AccountWarning#appeal_eligible?` method

### DIFF
--- a/app/models/account_warning.rb
+++ b/app/models/account_warning.rb
@@ -27,6 +27,7 @@ class AccountWarning < ApplicationRecord
     suspend: 4_000,
   }, suffix: :action
 
+  APPEAL_WINDOW = 20.days
   RECENT_PERIOD = 3.months.freeze
 
   normalizes :text, with: ->(text) { text.to_s }, apply_to_nil: true
@@ -47,6 +48,10 @@ class AccountWarning < ApplicationRecord
 
   def overruled?
     overruled_at.present?
+  end
+
+  def appeal_eligible?
+    created_at >= APPEAL_WINDOW.ago
   end
 
   def to_log_human_identifier

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -16,8 +16,6 @@
 #  updated_at             :datetime         not null
 #
 class Appeal < ApplicationRecord
-  MAX_STRIKE_AGE = 20.days
-
   TEXT_LENGTH_LIMIT = 2_000
 
   belongs_to :account
@@ -68,6 +66,6 @@ class Appeal < ApplicationRecord
   private
 
   def validate_time_frame
-    errors.add(:base, I18n.t('strikes.errors.too_late')) if strike.created_at < MAX_STRIKE_AGE.ago
+    errors.add(:base, I18n.t('strikes.errors.too_late')) unless strike.appeal_eligible?
   end
 end

--- a/app/policies/account_warning_policy.rb
+++ b/app/policies/account_warning_policy.rb
@@ -6,7 +6,7 @@ class AccountWarningPolicy < ApplicationPolicy
   end
 
   def appeal?
-    target? && record.created_at >= Appeal::MAX_STRIKE_AGE.ago
+    target? && record.appeal_eligible?
   end
 
   private

--- a/spec/models/account_warning_spec.rb
+++ b/spec/models/account_warning_spec.rb
@@ -8,4 +8,18 @@ RSpec.describe AccountWarning do
       it { is_expected.to normalize(:text).from(nil).to('') }
     end
   end
+
+  describe '#appeal_eligible?' do
+    context 'when created too long ago' do
+      subject { Fabricate.build :account_warning, created_at: (described_class::APPEAL_WINDOW * 2).ago }
+
+      it { is_expected.to_not be_appeal_eligible }
+    end
+
+    context 'when created recently' do
+      subject { Fabricate.build :account_warning, created_at: (described_class::APPEAL_WINDOW - 2.days).ago }
+
+      it { is_expected.to be_appeal_eligible }
+    end
+  end
 end

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Appeal do
     it { is_expected.to validate_length_of(:text).is_at_most(described_class::TEXT_LENGTH_LIMIT) }
 
     context 'with a strike created too long ago' do
-      let(:strike) { Fabricate.build :account_warning, created_at: (described_class::MAX_STRIKE_AGE * 2).ago }
+      let(:strike) { Fabricate.build :account_warning, created_at: (AccountWarning::APPEAL_WINDOW * 2).ago }
 
       it { is_expected.to_not allow_values(strike).for(:strike).against(:base).on(:create) }
     end

--- a/spec/policies/account_warning_policy_spec.rb
+++ b/spec/policies/account_warning_policy_spec.rb
@@ -31,11 +31,11 @@ RSpec.describe AccountWarningPolicy do
 
     context 'when account is target' do
       context 'when record is appealable' do
-        it { is_expected.to permit(account, AccountWarning.new(target_account_id: account.id, created_at: Appeal::MAX_STRIKE_AGE.ago + 1.hour)) }
+        it { is_expected.to permit(account, AccountWarning.new(target_account_id: account.id, created_at: AccountWarning::APPEAL_WINDOW.ago + 1.hour)) }
       end
 
       context 'when record is not appealable' do
-        it { is_expected.to_not permit(account, AccountWarning.new(target_account_id: account.id, created_at: Appeal::MAX_STRIKE_AGE.ago - 1.hour)) }
+        it { is_expected.to_not permit(account, AccountWarning.new(target_account_id: account.id, created_at: AccountWarning::APPEAL_WINDOW.ago - 1.hour)) }
       end
     end
   end


### PR DESCRIPTION
Extracted from what was previously a larger refactor of misc "policy" classes.

Originally the change was just to add a private method to the account warning policy -- but I realized while reworking that one that all (well, 2 spots) of the usage of that constant was other classes "reaching in" to account warning ("strike") to check against it's constant.

Instead...

- Move the constant definition to `AccountWarning` so that the strike owns the "how long can I be appealed" idea
- Add a query method, `appeal_eligible?` to capture the check
- Update the account warning policy and appeal validation spots to use that method
- Misc spec updates as needed to make that all make sense