### PR TITLE
Revert "Add compatibility hack for GoToSocial interaction policies (#36004)"

### DIFF
--- a/app/serializers/activitypub/note_serializer.rb
+++ b/app/serializers/activitypub/note_serializer.rb
@@ -241,15 +241,6 @@ class ActivityPub::NoteSerializer < ActivityPub::Serializer
       canQuote: {
         automaticApproval: approved_uris,
       },
-      canReply: {
-        always: 'https://www.w3.org/ns/activitystreams#Public',
-      },
-      canLike: {
-        always: 'https://www.w3.org/ns/activitystreams#Public',
-      },
-      canAnnounce: {
-        always: 'https://www.w3.org/ns/activitystreams#Public',
-      },
     }
   end
 


### PR DESCRIPTION
This reverts commit 14cb5ff88191528ed4240adcb66c77676a73ff43.

GoToSocial has pushed a patch release for this issue two weeks ago, as well as a new release candidate for the development branch that has fixed that as well.