### PR TITLE
Add optional bulk mailer settings

### DIFF
--- a/app/mailers/concerns/bulk_mail_settings_concern.rb
+++ b/app/mailers/concerns/bulk_mail_settings_concern.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module BulkMailSettingsConcern
+  include ActiveSupport::Concern
+  include Mastodon::EmailConfigurationHelper
+
+  private
+
+  def use_bulk_mail_delivery_settings
+    return if bulk_mail_configuration&.dig(:smtp_settings, :address).blank?
+
+    mail.delivery_method.settings = convert_smtp_settings(bulk_mail_configuration[:smtp_settings])
+  end
+
+  def bulk_mail_configuration
+    Rails.configuration.x.email&.bulk_mail
+  end
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class UserMailer < Devise::Mailer
+  include BulkMailSettingsConcern
+
   layout 'mailer'
 
   helper :accounts
@@ -11,6 +13,8 @@ class UserMailer < Devise::Mailer
   helper :statuses
 
   before_action :set_instance
+
+  after_action :use_bulk_mail_delivery_settings, only: [:announcement_published, :terms_of_service_changed]
 
   default to: -> { @resource.email }
 

--- a/app/workers/admin/distribute_announcement_notification_worker.rb
+++ b/app/workers/admin/distribute_announcement_notification_worker.rb
@@ -2,7 +2,7 @@
 
 class Admin::DistributeAnnouncementNotificationWorker
   include Sidekiq::IterableJob
-  include BulkMailer
+  include BulkMailingConcern
 
   def build_enumerator(announcement_id, cursor:)
     @announcement = Announcement.find(announcement_id)

--- a/app/workers/admin/distribute_terms_of_service_notification_worker.rb
+++ b/app/workers/admin/distribute_terms_of_service_notification_worker.rb
@@ -2,7 +2,7 @@
 
 class Admin::DistributeTermsOfServiceNotificationWorker
   include Sidekiq::IterableJob
-  include BulkMailer
+  include BulkMailingConcern
 
   def build_enumerator(terms_of_service_id, cursor:)
     @terms_of_service = TermsOfService.find(terms_of_service_id)

--- a/app/workers/concerns/bulk_mailing_concern.rb
+++ b/app/workers/concerns/bulk_mailing_concern.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module BulkMailer
+module BulkMailingConcern
   def push_bulk_mailer(mailer_class, mailer_method, args_array)
     raise ArgumentError, "No method #{mailer_method} on class #{mailer_class.name}" unless mailer_class.respond_to?(mailer_method)
 

--- a/config/email.yml
+++ b/config/email.yml
@@ -19,3 +19,18 @@ production:
     tls: <%= ENV.fetch('SMTP_TLS', false) == 'true' ? true : nil %>
     ssl: <%= ENV.fetch('SMTP_SSL', false) == 'true' ? true : nil %>
     read_timeout: 20
+  bulk_mail:
+    smtp_settings:
+      port: <%= ENV.fetch('BULK_SMTP_PORT', nil) %>
+      address: <%= ENV.fetch('BULK_SMTP_SERVER', nil) %>
+      user_name: <%= ENV.fetch('BULK_SMTP_LOGIN', nil) %>
+      password: <%= ENV.fetch('BULK_SMTP_PASSWORD', nil) %>
+      domain: <%= ENV.fetch('BULK_SMTP_DOMAIN', ENV.fetch('LOCAL_DOMAIN', nil)) %>
+      authentication: <%= ENV.fetch('BULK_SMTP_AUTH_METHOD', 'plain') %>
+      ca_file: <%= ENV.fetch('BULK_SMTP_CA_FILE', '/etc/ssl/certs/ca-certificates.crt') %>
+      openssl_verify_mode: <%= ENV.fetch('BULK_SMTP_OPENSSL_VERIFY_MODE', nil) %>
+      enable_starttls: <%= ENV.fetch('BULK_SMTP_ENABLE_STARTTLS', nil) %>
+      enable_starttls_auto: <%= ENV.fetch('BULK_SMTP_ENABLE_STARTTLS_AUTO', true) != 'false' %>
+      tls: <%= ENV.fetch('BULK_SMTP_TLS', false) == 'true' ? true : nil %>
+      ssl: <%= ENV.fetch('BULK_SMTP_SSL', false) == 'true' ? true : nil %>
+      read_timeout: 20

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -110,7 +110,7 @@ Rails.application.configure do
   config.action_mailer.default_options[:reply_to]    = config.x.email.reply_to if config.x.email.reply_to.present?
   config.action_mailer.default_options[:return_path] = config.x.email.return_path if config.x.email.return_path.present?
 
-  config.action_mailer.smtp_settings = Mastodon::EmailConfigurationHelper.smtp_settings(config.x.email.smtp_settings)
+  config.action_mailer.smtp_settings = Mastodon::EmailConfigurationHelper.convert_smtp_settings(config.x.email.smtp_settings)
 
   config.action_mailer.delivery_method = config.x.email.delivery_method.to_sym
 

--- a/lib/mastodon/email_configuration_helper.rb
+++ b/lib/mastodon/email_configuration_helper.rb
@@ -6,7 +6,7 @@ module Mastodon
 
     # Convert smtp settings from environment variables (or defaults in
     # `config/email.yml`) into the format that `ActionMailer` understands
-    def smtp_settings(config)
+    def convert_smtp_settings(config)
       enable_starttls = nil
       enable_starttls_auto = nil
 

--- a/spec/lib/mastodon/email_configuration_helper_spec.rb
+++ b/spec/lib/mastodon/email_configuration_helper_spec.rb
@@ -3,10 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe Mastodon::EmailConfigurationHelper do
-  describe '#smtp_settings' do
+  describe '#convert_smtp_settings' do
     subject { described_class }
 
-    let(:converted_settings) { subject.smtp_settings(configuration) }
+    let(:converted_settings) { subject.convert_smtp_settings(configuration) }
     let(:base_configuration) do
       {
         address: 'localhost',

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -103,4 +103,9 @@ class UserMailerPreview < ActionMailer::Preview
   def terms_of_service_changed
     UserMailer.terms_of_service_changed(User.first, TermsOfService.live.first)
   end
+
+  # Preview this email at http://localhost:3000/rails/mailers/user_mailer/announcement_published
+  def announcement_published
+    UserMailer.announcement_published(User.first, Announcement.last)
+  end
 end


### PR DESCRIPTION
Fixes MAS-462

We have two types of emails (server announcements and terms of service changes) that can be sent to many users at once. Turns out some transactional email service providers do not like this and require you to use different SMTP settings for these kinds of emails.

This change moves those mails into their own mailer, which will use different SMTP settings if available.

Those new settings work exactly as the existing ones, but are prefixed with `BULK_`.