### PR TITLE
Dockerfile: prevent unnecessary ffmpeg building

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,3 +20,9 @@ postgres14
 redis
 elasticsearch
 chart
+.yarn/
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions

--- a/.github/workflows/test-image-build.yml
+++ b/.github/workflows/test-image-build.yml
@@ -8,6 +8,7 @@ on:
       - .github/workflows/test-image-build.yml
       - Dockerfile
       - streaming/Dockerfile
+      - .dockerignore
 permissions:
   contents: read
 


### PR DESCRIPTION
The dockerfile is structured thus that `.yarn` gets included fairly early on. However, `.yarn/install-state.gz` is updated every time `yarn install` is invoked, which then gets copied into the dockerfile, altering the hash, causing the build process to skip over various caches (such as the `ffmpeg` download, build, and installation).

This prevents that, by aligning the `.dockerignore` file with the `.gitignore` file on these grounds, causing the build to hit the cache, even if `.yarn/install-state.gz` changes (which is not included, by this file)

---

For us, this fixes a unique problem;

On our mastodon server, we have a local checkout of our mastodon fork, build an image (to deploy to our mastodon cluster), while also installing the dependencies (`bundle install && yarn install --immutable`) to allow for `tootctl` access without needing to spawn a docker container for it.

However, after every pull, docker build, and `yarn install`, the docker file would rebuild the `ffmpeg` part *every time*. After a few instances of this, I hunted down why, and found the above file (`.yarn/install-state.gz`) being changed with every `yarn install`, and this change should fix that.