### PR TITLE
Emoji: Fix emoji picker not centering native emoji

### DIFF
--- a/app/javascript/styles/mastodon/emoji_picker.scss
+++ b/app/javascript/styles/mastodon/emoji_picker.scss
@@ -152,6 +152,9 @@
     z-index: 1;
     position: relative;
     text-align: center;
+    display: inline-flex !important;
+    align-items: center;
+    justify-content: center;
   }
 
   &:hover::before {


### PR DESCRIPTION
Fixes #36491 via forcing flexbox to center the emoji. This issue is mostly obvious with Safari, but is there subtly with Firefox. This fix isn't perfect as we're still dealing with sub-pixel centering, but it seems to improve things.

| Browser | Before | After |
| - | - | - |
| Firefox | <img width="636" height="502" alt="Screenshot 2025-10-16 at 13 07 32" src="https://github.com/user-attachments/assets/bf0d7395-c8ff-4057-a87a-7b76d7e7909c" /> | <img width="630" height="508" alt="Screenshot 2025-10-16 at 13 05 28" src="https://github.com/user-attachments/assets/2c2c7d14-3dd2-44dd-9106-a399d8e63801" /> |
| Safari | <img width="604" height="512" alt="Screenshot 2025-10-16 at 13 08 31" src="https://github.com/user-attachments/assets/0e9ffd0a-1d98-4746-ab28-fc652ef5e3fd" /> | <img width="624" height="528" alt="Screenshot 2025-10-16 at 13 08 50" src="https://github.com/user-attachments/assets/810bf08a-c6f4-4c65-8308-d5c28e4e3e95" /> |
| Twemoji (FF) | <img width="662" height="518" alt="Screenshot 2025-10-16 at 13 10 26" src="https://github.com/user-attachments/assets/2bed7832-21c6-4ad7-a3cb-1348ca162587" /> | <img width="662" height="524" alt="Screenshot 2025-10-16 at 13 10 06" src="https://github.com/user-attachments/assets/1a5698fe-5819-498f-9131-22d2510805a3" /> |