### PR TITLE
Move `layout` setup for OAuth views to controllers

### DIFF
--- a/app/controllers/oauth/authorizations_controller.rb
+++ b/app/controllers/oauth/authorizations_controller.rb
@@ -6,6 +6,8 @@ class OAuth::AuthorizationsController < Doorkeeper::AuthorizationsController
   before_action :store_current_location
   before_action :authenticate_resource_owner!
 
+  layout 'modal'
+
   content_security_policy do |p|
     p.form_action(false)
   end

--- a/app/controllers/oauth/authorized_applications_controller.rb
+++ b/app/controllers/oauth/authorized_applications_controller.rb
@@ -11,6 +11,8 @@ class OAuth::AuthorizedApplicationsController < Doorkeeper::AuthorizedApplicatio
 
   skip_before_action :require_functional!
 
+  layout 'admin'
+
   include Localized
 
   def destroy

--- a/config/application.rb
+++ b/config/application.rb
@@ -115,8 +115,6 @@ module Mastodon
     end
 
     config.to_prepare do
-      Doorkeeper::AuthorizationsController.layout 'modal'
-      Doorkeeper::AuthorizedApplicationsController.layout 'admin'
       Doorkeeper::Application.include ApplicationExtension
       Doorkeeper::AccessGrant.include AccessGrantExtension
       Doorkeeper::AccessToken.include AccessTokenExtension

--- a/spec/controllers/oauth/authorizations_controller_spec.rb
+++ b/spec/controllers/oauth/authorizations_controller_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe OAuth::AuthorizationsController do
+  render_views
+
   let(:app) { Doorkeeper::Application.create!(name: 'test', redirect_uri: 'http://localhost/', scopes: 'read') }
 
   describe 'GET #new' do
@@ -24,6 +26,8 @@ RSpec.describe OAuth::AuthorizationsController do
           .to have_http_status(200)
         expect(response.headers['Cache-Control'])
           .to include('private, no-store')
+        expect(response.parsed_body.at('body.modal-layout'))
+          .to be_present
         expect(controller.stored_location_for(:user))
           .to eq authorize_path_for(app)
       end

--- a/spec/controllers/oauth/authorized_applications_controller_spec.rb
+++ b/spec/controllers/oauth/authorized_applications_controller_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe OAuth::AuthorizedApplicationsController do
           .to have_http_status(200)
         expect(response.headers['Cache-Control'])
           .to include('private, no-store')
+        expect(response.parsed_body.at('body.admin'))
+          .to be_present
         expect(controller.stored_location_for(:user))
           .to eq '/oauth/authorized_applications'
       end


### PR DESCRIPTION
The assignment of layouts from application.rb here predates the addition of the sub-classed controller which inherit from the doorkeeper classes. With those in places, this can live there and happen on the controllers themselves.