### PR TITLE
Add `matching_day` to measure report query helper

### DIFF
--- a/app/lib/admin/metrics/measure/instance_accounts_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_accounts_measure.rb
@@ -37,7 +37,7 @@ class Admin::Metrics::Measure::InstanceAccountsMeasure < Admin::Metrics::Measure
         WITH new_accounts AS (
           SELECT accounts.id
           FROM accounts
-          WHERE date_trunc('day', accounts.created_at)::date = axis.period
+          WHERE #{matching_day(Account, :created_at)}
             AND #{account_domain_sql(params[:include_subdomains])}
         )
         SELECT count(*) FROM new_accounts

--- a/app/lib/admin/metrics/measure/instance_followers_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_followers_measure.rb
@@ -38,7 +38,7 @@ class Admin::Metrics::Measure::InstanceFollowersMeasure < Admin::Metrics::Measur
           SELECT follows.id
           FROM follows
           INNER JOIN accounts ON follows.account_id = accounts.id
-          WHERE date_trunc('day', follows.created_at)::date = axis.period
+          WHERE #{matching_day(Follow, :created_at)}
             AND #{account_domain_sql(params[:include_subdomains])}
         )
         SELECT count(*) FROM new_followers

--- a/app/lib/admin/metrics/measure/instance_follows_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_follows_measure.rb
@@ -38,7 +38,7 @@ class Admin::Metrics::Measure::InstanceFollowsMeasure < Admin::Metrics::Measure:
           SELECT follows.id
           FROM follows
           INNER JOIN accounts ON follows.target_account_id = accounts.id
-          WHERE date_trunc('day', follows.created_at)::date = axis.period
+          WHERE #{matching_day(Follow, :created_at)}
             AND #{account_domain_sql(params[:include_subdomains])}
         )
         SELECT count(*) FROM new_follows

--- a/app/lib/admin/metrics/measure/instance_media_attachments_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_media_attachments_measure.rb
@@ -47,7 +47,7 @@ class Admin::Metrics::Measure::InstanceMediaAttachmentsMeasure < Admin::Metrics:
           SELECT #{media_size_total} AS size
           FROM media_attachments
           INNER JOIN accounts ON accounts.id = media_attachments.account_id
-          WHERE date_trunc('day', media_attachments.created_at)::date = axis.period
+          WHERE #{matching_day(MediaAttachment, :created_at)}
             AND #{account_domain_sql(params[:include_subdomains])}
         )
         SELECT COALESCE(SUM(size), 0) FROM new_media_attachments

--- a/app/lib/admin/metrics/measure/instance_reports_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_reports_measure.rb
@@ -38,7 +38,7 @@ class Admin::Metrics::Measure::InstanceReportsMeasure < Admin::Metrics::Measure:
           SELECT reports.id
           FROM reports
           INNER JOIN accounts ON accounts.id = reports.target_account_id
-          WHERE date_trunc('day', reports.created_at)::date = axis.period
+          WHERE #{matching_day(Report, :created_at)}
             AND #{account_domain_sql(params[:include_subdomains])}
         )
         SELECT count(*) FROM new_reports

--- a/app/lib/admin/metrics/measure/instance_statuses_measure.rb
+++ b/app/lib/admin/metrics/measure/instance_statuses_measure.rb
@@ -40,7 +40,7 @@ class Admin::Metrics::Measure::InstanceStatusesMeasure < Admin::Metrics::Measure
           INNER JOIN accounts ON accounts.id = statuses.account_id
           WHERE statuses.id BETWEEN :earliest_status_id AND :latest_status_id
             AND #{account_domain_sql(params[:include_subdomains])}
-            AND date_trunc('day', statuses.created_at)::date = axis.period
+            AND #{matching_day(Status, :created_at)}
         )
         SELECT count(*) FROM new_statuses
       ) AS value

