### PR TITLE
Make pending hashtags count and actual records displayed consistent

### DIFF
--- a/app/controllers/admin/trends/tags_controller.rb
+++ b/app/controllers/admin/trends/tags_controller.rb
@@ -4,7 +4,7 @@ class Admin::Trends::TagsController < Admin::BaseController
   def index
     authorize :tag, :review?
 
-    @pending_tags_count = Tag.pending_review.async_count
+    @pending_tags_count = pending_tags.async_count
     @tags = filtered_tags.page(params[:page])
     @form = Trends::TagBatch.new
   end
@@ -24,6 +24,10 @@ class Admin::Trends::TagsController < Admin::BaseController
 
   def filtered_tags
     Trends::TagFilter.new(filter_params).results
+  end
+
+  def pending_tags
+    Trends::TagFilter.new(status: :pending_review).results
   end
 
   def filter_params


### PR DESCRIPTION
Fixes #35085

Use the same base query to count and fetch records, so the count and the actual records displayed are consistent.

This was not a problem when the hashtag trends were still in Redis I think, but now it can happen that a formerly trending hashtag is still pending approval but not trending anymore. In that case it would still have been counted, but not displayed.