### PR TITLE
Extract `api/v1/statuses#context` to separate controller

### DIFF
--- a/app/controllers/api/v1/statuses/contexts_controller.rb
+++ b/app/controllers/api/v1/statuses/contexts_controller.rb
@@ -20,8 +20,6 @@ class Api::V1::Statuses::ContextsController < Api::BaseController
   def show
     cache_if_unauthenticated!
 
-    ancestors_results   = @status.in_reply_to_id.nil? ? [] : @status.ancestors(ancestors_limit, current_account)
-    descendants_results = @status.descendants(descendants_limit, current_account, descendants_depth_limit)
     loaded_ancestors    = preload_collection(ancestors_results, Status)
     loaded_descendants  = preload_collection(descendants_results, Status)
 
@@ -46,6 +44,14 @@ class Api::V1::Statuses::ContextsController < Api::BaseController
   end
 
   private
+
+  def ancestors_results
+    @status.in_reply_to_id.nil? ? [] : @status.ancestors(ancestors_limit, current_account)
+  end
+
+  def descendants_results
+    @status.descendants(descendants_limit, current_account, descendants_depth_limit)
+  end
 
   def ancestors_limit
     current_account.present? ? CONTEXT_LIMIT : ANCESTORS_LIMIT

--- a/app/controllers/api/v1/statuses/contexts_controller.rb
+++ b/app/controllers/api/v1/statuses/contexts_controller.rb
@@ -21,7 +21,6 @@ class Api::V1::Statuses::ContextsController < Api::BaseController
     cache_if_unauthenticated!
 
     @context = Context.new(ancestors: loaded_ancestors, descendants: loaded_descendants)
-    statuses = [@status] + @context.ancestors + @context.descendants
 
     refresh_key = "context:#{@status.id}:refresh"
     async_refresh = AsyncRefresh.new(refresh_key)
@@ -41,6 +40,10 @@ class Api::V1::Statuses::ContextsController < Api::BaseController
   end
 
   private
+
+  def statuses
+    [@status] + @context.ancestors + @context.descendants
+  end
 
   def loaded_ancestors
     preload_collection(ancestors_results, Status)

--- a/app/controllers/api/v1/statuses/contexts_controller.rb
+++ b/app/controllers/api/v1/statuses/contexts_controller.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+class Api::V1::Statuses::ContextsController < Api::BaseController
+  include Authorization
+  include AsyncRefreshesConcern
+
+  before_action -> { authorize_if_got_token! :read, :'read:statuses' }
+  before_action :set_status
+
+  # This API was originally unlimited and pagination cannot be introduced
+  # without breaking backwards-compatibility. Use a relatively high number to
+  # cover most conversations as "unlimited", while enforcing a resource cap
+  CONTEXT_LIMIT = 4_096
+
+  # Avoid expensive computation and limit results for logged-out users
+  ANCESTORS_LIMIT         = 40
+  DESCENDANTS_LIMIT       = 60
+  DESCENDANTS_DEPTH_LIMIT = 20
+
+  def show
+    cache_if_unauthenticated!
+
+    ancestors_limit         = CONTEXT_LIMIT
+    descendants_limit       = CONTEXT_LIMIT
+    descendants_depth_limit = nil
+
+    if current_account.nil?
+      ancestors_limit         = ANCESTORS_LIMIT
+      descendants_limit       = DESCENDANTS_LIMIT
+      descendants_depth_limit = DESCENDANTS_DEPTH_LIMIT
+    end
+
+    ancestors_results   = @status.in_reply_to_id.nil? ? [] : @status.ancestors(ancestors_limit, current_account)
+    descendants_results = @status.descendants(descendants_limit, current_account, descendants_depth_limit)
+    loaded_ancestors    = preload_collection(ancestors_results, Status)
+    loaded_descendants  = preload_collection(descendants_results, Status)
+
+    @context = Context.new(ancestors: loaded_ancestors, descendants: loaded_descendants)
+    statuses = [@status] + @context.ancestors + @context.descendants
+
+    refresh_key = "context:#{@status.id}:refresh"
+    async_refresh = AsyncRefresh.new(refresh_key)
+
+    if async_refresh.running?
+      add_async_refresh_header(async_refresh)
+    elsif !current_account.nil? && @status.should_fetch_replies?
+      add_async_refresh_header(AsyncRefresh.create(refresh_key))
+
+      WorkerBatch.new.within do |batch|
+        batch.connect(refresh_key, threshold: 1.0)
+        ActivityPub::FetchAllRepliesWorker.perform_async(@status.id, { 'batch_id' => batch.id })
+      end
+    end
+
+    render json: @context, serializer: REST::ContextSerializer, relationships: StatusRelationshipsPresenter.new(statuses, current_user&.account_id)
+  end
+
+  private
+
+  def set_status
+    @status = Status.find(params[:status_id])
+    authorize @status, :show?
+  rescue Mastodon::NotPermittedError
+    not_found
+  end
+end

