### PR TITLE
fix: Improve support for safe area insets

### DIFF
--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -9,8 +9,11 @@ $content-width: 840px;
 .admin-wrapper {
   display: flex;
   justify-content: center;
+  box-sizing: border-box;
   width: 100%;
   min-height: 100vh;
+  padding: env(safe-area-inset-top) env(safe-area-inset-right)
+    env(safe-area-inset-bottom) env(safe-area-inset-left);
 
   .icon {
     width: 16px;

--- a/app/javascript/styles/mastodon/basics.scss
+++ b/app/javascript/styles/mastodon/basics.scss
@@ -50,6 +50,7 @@ body {
     padding: 0;
     padding-left: env(safe-area-inset-left);
     padding-right: env(safe-area-inset-right);
+    box-sizing: border-box;
 
     &.layout-single-column {
       height: auto;
@@ -61,6 +62,7 @@ body {
       position: absolute;
       width: 100%;
       height: 100%;
+      padding-bottom: env(safe-area-inset-bottom);
     }
 
     &.with-modals--active {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2817,12 +2817,14 @@ a.account__display-name {
   }
 
   &__panels {
+    box-sizing: border-box;
     display: flex;
     justify-content: center;
     gap: 16px;
     width: 100%;
     height: 100%;
     min-height: 100vh;
+    padding-bottom: env(safe-area-inset-bottom);
 
     &__pane {
       height: 100%;


### PR DESCRIPTION
Fixes #32410

### Changes proposed in this PR:
- Adds support for Safe Area Insets to the following places where they hadn't been taken into account yet:

| **Location** | **Before** | **After** |
|--------|--------|--------|
| Advanced web UI (bottom) | ![image](https://github.com/user-attachments/assets/d33df3dc-ccf1-4df7-b7d4-b09f98d093df) | ![image](https://github.com/user-attachments/assets/4666cf4f-6d3c-470c-81f8-a8f9d78c4e60) |
| Standard web UI (bottom) | ![image](https://github.com/user-attachments/assets/2d49d4c7-b6a2-4ea7-9c6d-490714e21eb9) | ![image](https://github.com/user-attachments/assets/63bc4254-415e-4124-9522-eb4fbb302185) |
| Admin UI (all sides) | ![image](https://github.com/user-attachments/assets/2adccbea-b7dd-4e3b-8be5-0472c556702a) | ![image](https://github.com/user-attachments/assets/02a74bc5-6287-4bf5-8828-667ec35c1bfe) | 