### PR TITLE
fix: Hide limited user info in hover card

### DIFF
--- a/app/javascript/mastodon/components/hover_card_account.tsx
+++ b/app/javascript/mastodon/components/hover_card_account.tsx
@@ -20,6 +20,7 @@ import { LoadingIndicator } from 'mastodon/components/loading_indicator';
 import { ShortNumber } from 'mastodon/components/short_number';
 import { useFetchFamiliarFollowers } from 'mastodon/features/account_timeline/hooks/familiar_followers';
 import { domain } from 'mastodon/initial_state';
+import { getAccountHidden } from 'mastodon/selectors/accounts';
 import { useAppSelector, useAppDispatch } from 'mastodon/store';
 
 export const HoverCardAccount = forwardRef<
@@ -31,6 +32,11 @@ export const HoverCardAccount = forwardRef<
   const account = useAppSelector((state) =>
     accountId ? state.accounts.get(accountId) : undefined,
   );
+  const suspended = account?.suspended;
+  const hidden = useAppSelector((state) =>
+    accountId ? getAccountHidden(state, accountId) : undefined,
+  );
+  const isSuspendedOrHidden = Boolean(suspended || hidden);
 
   const note = useAppSelector(
     (state) =>
@@ -70,69 +76,95 @@ export const HoverCardAccount = forwardRef<
       {account ? (
         <>
           <Link to={`/@${account.acct}`} className='hover-card__name'>
-            <Avatar account={account} size={46} />
+            <Avatar
+              account={isSuspendedOrHidden ? undefined : account}
+              size={46}
+            />
             <DisplayName account={account} localDomain={domain} />
           </Link>
 
-          <div className='hover-card__text-row'>
-            <AccountBio
-              note={account.note_emojified}
-              className='hover-card__bio'
-            />
-            <AccountFields fields={account.fields} limit={2} />
-            {note && note.length > 0 && (
-              <dl className='hover-card__note'>
-                <dt className='hover-card__note-label'>
-                  <FormattedMessage
-                    id='account.account_note_header'
-                    defaultMessage='Personal note'
-                  />
-                </dt>
-                <dd>{note}</dd>
-              </dl>
-            )}
-          </div>
-
-          <div className='hover-card__numbers'>
-            <ShortNumber
-              value={account.followers_count}
-              renderer={FollowersCounter}
-            />
-            {shouldDisplayFamiliarFollowers && (
-              <>
-                &middot;
-                <div className='hover-card__familiar-followers'>
-                  <ShortNumber
-                    value={familiarFollowers.length}
-                    renderer={FollowersYouKnowCounter}
-                  />
-                  <AvatarGroup compact>
-                    {familiarFollowers.slice(0, 3).map((account) => (
-                      <Avatar key={account.id} account={account} size={22} />
-                    ))}
-                  </AvatarGroup>
-                </div>
-              </>
-            )}
-            {(isMutual || isFollower) && (
-              <>
-                &middot;
-                {isMutual ? (
-                  <FormattedMessage
-                    id='account.mutual'
-                    defaultMessage='You follow each other'
-                  />
-                ) : (
-                  <FormattedMessage
-                    id='account.follows_you'
-                    defaultMessage='Follows you'
-                  />
+          {isSuspendedOrHidden ? (
+            <div className='hover-card__limited-account-note'>
+              {suspended ? (
+                <FormattedMessage
+                  id='empty_column.account_suspended'
+                  defaultMessage='Account suspended'
+                />
+              ) : (
+                <FormattedMessage
+                  id='limited_account_hint.title'
+                  defaultMessage='This profile has been hidden by the moderators of {domain}.'
+                  values={{ domain }}
+                />
+              )}
+            </div>
+          ) : (
+            <>
+              <div className='hover-card__text-row'>
+                <AccountBio
+                  note={account.note_emojified}
+                  className='hover-card__bio'
+                />
+                <AccountFields fields={account.fields} limit={2} />
+                {note && note.length > 0 && (
+                  <dl className='hover-card__note'>
+                    <dt className='hover-card__note-label'>
+                      <FormattedMessage
+                        id='account.account_note_header'
+                        defaultMessage='Personal note'
+                      />
+                    </dt>
+                    <dd>{note}</dd>
+                  </dl>
                 )}
-              </>
-            )}
-          </div>
+              </div>
 
-          <FollowButton accountId={accountId} />
+              <div className='hover-card__numbers'>
+                <ShortNumber
+                  value={account.followers_count}
+                  renderer={FollowersCounter}
+                />
+                {shouldDisplayFamiliarFollowers && (
+                  <>
+                    &middot;
+                    <div className='hover-card__familiar-followers'>
+                      <ShortNumber
+                        value={familiarFollowers.length}
+                        renderer={FollowersYouKnowCounter}
+                      />
+                      <AvatarGroup compact>
+                        {familiarFollowers.slice(0, 3).map((account) => (
+                          <Avatar
+                            key={account.id}
+                            account={account}
+                            size={22}
+                          />
+                        ))}
+                      </AvatarGroup>
+                    </div>
+                  </>
+                )}
+                {(isMutual || isFollower) && (
+                  <>
+                    &middot;
+                    {isMutual ? (
+                      <FormattedMessage
+                        id='account.mutual'
+                        defaultMessage='You follow each other'
+                      />
+                    ) : (
+                      <FormattedMessage
+                        id='account.follows_you'
+                        defaultMessage='Follows you'
+                      />
+                    )}
+                  </>
+                )}
+              </div>
+
+              <FollowButton accountId={accountId} />
+            </>
+          )}
         </>
       ) : (
         <LoadingIndicator />

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -10897,6 +10897,11 @@ noscript {
     }
   }
 
+  &__limited-account-note {
+    text-align: center;
+    font-weight: 500;
+  }
+
   .display-name {
     font-size: 15px;
     line-height: 22px;


### PR DESCRIPTION
Fixes #34915

### Changes proposed in this PR:
- The hover card for hidden or suspended accounts now hides all information that's also hidden on the full profile page

> [!TIP]
> This PR is best reviewed with [white-space changes turned off.](https://github.com/mastodon/mastodon/pull/35024/files?w=1)

### Screenshots
<img width="314" alt="image" src="https://github.com/user-attachments/assets/68388f7e-576c-445b-922c-142341fce597" />
