### PR TITLE
Move repeated snowflake ID gather to base classes

### DIFF
--- a/app/lib/admin/metrics/dimension/base_dimension.rb
+++ b/app/lib/admin/metrics/dimension/base_dimension.rb
@@ -65,4 +65,16 @@ class Admin::Metrics::Dimension::BaseDimension
   def canonicalized_params
     params.to_h.to_a.sort_by { |k, _v| k.to_s }.map { |k, v| "#{k}=#{v}" }.join(';')
   end
+
+  def earliest_status_id
+    snowflake_id(@start_at.beginning_of_day)
+  end
+
+  def latest_status_id
+    snowflake_id(@end_at.end_of_day)
+  end
+
+  def snowflake_id(datetime)
+    Mastodon::Snowflake.id_at(datetime, with_random: false)
+  end
 end

--- a/app/lib/admin/metrics/dimension/instance_languages_dimension.rb
+++ b/app/lib/admin/metrics/dimension/instance_languages_dimension.rb
@@ -19,7 +19,7 @@ class Admin::Metrics::Dimension::InstanceLanguagesDimension < Admin::Metrics::Di
   end
 
   def sql_array
-    [sql_query_string, { domain: params[:domain], earliest_status_id: earliest_status_id, latest_status_id: latest_status_id, limit: @limit }]
+    [sql_query_string, { domain: params[:domain], earliest_status_id:, latest_status_id:, limit: @limit }]
   end
 
   def sql_query_string
@@ -34,14 +34,6 @@ class Admin::Metrics::Dimension::InstanceLanguagesDimension < Admin::Metrics::Di
       ORDER BY count(*) DESC
       LIMIT :limit
     SQL
-  end
-
-  def earliest_status_id
-    Mastodon::Snowflake.id_at(@start_at.beginning_of_day, with_random: false)
-  end
-
-  def latest_status_id
-    Mastodon::Snowflake.id_at(@end_at.end_of_day, with_random: false)
   end
 
   def params

--- a/app/lib/admin/metrics/dimension/servers_dimension.rb
+++ b/app/lib/admin/metrics/dimension/servers_dimension.rb
@@ -14,7 +14,7 @@ class Admin::Metrics::Dimension::ServersDimension < Admin::Metrics::Dimension::B
   end
 
   def sql_array
-    [sql_query_string, { earliest_status_id: earliest_status_id, latest_status_id: latest_status_id, limit: @limit }]
+    [sql_query_string, { earliest_status_id:, latest_status_id:, limit: @limit }]
   end
 
   def sql_query_string
@@ -27,13 +27,5 @@ class Admin::Metrics::Dimension::ServersDimension < Admin::Metrics::Dimension::B
       ORDER BY count(*) DESC
       LIMIT :limit
     SQL
-  end
-
-  def earliest_status_id
-    Mastodon::Snowflake.id_at(@start_at.beginning_of_day, with_random: false)
-  end
-
-  def latest_status_id
-    Mastodon::Snowflake.id_at(@end_at.end_of_day, with_random: false)
   end
 end

--- a/app/lib/admin/metrics/dimension/tag_languages_dimension.rb
+++ b/app/lib/admin/metrics/dimension/tag_languages_dimension.rb
@@ -19,7 +19,7 @@ class Admin::Metrics::Dimension::TagLanguagesDimension < Admin::Metrics::Dimensi
   end
 
   def sql_array
-    [sql_query_string, { tag_id: tag_id, earliest_status_id: earliest_status_id, latest_status_id: latest_status_id, limit: @limit }]
+    [sql_query_string, { tag_id: tag_id, earliest_status_id:, latest_status_id:, limit: @limit }]
   end
 
   def sql_query_string
@@ -37,14 +37,6 @@ class Admin::Metrics::Dimension::TagLanguagesDimension < Admin::Metrics::Dimensi
 
   def tag_id
     params[:id]
-  end
-
-  def earliest_status_id
-    Mastodon::Snowflake.id_at(@start_at.beginning_of_day, with_random: false)
-  end
-
-  def latest_status_id
-    Mastodon::Snowflake.id_at(@end_at.end_of_day, with_random: false)
   end
 
   def params

