### PR TITLE
Update `OAuth` inflection to match spec

### DIFF
--- a/.rubocop/rspec.yml
+++ b/.rubocop/rspec.yml
@@ -23,5 +23,6 @@ RSpec/SpecFilePathFormat:
     ActivityPub: activitypub
     DeepL: deepl
     FetchOEmbedService: fetch_oembed_service
+    OAuth: oauth
     OEmbedController: oembed_controller
     OStatus: ostatus

--- a/app/controllers/oauth/authorizations_controller.rb
+++ b/app/controllers/oauth/authorizations_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Oauth::AuthorizationsController < Doorkeeper::AuthorizationsController
+class OAuth::AuthorizationsController < Doorkeeper::AuthorizationsController
   skip_before_action :authenticate_resource_owner!
 
   before_action :store_current_location

--- a/app/controllers/oauth/authorized_applications_controller.rb
+++ b/app/controllers/oauth/authorized_applications_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Oauth::AuthorizedApplicationsController < Doorkeeper::AuthorizedApplicationsController
+class OAuth::AuthorizedApplicationsController < Doorkeeper::AuthorizedApplicationsController
   skip_before_action :authenticate_resource_owner!
 
   before_action :store_current_location

--- a/app/controllers/oauth/tokens_controller.rb
+++ b/app/controllers/oauth/tokens_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Oauth::TokensController < Doorkeeper::TokensController
+class OAuth::TokensController < Doorkeeper::TokensController
   def revoke
     unsubscribe_for_token if token.present? && authorized? && token.accessible?
 

--- a/app/controllers/oauth/userinfo_controller.rb
+++ b/app/controllers/oauth/userinfo_controller.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-class Oauth::UserinfoController < Api::BaseController
+class OAuth::UserinfoController < Api::BaseController
   before_action -> { doorkeeper_authorize! :profile }, only: [:show]
   before_action :require_user!
 
   def show
     @account = current_account
-    render json: @account, serializer: OauthUserinfoSerializer
+    render json: @account, serializer: OAuthUserinfoSerializer
   end
 end

--- a/app/controllers/well_known/oauth_metadata_controller.rb
+++ b/app/controllers/well_known/oauth_metadata_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module WellKnown
-  class OauthMetadataController < ActionController::Base # rubocop:disable Rails/ApplicationController
+  class OAuthMetadataController < ActionController::Base # rubocop:disable Rails/ApplicationController
     include CacheConcern
 
     # Prevent `active_model_serializer`'s `ActionController::Serialization` from calling `current_user`
@@ -13,8 +13,8 @@ module WellKnown
       # new OAuth scopes are added), we don't use expires_in to cache upstream,
       # instead just caching in the rails cache:
       render_with_cache(
-        json: ::OauthMetadataPresenter.new,
-        serializer: ::OauthMetadataSerializer,
+        json: ::OAuthMetadataPresenter.new,
+        serializer: ::OAuthMetadataSerializer,
         content_type: 'application/json',
         expires_in: 15.minutes
       )

--- a/app/presenters/oauth_metadata_presenter.rb
+++ b/app/presenters/oauth_metadata_presenter.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class OauthMetadataPresenter < ActiveModelSerializers::Model
+class OAuthMetadataPresenter < ActiveModelSerializers::Model
   include RoutingHelper
 
   attributes :issuer, :authorization_endpoint, :token_endpoint,

--- a/app/serializers/oauth_metadata_serializer.rb
+++ b/app/serializers/oauth_metadata_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class OauthMetadataSerializer < ActiveModel::Serializer
+class OAuthMetadataSerializer < ActiveModel::Serializer
   attributes :issuer, :authorization_endpoint, :token_endpoint,
              :revocation_endpoint, :userinfo_endpoint, :scopes_supported,
              :response_types_supported, :response_modes_supported,

--- a/app/serializers/oauth_userinfo_serializer.rb
+++ b/app/serializers/oauth_userinfo_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class OauthUserinfoSerializer < ActiveModel::Serializer
+class OAuthUserinfoSerializer < ActiveModel::Serializer
   include RoutingHelper
 
   attributes :iss, :sub, :name, :preferred_username, :profile, :picture

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -20,6 +20,7 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym 'DeepL'
   inflect.acronym 'DSL'
   inflect.acronym 'JsonLd'
