### PR TITLE
Improve example wording in 2FA/confirmations controller spec

### DIFF
--- a/spec/controllers/settings/two_factor_authentication/confirmations_controller_spec.rb
+++ b/spec/controllers/settings/two_factor_authentication/confirmations_controller_spec.rb
@@ -116,18 +116,4 @@ RSpec.describe Settings::TwoFactorAuthentication::ConfirmationsController do
       end
     end
   end
-
-  context 'when not signed in' do
-    it 'redirects on POST to create' do
-      post :create, params: { form_two_factor_confirmation: { otp_attempt: '123456' } }
-
-      expect(response).to redirect_to('/auth/sign_in')
-    end
-
-    it 'redirects on GET to new' do
-      get :new
-
-      expect(response).to redirect_to('/auth/sign_in')
-    end
-  end
 end

--- a/spec/controllers/settings/two_factor_authentication/confirmations_controller_spec.rb
+++ b/spec/controllers/settings/two_factor_authentication/confirmations_controller_spec.rb
@@ -5,14 +5,14 @@ require 'rails_helper'
 RSpec.describe Settings::TwoFactorAuthentication::ConfirmationsController do
   render_views
 
-  shared_examples 'renders :new' do
-    it 'renders the new view' do
+  shared_examples 'renders expected page' do
+    it 'renders the new view with QR code' do
       subject
 
       expect(response).to have_http_status(200)
-      expect(response).to render_template(:new)
       expect(response.body)
         .to include(qr_code_markup)
+        .and include(I18n.t('settings.two_factor_authentication'))
     end
 
     def qr_code_markup
@@ -34,7 +34,7 @@ RSpec.describe Settings::TwoFactorAuthentication::ConfirmationsController do
             get :new, session: { challenge_passed_at: Time.now.utc, new_otp_secret: 'thisisasecretforthespecofnewview' }
           end
 
-          include_examples 'renders :new'
+          include_examples 'renders expected page'
         end
 
         it 'redirects if a new otp_secret has not been set in the session' do
@@ -66,10 +66,13 @@ RSpec.describe Settings::TwoFactorAuthentication::ConfirmationsController do
             expect { post_create_with_options }
               .to change { user.reload.otp_secret }.to 'thisisasecretforthespecofnewview'
 
-            expect(flash[:notice]).to eq 'Two-factor authentication successfully enabled'
-            expect(response).to have_http_status(200)
-            expect(response).to render_template('settings/two_factor_authentication/recovery_codes/index')
-            expect(response.body).to include(*otp_backup_codes)
+            expect(flash[:notice])
+              .to eq(I18n.t('two_factor_authentication.enabled_success'))
+            expect(response)
+              .to have_http_status(200)
+            expect(response.body)
+              .to include(*otp_backup_codes)
+              .and include(I18n.t('settings.two_factor_authentication'))
           end
         end
 
@@ -86,10 +89,12 @@ RSpec.describe Settings::TwoFactorAuthentication::ConfirmationsController do
 
           it 'renders page with error message' do
             subject
-            expect(response.body).to include 'The entered code was invalid! Are server time and device time correct?'
+
+            expect(response.body)
+              .to include(I18n.t('otp_authentication.wrong_code'))
           end
 
-          include_examples 'renders :new'
+          include_examples 'renders expected page'
         end
 
         private

--- a/spec/requests/settings/two_factor_authentication/confirmations_spec.rb
+++ b/spec/requests/settings/two_factor_authentication/confirmations_spec.rb
@@ -16,4 +16,20 @@ RSpec.describe 'Settings 2FA Confirmations' do
         .to have_http_status(400)
     end
   end
+
+  context 'when not signed in' do
+    it 'redirects on POST to create' do
+      post settings_two_factor_authentication_confirmation_path(form_two_factor_confirmation: { otp_attempt: '123456' })
+
+      expect(response)
+        .to redirect_to(new_user_session_path)
+    end
+
+    it 'redirects on GET to new' do
+      get new_settings_two_factor_authentication_confirmation_path
+
+      expect(response)
+        .to redirect_to(new_user_session_path)
+    end
+  end
 end


### PR DESCRIPTION
After https://github.com/mastodon/mastodon/pull/33921 merges, we are down to the last few usages of `render_template` in controller specs before being able to remove the rails controller testing gem. Some of the remaining ones are sort of awkward and I might do some prep work ahead of those conversions. In this group:

- Pull out the basic signed out checks to request spec
- Update some naming that didn't fully capture the check
- Assert on I18n lookup values instead of the literal strings
- Use some view strings instead of render template checks

This one is sort of awkward to convert ... there's a big outer loop around basically all the specs, and there's also some stuff with the challenge/session that doesn't translate directly. I'll get to this eventually, but would like to nudge forward the last few removals as well to get the gem out.