### PR TITLE
Reduce number of metric labels

### DIFF
--- a/lib/mastodon/middleware/prometheus_queue_time.rb
+++ b/lib/mastodon/middleware/prometheus_queue_time.rb
@@ -14,10 +14,8 @@ module Mastodon
         obj = {
           type: 'web',
           queue_time: queue_time,
-          default_labels: default_labels(env, result),
+          default_labels: {},
         }
-        labels = custom_labels(env)
-        obj = obj.merge(custom_labels: labels) if labels
 
         @client.send_json(obj)
       end


### PR DESCRIPTION
For this minimal middleware we do not need the full number of labels. And for queue time, that happens before a request hits the app, the actual endpoints within the app are not relevant.

People wanting the full number of labels can always set `MASTODON_PROMETHEUS_EXPORTER_WEB_DETAILED_METRICS`.