### PR TITLE
Reject incoming `QuoteRequest` activities

### DIFF
--- a/app/helpers/context_helper.rb
+++ b/app/helpers/context_helper.rb
@@ -25,6 +25,7 @@ module ContextHelper
     voters_count: { 'toot' => 'http://joinmastodon.org/ns#', 'votersCount' => 'toot:votersCount' },
     suspended: { 'toot' => 'http://joinmastodon.org/ns#', 'suspended' => 'toot:suspended' },
     attribution_domains: { 'toot' => 'http://joinmastodon.org/ns#', 'attributionDomains' => { '@id' => 'toot:attributionDomains', '@type' => '@id' } },
+    quote_requests: { 'QuoteRequest' => 'https://w3id.org/fep/044f#QuoteRequest' },
   }.freeze
 
   def full_context

--- a/app/lib/activitypub/activity.rb
+++ b/app/lib/activitypub/activity.rb
@@ -57,6 +57,8 @@ class ActivityPub::Activity
         ActivityPub::Activity::Remove
       when 'Move'
         ActivityPub::Activity::Move
+      when 'QuoteRequest'
+        ActivityPub::Activity::QuoteRequest
       end
     end
   end

--- a/app/lib/activitypub/activity/quote_request.rb
+++ b/app/lib/activitypub/activity/quote_request.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class ActivityPub::Activity::QuoteRequest < ActivityPub::Activity
+  include Payloadable
+
+  def perform
+    return unless Mastodon::Feature.inbound_quotes_enabled?
+    return if non_matching_uri_hosts?(@account.uri, @json['id'])
+
+    quoted_status = status_from_uri(object_uri)
+    return if quoted_status.nil? || !quoted_status.account.local? || !quoted_status.distributable?
+
+    # For now, we don't support being quoted by external servers
+    reject_quote_request!(quoted_status)
+  end
+
+  private
+
+  def reject_quote_request!(quoted_status)
+    quote = Quote.new(
+      quoted_status: quoted_status,
+      quoted_account: quoted_status.account,
+      status: Status.new(account: @account, uri: @json['instrument']),
+      account: @account,
+      activity_uri: @json['id']
+    )
+    json = Oj.dump(serialize_payload(quote, ActivityPub::RejectQuoteRequestSerializer))
+    ActivityPub::DeliveryWorker.perform_async(json, quoted_status.account_id, @account.inbox_url)
+  end
+end

--- a/app/serializers/activitypub/quote_request_serializer.rb
+++ b/app/serializers/activitypub/quote_request_serializer.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class ActivityPub::QuoteRequestSerializer < ActivityPub::Serializer
+  context_extensions :quote_requests
+
+  attributes :id, :type, :actor, :instrument
+  attribute :virtual_object, key: :object
+
+  def id
+    object.activity_uri || [ActivityPub::TagManager.instance.uri_for(object.target_account), '#quote_requests/', object.id].join
+  end
+
+  def type
+    'QuoteRequest'
+  end
+
+  def actor
+    ActivityPub::TagManager.instance.uri_for(object.account)
+  end
+
+  def virtual_object
+    ActivityPub::TagManager.instance.uri_for(object.quoted_status)
+  end
+
+  def instrument
+    ActivityPub::TagManager.instance.uri_for(object.status)
+  end
+end

--- a/app/serializers/activitypub/reject_quote_request_serializer.rb
+++ b/app/serializers/activitypub/reject_quote_request_serializer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class ActivityPub::RejectQuoteRequestSerializer < ActivityPub::Serializer
+  attributes :id, :type, :actor
+
+  has_one :object, serializer: ActivityPub::QuoteRequestSerializer
+
+  def id
+    [ActivityPub::TagManager.instance.uri_for(object.quoted_account), '#rejects/quote_requests/', object.id].join
+  end
+
+  def type
+    'Reject'
+  end
+
+  def actor
+    ActivityPub::TagManager.instance.uri_for(object.quoted_account)
+  end
+end

--- a/spec/lib/activitypub/activity/quote_request_spec.rb
+++ b/spec/lib/activitypub/activity/quote_request_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ActivityPub::Activity::QuoteRequest, feature: :inbound_quotes do
+  let(:sender)    { Fabricate(:account, domain: 'example.com') }
+  let(:recipient) { Fabricate(:account) }
+  let(:quoted_post) { Fabricate(:status, account: recipient) }
+  let(:request_uri) { 'https://example.com/missing-ui' }
+  let(:quoted_uri) { ActivityPub::TagManager.instance.uri_for(quoted_post) }
+
+  let(:json) do
+    {
+      '@context': [
+        'https://www.w3.org/ns/activitystreams',
+        {
+          QuoteRequest: 'https://w3id.org/fep/044f#QuoteRequest',
+        },
+      ],
+      id: request_uri,
+      type: 'QuoteRequest',
+      actor: ActivityPub::TagManager.instance.uri_for(sender),
+      object: quoted_uri,
+      instrument: 'https://example.com/unknown-status',
+    }.with_indifferent_access
+  end
+
+  describe '#perform' do
+    subject { described_class.new(json, sender) }
+
+    context 'when trying to quote an unknown status' do
+      let(:quoted_uri) { 'https://example.com/statuses/1234' }
+
+      it 'does not send anything' do
+        expect { subject.perform }
+          .to_not enqueue_sidekiq_job(ActivityPub::DeliveryWorker)
+      end
+    end
+
+    context 'when trying to quote an unquotable local status' do
+      it 'sends a Reject activity' do
+        expect { subject.perform }
+          .to enqueue_sidekiq_job(ActivityPub::DeliveryWorker)
+          .with(satisfying do |body|
+            outgoing_json = Oj.load(body)
+            outgoing_json['type'] == 'Reject' && %w(type id actor object instrument).all? { |key| json[key] == outgoing_json['object'][key] }
+          end, recipient.id, sender.inbox_url)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Implement rejection of incoming `QuoteRequest` activities according to https://codeberg.org/fediverse/fep/src/branch/main/fep/044f/fep-044f.md

This is optional, and more of a placeholder for further development when we will actually approve some of the quotes.

TODO:
- [x] double-check context of serialized activity