### PR TITLE
Add keyboard shortcut info banner to the boosting preferences section

### DIFF
--- a/app/javascript/mastodon/components/hotkeys/hotkeys.stories.tsx
+++ b/app/javascript/mastodon/components/hotkeys/hotkeys.stories.tsx
@@ -139,24 +139,24 @@ export const Default = {
             Last pressed hotkey: <output>{matchedHotkey ?? 'None'}</output>
           </p>
           <p>
-            Click within the dashed border and press the &quot;<kbd>n</kbd>
-            &quot; or &quot;<kbd>/</kbd>&quot; key. Press &quot;
-            <kbd>Backspace</kbd>&quot; to clear the displayed hotkey.
+            Click within the dashed border and press the <kbd>n</kbd>
+            or <kbd>/</kbd> key. Press
+            <kbd>Backspace</kbd> to clear the displayed hotkey.
           </p>
           <p>
-            Try typing a sequence, like &quot;<kbd>g</kbd>&quot; shortly
-            followed by &quot;<kbd>h</kbd>&quot;, &quot;<kbd>n</kbd>&quot;, or
-            &quot;<kbd>f</kbd>&quot;
+            Try typing a sequence, like <kbd>g</kbd> shortly followed by{' '}
+            <kbd>h</kbd>, <kbd>n</kbd>, or
+            <kbd>f</kbd>
           </p>
           <p>
             Note that this playground doesn&apos;t support all hotkeys we use in
             the app.
           </p>
           <p>
-            When a <button>Button</button> is focused, &quot;
+            When a <button>Button</button> is focused,
             <kbd>Enter</kbd>
-            &quot; should not trigger &quot;open&quot;, but &quot;<kbd>o</kbd>
-            &quot; should.
+            should not trigger open, but <kbd>o</kbd>
+            should.
           </p>
           <p>
             When an input element is focused, hotkeys should not interfere with

--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -524,3 +524,7 @@ a.sparkline {
     opacity: 0.25;
   }
 }
+
+kbd {
+  background-color: color.change($ui-highlight-color, $alpha: 0.1);
+}

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -488,6 +488,14 @@ body,
   }
 }
 
+kbd {
+  font-family: Courier, monospace;
+  background-color: color.change($ui-secondary-color, $alpha: 0.1);
+  padding: 4px;
+  padding-bottom: 2px;
+  border-radius: 5px;
+}
+
 .filters {
   display: flex;
   flex-wrap: wrap;

--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -755,6 +755,12 @@ code {
     display: none;
   }
 
+  &.hidden-on-mobile {
+    @media screen and (max-width: $mobile-menu-breakpoint) {
+      display: none;
+    }
+  }
+
   a {
     display: inline-block;
     color: $darker-text-color;

--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -755,8 +755,8 @@ code {
     display: none;
   }
 
-  &.hidden-on-mobile {
-    @media screen and (max-width: $mobile-menu-breakpoint) {
+  &.hidden-on-touch-devices {
+    @media screen and (pointer: coarse) {
       display: none;
     }
   }

--- a/app/views/settings/preferences/appearance/show.html.haml
+++ b/app/views/settings/preferences/appearance/show.html.haml
@@ -72,6 +72,7 @@
 
     .fields-group
       = ff.input :'web.reblog_modal', wrapper: :with_label, hint: I18n.t('simple_form.hints.defaults.setting_boost_modal'), label: I18n.t('simple_form.labels.defaults.setting_boost_modal')
+    .flash-message= t('appearance.boosting_preferences_info_html', icon: material_symbol('repeat'))
 
     %h4= t 'appearance.sensitive_content'
 

--- a/app/views/settings/preferences/appearance/show.html.haml
+++ b/app/views/settings/preferences/appearance/show.html.haml
@@ -72,7 +72,7 @@
 
     .fields-group
       = ff.input :'web.reblog_modal', wrapper: :with_label, hint: I18n.t('simple_form.hints.defaults.setting_boost_modal'), label: I18n.t('simple_form.labels.defaults.setting_boost_modal')
-    .flash-message.hidden-on-mobile= t('appearance.boosting_preferences_info_html', icon: material_symbol('repeat'))
+    .flash-message.hidden-on-touch-devices= t('appearance.boosting_preferences_info_html', icon: material_symbol('repeat'))
 
     %h4= t 'appearance.sensitive_content'
 

--- a/app/views/settings/preferences/appearance/show.html.haml
+++ b/app/views/settings/preferences/appearance/show.html.haml
@@ -72,7 +72,7 @@
 
     .fields-group
       = ff.input :'web.reblog_modal', wrapper: :with_label, hint: I18n.t('simple_form.hints.defaults.setting_boost_modal'), label: I18n.t('simple_form.labels.defaults.setting_boost_modal')
-    .flash-message= t('appearance.boosting_preferences_info_html', icon: material_symbol('repeat'))
+    .flash-message.hidden-on-mobile= t('appearance.boosting_preferences_info_html', icon: material_symbol('repeat'))
 
     %h4= t 'appearance.sensitive_content'
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1189,6 +1189,7 @@ en:
     advanced_settings: Advanced settings
     animations_and_accessibility: Animations and accessibility
     boosting_preferences: Boosting preferences
+    boosting_preferences_info_html: "<strong>Tip:</strong> Regardless of settings, <kbd>Shift</kbd> + <kbd>Click</kbd> on the %{icon} Boost icon will immediately boost."
     discovery: Discovery
     localization:
       body: Mastodon is translated by volunteers.


### PR DESCRIPTION
Fixes MAS-621

### Changes proposed in this PR:
- Adds a new info banner to the Boosting preferences section in the Appearance section of the settings
- Adds new styling for `kbd` elements to admin.scss
- Hides the info banner on devices where touch is the primary input method as the keyboard shortcuts are more likely to not be relevant there

### Screenshots

**Desktop:**
<img width="838" height="247" alt="image" src="https://github.com/user-attachments/assets/8de6857c-dc66-4b6a-aae8-08f2e8933a4b" />

**Mobile:**
<img width="575" height="178" alt="image" src="https://github.com/user-attachments/assets/de7edf44-93c2-4364-b2e3-e26da457f32a" />
