### PR TITLE
Use `in_order_of` in `trends/*` classes

### DIFF
--- a/app/models/trends/links.rb
+++ b/app/models/trends/links.rb
@@ -16,7 +16,7 @@ class Trends::Links < Trends::Base
   class Query < Trends::Query
     def to_arel
       scope = PreviewCard.joins(:trend).reorder(score: :desc)
-      scope = scope.reorder(language_order_clause.desc, score: :desc) if preferred_languages.present?
+      scope = scope.merge(language_order_clause) if preferred_languages.present?
       scope = scope.merge(PreviewCardTrend.allowed) if @allowed
       scope = scope.offset(@offset) if @offset.present?
       scope = scope.limit(@limit) if @limit.present?
@@ -26,7 +26,7 @@ class Trends::Links < Trends::Base
     private
 
     def language_order_clause
-      Arel::Nodes::Case.new.when(PreviewCardTrend.arel_table[:language].in(preferred_languages)).then(1).else(0)
+      language_order_for(PreviewCardTrend)
     end
   end
 

--- a/app/models/trends/query.rb
+++ b/app/models/trends/query.rb
@@ -94,6 +94,13 @@ class Trends::Query
     to_arel.to_a
   end
 
+  def language_order_for(trend_class)
+    trend_class
+      .reorder(nil)
+      .in_order_of(:language, [preferred_languages], filter: false)
+      .order(score: :desc)
+  end
+
   def preferred_languages
     if @account&.chosen_languages.present?
       @account.chosen_languages

--- a/app/models/trends/statuses.rb
+++ b/app/models/trends/statuses.rb
@@ -15,7 +15,7 @@ class Trends::Statuses < Trends::Base
   class Query < Trends::Query
     def to_arel
       scope = Status.joins(:trend).reorder(score: :desc)
-      scope = scope.reorder(language_order_clause.desc, score: :desc) if preferred_languages.present?
+      scope = scope.merge(language_order_clause) if preferred_languages.present?
       scope = scope.merge(StatusTrend.allowed) if @allowed
       scope = scope.not_excluded_by_account(@account).not_domain_blocked_by_account(@account) if @account.present?
       scope = scope.offset(@offset) if @offset.present?
@@ -26,7 +26,7 @@ class Trends::Statuses < Trends::Base
     private
 
     def language_order_clause
-      Arel::Nodes::Case.new.when(StatusTrend.arel_table[:language].in(preferred_languages)).then(1).else(0)
+      language_order_for(StatusTrend)
     end
   end
 

--- a/app/models/trends/tags.rb
+++ b/app/models/trends/tags.rb
@@ -15,7 +15,8 @@ class Trends::Tags < Trends::Base
 
   class Query < Trends::Query
     def to_arel
-      scope = Tag.joins(:trend).reorder(language_order_clause.desc, score: :desc)
+      scope = Tag.joins(:trend).reorder(score: :desc)
+      scope = scope.merge(language_order_clause) if preferred_languages.present?
       scope = scope.merge(TagTrend.allowed) if @allowed
       scope = scope.offset(@offset) if @offset.present?
       scope = scope.limit(@limit) if @limit.present?
@@ -25,7 +26,7 @@ class Trends::Tags < Trends::Base
     private
 
     def language_order_clause
-      Arel::Nodes::Case.new.when(TagTrend.arel_table[:language].in(preferred_languages)).then(1).else(0)
+      language_order_for(TagTrend)
     end
   end
 

--- a/spec/models/trends/links_spec.rb
+++ b/spec/models/trends/links_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Trends::Links do
   describe 'Trends::Links::Query' do
     subject { described_class.new.query }
 
-    describe '.records' do
+    describe '#records' do
       context 'with scored cards' do
         let!(:higher_score) { Fabricate :preview_card_trend, score: 10, language: 'en' }
         let!(:lower_score) { Fabricate :preview_card_trend, score: 1, language: 'es' }

