### PR TITLE
Update style in `spec/validators` to match model specs

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -119,6 +119,7 @@ RSpec.configure do |config|
   config.include SignedRequestHelpers, type: :request
   config.include CommandLineHelpers, type: :cli
   config.include SystemHelpers, type: :system
+  config.include Shoulda::Matchers::ActiveModel, type: :validator
 
   # TODO: Remove when Devise fixes https://github.com/heartcombo/devise/issues/5705
   config.before do

--- a/spec/validators/date_of_birth_validator_spec.rb
+++ b/spec/validators/date_of_birth_validator_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe DateOfBirthValidator, type: :model do
+RSpec.describe DateOfBirthValidator do
   subject { Fabricate.build :user }
 
   before { Setting.min_age = 16 }

--- a/spec/validators/date_of_birth_validator_spec.rb
+++ b/spec/validators/date_of_birth_validator_spec.rb
@@ -2,50 +2,24 @@
 
 require 'rails_helper'
 
-RSpec.describe DateOfBirthValidator do
-  let(:record_class) do
-    Class.new do
-      include ActiveModel::Validations
+RSpec.describe DateOfBirthValidator, type: :model do
+  subject { Fabricate.build :user }
 
-      attr_accessor :date_of_birth
+  before { Setting.min_age = 16 }
 
-      validates :date_of_birth, date_of_birth: true
-    end
+  context 'with an invalid date' do
+    it { is_expected.to_not allow_values('76.830.10').for(:date_of_birth).with_message(:invalid) }
   end
 
-  let(:record) { record_class.new }
+  context 'with a date below age limit' do
+    let(:too_young) { 13.years.ago.strftime('%d.%m.%Y') }
 
-  before do
-    Setting.min_age = 16
+    it { is_expected.to_not allow_values(too_young).for(:date_of_birth).with_message(:below_limit) }
   end
 
-  describe '#validate_each' do
-    context 'with an invalid date' do
-      it 'adds errors' do
-        record.date_of_birth = '76.830.10'
+  context 'with a date above age limit' do
+    let(:exact_age) { 16.years.ago.strftime('%d.%m.%Y') }
 
-        expect(record).to_not be_valid
-        expect(record.errors.first.attribute).to eq(:date_of_birth)
-        expect(record.errors.first.type).to eq(:invalid)
-      end
-    end
-
-    context 'with a date below age limit' do
-      it 'adds errors' do
-        record.date_of_birth = 13.years.ago.strftime('%d.%m.%Y')
-
-        expect(record).to_not be_valid
-        expect(record.errors.first.attribute).to eq(:date_of_birth)
-        expect(record.errors.first.type).to eq(:below_limit)
-      end
-    end
-
-    context 'with a date above age limit' do
-      it 'does not add errors' do
-        record.date_of_birth = 16.years.ago.strftime('%d.%m.%Y')
-
-        expect(record).to be_valid
-      end
-    end
+    it { is_expected.to allow_values(exact_age).for(:date_of_birth) }
   end
 end

--- a/spec/validators/date_of_birth_validator_spec.rb
+++ b/spec/validators/date_of_birth_validator_spec.rb
@@ -8,18 +8,20 @@ RSpec.describe DateOfBirthValidator do
   before { Setting.min_age = 16 }
 
   context 'with an invalid date' do
-    it { is_expected.to_not allow_values('76.830.10').for(:date_of_birth).with_message(:invalid) }
+    let(:invalid_date) { '76.830.10' }
+
+    it { is_expected.to_not allow_values(invalid_date).for(:date_of_birth).with_message(:invalid) }
   end
 
-  context 'with a date below age limit' do
+  context 'with a date below the age limit' do
     let(:too_young) { 13.years.ago.strftime('%d.%m.%Y') }
 
     it { is_expected.to_not allow_values(too_young).for(:date_of_birth).with_message(:below_limit) }
   end
 
-  context 'with a date above age limit' do
-    let(:exact_age) { 16.years.ago.strftime('%d.%m.%Y') }
+  context 'with a date above the age limit' do
+    let(:old_enough) { 16.years.ago.strftime('%d.%m.%Y') }
 
-    it { is_expected.to allow_values(exact_age).for(:date_of_birth) }
+    it { is_expected.to allow_values(old_enough).for(:date_of_birth) }
   end
 end

--- a/spec/validators/disallowed_hashtags_validator_spec.rb
+++ b/spec/validators/disallowed_hashtags_validator_spec.rb
@@ -2,47 +2,48 @@
 
 require 'rails_helper'
 
-RSpec.describe DisallowedHashtagsValidator do
-  let(:disallowed_tags) { [] }
+RSpec.describe DisallowedHashtagsValidator, type: :model do
+  subject { Fabricate.build :status }
 
-  describe '#validate' do
-    before do
-      disallowed_tags.each { |name| Fabricate(:tag, name: name, usable: false) }
-      described_class.new.validate(status)
+  let(:tag_string) { 'ok #a #b #c then' }
+
+  context 'when local' do
+    before { subject.local = true }
+
+    context 'when reblog? is true' do
+      before { subject.reblog = Fabricate(:status) }
+
+      it { is_expected.to allow_values(nil, tag_string).for(:text) }
     end
 
-    let(:status) { instance_double(Status, errors: errors, local?: local, reblog?: reblog, text: disallowed_tags.map { |x| "##{x}" }.join(' ')) }
-    let(:errors) { instance_double(ActiveModel::Errors, add: nil) }
+    context 'when reblog? is false' do
+      context 'when text does not contain unusable tags' do
+        it { is_expected.to allow_values('text', tag_string).for(:text) }
+      end
 
-    context 'with a remote reblog' do
-      let(:local)  { false }
-      let(:reblog) { true }
+      context 'when text contains unusable tags' do
+        before { Fabricate :tag, name: 'a', usable: false }
 
-      it 'does not add errors' do
-        expect(errors).to_not have_received(:add).with(:text, any_args)
+        it { is_expected.to_not allow_values(tag_string).for(:text).with_message(disallow_message) }
+
+        def disallow_message
+          I18n.t('statuses.disallowed_hashtags', tags: 'a', count: 1)
+        end
       end
     end
+  end
 
-    context 'with a local original status' do
-      let(:local)  { true }
-      let(:reblog) { false }
+  context 'when remote' do
+    before { subject.local = false }
 
-      context 'when does not contain any disallowed hashtags' do
-        let(:disallowed_tags) { [] }
+    context 'when reblog? is true' do
+      before { subject.reblog = Fabricate(:status) }
 
-        it 'does not add errors' do
-          expect(errors).to_not have_received(:add).with(:text, any_args)
-        end
-      end
+      it { is_expected.to allow_values(nil, tag_string).for(:text) }
+    end
 
-      context 'when contains disallowed hashtags' do
-        let(:disallowed_tags) { %w(a b c) }
-
-        it 'adds an error' do
-          expect(errors).to have_received(:add)
-            .with(:text, I18n.t('statuses.disallowed_hashtags', tags: disallowed_tags.join(', '), count: disallowed_tags.size))
-        end
-      end
+    context 'when reblog? is false' do
+      it { is_expected.to allow_values('text', tag_string).for(:text) }
     end
   end
 end

--- a/spec/validators/disallowed_hashtags_validator_spec.rb
+++ b/spec/validators/disallowed_hashtags_validator_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe DisallowedHashtagsValidator, type: :model do
+RSpec.describe DisallowedHashtagsValidator do
   subject { Fabricate.build :status }
 
   let(:tag_string) { 'ok #a #b #c then' }

--- a/spec/validators/domain_validator_spec.rb
+++ b/spec/validators/domain_validator_spec.rb
@@ -2,13 +2,15 @@
 
 require 'rails_helper'
 
-RSpec.describe DomainValidator do
-  let(:record) { record_class.new }
+RSpec.describe DomainValidator, type: :model do
+  subject { record_class.new }
 
   context 'with no options' do
     let(:record_class) do
       Class.new do
         include ActiveModel::Validations
+
+        def self.name = 'Record'
 
         attr_accessor :domain
 
@@ -16,60 +18,30 @@ RSpec.describe DomainValidator do
       end
     end
 
-    describe '#validate_each' do
-      context 'with a nil value' do
-        it 'does not add errors' do
-          record.domain = nil
+    context 'with a nil value' do
+      it { is_expected.to allow_value(nil).for(:domain) }
+    end
 
-          expect(record).to be_valid
-          expect(record.errors).to be_empty
-        end
-      end
+    context 'with a valid domain' do
+      it { is_expected.to allow_value('host.example').for(:domain) }
+    end
 
-      context 'with a valid domain' do
-        it 'does not add errors' do
-          record.domain = 'example.com'
+    context 'with a domain that is too long' do
+      before { stub_const 'DomainValidator::MAX_DOMAIN_LENGTH', 8 }
 
-          expect(record).to be_valid
-          expect(record.errors).to be_empty
-        end
-      end
+      it { is_expected.to_not allow_value('host.example').for(:domain) }
+    end
 
-      context 'with a domain that is too long' do
-        it 'adds an error' do
-          record.domain = "#{'a' * 300}.com"
+    context 'with a domain with an empty segment' do
+      it { is_expected.to_not allow_value('.example.com').for(:domain) }
+    end
 
