### PR TITLE
Update Redux to handle quote posts

### DIFF
--- a/app/javascript/mastodon/actions/compose.js
+++ b/app/javascript/mastodon/actions/compose.js
@@ -228,6 +228,8 @@ export function submitCompose() {
         visibility: getState().getIn(['compose', 'privacy']),
         poll: getState().getIn(['compose', 'poll'], null),
         language: getState().getIn(['compose', 'language']),
+        quoted_status_id: getState().getIn(['compose', 'quoted_status_id']),
+        quote_approval_policy: getState().getIn(['compose', 'quote_policy']),
       },
       headers: {
         'Idempotency-Key': getState().getIn(['compose', 'idempotencyKey']),

--- a/app/javascript/mastodon/actions/compose_typed.ts
+++ b/app/javascript/mastodon/actions/compose_typed.ts
@@ -4,8 +4,10 @@ import type { List as ImmutableList, Map as ImmutableMap } from 'immutable';
 import { apiUpdateMedia } from 'mastodon/api/compose';
 import type { ApiMediaAttachmentJSON } from 'mastodon/api_types/media_attachments';
 import type { MediaAttachment } from 'mastodon/models/media_attachment';
-import type { TypedThunkAction } from 'mastodon/store/typed_functions';
-import { createDataLoadingThunk } from 'mastodon/store/typed_functions';
+import {
+  createDataLoadingThunk,
+  createAppThunk,
+} from 'mastodon/store/typed_functions';
 
 import type { ApiQuotePolicy } from '../api_types/quotes';
 import type { Status } from '../models/status';
@@ -76,26 +78,22 @@ export const changeUploadCompose = createDataLoadingThunk(
   },
 );
 
