### PR TITLE
Add some missing pluralizations

### DIFF
--- a/app/models/scheduled_status.rb
+++ b/app/models/scheduled_status.rb
@@ -31,10 +31,10 @@ class ScheduledStatus < ApplicationRecord
   end
 
   def validate_total_limit
-    errors.add(:base, I18n.t('scheduled_statuses.over_total_limit', limit: TOTAL_LIMIT)) if account.scheduled_statuses.count >= TOTAL_LIMIT
+    errors.add(:base, I18n.t('scheduled_statuses.over_total_limit', count: TOTAL_LIMIT)) if account.scheduled_statuses.count >= TOTAL_LIMIT
   end
 
   def validate_daily_limit
-    errors.add(:base, I18n.t('scheduled_statuses.over_daily_limit', limit: DAILY_LIMIT)) if account.scheduled_statuses.where('scheduled_at::date = ?::date', scheduled_at).count >= DAILY_LIMIT
+    errors.add(:base, I18n.t('scheduled_statuses.over_daily_limit', count: DAILY_LIMIT)) if account.scheduled_statuses.where('scheduled_at::date = ?::date', scheduled_at).count >= DAILY_LIMIT
   end
 end

--- a/app/models/scheduled_status.rb
+++ b/app/models/scheduled_status.rb
@@ -31,10 +31,10 @@ class ScheduledStatus < ApplicationRecord
   end
 
   def validate_total_limit
-    errors.add(:base, I18n.t('scheduled_statuses.over_total_limit', count: TOTAL_LIMIT)) if account.scheduled_statuses.count >= TOTAL_LIMIT
+    errors.add(:base, I18n.t('scheduled_statuses.over_total_limit', limit: TOTAL_LIMIT)) if account.scheduled_statuses.count >= TOTAL_LIMIT
   end
 
   def validate_daily_limit
-    errors.add(:base, I18n.t('scheduled_statuses.over_daily_limit', count: DAILY_LIMIT)) if account.scheduled_statuses.where('scheduled_at::date = ?::date', scheduled_at).count >= DAILY_LIMIT
+    errors.add(:base, I18n.t('scheduled_statuses.over_daily_limit', limit: DAILY_LIMIT)) if account.scheduled_statuses.where('scheduled_at::date = ?::date', scheduled_at).count >= DAILY_LIMIT
   end
 end

--- a/app/views/admin_mailer/_new_trending_links.text.erb
+++ b/app/views/admin_mailer/_new_trending_links.text.erb
@@ -2,7 +2,7 @@
 
 <% new_trending_links.each do |link| %>
 - <%= link.title %> · <%= link.url %>
-  <%= standard_locale_name(link.language) %> · <%= raw t('admin.trends.links.usage_comparison', count: link.history.get(Time.now.utc).accounts, yesterday: link.history.get(Time.now.utc - 1.day).accounts) %> · <%= t('admin.trends.tags.current_score', score: link.trend.score.round(2)) %>
+  <%= standard_locale_name(link.language) %> · <%= raw t('admin.trends.links.usage_comparison', today: link.history.get(Time.now.utc).accounts, yesterday: link.history.get(Time.now.utc - 1.day).accounts) %> · <%= t('admin.trends.tags.current_score', score: link.trend.score.round(2)) %>
 <% end %>
 
 <%= raw t('application_mailer.view')%> <%= admin_trends_links_url %>

--- a/app/views/admin_mailer/_new_trending_links.text.erb
+++ b/app/views/admin_mailer/_new_trending_links.text.erb
@@ -2,7 +2,7 @@
 
 <% new_trending_links.each do |link| %>
 - <%= link.title %> · <%= link.url %>
