### PR TITLE
Change wording of disabled quote state to “You are not allowed to quote this post”

### DIFF
--- a/app/javascript/mastodon/api_types/quotes.ts
+++ b/app/javascript/mastodon/api_types/quotes.ts
@@ -4,6 +4,7 @@ export type ApiQuoteState = 'accepted' | 'pending' | 'revoked' | 'unauthorized';
 export type ApiQuotePolicy =
   | 'public'
   | 'followers'
+  | 'following'
   | 'nobody'
   | 'unsupported_policy';
 export type ApiUserQuotePolicy = 'automatic' | 'manual' | 'denied' | 'unknown';

--- a/app/javascript/mastodon/components/status/boost_button_utils.ts
+++ b/app/javascript/mastodon/components/status/boost_button_utils.ts
@@ -21,7 +21,7 @@ export const messages = defineMessages({
   quote: { id: 'status.quote', defaultMessage: 'Quote' },
   quote_cannot: {
     id: 'status.cannot_quote',
-    defaultMessage: 'Quotes are disabled on this post',
+    defaultMessage: 'You are not allowed to quote this post',
   },
   quote_followers_only: {
     id: 'status.quote_followers_only',

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -870,7 +870,7 @@
   "status.block": "Block @{name}",
   "status.bookmark": "Bookmark",
   "status.cancel_reblog_private": "Unboost",
-  "status.cannot_quote": "Quotes are disabled on this post",
+  "status.cannot_quote": "You are not allowed to quote this post",
   "status.cannot_reblog": "This post cannot be boosted",
   "status.context.load_new_replies": "New replies available",
   "status.context.loading": "Checking for more replies",


### PR DESCRIPTION
Change wording of disabled quote state to “You are not allowed to quote this post” so it remains accurate when dealing with following-only quotes.