### PR TITLE
docs: Improve local development readme

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -7,6 +7,19 @@ what changes are desirable and what general processes to use.
 
 ## Environments
 
+The following instructions will guide you through the process of setting up a local development instance of Mastodon on your computer.
+
+There are instructions for these environments:
+
+- [Vagrant](#vagrant)
+- [macOS](#macos)
+- [Linux](#linux)
+- [Docker](#docker)
+- [Dev Containers](#dev-containers)
+- [GitHub Codespaces](#github-codespaces)
+
+Once completed, continue with the [Next steps](#next-steps) section below.
+
 ### Vagrant
 
 A **Vagrant** configuration is included for development purposes. To use it,
@@ -28,10 +41,16 @@ To set up **macOS** for native development, complete the following steps:
   to install the required project dependencies
 - Use a Ruby version manager to activate the ruby in `.ruby-version` and run
   `nvm use` to activate the node version from `.nvmrc`
-- Run the `bin/setup` script, which will install the required ruby gems and node
+- Start the database services by running `brew services start postgresql` and
+  `brew services start redis`
+- Run `RAILS_ENV=development bin/setup`, which will install the required ruby gems and node
   packages and prepare the database for local development
 - Finally, run the `bin/dev` script which will launch services via `overmind`
   (if installed) or `foreman`
+
+### Linux
+
+The Mastodon documentation has a [guide on installing Mastodon from source](https://docs.joinmastodon.org/dev/setup/#manual) on Linux.
 
 ### Docker
 
@@ -66,6 +85,12 @@ development environment configured with the software needed for this project.
 - Wait for an _Open in Browser_ prompt. This will open Mastodon
 - On the _Ports_ tab "stream" setting change _Port visibility_ → _Public_
 
+## Next steps
+
+- Once you have successfully set up a development environment, it will be available on http://localhost:3000
+- Log in as the default admin user with the username `admin@mastodon.local` and the password `mastodonadmin`.
+- Check out the [Mastodon docs] for tips on working with emails in development (you'll need this when creating new user accounts) as well as a list of useful commands for testing and updating your dev instance.
+
 [codespace]: https://codespaces.new/mastodon/mastodon?quickstart=1&devcontainer_path=.devcontainer%2Fcodespaces%2Fdevcontainer.json
 [CONTRIBUTING]: ../CONTRIBUTING.md
 [Dev Container extension]: https://containers.dev/supporting#dev-containers
@@ -73,3 +98,4 @@ development environment configured with the software needed for this project.
 [Docker]: https://docs.docker.com
 [GitHub Codespaces]: https://docs.github.com/en/codespaces
 [Homebrew]: https://brew.sh
+[Mastodon docs]: https://docs.joinmastodon.org/dev/setup/#working-with-emails-in-development


### PR DESCRIPTION
Extends the docs on local development with some information that I was missing when setting up mine:

- Adds a TOC for the documented environments
- Adds a step around starting the database services on macOS
- Adds a section on Linux which simply links off to https://docs.joinmastodon.org/dev/setup/ (I'm not sure about how up-to-date these docs are – the Vagrant instructions are quite different from the ones in this file. So this might need further tweaking.)
- Adds a "Next steps" section with some key information that could previously be found in the main docs only