-  <%= standard_locale_name(link.language) %> · <%= raw t('admin.trends.links.usage_comparison', today: link.history.get(Time.now.utc).accounts, yesterday: link.history.get(Time.now.utc - 1.day).accounts) %> · <%= t('admin.trends.tags.current_score', score: link.trend.score.round(2)) %>
+  <%= standard_locale_name(link.language) %> · <%= raw t('admin.trends.links.usage_comparison', count: link.history.get(Time.now.utc).accounts, yesterday: link.history.get(Time.now.utc - 1.day).accounts) %> · <%= t('admin.trends.tags.current_score', score: link.trend.score.round(2)) %>
 <% end %>
 
 <%= raw t('application_mailer.view')%> <%= admin_trends_links_url %>

--- a/app/views/admin_mailer/_new_trending_tags.text.erb
+++ b/app/views/admin_mailer/_new_trending_tags.text.erb
@@ -2,7 +2,7 @@
 
 <% new_trending_tags.each do |tag| %>
 - #<%= tag.display_name %>
-  <%= raw t('admin.trends.tags.usage_comparison', today: tag.history.get(Time.now.utc).accounts, yesterday: tag.history.get(Time.now.utc - 1.day).accounts) %> · <%= t('admin.trends.tags.current_score', score: tag.trend.score.round(2)) %>
+  <%= raw t('admin.trends.tags.usage_comparison', count: tag.history.get(Time.now.utc).accounts, yesterday: tag.history.get(Time.now.utc - 1.day).accounts) %> · <%= t('admin.trends.tags.current_score', score: tag.trend.score.round(2)) %>
 <% end %>
 
 <%= raw t('application_mailer.view')%> <%= admin_trends_tags_url(status: 'pending_review') %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1156,8 +1156,8 @@ en:
           other: Shared by %{count} people over the last week
         title: Trending links
         usage_comparison:
-          one: Shared %{count} time today, compared to %{yesterday} yesterday
-          other: Shared %{count} times today, compared to %{yesterday} yesterday
+          one: Shared %{today} time today, compared to %{yesterday} yesterday
+          other: Shared %{today} times today, compared to %{yesterday} yesterday
       not_allowed_to_trend: Not allowed to trend
       only_allowed: Only allowed
       pending_review: Pending review
@@ -1203,8 +1203,8 @@ en:
         trending_rank: 'Trending #%{rank}'
         usable: Can be used
         usage_comparison:
-          one: Used %{count} time today, compared to %{yesterday} yesterday
-          other: Used %{count} times today, compared to %{yesterday} yesterday
+          one: Used %{today} time today, compared to %{yesterday} yesterday
+          other: Used %{today} times today, compared to %{yesterday} yesterday
         used_by_over_week:
           one: Used by one person over the last week
           other: Used by %{count} people over the last week

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1155,7 +1155,9 @@ en:
           one: Shared by one person over the last week
           other: Shared by %{count} people over the last week
         title: Trending links
-        usage_comparison: Shared %{today} times today, compared to %{yesterday} yesterday
+        usage_comparison:
+          one: Shared %{count} time today, compared to %{yesterday} yesterday
+          other: Shared %{count} times today, compared to %{yesterday} yesterday
       not_allowed_to_trend: Not allowed to trend
       only_allowed: Only allowed
       pending_review: Pending review
@@ -1200,7 +1202,9 @@ en:
         trendable: Can appear under trends
         trending_rank: 'Trending #%{rank}'
         usable: Can be used
-        usage_comparison: Used %{today} times today, compared to %{yesterday} yesterday
+        usage_comparison:
+          one: Used %{count} time today, compared to %{yesterday} yesterday
+          other: Used %{count} times today, compared to %{yesterday} yesterday
         used_by_over_week:
           one: Used by one person over the last week
           other: Used by %{count} people over the last week
@@ -1977,11 +1981,11 @@ en:
       tag: 'Public posts tagged #%{hashtag}'
   scheduled_statuses:
     over_daily_limit:
-      one: You have exceeded the limit of %{limit} scheduled post for today
-      other:  You have exceeded the limit of %{limit} scheduled posts for today
+      one: You have exceeded the limit of %{count} scheduled post for today
+      other:  You have exceeded the limit of %{count} scheduled posts for today
     over_total_limit:
