### PR TITLE
Fix reply indicator displaying wrong avatar in rare cases

### DIFF
--- a/app/javascript/mastodon/features/compose/components/reply_indicator.jsx
+++ b/app/javascript/mastodon/features/compose/components/reply_indicator.jsx
@@ -25,7 +25,7 @@ export const ReplyIndicator = () => {
       <div className='reply-indicator__line' />
 
       <Link to={`/@${account.get('acct')}`} className='detailed-status__display-avatar'>
-        <Avatar account={account} size={46} />
+        <Avatar key={`avatar-${account.get('id')}`} account={account} size={46} />
       </Link>
 
       <div className='reply-indicator__main'>


### PR DESCRIPTION
When starting to write a reply to someone, then replacing it with a reply to someone else (without exiting reply mode) and the second person's avatar takes some time to load, the avatar for the first user would be displayed, leading to confusion.

This PR makes it so the DOM is not reused when changing who the user is replying to.