### PR TITLE
Add ability to manually trigger i18n uploads

### DIFF
--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -14,6 +14,7 @@ on:
       - config/locales/devise.en.yml
       - config/locales/doorkeeper.en.yml
       - .github/workflows/crowdin-upload.yml
+  workflow_dispatch:
 
 jobs:
   upload-translations:


### PR DESCRIPTION
Currently, the job is only called when source string changes are pushed to a stable branch, which typically did not occur for 4.4 yet and may not occur anytime soon, preventing us from using the stable branch setup we have with Crowdin.

This PR allows us to manually trigger i18n uploads in such situations.