### PR TITLE
fix: Fix selected item in poll select menus is unreadable in Firefox

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -939,6 +939,7 @@ body > [data-popper-placement] {
         line-height: 20px;
         letter-spacing: 0.1px;
         color: $highlight-text-color;
+        background-color: var(--input-background-color);
         white-space: nowrap;
         text-overflow: ellipsis;
         overflow: hidden;


### PR DESCRIPTION
Fixes #35371

### Changes proposed in this PR:
- Fixes the selected item being unreadable in the select menus of the composer (poll options)
  Cause of this issue is a quirk in Firefox whereby the popover menu of `<select>` elements inherits the background colour of the select element, and ours didn't have one set

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="278" height="284" alt="Screenshot 2025-07-16 at 13 37 14" src="https://github.com/user-attachments/assets/679d0c4b-d8b8-438d-aab6-638cd1f8de93" /> | <img width="222" height="260" alt="Screenshot 2025-07-16 at 13 36 34" src="https://github.com/user-attachments/assets/ad0db5ad-3d3e-46e4-b484-ed76d4e96b1b" /> | 