### PR TITLE
Fix pinned carousel scroll on mobile

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -11044,7 +11044,7 @@ noscript {
   overflow: hidden;
   flex-shrink: 0;
   border-bottom: 1px solid var(--background-border-color);
-  touch-action: pan-x;
+  touch-action: pan-y;
 
   &__slides {
     display: flex;


### PR DESCRIPTION
Fixes #34852. The direction on the `touch-action` attribute was incorrect.