### PR TITLE
Fix inconsistent filtering of silenced accounts for other silenced accounts

### DIFF
--- a/app/lib/status_filter.rb
+++ b/app/lib/status_filter.rb
@@ -38,7 +38,7 @@ class StatusFilter
   end
 
   def silenced_account?
-    !account&.silenced? && status_account_silenced? && !account_following_status_account?
+    status_account_silenced? && !account_following_status_account?
   end
 
   def status_account_silenced?


### PR DESCRIPTION
Long ago, silenced accounts could see posts from other silenced accounts without filtering.

Before this PR, this was still the case in some specific contexts, but this was inconsistent.