### PR TITLE
fix: Fix column header overlapping mobile menu on old Safari

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -3247,6 +3247,7 @@ a.account__display-name {
 .columns-area__panels__pane--overlay {
   pointer-events: auto;
   background: rgba($base-overlay-background, 0.5);
+  z-index: 3;
 
   .columns-area__panels__pane__inner {
     box-shadow: var(--dropdown-shadow);


### PR DESCRIPTION
### Changes proposed in this PR:
- Fixes an issue in old Webkit versions that could cause the sticky column headers to be rendered on top of the mobile menu

### Screenshots

| **Before** | **After** |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/5cd01632-fae4-4ca5-8089-c65b485be4b8) | ![image](https://github.com/user-attachments/assets/9f3e4b0b-2ef9-4e9c-9f4a-26a96812cf2a) | 