### PR TITLE
Add missing mailer for quote notifications

### DIFF
--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -6,7 +6,7 @@ class NotificationMailer < ApplicationMailer
          :routing
 
   before_action :process_params
-  with_options only: %i(mention favourite reblog) do
+  with_options only: %i(mention favourite reblog quote) do
     before_action :set_status
     after_action :thread_by_conversation!
   end
@@ -20,6 +20,14 @@ class NotificationMailer < ApplicationMailer
   layout 'mailer'
 
   def mention
+    return if @status.blank?
+
+    locale_for_account(@me) do
+      mail subject: default_i18n_subject(name: @status.account.acct)
+    end
+  end
+
+  def quote
     return if @status.blank?
 
     locale_for_account(@me) do

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -30,6 +30,7 @@ class Notification < ApplicationRecord
     'FollowRequest' => :follow_request,
     'Favourite' => :favourite,
     'Poll' => :poll,
+    'Quote' => :quote,
   }.freeze
 
   # Please update app/javascript/api_types/notification.ts if you change this

--- a/app/models/user_settings.rb
+++ b/app/models/user_settings.rb
@@ -43,6 +43,7 @@ class UserSettings
     setting :reblog, default: false
     setting :favourite, default: false
     setting :mention, default: true
+    setting :quote, default: true
     setting :follow_request, default: true
     setting :report, default: true
     setting :pending_account, default: true

--- a/app/views/notification_mailer/quote.html.haml
+++ b/app/views/notification_mailer/quote.html.haml
@@ -1,0 +1,16 @@
+= content_for :heading do
+  = render 'application/mailer/heading',
+           image_url: frontend_asset_url('images/mailer-new/heading/boost.png'),
+           subtitle: t('notification_mailer.quote.body', name: @status.account.pretty_acct),
+           title: t('notification_mailer.quote.title')
+%table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+  %tr
+    %td.email-body-padding-td
+      %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+        %tr
+          %td.email-inner-card-td
+            = render 'status', status: @status, time_zone: @me.user_time_zone
+            %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
+              %tr
+                %td.email-padding-top-24
+                  = render 'application/mailer/button', text: t('notification_mailer.mention.action'), url: web_url("@#{@status.account.pretty_acct}/#{@status.id}")

--- a/app/views/notification_mailer/quote.text.erb
+++ b/app/views/notification_mailer/quote.text.erb
@@ -1,0 +1,5 @@
+<%= raw t('application_mailer.salutation', name: display_name(@me)) %>
+
+<%= raw t('notification_mailer.quote.body', name: @status.account.pretty_acct) %>
+
+<%= render 'status', status: @status %>

--- a/app/views/settings/preferences/notifications/show.html.haml
+++ b/app/views/settings/preferences/notifications/show.html.haml
@@ -18,6 +18,7 @@
       = ff.input :'notification_emails.reblog', wrapper: :with_label, label: I18n.t('simple_form.labels.notification_emails.reblog')
       = ff.input :'notification_emails.favourite', wrapper: :with_label, label: I18n.t('simple_form.labels.notification_emails.favourite')
       = ff.input :'notification_emails.mention', wrapper: :with_label, label: I18n.t('simple_form.labels.notification_emails.mention')
+      = ff.input :'notification_emails.quote', wrapper: :with_label, label: I18n.t('simple_form.labels.notification_emails.quote')
 
     .fields-group
       = ff.input :always_send_emails, wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_always_send_emails'), hint: I18n.t('simple_form.hints.defaults.setting_always_send_emails')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1687,6 +1687,10 @@ en:
       title: New mention
     poll:
       subject: A poll by %{name} has ended
+    quote:
+      body: 'Your post was quoted by %{name}:'
+      subject: "%{name} quoted your post"
+      title: New quote
     reblog:
       body: 'Your post was boosted by %{name}:'
       subject: "%{name} boosted your post"

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -329,6 +329,7 @@ en:
         follow_request: Someone requested to follow you
         mention: Someone mentioned you
         pending_account: New account needs review
+        quote: Someone quoted you
         reblog: Someone boosted your post
         report: New report is submitted
         software_updates:

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -51,6 +51,27 @@ RSpec.describe NotificationMailer do
     it_behaves_like 'delivery without status'
   end
 
+  describe 'quote' do
+    let(:quote) { Fabricate(:quote, state: :accepted, status: foreign_status, quoted_status: own_status) }
+    let(:notification) { Notification.create!(account: receiver.account, activity: quote) }
+    let(:mail) { prepared_mailer_for(own_status.account).quote }
+
+    it_behaves_like 'localized subject', 'notification_mailer.quote.subject', name: 'bob'
+
+    it 'renders the email' do
+      expect(mail)
+        .to be_present
+        .and(have_subject('bob quoted your post'))
+        .and(have_body_text('Your post was quoted by bob'))
+        .and(have_body_text('The body of the foreign status'))
+        .and have_thread_headers
+        .and have_standard_headers('quote').for(receiver)
+    end
+
+    it_behaves_like 'delivery to non functional user'
+    it_behaves_like 'delivery without status'
+  end
+
   describe 'follow' do
     let(:follow) { sender.follow!(receiver.account) }
     let(:notification) { Notification.create!(account: receiver.account, activity: follow) }

--- a/spec/mailers/previews/notification_mailer_preview.rb
+++ b/spec/mailers/previews/notification_mailer_preview.rb
@@ -33,6 +33,12 @@ class NotificationMailerPreview < ActionMailer::Preview
     mailer_for(activity.reblog.account, activity).reblog
   end
 
+  # Preview this email at http://localhost:3000/rails/mailers/notification_mailer/quote
+  def quote
+    activity = Quote.first
+    mailer_for(activity.quoted_account, activity).quote
+  end
+
   private
 
   def mailer_for(account, activity)

--- a/spec/requests/api/web/push_subscriptions_spec.rb
+++ b/spec/requests/api/web/push_subscriptions_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe 'API Web Push Subscriptions' do
           mention: false,
           poll: true,
           status: false,
+          quote: true,
         },
       },
     }


### PR DESCRIPTION
This needs an icon specific for boosts, though that can also be done later.

It also needs a design for quotes (in general) within notification emails, but that is kind of independent from this issue and would need to be backported to 4.4.