### PR TITLE
Add default visualizer for audio upload without poster

### DIFF
--- a/app/javascript/images/sound.svg
+++ b/app/javascript/images/sound.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 40 40">
+  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.333" d="M3.333 16.667v5M10 10v18.333M16.667 5v30m6.666-21.667V25M30 8.333V30m6.667-13.333v5"/>
+</svg>

--- a/app/javascript/images/sound.svg
+++ b/app/javascript/images/sound.svg
@@ -1,3 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 40 40">
-  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.333" d="M3.333 16.667v5M10 10v18.333M16.667 5v30m6.666-21.667V25M30 8.333V30m6.667-13.333v5"/>
-</svg>

--- a/app/javascript/mastodon/features/audio/index.tsx
+++ b/app/javascript/mastodon/features/audio/index.tsx
@@ -616,8 +616,6 @@ export const Audio: React.FC<{
       </div>
 
       <div className='audio-player__controls'>
-        <AudioVisualizer frequencyBands={frequencyBands} poster={poster} />
-
         <div className='audio-player__controls__play'>
           <button
             type='button'
@@ -631,6 +629,8 @@ export const Audio: React.FC<{
         </div>
 
         <div className='audio-player__controls__play'>
+          <AudioVisualizer frequencyBands={frequencyBands} poster={poster} />
+
           <button
             type='button'
             title={intl.formatMessage(paused ? messages.play : messages.pause)}

--- a/app/javascript/mastodon/features/audio/index.tsx
+++ b/app/javascript/mastodon/features/audio/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useCallback, useState, useId } from 'react';
+import { useEffect, useRef, useCallback, useState } from 'react';
 
 import { defineMessages, useIntl, FormattedMessage } from 'react-intl';
 
@@ -21,6 +21,8 @@ import { useAudioContext } from 'mastodon/hooks/useAudioContext';
 import { useAudioVisualizer } from 'mastodon/hooks/useAudioVisualizer';
 import { displayMedia, useBlurhash } from 'mastodon/initial_state';
 import { playerSettings } from 'mastodon/settings';
+
+import { AudioVisualizer } from './visualizer';
 
 const messages = defineMessages({
   play: { id: 'video.play', defaultMessage: 'Play' },
@@ -116,7 +118,6 @@ export const Audio: React.FC<{
   const seekRef = useRef<HTMLDivElement>(null);
   const volumeRef = useRef<HTMLDivElement>(null);
   const hoverTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>();
-  const accessibilityId = useId();
 
   const { audioContextRef, sourceRef, gainNodeRef, playAudio, pauseAudio } =
     useAudioContext({ audioElementRef: audioRef });
@@ -538,19 +539,6 @@ export const Audio: React.FC<{
     [togglePlay, toggleMute],
   );
 
-  const springForBand0 = useSpring({
-    to: { r: 50 + (frequencyBands[0] ?? 0) * 10 },
-    config: config.wobbly,
-  });
-  const springForBand1 = useSpring({
-    to: { r: 50 + (frequencyBands[1] ?? 0) * 10 },
-    config: config.wobbly,
-  });
-  const springForBand2 = useSpring({
-    to: { r: 50 + (frequencyBands[2] ?? 0) * 10 },
-    config: config.wobbly,
-  });
-
   const progress = Math.min((currentTime / loadedDuration) * 100, 100);
   const effectivelyMuted = muted || volume === 0;
 
@@ -628,6 +616,8 @@ export const Audio: React.FC<{
       </div>
 
       <div className='audio-player__controls'>
+        <AudioVisualizer frequencyBands={frequencyBands} poster={poster} />
+
         <div className='audio-player__controls__play'>
           <button
             type='button'
@@ -641,82 +631,6 @@ export const Audio: React.FC<{
         </div>
 
         <div className='audio-player__controls__play'>
-          <svg
-            className='audio-player__visualizer'
-            viewBox='0 0 124 124'
-            xmlns='http://www.w3.org/2000/svg'
-          >
-            <animated.circle
-              opacity={0.5}
-              cx={57}
-              cy={62.5}
-              r={springForBand0.r}
-              fill='var(--player-accent-color)'
-            />
-            <animated.circle
-              opacity={0.5}
-              cx={65}
-              cy={57.5}
-              r={springForBand1.r}
-              fill='var(--player-accent-color)'
-            />
-            <animated.circle
-              opacity={0.5}
-              cx={63}
-              cy={66.5}
-              r={springForBand2.r}
-              fill='var(--player-accent-color)'
-            />
-
-            <g clipPath={`url(#${accessibilityId}-clip)`}>
-              <rect
-                x={14}
-                y={14}
-                width={96}
-                height={96}
-                fill={`url(#${accessibilityId}-pattern)`}
-              />
-              <rect
-                x={14}
-                y={14}
-                width={96}
-                height={96}
-                fill='var(--player-background-color'
-                opacity={0.45}
-              />
-            </g>
-
-            <defs>
-              <pattern
-                id={`${accessibilityId}-pattern`}
-                patternContentUnits='objectBoundingBox'
-                width='1'
-                height='1'
-              >
-                <use href={`#${accessibilityId}-image`} />
-              </pattern>
-
-              <clipPath id={`${accessibilityId}-clip`}>
-                <rect
-                  x={14}
-                  y={14}
-                  width={96}
-                  height={96}
-                  rx={48}
-                  fill='white'
-                />
-              </clipPath>
-
-              <image
-                id={`${accessibilityId}-image`}
-                href={poster}
-                width={1}
-                height={1}
-                preserveAspectRatio='none'
-              />
-            </defs>
-          </svg>
-
           <button
             type='button'
             title={intl.formatMessage(paused ? messages.play : messages.pause)}

--- a/app/javascript/mastodon/features/audio/visualizer.tsx
+++ b/app/javascript/mastodon/features/audio/visualizer.tsx
@@ -1,0 +1,100 @@
+import { useId } from 'react';
+import type { FC } from 'react';
+
+import { animated, config, useSpring } from '@react-spring/web';
+
+interface AudioVisualizerProps {
+  frequencyBands?: number[];
+  poster?: string;
+}
+
+export const AudioVisualizer: FC<AudioVisualizerProps> = ({
+  frequencyBands = [],
+  poster,
+}) => {
+  const accessibilityId = useId();
+
+  const springForBand0 = useSpring({
+    to: { r: 50 + (frequencyBands[0] ?? 0) * 10 },
+    config: config.wobbly,
+  });
+  const springForBand1 = useSpring({
+    to: { r: 50 + (frequencyBands[1] ?? 0) * 10 },
+    config: config.wobbly,
+  });
+  const springForBand2 = useSpring({
+    to: { r: 50 + (frequencyBands[2] ?? 0) * 10 },
+    config: config.wobbly,
+  });
+
+  return (
+    <svg
+      className='audio-player__visualizer'
+      viewBox='0 0 124 124'
+      xmlns='http://www.w3.org/2000/svg'
+    >
+      <animated.circle
+        opacity={0.5}
+        cx={57}
+        cy={62.5}
+        r={springForBand0.r}
+        fill='var(--player-accent-color)'
+      />
+      <animated.circle
+        opacity={0.5}
+        cx={65}
+        cy={57.5}
+        r={springForBand1.r}
+        fill='var(--player-accent-color)'
+      />
+      <animated.circle
+        opacity={0.5}
+        cx={63}
+        cy={66.5}
+        r={springForBand2.r}
+        fill='var(--player-accent-color)'
+      />
+
+      <g clipPath={`url(#${accessibilityId}-clip)`}>
+        <rect
+          x={14}
+          y={14}
+          width={96}
+          height={96}
+          fill={`url(#${accessibilityId}-pattern)`}
+        />
+        <rect
+          x={14}
+          y={14}
+          width={96}
+          height={96}
+          fill='var(--player-background-color'
+          opacity={0.45}
+        />
+      </g>
+
+      <defs>
+        <pattern
+          id={`${accessibilityId}-pattern`}
+          patternContentUnits='objectBoundingBox'
+          width='1'
+          height='1'
+        >
+          <use href={`#${accessibilityId}-image`} />
+        </pattern>
+
+        <clipPath id={`${accessibilityId}-clip`}>
+          <rect x={14} y={14} width={96} height={96} rx={48} fill='white' />
+        </clipPath>
+
+        <image
+          id={`${accessibilityId}-image`}
+          href={poster}
+          width={1}
+          height={1}
+          preserveAspectRatio='none'
+        />
+      </defs>
+    </svg>
+  );
+};

--- a/app/javascript/mastodon/features/compose/components/upload.tsx
+++ b/app/javascript/mastodon/features/compose/components/upload.tsx
@@ -9,8 +9,8 @@ import type { Map as ImmutableMap, List as ImmutableList } from 'immutable';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 
-import SoundIcon from '@/images/sound.svg?react';
 import CloseIcon from '@/material-icons/400-20px/close.svg?react';
+import SoundIcon from '@/material-icons/400-24px/audio.svg?react';
 import EditIcon from '@/material-icons/400-24px/edit.svg?react';
 import WarningIcon from '@/material-icons/400-24px/warning.svg?react';
 import { undoUploadCompose } from 'mastodon/actions/compose';

--- a/app/javascript/mastodon/features/compose/components/upload.tsx
+++ b/app/javascript/mastodon/features/compose/components/upload.tsx
@@ -9,9 +9,9 @@ import type { Map as ImmutableMap, List as ImmutableList } from 'immutable';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 
+import SoundIcon from '@/images/sound.svg?react';
 import CloseIcon from '@/material-icons/400-20px/close.svg?react';
 import EditIcon from '@/material-icons/400-24px/edit.svg?react';
-import HeadphonesIcon from '@/material-icons/400-24px/headphones.svg?react';
 import WarningIcon from '@/material-icons/400-24px/warning.svg?react';
 import { undoUploadCompose } from 'mastodon/actions/compose';
 import { openModal } from 'mastodon/actions/modal';
@@ -111,7 +111,7 @@ export const Upload: React.FC<{
         {!sensitive && !preview_url && (
           <div className='compose-form__upload__visualizer'>
             <AudioVisualizer poster={userAvatar} />
-            <Icon id='music' icon={HeadphonesIcon} />
+            <Icon id='sound' icon={SoundIcon} />
           </div>
         )}
 

--- a/app/javascript/material-icons/400-24px/audio.svg
+++ b/app/javascript/material-icons/400-24px/audio.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="currentColor"><path d="M280-240v-480h80v480h-80ZM440-80v-800h80v800h-80ZM120-400v-160h80v160h-80Zm480 160v-480h80v480h-80Zm160-160v-160h80v160h-80Z"/></svg>

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -799,7 +799,7 @@
         height: 100%;
       }
 
-      .icon-music {
+      .icon {
         position: absolute;
         top: 50%;
         inset-inline-start: 50%;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -775,14 +775,41 @@
       padding: 8px;
     }
 
-    &__preview {
+    &__preview,
+    &__visualizer {
       position: absolute;
       width: 100%;
       height: 100%;
-      border-radius: 6px;
       z-index: -1;
       top: 0;
+    }
+
+    &__preview {
+      border-radius: 6px;
       inset-inline-start: 0;
+    }
+
+    &__visualizer {
+      padding: 16px;
+      box-sizing: border-box;
+
+      .audio-player__visualizer {
+        margin: 0 auto;
+        display: block;
+        height: 100%;
+      }
+
+      .icon-music {
+        position: absolute;
+        top: 50%;
+        inset-inline-start: 50%;
+        transform: translate(-50%, -50%);
+        opacity: 0.75;
+        color: var(--player-foreground-color);
+        filter: var(--overlay-icon-shadow);
+        width: 48px;
+        height: 48px;
+      }
     }
 
     &__thumbnail {


### PR DESCRIPTION
Fixes #36725.

This updates the audio component to show the visualizer UI if there is no poster art available. It uses the headphones icon to be clearer it's not playable.

<img width="640" height="1082" alt="Screenshot 2025-11-05 at 15 27 51" src="https://github.com/user-attachments/assets/817676e1-3e10-4322-9fc8-c3083ae3e07e" />

