### PR TITLE
Change API behavior of reblogs wrt. quotes for consistency

### DIFF
--- a/app/controllers/api/v1/statuses_controller.rb
+++ b/app/controllers/api/v1/statuses_controller.rb
@@ -157,7 +157,7 @@ class Api::V1::StatusesController < Api::BaseController
   end
 
   def set_quoted_status
-    @quoted_status = Status.find(status_params[:quoted_status_id]) if status_params[:quoted_status_id].present?
+    @quoted_status = Status.find(status_params[:quoted_status_id])&.proper if status_params[:quoted_status_id].present?
     authorize(@quoted_status, :quote?) if @quoted_status.present?
   rescue ActiveRecord::RecordNotFound, Mastodon::NotPermittedError
     # TODO: distinguish between non-existing and non-quotable posts

--- a/app/lib/status_cache_hydrator.rb
+++ b/app/lib/status_cache_hydrator.rb
@@ -61,6 +61,7 @@ class StatusCacheHydrator
       payload[:filtered]   = payload[:reblog][:filtered]
       payload[:favourited] = payload[:reblog][:favourited]
       payload[:reblogged]  = payload[:reblog][:reblogged]
+      payload[:quote_approval] = payload[:reblog][:quote_approval]
     end
   end
 

--- a/app/serializers/rest/status_serializer.rb
+++ b/app/serializers/rest/status_serializer.rb
@@ -168,9 +168,9 @@ class REST::StatusSerializer < ActiveModel::Serializer
 
   def quote_approval
     {
-      automatic: object.quote_policy_as_keys(:automatic),
-      manual: object.quote_policy_as_keys(:manual),
-      current_user: object.quote_policy_for_account(current_user&.account),
+      automatic: object.proper.quote_policy_as_keys(:automatic),
+      manual: object.proper.quote_policy_as_keys(:manual),
+      current_user: object.proper.quote_policy_for_account(current_user&.account),
     }
   end
 


### PR DESCRIPTION
Change the API to show the same quote policy for reblogs as for the original status, and treat an attempt to quote a reblog as an attempt to quote the original status.

This is in order to make the API consistent with the boosts, favourite, bookmark and reply features on reblogs.