### PR TITLE
Minor UX: Append Link on RelativeTimestamp in notifications

### DIFF
--- a/app/javascript/mastodon/features/notifications_v2/components/notification_group_with_status.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/components/notification_group_with_status.tsx
@@ -134,9 +134,9 @@ export const NotificationGroupWithStatus: React.FC<{
                   <span className='notification-group__main__header__label-separator'>
                     &middot;
                   </span>
-                      <Link to={`/@${account.acct}/${statusId}`}>
-                        <RelativeTimestamp timestamp={timestamp} />
-                      </Link>
+                  <Link to={`/@${account.acct}/${statusId}`}>
+                    <RelativeTimestamp timestamp={timestamp} />
+                  </Link>
                 </>
               )}
             </div>

--- a/app/javascript/mastodon/features/notifications_v2/components/notification_group_with_status.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/components/notification_group_with_status.tsx
@@ -1,10 +1,9 @@
 import { useMemo } from 'react';
 import type { JSX } from 'react';
 
-import { Link } from 'react-router-dom';
-
 import classNames from 'classnames';
 
+import { Link } from 'react-router-dom';
 import { LinkedDisplayName } from '@/mastodon/components/display_name';
 import { replyComposeById } from 'mastodon/actions/compose';
 import { navigateToStatus } from 'mastodon/actions/statuses';

--- a/app/javascript/mastodon/features/notifications_v2/components/notification_group_with_status.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/components/notification_group_with_status.tsx
@@ -2,8 +2,8 @@ import { useMemo } from 'react';
 import type { JSX } from 'react';
 
 import classNames from 'classnames';
-
 import { Link } from 'react-router-dom';
+
 import { LinkedDisplayName } from '@/mastodon/components/display_name';
 import { replyComposeById } from 'mastodon/actions/compose';
 import { navigateToStatus } from 'mastodon/actions/statuses';

--- a/app/javascript/mastodon/features/notifications_v2/components/notification_group_with_status.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/components/notification_group_with_status.tsx
@@ -65,6 +65,8 @@ export const NotificationGroupWithStatus: React.FC<{
   const account = useAppSelector((state) =>
     state.accounts.get(accountIds.at(0) ?? ''),
   );
+  const status = useSelector(state => state.getIn(['statuses', id]));
+  const statusaccount = useSelector(state => state.getIn(['accounts', status?.get('account')]));
 
   const label = useMemo(
     () =>
@@ -133,8 +135,8 @@ export const NotificationGroupWithStatus: React.FC<{
                   <span className='notification-group__main__header__label-separator'>
                     &middot;
                   </span>
-                  <Link to={`/@${account.acct}/${statusId}`}>
-                    <RelativeTimestamp timestamp={timestamp} />
+                  <Link to={`/@${statusaccount.get('acct')}/${status.get('id')}`}>
+                    <RelativeTimestamp timestamp={status.get('created_at')} />
                   </Link>
                 </>
               )}

--- a/app/javascript/mastodon/features/notifications_v2/components/notification_group_with_status.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/components/notification_group_with_status.tsx
@@ -65,8 +65,9 @@ export const NotificationGroupWithStatus: React.FC<{
   const account = useAppSelector((state) =>
     state.accounts.get(accountIds.at(0) ?? ''),
   );
-  const status = useSelector(state => state.getIn(['statuses', id]));
-  const statusaccount = useSelector(state => state.getIn(['accounts', status?.get('account')]));
+  const status = useSelector((state) =>
+    statusId ? state.getIn(['statuses', statusId]) : undefined,
+  );
 
   const label = useMemo(
     () =>
@@ -135,9 +136,13 @@ export const NotificationGroupWithStatus: React.FC<{
                   <span className='notification-group__main__header__label-separator'>
                     &middot;
                   </span>
-                  <Link to={`/@${statusaccount.get('acct')}/${status.get('id')}`}>
-                    <RelativeTimestamp timestamp={status.get('created_at')} />
-                  </Link>
+                  {status ? (
+                    <Link to={`/@${status.getIn(['account', 'acct'])}/${status.get('id')}`}>
+                      <RelativeTimestamp timestamp={timestamp} />
+                    </Link>
+                  ) : (
+                    <RelativeTimestamp timestamp={timestamp} />
+                  )}
                 </>
               )}
             </div>

--- a/app/javascript/mastodon/features/notifications_v2/components/notification_group_with_status.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/components/notification_group_with_status.tsx
@@ -65,6 +65,7 @@ export const NotificationGroupWithStatus: React.FC<{
   const account = useAppSelector((state) =>
     state.accounts.get(accountIds.at(0) ?? ''),
   );
+  // RelativeTimestamp
   const status = useSelector((state) =>
     statusId ? state.getIn(['statuses', statusId]) : undefined,
   );

--- a/app/javascript/mastodon/features/notifications_v2/components/notification_group_with_status.tsx
+++ b/app/javascript/mastodon/features/notifications_v2/components/notification_group_with_status.tsx
@@ -1,6 +1,8 @@
 import { useMemo } from 'react';
 import type { JSX } from 'react';
 
+import { Link } from 'react-router-dom';
+
 import classNames from 'classnames';
 
 import { LinkedDisplayName } from '@/mastodon/components/display_name';
@@ -132,7 +134,9 @@ export const NotificationGroupWithStatus: React.FC<{
                   <span className='notification-group__main__header__label-separator'>
                     &middot;
                   </span>
-                  <RelativeTimestamp timestamp={timestamp} />
+                      <Link to={`/@${account.acct}/${statusId}`}>
+                        <RelativeTimestamp timestamp={timestamp} />
+                      </Link>
                 </>
               )}
             </div>


### PR DESCRIPTION
The timestamp is a link to the toot for replies and mentions:

<img width="599" height="87" alt="image" src="https://github.com/user-attachments/assets/05eb5525-30ae-43ed-83a5-a22213466fd9" />

but not in notification actions:

<img width="363" height="84" alt="image" src="https://github.com/user-attachments/assets/bd244c9c-3fca-442a-8e17-134885480242" />
