### PR TITLE
Use plural forms for `date_of_birth` prompt

### DIFF
--- a/app/views/auth/registrations/new.html.haml
+++ b/app/views/auth/registrations/new.html.haml
@@ -56,7 +56,7 @@
     .fields-group
       = f.input :date_of_birth,
                 as: :date_of_birth,
-                hint: t('simple_form.hints.user.date_of_birth', age: Setting.min_age.to_i),
+                hint: t('simple_form.hints.user.date_of_birth', count: Setting.min_age.to_i),
                 required: true,
                 wrapper: :with_block_label
 

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -148,7 +148,9 @@ en:
         min_age: Should not be below the minimum age required by the laws of your jurisdiction.
       user:
         chosen_languages: When checked, only posts in selected languages will be displayed in public timelines
-        date_of_birth: We have to make sure you're at least %{age} to use Mastodon. We won't store this.
+        date_of_birth:
+          one: We have to make sure you're at least %{count} to use Mastodon. We won't store this.
+          other: We have to make sure you're at least %{count} to use Mastodon. We won't store this.
         role: The role controls which permissions the user has.
       user_role:
         color: Color to be used for the role throughout the UI, as RGB in hex format


### PR DESCRIPTION
See https://github.com/mastodon/mastodon/pull/34150#discussion_r2002651365

This sounds a bit silly because in English it's always the same, and the age requirement should be high enough for this to never matter for almost all languages, but “You're at least X” technically requires plural forms in most languages.

The fact that the variable has to be called `count` also makes it particularly awkward, but I'm not sure what can be done about that.