### PR TITLE
Fix #34517 with most basic change possible

### DIFF
--- a/streaming/database.js
+++ b/streaming/database.js
@@ -1,5 +1,5 @@
 import pg from 'pg';
-import pgConnectionString from 'pg-connection-string';
+import { parse } from 'pg-connection-string';
 
 import { parseIntFromEnvValue } from './utils.js';
 
@@ -16,7 +16,11 @@ export function configFromEnv(env, environment) {
       password: env.DB_PASS || pg.defaults.password,
       database: env.DB_NAME || 'mastodon_development',
       host: env.DB_HOST || pg.defaults.host,
-      port: parseIntFromEnvValue(env.DB_PORT, pg.defaults.port ?? 5432, 'DB_PORT')
+      port: parseIntFromEnvValue(
+        env.DB_PORT,
+        pg.defaults.port ?? 5432,
+        'DB_PORT',
+      ),
     },
 
     production: {
@@ -24,7 +28,7 @@ export function configFromEnv(env, environment) {
       password: env.DB_PASS || '',
       database: env.DB_NAME || 'mastodon_production',
       host: env.DB_HOST || 'localhost',
-      port: parseIntFromEnvValue(env.DB_PORT, 5432, 'DB_PORT')
+      port: parseIntFromEnvValue(env.DB_PORT, 5432, 'DB_PORT'),
     },
   };
 
@@ -34,7 +38,7 @@ export function configFromEnv(env, environment) {
   let baseConfig = {};
 
   if (env.DATABASE_URL) {
-    const parsedUrl = pgConnectionString.parse(env.DATABASE_URL);
+    const parsedUrl = parse(env.DATABASE_URL);
 
     // The result of dbUrlToConfig from pg-connection-string is not type
     // compatible with pg.PoolConfig, since parts of the connection URL may be
@@ -46,25 +50,34 @@ export function configFromEnv(env, environment) {
     // https://github.com/brianc/node-postgres/issues/2280
     //
     // FIXME: clean up once brianc/node-postgres#3128 lands
-    if (typeof parsedUrl.password === 'string') baseConfig.password = parsedUrl.password;
+    if (typeof parsedUrl.password === 'string')
+      baseConfig.password = parsedUrl.password;
     if (typeof parsedUrl.host === 'string') baseConfig.host = parsedUrl.host;
     if (typeof parsedUrl.user === 'string') baseConfig.user = parsedUrl.user;
     if (typeof parsedUrl.port === 'string' && parsedUrl.port) {
       const parsedPort = parseInt(parsedUrl.port, 10);
       if (isNaN(parsedPort)) {
-        throw new Error('Invalid port specified in DATABASE_URL environment variable');
+        throw new Error(
+          'Invalid port specified in DATABASE_URL environment variable',
+        );
       }
       baseConfig.port = parsedPort;
     }
-    if (typeof parsedUrl.database === 'string') baseConfig.database = parsedUrl.database;
-    if (typeof parsedUrl.options === 'string') baseConfig.options = parsedUrl.options;
+    if (typeof parsedUrl.database === 'string')
+      baseConfig.database = parsedUrl.database;
+    if (typeof parsedUrl.options === 'string')
+      baseConfig.options = parsedUrl.options;
 
     // The pg-connection-string type definition isn't correct, as parsedUrl.ssl
     // can absolutely be an Object, this is to work around these incorrect
     // types, including the casting of parsedUrl.ssl to Record<string, any>
     if (typeof parsedUrl.ssl === 'boolean') {
       baseConfig.ssl = parsedUrl.ssl;
-    } else if (typeof parsedUrl.ssl === 'object' && !Array.isArray(parsedUrl.ssl) && parsedUrl.ssl !== null) {
+    } else if (
+      typeof parsedUrl.ssl === 'object' &&
+      !Array.isArray(parsedUrl.ssl) &&
+      parsedUrl.ssl !== null
+    ) {
       /** @type {Record<string, any>} */
       const sslOptions = parsedUrl.ssl;
       baseConfig.ssl = {};
@@ -83,17 +96,17 @@ export function configFromEnv(env, environment) {
     baseConfig = pgConfigs[environment];
 
     if (env.DB_SSLMODE) {
-      switch(env.DB_SSLMODE) {
-      case 'disable':
-      case '':
-        baseConfig.ssl = false;
-        break;
-      case 'no-verify':
-        baseConfig.ssl = { rejectUnauthorized: false };
-        break;
-      default:
-        baseConfig.ssl = {};
-        break;
+      switch (env.DB_SSLMODE) {
+        case 'disable':
+        case '':
+          baseConfig.ssl = false;
+          break;
+        case 'no-verify':
+          baseConfig.ssl = { rejectUnauthorized: false };
+          break;
+        default:
+          baseConfig.ssl = {};
+          break;
       }
     }
   } else {
@@ -134,16 +147,23 @@ export function getPool(config, environment, logger) {
       return async (queryTextOrConfig, values, ...rest) => {
         const start = process.hrtime();
 
-        const result = await originalQuery.apply(pool, [queryTextOrConfig, values, ...rest]);
+        const result = await originalQuery.apply(pool, [
+          queryTextOrConfig,
+          values,
+          ...rest,
+        ]);
 
         const duration = process.hrtime(start);
         const durationInMs = (duration[0] * 1000000000 + duration[1]) / 1000000;
 
-        logger.debug({
-          query: queryTextOrConfig,
-          values,
-          duration: durationInMs
-        }, 'Executed database query');
+        logger.debug(
+          {
+            query: queryTextOrConfig,
+            values,
+            duration: durationInMs,
+          },
+          'Executed database query',
+        );
 
         return result;
       };

--- a/yarn.lock
+++ b/yarn.lock
@@ -13287,9 +13287,9 @@ __metadata:
   linkType: hard
 
 "pg-connection-string@npm:^2.6.0, pg-connection-string@npm:^2.7.0":
-  version: 2.7.0
-  resolution: "pg-connection-string@npm:2.7.0"
-  checksum: 10c0/50a1496a1c858f9495d78a2c7a66d93ef3602e718aff2953bb5738f3ea616d7f727f32fc20513c9bed127650cd14c1ddc7b458396f4000e689d4b64c65c5c51e
+  version: 2.8.0
+  resolution: "pg-connection-string@npm:2.8.0"
+  checksum: 10c0/5600e3992ddacaa1022e4260a7bb8f24cc187cec1fc5d1526a274a4edc8db8b446f2a9c7f552c6f71f2dc7b3b391ceedebfef93de26b4943b6a26dfaecdd5bbc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This should allow the tests to complete. Stacktrace was:

```
streaming/database.js:2
import pgConnectionString from 'pg-connection-string';
       ^^^^^^^^^^^^^^^^^^
SyntaxError: The requested module 'pg-connection-string' does not provide an export named 'default'
    at ModuleJob._instantiate (node:internal/modules/esm/module_job:180:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:263:5)
    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:578:26)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:116:5)

Node.js v22.14.0
```
