### PR TITLE
Use `ENV.fetch` for ffmpeg/ffprobe defaults

### DIFF
--- a/config/initializers/ffmpeg.rb
+++ b/config/initializers/ffmpeg.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 Rails.application.configure do
-  config.x.ffmpeg_binary = ENV['FFMPEG_BINARY'] || 'ffmpeg'
-  config.x.ffprobe_binary = ENV['FFPROBE_BINARY'] || 'ffprobe'
+  config.x.ffmpeg_binary = ENV.fetch('FFMPEG_BINARY', 'ffmpeg')
+  config.x.ffprobe_binary = ENV.fetch('FFPROBE_BINARY', 'ffprobe')
 end


### PR DESCRIPTION
Possible followup here (maybe around whenever the imagemagick/vips migration continues) would be to move the media-processing-related stuff into an `x.media.*` (or whatever) namespace. For now, just use `fetch` for default values as a first step.