### PR TITLE
Use existing time format string to generate backup archive filename

### DIFF
--- a/app/services/backup_service.rb
+++ b/app/services/backup_service.rb
@@ -63,7 +63,7 @@ class BackupService < BaseService
       dump_actor!(zipfile)
     end
 
-    archive_filename = "#{['archive', Time.now.utc.strftime('%Y%m%d%H%M%S'), SecureRandom.hex(16)].join('-')}.zip"
+    archive_filename = "#{['archive', Time.current.strftime('%Y%m%d%H%M%S'), SecureRandom.hex(16)].join('-')}.zip"
 
     @backup.dump      = ActionDispatch::Http::UploadedFile.new(tempfile: tmp_file, filename: archive_filename)
     @backup.processed = true

--- a/app/services/backup_service.rb
+++ b/app/services/backup_service.rb
@@ -63,7 +63,7 @@ class BackupService < BaseService
       dump_actor!(zipfile)
     end
 
-    archive_filename = "#{['archive', Time.current.strftime('%Y%m%d%H%M%S'), SecureRandom.hex(16)].join('-')}.zip"
+    archive_filename = "#{['archive', Time.current.to_fs(:number), SecureRandom.hex(16)].join('-')}.zip"
 
     @backup.dump      = ActionDispatch::Http::UploadedFile.new(tempfile: tmp_file, filename: archive_filename)
     @backup.processed = true


### PR DESCRIPTION
The `:number` string [from activesupport](https://github.com/rails/rails/blob/v8.0.3/activesupport/lib/active_support/core_ext/time/conversions.rb#L11) provides the same format used here - change is just to prefer using already-defined string over a custom `strftime` call.