### PR TITLE
Change how the modal stack is handled

### DIFF
--- a/app/javascript/mastodon/actions/modal.ts
+++ b/app/javascript/mastodon/actions/modal.ts
@@ -9,7 +9,6 @@ export type ModalType = keyof typeof MODAL_COMPONENTS;
 interface OpenModalPayload {
   modalType: ModalType;
   modalProps: ModalProps;
-  previousModalProps?: ModalProps;
 }
 export const openModal = createAction<OpenModalPayload>('MODAL_OPEN');
 

--- a/app/javascript/mastodon/features/alt_text_modal/index.tsx
+++ b/app/javascript/mastodon/features/alt_text_modal/index.tsx
@@ -262,11 +262,6 @@ const Preview: React.FC<{
   }
 };
 
-interface RestoreProps {
-  previousDescription: string;
-  previousPosition: FocalPoint;
-}
-
 interface Props {
   mediaId: string;
   onClose: () => void;
@@ -275,15 +270,14 @@ interface Props {
 interface ConfirmationMessage {
   message: string;
   confirm: string;
-  props?: RestoreProps;
 }
 
 export interface ModalRef {
   getCloseConfirmationMessage: () => null | ConfirmationMessage;
 }
 
-export const AltTextModal = forwardRef<ModalRef, Props & Partial<RestoreProps>>(
-  ({ mediaId, previousDescription, previousPosition, onClose }, ref) => {
+export const AltTextModal = forwardRef<ModalRef, Props>(
+  ({ mediaId, onClose }, ref) => {
     const intl = useIntl();
     const dispatch = useAppDispatch();
     const media = useAppSelector((state) =>
@@ -302,18 +296,15 @@ export const AltTextModal = forwardRef<ModalRef, Props & Partial<RestoreProps>>(
     const focusY =
       (media?.getIn(['meta', 'focus', 'y'], 0) as number | undefined) ?? 0;
     const [description, setDescription] = useState(
-      previousDescription ??
         (media?.get('description') as string | undefined) ??
         '',
     );
     const [position, setPosition] = useState<FocalPoint>(
-      previousPosition ?? [focusX / 2 + 0.5, focusY / -2 + 0.5],
+      [focusX / 2 + 0.5, focusY / -2 + 0.5],
     );
     const [isDetecting, setIsDetecting] = useState(false);
     const [isSaving, setIsSaving] = useState(false);
-    const dirtyRef = useRef(
-      previousDescription || previousPosition ? true : false,
-    );
+    const dirtyRef = useRef(false);
     const type = media?.get('type') as string;
     const valid = length(description) <= MAX_LENGTH;
 

--- a/app/javascript/mastodon/features/ui/containers/modal_container.js
+++ b/app/javascript/mastodon/features/ui/containers/modal_container.js
@@ -1,14 +1,12 @@
+import { List as ImmutableList } from 'immutable';
 import { connect } from 'react-redux';
 
 import { openModal, closeModal } from '../../../actions/modal';
 import ModalRoot from '../components/modal_root';
 
-const defaultProps = {};
-
 const mapStateToProps = state => ({
   ignoreFocus: state.getIn(['modal', 'ignoreFocus']),
-  type: state.getIn(['modal', 'stack', 0, 'modalType'], null),
-  props: state.getIn(['modal', 'stack', 0, 'modalProps'], defaultProps),
+  modals: state.getIn(['modal', 'stack'], ImmutableList()),
 });
 
 const mapDispatchToProps = dispatch => ({
@@ -16,7 +14,6 @@ const mapDispatchToProps = dispatch => ({
     if (confirmationMessage) {
       dispatch(
         openModal({
-          previousModalProps: confirmationMessage.props,
           modalType: 'CONFIRM',
           modalProps: {
             message: confirmationMessage.message,


### PR DESCRIPTION
Context: https://github.com/mastodon/mastodon/pull/33516#discussion_r1923473990

This is work in progress, with the most obvious issue being the modals being literally stacked above each other. Older modals should be either hidden, or displayed below newer modals.