### PR TITLE
Use collection partial for rule translation in signup flow

### DIFF
--- a/app/controllers/auth/registrations_controller.rb
+++ b/app/controllers/auth/registrations_controller.rb
@@ -130,13 +130,17 @@ class Auth::RegistrationsController < Devise::RegistrationsController
   end
 
   def require_rules_acceptance!
-    return if @rules.empty? || (session[:accept_token].present? && params[:accept] == session[:accept_token])
+    return if @rules.empty? || validated_accept_token?
 
     @accept_token = session[:accept_token] = SecureRandom.hex
     @invite_code  = invite_code
 
     @rule_translations = @rules.map { |rule| rule.translation_for(I18n.locale) }
     render :rules
+  end
+
+  def validated_accept_token?
+    session[:accept_token].present? && params[:accept] == session[:accept_token]
   end
 
   def is_flashing_format? # rubocop:disable Naming/PredicatePrefix

--- a/app/controllers/auth/registrations_controller.rb
+++ b/app/controllers/auth/registrations_controller.rb
@@ -135,6 +135,7 @@ class Auth::RegistrationsController < Devise::RegistrationsController
     @accept_token = session[:accept_token] = SecureRandom.hex
     @invite_code  = invite_code
 
+    @rule_translations = @rules.map { |rule| rule.translation_for(I18n.locale) }
     render :rules
   end
 

--- a/app/controllers/auth/registrations_controller.rb
+++ b/app/controllers/auth/registrations_controller.rb
@@ -133,9 +133,9 @@ class Auth::RegistrationsController < Devise::RegistrationsController
     return if @rules.empty? || validated_accept_token?
 
     @accept_token = session[:accept_token] = SecureRandom.hex
-    @invite_code  = invite_code
-
+    @invite_code = invite_code
     @rule_translations = @rules.map { |rule| rule.translation_for(I18n.locale) }
+
     render :rules
   end
 

--- a/app/views/auth/registrations/rules.html.haml
+++ b/app/views/auth/registrations/rules.html.haml
@@ -17,7 +17,7 @@
     %p.lead= t('auth.rules.preamble', domain: site_hostname)
 
   %ol.rules-list
-    = render @rule_translations
+    = render collection: @rule_translations, partial: 'auth/rule_translations/rule_translation'
 
   .stacked-actions
     - accept_path = @invite_code.present? ? public_invite_url(invite_code: @invite_code, accept: @accept_token) : new_user_registration_path(accept: @accept_token)

--- a/app/views/auth/registrations/rules.html.haml
+++ b/app/views/auth/registrations/rules.html.haml
@@ -17,12 +17,7 @@
     %p.lead= t('auth.rules.preamble', domain: site_hostname)
 
   %ol.rules-list
-    - @rules.each do |rule|
-      - translation = rule.translation_for(I18n.locale.to_s)
-      %li
-        %button{ type: 'button', aria: { expanded: 'false' } }
-          .rules-list__text= translation.text
-          .rules-list__hint= translation.hint
+    = render @rule_translations
 
   .stacked-actions
     - accept_path = @invite_code.present? ? public_invite_url(invite_code: @invite_code, accept: @accept_token) : new_user_registration_path(accept: @accept_token)

--- a/app/views/auth/rule_translations/_rule_translation.html.haml
+++ b/app/views/auth/rule_translations/_rule_translation.html.haml
@@ -1,0 +1,4 @@
+%li
+  %button{ type: 'button', aria: { expanded: 'false' } }
+    .rules-list__text= rule_translation.text
+    .rules-list__hint= rule_translation.hint


### PR DESCRIPTION
Main change here -- in the aftermath of adding rule translations, this view loop is basically rendering a collection of `RuleTranslation`, not `Rule`. Pull out a partial, and do a collection render.

At first I thought I'd be able to change the controller to just load `RuleTranslation` directly - but because the `translation_for` method has special handling for untranslated rules, its not that simple, so I kept the existing logic there, just moved to controller.

Side changes:

- I believe the previous call to `set_locale` here is extraneous? We are already in an action where that same method has been called as an around action, and I can't see anything which merits the double call. It's not really explained in the [initial commit](https://github.com/mastodon/mastodon/pull/19296/files#diff-039a93e4b95a7e308eb53d930f7a6e07e389e1e748e0fb35f15ca29a65ced88eR152) and there are no related specs.
- Pull out method grouping the "are we already in a valid accept token scenario?" logic

Future ideas:

- It's a little odd to do so much i-var setup and `render` here in a before action (as opposed to detecing the rules and lack of accept token, and redirecting). At first glance I thought it'd be straightforward to update, but I suspect there are more interactions with other portions of the sign up flow. Needs more review.
