### PR TITLE
Mark `Form::AdminSettings#persisted?` as true

### DIFF
--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -154,6 +154,10 @@ class Form::AdminSettings
     end
   end
 
+  def persisted?
+    true
+  end
+
   private
 
   def cache_digest_value(key)

--- a/app/views/admin/settings/about/show.html.haml
+++ b/app/views/admin/settings/about/show.html.haml
@@ -5,7 +5,7 @@
   %h2= t('admin.settings.title')
   = render partial: 'admin/settings/shared/links'
 
-= simple_form_for @admin_settings, url: admin_settings_about_path, html: { method: :patch } do |f|
+= simple_form_for @admin_settings, url: admin_settings_about_path do |f|
   = render 'shared/error_messages', object: @admin_settings
 
   %p.lead= t('admin.settings.about.preamble')

--- a/app/views/admin/settings/appearance/show.html.haml
+++ b/app/views/admin/settings/appearance/show.html.haml
@@ -5,7 +5,7 @@
   %h2= t('admin.settings.title')
   = render partial: 'admin/settings/shared/links'
 
-= simple_form_for @admin_settings, url: admin_settings_appearance_path, html: { method: :patch } do |f|
+= simple_form_for @admin_settings, url: admin_settings_appearance_path do |f|
   = render 'shared/error_messages', object: @admin_settings
 
   %p.lead= t('admin.settings.appearance.preamble')

--- a/app/views/admin/settings/branding/show.html.haml
+++ b/app/views/admin/settings/branding/show.html.haml
@@ -5,7 +5,7 @@
   %h2= t('admin.settings.title')
   = render partial: 'admin/settings/shared/links'
 
-= simple_form_for @admin_settings, url: admin_settings_branding_path, html: { method: :patch } do |f|
+= simple_form_for @admin_settings, url: admin_settings_branding_path do |f|
   = render 'shared/error_messages', object: @admin_settings
 
   %p.lead= t('admin.settings.branding.preamble')

--- a/app/views/admin/settings/content_retention/show.html.haml
+++ b/app/views/admin/settings/content_retention/show.html.haml
@@ -5,7 +5,7 @@
   %h2= t('admin.settings.title')
   = render partial: 'admin/settings/shared/links'
 
-= simple_form_for @admin_settings, url: admin_settings_content_retention_path, html: { method: :patch } do |f|
+= simple_form_for @admin_settings, url: admin_settings_content_retention_path do |f|
   = render 'shared/error_messages', object: @admin_settings
 
   %p.lead= t('admin.settings.content_retention.preamble')

--- a/app/views/admin/settings/discovery/show.html.haml
+++ b/app/views/admin/settings/discovery/show.html.haml
@@ -5,7 +5,7 @@
   %h2= t('admin.settings.title')
   = render partial: 'admin/settings/shared/links'
 
-= simple_form_for @admin_settings, url: admin_settings_discovery_path, html: { method: :patch } do |f|
+= simple_form_for @admin_settings, url: admin_settings_discovery_path do |f|
   = render 'shared/error_messages', object: @admin_settings
 
   %p.lead= t('admin.settings.discovery.preamble')

--- a/app/views/admin/settings/registrations/show.html.haml
+++ b/app/views/admin/settings/registrations/show.html.haml
@@ -5,7 +5,7 @@
   %h2= t('admin.settings.title')
   = render partial: 'admin/settings/shared/links'
 
-= simple_form_for @admin_settings, url: admin_settings_registrations_path, html: { method: :patch } do |f|
+= simple_form_for @admin_settings, url: admin_settings_registrations_path do |f|
   = render 'shared/error_messages', object: @admin_settings
 
   %p.lead= t('admin.settings.registrations.preamble')

--- a/spec/models/form/admin_settings_spec.rb
+++ b/spec/models/form/admin_settings_spec.rb
@@ -53,4 +53,8 @@ RSpec.describe Form::AdminSettings do
       end
     end
   end
+
+  describe '#persisted?' do
+    it { is_expected.to be_persisted }
+  end
 end


### PR DESCRIPTION
This is both logically true (the admin settings are persisted), but also lets us rely on reflection here to correctly mark the HTTP method in the generated form.