### PR TITLE
Update `rack-cors` to version 3.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ gem 'premailer-rails'
 gem 'public_suffix', '~> 6.0'
 gem 'pundit', '~> 2.3'
 gem 'rack-attack', '~> 6.6'
-gem 'rack-cors', '~> 2.0', require: 'rack/cors'
+gem 'rack-cors', require: 'rack/cors'
 gem 'rails-i18n', '~> 8.0'
 gem 'redcarpet', '~> 3.6'
 gem 'redis', '~> 4.5', require: ['redis', 'redis/connection/hiredis']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -636,8 +636,9 @@ GEM
     rack (3.1.15)
     rack-attack (6.7.0)
       rack (>= 1.0, < 4)
-    rack-cors (2.0.2)
-      rack (>= 2.0.0)
+    rack-cors (3.0.0)
+      logger
+      rack (>= 3.0.14)
     rack-oauth2 (2.2.1)
       activesupport
       attr_required
@@ -1046,7 +1047,7 @@ DEPENDENCIES
   puma (~> 6.3)
   pundit (~> 2.3)
   rack-attack (~> 6.6)
-  rack-cors (~> 2.0)
+  rack-cors
   rack-test (~> 2.1)
   rails (~> 8.0)
   rails-i18n (~> 8.0)


### PR DESCRIPTION
The [rack-cors 3.0 bump](https://github.com/cyu/rack-cors/compare/v2.0.2...v3.0.0) requires rack 3, which we now can satisfy, and drops support for old ruby that we already don't support. Should be safe.