### PR TITLE
nginx.conf - Fix large GET response from "/api/v1/accounts/relationships?" and similar errors.

### DIFF
--- a/dist/nginx.conf
+++ b/dist/nginx.conf
@@ -65,6 +65,13 @@ server {
   gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/rss+xml text/javascript image/svg+xml image/x-icon;
   gzip_static on;
 
+  # Fix "upstream sent too big header while reading response header from upstream" and similar (Large headers).
+  proxy_buffer_size 16k;  # (default 8k)
+  proxy_buffers 8 16k;  # (default 8 8k)
+  proxy_busy_buffers_size 32k;  # (default 8k|16k)
+  client_header_buffer_size 2k;  # Inbound headers/cookies (default 1k)
+  large_client_header_buffers 4 16k;  # (default 4 8k)
+
   location / {
     try_files $uri @proxy;
   }

--- a/dist/nginx.conf
+++ b/dist/nginx.conf
@@ -69,8 +69,6 @@ server {
   proxy_buffer_size 16k;  # (default 8k)
   proxy_buffers 8 16k;  # (default 8 8k)
   proxy_busy_buffers_size 32k;  # (default 8k|16k)
-  client_header_buffer_size 2k;  # Inbound headers/cookies (default 1k)
-  large_client_header_buffers 4 16k;  # (default 4 8k)
 
   location / {
     try_files $uri @proxy;


### PR DESCRIPTION
`upstream sent too big header while reading response header from upstream` when fetching a super long `GET to /api/v1/accounts/relationships?`

This issue has been becoming more common in my nginx errror 502 logs. Best to be resolved as a root fix.