### PR TITLE
Increase capybara wait in CI env

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -30,9 +30,10 @@ end
 
 Capybara.javascript_driver = :headless_chrome
 
-# Some of the flaky tests seem to be caused by github runners being too slow for the
-# default timeout of 2 seconds
-Capybara.default_max_wait_time = 8
+if ENV['CI'].present?
+  # Reduce some intermittent failures from slow CI runner environment
+  Capybara.default_max_wait_time = 60
+end
 
 RSpec.configure do |config|
   config.before(:each, type: :system) do


### PR DESCRIPTION
I've converted https://github.com/mastodon/mastodon/pull/34867 to draft mode and have been experimenting with different things there to try to reduce the intermittent failures on the selenium/JS/system specs.

It's a little challenging to reliabily measure any changes because the failures are not consistent and the feedback loop is slow. However, "increase the wait time even more" seems to have helped a little bit ... and even if that's a false positive, it may be harmless to increase it even more? I tried some different values. This seems to be in the sweet spot of "large enough to actually help some execution, but low enough that it does not make the whole thing comically long for real failures".

This is extracted from that PR, and also follow-up on https://github.com/mastodon/mastodon/pull/34859

Change here also to only do this in CI env, and preserve faster (legit) failures locally.

The other useful things in various versions of that PR (some since removed/replaced/etc) were things like: a) add a before hook which viewed the about page and using a long wait, assert something from the js-generated DOM to be sure we're in a js-loaded state, b) more `expect(page)` dotted throughout between other steps, c) remove selenium and use playwright instead.

That last step was by far most impactful in terms of failure-free CI runs. May open that as followup to this.