### PR TITLE
refactor: Only remove pointer-events when necessary

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2848,7 +2848,6 @@ a.account__display-name {
     &__pane {
       height: 100%;
       overflow: hidden;
-      pointer-events: none;
       display: flex;
       justify-content: flex-end;
       min-width: 285px;
@@ -2860,7 +2859,6 @@ a.account__display-name {
       &__inner {
         position: fixed;
         width: 285px;
-        pointer-events: auto;
         height: 100%;
       }
     }


### PR DESCRIPTION
Speculative fix for #35328

### Changes proposed in this PR:

- Removes `pointer-events: none` declarations where not necessary (i.e. on large viewports where the menu won't be displayed as an overlay), in the hopes that it'll fix an issue clicking menu items using graphics tablets.
   
   I confirmed that on mobile, `pointer-events: none/auto` is still applied via the `columns-area__panels__pane--navigational` class and I tested this in firefox dev tools mobile mode and Xcode Simulator to ensure that the mobile menu behaviour isn't affected.