### PR TITLE
Use `with_options` for Account `if: :local?` validation group

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -119,11 +119,11 @@ class Account < ApplicationRecord
   validates :note, note_length: { maximum: NOTE_LENGTH_LIMIT }, if: -> { local? && will_save_change_to_note? }
   validates :fields, length: { maximum: DEFAULT_FIELDS_SIZE }, if: -> { local? && will_save_change_to_fields? }
   validates_with EmptyProfileFieldNamesValidator, if: -> { local? && will_save_change_to_fields? }
-  with_options on: :create do
-    validates :uri, absence: true, if: :local?
-    validates :inbox_url, absence: true, if: :local?
-    validates :shared_inbox_url, absence: true, if: :local?
-    validates :followers_url, absence: true, if: :local?
+  with_options on: :create, if: :local? do
+    validates :followers_url, absence: true
+    validates :inbox_url, absence: true
+    validates :shared_inbox_url, absence: true
+    validates :uri, absence: true
   end
 
   normalizes :username, with: ->(username) { username.squish }

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -595,6 +595,11 @@ RSpec.describe Account do
 
       it { is_expected.to allow_value(fields_empty_name_value).for(:fields) }
       it { is_expected.to_not allow_values(fields_over_limit, fields_empty_name).for(:fields) }
+
+      it { is_expected.to validate_absence_of(:followers_url).on(:create) }
+      it { is_expected.to validate_absence_of(:inbox_url).on(:create) }
+      it { is_expected.to validate_absence_of(:shared_inbox_url).on(:create) }
+      it { is_expected.to validate_absence_of(:uri).on(:create) }
     end
 
     context 'when account is remote' do


### PR DESCRIPTION
Followup on https://github.com/mastodon/mastodon/pull/33525 and https://github.com/mastodon/mastodon/pull/33508 -- and quite possibly final prep for putting the larger local/remote groups into similar grouping.

In here -- add spec for the "absence on create when local" group of validations; then add the "if local" portion to the existing `with_options` block around that.