### PR TITLE
Spec for newline in request lib initialize

### DIFF
--- a/spec/lib/request_spec.rb
+++ b/spec/lib/request_spec.rb
@@ -40,6 +40,23 @@ RSpec.describe Request do
     end
   end
 
+  describe '#initialize' do
+    subject { described_class.new(:get, url) }
+
+    context 'when URL has new lines' do
+      let(:url) { "https://host.example/image\nhttps://badhost.example/page.jpg?overlay-align=bottom%2Cleft" }
+
+      it 'encodes new lines in url value after normalization' do
+        expect(initialized_url_value)
+          .to eq('https://host.example/image%0Ahttps://badhost.example/page.jpg?overlay-align=bottom,left')
+      end
+    end
+
+    def initialized_url_value
+      subject.instance_variable_get(:@url).to_s
+    end
+  end
+
   describe '#perform' do
     context 'with valid host and non-persistent connection' do
       before { stub_request(:get, 'http://example.com').to_return(body: 'lorem ipsum') }

--- a/spec/lib/request_spec.rb
+++ b/spec/lib/request_spec.rb
@@ -44,11 +44,11 @@ RSpec.describe Request do
     subject { described_class.new(:get, url) }
 
     context 'when URL has new lines' do
-      let(:url) { "https://host.example/image\nhttps://badhost.example/page.jpg?overlay-align=bottom%2Cleft" }
+      let(:url) { "https://host.example/image\nhttps://badhost.example/page.jpg" }
 
       it 'encodes new lines in url value after normalization' do
         expect(initialized_url_value)
-          .to eq('https://host.example/image%0Ahttps://badhost.example/page.jpg?overlay-align=bottom,left')
+          .to eq('https://host.example/image%0Ahttps://badhost.example/page.jpg')
       end
     end
 


### PR DESCRIPTION
Related to ongoing discussion in https://github.com/mastodon/mastodon/pull/36139

This adds spec which tries to wrap up what (currently) happens the inbound url value during initialization:

- Confirm we (as desired) convert the newlined into encoded chars
- Confirm we (not desired, but currently happens) un-encode the comma in the query params

From WIP branch here - https://github.com/mastodon/mastodon/compare/main...mjankowski:request-og-image-things - which I will rebase with changes that preserve newline thing but fix comma thing (and/or, the linked PR can rebase with another solution)

Reaching in to the object i-var is a little awkward, but -- a) the url is not available as getter, b) using the webmock expectations on the request from `perform` is confusing because those matchers have their own encode/decode logic as well which makes it less straightforward. Open to ideas there.