### PR TITLE
Track delivery failures to FASP

### DIFF
--- a/app/lib/fasp/request.rb
+++ b/app/lib/fasp/request.rb
@@ -32,8 +32,12 @@ class Fasp::Request
                .send(verb, url, body:)
 
     validate!(response)
+    @provider.delivery_failure_tracker.track_success!
 
     response.parse if response.body.present?
+  rescue *::Mastodon::HTTP_CONNECTION_ERRORS
+    @provider.delivery_failure_tracker.track_failure!
+    raise
   end
 
   def request_headers(_verb, _url, body = '')

--- a/app/models/fasp/provider.rb
+++ b/app/models/fasp/provider.rb
@@ -118,6 +118,10 @@ class Fasp::Provider < ApplicationRecord
     save!
   end
 
+  def delivery_failure_tracker
+    @delivery_failure_tracker ||= DeliveryFailureTracker.new(base_url, resolution: :minutes)
+  end
+
   private
 
   def create_keypair

--- a/spec/lib/fasp/request_spec.rb
+++ b/spec/lib/fasp/request_spec.rb
@@ -27,6 +27,14 @@ RSpec.describe Fasp::Request do
             'Signature-Input' => /.+/,
           })
       end
+
+      it 'tracks that a successful connection was made' do
+        provider.delivery_failure_tracker.track_failure!
+
+        expect do
+          subject.send(method, '/test_path')
+        end.to change(provider.delivery_failure_tracker, :failures).from(1).to(0)
+      end
     end
 
     context 'when the response is not signed' do
@@ -53,6 +61,21 @@ RSpec.describe Fasp::Request do
             subject.send(method, '/test_path')
           end.to raise_error(Mastodon::UnexpectedResponseError)
         end
+      end
+    end
+
+    context 'when the request raises an error' do
+      before do
+        stub_request(method, 'https://reqprov.example.com/fasp/test_path')
+          .to_raise(HTTP::ConnectionError)
+      end
+
+      it "records the failure using the provider's delivery failure tracker" do
+        expect do
+          subject.send(method, '/test_path')
+        end.to raise_error(HTTP::ConnectionError)
+
+        expect(provider.delivery_failure_tracker.failures).to eq 1
       end
     end
   end

--- a/spec/models/fasp/provider_spec.rb
+++ b/spec/models/fasp/provider_spec.rb
@@ -206,4 +206,12 @@ RSpec.describe Fasp::Provider do
       end
     end
   end
+
+  describe '#delivery_failure_tracker' do
+    subject { Fabricate(:fasp_provider) }
+
+    it 'returns a `DeliverFailureTracker` instance' do
+      expect(subject.delivery_failure_tracker).to be_a(DeliveryFailureTracker)
+    end
+  end
 end


### PR DESCRIPTION
Follow-up to #35625 and part 2/3 of improving FASP connection handling.

This just adds using the previously improved delivery failure track to track delivery failures to FASP.

The last step will be to actually act on that information.

part of MAS-484