### PR TITLE
Reduce factory creation across `spec/helpers`

### DIFF
--- a/spec/helpers/admin/account_moderation_notes_helper_spec.rb
+++ b/spec/helpers/admin/account_moderation_notes_helper_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Admin::AccountModerationNotesHelper do
     end
 
     context 'with account' do
-      let(:account) { Fabricate(:account) }
+      let(:account) { Fabricate.build(:account, id: 123) }
 
       it 'returns a labeled avatar link to the account' do
         expect(parsed_html.a[:href]).to eq admin_account_path(account.id)
@@ -39,7 +39,7 @@ RSpec.describe Admin::AccountModerationNotesHelper do
     end
 
     context 'with account' do
-      let(:account) { Fabricate(:account) }
+      let(:account) { Fabricate.build(:account, id: 123) }
 
       it 'returns an inline link to the account' do
         expect(parsed_html.a[:href]).to eq admin_account_path(account.id)

--- a/spec/helpers/admin/dashboard_helper_spec.rb
+++ b/spec/helpers/admin/dashboard_helper_spec.rb
@@ -4,8 +4,9 @@ require 'rails_helper'
 
 RSpec.describe Admin::DashboardHelper do
   describe 'relevant_account_timestamp' do
+    let(:account) { Fabricate(:account) }
+
     context 'with an account with older sign in' do
-      let(:account) { Fabricate(:account) }
       let(:stamp) { 10.days.ago }
 
       it 'returns a time element' do
@@ -18,8 +19,6 @@ RSpec.describe Admin::DashboardHelper do
     end
 
     context 'with an account with newer sign in' do
-      let(:account) { Fabricate(:account) }
-
       it 'returns a time element' do
         account.user.update(current_sign_in_at: 10.hours.ago)
         result = helper.relevant_account_timestamp(account)
@@ -29,8 +28,6 @@ RSpec.describe Admin::DashboardHelper do
     end
 
     context 'with an account where the user is pending' do
-      let(:account) { Fabricate(:account) }
-
       it 'returns a time element' do
         account.user.update(current_sign_in_at: nil)
         account.user.update(approved: false)
@@ -42,7 +39,6 @@ RSpec.describe Admin::DashboardHelper do
     end
 
     context 'with an account with a last status value' do
-      let(:account) { Fabricate(:account) }
       let(:stamp) { 5.minutes.ago }
 
       it 'returns a time element' do
@@ -56,8 +52,6 @@ RSpec.describe Admin::DashboardHelper do
     end
 
     context 'with an account without sign in or last status or pending' do
-      let(:account) { Fabricate(:account) }
-
       it 'returns a time element' do
         account.user.update(current_sign_in_at: nil)
         result = helper.relevant_account_timestamp(account)

--- a/spec/helpers/admin/trends/statuses_helper_spec.rb
+++ b/spec/helpers/admin/trends/statuses_helper_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Admin::Trends::StatusesHelper do
     context 'with a status that has emoji' do
       before { Fabricate(:custom_emoji, shortcode: 'florpy') }
 
-      let(:status) { Fabricate(:status, text: 'hello there :florpy:') }
+      let(:status) { Fabricate.build(:status, text: 'hello there :florpy:') }
 
       it 'renders a correct preview text' do
         result = helper.one_line_preview(status)

--- a/spec/helpers/formatting_helper_spec.rb
+++ b/spec/helpers/formatting_helper_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe FormattingHelper do
     end
 
     context 'with a spoiler and an emoji and a poll' do
-      let(:status) { Fabricate(:status, text: 'Hello :world: <>', spoiler_text: 'This is a spoiler<>', poll: Fabricate(:poll, options: %w(Yes<> No))) }
+      let(:status) { Fabricate(:status, text: 'Hello :world: <>', spoiler_text: 'This is a spoiler<>', poll: Fabricate.build(:poll, options: %w(Yes<> No))) }
 
       before { Fabricate :custom_emoji, shortcode: 'world' }
 

--- a/spec/helpers/home_helper_spec.rb
+++ b/spec/helpers/home_helper_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe HomeHelper do
     end
 
     context 'with a valid account' do
