### PR TITLE
Add server-side support for grouping account sign-up notifications

### DIFF
--- a/app/models/concerns/notification/groups.rb
+++ b/app/models/concerns/notification/groups.rb
@@ -4,7 +4,7 @@ module Notification::Groups
   extend ActiveSupport::Concern
 
   # `set_group_key!` needs to be updated if this list changes
-  GROUPABLE_NOTIFICATION_TYPES = %i(favourite reblog follow).freeze
+  GROUPABLE_NOTIFICATION_TYPES = %i(favourite reblog follow admin.sign_up).freeze
   MAXIMUM_GROUP_SPAN_HOURS = 12
 
   included do
@@ -17,7 +17,7 @@ module Notification::Groups
     type_prefix = case type
                   when :favourite, :reblog
                     [type, target_status&.id].join('-')
-                  when :follow
+                  when :follow, :'admin.sign_up'
                     type
                   else
                     raise NotImplementedError


### PR DESCRIPTION
Note that, according to the documentation (which should be edited to add this new types), this changes the default behavior of `/api/v2/notifications`, and `grouped_types` must be explicitly passed (as the WebUI already does) by clients not prepared to handle a new notification group type.

Documentation PR: https://github.com/mastodon/documentation/pull/1626