### PR TITLE
Fix some routes for numeric AP identifiers

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -123,14 +123,14 @@ Rails.application.routes.draw do
 
   scope path: 'ap', as: 'ap' do
     resources :accounts, path: 'users', only: [:show], param: :id, concerns: :account_resources do
-      resources :statuses, module: :activitypub, only: [:show] do
+      resources :statuses, only: [:show] do
         member do
           get :activity
         end
 
-        resources :replies, only: [:index]
-        resources :likes, only: [:index]
-        resources :shares, only: [:index]
+        resources :replies, only: [:index], module: :activitypub
+        resources :likes, only: [:index], module: :activitypub
+        resources :shares, only: [:index], module: :activitypub
       end
     end
   end

--- a/spec/requests/activitypub/replies_spec.rb
+++ b/spec/requests/activitypub/replies_spec.rb
@@ -220,6 +220,12 @@ RSpec.describe 'ActivityPub Replies' do
       it_behaves_like 'allowed access'
     end
 
+    context 'with no signature and requesting the numeric AP path' do
+      subject { get ap_account_status_replies_path(account_id: status.account_id, status_id: status.id, only_other_accounts: only_other_accounts) }
+
+      it_behaves_like 'allowed access'
+    end
+
     context 'with signature' do
       subject { get account_status_replies_path(account_username: status.account.username, status_id: status.id, only_other_accounts: only_other_accounts), headers: nil, sign_with: remote_querier }
 

--- a/spec/requests/statuses_spec.rb
+++ b/spec/requests/statuses_spec.rb
@@ -360,6 +360,30 @@ RSpec.describe 'Statuses' do
               .to include(content: include(status.text))
           end
         end
+
+        context 'with JSON and querying the new paths' do
+          subject do
+            get ap_account_status_path(account_id: status.account_id, id: status.id),
+                headers: { 'Accept' => 'application/activity+json' },
+                sign_with: remote_account
+          end
+
+          let(:format) { 'json' }
+
+          it 'renders ActivityPub Note object successfully', :aggregate_failures do
+            subject
+
+            expect(response)
+              .to have_http_status(200)
+              .and have_cacheable_headers.with_vary('Accept, Accept-Language, Cookie')
+            expect(response.headers).to include(
+              'Content-Type' => include('application/activity+json'),
+              'Link' => include('activity+json')
+            )
+            expect(response.parsed_body)
+              .to include(content: include(status.text))
+          end
+        end
       end
 
       context 'when status has private visibility' do


### PR DESCRIPTION
Those were looking in the wrong modules.

These routes are not used yet but will be when we enable `numeric_ap_id` on new accounts.