### PR TITLE
Add coverage for `valid_locale_or_nil` languages helper method

### DIFF
--- a/spec/helpers/languages_helper_spec.rb
+++ b/spec/helpers/languages_helper_spec.rb
@@ -86,4 +86,40 @@ RSpec.describe LanguagesHelper do
       end
     end
   end
+
+  describe '#valid_locale_or_nil' do
+    subject { helper.valid_locale_or_nil(string) }
+
+    context 'when string is nil' do
+      let(:string) { nil }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when string is empty' do
+      let(:string) { '' }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when string is valid locale' do
+      let(:string) { 'en' }
+
+      it { is_expected.to eq('en') }
+    end
+
+    context 'when string contains region' do
+      context 'when base locale is valid' do
+        let(:string) { 'en-US' }
+
+        it { is_expected.to eq('en') }
+      end
+
+      context 'when base locale is not valid' do
+        let(:string) { 'qq-US' }
+
+        it { is_expected.to be_nil }
+      end
+    end
+  end
 end


### PR DESCRIPTION
Prior to this change, the full suite only exercises the first two guard clauses here, but not the actual region/locale resolution portion. Added coverage to hit full method.