### PR TITLE
Convert age verification controller to system specs

### DIFF
--- a/spec/controllers/auth/registrations_controller_spec.rb
+++ b/spec/controllers/auth/registrations_controller_spec.rb
@@ -342,42 +342,6 @@ RSpec.describe Auth::RegistrationsController do
       end
     end
 
-    context 'when age verification is enabled' do
-      subject { post :create, params: { user: { account_attributes: { username: 'test' }, email: 'test@example.com', password: '12345678', password_confirmation: '12345678', agreement: 'true' }.merge(date_of_birth) } }
-
-      before do
-        Setting.min_age = 16
-      end
-
-      let(:date_of_birth) { {} }
-
-      context 'when date of birth is below age limit' do
-        let(:date_of_birth) { 13.years.ago.then { |date| { 'date_of_birth(1i)': date.day.to_s, 'date_of_birth(2i)': date.month.to_s, 'date_of_birth(3i)': date.year.to_s } } }
-
-        it 'does not create user' do
-          subject
-          user = User.find_by(email: 'test@example.com')
-          expect(user).to be_nil
-        end
-      end
-
-      context 'when date of birth is above age limit' do
-        let(:date_of_birth) { 17.years.ago.then { |date| { 'date_of_birth(1i)': date.day.to_s, 'date_of_birth(2i)': date.month.to_s, 'date_of_birth(3i)': date.year.to_s } } }
-
-        it 'redirects to setup and creates user' do
-          subject
-
-          expect(response).to redirect_to auth_setup_path
-
-          expect(User.find_by(email: 'test@example.com'))
-            .to be_present
-            .and have_attributes(
-              age_verified_at: not_eq(nil)
-            )
-        end
-      end
-    end
-
     it_behaves_like 'registration mode based responses', :create
   end
 

--- a/spec/requests/api/v1/accounts_spec.rb
+++ b/spec/requests/api/v1/accounts_spec.rb
@@ -129,6 +129,19 @@ RSpec.describe '/api/v1/accounts' do
             .to start_with('application/json')
         end
       end
+
+      context 'when date of birth is over age limit in ISO-8601 format' do
+        let(:date_of_birth) { 17.years.ago.to_date.iso8601 }
+
+        it 'creates a user', :aggregate_failures do
+          subject
+
+          expect(response)
+            .to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
+        end
+      end
     end
 
     context 'when given truthy agreement' do

--- a/spec/requests/api/v1/accounts_spec.rb
+++ b/spec/requests/api/v1/accounts_spec.rb
@@ -110,9 +110,12 @@ RSpec.describe '/api/v1/accounts' do
         let(:date_of_birth) { 13.years.ago.strftime('%d.%m.%Y') }
 
         it 'returns http unprocessable entity' do
-          subject
+          expect { subject }
+            .to not_change(User, :count)
+            .and not_change(Account, :count)
 
-          expect(response).to have_http_status(422)
+          expect(response)
+            .to have_http_status(422)
           expect(response.content_type)
             .to start_with('application/json')
         end
@@ -122,9 +125,12 @@ RSpec.describe '/api/v1/accounts' do
         let(:date_of_birth) { 17.years.ago.strftime('%d.%m.%Y') }
 
         it 'creates a user', :aggregate_failures do
-          subject
+          expect { subject }
+            .to change(User, :count).by(1)
+            .and change(Account, :count).by(1)
 
-          expect(response).to have_http_status(200)
+          expect(response)
+            .to have_http_status(200)
           expect(response.content_type)
             .to start_with('application/json')
         end
@@ -134,7 +140,9 @@ RSpec.describe '/api/v1/accounts' do
         let(:date_of_birth) { 17.years.ago.to_date.iso8601 }
 
         it 'creates a user', :aggregate_failures do
-          subject
+          expect { subject }
+            .to change(User, :count).by(1)
+            .and change(Account, :count).by(1)
 
           expect(response)
             .to have_http_status(200)

--- a/spec/system/auth/registrations_spec.rb
+++ b/spec/system/auth/registrations_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Auth Registration' do
+  context 'when age verification is enabled' do
+    before { Setting.min_age = 16 }
+
+    context 'when date of birth is below age limit' do
+      let(:date_of_birth) { 13.years.ago }
+
+      it 'does not create user record and displays errors' do
+        visit new_user_registration_path
+        expect(page)
+          .to have_title(I18n.t('auth.register'))
+
+        expect { fill_in_and_submit_form }
+          .to not_change(User, :count)
+        expect(page)
+          .to have_content(/error below/)
+      end
+    end
+
+    context 'when date of birth is above age limit' do
+      let(:date_of_birth) { 17.years.ago }
+
+      it 'creates user and marks as verified' do
+        visit new_user_registration_path
+        expect(page)
+          .to have_title(I18n.t('auth.register'))
+
+        expect { fill_in_and_submit_form }
+          .to change(User, :count).by(1)
+        expect(User.last)
+          .to have_attributes(email: 'test@example.com', age_verified_at: be_present)
+        expect(page)
+          .to have_content(I18n.t('auth.setup.title'))
+      end
+    end
+
+    def fill_in_and_submit_form
+      # Avoid the registration spam check
+      travel_to 10.seconds.from_now
+
+      fill_in 'user_account_attributes_username', with: 'test'
+      fill_in 'user_email', with: 'test@example.com'
+      fill_in 'user_password', with: 'Test.123.Pass'
+      fill_in 'user_password_confirmation', with: 'Test.123.Pass'
+      check 'user_agreement'
+
+      find('input[aria-label="Day"]').fill_in with: date_of_birth.day
+      find('input[autocomplete="bday-month"]').fill_in with: date_of_birth.month
+      find('input[autocomplete="bday-year"]').fill_in with: date_of_birth.year
+
+      click_on I18n.t('auth.register')
+    end
+  end
+end


### PR DESCRIPTION
Actual changes here:

- Add one request spec for an unofficial-but-supported format for inbound datea for `date_of_birth` (prior spec checked format like `DD.MM.YYYY`, new one adds `YYYY-MM-DD`). I don't think we need to even document both formats, but wanted to add this ahead of future refactor to simplify the model handling of this attribute, and want to be sure to not change support then
- Migrate the previous controller spec to system spec, which is mostly boring. Most notably, the date of birth format check we can now assert around "when I put the values in these form fields does that work?" rather than needing to know about the exact parameter naming implementation detail.
- The previous request specs look at response code, added check for actual user/account creation

Related here - the typical rails form helpers will generate these dates with `(1i)` being the year, then count up from there over month/day/etc. In the custom form builder for this DOB value, we went (I'm assuming unintentionally?) the other way, with `(1i)` being the day, then going up for month/year. On the assumption that this is an accident and we don't actually care about the mapping, I'm 90% sure we can replace the custom setter here with a native `attribute ..., :date` approach, without changing the form visuals or the API support. Will do that as followup, assuming correct. The spec change here is in part in support of that, because that will modify the form param names, but not the behavior.