### PR TITLE
Add flag to preserve cached media on cleanup

### DIFF
--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -219,6 +219,8 @@ class MediaAttachment < ApplicationRecord
          .where.not(Bookmark.where(Bookmark.arel_table[:status_id].eq(MediaAttachment.arel_table[:status_id])).select(1).arel.exists)
          .where.not(Status.local.where(Status.arel_table[:in_reply_to_id].eq(MediaAttachment.arel_table[:status_id])).select(1).arel.exists)
          .where.not(Status.local.where(Status.arel_table[:reblog_of_id].eq(MediaAttachment.arel_table[:status_id])).select(1).arel.exists)
+         .where.not(Quote.joins(:status).merge(Status.local).where(Quote.arel_table[:quoted_status_id].eq(MediaAttachment.arel_table[:status_id])).select(1).arel.exists)
+         .where.not(Quote.joins(:quoted_status).merge(Status.local).where(Quote.arel_table[:status_id].eq(MediaAttachment.arel_table[:status_id])).select(1).arel.exists)
   }
 
   attr_accessor :skip_download

--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -214,6 +214,12 @@ class MediaAttachment < ApplicationRecord
   scope :remote, -> { where.not(remote_url: '') }
   scope :unattached, -> { where(status_id: nil, scheduled_status_id: nil) }
   scope :updated_before, ->(value) { where(arel_table[:updated_at].lt(value)) }
+  scope :without_local_interaction, lambda {
+    where.not(Favourite.joins(:account).merge(Account.local).where(Favourite.arel_table[:status_id].eq(MediaAttachment.arel_table[:status_id])).select(1).arel.exists)
+         .where.not(Bookmark.where(Bookmark.arel_table[:status_id].eq(MediaAttachment.arel_table[:status_id])).select(1).arel.exists)
+         .where.not(Status.local.where(Status.arel_table[:in_reply_to_id].eq(MediaAttachment.arel_table[:status_id])).select(1).arel.exists)
+         .where.not(Status.local.where(Status.arel_table[:reblog_of_id].eq(MediaAttachment.arel_table[:status_id])).select(1).arel.exists)
+  }
 
   attr_accessor :skip_download
 

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -138,12 +138,6 @@ class Status < ApplicationRecord
     where('NOT EXISTS (SELECT * FROM statuses_tags forbidden WHERE forbidden.status_id = statuses.id AND forbidden.tag_id IN (?))', tag_ids)
   }
   scope :without_empty_attachments, -> { where(ordered_media_attachment_ids: nil).or(where.not(ordered_media_attachment_ids: [])) }
-  scope :with_local_interaction, lambda {
-    Status.where(id: Status.joins(:local_favorited).select(:id))
-          .or(Status.where(id: Status.joins(:local_bookmarked).select(:id)))
-          .or(Status.where(id: Status.joins(:local_replied).select(:id)))
-          .or(Status.where(id: Status.joins(:local_reblogged).select(:id)))
-  }
 
   after_create_commit :trigger_create_webhooks
   after_update_commit :trigger_update_webhooks

--- a/lib/mastodon/cli/media.rb
+++ b/lib/mastodon/cli/media.rb
@@ -28,8 +28,8 @@ module Mastodon::CLI
       the last webfinger request and update to the user has to be before they
       are pruned. It defaults to 7 days.
       If --keep-interacted is specified, any media attached to a status that
-      was favourited, bookmarked, replied to, or reblogged by a local account
-      will be preserved.
+      was favourited, bookmarked, quoted, replied to, or reblogged by a local
+      account will be preserved.
       If --prune-profiles is specified, only avatars and headers are removed.
       If --remove-headers is specified, only headers are removed.
       If --include-follows is specified along with --prune-profiles or

--- a/lib/mastodon/cli/media.rb
+++ b/lib/mastodon/cli/media.rb
@@ -67,7 +67,7 @@ module Mastodon::CLI
       unless options[:prune_profiles] || options[:remove_headers]
         attachment_scope = MediaAttachment.cached.remote.where(created_at: ..time_ago)
 
-        attachment_scope = attachment_scope.where.not(status_id: Status.with_local_interaction.select(:id)) if options[:keep_interacted]
+        attachment_scope = attachment_scope.without_local_interaction if options[:keep_interacted]
 
         processed, aggregate = parallelize_with_progress(attachment_scope) do |media_attachment|
           next if media_attachment.file.blank?

