### PR TITLE
Rely on `pluck` for the SELECT in `RuleTranslation.languages`

### DIFF
--- a/app/models/rule_translation.rb
+++ b/app/models/rule_translation.rb
@@ -22,6 +22,6 @@ class RuleTranslation < ApplicationRecord
   scope :by_language_length, -> { order(Arel.sql('LENGTH(LANGUAGE)').desc) }
 
   def self.languages
-    RuleTranslation.joins(:rule).merge(Rule.kept).select(:language).distinct.pluck(:language).sort
+    joins(:rule).merge(Rule.kept).distinct.pluck(:language).sort
   end
 end

--- a/spec/models/rule_translation_spec.rb
+++ b/spec/models/rule_translation_spec.rb
@@ -52,4 +52,22 @@ RSpec.describe RuleTranslation do
       end
     end
   end
+
+  describe '.languages' do
+    let(:discarded_rule) { Fabricate :rule, deleted_at: 5.days.ago }
+    let(:kept_rule) { Fabricate :rule }
+
+    before do
+      Fabricate :rule_translation, rule: discarded_rule, language: 'en'
+      Fabricate :rule_translation, rule: kept_rule, language: 'es'
+      Fabricate :rule_translation, language: 'fr'
+      Fabricate :rule_translation, language: 'es'
+    end
+
+    it 'returns ordered distinct languages connected to non-discarded rules' do
+      expect(described_class.languages)
+        .to be_an(Array)
+        .and eq(%w(es fr))
+    end
+  end
 end


### PR DESCRIPTION
Since it's applied to the query, the `pluck` contributes the `SELECT` to the underlying query generation. Added some coverage missed during original review.