### PR TITLE
Use RSpec tag (and class attr) to manage "skip mx check"

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -137,6 +137,8 @@ class User < ApplicationRecord
   attribute :external, :boolean, default: false
   attribute :bypass_registration_checks, :boolean, default: false
 
+  class_attribute :skip_mx_check, default: Rails.env.local?
+
   def self.those_who_can(*any_of_privileges)
     matching_role_ids = UserRole.that_can(*any_of_privileges).map(&:id)
 
@@ -145,10 +147,6 @@ class User < ApplicationRecord
     else
       where(role_id: matching_role_ids)
     end
-  end
-
-  def self.skip_mx_check?
-    Rails.env.local?
   end
 
   def date_of_birth=(hash_or_string)

--- a/spec/controllers/auth/registrations_controller_spec.rb
+++ b/spec/controllers/auth/registrations_controller_spec.rb
@@ -228,7 +228,7 @@ RSpec.describe Auth::RegistrationsController do
       end
     end
 
-    context 'when user has an email address requiring approval through a MX record' do
+    context 'when user has an email address requiring approval through a MX record', :enable_mx_checks do
       subject do
         request.headers['Accept-Language'] = accept_language
         post :create, params: { user: { account_attributes: { username: 'test' }, email: 'test@example.com', password: '12345678', password_confirmation: '12345678', agreement: 'true' } }
@@ -237,7 +237,6 @@ RSpec.describe Auth::RegistrationsController do
       before do
         Setting.registrations_mode = 'open'
         Fabricate(:email_domain_block, allow_with_approval: true, domain: 'mail.example.com')
-        allow(User).to receive(:skip_mx_check?).and_return(false)
         configure_mx(domain: 'example.com', exchange: 'mail.example.com')
       end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -139,6 +139,12 @@ RSpec.configure do |config|
     example.run
   end
 
+  config.around(:each, :enable_mx_checks) do |example|
+    User.skip_mx_check = false
+    example.run
+    User.skip_mx_check = true
+  end
+
   config.around(:each, type: :search) do |example|
     Chewy.settings[:enabled] = true
     example.run

--- a/spec/services/app_sign_up_service_spec.rb
+++ b/spec/services/app_sign_up_service_spec.rb
@@ -48,11 +48,10 @@ RSpec.describe AppSignUpService do
       end
     end
 
-    context 'when the email address requires approval through MX records' do
+    context 'when the email address requires approval through MX records', :enable_mx_checks do
       before do
         Setting.registrations_mode = 'open'
         Fabricate(:email_domain_block, allow_with_approval: true, domain: 'smtp.email.com')
-        allow(User).to receive(:skip_mx_check?).and_return(false)
         configure_mx(domain: 'email.com', exchange: 'smtp.email.com')
       end
 


### PR DESCRIPTION
Noticed while doing https://github.com/mastodon/mastodon/pull/35838

Main thing here is to sort of mirror how the sidekiq fake mode works on this setting as well so we can avoid stubbing User and rely on it as more of a setting value. The user instances are technically not the SUT in either test, but they are close-ish.

Moves this from stubbable method to settable class attribute. Should preserve defaults in production vs other modes.

Side note here ... thoughts on renaming this to be the opposite way? -- `proccess_mx_checks` or something? (and then have it true only in production by default). The few spots that access it all use it as an `unless`, or otherwise check its negation. Might read easier in all those checks to have it read more as "when enabled" rather than "when not skipping"?