### PR TITLE
Add digest re-check before removing followers in synchronization mechanism

### DIFF
--- a/app/services/activitypub/prepare_followers_synchronization_service.rb
+++ b/app/services/activitypub/prepare_followers_synchronization_service.rb
@@ -8,6 +8,6 @@ class ActivityPub::PrepareFollowersSynchronizationService < BaseService
 
     return if params['collectionId'] != @account.followers_url || non_matching_uri_hosts?(@account.uri, params['url']) || @account.local_followers_hash == params['digest']
 
-    ActivityPub::FollowersSynchronizationWorker.perform_async(@account.id, params['url'])
+    ActivityPub::FollowersSynchronizationWorker.perform_async(@account.id, params['url'], params['digest'])
   end
 end

--- a/app/workers/activitypub/followers_synchronization_worker.rb
+++ b/app/workers/activitypub/followers_synchronization_worker.rb
@@ -5,10 +5,10 @@ class ActivityPub::FollowersSynchronizationWorker
 
   sidekiq_options queue: 'push', lock: :until_executed
 
-  def perform(account_id, url)
+  def perform(account_id, url, expected_digest = nil)
     @account = Account.find_by(id: account_id)
     return true if @account.nil?
 
-    ActivityPub::SynchronizeFollowersService.new.call(@account, url)
+    ActivityPub::SynchronizeFollowersService.new.call(@account, url, expected_digest)
   end
 end

--- a/spec/services/activitypub/synchronize_followers_service_spec.rb
+++ b/spec/services/activitypub/synchronize_followers_service_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe ActivityPub::SynchronizeFollowersService do
 
   shared_examples 'synchronizes followers' do
     before do
-      subject.call(actor, collection_uri)
+      subject.call(actor, collection_uri, expected_digest)
     end
 
     it 'maintains following records and sends Undo Follow to actor' do
@@ -51,6 +51,8 @@ RSpec.describe ActivityPub::SynchronizeFollowersService do
   end
 
   describe '#call' do
+    let(:expected_digest) { nil }
+
     context 'when the endpoint is a Collection of actor URIs' do
       before do
         stub_request(:get, collection_uri).to_return(status: 200, body: Oj.dump(payload), headers: { 'Content-Type': 'application/activity+json' })
@@ -195,6 +197,132 @@ RSpec.describe ActivityPub::SynchronizeFollowersService do
           .to be_empty
         expect(mallory)
           .to be_following(actor)
