### PR TITLE
Rely on `mail_to` helper default name arg value

### DIFF
--- a/app/views/auth/confirmations/captcha.html.haml
+++ b/app/views/auth/confirmations/captcha.html.haml
@@ -14,7 +14,7 @@
 
   = render_captcha
 
-  %p.lead= t('auth.captcha_confirmation.help_html', email: mail_to(Setting.site_contact_email, nil))
+  %p.lead= t('auth.captcha_confirmation.help_html', email: mail_to(Setting.site_contact_email))
 
   .actions
     = form.button t('challenge.confirm'),

--- a/app/views/auth/sessions/two_factor/_otp_authentication_form.html.haml
+++ b/app/views/auth/sessions/two_factor/_otp_authentication_form.html.haml
@@ -16,7 +16,7 @@
     = f.button :button, t('auth.login'), type: :submit
 
   - if Setting.site_contact_email.present?
-    %p.hint.subtle-hint= t('users.otp_lost_help_html', email: mail_to(Setting.site_contact_email, nil))
+    %p.hint.subtle-hint= t('users.otp_lost_help_html', email: mail_to(Setting.site_contact_email))
 
   - if webauthn_enabled?
     .form-footer


### PR DESCRIPTION
The default second (name) arg value here is `nil`, and produces the same output with or without this argument sent in.