### PR TITLE
Update dependency net-imap to 0.5.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -416,7 +416,7 @@ GEM
     mutex_m (0.3.0)
     net-http (0.6.0)
       uri
-    net-imap (0.5.5)
+    net-imap (0.5.6)
       date
       net-protocol
     net-ldap (0.19.0)
@@ -424,7 +424,7 @@ GEM
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.5.0)
+    net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.4)
     nokogiri (1.18.2)


### PR DESCRIPTION
I don't think we use it at all, but it is flagged by bundler-audit because of a vulnerability. Doesn't hurt to update it.