### PR TITLE
Change `GET /api/v1/statuses/:id/quotes` to allow listing quotes to other people's posts

### DIFF
--- a/app/policies/status_policy.rb
+++ b/app/policies/status_policy.rb
@@ -36,10 +36,6 @@ class StatusPolicy < ApplicationPolicy
     owned?
   end
 
-  def list_quotes?
-    owned?
-  end
-
   alias unreblog? destroy?
 
   def update?


### PR DESCRIPTION
The initial reason to disallow this was to curb use of quote posts as “dunking”, but the quote control mechanisms in place should already deal with that.

The UI allowing this will come in another PR, and will need to have proper explanations.