### PR TITLE
Fix intermittent failure on account note system spec

### DIFF
--- a/spec/system/account_notes_spec.rb
+++ b/spec/system/account_notes_spec.rb
@@ -24,8 +24,10 @@ RSpec.describe 'Account notes', :inline_jobs, :js, :streaming do
     # The easiest way is to send ctrl+enter ourselves
     find_field(class: 'account__header__account-note__content').send_keys [:control, :enter]
 
-    expect(page)
-      .to have_css('.account__header__account-note .inline-alert', text: 'SAVED')
+    within('.account__header__account-note .inline-alert') do
+      expect(page)
+        .to have_content('SAVED')
+    end
 
     expect(page)
       .to have_css('.account__header__account-note__content', text: note_text)


### PR DESCRIPTION
Example failure: https://github.com/mastodon/mastodon/actions/runs/14109041705/job/39522711706

I THINK what's happening here is that the element with `.inline-alert` is already in the page DOM, so there's a timing issue where capybara immediately finds the element, but the text has not yet been changed on success. The intent of the change here is let it find the element right away ... but then have it wait on the content to show up.

That said, I'm not able to replicate this failure locally, so this is partially a guess. I think worst case it should have similar rate of intermittent failure, and best case it may fix it?