### PR TITLE
Change terms of service generator to not be displayed

### DIFF
--- a/app/views/admin/terms_of_service/index.html.haml
+++ b/app/views/admin/terms_of_service/index.html.haml
@@ -40,4 +40,3 @@
 
   .content__heading__actions
     = link_to t('admin.terms_of_service.create'), admin_terms_of_service_draft_path, class: 'button'
-    = link_to t('admin.terms_of_service.generate'), admin_terms_of_service_generate_path, class: 'button button-secondary'

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -71,6 +71,7 @@ ignore_unused:
   - 'mail_subscriptions.unsubscribe.emails.*'
   - 'preferences.other' # some locales are missing other keys, therefore leading i18n-tasks to detect `preferences` as plural and not finding use
   - 'edit_profile.other' # some locales are missing other keys, therefore leading i18n-tasks to detect `preferences` as plural and not finding use
+  - 'admin.terms_of_service.generate' # temporarily disabled
 
 ignore_inconsistent_interpolations:
   - '*.one'


### PR DESCRIPTION
Most likely the template will not be ready for 4.4 after all.