### PR TITLE
Don't show more than one quote removal hint on notifications page

### DIFF
--- a/app/javascript/mastodon/components/dismissable_banner.tsx
+++ b/app/javascript/mastodon/components/dismissable_banner.tsx
@@ -45,7 +45,7 @@ export function useDismissableBannerState({ id }: Props) {
   }, [id, dispatch, isVisible, dismissed]);
 
   return {
-    isVisible,
+    wasDismissed: !isVisible,
     dismiss,
   };
 }
@@ -55,11 +55,11 @@ export const DismissableBanner: React.FC<PropsWithChildren<Props>> = ({
   children,
 }) => {
   const intl = useIntl();
-  const { isVisible, dismiss } = useDismissableBannerState({
+  const { wasDismissed, dismiss } = useDismissableBannerState({
     id,
   });
 
-  if (!isVisible) {
+  if (wasDismissed) {
     return null;
   }
 


### PR DESCRIPTION
### Changes proposed in this PR:
- Prevent the quote removal hint popup from being displayed more than once
- Renamed the `isVisible` variable from the `useDismissableBannerState` hook to `wasDismissed` for accuracy

> [!NOTE]
> I had originally implemented this as part of #35986, but removed it again [in this commit](https://github.com/mastodon/mastodon/pull/35986/commits/1f3579e0f76f5f04d89492f11593204d58e7666b) as the approach using dedicated Redux state wasn't working reliably.
>
> The new approach is much simpler – I just keep track of the first rendered hint in a module-level `let` variable and check for it in a `useEffect`, this is more effective here as all components have access to the mutable variable immediately.

### Screenshots

<img width="603" height="1023" alt="image" src="https://github.com/user-attachments/assets/37f9b84e-43ec-4be8-96ce-1938e4d5bf8b" />
