### PR TITLE
Add some outer page spacing when viewport width equals content width

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2991,6 +2991,7 @@ a.account__display-name {
     height: 100%;
     min-height: 100vh;
     min-height: 100dvh;
+    padding-inline: 10px;
     padding-bottom: env(safe-area-inset-bottom);
 
     &__pane {
@@ -3330,6 +3331,7 @@ a.account__display-name {
     min-height: 100vh;
     min-height: 100dvh;
     gap: 0;
+    padding-inline: 0;
   }
 
   .columns-area__panels__pane--navigational {


### PR DESCRIPTION
### Changes proposed in this PR:
- Fixes page content bumping into viewport edges when the width of both is similar

### Screenshots

| **Before** | **After** |
|--------|--------|
| <img width="1173" height="732" alt="image" src="https://github.com/user-attachments/assets/76ba8c9c-402e-4d81-87de-95e2ccae1a30" /> | <img width="1175" height="719" alt="image" src="https://github.com/user-attachments/assets/4e2f98e7-761a-47b1-9db0-d4e1feeb0923" /> |