### PR TITLE
Remove unused local vars from user mailer warning

### DIFF
--- a/app/views/user_mailer/warning.html.haml
+++ b/app/views/user_mailer/warning.html.haml
@@ -35,11 +35,11 @@
               %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
                 %tr
                   %td.email-border-top
-                    - @statuses.each_with_index do |status, i|
+                    - @statuses.each do |status|
                       %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
                         %tr
                           %td.email-border-bottom.email-padding-24
-                            = render 'notification_mailer/status', status: status, i: i + 1, highlighted: true, time_zone: @resource.time_zone.presence
+                            = render 'notification_mailer/status', status: status, time_zone: @resource.time_zone.presence
 
             %table.email-w-full{ cellspacing: 0, cellpadding: 0, border: 0, role: 'presentation' }
               %tr


### PR DESCRIPTION
These are not used in that partial now, and as far as I can tell from the original commit -- part of the PR which changed all the mailer templates at one time - https://github.com/mastodon/mastodon/pull/28416 -- they never were. Maybe copy/paste or something? (or part of some plan that never got implemented)

Notably - all the `NotificationMailer` templates which also use this partial just pass in user and time zone, but not `i` or `highlighted`.