### PR TITLE
Change terms of service e-mail job to be iterable

### DIFF
--- a/app/workers/admin/distribute_announcement_notification_worker.rb
+++ b/app/workers/admin/distribute_announcement_notification_worker.rb
@@ -1,15 +1,18 @@
 # frozen_string_literal: true
 
 class Admin::DistributeAnnouncementNotificationWorker
-  include Sidekiq::Worker
+  include Sidekiq::IterableJob
+  include BulkMailer
 
-  def perform(announcement_id)
-    announcement = Announcement.find(announcement_id)
+  def build_enumerator(announcement_id, cursor:)
+    @announcement = Announcement.find(announcement_id)
 
-    announcement.scope_for_notification.find_each do |user|
-      UserMailer.announcement_published(user, announcement).deliver_later!
-    end
+    active_record_batches_enumerator(@announcement.scope_for_notification, cursor:)
   rescue ActiveRecord::RecordNotFound
-    true
+    nil
+  end
+
+  def each_iteration(batch_of_users, _announcement_id)
+    push_bulk_mailer(UserMailer, :announcement_published, batch_of_users.map { |user| [user, @announcement] })
   end
 end

--- a/app/workers/concerns/bulk_mailer.rb
+++ b/app/workers/concerns/bulk_mailer.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module BulkMailer
+  def push_bulk_mailer(mailer_class, mailer_method, args_array)
+    raise ArgumentError, "No method #{mailer_method} on class #{mailer_class.name}" unless mailer_class.respond_to?(mailer_method)
+
+    job_class = ActionMailer::MailDeliveryJob
+
+    Sidekiq::Client.push_bulk({
+      'class' => ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper,
+      'wrapped' => job_class,
+      'queue' => mailer_class.deliver_later_queue_name,
+      'args' => args_array.map do |args|
+        [
+          job_class.new(
+            mailer_class.name,
+            mailer_method.to_s,
+            'deliver_now',
+            args: args
+          ).serialize,
+        ]
+      end,
+    })
+  end
+end


### PR DESCRIPTION
Use the new iterable job API in Sidekiq to ensure that if the job is interrupted, it is resumed from the correct position and users are not e-mailed twice. Enqueues mailer jobs in bulk.
___

Fixes MAS-458