### PR TITLE
Update `selenium-webdriver` to version 4.28.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -566,7 +566,7 @@ GEM
     ox (2.14.22)
       bigdecimal (>= 3.0)
     parallel (1.26.3)
-    parser (3.3.7.0)
+    parser (3.3.7.1)
       ast (~> 2.4.1)
       racc
     parslet (2.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -670,7 +670,7 @@ GEM
       link_header (~> 0.0, >= 0.0.8)
     rdf-normalize (0.7.0)
       rdf (~> 3.3)
-    rdoc (6.11.0)
+    rdoc (6.12.0)
       psych (>= 4.0.0)
     redcarpet (3.6.0)
     redis (4.8.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -768,7 +768,7 @@ GEM
       activerecord (>= 4.0.0)
       railties (>= 4.0.0)
     securerandom (0.4.1)
-    selenium-webdriver (4.27.0)
+    selenium-webdriver (4.28.0)
       base64 (~> 0.2)
       logger (~> 1.4)
       rexml (~> 3.2, >= 3.2.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -328,7 +328,7 @@ GEM
       azure-blob (~> 0.5.2)
       hashie (~> 5.0)
     jmespath (1.6.2)
-    json (2.9.1)
+    json (2.10.1)
     json-canonicalization (1.0.0)
     json-jwt (1.15.3.1)
       activesupport (>= 4.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -818,8 +818,8 @@ GEM
       httpclient (>= 2.4)
     sysexits (1.2.0)
     temple (0.10.3)
-    terminal-table (3.0.2)
-      unicode-display_width (>= 1.1.1, < 3)
+    terminal-table (4.0.0)
+      unicode-display_width (>= 1.1.1, < 4)
     terrapin (1.0.1)
       climate_control
     test-prof (1.4.4)
@@ -850,7 +850,9 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.9.1)
-    unicode-display_width (2.6.0)
+    unicode-display_width (3.1.4)
+      unicode-emoji (~> 4.0, >= 4.0.4)
+    unicode-emoji (4.0.4)
     uri (1.0.2)
     useragent (0.16.11)
     validate_email (0.1.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -371,9 +371,10 @@ GEM
       mime-types
       terrapin (>= 0.6.0, < 2.0)
     language_server-protocol (3.17.0.4)
-    launchy (3.0.1)
+    launchy (3.1.0)
       addressable (~> 2.8)
       childprocess (~> 5.0)
+      logger (~> 1.6)
     letter_opener (1.10.0)
       launchy (>= 2.2, < 4)
     letter_opener_web (3.0.0)


### PR DESCRIPTION
Background on selenium-webdriver bump - https://github.com/mastodon/mastodon/pull/33821#issuecomment-2653813729

Bumped misc other minor stuff that renovate hasn't hit yet as well.