### PR TITLE
Simplify `Tag.search_for` method

### DIFF
--- a/app/models/admin/tag_filter.rb
+++ b/app/models/admin/tag_filter.rb
@@ -32,7 +32,7 @@ class Admin::TagFilter
     when :status
       status_scope(value)
     when :name
-      Tag.search_for(value.to_s.strip, params[:limit], params[:offset], exclude_unlistable: false)
+      Tag.search_for(value, params[:limit], params[:offset], exclude_unlistable: false)
     when :order
       order_scope(value)
     else

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -67,6 +67,8 @@ class Tag < ApplicationRecord
                         }
   scope :matches_name, ->(term) { where(arel_table[:name].lower.matches(arel_table.lower("#{sanitize_sql_like(Tag.normalize(term))}%"), nil, true)) } # Search with case-sensitive to use B-tree index
 
+  scope :by_name_length, -> { order(Arel.sql('LENGTH(name)').asc, name: :asc) }
+
   update_index('tags', :self)
 
   def to_param
@@ -122,16 +124,19 @@ class Tag < ApplicationRecord
     end
 
     def search_for(term, limit = 5, offset = 0, options = {})
-      stripped_term = term.strip
       options.reverse_merge!({ exclude_unlistable: true, exclude_unreviewed: false })
 
-      query = Tag.matches_name(stripped_term)
-      query = query.merge(Tag.listable) if options[:exclude_unlistable]
-      query = query.merge(matching_name(stripped_term).or(reviewed)) if options[:exclude_unreviewed]
+      search_query(term.to_s.strip, options)
+        .limit(limit)
+        .offset(offset)
+        .by_name_length
+    end
 
-      query.order(Arel.sql('LENGTH(name)').asc, name: :asc)
-           .limit(limit)
-           .offset(offset)
+    def search_query(term, options)
+      matches_name(term).tap do |query|
+        query.merge!(listable) if options[:exclude_unlistable]
+        query.merge!(reviewed) if options[:exclude_unreviewed]
+      end
     end
 
     def find_normalized(name)

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -280,6 +280,23 @@ RSpec.describe Tag do
       expect(results).to eq [tag]
     end
 
+    it 'finds tag records from padded term queries' do
+      tag = Fabricate(:tag, name: 'MATCH')
+      _miss_tag = Fabricate(:tag, name: 'miss')
+
+      results = described_class.search_for('  match  ')
+
+      expect(results)
+        .to contain_exactly(tag)
+    end
+
+    it 'handles nil query' do
+      results = described_class.search_for(nil)
+
+      expect(results)
+        .to be_empty
+    end
+
     it 'finds the exact matching tag as the first item' do
       similar_tag = Fabricate(:tag, name: 'matchlater', reviewed_at: Time.now.utc)
       tag = Fabricate(:tag, name: 'match', reviewed_at: Time.now.utc)
@@ -305,6 +322,17 @@ RSpec.describe Tag do
       results = described_class.search_for('match', 5, 0, exclude_unlistable: false)
 
       expect(results).to eq [tag, unlisted_tag]
+    end
+
+    it 'excludes non reviewed tags via option' do
+      tag = Fabricate(:tag, name: 'match', reviewed_at: 5.days.ago)
+      unreviewed_tag = Fabricate(:tag, name: 'matchreviewed', reviewed_at: nil)
+
+      results = described_class.search_for('match', 5, 0, exclude_unreviewed: true)
+
+      expect(results)
+        .to include(tag)
+        .and not_include(unreviewed_tag)
     end
   end
 end


### PR DESCRIPTION
From same branch as - https://github.com/mastodon/mastodon/pull/35797 - and also in prep for having `name` use normalizes api as well.

Related changes:

- Start to move the "normalizing" to the receiving side, so calling locations can just send in values
- Add coverage for some query/option scenarios not previously exercised
- We're in a class method, so call `matches_name` and `listable` directly
- Simplify the query merge/build portion
- Add scope for the order

The only small question mark and change note I have is -- I removed the `matching_name` call from the path where `exclude_unreviewed` is passed in. It was surprising to me that an option which seemingly would only impact whether to include unreviewed tags or not would also modify the matching query (this is subtle but: `matches_name` is a scope which is basically a private method for this search method - it calls `lower` on the column and also `lower` on the normalized value, and compares with `LIKE 'value%'` ... whereas `matching_name` is another class method that handles either single or array queries, also calls `lower` on both column and value, but does an `eq` or `in` query instead of the wildcard/LIKE).

I'm not sure about a scenario where adding that `matching_name` is meaningful now that it's an option. The idea was initially added as a requirement in - https://github.com/mastodon/mastodon/pull/11579/files#diff-175888239adc2b81ed2e4e82f0ee0663be0677f376e1aa1d9151baa69596e546R129-R132 - the logic there being to add an "either an exact match, or reviewed" to the existing "LIKE with wildcard match". Then when converted to a passable option in https://github.com/mastodon/mastodon/pull/11977/files#diff-175888239adc2b81ed2e4e82f0ee0663be0677f376e1aa1d9151baa69596e546R131 - it seems like it could have been removed there, but wasnt?

If I'm misunderstanding that bit and passing exclude_unreviewed as true SHOULD also constrict the search to an exact value match only, I can back out that part of the change and add coverage for that behaviour as well.
