### PR TITLE
Change `first_of_value` to `first_of_hash`, and add more test cases

### DIFF
--- a/app/lib/link_details_extractor.rb
+++ b/app/lib/link_details_extractor.rb
@@ -46,7 +46,7 @@ class LinkDetailsExtractor
     end
 
     def image
-      obj = first_of_value(json['image'])
+      obj = first_of_hash(json['image'])
 
       return obj['url'] if obj.is_a?(Hash)
 
@@ -85,15 +85,15 @@ class LinkDetailsExtractor
     private
 
     def author
-      first_of_value(json['author']) || {}
+      first_of_hash(json['author']) || {}
     end
 
     def publisher
-      first_of_value(json['publisher']) || {}
+      first_of_hash(json['publisher']) || {}
     end
 
-    def first_of_value(arr)
-      arr.is_a?(Array) ? arr.first : arr
+    def first_of_hash(arr)
+      arr.is_a?(Array) ? arr.select { |item| item.is_a?(Hash) }.first : arr
     end
 
     def root_array(root)

--- a/app/lib/link_details_extractor.rb
+++ b/app/lib/link_details_extractor.rb
@@ -93,7 +93,7 @@ class LinkDetailsExtractor
     end
 
     def first_of_hash(arr)
-      arr.is_a?(Array) ? arr.find { |item| item.is_a?(Hash) } : arr
+      arr.is_a?(Array) ? arr.flatten.find { |item| item.is_a?(Hash) } : arr
     end
 
     def root_array(root)

--- a/app/lib/link_details_extractor.rb
+++ b/app/lib/link_details_extractor.rb
@@ -93,7 +93,7 @@ class LinkDetailsExtractor
     end
 
     def first_of_hash(arr)
-      arr.is_a?(Array) ? arr.select { |item| item.is_a?(Hash) }.first : arr
+      arr.is_a?(Array) ? arr.find { |item| item.is_a?(Hash) } : arr
     end
 
     def root_array(root)

--- a/spec/helpers/json_ld_helper_spec.rb
+++ b/spec/helpers/json_ld_helper_spec.rb
@@ -49,18 +49,28 @@ RSpec.describe JsonLdHelper do
     end
   end
 
-  describe '#first_of_value' do
+  describe '#first_of_hash' do
     context 'when value.is_a?(Array)' do
-      it 'returns value.first' do
+      it 'returns value.first if value.first.is_a?(Hash)' do
+        value = [{a: 1}]
+        expect(helper.first_of_hash(value)).to be({a: 1})
+      end
+
+      it 'returns nil if value.first !is_a?(Hash)' do
         value = ['a']
-        expect(helper.first_of_value(value)).to be 'a'
+        expect(helper.first_of_hash(value)).to be_nil
       end
     end
 
     context 'with !value.is_a?(Array)' do
-      it 'returns value' do
+      it 'returns value (value.is_a?(Hash))' do
+        value = {a: 1}
+        expect(helper.first_of_hash(value)).to be({a: 1})
+      end
+
+      it 'returns value (!value.is_a?(Hash))' do
         value = 'a'
-        expect(helper.first_of_value(value)).to be 'a'
+        expect(helper.first_of_hash(value)).to be 'a'
       end
     end
   end

--- a/spec/helpers/json_ld_helper_spec.rb
+++ b/spec/helpers/json_ld_helper_spec.rb
@@ -49,28 +49,18 @@ RSpec.describe JsonLdHelper do
     end
   end
 
-  describe '#first_of_hash' do
+  describe '#first_of_value' do
     context 'when value.is_a?(Array)' do
-      it 'returns value.first if value.first.is_a?(Hash)' do
-        value = [{ a: 1 }]
-        expect(helper.first_of_hash(value)).to be({ a: 1 })
-      end
-
-      it 'returns nil if value.first !is_a?(Hash)' do
+      it 'returns value.first' do
         value = ['a']
-        expect(helper.first_of_hash(value)).to be_nil
+        expect(helper.first_of_value(value)).to be 'a'
       end
     end
 
     context 'with !value.is_a?(Array)' do
-      it 'returns value (value.is_a?(Hash))' do
-        value = { a: 1 }
-        expect(helper.first_of_hash(value)).to be({ a: 1 })
-      end
-
-      it 'returns value (!value.is_a?(Hash))' do
+      it 'returns value' do
         value = 'a'
