### PR TITLE
Visibility dialog: Add visual dropdown indicator to Dropdown component

### DIFF
--- a/app/javascript/mastodon/components/dropdown/index.tsx
+++ b/app/javascript/mastodon/components/dropdown/index.tsx
@@ -8,8 +8,11 @@ import classNames from 'classnames';
 
 import Overlay from 'react-overlays/Overlay';
 
+import UnfoldMoreIcon from '@/material-icons/400-24px/unfold_more.svg?react';
+
 import type { SelectItem } from '../dropdown_selector';
 import { DropdownSelector } from '../dropdown_selector';
+import { Icon } from '../icon';
 
 interface DropdownProps {
   title: string;
@@ -75,11 +78,16 @@ export const Dropdown: FC<
             defaultMessage='Select an option'
           />
         )}
+        <Icon
+          id='unfold-icon'
+          icon={UnfoldMoreIcon}
+          className={`${classPrefix}__icon`}
+        />
       </button>
 
       <Overlay
         show={open}
-        offset={[0, 4]}
+        offset={[0, 0]}
         placement='bottom-start'
         onHide={handleClose}
         flip

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -5711,6 +5711,8 @@ a.status-card {
   }
 
   &__button {
+    display: flex;
+    align-items: center;
     color: $primary-text-color;
     background: var(--dropdown-background-color);
     border: 1px solid var(--dropdown-border-color);
@@ -5724,6 +5726,13 @@ a.status-card {
     &:disabled {
       cursor: default;
     }
+  }
+
+  &__icon {
+    margin-inline: auto -4px;
+    width: 18px;
+    height: 18px;
+    opacity: 0.5;
   }
 
   &__helper {


### PR DESCRIPTION
Fixes MAS-562

### Changes proposed in this PR:
- Adds an icon to the dropdown component to indicate that it's not just a text field
- Removed gap between dropdown menu and its trigger button

### Screenshots

<img width="641" height="431" alt="image" src="https://github.com/user-attachments/assets/2129500e-aca4-4914-9368-ca4ca7c184b9" />

<img width="643" height="446" alt="Screenshot 2025-09-08 at 13 16 26" src="https://github.com/user-attachments/assets/eae20180-7000-49c7-9aa9-f7313284b323" />

<img width="615" height="443" alt="image" src="https://github.com/user-attachments/assets/81e54cca-4a68-4822-8126-1429b608a5ba" />
