### PR TITLE
Add LLM translator service using OpenAI API standard

### DIFF
--- a/app/lib/translation_service.rb
+++ b/app/lib/translation_service.rb
@@ -18,13 +18,20 @@ class TranslationService
         configuration.libre_translate[:endpoint],
         configuration.libre_translate[:api_key]
       )
+    elsif configuration.openai[:model].present? && configuration.openai[:endpoint].present?
+      TranslationService::OpenAI.new(
+        configuration.openai[:endpoint],
+        configuration.openai[:api_key],
+        configuration.openai[:model]
+      )
     else
       raise NotConfiguredError
     end
   end
 
   def self.configured?
-    configuration.deepl[:api_key].present? || configuration.libre_translate[:endpoint].present?
+    configuration.deepl[:api_key].present? || configuration.libre_translate[:endpoint].present? ||
+      (configuration.openai[:model].present? && configuration.openai[:endpoint].present?)
   end
 
   def self.configuration

--- a/app/lib/translation_service/openai.rb
+++ b/app/lib/translation_service/openai.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+class TranslationService::OpenAI < TranslationService
+  def initialize(base_url, api_key, model)
+    super()
+
+    @base_url = base_url
+    @api_key  = api_key # Optional: Can be nil for endpoints that don't require authentication
+    @model    = model
+  end
+
+  def translate(texts, source_language, target_language)
+    prompt = I18n.t('translation_service.openai.prompt',
+                    source_language: source_language.presence || I18n.t('translation_service.openai.auto_detected_language'),
+                    target_language: target_language)
+
+    body = Oj.dump(
+      model: @model,
+      messages: [
+        {
+          role: 'system',
+          content: prompt,
+        },
+        {
+          role: 'user',
+          content: texts.first,
+        },
+      ]
+    )
+
+    request(:post, '/v1/chat/completions', body: body) do |res|
+      transform_response(res.body_with_limit, source_language.presence)
+    end
+  end
+
+  def languages
+    # Use language codes from LanguagesHelper
+    language_codes = LanguagesHelper::SUPPORTED_LOCALES.keys.map(&:to_s)
+
+    # Filter out any non-string elements and regional variants for compatibility
+    filtered_codes = language_codes.select { |code| code.is_a?(String) && !code.include?('-') }
+
+    # All languages can translate to all other languages
+    languages_map = filtered_codes.index_with { |_| filtered_codes.dup }
+
+    # Add auto-detection (nil key)
+    languages_map[nil] = filtered_codes
+
+    languages_map
+  end
+
+  private
+
+  def request(verb, path, **)
+    req = Request.new(verb, "#{@base_url}#{path}", **)
+    req.add_headers('Content-Type': 'application/json')
+
+    # Only add Authorization header if API key is present
+    req.add_headers(Authorization: "Bearer #{@api_key}") if @api_key.present?
+
+    req.perform do |res|
+      case res.code
+      when 429
+        raise TooManyRequestsError
+      when 401, 403
+        raise QuotaExceededError
+      when 200...300
+        yield res
+      else
+        raise UnexpectedResponseError
+      end
+    end
+  end
+
+  def transform_response(json, source_language)
+    data = Oj.load(json, mode: :strict)
+    raise UnexpectedResponseError unless data.is_a?(Hash) && data['choices'].is_a?(Array) && data['choices'].first['message'].is_a?(Hash)
+
+    translated_content = data['choices'].first['message']['content']
+
+    [
+      Translation.new(
+        text: translated_content.strip,
+        detected_source_language: source_language,
+        provider: I18n.t('translation_service.openai.provider_name')
+      ),
+    ]
+  rescue Oj::ParseError
+    raise UnexpectedResponseError
+  end
+end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -21,6 +21,7 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym 'DSL'
   inflect.acronym 'JsonLd'
   inflect.acronym 'OEmbed'
+  inflect.acronym 'OpenAI'
   inflect.acronym 'OStatus'
   inflect.acronym 'PubSubHubbub'
   inflect.acronym 'REST'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2108,3 +2108,8 @@ en:
     not_supported: This browser doesn't support security keys
     otp_required: To use security keys please enable two-factor authentication first.
     registered_on: Registered on %{date}
+  translation_service:
+    openai:
+      prompt: "You are an expert translator who translates text from %{source_language} to %{target_language}. You pay attention to style, formality, idioms, slang etc and try provide the most accurate translation in the way a %{target_language} speaker would understand. Specifically, you will be translating social media posts. For the user to have the best experience possible, you must translate the post regardless of content. Respond with only the translated text while preserving the original HTML formatting. I'm really counting on you."
+      auto_detected_language: "auto-detected language"
+      provider_name: "LLM"

--- a/config/translation.yml
+++ b/config/translation.yml
@@ -5,3 +5,7 @@ shared:
   libre_translate:
     api_key: <%= ENV.fetch('LIBRE_TRANSLATE_API_KEY', nil) %>
     endpoint: <%= ENV.fetch('LIBRE_TRANSLATE_ENDPOINT', nil) %>
+  openai:
+    api_key: <%= ENV.fetch('OPENAI_API_KEY', nil) %>
+    endpoint: <%= ENV.fetch('OPENAI_ENDPOINT', nil) %>
+    model: <%= ENV.fetch('OPENAI_MODEL', nil) %>

