### PR TITLE
Move disallow unauthenticated to `x.mastodon` config area

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -92,7 +92,7 @@ class Api::BaseController < ApplicationController
   end
 
   def disallow_unauthenticated_api_access?
-    ENV['DISALLOW_UNAUTHENTICATED_API_ACCESS'] == 'true' || Rails.configuration.x.mastodon.limited_federation_mode
+    Rails.configuration.x.mastodon.disallow_unauthenticated_api_access || Rails.configuration.x.mastodon.limited_federation_mode
   end
 
   private

--- a/app/serializers/webfinger_serializer.rb
+++ b/app/serializers/webfinger_serializer.rb
@@ -30,12 +30,15 @@ class WebfingerSerializer < ActiveModel::Serializer
   private
 
   def show_avatar?
-    media_present = object.avatar.present? && object.avatar.content_type.present?
+    media_present? && config_allows_public_access?
+  end
 
-    # Show avatar only if an instance shows profiles to logged out users
-    allowed_by_config = ENV['DISALLOW_UNAUTHENTICATED_API_ACCESS'] != 'true' && !Rails.configuration.x.mastodon.limited_federation_mode
+  def media_present?
+    object.avatar.present? && object.avatar.content_type.present?
+  end
 
-    media_present && allowed_by_config
+  def config_allows_public_access?
+    !Rails.configuration.x.mastodon.disallow_unauthenticated_api_access && !Rails.configuration.x.mastodon.limited_federation_mode
   end
 
   def profile_page_href

--- a/config/mastodon.yml
+++ b/config/mastodon.yml
@@ -1,5 +1,6 @@
 ---
 shared:
+  disallow_unauthenticated_api_access: <%= ENV.fetch('DISALLOW_UNAUTHENTICATED_API_ACCESS', nil) == 'true' %>
   experimental_features: <%= ENV.fetch('EXPERIMENTAL_FEATURES', nil) %>
   limited_federation_mode: <%= (ENV.fetch('LIMITED_FEDERATION_MODE', nil) || ENV.fetch('WHITELIST_MODE', nil)) == 'true' %>
   self_destruct_value: <%= ENV.fetch('SELF_DESTRUCT', nil)&.to_json %>

--- a/spec/requests/cache_spec.rb
+++ b/spec/requests/cache_spec.rb
@@ -555,9 +555,10 @@ RSpec.describe 'Caching behavior' do
 
   context 'when enabling DISALLOW_UNAUTHENTICATED_API_ACCESS' do
     around do |example|
-      ClimateControl.modify DISALLOW_UNAUTHENTICATED_API_ACCESS: 'true' do
-        example.run
-      end
+      original = Rails.configuration.x.mastodon.disallow_unauthenticated_api_access
+      Rails.configuration.x.mastodon.disallow_unauthenticated_api_access = true
+      example.run
+      Rails.configuration.x.mastodon.disallow_unauthenticated_api_access = original
     end
 
     context 'when anonymously accessed' do

--- a/spec/requests/well_known/webfinger_spec.rb
+++ b/spec/requests/well_known/webfinger_spec.rb
@@ -189,9 +189,10 @@ RSpec.describe 'The /.well-known/webfinger endpoint' do
 
     context 'when enabling DISALLOW_UNAUTHENTICATED_API_ACCESS' do
       around do |example|
-        ClimateControl.modify DISALLOW_UNAUTHENTICATED_API_ACCESS: 'true' do
-          example.run
-        end
+        original = Rails.configuration.x.mastodon.disallow_unauthenticated_api_access
+        Rails.configuration.x.mastodon.disallow_unauthenticated_api_access = true
+        example.run
+        Rails.configuration.x.mastodon.disallow_unauthenticated_api_access = original
       end
 
       it 'does not return avatar in response' do


### PR DESCRIPTION
Follow-up on https://github.com/mastodon/mastodon/pull/35041

The move itself is straightforward enough. Two naming oddities here:

- Within the base controller, the helper method `disallow_unauthenticated_api_access?` checks BOTH this ENV var (moved to config here) and also the limited federation mode value -- but has the same exact name as just this value. Not a huge deal, just slightly confusing.
- The __double negative__ of "disallow unauthenticated" (ie, "do NOT allow when NOT auth'd") is sort of awkward. It probably doesn't make sense to rename the env var given ~3 years of usage ... but thoughts on renaming the internal code/config here to be like `x.mastodon.require_authenticated_api_access` or something?