### PR TITLE
Disallow making private posts quotable

### DIFF
--- a/app/models/concerns/status/interaction_policy_concern.rb
+++ b/app/models/concerns/status/interaction_policy_concern.rb
@@ -10,6 +10,10 @@ module Status::InteractionPolicyConcern
     followed: (1 << 3),
   }.freeze
 
+  included do
+    before_validation :downgrade_quote_policy, if: -> { local? && !distributable? }
+  end
+
   def quote_policy_as_keys(kind)
     case kind
     when :automatic
@@ -51,5 +55,9 @@ module Status::InteractionPolicyConcern
     return :unknown if (automatic_policy | manual_policy).anybits?(QUOTE_APPROVAL_POLICY_FLAGS[:unknown])
 
     :denied
+  end
+
+  def downgrade_quote_policy
+    self.quote_approval_policy = 0
   end
 end


### PR DESCRIPTION
We have decided for UX purposes to disallow making private posts quotable, as doing otherwise could cause a lot of confusion.

This PR implements it by silently downgrading the quote policy to “nobody” when the post is private.

I have chosen silently downgrading rather than raising an error because it was easier, is less likely to cause breakage that a end-user could not do anything about, and we have some precedent with reblogs. However, this can admittedly be a bit surprising, and it could be cleaner to return an error in such a case.