### PR TITLE
Use fixed order in flaky spec

### DIFF
--- a/spec/requests/api/v2/notifications_spec.rb
+++ b/spec/requests/api/v2/notifications_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe 'Notifications' do
       end
 
       context 'with min_id param' do
-        let(:params) { { min_id: user.account.notifications.reload.first.id - 1 } }
+        let(:params) { { min_id: user.account.notifications.order(id: :asc).first.id - 1 } }
 
         it 'returns a notification group covering all notifications' do
           subject


### PR DESCRIPTION
This spec fails on rare occasions such as here: https://github.com/mastodon/mastodon/actions/runs/14077970162/job/39424468411#step:9:1

This is an attempt to remove the flakiness of that test.