### PR TITLE
fix: Fix glitchy iOS media attachment drag interactions

### DIFF
--- a/app/javascript/mastodon/features/compose/components/upload.tsx
+++ b/app/javascript/mastodon/features/compose/components/upload.tsx
@@ -22,10 +22,11 @@ import { useAppDispatch, useAppSelector } from 'mastodon/store';
 export const Upload: React.FC<{
   id: string;
   dragging?: boolean;
+  draggable?: boolean;
   overlay?: boolean;
   tall?: boolean;
   wide?: boolean;
-}> = ({ id, dragging, overlay, tall, wide }) => {
+}> = ({ id, dragging, draggable = true, overlay, tall, wide }) => {
   const dispatch = useAppDispatch();
   const media = useAppSelector((state) =>
     (
@@ -71,6 +72,7 @@ export const Upload: React.FC<{
     <div
       className={classNames('compose-form__upload media-gallery__item', {
         dragging,
+        draggable,
         overlay,
         'media-gallery__item--tall': tall,
         'media-gallery__item--wide': wide,

--- a/app/javascript/mastodon/features/compose/components/upload_form.tsx
+++ b/app/javascript/mastodon/features/compose/components/upload_form.tsx
@@ -116,6 +116,10 @@ export const UploadForm: React.FC = () => {
     [dispatch, setActiveId],
   );
 
+  const handleDragCancel = useCallback(() => {
+    setActiveId(null);
+  }, [setActiveId]);
+
   const accessibility: {
     screenReaderInstructions: ScreenReaderInstructions;
     announcements: Announcements;
@@ -158,32 +162,46 @@ export const UploadForm: React.FC = () => {
         <div
           className={`compose-form__uploads media-gallery media-gallery--layout-${mediaIds.size}`}
         >
-          <DndContext
-            sensors={sensors}
-            collisionDetection={closestCenter}
-            onDragStart={handleDragStart}
-            onDragEnd={handleDragEnd}
-            accessibility={accessibility}
-          >
-            <SortableContext
-              items={mediaIds.toArray()}
-              strategy={rectSortingStrategy}
+          {mediaIds.size === 1 ? (
+            <Upload
+              id={mediaIds.first()}
+              dragging={false}
+              draggable={false}
+              tall
+              wide
+            />
+          ) : (
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragStart={handleDragStart}
+              onDragEnd={handleDragEnd}
+              onDragCancel={handleDragCancel}
+              onDragAbort={handleDragCancel}
+              accessibility={accessibility}
             >
-              {mediaIds.map((id, idx) => (
-                <Upload
-                  key={id}
-                  id={id}
-                  dragging={id === activeId}
-                  tall={mediaIds.size < 3 || (mediaIds.size === 3 && idx === 0)}
-                  wide={mediaIds.size === 1}
-                />
-              ))}
-            </SortableContext>
+              <SortableContext
+                items={mediaIds.toArray()}
+                strategy={rectSortingStrategy}
+              >
+                {mediaIds.map((id, idx) => (
+                  <Upload
+                    key={id}
+                    id={id}
+                    dragging={id === activeId}
+                    tall={
+                      mediaIds.size < 3 || (mediaIds.size === 3 && idx === 0)
+                    }
+                    wide={mediaIds.size === 1}
+                  />
+                ))}
+              </SortableContext>
 
-            <DragOverlay>
-              {activeId ? <Upload id={activeId as string} overlay /> : null}
-            </DragOverlay>
-          </DndContext>
+              <DragOverlay>
+                {activeId ? <Upload id={activeId as string} overlay /> : null}
+              </DragOverlay>
+            </DndContext>
+          )}
         </div>
       )}
     </>

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -708,7 +708,12 @@ body > [data-popper-placement] {
 
   &__upload {
     position: relative;
-    cursor: grab;
+
+    &.draggable {
+      will-change: transform, opacity;
+      touch-action: none;
+      cursor: grab;
+    }
 
     &.dragging {
       opacity: 0;
@@ -718,18 +723,6 @@ body > [data-popper-placement] {
       height: 100%;
       border-radius: 8px;
       pointer-events: none;
-    }
-
-    &__drag-handle {
-      position: absolute;
-      top: 50%;
-      inset-inline-start: 0;
-      transform: translateY(-50%);
-      color: $white;
-      background: transparent;
-      border: 0;
-      padding: 8px 3px;
-      cursor: grab;
     }
 
     &__actions {


### PR DESCRIPTION
Fixes #34936

### Changes proposed in this PR:
- Fixes glitchy drag & drop interactions on media attachments on iOS
  (Adding `touch-action: none` to the draggables' CSS was the key change)
- Removes all drag & drop functionality & affordances when there's just a single upload as there's nothing to re-order
- Removes a seemingly obsolete CSS class `.compose-form__drag-handle`

> [!TIP]
> This PR is best reviewed with [white-space changes turned off.](https://github.com/mastodon/mastodon/pull/35057/files?w=1)

### Screencap

https://github.com/user-attachments/assets/40fef0f8-b5e1-4469-8a76-f7ccdcfa4e96

