### PR TITLE
Move shared params to common method in admin/reports/actions

### DIFF
--- a/app/controllers/admin/reports/actions_controller.rb
+++ b/app/controllers/admin/reports/actions_controller.rb
@@ -13,27 +13,9 @@ class Admin::Reports::ActionsController < Admin::BaseController
 
     case action_from_button
     when 'delete', 'mark_as_sensitive'
-      status_batch_action = Admin::StatusBatchAction.new(
-        type: action_from_button,
-        status_ids: @report.status_ids,
-        current_account: current_account,
-        report_id: @report.id,
-        send_email_notification: !@report.spam?,
-        text: params[:text]
-      )
-
-      status_batch_action.save!
+      Admin::StatusBatchAction.new(status_batch_action_params).save!
     when 'silence', 'suspend'
-      account_action = Admin::AccountAction.new(
-        type: action_from_button,
-        report_id: @report.id,
-        target_account: @report.target_account,
-        current_account: current_account,
-        send_email_notification: !@report.spam?,
-        text: params[:text]
-      )
-
-      account_action.save!
+      Admin::AccountAction.new(account_action_params).save!
     else
       return redirect_to admin_report_path(@report), alert: I18n.t('admin.reports.unknown_action_msg', action: action_from_button)
     end
@@ -42,6 +24,26 @@ class Admin::Reports::ActionsController < Admin::BaseController
   end
 
   private
+
+  def status_batch_action_params
+    shared_params
+      .merge(status_ids: @report.status_ids)
+  end
+
+  def account_action_params
+    shared_params
+      .merge(target_account: @report.target_account)
+  end
+
+  def shared_params
+    {
+      current_account: current_account,
+      report_id: @report.id,
+      send_email_notification: !@report.spam?,
+      text: params[:text],
+      type: action_from_button,
+    }
+  end
 
   def set_report
     @report = Report.find(params[:report_id])

--- a/spec/controllers/admin/reports/actions_controller_spec.rb
+++ b/spec/controllers/admin/reports/actions_controller_spec.rb
@@ -144,6 +144,12 @@ RSpec.describe Admin::Reports::ActionsController do
           expect(media_attached_status.reload.sensitive).to be true
         end
       end
+
+      context 'when the action is "invalid_action"' do
+        let(:action) { 'invalid_action' }
+
+        it { is_expected.to redirect_to(admin_report_path(report)) }
+      end
     end
 
     context 'with action as submit button' do


### PR DESCRIPTION
The path where `action_from_button` winds up being nil was not covered -- add spec for that.

Separately, these two "action" model new+save calls have basically the same params. Pull out shared method and give each of them their own `_params` method to merge in the differences on top of that.