### PR TITLE
Fix extra space under left-indented vertical videos

### DIFF
--- a/app/javascript/mastodon/features/video/index.tsx
+++ b/app/javascript/mastodon/features/video/index.tsx
@@ -783,7 +783,7 @@ export const Video: React.FC<{
 
   // The outer wrapper is necessary to avoid reflowing the layout when going into full screen
   return (
-    <div style={{ aspectRatio }}>
+    <div>
       <div
         role='menuitem'
         className={classNames('video-player', {


### PR DESCRIPTION
The video wrapping was forced to have the aspect ratio of the video itself, even when it has left-padding (because it is a reply or an ancestor in a thread), causing extra padding below the video.