### PR TITLE
Reduce hard coding of `LOCAL_DOMAIN` env value throughout tests

### DIFF
--- a/spec/controllers/concerns/account_controller_concern_spec.rb
+++ b/spec/controllers/concerns/account_controller_concern_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe AccountControllerConcern do
 
   before do
     routes.draw { get 'success' => 'anonymous#success' }
+    request.host = Rails.configuration.x.local_domain
   end
 
   context 'when account is unconfirmed' do
@@ -56,8 +57,8 @@ RSpec.describe AccountControllerConcern do
 
       expect(response)
         .to have_http_status(200)
-        .and have_http_link_header('http://test.host/.well-known/webfinger?resource=acct%3Ausername%40cb6e6126.ngrok.io').for(rel: 'lrdd', type: 'application/jrd+json')
-        .and have_http_link_header('https://cb6e6126.ngrok.io/users/username').for(rel: 'alternate', type: 'application/activity+json')
+        .and have_http_link_header(webfinger_url(resource: account.to_webfinger_s)).for(rel: 'lrdd', type: 'application/jrd+json')
+        .and have_http_link_header(account_url(account, protocol: :https)).for(rel: 'alternate', type: 'application/activity+json')
       expect(response.body)
         .to include(account.username)
     end

--- a/spec/helpers/home_helper_spec.rb
+++ b/spec/helpers/home_helper_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe HomeHelper do
         allow(helper).to receive(:closed_registrations?).and_return(true)
         result = helper.sign_up_message
 
-        expect(result).to eq t('auth.registration_closed', instance: 'cb6e6126.ngrok.io')
+        expect(result).to eq t('auth.registration_closed', instance: Rails.configuration.x.local_domain)
       end
     end
 

--- a/spec/lib/admin/system_check/media_privacy_check_spec.rb
+++ b/spec/lib/admin/system_check/media_privacy_check_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Admin::SystemCheck::MediaPrivacyCheck do
   describe 'pass?' do
     context 'when the media cannot be listed' do
       before do
