### PR TITLE
Fix Renovate alert with the now deprecated `@types/emoji-mart` package

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,6 +15,8 @@
   // to `null` after any other rule set it to something.
   dependencyDashboardHeader: 'This issue lists Renovate updates and detected dependencies. Read the [Dependency Dashboard](https://docs.renovatebot.com/key-concepts/dashboard/) docs to learn more. Before approving any upgrade: read the description and comments in the [`renovate.json5` file](https://github.com/mastodon/mastodon/blob/main/.github/renovate.json5).',
   postUpdateOptions: ['yarnDedupeHighest'],
+  // The types are now included in recent versions,we ignore them here until we upgrade and remove the dependency
+  ignoreDeps: ['@types/emoji-mart'],
   packageRules: [
     {
       // Require Dependency Dashboard Approval for major version bumps of these node packages

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^16.0.0",
     "@types/babel__core": "^7.20.1",
-    "@types/emoji-mart": "^3.0.9",
+    "@types/emoji-mart": "3.0.14",
     "@types/escape-html": "^1.0.2",
     "@types/hoist-non-react-statics": "^3.3.1",
     "@types/http-link-header": "^1.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2848,7 +2848,7 @@ __metadata:
     "@testing-library/jest-dom": "npm:^6.0.0"
     "@testing-library/react": "npm:^16.0.0"
     "@types/babel__core": "npm:^7.20.1"
-    "@types/emoji-mart": "npm:^3.0.9"
+    "@types/emoji-mart": "npm:3.0.14"
     "@types/escape-html": "npm:^1.0.2"
     "@types/hoist-non-react-statics": "npm:^3.3.1"
     "@types/http-link-header": "npm:^1.0.3"
@@ -3819,7 +3819,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/emoji-mart@npm:^3.0.9":
+"@types/emoji-mart@npm:3.0.14":
   version: 3.0.14
   resolution: "@types/emoji-mart@npm:3.0.14"
   dependencies:


### PR DESCRIPTION
Those types have been removed from upstream as Emoji Mart 5.3 now include the types.

This caused Renovate to complain that it does not know what to do with this package, as it has been deprecated.

So I forced the version to the latest available, and disabled Renovate for it.