### PR TITLE
Add `EXTRA_MEDIA_HOSTS` environment variable to add extra hosts to Content-Security-Policy

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -80,7 +80,7 @@ AWS_SECRET_ACCESS_KEY=
 S3_ALIAS_HOST=files.example.com
 
 # Optional list of hosts that are allowed to serve media for your instance
-# EXTRA_DATA_HOSTS=https://data.example1.com,https://data.example2.com
+# EXTRA_MEDIA_HOSTS=https://data.example1.com,https://data.example2.com
 
 # IP and session retention
 # -----------------------

--- a/.env.production.sample
+++ b/.env.production.sample
@@ -79,6 +79,11 @@ AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 S3_ALIAS_HOST=files.example.com
 
+# Optional list of hosts that are allowed to serve media for your instance
+# This is useful if you include external media in your custom CSS or about page,
+# or if your data storage provider makes use of redirects to other domains.
+# EXTRA_DATA_HOSTS=https://data.example1.com|https://data.example2.com
+
 # IP and session retention
 # -----------------------
 # Make sure to modify the scheduling of ip_cleanup_scheduler in config/sidekiq.yml

--- a/.env.production.sample
+++ b/.env.production.sample
@@ -80,8 +80,6 @@ AWS_SECRET_ACCESS_KEY=
 S3_ALIAS_HOST=files.example.com
 
 # Optional list of hosts that are allowed to serve media for your instance
-# This is useful if you include external media in your custom CSS or about page,
-# or if your data storage provider makes use of redirects to other domains.
 # EXTRA_DATA_HOSTS=https://data.example1.com,https://data.example2.com
 
 # IP and session retention

--- a/.env.production.sample
+++ b/.env.production.sample
@@ -82,7 +82,7 @@ S3_ALIAS_HOST=files.example.com
 # Optional list of hosts that are allowed to serve media for your instance
 # This is useful if you include external media in your custom CSS or about page,
 # or if your data storage provider makes use of redirects to other domains.
-# EXTRA_DATA_HOSTS=https://data.example1.com|https://data.example2.com
+# EXTRA_DATA_HOSTS=https://data.example1.com,https://data.example2.com
 
 # IP and session retention
 # -----------------------

--- a/app/lib/content_security_policy.rb
+++ b/app/lib/content_security_policy.rb
@@ -10,7 +10,7 @@ class ContentSecurityPolicy
   end
 
   def media_hosts
-    [assets_host, cdn_host_value, paperclip_root_url].concat(extra_data_hosts).compact
+    [assets_host, cdn_host_value, paperclip_root_url].concat(extra_media_hosts).compact
   end
 
   def sso_host
@@ -31,8 +31,8 @@ class ContentSecurityPolicy
 
   private
 
-  def extra_data_hosts
-    ENV.fetch('EXTRA_DATA_HOSTS', '').split(/(?:\s*,\s*|\s+)/)
+  def extra_media_hosts
+    ENV.fetch('EXTRA_MEDIA_HOSTS', '').split(/(?:\s*,\s*|\s+)/)
   end
 
   def url_from_configured_asset_host

--- a/app/lib/content_security_policy.rb
+++ b/app/lib/content_security_policy.rb
@@ -10,7 +10,7 @@ class ContentSecurityPolicy
   end
 
   def media_hosts
-    [assets_host, cdn_host_value, paperclip_root_url].compact
+    [assets_host, cdn_host_value, paperclip_root_url].concat(extra_data_hosts).compact
   end
 
   def sso_host
@@ -30,6 +30,10 @@ class ContentSecurityPolicy
   end
 
   private
+
+  def extra_data_hosts
+    ENV.fetch('EXTRA_DATA_HOSTS', '').split('|')
+  end
 
   def url_from_configured_asset_host
     Rails.configuration.action_controller.asset_host

--- a/app/lib/content_security_policy.rb
+++ b/app/lib/content_security_policy.rb
@@ -32,7 +32,7 @@ class ContentSecurityPolicy
   private
 
   def extra_data_hosts
-    ENV.fetch('EXTRA_DATA_HOSTS', '').split(',')
+    ENV.fetch('EXTRA_DATA_HOSTS', '').split(/(?:\s*,\s*|\s+)/)
   end
 
   def url_from_configured_asset_host

--- a/app/lib/content_security_policy.rb
+++ b/app/lib/content_security_policy.rb
@@ -32,7 +32,7 @@ class ContentSecurityPolicy
   private
 
   def extra_data_hosts
-    ENV.fetch('EXTRA_DATA_HOSTS', '').split('|')
+    ENV.fetch('EXTRA_DATA_HOSTS', '').split(',')
   end
 
   def url_from_configured_asset_host


### PR DESCRIPTION
@ClearlyClaire has already added this wonderful ENV to gltich, so I've stolen the code from her fork.

This is jortage friendly, or for people using 301 redirections for the media.

I've just added this manually to my fork in a worse way, so I'd rather remove my jank.