### PR TITLE
Fix preview card being fetched even when a status has a quote or media attachment

### DIFF
--- a/app/services/fetch_link_card_service.rb
+++ b/app/services/fetch_link_card_service.rb
@@ -19,7 +19,7 @@ class FetchLinkCardService < BaseService
     @status       = status
     @original_url = parse_urls
 
-    return if @original_url.nil? || @status.with_preview_card?
+    return if @original_url.nil? || @status.with_preview_card? || @status.with_media? || @status.quote.present?
 
     @url = @original_url.to_s
 


### PR DESCRIPTION
In the Web UI and the main client, we skip displaying link previews when a media attachment is provided.

However, I noticed we were still creating the attachment, which is unnecessary, and may lead to inconsistencies between clients.