### PR TITLE
Refer to pinnable visibilities constant from status serializer `pinnable?` attribute

### DIFF
--- a/app/serializers/rest/status_serializer.rb
+++ b/app/serializers/rest/status_serializer.rb
@@ -155,7 +155,7 @@ class REST::StatusSerializer < ActiveModel::Serializer
     current_user? &&
       current_user.account_id == object.account_id &&
       !object.reblog? &&
-      %w(public unlisted private).include?(object.visibility)
+      StatusRelationshipsPresenter::PINNABLE_VISIBILITIES.include?(object.visibility)
   end
 
   def source_requested?


### PR DESCRIPTION
Smaller piece extracted from https://github.com/mastodon/mastodon/pull/35718

If that larger one has too much going on, perhaps this is easy enough to pull in ahead of that (and/or can skip the various naming conversations remnisced about on that one) ... though I guess the "are 'pinnable' and 'list eligible' the same?" and "should this constant live somewhere else?" questions are loosely related here.

Constant initially extracted in https://github.com/mastodon/mastodon/pull/24819/files#diff-511d37462501d190f26b021a37736f296ee0d1a5085530f5e4770135f6a5e203R4 but then not broadly applied

