### PR TITLE
Fix unfortunate action button wrapping in admin area

### DIFF
--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -163,7 +163,7 @@ $content-width: 840px;
     flex: 1 1 auto;
   }
 
-  @media screen and (max-width: $content-width + $sidebar-width) {
+  @media screen and (max-width: ($content-width + $sidebar-width)) {
     .sidebar-wrapper--empty {
       display: none;
     }
@@ -1065,6 +1065,17 @@ a.name-tag,
       }
     }
 
+    &__action-bar {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 8px;
+
+      &:not(.no-wrap) {
+        flex-wrap: wrap;
+      }
+    }
+
     &__meta {
       padding: 0 15px;
       color: $dark-text-color;
@@ -1081,10 +1092,8 @@ a.name-tag,
       }
     }
 
-    &__action-bar {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
+    &__actions {
+      margin-inline-start: auto;
     }
 
     &__permissions {

--- a/app/views/admin/announcements/_announcement.html.haml
+++ b/app/views/admin/announcements/_announcement.html.haml
@@ -9,7 +9,7 @@
       - else
         = l(announcement.created_at)
 
-    %div
+    .announcements-list__item__actions
       - if can?(:distribute, announcement)
         = table_link_to 'mail', t('admin.terms_of_service.notify_users'), admin_announcement_preview_path(announcement)
       - if can?(:update, announcement)

--- a/app/views/admin/roles/_role.html.haml
+++ b/app/views/admin/roles/_role.html.haml
@@ -26,5 +26,5 @@
         = link_to t('admin.roles.assigned_users', count: role.users.count), admin_accounts_path(role_ids: role.id)
         ·
         %abbr{ title: role.permissions_as_keys.map { |privilege| I18n.t("admin.roles.privileges.#{privilege}") }.join(', ') }= t('admin.roles.permissions_count', count: role.permissions_as_keys.size)
-    %div
+    .announcements-list__item__actions
       = table_link_to 'edit', t('admin.accounts.edit'), edit_admin_role_path(role) if can?(:update, role)

--- a/app/views/admin/rules/_rule.html.haml
+++ b/app/views/admin/rules/_rule.html.haml
@@ -3,7 +3,7 @@
     #{rule_counter + 1}.
     = truncate(rule.text)
 
-  .announcements-list__item__action-bar
+  .announcements-list__item__action-bar.no-wrap
     .announcements-list__item__meta
       = rule.hint
 

--- a/app/views/admin/warning_presets/_warning_preset.html.haml
+++ b/app/views/admin/warning_presets/_warning_preset.html.haml
@@ -6,5 +6,5 @@
     .announcements-list__item__meta
       = truncate(warning_preset.text)
 
-    %div
+    .announcements-list__item__actions
       = table_link_to 'delete', t('admin.warning_presets.delete'), admin_warning_preset_path(warning_preset), method: :delete, data: { confirm: t('admin.accounts.are_you_sure') } if can?(:destroy, warning_preset)

--- a/app/views/admin/webhooks/_webhook.html.haml
+++ b/app/views/admin/webhooks/_webhook.html.haml
@@ -14,6 +14,6 @@
 
       %abbr{ title: webhook.events.join(', ') }= t('admin.webhooks.enabled_events', count: webhook.events.size)
 
-    %div
+    .announcements-list__item__actions
       = table_link_to 'edit', t('admin.webhooks.edit'), edit_admin_webhook_path(webhook) if can?(:update, webhook)
       = table_link_to 'delete', t('admin.webhooks.delete'), admin_webhook_path(webhook), method: :delete, data: { confirm: t('admin.accounts.are_you_sure') } if can?(:destroy, webhook)

--- a/app/views/filters/_filter.html.haml
+++ b/app/views/filters/_filter.html.haml
@@ -32,10 +32,10 @@
             .permissions-list__item__text__type
               = t('filters.index.statuses_long', count: filter.statuses.size)
 
-  .announcements-list__item__action-bar
-    .announcements-list__item__meta
+  .filters-list__item__action-bar
+    .filters-list__item__meta
       = t('filters.index.contexts', contexts: filter.context.map { |context| I18n.t("filters.contexts.#{context}") }.join(', '))
 
-    %div
+    .filters-list__item__actions
       = table_link_to 'edit', t('filters.edit.title'), edit_filter_path(filter)
       = table_link_to 'close', t('filters.index.delete'), filter_path(filter), method: :delete, data: { confirm: t('admin.accounts.are_you_sure') }

--- a/app/views/oauth/authorized_applications/index.html.haml
+++ b/app/views/oauth/authorized_applications/index.html.haml
@@ -28,7 +28,7 @@
           = t('doorkeeper.authorized_applications.index.authorized_at', date: l(application.created_at.to_date))
 
         - unless application.superapp? || current_account.unavailable?
-          %div
+          .announcements-list__item__actions
             = table_link_to 'close', t('doorkeeper.authorized_applications.buttons.revoke'), oauth_authorized_application_path(application), method: :delete, data: { confirm: t('doorkeeper.authorized_applications.confirmations.revoke') }
 
       .announcements-list__item__permissions


### PR DESCRIPTION
### Changes proposed in this PR:
- Fixes stacking action buttons in the rules, roles, and other similar admin UI tables on narrower screen widths as [reported](https://mastodon.guerilla.studio/@tixie/115213822018447221) by @TixieSalander. The buttons will now wrap to a new line when space runs out.

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="405" height="286" alt="image" src="https://github.com/user-attachments/assets/952b78e1-3e6a-4224-bac4-98ab27f7ac78" /> | <img width="394" height="125" alt="image" src="https://github.com/user-attachments/assets/1f44cf85-e6e0-40e6-87ec-e868d2d73516" /> | 

https://github.com/user-attachments/assets/e9ec5911-8432-47fc-8bf9-b163618bc205


