### PR TITLE
Add `action_logs` association for account

### DIFF
--- a/app/controllers/concerns/accountable_concern.rb
+++ b/app/controllers/concerns/accountable_concern.rb
@@ -4,10 +4,8 @@ module AccountableConcern
   extend ActiveSupport::Concern
 
   def log_action(action, target)
-    Admin::ActionLog.create(
-      account: current_account,
-      action: action,
-      target: target
-    )
+    current_account
+      .action_logs
+      .create(action:, target:)
   end
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -156,7 +156,7 @@ class Account < ApplicationRecord
   scope :matches_username, ->(value) { where('lower((username)::text) LIKE lower(?)', "#{value}%") }
   scope :matches_display_name, ->(value) { where(arel_table[:display_name].matches("#{value}%")) }
   scope :without_unapproved, -> { left_outer_joins(:user).merge(User.approved.confirmed).or(remote) }
-  scope :auditable, -> { where(id: Admin::ActionLog.select(:account_id).distinct) }
+  scope :auditable, -> { where.associated(:action_logs).distinct }
   scope :searchable, -> { without_unapproved.without_suspended.where(moved_to_account_id: nil) }
   scope :discoverable, -> { searchable.without_silenced.where(discoverable: true).joins(:account_stat) }
   scope :by_recent_status, -> { includes(:account_stat).merge(AccountStat.by_recent_status).references(:account_stat) }

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -156,7 +156,7 @@ class Account < ApplicationRecord
   scope :matches_username, ->(value) { where('lower((username)::text) LIKE lower(?)', "#{value}%") }
   scope :matches_display_name, ->(value) { where(arel_table[:display_name].matches("#{value}%")) }
   scope :without_unapproved, -> { left_outer_joins(:user).merge(User.approved.confirmed).or(remote) }
-  scope :auditable, -> { where.associated(:action_logs).distinct }
+  scope :auditable, -> { where(id: Admin::ActionLog.select(:account_id).distinct) }
   scope :searchable, -> { without_unapproved.without_suspended.where(moved_to_account_id: nil) }
   scope :discoverable, -> { searchable.without_silenced.where(discoverable: true).joins(:account_stat) }
   scope :by_recent_status, -> { includes(:account_stat).merge(AccountStat.by_recent_status).references(:account_stat) }

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -12,6 +12,7 @@ module Account::Associations
         has_many :account_notes
         has_many :account_pins
         has_many :account_warnings
+        has_many :action_logs, class_name: 'Admin::ActionLog'
         has_many :aliases, class_name: 'AccountAlias'
         has_many :bookmarks
         has_many :collections

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Account do
 
   describe 'Associations' do
     it { is_expected.to have_many(:account_notes).inverse_of(:account) }
+    it { is_expected.to have_many(:action_logs).class_name('Admin::ActionLog') }
     it { is_expected.to have_many(:targeted_account_notes).inverse_of(:target_account) }
   end
 


### PR DESCRIPTION
Changes:

- Add the association
- Use it in the logging concern
- Use it in auditable scope -- there is spec coverage for this, and its logically equivalent (changes the underlying query from a subquery to an inner join, which I think should be more performant in most cases, but depends on data...)