### PR TITLE
Add `formatted_time` helper

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -22,6 +22,10 @@ module ApplicationHelper
     number_to_human(number, **options)
   end
 
+  def formatted_time(datetime)
+    tag.time(class: :formatted, datetime: datetime.iso8601, title: l(datetime)) { l(datetime) }
+  end
+
   def open_registrations?
     Setting.registrations_mode == 'open'
   end

--- a/app/views/admin/account_warnings/_account_warning.html.haml
+++ b/app/views/admin/account_warnings/_account_warning.html.haml
@@ -10,8 +10,7 @@
             name: content_tag(:span, account_warning.account ? account_warning.account.username : I18n.t('admin.action_logs.deleted_account'), class: 'username'),
             target: content_tag(:span, account_warning.target_account.pretty_acct, class: 'target')).html_safe
       .log-entry__timestamp
-        %time.formatted{ datetime: account_warning.created_at.iso8601 }
-          = l(account_warning.created_at)
+        = formatted_time(account_warning.created_at)
 
         - if account_warning.report_id.present?
           ·

--- a/app/views/admin/accounts/_local_account.html.haml
+++ b/app/views/admin/accounts/_local_account.html.haml
@@ -60,14 +60,14 @@
 %tr
   %th= t('admin.accounts.joined')
   %td
-    %time.formatted{ datetime: account.created_at.iso8601, title: l(account.created_at) }= l account.created_at
+    = formatted_time account.created_at
   %td
   = render partial: 'admin/accounts/user_ip', collection: account.user.ips.by_latest_used
 %tr
   %th= t('admin.accounts.most_recent_activity')
   %td
     - if account.user_current_sign_in_at
-      %time.formatted{ datetime: account.user_current_sign_in_at.iso8601, title: l(account.user_current_sign_in_at) }= l account.user_current_sign_in_at
+      = formatted_time account.user_current_sign_in_at
   %td
 - if account.user&.invited?
   %tr

--- a/app/views/admin/action_logs/_action_log.html.haml
+++ b/app/views/admin/action_logs/_action_log.html.haml
@@ -8,4 +8,4 @@
             name: content_tag(:span, action_log.account.username, class: 'username'),
             target: content_tag(:span, log_target(action_log), class: 'target')
       .log-entry__timestamp
-        %time.formatted{ datetime: action_log.created_at.iso8601 }
+        = formatted_time(action_log.created_at)

--- a/app/views/admin/disputes/appeals/_appeal.html.haml
+++ b/app/views/admin/disputes/appeals/_appeal.html.haml
@@ -6,8 +6,7 @@
       .log-entry__title
         = strike_action_label(appeal)
       .log-entry__timestamp
-        %time.formatted{ datetime: appeal.strike.created_at.iso8601 }
-          = l(appeal.strike.created_at)
+        = formatted_time appeal.strike.created_at
 
         - if appeal.strike.report_id.present?
           ·

--- a/app/views/admin/invites/_invite.html.haml
+++ b/app/views/admin/invites/_invite.html.haml
@@ -19,8 +19,7 @@
       - if invite.expires_at.nil?
         ∞
       - else
-        %time.formatted{ datetime: invite.expires_at.iso8601, title: l(invite.expires_at) }
-          = l invite.expires_at
+        = formatted_time invite.expires_at
   - else
     %td{ colspan: 2 }
       = t('invites.expired')

--- a/app/views/admin/reports/_header_details.html.haml
+++ b/app/views/admin/reports/_header_details.html.haml
@@ -3,7 +3,7 @@
     .report-header__details__item__header
       %strong= t('admin.reports.created_at')
     .report-header__details__item__content
-      %time.formatted{ datetime: report.created_at.iso8601 }
+      = formatted_time report.created_at
   .report-header__details__item
     .report-header__details__item__header
       %strong= t('admin.reports.reported_by')

--- a/app/views/admin/reports/actions/preview.html.haml
+++ b/app/views/admin/reports/actions/preview.html.haml
@@ -64,7 +64,7 @@
                       = media_attachment.file_file_name
                 .strike-card__statuses-list__item__meta
                   = link_to ActivityPub::TagManager.instance.url_for(status), target: '_blank', rel: 'noopener' do