--- a/app/lib/admin/metrics/dimension/tag_servers_dimension.rb
+++ b/app/lib/admin/metrics/dimension/tag_servers_dimension.rb
@@ -18,7 +18,7 @@ class Admin::Metrics::Dimension::TagServersDimension < Admin::Metrics::Dimension
   end
 
   def sql_array
-    [sql_query_string, { tag_id: tag_id, earliest_status_id: earliest_status_id, latest_status_id: latest_status_id, limit: @limit }]
+    [sql_query_string, { tag_id: tag_id, earliest_status_id:, latest_status_id:, limit: @limit }]
   end
 
   def sql_query_string
@@ -37,14 +37,6 @@ class Admin::Metrics::Dimension::TagServersDimension < Admin::Metrics::Dimension
 
   def tag_id
     params[:id]
-  end
-
-  def earliest_status_id
-    Mastodon::Snowflake.id_at(@start_at.beginning_of_day, with_random: false)
-  end
-
-  def latest_status_id
-    Mastodon::Snowflake.id_at(@end_at.end_of_day, with_random: false)
   end
 
   def params

--- a/app/lib/admin/metrics/measure/base_measure.rb
+++ b/app/lib/admin/metrics/measure/base_measure.rb
@@ -104,4 +104,16 @@ class Admin::Metrics::Measure::BaseMeasure
   def canonicalized_params
     params.to_h.to_a.sort_by { |k, _v| k.to_s }.map { |k, v| "#{k}=#{v}" }.join(';')
   end
+
+  def earliest_status_id
+    snowflake_id(@start_at.beginning_of_day)
+  end
+
+  def latest_status_id
+    snowflake_id(@end_at.end_of_day)
+  end
+
+  def snowflake_id(datetime)
+    Mastodon::Snowflake.id_at(datetime, with_random: false)
+  end
 end

--- a/app/lib/admin/metrics/measure/instance_statuses_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_statuses_measure.rb
@@ -28,7 +28,7 @@ class Admin::Metrics::Measure::InstanceStatusesMeasure < Admin::Metrics::Measure
   end
 
   def sql_array
-    [sql_query_string, { start_at: @start_at, end_at: @end_at, domain: params[:domain], earliest_status_id: earliest_status_id, latest_status_id: latest_status_id }]
+    [sql_query_string, { start_at: @start_at, end_at: @end_at, domain: params[:domain], earliest_status_id:, latest_status_id: }]
   end
 
   def sql_query_string
@@ -48,14 +48,6 @@ class Admin::Metrics::Measure::InstanceStatusesMeasure < Admin::Metrics::Measure
         #{generated_series_days}
       ) AS axis
     SQL
-  end
-
-  def earliest_status_id
-    Mastodon::Snowflake.id_at(@start_at.beginning_of_day, with_random: false)
-  end
-
-  def latest_status_id
-    Mastodon::Snowflake.id_at(@end_at.end_of_day, with_random: false)
   end
 
   def params

--- a/app/lib/admin/metrics/measure/tag_servers_measure.rb
+++ b/app/lib/admin/metrics/measure/tag_servers_measure.rb
@@ -22,7 +22,7 @@ class Admin::Metrics::Measure::TagServersMeasure < Admin::Metrics::Measure::Base
   end
 
   def sql_array
-    [sql_query_string, { start_at: @start_at, end_at: @end_at, tag_id: tag.id, earliest_status_id: earliest_status_id, latest_status_id: latest_status_id }]
+    [sql_query_string, { start_at: @start_at, end_at: @end_at, tag_id: tag.id, earliest_status_id:, latest_status_id: }]
   end
 
   def sql_query_string
@@ -43,14 +43,6 @@ class Admin::Metrics::Measure::TagServersMeasure < Admin::Metrics::Measure::Base
         #{generated_series_days}
       ) as axis
     SQL
-  end
-
-  def earliest_status_id
-    Mastodon::Snowflake.id_at(@start_at.beginning_of_day, with_random: false)
-  end
-
-  def latest_status_id
-    Mastodon::Snowflake.id_at(@end_at.end_of_day, with_random: false)
   end
 
   def tag


### PR DESCRIPTION
Kind of a followup on https://github.com/mastodon/mastodon/pull/30654 which stalled out. May try to revive that one.

The "measure" and "dimension" base classes have some similarity (beyond the methods added here) ... could potentially combine those, clean them up more, give them a share base or modules, etc.