### PR TITLE
Specs for validation error in API responses

### DIFF
--- a/spec/requests/api/v1/accounts/credentials_spec.rb
+++ b/spec/requests/api/v1/accounts/credentials_spec.rb
@@ -91,6 +91,11 @@ RSpec.describe 'credentials API' do
         expect(response).to have_http_status(422)
         expect(response.content_type)
           .to start_with('application/json')
+        expect(response.parsed_body)
+          .to include(
+            error: /Validation failed/,
+            details: include(note: contain_exactly(include(error: 'ERR_TOO_LONG', description: /character limit/)))
+          )
       end
     end
 

--- a/spec/requests/api/v1/accounts_spec.rb
+++ b/spec/requests/api/v1/accounts_spec.rb
@@ -118,6 +118,11 @@ RSpec.describe '/api/v1/accounts' do
             .to have_http_status(422)
           expect(response.content_type)
             .to start_with('application/json')
+          expect(response.parsed_body)
+            .to include(
+              error: /Validation failed/,
+              details: include(date_of_birth: contain_exactly(include(error: 'ERR_BELOW_LIMIT', description: /below the age limit/)))
+            )
         end
       end
 


### PR DESCRIPTION
There are a few spots which use the `ValidationErrorFormatter` class to dump a hash of attribute/errors-array pairs into the failed response.

I have a separate WIP refactor of that class, which I'm not actually sure yet is worthwhile, but in the process of doing that added some specs for placed which use that class, had validation-error-failing specs, but were only checking the 422 response, not the body. Adds some basic assertions about that validation error response.

Will rebase the refactor branch against this and open that only if it winds up useful.