### PR TITLE
Use `ActiveSupport::TaggedLogging.logger` shorthand to set logger

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,10 +37,8 @@ Rails.application.configure do
 
   config.action_controller.forgery_protection_origin_check = ENV['DISABLE_FORGERY_REQUEST_PROTECTION'].nil?
 
-  ActiveSupport::Logger.new($stdout).tap do |logger|
-    logger.formatter = config.log_formatter
-    config.logger = ActiveSupport::TaggedLogging.new(logger)
-  end
+  # Override default file logging in favor of STDOUT logging in dev environment
+  config.logger = ActiveSupport::TaggedLogging.logger($stdout, formatter: config.log_formatter)
 
   # Generate random VAPID keys
   Webpush.generate_key.tap do |vapid_key|


### PR DESCRIPTION
Sort of follow-up on https://github.com/mastodon/mastodon/pull/32357

This `logger` class method was added in rails 8 as a lightweight wrapper around the "auto wrap a logger as a tagged logger" idea - https://github.com/rails/rails/pull/52994 - end result should be the same here, and preserves dev mode logging along lines of https://github.com/mastodon/mastodon/pull/33057

If you set a logger at all, you also need to set a formatter, hence preserving that item here (the passed in args are sent along to the wrapped constructor, and set there).

Have similar change for production env, but I have some sort of native gem issue currently preventing testing that locally. Will do as followup assuming no issues on this one.