### PR TITLE
Fix processing of out-of-order `Update` as implicit updates

### DIFF
--- a/app/services/activitypub/process_status_update_service.rb
+++ b/app/services/activitypub/process_status_update_service.rb
@@ -25,6 +25,9 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
 
     if @status_parser.edited_at.present? && (@status.edited_at.nil? || @status_parser.edited_at > @status.edited_at)
       handle_explicit_update!
+    elsif @status.edited_at.present? && (@status_parser.edited_at.nil? || @status_parser.edited_at < @status.edited_at)
+      # This is an older update, reject it
+      return @status
     else
       handle_implicit_update!
     end


### PR DESCRIPTION
We handle “implicit” (able to update some metadata) and “explicit” (able to change the contents of the post) updates to statuses.

We consider an `Update` to be explicit if it has an `updated` attribute and this field is more recent than the last recorded one.

Everything else was considered an implicit update, but that included updates with an earlier `updated` attribute. This PR rejects such updates to avoid reverting metadata to an earlier state if activities are received out-of-order.