### PR TITLE
Fix “Alt text” button submitting form in moderation interface

### DIFF
--- a/app/javascript/mastodon/components/alt_text_badge.tsx
+++ b/app/javascript/mastodon/components/alt_text_badge.tsx
@@ -33,6 +33,7 @@ export const AltTextBadge: React.FC<{
   return (
     <>
       <button
+        type='button'
         ref={anchorRef}
         className='media-gallery__alt__label'
         onClick={handleClick}


### PR DESCRIPTION
Fixes #35145

Needs to be backported to 4.3 as well.