### PR TITLE
fix: Fix unreadable text in high-contrast-mode

### DIFF
--- a/app/javascript/styles/contrast/diff.scss
+++ b/app/javascript/styles/contrast/diff.scss
@@ -37,10 +37,6 @@
   color: $highlight-text-color;
 }
 
-.nothing-here {
-  color: $darker-text-color;
-}
-
 .report-dialog-modal__textarea::placeholder {
   color: $inverted-text-color;
 }

--- a/app/javascript/styles/contrast/variables.scss
+++ b/app/javascript/styles/contrast/variables.scss
@@ -21,5 +21,5 @@ $ui-highlight-color: $classic-highlight-color !default;
   $action-button-color: lighten($ui-base-color, 50%),
   $inverted-text-color: $black,
   $lighter-text-color: darken($ui-base-color, 6%),
-  $light-text-color: darken($ui-primary-color, 40%)
+  $light-text-color: $classic-primary-color
 );

--- a/app/javascript/styles/mastodon/accounts.scss
+++ b/app/javascript/styles/mastodon/accounts.scss
@@ -162,7 +162,7 @@
 .nothing-here {
   background: $ui-base-color;
   box-shadow: 0 0 15px rgba($base-shadow-color, 0.2);
-  color: $light-text-color;
+  color: $darker-text-color;
   font-size: 14px;
   font-weight: 500;
   text-align: center;


### PR DESCRIPTION
Fixes #34689

### Changes proposed in this PR:
- Fixes text colour being too dark in "switch-to-advanced" banner when "High contrast" theme is selected

I had planned to retire the `$light-text-color` Sass variable and replace with a CSS variable as it's only used in 2 places now, but I think it makes more sense to address our CSS variable structure more holistically, so I kept it for now.

I did check that elements using the `.nothing-here` class are still readable in all stock themes.

### Screenshots

| **Before** | **After** |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/a2bcdca2-bd7c-4ed9-a1fd-dff43138b68e) | ![image](https://github.com/user-attachments/assets/bda940ed-deff-430b-bece-5e048702eb4d) | 