### PR TITLE
Conditionally bump API version depending on quote post feature flag

### DIFF
--- a/lib/mastodon/version.rb
+++ b/lib/mastodon/version.rb
@@ -45,7 +45,7 @@ module Mastodon
 
     def api_versions
       {
-        mastodon: 6,
+        mastodon: Mastodon::Feature.outgoing_quotes_enabled? ? 7 : 6,
       }
     end
 


### PR DESCRIPTION
Having the API version bumped on a conditional feature flag is a bit weird, but in this case, we know quote posts to be the next versioned API change we want to make, and it's around the corner.