### PR TITLE
Revert "Remove cookie rotator (#32289)"

### DIFF
--- a/config/initializers/cookie_rotator.rb
+++ b/config/initializers/cookie_rotator.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# TODO: remove this file some time after 4.3.0
+
+Rails.application.config.after_initialize do
+  Rails.application.config.action_dispatch.cookies_rotations.tap do |cookies|
+    authenticated_encrypted_cookie_salt = Rails.application.config.action_dispatch.authenticated_encrypted_cookie_salt
+    signed_cookie_salt = Rails.application.config.action_dispatch.signed_cookie_salt
+
+    secret_key_base = Rails.application.secret_key_base
+
+    key_generator = ActiveSupport::KeyGenerator.new(
+      secret_key_base, iterations: 1000, hash_digest_class: OpenSSL::Digest::SHA1
+    )
+    key_len = ActiveSupport::MessageEncryptor.key_len
+
+    old_encrypted_secret = key_generator.generate_key(authenticated_encrypted_cookie_salt, key_len)
+    old_signed_secret = key_generator.generate_key(signed_cookie_salt)
+
+    cookies.rotate :encrypted, old_encrypted_secret
+    cookies.rotate :signed, old_signed_secret
+  end
+end


### PR DESCRIPTION
This reverts commit a139dac18ec6e50b35a51f664fd5b02b0f9f1c47.

See rationale in https://github.com/mastodon/mastodon/pull/32289#issuecomment-2930741732, basically this commit dropped Mastodon's ability to read pre-4.3.0 cookies, making it likely for users to lose their sessions if admins only briefly run 4.3, and move to 4.4 afterwards.