### PR TITLE
Fix broken custom radio buttons & checkboxes in modals

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -5668,9 +5668,20 @@ a.status-card {
     z-index: 9999;
   }
 
-  &__label.disabled {
-    cursor: default;
-    opacity: 0.5;
+  &__label {
+    cursor: pointer;
+    display: block;
+
+    > span {
+      display: block;
+      font-weight: 500;
+      margin-bottom: 8px;
+    }
+
+    &.disabled {
+      cursor: default;
+      opacity: 0.5;
+    }
   }
 
   &__button {
@@ -5985,17 +5996,6 @@ a.status-card {
 
   @media screen and (width <= $mobile-breakpoint) {
     margin-top: auto;
-  }
-}
-
-.modal-root label {
-  cursor: pointer;
-  display: block;
-
-  > span {
-    display: block;
-    font-weight: 500;
-    margin-bottom: 8px;
   }
 }
 


### PR DESCRIPTION
Fixes #35883

### Changes proposed in this PR:
- Fixes broken design of custom radio buttons & checkboxes in modals, caused by a too broad CSS selector introduced in #35762 

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="229" height="220" alt="image" src="https://github.com/user-attachments/assets/9cc502b4-c779-4f11-9ce4-734c8481c2d9" /> | <img width="219" height="217" alt="image" src="https://github.com/user-attachments/assets/74842b5e-0494-423b-879e-2007943f5eb2" /> | 