### PR TITLE
Use `expect` for nested params in more controllers

### DIFF
--- a/app/controllers/disputes/appeals_controller.rb
+++ b/app/controllers/disputes/appeals_controller.rb
@@ -21,6 +21,6 @@ class Disputes::AppealsController < Disputes::BaseController
   end
 
   def appeal_params
-    params.require(:appeal).permit(:text)
+    params.expect(appeal: [:text])
   end
 end

--- a/app/controllers/filters_controller.rb
+++ b/app/controllers/filters_controller.rb
@@ -48,7 +48,7 @@ class FiltersController < ApplicationController
   end
 
   def resource_params
-    params.require(:custom_filter).permit(:title, :expires_in, :filter_action, context: [], keywords_attributes: [:id, :keyword, :whole_word, :_destroy])
+    params.expect(custom_filter: [:title, :expires_in, :filter_action, context: [], keywords_attributes: [:id, :keyword, :whole_word, :_destroy]])
   end
 
   def set_cache_headers

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -43,7 +43,7 @@ class InvitesController < ApplicationController
   end
 
   def resource_params
-    params.require(:invite).permit(:max_uses, :expires_in, :autofollow, :comment)
+    params.expect(invite: [:max_uses, :expires_in, :autofollow, :comment])
   end
 
   def set_cache_headers

--- a/app/controllers/statuses_cleanup_controller.rb
+++ b/app/controllers/statuses_cleanup_controller.rb
@@ -15,8 +15,6 @@ class StatusesCleanupController < ApplicationController
     else
       render :show
     end
-  rescue ActionController::ParameterMissing
-    # Do nothing
   end
 
   def require_functional!
@@ -30,7 +28,7 @@ class StatusesCleanupController < ApplicationController
   end
 
   def resource_params
-    params.require(:account_statuses_cleanup_policy).permit(:enabled, :min_status_age, :keep_direct, :keep_pinned, :keep_polls, :keep_media, :keep_self_fav, :keep_self_bookmark, :min_favs, :min_reblogs)
+    params.expect(account_statuses_cleanup_policy: [:enabled, :min_status_age, :keep_direct, :keep_pinned, :keep_polls, :keep_media, :keep_self_fav, :keep_self_bookmark, :min_favs, :min_reblogs])
   end
 
   def set_cache_headers

--- a/spec/requests/disputes/appeals_spec.rb
+++ b/spec/requests/disputes/appeals_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Disputes Appeals' do
+  describe 'POST /disputes/appeals' do
+    before { sign_in strike.target_account.user }
+
+    let(:strike) { Fabricate :account_warning }
+
+    it 'gracefully handles invalid nested params' do
+      post disputes_strike_appeal_path(strike, appeal: 'invalid')
+
+      expect(response)
+        .to have_http_status(400)
+    end
+  end
+end

--- a/spec/requests/filters_spec.rb
+++ b/spec/requests/filters_spec.rb
@@ -13,4 +13,28 @@ RSpec.describe 'Filters' do
       end
     end
   end
+
+  describe 'POST /filters' do
+    before { sign_in Fabricate :user }
+
+    it 'gracefully handles invalid nested params' do
+      post filters_path(custom_filter: 'invalid')
+
+      expect(response)
+        .to have_http_status(400)
+    end
+  end
+
+  describe 'PUT /filters/:id' do
+    before { sign_in(filter.account.user) }
+
+    let(:filter) { Fabricate :custom_filter }
+
+    it 'gracefully handles invalid nested params' do
+      put filter_path(filter, custom_filter: 'invalid')
+
+      expect(response)
+        .to have_http_status(400)
+    end
+  end
 end

--- a/spec/requests/invites_spec.rb
+++ b/spec/requests/invites_spec.rb
@@ -28,4 +28,13 @@ RSpec.describe 'Invites' do
       end
     end
   end
+
+  describe 'POST /invites' do
+    it 'gracefully handles invalid nested params' do
+      post invites_path(invite: 'invalid')
+
+      expect(response)
+        .to have_http_status(400)
+    end
+  end
 end

--- a/spec/requests/statuses_cleanup_spec.rb
+++ b/spec/requests/statuses_cleanup_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Statuses Cleanup' do
+  describe 'PUT /statuses_cleanup' do
+    before { sign_in Fabricate(:user) }
+
+    it 'gracefully handles invalid nested params' do
+      put statuses_cleanup_path(account_statuses_cleanup_policy: 'invalid')
+
+      expect(response)
+        .to have_http_status(400)
+    end
+  end
+end


### PR DESCRIPTION
Same idea as https://github.com/mastodon/mastodon/pull/33673

Just auto-corrects + specs for most of them.

For statuses cleanup, we actually had a path which handled this scenario already, so the change there is to just let the framework do it.