### PR TITLE
Emoji: Account page

### DIFF
--- a/app/javascript/mastodon/components/account/index.tsx
+++ b/app/javascript/mastodon/components/account/index.tsx
@@ -5,6 +5,7 @@ import { defineMessages, useIntl, FormattedMessage } from 'react-intl';
 import classNames from 'classnames';
 import { Link } from 'react-router-dom';
 
+import { EmojiHTML } from '@/mastodon/components/emoji/html';
 import MoreHorizIcon from '@/material-icons/400-24px/more_horiz.svg?react';
 import {
   blockAccount,
@@ -331,9 +332,10 @@ export const Account: React.FC<AccountProps> = ({
           {account &&
             withBio &&
             (account.note.length > 0 ? (
-              <div
+              <EmojiHTML
                 className='account__note translate'
-                dangerouslySetInnerHTML={{ __html: account.note_emojified }}
+                htmlString={account.note_emojified}
+                extraEmojis={account.emojis}
               />
             ) : (
               <div className='account__note account__note--missing'>

--- a/app/javascript/mastodon/components/account_bio.tsx
+++ b/app/javascript/mastodon/components/account_bio.tsx
@@ -6,10 +6,9 @@ import { useLinks } from 'mastodon/hooks/useLinks';
 
 import { useAppSelector } from '../store';
 import { isModernEmojiEnabled } from '../utils/environment';
-import type { OnElementHandler } from '../utils/html';
 
 import { EmojiHTML } from './emoji/html';
-import { HandledLink } from './status/handled_link';
+import { useElementHandledLink } from './status/handled_link';
 
 interface AccountBioProps {
   className: string;
@@ -38,23 +37,9 @@ export const AccountBio: React.FC<AccountBioProps> = ({
     [showDropdown, accountId],
   );
 
-  const handleLink = useCallback<OnElementHandler>(
-    (element, { key, ...props }) => {
-      if (element instanceof HTMLAnchorElement) {
-        return (
-          <HandledLink
-            {...props}
-            key={key as string} // React requires keys to not be part of spread props.
-            href={element.href}
-            text={element.innerText}
-            hashtagAccountId={accountId}
-          />
-        );
-      }
-      return undefined;
-    },
-    [accountId],
-  );
+  const htmlHandlers = useElementHandledLink({
+    hashtagAccountId: showDropdown ? accountId : undefined,
+  });
 
   const note = useAppSelector((state) => {
     const account = state.accounts.get(accountId);
@@ -79,7 +64,7 @@ export const AccountBio: React.FC<AccountBioProps> = ({
       className={classNames(className, 'translate')}
       onClickCapture={isModernEmojiEnabled() ? undefined : handleClick}
       ref={handleNodeChange}
-      onElement={handleLink}
+      {...htmlHandlers}
     />
   );
 };

--- a/app/javascript/mastodon/components/account_bio.tsx
+++ b/app/javascript/mastodon/components/account_bio.tsx
@@ -62,7 +62,7 @@ export const AccountBio: React.FC<AccountBioProps> = ({
       htmlString={note}
       extraEmojis={extraEmojis}
       className={classNames(className, 'translate')}
-      onClickCapture={isModernEmojiEnabled() ? undefined : handleClick}
+      onClickCapture={handleClick}
       ref={handleNodeChange}
       {...htmlHandlers}
     />

--- a/app/javascript/mastodon/components/account_fields.tsx
+++ b/app/javascript/mastodon/components/account_fields.tsx
@@ -5,10 +5,14 @@ import { Icon } from 'mastodon/components/icon';
 import { useLinks } from 'mastodon/hooks/useLinks';
 import type { Account } from 'mastodon/models/account';
 
+import { CustomEmojiProvider } from './emoji/context';
+import { EmojiHTML } from './emoji/html';
+
 export const AccountFields: React.FC<{
   fields: Account['fields'];
+  extraEmojis: Account['emojis'];
   limit: number;
-}> = ({ fields, limit = -1 }) => {
+}> = ({ fields, extraEmojis, limit = -1 }) => {
   const handleClick = useLinks();
 
   if (fields.size === 0) {
@@ -17,26 +21,27 @@ export const AccountFields: React.FC<{
 
   return (
     <div className='account-fields' onClickCapture={handleClick}>
-      {fields.take(limit).map((pair, i) => (
-        <dl
-          key={i}
-          className={classNames({ verified: pair.get('verified_at') })}
-        >
-          <dt
-            dangerouslySetInnerHTML={{ __html: pair.get('name_emojified') }}
-            className='translate'
-          />
-
-          <dd className='translate' title={pair.get('value_plain') ?? ''}>
-            {pair.get('verified_at') && (
-              <Icon id='check' icon={CheckIcon} className='verified__mark' />
-            )}
-            <span
-              dangerouslySetInnerHTML={{ __html: pair.get('value_emojified') }}
+      <CustomEmojiProvider emojis={extraEmojis}>
+        {fields.take(limit).map((pair, i) => (
+          <dl
+            key={i}
+            className={classNames({ verified: pair.get('verified_at') })}
+          >
+            <EmojiHTML
+              as='dt'
+              htmlString={pair.get('name_emojified')}
+              className='translate'
             />
-          </dd>
-        </dl>
-      ))}
+
+            <dd className='translate' title={pair.get('value_plain') ?? ''}>
+              {pair.get('verified_at') && (
+                <Icon id='check' icon={CheckIcon} className='verified__mark' />
+              )}
+              <EmojiHTML as='span' htmlString={pair.get('value_emojified')} />
+            </dd>
+          </dl>
+        ))}
+      </CustomEmojiProvider>
     </div>
   );
 };

--- a/app/javascript/mastodon/components/account_fields.tsx
+++ b/app/javascript/mastodon/components/account_fields.tsx
@@ -1,47 +1,70 @@
+import { useIntl } from 'react-intl';
+
 import classNames from 'classnames';
 
 import CheckIcon from '@/material-icons/400-24px/check.svg?react';
 import { Icon } from 'mastodon/components/icon';
-import { useLinks } from 'mastodon/hooks/useLinks';
 import type { Account } from 'mastodon/models/account';
 
 import { CustomEmojiProvider } from './emoji/context';
 import { EmojiHTML } from './emoji/html';
+import { useElementHandledLink } from './status/handled_link';
 
-export const AccountFields: React.FC<{
-  fields: Account['fields'];
-  extraEmojis: Account['emojis'];
-  limit: number;
-}> = ({ fields, extraEmojis, limit = -1 }) => {
-  const handleClick = useLinks();
+export const AccountFields: React.FC<Pick<Account, 'fields' | 'emojis'>> = ({
+  fields,
+  emojis,
+}) => {
+  const intl = useIntl();
+  const htmlHandlers = useElementHandledLink();
 
   if (fields.size === 0) {
     return null;
   }
 
   return (
-    <div className='account-fields' onClickCapture={handleClick}>
-      <CustomEmojiProvider emojis={extraEmojis}>
-        {fields.take(limit).map((pair, i) => (
-          <dl
-            key={i}
-            className={classNames({ verified: pair.get('verified_at') })}
-          >
-            <EmojiHTML
-              as='dt'
-              htmlString={pair.get('name_emojified')}
-              className='translate'
-            />
+    <CustomEmojiProvider emojis={emojis}>
+      {fields.map((pair, i) => (
+        <dl key={i} className={classNames({ verified: pair.verified_at })}>
+          <EmojiHTML
+            as='dt'
+            htmlString={pair.name_emojified}
+            className='translate'
+            {...htmlHandlers}
+          />
 
-            <dd className='translate' title={pair.get('value_plain') ?? ''}>
-              {pair.get('verified_at') && (
+          <dd className='translate' title={pair.value_plain ?? ''}>
+            {pair.verified_at && (
+              <span
+                title={intl.formatMessage(
+                  {
+                    id: 'account.link_verified_on',
+                    defaultMessage:
+                      'Ownership of this link was checked on {date}',
+                  },
+                  {
+                    date: intl.formatDate(pair.verified_at, dateFormatOptions),
+                  },
+                )}
+              >
                 <Icon id='check' icon={CheckIcon} className='verified__mark' />
-              )}
-              <EmojiHTML as='span' htmlString={pair.get('value_emojified')} />
-            </dd>
-          </dl>
-        ))}
-      </CustomEmojiProvider>
-    </div>
+              </span>
+            )}{' '}
+            <EmojiHTML
+              as='span'
+              htmlString={pair.value_emojified}
+              {...htmlHandlers}
+            />
+          </dd>
+        </dl>
+      ))}
+    </CustomEmojiProvider>
   );
+};
+
+const dateFormatOptions: Intl.DateTimeFormatOptions = {
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit',
 };

--- a/app/javascript/mastodon/components/emoji/html.tsx
+++ b/app/javascript/mastodon/components/emoji/html.tsx
@@ -4,7 +4,10 @@ import classNames from 'classnames';
 
 import type { CustomEmojiMapArg } from '@/mastodon/features/emoji/types';
 import { isModernEmojiEnabled } from '@/mastodon/utils/environment';
-import type { OnElementHandler } from '@/mastodon/utils/html';
+import type {
+  OnAttributeHandler,
+  OnElementHandler,
+} from '@/mastodon/utils/html';
 import { htmlStringToComponents } from '@/mastodon/utils/html';
 import { polymorphicForwardRef } from '@/types/polymorphic';
 
@@ -16,6 +19,7 @@ interface EmojiHTMLProps {
   extraEmojis?: CustomEmojiMapArg;
   className?: string;
   onElement?: OnElementHandler;
+  onAttribute?: OnAttributeHandler;
 }
 
 export const ModernEmojiHTML = polymorphicForwardRef<'div', EmojiHTMLProps>(
@@ -26,14 +30,19 @@ export const ModernEmojiHTML = polymorphicForwardRef<'div', EmojiHTMLProps>(
       as: asProp = 'div', // Rename for syntax highlighting
       className = '',
       onElement,
+      onAttribute,
       ...props
     },
     ref,
   ) => {
     const contents = useMemo(
       () =>
-        htmlStringToComponents(htmlString, { onText: textToEmojis, onElement }),
-      [htmlString, onElement],
+        htmlStringToComponents(htmlString, {
+          onText: textToEmojis,
+          onElement,
+          onAttribute,
+        }),
+      [htmlString, onAttribute, onElement],
     );
 
     return (
@@ -60,6 +69,7 @@ export const LegacyEmojiHTML = polymorphicForwardRef<'div', EmojiHTMLProps>(
       extraEmojis,
       className,
       onElement,
+      onAttribute,
       ...rest
     } = props;
     const Wrapper = asElement ?? 'div';

--- a/app/javascript/mastodon/components/hover_card_account.tsx
+++ b/app/javascript/mastodon/components/hover_card_account.tsx
@@ -105,7 +105,11 @@ export const HoverCardAccount = forwardRef<
                   accountId={account.id}
                   className='hover-card__bio'
                 />
-                <AccountFields fields={account.fields} limit={2} />
+                <AccountFields
+                  fields={account.fields}
+                  limit={2}
+                  extraEmojis={account.emojis}
+                />
                 {note && note.length > 0 && (
                   <dl className='hover-card__note'>
                     <dt className='hover-card__note-label'>

--- a/app/javascript/mastodon/components/hover_card_account.tsx
+++ b/app/javascript/mastodon/components/hover_card_account.tsx
@@ -23,6 +23,8 @@ import { domain } from 'mastodon/initial_state';
 import { getAccountHidden } from 'mastodon/selectors/accounts';
 import { useAppSelector, useAppDispatch } from 'mastodon/store';
 
+import { useLinks } from '../hooks/useLinks';
+
 export const HoverCardAccount = forwardRef<
   HTMLDivElement,
   { accountId?: string }
@@ -63,6 +65,8 @@ export const HoverCardAccount = forwardRef<
     hasRelationshipLoaded &&
     !isMutual &&
     !isFollower;
+
+  const handleClick = useLinks();
 
   return (
     <div
@@ -105,11 +109,14 @@ export const HoverCardAccount = forwardRef<
                   accountId={account.id}
                   className='hover-card__bio'
                 />
-                <AccountFields
-                  fields={account.fields}
-                  limit={2}
-                  extraEmojis={account.emojis}
-                />
+
+                <div className='account-fields' onClickCapture={handleClick}>
+                  <AccountFields
+                    fields={account.fields.take(2)}
+                    emojis={account.emojis}
+                  />
+                </div>
+
                 {note && note.length > 0 && (
                   <dl className='hover-card__note'>
                     <dt className='hover-card__note-label'>

--- a/app/javascript/mastodon/components/status/handled_link.tsx
+++ b/app/javascript/mastodon/components/status/handled_link.tsx
@@ -1,6 +1,9 @@
+import { useCallback } from 'react';
 import type { ComponentProps, FC } from 'react';
 
 import { Link } from 'react-router-dom';
+
+import type { OnElementHandler } from '@/mastodon/utils/html';
 
 export interface HandledLinkProps {
   href: string;
@@ -76,4 +79,32 @@ export const HandledLink: FC<HandledLinkProps & ComponentProps<'a'>> = ({
   } catch {
     return text;
   }
+};
+
+export const useElementHandledLink = ({
+  hashtagAccountId,
+  mentionAccountId,
+}: {
+  hashtagAccountId?: string;
+  mentionAccountId?: string;
+} = {}) => {
+  const onElement = useCallback<OnElementHandler>(
+    (element, { key, ...props }) => {
+      if (element instanceof HTMLAnchorElement) {
+        return (
+          <HandledLink
+            {...props}
+            key={key as string} // React requires keys to not be part of spread props.
+            href={element.href}
+            text={element.innerText}
+            hashtagAccountId={hashtagAccountId}
+            mentionAccountId={mentionAccountId}
+          />
+        );
+      }
+      return undefined;
+    },
+    [hashtagAccountId, mentionAccountId],
+  );
+  return { onElement };
 };

--- a/app/javascript/mastodon/features/account_timeline/components/account_header.tsx
+++ b/app/javascript/mastodon/features/account_timeline/components/account_header.tsx
@@ -8,7 +8,11 @@ import { NavLink } from 'react-router-dom';
 
 import { AccountBio } from '@/mastodon/components/account_bio';
 import { DisplayName } from '@/mastodon/components/display_name';
-import { AnimateEmojiProvider } from '@/mastodon/components/emoji/context';
+import {
+  AnimateEmojiProvider,
+  CustomEmojiProvider,
+} from '@/mastodon/components/emoji/context';
+import { EmojiHTML } from '@/mastodon/components/emoji/html';
 import CheckIcon from '@/material-icons/400-24px/check.svg?react';
 import LockIcon from '@/material-icons/400-24px/lock.svg?react';
 import MoreHorizIcon from '@/material-icons/400-24px/more_horiz.svg?react';
@@ -898,37 +902,43 @@ export const AccountHeader: React.FC<{
                         verified: pair.verified_at,
                       })}
                     >
-                      <dt
-                        dangerouslySetInnerHTML={{
-                          __html: pair.name_emojified,
-                        }}
-                        title={pair.name}
-                        className='translate'
-                      />
-
-                      <dd className='translate' title={pair.value_plain ?? ''}>
-                        {pair.verified_at && (
-                          <span
-                            title={intl.formatMessage(messages.linkVerifiedOn, {
-                              date: intl.formatDate(
-                                pair.verified_at,
-                                dateFormatOptions,
-                              ),
-                            })}
-                          >
-                            <Icon
-                              id='check'
-                              icon={CheckIcon}
-                              className='verified__mark'
-                            />
-                          </span>
-                        )}{' '}
-                        <span
-                          dangerouslySetInnerHTML={{
-                            __html: pair.value_emojified,
-                          }}
+                      <CustomEmojiProvider emojis={account.emojis}>
+                        <EmojiHTML
+                          as='dt'
+                          htmlString={pair.name_emojified}
+                          title={pair.name}
+                          className='translate'
                         />
-                      </dd>
+
+                        <dd
+                          className='translate'
+                          title={pair.value_plain ?? ''}
+                        >
+                          {pair.verified_at && (
+                            <span
+                              title={intl.formatMessage(
+                                messages.linkVerifiedOn,
+                                {
+                                  date: intl.formatDate(
+                                    pair.verified_at,
+                                    dateFormatOptions,
+                                  ),
+                                },
+                              )}
+                            >
+                              <Icon
+                                id='check'
+                                icon={CheckIcon}
+                                className='verified__mark'
+                              />
+                            </span>
+                          )}{' '}
+                          <EmojiHTML
+                            as='span'
+                            htmlString={pair.value_emojified}
+                          />
+                        </dd>
+                      </CustomEmojiProvider>
                     </dl>
                   ))}
                 </div>

--- a/app/javascript/mastodon/features/account_timeline/components/account_header.tsx
+++ b/app/javascript/mastodon/features/account_timeline/components/account_header.tsx
@@ -7,13 +7,9 @@ import { Helmet } from 'react-helmet';
 import { NavLink } from 'react-router-dom';
 
 import { AccountBio } from '@/mastodon/components/account_bio';
+import { AccountFields } from '@/mastodon/components/account_fields';
 import { DisplayName } from '@/mastodon/components/display_name';
-import {
-  AnimateEmojiProvider,
-  CustomEmojiProvider,
-} from '@/mastodon/components/emoji/context';
-import { EmojiHTML } from '@/mastodon/components/emoji/html';
-import CheckIcon from '@/material-icons/400-24px/check.svg?react';
+import { AnimateEmojiProvider } from '@/mastodon/components/emoji/context';
 import LockIcon from '@/material-icons/400-24px/lock.svg?react';
 import MoreHorizIcon from '@/material-icons/400-24px/more_horiz.svg?react';
 import NotificationsIcon from '@/material-icons/400-24px/notifications.svg?react';
@@ -188,14 +184,6 @@ const titleFromAccount = (account: Account) => {
     displayName.trim().length === 0 ? account.username : displayName;
 
   return `${prefix} (@${acct})`;
-};
-
-const dateFormatOptions: Intl.DateTimeFormatOptions = {
-  month: 'short',
-  day: 'numeric',
-  year: 'numeric',
-  hour: '2-digit',
-  minute: '2-digit',
 };
 
 export const AccountHeader: React.FC<{
@@ -895,52 +883,7 @@ export const AccountHeader: React.FC<{
                     </dd>
                   </dl>
 
-                  {fields.map((pair, i) => (
-                    <dl
-                      key={i}
-                      className={classNames({
-                        verified: pair.verified_at,
-                      })}
-                    >
-                      <CustomEmojiProvider emojis={account.emojis}>
-                        <EmojiHTML
-                          as='dt'
-                          htmlString={pair.name_emojified}
-                          title={pair.name}
-                          className='translate'
-                        />
-
-                        <dd
-                          className='translate'
-                          title={pair.value_plain ?? ''}
-                        >
-                          {pair.verified_at && (
-                            <span
-                              title={intl.formatMessage(
-                                messages.linkVerifiedOn,
-                                {
-                                  date: intl.formatDate(
-                                    pair.verified_at,
-                                    dateFormatOptions,
-                                  ),
-                                },
-                              )}
-                            >
-                              <Icon
-                                id='check'
-                                icon={CheckIcon}
-                                className='verified__mark'
-                              />
-                            </span>
-                          )}{' '}
-                          <EmojiHTML
-                            as='span'
-                            htmlString={pair.value_emojified}
-                          />
-                        </dd>
-                      </CustomEmojiProvider>
-                    </dl>
-                  ))}
+                  <AccountFields fields={fields} emojis={account.emojis} />
                 </div>
               </div>
 

--- a/app/javascript/mastodon/hooks/useLinks.ts
+++ b/app/javascript/mastodon/hooks/useLinks.ts
@@ -7,6 +7,8 @@ import { isFulfilled, isRejected } from '@reduxjs/toolkit';
 import { openURL } from 'mastodon/actions/search';
 import { useAppDispatch } from 'mastodon/store';
 
+import { isModernEmojiEnabled } from '../utils/environment';
+
 const isMentionClick = (element: HTMLAnchorElement) =>
   element.classList.contains('mention') &&
   !element.classList.contains('hashtag');
@@ -53,6 +55,11 @@ export const useLinks = (skipHashtags?: boolean) => {
 
   const handleClick = useCallback(
     (e: React.MouseEvent) => {
+      // Exit early if modern emoji is enabled, as this is handled by HandledLink.
+      if (isModernEmojiEnabled()) {
+        return;
+      }
+
       const target = (e.target as HTMLElement).closest('a');
 
       if (!target || e.button !== 0 || e.ctrlKey || e.metaKey) {


### PR DESCRIPTION
This updates a few remaining areas of the account page to utilize the new emoji components. Specifically, these are:

- Account component
- Labels + verified badge
- Hover card
- Account header

As part of that, the `AccountLabels` component that was previously only used by the hover card is refactored to be the same across the hover card and account profile. Additionally the `useElementHandledLink` is created as a helper to replace previous link functionality with the one from #36341.