### PR TITLE
Change `AccountReachFinder` to consider statuses based on suspension date

### DIFF
--- a/app/lib/account_reach_finder.rb
+++ b/app/lib/account_reach_finder.rb
@@ -37,7 +37,11 @@ class AccountReachFinder
 
   def oldest_status_id
     Mastodon::Snowflake
-      .id_at(STATUS_SINCE.ago, with_random: false)
+      .id_at(oldest_status_date, with_random: false)
+  end
+
+  def oldest_status_date
+    @account.suspended? && @account.suspension_origin_local? ? @account.suspended_at - STATUS_SINCE : STATUS_SINCE.ago
   end
 
   def recent_statuses


### PR DESCRIPTION
When suspending or unsuspending an account, an `Update` is currently sent to:
- anyone who is following the account
- anyone who has reported the account
- anyone who was recently messaged by the account

However, “recently” in the last step means “2 days ago”, creating a discrepancy between suspension and unsuspension.

This PR treats suspended users as “2 days before the suspension” to reach the same audience.