### PR TITLE
Remove deprecated `content_tag` from react component helper

### DIFF
--- a/app/helpers/react_component_helper.rb
+++ b/app/helpers/react_component_helper.rb
@@ -6,7 +6,7 @@ module ReactComponentHelper
     if block.nil?
       div_tag_with_data(data)
     else
-      content_tag(:div, data: data, &block)
+      tag.div(data: data, &block)
     end
   end
 
@@ -22,7 +22,7 @@ module ReactComponentHelper
   private
 
   def div_tag_with_data(data)
-    content_tag(:div, nil, data: data)
+    tag.div(data: data)
   end
 
   def serialized_attachment(attachment)

--- a/spec/helpers/react_component_helper_spec.rb
+++ b/spec/helpers/react_component_helper_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe ReactComponentHelper do
     context 'with a block passed in' do
       let(:result) do
         helper.react_component('name', { one: :two }) do
-          helper.content_tag(:nav, 'ok')
+          helper.tag.nav('ok')
         end
       end
 


### PR DESCRIPTION
The `content_tag` method is "legacy" syntax and soft-deprecated, and the newer style has a nice (though admittedly minor) compactness to it.

There are more of these, I but picked a ❤️‍🔥simple❤️‍🔥 one to start.

The before/after usage is the same output, ie:

```
mastodon(dev)> helper.react_component 'name', {this: :that}
=> "<div data-component=\"Name\" data-props=\"{&quot;this&quot;:&quot;that&quot;}\"></div>"
mastodon(dev)* helper.react_component 'name', {this: :that} do
mastodon(dev)*   helper.tag.span :this
mastodon(dev)> end
=> "<div data-component=\"Name\" data-props=\"{&quot;this&quot;:&quot;that&quot;}\"><span>this</span></div>"
```
