### PR TITLE
Move "get untranslated languages" into method on `Rule` class

### DIFF
--- a/app/controllers/admin/rules_controller.rb
+++ b/app/controllers/admin/rules_controller.rb
@@ -3,6 +3,7 @@
 module Admin
   class RulesController < BaseController
     before_action :set_rule, except: [:index, :new, :create]
+    before_action :build_missing_translations, only: :edit
 
     def index
       authorize :rule, :index?
@@ -17,9 +18,6 @@ module Admin
 
     def edit
       authorize @rule, :update?
-
-      missing_languages = RuleTranslation.languages - @rule.translations.pluck(:language)
-      missing_languages.each { |lang| @rule.translations.build(language: lang) }
     end
 
     def create
@@ -77,6 +75,10 @@ module Admin
     def resource_params
       params
         .expect(rule: [:text, :hint, :priority, translations_attributes: [[:id, :language, :text, :hint, :_destroy]]])
+    end
+
+    def build_missing_translations
+      @rule.untranslated_languages.each { |language| @rule.translations.build(language:) }
     end
   end
 end

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -44,4 +44,8 @@ class Rule < ApplicationRecord
     @cached_translations ||= {}
     @cached_translations[locale] ||= translations.for_locale(locale).by_language_length.first || translations.build(language: locale, text: text, hint: hint)
   end
+
+  def untranslated_languages
+    RuleTranslation.excluding(translations).languages
+  end
 end

--- a/spec/models/rule_spec.rb
+++ b/spec/models/rule_spec.rb
@@ -47,4 +47,28 @@ RSpec.describe Rule do
       expect(rule.translation_for(:'fr-CA')).to have_attributes(text: translation.text, hint: translation.hint)
     end
   end
+
+  describe '#untranslated_languages' do
+    subject { rule.untranslated_languages }
+
+    let(:rule) { Fabricate :rule }
+
+    context 'when there are no translations' do
+      it { is_expected.to be_an(Array).and(be_empty) }
+    end
+
+    context 'when there are translations' do
+      let(:linked_to_rule_translation) { Fabricate :rule_translation, language: 'es', rule: }
+      let!(:missing_translation) { Fabricate :rule_translation, language: 'fr' }
+      let!(:discarded_rule_translation) { Fabricate :rule_translation, language: 'gb', rule: discarded_rule }
+      let(:discarded_rule) { Fabricate :rule, deleted_at: 5.days.ago }
+
+      it 'returns language strings of missing translations' do
+        expect(subject)
+          .to include(missing_translation.language)
+          .and not_include(linked_to_rule_translation.language)
+          .and not_include(discarded_rule_translation.language)
+      end
+    end
+  end
 end


### PR DESCRIPTION
The more relevant thing here is the addition of the method on Rule that we can then test to confirm the right values ... I don't have a strong opinion on stylistically whether the "build translations" part should be in the action like it was, in a before action like I have it here, or in a `build_...` method or somewhere on `Rule`. Happy to adjust this portion if desired.
