### PR TITLE
[Vite] Remove overridden `build.target` in favor of legacy plugin defaults

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -73,7 +73,6 @@ export const config: UserConfigFnPromise = async ({ mode, command }) => {
       port: 3036,
     },
     build: {
-      target: 'modules',
       commonjsOptions: { transformMixedEsModules: true },
       chunkSizeWarningLimit: 1 * 1024 * 1024, // 1MB
       sourcemap: true,


### PR DESCRIPTION
It appears that the [@vitejs/plugin-legacy](https://www.npmjs.com/package/@vitejs/plugin-legacy) overrides `build.target` and is emitting a warning it's doing so.

```
plugin-legacy overrode 'build.target'. You should pass 'modernTargets' as an option to this plugin with the list of browsers to support instead.
```

<img width="2880" height="1856" alt="Screenshot From 2025-10-27 11-58-58" src="https://github.com/user-attachments/assets/309c5f05-6855-439f-aab2-b1cdc4cbae47" />

It appears we can simply remove the `built.target` config entry since it was being overridden anyway. Doing so allows the legacy plugin to determine the targets, for which I've left as the defaults but not speechifying anything. That said, we _can_ be more specific if we want via [additional configuration](https://github.com/vitejs/vite/blob/a5e98e695ee4152127977abb506029dc8f7544fb/packages/plugin-legacy/README.md#options).

With the `built.target` config entry removed the warning no longer appears and everything seems to function fine. Effectively ends up being a no-op change besides preventing a warning, though those are always nice to clean up. :)

<img width="2880" height="1856" alt="Screenshot From 2025-10-27 12-01-58" src="https://github.com/user-attachments/assets/62974a85-c4fc-4a9b-bf1f-7d120dabfe4a" />

<img width="2880" height="1856" alt="Screenshot From 2025-10-27 12-03-02" src="https://github.com/user-attachments/assets/8a2ffb01-0b92-4bf4-b5b9-f4d739d71dee" />