--- a/lib/mastodon/cli/media.rb
+++ b/lib/mastodon/cli/media.rb
@@ -17,6 +17,7 @@ module Mastodon::CLI
     option :concurrency, type: :numeric, default: 5, aliases: [:c]
     option :verbose, type: :boolean, default: false, aliases: [:v]
     option :dry_run, type: :boolean, default: false
+    option :keep_interacted, type: :boolean, default: false
     desc 'remove', 'Remove remote media files, headers or avatars'
     long_desc <<-DESC
       Removes locally cached copies of media attachments (and optionally profile
@@ -26,6 +27,9 @@ module Mastodon::CLI
       they are removed. In case of avatars and headers, it specifies how old
       the last webfinger request and update to the user has to be before they
       are pruned. It defaults to 7 days.
+      If --keep-interacted is specified, any media attached to a status that
+      was favourited, bookmarked, replied to, or reblogged by a local account
+      will be preserved.
       If --prune-profiles is specified, only avatars and headers are removed.
       If --remove-headers is specified, only headers are removed.
       If --include-follows is specified along with --prune-profiles or
@@ -61,7 +65,11 @@ module Mastodon::CLI
       end
 
       unless options[:prune_profiles] || options[:remove_headers]
-        processed, aggregate = parallelize_with_progress(MediaAttachment.cached.remote.where(created_at: ..time_ago)) do |media_attachment|
+        attachment_scope = MediaAttachment.cached.remote.where(created_at: ..time_ago)
+
+        attachment_scope = attachment_scope.where.not(status_id: Status.with_local_interaction.select(:id)) if options[:keep_interacted]
+
+        processed, aggregate = parallelize_with_progress(attachment_scope) do |media_attachment|
           next if media_attachment.file.blank?
 
           size = (media_attachment.file_file_size || 0) + (media_attachment.thumbnail_file_size || 0)

--- a/spec/lib/mastodon/cli/media_spec.rb
+++ b/spec/lib/mastodon/cli/media_spec.rb
@@ -77,30 +77,45 @@ RSpec.describe Mastodon::CLI::Media do
       context 'with --keep-interacted' do
         let(:options) { { keep_interacted: true } }
 
-        let!(:local_account) { Fabricate(:account, username: 'alice') }
-        let!(:remote_account) { Fabricate(:account, username: 'bob', domain: 'example.com') }
-
-        let!(:favourited_status) { Fabricate(:status, account: remote_account) }
-        let!(:favourited_media) { Fabricate(:media_attachment, created_at: 1.month.ago, remote_url: 'https://example.com/image.jpg', status: favourited_status) }
-
-        let!(:bookmarked_status) { Fabricate(:status, account: remote_account) }
-        let!(:bookmarked_media) { Fabricate(:media_attachment, created_at: 1.month.ago, remote_url: 'https://example.com/image.jpg', status: bookmarked_status) }
-
-        let!(:replied_to_status) { Fabricate(:status, account: remote_account) }
-        let!(:replied_to_media) { Fabricate(:media_attachment, created_at: 1.month.ago, remote_url: 'https://example.com/image.jpg', status: replied_to_status) }
-
-        let!(:reblogged_status) { Fabricate(:status, account: remote_account) }
-        let!(:reblogged_media) { Fabricate(:media_attachment, created_at: 1.month.ago, remote_url: 'https://example.com/image.jpg', status: reblogged_status) }
-
-        let!(:non_interacted_status) { Fabricate(:status, account: remote_account) }
+        let!(:favourited_media) { Fabricate(:media_attachment, created_at: 1.month.ago, remote_url: 'https://example.com/image.jpg') }
+        let!(:bookmarked_media) { Fabricate(:media_attachment, created_at: 1.month.ago, remote_url: 'https://example.com/image.jpg') }
+        let!(:replied_to_media) { Fabricate(:media_attachment, created_at: 1.month.ago, remote_url: 'https://example.com/image.jpg') }
+        let!(:reblogged_media) { Fabricate(:media_attachment, created_at: 1.month.ago, remote_url: 'https://example.com/image.jpg') }
+        let!(:remote_quoted_media) { Fabricate(:media_attachment, created_at: 1.month.ago, remote_url: 'https://example.com/image.jpg') }
+        let!(:remote_quoting_media) { Fabricate(:media_attachment, created_at: 1.month.ago, remote_url: 'https://example.com/image.jpg') }
 
         before do
+          local_account = Fabricate(:account, username: 'alice')
+          remote_account = Fabricate(:account, username: 'bob', domain: 'example.com')
+
+          favourited_status = Fabricate(:status, account: remote_account)
+          bookmarked_status = Fabricate(:status, account: remote_account)
+          replied_to_status = Fabricate(:status, account: remote_account)
+          reblogged_status = Fabricate(:status, account: remote_account)
+
+          favourited_media.update!(status: favourited_status)
+          bookmarked_media.update!(status: bookmarked_status)
+          replied_to_media.update!(status: replied_to_status)
+          reblogged_media.update!(status: reblogged_status)
+
+          local_quoting_status = Fabricate(:status, account: local_account)
+          remote_quoted_status = Fabricate(:status, account: remote_account)
+          local_status_being_quoted = Fabricate(:status, account: local_account)
+          remote_quoting_status = Fabricate(:status, account: remote_account)
+
+          remote_quoted_media.update!(status: remote_quoted_status)
+          remote_quoting_media.update!(status: remote_quoting_status)
+
+          non_interacted_status = Fabricate(:status, account: remote_account)
+
           media_attachment.update(status: non_interacted_status)
 
           Fabricate(:favourite, account: local_account, status: favourited_status)
           Fabricate(:bookmark, account: local_account, status: bookmarked_status)
           Fabricate(:status, account: local_account, in_reply_to_id: replied_to_status.id)
           Fabricate(:status, account: local_account, reblog: reblogged_status)
+          Fabricate(:quote, account: local_account, status: local_quoting_status, quoted_status: remote_quoted_status)
+          Fabricate(:quote, account: remote_account, status: remote_quoting_status, quoted_status: local_status_being_quoted)
         end
 
         it 'keeps media associated with statuses that have been favourited, bookmarked, replied to, or reblogged by a local account' do
@@ -111,6 +126,8 @@ RSpec.describe Mastodon::CLI::Media do
           expect(bookmarked_media.reload.file).to be_present
           expect(replied_to_media.reload.file).to be_present
           expect(reblogged_media.reload.file).to be_present
+          expect(remote_quoted_media.reload.file).to be_present
+          expect(remote_quoting_media.reload.file).to be_present
 
           expect(media_attachment.reload.file).to be_blank
           expect(media_attachment.reload.thumbnail).to be_blank

--- a/spec/lib/mastodon/cli/media_spec.rb
+++ b/spec/lib/mastodon/cli/media_spec.rb
@@ -93,9 +93,10 @@ RSpec.describe Mastodon::CLI::Media do
         let!(:reblogged_media) { Fabricate(:media_attachment, created_at: 1.month.ago, remote_url: 'https://example.com/image.jpg', status: reblogged_status) }
 
         let!(:non_interacted_status) { Fabricate(:status, account: remote_account) }
-        let!(:non_interacted_media) { Fabricate(:media_attachment, created_at: 1.month.ago, remote_url: 'https://example.com/image.jpg', status: non_interacted_status) }
 
         before do
+          media_attachment.update(status: non_interacted_status)
+
           Fabricate(:favourite, account: local_account, status: favourited_status)
           Fabricate(:bookmark, account: local_account, status: bookmarked_status)
           Fabricate(:status, account: local_account, in_reply_to_id: replied_to_status.id)
@@ -110,7 +111,9 @@ RSpec.describe Mastodon::CLI::Media do
           expect(bookmarked_media.reload.file).to be_present
           expect(replied_to_media.reload.file).to be_present
           expect(reblogged_media.reload.file).to be_present
-          expect(non_interacted_media.reload.file).to be_blank
+
+          expect(media_attachment.reload.file).to be_blank
+          expect(media_attachment.reload.thumbnail).to be_blank
         end
       end
     end


### PR DESCRIPTION
Adding the flag --keep-interacted to the "media remove" tootctl command to preserve media cached from other servers if the related status has interactions from local accounts.

For example, you may wish to delete all cached media from other servers older than 3 months to save disk space on the local server. However, if the status was bookmarked by a user they likely want to keep a copy locally, preserving the media in case the remote server is closed or has decided themselves to clear out all old user media.

This flag was proposed in issue #30449.

The change does not impact the local content retention setting, which manages automated cleanup. A new setting would need to be added there in a future improvement.

This means to make use of this change a server admin would have to set a long content retention setting beyond which all remote media would be cleared, and then use a shorter range with the tootctl command where interacted media would be preserved with this new flag.

The flag is only to preserve media attached to statuses, and makes no difference to the logic removing cached avatars and headers.