### PR TITLE
Handle special characters in SMTP password env var

### DIFF
--- a/config/email.yml
+++ b/config/email.yml
@@ -9,7 +9,7 @@ production:
     port: <%= ENV.fetch('SMTP_PORT', nil) %>
     address: <%= ENV.fetch('SMTP_SERVER', nil) %>
     user_name: <%= ENV.fetch('SMTP_LOGIN', nil) %>
-    password: <%= ENV.fetch('SMTP_PASSWORD', nil) %>
+    password: "<%= ENV.fetch('SMTP_PASSWORD', nil) %>"
     domain: <%= ENV.fetch('SMTP_DOMAIN', ENV.fetch('LOCAL_DOMAIN', nil)) %>
     authentication: <%= ENV.fetch('SMTP_AUTH_METHOD', 'plain') %>
     ca_file: <%= ENV.fetch('SMTP_CA_FILE', '/etc/ssl/certs/ca-certificates.crt') %>

--- a/spec/configuration/email_spec.rb
+++ b/spec/configuration/email_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Configuration for email', type: :feature do
+  context 'with special characters in SMTP_PASSWORD env variable' do
+    let(:password) { ']]123456789[[' }
+
+    around do |example|
+      ClimateControl.modify SMTP_PASSWORD: password do
+        example.run
+      end
+    end
+
+    it 'parses value correctly' do
+      expect(Rails.application.config_for(:email, env: :production))
+        .to include(
+          smtp_settings: include(password: password)
+        )
+    end
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/mastodon/mastodon/issues/35305

I'm sort of surprised no one found this sooner in a nightly ... oh well.

The issue here is that the erb inserts an unescaped unquoted version of whatever it evaluates to. The yaml tries to parse that, and can trip up on special characters as in linked issue.

Opening this with JUST the fix to that one spot ... but there are almost definitely more places to add a fix/workaround here, where you could plausibly have special chars in env var values.