### PR TITLE
Refresh thread replies periodically & when refocusing window

### DIFF
--- a/app/javascript/mastodon/features/status/components/refresh_controller.tsx
+++ b/app/javascript/mastodon/features/status/components/refresh_controller.tsx
@@ -176,17 +176,17 @@ function useCheckForRemoteReplies({
 }
 
 /**
- * This component fetches new replies to a post in the background
- * and displays an alert giving the option to show them in the UI.
+ * This component fetches new post replies in the background
+ * and gives users the option to show them.
  *
  * The following three scenarios are handled:
  *
- * 1. As long as the tab is visible, replies are refetched periodically
+ * 1. When the browser tab is visible, replies are refetched periodically
  *    (more frequently for new posts, less frequently for old ones)
- * 2. Replies are refetched ahen the browser tab/window is refocused
+ * 2. Replies are refetched when the browser tab is refocused
  *    after it was hidden or minimised
- * 3. For remote posts, we check for and fetch remote replies using the
- *    AsyncRefresh API.
+ * 3. For remote posts, remote replies that might not yet be known to the
+ *    server are imported & fetched using the AsyncRefresh API.
  */
 export const RefreshController: React.FC<{
   statusId: string;

--- a/app/javascript/mastodon/features/status/components/refresh_controller.tsx
+++ b/app/javascript/mastodon/features/status/components/refresh_controller.tsx
@@ -224,7 +224,8 @@ export const RefreshController: React.FC<{
     () => {
       void dispatch(fetchContext({ statusId, prefetchOnly: true }));
     },
-    SHORT_AUTO_FETCH_REPLIES_INTERVAL,
+    // Ensure the debounce is a bit shorter than the auto-fetch interval
+    SHORT_AUTO_FETCH_REPLIES_INTERVAL - 500,
     {
       leading: true,
       trailing: false,

--- a/app/javascript/mastodon/features/status/index.jsx
+++ b/app/javascript/mastodon/features/status/index.jsx
@@ -571,14 +571,6 @@ class Status extends ImmutablePureComponent {
     const isLocal = status.getIn(['account', 'acct'], '').indexOf('@') === -1;
     const isIndexable = !status.getIn(['account', 'noindex']);
 
-    if (!isLocal) {
-      remoteHint = (
-        <RefreshController
-          statusId={status.get('id')}
-        />
-      );
-    }
-
     const handlers = {
       reply: this.handleHotkeyReply,
       favourite: this.handleHotkeyFavourite,
@@ -649,7 +641,11 @@ class Status extends ImmutablePureComponent {
             </Hotkeys>
 
             {descendants}
-            {remoteHint}
+            
+            <RefreshController
+              isLocal={isLocal}
+              statusId={status.get('id')}
+            />
           </div>
         </ScrollContainer>
 

--- a/app/javascript/mastodon/features/status/index.jsx
+++ b/app/javascript/mastodon/features/status/index.jsx
@@ -645,6 +645,7 @@ class Status extends ImmutablePureComponent {
             <RefreshController
               isLocal={isLocal}
               statusId={status.get('id')}
+              statusCreatedAt={status.get('created_at')}
             />
           </div>
         </ScrollContainer>

--- a/app/javascript/mastodon/hooks/useInterval.ts
+++ b/app/javascript/mastodon/hooks/useInterval.ts
@@ -1,0 +1,41 @@
+import { useEffect, useLayoutEffect, useRef } from 'react';
+
+/**
+ * Hook to create an interval that invokes a callback function
+ * at a specified delay using the setInterval API.
+ * Based on https://usehooks-ts.com/react-hook/use-interval
+ */
+export function useInterval(
+  callback: () => void,
+  {
+    delay,
+    isEnabled = true,
+  }: {
+    delay: number;
+    isEnabled?: boolean;
+  },
+) {
+  const savedCallback = useRef(callback);
+
+  // Remember the latest callback if it changes.
+  useLayoutEffect(() => {
+    savedCallback.current = callback;
+  }, [callback]);
+
+  // Set up the interval.
+  useEffect(() => {
+    // Don't schedule if no delay is specified.
+    // Note: 0 is a valid value for delay.
+    if (!isEnabled) {
+      return;
+    }
+
+    const id = setInterval(() => {
+      savedCallback.current();
+    }, delay);
+
+    return () => {
+      clearInterval(id);
+    };
+  }, [delay, isEnabled]);
+}

--- a/app/javascript/mastodon/hooks/useInterval.ts
+++ b/app/javascript/mastodon/hooks/useInterval.ts
@@ -15,27 +15,25 @@ export function useInterval(
     isEnabled?: boolean;
   },
 ) {
-  const savedCallback = useRef(callback);
-
-  // Remember the latest callback if it changes.
+  // Write callback to a ref so we can omit it from
+  // the interval effect's dependency array
+  const callbackRef = useRef(callback);
   useLayoutEffect(() => {
-    savedCallback.current = callback;
+    callbackRef.current = callback;
   }, [callback]);
 
   // Set up the interval.
   useEffect(() => {
-    // Don't schedule if no delay is specified.
-    // Note: 0 is a valid value for delay.
     if (!isEnabled) {
       return;
     }
 
-    const id = setInterval(() => {
-      savedCallback.current();
+    const intervalId = setInterval(() => {
+      callbackRef.current();
     }, delay);
 
     return () => {
-      clearInterval(id);
+      clearInterval(intervalId);
     };
   }, [delay, isEnabled]);
 }

--- a/app/javascript/mastodon/hooks/useIsDocumentVisible.ts
+++ b/app/javascript/mastodon/hooks/useIsDocumentVisible.ts
@@ -1,0 +1,32 @@
+import { useEffect, useRef, useState } from 'react';
+
+export function useIsDocumentVisible({
+  onChange,
+}: {
+  onChange?: (isVisible: boolean) => void;
+} = {}) {
+  const [isDocumentVisible, setIsDocumentVisible] = useState(
+    () => document.visibilityState === 'visible',
+  );
+
+  const onChangeRef = useRef(onChange);
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange]);
+
+  useEffect(() => {
+    function handleVisibilityChange() {
+      const isVisible = document.visibilityState === 'visible';
+
+      setIsDocumentVisible(isVisible);
+      onChangeRef.current?.(isVisible);
+    }
+    window.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      window.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, []);
+
+  return isDocumentVisible;
+}


### PR DESCRIPTION
### Changes proposed in this PR:
- Periodically refetch new replies in the background:
   - Every minute for posts that were created within the last 30 minutes
   - Every 5 minutes for posts that are older than 30 minutes
 - Refetch new replies when refocusing the browser tab/window after it was minimised or navigated away from (but at most once every minute)
 - Factors existing `AsyncRefresh` handling out into a separate hook
 - Factors important values out into named constants
 - Added two new utility hooks:
   - `useInterval` to easily make use of `setInterval` in React
   - `useIsDocumentVisible` to easily access the document visibility status and act on changes

### Screencap

For this demonstration, I lowered the refresh interval from 60 to 15 seconds.
It shows:
- When there are no replies yet, new replies are shown immediately
- When there are existing replies, the "More replies found" hint is shown
- Navigating to a different tab and back will trigger a refresh immediately, bypassing the usual refresh interval

https://github.com/user-attachments/assets/e59dfd2a-6cfc-4a6a-a0dd-20fea69c3cb5

