### PR TITLE
Simplify `WebauthnCredential` constant limit math

### DIFF
--- a/app/models/webauthn_credential.rb
+++ b/app/models/webauthn_credential.rb
@@ -21,5 +21,5 @@ class WebauthnCredential < ApplicationRecord
   validates :external_id, uniqueness: true
   validates :nickname, uniqueness: { scope: :user_id }
   validates :sign_count,
-            numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: SIGN_COUNT_LIMIT - 1 }
+            numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than: SIGN_COUNT_LIMIT }
 end

--- a/spec/models/webauthn_credential_spec.rb
+++ b/spec/models/webauthn_credential_spec.rb
@@ -14,6 +14,6 @@ RSpec.describe WebauthnCredential do
     it { is_expected.to validate_uniqueness_of(:external_id) }
     it { is_expected.to validate_uniqueness_of(:nickname).scoped_to(:user_id) }
 
-    it { is_expected.to validate_numericality_of(:sign_count).only_integer.is_greater_than_or_equal_to(0).is_less_than_or_equal_to(described_class::SIGN_COUNT_LIMIT - 1) }
+    it { is_expected.to validate_numericality_of(:sign_count).only_integer.is_greater_than_or_equal_to(0).is_less_than(described_class::SIGN_COUNT_LIMIT) }
   end
 end


### PR DESCRIPTION
The "less than or equal to one less than the value" feels weird? Just use the value directly instead.

Possible follow-up ... previous PR for `UserRole#position` solving basically the same column limit problem uses `in: ...` - could do that here as well for consistency.