### PR TITLE
Fix sidekiq health check in docker-compose for sidekiq 7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,7 +115,7 @@ services:
     volumes:
       - ./public/system:/mastodon/public/system
     healthcheck:
-      test: ['CMD-SHELL', "ps aux | grep '[s]idekiq\ 6' || false"]
+      test: ['CMD-SHELL', "ps aux | grep '[s]idekiq\ 7' || false"]
 
   ## Uncomment to enable federation with tor instances along with adding the following ENV variables
   ## http_hidden_proxy=http://privoxy:8118


### PR DESCRIPTION
#34745 updated sidekiq to v7, as a result the process name has also changed to 'sidekiq 7.x.x' and does't match the old grep regex anymore. The regex could probably also be changed to match `sidekiq [0-9]\.` or something but I went for the straight-forward fix