### PR TITLE
Fix issue with saving empty fields values on profile update

### DIFF
--- a/app/controllers/settings/profiles_controller.rb
+++ b/app/controllers/settings/profiles_controller.rb
@@ -20,7 +20,7 @@ class Settings::ProfilesController < Settings::BaseController
   private
 
   def account_params
-    params.expect(account: [:display_name, :note, :avatar, :header, :bot, fields_attributes: [:name, :value]])
+    params.expect(account: [:display_name, :note, :avatar, :header, :bot, fields_attributes: [[:name, :value]]])
   end
 
   def set_account


### PR DESCRIPTION
Resolves https://github.com/mastodon/mastodon/issues/33688

Some background in https://github.com/mastodon/mastodon/pull/33686 re: the double array approach needed for any "fields for" values we have.

Broken (by me) here - https://github.com/mastodon/mastodon/pull/33673/files#diff-e11d4f7b8ea0ce03ff22a8c5ec8f84f5c17316e72966f1f3ec88aed9c12ffb7eR23 - as part of why I thought was an innocuous auto-correct.

I'll do a once-over on open PRs and the already merged ones like this to see if there has already been any other similar breakage.