### PR TITLE
Fix parameter validation in our custom devise strategies

### DIFF
--- a/lib/devise/strategies/two_factor_ldap_authenticatable.rb
+++ b/lib/devise/strategies/two_factor_ldap_authenticatable.rb
@@ -23,7 +23,7 @@ module Devise
       protected
 
       def valid_params?
-        params[scope] && params[scope][:password].present?
+        params[scope].is_a?(Hash) && params[scope][:password].present?
       end
     end
   end

--- a/lib/devise/strategies/two_factor_pam_authenticatable.rb
+++ b/lib/devise/strategies/two_factor_pam_authenticatable.rb
@@ -22,7 +22,7 @@ module Devise
       protected
 
       def valid_params?
-        params[scope].respond_to?(:[]) && params[scope][:password].present?
+        params[scope].is_a?(Hash) && params[scope][:password].present?
       end
     end
   end


### PR DESCRIPTION
Follow-up to #33746

The issue was slightly different than what I thought. Turns out the spec passes a string there, which *does* respond to `[]` but expecting an integer.

I was reluctant to test for a `Hash` because I thought the underlying object could be an `ActionController::Parameters` object, but we are not testing the root parameters, but an extracted parameter. And it turns out testing for `is_a?(Hash)` is exactly what the built-in Devise strategies do.