### PR TITLE
Change /oauth/token request specs to use client_secret_basic authentication

### DIFF
--- a/spec/requests/oauth/token_spec.rb
+++ b/spec/requests/oauth/token_spec.rb
@@ -17,15 +17,8 @@ RSpec.describe 'Managing OAuth Tokens' do
     end
 
     context "with grant_type 'authorization_code'" do
-      let(:params) do
-        {
-          grant_type: 'authorization_code',
-          redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
-          code: code,
-        }
-      end
-
       let(:access_grant) { Fabricate(:access_grant, application: application, redirect_uri: 'urn:ietf:wg:oauth:2.0:oob', scopes: 'read write') }
+      let(:access_grant_scopes) { access_grant.scopes.to_s }
       let(:code) { access_grant.plaintext_token }
 
       shared_examples 'returns a correctly scoped access token' do
@@ -33,7 +26,7 @@ RSpec.describe 'Managing OAuth Tokens' do
           subject
 
           expect(response).to have_http_status(200)
-          expect(response.parsed_body[:scope]).to eq access_grant.scopes.to_s
+          expect(response.parsed_body[:scope]).to eq access_grant_scopes
         end
 
         context 'with additional parameters not used by the grant type' do
@@ -50,7 +43,7 @@ RSpec.describe 'Managing OAuth Tokens' do
             subject
 
             expect(response).to have_http_status(200)
-            expect(response.parsed_body[:scope]).to eq 'read write'
+            expect(response.parsed_body[:scope]).to eq access_grant_scopes
           end
         end
       end
@@ -77,6 +70,14 @@ RSpec.describe 'Managing OAuth Tokens' do
           }
         end
 
+        let(:params) do
+          {
+            grant_type: 'authorization_code',
+            redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
+            code: code,
+          }
+        end
+
         it_behaves_like 'returns a correctly scoped access token'
       end
     end
@@ -86,7 +87,7 @@ RSpec.describe 'Managing OAuth Tokens' do
         context 'with no scopes specified' do
           let(:scope) { nil }
 
-          it 'returns only the default scope' do
+          it 'returns only the authorization server default scope (read)' do
             subject
 
             expect(response).to have_http_status(200)

--- a/spec/requests/oauth/token_spec.rb
+++ b/spec/requests/oauth/token_spec.rb
@@ -5,18 +5,15 @@ require 'rails_helper'
 RSpec.describe 'Managing OAuth Tokens' do
   describe 'POST /oauth/token' do
     subject do
-      post '/oauth/token', params: params, headers: headers
+      post '/oauth/token', params: params.merge(additional_params), headers: headers
     end
+
+    let(:headers) { nil }
+    let(:additional_params) { {} }
+    let(:params) { {} }
 
     let(:application) do
       Fabricate(:application, scopes: 'read write follow', redirect_uri: 'urn:ietf:wg:oauth:2.0:oob')
-    end
-
-    # This is using the OAuth client_secret_basic client authentication method
-    let(:headers) do
-      {
-        Authorization: ActionController::HttpAuthentication::Basic.encode_credentials(application.uid, application.secret),
-      }
     end
 
     context "with grant_type 'authorization_code'" do
@@ -33,12 +30,30 @@ RSpec.describe 'Managing OAuth Tokens' do
         access_grant.plaintext_token
       end
 
-      shared_examples 'original scope request preservation' do
-        it 'returns all scopes requested by the authorization code' do
+      shared_examples 'returns a correctly scoped access token' do
+        it 'returns the scopes requested by the authorization code' do
           subject
 
           expect(response).to have_http_status(200)
           expect(response.parsed_body[:scope]).to eq 'read write'
+        end
+
+        context 'with additional parameters not used by the grant type' do
+          # When performing an authorization code grant flow, the `/oauth/token`
+          # endpoint does not accept a `scope` parameter, and should not
+          # override the scopes from the authorization grant.
+          let(:additional_params) do
+            {
+              scope: 'write',
+            }
+          end
+
+          it 'returns the scopes requested by the authorization code' do
+            subject
+
+            expect(response).to have_http_status(200)
+            expect(response.parsed_body[:scope]).to eq 'read write'
+          end
         end
       end
 
@@ -54,19 +69,73 @@ RSpec.describe 'Managing OAuth Tokens' do
           }
         end
 
-        it_behaves_like 'original scope request preservation'
+        it_behaves_like 'returns a correctly scoped access token'
       end
 
-      it_behaves_like 'original scope request preservation'
+      context 'with client authentication via basic auth' do
+        let(:headers) do
+          {
+            Authorization: ActionController::HttpAuthentication::Basic.encode_credentials(application.uid, application.secret),
+          }
+        end
+
+        it_behaves_like 'returns a correctly scoped access token'
+      end
     end
 
     context "with grant_type 'client_credentials'" do
