### PR TITLE
Fix text overflow alignment for long author names in News

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -9375,12 +9375,6 @@ noscript {
       font-size: 14px;
       line-height: 20px;
 
-      & > span {
-        display: flex;
-        align-items: baseline;
-        gap: 4px;
-      }
-
       &__pill {
         background: var(--surface-variant-background-color);
         border-radius: 4px;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -9368,7 +9368,7 @@ noscript {
 
     &__shared {
       display: flex;
-      align-items: center;
+      align-items: baseline;
       color: $darker-text-color;
       gap: 8px;
       justify-content: space-between;
@@ -9377,7 +9377,7 @@ noscript {
 
       & > span {
         display: flex;
-        align-items: center;
+        align-items: baseline;
         gap: 4px;
       }
 
@@ -9390,6 +9390,7 @@ noscript {
         font-size: 12px;
         font-weight: 500;
         line-height: 16px;
+        flex-shrink: 0;
       }
 
       &__author-link {


### PR DESCRIPTION
Fixes #36553

### Changes proposed in this PR:
- Fixes misaligned text wrapping for long authour names in Trending/News

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="493" height="180" alt="image" src="https://github.com/user-attachments/assets/7906b235-fdef-4b91-881b-e32b898e0dd8" /> | <img width="492" height="182" alt="image" src="https://github.com/user-attachments/assets/2cf4d5c3-9f6a-4b92-97e3-a7cd21261858" /> |