### PR TITLE
Fix login page linking to other pages within OAuth authorization flow

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -260,6 +260,10 @@ module ApplicationHelper
     'https://play.google.com/store/apps/details?id=org.joinmastodon.android'
   end
 
+  def within_authorization_flow?
+    session[:user_return_to].present? && Rails.application.routes.recognize_path(session[:user_return_to])[:controller] == 'oauth/authorizations'
+  end
+
   private
 
   def storage_host_var

--- a/app/views/auth/sessions/new.html.haml
+++ b/app/views/auth/sessions/new.html.haml
@@ -41,4 +41,5 @@
       - resource_class.omniauth_providers.each do |provider|
         = provider_sign_in_link(provider)
 
-.form-footer= render 'auth/shared/links'
+- unless within_authorization_flow?
+  .form-footer= render 'auth/shared/links'

--- a/app/views/layouts/auth.html.haml
+++ b/app/views/layouts/auth.html.haml
@@ -5,8 +5,11 @@
   .container-alt
     .logo-container
       %h1
-        = link_to root_path do
+        - if within_authorization_flow?
           = logo_as_symbol(:wordmark)
+        - else
+          = link_to root_path do
+            = logo_as_symbol(:wordmark)
 
     .form-container
       = render 'flashes'


### PR DESCRIPTION
The login page normally links to the frontpage via the logo, and to sign up, forgotten password, and confirmation e-mail in the footer. When the user is redirected to login from an OAuth authorization flow (i.e. an app web view), there is a risk that the user will navigate away from the flow and will remain in the temporary web view indefinitely while not completing the app authentication. For this reason, this PR un-links the logo when the user is within the flow, and removes all footer links.
___

Fixes #36114 