### PR TITLE
Replace local vars with `let` in JS-enabled system specs

### DIFF
--- a/spec/system/account_notes_spec.rb
+++ b/spec/system/account_notes_spec.rb
@@ -11,13 +11,13 @@ RSpec.describe 'Account notes', :inline_jobs, :js, :streaming do
   let(:finished_onboarding) { true }
 
   let!(:other_account) { Fabricate(:account) }
+  let(:note_text) { 'This is a personal note' }
 
   before { as_a_logged_in_user }
 
   it 'can be written and viewed' do
     visit_profile(other_account)
 
-    note_text = 'This is a personal note'
     fill_in frontend_translations('account_note.placeholder'), with: note_text
 
     # This is a bit awkward since there is no button to save the change

--- a/spec/system/new_statuses_spec.rb
+++ b/spec/system/new_statuses_spec.rb
@@ -9,12 +9,12 @@ RSpec.describe 'NewStatuses', :inline_jobs, :js, :streaming do
   let(:password)            { 'password' }
   let(:confirmed_at)        { Time.zone.now }
   let(:finished_onboarding) { true }
+  let(:status_text) { 'This is a new status!' }
 
   before { as_a_logged_in_user }
 
   it 'can be posted' do
     visit_homepage
-    status_text = 'This is a new status!'
 
     within('.compose-form') do
       fill_in frontend_translations('compose_form.placeholder'), with: status_text


### PR DESCRIPTION
As part of https://github.com/mastodon/mastodon/pull/34867 I've had several hundred full E2E suite runs without failures. This is the one spec that did have a failure, and my guess is that the example filled in the field and sent `ctrl+enter` before the JS was ready to process that. So, this adds an assertion that some JS-rendered DOM portion is actually there, in hope to make it less likely for that to happen.

Also extracted local var to a `let`.

The playwright branch seems promising - going to continue doing partial suite runs there to see what other E2E stuff I can get to fail. Regular runs seem sufficiently more reliable there that I think finding failures might indicate actually async/load issues, rather than flaky runner/manager stuff.