### PR TITLE
Change public self-quotes of private posts to be disallowed

### DIFF
--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -989,6 +989,7 @@
   "visibility_modal.header": "Visibility and interaction",
   "visibility_modal.helper.direct_quoting": "Private mentions authored on Mastodon can't be quoted by others.",
   "visibility_modal.helper.privacy_editing": "Published posts cannot change their visibility.",
+  "visibility_modal.helper.privacy_private_self_quote": "Self-quotes of private posts cannot be made public.",
   "visibility_modal.helper.private_quoting": "Follower-only posts authored on Mastodon can't be quoted by others.",
   "visibility_modal.helper.unlisted_quoting": "When people quote you, their post will also be hidden from trending timelines.",
   "visibility_modal.instructions": "Control who can interact with this post. You can also apply settings to all future posts by navigating to <link>Preferences > Posting defaults</link>.",

--- a/app/javascript/mastodon/reducers/compose.js
+++ b/app/javascript/mastodon/reducers/compose.js
@@ -334,7 +334,8 @@ export const composeReducer = (state = initialState, action) => {
     return state
       .set('quoted_status_id', status.get('id'))
       .set('spoiler', status.get('sensitive'))
-      .set('spoiler_text', status.get('spoiler_text'));
+      .set('spoiler_text', status.get('spoiler_text'))
+      .update('privacy', (visibility) => ['public', 'unlisted'].includes(visibility) && status.get('visibility') === 'private' ? 'private' : visibility);
   } else if (quoteComposeCancel.match(action)) {
     return state.set('quoted_status_id', null);
   } else if (setComposeQuotePolicy.match(action)) {

--- a/app/models/concerns/status/interaction_policy_concern.rb
+++ b/app/models/concerns/status/interaction_policy_concern.rb
@@ -27,7 +27,7 @@ module Status::InteractionPolicyConcern
 
   # Returns `:automatic`, `:manual`, `:unknown` or `:denied`
   def quote_policy_for_account(other_account, preloaded_relations: {})
-    return :denied if other_account.nil?
+    return :denied if other_account.nil? || direct_visibility?
 
     following_author = nil
 

--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -71,6 +71,7 @@ class PostStatusService < BaseService
     @text         = @options.delete(:spoiler_text) if @text.blank? && @options[:spoiler_text].present?
     @visibility   = @options[:visibility] || @account.user&.setting_default_privacy
     @visibility   = :unlisted if @visibility&.to_sym == :public && @account.silenced?
+    @visibility   = :private if @quoted_status&.private_visibility?
     @scheduled_at = @options[:scheduled_at]&.to_datetime
     @scheduled_at = nil if scheduled_in_the_past?
   rescue ArgumentError

--- a/spec/policies/status_policy_spec.rb
+++ b/spec/policies/status_policy_spec.rb
@@ -88,10 +88,10 @@ RSpec.describe StatusPolicy, type: :model do
 
   context 'with the permission of quote?' do
     permissions :quote? do
-      it 'grants access when direct and account is viewer' do
+      it 'does not grant access when direct and account is viewer' do
         status.visibility = :direct
 
-        expect(subject).to permit(status.account, status)
+        expect(subject).to_not permit(status.account, status)
       end
 
       it 'does not grant access access when direct and viewer is mentioned but not explicitly allowed' do

--- a/spec/services/post_status_service_spec.rb
+++ b/spec/services/post_status_service_spec.rb
@@ -305,6 +305,14 @@ RSpec.describe PostStatusService do
       .to enqueue_sidekiq_job(ActivityPub::QuoteRequestWorker)
   end
 
+  it 'correctly downgrades visibility for private self-quotes' do
+    account = Fabricate(:account)
+    quoted_status = Fabricate(:status, account: account, visibility: :private)
+
+    status = subject.call(account, text: 'test', quoted_status: quoted_status)
+    expect(status).to be_private_visibility
+  end
+
   it 'returns existing status when used twice with idempotency key' do
     account = Fabricate(:account)
     status1 = subject.call(account, text: 'test', idempotency: 'meepmeep')


### PR DESCRIPTION
Access was already properly checked, preventing inadvertent leaks of private posts, but this PR should avoid that case entirely, reducing possible confusion and strengthening user trust.

<img width="609" height="450" alt="image" src="https://github.com/user-attachments/assets/75174c66-a17f-4f32-882f-608633304bc9" />
<img width="609" height="450" alt="image" src="https://github.com/user-attachments/assets/3bdb27bf-3d45-465a-9dd1-36bf17cd016a" />

Irrelevant visibility options have been removed from the dropdown as we do not have a disabled state for them.