### PR TITLE
Fix clicking a status multiple times causing duplicate entries in browser history

### DIFF
--- a/app/javascript/mastodon/components/status.jsx
+++ b/app/javascript/mastodon/components/status.jsx
@@ -301,7 +301,11 @@ class Status extends ImmutablePureComponent {
     if (newTab) {
       window.open(path, '_blank', 'noopener');
     } else {
-      history.push(path);
+      if (history.location.pathname.replace('/deck/', '/') === path) {
+        history.replace(path);
+      } else {
+        history.push(path);
+      }
     }
   };
 


### PR DESCRIPTION
In the advanced interface, clicking any status opens it in the rightmost column, but if you click the same status multiple times, it will be pushed as many times as new browser history entries, which is inconsistent with built-in browser behavior.

Note that this issue also exists with react-router links, which is addressed in a later version of react-router: https://github.com/remix-run/react-router/issues/5362

The `.replace('/deck/', '/')` is a little awkward but it's necessary because of how `/deck` is pushed in `history.push` itself.