### PR TITLE
Fix quote serializer

### DIFF
--- a/app/presenters/status_relationships_presenter.rb
+++ b/app/presenters/status_relationships_presenter.rb
@@ -7,14 +7,24 @@ class StatusRelationshipsPresenter
               :bookmarks_map, :filters_map, :attributes_map
 
   def initialize(statuses, current_account_id = nil, **options)
+    @current_account_id = current_account_id
+
+    # Keeping a reference to @statuses is ok since `StatusRelationshipsPresenter`
+    # basically never outlives the statuses collection it is passed
+    @statuses = statuses
+
     if current_account_id.nil?
-      @reblogs_map    = {}
-      @favourites_map = {}
-      @bookmarks_map  = {}
-      @mutes_map      = {}
-      @pins_map       = {}
-      @filters_map    = {}
+      @preloaded_account_relations = {}
+      @filters_map     = {}
+      @reblogs_map     = {}
+      @favourites_map  = {}
+      @bookmarks_map   = {}
+      @mutes_map       = {}
+      @pins_map        = {}
+      @attributes_map  = {}
     else
+      @preloaded_account_relations = nil
+
       statuses            = statuses.compact
       status_ids          = statuses.flat_map { |s| [s.id, s.reblog_of_id, s.proper.quote&.quoted_status_id] }.uniq.compact
       conversation_ids    = statuses.flat_map { |s| [s.proper.conversation_id, s.proper.quote&.quoted_status&.conversation_id] }.uniq.compact
@@ -27,6 +37,17 @@ class StatusRelationshipsPresenter
       @mutes_map       = Status.mutes_map(conversation_ids, current_account_id).merge(options[:mutes_map] || {})
       @pins_map        = Status.pins_map(pinnable_status_ids, current_account_id).merge(options[:pins_map] || {})
       @attributes_map  = options[:attributes_map] || {}
+    end
+  end
+
+  # This one is currently on-demand as it is only used for quote posts
+  def preloaded_account_relations
+    @preloaded_account_relations ||= begin
+      accounts = @statuses.compact.flat_map { |s| [s.account, s.proper.account, s.proper.quote&.quoted_account] }.uniq.compact
+
+      account_ids = accounts.pluck(:id)
+      account_domains = accounts.pluck(:domain).uniq
+      Account.find(@current_account_id).relations_map(account_ids, account_domains)
     end
   end
 

--- a/app/serializers/rest/base_quote_serializer.rb
+++ b/app/serializers/rest/base_quote_serializer.rb
@@ -20,6 +20,6 @@ class REST::BaseQuoteSerializer < ActiveModel::Serializer
   private
 
   def status_filter
-    @status_filter ||= StatusFilter.new(object.quoted_status, current_user&.account, instance_options[:relationships] || {})
+    @status_filter ||= StatusFilter.new(object.quoted_status, current_user&.account, instance_options[:relationships]&.preloaded_account_relations || {})
   end
 end

--- a/spec/requests/api/v1/timelines/home_spec.rb
+++ b/spec/requests/api/v1/timelines/home_spec.rb
@@ -30,6 +30,9 @@ RSpec.describe 'Home', :inline_jobs do
         PostStatusService.new.call(tim, text: 'New toot from tim.')
         reblogged = PostStatusService.new.call(tim, text: 'New toot from tim, which will end up boosted.')
         ReblogService.new.call(bob, reblogged)
+        # TODO: use PostStatusService argument when available rather than manually creating quote
+        quoting = PostStatusService.new.call(bob, text: 'Self-quote from bob.')
+        Quote.create!(status: quoting, quoted_status: quoted, state: :accepted)
         PostStatusService.new.call(ana, text: 'New toot from ana.')
       end
 

--- a/spec/requests/api/v1/timelines/home_spec.rb
+++ b/spec/requests/api/v1/timelines/home_spec.rb
@@ -26,8 +26,10 @@ RSpec.describe 'Home', :inline_jobs do
       before do
         user.account.follow!(bob)
         user.account.follow!(ana)
-        PostStatusService.new.call(bob, text: 'New toot from bob.')
+        quoted = PostStatusService.new.call(bob, text: 'New toot from bob.')
         PostStatusService.new.call(tim, text: 'New toot from tim.')
+        reblogged = PostStatusService.new.call(tim, text: 'New toot from tim, which will end up boosted.')
+        ReblogService.new.call(bob, reblogged)
         PostStatusService.new.call(ana, text: 'New toot from ana.')
       end
 


### PR DESCRIPTION
Fixes preloaded relationships lookup in status serializer.

I had confused the purpose of `Account#relations_map` and `StatusRelationshipsPresenter`, passing the second to `StatusFilter` while it was expecting the first.

`StatusRelationshipsPresenter` fetches interaction status with a a batch of `Status` objects, while `Account#relations_map` fetches following/blocking/muting relations with a batch of `Account` objects. The former is exposed whenever we fetch one or more statuses, the second is only used in specific cases.

Since quote posts, and only quote posts, require an `Account#relationships_map` that can be computed from the information contained in `StatusRelationshipsPresenter`, add a memoized `StatusRelationshipsPresenter#preloaded_account_relations` for that purpose.

I also reordered the instance variable initialization so that they are in the same order in the two branches, leading to the same Ruby object shape.

---

Fixes MAS-410