### PR TITLE
Accept remote quotes of local quotes according to set policy

### DIFF
--- a/app/lib/activitypub/activity/quote_request.rb
+++ b/app/lib/activitypub/activity/quote_request.rb
@@ -9,11 +9,30 @@ class ActivityPub::Activity::QuoteRequest < ActivityPub::Activity
     quoted_status = status_from_uri(object_uri)
     return if quoted_status.nil? || !quoted_status.account.local? || !quoted_status.distributable?
 
-    # For now, we don't support being quoted by external servers
-    reject_quote_request!(quoted_status)
+    if Mastodon::Feature.outgoing_quotes_enabled? && StatusPolicy.new(@account, quoted_status).quote?
+      accept_quote_request!(quoted_status)
+    else
+      reject_quote_request!(quoted_status)
+    end
   end
 
   private
+
+  def accept_quote_request!(quoted_status)
+    status = status_from_uri(@json['instrument'])
+    # TODO: import inlined quote post if possible
+    status ||= ActivityPub::FetchRemoteStatusService.new.call(@json['instrument'], on_behalf_of: @account.followers.local.first, request_id: @options[:request_id])
+    # TODO: raise if status is nil
+
+    # Sanity check
+    return unless status.quote.quoted_status == quoted_status
+
+    status.quote.update!(activity_uri: @json['id'])
+    status.quote.accept!
+
+    json = Oj.dump(serialize_payload(status.quote, ActivityPub::AcceptQuoteRequestSerializer))
+    ActivityPub::DeliveryWorker.perform_async(json, quoted_status.account_id, @account.inbox_url)
+  end
 
   def reject_quote_request!(quoted_status)
     quote = Quote.new(

--- a/app/serializers/activitypub/accept_quote_request_serializer.rb
+++ b/app/serializers/activitypub/accept_quote_request_serializer.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class ActivityPub::AcceptQuoteRequestSerializer < ActivityPub::Serializer
+  attributes :id, :type, :actor, :result
+
+  has_one :object, serializer: ActivityPub::QuoteRequestSerializer
+
+  def id
+    [ActivityPub::TagManager.instance.uri_for(object.quoted_account), '#accepts/quote_requests/', object.id].join
+  end
+
+  def type
+    'Accept'
+  end
+
+  def actor
+    ActivityPub::TagManager.instance.uri_for(object.quoted_account)
+  end
+
+  def result
+    ActivityPub::TagManager.instance.approval_uri_for(object)
+  end
+end

--- a/app/serializers/activitypub/quote_request_serializer.rb
+++ b/app/serializers/activitypub/quote_request_serializer.rb
@@ -23,6 +23,7 @@ class ActivityPub::QuoteRequestSerializer < ActivityPub::Serializer
   end
 
   def instrument
+    # TODO: inline object?
     ActivityPub::TagManager.instance.uri_for(object.status)
   end
 end

--- a/spec/serializers/activitypub/accept_quote_request_serializer_spec.rb
+++ b/spec/serializers/activitypub/accept_quote_request_serializer_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ActivityPub::AcceptQuoteRequestSerializer do
+  subject { serialized_record_json(record, described_class, adapter: ActivityPub::Adapter) }
+
+  describe 'serializing an object' do
+    let(:record) { Fabricate(:quote, state: :accepted) }
+
+    it 'returns expected attributes' do
+      expect(subject.deep_symbolize_keys)
+        .to include(
+          actor: eq(ActivityPub::TagManager.instance.uri_for(record.quoted_account)),
+          id: match("#accepts/quote_requests/#{record.id}"),
+          object: include(
+            type: 'QuoteRequest',
+            instrument: ActivityPub::TagManager.instance.uri_for(record.status),
+            object: ActivityPub::TagManager.instance.uri_for(record.quoted_status)
+          ),
+          type: 'Accept'
+        )
+    end
+  end
+end


### PR DESCRIPTION
This still requires the `outgoing_quotes` experimental feature to be enabled, and this still does not actually let users set a policy, so local posts won't be quotable unless manually edited in the database.