### PR TITLE
Use `date` attribute for date of birth

### DIFF
--- a/app/inputs/date_of_birth_input.rb
+++ b/app/inputs/date_of_birth_input.rb
@@ -2,25 +2,25 @@
 
 class DateOfBirthInput < SimpleForm::Inputs::Base
   OPTIONS = [
-    { autocomplete: 'bday-day', maxlength: 2, pattern: '[0-9]+', placeholder: 'DD' }.freeze,
-    { autocomplete: 'bday-month', maxlength: 2, pattern: '[0-9]+', placeholder: 'MM' }.freeze,
     { autocomplete: 'bday-year', maxlength: 4, pattern: '[0-9]+', placeholder: 'YYYY' }.freeze,
+    { autocomplete: 'bday-month', maxlength: 2, pattern: '[0-9]+', placeholder: 'MM' }.freeze,
+    { autocomplete: 'bday-day', maxlength: 2, pattern: '[0-9]+', placeholder: 'DD' }.freeze,
   ].freeze
 
   def input(wrapper_options = nil)
     merged_input_options = merge_wrapper_options(input_html_options, wrapper_options)
     merged_input_options[:inputmode] = 'numeric'
 
-    values = (object.public_send(attribute_name) || '').split('.')
+    values = (object.public_send(attribute_name) || '').to_s.split('-')
 
-    safe_join(Array.new(3) do |index|
+    safe_join(2.downto(0).map do |index|
       options = merged_input_options.merge(OPTIONS[index]).merge id: generate_id(index), 'aria-label': I18n.t("simple_form.labels.user.date_of_birth_#{index + 1}i"), value: values[index]
       @builder.text_field("#{attribute_name}(#{index + 1}i)", options)
     end)
   end
 
   def label_target
-    "#{attribute_name}_1i"
+    "#{attribute_name}_3i"
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -131,11 +131,12 @@ class User < ApplicationRecord
 
   delegate :can?, to: :role
 
-  attr_reader :invite_code, :date_of_birth
+  attr_reader :invite_code
   attr_writer :current_account
 
   attribute :external, :boolean, default: false
   attribute :bypass_registration_checks, :boolean, default: false
+  attribute :date_of_birth, :date
 
   def self.those_who_can(*any_of_privileges)
     matching_role_ids = UserRole.that_can(*any_of_privileges).map(&:id)
@@ -149,17 +150,6 @@ class User < ApplicationRecord
 
   def self.skip_mx_check?
     Rails.env.local?
-  end
-
-  def date_of_birth=(hash_or_string)
-    @date_of_birth = begin
-      if hash_or_string.is_a?(Hash)
-        day, month, year = hash_or_string.values_at(1, 2, 3)
-        "#{day}.#{month}.#{year}"
-      else
-        hash_or_string
-      end
-    end
   end
 
   def role

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -372,9 +372,9 @@ en:
         jurisdiction: Legal jurisdiction
         min_age: Minimum age
       user:
-        date_of_birth_1i: Day
+        date_of_birth_1i: Year
         date_of_birth_2i: Month
-        date_of_birth_3i: Year
+        date_of_birth_3i: Day
         role: Role
         time_zone: Time zone
       user_role:


### PR DESCRIPTION
Follow up on https://github.com/mastodon/mastodon/pull/36026

As described there, this custom form input reverses the typical param naming for the date pieces -- the framework defaults - from https://github.com/rails/rails/blob/v8.0.2.1/actionview/lib/action_view/helpers/date_helper.rb#L714-L716 - are to use `1i` for year, `2i` month, etc. The custom input here puts day at `1i`, then month, then year. This mostly doesn't matter -- except that if we flip it back to "normal", we can use a `date` attribute for the value and get the param conversion and setter behavior "for free".

Changes here:

- Change the options constant order so we can rely on the index for the param naming
- Adjust how get the value in the custom input, since its now coming from a `Date` instead of a `String`
- Preserve the UX order of day/month/year on the form (more below on this)
- Preserve the label target being day
- In the model, declare attribute and remove custom setter
- In i18n, correct the labeling

Questions/followups:

- I also have a branch which restores the behavior of relying on the local for the order of the elements here - https://github.com/mastodon/mastodon/compare/main...mjankowski:mastodon:date-of-birth-attribute-also-remove-custom-input - in one additional commit. I'll plan on submitting that as followup, but if you want it all at once I can add it in here or open as new and close this, etc.
- The `rails-i18n` gem contains translation values for the labels (year, month, day) ... would it make sense to drop the custom i18n here and rely on that? (Seems like no reason not to once params are restored)
- I believe the existing relevant validator, system and request specs do capture the main paths through here - but let me know about any edge case concerns and I'll try to verify

Separately ... it's a little maddening that you can't pass per-option (ie, for each individual select) attribute options hashes here, only for the top level wrapper. If you could do that, I think we could delete the whole custom input here.