### PR TITLE
Use `expect` for nested params in `settings/*` controllers

### DIFF
--- a/app/controllers/settings/aliases_controller.rb
+++ b/app/controllers/settings/aliases_controller.rb
@@ -30,7 +30,7 @@ class Settings::AliasesController < Settings::BaseController
   private
 
   def resource_params
-    params.require(:account_alias).permit(:acct)
+    params.expect(account_alias: [:acct])
   end
 
   def set_alias

--- a/app/controllers/settings/deletes_controller.rb
+++ b/app/controllers/settings/deletes_controller.rb
@@ -21,7 +21,7 @@ class Settings::DeletesController < Settings::BaseController
   private
 
   def resource_params
-    params.require(:form_delete_confirmation).permit(:password, :username)
+    params.expect(form_delete_confirmation: [:password, :username])
   end
 
   def require_not_suspended!

--- a/app/controllers/settings/featured_tags_controller.rb
+++ b/app/controllers/settings/featured_tags_controller.rb
@@ -44,6 +44,6 @@ class Settings::FeaturedTagsController < Settings::BaseController
   end
 
   def featured_tag_params
-    params.require(:featured_tag).permit(:name)
+    params.expect(featured_tag: [:name])
   end
 end

--- a/app/controllers/settings/imports_controller.rb
+++ b/app/controllers/settings/imports_controller.rb
@@ -90,7 +90,7 @@ class Settings::ImportsController < Settings::BaseController
   private
 
   def import_params
-    params.require(:form_import).permit(:data, :type, :mode)
+    params.expect(form_import: [:data, :type, :mode])
   end
 
   def set_bulk_import

--- a/app/controllers/settings/migration/redirects_controller.rb
+++ b/app/controllers/settings/migration/redirects_controller.rb
@@ -33,6 +33,6 @@ class Settings::Migration::RedirectsController < Settings::BaseController
   private
 
   def resource_params
-    params.require(:form_redirect).permit(:acct, :current_password, :current_username)
+    params.expect(form_redirect: [:acct, :current_password, :current_username])
   end
 end

--- a/app/controllers/settings/migrations_controller.rb
+++ b/app/controllers/settings/migrations_controller.rb
@@ -27,7 +27,7 @@ class Settings::MigrationsController < Settings::BaseController
   private
 
   def resource_params
-    params.require(:account_migration).permit(:acct, :current_password, :current_username)
+    params.expect(account_migration: [:acct, :current_password, :current_username])
   end
 
   def set_migrations

--- a/app/controllers/settings/privacy_controller.rb
+++ b/app/controllers/settings/privacy_controller.rb
@@ -18,7 +18,7 @@ class Settings::PrivacyController < Settings::BaseController
   private
 
   def account_params
-    params.require(:account).permit(:discoverable, :unlocked, :indexable, :show_collections, settings: UserSettings.keys)
+    params.expect(account: [:discoverable, :unlocked, :indexable, :show_collections, settings: UserSettings.keys])
   end
 
   def set_account

--- a/app/controllers/settings/profiles_controller.rb
+++ b/app/controllers/settings/profiles_controller.rb
@@ -20,7 +20,7 @@ class Settings::ProfilesController < Settings::BaseController
   private
 
   def account_params
-    params.require(:account).permit(:display_name, :note, :avatar, :header, :bot, fields_attributes: [:name, :value])
+    params.expect(account: [:display_name, :note, :avatar, :header, :bot, fields_attributes: [:name, :value]])
   end
 
   def set_account

--- a/spec/requests/settings/aliases_spec.rb
+++ b/spec/requests/settings/aliases_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Settings Aliases' do
+  describe 'POST /settings/aliases' do
+    before { sign_in Fabricate(:user) }
+
+    it 'gracefully handles invalid nested params' do
+      post settings_aliases_path(account_alias: 'invalid')
+
+      expect(response)
+        .to have_http_status(400)
+    end
+  end
+end

--- a/spec/requests/settings/deletes_spec.rb
+++ b/spec/requests/settings/deletes_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Settings Deletes' do
+  describe 'DELETE /settings/delete' do
+    before { sign_in Fabricate(:user) }
+
+    it 'gracefully handles invalid nested params' do
+      delete settings_delete_path(form_delete_confirmation: 'invalid')
+
+      expect(response)
+        .to have_http_status(400)
+    end
+  end
+end

--- a/spec/requests/settings/featured_tags_spec.rb
+++ b/spec/requests/settings/featured_tags_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Settings Aliases' do
+  describe 'POST /settings/featured_tags' do
+    before { sign_in Fabricate(:user) }
+
+    it 'gracefully handles invalid nested params' do
+      post settings_featured_tags_path(featured_tag: 'invalid')
+
+      expect(response)
+        .to have_http_status(400)
+    end
+  end
+end

--- a/spec/requests/settings/imports_spec.rb
+++ b/spec/requests/settings/imports_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Settings Imports' do
+  describe 'POST /settings/imports' do
+    before { sign_in Fabricate(:user) }
+
+    it 'gracefully handles invalid nested params' do
+      post settings_imports_path(form_import: 'invalid')
+
+      expect(response)
+        .to have_http_status(400)
+    end
+  end
+end

--- a/spec/requests/settings/migration/redirects_spec.rb
+++ b/spec/requests/settings/migration/redirects_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Settings Migration Redirects' do
+  describe 'POST /settings/migration/redirect' do
+    before { sign_in Fabricate(:user) }
+
+    it 'gracefully handles invalid nested params' do
+      post settings_migration_redirect_path(form_redirect: 'invalid')
+
+      expect(response)
+        .to have_http_status(400)
+    end
+  end
+end

--- a/spec/requests/settings/migrations_spec.rb
+++ b/spec/requests/settings/migrations_spec.rb
@@ -18,4 +18,15 @@ RSpec.describe 'Settings Migrations' do
       it { is_expected.to redirect_to new_user_session_path }
     end
   end
+
+  context 'when user is signed in' do
+    before { sign_in Fabricate(:user) }
+
+    it 'gracefully handles invalid nested params' do
+      post settings_migration_path(account_migration: 'invalid')
+
+      expect(response)
+        .to have_http_status(400)
+    end
+  end
 end

--- a/spec/requests/settings/privacy_spec.rb
+++ b/spec/requests/settings/privacy_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Settings Privacy' do
+  describe 'PUT /settings/privacy' do
+    before { sign_in Fabricate(:user) }
+
+    it 'gracefully handles invalid nested params' do
+      put settings_privacy_path(account: 'invalid')
+
+      expect(response)
+        .to have_http_status(400)
+    end
+  end
+end

--- a/spec/requests/settings/profiles_spec.rb
+++ b/spec/requests/settings/profiles_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Settings Profiles' do
+  describe 'PUT /settings/profile' do
+    before { sign_in Fabricate(:user) }
+
+    it 'gracefully handles invalid nested params' do
+      put settings_profile_path(account: 'invalid')
+
+      expect(response)
+        .to have_http_status(400)
+    end
+  end
+end


### PR DESCRIPTION
More of https://github.com/mastodon/mastodon/pull/33657

This gets almost all of the "settings" controllers. Left out a few that were not just straightforward autocorrect which I'll handle with more consideration.

Like the previous one, all the changes in `app` here are just auto-corrects, and all the spec additions are showing that we do change from a 5xx to 4xx response when using `expect`.