### PR TITLE
Use target account from `group_by` result in admin/reports/index

### DIFF
--- a/app/views/admin/reports/index.html.haml
+++ b/app/views/admin/reports/index.html.haml
@@ -30,8 +30,7 @@
       %button.button= t('admin.accounts.search')
       = link_to t('admin.accounts.reset'), admin_reports_path, class: 'button button--dangerous'
 
-- @reports.group_by(&:target_account_id).each_value do |reports|
-  - target_account = reports.first.target_account
+- @reports.group_by(&:target_account).each do |target_account, reports|
   .report-card
     .report-card__profile
       = account_link_to target_account, '', path: admin_account_path(target_account.id)


### PR DESCRIPTION
These records are already loaded from the initial query which gets the reports, so there's no extra query here.