### PR TITLE
Disable `Metrics/*` cops

### DIFF
--- a/.rubocop/metrics.yml
+++ b/.rubocop/metrics.yml
@@ -1,17 +1,21 @@
 ---
 Metrics/AbcSize:
-  Exclude:
-    - lib/mastodon/cli/*.rb
+  Enabled: false
 
 Metrics/BlockLength:
+  Enabled: false
+
+Metrics/BlockNesting:
   Enabled: false
 
 Metrics/ClassLength:
   Enabled: false
 
+Metrics/CollectionLiteralLength:
+  Enabled: false
+
 Metrics/CyclomaticComplexity:
-  Exclude:
-    - lib/mastodon/cli/*.rb
+  Enabled: false
 
 Metrics/MethodLength:
   Enabled: false
@@ -20,4 +24,7 @@ Metrics/ModuleLength:
   Enabled: false
 
 Metrics/ParameterLists:
-  CountKeywordArgs: false
+  Enabled: false
+
+Metrics/PerceivedComplexity:
+  Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,23 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Configuration parameters: AllowedMethods, AllowedPatterns, CountRepeatedAttributes.
-Metrics/AbcSize:
-  Max: 82
-
-# Configuration parameters: CountBlocks, CountModifierForms, Max.
-Metrics/BlockNesting:
-  Exclude:
-    - 'lib/tasks/mastodon.rake'
-
-# Configuration parameters: AllowedMethods, AllowedPatterns.
-Metrics/CyclomaticComplexity:
-  Max: 25
-
-# Configuration parameters: AllowedMethods, AllowedPatterns.
-Metrics/PerceivedComplexity:
-  Max: 27
-
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowedVars, DefaultToNil.
 Style/FetchEnvVar:

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -12,7 +12,7 @@ class InitialStateSerializer < ActiveModel::Serializer
   has_one :push_subscription, serializer: REST::WebPushSubscriptionSerializer
   has_one :role, serializer: REST::RoleSerializer
 
-  def meta # rubocop:disable Metrics/AbcSize
+  def meta
     store = default_meta_store
 
     if object.current_account


### PR DESCRIPTION
The rationale on this one is basically -- the default values here are so far below where we are in practice, and there seems to be limited appetite/time to review any refactor-only PRs that would nudge these down -- so let's drop the rules entirely and defer to case by case judgement (which is effectively what we are doing already now...).

Combined with other open PRs, I think this is the final one needed to remove the rubocop todo file here, which I know has been a long-standing desire of everyone involved and not just some fringe esoteric pursuit that I've been on by myself for some inexplicable reason. I'll keep rebasing these depending what order they merge/change/etc in, and either do the file deletion in the final PR, or as a followup.

