### PR TITLE
Reduce `haml-lint` line length limit to 3x default

### DIFF
--- a/.haml-lint.yml
+++ b/.haml-lint.yml
@@ -10,6 +10,6 @@ linters:
   MiddleDot:
     enabled: true
   LineLength:
-    max: 300
+    max: 240 # Override default value of 80 inherited from rubocop
   ViewLength:
     max: 200 # Override default value of 100 inherited from rubocop

--- a/app/helpers/registration_helper.rb
+++ b/app/helpers/registration_helper.rb
@@ -7,6 +7,14 @@ module RegistrationHelper
     !Rails.configuration.x.single_user_mode && !omniauth_only? && (registrations_open? || invite&.valid_for_use?) && !ip_blocked?(remote_ip)
   end
 
+  def registration_agreement_label
+    if TermsOfService.live.exists?
+      t('auth.user_agreement_html', privacy_policy_path: privacy_policy_path, terms_of_service_path: terms_of_service_path)
+    else
+      t('auth.user_privacy_agreement_html', privacy_policy_path: privacy_policy_path)
+    end
+  end
+
   def registrations_open?
     Setting.registrations_mode != 'none'
   end

--- a/app/views/admin/announcements/previews/show.html.haml
+++ b/app/views/admin/announcements/previews/show.html.haml
@@ -8,7 +8,9 @@
       = t('admin.announcements.back')
 
 %p.lead
-  = t('admin.announcements.preview.explanation_html', count: @user_count, display_count: number_with_delimiter(@user_count))
+  = t 'admin.announcements.preview.explanation_html',
+      count: @user_count,
+      display_count: number_with_delimiter(@user_count)
 
 .prose
   = linkify(@announcement.text)
@@ -16,5 +18,12 @@
 %hr.spacer/
 
 .content__heading__actions
-  = link_to t('admin.terms_of_service.preview.send_preview', email: current_user.email), admin_announcement_test_path(@announcement), method: :post, class: 'button button-secondary'
-  = link_to t('admin.terms_of_service.preview.send_to_all', count: @user_count, display_count: number_with_delimiter(@user_count)), admin_announcement_distribution_path(@announcement), method: :post, class: 'button', data: { confirm: t('admin.reports.are_you_sure') }
+  = link_to t('admin.terms_of_service.preview.send_preview', email: current_user.email),
+            admin_announcement_test_path(@announcement),
+            class: 'button button-secondary',
+            method: :post
+  = link_to t('admin.terms_of_service.preview.send_to_all', count: @user_count, display_count: number_with_delimiter(@user_count)),
+            admin_announcement_distribution_path(@announcement),
+            class: 'button',
+            data: { confirm: t('admin.reports.are_you_sure') },
+            method: :post

--- a/app/views/admin/terms_of_service/previews/show.html.haml
+++ b/app/views/admin/terms_of_service/previews/show.html.haml
@@ -8,7 +8,10 @@
       = t('admin.terms_of_service.back')
 
 %p.lead
-  = t('admin.terms_of_service.preview.explanation_html', count: @user_count, display_count: number_with_delimiter(@user_count), date: l(@terms_of_service.published_at.to_date))
+  = t 'admin.terms_of_service.preview.explanation_html',
+      count: @user_count,
+      date: l(@terms_of_service.published_at.to_date),
+      display_count: number_with_delimiter(@user_count)
 
 .prose
   = markdown(@terms_of_service.changelog)
@@ -16,5 +19,12 @@
 %hr.spacer/
 
 .content__heading__actions
-  = link_to t('admin.terms_of_service.preview.send_preview', email: current_user.email), admin_terms_of_service_test_path(@terms_of_service), method: :post, class: 'button button-secondary'
-  = link_to t('admin.terms_of_service.preview.send_to_all', count: @user_count, display_count: number_with_delimiter(@user_count)), admin_terms_of_service_distribution_path(@terms_of_service), method: :post, class: 'button', data: { confirm: t('admin.reports.are_you_sure') }
+  = link_to t('admin.terms_of_service.preview.send_preview', email: current_user.email),
+            admin_terms_of_service_test_path(@terms_of_service),
+            class: 'button button-secondary',
+            method: :post
+  = link_to t('admin.terms_of_service.preview.send_to_all', count: @user_count, display_count: number_with_delimiter(@user_count)),
+            admin_terms_of_service_distribution_path(@terms_of_service),
+            class: 'button',
+            data: { confirm: t('admin.reports.are_you_sure') },
+            method: :post

