### PR TITLE
Use sequence for unique names on webauthn cred fabricator

### DIFF
--- a/spec/fabricators/webauthn_credential_fabricator.rb
+++ b/spec/fabricators/webauthn_credential_fabricator.rb
@@ -4,6 +4,6 @@ Fabricator(:webauthn_credential) do
   user_id { Fabricate(:user).id }
   external_id { Base64.urlsafe_encode64(SecureRandom.random_bytes(16)) }
   public_key { OpenSSL::PKey::EC.generate('prime256v1').public_key }
-  nickname 'USB key'
+  nickname { sequence(:nickname) { |i| "USB Key number #{i}" } }
   sign_count 0
 end


### PR DESCRIPTION
There is a uniqueness validation on user here which errors out when you attempt to create multiple of these for a single user.