### PR TITLE
Fix relationship not being fetched to evaluate whether to show a quote post

### DIFF
--- a/app/javascript/mastodon/components/status_quoted.tsx
+++ b/app/javascript/mastodon/components/status_quoted.tsx
@@ -12,6 +12,7 @@ import type { Status } from 'mastodon/models/status';
 import type { RootState } from 'mastodon/store';
 import { useAppDispatch, useAppSelector } from 'mastodon/store';
 
+import { fetchRelationships } from '../actions/accounts';
 import { revealAccount } from '../actions/accounts_typed';
 import { fetchStatus } from '../actions/statuses';
 import { makeGetStatusWithExtraInfo } from '../selectors';
@@ -147,6 +148,10 @@ export const QuotedStatus: React.FC<QuotedStatusProps> = ({
       isFetchingQuoteRef.current = true;
     }
   }, [shouldFetchQuote, quotedStatusId, parentQuotePostId, dispatch]);
+
+  useEffect(() => {
+    if (accountId && hiddenAccount) dispatch(fetchRelationships([accountId]));
+  }, [accountId, hiddenAccount, dispatch]);
 
   const isFilteredAndHidden = loadingState === 'filtered';
 


### PR DESCRIPTION
Fixes #36511

I'm not completely sure how to go about this, I think there are a few issues:
- the relationship data is not immediately fetched (which is made worse by the request being debounced)
- code-wise, it's a bit messy, and I wonder if it shouldn't be a hook instead?