### PR TITLE
Update docker-compose.yml sidekiq health check to work for both 4.4 and 4.5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,7 +115,7 @@ services:
     volumes:
       - ./public/system:/mastodon/public/system
     healthcheck:
-      test: ['CMD-SHELL', "ps aux | grep '[s]idekiq\ 7' || false"]
+      test: ['CMD-SHELL', "ps aux | grep '[s]idekiq\ [78]' || false"]
 
   ## Uncomment to enable federation with tor instances along with adding the following ENV variables
   ## http_hidden_proxy=http://privoxy:8118


### PR DESCRIPTION
The docker-compose is meant for running the latest release, not the development branch, and people need to edit it to run the development branch, but this makes it one less thing to edit.