### PR TITLE
Expose enabled features to the frontend

### DIFF
--- a/app/javascript/mastodon/initial_state.js
+++ b/app/javascript/mastodon/initial_state.js
@@ -1,6 +1,5 @@
 // @ts-check
 
-
 /**
  * @typedef {[code: string, name: string, localName: string]} InitialStateLanguage
  */
@@ -64,6 +63,7 @@
  * @property {boolean=} critical_updates_pending
  * @property {InitialStateMeta} meta
  * @property {Role?} role
+ * @property {string[]} features
  */
 
 const element = document.getElementById('initial-state');
@@ -138,6 +138,14 @@ export const languages = initialState?.languages?.map(lang => {
  */
 export function getAccessToken() {
   return getMeta('access_token');
+}
+
+/**
+ * @param {string} feature
+ * @returns {boolean}
+ */
+export function isFeatureEnabled(feature) {
+  return initialState?.features?.includes(feature) || false;
 }
 
 export default initialState;

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -5,7 +5,7 @@ class InitialStateSerializer < ActiveModel::Serializer
 
   attributes :meta, :compose, :accounts,
              :media_attachments, :settings,
-             :languages
+             :languages, :features
 
   attribute :critical_updates_pending, if: -> { object&.role&.can?(:view_devops) && SoftwareUpdate.check_enabled? }
 
@@ -83,6 +83,10 @@ class InitialStateSerializer < ActiveModel::Serializer
 
   def languages
     LanguagesHelper::SUPPORTED_LOCALES.map { |(key, value)| [key, value[0], value[1]] }
+  end
+
+  def features
+    Mastodon::Feature.enabled_features
   end
 
   private


### PR DESCRIPTION
This exposes enabled experimental features via `initial_state` to the front end, allowing feature flags be used in JS too.

This can be tested by passing `EXPERIMENTAL_FEATURES=test` env var to the server, which should be exposed in the initial state.