### PR TITLE
Fix `NoMethodError` in `ActivityPub::FetchAllRepliesWorker`

### DIFF
--- a/app/workers/activitypub/fetch_all_replies_worker.rb
+++ b/app/workers/activitypub/fetch_all_replies_worker.rb
@@ -78,7 +78,7 @@ class ActivityPub::FetchAllRepliesWorker
   # @param root_status_uri [String]
   def get_root_replies(root_status_uri, options = {})
     root_status_body = fetch_resource(root_status_uri, true)
-    raise RuntimeError("FetchAllRepliesWorker - #{@root_status.uri}: Root status could not be fetched") if root_status_body.nil?
+    return if root_status_body.nil?
 
     FetchReplyWorker.perform_async(root_status_uri, { **options, prefetched_body: root_status_body })
 


### PR DESCRIPTION
Follow-up to #34615

`raise RuntimeError(…)` would fail with `NoMethodError` since `RuntimeError` is not a method.

Instead of changing it to `raise RuntimeError.new(…)`, I opted to simply return `nil`, as that was the previous behavior, and in most case an error at this point would not be fixed by retrying, so having the job be retried would simply waste resources.