### PR TITLE
Bump version to v4.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project will be documented in this file.
 
+## [4.3.7] - 2025-04-02
+
+### Add
+
+- Add delay to profile updates to debounce them (#34137 by @ClearlyClaire)
+- Add support for paginating partial collections in `SynchronizeFollowersService` (#34272 and #34277 by @ClearlyClaire)
+
+### Changed
+
+- Change account suspensions to be federated to recently-followed accounts as well (#34294 by @ClearlyClaire)
+- Change `AccountReachFinder` to consider statuses based on suspension date (#32805 and #34291 by @ClearlyClaire and @mjankowski)
+- Change user archive signed URL TTL from 10 seconds to 1 hour (#34254 by @ClearlyClaire)
+
+### Fixed
+
+- Fix static version of animated PNG emojis not being properly extracted (#34337 by @ClearlyClaire)
+- Fix filters not applying in detailed view, favourites and bookmarks (#34259 and #34260 by @ClearlyClaire)
+- Fix handling of malformed/unusual HTML (#34201 by @ClearlyClaire)
+- Fix `CacheBuster` being queued for missing media attachments (#34253 by @ClearlyClaire)
+- Fix incorrect URL being used when cache busting (#34189 by @ClearlyClaire)
+- Fix streaming server refusing unix socket path in `DATABASE_URL` (#34091 by @ClearlyClaire)
+- Fix “x” hotkey not working on boosted filtered posts (#33758 by @ClearlyClaire)
+
 ## [4.3.6] - 2025-03-13
 
 ### Security

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
   web:
     # You can uncomment the following line if you want to not use the prebuilt image, for example if you have local code changes
     # build: .
-    image: ghcr.io/mastodon/mastodon:v4.3.6
+    image: ghcr.io/mastodon/mastodon:v4.3.7
     restart: always
     env_file: .env.production
     command: bundle exec puma -C config/puma.rb
@@ -83,7 +83,7 @@ services:
     # build:
     #   dockerfile: ./streaming/Dockerfile
     #   context: .
-    image: ghcr.io/mastodon/mastodon-streaming:v4.3.6
+    image: ghcr.io/mastodon/mastodon-streaming:v4.3.7
     restart: always
     env_file: .env.production
     command: node ./streaming/index.js
@@ -102,7 +102,7 @@ services:
   sidekiq:
     # You can uncomment the following line if you want to not use the prebuilt image, for example if you have local code changes
     # build: .
-    image: ghcr.io/mastodon/mastodon:v4.3.6
+    image: ghcr.io/mastodon/mastodon:v4.3.7
     restart: always
     env_file: .env.production
     command: bundle exec sidekiq

--- a/lib/mastodon/version.rb
+++ b/lib/mastodon/version.rb
@@ -13,7 +13,7 @@ module Mastodon
     end
 
     def patch
-      6
+      7
     end
 
     def default_prerelease


### PR DESCRIPTION
### Add

- Add delay to profile updates to debounce them (#34137 by `@ClearlyClaire`)
- Add support for paginating partial collections in `SynchronizeFollowersService` (#34272 and #34277 by `@ClearlyClaire`)

### Changed

- Change account suspensions to be federated to recently-followed accounts as well (#34294 by `@ClearlyClaire`)
- Change `AccountReachFinder` to consider statuses based on suspension date (#32805 and #34291 by `@ClearlyClaire` and `@mjankowski`)
- Change user archive signed URL TTL from 10 seconds to 1 hour (#34254 by `@ClearlyClaire`)

### Fixed

- Fix static version of animated PNG emojis not being properly extracted (#34337 by `@ClearlyClaire`)
- Fix filters not applying in detailed view, favourites and bookmarks (#34259 and #34260 by `@ClearlyClaire`)
- Fix handling of malformed/unusual HTML (#34201 by `@ClearlyClaire`)
- Fix `CacheBuster` being queued for missing media attachments (#34253 by `@ClearlyClaire`)
- Fix incorrect URL being used when cache busting (#34189 by `@ClearlyClaire`)
- Fix streaming server refusing unix socket path in `DATABASE_URL` (#34091 by `@ClearlyClaire`)
- Fix “x” hotkey not working on boosted filtered posts (#33758 by `@ClearlyClaire`)