### PR TITLE
ESLint: Ignore .bundle directory

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -179,6 +179,7 @@ export default tseslint.config([
     'tmp/**/*',
     'vendor/**/*',
     'streaming/**/*',
+    '.bundle/**/*',
   ]),
   react.configs.flat.recommended,
   react.configs.flat['jsx-runtime'],


### PR DESCRIPTION
I use the `.bundle` directory as my `BUNDLE_PATH` (I think many people do since it's the default in recent versions). As a result, `.bundle/ruby` often contains javascript and it's linted along with the rest of the repo. Ignoring it from eslint fixes the issue.