### PR TITLE
Change `DEFAULT_LOCALE` to not override unauthenticated users' browser language

### DIFF
--- a/app/controllers/concerns/localized.rb
+++ b/app/controllers/concerns/localized.rb
@@ -16,7 +16,7 @@ module Localized
   def requested_locale
     requested_locale_name   = available_locale_or_nil(params[:lang])
     requested_locale_name ||= available_locale_or_nil(current_user.locale) if respond_to?(:user_signed_in?) && user_signed_in?
-    requested_locale_name ||= http_accept_language if ENV['DEFAULT_LOCALE'].blank?
+    requested_locale_name ||= http_accept_language unless ENV['FORCE_DEFAULT_LOCALE'] == 'true'
     requested_locale_name
   end
 


### PR DESCRIPTION
Add `FORCE_DEFAULT_LOCALE` to enforce the previous behavior

---

Fixes MAS-411