-          expect(record).to_not be_valid
-          expect(record.errors.where(:domain)).to_not be_empty
-        end
-      end
+    context 'with a domain with an invalid character' do
+      it { is_expected.to_not allow_value('*.example.com').for(:domain) }
+    end
 
-      context 'with a domain with an empty segment' do
-        it 'adds an error' do
-          record.domain = '.example.com'
-
-          expect(record).to_not be_valid
-          expect(record.errors.where(:domain)).to_not be_empty
-        end
-      end
-
-      context 'with a domain with an invalid character' do
-        it 'adds an error' do
-          record.domain = '*.example.com'
-
-          expect(record).to_not be_valid
-          expect(record.errors.where(:domain)).to_not be_empty
-        end
-      end
-
-      context 'with a domain that would fail parsing' do
-        it 'adds an error' do
-          record.domain = '/'
-
-          expect(record).to_not be_valid
-          expect(record.errors.where(:domain)).to_not be_empty
-        end
-      end
+    context 'with a domain that would fail parsing' do
+      it { is_expected.to_not allow_value('/').for(:domain) }
     end
   end
 
@@ -78,48 +50,28 @@ RSpec.describe DomainValidator do
       Class.new do
         include ActiveModel::Validations
 
+        def self.name = 'Record'
+
         attr_accessor :acct
 
         validates :acct, domain: { acct: true }
       end
     end
 
-    describe '#validate_each' do
-      context 'with a nil value' do
-        it 'does not add errors' do
-          record.acct = nil
+    context 'with a nil value' do
+      it { is_expected.to allow_value(nil).for(:acct) }
+    end
 
-          expect(record).to be_valid
-          expect(record.errors).to be_empty
-        end
-      end
+    context 'with no domain' do
+      it { is_expected.to allow_value('hoge_123').for(:acct) }
+    end
 
-      context 'with no domain' do
-        it 'does not add errors' do
-          record.acct = 'hoge_123'
+    context 'with a valid domain' do
+      it { is_expected.to allow_value('hoge_123@example.com').for(:acct) }
+    end
 
-          expect(record).to be_valid
-          expect(record.errors).to be_empty
-        end
-      end
-
-      context 'with a valid domain' do
-        it 'does not add errors' do
-          record.acct = 'hoge_123@example.com'
-
-          expect(record).to be_valid
-          expect(record.errors).to be_empty
-        end
-      end
-
-      context 'with an invalid domain' do
-        it 'adds an error' do
-          record.acct = 'hoge_123@.example.com'
-
-          expect(record).to_not be_valid
-          expect(record.errors.where(:acct)).to_not be_empty
-        end
-      end
+    context 'with an invalid domain' do
+      it { is_expected.to_not allow_value('hoge_123@.example.com').for(:acct) }
     end
   end
 end

--- a/spec/validators/domain_validator_spec.rb
+++ b/spec/validators/domain_validator_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe DomainValidator, type: :model do
+RSpec.describe DomainValidator do
   subject { record_class.new }
 
   context 'with no options' do

--- a/spec/validators/email_mx_validator_spec.rb
+++ b/spec/validators/email_mx_validator_spec.rb
@@ -3,89 +3,115 @@
 require 'rails_helper'
 
 RSpec.describe EmailMxValidator do
-  describe '#validate' do
-    let(:user) { instance_double(User, email: 'foo@example.com', sign_up_ip: '1.2.3.4', errors: instance_double(ActiveModel::Errors, add: nil)) }
-    let(:resolv_dns_double) { instance_double(Resolv::DNS) }
+  let(:user) { Fabricate.build :user, email: }
+  let(:email) { 'foo@example.com' }
+  let(:resolv_dns_double) { instance_double(Resolv::DNS) }
 
-    context 'with an e-mail domain that is explicitly allowed' do
-      around do |block|
-        tmp = Rails.configuration.x.email_domains_allowlist
-        Rails.configuration.x.email_domains_allowlist = 'example.com'
-        block.call
-        Rails.configuration.x.email_domains_allowlist = tmp
-      end
+  context 'with an e-mail domain that is explicitly allowed' do
+    around do |example|
+      original = Rails.configuration.x.email_domains_allowlist
+      Rails.configuration.x.email_domains_allowlist = 'example.com'
+      example.run
+      Rails.configuration.x.email_domains_allowlist = original
+    end
 
-      it 'does not add errors if there are no DNS records' do
-        configure_resolver('example.com')
+    context 'when there are not DNS records' do
+      before { configure_resolver('example.com') }
 
+      it 'does not add errors to record' do
         subject.validate(user)
-        expect(user.errors).to_not have_received(:add)
+        expect(user.errors).to be_empty
       end
-    end
-
-    it 'adds no error if there are DNS records for the e-mail domain' do
-      configure_resolver('example.com', a: resolv_double_a('192.0.2.42'))
-
-      subject.validate(user)
-      expect(user.errors).to_not have_received(:add)
-    end
-
-    it 'adds an error if the TagManager fails to normalize domain' do
-      double = instance_double(TagManager)
-      allow(TagManager).to receive(:instance).and_return(double)
-      allow(double).to receive(:normalize_domain).with('example.com').and_raise(Addressable::URI::InvalidURIError)
-
-      user = instance_double(User, email: 'foo@example.com', errors: instance_double(ActiveModel::Errors, add: nil))
-      subject.validate(user)
-      expect(user.errors).to have_received(:add)
-    end
-
-    it 'adds an error if the domain email portion is blank' do
-      user = instance_double(User, email: 'foo@', errors: instance_double(ActiveModel::Errors, add: nil))
-      subject.validate(user)
-      expect(user.errors).to have_received(:add)
-    end
-
-    it 'adds an error if the email domain name contains empty labels' do
-      configure_resolver('example..com', a: resolv_double_a('192.0.2.42'))
-
-      user = instance_double(User, email: 'foo@example..com', sign_up_ip: '1.2.3.4', errors: instance_double(ActiveModel::Errors, add: nil))
-      subject.validate(user)
-      expect(user.errors).to have_received(:add)
-    end
-
-    it 'adds an error if there are no DNS records for the e-mail domain' do
-      configure_resolver('example.com')
-
-      subject.validate(user)
-      expect(user.errors).to have_received(:add)
-    end
-
-    it 'adds an error if a MX record does not lead to an IP' do
-      configure_resolver('example.com', mx: resolv_double_mx('mail.example.com'))
-      configure_resolver('mail.example.com')
-
-      subject.validate(user)
-      expect(user.errors).to have_received(:add)
-    end
-
-    it 'adds an error if the MX record has an email domain block' do
-      EmailDomainBlock.create!(domain: 'mail.example.com')
-
-      configure_resolver(
-        'example.com',
-        mx: resolv_double_mx('mail.example.com')
-      )
-      configure_resolver(
-        'mail.example.com',
-        a: instance_double(Resolv::DNS::Resource::IN::A, address: '2.3.4.5'),
-        aaaa: instance_double(Resolv::DNS::Resource::IN::AAAA, address: 'fd00::2')
-      )
-
-      subject.validate(user)
-      expect(user.errors).to have_received(:add)
     end
   end
+
+  context 'when there are DNS records for the domain' do
+    let(:a) { resolv_double_a('192.0.2.42') }
+
+    before { configure_resolver('example.com', a:) }
+
+    it 'does not add errors to record' do
+      subject.validate(user)
+      expect(user.errors).to be_empty
+    end
+  end
+
+  context 'when the TagManager fails to normalize the domain' do
+    before do
+      allow(TagManager).to receive(:instance).and_return(tag_manage_double)
+      allow(tag_manage_double).to receive(:normalize_domain).with('example.com').and_raise(Addressable::URI::InvalidURIError)
+    end
+
+    let(:tag_manage_double) { instance_double(TagManager) }
+
+    it 'adds errors to record' do
+      subject.validate(user)
+      expect(user.errors).to be_present
+    end
+  end
+
+  context 'when the email portion is blank' do
+    let(:email) { 'foo@' }
+
+    it 'adds errors to record' do
+      subject.validate(user)
+      expect(user.errors).to be_present
+    end
+  end
+
+  context 'when the email domain contains empty labels' do
+    let(:a) { resolv_double_a('192.0.2.42') }
+    let(:email) { 'foo@example..com' }
+
+    before { configure_resolver('example..com', a:) }
+
+    it 'adds errors to record' do
+      subject.validate(user)
+      expect(user.errors).to be_present
+    end
+  end
+
+  context 'when there are no DNS records for the email domain' do
+    before { configure_resolver('example.com') }
+
+    it 'adds errors to record' do
+      subject.validate(user)
+      expect(user.errors).to be_present
+    end
+  end
+
+  context 'when MX record does not lead to an IP' do
+    let(:mx) { resolv_double_mx('mail.example.com') }
+
+    before do
+      configure_resolver('example.com', mx:)
+      configure_resolver('mail.example.com')
+    end
+
+    it 'adds errors to record' do
+      subject.validate(user)
+      expect(user.errors).to be_present
+    end
+  end
+
+  context 'when the MX record has an email domain block' do
+    let(:mx) { resolv_double_mx('mail.example.com') }
+    let(:a) { instance_double(Resolv::DNS::Resource::IN::A, address: '2.3.4.5') }
+    let(:aaaa) { instance_double(Resolv::DNS::Resource::IN::AAAA, address: 'fd00::2') }
+
+    before do
+      Fabricate :email_domain_block, domain: 'mail.example.com'
+      configure_resolver('example.com', mx:)
+      configure_resolver('mail.example.com', a:, aaaa:)
+    end
+
+    it 'adds errors to record' do
+      subject.validate(user)
+      expect(user.errors).to be_present
+    end
+  end
+
+  private
 
   def configure_resolver(domain, options = {})
     allow(resolv_dns_double)

