### PR TITLE
Extract `CSS_COLORS` constant for `UserRole` regex validation

### DIFF
--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -42,7 +42,7 @@ class UserRole < ApplicationRecord
   NOBODY_POSITION = -1
 
   POSITION_LIMIT = (2**31) - 1
-  VALID_COLOR = /\A#?(?:[A-F0-9]{3}){1,2}\z/i # CSS-style hex colors
+  CSS_COLORS = /\A#?(?:[A-F0-9]{3}){1,2}\z/i # CSS-style hex colors
 
   module Flags
     NONE = 0
@@ -91,7 +91,7 @@ class UserRole < ApplicationRecord
   attr_writer :current_account
 
   validates :name, presence: true, unless: :everyone?
-  validates :color, format: { with: VALID_COLOR }, if: :color?
+  validates :color, format: { with: CSS_COLORS }, if: :color?
   validates :position, numericality: { in: (-POSITION_LIMIT..POSITION_LIMIT) }
 
   validate :validate_permissions_elevation

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -42,6 +42,7 @@ class UserRole < ApplicationRecord
   NOBODY_POSITION = -1
 
   POSITION_LIMIT = (2**31) - 1
+  VALID_COLOR = /\A#?(?:[A-F0-9]{3}){1,2}\z/i # CSS-style hex colors
 
   module Flags
     NONE = 0
@@ -90,7 +91,7 @@ class UserRole < ApplicationRecord
   attr_writer :current_account
 
   validates :name, presence: true, unless: :everyone?
-  validates :color, format: { with: /\A#?(?:[A-F0-9]{3}){1,2}\z/i }, unless: -> { color.blank? }
+  validates :color, format: { with: VALID_COLOR }, if: :color?
   validates :position, numericality: { in: (-POSITION_LIMIT..POSITION_LIMIT) }
 
   validate :validate_permissions_elevation


### PR DESCRIPTION
Was part of a much larger refactor in aftermatch of expanding `UserRole` spec coverage.

Changes:

- Move a regex to a constant which should assist future developers whose eyes glaze over when they look at a regex to be like "ah, yes, css hex colors! I remember those, this makes sense now!" It would be truly satisfying if ruby itself or some gem we used had a regex like this with a revealing name that we could re-use, but I didn't see an obvious one.
- Use "if present" instead of "unless blank" for what I suspect is a 0.1 percent better comprehension experience

There's existing coverage for the various validation scenarios here.