### PR TITLE
Modern Emoji: Use local storage to opt-in

### DIFF
--- a/app/javascript/mastodon/utils/environment.ts
+++ b/app/javascript/mastodon/utils/environment.ts
@@ -19,5 +19,8 @@ export function isFeatureEnabled(feature: Features) {
 }
 
 export function isModernEmojiEnabled() {
-  return isFeatureEnabled('modern_emojis') && isDevelopment();
+  return (
+    isFeatureEnabled('modern_emojis') &&
+    localStorage.getItem('experiments')?.split(',').includes('modern_emojis')
+  );
 }

--- a/app/javascript/mastodon/utils/environment.ts
+++ b/app/javascript/mastodon/utils/environment.ts
@@ -19,8 +19,12 @@ export function isFeatureEnabled(feature: Features) {
 }
 
 export function isModernEmojiEnabled() {
-  return (
-    isFeatureEnabled('modern_emojis') &&
-    localStorage.getItem('experiments')?.split(',').includes('modern_emojis')
-  );
+  try {
+    return (
+      isFeatureEnabled('modern_emojis') &&
+      localStorage.getItem('experiments')?.split(',').includes('modern_emojis')
+    );
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
In #35505 I forced the modern emoji field to be dev-only. This PR reverts that in favor of checking Local Storage.

To test:

1. Load this PR and ensure `localStorage.experiments = null`.
2. Ensure that your emoji preference is set to Auto or Native.
3. Verify that emojis are using the legacy rendering system.
4. In the console, type `localStorage.experiments = 'modern_emojis'` and reload the page.
5. Verify that the new emoji are appearing.