### PR TITLE
Fix timestamps not respecting users configured time zone setting

### DIFF
--- a/app/javascript/mastodon/components/formatted_date.tsx
+++ b/app/javascript/mastodon/components/formatted_date.tsx
@@ -2,10 +2,12 @@ import type { ComponentProps } from 'react';
 
 import { FormattedDate } from 'react-intl';
 
+import { timeZone } from 'mastodon/initial_state';
+
 export const FormattedDateWrapper = (
   props: ComponentProps<typeof FormattedDate> & { className?: string },
 ) => (
-  <FormattedDate {...props}>
+  <FormattedDate {...props} timeZone={timeZone}>
     {(date) => (
       <time dateTime={tryIsoString(props.value)} className={props.className}>
         {date}

--- a/app/javascript/mastodon/components/relative_timestamp.tsx
+++ b/app/javascript/mastodon/components/relative_timestamp.tsx
@@ -3,6 +3,8 @@ import { Component } from 'react';
 import type { MessageDescriptor, PrimitiveType, IntlShape } from 'react-intl';
 import { injectIntl, defineMessages } from 'react-intl';
 
+import { timeZone } from 'mastodon/initial_state';
+
 const messages = defineMessages({
   today: { id: 'relative_time.today', defaultMessage: 'today' },
   just_now: { id: 'relative_time.just_now', defaultMessage: 'now' },
@@ -58,11 +60,13 @@ const dateFormatOptions = {
   day: '2-digit',
   hour: '2-digit',
   minute: '2-digit',
+  timeZone,
 } as const;
 
 const shortDateFormatOptions = {
   month: 'short',
   day: 'numeric',
+  timeZone,
 } as const;
 
 const SECOND = 1000;

--- a/app/javascript/mastodon/components/status.jsx
+++ b/app/javascript/mastodon/components/status.jsx
@@ -24,7 +24,7 @@ import Card from '../features/status/components/card';
 import Bundle from '../features/ui/components/bundle';
 import { MediaGallery, Video, Audio } from '../features/ui/util/async-components';
 import { SensitiveMediaContext } from '../features/ui/util/sensitive_media_context';
-import { displayMedia } from '../initial_state';
+import { displayMedia, timeZone } from '../initial_state';
 
 import { Avatar } from './avatar';
 import { AvatarOverlay } from './avatar_overlay';
@@ -49,7 +49,7 @@ export const textForScreenReader = (intl, status, rebloggedByText = false) => {
   const values = [
     displayName.length === 0 ? status.getIn(['account', 'acct']).split('@')[0] : displayName,
     spoilerText && status.get('hidden') ? spoilerText : contentText,
-    intl.formatDate(status.get('created_at'), { hour: '2-digit', minute: '2-digit', month: 'short', day: 'numeric' }),
+    intl.formatDate(status.get('created_at'), { hour: '2-digit', minute: '2-digit', month: 'short', day: 'numeric', timeZone }),
     status.getIn(['account', 'acct']),
   ];
 
@@ -561,7 +561,7 @@ class Status extends ImmutablePureComponent {
             <div onClick={this.handleHeaderClick} onAuxClick={this.handleHeaderClick} className='status__info'>
               <Link to={`/@${status.getIn(['account', 'acct'])}/${status.get('id')}`} className='status__relative-time'>
                 <span className='status__visibility-icon'><VisibilityIcon visibility={status.get('visibility')} /></span>
-                <RelativeTimestamp timestamp={status.get('created_at')} />{status.get('edited_at') && <abbr title={intl.formatMessage(messages.edited, { date: intl.formatDate(status.get('edited_at'), { year: 'numeric', month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit' }) })}> *</abbr>}
+                <RelativeTimestamp timestamp={status.get('created_at')} />{status.get('edited_at') && <abbr title={intl.formatMessage(messages.edited, { date: intl.formatDate(status.get('edited_at'), { year: 'numeric', month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit', timeZone }) })}> *</abbr>}
               </Link>
 
               <Link to={`/@${status.getIn(['account', 'acct'])}`} title={status.getIn(['account', 'acct'])} data-hover-card-account={status.getIn(['account', 'id'])} className='status__display-name'>

--- a/app/javascript/mastodon/features/account_featured/components/featured_tag.tsx
+++ b/app/javascript/mastodon/features/account_featured/components/featured_tag.tsx
@@ -3,6 +3,7 @@ import { defineMessages, useIntl } from 'react-intl';
 import type { Map as ImmutableMap } from 'immutable';
 
 import { Hashtag } from 'mastodon/components/hashtag';
+import { timeZone } from 'mastodon/initial_state';
 
 export type TagMap = ImmutableMap<
   'id' | 'name' | 'url' | 'statuses_count' | 'last_status_at' | 'accountId',
@@ -43,6 +44,7 @@ export const FeaturedTag: React.FC<FeaturedTagProps> = ({ tag, account }) => {
                 month: 'short',
                 day: '2-digit',
                 year: 'numeric',
+                timeZone,
               }),
             })
           : intl.formatMessage(messages.empty)

--- a/app/javascript/mastodon/features/account_timeline/components/account_header.tsx
+++ b/app/javascript/mastodon/features/account_timeline/components/account_header.tsx
@@ -50,7 +50,12 @@ import { DomainPill } from 'mastodon/features/account/components/domain_pill';
 import FollowRequestNoteContainer from 'mastodon/features/account/containers/follow_request_note_container';
 import { useLinks } from 'mastodon/hooks/useLinks';
 import { useIdentity } from 'mastodon/identity_context';
-import { autoPlayGif, me, domain as localDomain } from 'mastodon/initial_state';
+import {
+  autoPlayGif,
+  me,
+  domain as localDomain,
+  timeZone,
+} from 'mastodon/initial_state';
 import type { Account } from 'mastodon/models/account';
 import type { MenuItem } from 'mastodon/models/dropdown_menu';
 import {
@@ -191,6 +196,7 @@ const dateFormatOptions: Intl.DateTimeFormatOptions = {
   year: 'numeric',
   hour: '2-digit',
   minute: '2-digit',
+  timeZone,
 };
 
 export const AccountHeader: React.FC<{

--- a/app/javascript/mastodon/features/notifications/components/notification.jsx
+++ b/app/javascript/mastodon/features/notifications/components/notification.jsx
@@ -21,7 +21,7 @@ import { Account } from 'mastodon/components/account';
 import { Icon }  from 'mastodon/components/icon';
 import { Hotkeys } from 'mastodon/components/hotkeys';
 import { StatusQuoteManager } from 'mastodon/components/status_quoted';
-import { me } from 'mastodon/initial_state';
+import { me, timeZone } from 'mastodon/initial_state';
 import { WithRouterPropTypes } from 'mastodon/utils/react_router';
 
 import FollowRequestContainer from '../containers/follow_request_container';
@@ -48,7 +48,7 @@ const messages = defineMessages({
 const notificationForScreenReader = (intl, message, timestamp) => {
   const output = [message];
 
-  output.push(intl.formatDate(timestamp, { hour: '2-digit', minute: '2-digit', month: 'short', day: 'numeric' }));
+  output.push(intl.formatDate(timestamp, { hour: '2-digit', minute: '2-digit', month: 'short', day: 'numeric', timeZone }));
 
   return output.join(', ');
 };

--- a/app/javascript/mastodon/initial_state.js
+++ b/app/javascript/mastodon/initial_state.js
@@ -46,6 +46,7 @@
  * @property {string} status_page_url
  * @property {boolean} terms_of_service_enabled
  * @property {string?} emoji_style
+ * @property {string=} time_zone
  */
 
 /**
@@ -123,6 +124,7 @@ export const criticalUpdatesPending = initialState?.critical_updates_pending;
 export const statusPageUrl = getMeta('status_page_url');
 export const sso_redirect = getMeta('sso_redirect');
 export const termsOfServiceEnabled = getMeta('terms_of_service_enabled');
+export const timeZone = getMeta('time_zone');
 
 const displayNames = Intl.DisplayNames && new Intl.DisplayNames(getMeta('locale'), {
   type: 'language',

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -31,6 +31,7 @@ class InitialStateSerializer < ActiveModel::Serializer
       store[:use_pending_items] = object_account_user.setting_use_pending_items
       store[:show_trends]       = Setting.trends && object_account_user.setting_trends
       store[:emoji_style]       = object_account_user.settings['web.emoji_style'] if Mastodon::Feature.modern_emojis_enabled?
+      store[:time_zone]         = object_account_user.time_zone
     else
       store[:auto_play_gif] = Setting.auto_play_gif
       store[:display_media] = Setting.display_media


### PR DESCRIPTION
Fixes #30956

Issue where timestamps throughout the application were displayed in utc or the browsers local time zone instead of respecting the users configured time zone setting from Preferences.

https://github.com/user-attachments/assets/0aeec384-8b3b-4855-a9d2-4df81a8795cd

