### PR TITLE
Fix filters not applying to search results

### DIFF
--- a/app/javascript/mastodon/features/search/index.tsx
+++ b/app/javascript/mastodon/features/search/index.tsx
@@ -53,7 +53,7 @@ const renderHashtags = (hashtags: HashtagType[]) =>
 
 const renderStatuses = (statusIds: string[]) =>
   hidePeek<string>(statusIds).map((id) => (
-    <StatusQuoteManager key={id} id={id} />
+    <StatusQuoteManager contextType='search' key={id} id={id} />
   ));
 
 type SearchType = 'all' | ApiSearchType;
@@ -189,7 +189,7 @@ export const SearchResults: React.FC<{ multiColumn: boolean }> = ({
                   onClickMore={handleSelectStatuses}
                 >
                   {results.statuses.slice(0, INITIAL_DISPLAY).map((id) => (
-                    <StatusQuoteManager key={id} id={id} />
+                    <StatusQuoteManager contextType='search' key={id} id={id} />
                   ))}
                 </SearchSection>
               )}

--- a/app/javascript/mastodon/selectors/index.js
+++ b/app/javascript/mastodon/selectors/index.js
@@ -14,7 +14,7 @@ const getStatusInputSelectors = [
   (state, { id }) => state.getIn(['accounts', state.getIn(['statuses', id, 'account'])]),
   (state, { id }) => state.getIn(['accounts', state.getIn(['statuses', state.getIn(['statuses', id, 'reblog']), 'account'])]),
   getFilters,
-  (_, { contextType }) => ['detailed', 'bookmarks', 'favourites'].includes(contextType),
+  (_, { contextType }) => ['detailed', 'bookmarks', 'favourites', 'search'].includes(contextType),
 ];
 
 function getStatusResultFunction(


### PR DESCRIPTION
Fixes #36296

This PR changes search results to make use of filters in the “public” context, albeit treating the `hide` action as `warn`, similar to what we did in #34260.

I am not completely sure “public” is the context we should use there.