### PR TITLE
fix: Fix glitchy status keyboard navigation

### DIFF
--- a/app/javascript/mastodon/components/status_list.jsx
+++ b/app/javascript/mastodon/components/status_list.jsx
@@ -65,8 +65,8 @@ export default class StatusList extends ImmutablePureComponent {
   _selectChild = (id, index, direction) => {
     const listContainer = this.node.node;
     let elementContainer = listContainer.querySelector(
-      // :nth-of-type uses 1-based indexing
-      `article:nth-of-type(${index + 1 + direction})`
+      // :nth-child uses 1-based indexing
+      `.item-list > :nth-child(${index + 1 + direction})`
     );
     
     if (!elementContainer) {
@@ -79,7 +79,7 @@ export default class StatusList extends ImmutablePureComponent {
       return;
     }
 
-    const loadMoreButton = elementContainer.querySelector('.load-more.load-gap');
+    const loadMoreButton = elementContainer.matches('.load-more') ? elementContainer : null;
     const element = loadMoreButton ?? elementContainer.querySelector('.focusable');
 
     if (element) {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2868,6 +2868,8 @@ a.account__display-name {
     }
 
     &__main {
+      --column-header-height: 60px;
+
       box-sizing: border-box;
       width: 100%;
       flex: 0 1 auto;
@@ -8814,6 +8816,10 @@ noscript {
 .status__wrapper,
 .conversation {
   position: relative;
+
+  // When scrolling these elements into view, take into account
+  // the column header and 2px for the focus outline
+  scroll-margin-top: calc(2px + var(--column-header-height, 0));
 
   &.unread {
     &::before {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2868,7 +2868,7 @@ a.account__display-name {
     }
 
     &__main {
-      --column-header-height: 60px;
+      --column-header-height: 62px;
 
       box-sizing: border-box;
       width: 100%;
@@ -8818,8 +8818,8 @@ noscript {
   position: relative;
 
   // When scrolling these elements into view, take into account
-  // the column header and 2px for the focus outline
-  scroll-margin-top: calc(2px + var(--column-header-height, 0));
+  // the column header height
+  scroll-margin-top: var(--column-header-height, 0);
 
   &.unread {
     &::before {


### PR DESCRIPTION
Fixes #27259, #29084, #15302, #13200
Supersedes #27560

### Changes proposed in this PR:
- Fixes glitchy status keyboard navigation:
   - Takes load gaps and inline follow suggestions panels into account. It skips empty panels and focuses them when they have content. Navigating away from follow suggestions and load gaps via hotkey is not yet implemented
   - Properly scrolls posts into view if they would otherwise not fit into the current viewport.

### Screenshots


https://github.com/user-attachments/assets/fa3aff5b-619c-4a56-a08a-d1a6344b7904