-                    %time.formatted{ datetime: status.created_at.iso8601, title: l(status.created_at) }= l(status.created_at)
+                    = formatted_time status.created_at
                   - unless status.application.nil?
                     ·
                     = status.application.name

--- a/app/views/admin/shared/_status.html.haml
+++ b/app/views/admin/shared/_status.html.haml
@@ -17,7 +17,7 @@
       = status.application.name
       ·
     = conditional_link_to can?(:show, status), admin_account_status_path(status.account.id, status), class: 'detailed-status__datetime' do
-      %time.formatted{ datetime: status.created_at.iso8601, title: l(status.created_at) }><= l(status.created_at)
+      = formatted_time status.created_at
     - if status.edited?
       &nbsp;·
       = conditional_link_to can?(:show, status), admin_account_status_path(status.account.id, status, { anchor: 'history' }), class: 'detailed-status__datetime' do

--- a/app/views/admin/status_edits/_status_edit.html.haml
+++ b/app/views/admin/status_edits/_status_edit.html.haml
@@ -6,13 +6,13 @@
       - else
         = t('admin.statuses.status_changed')
       ·
-      %time.formatted{ datetime: status_edit.created_at.iso8601, title: l(status_edit.created_at) }= l(status_edit.created_at)
+      = formatted_time status_edit.created_at
 
     .status
       = render partial: 'admin/shared/status_content', locals: { status: status_edit }
 
       .detailed-status__meta
-        %time.formatted{ datetime: status_edit.created_at.iso8601, title: l(status_edit.created_at) }= l(status_edit.created_at)
+        = formatted_time status_edit.created_at
 
         - if status_edit.sensitive?
           ·

--- a/app/views/auth/registrations/_account_warning.html.haml
+++ b/app/views/auth/registrations/_account_warning.html.haml
@@ -9,7 +9,7 @@
             action: t(account_warning.action, scope: 'disputes.strikes.title_actions'),
             date: l(account_warning.created_at.to_date)
       .strike-entry__timestamp
-        %time.formatted{ datetime: account_warning.created_at.iso8601 }= l(account_warning.created_at)
+        = formatted_time account_warning.created_at
 
         - if account_warning.overruled?
           ·

--- a/app/views/disputes/strikes/_card.html.haml
+++ b/app/views/disputes/strikes/_card.html.haml
@@ -28,7 +28,7 @@
                   = media_attachment.file_file_name
             .strike-card__statuses-list__item__meta
               = link_to ActivityPub::TagManager.instance.url_for(status), target: '_blank', rel: 'noopener' do
-                %time.formatted{ datetime: status.created_at.iso8601, title: l(status.created_at) }= l(status.created_at)
+                = formatted_time status.created_at
               - unless status.application.nil?
                 ·
                 = status.application.name

--- a/app/views/disputes/strikes/show.html.haml
+++ b/app/views/disputes/strikes/show.html.haml
@@ -28,7 +28,7 @@
       .report-header__details__item__header
         %strong= t('disputes.strikes.created_at')
       .report-header__details__item__content
-        %time.formatted{ datetime: @strike.created_at.iso8601, title: l(@strike.created_at) }= l(@strike.created_at)
+        = formatted_time @strike.created_at
     .report-header__details__item
       .report-header__details__item__header
         %strong= t('disputes.strikes.recipient')
@@ -53,7 +53,7 @@
         .report-header__details__item__header
           %strong= t('disputes.strikes.appeal_submitted_at')
         .report-header__details__item__content
-          %time.formatted{ datetime: @appeal.created_at.iso8601, title: l(@appeal.created_at) }= l(@appeal.created_at)
+          = formatted_time @appeal.created_at
 %hr.spacer/
 
 - if @appeal.persisted?

--- a/app/views/filters/statuses/_status_filter.html.haml
+++ b/app/views/filters/statuses/_status_filter.html.haml
@@ -24,7 +24,7 @@
         .username= status.account.acct
       ·
       = link_to ActivityPub::TagManager.instance.url_for(status), class: 'detailed-status__datetime', rel: 'noopener' do
-        %time.formatted{ datetime: status.created_at.iso8601, title: l(status.created_at) }= l(status.created_at)
+        = formatted_time status.created_at
       - if status.edited?
         ·
         = t('statuses.edited_at_html', date: content_tag(:time, l(status.edited_at), datetime: status.edited_at.iso8601, title: l(status.edited_at), class: 'formatted'))

