### PR TITLE
Change account suspensions to be federated to recently-followed accounts as well

### DIFF
--- a/app/lib/account_reach_finder.rb
+++ b/app/lib/account_reach_finder.rb
@@ -10,7 +10,7 @@ class AccountReachFinder
   end
 
   def inboxes
-    (followers_inboxes + reporters_inboxes + recently_mentioned_inboxes + relay_inboxes).uniq
+    (followers_inboxes + reporters_inboxes + recently_mentioned_inboxes + recently_followed_inboxes + recently_requested_inboxes + relay_inboxes).uniq
   end
 
   private
@@ -31,16 +31,31 @@ class AccountReachFinder
       .take(RECENT_LIMIT)
   end
 
+  def recently_followed_inboxes
+    @account
+      .following
+      .where(follows: { created_at: recent_date_cutoff... })
+      .inboxes
+      .take(RECENT_LIMIT)
+  end
+
+  def recently_requested_inboxes
+    Account
+      .where(id: @account.follow_requests.where({ created_at: recent_date_cutoff... }).select(:target_account_id))
+      .inboxes
+      .take(RECENT_LIMIT)
+  end
+
   def relay_inboxes
     Relay.enabled.pluck(:inbox_url)
   end
 
   def oldest_status_id
     Mastodon::Snowflake
-      .id_at(oldest_status_date, with_random: false)
+      .id_at(recent_date_cutoff, with_random: false)
   end
 
-  def oldest_status_date
+  def recent_date_cutoff
     @account.suspended? && @account.suspension_origin_local? ? @account.suspended_at - STATUS_SINCE : STATUS_SINCE.ago
   end
 

--- a/spec/lib/account_reach_finder_spec.rb
+++ b/spec/lib/account_reach_finder_spec.rb
@@ -13,12 +13,27 @@ RSpec.describe AccountReachFinder do
   let(:ap_mentioned_example_com) { Fabricate(:account, protocol: :activitypub, inbox_url: 'https://example.com/inbox-3', domain: 'example.com') }
   let(:ap_mentioned_example_org) { Fabricate(:account, protocol: :activitypub, inbox_url: 'https://example.org/inbox-4', domain: 'example.org') }
 
+  let(:ap_followed_example_com) { Fabricate(:account, protocol: :activitypub, inbox_url: 'https://example.com/inbox-5', domain: 'example.com') }
+  let(:ap_followed_example_org) { Fabricate(:account, protocol: :activitypub, inbox_url: 'https://example.com/inbox-6', domain: 'example.org') }
+
+  let(:ap_requested_example_com) { Fabricate(:account, protocol: :activitypub, inbox_url: 'https://example.com/inbox-7', domain: 'example.com') }
+  let(:ap_requested_example_org) { Fabricate(:account, protocol: :activitypub, inbox_url: 'https://example.com/inbox-8', domain: 'example.org') }
+
   let(:unrelated_account) { Fabricate(:account, protocol: :activitypub, inbox_url: 'https://example.com/unrelated-inbox', domain: 'example.com') }
+  let(:old_followed_account) { Fabricate(:account, protocol: :activitypub, inbox_url: 'https://example.com/old-followed-inbox', domain: 'example.com') }
 
   before do
+    travel_to(2.months.ago) { account.follow!(old_followed_account) }
+
     ap_follower_example_com.follow!(account)
     ap_follower_example_org.follow!(account)
     ap_follower_with_shared.follow!(account)
+
+    account.follow!(ap_followed_example_com)
+    account.follow!(ap_followed_example_org)
+
+    account.request_follow!(ap_requested_example_com)
+    account.request_follow!(ap_requested_example_org)
 
     Fabricate(:status, account: account).tap do |status|
       status.mentions << Mention.new(account: ap_follower_example_com)
@@ -44,7 +59,10 @@ RSpec.describe AccountReachFinder do
       expect(subject)
         .to include(*follower_inbox_urls)
         .and include(*mentioned_account_inbox_urls)
+        .and include(*recently_followed_inbox_urls)
+        .and include(*recently_requested_inbox_urls)
         .and not_include(unrelated_account.preferred_inbox_url)
+        .and not_include(old_followed_account.preferred_inbox_url)
     end
 
     def follower_inbox_urls
@@ -54,6 +72,16 @@ RSpec.describe AccountReachFinder do
 
     def mentioned_account_inbox_urls
       [ap_mentioned_with_shared, ap_mentioned_example_com, ap_mentioned_example_org]
+        .map(&:preferred_inbox_url)
+    end
+
+    def recently_followed_inbox_urls
+      [ap_followed_example_com, ap_followed_example_org]
+        .map(&:preferred_inbox_url)
+    end
+
+    def recently_requested_inbox_urls
+      [ap_requested_example_com, ap_requested_example_org]
         .map(&:preferred_inbox_url)
     end
   end


### PR DESCRIPTION
Currently, Mastodon sends suspension notice to servers which have followed it, reported it, or were recently mentioned.

This adds recently-followed and recently-requested accounts to the mix, to address the issue of follow bots.