### PR TITLE
Fix static version of animated PNG emojis not being properly extracted

### DIFF
--- a/lib/paperclip/vips_lazy_thumbnail.rb
+++ b/lib/paperclip/vips_lazy_thumbnail.rb
@@ -123,7 +123,14 @@ module Paperclip
     end
 
     def needs_convert?
-      needs_different_geometry? || needs_different_format? || needs_metadata_stripping?
+      strip_animations? || needs_different_geometry? || needs_different_format? || needs_metadata_stripping?
+    end
+
+    def strip_animations?
+      # Detecting whether the source image is animated across all our supported
+      # input file formats is not trivial, and converting unconditionally is just
+      # as simple for now
+      options[:style] == :static
     end
 
     def needs_different_geometry?


### PR DESCRIPTION
Fixes #34275

Background: https://github.com/mastodon/mastodon/issues/34275#issuecomment-2768476081