### PR TITLE
Add Git repository information to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,12 @@ FROM ${BASE_REGISTRY}/ruby:${RUBY_VERSION}-slim-${DEBIAN_VERSION} AS ruby
 ARG MASTODON_VERSION_PRERELEASE=""
 # Append build metadata or fork information to version.rb [--build-arg MASTODON_VERSION_METADATA="pr-123456"]
 ARG MASTODON_VERSION_METADATA=""
+# GitHub repository to use for 'View source code' link in Mastodon footer [--build-arg GITHUB_REPOSITORY="mastodon/mastodon"]
+ARG GITHUB_REPOSITORY=""
+# Git repository URL to use for 'View source code' link in Mastodon footer [--build-arg SOURCE_BASE_URL="https://github.com/$GITHUB_REPOSITORY"]
+ARG SOURCE_BASE_URL=""
+# Precise tag or branch to use for 'View source code' link in Mastodon footer [--build-arg SOURCE_TAG="v4.3.2"]
+ARG SOURCE_TAG=""
 # Will be available as Mastodon::Version.source_commit
 ARG SOURCE_COMMIT=""
 
@@ -50,6 +56,9 @@ ARG GID="991"
 ENV \
   MASTODON_VERSION_PRERELEASE="${MASTODON_VERSION_PRERELEASE}" \
   MASTODON_VERSION_METADATA="${MASTODON_VERSION_METADATA}" \
+  GITHUB_REPOSITORY="${GITHUB_REPOSITORY}" \
+  SOURCE_BASE_URL="${SOURCE_BASE_URL}" \
+  SOURCE_TAG="${SOURCE_TAG}" \
   SOURCE_COMMIT="${SOURCE_COMMIT}" \
   RAILS_SERVE_STATIC_FILES="${RAILS_SERVE_STATIC_FILES}" \
   RUBY_YJIT_ENABLE="${RUBY_YJIT_ENABLE}" \

--- a/config/mastodon.yml
+++ b/config/mastodon.yml
@@ -9,7 +9,7 @@ shared:
     environment: <%= ENV.fetch('DONATION_CAMPAIGNS_ENVIRONMENT', nil)&.to_json %>
   source:
     base_url: <%= ENV.fetch('SOURCE_BASE_URL', nil)&.to_json %>
-    repository: <%= ENV.fetch('GITHUB_REPOSITORY', 'mastodon/mastodon') %>
+    repository: <%= ENV.fetch('GITHUB_REPOSITORY', nil).presence || 'mastodon/mastodon' %>
     tag: <%= ENV.fetch('SOURCE_TAG', nil) %>
   version:
     metadata: <%= ENV.fetch('MASTODON_VERSION_METADATA', nil)&.to_json %>


### PR DESCRIPTION
This PR focuses on improving the ability to finely adjust the ‘View source code’ link in the footer of Mastodon without any separate source code modifications. It enhances flexibility when deploying with custom repositories or tags/branches by providing the following new build arguments and corresponding environment variables:

- `GITHUB_REPOSITORY`: Specifies a custom GitHub repository.  
    (Example: `mastodon/mastodon`)
- `SOURCE_BASE_URL`: Specifies a custom Git base URL.  
    (Example: `https://github.com/$GITHUB_REPOSITORY`)
- `SOURCE_TAG`: Specifies a custom tag/branch to provide more precise links.  
    (Example: `v4.3.2`)

~~The behaviour of setting defaults in `config/mastodon.yml` did not work when `GITHUB_REPOSITORY=""` was set to an empty string. Therefore, this behavior has been changed to set it to `nil`, and the default values are now determined in `lib/mastodon/version.rb`.~~

The default value setting behavior in `config/mastodon.yml` did not work when set to a blank value like `GITHUB_REPOSITORY=""`, so as mentioned in https://github.com/mastodon/mastodon/pull/34818#discussion_r2124047231, I changed the behavior to use `presence`.