### PR TITLE
Add `STREAMING_REDIS_` configuration prefix

### DIFF
--- a/app/lib/access_token_extension.rb
+++ b/app/lib/access_token_extension.rb
@@ -24,6 +24,6 @@ module AccessTokenExtension
   end
 
   def push_to_streaming_api
-    redis.publish("timeline:access_token:#{id}", Oj.dump(event: :kill)) if revoked? || destroyed?
+    streaming_redis.publish("timeline:access_token:#{id}", Oj.dump(event: :kill)) if revoked? || destroyed?
   end
 end

--- a/app/lib/application_extension.rb
+++ b/app/lib/application_extension.rb
@@ -39,7 +39,7 @@ module ApplicationExtension
     scope = access_tokens
     scope = scope.where(resource_owner_id: resource_owner.id) unless resource_owner.nil?
     scope.in_batches do |tokens|
-      redis.pipelined do |pipeline|
+      streaming_redis.pipelined do |pipeline|
         tokens.ids.each do |id|
           pipeline.publish("timeline:access_token:#{id}", payload)
         end

--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -90,7 +90,7 @@ class FeedManager
   def unpush_from_home(account, status, update: false)
     return false unless remove_from_feed(:home, account.id, status, aggregate_reblogs: account.user&.aggregates_reblogs?)
 
-    redis.publish("timeline:#{account.id}", Oj.dump(event: :delete, payload: status.id.to_s)) unless update
+    streaming_redis.publish("timeline:#{account.id}", Oj.dump(event: :delete, payload: status.id.to_s)) unless update
     true
   end
 
@@ -117,7 +117,7 @@ class FeedManager
   def unpush_from_list(list, status, update: false)
     return false unless remove_from_feed(:list, list.id, status, aggregate_reblogs: list.account.user&.aggregates_reblogs?)
 
-    redis.publish("timeline:list:#{list.id}", Oj.dump(event: :delete, payload: status.id.to_s)) unless update
+    streaming_redis.publish("timeline:list:#{list.id}", Oj.dump(event: :delete, payload: status.id.to_s)) unless update
     true
   end
 
@@ -428,7 +428,7 @@ class FeedManager
   # @param [String] timeline_key
   # @return [Boolean]
   def push_update_required?(timeline_key)
-    redis.exists?("subscribed:#{timeline_key}")
+    streaming_redis.exists?("subscribed:#{timeline_key}")
   end
 
   # Check if the account is blocking or muting any of the given accounts

--- a/app/lib/redis_connection.rb
+++ b/app/lib/redis_connection.rb
@@ -19,7 +19,7 @@ class RedisConnection
     end
 
     def streaming_pool
-      @streaming_pool ||= establish_pool(2)
+      @streaming_pool ||= establish_streaming_pool(2)
     end
 
     def pool_size

--- a/app/lib/redis_connection.rb
+++ b/app/lib/redis_connection.rb
@@ -19,6 +19,8 @@ class RedisConnection
     end
 
     def streaming_pool
+      return pool if REDIS_CONFIGURATION.streaming == REDIS_CONFIGURATION.base
+
       @streaming_pool ||= establish_streaming_pool(2)
     end
 

--- a/app/lib/redis_connection.rb
+++ b/app/lib/redis_connection.rb
@@ -2,15 +2,19 @@
 
 class RedisConnection
   class << self
-    def establish_pool(new_pool_size)
+    def establish_pool(new_pool_size, config)
       @pool&.shutdown(&:close)
-      @pool = ConnectionPool.new(size: new_pool_size) { new.connection }
+      @pool = ConnectionPool.new(size: new_pool_size) { new(config).connection }
     end
 
     delegate :with, to: :pool
 
     def pool
-      @pool ||= establish_pool(pool_size)
+      @pool ||= establish_pool(pool_size, REDIS_CONFIGURATION.base)
+    end
+
+    def streaming_pool
+      @pool ||= establish_pool(2, REDIS_CONFIGURATION.streaming)
     end
 
     def pool_size
@@ -24,8 +28,8 @@ class RedisConnection
 
   attr_reader :config
 
-  def initialize
-    @config = REDIS_CONFIGURATION.base
+  def initialize(config)
+    @config = config
   end
 
   def connection

--- a/app/lib/redis_connection.rb
+++ b/app/lib/redis_connection.rb
@@ -19,8 +19,6 @@ class RedisConnection
     end
 
     def streaming_pool
-      return pool if REDIS_CONFIGURATION.streaming == REDIS_CONFIGURATION.base
-
       @streaming_pool ||= establish_streaming_pool(2)
     end
 

