### PR TITLE
Remove unnecessary restrictions on HTML handling

### DIFF
--- a/app/javascript/mastodon/components/status/handled_link.tsx
+++ b/app/javascript/mastodon/components/status/handled_link.tsx
@@ -38,7 +38,7 @@ export const HandledLink: FC<HandledLinkProps & ComponentProps<'a'>> = ({
         {children}
       </Link>
     );
-  } else if ((text.startsWith('@') || prevText?.endsWith('@')) && mention) {
+  } else if (mention) {
     // Handle mentions
     return (
       <Link

--- a/app/javascript/mastodon/components/status_content.jsx
+++ b/app/javascript/mastodon/components/status_content.jsx
@@ -219,7 +219,7 @@ class StatusContent extends PureComponent {
           {children}
         </HandledLink>
       );
-    } else if (element instanceof HTMLParagraphElement && element.classList.contains('quote-inline')) {
+    } else if (element.classList.contains('quote-inline')) {
       return null;
     }
     return undefined;


### PR DESCRIPTION
- we previously had no requirement on the presence of `@` in or outside mention text for a link to be treated as a mention; I do not think this restriction is necessary
- Mastodon outputs quote fallback as a `p` element, but other implementations use different markup. I think we should only take the class into consideration here