### PR TITLE
Streaming: Use libpq compat mode for DATABASE_URL

### DIFF
--- a/streaming/database.js
+++ b/streaming/database.js
@@ -44,7 +44,7 @@ export function configFromEnv(env, environment, logger) {
     // of time to give a more specific error message:
     if (env.DATABASE_URL.includes('uselibpqcompat')) {
       throw new Error(
-        'SECURITY WARNING: Mastodon forces uselibpqcompat mode, do not include it in DATABASE_URL',
+        'Mastodon forces uselibpqcompat mode, do not include it in DATABASE_URL',
       );
     }
 

--- a/streaming/index.js
+++ b/streaming/index.js
@@ -101,7 +101,7 @@ const CHANNEL_NAMES = [
 ];
 
 const startServer = async () => {
-  const pgConfig = Database.configFromEnv(process.env, environment);
+  const pgConfig = Database.configFromEnv(process.env, environment, logger);
   const pgPool = Database.getPool(pgConfig, environment, logger);
 
   const metrics = setupMetrics(CHANNEL_NAMES, pgPool);


### PR DESCRIPTION
This also discourages using `DB_SSLMODE` as with that option, there is no way to set the certificates. Instead, using `DATABASE_URL` is preferred. This is also the case for Rails, where `DB_SSLMODE` can lead to insecure configurations, since in `verify-ca` or `verify-full` there's no CA certificate, and we don't support a `DB_SSLROOTCERT` option or anything like that, which is required for actually securely doing SSL with libpq — at present this can only be set via `DATABASE_URL` in rails.

The big diff in the `DATABASE_URL` handling is due to `toClientConfig` which does the correct types which we were previously manually having to convert to.

This fixes and closes:
- https://github.com/mastodon/mastodon/pull/31667
- https://github.com/mastodon/mastodon/pull/25483
- https://github.com/mastodon/mastodon/pull/31829
- https://github.com/mastodon/mastodon/issues/31774