### PR TITLE
Make account header profile pic exactly 2x post profile pic

### DIFF
--- a/app/javascript/mastodon/features/account_timeline/components/account_header.tsx
+++ b/app/javascript/mastodon/features/account_timeline/components/account_header.tsx
@@ -873,7 +873,7 @@ export const AccountHeader: React.FC<{
             >
               <Avatar
                 account={suspended || hidden ? undefined : account}
-                size={90}
+                size={92}
               />
             </a>
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -7963,7 +7963,6 @@ noscript {
     .avatar {
       display: block;
       flex: 0 0 auto;
-      width: 94px;
 
       .account__avatar {
         background: var(--background-color);


### PR DESCRIPTION
Simply sets the account header profile picture size to 92x instead of 94px/90px to ensure it's 2x the size of the profile picture shown next to posts. This will help address scaling inperfections for peeps with pixel art profile pictures.

Resolves https://github.com/mastodon/mastodon/issues/34802

While I did not specifically :tophat: this change I did take a look at the current state of profile picture sizes and the discrepencies mentioned in the original issue above do line up as noted.

Account header (various sizes other than 92px)
![Screenshot From 2025-05-26 15-19-35](https://github.com/user-attachments/assets/d95a7349-84a6-4dca-ae5c-21ee55c1b617)
![Screenshot From 2025-05-26 15-19-47](https://github.com/user-attachments/assets/1a17f70c-463d-45a6-bd2e-598955c24524)
![Screenshot From 2025-05-26 15-19-56](https://github.com/user-attachments/assets/a7cde44c-9c9d-40e6-88a9-7836002aecb9)

Post (specifically 46px)
![Screenshot From 2025-05-26 15-31-36](https://github.com/user-attachments/assets/654edb2d-534c-40f5-8614-e176419b7166)
