### PR TITLE
Reduce hard coding of instance hostname in `AdminMailer` specs

### DIFF
--- a/spec/mailers/admin_mailer_spec.rb
+++ b/spec/mailers/admin_mailer_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe AdminMailer do
         .to be_present
         .and(deliver_to(recipient.user_email))
         .and(deliver_from('notifications@localhost'))
-        .and(have_subject("New report for cb6e6126.ngrok.io (##{report.id})"))
-        .and(have_body_text("Mike,\r\n\r\nJohn has reported Mike\r\n\r\nView: https://cb6e6126.ngrok.io/admin/reports/#{report.id}\r\n"))
+        .and(have_subject(I18n.t('admin_mailer.new_report.subject', instance: Rails.configuration.x.local_domain, id: report.id)))
+        .and(have_body_text("Mike,\r\n\r\nJohn has reported Mike\r\n\r\nView: #{admin_report_url(report)}\r\n"))
     end
   end
 
@@ -37,7 +37,7 @@ RSpec.describe AdminMailer do
         .to be_present
         .and(deliver_to(recipient.user_email))
         .and(deliver_from('notifications@localhost'))
-        .and(have_subject("#{appeal.account.username} is appealing a moderation decision on cb6e6126.ngrok.io"))
+        .and(have_subject(I18n.t('admin_mailer.new_appeal.subject', instance: Rails.configuration.x.local_domain, username: appeal.account.username)))
         .and(have_body_text("#{appeal.account.username} is appealing a moderation decision by #{appeal.strike.account.username}"))
     end
   end
@@ -56,7 +56,7 @@ RSpec.describe AdminMailer do
         .to be_present
         .and(deliver_to(recipient.user_email))
         .and(deliver_from('notifications@localhost'))
-        .and(have_subject("New account up for review on cb6e6126.ngrok.io (#{user.account.username})"))
+        .and(have_subject(I18n.t('admin_mailer.new_pending_account.subject', instance: Rails.configuration.x.local_domain, username: user.account.username)))
         .and(have_body_text('The details of the new account are below. You can approve or reject this application.'))
     end
   end
@@ -80,7 +80,7 @@ RSpec.describe AdminMailer do
         .to be_present
         .and(deliver_to(recipient.user_email))
         .and(deliver_from('notifications@localhost'))
-        .and(have_subject('New trends up for review on cb6e6126.ngrok.io'))
+        .and(have_subject(I18n.t('admin_mailer.new_trends.subject', instance: Rails.configuration.x.local_domain)))
         .and(have_body_text('The following items need a review before they can be displayed publicly'))
         .and(have_body_text(ActivityPub::TagManager.instance.url_for(status)))
         .and(have_body_text(link.title))
@@ -101,7 +101,7 @@ RSpec.describe AdminMailer do
         .to be_present
         .and(deliver_to(recipient.user_email))
         .and(deliver_from('notifications@localhost'))
-        .and(have_subject('New Mastodon versions are available for cb6e6126.ngrok.io!'))
+        .and(have_subject(I18n.t('admin_mailer.new_software_updates.subject', instance: Rails.configuration.x.local_domain)))
         .and(have_body_text('New Mastodon versions have been released, you may want to update!'))
     end
   end
@@ -119,7 +119,7 @@ RSpec.describe AdminMailer do
         .to be_present
         .and(deliver_to(recipient.user_email))
         .and(deliver_from('notifications@localhost'))
-        .and(have_subject('Critical Mastodon updates are available for cb6e6126.ngrok.io!'))
+        .and(have_subject(I18n.t('admin_mailer.new_critical_software_updates.subject', instance: Rails.configuration.x.local_domain)))
         .and(have_body_text('New critical versions of Mastodon have been released, you may want to update as soon as possible!'))
         .and(have_header('Importance', 'high'))
         .and(have_header('Priority', 'urgent'))
@@ -140,7 +140,7 @@ RSpec.describe AdminMailer do
         .to be_present
         .and(deliver_to(recipient.user_email))
         .and(deliver_from('notifications@localhost'))
-        .and(have_subject('Registrations for cb6e6126.ngrok.io have been automatically switched to requiring approval'))
+        .and(have_subject(I18n.t('admin_mailer.auto_close_registrations.subject', instance: Rails.configuration.x.local_domain)))
         .and(have_body_text('have been automatically switched'))
     end
   end


### PR DESCRIPTION
Background: https://github.com/mastodon/mastodon/pull/34867#issuecomment-2963949283

In this one, we care mainly about "is this using the subject we expected", and less about the exact text or whether the instance hostname env var matches the hard-coded value.