### PR TITLE
Fix behavior of database schema loading with `SKIP_POST_DEPLOYMENT_MIGRATIONS`

### DIFF
--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -77,6 +77,18 @@ jobs:
       - name: Set up Ruby environment
         uses: ./.github/actions/setup-ruby
 
+      - name: Ensure no errors with `db:prepare`
+        run: |
+          bin/rails db:drop
+          bin/rails db:prepare
+          bin/rails db:migrate
+
+      - name: Ensure no errors with `db:prepare` and SKIP_POST_DEPLOYMENT_MIGRATIONS
+        run: |
+          bin/rails db:drop
+          SKIP_POST_DEPLOYMENT_MIGRATIONS=true bin/rails db:prepare
+          bin/rails db:migrate
+
       - name: Test "one step migration" flow
         run: |
           bin/rails db:drop

--- a/config/initializers/0_post_deployment_migrations.rb
+++ b/config/initializers/0_post_deployment_migrations.rb
@@ -4,14 +4,4 @@
 # before other initializers as Rails may otherwise memoize a list of migrations
 # excluding the post deployment migrations.
 
-unless ENV['SKIP_POST_DEPLOYMENT_MIGRATIONS']
-  Rails.application.config.paths['db'].each do |db_path|
-    path = Rails.root.join(db_path, 'post_migrate').to_s
-
-    Rails.application.config.paths['db/migrate'] << path
-
-    # Rails memoizes migrations at certain points where it won't read the above
-    # path just yet. As such we must also update the following list of paths.
-    ActiveRecord::Migrator.migrations_paths << path
-  end
-end
+Mastodon::Database.add_post_migrate_path_to_rails

--- a/lib/active_record/database_tasks_extensions.rb
+++ b/lib/active_record/database_tasks_extensions.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative '../mastodon/database'
 require_relative '../mastodon/snowflake'
 
 module ActiveRecord
@@ -8,6 +9,8 @@ module ActiveRecord
       original_load_schema = instance_method(:load_schema)
 
       define_method(:load_schema) do |db_config, *args|
+        Mastodon::Database.add_post_migrate_path_to_rails(force: true)
+
         ActiveRecord::Base.establish_connection(db_config)
         Mastodon::Snowflake.define_timestamp_id
 

--- a/lib/mastodon/database.rb
+++ b/lib/mastodon/database.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# This file is entirely lifted from GitLab.
+
+# The original file:
+# https://gitlab.com/gitlab-org/gitlab/-/blob/69127d59467185cf4ff1109d88ceec1f499f354f/lib/gitlab/database.rb#L244-258
+
+# Copyright (c) 2011-present GitLab B.V.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+module Mastodon
+  module Database
+    def self.add_post_migrate_path_to_rails(force: false)
+      return if ENV['SKIP_POST_DEPLOYMENT_MIGRATIONS'] && !force
+
+      Rails.application.config.paths['db'].each do |db_path|
+        path = Rails.root.join(db_path, 'post_migrate').to_s
+
+        next if Rails.application.config.paths['db/migrate'].include?(path)
+
+        Rails.application.config.paths['db/migrate'] << path
+
+        # Rails memoizes migrations at certain points where it won't read the above
+        # path just yet. As such we must also update the following list of paths.
+        ActiveRecord::Migrator.migrations_paths << path
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently, when running `db:prepare` or `db:schema:load` with a fresh database and `SKIP_POST_DEPLOYMENT_MIGRATIONS=true`, the post-deployment migrations will not be marked as having run despite the loaded schema assuming they have been run.

This means subsequent calls to `db:migrate` will try running migrations that assume an incompatible state.

This PR makes it so post-deployment migrations are loaded regardless of `SKIP_POST_DEPLOYMENT_MIGRATIONS` whenever the schema is loaded from `schema.db`, ensuring the migrations are properly recorded as run.