### PR TITLE
Add coverage for `FollowRecommendationMute` model

### DIFF
--- a/app/models/follow_recommendation_mute.rb
+++ b/app/models/follow_recommendation_mute.rb
@@ -14,7 +14,7 @@ class FollowRecommendationMute < ApplicationRecord
   belongs_to :account
   belongs_to :target_account, class_name: 'Account'
 
-  validates :target_account, uniqueness: { scope: :account_id }
+  validates :target_account_id, uniqueness: { scope: :account_id }
 
   after_commit :invalidate_follow_recommendations_cache
 

--- a/spec/models/follow_recommendation_mute_spec.rb
+++ b/spec/models/follow_recommendation_mute_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FollowRecommendationMute do
+  describe 'Associations' do
+    it { is_expected.to belong_to(:account) }
+    it { is_expected.to belong_to(:target_account).class_name('Account') }
+  end
+
+  describe 'Validations' do
+    subject { Fabricate.build :follow_recommendation_mute }
+
+    it { is_expected.to validate_uniqueness_of(:target_account_id).scoped_to(:account_id) }
+  end
+
+  describe 'Callbacks' do
+    describe 'Maintaining the recommendation cache' do
+      let(:account) { Fabricate :account }
+      let(:cache_key) { "follow_recommendations/#{account.id}" }
+
+      before { Rails.cache.write(cache_key, 123) }
+
+      it 'purges on save' do
+        expect { Fabricate :follow_recommendation_mute, account: account }
+          .to(change { Rails.cache.exist?(cache_key) }.from(true).to(false))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Same idea as https://github.com/mastodon/mastodon/pull/35374

Possible follow-up here -- that "delete the follow recommendation cache value" with that same key creation happens from many places as an `after_commit` ... could potentially pull that to a concern, and/or move the key string value generation somewhere, etc.