### PR TITLE
Change quote IDs to use snowflake IDs

### DIFF
--- a/db/migrate/20250425134308_quote_ids_to_timestamp_ids.rb
+++ b/db/migrate/20250425134308_quote_ids_to_timestamp_ids.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class QuoteIdsToTimestampIds < ActiveRecord::Migration[8.0]
+  def up
+    # Set up the media_attachments.id column to use our timestamp-based IDs.
+    safety_assured do
+      execute("ALTER TABLE quotes ALTER COLUMN id SET DEFAULT timestamp_id('quotes')")
+    end
+
+    # Make sure we have a sequence to use.
+    Mastodon::Snowflake.ensure_id_sequences_exist
+  end
+
+  def down
+    execute('LOCK quotes')
+    execute("SELECT setval('quotes_id_seq', (SELECT MAX(id) FROM quotes))")
+    execute("ALTER TABLE quotes ALTER COLUMN id SET DEFAULT nextval('quotes_id_seq')")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_22_085303) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_25_134654) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -871,7 +871,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_22_085303) do
     t.string "url"
   end
 
-  create_table "quotes", force: :cascade do |t|
+  create_table "quotes", id: :bigint, default: -> { "timestamp_id('quotes'::text)" }, force: :cascade do |t|
     t.bigint "account_id", null: false
     t.bigint "status_id", null: false
     t.bigint "quoted_status_id"


### PR DESCRIPTION
We are most likely going to use those IDs for quote approvals in the future. Just like for posts, they should not be easily enumerable.