### PR TITLE
Disable CSP on minimal/metadata controller classes

### DIFF
--- a/app/controllers/custom_css_controller.rb
+++ b/app/controllers/custom_css_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CustomCssController < ActionController::Base # rubocop:disable Rails/ApplicationController
+class CustomCssController < PrimitiveController
   def show
     expires_in 1.month, public: true
     render content_type: 'text/css'

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class HealthController < ActionController::Base # rubocop:disable Rails/ApplicationController
+class HealthController < PrimitiveController
   def show
     render plain: 'OK'
   end

--- a/app/controllers/manifests_controller.rb
+++ b/app/controllers/manifests_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ManifestsController < ActionController::Base # rubocop:disable Rails/ApplicationController
+class ManifestsController < PrimitiveController
   # Prevent `active_model_serializer`'s `ActionController::Serialization` from calling `current_user`
   # and thus re-issuing session cookies
   serialization_scope nil

--- a/app/controllers/primitive_controller.rb
+++ b/app/controllers/primitive_controller.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class PrimitiveController < ActionController::Base # rubocop:disable Rails/ApplicationController
+  content_security_policy(false)
+end

--- a/app/controllers/well_known/host_meta_controller.rb
+++ b/app/controllers/well_known/host_meta_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module WellKnown
-  class HostMetaController < ActionController::Base # rubocop:disable Rails/ApplicationController
+  class HostMetaController < PrimitiveController
     include RoutingHelper
 
     def show

--- a/app/controllers/well_known/node_info_controller.rb
+++ b/app/controllers/well_known/node_info_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module WellKnown
-  class NodeInfoController < ActionController::Base # rubocop:disable Rails/ApplicationController
+  class NodeInfoController < PrimitiveController
     include CacheConcern
 
     # Prevent `active_model_serializer`'s `ActionController::Serialization` from calling `current_user`

--- a/app/controllers/well_known/oauth_metadata_controller.rb
+++ b/app/controllers/well_known/oauth_metadata_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module WellKnown
-  class OAuthMetadataController < ActionController::Base # rubocop:disable Rails/ApplicationController
+  class OAuthMetadataController < PrimitiveController
     include CacheConcern
 
     # Prevent `active_model_serializer`'s `ActionController::Serialization` from calling `current_user`

--- a/app/controllers/well_known/webfinger_controller.rb
+++ b/app/controllers/well_known/webfinger_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module WellKnown
-  class WebfingerController < ActionController::Base # rubocop:disable Rails/ApplicationController
+  class WebfingerController < PrimitiveController
     include RoutingHelper
 
     before_action :set_account

--- a/spec/requests/custom_css_spec.rb
+++ b/spec/requests/custom_css_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe 'Custom CSS' do
           .to have_http_status(200)
           .and have_cacheable_headers
           .and have_attributes(
-            content_type: match('text/css')
+            content_type: match('text/css'),
+            headers: not_include('content-security-policy')
           )
         expect(response.body.presence)
           .to be_nil
@@ -33,7 +34,8 @@ RSpec.describe 'Custom CSS' do
           .to have_http_status(200)
           .and have_cacheable_headers
           .and have_attributes(
-            content_type: match('text/css')
+            content_type: match('text/css'),
+            headers: not_include('content-security-policy')
           )
         expect(response.body.strip)
           .to eq(expected_css)

--- a/spec/requests/health_spec.rb
+++ b/spec/requests/health_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe 'Health check endpoint' do
         .to have_http_status(200)
       expect(response.body)
         .to include('OK')
+      expect(response.headers)
+        .to not_include('content-security-policy')
+      expect(response.media_type)
+        .to eq('text/plain')
     end
   end
 end

