### PR TITLE
Composer Quote UI

### DIFF
--- a/app/javascript/mastodon/components/autosuggest_textarea.jsx
+++ b/app/javascript/mastodon/components/autosuggest_textarea.jsx
@@ -53,6 +53,7 @@ const AutosuggestTextarea = forwardRef(({
   onFocus,
   autoFocus = true,
   lang,
+  className,
 }, textareaRef) => {
 
   const [suggestionsHidden, setSuggestionsHidden] = useState(true);
@@ -192,7 +193,7 @@ const AutosuggestTextarea = forwardRef(({
   };
 
   return (
-    <div className='autosuggest-textarea'>
+    <div className={classNames('autosuggest-textarea', className)}>
       <Textarea
         ref={textareaRef}
         className='autosuggest-textarea__textarea'

--- a/app/javascript/mastodon/components/status.jsx
+++ b/app/javascript/mastodon/components/status.jsx
@@ -10,6 +10,7 @@ import ImmutablePureComponent from 'react-immutable-pure-component';
 
 import AlternateEmailIcon from '@/material-icons/400-24px/alternate_email.svg?react';
 import RepeatIcon from '@/material-icons/400-24px/repeat.svg?react';
+import CancelFillIcon from '@/material-icons/400-24px/cancel-fill.svg?react';
 import { Hotkeys } from 'mastodon/components/hotkeys';
 import { ContentWarning } from 'mastodon/components/content_warning';
 import { FilterWarning } from 'mastodon/components/filter_warning';
@@ -34,6 +35,8 @@ import StatusActionBar from './status_action_bar';
 import StatusContent from './status_content';
 import { StatusThreadLabel } from './status_thread_label';
 import { VisibilityIcon } from './visibility_icon';
+import { IconButton } from './icon_button';
+
 const domParser = new DOMParser();
 
 export const textForScreenReader = (intl, status, rebloggedByText = false) => {
@@ -75,6 +78,7 @@ const messages = defineMessages({
   private_short: { id: 'privacy.private.short', defaultMessage: 'Followers' },
   direct_short: { id: 'privacy.direct.short', defaultMessage: 'Specific people' },
   edited: { id: 'status.edited', defaultMessage: 'Edited {date}' },
+  quote_cancel: { id: 'status.quote.cancel', defaultMessage: 'Cancel quote' },
 });
 
 class Status extends ImmutablePureComponent {
@@ -126,6 +130,7 @@ class Status extends ImmutablePureComponent {
       inUse: PropTypes.bool,
       available: PropTypes.bool,
     }),
+    contextType: PropTypes.string,
     ...WithOptionalRouterPropTypes,
   };
 
@@ -359,6 +364,10 @@ class Status extends ImmutablePureComponent {
     this.setState(state => ({ ...state, showDespiteFilter: !state.showDespiteFilter }));
   };
 
+  handleQuoteCancel = () => {
+    this.props.onQuoteCancel?.();
+  }
+
   _properStatus () {
     const { status } = this.props;
 
@@ -573,6 +582,16 @@ class Status extends ImmutablePureComponent {
 
                 <DisplayName account={status.get('account')} />
               </Link>
+
+              {this.props.contextType === 'compose' && isQuotedPost &&  (
+                <IconButton
+                  onClick={this.handleQuoteCancel}
+                  className='status__quote-cancel'
+                  title={intl.formatMessage(messages.quote_cancel)}
+                  icon="cancel-fill"
+                  iconComponent={CancelFillIcon}
+                />
+              )}
             </div>
 
             {matchedFilters && <FilterWarning title={matchedFilters.join(', ')} expanded={this.state.showDespiteFilter} onClick={this.handleFilterToggle} />}

--- a/app/javascript/mastodon/containers/status_container.jsx
+++ b/app/javascript/mastodon/containers/status_container.jsx
@@ -44,6 +44,7 @@ import {
 import Status from '../components/status';
 import { deleteModal } from '../initial_state';
 import { makeGetStatus, makeGetPictureInPicture } from '../selectors';
+import { quoteComposeCancel } from '../actions/compose_typed';
 
 const makeMapStateToProps = () => {
   const getStatus = makeGetStatus();
@@ -108,6 +109,12 @@ const mapDispatchToProps = (dispatch, { contextType }) => ({
       dispatch(deleteStatus(status.get('id'), withRedraft));
     } else {
       dispatch(openModal({ modalType: 'CONFIRM_DELETE_STATUS', modalProps: { statusId: status.get('id'), withRedraft } }));
+    }
+  },
+
+  onQuoteCancel() {
+    if (contextType === 'compose') {
+      dispatch(quoteComposeCancel());
     }
   },
 

--- a/app/javascript/mastodon/features/compose/components/compose_form.jsx
+++ b/app/javascript/mastodon/features/compose/components/compose_form.jsx
@@ -31,6 +31,7 @@ import { PollForm } from "./poll_form";
 import { ReplyIndicator } from './reply_indicator';
 import { UploadForm } from './upload_form';
 import { Warning } from './warning';
+import { ComposeQuotedStatus } from './quoted_post';
 
 const allowedAroundShortCode = '><\u0085\u0020\u00a0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u202f\u205f\u3000\u2028\u2029\u0009\u000a\u000b\u000c\u000d';
 
@@ -304,10 +305,12 @@ class ComposeForm extends ImmutablePureComponent {
             onPaste={onPaste}
             autoFocus={autoFocus}
             lang={this.props.lang}
+            className='compose-form__input'
           />
 
           <UploadForm />
           <PollForm />
+          <ComposeQuotedStatus />
 
           <div className='compose-form__footer'>
             <div className='compose-form__actions'>

--- a/app/javascript/mastodon/features/compose/components/quoted_post.tsx
+++ b/app/javascript/mastodon/features/compose/components/quoted_post.tsx
@@ -1,0 +1,23 @@
+import type { FC } from 'react';
+
+import { Map } from 'immutable';
+
+import { QuotedStatus } from '@/mastodon/components/status_quoted';
+import { useAppSelector } from '@/mastodon/store';
+
+export const ComposeQuotedStatus: FC = () => {
+  const quotedStatusId = useAppSelector(
+    (state) => state.compose.get('quoted_status_id') as string | null,
+  );
+  if (!quotedStatusId) {
+    return null;
+  }
+  return (
+    <QuotedStatus
+      quote={Map<'state' | 'quoted_status', string>([
+        ['state', 'accepted'],
+        ['quoted_status', quotedStatusId],
+      ])}
+    />
+  );
+};

--- a/app/javascript/mastodon/features/compose/components/quoted_post.tsx
+++ b/app/javascript/mastodon/features/compose/components/quoted_post.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import type { FC } from 'react';
 
 import { Map } from 'immutable';
@@ -9,15 +10,18 @@ export const ComposeQuotedStatus: FC = () => {
   const quotedStatusId = useAppSelector(
     (state) => state.compose.get('quoted_status_id') as string | null,
   );
-  if (!quotedStatusId) {
+  const quote = useMemo(
+    () =>
+      quotedStatusId
+        ? Map<'state' | 'quoted_status', string>([
+            ['state', 'accepted'],
+            ['quoted_status', quotedStatusId],
+          ])
+        : null,
+    [quotedStatusId],
+  );
+  if (!quote) {
     return null;
   }
-  return (
-    <QuotedStatus
-      quote={Map<'state' | 'quoted_status', string>([
-        ['state', 'accepted'],
-        ['quoted_status', quotedStatusId],
-      ])}
-    />
-  );
+  return <QuotedStatus quote={quote} contextType='compose' />;
 };

--- a/app/javascript/mastodon/features/compose/containers/poll_button_container.js
+++ b/app/javascript/mastodon/features/compose/containers/poll_button_container.js
@@ -3,10 +3,16 @@ import { connect } from 'react-redux';
 import { addPoll, removePoll } from '../../../actions/compose';
 import PollButton from '../components/poll_button';
 
-const mapStateToProps = state => ({
-  disabled: state.getIn(['compose', 'is_uploading']) || (state.getIn(['compose', 'media_attachments']).size > 0),
-  active: state.getIn(['compose', 'poll']) !== null,
-});
+const mapStateToProps = state => {
+  const readyAttachmentsSize = state.compose.get('media_attachments').size ?? 0;
+  const hasAttachments = readyAttachmentsSize > 0 || !!state.compose.get('is_uploading');
+  const hasQuote = !!state.compose.get('quoted_status_id');
+
+  return ({
+    disabled: hasAttachments || hasQuote,
+    active: state.getIn(['compose', 'poll']) !== null,
+  });
+};
 
 const mapDispatchToProps = dispatch => ({
 

--- a/app/javascript/mastodon/features/compose/containers/upload_button_container.js
+++ b/app/javascript/mastodon/features/compose/containers/upload_button_container.js
@@ -11,9 +11,10 @@ const mapStateToProps = state => {
   const attachmentsSize = readyAttachmentsSize + pendingAttachmentsSize;
   const isOverLimit = attachmentsSize > state.getIn(['server', 'server', 'configuration', 'statuses', 'max_media_attachments'])-1;
   const hasVideoOrAudio = state.getIn(['compose', 'media_attachments']).some(m => ['video', 'audio'].includes(m.get('type')));
+  const hasQuote = !!state.compose.get('quoted_status_id');
 
   return {
-    disabled: isPoll || isUploading || isOverLimit || hasVideoOrAudio,
+    disabled: isPoll || isUploading || isOverLimit || hasVideoOrAudio || hasQuote,
     resetFileKey: state.getIn(['compose', 'resetFileKey']),
   };
 };

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -880,6 +880,7 @@
   "status.mute_conversation": "Mute conversation",
   "status.open": "Expand this post",
   "status.pin": "Pin on profile",
+  "status.quote.cancel": "Cancel quote",
   "status.quote_error.filtered": "Hidden due to one of your filters",
   "status.quote_error.not_available": "Post unavailable",
   "status.quote_error.pending_approval": "Post pending",

--- a/app/javascript/mastodon/reducers/compose.js
+++ b/app/javascript/mastodon/reducers/compose.js
@@ -331,7 +331,12 @@ export const composeReducer = (state = initialState, action) => {
     return state.set('is_changing_upload', false);
   } else if (quoteComposeByStatus.match(action)) {
     const status = action.payload;
-    if (status.getIn(['quote_approval', 'current_user']) === 'automatic') {
+    if (
+      status.getIn(['quote_approval', 'current_user']) === 'automatic' &&
+      state.get('media_attachments').size === 0 &&
+      !state.get('is_uploading') &&
+      !state.get('poll')
+    ) {
       return state
         .set('quoted_status_id', status.get('id'))
         .set('spoiler', status.get('sensitive'))

--- a/app/javascript/mastodon/reducers/compose.js
+++ b/app/javascript/mastodon/reducers/compose.js
@@ -332,7 +332,10 @@ export const composeReducer = (state = initialState, action) => {
   } else if (quoteComposeByStatus.match(action)) {
     const status = action.payload;
     if (status.getIn(['quote_approval', 'current_user']) === 'automatic') {
-      return state.set('quoted_status_id', status.get('id'));
+      return state
+        .set('quoted_status_id', status.get('id'))
+        .set('spoiler', status.get('sensitive'))
+        .set('spoiler_text', status.get('spoiler_text'));
     }
   } else if (quoteComposeCancel.match(action)) {
     return state.set('quoted_status_id', null);

--- a/app/javascript/mastodon/selectors/filters.ts
+++ b/app/javascript/mastodon/selectors/filters.ts
@@ -15,7 +15,7 @@ export const getFilters = createSelector(
     (_, { contextType }: { contextType: string }) => contextType,
   ],
   (filters, contextType) => {
-    if (!contextType) {
+    if (!contextType || contextType === 'compose') {
       return null;
     }
 

--- a/app/javascript/mastodon/store/typed_functions.ts
+++ b/app/javascript/mastodon/store/typed_functions.ts
@@ -129,7 +129,7 @@ export function createAppThunk<Arg = void, Returned = void, ExtraArg = unknown>(
     },
   }));
 
-  return Object.assign({}, action, actionCreator);
+  return Object.assign(actionCreator, action);
 }
 
 const createBaseAsyncThunk = rtkCreateAsyncThunk.withTypes<AppThunkConfig>();

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -672,11 +672,6 @@ body > [data-popper-placement] {
     }
   }
 
-  &__input > textarea {
-    overflow-y: auto;
-    max-height: 370px;
-  }
-
   .autosuggest-textarea__textarea,
   .spoiler-input__input {
     display: block;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -672,6 +672,11 @@ body > [data-popper-placement] {
     }
   }
 
+  &__input > textarea {
+    overflow-y: auto;
+    max-height: 370px;
+  }
+
   .autosuggest-textarea__textarea,
   .spoiler-input__input {
     display: block;
@@ -944,6 +949,21 @@ body > [data-popper-placement] {
         text-overflow: ellipsis;
         overflow: hidden;
       }
+    }
+  }
+
+  .status__quote {
+    --max-lines: 2;
+
+    margin-block-start: 0;
+    margin: 0 8px;
+    max-height: 200px;
+    overflow: hidden;
+
+    .status__content__text {
+      max-height: calc(20px * var(--max-lines));
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
   }
 }

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -955,7 +955,7 @@ body > [data-popper-placement] {
   .status__quote {
     margin-block-start: 0;
     margin: 0 8px;
-    max-height: 200px;
+    max-height: 220px;
     overflow: hidden;
 
     // Override .status__content .status__content__text.status__content__text--visible

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -953,17 +953,21 @@ body > [data-popper-placement] {
   }
 
   .status__quote {
-    --max-lines: 2;
-
     margin-block-start: 0;
     margin: 0 8px;
     max-height: 200px;
     overflow: hidden;
 
+    // Override .status__content .status__content__text.status__content__text--visible
+    .status__content__text.status__content__text {
+      display: -webkit-box;
+    }
+
     .status__content__text {
-      max-height: calc(20px * var(--max-lines));
+      -webkit-line-clamp: 4;
+      line-clamp: 4;
+      -webkit-box-orient: vertical;
       overflow: hidden;
-      text-overflow: ellipsis;
     }
   }
 }
@@ -1603,6 +1607,7 @@ body > [data-popper-placement] {
   align-items: center;
   gap: 10px;
   overflow: hidden;
+  flex-grow: 1;
 
   .display-name {
     bdi {
@@ -1617,6 +1622,11 @@ body > [data-popper-placement] {
       text-overflow: ellipsis;
     }
   }
+}
+
+.status__quote-cancel {
+  align-self: self-start;
+  order: 5;
 }
 
 .status__info {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -948,7 +948,6 @@ body > [data-popper-placement] {
   }
 
   .status__quote {
-    margin-block-start: 0;
     margin: 0 8px;
     max-height: 220px;
     overflow: hidden;


### PR DESCRIPTION
This adds quote posts to the composer UI.

| State | Screen |
| - | - |
| Text | <img width="602" height="860" alt="Screenshot 2025-08-18 at 14 41 23" src="https://github.com/user-attachments/assets/af6f5794-c9c5-43e8-871c-d74f0ceb3685" /> |
| Quote | <img width="612" height="706" alt="Screenshot 2025-08-18 at 14 41 40" src="https://github.com/user-attachments/assets/a1b21352-1717-4cfd-b1e3-cf64265f5a4e" /> |
| Video | <img width="606" height="868" alt="Screenshot 2025-08-18 at 14 41 55" src="https://github.com/user-attachments/assets/414c7694-fadd-4c60-bd65-5be26646c19d" /> |
| Photo | <img width="594" height="868" alt="Screenshot 2025-08-18 at 14 44 57" src="https://github.com/user-attachments/assets/45d1e97a-e07a-4971-a63e-ef3565038e4a" /> |
| Audio | <img width="598" height="866" alt="Screenshot 2025-08-18 at 14 43 13" src="https://github.com/user-attachments/assets/162576dd-8a5d-4cc2-bc0b-21943bd8f928" /> |
| Embed | <img width="604" height="870" alt="Screenshot 2025-08-18 at 14 43 27" src="https://github.com/user-attachments/assets/c91d931c-fb41-4774-b868-7185b28ba602" /> |
| CW + Photo | <img width="614" height="954" alt="Screenshot 2025-08-18 at 14 44 19" src="https://github.com/user-attachments/assets/ef4aa4d3-a5c8-46dc-9b1a-b8314120fd95" /> |
