### PR TITLE
Fix handling of inlined `featured` collections in ActivityPub actor objects

### DIFF
--- a/app/services/activitypub/fetch_featured_collection_service.rb
+++ b/app/services/activitypub/fetch_featured_collection_service.rb
@@ -4,13 +4,11 @@ class ActivityPub::FetchFeaturedCollectionService < BaseService
   include JsonLdHelper
 
   def call(account, **options)
-    return if account.featured_collection_url.blank? || account.suspended? || account.local?
+    return if (account.featured_collection_url.blank? && options[:collection].blank?) || account.suspended? || account.local?
 
     @account = account
     @options = options
-    @json    = fetch_resource(@account.featured_collection_url, true, local_follower)
-
-    return unless supported_context?(@json)
+    @json    = fetch_collection(options[:collection].presence || @account.featured_collection_url)
 
     process_items(collection_items(@json))
   end

--- a/app/workers/activitypub/synchronize_featured_collection_worker.rb
+++ b/app/workers/activitypub/synchronize_featured_collection_worker.rb
@@ -6,7 +6,7 @@ class ActivityPub::SynchronizeFeaturedCollectionWorker
   sidekiq_options queue: 'pull', lock: :until_executed, lock_ttl: 1.day.to_i
 
   def perform(account_id, options = {})
-    options = { note: true, hashtag: false }.deep_merge(options.deep_symbolize_keys)
+    options = { note: true, hashtag: false }.deep_merge(options.symbolize_keys)
 
     ActivityPub::FetchFeaturedCollectionService.new.call(Account.find(account_id), **options)
   rescue ActiveRecord::RecordNotFound


### PR DESCRIPTION
Fixes #34779

This passes the collection as job arguments instead of a database column. The database column is still updated as expected when the collection is an URL, and used if no job argument is provided, so as not to break existing queued jobs.