### PR TITLE
Remove unused `LanguagePresenter#native_name`

### DIFF
--- a/app/presenters/language_presenter.rb
+++ b/app/presenters/language_presenter.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class LanguagePresenter < ActiveModelSerializers::Model
-  attributes :code, :name, :native_name
+  attributes :code, :name
 
   def initialize(code)
     super()
@@ -12,9 +12,5 @@ class LanguagePresenter < ActiveModelSerializers::Model
 
   def name
     @item[0]
-  end
-
-  def native_name
-    @item[1]
   end
 end

--- a/spec/requests/api/v1/instances/languages_spec.rb
+++ b/spec/requests/api/v1/instances/languages_spec.rb
@@ -9,10 +9,21 @@ RSpec.describe 'Languages' do
     end
 
     it 'returns http success and includes supported languages' do
-      expect(response).to have_http_status(200)
+      expect(response)
+        .to have_http_status(200)
       expect(response.content_type)
         .to start_with('application/json')
-      expect(response.parsed_body.pluck(:code)).to match_array LanguagesHelper::SUPPORTED_LOCALES.keys.map(&:to_s)
+      expect(response.parsed_body)
+        .to match_array(supported_locale_expectations)
+    end
+
+    def supported_locale_expectations
+      LanguagesHelper::SUPPORTED_LOCALES.map do |key, values|
+        include(
+          code: key.to_s,
+          name: values.first
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
Alternative to https://github.com/mastodon/mastodon/pull/32562 which added the value to the response.

Adds spec for the values (code, name) from the presenter which ARE used by the serializer in the API response; removes a method (`native_name`) which has never been used since introduction.

If we actually DO want to expose the value, I can close this, rebase/rework/reopen the other, etc.