### PR TITLE
Replace `unprocessable_entity` -> `unprocessable_content`

### DIFF
--- a/app/controllers/api/v2/search_controller.rb
+++ b/app/controllers/api/v2/search_controller.rb
@@ -20,7 +20,7 @@ class Api::V2::SearchController < Api::BaseController
     @search = Search.new(search_results)
     render json: @search, serializer: REST::SearchSerializer
   rescue Mastodon::SyntaxError
-    unprocessable_entity
+    unprocessable_content
   rescue ActiveRecord::RecordNotFound
     not_found
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,7 +28,7 @@ class ApplicationController < ActionController::Base
   rescue_from Mastodon::NotPermittedError, with: :forbidden
   rescue_from ActionController::RoutingError, ActiveRecord::RecordNotFound, with: :not_found
   rescue_from ActionController::UnknownFormat, with: :not_acceptable
-  rescue_from ActionController::InvalidAuthenticityToken, with: :unprocessable_entity
+  rescue_from ActionController::InvalidAuthenticityToken, with: :unprocessable_content
   rescue_from Mastodon::RateLimitExceededError, with: :too_many_requests
 
   rescue_from(*Mastodon::HTTP_CONNECTION_ERRORS, with: :internal_server_error)
@@ -123,7 +123,7 @@ class ApplicationController < ActionController::Base
     respond_with_error(410)
   end
 
-  def unprocessable_entity
+  def unprocessable_content
     respond_with_error(422)
   end
 

--- a/app/controllers/settings/two_factor_authentication/webauthn_credentials_controller.rb
+++ b/app/controllers/settings/two_factor_authentication/webauthn_credentials_controller.rb
@@ -52,7 +52,7 @@ module Settings
             end
           else
             flash[:error] = I18n.t('webauthn_credentials.create.error')
-            status = :unprocessable_entity
+            status = :unprocessable_content
           end
         else
           flash[:error] = t('webauthn_credentials.create.error')

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -219,16 +219,16 @@ RSpec.describe ApplicationController do
     it_behaves_like 'error response', 410
   end
 
-  describe 'unprocessable_entity' do
+  describe 'unprocessable_content' do
     controller do
-      def route_unprocessable_entity
-        unprocessable_entity
+      def route_unprocessable_content
+        unprocessable_content
       end
     end
 
     subject do
-      routes.draw { get 'route_unprocessable_entity' => 'anonymous#route_unprocessable_entity' }
-      get 'route_unprocessable_entity'
+      routes.draw { get 'route_unprocessable_content' => 'anonymous#route_unprocessable_content' }
+      get 'route_unprocessable_content'
     end
 
     it_behaves_like 'error response', 422

--- a/spec/requests/api/v2/search_spec.rb
+++ b/spec/requests/api/v2/search_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe 'Search API' do
       context 'when search raises syntax error' do
         before { allow(Search).to receive(:new).and_raise(Mastodon::SyntaxError) }
 
-        it 'returns http unprocessable_entity' do
+        it 'returns http unprocessable_content' do
           get '/api/v2/search', headers: headers, params: params
 
           expect(response).to have_http_status(422)


### PR DESCRIPTION
This was renamed in the rack internals a while ago, and in rack 3.2 starts to emit deprecation warning.

This change quites most (but not all) of the warnings from the full suite ... I'm guessing there are more from underlying gems/deps, may review as followup, and/or can handle whenever renovate opens a 3.2 PR.