### PR TITLE
Fix `tootctl search deploy --only-mapping` not updating index settings

### DIFF
--- a/lib/chewy/index_extensions.rb
+++ b/lib/chewy/index_extensions.rb
@@ -12,6 +12,13 @@ module Chewy
         base_options.merge(number_of_replicas: 1, number_of_shards: (base_options[:number_of_shards] || 1) * 2)
       end
     end
+
+    def update_specification
+      client.indices.close index: index_name
+      client.indices.put_settings index: index_name, body: { settings: { analysis: settings_hash[:settings][:analysis] } }
+      client.indices.put_mapping index: index_name, body: root.mappings_hash
+      client.indices.open index: index_name
+    end
   end
 end
 

--- a/lib/mastodon/cli/search.rb
+++ b/lib/mastodon/cli/search.rb
@@ -56,7 +56,7 @@ module Mastodon::CLI
       if options[:only_mapping]
         indices.select { |index| index.specification.changed? }.each do |index|
           progress.title = "Updating mapping for #{index} "
-          index.update_mapping
+          index.update_specification
           index.specification.lock!
         end
 


### PR DESCRIPTION
The `Chewy::Index#update_mapping` method does not actually update index settings, only field mappings. To update index settings, the index must be closed, updated, then reopened.