### PR TITLE
Fix `Lint/NonLocalExitFromIterator` cop in JSON-LD helper

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,10 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-Lint/NonLocalExitFromIterator:
-  Exclude:
-    - 'app/helpers/json_ld_helper.rb'
-
 # Configuration parameters: AllowedMethods, AllowedPatterns, CountRepeatedAttributes.
 Metrics/AbcSize:
   Max: 82

--- a/app/helpers/json_ld_helper.rb
+++ b/app/helpers/json_ld_helper.rb
@@ -134,7 +134,7 @@ module JsonLdHelper
         patch_for_forwarding!(value, compacted_value)
       elsif value.is_a?(Array)
         compacted_value = [compacted_value] unless compacted_value.is_a?(Array)
-        return if value.size != compacted_value.size
+        return(nil) if value.size != compacted_value.size
 
         compacted[key] = value.zip(compacted_value).map do |v, vc|
           if v.is_a?(Hash) && vc.is_a?(Hash)

--- a/app/helpers/json_ld_helper.rb
+++ b/app/helpers/json_ld_helper.rb
@@ -134,7 +134,7 @@ module JsonLdHelper
         patch_for_forwarding!(value, compacted_value)
       elsif value.is_a?(Array)
         compacted_value = [compacted_value] unless compacted_value.is_a?(Array)
-        return(nil) if value.size != compacted_value.size
+        return nil if value.size != compacted_value.size
 
         compacted[key] = value.zip(compacted_value).map do |v, vc|
           if v.is_a?(Hash) && vc.is_a?(Hash)

--- a/spec/helpers/json_ld_helper_spec.rb
+++ b/spec/helpers/json_ld_helper_spec.rb
@@ -180,6 +180,14 @@ RSpec.describe JsonLdHelper do
         expect(compacted.dig('object', 'tag', 0, 'href')).to eq ['foo']
         expect(safe_for_forwarding?(json, compacted)).to be true
       end
+
+      context 'when array size mismatch exists' do
+        subject { helper.patch_for_forwarding!(json, alternate) }
+
+        let(:alternate) { json.merge('to' => %w(one two three)) }
+
+        it { is_expected.to be_nil }
+      end
     end
 
     describe 'safe_for_forwarding?' do


### PR DESCRIPTION
Previously attempted this one by switching to a `next` here - https://github.com/mastodon/mastodon/pull/27749 - however, we were concerned there that even though that seemed sort of safe and maybe what should have happened from the get-go, it was technically a behavior change and we didn't want to risk it. I extracted a typo fix and then it fizzled.

This is an alternate approach, which is to accept/embrace the current behavior, and just fix the cop violation (doing an explicit return of nil which was previously implicit satisfies the cop). Also added spec to capture the previous behavior of array size mismatch, and make sure we've preserved it.

As mentioned in previous PR, this method could use more specs and maybe some lightweight style/renaming refactor for clarity ... but for now, just do minimal thing to get rid of cop todo.