### PR TITLE
Add `AccountWarningPreset#to_label` method

### DIFF
--- a/app/controllers/admin/account_actions_controller.rb
+++ b/app/controllers/admin/account_actions_controller.rb
@@ -7,16 +7,13 @@ module Admin
     def new
       authorize @account, :show?
 
-      @account_action  = Admin::AccountAction.new(type: params[:type], report_id: params[:report_id], send_email_notification: true, include_statuses: true)
-      @warning_presets = AccountWarningPreset.all
+      @account_action = Admin::AccountAction.new(type: params[:type], report_id: params[:report_id], send_email_notification: true, include_statuses: true)
     end
 
     def create
       authorize @account, :show?
 
-      @account_action                 = Admin::AccountAction.new(resource_params)
-      @account_action.target_account  = @account
-      @account_action.current_account = current_account
+      @account_action = Admin::AccountAction.new(resource_params.merge(target_account: @account, current_account:))
 
       if @account_action.save
         if @account_action.with_report?
@@ -25,8 +22,6 @@ module Admin
           redirect_to admin_account_path(@account.id)
         end
       else
-        @warning_presets = AccountWarningPreset.all
-
         render :new
       end
     end

--- a/app/helpers/admin/account_actions_helper.rb
+++ b/app/helpers/admin/account_actions_helper.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 module Admin::AccountActionsHelper
+  def account_warning_presets
+    AccountWarningPreset.alphabetic
+  end
+
   def account_action_type_label(type)
     safe_join(
       [

--- a/app/models/account_warning_preset.rb
+++ b/app/models/account_warning_preset.rb
@@ -12,7 +12,15 @@
 #
 
 class AccountWarningPreset < ApplicationRecord
+  LABEL_TEXT_LENGTH = 30
+
   validates :text, presence: true
 
   scope :alphabetic, -> { order(title: :asc, text: :asc) }
+
+  def to_label
+    [title.presence, text.to_s.truncate(LABEL_TEXT_LENGTH)]
+      .compact
+      .join(' - ')
+  end
 end

--- a/app/views/admin/account_actions/new.html.haml
+++ b/app/views/admin/account_actions/new.html.haml
@@ -38,11 +38,11 @@
 
     %hr.spacer/
 
-    - unless @warning_presets.empty?
+    - unless account_warning_presets.empty?
       .fields-group
         = f.input :warning_preset_id,
-                  collection: @warning_presets,
-                  label_method: ->(warning_preset) { [warning_preset.title.presence, truncate(warning_preset.text)].compact.join(' - ') },
+                  collection: account_warning_presets,
+                  label_method: ->(warning_preset) { warning_preset.to_label },
                   wrapper: :with_block_label
 
     .fields-group

--- a/spec/models/account_warning_preset_spec.rb
+++ b/spec/models/account_warning_preset_spec.rb
@@ -3,7 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe AccountWarningPreset do
-  describe 'alphabetical' do
+  describe 'Validations' do
+    it { is_expected.to validate_presence_of(:text) }
+  end
+
+  describe '.alphabetical' do
     let(:first) { Fabricate(:account_warning_preset, title: 'aaa', text: 'aaa') }
     let(:second) { Fabricate(:account_warning_preset, title: 'bbb', text: 'aaa') }
     let(:third) { Fabricate(:account_warning_preset, title: 'bbb', text: 'bbb') }
@@ -12,6 +16,31 @@ RSpec.describe AccountWarningPreset do
       results = described_class.alphabetic
 
       expect(results).to eq([first, second, third])
+    end
+  end
+
+  describe '#to_label' do
+    subject { Fabricate.build(:account_warning_preset, title:, text:).to_label }
+
+    let(:title) { nil }
+    let(:text) { 'Preset text' }
+
+    context 'when title is blank' do
+      it { is_expected.to eq('Preset text') }
+    end
+
+    context 'when title is present' do
+      let(:title) { 'Title' }
+
+      it { is_expected.to eq('Title - Preset text') }
+    end
+
+    context 'when text is longer than limit' do
+      let(:title) { 'Title' }
+
+      before { stub_const('AccountWarningPreset::LABEL_TEXT_LENGTH', 10) }
+
+      it { is_expected.to eq('Title - Preset ...') }
     end
   end
 end

--- a/spec/system/admin/account_actions_spec.rb
+++ b/spec/system/admin/account_actions_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'Admin Account Actions' do
 
   describe 'Creating a new account action on an account' do
     let(:account) { Fabricate(:account) }
+    let!(:account_warning_preset) { Fabricate :account_warning_preset }
 
     it 'creates the action and redirects to the account page' do
       visit new_admin_account_action_path(account_id: account.id)
@@ -23,6 +24,7 @@ RSpec.describe 'Admin Account Actions' do
 
       # Valid submission
       choose(option: 'silence')
+      select account_warning_preset.to_label, from: 'admin_account_action_warning_preset_id'
       expect { submit_form }
         .to change { account.strikes.count }.by(1)
       expect(page)


### PR DESCRIPTION
Related changes:

- Add a `to_label` method to `AccountWarningPreset` and use this in the view to generate labels on the form option
- Pull the account warning presets from helper, instance of i-var in controller, and use their alphabetical order (matches what happens in their own controller)
- Simplify attribute assignment in admin/account_actions controller
