### PR TITLE
Move stray association declaration back to relevant section

### DIFF
--- a/app/lib/application_extension.rb
+++ b/app/lib/application_extension.rb
@@ -10,7 +10,7 @@ module ApplicationExtension
   included do
     include Redisable
 
-    has_many :created_users, class_name: 'User', foreign_key: 'created_by_application_id', inverse_of: :created_by_application
+    has_many :created_users, class_name: 'User', foreign_key: :created_by_application_id, inverse_of: :created_by_application
 
     validates :name, length: { maximum: APP_NAME_LIMIT }
     validates :redirect_uri, length: { maximum: APP_REDIRECT_URI_LIMIT }

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -19,7 +19,7 @@ class Appeal < ApplicationRecord
   TEXT_LENGTH_LIMIT = 2_000
 
   belongs_to :account
-  belongs_to :strike, class_name: 'AccountWarning', foreign_key: 'account_warning_id', inverse_of: :appeal
+  belongs_to :strike, class_name: 'AccountWarning', foreign_key: :account_warning_id, inverse_of: :appeal
 
   with_options class_name: 'Account', optional: true do
     belongs_to :approved_by_account

--- a/app/models/concerns/account/interactions.rb
+++ b/app/models/concerns/account/interactions.rb
@@ -8,16 +8,16 @@ module Account::Interactions
     has_many :follow_requests, dependent: :destroy
 
     with_options class_name: 'Follow', dependent: :destroy do
-      has_many :active_relationships,  foreign_key: 'account_id', inverse_of: :account
-      has_many :passive_relationships, foreign_key: 'target_account_id', inverse_of: :target_account
+      has_many :active_relationships,  foreign_key: :account_id, inverse_of: :account
+      has_many :passive_relationships, foreign_key: :target_account_id, inverse_of: :target_account
     end
 
     has_many :following, -> { order(follows: { id: :desc }) }, through: :active_relationships,  source: :target_account
     has_many :followers, -> { order(follows: { id: :desc }) }, through: :passive_relationships, source: :account
 
     with_options class_name: 'SeveredRelationship', dependent: :destroy do
-      has_many :severed_relationships, foreign_key: 'local_account_id', inverse_of: :local_account
-      has_many :remote_severed_relationships, foreign_key: 'remote_account_id', inverse_of: :remote_account
+      has_many :severed_relationships, foreign_key: :local_account_id, inverse_of: :local_account
+      has_many :remote_severed_relationships, foreign_key: :remote_account_id, inverse_of: :remote_account
     end
 
     # Hashtag follows
@@ -28,7 +28,7 @@ module Account::Interactions
 
     # Block relationships
     with_options class_name: 'Block', dependent: :destroy do
-      has_many :block_relationships, foreign_key: 'account_id', inverse_of: :account
+      has_many :block_relationships, foreign_key: :account_id, inverse_of: :account
       has_many :blocked_by_relationships, foreign_key: :target_account_id, inverse_of: :target_account
     end
     has_many :blocking, -> { order(blocks: { id: :desc }) }, through: :block_relationships, source: :target_account
@@ -36,7 +36,7 @@ module Account::Interactions
 
     # Mute relationships
     with_options class_name: 'Mute', dependent: :destroy do
-      has_many :mute_relationships, foreign_key: 'account_id', inverse_of: :account
+      has_many :mute_relationships, foreign_key: :account_id, inverse_of: :account
       has_many :muted_by_relationships, foreign_key: :target_account_id, inverse_of: :target_account
     end
     has_many :muting, -> { order(mutes: { id: :desc }) }, through: :mute_relationships, source: :target_account

--- a/app/models/custom_emoji_category.rb
+++ b/app/models/custom_emoji_category.rb
@@ -11,7 +11,7 @@
 #
 
 class CustomEmojiCategory < ApplicationRecord
-  has_many :emojis, class_name: 'CustomEmoji', foreign_key: 'category_id', inverse_of: :category, dependent: nil
+  has_many :emojis, class_name: 'CustomEmoji', foreign_key: :category_id, inverse_of: :category, dependent: nil
 
   validates :name, presence: true, uniqueness: true
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -100,7 +100,7 @@ class Notification < ApplicationRecord
   belongs_to :from_account, class_name: 'Account', optional: true
   belongs_to :activity, polymorphic: true, optional: true
 
-  with_options foreign_key: 'activity_id', optional: true do
+  with_options foreign_key: :activity_id, optional: true do
     belongs_to :mention, inverse_of: :notification
     belongs_to :status, inverse_of: :notification
     belongs_to :follow, inverse_of: :notification

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -63,24 +63,24 @@ class Status < ApplicationRecord
   belongs_to :account, inverse_of: :statuses
   belongs_to :in_reply_to_account, class_name: 'Account', optional: true
   belongs_to :conversation, optional: true
