### PR TITLE
Fix preview cards under Content Warnings not being shown in detailed statuses

### DIFF
--- a/app/javascript/mastodon/features/status/components/detailed_status.tsx
+++ b/app/javascript/mastodon/features/status/components/detailed_status.tsx
@@ -221,12 +221,12 @@ export const DetailedStatus: React.FC<{
         />
       );
     }
-  } else if (status.get('spoiler_text').length === 0) {
+  } else if (status.get('card')) {
     media = (
       <Card
         sensitive={status.get('sensitive')}
         onOpenMedia={onOpenMedia}
-        card={status.get('card', null)}
+        card={status.get('card')}
       />
     );
   }


### PR DESCRIPTION
Follow-up to #33827