### PR TITLE
Remove unused `button` argument to `account_link_to` helper

### DIFF
--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -7,34 +7,32 @@ module HomeHelper
     }
   end
 
-  def account_link_to(account, button = '', path: nil)
+  def account_link_to(account, path: nil)
     content_tag(:div, class: 'account account--minimal') do
       content_tag(:div, class: 'account__wrapper') do
-        section = if account.nil?
-                    content_tag(:div, class: 'account__display-name') do
-                      content_tag(:div, class: 'account__avatar-wrapper') do
-                        image_tag(full_asset_url('avatars/original/missing.png', skip_pipeline: true), class: 'account__avatar')
-                      end +
-                        content_tag(:span, class: 'display-name') do
-                          content_tag(:strong, t('about.contact_missing')) +
-                            content_tag(:span, t('about.contact_unavailable'), class: 'display-name__account')
-                        end
-                    end
-                  else
-                    link_to(path || ActivityPub::TagManager.instance.url_for(account), class: 'account__display-name') do
-                      content_tag(:div, class: 'account__avatar-wrapper') do
-                        image_tag(full_asset_url(current_account&.user&.setting_auto_play_gif ? account.avatar_original_url : account.avatar_static_url), class: 'account__avatar', width: 46, height: 46)
-                      end +
-                        content_tag(:span, class: 'display-name') do
-                          content_tag(:bdi) do
-                            content_tag(:strong, display_name(account, custom_emojify: true), class: 'display-name__html emojify')
-                          end +
-                            content_tag(:span, "@#{account.acct}", class: 'display-name__account')
-                        end
-                    end
-                  end
-
-        section + button
+        if account.nil?
+          content_tag(:div, class: 'account__display-name') do
+            content_tag(:div, class: 'account__avatar-wrapper') do
+              image_tag(full_asset_url('avatars/original/missing.png', skip_pipeline: true), class: 'account__avatar')
+            end +
+              content_tag(:span, class: 'display-name') do
+                content_tag(:strong, t('about.contact_missing')) +
+                  content_tag(:span, t('about.contact_unavailable'), class: 'display-name__account')
+              end
+          end
+        else
+          link_to(path || ActivityPub::TagManager.instance.url_for(account), class: 'account__display-name') do
+            content_tag(:div, class: 'account__avatar-wrapper') do
+              image_tag(full_asset_url(current_account&.user&.setting_auto_play_gif ? account.avatar_original_url : account.avatar_static_url), class: 'account__avatar', width: 46, height: 46)
+            end +
+              content_tag(:span, class: 'display-name') do
+                content_tag(:bdi) do
+                  content_tag(:strong, display_name(account, custom_emojify: true), class: 'display-name__html emojify')
+                end +
+                  content_tag(:span, "@#{account.acct}", class: 'display-name__account')
+              end
+          end
+        end
       end
     end
   end

--- a/app/views/admin/reports/index.html.haml
+++ b/app/views/admin/reports/index.html.haml
@@ -33,7 +33,7 @@
 - @reports.group_by(&:target_account).each do |target_account, reports|
   .report-card
     .report-card__profile
-      = account_link_to target_account, '', path: admin_account_path(target_account.id)
+      = account_link_to target_account, path: admin_account_path(target_account.id)
       .report-card__profile__stats
         = link_to t('admin.reports.account.notes', count: target_account.targeted_moderation_notes.count), admin_account_path(target_account.id)
         %br/


### PR DESCRIPTION
This argument was added with the original helper method - https://github.com/mastodon/mastodon/pull/8146/files#diff-e8828dd9799b83c1eb44c1e0039399517023233e8836eca2be7302cd27e4b7ceR10 - which itself was a seemingly unrelated side piece of a larger change. I think it's never been used (?) and is not currently used by any of the few spots which call the helper (the only spot passing a value is passing empty string).

The bulk of this diff is whitespace change ... with the `button` removed, we no longer need to append it to `section`, and once that's gone, the whole if/else that builds `section` can go as well, so the entire method has shifted left.

Related but separately -- this should almost definitely be a partial and not a helper method, just based on the sheer size and number of `_tag` calls here ... could do that as followup.
