### PR TITLE
Fix search operators sometimes getting lost

### DIFF
--- a/app/lib/search_query_transformer.rb
+++ b/app/lib/search_query_transformer.rb
@@ -35,7 +35,7 @@ class SearchQueryTransformer < Parslet::Transform
     private
 
     def clauses_by_operator
-      @clauses_by_operator ||= @clauses.compact.chunk(&:operator).to_h
+      @clauses_by_operator ||= @clauses.compact.group_by(&:operator)
     end
 
     def flags_from_clauses!

--- a/spec/lib/search_query_transformer_spec.rb
+++ b/spec/lib/search_query_transformer_spec.rb
@@ -129,4 +129,24 @@ RSpec.describe SearchQueryTransformer do
       end
     end
   end
+
+  context 'with multiple prefix clauses before a search term' do
+    let(:query) { 'from:me has:media foo' }
+
+    it 'transforms clauses' do
+      expect(subject.send(:must_clauses).map(&:term)).to contain_exactly('foo')
+      expect(subject.send(:must_not_clauses)).to be_empty
+      expect(subject.send(:filter_clauses).map(&:prefix)).to contain_exactly('from', 'has')
+    end
+  end
+
+  context 'with a search term between two prefix clauses' do
+    let(:query) { 'from:me foo has:media' }
+
+    it 'transforms clauses' do
+      expect(subject.send(:must_clauses).map(&:term)).to contain_exactly('foo')
+      expect(subject.send(:must_not_clauses)).to be_empty
+      expect(subject.send(:filter_clauses).map(&:prefix)).to contain_exactly('from', 'has')
+    end
+  end
 end


### PR DESCRIPTION
This fixes stuff like `from:me foo has:media` losing the `from:me` search operator.

This is a long-standing issue I kind of forgot about but rediscovered.

In the case of `from:me has:media foo`, `@clauses.compact.chunk(&:operator)` would create two chunks, one for `filter` clauses containing both `from:me` and `has:media`, and one for the `foo` `must` clause. However, for `from:me foo has:media`, it would create three chunks, since the `filter` clauses are separated by a `must` clause, and `to_h` would only keep one.

I believe `#group_by` directly does what we expect here.