### PR TITLE
Fix incorrect change of `unlisted` source strings

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -367,7 +367,7 @@ en:
       title: Custom emojis
       uncategorized: Uncategorized
       unlist: Unlist
-      unlisted: Quiet public
+      unlisted: Unlisted
       update_failed_msg: Could not update that emoji
       updated_msg: Emoji successfully updated!
       upload: Upload
@@ -1923,7 +1923,7 @@ en:
       private_long: Only show to followers
       public: Public
       public_long: Anyone on and off Mastodon
-      unlisted: Unlisted
+      unlisted: Quiet public
       unlisted_long: Hidden from Mastodon search results, trending, and public timelines
   statuses_cleanup:
     enabled: Automatically delete old posts


### PR DESCRIPTION
Fixes MAS-553

Seems like in a previous PR, I changed the wrong “unlisted” source string (unlisted custom emojis, a different concept) :pensive: