### PR TITLE
Fix media preview height in compose form when 3 or more images are attached

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -6815,6 +6815,8 @@ a.status-card {
   }
 
   &--layout-3 {
+    min-height: calc(64px * 2 + 8px);
+
     & > .media-gallery__item:nth-child(1) {
       border-end-end-radius: 0;
       border-start-end-radius: 0;
@@ -6834,6 +6836,8 @@ a.status-card {
   }
 
   &--layout-4 {
+    min-height: calc(64px * 2 + 8px);
+
     & > .media-gallery__item:nth-child(1) {
       border-end-end-radius: 0;
       border-start-end-radius: 0;


### PR DESCRIPTION
Fixes #33554

Note that the minimal height is still pretty awkward and could be increased, but at least it is functional again

## Before

![image](https://github.com/user-attachments/assets/f51d6cd5-74a2-4b47-9225-ff05cc2f1413)

## After

![image](https://github.com/user-attachments/assets/92a29b1c-244a-47af-9116-872601181c9c)
