### PR TITLE
Fix: persist poll type in status edits (multiple choice / single choice)

### DIFF
--- a/app/javascript/mastodon/features/ui/components/compare_history_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/compare_history_modal.jsx
@@ -3,6 +3,8 @@ import { PureComponent } from 'react';
 
 import { FormattedMessage } from 'react-intl';
 
+import classNames from 'classnames';
+
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
 
@@ -86,13 +88,17 @@ class CompareHistoryModal extends PureComponent {
                 <ul>
                   {currentVersion.getIn(['poll', 'options']).map(option => (
                     <li key={option.get('title')}>
-                      <span className='poll__input disabled' />
+                      <label className="poll__option disabled">
+                        <span className={classNames('poll__input', {
+                          checkbox: currentVersion.getIn(['poll', 'multiple']),
+                        })} />
 
-                      <span
-                        className='poll__option__text translate'
-                        dangerouslySetInnerHTML={{ __html: emojify(escapeTextContentForBrowser(option.get('title')), emojiMap) }}
-                        lang={language}
-                      />
+                        <span
+                          className='poll__option__text translate'
+                          dangerouslySetInnerHTML={{ __html: emojify(escapeTextContentForBrowser(option.get('title')), emojiMap) }}
+                          lang={language}
+                        />
+                      </label>
                     </li>
                   ))}
                 </ul>

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -1873,7 +1873,7 @@ a.sparkline {
   font-size: 15px;
   line-height: 22px;
 
-  li {
+  > li {
     counter-increment: step 1;
     padding-inline-start: 2.5rem;
     padding-bottom: 8px;

--- a/app/javascript/styles/mastodon/polls.scss
+++ b/app/javascript/styles/mastodon/polls.scss
@@ -102,7 +102,8 @@
       cursor: pointer;
     }
 
-    &.editable {
+    &.editable,
+    &.disabled {
       align-items: center;
       overflow: visible;
     }
@@ -160,7 +161,8 @@
     }
   }
 
-  &__option.editable &__input {
+  &__option.editable &__input,
+  &__option.disabled &__input {
     &:active,
     &:focus,
     &:hover {

--- a/app/models/concerns/status/snapshot_concern.rb
+++ b/app/models/concerns/status/snapshot_concern.rb
@@ -22,6 +22,7 @@ module Status::SnapshotConcern
       sensitive: sensitive,
       ordered_media_attachment_ids: ordered_media_attachment_ids&.dup || media_attachments.pluck(:id),
       media_descriptions: ordered_media_attachments.map(&:description),
+      poll_multiple_choice: preloadable_poll&.multiple,
       poll_options: preloadable_poll&.options&.dup,
       account_id: account_id || self.account_id,
       created_at: at_time || edited_at,

--- a/app/models/status_edit.rb
+++ b/app/models/status_edit.rb
@@ -43,16 +43,36 @@ class StatusEdit < ApplicationRecord
   scope :ordered, -> { order(id: :asc) }
 
   delegate :local?, :application, :edited?, :edited_at,
-           :discarded?, :visibility, :language, to: :status
+           :discarded?, :reply?, :visibility, :language, to: :status
 
   def with_media?
     ordered_media_attachments.any?
   end
 
+  def with_poll?
+    poll_options.present?
+  end
+
+  def poll
+    return @poll if defined?(@poll)
+    return @poll = nil if poll_options.blank?
+
+    @poll = Poll.new({
+      options: poll_options,
+      account_id: account_id,
+      status_id: status_id,
+    })
+  end
+
+  alias preloadable_poll poll
+
   def emojis
     return @emojis if defined?(@emojis)
 
-    @emojis = CustomEmoji.from_text([spoiler_text, text].join(' '), status.account.domain)
+    fields  = [spoiler_text, text]
+    fields += preloadable_poll.options unless preloadable_poll.nil?
+
+    @emojis = CustomEmoji.from_text(fields.join(' '), status.account.domain)
   end
 
   def ordered_media_attachments

--- a/app/models/status_edit.rb
+++ b/app/models/status_edit.rb
@@ -5,17 +5,18 @@
 # Table name: status_edits
 #
 #  id                           :bigint(8)        not null, primary key
-#  status_id                    :bigint(8)        not null
-#  account_id                   :bigint(8)
-#  text                         :text             default(""), not null
-#  spoiler_text                 :text             default(""), not null
-#  created_at                   :datetime         not null
-#  updated_at                   :datetime         not null
-#  ordered_media_attachment_ids :bigint(8)        is an Array
 #  media_descriptions           :text             is an Array
+#  ordered_media_attachment_ids :bigint(8)        is an Array
+#  poll_multiple_choice         :boolean          default(FALSE), not null
 #  poll_options                 :string           is an Array
 #  sensitive                    :boolean
+#  spoiler_text                 :text             default(""), not null
+#  text                         :text             default(""), not null
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  account_id                   :bigint(8)
 #  quote_id                     :bigint(8)
+#  status_id                    :bigint(8)        not null
 #
 
 class StatusEdit < ApplicationRecord
@@ -58,6 +59,7 @@ class StatusEdit < ApplicationRecord
     return @poll = nil if poll_options.blank?
 
     @poll = Poll.new({
+      multiple: poll_multiple_choice,
       options: poll_options,
       account_id: account_id,
       status_id: status_id,

--- a/app/serializers/rest/status_edit_serializer.rb
+++ b/app/serializers/rest/status_edit_serializer.rb
@@ -12,14 +12,10 @@ class REST::StatusEditSerializer < ActiveModel::Serializer
 
   has_one :quote, serializer: REST::QuoteSerializer, if: -> { object.quote_id.present? }
 
-  attribute :poll, if: -> { object.poll_options.present? }
+  has_one :poll, serializer: REST::PollSerializer, if: -> { object.with_poll? }
 
   def content
     status_content_format(object)
-  end
-
-  def poll
-    { options: object.poll_options.map { |title| { title: title } } }
   end
 
   def quote

--- a/app/views/admin/shared/_status_attachments.html.haml
+++ b/app/views/admin/shared/_status_attachments.html.haml
@@ -1,3 +1,18 @@
+- if status.with_poll?
+  .poll
+    %ul
+      - status.preloadable_poll.options.each_with_index do |option, _index|
+        %li
+          %label.poll__option.disabled<>
+            - if status.preloadable_poll.multiple?
+              %span.poll__input.checkbox{ role: 'checkbox', 'aria-label': option }
+            - else
+              %span.poll__input{ role: 'radio', 'aria-label': option }
+            %span.poll__option__text
+              = prerender_custom_emojis(html_aware_format(option, status.local?, multiline: false), status.emojis)
+    %button.button.button-secondary{ disabled: true }
+      = t('polls.vote')
+
 - if status.with_media?
   - if status.ordered_media_attachments.first.video?
     = render_video_component(status, visible: false)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1740,6 +1740,7 @@ en:
       self_vote: You cannot vote in your own polls
       too_few_options: must have more than one item
       too_many_options: can't contain more than %{max} items
+    vote: Vote
   preferences:
     other: Other
     posting_defaults: Posting defaults

--- a/db/migrate/20250827201410_add_poll_multiple_choice_to_status_edits.rb
+++ b/db/migrate/20250827201410_add_poll_multiple_choice_to_status_edits.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPollMultipleChoiceToStatusEdits < ActiveRecord::Migration[8.0]
+  def change
+    add_column :status_edits, :poll_multiple_choice, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_20_084312) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_27_201410) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -1081,6 +1081,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_20_084312) do
     t.string "poll_options", array: true
     t.boolean "sensitive"
     t.bigint "quote_id"
+    t.boolean "poll_multiple_choice", default: false, null: false
     t.index ["account_id"], name: "index_status_edits_on_account_id"
     t.index ["status_id"], name: "index_status_edits_on_status_id"
   end

--- a/spec/fabricators/status_edit_fabricator.rb
+++ b/spec/fabricators/status_edit_fabricator.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
 Fabricator(:status_edit) do
+  account { Fabricate.build(:account) }
   status { Fabricate.build(:status) }
+  poll_options { |attrs| attrs[:poll_options] }
 end

--- a/spec/serializers/rest/status_edit_serializer_spec.rb
+++ b/spec/serializers/rest/status_edit_serializer_spec.rb
@@ -6,17 +6,42 @@ RSpec.describe REST::StatusEditSerializer do
   subject do
     serialized_record_json(
       status_edit,
-      described_class
+      described_class,
+      options: {
+        scope: current_user,
+        scope_name: :current_user,
+      }
     )
   end
 
+  let(:current_user) { Fabricate(:user) }
   let(:status_edit) { Fabricate(:status_edit) }
+
+  it 'does not contain a poll' do
+    expect(subject).to_not include('poll')
+  end
 
   context 'when created_at is populated' do
     it 'parses as RFC 3339 datetime' do
       expect(subject)
         .to include(
           'created_at' => match_api_datetime_format
+        )
+    end
+  end
+
+  context 'when poll_options is populated' do
+    let(:status_edit) { Fabricate(:status_edit, poll_options: %w(Foo Bar)) }
+
+    it 'renders the poll' do
+      expect(subject)
+        .to include(
+          'poll' => include(
+            'options' => contain_exactly(
+              include('title' => 'Foo'),
+              include('title' => 'Bar')
+            )
+          )
         )
     end
   end


### PR DESCRIPTION
Currently status edits does not keep track of the type of poll, only the options in the poll. This PR builds off #35933 to implement tracking the type of poll in a status edit, which means the correct properties for the poll automatically pass down to the frontend via the API:

<img width="545" height="661" alt="Screenshot 2025-08-27 at 22 45 51" src="https://github.com/user-attachments/assets/72498878-997e-4bc0-8789-1763352c082b" />

I'm not sure if the migration here is safe, since we are setting `null: false` (but there is a default).

I've also updated the frontend to support rendering multiple versus single choice polls in status edit history modal (the Admin UI PR already added support for multiple choice polls). Before:

<img width="3456" height="1244" alt="image" src="https://github.com/user-attachments/assets/bc7a0a27-22d8-4e08-93ea-61f3291d33aa" />


after: 

<img width="3456" height="1244" alt="image" src="https://github.com/user-attachments/assets/a675fc0b-f2c1-4f70-bf4a-0cc7f4fc9840" />

(in the above, I manually went in and toggled the database flag for multiple choice to true to test the rendering)