### PR TITLE
Null Check on accountJson url

### DIFF
--- a/app/javascript/mastodon/models/account.ts
+++ b/app/javascript/mastodon/models/account.ts
@@ -148,9 +148,9 @@ export function createAccountFromServerJSON(serverJSON: ApiAccountJSON) {
     note_emojified: emojify(accountNote, emojiMap),
     note_plain: unescapeHTML(accountNote),
     url:
-      accountJSON.url.startsWith('http://') ||
-      accountJSON.url.startsWith('https://')
-        ? accountJSON.url
-        : accountJSON.uri,
+      (accountJSON.url?.startsWith('http://') || 
+      accountJSON.url?.startsWith('https://')) ? 
+      accountJSON.url: 
+      accountJSON.uri,
   });
 }


### PR DESCRIPTION
Title: Fix: Add null check for accountJson.url 

Body: Fixes #35635

This change adds a null check to ensure `accountJson.url` exists before calling `.startsWith()`. Without this, the app crashes if `url` is `null` or `undefined`.
