### PR TITLE
Make Vite respect CSP for styles

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -35,7 +35,7 @@
 
     = vite_preload_file_tag "mastodon/locales/#{I18n.locale}.json"
     = csrf_meta_tags unless skip_csrf_meta_tags?
-    %meta{ name: 'style-nonce', content: request.content_security_policy_nonce }
+    %meta{ name: 'style-nonce', content: request.content_security_policy_nonce, property: 'csp-nonce', nonce: request.content_security_policy_nonce }
 
     = custom_stylesheet
 


### PR DESCRIPTION
Allows Vite importing styles as part of components.