### PR TITLE
Use `expect` for `admin/` controllers

### DIFF
--- a/app/controllers/admin/account_actions_controller.rb
+++ b/app/controllers/admin/account_actions_controller.rb
@@ -34,7 +34,8 @@ module Admin
     end
 
     def resource_params
-      params.require(:admin_account_action).permit(:type, :report_id, :warning_preset_id, :text, :send_email_notification, :include_statuses)
+      params
+        .expect(admin_account_action: [:type, :report_id, :warning_preset_id, :text, :send_email_notification, :include_statuses])
     end
   end
 end

--- a/app/controllers/admin/account_moderation_notes_controller.rb
+++ b/app/controllers/admin/account_moderation_notes_controller.rb
@@ -29,10 +29,8 @@ module Admin
     private
 
     def resource_params
-      params.require(:account_moderation_note).permit(
-        :content,
-        :target_account_id
-      )
+      params
+        .expect(account_moderation_note: [:content, :target_account_id])
     end
 
     def set_account_moderation_note

--- a/app/controllers/admin/accounts_controller.rb
+++ b/app/controllers/admin/accounts_controller.rb
@@ -158,7 +158,8 @@ module Admin
     end
 
     def form_account_batch_params
-      params.require(:form_account_batch).permit(:action, account_ids: [])
+      params
+        .expect(form_account_batch: [:action, account_ids: []])
     end
 
     def action_from_button

--- a/app/controllers/admin/announcements_controller.rb
+++ b/app/controllers/admin/announcements_controller.rb
@@ -84,6 +84,7 @@ class Admin::AnnouncementsController < Admin::BaseController
   end
 
   def resource_params
-    params.require(:announcement).permit(:text, :scheduled_at, :starts_at, :ends_at, :all_day)
+    params
+      .expect(announcement: [:text, :scheduled_at, :starts_at, :ends_at, :all_day])
   end
 end

--- a/app/controllers/admin/change_emails_controller.rb
+++ b/app/controllers/admin/change_emails_controller.rb
@@ -41,9 +41,8 @@ module Admin
     end
 
     def resource_params
-      params.require(:user).permit(
-        :unconfirmed_email
-      )
+      params
+        .expect(user: [:unconfirmed_email])
     end
   end
 end

--- a/app/controllers/admin/custom_emojis_controller.rb
+++ b/app/controllers/admin/custom_emojis_controller.rb
@@ -44,7 +44,8 @@ module Admin
     private
 
     def resource_params
-      params.require(:custom_emoji).permit(:shortcode, :image, :visible_in_picker)
+      params
+        .expect(custom_emoji: [:shortcode, :image, :visible_in_picker])
     end
 
     def filtered_custom_emojis
@@ -74,7 +75,8 @@ module Admin
     end
 
     def form_custom_emoji_batch_params
-      params.require(:form_custom_emoji_batch).permit(:action, :category_id, :category_name, custom_emoji_ids: [])
+      params
+        .expect(form_custom_emoji_batch: [:action, :category_id, :category_name, custom_emoji_ids: []])
     end
   end
 end

--- a/app/controllers/admin/domain_allows_controller.rb
+++ b/app/controllers/admin/domain_allows_controller.rb
@@ -37,6 +37,7 @@ class Admin::DomainAllowsController < Admin::BaseController
   end
 
   def resource_params
-    params.require(:domain_allow).permit(:domain)
+    params
+      .expect(domain_allow: [:domain])
   end
 end

--- a/app/controllers/admin/domain_blocks_controller.rb
+++ b/app/controllers/admin/domain_blocks_controller.rb
@@ -24,8 +24,10 @@ module Admin
       flash[:alert] = I18n.t('admin.domain_blocks.no_domain_block_selected')
     rescue Mastodon::NotPermittedError
       flash[:alert] = I18n.t('admin.domain_blocks.not_permitted')
+    else
+      flash[:notice] = I18n.t('admin.domain_blocks.created_msg')
     ensure
-      redirect_to admin_instances_path(limited: '1'), notice: I18n.t('admin.domain_blocks.created_msg')
+      redirect_to admin_instances_path(limited: '1')
     end
 
     def new

