### PR TITLE
Remove faker usage from fabricators

### DIFF
--- a/spec/fabricators/account_fabricator.rb
+++ b/spec/fabricators/account_fabricator.rb
@@ -6,7 +6,7 @@ private_key = keypair.to_pem
 
 Fabricator(:account) do
   transient :suspended, :silenced
-  username            { sequence(:username) { |i| "#{Faker::Internet.user_name(separators: %w(_))}#{i}" } }
+  username            { sequence(:username) { |i| "account_user_#{i}" } }
   last_webfingered_at { Time.now.utc }
   public_key          { public_key }
   private_key         { private_key }

--- a/spec/fabricators/account_moderation_note_fabricator.rb
+++ b/spec/fabricators/account_moderation_note_fabricator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Fabricator(:account_moderation_note) do
-  content { Faker::Lorem.sentences }
+  content { 'Account moderation note content' }
   account { Fabricate.build(:account) }
   target_account { Fabricate.build(:account) }
 end

--- a/spec/fabricators/account_warning_fabricator.rb
+++ b/spec/fabricators/account_warning_fabricator.rb
@@ -3,6 +3,6 @@
 Fabricator(:account_warning) do
   account { Fabricate.build(:account) }
   target_account(fabricator: :account)
-  text { Faker::Lorem.paragraph }
+  text { 'Account warning text' }
   action 'suspend'
 end

--- a/spec/fabricators/account_warning_preset_fabricator.rb
+++ b/spec/fabricators/account_warning_preset_fabricator.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 Fabricator(:account_warning_preset) do
-  text { Faker::Lorem.paragraph }
+  text { 'Account warning preset text' }
 end

--- a/spec/fabricators/announcement_fabricator.rb
+++ b/spec/fabricators/announcement_fabricator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Fabricator(:announcement) do
-  text      { Faker::Lorem.paragraph(sentence_count: 2) }
+  text      { 'An announcement has been made. This is that very announcement.' }
   published true
   starts_at nil
   ends_at   nil

--- a/spec/fabricators/appeal_fabricator.rb
+++ b/spec/fabricators/appeal_fabricator.rb
@@ -3,5 +3,5 @@
 Fabricator(:appeal) do
   strike(fabricator: :account_warning)
   account { |attrs| attrs[:strike].target_account }
-  text { Faker::Lorem.paragraph }
+  text { 'Appeal text' }
 end

--- a/spec/fabricators/canonical_email_block_fabricator.rb
+++ b/spec/fabricators/canonical_email_block_fabricator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 Fabricator(:canonical_email_block) do
-  email { sequence(:email) { |i| "#{i}#{Faker::Internet.email}" } }
+  email { sequence(:email) { |i| "email_#{i}@host.example" } }
   reference_account { Fabricate.build(:account) }
 end

--- a/spec/fabricators/domain_block_fabricator.rb
+++ b/spec/fabricators/domain_block_fabricator.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 Fabricator(:domain_block) do
-  domain { sequence(:domain) { |i| "#{i}#{Faker::Internet.domain_name}" } }
+  domain { sequence(:domain) { |i| "host-#{i}-name.example" } }
 end

--- a/spec/fabricators/email_domain_block_fabricator.rb
+++ b/spec/fabricators/email_domain_block_fabricator.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 Fabricator(:email_domain_block) do
-  domain { sequence(:domain) { |i| "#{i}#{Faker::Internet.domain_name}" } }
+  domain { sequence(:domain) { |i| "host-#{i}-name.example" } }
 end

--- a/spec/fabricators/fasp/provider_fabricator.rb
+++ b/spec/fabricators/fasp/provider_fabricator.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 Fabricator(:fasp_provider, from: 'Fasp::Provider') do
-  name                    { Faker::App.name }
-  base_url                { Faker::Internet.unique.url }
-  sign_in_url             { Faker::Internet.url }
+  name                    { 'FASP Provider Name' }
+  base_url                { sequence { |n| "https://host-#{n}.example" } }
+  sign_in_url             { 'https://host.example/sign-in' }
   remote_identifier       'MyString'
   provider_public_key_pem "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAh2ldXsaej2MXj0DHdCx7XibSo66uKlrLfJ5J6hte1Gk=\n-----END PUBLIC KEY-----\n"
   server_private_key_pem  "-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEICDjlajhVb8XfzyTchQWKraMKwtQW+r4opoAg7V3kw1Q\n-----END PRIVATE KEY-----\n"

--- a/spec/fabricators/login_activity_fabricator.rb
+++ b/spec/fabricators/login_activity_fabricator.rb
@@ -5,6 +5,6 @@ Fabricator(:login_activity) do
   authentication_method 'password'
   success               true
   failure_reason        nil
-  ip                    { Faker::Internet.ip_v4_address }
-  user_agent            { Faker::Internet.user_agent }
+  ip                    { '192.168.1.1' }
+  user_agent            { 'Mozilla 1.0' }
 end

