### PR TITLE
Move `x.single_user_mode` config into `mastodon.x` area

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -148,7 +148,7 @@ class ApplicationController < ActionController::Base
   end
 
   def single_user_mode?
-    @single_user_mode ||= Rails.configuration.x.single_user_mode && Account.without_internal.exists?
+    @single_user_mode ||= Rails.configuration.x.mastodon.single_user_mode && Account.without_internal.exists?
   end
 
   def use_seamless_external_login?

--- a/app/helpers/registration_helper.rb
+++ b/app/helpers/registration_helper.rb
@@ -4,7 +4,7 @@ module RegistrationHelper
   extend ActiveSupport::Concern
 
   def allowed_registration?(remote_ip, invite)
-    !Rails.configuration.x.single_user_mode && !omniauth_only? && (registrations_open? || invite&.valid_for_use?) && !ip_blocked?(remote_ip)
+    !Rails.configuration.x.mastodon.single_user_mode && !omniauth_only? && (registrations_open? || invite&.valid_for_use?) && !ip_blocked?(remote_ip)
   end
 
   def registrations_open?

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -41,7 +41,7 @@ class InitialStateSerializer < ActiveModel::Serializer
     store[:disabled_account_id] = object.disabled_account.id.to_s if object.disabled_account
     store[:moved_to_account_id] = object.moved_to_account.id.to_s if object.moved_to_account
 
-    store[:owner] = object.owner&.id&.to_s if Rails.configuration.x.single_user_mode
+    store[:owner] = object.owner&.id&.to_s if Rails.configuration.x.mastodon.single_user_mode
 
     store
   end
@@ -102,10 +102,10 @@ class InitialStateSerializer < ActiveModel::Serializer
       locale: I18n.locale,
       mascot: instance_presenter.mascot&.file&.url,
       profile_directory: Setting.profile_directory,
-      registrations_open: Setting.registrations_mode != 'none' && !Rails.configuration.x.single_user_mode,
+      registrations_open: Setting.registrations_mode != 'none' && !Rails.configuration.x.mastodon.single_user_mode,
       repository: Mastodon::Version.repository,
       search_enabled: Chewy.enabled?,
-      single_user_mode: Rails.configuration.x.single_user_mode,
+      single_user_mode: Rails.configuration.x.mastodon.single_user_mode,
       source_url: instance_presenter.source_url,
       sso_redirect: sso_redirect,
       status_page_url: Setting.status_page_url,

--- a/app/serializers/node_info/serializer.rb
+++ b/app/serializers/node_info/serializer.rb
@@ -34,7 +34,7 @@ class NodeInfo::Serializer < ActiveModel::Serializer
   end
 
   def open_registrations
-    Setting.registrations_mode != 'none' && !Rails.configuration.x.single_user_mode
+    Setting.registrations_mode != 'none' && !Rails.configuration.x.mastodon.single_user_mode
   end
 
   def metadata

--- a/app/serializers/rest/instance_serializer.rb
+++ b/app/serializers/rest/instance_serializer.rb
@@ -122,7 +122,7 @@ class REST::InstanceSerializer < ActiveModel::Serializer
   private
 
   def registrations_enabled?
-    Setting.registrations_mode != 'none' && !Rails.configuration.x.single_user_mode
+    Setting.registrations_mode != 'none' && !Rails.configuration.x.mastodon.single_user_mode
   end
 
   def registrations_message

--- a/app/serializers/rest/v1/instance_serializer.rb
+++ b/app/serializers/rest/v1/instance_serializer.rb
@@ -79,7 +79,7 @@ class REST::V1::InstanceSerializer < ActiveModel::Serializer
   end
 
   def registrations
-    Setting.registrations_mode != 'none' && !Rails.configuration.x.single_user_mode
+    Setting.registrations_mode != 'none' && !Rails.configuration.x.mastodon.single_user_mode
   end
 
   def approval_required

--- a/config/initializers/single_user_mode.rb
+++ b/config/initializers/single_user_mode.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-Rails.application.configure do
-  config.x.single_user_mode = ENV['SINGLE_USER_MODE'] == 'true'
-end

--- a/config/mastodon.yml
+++ b/config/mastodon.yml
@@ -3,6 +3,7 @@ shared:
   experimental_features: <%= ENV.fetch('EXPERIMENTAL_FEATURES', nil) %>
   limited_federation_mode: <%= (ENV.fetch('LIMITED_FEDERATION_MODE', nil) || ENV.fetch('WHITELIST_MODE', nil)) == 'true' %>
   self_destruct_value: <%= ENV.fetch('SELF_DESTRUCT', nil)&.to_json %>
+  single_user_mode: <%= ENV.fetch('SINGLE_USER_MODE', nil) == 'true' %>
   software_update_url: <%= ENV.fetch('UPDATE_CHECK_URL', 'https://api.joinmastodon.org/update-check')&.to_json %>
   source:
     base_url: <%= ENV.fetch('SOURCE_BASE_URL', nil)&.to_json %>

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -68,18 +68,18 @@ RSpec.describe ApplicationController do
 
   describe 'helper_method :single_user_mode?' do
     it 'returns false if it is in single_user_mode but there is no account' do
-      allow(Rails.configuration.x).to receive(:single_user_mode).and_return(true)
+      allow(Rails.configuration.x.mastodon).to receive(:single_user_mode).and_return(true)
       expect(controller.view_context.single_user_mode?).to be false
     end
 
     it 'returns false if there is an account but it is not in single_user_mode' do
-      allow(Rails.configuration.x).to receive(:single_user_mode).and_return(false)
+      allow(Rails.configuration.x.mastodon).to receive(:single_user_mode).and_return(false)
       Fabricate(:account)
       expect(controller.view_context.single_user_mode?).to be false
     end
 
     it 'returns true if it is in single_user_mode and there is an account' do
-      allow(Rails.configuration.x).to receive(:single_user_mode).and_return(true)
+      allow(Rails.configuration.x.mastodon).to receive(:single_user_mode).and_return(true)
       Fabricate(:account)
       expect(controller.view_context.single_user_mode?).to be true
     end

--- a/spec/controllers/auth/registrations_controller_spec.rb
+++ b/spec/controllers/auth/registrations_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Auth::RegistrationsController do
     context 'when in single user mode and open for registration' do
       before do
         Setting.registrations_mode = 'open'
-        allow(Rails.configuration.x).to receive(:single_user_mode).and_return(true)
+        allow(Rails.configuration.x.mastodon).to receive(:single_user_mode).and_return(true)
       end
 
       it 'redirects to root' do
@@ -17,21 +17,21 @@ RSpec.describe Auth::RegistrationsController do
         get path
 
         expect(response).to redirect_to '/'
-        expect(Rails.configuration.x).to have_received(:single_user_mode)
+        expect(Rails.configuration.x.mastodon).to have_received(:single_user_mode)
       end
     end
 
     context 'when registrations closed and not in single user mode' do
       before do
         Setting.registrations_mode = 'none'
-        allow(Rails.configuration.x).to receive(:single_user_mode).and_return(false)
+        allow(Rails.configuration.x.mastodon).to receive(:single_user_mode).and_return(false)
       end
 
       it 'redirects to root' do
         get path
 
         expect(response).to redirect_to '/'
-        expect(Rails.configuration.x).to have_received(:single_user_mode)
+        expect(Rails.configuration.x.mastodon).to have_received(:single_user_mode)
       end
     end
   end


### PR DESCRIPTION
The ENV-var-derived value here was already set in the config object - just moving it into existing yml instead and removing initializer.