### PR TITLE
Assert usage of client credentials for account registration

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -50,6 +50,10 @@ class Api::BaseController < ApplicationController
     nil
   end
 
+  def require_client_credentials!
+    render json: { error: 'This method requires an client credentials authentication' }, status: 403 if doorkeeper_token.resource_owner_id.present?
+  end
+
   def require_authenticated_user!
     render json: { error: 'This method requires an authenticated user' }, status: 401 unless current_user
   end

--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -10,6 +10,7 @@ class Api::V1::AccountsController < Api::BaseController
   before_action -> { doorkeeper_authorize! :write, :'write:accounts' }, only: [:create]
 
   before_action :require_user!, except: [:index, :show, :create]
+  before_action :require_client_credentials!, only: [:create]
   before_action :set_account, except: [:index, :create]
   before_action :set_accounts, only: [:index]
   before_action :check_account_approval, except: [:index, :create]

--- a/spec/fabricators/client_credentials_token_fabricator.rb
+++ b/spec/fabricators/client_credentials_token_fabricator.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Fabricator :client_credentials_token, from: :access_token do
+  resource_owner_id { nil }
+  expires_in { nil }
+  revoked_at { nil }
+end

--- a/spec/fabricators/client_credentials_token_fabricator.rb
+++ b/spec/fabricators/client_credentials_token_fabricator.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-Fabricator :client_credentials_token, from: :access_token do
+Fabricator :client_credentials_token, from: :accessible_access_token do
   resource_owner_id { nil }
-  expires_in { nil }
-  revoked_at { nil }
 end

--- a/spec/requests/api/v1/accounts_spec.rb
+++ b/spec/requests/api/v1/accounts_spec.rb
@@ -78,9 +78,26 @@ RSpec.describe '/api/v1/accounts' do
     end
 
     let(:client_app) { Fabricate(:application) }
-    let(:token) { Doorkeeper::AccessToken.find_or_create_for(application: client_app, resource_owner: nil, scopes: 'read write', use_refresh_token: false) }
+    let(:token) { Fabricate(:client_credentials_token, application: client_app, scopes: 'read write') }
     let(:agreement) { nil }
     let(:date_of_birth) { nil }
+
+    context 'when not using client credentials token' do
+      let(:token) { Fabricate(:accessible_access_token, application: client_app, scopes: 'read write', resource_owner_id: user.id) }
+
+      it 'returns http forbidden error' do
+        subject
+
+        expect(response).to have_http_status(403)
+        expect(response.content_type)
+          .to start_with('application/json')
+
+        expect(response.parsed_body)
+          .to include(
+            error: 'This method requires an client credentials authentication'
+          )
+      end
+    end
 
     context 'when age verification is enabled' do
       before do


### PR DESCRIPTION
This prohibits the usage of a User's access token being used to register additional accounts, and instead forces using the client credentials grant type for account registration.

Doorkeeper notes:
- `doorkeeper_token.resource_owner_id` will be set to the user's ID if the access token was obtained via the authorization code grant flow, but will be nil if the access token was obtained via client credentials grant flow.
- this assertion more strongly matches the [documented API](https://docs.joinmastodon.org/methods/accounts/#create), which is that this endpoint requires a App Token (client credential).

Previously this would have allowed a user-scoped access token to register a new account, which I don't think is what we intended here, as we only really want applications to be registering new accounts.