### PR TITLE
Fix `Style/FetchEnvVar` cop in omniauth config

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -36,7 +36,6 @@ Rails/OutputSafety:
 Style/FetchEnvVar:
   Exclude:
     - 'config/initializers/2_limited_federation_mode.rb'
-    - 'config/initializers/3_omniauth.rb'
     - 'config/initializers/paperclip.rb'
     - 'lib/tasks/repo.rake'
 

--- a/config/initializers/3_omniauth.rb
+++ b/config/initializers/3_omniauth.rb
@@ -12,7 +12,7 @@ Devise.setup do |config|
   # CAS strategy
   if ENV['CAS_ENABLED'] == 'true'
     cas_options = {}
-    cas_options[:display_name] = ENV['CAS_DISPLAY_NAME']
+    cas_options[:display_name] = ENV.fetch('CAS_DISPLAY_NAME', nil)
     cas_options[:url] = ENV['CAS_URL'] if ENV['CAS_URL']
     cas_options[:host] = ENV['CAS_HOST'] if ENV['CAS_HOST']
     cas_options[:port] = ENV['CAS_PORT'] if ENV['CAS_PORT']
@@ -41,7 +41,7 @@ Devise.setup do |config|
   # SAML strategy
   if ENV['SAML_ENABLED'] == 'true'
     saml_options = {}
-    saml_options[:display_name] = ENV['SAML_DISPLAY_NAME']
+    saml_options[:display_name] = ENV.fetch('SAML_DISPLAY_NAME', nil)
     saml_options[:assertion_consumer_service_url] = ENV['SAML_ACS_URL'] if ENV['SAML_ACS_URL']
     saml_options[:issuer] = ENV['SAML_ISSUER'] if ENV['SAML_ISSUER']
     saml_options[:idp_sso_target_url] = ENV['SAML_IDP_SSO_TARGET_URL'] if ENV['SAML_IDP_SSO_TARGET_URL']
@@ -73,7 +73,7 @@ Devise.setup do |config|
   # OpenID Connect Strategy
   if ENV['OIDC_ENABLED'] == 'true'
     oidc_options = {}
-    oidc_options[:display_name] = ENV['OIDC_DISPLAY_NAME'] # OPTIONAL
+    oidc_options[:display_name] = ENV.fetch('OIDC_DISPLAY_NAME', nil) # OPTIONAL
     oidc_options[:issuer] = ENV['OIDC_ISSUER'] if ENV['OIDC_ISSUER'] # NEED
     oidc_options[:discovery] = ENV['OIDC_DISCOVERY'] == 'true' if ENV['OIDC_DISCOVERY'] # OPTIONAL (default: false)
     oidc_options[:client_auth_method] = ENV['OIDC_CLIENT_AUTH_METHOD'] if ENV['OIDC_CLIENT_AUTH_METHOD'] # OPTIONAL (default: basic)


### PR DESCRIPTION
Similar to other recent ones, just doing auto-correct here.

This one definitely has a good opportunity for followup moving to `config_for` ... each of the (cas, saml, oidc) sections are just building big hashes which are then conditionally loaded.

Another good improvement would be to a) make the loading at all conditional on the "enabled" setting, and then b) use `ENV.fetch` and actually let it raise when required things are missing (as opposed to the "NEED" comments in the code now).