### PR TITLE
Remove `OTP_SECRET` env configuration from setup

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -43,7 +43,6 @@ ES_PASS=password
 # Make sure to use `bundle exec rails secret` to generate secrets
 # -------
 SECRET_KEY_BASE=
-OTP_SECRET=
 
 # Encryption secrets
 # ------------------

--- a/app.json
+++ b/app.json
@@ -17,10 +17,6 @@
       "description": "The secret key base",
       "generator": "secret"
     },
-    "OTP_SECRET": {
-      "description": "One-time password secret",
-      "generator": "secret"
-    },
     "SINGLE_USER_MODE": {
       "description": "Should the instance run in single user mode? (Disable registrations, redirect to front page)",
       "value": "false",

--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -32,7 +32,7 @@ namespace :mastodon do
       prompt.say('Single user mode disables registrations and redirects the landing page to your public profile.')
       env['SINGLE_USER_MODE'] = prompt.yes?('Do you want to enable single user mode?', default: false)
 
-      %w(SECRET_KEY_BASE OTP_SECRET).each do |key|
+      %w(SECRET_KEY_BASE).each do |key|
         env[key] = SecureRandom.hex(64)
       end
 

--- a/scalingo.json
+++ b/scalingo.json
@@ -12,10 +12,6 @@
       "description": "The secret key base",
       "generator": "secret"
     },
-    "OTP_SECRET": {
-      "description": "One-time password secret",
-      "generator": "secret"
-    },
     "SINGLE_USER_MODE": {
       "description": "Should the instance run in single user mode? (Disable registrations, redirect to front page)",
       "value": "false",


### PR DESCRIPTION
Background: https://github.com/mastodon/mastodon/pull/34748#issuecomment-2897908481

This is the env-var-only stuff from that PR. It leaves the in-code config in place for now, pending more discussion on original PR.