### PR TITLE
Fix namespace of `QuoteAuthorization` type in specs

### DIFF
--- a/spec/lib/activitypub/activity/create_spec.rb
+++ b/spec/lib/activitypub/activity/create_spec.rb
@@ -958,8 +958,7 @@ RSpec.describe ActivityPub::Activity::Create do
             '@context': [
               'https://www.w3.org/ns/activitystreams',
               {
-                toot: 'http://joinmastodon.org/ns#',
-                QuoteAuthorization: 'toot:QuoteAuthorization',
+                QuoteAuthorization: 'https://w3id.org/fep/044f#QuoteAuthorization',
                 gts: 'https://gotosocial.org/ns#',
                 interactionPolicy: {
                   '@id': 'gts:interactionPolicy',

--- a/spec/services/activitypub/process_status_update_service_spec.rb
+++ b/spec/services/activitypub/process_status_update_service_spec.rb
@@ -469,8 +469,7 @@ RSpec.describe ActivityPub::ProcessStatusUpdateService do
         '@context': [
           'https://www.w3.org/ns/activitystreams',
           {
-            toot: 'http://joinmastodon.org/ns#',
-            QuoteAuthorization: 'toot:QuoteAuthorization',
+            QuoteAuthorization: 'https://w3id.org/fep/044f#QuoteAuthorization',
             gts: 'https://gotosocial.org/ns#',
             interactionPolicy: {
               '@id': 'gts:interactionPolicy',
@@ -569,8 +568,7 @@ RSpec.describe ActivityPub::ProcessStatusUpdateService do
         '@context': [
           'https://www.w3.org/ns/activitystreams',
           {
-            toot: 'http://joinmastodon.org/ns#',
-            QuoteAuthorization: 'toot:QuoteAuthorization',
+            QuoteAuthorization: 'https://w3id.org/fep/044f#QuoteAuthorization',
             gts: 'https://gotosocial.org/ns#',
             interactionPolicy: {
               '@id': 'gts:interactionPolicy',
@@ -721,8 +719,7 @@ RSpec.describe ActivityPub::ProcessStatusUpdateService do
         '@context': [
           'https://www.w3.org/ns/activitystreams',
           {
-            toot: 'http://joinmastodon.org/ns#',
-            QuoteAuthorization: 'toot:QuoteAuthorization',
+            QuoteAuthorization: 'https://w3id.org/fep/044f#QuoteAuthorization',
             gts: 'https://gotosocial.org/ns#',
             interactionPolicy: {
               '@id': 'gts:interactionPolicy',
@@ -792,8 +789,7 @@ RSpec.describe ActivityPub::ProcessStatusUpdateService do
         '@context': [
           'https://www.w3.org/ns/activitystreams',
           {
-            toot: 'http://joinmastodon.org/ns#',
-            QuoteAuthorization: 'toot:QuoteAuthorization',
+            QuoteAuthorization: 'https://w3id.org/fep/044f#QuoteAuthorization',
             gts: 'https://gotosocial.org/ns#',
             interactionPolicy: {
               '@id': 'gts:interactionPolicy',

--- a/spec/services/activitypub/verify_quote_service_spec.rb
+++ b/spec/services/activitypub/verify_quote_service_spec.rb
@@ -50,8 +50,7 @@ RSpec.describe ActivityPub::VerifyQuoteService do
         '@context': [
           'https://www.w3.org/ns/activitystreams',
           {
-            toot: 'http://joinmastodon.org/ns#',
-            QuoteAuthorization: 'toot:QuoteAuthorization',
+            QuoteAuthorization: 'https://w3id.org/fep/044f#QuoteAuthorization',
             gts: 'https://gotosocial.org/ns#',
             interactionPolicy: {
               '@id': 'gts:interactionPolicy',


### PR DESCRIPTION
The last FEP update introduced an inconsistency, but the aim was to move everything new to the FEP namespace, as will be done by the pending PR: https://codeberg.org/fediverse/fep/pulls/559