### PR TITLE
Persist follow recommendations from FASP

### DIFF
--- a/app/models/account_suggestions.rb
+++ b/app/models/account_suggestions.rb
@@ -8,6 +8,7 @@ class AccountSuggestions
     AccountSuggestions::FriendsOfFriendsSource,
     AccountSuggestions::SimilarProfilesSource,
     AccountSuggestions::GlobalSource,
+    AccountSuggestions::FaspSource,
   ].freeze
 
   BATCH_SIZE = 40

--- a/app/models/account_suggestions/fasp_source.rb
+++ b/app/models/account_suggestions/fasp_source.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AccountSuggestions::FaspSource < AccountSuggestions::Source
+  def get(account, limit: DEFAULT_LIMIT)
+    return [] unless Mastodon::Feature.fasp_enabled?
+
+    base_account_scope(account).where(id: fasp_follow_recommendations_for(account)).limit(limit).pluck(:id).map do |account_id|
+      [account_id, :fasp]
+    end
+  end
+
+  private
+
+  def fasp_follow_recommendations_for(account)
+    Fasp::FollowRecommendation.for_account(account).newest_first.select(:recommended_account_id)
+  end
+end

--- a/app/models/fasp/follow_recommendation.rb
+++ b/app/models/fasp/follow_recommendation.rb
@@ -11,9 +11,12 @@
 #  requesting_account_id  :bigint(8)        not null
 #
 class Fasp::FollowRecommendation < ApplicationRecord
+  MAX_AGE = 1.day.freeze
+
   belongs_to :requesting_account, class_name: 'Account'
   belongs_to :recommended_account, class_name: 'Account'
 
+  scope :outdated, -> { where(created_at: ...(MAX_AGE.ago)) }
   scope :for_account, ->(account) { where(requesting_account: account) }
   scope :newest_first, -> { order(created_at: :desc) }
 end

--- a/app/models/fasp/follow_recommendation.rb
+++ b/app/models/fasp/follow_recommendation.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: fasp_follow_recommendations
+#
+#  id                     :bigint(8)        not null, primary key
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  recommended_account_id :bigint(8)        not null
+#  requesting_account_id  :bigint(8)        not null
+#
+class Fasp::FollowRecommendation < ApplicationRecord
+  belongs_to :requesting_account, class_name: 'Account'
+  belongs_to :recommended_account, class_name: 'Account'
+
+  scope :for_account, ->(account) { where(requesting_account: account) }
+  scope :newest_first, -> { order(created_at: :desc) }
+end

--- a/app/workers/fasp/follow_recommendation_worker.rb
+++ b/app/workers/fasp/follow_recommendation_worker.rb
@@ -32,6 +32,9 @@ class Fasp::FollowRecommendationWorker
       end
     end
 
+    # Invalidate follow recommendation cache so it does not
+    # take up to 15 minutes for the new recommendations to
+    # show up
     Rails.cache.delete("follow_recommendations/#{account.id}")
   rescue ActiveRecord::RecordNotFound
     # Nothing to be done

--- a/app/workers/fasp/follow_recommendation_worker.rb
+++ b/app/workers/fasp/follow_recommendation_worker.rb
@@ -31,6 +31,8 @@ class Fasp::FollowRecommendationWorker
         end
       end
     end
+
+    Rails.cache.delete("follow_recommendations/#{account.id}")
   rescue ActiveRecord::RecordNotFound
     # Nothing to be done
   ensure

--- a/app/workers/scheduler/fasp/follow_recommendation_cleanup_scheduler.rb
+++ b/app/workers/scheduler/fasp/follow_recommendation_cleanup_scheduler.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class Scheduler::Fasp::FollowRecommendationCleanupScheduler
+  include Sidekiq::Worker
+
+  sidekiq_options retry: 0, lock: :until_executed, lock_ttl: 1.day.to_i
+
+  def perform
+    return unless Mastodon::Feature.fasp_enabled?
+
+    Fasp::FollowRecommendation.outdated.delete_all
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -68,3 +68,7 @@
       interval: 1 hour
       class: Scheduler::AutoCloseRegistrationsScheduler
       queue: scheduler
+    fasp_follow_recommendation_cleanup_scheduler:
+      interval: 1 day
+      class: Scheduler::Fasp::FollowRecommendationsScheduler
+      queue: scheduler

--- a/db/migrate/20250627132728_create_fasp_follow_recommendations.rb
+++ b/db/migrate/20250627132728_create_fasp_follow_recommendations.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateFaspFollowRecommendations < ActiveRecord::Migration[8.0]
+  def change
+    create_table :fasp_follow_recommendations do |t|
+      t.references :requesting_account, null: false, foreign_key: { to_table: :accounts }
+      t.references :recommended_account, null: false, foreign_key: { to_table: :accounts }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_05_110215) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_27_132728) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -191,8 +191,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_05_110215) do
     t.boolean "hide_collections"
     t.integer "avatar_storage_schema_version"
     t.integer "header_storage_schema_version"
-    t.integer "suspension_origin"
     t.datetime "sensitized_at", precision: nil
