### PR TITLE
Emoji: Swap mode test to an emoji from 16.0

### DIFF
--- a/app/javascript/mastodon/features/emoji/mode.ts
+++ b/app/javascript/mastodon/features/emoji/mode.ts
@@ -76,7 +76,7 @@ function testEmojiSupport(text: string) {
   return compareFeatures(feature1, feature2);
 }
 
-const EMOJI_VERSION_TEST_EMOJI = '🫨'; // shaking head, from v15
+const EMOJI_VERSION_TEST_EMOJI = '🫩'; // face with bags under eyes, from Unicode 16.0.
 const EMOJI_FLAG_TEST_EMOJI = '🇨🇭';
 
 export function determineEmojiMode(style: string): EmojiMode {


### PR DESCRIPTION
With #36501 we updated the allowed Twemoji to Unicode 16.0. This updates the test for emoji rendering when in `auto` to use an emoji from that version so that Twemoji are displayed if the browser doesn't support 16.0.