### PR TITLE
fix: Avatars too large on notifications page

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1980,6 +1980,13 @@ body > [data-popper-placement] {
     }
   }
 
+  &__avatar-wrapper .account__avatar {
+    @container (width < 360px) {
+      width: 35px !important;
+      height: 35px !important;
+    }
+  }
+
   &__domain-pill {
     display: inline-flex;
     background: rgba($highlight-text-color, 0.2);
@@ -2150,11 +2157,6 @@ body > [data-popper-placement] {
   position: relative;
   border-radius: var(--avatar-border-radius);
   background: var(--surface-background-color);
-
-  @container (width < 360px) {
-    width: 35px !important;
-    height: 35px !important;
-  }
 
   img {
     width: 100%;


### PR DESCRIPTION
### Changes proposed in this PR:
- Fixes avatars being too large on notifications page (and potentially other places) caused by a CSS override being applied too widely. The override is now scoped more safely.

### Screenshots

<img width="312" alt="image" src="https://github.com/user-attachments/assets/b460fe96-852f-4aff-aed8-3645bec07a3c" />
