### PR TITLE
Extract params hash for `api/v1/push/subscriptions#create`

### DIFF
--- a/app/controllers/api/v1/push/subscriptions_controller.rb
+++ b/app/controllers/api/v1/push/subscriptions_controller.rb
@@ -16,16 +16,7 @@ class Api::V1::Push::SubscriptionsController < Api::BaseController
   def create
     with_redis_lock("push_subscription:#{current_user.id}") do
       destroy_web_push_subscriptions!
-
-      @push_subscription = Web::PushSubscription.create!(
-        endpoint: subscription_params[:endpoint],
-        key_p256dh: subscription_params[:keys][:p256dh],
-        key_auth: subscription_params[:keys][:auth],
-        standard: subscription_params[:standard] || false,
-        data: data_params,
-        user_id: current_user.id,
-        access_token_id: doorkeeper_token.id
-      )
+      @push_subscription = Web::PushSubscription.create!(web_push_subscription_params)
     end
 
     render json: @push_subscription, serializer: REST::WebPushSubscriptionSerializer
@@ -53,6 +44,18 @@ class Api::V1::Push::SubscriptionsController < Api::BaseController
 
   def check_push_subscription
     not_found if @push_subscription.nil?
+  end
+
+  def web_push_subscription_params
+    {
+      access_token_id: doorkeeper_token.id,
+      data: data_params,
+      endpoint: subscription_params[:endpoint],
+      key_auth: subscription_params[:keys][:auth],
+      key_p256dh: subscription_params[:keys][:p256dh],
+      standard: subscription_params[:standard] || false,
+      user_id: current_user.id,
+    }
   end
 
   def subscription_params

--- a/spec/requests/api/v1/push/subscriptions_spec.rb
+++ b/spec/requests/api/v1/push/subscriptions_spec.rb
@@ -166,17 +166,30 @@ RSpec.describe 'API V1 Push Subscriptions' do
   describe 'GET /api/v1/push/subscription' do
     subject { get '/api/v1/push/subscription', headers: headers }
 
-    before { create_subscription_with_token }
+    context 'with a subscription' do
+      before { create_subscription_with_token }
 
-    it 'shows subscription details' do
-      subject
+      it 'shows subscription details' do
+        subject
 
-      expect(response)
-        .to have_http_status(200)
-      expect(response.content_type)
-        .to start_with('application/json')
-      expect(response.parsed_body)
-        .to include(endpoint: endpoint)
+        expect(response)
+          .to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
+        expect(response.parsed_body)
+          .to include(endpoint: endpoint)
+      end
+    end
+
+    context 'without a subscription' do
+      it 'returns not found' do
+        subject
+
+        expect(response)
+          .to have_http_status(404)
+        expect(response.content_type)
+          .to start_with('application/json')
+      end
     end
   end
 


### PR DESCRIPTION
Alternative to https://github.com/mastodon/mastodon/pull/35000

Changes:

- Add a spec for "no subscription" scenario which was missing
- Pull out params hash to method, which solves the `Metrics` violation from this controller