### PR TITLE
Extract `User::Registration` concern

### DIFF
--- a/app/models/concerns/user/registration.rb
+++ b/app/models/concerns/user/registration.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module User::Registration
+  extend ActiveSupport::Concern
+
+  REGISTRATION_ATTEMPT_WAIT_TIME = 3.seconds.freeze
+
+  included do
+    attribute :registration_form_time, :datetime
+
+    validate :validate_registration_wait, on: :create, if: :registration_form_time?
+  end
+
+  private
+
+  def validate_registration_wait
+    errors.add(:base, I18n.t('auth.too_fast')) if registration_form_time > REGISTRATION_ATTEMPT_WAIT_TIME.ago
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -64,6 +64,7 @@ class User < ApplicationRecord
   include User::LdapAuthenticable
   include User::Omniauthable
   include User::PamAuthenticable
+  include User::Registration
 
   devise :two_factor_authenticatable,
          otp_secret_length: 32
@@ -99,9 +100,8 @@ class User < ApplicationRecord
   validates :agreement, acceptance: { allow_nil: false, accept: [true, 'true', '1'] }, on: :create
 
   # Honeypot/anti-spam fields
-  attr_accessor :registration_form_time, :website, :confirm_password
+  attr_accessor :website, :confirm_password
 
-  validates_with RegistrationFormTimeValidator, on: :create
   validates :website, absence: true, on: :create
   validates :confirm_password, absence: true, on: :create
   validates :date_of_birth, presence: true, date_of_birth: true, on: :create, if: -> { Setting.min_age.present? && !bypass_registration_checks? }

--- a/app/validators/registration_form_time_validator.rb
+++ b/app/validators/registration_form_time_validator.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-class RegistrationFormTimeValidator < ActiveModel::Validator
-  REGISTRATION_FORM_MIN_TIME = 3.seconds.freeze
-
-  def validate(user)
-    user.errors.add(:base, I18n.t('auth.too_fast')) if user.registration_form_time.present? && user.registration_form_time > REGISTRATION_FORM_MIN_TIME.ago
-  end
-end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -39,6 +39,15 @@ RSpec.describe User do
     end
 
     it { is_expected.to allow_value('admin@localhost').for(:email) }
+
+    context 'when registration form time is present' do
+      subject { Fabricate.build :user }
+
+      before { stub_const 'User::REGISTRATION_ATTEMPT_WAIT_TIME', 3.seconds }
+
+      it { is_expected.to allow_value(10.seconds.ago).for(:registration_form_time) }
+      it { is_expected.to_not allow_value(1.second.ago).for(:registration_form_time).against(:base) }
+    end
   end
 
   describe 'Normalizations' do


### PR DESCRIPTION
Similar background/motivation as https://github.com/mastodon/mastodon/pull/35581

Extra notes here:

- Use `attribute` for registration_form_time, which gives us a query method, which slightly simplifies the validator call
- Deleted the one-off validator class (this is maybe subtle or nuanced - but I feel like validators should get their own classes if they are one of a) actually used by many models for same type of checks, b) just really complex -- in this case I don't think it crosses that bar? Only used by user, and especially after change here, pretty simple)

There are probably more "registration related" stuff that could be added here, but wanted to keep first pass small.