### PR TITLE
Fix intermittent services/ap/process_status_update tags failure

### DIFF
--- a/spec/services/activitypub/process_status_update_service_spec.rb
+++ b/spec/services/activitypub/process_status_update_service_spec.rb
@@ -268,7 +268,7 @@ RSpec.describe ActivityPub::ProcessStatusUpdateService do
 
       it 'updates tags and featured tags' do
         expect { subject.call(status, json, json) }
-          .to change { status.tags.reload.pluck(:name) }.from(%w(test foo)).to(%w(foo bar))
+          .to change { status.tags.reload.pluck(:name) }.from(contain_exactly('test', 'foo')).to(contain_exactly('foo', 'bar'))
           .and change { status.account.featured_tags.find_by(name: 'test').statuses_count }.by(-1)
           .and change { status.account.featured_tags.find_by(name: 'bar').statuses_count }.by(1)
           .and change { status.account.featured_tags.find_by(name: 'bar').last_status_at }.from(nil).to(be_present)


### PR DESCRIPTION
Failure: https://github.com/mastodon/mastodon/actions/runs/12914353452/job/36013864563?pr=33691

I wasn't actually able to replicate this failure locally, but I assume it's stemming from the order not being specified and relying on default creation order which is almost-but-not-always the same.