### PR TITLE
Fix `Style/OptionalBooleanParameter` cop

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -38,15 +38,3 @@ Style/FetchEnvVar:
 # Configuration parameters: MinBodyLength, AllowConsecutiveConditionals.
 Style/GuardClause:
   Enabled: false
-
-# Configuration parameters: AllowedMethods.
-# AllowedMethods: respond_to_missing?
-Style/OptionalBooleanParameter:
-  Exclude:
-    - 'app/lib/admin/system_check/message.rb'
-    - 'app/lib/request.rb'
-    - 'app/lib/webfinger.rb'
-    - 'app/services/block_domain_service.rb'
-    - 'app/services/fetch_resource_service.rb'
-    - 'app/workers/domain_block_worker.rb'
-    - 'app/workers/unfollow_follow_worker.rb'

--- a/app/lib/admin/system_check/media_privacy_check.rb
+++ b/app/lib/admin/system_check/media_privacy_check.rb
@@ -13,7 +13,7 @@ class Admin::SystemCheck::MediaPrivacyCheck < Admin::SystemCheck::BaseCheck
   end
 
   def message
-    Admin::SystemCheck::Message.new(@failure_message, @failure_value, @failure_action, true)
+    Admin::SystemCheck::Message.new(@failure_message, @failure_value, @failure_action, critical: true)
   end
 
   private

--- a/app/lib/admin/system_check/message.rb
+++ b/app/lib/admin/system_check/message.rb
@@ -3,7 +3,7 @@
 class Admin::SystemCheck::Message
   attr_reader :key, :value, :action, :critical
 
-  def initialize(key, value = nil, action = nil, critical = false)
+  def initialize(key, value = nil, action = nil, critical: false)
     @key      = key
     @value    = value
     @action   = action

--- a/app/lib/admin/system_check/software_version_check.rb
+++ b/app/lib/admin/system_check/software_version_check.rb
@@ -13,7 +13,7 @@ class Admin::SystemCheck::SoftwareVersionCheck < Admin::SystemCheck::BaseCheck
 
   def message
     if software_updates.any?(&:urgent?)
-      Admin::SystemCheck::Message.new(:software_version_critical_check, nil, admin_software_updates_path, true)
+      Admin::SystemCheck::Message.new(:software_version_critical_check, nil, admin_software_updates_path, critical: true)
     elsif software_updates.any?(&:patch_type?)
       Admin::SystemCheck::Message.new(:software_version_patch_check, nil, admin_software_updates_path)
     else

--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -20,7 +20,7 @@ class PerOperationWithDeadline < HTTP::Timeout::PerOperation
     @read_deadline = options.fetch(:read_deadline, READ_DEADLINE)
   end
 
-  def connect(socket_class, host, port, nodelay = false)
+  def connect(socket_class, host, port, nodelay = false) # rubocop:disable Style/OptionalBooleanParameter
     @socket = socket_class.open(host, port)
     @socket.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1) if nodelay
   end

--- a/app/lib/webfinger.rb
+++ b/app/lib/webfinger.rb
@@ -65,7 +65,7 @@ class Webfinger
 
   private
 
-  def body_from_webfinger(url = standard_url, use_fallback = true)
+  def body_from_webfinger(url = standard_url, use_fallback: true)
     webfinger_request(url).perform do |res|
       if res.code == 200
         body = res.body_with_limit
@@ -85,7 +85,7 @@ class Webfinger
   def body_from_host_meta
     host_meta_request.perform do |res|
       if res.code == 200
-        body_from_webfinger(url_from_template(res.body_with_limit), false)
+        body_from_webfinger(url_from_template(res.body_with_limit), use_fallback: false)
       else
         raise Webfinger::Error, "Request for #{@uri} returned HTTP #{res.code}"
       end

--- a/app/services/block_domain_service.rb
+++ b/app/services/block_domain_service.rb
@@ -3,7 +3,7 @@
 class BlockDomainService < BaseService
   attr_reader :domain_block
 
-  def call(domain_block, update = false)
+  def call(domain_block, update: false)
     @domain_block = domain_block
     @domain_block_event = nil
 

--- a/app/services/fetch_resource_service.rb
+++ b/app/services/fetch_resource_service.rb
@@ -22,7 +22,7 @@ class FetchResourceService < BaseService
   def process(url, terminal: false)
     @url = url
 
