### PR TITLE
Combine assignment params in `admin/accounts#batch` action

### DIFF
--- a/app/controllers/admin/accounts_controller.rb
+++ b/app/controllers/admin/accounts_controller.rb
@@ -16,11 +16,14 @@ module Admin
     def batch
       authorize :account, :index?
 
-      @form = Form::AccountBatch.new(form_account_batch_params)
-      @form.current_account = current_account
-      @form.action = action_from_button
-      @form.select_all_matching = params[:select_all_matching]
-      @form.query = filtered_accounts
+      @form = Form::AccountBatch.new(
+        form_account_batch_params.merge(
+          action: action_from_button,
+          current_account:,
+          query: filtered_accounts,
+          select_all_matching: params[:select_all_matching]
+        )
+      )
       @form.save
     rescue ActionController::ParameterMissing
       flash[:alert] = I18n.t('admin.accounts.no_account_selected')


### PR DESCRIPTION
Alternative to https://github.com/mastodon/mastodon/pull/35000

Just converts serial assignment into an initialization - matches style of other "batch" setup actions. Resolves the `Metrics` cop violation from this action.