--- a/spec/validators/existing_username_validator_spec.rb
+++ b/spec/validators/existing_username_validator_spec.rb
@@ -2,83 +2,45 @@
 
 require 'rails_helper'
 
-RSpec.describe ExistingUsernameValidator do
+RSpec.describe ExistingUsernameValidator, type: :model do
+  subject { record_class.new }
+
   let(:record_class) do
     Class.new do
       include ActiveModel::Validations
 
       attr_accessor :contact, :friends
 
-      def self.name
-        'Record'
-      end
+      def self.name = 'Record'
 
       validates :contact, existing_username: true
       validates :friends, existing_username: { multiple: true }
     end
   end
-  let(:record) { record_class.new }
 
-  describe '#validate_each' do
-    context 'with a nil value' do
-      it 'does not add errors' do
-        record.contact = nil
+  context 'with a nil value' do
+    it { is_expected.to allow_value(nil).for(:contact) }
+  end
 
-        expect(record).to be_valid
-        expect(record.errors).to be_empty
+  context 'when there are no accounts' do
+    it { is_expected.to_not allow_value('user@example.com').for(:contact).with_message(I18n.t('existing_username_validator.not_found')) }
+  end
+
+  context 'when there are accounts' do
+    before { Fabricate(:account, domain: 'example.com', username: 'user') }
+
+    context 'when the value does not match' do
+      it { is_expected.to_not allow_value('friend@other.host').for(:contact).with_message(I18n.t('existing_username_validator.not_found')) }
+
+      context 'when multiple is true' do
+        it { is_expected.to_not allow_value('friend@other.host').for(:friends).with_message(I18n.t('existing_username_validator.not_found_multiple', usernames: 'friend@other.host')) }
       end
     end
 
-    context 'when there are no accounts' do
-      it 'adds errors to the record' do
-        record.contact = 'user@example.com'
+    context 'when the value does match' do
+      it { is_expected.to allow_value('user@example.com').for(:contact) }
 
-        expect(record).to_not be_valid
-        expect(record.errors.first.attribute).to eq(:contact)
-        expect(record.errors.first.type).to eq I18n.t('existing_username_validator.not_found')
-      end
-    end
-
-    context 'when there are accounts' do
-      before { Fabricate(:account, domain: 'example.com', username: 'user') }
-
-      context 'when the value does not match' do
-        it 'adds errors to the record' do
-          record.contact = 'friend@other.host'
-
-          expect(record).to_not be_valid
-          expect(record.errors.first.attribute).to eq(:contact)
-          expect(record.errors.first.type).to eq I18n.t('existing_username_validator.not_found')
-        end
-
-        context 'when multiple is true' do
-          it 'adds errors to the record' do
-            record.friends = 'friend@other.host'
-
-            expect(record).to_not be_valid
-            expect(record.errors.first.attribute).to eq(:friends)
-            expect(record.errors.first.type).to eq I18n.t('existing_username_validator.not_found_multiple', usernames: 'friend@other.host')
-          end
-        end
-      end
-
-      context 'when the value does match' do
-        it 'does not add errors to the record' do
-          record.contact = 'user@example.com'
-
-          expect(record).to be_valid
-          expect(record.errors).to be_empty
-        end
-
-        context 'when multiple is true' do
-          it 'does not add errors to the record' do
-            record.friends = 'user@example.com'
-
-            expect(record).to be_valid
-            expect(record.errors).to be_empty
-          end
-        end
-      end
+      it { is_expected.to allow_value('user@example.com').for(:friends) }
     end
   end
 end

--- a/spec/validators/existing_username_validator_spec.rb
+++ b/spec/validators/existing_username_validator_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe ExistingUsernameValidator, type: :model do
+RSpec.describe ExistingUsernameValidator do
   subject { record_class.new }
 
   let(:record_class) do

--- a/spec/validators/follow_limit_validator_spec.rb
+++ b/spec/validators/follow_limit_validator_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe FollowLimitValidator, type: :model do
+RSpec.describe FollowLimitValidator do
   subject { Fabricate.build(:follow) }
 
   context 'with a nil account' do

--- a/spec/validators/follow_limit_validator_spec.rb
+++ b/spec/validators/follow_limit_validator_spec.rb
@@ -2,77 +2,45 @@
 
 require 'rails_helper'
 
-RSpec.describe FollowLimitValidator do
-  describe '#validate' do
-    context 'with a nil account' do
-      it 'does not add validation errors to base' do
-        follow = Fabricate.build(:follow, account: nil)
+RSpec.describe FollowLimitValidator, type: :model do
+  subject { Fabricate.build(:follow) }
 
-        follow.valid?
+  context 'with a nil account' do
+    it { is_expected.to allow_values(nil).for(:account).against(:base) }
+  end
 
-        expect(follow.errors[:base]).to be_empty
-      end
+  context 'with a non-local account' do
+    let(:account) { Account.new(domain: 'host.example') }
+
+    it { is_expected.to allow_values(account).for(:account).against(:base) }
+  end
+
+  context 'with a local account' do
+    let(:account) { Account.new }
+
+    context 'when the followers count is under the limit' do
+      before { account.following_count = described_class::LIMIT - 100 }
+
+      it { is_expected.to allow_values(account).for(:account).against(:base) }
     end
 
-    context 'with a non-local account' do
-      it 'does not add validation errors to base' do
-        follow = Fabricate.build(:follow, account: Account.new(domain: 'host.example'))
+    context 'when the following count is over the limit' do
+      before { account.following_count = described_class::LIMIT + 100 }
 
-        follow.valid?
+      context 'when the followers count is low' do
+        before { account.followers_count = 10 }
 
-        expect(follow.errors[:base]).to be_empty
-      end
-    end
+        it { is_expected.to_not allow_values(account).for(:account).against(:base).with_message(limit_reached_message) }
 
-    context 'with a local account' do
-      let(:account) { Account.new }
-
-      context 'when the followers count is under the limit' do
-        before do
-          allow(account).to receive(:following_count).and_return(described_class::LIMIT - 100)
-        end
-
-        it 'does not add validation errors to base' do
-          follow = Fabricate.build(:follow, account: account)
-
-          follow.valid?
-
-          expect(follow.errors[:base]).to be_empty
+        def limit_reached_message
+          I18n.t('users.follow_limit_reached', limit: described_class::LIMIT)
         end
       end
 
-      context 'when the following count is over the limit' do
-        before do
-          allow(account).to receive(:following_count).and_return(described_class::LIMIT + 100)
-        end
+      context 'when the followers count is high' do
+        before { account.followers_count = 100_000 }
 
-        context 'when the followers count is low' do
-          before do
-            allow(account).to receive(:followers_count).and_return(10)
-          end
-
-          it 'adds validation errors to base' do
-            follow = Fabricate.build(:follow, account: account)
-
-            follow.valid?
-
-            expect(follow.errors[:base]).to include(I18n.t('users.follow_limit_reached', limit: described_class::LIMIT))
-          end
-        end
-
-        context 'when the followers count is high' do
-          before do
-            allow(account).to receive(:followers_count).and_return(100_000)
-          end
-
-          it 'does not add validation errors to base' do
-            follow = Fabricate.build(:follow, account: account)
-
-            follow.valid?
-
-            expect(follow.errors[:base]).to be_empty
-          end
-        end
+        it { is_expected.to allow_values(account).for(:account).against(:base) }
       end
     end
   end

--- a/spec/validators/language_validator_spec.rb
+++ b/spec/validators/language_validator_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe LanguageValidator, type: :model do
+RSpec.describe LanguageValidator do
   subject { record_class.new }
 
   let(:record_class) do

--- a/spec/validators/language_validator_spec.rb
+++ b/spec/validators/language_validator_spec.rb
@@ -2,60 +2,34 @@
 
 require 'rails_helper'
 
-RSpec.describe LanguageValidator do
+RSpec.describe LanguageValidator, type: :model do
+  subject { record_class.new }
+
   let(:record_class) do
     Class.new do
       include ActiveModel::Validations
+
+      def self.name = 'Record'
 
       attr_accessor :locale
 
       validates :locale, language: true
     end
   end
-  let(:record) { record_class.new }
 
-  describe '#validate_each' do
-    context 'with a nil value' do
-      it 'does not add errors' do
-        record.locale = nil
+  context 'with a nil value' do
+    it { is_expected.to allow_value(nil).for(:locale) }
+  end
 
-        expect(record).to be_valid
-        expect(record.errors).to be_empty
-      end
-    end
+  context 'with an array of values' do
+    it { is_expected.to allow_value(%w(en fr)).for(:locale) }
 
