### PR TITLE
Add coverage for "domain variants" consumers

### DIFF
--- a/app/models/domain_allow.rb
+++ b/app/models/domain_allow.rb
@@ -33,7 +33,7 @@ class DomainAllow < ApplicationRecord
     def rule_for(domain)
       return if domain.blank?
 
-      uri = Addressable::URI.new.tap { |u| u.host = domain.delete('/') }
+      uri = Addressable::URI.new.tap { |u| u.host = domain.strip.delete('/') }
 
       find_by(domain: uri.normalized_host)
     end

--- a/spec/models/domain_allow_spec.rb
+++ b/spec/models/domain_allow_spec.rb
@@ -27,4 +27,27 @@ RSpec.describe DomainAllow do
       it { is_expected.to contain_exactly(allowed_domain.domain, other_allowed_domain.domain) }
     end
   end
+
+  describe '.rule_for' do
+    subject { described_class.rule_for(domain) }
+
+    let(:domain) { 'host.example' }
+
+    context 'with no records' do
+      it { is_expected.to be_nil }
+    end
+
+    context 'with matching record' do
+      let!(:domain_allow) { Fabricate :domain_allow, domain: }
+
+      it { is_expected.to eq(domain_allow) }
+    end
+
+    context 'when called with non normalized string' do
+      let!(:domain_allow) { Fabricate :domain_allow, domain: }
+      let(:domain) { '  HOST.example/' }
+
+      it { is_expected.to eq(domain_allow) }
+    end
+  end
 end

--- a/spec/models/domain_block_spec.rb
+++ b/spec/models/domain_block_spec.rb
@@ -35,6 +35,17 @@ RSpec.describe DomainBlock do
       expect(described_class.rule_for('example.com')).to eq block
     end
 
+    it 'returns most specific rule matching a blocked domain' do
+      _block = Fabricate(:domain_block, domain: 'example.com')
+      blog_block = Fabricate(:domain_block, domain: 'blog.example.com')
+      expect(described_class.rule_for('host.blog.example.com')).to eq blog_block
+    end
+
+    it 'returns rule matching a blocked domain when string needs normalization' do
+      block = Fabricate(:domain_block, domain: 'example.com')
+      expect(described_class.rule_for('  example.com/')).to eq block
+    end
+
     it 'returns a rule matching a subdomain of a blocked domain' do
       block = Fabricate(:domain_block, domain: 'example.com')
       expect(described_class.rule_for('sub.example.com')).to eq block

--- a/spec/models/email_domain_block_spec.rb
+++ b/spec/models/email_domain_block_spec.rb
@@ -4,6 +4,8 @@ require 'rails_helper'
 
 RSpec.describe EmailDomainBlock do
   describe 'block?' do
+    subject { described_class.block?(input) }
+
     let(:input) { nil }
 
     context 'when given an e-mail address' do
@@ -14,12 +16,12 @@ RSpec.describe EmailDomainBlock do
 
         it 'returns true if the domain is blocked' do
           Fabricate(:email_domain_block, domain: 'example.com')
-          expect(described_class.block?(input)).to be true
+          expect(subject).to be true
         end
 
         it 'returns false if the domain is not blocked' do
           Fabricate(:email_domain_block, domain: 'other-example.com')
-          expect(described_class.block?(input)).to be false
+          expect(subject).to be false
         end
       end
 
@@ -28,7 +30,7 @@ RSpec.describe EmailDomainBlock do
 
         it 'returns true if it is a subdomain of a blocked domain' do
           Fabricate(:email_domain_block, domain: 'example.com')
-          expect(described_class.block?(input)).to be true
+          expect(subject).to be true
         end
       end
     end
@@ -38,8 +40,40 @@ RSpec.describe EmailDomainBlock do
 
       it 'returns true if the domain is blocked' do
         Fabricate(:email_domain_block, domain: 'mail.foo.com')
-        expect(described_class.block?(input)).to be true
+        expect(subject).to be true
       end
+    end
+
+    context 'when given nil' do
+      it { is_expected.to be false }
+    end
+
+    context 'when given empty string' do
+      let(:input) { '' }
+
+      it { is_expected.to be true }
+    end
+  end
+
+  describe '.requires_approval?' do
+    subject { described_class.requires_approval?(input) }
+
+    let(:input) { nil }
+
+    context 'with a matching block requiring approval' do
+      before { Fabricate :email_domain_block, domain: input, allow_with_approval: true }
+
+      let(:input) { 'host.example' }
+
+      it { is_expected.to be true }
+    end
+
+    context 'with a matching block not requiring approval' do
+      before { Fabricate :email_domain_block, domain: input, allow_with_approval: false }
+
+      let(:input) { 'host.example' }
+
+      it { is_expected.to be false }
     end
   end
 end

--- a/spec/models/preview_card_provider_spec.rb
+++ b/spec/models/preview_card_provider_spec.rb
@@ -25,4 +25,36 @@ RSpec.describe PreviewCardProvider do
       end
     end
   end
+
+  describe '.matching_domain' do
+    subject { described_class.matching_domain(domain) }
+
+    let(:domain) { 'host.example' }
+
+    context 'without matching domains' do
+      it { is_expected.to be_nil }
+    end
+
+    context 'with exact matching domain' do
+      let!(:preview_card_provider) { Fabricate :preview_card_provider, domain: 'host.example' }
+
+      it { is_expected.to eq(preview_card_provider) }
+    end
+
+    context 'with matching domain segment' do
+      let!(:preview_card_provider) { Fabricate :preview_card_provider, domain: 'host.example' }
+      let(:domain) { 'www.blog.host.example' }
+
+      it { is_expected.to eq(preview_card_provider) }
+    end
+
+    context 'with multiple matching records' do
+      let!(:preview_card_provider_more) { Fabricate :preview_card_provider, domain: 'blog.host.example' }
+      let(:domain) { 'www.blog.host.example' }
+
+      before { Fabricate :preview_card_provider, domain: 'host.example' }
+
+      it { is_expected.to eq(preview_card_provider_more) }
+    end
+  end
 end


### PR DESCRIPTION
Coverage only portion (plus one `strip`) from https://github.com/mastodon/mastodon/pull/35770

Even if we don't pull in that shared method to the domain normalizable concern, this coverage rounded out the previous stuff in various spots for that, and seems useful on it's own.

One exception here, like in https://github.com/mastodon/mastodon/pull/35994 - is the addition of one `strip` which is needed for one of the added examples in the domain allow spec (could roll that back if desired, but seems harmless).