### PR TITLE
Extract "hints" partial from preview and use existing report method delegation more consistently

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -49,6 +49,7 @@ class Report < ApplicationRecord
 
   # A report is considered local if the reporter is local
   delegate :local?, to: :account
+  delegate :acct, :local?, to: :target_account, prefix: true
 
   validates :comment, length: { maximum: COMMENT_SIZE_LIMIT }, if: :local?
   validates :rule_ids, absence: true, if: -> { (category_changed? || rule_ids_changed?) && !violation? }

--- a/app/views/admin/reports/_comment.html.haml
+++ b/app/views/admin/reports/_comment.html.haml
@@ -1,12 +1,12 @@
 - if report.account.instance_actor?
   %p= t('admin.reports.comment_description_html', name: content_tag(:strong, site_hostname, class: 'username'))
-- elsif report.account.local?
+- elsif report.local?
   %p= t('admin.reports.comment_description_html', name: content_tag(:strong, report.account.username, class: 'username'))
 - else
   %p= t('admin.reports.comment_description_html', name: t('admin.reports.remote_user_placeholder', instance: report.account.domain))
 .report-notes
   .report-notes__item
-    - if report.account.local? && !report.account.instance_actor?
+    - if report.local? && !report.account.instance_actor?
       = image_tag report.account.avatar.url, class: 'report-notes__item__avatar'
     - else
       = image_tag(full_asset_url('avatars/original/missing.png', skip_pipeline: true), class: 'report-notes__item__avatar')
@@ -14,7 +14,7 @@
       %span.username
         - if report.account.instance_actor?
           = site_hostname
-        - elsif report.account.local?
+        - elsif report.local?
           = link_to report.account.username, admin_account_path(report.account_id)
         - else
           = link_to report.account.domain, admin_instance_path(report.account.domain)

--- a/app/views/admin/reports/_header_details.html.haml
+++ b/app/views/admin/reports/_header_details.html.haml
@@ -10,7 +10,7 @@
     .report-header__details__item__content
       - if report.account.instance_actor?
         = site_hostname
-      - elsif report.account.local?
+      - elsif report.local?
         = admin_account_link_to report.account
       - else
         = report.account.domain
@@ -28,7 +28,7 @@
         = t('admin.reports.resolved')
       - else
         = t('admin.reports.unresolved')
-  - if report.account.local? && !report.target_account.local?
+  - if report.local? && !report.target_account_local?
     .report-header__details__item
       .report-header__details__item__header
         %strong= t('admin.reports.forwarded')

--- a/app/views/admin/reports/actions/_hints.html.haml
+++ b/app/views/admin/reports/actions/_hints.html.haml
@@ -1,0 +1,14 @@
+-# locals(acct:, action:, report:)
+
+%p.hint= t("admin.reports.summary.action_preambles.#{action}_html", acct:)
+%ul.hint
+  %li.warning-hint= t("admin.reports.summary.actions.#{action}_html", acct:)
+  - if action == 'suspend'
+    %li.warning-hint= t('admin.reports.summary.delete_data_html', acct:)
+  - if %w(silence suspend).include?(action)
+    %li.warning-hint= t('admin.reports.summary.close_reports_html', acct:)
+  - else
+    %li= t('admin.reports.summary.close_report', id: report.id)
+  %li= t('admin.reports.summary.record_strike_html', acct:)
+  - if report.target_account_local? && !report.spam?
+    %li= t('admin.reports.summary.send_email_html', acct:)

--- a/app/views/admin/reports/actions/preview.html.haml
+++ b/app/views/admin/reports/actions/preview.html.haml
@@ -10,7 +10,7 @@
 
   %hr.spacer/
 
-  - if @report.target_account.local?
+  - if @report.target_account_local?
     %p.hint= t('admin.reports.summary.preview_preamble_html', acct: @report.target_account_acct)
 
     .strike-card

--- a/app/views/admin/reports/actions/preview.html.haml
+++ b/app/views/admin/reports/actions/preview.html.haml
@@ -1,29 +1,17 @@
-- target_acct = @report.target_account.acct
 - warning_action = { 'delete' => 'delete_statuses', 'mark_as_sensitive' => 'mark_statuses_as_sensitive' }.fetch(@moderation_action, @moderation_action)
 
 - content_for :page_title do
-  = t('admin.reports.confirm_action', acct: target_acct)
+  = t('admin.reports.confirm_action', acct: @report.target_account_acct)
 
 = form_with url: admin_report_actions_path(@report), class: :simple_form do |form|
   = form.hidden_field :moderation_action, value: @moderation_action
 
