### PR TITLE
fix: Fix glitchy video player controls in Safari

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -7309,6 +7309,7 @@ a.status-card {
     opacity: 0;
     pointer-events: none;
     transition: opacity 0.1s ease;
+    will-change: opacity, pointer-events;
 
     &.active {
       opacity: 1;


### PR DESCRIPTION
Fixes #34735

### Changes proposed in this PR:
- Give the video player controls their own stacking context to fix a rendering glitch when mousing over the video

### Screencaps

**Before:**

https://github.com/user-attachments/assets/1ad773ac-bf2c-4789-afc7-7cc6fbc8eeee 

**After:**

https://github.com/user-attachments/assets/28956ddd-1dab-474c-8701-b47569ee0d98