### PR TITLE
feat: Add relationship info to hover card

### DIFF
--- a/app/javascript/mastodon/components/hover_card_account.tsx
+++ b/app/javascript/mastodon/components/hover_card_account.tsx
@@ -107,22 +107,20 @@ export const HoverCardAccount = forwardRef<
                 </div>
               </>
             )}
-            {isMutual && (
+            {(isMutual || isFollower) && (
               <>
                 &middot;
-                <FormattedMessage
-                  id='account.mutual'
-                  defaultMessage='You follow each other'
-                />
-              </>
-            )}
-            {isFollower && !isMutual && (
-              <>
-                &middot;
-                <FormattedMessage
-                  id='account.follows_you'
-                  defaultMessage='Follows you'
-                />
+                {isMutual ? (
+                  <FormattedMessage
+                    id='account.mutual'
+                    defaultMessage='You follow each other'
+                  />
+                ) : (
+                  <FormattedMessage
+                    id='account.follows_you'
+                    defaultMessage='Follows you'
+                  />
+                )}
               </>
             )}
           </div>

--- a/app/javascript/mastodon/components/hover_card_account.tsx
+++ b/app/javascript/mastodon/components/hover_card_account.tsx
@@ -49,7 +49,14 @@ export const HoverCardAccount = forwardRef<
     accountId ? state.relationships.get(accountId) : undefined,
   );
   const isMutual = relationship?.followed_by && relationship.following;
-  const isFollower = relationship?.following;
+  const isFollower = relationship?.followed_by;
+  const hasRelationshipLoaded = !!relationship;
+
+  const shouldDisplayFamiliarFollowers =
+    familiarFollowers.length > 0 &&
+    hasRelationshipLoaded &&
+    !isMutual &&
+    !isFollower;
 
   return (
     <div
@@ -91,7 +98,7 @@ export const HoverCardAccount = forwardRef<
               value={account.followers_count}
               renderer={FollowersCounter}
             />
-            {familiarFollowers.length > 0 && !isMutual && (
+            {shouldDisplayFamiliarFollowers && (
               <>
                 &middot;
                 <div className='hover-card__familiar-followers'>

--- a/app/javascript/mastodon/components/hover_card_account.tsx
+++ b/app/javascript/mastodon/components/hover_card_account.tsx
@@ -45,6 +45,12 @@ export const HoverCardAccount = forwardRef<
 
   const { familiarFollowers } = useFetchFamiliarFollowers({ accountId });
 
+  const relationship = useAppSelector((state) =>
+    accountId ? state.relationships.get(accountId) : undefined,
+  );
+  const isMutual = relationship?.followed_by && relationship.following;
+  const isFollower = relationship?.following;
+
   return (
     <div
       ref={ref}
@@ -85,7 +91,7 @@ export const HoverCardAccount = forwardRef<
               value={account.followers_count}
               renderer={FollowersCounter}
             />
-            {familiarFollowers.length > 0 && (
+            {familiarFollowers.length > 0 && !isMutual && (
               <>
                 &middot;
                 <div className='hover-card__familiar-followers'>
@@ -99,6 +105,24 @@ export const HoverCardAccount = forwardRef<
                     ))}
                   </AvatarGroup>
                 </div>
+              </>
+            )}
+            {isMutual && (
+              <>
+                &middot;
+                <FormattedMessage
+                  id='account.mutual'
+                  defaultMessage='You follow each other'
+                />
+              </>
+            )}
+            {isFollower && !isMutual && (
+              <>
+                &middot;
+                <FormattedMessage
+                  id='account.follows_you'
+                  defaultMessage='Follows you'
+                />
               </>
             )}
           </div>

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -10766,7 +10766,7 @@ noscript {
     display: flex;
     align-items: center;
     flex-wrap: wrap;
-    gap: 10px;
+    gap: 2px 10px;
   }
 
   &__numbers {


### PR DESCRIPTION
### Changes proposed in this PR:
- Adds relationship info ("You follow each other", "Follows you") to account hovercard
- If this is shown, "Followers you know" is hidden to not clutter up the card

### Screenshots

![image](https://github.com/user-attachments/assets/42bc9dd3-886b-4d61-832f-713f1e246b97)

![Screenshot 2025-05-30 at 11 55 15](https://github.com/user-attachments/assets/4cf14cae-08af-456a-a30a-8b6e05e45621)

![Screenshot 2025-05-30 at 11 59 01](https://github.com/user-attachments/assets/b71d8eca-71b2-4188-a1e2-83f26178b7ab)
