### PR TITLE
Start local prometheus_exporter server only in puma/sidekiq startup

### DIFF
--- a/config/initializers/prometheus_exporter.rb
+++ b/config/initializers/prometheus_exporter.rb
@@ -4,7 +4,14 @@ if ENV['MASTODON_PROMETHEUS_EXPORTER_ENABLED'] == 'true'
   require 'prometheus_exporter'
   require 'prometheus_exporter/middleware'
 
-  require 'mastodon/prometheus_exporter/local_server' if ENV['MASTODON_PROMETHEUS_EXPORTER_LOCAL'] == 'true'
+  if ENV['MASTODON_PROMETHEUS_EXPORTER_LOCAL'] == 'true'
+    require 'mastodon/prometheus_exporter/local_server'
+
+    # bind is the address, on which the webserver will listen
+    # port is the port that will provide the /metrics route
+    Mastodon::PrometheusExporter::LocalServer.bind = ENV.fetch('MASTODON_PROMETHEUS_EXPORTER_HOST', 'localhost')
+    Mastodon::PrometheusExporter::LocalServer.port = ENV.fetch('MASTODON_PROMETHEUS_EXPORTER_PORT', '9394').to_i
+  end
 
   if ENV['MASTODON_PROMETHEUS_EXPORTER_WEB_DETAILED_METRICS'] == 'true'
     # Optional, as those metrics might generate extra overhead and be redundant with what OTEL provides

--- a/config/initializers/prometheus_exporter.rb
+++ b/config/initializers/prometheus_exporter.rb
@@ -8,13 +8,17 @@ if ENV['MASTODON_PROMETHEUS_EXPORTER_ENABLED'] == 'true'
     require 'prometheus_exporter/server'
     require 'prometheus_exporter/client'
 
-    # bind is the address, on which the webserver will listen
-    # port is the port that will provide the /metrics route
-    server = PrometheusExporter::Server::WebServer.new bind: ENV.fetch('MASTODON_PROMETHEUS_EXPORTER_HOST', 'localhost'), port: ENV.fetch('MASTODON_PROMETHEUS_EXPORTER_PORT', '9394').to_i
-    server.start
+    module Mastodon::PrometheusExporterLocalServer
+      def self.setup!
+        # bind is the address, on which the webserver will listen
+        # port is the port that will provide the /metrics route
+        server = PrometheusExporter::Server::WebServer.new bind: ENV.fetch('MASTODON_PROMETHEUS_EXPORTER_HOST', 'localhost'), port: ENV.fetch('MASTODON_PROMETHEUS_EXPORTER_PORT', '9394').to_i
+        server.start
 
-    # wire up a default local client
-    PrometheusExporter::Client.default = PrometheusExporter::LocalClient.new(collector: server.collector)
+        # wire up a default local client
+        PrometheusExporter::Client.default = PrometheusExporter::LocalClient.new(collector: server.collector)
+      end
+    end
   end
 
   if ENV['MASTODON_PROMETHEUS_EXPORTER_WEB_DETAILED_METRICS'] == 'true'

--- a/config/initializers/prometheus_exporter.rb
+++ b/config/initializers/prometheus_exporter.rb
@@ -4,22 +4,7 @@ if ENV['MASTODON_PROMETHEUS_EXPORTER_ENABLED'] == 'true'
   require 'prometheus_exporter'
   require 'prometheus_exporter/middleware'
 
-  if ENV['MASTODON_PROMETHEUS_EXPORTER_LOCAL'] == 'true'
-    require 'prometheus_exporter/server'
-    require 'prometheus_exporter/client'
-
-    module Mastodon::PrometheusExporterLocalServer
-      def self.setup!
-        # bind is the address, on which the webserver will listen
-        # port is the port that will provide the /metrics route
-        server = PrometheusExporter::Server::WebServer.new bind: ENV.fetch('MASTODON_PROMETHEUS_EXPORTER_HOST', 'localhost'), port: ENV.fetch('MASTODON_PROMETHEUS_EXPORTER_PORT', '9394').to_i
-        server.start
-
-        # wire up a default local client
-        PrometheusExporter::Client.default = PrometheusExporter::LocalClient.new(collector: server.collector)
-      end
-    end
-  end
+  require 'mastodon/prometheus_exporter/local_server' if ENV['MASTODON_PROMETHEUS_EXPORTER_LOCAL'] == 'true'
 
   if ENV['MASTODON_PROMETHEUS_EXPORTER_WEB_DETAILED_METRICS'] == 'true'
     # Optional, as those metrics might generate extra overhead and be redundant with what OTEL provides

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -28,7 +28,7 @@ Sidekiq.configure_server do |config|
 
     if ENV['MASTODON_PROMETHEUS_EXPORTER_LOCAL'] == 'true'
       config.on :startup do
