### PR TITLE
Fix accidentally instantiating Web Worker

### DIFF
--- a/app/javascript/mastodon/features/emoji/index.ts
+++ b/app/javascript/mastodon/features/emoji/index.ts
@@ -4,19 +4,27 @@ import { toSupportedLocale } from './locale';
 
 const userLocale = toSupportedLocale(initialState?.meta.locale ?? 'en');
 
-const worker =
-  'Worker' in window
-    ? new Worker(new URL('./worker', import.meta.url), {
-        type: 'module',
-      })
-    : null;
+let worker: Worker | null = null;
 
 export async function initializeEmoji() {
+  if (!worker && 'Worker' in window) {
+    try {
+      worker = new Worker(new URL('./worker', import.meta.url), {
+        type: 'module',
+        credentials: 'omit',
+      });
+    } catch (err) {
+      console.warn('Error creating web worker:', err);
+    }
+  }
+
   if (worker) {
-    worker.addEventListener('message', (event: MessageEvent<string>) => {
+    // Assign worker to const to make TS happy inside the event listener.
+    const thisWorker = worker;
+    thisWorker.addEventListener('message', (event: MessageEvent<string>) => {
       const { data: message } = event;
       if (message === 'ready') {
-        worker.postMessage('custom');
+        thisWorker.postMessage('custom');
         void loadEmojiLocale(userLocale);
         // Load English locale as well, because people are still used to
         // using it from before we supported other locales.

--- a/app/javascript/mastodon/features/emoji/render.ts
+++ b/app/javascript/mastodon/features/emoji/render.ts
@@ -4,7 +4,6 @@ import EMOJI_REGEX from 'emojibase-regex/emoji-loose';
 import { autoPlayGif } from '@/mastodon/initial_state';
 import { assetHost } from '@/mastodon/utils/config';
 
-import { loadEmojiLocale } from '.';
 import {
   EMOJI_MODE_NATIVE,
   EMOJI_MODE_NATIVE_WITH_FLAGS,
@@ -17,6 +16,7 @@ import {
   searchCustomEmojisByShortcodes,
   searchEmojisByHexcodes,
 } from './database';
+import { loadEmojiLocale } from './index';
 import {
   emojiToUnicodeHex,
   twemojiHasBorder,


### PR DESCRIPTION
Fixes #35461.

In #35424 `render.ts` imported `index.ts`, which attempts to instantiate a Web Worker. Unfortunately when using `CDN_URL` that triggers a security error as it's attempting to load the worker from a cross-origin script. While that's fine for Firefox, in Chromium-based browsers it causes a fatal error.

This PR moves the worker instantiation to be inside `initializeEmoji` and adds a try/catch around it to be sure.
