### PR TITLE
Change preview cards to be shown when Content Warnings are expanded

### DIFF
--- a/app/javascript/mastodon/components/status.jsx
+++ b/app/javascript/mastodon/components/status.jsx
@@ -527,7 +527,7 @@ class Status extends ImmutablePureComponent {
           </Bundle>
         );
       }
-    } else if (status.get('spoiler_text').length === 0 && status.get('card')) {
+    } else if (status.get('card')) {
       media = (
         <Card
           onOpenMedia={this.handleOpenMedia}


### PR DESCRIPTION
Preview cards are currently fetched even in the presence of Content Warnings, but are not displayed when a post has Content Warnings.

The reason was that previously, Content Warnings only hid the message's textual contents, and displaying preview cards outside of CWs would defeat their purpose.

However, since the redesign in 4.3.0, media (including would-be preview cards) are hidden below Content Warnings, meaning there is no reason to skip displaying them anymore.