### PR TITLE
Fix line break in Read more button

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1413,7 +1413,6 @@
 .status__content__translate-button {
   display: flex;
   align-items: center;
-  width: min-content;
   font-size: 15px;
   line-height: 22px;
   color: $highlight-text-color;
@@ -1422,6 +1421,14 @@
   padding: 0;
   margin-top: 16px;
   text-decoration: none;
+  text-wrap: nowrap;
+
+  .status--is-quote & {
+    // Needed to prevent buttons from stretching across whole
+    // status width in Safari due to line-clamp
+    width: min-content;
+    white-space: nowrap;
+  }
 
   &:hover,
   &:active {


### PR DESCRIPTION
### Changes proposed in this PR:
- Fixes a regression caused by https://github.com/mastodon/mastodon/pull/36164 where the Read more button in long posts contained a line break. Moved the CSS into a quote-specific CSS to limit the scope of the `white-space: nowrap`