### PR TITLE
Move allow/deny list config to `email_domains` area

### DIFF
--- a/app/validators/email_mx_validator.rb
+++ b/app/validators/email_mx_validator.rb
@@ -34,9 +34,13 @@ class EmailMxValidator < ActiveModel::Validator
   end
 
   def on_allowlist?(domain)
-    return false if Rails.configuration.x.email_domains_allowlist.blank?
+    return false if allowed_email_domains.blank?
 
-    Rails.configuration.x.email_domains_allowlist.include?(domain)
+    allowed_email_domains.include?(domain)
+  end
+
+  def allowed_email_domains
+    Rails.configuration.x.email_domains.allowlist
   end
 
   def resolve_mx(domain)

--- a/app/validators/user_email_validator.rb
+++ b/app/validators/user_email_validator.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class UserEmailValidator < ActiveModel::Validator
+  SEPARATOR = '|'
+
   def validate(user)
     return if user.valid_invitation? || user.email.blank?
 
@@ -25,19 +27,33 @@ class UserEmailValidator < ActiveModel::Validator
   def not_allowed_through_configuration?(email)
     return false if allowed_email_domains.blank?
 
-    domains = allowed_email_domains.gsub('.', '\.')
-    regexp  = Regexp.new("@(.+\\.)?(#{domains})$", true)
+    domains = escaped_domains(allowed_email_domains)
 
-    email !~ regexp
+    email !~ allowed_domain_pattern(domains)
   end
 
   def disallowed_through_configuration?(email)
     return false if denied_email_domains.blank?
 
-    domains = denied_email_domains.gsub('.', '\.')
-    regexp  = Regexp.new("@(.+\\.)?(#{domains})", true)
+    domains = escaped_domains(denied_email_domains)
 
-    regexp.match?(email)
+    denied_domain_pattern(domains).match?(email)
+  end
+
+  def allowed_domain_pattern(domains)
+    Regexp.new("@(.+\\.)?(#{domains})$", true)
+  end
+
+  def denied_domain_pattern(domains)
+    Regexp.new("@(.+\\.)?(#{domains})", true)
+  end
+
+  def escaped_domains(domains)
+    domains
+      .split(SEPARATOR)
+      .map { |domain| Regexp.escape(domain) }
+      .join(SEPARATOR)
+      .to_s
   end
 
   def allowed_email_domains

--- a/app/validators/user_email_validator.rb
+++ b/app/validators/user_email_validator.rb
@@ -23,20 +23,28 @@ class UserEmailValidator < ActiveModel::Validator
   end
 
   def not_allowed_through_configuration?(email)
-    return false if Rails.configuration.x.email_domains_allowlist.blank?
+    return false if allowed_email_domains.blank?
 
-    domains = Rails.configuration.x.email_domains_allowlist.gsub('.', '\.')
+    domains = allowed_email_domains.gsub('.', '\.')
     regexp  = Regexp.new("@(.+\\.)?(#{domains})$", true)
 
     email !~ regexp
   end
 
   def disallowed_through_configuration?(email)
-    return false if Rails.configuration.x.email_domains_denylist.blank?
+    return false if denied_email_domains.blank?
 
-    domains = Rails.configuration.x.email_domains_denylist.gsub('.', '\.')
+    domains = denied_email_domains.gsub('.', '\.')
     regexp  = Regexp.new("@(.+\\.)?(#{domains})", true)
 
     regexp.match?(email)
+  end
+
+  def allowed_email_domains
+    Rails.configuration.x.email_domains.allowlist
+  end
+
+  def denied_email_domains
+    Rails.configuration.x.email_domains.denylist
   end
 end

--- a/app/workers/scheduler/auto_close_registrations_scheduler.rb
+++ b/app/workers/scheduler/auto_close_registrations_scheduler.rb
@@ -11,7 +11,7 @@ class Scheduler::AutoCloseRegistrationsScheduler
   OPEN_REGISTRATIONS_MODERATOR_THRESHOLD = 1.week + UserTrackingConcern::SIGN_IN_UPDATE_FREQUENCY
 
   def perform
-    return if Rails.configuration.x.email_domains_allowlist.present? || ENV['DISABLE_AUTOMATIC_SWITCHING_TO_APPROVED_REGISTRATIONS'] == 'true'
+    return if Rails.configuration.x.email_domains.allowlist.present? || ENV['DISABLE_AUTOMATIC_SWITCHING_TO_APPROVED_REGISTRATIONS'] == 'true'
     return unless Setting.registrations_mode == 'open'
 
     switch_to_approval_mode! unless active_moderators?

--- a/config/application.rb
+++ b/config/application.rb
@@ -106,6 +106,7 @@ module Mastodon
     config.x.cache_buster = config_for(:cache_buster)
     config.x.captcha = config_for(:captcha)
     config.x.email = config_for(:email)
+    config.x.email_domains = config_for(:email_domains)
     config.x.mastodon = config_for(:mastodon)
     config.x.omniauth = config_for(:omniauth)
     config.x.translation = config_for(:translation)

