### PR TITLE
Add spec for `CanonicalEmailBlock.matching_email` scope

### DIFF
--- a/spec/models/canonical_email_block_spec.rb
+++ b/spec/models/canonical_email_block_spec.rb
@@ -3,6 +3,36 @@
 require 'rails_helper'
 
 RSpec.describe CanonicalEmailBlock do
+  describe 'Associations' do
+    it { is_expected.to belong_to(:reference_account).class_name('Account').optional }
+  end
+
+  describe 'Scopes' do
+    describe '.matching_email' do
+      subject { described_class.matching_email(email) }
+
+      let!(:block) { Fabricate :canonical_email_block, email: 'test@example.com' }
+
+      context 'when email is exact match' do
+        let(:email) { 'test@example.com' }
+
+        it { is_expected.to contain_exactly(block) }
+      end
+
+      context 'when email does not match' do
+        let(:email) { 'test@example.ORG' }
+
+        it { is_expected.to be_empty }
+      end
+
+      context 'when email is different but normalizes to same hash' do
+        let(:email) { 'te.st+more@EXAMPLE.com' }
+
+        it { is_expected.to contain_exactly(block) }
+      end
+    end
+  end
+
   describe '#email=' do
     let(:target_hash) { '973dfe463ec85785f5f95af5ba3906eedb2d931c24e69824a89ea65dba4e813b' }
 


### PR DESCRIPTION
This is pulled out of a WIP branch which is re-attempting something along the lines of https://github.com/mastodon/mastodon/pull/31202 - but using `normalizes` (which did not exist in rails at time of that PR).

However, in working on that I hit some API/docs/specs uncertainty, and am not sure that WIP branch will turn into anything useful ... so pulling out the added specs here to at least get these in for now, even if that branch doesn't shake out.

