### PR TITLE
Add `build_object` method for defaults in `AP::Activity::Create` spec

### DIFF
--- a/spec/lib/activitypub/activity/create_spec.rb
+++ b/spec/lib/activitypub/activity/create_spec.rb
@@ -162,12 +162,9 @@ RSpec.describe ActivityPub::Activity::Create do
 
       context 'when object publication date is below ISO8601 range' do
         let(:object_json) do
-          {
-            id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
-            type: 'Note',
-            content: 'Lorem ipsum',
-            published: '-0977-11-03T08:31:22Z',
-          }
+          build_object(
+            published: '-0977-11-03T08:31:22Z'
+          )
         end
 
         it 'creates status with a valid creation date', :aggregate_failures do
@@ -184,12 +181,9 @@ RSpec.describe ActivityPub::Activity::Create do
 
       context 'when object publication date is above ISO8601 range' do
         let(:object_json) do
-          {
-            id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
-            type: 'Note',
-            content: 'Lorem ipsum',
-            published: '10000-11-03T08:31:22Z',
-          }
+          build_object(
+            published: '10000-11-03T08:31:22Z'
+          )
         end
 
         it 'creates status with a valid creation date', :aggregate_failures do
@@ -206,13 +200,10 @@ RSpec.describe ActivityPub::Activity::Create do
 
       context 'when object has been edited' do
         let(:object_json) do
-          {
-            id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
-            type: 'Note',
-            content: 'Lorem ipsum',
+          build_object(
             published: '2022-01-22T15:00:00Z',
-            updated: '2022-01-22T16:00:00Z',
-          }
+            updated: '2022-01-22T16:00:00Z'
+          )
         end
 
         it 'creates status with appropriate creation and edition dates', :aggregate_failures do
@@ -232,13 +223,10 @@ RSpec.describe ActivityPub::Activity::Create do
 
       context 'when object has update date equal to creation date' do
         let(:object_json) do
-          {
-            id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
-            type: 'Note',
-            content: 'Lorem ipsum',
+          build_object(
             published: '2022-01-22T15:00:00Z',
-            updated: '2022-01-22T15:00:00Z',
-          }
+            updated: '2022-01-22T15:00:00Z'
+          )
         end
 
         it 'creates status and does not mark it as edited' do
@@ -254,11 +242,9 @@ RSpec.describe ActivityPub::Activity::Create do
 
       context 'with an unknown object type' do
         let(:object_json) do
-          {
-            id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
-            type: 'Banana',
-            content: 'Lorem ipsum',
-          }
+          build_object(
+            type: 'Banana'
+          )
         end
 
         it 'does not create a status' do
@@ -267,13 +253,7 @@ RSpec.describe ActivityPub::Activity::Create do
       end
 
       context 'with a standalone' do
-        let(:object_json) do
-          {
-            id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
-            type: 'Note',
-            content: 'Lorem ipsum',
-          }
-        end
+        let(:object_json) { build_object }
 
         it 'creates status' do
           expect { subject.perform }.to change(sender.statuses, :count).by(1)
@@ -296,12 +276,9 @@ RSpec.describe ActivityPub::Activity::Create do
 
       context 'when public with explicit public address' do
         let(:object_json) do
-          {
-            id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
-            type: 'Note',
-            content: 'Lorem ipsum',
-            to: 'https://www.w3.org/ns/activitystreams#Public',
-          }
+          build_object(
+            to: 'https://www.w3.org/ns/activitystreams#Public'
+          )
         end
 
         it 'creates status' do
@@ -316,12 +293,9 @@ RSpec.describe ActivityPub::Activity::Create do
 
       context 'when public with as:Public' do
         let(:object_json) do
-          {
-            id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
-            type: 'Note',
-            content: 'Lorem ipsum',
-            to: 'as:Public',
-          }
+          build_object(
+            to: 'as:Public'
+          )
         end
 
         it 'creates status' do
@@ -336,12 +310,9 @@ RSpec.describe ActivityPub::Activity::Create do
 
       context 'when public with Public' do
         let(:object_json) do
-          {
-            id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
-            type: 'Note',
-            content: 'Lorem ipsum',
-            to: 'Public',
-          }
+          build_object(
+            to: 'Public'
+          )
         end
 
         it 'creates status' do
@@ -356,12 +327,9 @@ RSpec.describe ActivityPub::Activity::Create do
 
       context 'when unlisted with explicit public address' do
         let(:object_json) do
