### PR TITLE
Remove shallow prop from Wrapper

### DIFF
--- a/app/javascript/mastodon/features/emoji/emoji_html.tsx
+++ b/app/javascript/mastodon/features/emoji/emoji_html.tsx
@@ -51,7 +51,14 @@ export const EmojiHTML = <Element extends ElementType>(
   if (isModernEmojiEnabled()) {
     return <ModernEmojiHTML {...props} />;
   }
-  const { as: asElement, htmlString, extraEmojis, className, ...rest } = props;
+  const {
+    as: asElement,
+    htmlString,
+    extraEmojis,
+    className,
+    shallow: _,
+    ...rest
+  } = props;
   const Wrapper = asElement ?? 'div';
   return (
     <Wrapper


### PR DESCRIPTION
Currently, the `shallow` prop is being passed to `Wrapper` via `rest`, causing the following warning in the console in development.

    Warning: Received `true` for a non-boolean attribute `shallow`.
    If you want to write it to the DOM, pass a string instead: shallow="true" or shallow={value.toString()}.

We don't want to write it at all because it's not intended for this component, but rather for `ModernEmojiHTML`. So I've removed it from `rest` by destructuring it.