### PR TITLE
Verify page content in `ChallengableConcern` spec

### DIFF
--- a/spec/controllers/concerns/challengable_concern_spec.rb
+++ b/spec/controllers/concerns/challengable_concern_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe ChallengableConcern do
+  render_views
+
   controller(ApplicationController) do
     include ChallengableConcern # rubocop:disable RSpec/DescribedClass
 
@@ -85,29 +87,38 @@ RSpec.describe ChallengableConcern do
       before { get :foo }
 
       it 'renders challenge' do
-        expect(response).to render_template('auth/challenges/new', layout: :auth)
+        expect(response.parsed_body)
+          .to have_title(I18n.t('challenge.prompt'))
+          .and have_css('.container-alt .logo-container')
       end
-
-      # See Auth::ChallengesControllerSpec
     end
 
     context 'with POST requests' do
       before { post :bar }
 
       it 'renders challenge' do
-        expect(response).to render_template('auth/challenges/new', layout: :auth)
+        expect(response.parsed_body)
+          .to have_title(I18n.t('challenge.prompt'))
+          .and have_css('.container-alt .logo-container')
       end
 
       it 'accepts correct password' do
         post :bar, params: { form_challenge: { current_password: password } }
-        expect(response.body).to eq 'bar'
-        expect(session[:challenge_passed_at]).to_not be_nil
+
+        expect(response.body)
+          .to eq 'bar'
+        expect(session[:challenge_passed_at])
+          .to_not be_nil
       end
 
       it 'rejects wrong password' do
         post :bar, params: { form_challenge: { current_password: 'dddfff888123' } }
-        expect(response.body).to render_template('auth/challenges/new', layout: :auth)
-        expect(session[:challenge_passed_at]).to be_nil
+
+        expect(response.parsed_body)
+          .to have_title(I18n.t('challenge.prompt'))
+          .and have_css('.container-alt .logo-container')
+        expect(session[:challenge_passed_at])
+          .to be_nil
       end
     end
   end

--- a/spec/controllers/concerns/challengable_concern_spec.rb
+++ b/spec/controllers/concerns/challengable_concern_spec.rb
@@ -89,7 +89,6 @@ RSpec.describe ChallengableConcern do
       it 'renders challenge' do
         expect(response.parsed_body)
           .to have_title(I18n.t('challenge.prompt'))
-          .and have_css('.container-alt .logo-container')
       end
     end
 
@@ -99,7 +98,6 @@ RSpec.describe ChallengableConcern do
       it 'renders challenge' do
         expect(response.parsed_body)
           .to have_title(I18n.t('challenge.prompt'))
-          .and have_css('.container-alt .logo-container')
       end
 
       it 'accepts correct password' do
@@ -116,7 +114,6 @@ RSpec.describe ChallengableConcern do
 
         expect(response.parsed_body)
           .to have_title(I18n.t('challenge.prompt'))
-          .and have_css('.container-alt .logo-container')
         expect(session[:challenge_passed_at])
           .to be_nil
       end


### PR DESCRIPTION
Same idea as https://github.com/mastodon/mastodon/pull/33891 ... though this one (basically a unit spec for the controller concern) may not be converted. I think this it the last of the "special case" changes, and the rest are just straightforward conversions in the admin/ and settings/ areas.