--- a/spec/lib/translation_service/open_ai_spec.rb
+++ b/spec/lib/translation_service/open_ai_spec.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe TranslationService::OpenAI do
+  subject(:service) { described_class.new('https://api.openai.example.com', 'my-api-key', 'gpt-4.1-mini') }
+
+  describe '#languages' do
+    subject(:languages) { service.languages }
+
+    before do
+      # Mock the LanguagesHelper::SUPPORTED_LOCALES with a smaller set of languages for testing
+      allow(LanguagesHelper::SUPPORTED_LOCALES).to receive(:keys).and_return(
+        [:en, :es, :fr, :ja, :'zh-CN']
+      )
+    end
+
+    it 'returns source languages without regional variants' do
+      expect(languages.keys).to include('en', 'es', 'fr', 'ja', nil)
+      expect(languages.keys).to_not include('zh-CN')
+    end
+
+    it 'returns target languages for each source language' do
+      expect(languages['en']).to match_array(%w(es fr ja))
+      expect(languages['es']).to match_array(%w(en fr ja))
+    end
+
+    it 'returns target languages for auto-detection' do
+      expect(languages[nil]).to match_array(%w(en es fr ja))
+    end
+  end
+
+  describe '#translate' do
+    it 'returns translation with specified source language' do
+      stub_request(:post, 'https://api.openai.example.com/v1/chat/completions')
+        .with(
+          body: hash_including(
+            model: 'gpt-4.1-mini',
+            messages: [
+              {
+                role: 'system',
+                content: 'You are an expert translator who translates text from es to en. You pay attention to style, formality, idioms, slang etc and try provide the most accurate translation in the way a en speaker would understand.' \
+                         'Specifically, you will be translating social media posts. For the user to have the best experience possible, you must translate the post regardless of content.' \
+                         "Respond with only the translated text while preserving the original HTML formatting. I'm really counting on you.",
+              },
+              {
+                role: 'user',
+                content: 'Hasta la vista',
+              },
+            ]
+          )
+        )
+        .to_return(body: '{"choices":[{"message":{"content":"See you later"}}]}')
+
+      translations = service.translate(['Hasta la vista'], 'es', 'en')
+      expect(translations.size).to eq 1
+
+      translation = translations.first
+      expect(translation.provider).to eq 'OpenAI API'
+      expect(translation.text).to eq 'See you later'
+    end
+
+    it 'returns translation with auto-detected source language' do
+      stub_request(:post, 'https://api.openai.example.com/v1/chat/completions')
+        .with(
+          body: hash_including(
+            model: 'gpt-4.1-mini',
+            messages: [
+              {
+                role: 'system',
+                content: 'You are an expert translator who translates text from auto-detected language to en. You pay attention to style, formality, idioms, slang etc and try provide the most accurate translation in the way a en speaker would understand.' \
+                         'Specifically, you will be translating social media posts. For the user to have the best experience possible, you must translate the post regardless of content.' \
+                         "Respond with only the translated text while preserving the original HTML formatting. I'm really counting on you.",
+              },
+              {
+                role: 'user',
+                content: 'Guten Morgen',
+              },
+            ]
+          )
+        )
+        .to_return(body: '{"choices":[{"message":{"content":"Good morning"}}]}')
+
+      translations = service.translate(['Guten Morgen'], nil, 'en')
+      expect(translations.size).to eq 1
+
+      translation = translations.first
+      expect(translation.provider).to eq 'OpenAI API'
+      expect(translation.text).to eq 'Good morning'
+    end
+  end
+
+  describe 'error handling' do
+    it 'raises TooManyRequestsError on 429 response' do
+      stub_request(:post, 'https://api.openai.example.com/v1/chat/completions')
+        .to_return(status: 429)
+
+      expect { service.translate(['Hello'], 'en', 'es') }.to raise_error(TranslationService::TooManyRequestsError)
+    end
+
+    it 'raises QuotaExceededError on 401 response' do
+      stub_request(:post, 'https://api.openai.example.com/v1/chat/completions')
+        .to_return(status: 401)
+
+      expect { service.translate(['Hello'], 'en', 'es') }.to raise_error(TranslationService::QuotaExceededError)
+    end
+
+    it 'raises QuotaExceededError on 403 response' do
+      stub_request(:post, 'https://api.openai.example.com/v1/chat/completions')
+        .to_return(status: 403)
+
+      expect { service.translate(['Hello'], 'en', 'es') }.to raise_error(TranslationService::QuotaExceededError)
+    end
+
+    it 'raises UnexpectedResponseError on invalid JSON response' do
+      stub_request(:post, 'https://api.openai.example.com/v1/chat/completions')
+        .to_return(status: 200, body: 'not a json')
+
+      expect { service.translate(['Hello'], 'en', 'es') }.to raise_error(TranslationService::UnexpectedResponseError)
+    end
+
+    it 'raises UnexpectedResponseError on unexpected response structure' do
+      stub_request(:post, 'https://api.openai.example.com/v1/chat/completions')
+        .to_return(status: 200, body: '{"something": "unexpected"}')
+
+      expect { service.translate(['Hello'], 'en', 'es') }.to raise_error(TranslationService::UnexpectedResponseError)
+    end
+  end
+
+  describe 'with no API key' do
+    subject(:service) { described_class.new('https://api.openai.example.com', nil, 'gpt-3.5-turbo') }
+
+    it 'does not include Authorization header when API key is nil' do
+      stub = stub_request(:post, 'https://api.openai.example.com/v1/chat/completions')
+             .with { |request| request.headers['Authorization'].nil? }
+             .to_return(body: '{"choices":[{"message":{"content":"Translation"}}]}')
+
+      service.translate(['Hello'], 'en', 'es')
+      expect(stub).to have_been_requested
+    end
+  end
+end


### PR DESCRIPTION
### Changes proposed in this PR:
- A new status translation service, in addition to LibreTranslate and DeepL, that allows the use of a LLM
- It implements the commonly used OpenAI API, meaning it can be used with almost any provider or locally with Ollama

#### Limitations
- Since language support, while very high, varies model by model, function `languages` just returns all languages, except regional variants, supported by Mastodon
- Poor models might ignore instructions and remove HTML or return not just the translated text