### PR TITLE
Add `db/migrate` to `Metrics/` cops exclude

### DIFF
--- a/.rubocop/metrics.yml
+++ b/.rubocop/metrics.yml
@@ -2,6 +2,7 @@
 Metrics/AbcSize:
   Exclude:
     - lib/mastodon/cli/*.rb
+    - db/*migrate/*.rb
 
 Metrics/BlockLength:
   Enabled: false
@@ -12,6 +13,7 @@ Metrics/ClassLength:
 Metrics/CyclomaticComplexity:
   Exclude:
     - lib/mastodon/cli/*.rb
+    - db/*migrate/*.rb
 
 Metrics/MethodLength:
   Enabled: false
@@ -21,3 +23,7 @@ Metrics/ModuleLength:
 
 Metrics/ParameterLists:
   CountKeywordArgs: false
+
+Metrics/PerceivedComplexity:
+  Exclude:
+    - db/*migrate/*.rb


### PR DESCRIPTION
Related to https://github.com/mastodon/mastodon/pull/35000

I was going to start solving some of these, but in basically every case the "violation" is just a long-ish migration up/down method creating or changing a table with many columns ... but it's utterly readable/understandable and I couldn't think of a way to change things without making it more confusing.