-    context 'with an array of values' do
-      it 'does not add errors with array of existing locales' do
-        record.locale = %w(en fr)
+    it { is_expected.to_not allow_value(%w(en fr missing)).for(:locale).with_message(:invalid) }
+  end
 
-        expect(record).to be_valid
-        expect(record.errors).to be_empty
-      end
+  context 'with a locale string' do
+    it { is_expected.to allow_value('en').for(:locale) }
 
-      it 'adds errors with array having some non-existing locales' do
-        record.locale = %w(en fr missing)
-
-        expect(record).to_not be_valid
-        expect(record.errors.first.attribute).to eq(:locale)
-        expect(record.errors.first.type).to eq(:invalid)
-      end
-    end
-
-    context 'with a locale string' do
-      it 'does not add errors when string is an existing locale' do
-        record.locale = 'en'
-
-        expect(record).to be_valid
-        expect(record.errors).to be_empty
-      end
-
-      it 'adds errors when string is non-existing locale' do
-        record.locale = 'missing'
-
-        expect(record).to_not be_valid
-        expect(record.errors.first.attribute).to eq(:locale)
-        expect(record.errors.first.type).to eq(:invalid)
-      end
-    end
+    it { is_expected.to_not allow_value('missing').for(:locale).with_message(:invalid) }
   end
 end

--- a/spec/validators/note_length_validator_spec.rb
+++ b/spec/validators/note_length_validator_spec.rb
@@ -2,62 +2,60 @@
 
 require 'rails_helper'
 
-RSpec.describe NoteLengthValidator do
-  subject { described_class.new(attributes: { note: true }, maximum: 500) }
+RSpec.describe NoteLengthValidator, type: :model do
+  subject { record_class.new }
 
-  describe '#validate' do
-    it 'adds an error when text is over configured character limit' do
-      text = 'a' * 520
-      account = instance_double(Account, note: text, errors: activemodel_errors)
+  let(:record_class) do
+    Class.new do
+      include ActiveModel::Validations
 
-      subject.validate_each(account, 'note', text)
-      expect(account.errors).to have_received(:add)
+      def self.name = 'Record'
+
+      attr_accessor :note
+
+      validates :note, note_length: { maximum: 100 }
     end
+  end
 
-    it 'reduces calculated length of auto-linkable space-separated URLs' do
-      text = [starting_string, example_link].join(' ')
-      account = instance_double(Account, note: text, errors: activemodel_errors)
+  context 'when note is too long' do
+    it { is_expected.to_not allow_value('a' * 200).for(:note).with_message(too_long_message) }
+  end
 
-      subject.validate_each(account, 'note', text)
-      expect(account.errors).to_not have_received(:add)
-    end
+  context 'when note has space separated linkable URLs' do
+    let(:text) { [starting_string, example_link].join(' ') }
 
-    it 'does not reduce calculated length of non-autolinkable URLs' do
-      text = [starting_string, example_link].join
-      account = instance_double(Account, note: text, errors: activemodel_errors)
+    it { is_expected.to allow_value(text).for(:note) }
+  end
 
-      subject.validate_each(account, 'note', text)
-      expect(account.errors).to have_received(:add)
-    end
+  context 'when note has non-separated URLs' do
+    let(:text) { [starting_string, example_link].join }
 
-    it 'counts multi byte emoji as single character' do
-      text = '✨' * 500
-      account = instance_double(Account, note: text, errors: activemodel_errors)
+    it { is_expected.to_not allow_value(text).for(:note).with_message(too_long_message) }
+  end
 
-      subject.validate_each(account, 'note', text)
-      expect(account.errors).to_not have_received(:add)
-    end
+  context 'with multi-byte emoji' do
+    let(:text) { '✨' * 100 }
 
-    it 'counts ZWJ sequence emoji as single character' do
-      text = '🏳️‍⚧️' * 500
-      account = instance_double(Account, note: text, errors: activemodel_errors)
+    it { is_expected.to allow_value(text).for(:note) }
+  end
 
-      subject.validate_each(account, 'note', text)
-      expect(account.errors).to_not have_received(:add)
-    end
+  context 'with ZWJ sequence emoji' do
+    let(:text) { '🏳️‍⚧️' * 100 }
 
-    private
+    it { is_expected.to allow_value(text).for(:note) }
+  end
 
-    def starting_string
-      'a' * 476
-    end
+  private
 
-    def example_link
-      "http://#{'b' * 30}.com/example"
-    end
+  def too_long_message
+    I18n.t('statuses.over_character_limit', max: 100)
+  end
 
-    def activemodel_errors
-      instance_double(ActiveModel::Errors, add: nil)
-    end
+  def starting_string
+    'a' * 76
+  end
+
+  def example_link
+    "http://#{'b' * 30}.com/example"
   end
 end

--- a/spec/validators/note_length_validator_spec.rb
+++ b/spec/validators/note_length_validator_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe NoteLengthValidator, type: :model do
+RSpec.describe NoteLengthValidator do
   subject { record_class.new }
 
   let(:record_class) do

--- a/spec/validators/note_length_validator_spec.rb
+++ b/spec/validators/note_length_validator_spec.rb
@@ -18,7 +18,9 @@ RSpec.describe NoteLengthValidator do
   end
 
   context 'when note is too long' do
-    it { is_expected.to_not allow_value('a' * 200).for(:note).with_message(too_long_message) }
+    let(:too_long) { 'a' * 200 }
+
+    it { is_expected.to_not allow_value(too_long).for(:note).with_message(too_long_message) }
   end
 
   context 'when note has space separated linkable URLs' do

--- a/spec/validators/poll_expiration_validator_spec.rb
+++ b/spec/validators/poll_expiration_validator_spec.rb
@@ -6,14 +6,20 @@ RSpec.describe PollExpirationValidator do
   subject { Fabricate.build :poll }
 
   context 'when poll expires in far future' do
-    it { is_expected.to_not allow_value(6.months.from_now).for(:expires_at).with_message(I18n.t('polls.errors.duration_too_long')) }
+    let(:far_future) { 6.months.from_now }
+
+    it { is_expected.to_not allow_value(far_future).for(:expires_at).with_message(I18n.t('polls.errors.duration_too_long')) }
   end
 
   context 'when poll expires in far past' do
-    it { is_expected.to_not allow_value(6.days.ago).for(:expires_at).with_message(I18n.t('polls.errors.duration_too_short')) }
+    let(:past_date) { 6.days.ago }
+
+    it { is_expected.to_not allow_value(past_date).for(:expires_at).with_message(I18n.t('polls.errors.duration_too_short')) }
   end
 
   context 'when poll expires in medium future' do
-    it { is_expected.to allow_value(10.minutes.from_now).for(:expires_at) }
+    let(:allowed_future) { 10.minutes.from_now }
+
+    it { is_expected.to allow_value(allowed_future).for(:expires_at) }
   end
 end

--- a/spec/validators/poll_expiration_validator_spec.rb
+++ b/spec/validators/poll_expiration_validator_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe PollExpirationValidator, type: :model do
+RSpec.describe PollExpirationValidator do
   subject { Fabricate.build :poll }
 
   context 'when poll expires in far future' do

--- a/spec/validators/poll_expiration_validator_spec.rb
+++ b/spec/validators/poll_expiration_validator_spec.rb
@@ -3,20 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe PollExpirationValidator, type: :model do
-  subject { record_class.new }
-
-  let(:record_class) do
-    Class.new do
-      include ActiveModel::Validations
-      include ActiveModel::Attributes
-
-      def self.name = 'Record'
-
-      attribute :expires_at, :datetime
-
-      validates_with PollExpirationValidator
-    end
-  end
+  subject { Fabricate.build :poll }
 
   context 'when poll expires in far future' do
     it { is_expected.to_not allow_value(6.months.from_now).for(:expires_at).with_message(I18n.t('polls.errors.duration_too_long')) }

--- a/spec/validators/poll_options_validator_spec.rb
+++ b/spec/validators/poll_options_validator_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe PollOptionsValidator, type: :model do
+RSpec.describe PollOptionsValidator do
   subject { Fabricate.build :poll }
 
   context 'when poll has unique valid options' do

--- a/spec/validators/poll_options_validator_spec.rb
+++ b/spec/validators/poll_options_validator_spec.rb
@@ -2,70 +2,56 @@
 
 require 'rails_helper'
 
-RSpec.describe PollOptionsValidator do
-  describe '#validate' do
-    before do
-      validator.validate(poll)
+RSpec.describe PollOptionsValidator, type: :model do
+  subject { record_class.new }
+
+  let(:record_class) do
+    Class.new do
+      include ActiveModel::Validations
+
+      def self.name = 'Record'
+
+      attr_accessor :options
+
+      validates_with PollOptionsValidator
+    end
+  end
+
+  context 'when poll has unique valid options' do
+    it { is_expected.to allow_values(%w(One Two)).for(:options) }
+  end
+
+  context 'when poll has too few options' do
+    it { is_expected.to_not allow_values([]).for(:options).with_message(I18n.t('polls.errors.too_few_options')) }
+  end
+
+  context 'when poll has too many options' do
+    before { stub_const 'PollOptionsValidator::MAX_OPTIONS', 2 }
+
+    it { is_expected.to_not allow_values(%w(One Two Three)).for(:options).with_message(I18n.t('polls.errors.too_many_options', max: 2)) }
+  end
+
+  context 'when poll has duplicate options' do
+    it { is_expected.to_not allow_values(%w(One One One)).for(:options).with_message(I18n.t('polls.errors.duplicate_options')) }
+  end
+
+  describe 'poll option length limits' do
+    let(:limit) { 5 }
+
+    before { stub_const 'PollOptionsValidator::MAX_OPTION_CHARS', limit }
+
+    context 'when poll has acceptable length options' do
+      it { is_expected.to allow_values(%w(One Two)).for(:options) }
     end
 
