### PR TITLE
Lighten up modal background colours in light mode

### DIFF
--- a/app/javascript/styles/mastodon-light/css_variables.scss
+++ b/app/javascript/styles/mastodon-light/css_variables.scss
@@ -7,7 +7,7 @@ body {
   --dropdown-border-color: hsl(240deg, 25%, 88%);
   --dropdown-background-color: #fff;
   --modal-border-color: hsl(240deg, 25%, 88%);
-  --modal-background-color: var(--background-color-tint);
+  --modal-background-color: var(--background-color);
   --background-border-color: hsl(240deg, 25%, 88%);
   --background-color: #fff;
   --background-color-tint: rgba(255, 255, 255, 80%);

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -5714,8 +5714,8 @@ a.status-card {
     display: flex;
     align-items: center;
     color: $primary-text-color;
-    background: var(--dropdown-background-color);
-    border: 1px solid var(--dropdown-border-color);
+    background: var(--input-background-color);
+    border: 1px solid var(--background-border-color);
     padding: 8px 12px;
     width: 100%;
     text-align: left;


### PR DESCRIPTION
### Changes proposed in this PR:

- Changes the background colour of modals in light mode from light grey to white
- Adapts the background colour of the visibility modal dropdown buttons to use standard input colours

### Screenshots

<img width="648" height="441" alt="Screenshot 2025-09-09 at 14 51 22" src="https://github.com/user-attachments/assets/6e36871c-810d-4a9f-a463-ee4388228de8" />
