### PR TITLE
Make `WorkerBatch` spec more robust

### DIFF
--- a/spec/models/worker_batch_spec.rb
+++ b/spec/models/worker_batch_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe WorkerBatch do
       end
 
       it 'persists the job IDs' do
-        expect(subject.jobs).to eq %w(foo bar)
+        expect(subject.jobs).to contain_exactly('foo', 'bar')
       end
     end
   end
@@ -67,7 +67,7 @@ RSpec.describe WorkerBatch do
     end
 
     it 'removes the job from pending jobs' do
-      expect(subject.jobs).to eq %w(bar baz)
+      expect(subject.jobs).to contain_exactly('bar', 'baz')
     end
 
     it 'decrements the number of pending jobs' do


### PR DESCRIPTION
I had a strange observation on my dev machine:
* Thursday: All specs green
* Friday: Two spec failures
* Today: One spec failure

Each time it was fully reproducible throughout the day. I am a bit baffled this did not happen to anyone else / on CI yet. But I think it makes sense. The results in these cases depend on the order in which redis returns set elements. And as far as I can tell, redis sets do not make any guarantees about the order.

I also believe, the exact order is not important for these methods to work, so I think these changes should be safe to make.