### PR TITLE
Use `debug?` query method on httplog initializer check

### DIFF
--- a/config/initializers/httplog.rb
+++ b/config/initializers/httplog.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-# Disable httplog in production unless log_level is `debug`
-if !Rails.env.production? || Rails.configuration.log_level == :debug
+# Disable in production unless log level is `debug`
+if Rails.env.local? || Rails.logger.debug?
   require 'httplog'
 
   HttpLog.configure do |config|


### PR DESCRIPTION
Background: https://github.com/mastodon/mastodon/pull/35825#pullrequestreview-3133081044

May be more resilient level check re: string/symbol thing in linked issue. 