### PR TITLE
Optimize timeline generation

### DIFF
--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -121,7 +121,7 @@ class FeedManager
 
     timeline_key = key(:home, into_account.id)
     aggregate    = into_account.user&.aggregates_reblogs?
-    query        = from_account.statuses.list_eligible_visibility.includes(:preloadable_poll, :media_attachments, reblog: :account).limit(FeedManager::MAX_ITEMS / 4)
+    query        = from_account.statuses.list_eligible_visibility.includes(reblog: :account).limit(FeedManager::MAX_ITEMS / 4)
 
     if redis.zcard(timeline_key) >= FeedManager::MAX_ITEMS / 4
       oldest_home_score = redis.zrange(timeline_key, 0, 0, with_scores: true).first.last.to_i
@@ -149,7 +149,7 @@ class FeedManager
 
     timeline_key = key(:list, list.id)
     aggregate    = list.account.user&.aggregates_reblogs?
-    query        = from_account.statuses.list_eligible_visibility.includes(:preloadable_poll, :media_attachments, reblog: :account).limit(FeedManager::MAX_ITEMS / 4)
+    query        = from_account.statuses.list_eligible_visibility.includes(reblog: :account).limit(FeedManager::MAX_ITEMS / 4)
 
     if redis.zcard(timeline_key) >= FeedManager::MAX_ITEMS / 4
       oldest_home_score = redis.zrange(timeline_key, 0, 0, with_scores: true).first.last.to_i
@@ -288,7 +288,7 @@ class FeedManager
         next if last_status_score < oldest_home_score
       end
 
-      statuses = target_account.statuses.list_eligible_visibility.includes(:preloadable_poll, :media_attachments, :account, reblog: :account).limit(limit)
+      statuses = target_account.statuses.list_eligible_visibility.includes(reblog: :account).limit(limit)
       crutches = build_crutches(account.id, statuses)
 
       statuses.each do |status|
@@ -320,7 +320,7 @@ class FeedManager
         next if last_status_score < oldest_home_score
       end
 
-      statuses = target_account.statuses.list_eligible_visibility.includes(:preloadable_poll, :media_attachments, :account, reblog: :account).limit(limit)
+      statuses = target_account.statuses.list_eligible_visibility.includes(reblog: :account).limit(limit)
       crutches = build_crutches(list.account_id, statuses)
 
       statuses.each do |status|

--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -282,7 +282,7 @@ class FeedManager
 
       if redis.zcard(timeline_key) >= limit
         oldest_home_score = redis.zrange(timeline_key, 0, 0, with_scores: true).first.last.to_i
-        last_status_score = Mastodon::Snowflake.id_at(target_account.last_status_at)
+        last_status_score = Mastodon::Snowflake.id_at(target_account.last_status_at, with_random: false)
 
         # If the feed is full and this account has not posted more recently
         # than the last item on the feed, then we can skip the whole account
@@ -319,7 +319,7 @@ class FeedManager
 
       if redis.zcard(timeline_key) >= limit
         oldest_home_score = redis.zrange(timeline_key, 0, 0, with_scores: true).first.last.to_i
-        last_status_score = Mastodon::Snowflake.id_at(target_account.last_status_at)
+        last_status_score = Mastodon::Snowflake.id_at(target_account.last_status_at, with_random: false)
 
         # If the feed is full and this account has not posted more recently
         # than the last item on the feed, then we can skip the whole account

--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -296,6 +296,8 @@ class FeedManager
       end
 
       statuses = query.to_a
+      next if statuses.empty?
+
       crutches = build_crutches(account.id, statuses)
 
       statuses.each do |status|
@@ -335,6 +337,8 @@ class FeedManager
       end
 
       statuses = query.to_a
+      next if statuses.empty?
+
       crutches = build_crutches(list.account_id, statuses)
 
       statuses.each do |status|


### PR DESCRIPTION
Those are somewhat low-hanging fruits for timeline generation.

## Before

Before the changes, generating my Home and two (small) list timelines from scratch took that amount of time:
```
 61.001444   6.975359  67.976803 (176.038725)
 11.526668   1.181717  12.708385 ( 33.958586)
  3.576163   0.401200   3.977363 ( 15.360795)
```

And when the timelines were already generated, filling them (which would be a no-op) took that amount of time:
```
 51.031345   6.324234  57.355579 (169.474034)
 10.023077   1.142712  11.165789 ( 23.435064)
  2.929509   0.277567   3.207076 ( 10.042510)
```

## After

After this PR's changes, generating the same timelines from scratch takes a reduced amount of time:
```
  9.817145   1.210652  11.027797 ( 19.110152)
  5.465910   0.680844   6.146754 ( 11.889094)
  2.949545   0.423947   3.373492 (  9.529031)
```

And when already generated:
```
  5.764612   0.619574   6.384186 ( 10.486542)
  2.226865   0.267550   2.494415 (  4.391762)
  1.532688   0.127098   1.659786 (  2.895375)
```