### PR TITLE
Preserve URL encoded query params from `Request#perform`

### DIFF
--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -92,6 +92,7 @@ class Request
 
     raise Mastodon::HostValidationError, 'Instance does not support hidden service connections' if block_hidden_service?
 
+    restore_query_encoding!
     set_common_headers!
     set_digest! if options.key?(:body)
   end
@@ -147,6 +148,10 @@ class Request
   end
 
   private
+
+  def restore_query_encoding!
+    @url.query_values = @url.query_values.to_a if @url.query_values.present?
+  end
 
   def set_common_headers!
     @headers['User-Agent']      = Mastodon::Version.user_agent

--- a/spec/lib/request_spec.rb
+++ b/spec/lib/request_spec.rb
@@ -52,6 +52,15 @@ RSpec.describe Request do
       end
     end
 
+    context 'when URL has encoded params and non-encoded params in query' do
+      let(:url) { 'https://host.example/media.jpg?precrop=40:21,offset-x50,offset-y0&overlay-align=bottom%2Cleft' }
+
+      it 'preserves query param encoding in url value after normalization' do
+        expect(initialized_url_value)
+          .to eq(url)
+      end
+    end
+
     context 'when URL has non sorted query params' do
       let(:url) { 'https://host.example/page?zeta=123&alpha=456' }
 

--- a/spec/lib/request_spec.rb
+++ b/spec/lib/request_spec.rb
@@ -43,6 +43,33 @@ RSpec.describe Request do
   describe '#initialize' do
     subject { described_class.new(:get, url) }
 
+    context 'when URL has encoded params in query' do
+      let(:url) { 'https://host.example/image.jpg?width=10&overlay-align=bottom%2Cleft' }
+
+      it 're-encodes query params in url value after normalization' do
+        expect(initialized_url_value)
+          .to eq(url)
+      end
+    end
+
+    context 'when URL has non sorted query params' do
+      let(:url) { 'https://host.example/page?zeta=123&alpha=456' }
+
+      it 'preserves query param order in url value after normalization' do
+        expect(initialized_url_value)
+          .to eq(url)
+      end
+    end
+
+    context 'when URL does not have query params' do
+      let(:url) { 'https://host.example/' }
+
+      it 'does not add query portion to string during initialize' do
+        expect(initialized_url_value)
+          .to eq(url)
+      end
+    end
+
     context 'when URL has new lines' do
       let(:url) { "https://host.example/image\nhttps://badhost.example/page.jpg" }
 


### PR DESCRIPTION
This is weirdly verbose for something so simple, but -- a) the re-assignment also re-encodes, b) using `to_a` preserves the order (otherwise alpha sorts params from a hash), c) the presence check avoids adding a stray `?` to end of string when no params present.

A previous PR added spec for the "remove newline" case of a previous change+revert+security thing for basically the same change here ... open to more ideas on edge cases to add coverage for here before applying this, would like to avoid needing to repeat that revert exercise if we miss something.

Follow-up: https://github.com/mastodon/mastodon/pull/36170
Alternative-to: https://github.com/mastodon/mastodon/pull/36139