### PR TITLE
Inline `instrument` quote post in outgoing `QuoteRequest` activities

### DIFF
--- a/app/serializers/activitypub/quote_request_serializer.rb
+++ b/app/serializers/activitypub/quote_request_serializer.rb
@@ -1,10 +1,21 @@
 # frozen_string_literal: true
 
 class ActivityPub::QuoteRequestSerializer < ActivityPub::Serializer
+  def self.serializer_for(model, options)
+    case model.class.name
+    when 'Status'
+      ActivityPub::NoteSerializer
+    else
+      super
+    end
+  end
+
   context_extensions :quote_requests
 
-  attributes :id, :type, :actor, :instrument
+  attributes :id, :type, :actor
   attribute :virtual_object, key: :object
+
+  has_one :instrument
 
   def id
     object.activity_uri
@@ -23,7 +34,6 @@ class ActivityPub::QuoteRequestSerializer < ActivityPub::Serializer
   end
 
   def instrument
-    # TODO: inline object?
-    ActivityPub::TagManager.instance.uri_for(object.status)
+    instance_options[:allow_post_inlining] && object.status.local? ? object.status : ActivityPub::TagManager.instance.uri_for(object.status)
   end
 end

--- a/app/workers/activitypub/quote_request_worker.rb
+++ b/app/workers/activitypub/quote_request_worker.rb
@@ -17,6 +17,6 @@ class ActivityPub::QuoteRequestWorker < ActivityPub::RawDistributionWorker
   end
 
   def payload
-    @payload ||= Oj.dump(serialize_payload(@quote, ActivityPub::QuoteRequestSerializer, signer: @account))
+    @payload ||= Oj.dump(serialize_payload(@quote, ActivityPub::QuoteRequestSerializer, signer: @account, allow_post_inlining: true))
   end
 end

--- a/spec/workers/activitypub/quote_request_worker_spec.rb
+++ b/spec/workers/activitypub/quote_request_worker_spec.rb
@@ -23,7 +23,9 @@ RSpec.describe ActivityPub::QuoteRequestWorker do
         type: 'QuoteRequest',
         actor: ActivityPub::TagManager.instance.uri_for(quote.account),
         object: ActivityPub::TagManager.instance.uri_for(quoted_status),
-        instrument: anything # TODO: inline post in request?
+        instrument: a_hash_including(
+          id: ActivityPub::TagManager.instance.uri_for(status)
+        )
       )
     end
   end


### PR DESCRIPTION
The PR itself should be fine, but processing of such activities is buggy for now, see #35714 which fixes it (as well as implementing importing from the inlined instrument itself)