### PR TITLE
Change github workflow for chromatic to only run on official Mastodon repository

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -20,6 +20,7 @@ jobs:
   chromatic:
     name: Run Chromatic
     runs-on: ubuntu-latest
+    if: github.repository == 'mastodon/mastodon'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Forks usually won't have chromatic set up.