### PR TITLE
Add click-through for quoted limited accounts

### DIFF
--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -895,6 +895,8 @@
   "status.quote": "Quote",
   "status.quote.cancel": "Cancel quote",
   "status.quote_error.filtered": "Hidden due to one of your filters",
+  "status.quote_error.limited_account_hint.action": "Show anyway",
+  "status.quote_error.limited_account_hint.title": "This account has been hidden by the moderators of {domain}.",
   "status.quote_error.not_available": "Post unavailable",
   "status.quote_error.pending_approval": "Post pending",
   "status.quote_error.pending_approval_popout.body": "On Mastodon, you can control whether someone can quote you. This post is pending while we're getting the original author's approval.",


### PR DESCRIPTION
See #36166

<img width="598" height="230" alt="image" src="https://github.com/user-attachments/assets/5340507e-95fe-485f-b3a0-808148b6933b" />