### PR TITLE
Extract method to DRY up month/year grouping in `AnnualReport::TimeSeries` class

### DIFF
--- a/app/lib/annual_report/time_series.rb
+++ b/app/lib/annual_report/time_series.rb
@@ -17,14 +17,20 @@ class AnnualReport::TimeSeries < AnnualReport::Source
   private
 
   def statuses_per_month
-    @statuses_per_month ||= report_statuses.group(:period).pluck(Arel.sql("date_part('month', created_at)::int AS period, count(*)")).to_h
+    @statuses_per_month ||= report_statuses.group(:period).pluck(date_part_month.as('period'), Arel.star.count).to_h
   end
 
   def following_per_month
-    @following_per_month ||= @account.active_relationships.where("date_part('year', created_at) = ?", @year).group(:period).pluck(Arel.sql("date_part('month', created_at)::int AS period, count(*)")).to_h
+    @following_per_month ||= @account.active_relationships.where("date_part('year', created_at) = ?", @year).group(:period).pluck(date_part_month.as('period'), Arel.star.count).to_h
   end
 
   def followers_per_month
-    @followers_per_month ||= @account.passive_relationships.where("date_part('year', created_at) = ?", @year).group(:period).pluck(Arel.sql("date_part('month', created_at)::int AS period, count(*)")).to_h
+    @followers_per_month ||= @account.passive_relationships.where("date_part('year', created_at) = ?", @year).group(:period).pluck(date_part_month.as('period'), Arel.star.count).to_h
+  end
+
+  def date_part_month
+    Arel.sql(<<~SQL.squish)
+      DATE_PART('month', created_at)::int
+    SQL
   end
 end


### PR DESCRIPTION
Changes:

- All three queries/methods here were repeating the same "month as period" sql - extract to method
- The following/followers methods were building effectively the same larger query, with diff base scopes. Pull that out to method as well
- Extract date part year portion to method as well, preferring "Arel sql" wrappers around raw sql strings