### PR TITLE
Remove duplicate cache header setting before action

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -7,16 +7,11 @@ module Admin
 
     layout 'admin'
 
-    before_action :set_cache_headers
     before_action :set_referrer_policy_header
 
     after_action :verify_authorized
 
     private
-
-    def set_cache_headers
-      response.cache_control.replace(private: true, no_store: true)
-    end
 
     def set_referrer_policy_header
       response.headers['Referrer-Policy'] = 'same-origin'

--- a/app/controllers/auth/registrations_controller.rb
+++ b/app/controllers/auth/registrations_controller.rb
@@ -12,7 +12,6 @@ class Auth::RegistrationsController < Devise::RegistrationsController
   before_action :set_sessions, only: [:edit, :update]
   before_action :set_strikes, only: [:edit, :update]
   before_action :require_not_suspended!, only: [:update]
-  before_action :set_cache_headers, only: [:edit, :update]
   before_action :set_rules, only: :new
   before_action :require_rules_acceptance!, only: :new
   before_action :set_registration_form_time, only: :new
@@ -137,10 +136,6 @@ class Auth::RegistrationsController < Devise::RegistrationsController
     @invite_code  = invite_code
 
     set_locale { render :rules }
-  end
-
-  def set_cache_headers
-    response.cache_control.replace(private: true, no_store: true)
   end
 
   def is_flashing_format? # rubocop:disable Naming/PredicateName

--- a/app/controllers/disputes/base_controller.rb
+++ b/app/controllers/disputes/base_controller.rb
@@ -8,11 +8,4 @@ class Disputes::BaseController < ApplicationController
   skip_before_action :require_functional!
 
   before_action :authenticate_user!
-  before_action :set_cache_headers
-
-  private
-
-  def set_cache_headers
-    response.cache_control.replace(private: true, no_store: true)
-  end
 end

--- a/app/controllers/filters/statuses_controller.rb
+++ b/app/controllers/filters/statuses_controller.rb
@@ -6,7 +6,6 @@ class Filters::StatusesController < ApplicationController
   before_action :authenticate_user!
   before_action :set_filter
   before_action :set_status_filters
-  before_action :set_cache_headers
 
   PER_PAGE = 20
 
@@ -39,9 +38,5 @@ class Filters::StatusesController < ApplicationController
 
   def action_from_button
     'remove' if params[:remove]
-  end
-
-  def set_cache_headers
-    response.cache_control.replace(private: true, no_store: true)
   end
 end

--- a/app/controllers/filters_controller.rb
+++ b/app/controllers/filters_controller.rb
@@ -5,7 +5,6 @@ class FiltersController < ApplicationController
 
   before_action :authenticate_user!
   before_action :set_filter, only: [:edit, :update, :destroy]
-  before_action :set_cache_headers
 
   def index
     @filters = current_account.custom_filters.includes(:keywords, :statuses).order(:phrase)
@@ -49,9 +48,5 @@ class FiltersController < ApplicationController
 
   def resource_params
     params.expect(custom_filter: [:title, :expires_in, :filter_action, context: [], keywords_attributes: [[:id, :keyword, :whole_word, :_destroy]]])
-  end
-
-  def set_cache_headers
-    response.cache_control.replace(private: true, no_store: true)
   end
 end

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -6,7 +6,6 @@ class InvitesController < ApplicationController
   layout 'admin'
 
   before_action :authenticate_user!
-  before_action :set_cache_headers
 
   def index
     authorize :invite, :create?
@@ -44,9 +43,5 @@ class InvitesController < ApplicationController
 
   def resource_params
     params.expect(invite: [:max_uses, :expires_in, :autofollow, :comment])
-  end
-
-  def set_cache_headers
-    response.cache_control.replace(private: true, no_store: true)
   end
 end

--- a/app/controllers/oauth/authorizations_controller.rb
+++ b/app/controllers/oauth/authorizations_controller.rb
@@ -5,7 +5,6 @@ class Oauth::AuthorizationsController < Doorkeeper::AuthorizationsController
 
   before_action :store_current_location
   before_action :authenticate_resource_owner!
-  before_action :set_cache_headers
 
   content_security_policy do |p|
     p.form_action(false)
@@ -31,9 +30,5 @@ class Oauth::AuthorizationsController < Doorkeeper::AuthorizationsController
 
   def truthy_param?(key)
     ActiveModel::Type::Boolean.new.cast(params[key])
