### PR TITLE
Add support for importing embedded self-quotes

### DIFF
--- a/app/helpers/json_ld_helper.rb
+++ b/app/helpers/json_ld_helper.rb
@@ -72,6 +72,18 @@ module JsonLdHelper
     !haystack.casecmp(needle).zero?
   end
 
+  def safe_prefetched_embed(account, object, context)
+    return unless object.is_a?(Hash)
+
+    # NOTE: Replacing the object's context by that of the parent activity is
+    # not sound, but it's consistent with the rest of the codebase
+    object = object.merge({ '@context' => context })
+
+    return if value_or_id(first_of_value(object['attributedTo'])) != account.uri || non_matching_uri_hosts?(account.uri, object['id'])
+
+    object
+  end
+
   def canonicalize(json)
     graph = RDF::Graph.new << JSON::LD::API.toRdf(json, documentLoader: method(:load_jsonld_context))
     graph.dump(:normalize)

--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -205,22 +205,10 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
     @quote.status = status
     @quote.save
 
-    ActivityPub::VerifyQuoteService.new.call(@quote, fetchable_quoted_uri: @quote_uri, prefetched_quoted_object: safe_prefetched_quoted_object, request_id: @options[:request_id])
+    embedded_quote = safe_prefetched_embed(@account, @status_parser.quoted_object, @json['context'])
+    ActivityPub::VerifyQuoteService.new.call(@quote, fetchable_quoted_uri: @quote_uri, prefetched_quoted_object: embedded_quote, request_id: @options[:request_id])
   rescue Mastodon::UnexpectedResponseError, *Mastodon::HTTP_CONNECTION_ERRORS
     ActivityPub::RefetchAndVerifyQuoteWorker.perform_in(rand(30..600).seconds, @quote.id, @quote_uri, { 'request_id' => @options[:request_id] })
-  end
-
-  def safe_prefetched_quoted_object
-    object = @status_parser.quoted_object
-    return unless object.is_a?(Hash)
-
-    # NOTE: Replacing the object's context by that of the parent activity is
-    # not sound, but it's consistent with the rest of the codebase
-    object = object.merge({ '@context' => @json['@context'] })
-
-    return if value_or_id(first_of_value(object['attributedTo'])) != @account.uri || non_matching_uri_hosts?(@account.uri, object['id'])
-
-    object
   end
 
   def process_tags

--- a/app/lib/activitypub/parser/status_parser.rb
+++ b/app/lib/activitypub/parser/status_parser.rb
@@ -120,6 +120,11 @@ class ActivityPub::Parser::StatusParser
     end.first
   end
 
+  # The inlined quote; out of the attributes we support, only `https://w3id.org/fep/044f#quote` explicitly supports inlined objects
+  def quoted_object
+    as_array(@object['quote']).first
+  end
+
   def quote_approval_uri
     as_array(@object['quoteAuthorization']).first
   end

--- a/app/services/activitypub/process_status_update_service.rb
+++ b/app/services/activitypub/process_status_update_service.rb
@@ -304,22 +304,10 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
   end
 
   def fetch_and_verify_quote!(quote, quote_uri)
-    ActivityPub::VerifyQuoteService.new.call(quote, fetchable_quoted_uri: quote_uri, prefetched_quoted_object: safe_prefetched_quoted_object, request_id: @request_id)
+    embedded_quote = safe_prefetched_embed(@account, @status_parser.quoted_object, @activity_json['context'])
+    ActivityPub::VerifyQuoteService.new.call(quote, fetchable_quoted_uri: quote_uri, prefetched_quoted_object: embedded_quote, request_id: @request_id)
   rescue Mastodon::UnexpectedResponseError, *Mastodon::HTTP_CONNECTION_ERRORS
     ActivityPub::RefetchAndVerifyQuoteWorker.perform_in(rand(30..600).seconds, quote.id, quote_uri, { 'request_id' => @request_id })
-  end
-
-  def safe_prefetched_quoted_object
-    object = @status_parser.quoted_object
-    return unless object.is_a?(Hash)
-
-    # NOTE: Replacing the object's context by that of the parent activity is
-    # not sound, but it's consistent with the rest of the codebase
-    object = object.merge({ '@context' => @activity_json['@context'] })
-
-    return if value_or_id(first_of_value(object['attributedTo'])) != @account.uri || non_matching_uri_hosts?(@account.uri, object['id'])
-
-    object
   end
 
   def update_counts!

--- a/app/services/activitypub/process_status_update_service.rb
+++ b/app/services/activitypub/process_status_update_service.rb
@@ -273,7 +273,6 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
   def update_quote!
     return unless Mastodon::Feature.inbound_quotes_enabled?
 
-    quote = nil
     quote_uri = @status_parser.quote_uri
 
     if quote_uri.present?
@@ -294,19 +293,20 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
         quote = Quote.create(status: @status, approval_uri: approval_uri)
         @quote_changed = true
       end
-    end
 
-    if quote.present?
-      begin
-        quote.save
-        ActivityPub::VerifyQuoteService.new.call(quote, fetchable_quoted_uri: quote_uri, request_id: @request_id)
-      rescue Mastodon::UnexpectedResponseError, *Mastodon::HTTP_CONNECTION_ERRORS
-        ActivityPub::RefetchAndVerifyQuoteWorker.perform_in(rand(30..600).seconds, quote.id, quote_uri, { 'request_id' => @request_id })
-      end
+      quote.save
+
+      fetch_and_verify_quote!(quote, quote_uri)
     elsif @status.quote.present?
       @status.quote.destroy!
       @quote_changed = true
     end
+  end
+
+  def fetch_and_verify_quote!(quote, quote_uri)
+    ActivityPub::VerifyQuoteService.new.call(quote, fetchable_quoted_uri: quote_uri, request_id: @request_id)
+  rescue Mastodon::UnexpectedResponseError, *Mastodon::HTTP_CONNECTION_ERRORS
+    ActivityPub::RefetchAndVerifyQuoteWorker.perform_in(rand(30..600).seconds, quote.id, quote_uri, { 'request_id' => @request_id })
   end
 
   def update_counts!


### PR DESCRIPTION
This adds support for importing embedded self-quotes, skipping the requirement to fetch a separate approval stamp and making private self-quotes easier to handle.