### PR TITLE
change: Mention reblogs in the mute modal dialog

### DIFF
--- a/app/javascript/mastodon/features/ui/components/mute_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/mute_modal.jsx
@@ -101,6 +101,11 @@ export const MuteModal = ({ accountId, acct }) => {
           </div>
 
           <div>
+            <div className='safety-action-modal__bullet-points__icon'><Icon icon={VisibilityOffIcon} /></div>
+            <div><FormattedMessage id='mute_modal.you_wont_see_reblogs' defaultMessage="They can still see your boosts, but you won't see theirs." /></div>
+          </div>
+
+          <div>
             <div className='safety-action-modal__bullet-points__icon'><Icon icon={AlternateEmailIcon} /></div>
             <div><FormattedMessage id='mute_modal.you_wont_see_mentions' defaultMessage="You won't see posts that mention them." /></div>
           </div>

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -548,6 +548,7 @@
   "mute_modal.title": "Mute user?",
   "mute_modal.you_wont_see_mentions": "You won't see posts that mention them.",
   "mute_modal.you_wont_see_posts": "They can still see your posts, but you won't see theirs.",
+  "mute_modal.you_wont_see_reblogs": "They can still see your boosts, but you won't see theirs.",
   "navigation_bar.about": "About",
   "navigation_bar.account_settings": "Password and security",
   "navigation_bar.administration": "Administration",


### PR DESCRIPTION
Clarify that muting an account also mutes boosts from that account.