### PR TITLE
Move language and visibility buttons above CW field

### DIFF
--- a/app/javascript/mastodon/features/compose/components/compose_form.jsx
+++ b/app/javascript/mastodon/features/compose/components/compose_form.jsx
@@ -259,6 +259,11 @@ class ComposeForm extends ImmutablePureComponent {
         <div className={classNames('compose-form__highlightable', { active: highlighted })} ref={this.setRef}>
           <EditIndicator />
 
+          <div className='compose-form__dropdowns'>
+            <PrivacyDropdownContainer disabled={this.props.isEditing} />
+            <LanguageDropdown />
+          </div>
+
           {this.props.spoiler && (
             <div className='spoiler-input'>
               <div className='spoiler-input__border' />
@@ -284,11 +289,6 @@ class ComposeForm extends ImmutablePureComponent {
               <div className='spoiler-input__border' />
             </div>
           )}
-
-          <div className='compose-form__dropdowns'>
-            <PrivacyDropdownContainer disabled={this.props.isEditing} />
-            <LanguageDropdown />
-          </div>
 
           <AutosuggestTextarea
             ref={this.textareaRef}

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -656,19 +656,12 @@ body > [data-popper-placement] {
       background: url('@/images/warning-stripes.svg') repeat-y;
       width: 5px;
       flex: 0 0 auto;
-
-      &:first-child {
-        border-start-start-radius: 4px;
-      }
-
-      &:last-child {
-        border-start-end-radius: 4px;
-      }
     }
 
     .autosuggest-input {
       flex: 1 1 auto;
-      border-bottom: 1px solid var(--background-border-color);
+      border: 1px solid var(--background-border-color);
+      border-width: 1px 0;
     }
   }
 


### PR DESCRIPTION
Moves the buttons from below to above the CW field:

<img width="608" height="522" alt="Screenshot 2025-08-19 at 17 13 52" src="https://github.com/user-attachments/assets/9bced641-0835-4441-aead-817179e4ff64" />
