### PR TITLE
Add `User#email_domain` method to extract domain from email address

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -163,6 +163,7 @@ class Account < ApplicationRecord
   after_update_commit :trigger_update_webhooks
 
   delegate :email,
+           :email_domain,
            :unconfirmed_email,
            :current_sign_in_at,
            :created_at,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -223,6 +223,12 @@ class User < ApplicationRecord
     end
   end
 
+  def email_domain
+    Mail::Address.new(email).domain
+  rescue Mail::Field::ParseError
+    nil
+  end
+
   def update_sign_in!(new_sign_in: false)
     old_current = current_sign_in_at
     new_current = Time.now.utc

--- a/app/views/admin/accounts/_account.html.haml
+++ b/app/views/admin/accounts/_account.html.haml
@@ -25,7 +25,7 @@
           %td.accounts-table__extra
             - if account.local?
               - if account.user_email
-                = link_to account.user_email.split('@').last, admin_accounts_path(email: "%@#{account.user_email.split('@').last}"), title: account.user_email
+                = link_to account.user_email_domain, admin_accounts_path(email: "%@#{account.user_email_domain}"), title: account.user_email
               - else
                 \-
               %br/

--- a/app/views/admin/accounts/_local_account.html.haml
+++ b/app/views/admin/accounts/_local_account.html.haml
@@ -22,10 +22,10 @@
   %td{ rowspan: can?(:create, :email_domain_block) ? 3 : 2 }= account.user_email
   %td= table_link_to 'edit', t('admin.accounts.change_email.label'), admin_account_change_email_path(account.id) if can?(:change_email, account.user)
 %tr
-  %td= table_link_to 'search', t('admin.accounts.search_same_email_domain'), admin_accounts_path(email: "%@#{account.user_email.split('@').last}")
+  %td= table_link_to 'search', t('admin.accounts.search_same_email_domain'), admin_accounts_path(email: "%@#{account.user_email_domain}")
 - if can?(:create, :email_domain_block)
   %tr
-    %td= table_link_to 'hide_source', t('admin.accounts.add_email_domain_block'), new_admin_email_domain_block_path(_domain: account.user_email.split('@').last)
+    %td= table_link_to 'hide_source', t('admin.accounts.add_email_domain_block'), new_admin_email_domain_block_path(_domain: account.user_email_domain)
 - if account.user_unconfirmed_email.present?
   %tr
     %th= t('admin.accounts.unconfirmed_email')

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -166,6 +166,34 @@ RSpec.describe User do
     end
   end
 
+  describe '#email_domain' do
+    subject { described_class.new(email: email).email_domain }
+
+    context 'when value is nil' do
+      let(:email) { nil }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when value is blank' do
+      let(:email) { '' }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when value has valid domain' do
+      let(:email) { 'user@host.example' }
+
+      it { is_expected.to eq('host.example') }
+    end
+
+    context 'when value has no split' do
+      let(:email) { 'user$host.example' }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
   describe '#update_sign_in!' do
     context 'with an existing user' do
       let!(:user) { Fabricate :user, last_sign_in_at: 10.days.ago, current_sign_in_at: 1.hour.ago, sign_in_count: 123 }


### PR DESCRIPTION
Basically de-dupes the repeated `split` calling in these views ... may be other places to update as follow-up.

Specifically, want to look at `sign_up_email_requires_approval?` further down in `User` model, but there's slightly more logic there, so will handle separately.