### PR TITLE
Fix `tootctl accounts create` failing because of date-of-birth check

### DIFF
--- a/lib/mastodon/cli/accounts.rb
+++ b/lib/mastodon/cli/accounts.rb
@@ -79,7 +79,14 @@ module Mastodon::CLI
 
       account  = Account.new(username: username)
       password = SecureRandom.hex
-      user     = User.new(email: options[:email], password: password, agreement: true, role_id: role_id, confirmed_at: options[:confirmed] ? Time.now.utc : nil, bypass_invite_request_check: true)
+      user = User.new(
+        email: options[:email],
+        password: password,
+        agreement: true,
+        role_id: role_id,
+        confirmed_at: options[:confirmed] ? Time.now.utc : nil,
+        bypass_registration_checks: true
+      )
 
       if options[:reattach]
         account = Account.find_local(username) || Account.new(username: username)

--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -552,7 +552,7 @@ namespace :mastodon do
           password = SecureRandom.hex(16)
 
           owner_role = UserRole.find_by(name: 'Owner')
-          user = User.new(email: email, password: password, confirmed_at: Time.now.utc, account_attributes: { username: username }, bypass_invite_request_check: true, role: owner_role)
+          user = User.new(email: email, password: password, confirmed_at: Time.now.utc, account_attributes: { username: username }, bypass_registration_checks: true, role: owner_role)
           user.save(validate: false)
           user.approve!
 

--- a/spec/lib/mastodon/cli/accounts_spec.rb
+++ b/spec/lib/mastodon/cli/accounts_spec.rb
@@ -70,6 +70,25 @@ RSpec.describe Mastodon::CLI::Accounts do
         end
       end
 
+      context 'with min_age setting' do
+        let(:options) { { email: 'tootctl@example.com', confirmed: true } }
+
+        before do
+          Setting.min_age = 42
+        end
+
+        it_behaves_like 'a new user with given email address and username'
+
+        it 'creates a new user with confirmed status' do
+          expect { subject }
+            .to output_results('New password')
+
+          user = User.find_by(email: options[:email])
+
+          expect(user.confirmed?).to be(true)
+        end
+      end
+
       context 'with --confirmed option' do
         let(:options) { { email: 'tootctl@example.com', confirmed: true } }
 


### PR DESCRIPTION
Fixes #34644

An alternative to this would be to actually pass a date of birth, but given the fact this is manual action from the admin, this seems unnecessary.