### PR TITLE
Allow `CustomEmoji` to normalize its own domain

### DIFF
--- a/app/models/custom_emoji.rb
+++ b/app/models/custom_emoji.rb
@@ -42,7 +42,7 @@ class CustomEmoji < ApplicationRecord
 
   has_attached_file :image, styles: { static: { format: 'png', convert_options: '-coalesce +profile "!icc,*" +set date:modify +set date:create +set date:timestamp', file_geometry_parser: FastGeometryParser } }, validate_media_type: false, processors: [:lazy_thumbnail]
 
-  normalizes :domain, with: ->(domain) { domain.downcase }
+  normalizes :domain, with: ->(domain) { domain.downcase.strip }
 
   validates_attachment :image, content_type: { content_type: IMAGE_MIME_TYPES }, presence: true, size: { less_than: LIMIT }
   validates :shortcode, uniqueness: { scope: :domain }, format: { with: SHORTCODE_ONLY_RE }, length: { minimum: MINIMUM_SHORTCODE_SIZE }

--- a/app/models/custom_emoji_filter.rb
+++ b/app/models/custom_emoji_filter.rb
@@ -35,7 +35,7 @@ class CustomEmojiFilter
     when 'remote'
       CustomEmoji.remote
     when 'by_domain'
-      CustomEmoji.where(domain: value.strip.downcase)
+      CustomEmoji.where(domain: value)
     when 'shortcode'
       CustomEmoji.search(value.strip)
     else

--- a/spec/models/custom_emoji_spec.rb
+++ b/spec/models/custom_emoji_spec.rb
@@ -80,6 +80,7 @@ RSpec.describe CustomEmoji, :attachment_processing do
 
   describe 'Normalizations' do
     describe 'domain' do
+      it { is_expected.to normalize(:domain).from('  www.mastodon.host   ').to('www.mastodon.host') }
       it { is_expected.to normalize(:domain).from('wWw.MaStOdOn.CoM').to('www.mastodon.com') }
       it { is_expected.to normalize(:domain).from(nil).to(nil) }
     end


### PR DESCRIPTION
The where query called from the filter is already applying the downcase, allow it to apply strip too.

Seems safe to add for attr assignment as well.