### PR TITLE
[Vite] Handle special translation in service worker

### DIFF
--- a/app/javascript/mastodon/actions/notifications.js
+++ b/app/javascript/mastodon/actions/notifications.js
@@ -21,7 +21,6 @@ export const NOTIFICATIONS_SET_BROWSER_PERMISSION = 'NOTIFICATIONS_SET_BROWSER_P
 
 defineMessages({
   mention: { id: 'notification.mention', defaultMessage: '{name} mentioned you' },
-  mentioned_you: { id: 'notification.mentioned_you', defaultMessage: '{name} mentioned you' },
   group: { id: 'notifications.group', defaultMessage: '{count} notifications' },
 });
 

--- a/config/vite/plugin-sw-locales.ts
+++ b/config/vite/plugin-sw-locales.ts
@@ -8,7 +8,20 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+import { defineMessages } from 'react-intl';
+
 import type { Plugin, ResolvedConfig } from 'vite';
+
+const translations = defineMessages({
+  mentioned_you: {
+    id: 'notification.mentioned_you',
+    defaultMessage: '{name} mentioned you',
+  },
+});
+
+const CUSTOM_TRANSLATIONS = {
+  'notification.mention': translations.mentioned_you.id,
+};
 
 const KEEP_KEYS = [
   'notification.favourite',
@@ -67,7 +80,14 @@ export function MastodonServiceWorkerLocales(): Plugin {
             const filteredLocale: Record<string, string> = {};
 
             Object.entries(full).forEach(([key, value]) => {
-              if (KEEP_KEYS.includes(key)) filteredLocale[key] = value;
+              if (KEEP_KEYS.includes(key)) {
+                filteredLocale[key] = value;
+              }
+            });
+
+            Object.entries(CUSTOM_TRANSLATIONS).forEach(([key, value]) => {
+              const translation = full[value];
+              if (translation) filteredLocale[key] = translation;
             });
 
             filteredLocales[locale] = filteredLocale;

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "fix": "yarn fix:js && yarn fix:css",
     "format": "prettier --write --log-level warn .",
     "format:check": "prettier --check --ignore-unknown .",
-    "i18n:extract": "formatjs extract 'app/javascript/**/*.{js,jsx,ts,tsx}' --ignore '**/*.d.ts' --out-file app/javascript/mastodon/locales/en.json --format config/formatjs-formatter.js",
+    "i18n:extract": "formatjs extract 'app/javascript/**/*.{js,jsx,ts,tsx}' config/vite/plugin-sw-locales.js --ignore '**/*.d.ts' --out-file app/javascript/mastodon/locales/en.json --format config/formatjs-formatter.js",
     "lint:js": "cd $INIT_CWD && eslint --cache --report-unused-disable-directives",
     "lint:css": "stylelint \"**/*.{css,scss}\"",
     "lint": "yarn lint:js && yarn lint:css",


### PR DESCRIPTION
One string (`notification.mention`) has a specific translation when used from the service worker.

This changes implements this specific case using the new Vite plugin.

I checked that the generated `sw.js` file conteins `"notification.mention":"{name} menciis vin"`, which is the specific translation (`notification.mentioned_you`) for the `GA ` language.

The extract script has been changed to also extract translatable strings from the plugin, so they get picked up.