### PR TITLE
Fix `Style/HashSlice` cop violations

### DIFF
--- a/app/lib/activitypub/adapter.rb
+++ b/app/lib/activitypub/adapter.rb
@@ -17,7 +17,7 @@ class ActivityPub::Adapter < ActiveModelSerializers::Adapter::Base
 
     options         = serialization_options(options)
     serialized_hash = serializer.serializable_hash(options.merge(named_contexts: named_contexts, context_extensions: context_extensions))
-    serialized_hash = serialized_hash.select { |k, _| options[:fields].include?(k) } if options[:fields]
+    serialized_hash = serialized_hash.slice(*options[:fields]) if options[:fields]
     serialized_hash = self.class.transform_key_casing!(serialized_hash, instance_options)
 
     { '@context': serialized_context(named_contexts, context_extensions) }.merge(serialized_hash)


### PR DESCRIPTION
I noticed that https://github.com/mastodon/mastodon/pull/33644 which was originally just a `rubocop-rails` bump, is now also a `rubocop` bump, and has a violation of this cop, added in latest release  https://github.com/rubocop/rubocop/pull/13507 - this is the auto-correct from that.

We have a few request specs for controllers which pass in `fields`, and the output looks equivalent to me, with one small note, which is that the order (but not the json equality) of the fields has changed ... I think this doesn't matter, but wanted to note that.

Before:

```json
{"@context" => ["https://www.w3.org/ns/activitystreams", "https://w3id.org/security/v1", {"manuallyApprovesFollowers" => "as:manuallyApprovesFollowers", "toot" => "http://joinmastodon.org/ns#", "featured" => {"@id" => "toot:featured", "@type" => "@id"}, "featuredTags" => {"@id" => "toot:featuredTags", "@type" => "@id"}, "alsoKnownAs" => {"@id" => "as:alsoKnownAs", "@type" => "@id"}, "movedTo" => {"@id" => "as:movedTo", "@type" => "@id"}, "schema" => "http://schema.org#", "PropertyValue" => "schema:PropertyValue", "value" => "schema:value", "discoverable" => "toot:discoverable", "suspended" => "toot:suspended", "memorial" => "toot:memorial", "indexable" => "toot:indexable", "attributionDomains" => {"@id" => "toot:attributionDomains", "@type" => "@id"}}], "id" => "https://cb6e6126.ngrok.io/actor", "type" => "Application", "inbox" => "https://cb6e6126.ngrok.io/actor/inbox", "outbox" => "https://cb6e6126.ngrok.io/actor/outbox", "preferredUsername" => "mastodon.internal", "url" => "https://cb6e6126.ngrok.io/about/more?instance_actor=true", "manuallyApprovesFollowers" => true, "publicKey" => {"id" => "https://cb6e6126.ngrok.io/actor#main-key", "owner" => "https://cb6e6126.ngrok.io/actor", "publicKeyPem" => "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArhH7F5xXgpIdkJfJPVGC\nTSNibxoBcKyW8pVg2j0dKFxgn5jvekcW/jwKd0++SwGxWBn+rN6DHCl/CMCEkTAl\nNGC+6Q94xRLTPfpgvMsS7Fa4KajUQvyheG8iKSeuTj7sCAwsSj19gm+k6tNQL8Nc\nMk+7NIR2NRh0JlHICcRRQJXfCwt0zGewQ4U1n8J+S2SwO1fFOIRYq6cZBXsUZVfa\nN8s4QGT2pgs/nunwX93AY+G8bJTPvqQDMcF2qvJ80Rqtu63DpnB9out+dMAdlf9r\nzBoBydiGWMDEDoSrlQukLWzng/f/YlL0zRdLlIO90P5rTevI+1OlpbZV4xIQ07dc\neQIDAQAB\n-----END PUBLIC KEY-----\n"}, "endpoints" => {"sharedInbox" => "https://cb6e6126.ngrok.io/inbox"}}
```

After:

```json
{"@context" => ["https://www.w3.org/ns/activitystreams", "https://w3id.org/security/v1", {"manuallyApprovesFollowers" => "as:manuallyApprovesFollowers", "toot" => "http://joinmastodon.org/ns#", "featured" => {"@id" => "toot:featured", "@type" => "@id"}, "featuredTags" => {"@id" => "toot:featuredTags", "@type" => "@id"}, "alsoKnownAs" => {"@id" => "as:alsoKnownAs", "@type" => "@id"}, "movedTo" => {"@id" => "as:movedTo", "@type" => "@id"}, "schema" => "http://schema.org#", "PropertyValue" => "schema:PropertyValue", "value" => "schema:value", "discoverable" => "toot:discoverable", "suspended" => "toot:suspended", "memorial" => "toot:memorial", "indexable" => "toot:indexable", "attributionDomains" => {"@id" => "toot:attributionDomains", "@type" => "@id"}}], "id" => "https://cb6e6126.ngrok.io/actor", "type" => "Application", "preferredUsername" => "mastodon.internal", "inbox" => "https://cb6e6126.ngrok.io/actor/inbox", "outbox" => "https://cb6e6126.ngrok.io/actor/outbox", "publicKey" => {"id" => "https://cb6e6126.ngrok.io/actor#main-key", "owner" => "https://cb6e6126.ngrok.io/actor", "publicKeyPem" => "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArhH7F5xXgpIdkJfJPVGC\nTSNibxoBcKyW8pVg2j0dKFxgn5jvekcW/jwKd0++SwGxWBn+rN6DHCl/CMCEkTAl\nNGC+6Q94xRLTPfpgvMsS7Fa4KajUQvyheG8iKSeuTj7sCAwsSj19gm+k6tNQL8Nc\nMk+7NIR2NRh0JlHICcRRQJXfCwt0zGewQ4U1n8J+S2SwO1fFOIRYq6cZBXsUZVfa\nN8s4QGT2pgs/nunwX93AY+G8bJTPvqQDMcF2qvJ80Rqtu63DpnB9out+dMAdlf9r\nzBoBydiGWMDEDoSrlQukLWzng/f/YlL0zRdLlIO90P5rTevI+1OlpbZV4xIQ07dc\neQIDAQAB\n-----END PUBLIC KEY-----\n"}, "endpoints" => {"sharedInbox" => "https://cb6e6126.ngrok.io/inbox"}, "url" => "https://cb6e6126.ngrok.io/about/more?instance_actor=true", "manuallyApprovesFollowers" => true}
```

Linked PR is still contingent on all the various "expect" ones working out.