### PR TITLE
Drop redis namespace code (except for Rails cache)

### DIFF
--- a/config/initializers/chewy.rb
+++ b/config/initializers/chewy.rb
@@ -5,8 +5,7 @@ host            = ENV.fetch('ES_HOST') { 'localhost' }
 port            = ENV.fetch('ES_PORT') { 9200 }
 user            = ENV.fetch('ES_USER', nil).presence
 password        = ENV.fetch('ES_PASS', nil).presence
-fallback_prefix = ENV.fetch('REDIS_NAMESPACE', nil).presence
-prefix          = ENV.fetch('ES_PREFIX') { fallback_prefix }
+prefix          = ENV.fetch('ES_PREFIX', nil)
 ca_file         = ENV.fetch('ES_CA_FILE', nil).presence
 
 transport_options = { ssl: { ca_file: ca_file } } if ca_file.present?

--- a/lib/mastodon/redis_configuration.rb
+++ b/lib/mastodon/redis_configuration.rb
@@ -43,7 +43,7 @@ class Mastodon::RedisConfiguration
     password = ENV.fetch("#{prefix}PASSWORD", nil)
     host     = ENV.fetch("#{prefix}HOST", defaults[:host])
     port     = ENV.fetch("#{prefix}PORT", defaults[:port])
-    db       = ENV.fetch("#{prefix}DB", defaults[:db])
+    db       = Rails.env.test? ? ENV.fetch('TEST_ENV_NUMBER', defaults[:db]).to_i + 1 : ENV.fetch("#{prefix}DB", defaults[:db])
 
     return { url:, driver: } if url
 

--- a/lib/mastodon/redis_configuration.rb
+++ b/lib/mastodon/redis_configuration.rb
@@ -9,18 +9,17 @@ class Mastodon::RedisConfiguration
 
   def base
     @base ||= setup_config(prefix: nil, defaults: DEFAULTS)
-              .merge(namespace: base_namespace)
+              .merge(namespace: nil)
   end
 
   def sidekiq
     @sidekiq ||= setup_config(prefix: 'SIDEKIQ_')
