### PR TITLE
Change quote action to error instead of insert link in Private Mentions

### DIFF
--- a/app/javascript/mastodon/actions/compose_typed.ts
+++ b/app/javascript/mastodon/actions/compose_typed.ts
@@ -41,6 +41,10 @@ const messages = defineMessages({
     id: 'quote_error.unauthorized',
     defaultMessage: 'You are not authorized to quote this post.',
   },
+  quoteErrorPrivateMention: {
+    id: 'quote_error.private_mentions',
+    defaultMessage: 'Quoting is not allowed with direct mentions.',
+  },
 });
 
 type SimulatedMediaAttachmentJSON = ApiMediaAttachmentJSON & {
@@ -163,6 +167,8 @@ export const quoteComposeByStatus = createAppThunk(
 
     if (composeState.get('id')) {
       dispatch(showAlert({ message: messages.quoteErrorEdit }));
+    } else if (composeState.get('privacy') === 'direct') {
+      dispatch(showAlert({ message: messages.quoteErrorPrivateMention }));
     } else if (composeState.get('poll')) {
       dispatch(showAlert({ message: messages.quoteErrorPoll }));
     } else if (

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -765,6 +765,7 @@
   "privacy_policy.title": "Privacy Policy",
   "quote_error.edit": "Quotes cannot be added when editing a post.",
   "quote_error.poll": "Quoting is not allowed with polls.",
+  "quote_error.private_mentions": "Quoting is not allowed with direct mentions.",
   "quote_error.quote": "Only one quote at a time is allowed.",
   "quote_error.unauthorized": "You are not authorized to quote this post.",
   "quote_error.upload": "Quoting is not allowed with media attachments.",

--- a/app/javascript/mastodon/reducers/compose.js
+++ b/app/javascript/mastodon/reducers/compose.js
@@ -345,16 +345,6 @@ export const composeReducer = (state = initialState, action) => {
           return 'private';
         }
         return visibility;
-      })
-      .update('text', (text) => {
-        if (!isDirect) {
-          return text;
-        }
-        const url = status.get('url');
-        if (text.includes(url)) {
-          return text;
-        }
-        return text.trim() ? `${text}\n\n${url}` : url;
       });
   } else if (quoteComposeCancel.match(action)) {
     return state.set('quoted_status_id', null);


### PR DESCRIPTION
While useful, I believe the behavior change to insert a link instead of quoting when pressing “Quote” when composing a Private Mention may be confusing, by doing something other than quoting and being inconsistent with other cases where quoting is not possible.

Instead, this PR proposes to change the behavior to an error stating “Quoting is not allowed with direct mentions.” in those cases.