### PR TITLE
Fix handling of edited status with new media and no text

### DIFF
--- a/app/services/activitypub/process_status_update_service.rb
+++ b/app/services/activitypub/process_status_update_service.rb
@@ -112,6 +112,8 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
     @status.ordered_media_attachment_ids = @next_media_attachments.map(&:id)
 
     @media_attachments_changed = true if @status.ordered_media_attachment_ids != previous_media_attachments_ids
+
+    @status.media_attachments.reload if @media_attachments_changed
   end
 
   def download_media_files!


### PR DESCRIPTION
Under certain conditions a valid edit of a status doesn't federate to Mastodon.

The conditions being:
1. The status edit contains neither text nor content warning
2. The status edit contains one or more media attachments
3. None of those media attachments were attached to the original post

## Reproduction

For reproduction we need accounts on two instances. One to post from, and a remote instance to observe the bug on.

1. Post a status
2. Observe the status from a remote instance
3. Edit the status:
  a. Keep text/CW empty
  b. Delete any existing images
  c. Add a new image
4. Observe that the status hasn't changed on the remote instance.
5. Refresh the post by pasting its source URL into the Mastodon search. The following error message should appear:
  `422 Validation failed: Text can't be blank`

## Analysis

As someone who's not deep into the Rails and Mastodon ecosystem investigating the issue sent me on a wild goose chase.

Post edits are processed in `app/services/activitypub/process_status_update_service.rb`. One of the steps is processing the changed media files. The fields `ordered_media_attachment_ids` on the post is overwritten with the new list.
The `media_attachments` object, which dynamically returns all media files that reference the post, is not refreshed, so it still returns an old cached state of attachments.
That results in the following constraint on the status object being violated:

https://github.com/mastodon/mastodon/blob/ab698ff52108dfbe6c9c27ba36a110532f97fdc2/app/models/status.rb#L103

This happens because `with_media?` checks `ordered_media_attachments`, which returns basically the intersection of `ordered_media_attachment_ids` and `media_attachment`, which is empty when none of the original media items are retained during the edit, due to the cached values.

https://github.com/mastodon/mastodon/blob/ab698ff52108dfbe6c9c27ba36a110532f97fdc2/app/models/status.rb#L287-L288

## Fix

The fix is simply reloading the `media_attachment` object right after processing changed media files. The existing [reload in `download_media_files`](https://github.com/mastodon/mastodon/blob/6f8187e595c7df471444c5d0536bcaaf40b0edc5/app/services/activitypub/process_status_update_service.rb#L130) is not sufficient, as it's happening too late in the process.


This is my first contribution to a Ruby project, please let me know if I made a mistake or misunderstood something. :)