### PR TITLE
fix: Improve status focus indicators

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1410,9 +1410,10 @@ body > [data-popper-placement] {
 }
 
 .focusable {
-  &:focus {
+  &:focus-visible {
     outline: 0;
     background: rgba($ui-highlight-color, 0.05);
+    box-shadow: inset 0 0 0 2px $ui-button-focus-outline-color;
   }
 }
 
@@ -1815,7 +1816,7 @@ body > [data-popper-placement] {
     background: color.mix($ui-base-color, $ui-highlight-color, 95%);
   }
 
-  &:focus {
+  &:focus-visible {
     .detailed-status,
     .detailed-status__action-bar {
       background: color.mix(


### PR DESCRIPTION
### Changes proposed in this PR:
- Reverts the visual change introduced by #35037 in which simply clicking the content of a status would make the status' focus indicator (a faint highlight) appear. Now this is only shown when the keyboard is used.
- Introduces a more visible focus outline to make keyboard focus much more easily visible

### Screenshots

![image](https://github.com/user-attachments/assets/64978d20-acbd-428b-a550-209d5b43f481)

https://github.com/user-attachments/assets/b5cee3b7-a100-4390-82ee-72b79362cf1d