### PR TITLE
Fix props in DisplayName component

### DIFF
--- a/app/javascript/mastodon/components/display_name/display_name.stories.tsx
+++ b/app/javascript/mastodon/components/display_name/display_name.stories.tsx
@@ -74,6 +74,6 @@ export const Linked: Story = {
           acct: username,
         })
       : undefined;
-    return <LinkedDisplayName {...args} displayProps={{ account }} />;
+    return <LinkedDisplayName displayProps={{ account, ...args }} />;
   },
 };

--- a/app/javascript/mastodon/components/display_name/no-domain.tsx
+++ b/app/javascript/mastodon/components/display_name/no-domain.tsx
@@ -9,9 +9,8 @@ import { Skeleton } from '../skeleton';
 import type { DisplayNameProps } from './index';
 
 export const DisplayNameWithoutDomain: FC<
-  Omit<DisplayNameProps, 'variant' | 'localDomain'> &
-    ComponentPropsWithoutRef<'span'>
-> = ({ account, className, children, ...props }) => {
+  Omit<DisplayNameProps, 'variant'> & ComponentPropsWithoutRef<'span'>
+> = ({ account, className, children, localDomain: _, ...props }) => {
   return (
     <AnimateEmojiProvider
       {...props}

--- a/app/javascript/mastodon/components/display_name/simple.tsx
+++ b/app/javascript/mastodon/components/display_name/simple.tsx
@@ -5,9 +5,8 @@ import { EmojiHTML } from '../emoji/html';
 import type { DisplayNameProps } from './index';
 
 export const DisplayNameSimple: FC<
-  Omit<DisplayNameProps, 'variant' | 'localDomain'> &
-    ComponentPropsWithoutRef<'span'>
-> = ({ account, ...props }) => {
+  Omit<DisplayNameProps, 'variant'> & ComponentPropsWithoutRef<'span'>
+> = ({ account, localDomain: _, ...props }) => {
   if (!account) {
     return null;
   }


### PR DESCRIPTION
This fixes the DisplayName component to not spread props in unexpected ways, causing React errors.