### PR TITLE
Rename misleading settings/applications token action method

### DIFF
--- a/app/controllers/settings/applications/tokens_controller.rb
+++ b/app/controllers/settings/applications/tokens_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Settings
+  class Applications::TokensController < BaseController
+    before_action :set_application
+
+    def destroy
+      @access_token = current_user.token_for_app(@application)
+      @access_token.destroy
+
+      redirect_to settings_application_path(@application), notice: t('applications.token_regenerated')
+    end
+
+    private
+
+    def set_application
+      @application = current_user.applications.find(params[:application_id])
+    end
+  end
+end

--- a/app/controllers/settings/applications_controller.rb
+++ b/app/controllers/settings/applications_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Settings::ApplicationsController < Settings::BaseController
-  before_action :set_application, only: [:show, :update, :destroy, :regenerate]
+  before_action :set_application, only: [:show, :update, :destroy]
 
   def index
     @applications = current_user.applications.order(id: :desc).page(params[:page])
@@ -43,13 +43,6 @@ class Settings::ApplicationsController < Settings::BaseController
   def destroy
     @application.destroy
     redirect_to settings_applications_path, notice: I18n.t('applications.destroyed')
-  end
-
-  def regenerate
-    @access_token = current_user.token_for_app(@application)
-    @access_token.destroy
-
-    redirect_to settings_application_path(@application), notice: I18n.t('applications.token_regenerated')
   end
 
   private

--- a/app/views/settings/applications/show.html.haml
+++ b/app/views/settings/applications/show.html.haml
@@ -20,7 +20,7 @@
           %code= current_user.token_for_app(@application).token
       %tr
         %th
-        %td= table_link_to 'refresh', t('applications.regenerate_token'), regenerate_settings_application_path(@application), method: :post
+        %td= table_link_to 'refresh', t('applications.regenerate_token'), settings_application_token_path(@application), method: :delete
 
 %hr/
 

--- a/config/routes/settings.rb
+++ b/config/routes/settings.rb
@@ -54,9 +54,7 @@ namespace :settings do
   end
 
   resources :applications, except: [:edit] do
-    member do
-      post :regenerate
-    end
+    resource :token, module: :applications, only: :destroy
   end
 
   resource :delete, only: [:show, :destroy]


### PR DESCRIPTION
Background: https://github.com/mastodon/mastodon/pull/35815#issue-3332110654

Just reflecting that we are not actually regenerating (but are destroying) the token in the action. Small improvements from slightly more RESTful naming/routing.

Separately -- it's slightly odd to me (but seems like it's always been this way) to use a `GET #show` request to generate these tokens (only when they dont exist), though I'm guessing at the time it was added that was the best way to get something there if it had not been generated previously. Doesn't necessarily need to be solved, just wanted to highlight.