### PR TITLE
fix: Fix zoomed images blurry in Safari

### DIFF
--- a/app/javascript/mastodon/features/ui/components/zoomable_image.tsx
+++ b/app/javascript/mastodon/features/ui/components/zoomable_image.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback, useRef, useEffect } from 'react';
 
 import classNames from 'classnames';
 
-import { useSpring, animated, config } from '@react-spring/web';
+import { useSpring, animated, config, to } from '@react-spring/web';
 import { createUseGesture, dragAction, pinchAction } from '@use-gesture/react';
 
 import { Blurhash } from 'mastodon/components/blurhash';
@@ -276,6 +276,13 @@ export const ZoomableImage: React.FC<ZoomableImageProps> = ({
     setError(true);
   }, [setError]);
 
+  // Convert the default style transform to a matrix transform to work around
+  // Safari bug https://github.com/mastodon/mastodon/issues/35042
+  const transform = to(
+    [style.scale, style.x, style.y],
+    (s, x, y) => `matrix(${s}, 0, 0, ${s}, ${x}, ${y})`,
+  );
+
   return (
     <div
       className={classNames('zoomable-image', {
@@ -298,7 +305,7 @@ export const ZoomableImage: React.FC<ZoomableImageProps> = ({
       )}
 
       <animated.img
-        style={style}
+        style={{ transform }}
         role='presentation'
         ref={imageRef}
         alt={alt}


### PR DESCRIPTION
Fixes #35042

### Changes proposed in this PR:
- Use `matrix` transform rather than `scale` and `translate` together as that causes blurry images in Safari, see [Webkit issue tracked here](https://bugs.webkit.org/show_bug.cgi?id=27684).

### Screenshots

| **Before** | **After** |
|--------|--------|
| ![Screenshot 2025-06-16 at 12 24 50](https://github.com/user-attachments/assets/d8db9f04-08d5-46ec-a6e6-f3e472c4ad01) | ![Screenshot 2025-06-16 at 12 24 38](https://github.com/user-attachments/assets/22297f47-7c5a-4353-aae4-da4ce1a2742a) | 