### PR TITLE
Do not mark remote quotes of local posts as approved before request

### DIFF
--- a/app/services/activitypub/process_status_update_service.rb
+++ b/app/services/activitypub/process_status_update_service.rb
@@ -307,7 +307,7 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
           @quote_changed = true
         else
           quote = @status.quote
-          quote.update(approval_uri: approval_uri, state: :pending, legacy: @status_parser.legacy_quote?) if quote.approval_uri != @status_parser.quote_approval_uri
+          quote.update(approval_uri: approval_uri, state: :pending, legacy: @status_parser.legacy_quote?) if quote.approval_uri != approval_uri
         end
       else
         quote = Quote.create(status: @status, approval_uri: approval_uri, legacy: @status_parser.legacy_quote?)

--- a/app/services/activitypub/verify_quote_service.rb
+++ b/app/services/activitypub/verify_quote_service.rb
@@ -13,7 +13,7 @@ class ActivityPub::VerifyQuoteService < BaseService
     @fetching_error = nil
 
     fetch_quoted_post_if_needed!(fetchable_quoted_uri, prefetched_body: prefetched_quoted_object)
-    return handle_local_quote! if quote.quoted_account&.local?
+    return if quote.quoted_account&.local?
     return if fast_track_approval! || quote.approval_uri.blank?
 
     @json = fetch_approval_object(quote.approval_uri, prefetched_body: prefetched_approval)
@@ -34,15 +34,6 @@ class ActivityPub::VerifyQuoteService < BaseService
   end
 
   private
-
-  def handle_local_quote!
-    @quote.update!(approval_uri: nil)
-    if StatusPolicy.new(@quote.account, @quote.quoted_status).quote?
-      @quote.accept!
-    else
-      @quote.reject!
-    end
-  end
 
   # FEP-044f defines rules that don't require the approval flow
   def fast_track_approval!


### PR DESCRIPTION
Before this change, remote quotes of local posts allowed by the quote policy were immediately considered as accepted.

This PR changes that, as in the absence of an explicit request, such posts cannot be proven as accepted to third-party servers, leading to inconsistencies.