### PR TITLE
Move more shared follow/follow_request code into concern

### DIFF
--- a/app/models/concerns/follow_limitable.rb
+++ b/app/models/concerns/follow_limitable.rb
@@ -9,7 +9,7 @@ module FollowLimitable
     attribute :bypass_follow_limit, :boolean, default: false
     validates_with FollowLimitValidator, on: :create, unless: :bypass_follow_limit
 
-    before_validation :set_uri, only: :create
+    before_validation :set_uri, only: :create, unless: :uri?
 
     after_commit :invalidate_follow_recommendations_cache
   end
@@ -21,7 +21,7 @@ module FollowLimitable
   private
 
   def set_uri
-    self.uri = ActivityPub::TagManager.instance.generate_uri_for(self) if uri.nil?
+    self.uri = ActivityPub::TagManager.instance.generate_uri_for(self)
   end
 
   def invalidate_follow_recommendations_cache

--- a/app/models/concerns/follow_limitable.rb
+++ b/app/models/concerns/follow_limitable.rb
@@ -4,16 +4,21 @@ module FollowLimitable
   extend ActiveSupport::Concern
 
   included do
-    validates_with FollowLimitValidator, on: :create, unless: :bypass_follow_limit
+    rate_limit by: :account, family: :follows
 
     attribute :bypass_follow_limit, :boolean, default: false
+    validates_with FollowLimitValidator, on: :create, unless: :bypass_follow_limit
 
-    rate_limit by: :account, family: :follows
+    before_validation :set_uri, only: :create
 
     after_commit :invalidate_follow_recommendations_cache
   end
 
   private
+
+  def set_uri
+    self.uri = ActivityPub::TagManager.instance.generate_uri_for(self) if uri.nil?
+  end
 
   def invalidate_follow_recommendations_cache
     Rails.cache.delete("follow_recommendations/#{account_id}")

--- a/app/models/concerns/follow_limitable.rb
+++ b/app/models/concerns/follow_limitable.rb
@@ -7,5 +7,7 @@ module FollowLimitable
     validates_with FollowLimitValidator, on: :create, unless: :bypass_follow_limit
 
     attribute :bypass_follow_limit, :boolean, default: false
+
+    rate_limit by: :account, family: :follows
   end
 end

--- a/app/models/concerns/follow_limitable.rb
+++ b/app/models/concerns/follow_limitable.rb
@@ -9,5 +9,13 @@ module FollowLimitable
     attribute :bypass_follow_limit, :boolean, default: false
 
     rate_limit by: :account, family: :follows
+
+    after_commit :invalidate_follow_recommendations_cache
+  end
+
+  private
+
+  def invalidate_follow_recommendations_cache
+    Rails.cache.delete("follow_recommendations/#{account_id}")
   end
 end

--- a/app/models/concerns/follow_limitable.rb
+++ b/app/models/concerns/follow_limitable.rb
@@ -14,6 +14,10 @@ module FollowLimitable
     after_commit :invalidate_follow_recommendations_cache
   end
 
+  def local?
+    false # Force uri_for to use uri attribute
+  end
+
   private
 
   def set_uri

--- a/app/models/follow.rb
+++ b/app/models/follow.rb
@@ -44,7 +44,6 @@ class Follow < ApplicationRecord
   after_create :increment_cache_counters
   after_destroy :remove_endorsements
   after_destroy :decrement_cache_counters
-  after_commit :invalidate_follow_recommendations_cache
   after_commit :invalidate_hash_cache
 
   private
@@ -71,9 +70,5 @@ class Follow < ApplicationRecord
     return if account.local? && target_account.local?
 
     Rails.cache.delete("followers_hash:#{target_account_id}:#{account.synchronization_uri_prefix}")
-  end
-
-  def invalidate_follow_recommendations_cache
-    Rails.cache.delete("follow_recommendations/#{account_id}")
   end
 end

--- a/app/models/follow.rb
+++ b/app/models/follow.rb
@@ -31,10 +31,6 @@ class Follow < ApplicationRecord
 
   scope :recent, -> { reorder(id: :desc) }
 
