### PR TITLE
Fix timeline banners sizing

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -9288,6 +9288,7 @@ noscript {
   border: 1px solid $highlight-text-color;
   background: rgba($highlight-text-color, 0.15);
   overflow: hidden;
+  flex-shrink: 0;
 
   &__background-image {
     width: 125%;


### PR DESCRIPTION
Fix regression from #33860

Another approach would be to remove the `overflow: hidden` which I think might not be relevant anymore (IIRC it was used when we were using the “This is you home base” design with a backdrop)