### PR TITLE
Fix `Metrics/BlockNesting` cop in `mastodon:setup` rake task

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -10,11 +10,6 @@
 Metrics/AbcSize:
   Max: 82
 
-# Configuration parameters: CountBlocks, CountModifierForms, Max.
-Metrics/BlockNesting:
-  Exclude:
-    - 'lib/tasks/mastodon.rake'
-
 # Configuration parameters: AllowedMethods, AllowedPatterns.
 Metrics/CyclomaticComplexity:
   Max: 25


### PR DESCRIPTION
Alternative to https://github.com/mastodon/mastodon/pull/35000

Previous attempt here - https://github.com/mastodon/mastodon/pull/33620 - was too large and not reviewed. This time around, just doing the bare minimum to solve that cop.

Even though this change solves the cop, this is still a 500+ line rake task -- follow up to break it out into more managable pieces per-config-area probably makes sense.