### PR TITLE
Expand coverage of `admin/*blocks` areas

### DIFF
--- a/spec/system/admin/email_domain_blocks_spec.rb
+++ b/spec/system/admin/email_domain_blocks_spec.rb
@@ -5,9 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Admin::EmailDomainBlocks' do
   let(:current_user) { Fabricate(:admin_user) }
 
-  before do
-    sign_in current_user
-  end
+  before { sign_in current_user }
 
   describe 'Performing batch updates' do
     before do
@@ -19,6 +17,27 @@ RSpec.describe 'Admin::EmailDomainBlocks' do
         click_on button_for_delete
 
         expect(page).to have_content(selection_error_text)
+      end
+    end
+
+    context 'with a selected block' do
+      let!(:email_domain_block) { Fabricate :email_domain_block }
+
+      it 'deletes the block' do
+        visit admin_email_domain_blocks_path
+
+        check_item
+
+        expect { click_on button_for_delete }
+          .to change(EmailDomainBlock, :count).by(-1)
+        expect { email_domain_block.reload }
+          .to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    def check_item
+      within '.batch-table__row' do
+        find('input[type=checkbox]').check
       end
     end
 

--- a/spec/system/admin/ip_blocks_spec.rb
+++ b/spec/system/admin/ip_blocks_spec.rb
@@ -48,6 +48,27 @@ RSpec.describe 'Admin::IpBlocks' do
       end
     end
 
+    context 'with a selected block' do
+      let!(:ip_block) { Fabricate :ip_block }
+
+      it 'deletes the block' do
+        visit admin_ip_blocks_path
+
+        check_item
+
+        expect { click_on button_for_delete }
+          .to change(IpBlock, :count).by(-1)
+        expect { ip_block.reload }
+          .to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    def check_item
+      within '.batch-table__row' do
+        find('input[type=checkbox]').check
+      end
+    end
+
     def button_for_delete
       I18n.t('admin.ip_blocks.delete')
     end


### PR DESCRIPTION
Similar to https://github.com/mastodon/mastodon/pull/33581 - hits a few more "batch" model paths.