### PR TITLE
Fix discovery preamble missing word in EN and EN-GB locales

### DIFF
--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -831,7 +831,7 @@ en-GB:
         title: Opt users out of search engine indexing by default
       discovery:
         follow_recommendations: Follow recommendations
-        preamble: Surfacing interesting content is instrumental in onboarding new users who may not know anyone Mastodon. Control how various discovery features work on your server.
+        preamble: Surfacing interesting content is instrumental in onboarding new users who may not know anyone on Mastodon. Control how various discovery features work on your server.
         privacy: Privacy
         profile_directory: Profile directory
         public_timelines: Public timelines

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -837,7 +837,7 @@ en:
         title: Opt users out of search engine indexing by default
       discovery:
         follow_recommendations: Follow recommendations
-        preamble: Surfacing interesting content is instrumental in onboarding new users who may not know anyone Mastodon. Control how various discovery features work on your server.
+        preamble: Surfacing interesting content is instrumental in onboarding new users who may not know anyone on Mastodon. Control how various discovery features work on your server.
         privacy: Privacy
         profile_directory: Profile directory
         public_timelines: Public timelines


### PR DESCRIPTION
I stumbled upon this in the admin settings for content discovery, the text said "Surfacing interesting content is instrumental in onboarding new users who may not know anyone Mastodon." It should read "...who may not know anyone *on* Mastodon" so I've updated it for both the EN and EN-GB locales

![Screenshot_20251022_030817_Waterfox](https://github.com/user-attachments/assets/4de01343-324c-4dd8-8b47-292cbf5528e9)