### PR TITLE
Add model coverage and scopes to `RuleTranslation` class

### DIFF
--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -42,6 +42,6 @@ class Rule < ApplicationRecord
 
   def translation_for(locale)
     @cached_translations ||= {}
-    @cached_translations[locale] ||= translations.for_locale(locale).by_language.first || translations.build(language: locale, text: text, hint: hint)
+    @cached_translations[locale] ||= translations.for_locale(locale).by_language_length.first || translations.build(language: locale, text: text, hint: hint)
   end
 end

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -42,6 +42,6 @@ class Rule < ApplicationRecord
 
   def translation_for(locale)
     @cached_translations ||= {}
-    @cached_translations[locale] ||= translations.where(language: [locale, locale.to_s.split('-').first]).order('length(language) desc').first || RuleTranslation.new(language: locale, text: text, hint: hint)
+    @cached_translations[locale] ||= translations.for_locale(locale).by_language.first || translations.build(language: locale, text: text, hint: hint)
   end
 end

--- a/app/models/rule_translation.rb
+++ b/app/models/rule_translation.rb
@@ -19,7 +19,7 @@ class RuleTranslation < ApplicationRecord
   validates :text, presence: true, length: { maximum: Rule::TEXT_SIZE_LIMIT }
 
   scope :for_locale, ->(locale) { where(language: I18n::Locale::Tag.tag(locale).to_a.first) }
-  scope :by_language, -> { order(language_length.desc) }
+  scope :by_language_length, -> { order(language_length.desc) }
 
   def self.language_length
     Arel.sql(<<~SQL.squish)

--- a/app/models/rule_translation.rb
+++ b/app/models/rule_translation.rb
@@ -17,4 +17,13 @@ class RuleTranslation < ApplicationRecord
 
   validates :language, presence: true, uniqueness: { scope: :rule_id }
   validates :text, presence: true, length: { maximum: Rule::TEXT_SIZE_LIMIT }
+
+  scope :for_locale, ->(locale) { where(language: [locale, locale.to_s.split('-').first]) }
+  scope :by_language, -> { order(language_length.desc) }
+
+  def self.language_length
+    Arel.sql(<<~SQL.squish)
+      LENGTH(language)
+    SQL
+  end
 end

--- a/app/models/rule_translation.rb
+++ b/app/models/rule_translation.rb
@@ -19,11 +19,5 @@ class RuleTranslation < ApplicationRecord
   validates :text, presence: true, length: { maximum: Rule::TEXT_SIZE_LIMIT }
 
   scope :for_locale, ->(locale) { where(language: I18n::Locale::Tag.tag(locale).to_a.first) }
-  scope :by_language_length, -> { order(language_length.desc) }
-
-  def self.language_length
-    Arel.sql(<<~SQL.squish)
-      LENGTH(language)
-    SQL
-  end
+  scope :by_language_length, -> { order(Arel.sql('LENGTH(LANGUAGE)').desc) }
 end

--- a/app/models/rule_translation.rb
+++ b/app/models/rule_translation.rb
@@ -18,7 +18,7 @@ class RuleTranslation < ApplicationRecord
   validates :language, presence: true, uniqueness: { scope: :rule_id }
   validates :text, presence: true, length: { maximum: Rule::TEXT_SIZE_LIMIT }
 
-  scope :for_locale, ->(locale) { where(language: [locale, locale.to_s.split('-').first]) }
+  scope :for_locale, ->(locale) { where(language: I18n::Locale::Tag.tag(locale).to_a.first) }
   scope :by_language, -> { order(language_length.desc) }
 
   def self.language_length

--- a/spec/models/rule_translation_spec.rb
+++ b/spec/models/rule_translation_spec.rb
@@ -15,4 +15,41 @@ RSpec.describe RuleTranslation do
     it { is_expected.to validate_length_of(:text).is_at_most(Rule::TEXT_SIZE_LIMIT) }
     it { is_expected.to validate_uniqueness_of(:language).scoped_to(:rule_id) }
   end
+
+  describe 'Scopes' do
+    describe '.for_locale' do
+      let!(:matching) { Fabricate :rule_translation, language: 'en' }
+      let!(:missing) { Fabricate :rule_translation, language: 'es' }
+
+      context 'when sent top-level string' do
+        it 'includes expected records' do
+          results = described_class.for_locale('en')
+
+          expect(results)
+            .to include(matching)
+            .and not_include(missing)
+        end
+      end
+
+      context 'when sent sub string' do
+        it 'includes expected records' do
+          results = described_class.for_locale('en-US')
+
+          expect(results)
+            .to include(matching)
+            .and not_include(missing)
+        end
+      end
+    end
+
+    describe '.by_language' do
+      let!(:top_level) { Fabricate :rule_translation, language: 'en' }
+      let!(:sub_level) { Fabricate :rule_translation, language: 'en-US' }
+
+      it 'returns results ordered by length' do
+        expect(described_class.by_language)
+          .to eq([sub_level, top_level])
+      end
+    end
+  end
 end

--- a/spec/models/rule_translation_spec.rb
+++ b/spec/models/rule_translation_spec.rb
@@ -42,12 +42,12 @@ RSpec.describe RuleTranslation do
       end
     end
 
-    describe '.by_language' do
+    describe '.by_language_length' do
       let!(:top_level) { Fabricate :rule_translation, language: 'en' }
       let!(:sub_level) { Fabricate :rule_translation, language: 'en-US' }
 
       it 'returns results ordered by length' do
-        expect(described_class.by_language)
+        expect(described_class.by_language_length)
           .to eq([sub_level, top_level])
       end
     end

--- a/spec/models/rule_translation_spec.rb
+++ b/spec/models/rule_translation_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RuleTranslation do
+  describe 'Associations' do
+    it { is_expected.to belong_to(:rule) }
+  end
+
+  describe 'Validations' do
+    subject { Fabricate.build :rule_translation }
+
+    it { is_expected.to validate_presence_of(:language) }
+    it { is_expected.to validate_presence_of(:text) }
+    it { is_expected.to validate_length_of(:text).is_at_most(Rule::TEXT_SIZE_LIMIT) }
+    it { is_expected.to validate_uniqueness_of(:language).scoped_to(:rule_id) }
+  end
+end


### PR DESCRIPTION
I missed when this was added.

Two changes: 

- Add some coverage missed in original PR
- Add some scopes to the translation class and use them from `Rule`