### PR TITLE
Add paragraph to tell admins that email announcements cannot be opted out

### DIFF
--- a/app/views/admin/announcements/previews/show.html.haml
+++ b/app/views/admin/announcements/previews/show.html.haml
@@ -7,6 +7,8 @@
       = material_symbol 'chevron_left'
       = t('admin.announcements.back')
 
+.flash-message.info= t('admin.announcements.preview.disclaimer')
+
 %p.lead
   = t('admin.announcements.preview.explanation_html', count: @user_count, display_count: number_with_delimiter(@user_count))
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -319,6 +319,7 @@ en:
         create: Create announcement
         title: New announcement
       preview:
+        disclaimer: As users cannot opt out of them, email notifications should be limited to important announcements such as personal data breach or server closure notifications.
         explanation_html: 'The email will be sent to <strong>%{display_count} users</strong>. The following text will be included in the e-mail:'
         title: Preview announcement notification
       publish: Publish


### PR DESCRIPTION
A few people have asked whether users could opt out of these e-mails. This clarifies it, and clarifies the intent of the feature.

![image](https://github.com/user-attachments/assets/5e658795-0454-452e-81ac-296fce6b8cdd)
