### PR TITLE
Force modern emoji experimental to be dev mode only

### DIFF
--- a/app/javascript/mastodon/components/account_bio.tsx
+++ b/app/javascript/mastodon/components/account_bio.tsx
@@ -3,9 +3,8 @@ import { useCallback } from 'react';
 import { useLinks } from 'mastodon/hooks/useLinks';
 
 import { EmojiHTML } from '../features/emoji/emoji_html';
-import { isFeatureEnabled } from '../initial_state';
 import { useAppSelector } from '../store';
-import { isDevelopment } from '../utils/environment';
+import { isModernEmojiEnabled } from '../utils/environment';
 
 interface AccountBioProps {
   className: string;
@@ -33,9 +32,7 @@ export const AccountBio: React.FC<AccountBioProps> = ({
     if (!account) {
       return '';
     }
-    return isFeatureEnabled('modern_emojis') && isDevelopment()
-      ? account.note
-      : account.note_emojified;
+    return isModernEmojiEnabled() ? account.note : account.note_emojified;
   });
   const extraEmojis = useAppSelector((state) => {
     const account = state.accounts.get(accountId);

--- a/app/javascript/mastodon/components/account_bio.tsx
+++ b/app/javascript/mastodon/components/account_bio.tsx
@@ -5,6 +5,7 @@ import { useLinks } from 'mastodon/hooks/useLinks';
 import { EmojiHTML } from '../features/emoji/emoji_html';
 import { isFeatureEnabled } from '../initial_state';
 import { useAppSelector } from '../store';
+import { isDevelopment } from '../utils/environment';
 
 interface AccountBioProps {
   className: string;
@@ -32,7 +33,7 @@ export const AccountBio: React.FC<AccountBioProps> = ({
     if (!account) {
       return '';
     }
-    return isFeatureEnabled('modern_emojis')
+    return isFeatureEnabled('modern_emojis') && isDevelopment()
       ? account.note
       : account.note_emojified;
   });

--- a/app/javascript/mastodon/components/status_content.jsx
+++ b/app/javascript/mastodon/components/status_content.jsx
@@ -15,6 +15,7 @@ import { Poll } from 'mastodon/components/poll';
 import { identityContextPropShape, withIdentity } from 'mastodon/identity_context';
 import { autoPlayGif, isFeatureEnabled, languages as preloadedLanguages } from 'mastodon/initial_state';
 import { EmojiHTML } from '../features/emoji/emoji_html';
+import { isDevelopment } from '../utils/environment';
 
 const MAX_HEIGHT = 706; // 22px * 32 (+ 2px padding at the top)
 
@@ -24,7 +25,7 @@ const MAX_HEIGHT = 706; // 22px * 32 (+ 2px padding at the top)
  * @returns {string}
  */
 export function getStatusContent(status) {
-  if (isFeatureEnabled('modern_emojis')) {
+  if (isFeatureEnabled('modern_emojis') && isDevelopment()) {
     return status.getIn(['translation', 'content']) || status.get('content');
   }
   return status.getIn(['translation', 'contentHtml']) || status.get('contentHtml');

--- a/app/javascript/mastodon/components/status_content.jsx
+++ b/app/javascript/mastodon/components/status_content.jsx
@@ -13,9 +13,9 @@ import ChevronRightIcon from '@/material-icons/400-24px/chevron_right.svg?react'
 import { Icon }  from 'mastodon/components/icon';
 import { Poll } from 'mastodon/components/poll';
 import { identityContextPropShape, withIdentity } from 'mastodon/identity_context';
-import { autoPlayGif, isFeatureEnabled, languages as preloadedLanguages } from 'mastodon/initial_state';
+import { autoPlayGif, languages as preloadedLanguages } from 'mastodon/initial_state';
 import { EmojiHTML } from '../features/emoji/emoji_html';
-import { isDevelopment } from '../utils/environment';
+import { isModernEmojiEnabled } from '../utils/environment';
 
 const MAX_HEIGHT = 706; // 22px * 32 (+ 2px padding at the top)
 
@@ -25,7 +25,7 @@ const MAX_HEIGHT = 706; // 22px * 32 (+ 2px padding at the top)
  * @returns {string}
  */
 export function getStatusContent(status) {
-  if (isFeatureEnabled('modern_emojis') && isDevelopment()) {
+  if (isModernEmojiEnabled()) {
     return status.getIn(['translation', 'content']) || status.get('content');
   }
   return status.getIn(['translation', 'contentHtml']) || status.get('contentHtml');

--- a/app/javascript/mastodon/features/emoji/emoji_html.tsx
+++ b/app/javascript/mastodon/features/emoji/emoji_html.tsx
@@ -7,6 +7,7 @@ import { isList } from 'immutable';
 import type { ApiCustomEmojiJSON } from '@/mastodon/api_types/custom_emoji';
 import { isFeatureEnabled } from '@/mastodon/initial_state';
 import type { CustomEmoji } from '@/mastodon/models/custom_emoji';
+import { isDevelopment } from '@/mastodon/utils/environment';
 
 import { useEmojiAppState } from './hooks';
 import { emojifyElement } from './render';
@@ -25,7 +26,7 @@ export const EmojiHTML: React.FC<EmojiHTMLProps> = ({
   extraEmojis,
   ...props
 }) => {
-  if (isFeatureEnabled('modern_emojis')) {
+  if (isFeatureEnabled('modern_emojis') && isDevelopment()) {
     return (
       <ModernEmojiHTML
         htmlString={htmlString}

--- a/app/javascript/mastodon/features/emoji/emoji_html.tsx
+++ b/app/javascript/mastodon/features/emoji/emoji_html.tsx
@@ -5,9 +5,8 @@ import type { List as ImmutableList } from 'immutable';
 import { isList } from 'immutable';
 
 import type { ApiCustomEmojiJSON } from '@/mastodon/api_types/custom_emoji';
-import { isFeatureEnabled } from '@/mastodon/initial_state';
 import type { CustomEmoji } from '@/mastodon/models/custom_emoji';
-import { isDevelopment } from '@/mastodon/utils/environment';
+import { isModernEmojiEnabled } from '@/mastodon/utils/environment';
 
 import { useEmojiAppState } from './hooks';
 import { emojifyElement } from './render';
@@ -26,7 +25,7 @@ export const EmojiHTML: React.FC<EmojiHTMLProps> = ({
   extraEmojis,
   ...props
 }) => {
-  if (isFeatureEnabled('modern_emojis') && isDevelopment()) {
+  if (isModernEmojiEnabled()) {
     return (
       <ModernEmojiHTML
         htmlString={htmlString}

--- a/app/javascript/mastodon/initial_state.js
+++ b/app/javascript/mastodon/initial_state.js
@@ -142,12 +142,4 @@ export function getAccessToken() {
   return getMeta('access_token');
 }
 
-/**
- * @param {string} feature
- * @returns {boolean}
- */
-export function isFeatureEnabled(feature) {
-  return initialState?.features?.includes(feature) || false;
-}
-
 export default initialState;

--- a/app/javascript/mastodon/main.tsx
+++ b/app/javascript/mastodon/main.tsx
@@ -29,7 +29,7 @@ function main() {
       });
     }
 
-    if (isFeatureEnabled('modern_emojis')) {
+    if (isFeatureEnabled('modern_emojis') && isDevelopment()) {
       const { initializeEmoji } = await import('@/mastodon/features/emoji');
       await initializeEmoji();
     }

--- a/app/javascript/mastodon/main.tsx
+++ b/app/javascript/mastodon/main.tsx
@@ -4,12 +4,16 @@ import { Globals } from '@react-spring/web';
 
 import { setupBrowserNotifications } from 'mastodon/actions/notifications';
 import Mastodon from 'mastodon/containers/mastodon';
-import { isFeatureEnabled, me, reduceMotion } from 'mastodon/initial_state';
+import { me, reduceMotion } from 'mastodon/initial_state';
 import * as perf from 'mastodon/performance';
 import ready from 'mastodon/ready';
 import { store } from 'mastodon/store';
 
-import { isProduction, isDevelopment } from './utils/environment';
+import {
+  isProduction,
+  isDevelopment,
+  isModernEmojiEnabled,
+} from './utils/environment';
 
 function main() {
   perf.start('main()');
@@ -29,7 +33,7 @@ function main() {
       });
     }
 
-    if (isFeatureEnabled('modern_emojis') && isDevelopment()) {
+    if (isModernEmojiEnabled()) {
       const { initializeEmoji } = await import('@/mastodon/features/emoji');
       await initializeEmoji();
     }

--- a/app/javascript/mastodon/utils/environment.ts
+++ b/app/javascript/mastodon/utils/environment.ts
@@ -1,3 +1,5 @@
+import initialState from '../initial_state';
+
 export function isDevelopment() {
   if (typeof process !== 'undefined')
     return process.env.NODE_ENV === 'development';
@@ -8,4 +10,14 @@ export function isProduction() {
   if (typeof process !== 'undefined')
     return process.env.NODE_ENV === 'production';
   else return import.meta.env.PROD;
+}
+
+export type Features = 'modern_emojis';
+
+export function isFeatureEnabled(feature: Features) {
+  return initialState?.features.includes(feature) ?? false;
+}
+
+export function isModernEmojiEnabled() {
+  return isFeatureEnabled('modern_emojis') && isDevelopment();
 }


### PR DESCRIPTION
With #35424 the new experimental emoji rendering was added behind the `EXPERIMENTAL_FEATURES` flag. Unfortunately it appears that was activated anyway on several production servers, leading to users experiencing known performance issues.

As this feature is still under heavy active development and is not ready for testing, this PR disables this feature in any production environment. When it becomes ready for real-world user testing we can remove this development check and accepting feedback.