### PR TITLE
Increase number of quote approval job retries

### DIFF
--- a/app/workers/activitypub/refetch_and_verify_quote_worker.rb
+++ b/app/workers/activitypub/refetch_and_verify_quote_worker.rb
@@ -5,7 +5,7 @@ class ActivityPub::RefetchAndVerifyQuoteWorker
   include ExponentialBackoff
   include JsonLdHelper
 
-  sidekiq_options queue: 'pull', retry: 3
+  sidekiq_options queue: 'pull', retry: 5
 
   def perform(quote_id, quoted_uri, options = {})
     quote = Quote.find(quote_id)


### PR DESCRIPTION
4 tries total over 17 minutes ~ 33 minutes was a bit limited to deal with very busy servers or servers experiencing temporary outage.
This brings it to 6 tries total over 2h30 ~ 5h30.

Opportunistic retries are still possible regardless of the change but lead to a worse experience.