### PR TITLE
fix: Prevent mobile navbar from overscrolling

### DIFF
--- a/app/javascript/styles/mastodon/_variables.scss
+++ b/app/javascript/styles/mastodon/_variables.scss
@@ -96,6 +96,7 @@ $media-modal-media-max-width: 100%;
 $media-modal-media-max-height: 80%;
 
 $no-gap-breakpoint: 1175px;
+$mobile-menu-breakpoint: 760px;
 $mobile-breakpoint: 630px;
 $no-columns-breakpoint: 600px;
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2863,17 +2863,18 @@ a.account__display-name {
 }
 
 .ui__navigation-bar {
-  position: sticky;
+  position: fixed;
   bottom: 0;
-  background: var(--background-color);
-  backdrop-filter: var(--background-filter);
-  border-top: 1px solid var(--background-border-color);
   z-index: 3;
   display: flex;
   align-items: center;
   justify-content: space-between;
+  width: 100%;
   gap: 8px;
   padding-bottom: env(safe-area-inset-bottom);
+  background: var(--background-color);
+  backdrop-filter: var(--background-filter);
+  border-top: 1px solid var(--background-border-color);
 
   .layout-multiple-columns & {
     display: none;
@@ -2984,11 +2985,20 @@ a.account__display-name {
 }
 
 .ui {
+  --mobile-bottom-nav-height: 55px;
+  --last-content-item-border-width: 2px;
+
   flex: 0 0 auto;
   display: flex;
   flex-direction: column;
   width: 100%;
   height: 100%;
+
+  @media (max-width: #{$mobile-menu-breakpoint - 1}) {
+    padding-bottom: calc(
+      var(--mobile-bottom-nav-height) - var(--last-content-item-border-width)
+    );
+  }
 }
 
 .drawer {


### PR DESCRIPTION
Fixes #35073

### Changes proposed in this PR:
- Uses `position: fixed` instead of `sticky` for the mobile navigation bar
- Note: I decided to subtract the height of the 2px bottom border of the last content item from the safe spacing below the navbar to prevent a "doubled up" thick border.

### Screencap

https://github.com/user-attachments/assets/3c38e1a0-bb1f-4b08-8f91-c53cd1b85d31

