### PR TITLE
Use `attribute` for defining `rate_limit` boolean

### DIFF
--- a/app/models/concerns/rate_limitable.rb
+++ b/app/models/concerns/rate_limitable.rb
@@ -3,12 +3,8 @@
 module RateLimitable
   extend ActiveSupport::Concern
 
-  def rate_limit=(value)
-    @rate_limit = value
-  end
-
-  def rate_limit?
-    @rate_limit
+  included do
+    attribute :rate_limit, :boolean, default: false
   end
 
   def rate_limiter(by, options = {})


### PR DESCRIPTION
Similar to https://github.com/mastodon/mastodon/pull/35327 and other similar PRs.

This one is passed in as a boolean attribute from various models/services using the rate limit feature (ie, this module and the rate limiter, not the api/rack stuff).