### PR TITLE
fix: Prevent click on content warning banner in notification from opening the post

### DIFF
--- a/app/javascript/mastodon/components/status_banner.tsx
+++ b/app/javascript/mastodon/components/status_banner.tsx
@@ -8,6 +8,10 @@ export enum BannerVariant {
   Filter = 'filter',
 }
 
+const stopPropagation: MouseEventHandler = (e) => {
+  e.stopPropagation();
+};
+
 export const StatusBanner: React.FC<{
   children: React.ReactNode;
   variant: BannerVariant;
@@ -38,6 +42,7 @@ export const StatusBanner: React.FC<{
           : 'content-warning content-warning--filter'
       }
       onClick={forwardClick}
+      onMouseUp={stopPropagation}
     >
       <p id={descriptionId}>{children}</p>
 


### PR DESCRIPTION
### Changes proposed in this PR:
- Prevents a post in a notification from being opened when the content warning banner is clicked