### PR TITLE
Re-check suspension status on remote accounts on incoming activity

### DIFF
--- a/app/lib/activitypub/activity/announce.rb
+++ b/app/lib/activitypub/activity/announce.rb
@@ -26,6 +26,9 @@ class ActivityPub::Activity::Announce < ActivityPub::Activity
 
       Trends.register!(@status)
 
+      # If we got a new reblog, the account is probably not suspended at origin anymore
+      @account.schedule_suspension_recheck!(interaction_time: @status.created_at)
+
       distribute
     end
 

--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -50,6 +50,9 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
     process_tags
     process_audience
 
+    # If we got a new status, the account is probably not suspended at origin anymore
+    @account.schedule_suspension_recheck!(interaction_time: @params[:created_at])
+
     ApplicationRecord.transaction do
       @status = Status.create!(@params)
       attach_tags(@status)

--- a/app/lib/activitypub/activity/follow.rb
+++ b/app/lib/activitypub/activity/follow.rb
@@ -8,6 +8,8 @@ class ActivityPub::Activity::Follow < ActivityPub::Activity
 
     return if target_account.nil? || !target_account.local? || delete_arrived_first?(@json['id'])
 
+    @account.schedule_suspension_recheck!
+
     # Update id of already-existing follow requests
     existing_follow_request = ::FollowRequest.find_by(account: @account, target_account: target_account)
     unless existing_follow_request.nil?

--- a/app/lib/activitypub/activity/like.rb
+++ b/app/lib/activitypub/activity/like.rb
@@ -6,6 +6,8 @@ class ActivityPub::Activity::Like < ActivityPub::Activity
 
     return if original_status.nil? || !original_status.account.local? || delete_arrived_first?(@json['id']) || @account.favourited?(original_status)
 
+    @account.schedule_suspension_recheck!
+
     favourite = original_status.favourites.create!(account: @account)
 
     LocalNotificationWorker.perform_async(original_status.account_id, favourite.id, 'Favourite', 'favourite')


### PR DESCRIPTION
This PR schedules an immediate re-check when a remotely-suspended account interacts with us (capped at one recheck per day).
