### PR TITLE
Enable parallel execution for linting tasks in HAML workflows

### DIFF
--- a/.github/workflows/lint-haml.yml
+++ b/.github/workflows/lint-haml.yml
@@ -43,4 +43,4 @@ jobs:
       - name: Run haml-lint
         run: |
           echo "::add-matcher::.github/workflows/haml-lint-problem-matcher.json"
-          bin/haml-lint --reporter github
+          bin/haml-lint --parallel --reporter github

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -3,7 +3,7 @@ const config = {
   'Gemfile|*.{rb,ruby,ru,rake}': 'bin/rubocop --force-exclusion -a',
   '*.{js,jsx,ts,tsx}': 'eslint --fix',
   '*.{css,scss}': 'stylelint --fix',
-  '*.haml': 'bin/haml-lint -a',
+  '*.haml': 'bin/haml-lint -a --parallel',
   '**/*.ts?(x)': () => 'tsc -p tsconfig.json --noEmit',
 };
 


### PR DESCRIPTION
This PR adds parallel option for rubocop and haml-lint.

Using this option, the linting time for all files was reduced by 63 seconds for rubocop and 13 seconds for haml-lint.

![image](https://github.com/user-attachments/assets/44b4cc8d-d4ed-428a-95bb-33e3561364ad)

![image](https://github.com/user-attachments/assets/4d14b051-100c-4f7c-8e2f-bf2179f5cd02)
These results ran on VM which has 4 vCPUs.