### PR TITLE
Verify page content in 2FA portion of `auth/sessions` controller spec

### DIFF
--- a/spec/controllers/auth/sessions_controller_spec.rb
+++ b/spec/controllers/auth/sessions_controller_spec.rb
@@ -223,8 +223,8 @@ RSpec.describe Auth::SessionsController do
           end
 
           it 'renders two factor authentication page' do
-            expect(controller).to render_template('two_factor')
-            expect(controller).to render_template(partial: '_otp_authentication_form')
+            expect(response.body)
+              .to include(I18n.t('simple_form.hints.sessions.otp'))
           end
         end
 
@@ -239,8 +239,8 @@ RSpec.describe Auth::SessionsController do
           end
 
           it 'renders two factor authentication page' do
-            expect(controller).to render_template('two_factor')
-            expect(controller).to render_template(partial: '_otp_authentication_form')
+            expect(response.body)
+              .to include(I18n.t('simple_form.hints.sessions.otp'))
           end
         end
 
@@ -250,8 +250,8 @@ RSpec.describe Auth::SessionsController do
           end
 
           it 'renders two factor authentication page' do
-            expect(controller).to render_template('two_factor')
-            expect(controller).to render_template(partial: '_otp_authentication_form')
+            expect(response.body)
+              .to include(I18n.t('simple_form.hints.sessions.otp'))
           end
         end
 
@@ -378,8 +378,8 @@ RSpec.describe Auth::SessionsController do
           end
 
           it 'renders webauthn authentication page' do
-            expect(controller).to render_template('two_factor')
-            expect(controller).to render_template(partial: '_webauthn_form')
+            expect(response.body)
+              .to include(I18n.t('simple_form.title.sessions.webauthn'))
           end
         end
 
@@ -389,8 +389,8 @@ RSpec.describe Auth::SessionsController do
           end
 
           it 'renders webauthn authentication page' do
-            expect(controller).to render_template('two_factor')
-            expect(controller).to render_template(partial: '_webauthn_form')
+            expect(response.body)
+              .to include(I18n.t('simple_form.title.sessions.webauthn'))
           end
         end
 


### PR DESCRIPTION
All of these are asserting on variations of this code path - https://github.com/mastodon/mastodon/blob/v4.3.3/app/controllers/concerns/auth/two_factor_authentication_concern.rb#L93

These I18n strings are used uniquely in the relevant partials, which are only ever rendered from that view, so we can consolidate this a bit w/out losing coverage.

Similar to https://github.com/mastodon/mastodon/pull/33866 in that this is also prep for converting a (large) controller spec to system spec ... but also chips away at our few remaining render_template spots as well.