### PR TITLE
Use true/false for boolean value in username block form?

### DIFF
--- a/app/models/username_block.rb
+++ b/app/models/username_block.rb
@@ -35,13 +35,7 @@ class UsernameBlock < ApplicationRecord
 
   normalizes :normalized_username, with: ->(value) { value.downcase.gsub(Regexp.union(HOMOGLYPHS.keys), HOMOGLYPHS) }
 
-  def comparison
-    exact? ? 'equals' : 'contains'
-  end
-
-  def comparison=(val)
-    self.exact = val == 'equals'
-  end
+  alias_attribute :comparison, :exact
 
   def self.matches?(str, allow_with_approval: false)
     matches_exactly(str).or(matches_partially(str)).where(allow_with_approval: allow_with_approval).any?

--- a/app/views/admin/username_blocks/_form.html.haml
+++ b/app/views/admin/username_blocks/_form.html.haml
@@ -7,9 +7,9 @@
   = form.input :comparison,
                as: :select,
                wrapper: :with_block_label,
-               collection: %w(equals contains),
+               collection: [[:equals, true], [:contains, false]],
                include_blank: false,
-               label_method: ->(type) { I18n.t(type, scope: 'admin.username_blocks.comparison') }
+               label_method: ->(type) { I18n.t(type.first, scope: 'admin.username_blocks.comparison') }
 
 .fields-group
   = form.input :allow_with_approval,

--- a/spec/requests/admin/username_blocks_spec.rb
+++ b/spec/requests/admin/username_blocks_spec.rb
@@ -24,13 +24,23 @@ RSpec.describe 'Admin Username Blocks' do
         .to have_http_status(400)
     end
 
-    it 'creates a username block' do
-      post admin_username_blocks_path(username_block: { username: 'banana', comparison: 'contains', allow_with_approval: '0' })
+    context 'with valid params' do
+      subject { post admin_username_blocks_path(username_block: { username: 'banana', comparison: 'false', allow_with_approval: '0' }) }
 
-      expect(response)
-        .to redirect_to(admin_username_blocks_path)
-      expect(UsernameBlock.find_by(username: 'banana'))
-        .to_not be_nil
+      it 'creates a username block' do
+        expect { subject }
+          .to change(UsernameBlock, :count).by(1)
+
+        expect(response)
+          .to redirect_to(admin_username_blocks_path)
+        expect(UsernameBlock.last)
+          .to be_present
+          .and have_attributes(
+            allow_with_approval: false,
+            exact: false,
+            username: 'banana'
+          )
+      end
     end
   end
 


### PR DESCRIPTION
The original PR here - https://github.com/mastodon/mastodon/pull/35407/files#diff-19ead4f4e7b9c4162d6e992e946fb3dc114b7ebe4709d6b6dbaef07eb3c9e00cR36-R42 - has a getter which turns the bool into a string, and a setter that turns a string into a bool. It's not obvious to me (and not mentioned in PR) why it's done this way instead of just using the bool (`exact`) attribute directly?

I initially *replaced* the `comparison` value in the form with `exact`, but then realized we'd have to move/rename multiple i18n keys around (and reset crowdin entries in the process) so I opted for the alias instead of the rename, which lets us keep the existing i18n keys, but also just directly use the bool value. This was the least awkward thing I could think of which would preserve the i18n entries.

If we dont care about the i18n shuffle, I can make this even cleaner and rework to just use `exact` directly everywhere (with either true/false or yes/no or whatever simpleform needs here as i18n keys). If there's something obvious I'm missing here about why it was done this way ... I'd love to know, and can close.

Separately, as a boolean value - might this be better as a checkbox or radio (which would both allow more inline hint copy), rather than select? I think this may be the only boolean value in the app using a select.