### PR TITLE
Use `pluck` on `DomainAllow.allowed_domains` for export

### DIFF
--- a/app/controllers/admin/export_domain_allows_controller.rb
+++ b/app/controllers/admin/export_domain_allows_controller.rb
@@ -49,8 +49,8 @@ module Admin
 
     def export_data
       CSV.generate(headers: export_headers, write_headers: true) do |content|
-        DomainAllow.allowed_domains.each do |instance|
-          content << [instance.domain]
+        DomainAllow.allowed_domains.each do |domain|
+          content << [domain]
         end
       end
     end

--- a/app/models/domain_allow.rb
+++ b/app/models/domain_allow.rb
@@ -27,7 +27,7 @@ class DomainAllow < ApplicationRecord
     end
 
     def allowed_domains
-      select(:domain)
+      pluck(:domain)
     end
 
     def rule_for(domain)

--- a/spec/controllers/admin/export_domain_allows_controller_spec.rb
+++ b/spec/controllers/admin/export_domain_allows_controller_spec.rb
@@ -17,17 +17,6 @@ RSpec.describe Admin::ExportDomainAllowsController do
     end
   end
 
-  describe 'GET #export' do
-    it 'renders instances' do
-      Fabricate(:domain_allow, domain: 'good.domain')
-      Fabricate(:domain_allow, domain: 'better.domain')
-
-      get :export, params: { format: :csv }
-      expect(response).to have_http_status(200)
-      expect(response.body).to eq(domain_allows_csv_file)
-    end
-  end
-
   describe 'POST #import' do
     it 'allows imported domains' do
       post :import, params: { admin_import: { data: fixture_file_upload('domain_allows.csv') } }
@@ -49,11 +38,5 @@ RSpec.describe Admin::ExportDomainAllowsController do
       expect(response).to redirect_to(admin_instances_path)
       expect(flash[:error]).to eq(I18n.t('admin.export_domain_allows.no_file'))
     end
-  end
-
-  private
-
-  def domain_allows_csv_file
-    File.read(File.join(file_fixture_path, 'domain_allows.csv'))
   end
 end

--- a/spec/models/domain_allow_spec.rb
+++ b/spec/models/domain_allow_spec.rb
@@ -12,4 +12,19 @@ RSpec.describe DomainAllow do
       it { is_expected.to_not allow_value('xn--r9j5b5b').for(:domain) }
     end
   end
+
+  describe '.allowed_domains' do
+    subject { described_class.allowed_domains }
+
+    context 'without domain allows' do
+      it { is_expected.to be_an(Array).and(be_empty) }
+    end
+
+    context 'with domain allows' do
+      let!(:allowed_domain) { Fabricate :domain_allow }
+      let!(:other_allowed_domain) { Fabricate :domain_allow }
+
+      it { is_expected.to contain_exactly(allowed_domain.domain, other_allowed_domain.domain) }
+    end
+  end
 end

--- a/spec/requests/admin/export_domain_allows_spec.rb
+++ b/spec/requests/admin/export_domain_allows_spec.rb
@@ -3,14 +3,38 @@
 require 'rails_helper'
 
 RSpec.describe 'Admin Export Domain Allows' do
-  describe 'POST /admin/export_domain_allows/import' do
-    before { sign_in Fabricate(:admin_user) }
+  before { sign_in Fabricate(:admin_user) }
 
+  describe 'POST /admin/export_domain_allows/import' do
     it 'gracefully handles invalid nested params' do
       post import_admin_export_domain_allows_path(admin_import: 'invalid')
 
       expect(response)
         .to redirect_to(admin_instances_path)
     end
+  end
+
+  describe 'GET /admin/export_domain_allows/export.csv' do
+    before do
+      Fabricate(:domain_allow, domain: 'good.domain')
+      Fabricate(:domain_allow, domain: 'better.domain')
+    end
+
+    it 'returns CSV response with instance domain values' do
+      get export_admin_export_domain_allows_path(format: :csv)
+
+      expect(response)
+        .to have_http_status(200)
+      expect(response.body)
+        .to eq(domain_allows_csv_file)
+      expect(response.media_type)
+        .to eq('text/csv')
+    end
+  end
+
+  private
+
+  def domain_allows_csv_file
+    File.read(File.join(file_fixture_path, 'domain_allows.csv'))
   end
 end


### PR DESCRIPTION
Changes here:

- The only spot the `DomainAllow.allowed_domains` method is used is in this controller to generate a CSV file, and the way it's used only needs the domain string values, not the full instances. Update to use `pluck` over `select` to get just the values we need - in theory slightly more efficient
- Move the  spec for the export action to request spec, add assertion about content type