### PR TITLE
Fix custom css cache miss

### DIFF
--- a/app/helpers/theme_helper.rb
+++ b/app/helpers/theme_helper.rb
@@ -45,7 +45,9 @@ module ThemeHelper
   end
 
   def cached_custom_css_digest
-    Rails.cache.read(:setting_digest_custom_css)
+    Rails.cache.fetch(:setting_digest_custom_css) do
+      Setting.custom_css&.then { |content| Digest::SHA256.hexdigest(content) }
+    end
   end
 
   def theme_color_for(theme)


### PR DESCRIPTION
Related: #33207

Rails cache could be expired which could result custom css is not applied at all
This PR will fix that problem.

BTW, generating digest need to be merged into single organised place