### PR TITLE
Move `ArgumentError` rescue to api/base controller

### DIFF
--- a/app/controllers/api/v1/lists_controller.rb
+++ b/app/controllers/api/v1/lists_controller.rb
@@ -7,10 +7,6 @@ class Api::V1::ListsController < Api::BaseController
   before_action :require_user!
   before_action :set_list, except: [:index, :create]
 
-  rescue_from ArgumentError do |e|
-    render json: { error: e.to_s }, status: 422
-  end
-
   def index
     @lists = List.where(account: current_account).all
     render json: @lists, each_serializer: REST::ListSerializer

--- a/app/controllers/concerns/api/error_handling.rb
+++ b/app/controllers/concerns/api/error_handling.rb
@@ -4,7 +4,7 @@ module Api::ErrorHandling
   extend ActiveSupport::Concern
 
   included do
-    rescue_from ActiveRecord::RecordInvalid, Mastodon::ValidationError do |e|
+    rescue_from ArgumentError, ActiveRecord::RecordInvalid, Mastodon::ValidationError do |e|
       render json: { error: e.to_s }, status: 422
     end
 

--- a/spec/controllers/concerns/api/error_handling_spec.rb
+++ b/spec/controllers/concerns/api/error_handling_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Api::ErrorHandling do
       ActiveRecord::RecordInvalid => 422,
       ActiveRecord::RecordNotFound => 404,
       ActiveRecord::RecordNotUnique => 422,
+      ArgumentError => 422,
       Date::Error => 422,
       HTTP::Error => 503,
       Mastodon::InvalidParameterError => 400,

--- a/spec/requests/api/v2/filters_spec.rb
+++ b/spec/requests/api/v2/filters_spec.rb
@@ -115,6 +115,19 @@ RSpec.describe 'Filters' do
           .to start_with('application/json')
       end
     end
+
+    context 'when the given filter_action value is invalid' do
+      let(:params) { { title: 'magic', filter_action: 'imaginary_value', keywords_attributes: [keyword: 'magic'] } }
+
+      it 'returns http unprocessable entity' do
+        subject
+
+        expect(response)
+          .to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
+      end
+    end
   end
 
   describe 'GET /api/v2/filters/:id' do


### PR DESCRIPTION
Resolves https://github.com/mastodon/mastodon/issues/34412

Several related changes:

- Add spec capturing problem in linked issue (unhandled argument error from invalid `enum` value causes 500/html response)
- Find another spot (lists) where we already handle this
- Move that approach to api/base
- Lists spec still passes, new spec passes

The only side effect I can think of here is there may be other places like that (which also inherit from base) for which we are unintentially changing a previous 500+html response into a 422+json-with-error-text response ... but this seems at least harmless, and maybe better?