### PR TITLE
Fix eslint import plugin resolution in vscode

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,7 @@
 // @ts-check
 
+import path from 'node:path';
+
 import js from '@eslint/js';
 import { globalIgnores } from 'eslint/config';
 import formatjs from 'eslint-plugin-formatjs';
@@ -204,7 +206,9 @@ export default tseslint.config([
       'import/ignore': ['node_modules', '\\.(css|scss|json)$'],
 
       'import/resolver': {
-        typescript: {},
+        typescript: {
+          project: path.resolve(import.meta.dirname, './tsconfig.json'),
+        },
       },
     },
 

--- a/streaming/eslint.config.mjs
+++ b/streaming/eslint.config.mjs
@@ -1,5 +1,7 @@
 // @ts-check
 
+import path from 'node:path';
+
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
 
@@ -20,7 +22,9 @@ export default tseslint.config([
     settings: {
       'import/ignore': ['node_modules', '\\.(json)$'],
       'import/resolver': {
-        typescript: {},
+        typescript: {
+          project: path.resolve(import.meta.dirname, './tsconfig.json'),
+        },
       },
     },
 


### PR DESCRIPTION
This avoids an issue in the vscode eslint plugin causing the files to not be resolved properly (randomly): https://github.com/microsoft/vscode-eslint/issues/1994

If you specify the absolute path to the `tsconfig.json`, then everything works