### PR TITLE
Add coverage for `media#player` scenarios

### DIFF
--- a/spec/requests/media_spec.rb
+++ b/spec/requests/media_spec.rb
@@ -87,4 +87,17 @@ RSpec.describe 'Media' do
       end
     end
   end
+
+  describe 'GET /media/:medium_id/player' do
+    context 'when media type is not large format type' do
+      let(:media) { Fabricate :media_attachment }
+
+      it 'responds with not found' do
+        get medium_player_path(media)
+
+        expect(response)
+          .to have_http_status(404)
+      end
+    end
+  end
 end

--- a/spec/system/media_spec.rb
+++ b/spec/system/media_spec.rb
@@ -4,19 +4,47 @@ require 'rails_helper'
 
 RSpec.describe 'Media' do
   describe 'Player page' do
+    let(:status) { Fabricate :status }
+
+    before { status.media_attachments << media }
+
     context 'when signed in' do
       before { sign_in Fabricate(:user) }
 
-      it 'visits the media player page and renders the media' do
-        status = Fabricate :status
-        media = Fabricate :media_attachment, type: :video
-        status.media_attachments << media
+      context 'when media type is video' do
+        let(:media) { Fabricate :media_attachment, type: :video }
 
-        visit medium_player_path(media)
+        it 'visits the player page and renders media' do
+          visit medium_player_path(media)
 
-        expect(page)
-          .to have_css('body', class: 'player')
-          .and have_css('div[data-component="Video"]')
+          expect(page)
+            .to have_css('body', class: 'player')
+            .and have_css('div[data-component="Video"] video[controls="controls"] source')
+        end
+      end
+
+      context 'when media type is gifv' do
+        let(:media) { Fabricate :media_attachment, type: :gifv }
+
+        it 'visits the player page and renders media' do
+          visit medium_player_path(media)
+
+          expect(page)
+            .to have_css('body', class: 'player')
+            .and have_css('div[data-component="MediaGallery"] video[loop="loop"] source')
+        end
+      end
+
+      context 'when media type is audio' do
+        let(:media) { Fabricate :media_attachment, type: :audio }
+
+        it 'visits the player page and renders media' do
+          visit medium_player_path(media)
+
+          expect(page)
+            .to have_css('body', class: 'player')
+            .and have_css('div[data-component="Audio"] audio source')
+        end
       end
     end
   end


### PR DESCRIPTION
Prep for idea in https://github.com/mastodon/mastodon/pull/35931

Adds request spec for the unsupported media type scenario, and system specs for each of the support types, with some basic "did we put the right component on the page" css checks.