--- a/app/lib/admin/metrics/measure/new_users_measure.rb
+++ b/app/lib/admin/metrics/measure/new_users_measure.rb
@@ -27,7 +27,7 @@ class Admin::Metrics::Measure::NewUsersMeasure < Admin::Metrics::Measure::BaseMe
         WITH new_users AS (
           SELECT users.id
           FROM users
-          WHERE date_trunc('day', users.created_at)::date = axis.period
+          WHERE #{matching_day(User, :created_at)}
         )
         SELECT count(*) FROM new_users
       ) AS value

--- a/app/lib/admin/metrics/measure/opened_reports_measure.rb
+++ b/app/lib/admin/metrics/measure/opened_reports_measure.rb
@@ -27,7 +27,7 @@ class Admin::Metrics::Measure::OpenedReportsMeasure < Admin::Metrics::Measure::B
         WITH new_reports AS (
           SELECT reports.id
           FROM reports
-          WHERE date_trunc('day', reports.created_at)::date = axis.period
+          WHERE #{matching_day(Report, :created_at)}
         )
         SELECT count(*) FROM new_reports
       ) AS value

--- a/app/lib/admin/metrics/measure/query_helper.rb
+++ b/app/lib/admin/metrics/measure/query_helper.rb
@@ -23,6 +23,12 @@ module Admin::Metrics::Measure::QueryHelper
     )
   end
 
+  def matching_day(model, column)
+    <<~SQL.squish
+      DATE_TRUNC('day', #{model.table_name}.#{column})::date = axis.period
+    SQL
+  end
+
   def account_domain_sql(include_subdomains)
     if include_subdomains
       "accounts.domain IN (SELECT domain FROM instances WHERE reverse('.' || domain) LIKE reverse('.' || :domain::text))"

--- a/app/lib/admin/metrics/measure/resolved_reports_measure.rb
+++ b/app/lib/admin/metrics/measure/resolved_reports_measure.rb
@@ -27,7 +27,7 @@ class Admin::Metrics::Measure::ResolvedReportsMeasure < Admin::Metrics::Measure:
         WITH resolved_reports AS (
           SELECT reports.id
           FROM reports
-          WHERE date_trunc('day', reports.action_taken_at)::date = axis.period
+          WHERE #{matching_day(Report, :action_taken_at)}
         )
         SELECT count(*) FROM resolved_reports
       ) AS value

--- a/app/lib/admin/metrics/measure/tag_servers_measure.rb
+++ b/app/lib/admin/metrics/measure/tag_servers_measure.rb
@@ -35,7 +35,7 @@ class Admin::Metrics::Measure::TagServersMeasure < Admin::Metrics::Measure::Base
           INNER JOIN accounts ON statuses.account_id = accounts.id
           WHERE statuses_tags.tag_id = :tag_id
             AND statuses.id BETWEEN :earliest_status_id AND :latest_status_id
-            AND date_trunc('day', statuses.created_at)::date = axis.period
+            AND #{matching_day(Status, :created_at)}
         )
         SELECT COUNT(*) FROM tag_servers
       ) AS value


### PR DESCRIPTION
As contemplated in https://github.com/mastodon/mastodon/pull/35554 I took a look at this older PR - https://github.com/mastodon/mastodon/pull/30654 - which wound up being closed unmerged. The goals there were to do some general DRY/tidy type work, and to reduce the amount of sql string passing in favor of more arel-generation. There was a side goal of getting all the way to be able to use `with` to build the CTE, and get rid of all the sql string passing entirely, but it got a little complex and didn't get all the way there.

This PR adds a `matching_day` method to the query helper used by these classes, and updates the classes to call it to generate the day<>period portion of their query. This is more or less extracted from that larger diff ... will attempt to keep pulling things out of there in smaller pieces and see if we can eventually wind up somewhere like where it was heading.

In this case, this is basically just a DRY-only change and keeps around the sql-string-passing (though note - we have a few other methods (account_domain_sql, generated_series_days) already doing exactly that ... the end goal of that PR would be to remove them all in favor of arel-building, let framework do quoting for us, etc).