### PR TITLE
Add FASP account search support

### DIFF
--- a/app/services/account_search_service.rb
+++ b/app/services/account_search_service.rb
@@ -178,6 +178,12 @@ class AccountSearchService < BaseService
         'search.backend' => Chewy.enabled? ? 'elasticsearch' : 'database'
       )
 
+      # Trigger searching accounts using providers.
+      # This will not return any immediate results but has the
+      # potential to fill the local database with relevant
+      # accounts for the next time the search is performed.
+      Fasp::AccountSearchWorker.perform_async(@query)
+
       search_service_results.compact.uniq.tap do |results|
         span.set_attribute('search.results.count', results.size)
       end

--- a/app/services/account_search_service.rb
+++ b/app/services/account_search_service.rb
@@ -182,7 +182,7 @@ class AccountSearchService < BaseService
       # This will not return any immediate results but has the
       # potential to fill the local database with relevant
       # accounts for the next time the search is performed.
-      Fasp::AccountSearchWorker.perform_async(@query)
+      Fasp::AccountSearchWorker.perform_async(@query) if options[:query_fasp]
 
       search_service_results.compact.uniq.tap do |results|
         span.set_attribute('search.results.count', results.size)

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -11,6 +11,7 @@ class SearchService < BaseService
     @offset    = options[:type].blank? ? 0 : options[:offset].to_i
     @resolve   = options[:resolve] || false
     @following = options[:following] || false
+    @query_fasp = options[:query_fasp] || false
 
     default_results.tap do |results|
       next if @query.blank? || @limit.zero?
@@ -36,7 +37,8 @@ class SearchService < BaseService
       offset: @offset,
       use_searchable_text: true,
       following: @following,
-      start_with_hashtag: @query.start_with?('#')
+      start_with_hashtag: @query.start_with?('#'),
+      query_fasp: @options[:query_fasp]
     )
   end
 

--- a/app/workers/fasp/account_search_worker.rb
+++ b/app/workers/fasp/account_search_worker.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class Fasp::AccountSearchWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: 'fasp', retry: 0
+
+  def perform(query)
+    return unless Mastodon::Feature.fasp_enabled?
+
+    account_search_providers = Fasp::Provider.with_capability('account_search')
+    return if account_search_providers.none?
+
+    params = { term: query, limit: 10 }.to_query
+    fetch_service = ActivityPub::FetchRemoteActorService.new
+
+    account_search_providers.each do |provider|
+      Fasp::Request.new(provider).get("/account_search/v0/search?#{params}").each do |uri|
+        next if Account.where(uri:).any?
+
+        fetch_service.call(uri)
+      end
+    end
+  end
+end

--- a/app/workers/fasp/account_search_worker.rb
+++ b/app/workers/fasp/account_search_worker.rb
@@ -8,6 +8,8 @@ class Fasp::AccountSearchWorker
   def perform(query)
     return unless Mastodon::Feature.fasp_enabled?
 
+    async_refresh = AsyncRefresh.new("fasp:account_search:#{Digest::MD5.base64digest(query)}")
+
     account_search_providers = Fasp::Provider.with_capability('account_search')
     return if account_search_providers.none?
 
@@ -18,8 +20,11 @@ class Fasp::AccountSearchWorker
       Fasp::Request.new(provider).get("/account_search/v0/search?#{params}").each do |uri|
         next if Account.where(uri:).any?
 
-        fetch_service.call(uri)
+        account = fetch_service.call(uri)
+        async_refresh.increment_result_count(by: 1) if account.present?
       end
     end
+  ensure
+    async_refresh&.finish!
   end
 end

--- a/spec/fabricators/fasp/provider_fabricator.rb
+++ b/spec/fabricators/fasp/provider_fabricator.rb
@@ -41,3 +41,15 @@ Fabricator(:follow_recommendation_fasp, from: :fasp_provider) do
     def fasp.update_remote_capabilities = true
   end
 end
