### PR TITLE
In composer, show when quoted post is also a quote post

### DIFF
--- a/app/javascript/mastodon/components/status_quoted.tsx
+++ b/app/javascript/mastodon/components/status_quoted.tsx
@@ -11,6 +11,7 @@ import type { RootState } from 'mastodon/store';
 import { useAppDispatch, useAppSelector } from 'mastodon/store';
 
 import { fetchStatus } from '../actions/statuses';
+import type { Account } from '../models/account';
 import { makeGetStatusWithExtraInfo } from '../selectors';
 
 import { Button } from './button';
@@ -18,7 +19,12 @@ import { Button } from './button';
 const MAX_QUOTE_POSTS_NESTING_LEVEL = 1;
 
 const NestedQuoteLink: React.FC<{ status: Status }> = ({ status }) => {
-  const accountId = status.get('account') as string;
+  const accountObjectOrId = status.get('account') as string | Account;
+  const accountId =
+    typeof accountObjectOrId === 'string'
+      ? accountObjectOrId
+      : accountObjectOrId.id;
+
   const account = useAppSelector((state) =>
     accountId ? state.accounts.get(accountId) : undefined,
   );

--- a/app/javascript/mastodon/components/status_quoted.tsx
+++ b/app/javascript/mastodon/components/status_quoted.tsx
@@ -2,8 +2,6 @@ import { useEffect, useMemo, useRef } from 'react';
 
 import { FormattedMessage } from 'react-intl';
 
-import classNames from 'classnames';
-
 import type { Map as ImmutableMap } from 'immutable';
 
 import { LearnMoreLink } from 'mastodon/components/learn_more_link';
@@ -18,28 +16,6 @@ import { makeGetStatusWithExtraInfo } from '../selectors';
 import { Button } from './button';
 
 const MAX_QUOTE_POSTS_NESTING_LEVEL = 1;
-
-const QuoteWrapper: React.FC<{
-  isError?: boolean;
-  contextType?: string;
-  onQuoteCancel?: () => void;
-  children: React.ReactElement;
-}> = ({ isError, contextType, onQuoteCancel, children }) => {
-  return (
-    <div
-      className={classNames('status__quote', {
-        'status__quote--error': isError,
-      })}
-    >
-      {children}
-      {contextType === 'composer' && (
-        <Button compact plain onClick={onQuoteCancel}>
-          <FormattedMessage id='status.remove_quote' defaultMessage='Remove' />
-        </Button>
-      )}
-    </div>
-  );
-};
 
 const NestedQuoteLink: React.FC<{ status: Status }> = ({ status }) => {
   const accountId = status.get('account') as string;
@@ -185,14 +161,20 @@ export const QuotedStatus: React.FC<QuotedStatusProps> = ({
   }
 
   if (quoteError) {
+    const hasRemoveButton = contextType === 'composer' && !!onQuoteCancel;
+
     return (
-      <QuoteWrapper
-        isError
-        contextType={contextType}
-        onQuoteCancel={onQuoteCancel}
-      >
+      <div className='status__quote status__quote--error'>
         {quoteError}
-      </QuoteWrapper>
+        {hasRemoveButton && (
+          <Button compact plain onClick={onQuoteCancel}>
+            <FormattedMessage
+              id='status.remove_quote'
+              defaultMessage='Remove'
+            />
+          </Button>
+        )}
+      </div>
     );
   }
 
@@ -205,7 +187,7 @@ export const QuotedStatus: React.FC<QuotedStatusProps> = ({
     childQuote && nestingLevel <= MAX_QUOTE_POSTS_NESTING_LEVEL;
 
   return (
-    <QuoteWrapper>
+    <div className='status__quote'>
       {/* @ts-expect-error Status is not yet typed */}
       <StatusContainer
         isQuotedPost
@@ -226,7 +208,7 @@ export const QuotedStatus: React.FC<QuotedStatusProps> = ({
           />
         )}
       </StatusContainer>
-    </QuoteWrapper>
+    </div>
   );
 };
 


### PR DESCRIPTION
### Changes proposed in this PR:
- Fixes a bug whereby the composer wouldn't indicate that a quoted post was itself a quote post. Now, the "Quoted a post by {author}" note is shown
- Reverts/cleans up some confusing changes from last week's PR #36090 that could make it hard to understand that the "Remove quote" button is only displayed for errors. I have now removed the `QuoteWrapper` component as its only purpose was to abstract away the classNames which doesn't really seem necessary.

### Screenshots

<img width="312" height="403" alt="image" src="https://github.com/user-attachments/assets/5a96e7ed-a581-42e7-8b09-97b3144de2e9" />
