### PR TITLE
Fix allow_referrer_origin typo

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -32,7 +32,7 @@ defaults: &defaults
   require_invite_text: false
   backups_retention_period: 7
   captcha_enabled: false
-  allow_referer_origin: false
+  allow_referrer_origin: false
 
 development:
   <<: *defaults


### PR DESCRIPTION
Found while looking at defaults; it seems that this config option was typo'd