### PR TITLE
Use `expect` for nested params in `auth/setup#update`

### DIFF
--- a/app/controllers/auth/setup_controller.rb
+++ b/app/controllers/auth/setup_controller.rb
@@ -35,6 +35,6 @@ class Auth::SetupController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:email)
+    params.expect(user: [:email])
   end
 end

--- a/spec/requests/auth/setup_spec.rb
+++ b/spec/requests/auth/setup_spec.rb
@@ -24,4 +24,15 @@ RSpec.describe 'Auth Setup' do
       end
     end
   end
+
+  describe 'PUT /auth/setup' do
+    before { sign_in Fabricate(:user, confirmed_at: nil) }
+
+    it 'gracefully handles invalid nested params' do
+      put '/auth/setup?user=invalid'
+
+      expect(response)
+        .to have_http_status(400)
+    end
+  end
 end


### PR DESCRIPTION
Background: https://github.com/mastodon/mastodon/pull/33644#issuecomment-2601804251

I'd been planning to do some of these as a post-rails-8 thing, and that rubocop PR reminded me. I suspect they will add/expand the cop over time to catch more conditions ... and we actually have a lot less of these than I would have guessed, since much of the API controllers are not nested (ie, just have top-level `params.permit(...)` but not nested require/permit combo).

For this first PR, I've done the simplest example I could find along with a spec to show what changes (prior to change, this would error out as 5xx response, post-change it's handled as 4xx due to invalid params).

Assuming we're good with the change and not worried about issues from the changing (but probably improved?) response codes, I'll do larger future batches, and/or just bulk autocorrect.