### PR TITLE
Extract `RecommendationMaintenance` concern

### DIFF
--- a/app/models/account_domain_block.rb
+++ b/app/models/account_domain_block.rb
@@ -14,21 +14,17 @@
 class AccountDomainBlock < ApplicationRecord
   include Paginable
   include DomainNormalizable
+  include RecommendationMaintenance
 
   belongs_to :account
   validates :domain, presence: true, uniqueness: { scope: :account_id }, domain: true
 
   after_commit :invalidate_domain_blocking_cache
-  after_commit :invalidate_follow_recommendations_cache
 
   private
 
   def invalidate_domain_blocking_cache
     Rails.cache.delete("exclude_domains_for:#{account_id}")
     Rails.cache.delete(['exclude_domains', account_id, domain])
-  end
-
-  def invalidate_follow_recommendations_cache
-    Rails.cache.delete("follow_recommendations/#{account_id}")
   end
 end

--- a/app/models/block.rb
+++ b/app/models/block.rb
@@ -15,6 +15,7 @@
 class Block < ApplicationRecord
   include Paginable
   include RelationshipCacheable
+  include RecommendationMaintenance
 
   belongs_to :account
   belongs_to :target_account, class_name: 'Account'
@@ -27,17 +28,12 @@ class Block < ApplicationRecord
 
   before_validation :set_uri, only: :create
   after_commit :invalidate_blocking_cache
-  after_commit :invalidate_follow_recommendations_cache
 
   private
 
   def invalidate_blocking_cache
     Rails.cache.delete("exclude_account_ids_for:#{account_id}")
     Rails.cache.delete("exclude_account_ids_for:#{target_account_id}")
-  end
-
-  def invalidate_follow_recommendations_cache
-    Rails.cache.delete("follow_recommendations/#{account_id}")
   end
 
   def set_uri

--- a/app/models/concerns/recommendation_maintenance.rb
+++ b/app/models/concerns/recommendation_maintenance.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module RecommendationMaintenance
+  extend ActiveSupport::Concern
+
+  included do
+    after_commit :invalidate_follow_recommendations_cache
+  end
+
+  private
+
+  def invalidate_follow_recommendations_cache
+    Rails.cache.delete("follow_recommendations/#{account_id}")
+  end
+end

--- a/app/models/concerns/recommendation_maintenance.rb
+++ b/app/models/concerns/recommendation_maintenance.rb
@@ -3,6 +3,8 @@
 module RecommendationMaintenance
   extend ActiveSupport::Concern
 
+  FOLLOW_RECOMMENDATIONS_SCOPE = 'follow_recommendations'
+
   included do
     after_commit :invalidate_follow_recommendations_cache
   end
@@ -10,6 +12,10 @@ module RecommendationMaintenance
   private
 
   def invalidate_follow_recommendations_cache
-    Rails.cache.delete("follow_recommendations/#{account_id}")
+    Rails.cache.delete(follow_recommendations_cache_key)
+  end
+
+  def follow_recommendations_cache_key
+    [FOLLOW_RECOMMENDATIONS_SCOPE, account_id].join('/')
   end
 end

--- a/app/models/follow.rb
+++ b/app/models/follow.rb
@@ -20,6 +20,7 @@ class Follow < ApplicationRecord
   include RelationshipCacheable
   include RateLimitable
   include FollowLimitable
+  include RecommendationMaintenance
 
   rate_limit by: :account, family: :follows
 
@@ -46,7 +47,6 @@ class Follow < ApplicationRecord
   after_create :increment_cache_counters
   after_destroy :remove_endorsements
   after_destroy :decrement_cache_counters
-  after_commit :invalidate_follow_recommendations_cache
   after_commit :invalidate_hash_cache
 
   private
@@ -73,9 +73,5 @@ class Follow < ApplicationRecord
     return if account.local? && target_account.local?
 
     Rails.cache.delete("followers_hash:#{target_account_id}:#{account.synchronization_uri_prefix}")
-  end
-
-  def invalidate_follow_recommendations_cache
-    Rails.cache.delete("follow_recommendations/#{account_id}")
   end
 end

--- a/app/models/follow_recommendation_mute.rb
+++ b/app/models/follow_recommendation_mute.rb
@@ -11,16 +11,10 @@
 #  updated_at        :datetime         not null
 #
 class FollowRecommendationMute < ApplicationRecord
+  include RecommendationMaintenance
+
   belongs_to :account
   belongs_to :target_account, class_name: 'Account'
 
   validates :target_account_id, uniqueness: { scope: :account_id }
-
-  after_commit :invalidate_follow_recommendations_cache
-
-  private
-
-  def invalidate_follow_recommendations_cache
-    Rails.cache.delete("follow_recommendations/#{account_id}")
-  end
 end

--- a/app/models/follow_request.rb
+++ b/app/models/follow_request.rb
@@ -20,6 +20,7 @@ class FollowRequest < ApplicationRecord
   include RelationshipCacheable
   include RateLimitable
   include FollowLimitable
+  include RecommendationMaintenance
 
   rate_limit by: :account, family: :follows
 
