### PR TITLE
Fix low-contrast hover colour of alert actions (light theme only)

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -10439,7 +10439,7 @@ noscript {
   &:hover,
   &:focus,
   &:active {
-    background: color.change($ui-base-color, $alpha: 0.85);
+    background: color.change($white, $alpha: 0.15);
   }
 }
 


### PR DESCRIPTION
### Changes proposed in this PR:
- Fix hard-to-read background colour of when hovering alert actions in light mode. Absolute (non-themed) colours are now used since the component looks the same in light and dark mode

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="228" height="95" alt="image" src="https://github.com/user-attachments/assets/98e5e880-f21f-4064-98d6-cb7d76573563" /> | <img width="222" height="93" alt="image" src="https://github.com/user-attachments/assets/63432383-d7ba-4a55-9539-306af826ce4d" /> |