### PR TITLE
Forces radio buttons to be correctly centred

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -7569,14 +7569,11 @@ a.status-card {
 }
 
 .radio-button__input.checked::before {
-  position: absolute;
-  left: 2px;
-  top: 2px;
   content: '';
   display: block;
   border-radius: 50%;
-  width: 12px;
-  height: 12px;
+  width: calc(100% - 4px);
+  height: calc(100% - 4px);
   background: $ui-highlight-color;
 }
 


### PR DESCRIPTION
Fixes #31996. It's not entirely perfect as the browser really determines how to handle sub-pixel rendering, but it improves things.

90%:
![Screenshot 2025-04-07 at 11 48 23](https://github.com/user-attachments/assets/7fe80b6d-c748-44b5-8425-a092a529f1c5)


80%:
![Screenshot 2025-04-07 at 11 48 40](https://github.com/user-attachments/assets/8143a145-a80a-4003-ad69-5d50b0189511)

67%:
![Screenshot 2025-04-07 at 11 48 51](https://github.com/user-attachments/assets/cbdf5863-f9b4-40b6-ae7c-616712d6cc49)


110%:
![Screenshot 2025-04-07 at 11 49 25](https://github.com/user-attachments/assets/75d44e59-3d64-4dd4-9803-5fd6d2213065)