### PR TITLE
Extract `INSTANCE_ACTOR_USERNAME` constant

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -78,6 +78,7 @@ class Account < ApplicationRecord
   STALE_THRESHOLD = 1.day
   DEFAULT_FIELDS_SIZE = 4
   INSTANCE_ACTOR_ID = -99
+  INSTANCE_ACTOR_USERNAME = 'mastodon.internal'
 
   USERNAME_RE   = /[a-z0-9_]+([.-]+[a-z0-9_]+)*/i
   MENTION_RE    = %r{(?<![=/[:word:]])@((#{USERNAME_RE})(?:@[[:word:]]+([.-]+[[:word:]]+)*)?)}

--- a/app/models/concerns/account/finder_concern.rb
+++ b/app/models/concerns/account/finder_concern.rb
@@ -13,11 +13,12 @@ module Account::FinderConcern
     end
 
     def representative
-      actor = Account.find(Account::INSTANCE_ACTOR_ID).tap(&:ensure_keys!)
-      actor.update!(username: 'mastodon.internal') if actor.username.include?(':')
-      actor
+      Account.find(Account::INSTANCE_ACTOR_ID).tap do |actor|
+        actor.ensure_keys!
+        actor.update!(username: Account::INSTANCE_ACTOR_USERNAME) if actor.username.include?(':')
+      end
     rescue ActiveRecord::RecordNotFound
-      Account.create!(id: Account::INSTANCE_ACTOR_ID, actor_type: 'Application', locked: true, username: 'mastodon.internal')
+      Account.create!(id: Account::INSTANCE_ACTOR_ID, actor_type: 'Application', locked: true, username: Account::INSTANCE_ACTOR_USERNAME)
     end
 
     def find_local(username)

--- a/db/seeds/02_instance_actor.rb
+++ b/db/seeds/02_instance_actor.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-Account.create_with(actor_type: 'Application', locked: true, username: 'mastodon.internal').find_or_create_by(id: Account::INSTANCE_ACTOR_ID)
+Account.create_with(actor_type: 'Application', locked: true, username: Account::INSTANCE_ACTOR_USERNAME).find_or_create_by(id: Account::INSTANCE_ACTOR_ID)

--- a/spec/models/concerns/account/finder_concern_spec.rb
+++ b/spec/models/concerns/account/finder_concern_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Account::FinderConcern do
 
       it 'updates the username to the new value' do
         expect { Account.representative }
-          .to change { Account.find(Account::INSTANCE_ACTOR_ID).username }.from(legacy_value).to('mastodon.internal')
+          .to change { Account.find(Account::INSTANCE_ACTOR_ID).username }.from(legacy_value).to(Account::INSTANCE_ACTOR_USERNAME)
       end
     end
 

--- a/spec/requests/instance_actor_spec.rb
+++ b/spec/requests/instance_actor_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Instance actor endpoint' do
           .to include(
             id: instance_actor_url,
             type: 'Application',
-            preferredUsername: 'mastodon.internal',
+            preferredUsername: Account::INSTANCE_ACTOR_USERNAME,
             inbox: instance_actor_inbox_url,
             outbox: instance_actor_outbox_url,
             publicKey: include(


### PR DESCRIPTION
More of https://github.com/mastodon/mastodon/pull/29260

Pull out constant and use in places referencing the instance actor username string value

Possible follow-up here ... the `representative` class method is slightly out of place in this "finder concern" next to the other find remote and find local methods. There are also a collection of "instance actor related stuff" (constants, scopes, query methods, etc) on Account ... extracting that all to something like `Account::InstanceActor` concern (and moving `representative` there) would be truly enjoyable, and -- weather permitting! -- I will take on that very task.
