### PR TITLE
Add scenario coverage `admin/domain_blocks#create` and avoid `return render...`

### DIFF
--- a/app/controllers/admin/domain_blocks_controller.rb
+++ b/app/controllers/admin/domain_blocks_controller.rb
@@ -7,7 +7,7 @@ module Admin
     with_options only: :create do
       before_action :populate_domain_block_from_params
       before_action :prevent_downgrade
-      before_action :attempt_transparent_upgrade, if: :existing_domain_block
+      before_action :perform_transparent_upgrade, if: :existing_domain_block_matches_domain?
       before_action :verify_confirmation_needed
     end
 
@@ -98,12 +98,15 @@ module Admin
       end
     end
 
-    def attempt_transparent_upgrade
-      # Allow transparently upgrading a domain block when existing is an exact match for domain value
-      if existing_domain_block.domain == TagManager.instance.normalize_domain(@domain_block.domain.strip)
-        @domain_block = existing_domain_block
-        @domain_block.assign_attributes(resource_params)
-      end
+    def perform_transparent_upgrade
+      @domain_block = existing_domain_block
+      @domain_block.assign_attributes(resource_params)
+    end
+
+    def existing_domain_block_matches_domain?
+      # Existing domain block exists and the domain is exact match for the value from incoming params
+      existing_domain_block.present? &&
+        existing_domain_block.domain == TagManager.instance.normalize_domain(@domain_block.domain.strip)
     end
 
     def verify_confirmation_needed

--- a/app/controllers/admin/domain_blocks_controller.rb
+++ b/app/controllers/admin/domain_blocks_controller.rb
@@ -92,7 +92,7 @@ module Admin
       # Disallow accidental downgrade of an existing domain block record
       if existing_domain_block.present? && !@domain_block.stricter_than?(existing_domain_block)
         @domain_block.validate
-        flash.now[:alert] = unblock_first_alert
+        flash.now.alert = unblock_first_alert
         @domain_block.errors.delete(:domain)
         render :new
       end

--- a/app/controllers/admin/domain_blocks_controller.rb
+++ b/app/controllers/admin/domain_blocks_controller.rb
@@ -41,7 +41,6 @@ module Admin
 
     def create
       @domain_block = DomainBlock.new(resource_params)
-      existing_domain_block = resource_params[:domain].present? ? DomainBlock.rule_for(resource_params[:domain]) : nil
 
       # Disallow accidentally downgrading a domain block
       if existing_domain_block.present? && !@domain_block.stricter_than?(existing_domain_block)
@@ -97,6 +96,10 @@ module Admin
 
     def authorize_domain_block_create
       authorize :domain_block, :create?
+    end
+
+    def existing_domain_block
+      @existing_domain_block ||= DomainBlock.rule_for(resource_params[:domain]) if resource_params[:domain].present?
     end
 
     def set_domain_block

--- a/app/controllers/admin/domain_blocks_controller.rb
+++ b/app/controllers/admin/domain_blocks_controller.rb
@@ -4,6 +4,8 @@ module Admin
   class DomainBlocksController < BaseController
     before_action :set_domain_block, only: [:destroy, :edit, :update]
 
+    before_action :authorize_domain_block_create, only: [:batch, :new, :create]
+
     PERMITTED_PARAMS = %i(
       domain
       obfuscate
@@ -17,7 +19,6 @@ module Admin
     PERMITTED_UPDATE_PARAMS = PERMITTED_PARAMS.without(:domain).freeze
 
     def batch
-      authorize :domain_block, :create?
       @form = Form::DomainBlockBatch.new(form_domain_block_batch_params.merge(current_account: current_account, action: action_from_button))
       @form.save
     rescue ActionController::ParameterMissing
@@ -31,7 +32,6 @@ module Admin
     end
 
     def new
-      authorize :domain_block, :create?
       @domain_block = DomainBlock.new(domain: params[:_domain])
     end
 
@@ -40,8 +40,6 @@ module Admin
     end
 
     def create
-      authorize :domain_block, :create?
-
       @domain_block = DomainBlock.new(resource_params)
       existing_domain_block = resource_params[:domain].present? ? DomainBlock.rule_for(resource_params[:domain]) : nil
 
@@ -96,6 +94,10 @@ module Admin
     end
 
     private
+
+    def authorize_domain_block_create
+      authorize :domain_block, :create?
+    end
 
     def set_domain_block
       @domain_block = DomainBlock.find(params[:id])

--- a/app/controllers/admin/domain_blocks_controller.rb
+++ b/app/controllers/admin/domain_blocks_controller.rb
@@ -92,7 +92,7 @@ module Admin
       # Disallow accidental downgrade of an existing domain block record
       if existing_domain_block.present? && !@domain_block.stricter_than?(existing_domain_block)
         @domain_block.validate
-        flash.now[:alert] = I18n.t('admin.domain_blocks.existing_domain_block_html', name: existing_domain_block.domain, unblock_url: admin_domain_block_path(existing_domain_block)).html_safe
+        flash.now[:alert] = unblock_first_alert
         @domain_block.errors.delete(:domain)
         render :new
       end
@@ -117,6 +117,14 @@ module Admin
 
     def set_domain_block
       @domain_block = DomainBlock.find(params[:id])
+    end
+
+    def unblock_first_alert
+      I18n.t(
+        'admin.domain_blocks.existing_domain_block_html',
+        name: existing_domain_block.domain,
+        unblock_url: admin_domain_block_path(existing_domain_block)
+      ).html_safe
     end
 
     def update_params

--- a/app/controllers/admin/domain_blocks_controller.rb
+++ b/app/controllers/admin/domain_blocks_controller.rb
@@ -3,8 +3,8 @@
 module Admin
   class DomainBlocksController < BaseController
     before_action :set_domain_block, only: [:destroy, :edit, :update]
-
     before_action :authorize_domain_block_create, only: [:batch, :new, :create]
+    before_action :populate_domain_block_from_params, only: :create
 
     PERMITTED_PARAMS = %i(
       domain
@@ -40,8 +40,6 @@ module Admin
     end
 
     def create
-      @domain_block = DomainBlock.new(resource_params)
-
       # Disallow accidentally downgrading a domain block
       if existing_domain_block.present? && !@domain_block.stricter_than?(existing_domain_block)
         @domain_block.validate
@@ -96,6 +94,10 @@ module Admin
 
     def authorize_domain_block_create
       authorize :domain_block, :create?
+    end
+
+    def populate_domain_block_from_params
+      @domain_block = DomainBlock.new(resource_params)
     end
 
     def existing_domain_block


### PR DESCRIPTION
Similar to https://github.com/mastodon/mastodon/pull/35392 re: the `return render` idea.

Changes in order of simplest...

- Coverage added for the domain block downgrade scenario, and missing value scenarios, which were missing
- I believe there was a previous typo  where `edit` action was authorizing for `create?` instead of `update?`, changed this (though this is inconsequential - in the actual policy they check same thing)
- Use generated query method from severity enum in existing requires confirmation method
- Each of new/create/batch do same auth check, pull this out to before action
- Oull out i-var set-up to before action, only to enable next few changes...
- For each of the "prevent downgrade", "perform transparent upgrade", and "confirm suspension" scenarios, convert these checks to `before_action` to rely on the implicit return of the `render` from these, and leaving the controller create action as a simple "if save, redirect or render" method

Happy to pull out the coverage addition and (hopefully uncontroversial) smaller changes ahead of time if it makes the core changes here easier to review with that done first.