-                 .merge(namespace: sidekiq_namespace)
   end
 
   def cache
     @cache ||= setup_config(prefix: 'CACHE_')
                .merge({
-                 namespace: cache_namespace,
+                 namespace: 'cache',
                  expires_in: 10.minutes,
                  connect_timeout: 5,
                  pool: {
@@ -34,24 +33,6 @@ class Mastodon::RedisConfiguration
 
   def driver
     ENV['REDIS_DRIVER'] == 'ruby' ? :ruby : :hiredis
-  end
-
-  def namespace
-    @namespace ||= ENV.fetch('REDIS_NAMESPACE', nil)
-  end
-
-  def base_namespace
-    return "mastodon_test#{ENV.fetch('TEST_ENV_NUMBER', nil)}" if Rails.env.test?
-
-    namespace
-  end
-
-  def sidekiq_namespace
-    namespace
-  end
-
-  def cache_namespace
-    namespace ? "#{namespace}_cache" : 'cache'
   end
 
   def setup_config(prefix: nil, defaults: {})

--- a/spec/lib/mastodon/redis_configuration_spec.rb
+++ b/spec/lib/mastodon/redis_configuration_spec.rb
@@ -26,20 +26,6 @@ RSpec.describe Mastodon::RedisConfiguration do
     end
   end
 
-  shared_examples 'setting a namespace' do
-    context 'when setting the `REDIS_NAMESPACE` variable' do
-      around do |example|
-        ClimateControl.modify REDIS_NAMESPACE: 'testns' do
-          example.run
-        end
-      end
-
-      it 'uses the value for the namespace' do
-        expect(subject[:namespace]).to eq 'testns'
-      end
-    end
-  end
-
   shared_examples 'secondary configuration' do |prefix|
     context "when no `#{prefix}_REDIS_` environment variables are present" do
       it 'uses the url from the base config' do
@@ -208,7 +194,6 @@ RSpec.describe Mastodon::RedisConfiguration do
     end
 
     it_behaves_like 'setting a different driver'
-    it_behaves_like 'setting a namespace'
     it_behaves_like 'sentinel support'
   end
 
@@ -217,7 +202,6 @@ RSpec.describe Mastodon::RedisConfiguration do
 
     it_behaves_like 'secondary configuration', 'SIDEKIQ'
     it_behaves_like 'setting a different driver'
-    it_behaves_like 'setting a namespace'
     it_behaves_like 'sentinel support', 'SIDEKIQ'
   end
 
@@ -238,22 +222,8 @@ RSpec.describe Mastodon::RedisConfiguration do
       })
     end
 
-    context 'when `REDIS_NAMESPACE` is not set' do
-      it 'uses the `cache` namespace' do
-        expect(subject[:namespace]).to eq 'cache'
-      end
-    end
-
-    context 'when setting the `REDIS_NAMESPACE` variable' do
-      around do |example|
-        ClimateControl.modify REDIS_NAMESPACE: 'testns' do
-          example.run
-        end
-      end
-
-      it 'attaches the `_cache` postfix to the namespace' do
-        expect(subject[:namespace]).to eq 'testns_cache'
-      end
+    it 'uses the `cache` namespace' do
+      expect(subject[:namespace]).to eq 'cache'
     end
 
     it_behaves_like 'secondary configuration', 'CACHE'

--- a/spec/support/streaming_server_manager.rb
+++ b/spec/support/streaming_server_manager.rb
@@ -17,7 +17,6 @@ class StreamingServerManager
     @running_thread = Thread.new do
       Open3.popen2e(
         {
-          'REDIS_NAMESPACE' => REDIS_CONFIGURATION.base[:namespace],
           'DB_NAME' => "#{ENV.fetch('DB_NAME', 'mastodon')}_test#{ENV.fetch('TEST_ENV_NUMBER', '')}",
           'RAILS_ENV' => ENV.fetch('RAILS_ENV', 'test'),
           'NODE_ENV' => ENV.fetch('STREAMING_NODE_ENV', 'development'),

--- a/spec/support/streaming_server_manager.rb
+++ b/spec/support/streaming_server_manager.rb
@@ -17,6 +17,7 @@ class StreamingServerManager
     @running_thread = Thread.new do
       Open3.popen2e(
         {
+          'REDIS_DB' => (ENV.fetch('TEST_ENV_NUMBER', 0).to_i + 1).to_s,
           'DB_NAME' => "#{ENV.fetch('DB_NAME', 'mastodon')}_test#{ENV.fetch('TEST_ENV_NUMBER', '')}",
           'RAILS_ENV' => ENV.fetch('RAILS_ENV', 'test'),
           'NODE_ENV' => ENV.fetch('STREAMING_NODE_ENV', 'development'),

--- a/streaming/redis.js
+++ b/streaming/redis.js
@@ -4,7 +4,6 @@ import { parseIntFromEnvValue } from './utils.js';
 
 /**
  * @typedef RedisConfiguration
- * @property {string|undefined} namespace
  * @property {string|undefined} url
  * @property {import('ioredis').RedisOptions} options
  */
@@ -64,8 +63,6 @@ function getSentinelConfiguration(env, commonOptions) {
  * @returns {RedisConfiguration} configuration for the Redis connection
  */
 export function configFromEnv(env) {
-  const redisNamespace = env.REDIS_NAMESPACE;
-
   // These options apply for both REDIS_URL based connections and connections
   // using the other REDIS_* environment variables:
   const commonOptions = {
@@ -82,16 +79,14 @@ export function configFromEnv(env) {
   if (typeof env.REDIS_URL === 'string' && env.REDIS_URL.length > 0) {
     return {
       url: env.REDIS_URL,
-      options: commonOptions,
-      namespace: redisNamespace
+      options: commonOptions
     };
   }
 
   // If we have configuration for Redis Sentinel mode, prefer that:
   if (hasSentinelConfiguration(env)) {
     return {
-      options: getSentinelConfiguration(env, commonOptions),
-      namespace: redisNamespace
+      options: getSentinelConfiguration(env, commonOptions)
     };
   }
 
@@ -110,8 +105,7 @@ export function configFromEnv(env) {
   };
 
   return {
-    options,
-    namespace: redisNamespace
+    options
   };
 }
 


### PR DESCRIPTION
Follow-up to #34664

This preserves Redis namespace usage for Rails' cache, but drops Redis namespace usage otherwise.

The biggest change is the switch from `mastodon_test#{TEST_ENV_NUMBER}` namespaces to Redis databases in test environments. This serves the same purpose but means Redis needs to be set up to support at least as many databases as test workers. It also does not provide quite the same amount of differentiation between test, development and production environments, should you use multiple on the same setup.