--- a/app/controllers/api/v1/statuses/contexts_controller.rb
+++ b/app/controllers/api/v1/statuses/contexts_controller.rb
@@ -24,10 +24,14 @@ class Api::V1::Statuses::ContextsController < Api::BaseController
 
     process_async_refresh!
 
-    render json: @context, serializer: REST::ContextSerializer, relationships: StatusRelationshipsPresenter.new(statuses, current_user&.account_id)
+    render json: @context, serializer: REST::ContextSerializer, relationships:
   end
 
   private
+
+  def relationships
+    StatusRelationshipsPresenter.new(statuses, current_user&.account_id)
+  end
 
   def process_async_refresh!
     async_refresh = AsyncRefresh.new(refresh_key)

--- a/app/controllers/api/v1/statuses/contexts_controller.rb
+++ b/app/controllers/api/v1/statuses/contexts_controller.rb
@@ -20,9 +20,6 @@ class Api::V1::Statuses::ContextsController < Api::BaseController
   def show
     cache_if_unauthenticated!
 
-    loaded_ancestors    = preload_collection(ancestors_results, Status)
-    loaded_descendants  = preload_collection(descendants_results, Status)
-
     @context = Context.new(ancestors: loaded_ancestors, descendants: loaded_descendants)
     statuses = [@status] + @context.ancestors + @context.descendants
 
@@ -44,6 +41,14 @@ class Api::V1::Statuses::ContextsController < Api::BaseController
   end
 
   private
+
+  def loaded_ancestors
+    preload_collection(ancestors_results, Status)
+  end
+
+  def loaded_descendants
+    preload_collection(descendants_results, Status)
+  end
 
   def ancestors_results
     @status.in_reply_to_id.nil? ? [] : @status.ancestors(ancestors_limit, current_account)

--- a/app/controllers/api/v1/statuses/contexts_controller.rb
+++ b/app/controllers/api/v1/statuses/contexts_controller.rb
@@ -20,16 +20,6 @@ class Api::V1::Statuses::ContextsController < Api::BaseController
   def show
     cache_if_unauthenticated!
 
-    ancestors_limit         = CONTEXT_LIMIT
-    descendants_limit       = CONTEXT_LIMIT
-    descendants_depth_limit = nil
-
-    if current_account.nil?
-      ancestors_limit         = ANCESTORS_LIMIT
-      descendants_limit       = DESCENDANTS_LIMIT
-      descendants_depth_limit = DESCENDANTS_DEPTH_LIMIT
-    end
-
     ancestors_results   = @status.in_reply_to_id.nil? ? [] : @status.ancestors(ancestors_limit, current_account)
     descendants_results = @status.descendants(descendants_limit, current_account, descendants_depth_limit)
     loaded_ancestors    = preload_collection(ancestors_results, Status)
@@ -56,6 +46,18 @@ class Api::V1::Statuses::ContextsController < Api::BaseController
   end
 
   private
+
+  def ancestors_limit
+    current_account.present? ? CONTEXT_LIMIT : ANCESTORS_LIMIT
+  end
+
+  def descendants_limit
+    current_account.present? ? CONTEXT_LIMIT : DESCENDANTS_LIMIT
+  end
+
+  def descendants_depth_limit
+    current_account.present? ? nil : DESCENDANTS_DEPTH_LIMIT
+  end
 
   def set_status
     @status = Status.find(params[:status_id])

