### PR TITLE
Improve display of content warnings in Admin UI

### DIFF
--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -1946,7 +1946,6 @@ a.sparkline {
 .status__card {
   padding: 15px;
   border-radius: 4px;
-  background: $ui-base-color;
   font-size: 15px;
   line-height: 20px;
   word-wrap: break-word;
@@ -1965,8 +1964,50 @@ a.sparkline {
   .status__content {
     padding-top: 0;
 
-    summary {
-      display: list-item;
+    > details {
+      summary {
+        display: block;
+        box-sizing: border-box;
+        background: var(--nested-card-background);
+        color: var(--nested-card-text);
+        border: var(--nested-card-border);
+        border-radius: 8px;
+        padding: 8px 13px;
+        position: relative;
+        font-size: 15px;
+        line-height: 22px;
+        cursor: pointer;
+
+        &::after {
+          content: attr(data-show, 'Show more');
+          margin-top: 8px;
+          display: block;
+          font-size: 15px;
+          line-height: 20px;
+          color: $highlight-text-color;
+          cursor: pointer;
+          border: 0;
+          background: transparent;
+          padding: 0;
+          text-decoration: none;
+          font-weight: 500;
+        }
+
+        &:hover,
+        &:focus-visible {
+          &::after {
+            text-decoration: underline !important;
+          }
+        }
+      }
+
+      &[open] summary {
+        margin-bottom: 16px;
+
+        &::after {
+          content: attr(data-hide, 'Hide post');
+        }
+      }
     }
   }
 }

--- a/app/views/admin/shared/_status_content.html.haml
+++ b/app/views/admin/shared/_status_content.html.haml
@@ -1,8 +1,14 @@
 .status__content><
   - if status.spoiler_text.present?
     %details<
-      %summary><
-        %strong> Content warning: #{prerender_custom_emojis(h(status.spoiler_text), status.emojis)}
+      %summary{
+        data: {
+          show: t('statuses.content_warnings.show'),
+          hide: t('statuses.content_warnings.hide'),
+        }
+      }><
+        %strong>
+          = prerender_custom_emojis(h(status.spoiler_text), status.emojis)
       = prerender_custom_emojis(status_content_format(status), status.emojis)
       = render partial: 'admin/shared/status_attachments', locals: { status: status.proper }
   - else

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1902,6 +1902,9 @@ en:
         other: "%{count} videos"
     boosted_from_html: Boosted from %{acct_link}
     content_warning: 'Content warning: %{warning}'
+    content_warnings:
+      hide: Hide post
+      show: Show more
     default_language: Same as interface language
     disallowed_hashtags:
       one: 'contained a disallowed hashtag: %{tags}'


### PR DESCRIPTION
This restyles the content warnings in the Admin UI to look more like content warnings in the frontend, without requiring javascript to expand and collapse them. The "show more" and "hide post" are fully localisable too, as the values for this text comes from a translated data attribute.

This PR currently builds of #35933 

Before:

<img width="3456" height="1942" alt="image" src="https://github.com/user-attachments/assets/10bdbf46-5db1-4531-a346-da880758e97a" />


After (collapsed):

<img width="3456" height="1942" alt="image" src="https://github.com/user-attachments/assets/52b89dc9-48f7-48dc-a36d-02688677c1bc" />

After (expanded):

<img width="3456" height="1942" alt="image" src="https://github.com/user-attachments/assets/2c416143-e4b5-4264-b25b-aeb7b4ed47b4" />

## Additional screenshots

Individual status page, before:
<img width="3456" height="1942" alt="image" src="https://github.com/user-attachments/assets/17df47e0-f890-4ff8-9f03-31b4e7544755" />

Individual status page, after:

<img width="3456" height="1942" alt="image" src="https://github.com/user-attachments/assets/16caf67c-54ef-4d14-9c60-586474b13211" />

<img width="3456" height="1942" alt="image" src="https://github.com/user-attachments/assets/a1e9bdf2-85e2-4bcc-ac5f-d3bc6e193e1a" />

