### PR TITLE
Remove Renovate postUpgrade commands

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -18,11 +18,6 @@
   postUpdateOptions: ['yarnDedupeHighest'],
   // The types are now included in recent versions,we ignore them here until we upgrade and remove the dependency
   ignoreDeps: ['@types/emoji-mart'],
-  postUpgradeTasks: {
-    // If JS deps are changed, then copy the MSW worker file, as it needs to be in sync with the version of MSW installed)
-    commands: ['yarn', 'yarn msw:updateWorker'],
-    fileFilters: ['yarn.lock'],
-  },
   packageRules: [
     {
       // Require Dependency Dashboard Approval for major version bumps of these node packages


### PR DESCRIPTION
Mend-hosted Renovate only allows a few commands in `postUpgrade`, and we can not use our own here.

This means that the `msw` worker will need to be manually updated everytime the package is updated by Renovate.