### PR TITLE
Assert on page contents before reloading report for interface JS spec

### DIFF
--- a/spec/system/report_interface_spec.rb
+++ b/spec/system/report_interface_spec.rb
@@ -40,5 +40,7 @@ RSpec.describe 'report interface', :attachment_processing, :js, :streaming do
     within '.report-actions' do
       click_on I18n.t('admin.reports.mark_as_resolved')
     end
+    expect(page)
+      .to have_content(I18n.t('admin.reports.resolved_msg'))
   end
 end


### PR DESCRIPTION
I've seen this intermittent failure a few spots, most recently - https://github.com/mastodon/mastodon/actions/runs/13769190337/job/38503378785 / https://github.com/mastodon/mastodon/actions/runs/13767131933/job/38496398506

I think what's happening here is a JS/async timing thing where we check for the `report.action_taken_at` value to have changed immediately after pressing the button. Usually, "immediately" is enough time for the server to have gotten the request and changed the value already, but sometimes it's not. By checking for some page content first (the flash success message) after clicking button we can delay the report reload/assert until after we are sure the server has done it's part.

In some local testing I saw this failure ~3/10 times before change, but zero after. Open to other ideas here.

There are some intermittent failures in new_statuses_spec as well, maybe similar reasons. Will review that separately.