### PR TITLE
Silence Storybook build warning

### DIFF
--- a/app/javascript/testing/api.ts
+++ b/app/javascript/testing/api.ts
@@ -53,6 +53,7 @@ export const mockHandlers = {
       const locale = toSupportedLocale(params.locale);
       action('fetching emoji data')(locale);
       const { default: data } = (await import(
+        /* @vite-ignore */
         `emojibase-data/${locale}/compact.json`
       )) as {
         default: CompactEmoji[];


### PR DESCRIPTION
Silences the build warning as we don't care about unoptimized builds for Storybook.