### PR TITLE
Add `Account.without_migrated` scope

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -135,6 +135,7 @@ class Account < ApplicationRecord
   scope :local, -> { where(domain: nil) }
   scope :partitioned, -> { order(Arel.sql('row_number() over (partition by domain)')) }
   scope :without_instance_actor, -> { where.not(id: INSTANCE_ACTOR_ID) }
+  scope :without_migrated, -> { where(moved_to_account_id: nil) }
   scope :recent, -> { reorder(id: :desc) }
   scope :bots, -> { where(actor_type: AUTOMATED_ACTOR_TYPES) }
   scope :non_automated, -> { where.not(actor_type: AUTOMATED_ACTOR_TYPES) }
@@ -145,7 +146,7 @@ class Account < ApplicationRecord
   scope :matches_display_name, ->(value) { where(arel_table[:display_name].matches("#{value}%")) }
   scope :without_unapproved, -> { left_outer_joins(:user).merge(User.approved.confirmed).or(remote) }
   scope :auditable, -> { where(id: Admin::ActionLog.select(:account_id).distinct) }
-  scope :searchable, -> { without_unapproved.without_suspended.where(moved_to_account_id: nil) }
+  scope :searchable, -> { without_unapproved.without_suspended.without_migrated }
   scope :discoverable, -> { searchable.without_silenced.where(discoverable: true).joins(:account_stat) }
   scope :by_recent_status, -> { includes(:account_stat).merge(AccountStat.by_recent_status).references(:account_stat) }
   scope :by_recent_activity, -> { left_joins(:user, :account_stat).order(coalesced_activity_timestamps.desc).order(id: :desc) }

--- a/app/models/relationship_filter.rb
+++ b/app/models/relationship_filter.rb
@@ -94,7 +94,7 @@ class RelationshipFilter
     when 'moved'
       Account.where.not(moved_to_account_id: nil)
     when 'primary'
-      Account.where(moved_to_account_id: nil)
+      Account.without_migrated
     else
       raise Mastodon::InvalidParameterError, "Unknown status: #{value}"
     end


### PR DESCRIPTION
Pulled out of previous larger PR.

This is sort of mundane by itself, but the intended followup here is something like...

- Also add a scope for `migrated`
- Add query methods like `migrated?` and `not_migrated?` and update across the app for what I think will be small but nice readability change in various places we do this check
- Add something like `Account#migrated_to?(account)` (or similar) and update to use in a few spots that do a check like that

Pull that whole collection out to `Account::Migration` concern as part of larger huge-LOC-classes campaign.

Will plan to do that one step at a time unless you'd prefer jump straight to concern and add all that at once.