### PR TITLE
Update playwright-ruby-client to version 1.55.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -438,7 +438,7 @@ GEM
     mime-types (3.7.0)
       logger
       mime-types-data (~> 3.2025, >= 3.2025.0507)
-    mime-types-data (3.2025.0729)
+    mime-types-data (3.2025.0916)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
     minitest (5.25.5)
@@ -610,7 +610,7 @@ GEM
     pg (1.6.2)
     pghero (3.7.0)
       activerecord (>= 7.1)
-    playwright-ruby-client (1.54.1)
+    playwright-ruby-client (1.55.0)
       concurrent-ruby (>= 1.1.6)
       mime-types (>= 3.0)
     pp (0.6.2)

--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
     "lint-staged": "^16.0.0",
     "msw": "^2.10.2",
     "msw-storybook-addon": "^2.0.5",
-    "playwright": "^1.54.1",
+    "playwright": "^1.55.0",
     "prettier": "^3.3.3",
     "react-test-renderer": "^18.2.0",
     "storybook": "^9.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2737,7 +2737,7 @@ __metadata:
     msw: "npm:^2.10.2"
     msw-storybook-addon: "npm:^2.0.5"
     path-complete-extname: "npm:^1.0.0"
-    playwright: "npm:^1.54.1"
+    playwright: "npm:^1.55.0"
     postcss-preset-env: "npm:^10.1.5"
     prettier: "npm:^3.3.3"
     prop-types: "npm:^15.8.1"
@@ -10310,27 +10310,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.54.2":
-  version: 1.54.2
-  resolution: "playwright-core@npm:1.54.2"
+"playwright-core@npm:1.55.0":
+  version: 1.55.0
+  resolution: "playwright-core@npm:1.55.0"
   bin:
     playwright-core: cli.js
-  checksum: 10c0/44850e20bf35237c8c3dedf1096c655f8af939dde53c5469f72cae3dd744966858a302419b909a73d7a2093323123e7ebcc0fdd55151b4193afb7812c1fd2c88
+  checksum: 10c0/c39d6aa30e7a4e73965942ca5e13405ae05c9cb49f755a35f04248c864c0b24cf662d9767f1797b3ec48d1cf4e54774dce4a19c16534bd5cfd2aa3da81c9dc3a
   languageName: node
   linkType: hard
 
-"playwright@npm:^1.54.1":
-  version: 1.54.2
-  resolution: "playwright@npm:1.54.2"
+"playwright@npm:^1.55.0":
+  version: 1.55.0
+  resolution: "playwright@npm:1.55.0"
   dependencies:
     fsevents: "npm:2.3.2"
-    playwright-core: "npm:1.54.2"
+    playwright-core: "npm:1.55.0"
   dependenciesMeta:
     fsevents:
       optional: true
   bin:
     playwright: cli.js
-  checksum: 10c0/6f642fa70179eee5d5bf8a90df2a6147c9638ff926f4f3ad0a0517396b8a3fe00ccebf13377e032a75b3f0b2610ec1562293e0cfc3bde234181c7a50af8af80a
+  checksum: 10c0/51605b7e57a5650e57972c5fdfc09d7a9934cca1cbee5beacca716fa801e25cb5bb7c1663de90c22b300fde884e5545a2b13a0505a93270b660687791c478304
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Renovate may submit this as well, but it needs to stay in step with the JS package, so doing both here.