--- a/app/controllers/admin/domain_blocks_controller.rb
+++ b/app/controllers/admin/domain_blocks_controller.rb
@@ -24,7 +24,7 @@ module Admin
       flash[:alert] = I18n.t('admin.domain_blocks.no_domain_block_selected')
     rescue Mastodon::NotPermittedError
       flash[:alert] = I18n.t('admin.domain_blocks.not_permitted')
-    else
+    ensure
       redirect_to admin_instances_path(limited: '1'), notice: I18n.t('admin.domain_blocks.created_msg')
     end
 
@@ -114,7 +114,12 @@ module Admin
     end
 
     def form_domain_block_batch_params
-      params.require(:form_domain_block_batch).permit(domain_blocks_attributes: [:enabled, :domain, :severity, :reject_media, :reject_reports, :private_comment, :public_comment, :obfuscate])
+      params
+        .expect(
+          form_domain_block_batch: [
+            domain_blocks_attributes: [[:enabled, :domain, :severity, :reject_media, :reject_reports, :private_comment, :public_comment, :obfuscate]],
+          ]
+        )
     end
 
     def action_from_button

--- a/app/controllers/admin/email_domain_blocks_controller.rb
+++ b/app/controllers/admin/email_domain_blocks_controller.rb
@@ -62,11 +62,13 @@ module Admin
     end
 
     def resource_params
-      params.require(:email_domain_block).permit(:domain, :allow_with_approval, other_domains: [])
+      params
+        .expect(email_domain_block: [:domain, :allow_with_approval, other_domains: []])
     end
 
     def form_email_domain_block_batch_params
-      params.require(:form_email_domain_block_batch).permit(email_domain_block_ids: [])
+      params
+        .expect(form_email_domain_block_batch: [email_domain_block_ids: []])
     end
 
     def action_from_button

--- a/app/controllers/admin/follow_recommendations_controller.rb
+++ b/app/controllers/admin/follow_recommendations_controller.rb
@@ -37,7 +37,8 @@ module Admin
     end
 
     def form_account_batch_params
-      params.require(:form_account_batch).permit(:action, account_ids: [])
+      params
+        .expect(form_account_batch: [:action, account_ids: []])
     end
 
     def filter_params

--- a/app/controllers/admin/invites_controller.rb
+++ b/app/controllers/admin/invites_controller.rb
@@ -39,7 +39,8 @@ module Admin
     private
 
     def resource_params
-      params.require(:invite).permit(:max_uses, :expires_in)
+      params
+        .expect(invite: [:max_uses, :expires_in])
     end
 
     def filtered_invites

--- a/app/controllers/admin/ip_blocks_controller.rb
+++ b/app/controllers/admin/ip_blocks_controller.rb
@@ -44,7 +44,8 @@ module Admin
     private
 
     def resource_params
-      params.require(:ip_block).permit(:ip, :severity, :comment, :expires_in)
+      params
+        .expect(ip_block: [:ip, :severity, :comment, :expires_in])
     end
 
     def action_from_button
@@ -52,7 +53,8 @@ module Admin
     end
 
     def form_ip_block_batch_params
-      params.require(:form_ip_block_batch).permit(ip_block_ids: [])
+      params
+        .expect(form_ip_block_batch: [ip_block_ids: []])
     end
   end
 end

--- a/app/controllers/admin/relays_controller.rb
+++ b/app/controllers/admin/relays_controller.rb
@@ -57,7 +57,8 @@ module Admin
     end
 
     def resource_params
-      params.require(:relay).permit(:inbox_url)
+      params
+        .expect(relay: [:inbox_url])
     end
 
     def warn_signatures_not_enabled!

--- a/app/controllers/admin/report_notes_controller.rb
+++ b/app/controllers/admin/report_notes_controller.rb
@@ -47,10 +47,8 @@ module Admin
     end
 
     def resource_params
-      params.require(:report_note).permit(
-        :content,
-        :report_id
-      )
+      params
+        .expect(report_note: [:content, :report_id])
     end
 
     def set_report_note

--- a/app/controllers/admin/roles_controller.rb
+++ b/app/controllers/admin/roles_controller.rb
@@ -61,7 +61,8 @@ module Admin
     end
 
     def resource_params
-      params.require(:user_role).permit(:name, :color, :highlighted, :position, permissions_as_keys: [])
+      params
+        .expect(user_role: [:name, :color, :highlighted, :position, permissions_as_keys: []])
     end
   end
 end

