### PR TITLE
fix: display description i/o `author_name` if `accountId` is available

### DIFF
--- a/app/javascript/mastodon/features/status/components/card.jsx
+++ b/app/javascript/mastodon/features/status/components/card.jsx
@@ -149,7 +149,15 @@ export default class Card extends PureComponent {
 
         <strong className='status-card__title' title={card.get('title')} lang={language}>{card.get('title')}</strong>
 
-        {!showAuthor && (card.get('author_name').length > 0 ? <span className='status-card__author'><FormattedMessage id='link_preview.author' defaultMessage='By {name}' values={{ name: <strong>{card.get('author_name')}</strong> }} /></span> : <span className='status-card__description' lang={language}>{card.get('description')}</span>)}
+        {!showAuthor && card.get('author_name').length > 0 ? (
+          <span className='status-card__author'>
+            <FormattedMessage id='link_preview.author' defaultMessage='By {name}' values={{ name: <strong>{card.get('author_name')}</strong> }} />
+          </span>
+        ) : (
+          <span className='status-card__description' lang={language}>
+            {card.get('description')}
+          </span>
+        )}
       </div>
     );
 


### PR DESCRIPTION
Trying to fix a bug introduce by the new `fediverse:creator` meta tag.

If there is an _author_, it is displayed instead of the _description_.
But in the case of an `accountId`, it is displayed below: we can therefore keep the _description_ displayed.

Page with a description:

<img width="565" height="163" alt="Capture d'écran 2025-08-24 010735" src="https://github.com/user-attachments/assets/d9ada4fa-2f8f-4164-b2fc-e727433c497d" />

Page with an author:

<img width="562" height="162" alt="image" src="https://github.com/user-attachments/assets/521b662c-a65a-470a-9ddd-fbd7c71c1030" />

Page with a description and `fediverse:creator`:

<img width="563" height="209" alt="Capture d'écran 2025-08-24 011012" src="https://github.com/user-attachments/assets/63233fcc-ad2f-4562-a624-b0f22452383f" />
