### PR TITLE
fix: Improve `Dropdown` component accessibility

### DIFF
--- a/app/javascript/mastodon/components/icon_button.tsx
+++ b/app/javascript/mastodon/components/icon_button.tsx
@@ -14,7 +14,6 @@ interface Props {
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
   onMouseDown?: React.MouseEventHandler<HTMLButtonElement>;
   onKeyDown?: React.KeyboardEventHandler<HTMLButtonElement>;
-  onKeyPress?: React.KeyboardEventHandler<HTMLButtonElement>;
   active?: boolean;
   expanded?: boolean;
   style?: React.CSSProperties;
@@ -45,7 +44,6 @@ export const IconButton = forwardRef<HTMLButtonElement, Props>(
       activeStyle,
       onClick,
       onKeyDown,
-      onKeyPress,
       onMouseDown,
       active = false,
       disabled = false,
@@ -84,16 +82,6 @@ export const IconButton = forwardRef<HTMLButtonElement, Props>(
       },
       [disabled, onClick],
     );
-
-    const handleKeyPress: React.KeyboardEventHandler<HTMLButtonElement> =
-      useCallback(
-        (e) => {
-          if (!disabled) {
-            onKeyPress?.(e);
-          }
-        },
-        [disabled, onKeyPress],
-      );
 
     const handleMouseDown: React.MouseEventHandler<HTMLButtonElement> =
       useCallback(
@@ -161,7 +149,6 @@ export const IconButton = forwardRef<HTMLButtonElement, Props>(
         onClick={handleClick}
         onMouseDown={handleMouseDown}
         onKeyDown={handleKeyDown}
-        onKeyPress={handleKeyPress} // eslint-disable-line @typescript-eslint/no-deprecated
         style={buttonStyle}
         tabIndex={tabIndex}
         disabled={disabled}

--- a/app/javascript/mastodon/features/navigation_panel/components/more_link.tsx
+++ b/app/javascript/mastodon/features/navigation_panel/components/more_link.tsx
@@ -112,7 +112,7 @@ export const MoreLink: React.FC = () => {
   }, [intl, dispatch, permissions]);
 
   return (
-    <Dropdown items={menu}>
+    <Dropdown items={menu} placement='bottom-start'>
       <button className='column-link column-link--transparent'>
         <Icon id='' icon={MoreHorizIcon} className='column-link__icon' />
 

--- a/app/javascript/mastodon/features/navigation_panel/components/more_link.tsx
+++ b/app/javascript/mastodon/features/navigation_panel/components/more_link.tsx
@@ -50,16 +50,22 @@ export const MoreLink: React.FC = () => {
 
   const menu = useMemo(() => {
     const arr: MenuItem[] = [
-      { text: intl.formatMessage(messages.filters), href: '/filters' },
-      { text: intl.formatMessage(messages.mutes), to: '/mutes' },
-      { text: intl.formatMessage(messages.blocks), to: '/blocks' },
       {
-        text: intl.formatMessage(messages.domainBlocks),
-        to: '/domain_blocks',
+        href: '/filters',
+        text: intl.formatMessage(messages.filters),
       },
-    ];
-
-    arr.push(
+      {
+        to: '/mutes',
+        text: intl.formatMessage(messages.mutes),
+      },
+      {
+        to: '/blocks',
+        text: intl.formatMessage(messages.blocks),
+      },
+      {
+        to: '/domain_blocks',
+        text: intl.formatMessage(messages.domainBlocks),
+      },
       null,
       {
         href: '/settings/privacy',
@@ -77,7 +83,7 @@ export const MoreLink: React.FC = () => {
         href: '/settings/export',
         text: intl.formatMessage(messages.importExport),
       },
-    );
+    ];
 
     if (canManageReports(permissions)) {
       arr.push(null, {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -3874,16 +3874,18 @@ a.account__display-name {
   display: flex;
   align-items: center;
   gap: 8px;
+  width: 100%;
+  padding: 12px;
   font-size: 16px;
   font-weight: 400;
-  padding: 12px;
   text-decoration: none;
   overflow: hidden;
   white-space: nowrap;
-  border: 0;
-  background: transparent;
   color: $secondary-text-color;
+  background: transparent;
+  border: 0;
   border-left: 4px solid transparent;
+  box-sizing: border-box;
 
   &:hover,
   &:focus,


### PR DESCRIPTION
Fixes #35338

### Changes proposed in this PR:
- Fixes keyboard accessibility of `Dropdown` component, adding missing aria attributes and simplifying focus handling:
  - When closing the menu, focus now always returns to the button that opened the menu as per [this WCAG Example implementation](https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/examples/disclosure-navigation/)
- Makes the "More" menu item take up the whole width of the menu, increasing its click target
- Adds a `placement` prop to customise the dropdown menu's position per component
- Removes deprecated `onKeyPress` prop from `IconButton` which was only used by the `Dropdown` component and is not needed anymore now since `onClick` handles keyboard interactions fine

### Screencap

This video shows the menu being opened by <kbd>Enter</kbd> key first, then <kbd>Space</kbd>, then by clicking on the empty space to the right of the "More" button. Each time the menu is navigated briefly and closed via <kbd>Esc</kbd>

https://github.com/user-attachments/assets/bb68a706-f335-4735-9e8a-f16f6624ad0c