### PR TITLE
Remove old search results with new search

### DIFF
--- a/app/javascript/mastodon/reducers/search.ts
+++ b/app/javascript/mastodon/reducers/search.ts
@@ -62,6 +62,9 @@ export const searchReducer = createReducer(initialState, (builder) => {
     (state, action) => {
       state.type = action.meta.arg.type;
       state.loading = true;
+      if (action.type === submitSearch.pending.type) {
+        state.results = undefined;
+      }
     },
   );
 


### PR DESCRIPTION
Fixes #35743.

When initiating a new search, the old search results are not replaced in Redux until the new search succeeds. This would be fine, except the search page only shows the loading indicator if there are no results in Redux. Changing that would mean the search indicator would also appear over results when fetching more, which is not desirable.