### PR TITLE
Use bundler version 2.7.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -767,7 +767,7 @@ GEM
       rspec-mocks (~> 3.0)
       sidekiq (>= 5, < 9)
     rspec-support (3.13.6)
-    rubocop (1.81.0)
+    rubocop (1.81.1)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -226,7 +226,7 @@ GEM
       activemodel
     erb (5.0.2)
     erubi (1.13.1)
-    et-orbi (1.2.11)
+    et-orbi (1.3.0)
       tzinfo
     excon (1.3.0)
       logger

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -226,7 +226,7 @@ GEM
       activemodel
     erb (5.0.2)
     erubi (1.13.1)
-    et-orbi (1.3.0)
+    et-orbi (1.4.0)
       tzinfo
     excon (1.3.0)
       logger

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -439,7 +439,7 @@ GEM
     mime-types (3.7.0)
       logger
       mime-types-data (~> 3.2025, >= 3.2025.0507)
-    mime-types-data (3.2025.0916)
+    mime-types-data (3.2025.0924)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
     minitest (5.25.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -813,7 +813,7 @@ GEM
     ruby-vips (2.2.5)
       ffi (~> 1.12)
       logger
-    rubyzip (3.1.0)
+    rubyzip (3.1.1)
     rufus-scheduler (3.9.2)
       fugit (~> 1.1, >= 1.11.1)
     safety_net_attestation (0.5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -277,8 +277,8 @@ GEM
     google-protobuf (4.32.0)
       bigdecimal
       rake (>= 13)
-    googleapis-common-protos-types (1.20.0)
-      google-protobuf (>= 3.18, < 5.a)
+    googleapis-common-protos-types (1.21.0)
+      google-protobuf (~> 4.26)
     haml (6.3.0)
       temple (>= 0.8.2)
       thor

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -293,7 +293,7 @@ GEM
       rainbow
       rubocop (>= 1.0)
       sysexits (~> 1.1)
-    hashdiff (1.2.0)
+    hashdiff (1.2.1)
     hashie (5.0.0)
     hcaptcha (7.1.0)
       json

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,7 @@ GEM
     ast (2.4.3)
     attr_required (1.0.2)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1135.0)
+    aws-partitions (1.1163.0)
     aws-sdk-core (3.215.1)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -765,7 +765,7 @@ GEM
       rspec-expectations (~> 3.0)
       rspec-mocks (~> 3.0)
       sidekiq (>= 5, < 9)
-    rspec-support (3.13.4)
+    rspec-support (3.13.6)
     rubocop (1.81.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -207,7 +207,7 @@ GEM
       railties (>= 5)
     dotenv (3.1.8)
     drb (2.2.3)
-    dry-cli (1.2.0)
+    dry-cli (1.3.0)
     elasticsearch (7.17.11)
       elasticsearch-api (= 7.17.11)
       elasticsearch-transport (= 7.17.11)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -274,7 +274,7 @@ GEM
       raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    google-protobuf (4.32.0)
+    google-protobuf (4.32.1)
       bigdecimal
       rake (>= 13)
     googleapis-common-protos-types (1.21.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,7 @@ GEM
     ast (2.4.3)
     attr_required (1.0.2)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1165.0)
+    aws-partitions (1.1166.0)
     aws-sdk-core (3.215.1)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,7 @@ GEM
     ast (2.4.3)
     attr_required (1.0.2)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1163.0)
+    aws-partitions (1.1165.0)
     aws-sdk-core (3.215.1)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -348,7 +348,7 @@ GEM
     jmespath (1.6.2)
     json (2.15.0)
     json-canonicalization (1.0.0)
-    json-jwt (1.16.7)
+    json-jwt (1.17.0)
       activesupport (>= 4.2)
       aes_key_wrap
       base64

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -274,7 +274,7 @@ GEM
       raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    google-protobuf (4.31.1)
+    google-protobuf (4.32.0)
       bigdecimal
       rake (>= 13)
     googleapis-common-protos-types (1.20.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,7 +228,7 @@ GEM
     erubi (1.13.1)
     et-orbi (1.2.11)
       tzinfo
-    excon (1.2.8)
+    excon (1.3.0)
       logger
     fabrication (3.0.0)
     faker (3.5.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -301,8 +301,8 @@ GEM
     highline (3.1.2)
       reline
     hiredis (0.6.3)
-    hiredis-client (0.26.0)
-      redis-client (= 0.26.0)
+    hiredis-client (0.26.1)
+      redis-client (= 0.26.1)
     hkdf (0.3.0)
     htmlentities (4.3.4)
     http (5.3.1)
@@ -721,7 +721,7 @@ GEM
       reline
     redcarpet (3.6.1)
     redis (4.8.1)
-    redis-client (0.26.0)
+    redis-client (0.26.1)
       connection_pool
     regexp_parser (2.11.3)
     reline (0.6.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1108,4 +1108,4 @@ RUBY VERSION
    ruby 3.4.1p0
 
 BUNDLED WITH
-   2.7.1
+   2.7.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -733,7 +733,7 @@ GEM
       railties (>= 5.2)
     rexml (3.4.4)
     rotp (6.3.0)
-    rouge (4.6.0)
+    rouge (4.6.1)
     rpam2 (4.0.2)
     rqrcode (3.1.0)
       chunky_png (~> 1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -233,7 +233,7 @@ GEM
     fabrication (3.0.0)
     faker (3.5.2)
       i18n (>= 1.8.11, < 2)
-    faraday (2.13.4)
+    faraday (2.14.0)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -266,7 +266,8 @@ GEM
     fog-openstack (1.1.5)
       fog-core (~> 2.1)
       fog-json (>= 1.0)
-    formatador (1.1.1)
+    formatador (1.2.1)
+      reline
     forwardable (1.3.3)
     fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -272,7 +272,7 @@ GEM
     fugit (1.11.2)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
-    globalid (1.2.1)
+    globalid (1.3.0)
       activesupport (>= 6.1)
     google-protobuf (4.32.1)
       bigdecimal

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -310,7 +310,7 @@ GEM
       http-cookie (~> 1.0)
       http-form_data (~> 2.2)
       llhttp-ffi (~> 0.5.0)
-    http-cookie (1.0.8)
+    http-cookie (1.1.0)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
     http_accept_language (2.1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -791,7 +791,7 @@ GEM
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.44.0, < 2.0)
-    rubocop-rails (2.33.3)
+    rubocop-rails (2.33.4)
       activesupport (>= 4.2.0)
       lint_roller (~> 1.1)
       rack (>= 1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -269,7 +269,7 @@ GEM
     formatador (1.2.1)
       reline
     forwardable (1.3.3)
-    fugit (1.11.1)
+    fugit (1.11.2)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
     globalid (1.2.1)


### PR DESCRIPTION
Bumps misc minor/patch gems that renovate misses as well.

Does not yet bump brakeman (pending issue to resolve in latest), or playwright (must bump js as well, https://github.com/mastodon/mastodon/pull/35854 )