### PR TITLE
Copy username and instance easily to clipboard.

### DIFF
--- a/app/javascript/mastodon/features/account_timeline/components/account_header.tsx
+++ b/app/javascript/mastodon/features/account_timeline/components/account_header.tsx
@@ -371,6 +371,19 @@ export const AccountHeader: React.FC<{
     });
   }, [account]);
 
+  const handleCopyUsername = useCallback(() => {
+    if (!account) {
+      return;
+    }
+  
+    const isLocal = !account.acct.includes('@');
+    const username = account.acct.split('@')[0];
+    const domain = isLocal ? localDomain : account.acct.split('@')[1];
+    const fullHandle = `@${username}@${domain}`;
+    
+    void navigator.clipboard.writeText(fullHandle);
+  }, [account]);
+
   const suspended = account?.suspended;
   const isRemote = account?.acct !== account?.username;
   const remoteDomain = isRemote ? account?.acct.split('@')[1] : null;
@@ -822,7 +835,11 @@ export const AccountHeader: React.FC<{
             <h1>
               <DisplayName account={account} variant='simple' />
               <small>
-                <span>
+                <span 
+                  onClick={handleCopyUsername}
+                  style={{ cursor: 'pointer' }}
+                  title={`Click to copy @${username}@${domain}`}
+                >
                   @{username}
                   <span className='invisible'>@{domain}</span>
                 </span>


### PR DESCRIPTION
The network effect is a driver of continuous growth.
Hence, it needs to be easy to share accountnames - no matter if they are shaered within or outside the mastodon network.

Future implementations of adjected software may even rely on an easy to copy usernames to curate pages like mastowall.

