### PR TITLE
Update `rack` to 3.1.16

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -633,7 +633,7 @@ GEM
       activesupport (>= 3.0.0)
     raabro (1.4.0)
     racc (1.8.1)
-    rack (3.1.15)
+    rack (3.1.16)
     rack-attack (6.7.0)
       rack (>= 1.0, < 4)
     rack-cors (3.0.0)


### PR DESCRIPTION
3.1.15 has a security issue: https://github.com/rack/rack/security/advisories/GHSA-47m2-26rw-j2jw