### PR TITLE
Mark `private` methods in `AnnualReport::TopStatuses`

### DIFF
--- a/app/lib/annual_report/top_statuses.rb
+++ b/app/lib/annual_report/top_statuses.rb
@@ -15,6 +15,8 @@ class AnnualReport::TopStatuses < AnnualReport::Source
     }
   end
 
+  private
+
   def base_scope
     report_statuses.public_visibility.joins(:status_stat)
   end

--- a/app/lib/annual_report/top_statuses.rb
+++ b/app/lib/annual_report/top_statuses.rb
@@ -2,15 +2,15 @@
 
 class AnnualReport::TopStatuses < AnnualReport::Source
   def generate
-    top_reblogs = base_scope.order(reblogs_count: :desc).first&.id
-    top_favourites = base_scope.where.not(id: top_reblogs).order(favourites_count: :desc).first&.id
-    top_replies = base_scope.where.not(id: [top_reblogs, top_favourites]).order(replies_count: :desc).first&.id
+    most_reblogged_status_id = base_scope.order(reblogs_count: :desc).first&.id
+    most_favourited_status_id = base_scope.where.not(id: most_reblogged_status_id).order(favourites_count: :desc).first&.id
+    most_replied_status_id = base_scope.where.not(id: [most_reblogged_status_id, most_favourited_status_id]).order(replies_count: :desc).first&.id
 
     {
       top_statuses: {
-        by_reblogs: top_reblogs&.to_s,
-        by_favourites: top_favourites&.to_s,
-        by_replies: top_replies&.to_s,
+        by_reblogs: most_reblogged_status_id&.to_s,
+        by_favourites: most_favourited_status_id&.to_s,
+        by_replies: most_replied_status_id&.to_s,
       },
     }
   end

--- a/app/lib/annual_report/top_statuses.rb
+++ b/app/lib/annual_report/top_statuses.rb
@@ -2,9 +2,9 @@
 
 class AnnualReport::TopStatuses < AnnualReport::Source
   def generate
