### PR TITLE
Fix unresponsive areas around GIFV modals in some cases

### DIFF
--- a/app/javascript/mastodon/features/ui/components/media_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/media_modal.jsx
@@ -201,8 +201,6 @@ class MediaModal extends ImmutablePureComponent {
             preview={image.get('preview_url')}
             blurhash={image.get('blurhash')}
             src={image.get('url')}
-            width={image.get('width')}
-            height={image.get('height')}
             frameRate={image.getIn(['meta', 'original', 'frame_rate'])}
             aspectRatio={`${image.getIn(['meta', 'original', 'width'])} / ${image.getIn(['meta', 'original', 'height'])}`}
             startTime={currentTime || 0}
@@ -219,8 +217,6 @@ class MediaModal extends ImmutablePureComponent {
         return (
           <GIFV
             src={image.get('url')}
-            width={width}
-            height={height}
             key={image.get('url')}
             alt={description}
             lang={lang}


### PR DESCRIPTION
When vertical videos don't fit the viewport, they are scaled down, but the `width` passed to the `<video>` tag still reserves some space that is unnecessarily wide for the video. This cause dead areas left and right of the video which do not close the video when clicked.

This PR fixes that. It also removes the `width` and `height` attributes passed to `<Video>` as those attributes have been dropped in #24686.

Note that in the `Video` case, we are still passing an aspect ratio, which we are not passing in the `GIFV` case. This might cause issues, although I did not run into any.