### PR TITLE
Set flash options via redirect where possible

### DIFF
--- a/app/controllers/admin/confirmations_controller.rb
+++ b/app/controllers/admin/confirmations_controller.rb
@@ -19,15 +19,13 @@ module Admin
 
       log_action :resend, @user
 
-      flash[:notice] = I18n.t('admin.accounts.resend_confirmation.success')
-      redirect_to admin_accounts_path
+      redirect_to admin_accounts_path, notice: t('admin.accounts.resend_confirmation.success')
     end
 
     private
 
     def redirect_confirmed_user
-      flash[:error] = I18n.t('admin.accounts.resend_confirmation.already_confirmed')
-      redirect_to admin_accounts_path
+      redirect_to admin_accounts_path, flash: { error: t('admin.accounts.resend_confirmation.already_confirmed') }
     end
 
     def user_confirmed?

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -14,8 +14,7 @@ module Admin
       @admin_settings = Form::AdminSettings.new(settings_params)
 
       if @admin_settings.save
-        flash[:notice] = I18n.t('generic.changes_saved_msg')
-        redirect_to after_update_redirect_path
+        redirect_to after_update_redirect_path, notice: t('generic.changes_saved_msg')
       else
         render :show
       end

--- a/app/controllers/auth/passwords_controller.rb
+++ b/app/controllers/auth/passwords_controller.rb
@@ -19,8 +19,7 @@ class Auth::PasswordsController < Devise::PasswordsController
   private
 
   def redirect_invalid_reset_token
-    flash[:error] = I18n.t('auth.invalid_reset_password_token')
-    redirect_to new_password_path(resource_name)
+    redirect_to new_password_path(resource_name), flash: { error: t('auth.invalid_reset_password_token') }
   end
 
   def reset_password_token_is_valid?

--- a/app/controllers/settings/sessions_controller.rb
+++ b/app/controllers/settings/sessions_controller.rb
@@ -8,8 +8,7 @@ class Settings::SessionsController < Settings::BaseController
 
   def destroy
     @session.destroy!
-    flash[:notice] = I18n.t('sessions.revoke_success')
-    redirect_to edit_user_registration_path
+    redirect_to edit_user_registration_path, notice: t('sessions.revoke_success')
   end
 
   private

--- a/app/controllers/settings/two_factor_authentication/webauthn_credentials_controller.rb
+++ b/app/controllers/settings/two_factor_authentication/webauthn_credentials_controller.rb
@@ -86,13 +86,11 @@ module Settings
       private
 
       def redirect_invalid_otp
-        flash[:error] = t('webauthn_credentials.otp_required')
-        redirect_to settings_two_factor_authentication_methods_path
+        redirect_to settings_two_factor_authentication_methods_path, flash: { error: t('webauthn_credentials.otp_required') }
       end
 
       def redirect_invalid_webauthn
-        flash[:error] = t('webauthn_credentials.not_enabled')
-        redirect_to settings_two_factor_authentication_methods_path
+        redirect_to settings_two_factor_authentication_methods_path, flash: { error: t('webauthn_credentials.not_enabled') }
       end
     end
   end


### PR DESCRIPTION
Did a quick pass to find places where we set flash and then redirect on the next line. Slight compactness improvement here (`notice` and `alert` can be set directly, others can be set via `flash:` key). 