### PR TITLE
Fix icon crushed when account name was too long

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -10399,6 +10399,10 @@ noscript {
       bdi {
         color: $darker-text-color;
       }
+
+      .account__avatar {
+        flex: 0 0 auto;
+      }
     }
 
     &__content {


### PR DESCRIPTION
As shown in the image, when the account name in the notification area is long, the icon gets squished.  
This PR correctly sets up a liquid layout to resolve this issue.

before:
![Screenshot_20250422_201612](https://github.com/user-attachments/assets/97280e14-6628-4b2f-a85b-286549ff7031)

after:
![Screenshot_20250422_201549](https://github.com/user-attachments/assets/5de969fd-47da-47f3-b430-ea242cf68951)
