### PR TITLE
Prepend “RE: <url>” fallback link to Mastodon-authored quote posts

### DIFF
--- a/app/helpers/formatting_helper.rb
+++ b/app/helpers/formatting_helper.rb
@@ -27,7 +27,9 @@ module FormattingHelper
   module_function :extract_status_plain_text
 
   def status_content_format(status)
-    html_aware_format(status.text, status.local?, preloaded_accounts: [status.account] + (status.respond_to?(:active_mentions) ? status.active_mentions.map(&:account) : []))
+    quoted_status = status.quote&.quoted_status if status.local?
+
+    html_aware_format(status.text, status.local?, preloaded_accounts: [status.account] + (status.respond_to?(:active_mentions) ? status.active_mentions.map(&:account) : []), quoted_status: quoted_status)
   end
 
   def rss_status_content_format(status)

--- a/app/models/status_edit.rb
+++ b/app/models/status_edit.rb
@@ -45,6 +45,13 @@ class StatusEdit < ApplicationRecord
   delegate :local?, :application, :edited?, :edited_at,
            :discarded?, :visibility, :language, to: :status
 
+  def quote
+    underlying_quote = status.quote
+    return if underlying_quote.nil? || underlying_quote.id != quote_id
+
+    underlying_quote
+  end
+
   def with_media?
     ordered_media_attachments.any?
   end


### PR DESCRIPTION
Currently, Mastodon's implementation of quote posts do not contain a fallback link for server or client implementations with no support for quote posts, meaning those will lose important meaning from the post.

This PR adds a fallback by dynamically prepending local quote posts with the following HTML:
```html
<p class="quote-inline">RE: (formatted link)</p>
```

This is similar to what Akkoma, Misskey and Sharkey are doing, except those append `<span class="quote-inline">RE: (link)</span>` instead.

## Caveats

- I have chosen to prepend the fallback instead of appending it, which is inconsistent with the order in which we display things in the UI, in order to avoid the inserted link from interfering with our last-line hashtag special treatment
- I am not completely happy with adding something to the post's body without giving the user a chance to review, but that is consistent with what Akkoma, Misskey and Sharkey do.
- finally, there is an edge case when the quoted post gets deleted: because we don't store the URL on its own, if the quoted post gets deleted, the “RE: link” won't be prepended either.