### PR TITLE
Remove final remaining `assigns` usage in controller specs

### DIFF
--- a/spec/controllers/admin/accounts_controller_spec.rb
+++ b/spec/controllers/admin/accounts_controller_spec.rb
@@ -59,16 +59,15 @@ RSpec.describe Admin::AccountsController do
       let(:account) { Fabricate(:account) }
 
       it 'includes moderation notes' do
-        note1 = Fabricate(:account_moderation_note, target_account: account)
-        note2 = Fabricate(:account_moderation_note, target_account: account)
+        note1 = Fabricate(:account_moderation_note, target_account: account, content: 'Note 1 remarks')
+        note2 = Fabricate(:account_moderation_note, target_account: account, content: 'Note 2 remarks')
 
         get :show, params: { id: account.id }
         expect(response).to have_http_status(200)
 
-        moderation_notes = assigns(:moderation_notes).to_a
-
-        expect(moderation_notes.size).to be 2
-        expect(moderation_notes).to eq [note1, note2]
+        expect(response.body)
+          .to include(note1.content)
+          .and include(note2.content)
       end
     end
 

--- a/spec/controllers/admin/instances_controller_spec.rb
+++ b/spec/controllers/admin/instances_controller_spec.rb
@@ -49,23 +49,11 @@ RSpec.describe Admin::InstancesController do
 
       expect(response).to have_http_status(200)
 
-      instance = assigns(:instance)
-      expect(instance).to_not be_new_record
+      expect(response.body)
+        .to include(I18n.t('admin.instances.totals_time_period_hint_html'))
+        .and include(I18n.t('accounts.nothing_here'))
 
       expect(Admin::ActionLogFilter).to have_received(:new).with(target_domain: account_popular_main.domain)
-
-      action_logs = assigns(:action_logs).to_a
-      expect(action_logs.size).to eq 0
-    end
-
-    context 'with an unknown domain' do
-      it 'returns http success' do
-        get :show, params: { id: 'unknown.example' }
-        expect(response).to have_http_status(200)
-
-        instance = assigns(:instance)
-        expect(instance).to be_new_record
-      end
     end
   end
 

--- a/spec/requests/admin/instances_spec.rb
+++ b/spec/requests/admin/instances_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin Instances' do
+  describe 'GET /admin/instances/:id' do
+    context 'with an unknown domain' do
+      before { sign_in Fabricate(:admin_user) }
+
+      it 'returns http success' do
+        get admin_instance_path(id: 'unknown.example')
+
+        expect(response)
+          .to have_http_status(200)
+      end
+    end
+  end
+end


### PR DESCRIPTION
As I've been migrating some of the controller specs into system and request specs, I've been periodically checking how many `assigns` and `render_template` usages are left. At some point in the migration they'll all be gone and we can remove the `rails-controller-testing` gem.

This PR:

- Does a controller->request spec conversion for the "accessing an unknown domain" path in admin/instances#show
- Does some pre-removal of `assigns` in two spots in admin/accounts and admin/instances, in advance of converting them to system specs as well (they are both large, may do in smaller pieces like some others)

There are still a lot of controller specs (many of which use `render_template`) to work through, but this is the last of `assigns` usage.