### PR TITLE
Remove unnecessary direct dependency to `glob`

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "emoji-mart": "npm:emoji-mart-lazyload@latest",
     "escape-html": "^1.0.3",
     "fuzzysort": "^3.0.0",
-    "glob": "^10.2.6",
     "history": "^4.10.1",
     "hoist-non-react-statics": "^3.3.2",
     "http-link-header": "^1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2514,7 +2514,6 @@ __metadata:
     eslint-plugin-react: "npm:^7.37.4"
     eslint-plugin-react-hooks: "npm:^5.2.0"
     fuzzysort: "npm:^3.0.0"
-    glob: "npm:^10.2.6"
     globals: "npm:^16.0.0"
     history: "npm:^4.10.1"
     hoist-non-react-statics: "npm:^3.3.2"
@@ -6919,7 +6918,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^10.2.2, glob@npm:^10.2.6, glob@npm:^10.3.10":
+"glob@npm:^10.2.2, glob@npm:^10.3.10":
   version: 10.4.5
   resolution: "glob@npm:10.4.5"
   dependencies:


### PR DESCRIPTION
This was used in our webpack code, but now the equivalent globbing is done by our `vite-plugin-ruby` dependency, using the `fast-glob` package.