### PR TITLE
Add `result_count` to `Mastodon-Async-Refresh` header when needed

### DIFF
--- a/app/controllers/concerns/async_refreshes_concern.rb
+++ b/app/controllers/concerns/async_refreshes_concern.rb
@@ -6,6 +6,9 @@ module AsyncRefreshesConcern
   def add_async_refresh_header(async_refresh, retry_seconds: 3)
     return unless async_refresh.running?
 
-    response.headers['Mastodon-Async-Refresh'] = "id=\"#{async_refresh.id}\", retry=#{retry_seconds}"
+    value = "id=\"#{async_refresh.id}\", retry=#{retry_seconds}"
+    value += ", result_count=#{async_refresh.result_count}" unless async_refresh.result_count.nil?
+
+    response.headers['Mastodon-Async-Refresh'] = value
   end
 end


### PR DESCRIPTION
Currently, a client can't know whether an async refresh job is just started or in progress, and when it is in progress, it can't know how much of the progress is actually achieved.

This is important for fetch all replies, as the job could be well underway when the API request is initially made, causing the `result_count` to include already-returned items. Should the job then finish with no new items, the client will get a `result_count` that is entirely covered by the client's already-known statuses, with no way for the client to know.

This PR changes it so that the header returns the current progress, so that the client can compare the final result with the previously-known progress, and correctly treat the absence of new items.