### PR TITLE
Remove environment variables to config Fetch All Replies behaviour

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -88,21 +88,3 @@ S3_ALIAS_HOST=files.example.com
 # -----------------------
 IP_RETENTION_PERIOD=31556952
 SESSION_RETENTION_PERIOD=31556952
-
-# Fetch All Replies Behavior
-# --------------------------
-
-# Period to wait between fetching replies (in minutes)
-FETCH_REPLIES_COOLDOWN_MINUTES=15
-
-# Period to wait after a post is first created before fetching its replies (in minutes)
-FETCH_REPLIES_INITIAL_WAIT_MINUTES=5
-
-# Max number of replies to fetch - total, recursively through a whole reply tree
-FETCH_REPLIES_MAX_GLOBAL=1000
-
-# Max number of replies to fetch - for a single post
-FETCH_REPLIES_MAX_SINGLE=500
-
-# Max number of replies Collection pages to fetch - total
-FETCH_REPLIES_MAX_PAGES=500

--- a/app/models/concerns/status/fetch_replies_concern.rb
+++ b/app/models/concerns/status/fetch_replies_concern.rb
@@ -4,8 +4,10 @@ module Status::FetchRepliesConcern
   extend ActiveSupport::Concern
 
   # debounce fetching all replies to minimize DoS
-  FETCH_REPLIES_COOLDOWN_MINUTES = (ENV['FETCH_REPLIES_COOLDOWN_MINUTES'] || 15).to_i.minutes
-  FETCH_REPLIES_INITIAL_WAIT_MINUTES = (ENV['FETCH_REPLIES_INITIAL_WAIT_MINUTES'] || 5).to_i.minutes
+  # Period to wait between fetching replies
+  FETCH_REPLIES_COOLDOWN_MINUTES = 15.minutes
+  # Period to wait after a post is first created before fetching its replies
+  FETCH_REPLIES_INITIAL_WAIT_MINUTES = 5.minutes
 
   included do
     scope :created_recently, -> { where(created_at: FETCH_REPLIES_INITIAL_WAIT_MINUTES.ago..) }

--- a/app/services/activitypub/fetch_all_replies_service.rb
+++ b/app/services/activitypub/fetch_all_replies_service.rb
@@ -3,8 +3,8 @@
 class ActivityPub::FetchAllRepliesService < ActivityPub::FetchRepliesService
   include JsonLdHelper
 
-  # Limit of replies to fetch per status
-  MAX_REPLIES = (ENV['FETCH_REPLIES_MAX_SINGLE'] || 500).to_i
+  # Max number of replies to fetch - for a single post
+  MAX_REPLIES = 500
 
   def call(status_uri, collection_or_uri, max_pages: 1, batch_id: nil, request_id: nil)
     @status_uri = status_uri

--- a/app/workers/activitypub/fetch_all_replies_worker.rb
+++ b/app/workers/activitypub/fetch_all_replies_worker.rb
@@ -11,9 +11,10 @@ class ActivityPub::FetchAllRepliesWorker
 
   sidekiq_options queue: 'pull', retry: 3
 
-  # Global max replies to fetch per request (all replies, recursively)
-  MAX_REPLIES = (ENV['FETCH_REPLIES_MAX_GLOBAL'] || 1000).to_i
-  MAX_PAGES = (ENV['FETCH_REPLIES_MAX_PAGES'] || 500).to_i
+  # Max number of replies to fetch - total, recursively through a whole reply tree
+  MAX_REPLIES = 1000
+  # Max number of replies Collection pages to fetch - total
+  MAX_PAGES = 500
 
   def perform(root_status_id, options = {})
     @batch = WorkerBatch.new(options['batch_id'])


### PR DESCRIPTION
This was useful while testing the feature, but those values seem to work fine, and changing them without understanding the consequences can be very bad, so it's better to avoid a way for admins to make mistakes here.