### PR TITLE
Prefer `record_timestamps` over local time var in `Form::Import#save`

### DIFF
--- a/app/models/form/import.rb
+++ b/app/models/form/import.rb
@@ -67,9 +67,8 @@ class Form::Import
     return false unless valid?
 
     ApplicationRecord.transaction do
-      now = Time.now.utc
       @bulk_import = current_account.bulk_imports.create(type: type, overwrite: overwrite || false, state: :unconfirmed, original_filename: data.original_filename, likely_mismatched: likely_mismatched?)
-      nb_items = BulkImportRow.insert_all(parsed_rows.map { |row| { bulk_import_id: bulk_import.id, data: row, created_at: now, updated_at: now } }).length
+      nb_items = BulkImportRow.insert_all(parsed_rows.map { |row| { bulk_import_id: bulk_import.id, data: row } }, record_timestamps: true).length
       @bulk_import.update(total_items: nb_items)
     end
   end


### PR DESCRIPTION
Use the `record_timestamps` option to allow framework to set created/updated times.
