### PR TITLE
Fix Stoplight errors when using `REDIS_NAMESPACE`

### DIFF
--- a/lib/redis/namespace_extensions.rb
+++ b/lib/redis/namespace_extensions.rb
@@ -5,6 +5,10 @@ class Redis
     def exists?(...)
       call_with_namespace('exists?', ...)
     end
+
+    def with
+      yield self
+    end
   end
 end
 


### PR DESCRIPTION
Fixes #34082

This basically does not impact Mastodon `main`, but it does not hurt to redefine `Redis::Namespace#with` since it is used by `RedLock` with assumptions that don't quite match the implementation provided by ActiveSupport.

This needs to be backported to 4.3, 4.2 and 4.1.

Indeed, `RedLock` 1.3.2, which we depend on indirectly through the `stoplight` gem, calls `.with` on the passed redis connection object, or redefines it if `.with` is not defined. The expectation is that `@redis.with` yields a Redis connection, possibly out of a connection pool.

No version of `redis-namespace` explicitly defines `Redis::Namespace#with`. The versions we use in Mastodon v4.1 and v4.2 instead forward it to the underlying Redis connection object, “escaping” the namespace.

The version we use in Mastodon v4.3 does not define `Redis::Namespace#with` at all, but it gets added by ActiveSupport's core extensions.

The version of ActiveSupport we use in `main` defines `with` to yield itself, but the version we use in v4.3 does not pass an argument to `yield`.

This means the impact of this bug is:
- `main`: none
- `4.3`: `NoMethodError` on trying to call methods on `nil` when using `REDIS_NAMESPACE` (#34082)
- earlier than `4.3`: stoplight controls are, at least in part, “escaping” the set `REDIS_NAMESPACE`, which means they could be littering the namespace of other applications, or other Mastodon instances depending on configuration: the impact is likely low, but would be stoplight competing for locks or counting failures multiple times across instances running with the same Redis instance