### PR TITLE
Rely on ASCII character mapping from I18n gem

### DIFF
--- a/app/lib/ascii_folding.rb
+++ b/app/lib/ascii_folding.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
 class ASCIIFolding
-  NON_ASCII_CHARS        = 'ÀÁÂÃÄÅàáâãäåĀāĂăĄąÇçĆćĈĉĊċČčÐðĎďĐđÈÉÊËèéêëĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħÌÍÎÏìíîïĨĩĪīĬĭĮįİıĴĵĶķĸĹĺĻļĽľĿŀŁłÑñŃńŅņŇňŉŊŋÒÓÔÕÖØòóôõöøŌōŎŏŐőŔŕŖŗŘřŚśŜŝŞşŠšſŢţŤťŦŧÙÚÛÜùúûüŨũŪūŬŭŮůŰűŲųŴŵÝýÿŶŷŸŹźŻżŽž'
-  EQUIVALENT_ASCII_CHARS = 'AAAAAAaaaaaaAaAaAaCcCcCcCcCcDdDdDdEEEEeeeeEeEeEeEeEeGgGgGgGgHhHhIIIIiiiiIiIiIiIiIiJjKkkLlLlLlLlLlNnNnNnNnnNnOOOOOOooooooOoOoOoRrRrRrSsSsSsSssTtTtTtUUUUuuuuUuUuUuUuUuUuWwYyyYyYZzZzZz'
+  CONVERSIONS = I18n::Backend::Transliterator::HashTransliterator::DEFAULT_APPROXIMATIONS
 
   def fold(str)
-    str.tr(NON_ASCII_CHARS, EQUIVALENT_ASCII_CHARS)
+    str.gsub(/[#{CONVERSIONS.keys.join}]/, CONVERSIONS)
   end
 end


### PR DESCRIPTION
Opening as draft for feedback on the idea.

I originally thought I'd be able to replace this whole class with the activesupport `transliterate` method -- however, the logic there is something like "replace any non mapped characters with a replacement character" (defaults to "?", can override) ... but for our actual usage here, we want something more like "replace the mapped chars with their equivalents, and leave everything else alone". It was awkward to achieve it that way.

That said, while attempting that I realized that what is an (almost the same!) very similar mapping exists already in the i18n gem, and we could rely on that.

Opening as draft because while the mapping is similar, it is not 100% exactly the same. It's close enough to pass the specs we have in place here (hashtag normalizer, languages helper), but may lead to different folded values for some input strings.

Will leave as draft for feedback, and if no huge objections I can add some more detail around the mapping differences and speculate on whether we care (and/or add more coverage for any cases we do care about).