### PR TITLE
Change language detection debouncing behavior to refresh at least once every 1.5 seconds

### DIFF
--- a/app/javascript/mastodon/features/compose/util/language_detection.js
+++ b/app/javascript/mastodon/features/compose/util/language_detection.js
@@ -73,4 +73,4 @@ const guessLanguage = (text) => {
 
 export const debouncedGuess = debounce((text, setGuess) => {
   setGuess(guessLanguage(text));
-}, 500, { leading: true, trailing: true });
+}, 500, { maxWait: 1500, leading: true, trailing: true });


### PR DESCRIPTION
Indeed, in the current behavior, if the user takes less than half a second between each keystroke, the language detection will only kick in half a second after they are done typing.

For quick typers who use ctrl+enter to send posts, this means they may not be notified of incorrect language.

This PR adds `maxWait: 1500` so that the language detection kicks in regularly even if the user types fast.