--- a/spec/models/trends/links_spec.rb
+++ b/spec/models/trends/links_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Trends::Links do
+  describe 'Trends::Links::Query' do
+    subject { described_class.new.query }
+
+    describe '.records' do
+      context 'with scored cards' do
+        let!(:higher_score) { Fabricate :preview_card_trend, score: 10, language: 'en' }
+        let!(:lower_score) { Fabricate :preview_card_trend, score: 1, language: 'es' }
+
+        it 'returns higher score first' do
+          expect(subject.records)
+            .to eq([higher_score.preview_card, lower_score.preview_card])
+        end
+
+        context 'with preferred locale' do
+          before { subject.in_locale!('es') }
+
+          it 'returns in language order' do
+            expect(subject.records)
+              .to eq([lower_score.preview_card, higher_score.preview_card])
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/trends/statuses_spec.rb
+++ b/spec/models/trends/statuses_spec.rb
@@ -45,6 +45,31 @@ RSpec.describe Trends::Statuses do
     end
   end
 
+  describe 'Trends::Statuses::Query methods' do
+    subject { described_class.new.query }
+
+    describe '.records' do
+      context 'with scored cards' do
+        let!(:higher_score) { Fabricate :status_trend, score: 10, language: 'en' }
+        let!(:lower_score) { Fabricate :status_trend, score: 1, language: 'es' }
+
+        it 'returns higher score first' do
+          expect(subject.records)
+            .to eq([higher_score.status, lower_score.status])
+        end
+
+        context 'with preferred locale' do
+          before { subject.in_locale!('es') }
+
+          it 'returns in language order' do
+            expect(subject.records)
+              .to eq([lower_score.status, higher_score.status])
+          end
+        end
+      end
+    end
+  end
+
   describe '#add' do
     let(:status) { Fabricate(:status) }
 

--- a/spec/models/trends/statuses_spec.rb
+++ b/spec/models/trends/statuses_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Trends::Statuses do
   describe 'Trends::Statuses::Query methods' do
     subject { described_class.new.query }
 
-    describe '.records' do
+    describe '#records' do
       context 'with scored cards' do
         let!(:higher_score) { Fabricate :status_trend, score: 10, language: 'en' }
         let!(:lower_score) { Fabricate :status_trend, score: 1, language: 'es' }

--- a/spec/models/trends/tags_spec.rb
+++ b/spec/models/trends/tags_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Trends::Tags do
   describe 'Trends::Tags::Query' do
     subject { described_class.new.query }
 
-    describe '.records' do
+    describe '#records' do
       context 'with scored cards' do
         let!(:higher_score) { Fabricate :tag_trend, score: 10, language: 'en' }
         let!(:lower_score) { Fabricate :tag_trend, score: 1, language: 'es' }

--- a/spec/models/trends/tags_spec.rb
+++ b/spec/models/trends/tags_spec.rb
@@ -29,6 +29,31 @@ RSpec.describe Trends::Tags do
     end
   end
 
+  describe 'Trends::Tags::Query' do
+    subject { described_class.new.query }
+
+    describe '.records' do
+      context 'with scored cards' do
+        let!(:higher_score) { Fabricate :tag_trend, score: 10, language: 'en' }
+        let!(:lower_score) { Fabricate :tag_trend, score: 1, language: 'es' }
+
+        it 'returns higher score first' do
+          expect(subject.records)
+            .to eq([higher_score.tag, lower_score.tag])
+        end
+
+        context 'with preferred locale' do
+          before { subject.in_locale!('es') }
+
+          it 'returns in language order' do
+            expect(subject.records)
+              .to eq([lower_score.tag, higher_score.tag])
+          end
+        end
+      end
+    end
+  end
+
   describe '#refresh' do
     let!(:today) { at_time }
     let!(:yesterday) { today - 1.day }


### PR DESCRIPTION
Same sort of change as https://github.com/mastodon/mastodon/pull/33446

Replaces the `Arel::Nodes::Case...` query build in these classes with an `in_order_of`, now that `filter: false` gives us the desired behavioűr there.

Will leave a few inline notes to explain or indicate possible future improvement ... did not want to do too much here because I think there may be other ongoing work here around shuffling these  more from redis into DB  (maybe?)