-          {
-            id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
-            type: 'Note',
-            content: 'Lorem ipsum',
-            cc: 'https://www.w3.org/ns/activitystreams#Public',
-          }
+          build_object(
+            cc: 'https://www.w3.org/ns/activitystreams#Public'
+          )
         end
 
         it 'creates status' do
@@ -376,12 +344,9 @@ RSpec.describe ActivityPub::Activity::Create do
 
       context 'when unlisted with as:Public' do
         let(:object_json) do
-          {
-            id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
-            type: 'Note',
-            content: 'Lorem ipsum',
-            cc: 'as:Public',
-          }
+          build_object(
+            cc: 'as:Public'
+          )
         end
 
         it 'creates status' do
@@ -396,12 +361,9 @@ RSpec.describe ActivityPub::Activity::Create do
 
       context 'when unlisted with Public' do
         let(:object_json) do
-          {
-            id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
-            type: 'Note',
-            content: 'Lorem ipsum',
-            cc: 'Public',
-          }
+          build_object(
+            cc: 'Public'
+          )
         end
 
         it 'creates status' do
@@ -416,12 +378,9 @@ RSpec.describe ActivityPub::Activity::Create do
 
       context 'when private' do
         let(:object_json) do
-          {
-            id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
-            type: 'Note',
-            content: 'Lorem ipsum',
-            to: 'http://example.com/followers',
-          }
+          build_object(
+            to: 'http://example.com/followers'
+          )
         end
 
         it 'creates status' do
@@ -436,16 +395,13 @@ RSpec.describe ActivityPub::Activity::Create do
 
       context 'when private with inlined Collection in audience' do
         let(:object_json) do
-          {
-            id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
-            type: 'Note',
-            content: 'Lorem ipsum',
+          build_object(
             to: {
               type: 'OrderedCollection',
               id: 'http://example.com/followers',
               first: 'http://example.com/followers?page=true',
-            },
-          }
+            }
+          )
         end
 
         it 'creates status' do
@@ -462,12 +418,9 @@ RSpec.describe ActivityPub::Activity::Create do
         let(:recipient) { Fabricate(:account) }
 
         let(:object_json) do
-          {
-            id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
-            type: 'Note',
-            content: 'Lorem ipsum',
-            to: ActivityPub::TagManager.instance.uri_for(recipient),
-          }
+          build_object(
+            to: ActivityPub::TagManager.instance.uri_for(recipient)
+          )
         end
 
         it 'creates status with a silent mention' do
@@ -485,16 +438,13 @@ RSpec.describe ActivityPub::Activity::Create do
         let(:recipient) { Fabricate(:account) }
 
         let(:object_json) do
-          {
-            id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
-            type: 'Note',
-            content: 'Lorem ipsum',
+          build_object(
             to: ActivityPub::TagManager.instance.uri_for(recipient),
             tag: {
               type: 'Mention',
               href: ActivityPub::TagManager.instance.uri_for(recipient),
-            },
-          }
+            }
+          )
         end
 
         it 'creates status' do
@@ -511,12 +461,9 @@ RSpec.describe ActivityPub::Activity::Create do
         let(:original_status) { Fabricate(:status) }
 
         let(:object_json) do
-          {
-            id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
-            type: 'Note',
-            content: 'Lorem ipsum',
-            inReplyTo: ActivityPub::TagManager.instance.uri_for(original_status),
-          }
+          build_object(
+            inReplyTo: ActivityPub::TagManager.instance.uri_for(original_status)
+          )
         end
 
         it 'creates status' do
@@ -536,17 +483,14 @@ RSpec.describe ActivityPub::Activity::Create do
         let(:recipient) { Fabricate(:account) }
 
         let(:object_json) do
-          {
-            id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
-            type: 'Note',
-            content: 'Lorem ipsum',
+          build_object(
             tag: [
               {
                 type: 'Mention',
                 href: ActivityPub::TagManager.instance.uri_for(recipient),
               },
-            ],
-          }
+            ]
+          )
         end
 
         it 'creates status' do
@@ -561,16 +505,13 @@ RSpec.describe ActivityPub::Activity::Create do
 
       context 'with mentions missing href' do
         let(:object_json) do