-        stub_request(:get, /ngrok.io/).to_return(status: 200, body: 'a list of no files')
+        stub_request(:get, /#{Regexp.quote(Rails.configuration.x.local_domain)}/).to_return(status: 200, body: 'a list of no files')
       end
 
       it 'returns true' do

--- a/spec/lib/ostatus/tag_manager_spec.rb
+++ b/spec/lib/ostatus/tag_manager_spec.rb
@@ -3,15 +3,25 @@
 require 'rails_helper'
 
 RSpec.describe OStatus::TagManager do
+  around do |example|
+    original = Rails.configuration.x.local_domain
+    example.run
+    Rails.configuration.x.local_domain = original
+  end
+
   describe '#unique_tag' do
+    before { Rails.configuration.x.local_domain = 'mastodon.example' }
+
     it 'returns a unique tag' do
-      expect(described_class.instance.unique_tag(Time.utc(2000), 12, 'Status')).to eq 'tag:cb6e6126.ngrok.io,2000-01-01:objectId=12:objectType=Status'
+      expect(described_class.instance.unique_tag(Time.utc(2000), 12, 'Status')).to eq 'tag:mastodon.example,2000-01-01:objectId=12:objectType=Status'
     end
   end
 
   describe '#unique_tag_to_local_id' do
+    before { Rails.configuration.x.local_domain = 'mastodon.example' }
+
     it 'returns the ID part' do
-      expect(described_class.instance.unique_tag_to_local_id('tag:cb6e6126.ngrok.io,2000-01-01:objectId=12:objectType=Status', 'Status')).to eql '12'
+      expect(described_class.instance.unique_tag_to_local_id('tag:mastodon.example,2000-01-01:objectId=12:objectType=Status', 'Status')).to eql '12'
     end
 
     it 'returns nil if it is not local id' do
@@ -19,17 +29,19 @@ RSpec.describe OStatus::TagManager do
     end
 
     it 'returns nil if it is not expected type' do
-      expect(described_class.instance.unique_tag_to_local_id('tag:cb6e6126.ngrok.io,2000-01-01:objectId=12:objectType=Block', 'Status')).to be_nil
+      expect(described_class.instance.unique_tag_to_local_id('tag:mastodon.example,2000-01-01:objectId=12:objectType=Block', 'Status')).to be_nil
     end
 
     it 'returns nil if it does not have object ID' do
-      expect(described_class.instance.unique_tag_to_local_id('tag:cb6e6126.ngrok.io,2000-01-01:objectType=Status', 'Status')).to be_nil
+      expect(described_class.instance.unique_tag_to_local_id('tag:mastodon.example,2000-01-01:objectType=Status', 'Status')).to be_nil
     end
   end
 
   describe '#local_id?' do
+    before { Rails.configuration.x.local_domain = 'mastodon.example' }
+
     it 'returns true for a local ID' do
-      expect(described_class.instance.local_id?('tag:cb6e6126.ngrok.io;objectId=12:objectType=Status')).to be true
+      expect(described_class.instance.local_id?('tag:mastodon.example;objectId=12:objectType=Status')).to be true
     end
 
     it 'returns false for a foreign ID' do
@@ -63,7 +75,7 @@ RSpec.describe OStatus::TagManager do
 
       it 'returns the URL for account' do
         expect(target.object_type).to eq :person
-        expect(subject).to eq 'https://cb6e6126.ngrok.io/users/alice'
+        expect(subject).to eq "https://#{Rails.configuration.x.local_domain}/users/alice"
       end
     end
   end

--- a/spec/lib/text_formatter_spec.rb
+++ b/spec/lib/text_formatter_spec.rb
@@ -29,7 +29,10 @@ RSpec.describe TextFormatter do
       let(:text) { '@alice' }
 
       it 'creates a mention link' do
-        expect(subject).to include '<a href="https://cb6e6126.ngrok.io/@alice" class="u-url mention">@<span>alice</span></a></span>'
+        expect(subject)
+          .to include(<<~LINK.squish)
+            <a href="https://#{Rails.configuration.x.local_domain}/@alice" class="u-url mention">@<span>alice</span></a>
+          LINK
       end
     end
 

--- a/spec/models/remote_follow_spec.rb
+++ b/spec/models/remote_follow_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe RemoteFollow do
     let(:account) { Fabricate(:account, username: 'alice') }
 
     it 'returns subscribe address' do
-      expect(subject).to eq 'https://quitter.no/main/ostatussub?profile=https%3A%2F%2Fcb6e6126.ngrok.io%2Fusers%2Falice'
+      expect(subject).to eq "https://quitter.no/main/ostatussub?profile=https%3A%2F%2F#{Rails.configuration.x.local_domain}%2Fusers%2Falice"
     end
   end
 end

--- a/spec/requests/api/v1/accounts/featured_tags_spec.rb
+++ b/spec/requests/api/v1/accounts/featured_tags_spec.rb
@@ -27,10 +27,10 @@ RSpec.describe 'account featured tags API' do
         .to start_with('application/json')
       expect(response.parsed_body).to contain_exactly(a_hash_including({
         name: 'bar',
-        url: "https://cb6e6126.ngrok.io/@#{account.username}/tagged/bar",
+        url: short_account_tag_url(username: account.username, tag: 'bar'),
       }), a_hash_including({
         name: 'foo',
-        url: "https://cb6e6126.ngrok.io/@#{account.username}/tagged/foo",
+        url: short_account_tag_url(username: account.username, tag: 'foo'),
       }))
     end
 
@@ -43,10 +43,10 @@ RSpec.describe 'account featured tags API' do
           .to start_with('application/json')
         expect(response.parsed_body).to contain_exactly(a_hash_including({
           name: 'bar',
-          url: "https://cb6e6126.ngrok.io/@#{account.pretty_acct}/tagged/bar",
+          url: short_account_tag_url(username: account.pretty_acct, tag: 'bar'),
         }), a_hash_including({
           name: 'foo',
-          url: "https://cb6e6126.ngrok.io/@#{account.pretty_acct}/tagged/foo",
+          url: short_account_tag_url(username: account.pretty_acct, tag: 'foo'),
         }))
       end
     end

--- a/spec/requests/content_security_policy_spec.rb
+++ b/spec/requests/content_security_policy_spec.rb
@@ -22,19 +22,23 @@ RSpec.describe 'Content-Security-Policy' do
   def expected_csp_headers
     <<~CSP.split("\n").map(&:strip)
       base-uri 'none'
-      child-src 'self' blob: https://cb6e6126.ngrok.io
-      connect-src 'self' data: blob: https://cb6e6126.ngrok.io #{Rails.configuration.x.streaming_api_base_url}
+      child-src 'self' blob: #{local_domain}
+      connect-src 'self' data: blob: #{local_domain} #{Rails.configuration.x.streaming_api_base_url}
       default-src 'none'
-      font-src 'self' https://cb6e6126.ngrok.io
+      font-src 'self' #{local_domain}
       form-action 'none'
       frame-ancestors 'none'
       frame-src 'self' https:
-      img-src 'self' data: blob: https://cb6e6126.ngrok.io
-      manifest-src 'self' https://cb6e6126.ngrok.io
-      media-src 'self' data: https://cb6e6126.ngrok.io
-      script-src 'self' https://cb6e6126.ngrok.io 'wasm-unsafe-eval'
-      style-src 'self' https://cb6e6126.ngrok.io 'nonce-ZbA+JmE7+bK8F5qvADZHuQ=='
-      worker-src 'self' blob: https://cb6e6126.ngrok.io
+      img-src 'self' data: blob: #{local_domain}
+      manifest-src 'self' #{local_domain}
+      media-src 'self' data: #{local_domain}
+      script-src 'self' #{local_domain} 'wasm-unsafe-eval'
+      style-src 'self' #{local_domain} 'nonce-ZbA+JmE7+bK8F5qvADZHuQ=='
+      worker-src 'self' blob: #{local_domain}
     CSP
+  end
+
+  def local_domain
+    root_url(host: Rails.configuration.x.local_domain).chop
   end
 end

--- a/spec/requests/link_headers_spec.rb
+++ b/spec/requests/link_headers_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe 'Link headers' do
       get short_account_path(username: account)
 
       expect(response)
-        .to have_http_link_header('https://cb6e6126.ngrok.io/.well-known/webfinger?resource=acct%3Atest%40cb6e6126.ngrok.io').for(rel: 'lrdd', type: 'application/jrd+json')
-        .and have_http_link_header('https://cb6e6126.ngrok.io/users/test').for(rel: 'alternate', type: 'application/activity+json')
+        .to have_http_link_header(webfinger_url(resource: account.to_webfinger_s)).for(rel: 'lrdd', type: 'application/jrd+json')
+        .and have_http_link_header(account_url(account)).for(rel: 'alternate', type: 'application/activity+json')
     end
   end
 end

--- a/spec/requests/remote_interaction_helper_spec.rb
+++ b/spec/requests/remote_interaction_helper_spec.rb
@@ -25,7 +25,15 @@ RSpec.describe 'Remote Interaction Helper' do
 
   def expected_csp_headers
     <<~CSP.squish
-      default-src 'none'; frame-ancestors 'self'; form-action 'none'; script-src 'self' https://cb6e6126.ngrok.io 'wasm-unsafe-eval'; connect-src https:
+      default-src 'none';
+      frame-ancestors 'self';
+      form-action 'none';
+      script-src 'self' #{local_domain} 'wasm-unsafe-eval';
+      connect-src https:
     CSP
+  end
+
+  def local_domain
+    root_url(host: Rails.configuration.x.local_domain).chop
   end
 end

--- a/spec/requests/well_known/host_meta_spec.rb
+++ b/spec/requests/well_known/host_meta_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'The /.well-known/host-meta request' do
         )
 
       expect(xrd_link_template_value)
