### PR TITLE
Rely on polymorphic admin report note url for delete links in partial

### DIFF
--- a/app/views/admin/report_notes/_report_note.html.haml
+++ b/app/views/admin/report_notes/_report_note.html.haml
@@ -13,9 +13,7 @@
 
   - if can?(:destroy, report_note)
     .report-notes__item__actions
-      - if report_note.is_a?(AccountModerationNote)
-        = table_link_to 'delete', t('admin.reports.notes.delete'), admin_account_moderation_note_path(report_note), method: :delete
-      - elsif report_note.is_a?(InstanceModerationNote)
+      - if report_note.is_a?(InstanceModerationNote)
         = table_link_to 'delete', t('admin.reports.notes.delete'), admin_instance_moderation_note_path(instance_id: report_note.domain, id: report_note.id), method: :delete
       - else
-        = table_link_to 'delete', t('admin.reports.notes.delete'), admin_report_note_path(report_note), method: :delete
+        = table_link_to 'delete', t('admin.reports.notes.delete'), url_for([:admin, report_note]), method: :delete


### PR DESCRIPTION
The `InstanceModerationNote` actually is a special case due to being nested under an instance, but the other two can generate their own admin area links without the special casing. Noticed this as accidental side effect of looking at brakeman update failures.

Possible future improvement here:

- All three classes (ReportNote, AccountModerationNote, InstanceModerationNote) are using this partial via their index views, and I believe those are both the only places that use this partial, but also the only places lists/records of those models are rendered. Could do one/both of a) add `to_partial_path` to the models to make collection render nicer, b) rename the partial to something less "report note" specific, and more "generic note on a record" sort of vibe.
- The models shared other stuff -- they all are owned by an account, all have `content` text field of same size and with same limit, have the same ordering scope, etc. Could contemplate combining all three into something with a `polymorphic: true` "note target" or whatever. I suspect this would be straightforward for report note and account mod note. Would have to contemplate whether the instance/domain thing makes it hard, or just needs prep work