### PR TITLE
Fix position of quote dropdown menu item when “quick boosting” is enabled

### DIFF
--- a/app/javascript/mastodon/components/status_action_bar/index.jsx
+++ b/app/javascript/mastodon/components/status_action_bar/index.jsx
@@ -272,7 +272,11 @@ class StatusActionBar extends ImmutablePureComponent {
     if (publicStatus && 'share' in navigator) {
       menu.push({ text: intl.formatMessage(messages.share), action: this.handleShareClick });
     }
-    
+
+    if (publicStatus && !isRemote) {
+      menu.push({ text: intl.formatMessage(messages.embed), action: this.handleEmbed });
+    }
+
     if (quickBoosting && signedIn) {
       const quoteItem = quoteItemState(statusQuoteState);
       menu.push(null);
@@ -284,11 +288,6 @@ class StatusActionBar extends ImmutablePureComponent {
         disabled: quoteItem.disabled,
         action: this.handleQuoteClick,
       });
-      menu.push(null);
-    }
-
-    if (publicStatus && !isRemote) {
-      menu.push({ text: intl.formatMessage(messages.embed), action: this.handleEmbed });
     }
 
     if (signedIn) {

--- a/app/javascript/mastodon/features/status/components/action_bar.jsx
+++ b/app/javascript/mastodon/features/status/components/action_bar.jsx
@@ -229,6 +229,10 @@ class ActionBar extends PureComponent {
       menu.push({ text: intl.formatMessage(messages.share), action: this.handleShare });
     }
 
+    if (publicStatus && (signedIn || !isRemote)) {
+      menu.push({ text: intl.formatMessage(messages.embed), action: this.handleEmbed });
+    }
+
     if (quickBoosting && signedIn) {
       const quoteItem = quoteItemState(statusQuoteState);
       menu.push(null);
@@ -240,11 +244,6 @@ class ActionBar extends PureComponent {
         disabled: quoteItem.disabled,
         action: this.handleQuoteClick,
       });
-      menu.push(null);
-    }
-
-    if (publicStatus && (signedIn || !isRemote)) {
-      menu.push({ text: intl.formatMessage(messages.embed), action: this.handleEmbed });
     }
 
     if (signedIn) {


### PR DESCRIPTION
This fixes the sharing options being broken into two blocks by the “Quote” option, and fixes the double separator when embedding is not offered.

## Before

<img width="181" height="233" alt="image" src="https://github.com/user-attachments/assets/50f22503-ab25-40f9-8191-c1cb432a8da6" />
<img width="178" height="203" alt="image" src="https://github.com/user-attachments/assets/872d0c9e-32c1-4bb5-98e6-47056a5ae9ea" />
<img width="325" height="226" alt="image" src="https://github.com/user-attachments/assets/0f1a941a-b53e-4186-b5c7-e06f2f5c42be" />
<img width="322" height="234" alt="image" src="https://github.com/user-attachments/assets/cd510882-8a52-4b86-bfe7-ccb19069c8fb" />

## After

<img width="187" height="244" alt="image" src="https://github.com/user-attachments/assets/347f33c8-dd49-4a8e-be7e-c4d84ed3e286" />
<img width="186" height="204" alt="image" src="https://github.com/user-attachments/assets/4fae765b-ed51-4131-acfb-3f32bf6511a0" />
<img width="332" height="226" alt="image" src="https://github.com/user-attachments/assets/cc732629-b647-4eb3-bff5-a657a8ce90e7" />
<img width="322" height="218" alt="image" src="https://github.com/user-attachments/assets/8d5fd213-93cd-4130-a6d8-663c074dc3e6" />
