### PR TITLE
Add coverage for `standard` params on push subs create

### DIFF
--- a/spec/controllers/api/web/push_subscriptions_controller_spec.rb
+++ b/spec/controllers/api/web/push_subscriptions_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Api::Web::PushSubscriptionsController do
           p256dh: 'BEm_a0bdPDhf0SOsrnB2-ategf1hHoCnpXgQsFj5JCkcoMrMt2WHoPfEYOYPzOIs9mZE8ZUaD7VA5vouy0kEkr8=',
           auth: 'eH_C8rq2raXqlcBVDa1gLg==',
         },
-        standard: 1,
+        standard: standard,
       },
     }
   end
@@ -37,6 +37,7 @@ RSpec.describe Api::Web::PushSubscriptionsController do
       },
     }
   end
+  let(:standard) { '1' }
 
   before do
     sign_in(user)
@@ -52,13 +53,25 @@ RSpec.describe Api::Web::PushSubscriptionsController do
 
       user.reload
 
-      expect(created_push_subscription).to have_attributes(
-        endpoint: eq(create_payload[:subscription][:endpoint]),
-        key_p256dh: eq(create_payload[:subscription][:keys][:p256dh]),
-        key_auth: eq(create_payload[:subscription][:keys][:auth]),
-        standard: true
-      )
+      expect(created_push_subscription)
+        .to have_attributes(
+          endpoint: eq(create_payload[:subscription][:endpoint]),
+          key_p256dh: eq(create_payload[:subscription][:keys][:p256dh]),
+          key_auth: eq(create_payload[:subscription][:keys][:auth])
+        )
+        .and be_standard
       expect(user.session_activations.first.web_push_subscription).to eq(created_push_subscription)
+    end
+
+    context 'when standard is provided as false value' do
+      let(:standard) { '0' }
+
+      it 'saves push subscription with standard as false' do
+        post :create, format: :json, params: create_payload
+
+        expect(created_push_subscription)
+          .to_not be_standard
+      end
     end
 
     context 'with a user who has a session with a prior subscription' do

--- a/spec/controllers/api/web/push_subscriptions_controller_spec.rb
+++ b/spec/controllers/api/web/push_subscriptions_controller_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Api::Web::PushSubscriptionsController do
           p256dh: 'BEm_a0bdPDhf0SOsrnB2-ategf1hHoCnpXgQsFj5JCkcoMrMt2WHoPfEYOYPzOIs9mZE8ZUaD7VA5vouy0kEkr8=',
           auth: 'eH_C8rq2raXqlcBVDa1gLg==',
         },
+        standard: 1,
       },
     }
   end
@@ -54,7 +55,8 @@ RSpec.describe Api::Web::PushSubscriptionsController do
       expect(created_push_subscription).to have_attributes(
         endpoint: eq(create_payload[:subscription][:endpoint]),
         key_p256dh: eq(create_payload[:subscription][:keys][:p256dh]),
-        key_auth: eq(create_payload[:subscription][:keys][:auth])
+        key_auth: eq(create_payload[:subscription][:keys][:auth]),
+        standard: true
       )
       expect(user.session_activations.first.web_push_subscription).to eq(created_push_subscription)
     end

--- a/spec/requests/api/v1/push/subscriptions_spec.rb
+++ b/spec/requests/api/v1/push/subscriptions_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'API V1 Push Subscriptions' do
       subscription: {
         endpoint: endpoint,
         keys: keys,
-        standard: 1,
+        standard: standard,
       },
     }.with_indifferent_access
   end
@@ -37,6 +37,7 @@ RSpec.describe 'API V1 Push Subscriptions' do
       },
     }.with_indifferent_access
   end
+  let(:standard) { '1' }
   let(:scopes) { 'push' }
   let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
@@ -65,14 +66,25 @@ RSpec.describe 'API V1 Push Subscriptions' do
           key_p256dh: eq(create_payload[:subscription][:keys][:p256dh]),
           key_auth: eq(create_payload[:subscription][:keys][:auth]),
           user_id: eq(user.id),
-          access_token_id: eq(token.id),
-          standard: true
+          access_token_id: eq(token.id)
         )
+        .and be_standard
 
       expect(response.parsed_body.with_indifferent_access)
         .to include(
           { endpoint: create_payload[:subscription][:endpoint], alerts: {}, policy: 'all' }
         )
+    end
+
+    context 'when standard is provided as false value' do
+      let(:standard) { '0' }
+
+      it 'saves push subscription with standard as false' do
+        subject
+
+        expect(endpoint_push_subscription)
+          .to_not be_standard
+      end
     end
 
     it 'replaces old subscription on repeat calls' do

--- a/spec/requests/api/v1/push/subscriptions_spec.rb
+++ b/spec/requests/api/v1/push/subscriptions_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe 'API V1 Push Subscriptions' do
       subscription: {
         endpoint: endpoint,
         keys: keys,
+        standard: 1,
       },
     }.with_indifferent_access
   end
@@ -64,7 +65,8 @@ RSpec.describe 'API V1 Push Subscriptions' do
           key_p256dh: eq(create_payload[:subscription][:keys][:p256dh]),
           key_auth: eq(create_payload[:subscription][:keys][:auth]),
           user_id: eq(user.id),
-          access_token_id: eq(token.id)
+          access_token_id: eq(token.id),
+          standard: true
         )
 
       expect(response.parsed_body.with_indifferent_access)


### PR DESCRIPTION
Resolves https://github.com/mastodon/mastodon/issues/34081

Not clear to me from that issue if there was some specific value not working correctly, but this does add a barebones check for the added param.
