### PR TITLE
Fix rendering of poll options in status history modal

### DIFF
--- a/app/javascript/mastodon/features/ui/components/compare_history_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/compare_history_modal.jsx
@@ -93,14 +93,16 @@ class CompareHistoryModal extends PureComponent {
                   <ul>
                     {currentVersion.getIn(['poll', 'options']).map(option => (
                       <li key={option.get('title')}>
-                        <span className='poll__input disabled' />
-
-                        <EmojiHTML
-                          as="span"
-                          className='poll__option__text translate'
-                          htmlString={emojify(escapeTextContentForBrowser(option.get('title')), emojiMap)}
-                          lang={language}
-                        />
+                        <label className='poll__option editable'>
+                          {/* FIXME: does not support multiple choice, #35632 */}
+                          <span className='poll__input' />
+                          <EmojiHTML
+                            as="span"
+                            className='poll__option__text translate'
+                            htmlString={emojify(escapeTextContentForBrowser(option.get('title')), emojiMap)}
+                            lang={language}
+                          />
+                        </label>
                       </li>
                     ))}
                   </ul>


### PR DESCRIPTION
I noticed this whilst working on the display of statuses in the admin panel.

Before:
<img width="533" height="375" alt="Screenshot 2025-08-02 at 03 05 53" src="https://github.com/user-attachments/assets/bfe27cc4-4fa6-4200-b41e-a812b40566c9" />

After:
<img width="572" height="356" alt="Screenshot 2025-08-02 at 03 07 28" src="https://github.com/user-attachments/assets/9d57328a-2a50-4add-95ec-ccd939384956" />