-      let(:scope) { nil }
-      let(:params) do
-        {
-          grant_type: 'client_credentials',
-          scope: scope,
-        }
+      shared_examples 'returns the correct scopes' do
+        context 'with no scopes specified' do
+          let(:scope) { nil }
+
+          it 'returns only the default scope' do
+            subject
+
+            expect(response).to have_http_status(200)
+            expect(response.parsed_body[:scope]).to eq('read')
+          end
+        end
+
+        context 'with scopes specified' do
+          context 'when the scopes belong to the application' do
+            let(:scope) { 'read write' }
+
+            it 'returns all the requested scopes' do
+              subject
+
+              expect(response).to have_http_status(200)
+              expect(response.parsed_body[:scope]).to eq 'read write'
+            end
+          end
+
+          context 'when some scopes do not belong to the application' do
+            let(:scope) { 'read write push' }
+
+            it 'returns an error' do
+              subject
+
+              expect(response).to have_http_status(400)
+              expect(response.parsed_body[:error]).to eq 'invalid_scope'
+            end
+          end
+        end
+      end
+
+      context 'with client authentication via basic auth' do
+        let(:headers) do
+          {
+            Authorization: ActionController::HttpAuthentication::Basic.encode_credentials(application.uid, application.secret),
+          }
+        end
+
+        let(:params) do
+          {
+            grant_type: 'client_credentials',
+            scope: scope,
+          }
+        end
+
+        it_behaves_like 'returns the correct scopes'
       end
 
       context 'with client authentication via params' do
@@ -80,47 +149,7 @@ RSpec.describe 'Managing OAuth Tokens' do
           }
         end
 
-        it 'returns only the default scope' do
-          subject
-
-          expect(response).to have_http_status(200)
-          expect(response.parsed_body[:scope]).to eq('read')
-        end
-      end
-
-      context 'with no scopes specified' do
-        let(:scope) { nil }
-
-        it 'returns only the default scope' do
-          subject
-
-          expect(response).to have_http_status(200)
-          expect(response.parsed_body[:scope]).to eq('read')
-        end
-      end
-
-      context 'with scopes specified' do
-        context 'when the scopes belong to the application' do
-          let(:scope) { 'read write' }
-
-          it 'returns all the requested scopes' do
-            subject
-
-            expect(response).to have_http_status(200)
-            expect(response.parsed_body[:scope]).to eq 'read write'
-          end
-        end
-
-        context 'when some scopes do not belong to the application' do
-          let(:scope) { 'read write push' }
-
-          it 'returns an error' do
-            subject
-
-            expect(response).to have_http_status(400)
-            expect(response.parsed_body[:error]).to eq 'invalid_scope'
-          end
-        end
+        it_behaves_like 'returns the correct scopes'
       end
     end
   end

--- a/spec/requests/oauth/token_spec.rb
+++ b/spec/requests/oauth/token_spec.rb
@@ -1,21 +1,28 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'debug'
 
 RSpec.describe 'Managing OAuth Tokens' do
   describe 'POST /oauth/token' do
     subject do
-      post '/oauth/token', params: params
+      post '/oauth/token', params: params, headers: headers
     end
 
     let(:application) do
       Fabricate(:application, scopes: 'read write follow', redirect_uri: 'urn:ietf:wg:oauth:2.0:oob')
     end
+
+    # This is using the OAuth client_secret_basic client authentication method
+    let(:headers) do
+      {
+        Authorization: ActionController::HttpAuthentication::Basic.encode_credentials(application.uid, application.secret),
+      }
+    end
+
     let(:params) do
       {
         grant_type: grant_type,
-        client_id: application.uid,
-        client_secret: application.secret,
         redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
         code: code,
         scope: scope,

--- a/spec/requests/oauth/token_spec.rb
+++ b/spec/requests/oauth/token_spec.rb
@@ -25,17 +25,15 @@ RSpec.describe 'Managing OAuth Tokens' do
         }
       end
 
-      let(:code) do
-        access_grant = Fabricate(:access_grant, application: application, redirect_uri: 'urn:ietf:wg:oauth:2.0:oob', scopes: 'read write')
-        access_grant.plaintext_token
-      end
+      let(:access_grant) { Fabricate(:access_grant, application: application, redirect_uri: 'urn:ietf:wg:oauth:2.0:oob', scopes: 'read write') }
+      let(:code) { access_grant.plaintext_token }
 
       shared_examples 'returns a correctly scoped access token' do
         it 'returns the scopes requested by the authorization code' do
           subject
 
           expect(response).to have_http_status(200)
-          expect(response.parsed_body[:scope]).to eq 'read write'
+          expect(response.parsed_body[:scope]).to eq access_grant.scopes.to_s
         end
 
         context 'with additional parameters not used by the grant type' do


### PR DESCRIPTION
I noticed this whilst working on the tests for #30329, where we were using `client_secret_post` as the client authentication mechanism, when generally `client_secret_basic` is preferred. This is per OAuth [RFC 6749 Section 2.3.1](https://www.rfc-editor.org/rfc/rfc6749#section-2.3). The names `client_secret_basic` and `client_secret_post` come from [RFC 7591](https://www.rfc-editor.org/rfc/rfc7591.html#section-2)

Here we are indeed using a POST request with body (I assume `params` becomes the body, and not query string params). The rationale for this change is that Doorkeeper's implementation of `client_secret_post` is actually technically broken: https://github.com/doorkeeper-gem/doorkeeper/issues/1769

So this is really playing it on the safe-side by using `client_secret_basic` as the client authentication mechanism.