### PR TITLE
fix: Fix search icon overlapping text on Trending page

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -3110,7 +3110,7 @@ a.account__display-name {
   .search__input {
     line-height: 18px;
     font-size: 16px;
-    padding: 15px;
+    padding-block: 15px;
     padding-inline-end: 30px;
   }
 
@@ -8977,7 +8977,7 @@ noscript {
 
   .search__input {
     border: 1px solid var(--background-border-color);
-    padding: 12px;
+    padding-block: 12px;
     padding-inline-end: 30px;
   }
 


### PR DESCRIPTION
### Changes proposed in this PR:
- Fixes search icon overlapping text on Trending page, a regression caused by #35152

### Screenshots

| **Before** | **After** |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/1e1516af-1086-4a53-9e1b-d8c5a0359f35) | ![image](https://github.com/user-attachments/assets/a01cd02a-fbc2-4152-8afc-fdc47d4557a7) | 