### PR TITLE
Add helper method to get "action explanation" text in report action preview page

### DIFF
--- a/app/helpers/admin/reports_helper.rb
+++ b/app/helpers/admin/reports_helper.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Admin::ReportsHelper
+  def explanation_key(action)
+    explanation_mapping.fetch(action) { action }
+  end
+
+  private
+
+  def explanation_mapping
+    {
+      'delete' => 'delete_statuses',
+      'mark_as_sensitive' => 'mark_statuses_as_sensitive',
+    }
+  end
+end

--- a/app/views/admin/reports/actions/preview.html.haml
+++ b/app/views/admin/reports/actions/preview.html.haml
@@ -1,5 +1,4 @@
 - target_acct = @report.target_account.acct
-- warning_action = { 'delete' => 'delete_statuses', 'mark_as_sensitive' => 'mark_statuses_as_sensitive' }.fetch(@moderation_action, @moderation_action)
 
 - content_for :page_title do
   = t('admin.reports.confirm_action', acct: target_acct)
@@ -26,8 +25,8 @@
     %p.hint= t('admin.reports.summary.preview_preamble_html', acct: target_acct)
 
     .strike-card
-      - unless warning_action == 'none'
-        %p= t "user_mailer.warning.explanation.#{warning_action}", instance: Rails.configuration.x.local_domain
+      - unless @moderation_action == 'none'
+        %p= t "user_mailer.warning.explanation.#{explanation_key(@moderation_action)}", instance: Rails.configuration.x.local_domain
 
       .fields-group
         = form.text_area :text,


### PR DESCRIPTION
Main thing here is just to pull out some inline ruby logic out of view and into helper.

Separately ... I didn't change it here, but I can't figure out if/how the `... = 'none'` check will ever be hit. I can think of ways that value might wind up being nil/blank, but not `'none'` specifically. Maybe I'm missing something there.

Also separately ... it might be even better here to just update all the values from the forms and i18n keys to be the same, and remove this mapping entirely? Presumably we'd want to leave the i18n alone (reduce churn there) and update the views/forms? Probably harmless since it's all internal admin pages stuff and no public API impacted? Let me know if that's preferred either instead of or in addition to this change.