### PR TITLE
Add `about`, `privacy_policy` and `terms_of_service` URLS to `/api/v2/instance`

### DIFF
--- a/app/serializers/rest/instance_serializer.rb
+++ b/app/serializers/rest/instance_serializer.rb
@@ -59,6 +59,9 @@ class REST::InstanceSerializer < ActiveModel::Serializer
       urls: {
         streaming: Rails.configuration.x.streaming_api_base_url,
         status: object.status_page_url,
+        about: about_url,
+        privacy_policy: privacy_policy_url,
+        terms_of_service: TermsOfService.live.exists? ? terms_of_service_url : nil,
       },
 
       vapid: {


### PR DESCRIPTION
Fixes #33793

(This would need a matching documentation PR if accepted)