### PR TITLE
Fix crash when `likes` or `shares` collections are not inlined, for real

### DIFF
--- a/app/lib/activitypub/parser/status_parser.rb
+++ b/app/lib/activitypub/parser/status_parser.rb
@@ -95,11 +95,11 @@ class ActivityPub::Parser::StatusParser
   end
 
   def favourites_count
-    @object.dig('likes', 'totalItems') if @object.is_a?(Hash)
+    @object['likes']['totalItems'] if @object.is_a?(Hash) && @object['likes'].is_a?(Hash)
   end
 
   def reblogs_count
-    @object.dig('shares', 'totalItems') if @object.is_a?(Hash)
+    @object['shares']['totalItems'] if @object.is_a?(Hash) && @object['shares'].is_a?(Hash)
   end
 
   def quote_policy

--- a/spec/lib/activitypub/parser/status_parser_spec.rb
+++ b/spec/lib/activitypub/parser/status_parser_spec.rb
@@ -49,6 +49,24 @@ RSpec.describe ActivityPub::Parser::StatusParser do
     )
   end
 
+  context 'when the likes collection is not inlined' do
+    let(:object_json) do
+      {
+        id: [ActivityPub::TagManager.instance.uri_for(sender), 'post1'].join('/'),
+        type: 'Note',
+        to: 'https://www.w3.org/ns/activitystreams#Public',
+        content: 'bleh',
+        published: 1.hour.ago.utc.iso8601,
+        updated: 1.hour.ago.utc.iso8601,
+        likes: 'https://example.com/collections/likes',
+      }
+    end
+
+    it 'does not raise an error' do
+      expect { subject.favourites_count }.to_not raise_error
+    end
+  end
+
   describe '#quote_policy' do
     subject do
       described_class


### PR DESCRIPTION
Follow-up to #34618