### PR TITLE
Fix emoji bundle size

### DIFF
--- a/app/javascript/mastodon/features/compose/components/emoji_picker_dropdown.jsx
+++ b/app/javascript/mastodon/features/compose/components/emoji_picker_dropdown.jsx
@@ -12,13 +12,9 @@ import Overlay from 'react-overlays/Overlay';
 
 import MoodIcon from '@/material-icons/400-20px/mood.svg?react';
 import { IconButton } from 'mastodon/components/icon_button';
-import emojiCompressed from 'mastodon/features/emoji/emoji_compressed';
-import { assetHost } from 'mastodon/utils/config';
 
 import { buildCustomEmojis, categoriesFromEmojis } from '../../emoji/emoji';
 import { EmojiPicker as EmojiPickerAsync } from '../../ui/util/async-components';
-
-const nimblePickerData = emojiCompressed[5];
 
 const messages = defineMessages({
   emoji: { id: 'emoji_button.label', defaultMessage: 'Insert emoji' },
@@ -40,19 +36,11 @@ let EmojiPicker, Emoji; // load asynchronously
 
 const listenerOptions = supportsPassiveEvents ? { passive: true, capture: true } : true;
 
-const backgroundImageFn = () => `${assetHost}/emoji/sheet_15_1.png`;
-
 const notFoundFn = () => (
   <div className='emoji-mart-no-results'>
     <Emoji
-      data={nimblePickerData}
       emoji='sleuth_or_spy'
-      set='twitter'
       size={32}
-      sheetSize={32}
-      sheetColumns={62}
-      sheetRows={62}
-      backgroundImageFn={backgroundImageFn}
     />
 
     <div className='emoji-mart-no-results-label'>
@@ -110,12 +98,12 @@ class ModifierPickerMenu extends PureComponent {
 
     return (
       <div className='emoji-picker-dropdown__modifiers__menu' style={{ display: active ? 'block' : 'none' }} ref={this.setRef}>
-        <button type='button' onClick={this.handleClick} data-index={1}><Emoji data={nimblePickerData} sheetColumns={62} sheetRows={62} emoji='fist' set='twitter' size={22} sheetSize={32} skin={1} backgroundImageFn={backgroundImageFn} /></button>
-        <button type='button' onClick={this.handleClick} data-index={2}><Emoji data={nimblePickerData} sheetColumns={62} sheetRows={62} emoji='fist' set='twitter' size={22} sheetSize={32} skin={2} backgroundImageFn={backgroundImageFn} /></button>
-        <button type='button' onClick={this.handleClick} data-index={3}><Emoji data={nimblePickerData} sheetColumns={62} sheetRows={62} emoji='fist' set='twitter' size={22} sheetSize={32} skin={3} backgroundImageFn={backgroundImageFn} /></button>
-        <button type='button' onClick={this.handleClick} data-index={4}><Emoji data={nimblePickerData} sheetColumns={62} sheetRows={62} emoji='fist' set='twitter' size={22} sheetSize={32} skin={4} backgroundImageFn={backgroundImageFn} /></button>
-        <button type='button' onClick={this.handleClick} data-index={5}><Emoji data={nimblePickerData} sheetColumns={62} sheetRows={62} emoji='fist' set='twitter' size={22} sheetSize={32} skin={5} backgroundImageFn={backgroundImageFn} /></button>
-        <button type='button' onClick={this.handleClick} data-index={6}><Emoji data={nimblePickerData} sheetColumns={62} sheetRows={62} emoji='fist' set='twitter' size={22} sheetSize={32} skin={6} backgroundImageFn={backgroundImageFn} /></button>
+        <button type='button' onClick={this.handleClick} data-index={1}><Emoji emoji='fist' size={22} skin={1} /></button>
+        <button type='button' onClick={this.handleClick} data-index={2}><Emoji emoji='fist' size={22} skin={2} /></button>
+        <button type='button' onClick={this.handleClick} data-index={3}><Emoji emoji='fist' size={22} skin={3} /></button>
+        <button type='button' onClick={this.handleClick} data-index={4}><Emoji emoji='fist' size={22} skin={4} /></button>
+        <button type='button' onClick={this.handleClick} data-index={5}><Emoji emoji='fist' size={22} skin={5} /></button>
+        <button type='button' onClick={this.handleClick} data-index={6}><Emoji emoji='fist' size={22} skin={6} /></button>
       </div>
     );
   }
@@ -150,7 +138,7 @@ class ModifierPicker extends PureComponent {
 
     return (
       <div className='emoji-picker-dropdown__modifiers'>
-        <Emoji data={nimblePickerData} sheetColumns={62} sheetRows={62} emoji='fist' set='twitter' size={22} sheetSize={32} skin={modifier} onClick={this.handleClick} backgroundImageFn={backgroundImageFn} />
+        <Emoji emoji='fist' size={22} skin={modifier} onClick={this.handleClick} />
         <ModifierPickerMenu active={active} onSelect={this.handleSelect} onClose={this.props.onClose} />
       </div>
     );
@@ -286,16 +274,11 @@ class EmojiPickerMenuImpl extends PureComponent {
     return (
       <div className={classNames('emoji-picker-dropdown__menu', { selecting: modifierOpen })} style={style} ref={this.setRef}>
         <EmojiPicker
-          data={nimblePickerData}
-          sheetColumns={62}
-          sheetRows={62}
           perLine={8}
           emojiSize={22}
-          sheetSize={32}
           custom={buildCustomEmojis(custom_emojis)}
           color=''
           emoji=''
-          set='twitter'
           title={title}
           i18n={this.getI18n()}
           onClick={this.handleClick}
@@ -304,7 +287,6 @@ class EmojiPickerMenuImpl extends PureComponent {
           skin={skinTone}
           showPreview={false}
           showSkinTones={false}
-          backgroundImageFn={backgroundImageFn}
           notFound={notFoundFn}
           autoFocus={this.state.readyToFocus}
           emojiTooltip

--- a/app/javascript/mastodon/features/emoji/emoji_compressed.d.ts
+++ b/app/javascript/mastodon/features/emoji/emoji_compressed.d.ts
@@ -45,7 +45,6 @@ type EmojiCompressed = [
   Category[],
   Data['aliases'],
   EmojisWithoutShortCodes,
-  Data,
 ];
 
 /*

--- a/app/javascript/mastodon/features/emoji/emoji_compressed.js
+++ b/app/javascript/mastodon/features/emoji/emoji_compressed.js
@@ -132,6 +132,5 @@ module.exports = JSON.parse(JSON.stringify([
   emojiMartData.skins,
   emojiMartData.categories,
   emojiMartData.aliases,
-  emojisWithoutShortCodes,
-  emojiMartData
+  emojisWithoutShortCodes
 ]));

--- a/app/javascript/mastodon/features/emoji/emoji_picker.js
+++ b/app/javascript/mastodon/features/emoji/emoji_picker.js
@@ -1,7 +1,0 @@
-import Emoji from 'emoji-mart/dist-es/components/emoji/nimble-emoji';
-import Picker from 'emoji-mart/dist-es/components/picker/nimble-picker';
-
-export {
-  Picker,
-  Emoji,
-};

--- a/app/javascript/mastodon/features/emoji/emoji_picker.tsx
+++ b/app/javascript/mastodon/features/emoji/emoji_picker.tsx
@@ -1,0 +1,50 @@
+import type { EmojiProps, PickerProps } from 'emoji-mart';
+import EmojiRaw from 'emoji-mart/dist-es/components/emoji/nimble-emoji';
+import PickerRaw from 'emoji-mart/dist-es/components/picker/nimble-picker';
+
+import { assetHost } from 'mastodon/utils/config';
+
+import EmojiData from './emoji_data.json';
+
+
+const backgroundImageFnDefault = () => `${assetHost}/emoji/sheet_15_1.png`;
+
+const Emoji = ({
+  set = 'twitter',
+  sheetSize = 32,
+  sheetColumns = 62,
+  sheetRows = 62,
+  backgroundImageFn = backgroundImageFnDefault,
+  ...props
+}: EmojiProps) => {
+  return (
+    <EmojiRaw
+      data={EmojiData}
+      set={set}
+      sheetSize={sheetSize}
+      sheetColumns={sheetColumns}
+      sheetRows={sheetRows}
+      backgroundImageFn={backgroundImageFn}
+      {...props}
+    />
+  );
+}
+
+const Picker = ({
+  set = 'twitter',
+  sheetSize = 32,
+  backgroundImageFn = backgroundImageFnDefault,
+  ...props
+}: PickerProps) => {
+  return (
+    <PickerRaw
+      data={EmojiData}
+      set={set}
+      sheetSize={sheetSize}
+      backgroundImageFn={backgroundImageFn}
+      {...props}
+    />
+  );
+}
+
+export { Picker, Emoji };

--- a/app/javascript/mastodon/features/emoji/emoji_picker.tsx
+++ b/app/javascript/mastodon/features/emoji/emoji_picker.tsx
@@ -6,7 +6,6 @@ import { assetHost } from 'mastodon/utils/config';
 
 import EmojiData from './emoji_data.json';
 
-
 const backgroundImageFnDefault = () => `${assetHost}/emoji/sheet_15_1.png`;
 
 const Emoji = ({
@@ -28,11 +27,13 @@ const Emoji = ({
       {...props}
     />
   );
-}
+};
 
 const Picker = ({
   set = 'twitter',
   sheetSize = 32,
+  sheetColumns = 62,
+  sheetRows = 62,
   backgroundImageFn = backgroundImageFnDefault,
   ...props
 }: PickerProps) => {
@@ -41,10 +42,12 @@ const Picker = ({
       data={EmojiData}
       set={set}
       sheetSize={sheetSize}
+      sheetColumns={sheetColumns}
+      sheetRows={sheetRows}
       backgroundImageFn={backgroundImageFn}
       {...props}
     />
   );
-}
+};
 
 export { Picker, Emoji };

--- a/app/javascript/types/emoji_picker.d.ts
+++ b/app/javascript/types/emoji_picker.d.ts
@@ -1,0 +1,8 @@
+declare module 'emoji-mart' {
+  interface PickerProps {
+    sheetColumns?: number;
+    sheetRows?: number;
+  }
+}
+
+export {};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "CommonJS",
     "moduleResolution": "node",
     "allowJs": true,
+    "resolveJsonModule": true,
     "noEmit": true,
     "strict": true,
     "noImplicitReturns": true,


### PR DESCRIPTION
This fixes a bug with #33395 that increased the bundle size by a large amount. This was due to the addition of the uncompressed emoji object being appended to the output of `emoji_compressed.js`, which is imported in multiple places.

That data is only used by the picker, as the prior PR switched to the `NimblePicker` which allows custom sheets. This PR moves that import and sets common default props in new wrapper components that are lazy-loaded.

Size stats according the Webpack Bundle Analyzer:
- Pre #33395 sizes are 8.15MB total, with 1.77MB of that from the common bundle, and ~660KB of that from the emoji picker.
- Post #33395 sizes are 8.66MB total, with 2.77MB in common, and ~11KB from the emoji picker.
- This PR's sizes are 8.43MB total, with 1.85MB from common, and ~760KB from the picker.

All reports can be found in this archive: [reports.zip](https://github.com/user-attachments/files/20189015/reports.zip)