### PR TITLE
fix: Bring back vertical borders on search input in new mobile menu (light theme)

### DIFF
--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -96,18 +96,6 @@
   color: $white;
 }
 
-.search__input {
-  @media screen and (max-width: $no-gap-breakpoint) {
-    border-top: 0;
-    border-bottom: 0;
-  }
-}
-
-.list-editor .search .search__input {
-  border-top: 0;
-  border-bottom: 0;
-}
-
 .upload-progress__backdrop {
   background: $ui-base-color;
 }


### PR DESCRIPTION
### Changes proposed in this PR:
- Bring back vertical borders on search input in new mobile menu
- Removed unrelated unused selector `.list-editor`

### Screenshots

| **Before** | **After** |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/99a454ee-05aa-4052-ab9b-8f1e0ed1fe31) | ![image](https://github.com/user-attachments/assets/8438c626-03c7-48c7-862b-6612344f3230) | 

