### PR TITLE
Use final specification for new WebPush subscriptions in web interface

### DIFF
--- a/app/javascript/mastodon/actions/push_notifications/registerer.js
+++ b/app/javascript/mastodon/actions/push_notifications/registerer.js
@@ -33,7 +33,7 @@ const unsubscribe = ({ registration, subscription }) =>
   subscription ? subscription.unsubscribe().then(() => registration) : registration;
 
 const sendSubscriptionToBackend = (subscription) => {
-  const params = { subscription };
+  const params = { subscription: { ...subscription.toJSON(), standard: true } };
 
   if (me) {
     const data = pushNotificationsSetting.get(me);


### PR DESCRIPTION
Now that #33528 has been merged, we can move away from the old draft to the final spec for Web Push subscriptions.

I have not been able to find a more reliable/authoritative source, but according to https://github.com/web-push-libs/ecec?tab=readme-ov-file#aes128gcm, the new spec should be handled by Firefox 55+ and Chrome 60+, which are significantly older than our target versions.