### PR TITLE
Exclude CLI classes from `Metrics/PerceivedComplexity` cop

### DIFF
--- a/.rubocop/metrics.yml
+++ b/.rubocop/metrics.yml
@@ -21,3 +21,7 @@ Metrics/ModuleLength:
 
 Metrics/ParameterLists:
   CountKeywordArgs: false
+
+Metrics/PerceivedComplexity:
+  Exclude:
+    - lib/mastodon/cli/*.rb

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -21,7 +21,7 @@ Metrics/CyclomaticComplexity:
 
 # Configuration parameters: AllowedMethods, AllowedPatterns.
 Metrics/PerceivedComplexity:
-  Max: 27
+  Max: 26
 
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowedVars, DefaultToNil.


### PR DESCRIPTION
Alternative to https://github.com/mastodon/mastodon/pull/35000

Related to https://github.com/mastodon/mastodon/pull/35459

We already exclude these from the others, I assume this one missing is an oversight.

Also regen'd the todo b/c it turns out the highest offender here was cli/domains#purge