### PR TITLE
Use consistent calling style for `TagManager#normalize_domain`

### DIFF
--- a/app/controllers/admin/domain_blocks_controller.rb
+++ b/app/controllers/admin/domain_blocks_controller.rb
@@ -54,7 +54,7 @@ module Admin
       end
 
       # Allow transparently upgrading a domain block
-      if existing_domain_block.present? && existing_domain_block.domain == TagManager.instance.normalize_domain(@domain_block.domain.strip)
+      if existing_domain_block.present? && existing_domain_block.domain == TagManager.instance.normalize_domain(@domain_block.domain)
         @domain_block = existing_domain_block
         @domain_block.assign_attributes(resource_params)
       end

--- a/app/controllers/admin/instances/moderation_notes_controller.rb
+++ b/app/controllers/admin/instances/moderation_notes_controller.rb
@@ -34,8 +34,11 @@ class Admin::Instances::ModerationNotesController < Admin::BaseController
   end
 
   def set_instance
-    domain = params[:instance_id]&.strip
-    @instance = Instance.find_or_initialize_by(domain: TagManager.instance.normalize_domain(domain))
+    @instance = Instance.find_or_initialize_by(domain: normalized_domain)
+  end
+
+  def normalized_domain
+    TagManager.instance.normalize_domain(params[:instance_id])
   end
 
   def set_instance_note

--- a/app/controllers/admin/instances_controller.rb
+++ b/app/controllers/admin/instances_controller.rb
@@ -55,8 +55,11 @@ module Admin
     private
 
     def set_instance
-      domain = params[:id]&.strip
-      @instance = Instance.find_or_initialize_by(domain: TagManager.instance.normalize_domain(domain))
+      @instance = Instance.find_or_initialize_by(domain: normalized_domain)
+    end
+
+    def normalized_domain
+      TagManager.instance.normalize_domain(params[:id])
     end
 
     def set_instances

--- a/app/controllers/api/v1/peers/search_controller.rb
+++ b/app/controllers/api/v1/peers/search_controller.rb
@@ -47,10 +47,6 @@ class Api::V1::Peers::SearchController < Api::BaseController
   end
 
   def normalized_domain
-    TagManager.instance.normalize_domain(query_value)
-  end
-
-  def query_value
-    params[:q].strip
+    TagManager.instance.normalize_domain(params[:q])
   end
 end

--- a/app/lib/tag_manager.rb
+++ b/app/lib/tag_manager.rb
@@ -17,9 +17,9 @@ class TagManager
   def normalize_domain(domain)
     return if domain.nil?
 
-    uri = Addressable::URI.new
-    uri.host = domain.strip.delete_suffix('/')
-    uri.normalized_host
+    Addressable::URI.new.tap do |uri|
+      uri.host = domain.strip.delete_suffix('/')
+    end.normalized_host
   end
 
   def local_url?(url)

--- a/app/models/concerns/domain_normalizable.rb
+++ b/app/models/concerns/domain_normalizable.rb
@@ -22,7 +22,7 @@ module DomainNormalizable
   private
 
   def normalize_domain
-    self.domain = TagManager.instance.normalize_domain(domain&.strip)
+    self.domain = TagManager.instance.normalize_domain(domain)
   rescue Addressable::URI::InvalidURIError
     errors.add(:domain, :invalid)
   end

--- a/app/services/report_service.rb
+++ b/app/services/report_service.rb
@@ -77,7 +77,7 @@ class ReportService < BaseService
   end
 
   def forward_to_domains
-    @forward_to_domains ||= (@options[:forward_to_domains] || [@target_account.domain]).filter_map { |domain| TagManager.instance.normalize_domain(domain&.strip) }.uniq
+    @forward_to_domains ||= (@options[:forward_to_domains] || [@target_account.domain]).filter_map { |domain| TagManager.instance.normalize_domain(domain) }.uniq
   end
 
   def reported_status_ids


### PR DESCRIPTION
While working on unrelated thing with the `DomainNormalizable` concern, I noticed a mix of calling styles for this method -- the majority of them just pass in whatever domain string they have, but some of them were calling `strip` first.

The main change here is to move the `strip` into the `normalize_domain` method so the calling sites can just pass whatever they have. The calling locations which were using safe nav for nils should all behave the same - the method handles nils the same way.

Possible followup here:

- I was looking at shifting the concern to actually use an AR `normalizes`, but the mix of error catching and validating and normalizing is all currently coupled, and might be hard to separate. TBD.
- Many of the classes which include the concern all have repeated logic on the "split a domain string into its parts and then build the 'variants' of the domain" logic ... may pull this into the concern as well to DRY that up