### PR TITLE
Change quote to be fetched with quoted account rather than random follower

### DIFF
--- a/app/lib/activitypub/activity/quote_request.rb
+++ b/app/lib/activitypub/activity/quote_request.rb
@@ -21,7 +21,7 @@ class ActivityPub::Activity::QuoteRequest < ActivityPub::Activity
   def accept_quote_request!(quoted_status)
     status = status_from_uri(@json['instrument'])
     # TODO: import inlined quote post if possible
-    status ||= ActivityPub::FetchRemoteStatusService.new.call(@json['instrument'], on_behalf_of: @account.followers.local.first, request_id: @options[:request_id])
+    status ||= ActivityPub::FetchRemoteStatusService.new.call(@json['instrument'], on_behalf_of: quoted_status.account, request_id: @options[:request_id])
     # TODO: raise if status is nil
 
     # Sanity check


### PR DESCRIPTION
This shouldn't change much in practice, but this should nicely handle edge cases, as the quoted account should always be able to see the quoting post.