### PR TITLE
Silence json key duplicate warning from `api/web/push_subscriptions`

### DIFF
--- a/app/controllers/api/web/push_subscriptions_controller.rb
+++ b/app/controllers/api/web/push_subscriptions_controller.rb
@@ -49,7 +49,7 @@ class Api::Web::PushSubscriptionsController < Api::Web::BaseController
     {
       policy: 'all',
       alerts: Notification::TYPES.index_with { alerts_enabled },
-    }
+    }.deep_stringify_keys
   end
 
   def alerts_enabled


### PR DESCRIPTION
The JSON gem [2.13 release](https://github.com/ruby/json/releases/tag/v2.13.0) added a warning (which will become an error in 3.0) when it finds duplicate keys in json strings during parsing. Here's example output from spec run: https://github.com/mastodon/mastodon/actions/runs/16470735118/job/46559136261#step:9:23 - showing one warning.

I tracked it down to this spot in `api/web/push_subscriptions` where we are merging hashes, and wind up merging a symbol-keyed hash with a string keyed hash.

Before:

```
{policy: "all", alerts: {mention: false, status: false, reblog: false, follow: false, follow_request: false, favourite: false, poll: false, update: false, severed_relationships: false, moderation_warning: false, annual_report: false, "admin.sign_up": false, "admin.report": false}, "policy" => "all", "alerts" => {"mention" => "false", "status" => "false", "reblog" => "true", "follow" => "true", "follow_request" => "false", "favourite" => "false", "poll" => "true"}}
```

After:

```
{"policy" => "all", "alerts" => {"mention" => "false", "status" => "false", "reblog" => "true", "follow" => "true", "follow_request" => "false", "favourite" => "false", "poll" => "true", "update" => false, "severed_relationships" => false, "moderation_warning" => false, "annual_report" => false, "admin.sign_up" => false, "admin.report" => false}}
```

(Note the duplicated "alerts" hash in the before ... same true/false values, just string vs symbol keys)

Other than seeing this warning silenced and seeing the specs still pass, not sure how else to verify this.
