### PR TITLE
Add short-time HTTP caching of quote authorizations for public posts

### DIFF
--- a/app/controllers/activitypub/quote_authorizations_controller.rb
+++ b/app/controllers/activitypub/quote_authorizations_controller.rb
@@ -9,7 +9,7 @@ class ActivityPub::QuoteAuthorizationsController < ActivityPub::BaseController
   before_action :set_quote_authorization
 
   def show
-    expires_in 0, public: @quote.status.distributable? && public_fetch_mode?
+    expires_in 30.seconds, public: true if @quote.status.distributable? && public_fetch_mode?
     render json: @quote, serializer: ActivityPub::QuoteAuthorizationSerializer, adapter: ActivityPub::Adapter, content_type: 'application/activity+json'
   end
 


### PR DESCRIPTION
The cache window must remain small to not prevent revocations.