### PR TITLE
Disable installation of instrumentation hooks

### DIFF
--- a/config/initializers/prometheus_exporter.rb
+++ b/config/initializers/prometheus_exporter.rb
@@ -24,6 +24,6 @@ if ENV['MASTODON_PROMETHEUS_EXPORTER_ENABLED'] == 'true'
   else
     # Include stripped down version of PrometheusExporter::Middleware that only collects queue time
     require 'mastodon/middleware/prometheus_queue_time'
-    Rails.application.middleware.unshift Mastodon::Middleware::PrometheusQueueTime
+    Rails.application.middleware.unshift Mastodon::Middleware::PrometheusQueueTime, instrument: false
   end
 end


### PR DESCRIPTION
This stripped down middleware does not use the instrumentation so it is not required to install these hooks.

In fact they seem to clash with OTEL trying something similar.