+    t.integer "suspension_origin"
     t.boolean "trendable"
     t.datetime "reviewed_at", precision: nil
     t.datetime "requested_review_at", precision: nil
@@ -465,6 +465,15 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_05_110215) do
     t.index ["fasp_provider_id"], name: "index_fasp_debug_callbacks_on_fasp_provider_id"
   end
 
+  create_table "fasp_follow_recommendations", force: :cascade do |t|
+    t.bigint "requesting_account_id", null: false
+    t.bigint "recommended_account_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["recommended_account_id"], name: "index_fasp_follow_recommendations_on_recommended_account_id"
+    t.index ["requesting_account_id"], name: "index_fasp_follow_recommendations_on_requesting_account_id"
+  end
+
   create_table "fasp_providers", force: :cascade do |t|
     t.boolean "confirmed", default: false, null: false
     t.string "name", null: false
@@ -604,12 +613,12 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_05_110215) do
   end
 
   create_table "ip_blocks", force: :cascade do |t|
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
-    t.datetime "expires_at", precision: nil
     t.inet "ip", default: "0.0.0.0", null: false
     t.integer "severity", default: 0, null: false
+    t.datetime "expires_at", precision: nil
     t.text "comment", default: "", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["ip"], name: "index_ip_blocks_on_ip", unique: true
   end
 
@@ -1367,6 +1376,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_05_110215) do
   add_foreign_key "email_domain_blocks", "email_domain_blocks", column: "parent_id", on_delete: :cascade
   add_foreign_key "fasp_backfill_requests", "fasp_providers"
   add_foreign_key "fasp_debug_callbacks", "fasp_providers"
+  add_foreign_key "fasp_follow_recommendations", "accounts", column: "recommended_account_id"
+  add_foreign_key "fasp_follow_recommendations", "accounts", column: "requesting_account_id"
   add_foreign_key "fasp_subscriptions", "fasp_providers"
   add_foreign_key "favourites", "accounts", name: "fk_5eb6c2b873", on_delete: :cascade
   add_foreign_key "favourites", "statuses", name: "fk_b0e856845e", on_delete: :cascade

--- a/spec/fabricators/fasp/follow_recommendation_fabricator.rb
+++ b/spec/fabricators/fasp/follow_recommendation_fabricator.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+Fabricator('Fasp::FollowRecommendation') do
+  requesting_account { Fabricate.build(:account) }
+  recommended_account { Fabricate.build(:account, domain: 'fedi.example.com') }
+end

--- a/spec/fabricators/fasp/follow_recommendation_fabricator.rb
+++ b/spec/fabricators/fasp/follow_recommendation_fabricator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-Fabricator('Fasp::FollowRecommendation') do
+Fabricator(:fasp_follow_recommendation, from: 'Fasp::FollowRecommendation') do
   requesting_account { Fabricate.build(:account) }
   recommended_account { Fabricate.build(:account, domain: 'fedi.example.com') }
 end

--- a/spec/models/account_suggestions/fasp_source_spec.rb
+++ b/spec/models/account_suggestions/fasp_source_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AccountSuggestions::FaspSource do
+  describe '#get', feature: :fasp do
+    subject { described_class.new }
+
+    let(:bob) { Fabricate(:account) }
+    let(:alice) { Fabricate(:account, domain: 'fedi.example.com') }
+    let(:eve) { Fabricate(:account, domain: 'fedi.example.com') }
+
+    before do
+      [alice, eve].each do |recommended_account|
+        Fasp::FollowRecommendation.create!(requesting_account: bob, recommended_account:)
+      end
+    end
+
+    it 'returns recommendations obtained by FASP' do
+      expect(subject.get(bob)).to contain_exactly([alice.id, :fasp], [eve.id, :fasp])
+    end
+  end
+end

--- a/spec/models/fasp/follow_recommendation_spec.rb
+++ b/spec/models/fasp/follow_recommendation_spec.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-require 'rails_helper'
-
-RSpec.describe Fasp::FollowRecommendation do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/spec/models/fasp/follow_recommendation_spec.rb
+++ b/spec/models/fasp/follow_recommendation_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Fasp::FollowRecommendation do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/workers/scheduler/fasp/follow_recommendation_cleanup_scheduler_spec.rb
+++ b/spec/workers/scheduler/fasp/follow_recommendation_cleanup_scheduler_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Scheduler::Fasp::FollowRecommendationCleanupScheduler do
+  let(:worker) { described_class.new }
+
+  describe '#perform', feature: :fasp do
+    before do
+      Fabricate(:fasp_follow_recommendation, created_at: 2.days.ago)
+    end
+
+    it 'deletes outdated recommendations' do
+      expect { worker.perform }.to change(Fasp::FollowRecommendation, :count).by(-1)
+    end
+  end
+end


### PR DESCRIPTION
Follow-up to #34964

That PR made Mastodon aware of accounts that might be worth following for a given user, but especially on small/new servers, these are then unlikely to actually show up in the user's follow recommendation. This is mostly due to fact that we prioritize local data (follow relationships, boost/favorite counts etc.) that those servers/users just do not have.

This improves the situation by persisting the fact that a given account was received as a recommendation and adding this as an additional source for local account suggestions.