### PR TITLE
Migrate visibility interaction checks on statuses to request spec

### DIFF
--- a/spec/controllers/statuses_controller_spec.rb
+++ b/spec/controllers/statuses_controller_spec.rb
@@ -9,45 +9,6 @@ RSpec.describe StatusesController do
     let(:account) { Fabricate(:account) }
     let(:status)  { Fabricate(:status, account: account) }
 
-    context 'when account is permanently suspended' do
-      before do
-        account.suspend!
-        account.deletion_request.destroy
-
-        get :show, params: { account_username: account.username, id: status.id }
-      end
-
-      it 'returns http gone' do
-        expect(response).to have_http_status(410)
-      end
-    end
-
-    context 'when account is temporarily suspended' do
-      before do
-        account.suspend!
-
-        get :show, params: { account_username: account.username, id: status.id }
-      end
-
-      it 'returns http forbidden' do
-        expect(response).to have_http_status(403)
-      end
-    end
-
-    context 'when status is a reblog' do
-      let(:original_account) { Fabricate(:account, domain: 'example.com') }
-      let(:original_status) { Fabricate(:status, account: original_account, url: 'https://example.com/123') }
-      let(:status) { Fabricate(:status, account: account, reblog: original_status) }
-
-      before do
-        get :show, params: { account_username: status.account.username, id: status.id }
-      end
-
-      it 'redirects to the original status' do
-        expect(response).to redirect_to(original_status.url)
-      end
-    end
-
     context 'when status is public' do
       before do
         get :show, params: { account_username: status.account.username, id: status.id, format: format }
@@ -140,17 +101,6 @@ RSpec.describe StatusesController do
 
       before do
         sign_in(user)
-      end
-
-      context 'when account blocks user' do
-        before do
-          account.block!(user.account)
-          get :show, params: { account_username: status.account.username, id: status.id }
-        end
-
-        it 'returns http not found' do
-          expect(response).to have_http_status(404)
-        end
       end
 
       context 'when status is public' do

--- a/spec/requests/statuses_spec.rb
+++ b/spec/requests/statuses_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Statuses' do
+  describe 'GET /@:account_username/:id' do
+    let(:account) { Fabricate(:account) }
+    let(:status)  { Fabricate(:status, account: account) }
+
+    context 'when signed out' do
+      context 'when account is permanently suspended' do
+        before do
+          account.suspend!
+          account.deletion_request.destroy
+        end
+
+        it 'returns http gone' do
+          get "/@#{account.username}/#{status.id}"
+
+          expect(response)
+            .to have_http_status(410)
+        end
+      end
+
+      context 'when account is temporarily suspended' do
+        before { account.suspend! }
+
+        it 'returns http forbidden' do
+          get "/@#{account.username}/#{status.id}"
+
+          expect(response)
+            .to have_http_status(403)
+        end
+      end
+
+      context 'when status is a reblog' do
+        let(:original_account) { Fabricate(:account, domain: 'example.com') }
+        let(:original_status) { Fabricate(:status, account: original_account, url: 'https://example.com/123') }
+        let(:status) { Fabricate(:status, account: account, reblog: original_status) }
+
+        it 'redirects to the original status' do
+          get "/@#{status.account.username}/#{status.id}"
+
+          expect(response)
+            .to redirect_to(original_status.url)
+        end
+      end
+    end
+
+    context 'when signed in' do
+      let(:user) { Fabricate(:user) }
+
+      before { sign_in(user) }
+
+      context 'when account blocks user' do
+        before { account.block!(user.account) }
+
+        it 'returns http not found' do
+          get "/@#{status.account.username}/#{status.id}"
+
+          expect(response)
+            .to have_http_status(404)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Follow up on https://github.com/mastodon/mastodon/pull/33336 (activity) and https://github.com/mastodon/mastodon/pull/32448 (embed), continuing to step through this large controller spec piece by piece.

The bulk of the rest of the examples here are all for the  `show` action, and there are a series of nested checks around signed out, signed in, signature modes - and then within each of those checks on various status visibilities, and within each of those, both a JSON and HTML version.

This change migrates out the examples which do NOT fit into that pattern and aren't grouped like that and all made sense in request specs.