--- a/app/views/invites/_invite.html.haml
+++ b/app/views/invites/_invite.html.haml
@@ -14,8 +14,7 @@
       - if invite.expires_at.nil?
         ∞
       - else
-        %time.formatted{ datetime: invite.expires_at.iso8601, title: l(invite.expires_at) }
-          = l invite.expires_at
+        = formatted_time invite.expires_at
   - else
     %td{ colspan: 2 }
       = t('invites.expired')

--- a/app/views/settings/exports/show.html.haml
+++ b/app/views/settings/exports/show.html.haml
@@ -62,7 +62,7 @@
         - @backups.each do |backup|
           %tr
             %td
-              %time.formatted{ datetime: backup.created_at.iso8601, title: l(backup.created_at) }= l backup.created_at
+              = formatted_time backup.created_at
             - if backup.processed?
               %td= number_to_human_size backup.dump_file_size
               %td= table_link_to 'download', t('exports.archive_takeout.download'), download_backup_url(backup)

--- a/app/views/settings/featured_tags/index.html.haml
+++ b/app/views/settings/featured_tags/index.html.haml
@@ -30,6 +30,6 @@
           - if featured_tag.last_status_at.nil?
             = t('accounts.nothing_here')
           - else
-            %time.formatted{ datetime: featured_tag.last_status_at.iso8601, title: l(featured_tag.last_status_at) }= l featured_tag.last_status_at
+            = formatted_time featured_tag.last_status_at
           = table_link_to 'delete', t('filters.index.delete'), settings_featured_tag_path(featured_tag), method: :delete, data: { confirm: t('admin.accounts.are_you_sure') }
       .trends__item__current= friendly_number_to_human featured_tag.statuses_count

--- a/app/views/settings/imports/index.html.haml
+++ b/app/views/settings/imports/index.html.haml
@@ -56,8 +56,7 @@
             %td
               #{import.imported_items} / #{import.total_items}
             %td
-              %time.formatted{ datetime: import.created_at.iso8601, title: l(import.created_at) }
-                = l(import.created_at)
+              = formatted_time import.created_at
 
             %td
               - num_failed = import.processed_items - import.imported_items

--- a/app/views/settings/login_activities/_login_activity.html.haml
+++ b/app/views/settings/login_activities/_login_activity.html.haml
@@ -7,4 +7,4 @@
       .log-entry__title
         = login_activity_title(login_activity)
       .log-entry__timestamp
-        %time.formatted{ datetime: login_activity.created_at.iso8601 }= l(login_activity.created_at)
+        = formatted_time login_activity.created_at

--- a/app/views/severed_relationships/_event.html.haml
+++ b/app/views/severed_relationships/_event.html.haml
@@ -2,8 +2,7 @@
 
 %tr
   %td
-    %time.formatted{ datetime: event.created_at.iso8601, title: l(event.created_at) }
-      = l(event.created_at)
+    = formatted_time event.created_at
   %td= t("severed_relationships.event_type.#{event.type}", target_name: event.target_name)
   - if event.purged?
     %td{ rowspan: 2 }= t('severed_relationships.purged')

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -42,6 +42,17 @@ RSpec.describe ApplicationHelper do
     end
   end
 
+  describe '#formatted_time' do
+    let(:datetime) { DateTime.new(2025, 1, 2, 3, 4, 5) }
+
+    it 'renders a time tag with expected attributes' do
+      expect(helper.formatted_time(datetime))
+        .to match(<<~HTML.squish)
+          <time class="formatted" datetime="2025-01-02T03:04:05+00:00" title="Jan 02, 2025, 03:04">Jan 02, 2025, 03:04</time>
+        HTML
+    end
+  end
+
   describe 'locale_direction' do
     it 'adds rtl body class if locale is Arabic' do
       I18n.with_locale(:ar) do


### PR DESCRIPTION
Extract a helper for this common pattern of showing various datetime `*_at` values across views. There is a JS hook which finds the `time.formatted` element and replaces its content based on the iso8601 value in the `datetime` attr.

Almost all of these are just straight helper extraction. In a few spots there are missing `title` attributes, and/or missing content, which are now added, so there's a minor consistency/accessibility improvement (any non-JS-users will now have values there).

Possible followup here -- add a delegate on appeal to strike.created_at