-      let(:account) { Fabricate(:account) }
+      let(:account) { Fabricate.build(:account) }
 
       before { helper.extend controller_helpers }
 

--- a/spec/helpers/media_component_helper_spec.rb
+++ b/spec/helpers/media_component_helper_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe MediaComponentHelper do
   before { helper.extend controller_helpers }
 
   describe 'render_video_component' do
-    let(:media) { Fabricate(:media_attachment, type: :video, status: Fabricate(:status)) }
+    let(:media) { Fabricate(:media_attachment, type: :video, status: Fabricate.build(:status)) }
     let(:result) { helper.render_video_component(media.status) }
 
     it 'renders a react component for the video' do
@@ -15,7 +15,7 @@ RSpec.describe MediaComponentHelper do
   end
 
   describe 'render_audio_component' do
-    let(:media) { Fabricate(:media_attachment, type: :audio, status: Fabricate(:status)) }
+    let(:media) { Fabricate(:media_attachment, type: :audio, status: Fabricate.build(:status)) }
     let(:result) { helper.render_audio_component(media.status) }
 
     it 'renders a react component for the audio' do
@@ -24,7 +24,7 @@ RSpec.describe MediaComponentHelper do
   end
 
   describe 'render_media_gallery_component' do
-    let(:media) { Fabricate(:media_attachment, type: :audio, status: Fabricate(:status)) }
+    let(:media) { Fabricate(:media_attachment, type: :audio, status: Fabricate.build(:status)) }
     let(:result) { helper.render_media_gallery_component(media.status) }
 
     it 'renders a react component for the media gallery' do

--- a/spec/helpers/media_component_helper_spec.rb
+++ b/spec/helpers/media_component_helper_spec.rb
@@ -5,8 +5,10 @@ require 'rails_helper'
 RSpec.describe MediaComponentHelper do
   before { helper.extend controller_helpers }
 
+  let(:media) { Fabricate.build(:media_attachment, type:, status: Fabricate.build(:status)) }
+
   describe 'render_video_component' do
-    let(:media) { Fabricate(:media_attachment, type: :video, status: Fabricate.build(:status)) }
+    let(:type) { :video }
     let(:result) { helper.render_video_component(media.status) }
 
     it 'renders a react component for the video' do
@@ -15,7 +17,7 @@ RSpec.describe MediaComponentHelper do
   end
 
   describe 'render_audio_component' do
-    let(:media) { Fabricate(:media_attachment, type: :audio, status: Fabricate.build(:status)) }
+    let(:type) { :audio }
     let(:result) { helper.render_audio_component(media.status) }
 
     it 'renders a react component for the audio' do
@@ -24,7 +26,7 @@ RSpec.describe MediaComponentHelper do
   end
 
   describe 'render_media_gallery_component' do
-    let(:media) { Fabricate(:media_attachment, type: :audio, status: Fabricate.build(:status)) }
+    let(:type) { :audio }
     let(:result) { helper.render_media_gallery_component(media.status) }
 
     it 'renders a react component for the media gallery' do

--- a/spec/helpers/statuses_helper_spec.rb
+++ b/spec/helpers/statuses_helper_spec.rb
@@ -24,16 +24,13 @@ RSpec.describe StatusesHelper do
   end
 
   describe '#media_summary' do
-    it 'describes the media on a status' do
-      status = Fabricate :status
-      Fabricate :media_attachment, status: status, type: :video
-      Fabricate :media_attachment, status: status, type: :audio
-      Fabricate :media_attachment, status: status, type: :image
+    subject { helper.media_summary(status) }
 
-      result = helper.media_summary(status)
+    let(:status) { Fabricate.build :status }
 
-      expect(result).to eq('Attached: 1 image · 1 video · 1 audio')
-    end
+    before { %i(video audio image).each { |type| Fabricate.build :media_attachment, status:, type: } }
+
+    it { is_expected.to eq('Attached: 1 image · 1 video · 1 audio') }
   end
 
   describe 'visibility_icon' do


### PR DESCRIPTION
Drops from 31 to 16 across various specs ... combining all as one here since they are all  pretty simple.

Almost all of them are just converting to `build` where we didn't really need a persisted objected. Some lightweight setup cleanup/refactor where straightforward to do so.