### PR TITLE
Fix `/settings/applications` rejecting scopes parameter

### DIFF
--- a/app/controllers/settings/applications_controller.rb
+++ b/app/controllers/settings/applications_controller.rb
@@ -2,7 +2,6 @@
 
 class Settings::ApplicationsController < Settings::BaseController
   before_action :set_application, only: [:show, :update, :destroy, :regenerate]
-  before_action :prepare_scopes, only: [:create, :update]
 
   def index
     @applications = current_user.applications.order(id: :desc).page(params[:page])
@@ -61,11 +60,9 @@ class Settings::ApplicationsController < Settings::BaseController
 
   def application_params
     params
-      .expect(doorkeeper_application: [:name, :redirect_uri, :scopes, :website])
-  end
-
-  def prepare_scopes
-    scopes = application_params.fetch(:doorkeeper_application, {}).fetch(:scopes, nil)
-    params[:doorkeeper_application][:scopes] = scopes.join(' ') if scopes.is_a? Array
+      .expect(doorkeeper_application: [:name, :redirect_uri, :website, scopes: []])
+      .tap do |params|
+      params[:scopes] = params[:scopes]&.join(' ')
+    end
   end
 end

--- a/spec/system/settings/applications_spec.rb
+++ b/spec/system/settings/applications_spec.rb
@@ -38,6 +38,9 @@ RSpec.describe 'Settings applications page' do
       expect(page)
         .to have_content(I18n.t('doorkeeper.applications.index.title'))
         .and have_content('My new app')
+        .and have_content('read')
+        .and have_content('write')
+        .and have_content('follow')
     end
 
     it 'does not save with invalid form values' do
@@ -73,10 +76,12 @@ RSpec.describe 'Settings applications page' do
 
       fill_in form_app_name_label,
               with: 'My new app name with a new value'
+      check 'push', id: :doorkeeper_application_scopes_push
       submit_form
 
       expect(page)
         .to have_content('My new app name with a new value')
+        .and have_checked_field('push', id: :doorkeeper_application_scopes_push)
     end
 
     it 'does not update with wrong values' do


### PR DESCRIPTION
Fixes #33801

Fixes a regression from #33717

The logic of this controller is pretty weird, it receive an array of `scopes` in parameters but turns it into a string. The change in the previous PR ignored that.