### PR TITLE
Fix: Use strings not symbols to access `totalItems` in interaction collections

### DIFF
--- a/app/lib/activitypub/parser/status_parser.rb
+++ b/app/lib/activitypub/parser/status_parser.rb
@@ -95,11 +95,11 @@ class ActivityPub::Parser::StatusParser
   end
 
   def favourites_count
-    @object.dig(:likes, :totalItems)
+    @object.dig('likes', 'totalItems')
   end
 
   def reblogs_count
-    @object.dig(:shares, :totalItems)
+    @object.dig('shares', 'totalItems')
   end
 
   def quote_policy


### PR DESCRIPTION
Related to: https://github.com/mastodon/mastodon/pull/32620

I had noticed this too, that even though i was running glitch and had this code in our instance that i wasn't getting the external counts.

Problem stems from my prior misunderstanding of how strings and symbols work in ruby (sorry). The activitypub object has strings for keys, not symbols.

distressingly, the tests still seem to pass without changing them? don't know what to make of that.

tested this on local development instance. prior impl had `null` in the untrusted counts columns, this version fills them and also displays them correctly.

edit: marking as draft until the tests finish
edit2: tests pass so good 2 go