### PR TITLE
Add option to set emoji preferences behind feature flag

### DIFF
--- a/app/models/user_settings.rb
+++ b/app/models/user_settings.rb
@@ -35,6 +35,7 @@ class UserSettings
     setting :expand_content_warnings, default: false
     setting :display_media, default: 'default', in: %w(default show_all hide_all)
     setting :auto_play, default: false
+    setting :emoji_style, default: 'auto', in: %w(auto native twemoji)
   end
 
   namespace :notification_emails do

--- a/app/views/settings/preferences/appearance/show.html.haml
+++ b/app/views/settings/preferences/appearance/show.html.haml
@@ -31,6 +31,17 @@
                  label: I18n.t('simple_form.labels.defaults.setting_theme'),
                  wrapper: :with_label
 
+  - if Mastodon::Feature.modern_emojis_enabled?
+    .fields-group
+      = f.simple_fields_for :settings, current_user.settings do |ff|
+        = ff.input :'web.emoji_style',
+                   collection: %w(auto twemoji native),
+                   include_blank: false,
+                   hint: I18n.t('simple_form.hints.defaults.setting_emoji_style'),
+                   label: I18n.t('simple_form.labels.defaults.setting_emoji_style'),
+                   label_method: ->(emoji_style) { I18n.t("emoji_styles.#{emoji_style}", default: emoji_style) },
+                   wrapper: :with_label
+
   - unless I18n.locale == :en
     .flash-message.translation-prompt
       #{t 'appearance.localization.body'} #{content_tag(:a, t('appearance.localization.guide_link_text'), href: t('appearance.localization.guide_link'), target: '_blank', rel: 'noopener')}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1349,6 +1349,10 @@ en:
     basic_information: Basic information
     hint_html: "<strong>Customize what people see on your public profile and next to your posts.</strong> Other people are more likely to follow you back and interact with you when you have a filled out profile and a profile picture."
     other: Other
+  emoji_styles:
+    auto: Auto
+    native: Native
+    twemoji: Twemoji
   errors:
     '400': The request you submitted was invalid or malformed.
     '403': You don't have permission to view this page.

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -61,6 +61,7 @@ en:
         setting_display_media_default: Hide media marked as sensitive
         setting_display_media_hide_all: Always hide media
         setting_display_media_show_all: Always show media
+        setting_emoji_style: How to display emojis. "Auto" will try using native emoji, but falls back to Twemoji for legacy browsers.
         setting_system_scrollbars_ui: Applies only to desktop browsers based on Safari and Chrome
         setting_use_blurhash: Gradients are based on the colors of the hidden visuals but obfuscate any details
         setting_use_pending_items: Hide timeline updates behind a click instead of automatically scrolling the feed
@@ -241,6 +242,7 @@ en:
         setting_display_media_default: Default
         setting_display_media_hide_all: Hide all
         setting_display_media_show_all: Show all
+        setting_emoji_style: Emoji style
         setting_expand_spoilers: Always expand posts marked with content warnings
         setting_hide_network: Hide your social graph
         setting_missing_alt_text_modal: Show confirmation dialog before posting media without alt text


### PR DESCRIPTION
This adds a setting to control how emoji are displayed. It is hidden behind the feature flag `modern_emoji`

- Auto: Attempt to show native emoji, but try to detect environments with limited emoji support to fall back to Twemoji.
- Native: Show the native emoji for the browser.
- Twemoji: The current standard for web, renders with Twemoji SVGs.

Questions:
- Is this verbiage clear?
- Should we default to Auto or Twemoji? We use native on our apps, so right now Twemoji is the exception.