### PR TITLE
Add ability to filter quote posts in home timeline

### DIFF
--- a/app/javascript/mastodon/features/home_timeline/components/column_settings.tsx
+++ b/app/javascript/mastodon/features/home_timeline/components/column_settings.tsx
@@ -43,6 +43,19 @@ export const ColumnSettings: React.FC = () => {
           <SettingToggle
             prefix='home_timeline'
             settings={settings}
+            settingPath={['shows', 'quote']}
+            onChange={onChange}
+            label={
+              <FormattedMessage
+                id='home.column_settings.show_quotes'
+                defaultMessage='Show quotes'
+              />
+            }
+          />
+
+          <SettingToggle
+            prefix='home_timeline'
+            settings={settings}
             settingPath={['shows', 'reply']}
             onChange={onChange}
             label={

--- a/app/javascript/mastodon/features/ui/containers/status_list_container.js
+++ b/app/javascript/mastodon/features/ui/containers/status_list_container.js
@@ -17,19 +17,22 @@ const makeGetStatusIds = (pending = false) => createSelector([
     if (id === null || id === 'inline-follow-suggestions') return true;
 
     const statusForId = statuses.get(id);
-    let showStatus    = true;
 
     if (statusForId.get('account') === me) return true;
 
-    if (columnSettings.getIn(['shows', 'reblog']) === false) {
-      showStatus = showStatus && statusForId.get('reblog') === null;
+    if (columnSettings.getIn(['shows', 'reblog']) === false && statusForId.get('reblog') !== null) {
+      return false;
     }
 
-    if (columnSettings.getIn(['shows', 'reply']) === false) {
-      showStatus = showStatus && (statusForId.get('in_reply_to_id') === null || statusForId.get('in_reply_to_account_id') === me);
+    if (columnSettings.getIn(['shows', 'reply']) === false && statusForId.get('in_reply_to_id') !== null && statusForId.get('in_reply_to_account_id') !== me) {
+      return false;
     }
 
-    return showStatus;
+    if (columnSettings.getIn(['shows', 'quote']) === false && statusForId.get('quote') !== null) {
+      return false;
+    }
+
+    return true;
   });
 });
 

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -430,6 +430,7 @@
   "hints.profiles.see_more_posts": "See more posts on {domain}",
   "hints.threads.replies_may_be_missing": "Replies from other servers may be missing.",
   "hints.threads.see_more": "See more replies on {domain}",
+  "home.column_settings.show_quotes": "Show quotes",
   "home.column_settings.show_reblogs": "Show boosts",
   "home.column_settings.show_replies": "Show replies",
   "home.hide_announcements": "Hide announcements",

--- a/app/javascript/mastodon/reducers/settings.js
+++ b/app/javascript/mastodon/reducers/settings.js
@@ -20,6 +20,7 @@ const initialState = ImmutableMap({
 
   home: ImmutableMap({
     shows: ImmutableMap({
+      quote: true,
       reblog: true,
       reply: true,
     }),


### PR DESCRIPTION
Filtering client-side is perhaps not the best way since it can result in empty pages, but that is consistent with the other kinds of post type filtering that we already have.

Being able to hide quote posts is a request that came up a bunch, and since we have filters for reblogs and replies, I don't see why not.