### PR TITLE
Add `Form::BaseBatch` class for "batch form update" objects

### DIFF
--- a/app/models/form/account_batch.rb
+++ b/app/models/form/account_batch.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
 
-class Form::AccountBatch
-  include ActiveModel::Model
-  include Authorization
-  include AccountableConcern
+class Form::AccountBatch < Form::BaseBatch
   include Payloadable
 
-  attr_accessor :account_ids, :action, :current_account,
-                :select_all_matching, :query
+  attr_accessor :account_ids,
+                :query,
+                :select_all_matching
 
   def save
     case action

--- a/app/models/form/base_batch.rb
+++ b/app/models/form/base_batch.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class Form::BaseBatch
+  include ActiveModel::Model
+  include Authorization
+  include AccountableConcern
+
+  attr_accessor :action,
+                :current_account
+
+  def save
+    raise 'Override in subclass'
+  end
+end

--- a/app/models/form/custom_emoji_batch.rb
+++ b/app/models/form/custom_emoji_batch.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
-class Form::CustomEmojiBatch
-  include ActiveModel::Model
-  include Authorization
-  include AccountableConcern
-
-  attr_accessor :custom_emoji_ids, :action, :current_account,
-                :category_id, :category_name, :visible_in_picker
+class Form::CustomEmojiBatch < Form::BaseBatch
+  attr_accessor :category_id,
+                :category_name,
+                :visible_in_picker,
+                :custom_emoji_ids
 
   def save
     case action

--- a/app/models/form/domain_block_batch.rb
+++ b/app/models/form/domain_block_batch.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
-class Form::DomainBlockBatch
-  include ActiveModel::Model
-  include Authorization
-  include AccountableConcern
-
-  attr_accessor :domain_blocks_attributes, :action, :current_account
+class Form::DomainBlockBatch < Form::BaseBatch
+  attr_accessor :domain_blocks_attributes
 
   def save
     case action

--- a/app/models/form/email_domain_block_batch.rb
+++ b/app/models/form/email_domain_block_batch.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
-class Form::EmailDomainBlockBatch
-  include ActiveModel::Model
-  include Authorization
-  include AccountableConcern
-
-  attr_accessor :email_domain_block_ids, :action, :current_account
+class Form::EmailDomainBlockBatch < Form::BaseBatch
+  attr_accessor :email_domain_block_ids
 
   def save
     case action

--- a/app/models/form/ip_block_batch.rb
+++ b/app/models/form/ip_block_batch.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
-class Form::IpBlockBatch
-  include ActiveModel::Model
-  include Authorization
-  include AccountableConcern
-
-  attr_accessor :ip_block_ids, :action, :current_account
+class Form::IpBlockBatch < Form::BaseBatch
+  attr_accessor :ip_block_ids
 
   def save
     case action


### PR DESCRIPTION
Noticed this pattern while reviewing https://github.com/mastodon/mastodon/pull/35407

This small collection of "batch update" classes all:

- Include these same three modules
- Expose at least `current_account` and `action` accessors (and then more within each class)
- Enable the "perform bulk update based on action from button" pattern in their controllers
- Expose a `save` method which delegates based on that action

As a first pass here, extracted a common base class to do those shared things.

Similar to https://github.com/mastodon/mastodon/pull/35154

Possible future changes:

- Move these to shared dir? (`app/models/batch/*` or something?)
- Build something to elegäntly capture the "take the action and call a bang method" pattern they all use in `save`, maybe reduce LOC
- With the batch classes somewhat standardized, might be room to clean up how all the controllers assign/save things as well?