### PR TITLE
Change wording on quote label when disabled

### DIFF
--- a/app/javascript/mastodon/components/status/reblog_button.tsx
+++ b/app/javascript/mastodon/components/status/reblog_button.tsx
@@ -44,7 +44,7 @@ const messages = defineMessages({
   quote: { id: 'status.quote', defaultMessage: 'Quote' },
   quote_cannot: {
     id: 'status.cannot_quote',
-    defaultMessage: 'Author has disabled quoting on this post',
+    defaultMessage: 'Quotes are disabled on this post',
   },
   quote_followers_only: {
     id: 'status.quote_followers_only',

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -863,7 +863,7 @@
   "status.block": "Block @{name}",
   "status.bookmark": "Bookmark",
   "status.cancel_reblog_private": "Unboost",
-  "status.cannot_quote": "Author has disabled quoting on this post",
+  "status.cannot_quote": "Quotes are disabled on this post",
   "status.cannot_reblog": "This post cannot be boosted",
   "status.context.load_new_replies": "New replies available",
   "status.context.loading": "Checking for more replies",


### PR DESCRIPTION
Fixes #35944

Change “Author has disabled quoting on this post” to “Quotes are disabled on this post” because our current implementation doesn't allow distinguishing a missing quote policy (thus defaulting to denying quotes) from an explicit decision from the user.