### PR TITLE
Fix WebUI fetching deleted quote in an endless loop

### DIFF
--- a/app/javascript/mastodon/components/status_quoted.tsx
+++ b/app/javascript/mastodon/components/status_quoted.tsx
@@ -84,12 +84,13 @@ export const QuotedStatus: React.FC<QuotedStatusProps> = ({
   const status = useAppSelector((state) =>
     quotedStatusId ? state.statuses.get(quotedStatusId) : undefined,
   );
+  const isQuoteLoaded = !!status && !status.get('isLoading');
 
   useEffect(() => {
-    if (!status && quotedStatusId) {
+    if (!isQuoteLoaded && quotedStatusId) {
       dispatch(fetchStatus(quotedStatusId));
     }
-  }, [status, quotedStatusId, dispatch]);
+  }, [isQuoteLoaded, quotedStatusId, dispatch]);
 
   // In order to find out whether the quoted post should be completely hidden
   // due to a matching filter, we run it through the selector used by `status_container`.


### PR DESCRIPTION
Partial fix to #35869

Triggering a fetch would create a dummy status in the redux store with `isLoading: true`, causing the `status` prop to change and the effect to fire in a loop (post missing causing the effect to trigger → fire `fetchStatus` and create dummy status → effect triggered because of `status` change, but `fetchStatus` skipped due to `status` being truthy → `fetchStatus` fails and deletes the dummy status → effect triggers again).

This PR fixes that so that the effect doesn't re-trigger in that scenario.

This is only a partial solution because it will show a 404 error each time the component is instantiated (but only once per instantiation).