### PR TITLE
Globally install corepack

### DIFF
--- a/.github/actions/setup-javascript/action.yml
+++ b/.github/actions/setup-javascript/action.yml
@@ -16,7 +16,7 @@ runs:
     # The following is needed because we can not use `cache: true` for `setup-node`, as it does not support Corepack yet and mess up with the cache location if ran after Node is installed
     - name: Enable corepack
       shell: bash
-      run: corepack enable
+      run: npm i -g corepack
 
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path

--- a/Dockerfile
+++ b/Dockerfile
@@ -342,7 +342,7 @@ COPY --from=node /usr/local/lib /usr/local/lib
 RUN \
   # Configure Corepack
   rm /usr/local/bin/yarn*; \
-  corepack enable; \
+  npm i -g corepack; \
   corepack prepare --activate;
 
 # hadolint ignore=DL3008

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -115,7 +115,7 @@ gem install bundler foreman
 bundle install
 
 # Install node modules
-sudo corepack enable
+sudo npm i -g corepack
 corepack prepare
 yarn install
 

--- a/bin/setup
+++ b/bin/setup
@@ -18,7 +18,7 @@ FileUtils.chdir APP_ROOT do
   system('bundle check') || system!('bundle install')
 
   puts "\n== Installing JS dependencies =="
-  system! 'corepack enable'
+  system! 'npm i -g corepack'
   system! 'bin/yarn install --immutable'
 
   puts "\n== Preparing database =="

--- a/streaming/Dockerfile
+++ b/streaming/Dockerfile
@@ -95,7 +95,7 @@ RUN \
   --mount=type=cache,id=yarn-cache-${TARGETPLATFORM},target=/usr/local/share/.cache/yarn,sharing=locked \
   # Configure Corepack
   rm /usr/local/bin/yarn*; \
-  corepack enable; \
+  npm i -g corepack; \
   corepack prepare --activate;
 
 RUN \


### PR DESCRIPTION
Corepack is not going to be distributed with Node.js v25+
TSC vote https://github.com/nodejs/TSC/pull/1697#issuecomment-2737093616

This PR updates the command to globally installing corepack.