### PR TITLE
Update to puma 7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 ruby '>= 3.2.0', '< 3.5.0'
 
 gem 'propshaft'
-gem 'puma', '~> 6.3'
+gem 'puma', '~> 7.0'
 gem 'rails', '~> 8.0'
 gem 'thor', '~> 1.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -637,7 +637,7 @@ GEM
       date
       stringio
     public_suffix (6.0.2)
-    puma (6.6.1)
+    puma (7.0.3)
       nio4r (~> 2.0)
     pundit (2.5.1)
       activesupport (>= 3.0.0)
@@ -1052,7 +1052,7 @@ DEPENDENCIES
   prometheus_exporter (~> 2.2)
   propshaft
   public_suffix (~> 6.0)
-  puma (~> 6.3)
+  puma (~> 7.0)
   pundit (~> 2.3)
   rack-attack (~> 6.6)
   rack-cors

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -27,7 +27,7 @@ if ENV['MASTODON_PROMETHEUS_EXPORTER_ENABLED'] == 'true'
     end
   end
 
-  on_worker_boot do
+  before_worker_boot do
     # Ruby process metrics (memory, GC, etc)
     PrometheusExporter::Instrumentation::Process.start(type: 'puma')
 
@@ -44,7 +44,7 @@ if ENV['MASTODON_PROMETHEUS_EXPORTER_ENABLED'] == 'true'
   end
 end
 
-on_worker_boot do
+before_worker_boot do
   ActiveSupport.on_load(:active_record) do
     ActiveRecord::Base.establish_connection
   end


### PR DESCRIPTION
Perform the update and use new name for deprecated hook method.

Supersedes #36014