### PR TITLE
Add API to delete media attachments that are not in use

### DIFF
--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -77,7 +77,7 @@ namespace :api, format: false do
       end
     end
 
-    resources :media, only: [:create, :update, :show]
+    resources :media, only: [:create, :update, :show, :destroy]
     resources :blocks, only: [:index]
     resources :mutes, only: [:index]
     resources :favourites, only: [:index]


### PR DESCRIPTION
This pairs nicely with #33988, allowing for clients to delete media which they have just uploaded, instead of leaving the file uploaded until the next scheduled cleanup.