### PR TITLE
Store Bootsnap cache outside bind mounts (devcontainer only)

### DIFF
--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -10,6 +10,7 @@ services:
       RAILS_ENV: development
       NODE_ENV: development
       BIND: 0.0.0.0
+      BOOTSNAP_CACHE_DIR: /tmp
       REDIS_HOST: redis
       REDIS_PORT: '6379'
       DB_HOST: db


### PR DESCRIPTION
Storing the Bootsnap cache in a Docker bind mount is bad for performance.

This change reduces the Rails boot time with ~30% on my machine (measures using `time rails r 1`).