### PR TITLE
Change libvips to be enabled by default

### DIFF
--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -143,7 +143,7 @@ jobs:
         uses: ./.github/actions/setup-ruby
         with:
           ruby-version: ${{ matrix.ruby-version}}
-          additional-system-dependencies: ffmpeg imagemagick libpam-dev
+          additional-system-dependencies: ffmpeg libpam-dev
 
       - name: Load database schema
         run: |
@@ -173,8 +173,8 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-  test-libvips:
-    name: Libvips tests
+  test-imagemagick:
+    name: ImageMagick tests
     runs-on: ubuntu-latest
 
     needs:
@@ -220,7 +220,7 @@ jobs:
       CAS_ENABLED: true
       BUNDLE_WITH: 'pam_authentication test'
       GITHUB_RSPEC: ${{ matrix.ruby-version == '.ruby-version' && github.event.pull_request && 'true' }}
-      MASTODON_USE_LIBVIPS: true
+      MASTODON_USE_LIBVIPS: false
 
     strategy:
       fail-fast: false
@@ -245,7 +245,7 @@ jobs:
         uses: ./.github/actions/setup-ruby
         with:
           ruby-version: ${{ matrix.ruby-version}}
-          additional-system-dependencies: ffmpeg libpam-dev
+          additional-system-dependencies: ffmpeg imagemagick libpam-dev
 
       - name: Load database schema
         run: './bin/rails db:create db:schema:load db:seed'
@@ -324,7 +324,7 @@ jobs:
         uses: ./.github/actions/setup-ruby
         with:
           ruby-version: ${{ matrix.ruby-version}}
-          additional-system-dependencies: ffmpeg imagemagick
+          additional-system-dependencies: ffmpeg
 
       - name: Set up Javascript environment
         uses: ./.github/actions/setup-javascript
@@ -443,7 +443,7 @@ jobs:
         uses: ./.github/actions/setup-ruby
         with:
           ruby-version: ${{ matrix.ruby-version}}
-          additional-system-dependencies: ffmpeg imagemagick
+          additional-system-dependencies: ffmpeg
 
       - name: Set up Javascript environment
         uses: ./.github/actions/setup-javascript

--- a/config/application.rb
+++ b/config/application.rb
@@ -95,7 +95,7 @@ module Mastodon
       require 'mastodon/redis_configuration'
       ::REDIS_CONFIGURATION = Mastodon::RedisConfiguration.new
 
-      config.x.use_vips = ENV['MASTODON_USE_LIBVIPS'] == 'true'
+      config.x.use_vips = ENV['MASTODON_USE_LIBVIPS'] != 'false'
 
       if config.x.use_vips
         require_relative '../lib/paperclip/vips_lazy_thumbnail'

--- a/config/initializers/deprecations.rb
+++ b/config/initializers/deprecations.rb
@@ -16,3 +16,9 @@ if ENV['REDIS_NAMESPACE']
 
   abort message
 end
+
+if ENV['MASTODON_USE_LIBVIPS'] == 'false'
+  warn <<~MESSAGE
+    WARNING: Mastodon support for ImageMagick is deprecated and will be removed in future versions. Please consider using libvips instead.
+  MESSAGE
+end


### PR DESCRIPTION
To use ImageMagick instead of libvips, set the `MASTODON_USE_LIBVIPS` environment variable to `false`.