### PR TITLE
Fix layout of severed relationships when purged events are listed

### DIFF
--- a/app/views/severed_relationships/_event.html.haml
+++ b/app/views/severed_relationships/_event.html.haml
@@ -6,7 +6,7 @@
       = l(event.created_at)
   %td= t("severed_relationships.event_type.#{event.type}", target_name: event.target_name)
   - if event.purged?
-    %td{ rowspan: 2 }= t('severed_relationships.purged')
+    %td{ colspan: 2 }= t('severed_relationships.purged')
   - else
     %td
       = render 'download', count: event.following_count, link: following_severed_relationship_path(event, format: :csv)


### PR DESCRIPTION
This needs to span two columns in the same row, 'Lost follows' and 'Lost followers', instead of two rows, which breaks the table layout because it impinges on the next row, which is a different entry that may or may not be purged.