### PR TITLE
Add restrictions on which quote posts can trend

### DIFF
--- a/app/models/trends/statuses.rb
+++ b/app/models/trends/statuses.rb
@@ -90,14 +90,28 @@ class Trends::Statuses < Trends::Base
 
   def eligible?(status)
     status.created_at.past? &&
-      status.public_visibility? &&
-      status.account.discoverable? &&
-      !status.account.silenced? &&
-      !status.account.sensitized? &&
-      status.spoiler_text.blank? &&
-      !status.sensitive? &&
+      opted_into_trends?(status) &&
+      !sensitive_content?(status) &&
       !status.reply? &&
-      valid_locale?(status.language)
+      valid_locale?(status.language) &&
+      (status.quote.nil? || trendable_quote?(status.quote))
+  end
+
+  def opted_into_trends?(status)
+    status.public_visibility? &&
+      status.account.discoverable? &&
+      !status.account.silenced?
+  end
+
+  def sensitive_content?(status)
+    status.account.sensitized? || status.spoiler_text.present? || status.sensitive?
+  end
+
+  def trendable_quote?(quote)
+    quote.acceptable? &&
+      quote.quoted_status.present? &&
+      opted_into_trends?(quote.quoted_status) &&
+      !sensitive_content?(quote.quoted_status)
   end
 
   def calculate_scores(statuses, at_time)

--- a/spec/models/trends/statuses_spec.rb
+++ b/spec/models/trends/statuses_spec.rb
@@ -111,17 +111,16 @@ RSpec.describe Trends::Statuses do
     let!(:yesterday) { today - 1.day }
 
     let!(:status_foo) { Fabricate(:status, text: 'Foo', language: 'en', trendable: true, created_at: yesterday) }
-    let!(:status_bar) { Fabricate(:status, text: 'Bar', language: 'en', trendable: true, created_at: today) }
+    let!(:status_bar) { Fabricate(:status, text: 'Bar', language: 'en', trendable: true, created_at: today, quote: Quote.new(state: :accepted, quoted_status: status_foo)) }
     let!(:status_baz) { Fabricate(:status, text: 'Baz', language: 'en', trendable: true, created_at: today) }
     let!(:untrendable) { Fabricate(:status, text: 'Untrendable', language: 'en', trendable: true, visibility: :unlisted) }
-    let!(:quote_post) { Fabricate(:status, text: 'Quote!', language: 'en', trendable: true, created_at: today, quote: Quote.new(state: :accepted, quoted_status: status_foo)) }
     let!(:untrendable_quote) { Fabricate(:status, text: 'Untrendable quote!', language: 'en', trendable: true, created_at: today, quote: Quote.new(state: :accepted, quoted_status: untrendable)) }
 
     before do
       default_threshold_value.times { reblog(status_foo, today) }
       default_threshold_value.times { reblog(status_bar, today) }
       default_threshold_value.times { reblog(untrendable, today) }
-      default_threshold_value.times { reblog(quote_post, today) }
+      default_threshold_value.times { reblog(untrendable_quote, today) }
       (default_threshold_value - 1).times { reblog(status_baz, today) }
     end
 
@@ -133,7 +132,7 @@ RSpec.describe Trends::Statuses do
       it 'returns correct statuses from query' do
         results = subject.query.limit(10).to_a
 
-        expect(results).to eq [quote_post, status_bar, status_foo]
+        expect(results).to eq [status_bar, status_foo]
         expect(results).to_not include(status_baz, untrendable, untrendable_quote)
       end
     end

--- a/spec/models/trends/statuses_spec.rb
+++ b/spec/models/trends/statuses_spec.rb
@@ -113,10 +113,15 @@ RSpec.describe Trends::Statuses do
     let!(:status_foo) { Fabricate(:status, text: 'Foo', language: 'en', trendable: true, created_at: yesterday) }
     let!(:status_bar) { Fabricate(:status, text: 'Bar', language: 'en', trendable: true, created_at: today) }
     let!(:status_baz) { Fabricate(:status, text: 'Baz', language: 'en', trendable: true, created_at: today) }
+    let!(:untrendable) { Fabricate(:status, text: 'Untrendable', language: 'en', trendable: true, visibility: :unlisted) }
+    let!(:quote_post) { Fabricate(:status, text: 'Quote!', language: 'en', trendable: true, created_at: today, quote: Quote.new(state: :accepted, quoted_status: status_foo)) }
+    let!(:untrendable_quote) { Fabricate(:status, text: 'Untrendable quote!', language: 'en', trendable: true, created_at: today, quote: Quote.new(state: :accepted, quoted_status: untrendable)) }
 
     before do
       default_threshold_value.times { reblog(status_foo, today) }
       default_threshold_value.times { reblog(status_bar, today) }
+      default_threshold_value.times { reblog(untrendable, today) }
+      default_threshold_value.times { reblog(quote_post, today) }
       (default_threshold_value - 1).times { reblog(status_baz, today) }
     end
 
@@ -128,8 +133,8 @@ RSpec.describe Trends::Statuses do
       it 'returns correct statuses from query' do
         results = subject.query.limit(10).to_a
 
-        expect(results).to eq [status_bar, status_foo]
-        expect(results).to_not include(status_baz)
+        expect(results).to eq [quote_post, status_bar, status_foo]
+        expect(results).to_not include(status_baz, untrendable, untrendable_quote)
       end
     end
 


### PR DESCRIPTION
This changes the trending behavior to only allow quote posts to trend if:
- the quoted post is resolvable and accepted
- the quoted post has opted into trending
- the quoted post is not sensitive content

This is similar to the original rules for trending posts, although:
- it allows the quoted post to be a reply (the rationale is that many quoted posts will be, and the quote post will provide context)
- it allows the quoted post to have an invalid language (the rationale for that is that the quoted post still has language restrictions and could be quoting from another language, providing a translation or sufficient context)
- it allows the quoted post to itself quote anything (this is partly for technical reasons, partly because those nested quotes are not directly displayed, and thus akin to a mention or a link)