### PR TITLE
Ensure featured carousel respects tags

### DIFF
--- a/app/javascript/mastodon/features/account_timeline/index.jsx
+++ b/app/javascript/mastodon/features/account_timeline/index.jsx
@@ -135,7 +135,7 @@ class AccountTimeline extends ImmutablePureComponent {
   };
 
   render () {
-    const { accountId, statusIds, isLoading, hasMore, blockedBy, suspended, isAccount, hidden, multiColumn, remote, remoteUrl } = this.props;
+    const { accountId, statusIds, isLoading, hasMore, blockedBy, suspended, isAccount, hidden, multiColumn, remote, remoteUrl, params: { tagged } } = this.props;
 
     if (isLoading && statusIds.isEmpty()) {
       return (
@@ -172,8 +172,8 @@ class AccountTimeline extends ImmutablePureComponent {
         <StatusList
           prepend={
             <>
-              <AccountHeader accountId={this.props.accountId} hideTabs={forceEmptyState} tagged={this.props.params.tagged} />
-              {!forceEmptyState && <FeaturedCarousel accountId={this.props.accountId} />}
+              <AccountHeader accountId={this.props.accountId} hideTabs={forceEmptyState} tagged={tagged} />
+              {!forceEmptyState && <FeaturedCarousel accountId={this.props.accountId} tagged={tagged} />}
             </>
         }
           alwaysPrepend


### PR DESCRIPTION
Fixes #34978. This ensures the pinned carousel respects the tag, if any.