### PR TITLE
Remove `rails-controller-testing` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -145,9 +145,6 @@ group :test do
   # Used to mock environment variables
   gem 'climate_control'
 
-  # Add back helpers functions removed in Rails 5.1
-  gem 'rails-controller-testing', '~> 1.0'
-
   # Validate schemas in specs
   gem 'json-schema', '~> 5.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -641,10 +641,6 @@ GEM
       activesupport (= 8.0.1)
       bundler (>= 1.15.0)
       railties (= 8.0.1)
-    rails-controller-testing (1.0.5)
-      actionpack (>= 5.0.1.rc1)
-      actionview (>= 5.0.1.rc1)
-      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.2.0)
       activesupport (>= 5.0.0)
       minitest
@@ -1009,7 +1005,6 @@ DEPENDENCIES
   rack-cors (~> 2.0)
   rack-test (~> 2.1)
   rails (~> 8.0)
-  rails-controller-testing (~> 1.0)
   rails-i18n (~> 8.0)
   rdf-normalize (~> 0.5)
   redcarpet (~> 3.6)

--- a/spec/controllers/admin/domain_blocks_controller_spec.rb
+++ b/spec/controllers/admin/domain_blocks_controller_spec.rb
@@ -69,7 +69,8 @@ RSpec.describe Admin::DomainBlocksController do
 
         expect(DomainBlockWorker).to_not have_received(:perform_async)
 
-        expect(response).to render_template :new
+        expect(response.parsed_body.title)
+          .to match(I18n.t('admin.domain_blocks.new.title'))
       end
     end
 
@@ -84,7 +85,8 @@ RSpec.describe Admin::DomainBlocksController do
 
           expect(DomainBlockWorker).to_not have_received(:perform_async)
 
-          expect(response).to render_template :confirm_suspension
+          expect(response.parsed_body.title)
+            .to match(I18n.t('admin.domain_blocks.confirm_suspension.title', domain: 'example.com'))
         end
       end
 
@@ -119,7 +121,8 @@ RSpec.describe Admin::DomainBlocksController do
 
           expect(DomainBlockWorker).to_not have_received(:perform_async)
 
-          expect(response).to render_template :confirm_suspension
+          expect(response.parsed_body.title)
+            .to match(I18n.t('admin.domain_blocks.confirm_suspension.title', domain: 'example.com'))
         end
       end
 


### PR DESCRIPTION
I've been slightly prioritizing the specs which use these methods as part of the larger system spec migration.

Opening as draft because https://github.com/mastodon/mastodon/pull/33947 and https://github.com/mastodon/mastodon/pull/33944 need to merge before this will pass CI. Will rebase and mark ready after those merge.

There are still ~70 controller specs remaining, but the vast majority of them are under 100 LOC, and many of them are really basic CRUD stuff that should be simple to convert and review. I may lump some together where they are related features, to reduce total PRs required here while also keeping them reviewable. I may also do a pass to ensure that the various `SystemHelpers` methods are used consistently, and/or add more common patterns there.