### PR TITLE
Add coverage for `AnnualReport.prepare` method

### DIFF
--- a/spec/lib/annual_report_spec.rb
+++ b/spec/lib/annual_report_spec.rb
@@ -13,4 +13,13 @@ RSpec.describe AnnualReport do
         .to change(GeneratedAnnualReport, :count).by(1)
     end
   end
+
+  describe '.prepare' do
+    before { Fabricate :status }
+
+    it 'generates records from source class which prepare data' do
+      expect { described_class.prepare(Time.current.year) }
+        .to change(AnnualReport::StatusesPerAccountCount, :count).by(1)
+    end
+  end
 end


### PR DESCRIPTION
Sort of odd because only one of the classes implements a prepare, but I guess we don't get to choose our battles.