### PR TITLE
Add: Update root status when fetching replies

### DIFF
--- a/app/workers/activitypub/fetch_all_replies_worker.rb
+++ b/app/workers/activitypub/fetch_all_replies_worker.rb
@@ -22,7 +22,7 @@ class ActivityPub::FetchAllRepliesWorker
     @root_status.touch(:fetched_replies_at)
     Rails.logger.debug { "FetchAllRepliesWorker - #{@root_status.uri}: Fetching all replies for status: #{@root_status}" }
 
-    uris_to_fetch, n_pages = get_replies(@root_status.uri, MAX_PAGES, options)
+    uris_to_fetch, n_pages = get_root_replies(@root_status.uri, options)
     return if uris_to_fetch.nil?
 
     fetched_uris = uris_to_fetch.clone.to_set
@@ -49,20 +49,39 @@ class ActivityPub::FetchAllRepliesWorker
 
   private
 
-  def get_replies(status_uri, max_pages, options = {})
-    replies_collection_or_uri = get_replies_uri(status_uri)
+  # @param status [String, Hash]
+  #   status URI, or the prefetched body of the Note object
+  def get_replies(status, max_pages, options = {})
+    replies_collection_or_uri = get_replies_uri(status)
     return if replies_collection_or_uri.nil?
 
-    ActivityPub::FetchAllRepliesService.new.call(status_uri, replies_collection_or_uri, max_pages: max_pages, **options.deep_symbolize_keys)
+    ActivityPub::FetchAllRepliesService.new.call(value_or_id(status), replies_collection_or_uri, max_pages: max_pages, **options.deep_symbolize_keys)
   end
 
-  def get_replies_uri(parent_status_uri)
-    fetch_resource(parent_status_uri, true)&.fetch('replies', nil)
+  # Get the URI of the replies collection of a status
+  #
+  # @param parent_status [String, Hash]
+  #   status URI, or the prefetched body of the Note object
+  def get_replies_uri(parent_status)
+    resource = parent_status.is_a?(Hash) ? parent_status : fetch_resource(parent_status, true)
+    resource&.fetch('replies', nil)
   rescue => e
-    Rails.logger.info { "FetchAllRepliesWorker - #{@root_status.uri}: Caught exception while resolving replies URI #{parent_status_uri}: #{e} - #{e.message}" }
+    Rails.logger.info { "FetchAllRepliesWorker - #{@root_status.uri}: Caught exception while resolving replies URI #{parent_status}: #{e} - #{e.message}" }
     # Raise if we can't get the collection for top-level status to trigger retry
-    raise e if parent_status_uri == @root_status.uri
+    raise e if value_or_id(parent_status) == @root_status.uri
 
     nil
+  end
+
+  # Get the root status, updating the status without fetching it twice
+  #
+  # @param root_status_uri [String]
+  def get_root_replies(root_status_uri, options = {})
+    root_status_body = fetch_resource(root_status_uri, true)
+    raise RuntimeError("FetchAllRepliesWorker - #{@root_status.uri}: Root status could not be fetched") if root_status_body.nil?
+
+    FetchReplyWorker.perform_async(root_status_uri, { prefetched_body: root_status_body })
+
+    get_replies(root_status_body, MAX_PAGES, options)
   end
 end

--- a/app/workers/activitypub/fetch_all_replies_worker.rb
+++ b/app/workers/activitypub/fetch_all_replies_worker.rb
@@ -80,7 +80,7 @@ class ActivityPub::FetchAllRepliesWorker
     root_status_body = fetch_resource(root_status_uri, true)
     raise RuntimeError("FetchAllRepliesWorker - #{@root_status.uri}: Root status could not be fetched") if root_status_body.nil?
 
-    FetchReplyWorker.perform_async(root_status_uri, { prefetched_body: root_status_body })
+    FetchReplyWorker.perform_async(root_status_uri, { **options, prefetched_body: root_status_body })
 
     get_replies(root_status_body, MAX_PAGES, options)
   end

