### PR TITLE
Use `config_for` for omniauth enabled values

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -98,7 +98,7 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sign_out_path_for(_resource_or_scope)
-    if ENV['OMNIAUTH_ONLY'] == 'true' && ENV['OIDC_ENABLED'] == 'true'
+    if ENV['OMNIAUTH_ONLY'] == 'true' && Rails.configuration.x.omniauth.oidc_enabled?
       '/auth/auth/openid_connect/logout'
     else
       new_user_session_path

--- a/config/application.rb
+++ b/config/application.rb
@@ -106,6 +106,7 @@ module Mastodon
     config.x.cache_buster = config_for(:cache_buster)
     config.x.captcha = config_for(:captcha)
     config.x.mastodon = config_for(:mastodon)
+    config.x.omniauth = config_for(:omniauth)
     config.x.translation = config_for(:translation)
     config.x.vapid = config_for(:vapid)
 

--- a/config/initializers/3_omniauth.rb
+++ b/config/initializers/3_omniauth.rb
@@ -10,7 +10,7 @@ end
 
 Devise.setup do |config|
   # CAS strategy
-  if ENV['CAS_ENABLED'] == 'true'
+  if Rails.configuration.x.omniauth.cas_enabled?
     cas_options = {}
     cas_options[:display_name] = ENV.fetch('CAS_DISPLAY_NAME', nil)
     cas_options[:url] = ENV['CAS_URL'] if ENV['CAS_URL']
@@ -39,7 +39,7 @@ Devise.setup do |config|
   end
 
   # SAML strategy
-  if ENV['SAML_ENABLED'] == 'true'
+  if Rails.configuration.x.omniauth.saml_enabled?
     saml_options = {}
     saml_options[:display_name] = ENV.fetch('SAML_DISPLAY_NAME', nil)
     saml_options[:assertion_consumer_service_url] = ENV['SAML_ACS_URL'] if ENV['SAML_ACS_URL']
@@ -71,7 +71,7 @@ Devise.setup do |config|
   end
 
   # OpenID Connect Strategy
-  if ENV['OIDC_ENABLED'] == 'true'
+  if Rails.configuration.x.omniauth.oidc_enabled?
     oidc_options = {}
     oidc_options[:display_name] = ENV.fetch('OIDC_DISPLAY_NAME', nil) # OPTIONAL
     oidc_options[:issuer] = ENV['OIDC_ISSUER'] if ENV['OIDC_ISSUER'] # NEED

--- a/config/omniauth.yml
+++ b/config/omniauth.yml
@@ -1,0 +1,4 @@
+shared:
+  cas_enabled?: <%= ENV.fetch('CAS_ENABLED', 'false') == 'true' %>
+  oidc_enabled?: <%= ENV.fetch('OIDC_ENABLED', 'false') == 'true' %>
+  saml_enabled?: <%= ENV.fetch('SAML_ENABLED', 'false') == 'true' %>

--- a/spec/requests/omniauth_callbacks_spec.rb
+++ b/spec/requests/omniauth_callbacks_spec.rb
@@ -129,15 +129,15 @@ RSpec.describe 'OmniAuth callbacks' do
     end
   end
 
-  describe '#openid_connect', if: ENV['OIDC_ENABLED'] == 'true' && ENV['OIDC_SCOPE'].present? do
+  describe '#openid_connect', if: Rails.configuration.x.omniauth.oidc_enabled? && ENV['OIDC_SCOPE'].present? do
     it_behaves_like 'omniauth provider callbacks', :openid_connect
   end
 
-  describe '#cas', if: ENV['CAS_ENABLED'] == 'true' do
+  describe '#cas', if: Rails.configuration.x.omniauth.cas_enabled? do
     it_behaves_like 'omniauth provider callbacks', :cas
   end
 
-  describe '#saml', if: ENV['SAML_ENABLED'] == 'true' do
+  describe '#saml', if: Rails.configuration.x.omniauth.saml_enabled? do
     it_behaves_like 'omniauth provider callbacks', :saml
   end
 end


### PR DESCRIPTION
Repeating portions of https://github.com/mastodon/mastodon/pull/30507 and https://github.com/mastodon/mastodon/pull/30650 - except on an even smaller and hopefully simpler portion this time.

The plan here would be to extract each of the cas/saml/oidc portions of the omniauth initializer into the yml as well, which I think would be an improved cleanup to that initializer when done (use yaml to build the hashes, use `fetch` for defaults, etc).