### PR TITLE
Use `expect` params wrapper for more "auth" and "2FA" "controllers"

### DIFF
--- a/app/controllers/auth/sessions_controller.rb
+++ b/app/controllers/auth/sessions_controller.rb
@@ -73,7 +73,7 @@ class Auth::SessionsController < Devise::SessionsController
   end
 
   def user_params
-    params.require(:user).permit(:email, :password, :otp_attempt, credential: {})
+    params.expect(user: [:email, :password, :otp_attempt, credential: {}])
   end
 
   def after_sign_in_path_for(resource)

--- a/app/controllers/settings/applications_controller.rb
+++ b/app/controllers/settings/applications_controller.rb
@@ -60,16 +60,12 @@ class Settings::ApplicationsController < Settings::BaseController
   end
 
   def application_params
-    params.require(:doorkeeper_application).permit(
-      :name,
-      :redirect_uri,
-      :scopes,
-      :website
-    )
+    params
+      .expect(doorkeeper_application: [:name, :redirect_uri, :scopes, :website])
   end
 
   def prepare_scopes
-    scopes = params.fetch(:doorkeeper_application, {}).fetch(:scopes, nil)
+    scopes = application_params.fetch(:doorkeeper_application, {}).fetch(:scopes, nil)
     params[:doorkeeper_application][:scopes] = scopes.join(' ') if scopes.is_a? Array
   end
 end

--- a/app/controllers/settings/two_factor_authentication/confirmations_controller.rb
+++ b/app/controllers/settings/two_factor_authentication/confirmations_controller.rb
@@ -38,7 +38,7 @@ module Settings
       private
 
       def confirmation_params
-        params.require(:form_two_factor_confirmation).permit(:otp_attempt)
+        params.expect(form_two_factor_confirmation: [:otp_attempt])
       end
 
       def prepare_two_factor_form

--- a/app/controllers/settings/verifications_controller.rb
+++ b/app/controllers/settings/verifications_controller.rb
@@ -18,7 +18,7 @@ class Settings::VerificationsController < Settings::BaseController
   private
 
   def account_params
-    params.require(:account).permit(:attribution_domains).tap do |params|
+    params.expect(account: [:attribution_domains]).tap do |params|
       params[:attribution_domains] = params[:attribution_domains].split if params[:attribution_domains]
     end
   end

--- a/spec/requests/auth/sessions_spec.rb
+++ b/spec/requests/auth/sessions_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Auth Sessions' do
+  describe 'POST /auth/sign_in' do
+    # The rack-attack check has issues with the non-nested invalid param used here
+    before { Rack::Attack.enabled = false }
+    after { Rack::Attack.enabled = true }
+
+    it 'gracefully handles invalid nested params' do
+      post user_session_path(user: 'invalid')
+
+      expect(response)
+        .to have_http_status(400)
+    end
+  end
+end

--- a/spec/requests/settings/applications_spec.rb
+++ b/spec/requests/settings/applications_spec.rb
@@ -40,5 +40,23 @@ RSpec.describe 'Settings / Exports' do
       expect(response)
         .to redirect_to(settings_applications_path)
     end
+
+    it 'gracefully handles invalid nested params' do
+      post settings_applications_path(doorkeeper_application: 'invalid')
+
+      expect(response)
+        .to have_http_status(400)
+    end
+  end
+
+  describe 'PUT /settings/applications/:id' do
+    let(:application) { Fabricate :application, owner: user }
+
+    it 'gracefully handles invalid nested params' do
+      put settings_application_path(application.id, doorkeeper_application: 'invalid')
+
+      expect(response)
+        .to have_http_status(400)
+    end
   end
 end

--- a/spec/requests/settings/two_factor_authentication/confirmations_spec.rb
+++ b/spec/requests/settings/two_factor_authentication/confirmations_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Settings 2FA Confirmations' do
+  describe 'POST /settings/two_factor_authentication/confirmations' do
+    before do
+      sign_in Fabricate(:user, encrypted_password: '') # Empty encrypted password avoids challengable flow
+      post settings_otp_authentication_path # Sets `session[:new_otp_secret]` which is needed for next step
+    end
+
+    it 'gracefully handles invalid nested params' do
+      post settings_two_factor_authentication_confirmation_path(form_two_factor_confirmation: 'invalid')
+
+      expect(response)
+        .to have_http_status(400)
+    end
+  end
+end

--- a/spec/requests/settings/verifications_spec.rb
+++ b/spec/requests/settings/verifications_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Settings Verifications' do
+  describe 'PUT /settings/verification' do
+    before { sign_in Fabricate(:user) }
+
+    it 'gracefully handles invalid nested params' do
+      put settings_verification_path(account: 'invalid')
+
+      expect(response)
+        .to have_http_status(400)
+    end
+  end
+end


### PR DESCRIPTION
After this one and after https://github.com/mastodon/mastodon/pull/33686 merges - we're down to just a final few. Maybe one more changes PR and than one final PR to bump the gems (or let renovate rebase).

Once again here, mostly auto-correct, with some notes:

- A `before_action` method in settings/applications was accessing the params directly, instead of via the wrapping method; updated that
- Had to work around rack attack in auth/sessions spec, comments inline
- Had to work around some session setup stuff in 2fa/confirmations spec, comments inline as well