### PR TITLE
Fix streaming and handling of `quoted_update` notifications

### DIFF
--- a/app/javascript/mastodon/actions/notification_groups.ts
+++ b/app/javascript/mastodon/actions/notification_groups.ts
@@ -30,9 +30,20 @@ import { importFetchedAccounts, importFetchedStatuses } from './importer';
 import { NOTIFICATIONS_FILTER_SET } from './notifications';
 import { saveSettings } from './settings';
 
+function notificationTypeForFilter(type: NotificationType) {
+  if (type === 'quoted_update') return 'update';
+  else return type;
+}
+
+function notificationTypeForQuickFilter(type: NotificationType) {
+  if (type === 'quoted_update') return 'update';
+  else if (type === 'quote') return 'mention';
+  else return type;
+}
+
 function excludeAllTypesExcept(filter: string) {
   return allNotificationTypes.filter(
-    (item) => item !== filter && !(item === 'quote' && filter === 'mention'),
+    (item) => notificationTypeForQuickFilter(item) !== filter,
   );
 }
 
@@ -157,16 +168,17 @@ export const processNewNotificationForGroups = createAppAsyncThunk(
 
     const showInColumn =
       activeFilter === 'all'
-        ? notificationShows[notification.type] !== false
-        : activeFilter === notification.type ||
-          (activeFilter === 'mention' && notification.type === 'quote');
+        ? notificationShows[notificationTypeForFilter(notification.type)] !==
+          false
+        : activeFilter === notificationTypeForQuickFilter(notification.type);
 
     if (!showInColumn) return;
 
     if (
       (notification.type === 'mention' ||
+        notification.type === 'quote' ||
         notification.type === 'update' ||
-        notification.type === 'quote') &&
+        notification.type === 'quoted_update') &&
       notification.status?.filtered
     ) {
       const filters = notification.status.filtered.filter((result) =>

--- a/app/javascript/mastodon/actions/notifications.js
+++ b/app/javascript/mastodon/actions/notifications.js
@@ -31,7 +31,7 @@ export function updateNotifications(notification, intlMessages, intlLocale) {
 
     let filtered = false;
 
-    if (['mention', 'status', 'quote'].includes(notification.type) && notification.status.filtered) {
+    if (['mention', 'quote', 'status'].includes(notification.type) && notification.status.filtered) {
       const filters = notification.status.filtered.filter(result => result.filter.context.includes('notifications'));
 
       if (filters.some(result => result.filter.filter_action === 'hide')) {

--- a/app/javascript/mastodon/api_types/notifications.ts
+++ b/app/javascript/mastodon/api_types/notifications.ts
@@ -7,7 +7,7 @@ import type { ApiReportJSON } from './reports';
 import type { ApiStatusJSON } from './statuses';
 
 // See app/model/notification.rb
-export const allNotificationTypes = [
+export const allNotificationTypes: NotificationType[] = [
   'follow',
   'follow_request',
   'favourite',

--- a/app/serializers/rest/notification_serializer.rb
+++ b/app/serializers/rest/notification_serializer.rb
@@ -21,7 +21,7 @@ class REST::NotificationSerializer < ActiveModel::Serializer
   end
 
   def status_type?
-    [:favourite, :reblog, :status, :mention, :poll, :update, :quote].include?(object.type)
+    [:favourite, :reblog, :status, :mention, :poll, :update, :quoted_update, :quote].include?(object.type)
   end
 
   def report_type?


### PR DESCRIPTION
Fetching the notifications worked correctly, but the streaming events were lacking the status, and the client-side code applied filtering incorrectly.