### PR TITLE
Disable ActiveRecord query cache in `Create` critical path

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -17,9 +17,11 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
     return reject_payload! if unsupported_object_type? || non_matching_uri_hosts?(@account.uri, object_uri) || tombstone_exists? || !related_to_local_activity?
 
     with_redis_lock("create:#{object_uri}") do
-      return if delete_arrived_first?(object_uri) || poll_vote?
+      Status.uncached do
+        return if delete_arrived_first?(object_uri) || poll_vote?
 
-      @status = find_existing_status
+        @status = find_existing_status
+      end
 
       if @status.nil?
         process_status


### PR DESCRIPTION
Call sites regularly check for the status existing before going into `Create`. When that happens, the critical section is useless as ActiveRecord will fail to find the status, because of the cached negative result.

I believe this will fix the occasional `Validation failed: Uri has already been taken` issues we've been seeing.