### PR TITLE
Fix incorrect `progress` value being passed to react-spring in video player

### DIFF
--- a/app/javascript/mastodon/features/video/index.tsx
+++ b/app/javascript/mastodon/features/video/index.tsx
@@ -346,8 +346,10 @@ export const Video: React.FC<{
     const updateProgress = () => {
       nextFrame = requestAnimationFrame(() => {
         if (videoRef.current) {
+          const progress =
+            videoRef.current.currentTime / videoRef.current.duration;
           void api.start({
-            progress: `${(videoRef.current.currentTime / videoRef.current.duration) * 100}%`,
+            progress: isNaN(progress) ? '0%' : `${progress * 100}%`,
             immediate: reduceMotion,
             config: config.stiff,
           });


### PR DESCRIPTION
Presumably because `videoRef.current.duration` is unknown or zero before the video starts, but I opted for a more defensive `isNaN` than checking on `videoRef.current.duration` specifically.