### PR TITLE
Increase capybara default timeout to reduce test flakiness

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -30,6 +30,10 @@ end
 
 Capybara.javascript_driver = :headless_chrome
 
+# Some of the flaky tests seem to be caused by github runners being too slow for the
+# default timeout of 2 seconds
+Capybara.default_max_wait_time = 8
+
 RSpec.configure do |config|
   config.before(:each, type: :system) do
     driven_by :rack_test


### PR DESCRIPTION
I have been investigating e2e test flakiness, and while I don't have a good explanation of some of them, I was able to reliably reproduce some of the common test failures by reducing Capybara's default wait time, suggesting that some of the test failures may simply be due to Github runner performance.