### PR TITLE
Don't require JSDoc params & return in TS

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -350,6 +350,8 @@ export default tseslint.config([
       'import/no-default-export': 'warn',
 
       'jsdoc/require-jsdoc': 'off',
+      'jsdoc/require-param': 'off',
+      'jsdoc/require-returns': 'off',
 
       'react/prefer-stateless-function': 'warn',
       'react/function-component-definition': [


### PR DESCRIPTION
### Changes proposed in this PR:
- Removes the need to define `@params` and `@returns` in JSDoc-style comments in TS/TSX files, allowing us to write simple comments like this one that can be picked up by an IDE
  <img width="325" height="126" alt="image" src="https://github.com/user-attachments/assets/7ae3d57e-e5c5-45de-a0bb-a522a829f309" />
