### PR TITLE
Reject announce payload if object is nil

### DIFF
--- a/app/lib/activitypub/activity/announce.rb
+++ b/app/lib/activitypub/activity/announce.rb
@@ -5,6 +5,8 @@ class ActivityPub::Activity::Announce < ActivityPub::Activity
     return reject_payload! if delete_arrived_first?(@json['id']) || !related_to_local_activity?
 
     with_redis_lock("announce:#{value_or_id(@object)}") do
+      return reject_payload! if @object.nil?
+
       original_status = status_from_object
 
       return reject_payload! if original_status.nil? || !announceable?(original_status)

--- a/app/lib/activitypub/activity/announce.rb
+++ b/app/lib/activitypub/activity/announce.rb
@@ -3,10 +3,9 @@
 class ActivityPub::Activity::Announce < ActivityPub::Activity
   def perform
     return reject_payload! if delete_arrived_first?(@json['id']) || !related_to_local_activity?
+    return reject_payload! if @object.nil?
 
     with_redis_lock("announce:#{value_or_id(@object)}") do
-      return reject_payload! if @object.nil?
-
       original_status = status_from_object
 
       return reject_payload! if original_status.nil? || !announceable?(original_status)


### PR DESCRIPTION
Fixes #33569

This will catch;
```json5
{
   "type": "Announce",
   "object": null,
   ...
}
```

and

```json5
{
   "type": "Announce",
   // no "object" key
   ...
}
```

These are remote development bugs, yes, but we should make sure that the AP parser/processor properly exits if it can't do anything about these activities.