### PR TITLE
Use tag filter for pending tag count on admin dashboard

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -9,10 +9,16 @@ module Admin
 
       @pending_appeals_count = Appeal.pending.async_count
       @pending_reports_count = Report.unresolved.async_count
-      @pending_tags_count    = Tag.pending_review.async_count
+      @pending_tags_count    = pending_tags.async_count
       @pending_users_count   = User.pending.async_count
       @system_checks         = Admin::SystemCheck.perform(current_user)
       @time_period           = (29.days.ago.to_date...Time.now.utc.to_date)
+    end
+
+    private
+
+    def pending_tags
+      ::Trends::TagFilter.new(status: :pending_review).results
     end
   end
 end

--- a/spec/system/admin/dashboard_spec.rb
+++ b/spec/system/admin/dashboard_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'Admin Dashboard' do
     before do
       stub_system_checks
       Fabricate :software_update
+      Fabricate :tag, requested_review_at: 5.minutes.ago
       sign_in(user)
     end
 
@@ -18,6 +19,7 @@ RSpec.describe 'Admin Dashboard' do
       expect(page)
         .to have_title(I18n.t('admin.dashboard.title'))
         .and have_content(I18n.t('admin.system_checks.software_version_patch_check.message_html'))
+        .and have_content('0 pending hashtags')
     end
 
     private


### PR DESCRIPTION
Same idea as https://github.com/mastodon/mastodon/pull/35120 - which fixed this issue on the trends/tags page in admin area, but not on the dashboard.

Fixes https://github.com/mastodon/mastodon/issues/34785

Possible followup here:

- This code is now repeated in both controllers. Not huge issue with just two spots, but could get out of sync again ... maybe extract these to some sort of presenter/facade (or at minimum, new class method on tagfilter?)
- Or even beyond that, extract the entirety of the various "get some pending/unresolved counts of stuff across the admin area" type stuff to somewhere? Used on maybe 5-6 views.