### PR TITLE
Include matrix values in upload artifact names

### DIFF
--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -345,7 +345,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: e2e-screenshots
+          name: e2e-screenshots-${{ matrix.ruby-version }}
           path: tmp/capybara/
 
   test-search:


### PR DESCRIPTION
This is a maddening thing to have to optimize for, but we sometimes have multiple failures of the E2E tests (ie, 3.2 and 3.3 from the matrix), but they cant both upload their screenshot artifacts because the names collide.

Change here, borrowed from the log naming section right above it, includes the matrix ruby version value in the name, which hopefully prevents the collision and will capture all failing screenshots for later download.