--- a/app/controllers/api/v1/statuses/contexts_controller.rb
+++ b/app/controllers/api/v1/statuses/contexts_controller.rb
@@ -13,9 +13,9 @@ class Api::V1::Statuses::ContextsController < Api::BaseController
   CONTEXT_LIMIT = 4_096
 
   # Avoid expensive computation and limit results for logged-out users
-  ANCESTORS_LIMIT         = 40
-  DESCENDANTS_LIMIT       = 60
+  ANCESTORS_LIMIT = 40
   DESCENDANTS_DEPTH_LIMIT = 20
+  DESCENDANTS_LIMIT = 60
 
   def show
     cache_if_unauthenticated!

--- a/app/controllers/api/v1/statuses_controller.rb
+++ b/app/controllers/api/v1/statuses_controller.rb
@@ -2,7 +2,6 @@
 
 class Api::V1::StatusesController < Api::BaseController
   include Authorization
-  include AsyncRefreshesConcern
   include Api::InteractionPoliciesConcern
 
   before_action -> { authorize_if_got_token! :read, :'read:statuses' }, except: [:create, :update, :destroy]

--- a/app/controllers/api/v1/statuses_controller.rb
+++ b/app/controllers/api/v1/statuses_controller.rb
@@ -7,26 +7,15 @@ class Api::V1::StatusesController < Api::BaseController
 
   before_action -> { authorize_if_got_token! :read, :'read:statuses' }, except: [:create, :update, :destroy]
   before_action -> { doorkeeper_authorize! :write, :'write:statuses' }, only:   [:create, :update, :destroy]
-  before_action :require_user!, except:      [:index, :show, :context]
+  before_action :require_user!, except:      [:index, :show]
   before_action :set_statuses, only:         [:index]
-  before_action :set_status, only:           [:show, :context]
+  before_action :set_status, only:           [:show]
   before_action :set_thread, only:           [:create]
   before_action :set_quoted_status, only:    [:create]
   before_action :check_statuses_limit, only: [:index]
 
   override_rate_limit_headers :create, family: :statuses
   override_rate_limit_headers :update, family: :statuses
-
-  # This API was originally unlimited, pagination cannot be introduced without
-  # breaking backwards-compatibility. Arbitrarily high number to cover most
-  # conversations as quasi-unlimited, it would be too much work to render more
-  # than this anyway
-  CONTEXT_LIMIT = 4_096
-
-  # This remains expensive and we don't want to show everything to logged-out users
-  ANCESTORS_LIMIT         = 40
-  DESCENDANTS_LIMIT       = 60
-  DESCENDANTS_DEPTH_LIMIT = 20
 
   def index
     @statuses = preload_collection(@statuses, Status)
@@ -37,44 +26,6 @@ class Api::V1::StatusesController < Api::BaseController
     cache_if_unauthenticated!
     @status = preload_collection([@status], Status).first
     render json: @status, serializer: REST::StatusSerializer
