### PR TITLE
Rename feed access setting values for consistency with domain block audiences

### DIFF
--- a/app/controllers/api/v1/timelines/public_controller.rb
+++ b/app/controllers/api/v1/timelines/public_controller.rb
@@ -16,11 +16,11 @@ class Api::V1::Timelines::PublicController < Api::V1::Timelines::BaseController
 
   def require_auth?
     if truthy_param?(:local)
-      Setting.local_live_feed_access != 'public'
+      Setting.local_live_feed_access != 'all'
     elsif truthy_param?(:remote)
-      Setting.remote_live_feed_access != 'public'
+      Setting.remote_live_feed_access != 'all'
     else
-      Setting.local_live_feed_access != 'public' || Setting.remote_live_feed_access != 'public'
+      Setting.local_live_feed_access != 'all' || Setting.remote_live_feed_access != 'all'
     end
   end
 

--- a/app/controllers/api/v1/timelines/topic_controller.rb
+++ b/app/controllers/api/v1/timelines/topic_controller.rb
@@ -7,11 +7,11 @@ class Api::V1::Timelines::TopicController < Api::V1::Timelines::BaseController
 
   def require_auth?
     if truthy_param?(:local)
-      Setting.local_topic_feed_access != 'public'
+      Setting.local_topic_feed_access != 'all'
     elsif truthy_param?(:remote)
-      Setting.remote_topic_feed_access != 'public'
+      Setting.remote_topic_feed_access != 'all'
     else
-      Setting.local_topic_feed_access != 'public' || Setting.remote_topic_feed_access != 'public'
+      Setting.local_topic_feed_access != 'all' || Setting.remote_topic_feed_access != 'all'
     end
   end
 end

--- a/app/javascript/mastodon/initial_state.ts
+++ b/app/javascript/mastodon/initial_state.ts
@@ -33,10 +33,10 @@ interface InitialStateMeta {
   single_user_mode: boolean;
   source_url: string;
   streaming_api_base_url: string;
-  local_live_feed_access: 'public' | 'authenticated' | 'disabled';
-  remote_live_feed_access: 'public' | 'authenticated' | 'disabled';
-  local_topic_feed_access: 'public' | 'authenticated' | 'disabled';
-  remote_topic_feed_access: 'public' | 'authenticated' | 'disabled';
+  local_live_feed_access: 'all' | 'users' | 'disabled';
+  remote_live_feed_access: 'all' | 'users' | 'disabled';
+  local_topic_feed_access: 'all' | 'users' | 'disabled';
+  remote_topic_feed_access: 'all' | 'users' | 'disabled';
   title: string;
   show_trends: boolean;
   trends_as_landing_page: boolean;

--- a/app/javascript/mastodon/permissions.ts
+++ b/app/javascript/mastodon/permissions.ts
@@ -27,12 +27,12 @@ export function canManageReports(permissions: number) {
 export const canViewFeed = (
   signedIn: boolean,
   permissions: number,
-  setting: 'public' | 'authenticated' | 'disabled' | undefined,
+  setting: 'all' | 'users' | 'disabled' | undefined,
 ) => {
   switch (setting) {
-    case 'public':
+    case 'all':
       return true;
-    case 'authenticated':
+    case 'users':
       return signedIn;
     case 'disabled':
     default:

--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -87,7 +87,7 @@ class Form::AdminSettings
   DESCRIPTION_LIMIT = 200
   DOMAIN_BLOCK_AUDIENCES = %w(disabled users all).freeze
   REGISTRATION_MODES = %w(open approved none).freeze
-  FEED_ACCESS_MODES = %w(public authenticated disabled).freeze
+  FEED_ACCESS_MODES = %w(all users disabled).freeze
 
   attr_accessor(*KEYS)
 

--- a/app/models/public_feed.rb
+++ b/app/models/public_feed.rb
@@ -44,9 +44,9 @@ class PublicFeed
 
   def user_has_access_to_feed?(setting)
     case setting
-    when 'public'
+    when 'public', 'all'
       true
-    when 'authenticated'
+    when 'authenticated', 'users'
       @account&.user&.functional?
     when 'disabled'
       @account&.user&.can?(:view_feeds)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -852,9 +852,9 @@ en:
         users: To logged-in local users
       feed_access:
         modes:
-          authenticated: Authenticated users only
+          all: Everyone
           disabled: Require specific user role
-          public: Everyone
+          users: Authenticated users only
       registrations:
         moderation_recommandation: Please make sure you have an adequate and reactive moderation team before you open registrations to everyone!
         preamble: Control who can create an account on your server.

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -12,10 +12,10 @@ defaults: &defaults
   registrations_mode: 'none'
   profile_directory: true
   closed_registrations_message: ''
-  local_live_feed_access: 'public'
-  remote_live_feed_access: 'public'
-  local_topic_feed_access: 'public'
-  remote_topic_feed_access: 'public'
+  local_live_feed_access: 'all'
+  remote_live_feed_access: 'all'
+  local_topic_feed_access: 'all'
+  remote_topic_feed_access: 'all'
   show_staff_badge: true
   preview_sensitive_media: false
   noindex: false

--- a/db/migrate/20251023125005_migrate_feed_access_values.rb
+++ b/db/migrate/20251023125005_migrate_feed_access_values.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class MigrateFeedAccessValues < ActiveRecord::Migration[8.0]
+  class Setting < ApplicationRecord; end
+
+  def up
+    %w(local_live_feed_access remote_live_feed_access local_topic_feed_access remote_topic_feed_access).each do |var|
+      setting = Setting.find_by(var: var)
+      next unless setting.present? && setting.attributes['value'].present?
+
+      value = YAML.safe_load(setting.attributes['value'], permitted_classes: [ActiveSupport::HashWithIndifferentAccess, Symbol])
+
+      case value
+      when 'public'
+        setting.update(value: "--- all\n")
+      when 'authenticated'
+        setting.update(value: "--- users\n")
+      end
+    end
+  end
+
+  def down; end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_07_142305) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_23_125005) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 


### PR DESCRIPTION
This changes the `public` and `authenticated` values to `all` and `users` respectively, for consistency with `show_domain_blocks`.

The values this changes are undocumented, but they have landed in 4.5.0-beta.1, so I'm not sure this is actually worth changing.