### PR TITLE
Extract `BaseFilter` class to hold common filter components

### DIFF
--- a/app/filters/announcement_filter.rb
+++ b/app/filters/announcement_filter.rb
@@ -1,16 +1,10 @@
 # frozen_string_literal: true
 
-class AnnouncementFilter
+class AnnouncementFilter < BaseFilter
   KEYS = %i(
     published
     unpublished
   ).freeze
-
-  attr_reader :params
-
-  def initialize(params)
-    @params = params
-  end
 
   def results
     scope = Announcement.unscoped

--- a/app/filters/base_filter.rb
+++ b/app/filters/base_filter.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class BaseFilter
+  attr_reader :params
+
+  def initialize(params)
+    @params = params
+  end
+end

--- a/app/filters/invite_filter.rb
+++ b/app/filters/invite_filter.rb
@@ -1,16 +1,10 @@
 # frozen_string_literal: true
 
-class InviteFilter
+class InviteFilter < BaseFilter
   KEYS = %i(
     available
     expired
   ).freeze
-
-  attr_reader :params
-
-  def initialize(params)
-    @params = params
-  end
 
   def results
     scope = Invite.order(created_at: :desc)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -18,6 +18,7 @@ if ENV.fetch('COVERAGE', false)
 
     add_filter 'lib/linter'
 
+    add_group 'Filters', 'app/filters'
     add_group 'Libraries', 'lib'
     add_group 'Policies', 'app/policies'
     add_group 'Presenters', 'app/presenters'


### PR DESCRIPTION
Follow-up on some previous PRs along the same lines, which received limited feedback.

- https://github.com/mastodon/mastodon/pull/28919 - which I suspect changed too much code
- https://github.com/mastodon/mastodon/pull/31894 - which only moved files, but did not change any code

Trying another pass here, which moves the two simplest classes as examples, and adds the base class. It would be sort of silly to merge this as-is without planned follow up to do more. I think that basically "the entirety of those other two PRs" would be good follow-up here, or good to add in here before merge.

Would love to get some feedback one way or the other. Motivations are same as previous writeups.