### PR TITLE
Fix Vite build failure on Node.js v20 due to undefined file.parentPath

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -193,10 +193,11 @@ async function findEntrypoints() {
     withFileTypes: true,
   });
   const jsExtTest = /\.[jt]sx?$/;
+  const jsEntrypointsDir = path.resolve(jsRoot, 'entrypoints');
   for (const file of jsEntrypoints) {
     if (file.isFile() && jsExtTest.test(file.name)) {
       entrypoints[file.name.replace(jsExtTest, '')] = path.resolve(
-        file.parentPath,
+        jsEntrypointsDir,
         file.name,
       );
     }
@@ -208,10 +209,11 @@ async function findEntrypoints() {
     { withFileTypes: true },
   );
   const scssExtTest = /\.s?css$/;
+  const scssEntrypointsDir = path.resolve(jsRoot, 'styles/entrypoints');
   for (const file of scssEntrypoints) {
     if (file.isFile() && scssExtTest.test(file.name)) {
       entrypoints[file.name.replace(scssExtTest, '')] = path.resolve(
-        file.parentPath,
+        scssEntrypointsDir,
         file.name,
       );
     }


### PR DESCRIPTION
## Problem

The Vite build fails on Node.js v20. The error occurs probably because the `findEntrypoints()` function uses `file.parentPath` on `fs.Dirent` objects returned by `fs.readdir()` with `withFileTypes: true`. However, the `parentPath` property is only available when using **both** `withFileTypes: true` AND `recursive: true`. Since we only use `withFileTypes: true`, `parentPath` is undefined on Node.js v20, causing `path.resolve()` to fail.

Noticed this only in live/production environment where I use node v20.10.0. I use node v22.13.1 in development environment so there I couldn't reproduce it first.

## Root cause

Likely caused by commit [9e6a9efe10](https://github.com/mastodon/mastodon/commit/9e6a9efe101b36291897ae9fd4dbc5163a6cef38) related to #35195 which introduced `file.parentPath` usage that fails on Node.js v20.

The issue manifests differently across Node.js versions:
- **Node.js v20.x**: `file.parentPath` is undefined, causing build failure
- **Node.js v22.x**: The property may be available or handled differently, masking the issue in development

This version-dependent behavior affects production deployments using the minimum required Node.js version
  (v20+).

## To reproduce

```bash
nvm install 20.10.0
nvm use 20.10.0
```

Pull `main` branch in a863e68 and recompile, my command:

```bash
yarn cache clean && rm -rf node_modules && bundle install && yarn install --immutable && RAILS_ENV=production bundle exec rails assets:precompile
```

Build fails, log:

```
➤ YN0000: Done in 0s 18ms
Bundle complete! 151 Gemfile dependencies, 349 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
7 installed gems you directly depend on are looking for funding.
  Run `bundle fund` for details
➤ YN0000: · Yarn 4.9.2
➤ YN0000: ┌ Resolution step
➤ YN0000: └ Completed in 0s 224ms
➤ YN0000: ┌ Post-resolution validation
➤ YN0060: │ @vitest/browser is listed by your project with version 3.2.1 (p8c139), which doesn't satisfy what @vitest/coverage-v8 and other dependencies request (but they have non-overlapping ranges!).
➤ YN0060: │ @vitest/ui is listed by your project with version 3.2.2 (pb80ee), which doesn't satisfy what vitest requests (3.2.1).
➤ YN0060: │ react is listed by your project with version 18.3.1 (p68bdc), which doesn't satisfy what emoji-mart-lazyload and other dependencies request (but they have non-overlapping ranges!).
➤ YN0060: │ react-dom is listed by your project with version 18.3.1 (p9d1ad), which doesn't satisfy what react-router-scroll-4 and other dependencies request (but they have non-overlapping ranges!).
➤ YN0060: │ react-router-dom is listed by your project with version 5.3.4 (p7a2e6), which doesn't satisfy what react-router-scroll-4 requests (^4.0.0).
➤ YN0060: │ vitest is listed by your project with version 3.2.1 (pae261), which doesn't satisfy what @vitest/coverage-v8 and other dependencies request (but they have non-overlapping ranges!).
➤ YN0002: │ @mastodon/mastodon@workspace:. doesn't provide postcss (pfe5f4), requested by postcss-preset-env and other dependencies.
➤ YN0002: │ @mastodon/mastodon@workspace:. doesn't provide redux (p7bebf), requested by react-redux-loading-bar and other dependencies.
➤ YN0002: │ @mastodon/mastodon@workspace:. doesn't provide rollup (p04c65), requested by @optimize-lodash/rollup-plugin and other dependencies.
➤ YN0002: │ @mastodon/mastodon@workspace:. doesn't provide terser (pf7324), requested by @vitejs/plugin-legacy and other dependencies.
➤ YN0002: │ @mastodon/streaming@workspace:streaming doesn't provide eslint (p62755), requested by typescript-eslint.
➤ YN0086: │ Some peer dependencies are incorrectly met by your project; run yarn explain peer-requirements <hash> for details, where <hash> is the six-letter p-prefixed code.
➤ YN0086: │ Some peer dependencies are incorrectly met by dependencies; run yarn explain peer-requirements for details.
➤ YN0000: └ Completed
➤ YN0000: ┌ Fetch step
➤ YN0013: │ 1336 packages were added to the project (+ 480.08 MiB).
➤ YN0000: └ Completed in 5s 448ms
➤ YN0000: ┌ Link step
➤ YN0007: │ core-js@npm:3.44.0 must be built because it never has been before or the last one failed
➤ YN0007: │ msw@npm:2.10.2 [15ffb] must be built because it never has been before or the last one failed
➤ YN0007: │ tesseract.js@npm:6.0.1 must be built because it never has been before or the last one failed
➤ YN0007: │ core-js@npm:2.6.12 must be built because it never has been before or the last one failed
➤ YN0007: │ esbuild@npm:0.25.5 must be built because it never has been before or the last one failed
➤ YN0007: │ @parcel/watcher@npm:2.5.0 must be built because it never has been before or the last one failed
➤ YN0007: │ bufferutil@npm:4.0.9 must be built because it never has been before or the last one failed
➤ YN0007: │ utf-8-validate@npm:6.0.5 must be built because it never has been before or the last one failed
➤ YN0007: │ @mastodon/mastodon@workspace:. must be built because it never has been before or the last one failed
➤ YN0000: └ Completed in 4s 891ms
➤ YN0000: · Done with warnings in 10s 764ms
I, [2025-07-24T21:14:32.727035 #91195]  INFO -- : [dotenv] Loaded .env.production
Building with Vite ⚡️
failed to load config from /opt/mastodon/vite.config.mts
error during build:
TypeError [ERR_INVALID_ARG_TYPE]: The "paths[0]" argument must be of type string. Received undefined
    at validateString (node:internal/validators:162:11)
    at Object.resolve (node:path:1101:7)
    at findEntrypoints (file:///opt/mastodon/node_modules/.vite-temp/vite.config.mts.timestamp-1753380874259-88298d78780f6.mjs:707:61)
    at async config (file:///opt/mastodon/node_modules/.vite-temp/vite.config.mts.timestamp-1753380874259-88298d78780f6.mjs:603:16)
    at async loadConfigFromFile (file:///opt/mastodon/node_modules/vite/dist/node/chunks/dep-DBxKXgDP.js:49224:20)
    at async resolveConfig (file:///opt/mastodon/node_modules/vite/dist/node/chunks/dep-DBxKXgDP.js:48718:24)
    at async createBuilder (file:///opt/mastodon/node_modules/vite/dist/node/chunks/dep-DBxKXgDP.js:46707:18)
    at async CAC.<anonymous> (file:///opt/mastodon/node_modules/vite/dist/node/cli.js:862:23)

pid 91265 exit 1
Build with Vite failed! ❌
```

## Solution

Replace the undefined `file.parentPath` references with the actual parent directory paths that are already known:

- For JS entrypoints: Use `path.resolve(jsRoot, 'entrypoints')`
- For SCSS entrypoints: Use `path.resolve(jsRoot, 'styles/entrypoints')`

## Testing

- Verified build completes successfully on Node.js v20.10.0
- Entry points are correctly resolved to their full paths
- No functional changes to the build output

## Impact

This fix ensures consistent Vite builds across all supported Node.js versions (v20+) and resolves production deployment failures.

## Disclaimer

I am _not_ established expert in particular with Vite and JS and used _some_ AI to solve this, keep that in mind. This PR can naturally be modified.