### PR TITLE
Add compatibility hack for GoToSocial interaction policies

### DIFF
--- a/app/serializers/activitypub/note_serializer.rb
+++ b/app/serializers/activitypub/note_serializer.rb
@@ -232,6 +232,15 @@ class ActivityPub::NoteSerializer < ActivityPub::Serializer
       canQuote: {
         automaticApproval: approved_uris,
       },
+      canReply: {
+        always: 'https://www.w3.org/ns/activitystreams#Public',
+      },
+      canLike: {
+        always: 'https://www.w3.org/ns/activitystreams#Public',
+      },
+      canAnnounce: {
+        always: 'https://www.w3.org/ns/activitystreams#Public',
+      },
     }
   end
 


### PR DESCRIPTION
This PR is particularly hacky as it adds ill-defined attributes that we don't currently use, contradict publicly available documentation, and are going to be phased out soon. They are nevertheless required in order not to break compatibility with current GoToSocial deployments.

More information below:

Mastodon 4.5.0 is adding quote posts, with interaction policies. The interaction policies have been developed in conjunction with GoToSocial, which had some incompatible prior definitions, and evolved it as we discussed it.

Unfortunately, the latest GoToSocial release still uses incompatible definitions, and in particular assumes that the presence of `interactionPolicy` and the lack of sub-policies means the action is denied.

In effect, this means that without this PR, GoToSocial will interpret every post as refusing boosts, replies and likes.

The next GoToSocial version should fix that, but it's still weeks before the first release candidate.