### PR TITLE
Move ES/chewy env var config to `search` area

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -108,6 +108,7 @@ module Mastodon
     config.x.email = config_for(:email)
     config.x.mastodon = config_for(:mastodon)
     config.x.omniauth = config_for(:omniauth)
+    config.x.search = config_for(:search)
     config.x.translation = config_for(:translation)
     config.x.vapid = config_for(:vapid)
 

--- a/config/initializers/chewy.rb
+++ b/config/initializers/chewy.rb
@@ -1,26 +1,16 @@
 # frozen_string_literal: true
 
-enabled         = ENV['ES_ENABLED'] == 'true'
-host            = ENV.fetch('ES_HOST') { 'localhost' }
-port            = ENV.fetch('ES_PORT') { 9200 }
-user            = ENV.fetch('ES_USER', nil).presence
-password        = ENV.fetch('ES_PASS', nil).presence
-prefix          = ENV.fetch('ES_PREFIX', nil)
-ca_file         = ENV.fetch('ES_CA_FILE', nil).presence
-
-transport_options = { ssl: { ca_file: ca_file } } if ca_file.present?
-
 Chewy.settings = {
-  host: "#{host}:#{port}",
-  prefix: prefix,
-  enabled: enabled,
+  host: "#{Rails.configuration.x.search.host}:#{Rails.configuration.x.search.port}",
+  prefix: Rails.configuration.x.search.prefix,
+  enabled: Rails.configuration.x.search.enabled,
   journal: false,
-  user: user,
-  password: password,
+  user: Rails.configuration.x.search.user,
+  password: Rails.configuration.x.search.password,
   index: {
-    number_of_replicas: ['single_node_cluster', nil].include?(ENV['ES_PRESET'].presence) ? 0 : 1,
+    number_of_replicas: ['single_node_cluster', nil].include?(Rails.configuration.x.search.preset) ? 0 : 1,
   },
-  transport_options: transport_options,
+  transport_options: { ssl: { ca_file: Rails.configuration.x.search.ca_file }.compact.presence }.compact.presence,
 }
 
 # We use our own async strategy even outside the request-response

--- a/config/search.yml
+++ b/config/search.yml
@@ -1,0 +1,9 @@
+shared:
+  ca_file: <%= ENV.fetch('ES_CA_FILE', nil).presence %>
+  enabled: <%= ENV.fetch('ES_ENABLED', nil) == 'true' %>
+  host: <%= ENV.fetch('ES_HOST') { 'localhost' } %>
+  password: <%= ENV.fetch('ES_PASS', nil).presence %>
+  port: <%= ENV.fetch('ES_PORT') { 9200 } %>
+  prefix: <%= ENV.fetch('ES_PREFIX', nil) %>
+  preset: <%= ENV.fetch('ES_PRESET', nil).presence %>
+  user: <%= ENV.fetch('ES_USER', nil).presence %>

--- a/lib/chewy/index_extensions.rb
+++ b/lib/chewy/index_extensions.rb
@@ -3,7 +3,7 @@
 module Chewy
   module IndexExtensions
     def index_preset(base_options = {})
-      case ENV['ES_PRESET'].presence
+      case Rails.configuration.x.search.preset
       when 'single_node_cluster', nil
         base_options.merge(number_of_replicas: 0)
       when 'small_cluster'


### PR DESCRIPTION
Rework of https://github.com/mastodon/mastodon/pull/30677 but rebased after redis namespace changes.