### PR TITLE
Fix QuoteAuthorization id not being properly serialized when federating revocation

### DIFF
--- a/app/serializers/activitypub/quote_authorization_serializer.rb
+++ b/app/serializers/activitypub/quote_authorization_serializer.rb
@@ -8,7 +8,7 @@ class ActivityPub::QuoteAuthorizationSerializer < ActivityPub::Serializer
   attributes :id, :type, :attributed_to, :interacting_object, :interaction_target
 
   def id
-    ActivityPub::TagManager.instance.approval_uri_for(object)
+    ActivityPub::TagManager.instance.approval_uri_for(object, check_approval: !instance_options[:force_approval_id])
   end
 
   def type

--- a/app/services/revoke_quote_service.rb
+++ b/app/services/revoke_quote_service.rb
@@ -34,6 +34,6 @@ class RevokeQuoteService < BaseService
   end
 
   def signed_activity_json
-    @signed_activity_json ||= Oj.dump(serialize_payload(@quote, ActivityPub::DeleteQuoteAuthorizationSerializer, signer: @account, always_sign: true))
+    @signed_activity_json ||= Oj.dump(serialize_payload(@quote, ActivityPub::DeleteQuoteAuthorizationSerializer, signer: @account, always_sign: true, force_approval_id: true))
   end
 end

--- a/spec/services/revoke_quote_service_spec.rb
+++ b/spec/services/revoke_quote_service_spec.rb
@@ -20,7 +20,22 @@ RSpec.describe RevokeQuoteService do
     it 'revokes the quote and sends a Delete activity' do
       expect { described_class.new.call(quote) }
         .to change { quote.reload.state }.from('accepted').to('revoked')
-        .and enqueue_sidekiq_job(ActivityPub::DeliveryWorker).with(/Delete/, alice.id, hank.inbox_url)
+        .and enqueue_sidekiq_job(ActivityPub::DeliveryWorker).with(
+          match_json_values(
+            type: 'Delete',
+            id: %r{https://.*},
+            object: include(
+              type: 'QuoteAuthorization',
+              id: %r{https://.*},
+              attributedTo: ActivityPub::TagManager.instance.uri_for(alice),
+              interactionTarget: ActivityPub::TagManager.instance.uri_for(status),
+              interactingObject: ActivityPub::TagManager.instance.uri_for(quote.status)
+            ),
+            actor: ActivityPub::TagManager.instance.uri_for(alice)
+          ),
+          alice.id,
+          hank.inbox_url
+        )
     end
   end
 end


### PR DESCRIPTION
Fixes an issue with quote revocation not federating correctly since #35725