### PR TITLE
Fix translate button width in CJK

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1413,7 +1413,7 @@
 .status__content__translate-button {
   display: flex;
   align-items: center;
-  width: min-content;
+  width: fit-content;
   font-size: 15px;
   line-height: 22px;
   color: $highlight-text-color;


### PR DESCRIPTION
#36164 broke translation button in CJK users.
(`min-content` doesn't work as intended in CJK languages, because it counts each character as **a word**)

| `min-content` | `fit-content` (This PR) |
|--------|--------|
| <img width="355" height="570" alt="before" src="https://github.com/user-attachments/assets/2fb0e561-0261-423b-9c2f-6e1f3906c340" /> | <img width="355" height="555" alt="after" src="https://github.com/user-attachments/assets/2234b7a8-97fa-4a1a-84a3-a22a72769cf3" /> | 


