### PR TITLE
Reduce `Metrics` violations throughout `spec/` classes

### DIFF
--- a/spec/lib/mastodon/cli/accounts_spec.rb
+++ b/spec/lib/mastodon/cli/accounts_spec.rb
@@ -1124,14 +1124,17 @@ RSpec.describe Mastodon::CLI::Accounts do
       end
 
       def expect_delete_inactive_remote_accounts
-        expect(delete_account_service).to have_received(:call).with(bob, reserve_username: false).once
-        expect(delete_account_service).to have_received(:call).with(gon, reserve_username: false).once
+        [bob, gon].each do |account|
+          expect(delete_account_service)
+            .to have_received(:call).with(account, reserve_username: false).once
+        end
       end
 
       def expect_not_delete_active_accounts
-        expect(delete_account_service).to_not have_received(:call).with(tom, reserve_username: false)
-        expect(delete_account_service).to_not have_received(:call).with(ana, reserve_username: false)
-        expect(delete_account_service).to_not have_received(:call).with(tales, reserve_username: false)
+        [tom, ana, tales].each do |account|
+          expect(delete_account_service)
+            .to_not have_received(:call).with(account, reserve_username: false)
+        end
       end
 
       it 'touches inactive remote accounts that have not been deleted and summarizes activity' do

--- a/spec/lib/mastodon/cli/search_spec.rb
+++ b/spec/lib/mastodon/cli/search_spec.rb
@@ -61,18 +61,25 @@ RSpec.describe Mastodon::CLI::Search do
 
     def stub_search_indexes
       described_class::INDICES.each do |index|
-        allow(index)
-          .to receive_messages(
-            specification: instance_double(Chewy::Index::Specification, changed?: true, lock!: nil),
-            purge: nil
-          )
-
-        importer_double = importer_double_for(index)
-        allow(importer_double).to receive(:on_progress).and_yield([indexed_count, deleted_count])
-        allow("Importer::#{index}Importer".constantize)
-          .to receive(:new)
-          .and_return(importer_double)
+        stub_index_spec(index)
+        stub_index_importer(index)
       end
+    end
+
+    def stub_index_spec(index)
+      allow(index)
+        .to receive_messages(
+          specification: instance_double(Chewy::Index::Specification, changed?: true, lock!: nil),
+          purge: nil
+        )
+    end
+
+    def stub_index_importer(index)
+      importer_double = importer_double_for(index)
+      allow(importer_double).to receive(:on_progress).and_yield([indexed_count, deleted_count])
+      allow("Importer::#{index}Importer".constantize)
+        .to receive(:new)
+        .and_return(importer_double)
     end
 
     def importer_double_for(index)

--- a/spec/requests/api/v1/trends/statuses_spec.rb
+++ b/spec/requests/api/v1/trends/statuses_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'API V1 Trends Statuses' do
       end
 
       context 'with a comically inflated external interactions count' do
-        def prepare_fake_trends
+        before do
           fake_remote_account = Fabricate(:account, domain: 'other.com')
           fake_status = Fabricate(:status, account: fake_remote_account, text: 'I am a big faker', trendable: true, language: 'en')
           fake_status.status_stat.tap do |status_stat|
@@ -66,7 +66,6 @@ RSpec.describe 'API V1 Trends Statuses' do
         end
 
         it 'ignores the feeble attempts at deception' do
-          prepare_fake_trends
           stub_const('Api::BaseController::DEFAULT_STATUSES_LIMIT', 10)
           get '/api/v1/trends/statuses'
 

--- a/spec/services/delete_account_service_spec.rb
+++ b/spec/services/delete_account_service_spec.rb
@@ -36,17 +36,21 @@ RSpec.describe DeleteAccountService do
     end
 
     def expect_deletion_of_associated_owned_records
