### PR TITLE
Fix issuance of quote approval for remote private statuses

### DIFF
--- a/app/controllers/activitypub/quote_authorizations_controller.rb
+++ b/app/controllers/activitypub/quote_authorizations_controller.rb
@@ -9,7 +9,7 @@ class ActivityPub::QuoteAuthorizationsController < ActivityPub::BaseController
   before_action :set_quote_authorization
 
   def show
-    expires_in 30.seconds, public: true if @quote.status.distributable? && public_fetch_mode?
+    expires_in 30.seconds, public: true if @quote.quoted_status.distributable? && public_fetch_mode?
     render json: @quote, serializer: ActivityPub::QuoteAuthorizationSerializer, adapter: ActivityPub::Adapter, content_type: 'application/activity+json'
   end
 
@@ -23,7 +23,7 @@ class ActivityPub::QuoteAuthorizationsController < ActivityPub::BaseController
     @quote = Quote.accepted.where(quoted_account: @account).find(params[:id])
     return not_found unless @quote.status.present? && @quote.quoted_status.present?
 
-    authorize @quote.status, :show?
+    authorize @quote.quoted_status, :show?
   rescue Mastodon::NotPermittedError
     not_found
   end


### PR DESCRIPTION
The controller for quote post approval was checking access to the quoting post and not the quoted post, hence refusing to serve quote stamps for private posts.

The new behavior is consistent with the spec:
> A `QuoteAuthorization` object MUST be dereferenceable by all parties allowed to see the original post, and MAY be publicly dereferenceable.