### PR TITLE
Fix visual glitches with filtering posts

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -5271,6 +5271,9 @@ a.status-card {
 
     &__results {
       &__item {
+        display: flex;
+        align-items: center;
+        gap: 0.5em;
         cursor: pointer;
         color: $primary-text-color;
         font-size: 14px;
@@ -6275,7 +6278,7 @@ a.status-card {
 
     a {
       text-decoration: none;
-      color: $inverted-text-color;
+      color: $highlight-text-color;
       font-weight: 500;
 
       &:hover {


### PR DESCRIPTION
Fixes #32750, and also vertically centers items in the language dropdown picker, which we reuse styles for the filter picker.

Before:
![Screenshot 2025-04-07 at 11 00 54](https://github.com/user-attachments/assets/ece29b6e-2133-405d-82b3-761bed82c6a2)

![Screenshot 2025-04-07 at 11 03 27](https://github.com/user-attachments/assets/d0323855-ede8-4c99-8a49-fad62b7eea9d)

After:
![Screenshot 2025-04-07 at 11 06 14](https://github.com/user-attachments/assets/aa9d423d-f5fa-4cf4-a94a-00958a5692fd)

![Screenshot 2025-04-07 at 10 59 23](https://github.com/user-attachments/assets/d6a4fc80-966f-4f77-9485-3d8eb772e78f)
