### PR TITLE
Fix async refresh never being finished when status cannot be fetched

### DIFF
--- a/app/models/concerns/status/fetch_replies_concern.rb
+++ b/app/models/concerns/status/fetch_replies_concern.rb
@@ -33,7 +33,7 @@ module Status::FetchRepliesConcern
 
   def should_fetch_replies?
     # we aren't brand new, and we haven't fetched replies since the debounce window
-    !local? && created_at <= FETCH_REPLIES_INITIAL_WAIT_MINUTES.ago && (
+    !local? && distributable? && created_at <= FETCH_REPLIES_INITIAL_WAIT_MINUTES.ago && (
       fetched_replies_at.nil? || fetched_replies_at <= FETCH_REPLIES_COOLDOWN_MINUTES.ago
     )
   end

--- a/app/services/activitypub/fetch_all_replies_service.rb
+++ b/app/services/activitypub/fetch_all_replies_service.rb
@@ -6,7 +6,7 @@ class ActivityPub::FetchAllRepliesService < ActivityPub::FetchRepliesService
   # Limit of replies to fetch per status
   MAX_REPLIES = (ENV['FETCH_REPLIES_MAX_SINGLE'] || 500).to_i
 
-  def call(status_uri, collection_or_uri, max_pages: 1, async_refresh_key: nil, request_id: nil)
+  def call(status_uri, collection_or_uri, max_pages: 1, batch_id: nil, request_id: nil)
     @status_uri = status_uri
 
     super

--- a/app/workers/activitypub/fetch_all_replies_worker.rb
+++ b/app/workers/activitypub/fetch_all_replies_worker.rb
@@ -16,7 +16,9 @@ class ActivityPub::FetchAllRepliesWorker
   MAX_PAGES = (ENV['FETCH_REPLIES_MAX_PAGES'] || 500).to_i
 
   def perform(root_status_id, options = {})
+    @batch = WorkerBatch.new(options['batch_id'])
     @root_status = Status.remote.find_by(id: root_status_id)
+
     return unless @root_status&.should_fetch_replies?
 
     @root_status.touch(:fetched_replies_at)
@@ -45,6 +47,8 @@ class ActivityPub::FetchAllRepliesWorker
 
     # Workers shouldn't be returning anything, but this is used in tests
     fetched_uris
+  ensure
+    @batch.remove_job(jid)
   end
 
   private
@@ -53,9 +57,10 @@ class ActivityPub::FetchAllRepliesWorker
   #   status URI, or the prefetched body of the Note object
   def get_replies(status, max_pages, options = {})
     replies_collection_or_uri = get_replies_uri(status)
+
     return if replies_collection_or_uri.nil?
 
-    ActivityPub::FetchAllRepliesService.new.call(value_or_id(status), replies_collection_or_uri, max_pages: max_pages, async_refresh_key: "context:#{@root_status.id}:refresh", **options.deep_symbolize_keys)
+    ActivityPub::FetchAllRepliesService.new.call(value_or_id(status), replies_collection_or_uri, max_pages: max_pages, **options.deep_symbolize_keys)
   end
 
   # Get the URI of the replies collection of a status
@@ -78,9 +83,12 @@ class ActivityPub::FetchAllRepliesWorker
   # @param root_status_uri [String]
   def get_root_replies(root_status_uri, options = {})
     root_status_body = fetch_resource(root_status_uri, true)
+
     return if root_status_body.nil?
 
-    FetchReplyWorker.perform_async(root_status_uri, { **options.deep_stringify_keys, 'prefetched_body' => root_status_body })
+    @batch.within do
+      FetchReplyWorker.perform_async(root_status_uri, { **options.deep_stringify_keys, 'prefetched_body' => root_status_body })
+    end
 
     get_replies(root_status_body, MAX_PAGES, options)
   end

--- a/app/workers/fetch_reply_worker.rb
+++ b/app/workers/fetch_reply_worker.rb
@@ -10,6 +10,6 @@ class FetchReplyWorker
     batch = WorkerBatch.new(options.delete('batch_id')) if options['batch_id']
     FetchRemoteStatusService.new.call(child_url, **options.symbolize_keys)
   ensure
-    batch&.remove_job(jid)
+    batch&.remove_job(jid, increment: true)
   end
 end

--- a/spec/models/worker_batch_spec.rb
+++ b/spec/models/worker_batch_spec.rb
@@ -42,14 +42,6 @@ RSpec.describe WorkerBatch do
       it 'does not persist the job IDs' do
         expect(subject.jobs).to eq []
       end
-
-      context 'when async refresh is connected' do
-        let(:async_refresh) { AsyncRefresh.new(async_refresh_key) }
-
-        it 'immediately marks the async refresh as finished' do
-          expect(async_refresh.reload.finished?).to be true
-        end
-      end
     end
 
     context 'when called with an array of job IDs' do
@@ -71,7 +63,7 @@ RSpec.describe WorkerBatch do
     before do
       subject.connect(async_refresh_key, threshold: 0.5) if async_refresh.present?
       subject.add_jobs(%w(foo bar baz))
-      subject.remove_job('foo')
+      subject.remove_job('foo', increment: true)
     end
 
     it 'removes the job from pending jobs' do


### PR DESCRIPTION
Change the worker batch to include the original job that queues the rest of the batch, that way, if that job doesn't queue anything, it's more straightforward to mark the whole thing as finished.