--- a/config/email_domains.yml
+++ b/config/email_domains.yml
@@ -1,0 +1,3 @@
+shared:
+  denylist: <%= ENV.fetch('EMAIL_DOMAIN_DENYLIST', nil) || ENV.fetch('EMAIL_DOMAIN_BLACKLIST', '') %>
+  allowlist: <%= ENV.fetch('EMAIL_DOMAIN_ALLOWLIST', nil) || ENV.fetch('EMAIL_DOMAIN_WHITELIST', '') %>

--- a/config/initializers/deprecations.rb
+++ b/config/initializers/deprecations.rb
@@ -29,3 +29,17 @@ if ENV.key?('WHITELIST_MODE')
     LIMITED_FEDERATION_MODE. Please update your configuration.
   MESSAGE
 end
+
+if ENV.key?('EMAIL_DOMAIN_BLACKLIST')
+  warn(<<~MESSAGE.squish)
+    WARNING: The environment variable EMAIL_DOMAIN_BLACKLIST has been replaced
+    with EMAIL_DOMAIN_DENYLIST. Please update your configuration.
+  MESSAGE
+end
+
+if ENV.key?('EMAIL_DOMAIN_WHITELIST')
+  warn(<<~MESSAGE.squish)
+    WARNING: The environment variable EMAIL_DOMAIN_WHITELIST has been replaced
+    with EMAIL_DOMAIN_ALLOWLIST. Please update your configuration.
+  MESSAGE
+end

--- a/config/initializers/email_domains_lists.rb
+++ b/config/initializers/email_domains_lists.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-Rails.application.configure do
-  config.x.email_domains_denylist = ENV.fetch('EMAIL_DOMAIN_DENYLIST', nil) || ENV.fetch('EMAIL_DOMAIN_BLACKLIST', '')
-  config.x.email_domains_allowlist = ENV.fetch('EMAIL_DOMAIN_ALLOWLIST', nil) || ENV.fetch('EMAIL_DOMAIN_WHITELIST', '')
-end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -139,13 +139,13 @@ RSpec.describe User do
 
   describe 'email domains denylist integration' do
     around do |example|
-      original = Rails.configuration.x.email_domains_denylist
+      original = Rails.configuration.x.email_domains.denylist
 
-      Rails.configuration.x.email_domains_denylist = 'mvrht.com'
+      Rails.configuration.x.email_domains.denylist = 'mvrht.com'
 
       example.run
 
-      Rails.configuration.x.email_domains_denylist = original
+      Rails.configuration.x.email_domains.denylist = original
     end
 
     it 'allows a user with an email domain that is not on the denylist to be created' do
@@ -392,13 +392,13 @@ RSpec.describe User do
 
   describe 'allowlist integration' do
     around do |example|
-      original = Rails.configuration.x.email_domains_allowlist
+      original = Rails.configuration.x.email_domains.allowlist
 
-      Rails.configuration.x.email_domains_allowlist = 'mastodon.space'
+      Rails.configuration.x.email_domains.allowlist = 'mastodon.space'
 
       example.run
 
-      Rails.configuration.x.email_domains_allowlist = original
+      Rails.configuration.x.email_domains.allowlist = original
     end
 
     it 'does not allow a user to be created when their email is not on the allowlist' do
@@ -418,13 +418,13 @@ RSpec.describe User do
 
     context 'with a subdomain on the denylist' do
       around do |example|
-        original = Rails.configuration.x.email_domains_denylist
+        original = Rails.configuration.x.email_domains.denylist
         example.run
-        Rails.configuration.x.email_domains_denylist = original
+        Rails.configuration.x.email_domains.denylist = original
       end
 
       it 'does not allow a user to be created with an email subdomain on the denylist even if the top domain is on the allowlist' do
-        Rails.configuration.x.email_domains_denylist = 'denylisted.mastodon.space'
+        Rails.configuration.x.email_domains.denylist = 'denylisted.mastodon.space'
 
         user = described_class.new(email: 'foo@denylisted.mastodon.space', account: account, password: password)
         expect(user).to_not be_valid

--- a/spec/validators/email_mx_validator_spec.rb
+++ b/spec/validators/email_mx_validator_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe EmailMxValidator do
 
     context 'with an e-mail domain that is explicitly allowed' do
       around do |block|
-        tmp = Rails.configuration.x.email_domains_allowlist
-        Rails.configuration.x.email_domains_allowlist = 'example.com'
+        tmp = Rails.configuration.x.email_domains.allowlist
+        Rails.configuration.x.email_domains.allowlist = 'example.com'
         block.call
-        Rails.configuration.x.email_domains_allowlist = tmp
+        Rails.configuration.x.email_domains.allowlist = tmp
       end
 
       it 'does not add errors if there are no DNS records' do


### PR DESCRIPTION
Similar to other migrations.

Notes:

- Added warnings for the migrated env var names to deprecations
- Pulled out private methods in a few spots where the full `Rails.configuration.x...` line was used multiple times in same methods
