### PR TITLE
Use `field` partial in admin account show view

### DIFF
--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -49,8 +49,8 @@ module HomeHelper
     end
   end
 
-  def custom_field_classes(field)
-    if field.verified?
+  def field_verified_class(verified)
+    if verified
       'verified'
     else
       'emojify'

--- a/app/views/admin/accounts/_field.html.haml
+++ b/app/views/admin/accounts/_field.html.haml
@@ -1,0 +1,9 @@
+-# locals: (field:, account:)
+%dl
+  %dt.emojify{ title: field.name }
+    = prerender_custom_emojis(h(field.name), account.emojis)
+  %dd{ title: field.value, class: field_verified_class(field.verified?) }
+    - if field.verified?
+      %span.verified__mark{ title: t('accounts.link_verified_on', date: l(field.verified_at)) }
+        = material_symbol 'check'
+    = prerender_custom_emojis(account_field_value_format(field, with_rel_me: false), account.emojis)

--- a/app/views/admin/accounts/show.html.haml
+++ b/app/views/admin/accounts/show.html.haml
@@ -7,25 +7,17 @@
 
 = render 'application/card', account: @account
 
-- account = @account
-- fields = account.fields
-- unless fields.empty? && account.note.blank?
+- if @account.fields? || @account.note?
   .admin-account-bio
-    - unless fields.empty?
+    - if @account.fields?
       %div
         .account__header__fields
-          - fields.each do |field|
-            %dl
-              %dt.emojify{ title: field.name }= prerender_custom_emojis(h(field.name), account.emojis)
-              %dd{ title: field.value, class: custom_field_classes(field) }
-                - if field.verified?
-                  %span.verified__mark{ title: t('accounts.link_verified_on', date: l(field.verified_at)) }
-                    = material_symbol 'check'
-                = prerender_custom_emojis(account_field_value_format(field, with_rel_me: false), account.emojis)
+          = render partial: 'field', collection: @account.fields, locals: { account: @account }
 
-    - if account.note.present?
+    - if @account.note?
       %div
-        .account__header__content.emojify= prerender_custom_emojis(account_bio_format(account), account.emojis)
+        .account__header__content.emojify
+          = prerender_custom_emojis(account_bio_format(@account), @account.emojis)
 
 = render 'admin/accounts/counters', account: @account
 

--- a/spec/helpers/home_helper_spec.rb
+++ b/spec/helpers/home_helper_spec.rb
@@ -75,23 +75,19 @@ RSpec.describe HomeHelper do
     end
   end
 
-  describe 'custom_field_classes' do
-    context 'with a verified field' do
-      let(:field) { instance_double(Account::Field, verified?: true) }
+  describe 'field_verified_class' do
+    subject { helper.field_verified_class(verified) }
 
-      it 'returns verified string' do
-        result = helper.custom_field_classes(field)
-        expect(result).to eq 'verified'
-      end
+    context 'with a verified field' do
+      let(:verified) { true }
+
+      it { is_expected.to eq('verified') }
     end
 
     context 'with a non-verified field' do
-      let(:field) { instance_double(Account::Field, verified?: false) }
+      let(:verified) { false }
 
-      it 'returns verified string' do
-        result = helper.custom_field_classes(field)
-        expect(result).to eq 'emojify'
-      end
+      it { is_expected.to eq('emojify') }
     end
   end
 


### PR DESCRIPTION
Small related changes:

- Extract a partial for the `fields` loop to collection render on this page
- Remove some local variable assignment from the top level view ... it wasn't clear to me from history why these were in place. I'm guessing maybe originated from some WIP that never made it to history or something - but seems inconsistent with the rest of the view which just uses `@account` directly.
- Rename a helper method, in part to satisfy brakeman in advance of https://github.com/mastodon/mastodon/pull/35434 - I suspect that dual nature of "field" here being both a user supplied value column, but also wrapped in it's own class, is confusing brakeman. Passing in the result of a method call, rather than the field object itself, satisifies brakeman.

I could separate the "work around brakeman thing" and "extract partial" portions if useful.