### PR TITLE
Assert on page contents while progressing through `new_statuses` system spec

### DIFF
--- a/spec/support/stories/profile_stories.rb
+++ b/spec/support/stories/profile_stories.rb
@@ -22,7 +22,11 @@ module ProfileStories
   def as_a_logged_in_user
     as_a_registered_user
     visit new_user_session_path
+    expect(page)
+      .to have_title(I18n.t('auth.login'))
     fill_in_auth_details(email, password)
+    expect(page)
+      .to have_css('.app-holder')
   end
 
   def as_a_logged_in_admin

--- a/spec/system/new_statuses_spec.rb
+++ b/spec/system/new_statuses_spec.rb
@@ -5,21 +5,15 @@ require 'rails_helper'
 RSpec.describe 'NewStatuses', :inline_jobs, :js, :streaming do
   include ProfileStories
 
-  subject { page }
-
   let(:email)               { 'test@example.com' }
   let(:password)            { 'password' }
   let(:confirmed_at)        { Time.zone.now }
   let(:finished_onboarding) { true }
 
-  before do
-    as_a_logged_in_user
-    visit root_path
-  end
+  before { as_a_logged_in_user }
 
   it 'can be posted' do
-    expect(subject).to have_css('div.app-holder')
-
+    visit_homepage
     status_text = 'This is a new status!'
 
     within('.compose-form') do
@@ -27,12 +21,12 @@ RSpec.describe 'NewStatuses', :inline_jobs, :js, :streaming do
       click_on 'Post'
     end
 
-    expect(subject).to have_css('.status__content__text', text: status_text)
+    expect(page)
+      .to have_css('.status__content__text', text: status_text)
   end
 
   it 'can be posted again' do
-    expect(subject).to have_css('div.app-holder')
-
+    visit_homepage
     status_text = 'This is a second status!'
 
     within('.compose-form') do
@@ -40,6 +34,15 @@ RSpec.describe 'NewStatuses', :inline_jobs, :js, :streaming do
       click_on 'Post'
     end
 
-    expect(subject).to have_css('.status__content__text', text: status_text)
+    expect(page)
+      .to have_css('.status__content__text', text: status_text)
+  end
+
+  def visit_homepage
+    visit root_path
+
+    expect(page)
+      .to have_css('div.app-holder')
+      .and have_css('form.compose-form')
   end
 end


### PR DESCRIPTION
Same idea as https://github.com/mastodon/mastodon/pull/34132 but for the new statuses JS-enabled spec. Example failure - https://github.com/mastodon/mastodon/actions/runs/13767131933/job/38496398506 - I was able to replicate this one locally with both a) the sign-in not fully happening before the spec moved on, b) the compose form not being available ... I think the changes in here should help both of those.

Separately ... within this existing spec before the changes here, I don't understand why there are two examples? They seemingly do the same thing. Happy to either remove one or clarify the wording or whatever makes sense on those.