### PR TITLE
Fix wrong policy authorization in admin controllers

### DIFF
--- a/app/controllers/admin/disputes/appeals_controller.rb
+++ b/app/controllers/admin/disputes/appeals_controller.rb
@@ -18,7 +18,7 @@ class Admin::Disputes::AppealsController < Admin::BaseController
   end
 
   def reject
-    authorize @appeal, :approve?
+    authorize @appeal, :reject?
     log_action :reject, @appeal
     @appeal.reject!(current_account)
     UserMailer.appeal_rejected(@appeal.account.user, @appeal).deliver_later

--- a/app/controllers/admin/domain_blocks_controller.rb
+++ b/app/controllers/admin/domain_blocks_controller.rb
@@ -17,7 +17,7 @@ module Admin
     PERMITTED_UPDATE_PARAMS = PERMITTED_PARAMS.without(:domain).freeze
 
     def batch
-      authorize :domain_block, :create?
+      authorize :domain_block, :index?
       @form = Form::DomainBlockBatch.new(form_domain_block_batch_params.merge(current_account: current_account, action: action_from_button))
       @form.save
     rescue ActionController::ParameterMissing
@@ -36,7 +36,7 @@ module Admin
     end
 
     def edit
-      authorize :domain_block, :create?
+      authorize :domain_block, :update?
     end
 
     def create

--- a/app/controllers/admin/domain_blocks_controller.rb
+++ b/app/controllers/admin/domain_blocks_controller.rb
@@ -17,7 +17,7 @@ module Admin
     PERMITTED_UPDATE_PARAMS = PERMITTED_PARAMS.without(:domain).freeze
 
     def batch
-      authorize :domain_block, :index?
+      authorize :domain_block, :create?
       @form = Form::DomainBlockBatch.new(form_domain_block_batch_params.merge(current_account: current_account, action: action_from_button))
       @form.save
     rescue ActionController::ParameterMissing


### PR DESCRIPTION
Noticed the `admin/domain_blocks#edit` one on https://github.com/mastodon/mastodon/pull/35446

In both of these, the _current_ permissions of the underlying policy are the same -- this is just aligning the naming with what other controllers do and what they (probably?) should have been for a bit of future proofing. I assume copy/paste stuff here to use the "wrong" ones.