-          {
-            id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
-            type: 'Note',
-            content: 'Lorem ipsum',
+          build_object(
             tag: [
               {
                 type: 'Mention',
               },
-            ],
-          }
+            ]
+          )
         end
 
         it 'creates status' do
@@ -583,10 +524,7 @@ RSpec.describe ActivityPub::Activity::Create do
 
       context 'with media attachments' do
         let(:object_json) do
-          {
-            id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
-            type: 'Note',
-            content: 'Lorem ipsum',
+          build_object(
             attachment: [
               {
                 type: 'Document',
@@ -598,8 +536,8 @@ RSpec.describe ActivityPub::Activity::Create do
                 mediaType: 'image/png',
                 url: 'http://example.com/emoji.png',
               },
-            ],
-          }
+            ]
+          )
         end
 
         it 'creates status with correctly-ordered media attachments' do
@@ -615,10 +553,7 @@ RSpec.describe ActivityPub::Activity::Create do
 
       context 'with media attachments with long description' do
         let(:object_json) do
-          {
-            id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
-            type: 'Note',
-            content: 'Lorem ipsum',
+          build_object(
             attachment: [
               {
                 type: 'Document',
@@ -626,8 +561,8 @@ RSpec.describe ActivityPub::Activity::Create do
                 url: 'http://example.com/attachment.png',
                 name: '*' * MediaAttachment::MAX_DESCRIPTION_LENGTH,
               },
-            ],
-          }
+            ]
+          )
         end
 
         it 'creates status' do
@@ -642,10 +577,7 @@ RSpec.describe ActivityPub::Activity::Create do
 
       context 'with media attachments with long description as summary' do
         let(:object_json) do
-          {
-            id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
-            type: 'Note',
-            content: 'Lorem ipsum',
+          build_object(
             attachment: [
               {
                 type: 'Document',
@@ -653,8 +585,8 @@ RSpec.describe ActivityPub::Activity::Create do
                 url: 'http://example.com/attachment.png',
                 summary: '*' * MediaAttachment::MAX_DESCRIPTION_LENGTH,
               },
-            ],
-          }
+            ]
+          )
         end
 
         it 'creates status' do
@@ -669,10 +601,7 @@ RSpec.describe ActivityPub::Activity::Create do
 
       context 'with media attachments with focal points' do
         let(:object_json) do
-          {
-            id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
-            type: 'Note',
-            content: 'Lorem ipsum',
+          build_object(
             attachment: [
               {
                 type: 'Document',
@@ -680,8 +609,8 @@ RSpec.describe ActivityPub::Activity::Create do
                 url: 'http://example.com/attachment.png',
                 focalPoint: [0.5, -0.7],
               },
-            ],
-          }
+            ]
+          )
         end
 
         it 'creates status' do
@@ -696,17 +625,14 @@ RSpec.describe ActivityPub::Activity::Create do
 
       context 'with media attachments missing url' do
         let(:object_json) do
-          {
-            id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
-            type: 'Note',
-            content: 'Lorem ipsum',
+          build_object(
             attachment: [
               {
                 type: 'Document',
                 mediaType: 'image/png',
               },
-            ],
-          }
+            ]
+          )
         end
 
         it 'creates status' do
@@ -719,18 +645,15 @@ RSpec.describe ActivityPub::Activity::Create do
 
       context 'with hashtags' do
         let(:object_json) do
-          {
-            id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
-            type: 'Note',
-            content: 'Lorem ipsum',
+          build_object(
             tag: [
               {
                 type: 'Hashtag',
                 href: 'http://example.com/blah',
                 name: '#test',
               },
-            ],
-          }
+            ]
+          )
         end
 
         it 'creates status' do
@@ -745,10 +668,7 @@ RSpec.describe ActivityPub::Activity::Create do
 
       context 'with featured hashtags' do
         let(:object_json) do
-          {
-            id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
-            type: 'Note',
-            content: 'Lorem ipsum',
+          build_object(
             to: 'https://www.w3.org/ns/activitystreams#Public',
             tag: [
               {
@@ -756,8 +676,8 @@ RSpec.describe ActivityPub::Activity::Create do
                 href: 'http://example.com/blah',
                 name: '#test',
               },
-            ],
-          }
+            ]
+          )
         end
 
         before do
@@ -779,17 +699,14 @@ RSpec.describe ActivityPub::Activity::Create do
 
       context 'with hashtags missing name' do
         let(:object_json) do