-        Mastodon::PrometheusExporterLocalServer.setup!
+        Mastodon::PrometheusExporter::LocalServer.setup!
       end
     end
 

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -26,6 +26,12 @@ Sidekiq.configure_server do |config|
     require 'prometheus_exporter'
     require 'prometheus_exporter/instrumentation'
 
+    if ENV['MASTODON_PROMETHEUS_EXPORTER_LOCAL'] == 'true'
+      config.on :startup do
+        Mastodon::PrometheusExporterLocalServer.setup!
+      end
+    end
+
     config.on :startup do
       # Ruby process metrics (memory, GC, etc)
       PrometheusExporter::Instrumentation::Process.start type: 'sidekiq'

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -21,6 +21,12 @@ if ENV['MASTODON_PROMETHEUS_EXPORTER_ENABLED'] == 'true'
   require 'prometheus_exporter'
   require 'prometheus_exporter/instrumentation'
 
+  if ENV['MASTODON_PROMETHEUS_EXPORTER_LOCAL'] == 'true'
+    before_fork do
+      Mastodon::PrometheusExporterLocalServer.setup!
+    end
+  end
+
   on_worker_boot do
     # Ruby process metrics (memory, GC, etc)
     PrometheusExporter::Instrumentation::Process.start(type: 'puma')

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -23,7 +23,7 @@ if ENV['MASTODON_PROMETHEUS_EXPORTER_ENABLED'] == 'true'
 
   if ENV['MASTODON_PROMETHEUS_EXPORTER_LOCAL'] == 'true'
     before_fork do
-      Mastodon::PrometheusExporterLocalServer.setup!
+      Mastodon::PrometheusExporter::LocalServer.setup!
     end
   end
 

--- a/lib/mastodon/prometheus_exporter/local_server.rb
+++ b/lib/mastodon/prometheus_exporter/local_server.rb
@@ -5,10 +5,10 @@ require 'prometheus_exporter/client'
 
 module Mastodon::PrometheusExporter
   module LocalServer
+    mattr_accessor :bind, :port
+
     def self.setup!
-      # bind is the address, on which the webserver will listen
-      # port is the port that will provide the /metrics route
-      server = PrometheusExporter::Server::WebServer.new bind: ENV.fetch('MASTODON_PROMETHEUS_EXPORTER_HOST', 'localhost'), port: ENV.fetch('MASTODON_PROMETHEUS_EXPORTER_PORT', '9394').to_i
+      server = PrometheusExporter::Server::WebServer.new(bind:, port:)
       server.start
 
       # wire up a default local client

--- a/lib/mastodon/prometheus_exporter/local_server.rb
+++ b/lib/mastodon/prometheus_exporter/local_server.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'prometheus_exporter/server'
+require 'prometheus_exporter/client'
+
+module Mastodon::PrometheusExporter
+  module LocalServer
+    def self.setup!
+      # bind is the address, on which the webserver will listen
+      # port is the port that will provide the /metrics route
+      server = PrometheusExporter::Server::WebServer.new bind: ENV.fetch('MASTODON_PROMETHEUS_EXPORTER_HOST', 'localhost'), port: ENV.fetch('MASTODON_PROMETHEUS_EXPORTER_PORT', '9394').to_i
+      server.start
+
+      # wire up a default local client
+      PrometheusExporter::Client.default = PrometheusExporter::LocalClient.new(collector: server.collector)
+    end
+  end
+end


### PR DESCRIPTION
Fixes MAS-451

When `MASTODON_PROMETHEUS_EXPORTER_LOCAL` was set to `true` (e.g. through system-wide settings or in `.env.production`) the initializer would try to start a (new) local server. On systems running puma or sidekiq, the server would have been running already, so this would fail. This meant that on those systems one could not easily run a rails console, rails runner script or rails/rake task.

This change moves the server initialization to puma and sidekiq startup respectively.

This fixes the issue described above at the cost of a little flexibility (i.e. you cannot easily start a local prometheus exporter server outside of sidekiq/puma anymore, but I am not sure if this has been a real use-case to begin with).

Note that you still cannot use `MASTODON_PROMETHEUS_EXPORTER_LOCAL` when you run puma and sidekiq on the same machine, which includes dev environments starting the servers with the `bin/dev` script.