--- a/app/controllers/admin/rules_controller.rb
+++ b/app/controllers/admin/rules_controller.rb
@@ -53,7 +53,8 @@ module Admin
     end
 
     def resource_params
-      params.require(:rule).permit(:text, :hint, :priority)
+      params
+        .expect(rule: [:text, :hint, :priority])
     end
   end
 end

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -28,7 +28,8 @@ module Admin
     end
 
     def settings_params
-      params.require(:form_admin_settings).permit(*Form::AdminSettings::KEYS)
+      params
+        .expect(form_admin_settings: [*Form::AdminSettings::KEYS])
     end
   end
 end

--- a/app/controllers/admin/statuses_controller.rb
+++ b/app/controllers/admin/statuses_controller.rb
@@ -39,7 +39,8 @@ module Admin
     helper_method :batched_ordered_status_edits
 
     def admin_status_batch_action_params
-      params.require(:admin_status_batch_action).permit(status_ids: [])
+      params
+        .expect(admin_status_batch_action: [status_ids: []])
     end
 
     def after_create_redirect_path

--- a/app/controllers/admin/tags_controller.rb
+++ b/app/controllers/admin/tags_controller.rb
@@ -37,7 +37,8 @@ module Admin
     end
 
     def tag_params
-      params.require(:tag).permit(:name, :display_name, :trendable, :usable, :listable)
+      params
+        .expect(tag: [:name, :display_name, :trendable, :usable, :listable])
     end
 
     def filtered_tags

--- a/app/controllers/admin/terms_of_service/drafts_controller.rb
+++ b/app/controllers/admin/terms_of_service/drafts_controller.rb
@@ -31,6 +31,7 @@ class Admin::TermsOfService::DraftsController < Admin::BaseController
   end
 
   def resource_params
-    params.require(:terms_of_service).permit(:text, :changelog)
+    params
+      .expect(terms_of_service: [:text, :changelog])
   end
 end

--- a/app/controllers/admin/terms_of_service/generates_controller.rb
+++ b/app/controllers/admin/terms_of_service/generates_controller.rb
@@ -32,6 +32,7 @@ class Admin::TermsOfService::GeneratesController < Admin::BaseController
   end
 
   def resource_params
-    params.require(:terms_of_service_generator).permit(*TermsOfService::Generator::VARIABLES)
+    params
+      .expect(terms_of_service_generator: [*TermsOfService::Generator::VARIABLES])
   end
 end

--- a/app/controllers/admin/trends/links/preview_card_providers_controller.rb
+++ b/app/controllers/admin/trends/links/preview_card_providers_controller.rb
@@ -31,7 +31,8 @@ class Admin::Trends::Links::PreviewCardProvidersController < Admin::BaseControll
   end
 
   def trends_preview_card_provider_batch_params
-    params.require(:trends_preview_card_provider_batch).permit(:action, preview_card_provider_ids: [])
+    params
+      .expect(trends_preview_card_provider_batch: [:action, preview_card_provider_ids: []])
   end
 
   def action_from_button

--- a/app/controllers/admin/trends/links_controller.rb
+++ b/app/controllers/admin/trends/links_controller.rb
@@ -31,7 +31,8 @@ class Admin::Trends::LinksController < Admin::BaseController
   end
 
   def trends_preview_card_batch_params
-    params.require(:trends_preview_card_batch).permit(:action, preview_card_ids: [])
+    params
+      .expect(trends_preview_card_batch: [:action, preview_card_ids: []])
   end
 
   def action_from_button

--- a/app/controllers/admin/trends/statuses_controller.rb
+++ b/app/controllers/admin/trends/statuses_controller.rb
@@ -31,7 +31,8 @@ class Admin::Trends::StatusesController < Admin::BaseController
   end
 
   def trends_status_batch_params
-    params.require(:trends_status_batch).permit(:action, status_ids: [])
+    params
+      .expect(trends_status_batch: [:action, status_ids: []])
   end
 
   def action_from_button

--- a/app/controllers/admin/trends/tags_controller.rb
+++ b/app/controllers/admin/trends/tags_controller.rb
@@ -31,7 +31,8 @@ class Admin::Trends::TagsController < Admin::BaseController
   end
 
   def trends_tag_batch_params
