### PR TITLE
Update stoplight to version 5.4.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -834,7 +834,7 @@ GEM
     stackprof (0.2.27)
     starry (0.2.0)
       base64
-    stoplight (5.3.8)
+    stoplight (5.4.0)
       zeitwerk
     stringio (3.1.7)
     strong_migrations (2.5.1)

--- a/spec/controllers/concerns/api/error_handling_spec.rb
+++ b/spec/controllers/concerns/api/error_handling_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Api::ErrorHandling do
       Mastodon::ValidationError => 422,
       OpenSSL::SSL::SSLError => 503,
       Seahorse::Client::NetworkingError => 503,
-      Stoplight::Error::RedLight => 503,
+      Stoplight::Error::RedLight.new(:name, cool_off_time: 1, retry_after: 1) => 503,
     }.each do |error, code|
       it "Handles error class of #{error}" do
         allow(FakeService)


### PR DESCRIPTION
Replaces https://github.com/mastodon/mastodon/pull/36579

Version bump from that PR plus a signature change in a spec for how errors are generated. I don't think we directly generate any of these errors other than this spec (we catch them, but all generation is stoplight-internal).