### PR TITLE
Add warning for Elasticsearch index analyzers mismatch

### DIFF
--- a/app/lib/admin/system_check/elasticsearch_check.rb
+++ b/app/lib/admin/system_check/elasticsearch_check.rb
@@ -38,6 +38,11 @@ class Admin::SystemCheck::ElasticsearchCheck < Admin::SystemCheck::BaseCheck
         :elasticsearch_index_mismatch,
         mismatched_indexes.join(' ')
       )
+    elsif !specifications_match?
+      Admin::SystemCheck::Message.new(
+        :elasticsearch_analysis_mismatch,
+        mismatched_specifications_indexes.join(' ')
+      )
     elsif cluster_health['status'] == 'red'
       Admin::SystemCheck::Message.new(:elasticsearch_health_red)
     elsif cluster_health['number_of_nodes'] < 2 && es_preset != 'single_node_cluster'
@@ -111,8 +116,18 @@ class Admin::SystemCheck::ElasticsearchCheck < Admin::SystemCheck::BaseCheck
     end
   end
 
+  def mismatched_specifications_indexes
+    @mismatched_specifications_indexes ||= INDEXES.filter_map do |klass|
+      klass.base_name if klass.specification.changed?
+    end
+  end
+
   def indexes_match?
     mismatched_indexes.empty?
+  end
+
+  def specifications_match?
+    mismatched_specifications_indexes.empty?
   end
 
   def es_preset

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -903,6 +903,8 @@ en:
     system_checks:
       database_schema_check:
         message_html: There are pending database migrations. Please run them to ensure the application behaves as expected
+      elasticsearch_analysis_index_mismatch:
+        message_html: Elasticsearch index analyzer settings are outdated. Please run <code>tootctl search deploy --only-mapping --only=%{value}</code>
       elasticsearch_health_red:
         message_html: Elasticsearch cluster is unhealthy (red status), search features are unavailable
       elasticsearch_health_yellow:


### PR DESCRIPTION
The change in #34455 does not currently trigger the existing warning, so this PR aims to add an appropriate one.

However, this is a draft because it seems running `tootctl search deploy` will only *add* to definitions, if we stop using an analyser, it seems its configuration will remain in Elasticsearch? This is a bit confusing