### PR TITLE
Add crossorigin back to inert css (regression? of #30687)

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -30,7 +30,7 @@
     = vite_react_refresh_tag
     = vite_polyfills_tag
     -# Needed for the wicg-inert polyfill. It needs to be on it's own <style> tag, with this `id`
-    = vite_stylesheet_tag 'styles/entrypoints/inert.scss', media: 'all', id: 'inert-style'
+    = vite_stylesheet_tag 'styles/entrypoints/inert.scss', media: 'all', id: 'inert-style', crossorigin: 'anonymous'
     = vite_typescript_tag 'common.ts', crossorigin: 'anonymous'
 
     = vite_preload_file_tag "mastodon/locales/#{I18n.locale}.json"


### PR DESCRIPTION
<img width="938" height="42" alt="image" src="https://github.com/user-attachments/assets/012b83ea-338e-412e-84e5-242f7fe9c272" />

This is showing on my instance running main.

edit: recently changed in #34450 