### PR TITLE
chore: Allow yuvj420p (full color range yuv420p) movies passthrough

### DIFF
--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -115,7 +115,7 @@ class MediaAttachment < ApplicationRecord
   VIDEO_PASSTHROUGH_OPTIONS = {
     video_codecs: ['h264'].freeze,
     audio_codecs: ['aac', nil].freeze,
-    colorspaces: ['yuv420p'].freeze,
+    colorspaces: ['yuv420p', 'yuvj420p'].freeze,
     options: {
       format: 'mp4',
       convert_options: {


### PR DESCRIPTION
If input video is using full color range and yuv420p, ffprobe says its yuv**j**420p, not a yuv420p.

(I heared **j** means JPEG, but I can't find reliable source)

but yuvj420p video is still playable on devices which only supports yuv420p, I tested on:

* iPhone 5s + iOS 12.x Safari
* New Nintendo 3DS web browser
* PlayStation Vita

and since current transcode settings isn't configured to convert color range to limited, Mastodon will try to transcode yuvj420p videos but it stays as yuvj420p.

I guess, which means If you upload full color range videos to Mastodon, It will causes to re-transcode on each federated server(s) ~~(not tested though)~~ UPDATE: tested, it does

this pull-request resolve it by simply allow `yuvj420p` colorspace.

(maybe you want to backport this p-r to older versions for reduce transcode)