### PR TITLE
refactor: Disable `useDrag` hook when main menu is not openable

### DIFF
--- a/app/javascript/mastodon/features/navigation_panel/index.tsx
+++ b/app/javascript/mastodon/features/navigation_panel/index.tsx
@@ -431,6 +431,7 @@ export const CollapsibleNavigationPanel: React.FC = () => {
       filterTaps: true,
       bounds: isLtrDir ? { left: 0 } : { right: 0 },
       rubberband: true,
+      enabled: openable,
     },
   );
 


### PR DESCRIPTION
This is another speculative fix for #35328

### Changes proposed in this PR:
- Disable drag handling when the main menu isn't "openable" (e.g. on non-mobile viewport sizes). This should cause no functional changes