### PR TITLE
Move mastodon version config to `config_for` yml

### DIFF
--- a/config/mastodon.yml
+++ b/config/mastodon.yml
@@ -2,6 +2,10 @@
 shared:
   self_destruct_value: <%= ENV.fetch('SELF_DESTRUCT', nil) %>
   software_update_url: <%= ENV.fetch('UPDATE_CHECK_URL', 'https://api.joinmastodon.org/update-check') %>
+  source:
+    base_url: <%= ENV.fetch('SOURCE_BASE_URL', nil) %>
+    repository: <%= ENV.fetch('GITHUB_REPOSITORY', 'mastodon/mastodon') %>
+    tag: <%= ENV.fetch('SOURCE_TAG', nil) %>
   version:
     metadata: <%= ENV.fetch('MASTODON_VERSION_METADATA', nil) %>
     prerelease: <%= ENV.fetch('MASTODON_VERSION_PRERELEASE', nil) %>

--- a/lib/mastodon/version.rb
+++ b/lib/mastodon/version.rb
@@ -50,16 +50,16 @@ module Mastodon
     end
 
     def repository
-      ENV.fetch('GITHUB_REPOSITORY', 'mastodon/mastodon')
+      source_configuration[:repository]
     end
 
     def source_base_url
-      ENV.fetch('SOURCE_BASE_URL', "https://github.com/#{repository}")
+      source_configuration[:base_url] || "https://github.com/#{repository}"
     end
 
     # specify git tag or commit hash here
     def source_tag
-      ENV.fetch('SOURCE_TAG', nil)
+      source_configuration[:tag]
     end
 
     def source_url
@@ -79,7 +79,15 @@ module Mastodon
     end
 
     def version_configuration
-      Rails.configuration.x.mastodon.version
+      mastodon_configuration.version
+    end
+
+    def source_configuration
+      mastodon_configuration.source
+    end
+
+    def mastodon_configuration
+      Rails.configuration.x.mastodon
     end
   end
 end

--- a/spec/presenters/instance_presenter_spec.rb
+++ b/spec/presenters/instance_presenter_spec.rb
@@ -66,10 +66,9 @@ RSpec.describe InstancePresenter do
 
   describe '#source_url' do
     context 'with the GITHUB_REPOSITORY env variable set' do
-      before { Rails.configuration.x.mastodon = Rails.application.config_for(:mastodon) }
-
       around do |example|
         ClimateControl.modify GITHUB_REPOSITORY: 'other/repo' do
+          reload_configuration
           example.run
         end
       end
@@ -82,6 +81,7 @@ RSpec.describe InstancePresenter do
     context 'without the GITHUB_REPOSITORY env variable set' do
       around do |example|
         ClimateControl.modify GITHUB_REPOSITORY: nil do
+          reload_configuration
           example.run
         end
       end
@@ -89,6 +89,10 @@ RSpec.describe InstancePresenter do
       it 'defaults to the core mastodon repo URL' do
         expect(instance_presenter.source_url).to eq('https://github.com/mastodon/mastodon')
       end
+    end
+
+    def reload_configuration
+      Rails.configuration.x.mastodon = Rails.application.config_for(:mastodon)
     end
   end
 

--- a/spec/presenters/instance_presenter_spec.rb
+++ b/spec/presenters/instance_presenter_spec.rb
@@ -66,6 +66,8 @@ RSpec.describe InstancePresenter do
 
   describe '#source_url' do
     context 'with the GITHUB_REPOSITORY env variable set' do
+      before { Rails.configuration.x.mastodon = Rails.application.config_for(:mastodon) }
+
       around do |example|
         ClimateControl.modify GITHUB_REPOSITORY: 'other/repo' do
           example.run


### PR DESCRIPTION
Extracted from same original PR as https://github.com/mastodon/mastodon/pull/33548

That one moved the "version" portion, this moves the "source" portion.