### PR TITLE
Add `quote_approval_policy` parameter when posting and editing statuses

### DIFF
--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -19,6 +19,7 @@ class PostStatusService < BaseService
   # @option [String] :text Message
   # @option [Status] :thread Optional status to reply to
   # @option [Status] :quoted_status Optional status to quote
+  # @option [String] :quote_approval_policy Approval policy for quotes, one of `public`, `followers` or `nobody`
   # @option [Boolean] :sensitive
   # @option [String] :visibility
   # @option [String] :spoiler_text
@@ -215,6 +216,7 @@ class PostStatusService < BaseService
       language: valid_locale_cascade(@options[:language], @account.user&.preferred_posting_language, I18n.default_locale),
       application: @options[:application],
       rate_limit: @options[:with_rate_limit],
+      quote_approval_policy: @options[:quote_approval_policy],
     }.compact
   end
 

--- a/app/services/update_status_service.rb
+++ b/app/services/update_status_service.rb
@@ -115,6 +115,7 @@ class UpdateStatusService < BaseService
     @status.spoiler_text = @options[:spoiler_text] || '' if @options.key?(:spoiler_text)
     @status.sensitive    = @options[:sensitive] || @options[:spoiler_text].present? if @options.key?(:sensitive) || @options.key?(:spoiler_text)
     @status.language     = valid_locale_cascade(@options[:language], @status.language, @status.account.user&.preferred_posting_language, I18n.default_locale)
+    @status.quote_approval_policy = @options[:quote_approval_policy] if @options[:quote_approval_policy].present?
 
     # We raise here to rollback the entire transaction
     raise NoChangesSubmittedError unless significant_changes?

--- a/spec/requests/api/v1/statuses_spec.rb
+++ b/spec/requests/api/v1/statuses_spec.rb
@@ -158,6 +158,31 @@ RSpec.describe '/api/v1/statuses' do
         end
       end
 
+      context 'with a quote policy', feature: :outgoing_quotes do
+        let(:quoted_status) { Fabricate(:status, account: user.account) }
+        let(:params) do
+          {
+            status: 'Hello world, this is a self-quote',
+            quote_approval_policy: 'followers',
+          }
+        end
+
+        it 'returns post with appropriate quote policy, as well as rate limit headers', :aggregate_failures do
+          subject
+
+          expect(response).to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
+          expect(response.parsed_body[:quote_approval]).to include({
+            automatic: ['followers'],
+            manual: [],
+            current_user: 'automatic',
+          })
+          expect(response.headers['X-RateLimit-Limit']).to eq RateLimiter::FAMILIES[:statuses][:limit].to_s
+          expect(response.headers['X-RateLimit-Remaining']).to eq (RateLimiter::FAMILIES[:statuses][:limit] - 1).to_s
+        end
+      end
+
       context 'with a self-quote post', feature: :outgoing_quotes do
         let(:quoted_status) { Fabricate(:status, account: user.account) }
         let(:params) do
@@ -307,9 +332,10 @@ RSpec.describe '/api/v1/statuses' do
 
     describe 'PUT /api/v1/statuses/:id' do
       subject do
-        put "/api/v1/statuses/#{status.id}", headers: headers, params: { status: 'I am updated' }
+        put "/api/v1/statuses/#{status.id}", headers: headers, params: params
       end
 
+      let(:params) { { status: 'I am updated' } }
       let(:scopes) { 'write:statuses' }
       let(:status) { Fabricate(:status, account: user.account) }
 
@@ -322,6 +348,19 @@ RSpec.describe '/api/v1/statuses' do
         expect(response.content_type)
           .to start_with('application/json')
         expect(status.reload.text).to eq 'I am updated'
+      end
+
+      context 'when updating only the quote policy' do
+        let(:params) { { status: status.text, quote_approval_policy: 'public' } }
+
+        it 'updates the status', :aggregate_failures, feature: :outgoing_quotes do
+          expect { subject }
+            .to change { status.reload.quote_approval_policy }.to(Status::QUOTE_APPROVAL_POLICY_FLAGS[:public] << 16)
+
+          expect(response).to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
+        end
       end
     end
   end

--- a/spec/services/post_status_service_spec.rb
+++ b/spec/services/post_status_service_spec.rb
@@ -160,6 +160,12 @@ RSpec.describe PostStatusService do
     expect(status.language).to eq 'en'
   end
 
+  it 'creates a status with the quote approval policy set' do
+    status = create_status_with_options(quote_approval_policy: Status::QUOTE_APPROVAL_POLICY_FLAGS[:followers] << 16)
+
+    expect(status.quote_approval_policy).to eq(Status::QUOTE_APPROVAL_POLICY_FLAGS[:followers] << 16)
+  end
+
   it 'processes mentions' do
     mention_service = instance_double(ProcessMentionsService)
     allow(mention_service).to receive(:call)


### PR DESCRIPTION
This adds the `quote_approval_policy` parameter to `POST /api/v1/statuses` and `PUT /api/v1/statuses/:id` to set and update a  quote policy.

This is still locked behind the `outgoing_quotes` feature flag, and it still does not fall back to using the specified setting.