### PR TITLE
Add systemd service file for prometheus exporter

### DIFF
--- a/dist/mastodon-prometheus-exporter.service
+++ b/dist/mastodon-prometheus-exporter.service
@@ -1,0 +1,51 @@
+[Unit]
+Description=mastodon-prometheus-exporter
+After=network.target
+
+[Service]
+Type=simple
+User=mastodon
+WorkingDirectory=/home/mastodon/live
+Environment="LD_PRELOAD=libjemalloc.so"
+ExecStart=/home/mastodon/.rbenv/shims/bundle exec bin/prometheus_exporter -p 9394 -b 127.0.0.1 --prefix 'mastodon_'
+ExecReload=/bin/kill -SIGUSR1 $MAINPID
+TimeoutSec=15
+Restart=always
+# Proc filesystem
+ProcSubset=pid
+ProtectProc=invisible
+# Capabilities
+CapabilityBoundingSet=
+# Security
+NoNewPrivileges=true
+# Sandboxing
+ProtectSystem=strict
+PrivateTmp=true
+PrivateDevices=true
+PrivateUsers=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectControlGroups=true
+RestrictAddressFamilies=AF_INET
+RestrictAddressFamilies=AF_INET6
+RestrictAddressFamilies=AF_NETLINK
+RestrictAddressFamilies=AF_UNIX
+RestrictNamespaces=true
+LockPersonality=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+RemoveIPC=true
+PrivateMounts=true
+ProtectClock=true
+# System Call Filtering
+SystemCallArchitectures=native
+SystemCallFilter=~@cpu-emulation @debug @keyring @ipc @mount @obsolete @privileged @setuid
+SystemCallFilter=@chown
+SystemCallFilter=pipe
+SystemCallFilter=pipe2
+ReadWritePaths=/home/mastodon/live
+
+[Install]
+WantedBy=multi-user.target

--- a/dist/mastodon-prometheus-exporter.service
+++ b/dist/mastodon-prometheus-exporter.service
@@ -1,5 +1,6 @@
 [Unit]
-Description=mastodon-prometheus-exporter
+Description=Prometheus Metrics Exporter Server for Mastodon
+Documentation="https://docs.joinmastodon.org/admin/config/#prometheus https://github.com/discourse/prometheus_exporter/?tab=readme-ov-file#exporter-process-configuration"
 After=network.target
 
 [Service]


### PR DESCRIPTION
Noticed that there wasn't a systemd service file for this, so I've created one based on the mastodon-web service file. It's unfortunate that this service cannot be configured via a configuration file.

I'd almost expect people to need an override for this file to specify labels and to bind to `0.0.0.0` instead, and use their firewall to secure it, but this should get people started.