### PR TITLE
Fix redirect after log-in when `allow_referrer_origin` setting is enabled

### DIFF
--- a/app/controllers/concerns/web_app_controller_concern.rb
+++ b/app/controllers/concerns/web_app_controller_concern.rb
@@ -46,6 +46,6 @@ module WebAppControllerConcern
   protected
 
   def set_referer_header
-    response.set_header('Referrer-Policy', Setting.allow_referrer_origin ? 'origin' : 'same-origin')
+    response.set_header('Referrer-Policy', Setting.allow_referrer_origin ? 'strict-origin-when-cross-origin' : 'same-origin')
   end
 end


### PR DESCRIPTION
Also only send referrer to potentially trustworthy URLs

Background: https://github.com/mastodon/mastodon/pull/33214#issuecomment-2651201839 and https://github.com/mastodon/mastodon/pull/33214#issuecomment-2653377445