### PR TITLE
Use `link_to` for contribute translation link

### DIFF
--- a/app/views/settings/preferences/appearance/show.html.haml
+++ b/app/views/settings/preferences/appearance/show.html.haml
@@ -43,7 +43,8 @@
 
   - unless I18n.locale == :en
     .flash-message.translation-prompt
-      #{t 'appearance.localization.body'} #{content_tag(:a, t('appearance.localization.guide_link_text'), href: t('appearance.localization.guide_link'), target: '_blank', rel: 'noopener')}
+      = t 'appearance.localization.body'
+      = link_to t('appearance.localization.guide_link_text'), t('appearance.localization.guide_link'), target: '_blank', rel: 'noopener'
 
   = f.simple_fields_for :settings, current_user.settings do |ff|
     %h4= t 'appearance.animations_and_accessibility'


### PR DESCRIPTION
Same idea as - https://github.com/mastodon/mastodon/pull/36009 - but instead of going to `tag.a` from `content_for`, just use a `link_to` (not clear to me why it wasnt like this when [added]).

[added]: https://github.com/mastodon/mastodon/pull/12736

Because I'm using `en` for my own usage, I had never seen this in the UI before. I briefly contemplated whether the comparison here should be `I18n.default_locale` rather than to `:en` (for servers that have set DEFAULT_LOCALE) ... but I think the answer is no, because even when running a different default locale, the "base language the translations are in" is still `en`, so its fine. If we want to be more elëgånt here, that `en` value could sit in like a `.mastodon.base_translations_language` config_for or something.