-    let(:validator) { described_class.new }
-    let(:poll) { instance_double(Poll, options: options, expires_at: expires_at, errors: errors) }
-    let(:errors) { instance_double(ActiveModel::Errors, add: nil) }
-    let(:options) { %w(foo bar) }
-    let(:expires_at) { 1.day.from_now }
+    context 'when poll has multibyte and ZWJ emoji options' do
+      let(:options) { ['✨' * limit, '🏳️‍⚧️' * limit] }
 
-    it 'has no errors' do
-      expect(errors).to_not have_received(:add)
+      it { is_expected.to allow_values(options).for(:options) }
     end
 
-    context 'when the poll has duplicate options' do
-      let(:options) { %w(foo foo) }
-
-      it 'adds errors' do
-        expect(errors).to have_received(:add)
-      end
-    end
-
-    context 'when the poll has no options' do
-      let(:options) { [] }
-
-      it 'adds errors' do
-        expect(errors).to have_received(:add)
-      end
-    end
-
-    context 'when the poll has too many options' do
-      let(:options) { Array.new(described_class::MAX_OPTIONS + 1) { |i| "option #{i}" } }
-
-      it 'adds errors' do
-        expect(errors).to have_received(:add)
-      end
-    end
-
-    describe 'character length of poll options' do
-      context 'when poll has acceptable length options' do
-        let(:options) { %w(test this) }
-
-        it 'has no errors' do
-          expect(errors).to_not have_received(:add)
-        end
-      end
-
-      context 'when poll has multibyte and ZWJ emoji options' do
-        let(:options) { ['✨' * described_class::MAX_OPTION_CHARS, '🏳️‍⚧️' * described_class::MAX_OPTION_CHARS] }
-
-        it 'has no errors' do
-          expect(errors).to_not have_received(:add)
-        end
-      end
-
-      context 'when poll has options that are too long' do
-        let(:options) { ['ok', 'a' * (described_class::MAX_OPTION_CHARS**2)] }
-
-        it 'has errors' do
-          expect(errors).to have_received(:add)
-        end
-      end
+    context 'when poll has options that are too long' do
+      it { is_expected.to_not allow_values(%w(Airplane Two Three)).for(:options).with_message(I18n.t('polls.errors.over_character_limit', max: limit)) }
     end
   end
 end

--- a/spec/validators/poll_options_validator_spec.rb
+++ b/spec/validators/poll_options_validator_spec.rb
@@ -3,19 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe PollOptionsValidator, type: :model do
-  subject { record_class.new }
-
-  let(:record_class) do
-    Class.new do
-      include ActiveModel::Validations
-
-      def self.name = 'Record'
-
-      attr_accessor :options
-
-      validates_with PollOptionsValidator
-    end
-  end
+  subject { Fabricate.build :poll }
 
   context 'when poll has unique valid options' do
     it { is_expected.to allow_values(%w(One Two)).for(:options) }

--- a/spec/validators/reaction_validator_spec.rb
+++ b/spec/validators/reaction_validator_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe ReactionValidator, type: :model do
+RSpec.describe ReactionValidator do
   subject { Fabricate.build :announcement_reaction }
 
   context 'when not valid unicode emoji' do

--- a/spec/validators/reaction_validator_spec.rb
+++ b/spec/validators/reaction_validator_spec.rb
@@ -2,42 +2,36 @@
 
 require 'rails_helper'
 
-RSpec.describe ReactionValidator do
-  let(:announcement) { Fabricate(:announcement) }
+RSpec.describe ReactionValidator, type: :model do
+  subject { Fabricate.build :announcement_reaction }
 
-  describe '#validate' do
-    it 'adds error when not a valid unicode emoji' do
-      reaction = announcement.announcement_reactions.build(name: 'F')
-      subject.validate(reaction)
-      expect(reaction.errors).to_not be_empty
-    end
+  context 'when not valid unicode emoji' do
+    it { is_expected.to_not allow_value('F').for(:name).with_message(I18n.t('reactions.errors.unrecognized_emoji')) }
+  end
 
-    it 'does not add error when non-unicode emoji is a custom emoji' do
-      custom_emoji = Fabricate(:custom_emoji)
-      reaction = announcement.announcement_reactions.build(name: custom_emoji.shortcode, custom_emoji_id: custom_emoji.id)
-      subject.validate(reaction)
-      expect(reaction.errors).to be_empty
-    end
+  context 'when non-unicode emoji is a custom emoji' do
+    let!(:custom_emoji) { Fabricate :custom_emoji }
 
-    it 'adds error when reaction limit count has already been reached' do
-      stub_const 'ReactionValidator::LIMIT', 2
-      %w(🐘 ❤️).each do |name|
-        announcement.announcement_reactions.create!(name: name, account: Fabricate(:account))
+    it { is_expected.to allow_value(custom_emoji.shortcode).for(:name) }
+  end
+
+  describe 'limiting reactions' do
+    subject { Fabricate.build :announcement_reaction, announcement: }
+
+    let(:announcement) { Fabricate :announcement }
+
+    before { stub_const 'ReactionValidator::LIMIT', 2 }
+
+    context 'when limit has been reached' do
+      before { %w(🐘 ❤️).each { |name| Fabricate :announcement_reaction, name: name, announcement: } }
+
+      context 'with emoji already used' do
+        it { is_expected.to allow_value('❤️').for(:name) }
       end
 
-      reaction = announcement.announcement_reactions.build(name: '😘')
-      subject.validate(reaction)
-      expect(reaction.errors).to_not be_empty
-    end
-
-    it 'does not add error when new reaction is part of the existing ones' do
-      %w(🐘 ❤️ 🙉 😍 😋 😂 😞 👍).each do |name|
-        announcement.announcement_reactions.create!(name: name, account: Fabricate(:account))
+      context 'with emoji not already used' do
+        it { is_expected.to_not allow_value('😘').for(:name).against(:base).with_message(I18n.t('reactions.errors.limit_reached')) }
       end
-
-      reaction = announcement.announcement_reactions.build(name: '😋')
-      subject.validate(reaction)
-      expect(reaction.errors).to be_empty
     end
   end
 end

--- a/spec/validators/reaction_validator_spec.rb
+++ b/spec/validators/reaction_validator_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe ReactionValidator do
     before { stub_const 'ReactionValidator::LIMIT', 2 }
 
     context 'when limit has been reached' do
-      before { %w(🐘 ❤️).each { |name| Fabricate :announcement_reaction, name: name, announcement: } }
+      before { %w(🐘 ❤️).each { |name| Fabricate :announcement_reaction, name:, announcement: } }
 
       context 'with emoji already used' do
         it { is_expected.to allow_value('❤️').for(:name) }

--- a/spec/validators/status_length_validator_spec.rb
+++ b/spec/validators/status_length_validator_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe StatusLengthValidator, type: :model do
+RSpec.describe StatusLengthValidator do
   subject { Fabricate.build :status }
 
   before { stub_const 'StatusLengthValidator::MAX_CHARS', 100 }

--- a/spec/validators/status_length_validator_spec.rb
+++ b/spec/validators/status_length_validator_spec.rb
@@ -2,124 +2,87 @@
 
 require 'rails_helper'
 
-RSpec.describe StatusLengthValidator do
-  describe '#validate' do
-    before { stub_const("#{described_class}::MAX_CHARS", 500) } # Example values below are relative to this baseline
+RSpec.describe StatusLengthValidator, type: :model do
+  subject { Fabricate.build :status }
 
-    it 'does not add errors onto remote statuses' do
-      status = instance_double(Status, local?: false)
-      allow(status).to receive(:errors)
+  before { stub_const 'StatusLengthValidator::MAX_CHARS', 100 }
 
-      subject.validate(status)
+  context 'when status is remote' do
+    before { subject.update! account: Fabricate(:account, domain: 'host.example') }
 
-      expect(status).to_not have_received(:errors)
-    end
+    it { is_expected.to allow_value('a' * 200).for(:text) }
+    it { is_expected.to allow_value('a' * 200).for(:spoiler_text).against(:text) }
+  end
 
-    it 'does not add errors onto local reblogs' do
-      status = instance_double(Status, local?: false, reblog?: true)
-      allow(status).to receive(:errors)
+  context 'when status is a local reblog' do
+    before { subject.update! reblog: Fabricate(:status) }
 
-      subject.validate(status)
+    it { is_expected.to allow_value('a' * 200).for(:text) }
+    it { is_expected.to allow_value('a' * 200).for(:spoiler_text).against(:text) }
+  end
 
-      expect(status).to_not have_received(:errors)
-    end
+  context 'when text is over character limit' do
+    it { is_expected.to_not allow_value('a' * 200).for(:text).with_message(too_long_message) }
+  end
 
