### PR TITLE
fix: Allow quotes to be filtered

### DIFF
--- a/app/javascript/mastodon/components/status_quoted.tsx
+++ b/app/javascript/mastodon/components/status_quoted.tsx
@@ -68,15 +68,15 @@ type QuoteMap = ImmutableMap<'state' | 'quoted_status', string | null>;
 
 export const QuotedStatus: React.FC<{
   quote: QuoteMap;
+  contextType?: string;
   variant?: 'full' | 'link';
   nestingLevel?: number;
-}> = ({ quote, nestingLevel = 1, variant = 'full' }) => {
+}> = ({ quote, contextType, nestingLevel = 1, variant = 'full' }) => {
   const quotedStatusId = quote.get('quoted_status');
   const state = quote.get('state');
   const status = useAppSelector((state) =>
     quotedStatusId ? state.statuses.get(quotedStatusId) : undefined,
   );
-
   let quoteError: React.ReactNode = null;
 
   if (state === 'deleted') {
@@ -131,10 +131,16 @@ export const QuotedStatus: React.FC<{
   return (
     <QuoteWrapper>
       {/* @ts-expect-error Status is not yet typed */}
-      <StatusContainer isQuotedPost id={quotedStatusId} avatarSize={40}>
+      <StatusContainer
+        isQuotedPost
+        id={quotedStatusId}
+        contextType={contextType}
+        avatarSize={40}
+      >
         {canRenderChildQuote && (
           <QuotedStatus
             quote={childQuote}
+            contextType={contextType}
             variant={
               nestingLevel === MAX_QUOTE_POSTS_NESTING_LEVEL ? 'link' : 'full'
             }
@@ -148,6 +154,7 @@ export const QuotedStatus: React.FC<{
 
 interface StatusQuoteManagerProps {
   id: string;
+  contextType?: string;
   [key: string]: unknown;
 }
 
@@ -168,7 +175,7 @@ export const StatusQuoteManager = (props: StatusQuoteManagerProps) => {
   if (quote) {
     return (
       <StatusContainer {...props}>
-        <QuotedStatus quote={quote} />
+        <QuotedStatus quote={quote} contextType={props.contextType} />
       </StatusContainer>
     );
   }


### PR DESCRIPTION
Closes MAS-430

### Changes proposed in this PR:
- Pass contextType through to quotes, allowing them to be filtered as long as the filter action is "Hide with a warning". Completely hiding filtered posts will be addressed in a follow-up PR.
- No special UI treatment here, the existing filtering from the Status component is used

### Screenshots

![image](https://github.com/user-attachments/assets/843ac8b4-b732-415c-baf6-8ecf61701349)