-  def local?
-    false # Force uri_for to use uri attribute
-  end
-
   def revoke_request!
     FollowRequest.create!(account: account, target_account: target_account, show_reblogs: show_reblogs, notify: notify, languages: languages, uri: uri)
     destroy!

--- a/app/models/follow.rb
+++ b/app/models/follow.rb
@@ -21,8 +21,6 @@ class Follow < ApplicationRecord
   include RateLimitable
   include FollowLimitable
 
-  rate_limit by: :account, family: :follows
-
   belongs_to :account
   belongs_to :target_account, class_name: 'Account'
 

--- a/app/models/follow.rb
+++ b/app/models/follow.rb
@@ -31,15 +31,15 @@ class Follow < ApplicationRecord
 
   scope :recent, -> { reorder(id: :desc) }
 
-  def revoke_request!
-    FollowRequest.create!(account: account, target_account: target_account, show_reblogs: show_reblogs, notify: notify, languages: languages, uri: uri)
-    destroy!
-  end
-
   after_create :increment_cache_counters
   after_destroy :remove_endorsements
   after_destroy :decrement_cache_counters
   after_commit :invalidate_hash_cache
+
+  def revoke_request!
+    FollowRequest.create!(account: account, target_account: target_account, show_reblogs: show_reblogs, notify: notify, languages: languages, uri: uri)
+    destroy!
+  end
 
   private
 

--- a/app/models/follow.rb
+++ b/app/models/follow.rb
@@ -40,17 +40,12 @@ class Follow < ApplicationRecord
     destroy!
   end
 
-  before_validation :set_uri, only: :create
   after_create :increment_cache_counters
   after_destroy :remove_endorsements
   after_destroy :decrement_cache_counters
   after_commit :invalidate_hash_cache
 
   private
-
-  def set_uri
-    self.uri = ActivityPub::TagManager.instance.generate_uri_for(self) if uri.nil?
-  end
 
   def remove_endorsements
     AccountPin.where(target_account_id: target_account_id, account_id: account_id).delete_all

--- a/app/models/follow_request.rb
+++ b/app/models/follow_request.rb
@@ -50,15 +50,10 @@ class FollowRequest < ApplicationRecord
   end
 
   before_validation :set_uri, only: :create
-  after_commit :invalidate_follow_recommendations_cache
 
   private
 
   def set_uri
     self.uri = ActivityPub::TagManager.instance.generate_uri_for(self) if uri.nil?
-  end
-
-  def invalidate_follow_recommendations_cache
-    Rails.cache.delete("follow_recommendations/#{account_id}")
   end
 end

--- a/app/models/follow_request.rb
+++ b/app/models/follow_request.rb
@@ -48,12 +48,4 @@ class FollowRequest < ApplicationRecord
   def local?
     false # Force uri_for to use uri attribute
   end
-
-  before_validation :set_uri, only: :create
-
-  private
-
-  def set_uri
-    self.uri = ActivityPub::TagManager.instance.generate_uri_for(self) if uri.nil?
-  end
 end

--- a/app/models/follow_request.rb
+++ b/app/models/follow_request.rb
@@ -21,8 +21,6 @@ class FollowRequest < ApplicationRecord
   include RateLimitable
   include FollowLimitable
 
-  rate_limit by: :account, family: :follows
-
   belongs_to :account
   belongs_to :target_account, class_name: 'Account'
 

--- a/app/models/follow_request.rb
+++ b/app/models/follow_request.rb
@@ -44,8 +44,4 @@ class FollowRequest < ApplicationRecord
   end
 
   alias reject! destroy!
-
-  def local?
-    false # Force uri_for to use uri attribute
-  end
 end

--- a/spec/models/follow_request_spec.rb
+++ b/spec/models/follow_request_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe FollowRequest do
+  it_behaves_like 'FollowLimitable'
+
   describe '#authorize!' do
     let!(:follow_request) { Fabricate(:follow_request, account: account, target_account: target_account) }
     let(:account)         { Fabricate(:account) }

--- a/spec/models/follow_spec.rb
+++ b/spec/models/follow_spec.rb
@@ -3,27 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe Follow do
+  it_behaves_like 'FollowLimitable'
+
   describe 'Associations' do
     it { is_expected.to belong_to(:account).required }
     it { is_expected.to belong_to(:target_account).required }
