### PR TITLE
Drop support for PostgreSQL 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Mastodon is a **free, open-source social network server** based on ActivityPub w
 
 ### Requirements
 
-- **PostgreSQL** 12+
+- **PostgreSQL** 13+
 - **Redis** 6.2+
 - **Ruby** 3.2+
 - **Node.js** 18+

--- a/config/initializers/strong_migrations.rb
+++ b/config/initializers/strong_migrations.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
 StrongMigrations.start_after = 2017_09_24_022025
-StrongMigrations.target_version = 12
+StrongMigrations.target_version = 13

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -63,7 +63,7 @@ namespace :db do
 
   task pre_migration_check: :environment do
     pg_version = ActiveRecord::Base.connection.database_version
-    abort 'This version of Mastodon requires PostgreSQL 12.0 or newer. Please update PostgreSQL before updating Mastodon.' if pg_version < 120_000
+    abort 'This version of Mastodon requires PostgreSQL 13.0 or newer. Please update PostgreSQL before updating Mastodon.' if pg_version < 130_000
 
     schema_version = ActiveRecord::Migrator.current_version
     abort <<~MESSAGE if ENV['SKIP_POST_DEPLOYMENT_MIGRATIONS'] && schema_version < 2023_09_07_150100


### PR DESCRIPTION
There is no immediate reason for us to drop PostgreSQL 12, but PostgreSQL 12 is already End-of-Life and we do not want to be stuck with old releases for the lifetime of Mastodon 4.4.