### PR TITLE
Add `disabled` setting for live and topic feeds, as well as user permission to bypass that

### DIFF
--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -87,7 +87,7 @@ class Form::AdminSettings
   DESCRIPTION_LIMIT = 200
   DOMAIN_BLOCK_AUDIENCES = %w(disabled users all).freeze
   REGISTRATION_MODES = %w(open approved none).freeze
-  FEED_ACCESS_MODES = %w(public authenticated).freeze
+  FEED_ACCESS_MODES = %w(public authenticated disabled).freeze
 
   attr_accessor(*KEYS)
 

--- a/app/models/link_feed.rb
+++ b/app/models/link_feed.rb
@@ -15,12 +15,16 @@ class LinkFeed < PublicFeed
   # @param [Integer] min_id
   # @return [Array<Status>]
   def get(limit, max_id = nil, since_id = nil, min_id = nil)
+    return [] if (local_only? && !user_has_access_to_feed?(Setting.local_topic_feed_access)) || (remote_only? && !user_has_access_to_feed?(Setting.remote_topic_feed_access))
+
     scope = public_scope
 
     scope.merge!(discoverable)
     scope.merge!(attached_to_preview_card)
     scope.merge!(account_filters_scope) if account?
     scope.merge!(language_scope) if account&.chosen_languages.present?
+    scope.merge!(local_only_scope) unless user_has_access_to_feed?(Setting.remote_topic_feed_access)
+    scope.merge!(remote_only_scope) unless user_has_access_to_feed?(Setting.local_topic_feed_access)
 
     scope.to_a_paginated_by_id(limit, max_id: max_id, since_id: since_id, min_id: min_id)
   end

--- a/app/models/link_feed.rb
+++ b/app/models/link_feed.rb
@@ -16,6 +16,7 @@ class LinkFeed < PublicFeed
   # @return [Array<Status>]
   def get(limit, max_id = nil, since_id = nil, min_id = nil)
     return [] if (local_only? && !user_has_access_to_feed?(Setting.local_topic_feed_access)) || (remote_only? && !user_has_access_to_feed?(Setting.remote_topic_feed_access))
+    return [] unless user_has_access_to_feed?(Setting.local_topic_feed_access) || user_has_access_to_feed?(Setting.remote_topic_feed_access)
 
     scope = public_scope
 

--- a/app/models/public_feed.rb
+++ b/app/models/public_feed.rb
@@ -19,15 +19,14 @@ class PublicFeed
   # @param [Integer] min_id
   # @return [Array<Status>]
   def get(limit, max_id = nil, since_id = nil, min_id = nil)
-    return [] if (local_only? && !user_has_access_to_feed?(Setting.local_live_feed_access)) || (remote_only? && !user_has_access_to_feed?(Setting.remote_live_feed_access))
-    return [] unless user_has_access_to_feed?(Setting.local_live_feed_access) || user_has_access_to_feed?(Setting.remote_live_feed_access)
+    return [] if incompatible_feed_settings?
 
     scope = public_scope
 
     scope.merge!(without_replies_scope) unless with_replies?
     scope.merge!(without_reblogs_scope) unless with_reblogs?
-    scope.merge!(local_only_scope) if local_only? || !user_has_access_to_feed?(Setting.remote_live_feed_access)
-    scope.merge!(remote_only_scope) if remote_only? || !user_has_access_to_feed?(Setting.local_live_feed_access)
+    scope.merge!(local_only_scope) if local_only?
+    scope.merge!(remote_only_scope) if remote_only?
     scope.merge!(account_filters_scope) if account?
     scope.merge!(media_only_scope) if media_only?
     scope.merge!(language_scope) if account&.chosen_languages.present?
@@ -38,6 +37,10 @@ class PublicFeed
   private
 
   attr_reader :account, :options
+
+  def incompatible_feed_settings?
+    (local_only? && !user_has_access_to_feed?(local_feed_setting)) || (remote_only? && !user_has_access_to_feed?(remote_feed_setting))
+  end
 
   def user_has_access_to_feed?(setting)
     case setting
@@ -58,12 +61,20 @@ class PublicFeed
     options[:with_replies]
   end
 
+  def local_feed_setting
+    Setting.local_live_feed_access
+  end
+
+  def remote_feed_setting
+    Setting.remote_live_feed_access
+  end
+
   def local_only?
