### PR TITLE
Fix translate button width in Safari

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1413,13 +1413,14 @@
 .status__content__translate-button {
   display: flex;
   align-items: center;
+  width: min-content;
   font-size: 15px;
   line-height: 22px;
   color: $highlight-text-color;
   border: 0;
   background: transparent;
   padding: 0;
-  padding-top: 16px;
+  margin-top: 16px;
   text-decoration: none;
 
   &:hover,


### PR DESCRIPTION
### Changes proposed in this PR:
- Fixes a small issue whereby a quoted post's Translate button takes up the entire width of the quote, making it easy to click by accident