### PR TITLE
Use `increment` for `User#update_sign_in!` optional change

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -237,10 +237,7 @@ class User < ApplicationRecord
     self.last_sign_in_at     = old_current || new_current
     self.current_sign_in_at  = new_current
 
-    if new_sign_in
-      self.sign_in_count ||= 0
-      self.sign_in_count  += 1
-    end
+    increment(:sign_in_count) if new_sign_in
 
     save(validate: false) unless new_record?
     prepare_returning_user!


### PR DESCRIPTION
Previous cleanup attempt of this method changed like four things at once - https://github.com/mastodon/mastodon/pull/32513/files#diff-9802ca3c9c4cf89904fd44bc114e35ebdf2c5dd3d5b645491e2b253e1afef29bR210-R215 - going for simpler here.

This does not immediately persist (which is what we want), and the logic of "set to zero if nil, then bump by one" is kept (although - the column itself is not nil and defaults to zero, so not sure how often that line is ever relevant). There is coverage for this aspect of the method (possibly extracted from that previous PR) in place.