-    it 'adds an error when content warning is over character limit' do
-      status = status_double(spoiler_text: 'a' * 520)
-      subject.validate(status)
-      expect(status.errors).to have_received(:add)
-    end
+  context 'when content warning text is over character limit' do
+    it { is_expected.to_not allow_value('a' * 200).for(:spoiler_text).against(:text).with_message(too_long_message) }
+  end
 
-    it 'adds an error when text is over character limit' do
-      status = status_double(text: 'a' * 520)
-      subject.validate(status)
-      expect(status.errors).to have_received(:add)
-    end
+  context 'when text and content warning combine to exceed limit' do
+    before { subject.text = 'a' * 50 }
 
-    it 'adds an error when text and content warning are over character limit total' do
-      status = status_double(spoiler_text: 'a' * 250, text: 'b' * 251)
-      subject.validate(status)
-      expect(status.errors).to have_received(:add)
-    end
+    it { is_expected.to_not allow_value('a' * 55).for(:spoiler_text).against(:text).with_message(too_long_message) }
+  end
 
-    it 'reduces calculated length of auto-linkable space-separated URLs' do
-      text = [starting_string, example_link].join(' ')
-      status = status_double(text: text)
+  context 'when text has space separated linkable URLs' do
+    let(:text) { [starting_string, example_link].join(' ') }
 
-      subject.validate(status)
-      expect(status.errors).to_not have_received(:add)
-    end
+    it { is_expected.to allow_value(text).for(:text) }
+  end
 
-    it 'does not reduce calculated length of non-autolinkable URLs' do
-      text = [starting_string, example_link].join
-      status = status_double(text: text)
+  context 'when text has non-separated URLs' do
+    let(:text) { [starting_string, example_link].join }
 
-      subject.validate(status)
-      expect(status.errors).to have_received(:add)
-    end
+    it { is_expected.to_not allow_value(text).for(:text).with_message(too_long_message) }
+  end
 
-    it 'does not reduce calculated length of count overly long URLs' do
-      text = "http://example.com/valid?#{'#foo?' * 1000}"
-      status = status_double(text: text)
-      subject.validate(status)
-      expect(status.errors).to have_received(:add)
-    end
+  context 'with excessively long URLs' do
+    let(:text) { "http://example.com/valid?#{'#foo?' * 1000}" }
 
-    it 'counts only the front part of remote usernames' do
-      text   = ('a' * 475) + " @alice@#{'b' * 30}.com"
-      status = status_double(text: text)
+    it { is_expected.to_not allow_value(text).for(:text).with_message(too_long_message) }
+  end
 
-      subject.validate(status)
-      expect(status.errors).to_not have_received(:add)
-    end
+  context 'when remote account usernames cause limit excess' do
+    let(:text) { ('a' * 75) + " @alice@#{'b' * 30}.com" }
 
-    it 'does count both parts of remote usernames for overly long domains' do
-      text   = "@alice@#{'b' * 500}.com"
-      status = status_double(text: text)
+    it { is_expected.to allow_value(text).for(:text) }
+  end
 
-      subject.validate(status)
-      expect(status.errors).to have_received(:add)
-    end
+  context 'when remote usernames are attached to long domains' do
+    let(:text) { "@alice@#{'b' * 300}.com" }
 
-    it 'counts multi byte emoji as single character' do
-      text = '✨' * 500
-      status = status_double(text: text)
+    it { is_expected.to_not allow_value(text).for(:text).with_message(too_long_message) }
+  end
 
-      subject.validate(status)
-      expect(status.errors).to_not have_received(:add)
-    end
+  context 'with special character strings' do
+    let(:multibyte_emoji) { '✨' * 100 }
+    let(:zwj_sequence) { '🏳️‍⚧️' * 100 }
 
-    it 'counts ZWJ sequence emoji as single character' do
-      text = '🏳️‍⚧️' * 500
-      status = status_double(text: text)
-
-      subject.validate(status)
-      expect(status.errors).to_not have_received(:add)
-    end
+    it { is_expected.to allow_values(multibyte_emoji, zwj_sequence).for(:text) }
   end
 
   private
 
+  def too_long_message
+    I18n.t('statuses.over_character_limit', max: described_class::MAX_CHARS)
+  end
+
   def starting_string
-    'a' * 476
+    'a' * 76
   end
 
   def example_link
     "http://#{'b' * 30}.com/example"
-  end
-
-  def status_double(spoiler_text: '', text: '')
-    instance_double(
-      Status,
-      spoiler_text: spoiler_text,
-      text: text,
-      errors: activemodel_errors,
-      local?: true,
-      reblog?: false
-    )
-  end
-
-  def activemodel_errors
-    instance_double(ActiveModel::Errors, add: nil)
   end
 end

--- a/spec/validators/status_length_validator_spec.rb
+++ b/spec/validators/status_length_validator_spec.rb
@@ -7,26 +7,28 @@ RSpec.describe StatusLengthValidator do
 
   before { stub_const 'StatusLengthValidator::MAX_CHARS', 100 }
 
+  let(:over_limit_text) { 'a' * described_class::MAX_CHARS * 2 }
+
   context 'when status is remote' do
     before { subject.update! account: Fabricate(:account, domain: 'host.example') }
 
-    it { is_expected.to allow_value('a' * 200).for(:text) }
-    it { is_expected.to allow_value('a' * 200).for(:spoiler_text).against(:text) }
+    it { is_expected.to allow_value(over_limit_text).for(:text) }
+    it { is_expected.to allow_value(over_limit_text).for(:spoiler_text).against(:text) }
   end
 
   context 'when status is a local reblog' do
     before { subject.update! reblog: Fabricate(:status) }
 
-    it { is_expected.to allow_value('a' * 200).for(:text) }
-    it { is_expected.to allow_value('a' * 200).for(:spoiler_text).against(:text) }
+    it { is_expected.to allow_value(over_limit_text).for(:text) }
+    it { is_expected.to allow_value(over_limit_text).for(:spoiler_text).against(:text) }
   end
 
   context 'when text is over character limit' do
-    it { is_expected.to_not allow_value('a' * 200).for(:text).with_message(too_long_message) }
+    it { is_expected.to_not allow_value(over_limit_text).for(:text).with_message(too_long_message) }
   end
 
   context 'when content warning text is over character limit' do
-    it { is_expected.to_not allow_value('a' * 200).for(:spoiler_text).against(:text).with_message(too_long_message) }
+    it { is_expected.to_not allow_value(over_limit_text).for(:spoiler_text).against(:text).with_message(too_long_message) }
   end
 
   context 'when text and content warning combine to exceed limit' do
@@ -66,8 +68,8 @@ RSpec.describe StatusLengthValidator do
   end
 
   context 'with special character strings' do
-    let(:multibyte_emoji) { '✨' * 100 }
-    let(:zwj_sequence) { '🏳️‍⚧️' * 100 }
+    let(:multibyte_emoji) { '✨' * described_class::MAX_CHARS }
+    let(:zwj_sequence) { '🏳️‍⚧️' * described_class::MAX_CHARS }
 
     it { is_expected.to allow_values(multibyte_emoji, zwj_sequence).for(:text) }
   end

--- a/spec/validators/status_length_validator_spec.rb
+++ b/spec/validators/status_length_validator_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe StatusLengthValidator do
   end
 
   context 'when remote usernames are attached to long domains' do
-    let(:text) { "@alice@#{'b' * 300}.com" }
+    let(:text) { "@alice@#{'b' * Extractor::MAX_DOMAIN_LENGTH * 2}.com" }
 
     it { is_expected.to_not allow_value(text).for(:text).with_message(too_long_message) }
   end

--- a/spec/validators/status_pin_validator_spec.rb
+++ b/spec/validators/status_pin_validator_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe StatusPinValidator, type: :model do
+RSpec.describe StatusPinValidator do
   subject { Fabricate.build :status_pin }
 
   context 'when status is a reblog' do

--- a/spec/validators/status_pin_validator_spec.rb
+++ b/spec/validators/status_pin_validator_spec.rb
@@ -2,56 +2,38 @@
 
 require 'rails_helper'
 
-RSpec.describe StatusPinValidator do
-  describe '#validate' do
-    before do
-      subject.validate(pin)
-    end
+RSpec.describe StatusPinValidator, type: :model do
+  subject { Fabricate.build :status_pin }
 
-    let(:pin) { instance_double(StatusPin, account: account, errors: errors, status: status, account_id: pin_account_id) }
-    let(:status) { instance_double(Status, reblog?: reblog, account_id: status_account_id, visibility: visibility, direct_visibility?: visibility == 'direct') }
-    let(:account)     { instance_double(Account, status_pins: status_pins, local?: local) }
-    let(:status_pins) { instance_double(Array, count: count) }
-    let(:errors)      { instance_double(ActiveModel::Errors, add: nil) }
-    let(:pin_account_id)    { 1 }
-    let(:status_account_id) { 1 }
-    let(:visibility)  { 'public' }
-    let(:local)       { false }
-    let(:reblog)      { false }
-    let(:count)       { 0 }
+  context 'when status is a reblog' do
+    let(:status) { Fabricate.build :status, reblog: Fabricate(:status) }
 
