### PR TITLE
Enable `validate: true` on `CustomFilter#action`

### DIFF
--- a/app/models/custom_filter.rb
+++ b/app/models/custom_filter.rb
@@ -33,7 +33,7 @@ class CustomFilter < ApplicationRecord
   include Expireable
   include Redisable
 
-  enum :action, { warn: 0, hide: 1, blur: 2 }, suffix: :action
+  enum :action, { warn: 0, hide: 1, blur: 2 }, suffix: :action, validate: true
 
   belongs_to :account
   has_many :keywords, class_name: 'CustomFilterKeyword', inverse_of: :custom_filter, dependent: :destroy

--- a/spec/requests/api/v2/filters_spec.rb
+++ b/spec/requests/api/v2/filters_spec.rb
@@ -115,6 +115,21 @@ RSpec.describe 'Filters' do
           .to start_with('application/json')
       end
     end
+
+    context 'when the given filter_action value is invalid' do
+      let(:params) { { title: 'magic', filter_action: 'imaginary_value', keywords_attributes: [keyword: 'magic'] } }
+
+      it 'returns http unprocessable entity' do
+        subject
+
+        expect(response)
+          .to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
+        expect(response.parsed_body)
+          .to include(error: /Action is not included/)
+      end
+    end
   end
 
   describe 'GET /api/v2/filters/:id' do


### PR DESCRIPTION
Alternate approach to https://github.com/mastodon/mastodon/pull/34419

If we like this way better -- a) do we need a migration here to handle previous invalid data edge case? (seems unlikely there'd be any); b) is this approach also better for the `List` case borrowed in other PR (which is catching `ArgumentError`, and possibly masking other issues)
