### PR TITLE
Fix quote post state sometimes not being updated through streaming server

### DIFF
--- a/app/services/activitypub/process_status_update_service.rb
+++ b/app/services/activitypub/process_status_update_service.rb
@@ -74,6 +74,8 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
       update_quote_approval!
       update_counts!
     end
+
+    broadcast_updates! if @status.quote&.state_previously_changed?
   end
 
   def update_interaction_policies!

--- a/app/workers/activitypub/refetch_and_verify_quote_worker.rb
+++ b/app/workers/activitypub/refetch_and_verify_quote_worker.rb
@@ -10,6 +10,7 @@ class ActivityPub::RefetchAndVerifyQuoteWorker
   def perform(quote_id, quoted_uri, options = {})
     quote = Quote.find(quote_id)
     ActivityPub::VerifyQuoteService.new.call(quote, fetchable_quoted_uri: quoted_uri, request_id: options[:request_id])
+    ::DistributionWorker.perform_async(quote.status_id, { 'update' => true }) if quote.state_previously_changed?
   rescue ActiveRecord::RecordNotFound
     # Do nothing
     true


### PR DESCRIPTION
Fixes #36305

Quotes of third-party posts made on a third-party server discovered before approval would not have their approval properly streamed.

This PR adds the distribution logic for the implicit update case as well as the async recheck case, that previously did not trigger distribution of a streaming event.