### PR TITLE
Expand coverage of admin/trends/* areas

### DIFF
--- a/spec/system/admin/trends/links/preview_card_providers_spec.rb
+++ b/spec/system/admin/trends/links/preview_card_providers_spec.rb
@@ -5,25 +5,58 @@ require 'rails_helper'
 RSpec.describe 'Admin::Trends::Links::PreviewCardProviders' do
   let(:current_user) { Fabricate(:admin_user) }
 
-  before do
-    sign_in current_user
-  end
+  before { sign_in current_user }
 
   describe 'Performing batch updates' do
-    before do
-      visit admin_trends_links_preview_card_providers_path
-    end
-
     context 'without selecting any records' do
       it 'displays a notice about selection' do
+        visit admin_trends_links_preview_card_providers_path
+
         click_on button_for_allow
 
-        expect(page).to have_content(selection_error_text)
+        expect(page)
+          .to have_content(selection_error_text)
+      end
+    end
+
+    context 'with providers that are not trendable' do
+      let!(:provider) { Fabricate :preview_card_provider, trendable: false }
+
+      it 'allows the providers' do
+        visit admin_trends_links_preview_card_providers_path
+
+        check_item
+
+        expect { click_on button_for_allow }
+          .to change { provider.reload.trendable? }.from(false).to(true)
+      end
+    end
+
+    context 'with providers that are trendable' do
+      let!(:provider) { Fabricate :preview_card_provider, trendable: true }
+
+      it 'disallows the providers' do
+        visit admin_trends_links_preview_card_providers_path
+
+        check_item
+
+        expect { click_on button_for_disallow }
+          .to change { provider.reload.trendable? }.from(true).to(false)
+      end
+    end
+
+    def check_item
+      within '.batch-table__row' do
+        find('input[type=checkbox]').check
       end
     end
 
     def button_for_allow
       I18n.t('admin.trends.allow')
+    end
+
+    def button_for_disallow
+      I18n.t('admin.trends.disallow')
     end
 
     def selection_error_text

--- a/spec/system/admin/trends/links_spec.rb
+++ b/spec/system/admin/trends/links_spec.rb
@@ -5,25 +5,94 @@ require 'rails_helper'
 RSpec.describe 'Admin::Trends::Links' do
   let(:current_user) { Fabricate(:admin_user) }
 
-  before do
-    sign_in current_user
-  end
+  before { sign_in current_user }
 
   describe 'Performing batch updates' do
-    before do
-      visit admin_trends_links_path
-    end
-
     context 'without selecting any records' do
       it 'displays a notice about selection' do
+        visit admin_trends_links_path
+
         click_on button_for_allow
 
-        expect(page).to have_content(selection_error_text)
+        expect(page)
+          .to have_content(selection_error_text)
+      end
+    end
+
+    context 'with links that are not trendable' do
+      let!(:preview_card_trend) { Fabricate :preview_card_trend, preview_card: Fabricate(:preview_card, trendable: false) }
+
+      it 'allows the links' do
+        visit admin_trends_links_path
+
+        check_item
+
+        expect { click_on button_for_allow }
+          .to change { preview_card_trend.preview_card.reload.trendable? }.from(false).to(true)
+      end
+    end
+
+    context 'with links whose providers are not trendable' do
+      let(:preview_card_provider) { Fabricate :preview_card_provider, trendable: false }
+      let!(:preview_card_trend) { Fabricate :preview_card_trend, preview_card: Fabricate(:preview_card, url: "https://#{preview_card_provider.domain}/page") }
+
+      it 'allows the providers of the links' do
+        visit admin_trends_links_path
+
+        check_item
+
+        expect { click_on button_for_allow_providers }
+          .to change { preview_card_trend.preview_card.provider.reload.trendable? }.from(false).to(true)
+      end
+    end
+
+    context 'with links that are trendable' do
+      let!(:preview_card_trend) { Fabricate :preview_card_trend, preview_card: Fabricate(:preview_card, trendable: true) }
+
+      it 'disallows the links' do
+        visit admin_trends_links_path
+
+        check_item
+
+        expect { click_on button_for_disallow }
+          .to change { preview_card_trend.preview_card.reload.trendable? }.from(true).to(false)
+      end
+    end
+
+    context 'with links whose providers are trendable' do
+      let(:preview_card_provider) { Fabricate :preview_card_provider, trendable: true }
+      let!(:preview_card_trend) { Fabricate :preview_card_trend, preview_card: Fabricate(:preview_card, url: "https://#{preview_card_provider.domain}/page") }
+
+      it 'disallows the links' do
+        visit admin_trends_links_path
+
+        check_item
+
+        expect { click_on button_for_disallow_providers }
+          .to change { preview_card_trend.preview_card.provider.reload.trendable? }.from(true).to(false)
+      end
+    end
+
+    def check_item
+      within '.batch-table__row' do
+        find('input[type=checkbox]').check
       end
     end
 
     def button_for_allow
       I18n.t('admin.trends.links.allow')
+    end
+
+    def button_for_allow_providers
+      I18n.t('admin.trends.links.allow_provider')
+    end
+
+    def button_for_disallow
+      I18n.t('admin.trends.links.disallow')
+    end
+
+    def button_for_disallow_providers
+      I18n.t('admin.trends.links.disallow_provider')
     end
 
     def selection_error_text

--- a/spec/system/admin/trends/statuses_spec.rb
+++ b/spec/system/admin/trends/statuses_spec.rb
@@ -5,25 +5,92 @@ require 'rails_helper'
 RSpec.describe 'Admin::Trends::Statuses' do
   let(:current_user) { Fabricate(:admin_user) }
 
-  before do
-    sign_in current_user
-  end
+  before { sign_in current_user }
 
   describe 'Performing batch updates' do
-    before do
-      visit admin_trends_statuses_path
-    end
-
     context 'without selecting any records' do
       it 'displays a notice about selection' do
+        visit admin_trends_statuses_path
+
         click_on button_for_allow
 
-        expect(page).to have_content(selection_error_text)
+        expect(page)
+          .to have_content(selection_error_text)
+      end
+    end
+
+    context 'with statuses that are not trendable' do
+      let!(:status_trend) { Fabricate :status_trend, status: Fabricate(:status, trendable: false) }
+
+      it 'allows the statuses' do
+        visit admin_trends_statuses_path
+
+        check_item
+
+        expect { click_on button_for_allow }
+          .to change { status_trend.status.reload.trendable? }.from(false).to(true)
+      end
+    end
+
+    context 'with statuses whose accounts are not trendable' do
+      let!(:status_trend) { Fabricate :status_trend, status: Fabricate(:status, account: Fabricate(:account, trendable: false)) }
+
+      it 'allows the accounts of the statuses' do
+        visit admin_trends_statuses_path
+
+        check_item
+
+        expect { click_on button_for_allow_accounts }
+          .to change { status_trend.status.account.reload.trendable? }.from(false).to(true)
+      end
+    end
+
+    context 'with statuses that are trendable' do
+      let!(:status_trend) { Fabricate :status_trend, status: Fabricate(:status, trendable: true) }
+
+      it 'disallows the statuses' do
+        visit admin_trends_statuses_path
+
+        check_item
+
+        expect { click_on button_for_disallow }
+          .to change { status_trend.status.reload.trendable? }.from(true).to(false)
+      end
+    end
+
+    context 'with statuses whose accounts are trendable' do
+      let!(:status_trend) { Fabricate :status_trend, status: Fabricate(:status, account: Fabricate(:account, trendable: true)) }
+
+      it 'disallows the statuses' do
+        visit admin_trends_statuses_path
+
+        check_item
+
+        expect { click_on button_for_disallow_accounts }
+          .to change { status_trend.status.reload.trendable? }.from(true).to(false)
+      end
+    end
+
+    def check_item
+      within '.batch-table__row' do
+        find('input[type=checkbox]').check
       end
     end
 
     def button_for_allow
       I18n.t('admin.trends.statuses.allow')
+    end
+
+    def button_for_allow_accounts
+      I18n.t('admin.trends.statuses.allow_account')
+    end
+
+    def button_for_disallow
+      I18n.t('admin.trends.statuses.disallow')
+    end
+
+    def button_for_disallow_accounts
+      I18n.t('admin.trends.statuses.disallow_account')
     end
 
     def selection_error_text

--- a/spec/system/admin/trends/tags_spec.rb
+++ b/spec/system/admin/trends/tags_spec.rb
@@ -5,25 +5,57 @@ require 'rails_helper'
 RSpec.describe 'Admin::Trends::Tags' do
   let(:current_user) { Fabricate(:admin_user) }
 
-  before do
-    sign_in current_user
-  end
+  before { sign_in current_user }
 
   describe 'Performing batch updates' do
-    before do
-      visit admin_trends_tags_path
-    end
-
     context 'without selecting any records' do
       it 'displays a notice about selection' do
+        visit admin_trends_tags_path
+
         click_on button_for_allow
 
         expect(page).to have_content(selection_error_text)
       end
     end
 
+    context 'with tags that are not trendable' do
+      let!(:tag_trend) { Fabricate :tag_trend, tag: Fabricate(:tag, trendable: false) }
+
+      it 'allows the tags' do
+        visit admin_trends_tags_path
+
+        check_item
+
+        expect { click_on button_for_allow }
+          .to change { tag_trend.tag.reload.trendable? }.from(false).to(true)
+      end
+    end
+
+    context 'with tags that are trendable' do
+      let!(:tag_trend) { Fabricate :tag_trend, tag: Fabricate(:tag, trendable: true) }
+
+      it 'disallows the tags' do
+        visit admin_trends_tags_path
+
+        check_item
+
+        expect { click_on button_for_disallow }
+          .to change { tag_trend.tag.reload.trendable? }.from(true).to(false)
+      end
+    end
+
+    def check_item
+      within '.batch-table__row' do
+        find('input[type=checkbox]').check
+      end
+    end
+
     def button_for_allow
       I18n.t('admin.trends.allow')
+    end
+
+    def button_for_disallow
+      I18n.t('admin.trends.disallow')
     end
 
     def selection_error_text


### PR DESCRIPTION
For each of these (admin/trends/links, admin/trends/tags, admin/trends/statuses, admin/trends/links/preview_card_providers) - the original system specs were just barebones first passes to capture one of the error states; and the controllers themselves and also the underlying models/trends/*_batch classes they call were not exercised beyond that.

Adds coverage for all of these, for the various allow/disallow action options they all have. I'd have done this as four separate PRs, but they are ... exceedingly similar to each other, basically copy/paste.

There's potentially more to do here on the filtering options, but this handles the bulk of the batch update paths.