### PR TITLE
Add coverage for `TagManager#normalize_domain`

### DIFF
--- a/app/lib/tag_manager.rb
+++ b/app/lib/tag_manager.rb
@@ -18,7 +18,7 @@ class TagManager
     return if domain.nil?
 
     uri = Addressable::URI.new
-    uri.host = domain.delete_suffix('/')
+    uri.host = domain.strip.delete_suffix('/')
     uri.normalized_host
   end
 

--- a/spec/lib/tag_manager_spec.rb
+++ b/spec/lib/tag_manager_spec.rb
@@ -54,12 +54,44 @@ RSpec.describe TagManager do
   end
 
   describe '#normalize_domain' do
-    it 'returns nil if the given parameter is nil' do
-      expect(described_class.instance.normalize_domain(nil)).to be_nil
+    subject { described_class.instance.normalize_domain(domain) }
+
+    context 'with a nil value' do
+      let(:domain) { nil }
+
+      it { is_expected.to be_nil }
     end
 
-    it 'returns normalized domain' do
-      expect(described_class.instance.normalize_domain('DoMaIn.Example.com/')).to eq 'domain.example.com'
+    context 'with a blank value' do
+      let(:domain) { '' }
+
+      it { is_expected.to be_blank }
+    end
+
+    context 'with a mixed case string' do
+      let(:domain) { 'DoMaIn.Example.com' }
+
+      it { is_expected.to eq('domain.example.com') }
+    end
+
+    context 'with a trailing slash string' do
+      let(:domain) { 'domain.example.com/' }
+
+      it { is_expected.to eq('domain.example.com') }
+    end
+
+    context 'with a space padded string' do
+      let(:domain) { '  domain.example.com  ' }
+
+      it { is_expected.to eq('domain.example.com') }
+    end
+
+    context 'with an invalid domain string' do
+      let(:domain) { '  !@#$@#$@$@#  ' }
+
+      it 'raises invalid uri error' do
+        expect { subject }.to raise_error(Addressable::URI::InvalidURIError)
+      end
     end
   end
 

--- a/spec/models/instance_moderation_note_spec.rb
+++ b/spec/models/instance_moderation_note_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe InstanceModerationNote do
   describe 'chronological' do
     it 'returns the instance notes sorted by oldest first' do
-      instance = Instance.find_or_initialize_by(domain: TagManager.instance.normalize_domain('mastodon.example'))
+      instance = Instance.find_or_initialize_by(domain: 'mastodon.example')
 
       note1 = Fabricate(:instance_moderation_note, domain: instance.domain)
       note2 = Fabricate(:instance_moderation_note, domain: instance.domain)


### PR DESCRIPTION
Coverage additions only (plus one `strip`) from https://github.com/mastodon/mastodon/pull/35764

Of the added specs here, all of them pass with the exception of the "space padding string" one, which is made to pass by the change to the class here. I guess I could pull out that example and change if needed, but figuring it's easier to review than the full prior PR.

Also from original PR - the `InstanceModerationNote` spec doesn't need to normalize that domain value.