### PR TITLE
Rely on `haml-lint` parallel default

### DIFF
--- a/.github/workflows/lint-haml.yml
+++ b/.github/workflows/lint-haml.yml
@@ -43,4 +43,4 @@ jobs:
       - name: Run haml-lint
         run: |
           echo "::add-matcher::.github/workflows/haml-lint-problem-matcher.json"
-          bin/haml-lint --parallel --reporter github
+          bin/haml-lint --reporter github

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -3,7 +3,7 @@ const config = {
   'Gemfile|*.{rb,ruby,ru,rake}': 'bin/rubocop --force-exclusion -a',
   '*.{js,jsx,ts,tsx}': 'eslint --fix',
   '*.{css,scss}': 'stylelint --fix',
-  '*.haml': 'bin/haml-lint -a --parallel',
+  '*.haml': 'bin/haml-lint -a',
   '**/*.ts?(x)': () => 'tsc -p tsconfig.json --noEmit',
 };
 


### PR DESCRIPTION
We merged the 0.60.0 release here https://github.com/mastodon/mastodon/pull/33791 which changed this option to default to parallel, so we dont need to specify the option to get the behavior.