### PR TITLE
Change `mastodon:setup` to prevent overwriting already-configured servers

### DIFF
--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -8,6 +8,12 @@ namespace :mastodon do
     prompt = TTY::Prompt.new
     env    = {}
 
+    if ENV['LOCAL_DOMAIN']
+      prompt.warn "It looks like you already configured Mastodon for domain '#{ENV['LOCAL_DOMAIN']}'."
+      prompt.warn 'Never re-run this task on an already-configured running server.'
+      next prompt.warn 'Nothing saved. Bye!' if prompt.no?('Continue anyway?')
+    end
+
     clear_environment!
 
     begin


### PR DESCRIPTION
At least one server that changed Active Record Encryption secrets after setup was because of re-running the `mastodon:setup` task.