### PR TITLE
Fix theme name requirement regression with efficient lookup by name

### DIFF
--- a/app/helpers/theme_helper.rb
+++ b/app/helpers/theme_helper.rb
@@ -4,13 +4,11 @@ module ThemeHelper
   def theme_style_tags(theme)
     if theme == 'system'
       ''.html_safe.tap do |tags|
-        tags << vite_stylesheet_tag('styles/mastodon-light.scss', media: 'not all and (prefers-color-scheme: dark)', crossorigin: 'anonymous')
-        tags << vite_stylesheet_tag('styles/application.scss', media: '(prefers-color-scheme: dark)', crossorigin: 'anonymous')
+        tags << vite_stylesheet_tag('themes/mastodon-light', type: :virtual, media: 'not all and (prefers-color-scheme: dark)', crossorigin: 'anonymous')
+        tags << vite_stylesheet_tag('themes/default', type: :virtual, media: '(prefers-color-scheme: dark)', crossorigin: 'anonymous')
       end
-    elsif theme == 'default'
-      vite_stylesheet_tag 'styles/application.scss', media: 'all', crossorigin: 'anonymous'
     else
-      vite_stylesheet_tag "styles/#{theme}.scss", media: 'all', crossorigin: 'anonymous'
+      vite_stylesheet_tag "themes/#{theme}", type: :virtual, media: 'all', crossorigin: 'anonymous'
     end
   end
 

--- a/config/vite/plugin-mastodon-themes.ts
+++ b/config/vite/plugin-mastodon-themes.ts
@@ -29,7 +29,7 @@ export function MastodonThemes(): Plugin {
         throw new Error('Invalid themes.yml file');
       }
 