--- a/app/lib/redis_connection.rb
+++ b/app/lib/redis_connection.rb
@@ -2,19 +2,24 @@
 
 class RedisConnection
   class << self
-    def establish_pool(new_pool_size, config)
+    def establish_pool(new_pool_size)
       @pool&.shutdown(&:close)
-      @pool = ConnectionPool.new(size: new_pool_size) { new(config).connection }
+      @pool = ConnectionPool.new(size: new_pool_size) { new.connection }
+    end
+
+    def establish_streaming_pool(new_pool_size)
+      @streaming_pool&.shutdown(&:close)
+      @streaming_pool = ConnectionPool.new(size: new_pool_size) { new(REDIS_CONFIGURATION.streaming).connection }
     end
 
     delegate :with, to: :pool
 
     def pool
-      @pool ||= establish_pool(pool_size, REDIS_CONFIGURATION.base)
+      @pool ||= establish_pool(pool_size)
     end
 
     def streaming_pool
-      @pool ||= establish_pool(2, REDIS_CONFIGURATION.streaming)
+      @streaming_pool ||= establish_pool(2)
     end
 
     def pool_size
@@ -28,8 +33,8 @@ class RedisConnection
 
   attr_reader :config
 
-  def initialize(config)
-    @config = config
+  def initialize(config = nil)
+    @config = config || REDIS_CONFIGURATION.base
   end
 
   def connection

--- a/app/models/account_conversation.rb
+++ b/app/models/account_conversation.rb
@@ -123,7 +123,7 @@ class AccountConversation < ApplicationRecord
   end
 
   def subscribed_to_timeline?
-    redis.exists?("subscribed:#{streaming_channel}")
+    streaming_redis.exists?("subscribed:#{streaming_channel}")
   end
 
   def streaming_channel

--- a/app/models/concerns/redisable.rb
+++ b/app/models/concerns/redisable.rb
@@ -5,6 +5,10 @@ module Redisable
     Thread.current[:redis] ||= RedisConnection.pool.checkout
   end
 
+  def streaming_redis
+    Thread.current[:streaming_redis] ||= RedisConnection.streaming_pool.checkout
+  end
+
   def with_redis(&block)
     RedisConnection.with(&block)
   end

--- a/app/models/custom_filter.rb
+++ b/app/models/custom_filter.rb
@@ -112,8 +112,8 @@ class CustomFilter < ApplicationRecord
     @should_invalidate_cache = false
 
     Rails.cache.delete("filters:v3:#{account_id}")
-    redis.publish("timeline:#{account_id}", Oj.dump(event: :filters_changed))
-    redis.publish("timeline:system:#{account_id}", Oj.dump(event: :filters_changed))
+    streaming_redis.publish("timeline:#{account_id}", Oj.dump(event: :filters_changed))
+    streaming_redis.publish("timeline:system:#{account_id}", Oj.dump(event: :filters_changed))
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -374,7 +374,7 @@ class User < ApplicationRecord
       # doesn't trigger ActiveRecord Callbacks:
       # TODO: #28793 Combine into a single topic
       payload = Oj.dump(event: :kill)
-      redis.pipelined do |pipeline|
+      streaming_redis.pipelined do |pipeline|
         batch.ids.each do |id|
           pipeline.publish("timeline:access_token:#{id}", payload)
         end

--- a/app/services/batched_remove_status_service.rb
+++ b/app/services/batched_remove_status_service.rb
@@ -54,7 +54,7 @@ class BatchedRemoveStatusService < BaseService
 
     # Cannot be batched
     @status_id_cutoff = Mastodon::Snowflake.id_at(2.weeks.ago)
-    redis.pipelined do |pipeline|
+    streaming_redis.pipelined do |pipeline|
       statuses.each do |status|
         unpush_from_public_timelines(status, pipeline)
       end

--- a/app/services/fan_out_on_write_service.rb
+++ b/app/services/fan_out_on_write_service.rb
@@ -128,20 +128,20 @@ class FanOutOnWriteService < BaseService
 
   def broadcast_to_hashtag_streams!
     @status.tags.map(&:name).each do |hashtag|
-      redis.publish("timeline:hashtag:#{hashtag.downcase}", anonymous_payload)
-      redis.publish("timeline:hashtag:#{hashtag.downcase}:local", anonymous_payload) if @status.local?
+      streaming_redis.publish("timeline:hashtag:#{hashtag.downcase}", anonymous_payload)
+      streaming_redis.publish("timeline:hashtag:#{hashtag.downcase}:local", anonymous_payload) if @status.local?
     end
   end
 
   def broadcast_to_public_streams!
     return if @status.reply? && @status.in_reply_to_account_id != @account.id
 
