### PR TITLE
Make more space for longer setting/admin navigator items

### DIFF
--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -3,7 +3,7 @@
 @use 'variables' as *;
 
 $no-columns-breakpoint: 890px;
-$sidebar-width: 300px;
+$sidebar-width: 360px;
 $content-width: 840px;
 
 .admin-wrapper {
@@ -180,8 +180,8 @@ $content-width: 840px;
   .content {
     padding-top: 55px;
     padding-bottom: 20px;
-    padding-inline-start: 25px;
-    padding-inline-end: 15px;
+    padding-inline-start: 15px;
+    padding-inline-end: 5px;
 
     @media screen and (max-width: $no-columns-breakpoint) {
       max-width: none;


### PR DESCRIPTION
I can't reopen https://github.com/mastodon/mastodon/pull/27104 so here's a new one.

I am getting a number of string truncations for the gd locale in the settings menu

![truncations](https://github.com/mastodon/mastodon/assets/4095570/4bd4650b-8efc-49d4-8140-0b21af6cb7d6)

I can't shorten the translations any further, so I have made the menu 30 pixels wider.