### PR TITLE
Change color of pinned carousel to avoid confusion with PMs

### DIFF
--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -530,9 +530,3 @@ a.sparkline {
     opacity: 0.25;
   }
 }
-
-.featured-carousel {
-  background: var(--nested-card-background);
-  border-bottom: var(--nested-card-border);
-  color: var(--nested-card-text);
-}

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -11118,7 +11118,6 @@ noscript {
 }
 
 .featured-carousel {
-  background: var(--surface-background-color);
   overflow: hidden;
   flex-shrink: 0;
   border-bottom: 1px solid var(--background-border-color);


### PR DESCRIPTION
Fixes #34969 by removing the background color from the pinned status carousel entirely.