### PR TITLE
Switch coverage generation default to false, allow opt in with `COVERAGE` env var

### DIFF
--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -64,7 +64,6 @@ jobs:
       DB_HOST: localhost
       DB_USER: postgres
       DB_PASS: postgres
-      DISABLE_SIMPLECOV: true
       RAILS_ENV: test
       BUNDLE_CLEAN: true
       BUNDLE_FROZEN: true

--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -107,7 +107,7 @@ jobs:
       DB_HOST: localhost
       DB_USER: postgres
       DB_PASS: postgres
-      DISABLE_SIMPLECOV: ${{ matrix.ruby-version != '.ruby-version' }}
+      COVERAGE: ${{ matrix.ruby-version == '.ruby-version' }}
       RAILS_ENV: test
       ALLOW_NOPAM: true
       PAM_ENABLED: true
@@ -208,7 +208,7 @@ jobs:
       DB_HOST: localhost
       DB_USER: postgres
       DB_PASS: postgres
-      DISABLE_SIMPLECOV: ${{ matrix.ruby-version != '.ruby-version' }}
+      COVERAGE: ${{ matrix.ruby-version == '.ruby-version' }}
       RAILS_ENV: test
       ALLOW_NOPAM: true
       PAM_ENABLED: true
@@ -295,7 +295,6 @@ jobs:
       DB_HOST: localhost
       DB_USER: postgres
       DB_PASS: postgres
-      DISABLE_SIMPLECOV: true
       RAILS_ENV: test
       BUNDLE_WITH: test
       LOCAL_DOMAIN: localhost:3000
@@ -411,7 +410,6 @@ jobs:
       DB_HOST: localhost
       DB_USER: postgres
       DB_PASS: postgres
-      DISABLE_SIMPLECOV: true
       RAILS_ENV: test
       BUNDLE_WITH: test
       ES_ENABLED: true

--- a/Gemfile
+++ b/Gemfile
@@ -156,7 +156,7 @@ group :test do
 
   gem 'shoulda-matchers'
 
-  # Coverage formatter for RSpec test if DISABLE_SIMPLECOV is false
+  # Coverage formatter for RSpec
   gem 'simplecov', '~> 0.22', require: false
   gem 'simplecov-lcov', '~> 0.8', require: false
 

--- a/spec/flatware_helper.rb
+++ b/spec/flatware_helper.rb
@@ -3,7 +3,7 @@
 if defined?(Flatware)
   Flatware.configure do |config|
     config.after_fork do |test_env_number|
-      unless ENV.fetch('DISABLE_SIMPLECOV', nil) == 'true'
+      if ENV.fetch('COVERAGE', false)
         require 'simplecov'
         SimpleCov.at_fork.call(test_env_number) # Combines parallel coverage results
       end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,7 +2,7 @@
 
 ENV['RAILS_ENV'] ||= 'test'
 
-unless ENV['DISABLE_SIMPLECOV'] == 'true'
+if ENV.fetch('COVERAGE', false)
   require 'simplecov'
 
   SimpleCov.start 'rails' do


### PR DESCRIPTION
Extracted from https://github.com/mastodon/mastodon/pull/33792 (which should prob be in draft?)

I did some informal local benchmark, and the "files took X to load" times from rspec are reduced (across several runs) by an amount that is significant re: loading time only, but sort of a rounding error on overall suite run.

Maybe more relevant, even if times were exact same, it probably does make sense to only generate these when opted in to doing so.