### PR TITLE
remove redundant `title` text from media modal images in web UI

### DIFF
--- a/app/javascript/mastodon/components/gifv.tsx
+++ b/app/javascript/mastodon/components/gifv.tsx
@@ -37,7 +37,6 @@ export const GIFV = forwardRef<HTMLVideoElement, Props>(
             role='button'
             tabIndex={0}
             aria-label={alt}
-            title={alt}
             lang={lang}
             onClick={handleClick}
           />
@@ -49,7 +48,6 @@ export const GIFV = forwardRef<HTMLVideoElement, Props>(
           role='button'
           tabIndex={0}
           aria-label={alt}
-          title={alt}
           lang={lang}
           width={width}
           height={height}

--- a/app/javascript/mastodon/features/ui/components/zoomable_image.tsx
+++ b/app/javascript/mastodon/features/ui/components/zoomable_image.tsx
@@ -306,7 +306,6 @@ export const ZoomableImage: React.FC<ZoomableImageProps> = ({
 
       <animated.img
         style={{ transform }}
-        role='presentation'
         ref={imageRef}
         alt={alt}
         lang={lang}

--- a/app/javascript/mastodon/features/ui/components/zoomable_image.tsx
+++ b/app/javascript/mastodon/features/ui/components/zoomable_image.tsx
@@ -309,7 +309,6 @@ export const ZoomableImage: React.FC<ZoomableImageProps> = ({
         role='presentation'
         ref={imageRef}
         alt={alt}
-        title={alt}
         lang={lang}
         src={src}
         width={width}


### PR DESCRIPTION
This PR removes the `title` attribute from the images shown in the media modal, making their behavior consistent with the feed items per #33736. In the places where `title` is removed, there is already an `alt` or `aria-label` with the same value.

Additionally, this PR [removes `role="presentation"`](https://github.com/mastodon/mastodon/pull/35468/files#r2227238954) which was hiding the image and its alt text from the accessibility tree.

### Rationale

While the original "content getting obscured" issue reported in #30016 also applies to the media modal to a lesser extent, the main motivation for this change — apart from consistency — is actually to prevent duplicate announcements.

When the `alt` and `title` are both present, this text can become duplicated depending on the browsers and assistive technologies used. As a quick test: if you inspect the accessibility tree using Firefox dev tools, you'll notice that the alt text is both the image's ["name"](https://developer.mozilla.org/en-US/docs/Glossary/Accessible_name) and ["description"](https://developer.mozilla.org/en-US/docs/Glossary/Accessible_description). Then, if you try to navigate to the image using a screen-reader like VoiceOver, you will hear the alt text be announced _twice_. Removing the `title` ensures that the alt text is only used as the image's "name" and only gets announced _once_.