### PR TITLE
Fix getting `Create` and `Update` out of order

### DIFF
--- a/app/lib/activitypub/activity/update.rb
+++ b/app/lib/activitypub/activity/update.rb
@@ -28,6 +28,9 @@ class ActivityPub::Activity::Update < ActivityPub::Activity
 
     @status = Status.find_by(uri: object_uri, account_id: @account.id)
 
+    # We may be getting `Create` and `Update` out of order
+    @status ||= ActivityPub::Activity::Create.new(@json, @account, **@options).perform
+
     return if @status.nil?
 
     ActivityPub::ProcessStatusUpdateService.new.call(@status, @json, @object, request_id: @options[:request_id])

--- a/spec/lib/activitypub/activity_spec.rb
+++ b/spec/lib/activitypub/activity_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ActivityPub::Activity do
+  describe 'processing a Create and an Update' do
+    let(:sender) { Fabricate(:account, followers_url: 'http://example.com/followers', domain: 'example.com', uri: 'https://example.com/actor') }
+    let(:quoted_account) { Fabricate(:account, domain: 'quoted.example.com') }
+    let(:quoted_status) { Fabricate(:status, account: quoted_account) }
+    let(:approval_uri) { 'https://quoted.example.com/approvals/1' }
+
+    let(:approval_payload) do
+      {
+        '@context': [
+          'https://www.w3.org/ns/activitystreams',
+          {
+            QuoteAuthorization: 'https://w3id.org/fep/044f#QuoteAuthorization',
+            gts: 'https://gotosocial.org/ns#',
+            interactingObject: {
+              '@id': 'gts:interactingObject',
+              '@type': '@id',
+            },
+            interactionTarget: {
+              '@id': 'gts:interactionTarget',
+              '@type': '@id',
+            },
+          },
+        ],
+        type: 'QuoteAuthorization',
+        id: approval_uri,
+        attributedTo: ActivityPub::TagManager.instance.uri_for(quoted_status.account),
+        interactingObject: [ActivityPub::TagManager.instance.uri_for(sender), 'post1'].join('/'),
+        interactionTarget: ActivityPub::TagManager.instance.uri_for(quoted_status),
+      }
+    end
+
+    let(:create_json) do
+      {
+        '@context': [
+          'https://www.w3.org/ns/activitystreams',
+          {
+            quote: 'https://w3id.org/fep/044f#quote',
+          },
+        ],
+        id: [ActivityPub::TagManager.instance.uri_for(sender), '#create'].join,
+        type: 'Create',
+        actor: ActivityPub::TagManager.instance.uri_for(sender),
+        object: {
+          id: [ActivityPub::TagManager.instance.uri_for(sender), 'post1'].join('/'),
+          type: 'Note',
+          to: [
+            'https://www.w3.org/ns/activitystreams#Public',
+          ],
+          content: 'foo',
+          published: '2025-05-24T11:03:10Z',
+          quote: ActivityPub::TagManager.instance.uri_for(quoted_status),
+        },
+      }.deep_stringify_keys
+    end
+
+    let(:update_json) do
+      {
+        '@context': [
+          'https://www.w3.org/ns/activitystreams',
+          {
+            quote: 'https://w3id.org/fep/044f#quote',
+            quoteAuthorization: { '@id': 'https://w3id.org/fep/044f#quoteAuthorization', '@type': '@id' },
+          },
+        ],
+        id: [ActivityPub::TagManager.instance.uri_for(sender), '#update'].join,
+        type: 'Update',
+        actor: ActivityPub::TagManager.instance.uri_for(sender),
+        object: {
+          id: [ActivityPub::TagManager.instance.uri_for(sender), 'post1'].join('/'),
+          type: 'Note',
+          to: [
+            'https://www.w3.org/ns/activitystreams#Public',
+          ],
+          content: 'foo',
+          published: '2025-05-24T11:03:10Z',
+          quote: ActivityPub::TagManager.instance.uri_for(quoted_status),
+          quoteAuthorization: approval_uri,
+        },
+      }.deep_stringify_keys
+    end
+
+    before do
+      sender.update(uri: ActivityPub::TagManager.instance.uri_for(sender))
+
+      stub_request(:get, approval_uri).to_return(headers: { 'Content-Type': 'application/activity+json' }, body: Oj.dump(approval_payload))
+    end
+
+    context 'when getting them in order' do
+      it 'creates a status and approves the quote' do
+        described_class.factory(create_json, sender).perform
+        status = described_class.factory(update_json, sender).perform
+
+        expect(status.quote.state).to eq 'accepted'
+      end
+    end
+
+    context 'when getting them out of order' do
+      it 'creates a status and approves the quote' do
+        described_class.factory(update_json, sender).perform
+        status = described_class.factory(create_json, sender).perform
+
+        expect(status.quote.state).to eq 'accepted'
+      end
+    end
+  end
+end


### PR DESCRIPTION
This might be the cause of some quote posts not displaying as approved.

The idea is as follows:
- if the post is not found, the post may or may not be of interest to us
- if it is of no interest to us, the `Create` handler will discard it
- if it is of interest to us, we either missed the `Create` or are likely to get it, so process the more-up-to-date version of the post immediately

This may cover the case when a post is `Create`d then `Update`d to add a `quoteApproval` and thus are received out-of-order.