### PR TITLE
Create reusable Alert/Snackbar component

### DIFF
--- a/.storybook/preview-body.html
+++ b/.storybook/preview-body.html
@@ -1,0 +1,2 @@
+<html class="no-reduce-motion">
+</html>

--- a/app/javascript/mastodon/components/alert/alert.stories.tsx
+++ b/app/javascript/mastodon/components/alert/alert.stories.tsx
@@ -84,8 +84,26 @@ export const WithTitle: Story = {
 
 export const WithDismissButton: Story = {
   args: {
-    ...WithAction.args,
+    message: 'More replies found',
+    action: 'Show',
     onDismiss: fn(),
   },
   render: Simple.render,
+};
+
+export const InSizedContainer: Story = {
+  args: WithDismissButton.args,
+  render: (args) => (
+    <div
+      style={{
+        overflow: 'clip',
+        padding: '1rem',
+        width: '380px',
+        maxWidth: '100%',
+        boxSizing: 'border-box',
+      }}
+    >
+      <Alert {...args} />
+    </div>
+  ),
 };

--- a/app/javascript/mastodon/components/alert/alert.stories.tsx
+++ b/app/javascript/mastodon/components/alert/alert.stories.tsx
@@ -1,0 +1,91 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn, expect } from 'storybook/test';
+
+import { Alert } from '.';
+
+const meta = {
+  title: 'Components/Alert',
+  component: Alert,
+  args: {
+    isActive: true,
+    animateFrom: 'start',
+    title: '',
+    message: '',
+    action: '',
+    onActionClick: fn(),
+  },
+  argTypes: {
+    isActive: {
+      control: 'boolean',
+      type: 'boolean',
+      description: 'Animate to the active (displayed) state of the alert',
+    },
+    animateFrom: {
+      control: 'radio',
+      type: 'string',
+      options: ['start', 'below'],
+      description: 'Direction that the alert animates in from when activated',
+    },
+    title: {
+      control: 'text',
+      type: 'string',
+      description: '(Optional) title of the alert',
+    },
+    message: {
+      control: 'text',
+      type: 'string',
+      description: 'Main alert text',
+    },
+    action: {
+      control: 'text',
+      type: 'string',
+      description:
+        'Label of the alert action (requires `onActionClick` handler)',
+    },
+  },
+  tags: ['test'],
+} satisfies Meta<typeof Alert>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Simple: Story = {
+  args: {
+    message: 'Post published.',
+  },
+  render: (args) => (
+    <div style={{ overflow: 'clip', padding: '1rem' }}>
+      <Alert {...args} />
+    </div>
+  ),
+};
+
+export const WithAction: Story = {
+  args: {
+    ...Simple.args,
+    action: 'Open',
+  },
+  render: Simple.render,
+  play: async ({ args, canvas, userEvent }) => {
+    const button = await canvas.findByRole('button', { name: 'Open' });
+    await userEvent.click(button);
+    await expect(args.onActionClick).toHaveBeenCalled();
+  },
+};
+
+export const WithTitle: Story = {
+  args: {
+    title: 'Warning:',
+    message: 'This is an alert',
+  },
+  render: Simple.render,
+};
+
+export const WithDismissButton: Story = {
+  args: {
+    ...WithAction.args,
+    onDismiss: fn(),
+  },
+  render: Simple.render,
+};

