### PR TITLE
Fix media URL inconsistency when deleting statuses via API

### DIFF
--- a/app/controllers/api/v1/statuses_controller.rb
+++ b/app/controllers/api/v1/statuses_controller.rb
@@ -126,10 +126,11 @@ class Api::V1::StatusesController < Api::BaseController
     @status = Status.where(account: current_account).find(params[:id])
     authorize @status, :destroy?
 
+    json = render_to_body json: @status, serializer: REST::StatusSerializer, source_requested: true
+
     @status.discard_with_reblogs
     StatusPin.find_by(status: @status)&.destroy
     @status.account.statuses_count = @status.account.statuses_count - 1
-    json = render_to_body json: @status, serializer: REST::StatusSerializer, source_requested: true
 
     RemovalWorker.perform_async(@status.id, { 'redraft' => !truthy_param?(:delete_media) })
 


### PR DESCRIPTION
Fixes #35669

Serialize the status before calling `discard_with_reblogs` to preserve the correct media urls in the DELETE response

1. Create a post with image in the web ui
2. Note the status id from the url
3. GET the status - note the media url:
  curl -H "Authorization: Bearer YOUR_TOKEN" \
    http://localhost:3000/api/v1/statuses/STATUS_ID | jq '.media_attachments[0].url'
4. DELETE the status - check the media URL matches:
  curl -X DELETE -H "Authorization: Bearer YOUR_TOKEN" \
    http://localhost:3000/api/v1/statuses/STATUS_ID | jq '.media_attachments[0].url'
5. Verify the URL works (should return 200 OK): curl -I "MEDIA_URL_FROM_DELETE"