### PR TITLE
Move row generation for `settings/imports#failures` to `BulkImportRow#to_csv`

### DIFF
--- a/app/models/bulk_import_row.rb
+++ b/app/models/bulk_import_row.rb
@@ -12,4 +12,27 @@
 #
 class BulkImportRow < ApplicationRecord
   belongs_to :bulk_import
+
+  def to_csv
+    case bulk_import.type.to_sym
+    when :following
+      [data['acct'], data.fetch('show_reblogs', true), data.fetch('notify', false), language_list]
+    when :blocking
+      [data['acct']]
+    when :muting
+      [data['acct'], data.fetch('hide_notifications', true)]
+    when :domain_blocking
+      [data['domain']]
+    when :bookmarks
+      [data['uri']]
+    when :lists
+      [data['list_name'], data['acct']]
+    end
+  end
+
+  private
+
+  def language_list
+    data['languages']&.join(', ')
+  end
 end

--- a/spec/models/bulk_import_row_spec.rb
+++ b/spec/models/bulk_import_row_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BulkImportRow do
+  describe 'Associations' do
+    it { is_expected.to belong_to(:bulk_import).required }
+  end
+
+  describe '#to_csv' do
+    subject { described_class.new(bulk_import: Fabricate.build(:bulk_import, type:), data: {}).to_csv }
+
+    context 'when bulk import is following type' do
+      let(:type) { :following }
+
+      it { is_expected.to be_a(Array) }
+    end
+
+    context 'when bulk import is blocking type' do
+      let(:type) { :blocking }
+
+      it { is_expected.to be_a(Array) }
+    end
+
+    context 'when bulk import is muting type' do
+      let(:type) { :muting }
+
+      it { is_expected.to be_a(Array) }
+    end
+
+    context 'when bulk import is domain_blocking type' do
+      let(:type) { :domain_blocking }
+
+      it { is_expected.to be_a(Array) }
+    end
+
+    context 'when bulk import is bookmarks type' do
+      let(:type) { :bookmarks }
+
+      it { is_expected.to be_a(Array) }
+    end
+
+    context 'when bulk import is lists type' do
+      let(:type) { :lists }
+
+      it { is_expected.to be_a(Array) }
+    end
+  end
+end


### PR DESCRIPTION
Changes:

- Pull out filename and headers map access to private methods
- All the branches in the large case statement here are reaching into the bulk import row ... so just move that csv row generation logic there where it can access it's `data` directly.

There is already fairly solid coverage for the actual data generation here in the existing controller spec, so I did something very barebones/first-pass on the new model method. Possible future work here would be some/all of a) shuffle those specs around to get more precise and edge case coverage into the model (and simplify controller spec in process?), b) refactor in model to give each row "type" it's own class (ie, `BulkImportFollowingRow` or something?) and initialize each class with `data`, then allow them to do their own row generation -- moving detailed spec coverage to those "row type" classes?