### PR TITLE
fix: Fix error caused by attempt to fetch non-existent quote

### DIFF
--- a/app/javascript/mastodon/components/status_quoted.tsx
+++ b/app/javascript/mastodon/components/status_quoted.tsx
@@ -89,7 +89,7 @@ export const QuotedStatus: React.FC<{
   );
 
   useEffect(() => {
-    if (!status) {
+    if (!status && quotedStatusId) {
       dispatch(fetchStatus(quotedStatusId));
     }
   }, [status, quotedStatusId, dispatch]);


### PR DESCRIPTION
### Changes proposed in this PR:
- Fixes oversight from #35016 that could cause an uncaught error and crash the app for statuses with `quotedStatusId: null`