### PR TITLE
Remove unused `DomainControlHelper` include from `SignedRequest`

### DIFF
--- a/app/lib/signed_request.rb
+++ b/app/lib/signed_request.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class SignedRequest
-  include DomainControlHelper
-
   EXPIRATION_WINDOW_LIMIT = 12.hours
   CLOCK_SKEW_MARGIN       = 1.hour
 


### PR DESCRIPTION
Added originally to the signature verification concern - https://github.com/mastodon/mastodon/pull/11268/files#diff-116b043503d1da3ba11ab590fc8c4e674fa0ae9c6dcaa3aed04255d460064481R131 - and was then (I suspect) copied over when `SignedRequest` was added - https://github.com/mastodon/mastodon/pull/34814/files#diff-19dcc67ffe1f00bcee9be5f1a2080586c347bef2fe7a380afcef726010346a02R4

However, the method used from the module (`domain_not_allowed?`) is only used in the concern portion (and is still used there now), but not in the extracted portion.

Separately, the `DomainControlHelper` is another lib where its usage is primarily NOT as controllers/view glue, but it's defined in app/helpers. May have follow-up here to improve that, but will likely do the two methods in that module separately since they have different usage.