-      expect { status.reload }.to raise_error(ActiveRecord::RecordNotFound)
-      expect { status_with_mention.reload }.to raise_error(ActiveRecord::RecordNotFound)
-      expect { mention.reload }.to raise_error(ActiveRecord::RecordNotFound)
-      expect { media_attachment.reload }.to raise_error(ActiveRecord::RecordNotFound)
-      expect { notification.reload }.to raise_error(ActiveRecord::RecordNotFound)
-      expect { favourite.reload }.to raise_error(ActiveRecord::RecordNotFound)
-      expect { active_relationship.reload }.to raise_error(ActiveRecord::RecordNotFound)
-      expect { passive_relationship.reload }.to raise_error(ActiveRecord::RecordNotFound)
-      expect { poll.reload }.to raise_error(ActiveRecord::RecordNotFound)
-      expect { poll_vote.reload }.to raise_error(ActiveRecord::RecordNotFound)
-      expect { account_note.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      [
+        account_note,
+        active_relationship,
+        favourite,
+        media_attachment,
+        mention,
+        notification,
+        passive_relationship,
+        poll_vote,
+        poll,
+        status_with_mention,
+        status,
+      ].each do |record|
+        expect { record.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
     end
 
     def expect_deletion_of_associated_target_records
@@ -54,11 +58,15 @@ RSpec.describe DeleteAccountService do
     end
 
     def expect_deletion_of_associated_target_notifications
-      expect { favourite_notification.reload }.to raise_error(ActiveRecord::RecordNotFound)
-      expect { follow_notification.reload }.to raise_error(ActiveRecord::RecordNotFound)
-      expect { mention_notification.reload }.to raise_error(ActiveRecord::RecordNotFound)
-      expect { poll_notification.reload }.to raise_error(ActiveRecord::RecordNotFound)
-      expect { status_notification.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      [
+        favourite_notification,
+        follow_notification,
+        mention_notification,
+        poll_notification,
+        status_notification,
+      ].each do |record|
+        expect { record.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
     end
   end
 

--- a/spec/services/unsuspend_account_service_spec.rb
+++ b/spec/services/unsuspend_account_service_spec.rb
@@ -49,18 +49,15 @@ RSpec.describe UnsuspendAccountService do
       it 'merges back into feeds of local followers and sends update', :inline_jobs do
         subject
 
-        expect_feeds_merged
-        expect_updates_sent
-      end
+        expect(FeedManager.instance)
+          .to have_received(:merge_into_home).with(account, local_follower)
+        expect(FeedManager.instance)
+          .to have_received(:merge_into_list).with(account, list)
 
-      def expect_feeds_merged
-        expect(FeedManager.instance).to have_received(:merge_into_home).with(account, local_follower)
-        expect(FeedManager.instance).to have_received(:merge_into_list).with(account, list)
-      end
-
-      def expect_updates_sent
-        expect(a_request(:post, remote_follower.inbox_url).with { |req| match_update_actor_request(req, account) }).to have_been_made.once
-        expect(a_request(:post, remote_reporter.inbox_url).with { |req| match_update_actor_request(req, account) }).to have_been_made.once
+        expect(a_request(:post, remote_follower.inbox_url).with { |req| match_update_actor_request(req, account) })
+          .to have_been_made.once
+        expect(a_request(:post, remote_reporter.inbox_url).with { |req| match_update_actor_request(req, account) })
+          .to have_been_made.once
       end
     end
   end

--- a/spec/system/admin/change_emails_spec.rb
+++ b/spec/system/admin/change_emails_spec.rb
@@ -28,8 +28,19 @@ RSpec.describe 'Admin Change Emails' do
     def process_change_email
       expect { click_on I18n.t('admin.accounts.change_email.submit') }
         .to not_change { user.reload.email }
-        .and(change { user.reload.unconfirmed_email }.to('test@host.example'))
-        .and(change { user.reload.confirmation_token }.from(nil).to(be_present))
+        .and(change_unconfirmed_email)
+        .and(change_confirmation_token)
+    end
+
+    def change_unconfirmed_email
+      change { user.reload.unconfirmed_email }
+        .to('test@host.example')
+    end
+
+    def change_confirmation_token
+      change { user.reload.confirmation_token }
+        .from(nil)
+        .to(be_present)
     end
   end
 end


### PR DESCRIPTION
Alternative to https://github.com/mastodon/mastodon/pull/35000

This solves all the `Metrics` violations in `spec`, with the exception of a few in `spec/support` which need more contemplation. Lumping these together since it all seemed pretty straightforward. Vast majority of this is either just breaking things into smaller methods, or looping/DRYing repeated setup. Let me know if any of it merits it's own PR for closer review.