### PR TITLE
Fix missing terms of services link

### DIFF
--- a/app/controllers/api/v1/instances/terms_of_services_controller.rb
+++ b/app/controllers/api/v1/instances/terms_of_services_controller.rb
@@ -15,8 +15,9 @@ class Api::V1::Instances::TermsOfServicesController < Api::V1::Instances::BaseCo
       if params[:date].present?
         TermsOfService.published.find_by!(effective_date: params[:date])
       else
-        TermsOfService.live.first || TermsOfService.published.first! # For the case when none of the published terms have become effective yet
+        TermsOfService.current
       end
     end
+    not_found if @terms_of_service.nil?
   end
 end

--- a/app/models/terms_of_service.rb
+++ b/app/models/terms_of_service.rb
@@ -16,6 +16,7 @@
 class TermsOfService < ApplicationRecord
   scope :published, -> { where.not(published_at: nil).order(Arel.sql('coalesce(effective_date, published_at) DESC')) }
   scope :live, -> { published.where('effective_date IS NULL OR effective_date < now()').limit(1) }
+  scope :upcoming, -> { published.reorder(effective_date: :asc).where('effective_date IS NOT NULL AND effective_date > now()').limit(1) }
   scope :draft, -> { where(published_at: nil).order(id: :desc).limit(1) }
 
   validates :text, presence: true
@@ -25,6 +26,10 @@ class TermsOfService < ApplicationRecord
   validate :effective_date_cannot_be_in_the_past
 
   NOTIFICATION_ACTIVITY_CUTOFF = 1.year.freeze
+
+  def self.current
+    TermsOfService.live.first || TermsOfService.upcoming.first # For the case when none of the published terms have become effective yet
+  end
 
   def published?
     published_at.present?

--- a/app/models/terms_of_service.rb
+++ b/app/models/terms_of_service.rb
@@ -28,7 +28,7 @@ class TermsOfService < ApplicationRecord
   NOTIFICATION_ACTIVITY_CUTOFF = 1.year.freeze
 
   def self.current
-    TermsOfService.live.first || TermsOfService.upcoming.first # For the case when none of the published terms have become effective yet
+    live.first || upcoming.first # For the case when none of the published terms have become effective yet
   end
 
   def published?

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -110,7 +110,7 @@ class InitialStateSerializer < ActiveModel::Serializer
       trends_as_landing_page: Setting.trends_as_landing_page,
       trends_enabled: Setting.trends,
       version: instance_presenter.version,
-      terms_of_service_enabled: TermsOfService.live.exists?,
+      terms_of_service_enabled: TermsOfService.current.present?,
     }
   end
 

--- a/app/serializers/rest/instance_serializer.rb
+++ b/app/serializers/rest/instance_serializer.rb
@@ -61,7 +61,7 @@ class REST::InstanceSerializer < ActiveModel::Serializer
         status: object.status_page_url,
         about: about_url,
         privacy_policy: privacy_policy_url,
-        terms_of_service: TermsOfService.live.exists? ? terms_of_service_url : nil,
+        terms_of_service: TermsOfService.current.present? ? terms_of_service_url : nil,
       },
 
       vapid: {

--- a/spec/models/terms_of_service_spec.rb
+++ b/spec/models/terms_of_service_spec.rb
@@ -24,4 +24,52 @@ RSpec.describe TermsOfService do
       expect(subject.pluck(:id)).to match_array(user_before.id)
     end
   end
+
+  describe '::current' do
+    context 'when no terms exist' do
+      it 'returns nil' do
+        expect(described_class.current).to be_nil
+      end
+    end
+
+    context 'when only unpublished terms exist' do
+      before do
+        past_terms = described_class.new(Fabricate.attributes_for(:terms_of_service, published_at: nil, effective_date: Date.yesterday))
+        past_terms.save(validate: false)
+        Fabricate(:terms_of_service, published_at: nil, effective_date: Date.tomorrow)
+      end
+
+      it 'returns nil' do
+        expect(described_class.current).to be_nil
+      end
+    end
+
+    context 'when both effective and future terms exist' do
+      let!(:effective_terms) do
+        effective_terms = described_class.new(Fabricate.attributes_for(:terms_of_service, effective_date: Date.yesterday))
+        effective_terms.save(validate: false)
+        effective_terms
+      end
+
+      before do
+        Fabricate(:terms_of_service, effective_date: Date.tomorrow)
+      end
+
+      it 'returns the effective terms' do
+        expect(described_class.current).to eq effective_terms
+      end
+    end
+
+    context 'when only future terms exist' do
+      let!(:upcoming_terms) { Fabricate(:terms_of_service, effective_date: Date.tomorrow) }
+
+      before do
+        Fabricate(:terms_of_service, effective_date: 10.days.since)
+      end
+
+      it 'returns the terms that are upcoming next' do
+        expect(described_class.current).to eq upcoming_terms
+      end
+    end
+  end
 end

--- a/spec/models/terms_of_service_spec.rb
+++ b/spec/models/terms_of_service_spec.rb
@@ -34,8 +34,10 @@ RSpec.describe TermsOfService do
 
     context 'when only unpublished terms exist' do
       before do
-        past_terms = described_class.new(Fabricate.attributes_for(:terms_of_service, published_at: nil, effective_date: Date.yesterday))
-        past_terms.save(validate: false)
+        yesterday = Date.yesterday
+        travel_to yesterday do
+          Fabricate(:terms_of_service, published_at: nil, effective_date: yesterday)
+        end
         Fabricate(:terms_of_service, published_at: nil, effective_date: Date.tomorrow)
       end
 
@@ -46,9 +48,10 @@ RSpec.describe TermsOfService do
 
     context 'when both effective and future terms exist' do
       let!(:effective_terms) do
-        effective_terms = described_class.new(Fabricate.attributes_for(:terms_of_service, effective_date: Date.yesterday))
-        effective_terms.save(validate: false)
-        effective_terms
+        yesterday = Date.yesterday
+        travel_to yesterday do
+          Fabricate(:terms_of_service, effective_date: yesterday)
+        end
       end
 
       before do


### PR DESCRIPTION
Fixes #35069

While the problem was pretty clear, I was not 100% sure how to fix it.

I opted for the following: When no terms are currently in effect take the published version that is next up to become effective. In effect the footer link appears if either of those exist.

This makes sense to me, but feel free to let me know if another solution is preferred or if there is something I have missed.

