### PR TITLE
Use strict locals and remove unused value in card partial

### DIFF
--- a/app/views/application/_card.html.haml
+++ b/app/views/application/_card.html.haml
@@ -1,8 +1,7 @@
-- account_url = local_assigns[:admin] ? admin_account_path(account.id) : ActivityPub::TagManager.instance.url_for(account)
-- compact ||= false
+-# locals: (account:, compact: false)
 
 .card.h-card
-  = link_to account_url, target: '_blank', rel: 'noopener' do
+  = link_to ActivityPub::TagManager.instance.url_for(account), target: '_blank', rel: 'noopener' do
     - unless compact
       .card__img
         = image_tag account.header.url, alt: ''


### PR DESCRIPTION
Related changes:

- It seems like the `admin` local var check here has existed since the initial commit, but has never actually been used by anything calling this partial. Remove that check and just use the version from the "tag manager" being used everywhere now.
- For `compact` (which is still used from one spot), rely on strict locals to set the default value

Side note - possible style regression on the card appearance (note corners/borders):

<img width="605" height="442" alt="Screenshot 2025-08-26 at 12 10 26" src="https://github.com/user-attachments/assets/f61ecd3a-fac1-45f6-99ff-8606cbaab33b" />
