### PR TITLE
Remove `admin_user` helper method from `SystemHelpers` module

### DIFF
--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 module SystemHelpers
-  def admin_user
-    Fabricate(:admin_user)
-  end
-
   def submit_button
     I18n.t('generic.save_changes')
   end

--- a/spec/system/admin/announcements/previews_spec.rb
+++ b/spec/system/admin/announcements/previews_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Admin Announcements Mail Previews' do
+  let(:admin_user) { Fabricate(:admin_user) }
   let(:announcement) { Fabricate(:announcement, notification_sent_at: nil) }
 
   before { sign_in(admin_user) }

--- a/spec/system/admin/relationships_spec.rb
+++ b/spec/system/admin/relationships_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe 'Admin Relationships' do
+  let(:admin_user) { Fabricate(:admin_user) }
+
   before { sign_in(admin_user) }
 
   describe 'Viewing account relationships page' do

--- a/spec/system/admin/settings/about_spec.rb
+++ b/spec/system/admin/settings/about_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe 'Admin::Settings::About' do
 
   it 'Saves changes to about settings' do
     visit admin_settings_about_path
+    expect(page)
+      .to have_title(I18n.t('admin.settings.about.title'))
 
     fill_in extended_description_field,
             with: 'new site description'

--- a/spec/system/admin/settings/about_spec.rb
+++ b/spec/system/admin/settings/about_spec.rb
@@ -3,8 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe 'Admin::Settings::About' do
+  let(:admin_user) { Fabricate(:admin_user) }
+
+  before { sign_in(admin_user) }
+
   it 'Saves changes to about settings' do
-    sign_in admin_user
     visit admin_settings_about_path
 
     fill_in extended_description_field,

--- a/spec/system/admin/settings/appearance_spec.rb
+++ b/spec/system/admin/settings/appearance_spec.rb
@@ -3,8 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe 'Admin::Settings::Appearance' do
+  let(:admin_user) { Fabricate(:admin_user) }
+
+  before { sign_in(admin_user) }
+
   it 'Saves changes to appearance settings' do
-    sign_in admin_user
     visit admin_settings_appearance_path
 
     fill_in custom_css_field,

--- a/spec/system/admin/settings/appearance_spec.rb
+++ b/spec/system/admin/settings/appearance_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe 'Admin::Settings::Appearance' do
 
   it 'Saves changes to appearance settings' do
     visit admin_settings_appearance_path
+    expect(page)
+      .to have_title(I18n.t('admin.settings.appearance.title'))
 
     fill_in custom_css_field,
             with: 'html { display: inline; }'

--- a/spec/system/admin/settings/branding_spec.rb
+++ b/spec/system/admin/settings/branding_spec.rb
@@ -3,8 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe 'Admin::Settings::Branding' do
+  let(:admin_user) { Fabricate(:admin_user) }
+
+  before { sign_in(admin_user) }
+
   it 'Saves changes to branding settings' do
-    sign_in admin_user
     visit admin_settings_branding_path
 
     fill_in short_description_field,

--- a/spec/system/admin/settings/branding_spec.rb
+++ b/spec/system/admin/settings/branding_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe 'Admin::Settings::Branding' do
 
   it 'Saves changes to branding settings' do
     visit admin_settings_branding_path
+    expect(page)
+      .to have_title(I18n.t('admin.settings.branding.title'))
 
     fill_in short_description_field,
             with: 'new key value'

--- a/spec/system/admin/settings/content_retention_spec.rb
+++ b/spec/system/admin/settings/content_retention_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe 'Admin::Settings::ContentRetention' do
 
   it 'Saves changes to content retention settings' do
     visit admin_settings_content_retention_path
+    expect(page)
+      .to have_title(I18n.t('admin.settings.content_retention.title'))
 
     fill_in media_cache_retention_period_field,
             with: '2'