-    redis.publish('timeline:public', anonymous_payload)
-    redis.publish(@status.local? ? 'timeline:public:local' : 'timeline:public:remote', anonymous_payload)
+    streaming_redis.publish('timeline:public', anonymous_payload)
+    streaming_redis.publish(@status.local? ? 'timeline:public:local' : 'timeline:public:remote', anonymous_payload)
 
     if @status.with_media?
-      redis.publish('timeline:public:media', anonymous_payload)
-      redis.publish(@status.local? ? 'timeline:public:local:media' : 'timeline:public:remote:media', anonymous_payload)
+      streaming_redis.publish('timeline:public:media', anonymous_payload)
+      streaming_redis.publish(@status.local? ? 'timeline:public:local:media' : 'timeline:public:remote:media', anonymous_payload)
     end
   end
 
@@ -173,6 +173,6 @@ class FanOutOnWriteService < BaseService
   end
 
   def subscribed_to_streaming_api?(account_id)
-    redis.exists?("subscribed:timeline:#{account_id}") || redis.exists?("subscribed:timeline:#{account_id}:notifications")
+    streaming_redis.exists?("subscribed:timeline:#{account_id}") || streaming_redis.exists?("subscribed:timeline:#{account_id}:notifications")
   end
 end

--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -260,11 +260,11 @@ class NotifyService < BaseService
   end
 
   def push_to_streaming_api!
-    redis.publish("timeline:#{@recipient.id}:notifications", Oj.dump(event: :notification, payload: InlineRenderer.render(@notification, @recipient, :notification)))
+    streaming_redis.publish("timeline:#{@recipient.id}:notifications", Oj.dump(event: :notification, payload: InlineRenderer.render(@notification, @recipient, :notification)))
   end
 
   def subscribed_to_streaming_api?
-    redis.exists?("subscribed:timeline:#{@recipient.id}") || redis.exists?("subscribed:timeline:#{@recipient.id}:notifications")
+    streaming_redis.exists?("subscribed:timeline:#{@recipient.id}") || streaming_redis.exists?("subscribed:timeline:#{@recipient.id}:notifications")
   end
 
   def push_to_conversation!

--- a/app/services/remove_status_service.rb
+++ b/app/services/remove_status_service.rb
@@ -82,7 +82,7 @@ class RemoveStatusService < BaseService
     return if skip_streaming?
 
     @status.active_mentions.find_each do |mention|
-      redis.publish("timeline:#{mention.account_id}", @payload)
+      streaming_redis.publish("timeline:#{mention.account_id}", @payload)
     end
   end
 
@@ -123,8 +123,8 @@ class RemoveStatusService < BaseService
     return if skip_streaming?
 
     @status.tags.map(&:name).each do |hashtag|
-      redis.publish("timeline:hashtag:#{hashtag.downcase}", @payload)
-      redis.publish("timeline:hashtag:#{hashtag.downcase}:local", @payload) if @status.local?
+      streaming_redis.publish("timeline:hashtag:#{hashtag.downcase}", @payload)
+      streaming_redis.publish("timeline:hashtag:#{hashtag.downcase}:local", @payload) if @status.local?
     end
   end
 
@@ -133,8 +133,8 @@ class RemoveStatusService < BaseService
 
     return if skip_streaming?
 
-    redis.publish('timeline:public', @payload)
-    redis.publish(@status.local? ? 'timeline:public:local' : 'timeline:public:remote', @payload)
+    streaming_redis.publish('timeline:public', @payload)
+    streaming_redis.publish(@status.local? ? 'timeline:public:local' : 'timeline:public:remote', @payload)
   end
 
   def remove_from_media
@@ -142,8 +142,8 @@ class RemoveStatusService < BaseService
 
     return if skip_streaming?
 
-    redis.publish('timeline:public:media', @payload)
-    redis.publish(@status.local? ? 'timeline:public:local:media' : 'timeline:public:remote:media', @payload)
+    streaming_redis.publish('timeline:public:media', @payload)
+    streaming_redis.publish(@status.local? ? 'timeline:public:local:media' : 'timeline:public:remote:media', @payload)
   end
 
   def remove_media

--- a/app/workers/publish_announcement_reaction_worker.rb
+++ b/app/workers/publish_announcement_reaction_worker.rb
@@ -14,7 +14,7 @@ class PublishAnnouncementReactionWorker
     payload = Oj.dump(event: :'announcement.reaction', payload: payload)
 
     FeedManager.instance.with_active_accounts do |account|
