### PR TITLE
Use default action of persisted records on edit forms

### DIFF
--- a/app/views/admin/domain_blocks/edit.html.haml
+++ b/app/views/admin/domain_blocks/edit.html.haml
@@ -1,7 +1,7 @@
 - content_for :page_title do
   = t('admin.domain_blocks.edit')
 
-= simple_form_for @domain_block, url: admin_domain_block_path(@domain_block), method: :put do |form|
+= simple_form_for @domain_block, url: admin_domain_block_path(@domain_block) do |form|
   = render 'shared/error_messages', object: @domain_block
 
   = render form

--- a/app/views/filters/edit.html.haml
+++ b/app/views/filters/edit.html.haml
@@ -1,7 +1,7 @@
 - content_for :page_title do
   = t('filters.edit.title')
 
-= simple_form_for @filter, url: filter_path(@filter), method: :put do |f|
+= simple_form_for @filter, url: filter_path(@filter) do |f|
   = render 'filter_fields', f: f
 
   .actions


### PR DESCRIPTION
Similar to https://github.com/mastodon/mastodon/pull/35872 -- for these ones both of these edit views will only ever have persisted records in place, which will use these actions by default.