### PR TITLE
Fix `CacheBuster` being queued for missing media attachments

### DIFF
--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -420,6 +420,8 @@ class MediaAttachment < ApplicationRecord
 
     @paths_to_cache_bust = MediaAttachment.attachment_definitions.keys.flat_map do |attachment_name|
       attachment = public_send(attachment_name)
+      next if attachment.blank?
+
       styles = DEFAULT_STYLES | attachment.styles.keys
       styles.map { |style| attachment.url(style) }
     end.compact

--- a/spec/models/media_attachment_spec.rb
+++ b/spec/models/media_attachment_spec.rb
@@ -302,6 +302,15 @@ RSpec.describe MediaAttachment, :attachment_processing do
         .to enqueue_sidekiq_job(CacheBusterWorker).with(original_url)
         .and enqueue_sidekiq_job(CacheBusterWorker).with(small_url)
     end
+
+    context 'with a missing remote attachment' do
+      let(:media) { Fabricate(:media_attachment, remote_url: 'https://example.com/foo.png', file: nil) }
+
+      it 'does not queue CacheBusterWorker jobs' do
+        expect { media.destroy }
+          .to_not enqueue_sidekiq_job(CacheBusterWorker)
+      end
+    end
   end
 
   private


### PR DESCRIPTION
Fixes #34251