### PR TITLE
Use `expect` in remaining controller locations

### DIFF
--- a/app/controllers/concerns/challengable_concern.rb
+++ b/app/controllers/concerns/challengable_concern.rb
@@ -58,6 +58,6 @@ module ChallengableConcern
   end
 
   def challenge_params
-    params.require(:form_challenge).permit(:current_password, :return_to)
+    params.expect(form_challenge: [:current_password, :return_to])
   end
 end

--- a/app/controllers/filters/statuses_controller.rb
+++ b/app/controllers/filters/statuses_controller.rb
@@ -34,7 +34,7 @@ class Filters::StatusesController < ApplicationController
   end
 
   def status_filter_batch_action_params
-    params.require(:form_status_filter_batch_action).permit(status_filter_ids: [])
+    params.expect(form_status_filter_batch_action: [status_filter_ids: []])
   end
 
   def action_from_button

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -36,7 +36,7 @@ class RelationshipsController < ApplicationController
   end
 
   def form_account_batch_params
-    params.require(:form_account_batch).permit(:action, account_ids: [])
+    params.expect(form_account_batch: [:action, account_ids: []])
   end
 
   def following_relationship?

--- a/app/controllers/settings/preferences/base_controller.rb
+++ b/app/controllers/settings/preferences/base_controller.rb
@@ -19,6 +19,6 @@ class Settings::Preferences::BaseController < Settings::BaseController
   end
 
   def user_params
-    params.require(:user).permit(:locale, :time_zone, chosen_languages: [], settings_attributes: UserSettings.keys)
+    params.expect(user: [:locale, :time_zone, chosen_languages: [], settings_attributes: UserSettings.keys])
   end
 end

--- a/spec/requests/auth/challenges_spec.rb
+++ b/spec/requests/auth/challenges_spec.rb
@@ -33,5 +33,14 @@ RSpec.describe 'Auth Challenges' do
           .to be_nil
       end
     end
+
+    context 'with invalid params' do
+      it 'gracefully handles invalid nested params' do
+        post auth_challenge_path(form_challenge: 'invalid')
+
+        expect(response)
+          .to have_http_status(400)
+      end
+    end
   end
 end

--- a/spec/requests/filters/statuses_spec.rb
+++ b/spec/requests/filters/statuses_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Filters Statuses' do
+  describe 'POST /filters/:filter_id/statuses/batch' do
+    before { sign_in(user) }
+
+    let(:filter) { Fabricate :custom_filter, account: user.account }
+    let(:user) { Fabricate :user }
+
+    it 'gracefully handles invalid nested params' do
+      post batch_filter_statuses_path(filter.id, form_status_filter_batch_action: 'invalid')
+
+      expect(response)
+        .to redirect_to(edit_filter_path(filter))
+    end
+  end
+end

--- a/spec/requests/relationships_spec.rb
+++ b/spec/requests/relationships_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Relationships' do
+  describe 'PUT /relationships' do
+    before { sign_in Fabricate(:user) }
+
+    it 'gracefully handles invalid nested params' do
+      put relationships_path(form_account_batch: 'invalid')
+
+      expect(response)
+        .to redirect_to(relationships_path)
+    end
+  end
+end

--- a/spec/requests/settings/preferences/appearance_spec.rb
+++ b/spec/requests/settings/preferences/appearance_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Settings Preferences Appearance' do
+  describe 'PUT /settings/preferences/appearance' do
+    before { sign_in Fabricate(:user) }
+
+    it 'gracefully handles invalid nested params' do
+      put settings_preferences_appearance_path(user: 'invalid')
+
+      expect(response)
+        .to have_http_status(400)
+    end
+  end
+end

--- a/spec/system/settings/preferences/appearance_spec.rb
+++ b/spec/system/settings/preferences/appearance_spec.rb
@@ -17,10 +17,13 @@ RSpec.describe 'Settings preferences appearance page' do
     check confirm_reblog_field
     uncheck confirm_delete_field
 
+    check advanced_layout_field
+
     expect { save_changes }
       .to change { user.reload.settings.theme }.to('contrast')
       .and change { user.reload.settings['web.reblog_modal'] }.to(true)
-      .and(change { user.reload.settings['web.delete_modal'] }.to(false))
+      .and change { user.reload.settings['web.delete_modal'] }.to(false)
+      .and(change { user.reload.settings['web.advanced_layout'] }.to(true))
     expect(page)
       .to have_title(I18n.t('settings.appearance'))
   end
@@ -39,5 +42,9 @@ RSpec.describe 'Settings preferences appearance page' do
 
   def theme_selection_field
     I18n.t('simple_form.labels.defaults.setting_theme')
+  end
+
+  def advanced_layout_field
+    I18n.t('simple_form.labels.defaults.setting_advanced_layout')
   end
 end


### PR DESCRIPTION
This converts the last few of these which are flagged by the cop. There are still some unflagged ones, and some instances of `permit` without `require`, or `require` without `permit`. There are also a few spots that hit params directly but maybe should be going through a wrapped method. Could review that as followup.

These are all auto-correct.

I think the only notable thing here is the `settings_attributes` one, which is using `simple_fields_for` in the view like the previously broken/fixed "filters" and "fields" changes. However, in this case its not a "nested attributes to create multiple records" like the filter/keywords one, or the (hard to describe, but also effectively multiple records) like fields ... its more of just a namespace. Updated that one's spec to have some update for one of the values within the nested namespace.