### PR TITLE
Allow quotes to be displayed in the featured carousel

### DIFF
--- a/app/javascript/mastodon/components/featured_carousel.tsx
+++ b/app/javascript/mastodon/components/featured_carousel.tsx
@@ -20,7 +20,7 @@ import { useDrag } from '@use-gesture/react';
 import { expandAccountFeaturedTimeline } from '@/mastodon/actions/timelines';
 import { Icon } from '@/mastodon/components/icon';
 import { IconButton } from '@/mastodon/components/icon_button';
-import StatusContainer from '@/mastodon/containers/status_container';
+import { StatusQuoteManager } from '@/mastodon/components/status_quoted';
 import { usePrevious } from '@/mastodon/hooks/usePrevious';
 import { useAppDispatch, useAppSelector } from '@/mastodon/store';
 import ChevronLeftIcon from '@/material-icons/400-24px/chevron_left.svg?react';
@@ -218,12 +218,7 @@ const FeaturedCarouselItem: React.FC<
       ref={handleRef}
       {...props}
     >
-      <StatusContainer
-        // @ts-expect-error inferred props are wrong
-        id={statusId}
-        contextType='account'
-        withCounters
-      />
+      <StatusQuoteManager id={statusId} contextType='account' withCounters />
     </animated.div>
   );
 };


### PR DESCRIPTION
### Changes proposed in this PR:
- Fixes quotes not being displayed in the featured carousel, a bug [reported here](https://mastodon.catgirl.cloud/@49016/115283277279892944)
   
   I also checked for other potential omissions, but the `StatusContainer` component is now exclusively being used inside of the `StatusQuoteManager` component, meaning that all other occurrances of statuses should now be using the correct component.

### Screenshots

<img width="612" height="471" alt="image" src="https://github.com/user-attachments/assets/b03a2598-708a-4b97-8c52-c0e9f860e281" />
