### PR TITLE
Use enum-generated bang methods on bulk import state change

### DIFF
--- a/app/controllers/settings/imports_controller.rb
+++ b/app/controllers/settings/imports_controller.rb
@@ -65,7 +65,7 @@ class Settings::ImportsController < Settings::BaseController
   end
 
   def confirm
-    @bulk_import.update!(state: :scheduled)
+    @bulk_import.state_scheduled!
     BulkImportWorker.perform_async(@bulk_import.id)
     redirect_to settings_imports_path, notice: I18n.t('imports.success')
   end

--- a/app/models/bulk_import.rb
+++ b/app/models/bulk_import.rb
@@ -27,6 +27,8 @@ class BulkImport < ApplicationRecord
   belongs_to :account
   has_many :rows, class_name: 'BulkImportRow', inverse_of: :bulk_import, dependent: :delete_all
 
+  after_save :finalize_import, if: [:state_previously_changed?, :state_finished?]
+
   enum :type, {
     following: 0,
     blocking: 1,
@@ -63,6 +65,10 @@ class BulkImport < ApplicationRecord
 
     # Since the incrementation has been done atomically, concurrent access to `bulk_import` is now benign
     bulk_import = BulkImport.find(bulk_import_id)
-    bulk_import.update!(state: :finished, finished_at: Time.now.utc) if bulk_import.processing_complete?
+    bulk_import.state_finished! if bulk_import.processing_complete?
+  end
+
+  def finalize_import
+    touch :finished_at
   end
 end

--- a/app/services/bulk_import_service.rb
+++ b/app/services/bulk_import_service.rb
@@ -20,9 +20,9 @@ class BulkImportService < BaseService
       import_lists!
     end
 
-    @import.update!(state: :finished, finished_at: Time.now.utc) if @import.processing_complete?
+    @import.state_finished! if @import.processing_complete?
   rescue
-    @import.update!(state: :finished, finished_at: Time.now.utc)
+    @import.state_finished!
 
     raise
   end

--- a/app/workers/bulk_import_worker.rb
+++ b/app/workers/bulk_import_worker.rb
@@ -7,7 +7,7 @@ class BulkImportWorker
 
   def perform(import_id)
     import = BulkImport.find(import_id)
-    import.update!(state: :in_progress)
+    import.state_in_progress!
     BulkImportService.new.call(import)
   end
 end

--- a/spec/fabricators/bulk_import_fabricator.rb
+++ b/spec/fabricators/bulk_import_fabricator.rb
@@ -1,12 +1,7 @@
 # frozen_string_literal: true
 
 Fabricator(:bulk_import) do
-  type            1
-  state           1
-  total_items     1
-  processed_items 1
-  imported_items  1
-  finished_at     '2022-11-18 14:55:07'
-  overwrite       false
+  type :blocking
+  state :scheduled
   account { Fabricate.build(:account) }
 end

--- a/spec/models/bulk_import_spec.rb
+++ b/spec/models/bulk_import_spec.rb
@@ -63,4 +63,20 @@ RSpec.describe BulkImport do
       it { is_expected.to_not be_processing_complete }
     end
   end
+
+  describe 'Callbacks' do
+    describe 'Finalizing an import' do
+      let(:bulk_import) { Fabricate :bulk_import, state: :scheduled }
+
+      it 'updates timestamp when record moves to finished state' do
+        expect { bulk_import.update(state: :finished) }
+          .to change(bulk_import, :finished_at).from(be_nil).to(be_present)
+      end
+
+      it 'does not update timestamp when record moves to other state' do
+        expect { bulk_import.update(state: :in_progress) }
+          .to not_change(bulk_import, :finished_at).from(be_nil)
+      end
+    end
+  end
 end


### PR DESCRIPTION
The `enum` declaration generates methods named after all the states which can do the update.

Related changes:

- Once over to use those bang methods over explicit update
- Every spot which was updating state to finished was also touching the finished_at time - move this to an after save callback to ensure its always touched when the state changes in that way
- The fabricator here had extra values beyond what is needed for valid record, remove those