### PR TITLE
Disable paste-link-to-quote flow when composing Private Mentions

### DIFF
--- a/app/javascript/mastodon/actions/compose_typed.ts
+++ b/app/javascript/mastodon/actions/compose_typed.ts
@@ -191,7 +191,8 @@ export const pasteLinkCompose = createDataLoadingThunk(
       composeState.get('is_submitting') ||
       composeState.get('poll') ||
       composeState.get('is_uploading') ||
-      composeState.get('id')
+      composeState.get('id') ||
+      composeState.get('privacy') === 'direct'
     )
       return;
 


### PR DESCRIPTION
This is not ideal because:
- this doesn't change anything when someone starts composing a post *then* switches to Private Mention
- it prevents the paste-link-to-quote flow in ways we might want to allow (self-quote, quoting someone we mention)

Nonetheless, this should reduce the risks a little, and also reduce error cases popping up in the Web UI if we implement https://github.com/mastodon/mastodon/pull/36689