@@ -52,15 +53,10 @@ class FollowRequest < ApplicationRecord
   end
 
   before_validation :set_uri, only: :create
-  after_commit :invalidate_follow_recommendations_cache
 
   private
 
   def set_uri
     self.uri = ActivityPub::TagManager.instance.generate_uri_for(self) if uri.nil?
-  end
-
-  def invalidate_follow_recommendations_cache
-    Rails.cache.delete("follow_recommendations/#{account_id}")
   end
 end

--- a/app/models/mute.rb
+++ b/app/models/mute.rb
@@ -17,6 +17,7 @@ class Mute < ApplicationRecord
   include Paginable
   include RelationshipCacheable
   include Expireable
+  include RecommendationMaintenance
 
   belongs_to :account
   belongs_to :target_account, class_name: 'Account'
@@ -24,15 +25,10 @@ class Mute < ApplicationRecord
   validates :account_id, uniqueness: { scope: :target_account_id }
 
   after_commit :invalidate_blocking_cache
-  after_commit :invalidate_follow_recommendations_cache
 
   private
 
   def invalidate_blocking_cache
     Rails.cache.delete("exclude_account_ids_for:#{account_id}")
-  end
-
-  def invalidate_follow_recommendations_cache
-    Rails.cache.delete("follow_recommendations/#{account_id}")
   end
 end

--- a/spec/models/account_domain_block_spec.rb
+++ b/spec/models/account_domain_block_spec.rb
@@ -5,6 +5,8 @@ require 'rails_helper'
 RSpec.describe AccountDomainBlock do
   let(:account) { Fabricate(:account) }
 
+  it_behaves_like 'Recommendation Maintenance'
+
   it 'removes blocking cache after creation' do
     Rails.cache.write("exclude_domains_for:#{account.id}", 'a.domain.already.blocked')
 

--- a/spec/models/block_spec.rb
+++ b/spec/models/block_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Block do
+  it_behaves_like 'Recommendation Maintenance'
+
   describe 'Associations' do
     it { is_expected.to belong_to(:account).required }
     it { is_expected.to belong_to(:target_account).required }

--- a/spec/models/follow_recommendation_mute_spec.rb
+++ b/spec/models/follow_recommendation_mute_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe FollowRecommendationMute do
+  it_behaves_like 'Recommendation Maintenance'
+
   describe 'Associations' do
     it { is_expected.to belong_to(:account) }
     it { is_expected.to belong_to(:target_account).class_name('Account') }
@@ -12,19 +14,5 @@ RSpec.describe FollowRecommendationMute do
     subject { Fabricate.build :follow_recommendation_mute }
 
     it { is_expected.to validate_uniqueness_of(:target_account_id).scoped_to(:account_id) }
-  end
-
-  describe 'Callbacks' do
-    describe 'Maintaining the recommendation cache' do
-      let(:account) { Fabricate :account }
-      let(:cache_key) { "follow_recommendations/#{account.id}" }
-
-      before { Rails.cache.write(cache_key, 123) }
-
-      it 'purges on save' do
-        expect { Fabricate :follow_recommendation_mute, account: account }
-          .to(change { Rails.cache.exist?(cache_key) }.from(true).to(false))
-      end
-    end
   end
 end

--- a/spec/models/follow_request_spec.rb
+++ b/spec/models/follow_request_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe FollowRequest do
+  it_behaves_like 'Recommendation Maintenance'
+
   describe '#authorize!' do
     let!(:follow_request) { Fabricate(:follow_request, account: account, target_account: target_account) }
     let(:account)         { Fabricate(:account) }

--- a/spec/models/follow_spec.rb
+++ b/spec/models/follow_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Follow do
+  it_behaves_like 'Recommendation Maintenance'
+
   describe 'Associations' do
     it { is_expected.to belong_to(:account).required }
     it { is_expected.to belong_to(:target_account).required }

--- a/spec/models/mute_spec.rb
+++ b/spec/models/mute_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Mute do
   it_behaves_like 'Expireable'
+  it_behaves_like 'Recommendation Maintenance'
 
   describe 'Associations' do
     it { is_expected.to belong_to(:account).required }

--- a/spec/support/examples/models/concerns/recommendation_maintenance.rb
+++ b/spec/support/examples/models/concerns/recommendation_maintenance.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'Recommendation Maintenance' do
+  describe 'Callbacks' do
+    describe 'Maintaining the cache' do
+      let(:account) { Fabricate :account }
+      let(:cache_key) { "follow_recommendations/#{account.id}" }
+
+      before { Rails.cache.write(cache_key, 123) }
+
+      it 'purges the cache value when record saved' do
+        expect { Fabricate factory_name, account: account }
+          .to(change { Rails.cache.exist?(cache_key) }.from(true).to(false))
+      end
+
+      def factory_name
+        described_class.name.underscore.to_sym
+      end
+    end
+  end
+end


### PR DESCRIPTION
Attempting the idea from https://github.com/mastodon/mastodon/pull/35376

This effectively duplicates a portion of the `FollowRecommendationMute` spec added in that other PR ... whichever merges first the other should rebase to de-dupe.