### PR TITLE
Fix Mastodon listing updates older or equal to current version

### DIFF
--- a/app/controllers/admin/software_updates_controller.rb
+++ b/app/controllers/admin/software_updates_controller.rb
@@ -6,7 +6,7 @@ module Admin
 
     def index
       authorize :software_update, :index?
-      @software_updates = SoftwareUpdate.by_version
+      @software_updates = SoftwareUpdate.by_version.filter(&:pending?)
     end
 
     private

--- a/spec/system/admin/software_updates_spec.rb
+++ b/spec/system/admin/software_updates_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe 'finding software updates through the admin interface' do
   before do
     Fabricate(:software_update, version: '99.99.99', type: 'major', urgent: true, release_notes: 'https://github.com/mastodon/mastodon/releases/v99')
+    Fabricate(:software_update, version: '3.5.0', type: 'major', urgent: true, release_notes: 'https://github.com/mastodon/mastodon/releases/v3.5.0')
 
     sign_in Fabricate(:owner_user), scope: :user
   end
@@ -16,6 +17,7 @@ RSpec.describe 'finding software updates through the admin interface' do
     expect(page).to have_title(I18n.t('admin.software_updates.title'))
 
     expect(page).to have_content('99.99.99')
+                .and have_no_content('3.5.0')
 
     click_on I18n.t('admin.software_updates.release_notes')
     expect(page).to have_current_path('https://github.com/mastodon/mastodon/releases/v99', url: true)


### PR DESCRIPTION
Fixes #33772

The reason we did not filter before is because we wanted to use server-provided values unconditionally to avoid being stuck with a possibly bogus version comparison.

However, even if version comparison can be awkward at times (e.g. `4.3.0-nightly.2024-03-05-security` being an inferior version to `4.3.0-nightly.2024-03-05`), we have consistently used the same versioning scheme for a while and for many situations now. I feel like it's fine to filter by version on Mastodon itself too.