### PR TITLE
Change activity distribution error handling to skip retrying for deleted accounts

### DIFF
--- a/app/workers/activitypub/delivery_worker.rb
+++ b/app/workers/activitypub/delivery_worker.rb
@@ -62,12 +62,16 @@ class ActivityPub::DeliveryWorker
     stoplight_wrapper.run do
       request_pool.with(@host) do |http_client|
         build_request(http_client).perform do |response|
-          raise Mastodon::UnexpectedResponseError, response unless response_successful?(response) || response_error_unsalvageable?(response)
+          raise Mastodon::UnexpectedResponseError, response unless response_successful?(response) || response_error_unsalvageable?(response) || unsalvageable_authorization_failure?(response)
 
           @performed = true
         end
       end
     end
+  end
+
+  def unsalvageable_authorization_failure?(response)
+    @source_account.permanently_unavailable? && response.code == 401
   end
 
   def stoplight_wrapper


### PR DESCRIPTION
See https://github.com/mastodon/mastodon/issues/33290#issuecomment-2595154685

Basically, Mastodon sends account deletion notices to all known servers so any record can be swiftly deleted across the network.

It is expected that remote servers which cannot verify the signature will either:
- skip processing the message because they do not know of the deleted account
- try to refresh the account and end up on a 410, promptly deleting the account

However, those behaviors, while sensible, implemented by and encouraged by Mastodon for several years, are not specified by ActivityPub.

When an ActivityPub delivery fails because of a signature verification failure, the most likely reason is that the recipient does not know the sender's key (either because it has changed, or because the sender is not known at all). In both cases, the recipient will be unable to fetch an updated key, as the sending server will return a 410, and retrying delivery in this scenario does not make sense.

However, signature verification could also fail because of an implementation bug (although that would affect pretty much all other activities as well) or significant clock skew. We unfortunately don't have a way to differentiate between these cases.