### PR TITLE
Bump version to 4.5.0-alpha.1

### DIFF
--- a/lib/mastodon/version.rb
+++ b/lib/mastodon/version.rb
@@ -9,7 +9,7 @@ module Mastodon
     end
 
     def minor
-      4
+      5
     end
 
     def patch
@@ -17,7 +17,7 @@ module Mastodon
     end
 
     def default_prerelease
-      'rc.1'
+      'alpha.1'
     end
 
     def prerelease


### PR DESCRIPTION
As we released 4.4.0 RC1, the `stable-4.4` branch has been created and we can bump `main` to 4.5