### PR TITLE
Fix libyaml missing from Dockerfile build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -153,6 +153,7 @@ RUN \
   libpq-dev \
   libssl-dev \
   libtool \
+  libyaml-dev \
   meson \
   nasm \
   pkg-config \


### PR DESCRIPTION
Fixes missing dependency of libyaml during Dockerfile build stage. This package was previously installed on the Ruby base image or by another Debian package (still sorting out) but now needs to be called for install otherwise `bundler` fails.

```
40.16 Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
40.16
40.16     current directory: /usr/local/bundle/gems/psych-5.2.2/ext/psych
40.16 /usr/local/bin/ruby extconf.rb
40.16 checking for pkg-config for yaml-0.1... not found
40.16 checking for yaml.h... no
40.16 yaml.h not found
40.16 *** extconf.rb failed ***
```

Will need to back port to 4.3 branch as well, otherwise it will fail to build.