### PR TITLE
Further harden the warnings against changing encryption secrets

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -50,7 +50,7 @@ OTP_SECRET=
 # Must be available (and set to same values) for all server processes
 # These are private/secret values, do not share outside hosting environment
 # Use `bin/rails db:encryption:init` to generate fresh secrets
-# Do not change these secrets once in use, as this would cause data loss and other issues
+# Do NOT change these secrets once in use, as this would cause data loss and other issues
 # ------------------
 # ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY=
 # ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT=

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -11,16 +11,35 @@ namespace :db do
         ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY
         ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT
         ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY
-      ).any? { |key| ENV.key?(key) }
+      ).any? { |key| ENV[key].present? }
+        unless ENV['IGNORE_ALREADY_SET_SECRETS'] == 'true'
+          puts <<~MSG
+            Secrets for this server have already been set, this step can likely be ignored!
+            In the unlikely event you need to generate new secrets, re-run this command with `IGNORE_ALREADY_SET_SECRETS=true`.
+          MSG
+
+          next
+        end
+
         pastel = Pastel.new
         puts pastel.red(<<~MSG)
-          WARNING: It looks like encryption secrets have already been set. Please ensure you are not changing secrets for a Mastodon installation that already uses them, as this will cause data loss and other issues that are difficult to recover from.
+          WARNING: It looks like encryption secrets have already been set.
+          WARNING: Ensure you are not changing secrets for a Mastodon installation that already uses them, as this will cause data loss and other issues that are difficult to recover from.
+          WARNING: Only proceed if you are absolutely sure of what you are doing!
+        MSG
+
+        puts <<~MSG
+          If you are sure of what you are doing, add the following secret environment variables to your Mastodon environment (e.g. .env.production), ensure they are shared across all your nodes and do not change them after they are set:#{' '}
+        MSG
+      else
+        puts <<~MSG
+          Add the following secret environment variables to your Mastodon environment (e.g. .env.production), ensure they are shared across all your nodes and do not change them after they are set:#{' '}
         MSG
       end
 
       puts <<~MSG
-        Add the following secret environment variables to your Mastodon environment (e.g. .env.production), ensure they are shared across all your nodes and do not change them after they are set:#{' '}
 
+        # Do NOT change these variables once they are set
         ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY=#{SecureRandom.alphanumeric(32)}
         ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT=#{SecureRandom.alphanumeric(32)}
         ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY=#{SecureRandom.alphanumeric(32)}


### PR DESCRIPTION
People are still falling into the trap of changing encryption secrets, despite the warnings.

This PR makes the warnings a little more noticeable and explicit, while also changing the `db:encryption:init` task to flat out refuse to output new secrets if existing secrets are detected, unless `IGNORE_ALREADY_SET_SECRETS` is set to `true`.