### PR TITLE
Fix `Style/FetchEnvVar` cop in devise config

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -39,7 +39,6 @@ Style/FetchEnvVar:
     - 'config/initializers/2_limited_federation_mode.rb'
     - 'config/initializers/3_omniauth.rb'
     - 'config/initializers/cache_buster.rb'
-    - 'config/initializers/devise.rb'
     - 'config/initializers/paperclip.rb'
     - 'config/initializers/vapid.rb'
     - 'lib/tasks/repo.rake'

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -377,7 +377,7 @@ Devise.setup do |config|
     config.usernamefield          = nil
     config.emailfield             = 'email'
     config.check_at_sign          = true
-    config.pam_default_suffix     = ENV.fetch('PAM_EMAIL_DOMAIN') { ENV['LOCAL_DOMAIN'] }
+    config.pam_default_suffix     = ENV.fetch('PAM_EMAIL_DOMAIN') { ENV.fetch('LOCAL_DOMAIN', nil) }
     config.pam_default_service    = ENV.fetch('PAM_DEFAULT_SERVICE') { 'rpam' }
     config.pam_controlled_service = ENV.fetch('PAM_CONTROLLED_SERVICE', nil).presence
   end


### PR DESCRIPTION
Same idea as https://github.com/mastodon/mastodon/pull/34844 - just do minimum to auto-correct.

Probably similar future improvement here, re: potentially moving some of the PAM and/or LDAP setup from this file into a `config_for` loader ... though would have to contemplate how to cleanly do that and set these config options, since it's not just one big hash.