-    params.require(:trends_tag_batch).permit(:action, tag_ids: [])
+    params
+      .expect(trends_tag_batch: [:action, tag_ids: []])
   end
 
   def action_from_button

--- a/app/controllers/admin/users/roles_controller.rb
+++ b/app/controllers/admin/users/roles_controller.rb
@@ -28,7 +28,8 @@ module Admin
     end
 
     def resource_params
-      params.require(:user).permit(:role_id)
+      params
+        .expect(user: [:role_id])
     end
   end
 end

--- a/app/controllers/admin/warning_presets_controller.rb
+++ b/app/controllers/admin/warning_presets_controller.rb
@@ -52,7 +52,8 @@ module Admin
     end
 
     def warning_preset_params
-      params.require(:account_warning_preset).permit(:title, :text)
+      params
+        .expect(account_warning_preset: [:title, :text])
     end
   end
 end

--- a/app/controllers/admin/webhooks_controller.rb
+++ b/app/controllers/admin/webhooks_controller.rb
@@ -74,7 +74,8 @@ module Admin
     end
 
     def resource_params
-      params.require(:webhook).permit(:url, :template, events: [])
+      params
+        .expect(webhook: [:url, :template, events: []])
     end
   end
 end

--- a/spec/controllers/admin/settings/branding_controller_spec.rb
+++ b/spec/controllers/admin/settings/branding_controller_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe Admin::Settings::BrandingController do
 
         patch :update, params: { form_admin_settings: { new_setting_key: 'New key value' } }
 
-        expect(response).to redirect_to(admin_settings_branding_path)
+        expect(response)
+          .to have_http_status(400)
         expect(Setting.new_setting_key).to be_nil
       end
     end

--- a/spec/requests/admin/account_actions_spec.rb
+++ b/spec/requests/admin/account_actions_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin Account Actions' do
+  describe 'POST /admin/accounts/:account_id/action' do
+    before { sign_in Fabricate(:admin_user) }
+
+    let(:account) { Fabricate :account }
+
+    it 'gracefully handles invalid nested params' do
+      post admin_account_action_path(account.id, admin_account_action: 'invalid')
+
+      expect(response)
+        .to have_http_status(400)
+    end
+  end
+end

--- a/spec/requests/admin/account_moderation_notes_spec.rb
+++ b/spec/requests/admin/account_moderation_notes_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin Account Moderation Notes' do
+  describe 'POST /admin/account_moderation_notes' do
+    before { sign_in Fabricate(:admin_user) }
+
+    it 'gracefully handles invalid nested params' do
+      post admin_account_moderation_notes_path(account_moderation_note: 'invalid')
+
+      expect(response)
+        .to have_http_status(400)
+    end
+  end
+end

--- a/spec/requests/admin/accounts_spec.rb
+++ b/spec/requests/admin/accounts_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin Accounts' do
+  describe 'POST /admin/accounts/batch' do
+    before { sign_in Fabricate(:admin_user) }
+
+    it 'gracefully handles invalid nested params' do
+      post batch_admin_accounts_path(form_account_batch: 'invalid')
+
+      expect(response)
+        .to redirect_to(admin_accounts_path)
+    end
+  end
+end

--- a/spec/requests/admin/announcements_spec.rb
+++ b/spec/requests/admin/announcements_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin Announcements' do
+  describe 'POST /admin/announcements' do
+    before { sign_in Fabricate(:admin_user) }
+
+    it 'gracefully handles invalid nested params' do
+      post admin_announcements_path(announcement: 'invalid')
+
+      expect(response)
+        .to have_http_status(400)
+    end
+  end
+end

--- a/spec/requests/admin/change_emails_spec.rb
+++ b/spec/requests/admin/change_emails_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin Account Change Email' do
+  describe 'PUT /admin/accounts/:account_id/change_email' do
+    before { sign_in Fabricate(:admin_user) }
+
+    let(:account) { Fabricate :account }
+
+    it 'gracefully handles invalid nested params' do
+      put admin_account_change_email_path(account.id, user: 'invalid')
+
+      expect(response)
+        .to have_http_status(400)
+    end
+  end
+end

