### PR TITLE
Fix up the off by one error on displayed rank for trending tags admin page.

### DIFF
--- a/app/views/admin/trends/tags/_tag.html.haml
+++ b/app/views/admin/trends/tags/_tag.html.haml
@@ -13,7 +13,7 @@
 
       - if tag.trendable?
         ·
-        %abbr{ title: t('admin.trends.tags.current_score', score: tag.trend.score) }= t('admin.trends.tags.trending_rank', rank: tag.trend.rank + 1)
+        %abbr{ title: t('admin.trends.tags.current_score', score: tag.trend.score) }= t('admin.trends.tags.trending_rank', rank: tag.trend.rank)
 
         - if tag.decaying?
           ·


### PR DESCRIPTION
This one has just bugged me a little bit when I pop in my trending tags page, and was a quick fix.

The row_number() window function that is used in [app/models/concerns/ranked_trend.rb](https://github.com/mastodon/mastodon/blob/main/app/models/concerns/ranked_trend.rb) to rank the trending items, counts starting from 1, as seen in [the PostgreSQL documentation on window functions](https://www.postgresql.org/docs/current/functions-window.html).

Thus, we do not need to add 1 to the rank before displaying it. This also brings the trending tags view in line with the views for trending [statuses](https://github.com/mastodon/mastodon/blob/main/app/views/admin/trends/statuses/_status.html.haml) and [links](https://github.com/mastodon/mastodon/blob/main/app/views/admin/trends/links/_preview_card.html.haml).

Please let me know if there are any issues, this is my first pull request against Mastodon. Thank you for your time reviewing it.