### PR TITLE
Add env var to disable LetterOpenerWeb

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -65,7 +65,7 @@ Rails.application.reloader.to_prepare do
     request.content_security_policy_nonce_generator = nil
   end
 
-  if Rails.env.development?
+  if Rails.env.development? && ENV['DISABLE_LETTER_OPENER'].nil?
     LetterOpenerWeb::LettersController.content_security_policy do |p|
       p.child_src       :self
       p.connect_src     :none

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,9 @@ end
 Rails.application.routes.draw do
   root 'home#index'
 
-  mount LetterOpenerWeb::Engine, at: 'letter_opener' if Rails.env.development?
+  if Rails.env.development? && ENV['DISABLE_LETTER_OPENER'].nil?
+    mount LetterOpenerWeb::Engine, at: 'letter_opener'
+  end
 
   get 'health', to: 'health#show'
 


### PR DESCRIPTION
This introduces a new env var (`DISABLE_LETTER_OPENER`) to disable LetterOpenerWeb in Rails development mode.

Closes #36281