### PR TITLE
Fix directory scroll position reset

### DIFF
--- a/app/javascript/mastodon/components/load_more.tsx
+++ b/app/javascript/mastodon/components/load_more.tsx
@@ -1,24 +1,32 @@
 import { FormattedMessage } from 'react-intl';
 
+import { LoadingIndicator } from './loading_indicator';
+
 interface Props {
   onClick: (event: React.MouseEvent) => void;
   disabled?: boolean;
   visible?: boolean;
+  loading?: boolean;
 }
 export const LoadMore: React.FC<Props> = ({
   onClick,
   disabled,
   visible = true,
+  loading = false,
 }) => {
   return (
     <button
       type='button'
       className='load-more'
-      disabled={disabled || !visible}
+      disabled={disabled || loading || !visible}
       style={{ visibility: visible ? 'visible' : 'hidden' }}
       onClick={onClick}
     >
-      <FormattedMessage id='status.load_more' defaultMessage='Load more' />
+      {loading ? (
+        <LoadingIndicator />
+      ) : (
+        <FormattedMessage id='status.load_more' defaultMessage='Load more' />
+      )}
     </button>
   );
 };

--- a/app/javascript/mastodon/features/directory/index.tsx
+++ b/app/javascript/mastodon/features/directory/index.tsx
@@ -130,6 +130,7 @@ export const Directory: React.FC<{
   }, [dispatch, order, local]);
 
   const pinned = !!columnId;
+  const initialLoad = isLoading && accountIds.size === 0;
 
   const scrollableArea = (
     <div className='scrollable'>
@@ -170,7 +171,7 @@ export const Directory: React.FC<{
       </div>
 
       <div className='directory__list'>
-        {isLoading ? (
+        {initialLoad ? (
           <LoadingIndicator />
         ) : (
           accountIds.map((accountId) => (
@@ -179,7 +180,11 @@ export const Directory: React.FC<{
         )}
       </div>
 
-      <LoadMore onClick={handleLoadMore} visible={!isLoading} />
+      <LoadMore
+        onClick={handleLoadMore}
+        visible={!initialLoad}
+        loading={isLoading}
+      />
     </div>
   );
 


### PR DESCRIPTION
Hey, 

This resolves the #18078 issue. 

I took a little liberty to change the behavior of `<LoadingIndicator />` on the directory feature. As current implementation manipulates the visibility of the `<AccountCard />` list, which resets the scroll position to the top whenever new elements are loaded. 

Proposed change swaps the `<LoadMore>` component with `<LoadingIndicator/>` each time new data is loaded. It utilizes the existing scss rule `.load-more .loading-indicator` which places the loader exactly at the previous position of the button. 

I'm aware that this changes the design slightly, but it seems to be the simplest solution to the problem. But if that's not possible, I'm open to any guidance how to resolve that issue differently. 