### PR TITLE
Use "namespace style" for URL generation in `admin/` area forms

### DIFF
--- a/app/views/admin/announcements/edit.html.haml
+++ b/app/views/admin/announcements/edit.html.haml
@@ -1,7 +1,7 @@
 - content_for :page_title do
   = t('.title')
 
-= simple_form_for @announcement, url: admin_announcement_path(@announcement), html: { novalidate: false } do |form|
+= simple_form_for [:admin, @announcement], html: { novalidate: false } do |form|
   = render 'shared/error_messages', object: @announcement
 
   = render form

--- a/app/views/admin/announcements/new.html.haml
+++ b/app/views/admin/announcements/new.html.haml
@@ -1,7 +1,7 @@
 - content_for :page_title do
   = t('.title')
 
-= simple_form_for @announcement, url: admin_announcements_path, html: { novalidate: false } do |form|
+= simple_form_for [:admin, @announcement], html: { novalidate: false } do |form|
   = render 'shared/error_messages', object: @announcement
 
   = render form

--- a/app/views/admin/custom_emojis/new.html.haml
+++ b/app/views/admin/custom_emojis/new.html.haml
@@ -1,7 +1,7 @@
 - content_for :page_title do
   = t('.title')
 
-= simple_form_for @custom_emoji, url: admin_custom_emojis_path do |f|
+= simple_form_for [:admin, @custom_emoji] do |f|
   = render 'shared/error_messages', object: @custom_emoji
 
   .fields-group

--- a/app/views/admin/domain_allows/new.html.haml
+++ b/app/views/admin/domain_allows/new.html.haml
@@ -1,7 +1,7 @@
 - content_for :page_title do
   = t('admin.domain_allows.add_new')
 
-= simple_form_for @domain_allow, url: admin_domain_allows_path do |f|
+= simple_form_for [:admin, @domain_allow] do |f|
   = render 'shared/error_messages', object: @domain_allow
 
   .fields-group

--- a/app/views/admin/domain_blocks/edit.html.haml
+++ b/app/views/admin/domain_blocks/edit.html.haml
@@ -1,7 +1,7 @@
 - content_for :page_title do
   = t('admin.domain_blocks.edit')
 
-= simple_form_for @domain_block, url: admin_domain_block_path(@domain_block) do |form|
+= simple_form_for [:admin, @domain_block] do |form|
   = render 'shared/error_messages', object: @domain_block
 
   = render form

--- a/app/views/admin/domain_blocks/new.html.haml
+++ b/app/views/admin/domain_blocks/new.html.haml
@@ -1,7 +1,7 @@
 - content_for :page_title do
   = t('.title')
 
-= simple_form_for @domain_block, url: admin_domain_blocks_path do |form|
+= simple_form_for [:admin, @domain_block] do |form|
   = render 'shared/error_messages', object: @domain_block
 
   = render form

--- a/app/views/admin/email_domain_blocks/new.html.haml
+++ b/app/views/admin/email_domain_blocks/new.html.haml
@@ -1,7 +1,7 @@
 - content_for :page_title do
   = t('.title')
 
-= simple_form_for @email_domain_block, url: admin_email_domain_blocks_path do |f|
+= simple_form_for [:admin, @email_domain_block] do |f|
   = render 'shared/error_messages', object: @email_domain_block
 
   .fields-group

--- a/app/views/admin/invites/index.html.haml
+++ b/app/views/admin/invites/index.html.haml
@@ -14,7 +14,7 @@
 - if policy(:invite).create?
   %p= t('invites.prompt')
 
-  = simple_form_for(@invite, url: admin_invites_path) do |form|
+  = simple_form_for [:admin, @invite] do |form|
     = render partial: 'invites/form', object: form
 
   %hr.spacer/

--- a/app/views/admin/ip_blocks/new.html.haml
+++ b/app/views/admin/ip_blocks/new.html.haml
@@ -1,7 +1,7 @@
 - content_for :page_title do
   = t('.title')
 
