### PR TITLE
Use `before_action` to protect hidden collections in following/followers lists

### DIFF
--- a/spec/controllers/follower_accounts_controller_spec.rb
+++ b/spec/controllers/follower_accounts_controller_spec.rb
@@ -57,6 +57,17 @@ RSpec.describe FollowerAccountsController do
             )
         end
 
+        context 'when account hides their network' do
+          before { alice.update(hide_collections: true) }
+
+          it 'returns forbidden response' do
+            expect(response)
+              .to have_http_status(403)
+            expect(response.parsed_body)
+              .to include(error: /forbidden/i)
+          end
+        end
+
         context 'when account is permanently suspended' do
           before do
             alice.suspend!

--- a/spec/controllers/following_accounts_controller_spec.rb
+++ b/spec/controllers/following_accounts_controller_spec.rb
@@ -57,6 +57,17 @@ RSpec.describe FollowingAccountsController do
             )
         end
 
+        context 'when account hides their network' do
+          before { alice.update(hide_collections: true) }
+
+          it 'returns forbidden response' do
+            expect(response)
+              .to have_http_status(403)
+            expect(response.parsed_body)
+              .to include(error: /forbidden/i)
+          end
+        end
+
         context 'when account is permanently suspended' do
           before do
             alice.suspend!


### PR DESCRIPTION
Pulled from same branch as https://github.com/mastodon/mastodon/pull/35782

The coverage here is to hit the scenario where a request for pagination is made against an account with `hide_collections` on.

The refactor is both to unite these controllers to do the same thing the same way, and because that `next` idiom is sort of odd? (comes from previous update to avoid double render - https://github.com/mastodon/mastodon/pull/18203/files#diff-683af9e68442a6a52e6895f0d11cb95c13267f5f495329c8bdb1d19080510f9bR26 - which did not add specs, but I believe the behavior is preserved here by shifting to a `before_action`).