### PR TITLE
Combine examples to reduce factories in specs

### DIFF
--- a/spec/controllers/concerns/api/rate_limit_headers_spec.rb
+++ b/spec/controllers/concerns/api/rate_limit_headers_spec.rb
@@ -40,15 +40,11 @@ RSpec.describe Api::RateLimitHeaders do
         end
       end
 
-      it 'applies rate limiting limit header' do
+      it 'provides rate limit information in headers' do
         expect(response.headers['X-RateLimit-Limit']).to eq '100'
-      end
 
-      it 'applies rate limiting remaining header' do
         expect(response.headers['X-RateLimit-Remaining']).to eq '80'
-      end
 
-      it 'applies rate limiting reset header' do
         expect(response.headers['X-RateLimit-Reset']).to eq (start_time + 10.seconds).iso8601(6)
       end
     end

--- a/spec/controllers/filters/statuses_controller_spec.rb
+++ b/spec/controllers/filters/statuses_controller_spec.rb
@@ -23,11 +23,9 @@ RSpec.describe Filters::StatusesController do
           get :index, params: { filter_id: filter }
         end
 
-        it 'returns http success' do
+        it 'returns http success and private cache control headers' do
           expect(response).to have_http_status(200)
-        end
 
-        it 'returns private cache control headers' do
           expect(response.headers['Cache-Control']).to include('private, no-store')
         end
       end

--- a/spec/controllers/relationships_controller_spec.rb
+++ b/spec/controllers/relationships_controller_spec.rb
@@ -14,11 +14,9 @@ RSpec.describe RelationshipsController do
         get :show, params: { page: 2, relationship: 'followed_by' }
       end
 
-      it 'returns http success' do
+      it 'returns http success and private cache control headers' do
         expect(response).to have_http_status(200)
-      end
 
-      it 'returns private cache control headers' do
         expect(response.headers['Cache-Control']).to include('private, no-store')
       end
     end

--- a/spec/requests/well_known/webfinger_spec.rb
+++ b/spec/requests/well_known/webfinger_spec.rb
@@ -116,19 +116,13 @@ RSpec.describe 'The /.well-known/webfinger endpoint' do
       perform_request!
     end
 
-    it 'returns http success' do
+    it 'returns http success with expect headers and media type' do
       expect(response).to have_http_status(200)
-    end
 
-    it 'sets only a Vary Origin header' do
       expect(response.headers['Vary']).to eq('Origin')
-    end
 
-    it 'returns application/jrd+json' do
       expect(response.media_type).to eq 'application/jrd+json'
-    end
 
-    it 'returns links for the internal account' do
       expect(response.parsed_body)
         .to include(
           subject: 'acct:mastodon.internal@cb6e6126.ngrok.io',

--- a/spec/workers/poll_expiration_notify_worker_spec.rb
+++ b/spec/workers/poll_expiration_notify_worker_spec.rb
@@ -33,15 +33,11 @@ RSpec.describe PollExpirationNotifyWorker do
       end
 
       context 'when poll is local' do
-        it 'notifies voters' do
+        it 'notifies voters, owner, and local voters' do
           expect(ActivityPub::DistributePollUpdateWorker).to have_enqueued_sidekiq_job(poll.status.id)
-        end
 
-        it 'notifies owner' do
           expect(LocalNotificationWorker).to have_enqueued_sidekiq_job(poll.account.id, poll.id, 'Poll', 'poll')
-        end
 
-        it 'notifies local voters' do
           expect(LocalNotificationWorker).to have_enqueued_sidekiq_job(poll_vote.account.id, poll.id, 'Poll', 'poll')
         end
       end
@@ -49,15 +45,11 @@ RSpec.describe PollExpirationNotifyWorker do
       context 'when poll is remote' do
         let(:remote?) { true }
 
-        it 'does not notify remote voters' do
+        it 'does not notify remote voters or owner, does notify local voters' do
           expect(ActivityPub::DistributePollUpdateWorker).to_not have_enqueued_sidekiq_job(poll.status.id)
-        end
 
-        it 'does not notify owner' do
           expect(LocalNotificationWorker).to_not have_enqueued_sidekiq_job(poll.account.id, poll.id, 'Poll', 'poll')
-        end
 
-        it 'notifies local voters' do
           expect(LocalNotificationWorker).to have_enqueued_sidekiq_job(poll_vote.account.id, poll.id, 'Poll', 'poll')
         end
       end

--- a/spec/workers/publish_scheduled_status_worker_spec.rb
+++ b/spec/workers/publish_scheduled_status_worker_spec.rb
@@ -13,11 +13,9 @@ RSpec.describe PublishScheduledStatusWorker do
     end
 
     context 'when the account is not disabled' do
-      it 'creates a status' do
+      it 'creates a status and removes scheduled record' do
         expect(scheduled_status.account.statuses.first.text).to eq 'Hello world, future!'
-      end
 
-      it 'removes the scheduled status' do
         expect(ScheduledStatus.find_by(id: scheduled_status.id)).to be_nil
       end
     end
@@ -25,11 +23,9 @@ RSpec.describe PublishScheduledStatusWorker do
     context 'when the account is disabled' do
       let(:scheduled_status) { Fabricate(:scheduled_status, account: Fabricate(:account, user: Fabricate(:user, disabled: true))) }
 
-      it 'does not create a status' do
+      it 'does not create a status and removes scheduled record' do
         expect(Status.count).to eq 0
-      end
 
-      it 'removes the scheduled status' do
         expect(ScheduledStatus.find_by(id: scheduled_status.id)).to be_nil
       end
     end

--- a/spec/workers/unfollow_follow_worker_spec.rb
+++ b/spec/workers/unfollow_follow_worker_spec.rb
@@ -18,14 +18,11 @@ RSpec.describe UnfollowFollowWorker do
     let(:show_reblogs) { true }
 
     describe 'perform' do
-      it 'unfollows source account and follows target account' do
+      it 'unfollows source account and follows target account and preserves show_reblogs' do
         subject.perform(local_follower.id, source_account.id, target_account.id)
         expect(local_follower.following?(source_account)).to be false
         expect(local_follower.following?(target_account)).to be true
-      end
 
-      it 'preserves show_reblogs' do
-        subject.perform(local_follower.id, source_account.id, target_account.id)
         expect(Follow.find_by(account: local_follower, target_account: target_account).show_reblogs?).to be show_reblogs
       end
     end
@@ -35,14 +32,11 @@ RSpec.describe UnfollowFollowWorker do
     let(:show_reblogs) { false }
 
     describe 'perform' do
-      it 'unfollows source account and follows target account' do
+      it 'unfollows source account and follows target account and preserves show_reblogs' do
         subject.perform(local_follower.id, source_account.id, target_account.id)
         expect(local_follower.following?(source_account)).to be false
         expect(local_follower.following?(target_account)).to be true
-      end
 
-      it 'preserves show_reblogs' do
-        subject.perform(local_follower.id, source_account.id, target_account.id)
         expect(Follow.find_by(account: local_follower, target_account: target_account).show_reblogs?).to be show_reblogs
       end
     end


### PR DESCRIPTION
A few more in advance of more controller->system migration. Same motivation in all cases here - combine examples with same exact setup to reduce factory creation. About ~40 factory reduction across full group.