### PR TITLE
fix hero image's radius on frame 59 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <a style="text-decoration:none" href="https://www.youtube.com/watch?v=IPSbNdBmWKE">
-    <img alt="Mastodon hero image" src="https://github.com/user-attachments/assets/ef53f5e9-c0d8-484d-9f53-00efdebb92c3" />
+    <img alt="Mastodon hero image" src="https://github.com/user-attachments/assets/7f171473-dc7a-4610-8489-d4abc42dad9d" />
   </a>
 </p>
 


### PR DESCRIPTION
For some reason the hero image in the README currently is missing rounded corners on frame 59, and only 59, or well, it's rounded, but it's instead of being rounded with transparency like all the other frames it is instead blue.