### PR TITLE
Use collection render on admin dashboard system checks

### DIFF
--- a/app/lib/admin/system_check/message.rb
+++ b/app/lib/admin/system_check/message.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Admin::SystemCheck::Message
-  include ActiveModel::Model
-
   attr_reader :key, :value, :action, :critical
 
   def initialize(key, value = nil, action = nil, critical: false)

--- a/app/lib/admin/system_check/message.rb
+++ b/app/lib/admin/system_check/message.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Admin::SystemCheck::Message
+  include ActiveModel::Model
+
   attr_reader :key, :value, :action, :critical
 
   def initialize(key, value = nil, action = nil, critical: false)

--- a/app/views/admin/dashboard/index.html.haml
+++ b/app/views/admin/dashboard/index.html.haml
@@ -6,11 +6,7 @@
 
 - unless @system_checks.empty?
   .flash-message-stack
-    - @system_checks.each do |message|
-      .flash-message{ class: message.critical ? 'alert' : 'warning' }
-        = t("admin.system_checks.#{message.key}.message_html", value: message.value ? content_tag(:strong, message.value) : nil)
-        - if message.action
-          = link_to t("admin.system_checks.#{message.key}.action"), message.action
+    = render @system_checks
 
 .dashboard
   .dashboard__item

--- a/app/views/admin/dashboard/index.html.haml
+++ b/app/views/admin/dashboard/index.html.haml
@@ -6,7 +6,7 @@
 
 - unless @system_checks.empty?
   .flash-message-stack
-    = render @system_checks
+    = render collection: @system_checks, partial: 'admin/system_check/messages/message'
 
 .dashboard
   .dashboard__item

--- a/app/views/admin/system_check/messages/_message.html.haml
+++ b/app/views/admin/system_check/messages/_message.html.haml
@@ -1,0 +1,4 @@
+.flash-message{ class: message.critical ? 'alert' : 'warning' }
+  = t("admin.system_checks.#{message.key}.message_html", value: message.value ? tag.strong(message.value) : nil)
+  - if message.action
+    = link_to t("admin.system_checks.#{message.key}.action"), message.action


### PR DESCRIPTION
The `ActiveModel::Model` addition here lets it return a partial path.

Side note -- might be worth converting the `initialize` method in system check `Message` class to take keyword hash instead -- some of the spots that call it dont have all values, so have to pass `nil` to keep arg order, which is really awkward for everyone.