### PR TITLE
Remove unused `options` arg from `TagRelationshipsPresenter`

### DIFF
--- a/app/presenters/tag_relationships_presenter.rb
+++ b/app/presenters/tag_relationships_presenter.rb
@@ -8,8 +8,24 @@ class TagRelationshipsPresenter
       @following_map = {}
       @featuring_map = {}
     else
-      @following_map = TagFollow.select(:tag_id).where(tag_id: tags.map(&:id), account_id: current_account_id).each_with_object({}) { |f, h| h[f.tag_id] = true }
-      @featuring_map = FeaturedTag.select(:tag_id).where(tag_id: tags.map(&:id), account_id: current_account_id).each_with_object({}) { |f, h| h[f.tag_id] = true }
+      @following_map = mapped_tag_follows(tags, current_account_id)
+      @featuring_map = mapped_featured_tags(tags, current_account_id)
     end
+  end
+
+  private
+
+  def mapped_tag_follows(tags, account_id)
+    TagFollow
+      .where(tag_id: tags.map(&:id), account_id: account_id)
+      .pluck(:tag_id)
+      .index_with(true)
+  end
+
+  def mapped_featured_tags(tags, account_id)
+    FeaturedTag
+      .where(tag_id: tags.map(&:id), account_id: account_id)
+      .pluck(:tag_id)
+      .index_with(true)
   end
 end

--- a/app/presenters/tag_relationships_presenter.rb
+++ b/app/presenters/tag_relationships_presenter.rb
@@ -3,13 +3,13 @@
 class TagRelationshipsPresenter
   attr_reader :following_map, :featuring_map
 
-  def initialize(tags, current_account_id = nil, **options)
+  def initialize(tags, current_account_id = nil)
     if current_account_id.nil?
       @following_map = {}
       @featuring_map = {}
     else
-      @following_map = TagFollow.select(:tag_id).where(tag_id: tags.map(&:id), account_id: current_account_id).each_with_object({}) { |f, h| h[f.tag_id] = true }.merge(options[:following_map] || {})
-      @featuring_map = FeaturedTag.select(:tag_id).where(tag_id: tags.map(&:id), account_id: current_account_id).each_with_object({}) { |f, h| h[f.tag_id] = true }.merge(options[:featuring_map] || {})
+      @following_map = TagFollow.select(:tag_id).where(tag_id: tags.map(&:id), account_id: current_account_id).each_with_object({}) { |f, h| h[f.tag_id] = true }
+      @featuring_map = FeaturedTag.select(:tag_id).where(tag_id: tags.map(&:id), account_id: current_account_id).each_with_object({}) { |f, h| h[f.tag_id] = true }
     end
   end
 end

--- a/spec/presenters/tag_relationships_presenter_spec.rb
+++ b/spec/presenters/tag_relationships_presenter_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe TagRelationshipsPresenter do
+  context 'without an account' do
+    subject { described_class.new(tags, nil) }
+
+    let(:tags) { Fabricate.times 2, :tag }
+
+    it 'includes empty hashes for maps' do
+      expect(subject)
+        .to have_attributes(
+          following_map: eq({}),
+          featuring_map: eq({})
+        )
+    end
+  end
+
+  context 'with an account and following and featured tags' do
+    subject { described_class.new(Tag.all, account.id) }
+
+    let(:account) { Fabricate :account }
+    let(:tag_to_feature) { Fabricate :tag }
+    let(:tag_to_follow) { Fabricate :tag }
+
+    before do
+      Fabricate :featured_tag, account: account, tag: tag_to_feature
+      Fabricate :tag_follow, account: account, tag: tag_to_follow
+    end
+
+    it 'includes map with relevant id values' do
+      expect(subject)
+        .to have_attributes(
+          featuring_map: eq(tag_to_feature.id => true),
+          following_map: eq(tag_to_follow.id => true)
+        )
+    end
+  end
+end


### PR DESCRIPTION
Added here - https://github.com/mastodon/mastodon/pull/18809/files#diff-37ed4e357c047bc0dfc297ccb6018719e4f410f53e1b1fc913e62dd060d48be2 - but as far as I can see was not used in that PR and has not been used since. Presumably a copy/paste from a different presenter which does have and use the option?

While removing - added lightweight presenter coverage for the class, tiny private method refactor to improve readability on long lines.