--- a/spec/requests/admin/custom_emojis_spec.rb
+++ b/spec/requests/admin/custom_emojis_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin Custom Emojis' do
+  describe 'POST /admin/custom_emojis' do
+    before { sign_in Fabricate(:admin_user) }
+
+    it 'gracefully handles invalid nested params' do
+      post admin_custom_emojis_path(custom_emoji: 'invalid')
+
+      expect(response)
+        .to have_http_status(400)
+    end
+  end
+end

--- a/spec/requests/admin/domain_allows_spec.rb
+++ b/spec/requests/admin/domain_allows_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin Domain Allows' do
+  describe 'POST /admin/domain_allows' do
+    before { sign_in Fabricate(:admin_user) }
+
+    it 'gracefully handles invalid nested params' do
+      post admin_domain_allows_path(domain_allow: 'invalid')
+
+      expect(response)
+        .to have_http_status(400)
+    end
+  end
+end

--- a/spec/requests/admin/domain_blocks_spec.rb
+++ b/spec/requests/admin/domain_blocks_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin Domain Blocks' do
+  describe 'POST /admin/domain_blocks/batch' do
+    before { sign_in Fabricate(:admin_user) }
+
+    it 'gracefully handles invalid nested params' do
+      post batch_admin_domain_blocks_path(form_domain_block_batch: 'invalid')
+
+      expect(response)
+        .to redirect_to(admin_instances_path(limited: '1'))
+    end
+  end
+end

--- a/spec/requests/admin/email_domain_blocks_spec.rb
+++ b/spec/requests/admin/email_domain_blocks_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin Email Domain Blocks' do
+  describe 'POST /admin/email_domain_blocks' do
+    before { sign_in Fabricate(:admin_user) }
+
+    it 'gracefully handles invalid nested params' do
+      post admin_email_domain_blocks_path(email_domain_block: 'invalid')
+
+      expect(response)
+        .to have_http_status(400)
+    end
+  end
+
+  describe 'POST /admin/email_domain_blocks/batch' do
+    before { sign_in Fabricate(:admin_user) }
+
+    it 'gracefully handles invalid nested params' do
+      post batch_admin_email_domain_blocks_path(form_email_domain_block_batch: 'invalid')
+
+      expect(response)
+        .to redirect_to(admin_email_domain_blocks_path)
+    end
+  end
+end

--- a/spec/requests/admin/follow_recommendations_spec.rb
+++ b/spec/requests/admin/follow_recommendations_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin Follow Recommendations' do
+  describe 'PUT /admin/follow_recommendations' do
+    before { sign_in Fabricate(:admin_user) }
+
+    it 'gracefully handles invalid nested params' do
+      put admin_follow_recommendations_path(form_account_batch: 'invalid')
+
+      expect(response)
+        .to redirect_to(admin_follow_recommendations_path)
+    end
+  end
+end

--- a/spec/requests/admin/invites_spec.rb
+++ b/spec/requests/admin/invites_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin Invites' do
+  describe 'POST /admin/invites' do
+    before { sign_in Fabricate(:admin_user) }
+
+    it 'gracefully handles invalid nested params' do
+      post admin_invites_path(invite: 'invalid')
+
+      expect(response)
+        .to have_http_status(400)
+    end
+  end
+end

--- a/spec/requests/admin/ip_blocks_spec.rb
+++ b/spec/requests/admin/ip_blocks_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin IP Blocks' do
+  describe 'POST /admin/ip_blocks' do
+    before { sign_in Fabricate(:admin_user) }
+
+    it 'gracefully handles invalid nested params' do
+      post admin_ip_blocks_path(ip_block: 'invalid')
+
+      expect(response)
+        .to have_http_status(400)
+    end
+  end
+
+  describe 'POST /admin/ip_blocks/batch' do
+    before { sign_in Fabricate(:admin_user) }
+
+    it 'gracefully handles invalid nested params' do
+      post batch_admin_ip_blocks_path(form_ip_block_batch: 'invalid')
+
+      expect(response)
+        .to redirect_to(admin_ip_blocks_path)
+    end
+  end
+end

--- a/spec/requests/admin/relays_spec.rb
+++ b/spec/requests/admin/relays_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin Relays' do
+  describe 'POST /admin/relays' do
+    before { sign_in Fabricate(:admin_user) }
+
+    it 'gracefully handles invalid nested params' do
+      post admin_relays_path(relay: 'invalid')
+
+      expect(response)
+        .to have_http_status(400)
+    end
+  end
+end

