### PR TITLE
Fix re-encoding of high-framerate VFR videos with FFmpeg 6+

### DIFF
--- a/lib/paperclip/transcoder.rb
+++ b/lib/paperclip/transcoder.rb
@@ -52,8 +52,8 @@ module Paperclip
           @output_options['bufsize'] = bitrate * 5
 
           if high_vfr?(metadata)
+            # TODO: change to `fps_mode` in the future, as `vsync` is being deprecated
             @output_options['vsync'] = 'vfr'
-            @output_options['r'] = @vfr_threshold
           end
         end
       end


### PR DESCRIPTION
As of commit https://github.com/FFmpeg/FFmpeg/commit/260f3918937463f1b90e1b77cba80b917f3cb8c1 included in FFmpeg 6, FFmpeg has started rejecting the options we use when encountering a variable framereate video with a peak framerate exceeding 120fps.

We started using these options in https://github.com/mastodon/mastodon/pull/17619 with the goal of encoding such videos as variable frame-rate but with a cap on the peak framerate. This supposedly worked as expected, although I have not double-checked. In any case, this now fails completely because of the FFmpeg behavior change discussed at https://trac.ffmpeg.org/ticket/10150

This PR drops the FPS limit when re-encoding as VFR, since it does not appear to be possible. Possible downsides of that include possibly more encoding work (as it would encode more frames, but the total number of frame per video file is still capped), and possibly limited compatibility with some devices (but again, the current behavior is to completely fail at processing the file).