### PR TITLE
Relax hard-coded attr names in system specs

### DIFF
--- a/spec/system/filters_spec.rb
+++ b/spec/system/filters_spec.rb
@@ -53,8 +53,8 @@ RSpec.describe 'Filters' do
       click_on filter_title
 
       fill_in filter_title_field, with: new_title
-      fill_in 'custom_filter_keywords_attributes_0_keyword', with: 'New value'
-      fill_in 'custom_filter_keywords_attributes_1_keyword', with: 'Wilderness'
+      custom_filter_keywords_fields.first.fill_in with: 'New value'
+      custom_filter_keywords_fields.last.fill_in with: 'Wilderness'
 
       expect { click_on submit_button }
         .to change { keyword_one.reload.keyword }.to(/New value/)
@@ -105,6 +105,10 @@ RSpec.describe 'Filters' do
       fill_in with: 'Keyword'
     end
     click_on I18n.t('filters.new.save')
+  end
+
+  def custom_filter_keywords_fields
+    page.all('.keywords-table .custom_filter_keywords_keyword')
   end
 
   def filter_title_field

--- a/spec/system/profile_spec.rb
+++ b/spec/system/profile_spec.rb
@@ -23,11 +23,11 @@ RSpec.describe 'Profile' do
     fill_in 'Display name', with: 'Bob'
     fill_in 'Bio', with: 'Bob is silent'
 
-    fill_in 'account_fields_attributes_0_name', with: 'Personal Website'
-    fill_in 'account_fields_attributes_0_value', with: 'https://host.example/personal'
+    account_fields_labels.first.fill_in with: 'Personal Website'
+    account_fields_values.first.fill_in with: 'https://host.example/personal'
 
-    fill_in 'account_fields_attributes_1_name', with: 'Professional Biography'
-    fill_in 'account_fields_attributes_1_value', with: 'https://host.example/pro'
+    account_fields_labels.last.fill_in with: 'Professional Biography'
+    account_fields_values.last.fill_in with: 'https://host.example/pro'
 
     expect { submit_form }
       .to change { bob.account.reload.display_name }.to('Bob')
@@ -38,6 +38,14 @@ RSpec.describe 'Profile' do
 
   def submit_form
     first('button[type=submit]').click
+  end
+
+  def account_fields_labels
+    page.all('.account_fields_name input')
+  end
+
+  def account_fields_values
+    page.all('.account_fields_value input')
   end
 
   def change_account_fields


### PR DESCRIPTION
Loosening this up a bit to be less about the specific names generated by nested attrs, and more about form structure.

There may be more of these (or others which could rely more on labels and less id values, etc), but found these on first pass.