-        expect(helper.first_of_hash(value)).to be 'a'
+        expect(helper.first_of_value(value)).to be 'a'
       end
     end
   end

--- a/spec/helpers/json_ld_helper_spec.rb
+++ b/spec/helpers/json_ld_helper_spec.rb
@@ -52,8 +52,8 @@ RSpec.describe JsonLdHelper do
   describe '#first_of_hash' do
     context 'when value.is_a?(Array)' do
       it 'returns value.first if value.first.is_a?(Hash)' do
-        value = [{a: 1}]
-        expect(helper.first_of_hash(value)).to be({a: 1})
+        value = [{ a: 1 }]
+        expect(helper.first_of_hash(value)).to be({ a: 1 })
       end
 
       it 'returns nil if value.first !is_a?(Hash)' do
@@ -64,8 +64,8 @@ RSpec.describe JsonLdHelper do
 
     context 'with !value.is_a?(Array)' do
       it 'returns value (value.is_a?(Hash))' do
-        value = {a: 1}
-        expect(helper.first_of_hash(value)).to be({a: 1})
+        value = { a: 1 }
+        expect(helper.first_of_hash(value)).to be({ a: 1 })
       end
 
       it 'returns value (!value.is_a?(Hash))' do

--- a/spec/lib/link_details_extractor_spec.rb
+++ b/spec/lib/link_details_extractor_spec.rb
@@ -43,34 +43,6 @@ RSpec.describe LinkDetailsExtractor do
     end
   end
 
-  describe '#first_of_hash' do
-    let(:html) { '' }
-
-    context 'when value.is_a?(Array)' do
-      it 'returns value.first if value.first.is_a?(Hash)' do
-        value = [{ a: 1 }]
-        expect(subject.first_of_hash(value)).to be({ a: 1 })
-      end
-
-      it 'returns nil if value.first !is_a?(Hash)' do
-        value = ['a']
-        expect(subject.first_of_hash(value)).to be_nil
-      end
-    end
-
-    context 'with !value.is_a?(Array)' do
-      it 'returns value (value.is_a?(Hash))' do
-        value = { a: 1 }
-        expect(subject.first_of_hash(value)).to be({ a: 1 })
-      end
-
-      it 'returns value (!value.is_a?(Hash))' do
-        value = 'a'
-        expect(subject.first_of_hash(value)).to be 'a'
-      end
-    end
-  end
-
   context 'when only basic metadata is present' do
     let(:html) { <<~HTML }
       <!doctype html>
@@ -310,6 +282,36 @@ RSpec.describe LinkDetailsExtractor do
           image_alt: eq('A good boy'),
           provider_name: eq('Pet News')
         )
+    end
+  end
+
+  RSpec.describe LinkDetailsExtractor::StructuredData do
+    subject { described_class.new('{}') }
+
+    describe '#first_of_hash' do
+      context 'when value.is_a?(Array)' do
+        it 'returns value.first if value.first.is_a?(Hash)' do
+          value = [{ a: 1 }]
+          expect(subject.first_of_hash(value)).to be({ a: 1 })
+        end
+
+        it 'returns nil if value.first !is_a?(Hash)' do
+          value = ['a']
+          expect(subject.first_of_hash(value)).to be_nil
+        end
+      end
+
+      context 'with !value.is_a?(Array)' do
+        it 'returns value (value.is_a?(Hash))' do
+          value = { a: 1 }
+          expect(subject.first_of_hash(value)).to be({ a: 1 })
+        end
+
+        it 'returns value (!value.is_a?(Hash))' do
+          value = 'a'
+          expect(subject.first_of_hash(value)).to be 'a'
+        end
+      end
     end
   end
 end

--- a/spec/lib/link_details_extractor_spec.rb
+++ b/spec/lib/link_details_extractor_spec.rb
@@ -280,11 +280,11 @@ RSpec.describe LinkDetailsExtractor do
       HTML
 
       it 'gives "" for author_name' do
-        expect(subject.author_name).to be ''
+        expect(subject.author_name).to eq ''
       end
 
       it 'gives "" for provider_name' do
-        expect(subject.provider_name).to be ''
+        expect(subject.provider_name).to eq ''
       end
     end
   end

--- a/spec/lib/link_details_extractor_spec.rb
+++ b/spec/lib/link_details_extractor_spec.rb
@@ -43,6 +43,32 @@ RSpec.describe LinkDetailsExtractor do
     end
   end
 
