### PR TITLE
Fix `Rails/OutputSafety` cop from rubocop todo via inline disable

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -27,10 +27,6 @@ Metrics/CyclomaticComplexity:
 Metrics/PerceivedComplexity:
   Max: 27
 
-Rails/OutputSafety:
-  Exclude:
-    - 'config/initializers/simple_form.rb'
-
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowedVars.
 Style/FetchEnvVar:

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -5,7 +5,7 @@
 module AppendComponent
   def append(_wrapper_options = nil)
     @append ||= begin
-      options[:append].to_s.html_safe if options[:append].present?
+      options[:append].to_s.html_safe if options[:append].present? # rubocop:disable Rails/OutputSafety
     end
   end
 end
@@ -24,7 +24,7 @@ end
 module WarningHintComponent
   def warning_hint(_wrapper_options = nil)
     @warning_hint ||= begin
-      options[:warning_hint].to_s.html_safe if options[:warning_hint].present?
+      options[:warning_hint].to_s.html_safe if options[:warning_hint].present? # rubocop:disable Rails/OutputSafety
     end
   end
 end


### PR DESCRIPTION
I'm not sure of a better alternate approach, so I think inline disable is the right solution here ... matches what we do elsewhere with similar strings, and matches what the simpleform component docs do re: `html_safe`, https://github.com/heartcombo/simple_form?tab=readme-ov-file#custom-components