### PR TITLE
Add UI support for displaying quotes of other people's posts

### DIFF
--- a/app/javascript/mastodon/features/quotes/index.tsx
+++ b/app/javascript/mastodon/features/quotes/index.tsx
@@ -12,6 +12,8 @@ import { ColumnHeader } from 'mastodon/components/column_header';
 import { Icon } from 'mastodon/components/icon';
 import { LoadingIndicator } from 'mastodon/components/loading_indicator';
 import StatusList from 'mastodon/components/status_list';
+import { useIdentity } from 'mastodon/identity_context';
+import { domain } from 'mastodon/initial_state';
 import { useAppDispatch, useAppSelector } from 'mastodon/store';
 
 import Column from '../ui/components/column';
@@ -31,8 +33,17 @@ export const Quotes: React.FC<{
 
   const statusId = params?.statusId;
 
+  const { accountId: me } = useIdentity();
+
   const isCorrectStatusId: boolean = useAppSelector(
     (state) => state.status_lists.getIn(['quotes', 'statusId']) === statusId,
+  );
+  const quotedAccountId = useAppSelector(
+    (state) =>
+      state.statuses.getIn([statusId, 'account']) as string | undefined,
+  );
+  const quotedAccount = useAppSelector((state) =>
+    quotedAccountId ? state.accounts.get(quotedAccountId) : undefined,
   );
   const statusIds = useAppSelector((state) =>
     state.status_lists.getIn(['quotes', 'items'], emptyList),
@@ -74,6 +85,32 @@ export const Quotes: React.FC<{
     />
   );
 
+  let prependMessage;
+
+  if (me === quotedAccountId) {
+    prependMessage = null;
+  } else if (quotedAccount?.username === quotedAccount?.acct) {
+    // Local account, we know this to be exhaustive
+    prependMessage = (
+      <div className='follow_requests-unlocked_explanation'>
+        <FormattedMessage
+          id='status.quotes.local_other_disclaimer'
+          defaultMessage='Quotes rejected by the author will not be shown.'
+        />
+      </div>
+    );
+  } else {
+    prependMessage = (
+      <div className='follow_requests-unlocked_explanation'>
+        <FormattedMessage
+          id='status.quotes.remote_other_disclaimer'
+          defaultMessage='Only quotes from {domain} are guaranteed to be shown here. Quotes rejected by the author will not be shown.'
+          values={{ domain: <strong>{domain}</strong> }}
+        />
+      </div>
+    );
+  }
+
   return (
     <Column bindToDocument={!multiColumn}>
       <ColumnHeader
@@ -100,6 +137,7 @@ export const Quotes: React.FC<{
         isLoading={isLoading}
         emptyMessage={emptyMessage}
         bindToDocument={!multiColumn}
+        prepend={prependMessage}
       />
 
       <Helmet>

--- a/app/javascript/mastodon/features/status/components/detailed_status.tsx
+++ b/app/javascript/mastodon/features/status/components/detailed_status.tsx
@@ -31,7 +31,7 @@ import { VisibilityIcon } from 'mastodon/components/visibility_icon';
 import { Audio } from 'mastodon/features/audio';
 import scheduleIdleTask from 'mastodon/features/ui/util/schedule_idle_task';
 import { Video } from 'mastodon/features/video';
-import { me } from 'mastodon/initial_state';
+import { useIdentity } from 'mastodon/identity_context';
 
 import Card from './card';
 
@@ -74,6 +74,8 @@ export const DetailedStatus: React.FC<{
   const [height, setHeight] = useState(0);
   const [showDespiteFilter, setShowDespiteFilter] = useState(false);
   const nodeRef = useRef<HTMLDivElement>();
+
+  const { signedIn } = useIdentity();
 
   const handleOpenVideo = useCallback(
     (options: VideoModalOptions) => {
@@ -283,7 +285,7 @@ export const DetailedStatus: React.FC<{
 
   if (['private', 'direct'].includes(status.get('visibility') as string)) {
     quotesLink = '';
-  } else if (status.getIn(['account', 'id']) === me) {
+  } else if (signedIn) {
     quotesLink = (
       <Link
         to={`/@${status.getIn(['account', 'acct'])}/${status.get('id')}/quotes`}

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -920,6 +920,8 @@
   "status.quote_private": "Private posts cannot be quoted",
   "status.quotes": "{count, plural, one {quote} other {quotes}}",
   "status.quotes.empty": "No one has quoted this post yet. When someone does, it will show up here.",
+  "status.quotes.local_other_disclaimer": "Quotes rejected by the author will not be shown.",
+  "status.quotes.remote_other_disclaimer": "Only quotes from {domain} are guaranteed to be shown here. Quotes rejected by the author will not be shown.",
   "status.read_more": "Read more",
   "status.reblog": "Boost",
   "status.reblog_or_quote": "Boost or quote",


### PR DESCRIPTION
This reuses the style for Private Mention and Follow request (only appears when the account is not locked) banners.

<img width="1273" height="616" alt="image" src="https://github.com/user-attachments/assets/bd50fe6b-2f38-44c7-95ae-59630de29ca5" />
<img width="1276" height="705" alt="image" src="https://github.com/user-attachments/assets/2b5e20d5-1b67-40bb-9967-672569ae77b7" />