### PR TITLE
fix: Fix unauthenticated familiar followers request, #34911

### DIFF
--- a/app/javascript/mastodon/features/account_timeline/hooks/familiar_followers.ts
+++ b/app/javascript/mastodon/features/account_timeline/hooks/familiar_followers.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 
 import { fetchAccountsFamiliarFollowers } from '@/mastodon/actions/accounts_familiar_followers';
+import { useIdentity } from '@/mastodon/identity_context';
 import { getAccountFamiliarFollowers } from '@/mastodon/selectors/accounts';
 import { useAppDispatch, useAppSelector } from '@/mastodon/store';
 import { me } from 'mastodon/initial_state';
@@ -14,14 +15,15 @@ export const useFetchFamiliarFollowers = ({
   const familiarFollowers = useAppSelector((state) =>
     accountId ? getAccountFamiliarFollowers(state, accountId) : null,
   );
+  const { signedIn } = useIdentity();
 
   const hasNoData = familiarFollowers === null;
 
   useEffect(() => {
-    if (hasNoData && accountId && accountId !== me) {
+    if (hasNoData && signedIn && accountId && accountId !== me) {
       void dispatch(fetchAccountsFamiliarFollowers({ id: accountId }));
     }
-  }, [dispatch, accountId, hasNoData]);
+  }, [dispatch, accountId, hasNoData, signedIn]);
 
   return {
     familiarFollowers: hasNoData ? [] : familiarFollowers,


### PR DESCRIPTION
Fixes #34911

### Changes proposed in this PR:
- Prevents a request for familiar followers in the hover card when not logged in