### PR TITLE
Always give local quote of remote posts a quote request URI

### DIFF
--- a/app/models/quote.rb
+++ b/app/models/quote.rb
@@ -31,7 +31,7 @@ class Quote < ApplicationRecord
   belongs_to :quoted_account, class_name: 'Account', optional: true
 
   before_validation :set_accounts
-
+  before_validation :set_activity_uri, only: :create, if: -> { account.local? && quoted_account&.remote? }
   validates :activity_uri, presence: true, if: -> { account.local? && quoted_account&.remote? }
   validate :validate_visibility
 
@@ -68,5 +68,9 @@ class Quote < ApplicationRecord
     return if account_id == quoted_account_id || quoted_status.nil? || quoted_status.distributable?
 
     errors.add(:quoted_status_id, :visibility_mismatch)
+  end
+
+  def set_activity_uri
+    self.activity_uri = [ActivityPub::TagManager.instance.uri_for(account), '/quote_requests/', SecureRandom.uuid].join
   end
 end

--- a/app/serializers/activitypub/quote_request_serializer.rb
+++ b/app/serializers/activitypub/quote_request_serializer.rb
@@ -7,7 +7,7 @@ class ActivityPub::QuoteRequestSerializer < ActivityPub::Serializer
   attribute :virtual_object, key: :object
 
   def id
-    object.activity_uri || [ActivityPub::TagManager.instance.uri_for(object.target_account), '#quote_requests/', object.id].join
+    object.activity_uri
   end
 
   def type


### PR DESCRIPTION
Populate the `activity_uri` with a `before_validation` callback, instead of relying on the calling sites for that.

Also remove the buggy `id` fallback, and mark the PR as to be backported for that.