-      one: You have exceeded the limit of %{limit} scheduled post
-      other:  You have exceeded the limit of %{limit} scheduled posts
+      one: You have exceeded the limit of %{count} scheduled post
+      other:  You have exceeded the limit of %{count} scheduled posts
     too_soon: The scheduled date must be in the future
   self_destruct:
     lead_html: Unfortunately, <strong>%{domain}</strong> is permanently closing down. If you had an account there, you will not be able to continue using it, but you can still request a backup of your data.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1981,11 +1981,11 @@ en:
       tag: 'Public posts tagged #%{hashtag}'
   scheduled_statuses:
     over_daily_limit:
-      one: You have exceeded the limit of %{count} scheduled post for today
-      other: You have exceeded the limit of %{count} scheduled posts for today
+      one: You have exceeded the limit of %{limit} scheduled post for today
+      other: You have exceeded the limit of %{limit} scheduled posts for today
     over_total_limit:
-      one: You have exceeded the limit of %{count} scheduled post
-      other: You have exceeded the limit of %{count} scheduled posts
+      one: You have exceeded the limit of %{limit} scheduled post
+      other: You have exceeded the limit of %{limit} scheduled posts
     too_soon: The scheduled date must be in the future
   self_destruct:
     lead_html: Unfortunately, <strong>%{domain}</strong> is permanently closing down. If you had an account there, you will not be able to continue using it, but you can still request a backup of your data.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1784,7 +1784,9 @@ en:
     incoming_migrations_html: To move from another account to this one, first you need to <a href="%{path}">create an account alias</a>.
     moved_msg: Your account is now redirecting to %{acct} and your followers are being moved over.
     not_redirecting: Your account is not redirecting to any other account currently.
-    on_cooldown: You have recently migrated your account. This function will become available again in %{count} days.
+    on_cooldown:
+      one: You have recently migrated your account. This function will become available again in %{count} day.
+      other: You have recently migrated your account. This function will become available again in %{count} days.
     past_migrations: Past migrations
     proceed_with_move: Move followers
     redirected_msg: Your account is now redirecting to %{acct}.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1156,8 +1156,8 @@ en:
           other: Shared by %{count} people over the last week
         title: Trending links
         usage_comparison:
-          one: Shared %{today} time today, compared to %{yesterday} yesterday
-          other: Shared %{today} times today, compared to %{yesterday} yesterday
+          one: Shared %{count} time today, compared to %{yesterday} yesterday
+          other: Shared %{count} times today, compared to %{yesterday} yesterday
       not_allowed_to_trend: Not allowed to trend
       only_allowed: Only allowed
       pending_review: Pending review
@@ -1203,8 +1203,8 @@ en:
         trending_rank: 'Trending #%{rank}'
         usable: Can be used
         usage_comparison:
-          one: Used %{today} time today, compared to %{yesterday} yesterday
-          other: Used %{today} times today, compared to %{yesterday} yesterday
+          one: Used %{count} time today, compared to %{yesterday} yesterday
+          other: Used %{count} times today, compared to %{yesterday} yesterday
         used_by_over_week:
           one: Used by one person over the last week
           other: Used by %{count} people over the last week
@@ -1981,11 +1981,11 @@ en:
       tag: 'Public posts tagged #%{hashtag}'
   scheduled_statuses:
     over_daily_limit:
-      one: You have exceeded the limit of %{limit} scheduled post for today
-      other: You have exceeded the limit of %{limit} scheduled posts for today
+      one: You have exceeded the limit of %{count} scheduled post for today
+      other: You have exceeded the limit of %{count} scheduled posts for today
     over_total_limit:
-      one: You have exceeded the limit of %{limit} scheduled post
-      other: You have exceeded the limit of %{limit} scheduled posts
+      one: You have exceeded the limit of %{count} scheduled post
+      other: You have exceeded the limit of %{count} scheduled posts
     too_soon: The scheduled date must be in the future
   self_destruct:
     lead_html: Unfortunately, <strong>%{domain}</strong> is permanently closing down. If you had an account there, you will not be able to continue using it, but you can still request a backup of your data.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1982,10 +1982,10 @@ en:
   scheduled_statuses:
     over_daily_limit:
       one: You have exceeded the limit of %{count} scheduled post for today