-  belongs_to :preloadable_poll, class_name: 'Poll', foreign_key: 'poll_id', optional: true, inverse_of: false
+  belongs_to :preloadable_poll, class_name: 'Poll', foreign_key: :poll_id, optional: true, inverse_of: false
 
   with_options class_name: 'Status', optional: true do
-    belongs_to :thread, foreign_key: 'in_reply_to_id', inverse_of: :replies
-    belongs_to :reblog, foreign_key: 'reblog_of_id', inverse_of: :reblogs
+    belongs_to :thread, foreign_key: :in_reply_to_id, inverse_of: :replies
+    belongs_to :reblog, foreign_key: :reblog_of_id, inverse_of: :reblogs
   end
 
   has_one :owned_conversation, class_name: 'Conversation', foreign_key: 'parent_status_id', inverse_of: :parent_status, dependent: nil
 
   has_many :favourites, inverse_of: :status, dependent: :destroy
   has_many :bookmarks, inverse_of: :status, dependent: :destroy
-  has_many :reblogs, foreign_key: 'reblog_of_id', class_name: 'Status', inverse_of: :reblog, dependent: :destroy
+  has_many :reblogs, foreign_key: :reblog_of_id, class_name: 'Status', inverse_of: :reblog, dependent: :destroy
   has_many :reblogged_by_accounts, through: :reblogs, class_name: 'Account', source: :account
-  has_many :replies, foreign_key: 'in_reply_to_id', class_name: 'Status', inverse_of: :thread, dependent: nil
+  has_many :replies, foreign_key: :in_reply_to_id, class_name: 'Status', inverse_of: :thread, dependent: nil
   has_many :mentions, dependent: :destroy, inverse_of: :status
   has_many :mentioned_accounts, through: :mentions, source: :account, class_name: 'Account'
   has_many :media_attachments, dependent: :nullify
-  has_many :quotes, foreign_key: 'quoted_status_id', inverse_of: :quoted_status, dependent: :nullify
+  has_many :quotes, foreign_key: :quoted_status_id, inverse_of: :quoted_status, dependent: :nullify
 
   # The `dependent` option is enabled by the initial `mentions` association declaration
   has_many :active_mentions, -> { active }, class_name: 'Mention', inverse_of: :status # rubocop:disable Rails/HasManyOrHasOneDependent

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -85,6 +85,7 @@ class User < ApplicationRecord
   has_many :invites, inverse_of: :user, dependent: nil
   has_many :login_activities, inverse_of: :user, dependent: :destroy
   has_many :markers, inverse_of: :user, dependent: :destroy
+  has_many :session_activations, dependent: :destroy
   has_many :webauthn_credentials, dependent: :destroy
   has_many :ips, class_name: 'UserIp', inverse_of: :user, dependent: nil
 
@@ -126,8 +127,6 @@ class User < ApplicationRecord
   normalizes :locale, with: ->(locale) { I18n.available_locales.exclude?(locale.to_sym) ? nil : locale }
   normalizes :time_zone, with: ->(time_zone) { ActiveSupport::TimeZone[time_zone].nil? ? nil : time_zone }
   normalizes :chosen_languages, with: ->(chosen_languages) { chosen_languages.compact_blank.presence }
-
-  has_many :session_activations, dependent: :destroy
 
   delegate :can?, to: :role
 

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -103,7 +103,7 @@ class UserRole < ApplicationRecord
 
   scope :assignable, -> { where.not(id: EVERYONE_ROLE_ID).order(position: :asc) }
 
-  has_many :users, inverse_of: :role, foreign_key: 'role_id', dependent: :nullify
+  has_many :users, inverse_of: :role, foreign_key: :role_id, dependent: :nullify
 
   def self.nobody
     @nobody ||= UserRole.new(permissions: Flags::NONE, position: NOBODY_POSITION)

--- a/app/models/web/push_subscription.rb
+++ b/app/models/web/push_subscription.rb
@@ -20,7 +20,7 @@ class Web::PushSubscription < ApplicationRecord
   belongs_to :user
   belongs_to :access_token, class_name: 'Doorkeeper::AccessToken'
 
-  has_one :session_activation, foreign_key: 'web_push_subscription_id', inverse_of: :web_push_subscription, dependent: nil
+  has_one :session_activation, foreign_key: :web_push_subscription_id, inverse_of: :web_push_subscription, dependent: nil
 
   validates :endpoint, presence: true, url: true
   validates :key_p256dh, presence: true


### PR DESCRIPTION
Noticed this while looking at something else ... presumably just historical accident that this was separated?

This is moving a line of code to a higher up line in the same file to re-join its friends.