### PR TITLE
Relax error restriction in initializer

### DIFF
--- a/config/initializers/settings_digests.rb
+++ b/config/initializers/settings_digests.rb
@@ -3,7 +3,7 @@
 Rails.application.config.to_prepare do
   custom_css = begin
     Setting.custom_css
-  rescue ActiveRecord::AdapterError # Running without a database, not migrated, no connection, etc
+  rescue # Running without a cache, database, not migrated, no connection, etc
     nil
   end
 


### PR DESCRIPTION
Fixes #35303

In the above issue it was noted that you can no longer run `RAILS_ENV=production bin/rails assets:precompile` without access to redis.

The code already accounted for the fact, that the database might not be available, but it did not recognize that the same might be true for the cache backend.

I had initially hoped I could just add a redis error to the list, and indeed the `redis` gem has its own error type for connection errors. But we use the "hiredis" driver which is a C extension that in some instances just raises `RuntimeError`.

I could have added `Redis::CannotConnectError`, `Redis::ConnectionError` (what is the difference, I wonder?) and `RuntimeError`. But I figured that a) once you include `RuntimeError` you are already casting a very wide net and b) there might be other errors (from AR, redis or even other places) that could be applicable here. So I decided to use the catch-all and rescue from all kinds of `StandardError`.

On the one hand, this is considered bad practice because it can mask all kinds of errors one would rather catch as early as possible. On the other hand, this is "only" an initializer and the method in question is also excersized elsewhere, including in tests.