### PR TITLE
Use `delegate` for token method in web/push_subscription

### DIFF
--- a/app/models/web/push_subscription.rb
+++ b/app/models/web/push_subscription.rb
@@ -29,15 +29,12 @@ class Web::PushSubscription < ApplicationRecord
   validates_with WebPushKeyValidator
 
   delegate :locale, to: :user
+  delegate :token, to: :access_token, prefix: :associated_access
 
   generates_token_for :unsubscribe, expires_in: Web::PushNotificationWorker::TTL
 
   def pushable?(notification)
     policy_allows_notification?(notification) && alert_enabled_for_notification_type?(notification)
-  end
-
-  def associated_access_token
-    access_token.token
   end
 
   class << self

--- a/spec/models/web/push_subscription_spec.rb
+++ b/spec/models/web/push_subscription_spec.rb
@@ -93,4 +93,8 @@ RSpec.describe Web::PushSubscription do
       end
     end
   end
+
+  describe 'Delegations' do
+    it { is_expected.to delegate_method(:token).to(:access_token).with_prefix(:associated_access) }
+  end
 end


### PR DESCRIPTION
Noticed this while looking elsewhere.

Preserving the naming because `access_token_token` sounds odd.