### PR TITLE
Add support for `preview` (FEP-b2b8) on unsupported ActivityPub objects

### DIFF
--- a/app/lib/activitypub/activity.rb
+++ b/app/lib/activitypub/activity.rb
@@ -78,7 +78,7 @@ class ActivityPub::Activity
   end
 
   def unsupported_object_type?
-    @object.is_a?(String) || !(supported_object_type? || converted_object_type?)
+    @object.is_a?(String) || !(supported_object_type? || converted_object_type? || supported_preview?)
   end
 
   def supported_object_type?
@@ -87,6 +87,10 @@ class ActivityPub::Activity
 
   def converted_object_type?
     equals_or_includes_any?(@object['type'], CONVERTED_TYPES)
+  end
+
+  def supported_preview?
+    @object['preview'].is_a?(Hash) && equals_or_includes_any?(@object['preview']['type'], SUPPORTED_TYPES)
   end
 
   def delete_arrived_first?(uri)

--- a/app/lib/activitypub/preview_builder.rb
+++ b/app/lib/activitypub/preview_builder.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class ActivityPub::PreviewBuilder
+  include FormattingHelper
+
+  def initialize(parser)
+    @parser = parser
+  end
+
+  def text
+    [title, summary, url].compact.join("\n\n")
+  end
+
+  private
+
+  def title
+    "<h2>#{@parser.title}</h2>" if @parser.title.present?
+  end
+
+  def summary
+    @parser.spoiler_text
+  end
+
+  def url
+    linkify(@parser.url || @parser.uri)
+  end
+end


### PR DESCRIPTION
The `preview` property from FEP-b2b8 allows the publishing platform to determine how the object will be displayed on platforms that don't natively support the original object type.