### PR TITLE
Use bundler version 2.6.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1059,4 +1059,4 @@ RUBY VERSION
    ruby 3.4.1p0
 
 BUNDLED WITH
-   2.6.3
+   2.6.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -814,7 +814,7 @@ GEM
     stackprof (0.2.27)
     stoplight (4.1.1)
       redlock (~> 1.0)
-    stringio (3.1.2)
+    stringio (3.1.4)
     strong_migrations (2.2.0)
       activerecord (>= 7)
     swd (1.3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -413,7 +413,7 @@ GEM
     mini_mime (1.1.5)
     mini_portile2 (2.8.8)
     minitest (5.25.4)
-    msgpack (1.7.5)
+    msgpack (1.8.0)
     multi_json (1.15.0)
     mutex_m (0.3.0)
     net-http (0.6.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -774,7 +774,7 @@ GEM
       activerecord (>= 4.0.0)
       railties (>= 4.0.0)
     securerandom (0.4.1)
-    selenium-webdriver (4.28.0)
+    selenium-webdriver (4.29.0)
       base64 (~> 0.2)
       logger (~> 1.4)
       rexml (~> 3.2, >= 3.2.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -898,7 +898,7 @@ GEM
     xorcist (1.1.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.7.1)
+    zeitwerk (2.7.2)
 
 PLATFORMS
   ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -409,7 +409,7 @@ GEM
     mime-types (3.6.0)
       logger
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2025.0204)
+    mime-types-data (3.2025.0220)
     mini_mime (1.1.5)
     mini_portile2 (2.8.8)
     minitest (5.25.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,7 +194,7 @@ GEM
     devise_pam_authenticatable2 (9.2.0)
       devise (>= 4.0.0)
       rpam2 (~> 4.0)
-    diff-lcs (1.5.1)
+    diff-lcs (1.6.0)
     discard (1.4.0)
       activerecord (>= 4.2, < 9.0)
     docile (1.4.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -687,7 +687,7 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    rexml (3.4.0)
+    rexml (3.4.1)
     rotp (6.3.0)
     rouge (4.5.1)
     rpam2 (4.0.2)


### PR DESCRIPTION
Bumped some misc stuff renovate seems to miss as well.

Sort of related to the selenium-webdriver bump here ... it does seem like the intermittent failures of system specs we were seeing have gone away (?) since the chrome on the GH runner image was bumped from 132 to 133, I'm guessing that issue was resolved there.