### PR TITLE
Use default for preselected default privacy post setting

### DIFF
--- a/app/views/settings/preferences/other/show.html.haml
+++ b/app/views/settings/preferences/other/show.html.haml
@@ -21,6 +21,7 @@
       .fields-group.fields-row__column.fields-row__column-6
         = ff.input :default_privacy,
                    collection: Status.selectable_visibilities,
+                   selected: current_user.setting_default_privacy,
                    hint: false,
                    include_blank: false,
                    label_method: ->(visibility) { safe_join([I18n.t("statuses.visibilities.#{visibility}"), I18n.t("statuses.visibilities.#{visibility}_long")], ' - ') },


### PR DESCRIPTION
Fixes #35122

This changes the settings form to use the default value that is also used by the compose form when the setting has never been set in the first place. This should make both views consistent, but what is more important, this will prevent people from changing this setting without realizing they did so (because they only wanted to change another setting on the same page).

I am not 100% happy with this solution here, as it seems strange to me that `UserSettings` knows about default values, but in this case there is another, somewhat hidden, default. The reason (at least on the surface, I do not know all the history here) is of course that `UserSettings` do not have access to the actual `User`. Changing this is a bigger refactor though, while this is a single line change, so I opted to keep it simple for now.