### PR TITLE
Prevent props being added as HTML attributes

### DIFF
--- a/app/javascript/mastodon/features/emoji/emoji_html.tsx
+++ b/app/javascript/mastodon/features/emoji/emoji_html.tsx
@@ -38,11 +38,7 @@ export const EmojiHTML = <Element extends ElementType>(
   if (isModernEmojiEnabled()) {
     return <ModernEmojiHTML {...props} />;
   }
-  const Wrapper = props.as ?? 'div';
-  return (
-    <Wrapper
-      {...props}
-      dangerouslySetInnerHTML={{ __html: props.htmlString }}
-    />
-  );
+  const { as: asElement, htmlString, extraEmojis, ...rest } = props;
+  const Wrapper = asElement ?? 'div';
+  return <Wrapper {...rest} dangerouslySetInnerHTML={{ __html: htmlString }} />;
 };


### PR DESCRIPTION
This removes `extraEmojis` prop from appearing as an HTML attribute.