### PR TITLE
Add a way to easily unpin profiles from the featured account area

### DIFF
--- a/app/javascript/mastodon/actions/accounts.js
+++ b/app/javascript/mastodon/actions/accounts.js
@@ -2,6 +2,7 @@ import { browserHistory } from 'mastodon/components/router';
 import { debounceWithDispatchAndArguments } from 'mastodon/utils/debounce';
 
 import api, { getLinks } from '../api';
+import { me } from '../initial_state';
 
 import {
   followAccountSuccess, unfollowAccountSuccess,
@@ -12,6 +13,7 @@ import {
   blockAccountSuccess, unblockAccountSuccess,
   pinAccountSuccess, unpinAccountSuccess,
   fetchRelationshipsSuccess,
+  fetchEndorsedAccounts,
 } from './accounts_typed';
 import { importFetchedAccount, importFetchedAccounts } from './importer';
 
@@ -634,6 +636,7 @@ export function pinAccount(id) {
 
     api().post(`/api/v1/accounts/${id}/pin`).then(response => {
       dispatch(pinAccountSuccess({ relationship: response.data }));
+      dispatch(fetchEndorsedAccounts({ accountId: me }));
     }).catch(error => {
       dispatch(pinAccountFail(error));
     });
@@ -646,6 +649,7 @@ export function unpinAccount(id) {
 
     api().post(`/api/v1/accounts/${id}/unpin`).then(response => {
       dispatch(unpinAccountSuccess({ relationship: response.data }));
+      dispatch(fetchEndorsedAccounts({ accountId: me }));
     }).catch(error => {
       dispatch(unpinAccountFail(error));
     });

--- a/app/javascript/mastodon/components/account.tsx
+++ b/app/javascript/mastodon/components/account.tsx
@@ -12,6 +12,7 @@ import {
   muteAccount,
   unmuteAccount,
   followAccountSuccess,
+  unpinAccount,
 } from 'mastodon/actions/accounts';
 import { showAlertForError } from 'mastodon/actions/alerts';
 import { openModal } from 'mastodon/actions/modal';
@@ -60,16 +61,29 @@ const messages = defineMessages({
     id: 'account.open_original_page',
     defaultMessage: 'Open original page',
   },
+  unendorse: {
+    id: 'account.unendorse',
+    defaultMessage: "Don't feature on profile",
+  },
 });
 
-export const Account: React.FC<{
+interface AccountProps {
   size?: number;
   id: string;
   hidden?: boolean;
   minimal?: boolean;
   defaultAction?: 'block' | 'mute';
   withBio?: boolean;
-}> = ({ id, size = 46, hidden, minimal, defaultAction, withBio }) => {
+}
+
+export const Account: React.FC<AccountProps> = ({
+  id,
+  size = 46,
+  hidden,
+  minimal,
+  defaultAction,
+  withBio,
+}) => {
   const intl = useIntl();
   const { signedIn } = useIdentity();
   const account = useAppSelector((state) => state.accounts.get(id));
@@ -119,8 +133,6 @@ export const Account: React.FC<{
         },
       ];
     } else if (defaultAction !== 'block') {
-      arr = [];
-
       if (isRemote && accountUrl) {
         arr.push({
           text: intl.formatMessage(messages.openOriginalPage),
@@ -173,6 +185,18 @@ export const Account: React.FC<{
           text: intl.formatMessage(messages.addToLists),
           action: handleAddToLists,
         });
+
+        const handleUnendorse = () => {
+          if (relationship?.endorsed) {
+            dispatch(unpinAccount(id));
+          }
+        };
+        if (relationship?.endorsed) {
+          arr.push({
+            text: intl.formatMessage(messages.unendorse),
+            action: handleUnendorse,
+          });
+        }
       }
     }
 

--- a/app/javascript/mastodon/components/account.tsx
+++ b/app/javascript/mastodon/components/account.tsx
@@ -183,22 +183,24 @@ export const Account: React.FC<AccountProps> = ({
           action: handleAddToLists,
         });
 
-        const handleEndorseToggle = () => {
-          if (relationship?.endorsed) {
-            dispatch(unpinAccount(id));
-          } else {
-            dispatch(pinAccount(id));
-          }
-        };
-        arr.push({
-          text: intl.formatMessage(
-            // Defined in features/account_timeline/components/account_header.tsx
-            relationship?.endorsed
-              ? { id: 'account.unendorse' }
-              : { id: 'account.endorse' },
-          ),
-          action: handleEndorseToggle,
-        });
+        if (id !== me && (relationship?.following || relationship?.requested)) {
+          const handleEndorseToggle = () => {
+            if (relationship.endorsed) {
+              dispatch(unpinAccount(id));
+            } else {
+              dispatch(pinAccount(id));
+            }
+          };
+          arr.push({
+            text: intl.formatMessage(
+              // Defined in features/account_timeline/components/account_header.tsx
+              relationship.endorsed
+                ? { id: 'account.unendorse' }
+                : { id: 'account.endorse' },
+            ),
+            action: handleEndorseToggle,
+          });
+        }
       }
     }
 

--- a/app/javascript/mastodon/components/account.tsx
+++ b/app/javascript/mastodon/components/account.tsx
@@ -13,6 +13,7 @@ import {
   unmuteAccount,
   followAccountSuccess,
   unpinAccount,
+  pinAccount,
 } from 'mastodon/actions/accounts';
 import { showAlertForError } from 'mastodon/actions/alerts';
 import { openModal } from 'mastodon/actions/modal';
@@ -60,10 +61,6 @@ const messages = defineMessages({
   openOriginalPage: {
     id: 'account.open_original_page',
     defaultMessage: 'Open original page',
-  },
-  unendorse: {
-    id: 'account.unendorse',
-    defaultMessage: "Don't feature on profile",
   },
 });
 
@@ -186,17 +183,22 @@ export const Account: React.FC<AccountProps> = ({
           action: handleAddToLists,
         });
 
-        const handleUnendorse = () => {
+        const handleEndorseToggle = () => {
           if (relationship?.endorsed) {
             dispatch(unpinAccount(id));
+          } else {
+            dispatch(pinAccount(id));
           }
         };
-        if (relationship?.endorsed) {
-          arr.push({
-            text: intl.formatMessage(messages.unendorse),
-            action: handleUnendorse,
-          });
-        }
+        arr.push({
+          text: intl.formatMessage(
+            // Defined in features/account_timeline/components/account_header.tsx
+            relationship?.endorsed
+              ? { id: 'account.unendorse' }
+              : { id: 'account.endorse' },
+          ),
+          action: handleEndorseToggle,
+        });
       }
     }
 


### PR DESCRIPTION
Fixes #34924. This PR does the following:
- Add menu items to pin and unpin accounts in the `Account` component, which is used in a few areas including followers, following, and featured.
- It only shows if you are a follower (or requested to follow).
- Will update the UI after unpinning an account.

https://github.com/user-attachments/assets/6ac995c6-caeb-4550-8f08-497f35ad61d5
