### PR TITLE
Use `ActiveSupport::TaggedLogging.logger` shorthand to set logger in production env

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -52,15 +52,15 @@ Rails.application.configure do
     },
   }
 
+  # Use default logging formatter so that PID and timestamp are not suppressed.
+  config.log_formatter = Logger::Formatter.new
+
   # Log to STDOUT with the current request id as a default log tag.
   config.log_tags = [:request_id]
   config.logger = ActiveSupport::TaggedLogging.logger($stdout, formatter: config.log_formatter)
 
   # Change to "debug" to log everything (including potentially personally-identifiable information!)
   config.log_level = ENV.fetch('RAILS_LOG_LEVEL', 'info')
-
-  # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = Logger::Formatter.new
 
   # Use a different cache store in production.
   config.cache_store = :redis_cache_store, REDIS_CONFIGURATION.cache

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -52,18 +52,15 @@ Rails.application.configure do
     },
   }
 
-  # Log to STDOUT by default
-  config.logger = ActiveSupport::Logger.new($stdout)
-                                       .tap  { |logger| logger.formatter = ::Logger::Formatter.new }
-                                       .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
-
-  # Prepend all log lines with the following tags.
+  # Log to STDOUT with the current request id as a default log tag.
   config.log_tags = [:request_id]
+  config.logger = ActiveSupport::TaggedLogging.logger($stdout, formatter: config.log_formatter)
 
-  # "info" includes generic and useful information about system operation, but avoids logging too much
-  # information to avoid inadvertent exposure of personally identifiable information (PII). If you
-  # want to log everything, set the level to "debug".
+  # Change to "debug" to log everything (including potentially personally-identifiable information!)
   config.log_level = ENV.fetch('RAILS_LOG_LEVEL', 'info')
+
+  # Use default logging formatter so that PID and timestamp are not suppressed.
+  config.log_formatter = Logger::Formatter.new
 
   # Use a different cache store in production.
   config.cache_store = :redis_cache_store, REDIS_CONFIGURATION.cache
@@ -89,9 +86,6 @@ Rails.application.configure do
 
   # Don't log any deprecations.
   config.active_support.report_deprecations = false
-
-  # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
 
   # Better log formatting
   config.lograge.enabled = true


### PR DESCRIPTION
This does for the production environment what https://github.com/mastodon/mastodon/pull/34734 did in development -- just shorthand method to wrap the tagged logger setup.

Only other stuff here:

- We were previously setting the `log_formatter` config value, but then not using that setting (and instead re-assigning same formatter). I didn't do a full history dive on this but I suspect the order got shuffled at some point and that's why we repeated it? Updated to move the setting closer to (and above) the other log-related stuff, and to then use the setting by passing it in via `formatter` arg.
- Aligned the `log_level` and `logger` comment lines to match output of rails 8 generator

Ran a few requests in production mode locally to verify format looks same as before.