### PR TITLE
Fix failing terms of service e-mail distribution job being retried

### DIFF
--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -14,6 +14,8 @@
 #
 
 class List < ApplicationRecord
+  self.inheritance_column = nil
+
   include Paginable
 
   PER_ACCOUNT_LIMIT = 50

--- a/app/workers/admin/distribute_terms_of_service_notification_worker.rb
+++ b/app/workers/admin/distribute_terms_of_service_notification_worker.rb
@@ -3,6 +3,8 @@
 class Admin::DistributeTermsOfServiceNotificationWorker
   include Sidekiq::Worker
 
+  sidekiq_options retry: false
+
   def perform(terms_of_service_id)
     terms_of_service = TermsOfService.find(terms_of_service_id)
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -209,7 +209,7 @@ export default tseslint.config([
 
       'import/resolver': {
         typescript: {
-          project: path.resolve(import.meta.dirname, './tsconfig.json'),
+          project: path.resolve('./tsconfig.json'),
         },
       },
     },


### PR DESCRIPTION
Retrying can cause large volume of e-mails being sent more than once.