-          {
-            id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
-            type: 'Note',
-            content: 'Lorem ipsum',
+          build_object(
             tag: [
               {
                 type: 'Hashtag',
                 href: 'http://example.com/blah',
               },
-            ],
-          }
+            ]
+          )
         end
 
         it 'creates status' do
@@ -802,18 +719,15 @@ RSpec.describe ActivityPub::Activity::Create do
 
       context 'with hashtags invalid name' do
         let(:object_json) do
-          {
-            id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
-            type: 'Note',
-            content: 'Lorem ipsum',
+          build_object(
             tag: [
               {
                 type: 'Hashtag',
                 href: 'http://example.com/blah',
                 name: 'foo, #eh !',
               },
-            ],
-          }
+            ]
+          )
         end
 
         it 'creates status' do
@@ -826,9 +740,7 @@ RSpec.describe ActivityPub::Activity::Create do
 
       context 'with emojis' do
         let(:object_json) do
-          {
-            id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
-            type: 'Note',
+          build_object(
             content: 'Lorem ipsum :tinking:',
             tag: [
               {
@@ -838,8 +750,8 @@ RSpec.describe ActivityPub::Activity::Create do
                 },
                 name: 'tinking',
               },
-            ],
-          }
+            ]
+          )
         end
 
         it 'creates status' do
@@ -854,9 +766,7 @@ RSpec.describe ActivityPub::Activity::Create do
 
       context 'with emojis served with invalid content-type' do
         let(:object_json) do
-          {
-            id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
-            type: 'Note',
+          build_object(
             content: 'Lorem ipsum :tinkong:',
             tag: [
               {
@@ -866,8 +776,8 @@ RSpec.describe ActivityPub::Activity::Create do
                 },
                 name: 'tinkong',
               },
-            ],
-          }
+            ]
+          )
         end
 
         it 'creates status' do
@@ -882,9 +792,7 @@ RSpec.describe ActivityPub::Activity::Create do
 
       context 'with emojis missing name' do
         let(:object_json) do
-          {
-            id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
-            type: 'Note',
+          build_object(
             content: 'Lorem ipsum :tinking:',
             tag: [
               {
@@ -893,8 +801,8 @@ RSpec.describe ActivityPub::Activity::Create do
                   url: 'http://example.com/emoji.png',
                 },
               },
-            ],
-          }
+            ]
+          )
         end
 
         it 'creates status' do
@@ -907,17 +815,15 @@ RSpec.describe ActivityPub::Activity::Create do
 
       context 'with emojis missing icon' do
         let(:object_json) do
-          {
-            id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
-            type: 'Note',
+          build_object(
             content: 'Lorem ipsum :tinking:',
             tag: [
               {
                 type: 'Emoji',
                 name: 'tinking',
               },
-            ],
-          }
+            ]
+          )
         end
 
         it 'creates status' do
@@ -930,8 +836,7 @@ RSpec.describe ActivityPub::Activity::Create do
 
       context 'with poll' do
         let(:object_json) do
-          {
-            id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
+          build_object(
             type: 'Question',
             content: 'Which color was the submarine?',
             oneOf: [
@@ -949,8 +854,8 @@ RSpec.describe ActivityPub::Activity::Create do
                   totalItems: 3,
                 },
               },
-            ],
-          }
+            ]
+          )
         end
 
         it 'creates status with a poll' do
@@ -973,12 +878,10 @@ RSpec.describe ActivityPub::Activity::Create do
         let!(:local_status) { Fabricate(:status, poll: poll) }
 
         let(:object_json) do
-          {
-            id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
-            type: 'Note',
+          build_object(
             name: 'Yellow',
-            inReplyTo: ActivityPub::TagManager.instance.uri_for(local_status),
-          }
+            inReplyTo: ActivityPub::TagManager.instance.uri_for(local_status)
+          ).except(:content)
         end
 
         it 'adds a vote to the poll with correct uri' do
@@ -1000,12 +903,10 @@ RSpec.describe ActivityPub::Activity::Create do
         let!(:local_status) { Fabricate(:status, poll: poll) }
 
         let(:object_json) do
-          {
-            id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
-            type: 'Note',
+          build_object(
             name: 'Yellow',
-            inReplyTo: ActivityPub::TagManager.instance.uri_for(local_status),
-          }
+            inReplyTo: ActivityPub::TagManager.instance.uri_for(local_status)
+          ).except(:content)
         end
 
         it 'does not add a vote to the poll' do
