### PR TITLE
Rely on built-in query methods for timestamp presence checks

### DIFF
--- a/app/helpers/admin/dashboard_helper.rb
+++ b/app/helpers/admin/dashboard_helper.rb
@@ -30,7 +30,7 @@ module Admin::DashboardHelper
                          [account.user_current_sign_in_at, false]
                        elsif account.user_pending?
                          [account.user_created_at, true]
-                       elsif account.suspended_at.present? && account.local? && account.user.nil?
+                       elsif account.suspended_at? && account.local? && account.user.nil?
                          [account.suspended_at, true]
                        elsif account.last_status_at.present?
                          [account.last_status_at, true]

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -247,7 +247,7 @@ class Account < ApplicationRecord
   end
 
   def schedule_refresh_if_stale!
-    return unless last_webfingered_at.present? && last_webfingered_at <= BACKGROUND_REFRESH_INTERVAL.ago
+    return unless last_webfingered_at? && last_webfingered_at <= BACKGROUND_REFRESH_INTERVAL.ago
 
     AccountRefreshWorker.perform_in(rand(REFRESH_DEADLINE), id)
   end

--- a/app/models/account_warning.rb
+++ b/app/models/account_warning.rb
@@ -47,7 +47,7 @@ class AccountWarning < ApplicationRecord
   end
 
   def overruled?
-    overruled_at.present?
+    overruled_at?
   end
 
   def appeal_eligible?

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -56,7 +56,7 @@ class Announcement < ApplicationRecord
   end
 
   def notification_sent?
-    notification_sent_at.present?
+    notification_sent_at?
   end
 
   def mentions

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -40,11 +40,11 @@ class Appeal < ApplicationRecord
   end
 
   def approved?
-    approved_at.present?
+    approved_at?
   end
 
   def rejected?
-    rejected_at.present?
+    rejected_at?
   end
 
   def approve!(current_account)

--- a/app/models/concerns/account/sensitizes.rb
+++ b/app/models/concerns/account/sensitizes.rb
@@ -8,7 +8,7 @@ module Account::Sensitizes
   end
 
   def sensitized?
-    sensitized_at.present?
+    sensitized_at?
   end
 
   def sensitize!(date = Time.now.utc)

--- a/app/models/concerns/account/silences.rb
+++ b/app/models/concerns/account/silences.rb
@@ -9,7 +9,7 @@ module Account::Silences
   end
 
   def silenced?
-    silenced_at.present?
+    silenced_at?
   end
 
   def silence!(date = Time.now.utc)

--- a/app/models/concerns/account/suspensions.rb
+++ b/app/models/concerns/account/suspensions.rb
@@ -9,7 +9,7 @@ module Account::Suspensions
   end
 
   def suspended?
-    suspended_at.present? && !instance_actor?
+    suspended_at? && !instance_actor?
   end
   alias unavailable? suspended?
 

--- a/app/models/concerns/reviewable.rb
+++ b/app/models/concerns/reviewable.rb
@@ -13,11 +13,11 @@ module Reviewable
   end
 
   def reviewed?
-    reviewed_at.present?
+    reviewed_at?
   end
 
   def requested_review?
-    requested_review_at.present?
+    requested_review_at?
   end
 
   def requires_review_notification?

--- a/app/models/concerns/status/snapshot_concern.rb
+++ b/app/models/concerns/status/snapshot_concern.rb
@@ -8,7 +8,7 @@ module Status::SnapshotConcern
   end
 
   def edited?
-    edited_at.present?
+    edited_at?
   end
 
   def build_snapshot(account_id: nil, at_time: nil, rate_limit: true)

--- a/app/models/concerns/user/activity.rb
+++ b/app/models/concerns/user/activity.rb
@@ -17,7 +17,7 @@ module User::Activity
   end
 
   def signed_in_recently?
-    current_sign_in_at.present? && current_sign_in_at >= ACTIVE_DURATION.ago
+    current_sign_in_at? && current_sign_in_at >= ACTIVE_DURATION.ago
   end
 
   private

--- a/app/models/concerns/user/confirmation.rb
+++ b/app/models/concerns/user/confirmation.rb
@@ -13,7 +13,7 @@ module User::Confirmation
   end
 
   def confirmed?
-    confirmed_at.present?
+    confirmed_at?
   end
 
   def unconfirmed?

--- a/app/models/featured_tag.rb
+++ b/app/models/featured_tag.rb
@@ -49,7 +49,7 @@ class FeaturedTag < ApplicationRecord
   def decrement(deleted_status)
     if statuses_count <= 1
       update(statuses_count: 0, last_status_at: nil)
