### PR TITLE
Fix `NoMethodError` in edge case of emoji cache handling

### DIFF
--- a/app/lib/entity_cache.rb
+++ b/app/lib/entity_cache.rb
@@ -26,12 +26,14 @@ class EntityCache
       uncached_ids << shortcode unless cached.key?(to_key(:emoji, shortcode, domain))
     end
 
-    unless uncached_ids.empty?
+    if uncached_ids.empty?
+      uncached = {}
+    else
       uncached = CustomEmoji.enabled.where(shortcode: shortcodes, domain: domain).index_by(&:shortcode)
       uncached.each_value { |item| Rails.cache.write(to_key(:emoji, item.shortcode, domain), item, expires_in: MAX_EXPIRATION) }
     end
 
-    shortcodes.filter_map { |shortcode| cached[to_key(:emoji, shortcode, domain)] || (uncached[shortcode] if uncached) }
+    shortcodes.filter_map { |shortcode| cached[to_key(:emoji, shortcode, domain)] || uncached[shortcode] }
   end
 
   def to_key(type, *ids)

--- a/app/lib/entity_cache.rb
+++ b/app/lib/entity_cache.rb
@@ -31,7 +31,7 @@ class EntityCache
       uncached.each_value { |item| Rails.cache.write(to_key(:emoji, item.shortcode, domain), item, expires_in: MAX_EXPIRATION) }
     end
 
-    shortcodes.filter_map { |shortcode| cached[to_key(:emoji, shortcode, domain)] || uncached[shortcode] }
+    shortcodes.filter_map { |shortcode| cached[to_key(:emoji, shortcode, domain)] || (uncached[shortcode] if uncached) }
   end
 
   def to_key(type, *ids)


### PR DESCRIPTION
https://github.com/mastodon/mastodon/blob/f7182ddc8b44f71f6991941b9356454e4468bcd7/app/lib/entity_cache.rb#L34

In the rare case where `cached[to_key(:emoji, shortcode, domain)]` resolves to `nil` and `uncached` is also `nil`, this can throw an error while attempting to access `nil[shortcode]` that causes the `/api/v1/timelines/home` to return an error 500 and no data. Safely accessing `uncached` here results in the ultimate error state of "we have no cached or uncached data for this emoji" to be a simple rendering of the emoji shortcode in the text of the post, like so:

![image](https://github.com/user-attachments/assets/1993023b-fb5d-4dfc-a3b3-0b2f82132e86)

Note: I have no idea what's idiomatic in Ruby these days but it seems like the Mastodon source code in general prefers appending `if uncached` for safety rather than something like `uncached&.[](shortcode)`