### PR TITLE
Add coverage to user spec for missing `last_sign_in_at` scenario

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -207,11 +207,8 @@ class User < ApplicationRecord
     nil
   end
 
-  def update_sign_in!(new_sign_in: false)
-    old_current = current_sign_in_at
-    new_current = Time.now.utc
-
-    self.last_sign_in_at     = old_current || new_current
+  def update_sign_in!(new_sign_in: false, new_current: Time.now.utc)
+    self.last_sign_in_at     = current_sign_in_at || new_current
     self.current_sign_in_at  = new_current
 
     increment(:sign_in_count) if new_sign_in

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -207,7 +207,8 @@ class User < ApplicationRecord
     nil
   end
 
-  def update_sign_in!(new_sign_in: false, new_current: Time.now.utc)
+  def update_sign_in!(new_sign_in: false)
+    new_current = Time.now.utc
     self.last_sign_in_at     = current_sign_in_at || new_current
     self.current_sign_in_at  = new_current
 


### PR DESCRIPTION
The other portion of https://github.com/mastodon/mastodon/pull/35573 pulled from same original PR.

Changes here:

- In spec, be more explicit about the changing value on existing coverage - and add the "current sign in at is nil and gets changed" scenario
- In method, we dont need the `old_current` local var because we don't change `current_sign_in_at` before using `old_current`, so just use `current_sign_in_at` directly
- In the method, reduce by ONE more LOC by bumping `new_current` initialization to the args