--- a/spec/system/admin/settings/content_retention_spec.rb
+++ b/spec/system/admin/settings/content_retention_spec.rb
@@ -3,8 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe 'Admin::Settings::ContentRetention' do
+  let(:admin_user) { Fabricate(:admin_user) }
+
+  before { sign_in(admin_user) }
+
   it 'Saves changes to content retention settings' do
-    sign_in admin_user
     visit admin_settings_content_retention_path
 
     fill_in media_cache_retention_period_field,

--- a/spec/system/admin/settings/discovery_spec.rb
+++ b/spec/system/admin/settings/discovery_spec.rb
@@ -3,8 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe 'Admin::Settings::Discovery' do
+  let(:admin_user) { Fabricate(:admin_user) }
+
+  before { sign_in(admin_user) }
+
   it 'Saves changes to discovery settings' do
-    sign_in admin_user
     visit admin_settings_discovery_path
 
     check trends_box

--- a/spec/system/admin/settings/discovery_spec.rb
+++ b/spec/system/admin/settings/discovery_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe 'Admin::Settings::Discovery' do
 
   it 'Saves changes to discovery settings' do
     visit admin_settings_discovery_path
+    expect(page)
+      .to have_title(I18n.t('admin.settings.discovery.title'))
 
     check trends_box
 

--- a/spec/system/admin/settings/registrations_spec.rb
+++ b/spec/system/admin/settings/registrations_spec.rb
@@ -3,8 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe 'Admin::Settings::Registrations' do
+  let(:admin_user) { Fabricate(:admin_user) }
+
+  before { sign_in(admin_user) }
+
   it 'Saves changes to registrations settings' do
-    sign_in admin_user
     visit admin_settings_registrations_path
 
     select open_mode_option,

--- a/spec/system/admin/settings/registrations_spec.rb
+++ b/spec/system/admin/settings/registrations_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe 'Admin::Settings::Registrations' do
 
   it 'Saves changes to registrations settings' do
     visit admin_settings_registrations_path
+    expect(page)
+      .to have_title(I18n.t('admin.settings.registrations.title'))
 
     select open_mode_option,
            from: registrations_mode_field

--- a/spec/system/admin/terms_of_service/drafts_spec.rb
+++ b/spec/system/admin/terms_of_service/drafts_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe 'Admin TermsOfService Drafts' do
+  let(:admin_user) { Fabricate(:admin_user) }
+
   before { sign_in(admin_user) }
 
   describe 'Managing TOS drafts' do

--- a/spec/system/admin/terms_of_service/generates_spec.rb
+++ b/spec/system/admin/terms_of_service/generates_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe 'Admin TermsOfService Generates' do
+  let(:admin_user) { Fabricate(:admin_user) }
+
   before { sign_in(admin_user) }
 
   describe 'Generating a TOS policy' do

--- a/spec/system/admin/terms_of_service/previews_spec.rb
+++ b/spec/system/admin/terms_of_service/previews_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Admin TermsOfService Previews' do
   let(:terms_of_service) { Fabricate(:terms_of_service, notification_sent_at: nil) }
+  let(:admin_user) { Fabricate(:admin_user) }
 
   before { sign_in(admin_user) }
 


### PR DESCRIPTION
I started doing a followup to https://github.com/mastodon/mastodon/pull/33973 to use this method in MORE places (WIP here - https://github.com/mastodon/mastodon/compare/main...mjankowski:admin-user-system-helpers?expand=1 ) but as I worked through it I changed my mind on the usefulness of this in the first place:

- It has an element of "mystery guest" to it - not totally clear where the var/method comes from if you dont know the helpers exist
- Because it was not memoized, it makes using it multiple times not work as expected ... and if we DO memoize it, its basically a `let` at that point

So the changes here:

- Remove the `admin_user` method in favour of just defining and using it where needed in the specs
- While in here, add some page title assertions to the admin/settings system specs
- Move some of the signing in to `before`, mostly to be consistent with how almost all of the rest of these have been going

I still think the linked PR (using more of the existing helpers) makes sense and is useful - just this one specifically I think is questionable.