### PR TITLE
Re-disable `Style/GuardClause` cop

### DIFF
--- a/.rubocop/style.yml
+++ b/.rubocop/style.yml
@@ -15,6 +15,9 @@ Style/FormatStringToken:
     merge:
       - AllowedMethods
 
+Style/GuardClause:
+  Enabled: false
+
 Style/HashAsLastArrayItem:
   Enabled: false
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -53,11 +53,6 @@ Style/FormatStringToken:
     - 'config/initializers/devise.rb'
     - 'lib/paperclip/color_extractor.rb'
 
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: MinBodyLength, AllowConsecutiveConditionals.
-Style/GuardClause:
-  Enabled: false
-
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Style/HashTransformValues:
   Exclude:


### PR DESCRIPTION
This was purposefully disabled in https://github.com/mastodon/mastodon/pull/3316 and then enabled in https://github.com/mastodon/mastodon/pull/23629 (I suspect accidentally, as side effect of creating the `_todo`). The original desire here of allowing the mix of styles (still true in app) and going case by case (still seems appropriate) merits the disable, and "fixes" a todo in the process.