### PR TITLE
Use `require: false` on CLI/console tool gems in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -174,7 +174,7 @@ group :development do
   gem 'rubocop-rspec_rails', require: false
 
   # Annotates modules with schema
-  gem 'annotaterb', '~> 4.13'
+  gem 'annotaterb', '~> 4.13', require: false
 
   # Enhanced error message pages for development
   gem 'better_errors', '~> 2.9'
@@ -197,7 +197,7 @@ end
 
 group :development, :test do
   # Interactive Debugging tools
-  gem 'debug', '~> 1.8'
+  gem 'debug', '~> 1.8', require: false
 
   # Generate fake data values
   gem 'faker', '~> 3.2'
@@ -209,7 +209,7 @@ group :development, :test do
   gem 'memory_profiler', require: false
   gem 'ruby-prof', require: false
   gem 'stackprof', require: false
-  gem 'test-prof'
+  gem 'test-prof', require: false
 
   # RSpec runner for rails
   gem 'rspec-rails', '~> 7.0'


### PR DESCRIPTION
Another extraction from https://github.com/mastodon/mastodon/pull/33792

Similar to https://github.com/mastodon/mastodon/pull/33824 - leads to a small but consistent improvement in file loading time on rspec runs.