### PR TITLE
Avoid method that makes tokens while checking for tokens

### DIFF
--- a/spec/system/settings/applications_spec.rb
+++ b/spec/system/settings/applications_spec.rb
@@ -130,12 +130,17 @@ RSpec.describe 'Settings applications page' do
 
   describe 'Regenerating an app token' do
     it 'updates the app token' do
-      visit settings_application_path(application)
+      expect { visit settings_application_path(application) }
+        .to change(user_application_token, :first).from(be_nil).to(be_present)
 
       expect { regenerate_token }
-        .to(change { user.token_for_app(application) })
+        .to(change { user_application_token.first.token })
       expect(page)
         .to have_content(I18n.t('applications.token_regenerated'))
+    end
+
+    def user_application_token
+      Doorkeeper::AccessToken.where(application:).where(resource_owner_id: user)
     end
 
     def regenerate_token


### PR DESCRIPTION
In this spec we are calling `token_for_app`, which will make an application token if none exists. It seems a little odd to use that method to check for the results of something which is changing the token.

The flow here is that the show view will create a token if none exists when rendered, and then "regenerate" doesn't actually regenerate, it just destroys, and relies on the next request to make a new one.

For now, just improve the spec to not flow through that possibly-creating-tokens method. Possible future improvement: rename and/or change the "regenerate" method.