--- a/spec/fabricators/preview_card_fabricator.rb
+++ b/spec/fabricators/preview_card_fabricator.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 Fabricator(:preview_card) do
-  url { Faker::Internet.url }
-  title { Faker::Lorem.sentence }
-  description { Faker::Lorem.paragraph }
+  url { sequence(:url) { |i| "https://host.example/pages/#{i}" } }
+  title { 'Preview Card title' }
+  description { 'Preview Card description text' }
   type 'link'
   image { attachment_fixture('attachment.jpg') }
 end

--- a/spec/fabricators/preview_card_provider_fabricator.rb
+++ b/spec/fabricators/preview_card_provider_fabricator.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 Fabricator(:preview_card_provider) do
-  domain { sequence(:domain) { |i| "#{i}#{Faker::Internet.domain_name}" } }
+  domain { sequence(:domain) { |i| "host-#{i}-name.example" } }
 end

--- a/spec/fabricators/report_note_fabricator.rb
+++ b/spec/fabricators/report_note_fabricator.rb
@@ -3,5 +3,5 @@
 Fabricator(:report_note) do
   report { Fabricate.build(:report) }
   account { Fabricate.build(:account) }
-  content { Faker::Lorem.sentences }
+  content { 'Report note content' }
 end

--- a/spec/fabricators/rule_fabricator.rb
+++ b/spec/fabricators/rule_fabricator.rb
@@ -3,5 +3,5 @@
 Fabricator(:rule) do
   priority   0
   deleted_at nil
-  text       { Faker::Lorem.paragraph }
+  text       { 'Rule text' }
 end

--- a/spec/fabricators/status_fabricator.rb
+++ b/spec/fabricators/status_fabricator.rb
@@ -5,6 +5,6 @@ Fabricator(:status) do
   text 'Lorem ipsum dolor sit amet'
 
   after_build do |status|
-    status.uri = Faker::Internet.device_token if !status.account.local? && status.uri.nil?
+    status.uri = SecureRandom.hex(32) if !status.account.local? && status.uri.nil?
   end
 end

--- a/spec/fabricators/tag_fabricator.rb
+++ b/spec/fabricators/tag_fabricator.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 Fabricator(:tag) do
-  name { sequence(:hashtag) { |i| "#{Faker::Lorem.word}#{i}" } }
+  name { sequence(:hashtag) { |i| "tag#{i}" } }
 end

--- a/spec/fabricators/terms_of_service_fabricator.rb
+++ b/spec/fabricators/terms_of_service_fabricator.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 Fabricator(:terms_of_service) do
-  text { Faker::Lorem.paragraph }
-  changelog { Faker::Lorem.paragraph }
+  text { 'Terms of service text' }
+  changelog { 'Terms of service changelog text' }
   published_at { Time.zone.now }
   notification_sent_at { Time.zone.now }
-  effective_date { Faker::Date.unique.forward }
+  effective_date { sequence(:effective_date) { |i| i.days.from_now } }
 end

--- a/spec/fabricators/unavailable_domain_fabricator.rb
+++ b/spec/fabricators/unavailable_domain_fabricator.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 Fabricator(:unavailable_domain) do
-  domain { sequence(:domain) { |i| "#{i}#{Faker::Internet.domain_name}" } }
+  domain { sequence(:domain) { |i| "host-#{i}-name.example" } }
 end

--- a/spec/fabricators/user_fabricator.rb
+++ b/spec/fabricators/user_fabricator.rb
@@ -7,7 +7,7 @@ Fabricator(:user) do
       attrs.fetch(:account_attributes, {}).merge(user: nil)
     )
   end
-  email        { sequence(:email) { |i| "#{i}#{Faker::Internet.email}" } }
+  email        { sequence(:email) { |i| "user_#{i}@host.example" } }
   password     '123456789'
   confirmed_at { Time.zone.now }
   current_sign_in_at { Time.zone.now }

--- a/spec/fabricators/web_push_subscription_fabricator.rb
+++ b/spec/fabricators/web_push_subscription_fabricator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Fabricator(:web_push_subscription, from: Web::PushSubscription) do
-  endpoint   Faker::Internet.url
+  endpoint   'https://host.example/endpoint'
   key_p256dh do
     curve = OpenSSL::PKey::EC.generate('prime256v1')
     ecdh_key = curve.public_key.to_bn.to_s(2)

--- a/spec/fabricators/webhook_fabricator.rb
+++ b/spec/fabricators/webhook_fabricator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Fabricator(:webhook) do
-  url { Faker::Internet.url }
+  url { sequence(:url) { |i| "https://host.example/pages/#{i}" } }
   secret { SecureRandom.hex }
   events { Webhook::EVENTS }
 end


### PR DESCRIPTION
Follow-up on https://github.com/mastodon/mastodon/pull/34122

Minimizing randomly generated values across the specs should reduce the chance of uniqueness collissions and other intermittent failure issues.