### PR TITLE
Fix applying user's default quote policy if API parameter is not specified

### DIFF
--- a/app/controllers/concerns/api/interaction_policies_concern.rb
+++ b/app/controllers/concerns/api/interaction_policies_concern.rb
@@ -14,7 +14,7 @@ module Api::InteractionPoliciesConcern
     when 'nobody'
       0
     when nil
-      current_user.setting_default_quote_policy
+      Status::QUOTE_APPROVAL_POLICY_FLAGS[current_user.setting_default_quote_policy&.to_sym] << 16
     else
       # TODO: raise more useful message
       raise ActiveRecord::RecordInvalid

--- a/spec/requests/api/v1/statuses_spec.rb
+++ b/spec/requests/api/v1/statuses_spec.rb
@@ -158,6 +158,28 @@ RSpec.describe '/api/v1/statuses' do
         end
       end
 
+      context 'without a quote policy', feature: :outgoing_quotes do
+        let(:user) do
+          Fabricate(:user, settings: { default_quote_policy: 'followers' })
+        end
+
+        it 'returns post with user default quote policy, as well as rate limit headers', :aggregate_failures do
+          subject
+          expect(user.setting_default_quote_policy).to eq 'followers'
+
+          expect(response).to have_http_status(200)
+          expect(response.content_type)
+            .to start_with('application/json')
+          expect(response.parsed_body[:quote_approval]).to include({
+            automatic: ['followers'],
+            manual: [],
+            current_user: 'automatic',
+          })
+          expect(response.headers['X-RateLimit-Limit']).to eq RateLimiter::FAMILIES[:statuses][:limit].to_s
+          expect(response.headers['X-RateLimit-Remaining']).to eq (RateLimiter::FAMILIES[:statuses][:limit] - 1).to_s
+        end
+      end
+
       context 'with a quote policy', feature: :outgoing_quotes do
         let(:quoted_status) { Fabricate(:status, account: user.account) }
         let(:params) do


### PR DESCRIPTION
User's preferences were not effected when using old version of API or just omit the `quote_approval_policy` parameter

related: #36094 