-  end
-
-  describe 'Validations' do
-    subject { Fabricate.build :follow, rate_limit: true }
-
-    let(:account) { Fabricate(:account) }
-
-    context 'when account follows too many people' do
-      before { account.update(following_count: FollowLimitValidator::LIMIT) }
-
-      it { is_expected.to_not allow_value(account).for(:account).against(:base) }
-    end
-
-    context 'when account is on brink of following too many people' do
-      before { account.update(following_count: FollowLimitValidator::LIMIT - 1) }
-
-      it { is_expected.to allow_value(account).for(:account).against(:base) }
-    end
   end
 
   describe '.recent' do
@@ -54,31 +38,7 @@ RSpec.describe Follow do
     end
   end
 
-  describe '#local?' do
-    it { is_expected.to_not be_local }
-  end
-
   describe 'Callbacks' do
-    describe 'Setting a URI' do
-      context 'when URI exists' do
-        subject { Fabricate.build :follow, uri: 'https://uri/value' }
-
-        it 'does not change' do
-          expect { subject.save }
-            .to not_change(subject, :uri)
-        end
-      end
-
-      context 'when URI is blank' do
-        subject { Fabricate.build :follow, uri: nil }
-
-        it 'populates the value' do
-          expect { subject.save }
-            .to change(subject, :uri).to(be_present)
-        end
-      end
-    end
-
     describe 'Maintaining counters' do
       subject { Fabricate.build :follow, account:, target_account: }
 

--- a/spec/support/examples/models/concerns/follow_limitable.rb
+++ b/spec/support/examples/models/concerns/follow_limitable.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'FollowLimitable' do
+  describe 'Validations' do
+    subject { Fabricate.build factory_name, rate_limit: true }
+
+    let(:account) { Fabricate(:account) }
+
+    context 'when account follows too many people' do
+      before { account.update(following_count: FollowLimitValidator::LIMIT) }
+
+      it { is_expected.to_not allow_value(account).for(:account).against(:base) }
+    end
+
+    context 'when account is on brink of following too many people' do
+      before { account.update(following_count: FollowLimitValidator::LIMIT - 1) }
+
+      it { is_expected.to allow_value(account).for(:account).against(:base) }
+    end
+  end
+
+  describe '#local?' do
+    it { is_expected.to_not be_local }
+  end
+
+  describe 'Callbacks' do
+    describe 'Setting a URI' do
+      context 'when URI exists' do
+        subject { Fabricate.build factory_name, uri: 'https://uri/value' }
+
+        it 'does not change' do
+          expect { subject.save }
+            .to not_change(subject, :uri)
+        end
+      end
+
+      context 'when URI is blank' do
+        subject { Fabricate.build factory_name, uri: nil }
+
+        it 'populates the value' do
+          expect { subject.save }
+            .to change(subject, :uri).to(be_present)
+        end
+      end
+    end
+
+    describe 'Managing the cache' do
+      subject { Fabricate.build factory_name, account: }
+
+      context 'when the follow recommendations cache has a value' do
+        before { Rails.cache.write(cache_key, 'Value') }
+
+        let(:account) { Fabricate :account }
+        let(:cache_key) { "follow_recommendations/#{account.id}" }
+
+        it 'invalidates cache on save' do
+          expect { subject.save }
+            .to(change { Rails.cache.read(cache_key) }.from('Value').to(be_blank))
+        end
+      end
+    end
+  end
+
+  def factory_name
+    described_class.name.underscore.to_sym
+  end
+end


### PR DESCRIPTION
We already have this `FollowLimitable` concern which captures the follow limit validation config that both `Follow` and `FollowRequest` use.

This pulls out a few more callbacks where they both have the same exact code (and I suspect will continue to have the same,  indefinitely) into that concern. They are the only two models which include the concern.

I left the name the same for now since the rate limit line at least is "limit"-related ... but the other moved stuff is less so. Open to naming ideas for something short/terse which captures "the shared components of follow and follow request". Can modify here or as followup.

While in here, pull out the relevant spec coverage previously only on `Follow` to a shared example, and include that both in follow/follow_request as well. This is a coverage increase for both classes (for request, because it was missing it all, and for follow, because I added the cache invalidate section).