### PR TITLE
Extract common lists for status/reblog preload/cacheable

### DIFF
--- a/app/controllers/admin/statuses_controller.rb
+++ b/app/controllers/admin/statuses_controller.rb
@@ -62,7 +62,11 @@ module Admin
     end
 
     def set_statuses
-      @statuses = Admin::StatusFilter.new(@account, filter_params).results.preload(:application, :preloadable_poll, :media_attachments, active_mentions: :account, reblog: [:account, :application, :preloadable_poll, :media_attachments, active_mentions: :account]).page(params[:page]).per(PER_PAGE)
+      @statuses = Admin::StatusFilter.new(@account, filter_params).results.preload(*preload_columns, reblog: [:account, *preload_columns]).page(params[:page]).per(PER_PAGE)
+    end
+
+    def preload_columns
+      [:application, :preloadable_poll, :media_attachments, active_mentions: :account]
     end
 
     def filter_params

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -45,6 +45,20 @@ class Status < ApplicationRecord
   include Status::Visibility
   include Status::InteractionPolicyConcern
 
+  CACHEABLE_ASSOCIATIONS = [
+    :application,
+    :conversation,
+    :media_attachments,
+    :preloadable_poll,
+    :status_stat,
+    :tags,
+    account: [:account_stat, user: :role],
+    active_mentions: :account,
+    tagged_objects: :object,
+    preview_cards_status: { preview_card: { author_account: [:account_stat, user: :role] } },
+    quote: { status: { account: [:account_stat, user: :role] } },
+  ].freeze
+
   MEDIA_ATTACHMENTS_LIMIT = 4
 
   rate_limit by: :account, family: :statuses
@@ -163,31 +177,11 @@ class Status < ApplicationRecord
   # the `dependent: destroy` callbacks remove relevant records
   before_destroy :unlink_from_conversations!, prepend: true
 
-  cache_associated :application,
-                   :media_attachments,
-                   :conversation,
-                   :status_stat,
-                   :tags,
-                   :preloadable_poll,
-                   quote: { status: { account: [:account_stat, user: :role] } },
-                   preview_cards_status: { preview_card: { author_account: [:account_stat, user: :role] } },
-                   account: [:account_stat, user: :role],
-                   active_mentions: :account,
-                   tagged_objects: :object,
-                   reblog: [
-                     :application,
-                     :media_attachments,
-                     :conversation,
-                     :status_stat,
-                     :tags,
-                     :preloadable_poll,
-                     quote: { status: { account: [:account_stat, user: :role] } },
-                     preview_cards_status: { preview_card: { author_account: [:account_stat, user: :role] } },
-                     account: [:account_stat, user: :role],
-                     active_mentions: :account,
-                     tagged_objects: :object,
-                   ],
-                   thread: :account
+  cache_associated(
+    *CACHEABLE_ASSOCIATIONS,
+    reblog: [*CACHEABLE_ASSOCIATIONS],
+    thread: :account
+  )
 
   delegate :domain, :indexable?, to: :account, prefix: true
 


### PR DESCRIPTION
In both of these spots, we are passing in the same lists to both a top level status scope, and also the reblog component within that scope. I suspect these attribute lists will remain the same in both spots -- so the change is just to extract that currently repeated list into a separate method in one spot and constant in another spot.

Separately - for the `cache_associated` usage here ... I think this concern maybe used to be used in multiple models, but is currently only used by `Status`. If that's correct, and that will remain true for foreseeable future, we could do some variation on:

- Rename the concern
- Scope the concern under status
- Move the constant and `cache_associated` call right into an `included` block on the concern (further LOC reduction to status itself).

This is probably reviewable/mergeable as-is -- but could add all/any of those as well.