### PR TITLE
First pass coverage addition for antispam class

### DIFF
--- a/app/lib/antispam.rb
+++ b/app/lib/antispam.rb
@@ -71,8 +71,16 @@ class Antispam
   end
 
   def report_if_needed!(account)
-    return if Report.unresolved.exists?(account: Account.representative, target_account: account)
+    return if system_reports.unresolved.exists?(target_account: account)
 
-    Report.create!(account: Account.representative, target_account: account, category: :spam, comment: 'Account automatically reported for posting a banned URL')
+    system_reports.create!(
+      category: :spam,
+      comment: 'Account automatically reported for posting a banned URL',
+      target_account: account
+    )
+  end
+
+  def system_reports
+    Account.representative.reports
   end
 end

--- a/spec/lib/antispam_spec.rb
+++ b/spec/lib/antispam_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Antispam do
+  describe '#local_preflight_check!' do
+    subject { described_class.new.local_preflight_check!(status) }
+
+    let(:status) { Fabricate :status }
+
+    context 'when there is no spammy text registered' do
+      it { is_expected.to be_nil }
+    end
+
+    context 'with spammy text' do
+      before { redis.sadd 'antispam:spammy_texts', 'https://banned.example' }
+
+      context 'when status matches' do
+        let(:status) { Fabricate :status, text: 'I use https://banned.example urls in my text' }
+
+        it 'raises error and reports' do
+          expect { subject }
+            .to raise_error(described_class::SilentlyDrop)
+            .and change(spam_reports, :count).by(1)
+        end
+
+        context 'when report already exists' do
+          before { Fabricate :report, account: Account.representative, target_account: status.account }
+
+          it 'raises error and does not report' do
+            expect { subject }
+              .to raise_error(described_class::SilentlyDrop)
+              .and not_change(spam_reports, :count)
+          end
+        end
+
+        def spam_reports
+          Account.representative.reports.where(target_account: status.account).spam
+        end
+      end
+
+      context 'when status does not match' do
+        it { is_expected.to be_nil }
+      end
+    end
+  end
+end


### PR DESCRIPTION
The coverage does not exhaustively hit every code path, but hits the few most obvious high level flows.

Minor refactor to use existing association in the class.