### PR TITLE
Add notifications for inbound quotes

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -73,6 +73,9 @@ class Notification < ApplicationRecord
     'admin.report': {
       filterable: false,
     }.freeze,
+    quote: {
+      filterable: true,
+    }.freeze,
   }.freeze
 
   TYPES = PROPERTIES.keys.freeze
@@ -81,6 +84,7 @@ class Notification < ApplicationRecord
     status: :status,
     reblog: [status: :reblog],
     mention: [mention: :status],
+    quote: [quote: :status],
     favourite: [favourite: :status],
     poll: [poll: :status],
     update: :status,
@@ -102,6 +106,7 @@ class Notification < ApplicationRecord
     belongs_to :account_relationship_severance_event, inverse_of: false
     belongs_to :account_warning, inverse_of: false
     belongs_to :generated_annual_report, inverse_of: false
+    belongs_to :quote, inverse_of: :notification
   end
 
   validates :type, inclusion: { in: TYPES }
@@ -122,6 +127,8 @@ class Notification < ApplicationRecord
       favourite&.status
     when :mention
       mention&.status
+    when :quote
+      quote&.status
     when :poll
       poll&.status
     end
@@ -174,6 +181,8 @@ class Notification < ApplicationRecord
           notification.mention.status = cached_status
         when :poll
           notification.poll.status = cached_status
+        when :quote
+          notification.quote.status = cached_status
         end
       end
 
@@ -192,7 +201,7 @@ class Notification < ApplicationRecord
     return unless new_record?
 
     case activity_type
-    when 'Status', 'Follow', 'Favourite', 'FollowRequest', 'Poll', 'Report'
+    when 'Status', 'Follow', 'Favourite', 'FollowRequest', 'Poll', 'Report', 'Quote'
       self.from_account_id = activity&.account_id
     when 'Mention'
       self.from_account_id = activity&.status&.account_id

--- a/app/models/notification_request.rb
+++ b/app/models/notification_request.rb
@@ -49,6 +49,6 @@ class NotificationRequest < ApplicationRecord
   private
 
   def prepare_notifications_count
-    self.notifications_count = Notification.where(account: account, from_account: from_account, type: :mention, filtered: true).limit(MAX_MEANINGFUL_COUNT).count
+    self.notifications_count = Notification.where(account: account, from_account: from_account, type: [:mention, :quote], filtered: true).limit(MAX_MEANINGFUL_COUNT).count
   end
 end

--- a/app/models/quote.rb
+++ b/app/models/quote.rb
@@ -19,6 +19,8 @@
 class Quote < ApplicationRecord
   include Paginable
 
+  has_one :notification, as: :activity, dependent: :destroy
+
   BACKGROUND_REFRESH_INTERVAL = 1.week.freeze
   REFRESH_DEADLINE = 6.hours
 

--- a/app/serializers/rest/notification_serializer.rb
+++ b/app/serializers/rest/notification_serializer.rb
@@ -21,7 +21,7 @@ class REST::NotificationSerializer < ActiveModel::Serializer
   end
 
   def status_type?
-    [:favourite, :reblog, :status, :mention, :poll, :update].include?(object.type)
+    [:favourite, :reblog, :status, :mention, :poll, :update, :quote].include?(object.type)
   end
 
   def report_type?

--- a/app/services/fan_out_on_write_service.rb
+++ b/app/services/fan_out_on_write_service.rb
@@ -40,6 +40,7 @@ class FanOutOnWriteService < BaseService
     deliver_to_self!
 
     unless @options[:skip_notifications]
+      notify_quoted_account!
       notify_mentioned_accounts!
       notify_about_update! if update?
     end
@@ -67,6 +68,12 @@ class FanOutOnWriteService < BaseService
 
   def deliver_to_self!
     FeedManager.instance.push_to_home(@account, @status, update: update?) if @account.local?
+  end
+
+  def notify_quoted_account!
+    return unless @status.quote&.quoted_account&.local? && @status.quote&.accepted?
+
+    LocalNotificationWorker.perform_async(@status.quote.quoted_account_id, @status.quote.id, 'Quote', 'quote')
   end
 
   def notify_mentioned_accounts!

--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -247,7 +247,7 @@ class NotifyService < BaseService
   end
 
   def update_notification_request!
-    return unless @notification.type == :mention
+    return unless %i(mention quote).include?(@notification.type)
 
     notification_request = NotificationRequest.find_or_initialize_by(account_id: @recipient.id, from_account_id: @notification.from_account_id)
     notification_request.last_status_id = @notification.target_status.id


### PR DESCRIPTION
Sends quoted users a notification when they get an accepted quote (this is not currently possible).

There is some open question regarding whether filtered quote notifications should create notification requests.