### PR TITLE
Remove legacy AR connection boot from puma config

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -44,12 +44,6 @@ if ENV['MASTODON_PROMETHEUS_EXPORTER_ENABLED'] == 'true'
   end
 end
 
-before_worker_boot do
-  ActiveSupport.on_load(:active_record) do
-    ActiveRecord::Base.establish_connection
-  end
-end
-
 plugin :tmp_restart
 
 set_remote_address(proxy_protocol: :v1) if ENV['PROXY_PROTO_V1'] == 'true'


### PR DESCRIPTION
This was removed from the rails default generated config a very long time (~8 years) ago, and I don't believe is needed here anymore.

Will silence warnings in E2E spec runs, ie: https://github.com/mastodon/mastodon/actions/runs/19134849860/job/54684461077#step:12:20