-  end
-
-  def context
-    cache_if_unauthenticated!
-
-    ancestors_limit         = CONTEXT_LIMIT
-    descendants_limit       = CONTEXT_LIMIT
-    descendants_depth_limit = nil
-
-    if current_account.nil?
-      ancestors_limit         = ANCESTORS_LIMIT
-      descendants_limit       = DESCENDANTS_LIMIT
-      descendants_depth_limit = DESCENDANTS_DEPTH_LIMIT
-    end
-
-    ancestors_results   = @status.in_reply_to_id.nil? ? [] : @status.ancestors(ancestors_limit, current_account)
-    descendants_results = @status.descendants(descendants_limit, current_account, descendants_depth_limit)
-    loaded_ancestors    = preload_collection(ancestors_results, Status)
-    loaded_descendants  = preload_collection(descendants_results, Status)
-
-    @context = Context.new(ancestors: loaded_ancestors, descendants: loaded_descendants)
-    statuses = [@status] + @context.ancestors + @context.descendants
-
-    refresh_key = "context:#{@status.id}:refresh"
-    async_refresh = AsyncRefresh.new(refresh_key)
-
-    if async_refresh.running?
-      add_async_refresh_header(async_refresh)
-    elsif !current_account.nil? && @status.should_fetch_replies?
-      add_async_refresh_header(AsyncRefresh.create(refresh_key))
-
-      WorkerBatch.new.within do |batch|
-        batch.connect(refresh_key, threshold: 1.0)
-        ActivityPub::FetchAllRepliesWorker.perform_async(@status.id, { 'batch_id' => batch.id })
-      end
-    end
-
-    render json: @context, serializer: REST::ContextSerializer, relationships: StatusRelationshipsPresenter.new(statuses, current_user&.account_id)
   end
 
   def create

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -16,6 +16,7 @@ namespace :api, format: false do
         resources :reblogged_by, controller: :reblogged_by_accounts, only: :index
         resources :favourited_by, controller: :favourited_by_accounts, only: :index
         resource :reblog, only: :create
+        resource :context, only: :show
         post :unreblog, to: 'reblogs#destroy'
 
         resources :quotes, only: :index do
@@ -42,10 +43,6 @@ namespace :api, format: false do
         resource :interaction_policy, only: :update
 
         post :translate, to: 'translations#create'
-      end
-
-      member do
-        get :context
       end
     end
 

--- a/spec/requests/api/v1/statuses/contexts_spec.rb
+++ b/spec/requests/api/v1/statuses/contexts_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe 'API V1 Statuses Contexts' do
           expect(response.content_type)
             .to start_with('application/json')
           expect(response.parsed_body)
-            .to include(ancestors: be_an(Array)).and include(descendants: be_an(Array))
+            .to include(ancestors: be_an(Array).and(be_empty))
+            .and include(descendants: be_an(Array).and(be_present))
         end
       end
 
@@ -42,7 +43,8 @@ RSpec.describe 'API V1 Statuses Contexts' do
           expect(response.content_type)
             .to start_with('application/json')
           expect(response.parsed_body)
-            .to include(ancestors: be_an(Array)).and include(descendants: be_an(Array))
+            .to include(ancestors: be_an(Array).and(be_present))
+            .and include(descendants: be_an(Array).and(be_present))
         end
       end
     end
@@ -61,7 +63,8 @@ RSpec.describe 'API V1 Statuses Contexts' do
           expect(response.content_type)
             .to start_with('application/json')
           expect(response.parsed_body)
-            .to include(ancestors: be_an(Array)).and include(descendants: be_an(Array))
+            .to include(ancestors: be_an(Array).and(be_empty))
+            .and include(descendants: be_an(Array).and(be_present))
         end
       end
 
@@ -78,7 +81,8 @@ RSpec.describe 'API V1 Statuses Contexts' do
           expect(response.content_type)
             .to start_with('application/json')
           expect(response.parsed_body)
-            .to include(ancestors: be_an(Array)).and include(descendants: be_an(Array))
+            .to include(ancestors: be_an(Array).and(be_present))
+            .and include(descendants: be_an(Array).and(be_present))
         end
       end
     end

--- a/spec/requests/api/v1/statuses/contexts_spec.rb
+++ b/spec/requests/api/v1/statuses/contexts_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe 'API V1 Statuses Contexts' do
             .to have_http_status(200)
           expect(response.content_type)
             .to start_with('application/json')
+          expect(response.parsed_body)
+            .to include(ancestors: be_an(Array)).and include(descendants: be_an(Array))
         end
       end
 
@@ -39,6 +41,8 @@ RSpec.describe 'API V1 Statuses Contexts' do
             .to have_http_status(200)
           expect(response.content_type)
             .to start_with('application/json')
+          expect(response.parsed_body)
+            .to include(ancestors: be_an(Array)).and include(descendants: be_an(Array))
         end
       end
     end
@@ -56,6 +60,8 @@ RSpec.describe 'API V1 Statuses Contexts' do
             .to have_http_status(200)
           expect(response.content_type)
             .to start_with('application/json')
