### PR TITLE
Drop support for PostgreSQL 13

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Mastodon is a **free, open-source social network server** based on [ActivityPub]
 ### Requirements
 
 - **Ruby** 3.2+
-- **PostgreSQL** 13+
+- **PostgreSQL** 14+
 - **Redis** 7.0+
 - **Node.js** 20+
 

--- a/config/initializers/strong_migrations.rb
+++ b/config/initializers/strong_migrations.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
 StrongMigrations.start_after = 2017_09_24_022025
-StrongMigrations.target_version = 13
+StrongMigrations.target_version = 14

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -63,7 +63,7 @@ namespace :db do
 
   task pre_migration_check: :environment do
     pg_version = ActiveRecord::Base.connection.database_version
-    abort 'This version of Mastodon requires PostgreSQL 13.0 or newer. Please update PostgreSQL before updating Mastodon.' if pg_version < 130_000
+    abort 'This version of Mastodon requires PostgreSQL 14.0 or newer. Please update PostgreSQL before updating Mastodon.' if pg_version < 140_000
 
     schema_version = ActiveRecord::Migrator.current_version
     abort <<~MESSAGE if ENV['SKIP_POST_DEPLOYMENT_MIGRATIONS'] && schema_version < 2023_09_07_150100


### PR DESCRIPTION
PG 13 was released 5 years ago, and will no longer be maintained [in 3 weeks](https://endoflife.date/postgresql).

This bumps the minimum version to PG 14.

Note: before the next version bump, we will need to take care of our Compose file (see #32747)