### PR TITLE
Remove double-query for signed query strings

### DIFF
--- a/app/lib/http_signature_draft.rb
+++ b/app/lib/http_signature_draft.rb
@@ -6,14 +6,13 @@
 class HttpSignatureDraft
   REQUEST_TARGET = '(request-target)'
 
-  def initialize(keypair, key_id, full_path: true)
+  def initialize(keypair, key_id)
     @keypair = keypair
     @key_id = key_id
-    @full_path = full_path
   end
 
   def request_target(verb, url)
-    if url.query.nil? || !@full_path
+    if url.query.nil?
       "#{verb} #{url.path}"
     else
       "#{verb} #{url.path}?#{url.query}"

--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -75,7 +75,6 @@ class Request
     @url         = Addressable::URI.parse(url).normalize
     @http_client = options.delete(:http_client)
     @allow_local = options.delete(:allow_local)
-    @full_path   = !options.delete(:omit_query_string)
     @options     = {
       follow: {
         max_hops: 3,
@@ -102,7 +101,7 @@ class Request
 
     key_id = ActivityPub::TagManager.instance.key_uri_for(actor)
     keypair = sign_with.present? ? OpenSSL::PKey::RSA.new(sign_with) : actor.keypair
-    @signing = HttpSignatureDraft.new(keypair, key_id, full_path: @full_path)
+    @signing = HttpSignatureDraft.new(keypair, key_id)
 
     self
   end

--- a/app/services/activitypub/fetch_replies_service.rb
+++ b/app/services/activitypub/fetch_replies_service.rb
@@ -57,20 +57,7 @@ class ActivityPub::FetchRepliesService < BaseService
     return unless @allow_synchronous_requests
     return if non_matching_uri_hosts?(@reference_uri, collection_or_uri)
 
-    # NOTE: For backward compatibility reasons, Mastodon signs outgoing
-    # queries incorrectly by default.
-    #
-    # While this is relevant for all URLs with query strings, this is
-    # the only code path where this happens in practice.
-    #
-    # Therefore, retry with correct signatures if this fails.
-    begin
-      fetch_resource_without_id_validation(collection_or_uri, nil, raise_on_error: :temporary)
-    rescue Mastodon::UnexpectedResponseError => e
-      raise unless e.response && e.response.code == 401 && Addressable::URI.parse(collection_or_uri).query.present?
-
-      fetch_resource_without_id_validation(collection_or_uri, nil, raise_on_error: :temporary, request_options: { omit_query_string: false })
-    end
+    fetch_resource_without_id_validation(collection_or_uri, nil, raise_on_error: :temporary)
   end
 
   def filter_replies(items)


### PR DESCRIPTION
#31994 was supposed to try the “correct” (still draft) signature first, then try the bogus one. However, it tried the “correct” one twice, providing no value.

Since this change has been live for several months (it's been backported to 4.1 and up on September 2024), it's probably fine to remove that behavior instead of simply fixing it.