### PR TITLE
Fix WebUI crashing for accounts with `null` URL

### DIFF
--- a/app/javascript/mastodon/api_types/accounts.ts
+++ b/app/javascript/mastodon/api_types/accounts.ts
@@ -37,7 +37,7 @@ export interface BaseApiAccountJSON {
   roles?: ApiAccountJSON[];
   statuses_count: number;
   uri: string;
-  url: string;
+  url?: string;
   username: string;
   moved?: ApiAccountJSON;
   suspended?: boolean;

--- a/app/javascript/mastodon/models/account.ts
+++ b/app/javascript/mastodon/models/account.ts
@@ -45,7 +45,7 @@ const AccountRoleFactory = ImmutableRecord<AccountRoleShape>({
 // Account
 export interface AccountShape
   extends Required<
-    Omit<ApiAccountJSON, 'emojis' | 'fields' | 'roles' | 'moved'>
+    Omit<ApiAccountJSON, 'emojis' | 'fields' | 'roles' | 'moved' | 'url'>
   > {
   emojis: ImmutableList<CustomEmoji>;
   fields: ImmutableList<AccountField>;
@@ -55,6 +55,7 @@ export interface AccountShape
   note_plain: string | null;
   hidden: boolean;
   moved: string | null;
+  url: string;
 }
 
 export type Account = RecordOf<AccountShape>;
@@ -148,8 +149,8 @@ export function createAccountFromServerJSON(serverJSON: ApiAccountJSON) {
     note_emojified: emojify(accountNote, emojiMap),
     note_plain: unescapeHTML(accountNote),
     url:
-      accountJSON.url.startsWith('http://') ||
-      accountJSON.url.startsWith('https://')
+      accountJSON.url?.startsWith('http://') ||
+      accountJSON.url?.startsWith('https://')
         ? accountJSON.url
         : accountJSON.uri,
   });

--- a/app/serializers/rest/account_serializer.rb
+++ b/app/serializers/rest/account_serializer.rb
@@ -65,7 +65,7 @@ class REST::AccountSerializer < ActiveModel::Serializer
   end
 
   def url
-    ActivityPub::TagManager.instance.url_for(object)
+    ActivityPub::TagManager.instance.url_for(object) || ActivityPub::TagManager.instance.uri_for(object)
   end
 
   def uri


### PR DESCRIPTION
Fixes #35635

In 79931bf3ae4, we at the same time added JS code that relied on `url` never to be `null`, and introduced a new way for `url` to be `null`. This PR changes it to consider the `url` field in the API response to be potentially `null`, according to the specifications, and also provides a server-side fallback in line with what we used to have before 79931bf3ae4 so that other clients are less likely to run into the same issue.