### PR TITLE
Fix intermittent account note failure by removing disappearing content check

### DIFF
--- a/spec/system/account_notes_spec.rb
+++ b/spec/system/account_notes_spec.rb
@@ -24,11 +24,6 @@ RSpec.describe 'Account notes', :inline_jobs, :js, :streaming do
     # The easiest way is to send ctrl+enter ourselves
     find_field(class: 'account__header__account-note__content').send_keys [:control, :enter]
 
-    within('.account__header__account-note .inline-alert') do
-      expect(page)
-        .to have_content('SAVED')
-    end
-
     expect(page)
       .to have_css('.account__header__account-note__content', text: note_text)
 


### PR DESCRIPTION
Essentially another pass at https://github.com/mastodon/mastodon/pull/34295

What I thought was happening in original was that the inline-alert element and the text within that element were being added separately and we had a timing thing where capybara would see the wrapper element but not (yet) the inner text, and fail.

Having done a variety of local browser experimenting, and putting `sleep` in various places to replicate the failure, I now think what's happening is: the DOM element is always there, but its visibility (and text content) is toggled. It has a transition/animation to disappear, with a time value set for that in the `AccountNote` jsx.

I think the failure issue here is that on some runs, after the field is submitted, the headless browser has already added/removed the "Saved" element before the rspec process can run the next line and check for that content, so it fails. I was able to replicate that by playing with various `sleep` values in between the send_keys line and the next line doing the check ... with no sleep it passes, but as I crept the value up past the transition threshold it would start to fail.

Since the original regression here was around the note update feature working AT ALL (and we preserve that coverage in the rest of this spec), and not the transition/animation/status text, I opted to just remove that portion of the spec here. It strikes me as the sort of thing better suited for a JS unit spec if we want to narrowly fiddle with the animation appearance/disappearance dynamics? Also open to other ideas on how to use capybara here, but I don't think we should go too deep on messing with sync/wait/etc internals.
