### PR TITLE
Fix potential inefficiency in media privacy system check

### DIFF
--- a/app/lib/admin/system_check/media_privacy_check.rb
+++ b/app/lib/admin/system_check/media_privacy_check.rb
@@ -76,7 +76,7 @@ class Admin::SystemCheck::MediaPrivacyCheck < Admin::SystemCheck::BaseCheck
 
   def media_attachment
     @media_attachment ||= begin
-      attachment = Account.representative.media_attachments.first
+      attachment = Account.representative.media_attachments.take
       if attachment.present?
         attachment.touch
         attachment


### PR DESCRIPTION
We don't expect there to be more than one attachment for that account, and we don't care which one is picked if there is more than one.