### PR TITLE
Add validation spec and use `with_options` on remote `Account#uri` presence

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -110,7 +110,9 @@ class Account < ApplicationRecord
   validates :username, format: { with: USERNAME_ONLY_RE }, if: -> { (remote? || actor_type_application?) && will_save_change_to_username? }
 
   # Remote user validations
-  validates :uri, presence: true, unless: :local?, on: :create
+  with_options if: :remote? do
+    validates :uri, presence: true, on: :create
+  end
 
   # Local user validations
   validates :username, format: { with: /\A[a-z0-9_]+\z/i }, length: { maximum: USERNAME_LENGTH_LIMIT }, if: -> { local? && will_save_change_to_username? && !actor_type_application? }

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -619,6 +619,8 @@ RSpec.describe Account do
       it { is_expected.to allow_values(display_name_over_limit).for(:display_name) }
 
       it { is_expected.to allow_values(account_note_over_limit).for(:note) }
+
+      it { is_expected.to validate_presence_of(:uri).on(:create) }
     end
 
     def username_over_limit


### PR DESCRIPTION
Adds missing validation spec, and adds a `with_options` in the declaration ... which in this case is not super interesting by itself, but is also in advance of doing the opposite for the section right below this, which I think will make sense once they are both like that.