-    context 'when pin.status.reblog?' do
-      let(:reblog) { true }
+    it { is_expected.to_not allow_value(status).for(:status).against(:base).with_message(I18n.t('statuses.pin_errors.reblog')) }
+  end
 
-      it 'calls errors.add' do
-        expect(errors).to have_received(:add).with(:base, I18n.t('statuses.pin_errors.reblog'))
-      end
-    end
+  context 'when pin account is not status account' do
+    before { subject.save }
 
-    context 'when pin.account_id != pin.status.account_id' do
-      let(:pin_account_id)    { 1 }
-      let(:status_account_id) { 2 }
+    let(:status) { Fabricate :status, account: Fabricate(:account) }
 
-      it 'calls errors.add' do
-        expect(errors).to have_received(:add).with(:base, I18n.t('statuses.pin_errors.ownership'))
-      end
-    end
+    it { is_expected.to_not allow_value(status).for(:status).against(:base).with_message(I18n.t('statuses.pin_errors.ownership')) }
+  end
 
-    context 'when pin.status.direct_visibility?' do
-      let(:visibility) { 'direct' }
+  context 'when status visibility is direct' do
+    let(:status) { Fabricate.build :status, visibility: :direct }
 
-      it 'calls errors.add' do
-        expect(errors).to have_received(:add).with(:base, I18n.t('statuses.pin_errors.direct'))
-      end
-    end
+    it { is_expected.to_not allow_value(status).for(:status).against(:base).with_message(I18n.t('statuses.pin_errors.direct')) }
+  end
 
-    context 'when pin account is local and has too many pins' do
-      let(:count) { described_class::PIN_LIMIT + 1 }
-      let(:local) { true }
+  describe 'status pin limits' do
+    before { stub_const 'StatusPinValidator::PIN_LIMIT', 2 }
 
-      it 'calls errors.add' do
-        expect(errors).to have_received(:add).with(:base, I18n.t('statuses.pin_errors.limit'))
-      end
+    context 'when account has reached the limit' do
+      before { Fabricate.times 2, :status_pin, account: }
+
+      let(:account) { subject.account }
+
+      it { is_expected.to_not allow_value(account).for(:account).against(:base).with_message(I18n.t('statuses.pin_errors.limit')) }
     end
   end
 end

--- a/spec/validators/unique_username_validator_spec.rb
+++ b/spec/validators/unique_username_validator_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe UniqueUsernameValidator, type: :model do
+RSpec.describe UniqueUsernameValidator do
   subject { Fabricate.build :account, username: 'abcdef', domain: }
 
   context 'when local account' do

--- a/spec/validators/unique_username_validator_spec.rb
+++ b/spec/validators/unique_username_validator_spec.rb
@@ -2,73 +2,64 @@
 
 require 'rails_helper'
 
-RSpec.describe UniqueUsernameValidator do
-  describe '#validate' do
-    context 'when local account' do
-      it 'does not add errors if username is nil' do
-        account = instance_double(Account, username: nil, domain: nil, persisted?: false, errors: activemodel_errors)
-        subject.validate(account)
-        expect(account.errors).to_not have_received(:add)
-      end
+RSpec.describe UniqueUsernameValidator, type: :model do
+  subject { Fabricate.build :account, username: 'abcdef', domain: }
 
-      it 'does not add errors when existing one is subject itself' do
-        account = Fabricate(:account, username: 'abcdef')
-        expect(account).to be_valid
-      end
+  context 'when local account' do
+    let(:domain) { nil }
 
-      it 'adds an error when the username is already used with ignoring cases' do
-        Fabricate(:account, username: 'ABCdef')
-        account = instance_double(Account, username: 'abcDEF', domain: nil, persisted?: false, errors: activemodel_errors)
-        subject.validate(account)
-        expect(account.errors).to have_received(:add)
-      end
+    context 'when username is nil' do
+      it { is_expected.to allow_value(nil).for(:username).with_message(:taken) }
+    end
 
-      it 'does not add errors when same username remote account exists' do
-        Fabricate(:account, username: 'abcdef', domain: 'example.com')
-        account = instance_double(Account, username: 'abcdef', domain: nil, persisted?: false, errors: activemodel_errors)
-        subject.validate(account)
-        expect(account.errors).to_not have_received(:add)
-      end
+    context 'when record is persisted and checking own name' do
+      before { subject.save }
+
+      it { is_expected.to allow_value(subject.username).for(:username) }
+    end
+
+    context 'when username case insensitive in use already' do
+      before { Fabricate :account, username: 'ABCdef' }
+
+      it { is_expected.to_not allow_value('abcDEF').for(:username) }
+    end
+
+    context 'when username on remote account is in use' do
+      before { Fabricate :account, username: 'ABCdef', domain: 'host.example' }
+
+      it { is_expected.to allow_value('abcDEF').for(:username) }
     end
   end
 
   context 'when remote account' do
-    it 'does not add errors if username is nil' do
-      account = instance_double(Account, username: nil, domain: 'example.com', persisted?: false, errors: activemodel_errors)
-      subject.validate(account)
-      expect(account.errors).to_not have_received(:add)
+    let(:domain) { 'host.example' }
+
+    context 'when username is nil' do
+      it { is_expected.to allow_value(nil).for(:username).with_message(:taken) }
     end
 
-    it 'does not add errors when existing one is subject itself' do
-      account = Fabricate(:account, username: 'abcdef', domain: 'example.com')
-      expect(account).to be_valid
+    context 'when record is persisted and checking own name' do
+      before { subject.save }
+
+      it { is_expected.to allow_value('abcdef').for(:username) }
     end
 
-    it 'adds an error when the username is already used with ignoring cases' do
-      Fabricate(:account, username: 'ABCdef', domain: 'example.com')
-      account = instance_double(Account, username: 'abcDEF', domain: 'example.com', persisted?: false, errors: activemodel_errors)
-      subject.validate(account)
-      expect(account.errors).to have_received(:add)
+    context 'when username case insensitive in use already' do
+      before { Fabricate :account, username: 'ABCdef', domain: 'host.example' }
+
+      it { is_expected.to_not allow_value('abcDEF').for(:username) }
     end
 
-    it 'adds an error when the domain is already used with ignoring cases' do
-      Fabricate(:account, username: 'ABCdef', domain: 'example.com')
-      account = instance_double(Account, username: 'ABCdef', domain: 'EXAMPLE.COM', persisted?: false, errors: activemodel_errors)
-      subject.validate(account)
-      expect(account.errors).to have_received(:add)
+    context 'when domain case insensitive in use already' do
+      before { Fabricate :account, username: 'ABCdef', domain: 'HOST.EXAMPLE' }
+
+      it { is_expected.to_not allow_value('abcDEF').for(:username) }
     end
 
-    it 'does not add errors when account with the same username and another domain exists' do
-      Fabricate(:account, username: 'abcdef', domain: 'example.com')
-      account = instance_double(Account, username: 'abcdef', domain: 'example2.com', persisted?: false, errors: activemodel_errors)
-      subject.validate(account)
-      expect(account.errors).to_not have_received(:add)
+    context 'when same username on other domain is in use already' do
+      before { Fabricate :account, username: 'abcdef', domain: 'other.example' }
+
+      it { is_expected.to allow_value('abcdef').for(:username) }
     end
-  end
-
-  private
-
-  def activemodel_errors
-    instance_double(ActiveModel::Errors, add: nil)
   end
 end

--- a/spec/validators/unreserved_username_validator_spec.rb
+++ b/spec/validators/unreserved_username_validator_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe UnreservedUsernameValidator, type: :model do
+RSpec.describe UnreservedUsernameValidator do
   subject { record_class.new }
 
   let(:record_class) do

--- a/spec/validators/unreserved_username_validator_spec.rb
+++ b/spec/validators/unreserved_username_validator_spec.rb
@@ -2,7 +2,9 @@
 
 require 'rails_helper'
 
-RSpec.describe UnreservedUsernameValidator do
+RSpec.describe UnreservedUsernameValidator, type: :model do
+  subject { record_class.new }
+
   let(:record_class) do
     Class.new do
       include ActiveModel::Validations
@@ -11,115 +13,67 @@ RSpec.describe UnreservedUsernameValidator do
 
       validates_with UnreservedUsernameValidator
 
-      def self.name
-        'Foo'
-      end
+      def self.name = 'Record'
     end
   end
 
-  let(:record) { record_class.new }
+  context 'when username is nil' do
+    it { is_expected.to allow_value(nil).for(:username) }
+  end
 
-  describe '#validate' do
-    context 'when username is nil' do
-      it 'does not add errors' do
-        record.username = nil
+  context 'when PAM is enabled' do
+    before do
+      allow(Devise).to receive(:pam_authentication).and_return(true)
+    end
 
-        expect(record).to be_valid
-        expect(record.errors).to be_empty
+    context 'with a pam service available' do
+      let(:service) { double }
+      let(:pam_class) do
+        Class.new do
+          def self.account(service, username); end
+        end
+      end
+
+      before do
+        stub_const('Rpam2', pam_class)
+        allow(Devise).to receive(:pam_controlled_service).and_return(service)
+      end
+
+      context 'when the account exists' do
+        before do
+          allow(Rpam2).to receive(:account).with(service, 'username').and_return(true)
+        end
+
+        it { is_expected.to_not allow_value('username').for(:username).with_message(:reserved) }
+      end
+
+      context 'when the account does not exist' do
+        before do
+          allow(Rpam2).to receive(:account).with(service, 'username').and_return(false)
+        end
+
+        it { is_expected.to allow_value('username').for(:username) }
       end
     end
 
