### PR TITLE
Add feature to automatically attach quote on eligible link past in Web UI composer

### DIFF
--- a/app/javascript/mastodon/actions/compose_typed.ts
+++ b/app/javascript/mastodon/actions/compose_typed.ts
@@ -4,6 +4,7 @@ import { createAction } from '@reduxjs/toolkit';
 import type { List as ImmutableList, Map as ImmutableMap } from 'immutable';
 
 import { apiUpdateMedia } from 'mastodon/api/compose';
+import { apiGetSearch } from 'mastodon/api/search';
 import type { ApiMediaAttachmentJSON } from 'mastodon/api_types/media_attachments';
 import type { MediaAttachment } from 'mastodon/models/media_attachment';
 import {
@@ -16,6 +17,7 @@ import type { Status } from '../models/status';
 
 import { showAlert } from './alerts';
 import { focusCompose } from './compose';
+import { importFetchedStatuses } from './importer';
 import { openModal } from './modal';
 
 const messages = defineMessages({
@@ -161,6 +163,41 @@ export const quoteComposeById = createAppThunk(
     const status = getState().statuses.get(statusId);
     if (status) {
       dispatch(quoteComposeByStatus(status));
+    }
+  },
+);
+
+export const pasteLinkCompose = createDataLoadingThunk(
+  'compose/pasteLink',
+  async ({ url }: { url: string }) => {
+    return await apiGetSearch({
+      q: url,
+      type: 'statuses',
+      resolve: true,
+      limit: 2,
+    });
+  },
+  (data, { dispatch, getState }) => {
+    const composeState = getState().compose;
+
+    if (
+      composeState.get('quoted_status_id') ||
+      composeState.get('is_submitting') ||
+      composeState.get('poll') ||
+      composeState.get('is_uploading')
+    )
+      return;
+
+    dispatch(importFetchedStatuses(data.statuses));
+
+    if (
+      data.statuses.length === 1 &&
+      data.statuses[0] &&
+      ['automatic', 'manual'].includes(
+        data.statuses[0].quote_approval?.current_user ?? 'denied',
+      )
+    ) {
+      dispatch(quoteComposeById(data.statuses[0].id));
     }
   },
 );

--- a/app/javascript/mastodon/components/autosuggest_textarea.jsx
+++ b/app/javascript/mastodon/components/autosuggest_textarea.jsx
@@ -150,10 +150,7 @@ const AutosuggestTextarea = forwardRef(({
   }, [suggestions, onSuggestionSelected, textareaRef]);
 
   const handlePaste = useCallback((e) => {
-    if (e.clipboardData && e.clipboardData.files.length === 1) {
-      onPaste(e.clipboardData.files);
-      e.preventDefault();
-    }
+    onPaste(e);
   }, [onPaste]);
 
   // Show the suggestions again whenever they change and the textarea is focused


### PR DESCRIPTION
When an URL (and only an URL) is pasted, it tries to resolve it through the search API, and attaches it if it's a quotable status.

https://github.com/user-attachments/assets/ae5a3f38-5b99-4673-bbc0-636f0c760fbf