### PR TITLE
Dockerfile: Limit Yarn copy operations to reduce cache impact

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -276,9 +276,6 @@ FROM build AS yarn
 
 ARG TARGETPLATFORM
 
-# Copy libvips components to layer for precompiler
-COPY --from=libvips /usr/local/libvips/bin /usr/local/bin
-COPY --from=libvips /usr/local/libvips/lib /usr/local/lib
 # Copy Node.js package configuration files into working directory
 COPY package.json yarn.lock .yarnrc.yml /opt/mastodon/
 COPY streaming/package.json /opt/mastodon/streaming/
@@ -306,6 +303,9 @@ FROM build AS precompiler
 # Copy Mastodon sources into precompiler layer
 COPY . /opt/mastodon/
 
+# Copy libvips components to layer for precompiler
+COPY --from=libvips /usr/local/libvips/bin /usr/local/bin
+COPY --from=libvips /usr/local/libvips/lib /usr/local/lib
 # Copy bundler and Node.js packages from build layer to container
 COPY --from=yarn /opt/mastodon /opt/mastodon/
 COPY --from=bundler /opt/mastodon /opt/mastodon/

--- a/Dockerfile
+++ b/Dockerfile
@@ -128,13 +128,6 @@ RUN \
 # Create temporary build layer from base image
 FROM ruby AS build
 
-# Copy Node package configuration files into working directory
-COPY package.json yarn.lock .yarnrc.yml /opt/mastodon/
-COPY .yarn /opt/mastodon/.yarn
-
-COPY --from=node /usr/local/bin /usr/local/bin
-COPY --from=node /usr/local/lib /usr/local/lib
-
 ARG TARGETPLATFORM
 
 # hadolint ignore=DL3008
@@ -187,12 +180,6 @@ RUN \
   libx264-dev \
   libx265-dev \
   ;
-
-RUN \
-  # Configure Corepack
-  rm /usr/local/bin/yarn*; \
-  corepack enable; \
-  corepack prepare --activate;
 
 # Create temporary libvips specific build layer from build layer
 FROM build AS libvips
@@ -293,6 +280,15 @@ ARG TARGETPLATFORM
 COPY package.json yarn.lock .yarnrc.yml /opt/mastodon/
 COPY streaming/package.json /opt/mastodon/streaming/
 COPY .yarn /opt/mastodon/.yarn
+# Copy node binaries/libraries to layer
+COPY --from=node /usr/local/bin /usr/local/bin
+COPY --from=node /usr/local/lib /usr/local/lib
+
+RUN \
+  # Configure Corepack
+  rm /usr/local/bin/yarn*; \
+  corepack enable; \
+  corepack prepare --activate;
 
 # hadolint ignore=DL3008
 RUN \
@@ -311,9 +307,15 @@ COPY . /opt/mastodon/
 COPY --from=yarn /opt/mastodon /opt/mastodon/
 COPY --from=bundler /opt/mastodon /opt/mastodon/
 COPY --from=bundler /usr/local/bundle/ /usr/local/bundle/
-# Copy libvips components to layer for precompiler
-COPY --from=libvips /usr/local/libvips/bin /usr/local/bin
-COPY --from=libvips /usr/local/libvips/lib /usr/local/lib
+# Copy node binaries/libraries to layer
+COPY --from=node /usr/local/bin /usr/local/bin
+COPY --from=node /usr/local/lib /usr/local/lib
+
+RUN \
+  # Configure Corepack
+  rm /usr/local/bin/yarn*; \
+  corepack enable; \
+  corepack prepare --activate;
 
 ARG TARGETPLATFORM
 


### PR DESCRIPTION
As noted in #34084 this moves the copy operations for Node, Yarn, Corepack from the `build` layer into the specific `yarn` and `precompiler` layers where it's needed. Some of these copy operations already duplicated in those layers. 

Taking them out of the `build` layer removes their availability during the `ffmpeg` and `libvips` compile operations, with the goal of minimizing changes to those layers that would trigger cache changes that require them to be rebuilt unnecessarily. 