### PR TITLE
Fix deprecated nginx HTTP/2 directive

### DIFF
--- a/dist/nginx.conf
+++ b/dist/nginx.conf
@@ -31,8 +31,9 @@ server {
 }
 
 server {
-  listen 443 ssl http2;
-  listen [::]:443 ssl http2;
+  listen 443 ssl;
+  listen [::]:443 ssl;
+  http2 on;
   server_name example.com;
 
   ssl_protocols TLSv1.2 TLSv1.3;


### PR DESCRIPTION
The nginx configuration was using the now deprecated `listen ... http2` directive syntax, which generates the following warning with `nginx -t`:

```
the "listen ... http2" directive is deprecated, use the "http2" directive instead in /etc/nginx/sites-enabled/mastodon:34
```

I updated the SSL server block in `dist/nginx.conf` to use the new syntax. See:

* https://docs.nginx.com/nginx/releases/#r30
* https://hg.nginx.org/nginx/rev/08ef02ad5c54