### PR TITLE
Add minute resolution to `DeliveryFailureTracker`

### DIFF
--- a/app/views/admin/instances/show.html.haml
+++ b/app/views/admin/instances/show.html.haml
@@ -78,7 +78,7 @@
   %h3= t('admin.instances.availability.title')
 
   %p
-    = t('admin.instances.availability.description_html', count: DeliveryFailureTracker::FAILURE_DAYS_THRESHOLD)
+    = t('admin.instances.availability.description_html', count: DeliveryFailureTracker::FAILURE_THRESHOLDS[:days])
 
   .availability-indicator
     %ul.availability-indicator__graphic

--- a/spec/lib/delivery_failure_tracker_spec.rb
+++ b/spec/lib/delivery_failure_tracker_spec.rb
@@ -3,37 +3,101 @@
 require 'rails_helper'
 
 RSpec.describe DeliveryFailureTracker do
-  subject { described_class.new('http://example.com/inbox') }
+  context 'with the default resolution of :days' do
+    subject { described_class.new('http://example.com/inbox') }
 
-  describe '#track_success!' do
-    before do
-      subject.track_failure!
-      subject.track_success!
+    describe '#track_success!' do
+      before do
+        track_failure(7, :days)
+        subject.track_success!
+      end
+
+      it 'marks URL as available again' do
+        expect(described_class.available?('http://example.com/inbox')).to be true
+      end
+
+      it 'resets days to 0' do
+        expect(subject.days).to be_zero
+      end
     end
 
-    it 'marks URL as available again' do
-      expect(described_class.available?('http://example.com/inbox')).to be true
+    describe '#track_failure!' do
+      it 'marks URL as unavailable after 7 days of being called' do
+        track_failure(7, :days)
+
+        expect(subject.days).to eq 7
+        expect(described_class.available?('http://example.com/inbox')).to be false
+      end
+
+      it 'repeated calls on the same day do not count' do
+        subject.track_failure!
+        subject.track_failure!
+
+        expect(subject.days).to eq 1
+      end
     end
 
-    it 'resets days to 0' do
-      expect(subject.days).to be_zero
+    describe '#exhausted_deliveries_days' do
+      it 'returns the days on which failures were recorded' do
+        track_failure(3, :days)
+
+        expect(subject.exhausted_deliveries_days).to contain_exactly(3.days.ago.to_date, 2.days.ago.to_date, Date.yesterday)
+      end
     end
   end
 
-  describe '#track_failure!' do
-    it 'marks URL as unavailable after 7 days of being called' do
-      6.times { |i| redis.sadd('exhausted_deliveries:example.com', i) }
-      subject.track_failure!
+  context 'with a resolution of :minutes' do
+    subject { described_class.new('http://example.com/inbox', resolution: :minutes) }
 
-      expect(subject.days).to eq 7
-      expect(described_class.available?('http://example.com/inbox')).to be false
+    describe '#track_success!' do
+      before do
+        track_failure(5, :minutes)
+        subject.track_success!
+      end
+
+      it 'marks URL as available again' do
+        expect(described_class.available?('http://example.com/inbox')).to be true
+      end
+
+      it 'resets failures to 0' do
+        expect(subject.failures).to be_zero
+      end
     end
 
-    it 'repeated calls on the same day do not count' do
-      subject.track_failure!
-      subject.track_failure!
+    describe '#track_failure!' do
+      it 'marks URL as unavailable after 5 minutes of being called' do
+        track_failure(5, :minutes)
 
-      expect(subject.days).to eq 1
+        expect(subject.failures).to eq 5
+        expect(described_class.available?('http://example.com/inbox')).to be false
+      end
+
+      it 'repeated calls within the same minute do not count' do
+        freeze_time
+        subject.track_failure!
+        subject.track_failure!
+
+        expect(subject.failures).to eq 1
+      end
+    end
+
+    describe '#exhausted_deliveries_days' do
+      it 'returns the days on which failures were recorded' do
+        # Make sure this does not accidentally span two days when run
+        # around midnight
+        travel_to Time.zone.now.change(hour: 10)
+        track_failure(3, :minutes)
+
+        expect(subject.exhausted_deliveries_days).to contain_exactly(Time.zone.today)
+      end
+    end
+
+    describe '#days' do
+      it 'raises due to wrong resolution' do
+        assert_raises TypeError do
+          subject.days
+        end
+      end
     end
   end
 
@@ -59,5 +123,13 @@ RSpec.describe DeliveryFailureTracker do
     it 'marks inbox URL as available again' do
       expect(described_class.available?('http://foo.bar/inbox')).to be true
     end
+  end
+
+  def track_failure(times, unit)
+    times.times do
+      travel_to 1.send(unit).ago
+      subject.track_failure!
+    end
+    travel_back
   end
 end


### PR DESCRIPTION
In preparation for using it to track delivery to FASP, where a lot of jobs can pile on if we do not throttle them *way* before the original threshold of 7 days.

This introduces `minutes` in addition to the original resolution of `days` with a threshold of 5 minutes after which a server is marked as unavailable.

It should be easy to extend this to support other resolutions.

It includes one decision I am not entirely confident about. My goal was to not change existing behavior and there was a method `#days` that returns the number of recorded failures as a number of days. That just does not make sense with a resolution of minutes. So I now raise an exception in that case.

I also pondered using metaprogramming to create the `#days` method on demand (only if the resolution is days) or use `method_missing` to the same effect. But I generally prefer a class to have all methods present and readable if at all possible, so I decided against it.

part of MAS-484