### PR TITLE
Use `config_for` for `Mastodon::Version` metadata/prerelease values

### DIFF
--- a/config/mastodon.yml
+++ b/config/mastodon.yml
@@ -2,3 +2,6 @@
 shared:
   self_destruct_value: <%= ENV.fetch('SELF_DESTRUCT', nil) %>
   software_update_url: <%= ENV.fetch('UPDATE_CHECK_URL', 'https://api.joinmastodon.org/update-check') %>
+  version:
+    metadata: <%= ENV.fetch('MASTODON_VERSION_METADATA', nil) %>
+    prerelease: <%= ENV.fetch('MASTODON_VERSION_PRERELEASE', nil) %>

--- a/lib/mastodon/version.rb
+++ b/lib/mastodon/version.rb
@@ -21,11 +21,11 @@ module Mastodon
     end
 
     def prerelease
-      ENV['MASTODON_VERSION_PRERELEASE'].presence || default_prerelease
+      version_configuration[:prerelease].presence || default_prerelease
     end
 
     def build_metadata
-      ENV.fetch('MASTODON_VERSION_METADATA', nil)
+      version_configuration[:metadata]
     end
 
     def to_a
@@ -76,6 +76,10 @@ module Mastodon
 
     def user_agent
       @user_agent ||= "Mastodon/#{Version} (#{HTTP::Request::USER_AGENT}; +http#{Rails.configuration.x.use_https ? 's' : ''}://#{Rails.configuration.x.web_domain}/)"
+    end
+
+    def version_configuration
+      Rails.configuration.x.mastodon.version
     end
   end
 end


### PR DESCRIPTION
Extracted from previous larger PR which was converting too much at once. Will keep pulling smaller pieces out.