### PR TITLE
Extract `Status::Mappings` concern for `*_map` methods

### DIFF
--- a/app/models/concerns/status/mappings.rb
+++ b/app/models/concerns/status/mappings.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Status::Mappings
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def bookmarks_map(status_ids, account_id)
+      Bookmark
+        .where(status_id: status_ids, account_id: account_id)
+        .pluck(:status_id)
+        .index_with(true)
+    end
+
+    def favourites_map(status_ids, account_id)
+      Favourite
+        .where(status_id: status_ids, account_id: account_id)
+        .pluck(:status_id)
+        .index_with(true)
+    end
+
+    def mutes_map(conversation_ids, account_id)
+      ConversationMute
+        .where(conversation_id: conversation_ids, account_id: account_id)
+        .pluck(:conversation_id)
+        .index_with(true)
+    end
+
+    def pins_map(status_ids, account_id)
+      StatusPin
+        .where(status_id: status_ids, account_id: account_id)
+        .pluck(:status_id)
+        .index_with(true)
+    end
+
+    def reblogs_map(status_ids, account_id)
+      Status
+        .unscoped
+        .where(reblog_of_id: status_ids, account_id: account_id)
+        .pluck(:reblog_of_id)
+        .index_with(true)
+    end
+  end
+end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -38,6 +38,7 @@ class Status < ApplicationRecord
   include RateLimitable
   include Status::FaspConcern
   include Status::FetchRepliesConcern
+  include Status::Mappings
   include Status::SafeReblogInsert
   include Status::SearchConcern
   include Status::SnapshotConcern
@@ -358,26 +359,6 @@ class Status < ApplicationRecord
   end
 
   class << self
-    def favourites_map(status_ids, account_id)
-      Favourite.select(:status_id).where(status_id: status_ids).where(account_id: account_id).each_with_object({}) { |f, h| h[f.status_id] = true }
-    end
-
-    def bookmarks_map(status_ids, account_id)
-      Bookmark.select(:status_id).where(status_id: status_ids).where(account_id: account_id).to_h { |f| [f.status_id, true] }
-    end
-
-    def reblogs_map(status_ids, account_id)
-      unscoped.select(:reblog_of_id).where(reblog_of_id: status_ids).where(account_id: account_id).each_with_object({}) { |s, h| h[s.reblog_of_id] = true }
-    end
-
-    def mutes_map(conversation_ids, account_id)
-      ConversationMute.select(:conversation_id).where(conversation_id: conversation_ids).where(account_id: account_id).each_with_object({}) { |m, h| h[m.conversation_id] = true }
-    end
-
-    def pins_map(status_ids, account_id)
-      StatusPin.select(:status_id).where(status_id: status_ids).where(account_id: account_id).each_with_object({}) { |p, h| h[p.status_id] = true }
-    end
-
     def from_text(text)
       return [] if text.blank?
 

--- a/spec/models/concerns/status/mappings_spec.rb
+++ b/spec/models/concerns/status/mappings_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Status::Mappings do
+  describe '.bookmarks_map' do
+    subject { Status.bookmarks_map([status], account) }
+
+    let(:status)  { Fabricate(:status) }
+    let(:account) { Fabricate(:account) }
+
+    context 'with a bookmarkeded status' do
+      before { Fabricate(:bookmark, account: account, status: status) }
+
+      it { is_expected.to be_a(Hash).and include(status.id => true) }
+    end
+  end
+
+  describe '.favourites_map' do
+    subject { Status.favourites_map([status], account) }
+
+    let(:status)  { Fabricate(:status) }
+    let(:account) { Fabricate(:account) }
+
+    context 'with a favourited status' do
+      before { Fabricate(:favourite, status: status, account: account) }
+
+      it { is_expected.to be_a(Hash).and include(status.id => true) }
+    end
+  end
+
+  describe '.mutes_map' do
+    subject { Status.mutes_map([status.conversation.id], account) }
+
+    let(:status)  { Fabricate(:status) }
+    let(:account) { Fabricate(:account) }
+
+    context 'with a muted conversation' do
+      before { account.mute_conversation!(status.conversation) }
+
+      it { is_expected.to be_a(Hash).and include(status.conversation_id => true) }
+    end
+  end
+
+  describe '.pins_map' do
+    subject { Status.pins_map([status], account) }
+
+    let(:status)  { Fabricate(:status, account: account) }
+    let(:account) { Fabricate(:account) }
+
+    context 'with a pinned status' do
+      before { Fabricate(:status_pin, account: account, status: status) }
+
+      it { is_expected.to be_a(Hash).and include(status.id => true) }
+    end
+  end
+
+  describe '.reblogs_map' do
+    subject { Status.reblogs_map([status], account) }
+
+    let(:status)  { Fabricate(:status) }
+    let(:account) { Fabricate(:account) }
+
+    context 'with a reblogged status' do
+      before { Fabricate(:status, account: account, reblog: status) }
+
+      it { is_expected.to be_a(Hash).and include(status.id => true) }
+    end
+  end
+end

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -317,54 +317,6 @@ RSpec.describe Status do
     end
   end
 
-  describe '.mutes_map' do
-    subject { described_class.mutes_map([status.conversation.id], account) }
-
-    let(:status)  { Fabricate(:status) }
-    let(:account) { Fabricate(:account) }
-
-    it 'returns a hash' do
-      expect(subject).to be_a Hash
-    end
-
-    it 'contains true value' do
-      account.mute_conversation!(status.conversation)
-      expect(subject[status.conversation.id]).to be true
-    end
-  end
-
-  describe '.favourites_map' do
-    subject { described_class.favourites_map([status], account) }
-
-    let(:status)  { Fabricate(:status) }
-    let(:account) { Fabricate(:account) }
-
-    it 'returns a hash' do
-      expect(subject).to be_a Hash
-    end
-
-    it 'contains true value' do
-      Fabricate(:favourite, status: status, account: account)
-      expect(subject[status.id]).to be true
-    end
-  end
-
-  describe '.reblogs_map' do
-    subject { described_class.reblogs_map([status], account) }
-
-    let(:status)  { Fabricate(:status) }
-    let(:account) { Fabricate(:account) }
-
-    it 'returns a hash' do
-      expect(subject).to be_a Hash
-    end
-
-    it 'contains true value' do
-      Fabricate(:status, account: account, reblog: status)
-      expect(subject[status.id]).to be true
-    end
-  end
-
   describe '.only_reblogs' do
     let!(:status) { Fabricate :status }
     let!(:reblog) { Fabricate :status, reblog: Fabricate(:status) }


### PR DESCRIPTION
Very similar to https://github.com/mastodon/mastodon/pull/35119 except for statuses instead of accounts.

Notes:

- Three of the methods had specs, moved those to concern spec, added specs for the missing ones
- In all specs, did some example combining to reduce factory count
- In the concern, converted to a `pluck` + `index_with` approach (replacing `select` + `each_with_object`) both to match what's done elsewhere, and because that seems slightly more idiomatic/compact in this particular scenario
- Decent LOC reduction for two of the larger model and model spec files