### PR TITLE
Replace ThreadingHelper wait loop with functional CyclicBarrier

### DIFF
--- a/spec/support/threading_helpers.rb
+++ b/spec/support/threading_helpers.rb
@@ -1,17 +1,18 @@
 # frozen_string_literal: true
 
+require 'concurrent/atomic/cyclic_barrier'
+
 module ThreadingHelpers
   def multi_threaded_execution(thread_count)
-    wait_for_start = true
+    barrier = Concurrent::CyclicBarrier.new(thread_count)
 
     threads = Array.new(thread_count) do
       Thread.new do
-        true while wait_for_start
+        barrier.wait
         yield
       end
     end
 
-    wait_for_start = false
     threads.each(&:join)
   end
 end


### PR DESCRIPTION
A Cyclic Barrier is the correct synchronization object to use when trying to get a number of threads to wait together: https://ruby-concurrency.github.io/concurrent-ruby/master/Concurrent/CyclicBarrier.html

The previous pattern was non-functional.  When Ruby does a `Thread.new` there is no guarantee it starts executing that thread immediately. The outer thread just keeps executing through the `wait_for_start = true` and doesn’t stop until the join. Also, if it _did_ work, the `true while wait_for_start` is very inefficient because it doesn't release GVL so each thread would spin for the 100ms quantum instead of immediately yielding to a different thread.

The previous pattern was referenced by another project where I flagged it. I imagine it maybe came from [this blog post](https://blog.arkency.com/2015/09/testing-race-conditions/), but regardless, it doesn't work.
