### PR TITLE
Generate `update` notification for quoting users when a quoted post is edited

### DIFF
--- a/app/services/fan_out_on_write_service.rb
+++ b/app/services/fan_out_on_write_service.rb
@@ -99,6 +99,12 @@ class FanOutOnWriteService < BaseService
         [account.id, @status.id, 'Status', 'update']
       end
     end
+
+    @status.quotes.accepted.find_in_batches do |quotes|
+      LocalNotificationWorker.push_bulk(quotes) do |quote|
+        [quote.account_id, quote.status_id, 'Status', 'update']
+      end
+    end
   end
 
   def deliver_to_all_followers!


### PR DESCRIPTION
This re-uses the existing `update` notification type, and is a simpler alternative to #35820.

However, it does not currently enable the notified user to easily view and edit their relevant quote posts.