-      redis.publish("timeline:#{account.id}", payload) if redis.exists?("subscribed:timeline:#{account.id}")
+      streaming_redis.publish("timeline:#{account.id}", payload) if streaming_redis.exists?("subscribed:timeline:#{account.id}")
     end
   rescue ActiveRecord::RecordNotFound
     true

--- a/app/workers/publish_scheduled_announcement_worker.rb
+++ b/app/workers/publish_scheduled_announcement_worker.rb
@@ -15,7 +15,7 @@ class PublishScheduledAnnouncementWorker
     payload = Oj.dump(event: :announcement, payload: payload)
 
     FeedManager.instance.with_active_accounts do |account|
-      redis.publish("timeline:#{account.id}", payload) if redis.exists?("subscribed:timeline:#{account.id}")
+      streaming_redis.publish("timeline:#{account.id}", payload) if streaming_redis.exists?("subscribed:timeline:#{account.id}")
     end
   end
 

--- a/app/workers/push_conversation_worker.rb
+++ b/app/workers/push_conversation_worker.rb
@@ -9,7 +9,7 @@ class PushConversationWorker
     message      = InlineRenderer.render(conversation, conversation.account, :conversation)
     timeline_id  = "timeline:direct:#{conversation.account_id}"
 
-    redis.publish(timeline_id, Oj.dump(event: :conversation, payload: message))
+    streaming_redis.publish(timeline_id, Oj.dump(event: :conversation, payload: message))
   rescue ActiveRecord::RecordNotFound
     true
   end

--- a/app/workers/push_update_worker.rb
+++ b/app/workers/push_update_worker.rb
@@ -30,7 +30,7 @@ class PushUpdateWorker
   end
 
   def publish!
-    redis.publish(@timeline_id, message)
+    streaming_redis.publish(@timeline_id, message)
   end
 
   def update?

--- a/app/workers/unfilter_notifications_worker.rb
+++ b/app/workers/unfilter_notifications_worker.rb
@@ -54,10 +54,10 @@ class UnfilterNotificationsWorker
   end
 
   def push_streaming_event!
-    redis.publish("timeline:#{@recipient.id}:notifications", Oj.dump(event: :notifications_merged, payload: '1'))
+    streaming_redis.publish("timeline:#{@recipient.id}:notifications", Oj.dump(event: :notifications_merged, payload: '1'))
   end
 
   def subscribed_to_streaming_api?
-    redis.exists?("subscribed:timeline:#{@recipient.id}") || redis.exists?("subscribed:timeline:#{@recipient.id}:notifications")
+    streaming_redis.exists?("subscribed:timeline:#{@recipient.id}") || streaming_redis.exists?("subscribed:timeline:#{@recipient.id}:notifications")
   end
 end

--- a/app/workers/unpublish_announcement_worker.rb
+++ b/app/workers/unpublish_announcement_worker.rb
@@ -8,7 +8,7 @@ class UnpublishAnnouncementWorker
     payload = Oj.dump(event: :'announcement.delete', payload: announcement_id.to_s)
 
     FeedManager.instance.with_active_accounts do |account|
-      redis.publish("timeline:#{account.id}", payload) if redis.exists?("subscribed:timeline:#{account.id}")
+      streaming_redis.publish("timeline:#{account.id}", payload) if streaming_redis.exists?("subscribed:timeline:#{account.id}")
     end
   end
 end

--- a/lib/mastodon/cli/base.rb
+++ b/lib/mastodon/cli/base.rb
@@ -41,6 +41,7 @@ module Mastodon
             .tap { |config| config['pool'] = options[:concurrency] + 1 }
         )
         RedisConnection.establish_pool(options[:concurrency])
+        RedisConnection.establish_streaming_pool(2)
       end
     end
   end

--- a/lib/mastodon/cli/progress_helper.rb
+++ b/lib/mastodon/cli/progress_helper.rb
@@ -53,6 +53,9 @@ module Mastodon::CLI
               ensure
                 RedisConnection.pool.checkin if Thread.current[:redis]
                 Thread.current[:redis] = nil
+
+                RedisConnection.streaming_pool.checkin if Thread.current[:streaming_redis]
+                Thread.current[:streaming_redis] = nil
               end
 
               aggregate.increment(result) if result.is_a?(Integer)

--- a/lib/mastodon/middleware/socket_cleanup.rb
+++ b/lib/mastodon/middleware/socket_cleanup.rb
@@ -23,6 +23,9 @@ module Mastodon
       def clean_up_redis_socket!
         RedisConnection.pool.checkin if Thread.current[:redis]
         Thread.current[:redis] = nil
+
+        RedisConnection.streaming_pool.checkin if Thread.current[:streaming_redis]
+        Thread.current[:streaming_redis] = nil
       end
 
       def clean_up_statsd_socket!

