### PR TITLE
Revert "Fix custom emoji width (#27969)"

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1101,7 +1101,8 @@
   font-size: inherit;
   vertical-align: middle;
   object-fit: contain;
-  margin: -0.2ex 0.15em 0;
+  margin: -0.2ex 0.15em 0.2ex;
+  width: 16px;
   height: 16px;
 
   img {
@@ -1143,6 +1144,7 @@
   }
 
   .emojione {
+    width: 20px;
     height: 20px;
     margin: -3px 0 0;
   }
@@ -1365,6 +1367,7 @@
   overflow-y: auto;
 
   .emojione {
+    width: 20px;
     height: 20px;
     margin: -3px 0 0;
   }
@@ -1791,6 +1794,7 @@
     line-height: 24px;
 
     .emojione {
+      width: 24px;
       height: 24px;
       margin: -1px 0 0;
     }
@@ -7085,6 +7089,7 @@ a.status-card {
     line-height: 24px;
 
     .emojione {
+      width: 24px;
       height: 24px;
       margin: -1px 0 0;
     }
@@ -8416,6 +8421,7 @@ noscript {
       margin-bottom: 16px;
 
       .emojione {
+        width: 22px;
         height: 22px;
       }
 


### PR DESCRIPTION
This reverts the changes introduced by PR #27969 yesterday

Supporting extra-wide custom emojis required removing the fixed width from them since we don't store the original measurements of custom emojis. This however causes layout reflows in posts with custom emojis, which is not an acceptable trade-off for what's arguably an edge-case feature.