### PR TITLE
Re-instate rescuing signature errors

### DIFF
--- a/app/controllers/concerns/signature_verification.rb
+++ b/app/controllers/concerns/signature_verification.rb
@@ -24,14 +24,14 @@ module SignatureVerification
 
   def signature_key_id
     signed_request.key_id
+  rescue Mastodon::SignatureVerificationError
+    nil
   end
 
   private
 
   def signed_request
     @signed_request ||= SignedRequest.new(request) if signed_request?
-  rescue SignatureVerificationError
-    nil
   end
 
   def signature_verification_failure_reason


### PR DESCRIPTION
...when trying to access the key id. This was a regression in #34814.

This only became a problem in `production` because of this line here: https://github.com/mastodon/mastodon/blob/5ce055759fe52417da9d28773d9daa968c07d026/config/environments/production.rb#L94 which calls `#signature_key_id`.

Also removes a similar handler when initializing a signed request object, as the initializers involved do not raise.