### PR TITLE
Add coverage for `CustomFilterStatus` model

### DIFF
--- a/app/models/custom_filter_status.rb
+++ b/app/models/custom_filter_status.rb
@@ -17,12 +17,14 @@ class CustomFilterStatus < ApplicationRecord
   belongs_to :custom_filter
   belongs_to :status
 
-  validates :status, uniqueness: { scope: :custom_filter }
-  validate :validate_status_access
+  validates :status_id, uniqueness: { scope: :custom_filter_id }
+  validate :validate_status_access, if: [:custom_filter_account, :status]
+
+  delegate :account, to: :custom_filter, prefix: true, allow_nil: true
 
   private
 
   def validate_status_access
-    errors.add(:status_id, :invalid) unless StatusPolicy.new(custom_filter.account, status).show?
+    errors.add(:status_id, :invalid) unless StatusPolicy.new(custom_filter_account, status).show?
   end
 end

--- a/spec/models/custom_filter_status_spec.rb
+++ b/spec/models/custom_filter_status_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CustomFilterStatus do
+  describe 'Associations' do
+    it { is_expected.to belong_to(:custom_filter) }
+    it { is_expected.to belong_to(:status) }
+  end
+
+  describe 'Validations' do
+    subject { Fabricate.build :custom_filter_status }
+
+    it { is_expected.to validate_uniqueness_of(:status_id).scoped_to(:custom_filter_id) }
+
+    describe 'Status access' do
+      subject { Fabricate.build :custom_filter_status, custom_filter:, status: }
+
+      let(:custom_filter) { Fabricate :custom_filter }
+      let(:status) { Fabricate :status }
+
+      context 'when policy allows filter account to access status' do
+        it { is_expected.to allow_value(status.id).for(:status_id) }
+      end
+
+      context 'when policy does not allow filter account to access status' do
+        before { status.account.touch(:suspended_at) }
+
+        it { is_expected.to_not allow_value(status.id).for(:status_id) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Specs cover the model basics and the one custom validation.

Model changes are:

- Align the uniqueness declaration with the db uniqueness index and style consistency, along same lines as https://github.com/mastodon/mastodon/pull/33247#issuecomment-2532091764
- Better handle nil/missing values for the custom validation error (previously would error out with missing custom filter)