### PR TITLE
Rename container images and version information for fork

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   compute-suffix:
     runs-on: ubuntu-latest
-    if: github.repository == 'mastodon/mastodon'
+    if: github.repository == 'altstoreio/mastodon'
     steps:
       - id: version_vars
         env:
@@ -28,8 +28,7 @@ jobs:
       file_to_build: Dockerfile
       cache: false
       push_to_images: |
-        tootsuite/mastodon
-        ghcr.io/mastodon/mastodon
+        ghcr.io/${{ github.repository_owner }}/mastodon
       version_prerelease: ${{ needs.compute-suffix.outputs.prerelease }}
       labels: |
         org.opencontainers.image.description=Nightly build image used for testing purposes
@@ -48,8 +47,7 @@ jobs:
       file_to_build: streaming/Dockerfile
       cache: false
       push_to_images: |
-        tootsuite/mastodon-streaming
-        ghcr.io/mastodon/mastodon-streaming
+        ghcr.io/${{ github.repository_owner }}/mastodon-streaming
       version_prerelease: ${{ needs.compute-suffix.outputs.prerelease }}
       labels: |
         org.opencontainers.image.description=Nightly build image used for testing purposes

--- a/.github/workflows/build-push-pr.yml
+++ b/.github/workflows/build-push-pr.yml
@@ -33,7 +33,7 @@ jobs:
     with:
       file_to_build: Dockerfile
       push_to_images: |
-        ghcr.io/mastodon/mastodon
+        ghcr.io/${{ github.repository_owner }}/mastodon
       version_metadata: ${{ needs.compute-suffix.outputs.metadata }}
       flavor: |
         latest=auto
@@ -48,7 +48,7 @@ jobs:
     with:
       file_to_build: streaming/Dockerfile
       push_to_images: |
-        ghcr.io/mastodon/mastodon-streaming
+        ghcr.io/${{ github.repository_owner }}/mastodon-streaming
       version_metadata: ${{ needs.compute-suffix.outputs.metadata }}
       flavor: |
         latest=auto

--- a/.github/workflows/build-releases.yml
+++ b/.github/workflows/build-releases.yml
@@ -14,8 +14,7 @@ jobs:
     with:
       file_to_build: Dockerfile
       push_to_images: |
-        tootsuite/mastodon
-        ghcr.io/mastodon/mastodon
+        ghcr.io/${{ github.repository_owner }}/mastodon
       # Do not use cache when building releases, so apt update is always ran and the release always contain the latest packages
       cache: false
       # Only tag with latest when ran against the latest stable branch
@@ -32,8 +31,7 @@ jobs:
     with:
       file_to_build: streaming/Dockerfile
       push_to_images: |
-        tootsuite/mastodon-streaming
-        ghcr.io/mastodon/mastodon-streaming
+        ghcr.io/${{ github.repository_owner }}/mastodon-streaming
       # Do not use cache when building releases, so apt update is always ran and the release always contain the latest packages
       cache: false
       # Only tag with latest when ran against the latest stable branch

--- a/.github/workflows/build-security.yml
+++ b/.github/workflows/build-security.yml
@@ -9,7 +9,6 @@ permissions:
 jobs:
   compute-suffix:
     runs-on: ubuntu-latest
-    if: github.repository == 'mastodon/mastodon'
     steps:
       - id: version_vars
         env:
@@ -26,8 +25,7 @@ jobs:
       file_to_build: Dockerfile
       cache: false
       push_to_images: |
-        tootsuite/mastodon
-        ghcr.io/mastodon/mastodon
+        ghcr.io/${{ github.repository_owner }}/mastodon
       version_prerelease: ${{ needs.compute-suffix.outputs.prerelease }}
       labels: |
         org.opencontainers.image.description=Nightly build image used for testing purposes
@@ -46,8 +44,7 @@ jobs:
       file_to_build: streaming/Dockerfile
       cache: false
       push_to_images: |
-        tootsuite/mastodon-streaming
-        ghcr.io/mastodon/mastodon-streaming
+        ghcr.io/${{ github.repository_owner }}/mastodon-streaming
       version_prerelease: ${{ needs.compute-suffix.outputs.prerelease }}
       labels: |
         org.opencontainers.image.description=Nightly build image used for testing purposes

--- a/config/mastodon.yml
+++ b/config/mastodon.yml
@@ -6,10 +6,10 @@ shared:
   software_update_url: <%= ENV.fetch('UPDATE_CHECK_URL', 'https://api.joinmastodon.org/update-check')&.to_json %>
   source:
     base_url: <%= ENV.fetch('SOURCE_BASE_URL', nil)&.to_json %>
-    repository: <%= ENV.fetch('GITHUB_REPOSITORY', 'mastodon/mastodon') %>
+    repository: <%= ENV.fetch('GITHUB_REPOSITORY', 'altstoreio/mastodon') %>
     tag: <%= ENV.fetch('SOURCE_TAG', nil) %>
   version:
-    metadata: <%= ENV.fetch('MASTODON_VERSION_METADATA', nil)&.to_json %>
+    metadata: <%= ['altstore', ENV.fetch('MASTODON_VERSION_METADATA', nil)].compact_blank.join('.').to_json %>
     prerelease: <%= ENV.fetch('MASTODON_VERSION_PRERELEASE', nil)&.to_json %>
 test:
   experimental_features: <%= [ENV.fetch('EXPERIMENTAL_FEATURES', nil), 'testing_only'].compact.join(',') %>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
   web:
     # You can uncomment the following line if you want to not use the prebuilt image, for example if you have local code changes
     # build: .
-    image: ghcr.io/mastodon/mastodon:v4.4.3
+    image: ghcr.io/altstoreio/mastodon:v4.4.3
     restart: always
     env_file: .env.production
     command: bundle exec puma -C config/puma.rb
@@ -83,7 +83,7 @@ services:
     # build:
     #   dockerfile: ./streaming/Dockerfile
     #   context: .
-    image: ghcr.io/mastodon/mastodon-streaming:v4.4.3
+    image: ghcr.io/altstoreio/mastodon-streaming:v4.4.3
     restart: always
     env_file: .env.production
     command: node ./streaming/index.js
@@ -102,7 +102,7 @@ services:
   sidekiq:
     # You can uncomment the following line if you want to not use the prebuilt image, for example if you have local code changes
     # build: .
-    image: ghcr.io/mastodon/mastodon:v4.4.3
+    image: ghcr.io/altstoreio/mastodon:v4.4.3
     restart: always
     env_file: .env.production
     command: bundle exec sidekiq


### PR DESCRIPTION
The `docker-compose.yml` in particular are annoying because they will change with each version.

Needs to be backported to every relevant release branch.