### PR TITLE
Emoji: Fix unneeded re-renders when StatusContent changes

### DIFF
--- a/app/javascript/mastodon/components/status_content.jsx
+++ b/app/javascript/mastodon/components/status_content.jsx
@@ -269,7 +269,7 @@ class StatusContent extends PureComponent {
               lang={language}
               htmlString={content}
               extraEmojis={status.get('emojis')}
-              onElement={this.handleElement.bind(this)}
+              onElement={this.handleElement}
             />
 
             {poll}
@@ -287,7 +287,7 @@ class StatusContent extends PureComponent {
             lang={language}
             htmlString={content}
             extraEmojis={status.get('emojis')}
-            onElement={this.handleElement.bind(this)}
+            onElement={this.handleElement}
           />
 
           {poll}

--- a/app/javascript/mastodon/features/notifications_v2/components/embedded_status_content.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/components/embedded_status_content.tsx
@@ -46,11 +46,15 @@ export const EmbeddedStatusContent: React.FC<{
     () => (status.get('mentions') as List<Mention>).toJS(),
     [status],
   );
-  const htmlHandlers = useElementHandledLink({
-    hashtagAccountId: status.get('account') as string | undefined,
-    hrefToMention(href) {
+  const hrefToMention = useCallback(
+    (href: string) => {
       return mentions.find((item) => item.url === href);
     },
+    [mentions],
+  );
+  const htmlHandlers = useElementHandledLink({
+    hashtagAccountId: status.get('account') as string | undefined,
+    hrefToMention,
   });
 
   const handleContentRef = useCallback(


### PR DESCRIPTION
Fixes an issue where the emoji HTML contents were getting re-rendered, causing a tiny height jump.