### PR TITLE
Add separate translation key for "About this server" string

### DIFF
--- a/app/javascript/mastodon/features/ui/components/link_footer.tsx
+++ b/app/javascript/mastodon/features/ui/components/link_footer.tsx
@@ -21,7 +21,10 @@ export const LinkFooter: React.FC<{
       <p>
         <strong>{domain}</strong>:{' '}
         <Link to='/about' target={multiColumn ? '_blank' : undefined}>
-          <FormattedMessage id='footer.about' defaultMessage='About' />
+          <FormattedMessage
+            id='footer.about_this_server'
+            defaultMessage='About'
+          />
         </Link>
         {statusPageUrl && (
           <>

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -408,6 +408,7 @@
   "follow_suggestions.who_to_follow": "Who to follow",
   "followed_tags": "Followed hashtags",
   "footer.about": "About",
+  "footer.about_this_server": "About",
   "footer.directory": "Profiles directory",
   "footer.get_app": "Get the app",
   "footer.keyboard_shortcuts": "Keyboard shortcuts",


### PR DESCRIPTION
### Changes proposed in this PR:
- Adds a separate translation string for "About" in the "server" part of the link footer, so that languages in which "about" requires an object can have different wording for "About this server" and "About Mastodon"