### PR TITLE
Fix incorrect signature after HTTP redirect

### DIFF
--- a/app/controllers/concerns/signature_verification.rb
+++ b/app/controllers/concerns/signature_verification.rb
@@ -117,7 +117,7 @@ module SignatureVerification
 
   def verify_signature_strength!
     raise SignatureVerificationError, 'Mastodon requires the Date header or (created) pseudo-header to be signed' unless signed_headers.include?('date') || signed_headers.include?('(created)')
-    raise SignatureVerificationError, 'Mastodon requires the Digest header or (request-target) pseudo-header to be signed' unless signed_headers.include?(Request::REQUEST_TARGET) || signed_headers.include?('digest')
+    raise SignatureVerificationError, 'Mastodon requires the Digest header or (request-target) pseudo-header to be signed' unless signed_headers.include?(HttpSignatureDraft::REQUEST_TARGET) || signed_headers.include?('digest')
     raise SignatureVerificationError, 'Mastodon requires the Host header to be signed when doing a GET request' if request.get? && !signed_headers.include?('host')
     raise SignatureVerificationError, 'Mastodon requires the Digest header to be signed when doing a POST request' if request.post? && !signed_headers.include?('digest')
   end
@@ -155,14 +155,14 @@ module SignatureVerification
   def build_signed_string(include_query_string: true)
     signed_headers.map do |signed_header|
       case signed_header
-      when Request::REQUEST_TARGET
+      when HttpSignatureDraft::REQUEST_TARGET
         if include_query_string
-          "#{Request::REQUEST_TARGET}: #{request.method.downcase} #{request.original_fullpath}"
+          "#{HttpSignatureDraft::REQUEST_TARGET}: #{request.method.downcase} #{request.original_fullpath}"
         else
           # Current versions of Mastodon incorrectly omit the query string from the (request-target) pseudo-header.
           # Therefore, temporarily support such incorrect signatures for compatibility.
           # TODO: remove eventually some time after release of the fixed version
-          "#{Request::REQUEST_TARGET}: #{request.method.downcase} #{request.path}"
+          "#{HttpSignatureDraft::REQUEST_TARGET}: #{request.method.downcase} #{request.path}"
         end
       when '(created)'
         raise SignatureVerificationError, 'Invalid pseudo-header (created) for rsa-sha256' unless signature_algorithm == 'hs2019'

--- a/app/lib/http_signature_draft.rb
+++ b/app/lib/http_signature_draft.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# This implements an older draft of HTTP Signatures:
+# https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures
+
+class HttpSignatureDraft
+  REQUEST_TARGET = '(request-target)'
+
+  def initialize(keypair, key_id, full_path: true)
+    @keypair = keypair
+    @key_id = key_id
+    @full_path = full_path
+  end
+
+  def request_target(verb, url)
+    if url.query.nil? || !@full_path
+      "#{verb} #{url.path}"
+    else
+      "#{verb} #{url.path}?#{url.query}"
+    end
+  end
+
+  def sign(signed_headers, verb, url)
+    signed_headers = signed_headers.merge(REQUEST_TARGET => request_target(verb, url))
+    signed_string = signed_headers.map { |key, value| "#{key.downcase}: #{value}" }.join("\n")
+    algorithm = 'rsa-sha256'
+    signature = Base64.strict_encode64(@keypair.sign(OpenSSL::Digest.new('SHA256'), signed_string))
+
+    "keyId=\"#{@key_id}\",algorithm=\"#{algorithm}\",headers=\"#{signed_headers.keys.join(' ').downcase}\",signature=\"#{signature}\""
+  end
+end


### PR DESCRIPTION
Fixes #26529

Currently, we are signing HTTP requests ourselves then letting HTTP.rb do its work, including following redirects.
This means that redirects carry an incorrect signature.

This PR changes it to use HTTP.rb's `on_redirect` callback to recompute the signature from the redirected request. In order to do so, it also refactors signing code a bit.