--- a/lib/mastodon/redis_configuration.rb
+++ b/lib/mastodon/redis_configuration.rb
@@ -18,7 +18,7 @@ class Mastodon::RedisConfiguration
   end
 
   def streaming
-    @sidekiq ||= setup_config(prefix: 'STREAMING_')
+    @streaming ||= setup_config(prefix: 'STREAMING_')
                    .merge(namespace: sidekiq_namespace)
   end
 

--- a/lib/mastodon/redis_configuration.rb
+++ b/lib/mastodon/redis_configuration.rb
@@ -17,6 +17,11 @@ class Mastodon::RedisConfiguration
                  .merge(namespace: sidekiq_namespace)
   end
 
+  def streaming
+    @sidekiq ||= setup_config(prefix: 'STREAMING_')
+                   .merge(namespace: sidekiq_namespace)
+  end
+
   def cache
     @cache ||= setup_config(prefix: 'CACHE_')
                .merge({

--- a/lib/mastodon/sidekiq_middleware.rb
+++ b/lib/mastodon/sidekiq_middleware.rb
@@ -57,6 +57,9 @@ class Mastodon::SidekiqMiddleware
   def clean_up_redis_socket!
     RedisConnection.pool.checkin if Thread.current[:redis]
     Thread.current[:redis] = nil
+
+    RedisConnection.streaming_pool.checkin if Thread.current[:streaming_redis]
+    Thread.current[:streaming_redis] = nil
   end
 
   def clean_up_statsd_socket!

--- a/spec/controllers/oauth/authorized_applications_controller_spec.rb
+++ b/spec/controllers/oauth/authorized_applications_controller_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Oauth::AuthorizedApplicationsController do
 
     before do
       sign_in user, scope: :user
-      allow(redis).to receive(:pipelined).and_yield(redis_pipeline_stub)
+      allow(streaming_redis).to receive(:pipelined).and_yield(redis_pipeline_stub)
     end
 
     it 'revokes access tokens for the application and removes subscriptions and sends kill payload to streaming' do

--- a/spec/lib/feed_manager_spec.rb
+++ b/spec/lib/feed_manager_spec.rb
@@ -543,11 +543,11 @@ RSpec.describe FeedManager do
 
       subject.push_to_home(receiver, status)
 
-      allow(redis).to receive_messages(publish: nil)
+      allow(streaming_redis).to receive_messages(publish: nil)
       subject.unpush_from_home(receiver, status)
 
       deletion = Oj.dump(event: :delete, payload: status.id.to_s)
-      expect(redis).to have_received(:publish).with("timeline:#{receiver.id}", deletion)
+      expect(streaming_redis).to have_received(:publish).with("timeline:#{receiver.id}", deletion)
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -491,7 +491,7 @@ RSpec.describe User do
 
     let(:redis_pipeline_stub) { instance_double(Redis::Namespace, publish: nil) }
 
-    before { stub_redis }
+    before { stub_streaming_redis }
 
     it 'changes the password immediately and revokes related access' do
       expect { user.reset_password! }
@@ -521,8 +521,8 @@ RSpec.describe User do
       change { Web::PushSubscription.where(user: user).or(Web::PushSubscription.where(access_token: access_token)).count }.to(0)
     end
 
-    def stub_redis
-      allow(redis)
+    def stub_streaming_redis
+      allow(streaming_redis)
         .to receive(:pipelined)
         .and_yield(redis_pipeline_stub)
     end

--- a/spec/requests/api/v2/filters_spec.rb
+++ b/spec/requests/api/v2/filters_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe 'Filters' do
       let(:params) { { keywords_attributes: [{ id: keyword.id, keyword: 'updated' }] } }
 
       before do
-        allow(redis).to receive_messages(publish: nil)
+        allow(streaming_redis).to receive_messages(publish: nil)
       end
 
       it 'returns http success and updates keyword and sends a filters_changed event' do

--- a/spec/requests/api/v2/filters_spec.rb
+++ b/spec/requests/api/v2/filters_spec.rb
@@ -210,7 +210,7 @@ RSpec.describe 'Filters' do
 
         expect(keyword.reload.keyword).to eq 'updated'
 
-        expect(redis).to have_received(:publish).with("timeline:#{user.account.id}", Oj.dump(event: :filters_changed)).once
+        expect(streaming_redis).to have_received(:publish).with("timeline:#{user.account.id}", Oj.dump(event: :filters_changed)).once
       end
     end
 

--- a/spec/services/batched_remove_status_service_spec.rb
+++ b/spec/services/batched_remove_status_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe BatchedRemoveStatusService, :inline_jobs do
   let(:status_alice_other) { PostStatusService.new.call(alice, text: 'Another status') }
 
   before do
-    allow(redis).to receive_messages(publish: nil)
+    allow(streaming_redis).to receive_messages(publish: nil)
 
     stub_request(:post, 'http://example.com/inbox').to_return(status: 200)
 

--- a/spec/services/batched_remove_status_service_spec.rb
+++ b/spec/services/batched_remove_status_service_spec.rb
@@ -40,11 +40,11 @@ RSpec.describe BatchedRemoveStatusService, :inline_jobs do
     expect(feed_ids_for(jeff))
       .to_not include(status_alice_hello.id, status_alice_other.id)
 
-    expect(redis)
+    expect(streaming_redis)
       .to have_received(:publish)
       .with("timeline:#{jeff.id}", any_args).at_least(:once)
 
-    expect(redis)
+    expect(streaming_redis)
       .to have_received(:publish)
       .with('timeline:public', any_args).at_least(:once)
 

--- a/spec/services/fan_out_on_write_service_spec.rb
+++ b/spec/services/fan_out_on_write_service_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe FanOutOnWriteService do
 
     Fabricate(:media_attachment, status: status, account: alice)
 
-    allow(redis).to receive(:publish)
+    allow(streaming_redis).to receive(:publish)
 
     subject.call(status)
   end
@@ -40,11 +40,11 @@ RSpec.describe FanOutOnWriteService do
         .and be_in(home_feed_of(bob))
         .and be_in(home_feed_of(tom))
 
-      expect(redis).to have_received(:publish).with('timeline:hashtag:hoge', anything)
-      expect(redis).to have_received(:publish).with('timeline:hashtag:hoge:local', anything)
-      expect(redis).to have_received(:publish).with('timeline:public', anything)
-      expect(redis).to have_received(:publish).with('timeline:public:local', anything)
-      expect(redis).to have_received(:publish).with('timeline:public:media', anything)
+      expect(streaming_redis).to have_received(:publish).with('timeline:hashtag:hoge', anything)
+      expect(streaming_redis).to have_received(:publish).with('timeline:hashtag:hoge:local', anything)
+      expect(streaming_redis).to have_received(:publish).with('timeline:public', anything)
+      expect(streaming_redis).to have_received(:publish).with('timeline:public:local', anything)
+      expect(streaming_redis).to have_received(:publish).with('timeline:public:media', anything)
     end
   end
 
@@ -96,7 +96,7 @@ RSpec.describe FanOutOnWriteService do
         status.update!(text: 'Hello @bob @eve #hoge (edited)')
         status.snapshot!(account_id: status.account_id)
 
-        redis.set("subscribed:timeline:#{eve.id}:notifications", '1')
+        streaming_redis.set("subscribed:timeline:#{eve.id}:notifications", '1')
       end
 
       it 'pushes the update to mentioned users through the notifications streaming channel' do
@@ -107,10 +107,10 @@ RSpec.describe FanOutOnWriteService do
   end
 
   def expect_no_broadcasting
-    expect(redis)
+    expect(streaming_redis)
       .to_not have_received(:publish)
       .with('timeline:hashtag:hoge', anything)
-    expect(redis)
+    expect(streaming_redis)
       .to_not have_received(:publish)
       .with('timeline:public', anything)
   end

--- a/spec/services/remove_status_service_spec.rb
+++ b/spec/services/remove_status_service_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe RemoveStatusService, :inline_jobs do
     end
 
     it 'removes status from notifications and from author and local follower home feeds, publishes to media timeline, sends delete activities' do
-      allow(redis).to receive(:publish).with(any_args)
+      allow(streaming_redis).to receive(:publish).with(any_args)
 
       expect { subject.call(status) }
         .to remove_status_from_notifications
@@ -39,7 +39,7 @@ RSpec.describe RemoveStatusService, :inline_jobs do
       expect(home_feed_ids(jeff))
         .to_not include(status.id)
 
-      expect(redis)
+      expect(streaming_redis)
         .to have_received(:publish).with('timeline:public:media', Oj.dump(event: :delete, payload: status.id.to_s))
 
       expect(delete_delivery(hank, status))

--- a/spec/services/resolve_account_service_spec.rb
+++ b/spec/services/resolve_account_service_spec.rb
@@ -245,6 +245,7 @@ RSpec.describe ResolveAccountService do
         fail_occurred = true
       ensure
         RedisConnection.pool.checkin if Thread.current[:redis]
+        RedisConnection.streaming_pool.checkin if Thread.current[:streaming_redis]
       end
     end
 

--- a/spec/system/settings/applications_spec.rb
+++ b/spec/system/settings/applications_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe 'Settings applications page' do
     end
 
     def stub_redis_pipeline
-      allow(redis)
+      allow(streaming_redis)
         .to receive(:pipelined)
         .and_yield(redis_pipeline_stub)
     end

--- a/spec/system/settings/applications_spec.rb
+++ b/spec/system/settings/applications_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe 'Settings applications page' do
     let(:redis_pipeline_stub) { instance_double(Redis::Namespace, publish: nil) }
     let!(:access_token) { Fabricate(:accessible_access_token, application: application) }
 
-    before { stub_redis_pipeline }
+    before { stub_streaming_redis_pipeline }
 
     it 'destroys the record and tells the broader universe about that' do
       visit settings_applications_path
@@ -121,7 +121,7 @@ RSpec.describe 'Settings applications page' do
       click_on I18n.t('doorkeeper.applications.index.delete')
     end
 
-    def stub_redis_pipeline
+    def stub_streaming_redis_pipeline
       allow(streaming_redis)
         .to receive(:pipelined)
         .and_yield(redis_pipeline_stub)

--- a/spec/workers/publish_announcement_reaction_worker_spec.rb
+++ b/spec/workers/publish_announcement_reaction_worker_spec.rb
@@ -12,21 +12,21 @@ RSpec.describe PublishAnnouncementReactionWorker do
     let(:name) { 'name value' }
 
     it 'sends the announcement and name to the service when subscribed' do
-      allow(redis).to receive(:exists?).and_return(true)
-      allow(redis).to receive(:publish)
+      allow(streaming_redis).to receive(:exists?).and_return(true)
+      allow(streaming_redis).to receive(:publish)
 
       worker.perform(announcement.id, name)
 
-      expect(redis).to have_received(:publish)
+      expect(streaming_redis).to have_received(:publish)
     end
 
     it 'does not send the announcement and name to the service when not subscribed' do
-      allow(redis).to receive(:exists?).and_return(false)
-      allow(redis).to receive(:publish)
+      allow(streaming_redis).to receive(:exists?).and_return(false)
+      allow(streaming_redis).to receive(:publish)
 
       worker.perform(announcement.id, name)
 
-      expect(redis).to_not have_received(:publish)
+      expect(streaming_redis).to_not have_received(:publish)
     end
 
     it 'returns true for non-existent record' do

--- a/spec/workers/push_conversation_worker_spec.rb
+++ b/spec/workers/push_conversation_worker_spec.rb
@@ -16,13 +16,13 @@ RSpec.describe PushConversationWorker do
     context 'with valid records' do
       let(:account_conversation) { Fabricate :account_conversation }
 
-      before { allow(redis).to receive(:publish) }
+      before { allow(streaming_redis).to receive(:publish) }
 
       it 'pushes message to timeline' do
         expect { worker.perform(account_conversation.id) }
           .to_not raise_error
 
-        expect(redis)
+        expect(streaming_redis)
           .to have_received(:publish)
           .with(redis_key, anything)
       end

--- a/spec/workers/push_update_worker_spec.rb
+++ b/spec/workers/push_update_worker_spec.rb
@@ -17,13 +17,13 @@ RSpec.describe PushUpdateWorker do
       let(:account) { Fabricate :account }
       let(:status) { Fabricate :status }
 
-      before { allow(redis).to receive(:publish) }
+      before { allow(streaming_redis).to receive(:publish) }
 
       it 'pushes message to timeline' do
         expect { worker.perform(account.id, status.id) }
           .to_not raise_error
 
-        expect(redis)
+        expect(streaming_redis)
           .to have_received(:publish)
           .with(redis_key, anything)
       end

--- a/spec/workers/unfilter_notifications_worker_spec.rb
+++ b/spec/workers/unfilter_notifications_worker_spec.rb
@@ -13,15 +13,15 @@ RSpec.describe UnfilterNotificationsWorker do
     Fabricate(:notification, filtered: true, from_account: sender, account: recipient, type: :mention, activity: mention)
     follow_request = sender.request_follow!(recipient)
     Fabricate(:notification, filtered: true, from_account: sender, account: recipient, type: :follow_request, activity: follow_request)
-    allow(redis).to receive(:publish)
-    allow(redis).to receive(:exists?).and_return(false)
+    allow(streaming_redis).to receive(:publish)
+    allow(streaming_redis).to receive(:exists?).and_return(false)
   end
 
   shared_examples 'shared behavior' do
     context 'when this is the last pending merge job and the user is subscribed to streaming' do
       before do
         redis.set("notification_unfilter_jobs:#{recipient.id}", 1)
-        allow(redis).to receive(:exists?).with("subscribed:timeline:#{recipient.id}").and_return(true)
+        allow(streaming_redis).to receive(:exists?).with("subscribed:timeline:#{recipient.id}").and_return(true)
       end
 
       it 'unfilters notifications, adds private messages to conversations, and pushes to redis' do
@@ -30,14 +30,14 @@ RSpec.describe UnfilterNotificationsWorker do
           .and change { recipient.conversations.exists?(last_status_id: sender.statuses.first.id) }.to(true)
           .and change { redis.get("notification_unfilter_jobs:#{recipient.id}").to_i }.by(-1)
 
-        expect(redis).to have_received(:publish).with("timeline:#{recipient.id}:notifications", '{"event":"notifications_merged","payload":"1"}')
+        expect(streaming_redis).to have_received(:publish).with("timeline:#{recipient.id}:notifications", '{"event":"notifications_merged","payload":"1"}')
       end
     end
 
     context 'when this is not last pending merge job and the user is subscribed to streaming' do
       before do
         redis.set("notification_unfilter_jobs:#{recipient.id}", 2)
-        allow(redis).to receive(:exists?).with("subscribed:timeline:#{recipient.id}").and_return(true)
+        allow(streaming_redis).to receive(:exists?).with("subscribed:timeline:#{recipient.id}").and_return(true)
       end
 
       it 'unfilters notifications, adds private messages to conversations, and does not push to redis' do
@@ -46,7 +46,7 @@ RSpec.describe UnfilterNotificationsWorker do
           .and change { recipient.conversations.exists?(last_status_id: sender.statuses.first.id) }.to(true)
           .and change { redis.get("notification_unfilter_jobs:#{recipient.id}").to_i }.by(-1)
 
-        expect(redis).to_not have_received(:publish).with("timeline:#{recipient.id}:notifications", '{"event":"notifications_merged","payload":"1"}')
+        expect(streaming_redis).to_not have_received(:publish).with("timeline:#{recipient.id}:notifications", '{"event":"notifications_merged","payload":"1"}')
       end
     end
 
@@ -61,7 +61,7 @@ RSpec.describe UnfilterNotificationsWorker do
           .and change { recipient.conversations.exists?(last_status_id: sender.statuses.first.id) }.to(true)
           .and change { redis.get("notification_unfilter_jobs:#{recipient.id}").to_i }.by(-1)
 
-        expect(redis).to_not have_received(:publish).with("timeline:#{recipient.id}:notifications", '{"event":"notifications_merged","payload":"1"}')
+        expect(streaming_redis).to_not have_received(:publish).with("timeline:#{recipient.id}:notifications", '{"event":"notifications_merged","payload":"1"}')
       end
     end
   end

--- a/streaming/redis.js
+++ b/streaming/redis.js
@@ -75,9 +75,9 @@ function getStreamingOrBaseConfiguration(env) {
       REDIS_HOST: env.REDIS_HOST,
       REDIS_PORT: env.REDIS_PORT,
       REDIS_DB: env.REDIS_DB,
-    }
+    };
   } else {
-    return env
+    return env;
   }
 }
 
