### PR TITLE
fix: Show hint for quotes hidden by filter

### DIFF
--- a/app/javascript/mastodon/components/status_quoted.tsx
+++ b/app/javascript/mastodon/components/status_quoted.tsx
@@ -12,6 +12,7 @@ import ChevronRightIcon from '@/material-icons/400-24px/chevron_right.svg?react'
 import { Icon } from 'mastodon/components/icon';
 import StatusContainer from 'mastodon/containers/status_container';
 import type { Status } from 'mastodon/models/status';
+import type { RootState } from 'mastodon/store';
 import { useAppSelector } from 'mastodon/store';
 
 import QuoteIcon from '../../images/quote.svg?react';
@@ -68,6 +69,10 @@ const QuoteLink: React.FC<{
 };
 
 type QuoteMap = ImmutableMap<'state' | 'quoted_status', string | null>;
+type GetStatusSelector = (
+  state: RootState,
+  props: { id?: string | null; contextType?: string },
+) => Status | null;
 
 export const QuotedStatus: React.FC<{
   quote: QuoteMap;
@@ -85,11 +90,9 @@ export const QuotedStatus: React.FC<{
   // In order to find out whether the quoted post should be completely hidden
   // due to a matching filter, we run it through the selector used by `status_container`.
   // If this returns null even though `status` exists, it's because it's filtered.
-  const getStatus = useMemo(() => makeGetStatus(), []);
-  const statusWithExtraData = useAppSelector(
-    (state) =>
-      // @ts-expect-error getStatus types aren't inferred correctly
-      getStatus(state, { id: quotedStatusId, contextType }) as Status | null,
+  const getStatus = useMemo(() => makeGetStatus(), []) as GetStatusSelector;
+  const statusWithExtraData = useAppSelector((state) =>
+    getStatus(state, { id: quotedStatusId, contextType }),
   );
   const isFilteredAndHidden = status && statusWithExtraData === null;
 

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -864,6 +864,7 @@
   "status.mute_conversation": "Mute conversation",
   "status.open": "Expand this post",
   "status.pin": "Feature on profile",
+  "status.quote_error.filtered": "Hidden due to one of your filters",
   "status.quote_error.not_found": "This post cannot be displayed.",
   "status.quote_error.pending_approval": "This post is pending approval from the original author.",
   "status.quote_error.rejected": "This post cannot be displayed as the original author does not allow it to be quoted.",


### PR DESCRIPTION
Closes MAS-430

### Changes proposed in this PR:
- Shows a hint for quotes that are matching a filter with a filter action of "Hide completely"
   The implementation feels quite hacky, but a cleaner approach would require duplicating or entirely refactoring code from `status_container`

### Screenshots

![image](https://github.com/user-attachments/assets/da454ca3-505d-4636-815b-31c4f3b6a616)
