### PR TITLE
Fix error in `TwoFactorPamAuthenticatable` when handling invalid params

### DIFF
--- a/lib/devise/strategies/two_factor_pam_authenticatable.rb
+++ b/lib/devise/strategies/two_factor_pam_authenticatable.rb
@@ -22,7 +22,7 @@ module Devise
       protected
 
       def valid_params?
-        params[scope] && params[scope][:password].present?
+        params[scope].respond_to?(:[]) && params[scope][:password].present?
       end
     end
   end


### PR DESCRIPTION
This is a very minor edge case, but it shows up in tests in some forks now that we are more extensively testing invalid parameters.