@@ -86,7 +86,7 @@ function getStreamingOrBaseConfiguration(env) {
  * @returns {RedisConfiguration} configuration for the Redis connection
  */
 export function configFromEnv(realEnv) {
-  const env = getStreamingOrBaseConfiguration(realEnv)
+  const env = getStreamingOrBaseConfiguration(realEnv);
 
   const redisNamespace = env.REDIS_NAMESPACE;
 

--- a/streaming/utils.js
+++ b/streaming/utils.js
@@ -79,3 +79,12 @@ export function parseIntFromEnvValue(value, defaultValue, variableName) {
     return defaultValue;
   }
 }
+
+/**
+ * Takes a value, and tests if it is a non-empty string.
+ * @param {string|undefined} value
+ * @returns {boolean}
+ */
+export function stringPresent(value) {
+  return typeof value === 'string' && value.length > 0
+}

--- a/streaming/utils.js
+++ b/streaming/utils.js
@@ -86,5 +86,5 @@ export function parseIntFromEnvValue(value, defaultValue, variableName) {
  * @returns {boolean}
  */
 export function stringPresent(value) {
-  return typeof value === 'string' && value.length > 0
+  return typeof value === 'string' && value.length > 0;
 }


### PR DESCRIPTION
Follows a [discussion thread](https://github.com/mastodon/mastodon/discussions/34198#discussioncomment-12537359), where it became interesting to consider allowing streaming/publishing/subscribing to happen via a different redis server, defaulting to the main one.