### PR TITLE
Update Visibility modal copy & preferences link

### DIFF
--- a/app/javascript/mastodon/features/ui/components/visibility_modal.tsx
+++ b/app/javascript/mastodon/features/ui/components/visibility_modal.tsx
@@ -198,10 +198,10 @@ export const VisibilityModal: FC<VisibilityModalProps> = forwardRef(
           <div className='dialog-modal__content__description'>
             <FormattedMessage
               id='visibility_modal.instructions'
-              defaultMessage='Control who can interact with this post. Global settings can be found under <link>Preferences > Other</link>.'
+              defaultMessage='Control who can interact with this post. You can also apply settings to all future posts by navigating to <link>Preferences > Posting defaults</link>.'
               values={{
                 link: (chunks) => (
-                  <a href='/settings/preferences/other'>{chunks}</a>
+                  <a href='/settings/preferences/posting_defaults'>{chunks}</a>
                 ),
               }}
               tagName='p'
@@ -216,7 +216,7 @@ export const VisibilityModal: FC<VisibilityModalProps> = forwardRef(
             >
               <FormattedMessage
                 id='visibility_modal.privacy_label'
-                defaultMessage='Privacy'
+                defaultMessage='Visibility'
               />
 
               <Dropdown
@@ -246,7 +246,7 @@ export const VisibilityModal: FC<VisibilityModalProps> = forwardRef(
             >
               <FormattedMessage
                 id='visibility_modal.quote_label'
-                defaultMessage='Change who can quote'
+                defaultMessage='Who can quote'
               />
 
               <Dropdown

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -991,10 +991,10 @@
   "visibility_modal.helper.privacy_editing": "Published posts cannot change their visibility.",
   "visibility_modal.helper.private_quoting": "Follower-only posts authored on Mastodon can't be quoted by others.",
   "visibility_modal.helper.unlisted_quoting": "When people quote you, their post will also be hidden from trending timelines.",
-  "visibility_modal.instructions": "Control who can interact with this post. Global settings can be found under <link>Preferences > Other</link>.",
-  "visibility_modal.privacy_label": "Privacy",
+  "visibility_modal.instructions": "Control who can interact with this post. You can also apply settings to all future posts by navigating to <link>Preferences > Posting defaults</link>.",
+  "visibility_modal.privacy_label": "Visibility",
   "visibility_modal.quote_followers": "Followers only",
-  "visibility_modal.quote_label": "Change who can quote",
+  "visibility_modal.quote_label": "Who can quote",
   "visibility_modal.quote_nobody": "Just me",
   "visibility_modal.quote_public": "Anyone",
   "visibility_modal.save": "Save"


### PR DESCRIPTION
### Changes proposed in this PR:
- Changes the copy of the "Visibility and interaction" modal to match our latest designs
- Updates the link target of the included preferences link to the new `/preferences/posting_defaults` route

### Screenshots

<img width="622" height="417" alt="image" src="https://github.com/user-attachments/assets/125acd72-33c8-4131-9a6b-93f96c6783f6" />
