### PR TITLE
Fix failure to verify changes in api/v1/accounts/credentials spec

### DIFF
--- a/spec/requests/api/v1/accounts/credentials_spec.rb
+++ b/spec/requests/api/v1/accounts/credentials_spec.rb
@@ -101,20 +101,14 @@ RSpec.describe 'credentials API' do
         .to have_http_status(200)
       expect(response.content_type)
         .to start_with('application/json')
-
-      expect(response.parsed_body).to include({
-        source: hash_including({
-          discoverable: true,
-          indexable: true,
-        }),
-        locked: false,
-      })
-
-      expect(ActivityPub::UpdateDistributionWorker)
-        .to have_enqueued_sidekiq_job(user.account_id)
-    end
-
-    def expect_account_updates
+      expect(response.parsed_body)
+        .to include({
+          source: hash_including({
+            discoverable: true,
+            indexable: true,
+          }),
+          locked: false,
+        })
       expect(user.account.reload)
         .to have_attributes(
           display_name: eq("Alice Isn't Dead"),
@@ -123,14 +117,13 @@ RSpec.describe 'credentials API' do
           header: exist,
           attribution_domains: ['example.com']
         )
-    end
-
-    def expect_user_updates
       expect(user.reload)
         .to have_attributes(
           setting_default_privacy: eq('unlisted'),
           setting_default_sensitive: be(true)
         )
+      expect(ActivityPub::UpdateDistributionWorker)
+        .to have_enqueued_sidekiq_job(user.account_id)
     end
   end
 end


### PR DESCRIPTION
Apparently when this was converted from controller spec in https://github.com/mastodon/mastodon/pull/29006/files - these assertions were brought over from the previous controller spec and pulled out to some `expect_` methods (possibly re: the rspec cop config at the time?) ... but not actually called from the example.

Update to just fold them into the example.