### PR TITLE
Change `/api/v2/instance` to be enabled without authentication when limited federation mode is enabled

### DIFF
--- a/app/controllers/api/v2/instances_controller.rb
+++ b/app/controllers/api/v2/instances_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Api::V2::InstancesController < Api::BaseController
-  skip_before_action :require_authenticated_user!, unless: :limited_federation_mode?
+  skip_before_action :require_authenticated_user!
   skip_around_action :set_locale
 
   vary_by ''

--- a/app/serializers/rest/instance_serializer.rb
+++ b/app/serializers/rest/instance_serializer.rb
@@ -49,7 +49,7 @@ class REST::InstanceSerializer < ActiveModel::Serializer
   def usage
     {
       users: {
-        active_month: object.active_user_count(4),
+        active_month: limited_federation? ? 0 : object.active_user_count(4),
       },
     }
   end
@@ -99,6 +99,8 @@ class REST::InstanceSerializer < ActiveModel::Serializer
       translation: {
         enabled: TranslationService.configured?,
       },
+
+      limited_federation: limited_federation?,
     }
   end
 
@@ -125,6 +127,10 @@ class REST::InstanceSerializer < ActiveModel::Serializer
 
   def registrations_message
     markdown.render(Setting.closed_registrations_message) if Setting.closed_registrations_message.present?
+  end
+
+  def limited_federation?
+    Rails.configuration.x.limited_federation_mode
   end
 
   def markdown


### PR DESCRIPTION
Additionally, add `configuration.limited_federation` to indicate whether the server has switched to limited federation.

Also sets `usage.users.active_month` to `0` in limited federation mode.

---

Fixes MAS-389