### PR TITLE
Change serialization of `Delete` activities for `QuoteAuthorization` to inline the latter

### DIFF
--- a/app/serializers/activitypub/delete_quote_authorization_serializer.rb
+++ b/app/serializers/activitypub/delete_quote_authorization_serializer.rb
@@ -3,15 +3,14 @@
 class ActivityPub::DeleteQuoteAuthorizationSerializer < ActivityPub::Serializer
   attributes :id, :type, :actor, :to
 
-  # TODO: change the `object` to a `QuoteAuthorization` object instead of just the URI?
-  attribute :virtual_object, key: :object
+  has_one :virtual_object, key: :object, serializer: ActivityPub::QuoteAuthorizationSerializer
 
   def id
     [ActivityPub::TagManager.instance.approval_uri_for(object, check_approval: false), '#delete'].join
   end
 
   def virtual_object
-    ActivityPub::TagManager.instance.approval_uri_for(object, check_approval: false)
+    object
   end
 
   def type

--- a/spec/serializers/activitypub/delete_quote_authorization_serializer_spec.rb
+++ b/spec/serializers/activitypub/delete_quote_authorization_serializer_spec.rb
@@ -13,7 +13,10 @@ RSpec.describe ActivityPub::DeleteQuoteAuthorizationSerializer do
       expect(subject.deep_symbolize_keys)
         .to include(
           actor: eq(ActivityPub::TagManager.instance.uri_for(status.account)),
-          object: ActivityPub::TagManager.instance.approval_uri_for(quote, check_approval: false),
+          object: a_hash_including(
+            type: 'QuoteAuthorization',
+            id: ActivityPub::TagManager.instance.approval_uri_for(quote, check_approval: false)
+          ),
           type: 'Delete'
         )
     end


### PR DESCRIPTION
This makes it easier to handle on the receiving side, sparing one PostgreSQL query in Mastodon's case.