### PR TITLE
Use `ActiveModel::Attributes` in `FollowLimitable` concern

### DIFF
--- a/app/models/concerns/follow_limitable.rb
+++ b/app/models/concerns/follow_limitable.rb
@@ -4,14 +4,8 @@ module FollowLimitable
   extend ActiveSupport::Concern
 
   included do
-    validates_with FollowLimitValidator, on: :create, unless: :bypass_follow_limit?
-  end
+    validates_with FollowLimitValidator, on: :create, unless: :bypass_follow_limit
 
-  def bypass_follow_limit=(value)
-    @bypass_follow_limit = value
-  end
-
-  def bypass_follow_limit?
-    @bypass_follow_limit
+    attribute :bypass_follow_limit, :boolean, default: false
   end
 end


### PR DESCRIPTION
Similar to https://github.com/mastodon/mastodon/pull/35247 and https://github.com/mastodon/mastodon/pull/35255 - replaces custom setter/query with attributes api, defaulting to false to preserve current behavior.

This concern is included in `Follow` and `FollowRequest` to capture the running or not of the follow limit validator. The `bypass_follow_limit` value is only ever used from the `follow!` and `request_follow!` methods of the `Interactions` concern, which are in turn both passing along their own `bypass_limit` value. The `bypass_follow_limit?` query method was only used internally by this concern, so updated that to just hit the attribute directly.
