### PR TITLE
Allow modern_emojis to be enabled purely server-side

### DIFF
--- a/app/javascript/mastodon/utils/environment.ts
+++ b/app/javascript/mastodon/utils/environment.ts
@@ -20,10 +20,7 @@ export function isFeatureEnabled(feature: Features) {
 
 export function isModernEmojiEnabled() {
   try {
-    return (
-      isFeatureEnabled('modern_emojis') &&
-      localStorage.getItem('experiments')?.split(',').includes('modern_emojis')
-    );
+    return isFeatureEnabled('modern_emojis');
   } catch {
     return false;
   }


### PR DESCRIPTION
Removes the requirement for local storage to have the modern_emojis flag so this experiment is available purely via the server flag.

Do not merge before #36341!