### PR TITLE
Use preferred allowed origin configuration style for webauthn config

### DIFF
--- a/config/initializers/webauthn.rb
+++ b/config/initializers/webauthn.rb
@@ -3,7 +3,7 @@
 WebAuthn.configure do |config|
   # This value needs to match `window.location.origin` evaluated by
   # the User Agent during registration and authentication ceremonies.
-  config.origin = "#{Rails.configuration.x.use_https ? 'https' : 'http'}://#{Rails.configuration.x.web_domain}"
+  config.allowed_origins = ["#{Rails.configuration.x.use_https ? 'https' : 'http'}://#{Rails.configuration.x.web_domain}"]
 
   # Relying Party name for display purposes
   config.rp_name = 'Mastodon'


### PR DESCRIPTION
Silences deprecation warning. In latest release: https://github.com/cedarcode/webauthn-ruby/blob/master/CHANGELOG.md