### PR TITLE
Prevent duplicate REST API requests on submitting account personal note with ctrl+enter

### DIFF
--- a/app/javascript/mastodon/features/account/components/account_note.jsx
+++ b/app/javascript/mastodon/features/account/components/account_note.jsx
@@ -101,10 +101,10 @@ class AccountNote extends ImmutablePureComponent {
     if (e.keyCode === 13 && (e.ctrlKey || e.metaKey)) {
       e.preventDefault();
 
-      this._save();
-
       if (this.textarea) {
         this.textarea.blur();
+      } else {
+        this._save();
       }
     } else if (e.keyCode === 27) {
       e.preventDefault();


### PR DESCRIPTION
Submitting a personal account note for an account by pressing “ctrl+enter” would trigger a `_save()` call twice: once in the keyboard event handler and once in the `blur` event handler.

When submitting a new personal note rather than editing one, this would very often result in a 422 error because of the two requests attempting to create the object at the same time (race condition).