### PR TITLE
Change Node.js minimum version to Node 20

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Mastodon is a **free, open-source social network server** based on ActivityPub w
 - **PostgreSQL** 12+
 - **Redis** 4+
 - **Ruby** 3.2+
-- **Node.js** 18+
+- **Node.js** 20+
 
 The repository includes deployment configurations for **Docker and docker-compose** as well as specific platforms like **Heroku**, and **Scalingo**. For Helm charts, reference the [mastodon/chart repository](https://github.com/mastodon/chart). The [**standalone** installation guide](https://docs.joinmastodon.org/admin/install/) is available in the documentation.
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "license": "AGPL-3.0-or-later",
   "packageManager": "yarn@4.8.1",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "workspaces": [
     ".",

--- a/streaming/package.json
+++ b/streaming/package.json
@@ -3,7 +3,7 @@
   "license": "AGPL-3.0-or-later",
   "packageManager": "yarn@4.8.1",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "description": "Mastodon's Streaming Server",
   "private": true,


### PR DESCRIPTION
Node 18 will be EOL at the end of the month, we should probably not support it for Mastodon 4.4.