### PR TITLE
Fix `Style/GuardClause` in `Tag`

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -164,9 +164,10 @@ class Tag < ApplicationRecord
   end
 
   def validate_display_name_change
-    unless HashtagNormalizer.new.normalize(display_name).casecmp(name).zero?
-      errors.add(:display_name,
-                 I18n.t('tags.does_not_match_previous_name'))
-    end
+    errors.add(:display_name, I18n.t('tags.does_not_match_previous_name')) unless display_name_matches_name?
+  end
+
+  def display_name_matches_name?
+    HashtagNormalizer.new.normalize(display_name).casecmp(name).zero?
   end
 end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Tag do
         subject { Fabricate :tag, name: 'original' }
 
         it { is_expected.to_not allow_value('changed').for(:name).with_message(previous_name_error_message) }
+        it { is_expected.to allow_value('ORIGINAL').for(:name) }
       end
     end
 
@@ -31,6 +32,7 @@ RSpec.describe Tag do
         subject { Fabricate :tag, name: 'original', display_name: 'OriginalDisplayName' }
 
         it { is_expected.to_not allow_value('ChangedDisplayName').for(:display_name).with_message(previous_name_error_message) }
+        it { is_expected.to allow_value('ORIGINAL').for(:display_name) }
       end
     end
 


### PR DESCRIPTION
Alternative to https://github.com/mastodon/mastodon/pull/34904

Rounded out validation coverage for non-failure scenarios in these two related methods.