### PR TITLE
feat: use `<time>` tag

### DIFF
--- a/app/javascript/mastodon/components/edited_timestamp/index.jsx
+++ b/app/javascript/mastodon/components/edited_timestamp/index.jsx
@@ -6,6 +6,7 @@ import { FormattedMessage, injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 
 import { openModal } from 'mastodon/actions/modal';
+import { FormattedDateWrapper } from 'mastodon/components/formatted_date';
 import InlineAccount from 'mastodon/components/inline_account';
 import { RelativeTimestamp } from 'mastodon/components/relative_timestamp';
 
@@ -60,12 +61,12 @@ class EditedTimestamp extends PureComponent {
   };
 
   render () {
-    const { timestamp, intl, statusId } = this.props;
+    const { timestamp, statusId } = this.props;
 
     return (
       <DropdownMenu statusId={statusId} renderItem={this.renderItem} scrollable renderHeader={this.renderHeader} onItemClick={this.handleItemClick}>
         <button className='dropdown-menu__text-button'>
-          <FormattedMessage id='status.edited' defaultMessage='Edited {date}' values={{ date: <span className='animated-number'>{intl.formatDate(timestamp, { month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit' })}</span> }} />
+          <FormattedMessage id='status.edited' defaultMessage='Edited {date}' values={{ date: <FormattedDateWrapper className='animated-number' value={timestamp} month='short' day='2-digit' hour='2-digit' minute='2-digit' /> }} />
         </button>
       </DropdownMenu>
     );

--- a/app/javascript/mastodon/components/formatted_date.tsx
+++ b/app/javascript/mastodon/components/formatted_date.tsx
@@ -1,0 +1,26 @@
+import type { ComponentProps } from 'react';
+
+import { FormattedDate } from 'react-intl';
+
+export const FormattedDateWrapper = (
+  props: ComponentProps<typeof FormattedDate> & { className?: string },
+) => (
+  <FormattedDate {...props}>
+    {(date) => (
+      <time dateTime={tryIsoString(props.value)} className={props.className}>
+        {date}
+      </time>
+    )}
+  </FormattedDate>
+);
+
+const tryIsoString = (date?: string | number | Date): string => {
+  if (!date) {
+    return '';
+  }
+  try {
+    return new Date(date).toISOString();
+  } catch {
+    return date.toString();
+  }
+};

--- a/app/javascript/mastodon/features/account_timeline/components/account_header.tsx
+++ b/app/javascript/mastodon/features/account_timeline/components/account_header.tsx
@@ -37,6 +37,7 @@ import {
   FollowingCounter,
   StatusesCounter,
 } from 'mastodon/components/counters';
+import { FormattedDateWrapper } from 'mastodon/components/formatted_date';
 import { Icon } from 'mastodon/components/icon';
 import { IconButton } from 'mastodon/components/icon_button';
 import { LoadingIndicator } from 'mastodon/components/loading_indicator';
@@ -938,11 +939,12 @@ export const AccountHeader: React.FC<{
                       />
                     </dt>
                     <dd>
-                      {intl.formatDate(account.created_at, {
-                        year: 'numeric',
-                        month: 'short',
-                        day: '2-digit',
-                      })}
+                      <FormattedDateWrapper
+                        value={account.created_at}
+                        year='numeric'
+                        month='short'
+                        day='2-digit'
+                      />
                     </dd>
                   </dl>
 

--- a/app/javascript/mastodon/features/privacy_policy/index.tsx
+++ b/app/javascript/mastodon/features/privacy_policy/index.tsx
@@ -1,17 +1,13 @@
 import { useState, useEffect } from 'react';
 
-import {
-  FormattedMessage,
-  FormattedDate,
-  useIntl,
-  defineMessages,
-} from 'react-intl';
+import { FormattedMessage, useIntl, defineMessages } from 'react-intl';
 
 import { Helmet } from 'react-helmet';
 
 import { apiGetPrivacyPolicy } from 'mastodon/api/instance';
 import type { ApiPrivacyPolicyJSON } from 'mastodon/api_types/instance';
 import { Column } from 'mastodon/components/column';
+import { FormattedDateWrapper } from 'mastodon/components/formatted_date';
 import { Skeleton } from 'mastodon/components/skeleton';
 
 const messages = defineMessages({
@@ -58,7 +54,7 @@ const PrivacyPolicy: React.FC<{
                 date: loading ? (
                   <Skeleton width='10ch' />
                 ) : (
-                  <FormattedDate
+                  <FormattedDateWrapper
                     value={response?.updated_at}
                     year='numeric'
                     month='short'

--- a/app/javascript/mastodon/features/status/components/detailed_status.tsx
+++ b/app/javascript/mastodon/features/status/components/detailed_status.tsx
@@ -6,7 +6,7 @@
 import type { CSSProperties } from 'react';
 import { useState, useRef, useCallback } from 'react';
 
-import { FormattedDate, FormattedMessage } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
 import classNames from 'classnames';
 import { Link } from 'react-router-dom';
@@ -16,6 +16,7 @@ import { AnimatedNumber } from 'mastodon/components/animated_number';
 import { ContentWarning } from 'mastodon/components/content_warning';
 import EditedTimestamp from 'mastodon/components/edited_timestamp';
 import { FilterWarning } from 'mastodon/components/filter_warning';
+import { FormattedDateWrapper } from 'mastodon/components/formatted_date';
 import type { StatusLike } from 'mastodon/components/hashtag_bar';
 import { getHashtagBarForStatus } from 'mastodon/components/hashtag_bar';
 import { Icon } from 'mastodon/components/icon';
@@ -388,7 +389,7 @@ export const DetailedStatus: React.FC<{
               target='_blank'
               rel='noopener noreferrer'
             >
-              <FormattedDate
+              <FormattedDateWrapper
                 value={new Date(status.get('created_at') as string)}
                 year='numeric'
                 month='short'


### PR DESCRIPTION
## Summary

| message | messege (edited) |
| :-: | :-: |
| ![image](https://github.com/user-attachments/assets/adead2eb-5d44-4fe8-9404-aad98877630f) | ![image](https://github.com/user-attachments/assets/b5f508b5-3268-41a4-ab4f-ac8dc74b3c7c) |
| **account header** |  **privacy policy** |
| ![image](https://github.com/user-attachments/assets/9254d529-0a7f-4d3b-9718-572abd6da12f) | ![image](https://github.com/user-attachments/assets/87be337e-5054-4c4b-b509-446500b523eb) |

Adds [`<time>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time) tag to some of mastodon's date-time elements.

## Why?

using `<time>` tag helps with accessibility, e.g screen reader.

see: https://shkspr.mobi/blog/2020/12/making-time-more-accessible/ 

## Impacts

likely low. I've checked affected pages and they didn't seem to have noticeable changes in styles.

## Description

I've made a custom `<FormattedDateWrapper>` wrapper component that wraps `<FormattedDate>` of react-intl, in order to not wrap the time part in `<span>` (due to https://formatjs.github.io/docs/react-intl/components/#textcomponent).

I haven't touched other places that uses `FormattedDate`, such as `components/admin/Retention`, announcements, and terms of service as i weren't able to find them (at least in localhost).

<details><summary>Memo for future podman+selinux (fedora) users trying to run mastodon dev server on docker:</summary>

1. podman compose won't work without absolute path. used `podman compose -f $(pwd)/.devcontainer/compose.yaml exec app bash`
2. there's various permission issues. solved by adding `:z` to all volumes:

```diff
diff --git a/.devcontainer/compose.yaml b/.devcontainer/compose.yaml
index 4d5ed0f25..7eda32e27 100644
--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -5,7 +5,7 @@ services:
       context: ..
       dockerfile: .devcontainer/Dockerfile
     volumes:
-      - ..:/workspaces/mastodon:cached
+      - ..:/workspaces/mastodon:z,cached
     environment:
       RAILS_ENV: development
       NODE_ENV: development
@@ -35,7 +35,7 @@ services:
     image: postgres:14-alpine
     restart: unless-stopped
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql/data:z
     environment:
       POSTGRES_USER: postgres
       POSTGRES_DB: postgres
@@ -48,7 +48,7 @@ services:
     image: redis:7-alpine
     restart: unless-stopped
     volumes:
-      - redis-data:/data
+      - redis-data:/data:z
     networks:
       - internal_network
 
@@ -61,7 +61,7 @@ services:
       discovery.type: single-node
       bootstrap.memory_lock: 'true'
     volumes:
-      - es-data:/usr/share/elasticsearch/data
+      - es-data:/usr/share/elasticsearch/data:z
     networks:
       - internal_network
     ulimits:
@@ -73,7 +73,7 @@ services:
     image: libretranslate/libretranslate:v1.6.2
     restart: unless-stopped
     volumes:
-      - lt-data:/home/libretranslate/.local
+      - lt-data:/home/libretranslate/.local:z
     networks:
       - external_network
       - internal_network
```

3. [DEVELOPMENT](https://github.com/mastodon/mastodon/blob/4bd969e4bb54297981d385903bf8a4348b394f09/docs/DEVELOPMENT.md) doesn't explain how to login after running compose. despite running 

```sh
podman compose -f (pwd)/.devcontainer/compose.yaml exec app bin/setup
podman compose -f (pwd)/.devcontainer/compose.yaml exec app bin/dev
```
i couldn't login as `admin@localhost`. I've followed <https://docs.joinmastodon.org/dev/setup/#setup>, ran following commands:

```sh
podman compose -f (pwd)/.devcontainer/compose.yaml exec --user=postgres db bash
$ createuser <my_username> --createdb
podman compose -f (pwd)/.devcontainer/compose.yaml exec app bash
$ rails db:setup
```

and then i could login as `admin@localhost` with password `mastodon`.

I've probably missed some critical steps and had to resort to above hacks, if anyone knows better way please let me know.

</details> 