### PR TITLE
Fix sign-up e-mail confirmation page reloading on error or redirect

### DIFF
--- a/app/javascript/entrypoints/sign_up.ts
+++ b/app/javascript/entrypoints/sign_up.ts
@@ -4,9 +4,12 @@ import axios from 'axios';
 import ready from '../mastodon/ready';
 
 async function checkConfirmation() {
-  const response = await axios.get('/api/v1/emails/check_confirmation');
+  const response = await axios.get('/api/v1/emails/check_confirmation', {
+    headers: { Accept: 'application/json' },
+    withCredentials: true,
+  });
 
-  if (response.data) {
+  if (response.status === 200 && response.data === true) {
     window.location.href = '/start';
   }
 }


### PR DESCRIPTION
On error or redirect (such as is currently the case with `LIMITED_FEDERATION_MODE=true`), the sign-up screen would erroneously try to proceed to `/start`.

This PR changes it to have stricter verification of the API result, and also requests `application/json` explicitly.

The issue of API endpoints redirecting to HTML pages in `LIMITED_FEDERATION_MODE=true` should be addressed in a separate PR.