+          expect(response.parsed_body)
+            .to include(ancestors: be_an(Array)).and include(descendants: be_an(Array))
         end
       end
 
@@ -71,6 +77,8 @@ RSpec.describe 'API V1 Statuses Contexts' do
             .to have_http_status(200)
           expect(response.content_type)
             .to start_with('application/json')
+          expect(response.parsed_body)
+            .to include(ancestors: be_an(Array)).and include(descendants: be_an(Array))
         end
       end
     end

--- a/spec/requests/api/v1/statuses/contexts_spec.rb
+++ b/spec/requests/api/v1/statuses/contexts_spec.rb
@@ -3,39 +3,66 @@
 require 'rails_helper'
 
 RSpec.describe 'API V1 Statuses Contexts' do
-  context 'with an oauth token' do
-    let(:user) { Fabricate(:user) }
-    let(:client_app) { Fabricate(:application, name: 'Test app', website: 'http://testapp.com') }
-    let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, application: client_app, scopes: scopes) }
-    let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
+  describe 'GET /api/v1/statuses/:status_id/context' do
+    context 'with an oauth token' do
+      let(:user) { Fabricate(:user) }
+      let(:client_app) { Fabricate(:application, name: 'Test app', website: 'http://testapp.com') }
+      let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, application: client_app, scopes: scopes) }
+      let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
 
-    describe 'GET /api/v1/statuses/:status_id/context' do
       let(:scopes) { 'read:statuses' }
-      let(:status) { Fabricate(:status, account: user.account) }
 
-      before do
-        Fabricate(:status, account: user.account, thread: status)
+      context 'with a public status' do
+        let(:status) { Fabricate(:status, account: user.account) }
+
+        before { Fabricate(:status, account: user.account, thread: status) }
+
+        it 'returns http success' do
+          get "/api/v1/statuses/#{status.id}/context", headers: headers
+
+          expect(response)
+            .to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
+        end
       end
 
-      it 'returns http success' do
-        get "/api/v1/statuses/#{status.id}/context", headers: headers
+      context 'with a public status that is a reply' do
+        let(:status) { Fabricate(:status, account: user.account, thread: Fabricate(:status)) }
 
-        expect(response)
-          .to have_http_status(200)
-        expect(response.content_type)
-          .to start_with('application/json')
+        before { Fabricate(:status, account: user.account, thread: status) }
+
+        it 'returns http success' do
+          get "/api/v1/statuses/#{status.id}/context", headers: headers
+
+          expect(response)
+            .to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
+        end
       end
     end
-  end
 
-  context 'without an oauth token' do
-    context 'with a public status' do
-      let(:status) { Fabricate(:status, visibility: :public) }
+    context 'without an oauth token' do
+      context 'with a public status' do
+        let(:status) { Fabricate(:status, visibility: :public) }
 
-      describe 'GET /api/v1/statuses/:status_id/context' do
-        before do
-          Fabricate(:status, thread: status)
+        before { Fabricate(:status, thread: status) }
+
+        it 'returns http success' do
+          get "/api/v1/statuses/#{status.id}/context"
+
+          expect(response)
+            .to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
         end
+      end
+
+      context 'with a public status that is a reply' do
+        let(:status) { Fabricate(:status, visibility: :public, thread: Fabricate(:status)) }
+
+        before { Fabricate(:status, thread: status) }
 
         it 'returns http success' do
           get "/api/v1/statuses/#{status.id}/context"

