### PR TITLE
Fix processing errors for some HEIF images from iOS 18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,6 +96,9 @@ RUN \
 # Set /opt/mastodon as working directory
 WORKDIR /opt/mastodon
 
+# Add backport repository for some specific packages where we need the latest version
+RUN echo 'deb http://deb.debian.org/debian bookworm-backports main' >> /etc/apt/sources.list
+
 # hadolint ignore=DL3008,DL3005
 RUN \
   # Mount Apt cache and lib directories from Docker buildx caches
@@ -165,7 +168,7 @@ RUN \
   libexif-dev \
   libexpat1-dev \
   libgirepository1.0-dev \
-  libheif-dev \
+  libheif-dev/bookworm-backports \
   libimagequant-dev \
   libjpeg62-turbo-dev \
   liblcms2-dev \
@@ -348,7 +351,7 @@ RUN \
   # libvips components
   libcgif0 \
   libexif12 \
-  libheif1 \
+  libheif1/bookworm-backports \
   libimagequant0 \
   libjpeg62-turbo \
   liblcms2-2 \


### PR DESCRIPTION
Old versions of `libheif` have a bug with those images (related to HDR metadata). The easiest solution for us is to use `libheif` from Debian backports, which is a recent version (1.19, vs 1.15 in mainline).

The issue should happen wether `imagemagick` or `vips` is used, as this is a bug in the underlying library.

See https://github.com/libvips/libvips/issues/4169

Fixes #31570