### PR TITLE
Fix crash in `/about` when server returns cached rules without `translations` attribute

### DIFF
--- a/app/javascript/mastodon/features/about/components/rules.tsx
+++ b/app/javascript/mastodon/features/about/components/rules.tsx
@@ -119,15 +119,17 @@ const rulesSelector = createSelector(
         return rule;
       }
 
-      if (translations[locale]) {
-        rule.text = translations[locale].text;
-        rule.hint = translations[locale].hint;
-      }
       const partialLocale = locale.split('-')[0];
       if (partialLocale && translations[partialLocale]) {
         rule.text = translations[partialLocale].text;
         rule.hint = translations[partialLocale].hint;
       }
+
+      if (translations[locale]) {
+        rule.text = translations[locale].text;
+        rule.hint = translations[locale].hint;
+      }
+
       return rule;
     });
   },

--- a/app/javascript/mastodon/features/about/components/rules.tsx
+++ b/app/javascript/mastodon/features/about/components/rules.tsx
@@ -29,7 +29,7 @@ interface BaseRule {
 
 interface Rule extends BaseRule {
   id: string;
-  translations: Record<string, BaseRule>;
+  translations?: Record<string, BaseRule>;
 }
 
 export const RulesSection: FC<RulesSectionProps> = ({ isLoading = false }) => {
@@ -113,6 +113,12 @@ const rulesSelector = createSelector(
   (rules, locale): Rule[] => {
     return rules.map((rule) => {
       const translations = rule.translations;
+
+      // Handle cached responses from earlier versions
+      if (!translations) {
+        return rule;
+      }
+
       if (translations[locale]) {
         rule.text = translations[locale].text;
         rule.hint = translations[locale].hint;


### PR DESCRIPTION
This can happen for a few minutes after upgrade, because `/api/v2/instance` is heavily cached.

This can also happen if someone reuses the front-end on a different piece of software.

Also fixes region-specific translation being overridden in `/about` if more generic translation is available.