### PR TITLE
Fix poll refresh button being incorrectly hidden

### DIFF
--- a/app/javascript/mastodon/components/poll.tsx
+++ b/app/javascript/mastodon/components/poll.tsx
@@ -7,7 +7,6 @@ import classNames from 'classnames';
 
 import { animated, useSpring } from '@react-spring/web';
 import escapeTextContentForBrowser from 'escape-html';
-import { debounce } from 'lodash';
 
 import CheckIcon from '@/material-icons/400-24px/check.svg?react';
 import { openModal } from 'mastodon/actions/modal';
@@ -128,13 +127,7 @@ export const Poll: React.FC<PollProps> = ({ pollId, disabled, status }) => {
     if (disabled) {
       return;
     }
-    debounce(
-      () => {
-        void dispatch(fetchPoll({ pollId }));
-      },
-      1000,
-      { leading: true },
-    );
+    void dispatch(fetchPoll({ pollId }));
   }, [disabled, dispatch, pollId]);
 
   const handleOptionChange = useCallback(

--- a/app/javascript/mastodon/components/poll.tsx
+++ b/app/javascript/mastodon/components/poll.tsx
@@ -45,9 +45,7 @@ interface PollProps {
   disabled?: boolean;
 }
 
-export const Poll: React.FC<PollProps> = (props) => {
-  const { pollId, status } = props;
-
+export const Poll: React.FC<PollProps> = ({ pollId, disabled, status }) => {
   // Third party hooks
   const poll = useAppSelector((state) => state.polls[pollId]);
   const identity = useIdentity();
@@ -97,12 +95,12 @@ export const Poll: React.FC<PollProps> = (props) => {
     );
   }, [poll]);
 
-  const disabled =
-    props.disabled || Object.values(selected).every((item) => !item);
+  const voteDisabled =
+    disabled || Object.values(selected).every((item) => !item);
 
   // Event handlers
   const handleVote = useCallback(() => {
-    if (disabled) {
+    if (voteDisabled) {
       return;
     }
 
@@ -120,7 +118,7 @@ export const Poll: React.FC<PollProps> = (props) => {
         }),
       );
     }
-  }, [disabled, dispatch, identity, pollId, selected, status]);
+  }, [voteDisabled, dispatch, identity, pollId, selected, status]);
 
   const handleReveal = useCallback(() => {
     setRevealed(true);
@@ -181,7 +179,7 @@ export const Poll: React.FC<PollProps> = (props) => {
         {!showResults && (
           <button
             className='button button-secondary'
-            disabled={disabled}
+            disabled={voteDisabled}
             onClick={handleVote}
           >
             <FormattedMessage id='poll.vote' defaultMessage='Vote' />


### PR DESCRIPTION
Fix regression from #34293

The original code had weird shadowing for the `disabled` variable, initially loaded from props and later on redefined for the vote button. Instead of shadowing, added a new `voteDisabled` variable.

The button itself was not working because of the `debounce`d function not being called. I decided to remove the debouncing altogether because it's easier and it was absent from the pre-rewrite component, but it can be added back in a later PR.