--- a/app/javascript/mastodon/components/alert/alert.stories.tsx
+++ b/app/javascript/mastodon/components/alert/alert.stories.tsx
@@ -8,7 +8,7 @@ const meta = {
   component: Alert,
   args: {
     isActive: true,
-    animateFrom: 'start',
+    animateFrom: 'side',
     title: '',
     message: '',
     action: '',
@@ -23,8 +23,9 @@ const meta = {
     animateFrom: {
       control: 'radio',
       type: 'string',
-      options: ['start', 'below'],
-      description: 'Direction that the alert animates in from when activated',
+      options: ['side', 'below'],
+      description:
+        'Direction that the alert animates in from when activated. `side` is dependent on reading direction, defaulting to left in ltr languages.',
     },
     title: {
       control: 'text',

--- a/app/javascript/mastodon/components/alert/index.tsx
+++ b/app/javascript/mastodon/components/alert/index.tsx
@@ -38,7 +38,9 @@ export const Alert: React.FC<{
         'from-below': animateFrom === 'below',
       })}
     >
-      {!!title && <span className='notification-bar-title'>{title}</span>}
+      {Boolean(title) && (
+        <span className='notification-bar-title'>{title}</span>
+      )}
 
       <span className='notification-bar-message'>{message}</span>
 
@@ -48,7 +50,7 @@ export const Alert: React.FC<{
         </button>
       )}
 
-      {!!onDismiss && (
+      {onDismiss && (
         <IconButton
           title={intl.formatMessage({
             id: 'dismissable_banner.dismiss',

--- a/app/javascript/mastodon/components/alert/index.tsx
+++ b/app/javascript/mastodon/components/alert/index.tsx
@@ -1,0 +1,65 @@
+import { useIntl } from 'react-intl';
+
+import classNames from 'classnames';
+
+import CloseIcon from '@/material-icons/400-24px/close.svg?react';
+
+import { IconButton } from '../icon_button';
+
+/**
+ * Snackbar/Toast-style notification component.
+ */
+export const Alert: React.FC<{
+  isActive?: boolean;
+  animateFrom?: 'start' | 'below';
+  title?: string;
+  message: string;
+  action?: string;
+  onActionClick?: () => void;
+  onDismiss?: () => void;
+}> = ({
+  isActive,
+  animateFrom = 'start',
+  title,
+  message,
+  action,
+  onActionClick,
+  onDismiss,
+}) => {
+  const intl = useIntl();
+
+  const hasAction = Boolean(action && onActionClick);
+
+  return (
+    <div
+      className={classNames('notification-bar', {
+        'notification-bar-active': isActive,
+        'from-start': animateFrom === 'start',
+        'from-below': animateFrom === 'below',
+      })}
+    >
+      {!!title && <span className='notification-bar-title'>{title}</span>}
+
+      <span className='notification-bar-message'>{message}</span>
+
+      {hasAction && (
+        <button className='notification-bar-action' onClick={onActionClick}>
+          {action}
+        </button>
+      )}
+
+      {!!onDismiss && (
+        <IconButton
+          title={intl.formatMessage({
+            id: 'alerts.dismiss',
+            defaultMessage: 'Dismiss',
+          })}
+          icon='times'
+          iconComponent={CloseIcon}
+          className='notification-bar-dismiss-button'
+          onClick={onDismiss}
+        />
+      )}
+    </div>
+  );
+};

--- a/app/javascript/mastodon/components/alert/index.tsx
+++ b/app/javascript/mastodon/components/alert/index.tsx
@@ -33,7 +33,7 @@ export const Alert: React.FC<{
   return (
     <div
       className={classNames('notification-bar', {
-        'notification-bar-active': isActive,
+        'notification-bar--active': isActive,
         'from-start': animateFrom === 'start',
         'from-below': animateFrom === 'below',
       })}

--- a/app/javascript/mastodon/components/alert/index.tsx
+++ b/app/javascript/mastodon/components/alert/index.tsx
@@ -38,14 +38,15 @@ export const Alert: React.FC<{
         'from-below': animateFrom === 'below',
       })}
     >
-      {Boolean(title) && (
-        <span className='notification-bar-title'>{title}</span>
-      )}
-
-      <span className='notification-bar-message'>{message}</span>
+      <span className='notification-bar__content'>
+        {Boolean(title) && (
+          <span className='notification-bar__title'>{title}</span>
+        )}
+        {message}
+      </span>
 
       {hasAction && (
-        <button className='notification-bar-action' onClick={onActionClick}>
+        <button className='notification-bar__action' onClick={onActionClick}>
           {action}
         </button>
       )}
@@ -58,7 +59,7 @@ export const Alert: React.FC<{
           })}
           icon='times'
           iconComponent={CloseIcon}
-          className='notification-bar-dismiss-button'
+          className='notification-bar__dismiss-button'
           onClick={onDismiss}
         />
       )}

--- a/app/javascript/mastodon/components/alert/index.tsx
+++ b/app/javascript/mastodon/components/alert/index.tsx
@@ -51,7 +51,7 @@ export const Alert: React.FC<{
       {!!onDismiss && (
         <IconButton
           title={intl.formatMessage({
-            id: 'alerts.dismiss',
+            id: 'dismissable_banner.dismiss',
             defaultMessage: 'Dismiss',
           })}
           icon='times'

--- a/app/javascript/mastodon/components/alert/index.tsx
+++ b/app/javascript/mastodon/components/alert/index.tsx
@@ -11,7 +11,7 @@ import { IconButton } from '../icon_button';
  */
 export const Alert: React.FC<{
   isActive?: boolean;
-  animateFrom?: 'start' | 'below';
+  animateFrom?: 'side' | 'below';
   title?: string;
   message: string;
   action?: string;
@@ -19,7 +19,7 @@ export const Alert: React.FC<{
   onDismiss?: () => void;
 }> = ({
   isActive,
-  animateFrom = 'start',
+  animateFrom = 'side',
   title,
   message,
   action,
@@ -34,7 +34,7 @@ export const Alert: React.FC<{
     <div
       className={classNames('notification-bar', {
         'notification-bar--active': isActive,
-        'from-start': animateFrom === 'start',
+        'from-side': animateFrom === 'side',
         'from-below': animateFrom === 'below',
       })}
     >

--- a/app/javascript/mastodon/components/alerts_controller.tsx
+++ b/app/javascript/mastodon/components/alerts_controller.tsx
@@ -3,15 +3,15 @@ import { useState, useEffect } from 'react';
 import { useIntl } from 'react-intl';
 import type { IntlShape } from 'react-intl';
 
-import classNames from 'classnames';
-
 import { dismissAlert } from 'mastodon/actions/alerts';
 import type {
-  Alert,
+  Alert as AlertType,
   TranslatableString,
   TranslatableValues,
 } from 'mastodon/models/alert';
 import { useAppSelector, useAppDispatch } from 'mastodon/store';
+
+import { Alert } from './alert';
 
 const formatIfNeeded = (
   intl: IntlShape,
@@ -25,8 +25,8 @@ const formatIfNeeded = (
   return message;
 };
 
-const Alert: React.FC<{
-  alert: Alert;
+const TimedAlert: React.FC<{
+  alert: AlertType;
   dismissAfter: number;
 }> = ({
   alert: { key, title, message, values, action, onClick },
@@ -62,29 +62,13 @@ const Alert: React.FC<{
   }, [dispatch, setActive, key, dismissAfter]);
 
   return (
-    <div
-      className={classNames('notification-bar', {
-        'notification-bar-active': active,
-      })}
-    >
-      <div className='notification-bar-wrapper'>
-        {title && (
-          <span className='notification-bar-title'>
-            {formatIfNeeded(intl, title, values)}
-          </span>
-        )}
-
-        <span className='notification-bar-message'>
-          {formatIfNeeded(intl, message, values)}
-        </span>
-
-        {action && (
-          <button className='notification-bar-action' onClick={onClick}>
-            {formatIfNeeded(intl, action, values)}
-          </button>
-        )}
-      </div>
-    </div>
+    <Alert
+      isActive={active}
+      title={title ? formatIfNeeded(intl, title, values) : undefined}
+      message={formatIfNeeded(intl, message, values)}
+      action={action ? formatIfNeeded(intl, action, values) : undefined}
+      onActionClick={onClick}
+    />
   );
 };
 
@@ -98,7 +82,11 @@ export const AlertsController: React.FC = () => {
   return (
     <div className='notification-list'>
       {alerts.map((alert, idx) => (
-        <Alert key={alert.key} alert={alert} dismissAfter={5000 + idx * 1000} />
+        <TimedAlert
+          key={alert.key}
+          alert={alert}
+          dismissAfter={5000 + idx * 1000}
+        />
       ))}
     </div>
   );

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -10305,7 +10305,7 @@ noscript {
   --alert-edge-spacing: 1rem;
 
   display: flex;
-  gap: 5px;
+  gap: 10px;
   flex: 0 0 auto;
   width: auto;
   padding: 15px;
@@ -10342,16 +10342,20 @@ noscript {
   }
 }
 
-.notification-bar-title {
+.notification-bar__content {
+  margin-inline-end: auto;
+}
+
+.notification-bar__title {
+  margin-inline-end: 5px;
   font-weight: 700;
 }
 
-.notification-bar-action {
+.notification-bar__action {
   display: inline-block;
   border: 0;
   background: transparent;
   text-transform: uppercase;
-  margin-inline-start: 5px;
   cursor: pointer;
   color: $blurple-300;
   font-weight: 700;
@@ -10365,9 +10369,8 @@ noscript {
   }
 }
 
-.notification-bar-dismiss-button {
+.notification-bar__dismiss-button {
   margin-top: -2px;
-  margin-inline-start: auto;
   color: rgb(from currentColor r g b / 85%);
 
   &:hover,

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -10302,9 +10302,10 @@ noscript {
 }
 
 .notification-bar {
+  --alert-edge-spacing: 1rem;
+
+  display: flex;
   flex: 0 0 auto;
-  position: relative;
-  inset-inline-start: -100%;
   width: auto;
   padding: 15px;
   margin: 0;
@@ -10320,13 +10321,23 @@ noscript {
   font-size: 15px;
   line-height: 21px;
 
+  &.from-start {
+    translate: calc(
+      -1 * (100% + var(--alert-edge-spacing)) * var(--text-x-direction)
+    );
+  }
+
+  &.from-below {
+    translate: 0 calc(100% + var(--alert-edge-spacing));
+  }
+
   &.notification-bar-active {
-    inset-inline-start: 1rem;
+    translate: none;
   }
 
   .no-reduce-motion & {
     transition: 0.5s cubic-bezier(0.89, 0.01, 0.5, 1.1);
-    transform: translateZ(0);
+    will-change: translate;
   }
 }
 
@@ -10354,6 +10365,18 @@ noscript {
   &:focus,
   &:active {
     background: color.change($ui-base-color, $alpha: 0.85);
+  }
+}
+
+.notification-bar-dismiss-button {
+  margin-top: -2px;
+  margin-inline-start: 15px;
+  color: rgb(from currentColor r g b / 70%);
+
+  &:hover,
+  &:focus,
+  &:active {
+    color: currentColor;
   }
 }
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -10368,7 +10368,7 @@ noscript {
 .notification-bar-dismiss-button {
   margin-top: -2px;
   margin-inline-start: auto;
-  color: rgb(from currentColor r g b / 70%);
+  color: rgb(from currentColor r g b / 85%);
 
   &:hover,
   &:focus,

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -10294,7 +10294,7 @@ noscript {
 .notification-list {
   position: fixed;
   bottom: 2rem;
-  inset-inline-start: 0;
+  inset-inline-start: 1rem;
   z-index: 9999;
   display: flex;
   flex-direction: column;
@@ -10305,6 +10305,7 @@ noscript {
   --alert-edge-spacing: 1rem;
 
   display: flex;
+  gap: 5px;
   flex: 0 0 auto;
   width: auto;
   padding: 15px;
@@ -10331,7 +10332,7 @@ noscript {
     translate: 0 calc(100% + var(--alert-edge-spacing));
   }
 
-  &.notification-bar-active {
+  &.notification-bar--active {
     translate: none;
   }
 
@@ -10342,11 +10343,6 @@ noscript {
 }
 
 .notification-bar-title {
-  margin-inline-end: 5px;
-}
-
-.notification-bar-title,
-.notification-bar-action {
   font-weight: 700;
 }
 
@@ -10355,9 +10351,10 @@ noscript {
   border: 0;
   background: transparent;
   text-transform: uppercase;
-  margin-inline-start: 10px;
+  margin-inline-start: 5px;
   cursor: pointer;
   color: $blurple-300;
+  font-weight: 700;
   border-radius: 4px;
   padding: 0 4px;
 
@@ -10370,7 +10367,7 @@ noscript {
 
 .notification-bar-dismiss-button {
   margin-top: -2px;
-  margin-inline-start: 15px;
+  margin-inline-start: auto;
   color: rgb(from currentColor r g b / 70%);
 
   &:hover,

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -10322,7 +10322,7 @@ noscript {
   font-size: 15px;
   line-height: 21px;
 
-  &.from-start {
+  &.from-side {
     translate: calc(
       -1 * (100% + var(--alert-edge-spacing)) * var(--text-x-direction)
     );


### PR DESCRIPTION
In preparation for MAS-569

### Changes proposed in this PR:

- Moves the basic, non-timed alert component to its own module [with Storybook 📖](https://684157922c67cb435d550a35-skawxxhaec.chromatic.com/?path=/docs/components-alert--docs)
- Adds the ability to add a "dismiss" icon button to the alert
- Adds the ability for the alert to animate in from the bottom as well as the `inline-start` direction
- Uses transforms for the animation rather than `inset-inline-start`

### Screenshots


https://github.com/user-attachments/assets/8a498150-f8ed-4735-89a5-7aa254e1462d


<img width="612" height="1223" alt="image" src="https://github.com/user-attachments/assets/11d335eb-fd8e-4d19-9a75-3cbe59edbaf9" />
