### PR TITLE
Add choice of law to terms of service generator

### DIFF
--- a/app/models/terms_of_service/generator.rb
+++ b/app/models/terms_of_service/generator.rb
@@ -13,6 +13,7 @@ class TermsOfService::Generator
     dmca_email
     domain
     jurisdiction
+    choice_of_law
   ).freeze
 
   attr_accessor(*VARIABLES)

--- a/app/views/admin/terms_of_service/generates/show.html.haml
+++ b/app/views/admin/terms_of_service/generates/show.html.haml
@@ -23,6 +23,9 @@
     = form.input :jurisdiction, wrapper: :with_label
 
   .fields-group
+    = form.input :choice_of_law, wrapper: :with_label
+
+  .fields-group
     = form.input :admin_email, wrapper: :with_label
 
   .fields-group

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -137,6 +137,7 @@ en:
         admin_email: Legal notices include counternotices, court orders, takedown requests, and law enforcement requests.
         arbitration_address: Can be the same as Physical address above, or “N/A” if using email
         arbitration_website: Can be a web form, or “N/A” if using email
+        choice_of_law: City, region, territory or state the internal substantive laws of which shall govern any and all claims.
         dmca_address: For US operators, use the address registered in the DMCA Designated Agent Directory. A P.O. Box listing is available upon direct request, use the DMCA Designated Agent Post Office Box Waiver Request to email the Copyright Office and describe that you are a home-based content moderator who fears revenge or retribution for your actions and need to use a P.O. Box to remove your home address from public view.
         dmca_email: Can be the same email used for “Email address for legal notices” above
         domain: Unique identification of the online service you are providing.
@@ -338,6 +339,7 @@ en:
         admin_email: Email address for legal notices
         arbitration_address: Physical address for arbitration notices
         arbitration_website: Website for submitting arbitration notices
+        choice_of_law: Choice of Law
         dmca_address: Physical address for DMCA/copyright notices
         dmca_email: Email address for DMCA/copyright notices
         domain: Domain

--- a/config/templates/terms-of-service.md
+++ b/config/templates/terms-of-service.md
@@ -249,7 +249,7 @@ individual basis.
 ## Choice of Law
 
 Any and all claims related to or arising out of your use of, or access to the
-Instance shall be governed by internal substantive laws of New York in all
+Instance shall be governed by internal substantive laws of %{choice_of_law} in all
 respects, without regard for the jurisdiction or forum in which you are
 domiciled, reside, or located at the time of such access or use.
 

--- a/spec/controllers/admin/terms_of_service/generates_controller_spec.rb
+++ b/spec/controllers/admin/terms_of_service/generates_controller_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe Admin::TermsOfService::GeneratesController do
             dmca_email: 'dmca@host.example',
             domain: 'host.example',
             jurisdiction: 'Europe',
+            choice_of_law: 'New York',
           },
         }
       end


### PR DESCRIPTION
Instead of always using "New York" in the terms of service template, allow it to be filled in the generator.

___

Fixes MAS-345