### PR TITLE
Move remaining `_map` method specs from account to mappings spec

### DIFF
--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -386,36 +386,6 @@ RSpec.describe Account do
     end
   end
 
-  describe '.following_map' do
-    it 'returns an hash' do
-      expect(described_class.following_map([], 1)).to be_a Hash
-    end
-  end
-
-  describe '.followed_by_map' do
-    it 'returns an hash' do
-      expect(described_class.followed_by_map([], 1)).to be_a Hash
-    end
-  end
-
-  describe '.blocking_map' do
-    it 'returns an hash' do
-      expect(described_class.blocking_map([], 1)).to be_a Hash
-    end
-  end
-
-  describe '.requested_map' do
-    it 'returns an hash' do
-      expect(described_class.requested_map([], 1)).to be_a Hash
-    end
-  end
-
-  describe '.requested_by_map' do
-    it 'returns an hash' do
-      expect(described_class.requested_by_map([], 1)).to be_a Hash
-    end
-  end
-
   describe 'MENTION_RE' do
     subject { described_class::MENTION_RE }
 

--- a/spec/models/concerns/account/mappings_spec.rb
+++ b/spec/models/concerns/account/mappings_spec.rb
@@ -22,6 +22,13 @@ RSpec.describe Account::Mappings do
     context 'when Account is without Follow' do
       it { is_expected.to eq({}) }
     end
+
+    context 'when given empty values' do
+      let(:target_account_ids) { [] }
+      let(:account_id) { 1 }
+
+      it { is_expected.to be_a(Hash) }
+    end
   end
 
   describe '.followed_by_map' do
@@ -36,6 +43,13 @@ RSpec.describe Account::Mappings do
     context 'when Account is without Follow' do
       it { is_expected.to eq({}) }
     end
+
+    context 'when given empty values' do
+      let(:target_account_ids) { [] }
+      let(:account_id) { 1 }
+
+      it { is_expected.to be_a(Hash) }
+    end
   end
 
   describe '.blocking_map' do
@@ -49,6 +63,24 @@ RSpec.describe Account::Mappings do
 
     context 'when Account is without Block' do
       it { is_expected.to eq({}) }
+    end
+
+    context 'when given empty values' do
+      let(:target_account_ids) { [] }
+      let(:account_id) { 1 }
+
+      it { is_expected.to be_a(Hash) }
+    end
+  end
+
+  describe '.blocked_by_map' do
+    subject { Account.blocked_by_map(target_account_ids, account_id) }
+
+    context 'when given empty values' do
+      let(:target_account_ids) { [] }
+      let(:account_id) { 1 }
+
+      it { is_expected.to be_a(Hash) }
     end
   end
 
@@ -73,6 +105,57 @@ RSpec.describe Account::Mappings do
 
     context 'when Account without Mute' do
       it { is_expected.to eq({}) }
+    end
+
+    context 'when given empty values' do
+      let(:target_account_ids) { [] }
+      let(:account_id) { 1 }
+
+      it { is_expected.to be_a(Hash) }
+    end
+  end
+
+  describe '.requested_map' do
+    subject { Account.requested_map(target_account_ids, account_id) }
+
+    context 'when given empty values' do
+      let(:target_account_ids) { [] }
+      let(:account_id) { 1 }
+
+      it { is_expected.to be_a(Hash) }
+    end
+  end
+
+  describe '.requested_by_map' do
+    subject { Account.requested_by_map(target_account_ids, account_id) }
+
+    context 'when given empty values' do
+      let(:target_account_ids) { [] }
+      let(:account_id) { 1 }
+
+      it { is_expected.to be_a(Hash) }
+    end
+  end
+
+  describe '.endorsed_map' do
+    subject { Account.endorsed_map(target_account_ids, account_id) }
+
+    context 'when given empty values' do
+      let(:target_account_ids) { [] }
+      let(:account_id) { 1 }
+
+      it { is_expected.to be_a(Hash) }
+    end
+  end
+
+  describe '.account_note_map' do
+    subject { Account.account_note_map(target_account_ids, account_id) }
+
+    context 'when given empty values' do
+      let(:target_account_ids) { [] }
+      let(:account_id) { 1 }
+
+      it { is_expected.to be_a(Hash) }
     end
   end
 end


### PR DESCRIPTION
This is a follow-up on https://github.com/mastodon/mastodon/pull/35119

In that PR, I moved the specs from `Interactions` -> `Mappings`, but I did not also move the specs which were in `account_spec` over as well. In addition to the logical consolidation of putting them all together, there's a small LOC reduction win here (account spec is one of the largest ruby files in repo). 

This moves those ones, and also adds a few that were missing. A few more follow-ups...

- As noted in original PR, some of this coverage is pretty bare-bones, could be fleshed out
- I noticed that many of these `_map` methods are pretty similar to some of the methods in the "crutches" portion of `FeedManager` ... might be opportunity there for further sharing/refactor. That (Feed manager) is also a pretty huge class, so that might be nice to pull out something to share if there really is enough overlap with this usage.