### PR TITLE
Change account search to be more forgiving of spaces

### DIFF
--- a/app/chewy/accounts_index.rb
+++ b/app/chewy/accounts_index.rb
@@ -19,9 +19,16 @@ class AccountsIndex < Chewy::Index
         type: 'stemmer',
         language: 'possessive_english',
       },
+
+      word_joiner: {
+        type: 'shingle',
+        output_unigrams: true,
+        token_separator: '',
+      },
     },
 
     analyzer: {
+      # "The FOOING's bar" becomes "foo bar"
       natural: {
         tokenizer: 'standard',
         filter: %w(
@@ -35,11 +42,20 @@ class AccountsIndex < Chewy::Index
         ),
       },
 
+      # "FOO bar" becomes "foo bar"
       verbatim: {
         tokenizer: 'standard',
         filter: %w(lowercase asciifolding cjk_width),
       },
 
+      # "Foo bar" becomes "foo bar foobar"
+      word_join_analyzer: {
+        type: 'custom',
+        tokenizer: 'standard',
+        filter: %w(lowercase asciifolding cjk_width word_joiner),
+      },
+
+      # "Foo bar" becomes "f fo foo b ba bar"
       edge_ngram: {
         tokenizer: 'edge_ngram',
         filter: %w(lowercase asciifolding cjk_width),

--- a/app/services/account_search_service.rb
+++ b/app/services/account_search_service.rb
@@ -128,11 +128,37 @@ class AccountSearchService < BaseService
 
     def core_query
       {
-        multi_match: {
-          query: @query,
-          type: 'best_fields',
-          fields: %w(username^2 display_name^2 text text.*),
-          operator: 'and',
+        dis_max: {
+          queries: [
+            {
+              match: {
+                username: {
+                  query: @query,
+                  analyzer: 'word_join_analyzer',
+                },
+              },
+            },
+
+            {
+              match: {
+                display_name: {
+                  query: @query,
+                  analyzer: 'word_join_analyzer',
+                },
+              },
+            },
+
+            {
+              multi_match: {
+                query: @query,
+                type: 'best_fields',
+                fields: %w(text text.*),
+                operator: 'and',
+              },
+            },
+          ],
+
+          tie_breaker: 0.5,
         },
       }
     end


### PR DESCRIPTION
Example queries that were not possible before:

|Username|Display name|Query|Possible before|Possible after|
|--|--|--|--|--|
|mike|Mike McCue|mikemccue|**No**|Yes|
|||Mike M|**No**|Yes|
|||mike mc cue|**No**|Yes|
|||mike mccue mike|Yes|Yes|
|||mccue|Yes|Yes|
|gargron|Eugen Rochko|eugenrochko|**No**|Yes|
|||Eugen Rochko gargron|**No**|Yes|
|||Eugen gargron|**No**|Yes|
|||gar gron|**No**|Yes|
|||rochko|Yes|Yes|

Note: This adds a new analyzer to the index, however, the analyzer is used during query-time, not indexing-time, so technically re-indexing all documents is not necessary.

___ 

Fixes MAS-348