### PR TITLE
fix: Hide FamiliarFollowers widget when logged out

### DIFF
--- a/app/javascript/mastodon/features/account_timeline/components/account_header.tsx
+++ b/app/javascript/mastodon/features/account_timeline/components/account_header.tsx
@@ -1023,7 +1023,7 @@ export const AccountHeader: React.FC<{
                   />
                 </NavLink>
               </div>
-              <FamiliarFollowers accountId={accountId} />
+              {signedIn && <FamiliarFollowers accountId={accountId} />}
             </div>
           )}
         </div>


### PR DESCRIPTION
Changes in this PR:
- Hide the `FamiliarFollowers` component when logged out, preventing a 401 error