### PR TITLE
Add coverage for signed-in-with-blocks scenario on followers/following

### DIFF
--- a/app/controllers/follower_accounts_controller.rb
+++ b/app/controllers/follower_accounts_controller.rb
@@ -36,13 +36,17 @@ class FollowerAccountsController < ApplicationController
   def follows
     return @follows if defined?(@follows)
 
-    scope = Follow.where(target_account: @account)
-    scope = scope.where.not(account_id: current_account.excluded_from_timeline_account_ids) if user_signed_in?
-    @follows = scope.recent.page(params[:page]).per(FOLLOW_PER_PAGE).preload(:account)
+    @follows = passive_relationships.recent.page(params[:page]).per(FOLLOW_PER_PAGE).preload(:account)
   end
 
   def page_requested?
     params[:page].present?
+  end
+
+  def passive_relationships
+    @account.passive_relationships.tap do |scope|
+      scope.merge! scope.where.not(account_id: current_account.excluded_from_timeline_account_ids) if user_signed_in?
+    end
   end
 
   def page_url(page)

--- a/app/controllers/following_accounts_controller.rb
+++ b/app/controllers/following_accounts_controller.rb
@@ -39,13 +39,17 @@ class FollowingAccountsController < ApplicationController
   def follows
     return @follows if defined?(@follows)
 
-    scope = Follow.where(account: @account)
-    scope = scope.where.not(target_account_id: current_account.excluded_from_timeline_account_ids) if user_signed_in?
-    @follows = scope.recent.page(params[:page]).per(FOLLOW_PER_PAGE).preload(:target_account)
+    @follows = active_relationships.recent.page(params[:page]).per(FOLLOW_PER_PAGE).preload(:target_account)
   end
 
   def page_requested?
     params[:page].present?
+  end
+
+  def active_relationships
+    @account.active_relationships.tap do |scope|
+      scope.merge! scope.where.not(target_account_id: current_account.excluded_from_timeline_account_ids) if user_signed_in?
+    end
   end
 
   def page_url(page)

--- a/spec/controllers/follower_accounts_controller_spec.rb
+++ b/spec/controllers/follower_accounts_controller_spec.rb
@@ -57,6 +57,26 @@ RSpec.describe FollowerAccountsController do
             )
         end
 
+        context 'when request is signed in and user blocks an account' do
+          let(:account) { Fabricate :account }
+
+          before do
+            Fabricate :block, account:, target_account: follower_bob
+            sign_in(account.user)
+          end
+
+          it 'returns followers without blocked' do
+            expect(response)
+              .to have_http_status(200)
+            expect(response.parsed_body)
+              .to include(
+                orderedItems: contain_exactly(
+                  include(follow_from_chris.account.username)
+                )
+              )
+          end
+        end
+
         context 'when account is permanently suspended' do
           before do
             alice.suspend!

--- a/spec/controllers/following_accounts_controller_spec.rb
+++ b/spec/controllers/following_accounts_controller_spec.rb
@@ -57,6 +57,26 @@ RSpec.describe FollowingAccountsController do
             )
         end
 
+        context 'when request is signed in and user blocks an account' do
+          let(:account) { Fabricate :account }
+
+          before do
+            Fabricate :block, account:, target_account: followee_bob
+            sign_in(account.user)
+          end
+
+          it 'returns followers without blocked' do
+            expect(response)
+              .to have_http_status(200)
+            expect(response.parsed_body)
+              .to include(
+                orderedItems: contain_exactly(
+                  include(follow_of_chris.target_account.username)
+                )
+              )
+          end
+        end
+
         context 'when account is permanently suspended' do
           before do
             alice.suspend!


### PR DESCRIPTION
These controller actions are basically mirrors of each other, just working on followers vs following.

They both have a feature where they will remove accounts from the query when the user is signed in and that signed in user is blocking accounts which would have returned in the results (in the followers/following collection of requested account).

That particular aspect did not have spec coverage, so add the coverage.

The refactor to both controllers preserves the behavior, and comes out of separate branch working on reducing `Metrics` scores in various spots.