### PR TITLE
Use `Account#targeted_reports` association where needed

### DIFF
--- a/app/models/admin/account_action.rb
+++ b/app/models/admin/account_action.rb
@@ -185,7 +185,7 @@ class Admin::AccountAction
     @reports ||= if type == 'none'
                    with_report? ? [report] : []
                  else
-                   Report.where(target_account: target_account).unresolved
+                   target_account.targeted_reports.unresolved
                  end
   end
 

--- a/app/models/form/account_batch.rb
+++ b/app/models/form/account_batch.rb
@@ -128,7 +128,7 @@ class Form::AccountBatch
 
     # Suspending a single account closes their associated reports, so
     # mass-suspending would be consistent.
-    Report.where(target_account: account).unresolved.find_each do |report|
+    account.targeted_reports.unresolved.find_each do |report|
       authorize(report, :update?)
       log_action(:resolve, report)
       report.resolve!(current_account)

--- a/app/services/delete_account_service.rb
+++ b/app/services/delete_account_service.rb
@@ -297,7 +297,7 @@ class DeleteAccountService < BaseService
   end
 
   def reported_status_ids
-    @reported_status_ids ||= Report.where(target_account: @account).unresolved.pluck(:status_ids).flatten.uniq
+    @reported_status_ids ||= @account.targeted_reports.unresolved.pluck(:status_ids).flatten.uniq
   end
 
   def associations_for_destruction


### PR DESCRIPTION
Follow-up on https://github.com/mastodon/mastodon/pull/32840/files#diff-8d0aaf2e59029dbcfc25eeb53c4937bce3ee60402798b1ba47d6ecee6255a012R46 which added this association but did not update to use it in these spots.