### PR TITLE
Remove the "to triage" label status

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.web_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1.web_bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug Report (Web Interface)
 description: There is a problem using Mastodon's web interface.
-labels: ['status/to triage', 'area/web interface']
+labels: ['area/web interface']
 type: Bug
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/2.server_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/2.server_bug_report.yml
@@ -1,7 +1,6 @@
 name: Bug Report (server / API)
 description: |
   There is a problem with the HTTP server, REST API, ActivityPub interaction, etc.
-labels: ['status/to triage']
 type: 'Bug'
 body:
   - type: markdown


### PR DESCRIPTION
We are now tracking bugs in a dedicated GitHub project, with proper fields. The labels are no longer relevant, so let's stop adding them.