### PR TITLE
Move clear environment portion of `mastodon:setup` to private method

### DIFF
--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -8,13 +8,7 @@ namespace :mastodon do
     prompt = TTY::Prompt.new
     env    = {}
 
-    # When the application code gets loaded, it runs `lib/mastodon/redis_configuration.rb`.
-    # This happens before application environment configuration and sets REDIS_URL etc.
-    # These variables are then used even when REDIS_HOST etc. are changed, so clear them
-    # out so they don't interfere with our new configuration.
-    ENV.delete('REDIS_URL')
-    ENV.delete('CACHE_REDIS_URL')
-    ENV.delete('SIDEKIQ_REDIS_URL')
+    clear_environment!
 
     begin
       errors = []
@@ -579,6 +573,17 @@ namespace :mastodon do
   end
 
   private
+
+  def clear_environment!
+    # When the application code gets loaded, it runs `lib/mastodon/redis_configuration.rb`.
+    # This happens before application environment configuration and sets REDIS_URL etc.
+    # These variables are then used even when REDIS_HOST etc. are changed, so clear them
+    # out so they don't interfere with our new configuration.
+
+    ENV.delete('REDIS_URL')
+    ENV.delete('CACHE_REDIS_URL')
+    ENV.delete('SIDEKIQ_REDIS_URL')
+  end
 
   def generate_header(include_warning)
     default_message = "# Generated with mastodon:setup on #{Time.now.utc}\n\n"


### PR DESCRIPTION
Background: https://github.com/mastodon/mastodon/pull/33603

Going to attempt to chip away at this (~600 line method) in small pieces to see if we can simplify a bit. The deep nesting and long sections makes it tough to navigate.