### PR TITLE
Remove duplicate `set_locale` around action in auth/registrations

### DIFF
--- a/app/controllers/auth/registrations_controller.rb
+++ b/app/controllers/auth/registrations_controller.rb
@@ -135,7 +135,7 @@ class Auth::RegistrationsController < Devise::RegistrationsController
     @accept_token = session[:accept_token] = SecureRandom.hex
     @invite_code  = invite_code
 
-    set_locale { render :rules }
+    render :rules
   end
 
   def is_flashing_format? # rubocop:disable Naming/PredicatePrefix

--- a/spec/system/auth/registrations_spec.rb
+++ b/spec/system/auth/registrations_spec.rb
@@ -3,6 +3,17 @@
 require 'rails_helper'
 
 RSpec.describe 'Auth Registration' do
+  context 'when there are server rules' do
+    let!(:rule) { Fabricate :rule, text: 'You must be seven meters tall' }
+
+    it 'shows rules page before proceeding with sign up' do
+      visit new_user_registration_path
+      expect(page)
+        .to have_title(I18n.t('auth.register'))
+        .and have_content(rule.text)
+    end
+  end
+
   context 'when age verification is enabled' do
     before { Setting.min_age = 16 }
 


### PR DESCRIPTION
This is already called from an `around_action` in the Localized concern, and this appears to be a dupe call. It's not totally clear to me from the history if this was always a double call, or if behavior changed at some point to make it one -- but in either case, I think its currently not needed.

Added spec here is not directly pertinent to the removal of the double call, but I couldn't find other coverage exercising this specific behavior of redirecting when rules are present, so added here as well.