### PR TITLE
Change viewport behaviour to cover

### DIFF
--- a/app/javascript/styles/mastodon/basics.scss
+++ b/app/javascript/styles/mastodon/basics.scss
@@ -48,6 +48,8 @@ body {
 
   &.app-body {
     padding: 0;
+    padding-left: env(safe-area-inset-left);
+    padding-right: env(safe-area-inset-right);
 
     &.layout-single-column {
       height: auto;

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -2,7 +2,7 @@
 %html{ lang: I18n.locale }
   %head
     %meta{ charset: 'utf-8' }/
-    %meta{ name: 'viewport', content: 'width=device-width, initial-scale=1' }/
+    %meta{ name: 'viewport', content: 'width=device-width, initial-scale=1, viewport-fit=cover' }/
 
     - if cdn_host?
       %link{ rel: 'dns-prefetch', href: cdn_host }/


### PR DESCRIPTION
Without this directive, `env(safe-area-inset-bottom)` is always 0. This enables it for when Mastodon is a PWA.

Based on #34910.