### PR TITLE
Emoji Rendering

### DIFF
--- a/app/javascript/mastodon/components/account_bio.tsx
+++ b/app/javascript/mastodon/components/account_bio.tsx
@@ -3,7 +3,6 @@ import { useCallback } from 'react';
 import { useLinks } from 'mastodon/hooks/useLinks';
 
 import { EmojiHTML } from '../features/emoji/emoji_html';
-import type { ExtraCustomEmojiMap } from '../features/emoji/types';
 import { isFeatureEnabled } from '../initial_state';
 import { useAppSelector } from '../store';
 
@@ -28,16 +27,6 @@ export const AccountBio: React.FC<AccountBioProps> = ({
     },
     [showDropdown, accountId],
   );
-  const extraEmoji = useAppSelector((state) => {
-    const account = state.accounts.get(accountId);
-    if (!account || account.emojis.size === 0) {
-      return {};
-    }
-    return account.emojis.reduce((map, emoji) => {
-      map[emoji.shortcode] = emoji.toJS();
-      return map;
-    }, {} as ExtraCustomEmojiMap);
-  });
   const note = useAppSelector((state) => {
     const account = state.accounts.get(accountId);
     if (!account) {
@@ -46,6 +35,10 @@ export const AccountBio: React.FC<AccountBioProps> = ({
     return isFeatureEnabled('modern_emojis')
       ? account.note
       : account.note_emojified;
+  });
+  const extraEmojis = useAppSelector((state) => {
+    const account = state.accounts.get(accountId);
+    return account?.emojis;
   });
 
   if (note.length === 0) {
@@ -58,7 +51,7 @@ export const AccountBio: React.FC<AccountBioProps> = ({
       onClickCapture={handleClick}
       ref={handleNodeChange}
     >
-      <EmojiHTML htmlString={note} extraEmojis={extraEmoji} />
+      <EmojiHTML htmlString={note} extraEmojis={extraEmojis} />
     </div>
   );
 };

--- a/app/javascript/mastodon/components/account_bio.tsx
+++ b/app/javascript/mastodon/components/account_bio.tsx
@@ -2,6 +2,8 @@ import { useCallback } from 'react';
 
 import { useLinks } from 'mastodon/hooks/useLinks';
 
+import { EmojiHTML } from '../features/emoji/emoji_html';
+
 interface AccountBioProps {
   note: string;
   className: string;
@@ -31,10 +33,11 @@ export const AccountBio: React.FC<AccountBioProps> = ({
   return (
     <div
       className={`${className} translate`}
-      dangerouslySetInnerHTML={{ __html: note }}
       onClickCapture={handleClick}
       ref={handleNodeChange}
-    />
+    >
+      <EmojiHTML htmlString={note} />
+    </div>
   );
 };
 

--- a/app/javascript/mastodon/components/hover_card_account.tsx
+++ b/app/javascript/mastodon/components/hover_card_account.tsx
@@ -19,7 +19,7 @@ import { FollowButton } from 'mastodon/components/follow_button';
 import { LoadingIndicator } from 'mastodon/components/loading_indicator';
 import { ShortNumber } from 'mastodon/components/short_number';
 import { useFetchFamiliarFollowers } from 'mastodon/features/account_timeline/hooks/familiar_followers';
-import { domain } from 'mastodon/initial_state';
+import { domain, isFeatureEnabled } from 'mastodon/initial_state';
 import { getAccountHidden } from 'mastodon/selectors/accounts';
 import { useAppSelector, useAppDispatch } from 'mastodon/store';
 
@@ -102,7 +102,11 @@ export const HoverCardAccount = forwardRef<
             <>
               <div className='hover-card__text-row'>
                 <AccountBio
-                  note={account.note_emojified}
+                  note={
+                    isFeatureEnabled('modern_emojis')
+                      ? account.note
+                      : account.note_emojified
+                  }
                   className='hover-card__bio'
                 />
                 <AccountFields fields={account.fields} limit={2} />

--- a/app/javascript/mastodon/components/hover_card_account.tsx
+++ b/app/javascript/mastodon/components/hover_card_account.tsx
@@ -19,7 +19,7 @@ import { FollowButton } from 'mastodon/components/follow_button';
 import { LoadingIndicator } from 'mastodon/components/loading_indicator';
 import { ShortNumber } from 'mastodon/components/short_number';
 import { useFetchFamiliarFollowers } from 'mastodon/features/account_timeline/hooks/familiar_followers';
-import { domain, isFeatureEnabled } from 'mastodon/initial_state';
+import { domain } from 'mastodon/initial_state';
 import { getAccountHidden } from 'mastodon/selectors/accounts';
 import { useAppSelector, useAppDispatch } from 'mastodon/store';
 
@@ -102,11 +102,7 @@ export const HoverCardAccount = forwardRef<
             <>
               <div className='hover-card__text-row'>
                 <AccountBio
-                  note={
-                    isFeatureEnabled('modern_emojis')
-                      ? account.note
-                      : account.note_emojified
-                  }
+                  accountId={account.id}
                   className='hover-card__bio'
                 />
                 <AccountFields fields={account.fields} limit={2} />

--- a/app/javascript/mastodon/components/status_content.jsx
+++ b/app/javascript/mastodon/components/status_content.jsx
@@ -257,7 +257,12 @@ class StatusContent extends PureComponent {
       return (
         <>
           <div className={classNames} ref={this.setRef} onMouseDown={this.handleMouseDown} onMouseUp={this.handleMouseUp} key='status-content' onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave}>
-            <div className='status__content__text status__content__text--visible translate' lang={language} dangerouslySetInnerHTML={content} />
+            <EmojiHTML
+              className='status__content__text status__content__text--visible translate'
+              lang={language}
+              htmlString={content}
+              extraEmojis={status.get('emojis')}
+            />
 
             {poll}
             {translateButton}

--- a/app/javascript/mastodon/components/status_content.jsx
+++ b/app/javascript/mastodon/components/status_content.jsx
@@ -13,7 +13,7 @@ import ChevronRightIcon from '@/material-icons/400-24px/chevron_right.svg?react'
 import { Icon }  from 'mastodon/components/icon';
 import { Poll } from 'mastodon/components/poll';
 import { identityContextPropShape, withIdentity } from 'mastodon/identity_context';
-import { autoPlayGif, languages as preloadedLanguages } from 'mastodon/initial_state';
+import { autoPlayGif, isFeatureEnabled, languages as preloadedLanguages } from 'mastodon/initial_state';
 import { EmojiHTML } from '../features/emoji/emoji_html';
 
 const MAX_HEIGHT = 706; // 22px * 32 (+ 2px padding at the top)
@@ -24,6 +24,9 @@ const MAX_HEIGHT = 706; // 22px * 32 (+ 2px padding at the top)
  * @returns {string}
  */
 export function getStatusContent(status) {
+  if (isFeatureEnabled('modern_emojis')) {
+    return status.getIn(['translation', 'content']) || status.get('content');
+  }
   return status.getIn(['translation', 'content']) || status.get('content');
 }
 

--- a/app/javascript/mastodon/components/status_content.jsx
+++ b/app/javascript/mastodon/components/status_content.jsx
@@ -14,6 +14,7 @@ import { Icon }  from 'mastodon/components/icon';
 import { Poll } from 'mastodon/components/poll';
 import { identityContextPropShape, withIdentity } from 'mastodon/identity_context';
 import { autoPlayGif, languages as preloadedLanguages } from 'mastodon/initial_state';
+import { EmojiHTML } from '../features/emoji/emoji_html';
 
 const MAX_HEIGHT = 706; // 22px * 32 (+ 2px padding at the top)
 
@@ -23,7 +24,7 @@ const MAX_HEIGHT = 706; // 22px * 32 (+ 2px padding at the top)
  * @returns {string}
  */
 export function getStatusContent(status) {
-  return status.getIn(['translation', 'contentHtml']) || status.get('contentHtml');
+  return status.getIn(['translation', 'content']) || status.get('content');
 }
 
 class TranslateButton extends PureComponent {
@@ -228,7 +229,7 @@ class StatusContent extends PureComponent {
     const targetLanguages = this.props.languages?.get(status.get('language') || 'und');
     const renderTranslate = this.props.onTranslate && this.props.identity.signedIn && ['public', 'unlisted'].includes(status.get('visibility')) && status.get('search_index').trim().length > 0 && targetLanguages?.includes(contentLocale);
 
-    const content = { __html: statusContent ?? getStatusContent(status) };
+    const content = statusContent ?? getStatusContent(status);
     const language = status.getIn(['translation', 'language']) || status.get('language');
     const classNames = classnames('status__content', {
       'status__content--with-action': this.props.onClick && this.props.history,
@@ -265,7 +266,12 @@ class StatusContent extends PureComponent {
     } else {
       return (
         <div className={classNames} ref={this.setRef} onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave}>
-          <div className='status__content__text status__content__text--visible translate' lang={language} dangerouslySetInnerHTML={content} />
+          <EmojiHTML
+            className='status__content__text status__content__text--visible translate'
+            lang={language}
+            htmlString={content}
+            extraEmojis={status.get('emojis')}
+          />
 
           {poll}
           {translateButton}

--- a/app/javascript/mastodon/components/status_content.jsx
+++ b/app/javascript/mastodon/components/status_content.jsx
@@ -27,7 +27,7 @@ export function getStatusContent(status) {
   if (isFeatureEnabled('modern_emojis')) {
     return status.getIn(['translation', 'content']) || status.get('content');
   }
-  return status.getIn(['translation', 'content']) || status.get('content');
+  return status.getIn(['translation', 'contentHtml']) || status.get('contentHtml');
 }
 
 class TranslateButton extends PureComponent {

--- a/app/javascript/mastodon/features/account_timeline/components/account_header.tsx
+++ b/app/javascript/mastodon/features/account_timeline/components/account_header.tsx
@@ -50,7 +50,12 @@ import { DomainPill } from 'mastodon/features/account/components/domain_pill';
 import FollowRequestNoteContainer from 'mastodon/features/account/containers/follow_request_note_container';
 import { useLinks } from 'mastodon/hooks/useLinks';
 import { useIdentity } from 'mastodon/identity_context';
-import { autoPlayGif, me, domain as localDomain } from 'mastodon/initial_state';
+import {
+  autoPlayGif,
+  me,
+  domain as localDomain,
+  isFeatureEnabled,
+} from 'mastodon/initial_state';
 import type { Account } from 'mastodon/models/account';
 import type { MenuItem } from 'mastodon/models/dropdown_menu';
 import {
@@ -898,7 +903,11 @@ export const AccountHeader: React.FC<{
                 )}
 
                 <AccountBio
-                  note={account.note_emojified}
+                  note={
+                    isFeatureEnabled('modern_emojis')
+                      ? account.note
+                      : account.note_emojified
+                  }
                   dropdownAccountId={accountId}
                   className='account__header__content'
                 />

--- a/app/javascript/mastodon/features/account_timeline/components/account_header.tsx
+++ b/app/javascript/mastodon/features/account_timeline/components/account_header.tsx
@@ -50,12 +50,7 @@ import { DomainPill } from 'mastodon/features/account/components/domain_pill';
 import FollowRequestNoteContainer from 'mastodon/features/account/containers/follow_request_note_container';
 import { useLinks } from 'mastodon/hooks/useLinks';
 import { useIdentity } from 'mastodon/identity_context';
-import {
-  autoPlayGif,
-  me,
-  domain as localDomain,
-  isFeatureEnabled,
-} from 'mastodon/initial_state';
+import { autoPlayGif, me, domain as localDomain } from 'mastodon/initial_state';
 import type { Account } from 'mastodon/models/account';
 import type { MenuItem } from 'mastodon/models/dropdown_menu';
 import {
@@ -903,12 +898,7 @@ export const AccountHeader: React.FC<{
                 )}
 
                 <AccountBio
-                  note={
-                    isFeatureEnabled('modern_emojis')
-                      ? account.note
-                      : account.note_emojified
-                  }
-                  dropdownAccountId={accountId}
+                  accountId={accountId}
                   className='account__header__content'
                 />
 

--- a/app/javascript/mastodon/features/emoji/constants.ts
+++ b/app/javascript/mastodon/features/emoji/constants.ts
@@ -15,6 +15,11 @@ export const SKIN_TONE_CODES = [
   0x1f3ff, // Dark skin tone
 ] as const;
 
+// Emoji rendering modes. A mode is what we are using to render emojis, a style is what the user has selected.
+export const EMOJI_MODE_NATIVE = 'native';
+export const EMOJI_MODE_NATIVE_WITH_FLAGS = 'native-flags';
+export const EMOJI_MODE_TWEMOJI = 'twemoji';
+
 export const EMOJIS_WITH_DARK_BORDER = [
   '🎱', // 1F3B1
   '🐜', // 1F41C

--- a/app/javascript/mastodon/features/emoji/constants.ts
+++ b/app/javascript/mastodon/features/emoji/constants.ts
@@ -20,6 +20,12 @@ export const EMOJI_MODE_NATIVE = 'native';
 export const EMOJI_MODE_NATIVE_WITH_FLAGS = 'native-flags';
 export const EMOJI_MODE_TWEMOJI = 'twemoji';
 
+export const EMOJI_TYPE_UNICODE = 'unicode';
+export const EMOJI_TYPE_CUSTOM = 'custom';
+
+export const EMOJI_STATE_LOADING = 'loading';
+export const EMOJI_STATE_MISSING = 'missing';
+
 export const EMOJIS_WITH_DARK_BORDER = [
   '🎱', // 1F3B1
   '🐜', // 1F41C

--- a/app/javascript/mastodon/features/emoji/constants.ts
+++ b/app/javascript/mastodon/features/emoji/constants.ts
@@ -23,7 +23,6 @@ export const EMOJI_MODE_TWEMOJI = 'twemoji';
 export const EMOJI_TYPE_UNICODE = 'unicode';
 export const EMOJI_TYPE_CUSTOM = 'custom';
 
-export const EMOJI_STATE_LOADING = 'loading';
 export const EMOJI_STATE_MISSING = 'missing';
 
 export const EMOJIS_WITH_DARK_BORDER = [

--- a/app/javascript/mastodon/features/emoji/database.ts
+++ b/app/javascript/mastodon/features/emoji/database.ts
@@ -4,12 +4,16 @@ import type { DBSchema } from 'idb';
 import { openDB } from 'idb';
 
 import { toSupportedLocale, toSupportedLocaleOrCustom } from './locale';
-import type { CustomEmoji, UnicodeEmoji, LocaleOrCustom } from './types';
+import type {
+  CustomEmojiData,
+  UnicodeEmojiData,
+  LocaleOrCustom,
+} from './types';
 
 interface EmojiDB extends LocaleTables, DBSchema {
   custom: {
     key: string;
-    value: CustomEmoji;
+    value: CustomEmojiData;
     indexes: {
       category: string;
     };
@@ -22,7 +26,7 @@ interface EmojiDB extends LocaleTables, DBSchema {
 
 interface LocaleTable {
   key: string;
-  value: UnicodeEmoji;
+  value: UnicodeEmojiData;
   indexes: {
     group: number;
     label: string;
@@ -57,13 +61,13 @@ const db = await openDB<EmojiDB>('mastodon-emoji', SCHEMA_VERSION, {
   },
 });
 
-export async function putEmojiData(emojis: UnicodeEmoji[], locale: Locale) {
+export async function putEmojiData(emojis: UnicodeEmojiData[], locale: Locale) {
   const trx = db.transaction(locale, 'readwrite');
   await Promise.all(emojis.map((emoji) => trx.store.put(emoji)));
   await trx.done;
 }
 
-export async function putCustomEmojiData(emojis: CustomEmoji[]) {
+export async function putCustomEmojiData(emojis: CustomEmojiData[]) {
   const trx = db.transaction('custom', 'readwrite');
   await Promise.all(emojis.map((emoji) => trx.store.put(emoji)));
   await trx.done;

--- a/app/javascript/mastodon/features/emoji/database.ts
+++ b/app/javascript/mastodon/features/emoji/database.ts
@@ -83,6 +83,17 @@ export function searchEmojiByHexcode(hexcode: string, localeString: string) {
   return db.get(locale, hexcode);
 }
 
+export function searchEmojisByHexcodes(
+  hexcodes: string[],
+  localeString: string,
+) {
+  const locale = toSupportedLocale(localeString);
+  return db.getAll(
+    locale,
+    IDBKeyRange.bound(hexcodes[0], hexcodes[hexcodes.length - 1]),
+  );
+}
+
 export function searchEmojiByTag(tag: string, localeString: string) {
   const locale = toSupportedLocale(localeString);
   const range = IDBKeyRange.only(tag.toLowerCase());
@@ -91,6 +102,25 @@ export function searchEmojiByTag(tag: string, localeString: string) {
 
 export function searchCustomEmojiByShortcode(shortcode: string) {
   return db.get('custom', shortcode);
+}
+
+export function searchCustomEmojisByShortcodes(shortcodes: string[]) {
+  return db.getAll(
+    'custom',
+    IDBKeyRange.bound(shortcodes[0], shortcodes[shortcodes.length - 1]),
+  );
+}
+
+export async function findMissingLocales(localeStrings: string[]) {
+  const locales = new Set(localeStrings.map(toSupportedLocale));
+  const missingLocales: Locale[] = [];
+  for (const locale of locales) {
+    const rowCount = await db.count(locale);
+    if (!rowCount) {
+      missingLocales.push(locale);
+    }
+  }
+  return missingLocales;
 }
 
 export async function loadLatestEtag(localeString: string) {

--- a/app/javascript/mastodon/features/emoji/database.ts
+++ b/app/javascript/mastodon/features/emoji/database.ts
@@ -1,17 +1,15 @@
 import { SUPPORTED_LOCALES } from 'emojibase';
-import type { FlatCompactEmoji, Locale } from 'emojibase';
+import type { Locale } from 'emojibase';
 import type { DBSchema } from 'idb';
 import { openDB } from 'idb';
 
-import type { ApiCustomEmojiJSON } from '@/mastodon/api_types/custom_emoji';
-
-import type { LocaleOrCustom } from './locale';
 import { toSupportedLocale, toSupportedLocaleOrCustom } from './locale';
+import type { CustomEmoji, UnicodeEmoji, LocaleOrCustom } from './types';
 
 interface EmojiDB extends LocaleTables, DBSchema {
   custom: {
     key: string;
-    value: ApiCustomEmojiJSON;
+    value: CustomEmoji;
     indexes: {
       category: string;
     };
@@ -24,7 +22,7 @@ interface EmojiDB extends LocaleTables, DBSchema {
 
 interface LocaleTable {
   key: string;
-  value: FlatCompactEmoji;
+  value: UnicodeEmoji;
   indexes: {
     group: number;
     label: string;
@@ -59,13 +57,13 @@ const db = await openDB<EmojiDB>('mastodon-emoji', SCHEMA_VERSION, {
   },
 });
 
-export async function putEmojiData(emojis: FlatCompactEmoji[], locale: Locale) {
+export async function putEmojiData(emojis: UnicodeEmoji[], locale: Locale) {
   const trx = db.transaction(locale, 'readwrite');
   await Promise.all(emojis.map((emoji) => trx.store.put(emoji)));
   await trx.done;
 }
 
-export async function putCustomEmojiData(emojis: ApiCustomEmojiJSON[]) {
+export async function putCustomEmojiData(emojis: CustomEmoji[]) {
   const trx = db.transaction('custom', 'readwrite');
   await Promise.all(emojis.map((emoji) => trx.store.put(emoji)));
   await trx.done;

--- a/app/javascript/mastodon/features/emoji/emoji_html.tsx
+++ b/app/javascript/mastodon/features/emoji/emoji_html.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+
+import { isFeatureEnabled } from '@/mastodon/initial_state';
+
+import emojify from './emoji';
+import { useEmojiAppState } from './hooks';
+import { emojifyElement } from './render';
+
+interface EmojiHTMLProps {
+  htmlString: string;
+}
+
+export const EmojiHTML: React.FC<EmojiHTMLProps> = ({ htmlString: text }) => {
+  const appState = useEmojiAppState();
+  const [innerHTML, setInnerHTML] = useState('');
+
+  useEffect(() => {
+    const cb = async () => {
+      const div = document.createElement('div');
+      div.innerHTML = text;
+      const ele = await emojifyElement(div, appState);
+      setInnerHTML(ele.innerHTML);
+    };
+    if (isFeatureEnabled('modern_emojis')) {
+      void cb();
+    } else {
+      setInnerHTML(emojify(text));
+    }
+  }, [text, appState]);
+
+  if (!innerHTML) {
+    return null;
+  }
+
+  return <div dangerouslySetInnerHTML={{ __html: innerHTML }} />;
+};

--- a/app/javascript/mastodon/features/emoji/emoji_html.tsx
+++ b/app/javascript/mastodon/features/emoji/emoji_html.tsx
@@ -5,12 +5,17 @@ import { isFeatureEnabled } from '@/mastodon/initial_state';
 import emojify from './emoji';
 import { useEmojiAppState } from './hooks';
 import { emojifyElement } from './render';
+import type { ExtraCustomEmojiMap } from './types';
 
 interface EmojiHTMLProps {
   htmlString: string;
+  extraEmojis?: ExtraCustomEmojiMap;
 }
 
-export const EmojiHTML: React.FC<EmojiHTMLProps> = ({ htmlString: text }) => {
+export const EmojiHTML: React.FC<EmojiHTMLProps> = ({
+  htmlString: text,
+  extraEmojis = {},
+}) => {
   const appState = useEmojiAppState();
   const [innerHTML, setInnerHTML] = useState('');
 
@@ -18,7 +23,7 @@ export const EmojiHTML: React.FC<EmojiHTMLProps> = ({ htmlString: text }) => {
     const cb = async () => {
       const div = document.createElement('div');
       div.innerHTML = text;
-      const ele = await emojifyElement(div, appState);
+      const ele = await emojifyElement(div, appState, extraEmojis);
       setInnerHTML(ele.innerHTML);
     };
     if (isFeatureEnabled('modern_emojis')) {
@@ -26,7 +31,7 @@ export const EmojiHTML: React.FC<EmojiHTMLProps> = ({ htmlString: text }) => {
     } else {
       setInnerHTML(emojify(text));
     }
-  }, [text, appState]);
+  }, [text, appState, extraEmojis]);
 
   if (!innerHTML) {
     return null;

--- a/app/javascript/mastodon/features/emoji/emoji_html.tsx
+++ b/app/javascript/mastodon/features/emoji/emoji_html.tsx
@@ -1,25 +1,48 @@
-import { useEffect, useState } from 'react';
+import type { HTMLAttributes } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
+import type { List as ImmutableList } from 'immutable';
+import { isList } from 'immutable';
+
+import type { ApiCustomEmojiJSON } from '@/mastodon/api_types/custom_emoji';
 import { isFeatureEnabled } from '@/mastodon/initial_state';
+import type { CustomEmoji } from '@/mastodon/models/custom_emoji';
 
-import emojify from './emoji';
 import { useEmojiAppState } from './hooks';
 import { emojifyElement } from './render';
 import type { ExtraCustomEmojiMap } from './types';
 
 interface EmojiHTMLProps {
   htmlString: string;
-  extraEmojis?: ExtraCustomEmojiMap;
+  extraEmojis?: ExtraCustomEmojiMap | ImmutableList<CustomEmoji>;
 }
 
-export const EmojiHTML: React.FC<EmojiHTMLProps> = ({
-  htmlString: text,
-  extraEmojis = {},
-}) => {
+export const EmojiHTML: React.FC<
+  EmojiHTMLProps &
+    Omit<HTMLAttributes<HTMLDivElement>, 'dangerouslySetInnerHTML'>
+> = ({ extraEmojis: rawEmojis, htmlString: text, ...props }) => {
   const appState = useEmojiAppState();
   const [innerHTML, setInnerHTML] = useState('');
 
+  const extraEmojis: ExtraCustomEmojiMap = useMemo(() => {
+    if (!rawEmojis) {
+      return {};
+    }
+    if (isList(rawEmojis)) {
+      return (
+        rawEmojis.toJS() as ApiCustomEmojiJSON[]
+      ).reduce<ExtraCustomEmojiMap>(
+        (acc, emoji) => ({ ...acc, [emoji.shortcode]: emoji }),
+        {},
+      );
+    }
+    return rawEmojis;
+  }, [rawEmojis]);
+
   useEffect(() => {
+    if (!text) {
+      return;
+    }
     const cb = async () => {
       const div = document.createElement('div');
       div.innerHTML = text;
@@ -29,7 +52,7 @@ export const EmojiHTML: React.FC<EmojiHTMLProps> = ({
     if (isFeatureEnabled('modern_emojis')) {
       void cb();
     } else {
-      setInnerHTML(emojify(text));
+      setInnerHTML(text); // Assume the text is already emojified
     }
   }, [text, appState, extraEmojis]);
 
@@ -37,5 +60,5 @@ export const EmojiHTML: React.FC<EmojiHTMLProps> = ({
     return null;
   }
 
-  return <div dangerouslySetInnerHTML={{ __html: innerHTML }} />;
+  return <div {...props} dangerouslySetInnerHTML={{ __html: innerHTML }} />;
 };

--- a/app/javascript/mastodon/features/emoji/emoji_text.tsx
+++ b/app/javascript/mastodon/features/emoji/emoji_text.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+
+import { useEmojiAppState } from './hooks';
+import { emojifyText } from './render';
+
+interface EmojiTextProps {
+  text: string;
+}
+
+export const EmojiText: React.FC<EmojiTextProps> = ({ text }) => {
+  const appState = useEmojiAppState();
+  const [rendered, setRendered] = useState<(string | HTMLImageElement)[]>([]);
+
+  useEffect(() => {
+    const cb = async () => {
+      const rendered = await emojifyText(text, appState);
+      setRendered(rendered ?? []);
+    };
+    void cb();
+  }, [text, appState]);
+
+  if (rendered.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      {rendered.map((fragment, index) => {
+        if (typeof fragment === 'string') {
+          return <span key={index}>{fragment}</span>;
+        }
+        return (
+          <img
+            key={index}
+            draggable='false'
+            src={fragment.src}
+            alt={fragment.alt}
+            title={fragment.title}
+            className={fragment.className}
+          />
+        );
+      })}
+    </>
+  );
+};

--- a/app/javascript/mastodon/features/emoji/hooks.ts
+++ b/app/javascript/mastodon/features/emoji/hooks.ts
@@ -1,0 +1,16 @@
+import { useAppSelector } from '@/mastodon/store';
+
+import { toSupportedLocale } from './locale';
+import { determineEmojiMode } from './mode';
+import type { EmojiAppState } from './types';
+
+export function useEmojiAppState(): EmojiAppState {
+  const locale = useAppSelector((state) =>
+    toSupportedLocale(state.meta.get('locale') as string),
+  );
+  const mode = useAppSelector((state) =>
+    determineEmojiMode(state.meta.get('emojiStyle') as string),
+  );
+
+  return { currentLocale: locale, locales: [locale], mode };
+}

--- a/app/javascript/mastodon/features/emoji/hooks.ts
+++ b/app/javascript/mastodon/features/emoji/hooks.ts
@@ -9,7 +9,7 @@ export function useEmojiAppState(): EmojiAppState {
     toSupportedLocale(state.meta.get('locale') as string),
   );
   const mode = useAppSelector((state) =>
-    determineEmojiMode(state.meta.get('emojiStyle') as string),
+    determineEmojiMode(state.meta.get('emoji_style') as string),
   );
 
   return { currentLocale: locale, locales: [locale], mode };

--- a/app/javascript/mastodon/features/emoji/loader.ts
+++ b/app/javascript/mastodon/features/emoji/loader.ts
@@ -11,7 +11,7 @@ import {
   putLatestEtag,
 } from './database';
 import { toSupportedLocale, toSupportedLocaleOrCustom } from './locale';
-import type { LocaleOrCustom } from './locale';
+import type { LocaleOrCustom } from './types';
 
 export async function importEmojiData(localeString: string) {
   const locale = toSupportedLocale(localeString);

--- a/app/javascript/mastodon/features/emoji/locale.ts
+++ b/app/javascript/mastodon/features/emoji/locale.ts
@@ -1,7 +1,7 @@
 import type { Locale } from 'emojibase';
 import { SUPPORTED_LOCALES } from 'emojibase';
 
-export type LocaleOrCustom = Locale | 'custom';
+import type { LocaleOrCustom } from './types';
 
 export function toSupportedLocale(localeBase: string): Locale {
   const locale = localeBase.toLowerCase();

--- a/app/javascript/mastodon/features/emoji/mode.ts
+++ b/app/javascript/mastodon/features/emoji/mode.ts
@@ -1,0 +1,119 @@
+// Credit to Nolan Lawson for the original implementation.
+// See: https://github.com/nolanlawson/emoji-picker-element/blob/master/src/picker/utils/testColorEmojiSupported.js
+
+import { isDevelopment } from '@/mastodon/utils/environment';
+
+import {
+  EMOJI_MODE_NATIVE,
+  EMOJI_MODE_NATIVE_WITH_FLAGS,
+  EMOJI_MODE_TWEMOJI,
+} from './constants';
+import type { EmojiMode } from './types';
+
+type Feature = Uint8ClampedArray;
+
+// See: https://github.com/nolanlawson/emoji-picker-element/blob/master/src/picker/constants.js
+const FONT_FAMILY =
+  '"Twemoji Mozilla","Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol",' +
+  '"Noto Color Emoji","EmojiOne Color","Android Emoji",sans-serif';
+
+function getTextFeature(text: string, color: string) {
+  const canvas = document.createElement('canvas');
+  canvas.width = canvas.height = 1;
+
+  const ctx = canvas.getContext('2d', {
+    // Improves the performance of `getImageData()`
+    // https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/getContextAttributes#willreadfrequently
+    willReadFrequently: true,
+  });
+  if (!ctx) {
+    throw new Error('Canvas context not available');
+  }
+  ctx.textBaseline = 'top';
+  ctx.font = `100px ${FONT_FAMILY}`;
+  ctx.fillStyle = color;
+  ctx.scale(0.01, 0.01);
+  ctx.fillText(text, 0, 0);
+
+  return ctx.getImageData(0, 0, 1, 1).data satisfies Feature;
+}
+
+function compareFeatures(feature1: Feature, feature2: Feature) {
+  const feature1Str = [...feature1].join(',');
+  const feature2Str = [...feature2].join(',');
+  // This is RGBA, so for 0,0,0, we are checking that the first RGB is not all zeroes.
+  // Most of the time when unsupported this is 0,0,0,0, but on Chrome on Mac it is
+  // 0,0,0,61 - there is a transparency here.
+  return feature1Str === feature2Str && !feature1Str.startsWith('0,0,0,');
+}
+
+function testEmojiSupport(text: string) {
+  // Render white and black and then compare them to each other and ensure they're the same
+  // color, and neither one is black. This shows that the emoji was rendered in color.
+  const feature1 = getTextFeature(text, '#000');
+  const feature2 = getTextFeature(text, '#fff');
+  return compareFeatures(feature1, feature2);
+}
+
+const EMOJI_VERSION_TEST_EMOJI = '🫨'; // shaking head, from v15
+const EMOJI_FLAG_TEST_EMOJI = '🇨🇭';
+
+export function determineEmojiMode(style: string): EmojiMode {
+  if (style === EMOJI_MODE_NATIVE) {
+    // If flags are not supported, we replace them with Twemoji.
+    if (shouldReplaceFlags()) {
+      return EMOJI_MODE_NATIVE_WITH_FLAGS;
+    }
+    return EMOJI_MODE_NATIVE;
+  }
+  if (style === EMOJI_MODE_TWEMOJI) {
+    return EMOJI_MODE_TWEMOJI;
+  }
+
+  // Auto style so determine based on browser capabilities.
+  if (shouldUseTwemoji()) {
+    return EMOJI_MODE_TWEMOJI;
+  } else if (shouldReplaceFlags()) {
+    return EMOJI_MODE_NATIVE_WITH_FLAGS;
+  }
+  return EMOJI_MODE_NATIVE;
+}
+
+export function shouldUseTwemoji(): boolean {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+  try {
+    // Test a known color emoji to see if 15.1 is supported.
+    return !testEmojiSupport(EMOJI_VERSION_TEST_EMOJI);
+  } catch (err: unknown) {
+    // If an error occurs, fall back to Twemoji to be safe.
+    if (isDevelopment()) {
+      console.warn(
+        'Emoji rendering test failed, defaulting to Twemoji. Error:',
+        err,
+      );
+    }
+    return true;
+  }
+}
+
+// Based on https://github.com/talkjs/country-flag-emoji-polyfill/blob/master/src/index.ts#L19
+export function shouldReplaceFlags(): boolean {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+  try {
+    // Test a known flag emoji to see if it is rendered in color.
+    return !testEmojiSupport(EMOJI_FLAG_TEST_EMOJI);
+  } catch (err: unknown) {
+    // If an error occurs, assume flags should be replaced.
+    if (isDevelopment()) {
+      console.warn(
+        'Flag emoji rendering test failed, defaulting to replacement. Error:',
+        err,
+      );
+    }
+    return true;
+  }
+}

--- a/app/javascript/mastodon/features/emoji/normalize.test.ts
+++ b/app/javascript/mastodon/features/emoji/normalize.test.ts
@@ -22,9 +22,9 @@ const emojiSVGFiles = await readdir(
 );
 const svgFileNames = emojiSVGFiles
   .filter((file) => file.isFile() && file.name.endsWith('.svg'))
-  .map((file) => basename(file.name, '.svg').toUpperCase());
+  .map((file) => basename(file.name, '.svg'));
 const svgFileNamesWithoutBorder = svgFileNames.filter(
-  (fileName) => !fileName.endsWith('_BORDER'),
+  (fileName) => !fileName.endsWith('_border'),
 );
 
 const unicodeEmojis = flattenEmojiData(unicodeRawEmojis);
@@ -60,13 +60,13 @@ describe('unicodeToTwemojiHex', () => {
 describe('twemojiHasBorder', () => {
   test.concurrent.for(
     svgFileNames
-      .filter((file) => file.endsWith('_BORDER'))
+      .filter((file) => file.endsWith('_border'))
       .map((file) => {
-        const hexCode = file.replace('_BORDER', '');
+        const hexCode = file.replace('_border', '');
         return [
           hexCode,
-          CODES_WITH_LIGHT_BORDER.includes(hexCode),
-          CODES_WITH_DARK_BORDER.includes(hexCode),
+          CODES_WITH_LIGHT_BORDER.includes(hexCode.toUpperCase()),
+          CODES_WITH_DARK_BORDER.includes(hexCode.toUpperCase()),
         ] as const;
       }),
   )('twemojiHasBorder for %s', ([hexCode, isLight, isDark], { expect }) => {

--- a/app/javascript/mastodon/features/emoji/normalize.ts
+++ b/app/javascript/mastodon/features/emoji/normalize.ts
@@ -52,7 +52,7 @@ export function unicodeToTwemojiHex(unicodeHex: string): string {
     normalizedCodes.push(code);
   }
 
-  return hexNumbersToString(normalizedCodes, 0);
+  return hexNumbersToString(normalizedCodes, 0).toLowerCase();
 }
 
 export const CODES_WITH_DARK_BORDER =
@@ -72,7 +72,7 @@ export function twemojiHasBorder(twemojiHex: string): TwemojiBorderInfo {
     hasDarkBorder = true;
   }
   return {
-    hexCode: normalizedHex,
+    hexCode: twemojiHex,
     hasLightBorder,
     hasDarkBorder,
   };

--- a/app/javascript/mastodon/features/emoji/normalize.ts
+++ b/app/javascript/mastodon/features/emoji/normalize.ts
@@ -7,6 +7,7 @@ import {
   EMOJIS_WITH_DARK_BORDER,
   EMOJIS_WITH_LIGHT_BORDER,
 } from './constants';
+import type { TwemojiBorderInfo } from './types';
 
 // Misc codes that have special handling
 const SKIER_CODE = 0x26f7;
@@ -52,12 +53,6 @@ export function unicodeToTwemojiHex(unicodeHex: string): string {
   }
 
   return hexNumbersToString(normalizedCodes, 0);
-}
-
-interface TwemojiBorderInfo {
-  hexCode: string;
-  hasLightBorder: boolean;
-  hasDarkBorder: boolean;
 }
 
 export const CODES_WITH_DARK_BORDER =

--- a/app/javascript/mastodon/features/emoji/render.test.ts
+++ b/app/javascript/mastodon/features/emoji/render.test.ts
@@ -47,8 +47,12 @@ describe('emojifyElement', () => {
   const testElement = document.createElement('div');
   testElement.innerHTML = '<p>Hello 😊🇪🇺!</p><p>:custom:</p>';
 
+  function cloneTestElement() {
+    return testElement.cloneNode(true) as HTMLElement;
+  }
+
   test('emojifies custom emoji in native mode', async () => {
-    const emojifiedElement = await emojifyElement(testElement, {
+    const emojifiedElement = await emojifyElement(cloneTestElement(), {
       locales: ['en'],
       mode: EMOJI_MODE_NATIVE,
       currentLocale: 'en',
@@ -60,7 +64,7 @@ describe('emojifyElement', () => {
   });
 
   test('emojifies flag emoji in native-with-flags mode', async () => {
-    const emojifiedElement = await emojifyElement(testElement, {
+    const emojifiedElement = await emojifyElement(cloneTestElement(), {
       locales: ['en'],
       mode: EMOJI_MODE_NATIVE_WITH_FLAGS,
       currentLocale: 'en',
@@ -72,7 +76,7 @@ describe('emojifyElement', () => {
   });
 
   test('emojifies everything in twemoji mode', async () => {
-    const emojifiedElement = await emojifyElement(testElement, {
+    const emojifiedElement = await emojifyElement(cloneTestElement(), {
       locales: ['en'],
       mode: EMOJI_MODE_TWEMOJI,
       currentLocale: 'en',

--- a/app/javascript/mastodon/features/emoji/render.test.ts
+++ b/app/javascript/mastodon/features/emoji/render.test.ts
@@ -1,31 +1,44 @@
-import { EMOJI_MODE_NATIVE, EMOJI_MODE_NATIVE_WITH_FLAGS } from './constants';
+import {
+  EMOJI_MODE_NATIVE,
+  EMOJI_MODE_NATIVE_WITH_FLAGS,
+  EMOJI_MODE_TWEMOJI,
+} from './constants';
 import { emojifyElement, tokenizeText } from './render';
 
 describe('emojifyElement', () => {
   const testElement = document.createElement('div');
   testElement.innerHTML = '<p>Hello 😊🇪🇺!</p><p>:custom:</p>';
 
-  test('emojifies custom emoji in native mode', () => {
-    const emojifiedElement = emojifyElement(testElement, EMOJI_MODE_NATIVE);
+  test('emojifies custom emoji in native mode', async () => {
+    const emojifiedElement = await emojifyElement(testElement, {
+      locales: ['en'],
+      mode: EMOJI_MODE_NATIVE,
+      currentLocale: 'en',
+    });
     expect(emojifiedElement.innerHTML).toBe(
       '<p>Hello 😊🇪🇺!</p>' +
         '<p><img draggable="false" class="emojione custom-emoji" alt=":custom:" title=":custom:"></p>',
     );
   });
 
-  test('emojifies flag emoji in native-with-flags mode', () => {
-    const emojifiedElement = emojifyElement(
-      testElement,
-      EMOJI_MODE_NATIVE_WITH_FLAGS,
-    );
+  test('emojifies flag emoji in native-with-flags mode', async () => {
+    const emojifiedElement = await emojifyElement(testElement, {
+      locales: ['en'],
+      mode: EMOJI_MODE_NATIVE_WITH_FLAGS,
+      currentLocale: 'en',
+    });
     expect(emojifiedElement.innerHTML).toBe(
       '<p>Hello 😊<img draggable="false" class="emojione" alt="🇪🇺" data-code="1F1EA-1F1FA">!</p>' +
         '<p><img draggable="false" class="emojione custom-emoji" alt=":custom:" title=":custom:"></p>',
     );
   });
 
-  test('emojifies everything in twemoji mode', () => {
-    const emojifiedElement = emojifyElement(testElement, 'twemoji');
+  test('emojifies everything in twemoji mode', async () => {
+    const emojifiedElement = await emojifyElement(testElement, {
+      locales: ['en'],
+      mode: EMOJI_MODE_TWEMOJI,
+      currentLocale: 'en',
+    });
     expect(emojifiedElement.innerHTML).toBe(
       '<p>Hello <img draggable="false" class="emojione" alt="😊" data-code="1F60A">' +
         '<img draggable="false" class="emojione" alt="🇪🇺" data-code="1F1EA-1F1FA">!</p>' +

--- a/app/javascript/mastodon/features/emoji/render.test.ts
+++ b/app/javascript/mastodon/features/emoji/render.test.ts
@@ -1,0 +1,105 @@
+import { EMOJI_MODE_NATIVE, EMOJI_MODE_NATIVE_WITH_FLAGS } from './constants';
+import { emojifyElement, tokenizeText } from './render';
+
+describe('emojifyElement', () => {
+  const testElement = document.createElement('div');
+  testElement.innerHTML = '<p>Hello 😊🇪🇺!</p><p>:custom:</p>';
+
+  test('emojifies custom emoji in native mode', () => {
+    const emojifiedElement = emojifyElement(testElement, EMOJI_MODE_NATIVE);
+    expect(emojifiedElement.innerHTML).toBe(
+      '<p>Hello 😊🇪🇺!</p>' +
+        '<p><img draggable="false" class="emojione custom-emoji" alt=":custom:" title=":custom:"></p>',
+    );
+  });
+
+  test('emojifies flag emoji in native-with-flags mode', () => {
+    const emojifiedElement = emojifyElement(
+      testElement,
+      EMOJI_MODE_NATIVE_WITH_FLAGS,
+    );
+    expect(emojifiedElement.innerHTML).toBe(
+      '<p>Hello 😊<img draggable="false" class="emojione" alt="🇪🇺" data-code="1F1EA-1F1FA">!</p>' +
+        '<p><img draggable="false" class="emojione custom-emoji" alt=":custom:" title=":custom:"></p>',
+    );
+  });
+
+  test('emojifies everything in twemoji mode', () => {
+    const emojifiedElement = emojifyElement(testElement, 'twemoji');
+    expect(emojifiedElement.innerHTML).toBe(
+      '<p>Hello <img draggable="false" class="emojione" alt="😊" data-code="1F60A">' +
+        '<img draggable="false" class="emojione" alt="🇪🇺" data-code="1F1EA-1F1FA">!</p>' +
+        '<p><img draggable="false" class="emojione custom-emoji" alt=":custom:" title=":custom:"></p>',
+    );
+  });
+});
+
+describe('tokenizeText', () => {
+  test('returns empty array for string with only whitespace', () => {
+    expect(tokenizeText('   \n')).toEqual([]);
+  });
+
+  test('returns an array of text to be a single token', () => {
+    expect(tokenizeText('Hello')).toEqual(['Hello']);
+  });
+
+  test('returns tokens for text with emoji', () => {
+    expect(tokenizeText('Hello 😊 🇿🇼!!')).toEqual([
+      'Hello ',
+      {
+        type: 'unicode',
+        code: '😊',
+      },
+      ' ',
+      {
+        type: 'unicode',
+        code: '🇿🇼',
+      },
+      '!!',
+    ]);
+  });
+
+  test('returns tokens for text with custom emoji', () => {
+    expect(tokenizeText('Hello :smile:!!')).toEqual([
+      'Hello ',
+      {
+        type: 'custom',
+        code: 'smile',
+      },
+      '!!',
+    ]);
+  });
+
+  test('handles custom emoji with underscores and numbers', () => {
+    expect(tokenizeText('Hello :smile_123:!!')).toEqual([
+      'Hello ',
+      {
+        type: 'custom',
+        code: 'smile_123',
+      },
+      '!!',
+    ]);
+  });
+
+  test('returns tokens for text with mixed emoji', () => {
+    expect(tokenizeText('Hello 😊 :smile:!!')).toEqual([
+      'Hello ',
+      {
+        type: 'unicode',
+        code: '😊',
+      },
+      ' ',
+      {
+        type: 'custom',
+        code: 'smile',
+      },
+      '!!',
+    ]);
+  });
+
+  test('does not capture custom emoji with invalid characters', () => {
+    expect(tokenizeText('Hello :smile-123:!!')).toEqual([
+      'Hello :smile-123:!!',
+    ]);
+  });
+});

--- a/app/javascript/mastodon/features/emoji/render.test.ts
+++ b/app/javascript/mastodon/features/emoji/render.test.ts
@@ -48,9 +48,9 @@ describe('emojifyElement', () => {
   testElement.innerHTML = '<p>Hello 😊🇪🇺!</p><p>:custom:</p>';
 
   const expectedSmileImage =
-    '<img draggable="false" class="emojione" alt="😊" title="smiling face with smiling eyes" src="/emoji/1F60A.svg">';
+    '<img draggable="false" class="emojione" alt="😊" title="smiling face with smiling eyes" src="/emoji/1f60a.svg">';
   const expectedFlagImage =
-    '<img draggable="false" class="emojione" alt="🇪🇺" title="flag-eu" src="/emoji/1F1EA-1F1FA.svg">';
+    '<img draggable="false" class="emojione" alt="🇪🇺" title="flag-eu" src="/emoji/1f1ea-1f1fa.svg">';
   const expectedCustomEmojiImage =
     '<img draggable="false" class="emojione custom-emoji" alt=":custom:" title=":custom:" src="emoji/static" data-original="emoji/custom" data-static="emoji/static">';
 

--- a/app/javascript/mastodon/features/emoji/render.test.ts
+++ b/app/javascript/mastodon/features/emoji/render.test.ts
@@ -4,6 +4,44 @@ import {
   EMOJI_MODE_TWEMOJI,
 } from './constants';
 import { emojifyElement, tokenizeText } from './render';
+import type { CustomEmojiData, UnicodeEmojiData } from './types';
+
+vitest.mock('./database', () => ({
+  searchCustomEmojisByShortcodes: vitest.fn(
+    () =>
+      [
+        {
+          shortcode: 'custom',
+          static_url: 'emoji/static',
+          url: 'emoji/custom',
+          category: 'test',
+          visible_in_picker: true,
+        },
+      ] satisfies CustomEmojiData[],
+  ),
+  searchEmojisByHexcodes: vitest.fn(
+    () =>
+      [
+        {
+          hexcode: '1F60A',
+          group: 0,
+          label: 'smiling face with smiling eyes',
+          order: 0,
+          tags: ['smile', 'happy'],
+          unicode: '😊',
+        },
+        {
+          hexcode: '1F1EA-1F1FA',
+          group: 0,
+          label: 'flag-eu',
+          order: 0,
+          tags: ['flag', 'european union'],
+          unicode: '🇪🇺',
+        },
+      ] satisfies UnicodeEmojiData[],
+  ),
+  findMissingLocales: vitest.fn(() => []),
+}));
 
 describe('emojifyElement', () => {
   const testElement = document.createElement('div');
@@ -17,7 +55,7 @@ describe('emojifyElement', () => {
     });
     expect(emojifiedElement.innerHTML).toBe(
       '<p>Hello 😊🇪🇺!</p>' +
-        '<p><img draggable="false" class="emojione custom-emoji" alt=":custom:" title=":custom:"></p>',
+        '<p><img draggable="false" class="emojione custom-emoji" alt=":custom:" title=":custom:" src="emoji/static"></p>',
     );
   });
 
@@ -28,8 +66,8 @@ describe('emojifyElement', () => {
       currentLocale: 'en',
     });
     expect(emojifiedElement.innerHTML).toBe(
-      '<p>Hello 😊<img draggable="false" class="emojione" alt="🇪🇺" data-code="1F1EA-1F1FA">!</p>' +
-        '<p><img draggable="false" class="emojione custom-emoji" alt=":custom:" title=":custom:"></p>',
+      '<p>Hello 😊<img draggable="false" class="emojione" alt="🇪🇺" title="flag-eu" src="/emoji/1F1EA-1F1FA.svg">!</p>' +
+        '<p><img draggable="false" class="emojione custom-emoji" alt=":custom:" title=":custom:" src="emoji/static"></p>',
     );
   });
 
@@ -40,9 +78,9 @@ describe('emojifyElement', () => {
       currentLocale: 'en',
     });
     expect(emojifiedElement.innerHTML).toBe(
-      '<p>Hello <img draggable="false" class="emojione" alt="😊" data-code="1F60A">' +
-        '<img draggable="false" class="emojione" alt="🇪🇺" data-code="1F1EA-1F1FA">!</p>' +
-        '<p><img draggable="false" class="emojione custom-emoji" alt=":custom:" title=":custom:"></p>',
+      '<p>Hello <img draggable="false" class="emojione" alt="😊" title="smiling face with smiling eyes" src="/emoji/1F60A.svg">' +
+        '<img draggable="false" class="emojione" alt="🇪🇺" title="flag-eu" src="/emoji/1F1EA-1F1FA.svg">!</p>' +
+        '<p><img draggable="false" class="emojione custom-emoji" alt=":custom:" title=":custom:" src="emoji/static"></p>',
     );
   });
 });

--- a/app/javascript/mastodon/features/emoji/render.test.ts
+++ b/app/javascript/mastodon/features/emoji/render.test.ts
@@ -47,6 +47,13 @@ describe('emojifyElement', () => {
   const testElement = document.createElement('div');
   testElement.innerHTML = '<p>Hello 😊🇪🇺!</p><p>:custom:</p>';
 
+  const expectedSmileImage =
+    '<img draggable="false" class="emojione" alt="😊" title="smiling face with smiling eyes" src="/emoji/1F60A.svg">';
+  const expectedFlagImage =
+    '<img draggable="false" class="emojione" alt="🇪🇺" title="flag-eu" src="/emoji/1F1EA-1F1FA.svg">';
+  const expectedCustomEmojiImage =
+    '<img draggable="false" class="emojione custom-emoji" alt=":custom:" title=":custom:" src="emoji/static" data-original="emoji/custom" data-static="emoji/static">';
+
   function cloneTestElement() {
     return testElement.cloneNode(true) as HTMLElement;
   }
@@ -58,8 +65,7 @@ describe('emojifyElement', () => {
       currentLocale: 'en',
     });
     expect(emojifiedElement.innerHTML).toBe(
-      '<p>Hello 😊🇪🇺!</p>' +
-        '<p><img draggable="false" class="emojione custom-emoji" alt=":custom:" title=":custom:" src="emoji/static"></p>',
+      `<p>Hello 😊🇪🇺!</p><p>${expectedCustomEmojiImage}</p>`,
     );
   });
 
@@ -70,8 +76,7 @@ describe('emojifyElement', () => {
       currentLocale: 'en',
     });
     expect(emojifiedElement.innerHTML).toBe(
-      '<p>Hello 😊<img draggable="false" class="emojione" alt="🇪🇺" title="flag-eu" src="/emoji/1F1EA-1F1FA.svg">!</p>' +
-        '<p><img draggable="false" class="emojione custom-emoji" alt=":custom:" title=":custom:" src="emoji/static"></p>',
+      `<p>Hello 😊${expectedFlagImage}!</p><p>${expectedCustomEmojiImage}</p>`,
     );
   });
 
@@ -82,9 +87,7 @@ describe('emojifyElement', () => {
       currentLocale: 'en',
     });
     expect(emojifiedElement.innerHTML).toBe(
-      '<p>Hello <img draggable="false" class="emojione" alt="😊" title="smiling face with smiling eyes" src="/emoji/1F60A.svg">' +
-        '<img draggable="false" class="emojione" alt="🇪🇺" title="flag-eu" src="/emoji/1F1EA-1F1FA.svg">!</p>' +
-        '<p><img draggable="false" class="emojione custom-emoji" alt=":custom:" title=":custom:" src="emoji/static"></p>',
+      `<p>Hello ${expectedSmileImage}${expectedFlagImage}!</p><p>${expectedCustomEmojiImage}</p>`,
     );
   });
 });

--- a/app/javascript/mastodon/features/emoji/render.ts
+++ b/app/javascript/mastodon/features/emoji/render.ts
@@ -1,0 +1,166 @@
+import EMOJI_REGEX from 'emojibase-regex/emoji-loose';
+
+import { EMOJI_MODE_NATIVE, EMOJI_MODE_NATIVE_WITH_FLAGS } from './constants';
+import {
+  emojiToUnicodeHex,
+  twemojiHasBorder,
+  unicodeToTwemojiHex,
+} from './normalize';
+import type {
+  CustomEmojiToken,
+  EmojiMode,
+  EmojiToken,
+  UnicodeEmojiToken,
+} from './types';
+import { stringHasUnicodeFlags } from './utils';
+
+// Emojifies an element. This modifies the element in place, replacing text nodes with emojified versions.
+export function emojifyElement<Element extends HTMLElement>(
+  element: Element,
+  mode: EmojiMode,
+): Element {
+  const elementCopy = element.cloneNode(true) as Element;
+  const queue: (HTMLElement | Text)[] = [elementCopy];
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (
+      !current ||
+      current instanceof HTMLScriptElement ||
+      current instanceof HTMLStyleElement
+    ) {
+      continue;
+    }
+
+    if (current instanceof Text && current.textContent) {
+      const emojifiedNode = emojifyText(current.textContent, mode);
+      if (emojifiedNode) {
+        current.replaceWith(emojifiedNode);
+      }
+      continue; // Text nodes cannot have children.
+    } else if (current.textContent && !current.hasChildNodes()) {
+      const emojifiedText = emojifyText(current.textContent, mode);
+      if (emojifiedText) {
+        current.textContent = null;
+        current.appendChild(emojifiedText);
+      }
+      continue;
+    }
+
+    for (const child of current.childNodes) {
+      if (child instanceof HTMLElement || child instanceof Text) {
+        queue.push(child);
+      }
+    }
+  }
+  return elementCopy;
+}
+
+const CUSTOM_EMOJI_REGEX = /:([a-z0-9_]+):/i;
+const TOKENIZE_REGEX = new RegExp(
+  `(${EMOJI_REGEX.source}|${CUSTOM_EMOJI_REGEX.source})`,
+  'g',
+);
+
+type TokenizedText = (string | CustomEmojiToken | UnicodeEmojiToken)[];
+
+export function tokenizeText(text: string): TokenizedText {
+  if (!text.trim()) {
+    return [];
+  }
+
+  const tokens = [];
+  let lastIndex = 0;
+  for (const match of text.matchAll(TOKENIZE_REGEX)) {
+    if (match.index > lastIndex) {
+      tokens.push(text.slice(lastIndex, match.index));
+    }
+
+    if (match[0].startsWith(':') && match[0].endsWith(':')) {
+      // Custom emoji
+      tokens.push({
+        type: 'custom',
+        code: match[0].slice(1, -1),
+      } satisfies CustomEmojiToken);
+    } else {
+      // Unicode emoji
+      tokens.push({
+        type: 'unicode',
+        code: match[0],
+      } satisfies UnicodeEmojiToken);
+    }
+    lastIndex = match.index + match[0].length;
+  }
+  if (lastIndex < text.length) {
+    tokens.push(text.slice(lastIndex));
+  }
+  return tokens;
+}
+
+export function tokenToElement(
+  token: EmojiToken,
+  mode: EmojiMode,
+): HTMLImageElement | null {
+  const image = document.createElement('img');
+  image.draggable = false;
+  image.classList.add('emojione');
+  image.alt = token.code;
+  if (token.type === 'unicode') {
+    // If the mode is native or native with flags for non-flag emoji
+    // we can just append the text node directly.
+    if (
+      mode === EMOJI_MODE_NATIVE ||
+      (mode === EMOJI_MODE_NATIVE_WITH_FLAGS &&
+        !stringHasUnicodeFlags(token.code))
+    ) {
+      return null; // No need to create an image for native emoji.
+    }
+    const emojiInfo = twemojiHasBorder(
+      unicodeToTwemojiHex(emojiToUnicodeHex(token.code)),
+    );
+    image.dataset.code = emojiInfo.hexCode;
+    if (emojiInfo.hasLightBorder) {
+      image.dataset.lightCode = `${emojiInfo.hexCode}_BORDER`;
+    } else if (emojiInfo.hasDarkBorder) {
+      image.dataset.darkCode = `${emojiInfo.hexCode}_BORDER`;
+    }
+  } else {
+    // Custom emoji
+    const shortCode = `:${token.code}:`;
+    image.classList.add('custom-emoji');
+    image.alt = shortCode;
+    image.title = shortCode;
+  }
+
+  return image;
+}
+
+function emojifyText(text: string, mode: EmojiMode) {
+  // Exit if no text to convert.
+  if (!text.trim()) {
+    return null;
+  }
+
+  const tokens = tokenizeText(text);
+
+  // If only one token and it's a string, exit early.
+  if (tokens.length === 1 && typeof tokens[0] === 'string') {
+    return null;
+  }
+  const fragment = document.createDocumentFragment();
+  for (const token of tokens) {
+    if (typeof token === 'string') {
+      fragment.appendChild(document.createTextNode(token));
+      continue;
+    }
+
+    const image = tokenToElement(token, mode);
+    if (image) {
+      fragment.appendChild(image);
+    } else {
+      // If there is no image, it means we should just use native rendering.
+      fragment.appendChild(document.createTextNode(token.code));
+    }
+  }
+
+  return fragment;
+}

--- a/app/javascript/mastodon/features/emoji/types.ts
+++ b/app/javascript/mastodon/features/emoji/types.ts
@@ -6,6 +6,10 @@ import type {
   EMOJI_MODE_NATIVE,
   EMOJI_MODE_NATIVE_WITH_FLAGS,
   EMOJI_MODE_TWEMOJI,
+  EMOJI_STATE_LOADING,
+  EMOJI_STATE_MISSING,
+  EMOJI_TYPE_CUSTOM,
+  EMOJI_TYPE_UNICODE,
 } from './constants';
 
 export type EmojiMode =
@@ -13,44 +17,49 @@ export type EmojiMode =
   | typeof EMOJI_MODE_NATIVE_WITH_FLAGS
   | typeof EMOJI_MODE_TWEMOJI;
 
-export type LocaleOrCustom = Locale | 'custom';
+export type LocaleOrCustom = Locale | typeof EMOJI_TYPE_CUSTOM;
+
+export interface EmojiAppState {
+  locales: Locale[];
+  currentLocale: Locale;
+  mode: EmojiMode;
+}
+
+export interface UnicodeEmojiToken {
+  type: typeof EMOJI_TYPE_UNICODE;
+  code: string;
+}
+export interface CustomEmojiToken {
+  type: typeof EMOJI_TYPE_CUSTOM;
+  code: string;
+}
+export type EmojiToken = UnicodeEmojiToken | CustomEmojiToken;
 
 export type CustomEmojiData = ApiCustomEmojiJSON;
 export type UnicodeEmojiData = FlatCompactEmoji;
 export type AnyEmojiData = CustomEmojiData | UnicodeEmojiData;
 
-export interface CustomEmojiToken {
-  type: 'custom';
-  code: string;
+export type EmojiStateLoading = typeof EMOJI_STATE_LOADING;
+export type EmojiStateMissing = typeof EMOJI_STATE_MISSING;
+export interface EmojiStateUnicode {
+  type: typeof EMOJI_TYPE_UNICODE;
+  data: UnicodeEmojiData;
 }
-export interface UnicodeEmojiToken {
-  type: 'unicode';
-  code: string;
+export interface EmojiStateCustom {
+  type: typeof EMOJI_TYPE_CUSTOM;
+  data: CustomEmojiData;
 }
-export type EmojiToken = CustomEmojiToken | UnicodeEmojiToken;
+export type EmojiState =
+  | EmojiStateLoading
+  | EmojiStateMissing
+  | EmojiStateUnicode
+  | EmojiStateCustom;
+export type EmojiLoadedState = EmojiStateUnicode | EmojiStateCustom;
+
+export type EmojiStateMap = Map<string, EmojiState>;
 
 export interface TwemojiBorderInfo {
   hexCode: string;
   hasLightBorder: boolean;
   hasDarkBorder: boolean;
-}
-
-// Type Guards
-
-export function isUnicodeEmojiData(data: unknown): data is UnicodeEmojiData {
-  return (
-    typeof data === 'object' &&
-    !!data &&
-    'hexcode' in data &&
-    typeof data.hexcode === 'string'
-  );
-}
-
-export function isCustomEmojiData(data: unknown): data is CustomEmojiData {
-  return (
-    typeof data === 'object' &&
-    !!data &&
-    'static_url' in data &&
-    typeof data.static_url === 'string'
-  );
 }

--- a/app/javascript/mastodon/features/emoji/types.ts
+++ b/app/javascript/mastodon/features/emoji/types.ts
@@ -15,9 +15,9 @@ export type EmojiMode =
 
 export type LocaleOrCustom = Locale | 'custom';
 
-export type CustomEmoji = ApiCustomEmojiJSON;
-export type UnicodeEmoji = FlatCompactEmoji;
-export type AnyEmoji = CustomEmoji | UnicodeEmoji;
+export type CustomEmojiData = ApiCustomEmojiJSON;
+export type UnicodeEmojiData = FlatCompactEmoji;
+export type AnyEmojiData = CustomEmojiData | UnicodeEmojiData;
 
 export interface CustomEmojiToken {
   type: 'custom';
@@ -33,4 +33,24 @@ export interface TwemojiBorderInfo {
   hexCode: string;
   hasLightBorder: boolean;
   hasDarkBorder: boolean;
+}
+
+// Type Guards
+
+export function isUnicodeEmojiData(data: unknown): data is UnicodeEmojiData {
+  return (
+    typeof data === 'object' &&
+    !!data &&
+    'hexcode' in data &&
+    typeof data.hexcode === 'string'
+  );
+}
+
+export function isCustomEmojiData(data: unknown): data is CustomEmojiData {
+  return (
+    typeof data === 'object' &&
+    !!data &&
+    'static_url' in data &&
+    typeof data.static_url === 'string'
+  );
 }

--- a/app/javascript/mastodon/features/emoji/types.ts
+++ b/app/javascript/mastodon/features/emoji/types.ts
@@ -1,3 +1,7 @@
+import type { FlatCompactEmoji, Locale } from 'emojibase';
+
+import type { ApiCustomEmojiJSON } from '@/mastodon/api_types/custom_emoji';
+
 import type {
   EMOJI_MODE_NATIVE,
   EMOJI_MODE_NATIVE_WITH_FLAGS,
@@ -8,3 +12,25 @@ export type EmojiMode =
   | typeof EMOJI_MODE_NATIVE
   | typeof EMOJI_MODE_NATIVE_WITH_FLAGS
   | typeof EMOJI_MODE_TWEMOJI;
+
+export type LocaleOrCustom = Locale | 'custom';
+
+export type CustomEmoji = ApiCustomEmojiJSON;
+export type UnicodeEmoji = FlatCompactEmoji;
+export type AnyEmoji = CustomEmoji | UnicodeEmoji;
+
+export interface CustomEmojiToken {
+  type: 'custom';
+  code: string;
+}
+export interface UnicodeEmojiToken {
+  type: 'unicode';
+  code: string;
+}
+export type EmojiToken = CustomEmojiToken | UnicodeEmojiToken;
+
+export interface TwemojiBorderInfo {
+  hexCode: string;
+  hasLightBorder: boolean;
+  hasDarkBorder: boolean;
+}

--- a/app/javascript/mastodon/features/emoji/types.ts
+++ b/app/javascript/mastodon/features/emoji/types.ts
@@ -6,7 +6,6 @@ import type {
   EMOJI_MODE_NATIVE,
   EMOJI_MODE_NATIVE_WITH_FLAGS,
   EMOJI_MODE_TWEMOJI,
-  EMOJI_STATE_LOADING,
   EMOJI_STATE_MISSING,
   EMOJI_TYPE_CUSTOM,
   EMOJI_TYPE_UNICODE,
@@ -39,7 +38,6 @@ export type CustomEmojiData = ApiCustomEmojiJSON;
 export type UnicodeEmojiData = FlatCompactEmoji;
 export type AnyEmojiData = CustomEmojiData | UnicodeEmojiData;
 
-export type EmojiStateLoading = typeof EMOJI_STATE_LOADING;
 export type EmojiStateMissing = typeof EMOJI_STATE_MISSING;
 export interface EmojiStateUnicode {
   type: typeof EMOJI_TYPE_UNICODE;
@@ -50,7 +48,6 @@ export interface EmojiStateCustom {
   data: CustomEmojiData;
 }
 export type EmojiState =
-  | EmojiStateLoading
   | EmojiStateMissing
   | EmojiStateUnicode
   | EmojiStateCustom;

--- a/app/javascript/mastodon/features/emoji/types.ts
+++ b/app/javascript/mastodon/features/emoji/types.ts
@@ -55,6 +55,8 @@ export type EmojiLoadedState = EmojiStateUnicode | EmojiStateCustom;
 
 export type EmojiStateMap = Map<string, EmojiState>;
 
+export type ExtraCustomEmojiMap = Record<string, ApiCustomEmojiJSON>;
+
 export interface TwemojiBorderInfo {
   hexCode: string;
   hasLightBorder: boolean;

--- a/app/javascript/mastodon/features/emoji/types.ts
+++ b/app/javascript/mastodon/features/emoji/types.ts
@@ -1,0 +1,10 @@
+import type {
+  EMOJI_MODE_NATIVE,
+  EMOJI_MODE_NATIVE_WITH_FLAGS,
+  EMOJI_MODE_TWEMOJI,
+} from './constants';
+
+export type EmojiMode =
+  | typeof EMOJI_MODE_NATIVE
+  | typeof EMOJI_MODE_NATIVE_WITH_FLAGS
+  | typeof EMOJI_MODE_TWEMOJI;

--- a/app/javascript/mastodon/features/emoji/utils.test.ts
+++ b/app/javascript/mastodon/features/emoji/utils.test.ts
@@ -1,4 +1,4 @@
-import { stringHasEmoji, stringHasFlags } from './utils';
+import { stringHasUnicodeEmoji, stringHasUnicodeFlags } from './utils';
 
 describe('stringHasEmoji', () => {
   test.concurrent.for([
@@ -21,7 +21,7 @@ describe('stringHasEmoji', () => {
   ] as const)(
     'stringHasEmoji has emojis in "%s": %o',
     ([text, expected], { expect }) => {
-      expect(stringHasEmoji(text)).toBe(expected);
+      expect(stringHasUnicodeEmoji(text)).toBe(expected);
     },
   );
 });
@@ -41,7 +41,7 @@ describe('stringHasFlags', () => {
   ] as const)(
     'stringHasFlags has flag in "%s": %o',
     ([text, expected], { expect }) => {
-      expect(stringHasFlags(text)).toBe(expected);
+      expect(stringHasUnicodeFlags(text)).toBe(expected);
     },
   );
 });

--- a/app/javascript/mastodon/features/emoji/utils.test.ts
+++ b/app/javascript/mastodon/features/emoji/utils.test.ts
@@ -1,0 +1,47 @@
+import { stringHasEmoji, stringHasFlags } from './utils';
+
+describe('stringHasEmoji', () => {
+  test.concurrent.for([
+    ['only text', false],
+    ['text with emoji 😀', true],
+    ['multiple emojis 😀😃😄', true],
+    ['emoji with skin tone 👍🏽', true],
+    ['emoji with ZWJ 👩‍❤️‍👨', true],
+    ['emoji with variation selector ✊️', true],
+    ['emoji with keycap 1️⃣', true],
+    ['emoji with flags 🇺🇸', true],
+    ['emoji with regional indicators 🇦🇺', true],
+    ['emoji with gender 👩‍⚕️', true],
+    ['emoji with family 👨‍👩‍👧‍👦', true],
+    ['emoji with zero width joiner 👩‍🔬', true],
+    ['emoji with non-BMP codepoint 🧑‍🚀', true],
+    ['emoji with combining marks 👨‍👩‍👧‍👦', true],
+    ['emoji with enclosing keycap #️⃣', true],
+    ['emoji with no visible glyph \u200D', false],
+  ] as const)(
+    'stringHasEmoji has emojis in "%s": %o',
+    ([text, expected], { expect }) => {
+      expect(stringHasEmoji(text)).toBe(expected);
+    },
+  );
+});
+
+describe('stringHasFlags', () => {
+  test.concurrent.for([
+    ['EU 🇪🇺', true],
+    ['Germany 🇩🇪', true],
+    ['Canada 🇨🇦', true],
+    ['São Tomé & Príncipe 🇸🇹', true],
+    ['Scotland 🏴󠁧󠁢󠁳󠁣󠁴󠁿', true],
+    ['black flag 🏴', false],
+    ['arrr 🏴‍☠️', false],
+    ['rainbow flag 🏳️‍🌈', false],
+    ['non-flag 🔥', false],
+    ['only text', false],
+  ] as const)(
+    'stringHasFlags has flag in "%s": %o',
+    ([text, expected], { expect }) => {
+      expect(stringHasFlags(text)).toBe(expected);
+    },
+  );
+});

--- a/app/javascript/mastodon/features/emoji/utils.ts
+++ b/app/javascript/mastodon/features/emoji/utils.ts
@@ -1,6 +1,6 @@
 import EMOJI_REGEX from 'emojibase-regex/emoji-loose';
 
-export function stringHasEmoji(text: string): boolean {
+export function stringHasUnicodeEmoji(text: string): boolean {
   return EMOJI_REGEX.test(text);
 }
 
@@ -8,6 +8,6 @@ export function stringHasEmoji(text: string): boolean {
 const EMOJIS_FLAGS_REGEX =
   /[\u{1F1E6}-\u{1F1FF}|\u{E0062}-\u{E0063}|\u{E0065}|\u{E0067}|\u{E006C}|\u{E006E}|\u{E0073}-\u{E0074}|\u{E0077}|\u{E007F}]+/u;
 
-export function stringHasFlags(text: string): boolean {
+export function stringHasUnicodeFlags(text: string): boolean {
   return EMOJIS_FLAGS_REGEX.test(text);
 }

--- a/app/javascript/mastodon/features/emoji/utils.ts
+++ b/app/javascript/mastodon/features/emoji/utils.ts
@@ -1,0 +1,13 @@
+import EMOJI_REGEX from 'emojibase-regex/emoji-loose';
+
+export function stringHasEmoji(text: string): boolean {
+  return EMOJI_REGEX.test(text);
+}
+
+// From https://github.com/talkjs/country-flag-emoji-polyfill/blob/master/src/index.ts#L49-L50
+const EMOJIS_FLAGS_REGEX =
+  /[\u{1F1E6}-\u{1F1FF}|\u{E0062}-\u{E0063}|\u{E0065}|\u{E0067}|\u{E006C}|\u{E006E}|\u{E0073}-\u{E0074}|\u{E0077}|\u{E007F}]+/u;
+
+export function stringHasFlags(text: string): boolean {
+  return EMOJIS_FLAGS_REGEX.test(text);
+}

--- a/app/javascript/mastodon/initial_state.js
+++ b/app/javascript/mastodon/initial_state.js
@@ -96,6 +96,7 @@ export const disableHoverCards = getMeta('disable_hover_cards');
 export const disabledAccountId = getMeta('disabled_account_id');
 export const displayMedia = getMeta('display_media');
 export const domain = getMeta('domain');
+export const emojiStyle = getMeta('emoji_style') || 'auto';
 export const expandSpoilers = getMeta('expand_spoilers');
 export const forceSingleColumn = !getMeta('advanced_layout');
 export const limitedFederationMode = getMeta('limited_federation_mode');

--- a/app/javascript/mastodon/initial_state.js
+++ b/app/javascript/mastodon/initial_state.js
@@ -45,6 +45,7 @@
  * @property {string} sso_redirect
  * @property {string} status_page_url
  * @property {boolean} terms_of_service_enabled
+ * @property {string?} emoji_style
  */
 
 /**

--- a/app/javascript/mastodon/main.tsx
+++ b/app/javascript/mastodon/main.tsx
@@ -29,7 +29,7 @@ function main() {
       });
     }
 
-    if (isFeatureEnabled('modern_emoji')) {
+    if (isFeatureEnabled('modern_emojis')) {
       const { initializeEmoji } = await import('@/mastodon/features/emoji');
       await initializeEmoji();
     }

--- a/app/javascript/mastodon/main.tsx
+++ b/app/javascript/mastodon/main.tsx
@@ -4,7 +4,7 @@ import { Globals } from '@react-spring/web';
 
 import { setupBrowserNotifications } from 'mastodon/actions/notifications';
 import Mastodon from 'mastodon/containers/mastodon';
-import { me, reduceMotion } from 'mastodon/initial_state';
+import { isFeatureEnabled, me, reduceMotion } from 'mastodon/initial_state';
 import * as perf from 'mastodon/performance';
 import ready from 'mastodon/ready';
 import { store } from 'mastodon/store';
@@ -27,6 +27,11 @@ function main() {
       Globals.assign({
         skipAnimation: true,
       });
+    }
+
+    if (isFeatureEnabled('modern_emoji')) {
+      const { initializeEmoji } = await import('@/mastodon/features/emoji');
+      await initializeEmoji();
     }
 
     const root = createRoot(mountNode);

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -30,6 +30,7 @@ class InitialStateSerializer < ActiveModel::Serializer
       store[:use_blurhash]      = object_account_user.setting_use_blurhash
       store[:use_pending_items] = object_account_user.setting_use_pending_items
       store[:show_trends]       = Setting.trends && object_account_user.setting_trends
+      store[:emoji_style]       = object_account_user.settings['web.emoji_style'] if Mastodon::Feature.modern_emojis_enabled?
     else
       store[:auto_play_gif] = Setting.auto_play_gif
       store[:display_media] = Setting.display_media

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "emoji-mart": "npm:emoji-mart-lazyload@latest",
     "emojibase": "^16.0.0",
     "emojibase-data": "^16.0.3",
+    "emojibase-regex": "^16.0.0",
     "escape-html": "^1.0.3",
     "fast-glob": "^3.3.3",
     "fuzzysort": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2669,6 +2669,7 @@ __metadata:
     emoji-mart: "npm:emoji-mart-lazyload@latest"
     emojibase: "npm:^16.0.0"
     emojibase-data: "npm:^16.0.3"
+    emojibase-regex: "npm:^16.0.0"
     escape-html: "npm:^1.0.3"
     eslint: "npm:^9.23.0"
     eslint-import-resolver-typescript: "npm:^4.2.5"
@@ -6595,6 +6596,13 @@ __metadata:
   peerDependencies:
     emojibase: "*"
   checksum: 10c0/d82520917c2ec326e737da9c5a57472e41a719777fa4770b52b75f0568791613fc94829898831c7b3fff1528134de01019cdf34e571d214fee19e40950d68b7f
+  languageName: node
+  linkType: hard
+
+"emojibase-regex@npm:^16.0.0":
+  version: 16.0.0
+  resolution: "emojibase-regex@npm:16.0.0"
+  checksum: 10c0/8ee5ff798e51caa581434b1cb2f9737e50195093c4efa1739df21a50a5496f80517924787d865e8cf7d6a0b4c90dbedc04bdc506dcbcc582e14cdf0bb47af0f0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This is another piece of the emoji handling refactor. This uses the experimental flag along with user emoji style preferences to replace emoji conditionally and using the new IndexedDB solution.

With this PR, emoji are rendered using the new system for statuses inside the timeline, and account bios. Other areas will follow after merging, as there is inconsistency or other issues that need to be dealt with first that would increase this PR's size.

To test, set the `EXPERIMENTAL_FEATURES=modern_emojis` env var on your server. You should see by default native rendering for emojis in your timeline. There's a new preference from #35282 that will control what you see- Twemoji for the old style, Auto or Native for latest. In all cases, flags on Windows Chrome or Edge should be replaced with Twemoji.

Without the experimental feature flag, behavior should be identical to existing emoji behavior.