### PR TITLE
Left-align boost/quote menu to prevent shift based on descriptions

### DIFF
--- a/app/javascript/mastodon/components/dropdown_menu.tsx
+++ b/app/javascript/mastodon/components/dropdown_menu.tsx
@@ -333,6 +333,7 @@ interface DropdownProps<Item extends object | null = MenuItem> {
   disabled?: boolean;
   scrollable?: boolean;
   placement?: Placement;
+  offset?: OffsetValue;
   /**
    * Prevent the `ScrollableList` with this scrollKey
    * from being scrolled while the dropdown is open
@@ -348,7 +349,6 @@ interface DropdownProps<Item extends object | null = MenuItem> {
   onItemClick?: ItemClickFn<Item>;
 }
 
-const offset = [5, 5] as OffsetValue;
 const popperConfig = { strategy: 'fixed' } as UsePopperOptions;
 
 export const Dropdown = <Item extends object | null = MenuItem>({
@@ -361,6 +361,7 @@ export const Dropdown = <Item extends object | null = MenuItem>({
   disabled,
   scrollable,
   placement = 'bottom',
+  offset = [5, 5],
   status,
   forceDropdown = false,
   renderItem,

--- a/app/javascript/mastodon/components/status/boost_button.tsx
+++ b/app/javascript/mastodon/components/status/boost_button.tsx
@@ -134,6 +134,8 @@ export const StatusBoostButton: FC<ReblogButtonProps> = ({
 
   return (
     <Dropdown
+      placement='bottom-start'
+      offset={[-19, 5]} // This aligns button icon with menu icons
       items={items}
       renderItem={renderMenuItem}
       onOpen={handleDropdownOpen}


### PR DESCRIPTION
### Changes proposed in this PR:
- Changes the alignment of the boost/quote menu from centre to left, to prevent the position of the main menu labels from shifting when the menu items have a longer description

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="364" height="280" alt="image" src="https://github.com/user-attachments/assets/76aca192-34dc-4675-b8a5-289ef8c31d84" /> | <img width="369" height="275" alt="Screenshot 2025-09-22 at 12 32 46" src="https://github.com/user-attachments/assets/c0b9566b-8222-4c76-89f4-4cc8c1d059b8" /> |
| <img width="493" height="264" alt="image" src="https://github.com/user-attachments/assets/de3bd3cb-3ea2-4de3-9a20-343e0c0b14db" /> | <img width="477" height="272" alt="Screenshot 2025-09-22 at 12 32 58" src="https://github.com/user-attachments/assets/138f05bd-e2ab-48d2-9833-2654847af719" /> | 