+  describe '#first_of_hash' do
+    context 'when value.is_a?(Array)' do
+      it 'returns value.first if value.first.is_a?(Hash)' do
+        value = [{ a: 1 }]
+        expect(subject.first_of_hash(value)).to be({ a: 1 })
+      end
+
+      it 'returns nil if value.first !is_a?(Hash)' do
+        value = ['a']
+        expect(subject.first_of_hash(value)).to be_nil
+      end
+    end
+
+    context 'with !value.is_a?(Array)' do
+      it 'returns value (value.is_a?(Hash))' do
+        value = { a: 1 }
+        expect(subject.first_of_hash(value)).to be({ a: 1 })
+      end
+
+      it 'returns value (!value.is_a?(Hash))' do
+        value = 'a'
+        expect(subject.first_of_hash(value)).to be 'a'
+      end
+    end
+  end
+
   context 'when only basic metadata is present' do
     let(:html) { <<~HTML }
       <!doctype html>

--- a/spec/lib/link_details_extractor_spec.rb
+++ b/spec/lib/link_details_extractor_spec.rb
@@ -266,9 +266,6 @@ RSpec.describe LinkDetailsExtractor do
             'name' => 'Pet News',
             'url' => 'https://example.com',
           }]],
-          'image' => [[{
-            'url' => 'https://example.com/image.png',
-          }]],
         }.to_json
       end
       let(:html) { <<~HTML }
@@ -282,16 +279,12 @@ RSpec.describe LinkDetailsExtractor do
         </html>
       HTML
 
-      it 'gives nil for author_name' do
-        expect(subject.author_name).to be_nil
+      it 'gives "" for author_name' do
+        expect(subject.author_name).to be ''
       end
 
-      it 'gives nil for publisher_name' do
-        expect(subject.publisher_name).to be_nil
-      end
-
-      it 'gives nil for image' do
-        expect(subject.image).to be_nil
+      it 'gives "" for provider_name' do
+        expect(subject.provider_name).to be ''
       end
     end
   end

--- a/spec/lib/link_details_extractor_spec.rb
+++ b/spec/lib/link_details_extractor_spec.rb
@@ -250,7 +250,7 @@ RSpec.describe LinkDetailsExtractor do
       end
     end
 
-    context 'with incorrect ld_json data' do
+    context 'with embedded arrays' do
       let(:ld_json) do
         {
           '@context' => 'https://schema.org',
@@ -279,12 +279,12 @@ RSpec.describe LinkDetailsExtractor do
         </html>
       HTML
 
-      it 'gives "" for author_name' do
-        expect(subject.author_name).to eq ''
+      it 'gives correct author_name' do
+        expect(subject.author_name).to eq 'Author 1'
       end
 
-      it 'gives "" for provider_name' do
-        expect(subject.provider_name).to eq ''
+      it 'gives provider_name' do
+        expect(subject.provider_name).to eq 'Pet News'
       end
     end
   end

--- a/spec/lib/link_details_extractor_spec.rb
+++ b/spec/lib/link_details_extractor_spec.rb
@@ -285,7 +285,7 @@ RSpec.describe LinkDetailsExtractor do
     end
   end
 
-  RSpec.describe LinkDetailsExtractor::StructuredData do
+  describe LinkDetailsExtractor::StructuredData do
     subject { described_class.new('{}') }
 
     describe '#first_of_hash' do

--- a/spec/lib/link_details_extractor_spec.rb
+++ b/spec/lib/link_details_extractor_spec.rb
@@ -44,6 +44,8 @@ RSpec.describe LinkDetailsExtractor do
   end
 
   describe '#first_of_hash' do
+    let(:html) { '' }
+
     context 'when value.is_a?(Array)' do
       it 'returns value.first if value.first.is_a?(Hash)' do
         value = [{ a: 1 }]


### PR DESCRIPTION
Fixes #33646, and possibly many more parsing errors.

The rest of `LinkDetailsExtractor` expects these to be `Hash`es, but that's never enforced anywhere, except for here.

This will now catch:
- `"author": [[]]`

This will also discard `"author": ["John Mastodon"]`, but considering this was never expected or rectified anywhere (I checked), similar to `"author": "John Mastodon"`, I assume this is alright.

This'll also now properly catch an author object in a multi-author array; `"author": ["John", { ... }]`, here it'll catch the second value.