### PR TITLE
Add support for dynamic viewport height

### DIFF
--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -12,12 +12,8 @@ $content-width: 840px;
   justify-content: center;
   box-sizing: border-box;
   width: 100%;
-  @supports (min-height: 100dvh) {
-    min-height: 100dvh;
-  }
-  @supports not (min-height: 100dvh) {
-    min-height: 100vh;
-  }
+  min-height: 100vh;
+  min-height: 100dvh;
   padding: env(safe-area-inset-top) env(safe-area-inset-right)
     env(safe-area-inset-bottom) env(safe-area-inset-left);
 
@@ -29,12 +25,8 @@ $content-width: 840px;
   }
 
   .sidebar-wrapper {
-    @supports (min-height: 100dvh) {
-      min-height: 100dvh;
-    }
-    @supports not (min-height: 100dvh) {
-      min-height: 100vh;
-    }
+    min-height: 100vh;
+    min-height: 100dvh;
     overflow: hidden;
     pointer-events: none;
     flex: 1 1 auto;

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -12,7 +12,12 @@ $content-width: 840px;
   justify-content: center;
   box-sizing: border-box;
   width: 100%;
-  min-height: 100vh;
+  @supports (min-height: 100dvh) {
+    min-height: 100dvh;
+  }
+  @supports not (min-height: 100dvh) {
+    min-height: 100vh;
+  }
   padding: env(safe-area-inset-top) env(safe-area-inset-right)
     env(safe-area-inset-bottom) env(safe-area-inset-left);
 
@@ -24,7 +29,12 @@ $content-width: 840px;
   }
 
   .sidebar-wrapper {
-    min-height: 100vh;
+    @supports (min-height: 100dvh) {
+      min-height: 100dvh;
+    }
+    @supports not (min-height: 100dvh) {
+      min-height: 100vh;
+    }
     overflow: hidden;
     pointer-events: none;
     flex: 1 1 auto;

--- a/app/javascript/styles/mastodon/basics.scss
+++ b/app/javascript/styles/mastodon/basics.scss
@@ -68,7 +68,12 @@ body {
 
     &.layout-single-column {
       height: auto;
-      min-height: 100vh;
+      @supports (min-height: 100dvh) {
+        min-height: 100dvh;
+      }
+      @supports not (min-height: 100dvh) {
+        min-height: 100vh;
+      }
       overflow-y: scroll;
     }
 
@@ -185,7 +190,12 @@ button {
   }
 
   & > noscript {
-    height: 100vh;
+    @supports (min-height: 100dvh) {
+      min-height: 100dvh;
+    }
+    @supports not (min-height: 100dvh) {
+      min-height: 100vh;
+    }
   }
 }
 

--- a/app/javascript/styles/mastodon/basics.scss
+++ b/app/javascript/styles/mastodon/basics.scss
@@ -68,12 +68,8 @@ body {
 
     &.layout-single-column {
       height: auto;
-      @supports (min-height: 100dvh) {
-        min-height: 100dvh;
-      }
-      @supports not (min-height: 100dvh) {
-        min-height: 100vh;
-      }
+      min-height: 100vh;
+      min-height: 100dvh;
       overflow-y: scroll;
     }
 
@@ -190,24 +186,16 @@ button {
   }
 
   & > noscript {
-    @supports (min-height: 100dvh) {
-      min-height: 100dvh;
-    }
-    @supports not (min-height: 100dvh) {
-      min-height: 100vh;
-    }
+    min-height: 100vh;
+    min-height: 100dvh;
   }
 }
 
 .layout-single-column .app-holder {
   &,
   & > div {
-    @supports (min-height: 100dvh) {
-      min-height: 100dvh;
-    }
-    @supports not (min-height: 100dvh) {
-      min-height: 100vh;
-    }
+    min-height: 100vh;
+    min-height: 100dvh;
   }
 }
 

--- a/app/javascript/styles/mastodon/basics.scss
+++ b/app/javascript/styles/mastodon/basics.scss
@@ -192,7 +192,12 @@ button {
 .layout-single-column .app-holder {
   &,
   & > div {
-    min-height: 100vh;
+    @supports (min-height: 100dvh) {
+      min-height: 100dvh;
+    }
+    @supports not (min-height: 100dvh) {
+      min-height: 100vh;
+    }
   }
 }
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2983,12 +2983,8 @@ a.account__display-name {
     gap: 16px;
     width: 100%;
     height: 100%;
-    @supports (min-height: 100dvh) {
-      min-height: 100dvh;
-    }
-    @supports not (min-height: 100dvh) {
-      min-height: 100vh;
-    }
+    min-height: 100vh;
+    min-height: 100dvh;
     padding-bottom: env(safe-area-inset-bottom);
 
     &__pane {
@@ -3320,12 +3316,8 @@ a.account__display-name {
   }
 
   .columns-area__panels {
-    @supports (min-height: 100dvh) {
-      min-height: 100dvh;
-    }
-    @supports not (min-height: 100dvh) {
-      min-height: 100vh;
-    }
+    min-height: 100vh;
+    min-height: 100dvh;
     gap: 0;
   }
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2983,7 +2983,12 @@ a.account__display-name {
     gap: 16px;
     width: 100%;
     height: 100%;
-    min-height: 100vh;
+    @supports (min-height: 100dvh) {
+      min-height: 100dvh;
+    }
+    @supports not (min-height: 100dvh) {
+      min-height: 100vh;
+    }
     padding-bottom: env(safe-area-inset-bottom);
 
     &__pane {
@@ -3315,7 +3320,12 @@ a.account__display-name {
   }
 
   .columns-area__panels {
-    min-height: 100vh;
+    @supports (min-height: 100dvh) {
+      min-height: 100dvh;
+    }
+    @supports not (min-height: 100dvh) {
+      min-height: 100vh;
+    }
     gap: 0;
   }
 


### PR DESCRIPTION
This PR introduces support for dynamic viewport height (100dvh).

Falls back to 100vh in browsers that do not support dvh.

Ensures consistent layout behavior on mobile devices when browser UI (address bar, navigation bar) expands or collapses.

Why
Previously, using 100vh could cause layout issues on mobile due to the dynamic browser UI. With 100dvh, the layout adapts correctly to the visible viewport.