### PR TITLE
Change rule translation interface to display english name and populate empty translations

### DIFF
--- a/app/controllers/admin/rules_controller.rb
+++ b/app/controllers/admin/rules_controller.rb
@@ -17,6 +17,9 @@ module Admin
 
     def edit
       authorize @rule, :update?
+
+      missing_languages = RuleTranslation.languages - @rule.translations.pluck(:language)
+      missing_languages.each { |lang| @rule.translations.build(language: lang) }
     end
 
     def create

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -20,7 +20,7 @@ class Rule < ApplicationRecord
   self.discard_column = :deleted_at
 
   has_many :translations, inverse_of: :rule, class_name: 'RuleTranslation', dependent: :destroy
-  accepts_nested_attributes_for :translations, reject_if: :all_blank, allow_destroy: true
+  accepts_nested_attributes_for :translations, reject_if: ->(attributes) { attributes['text'].blank? }, allow_destroy: true
 
   validates :text, presence: true, length: { maximum: TEXT_SIZE_LIMIT }
 

--- a/app/models/rule_translation.rb
+++ b/app/models/rule_translation.rb
@@ -20,4 +20,8 @@ class RuleTranslation < ApplicationRecord
 
   scope :for_locale, ->(locale) { where(language: I18n::Locale::Tag.tag(locale).to_a.first) }
   scope :by_language_length, -> { order(Arel.sql('LENGTH(LANGUAGE)').desc) }
+
+  def self.languages
+    RuleTranslation.joins(:rule).merge(Rule.kept).select(:language).distinct.pluck(:language).sort
+  end
 end

--- a/app/views/admin/rules/_translation_fields.html.haml
+++ b/app/views/admin/rules/_translation_fields.html.haml
@@ -5,7 +5,7 @@
         = f.input :language,
                   collection: ui_languages,
                   include_blank: false,
-                  label_method: ->(locale) { native_locale_name(locale) }
+                  label_method: ->(locale) { "#{native_locale_name(locale)} (#{standard_locale_name(locale)})" }
 
       .fields-row__column.fields-group
         = f.hidden_field :id if f.object&.persisted? # Required so Rails doesn't put the field outside of the <tr/>


### PR DESCRIPTION
This changes the admin interface for editing rule translations to display the English name of the locale besides the native name, and populate the form with empty translations for languages covered by translations for other rules in order to ease the process of bulk-translating.

![image](https://github.com/user-attachments/assets/c59e6a75-9307-431e-98a9-db0eba97ca0e)