### PR TITLE
Fix `NoMethodError` in `ActivityPub::FetchFeaturedCollectionService`

### DIFF
--- a/app/services/activitypub/fetch_featured_collection_service.rb
+++ b/app/services/activitypub/fetch_featured_collection_service.rb
@@ -9,6 +9,7 @@ class ActivityPub::FetchFeaturedCollectionService < BaseService
     @account = account
     @options = options
     @json    = fetch_collection(options[:collection].presence || @account.featured_collection_url)
+    return if @json.blank?
 
     process_items(collection_items(@json))
   end


### PR DESCRIPTION
Follow-up to #34789

The removed check for `supported_context?(@json)` also covered `@json` being `nil`, which may happen with some HTTP responses, or the collection being hosted on another domain than the author.