### PR TITLE
Relax `aws-sdk-core` version limit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'haml-rails', '~>3.0'
 gem 'pg', '~> 1.5'
 gem 'pghero'
 
-gem 'aws-sdk-core', '< 3.216.0', require: false # TODO: https://github.com/mastodon/mastodon/pull/34173#issuecomment-2733378873
+gem 'aws-sdk-core', require: false
 gem 'aws-sdk-s3', '~> 1.123', require: false
 gem 'blurhash', '~> 0.1'
 gem 'fog-core', '<= 2.6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,12 +96,15 @@ GEM
     ast (2.4.3)
     attr_required (1.0.2)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1168.0)
-    aws-sdk-core (3.215.1)
+    aws-partitions (1.1180.0)
+    aws-sdk-core (3.236.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)
+      base64
+      bigdecimal
       jmespath (~> 1, >= 1.6.1)
+      logger
     aws-sdk-kms (1.96.0)
       aws-sdk-core (~> 3, >= 3.210.0)
       aws-sigv4 (~> 1.5)
@@ -933,7 +936,7 @@ DEPENDENCIES
   active_model_serializers (~> 0.10)
   addressable (~> 2.8)
   annotaterb (~> 4.13)
-  aws-sdk-core (< 3.216.0)
+  aws-sdk-core
   aws-sdk-s3 (~> 1.123)
   better_errors (~> 2.9)
   binding_of_caller (~> 1.0)


### PR DESCRIPTION
Some background:

- https://github.com/mastodon/mastodon/pull/34173#issuecomment-2733378873
- https://github.com/mastodon/mastodon/pull/34202
- https://github.com/mastodon/mastodon/pull/34203
- https://github.com/mastodon/mastodon/issues/33624

Recent changes:

- Confirmation from dev-rel person from backblaze that they support the header now: https://meta.discourse.org/t/cant-rebuild-due-to-aws-sdk-gem-bump-and-new-aws-data-integrity-protections/354217/53?u=mattjankowski
- Change in client lib to more fully support "when required" setting - https://github.com/aws/aws-sdk-ruby/pull/3307 - which was included a few releases ago.

I guess there's a remaining test here which is to set those env vars on a server configured against a cloudflare R2 setup and use the env vars and confirm that does not error out anymore.