--- a/app/workers/fetch_reply_worker.rb
+++ b/app/workers/fetch_reply_worker.rb
@@ -7,6 +7,6 @@ class FetchReplyWorker
   sidekiq_options queue: 'pull', retry: 3
 
   def perform(child_url, options = {})
-    FetchRemoteStatusService.new.call(child_url, **options.deep_symbolize_keys)
+    FetchRemoteStatusService.new.call(child_url, **options.symbolize_keys)
   end
 end

--- a/spec/workers/activitypub/fetch_all_replies_worker_spec.rb
+++ b/spec/workers/activitypub/fetch_all_replies_worker_spec.rb
@@ -125,6 +125,7 @@ RSpec.describe ActivityPub::FetchAllRepliesWorker do
   before do
     stub_const('Status::FetchRepliesConcern::FETCH_REPLIES_ENABLED', true)
     allow(FetchReplyWorker).to receive(:push_bulk)
+    allow(FetchReplyWorker).to receive(:perform_async)
     all_items.each do |item|
       next if [top_note_uri, reply_note_uri].include? item
 
@@ -145,6 +146,12 @@ RSpec.describe ActivityPub::FetchAllRepliesWorker do
       stub_const('ActivityPub::FetchAllRepliesWorker::MAX_REPLIES', 5)
       got_uris = subject.perform(status.id)
       expect(got_uris).to match_array(top_items + top_items_paged)
+    end
+
+    it 'fetches the top status only once' do
+      _ = subject.perform(status.id)
+      expect(FetchReplyWorker).to have_received(:perform_async).with(top_note_uri, { prefetched_body: top_object.deep_stringify_keys })
+      expect(a_request(:get, top_note_uri)).to have_been_made.once
     end
   end
 

--- a/spec/workers/activitypub/fetch_all_replies_worker_spec.rb
+++ b/spec/workers/activitypub/fetch_all_replies_worker_spec.rb
@@ -149,8 +149,8 @@ RSpec.describe ActivityPub::FetchAllRepliesWorker do
     end
 
     it 'fetches the top status only once' do
-      _ = subject.perform(status.id)
-      expect(FetchReplyWorker).to have_received(:perform_async).with(top_note_uri, { prefetched_body: top_object.deep_stringify_keys })
+      _ = subject.perform(status.id, { request_id: 0 })
+      expect(FetchReplyWorker).to have_received(:perform_async).with(top_note_uri, { prefetched_body: top_object.deep_stringify_keys, request_id: 0 })
       expect(a_request(:get, top_note_uri)).to have_been_made.once
     end
   end


### PR DESCRIPTION
Continues: https://github.com/mastodon/mastodon/pull/32620

In #32620 i said

> When combined with https://github.com/mastodon/mastodon/pull/32615 , this means that expanding a status to its detailed view will update the boost and favorite count for a status and all its replies.
>
> [...]
> 
> If this looks acceptable, i will update https://github.com/mastodon/mastodon/pull/32615 to also fetch the root post in order to update its stats

but I never did that, so this PR does.

The motivation is the same - when someone expands a post, they are interested in seeing that post, so they should see the updated view of that post. Without this PR, the external interaction stats will only update for child posts or if a thread root post is edited, which is pretty odd. So in most cases showing the external stats won't actually work, since we would only receive them on the initial status creation.

The reason this PR is not just one line is that it seemed wasteful to fetch the status twice, once to update the status, and once to get its replies collection. This is somewhat necessary to do in all the child statuses since 1) we don't store the replies URI in the db, 2) don't have a good way of passing the prefetched body from the `FetchReplyWorker` to the `FetchAllRepliesService`, and 3) we can't just do a recursive job where we fetch the note body, process it, and then dispatch subsidiary jobs for its replies collection because we want to have the fetch limits at the top level.

but for the topmost status we have both in the same place, so we might as well use it. This required minor changes to accept both URIs and prefetched body. I tried to reuse the same methods so that we didn't have *totally* divergent functionality for the root status, but i can split it out and revert changes to the other methods if that would be preferable.

The reason for the `deep_symbolize_keys` -> `symbolize_keys` switch is the same as [here](https://github.com/mastodon/mastodon/pull/34597#discussion_r2072483486)