### PR TITLE
Fix SMTP configuration with `mail` 2.9.0

### DIFF
--- a/lib/mastodon/email_configuration_helper.rb
+++ b/lib/mastodon/email_configuration_helper.rb
@@ -8,25 +8,23 @@ module Mastodon
     # `config/email.yml`) into the format that `ActionMailer` understands
     def convert_smtp_settings(config)
       enable_starttls = nil
-      enable_starttls_auto = nil
 
       case config[:enable_starttls]
       when 'always'
-        enable_starttls = true
-      when 'never'
+        enable_starttls = :always
+      when 'never', 'false'
         enable_starttls = false
       when 'auto'
-        enable_starttls_auto = true
+        enable_starttls = :auto
       else
-        enable_starttls_auto = config[:enable_starttls_auto] != 'false'
+        enable_starttls = config[:enable_starttls_auto] ? :auto : false unless config[:tls] || config[:ssl]
       end
 
       authentication = config[:authentication] == 'none' ? nil : (config[:authentication] || 'plain')
 
-      config.merge(
+      config.without(:enable_starttls_auto).merge(
         authentication:,
-        enable_starttls:,
-        enable_starttls_auto:
+        enable_starttls:
       )
     end
   end

--- a/spec/lib/mastodon/email_configuration_helper_spec.rb
+++ b/spec/lib/mastodon/email_configuration_helper_spec.rb
@@ -21,8 +21,9 @@ RSpec.describe Mastodon::EmailConfigurationHelper do
         base_configuration.merge({ enable_starttls: 'always' })
       end
 
-      it 'converts this to `true`' do
-        expect(converted_settings[:enable_starttls]).to be true
+      it 'converts this to `:always`' do
+        expect(converted_settings[:enable_starttls]).to eq :always
+        expect(converted_settings[:enable_starttls_auto]).to be_nil
       end
     end
 
@@ -33,6 +34,7 @@ RSpec.describe Mastodon::EmailConfigurationHelper do
 
       it 'converts this to `false`' do
         expect(converted_settings[:enable_starttls]).to be false
+        expect(converted_settings[:enable_starttls_auto]).to be_nil
       end
     end
 
@@ -41,28 +43,43 @@ RSpec.describe Mastodon::EmailConfigurationHelper do
         base_configuration.merge({ enable_starttls: 'auto' })
       end
 
-      it 'sets `enable_starttls_auto` instead' do
-        expect(converted_settings[:enable_starttls]).to be_nil
-        expect(converted_settings[:enable_starttls_auto]).to be true
+      it 'sets `enable_starttls` to `:auto`' do
+        expect(converted_settings[:enable_starttls]).to eq :auto
+        expect(converted_settings[:enable_starttls_auto]).to be_nil
       end
     end
 
     context 'when `enable_starttls` is unset' do
-      context 'when `enable_starttls_auto` is unset' do
-        let(:configuration) { base_configuration }
+      context 'when `enable_starttls_auto` is true' do
+        let(:configuration) do
+          base_configuration.merge({ enable_starttls_auto: true })
+        end
 
-        it 'sets `enable_starttls_auto` to `true`' do
-          expect(converted_settings[:enable_starttls_auto]).to be true
+        it 'sets `enable_starttls` to `:auto`' do
+          expect(converted_settings[:enable_starttls]).to eq :auto
+          expect(converted_settings[:enable_starttls_auto]).to be_nil
         end
       end
 
-      context 'when `enable_starttls_auto` is set to "false"' do
+      context 'when `tls` is set to true' do
         let(:configuration) do
-          base_configuration.merge({ enable_starttls_auto: 'false' })
+          base_configuration.merge({ tls: true })
         end
 
-        it 'sets `enable_starttls_auto` to `false`' do
-          expect(converted_settings[:enable_starttls_auto]).to be false
+        it 'sets `enable_starttls` to `nil`' do
+          expect(converted_settings[:enable_starttls]).to be_nil
+          expect(converted_settings[:enable_starttls_auto]).to be_nil
+        end
+      end
+
+      context 'when `enable_starttls_auto` is set to false' do
+        let(:configuration) do
+          base_configuration.merge({ enable_starttls_auto: false })
+        end
+
+        it 'sets `enable_starttls` to `false`' do
+          expect(converted_settings[:enable_starttls]).to be false
+          expect(converted_settings[:enable_starttls_auto]).to be_nil
         end
       end
     end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe UserMailer do
           address: 'localhost',
           port: 25,
           authentication: 'none',
+          enable_starttls_auto: true,
         }
       end
 
@@ -44,8 +45,7 @@ RSpec.describe UserMailer do
           address: 'localhost',
           port: 25,
           authentication: nil,
-          enable_starttls: nil,
-          enable_starttls_auto: true,
+          enable_starttls: :auto,
         })
       end
     end


### PR DESCRIPTION
Fixes #36639

My understanding is that https://github.com/mikel/mail/pull/1536, in addition to handling `:auto` and `:always` for `enable_starttls`, better matching the values of `SMTP_ENABLE_STARTTLS` we expect, started raising an exception whenever TLS was enabled and either `enable_starttls` or `enable_starttls_auto` was passed.

In Mastodon, we enable `enable_starttls_auto` by default unless explicitly disabled.

This PR changes that to not enable `enable_starttls_auto` by default if TLS is enabled. It also rewrites the logic to use `enable_starttls`'s new values instead of relying on `enable_starttls_auto`.