### PR TITLE
Collect errors in setup rake task

### DIFF
--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -17,7 +17,7 @@ namespace :mastodon do
     ENV.delete('SIDEKIQ_REDIS_URL')
 
     begin
-      errors = false
+      errors = []
 
       prompt.say('Your instance is identified by its domain name. Changing it afterward will break things.')
       env['LOCAL_DOMAIN'] = prompt.ask('Domain name:') do |q|
@@ -109,7 +109,7 @@ namespace :mastodon do
           unless prompt.yes?('Try again?')
             return prompt.warn 'Nothing saved. Bye!' unless prompt.yes?('Continue anyway?')
 
-            errors = true
+            errors << 'Database connection could not be established.'
             break
           end
         end
@@ -155,7 +155,7 @@ namespace :mastodon do
           unless prompt.yes?('Try again?')
             return prompt.warn 'Nothing saved. Bye!' unless prompt.yes?('Continue anyway?')
 
-            errors = true
+            errors << 'Redis connection could not be established.'
             break
           end
         end
@@ -450,7 +450,7 @@ namespace :mastodon do
           unless prompt.yes?('Try again?')
             return prompt.warn 'Nothing saved. Bye!' unless prompt.yes?('Continue anyway?')
 
-            errors = true
+            errors << 'E-email was not sent successfully.'
             break
           end
         end
@@ -498,7 +498,7 @@ namespace :mastodon do
             prompt.ok 'Done!'
           else
             prompt.error 'That failed! Perhaps your configuration is not right'
-            errors = true
+            errors << 'Preparing the database failed'
           end
         end
 
@@ -515,14 +515,15 @@ namespace :mastodon do
               prompt.say 'Done!'
             else
               prompt.error 'That failed! Maybe you need swap space?'
-              errors = true
+              errors << 'Compiling assets failed.'
             end
           end
         end
 
         prompt.say "\n"
-        if errors
-          prompt.warn 'Your Mastodon server is set up, but there were some errors along the way, you may have to fix them.'
+        if errors.any?
+          prompt.warn 'Your Mastodon server is set up, but there were some errors along the way, you may have to fix them:'
+          errors.each { |error| prompt.warn "- #{error}" }
         else
           prompt.ok 'All done! You can now power on the Mastodon server 🐘'
         end


### PR DESCRIPTION
Instead of just tracking true/false on whether we've had an error, collect them as we go and then summarize at the end.

Example output:

```
Your Mastodon server is set up, but there were some errors along the way, you may have to fix them:
- Redis connection could not be established.
```

Ran this a few times with various scenarios and seems to do what I want.

Separately - this method is truly enormous and unwieldy. I'd like to refactor this a bit, but it's challenging to find something which would be meaningfully better but not create a pretty crazy diff.

I think if we pull out the prompt, env, errors - we might be able at minimum to make this look sort of like the CLI maintenance task does, with one private method per "section" of the setup.

Also separately - I suspect that the "does the db connection work" check is ... not actually checking. I think the method it uses changed to not raise, so it just always says its good now even with garbage values. May try to improve that as followup here.