-    perform_request { |response| process_response(response, terminal) }
+    perform_request { |response| process_response(response, terminal:) }
   end
 
   def perform_request(&block)
@@ -40,7 +40,7 @@ class FetchResourceService < BaseService
     end.perform(&block)
   end
 
-  def process_response(response, terminal = false)
+  def process_response(response, terminal: false)
     @response_code = response.code
     return nil if response.code != 200
 

--- a/app/workers/domain_block_worker.rb
+++ b/app/workers/domain_block_worker.rb
@@ -3,10 +3,10 @@
 class DomainBlockWorker
   include Sidekiq::Worker
 
-  def perform(domain_block_id, update = false)
+  def perform(domain_block_id, update = false) # rubocop:disable Style/OptionalBooleanParameter
     domain_block = DomainBlock.find_by(id: domain_block_id)
     return true if domain_block.nil?
 
-    BlockDomainService.new.call(domain_block, update)
+    BlockDomainService.new.call(domain_block, update:)
   end
 end

--- a/app/workers/unfollow_follow_worker.rb
+++ b/app/workers/unfollow_follow_worker.rb
@@ -5,7 +5,7 @@ class UnfollowFollowWorker
 
   sidekiq_options queue: 'pull'
 
-  def perform(follower_account_id, old_target_account_id, new_target_account_id, bypass_locked = false)
+  def perform(follower_account_id, old_target_account_id, new_target_account_id, bypass_locked = false) # rubocop:disable Style/OptionalBooleanParameter
     follower_account   = Account.find(follower_account_id)
     old_target_account = Account.find(old_target_account_id)
     new_target_account = Account.find(new_target_account_id)

--- a/spec/lib/admin/system_check/media_privacy_check_spec.rb
+++ b/spec/lib/admin/system_check/media_privacy_check_spec.rb
@@ -23,11 +23,11 @@ RSpec.describe Admin::SystemCheck::MediaPrivacyCheck do
 
   describe 'message' do
     it 'sends values to message instance' do
-      allow(Admin::SystemCheck::Message).to receive(:new).with(nil, nil, nil, true)
+      allow(Admin::SystemCheck::Message).to receive(:new).with(nil, nil, nil, critical: true)
 
       check.message
 
-      expect(Admin::SystemCheck::Message).to have_received(:new).with(nil, nil, nil, true)
+      expect(Admin::SystemCheck::Message).to have_received(:new).with(nil, nil, nil, critical: true)
     end
   end
 end

--- a/spec/lib/admin/system_check/message_spec.rb
+++ b/spec/lib/admin/system_check/message_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Admin::SystemCheck::Message do
-  subject(:check) { described_class.new(:key_value, :value_value, :action_value, :critical_value) }
+  subject(:check) { described_class.new(:key_value, :value_value, :action_value, critical: :critical_value) }
 
   it 'providers readers when initialized' do
     expect(check.key).to eq :key_value

--- a/spec/lib/admin/system_check/software_version_check_spec.rb
+++ b/spec/lib/admin/system_check/software_version_check_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe Admin::SystemCheck::SoftwareVersionCheck do
         check.message
 
         expect(Admin::SystemCheck::Message).to have_received(:new)
-          .with(:software_version_critical_check, nil, admin_software_updates_path, true)
+          .with(:software_version_critical_check, nil, admin_software_updates_path, critical: true)
       end
     end
   end

--- a/spec/workers/domain_block_worker_spec.rb
+++ b/spec/workers/domain_block_worker_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe DomainBlockWorker do
       result = subject.perform(domain_block.id)
 
       expect(result).to be_nil
-      expect(service).to have_received(:call).with(domain_block, false)
+      expect(service).to have_received(:call).with(domain_block, update: false)
     end
 
     it 'returns true for non-existent domain block' do


### PR DESCRIPTION
The rationale of this rule is to prefer keyword args for boolean params so that from the calling site its more clear what you are passing in. Summary here:

- system check message `critical` was corrected, and I think does read slightly better
- request is a subclass, cant change signature, did inline disable
- the webfinger and fetch resource ones are private methods only called from own class
- BlockDomainService is only called (with that arg) from domain block worker, updated in that spot
- I assume we'd rather not change the signature for workers that could be in a queue retry, did inline disable for both of those `perform` methods. Could correct those as well if queue thing is not a concern.

I was going to just disable this, but did a quick scan and noticed this style actually is used pretty consistently. Happy to chop this up into smaller pieces if easier.