### PR TITLE
Add language picker to server rules section

### DIFF
--- a/app/javascript/mastodon/components/dropdown_selector.tsx
+++ b/app/javascript/mastodon/components/dropdown_selector.tsx
@@ -18,7 +18,7 @@ export interface SelectItem {
   icon?: string;
   iconComponent?: IconProp;
   text: string;
-  meta: string;
+  meta?: string;
   extra?: string;
 }
 

--- a/app/javascript/mastodon/features/about/components/rules.tsx
+++ b/app/javascript/mastodon/features/about/components/rules.tsx
@@ -1,0 +1,139 @@
+import { useCallback, useMemo, useState } from 'react';
+import type { ChangeEventHandler, FC } from 'react';
+
+import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
+
+import { createSelector } from '@reduxjs/toolkit';
+import type { List as ImmutableList } from 'immutable';
+
+import type { SelectItem } from '@/mastodon/components/dropdown_selector';
+import type { RootState } from '@/mastodon/store';
+import { useAppSelector } from '@/mastodon/store';
+
+import { Section } from './section';
+
+const messages = defineMessages({
+  rules: { id: 'about.rules', defaultMessage: 'Server rules' },
+  defaultLocale: { id: 'about.default_locale', defaultMessage: 'Default' },
+});
+
+interface RulesSectionProps {
+  isLoading?: boolean;
+}
+
+interface BaseRule {
+  text: string;
+  hint: string;
+}
+
+interface Rule extends BaseRule {
+  id: string;
+  translations: Record<string, BaseRule>;
+}
+
+const rulesSelector = createSelector(
+  [
+    (state: RootState) =>
+      state.server.getIn(['server', 'rules']) as ImmutableList<Rule> | null,
+  ],
+  (rules) => (rules?.toJS() ?? []) as Rule[],
+);
+
+export const RulesSection: FC<RulesSectionProps> = ({ isLoading = false }) => {
+  const intl = useIntl();
+  const rules = useAppSelector(rulesSelector);
+  const [locale, setLocale] = useState(intl.locale);
+  const localeOptions: SelectItem[] = useMemo(() => {
+    const langs: Record<string, SelectItem> = {
+      default: {
+        value: 'default',
+        text: intl.formatMessage(messages.defaultLocale),
+      },
+    };
+    // Use the default locale as a target to translate language names.
+    const intlLocale = new Intl.DisplayNames(intl.locale, {
+      type: 'language',
+    });
+    for (const { translations } of rules) {
+      for (const locale in translations) {
+        if (langs[locale]) {
+          continue; // Skip if already added
+        }
+        langs[locale] = {
+          value: locale,
+          text: intlLocale.of(locale) ?? locale,
+        };
+      }
+    }
+    return Object.values(langs);
+  }, [intl, rules]);
+  const handleLocaleChange: ChangeEventHandler<HTMLSelectElement> = useCallback(
+    (e) => {
+      setLocale(e.currentTarget.value);
+    },
+    [],
+  );
+
+  if (isLoading) {
+    return <Section title={intl.formatMessage(messages.rules)} />;
+  }
+
+  if (rules.length === 0) {
+    return (
+      <Section title={intl.formatMessage(messages.rules)}>
+        <p>
+          <FormattedMessage
+            id='about.not_available'
+            defaultMessage='This information has not been made available on this server.'
+          />
+        </p>
+      </Section>
+    );
+  }
+
+  return (
+    <Section title={intl.formatMessage(messages.rules)}>
+      <ol className='rules-list'>
+        {rules.map((rule) => {
+          const firstLocale = locale.split('-')[0] ?? '';
+          /* eslint-disable @typescript-eslint/prefer-nullish-coalescing -- Safer to use conditionals. */
+          const text =
+            rule.translations[locale]?.text ||
+            rule.translations[firstLocale]?.text ||
+            rule.text;
+          const hint =
+            rule.translations[locale]?.hint ||
+            rule.translations[firstLocale]?.hint ||
+            rule.hint;
+          /* eslint-enable */
+          return (
+            <li key={rule.id}>
+              <div className='rules-list__text'>{text}</div>
+              {!!hint && <div className='rules-list__hint'>{hint}</div>}
+            </li>
+          );
+        })}
+      </ol>
+
+      <div className='rules-languages'>
+        <label htmlFor='language-select'>
+          <FormattedMessage
+            id='about.language_label'
+            defaultMessage='Language'
+          />
+        </label>
+        <select onChange={handleLocaleChange} id='language-select'>
+          {localeOptions.map((option) => (
+            <option
+              key={option.value}
+              value={option.value}
+              selected={option.value === locale}
+            >
+              {option.text}
+            </option>
+          ))}
+        </select>
+      </div>
+    </Section>
+  );
+};