--- a/spec/requests/manifest_spec.rb
+++ b/spec/requests/manifest_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe 'Manifest' do
         .to have_http_status(200)
         .and have_cacheable_headers
         .and have_attributes(
-          content_type: match('application/json')
+          content_type: match('application/json'),
+          headers: not_include('content-security-policy')
         )
       expect(response.parsed_body)
         .to include(

--- a/spec/requests/well_known/host_meta_spec.rb
+++ b/spec/requests/well_known/host_meta_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe 'The /.well-known/host-meta request' do
       expect(response)
         .to have_http_status(200)
         .and have_attributes(
-          media_type: 'application/xrd+xml'
+          media_type: 'application/xrd+xml',
+          headers: not_include('content-security-policy')
         )
 
       expect(xrd_link_template_value)
@@ -32,7 +33,8 @@ RSpec.describe 'The /.well-known/host-meta request' do
       expect(response)
         .to have_http_status(200)
         .and have_attributes(
-          media_type: 'application/json'
+          media_type: 'application/json',
+          headers: not_include('content-security-policy')
         )
       expect(response.parsed_body)
         .to include(expected_json_template)
@@ -46,7 +48,8 @@ RSpec.describe 'The /.well-known/host-meta request' do
       expect(response)
         .to have_http_status(200)
         .and have_attributes(
-          media_type: 'application/json'
+          media_type: 'application/json',
+          headers: not_include('content-security-policy')
         )
       expect(response.parsed_body)
         .to include(expected_json_template)

--- a/spec/requests/well_known/node_info_spec.rb
+++ b/spec/requests/well_known/node_info_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe 'The well-known node-info endpoints' do
       expect(response)
         .to have_http_status(200)
         .and have_attributes(
-          media_type: 'application/json'
+          media_type: 'application/json',
+          headers: not_include('content-security-policy')
         )
 
       expect(response.parsed_body).to include(
@@ -33,7 +34,8 @@ RSpec.describe 'The well-known node-info endpoints' do
       expect(response)
         .to have_http_status(200)
         .and have_attributes(
-          media_type: 'application/json'
+          media_type: 'application/json',
+          headers: not_include('content-security-policy')
         )
 
       expect(non_matching_hash)

--- a/spec/requests/well_known/oauth_metadata_spec.rb
+++ b/spec/requests/well_known/oauth_metadata_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe 'The /.well-known/oauth-authorization-server request' do
     expect(response)
       .to have_http_status(200)
       .and have_attributes(
-        media_type: 'application/json'
+        media_type: 'application/json',
+        headers: not_include('content-security-policy')
       )
 
     grant_types_supported = Doorkeeper.configuration.grant_flows.dup

--- a/spec/requests/well_known/webfinger_spec.rb
+++ b/spec/requests/well_known/webfinger_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe 'The /.well-known/webfinger endpoint' do
 
       expect(response.media_type).to eq 'application/jrd+json'
 
+      expect(response.headers).to not_include('content-security-policy')
+
       expect(response.parsed_body)
         .to include(
           subject: eq(alice.to_webfinger_s),


### PR DESCRIPTION
There's already something like this in the remote interaction helper controller, where we disable/re-enable CSP headers for the purpose of (according to code comment) reducing response size on an endpoint where the headers are not especially relevant. I'm not sure if this was motivated by any measurements, or just an in-the-moment "we can make this smaller so why not" vibe.

This is a pass along the sames lines, hitting some text-only or json-only metadata-response type controllers. It's possible there are more of these, just did a first pass to get obvious ones. Open to naming ideas on the controller.

From a demo server, current main has ~1400 characters of headers, and removing the CSP header drops that to ~550 (tested on the custom css endpoint). Obviously this will vary server to server based on hostnames/etc in those headers.

Possible followup here:

- There is an `Api::ContentSecurityPolicy` concern which does something very similar to the inline code in the remote interaction helper controller ... I wonder if that could be combined?
- Could the API approach be to completely remove the header (like in this PR)? or are there scenarios where some of the CSP headers are relevant to API responses
- There are a few spots in other controllers which update various specific CSP values ... but there's some repetition here, could possibly pull those to concerns -- though it's only a handful here so not a huge deal either way