-    most_reblogged_status_id = base_scope.order(reblogs_count: :desc).first&.id
-    most_favourited_status_id = base_scope.where.not(id: most_reblogged_status_id).order(favourites_count: :desc).first&.id
-    most_replied_status_id = base_scope.where.not(id: [most_reblogged_status_id, most_favourited_status_id]).order(replies_count: :desc).first&.id
+    most_reblogged_status_id = most_reblogged_status&.id
+    most_favourited_status_id = most_favourited_status&.id
+    most_replied_status_id = most_replied_status&.id
 
     {
       top_statuses: {
@@ -16,6 +16,18 @@ class AnnualReport::TopStatuses < AnnualReport::Source
   end
 
   private
+
+  def most_reblogged_status
+    base_scope.order(reblogs_count: :desc).first
+  end
+
+  def most_favourited_status
+    base_scope.excluding(most_reblogged_status).order(favourites_count: :desc).first
+  end
+
+  def most_replied_status
+    base_scope.excluding(most_reblogged_status, most_favourited_status).order(replies_count: :desc).first
+  end
 
   def base_scope
     report_statuses.public_visibility.joins(:status_stat)

--- a/app/lib/annual_report/top_statuses.rb
+++ b/app/lib/annual_report/top_statuses.rb
@@ -4,9 +4,9 @@ class AnnualReport::TopStatuses < AnnualReport::Source
   def generate
     {
       top_statuses: {
-        by_reblogs: most_reblogged_status_id&.to_s,
-        by_favourites: most_favourited_status_id&.to_s,
-        by_replies: most_replied_status_id&.to_s,
+        by_reblogs: most_reblogged_status_id,
+        by_favourites: most_favourited_status_id,
+        by_replies: most_replied_status_id,
       },
     }
   end
@@ -14,15 +14,15 @@ class AnnualReport::TopStatuses < AnnualReport::Source
   private
 
   def most_reblogged_status_id
-    most_reblogged_status&.id
+    most_reblogged_status&.id&.to_s
   end
 
   def most_favourited_status_id
-    most_favourited_status&.id
+    most_favourited_status&.id&.to_s
   end
 
   def most_replied_status_id
-    most_replied_status&.id
+    most_replied_status&.id&.to_s
   end
 
   def most_reblogged_status

--- a/app/lib/annual_report/top_statuses.rb
+++ b/app/lib/annual_report/top_statuses.rb
@@ -2,10 +2,6 @@
 
 class AnnualReport::TopStatuses < AnnualReport::Source
   def generate
-    most_reblogged_status_id = most_reblogged_status&.id
-    most_favourited_status_id = most_favourited_status&.id
-    most_replied_status_id = most_replied_status&.id
-
     {
       top_statuses: {
         by_reblogs: most_reblogged_status_id&.to_s,
@@ -16,6 +12,18 @@ class AnnualReport::TopStatuses < AnnualReport::Source
   end
 
   private
+
+  def most_reblogged_status_id
+    most_reblogged_status&.id
+  end
+
+  def most_favourited_status_id
+    most_favourited_status&.id
+  end
+
+  def most_replied_status_id
+    most_replied_status&.id
+  end
 
   def most_reblogged_status
     base_scope.order(reblogs_count: :desc).first

--- a/app/lib/annual_report/top_statuses.rb
+++ b/app/lib/annual_report/top_statuses.rb
@@ -4,16 +4,16 @@ class AnnualReport::TopStatuses < AnnualReport::Source
   def generate
     {
       top_statuses: {
-        by_reblogs: formatted_status(most_reblogged_status),
-        by_favourites: formatted_status(most_favourited_status),
-        by_replies: formatted_status(most_replied_status),
+        by_reblogs: status_identifier(most_reblogged_status),
+        by_favourites: status_identifier(most_favourited_status),
+        by_replies: status_identifier(most_replied_status),
       },
     }
   end
 
   private
 
-  def formatted_status(status)
+  def status_identifier(status)
     status.id.to_s if status.present?
   end
 

--- a/app/lib/annual_report/top_statuses.rb
+++ b/app/lib/annual_report/top_statuses.rb
@@ -4,40 +4,42 @@ class AnnualReport::TopStatuses < AnnualReport::Source
   def generate
     {
       top_statuses: {
-        by_reblogs: most_reblogged_status_id,
-        by_favourites: most_favourited_status_id,
-        by_replies: most_replied_status_id,
+        by_reblogs: formatted_status(most_reblogged_status),
+        by_favourites: formatted_status(most_favourited_status),
+        by_replies: formatted_status(most_replied_status),
       },
     }
   end
 
   private
 
-  def most_reblogged_status_id
-    most_reblogged_status&.id&.to_s
-  end
-
-  def most_favourited_status_id
-    most_favourited_status&.id&.to_s
-  end
-
-  def most_replied_status_id
-    most_replied_status&.id&.to_s
+  def formatted_status(status)
+    status.id.to_s if status.present?
   end
 
   def most_reblogged_status
-    base_scope.order(reblogs_count: :desc).first
+    base_scope
+      .order(reblogs_count: :desc)
+      .first
   end
 
   def most_favourited_status
-    base_scope.excluding(most_reblogged_status).order(favourites_count: :desc).first
+    base_scope
+      .excluding(most_reblogged_status)
+      .order(favourites_count: :desc)
+      .first
   end
 
   def most_replied_status
-    base_scope.excluding(most_reblogged_status, most_favourited_status).order(replies_count: :desc).first
+    base_scope
+      .excluding(most_reblogged_status, most_favourited_status)
+      .order(replies_count: :desc)
+      .first
   end
 
   def base_scope
-    report_statuses.public_visibility.joins(:status_stat)
+    report_statuses
+      .public_visibility
+      .joins(:status_stat)
   end
 end


### PR DESCRIPTION
Some related changes:

- Mark the existing `base_scope` method (and the added methods) private, which matches the other classes that inherit from `Source`
- Refactor as noted in https://github.com/mastodon/mastodon/pull/35254 to allow for use of `excluding` in the methods by getting the actual status, and not just the ID from the private methods
- Add formatting method wrapper to capture the "nil or string id" logic w/ fewer safe-navigation chains