### PR TITLE
Remove unneeded type check in `statuses/og_image` partial

### DIFF
--- a/app/views/statuses/_og_description.html.haml
+++ b/app/views/statuses/_og_description.html.haml
@@ -1,4 +1,4 @@
-- description = status_description(activity)
+-# locals(description:)
 
 %meta{ name: 'description', content: description }/
 = opengraph 'og:description', description

--- a/app/views/statuses/_og_image.html.haml
+++ b/app/views/statuses/_og_image.html.haml
@@ -1,6 +1,6 @@
-- if activity.is_a?(Status) && (activity.non_sensitive_with_media? || (activity.with_media? && Setting.preview_sensitive_media))
+- if status.non_sensitive_with_media? || (status.with_media? && Setting.preview_sensitive_media)
   - player_card = false
-  - activity.ordered_media_attachments.each do |media|
+  - status.ordered_media_attachments.each do |media|
     - if media.image?
       = opengraph 'og:image', full_asset_url(media.file.url(:original))
       = opengraph 'og:image:type', media.file_content_type

--- a/app/views/statuses/_og_image.html.haml
+++ b/app/views/statuses/_og_image.html.haml
@@ -1,5 +1,6 @@
+-# locals(status:, account:)
+
 - if status.non_sensitive_with_media? || (status.with_media? && Setting.preview_sensitive_media)
-  - player_card = false
   - status.ordered_media_attachments.each do |media|
     - if media.image?
       = opengraph 'og:image', full_asset_url(media.file.url(:original))
@@ -10,7 +11,6 @@
       - if media.description.present?
         = opengraph 'og:image:alt', media.description
     - elsif media.video? || media.gifv?
-      - player_card = true
       = opengraph 'og:image', full_asset_url(media.file.url(:small))
       = opengraph 'og:image:type', 'image/png'
       - unless media.file.meta.nil?
@@ -28,7 +28,6 @@
         = opengraph 'twitter:player:width', media.file.meta.dig('original', 'width')
         = opengraph 'twitter:player:height', media.file.meta.dig('original', 'height')
     - elsif media.audio?
-      - player_card = true
       = opengraph 'og:image', full_asset_url(account.avatar.url(:original))
       = opengraph 'og:image:width', '400'
       = opengraph 'og:image:height', '400'
@@ -40,7 +39,7 @@
       = opengraph 'twitter:player:stream:content_type', media.file_content_type
       = opengraph 'twitter:player:width', '670'
       = opengraph 'twitter:player:height', '380'
-  - if player_card
+  - if status.ordered_media_attachments.any?(&:larger_media_format?)
     = opengraph 'twitter:card', 'player'
   - else
     = opengraph 'twitter:card', 'summary_large_image'

--- a/app/views/statuses/show.html.haml
+++ b/app/views/statuses/show.html.haml
@@ -19,6 +19,6 @@
   = opengraph 'profile:username', acct(@account)[1..]
 
   = render 'og_description', activity: @status
-  = render 'og_image', activity: @status, account: @account
+  = render 'og_image', status: @status, account: @account
 
 = render 'shared/web_app'

--- a/app/views/statuses/show.html.haml
+++ b/app/views/statuses/show.html.haml
@@ -18,7 +18,7 @@
     = opengraph 'og:locale', @status.language
   = opengraph 'profile:username', acct(@account)[1..]
 
-  = render 'og_description', activity: @status
+  = render 'og_description', description: status_description(@status)
   = render 'og_image', status: @status, account: @account
 
 = render 'shared/web_app'


### PR DESCRIPTION
These partials were originally extracted from a larger view - https://github.com/mastodon/mastodon/commit/73b0af5c938b49ef0a4a21921b41a3b1bcd4e05e#diff-008f6f39e1453f70aacd986993be7faab4211207b57d5480f68c45da8aa8f311R9-R10 - when there were "stream entries" which could pass (potentially non-status) activities in. But, ever since - https://github.com/mastodon/mastodon/pull/11247/files#diff-bf84098206e45d35b1d352adfd5b72d78fdeaf0cf64984d0b3dd83e8f0ce63daR16-R17 - the partials are only used by the status show view, and probably this simplification could have been done then.

Changes to `og_image` partial:

- Since we only pass in `Status`, remove the `is_a?` check
- Also since the original partial, we added a `larger_media_format?` method on `MediaAttachment` which has the exact check we want for when to add the "player" opengraph markup ... use that method instead of accumulating true/false into the local `player_card` var
- In the calling view, update passed in var name from activity to status, since its always that

While in there - also noticed similar disconnect to the `og_description` partial, and did similar change there.

More future stuff...

- We could probably skip passing in `account` to this partial ... only used once, and is available from `status`
- There are separate `accounts/og` and `shared/og` partials which do both description and image info in one partial. Given these are only used in this one spot, and given how small the description one is, they could be combined?
- There are a bunch of shared numbers between the og metadata and `player` view template ... could pull out to helpers/constants (separately - the `player` view has some really large ruby blocks that are maybe better as helper methods as well)