### PR TITLE
Fix Firefox not updating spellcheck language in textarea

### DIFF
--- a/app/javascript/mastodon/components/autosuggest_textarea.jsx
+++ b/app/javascript/mastodon/components/autosuggest_textarea.jsx
@@ -162,6 +162,14 @@ const AutosuggestTextarea = forwardRef(({
     }
   }, [suggestions, textareaRef, setSuggestionsHidden]);
 
+  // Hack to force Firefox to change language in autocorrect
+  useEffect(() => {
+    if (lang && textareaRef.current && textareaRef.current === document.activeElement) {
+      textareaRef.current.blur();
+      textareaRef.current.focus();
+    }
+  }, [lang]);
+
   const renderSuggestion = (suggestion, i) => {
     let inner, key;
 


### PR DESCRIPTION
I noticed that on my netbook, Firefox did not update the spellchecking language on `lang` attribute change unless the textarea was unfocused and re-focused.

Doing that programmatically fixes the issue and should be safe to do.