### PR TITLE
Fix unexpected "cache-control: no-cache" header in public file server

### DIFF
--- a/lib/mastodon/middleware/public_file_server.rb
+++ b/lib/mastodon/middleware/public_file_server.rb
@@ -22,7 +22,7 @@ module Mastodon
         status, headers, response = file
 
         # Set cache headers on static files. Some paths require different cache headers
-        headers['Cache-Control'] = begin
+        headers['cache-control'] = begin
           request_path = env['REQUEST_PATH']
 
           if request_path.start_with?('/sw.js')


### PR DESCRIPTION
For some reason(Maybe rack's bug), unexpected `cache-control: no-cache` header was added on /public responses
It seems rack uses only lower cases on header name. So this should be OK and proper way to fix it.

https://grep.app/search?f.lang=Ruby&f.repo.pattern=rack%2Frack&q=%5B%27Cache-Control%27%5D

![image](https://github.com/user-attachments/assets/9b0de9f7-3ef7-40fc-bf61-6958c93778df)

![image](https://github.com/user-attachments/assets/68e86ed7-63e7-43af-a530-97feeffdf331)
