### PR TITLE
Bypass registration checks for seeded admin user

### DIFF
--- a/db/seeds/04_admin.rb
+++ b/db/seeds/04_admin.rb
@@ -7,7 +7,17 @@ if Rails.env.development?
   admin = Account.where(username: 'admin').first_or_initialize(username: 'admin')
   admin.save(validate: false)
 
-  user = User.where(email: "admin@#{domain}").first_or_initialize(email: "admin@#{domain}", password: 'mastodonadmin', password_confirmation: 'mastodonadmin', confirmed_at: Time.now.utc, role: UserRole.find_by(name: 'Owner'), account: admin, agreement: true, approved: true)
+  user = User.where(email: "admin@#{domain}").first_or_initialize(
+    email: "admin@#{domain}",
+    password: 'mastodonadmin',
+    password_confirmation: 'mastodonadmin',
+    confirmed_at: Time.now.utc,
+    role: UserRole.find_by(name: 'Owner'),
+    account: admin,
+    agreement: true,
+    approved: true,
+    bypass_registration_checks: true
+  )
   user.save!
   user.approve!
 end


### PR DESCRIPTION
Fixes #35536

This fixes the problem mentioned in the issue above (and probably a couple of similar cases). I also believe that since this is for the admin user and is only run in `development` it should be a safe change.

The only thing I wonder is how one would end up in such a situation. If your dev environment does not have the original admin user (anymore?) or you renamed it, this will now silently create a new one. Should not hurt, but could this maybe be surprising? I am not sure.