### PR TITLE
Change web client settings to be saved earlier and more often

### DIFF
--- a/app/javascript/mastodon/actions/settings.js
+++ b/app/javascript/mastodon/actions/settings.js
@@ -29,7 +29,7 @@ const debouncedSave = debounce((dispatch, getState) => {
   api().put('/api/web/settings', { data })
     .then(() => dispatch({ type: SETTING_SAVE }))
     .catch(error => dispatch(showAlertForError(error)));
-}, 5000, { trailing: true });
+}, 2000, { leading: true, trailing: true });
 
 export function saveSettings() {
   return (dispatch, getState) => debouncedSave(dispatch, getState);


### PR DESCRIPTION
Changes the debounce delay from 5 seconds to 2 seconds, and change it so that the first setting change is saved immediately.

Addresses #31718, somewhat.