### PR TITLE
Automatically remove invalid Web::PushSubscriptions

### DIFF
--- a/app/workers/web/push_notification_worker.rb
+++ b/app/workers/web/push_notification_worker.rb
@@ -18,7 +18,7 @@ class Web::PushNotificationWorker
     # Clean up old Web::PushSubscriptions that were added before validation of
     # the endpoint and keys: #30542, #30540
     unless @subscription.valid?
-      Rails.logger.error { "Web::PushSubscription is invalid, removing: #{subscription_id}" }
+      Rails.logger.debug { "Web::PushSubscription is invalid, removing: #{subscription_id}" }
       @subscription.destroy!
 
       return

--- a/app/workers/web/push_notification_worker.rb
+++ b/app/workers/web/push_notification_worker.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'debug'
 class Web::PushNotificationWorker
   include Sidekiq::Worker
   include RoutingHelper

--- a/app/workers/web/push_notification_worker.rb
+++ b/app/workers/web/push_notification_worker.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'debug'
 class Web::PushNotificationWorker
   include Sidekiq::Worker
   include RoutingHelper
@@ -14,6 +15,15 @@ class Web::PushNotificationWorker
     @notification = Notification.find(notification_id)
 
     return if @notification.updated_at < TTL.ago
+
+    # Clean up old Web::PushSubscriptions that were added before validation of
+    # the endpoint and keys: #30542, #30540
+    unless @subscription.valid?
+      Rails.logger.error { "Web::PushSubscription is invalid, removing: #{subscription_id}" }
+      @subscription.destroy
+
+      return
+    end
 
     # Polymorphically associated activity could have been deleted
     # in the meantime, so we have to double-check before proceeding

--- a/app/workers/web/push_notification_worker.rb
+++ b/app/workers/web/push_notification_worker.rb
@@ -19,7 +19,7 @@ class Web::PushNotificationWorker
     # the endpoint and keys: #30542, #30540
     unless @subscription.valid?
       Rails.logger.error { "Web::PushSubscription is invalid, removing: #{subscription_id}" }
-      @subscription.destroy
+      @subscription.destroy!
 
       return
     end

--- a/spec/workers/web/push_notification_worker_spec.rb
+++ b/spec/workers/web/push_notification_worker_spec.rb
@@ -95,7 +95,8 @@ RSpec.describe Web::PushNotificationWorker do
       end
 
       it 'removes the record and does not process the request' do
-        subject.perform(invalid_subscription.id, notification.id)
+        expect { subject.perform(invalid_subscription.id, notification.id) }
+          .to_not raise_error
 
         expect { invalid_subscription.reload }
           .to raise_error ActiveRecord::RecordNotFound

--- a/spec/workers/web/push_notification_worker_spec.rb
+++ b/spec/workers/web/push_notification_worker_spec.rb
@@ -36,6 +36,9 @@ RSpec.describe Web::PushNotificationWorker do
   let(:std_input) { 'When I grow up, I want to be a watermelon' }
   let(:std_ciphertext) { 'DGv6ra1nlYgDCS1FRnbzlwAAEABBBP4z9KsN6nGRTbVYI_c7VJSPQTBtkgcy27mlmlMoZIIgDll6e3vCYLocInmYWAmS6TlzAC8wEqKK6PBru3jl7A_yl95bQpu6cVPTpK4Mqgkf1CXztLVBSt2Ks3oZwbuwXPXLWyouBWLVWGNWQexSgSxsj_Qulcy4a-fN' }
 
+  # Invalid subscription:
+  let(:invalid_subscription) { Fabricate.build(:web_push_subscription, user_id: user.id, key_p256dh: 'invalid', key_auth: 'invalid', endpoint: endpoint, standard: true, data: { alerts: { notification.type => true } }) }
+
   describe 'perform' do
     around do |example|
       original_private = Rails.configuration.x.vapid.private_key
@@ -82,6 +85,18 @@ RSpec.describe Web::PushNotificationWorker do
         .to have_been_made
     end
     # rubocop:enable RSpec/SubjectStub
+
+    it 'Removes invalid Web::PushSubscriptions that will never complete' do
+      # Fabricator always runs validation, here we deliberately want to bypass
+      # the validation, simulating an invalid Web::PushSubscription that was
+      # created before PRs #30542, #30540 added validation.
+      invalid_subscription.save(validate: false)
+
+      subject.perform(invalid_subscription.id, notification.id)
+
+      expect { invalid_subscription.reload }
+        .to raise_error ActiveRecord::RecordNotFound
+    end
 
     def legacy_web_push_endpoint_request
       a_request(

--- a/spec/workers/web/push_notification_worker_spec.rb
+++ b/spec/workers/web/push_notification_worker_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe Web::PushNotificationWorker do
         expect { invalid_subscription.reload }
           .to raise_error ActiveRecord::RecordNotFound
 
-        assert_not_requested(:post, endpoint)
+        expect(a_request(:post, endpoint)).to_not have_been_made
       end
     end
 


### PR DESCRIPTION
I noticed in our dead jobs queue we had:
<img width="1820" height="276" alt="image" src="https://github.com/user-attachments/assets/8161d932-4f61-4984-9e28-a61a58ff3d02" />

Upon investigating, it appears to be an invalid `Web::PushSubscription` that was created before we implemented validation on the parameters in #30542, #30540

<img width="2068" height="388" alt="image" src="https://github.com/user-attachments/assets/d5b48ae5-15f3-4213-8906-7cb8d35716d6" />

This change checks that a Web::PushSubscription is valid before proceeding to perform the push, deleting the subscription if it is not valid.