--- a/spec/requests/admin/report_notes_spec.rb
+++ b/spec/requests/admin/report_notes_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin Report Notes' do
+  describe 'POST /admin/report_notes' do
+    before { sign_in Fabricate(:admin_user) }
+
+    it 'gracefully handles invalid nested params' do
+      post admin_report_notes_path(report_note: 'invalid')
+
+      expect(response)
+        .to have_http_status(400)
+    end
+  end
+end

--- a/spec/requests/admin/roles_spec.rb
+++ b/spec/requests/admin/roles_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin Roles' do
+  describe 'POST /admin/roles' do
+    before { sign_in Fabricate(:admin_user) }
+
+    it 'gracefully handles invalid nested params' do
+      post admin_roles_path(user_role: 'invalid')
+
+      expect(response)
+        .to have_http_status(400)
+    end
+  end
+end

--- a/spec/requests/admin/rules_spec.rb
+++ b/spec/requests/admin/rules_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin Rules' do
+  describe 'POST /admin/rules' do
+    before { sign_in Fabricate(:admin_user) }
+
+    it 'gracefully handles invalid nested params' do
+      post admin_rules_path(rule: 'invalid')
+
+      expect(response)
+        .to have_http_status(400)
+    end
+  end
+end

--- a/spec/requests/admin/settings/about_spec.rb
+++ b/spec/requests/admin/settings/about_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin Settings About' do
+  describe 'PUT /admin/settings/about' do
+    before { sign_in Fabricate(:admin_user) }
+
+    it 'gracefully handles invalid nested params' do
+      put admin_settings_about_path(form_admin_settings: 'invalid')
+
+      expect(response)
+        .to have_http_status(400)
+    end
+  end
+end

--- a/spec/requests/admin/statuses_spec.rb
+++ b/spec/requests/admin/statuses_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin Statuses' do
+  describe 'POST /admin/accounts/:account_id/statuses/batch' do
+    before { sign_in Fabricate(:admin_user) }
+
+    let(:account) { Fabricate :account }
+
+    it 'gracefully handles invalid nested params' do
+      post batch_admin_account_statuses_path(account.id, admin_status_batch_action: 'invalid')
+
+      expect(response)
+        .to redirect_to(admin_account_statuses_path(account.id))
+    end
+  end
+end

--- a/spec/requests/admin/tags_spec.rb
+++ b/spec/requests/admin/tags_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin Tags' do
+  describe 'PUT /admin/tags/:id' do
+    before { sign_in Fabricate(:admin_user) }
+
+    let(:tag) { Fabricate :tag }
+
+    it 'gracefully handles invalid nested params' do
+      put admin_tag_path(tag.id, tag: 'invalid')
+
+      expect(response)
+        .to have_http_status(400)
+    end
+  end
+end

--- a/spec/requests/admin/terms_of_service/drafts_spec.rb
+++ b/spec/requests/admin/terms_of_service/drafts_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin Terms Drafts' do
+  describe 'PUT /admin/terms_of_service/draft' do
+    before { sign_in Fabricate(:admin_user) }
+
+    it 'gracefully handles invalid nested params' do
+      put admin_terms_of_service_draft_path(terms_of_service: 'invalid')
+
+      expect(response)
+        .to have_http_status(400)
+    end
+  end
+end

--- a/spec/requests/admin/terms_of_service/generates_spec.rb
+++ b/spec/requests/admin/terms_of_service/generates_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin Terms Generates' do
+  describe 'POST /admin/terms_of_service/generates' do
+    before { sign_in Fabricate(:admin_user) }
+
+    it 'gracefully handles invalid nested params' do
+      post admin_terms_of_service_generate_path(terms_of_service_generator: 'invalid')
+
+      expect(response)
+        .to have_http_status(400)
+    end
+  end
+end

--- a/spec/requests/admin/trends/links/preview_card_providers_spec.rb
+++ b/spec/requests/admin/trends/links/preview_card_providers_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin Trends Links Preview Card Providers' do
+  describe 'POST /admin/trends/links/publishers/batch' do
+    before { sign_in Fabricate(:admin_user) }
+
+    it 'gracefully handles invalid nested params' do
+      post batch_admin_trends_links_preview_card_providers_path(trends_preview_card_provider_batch: 'invalid')
+
+      expect(response)
+        .to redirect_to(admin_trends_links_preview_card_providers_path)
+    end
+  end
+end