--- a/app/javascript/mastodon/features/about/components/section.tsx
+++ b/app/javascript/mastodon/features/about/components/section.tsx
@@ -1,0 +1,45 @@
+import type { FC, MouseEventHandler } from 'react';
+import { useCallback, useState } from 'react';
+
+import classNames from 'classnames';
+
+import { Icon } from '@/mastodon/components/icon';
+import ChevronRightIcon from '@/material-icons/400-24px/chevron_right.svg?react';
+import ExpandMoreIcon from '@/material-icons/400-24px/expand_more.svg?react';
+
+interface SectionProps {
+  title: string;
+  children?: React.ReactNode;
+  open?: boolean;
+  onOpen?: () => void;
+}
+
+export const Section: FC<SectionProps> = ({
+  title,
+  children,
+  open = false,
+  onOpen,
+}) => {
+  const [collapsed, setCollapsed] = useState(!open);
+  const handleClick: MouseEventHandler = useCallback(() => {
+    setCollapsed((prev) => !prev);
+    onOpen?.();
+  }, [onOpen]);
+  return (
+    <div className={classNames('about__section', { active: !collapsed })}>
+      <button
+        className='about__section__title'
+        tabIndex={0}
+        onClick={handleClick}
+      >
+        <Icon
+          id={collapsed ? 'chevron-right' : 'chevron-down'}
+          icon={collapsed ? ChevronRightIcon : ExpandMoreIcon}
+        />{' '}
+        {title}
+      </button>
+
+      {!collapsed && <div className='about__section__body'>{children}</div>}
+    </div>
+  );
+};

--- a/app/javascript/mastodon/features/about/index.jsx
+++ b/app/javascript/mastodon/features/about/index.jsx
@@ -3,26 +3,23 @@ import { PureComponent } from 'react';
 
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
 
-import classNames from 'classnames';
 import { Helmet } from 'react-helmet';
 
-import { List as ImmutableList } from 'immutable';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
 
-import ChevronRightIcon from '@/material-icons/400-24px/chevron_right.svg?react';
-import ExpandMoreIcon from '@/material-icons/400-24px/expand_more.svg?react';
 import { fetchServer, fetchExtendedDescription, fetchDomainBlocks  } from 'mastodon/actions/server';
 import { Account } from 'mastodon/components/account';
 import Column from 'mastodon/components/column';
-import { Icon  }  from 'mastodon/components/icon';
 import { ServerHeroImage } from 'mastodon/components/server_hero_image';
 import { Skeleton } from 'mastodon/components/skeleton';
 import { LinkFooter} from 'mastodon/features/ui/components/link_footer';
 
