### PR TITLE
hotkeys: only match `just()` when no modifiers are held

### DIFF
--- a/app/javascript/mastodon/components/hotkeys/index.tsx
+++ b/app/javascript/mastodon/components/hotkeys/index.tsx
@@ -40,8 +40,11 @@ type KeyMatcher = (
  */
 function just(keyName: string): KeyMatcher {
   return (event) => ({
-    isMatch: normalizeKey(event.key) === keyName
-      && !event.altKey && !event.ctrlKey && !event.metaKey,
+    isMatch:
+      normalizeKey(event.key) === keyName &&
+      !event.altKey &&
+      !event.ctrlKey &&
+      !event.metaKey,
     priority: hotkeyPriority.singleKey,
   });
 }

--- a/app/javascript/mastodon/components/hotkeys/index.tsx
+++ b/app/javascript/mastodon/components/hotkeys/index.tsx
@@ -40,7 +40,8 @@ type KeyMatcher = (
  */
 function just(keyName: string): KeyMatcher {
   return (event) => ({
-    isMatch: normalizeKey(event.key) === keyName,
+    isMatch: normalizeKey(event.key) === keyName
+      && !event.altKey && !event.ctrlKey && !event.metaKey,
     priority: hotkeyPriority.singleKey,
   });
 }


### PR DESCRIPTION
The new hotkeys component introduced in #35425 matches keys even when modifiers are held. In the case of numeric keys, this overrides/breaks Firefox functionality for switching tabs (Alt-1, Alt-2, etc).

I'm not sure if this is the correct fix, or if you'd prefer more nuanced matching logic, but I think at the very least that grabbing keys with modifiers should be an explicit choice because of the potential for browser conflicts.