### PR TITLE
Return error when reporting your own post via POST /api/v1/reports

### DIFF
--- a/app/controllers/api/v1/reports_controller.rb
+++ b/app/controllers/api/v1/reports_controller.rb
@@ -7,6 +7,8 @@ class Api::V1::ReportsController < Api::BaseController
   override_rate_limit_headers :create, family: :reports
 
   def create
+    raise Mastodon::ValidationError, I18n.t('reports.errors.cannot_report_yourself') if current_account == reported_account
+
     @report = ReportService.new.call(
       current_account,
       reported_account,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1700,6 +1700,7 @@ en:
     missing_resource: Could not find the required redirect URL for your account
   reports:
     errors:
+      cannot_report_yourself: You cannot report your own posts.
       invalid_rules: does not reference valid rules
   rss:
     content_warning: 'Content warning:'

--- a/spec/requests/api/v1/reports_spec.rb
+++ b/spec/requests/api/v1/reports_spec.rb
@@ -72,6 +72,21 @@ RSpec.describe 'Reports' do
       end
     end
 
+    context 'when reporting yourself' do
+      let(:status)         { Fabricate(:status, account: user.account) }
+
+      it 'returns 422' do
+        subject
+
+        expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
+        expect(response.parsed_body).to match(a_hash_including(
+          error: "You cannot report your own posts."
+        ))
+      end
+    end
+
     context 'when a category is chosen' do
       let(:category) { 'spam' }
 


### PR DESCRIPTION
Related to https://github.com/mastodon/mastodon/issues/32630

To my understanding this should solve https://github.com/mastodon/mastodon/issues/32630 so that `POST /api/v1/reports` returns status 422 when reporting your own posts.



