### PR TITLE
Fix accpeted quotes sometimes not generating notifications

### DIFF
--- a/app/lib/activitypub/activity/quote_request.rb
+++ b/app/lib/activitypub/activity/quote_request.rb
@@ -33,6 +33,9 @@ class ActivityPub::Activity::QuoteRequest < ActivityPub::Activity
 
     json = Oj.dump(serialize_payload(status.quote, ActivityPub::AcceptQuoteRequestSerializer))
     ActivityPub::DeliveryWorker.perform_async(json, quoted_status.account_id, @account.inbox_url)
+
+    # Ensure the user is notified
+    LocalNotificationWorker.perform_async(quoted_status.account_id, status.quote.id, 'Quote', 'quote')
   end
 
   def import_instrument(quoted_status)

--- a/app/services/fan_out_on_write_service.rb
+++ b/app/services/fan_out_on_write_service.rb
@@ -40,7 +40,6 @@ class FanOutOnWriteService < BaseService
     deliver_to_self!
 
     unless @options[:skip_notifications]
-      notify_quoted_account!
       notify_mentioned_accounts!
       notify_about_update! if update?
     end
@@ -68,12 +67,6 @@ class FanOutOnWriteService < BaseService
 
   def deliver_to_self!
     FeedManager.instance.push_to_home(@account, @status, update: update?) if @account.local?
-  end
-
-  def notify_quoted_account!
-    return unless @status.quote&.quoted_account&.local? && @status.quote&.accepted?
-
-    LocalNotificationWorker.perform_async(@status.quote.quoted_account_id, @status.quote.id, 'Quote', 'quote')
   end
 
   def notify_mentioned_accounts!


### PR DESCRIPTION
This moves where such notifications are generated to when the quote is approved.