### PR TITLE
Add coverage for `TermsOfService` scopes/validations

### DIFF
--- a/app/models/terms_of_service.rb
+++ b/app/models/terms_of_service.rb
@@ -15,9 +15,9 @@
 #
 class TermsOfService < ApplicationRecord
   scope :published, -> { where.not(published_at: nil).order(Arel.sql('coalesce(effective_date, published_at) DESC')) }
-  scope :live, -> { published.where('effective_date IS NULL OR effective_date < now()').limit(1) }
-  scope :upcoming, -> { published.reorder(effective_date: :asc).where('effective_date IS NOT NULL AND effective_date > now()').limit(1) }
-  scope :draft, -> { where(published_at: nil).order(id: :desc).limit(1) }
+  scope :live, -> { published.where('effective_date IS NULL OR effective_date < now()') }
+  scope :upcoming, -> { published.reorder(effective_date: :asc).where('effective_date IS NOT NULL AND effective_date > now()') }
+  scope :draft, -> { where(published_at: nil).order(id: :desc) }
 
   validates :text, presence: true
   validates :changelog, :effective_date, presence: true, if: -> { published? }

--- a/spec/models/terms_of_service_spec.rb
+++ b/spec/models/terms_of_service_spec.rb
@@ -3,6 +3,33 @@
 require 'rails_helper'
 
 RSpec.describe TermsOfService do
+  describe 'Validations' do
+    subject { Fabricate.build :terms_of_service }
+
+    it { is_expected.to validate_presence_of(:text) }
+    it { is_expected.to validate_uniqueness_of(:effective_date) }
+
+    it { is_expected.to allow_values(2.days.from_now).for(:effective_date) }
+    it { is_expected.to_not allow_values(2.days.ago).for(:effective_date) }
+
+    context 'with an existing published effective TOS' do
+      before do
+        travel_to 5.days.ago do
+          Fabricate :terms_of_service, published_at: 2.days.ago, effective_date: 1.day.from_now
+        end
+      end
+
+      it { is_expected.to allow_values(1.day.ago).for(:effective_date) }
+    end
+
+    context 'when published' do
+      subject { Fabricate.build :terms_of_service, published_at: Time.zone.today }
+
+      it { is_expected.to validate_presence_of(:changelog) }
+      it { is_expected.to validate_presence_of(:effective_date) }
+    end
+  end
+
   describe '#scope_for_notification' do
     subject { terms_of_service.scope_for_notification }
 


### PR DESCRIPTION
This is in prep for something like - https://github.com/mastodon/mastodon/pull/35115#discussion_r2159113889 - looking to break up these scopes a bit. The main thing here is adding the spec coverage in advance of that, without the actual composability refactor yet.

I also realized that each of live/upcoming/draft scopes are only used in one spot each in the app, and in those spots they all call `first` on the result, which gets us the sql `LIMIT` as part of the `first` call. I think these are the only scopes in the app that include a `limit` -- removing these in favor of keeping the scope as just the conditions and then using `take` or `first` as appropriate when called. If we're really worried about possibly calling one of these in error without a limit, I'd probably do a class method (similar to recently added `self.current` to wrap that up).