### PR TITLE
Move lengthy ruby logic from mailer view to helper

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -243,6 +243,10 @@ module ApplicationHelper
     tag.input(type: :text, maxlength: 999, spellcheck: false, readonly: true, **options)
   end
 
+  def recent_tag_users(tag)
+    tag.statuses.public_visibility.joins(:account).merge(Account.without_suspended.without_silenced).includes(:account).limit(3).map(&:account)
+  end
+
   def recent_tag_usage(tag)
     people = tag.history.aggregate(2.days.ago.to_date..Time.zone.today).accounts
     I18n.t 'user_mailer.welcome.hashtags_recent_count', people: number_with_delimiter(people), count: people

--- a/app/views/application/mailer/_hashtag.html.haml
+++ b/app/views/application/mailer/_hashtag.html.haml
@@ -1,5 +1,3 @@
-- accounts = hashtag.statuses.public_visibility.joins(:account).merge(Account.without_suspended.without_silenced).includes(:account).limit(3).map(&:account)
-
 %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
   %tr
     %td.email-mini-wrapper-td
@@ -13,7 +11,7 @@
                   %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
                     %tr
                       %td.email-mini-hashtag-img-td
-                        - accounts.each do |account|
+                        - recent_tag_users(hashtag).each do |account|
                           %span.email-mini-hashtag-img-span
                             = image_tag full_asset_url(account.avatar.url), alt: '', width: 16, height: 16
                       %td


### PR DESCRIPTION
This is a large amount of inline ruby code for a view. There's a similar helper a few lines below this one in view, moving to similar spot.

I chose to do zero refactor here and just pull out the helper method. Possible followup:

- More broadly for this welcome view, I still think some of the setup could benefit from a welcome/onboarding/etc presenter along the lines of - https://github.com/mastodon/mastodon/pull/32859 - may take another crack at that
- In this method specifically, we could probably grab the accounts directly instead of getting statuses and then ruby-mapping through them