### PR TITLE
Add alt text back again

### DIFF
--- a/app/javascript/mastodon/components/media_gallery.jsx
+++ b/app/javascript/mastodon/components/media_gallery.jsx
@@ -145,6 +145,7 @@ class Item extends PureComponent {
             srcSet={srcSet}
             sizes={sizes}
             alt={description}
+            title={description}
             lang={lang}
             style={{ objectPosition: `${x}% ${y}%` }}
             onLoad={this.handleImageLoad}
@@ -166,6 +167,7 @@ class Item extends PureComponent {
           <video
             className='media-gallery__item-gifv-thumbnail'
             aria-label={description}
+            title={description}
             lang={lang}
             role='application'
             src={attachment.get('url')}

--- a/app/javascript/mastodon/features/account_gallery/components/media_item.tsx
+++ b/app/javascript/mastodon/features/account_gallery/components/media_item.tsx
@@ -93,6 +93,7 @@ export const MediaItem: React.FC<{
         <img
           src={previewUrl || avatarUrl}
           alt={description}
+          title={description}
           lang={lang}
           onLoad={handleImageLoad}
         />
@@ -112,6 +113,7 @@ export const MediaItem: React.FC<{
       <img
         src={previewUrl}
         alt={description}
+        title={description}
         lang={lang}
         style={{ objectPosition: `${x}% ${y}%` }}
         onLoad={handleImageLoad}
@@ -129,6 +131,7 @@ export const MediaItem: React.FC<{
         <video
           className='media-gallery__item-gifv-thumbnail'
           aria-label={description}
+          title={description}
           lang={lang}
           src={fullUrl}
           onMouseEnter={handleMouseEnter}


### PR DESCRIPTION
Fixes https://github.com/mastodon/mastodon/issues/33799, reverts https://github.com/mastodon/mastodon/pull/33736

At the risk of sounding like "this broke my workflow"; it broke my years-long workflow and expectation to simply hover over images to get a system tooltip for its alt text, *just like every other website*, so I'd like to think that the change to remove it was made in error.

While I get and understand that the alt text button can be more ergonomic; it's not standard HTML, it becomes more like a PWA.

----

If the change isn't acceptable in the current form, I can remake it so that it becomes dependent on user-configurable settings.