### PR TITLE
Fix handling of malformed/unusual HTML

### DIFF
--- a/app/helpers/admin/trends/statuses_helper.rb
+++ b/app/helpers/admin/trends/statuses_helper.rb
@@ -2,11 +2,18 @@
 
 module Admin::Trends::StatusesHelper
   def one_line_preview(status)
-    text = if status.local?
-             status.text.split("\n").first
-           else
-             Nokogiri::HTML5(status.text).css('html > body > *').first&.text
-           end
+    text = begin
+      if status.local?
+        status.text.split("\n").first
+      else
+        Nokogiri::HTML5(status.text).css('html > body > *').first&.text
+      end
+    rescue ArgumentError
+      # This can happen if one of the Nokogumbo limits is encountered
+      # Unfortunately, it does not use a more precise error class
+      # nor allows more graceful handling
+      ''
+    end
 
     return '' if text.blank?
 

--- a/app/lib/emoji_formatter.rb
+++ b/app/lib/emoji_formatter.rb
@@ -24,7 +24,15 @@ class EmojiFormatter
   def to_s
     return html if custom_emojis.empty? || html.blank?
 
-    tree = Nokogiri::HTML5.fragment(html)
+    begin
+      tree = Nokogiri::HTML5.fragment(html)
+    rescue ArgumentError
+      # This can happen if one of the Nokogumbo limits is encountered
+      # Unfortunately, it does not use a more precise error class
+      # nor allows more graceful handling
+      return ''
+    end
+
     tree.xpath('./text()|.//text()[not(ancestor[@class="invisible"])]').to_a.each do |node|
       i                     = -1
       inside_shortname      = false

--- a/app/lib/plain_text_formatter.rb
+++ b/app/lib/plain_text_formatter.rb
@@ -16,7 +16,15 @@ class PlainTextFormatter
     if local?
       text
     else
-      node = Nokogiri::HTML5.fragment(insert_newlines)
+      begin
+        node = Nokogiri::HTML5.fragment(insert_newlines)
+      rescue ArgumentError
+        # This can happen if one of the Nokogumbo limits is encountered
+        # Unfortunately, it does not use a more precise error class
+        # nor allows more graceful handling
+        return ''
+      end
+
       # Elements that are entirely removed with our Sanitize config
       node.xpath('.//iframe|.//math|.//noembed|.//noframes|.//noscript|.//plaintext|.//script|.//style|.//svg|.//xmp').remove
       node.text.chomp

--- a/app/models/account/field.rb
+++ b/app/models/account/field.rb
@@ -73,7 +73,14 @@ class Account::Field < ActiveModelSerializers::Model
   end
 
   def extract_url_from_html
-    doc = Nokogiri::HTML5.fragment(value)
+    begin
+      doc = Nokogiri::HTML5.fragment(value)
+    rescue ArgumentError
+      # This can happen if one of the Nokogumbo limits is encountered
+      # Unfortunately, it does not use a more precise error class
+      # nor allows more graceful handling
+      return
+    end
 
     return if doc.nil?
     return if doc.children.size != 1


### PR DESCRIPTION
We encountered at least one status with accidentally malformed HTML and a very large number of tag attributes as a result.

Nokgoiri's HTML5 parser, which we use, by default, raises `ArgumentError` when a tag has too many attributes: https://nokogiri.org/rdoc/Nokogiri/HTML5.html#module-Nokogiri::HTML5-label-Attribute+limit+per+element-3A+max_attributes-3A