+import { Section } from './components/section';
+import { RulesSection } from './components/rules';
+
 const messages = defineMessages({
   title: { id: 'column.about', defaultMessage: 'About' },
-  rules: { id: 'about.rules', defaultMessage: 'Server rules' },
   blocks: { id: 'about.blocks', defaultMessage: 'Moderated servers' },
   silenced: { id: 'about.domain_blocks.silenced.title', defaultMessage: 'Limited' },
   silencedExplanation: { id: 'about.domain_blocks.silenced.explanation', defaultMessage: 'You will generally not see profiles and content from this server, unless you explicitly look it up or opt into it by following.' },
@@ -48,45 +45,6 @@ const mapStateToProps = state => ({
   extendedDescription: state.getIn(['server', 'extendedDescription']),
   domainBlocks: state.getIn(['server', 'domainBlocks']),
 });
-
-class Section extends PureComponent {
-
-  static propTypes = {
-    title: PropTypes.string,
-    children: PropTypes.node,
-    open: PropTypes.bool,
-    onOpen: PropTypes.func,
-  };
-
-  state = {
-    collapsed: !this.props.open,
-  };
-
-  handleClick = () => {
-    const { onOpen } = this.props;
-    const { collapsed } = this.state;
-
-    this.setState({ collapsed: !collapsed }, () => onOpen && onOpen());
-  };
-
-  render () {
-    const { title, children } = this.props;
-    const { collapsed } = this.state;
-
-    return (
-      <div className={classNames('about__section', { active: !collapsed })}>
-        <div className='about__section__title' role='button' tabIndex={0} onClick={this.handleClick}>
-          <Icon id={collapsed ? 'chevron-right' : 'chevron-down'} icon={collapsed ? ChevronRightIcon : ExpandMoreIcon} /> {title}
-        </div>
-
-        {!collapsed && (
-          <div className='about__section__body'>{children}</div>
-        )}
-      </div>
-    );
-  }
-
-}
 
 class About extends PureComponent {
 
@@ -165,23 +123,7 @@ class About extends PureComponent {
             ))}
           </Section>
 
-          <Section title={intl.formatMessage(messages.rules)}>
-            {!isLoading && (server.get('rules', ImmutableList()).isEmpty() ? (
-              <p><FormattedMessage id='about.not_available' defaultMessage='This information has not been made available on this server.' /></p>
-            ) : (
-              <ol className='rules-list'>
-                {server.get('rules').map(rule => {
-                  const text = rule.getIn(['translations', locale, 'text']) || rule.getIn(['translations', locale.split('-')[0], 'text']) || rule.get('text');
-                  const hint = rule.getIn(['translations', locale, 'hint']) || rule.getIn(['translations', locale.split('-')[0], 'hint']) || rule.get('hint');
-                  return (
-                    <li key={rule.get('id')}>
-                      <div className='rules-list__text'>{text}</div>
-                      {hint.length > 0 && (<div className='rules-list__hint'>{hint}</div>)}
-                    </li>
-                  )})}
-              </ol>
-            ))}
-          </Section>
+          <RulesSection />
 
           <Section title={intl.formatMessage(messages.blocks)} onOpen={this.handleDomainBlocksOpen}>
             {domainBlocks.get('isLoading') ? (

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -1,6 +1,7 @@
 {
   "about.blocks": "Moderated servers",
   "about.contact": "Contact:",
+  "about.default_locale": "Default",
   "about.disclaimer": "Mastodon is free, open-source software, and a trademark of Mastodon gGmbH.",
   "about.domain_blocks.no_reason_available": "Reason not available",
   "about.domain_blocks.preamble": "Mastodon generally allows you to view content from and interact with users from any other server in the fediverse. These are the exceptions that have been made on this particular server.",
@@ -8,6 +9,7 @@
   "about.domain_blocks.silenced.title": "Limited",
   "about.domain_blocks.suspended.explanation": "No data from this server will be processed, stored or exchanged, making any interaction or communication with users from this server impossible.",
   "about.domain_blocks.suspended.title": "Suspended",
+  "about.language_label": "Language",
   "about.not_available": "This information has not been made available on this server.",
   "about.powered_by": "Decentralized social media powered by {mastodon}",
   "about.rules": "Server rules",

--- a/app/javascript/styles/mastodon/about.scss
+++ b/app/javascript/styles/mastodon/about.scss
@@ -93,3 +93,39 @@ $fluid-breakpoint: $maximum-width + 20px;
     color: $darker-text-color;
   }
 }
+
+.rules-languages {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+
+  > label {
+    font-size: 14px;
+    font-weight: 600;
+    color: $primary-text-color;
+  }
+
+  > select {
+    appearance: none;
+    box-sizing: border-box;
+    font-size: 14px;
+    color: $primary-text-color;
+    display: block;
+    width: 100%;
+    outline: 0;
+    font-family: inherit;
+    resize: vertical;
+    background: $ui-base-color
+      url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14.933 18.467' height='19.698' width='15.929'><path d='M3.467 14.967l-3.393-3.5H14.86l-3.392 3.5c-1.866 1.925-3.666 3.5-4 3.5-.335 0-2.135-1.575-4-3.5zm.266-11.234L7.467 0 11.2 3.733l3.733 3.734H0l3.733-3.734z' fill='#{hex-color(lighten($ui-base-color, 12%))}'/></svg>")
+      no-repeat right 8px center / auto 14px;
+    border: 1px solid var(--background-border-color);
+    border-radius: 4px;
+    padding-inline-start: 10px;
+    padding-inline-end: 30px;
+    height: 41px;
+
+    @media screen and (width <= 600px) {
+      font-size: 16px;
+    }
+  }
+}

--- a/app/javascript/styles/mastodon/about.scss
+++ b/app/javascript/styles/mastodon/about.scss
@@ -98,6 +98,7 @@ $fluid-breakpoint: $maximum-width + 20px;
   display: flex;
   gap: 1rem;
   align-items: center;
+  position: relative;
 
   > label {
     font-size: 14px;
@@ -115,9 +116,7 @@ $fluid-breakpoint: $maximum-width + 20px;
     outline: 0;
     font-family: inherit;
     resize: vertical;
-    background: $ui-base-color
-      url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14.933 18.467' height='19.698' width='15.929'><path d='M3.467 14.967l-3.393-3.5H14.86l-3.392 3.5c-1.866 1.925-3.666 3.5-4 3.5-.335 0-2.135-1.575-4-3.5zm.266-11.234L7.467 0 11.2 3.733l3.733 3.734H0l3.733-3.734z' fill='#{hex-color(lighten($ui-base-color, 12%))}'/></svg>")
-      no-repeat right 8px center / auto 14px;
+    background: $ui-base-color;
     border: 1px solid var(--background-border-color);
     border-radius: 4px;
     padding-inline-start: 10px;
@@ -126,6 +125,26 @@ $fluid-breakpoint: $maximum-width + 20px;
 
     @media screen and (width <= 600px) {
       font-size: 16px;
+    }
+  }
+
+  &::after {
+    --lighten: 12;
+
+    display: block;
+    position: absolute;
+    width: 15px;
+    height: 15px;
+    content: '';
+    mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='14.933' height='18.467' viewBox='0 0 14.933 18.467'><path d='M3.467 14.967l-3.393-3.5H14.86l-3.392 3.5c-1.866 1.925-3.666 3.5-4 3.5-.335 0-2.135-1.575-4-3.5zm.266-11.234L7.467 0 11.2 3.733l3.733 3.734H0l3.733-3.734z' fill='currentColor' /></svg>")
+      no-repeat 50% 50%;
+    mask-size: contain;
+    right: 8px;
+    background-color: hsl(from $ui-base-color h s calc(l + var(--lighten)));
+    pointer-events: none;
+
+    .theme-mastodon-light & {
+      --lighten: -12;
     }
   }
 }

--- a/app/javascript/styles/mastodon/about.scss
+++ b/app/javascript/styles/mastodon/about.scss
@@ -1,4 +1,5 @@
 @use 'variables' as *;
+@use 'functions' as *;
 
 $maximum-width: 1235px;
 $fluid-breakpoint: $maximum-width + 20px;
@@ -129,8 +130,6 @@ $fluid-breakpoint: $maximum-width + 20px;
   }
 
   &::after {
-    --lighten: 12;
-
     display: block;
     position: absolute;
     width: 15px;
@@ -140,11 +139,7 @@ $fluid-breakpoint: $maximum-width + 20px;
       no-repeat 50% 50%;
     mask-size: contain;
     right: 8px;
-    background-color: hsl(from $ui-base-color h s calc(l + var(--lighten)));
+    background-color: lighten($ui-base-color, 12%);
     pointer-events: none;
-
-    .theme-mastodon-light & {
-      --lighten: -12;
-    }
   }
 }

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -9848,6 +9848,8 @@ noscript {
       border: 1px solid var(--background-border-color);
       color: $highlight-text-color;
       cursor: pointer;
+      width: 100%;
+      background: none;
     }
 
     &.active &__title {


### PR DESCRIPTION
With the new multi-language server rules, we want people the ability to view the different languages.

This refactors the About page components to break out sections and the rules section in particular, and adds the dropdown.

Default theme
![Screenshot 2025-05-27 at 14 51 01](https://github.com/user-attachments/assets/cc2afb07-7afd-4c79-94fe-f213608f1137)

Light theme
![Screenshot 2025-05-27 at 14 50 36](https://github.com/user-attachments/assets/58395ab8-443f-4d40-b230-f54eee765250)


Multi-lingual language names
![Screenshot 2025-05-27 at 12 23 59](https://github.com/user-attachments/assets/16b9ba1b-cc31-4ca0-9124-216575b9a46b)