-/** For the reducer. You typically should call quoteComposeByStatus or quoteComposeById. */
-export const quoteComposeStatus = createAction<Status>(
+export const quoteComposeByStatus = createAppThunk(
   'compose/quoteComposeStatus',
+  (status: Status, { getState }) => {
+    ensureComposeIsVisible(getState);
+    return status;
+  },
 );
 
-export function quoteComposeByStatus(status: Status): TypedThunkAction {
-  return (dispatch, getState) => {
-    dispatch(quoteComposeStatus(status));
-    ensureComposeIsVisible(getState);
-  };
-}
-
-export function quoteComposeById(statusId: string): TypedThunkAction {
-  return (dispatch, getState) => {
+export const quoteComposeById = createAppThunk(
+  (statusId: string, { dispatch, getState }) => {
     const status = getState().statuses.get(statusId);
     if (status) {
       dispatch(quoteComposeByStatus(status));
     }
-  };
-}
+  },
+);
 
 export const quoteComposeCancel = createAction('compose/quoteComposeCancel');
 

--- a/app/javascript/mastodon/actions/compose_typed.ts
+++ b/app/javascript/mastodon/actions/compose_typed.ts
@@ -1,9 +1,16 @@
+import { createAction } from '@reduxjs/toolkit';
 import type { List as ImmutableList, Map as ImmutableMap } from 'immutable';
 
 import { apiUpdateMedia } from 'mastodon/api/compose';
 import type { ApiMediaAttachmentJSON } from 'mastodon/api_types/media_attachments';
 import type { MediaAttachment } from 'mastodon/models/media_attachment';
+import type { TypedThunkAction } from 'mastodon/store/typed_functions';
 import { createDataLoadingThunk } from 'mastodon/store/typed_functions';
+
+import type { ApiQuotePolicy } from '../api_types/quotes';
+import type { Status } from '../models/status';
+
+import { ensureComposeIsVisible } from './compose';
 
 type SimulatedMediaAttachmentJSON = ApiMediaAttachmentJSON & {
   unattached?: boolean;
@@ -67,4 +74,31 @@ export const changeUploadCompose = createDataLoadingThunk(
   {
     useLoadingBar: false,
   },
+);
+
+/** For the reducer. You typically should call quoteComposeByStatus or quoteComposeById. */
+export const quoteComposeStatus = createAction<Status>(
+  'compose/quoteComposeStatus',
+);
+
+export function quoteComposeByStatus(status: Status): TypedThunkAction {
+  return (dispatch, getState) => {
+    dispatch(quoteComposeStatus(status));
+    ensureComposeIsVisible(getState);
+  };
+}
+
+export function quoteComposeById(statusId: string): TypedThunkAction {
+  return (dispatch, getState) => {
+    const status = getState().statuses.get(statusId);
+    if (status) {
+      dispatch(quoteComposeByStatus(status));
+    }
+  };
+}
+
+export const quoteComposeCancel = createAction('compose/quoteComposeCancel');
+
+export const setQuotePolicy = createAction<ApiQuotePolicy>(
+  'compose/setQuotePolicy',
 );

--- a/app/javascript/mastodon/api_types/quotes.ts
+++ b/app/javascript/mastodon/api_types/quotes.ts
@@ -1,6 +1,7 @@
 import type { ApiStatusJSON } from './statuses';
 
 export type ApiQuoteState = 'accepted' | 'pending' | 'revoked' | 'unauthorized';
+export type ApiQuotePolicy = 'public' | 'followers' | 'nobody';
 
 interface ApiQuoteEmptyJSON {
   state: Exclude<ApiQuoteState, 'accepted'>;

--- a/app/javascript/mastodon/api_types/quotes.ts
+++ b/app/javascript/mastodon/api_types/quotes.ts
@@ -1,0 +1,22 @@
+import type { ApiStatusJSON } from './statuses';
+
+export type ApiQuoteState = 'accepted' | 'pending' | 'revoked' | 'unauthorized';
+
+interface ApiQuoteEmptyJSON {
+  state: Exclude<ApiQuoteState, 'accepted'>;
+  quoted_status: null;
+}
+
+interface ApiNestedQuoteJSON {
+  state: 'accepted';
+  quoted_status_id: string;
+}
+
+interface ApiQuoteAcceptedJSON {
+  state: 'accepted';
+  quoted_status: Omit<ApiStatusJSON, 'quote'> & {
+    quote: ApiNestedQuoteJSON | ApiQuoteEmptyJSON;
+  };
+}
+
+export type ApiQuoteJSON = ApiQuoteAcceptedJSON | ApiQuoteEmptyJSON;

--- a/app/javascript/mastodon/api_types/statuses.ts
+++ b/app/javascript/mastodon/api_types/statuses.ts
@@ -4,6 +4,7 @@ import type { ApiAccountJSON } from './accounts';
 import type { ApiCustomEmojiJSON } from './custom_emoji';
 import type { ApiMediaAttachmentJSON } from './media_attachments';
 import type { ApiPollJSON } from './polls';
+import type { ApiQuoteJSON } from './quotes';
 
 // See app/modals/status.rb
 export type StatusVisibility =
@@ -118,6 +119,7 @@ export interface ApiStatusJSON {
 
   card?: ApiPreviewCardJSON;
   poll?: ApiPollJSON;
+  quote?: ApiQuoteJSON;
 }
 
 export interface ApiContextJSON {

--- a/app/javascript/mastodon/reducers/compose.js
+++ b/app/javascript/mastodon/reducers/compose.js
@@ -2,7 +2,7 @@ import { Map as ImmutableMap, List as ImmutableList, OrderedSet as ImmutableOrde
 
 import {
   changeUploadCompose,
-  quoteComposeStatus,
+  quoteComposeByStatus,
   quoteComposeCancel,
   setQuotePolicy,
 } from 'mastodon/actions/compose_typed';
@@ -329,7 +329,7 @@ export const composeReducer = (state = initialState, action) => {
     return state.set('is_changing_upload', true);
   } else if (changeUploadCompose.rejected.match(action)) {
     return state.set('is_changing_upload', false);
-  } else if (quoteComposeStatus.match(action)) {
+  } else if (quoteComposeByStatus.match(action)) {
     const status = action.payload;
     if (status.getIn(['quote_approval', 'current_user']) === 'automatic') {
       return state.set('quoted_status_id', status.get('id'));

--- a/app/javascript/mastodon/reducers/compose.js
+++ b/app/javascript/mastodon/reducers/compose.js
@@ -1,6 +1,11 @@
 import { Map as ImmutableMap, List as ImmutableList, OrderedSet as ImmutableOrderedSet, fromJS } from 'immutable';
 
-import { changeUploadCompose } from 'mastodon/actions/compose_typed';
+import {
+  changeUploadCompose,
+  quoteComposeStatus,
+  quoteComposeCancel,
+  setQuotePolicy,
+} from 'mastodon/actions/compose_typed';
 import { timelineDelete } from 'mastodon/actions/timelines_typed';
 
 import {
@@ -83,6 +88,11 @@ const initialState = ImmutableMap({
   resetFileKey: Math.floor((Math.random() * 0x10000)),
   idempotencyKey: null,
   tagHistory: ImmutableList(),
+
+  // Quotes
+  quoted_status_id: null,
+  quote_policy: 'public',
+  default_quote_policy: 'public', // Set in hydration.
 });
 
 const initialPoll = ImmutableMap({
@@ -117,6 +127,8 @@ function clearAll(state) {
     map.set('progress', 0);
     map.set('poll', null);
     map.set('idempotencyKey', uuid());
+    map.set('quoted_status_id', null);
+    map.set('quote_policy', state.get('default_quote_policy'));
   });
 }
 
@@ -317,6 +329,15 @@ export const composeReducer = (state = initialState, action) => {
     return state.set('is_changing_upload', true);
   } else if (changeUploadCompose.rejected.match(action)) {
     return state.set('is_changing_upload', false);
+  } else if (quoteComposeStatus.match(action)) {
+    const status = action.payload;
+    if (status.getIn(['quote_approval', 'current_user']) === 'automatic') {
+      return state.set('quoted_status_id', status.get('id'));
+    }
+  } else if (quoteComposeCancel.match(action)) {
+    return state.set('quoted_status_id', null);
+  } else if (setQuotePolicy.match(action)) {
+    return state.set('quote_policy', action.payload);
   }
 
   switch(action.type) {

--- a/app/javascript/mastodon/store/typed_functions.ts
+++ b/app/javascript/mastodon/store/typed_functions.ts
@@ -1,5 +1,12 @@
-import type { GetThunkAPI } from '@reduxjs/toolkit';
-import { createAsyncThunk, createSelector } from '@reduxjs/toolkit';
+import type {
+  ActionCreatorWithPreparedPayload,
+  GetThunkAPI,
+} from '@reduxjs/toolkit';
+import {
+  createAsyncThunk as rtkCreateAsyncThunk,
+  createSelector,
+  createAction,
+} from '@reduxjs/toolkit';
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -18,12 +25,7 @@ interface AppMeta {
   useLoadingBar?: boolean;
 }
 
-export type TypedThunkAction = (
-  dispatch: AppDispatch,
-  getState: () => RootState,
-) => void;
-
-export const createAppAsyncThunk = createAsyncThunk.withTypes<{
+export const createAppAsyncThunk = rtkCreateAsyncThunk.withTypes<{
   state: RootState;
   dispatch: AppDispatch;
   rejectValue: AsyncThunkRejectValue;
@@ -48,9 +50,88 @@ interface AppThunkOptions<Arg> {
   ) => boolean;
 }
 
-const createBaseAsyncThunk = createAsyncThunk.withTypes<AppThunkConfig>();
+// Type definitions for the sync thunks.
+type AppThunk<Arg = void, Returned = void> = (
+  arg: Arg,
+) => (dispatch: AppDispatch, getState: () => RootState) => Returned;
 
-export function createThunk<Arg = void, Returned = void>(
+type AppThunkCreator<Arg = void, Returned = void, ExtraArg = unknown> = (
+  arg: Arg,
+  api: AppThunkApi,
+  extra?: ExtraArg,
+) => Returned;
+
+type AppThunkActionCreator<
+  Arg = void,
+  Returned = void,
+> = ActionCreatorWithPreparedPayload<
+  [Returned, Arg],
+  Returned,
+  string,
+  never,
+  { arg: Arg }
+>;
+
+// Version that does not dispatch it's own action.
+export function createAppThunk<Arg = void, Returned = void, ExtraArg = unknown>(
+  creator: AppThunkCreator<Arg, Returned, ExtraArg>,
+  extra?: ExtraArg,
+): AppThunk<Arg, Returned>;
+
+// Version that dispatches an named action with the result of the creator callback.
+export function createAppThunk<Arg = void, Returned = void, ExtraArg = unknown>(
+  name: string,
+  creator: AppThunkCreator<Arg, Returned, ExtraArg>,
+  extra?: ExtraArg,
+): AppThunk<Arg, Returned> & AppThunkActionCreator<Arg, Returned>;
+
+/** Creates a thunk that dispatches an action. */
+export function createAppThunk<Arg = void, Returned = void, ExtraArg = unknown>(
+  nameOrCreator: string | AppThunkCreator<Arg, Returned, ExtraArg>,
+  maybeCreatorOrExtra?: AppThunkCreator<Arg, Returned, ExtraArg> | ExtraArg,
+  maybeExtra?: ExtraArg,
+) {
+  const isDispatcher = typeof nameOrCreator === 'string';
+  const name = isDispatcher ? nameOrCreator : undefined;
+  const creator = isDispatcher
+    ? (maybeCreatorOrExtra as AppThunkCreator<Arg, Returned, ExtraArg>)
+    : nameOrCreator;
+  const extra = isDispatcher ? maybeExtra : (maybeCreatorOrExtra as ExtraArg);
+  let action: null | AppThunkActionCreator<Arg, Returned> = null;
+
+  // Creates a thunk that dispatches the action with the result of the creator.
+  const actionCreator: AppThunk<Arg, Returned> = (arg) => {
+    return (dispatch, getState) => {
+      const result = creator(arg, { dispatch, getState }, extra);
+      if (action) {
+        // Dispatches the action with the result.
+        const actionObj = action(result, arg);
+        dispatch(actionObj);
+      }
+      return result;
+    };
+  };
+
+  // No action name provided, return the thunk directly.
+  if (!name) {
+    return actionCreator;
+  }
+
+  // Create the action and assign the action creator to it in order
+  // to have things like `toString` and `match` available.
+  action = createAction(name, (payload: Returned, arg: Arg) => ({
+    payload,
+    meta: {
+      arg,
+    },
+  }));
+
+  return Object.assign({}, action, actionCreator);
+}
+
+const createBaseAsyncThunk = rtkCreateAsyncThunk.withTypes<AppThunkConfig>();
+
+export function createAsyncThunk<Arg = void, Returned = void>(
   name: string,
   creator: (arg: Arg, api: AppThunkApi) => Returned | Promise<Returned>,
   options: AppThunkOptions<Arg> = {},
@@ -109,7 +190,7 @@ export function createDataLoadingThunk<LoadDataResult, Args extends ArgsType>(
   name: string,
   loadData: (args: Args) => Promise<LoadDataResult>,
   thunkOptions?: AppThunkOptions<Args>,
-): ReturnType<typeof createThunk<Args, LoadDataResult>>;
+): ReturnType<typeof createAsyncThunk<Args, LoadDataResult>>;
 
 // Overload when the `onData` method returns discardLoadDataInPayload, then the payload is empty
 export function createDataLoadingThunk<LoadDataResult, Args extends ArgsType>(
@@ -119,7 +200,7 @@ export function createDataLoadingThunk<LoadDataResult, Args extends ArgsType>(
     | AppThunkOptions<Args>
     | OnData<Args, LoadDataResult, DiscardLoadData>,
   thunkOptions?: AppThunkOptions<Args>,
-): ReturnType<typeof createThunk<Args, void>>;
+): ReturnType<typeof createAsyncThunk<Args, void>>;
 
 // Overload when the `onData` method returns nothing, then the mayload is the `onData` result
 export function createDataLoadingThunk<LoadDataResult, Args extends ArgsType>(
@@ -129,7 +210,7 @@ export function createDataLoadingThunk<LoadDataResult, Args extends ArgsType>(
     | AppThunkOptions<Args>
     | OnData<Args, LoadDataResult, void>,
   thunkOptions?: AppThunkOptions<Args>,
-): ReturnType<typeof createThunk<Args, LoadDataResult>>;
+): ReturnType<typeof createAsyncThunk<Args, LoadDataResult>>;
 
 // Overload when there is an `onData` method returning something
 export function createDataLoadingThunk<
@@ -143,7 +224,7 @@ export function createDataLoadingThunk<
     | AppThunkOptions<Args>
     | OnData<Args, LoadDataResult, Returned>,
   thunkOptions?: AppThunkOptions<Args>,
-): ReturnType<typeof createThunk<Args, Returned>>;
+): ReturnType<typeof createAsyncThunk<Args, Returned>>;
 
 /**
  * This function creates a Redux Thunk that handles loading data asynchronously (usually from the API), dispatching `pending`, `fullfilled` and `rejected` actions.
@@ -194,7 +275,7 @@ export function createDataLoadingThunk<
     thunkOptions = maybeThunkOptions;
   }
 
-  return createThunk<Args, Returned>(
+  return createAsyncThunk<Args, Returned>(
     name,
     async (arg, { getState, dispatch }) => {
       const data = await loadData(arg, {

--- a/app/javascript/mastodon/store/typed_functions.ts
+++ b/app/javascript/mastodon/store/typed_functions.ts
@@ -18,6 +18,11 @@ interface AppMeta {
   useLoadingBar?: boolean;
 }
 
+export type TypedThunkAction = (
+  dispatch: AppDispatch,
+  getState: () => RootState,
+) => void;
+
 export const createAppAsyncThunk = createAsyncThunk.withTypes<{
   state: RootState;
   dispatch: AppDispatch;

--- a/app/models/concerns/user/has_settings.rb
+++ b/app/models/concerns/user/has_settings.rb
@@ -107,6 +107,10 @@ module User::HasSettings
     settings['default_privacy'] || (account.locked? ? 'private' : 'public')
   end
 
+  def setting_default_quote_policy
+    settings['default_quote_policy'] || 'public'
+  end
+
   def allows_report_emails?
     settings['notification_emails.report']
   end

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -54,6 +54,7 @@ class InitialStateSerializer < ActiveModel::Serializer
       store[:default_privacy]   = object.visibility || object_account_user.setting_default_privacy
       store[:default_sensitive] = object_account_user.setting_default_sensitive
       store[:default_language]  = object_account_user.preferred_posting_language
+      store[:default_quote_policy] = object_account_user.setting_default_quote_policy
     end
 
     store[:text] = object.text if object.text


### PR DESCRIPTION
This PR exposes a user's default quote policy in the initial state, and adds quoting to the Redux store.

Quoting can be tested via calling `quoteComposeById` with a status that has approved quoting, verifying the Redux state has the quoted post ID, and submitting the new post is a quote post.