### PR TITLE
Remove unused require of `rubygems/package` from ip blocks CLI class

### DIFF
--- a/lib/mastodon/cli/ip_blocks.rb
+++ b/lib/mastodon/cli/ip_blocks.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'rubygems/package'
 require_relative 'base'
 
 module Mastodon::CLI


### PR DESCRIPTION
I'm guessing this was copy/pasted in from the emoji CLI class, which does use `Gem::Package` -- but this one does not.