### PR TITLE
Update CSP to include both s3_alias_host and s3_hostname_host paths

### DIFF
--- a/app/lib/content_security_policy.rb
+++ b/app/lib/content_security_policy.rb
@@ -36,7 +36,7 @@ class ContentSecurityPolicy
   end
 
   def cdn_host_value
-    s3_alias_host || s3_cloudfront_host || azure_alias_host || s3_hostname_host || swift_object_url
+    [s3_alias_host, s3_cloudfront_host, azure_alias_host, s3_hostname_host, swift_object_url].compact
   end
 
   def paperclip_root_url


### PR DESCRIPTION
Enables support for media to be redirected (302) instead of just cached and served from the alias host.

```
curl -I https://mediacdn.xxxxx.social/media_attachments/files/113/927/122/965/448/900/original/6401f7b307567ccd.jpeg

HTTP/2 302
location: https://s3.ap-southeast-2.wasabisys.com/xxxxx/media_attachments/files/113/927/122/965/448/900/original/6401f7b307567ccd.jpeg
<deleted other headers>
```

This requires the CSP from aus.social to included the S3 Alias and the redirected host.
`data: blob: https://mediacdn.xxxxx.social https://s3.ap-southeast-2.wasabisys.com etc etc`