### PR TITLE
Update `rubocop-rails` to version 2.33.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -789,7 +789,7 @@ GEM
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.38.0, < 2.0)
-    rubocop-rails (2.32.0)
+    rubocop-rails (2.33.0)
       activesupport (>= 4.2.0)
       lint_roller (~> 1.1)
       rack (>= 1.1)

--- a/app/controllers/auth/registrations_controller.rb
+++ b/app/controllers/auth/registrations_controller.rb
@@ -23,11 +23,11 @@ class Auth::RegistrationsController < Devise::RegistrationsController
     super(&:build_invite_request)
   end
 
-  def edit # rubocop:disable Lint/UselessMethodDefinition
+  def edit
     super
   end
 
-  def create # rubocop:disable Lint/UselessMethodDefinition
+  def create
     super
   end
 


### PR DESCRIPTION
Replaces https://github.com/mastodon/mastodon/pull/35730

Just the bump plus removing a disable of what was previously classed as useless method, but in latest version no longer is (they resolved a conflict between two rules in https://github.com/rubocop/rubocop-rails/pull/1500 ).