### PR TITLE
Improve feed item focus outlines

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1438,9 +1438,9 @@ body > [data-popper-placement] {
 
 .focusable {
   &:focus-visible {
-    outline: 0;
+    outline: 2px solid $ui-button-focus-outline-color;
+    outline-offset: -2px;
     background: color.change($ui-highlight-color, $alpha: 0.05);
-    box-shadow: inset 0 0 0 2px $ui-button-focus-outline-color;
   }
 }
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -4373,6 +4373,11 @@ a.status-card {
     background: var(--on-surface-color);
   }
 
+  &:focus-visible {
+    outline: 2px solid $ui-button-focus-outline-color;
+    outline-offset: -2px;
+  }
+
   .icon {
     width: 22px;
     height: 22px;


### PR DESCRIPTION
### Changes proposed in this PR:
- Fixes focus outline of feed items being cut off by 1 pixel at the bottom (by using an `outline` with `outline-offset` instead of an inset `box-shadow` for the outline)
- Add a proper focus outline to the "Load more" button

### Screenshots

| **BEFORE** | **AFTER** |
|--------|--------|
| <img width="611" height="181" alt="image" src="https://github.com/user-attachments/assets/feb94f4a-bb2d-4bdf-8d32-9769ed933d5f" /> | <img width="615" height="171" alt="image" src="https://github.com/user-attachments/assets/1ad5faa0-7a55-4f9c-82ac-0f3235a71153" /> |
| <img width="618" height="180" alt="image" src="https://github.com/user-attachments/assets/76ec04f7-2c14-416c-b16e-63ba36ca3ea5" /> | <img width="621" height="179" alt="image" src="https://github.com/user-attachments/assets/cc7a98bf-aaf9-4d12-ab65-9a5a49f8d3fa" /> | 