-        .to eq 'https://cb6e6126.ngrok.io/.well-known/webfinger?resource={uri}'
+        .to eq "https://#{Rails.configuration.x.local_domain}/.well-known/webfinger?resource={uri}"
     end
 
     def xrd_link_template_value
@@ -57,7 +57,7 @@ RSpec.describe 'The /.well-known/host-meta request' do
     {
       links: [
         'rel' => 'lrdd',
-        'template' => 'https://cb6e6126.ngrok.io/.well-known/webfinger?resource={uri}',
+        'template' => "https://#{Rails.configuration.x.local_domain}/.well-known/webfinger?resource={uri}",
       ],
     }
   end

--- a/spec/requests/well_known/webfinger_spec.rb
+++ b/spec/requests/well_known/webfinger_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe 'The /.well-known/webfinger endpoint' do
 
       expect(response.parsed_body)
         .to include(
-          subject: eq('acct:alice@cb6e6126.ngrok.io'),
-          aliases: include('https://cb6e6126.ngrok.io/@alice', 'https://cb6e6126.ngrok.io/users/alice')
+          subject: eq(alice.to_webfinger_s),
+          aliases: include("https://#{Rails.configuration.x.local_domain}/@alice", "https://#{Rails.configuration.x.local_domain}/users/alice")
         )
     end
   end
