### PR TITLE
Disable `Style/GuardClause` cop

### DIFF
--- a/.rubocop/style.yml
+++ b/.rubocop/style.yml
@@ -15,6 +15,9 @@ Style/FormatStringToken:
     merge:
       - AllowedMethods
 
+Style/GuardClause:
+  Enabled: false
+
 Style/HashAsLastArrayItem:
   Enabled: false
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -11,8 +11,3 @@
 Style/FetchEnvVar:
   Exclude:
     - 'config/initializers/paperclip.rb'
-
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: MinBodyLength, AllowConsecutiveConditionals.
-Style/GuardClause:
-  Enabled: false


### PR DESCRIPTION
This is used inconsistently enough that the todo generator just disables it entirely ... which I suspect means we actually have varied accepted styles on this, and should just turn off the rule and leave as a case-by-case thing as it implicitly is now.