### PR TITLE
Use `if_exists: true` when removing duplicate indexes

### DIFF
--- a/db/migrate/20241014010506_remove_duplicate_indexes.rb
+++ b/db/migrate/20241014010506_remove_duplicate_indexes.rb
@@ -2,9 +2,11 @@
 
 class RemoveDuplicateIndexes < ActiveRecord::Migration[7.1]
   def change
-    remove_index :account_aliases, :account_id
-    remove_index :account_relationship_severance_events, :account_id
-    remove_index :custom_filter_statuses, :status_id
-    remove_index :webauthn_credentials, :user_id
+    with_options if_exists: true do
+      remove_index :account_aliases, :account_id
+      remove_index :account_relationship_severance_events, :account_id
+      remove_index :custom_filter_statuses, :status_id
+      remove_index :webauthn_credentials, :user_id
+    end
   end
 end


### PR DESCRIPTION
Resolves https://github.com/mastodon/mastodon/issues/35304

I'd generally avoid changing previous migrations but I can't think of how else to make this less bad for anyone getting hung up on this one (as in linked issue). I'm not sure how you get into this state (maybe manually remove things? I think pghero has been warning about them), but this is probably safe to reduce those issues.

I was able to verify this locally by modifying some old migrations to NOT have created the indexes in the first place, and confirm that it errors out as in linked issue in that case, and that this change fixes that.