### PR TITLE
feat(accessibility): Add AI-generated alt text for images

### DIFF
--- a/app/controllers/api/v1/media/alt_text_controller.rb
+++ b/app/controllers/api/v1/media/alt_text_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class Api::V1::Media::AltTextController < Api::BaseController
+  before_action -> { doorkeeper_authorize! :write, :'write:media' }
+  before_action :require_user!
+  before_action :set_media_attachment
+
+  def create
+    authorize @media_attachment, :update?
+
+    if !Mastodon::Feature.alt_text_ai_enabled?
+      render json: { error: 'AI alt text generation is not enabled' }, status: 422
+      return
+    end
+
+    if !@media_attachment.image?
+      render json: { error: 'AI alt text generation is only available for images' }, status: 422
+      return
+    end
+
+    alt_text = AltTextAiService.instance.generate_alt_text(@media_attachment)
+
+    if alt_text.present?
+      render json: { description: alt_text }
+    else
+      render json: { error: 'Failed to generate alt text' }, status: 422
+    end
+  end
+
+  private
+
+  def set_media_attachment
+    @media_attachment = current_account.media_attachments.where(status_id: nil).find(params[:media_id])
+  end
+end

--- a/app/javascript/mastodon/features/alt_text_modal/components/ai_button.tsx
+++ b/app/javascript/mastodon/features/alt_text_modal/components/ai_button.tsx
@@ -1,0 +1,56 @@
+import { useState, useCallback } from 'react';
+
+import { FormattedMessage } from 'react-intl';
+
+import axios from 'axios';
+
+import AutoIcon from '@/material-icons/400-24px/auto_awesome.svg?react';
+import { Icon } from 'mastodon/components/icon';
+import { LoadingIndicator } from 'mastodon/components/loading_indicator';
+
+interface Props {
+  mediaId: string;
+  onSuccess: (text: string) => void;
+}
+
+export const AiButton: React.FC<Props> = ({ mediaId, onSuccess }) => {
+  const [loading, setLoading] = useState(false);
+
+  const handleClick = useCallback(() => {
+    setLoading(true);
+
+    axios
+      .post(`/api/v1/media/${mediaId}/alt_text`)
+      .then((res) => {
+        if (res.data.description) {
+          onSuccess(res.data.description);
+        }
+      })
+      .catch((error) => {
+        console.error('Error generating alt text:', error);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [mediaId, onSuccess, setLoading]);
+
+  return (
+    <button
+      className="link-button"
+      onClick={handleClick}
+      disabled={loading}
+    >
+      {loading ? (
+        <LoadingIndicator />
+      ) : (
+        <>
+          <Icon id="auto" icon={AutoIcon} />
+          <FormattedMessage
+            id="media_modal.generate_alt_with_ai"
+            defaultMessage="Generate with AI"
+          />
+        </>
+      )}
+    </button>
+  );
+};

--- a/app/javascript/mastodon/features/alt_text_modal/components/ai_button.tsx
+++ b/app/javascript/mastodon/features/alt_text_modal/components/ai_button.tsx
@@ -2,9 +2,9 @@ import { useState, useCallback } from 'react';
 
 import { FormattedMessage } from 'react-intl';
 
-import axios from 'axios';
+import { apiRequestPost } from 'mastodon/api';
 
-import AutoIcon from '@/material-icons/400-24px/auto_awesome.svg?react';
+import SmartIcon from '@/material-icons/400-24px/edit.svg?react';
 import { Icon } from 'mastodon/components/icon';
 import { LoadingIndicator } from 'mastodon/components/loading_indicator';
 
@@ -19,14 +19,13 @@ export const AiButton: React.FC<Props> = ({ mediaId, onSuccess }) => {
   const handleClick = useCallback(() => {
     setLoading(true);
 
-    axios
-      .post(`/api/v1/media/${mediaId}/alt_text`)
-      .then((res) => {
-        if (res.data.description) {
-          onSuccess(res.data.description);
+    apiRequestPost<{ description: string }>(`v1/media/${mediaId}/alt_text/ai`)
+      .then((data) => {
+        if (data.description) {
+          onSuccess(data.description);
         }
       })
-      .catch((error) => {
+      .catch((error: Error) => {
         console.error('Error generating alt text:', error);
       })
       .finally(() => {
@@ -44,7 +43,7 @@ export const AiButton: React.FC<Props> = ({ mediaId, onSuccess }) => {
         <LoadingIndicator />
       ) : (
         <>
-          <Icon id="auto" icon={AutoIcon} />
+          <Icon id="edit" icon={SmartIcon} />
           <FormattedMessage
             id="media_modal.generate_alt_with_ai"
             defaultMessage="Generate with AI"

--- a/app/javascript/mastodon/features/alt_text_modal/index.tsx
+++ b/app/javascript/mastodon/features/alt_text_modal/index.tsx
@@ -31,12 +31,13 @@ import Audio from 'mastodon/features/audio';
 import { CharacterCounter } from 'mastodon/features/compose/components/character_counter';
 import { Tesseract as fetchTesseract } from 'mastodon/features/ui/util/async-components';
 import Video, { getPointerPosition } from 'mastodon/features/video';
-import { me } from 'mastodon/initial_state';
 import type { MediaAttachment } from 'mastodon/models/media_attachment';
 import { useAppSelector, useAppDispatch } from 'mastodon/store';
 import { assetHost } from 'mastodon/utils/config';
 
+import { AiButton } from './components/ai_button';
 import { InfoButton } from './components/info_button';
+import { me, features } from 'mastodon/initial_state';
 
 const messages = defineMessages({
   placeholderVisual: {
@@ -523,6 +524,13 @@ export const AltTextModal = forwardRef<ModalRef, Props & Partial<RestoreProps>>(
                     defaultMessage='Add text from image'
                   />
                 </button>
+
+                {features?.alt_text_ai && type === 'image' && (
+                  <AiButton
+                    mediaId={mediaId}
+                    onSuccess={setDescription}
+                  />
+                )}
 
                 <InfoButton />
               </div>

--- a/app/javascript/mastodon/initial_state.js
+++ b/app/javascript/mastodon/initial_state.js
@@ -46,6 +46,7 @@
  * @property {string} sso_redirect
  * @property {string} status_page_url
  * @property {boolean} terms_of_service_enabled
+ * @property {boolean} alt_text_ai_enabled
  */
 
 /**
@@ -121,6 +122,11 @@ export const criticalUpdatesPending = initialState?.critical_updates_pending;
 export const statusPageUrl = getMeta('status_page_url');
 export const sso_redirect = getMeta('sso_redirect');
 export const termsOfServiceEnabled = getMeta('terms_of_service_enabled');
+
+// Feature flags
+export const features = {
+  alt_text_ai: getMeta('alt_text_ai_enabled'),
+};
 
 const displayNames = Intl.DisplayNames && new Intl.DisplayNames(getMeta('locale'), {
   type: 'language',

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -88,6 +88,7 @@
   "alt_text_badge.title": "Alt text",
   "alt_text_modal.add_alt_text": "Add alt text",
   "alt_text_modal.add_text_from_image": "Add text from image",
+  "media_modal.generate_alt_with_ai": "Generate with AI",
   "alt_text_modal.cancel": "Cancel",
   "alt_text_modal.change_thumbnail": "Change thumbnail",
   "alt_text_modal.describe_for_people_with_hearing_impairments": "Describe this for people with hearing impairments…",

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -111,6 +111,7 @@ class InitialStateSerializer < ActiveModel::Serializer
       trends_enabled: Setting.trends,
       version: instance_presenter.version,
       terms_of_service_enabled: TermsOfService.live.exists?,
+      alt_text_ai_enabled: Mastodon::Feature.alt_text_ai_enabled?,
     }
   end
 

--- a/app/services/alt_text_ai_service.rb
+++ b/app/services/alt_text_ai_service.rb
@@ -6,6 +6,7 @@ class AltTextAiService
   def initialize
     @prompt = ENV.fetch('ALT_TEXT_AI_PROMPT', 'Describe this image in detail for someone who cannot see it.')
     @api_base = ENV.fetch('ALT_TEXT_AI_API_BASE', nil)
+    @api_key = ENV.fetch('ALT_TEXT_AI_API_KEY', nil)
     @model = ENV.fetch('ALT_TEXT_AI_MODEL', 'google/gemma-3-4b-it')
   end
 
@@ -36,6 +37,7 @@ class AltTextAiService
     
     request = Net::HTTP::Post.new(uri.request_uri)
     request['Content-Type'] = 'application/json'
+    request['Authorization'] = "Bearer #{@api_key}" if @api_key.present?
     
     request.body = {
       model: @model,

--- a/app/services/alt_text_ai_service.rb
+++ b/app/services/alt_text_ai_service.rb
@@ -7,7 +7,7 @@ class AltTextAiService
     @prompt = ENV.fetch('ALT_TEXT_AI_PROMPT', 'Describe this image in detail for someone who cannot see it.')
     @api_base = ENV.fetch('ALT_TEXT_AI_API_BASE', nil)
     @api_key = ENV.fetch('ALT_TEXT_AI_API_KEY', nil)
-    @model = ENV.fetch('ALT_TEXT_AI_MODEL', 'google/gemma-3-4b-it')
+    @model = ENV.fetch('ALT_TEXT_AI_MODEL', 'google/gemma-3-4b-it:free')
   end
 
   def generate_alt_text(media_attachment)
@@ -31,7 +31,10 @@ class AltTextAiService
   end
 
   def make_openai_request(image_data)
+    #uri = URI.parse(@api_base + "/chat/completions")
     uri = URI.parse(@api_base)
+    uri.path = File.join(uri.path, 'chat/completions')
+
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = uri.scheme == 'https'
     
@@ -62,6 +65,7 @@ class AltTextAiService
     }.to_json
     
     response = http.request(request)
+    Rails.logger.error "it return #{response.body}"
     JSON.parse(response.body)
   end
 

--- a/app/services/alt_text_ai_service.rb
+++ b/app/services/alt_text_ai_service.rb
@@ -6,7 +6,7 @@ class AltTextAiService
   def initialize
     @prompt = ENV.fetch('ALT_TEXT_AI_PROMPT', 'Describe this image in detail for someone who cannot see it.')
     @api_base = ENV.fetch('ALT_TEXT_AI_API_BASE', nil)
-    @model = ENV.fetch('ALT_TEXT_AI_MODEL', 'gpt-4-vision-preview')
+    @model = ENV.fetch('ALT_TEXT_AI_MODEL', 'google/gemma-3-4b-it')
   end
 
   def generate_alt_text(media_attachment)

--- a/app/services/alt_text_ai_service.rb
+++ b/app/services/alt_text_ai_service.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+class AltTextAiService
+  include Singleton
+
+  def initialize
+    @prompt = ENV.fetch('ALT_TEXT_AI_PROMPT', 'Describe this image in detail for someone who cannot see it.')
+    @api_base = ENV.fetch('ALT_TEXT_AI_API_BASE', nil)
+    @model = ENV.fetch('ALT_TEXT_AI_MODEL', 'gpt-4-vision-preview')
+  end
+
+  def generate_alt_text(media_attachment)
+    return nil unless Mastodon::Feature.alt_text_ai_enabled?
+    return nil unless media_attachment.image?
+    return nil unless media_attachment.file.exists?
+
+    image_data = encode_image(media_attachment.file.path(:original))
+    response = make_openai_request(image_data)
+    
+    parse_response(response)
+  rescue => e
+    Rails.logger.error "Error generating alt text with AI: #{e}"
+    nil
+  end
+
+  private
+
+  def encode_image(file_path)
+    Base64.strict_encode64(File.read(file_path))
+  end
+
+  def make_openai_request(image_data)
+    uri = URI.parse(@api_base)
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = uri.scheme == 'https'
+    
+    request = Net::HTTP::Post.new(uri.request_uri)
+    request['Content-Type'] = 'application/json'
+    
+    request.body = {
+      model: @model,
+      messages: [
+        {
+          role: 'system',
+          content: @prompt
+        },
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'image_url',
+              image_url: {
+                url: "data:image/jpeg;base64,#{image_data}"
+              }
+            }
+          ]
+        }
+      ],
+      max_tokens: 300
+    }.to_json
+    
+    response = http.request(request)
+    JSON.parse(response.body)
+  end
+
+  def parse_response(response)
+    return nil unless response['choices'] && response['choices'].first && response['choices'].first['message']
+    
+    response['choices'].first['message']['content'].strip
+  end
+end

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -77,7 +77,11 @@ namespace :api, format: false do
       end
     end
 
-    resources :media, only: [:create, :update, :show, :destroy]
+    resources :media, only: [:create, :update, :show, :destroy] do
+      scope module: :media do
+        resources :alt_text, only: [:create]
+      end
+    end
     resources :blocks, only: [:index]
     resources :mutes, only: [:index]
     resources :favourites, only: [:index]

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -80,6 +80,7 @@ namespace :api, format: false do
     resources :media, only: [:create, :update, :show, :destroy] do
       scope module: :media do
         resources :alt_text, only: [:create]
+        post 'alt_text/ai', to: 'alt_text#create'
       end
     end
     resources :blocks, only: [:index]

--- a/docs/alt-text-ai.md
+++ b/docs/alt-text-ai.md
@@ -1,0 +1,47 @@
+# AI-Generated Alt Text for Images
+
+Mastodon now supports automatically generating alternative (alt) text for images using OpenAI's API. This feature helps improve accessibility by providing descriptions for images that might otherwise lack them.
+
+## Configuration
+
+This feature is optional and disabled by default. To enable it, you need to set the following environment variables:
+
+```bash
+# The system prompt to send to the OpenAI API
+ALT_TEXT_AI_PROMPT="Describe this image in detail for someone who cannot see it. Focus on the main subjects, actions, and important details. Be concise but thorough."
+
+# The base URL for the OpenAI API
+ALT_TEXT_AI_API_BASE="https://api.openai.com/v1/chat/completions"
+
+# The AI model to use (optional, defaults to gpt-4-vision-preview)
+ALT_TEXT_AI_MODEL="gpt-4-vision-preview"
+```
+
+The `ALT_TEXT_AI_PROMPT` and `ALT_TEXT_AI_API_BASE` environment variables must be set for the feature to be enabled. If either is missing, the feature will be completely hidden from the user interface. The `ALT_TEXT_AI_MODEL` variable is optional and defaults to "gpt-4-vision-preview".
+
+## How It Works
+
+When enabled, a "Generate with AI" button appears in the alt text modal when uploading or editing an image. Clicking this button sends the image to the configured OpenAI API endpoint using the GPT-4 Vision model, along with the system prompt specified in the environment variable.
+
+The generated description is then automatically populated in the alt text field, where users can review and edit it before saving.
+
+## Privacy and Security
+
+- Image data is only sent to the external API if the instance admin has explicitly enabled this feature by setting both required environment variables.
+- The feature is designed to work with OpenAI's API, but it can be configured to work with any compatible API endpoint that follows the same request/response format.
+- Users should always review the generated alt text before publishing to ensure it accurately describes the image.
+
+## Customization
+
+You can customize the system prompt by changing the `ALT_TEXT_AI_PROMPT` environment variable. A good prompt should instruct the AI to focus on the most important aspects of the image and provide clear, concise descriptions suitable for screen readers.
+
+## Troubleshooting
+
+If the "Generate with AI" button doesn't appear:
+- Verify that both environment variables are set correctly
+- Check that the image is in a supported format (JPEG, PNG, GIF, etc.)
+- Ensure your server can connect to the specified API endpoint
+
+If the generated descriptions are poor quality:
+- Try adjusting the system prompt to be more specific about what details to include or exclude
+- Consider using a different API endpoint that might provide better results for your use case

--- a/docs/alt-text-ai.md
+++ b/docs/alt-text-ai.md
@@ -13,11 +13,14 @@ ALT_TEXT_AI_PROMPT="Describe this image in detail for someone who cannot see it.
 # The base URL for the OpenAI-compatible API
 ALT_TEXT_AI_API_BASE="https://openrouter.ai/api/v1"
 
+# The API key for authentication
+ALT_TEXT_AI_API_KEY="your-api-key-here"
+
 # The AI model to use (optional, defaults to google/gemma-3-4b-it)
 ALT_TEXT_AI_MODEL="google/gemma-3-4b-it"
 ```
 
-The `ALT_TEXT_AI_PROMPT` and `ALT_TEXT_AI_API_BASE` environment variables must be set for the feature to be enabled. If either is missing, the feature will be completely hidden from the user interface. The `ALT_TEXT_AI_MODEL` variable is optional and defaults to "google/gemma-3-4b-it", which is available for free on OpenRouter at the time of creating this documentation.
+The `ALT_TEXT_AI_PROMPT`, `ALT_TEXT_AI_API_BASE`, and `ALT_TEXT_AI_API_KEY` environment variables must be set for the feature to be enabled. If any of these is missing, the feature will be completely hidden from the user interface. The `ALT_TEXT_AI_MODEL` variable is optional and defaults to "google/gemma-3-4b-it", which is available for free on OpenRouter at the time of creating this documentation.
 
 ## How It Works
 
@@ -33,7 +36,6 @@ The generated description is then automatically populated in the alt text field,
 ## Customization
 
 You can customize the system prompt by changing the `ALT_TEXT_AI_PROMPT` environment variable. A good prompt should instruct the AI to focus on the most important aspects of the image and provide clear, concise descriptions suitable for screen readers.
-
 ## Using OpenRouter
 
 The default configuration uses [OpenRouter](https://openrouter.ai/) as the API provider, which offers access to various AI models including the default "google/gemma-3-4b-it" model that is free to use (as of the time this documentation was created). To use OpenRouter:
@@ -41,8 +43,9 @@ The default configuration uses [OpenRouter](https://openrouter.ai/) as the API p
 1. Sign up for an account at [OpenRouter](https://openrouter.ai/)
 2. Get your API key from the dashboard
 3. Set `ALT_TEXT_AI_API_BASE` to "https://openrouter.ai/api/v1"
-4. Add your API key to the request headers in the service implementation if needed
+4. Set `ALT_TEXT_AI_API_KEY` to your OpenRouter API key
 
+OpenRouter provides a cost-effective way to access various AI models without having to set up separate accounts with each provider.
 OpenRouter provides a cost-effective way to access various AI models without having to set up separate accounts with each provider.
 You can customize the system prompt by changing the `ALT_TEXT_AI_PROMPT` environment variable. A good prompt should instruct the AI to focus on the most important aspects of the image and provide clear, concise descriptions suitable for screen readers.
 

--- a/docs/alt-text-ai.md
+++ b/docs/alt-text-ai.md
@@ -10,14 +10,14 @@ This feature is optional and disabled by default. To enable it, you need to set 
 # The system prompt to send to the OpenAI API
 ALT_TEXT_AI_PROMPT="Describe this image in detail for someone who cannot see it. Focus on the main subjects, actions, and important details. Be concise but thorough."
 
-# The base URL for the OpenAI API
-ALT_TEXT_AI_API_BASE="https://api.openai.com/v1/chat/completions"
+# The base URL for the OpenAI-compatible API
+ALT_TEXT_AI_API_BASE="https://openrouter.ai/api/v1"
 
-# The AI model to use (optional, defaults to gpt-4-vision-preview)
-ALT_TEXT_AI_MODEL="gpt-4-vision-preview"
+# The AI model to use (optional, defaults to google/gemma-3-4b-it)
+ALT_TEXT_AI_MODEL="google/gemma-3-4b-it"
 ```
 
-The `ALT_TEXT_AI_PROMPT` and `ALT_TEXT_AI_API_BASE` environment variables must be set for the feature to be enabled. If either is missing, the feature will be completely hidden from the user interface. The `ALT_TEXT_AI_MODEL` variable is optional and defaults to "gpt-4-vision-preview".
+The `ALT_TEXT_AI_PROMPT` and `ALT_TEXT_AI_API_BASE` environment variables must be set for the feature to be enabled. If either is missing, the feature will be completely hidden from the user interface. The `ALT_TEXT_AI_MODEL` variable is optional and defaults to "google/gemma-3-4b-it", which is available for free on OpenRouter at the time of creating this documentation.
 
 ## How It Works
 
@@ -30,9 +30,20 @@ The generated description is then automatically populated in the alt text field,
 - Image data is only sent to the external API if the instance admin has explicitly enabled this feature by setting both required environment variables.
 - The feature is designed to work with OpenAI's API, but it can be configured to work with any compatible API endpoint that follows the same request/response format.
 - Users should always review the generated alt text before publishing to ensure it accurately describes the image.
-
 ## Customization
 
+You can customize the system prompt by changing the `ALT_TEXT_AI_PROMPT` environment variable. A good prompt should instruct the AI to focus on the most important aspects of the image and provide clear, concise descriptions suitable for screen readers.
+
+## Using OpenRouter
+
+The default configuration uses [OpenRouter](https://openrouter.ai/) as the API provider, which offers access to various AI models including the default "google/gemma-3-4b-it" model that is free to use (as of the time this documentation was created). To use OpenRouter:
+
+1. Sign up for an account at [OpenRouter](https://openrouter.ai/)
+2. Get your API key from the dashboard
+3. Set `ALT_TEXT_AI_API_BASE` to "https://openrouter.ai/api/v1"
+4. Add your API key to the request headers in the service implementation if needed
+
+OpenRouter provides a cost-effective way to access various AI models without having to set up separate accounts with each provider.
 You can customize the system prompt by changing the `ALT_TEXT_AI_PROMPT` environment variable. A good prompt should instruct the AI to focus on the most important aspects of the image and provide clear, concise descriptions suitable for screen readers.
 
 ## Troubleshooting

--- a/lib/mastodon/feature.rb
+++ b/lib/mastodon/feature.rb
@@ -12,7 +12,7 @@ module Mastodon::Feature
     end
 
     def alt_text_ai_model
-      ENV.fetch('ALT_TEXT_AI_MODEL', 'gpt-4-vision-preview')
+      ENV.fetch('ALT_TEXT_AI_MODEL', 'google/gemma-3-4b-it')
     end
 
     def method_missing(name)

--- a/lib/mastodon/feature.rb
+++ b/lib/mastodon/feature.rb
@@ -8,7 +8,7 @@ module Mastodon::Feature
     end
 
     def alt_text_ai_enabled?
-      ENV['ALT_TEXT_AI_PROMPT'].present? && ENV['ALT_TEXT_AI_API_BASE'].present?
+      ENV['ALT_TEXT_AI_PROMPT'].present? && ENV['ALT_TEXT_AI_API_BASE'].present? && ENV['ALT_TEXT_AI_API_KEY'].present?
     end
 
     def alt_text_ai_model

--- a/lib/mastodon/feature.rb
+++ b/lib/mastodon/feature.rb
@@ -7,6 +7,14 @@ module Mastodon::Feature
         (Rails.configuration.x.mastodon.experimental_features || '').split(',').map(&:strip)
     end
 
+    def alt_text_ai_enabled?
+      ENV['ALT_TEXT_AI_PROMPT'].present? && ENV['ALT_TEXT_AI_API_BASE'].present?
+    end
+
+    def alt_text_ai_model
+      ENV.fetch('ALT_TEXT_AI_MODEL', 'gpt-4-vision-preview')
+    end
+
     def method_missing(name)
       if respond_to_missing?(name)
         feature = name.to_s.delete_suffix('_enabled?')


### PR DESCRIPTION
feat(accessibility): Add AI-generated alt text for images
This commit adds an optional feature that allows Mastodon instances to use
OpenAI's API (or compatible APIs) to automatically generate alternative text
for images in posts.

Key components:
- Backend service to communicate with OpenAI API
- Frontend button in the alt text modal
- Feature flag system using environment variables
- Comprehensive documentation

The feature is completely optional and only activates when the required
environment variables are set:
- ALT_TEXT_AI_PROMPT: System prompt for the AI
- ALT_TEXT_AI_API_BASE: Base URL for the API
- ALT_TEXT_AI_MODEL (optional): AI model to use, defaults to google/gemma-3-4b-it:free

This enhances accessibility by making it easier for users to add descriptive
alt text to their images, which is essential for screen reader users and
improves the experience for everyone.

This is created by Polish Foundation Technologies for People  https://ftdl.pl/ 

https://github.com/user-attachments/assets/56cb4b35-0f6c-4b5e-ac16-4049b34353ec

