### PR TITLE
Add concern for `MediaAttachment` file extensions

### DIFF
--- a/app/models/concerns/media_attachment/extensions.rb
+++ b/app/models/concerns/media_attachment/extensions.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module MediaAttachment::Extensions
+  extend ActiveSupport::Concern
+
+  AUDIO_FILE_EXTENSIONS = %w(
+    .3gp
+    .aac
+    .flac
+    .m4a
+    .mp3
+    .oga
+    .ogg
+    .opus
+    .wav
+    .wma
+  ).freeze
+
+  IMAGE_FILE_EXTENSIONS = %w(
+    .avif
+    .gif
+    .heic
+    .heif
+    .jpeg
+    .jpg
+    .png
+    .webp
+  ).freeze
+
+  VIDEO_FILE_EXTENSIONS = %w(
+    .m4v
+    .mov
+    .mp4
+    .webm
+  ).freeze
+
+  class_methods do
+    def supported_file_extensions
+      [
+        AUDIO_FILE_EXTENSIONS,
+        IMAGE_FILE_EXTENSIONS,
+        VIDEO_FILE_EXTENSIONS,
+      ]
+        .flatten
+        .sort
+    end
+  end
+end

--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -33,6 +33,7 @@ class MediaAttachment < ApplicationRecord
   self.inheritance_column = nil
 
   include Attachmentable
+  include MediaAttachment::Extensions
 
   enum :type, { image: 0, gifv: 1, video: 2, unknown: 3, audio: 4 }
   enum :processing, { queued: 0, in_progress: 1, complete: 2, failed: 3 }, prefix: true
@@ -45,10 +46,6 @@ class MediaAttachment < ApplicationRecord
   MAX_VIDEO_MATRIX_LIMIT = 8_294_400 # 3840x2160px
   MAX_VIDEO_FRAME_RATE   = 120
   MAX_VIDEO_FRAMES       = 36_000 # Approx. 5 minutes at 120 fps
-
-  IMAGE_FILE_EXTENSIONS = %w(.jpg .jpeg .png .gif .webp .heic .heif .avif).freeze
-  VIDEO_FILE_EXTENSIONS = %w(.webm .mp4 .m4v .mov).freeze
-  AUDIO_FILE_EXTENSIONS = %w(.ogg .oga .mp3 .wav .flac .opus .aac .m4a .3gp .wma).freeze
 
   META_KEYS = %i(
     focus
@@ -292,10 +289,6 @@ class MediaAttachment < ApplicationRecord
   class << self
     def supported_mime_types
       IMAGE_MIME_TYPES + VIDEO_MIME_TYPES + AUDIO_MIME_TYPES
-    end
-
-    def supported_file_extensions
-      IMAGE_FILE_EXTENSIONS + VIDEO_FILE_EXTENSIONS + AUDIO_FILE_EXTENSIONS
     end
 
     def combined_media_file_size


### PR DESCRIPTION
In addition to the ~500 LOC user/status/account classes, `MediaAttachment` is the next largest, and then there's a pretty big fall off down to another group in the high ~100s and low ~200s LOC. I've been trying to chip away at those other three, and am also looking at media attachment as well.

This change is aimed at reducing LOC in MediaAttachment, making future changes to these formats/extensions more easily diffable, etc -- but this is admittedly sort of small gain all by itself. A really big chunk of LOC in the media attachment class comes from all the various (rarely changing, but large LOC) constants related to defining media processing options/formats/etc. The idea here would be to do followup PRs (or add to this one) which also move out the mime types constant, and then the audio/video/image defs as well. I think this does not really make sense to just merge by itself if we're not going to continue down that path - but is a decent first step if we'd like to.

The `supported_file_extensions` class method moved here is used only in the initial state serializer, where it combines with other values to expose a `accept_content_types` key that the JS consumes. Other than an order change from the added `sort`, the exposed list there should be the same.