-  end
-
-  def set_cache_headers
-    response.cache_control.replace(private: true, no_store: true)
   end
 end

--- a/app/controllers/oauth/authorized_applications_controller.rb
+++ b/app/controllers/oauth/authorized_applications_controller.rb
@@ -6,7 +6,6 @@ class Oauth::AuthorizedApplicationsController < Doorkeeper::AuthorizedApplicatio
   before_action :store_current_location
   before_action :authenticate_resource_owner!
   before_action :require_not_suspended!, only: :destroy
-  before_action :set_cache_headers
 
   before_action :set_last_used_at_by_app, only: :index, unless: -> { request.format == :json }
 
@@ -28,10 +27,6 @@ class Oauth::AuthorizedApplicationsController < Doorkeeper::AuthorizedApplicatio
 
   def require_not_suspended!
     forbidden if current_account.unavailable?
-  end
-
-  def set_cache_headers
-    response.cache_control.replace(private: true, no_store: true)
   end
 
   def set_last_used_at_by_app

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -6,7 +6,6 @@ class RelationshipsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_accounts, only: :show
   before_action :set_relationships, only: :show
-  before_action :set_cache_headers
 
   helper_method :following_relationship?, :followed_by_relationship?, :mutual_relationship?
 
@@ -65,9 +64,5 @@ class RelationshipsController < ApplicationController
     elsif params[:block_domains] || params[:remove_domains_from_followers]
       'remove_domains_from_followers'
     end
-  end
-
-  def set_cache_headers
-    response.cache_control.replace(private: true, no_store: true)
   end
 end

--- a/app/controllers/settings/base_controller.rb
+++ b/app/controllers/settings/base_controller.rb
@@ -4,13 +4,8 @@ class Settings::BaseController < ApplicationController
   layout 'admin'
 
   before_action :authenticate_user!
-  before_action :set_cache_headers
 
   private
-
-  def set_cache_headers
-    response.cache_control.replace(private: true, no_store: true)
-  end
 
   def require_not_suspended!
     forbidden if current_account.unavailable?

--- a/app/controllers/severed_relationships_controller.rb
+++ b/app/controllers/severed_relationships_controller.rb
@@ -4,7 +4,6 @@ class SeveredRelationshipsController < ApplicationController
   layout 'admin'
 
   before_action :authenticate_user!
-  before_action :set_cache_headers
 
   before_action :set_event, only: [:following, :followers]
 
@@ -48,9 +47,5 @@ class SeveredRelationshipsController < ApplicationController
 
   def acct(account)
     account.local? ? account.local_username_and_domain : account.acct
-  end
-
-  def set_cache_headers
-    response.cache_control.replace(private: true, no_store: true)
   end
 end

--- a/app/controllers/statuses_cleanup_controller.rb
+++ b/app/controllers/statuses_cleanup_controller.rb
@@ -5,7 +5,6 @@ class StatusesCleanupController < ApplicationController
 
   before_action :authenticate_user!
   before_action :set_policy
-  before_action :set_cache_headers
 
   def show; end
 
@@ -29,9 +28,5 @@ class StatusesCleanupController < ApplicationController
 
   def resource_params
     params.expect(account_statuses_cleanup_policy: [:enabled, :min_status_age, :keep_direct, :keep_pinned, :keep_polls, :keep_media, :keep_self_fav, :keep_self_bookmark, :min_favs, :min_reblogs])
-  end
-
-  def set_cache_headers
-    response.cache_control.replace(private: true, no_store: true)
   end
 end


### PR DESCRIPTION
There is a `before_action` declared in the top level `ApplicationController` which does this same thing - https://github.com/mastodon/mastodon/blob/v4.3.3/app/controllers/application_controller.rb#L181-L183 - all the spots this is removed in this PR inherit from that controller.

I think the history here is that one refactor added these all in to the individual controllers, and then a separate subsequent one added the default before_action but did not fully clean up all the subclassed controllers.

Possible followup - the `CacheConcern` module is ALSO doing this same thing - https://github.com/mastodon/mastodon/blob/v4.3.3/app/controllers/concerns/cache_concern.rb#L25 - and doing it in a default `after_action` run everywhere, so its possible some places were doing this three times and will still be doing it two times after this PR. Will review that more.

The `requests/cache_spec` assertions do have relevant checks for both `private` and `no-store` in the shared examples there, so I think this is safe.