-    context 'when PAM is enabled' do
+    context 'without a pam service' do
       before do
-        allow(Devise).to receive(:pam_authentication).and_return(true)
+        allow(Devise).to receive(:pam_controlled_service).and_return(false)
       end
 
-      context 'with a pam service available' do
-        let(:service) { double }
-        let(:pam_class) do
-          Class.new do
-            def self.account(service, username); end
-          end
-        end
-
-        before do
-          stub_const('Rpam2', pam_class)
-          allow(Devise).to receive(:pam_controlled_service).and_return(service)
-        end
-
-        context 'when the account exists' do
-          before do
-            allow(Rpam2).to receive(:account).with(service, 'username').and_return(true)
-          end
-
-          it 'adds errors to the record' do
-            record.username = 'username'
-
-            expect(record).to_not be_valid
-            expect(record.errors.first.attribute).to eq(:username)
-            expect(record.errors.first.type).to eq(:reserved)
-          end
-        end
-
-        context 'when the account does not exist' do
-          before do
-            allow(Rpam2).to receive(:account).with(service, 'username').and_return(false)
-          end
-
-          it 'does not add errors to the record' do
-            record.username = 'username'
-
-            expect(record).to be_valid
-            expect(record.errors).to be_empty
-          end
-        end
+      context 'when there are not any reserved usernames' do
+        it { is_expected.to allow_value('username').for(:username) }
       end
 
-      context 'without a pam service' do
-        before do
-          allow(Devise).to receive(:pam_controlled_service).and_return(false)
+      context 'when there are reserved usernames' do
+        before { %w(alice bob).each { |username| Fabricate(:username_block, exact: true, username:) } }
+
+        context 'when the username is reserved' do
+          it { is_expected.to_not allow_values('alice', 'bob').for(:username).with_message(:reserved) }
         end
 
-        context 'when there are not any reserved usernames' do
-          before do
-            stub_reserved_usernames(nil)
-          end
-
-          it 'does not add errors to the record' do
-            record.username = 'username'
-
-            expect(record).to be_valid
-            expect(record.errors).to be_empty
-          end
-        end
-
-        context 'when there are reserved usernames' do
-          before do
-            stub_reserved_usernames(%w(alice bob))
-          end
-
-          context 'when the username is reserved' do
-            it 'adds errors to the record' do
-              record.username = 'alice'
-
-              expect(record).to_not be_valid
-              expect(record.errors.first.attribute).to eq(:username)
-              expect(record.errors.first.type).to eq(:reserved)
-            end
-          end
-
-          context 'when the username is not reserved' do
-            it 'does not add errors to the record' do
-              record.username = 'chris'
-
-              expect(record).to be_valid
-              expect(record.errors).to be_empty
-            end
-          end
-        end
-
-        def stub_reserved_usernames(value)
-          value&.each { |str| Fabricate(:username_block, username: str, exact: true) }
+        context 'when the username is not reserved' do
+          it { is_expected.to allow_value('chris').for(:username) }
         end
       end
     end

--- a/spec/validators/url_validator_spec.rb
+++ b/spec/validators/url_validator_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe URLValidator, type: :model do
+RSpec.describe URLValidator do
   subject { record_class.new }
 
   let(:record_class) do

--- a/spec/validators/url_validator_spec.rb
+++ b/spec/validators/url_validator_spec.rb
@@ -22,19 +22,26 @@ RSpec.describe URLValidator do
   end
 
   context 'with an invalid url scheme' do
-    it { is_expected.to_not allow_value('ftp://example.com/page').for(:profile).with_message(:invalid) }
+    let(:invalid_scheme_url) { 'ftp://example.com/page' }
+
+    it { is_expected.to_not allow_value(invalid_scheme_url).for(:profile).with_message(:invalid) }
   end
 
   context 'without a hostname' do
-    it { is_expected.to_not allow_value('https:///page').for(:profile).with_message(:invalid) }
+    let(:no_hostname_url) { 'https:///page' }
+
+    it { is_expected.to_not allow_value(no_hostname_url).for(:profile).with_message(:invalid) }
   end
 
   context 'with an unparseable value' do
-    # The non-numeric port string causes an invalid uri error
-    it { is_expected.to_not allow_value('https://host:port/page').for(:profile).with_message(:invalid) }
+    let(:non_numeric_port_url) { 'https://host:port/page' }
+
+    it { is_expected.to_not allow_value(non_numeric_port_url).for(:profile).with_message(:invalid) }
   end
 
   context 'with a valid url' do
-    it { is_expected.to allow_value('https://example.com/page').for(:profile) }
+    let(:valid_url) { 'https://example.com/page' }
+
+    it { is_expected.to allow_value(valid_url).for(:profile) }
   end
 end

--- a/spec/validators/user_email_validator_spec.rb
+++ b/spec/validators/user_email_validator_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe UserEmailValidator, type: :model do
+RSpec.describe UserEmailValidator do
   subject { Fabricate.build :user, confirmed_at: nil }
 
   context 'when email provider is blocked' do

--- a/spec/validators/user_email_validator_spec.rb
+++ b/spec/validators/user_email_validator_spec.rb
@@ -5,21 +5,23 @@ require 'rails_helper'
 RSpec.describe UserEmailValidator do
   subject { Fabricate.build :user, confirmed_at: nil }
 
-  context 'when email provider is blocked' do
-    before { Fabricate :email_domain_block, domain: 'mail.com' }
+  let(:email_address) { 'info@host.example' }
 
-    it { is_expected.to_not allow_value('info@mail.com').for(:email).with_message(:blocked) }
+  context 'when email provider is blocked' do
+    before { Fabricate :email_domain_block, domain: 'host.example' }
+
+    it { is_expected.to_not allow_value(email_address).for(:email).with_message(:blocked) }
   end
 
   context 'when email provider is not blocked' do
-    it { is_expected.to allow_value('info@mail.com').for(:email) }
+    it { is_expected.to allow_value(email_address).for(:email) }
   end
 
   context 'when canonical email address is blocked' do
-    let(:other_user) { Fabricate(:user, email: 'i.n.f.o@mail.com') }
+    let(:other_user) { Fabricate(:user, email: 'i.n.f.o@host.example') }
 
     before { other_user.account.suspend! }
 
-    it { is_expected.to_not allow_value('info@mail.com').for(:email).with_message(:taken) }
+    it { is_expected.to_not allow_value(email_address).for(:email).with_message(:taken) }
   end
 end


### PR DESCRIPTION
While looking at the validator related to https://github.com/mastodon/mastodon/pull/36039 I was reminded that I'd been meaning to update these with newer style for consistency. This is a follow-up both to some earlier PRs which improved coverage across all the validators, and also to a collection of PRs improving validation coverage (adopting `allow_value`, removing SUT stubs, etc) in the model specs.

Basically two categories of change here:

- There are many places where the model and the validator are very tightly coupled and effectively one unit for the purpose of the spec -- we were stubbing out many models (some of these specs may predate activemodel?) ... which while maybe technically not the SUT, is very close and we should avoid if we can. I eliminated (model) stubbing in all but a few spots (may do followup, may just leave) where it was complex to do so.
- We did not have the `allow_value` matcher available when the majority of the validator specs were written, so this is also just a once over to adopt that style where relevant and gain a little compactness/terseness on the repeated assign/validate/assert boilerplate while preserving coverage.

Generally speaking, where validators are actually "general purpose" and not very tightly coupled to one specific model I kept the approach of anonymous activemodel classes for passing in records to the validators. Where validators were very tightly coupled and unlikely to ever be used on other models, I swapped in a Fabricator-built model instance in some spots where that made it easier to test and seems low risk due to the coupling/non-reuse.

There is a slight coverage increase (because some previously stubbed code is now running). There's a slight assertion specificity improvement - I added some more narrow checks in a few spots around the attribute or specific error message where previously it was sometimes just high-level errors check.

On the advice of batman I'm putting this all in one PR instead of splitting up, but let me know if better prepared one by one. Might be best viewed with split view?

Future ideas here:

- I stayed away from refactor entirely, but there are some spots in validators where simple stuff like pulling out private methods for some checks and error messages and so on would be good.
- We could possibly abstract the "build an anonymous class with activemodel that I can use in specs" idea to `support/`
- May be bigger change, but -- a few of these single-use classes barely merit existence as validator classes unique from their base model. Some of them (poll ones, status pin, registration, etc) would almost definitely improve by just being right on the model, and could be moved there without adding excessive LOC. Others (date of birth, disallowed hashtags, misc username validators) might have enough LOC/complexity to make sense as part of themed "concerns" (add to existing where relevant, make new where not). Some of them (domain, language, note length, etc) are indeed used in multiple spots and are general purpose and make sense to continue as validator classes.
- This group of specs creates relatively low number of factory records since many of the validations dont need DB access ... but we could do another pass to see if we can reduce even further.
