### PR TITLE
Fix broken `CONTRIBUTING` link in `DEVELOPMENT`

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -67,7 +67,7 @@ development environment configured with the software needed for this project.
 - On the _Ports_ tab "stream" setting change _Port visibility_ → _Public_
 
 [codespace]: https://codespaces.new/mastodon/mastodon?quickstart=1&devcontainer_path=.devcontainer%2Fcodespaces%2Fdevcontainer.json
-[CONTRIBUTING]: CONTRIBUTING.md
+[CONTRIBUTING]: ../CONTRIBUTING.md
 [Dev Container extension]: https://containers.dev/supporting#dev-containers
 [Development Containers]: https://containers.dev/supporting
 [Docker]: https://docs.docker.com


### PR DESCRIPTION
Fixing the `CONTRIBUTING` link in `DEVELOPMENT` as it is broken. Hot fix for last week's https://github.com/mastodon/mastodon/pull/33328, I believe.

Before (`main`)

https://github.com/user-attachments/assets/9db7eed9-3afb-4874-bd58-f2de2784a380

After (this PR)

https://github.com/user-attachments/assets/66a3fa66-a92f-45ce-a4e0-bc8e171b2cc3