### PR TITLE
Move list owner check to `validate` declaration in `ListAccount`

### DIFF
--- a/app/models/list_account.rb
+++ b/app/models/list_account.rb
@@ -18,11 +18,16 @@ class ListAccount < ApplicationRecord
   belongs_to :follow_request, optional: true
 
   validates :account_id, uniqueness: { scope: :list_id }
-  validate :validate_relationship
+
+  with_options unless: :list_owner_account_is_account? do
+    before_validation :set_follow
+
+    validate :verify_follow_or_follow_request_presence
+    validate :verify_follow_target_account, if: :follow_id?
+    validate :verify_follow_request_target_account, if: :follow_request_id?
+  end
 
   scope :active, -> { where.not(follow_id: nil) }
-
-  before_validation :set_follow, unless: :list_owner_account_is_account?
 
   private
 
@@ -31,12 +36,16 @@ class ListAccount < ApplicationRecord
     self.follow_request = FollowRequest.find_by(account_id: list.account_id, target_account_id: account.id) if follow.nil?
   end
 
-  def validate_relationship
-    return if list_owner_account_is_account?
-
+  def verify_follow_or_follow_request_presence
     errors.add(:account_id, :must_be_following) if follow_id.nil? && follow_request_id.nil?
-    errors.add(:follow, :invalid) if follow_id.present? && follow.target_account_id != account_id
-    errors.add(:follow_request, :invalid) if follow_request_id.present? && follow_request.target_account_id != account_id
+  end
+
+  def verify_follow_target_account
+    errors.add(:follow, :invalid) if follow.target_account_id != account_id
+  end
+
+  def verify_follow_request_target_account
+    errors.add(:follow_request, :invalid) if follow_request.target_account_id != account_id
   end
 
   def list_owner_account_is_account?


### PR DESCRIPTION
Basically two changes here:

- We're already using `unless: :list_owner_account_is_account?` on the `before_valiation`, which is the same condition as running these account related validations. Bump that out to a `with_options` wrapper and apply it to the validations as well.
- Pull out the "do we have one of follow or follow request?" and each of the target account checks to separate methods
