### PR TITLE
Ensure carousel slides don't overflow

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -11053,6 +11053,8 @@ noscript {
   &__slide {
     flex: 0 0 auto;
     flex-basis: 100%;
+    width: 100%;
+    overflow: hidden;
   }
 
   .status {


### PR DESCRIPTION
Fixes #34913. This forces slides to be 100% width, so they aren't wider than the parent space.