### PR TITLE
Bump version to v4.2.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [4.2.20] - 2025-04-02
+
+### Add
+
+- Add delay to profile updates to debounce them (#34137 by @ClearlyClaire)
+- Add support for paginating partial collections in `SynchronizeFollowersService` (#34272 and #34277 by @ClearlyClaire)
+
+### Changed
+
+- Change account suspensions to be federated to recently-followed accounts as well (#34294 by @ClearlyClaire)
+- Change `AccountReachFinder` to consider statuses based on suspension date (#32805 and #34291 by @ClearlyClaire and @mjankowski)
+- Change user archive signed URL TTL from 10 seconds to 1 hour (#34254 by @ClearlyClaire)
+
+### Fixed
+
+- Fix incorrect URL being used when cache busting (#34189 by @ClearlyClaire)
+
 ## [4.2.19] - 2025-03-13
 
 ### Security

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
 
   web:
     build: .
-    image: ghcr.io/mastodon/mastodon:v4.2.19
+    image: ghcr.io/mastodon/mastodon:v4.2.20
     restart: always
     env_file: .env.production
     command: bash -c "rm -f /mastodon/tmp/pids/server.pid; bundle exec rails s -p 3000"
@@ -77,7 +77,7 @@ services:
 
   streaming:
     build: .
-    image: ghcr.io/mastodon/mastodon:v4.2.19
+    image: ghcr.io/mastodon/mastodon:v4.2.20
     restart: always
     env_file: .env.production
     command: node ./streaming
@@ -95,7 +95,7 @@ services:
 
   sidekiq:
     build: .
-    image: ghcr.io/mastodon/mastodon:v4.2.19
+    image: ghcr.io/mastodon/mastodon:v4.2.20
     restart: always
     env_file: .env.production
     command: bundle exec sidekiq

--- a/lib/mastodon/version.rb
+++ b/lib/mastodon/version.rb
@@ -13,7 +13,7 @@ module Mastodon
     end
 
     def patch
-      19
+      20
     end
 
     def default_prerelease


### PR DESCRIPTION
### Add

- Add delay to profile updates to debounce them (#34137 by `@ClearlyClaire`)
- Add support for paginating partial collections in `SynchronizeFollowersService` (#34272 and #34277 by `@ClearlyClaire`)

### Changed

- Change account suspensions to be federated to recently-followed accounts as well (#34294 by `@ClearlyClaire`)
- Change `AccountReachFinder` to consider statuses based on suspension date (#32805 and #34291 by `@ClearlyClaire` and `@mjankowski`)
- Change user archive signed URL TTL from 10 seconds to 1 hour (#34254 by `@ClearlyClaire`)

### Fixed

- Fix incorrect URL being used when cache busting (#34189 by `@ClearlyClaire`)