### PR TITLE
Use methods from `SystemHelpers` more consistently

### DIFF
--- a/spec/system/admin/announcements_spec.rb
+++ b/spec/system/admin/announcements_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe 'Admin::Announcements' do
   end
 
   def text_label
-    I18n.t('simple_form.labels.announcement.text')
+    form_label('announcement.text')
   end
 
   def admin_user

--- a/spec/system/admin/invites_spec.rb
+++ b/spec/system/admin/invites_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe 'Admin Invites' do
     end
 
     def max_use_field
-      I18n.t('simple_form.labels.defaults.max_uses')
+      form_label('defaults.max_uses')
     end
   end
 end

--- a/spec/system/admin/rules_spec.rb
+++ b/spec/system/admin/rules_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe 'Admin Rules' do
       end
 
       def submit_form
-        click_on I18n.t('generic.save_changes')
+        click_on(submit_button)
       end
     end
 

--- a/spec/system/admin/tags_spec.rb
+++ b/spec/system/admin/tags_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Admin Tags' do
     end
 
     def display_name_field
-      I18n.t('simple_form.labels.defaults.display_name')
+      form_label('defaults.display_name')
     end
 
     def match_error_text

--- a/spec/system/admin/warning_presets_spec.rb
+++ b/spec/system/admin/warning_presets_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe 'Admin Warning Presets' do
       end
 
       def submit_form
-        click_on I18n.t('generic.save_changes')
+        click_on(submit_button)
       end
     end
 

--- a/spec/system/admin/webhooks_spec.rb
+++ b/spec/system/admin/webhooks_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe 'Admin Webhooks' do
       end
 
       def submit_form
-        click_on I18n.t('generic.save_changes')
+        click_on(submit_button)
       end
     end
 

--- a/spec/system/filters_spec.rb
+++ b/spec/system/filters_spec.rb
@@ -108,6 +108,6 @@ RSpec.describe 'Filters' do
   end
 
   def filter_title_field
-    I18n.t('simple_form.labels.defaults.title')
+    form_label('defaults.title')
   end
 end

--- a/spec/system/invites_spec.rb
+++ b/spec/system/invites_spec.rb
@@ -71,9 +71,9 @@ RSpec.describe 'Invites' do
 
   def fill_invite_form
     select I18n.t('invites.max_uses', count: 100),
-           from: I18n.t('simple_form.labels.defaults.max_uses')
+           from: form_label('defaults.max_uses')
     select I18n.t("invites.expires_in.#{30.minutes.to_i}"),
-           from: I18n.t('simple_form.labels.defaults.expires_in')
-    check I18n.t('simple_form.labels.defaults.autofollow')
+           from: form_label('defaults.expires_in')
+    check form_label('defaults.autofollow')
   end
 end

--- a/spec/system/settings/applications_spec.rb
+++ b/spec/system/settings/applications_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe 'Settings applications page' do
     end
 
     def submit_form
-      click_on I18n.t('generic.save_changes')
+      click_on(submit_button)
     end
   end
 

--- a/spec/system/settings/preferences/appearance_spec.rb
+++ b/spec/system/settings/preferences/appearance_spec.rb
@@ -33,18 +33,18 @@ RSpec.describe 'Settings preferences appearance page' do
   end
 
   def confirm_delete_field
-    I18n.t('simple_form.labels.defaults.setting_delete_modal')
+    form_label('defaults.setting_delete_modal')
   end
 
   def confirm_reblog_field
-    I18n.t('simple_form.labels.defaults.setting_boost_modal')
+    form_label('defaults.setting_boost_modal')
   end
 
   def theme_selection_field
-    I18n.t('simple_form.labels.defaults.setting_theme')
+    form_label('defaults.setting_theme')
   end
 
   def advanced_layout_field
-    I18n.t('simple_form.labels.defaults.setting_advanced_layout')
+    form_label('defaults.setting_advanced_layout')
   end
 end

--- a/spec/system/settings/preferences/notifications_spec.rb
+++ b/spec/system/settings/preferences/notifications_spec.rb
@@ -22,6 +22,6 @@ RSpec.describe 'Settings preferences notifications page' do
   end
 
   def notifications_follow_field
-    I18n.t('simple_form.labels.notification_emails.follow')
+    form_label('notification_emails.follow')
   end
 end

--- a/spec/system/settings/preferences/other_spec.rb
+++ b/spec/system/settings/preferences/other_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Settings preferences other page' do
   end
 
   def mark_sensitive_field
-    I18n.t('simple_form.labels.defaults.setting_default_sensitive')
+    form_label('defaults.setting_default_sensitive')
   end
 
   def language_field(key)

--- a/spec/system/settings/privacy_spec.rb
+++ b/spec/system/settings/privacy_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Settings Privacy' do
           .to change { user.account.reload.discoverable }.to(true)
         expect(page)
           .to have_content(I18n.t('privacy.title'))
-          .and have_content(I18n.t('generic.changes_saved_msg'))
+          .and have_content(success_message)
         expect(ActivityPub::UpdateDistributionWorker)
           .to have_received(:perform_async).with(user.account.id)
       end

--- a/spec/system/settings/profiles_spec.rb
+++ b/spec/system/settings/profiles_spec.rb
@@ -28,10 +28,10 @@ RSpec.describe 'Settings profile page' do
   end
 
   def display_name_field
-    I18n.t('simple_form.labels.defaults.display_name')
+    form_label('defaults.display_name')
   end
 
   def avatar_field
-    I18n.t('simple_form.labels.defaults.avatar')
+    form_label('defaults.avatar')
   end
 end

--- a/spec/system/settings/verifications_spec.rb
+++ b/spec/system/settings/verifications_spec.rb
@@ -44,6 +44,6 @@ RSpec.describe 'Settings verification page' do
   end
 
   def attribution_field
-    I18n.t('simple_form.labels.account.attribution_domains')
+    form_label('account.attribution_domains')
   end
 end


### PR DESCRIPTION
Part of the follow-up mentioned in https://github.com/mastodon/mastodon/pull/33955 - these support methods which were extracted from some system specs were not being used everywhere (`form_label`, `submit_button`,  `success_message`). May be opportunity to pull more out into this helper, but for now just using the ones we already have.

