### PR TITLE
Fix `Style/GuardClause` in `Webfinger` lib

### DIFF
--- a/app/lib/webfinger.rb
+++ b/app/lib/webfinger.rb
@@ -84,22 +84,18 @@ class Webfinger
 
   def body_from_host_meta
     host_meta_request.perform do |res|
-      if res.code == 200
-        body_from_webfinger(url_from_template(res.body_with_limit), use_fallback: false)
-      else
-        raise Webfinger::Error, "Request for #{@uri} returned HTTP #{res.code}"
-      end
+      raise Webfinger::Error, "Request for #{@uri} returned HTTP #{res.code}" unless res.code == 200
+
+      body_from_webfinger(url_from_template(res.body_with_limit), use_fallback: false)
     end
   end
 
   def url_from_template(str)
     link = Nokogiri::XML(str).at_xpath('//xmlns:Link[@rel="lrdd"]')
 
-    if link.present?
-      link['template'].gsub('{uri}', @uri)
-    else
-      raise Webfinger::Error, "Request for #{@uri} returned host-meta without link to Webfinger"
-    end
+    raise Webfinger::Error, "Request for #{@uri} returned host-meta without link to Webfinger" if link.blank?
+
+    link['template'].gsub('{uri}', @uri)
   rescue Nokogiri::XML::XPath::SyntaxError
     raise Webfinger::Error, "Invalid XML encountered in host-meta for #{@uri}"
   end

--- a/spec/lib/webfinger_spec.rb
+++ b/spec/lib/webfinger_spec.rb
@@ -4,15 +4,15 @@ require 'rails_helper'
 
 RSpec.describe Webfinger do
   describe 'self link' do
+    subject { described_class.new('acct:alice@example.com').perform }
+
     context 'when self link is specified with type application/activity+json' do
       let!(:webfinger) { { subject: 'acct:alice@example.com', links: [{ rel: 'self', href: 'https://example.com/alice', type: 'application/activity+json' }] } }
 
       it 'correctly parses the response' do
         stub_request(:get, 'https://example.com/.well-known/webfinger?resource=acct:alice@example.com').to_return(body: Oj.dump(webfinger), headers: { 'Content-Type': 'application/jrd+json' })
 
-        response = described_class.new('acct:alice@example.com').perform
-
-        expect(response.self_link_href).to eq 'https://example.com/alice'
+        expect(subject.self_link_href).to eq 'https://example.com/alice'
       end
     end
 
@@ -22,9 +22,7 @@ RSpec.describe Webfinger do
       it 'correctly parses the response' do
         stub_request(:get, 'https://example.com/.well-known/webfinger?resource=acct:alice@example.com').to_return(body: Oj.dump(webfinger), headers: { 'Content-Type': 'application/jrd+json' })
 
-        response = described_class.new('acct:alice@example.com').perform
-
-        expect(response.self_link_href).to eq 'https://example.com/alice'
+        expect(subject.self_link_href).to eq 'https://example.com/alice'
       end
     end
 
@@ -34,7 +32,45 @@ RSpec.describe Webfinger do
       it 'raises an error' do
         stub_request(:get, 'https://example.com/.well-known/webfinger?resource=acct:alice@example.com').to_return(body: Oj.dump(webfinger), headers: { 'Content-Type': 'application/jrd+json' })
 
-        expect { described_class.new('acct:alice@example.com').perform }.to raise_error(Webfinger::Error)
+        expect { subject }
+          .to raise_error(Webfinger::Error)
+      end
+    end
+
+    context 'when webfinger fails and host meta is used' do
+      before { stub_request(:get, 'https://example.com/.well-known/webfinger?resource=acct:alice@example.com').to_return(status: 404) }
+
+      context 'when host meta succeeds' do
+        let(:host_meta) do
+          <<~XML
+            <?xml version="1.0"?>
+            <XRD xmlns="http://docs.oasis-open.org/ns/xri/xrd-1.0">
+              <Link rel="lrdd" type="application/xrd+xml" template="https://example.com/.well-known/nonStandardWebfinger?resource={uri}"/>
+            </XRD>
+          XML
+        end
+        let(:webfinger) { { subject: 'acct:alice@example.com', links: [{ rel: 'self', href: 'https://example.com/alice-from-NS', type: 'application/activity+json' }] } }
+
+        before do
+          stub_request(:get, 'https://example.com/.well-known/host-meta').to_return(body: host_meta, headers: { 'Content-Type': 'application/jrd+json' })
+          stub_request(:get, 'https://example.com/.well-known/nonStandardWebfinger?resource=acct:alice@example.com').to_return(body: Oj.dump(webfinger), headers: { 'Content-Type': 'application/jrd+json' })
+        end
+
+        it 'uses host meta details' do
+          expect(subject.self_link_href)
+            .to eq 'https://example.com/alice-from-NS'
+        end
+      end
+
+      context 'when host meta fails' do
+        before do
+          stub_request(:get, 'https://example.com/.well-known/host-meta').to_return(status: 500)
+        end
+
+        it 'raises error' do
+          expect { subject }
+            .to raise_error(Webfinger::Error)
+        end
       end
     end
   end


### PR DESCRIPTION
Alternative to https://github.com/mastodon/mastodon/pull/34904

Auto-correct in the actual lib -- added some coverage for the cases this code handles.