### PR TITLE
Use `excluding` in simple queries

### DIFF
--- a/app/models/account_suggestions/source.rb
+++ b/app/models/account_suggestions/source.rb
@@ -19,7 +19,7 @@ class AccountSuggestions::Source
       .where.not(follow_requests_sql, id: account.id)
       .not_excluded_by_account(account)
       .not_domain_blocked_by_account(account)
-      .where.not(id: account.id)
+      .excluding(account)
       .where.not(follow_recommendation_mutes_sql, id: account.id)
   end
 

--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -199,7 +199,7 @@ class ActivityPub::ProcessAccountService < BaseService
   end
 
   def process_duplicate_accounts!
-    return unless Account.where(uri: @account.uri).where.not(id: @account.id).exists?
+    return unless Account.where(uri: @account.uri).excluding(@account).exists?
 
     AccountMergingWorker.perform_async(@account.id)
   end

--- a/app/validators/unique_username_validator.rb
+++ b/app/validators/unique_username_validator.rb
@@ -7,7 +7,7 @@ class UniqueUsernameValidator < ActiveModel::Validator
     return if account.username.blank?
 
     scope = Account.with_username(account.username).with_domain(account.domain)
-    scope = scope.where.not(id: account.id) if account.persisted?
+    scope = scope.excluding(account) if account.persisted?
 
     account.errors.add(:username, :taken) if scope.exists?
   end

--- a/app/workers/account_merging_worker.rb
+++ b/app/workers/account_merging_worker.rb
@@ -10,7 +10,7 @@ class AccountMergingWorker
 
     return true if account.nil? || account.local?
 
-    Account.where(uri: account.uri).where.not(id: account.id).find_each do |duplicate|
+    Account.where(uri: account.uri).excluding(account).find_each do |duplicate|
       account.merge_with!(duplicate)
       duplicate.destroy
     end

--- a/app/workers/backup_worker.rb
+++ b/app/workers/backup_worker.rb
@@ -22,7 +22,7 @@ class BackupWorker
 
     BackupService.new.call(backup)
 
-    user.backups.where.not(id: backup.id).destroy_all
+    user.backups.excluding(backup).destroy_all
     UserMailer.backup_ready(user, backup).deliver_later
   end
 end


### PR DESCRIPTION
As a first pass, this does a batch of very simple ones where there's no other refactoring needed, we are just passing a single record of the class, etc.

There's a spot in the annual reports that could improve from this, but needs a little refactor first to work out. Will do as follow-up. Also a few where we can either pass `self` and/or where we can pass a scope/collection of same-class to `excluding`, which will be follow-up as well.