### PR TITLE
Update Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -54,6 +54,7 @@ sudo apt-get install \
   pkg-config \
   protobuf-compiler \
   zlib1g-dev \
+  libvips42t64 \
   -y
 
 # Install rvm
@@ -134,7 +135,7 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
-  config.vm.box = "ubuntu/focal64"
+  config.vm.box = "bento/ubuntu-24.04"
 
   config.vm.provider :virtualbox do |vb|
     vb.name = "mastodon"


### PR DESCRIPTION
Fixes #35731

We were still using Ubuntu 20.04 for the Vagrant file, which is not compatible with some changes we made in Mastodon 4.4.

Furthermore, we did not include libvips in the Vagrant container while it is now required by default.

Update from `ubuntu/focal64` (Canonical-provided Vagrant image for Ubuntu 20.04) to `bento/ubuntu-24.04` as Canonical has stopped providing Vagrant images for Ubuntu after 22.04.