### PR TITLE
Add setting to disable live feeds

### DIFF
--- a/app/javascript/mastodon/features/ui/components/navigation_panel.tsx
+++ b/app/javascript/mastodon/features/ui/components/navigation_panel.tsx
@@ -35,7 +35,12 @@ import { WordmarkLogo } from 'mastodon/components/logo';
 import { NavigationPortal } from 'mastodon/components/navigation_portal';
 import { useBreakpoint } from 'mastodon/features/ui/hooks/useBreakpoint';
 import { useIdentity } from 'mastodon/identity_context';
-import { timelinePreview, trendsEnabled, me } from 'mastodon/initial_state';
+import {
+  timelinePreview,
+  firehoseEnabled,
+  trendsEnabled,
+  me,
+} from 'mastodon/initial_state';
 import { transientSingleColumn } from 'mastodon/is_mobile';
 import { selectUnreadNotificationGroupsCount } from 'mastodon/selectors/notifications';
 import { useAppSelector, useAppDispatch } from 'mastodon/store';
@@ -365,7 +370,7 @@ export const NavigationPanel: React.FC = () => {
 
             <SearchLink />
 
-            {(signedIn || timelinePreview) && (
+            {firehoseEnabled && (signedIn || timelinePreview) && (
               <ColumnLink
                 transparent
                 to='/public/local'

--- a/app/javascript/mastodon/initial_state.js
+++ b/app/javascript/mastodon/initial_state.js
@@ -37,6 +37,7 @@
  * @property {string} source_url
  * @property {string} streaming_api_base_url
  * @property {boolean} timeline_preview
+ * @property {boolean} firehose_enabled
  * @property {string} title
  * @property {boolean} show_trends
  * @property {boolean} trends_as_landing_page
@@ -112,6 +113,7 @@ export const showTrends = getMeta('show_trends');
 export const singleUserMode = getMeta('single_user_mode');
 export const source_url = getMeta('source_url');
 export const timelinePreview = getMeta('timeline_preview');
+export const firehoseEnabled = getMeta('firehose_enabled');
 export const title = getMeta('title');
 export const trendsAsLanding = getMeta('trends_as_landing_page');
 export const useBlurhash = getMeta('use_blurhash');

--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -15,6 +15,7 @@ class Form::AdminSettings
     registrations_mode
     closed_registrations_message
     timeline_preview
+    firehose_enabled
     bootstrap_timeline_accounts
     theme
     activity_api_enabled
@@ -53,6 +54,7 @@ class Form::AdminSettings
   BOOLEAN_KEYS = %i(
     allow_referrer_origin
     timeline_preview
+    firehose_enabled
     activity_api_enabled
     peers_api_enabled
     preview_sensitive_media

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -106,6 +106,7 @@ class InitialStateSerializer < ActiveModel::Serializer
       status_page_url: Setting.status_page_url,
       streaming_api_base_url: Rails.configuration.x.streaming_api_base_url,
       timeline_preview: Setting.timeline_preview,
+      firehose_enabled: Setting.firehose_enabled,
       title: instance_presenter.title,
       trends_as_landing_page: Setting.trends_as_landing_page,
       trends_enabled: Setting.trends,

--- a/app/views/admin/settings/discovery/show.html.haml
+++ b/app/views/admin/settings/discovery/show.html.haml
@@ -31,6 +31,11 @@
   %h4= t('admin.settings.discovery.public_timelines')
 
   .fields-group
+    = f.input :firehose_enabled,
+              as: :boolean,
+              wrapper: :with_label
+
+  .fields-group
     = f.input :timeline_preview,
               as: :boolean,
               wrapper: :with_label

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -827,7 +827,7 @@ en:
         preamble: Surfacing interesting content is instrumental in onboarding new users who may not know anyone Mastodon. Control how various discovery features work on your server.
         privacy: Privacy
         profile_directory: Profile directory
-        public_timelines: Public timelines
+        public_timelines: Live feeds
         publish_statistics: Publish statistics
         title: Discovery
         trends: Trends

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -88,6 +88,7 @@ en:
         content_cache_retention_period: All posts from other servers (including boosts and replies) will be deleted after the specified number of days, without regard to any local user interaction with those posts. This includes posts where a local user has marked it as bookmarks or favorites. Private mentions between users from different instances will also be lost and impossible to restore. Use of this setting is intended for special purpose instances and breaks many user expectations when implemented for general purpose use.
         custom_css: You can apply custom styles on the web version of Mastodon.
         favicon: WEBP, PNG, GIF or JPG. Overrides the default Mastodon favicon with a custom icon.
+        firehose_enabled: Live feeds allow browsing all public posts on this and other servers in chronological order.
         mascot: Overrides the illustration in the advanced web interface.
         media_cache_retention_period: Media files from posts made by remote users are cached on your server. When set to a positive value, media will be deleted after the specified number of days. If the media data is requested after it is deleted, it will be re-downloaded, if the source content is still available. Due to restrictions on how often link preview cards poll third-party sites, it is recommended to set this value to at least 14 days, or link preview cards will not be updated on demand before that time.
         min_age: Users will be asked to confirm their date of birth during sign-up
@@ -277,6 +278,7 @@ en:
         content_cache_retention_period: Remote content retention period
         custom_css: Custom CSS
         favicon: Favicon
+        firehose_enabled: Enable live feeds
         mascot: Custom mascot (legacy)
         media_cache_retention_period: Media cache retention period
         min_age: Minimum age requirement
@@ -295,7 +297,7 @@ en:
         status_page_url: Status page URL
         theme: Default theme
         thumbnail: Server thumbnail
-        timeline_preview: Allow unauthenticated access to public timelines
+        timeline_preview: Allow unauthenticated access to live feeds
         trendable_by_default: Allow trends without prior review
         trends: Enable trends
         trends_as_landing_page: Use trends as the landing page

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -12,6 +12,7 @@ defaults: &defaults
   registrations_mode: 'none'
   profile_directory: true
   closed_registrations_message: ''
+  firehose_enabled: true
   timeline_preview: true
   show_staff_badge: true
   preview_sensitive_media: false


### PR DESCRIPTION
This is a setting for larger servers where the local and federated feeds move too much to be useful.