### PR TITLE
Consistent usage of constants for `perform_in`

### DIFF
--- a/app/controllers/api/v1/accounts/credentials_controller.rb
+++ b/app/controllers/api/v1/accounts/credentials_controller.rb
@@ -14,7 +14,7 @@ class Api::V1::Accounts::CredentialsController < Api::BaseController
     @account = current_account
     UpdateAccountService.new.call(@account, account_params, raise_error: true)
     current_user.update(user_params) if user_params
-    ActivityPub::UpdateDistributionWorker.perform_in(ActivityPub::UpdateDistributionWorker::DEBOUNCE_DELAY, @account.id)
+    ActivityPub::UpdateDistributionWorker.distribute(@account)
     render json: @account, serializer: REST::CredentialAccountSerializer
   rescue ActiveRecord::RecordInvalid => e
     render json: ValidationErrorFormatter.new(e).as_json, status: 422

--- a/app/controllers/api/v1/profile/avatars_controller.rb
+++ b/app/controllers/api/v1/profile/avatars_controller.rb
@@ -7,7 +7,7 @@ class Api::V1::Profile::AvatarsController < Api::BaseController
   def destroy
     @account = current_account
     UpdateAccountService.new.call(@account, { avatar: nil }, raise_error: true)
-    ActivityPub::UpdateDistributionWorker.perform_in(ActivityPub::UpdateDistributionWorker::DEBOUNCE_DELAY, @account.id)
+    ActivityPub::UpdateDistributionWorker.distribute(@account)
     render json: @account, serializer: REST::CredentialAccountSerializer
   end
 end

--- a/app/controllers/api/v1/profile/headers_controller.rb
+++ b/app/controllers/api/v1/profile/headers_controller.rb
@@ -7,7 +7,7 @@ class Api::V1::Profile::HeadersController < Api::BaseController
   def destroy
     @account = current_account
     UpdateAccountService.new.call(@account, { header: nil }, raise_error: true)
-    ActivityPub::UpdateDistributionWorker.perform_in(ActivityPub::UpdateDistributionWorker::DEBOUNCE_DELAY, @account.id)
+    ActivityPub::UpdateDistributionWorker.distribute(@account)
     render json: @account, serializer: REST::CredentialAccountSerializer
   end
 end

--- a/app/controllers/settings/pictures_controller.rb
+++ b/app/controllers/settings/pictures_controller.rb
@@ -8,7 +8,7 @@ module Settings
     def destroy
       if valid_picture?
         if UpdateAccountService.new.call(@account, { @picture => nil, "#{@picture}_remote_url" => '' })
-          ActivityPub::UpdateDistributionWorker.perform_in(ActivityPub::UpdateDistributionWorker::DEBOUNCE_DELAY, @account.id)
+          ActivityPub::UpdateDistributionWorker.distribute(@account)
           redirect_to settings_profile_path, notice: I18n.t('generic.changes_saved_msg'), status: 303
         else
           redirect_to settings_profile_path

--- a/app/controllers/settings/privacy_controller.rb
+++ b/app/controllers/settings/privacy_controller.rb
@@ -8,7 +8,7 @@ class Settings::PrivacyController < Settings::BaseController
   def update
     if UpdateAccountService.new.call(@account, account_params.except(:settings))
       current_user.update!(settings_attributes: account_params[:settings])
-      ActivityPub::UpdateDistributionWorker.perform_in(ActivityPub::UpdateDistributionWorker::DEBOUNCE_DELAY, @account.id)
+      ActivityPub::UpdateDistributionWorker.distribute(@account)
       redirect_to settings_privacy_path, notice: I18n.t('generic.changes_saved_msg')
     else
       render :show

--- a/app/controllers/settings/profiles_controller.rb
+++ b/app/controllers/settings/profiles_controller.rb
@@ -9,7 +9,7 @@ class Settings::ProfilesController < Settings::BaseController
 
   def update
     if UpdateAccountService.new.call(@account, account_params)
-      ActivityPub::UpdateDistributionWorker.perform_in(ActivityPub::UpdateDistributionWorker::DEBOUNCE_DELAY, @account.id)
+      ActivityPub::UpdateDistributionWorker.distribute(@account)
       redirect_to settings_profile_path, notice: I18n.t('generic.changes_saved_msg')
     else
       @account.build_fields

--- a/app/controllers/settings/verifications_controller.rb
+++ b/app/controllers/settings/verifications_controller.rb
@@ -8,7 +8,7 @@ class Settings::VerificationsController < Settings::BaseController
 
   def update
     if UpdateAccountService.new.call(@account, account_params)
-      ActivityPub::UpdateDistributionWorker.perform_in(ActivityPub::UpdateDistributionWorker::DEBOUNCE_DELAY, @account.id)
+      ActivityPub::UpdateDistributionWorker.distribute(@account)
       redirect_to settings_verification_path, notice: I18n.t('generic.changes_saved_msg')
     else
       render :show

--- a/app/services/vote_service.rb
+++ b/app/services/vote_service.rb
@@ -45,7 +45,7 @@ class VoteService < BaseService
   def distribute_poll!
     return if @poll.hide_totals?
 
-    ActivityPub::DistributePollUpdateWorker.perform_in(3.minutes, @poll.status.id)
+    ActivityPub::DistributePollUpdateWorker.distribute(@poll.status)
   end
 
   def queue_final_poll_check!

--- a/app/workers/activitypub/distribute_poll_update_worker.rb
+++ b/app/workers/activitypub/distribute_poll_update_worker.rb
@@ -4,6 +4,8 @@ class ActivityPub::DistributePollUpdateWorker
   include Sidekiq::Worker
   include Payloadable
 
+  PROCESSING_DELAY = 3.minutes
+
   sidekiq_options queue: 'push', lock: :until_executed, retry: 0
 
   def perform(status_id)
@@ -19,6 +21,10 @@ class ActivityPub::DistributePollUpdateWorker
     relay! if relayable?
   rescue ActiveRecord::RecordNotFound
     true
+  end
+
+  def self.distribute(status)
+    perform_in(PROCESSING_DELAY, status.id)
   end
 
   private

--- a/app/workers/activitypub/update_distribution_worker.rb
+++ b/app/workers/activitypub/update_distribution_worker.rb
@@ -16,6 +16,10 @@ class ActivityPub::UpdateDistributionWorker < ActivityPub::RawDistributionWorker
     true
   end
 
+  def self.distribute(account)
+    perform_in(DEBOUNCE_DELAY, account.id)
+  end
+
   protected
 
   def inboxes


### PR DESCRIPTION
Prior to these changes, there's sort of a mix of styles here ... some spots use a constant, some dont. Some call `to_i` on the value, some dont, etc.

Changes:

- There are many controller spots doing the same call into `ActivityPub::UpdateDistributionWorker` and using a constant it defines ... instead, wrap this in a class method which keeps the constant reference internal to that class.
- Similar change for two spots calling `DistributePollUpdateWorker` as well
- In misc services classes, pull out constants to capture the delay ranges (side note here: sidekiq calls `to_f` on the value passed in here - so its safe to remove the `to_i` we had, and its safe to pass in the duration objects from these ranges ... they will all get cast to float before being queueueued).

Open to diff naming ideas here.

Separately - every single spot calling the update distribution worker comes right after calling the update account service (and I think that goes the other way too -- every spot the service is called also calls the worker) ... should that enqueue just be a side effect of calling that service?

I could PR-separate the "add some constants" portions here from the "use class methods" portions if we like one but not the other.