### PR TITLE
Use `ActiveModel::Attributes` for admin/account_action boolean values

### DIFF
--- a/app/models/admin/account_action.rb
+++ b/app/models/admin/account_action.rb
@@ -2,6 +2,7 @@
 
 class Admin::AccountAction
   include ActiveModel::Model
+  include ActiveModel::Attributes
   include AccountableConcern
   include Authorization
 
@@ -20,28 +21,16 @@ class Admin::AccountAction
                 :report_id,
                 :warning_preset_id
 
-  attr_reader :warning, :send_email_notification, :include_statuses
+  attr_reader :warning
+
+  attribute :include_statuses, :boolean, default: true
+  attribute :send_email_notification, :boolean, default: true
 
   alias send_email_notification? send_email_notification
   alias include_statuses? include_statuses
 
   validates :type, :target_account, :current_account, presence: true
   validates :type, inclusion: { in: TYPES }
-
-  def initialize(attributes = {})
-    @send_email_notification = true
-    @include_statuses        = true
-
-    super
-  end
-
-  def send_email_notification=(value)
-    @send_email_notification = ActiveModel::Type::Boolean.new.cast(value)
-  end
-
-  def include_statuses=(value)
-    @include_statuses = ActiveModel::Type::Boolean.new.cast(value)
-  end
 
   def save!
     raise ActiveRecord::RecordInvalid, self unless valid?


### PR DESCRIPTION
Background: idea during review of https://github.com/mastodon/mastodon/pull/35246#issuecomment-3028441812

I think this preserves exactly previous behavior (the internal implementation uses the same exact `cast` method), quick console session shows similar behavior, true/false classes, etc. I suspect there are more of these in other classes, but wanted to start with just one example.