### PR TITLE
fix: Tweak focus style & spacing of list/hashtags expand/collapse button

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -3475,7 +3475,7 @@ a.account__display-name {
     &__header {
       display: flex;
       align-items: center;
-      padding-right: 4px;
+      padding-inline-end: 4px;
 
       &__sep {
         width: 0;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -294,7 +294,7 @@
 
   &:hover,
   &:active,
-  &:focus {
+  &:focus-visible {
     color: lighten($action-button-color, 7%);
     background-color: rgba($action-button-color, 0.15);
   }
@@ -314,7 +314,7 @@
 
     &:hover,
     &:active,
-    &:focus {
+    &:focus-visible {
       color: darken($lighter-text-color, 7%);
       background-color: rgba($lighter-text-color, 0.15);
     }
@@ -334,7 +334,7 @@
 
     &:hover,
     &:active,
-    &:focus {
+    &:focus-visible {
       color: $highlight-text-color;
       background-color: transparent;
     }
@@ -3475,6 +3475,7 @@ a.account__display-name {
     &__header {
       display: flex;
       align-items: center;
+      padding-right: 4px;
 
       &__sep {
         width: 0;


### PR DESCRIPTION
Fixes #35061

### Changes proposed in this PR:
- Uses `.icon-button:focus-visible` to make its focus style less sticky when a mouse is used
- Adds a small amount of spacing to the right of the button to prevent cut-off focus outline and avoid the scrollbar from overlapping the button

### Screencap

https://github.com/user-attachments/assets/33d9ae3f-8d46-49f5-8034-01de364abab7



