### PR TITLE
Fix page being vertically scrollable in Advanced UI

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2972,8 +2972,12 @@ a.account__display-name {
   justify-content: flex-start;
   position: relative;
 
-  &.unscrollable {
-    overflow-x: hidden;
+  .layout-multiple-columns & {
+    overflow-x: auto;
+
+    &.unscrollable {
+      overflow-x: hidden;
+    }
   }
 
   &__panels {


### PR DESCRIPTION
Fixes #36250

### Changes proposed in this PR:
- Fixes page being vertically scrollable in Advanced UI (a regression caused by #36172)

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="1541" height="660" alt="image" src="https://github.com/user-attachments/assets/a2b65e04-93ba-450b-a432-6a2a9835a843" /> | <img width="1484" height="659" alt="image" src="https://github.com/user-attachments/assets/8f98a0f4-4ab8-4d56-9e62-790d60c4f000" /> | 

