### PR TITLE
Use `expect` in `Admin::ExportControllerConcern` import params

### DIFF
--- a/app/controllers/concerns/admin/export_controller_concern.rb
+++ b/app/controllers/concerns/admin/export_controller_concern.rb
@@ -24,6 +24,6 @@ module Admin::ExportControllerConcern
   end
 
   def import_params
-    params.require(:admin_import).permit(:data)
+    params.expect(admin_import: [:data])
   end
 end

--- a/spec/requests/admin/export_domain_allows_spec.rb
+++ b/spec/requests/admin/export_domain_allows_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin Export Domain Allows' do
+  describe 'POST /admin/export_domain_allows/import' do
+    before { sign_in Fabricate(:admin_user) }
+
+    it 'gracefully handles invalid nested params' do
+      post import_admin_export_domain_allows_path(admin_import: 'invalid')
+
+      expect(response)
+        .to redirect_to(admin_instances_path)
+    end
+  end
+end

--- a/spec/requests/admin/export_domain_blocks_spec.rb
+++ b/spec/requests/admin/export_domain_blocks_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin Export Domain Blocks' do
+  describe 'POST /admin/export_domain_blocks/import' do
+    before { sign_in Fabricate(:admin_user) }
+
+    it 'gracefully handles invalid nested params' do
+      post import_admin_export_domain_blocks_path(admin_import: 'invalid')
+
+      expect(response.body)
+        .to include(I18n.t('admin.export_domain_blocks.no_file'))
+    end
+  end
+end


### PR DESCRIPTION
This concern is used in both of these controllers (and only there) for basically same purpose in each. They both have pre-existing (but different from each other) handling of parameter errors.

Coverage captures the previous behavior, app change is auto-correct.