### PR TITLE
Update `fabrication` to version 3.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -201,7 +201,7 @@ group :development, :test do
   gem 'faker', '~> 3.2'
 
   # Generate factory objects
-  gem 'fabrication', '~> 2.30'
+  gem 'fabrication'
 
   # Profiling tools
   gem 'memory_profiler', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,7 +223,7 @@ GEM
       tzinfo
     excon (1.2.5)
       logger
-    fabrication (2.31.0)
+    fabrication (3.0.0)
     faker (3.5.1)
       i18n (>= 1.8.11, < 2)
     faraday (2.13.1)
@@ -972,7 +972,7 @@ DEPENDENCIES
   doorkeeper (~> 5.6)
   dotenv
   email_spec
-  fabrication (~> 2.30)
+  fabrication
   faker (~> 3.2)
   faraday-httpclient
   fast_blank (~> 1.0)


### PR DESCRIPTION
This major version bump is also almost entirely just dropping support for old ruby/rails versions -- https://gitlab.com/fabrication-gem/fabrication/-/compare/2.31.0...3.0.0