--- a/spec/requests/api/v1/statuses/contexts_spec.rb
+++ b/spec/requests/api/v1/statuses/contexts_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'API V1 Statuses Contexts' do
+  context 'with an oauth token' do
+    let(:user) { Fabricate(:user) }
+    let(:client_app) { Fabricate(:application, name: 'Test app', website: 'http://testapp.com') }
+    let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, application: client_app, scopes: scopes) }
+    let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
+
+    describe 'GET /api/v1/statuses/:status_id/context' do
+      let(:scopes) { 'read:statuses' }
+      let(:status) { Fabricate(:status, account: user.account) }
+
+      before do
+        Fabricate(:status, account: user.account, thread: status)
+      end
+
+      it 'returns http success' do
+        get "/api/v1/statuses/#{status.id}/context", headers: headers
+
+        expect(response)
+          .to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
+      end
+    end
+  end
+
+  context 'without an oauth token' do
+    context 'with a public status' do
+      let(:status) { Fabricate(:status, visibility: :public) }
+
+      describe 'GET /api/v1/statuses/:status_id/context' do
+        before do
+          Fabricate(:status, thread: status)
+        end
+
+        it 'returns http success' do
+          get "/api/v1/statuses/#{status.id}/context"
+
+          expect(response)
+            .to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/statuses_spec.rb
+++ b/spec/requests/api/v1/statuses_spec.rb
@@ -25,6 +25,19 @@ RSpec.describe '/api/v1/statuses' do
           hash_including(id: other_status.id.to_s)
         )
       end
+
+      context 'with too many IDs' do
+        before { stub_const 'Api::BaseController::DEFAULT_STATUSES_LIMIT', 2 }
+
+        it 'returns error response' do
+          get '/api/v1/statuses', headers: headers, params: { id: [123, 456, 789] }
+
+          expect(response)
+            .to have_http_status(422)
+          expect(response.content_type)
+            .to start_with('application/json')
+        end
+      end
     end
 
     describe 'GET /api/v1/statuses/:id' do

--- a/spec/requests/api/v1/statuses_spec.rb
+++ b/spec/requests/api/v1/statuses_spec.rb
@@ -119,23 +119,6 @@ RSpec.describe '/api/v1/statuses' do
       end
     end
 
-    describe 'GET /api/v1/statuses/:id/context' do
-      let(:scopes) { 'read:statuses' }
-      let(:status) { Fabricate(:status, account: user.account) }
-
-      before do
-        Fabricate(:status, account: user.account, thread: status)
-      end
-
-      it 'returns http success' do
-        get "/api/v1/statuses/#{status.id}/context", headers: headers
-
-        expect(response).to have_http_status(200)
-        expect(response.content_type)
-          .to start_with('application/json')
-      end
-    end
-
     describe 'POST /api/v1/statuses' do
       subject do
         post '/api/v1/statuses', headers: headers, params: params
@@ -467,20 +450,6 @@ RSpec.describe '/api/v1/statuses' do
       describe 'GET /api/v1/statuses/:id' do
         it 'returns http success' do
           get "/api/v1/statuses/#{status.id}"
-
-          expect(response).to have_http_status(200)
-          expect(response.content_type)
-            .to start_with('application/json')
-        end
-      end
-
-      describe 'GET /api/v1/statuses/:id/context' do
-        before do
-          Fabricate(:status, thread: status)
-        end
-
-        it 'returns http success' do
-          get "/api/v1/statuses/#{status.id}/context"
 
           expect(response).to have_http_status(200)
           expect(response.content_type)


### PR DESCRIPTION
Motivations here:

- The `api/v1/statuses` controller is the largest controller as measured by LOC
- This `context` method/action in particular contributes to the metrics cops violations
- The "context" portion is the only action using the async refresh stuff
- The "context" portion does NOT use the interaction policies concern that the other actions do
- A good portion of the constants and comments noise there is narrowly used for the context action and nothing else
- The "context" actually is somewhat of a first class object, with it's own model/serializer/etc, and not merely a minor aspect of a status

So with that as background, the change here is just to pull this action out to it's own isolated controller. The path to access should not change, so this is transparent to consumers. Notes:

- I attempted to keep the initial move and the subsequent refactors chopped up in small pieces in the commit history - might be easier to parse the refactor one piece at a time that way?
- There might be further improvement to be had on the async refresh portion, but I know that is both a) in alpha/experiment mode, b) maybe still in flux - so I did not change that as much as I could have
- Previous specs were pretty barebones ... updated this to be a little more exhaustive (but still room for more, esp re: the async/batch/etc stuff)
- Added one scenario to flesh out coverage in original controller while doing this other stuff