### PR TITLE
Better error response to malformed headers

### DIFF
--- a/app/controllers/concerns/signature_verification.rb
+++ b/app/controllers/concerns/signature_verification.rb
@@ -10,6 +10,11 @@ module SignatureVerification
   EXPIRATION_WINDOW_LIMIT = 12.hours
   CLOCK_SKEW_MARGIN       = 1.hour
 
+  included do
+    # Starry parses headers, so a parse error means malformed headers
+    rescue_from Starry::ParseError, with: :bad_request
+  end
+
   def require_account_signature!
     render json: signature_verification_failure_reason, status: signature_verification_failure_code unless signed_request_account
   end

--- a/app/lib/signed_request.rb
+++ b/app/lib/signed_request.rb
@@ -196,6 +196,8 @@ class SignedRequest
       return if body_digest == received_digest
 
       raise Mastodon::SignatureVerificationError, "Invalid Digest value. Computed SHA-256 digest: #{body_digest}; given: #{received_digest}"
+    rescue Starry::ParseError
+      raise Mastodon::MalformedHeaderError, 'Content-Digest could not be parsed. It does not contain a valid RFC8941 dictionary.'
     end
 
     def created_time

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -13,6 +13,7 @@ module Mastodon
   class SyntaxError < Error; end
   class InvalidParameterError < Error; end
   class SignatureVerificationError < Error; end
+  class MalformedHeaderError < Error; end
 
   class UnexpectedResponseError < Error
     attr_reader :response

--- a/spec/requests/signature_verification_spec.rb
+++ b/spec/requests/signature_verification_spec.rb
@@ -628,11 +628,11 @@ RSpec.describe 'signature verification concern' do
           'sig1=("@method" "@target-uri" "content-digest");created=1703066400;keyid="https://remote.domain/users/bob#main-key"'
         end
         let(:signature_header) do
-          'sig1=:c4jGY/PnOV4CwyvNnAmY6NLX0sf6EtbKu7kYseNARRZaq128PrP0GNQ4cd3XsX9cbMfJMw1ntI4zuEC81ncW8g+90OHP02bX0LkT57RweUtN4CSA01hRqSVe/MW32tjGixCiItvWqjNHoIZnZApu1bd+M3zMR+VCEue4/8a0D2eRrvfQxJUUBXZR1ZTRFlf1LNFDW3U7cuTbAKYr2zWVr7on+h2vA+vzEND9WE8z1SHd6SIFFgP0QRqrCXYx+vsTs3aLusTsamRWissoycJGexb64mI9iqiD8SD+uN1xk6iRU3nkUmhUquugjlOFyjxbbLo5ZnYjsECMt/BW+Catxw==:' # rubocop:disable Layout/LineLength
+          'sig1=:aXua24cIlBi8akNXg/Vc5pU8fNGXo0f4U2qQk42iWoIaCcH3G+z2edPMQTNM/aZmD0bULqvb/yi6ZXgRls1ereq3OqnvA4JBLKx15O/jLayS/FhR4d/2vaeXuBOYXM7EGXItKkFxEXn3J+FCQPb5wY31GlbljrESjsiZ6gtrSmwryBluQCwMJ59LACzocxbWo42Kv3cpSig2aCu9CYXKC4sCH3eSKjwPtjdlpmX1VkYX5ge+JaZMn7A218ZgZOc9xpPawESOuIF9axcKW5PDEhOwmswFd2G65c8H9kJY6zEnqbArP9lRQMmjuAb011NILClaaRZOOupz2HZUdm+91Q==:' # rubocop:disable Layout/LineLength
         end
 
         it 'returns `400` (Bad Request)', :aggregate_failures do
-          post '/activitypub/success', params: 'Hello world', headers: {
+          post '/activitypub/signature_required', params: 'Hello world', headers: {
             'Host' => 'www.example.com',
             'Content-Digest' => digest_header,
             'Signature-Input' => signature_input,
@@ -640,6 +640,9 @@ RSpec.describe 'signature verification concern' do
           }
 
           expect(response).to have_http_status(400)
+          expect(response.parsed_body).to match(
+            error: 'Content-Digest could not be parsed. It does not contain a valid RFC8941 dictionary.'
+          )
         end
       end
     end

--- a/spec/requests/signature_verification_spec.rb
+++ b/spec/requests/signature_verification_spec.rb
@@ -621,6 +621,27 @@ RSpec.describe 'signature verification concern' do
           )
         end
       end
+
+      context 'with a malformed `Content-Digest` header' do
+        let(:digest_header) { 'SHA-256=:ZOyIygCyaOW6GjVnihtTFtIS9PNmskdyMlNKiuyjfzw=:' }
+        let(:signature_input) do
+          'sig1=("@method" "@target-uri" "content-digest");created=1703066400;keyid="https://remote.domain/users/bob#main-key"'
+        end
+        let(:signature_header) do
+          'sig1=:c4jGY/PnOV4CwyvNnAmY6NLX0sf6EtbKu7kYseNARRZaq128PrP0GNQ4cd3XsX9cbMfJMw1ntI4zuEC81ncW8g+90OHP02bX0LkT57RweUtN4CSA01hRqSVe/MW32tjGixCiItvWqjNHoIZnZApu1bd+M3zMR+VCEue4/8a0D2eRrvfQxJUUBXZR1ZTRFlf1LNFDW3U7cuTbAKYr2zWVr7on+h2vA+vzEND9WE8z1SHd6SIFFgP0QRqrCXYx+vsTs3aLusTsamRWissoycJGexb64mI9iqiD8SD+uN1xk6iRU3nkUmhUquugjlOFyjxbbLo5ZnYjsECMt/BW+Catxw==:' # rubocop:disable Layout/LineLength
+        end
+
+        it 'returns `400` (Bad Request)', :aggregate_failures do
+          post '/activitypub/success', params: 'Hello world', headers: {
+            'Host' => 'www.example.com',
+            'Content-Digest' => digest_header,
+            'Signature-Input' => signature_input,
+            'Signature' => signature_header,
+          }
+
+          expect(response).to have_http_status(400)
+        end
+      end
     end
 
     context 'with an inaccessible key' do


### PR DESCRIPTION
`starry` is used by both linzer internally and our code to parse RFC8941 conformant headers.

When a parse error occurs this means that those headers were not well-formed/standards compliant or were otherwise incorrect. This should always result in an HTTP `400` (Bad Request) response.