### PR TITLE
Remove system tooltip for alt text in web UI

### DIFF
--- a/app/javascript/mastodon/components/media_gallery.jsx
+++ b/app/javascript/mastodon/components/media_gallery.jsx
@@ -145,7 +145,6 @@ class Item extends PureComponent {
             srcSet={srcSet}
             sizes={sizes}
             alt={description}
-            title={description}
             lang={lang}
             style={{ objectPosition: `${x}% ${y}%` }}
             onLoad={this.handleImageLoad}
@@ -167,7 +166,6 @@ class Item extends PureComponent {
           <video
             className='media-gallery__item-gifv-thumbnail'
             aria-label={description}
-            title={description}
             lang={lang}
             role='application'
             src={attachment.get('url')}

--- a/app/javascript/mastodon/features/account_gallery/components/media_item.tsx
+++ b/app/javascript/mastodon/features/account_gallery/components/media_item.tsx
@@ -93,7 +93,6 @@ export const MediaItem: React.FC<{
         <img
           src={previewUrl || avatarUrl}
           alt={description}
-          title={description}
           lang={lang}
           onLoad={handleImageLoad}
         />
@@ -113,7 +112,6 @@ export const MediaItem: React.FC<{
       <img
         src={previewUrl}
         alt={description}
-        title={description}
         lang={lang}
         style={{ objectPosition: `${x}% ${y}%` }}
         onLoad={handleImageLoad}
@@ -131,7 +129,6 @@ export const MediaItem: React.FC<{
         <video
           className='media-gallery__item-gifv-thumbnail'
           aria-label={description}
-          title={description}
           lang={lang}
           src={fullUrl}
           onMouseEnter={handleMouseEnter}


### PR DESCRIPTION
Now there's a clickable ALT badge that also works on mobile.

Fixes #30016
