### PR TITLE
Fix export of large user archives on 4.4 by enabling Zip64

### DIFF
--- a/app/services/backup_service.rb
+++ b/app/services/backup_service.rb
@@ -55,6 +55,7 @@ class BackupService < BaseService
   def build_archive!
     tmp_file = Tempfile.new(%w(archive .zip))
 
+    Zip.write_zip64_support = true
     Zip::File.open(tmp_file, create: true) do |zipfile|
       dump_outbox!(zipfile)
       dump_media_attachments!(zipfile)


### PR DESCRIPTION
As far as I understand, Zip64 is required for archives over 4GB, which can happen when some Mastodon users request an archive of their account.

Rubyzip 3 enables Zip64 by default, but not earlier versions, which are used in current Mastodon stable releases.

A downside of this change is that Zip64 is a breaking change from earlier versions of the Zip format, but support should now be widespread.