+  inflect.acronym 'OAuth'
   inflect.acronym 'OEmbed'
   inflect.acronym 'OStatus'
   inflect.acronym 'PubSubHubbub'

--- a/db/migrate/20160826155805_add_superapp_to_oauth_applications.rb
+++ b/db/migrate/20160826155805_add_superapp_to_oauth_applications.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddSuperappToOauthApplications < ActiveRecord::Migration[5.0]
+class AddSuperappToOAuthApplications < ActiveRecord::Migration[5.0]
   def change
     add_column :oauth_applications, :superapp, :boolean, default: false, null: false
   end

--- a/db/migrate/20170114203041_add_website_to_oauth_application.rb
+++ b/db/migrate/20170114203041_add_website_to_oauth_application.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddWebsiteToOauthApplication < ActiveRecord::Migration[5.0]
+class AddWebsiteToOAuthApplication < ActiveRecord::Migration[5.0]
   def change
     add_column :oauth_applications, :website, :string
   end

--- a/db/migrate/20220227041951_add_last_used_at_to_oauth_access_tokens.rb
+++ b/db/migrate/20220227041951_add_last_used_at_to_oauth_access_tokens.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddLastUsedAtToOauthAccessTokens < ActiveRecord::Migration[6.1]
+class AddLastUsedAtToOAuthAccessTokens < ActiveRecord::Migration[6.1]
   def change
     safety_assured do
       change_table(:oauth_access_tokens, bulk: true) do |t|

--- a/db/post_migrate/20220310060740_optimize_null_index_oauth_access_tokens_refresh_token.rb
+++ b/db/post_migrate/20220310060740_optimize_null_index_oauth_access_tokens_refresh_token.rb
@@ -2,7 +2,7 @@
 
 require Rails.root.join('lib', 'mastodon', 'migration_helpers')
 
-class OptimizeNullIndexOauthAccessTokensRefreshToken < ActiveRecord::Migration[5.2]
+class OptimizeNullIndexOAuthAccessTokensRefreshToken < ActiveRecord::Migration[5.2]
   include Mastodon::MigrationHelpers
 
   disable_ddl_transaction!

--- a/db/post_migrate/20220310060809_optimize_null_index_oauth_access_tokens_resource_owner_id.rb
+++ b/db/post_migrate/20220310060809_optimize_null_index_oauth_access_tokens_resource_owner_id.rb
@@ -2,7 +2,7 @@
 
 require Rails.root.join('lib', 'mastodon', 'migration_helpers')
 
-class OptimizeNullIndexOauthAccessTokensResourceOwnerId < ActiveRecord::Migration[5.2]
+class OptimizeNullIndexOAuthAccessTokensResourceOwnerId < ActiveRecord::Migration[5.2]
   include Mastodon::MigrationHelpers
 
   disable_ddl_transaction!

--- a/spec/controllers/oauth/authorizations_controller_spec.rb
+++ b/spec/controllers/oauth/authorizations_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe Oauth::AuthorizationsController do
+RSpec.describe OAuth::AuthorizationsController do
   let(:app) { Doorkeeper::Application.create!(name: 'test', redirect_uri: 'http://localhost/', scopes: 'read') }
 
   describe 'GET #new' do

--- a/spec/controllers/oauth/authorized_applications_controller_spec.rb
+++ b/spec/controllers/oauth/authorized_applications_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe Oauth::AuthorizedApplicationsController do
+RSpec.describe OAuth::AuthorizedApplicationsController do
   render_views
 
   describe 'GET #index' do

--- a/spec/requests/oauth/userinfo_spec.rb
+++ b/spec/requests/oauth/userinfo_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Oauth Userinfo Endpoint' do
+RSpec.describe 'OAuth Userinfo Endpoint' do
   include RoutingHelper
 
   let(:user)     { Fabricate(:user) }


### PR DESCRIPTION
I have a still-WIP branch - https://github.com/mastodon/mastodon/compare/main...mjankowski:doorkeeper-model-convert - which is experimenting with the "convert to use the mixin style for doorkeeper models" idea.

While doing that, I wound up making this change for the things I was adding, and realized I'd have to change the old stuff as well. So, this brings current code in line with what we do elsewhere (see OEmbed and OStatus for example), and is both a) probably useful even if we don't pursue that mixin angle, b) a good precursor if we do because it will make the PR more about just that change and not about these inflector changes.