--- a/spec/requests/admin/trends/links_spec.rb
+++ b/spec/requests/admin/trends/links_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin Trends Links' do
+  describe 'POST /admin/trends/links/batch' do
+    before { sign_in Fabricate(:admin_user) }
+
+    it 'gracefully handles invalid nested params' do
+      post batch_admin_trends_links_path(trends_preview_card_batch: 'invalid')
+
+      expect(response)
+        .to redirect_to(admin_trends_links_path)
+    end
+  end
+end

--- a/spec/requests/admin/trends/statuses_spec.rb
+++ b/spec/requests/admin/trends/statuses_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin Trends Statuses' do
+  describe 'POST /admin/trends/statuses/batch' do
+    before { sign_in Fabricate(:admin_user) }
+
+    it 'gracefully handles invalid nested params' do
+      post batch_admin_trends_statuses_path(trends_status_batch: 'invalid')
+
+      expect(response)
+        .to redirect_to(admin_trends_statuses_path)
+    end
+  end
+end

--- a/spec/requests/admin/trends/tags_spec.rb
+++ b/spec/requests/admin/trends/tags_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin Trends Tags' do
+  describe 'POST /admin/trends/tags/batch' do
+    before { sign_in Fabricate(:admin_user) }
+
+    it 'gracefully handles invalid nested params' do
+      post batch_admin_trends_tags_path(trends_tag_batch: 'invalid')
+
+      expect(response)
+        .to redirect_to(admin_trends_tags_path)
+    end
+  end
+end

--- a/spec/requests/admin/users/roles_spec.rb
+++ b/spec/requests/admin/users/roles_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin Users Roles' do
+  describe 'PUT /admin/users/:user_id/role' do
+    before { sign_in Fabricate(:admin_user) }
+
+    let(:user) { Fabricate :user }
+
+    it 'gracefully handles invalid nested params' do
+      put admin_user_role_path(user.id, user: 'invalid')
+
+      expect(response)
+        .to have_http_status(400)
+    end
+  end
+end

--- a/spec/requests/admin/warning_presets_spec.rb
+++ b/spec/requests/admin/warning_presets_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin Warning Presets' do
+  describe 'POST /admin/warning_presets' do
+    before { sign_in Fabricate(:admin_user) }
+
+    it 'gracefully handles invalid nested params' do
+      post admin_warning_presets_path(account_warning_preset: 'invalid')
+
+      expect(response)
+        .to have_http_status(400)
+    end
+  end
+end

--- a/spec/requests/admin/webhooks_spec.rb
+++ b/spec/requests/admin/webhooks_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin Webhooks' do
+  describe 'POST /admin/webhooks' do
+    before { sign_in Fabricate(:admin_user) }
+
+    it 'gracefully handles invalid nested params' do
+      post admin_webhooks_path(webhook: 'invalid')
+
+      expect(response)
+        .to have_http_status(400)
+    end
+  end
+end


### PR DESCRIPTION
Similar update as other recent PRs, for controllers in the admin area. Mix of changes:

- The vast bulk are exactly same as previous ones: add spec to show the changing 5xx-4xx behaviour, and auto-correct to `expect`
- Some of them (in particular, some "batch" ones) already had handling for a params error, which generally was a redirect somewhere. I chose to preserve this, so for these ones its a spec addition for the existing behavior, and also the auto-correct. Seems better to keep the graceful handling when it plausibly could have come from the app and not just params games.
- Similarly, I let the handling change from a redirect to a 400 on the admin/settings ones, since the error there would only come from params mischief.
- For `admin/domain_blocks` there was a code path not being reached, switched that to use an `ensure`, so technically a bug fix and also auto-correct for that specific one.
- Anywhere we use any `fields_for` needs a "double array" declaration (note admin/domain_blocks) for the `_attributes` param. I'll keep this in mind as I keep doing these, but might also make sense to do a pass that does nothing but add system specs making sure we do a multi-field form submit with all of those (under 10 app wide) to be confident that doesn't break.

I think these are probably all safe, but LMK if you'd like the "interesting" ones pulled out first before all the auto-correct-only ones.