### PR TITLE
fix: Remove focus highlight when status is clicked in light mode

### DIFF
--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -101,7 +101,7 @@
 }
 
 // Change the background colors of statuses
-.focusable:focus {
+.focusable:focus-visible {
   background: lighten($white, 4%);
 }
 


### PR DESCRIPTION
### Changes proposed in this PR:
- Fixes an oversight from PR #35150 which didn't handle light mode, causing detailed statuses to show their focus shading when clicking or selecting their content

### Screencaps

**Before**

https://github.com/user-attachments/assets/a63a1461-3302-48b2-a577-3651ac1f6dd9

**After**

https://github.com/user-attachments/assets/8b70b3d0-8b76-4aa4-adea-5247d28c307b

