### PR TITLE
Fix `Invite#code` changing value on every save

### DIFF
--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -31,7 +31,7 @@ class Invite < ApplicationRecord
 
   validates :comment, length: { maximum: COMMENT_SIZE_LIMIT }
 
-  before_validation :set_code
+  before_validation :set_code, on: :create
 
   def valid_for_use?
     (max_uses.nil? || uses < max_uses) && !expired? && user&.functional?

--- a/spec/models/invite_spec.rb
+++ b/spec/models/invite_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe Invite do
     it { is_expected.to have_many(:users).inverse_of(:invite) }
   end
 
+  describe 'Validations' do
+    it { is_expected.to validate_length_of(:comment).is_at_most(described_class::COMMENT_SIZE_LIMIT) }
+  end
+
   describe '#valid_for_use?' do
     it 'returns true when there are no limitations' do
       invite = Fabricate(:invite, max_uses: nil, expires_at: nil)

--- a/spec/models/invite_spec.rb
+++ b/spec/models/invite_spec.rb
@@ -14,6 +14,20 @@ RSpec.describe Invite do
     it { is_expected.to validate_length_of(:comment).is_at_most(described_class::COMMENT_SIZE_LIMIT) }
   end
 
+  describe 'Scopes' do
+    describe '.available' do
+      let!(:no_expires) { Fabricate :invite, expires_at: nil }
+      let!(:past_expires) { Fabricate :invite, expires_at: 2.days.ago }
+      let!(:future_expires) { Fabricate :invite, expires_at: 2.days.from_now }
+
+      it 'returns future and non-epiring records' do
+        expect(described_class.available)
+          .to include(no_expires, future_expires)
+          .and not_include(past_expires)
+      end
+    end
+  end
+
   describe '#valid_for_use?' do
     it 'returns true when there are no limitations' do
       invite = Fabricate(:invite, max_uses: nil, expires_at: nil)

--- a/spec/models/invite_spec.rb
+++ b/spec/models/invite_spec.rb
@@ -37,4 +37,26 @@ RSpec.describe Invite do
       expect(invite.valid_for_use?).to be false
     end
   end
+
+  describe 'Callbacks' do
+    describe 'Setting the invite code' do
+      context 'when creating a new record' do
+        subject { Fabricate.build :invite }
+
+        it 'sets a code value' do
+          expect { subject.save }
+            .to change(subject, :code).from(be_blank).to(be_present)
+        end
+      end
+
+      context 'when updating a record' do
+        subject { Fabricate :invite }
+
+        it 'does not change the code value' do
+          expect { subject.update(max_uses: 123_456) }
+            .to not_change(subject, :code)
+        end
+      end
+    end
+  end
 end

--- a/spec/models/invite_spec.rb
+++ b/spec/models/invite_spec.rb
@@ -5,6 +5,11 @@ require 'rails_helper'
 RSpec.describe Invite do
   include_examples 'Expireable'
 
+  describe 'Associations' do
+    it { is_expected.to belong_to(:user).inverse_of(:invites) }
+    it { is_expected.to have_many(:users).inverse_of(:invite) }
+  end
+
   describe '#valid_for_use?' do
     it 'returns true when there are no limitations' do
       invite = Fabricate(:invite, max_uses: nil, expires_at: nil)


### PR DESCRIPTION
Resolves https://github.com/mastodon/mastodon/issues/33549

First commit is actual fix, subsequent commits are tacking on some missing coverage notice while doing this.