@@ -125,9 +125,13 @@ RSpec.describe 'The /.well-known/webfinger endpoint' do
 
       expect(response.parsed_body)
         .to include(
-          subject: 'acct:mastodon.internal@cb6e6126.ngrok.io',
-          aliases: ['https://cb6e6126.ngrok.io/actor']
+          subject: instance_actor.to_webfinger_s,
+          aliases: [instance_actor_url]
         )
+    end
+
+    def instance_actor
+      Account.where(id: Account::INSTANCE_ACTOR_ID).first
     end
   end
 

--- a/spec/support/examples/mailers.rb
+++ b/spec/support/examples/mailers.rb
@@ -21,7 +21,7 @@ RSpec::Matchers.define :have_thread_headers do
       .and(have_header('References', conversation_header_regex))
   end
 
-  def conversation_header_regex = /<conversation-\d+.\d\d\d\d-\d\d-\d\d@cb6e6126.ngrok.io>/
+  def conversation_header_regex = /<conversation-\d+.\d\d\d\d-\d\d-\d\d@#{Regexp.quote(Rails.configuration.x.local_domain)}>/
 end
 
 RSpec::Matchers.define :have_standard_headers do |type|

--- a/spec/system/captcha_spec.rb
+++ b/spec/system/captcha_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'email confirmation flow when captcha is enabled' do
 
       # It presents a page with a link to the app callback
       expect(page)
-        .to have_content(I18n.t('auth.confirmations.registration_complete', domain: 'cb6e6126.ngrok.io'))
+        .to have_content(I18n.t('auth.confirmations.registration_complete', domain: Rails.configuration.x.local_domain))
         .and have_link(I18n.t('auth.confirmations.clicking_this_link'), href: client_app.confirmation_redirect_uri)
     end
   end

--- a/spec/system/redirections_spec.rb
+++ b/spec/system/redirections_spec.rb
@@ -31,6 +31,6 @@ RSpec.describe 'redirection confirmations' do
   end
 
   def redirect_title
-    I18n.t('redirects.title', instance: 'cb6e6126.ngrok.io')
+    I18n.t('redirects.title', instance: Rails.configuration.x.local_domain)
   end
 end


### PR DESCRIPTION
Following up on https://github.com/mastodon/mastodon/pull/35019 and https://github.com/mastodon/mastodon/pull/35020

Background: https://github.com/mastodon/mastodon/pull/34867#issuecomment-2963949283

I believe this handles the remainder of the hard-coded references to the env var, and should make it easier to address concerns from the linked comment.
