### PR TITLE
Fix sidekiq JSON serialization warning in `ActivityPub::FetchAllRepliesWorker`

### DIFF
--- a/app/workers/activitypub/fetch_all_replies_worker.rb
+++ b/app/workers/activitypub/fetch_all_replies_worker.rb
@@ -80,7 +80,7 @@ class ActivityPub::FetchAllRepliesWorker
     root_status_body = fetch_resource(root_status_uri, true)
     return if root_status_body.nil?
 
-    FetchReplyWorker.perform_async(root_status_uri, { **options, prefetched_body: root_status_body })
+    FetchReplyWorker.perform_async(root_status_uri, { **options.deep_stringify_keys, 'prefetched_body' => root_status_body })
 
     get_replies(root_status_body, MAX_PAGES, options)
   end

--- a/spec/workers/activitypub/fetch_all_replies_worker_spec.rb
+++ b/spec/workers/activitypub/fetch_all_replies_worker_spec.rb
@@ -124,8 +124,6 @@ RSpec.describe ActivityPub::FetchAllRepliesWorker do
 
   before do
     stub_const('Status::FetchRepliesConcern::FETCH_REPLIES_ENABLED', true)
-    allow(FetchReplyWorker).to receive(:push_bulk)
-    allow(FetchReplyWorker).to receive(:perform_async)
     all_items.each do |item|
       next if [top_note_uri, reply_note_uri].include? item
 
@@ -150,7 +148,7 @@ RSpec.describe ActivityPub::FetchAllRepliesWorker do
 
     it 'fetches the top status only once' do
       _ = subject.perform(status.id, { request_id: 0 })
-      expect(FetchReplyWorker).to have_received(:perform_async).with(top_note_uri, { prefetched_body: top_object.deep_stringify_keys, request_id: 0 })
+      expect(FetchReplyWorker).to have_enqueued_sidekiq_job(top_note_uri, { 'prefetched_body' => top_object.deep_stringify_keys, 'request_id' => 0})
       expect(a_request(:get, top_note_uri)).to have_been_made.once
     end
   end

--- a/spec/workers/activitypub/fetch_all_replies_worker_spec.rb
+++ b/spec/workers/activitypub/fetch_all_replies_worker_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe ActivityPub::FetchAllRepliesWorker do
 
     it 'fetches the top status only once' do
       _ = subject.perform(status.id, { request_id: 0 })
-      expect(FetchReplyWorker).to have_enqueued_sidekiq_job(top_note_uri, { 'prefetched_body' => top_object.deep_stringify_keys, 'request_id' => 0})
+      expect(FetchReplyWorker).to have_enqueued_sidekiq_job(top_note_uri, { 'prefetched_body' => top_object.deep_stringify_keys, 'request_id' => 0 })
       expect(a_request(:get, top_note_uri)).to have_been_made.once
     end
   end


### PR DESCRIPTION
Follow-up to #34615

The reason this wasn't caught in tests despite our use of `Sidekiq.strict_args!` is that `#perform_async` was stubbed by the spec.