### PR TITLE
fix: More "Followers you know" polish & bug fixes

### DIFF
--- a/app/javascript/mastodon/features/account_timeline/components/account_header.tsx
+++ b/app/javascript/mastodon/features/account_timeline/components/account_header.tsx
@@ -912,6 +912,8 @@ export const AccountHeader: React.FC<{
             <div className='account__header__badges'>{badges}</div>
           )}
 
+          {signedIn && <FamiliarFollowers accountId={accountId} />}
+
           {!(suspended || hidden) && (
             <div className='account__header__extra'>
               <div
@@ -1023,7 +1025,6 @@ export const AccountHeader: React.FC<{
                   />
                 </NavLink>
               </div>
-              {signedIn && <FamiliarFollowers accountId={accountId} />}
             </div>
           )}
         </div>

--- a/app/javascript/mastodon/features/account_timeline/components/familiar_followers.tsx
+++ b/app/javascript/mastodon/features/account_timeline/components/familiar_followers.tsx
@@ -82,7 +82,7 @@ export const FamiliarFollowers: React.FC<{ accountId: string }> = ({
   return (
     <div className='account__header__familiar-followers'>
       <AvatarGroup compact>
-        {familiarFollowers.map((account) => (
+        {familiarFollowers.slice(0, 3).map((account) => (
           <Avatar withLink key={account.id} account={account} size={28} />
         ))}
       </AvatarGroup>

--- a/app/javascript/mastodon/features/account_timeline/components/familiar_followers.tsx
+++ b/app/javascript/mastodon/features/account_timeline/components/familiar_followers.tsx
@@ -52,7 +52,7 @@ const FamiliarFollowersReadout: React.FC<{ familiarFollowers: Account[] }> = ({
     return (
       <FormattedMessage
         id='account.familiar_followers_many'
-        defaultMessage='Followed by {name1}, {name2}, and {othersCount, plural, one {# other} other {# others}}'
+        defaultMessage='Followed by {name1}, {name2}, and {othersCount, plural, one {one other you know} other {# others you know}}'
         values={messageData}
       />
     );

--- a/app/javascript/mastodon/features/account_timeline/components/familiar_followers.tsx
+++ b/app/javascript/mastodon/features/account_timeline/components/familiar_followers.tsx
@@ -13,11 +13,13 @@ import { useAppDispatch, useAppSelector } from '@/mastodon/store';
 
 const AccountLink: React.FC<{ account?: Account }> = ({ account }) => {
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  const name = account?.display_name || `@${account?.acct}`;
+  const name = account?.display_name_html || `@${account?.acct}`;
   return (
-    <Link to={`/@${account?.acct}`} data-hover-card-account={account?.id}>
-      {name}
-    </Link>
+    <Link
+      to={`/@${account?.acct}`}
+      data-hover-card-account={account?.id}
+      dangerouslySetInnerHTML={{ __html: name }}
+    />
   );
 };
 

--- a/app/javascript/mastodon/features/account_timeline/components/familiar_followers.tsx
+++ b/app/javascript/mastodon/features/account_timeline/components/familiar_followers.tsx
@@ -12,13 +12,15 @@ import { getAccountFamiliarFollowers } from '@/mastodon/selectors/accounts';
 import { useAppDispatch, useAppSelector } from '@/mastodon/store';
 
 const AccountLink: React.FC<{ account?: Account }> = ({ account }) => {
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  const name = account?.display_name_html || `@${account?.acct}`;
+  if (!account) {
+    return null;
+  }
+
   return (
     <Link
-      to={`/@${account?.acct}`}
-      data-hover-card-account={account?.id}
-      dangerouslySetInnerHTML={{ __html: name }}
+      to={`/@${account.acct}`}
+      data-hover-card-account={account.id}
+      dangerouslySetInnerHTML={{ __html: account.display_name_html }}
     />
   );
 };

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -28,7 +28,7 @@
   "account.edit_profile": "Edit profile",
   "account.enable_notifications": "Notify me when @{name} posts",
   "account.endorse": "Feature on profile",
-  "account.familiar_followers_many": "Followed by {name1}, {name2}, and {othersCount, plural, one {# other} other {# others}}",
+  "account.familiar_followers_many": "Followed by {name1}, {name2}, and {othersCount, plural, one {one other you know} other {# others you know}}",
   "account.familiar_followers_one": "Followed by {name1}",
   "account.familiar_followers_two": "Followed by {name1} and {name2}",
   "account.featured": "Featured",

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -8155,12 +8155,9 @@ noscript {
     color: $darker-text-color;
 
     a:any-link {
-      color: inherit;
-      text-decoration: underline;
-    }
-
-    a:hover {
+      font-weight: 500;
       text-decoration: none;
+      color: $primary-text-color;
     }
   }
 }

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2091,6 +2091,7 @@ body > [data-popper-placement] {
   display: block;
   position: relative;
   border-radius: var(--avatar-border-radius);
+  background: var(--surface-background-color);
 
   img {
     width: 100%;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -8151,7 +8151,7 @@ noscript {
     display: flex;
     align-items: center;
     gap: 10px;
-    margin-block-end: 16px;
+    margin-block: 16px;
     color: $darker-text-color;
 
     a:any-link {


### PR DESCRIPTION
Fixes #34687

Changes proposed in this PR:
- Fixes emoji rendering in the followers you know widget
- Fixes the number of avatars not being limited to 3 anymore
- Adds the word "you know" when there are more than 2 familiar followers
- Make link styles more consistent (e.g. with the Notifications page)
- Moves the widget up on the account page, underneath the user name and badges

![image](https://github.com/user-attachments/assets/59d9d8d5-3f05-4337-8f99-689c868798b5)