### PR TITLE
Fix WebUI crash when language detection code returns `undefined`

### DIFF
--- a/app/javascript/mastodon/features/compose/containers/language_dropdown_container.js
+++ b/app/javascript/mastodon/features/compose/containers/language_dropdown_container.js
@@ -78,6 +78,9 @@ const detectedLanguage = createSelector([
 ], text => {
   if (text.length > 20) {
     const guesses = debouncedLande(text);
+    if (!guesses)
+      return '';
+
     const [lang, confidence] = guesses[0];
 
     if (confidence > 0.8) {


### PR DESCRIPTION
Fixes #33681

I am not completely sure why this returns `undefined`, but it does on initial load, so fix it to not crash when it does.