### PR TITLE
Confirm `User#login_activities` in auth/sessions spec

### DIFF
--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -38,8 +38,7 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   private
 
   def record_login_activity
-    LoginActivity.create(
-      user: @user,
+    @user.login_activities.create(
       success: true,
       authentication_method: :omniauth,
       provider: @provider,

--- a/app/controllers/settings/login_activities_controller.rb
+++ b/app/controllers/settings/login_activities_controller.rb
@@ -5,6 +5,6 @@ class Settings::LoginActivitiesController < Settings::BaseController
   skip_before_action :require_functional!
 
   def index
-    @login_activities = LoginActivity.where(user: current_user).order(id: :desc).page(params[:page])
+    @login_activities = current_user.login_activities.order(id: :desc).page(params[:page])
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -90,6 +90,7 @@ class User < ApplicationRecord
   has_many :applications, class_name: 'Doorkeeper::Application', as: :owner, dependent: nil
   has_many :backups, inverse_of: :user, dependent: nil
   has_many :invites, inverse_of: :user, dependent: nil
+  has_many :login_activities, inverse_of: :user, dependent: :destroy
   has_many :markers, inverse_of: :user, dependent: :destroy
   has_many :webauthn_credentials, dependent: :destroy
   has_many :ips, class_name: 'UserIp', inverse_of: :user, dependent: nil

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe User do
 
   describe 'Associations' do
     it { is_expected.to belong_to(:account).required }
+    it { is_expected.to have_many(:login_activities) }
   end
 
   describe 'Validations' do


### PR DESCRIPTION
Both the `auth/omniauth_callbacks` and `auth/sessions` controllers have flows where they create a `LoginActivity` record for the user attempting to sign in. I noticed that the omniauth flow had coverage around these records being made, but the `auth/sessions` one did not. Initial change here was just to the specs to add that coverage.

While in there, added a `login_activities` association to `User` (the inverse already existed) and used it in a few spots where appropriate.