### PR TITLE
Limit count to pending&trending on admin/trends/tags page

### DIFF
--- a/app/controllers/admin/trends/tags_controller.rb
+++ b/app/controllers/admin/trends/tags_controller.rb
@@ -4,7 +4,7 @@ class Admin::Trends::TagsController < Admin::BaseController
   def index
     authorize :tag, :review?
 
-    @pending_tags_count = Tag.pending_review.async_count
+    @pending_tags_count = Tag.joins(:trend).pending_review.async_count
     @tags = filtered_tags.page(params[:page])
     @form = Trends::TagBatch.new
   end

--- a/app/controllers/admin/trends/tags_controller.rb
+++ b/app/controllers/admin/trends/tags_controller.rb
@@ -4,7 +4,7 @@ class Admin::Trends::TagsController < Admin::BaseController
   def index
     authorize :tag, :review?
 
-    @pending_tags_count = Tag.joins(:trend).pending_review.async_count
+    @pending_tags_count = pending_tags.async_count
     @tags = filtered_tags.page(params[:page])
     @form = Trends::TagBatch.new
   end
@@ -21,6 +21,10 @@ class Admin::Trends::TagsController < Admin::BaseController
   end
 
   private
+
+  def pending_tags
+    Trends::TagFilter.new(status: :pending_review).results
+  end
 
   def filtered_tags
     Trends::TagFilter.new(filter_params).results

--- a/spec/system/admin/trends/tags_spec.rb
+++ b/spec/system/admin/trends/tags_spec.rb
@@ -7,6 +7,21 @@ RSpec.describe 'Admin::Trends::Tags' do
 
   before { sign_in current_user }
 
+  describe 'Viewing tags lists' do
+    context 'with a tag that needs review but is not trending' do
+      before { Fabricate :tag, requested_review_at: 5.minutes.ago }
+
+      it 'includes a correct pending tag count in navigation' do
+        visit admin_trends_tags_path
+
+        within('.filter-subset') do
+          expect(page)
+            .to have_content("#{I18n.t('admin.accounts.moderation.pending')} (0)")
+        end
+      end
+    end
+  end
+
   describe 'Performing batch updates' do
     context 'without selecting any records' do
       it 'displays a notice about selection' do


### PR DESCRIPTION
Fixes https://github.com/mastodon/mastodon/issues/35085 (first comment there is the explanation)

Example from console when there is a review-request but not-trending tag:

```
mastodon(dev)> Tag.pending_review.async_count.value
  Tag Count (12.5ms)  SELECT COUNT(*) FROM "tags" WHERE "tags"."reviewed_at" IS NULL AND "tags"."requested_review_at" IS NOT NULL
=> 1
mastodon(dev)> Tag.joins(:trend).pending_review.async_count.value
  Tag Count (1.3ms)  SELECT COUNT(*) FROM "tags" INNER JOIN "tag_trends" ON "tag_trends"."tag_id" = "tags"."id" WHERE "tags"."reviewed_at" IS NULL AND "tags"."requested_review_at" IS NOT NULL
=> 0
```
