### PR TITLE
Make `Faker` generate unique TOS effective dates

### DIFF
--- a/spec/fabricators/terms_of_service_fabricator.rb
+++ b/spec/fabricators/terms_of_service_fabricator.rb
@@ -5,5 +5,5 @@ Fabricator(:terms_of_service) do
   changelog { Faker::Lorem.paragraph }
   published_at { Time.zone.now }
   notification_sent_at { Time.zone.now }
-  effective_date { Faker::Date.forward }
+  effective_date { Faker::Date.unique.forward }
 end


### PR DESCRIPTION
I saw a test failure here: https://github.com/mastodon/mastodon/actions/runs/13759958750/job/38473991335

While `Faker::Date.forward` generates random future dates, it can, as this case shows, generate duplicate values.

This change should make specs more robust by asking faker to generate unique values.