### PR TITLE
Fix follower synchronization mechanism erroneously removing followers from multi-page collections

### DIFF
--- a/app/services/activitypub/synchronize_followers_service.rb
+++ b/app/services/activitypub/synchronize_followers_service.rb
@@ -57,6 +57,9 @@ class ActivityPub::SynchronizeFollowersService < BaseService
     collection = fetch_collection(collection['first']) if collection['first'].present?
     return unless collection.is_a?(Hash)
 
+    # Abort if we'd have to paginate through more than one page of followers
+    return if collection['next'].present?
+
     case collection['type']
     when 'Collection', 'CollectionPage'
       as_array(collection['items'])


### PR DESCRIPTION
Mastodon implements [FEP-8fcf: Followers collection synchronization across servers](https://codeberg.org/fediverse/fep/src/branch/main/fep/8fcf/fep-8fcf.md), but requires every identifier to be in a single page.

The reasons for only supporting one page are:
- Mastodon must hold all the identifiers in memory anyway
- this puts a bound on the number of network requests required
- this is easier to implement and less error-prone

However, when such a partial collection is split in multiple pages, Mastodon currently ignores everything past the first page, effectively incorrectly removing every follower represented by other pages.

This PR fixes that by aborting if there are multiple pages involved.