### PR TITLE
fix: Ensure digits in media player time readout have a consistent width

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -7415,6 +7415,9 @@ a.status-card {
     overflow: hidden;
     text-overflow: ellipsis;
     margin: 0 5px;
+
+    // Ensure digits maintain a consistent width
+    font-variant-numeric: tabular-nums;
   }
 
   &__time-sep,


### PR DESCRIPTION
Fixes #34778

### Changes proposed in this PR:
- Ensures digits in the audio or video player time readout have a consistent width when the "Use system’s default font" option is enabled

### Screencap

https://github.com/user-attachments/assets/c1819c7c-0170-42aa-813b-4a3a1700588f

