### PR TITLE
Fix language detection taking mentions and URLs into account

### DIFF
--- a/app/javascript/mastodon/features/compose/containers/language_dropdown_container.js
+++ b/app/javascript/mastodon/features/compose/containers/language_dropdown_container.js
@@ -8,6 +8,7 @@ import { debounce } from 'lodash';
 import { changeComposeLanguage } from 'mastodon/actions/compose';
 
 import LanguageDropdown from '../components/language_dropdown';
+import { urlRegex } from '../util/url_regex';
 
 const getFrequentlyUsedLanguages = createSelector([
   state => state.getIn(['settings', 'frequentlyUsedLanguages'], ImmutableMap()),
@@ -71,7 +72,16 @@ const ISO_639_MAP = {
   vie: 'vi', // Vietnamese
 };
 
-const debouncedLande = debounce((text) => lande(text), 500, { trailing: true });
+const debouncedLande = debounce((text) => {
+  text = text
+    .replace(urlRegex, '')
+    .replace(/(^|[^/\w])@(([a-z0-9_]+)@[a-z0-9.-]+[a-z0-9]+)/ig, '');
+
+  if (text.length <= 20)
+    return undefined;
+
+  return lande(text);
+}, 500, { trailing: true });
 
 const detectedLanguage = createSelector([
   state => state.getIn(['compose', 'text']),


### PR DESCRIPTION
Fixes #33694

This should significantly improve detection accuracy.

There is still an issue with the way the function is called: it's debounced, but its result is used synchronously. I'm surprised lodash's debounce even allows you to return a value at all. The  correct way is likely to use the debounced function in an effect hook and have it change the state, but it will be more work.