### PR TITLE
Add `MediaAttachment.combined_media_file_size` method

### DIFF
--- a/app/lib/admin/metrics/dimension/space_usage_dimension.rb
+++ b/app/lib/admin/metrics/dimension/space_usage_dimension.rb
@@ -40,7 +40,7 @@ class Admin::Metrics::Dimension::SpaceUsageDimension < Admin::Metrics::Dimension
 
   def media_size
     value = [
-      MediaAttachment.sum(Arel.sql('COALESCE(file_file_size, 0) + COALESCE(thumbnail_file_size, 0)')),
+      MediaAttachment.sum(MediaAttachment.combined_media_file_size),
       CustomEmoji.sum(:image_file_size),
       PreviewCard.sum(:image_file_size),
       Account.sum(Arel.sql('COALESCE(avatar_file_size, 0) + COALESCE(header_file_size, 0)')),

--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -298,6 +298,10 @@ class MediaAttachment < ApplicationRecord
       IMAGE_FILE_EXTENSIONS + VIDEO_FILE_EXTENSIONS + AUDIO_FILE_EXTENSIONS
     end
 
+    def combined_media_file_size
+      arel_table.coalesce(arel_table[:file_file_size], 0) + arel_table.coalesce(arel_table[:thumbnail_file_size], 0)
+    end
+
     private
 
     def file_styles(attachment)

--- a/lib/mastodon/cli/media.rb
+++ b/lib/mastodon/cli/media.rb
@@ -313,9 +313,7 @@ module Mastodon::CLI
     end
 
     def combined_media_sum
-      Arel.sql(<<~SQL.squish)
-        COALESCE(file_file_size, 0) + COALESCE(thumbnail_file_size, 0)
-      SQL
+      MediaAttachment.combined_media_file_size
     end
 
     def preload_records_from_mixed_objects(objects)

--- a/spec/models/media_attachment_spec.rb
+++ b/spec/models/media_attachment_spec.rb
@@ -313,6 +313,12 @@ RSpec.describe MediaAttachment, :attachment_processing do
     end
   end
 
+  describe '.combined_media_file_size' do
+    subject { described_class.combined_media_file_size }
+
+    it { is_expected.to be_an(Arel::Nodes::Grouping) }
+  end
+
   private
 
   def media_metadata


### PR DESCRIPTION
Original motivation here was similar to https://github.com/mastodon/mastodon/pull/35569 - looking to pull out more portions of https://github.com/mastodon/mastodon/pull/30654 that might stand on their own and make something like that eventually easier to merge in. In process I realized this particular string is built up in a few different spots so the application was beyond just the measure/reporting class.

I believe that with the exception of the generated queries being quoted slightly different by framework, results should be the same.

Possible future improvement/change ... every single spot using this is calling `.sum` except for the measure reporting class ... could contemplate 