### PR TITLE
feat: More obvious loading state when submitting a post

### DIFF
--- a/app/javascript/mastodon/components/button/button.stories.tsx
+++ b/app/javascript/mastodon/components/button/button.stories.tsx
@@ -78,7 +78,10 @@ const disabledButtonTest: Story['play'] = async ({
   canvas,
   userEvent,
 }) => {
-  await userEvent.click(canvas.getByRole('button'));
+  const button = await canvas.findByRole('button');
+  await userEvent.click(button);
+  // Disabled controls can't be focused
+  await expect(button).not.toHaveFocus();
   await expect(args.onClick).not.toHaveBeenCalled();
 };
 
@@ -104,9 +107,10 @@ const loadingButtonTest: Story['play'] = async ({
   userEvent,
 }) => {
   const button = await canvas.findByRole('button', {
-    name: 'Primary button Loading',
+    name: 'Primary button Loading…',
   });
   await userEvent.click(button);
+  await expect(button).toHaveFocus();
   await expect(args.onClick).not.toHaveBeenCalled();
 };
 

--- a/app/javascript/mastodon/components/button/button.stories.tsx
+++ b/app/javascript/mastodon/components/button/button.stories.tsx
@@ -11,6 +11,7 @@ const meta = {
     compact: false,
     dangerous: false,
     disabled: false,
+    loading: false,
     onClick: fn(),
   },
   argTypes: {
@@ -39,16 +40,6 @@ const buttonTest: Story['play'] = async ({ args, canvas, userEvent }) => {
   const button = await canvas.findByRole('button');
   await userEvent.click(button);
   await expect(args.onClick).toHaveBeenCalled();
-};
-
-const disabledButtonTest: Story['play'] = async ({
-  args,
-  canvas,
-  userEvent,
-}) => {
-  const button = await canvas.findByRole('button');
-  await userEvent.click(button);
-  await expect(args.onClick).not.toHaveBeenCalled();
 };
 
 export const Primary: Story = {
@@ -82,6 +73,15 @@ export const Dangerous: Story = {
   play: buttonTest,
 };
 
+const disabledButtonTest: Story['play'] = async ({
+  args,
+  canvas,
+  userEvent,
+}) => {
+  await userEvent.click(canvas.getByRole('button'));
+  await expect(args.onClick).not.toHaveBeenCalled();
+};
+
 export const PrimaryDisabled: Story = {
   args: {
     ...Primary.args,
@@ -96,4 +96,24 @@ export const SecondaryDisabled: Story = {
     disabled: true,
   },
   play: disabledButtonTest,
+};
+
+const loadingButtonTest: Story['play'] = async ({
+  args,
+  canvas,
+  userEvent,
+}) => {
+  const button = await canvas.findByRole('button', {
+    name: 'Primary button Loading',
+  });
+  await userEvent.click(button);
+  await expect(args.onClick).not.toHaveBeenCalled();
+};
+
+export const Loading: Story = {
+  args: {
+    ...Primary.args,
+    loading: true,
+  },
+  play: loadingButtonTest,
 };

--- a/app/javascript/mastodon/components/button/index.tsx
+++ b/app/javascript/mastodon/components/button/index.tsx
@@ -3,12 +3,15 @@ import { useCallback } from 'react';
 
 import classNames from 'classnames';
 
+import { LoadingIndicator } from 'mastodon/components/loading_indicator';
+
 interface BaseProps
   extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'children'> {
   block?: boolean;
   secondary?: boolean;
   compact?: boolean;
   dangerous?: boolean;
+  loading?: boolean;
 }
 
 interface PropsChildren extends PropsWithChildren<BaseProps> {
@@ -34,6 +37,7 @@ export const Button: React.FC<Props> = ({
   secondary,
   compact,
   dangerous,
+  loading,
   className,
   title,
   text,
@@ -49,6 +53,8 @@ export const Button: React.FC<Props> = ({
     [disabled, onClick],
   );
 
+  const label = text ?? children;
+
   return (
     <button
       className={classNames('button', className, {
@@ -56,14 +62,24 @@ export const Button: React.FC<Props> = ({
         'button--compact': compact,
         'button--block': block,
         'button--dangerous': dangerous,
+        loading,
       })}
-      disabled={disabled}
+      disabled={(disabled && !loading) || loading}
+      // If the loading prop is used, announce label changes
+      aria-live={loading !== undefined ? 'polite' : undefined}
       onClick={handleClick}
       title={title}
       type={type}
       {...props}
     >
-      {text ?? children}
+      {loading ? (
+        <>
+          <span className='button__label-wrapper'>{label}</span>
+          <LoadingIndicator role='none' />
+        </>
+      ) : (
+        label
+      )}
     </button>
   );
 };

--- a/app/javascript/mastodon/components/button/index.tsx
+++ b/app/javascript/mastodon/components/button/index.tsx
@@ -46,11 +46,14 @@ export const Button: React.FC<Props> = ({
 }) => {
   const handleClick = useCallback<React.MouseEventHandler<HTMLButtonElement>>(
     (e) => {
-      if (!disabled && onClick) {
+      if (disabled || loading) {
+        e.stopPropagation();
+        e.preventDefault();
+      } else if (onClick) {
         onClick(e);
       }
     },
-    [disabled, onClick],
+    [disabled, loading, onClick],
   );
 
   const label = text ?? children;
@@ -64,7 +67,10 @@ export const Button: React.FC<Props> = ({
         'button--dangerous': dangerous,
         loading,
       })}
-      disabled={(disabled && !loading) || loading}
+      // Disabled buttons can't have focus, so we don't really
+      // disable the button during loading
+      disabled={disabled && !loading}
+      aria-disabled={loading}
       // If the loading prop is used, announce label changes
       aria-live={loading !== undefined ? 'polite' : undefined}
       onClick={handleClick}

--- a/app/javascript/mastodon/components/loading_indicator.tsx
+++ b/app/javascript/mastodon/components/loading_indicator.tsx
@@ -6,15 +6,34 @@ const messages = defineMessages({
   loading: { id: 'loading_indicator.label', defaultMessage: 'Loading…' },
 });
 
-export const LoadingIndicator: React.FC = () => {
+interface LoadingIndicatorProps {
+  /**
+   * Use role='none' to opt out of the current default role 'progressbar'
+   * and aria attributes which we should re-visit to check if they're appropriate.
+   * In Firefox the aria-label is not applied, instead an implied value of `50` is
+   * used as the label.
+   */
+  role?: string;
+}
+
+export const LoadingIndicator: React.FC<LoadingIndicatorProps> = ({
+  role = 'progressbar',
+}) => {
   const intl = useIntl();
+
+  const a11yProps =
+    role === 'progressbar'
+      ? ({
+          role,
+          'aria-busy': true,
+          'aria-live': 'polite',
+        } as const)
+      : undefined;
 
   return (
     <div
       className='loading-indicator'
-      role='progressbar'
-      aria-busy
-      aria-live='polite'
+      {...a11yProps}
       aria-label={intl.formatMessage(messages.loading)}
     >
       <CircularProgress size={50} strokeWidth={6} />

--- a/app/javascript/mastodon/features/compose/components/compose_form.jsx
+++ b/app/javascript/mastodon/features/compose/components/compose_form.jsx
@@ -12,9 +12,10 @@ import { length } from 'stringz';
 
 import { missingAltTextModal } from 'mastodon/initial_state';
 
-import AutosuggestInput from '../../../components/autosuggest_input';
-import AutosuggestTextarea from '../../../components/autosuggest_textarea';
-import { Button } from '../../../components/button';
+import AutosuggestInput from 'mastodon/components/autosuggest_input';
+import AutosuggestTextarea from 'mastodon/components/autosuggest_textarea';
+import { Button } from 'mastodon/components/button';
+import { LoadingIndicator } from 'mastodon/components/loading_indicator';
 import EmojiPickerDropdown from '../containers/emoji_picker_dropdown_container';
 import PollButtonContainer from '../containers/poll_button_container';
 import PrivacyDropdownContainer from '../containers/privacy_dropdown_container';
@@ -225,9 +226,8 @@ class ComposeForm extends ImmutablePureComponent {
   };
 
   render () {
-    const { intl, onPaste, autoFocus, withoutNavigation, maxChars } = this.props;
+    const { intl, onPaste, autoFocus, withoutNavigation, maxChars, isSubmitting } = this.props;
     const { highlighted } = this.state;
-    const disabled = this.props.isSubmitting;
 
     return (
       <form className='compose-form' onSubmit={this.handleSubmit}>
@@ -246,7 +246,7 @@ class ComposeForm extends ImmutablePureComponent {
                 <AutosuggestInput
                   placeholder={intl.formatMessage(messages.spoiler_placeholder)}
                   value={this.props.spoilerText}
-                  disabled={disabled}
+                  disabled={isSubmitting}
                   onChange={this.handleChangeSpoilerText}
                   onKeyDown={this.handleKeyDown}
                   ref={this.setSpoilerText}
@@ -268,7 +268,7 @@ class ComposeForm extends ImmutablePureComponent {
             <AutosuggestTextarea
               ref={this.textareaRef}
               placeholder={intl.formatMessage(messages.placeholder)}
-              disabled={disabled}
+              disabled={isSubmitting}
               value={this.props.text}
               onChange={this.handleChange}
               suggestions={this.props.suggestions}
@@ -305,9 +305,15 @@ class ComposeForm extends ImmutablePureComponent {
                 <Button
                   type='submit'
                   compact
-                  text={intl.formatMessage(this.props.isEditing ? messages.saveChanges : (this.props.isInReply ? messages.reply : messages.publish))}
                   disabled={!this.canSubmit()}
-                />
+                  loading={isSubmitting}
+                >
+                  {intl.formatMessage(
+                    this.props.isEditing ?
+                      messages.saveChanges : 
+                      (this.props.isInReply ? messages.reply : messages.publish)
+                  )}
+                </Button>
               </div>
             </div>
           </div>

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -250,8 +250,11 @@
   }
 
   &.loading {
+    cursor: wait;
+
     .button__label-wrapper {
-      // Hide the label so that it keeps its layout and accessibility
+      // Hide the label only visually, so that
+      // it keeps its layout and accessibility
       opacity: 0;
     }
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -249,6 +249,18 @@
     width: 100%;
   }
 
+  &.loading {
+    .button__label-wrapper {
+      // Hide the label so that it keeps its layout and accessibility
+      opacity: 0;
+    }
+
+    .loading-indicator {
+      position: absolute;
+      inset: 0;
+    }
+  }
+
   .icon {
     width: 18px;
     height: 18px;
@@ -4645,12 +4657,18 @@ a.status-card {
 .icon-button .loading-indicator {
   position: static;
   transform: none;
+  color: inherit;
 
   .circular-progress {
-    color: $primary-text-color;
+    color: inherit;
     width: 22px;
     height: 22px;
   }
+}
+
+.button--compact .loading-indicator .circular-progress {
+  width: 17px;
+  height: 17px;
 }
 
 .icon-button .loading-indicator .circular-progress {


### PR DESCRIPTION
Fixes #34896

### Changes proposed in this PR:
- Introduces a new `<Button loading>` prop that displays a loading indicator inside of the button without changing the button's layout. It's also implemented so that both the loading and the disabled states are correctly conveyed to users of assistive tech.
- Currently, this prop is only used inside of the compose form to show that a post is being submitted, but there are probably lots of other places where it'll come in handy
- Refactors the `LoadingIndicator` component to allow opting out of its `progressbar` role which doesn't seem appropriate (but which I'm not comfortable removing entirely at this stage)

### Screenshots

https://github.com/user-attachments/assets/4f9f57a3-ca9a-4704-9051-c23967938698


https://github.com/user-attachments/assets/b48c74af-ee5a-45b6-98ce-730aedeccfcb

