### PR TITLE
Move feature flag test setup into config

### DIFF
--- a/config/mastodon.yml
+++ b/config/mastodon.yml
@@ -11,4 +11,4 @@ shared:
     metadata: <%= ENV.fetch('MASTODON_VERSION_METADATA', nil) %>
     prerelease: <%= ENV.fetch('MASTODON_VERSION_PRERELEASE', nil) %>
 test:
-  experimental_features: <%= ENV.fetch('EXPERIMENTAL_FEATURES', 'testing_only') %>
+  experimental_features: <%= [ENV.fetch('EXPERIMENTAL_FEATURES', nil), 'testing_only'].compact.join(',') %>

--- a/config/mastodon.yml
+++ b/config/mastodon.yml
@@ -11,4 +11,4 @@ shared:
     metadata: <%= ENV.fetch('MASTODON_VERSION_METADATA', nil) %>
     prerelease: <%= ENV.fetch('MASTODON_VERSION_PRERELEASE', nil) %>
 test:
-  experimental_features: fasp
+  experimental_features: <%= ENV.fetch('EXPERIMENTAL_FEATURES', 'testing_only') %>

--- a/config/mastodon.yml
+++ b/config/mastodon.yml
@@ -10,3 +10,5 @@ shared:
   version:
     metadata: <%= ENV.fetch('MASTODON_VERSION_METADATA', nil) %>
     prerelease: <%= ENV.fetch('MASTODON_VERSION_PRERELEASE', nil) %>
+test:
+  experimental_features: fasp

--- a/lib/mastodon/feature.rb
+++ b/lib/mastodon/feature.rb
@@ -19,8 +19,8 @@ module Mastodon::Feature
       super
     end
 
-    def respond_to_missing?(name)
-      name.to_s.end_with?('_enabled?')
+    def respond_to_missing?(name, include_all = false)
+      name.to_s.end_with?('_enabled?') || super
     end
   end
 end

--- a/spec/lib/mastodon/feature_spec.rb
+++ b/spec/lib/mastodon/feature_spec.rb
@@ -3,21 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Mastodon::Feature do
-  around do |example|
-    original_value = Rails.configuration.x.mastodon.experimental_features
-    Rails.configuration.x.mastodon.experimental_features = 'fasp,fetch_all_replies'
-    example.run
-    Rails.configuration.x.mastodon.experimental_features = original_value
-  end
-
   describe '::fasp_enabled?' do
     subject { described_class.fasp_enabled? }
-
-    it { is_expected.to be true }
-  end
-
-  describe '::fetch_all_replies_enabled?' do
-    subject { described_class.fetch_all_replies_enabled? }
 
     it { is_expected.to be true }
   end

--- a/spec/lib/mastodon/feature_spec.rb
+++ b/spec/lib/mastodon/feature_spec.rb
@@ -3,15 +3,23 @@
 require 'rails_helper'
 
 RSpec.describe Mastodon::Feature do
-  describe '::fasp_enabled?' do
-    subject { described_class.fasp_enabled? }
+  describe '::testing_only_enabled?' do
+    subject { described_class.testing_only_enabled? }
 
     it { is_expected.to be true }
   end
 
   describe '::unspecified_feature_enabled?' do
-    subject { described_class.unspecified_feature_enabled? }
+    context 'when example is not tagged with a feature' do
+      subject { described_class.unspecified_feature_enabled? }
 
-    it { is_expected.to be false }
+      it { is_expected.to be false }
+    end
+
+    context 'when example is tagged with a feature', feature: 'unspecified_feature' do
+      subject { described_class.unspecified_feature_enabled? }
+
+      it { is_expected.to be true }
+    end
   end
 end

--- a/spec/support/feature_flags.rb
+++ b/spec/support/feature_flags.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  config.before(:example, :feature) do |example|
+    feature = example.metadata[:feature]
+    allow(Mastodon::Feature).to receive(:"#{feature}_enabled?").and_return(true)
+  end
+end


### PR DESCRIPTION
Follow-up to #34038 

There, I tried to make it so that feature flags could be tested dynamically. But mindful of performance I also memoized a lot.

Turns out this does not really work together: Once you actually exercise code that *uses* those feature flags, memoization kicks in and the feature flag tests fail.

I pondered a couple of possible changes and then settled on this one here: Rails already supports environment-specific overrides in config files, so I just moved the test setup to that.

Besides making tests more robust this has a second advantage: It makes it a lot easier to test the actual features under those flags and make sure they do not interfere with existing code.