### PR TITLE
Cause Request.Socket.open to check `/etc/hosts` as well as DNS when resolving hostnames.

### DIFF
--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -267,8 +267,9 @@ class Request
           Resolv::DNS.open do |dns|
             dns.timeouts = 5
             addresses = dns.getaddresses(host)
-            addresses = addresses.filter { |addr| addr.is_a?(Resolv::IPv6) }.take(2) + addresses.filter { |addr| !addr.is_a?(Resolv::IPv6) }.take(2)
           end
+          addresses.concat(Resolv::Hosts.new().getaddresses(host))
+          addresses = addresses.filter { |addr| addr.is_a?(Resolv::IPv6) }.take(2) + addresses.filter { |addr| !addr.is_a?(Resolv::IPv6) }.take(2)
         end
 
         socks = []


### PR DESCRIPTION
I'm new to Mastodon development, so I'm not sure how the team will feel about this. It could be that there was a deliberate choice to ignore `/etc/hosts` (tho if there was, I'll cancel this PR & submit another documenting that fact in the code).

During development, it can be useful to add entries to `/etc/hosts` in the Docker container (to test ActivityPub federation, e.g.). The Socket implementation in Request currently ignores `/etc/hosts`, and only consults DNS. This patch changes that.