### PR TITLE
Fix: correctly dismisses announcement when viewed

### DIFF
--- a/app/javascript/mastodon/features/home_timeline/components/announcements/announcement.tsx
+++ b/app/javascript/mastodon/features/home_timeline/components/announcements/announcement.tsx
@@ -1,11 +1,13 @@
-import { useEffect, useState } from 'react';
 import type { FC } from 'react';
+import { useEffect, useState } from 'react';
 
 import { FormattedDate, FormattedMessage } from 'react-intl';
 
+import { dismissAnnouncement } from '@/mastodon/actions/announcements';
 import type { ApiAnnouncementJSON } from '@/mastodon/api_types/announcements';
 import { AnimateEmojiProvider } from '@/mastodon/components/emoji/context';
 import { EmojiHTML } from '@/mastodon/components/emoji/html';
+import { useAppDispatch } from '@/mastodon/store';
 
 import { ReactionsBar } from './reactions';
 
@@ -22,13 +24,23 @@ export const Announcement: FC<AnnouncementProps> = ({
   announcement,
   active,
 }) => {
-  const [unread, setUnread] = useState(!announcement.read);
+  const read = announcement.read;
+
+  // Dismiss announcement when it becomes active.
+  const dispatch = useAppDispatch();
   useEffect(() => {
-    // Only update `unread` marker once the announcement is out of view
-    if (!active && unread !== !announcement.read) {
-      setUnread(!announcement.read);
+    if (active && !read) {
+      dispatch(dismissAnnouncement(announcement.id));
     }
-  }, [announcement.read, active, unread]);
+  }, [active, announcement.id, dispatch, read]);
+
+  // But visually show the announcement as read only when it goes out of view.
+  const [unread, setUnread] = useState(!read);
+  useEffect(() => {
+    if (!active && unread !== !read) {
+      setUnread(!read);
+    }
+  }, [active, unread, announcement.id, read]);
 
   return (
     <AnimateEmojiProvider>

--- a/app/javascript/mastodon/features/home_timeline/components/announcements/announcement.tsx
+++ b/app/javascript/mastodon/features/home_timeline/components/announcements/announcement.tsx
@@ -24,15 +24,15 @@ export const Announcement: FC<AnnouncementProps> = ({
   announcement,
   active,
 }) => {
-  const read = announcement.read;
+  const { read, id } = announcement;
 
   // Dismiss announcement when it becomes active.
   const dispatch = useAppDispatch();
   useEffect(() => {
     if (active && !read) {
-      dispatch(dismissAnnouncement(announcement.id));
+      dispatch(dismissAnnouncement(id));
     }
-  }, [active, announcement.id, dispatch, read]);
+  }, [active, id, dispatch, read]);
 
   // But visually show the announcement as read only when it goes out of view.
   const [unread, setUnread] = useState(!read);
@@ -40,7 +40,7 @@ export const Announcement: FC<AnnouncementProps> = ({
     if (!active && unread !== !read) {
       setUnread(!read);
     }
-  }, [active, unread, announcement.id, read]);
+  }, [active, unread, read]);
 
   return (
     <AnimateEmojiProvider>


### PR DESCRIPTION
When creating the new announcement components, I forgot to actually dismiss anything! This corrects that, so announcements should be dismissed on view.