### PR TITLE
Use attribute for `User#external?`

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -143,7 +143,9 @@ class User < ApplicationRecord
   delegate :can?, to: :role
 
   attr_reader :invite_code, :date_of_birth
-  attr_writer :external, :bypass_registration_checks, :current_account
+  attr_writer :bypass_registration_checks, :current_account
+
+  attribute :external, :boolean, default: false
 
   def self.those_who_can(*any_of_privileges)
     matching_role_ids = UserRole.that_can(*any_of_privileges).map(&:id)
@@ -505,10 +507,6 @@ class User < ApplicationRecord
 
   def open_registrations?
     Setting.registrations_mode == 'open'
-  end
-
-  def external?
-    !!@external
   end
 
   def bypass_registration_checks?


### PR DESCRIPTION
Small change to get the query method generation and type-casting from the previous method "for free" from the attribute declaration.

Technically a visibility change from private to public for the query method, but preserves public for the setter (used by some PAM/LDAP/etc flows).