### PR TITLE
refactor: Prevent leading slashes in API urls

### DIFF
--- a/app/javascript/mastodon/api.ts
+++ b/app/javascript/mastodon/api.ts
@@ -83,6 +83,7 @@ export default function api(withAuthorization = true) {
   return instance;
 }
 
+type ApiUrl = `v${1 | 2}/${string}`;
 type RequestParamsOrData = Record<string, unknown>;
 
 export async function apiRequest<ApiResponse = unknown>(
@@ -105,28 +106,28 @@ export async function apiRequest<ApiResponse = unknown>(
 }
 
 export async function apiRequestGet<ApiResponse = unknown>(
-  url: string,
+  url: ApiUrl,
   params?: RequestParamsOrData,
 ) {
   return apiRequest<ApiResponse>('GET', url, { params });
 }
 
 export async function apiRequestPost<ApiResponse = unknown>(
-  url: string,
+  url: ApiUrl,
   data?: RequestParamsOrData,
 ) {
   return apiRequest<ApiResponse>('POST', url, { data });
 }
 
 export async function apiRequestPut<ApiResponse = unknown>(
-  url: string,
+  url: ApiUrl,
   data?: RequestParamsOrData,
 ) {
   return apiRequest<ApiResponse>('PUT', url, { data });
 }
 
 export async function apiRequestDelete<ApiResponse = unknown>(
-  url: string,
+  url: ApiUrl,
   params?: RequestParamsOrData,
 ) {
   return apiRequest<ApiResponse>('DELETE', url, { params });

--- a/app/javascript/mastodon/api/accounts.ts
+++ b/app/javascript/mastodon/api/accounts.ts
@@ -36,6 +36,6 @@ export const apiGetEndorsedAccounts = (id: string) =>
   apiRequestGet<ApiAccountJSON>(`v1/accounts/${id}/endorsements`);
 
 export const apiGetFamiliarFollowers = (id: string) =>
-  apiRequestGet<ApiFamiliarFollowersJSON>('/v1/accounts/familiar_followers', {
+  apiRequestGet<ApiFamiliarFollowersJSON>('v1/accounts/familiar_followers', {
     id,
   });

--- a/app/javascript/mastodon/api/polls.ts
+++ b/app/javascript/mastodon/api/polls.ts
@@ -2,9 +2,9 @@ import { apiRequestGet, apiRequestPost } from 'mastodon/api';
 import type { ApiPollJSON } from 'mastodon/api_types/polls';
 
 export const apiGetPoll = (pollId: string) =>
-  apiRequestGet<ApiPollJSON>(`/v1/polls/${pollId}`);
+  apiRequestGet<ApiPollJSON>(`v1/polls/${pollId}`);
 
 export const apiPollVote = (pollId: string, choices: string[]) =>
-  apiRequestPost<ApiPollJSON>(`/v1/polls/${pollId}/votes`, {
+  apiRequestPost<ApiPollJSON>(`v1/polls/${pollId}/votes`, {
     choices,
   });


### PR DESCRIPTION
Changes proposed in this PR:
- Constrains the `url` parameter of the functions `apiRequestGet`, `apiRequestPost`, `apiRequestPut`, and `apiRequestDelete`to start with `v1/` or `v2/` instead of allowing any string
- Fixes the three occurrences of the leading slash