### PR TITLE
fix: Hide "Followers you know" widget from your own profile, #34698

### DIFF
--- a/app/javascript/mastodon/features/account_timeline/components/account_header.tsx
+++ b/app/javascript/mastodon/features/account_timeline/components/account_header.tsx
@@ -912,7 +912,9 @@ export const AccountHeader: React.FC<{
             <div className='account__header__badges'>{badges}</div>
           )}
 
-          {signedIn && <FamiliarFollowers accountId={accountId} />}
+          {account.id !== me && signedIn && (
+            <FamiliarFollowers accountId={accountId} />
+          )}
 
           {!(suspended || hidden) && (
             <div className='account__header__extra'>

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2179,7 +2179,7 @@ a .account__avatar {
   flex-wrap: nowrap;
 
   & > :not(:first-child) {
-    margin-inline-start: -8px;
+    margin-inline-start: -12px;
   }
 
   & > :first-child {


### PR DESCRIPTION
Fixes #34698

Changes proposed in this PR:
- Hides "Followers you know" widget from your own profile
- Makes avatars overlap more inside of compact avatar group