### PR TITLE
Fix videos not being indented properly in thread view

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1528,7 +1528,7 @@
     & > .status__content,
     & > .status__action-bar,
     & > .media-gallery,
-    & > .video-player,
+    & .video-player,
     & > .audio-player,
     & > .attachment-list,
     & > .picture-in-picture-placeholder,

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1528,7 +1528,7 @@
     & > .status__content,
     & > .status__action-bar,
     & > .media-gallery,
-    & .video-player,
+    & > div > .video-player,
     & > .audio-player,
     & > .attachment-list,
     & > .picture-in-picture-placeholder,


### PR DESCRIPTION
### Changes proposed in this PR:
- Fixes videos not being indented properly in thread view, a regression from #35834

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="611" height="484" alt="image" src="https://github.com/user-attachments/assets/29c39eae-3250-4ba4-a3e4-3f2030904aee" /> | <img width="613" height="454" alt="image" src="https://github.com/user-attachments/assets/50b14309-187d-483b-830e-ebc60b7daab4" /> |