### PR TITLE
Add default quote policy to API

### DIFF
--- a/app/controllers/api/v1/accounts/credentials_controller.rb
+++ b/app/controllers/api/v1/accounts/credentials_controller.rb
@@ -48,6 +48,7 @@ class Api::V1::Accounts::CredentialsController < Api::BaseController
         default_privacy: source_params.fetch(:privacy, @account.user.setting_default_privacy),
         default_sensitive: source_params.fetch(:sensitive, @account.user.setting_default_sensitive),
         default_language: source_params.fetch(:language, @account.user.setting_default_language),
+        default_quote_policy: source_params.fetch(:quote_policy, @account.user.setting_default_quote_policy),
       },
     }
   end

--- a/app/serializers/rest/credential_account_serializer.rb
+++ b/app/serializers/rest/credential_account_serializer.rb
@@ -19,6 +19,7 @@ class REST::CredentialAccountSerializer < REST::AccountSerializer
       discoverable: object.discoverable,
       indexable: object.indexable,
       attribution_domains: object.attribution_domains,
+      quote_policy: user.setting_default_quote_policy,
     }
   end
 

--- a/app/serializers/rest/preferences_serializer.rb
+++ b/app/serializers/rest/preferences_serializer.rb
@@ -4,6 +4,7 @@ class REST::PreferencesSerializer < ActiveModel::Serializer
   attribute :posting_default_privacy, key: 'posting:default:visibility'
   attribute :posting_default_sensitive, key: 'posting:default:sensitive'
   attribute :posting_default_language, key: 'posting:default:language'
+  attribute :posting_default_quote_policy, key: 'posting:default:quote_policy'
 
   attribute :reading_default_sensitive_media, key: 'reading:expand:media'
   attribute :reading_default_sensitive_text, key: 'reading:expand:spoilers'
@@ -11,6 +12,10 @@ class REST::PreferencesSerializer < ActiveModel::Serializer
 
   def posting_default_privacy
     object.user.setting_default_privacy
+  end
+
+  def posting_default_quote_policy
+    object.user.setting_default_quote_policy
   end
 
   def posting_default_sensitive


### PR DESCRIPTION
Fixes #35898

- add `quote_policy` to `GET /api/v1/accounts/verify_credentials` response
- add `quote_policy` to `PATCH /api/v1/accounts/update_credentials` parameters
- add `posting:default:quote_policy` to `GET /api/v1/preferences` response