### PR TITLE
Fix jobs being added to batch after they might already execute

### DIFF
--- a/app/models/worker_batch.rb
+++ b/app/models/worker_batch.rb
@@ -19,17 +19,22 @@ class WorkerBatch
     redis.hset(key, { 'async_refresh_key' => async_refresh_key, 'threshold' => threshold })
   end
 
+  def within
+    raise NoBlockGivenError unless block_given?
+
+    begin
+      Thread.current[:batch] = self
+      yield
+    ensure
+      Thread.current[:batch] = nil
+    end
+  end
+
   # Add jobs to the batch. Usually when the batch is created.
   # @param [Array<String>] jids
   def add_jobs(jids)
     if jids.blank?
-      async_refresh_key = redis.hget(key, 'async_refresh_key')
-
-      if async_refresh_key.present?
-        async_refresh = AsyncRefresh.new(async_refresh_key)
-        async_refresh.finish!
-      end
-
+      finish!
       return
     end
 
@@ -55,8 +60,23 @@ class WorkerBatch
     if async_refresh_key.present?
       async_refresh = AsyncRefresh.new(async_refresh_key)
       async_refresh.increment_result_count(by: 1)
-      async_refresh.finish! if pending.zero? || processed >= threshold.to_f * (processed + pending)
     end
+
+    if pending.zero? || processed >= (threshold || 1.0).to_f * (processed + pending)
+      async_refresh&.finish!
+      cleanup
+    end
+  end
+
+  def finish!
+    async_refresh_key = redis.hget(key, 'async_refresh_key')
+
+    if async_refresh_key.present?
+      async_refresh = AsyncRefresh.new(async_refresh_key)
+      async_refresh.finish!
+    end
+
+    cleanup
   end
 
   # Get pending jobs.
@@ -75,5 +95,9 @@ class WorkerBatch
 
   def key(suffix = nil)
     "worker_batch:#{@id}#{":#{suffix}" if suffix}"
+  end
+
+  def cleanup
+    redis.del(key, key('jobs'))
   end
 end

--- a/lib/mastodon/worker_batch_middleware.rb
+++ b/lib/mastodon/worker_batch_middleware.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Mastodon::WorkerBatchMiddleware
+  def call(_worker, msg, _queue, _redis_pool = nil)
+    if (batch = Thread.current[:batch])
+      batch.add_jobs([msg['jid']])
+    end
+
+    yield
+  end
+end


### PR DESCRIPTION
By the time `push_bulk` returns the job IDs, they're already queued in Sidekiq, so there could be scenarios where a Sidekiq worker begins executing one of these jobs before the original code moves to the next line, which is saving the job IDs to the batch. This would mean a job ID never being removed from the batch and ergo the batch never completing. So we have to go through Sidekiq client middleware to capture the job IDs before they're pushed to Redis.