### PR TITLE
Add partials for status list in report action preview page

### DIFF
--- a/app/controllers/admin/reports/actions_controller.rb
+++ b/app/controllers/admin/reports/actions_controller.rb
@@ -6,6 +6,7 @@ class Admin::Reports::ActionsController < Admin::BaseController
   def preview
     authorize @report, :show?
     @moderation_action = action_from_button
+    @statuses = @report.statuses.includes(:application, :media_attachments)
   end
 
   def create

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -79,6 +79,10 @@ class Report < ApplicationRecord
     Status.with_discarded.where(id: status_ids)
   end
 
+  def deleted_status_ids
+    status_ids.difference(statuses.pluck(:id))
+  end
+
   def media_attachments_count
     statuses_to_query = []
     count = 0

--- a/app/views/admin/reports/actions/_deleted_status.html.haml
+++ b/app/views/admin/reports/actions/_deleted_status.html.haml
@@ -1,0 +1,4 @@
+.strike-card__statuses-list__item
+  .one-liner= t('disputes.strikes.status', id: status_id)
+  .strike-card__statuses-list__item__meta
+    = t('disputes.strikes.status_removed')

--- a/app/views/admin/reports/actions/_status.html.haml
+++ b/app/views/admin/reports/actions/_status.html.haml
@@ -1,0 +1,13 @@
+.strike-card__statuses-list__item
+  .one-liner
+    .emojify= one_line_preview(status)
+    - status.ordered_media_attachments.each do |media|
+      %abbr{ title: media.description }
+        = material_symbol 'link'
+        = media.file_file_name
+  .strike-card__statuses-list__item__meta
+    = link_to ActivityPub::TagManager.instance.url_for(status), target: '_blank', rel: 'noopener' do
+      %time.formatted{ datetime: status.created_at.iso8601, title: l(status.created_at) }= l(status.created_at)
+    - if status.application.present?
+      ·
+      = status.application.name

--- a/app/views/admin/reports/actions/preview.html.haml
+++ b/app/views/admin/reports/actions/preview.html.haml
@@ -50,28 +50,8 @@
           %strong= t('user_mailer.warning.statuses')
 
         .strike-card__statuses-list
-          - status_map = @report.statuses.includes(:application, :media_attachments).index_by(&:id)
-
-          - @report.status_ids.each do |status_id|
-            .strike-card__statuses-list__item
-              - if (status = status_map[status_id.to_i])
-                .one-liner
-                  .emojify= one_line_preview(status)
-
-                  - status.ordered_media_attachments.each do |media_attachment|
-                    %abbr{ title: media_attachment.description }
-                      = material_symbol 'link'
-                      = media_attachment.file_file_name
-                .strike-card__statuses-list__item__meta
-                  = link_to ActivityPub::TagManager.instance.url_for(status), target: '_blank', rel: 'noopener' do
-                    %time.formatted{ datetime: status.created_at.iso8601, title: l(status.created_at) }= l(status.created_at)
-                  - unless status.application.nil?
-                    ·
-                    = status.application.name
-              - else
-                .one-liner= t('disputes.strikes.status', id: status_id)
-                .strike-card__statuses-list__item__meta
-                  = t('disputes.strikes.status_removed')
+          = render partial: 'status', collection: @statuses
+          = render partial: 'deleted_status', collection: @report.deleted_status_ids, as: :status_id
 
     %hr.spacer/
 

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -13,6 +13,17 @@ RSpec.describe Report do
     end
   end
 
+  describe '#deleted_status_ids' do
+    let!(:status) { Fabricate :status }
+    let(:report) { Fabricate.build :report, status_ids: [deleted, status.id] }
+    let(:deleted) { 123_123_123 }
+
+    it 'returns ids of stored statuses which no longer exist' do
+      expect(report.deleted_status_ids)
+        .to contain_exactly(deleted)
+    end
+  end
+
   describe 'media_attachments_count' do
     it 'returns count of media attachments in statuses' do
       status1 = Fabricate(:status, ordered_media_attachment_ids: [1, 2])


### PR DESCRIPTION
Related changes:

- Pull the loading of the statuses with included application/attachments out of the view render and into control
- The previous view logic was to first build a map of all still-existing statuses, then loop through all the status ids, check whether they were in that map or not, and either render the status information or the missing information ... update this to loop separately first through all existing statuses, and then through all missing statuses -- this is technically a visual change in that the ordering will now always put all the missing statuses (if any) at the end of the list. This is probably a small improvement (I suspect they are the least interesting/important portion of this list most of the time), but wanted to note it.
- Pull out partials both for the existing and missing statuses, so we can collection render both of those