+
+Fabricator(:account_search_fasp, from: :fasp_provider) do
+  confirmed    true
+  capabilities [
+    { id: 'account_search', version: '0.1', enabled: true },
+  ]
+
+  after_build do |fasp|
+    # Prevent fabrication from attempting an HTTP call to the provider
+    def fasp.update_remote_capabilities = true
+  end
+end

--- a/spec/requests/api/v2/search_spec.rb
+++ b/spec/requests/api/v2/search_spec.rb
@@ -118,6 +118,15 @@ RSpec.describe 'Search API' do
             .to start_with('application/json')
         end
       end
+
+      context 'when `account_search` FASP is enabled', feature: :fasp do
+        it 'enqueues a retrieval job and adds a header to inform the client' do
+          get '/api/v2/search', headers: headers, params: params
+
+          expect(Fasp::AccountSearchWorker).to have_enqueued_sidekiq_job
+          expect(response.headers['Mastodon-Async-Refresh']).to be_present
+        end
+      end
     end
   end
 

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe SearchService do
           allow(AccountSearchService).to receive(:new).and_return(service)
 
           results = subject.call(query, nil, 10)
-          expect(service).to have_received(:call).with(query, nil, limit: 10, offset: 0, resolve: false, start_with_hashtag: false, use_searchable_text: true, following: false)
+          expect(service).to have_received(:call).with(query, nil, limit: 10, offset: 0, resolve: false, start_with_hashtag: false, use_searchable_text: true, following: false, query_fasp: nil)
           expect(results).to eq empty_results.merge(accounts: [account])
         end
       end

--- a/spec/workers/fasp/account_search_worker_spec.rb
+++ b/spec/workers/fasp/account_search_worker_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Fasp::AccountSearchWorker, feature: :fasp do
+  include ProviderRequestHelper
+
+  let(:provider) { Fabricate(:account_search_fasp) }
+  let(:account) { Fabricate(:account) }
+  let(:fetch_service) { instance_double(ActivityPub::FetchRemoteActorService, call: true) }
+
+  let!(:stubbed_request) do
+    path = '/account_search/v0/search?term=cats&limit=10'
+    stub_provider_request(provider,
+                          method: :get,
+                          path:,
+                          response_body: [
+                            'https://fedi.example.com/accounts/2',
+                            'https://fedi.example.com/accounts/9',
+                          ])
+  end
+
+  before do
+    allow(ActivityPub::FetchRemoteActorService).to receive(:new).and_return(fetch_service)
+  end
+
+  it 'requests search results and fetches received account uris' do
+    described_class.new.perform('cats')
+
+    expect(stubbed_request).to have_been_made
+    expect(fetch_service).to have_received(:call).with('https://fedi.example.com/accounts/2')
+    expect(fetch_service).to have_received(:call).with('https://fedi.example.com/accounts/9')
+  end
+
+  it 'marks a running async refresh as finished' do
+    async_refresh = AsyncRefresh.create("fasp:account_search:#{Digest::MD5.base64digest('cats')}", count_results: true)
+
+    described_class.new.perform('cats')
+
+    expect(async_refresh.reload).to be_finished
+  end
+
+  it 'tracks the number of fetched accounts in the async refresh' do
+    async_refresh = AsyncRefresh.create("fasp:account_search:#{Digest::MD5.base64digest('cats')}", count_results: true)
+
+    described_class.new.perform('cats')
+
+    expect(async_refresh.reload.result_count).to eq 2
+  end
+end


### PR DESCRIPTION
This is built atop #34032 and adds support for the [`account_search`](https://github.com/mastodon/fediverse_auxiliary_service_provider_specifications/blob/main/discovery/trends/v0.1/trends.md) capability of FASP.

It works by sending user's search terms to connected FASP. If a result is returned, the corresponding actors are being fetched, so their data is available locally.

This does not (yet) improve the initial user search, but subsequent searches (and other interactions with actors that are discovered this way) will benefit from this.

Marked as draft because it is based on and in a similar state as #34032.