### PR TITLE
Prevent inline font files in Vite build

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -42,6 +42,13 @@ export const config: UserConfigFnPromise = async ({ mode, command }) => {
       },
     },
     build: {
+      assetsInlineLimit(filePath, _content) {
+        const relativePath = path.relative(jsRoot, filePath);
+
+        if (relativePath.startsWith('fonts/')) {
+          return false;
+        }
+      },
       commonjsOptions: { transformMixedEsModules: true },
       chunkSizeWarningLimit: 1 * 1024 * 1024, // 1MB
       sourcemap: true,


### PR DESCRIPTION
Vite can automatically inline font files into `data:font/xxx;base64,…` format. But CSP header doesn't allow it.
Mastodon's current build doesn't have this problem for now. But someday in the future could have this problem. Or admins who want to put some customised font will have this problem.

This PR prevent that problem

For now, Only `app/javascript/fonts/` is affected. Is there any other directory to be excluded from inlining, Let me know.