### PR TITLE
Refactor `getFocusedItemIndex` to avoid conditionals that `closest` already handles

### DIFF
--- a/app/javascript/mastodon/features/ui/util/focusUtils.ts
+++ b/app/javascript/mastodon/features/ui/util/focusUtils.ts
@@ -67,12 +67,7 @@ export function getFocusedItemIndex() {
     return -1;
   }
 
-  let focusedItem: HTMLElement | null = null;
-  if (focusedElement.parentElement === itemList) {
-    focusedItem = focusedElement as HTMLElement;
-  } else {
-    focusedItem = focusedElement.closest('.item-list > *');
-  }
+  const focusedItem = focusedElement.closest('.item-list > *');
 
   if (!focusedItem) return -1;
 

--- a/app/javascript/mastodon/features/ui/util/focusUtils.ts
+++ b/app/javascript/mastodon/features/ui/util/focusUtils.ts
@@ -60,18 +60,13 @@ export function focusColumn({
  * Get the index of the currently focused item in one of our item lists
  */
 export function getFocusedItemIndex() {
-  const focusedElement = document.activeElement;
-  const itemList = focusedElement?.closest('.item-list');
-
-  if (!focusedElement || !itemList) {
-    return -1;
-  }
-
-  const focusedItem = focusedElement.closest('.item-list > *');
-
+  const focusedItem = document.activeElement?.closest('.item-list > *');
   if (!focusedItem) return -1;
 
-  const items = Array.from(itemList.children);
+  const { parentElement } = focusedItem;
+  if (!parentElement) return -1;
+
+  const items = Array.from(parentElement.children);
   return items.indexOf(focusedItem);
 }
 


### PR DESCRIPTION
The `Element#closest` method traverses the current element *and* its parents. That means we don't need a separate check for child elements since we're already using the child selector (`> *`). If the element is a child of the `.item-list` element, `.closest('.item-list > *')` will match.

Further, if we already know that `focusedItem` is a child of `.item-list`, then we don't need to make a separate query. We can just use `#parentElement`.