### PR TITLE
Add `TermsOfService#usable_effective_date` to wrap up default value

### DIFF
--- a/app/views/terms_of_service_interstitial/show.html.haml
+++ b/app/views/terms_of_service_interstitial/show.html.haml
@@ -6,8 +6,10 @@
 .simple_form
   %h1.title= t('terms_of_service_interstitial.title', domain: site_hostname)
 
-  - effective_date = @terms_of_service.effective_date || Time.zone.today
-  %p.lead= effective_date.past? ? t('terms_of_service_interstitial.past_preamble_html') : t('terms_of_service_interstitial.future_preamble_html', date: l(effective_date))
+  - if @terms_of_service.usable_effective_date.past?
+    %p.lead= t('terms_of_service_interstitial.past_preamble_html')
+  - else
+    %p.lead= t('terms_of_service_interstitial.future_preamble_html', date: l(@terms_of_service.usable_effective_date))
 
   %p.lead= t('user_mailer.terms_of_service_changed.agreement', domain: site_hostname)
 

--- a/app/views/user_mailer/terms_of_service_changed.html.haml
+++ b/app/views/user_mailer/terms_of_service_changed.html.haml
@@ -9,7 +9,7 @@
       %table.email-inner-card-table{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
         %tr
           %td.email-inner-card-td.email-prose
-            %p= t('user_mailer.terms_of_service_changed.description_html', path: terms_of_service_version_url(date: @terms_of_service.effective_date), domain: site_hostname, date: l(@terms_of_service.effective_date || Time.zone.today))
+            %p= t('user_mailer.terms_of_service_changed.description_html', path: terms_of_service_version_url(date: @terms_of_service.effective_date), domain: site_hostname, date: l(@terms_of_service.usable_effective_date))
             %p
               %strong= t('user_mailer.terms_of_service_changed.changelog')
             = markdown(@terms_of_service.changelog)

--- a/app/views/user_mailer/terms_of_service_changed.text.erb
+++ b/app/views/user_mailer/terms_of_service_changed.text.erb
@@ -2,7 +2,7 @@
 
 ===
 
-<%= t('user_mailer.terms_of_service_changed.description', domain: site_hostname, date: l(@terms_of_service.effective_date || Time.zone.today)) %>
+<%= t('user_mailer.terms_of_service_changed.description', domain: site_hostname, date: l(@terms_of_service.usable_effective_date)) %>
 
 => <%= terms_of_service_version_url(date: @terms_of_service.effective_date) %>
 

--- a/spec/models/terms_of_service_spec.rb
+++ b/spec/models/terms_of_service_spec.rb
@@ -108,6 +108,24 @@ RSpec.describe TermsOfService do
     end
   end
 
+  describe '#usable_effective_date' do
+    subject { terms_of_service.usable_effective_date }
+
+    let(:terms_of_service) { Fabricate.build(:terms_of_service, effective_date:) }
+
+    context 'when effective_date value is set' do
+      let(:effective_date) { 5.days.ago }
+
+      it { is_expected.to eq(effective_date.to_date) }
+    end
+
+    context 'when effective_date value is not set' do
+      let(:effective_date) { nil }
+
+      it { is_expected.to eq(Time.zone.today) }
+    end
+  end
+
   describe '::current' do
     context 'when no terms exist' do
       it 'returns nil' do


### PR DESCRIPTION
Two changes:

- Multiple spots in views were doing this "either the effective date from the record, or today date" logic ... wrap that into a method on the model class
- Extract method for similar default in validation method (in this case, we cant use the just-added method - because it's also handling the scenario where a record might not exist)