### PR TITLE
Avoid name conflict with AR::Persistence methods in `FeaturedTag`

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -179,7 +179,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
     return if @tags.empty? || !status.distributable?
 
     @account.featured_tags.where(tag_id: @tags.pluck(:id)).find_each do |featured_tag|
-      featured_tag.increment(status.created_at)
+      featured_tag.increment_count(status.created_at)
     end
   end
 

--- a/app/models/featured_tag.rb
+++ b/app/models/featured_tag.rb
@@ -42,11 +42,11 @@ class FeaturedTag < ApplicationRecord
     attributes['name'] || tag.display_name
   end
 
-  def increment(timestamp)
+  def increment_count(timestamp)
     update(statuses_count: statuses_count + 1, last_status_at: timestamp)
   end
 
-  def decrement(deleted_status)
+  def decrement_count(deleted_status)
     if statuses_count <= 1
       update(statuses_count: 0, last_status_at: nil)
     elsif last_status_at.present? && last_status_at > deleted_status.created_at

--- a/app/services/activitypub/process_status_update_service.rb
+++ b/app/services/activitypub/process_status_update_service.rb
@@ -208,7 +208,7 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
 
     unless added_tags.empty?
       @account.featured_tags.where(tag_id: added_tags.pluck(:id)).find_each do |featured_tag|
-        featured_tag.increment(@status.created_at)
+        featured_tag.increment_count(@status.created_at)
       end
     end
 
@@ -216,7 +216,7 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
 
     unless removed_tags.empty?
       @account.featured_tags.where(tag_id: removed_tags.pluck(:id)).find_each do |featured_tag|
-        featured_tag.decrement(@status)
+        featured_tag.decrement_count(@status)
       end
     end
   end

--- a/app/services/process_hashtags_service.rb
+++ b/app/services/process_hashtags_service.rb
@@ -25,7 +25,7 @@ class ProcessHashtagsService < BaseService
 
     unless added_tags.empty?
       @account.featured_tags.where(tag_id: added_tags.map(&:id)).find_each do |featured_tag|
-        featured_tag.increment(@status.created_at)
+        featured_tag.increment_count(@status.created_at)
       end
     end
 
@@ -33,7 +33,7 @@ class ProcessHashtagsService < BaseService
 
     unless removed_tags.empty?
       @account.featured_tags.where(tag_id: removed_tags.map(&:id)).find_each do |featured_tag|
-        featured_tag.decrement(@status)
+        featured_tag.decrement_count(@status)
       end
     end
   end

--- a/app/services/remove_status_service.rb
+++ b/app/services/remove_status_service.rb
@@ -118,7 +118,7 @@ class RemoveStatusService < BaseService
 
   def remove_from_hashtags
     @account.featured_tags.where(tag_id: @status.tags.map(&:id)).find_each do |featured_tag|
-      featured_tag.decrement(@status)
+      featured_tag.decrement_count(@status)
     end
 
     return unless @status.public_visibility?

--- a/spec/models/featured_tag_spec.rb
+++ b/spec/models/featured_tag_spec.rb
@@ -114,18 +114,18 @@ RSpec.describe FeaturedTag do
     end
   end
 
-  describe '#increment' do
+  describe '#increment_count' do
     it 'increases the count and updates the last_status_at timestamp' do
       featured_tag = Fabricate :featured_tag
       timestamp = 5.days.ago
 
-      expect { featured_tag.increment(timestamp) }
+      expect { featured_tag.increment_count(timestamp) }
         .to change(featured_tag, :statuses_count).from(0).to(1)
         .and change(featured_tag, :last_status_at).from(nil).to(be_within(0.1).of(timestamp))
     end
   end
 
-  describe '#decrement' do
+  describe '#decrement_count' do
     let(:tag) { Fabricate(:tag, name: 'test') }
     let(:account) { Fabricate(:account) }
     let(:featured_tag) { Fabricate(:featured_tag, name: 'test', account: account) }
@@ -138,7 +138,7 @@ RSpec.describe FeaturedTag do
       end
 
       it 'decreases the count and updates the last_status_at timestamp' do
-        expect { featured_tag.decrement(status) }
+        expect { featured_tag.decrement_count(status) }
           .to change(featured_tag, :statuses_count).from(1).to(0)
           .and change(featured_tag, :last_status_at).to(nil)
       end
@@ -154,7 +154,7 @@ RSpec.describe FeaturedTag do
       end
 
       it 'decreases the count and updates the last_status_at timestamp' do
-        expect { featured_tag.decrement(previous_status) }
+        expect { featured_tag.decrement_count(previous_status) }
           .to change(featured_tag, :statuses_count).from(2).to(1)
           .and not_change(featured_tag, :last_status_at)
       end
@@ -170,7 +170,7 @@ RSpec.describe FeaturedTag do
       end
 
       it 'decreases the count and updates the last_status_at timestamp' do
-        expect { featured_tag.decrement(status) }
+        expect { featured_tag.decrement_count(status) }
           .to change(featured_tag, :statuses_count).from(2).to(1)
           .and change(featured_tag, :last_status_at)
       end

--- a/spec/serializers/rest/featured_tag_serializer_spec.rb
+++ b/spec/serializers/rest/featured_tag_serializer_spec.rb
@@ -13,9 +13,7 @@ RSpec.describe REST::FeaturedTagSerializer do
   let(:featured_tag) { Fabricate :featured_tag }
 
   context 'when last_status_at is populated' do
-    before do
-      featured_tag.increment(DateTime.new(2024, 11, 28, 16, 20, 0))
-    end
+    before { featured_tag.update last_status_at: DateTime.new(2024, 11, 28, 16, 20, 0) }
 
     it 'is serialized as yyyy-mm-dd' do
       expect(subject['last_status_at']).to eq('2024-11-28')


### PR DESCRIPTION
These methods are (accidentally, I suspect?) overriding the `increment`/`decrement` methods from activerecord.

Updated naming to match what other classes do (there's a general `increment_<something>` pattern) and avoid the collision.