### PR TITLE
Renovate config improvements

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,6 +6,7 @@
     ':labels(dependencies)',
     ':prConcurrentLimitNone', // Remove limit for open PRs at any time.
     ':prHourlyLimit2', // Rate limit PR creation to a maximum of two per hour.
+    ':enableVulnerabilityAlertsWithLabel(security)',
   ],
   rebaseWhen: 'conflicted',
   minimumReleaseAge: '3', // Wait 3 days after the package has been published before upgrading it

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -17,6 +17,11 @@
   postUpdateOptions: ['yarnDedupeHighest'],
   // The types are now included in recent versions,we ignore them here until we upgrade and remove the dependency
   ignoreDeps: ['@types/emoji-mart'],
+  postUpgradeTasks: {
+    // If JS deps are changed, then copy the MSW worker file, as it needs to be in sync with the version of MSW installed)
+    commands: ['yarn', 'yarn msw:updateWorker'],
+    fileFilters: ['yarn.lock'],
+  },
   packageRules: [
     {
       // Require Dependency Dashboard Approval for major version bumps of these node packages

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -160,6 +160,12 @@
       matchUpdateTypes: ['patch', 'minor'],
       groupName: 'opentelemetry-ruby (non-major)',
     },
+    {
+      // Group Playwright Ruby & JS deps in the same PR, as they need to be in sync
+      matchManagers: ['bundler', 'npm'],
+      matchPackageNames: ['playwright-ruby-client', 'playwright'],
+      groupName: 'Playwright',
+    },
     // Add labels depending on package manager
     { matchManagers: ['npm', 'nvm'], addLabels: ['javascript'] },
     { matchManagers: ['bundler', 'ruby-version'], addLabels: ['ruby'] },

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -100,6 +100,19 @@
       groupName: 'eslint (non-major)',
     },
     {
+      // Group all Storybook-related packages in the same PR
+      matchManagers: ['npm'],
+      matchPackageNames: [
+        'chromatic',
+        'storybook',
+        '@storybook/*',
+        'msw',
+        'msw-storybook-addon',
+      ],
+      matchUpdateTypes: ['patch', 'minor'],
+      groupName: 'storybook (non-major)',
+    },
+    {
       // Group actions/*-artifact in the same PR
       matchManagers: ['github-actions'],
       matchPackageNames: [

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "typecheck": "tsc --noEmit",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "chromatic": "npx chromatic -d storybook-static"
+    "chromatic": "npx chromatic -d storybook-static",
+    "msw:updateWorker": "msw init"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Groups Storybook-related packages
- Automatically copy the MSW service worker after a dependency update
- Group JS & Ruby Playwright packages, as they need to be kept in sync (see #35854)
- Enable Renovate integration with Dependabot Alerts. This should make Renovate immediately open update PRs when there is a new Dependabot Alert, bypassing the existing schedules
