### PR TITLE
Use enum validation instead of `ArgumentError` rescue for `List` replies policy check

### DIFF
--- a/app/controllers/api/v1/lists_controller.rb
+++ b/app/controllers/api/v1/lists_controller.rb
@@ -7,10 +7,6 @@ class Api::V1::ListsController < Api::BaseController
   before_action :require_user!
   before_action :set_list, except: [:index, :create]
 
-  rescue_from ArgumentError do |e|
-    render json: { error: e.to_s }, status: 422
-  end
-
   def index
     @lists = List.where(account: current_account).all
     render json: @lists, each_serializer: REST::ListSerializer

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -18,7 +18,7 @@ class List < ApplicationRecord
 
   PER_ACCOUNT_LIMIT = 50
 
-  enum :replies_policy, { list: 0, followed: 1, none: 2 }, prefix: :show
+  enum :replies_policy, { list: 0, followed: 1, none: 2 }, prefix: :show, validate: true
 
   belongs_to :account
 

--- a/spec/requests/api/v1/lists_spec.rb
+++ b/spec/requests/api/v1/lists_spec.rb
@@ -132,9 +132,12 @@ RSpec.describe 'Lists' do
       it 'returns http unprocessable entity' do
         subject
 
-        expect(response).to have_http_status(422)
+        expect(response)
+          .to have_http_status(422)
         expect(response.content_type)
           .to start_with('application/json')
+        expect(response.parsed_body)
+          .to include(error: /Replies policy is not included/)
       end
     end
   end


### PR DESCRIPTION
Background: https://github.com/mastodon/mastodon/pull/34434