### PR TITLE
Include `update` in the resources args for api/web/push_subscriptions route

### DIFF
--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -369,10 +369,6 @@ namespace :api, format: false do
   namespace :web do
     resource :settings, only: [:update]
     resources :embeds, only: [:show]
-    resources :push_subscriptions, only: [:create, :destroy] do
-      member do
-        put :update
-      end
-    end
+    resources :push_subscriptions, only: [:create, :destroy, :update]
   end
 end

--- a/spec/requests/api/web/push_subscriptions_spec.rb
+++ b/spec/requests/api/web/push_subscriptions_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe 'API Web Push Subscriptions' do
     end
   end
 
-  describe 'PUT /api/web/push_subscriptions' do
+  describe 'PUT /api/web/push_subscriptions/:id' do
     before { sign_in Fabricate :user }
 
     let(:subscription) { Fabricate :web_push_subscription }


### PR DESCRIPTION
This has been this way since the original PR - https://github.com/mastodon/mastodon/pull/3243 - but I can't find a good explanation for why it was done that way. There's some vaguely related discussion of `resource` -vs- `resources` in there, so may have been a case of copy/paste or lack of familiarity with what those generate by default?

Either way, it seems odd to declare `update` that way, and the before/after route generation yields same thing.

Spec typo fix while in there.