### PR TITLE
Switch `webpush` dependency to latest version of Mastodon-maintained fork

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,7 +94,7 @@ gem 'twitter-text', '~> 3.1.0'
 gem 'tzinfo-data', '~> 1.2023'
 gem 'webauthn', '~> 3.0'
 gem 'webpacker', '~> 5.4'
-gem 'webpush', github: 'ClearlyClaire/webpush', ref: 'f14a4d52e201128b1b00245d11b6de80d6cfdcd9'
+gem 'webpush', github: 'mastodon/webpush', ref: '52725def8baf67e0d645c9d1c6c0bdff69da0c60'
 
 gem 'json-ld'
 gem 'json-ld-preloaded', '~> 3.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
-  remote: https://github.com/ClearlyClaire/webpush.git
-  revision: f14a4d52e201128b1b00245d11b6de80d6cfdcd9
-  ref: f14a4d52e201128b1b00245d11b6de80d6cfdcd9
+  remote: https://github.com/mastodon/webpush.git
+  revision: 52725def8baf67e0d645c9d1c6c0bdff69da0c60
+  ref: 52725def8baf67e0d645c9d1c6c0bdff69da0c60
   specs:
-    webpush (0.3.8)
+    webpush (1.1.0)
       hkdf (~> 0.2)
       jwt (~> 2.0)
 

--- a/app/lib/web_push_request.rb
+++ b/app/lib/web_push_request.rb
@@ -33,7 +33,7 @@ class WebPushRequest
   end
 
   def encrypt(payload)
-    Webpush::Encryption.encrypt(payload, key_p256dh, key_auth)
+    Webpush::Legacy::Encryption.encrypt(payload, key_p256dh, key_auth)
   end
 
   private

--- a/app/validators/web_push_key_validator.rb
+++ b/app/validators/web_push_key_validator.rb
@@ -3,7 +3,7 @@
 class WebPushKeyValidator < ActiveModel::Validator
   def validate(subscription)
     begin
-      Webpush::Encryption.encrypt('validation_test', subscription.key_p256dh, subscription.key_auth)
+      Webpush::Legacy::Encryption.encrypt('validation_test', subscription.key_p256dh, subscription.key_auth)
     rescue ArgumentError, OpenSSL::PKey::EC::Point::Error
       subscription.errors.add(:base, I18n.t('crypto.errors.invalid_key'))
     end

--- a/spec/workers/web/push_notification_worker_spec.rb
+++ b/spec/workers/web/push_notification_worker_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Web::PushNotificationWorker do
     before do
       Setting.site_contact_email = contact_email
 
-      allow(Webpush::Encryption).to receive(:encrypt).and_return(payload)
+      allow(Webpush::Legacy::Encryption).to receive(:encrypt).and_return(payload)
       allow(JWT).to receive(:encode).and_return('jwt.encoded.payload')
 
       stub_request(:post, endpoint).to_return(status: 201, body: '')


### PR DESCRIPTION
Precursor to #33528