### PR TITLE
Align versions in templates to current/plausible values

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.web_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1.web_bug_report.yml
@@ -48,8 +48,8 @@ body:
     attributes:
       label: Mastodon version
       description: |
-        This is displayed at the bottom of the About page, eg. `v4.4.0-alpha.1`
-      placeholder: v4.3.0
+        This is displayed at the bottom of the About page, eg. `v4.4.0-beta.1`
+      placeholder: v4.4.0-beta.1
     validations:
       required: true
   - type: input
@@ -57,7 +57,7 @@ body:
       label: Browser name and version
       description: |
         What browser are you using when getting this bug? Please specify the version as well.
-      placeholder: Firefox 131.0.0
+      placeholder: Firefox 139.0.0
     validations:
       required: true
   - type: input
@@ -65,7 +65,7 @@ body:
       label: Operating system
       description: |
         What OS are you running? Please specify the version as well.
-      placeholder: macOS 15.0.1
+      placeholder: macOS 15.5
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/2.server_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/2.server_bug_report.yml
@@ -49,8 +49,8 @@ body:
     attributes:
       label: Mastodon version
       description: |
-        This is displayed at the bottom of the About page, eg. `v4.4.0-alpha.1`
-      placeholder: v4.3.0
+        This is displayed at the bottom of the About page, eg. `v4.4.0-beta.1`
+      placeholder: v4.4.0-beta.1
     validations:
       required: false
   - type: textarea
@@ -60,7 +60,7 @@ body:
         Any additional technical details you may have, like logs or error traces
       value: |
         If this is happening on your own Mastodon server, please fill out those:
-        - Ruby version: (from `ruby --version`, eg. v3.4.1)
-        - Node.js version: (from `node --version`, eg. v20.18.0)
+        - Ruby version: (from `ruby --version`, eg. v3.4.4)
+        - Node.js version: (from `node --version`, eg. v22.16.0)
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/3.troubleshooting.yml
+++ b/.github/ISSUE_TEMPLATE/3.troubleshooting.yml
@@ -50,7 +50,7 @@ body:
       label: Mastodon version
       description: |
         This is displayed at the bottom of the About page, eg. `v4.4.0-alpha.1`
-      placeholder: v4.3.0
+      placeholder: v4.4.0-beta.1
     validations:
       required: false
   - type: textarea
@@ -60,9 +60,9 @@ body:
         Details about your environment, like how Mastodon is deployed, if containers are used, version numbers, etc.
       value: |
         Please at least include those informations:
-        - Operating system: (eg. Ubuntu 22.04)
-        - Ruby version: (from `ruby --version`, eg. v3.4.1)
-        - Node.js version: (from `node --version`, eg. v20.18.0)
+        - Operating system: (eg. Ubuntu 24.04.2)
+        - Ruby version: (from `ruby --version`, eg. v3.4.4)
+        - Node.js version: (from `node --version`, eg. v22.16.0)
     validations:
       required: false
   - type: textarea


### PR DESCRIPTION
With `4.4.0-beta.1` tagged, do a pass over the templates.

it would be truly funny to someday configure renovate to update these. I would laugh and tell everyone on the street.