-    options[:local] && !options[:remote]
+    (options[:local] && !options[:remote]) || !user_has_access_to_feed?(remote_feed_setting)
   end
 
   def remote_only?
-    options[:remote] && !options[:local]
+    (options[:remote] && !options[:local]) || !user_has_access_to_feed?(local_feed_setting)
   end
 
   def account?

--- a/app/models/public_feed.rb
+++ b/app/models/public_feed.rb
@@ -20,6 +20,7 @@ class PublicFeed
   # @return [Array<Status>]
   def get(limit, max_id = nil, since_id = nil, min_id = nil)
     return [] if (local_only? && !user_has_access_to_feed?(Setting.local_live_feed_access)) || (remote_only? && !user_has_access_to_feed?(Setting.remote_live_feed_access))
+    return [] unless user_has_access_to_feed?(Setting.local_live_feed_access) || user_has_access_to_feed?(Setting.remote_live_feed_access)
 
     scope = public_scope
 

--- a/app/models/tag_feed.rb
+++ b/app/models/tag_feed.rb
@@ -23,13 +23,15 @@ class TagFeed < PublicFeed
   # @param [Integer] min_id
   # @return [Array<Status>]
   def get(limit, max_id = nil, since_id = nil, min_id = nil)
+    return [] if (local_only? && !user_has_access_to_feed?(Setting.local_topic_feed_access)) || (remote_only? && !user_has_access_to_feed?(Setting.remote_topic_feed_access))
+
     scope = public_scope
 
     scope.merge!(tagged_with_any_scope)
     scope.merge!(tagged_with_all_scope)
     scope.merge!(tagged_with_none_scope)
-    scope.merge!(local_only_scope) if local_only?
-    scope.merge!(remote_only_scope) if remote_only?
+    scope.merge!(local_only_scope) if local_only? || !user_has_access_to_feed?(Setting.remote_topic_feed_access)
+    scope.merge!(remote_only_scope) if remote_only? || !user_has_access_to_feed?(Setting.local_topic_feed_access)
     scope.merge!(account_filters_scope) if account?
     scope.merge!(media_only_scope) if media_only?
 

--- a/app/models/tag_feed.rb
+++ b/app/models/tag_feed.rb
@@ -24,6 +24,7 @@ class TagFeed < PublicFeed
   # @return [Array<Status>]
   def get(limit, max_id = nil, since_id = nil, min_id = nil)
     return [] if (local_only? && !user_has_access_to_feed?(Setting.local_topic_feed_access)) || (remote_only? && !user_has_access_to_feed?(Setting.remote_topic_feed_access))
+    return [] unless user_has_access_to_feed?(Setting.local_topic_feed_access) || user_has_access_to_feed?(Setting.remote_topic_feed_access)
 
     scope = public_scope
 

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -36,6 +36,7 @@ class UserRole < ApplicationRecord
     manage_roles: (1 << 17),
     manage_user_access: (1 << 18),
     delete_user_data: (1 << 19),
+    view_feeds: (1 << 20),
   }.freeze
 
   EVERYONE_ROLE_ID = -99
@@ -67,6 +68,7 @@ class UserRole < ApplicationRecord
         manage_blocks
         manage_taxonomies
         manage_invites
