### PR TITLE
Fix account note textarea being interactable before the relationship gets fetched

### DIFF
--- a/app/javascript/mastodon/features/account/components/account_note.jsx
+++ b/app/javascript/mastodon/features/account/components/account_note.jsx
@@ -8,6 +8,8 @@ import ImmutablePureComponent from 'react-immutable-pure-component';
 
 import Textarea from 'react-textarea-autosize';
 
+import { Skeleton } from '@/mastodon/components/skeleton';
+
 const messages = defineMessages({
   placeholder: { id: 'account_note.placeholder', defaultMessage: 'Click to add a note' },
 });
@@ -153,17 +155,21 @@ class AccountNote extends ImmutablePureComponent {
           <FormattedMessage id='account.account_note_header' defaultMessage='Personal note' /> <InlineAlert show={saved} />
         </label>
 
-        <Textarea
-          id={`account-note-${accountId}`}
-          className='account__header__account-note__content'
-          disabled={this.props.value === null || value === null}
-          placeholder={intl.formatMessage(messages.placeholder)}
-          value={value || ''}
-          onChange={this.handleChange}
-          onKeyDown={this.handleKeyDown}
-          onBlur={this.handleBlur}
-          ref={this.setTextareaRef}
-        />
+        {this.props.value === undefined ? (
+          <Skeleton width='20ch' height='35px' />
+        ) : (
+          <Textarea
+            id={`account-note-${accountId}`}
+            className='account__header__account-note__content'
+            disabled={value === null}
+            placeholder={intl.formatMessage(messages.placeholder)}
+            value={value || ''}
+            onChange={this.handleChange}
+            onKeyDown={this.handleKeyDown}
+            onBlur={this.handleBlur}
+            ref={this.setTextareaRef}
+          />
+        )}
       </div>
     );
   }

--- a/app/javascript/mastodon/features/account/components/account_note.jsx
+++ b/app/javascript/mastodon/features/account/components/account_note.jsx
@@ -8,7 +8,7 @@ import ImmutablePureComponent from 'react-immutable-pure-component';
 
 import Textarea from 'react-textarea-autosize';
 
-import { Skeleton } from '@/mastodon/components/skeleton';
+import { LoadingIndicator } from '@/mastodon/components/loading_indicator';
 
 const messages = defineMessages({
   placeholder: { id: 'account_note.placeholder', defaultMessage: 'Click to add a note' },
@@ -156,7 +156,9 @@ class AccountNote extends ImmutablePureComponent {
         </label>
 
         {this.props.value === undefined ? (
-          <Skeleton width='20ch' height='35px' />
+          <div className='account__header__account-note__loading-indicator-wrapper'>
+            <LoadingIndicator />
+          </div>
         ) : (
           <Textarea
             id={`account-note-${accountId}`}

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -8194,6 +8194,20 @@ noscript {
     font-weight: 400;
     margin-bottom: 10px;
 
+    &__loading-indicator-wrapper {
+      position: relative;
+      height: 37px;
+
+      .loading-indicator {
+        left: 10px;
+      }
+
+      .circular-progress {
+        width: 14px;
+        height: 14px;
+      }
+    }
+
     label {
       display: block;
       font-size: 12px;


### PR DESCRIPTION
I believe this is the reason for one class of flaky tests: the tests start writing in the textarea before the relationship gets loaded, which resets the textarea and discards the text input.

The textarea was supposed to be disabled when the relationship isn't loaded yet, but the check was incorrect, comparing the value to `null` whereas it is actually `undefined`.

Instead of having an uninteractable placeholder that says to click it, opted for a skeleton loader, although this may be a bit too distracting.

https://github.com/user-attachments/assets/832c64a3-0349-4f54-aa44-ce9a8a52e446