### PR TITLE
Fix Typescript dependency resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
     "stylelint": "^16.11.0",
     "stylelint-config-prettier-scss": "^1.0.0",
     "stylelint-config-standard-scss": "^14.0.0",
-    "typescript": "^5.0.4",
+    "typescript": "~5.7.3",
     "typescript-eslint": "^8.28.0",
     "webpack-dev-server": "^3.11.3"
   },

--- a/streaming/package.json
+++ b/streaming/package.json
@@ -39,7 +39,7 @@
     "@types/ws": "^8.5.9",
     "globals": "^16.0.0",
     "pino-pretty": "^13.0.0",
-    "typescript": "^5.0.4",
+    "typescript": "~5.7.3",
     "typescript-eslint": "^8.28.0"
   },
   "optionalDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2967,7 +2967,7 @@ __metadata:
     tesseract.js: "npm:^6.0.0"
     tiny-queue: "npm:^0.2.1"
     twitter-text: "npm:3.1.0"
-    typescript: "npm:^5.0.4"
+    typescript: "npm:~5.7.3"
     typescript-eslint: "npm:^8.28.0"
     use-debounce: "npm:^10.0.0"
     webpack: "npm:^4.47.0"
@@ -3016,7 +3016,7 @@ __metadata:
     pino-http: "npm:^10.0.0"
     pino-pretty: "npm:^13.0.0"
     prom-client: "npm:^15.0.0"
-    typescript: "npm:^5.0.4"
+    typescript: "npm:~5.7.3"
     typescript-eslint: "npm:^8.28.0"
     utf-8-validate: "npm:^6.0.3"
     uuid: "npm:^11.0.0"
@@ -17727,16 +17727,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.0.4":
-  version: 5.7.3
-  resolution: "typescript@npm:5.7.3"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10c0/b7580d716cf1824736cc6e628ab4cd8b51877408ba2be0869d2866da35ef8366dd6ae9eb9d0851470a39be17cbd61df1126f9e211d8799d764ea7431d5435afa
-  languageName: node
-  linkType: hard
-
 "typescript@npm:^5.6.0":
   version: 5.8.2
   resolution: "typescript@npm:5.8.2"
@@ -17747,13 +17737,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5.0.4#optional!builtin<compat/typescript>":
+"typescript@npm:~5.7.3":
   version: 5.7.3
-  resolution: "typescript@patch:typescript@npm%3A5.7.3#optional!builtin<compat/typescript>::version=5.7.3&hash=5786d5"
+  resolution: "typescript@npm:5.7.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/6fd7e0ed3bf23a81246878c613423730c40e8bdbfec4c6e4d7bf1b847cbb39076e56ad5f50aa9d7ebd89877999abaee216002d3f2818885e41c907caaa192cc4
+  checksum: 10c0/b7580d716cf1824736cc6e628ab4cd8b51877408ba2be0869d2866da35ef8366dd6ae9eb9d0851470a39be17cbd61df1126f9e211d8799d764ea7431d5435afa
   languageName: node
   linkType: hard
 
@@ -17764,6 +17754,16 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/5448a08e595cc558ab321e49d4cac64fb43d1fa106584f6ff9a8d8e592111b373a995a1d5c7f3046211c8a37201eb6d0f1566f15cdb7a62a5e3be01d087848e2
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A~5.7.3#optional!builtin<compat/typescript>":
+  version: 5.7.3
+  resolution: "typescript@patch:typescript@npm%3A5.7.3#optional!builtin<compat/typescript>::version=5.7.3&hash=5786d5"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/6fd7e0ed3bf23a81246878c613423730c40e8bdbfec4c6e4d7bf1b847cbb39076e56ad5f50aa9d7ebd89877999abaee216002d3f2818885e41c907caaa192cc4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This will avoid unrelated dependency update PRs to try to update Typescript to the next minor, as updating minor TS versions can break things