-      for (const themePath of Object.values(themes)) {
+      for (const [themeName, themePath] of Object.entries(themes)) {
         if (
           typeof themePath !== 'string' ||
           themePath.split('.').length !== 2 || // Ensure it has exactly one period
@@ -40,7 +40,7 @@ export function MastodonThemes(): Plugin {
           );
           continue;
         }
-        entrypoints[path.basename(themePath)] = path.resolve(
+        entrypoints[`themes/${themeName}`] = path.resolve(
           userConfig.root,
           themePath,
         );

--- a/config/vite/plugin-name-lookup.ts
+++ b/config/vite/plugin-name-lookup.ts
@@ -39,6 +39,13 @@ export function MastodonNameLookup(): Plugin {
         );
         const ext = extname(relativePath);
         const name = chunk.name.replace(ext, '');
+
+        if (nameMap[name]) {
+          throw new Error(
+            `Entrypoint ${relativePath} conflicts with ${nameMap[name]}`,
+          );
+        }
+
         nameMap[name] = relativePath;
       }
 

--- a/config/vite/plugin-name-lookup.ts
+++ b/config/vite/plugin-name-lookup.ts
@@ -1,0 +1,95 @@
+import { dirname, basename, extname, relative } from 'node:path';
+
+import type { Plugin } from 'vite';
+
+export function MastodonNameLookup(): Plugin {
+  const chunkNames = new Set<string>();
+  const nameMap = new Map<string, string>();
+
+  let root = '';
+
+  return {
+    name: 'mastodon-name-lookup',
+    applyToEnvironment(environment) {
+      return !!environment.config.build.manifest;
+    },
+    configResolved(userConfig) {
+      root = userConfig.root;
+    },
+    generateBundle(options, bundle) {
+      if (!root) {
+        throw new Error(
+          'MastodonNameLookup plugin requires the root to be set in the config.',
+        );
+      }
+
+      // Iterate over all chunks in the bundle and create a lookup map
+      for (const file in bundle) {
+        const chunk = bundle[file];
+        if (chunk?.type !== 'chunk') {
+          continue;
+        }
+        // Virtual chunks
+        let fileName = `_${chunk.fileName}`;
+        if (chunk.facadeModuleId) {
+          fileName = relative(root, chunk.facadeModuleId);
+        }
+        fileName = sanitizeFileName(fileName);
+        if (!chunkNames.has(chunk.name)) {
+          chunkNames.add(chunk.name);
+          nameMap.set(chunk.name, fileName);
+          continue;
+        }
+
+        let newName = chunk.name;
+        if (chunk.fileName) {
+          newName = chunk.fileName.replace(/-[a-z0-9]{8}\.js/i, '');
+        } else if (chunk.facadeModuleId) {
+          newName = `${dirname(chunk.facadeModuleId)}-${basename(chunk.facadeModuleId, extname(chunk.facadeModuleId))}`;
+        }
+
+        const originalNewName = newName;
+        let counter = 0;
+        while (chunkNames.has(newName)) {
+          counter++;
+          newName = `${originalNewName}-${counter}`;
+        }
+        chunkNames.add(newName);
+        nameMap.set(newName, fileName);
+        chunk.name = newName;
+      }
+
+      // Build the lookup object and emit it as an asset
+      const lookupObject = nameMap.entries().reduce(
+        (acc, [name, fileName]) => ({
+          ...acc,
+          [name]: fileName,
+        }),
+        {} as Record<string, string>,
+      );
+      this.emitFile({
+        type: 'asset',
+        fileName: '.vite/lookup.json',
+        source: JSON.stringify(lookupObject, null, 2),
+      });
+    },
+  };
+}
+
+// Taken from https://github.com/rollup/rollup/blob/4f69d33af3b2ec9320c43c9e6c65ea23a02bdde3/src/utils/sanitizeFileName.ts
+// https://datatracker.ietf.org/doc/html/rfc2396
+// eslint-disable-next-line no-control-regex
+const INVALID_CHAR_REGEX = /[\u0000-\u001F"#$%&*+,:;<=>?[\]^`{|}\u007F]/g;
+const DRIVE_LETTER_REGEX = /^[a-z]:/i;
+
+function sanitizeFileName(name: string): string {
+  const match = DRIVE_LETTER_REGEX.exec(name);
+  const driveLetter = match ? match[0] : '';
+
+  // A `:` is only allowed as part of a windows drive letter (ex: C:\foo)
+  // Otherwise, avoid them because they can refer to NTFS alternate data streams.
+  return (
+    driveLetter +
+    name.slice(driveLetter.length).replace(INVALID_CHAR_REGEX, '_')
+  );
+}

--- a/config/vite/plugin-name-lookup.ts
+++ b/config/vite/plugin-name-lookup.ts
@@ -3,7 +3,7 @@ import { relative, extname } from 'node:path';
 import type { Plugin } from 'vite';
 
 export function MastodonNameLookup(): Plugin {
-  const nameMap = new Map<string, string>();
+  const nameMap: Record<string, string> = {};
 
   let root = '';
 
@@ -39,21 +39,13 @@ export function MastodonNameLookup(): Plugin {
         );
         const ext = extname(relativePath);
         const name = chunk.name.replace(ext, '');
-        nameMap.set(name, relativePath);
+        nameMap[name] = relativePath;
       }
 
-      // Build the lookup object and emit it as an asset
-      const lookupObject: Record<string, string> = nameMap.entries().reduce(
-        (acc, [name, fileName]) => ({
-          ...acc,
-          [name]: fileName,
-        }),
-        {},
-      );
       this.emitFile({
         type: 'asset',
         fileName: '.vite/manifest-lookup.json',
-        source: JSON.stringify(lookupObject, null, 2),
+        source: JSON.stringify(nameMap, null, 2),
       });
     },
   };

--- a/config/vite/plugin-name-lookup.ts
+++ b/config/vite/plugin-name-lookup.ts
@@ -1,9 +1,8 @@
-import { dirname, basename, extname, relative } from 'node:path';
+import { relative, extname } from 'node:path';
 
 import type { Plugin } from 'vite';
 
 export function MastodonNameLookup(): Plugin {
-  const chunkNames = new Set<string>();
   const nameMap = new Map<string, string>();
 
   let root = '';
@@ -26,50 +25,34 @@ export function MastodonNameLookup(): Plugin {
       // Iterate over all chunks in the bundle and create a lookup map
       for (const file in bundle) {
         const chunk = bundle[file];
-        if (chunk?.type !== 'chunk') {
-          continue;
-        }
-        // Virtual chunks
-        let fileName = `_${chunk.fileName}`;
-        if (chunk.facadeModuleId) {
-          fileName = relative(root, chunk.facadeModuleId);
-        }
-        fileName = sanitizeFileName(fileName);
-        if (!chunkNames.has(chunk.name)) {
-          chunkNames.add(chunk.name);
-          nameMap.set(chunk.name, fileName);
+        if (
+          chunk?.type !== 'chunk' ||
+          !chunk.isEntry ||
+          !chunk.facadeModuleId
+        ) {
           continue;
         }
 
-        let newName = chunk.name;
-        if (chunk.fileName) {
-          newName = chunk.fileName.replace(/-[a-z0-9]{8}\.js/i, '');
-        } else if (chunk.facadeModuleId) {
-          newName = `${dirname(chunk.facadeModuleId)}-${basename(chunk.facadeModuleId, extname(chunk.facadeModuleId))}`;
-        }
-
-        const originalNewName = newName;
-        let counter = 0;
-        while (chunkNames.has(newName)) {
-          counter++;
-          newName = `${originalNewName}-${counter}`;
-        }
-        chunkNames.add(newName);
-        nameMap.set(newName, fileName);
-        chunk.name = newName;
+        const relativePath = relative(
+          root,
+          sanitizeFileName(chunk.facadeModuleId),
+        );
+        const ext = extname(relativePath);
+        const name = chunk.name.replace(ext, '');
+        nameMap.set(name, relativePath);
       }
 
       // Build the lookup object and emit it as an asset
-      const lookupObject = nameMap.entries().reduce(
+      const lookupObject: Record<string, string> = nameMap.entries().reduce(
         (acc, [name, fileName]) => ({
           ...acc,
           [name]: fileName,
         }),
-        {} as Record<string, string>,
+        {},
       );
       this.emitFile({
         type: 'asset',
-        fileName: '.vite/lookup.json',
+        fileName: '.vite/manifest-lookup.json',
         source: JSON.stringify(lookupObject, null, 2),
       });
     },
@@ -80,16 +63,7 @@ export function MastodonNameLookup(): Plugin {
 // https://datatracker.ietf.org/doc/html/rfc2396
 // eslint-disable-next-line no-control-regex
 const INVALID_CHAR_REGEX = /[\u0000-\u001F"#$%&*+,:;<=>?[\]^`{|}\u007F]/g;
-const DRIVE_LETTER_REGEX = /^[a-z]:/i;
 
 function sanitizeFileName(name: string): string {
-  const match = DRIVE_LETTER_REGEX.exec(name);
-  const driveLetter = match ? match[0] : '';
-
-  // A `:` is only allowed as part of a windows drive letter (ex: C:\foo)
-  // Otherwise, avoid them because they can refer to NTFS alternate data streams.
-  return (
-    driveLetter +
-    name.slice(driveLetter.length).replace(INVALID_CHAR_REGEX, '_')
-  );
+  return name.replace(INVALID_CHAR_REGEX, '');
 }

--- a/lib/vite_ruby/sri_extensions.rb
+++ b/lib/vite_ruby/sri_extensions.rb
@@ -7,6 +7,24 @@ module ViteRuby::ManifestIntegrityExtension
     { path: entry.fetch('file'), integrity: entry.fetch('integrity', nil) }
   end
 
+  def load_manifest
+    # Invalidate the name lookup cache when reloading manifest
+    @name_lookup_cache = load_name_lookup_cache
+
+    super
+  end
+
+  def load_name_lookup_cache
+    Oj.load(config.build_output_dir.join('.vite/manifest-lookup.json').read)
+  end
+
+  # Upstream's `virtual` type is a hack, re-implement it with efficient exact name lookup
+  def resolve_virtual_entry(name)
+    @name_lookup_cache ||= load_name_lookup_cache
+
+    @name_lookup_cache.fetch(name)
+  end
+
   # Find a manifest entry by the *final* file name
   def integrity_hash_for_file(file_name)
     @integrity_cache ||= {}

--- a/lib/vite_ruby/sri_extensions.rb
+++ b/lib/vite_ruby/sri_extensions.rb
@@ -112,10 +112,10 @@ module ViteRails::TagHelpers::IntegrityExtension
     end
   end
 
-  def vite_stylesheet_tag(*names, **options)
+  def vite_stylesheet_tag(*names, type: :stylesheet, **options)
     ''.html_safe.tap do |tags|
       names.each do |name|
-        entry = vite_manifest.path_and_integrity_for(name, type: :stylesheet)
+        entry = vite_manifest.path_and_integrity_for(name, type:)
 
         options[:extname] = false if Rails::VERSION::MAJOR >= 7
 

--- a/spec/helpers/theme_helper_spec.rb
+++ b/spec/helpers/theme_helper_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ThemeHelper do
           )
         expect(html_links.last.attributes.symbolize_keys)
           .to include(
-            href: have_attributes(value: match(/application/)),
+            href: have_attributes(value: match(/default/)),
             media: have_attributes(value: '(prefers-color-scheme: dark)')
           )
       end
@@ -26,10 +26,10 @@ RSpec.describe ThemeHelper do
     context 'when using "default" theme' do
       let(:theme) { 'default' }
 
-      it 'returns the application stylesheet' do
+      it 'returns the default stylesheet' do
         expect(html_links.last.attributes.symbolize_keys)
           .to include(
-            href: have_attributes(value: match(/application/))
+            href: have_attributes(value: match(/default/))
           )
       end
     end

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -16,6 +16,7 @@ import postcssPresetEnv from 'postcss-preset-env';
 import { MastodonServiceWorkerLocales } from './config/vite/plugin-sw-locales';
 import { MastodonEmojiCompressed } from './config/vite/plugin-emoji-compressed';
 import { MastodonThemes } from './config/vite/plugin-mastodon-themes';
+import { MastodonNameLookup } from './config/vite/plugin-name-lookup';
 
 const jsRoot = path.resolve(__dirname, 'app/javascript');
 
@@ -125,6 +126,7 @@ export const config: UserConfigFnPromise = async ({ mode, command }) => {
       // Old library types need to be converted
       optimizeLodashImports() as PluginOption,
       !!process.env.ANALYZE_BUNDLE_SIZE && (visualizer() as PluginOption),
+      MastodonNameLookup(),
     ],
   } satisfies UserConfig;
 };


### PR DESCRIPTION
This adds a new plugin that generates a lookup file for use of fast name-based chunk lookups. This also sets theme chunk names to be prefixed with `themes/` followed by theme name in `themes.yml`.