### PR TITLE
Fix opening modals losing some location parameters

### DIFF
--- a/app/javascript/mastodon/components/modal_root.jsx
+++ b/app/javascript/mastodon/components/modal_root.jsx
@@ -118,9 +118,9 @@ class ModalRoot extends PureComponent {
   }
 
   _ensureHistoryBuffer () {
-    const { pathname, state } = this.history.location;
+    const { pathname, search, hash, state } = this.history.location;
     if (!state || state.mastodonModalKey !== this._modalHistoryKey) {
-      this.history.push(pathname, { ...state, mastodonModalKey: this._modalHistoryKey });
+      this.history.push({ pathname, search, hash }, { ...state, mastodonModalKey: this._modalHistoryKey });
     }
   }
 


### PR DESCRIPTION
Before the search interface rework, search params did not matter, but now they do.

Opening any modal (boost confirmation, media modal and so on) caused the temporary history state to lose its search parameter, resetting search results.