-  %p.hint= t("admin.reports.summary.action_preambles.#{@moderation_action}_html", acct: target_acct)
-  %ul.hint
-    %li.warning-hint= t("admin.reports.summary.actions.#{@moderation_action}_html", acct: target_acct)
-    - if @moderation_action == 'suspend'
-      %li.warning-hint= t('admin.reports.summary.delete_data_html', acct: target_acct)
-    - if %w(silence suspend).include?(@moderation_action)
-      %li.warning-hint= t('admin.reports.summary.close_reports_html', acct: target_acct)
-    - else
-      %li= t('admin.reports.summary.close_report', id: @report.id)
-    %li= t('admin.reports.summary.record_strike_html', acct: target_acct)
-    - if @report.target_account.local? && !@report.spam?
-      %li= t('admin.reports.summary.send_email_html', acct: target_acct)
+  = render 'hints', acct: @report.target_account_acct, action: @moderation_action, report: @report
 
   %hr.spacer/
 
   - if @report.target_account.local?
-    %p.hint= t('admin.reports.summary.preview_preamble_html', acct: target_acct)
+    %p.hint= t('admin.reports.summary.preview_preamble_html', acct: @report.target_account_acct)
 
     .strike-card
       - unless warning_action == 'none'

--- a/app/views/admin/reports/index.html.haml
+++ b/app/views/admin/reports/index.html.haml
@@ -51,7 +51,7 @@
           .report-card__summary__item__reported-by
             - if report.account.instance_actor?
               = site_hostname
-            - elsif report.account.local?
+            - elsif report.local?
               = admin_account_link_to report.account
             - else
               = report.account.domain

--- a/app/views/admin/reports/show.html.haml
+++ b/app/views/admin/reports/show.html.haml
@@ -7,7 +7,7 @@
   - else
     = link_to t('admin.reports.mark_as_unresolved'), reopen_admin_report_path(@report), method: :post, class: 'button'
 
-- unless @report.account.local? || @report.target_account.local?
+- unless @report.local? || @report.target_account_local?
   .flash-message= t('admin.reports.forwarded_replies_explanation')
 
 .report-header
@@ -61,7 +61,7 @@
 - if @report.unresolved?
   %hr.spacer/
 
-  %p#actions= t(@report.target_account.local? ? 'admin.reports.actions_description_html' : 'admin.reports.actions_description_remote_html')
+  %p#actions= t(@report.target_account_local? ? 'admin.reports.actions_description_html' : 'admin.reports.actions_description_remote_html')
 
   = render partial: 'admin/reports/actions', locals: { report: @report, statuses: @statuses }
 

--- a/app/views/admin_mailer/new_report.text.erb
+++ b/app/views/admin_mailer/new_report.text.erb
@@ -1,3 +1,3 @@
-<%= raw(@report.account.local? ? t('admin_mailer.new_report.body', target: @report.target_account.pretty_acct, reporter: @report.account.pretty_acct) : t('admin_mailer.new_report.body_remote', target: @report.target_account.acct, domain: @report.account.domain)) %>
+<%= raw(@report.local? ? t('admin_mailer.new_report.body', target: @report.target_account.pretty_acct, reporter: @report.account.pretty_acct) : t('admin_mailer.new_report.body_remote', target: @report.target_account_acct, domain: @report.account.domain)) %>
 
 <%= raw t('application_mailer.view')%> <%= admin_report_url(@report) %>

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -156,6 +156,11 @@ RSpec.describe Report do
     end
   end
 
+  describe 'Delegations' do
+    it { is_expected.to delegate_method(:acct).to(:target_account).with_prefix }
+    it { is_expected.to delegate_method(:local?).to(:target_account).with_prefix }
+  end
+
   describe 'Validations' do
     let(:remote_account) { Fabricate(:account, domain: 'example.com', protocol: :activitypub, inbox_url: 'http://example.com/inbox') }
 


### PR DESCRIPTION
Related changes:

- We already have a `local?` delegation (to account) on report, but it was not being used everywhere consistently. Do a once over to update places to use it.
- Add similar delegation to `target_account` (on `local?` and `acct`), and apply them as well (use `prefix: true` here to not collide with the existing account ones)
- Within the preview view, extract a `hints` partial

Opportunities:

- The `@moderation_action` variable exists just to wrap the current `action_from_button` ... that could be exposed by controller with `helper_method` instead?
- The entire preview action form could benefit from a form model and/or extract to a form partial to further improve the view
- If something like https://github.com/mastodon/mastodon/pull/35386 merges we could add a helper to wrap up the "is this an account action?" check being done in this hints list in the extracted partial
- The logic of "send the warning email if local and non-spam" is spread around in parts in different spots of the app. Could wrap that up either into new form object, or borrow something from Report or AccountAction, etc

Related to (and may merge conflict with) https://github.com/mastodon/mastodon/pull/35926

Could probably split up the "use delegated methods more" from the "hints partial" portion here if desired.