### PR TITLE
Fix initially selected language in Rules panel, hide selector when no alternative translations exist

### DIFF
--- a/app/javascript/mastodon/features/about/components/rules.tsx
+++ b/app/javascript/mastodon/features/about/components/rules.tsx
@@ -32,16 +32,38 @@ interface Rule extends BaseRule {
   translations?: Record<string, BaseRule>;
 }
 
+function getDefaultSelectedLocale(
+  currentUiLocale: string,
+  localeOptions: SelectItem[],
+) {
+  const preciseMatch = localeOptions.find(
+    (option) => option.value === currentUiLocale,
+  );
+  if (preciseMatch) {
+    return preciseMatch.value;
+  }
+
+  const partialLocale = currentUiLocale.split('-')[0];
+  const partialMatch = localeOptions.find(
+    (option) => option.value.split('-')[0] === partialLocale,
+  );
+
+  return partialMatch?.value ?? 'default';
+}
+
 export const RulesSection: FC<RulesSectionProps> = ({ isLoading = false }) => {
   const intl = useIntl();
-  const [locale, setLocale] = useState(intl.locale);
-  const rules = useAppSelector((state) => rulesSelector(state, locale));
   const localeOptions = useAppSelector((state) =>
     localeOptionsSelector(state, intl),
   );
+  const [selectedLocale, setSelectedLocale] = useState(() =>
+    getDefaultSelectedLocale(intl.locale, localeOptions),
+  );
+  const rules = useAppSelector((state) => rulesSelector(state, selectedLocale));
+
   const handleLocaleChange: ChangeEventHandler<HTMLSelectElement> = useCallback(
     (e) => {
-      setLocale(e.currentTarget.value);
+      setSelectedLocale(e.currentTarget.value);
     },
     [],
   );
@@ -74,25 +96,27 @@ export const RulesSection: FC<RulesSectionProps> = ({ isLoading = false }) => {
         ))}
       </ol>
 
-      <div className='rules-languages'>
-        <label htmlFor='language-select'>
-          <FormattedMessage
-            id='about.language_label'
-            defaultMessage='Language'
-          />
-        </label>
-        <select onChange={handleLocaleChange} id='language-select'>
-          {localeOptions.map((option) => (
-            <option
-              key={option.value}
-              value={option.value}
-              selected={option.value === locale}
-            >
-              {option.text}
-            </option>
-          ))}
-        </select>
-      </div>
+      {localeOptions.length > 1 && (
+        <div className='rules-languages'>
+          <label htmlFor='language-select'>
+            <FormattedMessage
+              id='about.language_label'
+              defaultMessage='Language'
+            />
+          </label>
+          <select onChange={handleLocaleChange} id='language-select'>
+            {localeOptions.map((option) => (
+              <option
+                key={option.value}
+                value={option.value}
+                selected={option.value === selectedLocale}
+              >
+                {option.text}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
     </Section>
   );
 };


### PR DESCRIPTION
### Changes proposed in this PR:
- Hides the language selector in the Server Rules panel when no translations are available
- Improves the logic for selecting the initially selected language, allowing partial matches. For example, if the rules translation has the language key `en`, visiting the page with a browser set to `en-GB` wouldn't preselect the "English" option. However, the English rules would be shown, leading to a mismatch between displayed rules and the selector.

### Screenshots

| Before | After |
|--------|--------|
| <img width="565" height="140" alt="image" src="https://github.com/user-attachments/assets/f6afc35f-17ed-43c6-9ab2-8f8a9b7f53fc" /> | <img width="579" height="129" alt="image" src="https://github.com/user-attachments/assets/1fd9cf9c-7486-4e57-8bb2-9ac5a5bd2847" /> | 

Language mismatch:

**Before**

https://github.com/user-attachments/assets/a6dccdc2-020a-4b29-a61f-98b07e2a4f1b

**After**

https://github.com/user-attachments/assets/235e444e-e8a7-45d3-8aa6-2bd2b4868b01

