### PR TITLE
Fix wrong styles on rules and buttons in the sign-up form

### DIFF
--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -564,11 +564,14 @@ code {
   }
 
   .stacked-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
     margin-top: 30px;
     margin-bottom: 15px;
   }
 
-  button:not(.button, .link-button, .help-button) {
+  .btn {
     display: block;
     width: 100%;
     border: 0;
@@ -585,8 +588,6 @@ code {
     cursor: pointer;
     font-weight: 500;
     outline: 0;
-    margin-bottom: 10px;
-    margin-inline-end: 10px;
 
     &:last-child {
       margin-inline-end: 0;


### PR DESCRIPTION
Turns out `simple_form` puts a `.btn` class on its generated buttons, so we only need to style those.