### PR TITLE
Bump Mastodon API version for new media deletion methods/parameters

### DIFF
--- a/lib/mastodon/version.rb
+++ b/lib/mastodon/version.rb
@@ -45,7 +45,7 @@ module Mastodon
 
     def api_versions
       {
-        mastodon: 3,
+        mastodon: 4,
       }
     end
 


### PR DESCRIPTION
Signal #33988 and #33991 through API version bump.