### PR TITLE
Ensure Fetch-all-replies snackbar is shown at the bottom of the screen

### DIFF
--- a/app/javascript/mastodon/features/status/index.jsx
+++ b/app/javascript/mastodon/features/status/index.jsx
@@ -603,7 +603,7 @@ class Status extends ImmutablePureComponent {
         />
 
         <ScrollContainer scrollKey='thread' shouldUpdateScroll={this.shouldUpdateScroll} childRef={this.setContainerRef}>
-          <div className={classNames('scrollable item-list', { fullscreen })} ref={this.setContainerRef}>
+          <div className={classNames('item-list scrollable scrollable--flex', { fullscreen })} ref={this.setContainerRef}>
             {ancestors}
 
             <Hotkeys handlers={handlers}>

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -3153,18 +3153,23 @@ a.account__display-name {
 
 .column__alert {
   position: sticky;
-  bottom: 1rem;
+  bottom: 0;
   z-index: 10;
   box-sizing: border-box;
   display: grid;
   width: 100%;
   max-width: 360px;
-  padding-inline: 10px;
-  margin-top: 1rem;
-  margin-inline: auto;
+  padding: 1rem;
+  margin: auto auto 0;
+  overflow: clip;
+
+  &:empty {
+    padding: 0;
+  }
 
   @media (max-width: #{$mobile-menu-breakpoint - 1}) {
-    bottom: 4rem;
+    // Compensate for mobile menubar
+    bottom: var(--mobile-bottom-nav-height);
   }
 
   & > * {


### PR DESCRIPTION
### Changes proposed in this PR:
- Fixes a bug whereby the fetch-all-replies snackbar was not shown at the bottom of the screen in threads with no or few replies

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="376" height="714" alt="image" src="https://github.com/user-attachments/assets/8c7a206b-a5ed-434e-a2bc-ad9e07961353" /> | <img width="376" height="715" alt="image" src="https://github.com/user-attachments/assets/22b55fe1-97e4-4643-b0d1-931e49b1b312" /> | 