### PR TITLE
TypeScript: substring-trie

### DIFF
--- a/app/javascript/mastodon/features/emoji/__tests__/trie-test.ts
+++ b/app/javascript/mastodon/features/emoji/__tests__/trie-test.ts
@@ -1,0 +1,80 @@
+import { Trie } from '../trie';
+
+describe('main', () => {
+  it('test basic', () => {
+    const trie = new Trie(['banana']);
+    expect(trie.search('bananas')).toEqual('banana');
+    expect(trie.search('banana')).toEqual('banana');
+    expect(trie.search('bananass')).toEqual('banana');
+    expect(trie.search('banan')).toEqual(undefined);
+  });
+
+  it('test substring', () => {
+    const trie = new Trie(['banana', 'bananas']);
+    expect(trie.search('bananas')).toEqual('bananas');
+    expect(trie.search('banana')).toEqual('banana');
+    expect(trie.search('bananass')).toEqual('bananas');
+    expect(trie.search('bananat')).toEqual('banana');
+    expect(trie.search('banan')).toEqual(undefined);
+  });
+
+  it('test substring ordering', () => {
+    const trie = new Trie(['bananas', 'banana']);
+    expect(trie.search('bananas')).toEqual('bananas');
+    expect(trie.search('banana')).toEqual('banana');
+    expect(trie.search('bananass')).toEqual('bananas');
+    expect(trie.search('bananat')).toEqual('banana');
+    expect(trie.search('banan')).toEqual(undefined);
+  });
+
+  it('test readme examples', () => {
+    const trie = new Trie(['banana', 'grape', 'grapefruit']);
+    expect(trie.search('banana')).toEqual('banana');
+    expect(trie.search('banan')).toEqual(undefined);
+    expect(trie.search('bananas')).toEqual('banana');
+    expect(trie.search('grape')).toEqual('grape');
+    expect(trie.search('grapefruit')).toEqual('grapefruit');
+    expect(trie.search('grapefruit and other fruit')).toEqual('grapefruit');
+  });
+
+  it('test negative cases', () => {
+    const trie = new Trie(['banana', 'grape', 'grapefruit']);
+    expect(trie.search('apple')).toEqual(undefined);
+    expect(trie.search('grapple')).toEqual(undefined);
+    expect(trie.search('')).toEqual(undefined);
+  });
+
+  it('test garden-path substrings', () => {
+    let trie = new Trie(['grape']);
+    expect(trie.search('grapef')).toEqual('grape');
+
+    trie = new Trie(['grape', 'grapefruit']);
+    expect(trie.search('grape')).toEqual('grape');
+    expect(trie.search('grapef')).toEqual('grape');
+    expect(trie.search('grapefr')).toEqual('grape');
+    expect(trie.search('grapefru')).toEqual('grape');
+    expect(trie.search('grapefruit')).toEqual('grapefruit');
+
+    trie = new Trie(['grape', 'grapefruit', 'grapefruities']);
+    expect(trie.search('grape')).toEqual('grape');
+    expect(trie.search('grapef')).toEqual('grape');
+    expect(trie.search('grapefr')).toEqual('grape');
+    expect(trie.search('grapefru')).toEqual('grape');
+    expect(trie.search('grapefruit')).toEqual('grapefruit');
+    expect(trie.search('grapefruitzzz')).toEqual('grapefruit');
+    expect(trie.search('grapefruiti')).toEqual('grapefruit');
+    expect(trie.search('grapefruitie')).toEqual('grapefruit');
+    expect(trie.search('grapefruities')).toEqual('grapefruities');
+    expect(trie.search('grapefruitiessss')).toEqual('grapefruities');
+  });
+
+  it('test issue #1', () => {
+    const trie = new Trie([
+      'banana',
+      'grape',
+      'grape fruit',
+      'grape fruit sweet',
+    ]);
+    expect(trie.search('grape fruit sour')).toEqual('grape fruit');
+  });
+});

--- a/app/javascript/mastodon/features/emoji/emoji.js
+++ b/app/javascript/mastodon/features/emoji/emoji.js
@@ -1,10 +1,9 @@
-import Trie from 'substring-trie';
-
 import { assetHost } from 'mastodon/utils/config';
 
 import { autoPlayGif } from '../../initial_state';
 
 import { unicodeMapping } from './emoji_unicode_mapping_light';
+import { Trie } from './trie';
 
 const trie = new Trie(Object.keys(unicodeMapping));
 

--- a/app/javascript/mastodon/features/emoji/trie.ts
+++ b/app/javascript/mastodon/features/emoji/trie.ts
@@ -1,0 +1,43 @@
+const CODA_MARKER = '$$'; // marks the end of the string
+
+interface Dict {
+  [key: string]: Dict;
+}
+
+export class Trie {
+  #dict: Dict;
+
+  constructor(words: string[]) {
+    this.#dict = {};
+    for (const word of words) {
+      let dict = this.#dict;
+      for (let j = 0, len2 = word.length; j < len2; j++) {
+        const char = word.charAt(j);
+        dict = dict[char] ??= {};
+      }
+      dict[CODA_MARKER] = {};
+    }
+  }
+
+  search(str: string): string | undefined {
+    let i = -1;
+    const len = str.length;
+    const stack = [this.#dict];
+    while (++i < len) {
+      const dict = stack[i];
+      const char = str.charAt(i);
+      const next = dict?.[char];
+      if (next) {
+        stack.push(next);
+      } else {
+        break;
+      }
+    }
+    while (stack.length) {
+      if (stack.pop()?.[CODA_MARKER]) {
+        return str.slice(0, stack.length);
+      }
+    }
+    return undefined;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -113,7 +113,6 @@
     "scroll-behavior": "^0.11.0",
     "stacktrace-js": "^2.0.2",
     "stringz": "^2.1.0",
-    "substring-trie": "^1.0.2",
     "tesseract.js": "^6.0.0",
     "tiny-queue": "^0.2.1",
     "twitter-text": "3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2855,7 +2855,6 @@ __metadata:
     stylelint: "npm:^16.19.1"
     stylelint-config-prettier-scss: "npm:^1.0.0"
     stylelint-config-standard-scss: "npm:^15.0.1"
-    substring-trie: "npm:^1.0.2"
     tesseract.js: "npm:^6.0.0"
     tiny-queue: "npm:^0.2.1"
     twitter-text: "npm:3.1.0"
@@ -12923,13 +12922,6 @@ __metadata:
   version: 4.2.0
   resolution: "stylis@npm:4.2.0"
   checksum: 10c0/a7128ad5a8ed72652c6eba46bed4f416521bc9745a460ef5741edc725252cebf36ee45e33a8615a7057403c93df0866ab9ee955960792db210bb80abd5ac6543
-  languageName: node
-  linkType: hard
-
-"substring-trie@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "substring-trie@npm:1.0.2"
-  checksum: 10c0/ee1a65a6282f57fc4a97ded6dd057ffc597516ea7a4b0ae7374c0c0313ca4d9f3cb0652ae0294ca52232f2d5dedf13c27e9e442666d8ad51bcf91877cd18c092
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Rather than adding type declarations, I thought I would just pull in this small dependency. The last version was published eight years ago, there are no published types, and there's no repository to report issues.

I made minimal updates to the code to satisfy TypeScript. Otherwise, [the algorithm is unchanged](https://www.npmjs.com/package/substring-trie?activeTab=code).