--- a/app/views/auth/registrations/new.html.haml
+++ b/app/views/auth/registrations/new.html.haml
@@ -79,7 +79,7 @@
   .fields-group
     = f.input :agreement,
               as: :boolean,
-              label: TermsOfService.live.exists? ? t('auth.user_agreement_html', privacy_policy_path: privacy_policy_path, terms_of_service_path: terms_of_service_path) : t('auth.user_privacy_agreement_html', privacy_policy_path: privacy_policy_path),
+              label: registration_agreement_label,
               required: false,
               wrapper: :with_label
 

--- a/app/views/settings/verifications/show.html.haml
+++ b/app/views/settings/verifications/show.html.haml
@@ -51,7 +51,8 @@
           %strong.status-card__title= t('author_attribution.example_title')
       .more-from-author
         = logo_as_symbol(:icon)
-        = t('author_attribution.more_from_html', name: link_to(root_url, class: 'story__details__shared__author-link') { image_tag(@account.avatar.url, class: 'account__avatar', width: 16, height: 16, alt: '') + tag.bdi(display_name(@account)) })
+        = t 'author_attribution.more_from_html',
+            name: link_to(root_url, class: 'story__details__shared__author-link') { image_tag(@account.avatar.url, class: 'account__avatar', width: 16, height: 16, alt: '') + tag.bdi(display_name(@account)) }
 
   %h4= t('verification.here_is_how')
 
@@ -65,7 +66,10 @@
   %p.lead= t('author_attribution.then_instructions')
 
   .fields-group
-    = f.input :attribution_domains, as: :text, wrapper: :with_block_label, input_html: { value: @account.attribution_domains.join("\n"), placeholder: "example1.com\nexample2.com\nexample3.com", rows: 4, autocapitalize: 'none', autocorrect: 'off' }
+    = f.input :attribution_domains,
+              as: :text,
+              input_html: { value: @account.attribution_domains.join("\n"), placeholder: "example1.com\nexample2.com\nexample3.com", rows: 4, autocapitalize: 'none', autocorrect: 'off' },
+              wrapper: :with_block_label
 
   .actions
     = f.button :button, t('generic.save_changes'), type: :submit

--- a/app/views/user_mailer/confirmation_instructions.html.haml
+++ b/app/views/user_mailer/confirmation_instructions.html.haml
@@ -10,7 +10,11 @@
           %td.email-inner-card-td.email-prose
             %p= t @resource.approved? ? 'devise.mailer.confirmation_instructions.explanation' : 'devise.mailer.confirmation_instructions.explanation_when_pending', host: site_hostname
             - if @resource.created_by_application
-              = render 'application/mailer/button', text: t('devise.mailer.confirmation_instructions.action_with_app', app: @resource.created_by_application.name), url: confirmation_url(@resource, confirmation_token: @token, redirect_to_app: 'true')
+              = render 'application/mailer/button',
+                       text: t('devise.mailer.confirmation_instructions.action_with_app', app: @resource.created_by_application.name),
+                       url: confirmation_url(@resource, confirmation_token: @token, redirect_to_app: 'true')
             - else
-              = render 'application/mailer/button', text: t('devise.mailer.confirmation_instructions.action'), url: confirmation_url(@resource, confirmation_token: @token)
+              = render 'application/mailer/button',
+                       text: t('devise.mailer.confirmation_instructions.action'),
+                       url: confirmation_url(@resource, confirmation_token: @token)
             %p= t 'devise.mailer.confirmation_instructions.extra_html', terms_path: about_more_url, policy_path: privacy_policy_url


### PR DESCRIPTION
Drops our override from 300 to 240 (default is 80).

With the exception of the auth/registrations/new change, where I extracted a helper method (pulls constant usage out of view), the rest are just arg shuffling to new lines. Where there were multiple similar things near each other, I chose to keep them all consistent with each other instead of only changing the violating line. Did visual browser review for all to confirm no changes.

There are another ~40 or so above 200, possibly future pass reduction.