### PR TITLE
Resume Renovate updates for `tesseract`

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -23,8 +23,6 @@
       // Require Dependency Dashboard Approval for major version bumps of these node packages
       matchManagers: ['npm'],
       matchPackageNames: [
-        'tesseract.js', // Requires code changes
-
         // react-router: Requires manual upgrade
         'history',
         'react-router-dom',


### PR DESCRIPTION
We updated to a more recent update for this package, so we can let Renovate update it automatically again