### PR TITLE
Add `targeted_account_notes` association to simplify usage

### DIFF
--- a/app/controllers/api/v1/accounts/notes_controller.rb
+++ b/app/controllers/api/v1/accounts/notes_controller.rb
@@ -9,9 +9,9 @@ class Api::V1::Accounts::NotesController < Api::BaseController
 
   def create
     if params[:comment].blank?
-      AccountNote.find_by(account: current_account, target_account: @account)&.destroy
+      current_account.account_notes.find_by(target_account: @account)&.destroy
     else
-      @note = AccountNote.find_or_initialize_by(account: current_account, target_account: @account)
+      @note = current_account.account_notes.find_or_initialize_by(target_account: @account)
       @note.comment = params[:comment]
       @note.save! if @note.changed?
     end

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -9,6 +9,7 @@ module Account::Associations
       # Association where account owns record
       with_options inverse_of: :account do
         has_many :account_moderation_notes
+        has_many :account_notes
         has_many :account_pins
         has_many :account_warnings
         has_many :aliases, class_name: 'AccountAlias'
@@ -45,6 +46,7 @@ module Account::Associations
       # Association where account is targeted by record
       with_options foreign_key: :target_account_id, inverse_of: :target_account do
         has_many :strikes, class_name: 'AccountWarning'
+        has_many :targeted_account_notes, class_name: 'AccountNote'
         has_many :targeted_moderation_notes, class_name: 'AccountModerationNote'
         has_many :targeted_reports, class_name: 'Report'
       end

--- a/app/models/concerns/account/interactions.rb
+++ b/app/models/concerns/account/interactions.rb
@@ -23,9 +23,6 @@ module Account::Interactions
     # Hashtag follows
     has_many :tag_follows, inverse_of: :account, dependent: :destroy
 
-    # Account notes
-    has_many :account_notes, dependent: :destroy
-
     # Block relationships
     with_options class_name: 'Block', dependent: :destroy do
       has_many :block_relationships, foreign_key: 'account_id', inverse_of: :account

--- a/app/workers/move_worker.rb
+++ b/app/workers/move_worker.rb
@@ -84,17 +84,17 @@ class MoveWorker
   end
 
   def copy_account_notes!
-    AccountNote.where(target_account: @source_account).find_each do |note|
+    @source_account.targeted_account_notes.find_each do |note|
       text = I18n.with_locale(note.account.user_locale.presence || I18n.default_locale) do
         I18n.t('move_handler.copy_account_note_text', acct: @source_account.acct)
       end
 
-      new_note = AccountNote.find_by(account: note.account, target_account: @target_account)
+      new_note = @target_account.targeted_account_notes.find_by(account: note.account)
       if new_note.nil?
         begin
-          AccountNote.create!(account: note.account, target_account: @target_account, comment: [text, note.comment].join("\n"))
+          @target_account.targeted_account_notes.create!(account: note.account, comment: [text, note.comment].join("\n"))
         rescue ActiveRecord::RecordInvalid
-          AccountNote.create!(account: note.account, target_account: @target_account, comment: note.comment)
+          @target_account.targeted_account_notes.create!(account: note.account, comment: note.comment)
         end
       else
         new_note.update!(comment: [text, note.comment, "\n", new_note.comment].join("\n"))
@@ -129,7 +129,7 @@ class MoveWorker
   end
 
   def add_account_note_if_needed!(account, id)
-    return if AccountNote.exists?(account: account, target_account: @target_account)
+    return if @target_account.targeted_account_notes.exists?(account:)
 
     text = I18n.with_locale(account.user_locale.presence || I18n.default_locale) do
       I18n.t(id, acct: @source_account.acct)

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -6,6 +6,11 @@ RSpec.describe Account do
   it_behaves_like 'Account::Search'
   it_behaves_like 'Reviewable'
 
+  describe 'Associations' do
+    it { is_expected.to have_many(:account_notes).inverse_of(:account) }
+    it { is_expected.to have_many(:targeted_account_notes).inverse_of(:target_account) }
+  end
+
   context 'with an account record' do
     subject { Fabricate(:account) }
 


### PR DESCRIPTION
Related changes:

- Move the existing account notes association declaration from "interactions" to "associations", which, to the extent there's any rhyme or reason to these, seems more accurate
- Add a "targeted" version, using existing pattern of `with_options` wrapper on various options, and move both to correct section
- In multiple spots that could use one/both of these for more compact calls, use them!