### PR TITLE
Fix streaming server not filtering unknown-language posts from public timelines

### DIFF
--- a/streaming/index.js
+++ b/streaming/index.js
@@ -652,7 +652,7 @@ const startServer = async () => {
       // filtering of statuses:
 
       // Filter based on language:
-      if (Array.isArray(req.chosenLanguages) && payload.language !== null && req.chosenLanguages.indexOf(payload.language) === -1) {
+      if (Array.isArray(req.chosenLanguages) && req.chosenLanguages.indexOf(payload.language) === -1) {
         log.debug(`Message ${payload.id} filtered by language (${payload.language})`);
         return;
       }


### PR DESCRIPTION
Fixes #33742

I am not 100% sure whether we want the streaming server to adopt the REST API behavior (this PR), or the REST API behavior to change to adopt the streaming server's behavior, but I have a preference for the former, hence the PR.