### PR TITLE
Remove "irrevocable" and "perpetual" from license

### DIFF
--- a/config/templates/terms-of-service.md
+++ b/config/templates/terms-of-service.md
@@ -83,7 +83,7 @@ that you submit to the Instance, you may expose yourself to liability from third
 parties if you post or share such Content without all necessary rights.
 
 You retain all ownership rights you have in the Content that you submit to the
-Instance, but you grant us a limited, non-exclusive, transferable, royalty-free,
+Instance, but you grant us a limited, non-exclusive, transferable, royalty-free
 license to use, copy, store, display, share, distribute, communicate and
 transfer the Content in ways that are consistent with your use of the Instance.
 To the fullest extent possible, you agree to waive or promise not to assert

--- a/config/templates/terms-of-service.md
+++ b/config/templates/terms-of-service.md
@@ -83,13 +83,24 @@ that you submit to the Instance, you may expose yourself to liability from third
 parties if you post or share such Content without all necessary rights.
 
 You retain all ownership rights you have in the Content that you submit to the
-Instance, but you grant us a limited, non-exclusive, irrevocable, transferable,
-royalty-free, perpetual license to use, copy, store, display, share, distribute,
-communicate and transfer the Content in ways that are consistent with your use
-of the Instance. To the fullest extent possible, you agree to waive or promise
-not to assert against the Administrator all moral rights you may have in the
-Content to the extent those rights are necessary for the Administrator to host
-the Content on the Instance.
+Instance, but you grant us a limited, non-exclusive, transferable, royalty-free,
+license to use, copy, store, display, share, distribute, communicate and
+transfer the Content in ways that are consistent with your use of the Instance.
+To the fullest extent possible, you agree to waive or promise not to assert
+against the Administrator all moral rights you may have in the Content to the
+extent those rights are necessary for the Administrator to host the Content on
+the Instance.
+
+This license grant will end when you remove your Content from the Instance.
+However, incidental copies may be stored in caches, backups, and other places
+for technical reasons for indefinite periods after your Content is removed, and
+you agree that the Instance may store these for whatever period is technically
+necessary for the operation of the Instance.
+
+Furthermore, by the nature of federation in which Content is propagated to other
+servers on the network, there may be copies of your Content stored on other
+instances outside the Administrator's control, which are not subject to the
+terms of this agreement.
 
 ## DMCA Copyright Infringement Notice
 


### PR DESCRIPTION
Per #35086, requiring users to grant an "irrevocable" and "perpetual" license to content is a considerable overreach, and most similar services have clauses that sever such grants once content is removed from services.

Update the ToS template to reflect this, while adding clauses to allow for incidental continued storage as part of caches or backups which may not be stored for an indefinite period. Given the variety of ways in which people may configure caching or backup, I'm not sure it would be a good idea to commit to a time period in which caches and backups would be deleted in a default ToS, so leave that period indefinite.

Additionally, clarify that due to the nature of federation, copies may have been propagated to servers outside of the Administrator's control, and such copies are not subject to the terms of this agreement. Since this is simply an agreement between the user and the administrator of a particular instance, I don't think that anything can be said about agreements with other instances, but I think that it is worth mentioning for clarity.

Note that I am not a lawyer; this is just an attempt to limit the scope of the license grant somwhat, while still keeping the liability of the administrator relatively constrained as long as they administer the software in a fairly standard way and don't do anything to interfere with the deletion of content. I am open to suggestions on alternate ways of wording this.