### PR TITLE
Add coverage for api/v1/invites scenarios

### DIFF
--- a/app/controllers/api/v1/invites_controller.rb
+++ b/app/controllers/api/v1/invites_controller.rb
@@ -7,6 +7,7 @@ class Api::V1::InvitesController < Api::BaseController
   skip_around_action :set_locale
 
   before_action :set_invite
+  before_action :check_valid_usage!
   before_action :check_enabled_registrations!
 
   # Override `current_user` to avoid reading session cookies
@@ -22,9 +23,11 @@ class Api::V1::InvitesController < Api::BaseController
     @invite = Invite.find_by!(code: params[:invite_code])
   end
 
-  def check_enabled_registrations!
-    return render json: { error: I18n.t('invites.invalid') }, status: 401 unless @invite.valid_for_use?
+  def check_valid_usage!
+    render json: { error: I18n.t('invites.invalid') }, status: 401 unless @invite.valid_for_use?
+  end
 
+  def check_enabled_registrations!
     raise Mastodon::NotPermittedError unless allowed_registration?(request.remote_ip, @invite)
   end
 end

--- a/spec/requests/invite_spec.rb
+++ b/spec/requests/invite_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'invites' do
     context 'when invite is expired' do
       before { invite.update(expires_at: 3.days.ago) }
 
-      it 'returns a JSON document with expected attributes' do
+      it 'returns a JSON document with error details' do
         subject
 
         expect(response)
@@ -33,6 +33,21 @@ RSpec.describe 'invites' do
           .to eq 'application/json'
         expect(response.parsed_body)
           .to include(error: I18n.t('invites.invalid'))
+      end
+    end
+
+    context 'when user IP is blocked' do
+      before { Fabricate :ip_block, severity: :sign_up_block, ip: '127.0.0.1' }
+
+      it 'returns a JSON document with error details' do
+        subject
+
+        expect(response)
+          .to have_http_status(403)
+        expect(response.media_type)
+          .to eq 'application/json'
+        expect(response.parsed_body)
+          .to include(error: /This action is not allowed/)
       end
     end
   end


### PR DESCRIPTION
In the spec - add coverage for the "expired invite" and "blocked registration" scenarios, which gets us to 100% C0 on the controller class.

In the controller - prefer the implicit halt of before action to the previous `return render...` style.

Side note here - I looked first for a spec/requests/api/v1/invites_spec here, didn't find one, and then searched a bit and found this requests/invite_spec. I see why its like this (the route is `/invite/:invite_code`) and the spec does separate out the JSON (api) and normal html response versions ... may be worth contemplating splitting this into spec/requests/api/v1/invites and spec/system/invites - if/when this spec gets any larger. Don't feel strongly here.