@@ -1017,10 +918,7 @@ RSpec.describe ActivityPub::Activity::Create do
 
       context 'with counts' do
         let(:object_json) do
-          {
-            id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
-            type: 'Note',
-            content: 'Lorem ipsum',
+          build_object(
             likes: {
               id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar', '/likes'].join,
               type: 'Collection',
@@ -1030,8 +928,8 @@ RSpec.describe ActivityPub::Activity::Create do
               id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar', '/shares'].join,
               type: 'Collection',
               totalItems: 100,
-            },
-          }
+            }
+          )
         end
 
         it 'uses the counts from the created object' do
@@ -1060,12 +958,9 @@ RSpec.describe ActivityPub::Activity::Create do
       end
 
       let(:object_json) do
-        {
-          id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
-          type: 'Note',
-          content: 'Lorem ipsum',
-          to: 'https://www.w3.org/ns/activitystreams#Public',
-        }
+        build_object(
+          to: 'https://www.w3.org/ns/activitystreams#Public'
+        )
       end
 
       before do
@@ -1095,13 +990,7 @@ RSpec.describe ActivityPub::Activity::Create do
         subject.perform
       end
 
-      let(:object_json) do
-        {
-          id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
-          type: 'Note',
-          content: 'Lorem ipsum',
-        }
-      end
+      let(:object_json) { build_object }
 
       it 'creates status' do
         status = sender.statuses.first
@@ -1116,12 +1005,9 @@ RSpec.describe ActivityPub::Activity::Create do
 
       let!(:local_status) { Fabricate(:status) }
       let(:object_json) do
-        {
-          id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
-          type: 'Note',
-          content: 'Lorem ipsum',
-          inReplyTo: ActivityPub::TagManager.instance.uri_for(local_status),
-        }
+        build_object(
+          inReplyTo: ActivityPub::TagManager.instance.uri_for(local_status)
+        )
       end
 
       before do
@@ -1140,13 +1026,11 @@ RSpec.describe ActivityPub::Activity::Create do
       subject { described_class.new(json, sender, delivery: true) }
 
       let!(:local_account) { Fabricate(:account) }
+
       let(:object_json) do
-        {
-          id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
-          type: 'Note',
-          content: 'Lorem ipsum',
-          to: ActivityPub::TagManager.instance.uri_for(local_account),
-        }
+        build_object(
+          to: ActivityPub::TagManager.instance.uri_for(local_account)
+        )
       end
 
       before do
@@ -1166,12 +1050,9 @@ RSpec.describe ActivityPub::Activity::Create do
 
       let!(:local_account) { Fabricate(:account) }
       let(:object_json) do
-        {
-          id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
-          type: 'Note',
-          content: 'Lorem ipsum',
-          cc: ActivityPub::TagManager.instance.uri_for(local_account),
-        }
+        build_object(
+          cc: ActivityPub::TagManager.instance.uri_for(local_account)
+        )
       end
 
       before do
@@ -1193,17 +1074,19 @@ RSpec.describe ActivityPub::Activity::Create do
         subject.perform
       end
 
-      let(:object_json) do
-        {
-          id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
-          type: 'Note',
-          content: 'Lorem ipsum',
-        }
-      end
+      let(:object_json) { build_object }
 
       it 'does not create anything' do
         expect(sender.statuses.count).to eq 0
       end
+    end
+
+    def build_object(options = {})
+      {
+        id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
+        type: 'Note',
+        content: 'Lorem ipsum',
+      }.merge(options)
     end
   end
 end


### PR DESCRIPTION
Sort of related to https://github.com/mastodon/mastodon/pull/33507 in that they both belong to the "more than 1k LOC" club.

The structure of basically all the `perform` examples in this file is to have a well named context which sets up some JSON, `perform` is ... performed ... and then assert against whatever happened. The vast majority of these have the exact same basic/default attributes in that object hash. So, this is sort of a mix of LOC reduction in the file, and DRY up all that setup via a factory-style private method here to build the json.

I think it also makes each example a little more readable as well, since the "interesting" part about each one is what is sent to the method.

Preserves coverage, drops file from just over ~1200 to just under ~1100 LOC.

There are a few other repeated or reducable things in this and the other AP specs, but wanted to isolate this relatively large yet very boring one by itself first.