### PR TITLE
fix: Prevent long link names in admin sidebar from being truncated

### DIFF
--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -114,15 +114,14 @@ $content-width: 840px;
 
       a {
         font-size: 14px;
-        display: block;
+        display: flex;
+        align-items: center;
+        gap: 6px;
         padding: 15px;
         color: $darker-text-color;
         text-decoration: none;
         transition: all 200ms linear;
         transition-property: color, background-color;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
 
         &:hover {
           color: $primary-text-color;


### PR DESCRIPTION
### Changes proposed in this PR:
- Allow long link names in the admin sidebar to wrap onto a new line. Prevent cut-off link labels to avoid having to increase the sidebar width as proposed in #34714 
- The icons are aligned a tiny bit more nicely with their text (as a side-effect of using flex alignment for the item layout)

### Screenshots

| **BEFORE** | **AFTER** |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/91f01c16-08a0-4e9a-be3a-0ce7158988d0) | ![image](https://github.com/user-attachments/assets/1f33a7cf-288f-4bb6-9911-3acda668c24b) |