### PR TITLE
Extract `frontend_translations` helper to support module

### DIFF
--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -19,8 +19,7 @@ module SystemHelpers
     "##{dom_id(record)}"
   end
 
-  def frontend_translations(*args)
-    key = args.map(&:to_s).join('.')
+  def frontend_translations(key)
     FRONTEND_TRANSLATIONS[key]
   end
 end

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module SystemHelpers
+  FRONTEND_TRANSLATIONS = JSON.parse Rails.root.join('app', 'javascript', 'mastodon', 'locales', 'en.json').read
+
   def submit_button
     I18n.t('generic.save_changes')
   end
@@ -15,5 +17,10 @@ module SystemHelpers
 
   def css_id(record)
     "##{dom_id(record)}"
+  end
+
+  def frontend_translations(*args)
+    key = args.map(&:to_s).join('.')
+    FRONTEND_TRANSLATIONS[key]
   end
 end

--- a/spec/system/account_notes_spec.rb
+++ b/spec/system/account_notes_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Account notes', :inline_jobs, :js, :streaming do
     visit_profile(other_account)
 
     note_text = 'This is a personal note'
-    fill_in frontend_translations(:account_note, :placeholder), with: note_text
+    fill_in frontend_translations('account_note.placeholder'), with: note_text
 
     # This is a bit awkward since there is no button to save the change
     # The easiest way is to send ctrl+enter ourselves

--- a/spec/system/account_notes_spec.rb
+++ b/spec/system/account_notes_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Account notes', :inline_jobs, :js, :streaming do
     visit_profile(other_account)
 
     note_text = 'This is a personal note'
-    fill_in 'Click to add note', with: note_text
+    fill_in frontend_translations(:account_note, :placeholder), with: note_text
 
     # This is a bit awkward since there is no button to save the change
     # The easiest way is to send ctrl+enter ourselves

--- a/spec/system/log_out_spec.rb
+++ b/spec/system/log_out_spec.rb
@@ -17,8 +17,9 @@ RSpec.describe 'Log out' do
         click_on 'Logout'
       end
 
-      expect(page).to have_title(I18n.t('auth.login'))
-      expect(page).to have_current_path('/auth/sign_in')
+      expect(page)
+        .to have_title(I18n.t('auth.login'))
+        .and have_current_path('/auth/sign_in')
     end
   end
 
@@ -28,6 +29,8 @@ RSpec.describe 'Log out' do
       ignore_js_error(/Failed to load resource: the server responded with a status of 422/)
 
       visit root_path
+      expect(page)
+        .to have_css('body', class: 'app-body')
 
       within '.navigation-bar' do
         click_on 'Menu'
@@ -39,8 +42,9 @@ RSpec.describe 'Log out' do
 
       click_on 'Log out'
 
-      expect(page).to have_title(I18n.t('auth.login'))
-      expect(page).to have_current_path('/auth/sign_in')
+      expect(page)
+        .to have_title(I18n.t('auth.login'))
+        .and have_current_path('/auth/sign_in')
     end
   end
 end

--- a/spec/system/new_statuses_spec.rb
+++ b/spec/system/new_statuses_spec.rb
@@ -17,20 +17,7 @@ RSpec.describe 'NewStatuses', :inline_jobs, :js, :streaming do
     status_text = 'This is a new status!'
 
     within('.compose-form') do
-      fill_in "What's on your mind?", with: status_text
-      click_on 'Post'
-    end
-
-    expect(page)
-      .to have_css('.status__content__text', text: status_text)
-  end
-
-  it 'can be posted again' do
-    visit_homepage
-    status_text = 'This is a second status!'
-
-    within('.compose-form') do
-      fill_in "What's on your mind?", with: status_text
+      fill_in frontend_translations(:compose_form, :placeholder), with: status_text
       click_on 'Post'
     end
 

--- a/spec/system/new_statuses_spec.rb
+++ b/spec/system/new_statuses_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'NewStatuses', :inline_jobs, :js, :streaming do
     status_text = 'This is a new status!'
 
     within('.compose-form') do
-      fill_in frontend_translations(:compose_form, :placeholder), with: status_text
+      fill_in frontend_translations('compose_form.placeholder'), with: status_text
       click_on 'Post'
     end
 

--- a/spec/system/share_entrypoint_spec.rb
+++ b/spec/system/share_entrypoint_spec.rb
@@ -23,14 +23,14 @@ RSpec.describe 'Share page', :js, :streaming do
     fill_in_form
 
     expect(page)
-      .to have_css('.notification-bar-message', text: frontend_translations(:compose, :published, :body))
+      .to have_css('.notification-bar-message', text: frontend_translations('compose.published.body'))
   end
 
   def fill_in_form
     within('.compose-form') do
-      fill_in frontend_translations(:compose_form, :placeholder),
+      fill_in frontend_translations('compose_form.placeholder'),
               with: 'This is a new status!'
-      click_on frontend_translations(:compose_form, :publish)
+      click_on frontend_translations('compose_form.publish')
     end
   end
 end

--- a/spec/system/share_entrypoint_spec.rb
+++ b/spec/system/share_entrypoint_spec.rb
@@ -23,24 +23,14 @@ RSpec.describe 'Share page', :js, :streaming do
     fill_in_form
 
     expect(page)
-      .to have_css('.notification-bar-message', text: translations['compose.published.body'])
+      .to have_css('.notification-bar-message', text: frontend_translations(:compose, :published, :body))
   end
 
   def fill_in_form
     within('.compose-form') do
-      fill_in translations['compose_form.placeholder'],
+      fill_in frontend_translations(:compose_form, :placeholder),
               with: 'This is a new status!'
-      click_on translations['compose_form.publish']
+      click_on frontend_translations(:compose_form, :publish)
     end
-  end
-
-  def translations
-    # TODO: Extract to system spec helper for re-use?
-    JSON.parse(
-      Rails
-        .root
-        .join('app', 'javascript', 'mastodon', 'locales', 'en.json')
-        .read
-    )
   end
 end


### PR DESCRIPTION
This was previously just used in one system spec where we want to access the JS translations from a ruby-written system spec. Main change is just to pull that out to a helper module, solving the TODO, and then use that method from other places where relevant.

While in there, I saw a local failure from what I think is a timing/async issue, so threw a change in to help mitigate that.

Also deleted a spec within new_statuses_spec which as far as I can tell is a dupe of the one right above it, and I'm not sure what the additional benefit is.

Possible future improvements:

- There are still places within the system specs where we are using direct UI strings, instead of refs to either the js or ruby translations -- could do a pass to be even more exhaustive here, but for now just wanted to hit this TODO.
- Since it's currently only used 3-4 times I suspect this barely matters, but could do some sort of caching/memoizing/loading improvement to loading these JS translations from the system specs.