### PR TITLE
Add `Status.only_replies` scope for use in annual reports

### DIFF
--- a/app/lib/annual_report/archetype.rb
+++ b/app/lib/annual_report/archetype.rb
@@ -36,7 +36,7 @@ class AnnualReport::Archetype < AnnualReport::Source
   end
 
   def replies_count
-    @replies_count ||= report_statuses.where.not(in_reply_to_id: nil).not_replying_to_account(@account).count
+    @replies_count ||= report_statuses.only_replies.not_replying_to_account(@account).count
   end
 
   def standalone_count

--- a/app/lib/annual_report/type_distribution.rb
+++ b/app/lib/annual_report/type_distribution.rb
@@ -6,7 +6,7 @@ class AnnualReport::TypeDistribution < AnnualReport::Source
       type_distribution: {
         total: report_statuses.count,
         reblogs: report_statuses.only_reblogs.count,
-        replies: report_statuses.where.not(in_reply_to_id: nil).not_replying_to_account(@account).count,
+        replies: report_statuses.only_replies.not_replying_to_account(@account).count,
         standalone: report_statuses.without_replies.without_reblogs.count,
       },
     }

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -117,6 +117,7 @@ class Status < ApplicationRecord
   scope :with_accounts, ->(ids) { where(id: ids).includes(:account) }
   scope :without_replies, -> { not_reply.or(reply_to_account) }
   scope :not_reply, -> { where(reply: false) }
+  scope :only_replies, -> { where.not(in_reply_to_id: nil) }
   scope :only_reblogs, -> { where.not(reblog_of_id: nil) }
   scope :only_polls, -> { where.not(poll_id: nil) }
   scope :without_polls, -> { where(poll_id: nil) }

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -376,6 +376,17 @@ RSpec.describe Status do
     end
   end
 
+  describe '.only_replies' do
+    let!(:status) { Fabricate :status }
+    let!(:replying_status) { Fabricate :status, thread: Fabricate(:status) }
+
+    it 'returns the expected statuses' do
+      expect(described_class.only_replies)
+        .to include(replying_status)
+        .and not_include(status)
+    end
+  end
+
   describe '.only_polls' do
     let!(:poll_status) { Fabricate :status, poll: Fabricate(:poll) }
     let!(:no_poll_status) { Fabricate :status }


### PR DESCRIPTION
Follow up on https://github.com/mastodon/mastodon/pull/35330 and https://github.com/mastodon/mastodon/pull/35141

This one is (I think?!) the last scope to extract from the various annual report classes. There are a few more stylistic things in there (the trailing-comma do/end blocks in the middle of some hashes bother me), but its getting close.

Side note here -- while these two updated reports (archetype and type distribution) use both this just-added "only replies" scope and also the previously added "not replying to account" scope (to exclude replies from the account for whom the report is being generated), the "commonly interacted with" report includes the "not replying to account" part, but not this "only replies" part. I think practically speaking this doesnt matter for the results of the report -- it requires a minimum threshold of interactions and so will only include accounts that do have some interaction -- but the query may be made slightly more efficient by also adding that "only replies" scope/condition as well.