### PR TITLE
Fix issue with saving empty fields values on filter keyword updates

### DIFF
--- a/app/controllers/filters_controller.rb
+++ b/app/controllers/filters_controller.rb
@@ -48,7 +48,7 @@ class FiltersController < ApplicationController
   end
 
   def resource_params
-    params.expect(custom_filter: [:title, :expires_in, :filter_action, context: [], keywords_attributes: [:id, :keyword, :whole_word, :_destroy]])
+    params.expect(custom_filter: [:title, :expires_in, :filter_action, context: [], keywords_attributes: [[:id, :keyword, :whole_word, :_destroy]]])
   end
 
   def set_cache_headers

--- a/spec/system/filters_spec.rb
+++ b/spec/system/filters_spec.rb
@@ -44,6 +44,8 @@ RSpec.describe 'Filters' do
     let(:new_title) { 'Change title value' }
 
     let!(:custom_filter) { Fabricate :custom_filter, account: user.account, title: filter_title }
+    let!(:keyword_one) { Fabricate :custom_filter_keyword, custom_filter: custom_filter }
+    let!(:keyword_two) { Fabricate :custom_filter_keyword, custom_filter: custom_filter }
 
     it 'Updates the saved filter' do
       navigate_to_filters
@@ -51,7 +53,12 @@ RSpec.describe 'Filters' do
       click_on filter_title
 
       fill_in filter_title_field, with: new_title
-      click_on submit_button
+      fill_in 'custom_filter_keywords_attributes_0_keyword', with: 'New value'
+      fill_in 'custom_filter_keywords_attributes_1_keyword', with: 'Wilderness'
+
+      expect { click_on submit_button }
+        .to change { keyword_one.reload.keyword }.to(/New value/)
+        .and(change { keyword_two.reload.keyword }.to(/Wilderness/))
 
       expect(page).to have_content(new_title)
     end


### PR DESCRIPTION
Resolves same issue as https://github.com/mastodon/mastodon/pull/33689 but in filters area.