### PR TITLE
Handle unreachable network error for search services

### DIFF
--- a/app/services/account_search_service.rb
+++ b/app/services/account_search_service.rb
@@ -256,7 +256,7 @@ class AccountSearchService < BaseService
     ActiveRecord::Associations::Preloader.new(records: records, associations: [:account_stat, { user: :role }]).call
 
     records
-  rescue Faraday::ConnectionFailed, Parslet::ParseFailed
+  rescue Faraday::ConnectionFailed, Parslet::ParseFailed, Errno::ENETUNREACH
     nil
   end
 

--- a/app/services/statuses_search_service.rb
+++ b/app/services/statuses_search_service.rb
@@ -32,7 +32,7 @@ class StatusesSearchService < BaseService
     preloaded_relations = @account.relations_map(account_ids, account_domains)
 
     results.reject { |status| StatusFilter.new(status, @account, preloaded_relations).filtered? }
-  rescue Faraday::ConnectionFailed, Parslet::ParseFailed
+  rescue Faraday::ConnectionFailed, Parslet::ParseFailed, Errno::ENETUNREACH
     []
   end
 

--- a/app/services/tag_search_service.rb
+++ b/app/services/tag_search_service.rb
@@ -30,7 +30,7 @@ class TagSearchService < BaseService
     definition = definition.filter(elastic_search_filter) if @options[:exclude_unreviewed]
 
     ensure_exact_match(definition.limit(@limit).offset(@offset).objects.compact)
-  rescue Faraday::ConnectionFailed, Parslet::ParseFailed
+  rescue Faraday::ConnectionFailed, Parslet::ParseFailed, Errno::ENETUNREACH
     nil
   end
 


### PR DESCRIPTION
Fixes https://github.com/mastodon/mastodon/issues/36131

The faraday error rescue here catches most things going wrong at the http connection level, but this `Errno` error is bubbling up from OS/network level issues. I struggled to literally recreate this error locally because I'm not sure on exact network/hostname/whatever issues needed to trigger in the way described and I don't think it mirrors the default dev setup ... but I was able to "replicate" by throwing a `raise` in a spot near the search which probably represents what's happening, and confirm that the backup behavior of hitting DB results does kick in when the rescue is added.

Possible followups here:

- Roll these errors up into a `Mastodon::SEARCH_ERRORS` constant (or whatever), similar to what we have for the http connection errors list used elsewhere
- There is a partial overlap of error class catching from here and in the "metrics/dimension" classes where we are grabbing ES service data ... I suspect that the combined errors lists from these and those could all be put together into that constant as well
- The search service integration is pretty light on coverage, especially around edge/error cases like this, could round that out more