-      other:  You have exceeded the limit of %{count} scheduled posts for today
+      other: You have exceeded the limit of %{count} scheduled posts for today
     over_total_limit:
       one: You have exceeded the limit of %{count} scheduled post
-      other:  You have exceeded the limit of %{count} scheduled posts
+      other: You have exceeded the limit of %{count} scheduled posts
     too_soon: The scheduled date must be in the future
   self_destruct:
     lead_html: Unfortunately, <strong>%{domain}</strong> is permanently closing down. If you had an account there, you will not be able to continue using it, but you can still request a backup of your data.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1972,9 +1972,13 @@ en:
       account: Public posts from @%{acct}
       tag: 'Public posts tagged #%{hashtag}'
   scheduled_statuses:
-    over_daily_limit: You have exceeded the limit of %{limit} scheduled posts for today
-    over_total_limit: You have exceeded the limit of %{limit} scheduled posts
-    too_soon: date must be in the future
+    over_daily_limit:
+      one: You have exceeded the limit of %{limit} scheduled post for today
+      other:  You have exceeded the limit of %{limit} scheduled posts for today
+    over_total_limit:
+      one: You have exceeded the limit of %{limit} scheduled post
+      other:  You have exceeded the limit of %{limit} scheduled posts
+    too_soon: The scheduled date must be in the future
   self_destruct:
     lead_html: Unfortunately, <strong>%{domain}</strong> is permanently closing down. If you had an account there, you will not be able to continue using it, but you can still request a backup of your data.
     title: This server is closing down

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1641,7 +1641,9 @@ en:
       empty: Empty CSV file
       incompatible_type: Incompatible with the selected import type
       invalid_csv_file: 'Invalid CSV file. Error: %{error}'
-      over_rows_processing_limit: contains more than %{count} rows
+      over_rows_processing_limit:
+        one: contains more than %{count} row
+        other: contains more than %{count} rows
       too_large: File is too large
     failures: Failures
     imported: Imported

--- a/spec/models/scheduled_status_spec.rb
+++ b/spec/models/scheduled_status_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ScheduledStatus do
 
       it 'is not valid', :aggregate_failures do
         expect(subject).to_not be_valid
-        expect(subject.errors[:base]).to include(I18n.t('scheduled_statuses.over_total_limit', limit: ScheduledStatus::TOTAL_LIMIT))
+        expect(subject.errors[:base]).to include(I18n.t('scheduled_statuses.over_total_limit', count: ScheduledStatus::TOTAL_LIMIT))
       end
     end
 
@@ -43,7 +43,7 @@ RSpec.describe ScheduledStatus do
 
       it 'is not valid', :aggregate_failures do
         expect(subject).to_not be_valid
-        expect(subject.errors[:base]).to include(I18n.t('scheduled_statuses.over_daily_limit', limit: ScheduledStatus::DAILY_LIMIT))
+        expect(subject.errors[:base]).to include(I18n.t('scheduled_statuses.over_daily_limit', count: ScheduledStatus::DAILY_LIMIT))
       end
     end
   end


### PR DESCRIPTION
Follow-up PR to https://github.com/mastodon/mastodon/pull/26770, since we can't reopen.

Regarding the feedback about not needing this for hard-coded or large numbers in the other PR:

1. Translators won't know it's hard-coded. If it's hard-coded, you could put the number in the string instead of using a placeholder, but then you also have to ensure that if the hard-coded value should ever change, the string is aligned with the new number. Translators will then have to retranslate the string.
2. Numbers being large doesn't matter for correct string markup, Slavic languages have some really interesting modulo math going on there. For example, https://www.unicode.org/cldr/charts/47/supplemental/language_plural_rules.html#pl

The feedback about having to name the key `count` has been addressed.