### PR TITLE
Fix "new post highlighting" in threads being applied when navigating between posts

### DIFF
--- a/app/javascript/mastodon/features/status/index.jsx
+++ b/app/javascript/mastodon/features/status/index.jsx
@@ -504,12 +504,14 @@ class Status extends ImmutablePureComponent {
   componentDidUpdate (prevProps) {
     const { status, ancestorsIds, descendantsIds } = this.props;
 
-    if (status && (ancestorsIds.length > prevProps.ancestorsIds.length || prevProps.status?.get('id') !== status.get('id'))) {
+    const isSameStatus = status && (prevProps.status?.get('id') === status.get('id'));
+
+    if (status && (ancestorsIds.length > prevProps.ancestorsIds.length || !isSameStatus)) {
       this._scrollStatusIntoView();
     }
 
     // Only highlight replies after the initial load
-    if (prevProps.descendantsIds.length) {
+    if (prevProps.descendantsIds.length && isSameStatus) {
       const newRepliesIds = difference(descendantsIds, prevProps.descendantsIds);
       
       if (newRepliesIds.length) {


### PR DESCRIPTION
### Changes proposed in this PR:
- Fixes the "new post highlight" (flash of the background colour) being applied too liberally – not just when new posts are rendered, but also when simply clicking on different posts within the same thread

### Screenshots

**Before**


https://github.com/user-attachments/assets/fde077a3-0d3e-43df-9daf-43b6f9cc43f6


 **After**

https://github.com/user-attachments/assets/047f750b-5516-49be-a29e-f77f23c28ad9

