### PR TITLE
Change devise to not use HTTP Basic Authentication

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -158,13 +158,15 @@ Devise.setup do |config|
   # given strategies, for example, `config.params_authenticatable = [:database]` will
   # enable it only for database (email + password) authentication.
   # config.params_authenticatable = true
+  config.params_authenticatable = true
 
   # Tell if authentication through HTTP Auth is enabled. False by default.
   # It can be set to an array that will enable http authentication only for the
   # given strategies, for example, `config.http_authenticatable = [:database]` will
   # enable it only for database authentication. The supported strategies are:
   # :database      = Support basic authentication with authentication key + password
-  config.http_authenticatable = [:pam, :database]
+  # config.http_authenticatable = [:pam, :database]
+  config.http_authenticatable = false
 
   # If 401 status code should be returned for AJAX requests. True by default.
   # config.http_authenticatable_on_xhr = true


### PR DESCRIPTION
I can't see when we would ever use HTTP Basic Authentication given all of our session stuff happens through forms with params. The only details for why this was enabled was "support PAM"

Edit: See the comments below for the full history.