### PR TITLE
Raise better exception on FASP error responses

### DIFF
--- a/app/lib/fasp/request.rb
+++ b/app/lib/fasp/request.rb
@@ -49,6 +49,8 @@ class Fasp::Request
   end
 
   def validate!(response)
+    raise Mastodon::UnexpectedResponseError, response if response.code >= 400
+
     content_digest_header = response.headers['content-digest']
     raise Mastodon::SignatureVerificationError, 'content-digest missing' if content_digest_header.blank?
     raise Mastodon::SignatureVerificationError, 'content-digest does not match' if content_digest_header != content_digest(response.body)

--- a/spec/lib/fasp/request_spec.rb
+++ b/spec/lib/fasp/request_spec.rb
@@ -32,13 +32,27 @@ RSpec.describe Fasp::Request do
     context 'when the response is not signed' do
       before do
         stub_request(method, 'https://reqprov.example.com/fasp/test_path')
-          .to_return(status: 200)
+          .to_return(status:)
       end
 
-      it 'raises an error' do
-        expect do
-          subject.send(method, '/test_path')
-        end.to raise_error(Mastodon::SignatureVerificationError)
+      context 'when the request was successful' do
+        let(:status) { 200 }
+
+        it 'raises a signature verification error' do
+          expect do
+            subject.send(method, '/test_path')
+          end.to raise_error(Mastodon::SignatureVerificationError)
+        end
+      end
+
+      context 'when an error response is received' do
+        let(:status) { 401 }
+
+        it 'raises an unexpected response error' do
+          expect do
+            subject.send(method, '/test_path')
+          end.to raise_error(Mastodon::UnexpectedResponseError)
+        end
       end
     end
   end


### PR DESCRIPTION
Would otherwise raise a signature verification error which is not wrong, but utterly unhelpful when trying to get to the bottom of the reason for the failure.

Marked this as `to backport` so we can include it in 4.4. Without I fear we would run the risk of getting some very unspecific bug reports.