### PR TITLE
Avoid `return render...` in api/v1/apps/credentials

### DIFF
--- a/app/controllers/api/v1/apps/credentials_controller.rb
+++ b/app/controllers/api/v1/apps/credentials_controller.rb
@@ -1,9 +1,15 @@
 # frozen_string_literal: true
 
 class Api::V1::Apps::CredentialsController < Api::BaseController
-  def show
-    return doorkeeper_render_error unless valid_doorkeeper_token?
+  before_action :verify_doorkeeper_token
 
+  def show
     render json: doorkeeper_token.application, serializer: REST::ApplicationSerializer
+  end
+
+  private
+
+  def verify_doorkeeper_token
+    doorkeeper_render_error unless valid_doorkeeper_token?
   end
 end


### PR DESCRIPTION
Similar to https://github.com/mastodon/mastodon/pull/35585 and some other still-open PRs -- prefer the implicit render.

In this case, the doorkeeper helper method calls render.

