### PR TITLE
Allow more flexible host/port treatment with LOCAL_DOMAIN values in tests

### DIFF
--- a/spec/helpers/home_helper_spec.rb
+++ b/spec/helpers/home_helper_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe HomeHelper do
         allow(helper).to receive(:closed_registrations?).and_return(true)
         result = helper.sign_up_message
 
-        expect(result).to eq t('auth.registration_closed', instance: Rails.configuration.x.local_domain)
+        expect(result).to eq t('auth.registration_closed', instance: local_domain_uri.host)
       end
     end
 

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -326,7 +326,7 @@ RSpec.describe UserMailer do
       expect(mail)
         .to be_present
         .and(have_subject(I18n.t('user_mailer.announcement_published.subject')))
-        .and(have_body_text(I18n.t('user_mailer.announcement_published.description', domain: Rails.configuration.x.local_domain)))
+        .and(have_body_text(I18n.t('user_mailer.announcement_published.description', domain: local_domain_uri.host)))
     end
   end
 end

--- a/spec/models/remote_follow_spec.rb
+++ b/spec/models/remote_follow_spec.rb
@@ -61,7 +61,16 @@ RSpec.describe RemoteFollow do
     let(:account) { Fabricate(:account, username: 'alice') }
 
     it 'returns subscribe address' do
-      expect(subject).to eq "https://quitter.no/main/ostatussub?profile=https%3A%2F%2F#{Rails.configuration.x.local_domain}%2Fusers%2Falice"
+      expect(subject).to eq(expected_subscribe_url)
+    end
+
+    def expected_subscribe_url
+      Addressable::URI.new(
+        host: 'quitter.no',
+        path: '/main/ostatussub',
+        query_values: { profile: "https://#{Rails.configuration.x.local_domain}/users/alice" },
+        scheme: 'https'
+      ).to_s
     end
   end
 end

--- a/spec/requests/status_show_page_spec.rb
+++ b/spec/requests/status_show_page_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Statuses' do
     include AccountsHelper
 
     def site_hostname
-      Rails.configuration.x.web_domain || Rails.configuration.x.local_domain
+      local_domain_uri.host
     end
 
     it 'has valid opengraph tags' do

--- a/spec/support/domain_helpers.rb
+++ b/spec/support/domain_helpers.rb
@@ -48,7 +48,7 @@ module DomainHelpers
   end
 
   def local_domain_uri
-    Addressable::URI.parse("//#{Rails.configuration.x.local_domain}").display_uri
+    Addressable::URI.parse("//#{Rails.configuration.x.local_domain}")
   end
 
   private

--- a/spec/support/domain_helpers.rb
+++ b/spec/support/domain_helpers.rb
@@ -47,6 +47,10 @@ module DomainHelpers
       .and_yield(resolver)
   end
 
+  def local_domain_uri
+    Addressable::URI.parse("//#{Rails.configuration.x.local_domain}").display_uri
+  end
+
   private
 
   def double_mx(exchange)

--- a/spec/system/captcha_spec.rb
+++ b/spec/system/captcha_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'email confirmation flow when captcha is enabled' do
 
       # It presents a page with a link to the app callback
       expect(page)
-        .to have_content(I18n.t('auth.confirmations.registration_complete', domain: Rails.configuration.x.local_domain))
+        .to have_content(I18n.t('auth.confirmations.registration_complete', domain: local_domain_uri.host))
         .and have_link(I18n.t('auth.confirmations.clicking_this_link'), href: client_app.confirmation_redirect_uri)
     end
   end

--- a/spec/system/profile_spec.rb
+++ b/spec/system/profile_spec.rb
@@ -5,8 +5,6 @@ require 'rails_helper'
 RSpec.describe 'Profile' do
   include ProfileStories
 
-  let(:local_domain) { Rails.configuration.x.local_domain }
-
   before do
     as_a_logged_in_user
     Fabricate(:user, account: Fabricate(:account, username: 'alice'))
@@ -16,7 +14,7 @@ RSpec.describe 'Profile' do
     visit account_path('alice')
 
     expect(page)
-      .to have_title("alice (@alice@#{local_domain})")
+      .to have_title("alice (@alice@#{local_domain_uri.host})")
   end
 
   it 'I can change my account' do

--- a/spec/system/redirections_spec.rb
+++ b/spec/system/redirections_spec.rb
@@ -31,6 +31,6 @@ RSpec.describe 'redirection confirmations' do
   end
 
   def redirect_title
-    I18n.t('redirects.title', instance: Rails.configuration.x.local_domain)
+    I18n.t('redirects.title', instance: local_domain_uri.host)
   end
 end

--- a/spec/workers/publish_scheduled_announcement_worker_spec.rb
+++ b/spec/workers/publish_scheduled_announcement_worker_spec.rb
@@ -5,6 +5,14 @@ require 'rails_helper'
 RSpec.describe PublishScheduledAnnouncementWorker do
   subject { described_class.new }
 
+  around do |example|
+    original_web_domain = Rails.configuration.x.web_domain
+    original_default_host = Rails.configuration.action_mailer.default_url_options[:host]
+    example.run
+    Rails.configuration.x.web_domain = original_web_domain
+    Rails.configuration.action_mailer.default_url_options[:host] = original_default_host
+  end
+
   let!(:remote_account) { Fabricate(:account, domain: 'domain.com', username: 'foo', uri: 'https://domain.com/users/foo') }
   let!(:remote_status)  { Fabricate(:status, uri: 'https://domain.com/users/foo/12345', account: remote_account) }
   let!(:local_status)   { Fabricate(:status) }
@@ -12,15 +20,16 @@ RSpec.describe PublishScheduledAnnouncementWorker do
 
   describe 'perform' do
     before do
+      Rails.configuration.x.web_domain = 'mastodon.social' # The TwitterText Regex needs a real/plausible link target
+      Rails.configuration.action_mailer.default_url_options[:host] = Rails.configuration.x.web_domain
       service = instance_double(FetchRemoteStatusService)
       allow(FetchRemoteStatusService).to receive(:new).and_return(service)
       allow(service).to receive(:call).with('https://domain.com/users/foo/12345') { remote_status.reload }
-
-      subject.perform(scheduled_announcement.id)
     end
 
     it 'updates the linked statuses' do
-      expect(scheduled_announcement.reload.status_ids).to eq [remote_status.id, local_status.id]
+      expect { subject.perform(scheduled_announcement.id) }
+        .to change { scheduled_announcement.reload.status_ids }.from(nil).to([remote_status.id, local_status.id])
     end
   end
 end


### PR DESCRIPTION
Follows up on https://github.com/mastodon/mastodon/pull/35025 and the other ones which explicitly removed the previous `ngrok` hostname value from specs.

One edge case I hadn't contemplated until I actually tried to remove that value or set it to something else ... there's subtle/different treatment of hostname-only vs hostname-plus-port here. With the default value of `localhost:3000` being used as the `LOCAL_DOMAIN` (set in 1_hosts initializer if no env var), some assertions which previously passed with the ngrok value (no port) now fail with that new value.

This is basically a once over for the failing spots where we **should have been** comparing just the host value but were getting away with the full compare due to how that value was set.

Main thing here is introduction of new spec helper method into an existing support file which lets us wrap up the "parse and pull out the host without port from the local domain" idea, and then updates to use that where relevant.

Small readability refactor in remote follow spec, and edge case handling in published scheduled announcement worker spec (twitter text regex needs a "real domain" to match in `Status.from_text`, so fails on `localhost`)