### PR TITLE
Simplify `DatabaseViewRecord.refresh`

### DIFF
--- a/app/models/concerns/database_view_record.rb
+++ b/app/models/concerns/database_view_record.rb
@@ -10,12 +10,6 @@ module DatabaseViewRecord
         concurrently: true,
         cascade: false
       )
-    rescue ActiveRecord::StatementInvalid
-      Scenic.database.refresh_materialized_view(
-        table_name,
-        concurrently: false,
-        cascade: false
-      )
     end
   end
 


### PR DESCRIPTION
This is now redundant with the Scenic update in #35226