### PR TITLE
fix: do not use the deprecated `/api/v1/instance` end point

### DIFF
--- a/app/javascript/mastodon/components/admin/ReportReasonSelector.jsx
+++ b/app/javascript/mastodon/components/admin/ReportReasonSelector.jsx
@@ -105,7 +105,7 @@ class ReportReasonSelector extends PureComponent {
   };
 
   componentDidMount() {
-    api(false).get('/api/v1/instance').then(res => {
+    api(false).get('/api/v2/instance').then(res => {
       this.setState({
         rules: res.data.rules,
       });


### PR DESCRIPTION
I noticed this was outputting a warning in the console when running the JS tests