+      end
+    end
+
+    context 'when passing a matching expected_digest' do
+      let(:expected_digest) do
+        digest = "\x00" * 32
+
+        items.each do |uri|
+          Xorcist.xor!(digest, Digest::SHA256.digest(uri))
+        end
+
+        digest.unpack1('H*')
+      end
+
+      context 'when the endpoint is a Collection of actor URIs' do
+        before do
+          stub_request(:get, collection_uri).to_return(status: 200, body: Oj.dump(payload), headers: { 'Content-Type': 'application/activity+json' })
+        end
+
+        it_behaves_like 'synchronizes followers'
+      end
+
+      context 'when the endpoint is an OrderedCollection of actor URIs' do
+        let(:payload) do
+          {
+            '@context': 'https://www.w3.org/ns/activitystreams',
+            type: 'OrderedCollection',
+            id: collection_uri,
+            orderedItems: items,
+          }.with_indifferent_access
+        end
+
+        before do
+          stub_request(:get, collection_uri).to_return(status: 200, body: Oj.dump(payload), headers: { 'Content-Type': 'application/activity+json' })
+        end
+
+        it_behaves_like 'synchronizes followers'
+      end
+
+      context 'when the endpoint is a single-page paginated Collection of actor URIs' do
+        let(:payload) do
+          {
+            '@context': 'https://www.w3.org/ns/activitystreams',
+            type: 'Collection',
+            id: collection_uri,
+            first: {
+              type: 'CollectionPage',
+              partOf: collection_uri,
+              items: items,
+            },
+          }.with_indifferent_access
+        end
+
+        before do
+          stub_request(:get, collection_uri).to_return(status: 200, body: Oj.dump(payload), headers: { 'Content-Type': 'application/activity+json' })
+        end
+
+        it_behaves_like 'synchronizes followers'
+      end
+    end
+
+    context 'when passing a non-matching expected_digest' do
+      let(:expected_digest) { '123456789' }
+
+      context 'when the endpoint is a Collection of actor URIs' do
+        before do
+          stub_request(:get, collection_uri).to_return(status: 200, body: Oj.dump(payload), headers: { 'Content-Type': 'application/activity+json' })
+        end
+
+        it 'does not remove followers' do
+          follower_ids = actor.followers.reload.pluck(:id)
+
+          subject.call(actor, collection_uri, expected_digest)
+
+          expect(follower_ids - actor.followers.reload.pluck(:id)).to be_empty
+        end
+      end
+
+      context 'when the endpoint is an OrderedCollection of actor URIs' do
+        let(:payload) do
+          {
+            '@context': 'https://www.w3.org/ns/activitystreams',
+            type: 'OrderedCollection',
+            id: collection_uri,
+            orderedItems: items,
+          }.with_indifferent_access
+        end
+
+        before do
+          stub_request(:get, collection_uri).to_return(status: 200, body: Oj.dump(payload), headers: { 'Content-Type': 'application/activity+json' })
+        end
+
+        it 'does not remove followers' do
+          follower_ids = actor.followers.reload.pluck(:id)
+
+          subject.call(actor, collection_uri, expected_digest)
+
+          expect(follower_ids - actor.followers.reload.pluck(:id)).to be_empty
+        end
+      end
+
+      context 'when the endpoint is a single-page paginated Collection of actor URIs' do
+        let(:payload) do
+          {
+            '@context': 'https://www.w3.org/ns/activitystreams',
+            type: 'Collection',
+            id: collection_uri,
+            first: {
+              type: 'CollectionPage',
+              partOf: collection_uri,
+              items: items,
+            },
+          }.with_indifferent_access
+        end
+
+        before do
+          stub_request(:get, collection_uri).to_return(status: 200, body: Oj.dump(payload), headers: { 'Content-Type': 'application/activity+json' })
+        end
+
+        it 'does not remove followers' do
+          follower_ids = actor.followers.reload.pluck(:id)
+
+          subject.call(actor, collection_uri, expected_digest)
+
+          expect(follower_ids - actor.followers.reload.pluck(:id)).to be_empty
+        end
       end
     end
   end

--- a/spec/workers/activitypub/followers_synchronization_worker_spec.rb
+++ b/spec/workers/activitypub/followers_synchronization_worker_spec.rb
@@ -15,7 +15,13 @@ RSpec.describe ActivityPub::FollowersSynchronizationWorker do
     it 'sends the status to the service' do
       worker.perform(account.id, url)
 
-      expect(service).to have_received(:call).with(account, url)
+      expect(service).to have_received(:call).with(account, url, nil)
+    end
+
+    it 'sends the status to the service with the passed digest' do
+      worker.perform(account.id, url, 'digest-123')
+
+      expect(service).to have_received(:call).with(account, url, 'digest-123')
     end
 
     it 'returns nil for non-existent record' do


### PR DESCRIPTION
The follower synchronization mechanism works by computing a digest of follow the expected followers of an account on a remote server, then fetching that collection if needed.

Currently, Mastodon does not re-check the expected digest on the newly-fetched collection, as it assumes any change may just be down to the newly-fetched collection having more up-to-date values.

This PR adds re-checking of the digest before removing any follower, potentially guarding against stale caches and possible other errors, although I'm not sure when this would actually occur.

This also requires that the partial collection features no duplication, even across pages.

## Benefits

- may guard against some unlikely classes of implementation issues
- may guard against wrongly undoing recent follows in case of stale cached collections

## Drawbacks

- increased code complexity
- increased computation
- requires the collection to not have duplicates across pages
- may cause follower synchronization to be skipped if too much time occurs between receiving a hash and processing the collection