### PR TITLE
Add `quotes_count` to statuses stats

### DIFF
--- a/app/javascript/mastodon/api_types/statuses.ts
+++ b/app/javascript/mastodon/api_types/statuses.ts
@@ -96,6 +96,7 @@ export interface ApiStatusJSON {
   replies_count: number;
   reblogs_count: number;
   favorites_count: number;
+  quotes_count: number;
   edited_at?: string;
 
   favorited?: boolean;

--- a/app/javascript/mastodon/components/status/reblog_button.tsx
+++ b/app/javascript/mastodon/components/status/reblog_button.tsx
@@ -160,7 +160,12 @@ export const StatusReblogButton: FC<ReblogButtonProps> = ({
         )}
         icon='retweet'
         iconComponent={iconComponent}
-        counter={counters ? (status.get('reblogs_count') as number) : undefined}
+        counter={
+          counters
+            ? (status.get('reblogs_count') as number) +
+              (status.get('quotes_count') as number)
+            : undefined
+        }
         active={isReblogged}
       />
     </Dropdown>
@@ -283,7 +288,12 @@ export const LegacyReblogButton: FC<ReblogButtonProps> = ({
       icon='retweet'
       iconComponent={iconComponent}
       onClick={!disabled ? handleClick : undefined}
-      counter={counters ? (status.get('reblogs_count') as number) : undefined}
+      counter={
+        counters
+          ? (status.get('reblogs_count') as number) +
+            (status.get('quotes_count') as number)
+          : undefined
+      }
     />
   );
 };

--- a/app/javascript/mastodon/features/picture_in_picture/components/footer.tsx
+++ b/app/javascript/mastodon/features/picture_in_picture/components/footer.tsx
@@ -233,7 +233,10 @@ export const Footer: React.FC<{
         icon='retweet'
         iconComponent={reblogIconComponent}
         onClick={handleReblogClick}
-        counter={status.get('reblogs_count') as number}
+        counter={
+          (status.get('reblogs_count') as number) +
+          (status.get('quotes_count') as number)
+        }
       />
 
       <IconButton

--- a/app/javascript/mastodon/features/status/components/detailed_status.tsx
+++ b/app/javascript/mastodon/features/status/components/detailed_status.tsx
@@ -127,6 +127,7 @@ export const DetailedStatus: React.FC<{
   let media;
   let applicationLink;
   let reblogLink;
+  let quotesLink;
   let attachmentAspectRatio;
 
   if (properStatus.get('media_attachments').getIn([0, 'type']) === 'video') {
@@ -279,6 +280,23 @@ export const DetailedStatus: React.FC<{
     );
   }
 
+  if (['private', 'direct'].includes(status.get('visibility') as string)) {
+    quotesLink = '';
+  } else {
+    quotesLink = (
+      <span className='detailed-status__link'>
+        <span className='detailed-status__quotes'>
+          <AnimatedNumber value={status.get('quotes_count')} />
+        </span>
+        <FormattedMessage
+          id='status.quotes'
+          defaultMessage='{count, plural, one {quote} other {quotes}}'
+          values={{ count: status.get('quotes_count') }}
+        />
+      </span>
+    );
+  }
+
   const favouriteLink = (
     <Link
       to={`/@${status.getIn(['account', 'acct'])}/${status.get('id')}/favourites`}
@@ -420,6 +438,8 @@ export const DetailedStatus: React.FC<{
           <div className='detailed-status__meta__line'>
             {reblogLink}
             {reblogLink && <>·</>}
+            {quotesLink}
+            {quotesLink && <>·</>}
             {favouriteLink}
           </div>
         </div>

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -892,6 +892,7 @@
   "status.quote_policy_change": "Change who can quote",
   "status.quote_post_author": "Quoted a post by @{name}",
   "status.quote_private": "Private posts cannot be quoted",
+  "status.quotes": "{count, plural, one {quote} other {quotes}}",
   "status.read_more": "Read more",
   "status.reblog": "Boost",
   "status.reblog_private": "Boost with original visibility",

--- a/app/javascript/testing/factories.ts
+++ b/app/javascript/testing/factories.ts
@@ -68,6 +68,7 @@ export const statusFactory: FactoryFunction<ApiStatusJSON> = ({
   url: 'https://example.com/status/1',
   replies_count: 0,
   reblogs_count: 0,
+  quotes_count: 0,
   favorites_count: 0,
   account: accountFactory(),
   media_attachments: [],

--- a/app/models/quote.rb
+++ b/app/models/quote.rb
@@ -40,6 +40,10 @@ class Quote < ApplicationRecord
   validates :approval_uri, absence: true, if: -> { quoted_account&.local? }
   validate :validate_visibility
 
+  after_create_commit :increment_counter_caches!
+  after_destroy_commit :decrement_counter_caches!
+  after_update_commit :update_counter_caches!
+
   def accept!
     update!(state: :accepted)
   end
@@ -83,5 +87,28 @@ class Quote < ApplicationRecord
 
   def set_activity_uri
     self.activity_uri = [ActivityPub::TagManager.instance.uri_for(account), '/quote_requests/', SecureRandom.uuid].join
+  end
+
+  def increment_counter_caches!
+    return unless acceptable?
+
+    quoted_status&.increment_count!(:quotes_count)
+  end
+
+  def decrement_counter_caches!
+    return unless acceptable?
+
+    quoted_status&.decrement_count!(:quotes_count)
+  end
+
+  def update_counter_caches!
+    return if legacy? || !state_previously_changed?
+
+    if acceptable?
+      quoted_status&.increment_count!(:quotes_count)
+    else
+      # TODO: are there cases where this would not be correct?
+      quoted_status&.decrement_count!(:quotes_count)
+    end
   end
 end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -301,6 +301,10 @@ class Status < ApplicationRecord
     status_stat&.favourites_count || 0
   end
 
+  def quotes_count
+    status_stat&.quotes_count || 0
+  end
+
   # Reblogs count received from an external instance
   def untrusted_reblogs_count
     status_stat&.untrusted_reblogs_count unless local?

--- a/app/models/status_stat.rb
+++ b/app/models/status_stat.rb
@@ -5,14 +5,15 @@
 # Table name: status_stats
 #
 #  id                         :bigint(8)        not null, primary key
-#  status_id                  :bigint(8)        not null
-#  replies_count              :bigint(8)        default(0), not null
-#  reblogs_count              :bigint(8)        default(0), not null
 #  favourites_count           :bigint(8)        default(0), not null
-#  created_at                 :datetime         not null
-#  updated_at                 :datetime         not null
+#  quotes_count               :bigint(8)        default(0), not null
+#  reblogs_count              :bigint(8)        default(0), not null
+#  replies_count              :bigint(8)        default(0), not null
 #  untrusted_favourites_count :bigint(8)
 #  untrusted_reblogs_count    :bigint(8)
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
+#  status_id                  :bigint(8)        not null
 #
 
 class StatusStat < ApplicationRecord
@@ -32,6 +33,10 @@ class StatusStat < ApplicationRecord
 
   def favourites_count
     [attributes['favourites_count'], 0].max
+  end
+
+  def quotes_count
+    [attributes['quotes_count'], 0].max
   end
 
   private

--- a/app/serializers/rest/status_serializer.rb
+++ b/app/serializers/rest/status_serializer.rb
@@ -99,6 +99,10 @@ class REST::StatusSerializer < ActiveModel::Serializer
     object.untrusted_favourites_count || relationships&.attributes_map&.dig(object.id, :favourites_count) || object.favourites_count
   end
 
+  def quotes_count
+    relationships&.attributes_map&.dig(object.id, :quotes_count) || object.quotes_count
+  end
+
   def favourited
     if relationships
       relationships.favourites_map[object.id] || false

--- a/db/migrate/20250820084312_add_quotes_count_to_status_stat.rb
+++ b/db/migrate/20250820084312_add_quotes_count_to_status_stat.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddQuotesCountToStatusStat < ActiveRecord::Migration[8.0]
+  def change
+    add_column :status_stats, :quotes_count, :bigint, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_19_100545) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_20_084312) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -1103,6 +1103,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_19_100545) do
     t.datetime "updated_at", precision: nil, null: false
     t.bigint "untrusted_favourites_count"
     t.bigint "untrusted_reblogs_count"
+    t.bigint "quotes_count", default: 0, null: false
     t.index ["status_id"], name: "index_status_stats_on_status_id", unique: true
   end
 

--- a/lib/mastodon/cli/cache.rb
+++ b/lib/mastodon/cli/cache.rb
@@ -63,6 +63,7 @@ module Mastodon::CLI
         status_stat.replies_count    = status.replies.not_direct_visibility.count
         status_stat.reblogs_count    = status.reblogs.count
         status_stat.favourites_count = status.favourites.count
+        status_stat.quotes_count     = status.quotes.accepted.count
 
         status_stat.save if status_stat.changed?
       end


### PR DESCRIPTION
This counts quotes separately, and adds them to the boost count everywhere in the UI except in detailed status view:
<img width="598" height="307" alt="image" src="https://github.com/user-attachments/assets/e0fc4928-ba9a-4752-a2f9-067476f5a153" />

In detailed status view, the count is not clickable for now, but could be made clickable for the user's own posts, or, if we decide, for everyone.

I am not completely confident with the code that updates the counters, doing it this way seems a bit brittle.