### PR TITLE
Clean up announcements (with mutes/reactions) associations

### DIFF
--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -24,8 +24,10 @@ class Announcement < ApplicationRecord
   scope :chronological, -> { order(coalesced_chronology_timestamps.asc) }
   scope :reverse_chronological, -> { order(coalesced_chronology_timestamps.desc) }
 
-  has_many :announcement_mutes, dependent: :destroy
-  has_many :announcement_reactions, dependent: :destroy
+  with_options dependent: :destroy, inverse_of: :announcement do
+    has_many :announcement_mutes
+    has_many :announcement_reactions
+  end
 
   validates :text, presence: true
   validates :starts_at, presence: true, if: :ends_at?

--- a/app/models/announcement_mute.rb
+++ b/app/models/announcement_mute.rb
@@ -12,8 +12,10 @@
 #
 
 class AnnouncementMute < ApplicationRecord
-  belongs_to :account
-  belongs_to :announcement, inverse_of: :announcement_mutes
+  with_options inverse_of: :announcement_mutes do
+    belongs_to :account
+    belongs_to :announcement
+  end
 
   validates :account_id, uniqueness: { scope: :announcement_id }
 end

--- a/app/models/announcement_reaction.rb
+++ b/app/models/announcement_reaction.rb
@@ -17,8 +17,11 @@ class AnnouncementReaction < ApplicationRecord
   before_validation :set_custom_emoji, if: :name?
   after_commit :queue_publish
 
-  belongs_to :account
-  belongs_to :announcement, inverse_of: :announcement_reactions
+  with_options inverse_of: :announcement_reactions do
+    belongs_to :account
+    belongs_to :announcement
+  end
+
   belongs_to :custom_emoji, optional: true
 
   validates :name, presence: true

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -12,6 +12,8 @@ module Account::Associations
         has_many :account_pins
         has_many :account_warnings
         has_many :aliases, class_name: 'AccountAlias'
+        has_many :announcement_mutes
+        has_many :announcement_reactions
         has_many :bookmarks
         has_many :conversations, class_name: 'AccountConversation'
         has_many :custom_filters

--- a/app/models/concerns/account/interactions.rb
+++ b/app/models/concerns/account/interactions.rb
@@ -43,7 +43,6 @@ module Account::Interactions
     has_many :muted_by, -> { order(mutes: { id: :desc }) }, through: :muted_by_relationships, source: :account
     has_many :conversation_mutes, dependent: :destroy
     has_many :domain_blocks, class_name: 'AccountDomainBlock', dependent: :destroy
-    has_many :announcement_mutes, dependent: :destroy
   end
 
   def follow!(other_account, reblogs: nil, notify: nil, languages: nil, uri: nil, rate_limit: false, bypass_limit: false)

--- a/spec/models/announcement_mute_spec.rb
+++ b/spec/models/announcement_mute_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AnnouncementMute do
+  describe 'Associations' do
+    it { is_expected.to belong_to(:account).inverse_of(:announcement_mutes) }
+    it { is_expected.to belong_to(:announcement).inverse_of(:announcement_mutes) }
+  end
+
+  describe 'Validations' do
+    subject { Fabricate.build :announcement_mute }
+
+    it { is_expected.to validate_uniqueness_of(:account_id).scoped_to(:announcement_id) }
+  end
+end

--- a/spec/models/announcement_reaction_spec.rb
+++ b/spec/models/announcement_reaction_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe AnnouncementReaction do
   describe 'Associations' do
-    it { is_expected.to belong_to(:account) }
+    it { is_expected.to belong_to(:account).inverse_of(:announcement_reactions) }
     it { is_expected.to belong_to(:announcement).inverse_of(:announcement_reactions) }
     it { is_expected.to belong_to(:custom_emoji).optional }
   end

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -3,6 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe Announcement do
+  describe 'Associations' do
+    it { is_expected.to have_many(:announcement_mutes).inverse_of(:announcement).dependent(:destroy) }
+    it { is_expected.to have_many(:announcement_reactions).inverse_of(:announcement).dependent(:destroy) }
+  end
+
   describe 'Scopes' do
     context 'with published and unpublished records' do
       let!(:published) { Fabricate(:announcement, published: true) }


### PR DESCRIPTION
Mix of adding some missing specs, tidying up association declarations, etc.

Related to https://github.com/mastodon/mastodon/pull/35540 in that both are starting to nudge the "non core interactions" associations out of that file in prep for further clean up there.
