### PR TITLE
Change “Boost with original visibility” to “Share again with your followers”

### DIFF
--- a/app/javascript/mastodon/components/status/reblog_button.tsx
+++ b/app/javascript/mastodon/components/status/reblog_button.tsx
@@ -69,7 +69,7 @@ const messages = defineMessages({
   },
   reblog_private: {
     id: 'status.reblog_private',
-    defaultMessage: 'Boost with original visibility',
+    defaultMessage: 'Share again with your followers',
   },
   reblog_cannot: {
     id: 'status.cannot_reblog',

--- a/app/javascript/mastodon/features/picture_in_picture/components/footer.tsx
+++ b/app/javascript/mastodon/features/picture_in_picture/components/footer.tsx
@@ -33,7 +33,7 @@ const messages = defineMessages({
   reblog: { id: 'status.reblog', defaultMessage: 'Boost' },
   reblog_private: {
     id: 'status.reblog_private',
-    defaultMessage: 'Boost with original visibility',
+    defaultMessage: 'Share again with your followers',
   },
   cancel_reblog_private: {
     id: 'status.cancel_reblog_private',

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -913,7 +913,7 @@
   "status.read_more": "Read more",
   "status.reblog": "Boost",
   "status.reblog_or_quote": "Boost or quote",
-  "status.reblog_private": "Boost with original visibility",
+  "status.reblog_private": "Share again with your followers",
   "status.reblogged_by": "{name} boosted",
   "status.reblogs": "{count, plural, one {boost} other {boosts}}",
   "status.reblogs.empty": "No one has boosted this post yet. When someone does, they will show up here.",


### PR DESCRIPTION
Fixes MAS-564

<img width="405" height="273" alt="image" src="https://github.com/user-attachments/assets/abc9f1e3-6638-4c3d-9b9c-9c5fd267ea3a" />