### PR TITLE
Avoid `return not_found` in statuses controller

### DIFF
--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -11,6 +11,7 @@ class StatusesController < ApplicationController
   before_action :require_account_signature!, only: [:show, :activity], if: -> { request.format == :json && authorized_fetch_mode? }
   before_action :set_status
   before_action :redirect_to_original, only: :show
+  before_action :verify_embed_allowed, only: :embed
 
   after_action :set_link_headers
 
@@ -40,8 +41,6 @@ class StatusesController < ApplicationController
   end
 
   def embed
-    return not_found if @status.hidden? || @status.reblog?
-
     expires_in 180, public: true
     response.headers.delete('X-Frame-Options')
 
@@ -49,6 +48,10 @@ class StatusesController < ApplicationController
   end
 
   private
+
+  def verify_embed_allowed
+    not_found if @status.hidden? || @status.reblog?
+  end
 
   def set_link_headers
     response.headers['Link'] = LinkHeader.new(


### PR DESCRIPTION
Extracted from https://github.com/mastodon/mastodon/pull/35385 which originally changed multiple spots. This is one of the simpler ones.