+        view_feeds
       ).freeze,
 
       administration: %i(

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -796,6 +796,8 @@ en:
         view_dashboard_description: Allows users to access the dashboard and various metrics
         view_devops: DevOps
         view_devops_description: Allows users to access Sidekiq and pgHero dashboards
+        view_feeds: View live and topic feeds
+        view_feeds_description: Allows users to access the live and topic feeds regardless of server settings
       title: Roles
     rules:
       add_new: Add rule
@@ -851,6 +853,7 @@ en:
       feed_access:
         modes:
           authenticated: Authenticated users only
+          disabled: Require specific user role
           public: Everyone
       registrations:
         moderation_recommandation: Please make sure you have an adequate and reactive moderation team before you open registrations to everyone!

--- a/config/roles.yml
+++ b/config/roles.yml
@@ -4,6 +4,7 @@ moderator:
   permissions:
     - view_dashboard
     - view_audit_log
+    - view_feeds
     - manage_users
     - manage_reports
     - manage_taxonomies

--- a/spec/models/public_feed_spec.rb
+++ b/spec/models/public_feed_spec.rb
@@ -203,6 +203,117 @@ RSpec.describe PublicFeed do
       end
     end
 
+    context 'when both local_live_feed_access and remote_live_feed_access are disabled' do
+      before do
+        Setting.local_live_feed_access = 'disabled'
+        Setting.remote_live_feed_access = 'disabled'
+      end
+
+      context 'without local_only option' do
+        subject { described_class.new(viewer).get(20).map(&:id) }
+
+        let(:viewer) { nil }
+
+        let!(:local_account)  { Fabricate(:account, domain: nil) }
+        let!(:remote_account) { Fabricate(:account, domain: 'test.com') }
+        let!(:local_status)   { Fabricate(:status, account: local_account) }
+        let!(:remote_status)  { Fabricate(:status, account: remote_account) }
+
+        context 'without a viewer' do
+          let(:viewer) { nil }
+
+          it 'returns an empty list' do
+            expect(subject).to be_empty
+          end
+        end
+
+        context 'with a viewer' do
+          let(:viewer) { Fabricate(:account, username: 'viewer') }
+
+          it 'returns an empty list' do
+            expect(subject).to be_empty
+          end
+        end
+
+        context 'with a moderator as viewer' do
+          let(:viewer) { Fabricate(:moderator_user).account }
+
+          it 'includes all expected statuses' do
+            expect(subject).to include(local_status.id)
+            expect(subject).to include(remote_status.id)
+          end
+        end
+      end
+
+      context 'with a local_only option set' do
+        subject { described_class.new(viewer, local: true).get(20).map(&:id) }
+
+        let!(:local_account)  { Fabricate(:account, domain: nil) }
+        let!(:remote_account) { Fabricate(:account, domain: 'test.com') }
+        let!(:local_status)   { Fabricate(:status, account: local_account) }
+        let!(:remote_status)  { Fabricate(:status, account: remote_account) }
+
+        context 'without a viewer' do
+          let(:viewer) { nil }
+
+          it 'returns an empty list' do
+            expect(subject).to be_empty
+          end
+        end
+
+        context 'with a viewer' do
+          let(:viewer) { Fabricate(:account, username: 'viewer') }
+
+          it 'returns an empty list' do
+            expect(subject).to be_empty
+          end
+        end
+
+        context 'with a moderator as viewer' do
+          let(:viewer) { Fabricate(:moderator_user).account }
+
+          it 'does not include remote instances statuses' do
+            expect(subject).to include(local_status.id)
+            expect(subject).to_not include(remote_status.id)
+          end
+        end
+      end
+
+      context 'with a remote_only option set' do
+        subject { described_class.new(viewer, remote: true).get(20).map(&:id) }
+
+        let!(:local_account)  { Fabricate(:account, domain: nil) }
+        let!(:remote_account) { Fabricate(:account, domain: 'test.com') }
+        let!(:local_status)   { Fabricate(:status, account: local_account) }
+        let!(:remote_status)  { Fabricate(:status, account: remote_account) }
+
+        context 'without a viewer' do
+          let(:viewer) { nil }
+
+          it 'returns an empty list' do
+            expect(subject).to be_empty
+          end
+        end
+
+        context 'with a viewer' do
+          let(:viewer) { Fabricate(:account, username: 'viewer') }
+
+          it 'returns an empty list' do
+            expect(subject).to be_empty
+          end
+        end
+
+        context 'with a moderator as viewer' do
+          let(:viewer) { Fabricate(:moderator_user).account }
+
+          it 'includes remote statuses only' do
+            expect(subject).to_not include(local_status.id)
+            expect(subject).to include(remote_status.id)
+          end
+        end
+      end
+    end
+
     context 'when local_live_feed_access is disabled' do
       before do
         Setting.local_live_feed_access = 'disabled'

--- a/spec/models/public_feed_spec.rb
+++ b/spec/models/public_feed_spec.rb
@@ -202,5 +202,209 @@ RSpec.describe PublicFeed do
         end
       end
     end
+
+    context 'when local_live_feed_access is disabled' do
+      before do
+        Setting.local_live_feed_access = 'disabled'
+      end
+
+      context 'without local_only option' do
+        subject { described_class.new(viewer).get(20).map(&:id) }
+
+        let(:viewer) { nil }
+
+        let!(:local_account)  { Fabricate(:account, domain: nil) }
+        let!(:remote_account) { Fabricate(:account, domain: 'test.com') }
+        let!(:local_status)   { Fabricate(:status, account: local_account) }
+        let!(:remote_status)  { Fabricate(:status, account: remote_account) }
+
+        context 'without a viewer' do
+          let(:viewer) { nil }
+
+          it 'does not include local instances statuses' do
+            expect(subject).to_not include(local_status.id)
+            expect(subject).to include(remote_status.id)
+          end
+        end
+
+        context 'with a viewer' do
+          let(:viewer) { Fabricate(:account, username: 'viewer') }
+
+          it 'does not include local instances statuses' do
+            expect(subject).to_not include(local_status.id)
+            expect(subject).to include(remote_status.id)
+          end
+        end
+      end
+
+      context 'with a local_only option set' do
+        subject { described_class.new(viewer, local: true).get(20).map(&:id) }
+
+        let!(:local_account)  { Fabricate(:account, domain: nil) }
+        let!(:remote_account) { Fabricate(:account, domain: 'test.com') }
+        let!(:local_status)   { Fabricate(:status, account: local_account) }
+        let!(:remote_status)  { Fabricate(:status, account: remote_account) }
+
+        context 'without a viewer' do
+          let(:viewer) { nil }
+
+          it 'returns an empty list' do
+            expect(subject).to be_empty
+          end
+        end
+
+        context 'with a viewer' do
+          let(:viewer) { Fabricate(:account, username: 'viewer') }
+
+          it 'returns an empty list' do
+            expect(subject).to be_empty
+          end
+        end
+
+        context 'with a moderator as viewer' do
+          let(:viewer) { Fabricate(:moderator_user).account }
+
+          it 'does not include remote instances statuses' do
+            expect(subject).to include(local_status.id)
+            expect(subject).to_not include(remote_status.id)
+          end
+        end
+      end
+
+      context 'with a remote_only option set' do
+        subject { described_class.new(viewer, remote: true).get(20).map(&:id) }
+
+        let!(:local_account)  { Fabricate(:account, domain: nil) }
+        let!(:remote_account) { Fabricate(:account, domain: 'test.com') }
+        let!(:local_status)   { Fabricate(:status, account: local_account) }
+        let!(:remote_status)  { Fabricate(:status, account: remote_account) }
+
+        context 'without a viewer' do
+          let(:viewer) { nil }
+
+          it 'does not include local instances statuses' do
+            expect(subject).to_not include(local_status.id)
+            expect(subject).to include(remote_status.id)
+          end
+        end
+
+        context 'with a viewer' do
+          let(:viewer) { Fabricate(:account, username: 'viewer') }
+
+          it 'does not include local instances statuses' do
+            expect(subject).to_not include(local_status.id)
+            expect(subject).to include(remote_status.id)
+          end
+        end
+      end
+    end
+
+    context 'when remote_live_feed_access is disabled' do
+      before do
+        Setting.remote_live_feed_access = 'disabled'
+      end
+
+      context 'without local_only option' do
+        subject { described_class.new(viewer).get(20).map(&:id) }
+
+        let(:viewer) { nil }
+
+        let!(:local_account)  { Fabricate(:account, domain: nil) }
+        let!(:remote_account) { Fabricate(:account, domain: 'test.com') }
+        let!(:local_status)   { Fabricate(:status, account: local_account) }
+        let!(:remote_status)  { Fabricate(:status, account: remote_account) }
+
+        context 'without a viewer' do
+          let(:viewer) { nil }
+
+          it 'does not include remote instances statuses' do
+            expect(subject).to include(local_status.id)
+            expect(subject).to_not include(remote_status.id)
+          end
+        end
+
+        context 'with a viewer' do
+          let(:viewer) { Fabricate(:account, username: 'viewer') }
+
+          it 'does not include remote instances statuses' do
+            expect(subject).to include(local_status.id)
+            expect(subject).to_not include(remote_status.id)
+          end
+
+          it 'is not affected by personal domain blocks' do
+            viewer.block_domain!('test.com')
+            expect(subject).to include(local_status.id)
+            expect(subject).to_not include(remote_status.id)
+          end
+        end
+      end
+
+      context 'with a local_only option set' do
+        subject { described_class.new(viewer, local: true).get(20).map(&:id) }
+
+        let!(:local_account)  { Fabricate(:account, domain: nil) }
+        let!(:remote_account) { Fabricate(:account, domain: 'test.com') }
+        let!(:local_status)   { Fabricate(:status, account: local_account) }
+        let!(:remote_status)  { Fabricate(:status, account: remote_account) }
+
+        context 'without a viewer' do
+          let(:viewer) { nil }
+
+          it 'does not include remote instances statuses' do
+            expect(subject).to include(local_status.id)
+            expect(subject).to_not include(remote_status.id)
+          end
+        end
+
+        context 'with a viewer' do
+          let(:viewer) { Fabricate(:account, username: 'viewer') }
+
+          it 'does not include remote instances statuses' do
+            expect(subject).to include(local_status.id)
+            expect(subject).to_not include(remote_status.id)
+          end
+
+          it 'is not affected by personal domain blocks' do
+            viewer.block_domain!('test.com')
+            expect(subject).to include(local_status.id)
+            expect(subject).to_not include(remote_status.id)
+          end
+        end
+      end
+
+      context 'with a remote_only option set' do
+        subject { described_class.new(viewer, remote: true).get(20).map(&:id) }
+
+        let!(:local_account)  { Fabricate(:account, domain: nil) }
+        let!(:remote_account) { Fabricate(:account, domain: 'test.com') }
+        let!(:local_status)   { Fabricate(:status, account: local_account) }
+        let!(:remote_status)  { Fabricate(:status, account: remote_account) }
+
+        context 'without a viewer' do
+          let(:viewer) { nil }
+
+          it 'returns an empty list' do
+            expect(subject).to be_empty
+          end
+        end
+
+        context 'with a viewer' do
+          let(:viewer) { Fabricate(:account, username: 'viewer') }
+
+          it 'returns an empty list' do
+            expect(subject).to be_empty
+          end
+        end
+
+        context 'with a moderator as viewer' do
+          let(:viewer) { Fabricate(:moderator_user).account }
+
+          it 'does not include local instances statuses' do
+            expect(subject).to_not include(local_status.id)
+            expect(subject).to include(remote_status.id)
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/models/tag_feed_spec.rb
+++ b/spec/models/tag_feed_spec.rb
@@ -67,6 +67,114 @@ RSpec.describe TagFeed do
       expect(results).to include(status)
     end
 
+    context 'when both local_topic_feed_access and remote_topic_feed_access are disabled' do
+      before do
+        Setting.local_topic_feed_access = 'disabled'
+        Setting.remote_topic_feed_access = 'disabled'
+      end
+
+      context 'without local_only option' do
+        subject { described_class.new(tag_cats, viewer).get(20).map(&:id) }
+
+        let(:viewer) { nil }
+
+        let!(:remote_account) { Fabricate(:account, domain: 'test.com') }
+        let!(:local_status)   { status_tagged_with_cats }
+        let!(:remote_status)  { Fabricate(:status, account: remote_account, tags: [tag_cats]) }
+
+        context 'without a viewer' do
+          let(:viewer) { nil }
+
+          it 'returns an empty list' do
+            expect(subject).to be_empty
+          end
+        end
+
+        context 'with a viewer' do
+          let(:viewer) { Fabricate(:account, username: 'viewer') }
+
+          it 'returns an empty list' do
+            expect(subject).to be_empty
+          end
+        end
+
+        context 'with a moderator as viewer' do
+          let(:viewer) { Fabricate(:moderator_user).account }
+
+          it 'includes all expected statuses' do
+            expect(subject).to include(local_status.id)
+            expect(subject).to include(remote_status.id)
+          end
+        end
+      end
+
+      context 'with a local_only option set' do
+        subject { described_class.new(tag_cats, viewer, local: true).get(20).map(&:id) }
+
+        let!(:remote_account) { Fabricate(:account, domain: 'test.com') }
+        let!(:local_status)   { status_tagged_with_cats }
+        let!(:remote_status)  { Fabricate(:status, account: remote_account, tags: [tag_cats]) }
+
+        context 'without a viewer' do
+          let(:viewer) { nil }
+
+          it 'returns an empty list' do
+            expect(subject).to be_empty
+          end
+        end
+
+        context 'with a viewer' do
+          let(:viewer) { Fabricate(:account, username: 'viewer') }
+
+          it 'returns an empty list' do
+            expect(subject).to be_empty
+          end
+        end
+
+        context 'with a moderator as viewer' do
+          let(:viewer) { Fabricate(:moderator_user).account }
+
+          it 'does not include remote instances statuses' do
+            expect(subject).to include(local_status.id)
+            expect(subject).to_not include(remote_status.id)
+          end
+        end
+      end
+
+      context 'with a remote_only option set' do
+        subject { described_class.new(tag_cats, viewer, remote: true).get(20).map(&:id) }
+
+        let!(:remote_account) { Fabricate(:account, domain: 'test.com') }
+        let!(:local_status)   { status_tagged_with_cats }
+        let!(:remote_status)  { Fabricate(:status, account: remote_account, tags: [tag_cats]) }
+
+        context 'without a viewer' do
+          let(:viewer) { nil }
+
+          it 'returns an empty list' do
+            expect(subject).to be_empty
+          end
+        end
+
+        context 'with a viewer' do
+          let(:viewer) { Fabricate(:account, username: 'viewer') }
+
+          it 'returns an empty list' do
+            expect(subject).to be_empty
+          end
+        end
+
+        context 'with a moderator as viewer' do
+          let(:viewer) { Fabricate(:moderator_user).account }
+
+          it 'includes remote statuses only' do
+            expect(subject).to_not include(local_status.id)
+            expect(subject).to include(remote_status.id)
+          end
+        end
+      end
+    end
+
     context 'when local_topic_feed_access is disabled' do
       before do
         Setting.local_topic_feed_access = 'disabled'

--- a/spec/models/tag_feed_spec.rb
+++ b/spec/models/tag_feed_spec.rb
@@ -66,5 +66,203 @@ RSpec.describe TagFeed do
       results = described_class.new(tag_cats, nil).get(20)
       expect(results).to include(status)
     end
+
+    context 'when local_topic_feed_access is disabled' do
+      before do
+        Setting.local_topic_feed_access = 'disabled'
+      end
+
+      context 'without local_only option' do
+        subject { described_class.new(tag_cats, viewer).get(20).map(&:id) }
+
+        let(:viewer) { nil }
+
+        let!(:remote_account) { Fabricate(:account, domain: 'test.com') }
+        let!(:local_status)   { status_tagged_with_cats }
+        let!(:remote_status)  { Fabricate(:status, account: remote_account, tags: [tag_cats]) }
+
+        context 'without a viewer' do
+          let(:viewer) { nil }
+
+          it 'does not include local instances statuses' do
+            expect(subject).to_not include(local_status.id)
+            expect(subject).to include(remote_status.id)
+          end
+        end
+
+        context 'with a viewer' do
+          let(:viewer) { Fabricate(:account, username: 'viewer') }
+
+          it 'does not include local instances statuses' do
+            expect(subject).to_not include(local_status.id)
+            expect(subject).to include(remote_status.id)
+          end
+        end
+      end
+
+      context 'with a local_only option set' do
+        subject { described_class.new(tag_cats, viewer, local: true).get(20).map(&:id) }
+
+        let!(:remote_account) { Fabricate(:account, domain: 'test.com') }
+        let!(:local_status)   { status_tagged_with_cats }
+        let!(:remote_status)  { Fabricate(:status, account: remote_account, tags: [tag_cats]) }
+
+        context 'without a viewer' do
+          let(:viewer) { nil }
+
+          it 'returns an empty list' do
+            expect(subject).to be_empty
+          end
+        end
+
+        context 'with a viewer' do
+          let(:viewer) { Fabricate(:account, username: 'viewer') }
+
+          it 'returns an empty list' do
+            expect(subject).to be_empty
+          end
+        end
+
+        context 'with a moderator as viewer' do
+          let(:viewer) { Fabricate(:moderator_user).account }
+
+          it 'does not include remote instances statuses' do
+            expect(subject).to include(local_status.id)
+            expect(subject).to_not include(remote_status.id)
+          end
+        end
+      end
+
+      context 'with a remote_only option set' do
+        subject { described_class.new(tag_cats, viewer, remote: true).get(20).map(&:id) }
+
+        let!(:remote_account) { Fabricate(:account, domain: 'test.com') }
+        let!(:local_status)   { status_tagged_with_cats }
+        let!(:remote_status)  { Fabricate(:status, account: remote_account, tags: [tag_cats]) }
+
+        context 'without a viewer' do
+          let(:viewer) { nil }
+
+          it 'does not include local instances statuses' do
+            expect(subject).to_not include(local_status.id)
+            expect(subject).to include(remote_status.id)
+          end
+        end
+
+        context 'with a viewer' do
+          let(:viewer) { Fabricate(:account, username: 'viewer') }
+
+          it 'does not include local instances statuses' do
+            expect(subject).to_not include(local_status.id)
+            expect(subject).to include(remote_status.id)
+          end
+        end
+      end
+    end
+
+    context 'when remote_topic_feed_access is disabled' do
+      before do
+        Setting.remote_topic_feed_access = 'disabled'
+      end
+
+      context 'without local_only option' do
+        subject { described_class.new(tag_cats, viewer).get(20).map(&:id) }
+
+        let(:viewer) { nil }
+
+        let!(:remote_account) { Fabricate(:account, domain: 'test.com') }
+        let!(:local_status)   { status_tagged_with_cats }
+        let!(:remote_status)  { Fabricate(:status, account: remote_account, tags: [tag_cats]) }
+
+        context 'without a viewer' do
+          let(:viewer) { nil }
+
+          it 'does not include remote instances statuses' do
+            expect(subject).to include(local_status.id)
+            expect(subject).to_not include(remote_status.id)
+          end
+        end
+
+        context 'with a viewer' do
+          let(:viewer) { Fabricate(:account, username: 'viewer') }
+
+          it 'does not include remote instances statuses' do
+            expect(subject).to include(local_status.id)
+            expect(subject).to_not include(remote_status.id)
+          end
+
+          it 'is not affected by personal domain blocks' do
+            viewer.block_domain!('test.com')
+            expect(subject).to include(local_status.id)
+            expect(subject).to_not include(remote_status.id)
+          end
+        end
+      end
+
+      context 'with a local_only option set' do
+        subject { described_class.new(tag_cats, viewer, local: true).get(20).map(&:id) }
+
+        let!(:remote_account) { Fabricate(:account, domain: 'test.com') }
+        let!(:local_status)   { status_tagged_with_cats }
+        let!(:remote_status)  { Fabricate(:status, account: remote_account, tags: [tag_cats]) }
+
+        context 'without a viewer' do
+          let(:viewer) { nil }
+
+          it 'does not include remote instances statuses' do
+            expect(subject).to include(local_status.id)
+            expect(subject).to_not include(remote_status.id)
+          end
+        end
+
+        context 'with a viewer' do
+          let(:viewer) { Fabricate(:account, username: 'viewer') }
+
+          it 'does not include remote instances statuses' do
+            expect(subject).to include(local_status.id)
+            expect(subject).to_not include(remote_status.id)
+          end
+
+          it 'is not affected by personal domain blocks' do
+            viewer.block_domain!('test.com')
+            expect(subject).to include(local_status.id)
+            expect(subject).to_not include(remote_status.id)
+          end
+        end
+      end
+
+      context 'with a remote_only option set' do
+        subject { described_class.new(tag_cats, viewer, remote: true).get(20).map(&:id) }
+
+        let!(:remote_account) { Fabricate(:account, domain: 'test.com') }
+        let!(:local_status)   { status_tagged_with_cats }
+        let!(:remote_status)  { Fabricate(:status, account: remote_account, tags: [tag_cats]) }
+
+        context 'without a viewer' do
+          let(:viewer) { nil }
+
+          it 'returns an empty list' do
+            expect(subject).to be_empty
+          end
+        end
+
+        context 'with a viewer' do
+          let(:viewer) { Fabricate(:account, username: 'viewer') }
+
+          it 'returns an empty list' do
+            expect(subject).to be_empty
+          end
+        end
+
+        context 'with a moderator as viewer' do
+          let(:viewer) { Fabricate(:moderator_user).account }
+
+          it 'does not include local instances statuses' do
+            expect(subject).to_not include(local_status.id)
+            expect(subject).to include(remote_status.id)
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## New server settings values to disable topic and live feeds

This adds a new `disabled` value for `live_feeds.local`, `live_feeds.remote`, `hashtag_feeds.local`, `hashtag_feeds.remote`, `trending_link_feeds.local` and `trending_link_feeds.remote`.

This will allow authenticated access to the endpoints, but prevent local or remote content form appearing in the response according to settings.

<img width="844" height="236" alt="image" src="https://github.com/user-attachments/assets/6bc51692-894d-4291-80bd-0f4627977705" />

## New user permission

Intended for moderators doing proactive moderation of content, there is a new permission to always allow access to live and topic feeds regardless of settings.

<img width="471" height="117" alt="image" src="https://github.com/user-attachments/assets/3f3c7aab-153c-4042-b8b0-35a9b70a3e16" />