### PR TITLE
Bump version to v4.1.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+## [4.1.25] - 2025-04-02
+
+### Add
+
+- Add support for paginating partial collections in `SynchronizeFollowersService` (#34272 and #34277 by @ClearlyClaire)
+
+### Fixed
+
+- Fix incorrect URL being used when cache busting (#34189 by @ClearlyClaire)
+
 ## [4.1.24] - 2025-03-13
 
 ### Security

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
 
   web:
     build: .
-    image: ghcr.io/mastodon/mastodon:v4.1.24
+    image: ghcr.io/mastodon/mastodon:v4.1.25
     restart: always
     env_file: .env.production
     command: bash -c "rm -f /mastodon/tmp/pids/server.pid; bundle exec rails s -p 3000"
@@ -77,7 +77,7 @@ services:
 
   streaming:
     build: .
-    image: ghcr.io/mastodon/mastodon:v4.1.24
+    image: ghcr.io/mastodon/mastodon:v4.1.25
     restart: always
     env_file: .env.production
     command: node ./streaming
@@ -95,7 +95,7 @@ services:
 
   sidekiq:
     build: .
-    image: ghcr.io/mastodon/mastodon:v4.1.24
+    image: ghcr.io/mastodon/mastodon:v4.1.25
     restart: always
     env_file: .env.production
     command: bundle exec sidekiq

--- a/lib/mastodon/version.rb
+++ b/lib/mastodon/version.rb
@@ -13,7 +13,7 @@ module Mastodon
     end
 
     def patch
-      24
+      25
     end
 
     def flags


### PR DESCRIPTION
### Add

- Add support for paginating partial collections in `SynchronizeFollowersService` (#34272 and #34277 by `@ClearlyClaire`)

### Fixed

- Fix incorrect URL being used when cache busting (#34189 by `@ClearlyClaire`)