### PR TITLE
Fix issue with trending order when user has chosen languages

### DIFF
--- a/app/models/trends/links.rb
+++ b/app/models/trends/links.rb
@@ -16,7 +16,7 @@ class Trends::Links < Trends::Base
   class Query < Trends::Query
     def to_arel
       scope = PreviewCard.joins(:trend).reorder(score: :desc)
-      scope = scope.merge(language_order_clause) if preferred_languages.present?
+      scope = scope.reorder(language_order_clause, score: :desc) if preferred_languages.present?
       scope = scope.merge(PreviewCardTrend.allowed) if @allowed
       scope = scope.offset(@offset) if @offset.present?
       scope = scope.limit(@limit) if @limit.present?
@@ -25,8 +25,8 @@ class Trends::Links < Trends::Base
 
     private
 
-    def language_order_clause
-      language_order_for(PreviewCardTrend)
+    def trend_class
+      PreviewCardTrend
     end
   end
 

--- a/app/models/trends/query.rb
+++ b/app/models/trends/query.rb
@@ -94,11 +94,14 @@ class Trends::Query
     to_arel.to_a
   end
 
-  def language_order_for(trend_class)
+  def language_order_clause
+    Arel::Nodes::Case.new.when(language_is_preferred).then(1).else(0).desc
+  end
+
+  def language_is_preferred
     trend_class
-      .reorder(nil)
-      .in_order_of(:language, [preferred_languages], filter: false)
-      .order(score: :desc)
+      .arel_table[:language]
+      .in(preferred_languages)
   end
 
   def preferred_languages

--- a/app/models/trends/statuses.rb
+++ b/app/models/trends/statuses.rb
@@ -15,7 +15,7 @@ class Trends::Statuses < Trends::Base
   class Query < Trends::Query
     def to_arel
       scope = Status.joins(:trend).reorder(score: :desc)
-      scope = scope.merge(language_order_clause) if preferred_languages.present?
+      scope = scope.reorder(language_order_clause, score: :desc) if preferred_languages.present?
       scope = scope.merge(StatusTrend.allowed) if @allowed
       scope = scope.not_excluded_by_account(@account).not_domain_blocked_by_account(@account) if @account.present?
       scope = scope.offset(@offset) if @offset.present?
@@ -25,8 +25,8 @@ class Trends::Statuses < Trends::Base
 
     private
 
-    def language_order_clause
-      language_order_for(StatusTrend)
+    def trend_class
+      StatusTrend
     end
   end
 

--- a/app/models/trends/tags.rb
+++ b/app/models/trends/tags.rb
@@ -16,7 +16,7 @@ class Trends::Tags < Trends::Base
   class Query < Trends::Query
     def to_arel
       scope = Tag.joins(:trend).reorder(score: :desc)
-      scope = scope.merge(language_order_clause) if preferred_languages.present?
+      scope = scope.reorder(language_order_clause, score: :desc) if preferred_languages.present?
       scope = scope.merge(TagTrend.allowed) if @allowed
       scope = scope.offset(@offset) if @offset.present?
       scope = scope.limit(@limit) if @limit.present?
@@ -25,8 +25,8 @@ class Trends::Tags < Trends::Base
 
     private
 
-    def language_order_clause
-      language_order_for(TagTrend)
+    def trend_class
+      TagTrend
     end
   end
 

--- a/spec/models/trends/links_spec.rb
+++ b/spec/models/trends/links_spec.rb
@@ -24,6 +24,20 @@ RSpec.describe Trends::Links do
               .to eq([lower_score.preview_card, higher_score.preview_card])
           end
         end
+
+        context 'when account has chosen languages' do
+          let!(:lang_match_higher_score) { Fabricate :preview_card_trend, score: 10, language: 'is' }
+          let!(:lang_match_lower_score) { Fabricate :preview_card_trend, score: 1, language: 'da' }
+          let(:user) { Fabricate :user, chosen_languages: %w(da is) }
+          let(:account) { Fabricate :account, user: user }
+
+          before { subject.filtered_for!(account) }
+
+          it 'returns results' do
+            expect(subject.records)
+              .to eq([lang_match_higher_score.preview_card, lang_match_lower_score.preview_card, higher_score.preview_card, lower_score.preview_card])
+          end
+        end
       end
     end
   end

--- a/spec/models/trends/statuses_spec.rb
+++ b/spec/models/trends/statuses_spec.rb
@@ -66,6 +66,20 @@ RSpec.describe Trends::Statuses do
               .to eq([lower_score.status, higher_score.status])
           end
         end
+
+        context 'when account has chosen languages' do
+          let!(:lang_match_higher_score) { Fabricate :status_trend, score: 10, language: 'is' }
+          let!(:lang_match_lower_score) { Fabricate :status_trend, score: 1, language: 'da' }
+          let(:user) { Fabricate :user, chosen_languages: %w(da is) }
+          let(:account) { Fabricate :account, user: user }
+
+          before { subject.filtered_for!(account) }
+
+          it 'returns results' do
+            expect(subject.records)
+              .to eq([lang_match_higher_score.status, lang_match_lower_score.status, higher_score.status, lower_score.status])
+          end
+        end
       end
     end
   end

--- a/spec/models/trends/tags_spec.rb
+++ b/spec/models/trends/tags_spec.rb
@@ -50,6 +50,20 @@ RSpec.describe Trends::Tags do
               .to eq([lower_score.tag, higher_score.tag])
           end
         end
+
+        context 'when account has chosen languages' do
+          let!(:lang_match_higher_score) { Fabricate :tag_trend, score: 10, language: 'is' }
+          let!(:lang_match_lower_score) { Fabricate :tag_trend, score: 1, language: 'da' }
+          let(:user) { Fabricate :user, chosen_languages: %w(da is) }
+          let(:account) { Fabricate :account, user: user }
+
+          before { subject.filtered_for!(account) }
+
+          it 'returns results' do
+            expect(subject.records)
+              .to eq([lang_match_higher_score.tag, lang_match_lower_score.tag, higher_score.tag, lower_score.tag])
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Resolves https://github.com/mastodon/mastodon/issues/33555

The specs added in https://github.com/mastodon/mastodon/pull/33531 only covered the base "default locale" case, not the scenario where the account querying for trends has chosen languages set. The locale comes in as a flat single value, whereas the languages come in as an array. With languages set, we effectively had a double array which the query builder could not quote (hence `TypeError` in linked issue).

I believe this change resolves this issue in the sense of there no longer being errors, and both the "default locale" and "chosen languages" scenarios being handled correctly (without runtime error) ... but I also want to do some followup here to contemplate whether we also had an unintended behavior change around how the languages are ordered/prioritized relative to each other.