### PR TITLE
Do not automatically run Prettier on the streaming server code.

### DIFF
--- a/streaming/lint-staged.config.mjs
+++ b/streaming/lint-staged.config.mjs
@@ -1,5 +1,4 @@
 const config = {
-  '*': 'prettier --ignore-unknown --write',
   '*.{js,ts}': 'eslint --fix',
   '**/*.ts': () => 'tsc -p tsconfig.json --noEmit',
 };


### PR DESCRIPTION
This was mistakenly added during the ESLint upgrade, but it creates extra changes in every commit touching this code.

If this is what we want (ultimately, we do), it must come with a commit updating all of the files at once with the new format.