-    elsif last_status_at.present? && last_status_at > deleted_status.created_at
+    elsif last_status_at? && last_status_at > deleted_status.created_at
       update(statuses_count: statuses_count - 1)
     else
       # Fetching the latest status creation time can be expensive, so only perform it

--- a/app/models/generated_annual_report.rb
+++ b/app/models/generated_annual_report.rb
@@ -20,7 +20,7 @@ class GeneratedAnnualReport < ApplicationRecord
   scope :pending, -> { where(viewed_at: nil) }
 
   def viewed?
-    viewed_at.present?
+    viewed_at?
   end
 
   def view!

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -116,7 +116,7 @@ class Report < ApplicationRecord
   end
 
   def action_taken?
-    action_taken_at.present?
+    action_taken_at?
   end
 
   alias action_taken action_taken?

--- a/app/models/scheduled_status.rb
+++ b/app/models/scheduled_status.rb
@@ -27,7 +27,7 @@ class ScheduledStatus < ApplicationRecord
   private
 
   def validate_future_date
-    errors.add(:scheduled_at, I18n.t('scheduled_statuses.too_soon')) if scheduled_at.present? && scheduled_at <= Time.now.utc + MINIMUM_OFFSET
+    errors.add(:scheduled_at, I18n.t('scheduled_statuses.too_soon')) if scheduled_at? && scheduled_at <= Time.now.utc + MINIMUM_OFFSET
   end
 
   def validate_total_limit

--- a/app/models/terms_of_service.rb
+++ b/app/models/terms_of_service.rb
@@ -32,7 +32,7 @@ class TermsOfService < ApplicationRecord
   end
 
   def published?
-    published_at.present?
+    published_at?
   end
 
   def effective?
@@ -44,7 +44,7 @@ class TermsOfService < ApplicationRecord
   end
 
   def notification_sent?
-    notification_sent_at.present?
+    notification_sent_at?
   end
 
   def base_user_scope

--- a/app/services/update_status_service.rb
+++ b/app/services/update_status_service.rb
@@ -147,7 +147,7 @@ class UpdateStatusService < BaseService
     # If the poll had no expiration date set but now has, or now has a sooner
     # expiration date, schedule a notification
 
-    return unless poll.present? && poll.expires_at.present?
+    return unless poll.present? && poll.expires_at?
 
     PollExpirationNotifyWorker.remove_from_scheduled(poll.id) if @previous_expires_at.present? && @previous_expires_at > poll.expires_at
     PollExpirationNotifyWorker.perform_at(poll.expires_at + 5.minutes, poll.id)

--- a/app/workers/poll_expiration_notify_worker.rb
+++ b/app/workers/poll_expiration_notify_worker.rb
@@ -29,7 +29,7 @@ class PollExpirationNotifyWorker
   end
 
   def not_due_yet?
-    @poll.expires_at.present? && !@poll.expired?
+    @poll.expires_at? && !@poll.expired?
   end
 
   def requeue!

--- a/lib/mastodon/cli/accounts.rb
+++ b/lib/mastodon/cli/accounts.rb
@@ -305,7 +305,7 @@ module Mastodon::CLI
       query = query.where(domain: domains) unless domains.empty?
 
       processed, culled = parallelize_with_progress(query.partitioned) do |account|
-        next if account.updated_at >= skip_threshold || (account.last_webfingered_at.present? && account.last_webfingered_at >= skip_threshold) || skip_domains.include?(account.domain)
+        next if account.updated_at >= skip_threshold || (account.last_webfingered_at? && account.last_webfingered_at >= skip_threshold) || skip_domains.include?(account.domain)
 
         code = 0
 


### PR DESCRIPTION
There are probably more like this where we could use the generated query methods for attributes, but as a first pass I did just the timestamp ones because they were easiest to bulk find/update.

Follow-ups:

- Find other quick/easy shortening like this for other attributes
- For the methods where we are just doing an "alias" style name wrapper on a query method (ie, `overruled?` wrapping `overruled_at` sort of thing), it seems like adding spec coverage and then doing `alias` or `alias_method` would turn them all into nice one-liners ... but because of how rails makes the attribute query methods that won't work -- however, there is an `alias_attribute` which would generate aliased getter/setter/query methods. We'd have to just be careful that we weren't overwriting any spots where our current getter/query differ (ie, `Report#action_taken` is like this from a legacy data change) ... but I think it could be safely done for many/most of them.