### PR TITLE
Redirect on success for standalone compose

### DIFF
--- a/app/javascript/mastodon/actions/compose.js
+++ b/app/javascript/mastodon/actions/compose.js
@@ -183,7 +183,7 @@ export function directCompose(account) {
   };
 }
 
-export function submitCompose() {
+export function submitCompose(successCallback) {
   return function (dispatch, getState) {
     const status   = getState().getIn(['compose', 'text'], '');
     const media    = getState().getIn(['compose', 'media_attachments']);
@@ -241,6 +241,9 @@ export function submitCompose() {
 
       dispatch(insertIntoTagHistory(response.data.tags, status));
       dispatch(submitComposeSuccess({ ...response.data }));
+      if (typeof successCallback === 'function') {
+        successCallback(response.data);
+      }
 
       // To make the app more responsive, immediately push the status
       // into the columns

--- a/app/javascript/mastodon/features/compose/components/compose_form.jsx
+++ b/app/javascript/mastodon/features/compose/components/compose_form.jsx
@@ -73,6 +73,7 @@ class ComposeForm extends ImmutablePureComponent {
     singleColumn: PropTypes.bool,
     lang: PropTypes.string,
     maxChars: PropTypes.number,
+    redirectOnSuccess: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -329,7 +330,7 @@ class ComposeForm extends ImmutablePureComponent {
                 >
                   {intl.formatMessage(
                     this.props.isEditing ?
-                      messages.saveChanges : 
+                      messages.saveChanges :
                       (this.props.isInReply ? messages.reply : messages.publish)
                   )}
                 </Button>

--- a/app/javascript/mastodon/features/compose/containers/compose_form_container.js
+++ b/app/javascript/mastodon/features/compose/containers/compose_form_container.js
@@ -34,7 +34,7 @@ const mapStateToProps = state => ({
   maxChars: state.getIn(['server', 'server', 'configuration', 'statuses', 'max_characters'], 500),
 });
 
-const mapDispatchToProps = (dispatch) => ({
+const mapDispatchToProps = (dispatch, props) => ({
 
   onChange (text) {
     dispatch(changeCompose(text));
@@ -47,7 +47,11 @@ const mapDispatchToProps = (dispatch) => ({
         modalProps: {},
       }));
     } else {
-      dispatch(submitCompose());
+      dispatch(submitCompose((status) => {
+        if (props.redirectOnSuccess) {
+          window.location.assign(status.url);
+        }
+      }));
     }
   },
 

--- a/app/javascript/mastodon/features/standalone/compose/index.jsx
+++ b/app/javascript/mastodon/features/standalone/compose/index.jsx
@@ -5,7 +5,7 @@ import ModalContainer from 'mastodon/features/ui/containers/modal_container';
 
 const Compose = () => (
   <>
-    <ComposeFormContainer autoFocus withoutNavigation />
+    <ComposeFormContainer autoFocus withoutNavigation redirectOnSuccess />
     <AlertsController />
     <ModalContainer />
     <LoadingBarContainer className='loading-bar' />

--- a/spec/system/share_entrypoint_spec.rb
+++ b/spec/system/share_entrypoint_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Share page', :js, :streaming do
     fill_in_form
 
     expect(page)
-      .to have_css('.notification-bar-message', text: frontend_translations('compose.published.body'))
+      .to have_current_path(%r{/@bob/[0-9]+})
   end
 
   def fill_in_form


### PR DESCRIPTION
Fixes #35322.

Right now, on the `/share` standalone composer page, with the status creation we show an alert in the corner with a link to open the newly created post, but otherwise reset the composer. The aforementioned bug was how the open button does not work.

As the standalone share page doesn't load any other routes in the main Mastodon app, the button was silently failing. And as we directly import the history as a const throughout the application, there isn't a clean way to tell it to do a direct page refresh instead of navigating to a non-existent route.

This PR bypasses that whole issue by just redirecting on status submission via an optional callback. I feel this makes more sense as the `/share` screen is designed for authoring a single status with prefilled text, so the standard behavior of resetting the composer is not correct.