-= simple_form_for @ip_block, url: admin_ip_blocks_path do |f|
+= simple_form_for [:admin, @ip_block] do |f|
   = render 'shared/error_messages', object: @ip_block
 
   .fields-group

--- a/app/views/admin/relays/new.html.haml
+++ b/app/views/admin/relays/new.html.haml
@@ -1,7 +1,7 @@
 - content_for :page_title do
   = t('admin.relays.add_new')
 
-= simple_form_for @relay, url: admin_relays_path do |f|
+= simple_form_for [:admin, @relay] do |f|
   = render 'shared/error_messages', object: @relay
 
   .field-group

--- a/app/views/admin/rules/edit.html.haml
+++ b/app/views/admin/rules/edit.html.haml
@@ -1,7 +1,7 @@
 - content_for :page_title do
   = t('admin.rules.edit')
 
-= simple_form_for @rule, url: admin_rule_path(@rule) do |form|
+= simple_form_for [:admin, @rule] do |form|
   = render 'shared/error_messages', object: @rule
 
   = render form

--- a/app/views/admin/rules/new.html.haml
+++ b/app/views/admin/rules/new.html.haml
@@ -5,7 +5,7 @@
 
 %hr.spacer/
 
-= simple_form_for @rule, url: admin_rules_path do |form|
+= simple_form_for [:admin, @rule] do |form|
   = render 'shared/error_messages', object: @rule
 
   = render form

--- a/app/views/admin/username_blocks/edit.html.haml
+++ b/app/views/admin/username_blocks/edit.html.haml
@@ -1,7 +1,7 @@
 - content_for :page_title do
   = t('admin.username_blocks.edit.title')
 
-= simple_form_for @username_block, url: admin_username_block_path(@username_block) do |form|
+= simple_form_for [:admin, @username_block] do |form|
   = render 'shared/error_messages', object: @username_block
 
   = render form

--- a/app/views/admin/username_blocks/new.html.haml
+++ b/app/views/admin/username_blocks/new.html.haml
@@ -1,7 +1,7 @@
 - content_for :page_title do
   = t('admin.username_blocks.new.title')
 
-= simple_form_for @username_block, url: admin_username_blocks_path do |form|
+= simple_form_for [:admin, @username_block] do |form|
   = render 'shared/error_messages', object: @username_block
 
   = render form

--- a/app/views/admin/webhooks/edit.html.haml
+++ b/app/views/admin/webhooks/edit.html.haml
@@ -1,7 +1,7 @@
 - content_for :page_title do
   = t('admin.webhooks.edit')
 
-= simple_form_for @webhook, url: admin_webhook_path(@webhook) do |form|
+= simple_form_for [:admin, @webhook] do |form|
   = render form
   .actions
     = form.button :button, t('generic.save_changes'), type: :submit

--- a/app/views/admin/webhooks/new.html.haml
+++ b/app/views/admin/webhooks/new.html.haml
@@ -1,7 +1,7 @@
 - content_for :page_title do
   = t('admin.webhooks.new')
 
-= simple_form_for @webhook, url: admin_webhooks_path do |form|
+= simple_form_for [:admin, @webhook] do |form|
   = render form
   .actions
     = form.button :button, t('admin.webhooks.add_new'), type: :submit


### PR DESCRIPTION
I had previously attempted some changes like this as part of separate PR - https://github.com/mastodon/mastodon/pull/29608#discussion_r1528640574 - but this style change specifically was deemed too obscure.

However, I noticed in a separate recent change - https://github.com/mastodon/mastodon/pull/34031/files#diff-6fab92f6aad208e202149c77a6b16c8b24372c6067cafe18a0cc1e4315adf306R4 - that this style is being embraced now on newer pages.

The generated `<form>` element markup stays the same. This is a style/best-practice/refactor change only.