### PR TITLE
Change “legacy” non-fast-tracked quote posts to not be displayed as such

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -233,7 +233,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
 
     approval_uri = @status_parser.quote_approval_uri
     approval_uri = nil if unsupported_uri_scheme?(approval_uri)
-    @quote = Quote.new(account: @account, approval_uri: approval_uri)
+    @quote = Quote.new(account: @account, approval_uri: approval_uri, legacy: @status_parser.legacy_quote?)
   end
 
   def process_hashtag(tag)

--- a/app/lib/activitypub/parser/status_parser.rb
+++ b/app/lib/activitypub/parser/status_parser.rb
@@ -123,6 +123,10 @@ class ActivityPub::Parser::StatusParser
     end.first
   end
 
+  def legacy_quote?
+    !@object.key?('quote')
+  end
+
   # The inlined quote; out of the attributes we support, only `https://w3id.org/fep/044f#quote` explicitly supports inlined objects
   def quoted_object
     as_array(@object['quote']).first

--- a/app/models/quote.rb
+++ b/app/models/quote.rb
@@ -7,6 +7,7 @@
 #  id                :bigint(8)        not null, primary key
 #  activity_uri      :string
 #  approval_uri      :string
+#  legacy            :boolean          default(FALSE), not null
 #  state             :integer          default("pending"), not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
@@ -44,6 +45,10 @@ class Quote < ApplicationRecord
     elsif !revoked?
       update!(state: :rejected)
     end
+  end
+
+  def acceptable?
+    accepted? || !legacy?
   end
 
   def schedule_refresh_if_stale!

--- a/app/serializers/rest/status_serializer.rb
+++ b/app/serializers/rest/status_serializer.rb
@@ -33,6 +33,10 @@ class REST::StatusSerializer < ActiveModel::Serializer
   has_one :preview_card, key: :card, serializer: REST::PreviewCardSerializer
   has_one :preloadable_poll, key: :poll, serializer: REST::PollSerializer
 
+  def quote
+    object.quote if object.quote&.acceptable?
+  end
+
   def id
     object.id.to_s
   end

--- a/app/services/activitypub/process_status_update_service.rb
+++ b/app/services/activitypub/process_status_update_service.rb
@@ -283,14 +283,14 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
         # If the quoted post has changed, discard the old object and create a new one
         if @status.quote.quoted_status.present? && ActivityPub::TagManager.instance.uri_for(@status.quote.quoted_status) != quote_uri
           @status.quote.destroy
-          quote = Quote.create(status: @status, approval_uri: approval_uri)
+          quote = Quote.create(status: @status, approval_uri: approval_uri, legacy: @status_parser.legacy_quote?)
           @quote_changed = true
         else
           quote = @status.quote
-          quote.update(approval_uri: approval_uri, state: :pending) if quote.approval_uri != @status_parser.quote_approval_uri
+          quote.update(approval_uri: approval_uri, state: :pending, legacy: @status_parser.legacy_quote?) if quote.approval_uri != @status_parser.quote_approval_uri
         end
       else
-        quote = Quote.create(status: @status, approval_uri: approval_uri)
+        quote = Quote.create(status: @status, approval_uri: approval_uri, legacy: @status_parser.legacy_quote?)
         @quote_changed = true
       end
 

--- a/db/migrate/20250605110215_add_legacy_to_quotes.rb
+++ b/db/migrate/20250605110215_add_legacy_to_quotes.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddLegacyToQuotes < ActiveRecord::Migration[8.0]
+  def change
+    add_column :quotes, :legacy, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_20_204643) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_05_110215) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -906,6 +906,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_20_204643) do
     t.string "activity_uri"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "legacy", default: false, null: false
     t.index ["account_id", "quoted_account_id"], name: "index_quotes_on_account_id_and_quoted_account_id"
     t.index ["activity_uri"], name: "index_quotes_on_activity_uri", unique: true, where: "(activity_uri IS NOT NULL)"
     t.index ["approval_uri"], name: "index_quotes_on_approval_uri", where: "(approval_uri IS NOT NULL)"


### PR DESCRIPTION
Fixes #34943

This effectively downgrades compatibility with non-FEP-044f quote posts to only treat them as quote posts in the REST API if they are accepted.

In practice, this means fast-track (self-quotes or quotes from mentioned users) will be accepted and displayed as quote posts, other posts will just be whatever fallback the authoring software outputs.

This PR doesn't alter our compliance with FEP-044f, which mandates support for quote controls (since it's the point), but affects the fallback behavior with `quoteUri`, `quoteUrl`, and `_misskey_quote`, and may lead to confusion as to why some of those quote-posts work and some of them don't.